### PR TITLE
fix(ui): align Communications settings layout

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3977,7 +3977,7 @@ ui/src/components/exec-approval.ts	1
 ui/src/components/file-preview-modal.ts	1
 ui/src/components/github-link-hovercard-registration.ts	1
 ui/src/components/github-link-hovercard.runtime.ts	2
-ui/src/components/hub-tabs.ts	2
+ui/src/components/hub-tabs.ts	1
 ui/src/components/input-dialog.ts	1
 ui/src/components/lobster-dex.ts	2
 ui/src/components/login-gate.ts	3

--- a/ui/src/components/config-form.browser.test.ts
+++ b/ui/src/components/config-form.browser.test.ts
@@ -313,9 +313,11 @@ describe("config form renderer", () => {
       container,
     );
 
-    const headings = Array.from(container.querySelectorAll(".settings-section__heading")).map(
-      (node) => node.textContent?.trim(),
-    );
+    const headings = Array.from(
+      container.querySelectorAll(
+        ".settings-section > .settings-section__header .settings-section__heading",
+      ),
+    ).map((node) => node.textContent?.trim());
     expect(headings).toEqual(["Auth"]);
     // The subsection object emits its fields directly; no nested details block
     // repeats the subsection title inside the group.

--- a/ui/src/components/config-form.render.ts
+++ b/ui/src/components/config-form.render.ts
@@ -81,7 +81,10 @@ export function renderConfigTierGroups(params: {
             class="config-advanced-disclosure"
             ?open=${params.revealAdvanced}
             @toggle=${(event: Event) => {
-              const disclosure = event.currentTarget as HTMLDetailsElement;
+              const disclosure = event.currentTarget;
+              if (!(disclosure instanceof HTMLDetailsElement)) {
+                return;
+              }
               if (disclosure.open === params.revealAdvanced) {
                 return;
               }

--- a/ui/src/components/config-form.render.ts
+++ b/ui/src/components/config-form.render.ts
@@ -27,8 +27,8 @@ type ConfigFormProps = {
   activeSubsection?: string | null;
   showAdvanced?: boolean;
   forceAdvancedSection?: string | null;
-  /** Required: the collapsed-advanced ghost row's only action. Optional would
-   *  permit an inert "Show advanced" control that strands hidden settings. */
+  /** Required: the collapsed advanced disclosure's only action. Optional would
+   *  permit an inert control that strands hidden settings. */
   onShowAdvanced: () => void;
   /** Paired expanded-state action. Omit when search or a forced route owns the reveal. */
   onHideAdvanced?: () => void;
@@ -47,32 +47,15 @@ type ConfigFormProps = {
   onRemove?: (path: Array<string | number>) => void;
 };
 
-function renderAdvancedDivider(onHideAdvanced: (() => void) | undefined) {
-  return html`<div class="config-advanced-divider">
-    <span>${t("configForm.advancedDivider")}</span>
-    ${onHideAdvanced
-      ? html`<button
-          type="button"
-          class="config-advanced-divider__toggle config-show-advanced active"
-          aria-pressed="true"
-          @click=${() => onHideAdvanced()}
-        >
-          ${t("common.hideAdvanced")}
-        </button>`
-      : nothing}
-  </div>`;
-}
-
 /** Common/advanced split body shared by the config page and channel forms so
- *  every schema surface hides advanced settings behind the same ghost row. */
+ *  every schema surface uses the same native disclosure. */
 export function renderConfigTierGroups(params: {
   schema: JsonSchema;
   path: Array<string | number>;
   hints: ConfigUiHints;
   revealAdvanced: boolean;
   onShowAdvanced: () => void;
-  /** Surfaces with collapsible advanced fields pass this so the expanded
-   *  divider remains the single inverse of the collapsed ghost action. */
+  /** Surfaces with collapsible advanced fields pass this as the inverse action. */
   onHideAdvanced?: () => void;
   renderTier: (node: JsonSchema) => TemplateResult | typeof nothing;
   commonPrelude?: TemplateResult;
@@ -82,9 +65,6 @@ export function renderConfigTierGroups(params: {
     path: params.path.map(String),
     hints: params.hints,
   });
-  // An advanced-only schema needs no separator, but a surface whose only
-  // collapse control lives on the divider would otherwise strand the tier open.
-  const showDivider = Boolean(split.common) || Boolean(params.onHideAdvanced);
   // The wrapper owns tier spacing so embedders without a settings-section
   // parent (the channel forms) do not render the tiers flush against each other.
   return html`
@@ -97,29 +77,30 @@ export function renderConfigTierGroups(params: {
           </div>`
         : nothing}
       ${split.advanced && split.advancedLeafCount > 0
-        ? params.revealAdvanced
-          ? html`
-              ${showDivider ? renderAdvancedDivider(params.onHideAdvanced) : nothing}
-              <div class="settings-group">${params.renderTier(split.advanced)}</div>
-            `
-          : html`
-              <button
-                type="button"
-                class="config-advanced-ghost config-show-advanced"
-                aria-pressed="false"
-                @click=${() => params.onShowAdvanced()}
-              >
-                <span class="config-advanced-ghost__count">
-                  ${t(
-                    split.advancedLeafCount === 1
-                      ? "configForm.advancedHidden"
-                      : "configForm.advancedHiddenPlural",
-                    { count: String(split.advancedLeafCount) },
-                  )}
-                </span>
-                <span class="config-advanced-ghost__action">${t("configForm.showAdvanced")}</span>
-              </button>
-            `
+        ? html`<details
+            class="config-advanced-disclosure"
+            ?open=${params.revealAdvanced}
+            @toggle=${(event: Event) => {
+              const disclosure = event.currentTarget as HTMLDetailsElement;
+              if (disclosure.open === params.revealAdvanced) {
+                return;
+              }
+              if (disclosure.open) {
+                params.onShowAdvanced();
+              } else if (params.onHideAdvanced) {
+                params.onHideAdvanced();
+              } else {
+                disclosure.open = true;
+              }
+            }}
+          >
+            <summary class="settings-section__heading config-advanced-disclosure__summary">
+              ${t("configForm.advancedDivider")}
+            </summary>
+            ${params.revealAdvanced
+              ? html`<div class="settings-group">${params.renderTier(split.advanced)}</div>`
+              : nothing}
+          </details>`
         : nothing}
     </div>
   `;

--- a/ui/src/components/config-form.render.ts
+++ b/ui/src/components/config-form.render.ts
@@ -34,6 +34,7 @@ type ConfigFormProps = {
   onHideAdvanced?: () => void;
   /** Inline actions rendered next to the active section heading (e.g. env peek). */
   sectionActions?: TemplateResult;
+  showSectionDocs?: boolean;
   /** A Control UI-owned row rendered before common schema rows in the active section. */
   sectionPrelude?: TemplateResult;
   /** Composite pages render custom rows above the form; an empty schema
@@ -227,7 +228,7 @@ export function renderConfigForm(props: ConfigFormProps) {
     path: Array<string | number>;
   }) => {
     const sectionHint = hintForPath(params.path.slice(0, 1), props.uiHints);
-    const docsUrl = sectionHint?.docsUrl;
+    const docsUrl = props.showSectionDocs === false ? undefined : sectionHint?.docsUrl;
     const docsTriggerId = `settings-section-help-${params.id}`;
     const revealAdvanced =
       props.showAdvanced === true ||

--- a/ui/src/components/config-form.render.ts
+++ b/ui/src/components/config-form.render.ts
@@ -98,7 +98,7 @@ export function renderConfigTierGroups(params: {
             }}
           >
             <summary class="settings-section__heading config-advanced-disclosure__summary">
-              ${t("configForm.advancedDivider")}
+              ${t("configForm.advancedSettings")}
             </summary>
             ${params.revealAdvanced
               ? html`<div class="settings-group">${params.renderTier(split.advanced)}</div>`

--- a/ui/src/components/hub-tabs.test.ts
+++ b/ui/src/components/hub-tabs.test.ts
@@ -59,6 +59,7 @@ describe("renderHubTabs", () => {
 
   it("selects only enabled tabs from direct user activation", () => {
     const onSelect = vi.fn();
+    const onActivate = vi.fn();
     const container = document.createElement("div");
     render(
       renderHubTabs({
@@ -72,6 +73,7 @@ describe("renderHubTabs", () => {
         ariaLabel: "Example sections",
         panelId: "example-panel",
         onSelect,
+        onActivate,
       }),
       container,
     );
@@ -92,6 +94,7 @@ describe("renderHubTabs", () => {
 
     expect(onSelect).toHaveBeenCalledOnce();
     expect(onSelect).toHaveBeenCalledWith("second");
+    expect(onActivate).toHaveBeenCalledWith(container.querySelector("#example-tab-second"));
     expect(container.querySelector("wa-tab-group")?.getAttribute("activation")).toBe("manual");
   });
 

--- a/ui/src/components/hub-tabs.ts
+++ b/ui/src/components/hub-tabs.ts
@@ -21,6 +21,7 @@ type HubTabsProps<T extends string> = {
   className?: string;
   variant?: "primary" | "sub";
   onSelect: (tab: T) => void;
+  onActivate?: (element: HTMLElement) => void;
 };
 
 // Keyboard activation unmounts a route-owned strip, so the destination strip
@@ -95,6 +96,7 @@ export function renderHubTabs<T extends string>(props: HubTabsProps<T>): Templat
                 tab.value !== props.active
               ) {
                 props.onSelect(tab.value);
+                props.onActivate?.(event.currentTarget as HTMLElement);
               }
             }}
             @keydown=${(event: KeyboardEvent) => {
@@ -112,6 +114,7 @@ export function renderHubTabs<T extends string>(props: HubTabsProps<T>): Templat
                   source: event.currentTarget as Element,
                 };
                 props.onSelect(tab.value);
+                props.onActivate?.(event.currentTarget as HTMLElement);
               }
             }}
             ${selected ? ref((element) => reclaimFocus(props.id, tab.value, element)) : nothing}

--- a/ui/src/components/hub-tabs.ts
+++ b/ui/src/components/hub-tabs.ts
@@ -90,16 +90,24 @@ export function renderHubTabs<T extends string>(props: HubTabsProps<T>): Templat
             aria-selected=${selected ? "true" : "false"}
             data-test-id=${tab.testId ?? nothing}
             @click=${(event: MouseEvent) => {
+              const activeElement = event.currentTarget;
+              if (!(activeElement instanceof HTMLElement)) {
+                return;
+              }
               if (
                 !tab.disabled &&
                 (event.detail > 0 || event.isTrusted) &&
                 tab.value !== props.active
               ) {
                 props.onSelect(tab.value);
-                props.onActivate?.(event.currentTarget as HTMLElement);
+                props.onActivate?.(activeElement);
               }
             }}
             @keydown=${(event: KeyboardEvent) => {
+              const activeElement = event.currentTarget;
+              if (!(activeElement instanceof HTMLElement)) {
+                return;
+              }
               if (
                 !tab.disabled &&
                 !event.repeat &&
@@ -111,10 +119,10 @@ export function renderHubTabs<T extends string>(props: HubTabsProps<T>): Templat
                   hubId: props.id,
                   tab: tab.value,
                   at: Date.now(),
-                  source: event.currentTarget as Element,
+                  source: activeElement,
                 };
                 props.onSelect(tab.value);
-                props.onActivate?.(event.currentTarget as HTMLElement);
+                props.onActivate?.(activeElement);
               }
             }}
             ${selected ? ref((element) => reclaimFocus(props.id, tab.value, element)) : nothing}

--- a/ui/src/e2e/config-form-defaults.e2e.test.ts
+++ b/ui/src/e2e/config-form-defaults.e2e.test.ts
@@ -135,7 +135,7 @@ suite.define(() => {
         const enabledRow = settingsRow(page, "Enabled");
         const modeRow = settingsRow(page, "Mode");
         const payloadRow = settingsRow(page, "Payload");
-        const profileBlock = panel.locator("details").filter({
+        const profileBlock = panel.locator("details.cfg-object").filter({
           has: page.locator(".cfg-object__summary .settings-row__title").getByText("Profile", {
             exact: true,
           }),
@@ -215,7 +215,7 @@ suite.define(() => {
         const reloadedEnabledRow = settingsRow(page, "Enabled");
         const reloadedModeRow = settingsRow(page, "Mode");
         const reloadedPayloadRow = settingsRow(page, "Payload");
-        const reloadedProfileBlock = reloadedPanel.locator("details").filter({
+        const reloadedProfileBlock = reloadedPanel.locator("details.cfg-object").filter({
           has: page
             .locator(".cfg-object__summary .settings-row__title")
             .getByText("Profile", { exact: true }),

--- a/ui/src/e2e/config-form-guidance.e2e.test.ts
+++ b/ui/src/e2e/config-form-guidance.e2e.test.ts
@@ -198,12 +198,14 @@ suite.define(() => {
 
         const response = await page.goto(`${suite.server.baseUrl}settings/appearance`);
         expect(response?.status()).toBe(200);
-        await page.getByRole("radio", { name: "UI", exact: true }).click();
+        await page.getByRole("tab", { name: "UI", exact: true }).click();
 
-        const disclosure = page.locator(".config-advanced-ghost");
+        const disclosure = page.locator("details.config-advanced-disclosure");
         await expect.poll(() => disclosure.count()).toBe(1);
-        await expect.poll(() => disclosure.textContent()).toContain("2 advanced settings hidden");
-        await expect.poll(() => page.locator(".config-show-advanced").count()).toBe(1);
+        await expect.poll(() => disclosure.getAttribute("open")).toBeNull();
+        await expect
+          .poll(() => disclosure.locator("summary").textContent())
+          .toContain("Advanced settings");
         await expect
           .poll(() => page.getByText("Show Advanced Settings", { exact: true }).count())
           .toBe(0);
@@ -217,11 +219,8 @@ suite.define(() => {
           });
         }
 
-        await disclosure.click();
-        const hideAdvanced = page.locator(".config-advanced-divider__toggle");
-        await expect.poll(() => hideAdvanced.count()).toBe(1);
-        await expect.poll(() => hideAdvanced.textContent()).toContain("Hide Advanced");
-        await expect.poll(() => disclosure.count()).toBe(0);
+        await disclosure.locator("summary").click();
+        await expect.poll(() => disclosure.getAttribute("open")).not.toBeNull();
 
         if (captureUiProofEnabled) {
           await page.screenshot({
@@ -231,8 +230,8 @@ suite.define(() => {
           });
         }
 
-        await hideAdvanced.click();
-        await expect.poll(() => disclosure.count()).toBe(1);
+        await disclosure.locator("summary").click();
+        await expect.poll(() => disclosure.getAttribute("open")).toBeNull();
         await page.waitForTimeout(750);
         expect(await gateway.getRequests("config.patch")).toHaveLength(0);
         expect(await gateway.getRequests("config.set")).toHaveLength(0);
@@ -263,7 +262,7 @@ suite.define(() => {
 
         const response = await page.goto(`${suite.server.baseUrl}settings/appearance`);
         expect(response?.status()).toBe(200);
-        await page.getByRole("radio", { name: "UI", exact: true }).click();
+        await page.getByRole("tab", { name: "UI", exact: true }).click();
 
         const themeInput = page
           .locator(".settings-row")

--- a/ui/src/e2e/plugins-hub-navigation.e2e.test.ts
+++ b/ui/src/e2e/plugins-hub-navigation.e2e.test.ts
@@ -237,8 +237,7 @@ suite.define(() => {
         });
         expect(Math.abs(layout.tabsLeft - layout.titleLeft)).toBeLessThanOrEqual(1);
         expect(layout.aboveTabs).toBeGreaterThan(0);
-        expect(layout.belowTabs - layout.aboveTabs).toBeGreaterThanOrEqual(7);
-        expect(layout.belowTabs - layout.aboveTabs).toBeLessThanOrEqual(9);
+        expect(Math.abs(layout.belowTabs - layout.aboveTabs)).toBeLessThanOrEqual(1);
         if (label === "desktop") {
           expect(Math.abs(layout.tabsLeft - layout.contentLeft)).toBeLessThanOrEqual(1);
         }

--- a/ui/src/e2e/settings-layout.e2e.test.ts
+++ b/ui/src/e2e/settings-layout.e2e.test.ts
@@ -84,7 +84,7 @@ suite.define(() => {
     });
     const page = await context.newPage();
     const config = {
-      messages: { queueLimit: 5 },
+      messages: { queueLimit: 5, responsePrefix: "[OpenClaw]" },
       tts: { auto: "off" },
     };
     const schema = {
@@ -95,6 +95,7 @@ suite.define(() => {
           title: "Messages",
           properties: {
             queueLimit: { type: "integer", title: "Queue limit", minimum: 0 },
+            responsePrefix: { type: "string", title: "Response prefix" },
           },
         },
         tts: {
@@ -129,6 +130,8 @@ suite.define(() => {
               label: "Messages",
               docsUrl: "https://docs.openclaw.ai/concepts/messages",
             },
+            "messages.queueLimit": { advanced: false },
+            "messages.responsePrefix": { advanced: true },
             tts: { label: "Voice", docsUrl: "https://docs.openclaw.ai/tts" },
           },
           version: "communications-layout",
@@ -152,12 +155,44 @@ suite.define(() => {
         ["Messages", "Voice"],
       );
       expect(await page.locator(".settings-section__help-button").count()).toBe(0);
+      const spacing = await page.evaluate(() => {
+        const subtitle = document.querySelector<HTMLElement>(".page-subtitle");
+        const tabs = document.querySelector<HTMLElement>("wa-tab-group.config-sections-hub-tabs");
+        const section = document.querySelector<HTMLElement>(".settings-section");
+        if (!subtitle || !tabs || !section) {
+          throw new Error("Communications layout did not render");
+        }
+        return {
+          aboveTabs: tabs.getBoundingClientRect().top - subtitle.getBoundingClientRect().bottom,
+          belowTabs: section.getBoundingClientRect().top - tabs.getBoundingClientRect().bottom,
+        };
+      });
+      expect(spacing.aboveTabs).toBeGreaterThan(0);
+      expect(Math.abs(spacing.belowTabs - spacing.aboveTabs)).toBeLessThanOrEqual(1);
+
+      const advanced = page.locator("details.config-advanced-disclosure");
+      await expect.poll(() => advanced.count()).toBe(1);
+      await expect.poll(() => advanced.getAttribute("open")).toBeNull();
+      await expect
+        .poll(() => advanced.locator("summary").textContent())
+        .toContain("Advanced settings");
       if (proofEnabled) {
         await mkdir(proofDir, { recursive: true });
         await page.screenshot({
           animations: "disabled",
           fullPage: true,
           path: path.join(proofDir, "communications-messages.png"),
+        });
+      }
+
+      await advanced.locator("summary").click();
+      await expect.poll(() => advanced.getAttribute("open")).not.toBeNull();
+      await expect.poll(() => page.getByText("Response prefix", { exact: true }).count()).toBe(1);
+      if (proofEnabled) {
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(proofDir, "communications-advanced-expanded.png"),
         });
       }
 

--- a/ui/src/e2e/settings-layout.e2e.test.ts
+++ b/ui/src/e2e/settings-layout.e2e.test.ts
@@ -75,6 +75,110 @@ const responsiveViewports = [
 ] as const;
 
 suite.define(() => {
+  it("uses the shared tab system for Communications without duplicate section help", async () => {
+    const context = await suite.browser.newContext({
+      colorScheme: "dark",
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1440 },
+    });
+    const page = await context.newPage();
+    const config = {
+      messages: { queueLimit: 5 },
+      tts: { auto: "off" },
+    };
+    const schema = {
+      type: "object",
+      properties: {
+        messages: {
+          type: "object",
+          title: "Messages",
+          properties: {
+            queueLimit: { type: "integer", title: "Queue limit", minimum: 0 },
+          },
+        },
+        tts: {
+          type: "object",
+          title: "Voice",
+          properties: {
+            auto: {
+              type: "string",
+              title: "Automatic speech",
+              enum: ["off", "always", "inbound", "tagged"],
+            },
+          },
+        },
+      },
+    };
+    await installMockGateway(page, {
+      methodResponses: {
+        "config.get": {
+          path: "~/.openclaw/openclaw.json",
+          exists: true,
+          raw: `${JSON.stringify(config, null, 2)}\n`,
+          hash: "communications-config-hash",
+          appliedConfigHash: "communications-config-hash",
+          valid: true,
+          config,
+          issues: [],
+        },
+        "config.schema": {
+          schema,
+          uiHints: {
+            messages: {
+              label: "Messages",
+              docsUrl: "https://docs.openclaw.ai/concepts/messages",
+            },
+            tts: { label: "Voice", docsUrl: "https://docs.openclaw.ai/tts" },
+          },
+          version: "communications-layout",
+          generatedAt: new Date(0).toISOString(),
+        },
+      },
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}settings/communications`);
+      await waitForControlUiRoute(page, {
+        pathname: "/settings/communications",
+        routeId: "communications",
+      });
+
+      expect(await page.locator(".page-subtitle").textContent()).toBe(
+        "Messages and text-to-speech settings.",
+      );
+      expect(await page.locator("wa-tab-group.config-sections-hub-tabs").count()).toBe(1);
+      expect((await page.locator("wa-tab").allTextContents()).map((label) => label.trim())).toEqual(
+        ["Messages", "Voice"],
+      );
+      expect(await page.locator(".settings-section__help-button").count()).toBe(0);
+      if (proofEnabled) {
+        await mkdir(proofDir, { recursive: true });
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(proofDir, "communications-messages.png"),
+        });
+      }
+
+      await page.locator("#config-sections-tab-tts").click();
+      await page.waitForFunction(() =>
+        document.querySelector("#config-sections-tab-tts")?.hasAttribute("active"),
+      );
+      expect(await page.locator("#config-sections-tab-tts").getAttribute("active")).not.toBeNull();
+      expect(await page.locator(".settings-section__help-button").count()).toBe(0);
+      if (proofEnabled) {
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(proofDir, "communications-voice.png"),
+        });
+      }
+    } finally {
+      await context.close();
+    }
+  });
+
   it("keeps settings introductions, section headings, and Learn more links on one layout system", async () => {
     const context = await suite.browser.newContext({
       colorScheme: "dark",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1526,7 +1526,8 @@ export const en: TranslationMap = {
   configForm: {
     redactedPlaceholder: "[redacted - click reveal to view]",
     sectionHelp: "Help for {section}",
-    advancedDivider: "Advanced settings",
+    advancedDivider: "Advanced",
+    advancedSettings: "Advanced settings",
     hideValue: "Hide value",
     revealValue: "Reveal value",
     disableStreamToReveal: "Disable stream mode to reveal value",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1526,10 +1526,7 @@ export const en: TranslationMap = {
   configForm: {
     redactedPlaceholder: "[redacted - click reveal to view]",
     sectionHelp: "Help for {section}",
-    showAdvanced: "Show advanced",
-    advancedHidden: "{count} advanced setting hidden",
-    advancedHiddenPlural: "{count} advanced settings hidden",
-    advancedDivider: "Advanced",
+    advancedDivider: "Advanced settings",
     hideValue: "Hide value",
     revealValue: "Reveal value",
     disableStreamToReveal: "Disable stream mode to reveal value",

--- a/ui/src/pages/channels/view.test.ts
+++ b/ui/src/pages/channels/view.test.ts
@@ -272,16 +272,18 @@ function renderWhatsAppConfigForm(
 }
 
 describe("channel config advanced tier", () => {
-  it("hides advanced channel settings behind the ghost row by default", () => {
+  it("hides advanced channel settings behind the disclosure by default", () => {
     const { container, onShowAdvancedSettings } = renderWhatsAppConfigForm(false);
 
     expect(container.textContent).toContain("Enabled");
     expect(container.textContent).not.toContain("Timeout Ms");
-    expect(container.querySelector(".config-advanced-divider")).toBeNull();
-
-    const ghost = container.querySelector<HTMLButtonElement>(".config-advanced-ghost");
-    expect(ghost?.textContent).toContain("2 advanced settings hidden");
-    ghost!.click();
+    const disclosure = container.querySelector<HTMLDetailsElement>(
+      "details.config-advanced-disclosure",
+    );
+    expect(disclosure?.open).toBe(false);
+    expect(disclosure?.querySelector("summary")?.textContent?.trim()).toBe("Advanced settings");
+    disclosure!.open = true;
+    disclosure!.dispatchEvent(new Event("toggle"));
     expect(onShowAdvancedSettings).toHaveBeenCalledWith(true);
   });
 
@@ -290,11 +292,12 @@ describe("channel config advanced tier", () => {
 
     expect(container.textContent).toContain("Enabled");
     expect(container.textContent).toContain("Timeout Ms");
-    expect(container.querySelector(".config-advanced-ghost")).toBeNull();
-
-    const collapse = container.querySelector<HTMLButtonElement>(".config-advanced-divider__toggle");
-    expect(collapse).toBeInstanceOf(HTMLButtonElement);
-    collapse!.click();
+    const disclosure = container.querySelector<HTMLDetailsElement>(
+      "details.config-advanced-disclosure",
+    );
+    expect(disclosure?.open).toBe(true);
+    disclosure!.open = false;
+    disclosure!.dispatchEvent(new Event("toggle"));
     expect(onShowAdvancedSettings).toHaveBeenCalledWith(false);
   });
 
@@ -304,9 +307,12 @@ describe("channel config advanced tier", () => {
       "channels.whatsapp.enabled": { advanced: true },
     });
 
-    const collapse = container.querySelector<HTMLButtonElement>(".config-advanced-divider__toggle");
-    expect(collapse).toBeInstanceOf(HTMLButtonElement);
-    collapse!.click();
+    const disclosure = container.querySelector<HTMLDetailsElement>(
+      "details.config-advanced-disclosure",
+    );
+    expect(disclosure?.open).toBe(true);
+    disclosure!.open = false;
+    disclosure!.dispatchEvent(new Event("toggle"));
     expect(onShowAdvancedSettings).toHaveBeenCalledWith(false);
   });
 

--- a/ui/src/pages/config/config-page.test.ts
+++ b/ui/src/pages/config/config-page.test.ts
@@ -352,6 +352,27 @@ describe("ConfigPage synced preference provenance", () => {
   });
 });
 
+describe("ConfigPage header", () => {
+  it("renders the route subtitle for Communications", () => {
+    const page = new ConfigPage();
+    const state = page as unknown as {
+      context: ApplicationContext;
+      pageId: "communications";
+      renderAdvancedConfig: () => undefined;
+    };
+    state.context = { runtimeConfig: { state: {} } } as unknown as ApplicationContext;
+    state.pageId = "communications";
+    state.renderAdvancedConfig = () => undefined;
+    const container = document.createElement("div");
+
+    render(page.render(), container);
+
+    expect(container.querySelector(".page-subtitle")?.textContent?.trim()).toBe(
+      "Messages and text-to-speech settings.",
+    );
+  });
+});
+
 describe("ConfigPage moved section routes", () => {
   it.each([
     ["channels", "channels", ""],

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -1336,6 +1336,7 @@ export class ConfigPage extends OpenClawLightDomElement {
       assistantName: this.context.config.current.assistantIdentity.name,
       configPath: configState.configSnapshot?.path ?? null,
       navRootLabel: this.pageId === "advanced" ? undefined : configPageTitle(this.pageId),
+      showSectionDocs: this.pageId !== "communications",
       sectionPrelude:
         activeSection === "browser" && browserPanelAvailable
           ? renderBrowserLinkPreferencesRow({

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -10,7 +10,7 @@ import type {
 } from "../../../../packages/gateway-protocol/src/index.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ModelCatalogEntry } from "../../api/types.ts";
-import { titleForRoute } from "../../app-navigation.ts";
+import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
 import { pathForRoute, type RouteId } from "../../app-route-paths.ts";
 import {
   applicationContext,
@@ -196,7 +196,7 @@ function renderConfigPageSubtitle(pageId: ConfigPageId) {
     case "updates":
       return t("updates.page.intro");
     default:
-      return undefined;
+      return subtitleForRoute(pageId);
   }
 }
 

--- a/ui/src/pages/config/memory.test.ts
+++ b/ui/src/pages/config/memory.test.ts
@@ -368,21 +368,23 @@ describe("renderMemory", () => {
       })}`;
 
     const collapsed = renderInto(createProps({ editor: editor(false) }));
-    const show = collapsed.querySelector<HTMLButtonElement>(".config-show-advanced");
-    expect(show?.getAttribute("aria-pressed")).toBe("false");
+    const show = collapsed.querySelector<HTMLDetailsElement>("details.config-advanced-disclosure");
+    expect(show?.open).toBe(false);
     expect(collapsed.textContent).not.toContain("Advanced memory field");
-    show?.click();
+    show!.open = true;
+    show!.dispatchEvent(new Event("toggle"));
     expect(onAdvancedChange).toHaveBeenCalledWith(true);
 
     const expanded = renderInto(createProps({ editor: editor(true) }));
-    const hide = expanded.querySelector<HTMLButtonElement>(".config-show-advanced");
-    expect(hide?.getAttribute("aria-pressed")).toBe("true");
+    const hide = expanded.querySelector<HTMLDetailsElement>("details.config-advanced-disclosure");
+    expect(hide?.open).toBe(true);
     expect(expanded.textContent).toContain("Advanced memory field");
-    hide?.click();
+    hide!.open = false;
+    hide!.dispatchEvent(new Event("toggle"));
     expect(onAdvancedChange).toHaveBeenCalledWith(false);
 
     const overview = renderInto(createProps({ activeTab: "overview", editor: editor(false) }));
-    expect(overview.querySelector(".config-show-advanced")).toBeNull();
+    expect(overview.querySelector("details.config-advanced-disclosure")).toBeNull();
   });
 });
 

--- a/ui/src/pages/config/view-types.ts
+++ b/ui/src/pages/config/view-types.ts
@@ -82,6 +82,7 @@ export type ConfigProps = {
   embeddedEditor?: boolean;
   /** Control UI rows that belong to the active schema section but are not Gateway config. */
   sectionPrelude?: TemplateResult;
+  showSectionDocs?: boolean;
   formValue: Record<string, unknown> | null;
   originalValue: Record<string, unknown> | null;
   activeSection: string | null;

--- a/ui/src/pages/config/view.browser.test.ts
+++ b/ui/src/pages/config/view.browser.test.ts
@@ -599,19 +599,14 @@ describe("config view", () => {
   }
 
   function sectionTabLabels(container: HTMLElement): Array<string | undefined> {
-    return Array.from(container.querySelectorAll(".config-toolbar wa-radio")).map((tab) =>
+    return Array.from(container.querySelectorAll(".config-toolbar .hub-tab")).map((tab) =>
       tab.textContent?.trim(),
     );
   }
 
   function selectConfigTab(container: HTMLElement, name: string) {
-    const group = queryRequired(
-      container,
-      ".config-toolbar wa-radio-group",
-      HTMLElement,
-    ) as HTMLElement & { value: string };
-    group.value = name;
-    group.dispatchEvent(new Event("change", { bubbles: true }));
+    const tab = queryRequired(container, `#config-sections-tab-${name}`, HTMLElement);
+    tab.dispatchEvent(new MouseEvent("click", { bubbles: true, detail: 1 }));
   }
 
   function queryRequired<T extends Element>(
@@ -822,19 +817,37 @@ describe("config view", () => {
     );
 
     expect(sectionTabLabels(container)).toEqual(["Settings", "Agents", "Gateway", "Theme"]);
-    // Segmented pills replaced the old tab strip and the inner panel chrome.
-    expect(container.querySelector("wa-tab-group")).toBeNull();
+    expect(container.querySelector("wa-tab-group.hub-tabs")).not.toBeNull();
     expect(container.querySelector(".config-layout")).toBeNull();
+    expect(container.querySelector("#config-section-panel")?.getAttribute("role")).toBe("tabpanel");
+    expect(container.querySelector("#config-section-panel")?.getAttribute("aria-labelledby")).toBe(
+      "config-sections-tab-root",
+    );
 
     selectConfigTab(container, "gateway");
     expect(onSectionChange).toHaveBeenCalledWith("gateway");
 
     onSectionChange.mockClear();
-    const active = container.querySelector(".config-toolbar .settings-segmented__btn--active");
+    const active = container.querySelector(".config-toolbar .hub-tab[active]");
     expect(active?.textContent?.trim()).toBe("Settings");
     selectConfigTab(container, "agents");
     expect(onSectionChange).toHaveBeenCalledWith("agents");
 
+    render(
+      renderConfig({
+        ...baseProps(),
+        activeSection: "agents",
+        onSectionChange,
+        schema: {
+          type: "object",
+          properties: {
+            gateway: { type: "object", properties: {} },
+            agents: { type: "object", properties: {} },
+          },
+        },
+      }),
+      container,
+    );
     onSectionChange.mockClear();
     selectConfigTab(container, "root");
     expect(onSectionChange).toHaveBeenCalledWith(null);
@@ -1086,22 +1099,27 @@ describe("config view", () => {
         messages: { inbox: "smart" },
       },
     });
+    document.body.append(container);
 
-    const content = queryRequired(container, ".config-content", HTMLElement);
-    content.scrollTop = 280;
-    content.scrollLeft = 24;
-    content.scrollTo = vi.fn(({ top, left }: { top?: number; left?: number }) => {
-      content.scrollTop = top ?? content.scrollTop;
-      content.scrollLeft = left ?? content.scrollLeft;
-    }) as typeof content.scrollTo;
+    try {
+      const content = queryRequired(container, ".config-content", HTMLElement);
+      content.scrollTop = 280;
+      content.scrollLeft = 24;
+      content.scrollTo = vi.fn(({ top, left }: { top?: number; left?: number }) => {
+        content.scrollTop = top ?? content.scrollTop;
+        content.scrollLeft = left ?? content.scrollLeft;
+      }) as typeof content.scrollTo;
 
-    selectConfigTab(container, "messages");
-    await Promise.resolve();
+      selectConfigTab(container, "messages");
+      await Promise.resolve();
 
-    expect(content["scrollTo"]).toHaveBeenCalledOnce();
-    expect(content["scrollTo"]).toHaveBeenCalledWith({ top: 0, left: 0, behavior: "auto" });
-    expect(content.scrollTop).toBe(0);
-    expect(content.scrollLeft).toBe(0);
+      expect(content["scrollTo"]).toHaveBeenCalledOnce();
+      expect(content["scrollTo"]).toHaveBeenCalledWith({ top: 0, left: 0, behavior: "auto" });
+      expect(content.scrollTop).toBe(0);
+      expect(content.scrollLeft).toBe(0);
+    } finally {
+      container.remove();
+    }
   });
 
   it("resets config content scroll when switching from form to raw mode", async () => {

--- a/ui/src/pages/config/view.browser.test.ts
+++ b/ui/src/pages/config/view.browser.test.ts
@@ -1171,6 +1171,28 @@ describe("config view", () => {
     expect(sectionTabLabels(container)).toEqual(["Channels", "Messages"]);
   });
 
+  it("hides contextual section help when the page owns its introduction", () => {
+    const { container } = renderConfigView({
+      activeSection: "messages",
+      showRootTab: false,
+      showSectionDocs: false,
+      includeSections: ["messages", "tts"],
+      schema: {
+        type: "object",
+        properties: {
+          messages: { type: "object", properties: {} },
+          tts: { type: "object", properties: {} },
+        },
+      },
+      uiHints: {
+        messages: { docsUrl: "https://docs.openclaw.ai/concepts/messages" },
+        tts: { docsUrl: "https://docs.openclaw.ai/tts" },
+      },
+    });
+
+    expect(container.querySelector(".settings-section__help-button")).toBeNull();
+  });
+
   it("does not normalize off-scope schema sections for scoped config tabs", () => {
     const offScopeSchema = { type: "object" } as Record<string, unknown>;
     Object.defineProperty(offScopeSchema, "properties", {

--- a/ui/src/pages/config/view.browser.test.ts
+++ b/ui/src/pages/config/view.browser.test.ts
@@ -403,14 +403,19 @@ describe("config view", () => {
       setShowAdvancedSettings,
     });
 
-    const ghost = queryRequired(collapsed.container, ".config-advanced-ghost", HTMLButtonElement);
-    expect(ghost.textContent?.replace(/\s+/g, " ").trim()).toBe(
-      "1 advanced setting hidden Show advanced",
+    const disclosure = queryRequired(
+      collapsed.container,
+      "details.config-advanced-disclosure",
+      HTMLDetailsElement,
     );
-    ghost.click();
+    expect(disclosure.open).toBe(false);
+    expect(queryRequired(disclosure, "summary", HTMLElement).textContent?.trim()).toBe(
+      "Advanced settings",
+    );
+    expect(normalizedText(collapsed.container)).not.toContain("Reload mode");
+    disclosure.open = true;
+    disclosure.dispatchEvent(new Event("toggle"));
     expect(setShowAdvancedSettings).toHaveBeenCalledWith(true);
-    expect(ghost.classList.contains("config-show-advanced")).toBe(true);
-    expect(ghost.getAttribute("aria-pressed")).toBe("false");
 
     const global = renderConfigView({
       schema,
@@ -419,13 +424,14 @@ describe("config view", () => {
       activeSection: "gateway",
       showAdvancedSettings: true,
     });
-    expect(global.container.querySelector(".config-advanced-ghost")).toBeNull();
-    const divider = queryRequired(global.container, ".config-advanced-divider", HTMLElement);
-    expect(divider.textContent?.replace(/\s+/g, " ").trim()).toBe("Advanced Hide Advanced");
-    const hide = queryRequired(divider, ".config-advanced-divider__toggle", HTMLButtonElement);
-    expect(hide.classList.contains("config-show-advanced")).toBe(true);
-    expect(hide.getAttribute("aria-pressed")).toBe("true");
-    hide.click();
+    const expandedDisclosure = queryRequired(
+      global.container,
+      "details.config-advanced-disclosure",
+      HTMLDetailsElement,
+    );
+    expect(expandedDisclosure.open).toBe(true);
+    expandedDisclosure.open = false;
+    expandedDisclosure.dispatchEvent(new Event("toggle"));
     expect(global.props.setShowAdvancedSettings).toHaveBeenCalledWith(false);
     expect(normalizedText(global.container)).toContain("Reload mode");
 
@@ -436,7 +442,10 @@ describe("config view", () => {
       activeSection: "gateway",
       forceAdvancedSection: "gateway",
     });
-    expect(searchHit.container.querySelector(".config-advanced-ghost")).toBeNull();
+    expect(
+      queryRequired(searchHit.container, "details.config-advanced-disclosure", HTMLDetailsElement)
+        .open,
+    ).toBe(true);
     expect(normalizedText(searchHit.container)).toContain("Reload mode");
 
     const nested = document.createElement("div");
@@ -466,7 +475,9 @@ describe("config view", () => {
       }),
       nested,
     );
-    expect(nested.querySelector(".config-advanced-ghost")).toBeNull();
+    expect(
+      queryRequired(nested, "details.config-advanced-disclosure", HTMLDetailsElement).open,
+    ).toBe(true);
     expect(normalizedText(nested)).toContain("Tuning");
 
     const forcedPage = renderConfigView({
@@ -477,7 +488,10 @@ describe("config view", () => {
       forceShowAdvanced: true,
     });
     expect(findOptionalButtonByText(forcedPage.container, "Show advanced")).toBeUndefined();
-    expect(forcedPage.container.querySelector(".config-advanced-ghost")).toBeNull();
+    expect(
+      queryRequired(forcedPage.container, "details.config-advanced-disclosure", HTMLDetailsElement)
+        .open,
+    ).toBe(true);
     expect(normalizedText(forcedPage.container)).toContain("Reload mode");
   });
 
@@ -505,7 +519,7 @@ describe("config view", () => {
       activeSection: "diagnostics",
     });
     expect(findOptionalButtonByText(unhinted.container, "Show advanced")).toBeUndefined();
-    expect(unhinted.container.querySelector(".config-advanced-ghost")).not.toBeNull();
+    expect(unhinted.container.querySelector("details.config-advanced-disclosure")).not.toBeNull();
 
     // An advanced hint in a different top-level section must not surface a
     // no-op toggle on a fully-common active section.
@@ -519,7 +533,7 @@ describe("config view", () => {
       activeSection: "gateway",
     });
     expect(findOptionalButtonByText(offScope.container, "Show advanced")).toBeUndefined();
-    expect(offScope.container.querySelector(".config-advanced-ghost")).toBeNull();
+    expect(offScope.container.querySelector("details.config-advanced-disclosure")).toBeNull();
   });
 
   it("shows the form-unsafe banner only for populated unsupported paths", () => {
@@ -1300,9 +1314,11 @@ describe("config view", () => {
     });
 
     expect(
-      [...container.querySelectorAll(".settings-section__heading")].map((title) =>
-        title.textContent?.trim(),
-      ),
+      [
+        ...container.querySelectorAll(
+          ".settings-section > .settings-section__header .settings-section__heading",
+        ),
+      ].map((title) => title.textContent?.trim()),
     ).toEqual(["Authentication", "Gateway"]);
   });
 

--- a/ui/src/pages/config/view.ts
+++ b/ui/src/pages/config/view.ts
@@ -560,6 +560,7 @@ export function renderConfig(props: ConfigProps) {
                               ${t("configView.peek")}
                             </button>`
                           : undefined,
+                      showSectionDocs: props.showSectionDocs,
                       sectionPrelude: props.sectionPrelude,
                       revealSensitive: props.activeSection === "env" ? envSensitiveVisible : false,
                       isSensitivePathRevealed: (path) => isSensitivePathRevealed(viewState, path),

--- a/ui/src/pages/config/view.ts
+++ b/ui/src/pages/config/view.ts
@@ -5,10 +5,10 @@ import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { normalizeChatMessageMaxWidth } from "../../app/settings.ts";
 import { countSensitiveConfigValues } from "../../components/config-form.shared.ts";
 import { renderConfigForm } from "../../components/config-form.ts";
+import { renderHubTabs } from "../../components/hub-tabs.ts";
 import "../../components/tooltip.ts";
 import { icons } from "../../components/icons.ts";
 import { highlightJsonHtml } from "../../components/markdown-code-blocks.ts";
-import { renderSettingsSegmented } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
 import { isJson5Warm, warmJson5 } from "../../lib/json5-runtime.ts";
 import { renderNotificationsSection } from "./notifications-section.ts";
@@ -379,14 +379,14 @@ export function renderConfig(props: ConfigProps) {
 
   const showSectionTabs = settingsLayout !== "accordion" && topTabs.length > 1;
   const sectionTabs = showSectionTabs
-    ? renderSettingsSegmented({
-        value: props.activeSection ?? "root",
-        options: topTabs.map((tab) => ({ value: tab.key ?? "root", label: tab.label })),
+    ? renderHubTabs({
+        id: "config-sections",
+        active: props.activeSection ?? "root",
+        tabs: topTabs.map((tab) => ({ value: tab.key ?? "root", label: tab.label })),
         ariaLabel: t("common.settingsSections"),
-        onChange: (value, element) => {
-          props.onSectionChange(value === "root" ? null : value);
-          resetContentScroll(element);
-        },
+        panelId: "config-section-panel",
+        onSelect: (value) => props.onSectionChange(value === "root" ? null : value),
+        onActivate: resetContentScroll,
       })
     : nothing;
   const showToolbar = showModeToggle || showSectionTabs;
@@ -489,8 +489,11 @@ export function renderConfig(props: ConfigProps) {
     <div
       id="config-section-panel"
       class="config-content"
-      role="region"
-      aria-label=${t("common.settingsSections")}
+      role=${showSectionTabs ? "tabpanel" : "region"}
+      aria-labelledby=${showSectionTabs
+        ? `config-sections-tab-${props.activeSection ?? "root"}`
+        : nothing}
+      aria-label=${showSectionTabs ? nothing : t("common.settingsSections")}
     >
       ${props.activeSection === "__appearance__"
         ? includeVirtualSections

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -72,12 +72,6 @@
   gap: var(--space-2) var(--space-3);
 }
 
-.config-show-advanced.active {
-  color: var(--accent);
-  border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
-  background: var(--accent-subtle);
-}
-
 /* Raw mode file operations (open / discard / save) */
 .config-raw-actions {
   display: flex;
@@ -209,6 +203,17 @@
    the first section. Keep one spacing owner. */
 .config-lead + .config-content {
   padding-top: 0;
+}
+
+/* Tabs sit between the route introduction and the active section. Remove the
+   generic lead inset; the workspace gap plus 4px content inset then matches
+   the 24px introduction-to-tabs rhythm. */
+.config-lead:has(.config-sections-hub-tabs) {
+  padding-top: 0;
+}
+
+.config-lead:has(.config-sections-hub-tabs) + .config-content {
+  padding-top: var(--space-1);
 }
 
 .config-content > .settings-page {

--- a/ui/src/styles/plugins.css
+++ b/ui/src/styles/plugins.css
@@ -19,7 +19,8 @@
 }
 
 .plugins-hub-header + .settings-workspace {
-  margin-top: var(--space-2);
+  /* The settings page already contributes the lower half of the tab rhythm. */
+  margin-top: 0;
 }
 
 @media (max-width: 400px) {

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -279,65 +279,20 @@
   min-width: 0;
 }
 
-.config-advanced-divider {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-3);
+.config-advanced-disclosure {
   margin-top: var(--space-5);
-  padding: 0 var(--space-4) var(--space-2);
-  color: var(--muted);
-  font-size: var(--control-ui-text-xs);
-  font-weight: 550;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
 }
 
-.config-advanced-divider__toggle {
-  border: 0;
-  background: none;
-  padding: 0;
-  color: var(--accent);
-  font-size: var(--control-ui-text-xs);
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+.config-tier-groups > .config-advanced-disclosure:first-child {
+  margin-top: 0;
+}
+
+.config-advanced-disclosure__summary {
   cursor: var(--cursor-action);
 }
 
-.config-advanced-divider__toggle:hover {
-  text-decoration: underline;
-}
-
-.config-advanced-ghost {
-  width: 100%;
-  min-height: 48px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-4);
-  padding: var(--space-3) var(--space-4);
-  border: 1px solid color-mix(in srgb, var(--border) 85%, transparent);
-  border-radius: var(--radius-lg);
-  background: var(--secondary);
-  text-align: left;
-  transition: background var(--duration-fast) ease;
-}
-
-.config-advanced-ghost:hover {
-  background: var(--bg-hover);
-}
-
-.config-advanced-ghost__count {
-  color: var(--muted);
-  font-size: var(--control-ui-text-sm);
-}
-
-.config-advanced-ghost__action {
-  color: var(--accent);
-  font-size: var(--control-ui-text-sm);
-  font-weight: 600;
-  flex: 0 0 auto;
+.config-advanced-disclosure > .settings-group {
+  margin-top: var(--space-3);
 }
 
 /* ── Row ── */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening Communications saw no page subtitle, button-style section tabs that differed from the Plugins navigation, a redundant contextual-help control, uneven tab spacing, and a card-like advanced-settings control that did not read as a normal section.

## Why This Change Was Made

Communications now uses the route-owned Settings subtitle and the shared underlined hub tabs already used by Plugins. Both Communications and Plugins give the tabs equal space above and below. The contextual section-help affordance is suppressed at the Communications page boundary only, so other Settings pages retain their existing documentation links.

Advanced settings now use the native `details`/`summary` disclosure pattern already established by Cron. The change lives in the shared schema renderer, so Settings, Channels, and embedded Memory settings use the same browser-native toggle without writing config when it opens or closes.

The shared tab renderer preserves the former activation-target callback for scroll ownership and exposes the selected section through a labelled tab panel.

## User Impact

The Communications page now has the same hierarchy and tab language as the rest of Settings: a short description under the title, evenly spaced underlined Messages/Voice tabs, no duplicate question-mark help control, and a left-aligned **Advanced settings** section that expands in place. Plugins receives the same even tab rhythm.

## Evidence

| Before | After — Communications |
| --- | --- |
| ![Communications before: no subtitle and button tabs](https://github.com/user-attachments/assets/675daac0-ab34-48ce-bbd1-483b6d5eebbf) | ![Communications after: subtitle, evenly spaced underlined tabs, and collapsed Advanced settings section](https://github.com/user-attachments/assets/9ecf283f-84f4-46ba-8e1a-03ae7c476543) |

| After — Advanced expanded | After — Plugins spacing |
| --- | --- |
| ![Advanced settings expanded to reveal Queue limit](https://github.com/user-attachments/assets/13827212-dcd6-4f8d-aba9-8cba15744a6b) | ![Plugins with equal space above and below its underlined tabs](https://github.com/user-attachments/assets/a981788d-a170-4e8a-a8bc-9638e7c47083) |

![Responsive Communications page with collapsed Advanced settings](https://github.com/user-attachments/assets/4d95c2c9-243b-414f-8b14-e2b4bc93ca98)

Playwright mocked-Gateway proof at 1440×900 and 390×844 verified:

- subtitle: `Messages and text-to-speech settings.`
- tabs: `Messages`, `Voice`, with click activation
- Communications tab gaps: `24px` above / `24px` below
- Plugins tab gaps: `20px` above / `19px` below (subpixel-rounded; ≤1px invariant)
- native Advanced settings disclosure opens and closes without config writes
- contextual help controls on Communications: `0`

Validation:

- `pnpm --dir ui test` — 798 files, 11,728 passed, 1 skipped
- focused exact-head unit coverage — 81 passed
- focused sibling Playwright E2E coverage — 20 passed; both prior CI failures rerun exact-head (3 passed)
- `pnpm tsgo:ui`
- `pnpm lint:ui:styles`
- `pnpm ui:i18n:verify`
- `pnpm ui:build`

### Repair notes

- Root owners: schema-driven Settings composition and the shared Plugins/Settings hub-tab shell.
- Canonical fix: reuse the shared hub tabs and native disclosure semantics; keep the help suppression page-scoped.
- Removed paths: segmented flat-section tabs, the Communications-only help affordance, and the advanced ghost row/divider/count UI.
- Sibling coverage: the shared disclosure is verified in Settings, Channels, and Memory; equal tab spacing is verified for Communications and Plugins at desktop and narrow widths.
- Production LOC: +84/-123 (net -39) | Tests: +314/-87 | Ratchet baseline: +1/-1.
