### PR TITLE
perf(plugins): keep state-db write machinery out of metadata read paths

### DIFF
--- a/scripts/check-kysely-guardrails.mts
+++ b/scripts/check-kysely-guardrails.mts
@@ -137,6 +137,7 @@ const rawSqliteAllowPathGroups = {
     "src/media/store.ts",
     "src/plugin-sdk/memory-core-host-engine-storage.ts",
     "src/plugins/installed-plugin-index-record-reader.ts",
+    "src/plugins/installed-plugin-index-store-write.ts",
     "src/plugins/installed-plugin-index-store.ts",
     "src/plugin-state/plugin-state-store.sqlite.ts",
     "src/tasks/task-flow-registry.store.sqlite.ts",

--- a/src/agents/mcp-oauth-store.test.ts
+++ b/src/agents/mcp-oauth-store.test.ts
@@ -1,9 +1,9 @@
 import { withTempHome as withBaseTempHome } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it } from "vitest";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
-  OPENCLAW_STATE_SCHEMA_VERSION,
 } from "../state/openclaw-state-db.js";
 import { operatorMcpOAuthIdentity } from "./mcp-oauth-identity.js";
 import {

--- a/src/agents/tools/transcripts-tool.auto-start.test.ts
+++ b/src/agents/tools/transcripts-tool.auto-start.test.ts
@@ -6,11 +6,12 @@ import { createDeferred } from "../../../test/helpers/promise.js";
 import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
 import { withPluginRuntimeRegistryScope } from "../../plugins/runtime/gateway-request-scope.js";
+import { openClawStateDatabaseCache } from "../../state/openclaw-state-db-cache.js";
 import {
   closeOpenClawStateDatabaseByPath,
   closeOpenClawStateDatabaseForTest,
-  getOpenClawStateDatabaseIfOpen,
 } from "../../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
 import type {
   TranscriptSourceProvider,
   TranscriptStartRequest,
@@ -52,6 +53,7 @@ describe("transcripts auto-start stop reporting", () => {
   ])("$name preserves state and finishes siblings", async ({ blocked, outcome, manual }) => {
     const stateDir = await fs.realpath(tempDirs.make("openclaw-transcripts-auto-stop-"));
     const options = { env: { ...process.env, OPENCLAW_STATE_DIR: stateDir } };
+    const databasePath = path.resolve(resolveOpenClawStateSqlitePath(options.env));
     const exportRoot = path.join(stateDir, "transcripts");
     const store = new TranscriptsStore(exportRoot, options);
     const requests = new Map<string, TranscriptStartRequest>();
@@ -150,7 +152,8 @@ describe("transcripts auto-start stop reporting", () => {
         expect(stop).toHaveBeenCalledTimes(2);
         expect(logger.warn.mock.calls.map(([message]) => message)).toEqual(warnings);
 
-        const database = getOpenClawStateDatabaseIfOpen(options)!;
+        const database =
+          openClawStateDatabaseCache.getOpenClawStateDatabaseIfOpenAtPath(databasePath)!;
         expect(database.db.isOpen).toBe(true);
         expect(closeOpenClawStateDatabaseByPath(database.path)).toBe(true);
         expect(database.db.isOpen).toBe(false);
@@ -178,7 +181,9 @@ describe("transcripts auto-start stop reporting", () => {
             ).toContain(capturedText);
           }
         }
-        expect(getOpenClawStateDatabaseIfOpen(options)).not.toBe(database);
+        expect(
+          openClawStateDatabaseCache.getOpenClawStateDatabaseIfOpenAtPath(databasePath),
+        ).not.toBe(database);
         await expect(execute("status")).resolves.toMatchObject({
           details: {
             active:

--- a/src/audit/execution-owner-lifecycle-receipts.test.ts
+++ b/src/audit/execution-owner-lifecycle-receipts.test.ts
@@ -6,9 +6,9 @@ import type { ExecutionIdentityContextV1 } from "../../packages/gateway-protocol
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { AdmittedRunContext } from "../agents/admitted-run-context.js";
 import { bindCronRunReceiptExecution } from "../cron/store/run-receipt-store.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
 import { tableHasColumn, tableExists } from "../state/openclaw-state-db-schema-helpers.js";
 import {
-  OPENCLAW_STATE_SCHEMA_VERSION,
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";

--- a/src/cli/plugins-cli-test-helpers.ts
+++ b/src/cli/plugins-cli-test-helpers.ts
@@ -34,7 +34,7 @@ type UpdateNpmInstalledHookPacksFn =
 type ReadPersistedInstalledPluginIndexFn =
   (typeof import("../plugins/installed-plugin-index-store.js"))["readPersistedInstalledPluginIndex"];
 type RestorePersistedInstalledPluginIndexIfCurrentFn =
-  (typeof import("../plugins/installed-plugin-index-store.js"))["restorePersistedInstalledPluginIndexIfCurrent"];
+  (typeof import("../plugins/installed-plugin-index-store-write.js"))["restorePersistedInstalledPluginIndexIfCurrent"];
 type WritePersistedInstalledPluginIndexInstallRecordsFn =
   (typeof import("../plugins/installed-plugin-index-records.js"))["writePersistedInstalledPluginIndexInstallRecords"];
 type WritePersistedInstalledPluginIndexInstallRecordsWithLeaseFn =
@@ -425,6 +425,14 @@ vi.mock("../plugins/installed-plugin-index-store.js", async (importOriginal) => 
       invokeMock<unknown[], unknown>(readPersistedInstalledPluginIndexMock, ...args)) as (
       ...args: unknown[]
     ) => unknown,
+  };
+});
+
+vi.mock("../plugins/installed-plugin-index-store-write.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../plugins/installed-plugin-index-store-write.js")>();
+  return {
+    ...actual,
     restorePersistedInstalledPluginIndexIfCurrent: ((...args: unknown[]) =>
       invokeMock<unknown[], unknown>(
         restorePersistedInstalledPluginIndexIfCurrentMock,
@@ -552,17 +560,30 @@ vi.mock("../plugins/plugin-registry.js", () => ({
       inspectPluginRegistryMock,
       ...args,
     )) as (typeof import("../plugins/plugin-registry.js"))["inspectPluginRegistry"],
-  refreshPluginRegistry: ((
-    ...args: Parameters<(typeof import("../plugins/plugin-registry.js"))["refreshPluginRegistry"]>
-  ) =>
-    invokeMock<
-      Parameters<(typeof import("../plugins/plugin-registry.js"))["refreshPluginRegistry"]>,
-      ReturnType<(typeof import("../plugins/plugin-registry.js"))["refreshPluginRegistry"]>
-    >(
-      refreshPluginRegistryMock,
-      ...args,
-    )) as (typeof import("../plugins/plugin-registry.js"))["refreshPluginRegistry"],
 }));
+
+vi.mock("../plugins/plugin-registry-refresh.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../plugins/plugin-registry-refresh.js")>();
+  return {
+    ...actual,
+    refreshPluginRegistry: ((
+      ...args: Parameters<
+        (typeof import("../plugins/plugin-registry-refresh.js"))["refreshPluginRegistry"]
+      >
+    ) =>
+      invokeMock<
+        Parameters<
+          (typeof import("../plugins/plugin-registry-refresh.js"))["refreshPluginRegistry"]
+        >,
+        ReturnType<
+          (typeof import("../plugins/plugin-registry-refresh.js"))["refreshPluginRegistry"]
+        >
+      >(
+        refreshPluginRegistryMock,
+        ...args,
+      )) as (typeof import("../plugins/plugin-registry-refresh.js"))["refreshPluginRegistry"],
+  };
+});
 
 vi.mock("../plugins/loader.js", () => ({
   clearPluginRegistryLoadCache: ((...args: unknown[]) =>

--- a/src/cli/plugins-cli.runtime.ts
+++ b/src/cli/plugins-cli.runtime.ts
@@ -340,10 +340,10 @@ export async function runPluginsInstallAction(
 
 /** Inspect or refresh the persisted plugin registry index. */
 export async function runPluginsRegistryCommand(opts: PluginRegistryOptions): Promise<void> {
-  const { inspectPluginRegistry, refreshPluginRegistry } =
-    await import("../plugins/plugin-registry.js");
+  const { inspectPluginRegistry } = await import("../plugins/plugin-registry.js");
 
   if (opts.refresh) {
+    const { refreshPluginRegistry } = await import("../plugins/plugin-registry-refresh.js");
     return await withPluginLifecycleLease({}, async () => {
       const index = await refreshPluginRegistry({
         config: getRuntimeConfig(),

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -71,9 +71,8 @@ const loadInstalledPluginIndexInstallRecords = vi.fn(
     params.config?.plugins?.installs ?? {},
 );
 const readPersistedInstalledPluginIndex = vi.fn(async () => null);
-const restorePersistedInstalledPluginIndex = vi.fn(async () => undefined);
 const restorePersistedInstalledPluginIndexIfCurrent = vi.fn<
-  typeof import("../plugins/installed-plugin-index-store.js").restorePersistedInstalledPluginIndexIfCurrent
+  typeof import("../plugins/installed-plugin-index-store-write.js").restorePersistedInstalledPluginIndexIfCurrent
 >(async () => true);
 const writePersistedInstalledPluginIndexInstallRecords = vi.fn(async () => undefined);
 const writePersistedInstalledPluginIndexInstallRecordsWithLease = vi.fn(async () => ({
@@ -321,7 +320,14 @@ vi.mock("../plugins/installed-plugin-index-store.js", async (importOriginal) => 
   return {
     ...actual,
     readPersistedInstalledPluginIndex,
-    restorePersistedInstalledPluginIndex,
+  };
+});
+
+vi.mock("../plugins/installed-plugin-index-store-write.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../plugins/installed-plugin-index-store-write.js")>();
+  return {
+    ...actual,
     restorePersistedInstalledPluginIndexIfCurrent,
   };
 });
@@ -1479,7 +1485,6 @@ describe("update-cli", () => {
     vi.resetAllMocks();
     serviceEnabled.mockResolvedValue(true);
     readPersistedInstalledPluginIndex.mockResolvedValue(null);
-    restorePersistedInstalledPluginIndex.mockResolvedValue(undefined);
     restorePersistedInstalledPluginIndexIfCurrent.mockResolvedValue(true);
     writePersistedInstalledPluginIndexInstallRecords.mockResolvedValue(undefined);
     writePersistedInstalledPluginIndexInstallRecordsWithLease.mockResolvedValue({

--- a/src/cli/update-cli/update-command-post-core.ts
+++ b/src/cli/update-cli/update-command-post-core.ts
@@ -36,7 +36,7 @@ import {
 import type { UpdateRunResult } from "../../infra/update-runner.js";
 import { getWindowsSystem32ExePath } from "../../infra/windows-install-roots.js";
 import { writePersistedInstalledPluginIndexInstallRecordsWithLease } from "../../plugins/installed-plugin-index-records.js";
-import { restorePersistedInstalledPluginIndexIfCurrent } from "../../plugins/installed-plugin-index-store.js";
+import { restorePersistedInstalledPluginIndexIfCurrent } from "../../plugins/installed-plugin-index-store-write.js";
 import { withPluginLifecycleLease } from "../../plugins/plugin-lifecycle-lease.js";
 import { runExec } from "../../process/exec.js";
 import { defaultRuntime } from "../../runtime.js";

--- a/src/commands/backup-sqlite.test.ts
+++ b/src/commands/backup-sqlite.test.ts
@@ -7,7 +7,7 @@ import { createLocalSqliteSnapshotProvider } from "../snapshot/local-repository.
 import { OPENCLAW_AGENT_SCHEMA_VERSION } from "../state/openclaw-agent-db.js";
 import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.paths.js";
 import { OPENCLAW_AGENT_SCHEMA_SQL } from "../state/openclaw-agent-schema.js";
-import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { OPENCLAW_STATE_SCHEMA_SQL } from "../state/openclaw-state-schema.js";
 import {

--- a/src/commands/doctor-config-preflight-plugin-index.test.ts
+++ b/src/commands/doctor-config-preflight-plugin-index.test.ts
@@ -6,7 +6,7 @@ import type { DoctorConfigPreflightPluginSnapshotRead } from "./doctor-config-pr
 
 const writePersistedInstalledPluginIndexWithLeaseSync = vi.hoisted(() => vi.fn());
 
-vi.mock("../plugins/installed-plugin-index-store.js", () => ({
+vi.mock("../plugins/installed-plugin-index-store-write.js", () => ({
   writePersistedInstalledPluginIndexWithLeaseSync,
 }));
 

--- a/src/commands/doctor-config-preflight-plugin-index.ts
+++ b/src/commands/doctor-config-preflight-plugin-index.ts
@@ -10,8 +10,8 @@ import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { addDoctorLegacyIssues } from "./doctor/shared/legacy-config-issues.js";
 import { completeDoctorPluginMetadataSnapshot } from "./doctor/shared/plugin-metadata-snapshot-scope.js";
 
-const loadInstalledPluginIndexStore = createLazyRuntimeModule(
-  () => import("../plugins/installed-plugin-index-store.js"),
+const loadInstalledPluginIndexStoreWrite = createLazyRuntimeModule(
+  () => import("../plugins/installed-plugin-index-store-write.js"),
 );
 
 export type DoctorConfigPreflightPluginSnapshotRead = {
@@ -89,7 +89,7 @@ export async function persistRefreshedPluginIndex(params: {
   }
   const { writePersistedInstalledPluginIndexWithLeaseSync } = await params.measure(
     "plugin-index-store-import",
-    loadInstalledPluginIndexStore,
+    loadInstalledPluginIndexStoreWrite,
   );
   // The checkpoint certifies the persisted inventory, not a process-local replacement.
   // Write the exact derived index first, then prove a fresh reader can reuse it.

--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -203,7 +203,7 @@ vi.mock("../infra/startup-migration-checkpoint.js", () => ({
   recordSuccessfulStartupMigrations,
 }));
 
-vi.mock("../plugins/installed-plugin-index-store.js", () => ({
+vi.mock("../plugins/installed-plugin-index-store-write.js", () => ({
   writePersistedInstalledPluginIndexWithLeaseSync,
 }));
 

--- a/src/commands/doctor-plugin-registry.retirement.test.ts
+++ b/src/commands/doctor-plugin-registry.retirement.test.ts
@@ -2,10 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { resolvePluginNpmProjectDir } from "../plugins/install-paths.js";
-import {
-  readPersistedInstalledPluginIndex,
-  writePersistedInstalledPluginIndex,
-} from "../plugins/installed-plugin-index-store.js";
+import { writePersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store-write.js";
+import { readPersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "../plugins/test-helpers/fs-fixtures.js";
 import { maybeRepairStaleManagedNpmBundledPlugins } from "./doctor-plugin-registry.js";
 

--- a/src/commands/doctor-plugin-registry.test.ts
+++ b/src/commands/doctor-plugin-registry.test.ts
@@ -6,10 +6,10 @@ import { note } from "../../packages/terminal-core/src/note.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginCandidate } from "../plugins/discovery.js";
 import { resolvePluginNpmProjectDir } from "../plugins/install-paths.js";
+import { writePersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store-write.js";
 import {
   readPersistedInstalledPluginIndex,
   resolveInstalledPluginIndexStorePath,
-  writePersistedInstalledPluginIndex,
 } from "../plugins/installed-plugin-index-store.js";
 import type { InstalledPluginIndex } from "../plugins/installed-plugin-index.js";
 import { markRetainedManagedNpmInstall } from "../plugins/managed-npm-retention.js";

--- a/src/commands/doctor-plugin-registry.ts
+++ b/src/commands/doctor-plugin-registry.ts
@@ -19,7 +19,7 @@ import {
 import { loadInstalledPluginIndex } from "../plugins/installed-plugin-index.js";
 import { hasRetainedManagedNpmInstallMarker } from "../plugins/managed-npm-retention.js";
 import { resolveInstalledManifestRegistryIndexFingerprint } from "../plugins/manifest-registry-installed.js";
-import { refreshPluginRegistry } from "../plugins/plugin-registry.js";
+import { refreshPluginRegistry } from "../plugins/plugin-registry-refresh.js";
 import {
   listStaleLocalBundledPluginInstallRecords,
   type StaleLocalBundledPluginInstallRecord,

--- a/src/commands/doctor-post-upgrade.test.ts
+++ b/src/commands/doctor-post-upgrade.test.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { resetLogger, setLoggerOverride } from "../logging.js";
-import { writePersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store.js";
+import { writePersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store-write.js";
 import type { InstalledPluginIndex } from "../plugins/installed-plugin-index.js";
 import { runPostUpgradeProbes } from "./doctor-post-upgrade.js";
 

--- a/src/commands/doctor-skill-workshop-sqlite.test.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.test.ts
@@ -15,10 +15,8 @@ import {
   type SkillProposalRecord,
   type SkillProposalRollback,
 } from "../skills/workshop/types.js";
-import {
-  OPENCLAW_STATE_SCHEMA_VERSION,
-  openOpenClawStateDatabase,
-} from "../state/openclaw-state-db.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
+import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,

--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -24,18 +24,16 @@ import {
   seedPluginStateEntriesForTests,
   setMaxPluginStateEntriesPerPluginForTests,
 } from "../plugin-state/plugin-state-store.test-helpers.js";
-import {
-  readPersistedInstalledPluginIndex,
-  writePersistedInstalledPluginIndex,
-} from "../plugins/installed-plugin-index-store.js";
+import { writePersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store-write.js";
+import { readPersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store.js";
 import type { InstalledPluginInstallRecordInfo } from "../plugins/installed-plugin-index.js";
 import { EMPTY_LEGACY_SESSION_SURFACES } from "../plugins/legacy-session-surfaces.types.js";
 import { readConfigMachineState, writeConfigMachineState } from "../state/config-machine-state.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
-  OPENCLAW_STATE_SCHEMA_VERSION,
 } from "../state/openclaw-state-db.js";
 import { loadTaskFlowRegistryStateFromSqlite } from "../tasks/task-flow-registry.store.sqlite.js";
 import { loadTaskRegistryStateFromSqlite } from "../tasks/task-registry.store.sqlite.js";

--- a/src/commands/doctor-state-sqlite-compact.test.ts
+++ b/src/commands/doctor-state-sqlite-compact.test.ts
@@ -8,10 +8,10 @@ import {
   readOpenClawDatabaseQuarantine,
   recordOpenClawDatabaseQuarantine,
 } from "../state/openclaw-quarantine-store.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
 import {
   closeOpenClawStateDatabase,
   openOpenClawStateDatabase,
-  OPENCLAW_STATE_SCHEMA_VERSION,
 } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { OPENCLAW_STATE_SCHEMA_SQL } from "../state/openclaw-state-schema.js";

--- a/src/commands/doctor.refuses-newer-database-schemas.e2e.test.ts
+++ b/src/commands/doctor.refuses-newer-database-schemas.e2e.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
-import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import {
   autoMigrateLegacyStateDir,

--- a/src/commands/doctor/cron/schema-safety.test.ts
+++ b/src/commands/doctor/cron/schema-safety.test.ts
@@ -6,10 +6,8 @@ import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { isSqliteSchemaVersionError } from "../../../infra/sqlite-user-version.js";
-import {
-  closeOpenClawStateDatabaseForTest,
-  OPENCLAW_STATE_SCHEMA_VERSION,
-} from "../../../state/openclaw-state-db.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../../../state/openclaw-state-db-contract.js";
+import { closeOpenClawStateDatabaseForTest } from "../../../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../../../state/openclaw-state-db.paths.js";
 import { collectLegacyCronStoreHealthFindings, maybeRepairLegacyCronStore } from "./index.js";
 import {

--- a/src/commands/doctor/shared/plugin-registry-migration.test.ts
+++ b/src/commands/doctor/shared/plugin-registry-migration.test.ts
@@ -6,10 +6,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { recordPluginCandidateInstallOwner } from "../../../plugins/candidate-install-owner.js";
 import type { PluginCandidate } from "../../../plugins/discovery.js";
+import { writePersistedInstalledPluginIndex } from "../../../plugins/installed-plugin-index-store-write.js";
 import {
   readPersistedInstalledPluginIndex,
   resolveInstalledPluginIndexStorePath,
-  writePersistedInstalledPluginIndex,
 } from "../../../plugins/installed-plugin-index-store.js";
 import type { InstalledPluginIndex } from "../../../plugins/installed-plugin-index.js";
 import {

--- a/src/commands/doctor/shared/plugin-registry-migration.ts
+++ b/src/commands/doctor/shared/plugin-registry-migration.ts
@@ -13,10 +13,10 @@ import {
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { inspectPersistedInstalledPluginIndexInstallRecordsSync } from "../../../plugins/installed-plugin-index-record-state.js";
 import { loadInstalledPluginIndexInstallRecords } from "../../../plugins/installed-plugin-index-records.js";
+import { writePersistedInstalledPluginIndex } from "../../../plugins/installed-plugin-index-store-write.js";
 import {
   readPersistedInstalledPluginIndexSync,
   resolveInstalledPluginIndexStorePath,
-  writePersistedInstalledPluginIndex,
   type InstalledPluginIndexStoreOptions,
 } from "../../../plugins/installed-plugin-index-store.js";
 import {

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { clearLoadInstalledPluginIndexInstallRecordsCache } from "../plugins/installed-plugin-index-records.js";
-import { writePersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store.js";
+import { writePersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store-write.js";
 import { shouldSuppressMissingCodexPluginDiagnostics } from "./codex-plugin-diagnostics.js";
 import { resolveConfigWidePluginManifestRegistry } from "./io.plugin-metadata.js";
 import { validateConfigObjectWithPlugins as validateConfigObjectWithPluginsRaw } from "./validation.js";

--- a/src/flows/doctor-health.test.ts
+++ b/src/flows/doctor-health.test.ts
@@ -24,7 +24,7 @@ vi.mock("../state/openclaw-agent-db.js", () => ({
   OPENCLAW_AGENT_SCHEMA_VERSION: 1,
 }));
 
-vi.mock("../state/openclaw-state-db.js", () => ({
+vi.mock("../state/openclaw-state-db-contract.js", () => ({
   OPENCLAW_STATE_SCHEMA_VERSION: 1,
 }));
 

--- a/src/flows/doctor-health.ts
+++ b/src/flows/doctor-health.ts
@@ -19,7 +19,7 @@ async function assertDoctorDatabaseSchemasCompatible(): Promise<void> {
   const [databasePreflight, agentDatabase, stateDatabase] = await Promise.all([
     import("../state/openclaw-database-preflight.js"),
     import("../state/openclaw-agent-db.js"),
-    import("../state/openclaw-state-db.js"),
+    import("../state/openclaw-state-db-contract.js"),
   ]);
   const databaseSchemas = databasePreflight.preflightOpenClawDatabaseSchemas({
     env: process.env,

--- a/src/gateway/server-startup-bootstrap.ts
+++ b/src/gateway/server-startup-bootstrap.ts
@@ -97,7 +97,7 @@ export async function prepareGatewayServerBootstrap(input: {
   ] = await Promise.all([
     import("../state/openclaw-database-preflight.js"),
     import("../state/openclaw-agent-db.js"),
-    import("../state/openclaw-state-db.js"),
+    import("../state/openclaw-state-db-contract.js"),
   ]);
   const databaseSchemas = preflightOpenClawDatabaseSchemas({
     env: process.env,

--- a/src/gateway/worker-environments/store.test.ts
+++ b/src/gateway/worker-environments/store.test.ts
@@ -9,12 +9,12 @@ import type {
   WorkerProfile,
   WorkerSshEndpoint,
 } from "../../plugins/types.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../../state/openclaw-state-db-contract.js";
 import { ensureAdditiveStateColumns } from "../../state/openclaw-state-db-schema-additive.js";
 import {
   assertOpenClawStateDatabaseForMaintenance,
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
-  OPENCLAW_STATE_SCHEMA_VERSION,
   type OpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
 import { hashWorkerCredential } from "./credential.js";

--- a/src/infra/device-identity.test.ts
+++ b/src/infra/device-identity.test.ts
@@ -4,10 +4,8 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  closeOpenClawStateDatabaseForTest,
-  OPENCLAW_STATE_SCHEMA_VERSION,
-} from "../state/openclaw-state-db.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { withTempDir } from "../test-utils/temp-dir.js";
 import { resolveDeviceIdentityCoordinatorPaths } from "./device-identity-coordinator-paths.js";
 import { acquireDeviceIdentityCoordinator } from "./device-identity-coordinator.js";

--- a/src/infra/kysely-sync-cache-state.ts
+++ b/src/infra/kysely-sync-cache-state.ts
@@ -10,6 +10,14 @@ export const queryErrorHandlerByDatabase = new WeakMap<DatabaseSync, (error: unk
 // both caches before the native database handle closes.
 export const statementCacheSymbol = Symbol("openclaw.kyselySyncStatementCache");
 
+/** Register the lifecycle owner's handler for synchronous Kysely query failures. */
+export function registerNodeSqliteKyselyQueryErrorHandler(
+  db: DatabaseSync,
+  handler: (error: unknown) => void,
+): void {
+  queryErrorHandlerByDatabase.set(db, handler);
+}
+
 /** Drop cached Kysely state for a DatabaseSync. */
 export function clearNodeSqliteKyselyCacheForDatabase(db: DatabaseSync): void {
   // Delete the database-owned cache before close so statements release their

--- a/src/infra/kysely-sync.test.ts
+++ b/src/infra/kysely-sync.test.ts
@@ -4,6 +4,7 @@ import { constants, DatabaseSync } from "node:sqlite";
 import { sql, type Generated } from "kysely";
 import { afterEach, describe, expect, it } from "vitest";
 import { withTestTimeout } from "../../test/helpers/promise.js";
+import { registerNodeSqliteKyselyQueryErrorHandler } from "./kysely-sync-cache-state.js";
 import {
   clearNodeSqliteKyselyCacheForDatabase,
   enableNodeSqliteKyselyStatementCache,
@@ -11,7 +12,6 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
   iterateSqliteQuerySync,
-  registerNodeSqliteKyselyQueryErrorHandler,
 } from "./kysely-sync.js";
 
 type SyncHelperTestDatabase = {

--- a/src/infra/kysely-sync.ts
+++ b/src/infra/kysely-sync.ts
@@ -58,14 +58,6 @@ export function getNodeSqliteKysely<Database>(db: DatabaseSync): Kysely<Database
   return kysely;
 }
 
-/** Register the lifecycle owner's handler for synchronous Kysely query failures. */
-export function registerNodeSqliteKyselyQueryErrorHandler(
-  db: DatabaseSync,
-  handler: (error: unknown) => void,
-): void {
-  queryErrorHandlerByDatabase.set(db, handler);
-}
-
 function reportNodeSqliteKyselyQueryError(db: DatabaseSync, error: unknown): void {
   try {
     queryErrorHandlerByDatabase.get(db)?.(error);

--- a/src/infra/restart-handoff.test.ts
+++ b/src/infra/restart-handoff.test.ts
@@ -5,10 +5,10 @@ import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   closeOpenClawStateDatabaseForTest,
-  OPENCLAW_STATE_SCHEMA_VERSION,
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
 import {

--- a/src/infra/startup-migration-checkpoint.test.ts
+++ b/src/infra/startup-migration-checkpoint.test.ts
@@ -3,10 +3,10 @@ import { existsSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   closeOpenClawStateDatabaseForTest,
-  OPENCLAW_STATE_SCHEMA_VERSION,
   runOpenClawStateWriteTransaction,
   withOpenClawStateStartupMigrationCheckpointDatabase,
 } from "../state/openclaw-state-db.js";

--- a/src/infra/state-migrations.plugin-state.ts
+++ b/src/infra/state-migrations.plugin-state.ts
@@ -8,10 +8,10 @@ import {
   resolveMaxPluginStateEntriesPerPlugin,
 } from "../plugin-state/plugin-state-store.js";
 import { inspectPersistedInstalledPluginIndexInstallRecordsSync } from "../plugins/installed-plugin-index-record-state.js";
+import { writePersistedInstalledPluginIndexSync } from "../plugins/installed-plugin-index-store-write.js";
 import {
   readPersistedInstalledPluginIndexSync,
   resolveLegacyInstalledPluginIndexStorePath,
-  writePersistedInstalledPluginIndexSync,
 } from "../plugins/installed-plugin-index-store.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";

--- a/src/infra/state-migrations.state-dir.test.ts
+++ b/src/infra/state-migrations.state-dir.test.ts
@@ -4,10 +4,8 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { getPluginInstallRecordMapEntry } from "../config/plugin-install-record-map.js";
 import { hashJson } from "../plugins/installed-plugin-index-hash.js";
-import {
-  readPersistedInstalledPluginIndex,
-  writePersistedInstalledPluginIndex,
-} from "../plugins/installed-plugin-index-store.js";
+import { writePersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store-write.js";
+import { readPersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store.js";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
 import { withTestDir } from "../test-helpers/temp-dir.js";
 import {

--- a/src/infra/state-migrations.test.ts
+++ b/src/infra/state-migrations.test.ts
@@ -27,11 +27,11 @@ import {
   OPENCLAW_AGENT_SCHEMA_VERSION,
   runOpenClawAgentWriteTransaction,
 } from "../state/openclaw-agent-db.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
-  OPENCLAW_STATE_SCHEMA_VERSION,
 } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";

--- a/src/node-host/node-worker-launch-store.test.ts
+++ b/src/node-host/node-worker-launch-store.test.ts
@@ -2,9 +2,9 @@ import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { assertSqliteSchemaContains } from "../infra/sqlite-schema-contract.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
 import {
   closeOpenClawStateDatabaseForTest,
-  OPENCLAW_STATE_SCHEMA_VERSION,
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
 import { OPENCLAW_STATE_MAINTENANCE_SCHEMA_COMPATIBILITY } from "../state/openclaw-state-schema-compatibility.js";

--- a/src/plugin-state/plugin-state-store.fresh-store.test.ts
+++ b/src/plugin-state/plugin-state-store.fresh-store.test.ts
@@ -1,10 +1,8 @@
 // Fresh-store reads remain empty after checkpoint bootstrap; missing canonical tables stay errors.
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
-import {
-  OPENCLAW_STATE_SCHEMA_VERSION,
-  withOpenClawStateStartupMigrationCheckpointDatabase,
-} from "../state/openclaw-state-db.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
+import { withOpenClawStateStartupMigrationCheckpointDatabase } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import {

--- a/src/plugin-state/plugin-state-store.schema.test.ts
+++ b/src/plugin-state/plugin-state-store.schema.test.ts
@@ -1,6 +1,6 @@
 import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
-import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import {

--- a/src/plugin-state/plugin-state-store.test.ts
+++ b/src/plugin-state/plugin-state-store.test.ts
@@ -8,10 +8,10 @@ import {
   clearOpenClawDatabaseQuarantine,
   recordOpenClawDatabaseQuarantine,
 } from "../state/openclaw-quarantine-store.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
 import {
   clearOpenClawStateDatabaseOpenFailure,
   isOpenClawStateDatabaseOpen,
-  OPENCLAW_STATE_SCHEMA_VERSION,
   openOpenClawStateDatabase,
   recordOpenClawStateDatabaseOpenFailure,
 } from "../state/openclaw-state-db.js";

--- a/src/plugins/current-plugin-metadata-snapshot.test.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.test.ts
@@ -14,7 +14,7 @@ import {
 import { clearCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-state.js";
 import { getGlobalHookRunnerRegistry } from "./hook-runner-global-state.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
-import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store.js";
+import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store-write.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";

--- a/src/plugins/install-record-commit.test.ts
+++ b/src/plugins/install-record-commit.test.ts
@@ -36,7 +36,7 @@ const mocks = vi.hoisted(() => {
     replaceConfigFile: vi.fn(),
     restorePersistedInstalledPluginIndexIfCurrent:
       vi.fn<
-        typeof import("./installed-plugin-index-store.js").restorePersistedInstalledPluginIndexIfCurrent
+        typeof import("./installed-plugin-index-store-write.js").restorePersistedInstalledPluginIndexIfCurrent
       >(),
     transformConfigFileWithRetry: vi.fn(),
     withPluginLifecycleLease: vi.fn(
@@ -67,8 +67,8 @@ vi.mock("./installed-plugin-index-records.js", async (importOriginal) => {
   };
 });
 
-vi.mock("./installed-plugin-index-store.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./installed-plugin-index-store.js")>();
+vi.mock("./installed-plugin-index-store-write.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./installed-plugin-index-store-write.js")>();
   return {
     ...actual,
     restorePersistedInstalledPluginIndexIfCurrent:

--- a/src/plugins/install-record-commit.ts
+++ b/src/plugins/install-record-commit.ts
@@ -32,10 +32,10 @@ import {
   writePersistedInstalledPluginIndexInstallRecordsWithLease,
 } from "./installed-plugin-index-records.js";
 import {
-  readPersistedInstalledPluginIndex,
   restorePersistedInstalledPluginIndexIfCurrent,
   type InstalledPluginIndexWriteReceipt,
-} from "./installed-plugin-index-store.js";
+} from "./installed-plugin-index-store-write.js";
+import { readPersistedInstalledPluginIndex } from "./installed-plugin-index-store.js";
 import { RETAINED_MANAGED_NPM_KEEP_FILES_REASON } from "./managed-npm-retention-contract.js";
 import {
   clearRetainedManagedNpmInstallMarker,

--- a/src/plugins/installed-plugin-index-records.test.ts
+++ b/src/plugins/installed-plugin-index-records.test.ts
@@ -11,9 +11,9 @@ import {
 } from "../config/plugin-install-record-map.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
 import {
   closeOpenClawStateDatabaseForTest,
-  OPENCLAW_STATE_SCHEMA_VERSION,
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
 import { withMockedWindowsPlatform } from "../test-utils/vitest-spies.js";

--- a/src/plugins/installed-plugin-index-records.ts
+++ b/src/plugins/installed-plugin-index-records.ts
@@ -19,7 +19,7 @@ import {
   refreshPersistedInstalledPluginIndexWithLeaseSync,
   type InstalledPluginIndexWriteLease,
   type InstalledPluginIndexWriteReceipt,
-} from "./installed-plugin-index-store.js";
+} from "./installed-plugin-index-store-write.js";
 import type { RefreshInstalledPluginIndexParams } from "./installed-plugin-index.js";
 import { recordPluginInstall, type PluginInstallUpdate } from "./installs.js";
 

--- a/src/plugins/installed-plugin-index-store-write.ts
+++ b/src/plugins/installed-plugin-index-store-write.ts
@@ -1,0 +1,363 @@
+/** Writes, restores, and refreshes the installed plugin index in the state database. */
+import { existsSync } from "node:fs";
+import type { DatabaseSync } from "node:sqlite";
+import {
+  createPluginInstallRecordMap,
+  inspectPluginInstallRecordMap,
+  parsePluginInstallRecord,
+  serializePluginInstallRecordMap,
+  setPluginInstallRecordMapEntry,
+} from "../config/plugin-install-record-map.js";
+import type { PluginInstallRecord } from "../config/types.plugins.js";
+import { resolveUserPath } from "../infra/home-dir.js";
+import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
+import { resolveCompatibilityHostVersion } from "../version.js";
+import { normalizePluginsConfig, resolveEffectiveEnableState } from "./config-state.js";
+import { isPluginEnabledByDefaultForPlatform } from "./default-enablement.js";
+import { hashStableJson } from "./installed-plugin-index-hash.js";
+import {
+  isInstalledPluginIndexInstallOwnerAmbiguous,
+  resolveInstalledPluginIndexInstallOwner,
+} from "./installed-plugin-index-install-owner.js";
+import { resolveCompatRegistryVersion } from "./installed-plugin-index-policy.js";
+import { clearLoadInstalledPluginIndexInstallRecordsCache } from "./installed-plugin-index-record-cache.js";
+import { resolveInstalledPluginIndexStateDatabaseOptions } from "./installed-plugin-index-store-path.js";
+import {
+  INSTALLED_PLUGIN_INDEX_STATE_KEY,
+  parseInstalledPluginIndexSqliteRow,
+  readInstalledPluginIndexRow,
+  readPersistedInstalledPluginIndexSync,
+  resolveInstalledPluginIndexStorePath,
+  type InstalledPluginIndexStoreOptions,
+  type PersistedInstalledPluginIndexValue,
+} from "./installed-plugin-index-store.js";
+import {
+  extractPluginInstallRecordsFromInstalledPluginIndex,
+  hasInstalledPluginIndexWorkspaceScopeMismatch,
+  hasMissingConfigPathActivationMetadata,
+  INSTALLED_PLUGIN_INDEX_WARNING,
+  INSTALLED_PLUGIN_INDEX_VERSION,
+  INSTALLED_PLUGIN_INDEX_MIGRATION_VERSION,
+  resolveInstalledPluginIndexPolicyHash,
+  refreshInstalledPluginIndex,
+  type InstalledPluginIndex,
+  type RefreshInstalledPluginIndexParams,
+} from "./installed-plugin-index.js";
+import { hasMissingInstalledPluginOwnerMetadata } from "./installed-plugin-package-ownership.js";
+import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
+
+export type InstalledPluginIndexWriteLease = {
+  assertOwnedInTransaction(database: DatabaseSync): void;
+};
+
+export type InstalledPluginIndexWriteReceipt = {
+  previous: InstalledPluginIndex | null;
+  revision: number;
+};
+
+function assertWritableInstalledPluginIndexStoreOptions(
+  options: InstalledPluginIndexStoreOptions,
+): void {
+  if (options.filePath?.endsWith(".json")) {
+    throw new Error(
+      "Explicit JSON installed plugin index paths are retired. Use the shared SQLite state DB or run openclaw doctor --fix to migrate legacy plugins/installs.json.",
+    );
+  }
+}
+
+function preparePersistedInstalledPluginIndex(index: InstalledPluginIndex): InstalledPluginIndex {
+  const installRecords = createPluginInstallRecordMap<PluginInstallRecord>();
+  for (const [pluginId, rawRecord] of Object.entries(index.installRecords)) {
+    const record = parsePluginInstallRecord(rawRecord);
+    if (!record) {
+      throw new Error("Invalid plugin install record");
+    }
+    setPluginInstallRecordMapEntry(installRecords, pluginId, record);
+  }
+  return {
+    ...index,
+    warning: INSTALLED_PLUGIN_INDEX_WARNING,
+    installRecords,
+  };
+}
+
+function resolveNextInstalledPluginIndexRevision(current: number | null): number {
+  // Revisions fence rollback across processes, so same-millisecond writes must
+  // still receive distinct values.
+  return Math.max(Date.now(), (current ?? 0) + 1);
+}
+
+function writePersistedInstalledPluginIndexRow(
+  database: DatabaseSync,
+  index: InstalledPluginIndex,
+  revision: number,
+): void {
+  const persistedIndex = {
+    version: index.version,
+    warning: index.warning ?? INSTALLED_PLUGIN_INDEX_WARNING,
+    hostContractVersion: index.hostContractVersion,
+    compatRegistryVersion: index.compatRegistryVersion,
+    migrationVersion: index.migrationVersion,
+    policyHash: index.policyHash,
+    generatedAtMs: index.generatedAtMs,
+    ...(index.workspaceDir !== undefined ? { workspaceDir: index.workspaceDir } : {}),
+    ...(index.refreshReason ? { refreshReason: index.refreshReason } : {}),
+    // SAFETY: canonical serializer output re-parsed for byte-order-stable embedding.
+    installRecords: JSON.parse(serializePluginInstallRecordMap(index.installRecords)) as unknown,
+    plugins: index.plugins.map((plugin) => {
+      const installOwner = resolveInstalledPluginIndexInstallOwner(plugin);
+      return {
+        ...plugin,
+        ...(installOwner ? { installOwner } : {}),
+        ...(isInstalledPluginIndexInstallOwnerAmbiguous(plugin)
+          ? { installOwnerAmbiguous: true }
+          : {}),
+      };
+    }),
+    diagnostics: index.diagnostics,
+  };
+  const valueJson = JSON.stringify({
+    revision,
+    index: persistedIndex,
+  } satisfies PersistedInstalledPluginIndexValue);
+  database
+    .prepare(
+      `
+        INSERT INTO config_machine_state (state_key, value_json, updated_at_ms)
+        VALUES (?, ?, ?)
+        ON CONFLICT(state_key) DO UPDATE SET
+          value_json = excluded.value_json,
+          updated_at_ms = excluded.updated_at_ms
+      `,
+    )
+    .run(INSTALLED_PLUGIN_INDEX_STATE_KEY, valueJson, revision);
+}
+
+function writePersistedInstalledPluginIndexToSqlite(
+  index: InstalledPluginIndex,
+  options: InstalledPluginIndexStoreOptions = {},
+  lease?: InstalledPluginIndexWriteLease,
+): InstalledPluginIndexWriteReceipt {
+  assertWritableInstalledPluginIndexStoreOptions(options);
+  const persisted = preparePersistedInstalledPluginIndex(index);
+  return runOpenClawStateWriteTransaction(({ db }) => {
+    const previousRow = readInstalledPluginIndexRow(db);
+    if (previousRow) {
+      // SAFETY: field probe on the stored value; inspectPluginInstallRecordMap validates it.
+      const previousInstallRecords = (previousRow.index as { installRecords?: unknown } | null)
+        ?.installRecords;
+      if (
+        previousInstallRecords === undefined ||
+        inspectPluginInstallRecordMap(previousInstallRecords).status === "invalid"
+      ) {
+        throw new Error(
+          "Persisted plugin install records are invalid. Repair the state before writing plugin installation metadata.",
+        );
+      }
+    }
+    lease?.assertOwnedInTransaction(db);
+    const revision = resolveNextInstalledPluginIndexRevision(
+      previousRow ? previousRow.revision : null,
+    );
+    writePersistedInstalledPluginIndexRow(db, persisted, revision);
+    return {
+      previous: parseInstalledPluginIndexSqliteRow(previousRow),
+      revision,
+    };
+  }, resolveInstalledPluginIndexStateDatabaseOptions(options));
+}
+
+function clearPersistedInstalledPluginIndexCaches(): void {
+  clearPluginMetadataLifecycleCaches();
+  clearLoadInstalledPluginIndexInstallRecordsCache();
+}
+
+export async function writePersistedInstalledPluginIndex(
+  index: InstalledPluginIndex,
+  options: InstalledPluginIndexStoreOptions = {},
+): Promise<string> {
+  return writePersistedInstalledPluginIndexSync(index, options);
+}
+
+/** Restore a snapshot only while the caller's tentative write is still current. */
+export async function restorePersistedInstalledPluginIndexIfCurrent(
+  index: InstalledPluginIndex | null,
+  expectedRevision: number,
+  options: InstalledPluginIndexStoreOptions & {
+    lease: InstalledPluginIndexWriteLease;
+  },
+): Promise<boolean> {
+  const { lease, ...storeOptions } = options;
+  assertWritableInstalledPluginIndexStoreOptions(storeOptions);
+  if (!existsSync(resolveInstalledPluginIndexStorePath(storeOptions))) {
+    return false;
+  }
+  const restored = runOpenClawStateWriteTransaction(({ db }) => {
+    lease.assertOwnedInTransaction(db);
+    const currentRow = readInstalledPluginIndexRow(db);
+    const currentRevision = currentRow ? currentRow.revision : null;
+    if (currentRevision !== expectedRevision) {
+      return false;
+    }
+    if (index) {
+      writePersistedInstalledPluginIndexRow(
+        db,
+        preparePersistedInstalledPluginIndex(index),
+        resolveNextInstalledPluginIndexRevision(currentRevision),
+      );
+    } else {
+      db.prepare("DELETE FROM config_machine_state WHERE state_key = ?").run(
+        INSTALLED_PLUGIN_INDEX_STATE_KEY,
+      );
+    }
+    return true;
+  }, resolveInstalledPluginIndexStateDatabaseOptions(storeOptions));
+  // A mismatched revision means another process committed, which also makes
+  // this process's cached metadata stale.
+  clearPersistedInstalledPluginIndexCaches();
+  return restored;
+}
+
+export function writePersistedInstalledPluginIndexSync(
+  index: InstalledPluginIndex,
+  options: InstalledPluginIndexStoreOptions = {},
+): string {
+  const filePath = resolveInstalledPluginIndexStorePath(options);
+  writePersistedInstalledPluginIndexToSqlite(index, options);
+  clearPersistedInstalledPluginIndexCaches();
+  return filePath;
+}
+
+export function writePersistedInstalledPluginIndexWithLeaseSync(
+  index: InstalledPluginIndex,
+  options: InstalledPluginIndexStoreOptions & {
+    lease: InstalledPluginIndexWriteLease;
+  },
+): string {
+  const { lease, ...storeOptions } = options;
+  const filePath = resolveInstalledPluginIndexStorePath(storeOptions);
+  writePersistedInstalledPluginIndexToSqlite(index, storeOptions, lease);
+  clearPersistedInstalledPluginIndexCaches();
+  return filePath;
+}
+
+function hasCompletePolicyRefreshProjection(
+  persisted: InstalledPluginIndex,
+  policyPluginIds: readonly string[] | undefined,
+  env: NodeJS.ProcessEnv,
+): boolean {
+  const pluginIds = new Set(persisted.plugins.map((plugin) => plugin.pluginId));
+  if (policyPluginIds?.some((pluginId) => !pluginIds.has(pluginId))) {
+    return false;
+  }
+  const installOwners = new Set(persisted.plugins.map(resolveInstalledPluginIndexInstallOwner));
+  return Object.entries(persisted.installRecords).every(([installOwner, record]) => {
+    if (installOwners.has(installOwner)) {
+      return true;
+    }
+    const installedPath = record.installPath?.trim() || record.sourcePath?.trim();
+    // Missing package bytes are orphaned owner records, not rediscoverable plugins.
+    return !installedPath || !existsSync(resolveUserPath(installedPath, env));
+  });
+}
+
+function canRefreshPersistedPolicyState(
+  persisted: InstalledPluginIndex | null,
+  params: RefreshInstalledPluginIndexParams & InstalledPluginIndexStoreOptions,
+): persisted is InstalledPluginIndex {
+  if (!persisted || params.reason !== "policy-changed") {
+    return false;
+  }
+  if (
+    (params.diagnostics?.length ?? 0) > 0 ||
+    persisted.diagnostics.some((diagnostic) => diagnostic.code === "workspace-scope-omitted") ||
+    hasInstalledPluginIndexWorkspaceScopeMismatch(persisted, params.workspaceDir)
+  ) {
+    return false;
+  }
+  const env = params.env ?? process.env;
+  if (
+    persisted.version !== INSTALLED_PLUGIN_INDEX_VERSION ||
+    persisted.hostContractVersion !== resolveCompatibilityHostVersion(env) ||
+    persisted.compatRegistryVersion !== resolveCompatRegistryVersion() ||
+    persisted.migrationVersion !== INSTALLED_PLUGIN_INDEX_MIGRATION_VERSION ||
+    hasMissingConfigPathActivationMetadata(persisted) ||
+    hasMissingInstalledPluginOwnerMetadata(persisted, env)
+  ) {
+    return false;
+  }
+  if (
+    params.installRecords &&
+    hashStableJson(params.installRecords) !== hashStableJson(persisted.installRecords ?? {})
+  ) {
+    return false;
+  }
+  return hasCompletePolicyRefreshProjection(persisted, params.policyPluginIds, env);
+}
+
+function refreshPersistedPolicyState(
+  persisted: InstalledPluginIndex,
+  params: RefreshInstalledPluginIndexParams,
+): InstalledPluginIndex {
+  const normalizedConfig = normalizePluginsConfig(params.config?.plugins);
+  return {
+    ...persisted,
+    policyHash: resolveInstalledPluginIndexPolicyHash(params.config),
+    generatedAtMs: (params.now?.() ?? new Date()).getTime(),
+    refreshReason: params.reason,
+    plugins: persisted.plugins.map((plugin) => ({
+      ...plugin,
+      enabled: resolveEffectiveEnableState({
+        id: plugin.pluginId,
+        origin: plugin.origin,
+        config: normalizedConfig,
+        rootConfig: params.config,
+        enabledByDefault: isPluginEnabledByDefaultForPlatform(plugin),
+      }).enabled,
+    })),
+  };
+}
+
+export async function refreshPersistedInstalledPluginIndex(
+  params: RefreshInstalledPluginIndexParams & InstalledPluginIndexStoreOptions,
+): Promise<InstalledPluginIndex> {
+  return refreshPersistedInstalledPluginIndexSync(params);
+}
+
+function resolveRefreshedPersistedInstalledPluginIndex(
+  params: RefreshInstalledPluginIndexParams & InstalledPluginIndexStoreOptions,
+): InstalledPluginIndex {
+  const persisted =
+    params.reason === "policy-changed" || !params.installRecords
+      ? readPersistedInstalledPluginIndexSync(params)
+      : null;
+  if (canRefreshPersistedPolicyState(persisted, params)) {
+    return refreshPersistedPolicyState(persisted, params);
+  }
+  return refreshInstalledPluginIndex({
+    ...params,
+    installRecords:
+      params.installRecords ?? extractPluginInstallRecordsFromInstalledPluginIndex(persisted),
+  });
+}
+
+export function refreshPersistedInstalledPluginIndexSync(
+  params: RefreshInstalledPluginIndexParams & InstalledPluginIndexStoreOptions,
+): InstalledPluginIndex {
+  const index = resolveRefreshedPersistedInstalledPluginIndex(params);
+  writePersistedInstalledPluginIndexSync(index, params);
+  return index;
+}
+
+export function refreshPersistedInstalledPluginIndexWithLeaseSync(
+  params: RefreshInstalledPluginIndexParams &
+    InstalledPluginIndexStoreOptions & {
+      lease: InstalledPluginIndexWriteLease;
+    },
+): InstalledPluginIndexWriteReceipt {
+  const { lease, ...storeParams } = params;
+  const index = resolveRefreshedPersistedInstalledPluginIndex(storeParams);
+  const receipt = writePersistedInstalledPluginIndexToSqlite(index, storeParams, lease);
+  clearPersistedInstalledPluginIndexCaches();
+  return receipt;
+}

--- a/src/plugins/installed-plugin-index-store.install-record-map.test.ts
+++ b/src/plugins/installed-plugin-index-store.install-record-map.test.ts
@@ -8,10 +8,8 @@ import {
   closeOpenClawStateDatabaseForTest,
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
-import {
-  readPersistedInstalledPluginIndex,
-  writePersistedInstalledPluginIndex,
-} from "./installed-plugin-index-store.js";
+import { writePersistedInstalledPluginIndex } from "./installed-plugin-index-store-write.js";
+import { readPersistedInstalledPluginIndex } from "./installed-plugin-index-store.js";
 import type { InstalledPluginIndex } from "./installed-plugin-index.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
 

--- a/src/plugins/installed-plugin-index-store.test.ts
+++ b/src/plugins/installed-plugin-index-store.test.ts
@@ -7,9 +7,9 @@ import {
   acquireStartupMigrationLease,
   STARTUP_MIGRATION_LEASE_TTL_MS,
 } from "../infra/startup-migration-checkpoint.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
 import {
   closeOpenClawStateDatabaseForTest,
-  OPENCLAW_STATE_SCHEMA_VERSION,
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
 import { recordPluginCandidateInstallOwner } from "./candidate-install-owner.js";
@@ -20,12 +20,14 @@ import {
   writePersistedInstalledPluginIndexInstallRecordsWithLease,
 } from "./installed-plugin-index-records.js";
 import {
-  readPersistedInstalledPluginIndex,
   refreshPersistedInstalledPluginIndex,
-  resolveInstalledPluginIndexStorePath,
   restorePersistedInstalledPluginIndexIfCurrent,
   writePersistedInstalledPluginIndex,
   writePersistedInstalledPluginIndexWithLeaseSync,
+} from "./installed-plugin-index-store-write.js";
+import {
+  readPersistedInstalledPluginIndex,
+  resolveInstalledPluginIndexStorePath,
 } from "./installed-plugin-index-store.js";
 import {
   resolveInstalledPluginIndexPolicyHash,

--- a/src/plugins/installed-plugin-index-store.ts
+++ b/src/plugins/installed-plugin-index-store.ts
@@ -1,70 +1,35 @@
-/** Persists, inspects, and refreshes the installed plugin index in the state database. */
-import { existsSync } from "node:fs";
+/** Reads and parses the installed plugin index in the state database. */
 import type { DatabaseSync } from "node:sqlite";
 import { safeParseJson } from "@openclaw/normalization-core/json-coercion";
 import { z } from "zod";
 import {
-  createPluginInstallRecordMap,
-  inspectPluginInstallRecordMap,
-  parsePluginInstallRecord,
   parsePluginInstallRecordMap,
   PluginInstallRecordSchema,
-  serializePluginInstallRecordMap,
-  setPluginInstallRecordMapEntry,
 } from "../config/plugin-install-record-map.js";
-import type { PluginInstallRecord } from "../config/types.plugins.js";
-import { resolveUserPath } from "../infra/home-dir.js";
 import { isSqliteSchemaVersionError } from "../infra/sqlite-user-version.js";
 import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
-import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
 import { safeParseWithSchema } from "../utils/zod-parse.js";
-import { resolveCompatibilityHostVersion } from "../version.js";
-import { normalizePluginsConfig, resolveEffectiveEnableState } from "./config-state.js";
-import { isPluginEnabledByDefaultForPlatform } from "./default-enablement.js";
-import { hashStableJson } from "./installed-plugin-index-hash.js";
-import {
-  isInstalledPluginIndexInstallOwnerAmbiguous,
-  recordInstalledPluginIndexInstallOwner,
-  resolveInstalledPluginIndexInstallOwner,
-} from "./installed-plugin-index-install-owner.js";
-import { resolveCompatRegistryVersion } from "./installed-plugin-index-policy.js";
-import { clearLoadInstalledPluginIndexInstallRecordsCache } from "./installed-plugin-index-record-cache.js";
+import { recordInstalledPluginIndexInstallOwner } from "./installed-plugin-index-install-owner.js";
 import {
   resolveInstalledPluginIndexStateDatabaseOptions,
-  resolveInstalledPluginIndexStorePath,
   type InstalledPluginIndexStoreOptions,
 } from "./installed-plugin-index-store-path.js";
 import {
   extractPluginInstallRecordsFromInstalledPluginIndex,
-  hasInstalledPluginIndexWorkspaceScopeMismatch,
-  hasMissingConfigPathActivationMetadata,
-  INSTALLED_PLUGIN_INDEX_WARNING,
   INSTALLED_PLUGIN_INDEX_VERSION,
   INSTALLED_PLUGIN_INDEX_MIGRATION_VERSION,
-  resolveInstalledPluginIndexPolicyHash,
-  refreshInstalledPluginIndex,
   type InstalledPluginIndex,
-  type RefreshInstalledPluginIndexParams,
 } from "./installed-plugin-index.js";
-import { hasMissingInstalledPluginOwnerMetadata } from "./installed-plugin-package-ownership.js";
-import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
+
 export {
   resolveInstalledPluginIndexStorePath,
   resolveLegacyInstalledPluginIndexStorePath,
   type InstalledPluginIndexStoreOptions,
 } from "./installed-plugin-index-store-path.js";
 
-export type InstalledPluginIndexWriteLease = {
-  assertOwnedInTransaction(database: DatabaseSync): void;
-};
-
-export type InstalledPluginIndexWriteReceipt = {
-  previous: InstalledPluginIndex | null;
-  revision: number;
-};
-
 const StringArraySchema = z.array(z.string());
-const INSTALLED_PLUGIN_INDEX_STATE_KEY = "plugins.installedIndex";
+// Shared with installed-plugin-index-store-write.ts.
+export const INSTALLED_PLUGIN_INDEX_STATE_KEY = "plugins.installedIndex";
 
 const InstalledPluginIndexStartupSchema = z.object({
   sidecar: z.boolean(),
@@ -195,44 +160,21 @@ export function parseInstalledPluginIndex(value: unknown): InstalledPluginIndex 
   };
 }
 
-type PersistedInstalledPluginIndexValue = {
+// Shared with installed-plugin-index-store-write.ts.
+export type PersistedInstalledPluginIndexValue = {
   revision: number;
   index: unknown;
 };
 
-function assertWritableInstalledPluginIndexStoreOptions(
-  options: InstalledPluginIndexStoreOptions,
-): void {
-  if (options.filePath?.endsWith(".json")) {
-    throw new Error(
-      "Explicit JSON installed plugin index paths are retired. Use the shared SQLite state DB or run openclaw doctor --fix to migrate legacy plugins/installs.json.",
-    );
-  }
-}
-
-function parseInstalledPluginIndexSqliteRow(
+// Shared with installed-plugin-index-store-write.ts.
+export function parseInstalledPluginIndexSqliteRow(
   value: PersistedInstalledPluginIndexValue | undefined,
 ): InstalledPluginIndex | null {
   return value ? parseInstalledPluginIndex(value.index) : null;
 }
 
-function preparePersistedInstalledPluginIndex(index: InstalledPluginIndex): InstalledPluginIndex {
-  const installRecords = createPluginInstallRecordMap<PluginInstallRecord>();
-  for (const [pluginId, rawRecord] of Object.entries(index.installRecords)) {
-    const record = parsePluginInstallRecord(rawRecord);
-    if (!record) {
-      throw new Error("Invalid plugin install record");
-    }
-    setPluginInstallRecordMapEntry(installRecords, pluginId, record);
-  }
-  return {
-    ...index,
-    warning: INSTALLED_PLUGIN_INDEX_WARNING,
-    installRecords,
-  };
-}
-
-function readInstalledPluginIndexRow(
+// Shared with installed-plugin-index-store-write.ts.
+export function readInstalledPluginIndexRow(
   database: DatabaseSync,
 ): PersistedInstalledPluginIndexValue | undefined {
   const row = database
@@ -253,58 +195,6 @@ function readInstalledPluginIndexRow(
   }
   // SAFETY: revision checked above; index stays unknown until parseInstalledPluginIndex.
   return value as PersistedInstalledPluginIndexValue;
-}
-
-function resolveNextInstalledPluginIndexRevision(current: number | null): number {
-  // Revisions fence rollback across processes, so same-millisecond writes must
-  // still receive distinct values.
-  return Math.max(Date.now(), (current ?? 0) + 1);
-}
-
-function writePersistedInstalledPluginIndexRow(
-  database: DatabaseSync,
-  index: InstalledPluginIndex,
-  revision: number,
-): void {
-  const persistedIndex = {
-    version: index.version,
-    warning: index.warning ?? INSTALLED_PLUGIN_INDEX_WARNING,
-    hostContractVersion: index.hostContractVersion,
-    compatRegistryVersion: index.compatRegistryVersion,
-    migrationVersion: index.migrationVersion,
-    policyHash: index.policyHash,
-    generatedAtMs: index.generatedAtMs,
-    ...(index.workspaceDir !== undefined ? { workspaceDir: index.workspaceDir } : {}),
-    ...(index.refreshReason ? { refreshReason: index.refreshReason } : {}),
-    // SAFETY: canonical serializer output re-parsed for byte-order-stable embedding.
-    installRecords: JSON.parse(serializePluginInstallRecordMap(index.installRecords)) as unknown,
-    plugins: index.plugins.map((plugin) => {
-      const installOwner = resolveInstalledPluginIndexInstallOwner(plugin);
-      return {
-        ...plugin,
-        ...(installOwner ? { installOwner } : {}),
-        ...(isInstalledPluginIndexInstallOwnerAmbiguous(plugin)
-          ? { installOwnerAmbiguous: true }
-          : {}),
-      };
-    }),
-    diagnostics: index.diagnostics,
-  };
-  const valueJson = JSON.stringify({
-    revision,
-    index: persistedIndex,
-  } satisfies PersistedInstalledPluginIndexValue);
-  database
-    .prepare(
-      `
-        INSERT INTO config_machine_state (state_key, value_json, updated_at_ms)
-        VALUES (?, ?, ?)
-        ON CONFLICT(state_key) DO UPDATE SET
-          value_json = excluded.value_json,
-          updated_at_ms = excluded.updated_at_ms
-      `,
-    )
-    .run(INSTALLED_PLUGIN_INDEX_STATE_KEY, valueJson, revision);
 }
 
 function readPersistedInstalledPluginIndexFromSqlite(
@@ -328,45 +218,6 @@ function readPersistedInstalledPluginIndexFromSqlite(
   }
 }
 
-function writePersistedInstalledPluginIndexToSqlite(
-  index: InstalledPluginIndex,
-  options: InstalledPluginIndexStoreOptions = {},
-  lease?: InstalledPluginIndexWriteLease,
-): InstalledPluginIndexWriteReceipt {
-  assertWritableInstalledPluginIndexStoreOptions(options);
-  const persisted = preparePersistedInstalledPluginIndex(index);
-  return runOpenClawStateWriteTransaction(({ db }) => {
-    const previousRow = readInstalledPluginIndexRow(db);
-    if (previousRow) {
-      // SAFETY: field probe on the stored value; inspectPluginInstallRecordMap validates it.
-      const previousInstallRecords = (previousRow.index as { installRecords?: unknown } | null)
-        ?.installRecords;
-      if (
-        previousInstallRecords === undefined ||
-        inspectPluginInstallRecordMap(previousInstallRecords).status === "invalid"
-      ) {
-        throw new Error(
-          "Persisted plugin install records are invalid. Repair the state before writing plugin installation metadata.",
-        );
-      }
-    }
-    lease?.assertOwnedInTransaction(db);
-    const revision = resolveNextInstalledPluginIndexRevision(
-      previousRow ? previousRow.revision : null,
-    );
-    writePersistedInstalledPluginIndexRow(db, persisted, revision);
-    return {
-      previous: parseInstalledPluginIndexSqliteRow(previousRow),
-      revision,
-    };
-  }, resolveInstalledPluginIndexStateDatabaseOptions(options));
-}
-
-function clearPersistedInstalledPluginIndexCaches(): void {
-  clearPluginMetadataLifecycleCaches();
-  clearLoadInstalledPluginIndexInstallRecordsCache();
-}
-
 export async function readPersistedInstalledPluginIndex(
   options: InstalledPluginIndexStoreOptions = {},
 ): Promise<InstalledPluginIndex | null> {
@@ -377,194 +228,4 @@ export function readPersistedInstalledPluginIndexSync(
   options: InstalledPluginIndexStoreOptions = {},
 ): InstalledPluginIndex | null {
   return readPersistedInstalledPluginIndexFromSqlite(options);
-}
-
-export async function writePersistedInstalledPluginIndex(
-  index: InstalledPluginIndex,
-  options: InstalledPluginIndexStoreOptions = {},
-): Promise<string> {
-  return writePersistedInstalledPluginIndexSync(index, options);
-}
-
-/** Restore a snapshot only while the caller's tentative write is still current. */
-export async function restorePersistedInstalledPluginIndexIfCurrent(
-  index: InstalledPluginIndex | null,
-  expectedRevision: number,
-  options: InstalledPluginIndexStoreOptions & {
-    lease: InstalledPluginIndexWriteLease;
-  },
-): Promise<boolean> {
-  const { lease, ...storeOptions } = options;
-  assertWritableInstalledPluginIndexStoreOptions(storeOptions);
-  if (!existsSync(resolveInstalledPluginIndexStorePath(storeOptions))) {
-    return false;
-  }
-  const restored = runOpenClawStateWriteTransaction(({ db }) => {
-    lease.assertOwnedInTransaction(db);
-    const currentRow = readInstalledPluginIndexRow(db);
-    const currentRevision = currentRow ? currentRow.revision : null;
-    if (currentRevision !== expectedRevision) {
-      return false;
-    }
-    if (index) {
-      writePersistedInstalledPluginIndexRow(
-        db,
-        preparePersistedInstalledPluginIndex(index),
-        resolveNextInstalledPluginIndexRevision(currentRevision),
-      );
-    } else {
-      db.prepare("DELETE FROM config_machine_state WHERE state_key = ?").run(
-        INSTALLED_PLUGIN_INDEX_STATE_KEY,
-      );
-    }
-    return true;
-  }, resolveInstalledPluginIndexStateDatabaseOptions(storeOptions));
-  // A mismatched revision means another process committed, which also makes
-  // this process's cached metadata stale.
-  clearPersistedInstalledPluginIndexCaches();
-  return restored;
-}
-
-export function writePersistedInstalledPluginIndexSync(
-  index: InstalledPluginIndex,
-  options: InstalledPluginIndexStoreOptions = {},
-): string {
-  const filePath = resolveInstalledPluginIndexStorePath(options);
-  writePersistedInstalledPluginIndexToSqlite(index, options);
-  clearPersistedInstalledPluginIndexCaches();
-  return filePath;
-}
-
-export function writePersistedInstalledPluginIndexWithLeaseSync(
-  index: InstalledPluginIndex,
-  options: InstalledPluginIndexStoreOptions & {
-    lease: InstalledPluginIndexWriteLease;
-  },
-): string {
-  const { lease, ...storeOptions } = options;
-  const filePath = resolveInstalledPluginIndexStorePath(storeOptions);
-  writePersistedInstalledPluginIndexToSqlite(index, storeOptions, lease);
-  clearPersistedInstalledPluginIndexCaches();
-  return filePath;
-}
-
-function hasCompletePolicyRefreshProjection(
-  persisted: InstalledPluginIndex,
-  policyPluginIds: readonly string[] | undefined,
-  env: NodeJS.ProcessEnv,
-): boolean {
-  const pluginIds = new Set(persisted.plugins.map((plugin) => plugin.pluginId));
-  if (policyPluginIds?.some((pluginId) => !pluginIds.has(pluginId))) {
-    return false;
-  }
-  const installOwners = new Set(persisted.plugins.map(resolveInstalledPluginIndexInstallOwner));
-  return Object.entries(persisted.installRecords).every(([installOwner, record]) => {
-    if (installOwners.has(installOwner)) {
-      return true;
-    }
-    const installedPath = record.installPath?.trim() || record.sourcePath?.trim();
-    // Missing package bytes are orphaned owner records, not rediscoverable plugins.
-    return !installedPath || !existsSync(resolveUserPath(installedPath, env));
-  });
-}
-
-function canRefreshPersistedPolicyState(
-  persisted: InstalledPluginIndex | null,
-  params: RefreshInstalledPluginIndexParams & InstalledPluginIndexStoreOptions,
-): persisted is InstalledPluginIndex {
-  if (!persisted || params.reason !== "policy-changed") {
-    return false;
-  }
-  if (
-    (params.diagnostics?.length ?? 0) > 0 ||
-    persisted.diagnostics.some((diagnostic) => diagnostic.code === "workspace-scope-omitted") ||
-    hasInstalledPluginIndexWorkspaceScopeMismatch(persisted, params.workspaceDir)
-  ) {
-    return false;
-  }
-  const env = params.env ?? process.env;
-  if (
-    persisted.version !== INSTALLED_PLUGIN_INDEX_VERSION ||
-    persisted.hostContractVersion !== resolveCompatibilityHostVersion(env) ||
-    persisted.compatRegistryVersion !== resolveCompatRegistryVersion() ||
-    persisted.migrationVersion !== INSTALLED_PLUGIN_INDEX_MIGRATION_VERSION ||
-    hasMissingConfigPathActivationMetadata(persisted) ||
-    hasMissingInstalledPluginOwnerMetadata(persisted, env)
-  ) {
-    return false;
-  }
-  if (
-    params.installRecords &&
-    hashStableJson(params.installRecords) !== hashStableJson(persisted.installRecords ?? {})
-  ) {
-    return false;
-  }
-  return hasCompletePolicyRefreshProjection(persisted, params.policyPluginIds, env);
-}
-
-function refreshPersistedPolicyState(
-  persisted: InstalledPluginIndex,
-  params: RefreshInstalledPluginIndexParams,
-): InstalledPluginIndex {
-  const normalizedConfig = normalizePluginsConfig(params.config?.plugins);
-  return {
-    ...persisted,
-    policyHash: resolveInstalledPluginIndexPolicyHash(params.config),
-    generatedAtMs: (params.now?.() ?? new Date()).getTime(),
-    refreshReason: params.reason,
-    plugins: persisted.plugins.map((plugin) => ({
-      ...plugin,
-      enabled: resolveEffectiveEnableState({
-        id: plugin.pluginId,
-        origin: plugin.origin,
-        config: normalizedConfig,
-        rootConfig: params.config,
-        enabledByDefault: isPluginEnabledByDefaultForPlatform(plugin),
-      }).enabled,
-    })),
-  };
-}
-
-export async function refreshPersistedInstalledPluginIndex(
-  params: RefreshInstalledPluginIndexParams & InstalledPluginIndexStoreOptions,
-): Promise<InstalledPluginIndex> {
-  return refreshPersistedInstalledPluginIndexSync(params);
-}
-
-function resolveRefreshedPersistedInstalledPluginIndex(
-  params: RefreshInstalledPluginIndexParams & InstalledPluginIndexStoreOptions,
-): InstalledPluginIndex {
-  const persisted =
-    params.reason === "policy-changed" || !params.installRecords
-      ? readPersistedInstalledPluginIndexSync(params)
-      : null;
-  if (canRefreshPersistedPolicyState(persisted, params)) {
-    return refreshPersistedPolicyState(persisted, params);
-  }
-  return refreshInstalledPluginIndex({
-    ...params,
-    installRecords:
-      params.installRecords ?? extractPluginInstallRecordsFromInstalledPluginIndex(persisted),
-  });
-}
-
-export function refreshPersistedInstalledPluginIndexSync(
-  params: RefreshInstalledPluginIndexParams & InstalledPluginIndexStoreOptions,
-): InstalledPluginIndex {
-  const index = resolveRefreshedPersistedInstalledPluginIndex(params);
-  writePersistedInstalledPluginIndexSync(index, params);
-  return index;
-}
-
-export function refreshPersistedInstalledPluginIndexWithLeaseSync(
-  params: RefreshInstalledPluginIndexParams &
-    InstalledPluginIndexStoreOptions & {
-      lease: InstalledPluginIndexWriteLease;
-    },
-): InstalledPluginIndexWriteReceipt {
-  const { lease, ...storeParams } = params;
-  const index = resolveRefreshedPersistedInstalledPluginIndex(storeParams);
-  const receipt = writePersistedInstalledPluginIndexToSqlite(index, storeParams, lease);
-  clearPersistedInstalledPluginIndexCaches();
-  return receipt;
 }

--- a/src/plugins/manifest-metadata-scan.test.ts
+++ b/src/plugins/manifest-metadata-scan.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, assert, beforeEach, describe, expect, it, vi } from "vitest";
-import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store.js";
+import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store-write.js";
 import { listOpenClawPluginManifestMetadata } from "./manifest-metadata-scan.js";
 import { loadPluginManifest } from "./manifest.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";

--- a/src/plugins/manifest-model-id-normalization.test.ts
+++ b/src/plugins/manifest-model-id-normalization.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
-import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store.js";
+import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store-write.js";
 import { listOpenClawPluginManifestMetadata } from "./manifest-metadata-scan.js";
 import { normalizeProviderModelIdWithManifest } from "./manifest-model-id-normalization.js";
 // Registers the snapshot resolver in the runtime bridge slot. Production and

--- a/src/plugins/manifest-registry-installed.test.ts
+++ b/src/plugins/manifest-registry-installed.test.ts
@@ -7,10 +7,8 @@ import {
   recordInstalledPluginIndexInstallOwner,
   resolveInstalledPluginIndexInstallOwner,
 } from "./installed-plugin-index-install-owner.js";
-import {
-  readPersistedInstalledPluginIndex,
-  writePersistedInstalledPluginIndex,
-} from "./installed-plugin-index-store.js";
+import { writePersistedInstalledPluginIndex } from "./installed-plugin-index-store-write.js";
+import { readPersistedInstalledPluginIndex } from "./installed-plugin-index-store.js";
 import { loadInstalledPluginIndex, type InstalledPluginIndex } from "./installed-plugin-index.js";
 import {
   hasMissingInstalledPluginOwnerMetadata,

--- a/src/plugins/plugin-registry-inspection.test.ts
+++ b/src/plugins/plugin-registry-inspection.test.ts
@@ -4,16 +4,16 @@ import { afterEach, describe, expect, it } from "vitest";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import type { PluginCandidate } from "./discovery.js";
 import {
-  readPersistedInstalledPluginIndex,
   refreshPersistedInstalledPluginIndex,
   writePersistedInstalledPluginIndex,
-} from "./installed-plugin-index-store.js";
+} from "./installed-plugin-index-store-write.js";
+import { readPersistedInstalledPluginIndex } from "./installed-plugin-index-store.js";
 import type { InstalledPluginIndex } from "./installed-plugin-index.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
+import { refreshPluginRegistry } from "./plugin-registry-refresh.js";
 import {
   inspectPluginRegistry,
   loadPluginRegistrySnapshotWithMetadata,
-  refreshPluginRegistry,
 } from "./plugin-registry.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
 

--- a/src/plugins/plugin-registry-refresh.ts
+++ b/src/plugins/plugin-registry-refresh.ts
@@ -1,0 +1,17 @@
+/** Refreshes the persisted plugin registry for mutation and doctor flows. */
+import { refreshPersistedInstalledPluginIndex } from "./installed-plugin-index-store-write.js";
+import type { InstalledPluginIndexStoreOptions } from "./installed-plugin-index-store.js";
+import type { RefreshInstalledPluginIndexParams } from "./installed-plugin-index.js";
+import {
+  resolveControlPlaneRegistryParams,
+  type PluginRegistrySnapshot,
+} from "./plugin-registry-snapshot.js";
+
+export function refreshPluginRegistry(
+  params: RefreshInstalledPluginIndexParams & InstalledPluginIndexStoreOptions,
+): Promise<PluginRegistrySnapshot> {
+  if (!params.config) {
+    return refreshPersistedInstalledPluginIndex(params);
+  }
+  return refreshPersistedInstalledPluginIndex(resolveControlPlaneRegistryParams(params));
+}

--- a/src/plugins/plugin-registry-snapshot.state-migration.test.ts
+++ b/src/plugins/plugin-registry-snapshot.state-migration.test.ts
@@ -14,7 +14,7 @@ import {
 import { resetAutoMigrateLegacyStateDirForTest } from "../infra/state-migrations.state-dir.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { clearPluginDoctorContractRegistryCache } from "./doctor-contract-registry.test-fixtures.js";
-import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store.js";
+import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store-write.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 import {
   loadPluginMetadataSnapshot,

--- a/src/plugins/plugin-registry-snapshot.test.ts
+++ b/src/plugins/plugin-registry-snapshot.test.ts
@@ -7,7 +7,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { setCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
 import type { PluginCandidate } from "./discovery.js";
 import { loadInstalledPluginIndexInstallRecordsSync } from "./installed-plugin-index-records.js";
-import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store.js";
+import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store-write.js";
 import {
   loadInstalledPluginIndex,
   resolveInstalledPluginIndexPolicyHash,

--- a/src/plugins/plugin-registry-snapshot.ts
+++ b/src/plugins/plugin-registry-snapshot.ts
@@ -19,7 +19,6 @@ import { hasOptionalMissingPluginManifestFile } from "./installed-plugin-index-m
 import { loadInstalledPluginIndexInstallRecordsSync } from "./installed-plugin-index-record-reader.js";
 import {
   readPersistedInstalledPluginIndexSync,
-  refreshPersistedInstalledPluginIndex,
   type InstalledPluginIndexStoreOptions,
 } from "./installed-plugin-index-store.js";
 import {
@@ -34,7 +33,6 @@ import {
   type InstalledPluginIndex,
   type InstalledPluginIndexRecord,
   type LoadInstalledPluginIndexParams,
-  type RefreshInstalledPluginIndexParams,
 } from "./installed-plugin-index.js";
 import { hasMissingInstalledPluginOwnerMetadata } from "./installed-plugin-package-ownership.js";
 import {
@@ -154,7 +152,10 @@ type GetPluginRecordParams = LoadPluginRegistryParams & {
   pluginId: string;
 };
 
-function resolveControlPlaneRegistryParams<T extends LoadInstalledPluginIndexParams>(params: T): T {
+// Shared with plugin-registry-refresh.ts.
+export function resolveControlPlaneRegistryParams<T extends LoadInstalledPluginIndexParams>(
+  params: T,
+): T {
   if (!params.config) {
     return params;
   }
@@ -672,13 +673,4 @@ export async function inspectPluginRegistry(
     persisted,
     current: result.snapshot,
   };
-}
-
-export function refreshPluginRegistry(
-  params: RefreshInstalledPluginIndexParams & InstalledPluginIndexStoreOptions,
-): Promise<PluginRegistrySnapshot> {
-  if (!params.config) {
-    return refreshPersistedInstalledPluginIndex(params);
-  }
-  return refreshPersistedInstalledPluginIndex(resolveControlPlaneRegistryParams(params));
 }

--- a/src/plugins/plugin-registry.test.ts
+++ b/src/plugins/plugin-registry.test.ts
@@ -8,7 +8,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { recordPluginCandidateInstallOwner } from "./candidate-install-owner.js";
 import type { PluginCandidate } from "./discovery.js";
-import { writePersistedInstalledPluginIndex } from "./installed-plugin-index-store.js";
+import { writePersistedInstalledPluginIndex } from "./installed-plugin-index-store-write.js";
 import {
   resolveInstalledPluginIndexPolicyHash,
   type InstalledPluginIndex,

--- a/src/plugins/registry-refresh.ts
+++ b/src/plugins/registry-refresh.ts
@@ -4,7 +4,7 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { loadInstalledPluginIndexInstallRecords } from "./installed-plugin-index-records.js";
 import type { InstalledPluginIndexRefreshReason } from "./installed-plugin-index.js";
 import { tracePluginLifecyclePhaseAsync } from "./plugin-lifecycle-trace.js";
-import { refreshPluginRegistry } from "./plugin-registry.js";
+import { refreshPluginRegistry } from "./plugin-registry-refresh.js";
 
 /** Optional warning sink for best-effort registry/cache refresh failures. */
 export type PluginRegistryRefreshLogger = {

--- a/src/plugins/status.registry-snapshot.test.ts
+++ b/src/plugins/status.registry-snapshot.test.ts
@@ -9,14 +9,12 @@ import {
   getCurrentPluginMetadataSnapshot,
   setCurrentPluginMetadataSnapshot,
 } from "./current-plugin-metadata-snapshot.js";
-import {
-  readPersistedInstalledPluginIndex,
-  writePersistedInstalledPluginIndexSync,
-} from "./installed-plugin-index-store.js";
+import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store-write.js";
+import { readPersistedInstalledPluginIndex } from "./installed-plugin-index-store.js";
 import { loadInstalledPluginIndex } from "./installed-plugin-index.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 import { loadPluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
-import { refreshPluginRegistry } from "./plugin-registry.js";
+import { refreshPluginRegistry } from "./plugin-registry-refresh.js";
 import { collectPluginCapabilityConsentDiagnostics } from "./status-snapshot.js";
 import {
   buildPluginDiagnosticsReport,

--- a/src/secrets/store/secret-store.test.ts
+++ b/src/secrets/store/secret-store.test.ts
@@ -4,10 +4,10 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { requireNodeSqlite } from "../../infra/node-sqlite.js";
 import { isSecretValueRegisteredForRedaction } from "../../logging/secret-redaction-registry.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../../state/openclaw-state-db-contract.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
-  OPENCLAW_STATE_SCHEMA_VERSION,
 } from "../../state/openclaw-state-db.js";
 import {
   consumeGitHubSetupHandoff,

--- a/src/security/audit-plugins-trust.test.ts
+++ b/src/security/audit-plugins-trust.test.ts
@@ -6,7 +6,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { HookInstallRecord } from "../config/types.hooks.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
-import { writePersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store.js";
+import { writePersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store-write.js";
 import type { InstalledPluginIndex } from "../plugins/installed-plugin-index.js";
 import { writeConfigMachineState } from "../state/config-machine-state.js";
 import {

--- a/src/skills/workshop/store.test.ts
+++ b/src/skills/workshop/store.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { requireNodeSqlite } from "../../infra/node-sqlite.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../../state/openclaw-state-db-contract.js";
 import {
   closeOpenClawStateDatabaseForTest,
-  OPENCLAW_STATE_SCHEMA_VERSION,
   openOpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
 import {

--- a/src/snapshot/local-repository.test.ts
+++ b/src/snapshot/local-repository.test.ts
@@ -9,7 +9,7 @@ import { createPrivateSqliteDirectory } from "../infra/sqlite-private-directory.
 import { runExec } from "../process/exec.js";
 import { OPENCLAW_AGENT_SCHEMA_VERSION } from "../state/openclaw-agent-db.js";
 import { OPENCLAW_AGENT_SCHEMA_SQL } from "../state/openclaw-agent-schema.js";
-import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
 import { OPENCLAW_STATE_SCHEMA_SQL } from "../state/openclaw-state-schema.js";
 import { hashSnapshotArtifact, readSnapshotManifest } from "./manifest.js";
 import {

--- a/src/state/openclaw-database-maintenance.test.ts
+++ b/src/state/openclaw-database-maintenance.test.ts
@@ -11,14 +11,12 @@ import {
   CLAW_LAZY_ADDITIVE_STATE_COLUMN_DEFINITIONS,
   CLAW_STARTUP_ADDITIVE_STATE_COLUMN_DEFINITIONS,
 } from "./openclaw-state-db-additive-columns.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "./openclaw-state-db-contract.js";
 import {
   ensureAdditiveStateColumns,
   ensureDevicePairSetupBootstrapSchema,
 } from "./openclaw-state-db-schema-additive.js";
-import {
-  assertOpenClawStateDatabaseForMaintenance,
-  OPENCLAW_STATE_SCHEMA_VERSION,
-} from "./openclaw-state-db.js";
+import { assertOpenClawStateDatabaseForMaintenance } from "./openclaw-state-db.js";
 import { OPENCLAW_STATE_MAINTENANCE_SCHEMA_COMPATIBILITY } from "./openclaw-state-schema-compatibility.js";
 import { OPENCLAW_STATE_SCHEMA_SQL } from "./openclaw-state-schema.js";
 

--- a/src/state/openclaw-database-paths.windows.test.ts
+++ b/src/state/openclaw-database-paths.windows.test.ts
@@ -13,11 +13,11 @@ import {
 } from "./openclaw-agent-db.js";
 import { resolveOpenClawAgentSqlitePath } from "./openclaw-agent-db.paths.js";
 import { preflightOpenClawDatabaseSchemas } from "./openclaw-database-preflight.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "./openclaw-state-db-contract.js";
 import { withOpenClawStateDatabaseReadOnly } from "./openclaw-state-db-readonly.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openExistingOpenClawStateDatabaseReadOnly,
-  OPENCLAW_STATE_SCHEMA_VERSION,
   openOpenClawStateDatabase,
 } from "./openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";

--- a/src/state/openclaw-database-preflight.test.ts
+++ b/src/state/openclaw-database-preflight.test.ts
@@ -15,9 +15,9 @@ import {
   preflightOpenClawStateDatabasePath,
   preflightOpenClawDatabaseSchemas,
 } from "./openclaw-database-preflight.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "./openclaw-state-db-contract.js";
 import {
   closeOpenClawStateDatabaseForTest,
-  OPENCLAW_STATE_SCHEMA_VERSION,
   openOpenClawStateDatabase,
 } from "./openclaw-state-db.js";
 import { OPENCLAW_STATE_SCHEMA_SQL } from "./openclaw-state-schema.js";

--- a/src/state/openclaw-state-db-cache.ts
+++ b/src/state/openclaw-state-db-cache.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import {
   clearNodeSqliteKyselyCacheForDatabase,
   registerNodeSqliteKyselyQueryErrorHandler,
-} from "../infra/kysely-sync.js";
+} from "../infra/kysely-sync-cache-state.js";
 import type { SqliteFileGeneration } from "../infra/sqlite-file-generation.js";
 import { createSqliteTerminalOpenLatch } from "../infra/sqlite-terminal-open-latch.js";
 import { isSqliteCorruptionError } from "../infra/sqlite-transaction.js";

--- a/src/state/openclaw-state-db-first-use-column-strict-migration.test.ts
+++ b/src/state/openclaw-state-db-first-use-column-strict-migration.test.ts
@@ -4,10 +4,10 @@ import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { CLAW_FIRST_USE_ADDITIVE_STATE_COLUMN_DEFINITIONS } from "./openclaw-state-db-additive-columns.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "./openclaw-state-db-contract.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
-  OPENCLAW_STATE_SCHEMA_VERSION,
   repairOpenClawStateDatabaseSchema,
 } from "./openclaw-state-db.js";
 import { OPENCLAW_STATE_SCHEMA_SQL } from "./openclaw-state-schema.js";

--- a/src/state/openclaw-state-db-readonly.ts
+++ b/src/state/openclaw-state-db-readonly.ts
@@ -1,7 +1,7 @@
 import { statSync } from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
-import { clearNodeSqliteKyselyCacheForDatabase } from "../infra/kysely-sync.js";
+import { clearNodeSqliteKyselyCacheForDatabase } from "../infra/kysely-sync-cache-state.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import {
   prepareSqliteReadOnlyLocationSync,
@@ -11,14 +11,12 @@ import {
   createNewerSqliteSchemaVersionError,
   readSqliteUserVersion,
 } from "../infra/sqlite-user-version.js";
+import { openClawStateDatabaseCache } from "./openclaw-state-db-cache.js";
 import {
-  assertOpenClawStateDatabaseFreshOpenAllowed,
-  evictOpenClawStateDatabaseAfterCorruption,
-  getOpenClawStateDatabaseIfOpen,
   OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
   OPENCLAW_STATE_SCHEMA_VERSION,
   type OpenClawStateDatabaseOptions,
-} from "./openclaw-state-db.js";
+} from "./openclaw-state-db-contract.js";
 import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
 
 type OpenClawStateReadOnlyDatabase = {
@@ -61,7 +59,9 @@ function withOpenClawStateDatabaseReadOnlyIfOpen<T>(
   options: OpenClawStateDatabaseOptions,
   pathname: string,
 ): ReusedOpenClawStateReadOnlyDatabase<T> {
-  const opened = getOpenClawStateDatabaseIfOpen(options);
+  const opened = openClawStateDatabaseCache.getOpenClawStateDatabaseIfOpenAtPath(
+    resolveReadOnlyPath(options),
+  );
   if (!opened || opened.db.isTransaction) {
     return { reused: false };
   }
@@ -73,7 +73,7 @@ function withOpenClawStateDatabaseReadOnlyIfOpen<T>(
     assertSupportedSchemaVersion(opened.db, pathname);
     return { reused: true, value: operation(opened) };
   } catch (error) {
-    evictOpenClawStateDatabaseAfterCorruption(opened, error);
+    openClawStateDatabaseCache.evictOpenClawStateDatabaseAfterCorruption(opened, error);
     throw error;
   }
 }
@@ -84,7 +84,11 @@ function withFreshOpenClawStateDatabaseReadOnly<T>(
   pathname: string,
   location = pathname,
 ): T {
-  assertOpenClawStateDatabaseFreshOpenAllowed(options);
+  const env = options.env ?? process.env;
+  openClawStateDatabaseCache.assertOpenClawStateDatabaseFreshOpenAllowedAtPath(
+    resolveReadOnlyPath(options),
+    env,
+  );
   const db = openNodeSqliteDatabase(location, { readOnly: true });
   try {
     db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
@@ -154,7 +158,9 @@ export function withExistingOpenClawStateDatabaseArtifactPreservingReadOnly<T>(
   }
   // In-process preparation is safe only when this process holds no writable
   // handle. Otherwise closing the snapshot source can drop the writer's POSIX locks.
-  const prepare = getOpenClawStateDatabaseIfOpen(options)
+  const prepare = openClawStateDatabaseCache.getOpenClawStateDatabaseIfOpenAtPath(
+    resolveReadOnlyPath(options),
+  )
     ? prepareSqliteReadOnlyLocationSync
     : prepareSqliteReadOnlyLocationSyncInProcess;
   const prepared = prepare(existingPath);

--- a/src/state/openclaw-state-db-restart-handoff-migration.test.ts
+++ b/src/state/openclaw-state-db-restart-handoff-migration.test.ts
@@ -2,11 +2,11 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "./openclaw-state-db-contract.js";
 import {
   closeOpenClawStateDatabaseForTest,
   detectOpenClawStateDatabaseSchemaMigrations,
   openOpenClawStateDatabase,
-  OPENCLAW_STATE_SCHEMA_VERSION,
   repairOpenClawStateDatabaseSchema,
 } from "./openclaw-state-db.js";
 

--- a/src/state/openclaw-state-db.corruption-recovery.test.ts
+++ b/src/state/openclaw-state-db.corruption-recovery.test.ts
@@ -7,12 +7,11 @@ import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { isSqliteCorruptionError } from "../infra/sqlite-transaction.js";
+import { openClawStateDatabaseCache } from "./openclaw-state-db-cache.js";
 import { withOpenClawStateDatabaseReadOnly } from "./openclaw-state-db-readonly.js";
 import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
 import {
   closeOpenClawStateDatabaseForTest,
-  evictOpenClawStateDatabaseAfterCorruption,
-  getOpenClawStateDatabaseIfOpen,
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
 } from "./openclaw-state-db.js";
@@ -182,14 +181,16 @@ describe("shared state write transaction corruption recovery", () => {
       peer.prepare("SELECT count(*) FROM diagnostic_events").get();
       const evictionStartedAt = performance.now();
       expect(
-        evictOpenClawStateDatabaseAfterCorruption(
+        openClawStateDatabaseCache.evictOpenClawStateDatabaseAfterCorruption(
           cached,
           sqliteError("database disk image is malformed", 11),
         ),
       ).toBe(true);
       const evictionElapsedMs = performance.now() - evictionStartedAt;
 
-      expect(getOpenClawStateDatabaseIfOpen({ env })).toBeUndefined();
+      expect(
+        openClawStateDatabaseCache.getOpenClawStateDatabaseIfOpenAtPath(cached.path),
+      ).toBeUndefined();
       expect(evictionElapsedMs).toBeLessThan(250);
       expect(fs.statSync(walPath).size).toBe(walBytesBeforeEviction);
       expect(peer.prepare("PRAGMA quick_check").get()).toEqual({ quick_check: "ok" });
@@ -207,7 +208,9 @@ describe("shared state write transaction corruption recovery", () => {
     const { databasePath, healthySnapshot, poisoned } = prepareCorruptedCachedDatabase(env);
 
     expectNotADatabaseError(() => insertProbeEvent(env, "during-corruption"));
-    expect(getOpenClawStateDatabaseIfOpen({ env })).toBeUndefined();
+    expect(
+      openClawStateDatabaseCache.getOpenClawStateDatabaseIfOpenAtPath(databasePath),
+    ).toBeUndefined();
 
     fs.writeFileSync(databasePath, healthySnapshot);
 
@@ -241,7 +244,9 @@ describe("shared state write transaction corruption recovery", () => {
         ),
       ).toThrow(/file is not a database/u);
 
-      expect(getOpenClawStateDatabaseIfOpen({ env })).toBe(cached);
+      expect(openClawStateDatabaseCache.getOpenClawStateDatabaseIfOpenAtPath(cached.path)).toBe(
+        cached,
+      );
       expect(cached.db.isOpen).toBe(true);
       expect(injectedDb.isOpen).toBe(true);
     } finally {
@@ -262,7 +267,9 @@ describe("shared state write transaction corruption recovery", () => {
       ),
     ).toThrow(/database is locked/u);
 
-    expect(getOpenClawStateDatabaseIfOpen({ env })).toBe(cached);
+    expect(openClawStateDatabaseCache.getOpenClawStateDatabaseIfOpenAtPath(cached.path)).toBe(
+      cached,
+    );
   });
 });
 
@@ -272,7 +279,9 @@ describe("shared state read corruption recovery", () => {
     const { databasePath, healthySnapshot, poisoned } = prepareCorruptedCachedDatabase(env);
 
     expectNotADatabaseError(() => readProbeEventKeys(poisoned));
-    expect(getOpenClawStateDatabaseIfOpen({ env })).toBeUndefined();
+    expect(
+      openClawStateDatabaseCache.getOpenClawStateDatabaseIfOpenAtPath(databasePath),
+    ).toBeUndefined();
 
     fs.writeFileSync(databasePath, healthySnapshot);
 
@@ -291,7 +300,9 @@ describe("shared state read corruption recovery", () => {
         { env },
       ),
     );
-    expect(getOpenClawStateDatabaseIfOpen({ env })).toBeUndefined();
+    expect(
+      openClawStateDatabaseCache.getOpenClawStateDatabaseIfOpenAtPath(databasePath),
+    ).toBeUndefined();
 
     fs.writeFileSync(databasePath, healthySnapshot);
 

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -36,7 +36,10 @@ import {
   readConfigMachineStateWithMetadata,
 } from "./config-machine-state.js";
 import { listOpenClawRegisteredAgentDatabases } from "./openclaw-agent-db-registry.js";
-import { FIRST_USE_STATE_TABLES } from "./openclaw-state-db-contract.js";
+import {
+  FIRST_USE_STATE_TABLES,
+  OPENCLAW_STATE_SCHEMA_VERSION,
+} from "./openclaw-state-db-contract.js";
 import { ensureGitHubPublicationSchema } from "./openclaw-state-db-schema-additive.js";
 import {
   findOpenClawStateDatabaseSchemaMigrationRequiredError,
@@ -51,7 +54,6 @@ import {
   OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
   openExistingOpenClawStateDatabaseReadOnly,
   openOpenClawStateDatabase,
-  OPENCLAW_STATE_SCHEMA_VERSION,
   repairOpenClawStateDatabaseSchema,
   repairOpenClawStateDatabaseSchemaIfNeeded,
   runWithOpenClawStateBusyTimeout,

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -95,11 +95,7 @@ import { getOpenClawStateRuntimeSchema } from "./openclaw-state-schema-compatibi
 import { OPENCLAW_STATE_SCHEMA_SQL } from "./openclaw-state-schema.js";
 export { registerOpenClawStateDatabaseLifecycleListener } from "./openclaw-state-db-cache.js";
 
-export {
-  OPENCLAW_DATABASE_SCHEMA_DOCS_URL,
-  OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
-  OPENCLAW_STATE_SCHEMA_VERSION,
-};
+export { OPENCLAW_DATABASE_SCHEMA_DOCS_URL, OPENCLAW_SQLITE_BUSY_TIMEOUT_MS };
 export type {
   OpenClawStateDatabase,
   OpenClawStateDatabaseOptions,
@@ -136,7 +132,7 @@ export function clearOpenClawStateDatabaseOpenFailure(pathname: string): void {
 }
 
 /** Reject a fresh shared-state open after known corruption until repair clears it. */
-export function assertOpenClawStateDatabaseFreshOpenAllowed(
+function assertOpenClawStateDatabaseFreshOpenAllowed(
   options: OpenClawStateDatabaseOptions = {},
 ): void {
   const env = options.env ?? process.env;
@@ -721,18 +717,10 @@ export function runOpenClawStateWriteTransaction<T>(
  * Read-only callers use this to avoid opening a connection per call; it never
  * creates, repairs, or registers a handle.
  */
-export function getOpenClawStateDatabaseIfOpen(
+function getOpenClawStateDatabaseIfOpen(
   options: OpenClawStateDatabaseOptions = {},
 ): OpenClawStateDatabase | undefined {
   return stateDbCache.getOpenClawStateDatabaseIfOpenAtPath(resolveDatabasePath(options));
-}
-
-/** Evict an exact cached shared-state owner after a proven corruption read. */
-export function evictOpenClawStateDatabaseAfterCorruption(
-  database: OpenClawStateDatabase,
-  error: unknown,
-): boolean {
-  return stateDbCache.evictOpenClawStateDatabaseAfterCorruption(database, error);
 }
 
 /** Close one cached shared state database handle by exact pathname. */

--- a/src/state/openclaw-state-ownership.test.ts
+++ b/src/state/openclaw-state-ownership.test.ts
@@ -15,9 +15,9 @@ import { sha256HexPrefixCore } from "../infra/crypto-digest.js";
 import { requireNodeSqlite, resolveImmutableSqliteFileUri } from "../infra/node-sqlite.js";
 import * as sqliteReadonlyLocation from "../infra/sqlite-readonly-location.js";
 import { withEnv, withEnvAsync } from "../test-utils/env.js";
+import { openClawStateDatabaseCache } from "./openclaw-state-db-cache.js";
 import {
   closeOpenClawStateDatabaseForTest,
-  getOpenClawStateDatabaseIfOpen,
   openExistingOpenClawStateDatabaseReadOnly,
   openOpenClawStateDatabase,
   repairOpenClawStateDatabaseSchema,
@@ -25,7 +25,10 @@ import {
   runOpenClawStateWriteTransaction,
   withOpenClawStateStartupMigrationCheckpointDatabase,
 } from "./openclaw-state-db.js";
-import { resolveOpenClawStateDirForDatabasePath } from "./openclaw-state-db.paths.js";
+import {
+  resolveOpenClawStateDirForDatabasePath,
+  resolveOpenClawStateSqlitePath,
+} from "./openclaw-state-db.paths.js";
 import { claimOpenClawStateOwnership } from "./openclaw-state-ownership-operations.js";
 import {
   assertOpenClawStateWriteAllowedAtPath,
@@ -529,9 +532,13 @@ describe("external shared-state ownership", () => {
 
   it("closes an unpublished fresh handle when coordinator release fails", () => {
     const env = createEnv();
-    let cachedDuringRelease: ReturnType<typeof getOpenClawStateDatabaseIfOpen> = undefined;
+    const databasePath = path.resolve(resolveOpenClawStateSqlitePath(env));
+    let cachedDuringRelease: ReturnType<
+      typeof openClawStateDatabaseCache.getOpenClawStateDatabaseIfOpenAtPath
+    > = undefined;
     const exec = mockCoordinatorRollbackFailure(() => {
-      cachedDuringRelease = getOpenClawStateDatabaseIfOpen({ env });
+      cachedDuringRelease =
+        openClawStateDatabaseCache.getOpenClawStateDatabaseIfOpenAtPath(databasePath);
     });
 
     try {
@@ -542,7 +549,9 @@ describe("external shared-state ownership", () => {
       exec.mockRestore();
     }
     expect(cachedDuringRelease).toBeUndefined();
-    expect(getOpenClawStateDatabaseIfOpen({ env })).toBeUndefined();
+    expect(
+      openClawStateDatabaseCache.getOpenClawStateDatabaseIfOpenAtPath(databasePath),
+    ).toBeUndefined();
     expect(openOpenClawStateDatabase({ env }).db.isOpen).toBe(true);
   });
 

--- a/src/state/user-profiles.test.ts
+++ b/src/state/user-profiles.test.ts
@@ -3,9 +3,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { GIT_COAUTHOR_PREFERENCE_KEY } from "../../packages/gateway-protocol/src/index.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "./openclaw-state-db-contract.js";
 import { tableExists, tableHasColumn } from "./openclaw-state-db-schema-helpers.js";
 import {
-  OPENCLAW_STATE_SCHEMA_VERSION,
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "./openclaw-state-db.js";

--- a/test/scripts/doctor-config-preflight-plugin-index.built-cli.e2e.test.ts
+++ b/test/scripts/doctor-config-preflight-plugin-index.built-cli.e2e.test.ts
@@ -5,10 +5,8 @@ import { afterEach, describe, expect, it } from "vitest";
 import { resolveDefaultAgentWorkspaceDir } from "../../src/agents/workspace-default.js";
 import type { OpenClawConfig } from "../../src/config/types.openclaw.js";
 import { hasActiveStartupMigrationLease } from "../../src/infra/startup-migration-checkpoint.js";
-import {
-  readPersistedInstalledPluginIndexSync,
-  writePersistedInstalledPluginIndexSync,
-} from "../../src/plugins/installed-plugin-index-store.js";
+import { writePersistedInstalledPluginIndexSync } from "../../src/plugins/installed-plugin-index-store-write.js";
+import { readPersistedInstalledPluginIndexSync } from "../../src/plugins/installed-plugin-index-store.js";
 import { clearPluginMetadataLifecycleCaches } from "../../src/plugins/plugin-metadata-lifecycle.js";
 import { loadPluginMetadataSnapshot } from "../../src/plugins/plugin-metadata-snapshot.js";
 import { writeManagedNpmPlugin } from "../../src/plugins/test-helpers/managed-npm-plugin.js";

--- a/test/test-env.state-lifetime.test.ts
+++ b/test/test-env.state-lifetime.test.ts
@@ -8,10 +8,10 @@ import { pathToFileURL } from "node:url";
 import { Worker } from "node:worker_threads";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { listOpenClawRegisteredAgentDatabases } from "../src/state/openclaw-agent-db-registry-listing.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../src/state/openclaw-state-db-contract.js";
 import {
   closeOpenClawStateDatabaseByPath,
   openOpenClawStateDatabase,
-  OPENCLAW_STATE_SCHEMA_VERSION,
 } from "../src/state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../src/state/openclaw-state-db.paths.js";
 import { captureFullEnv, setTestEnvValue, withPathResolutionEnv } from "../src/test-utils/env.js";


### PR DESCRIPTION
## What Problem This Solves

Metadata-only CLI reads (`openclaw plugins list --json` and every path through config io → plugin-metadata-snapshot → manifest-registry → installed-plugin-index) load the full Kysely-backed state-db graph (~250 modules: the `openclaw-state-db` chunk, `kysely`, and its zod v4 baggage) that they never use. This is the named follow-up from #131181, which removed the other startup paths that loaded this graph.

A module-load census on the pre-fix dist showed three distinct read-path fusions dragging the write machinery in:

1. `src/plugins/installed-plugin-index-store.ts` mixed readers (lean `withExistingOpenClawStateDatabaseReadOnly`) with writers that statically import `runOpenClawStateWriteTransaction`.
2. `src/plugins/plugin-registry-snapshot.ts` — loaded on the metadata path — statically imported the `refreshPersistedInstalledPluginIndex` writer for one 8-line function used only by mutation/doctor flows, and the `plugin-registry.ts` barrel re-exported it. ESM evaluates every barrel re-export source, so that single writer re-export forced the write graph onto every barrel consumer.
3. `src/state/openclaw-state-db-readonly.ts` imported the open-database cache trio and constants from the heavy `openclaw-state-db.js` module, and `openclaw-state-db-cache.ts` imported two functions from `kysely-sync.js`, whose module body instantiates a Kysely dialect.

## Why This Change Was Made

Write transactions are synchronous (SQLite sync-commit doctrine), so a dynamic import inside the sync writers is not an option — these are module splits, following the precedent stated in `src/infra/kysely-sync-cache-state.ts`'s own header ("split from kysely-sync so lifecycle owners can clear caches without value-loading kysely"). All three legs are behavior-neutral: identical function bodies and semantics, module layout and imports only.

- `installed-plugin-index-store.ts` keeps read/parse; write/restore/refresh functions move verbatim to a new `installed-plugin-index-store-write.ts`. Writer callers and test mocks route to the write module; the kysely-guardrails raw-SQLite allowlist gains the write module entry recording the 1:1 move of the existing INSERT/DELETE calls.
- `refreshPluginRegistry` moves to a new `plugin-registry-refresh.ts`; the barrel no longer re-exports it and its three callers import it directly (the CLI now loads it only inside the `--refresh` branch).
- `openclaw-state-db-readonly.ts` calls `openClawStateDatabaseCache` directly and takes constants from `openclaw-state-db-contract.js`; `registerNodeSqliteKyselyQueryErrorHandler` (a pure WeakMap set) moves into `kysely-sync-cache-state.ts`. Doctor and gateway schema preflights read `OPENCLAW_STATE_SCHEMA_VERSION` from the contract module instead of value-loading the heavy module. Now-dead wrapper exports are deleted or un-exported (bodies unchanged where internal callers remain).

## User Impact

Metadata-only CLI commands stop paying module-load and allocation cost for write machinery they never invoke. No behavior change: same exports/semantics, no config surface, no schema change, no migration. Groundwork for the remaining #131181 follow-ups (config io `io.health-state`, legacy-config-migrations → `config-machine-state`, audit record store, cron store are now the only loaded importers of the heavy chunk).

## Evidence

- Module-load census on built dist (`module.registerHooks` load/edge recorder via `--import`, isolated HOME, `OPENCLAW_NO_RESPAWN=1`, `plugins list --json`): before — the plugins chain loaded the `openclaw-state-db` chunk + 254 kysely modules via `manifest-registry` and the store; after — the `installed-plugin-index-store-write` chunk does not load at all, and no chunk in the installed-plugin-index / manifest-registry / store / readonly / snapshot chain imports the heavy state-db chunk. kysely still loads through the separately-owned config-io fusions named above (the remaining #131181 follow-ups, tracked as a spawned task).
- Tests: focused suites green across four proof rounds — 255 + 388 + 634 + 892 + 509 tests in the store/plugins/doctor/cli/state neighborhoods, plus a 9,493-test broad round; built-CLI e2e `test/scripts/doctor-config-preflight-plugin-index.built-cli.e2e.test.ts` green against fresh dist (doctor preflight lease-write through the new write module).
- `node scripts/check-changed.mjs` exit 0: format, all tsgo lanes, lint, kysely guardrails, Knip dead-export scan (zero entries), import cycles (zero runtime value cycles).
- Codex autoreview (`gpt-5.6-sol`, high): clean, no accepted/actionable findings.
- LOC (`git diff --numstat`, classified): production 20 files +437/−410 (net +27, module-boundary imports and shared-export comments only), tooling +1 (allowlist entry), tests/support 56 files +152/−126.


## Post-rebase integration proof

Head `3a25fffd2f2a01093684b5a7f47a2af0fbed9ac6` adds only the two remaining test-consumer migrations in commit [3a25fffd2f2](https://github.com/openclaw/openclaw/commit/3a25fffd2f2a01093684b5a7f47a2af0fbed9ac6): the state-lifetime test imports the schema version from the contract module, and the transcript auto-start test uses the cache owner with the same resolved database path. Assertions are unchanged. Follow-up production LOC: +0/-0; tests: +9/-4.

Fresh validation:

- `node scripts/run-vitest.mjs test/test-env.state-lifetime.test.ts src/agents/tools/transcripts-tool.auto-start.test.ts`: 11 tests passed (4 state-lifetime, 7 transcript auto-stop).
- `node scripts/check-changed.mjs`: exit 0, including core/test/script/root-test typechecks, lint, formatting for all 79 changed files, zero dead exports, and zero runtime value import cycles.
- Isolated Codex autoreview of the two-file repair: clean, no accepted/actionable findings.
- [Exact-head CI run 33138778640](https://github.com/openclaw/openclaw/actions/runs/33138778640): the native watcher returned `GREEN`, with zero pending checks. No CI rerun was needed.
- Exact-head source CLI: `node --import ./scripts/tsx.mjs src/entry.ts plugins list --json`, with an isolated temporary HOME/state directory, `OPENCLAW_NO_RESPAWN=1`, and a credential-free environment, exited 0. JSON parsing succeeded and the result contained 151 plugins. This is source-CLI behavior proof, not a packaged-build replay or a new module-load census. An initial invocation outside the checkout could not resolve a workspace package; running from the checkout supplied the normal TypeScript path configuration.

ClawSweeper follow-through for the published review of `8640e421fc9`:

- Both P1 test-consumer migration findings are fixed by the follow-up commit above.
- “Complete next step” and “Address the highest-priority review finding and re-run the changed-surface validation” are covered by the passing focused tests, changed gate, and exact-head CI.
- “Add real behavior proof” and the request for after-fix terminal evidence are covered by the successful exact-head source-CLI command above. ClawSweeper's own packaged attempt timed out during build before it reached the CLI; that attempt is not counted as passing proof.
- For “Resolve merge risk,” typecheck, transcript coverage, and metadata-command behavior have fresh proof. The built-distribution module census and built-CLI E2E in the original Evidence section remain prior implementation evidence, not new-head reruns. Repeating those previously completed suites was outside the requested landing scope; this follow-up changes no production code. No SQLite schema, persistence contract, configuration option, or assertion was changed.

A new-head ClawSweeper review is in progress. The latest completed review is less than 12 hours old; no redundant re-review request was posted.
