### PR TITLE
fix(worktrees): keep setup and cleanup failures readable

### DIFF
--- a/docs/concepts/managed-worktrees.md
+++ b/docs/concepts/managed-worktrees.md
@@ -43,6 +43,8 @@ OPENCLAW_WORKTREE_PATH=<managed worktree>
 
 A nonzero exit aborts creation and removes the new worktree and branch. This is a repository-local contract; there is no OpenClaw config key for it.
 
+Setup failures report the exit code or termination signal, or an actual timeout after 120 seconds, with a bounded excerpt of recent output rather than the full setup log. If setup times out, inspect `.openclaw/worktree-setup.sh` and its dependencies for slow downloads, unavailable services, or commands waiting for interactive input.
+
 ## Session worktrees
 
 Start an isolated chat from a Git-backed folder with a worktree session: on the Control UI's New session page, use the **Place** picker to choose a Gateway source folder, then select **Worktree** (with an optional base branch and worktree name). Choosing a paired device or cloud profile forces this managed-worktree path from the selected Gateway source; remote placement never browses or binds a node working directory. When the name is omitted, OpenClaw derives it from the explicit session label or the concise title generated from the first message, then falls back to a crustacean-themed name. The choice appears only after the Gateway confirms that the selected folder is a Git checkout; ordinary folders can run directly only on the Gateway and show no Git isolation control. iOS exposes the same choice from Chat actions, and Android exposes it beside New Chat, when the active agent workspace is Git-backed.

