### PR TITLE
fix(ui): tighten settings title spacing

### DIFF
--- a/ui/src/e2e/settings-layout.e2e.test.ts
+++ b/ui/src/e2e/settings-layout.e2e.test.ts
@@ -1,6 +1,7 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { pathForRoute, type RouteId } from "../app-route-paths.ts";
 import { installMockGateway, waitForControlUiRoute } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -66,6 +67,36 @@ const actionSectionCases = [
   { route: "mcp", heading: "Configured servers" },
   { route: "model-providers", heading: "Default models" },
 ] as const;
+
+const settingsRowRoutes = [
+  "profile",
+  "appearance",
+  "lobsterdex",
+  "notifications",
+  "connection",
+  "channels",
+  "communications",
+  "talk",
+  "devices",
+  "cloud-workers",
+  "agents",
+  "ai-agents",
+  "labs",
+  "model-setup",
+  "model-providers",
+  "mcp",
+  "memory",
+  "automation",
+  "security",
+  "secrets",
+  "approvals",
+  "infrastructure",
+  "updates",
+  "advanced",
+  "plugins",
+  "about",
+  "debug",
+] as const satisfies readonly RouteId[];
 
 const responsiveViewports = [
   { width: 390, height: 844 },
@@ -212,6 +243,44 @@ suite.define(() => {
     } finally {
       await context.close();
     }
+  });
+
+  it("binds every settings row subtitle directly to its title", async () => {
+    await suite.withPage(
+      { colorScheme: "dark", locale: "en-US", viewport: { height: 900, width: 1440 } },
+      async ({ page }) => {
+        await installMockGateway(page);
+        let auditedPairCount = 0;
+
+        for (const route of settingsRowRoutes) {
+          const pathname = pathForRoute(route);
+          await page.goto(new URL(pathname, suite.server.baseUrl).toString());
+          await waitForControlUiRoute(page, {
+            pathname,
+            routeId: route,
+          });
+
+          const titleDescriptionPairs = page.locator(
+            ".settings-row__text > .settings-row__title + .settings-row__desc",
+          );
+          const gaps = await titleDescriptionPairs.evaluateAll((descriptions) =>
+            descriptions.map((description) => {
+              const title = description.previousElementSibling;
+              if (!(title instanceof HTMLElement)) {
+                throw new Error("settings row description is missing its title");
+              }
+              const titleBox = title.getBoundingClientRect();
+              const descriptionBox = description.getBoundingClientRect();
+              return Math.round(descriptionBox.y - titleBox.y - titleBox.height);
+            }),
+          );
+          auditedPairCount += gaps.length;
+          expect(gaps, `${route} title/subtitle gaps`).toEqual(gaps.map(() => 0));
+        }
+
+        expect(auditedPairCount).toBeGreaterThan(0);
+      },
+    );
   });
 
   it("keeps settings introductions, section headings, and Learn more links on one layout system", async () => {

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -315,7 +315,7 @@
 .settings-row__text {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 0;
   min-width: 0;
   flex: 1 1 auto;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Settings row subtitles sat too far below their titles because every row added an explicit 2px gap on top of the typography's line-height spacing.

## Why This Change Was Made

Removes that extra gap at the shared Settings row layout owner, so schema-driven fields and hand-authored Settings rows stay consistent without page-specific overrides. A mocked-Gateway browser regression audits every rendered adjacent title/subtitle pair across 27 canonical Settings-sidebar surfaces, including Debug at `/debug`.

## User Impact

Settings titles and their explanatory subtitles now read as one compact text block throughout the Control UI.

## Evidence

Before (2px layout gap):

![Before: Settings row title and subtitle with extra spacing](https://github.com/user-attachments/assets/6e53b576-2a05-4ab8-ac9c-3026ab0314ba)

After (0px layout gap):

![After: Settings row title and subtitle with compact spacing](https://github.com/user-attachments/assets/540d772e-b676-4f59-9e98-a006efba3636)

- Pre-fix regression: `profile title/subtitle gaps: expected [2] to deeply equal [0]`
- Post-fix: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/settings-layout.e2e.test.ts`
- Review follow-up: canonical route resolution now covers Debug at `/debug`
- Changed-surface gate: `node scripts/check-changed.mjs --base origin/main --head HEAD`
- Autoreview: clean, no accepted/actionable findings (0.99)

AI-assisted: yes