--- a/src/agents/worktrees/service.diagnostics.test.ts
+++ b/src/agents/worktrees/service.diagnostics.test.ts
@@ -1,0 +1,256 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as commandExec from "../../process/exec.js";
+import type { SpawnResult } from "../../process/exec.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { ManagedWorktreeService } from "./service.js";
+import { initializeManagedWorktreeTestRepository } from "./service.test-support.js";
+
+const execFileAsync = promisify(execFile);
+const realRunCommand = commandExec.runCommandWithTimeout;
+const emptyFailure: SpawnResult = {
+  stdout: "",
+  stderr: "",
+  code: 73,
+  signal: null,
+  killed: false,
+  termination: "exit",
+};
+
+async function failureMessage(operation: Promise<unknown>): Promise<string> {
+  try {
+    await operation;
+  } catch (error) {
+    if (error instanceof Error) {
+      return error.message;
+    }
+    throw error;
+  }
+  throw new Error("expected worktree operation to fail");
+}
+
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("git", ["-C", cwd, ...args]);
+  return stdout.trim();
+}
+
+const terminationCases: Array<{
+  name: string;
+  result: Partial<SpawnResult>;
+  expected: RegExp[];
+}> = [
+  {
+    name: "exit without output",
+    result: { code: 23 },
+    expected: [/(?:exit|code|status)[^\n]*23/i],
+  },
+  {
+    name: "exit with output",
+    result: { code: 23, stderr: "fatal: dependency unavailable" },
+    expected: [/fatal: dependency unavailable/, /(?:exit|code|status)[^\n]*23/i],
+  },
+  {
+    name: "timeout with output",
+    result: {
+      code: 124,
+      termination: "timeout",
+      signal: "SIGTERM",
+      killed: true,
+      stderr: "waiting for dependency",
+    },
+    expected: [/waiting for dependency/, /timed?\s*out|timeout/i, /SIGTERM/],
+  },
+  {
+    name: "timeout without output",
+    result: {
+      code: 124,
+      termination: "timeout",
+      signal: "SIGKILL",
+      killed: true,
+    },
+    expected: [/timed?\s*out|timeout/i, /SIGKILL/],
+  },
+  {
+    name: "signal without output",
+    result: { code: null, termination: "signal", signal: "SIGTERM" },
+    expected: [/SIGTERM/],
+  },
+];
+
+describe("ManagedWorktreeService failure diagnostics", () => {
+  let root: string;
+  let repo: string;
+  let service: ManagedWorktreeService;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(await fs.realpath(os.tmpdir()), "openclaw-worktree-errors-"));
+    repo = await initializeManagedWorktreeTestRepository(root);
+    service = new ManagedWorktreeService({
+      env: { ...process.env, OPENCLAW_STATE_DIR: path.join(root, "state") },
+    });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  async function writeFailingSetup(): Promise<string> {
+    const script = path.join(repo, ".openclaw", "worktree-setup.sh");
+    await fs.mkdir(path.dirname(script));
+    await fs.writeFile(script, "#!/bin/sh\nprintf 'fatal: setup failed\\n' >&2\nexit 9\n", {
+      mode: 0o755,
+    });
+    return script;
+  }
+
+  it.each(terminationCases)("reports setup $name and removes its allocation", async (entry) => {
+    const script = await writeFailingSetup();
+    vi.spyOn(commandExec, "runCommandWithTimeout").mockImplementation(async (argv, options) => {
+      if (argv[0] === script) {
+        return { ...emptyFailure, ...entry.result };
+      }
+      return await realRunCommand(argv, options);
+    });
+
+    const message = await failureMessage(
+      service.create({ repoRoot: repo, name: "terminated-setup", baseRef: "HEAD" }),
+    );
+
+    expect(await git(repo, "worktree", "list", "--porcelain")).not.toContain("terminated-setup");
+    expect(await git(repo, "branch", "--list", "openclaw/terminated-setup")).toBe("");
+    expect(service.listRegistryRecords()).toEqual([]);
+    expect(message).toContain("worktree setup failed");
+    for (const pattern of entry.expected) {
+      expect.soft(message).toMatch(pattern);
+    }
+    expect(message.length).toBeLessThanOrEqual(2_300);
+  });
+
+  it.each([
+    { phase: "create", failedOperation: "remove" },
+    { phase: "create", failedOperation: "branch" },
+    { phase: "create", failedOperation: "both" },
+    { phase: "restore", failedOperation: "remove" },
+    { phase: "restore", failedOperation: "branch" },
+    { phase: "restore", failedOperation: "both" },
+  ] as const)(
+    "reports the failed $failedOperation operation during $phase cleanup",
+    async ({ phase, failedOperation }) => {
+      const removeFails = failedOperation !== "branch";
+      const branchFails = failedOperation !== "remove";
+      const name = "cleanup-failure";
+      const branch = `openclaw/${name}`;
+      let record;
+      if (phase === "restore") {
+        record = await service.create({ repoRoot: repo, name, baseRef: "HEAD" });
+        await service.remove({ id: record.id, reason: "test" });
+      } else {
+        await writeFailingSetup();
+      }
+      const registryBefore = service.listRegistryRecords();
+      const fatal = "fatal: branch deletion denied";
+      let cleanupPath: string | undefined;
+      vi.spyOn(commandExec, "runCommandWithTimeout").mockImplementation(async (argv, options) => {
+        const args = argv[0] === "git" ? argv.slice(3) : [];
+        if (phase === "restore" && args[0] === "reset") {
+          return { ...emptyFailure, code: 45, stderr: "fatal: restore index failed" };
+        }
+        if (args[0] === "worktree" && args[1] === "remove") {
+          cleanupPath = args.at(-1);
+          const removed = await realRunCommand(argv, options);
+          expect(removed.code).toBe(0);
+          // A child can fail after applying its filesystem effects. Later branch
+          // deletion output must not mask this removal failure.
+          return removeFails ? emptyFailure : { ...removed, stdout: "worktree removal complete" };
+        }
+        if (args[0] === "branch" && args[1] === "-D" && branchFails) {
+          return {
+            ...emptyFailure,
+            stderr: `${"Deleting branch\r".repeat(200)}\n${"x".repeat(8_000)}${fatal}`,
+          };
+        }
+        return await realRunCommand(argv, options);
+      });
+
+      const message = await failureMessage(
+        record
+          ? service.restore({ id: record.id })
+          : service.create({ repoRoot: repo, name, baseRef: "HEAD" }),
+      );
+
+      expect(cleanupPath).toBeDefined();
+      await expect(fs.stat(cleanupPath!)).rejects.toMatchObject({ code: "ENOENT" });
+      expect(service.listRegistryRecords()).toEqual(registryBefore);
+      expect(await git(repo, "branch", "--list", branch)).toBe(branchFails ? branch : "");
+      if (record) {
+        expect(await git(repo, "show-ref", "--verify", registryBefore[0]!.snapshotRef!)).not.toBe(
+          "",
+        );
+      }
+      expect(message).toContain(
+        phase === "restore" ? "fatal: restore index failed" : "fatal: setup failed",
+      );
+      const label =
+        phase === "restore" ? "restore cleanup failed:" : "failed to clean up worktree creation:";
+      expect(message).toContain(label);
+      const cleanupMessage = message.slice(message.indexOf(label) + label.length);
+      expect.soft(cleanupMessage).toContain(removeFails ? "git worktree remove" : "git branch -D");
+      expect.soft(/(?:exit|code|status)[^\n]*73/i.test(cleanupMessage)).toBe(true);
+      expect.soft(cleanupMessage).not.toContain("worktree removal complete");
+      expect.soft(cleanupMessage).not.toContain("Deleted branch");
+      if (!removeFails) {
+        expect.soft(cleanupMessage.includes(fatal)).toBe(true);
+      } else {
+        expect.soft(cleanupMessage).not.toContain(fatal);
+      }
+      expect.soft(cleanupMessage.length).toBeLessThanOrEqual(2_300);
+    },
+  );
+
+  it.each([
+    { name: "long evidence inside the existing window", oldEvidenceVisible: true },
+    { name: "evidence outside the existing newline window", oldEvidenceVisible: false },
+  ])("preserves retry authority for $name", async ({ oldEvidenceVisible }) => {
+    await git(path.join(root, "remote.git"), "symbolic-ref", "HEAD", "refs/heads/main");
+    await git(repo, "remote", "set-head", "origin", "-a");
+    const name = "retry-evidence";
+    const branch = `openclaw/${name}`;
+    let allocatedPath: string | undefined;
+    let firstAdd = true;
+    vi.spyOn(commandExec, "runCommandWithTimeout").mockImplementation(async (argv, options) => {
+      const result = await realRunCommand(argv, options);
+      const args = argv[0] === "git" ? argv.slice(3) : [];
+      if (firstAdd && args[0] === "worktree" && args[1] === "add") {
+        firstAdd = false;
+        allocatedPath = args.at(-2);
+        expect(result.code).toBe(0);
+        const separator = oldEvidenceVisible ? "\r" : "\n";
+        return {
+          ...result,
+          code: 1,
+          stderr: `Preparing worktree (new branch '${branch}')${separator}${`progress ${"x".repeat(200)}${separator}`.repeat(20)}fatal: checkout failed`,
+        };
+      }
+      return result;
+    });
+
+    if (oldEvidenceVisible) {
+      const created = await service.create({ repoRoot: repo, name });
+      expect(created.baseRef).toBe("HEAD");
+      expect(await git(created.path, "branch", "--show-current")).toBe(branch);
+      expect(service.listRegistryRecords()).toEqual([created]);
+    } else {
+      await expect(service.create({ repoRoot: repo, name })).rejects.toThrow("checkout failed");
+      expect(service.listRegistryRecords()).toEqual([]);
+    }
+    expect(allocatedPath).toBeDefined();
+    expect(await git(repo, "worktree", "list", "--porcelain")).toContain(allocatedPath);
+    expect(await git(allocatedPath!, "branch", "--show-current")).toBe(branch);
+  });
+});

--- a/src/agents/worktrees/service.test.ts
+++ b/src/agents/worktrees/service.test.ts
@@ -530,15 +530,34 @@ describe("ManagedWorktreeService", () => {
     await expect(fs.access(setupMarker)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it("removes the worktree and branch when setup fails", async () => {
+  it("bounds failed setup diagnostics without losing the fatal detail or cleanup", async () => {
     await fs.mkdir(path.join(repo, ".openclaw"));
     const script = path.join(repo, ".openclaw", "worktree-setup.sh");
-    await fs.writeFile(script, "#!/bin/sh\necho setup-broke >&2\nexit 9\n", { mode: 0o755 });
-    await expect(
-      service.create({ repoRoot: repo, name: "broken-setup", baseRef: "HEAD" }),
-    ).rejects.toThrow("setup-broke");
+    const fatal = "fatal: setup dependency could not be resolved";
+    const progress = Array.from(
+      { length: 2_000 },
+      (_, index) => `Receiving objects: ${index}/2000\r`,
+    ).join("");
+    await fs.writeFile(
+      script,
+      `#!/bin/sh\nprintf '%s\\n' "$OPENCLAW_WORKTREE_PATH" > "$OPENCLAW_SOURCE_TREE_PATH/setup-path.txt"\nprintf '%s' '${progress}\n${"x".repeat(65_536)}${fatal}\n' >&2\nexit 23\n`,
+      { mode: 0o755 },
+    );
+    const failure: unknown = await service
+      .create({ repoRoot: repo, name: "broken-setup", baseRef: "HEAD" })
+      .catch((error: unknown) => error);
+    expect(failure).toBeInstanceOf(Error);
+    if (!(failure instanceof Error)) {
+      throw new Error("expected setup failure");
+    }
+    const worktreePath = (await fs.readFile(path.join(repo, "setup-path.txt"), "utf8")).trim();
+    await expect(fs.stat(worktreePath)).rejects.toMatchObject({ code: "ENOENT" });
     expect(await git(repo, "worktree", "list", "--porcelain")).not.toContain("broken-setup");
     expect(await git(repo, "branch", "--list", "openclaw/broken-setup")).toBe("");
+    expect(service.listRegistryRecords()).toEqual([]);
+    expect.soft(failure.message).toContain(fatal);
+    expect.soft(failure.message.length).toBeLessThanOrEqual(2_300);
+    expect.soft(/(?:exit|code|status)[^\n]*23/i.test(failure.message)).toBe(true);
   });
 
   it("restores tracked, untracked, and provisioned ignored files from the snapshot", async () => {

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -7,6 +7,7 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveStateDir } from "../../config/paths.js";
 import { isMissingPathError, formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { createCommandError } from "../../process/command-error.js";
 import { runCommandWithTimeout } from "../../process/exec.js";
 import { withOpenClawStateLease } from "../../state/openclaw-state-lease.js";
 import { createCrustaceanSlug } from "../session-slug.js";
@@ -133,10 +134,6 @@ type ManagedWorktreeGcParams = {
 /** Returns the default no-limit policy for age-based managed-worktree cleanup. */
 export function resolveWorktreeCleanupLimits(): WorktreeCleanupLimits {
   return {};
-}
-
-function resultMessage(result: GitResult): string {
-  return (result.stderr || result.stdout).trim().split("\n").slice(-12).join("\n");
 }
 
 function validateName(name: string): string {
@@ -275,9 +272,11 @@ async function cleanupFailedCreate(repoRoot: string, worktreePath: string, branc
   const deletedBranch = await runGit(repoRoot, ["branch", "-D", branch]);
   await runGit(repoRoot, ["worktree", "prune"]);
   if (removed.code !== 0 || deletedBranch.code !== 0) {
-    throw new Error(
-      `failed to clean up worktree creation: ${resultMessage(removed) || resultMessage(deletedBranch)}`,
-    );
+    const failure =
+      removed.code !== 0
+        ? commandError("git worktree remove", removed)
+        : commandError("git branch -D", deletedBranch);
+    throw new Error(`failed to clean up worktree creation: ${failure.message}`);
   }
 }
 
@@ -316,7 +315,9 @@ async function canResetFailedWorktreeAdd(
   branch: string,
   failure: GitResult,
 ): Promise<boolean> {
-  const message = resultMessage(failure);
+  // Keep retry evidence unchanged: diagnostic rendering/truncation must never
+  // grant cleanup or retry authority.
+  const message = (failure.stderr || failure.stdout).trim().split("\n").slice(-12).join("\n");
   const createdBranch = message.includes(`Preparing worktree (new branch '${branch}')`);
   if (message.includes("unable to checkout working tree") || createdBranch) {
     return true;
@@ -342,8 +343,9 @@ async function runSetupScript(repoRoot: string, worktreePath: string): Promise<v
   if (!stat?.isFile() || (stat.mode & 0o111) === 0) {
     return;
   }
+  const timeoutMs = 120_000;
   const result = await runCommandWithTimeout([setupScript], {
-    timeoutMs: 120_000,
+    timeoutMs,
     cwd: worktreePath,
     env: {
       OPENCLAW_SOURCE_TREE_PATH: repoRoot,
@@ -351,9 +353,7 @@ async function runSetupScript(repoRoot: string, worktreePath: string): Promise<v
     },
   });
   if (result.code !== 0) {
-    throw new Error(
-      `worktree setup failed${resultMessage(result) ? `:\n${resultMessage(result)}` : ""}`,
-    );
+    throw createCommandError("worktree setup", result, { timeoutMs });
   }
 }
 
@@ -1092,10 +1092,13 @@ export class ManagedWorktreeService {
         ? await runGit(record.repoRoot, ["branch", "-D", record.branch])
         : undefined;
       if (removed.code !== 0 || (branchDeleted && branchDeleted.code !== 0)) {
-        throw new Error(
-          `${String(error)}\nrestore cleanup failed: ${resultMessage(removed) || (branchDeleted ? resultMessage(branchDeleted) : "")}`,
-          { cause: error },
-        );
+        const failure =
+          branchDeleted && removed.code === 0
+            ? commandError("git branch -D", branchDeleted)
+            : commandError("git worktree remove", removed);
+        throw new Error(`${String(error)}\nrestore cleanup failed: ${failure.message}`, {
+          cause: error,
+        });
       }
       throw error;
     }

--- a/src/infra/git-exec.test.ts
+++ b/src/infra/git-exec.test.ts
@@ -39,6 +39,7 @@ describe.each([
       ...result,
       stdout: Buffer.from(result.stdout),
       stderr: Buffer.from(result.stderr),
+      code: result.termination === "exit" && !result.outputLimitExceeded ? result.code : null,
       termination: result.outputLimitExceeded
         ? "output-limit"
         : result.termination === "no-output-timeout"
@@ -112,7 +113,7 @@ describe.each([
     },
   );
 
-  it.each(["", " \t\r\n", `${String.fromCharCode(27)}[0m`])(
+  it.each(["", " \t\r\n", `${String.fromCharCode(27)}[0m`, "progress\r \t"])(
     "uses stdout when stderr has no visible diagnostic: %j",
     async (stderr) => {
       failWith({ stderr, stdout: "error: cannot read index\n" });

--- a/src/infra/git-exec.ts
+++ b/src/infra/git-exec.ts
@@ -1,6 +1,6 @@
-import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
-import { runCommandBuffered, runCommandWithTimeout, type SpawnResult } from "../process/exec.js";
+import { createCommandError } from "../process/command-error.js";
+import type { SpawnResult } from "../process/exec-result.js";
+import { runCommandBuffered, runCommandWithTimeout } from "../process/exec.js";
 
 export const GIT_TIMEOUT_MS = 120_000;
 
@@ -20,42 +20,11 @@ export function createGitCommandError(
   command: string,
   result: SpawnResult | Awaited<ReturnType<typeof runCommandBuffered>>,
 ): Error {
-  const output = stripAnsi(result.stderr.toString()).trim() || stripAnsi(result.stdout.toString());
-  // Git progress redraws use CR, not LF. Keep the last frame of each line,
-  // including an unfinished redraw, without changing successful command output.
-  const normalized = output
-    .replace(/\r\n/g, "\n")
-    .split("\n")
-    .map((line) => line.replace(/\r+$/, "").split("\r").at(-1) ?? "")
-    .join("\n")
-    .trim();
-  const tail = normalized.split("\n").slice(-12).join("\n");
-  const omitted = tail.length < normalized.length || tail.length > 2000;
-  const detail = `${omitted ? "…\n" : ""}${sliceUtf16Safe(tail, -2000)}`;
-  const reasons: string[] = [];
-  const timedOut = result.termination === "timeout";
-  if (timedOut) {
-    reasons.push(`timed out after ${GIT_TIMEOUT_MS / 1000} seconds`);
-  } else if (result.termination === "no-output-timeout") {
-    reasons.push("timed out waiting for output");
-  } else if (
-    result.termination === "output-limit" ||
-    ("outputLimitExceeded" in result && result.outputLimitExceeded)
-  ) {
-    reasons.push("output limit exceeded");
+  const error = createCommandError(command, result, { timeoutMs: GIT_TIMEOUT_MS });
+  if (result.termination === "timeout") {
+    error.message += "\nCheck repository access and disk space.";
   }
-  if (result.signal) {
-    reasons.push(`signal ${result.signal}`);
-  } else if (result.termination === "signal" && reasons.length === 0) {
-    reasons.push("terminated");
-  }
-  if (reasons.length === 0 && result.code !== null) {
-    reasons.push(`exit code ${result.code}`);
-  }
-  const label = truncateUtf16Safe(stripAnsi(command).replace(/[\r\n]+/g, " "), 256);
-  const reason = reasons.length > 0 ? ` (${reasons.join("; ")})` : "";
-  const nextStep = timedOut ? "\nCheck repository access and disk space." : "";
-  return new Error(`${label} failed${reason}${detail ? `:\n${detail}` : ""}${nextStep}`);
+  return error;
 }
 
 export async function requireGitCommand(

--- a/src/process/command-error.test.ts
+++ b/src/process/command-error.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { createCommandError } from "./command-error.js";
+import type { SpawnResult } from "./exec-result.js";
+
+const failure: SpawnResult = {
+  stdout: "",
+  stderr: "",
+  code: 124,
+  signal: null,
+  killed: true,
+  termination: "timeout",
+};
+
+describe("createCommandError", () => {
+  it.each([
+    { termination: "timeout", expected: "timed out after 3 seconds" },
+    { termination: "no-output-timeout", expected: "timed out waiting for output" },
+    { termination: "signal", expected: "terminated" },
+  ] as const)("reports $termination without inventing a signal or Git advice", (entry) => {
+    const error = createCommandError(
+      "setup",
+      { ...failure, termination: entry.termination, code: null },
+      { timeoutMs: 3_000 },
+    );
+    expect(error.message).toBe(`setup failed (${entry.expected})`);
+  });
+
+  it("bounds labels and diagnostic tails without splitting surrogate pairs", () => {
+    const command = `\u001b[31m${"x".repeat(254)}\r\n🦞${"y".repeat(300)}\u001b[0m`;
+    const stderr = `${"x".repeat(100)}🦞${"y".repeat(1999)}`;
+    const error = createCommandError(command, { ...failure, stderr }, { timeoutMs: 120_000 });
+
+    const [label, detail] = error.message.split(" failed (timed out after 120 seconds):\n");
+    expect(label).toBe(`${"x".repeat(254)} `);
+    expect(detail).toBe(`…\n${"y".repeat(1999)}`);
+  });
+});

--- a/src/process/command-error.ts
+++ b/src/process/command-error.ts
@@ -1,0 +1,48 @@
+import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
+import type { SpawnResult } from "./exec-result.js";
+import type { runCommandBuffered } from "./exec.js";
+
+function normalizeDiagnostic(output: string | Buffer): string {
+  // Progress redraws use CR, not LF. Keep the last frame, including an
+  // unfinished redraw, before deciding whether this stream has visible text.
+  return stripAnsi(output.toString())
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .map((line) => line.replace(/\r+$/, "").split("\r").at(-1) ?? "")
+    .join("\n")
+    .trim();
+}
+
+export function createCommandError(
+  command: string,
+  result: SpawnResult | Awaited<ReturnType<typeof runCommandBuffered>>,
+  options: { timeoutMs: number },
+): Error {
+  const output = normalizeDiagnostic(result.stderr) || normalizeDiagnostic(result.stdout);
+  const tail = output.split("\n").slice(-12).join("\n");
+  const omitted = tail.length < output.length || tail.length > 2000;
+  const detail = `${omitted ? "…\n" : ""}${sliceUtf16Safe(tail, -2000)}`;
+  const reasons: string[] = [];
+  if (result.termination === "timeout") {
+    reasons.push(`timed out after ${options.timeoutMs / 1000} seconds`);
+  } else if (result.termination === "no-output-timeout") {
+    reasons.push("timed out waiting for output");
+  } else if (
+    result.termination === "output-limit" ||
+    ("outputLimitExceeded" in result && result.outputLimitExceeded)
+  ) {
+    reasons.push("output limit exceeded");
+  }
+  if (result.signal) {
+    reasons.push(`signal ${result.signal}`);
+  } else if (result.termination === "signal" && reasons.length === 0) {
+    reasons.push("terminated");
+  }
+  if (reasons.length === 0 && result.code !== null) {
+    reasons.push(`exit code ${result.code}`);
+  }
+  const label = truncateUtf16Safe(stripAnsi(command).replace(/[\r\n]+/g, " "), 256);
+  const reason = reasons.length > 0 ? ` (${reasons.join("; ")})` : "";
+  return new Error(`${label} failed${reason}${detail ? `:\n${detail}` : ""}`);
+}


### PR DESCRIPTION
Related: #131363 — readable shared Git diagnostics; follows its named setup/cleanup diagnostic follow-up. The original Git banner context is #131323 (already closed by that repair).

## What Problem This Solves

Fixes an issue where users creating a managed worktree would receive an oversized setup error when a repository setup script emitted carriage-return progress or a long line. Setup failures also omitted the recorded exit or termination reason. If creation or restore cleanup failed, successful output from another cleanup command could hide the operation that actually failed.

## Why This Change Was Made

The process diagnostic owner now serves both Git and repository setup: normalize each stream before choosing stderr or stdout, collapse redraws, strip ANSI, retain the last 12 logical lines within a surrogate-safe 2,000-character detail cap, bound the command label, and report actual process termination facts. The Git wrapper retains its 120-second timeout policy and Git-specific advice; setup uses its unchanged 120-second timeout for execution and reporting. Cleanup renders the failed operation, preferring removal if both operations fail.

This removes the service's duplicate renderer and moves the formatter landed in #131363 into one shared process module. Service-only truncation would duplicate policy and leave termination reporting inconsistent. Using formatted text as retry evidence would change cleanup authority, so the exact previous raw stderr/stdout, trim, last-12-newline expression stays in the retry owner. Commands, sequencing, conditions, hooks, success classification, retry authority, leases, registry lifecycle, schema, protocol, and configuration are unchanged.

## User Impact

Failed setup and cleanup operations now show compact, useful diagnostics with the actual failure reason. No new options or operator migration are required. [Repository setup guidance](https://docs.openclaw.ai/concepts/managed-worktrees#run-repository-setup) explains the output and timeout troubleshooting. The existing Git troubleshooting added by #131363 is preserved.

Release-note context: managed worktree setup/cleanup errors stay readable and identify the failed process or Git operation. AI-assisted, maintainer-authored work by @steipete; the implementation and its authority boundaries have been reviewed and understood.

## Evidence

`node --import tsx /tmp/worktree-diagnostics-repro.mts` (local scratch reproduction, not a committed artifact) used a real executable setup script, real subprocesses, and a disposable Git repository with isolated state and a local bare remote. Its 122,473-character output produced a 122,495-character error containing 2,000 carriage returns and no exit code. The fixed error is 2,040 characters, contains no carriage returns, and retains the fatal detail and exit code 23. Worktree, branch, registry allocation, setup process, and fixture cleanup were checked.

The original six-file regression command failed with 10 intended failures, 65 passes, and one macOS skip before the production repair, then passed 75 tests with one skip. Existing retry-window tests already passed before the fix. The retained red/green logs are prior proof, not a claim of a newly rerun baseline.

Fresh reconciled-head validation:

```sh
node scripts/run-vitest.mjs src/agents/worktrees/service.diagnostics.test.ts src/agents/worktrees/service.test.ts src/agents/worktrees/service.hooks.test.ts src/agents/worktrees/service.provisioned.test.ts src/agents/worktrees/service.run-end-cleanup.test.ts src/agents/worktrees/service.remove-lease.test.ts src/infra/git-exec.test.ts src/agents/worktrees/git.test.ts src/process/command-error.test.ts src/process/exec.test.ts src/process/exec.no-output-timer.test.ts src/snapshot/git-backup.test.ts src/gateway/control-ui-session-prs.test.ts
node scripts/check-changed.mjs -- docs/concepts/managed-worktrees.md src/agents/worktrees/service.diagnostics.test.ts src/agents/worktrees/service.test.ts src/agents/worktrees/service.ts src/infra/git-exec.test.ts src/infra/git-exec.ts src/process/command-error.test.ts src/process/command-error.ts
pnpm docs:list
git diff --check
```

Fresh precommit and reconciled-branch Codex autoreviews both passed with no actionable P0 findings. The real subprocess reproduction was rerun on `aa7f2904036b8e3bd18aebc45459d7dd223f459b` with the fixed results above. The full focused command passed all 13 files: **202 passed, 2 existing platform skips**, across six routed Vitest shards. It includes the generic formatter through normal tracked routing, all six worktree lifecycle files, the shared Git tests, real process-runner tests, backup caller tests, and the Gateway PR caller. No test rerun or repair was needed; the loaded local host took 19m38s. [Exact-head CI run 33135477052](https://github.com/openclaw/openclaw/actions/runs/33135477052) is successful at `aa7f2904036b8e3bd18aebc45459d7dd223f459b`. `node scripts/watch-pr-ci.mjs 131420 aa7f2904036b8e3bd18aebc45459d7dd223f459b` exited 0 with `GREEN` and zero pending checks. One changing-pagination read was retried; no CI job rerun or repair was needed. The actual local changed-file gate passed (exit 0), including production/test types, lint, format, zero-entry dead-code scans, schema/database guards and zero runtime value import cycles. The only warning was manual test fixture creation; teardown closes database handles and removes the fixture, and the real reproduction verifies cleanup.

Proof limits: service + real subprocess + isolated Git proof; no Gateway/UI screenshot or live Gateway flow. The operator expressly excluded Gateway launches and live operator-state changes for this task, so UI proof cannot be performed within the authorized scope. This changes error rendering, not UI layout. Timeout and signal metadata cases are injected at the process-result boundary; the process runner suite exercises real processes. No external API, package, or lazy-loader boundary changed, so no broad local build/full-suite run was added.

Production LOC against reconciled main: +74/-54 (net +20). Tests: +319/-6 (net +313). Docs: +2. The shared owner absorbs the old Git formatter; remaining production growth supplies setup termination reporting, per-stream normalization before selection, and failed-operation selection at both lifecycle cleanup sites. Further reduction would either mix Git policy into setup or conflate diagnostics with retry authority.

Provenance: stable v2026.7.1 contains the original newline-only service renderer. Local history is shallow and does not establish its original introducing commit; the later shared extraction and #131363 are not attributed as its introduction. The already-landed result types, caller fixtures, and Git wrapper regressions are retained without duplication.

Unchanged follow-ups remain out of scope: Gmail setup diagnostics, untracked-test discovery, and existing managed-worktree hook-policy prose. No redundant issue was opened.

Latest [ClawSweeper review](https://github.com/openclaw/openclaw/pull/131420#issuecomment-5447724714) covers this exact head and reports no correctness or security findings. Both before-merge items request exact-head validation of the consolidated formatter and its justified net +20 production lines; the 202-pass focused command and successful hosted CI above address them. No separate Rank-up moves list was published. Its reported live-verification failure is an output-matching failure: the command exited successfully with 13 tests passed, but the default reporter did not print the suite title expected by the harness. No test or assertion was weakened to address that mismatch. Gateway proof remains outside the explicitly authorized scope.
