### PR TITLE
fix(ui): use the regular cursor for sidebar navigation

### DIFF
--- a/ui/src/styles/cursor-policy.browser.test.ts
+++ b/ui/src/styles/cursor-policy.browser.test.ts
@@ -33,9 +33,26 @@ const CURSOR_CASES: readonly CursorCase[] = [
   { expected: "default", selector: "#plain-checkbox" },
   { expected: "default", selector: "#role-button" },
   { expected: "default", selector: ".settings-secret__toggle" },
+  { expected: "default", selector: ".nav-item" },
+  { expected: "default", selector: ".nav-item__text" },
+  { expected: "default", selector: ".sidebar-recent-session__link" },
+  { expected: "default", selector: ".sidebar-recent-session__name" },
+  { expected: "default", selector: ".sidebar-online__person" },
+  { expected: "default", selector: ".sidebar-brand__new-thread" },
+  { expected: "default", selector: ".sidebar-new-session" },
+  { expected: "default", selector: ".sidebar-session-catalog-new" },
+  { expected: "default", selector: ".settings-sidebar__item" },
+  { expected: "default", selector: ".settings-sidebar__subitem" },
+  { expected: "default", selector: ".sidebar-issues-panel__navigation-link" },
+  { expected: "default", selector: ".sidebar-approval-row__open-session" },
+  { expected: "default", selector: ".sidebar-footer-build" },
+  { expected: "default", selector: ".sidebar-more-menu a" },
   // Links and explicit new-tab controls keep the hand.
   { expected: "pointer", selector: "#real-link" },
-  { expected: "pointer", selector: ".nav-item" },
+  { expected: "pointer", selector: "#sidebar-external-link" },
+  { expected: "pointer", selector: "#sidebar-help-link" },
+  { expected: "pointer", selector: "#sidebar-new-tab-link" },
+  { expected: "pointer", selector: "#sidebar-new-tab-action" },
   { expected: "pointer", selector: "#new-tab-link" },
   { expected: "pointer", selector: "#new-tab-button" },
   { expected: "pointer", selector: "#shadow-new-tab-button", shadow: true },
@@ -60,6 +77,7 @@ function readUiCss(): string {
     "ui/src/styles/components.css",
     "ui/src/styles/layout.css",
     "ui/src/styles/sidebar-update-card.css",
+    "ui/src/styles/sidebar-issues.css",
     "ui/src/styles/sessions.css",
     "ui/src/styles/settings-controls.css",
     "ui/src/styles/settings.css",
@@ -83,7 +101,26 @@ function fixtureDocument(): string {
       <input id="plain-text-input" type="text" value="text" />
       <div id="role-button" role="button" tabindex="0">Role button</div>
       <a id="real-link" href="https://example.com">Real link</a>
-      <a class="nav-item" href="#/chat">Nav rail</a>
+      <aside class="sidebar">
+        <a class="nav-item" href="/chat"><span class="nav-item__text">Home</span></a>
+        <a class="sidebar-recent-session__link" href="/chat/test"><span class="sidebar-recent-session__name">Session</span></a>
+        <a class="sidebar-online__person" href="/activity">Person</a>
+        <a class="sidebar-brand__new-thread" href="/new">New session</a>
+        <a class="sidebar-new-session" href="/new">New group session</a>
+        <a class="sidebar-session-catalog-new" href="/new">New catalog session</a>
+        <a class="sidebar-issues-panel__navigation-link" href="/settings/channels">Channel issue</a>
+        <a class="sidebar-approval-row__open-session" href="/chat/test">Open approval session</a>
+        <a id="sidebar-external-link" href="https://example.com">External link</a>
+        <a id="sidebar-new-tab-link" class="nav-item" href="/chat" target="_BLANK">New tab</a>
+        <a id="sidebar-new-tab-action" class="nav-item" href="/chat" data-new-tab-action>New window</a>
+      </aside>
+      <aside class="settings-sidebar">
+        <a class="settings-sidebar__item" href="/settings">Settings</a>
+        <a class="settings-sidebar__subitem" href="/settings#theme">Theme</a>
+        <a class="sidebar-footer-build" href="/settings/about">Build</a>
+      </aside>
+      <div class="sidebar-more-menu"><div class="sidebar-customize-menu__item"><a href="/activity">Activity</a></div></div>
+      <div class="sidebar-agent-menu"><div class="sidebar-customize-menu__item"><a id="sidebar-help-link" href="https://example.com/docs" target="_blank">Docs</a></div></div>
       <a id="new-tab-link" class="btn" href="https://example.com/docs" target="_blank">Docs</a>
       <button id="new-tab-button" class="btn" type="button" data-new-tab-action>New tab</button>
       <button id="disabled-new-tab-button" class="btn btn--ghost" type="button" data-new-tab-action disabled>Unavailable new tab</button>

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -558,7 +558,6 @@ html.openclaw-native-web-chrome .shell-chrome-controls {
   color: var(--muted);
 }
 
-/* Settings rail entries are navigation anchors and keep the link pointer. */
 .settings-sidebar__item {
   position: relative;
   display: flex;
@@ -1842,7 +1841,6 @@ openclaw-settings-save-indicator:empty {
   min-width: 0;
   padding: 4px 2px 4px var(--sidebar-inset);
   color: inherit;
-  cursor: var(--cursor-action);
   text-decoration: none;
 }
 
@@ -2882,7 +2880,26 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
   outline-offset: -2px;
 }
 
-/* Nav rail entries are anchors so middle-click/new-tab keeps link behavior. */
+/* Sidebar destinations act as app controls, but stay anchors for native
+   modifier/middle-click navigation. Match a[href] specificity; real links
+   and explicit new-tab actions keep the pointer. */
+a:is(
+  .nav-item,
+  .sidebar-recent-session__link,
+  .sidebar-online__person,
+  .sidebar-brand__new-thread,
+  .sidebar-new-session,
+  .sidebar-session-catalog-new,
+  .settings-sidebar__item,
+  .settings-sidebar__subitem,
+  .sidebar-issues-panel__navigation-link,
+  .sidebar-approval-row__open-session,
+  .sidebar-footer-build
+):where(:not([target="_blank" i], [data-new-tab-action])),
+.sidebar-more-menu a:where(:not([target="_blank" i], [data-new-tab-action])) {
+  cursor: var(--cursor-action);
+}
+
 .nav-item {
   position: relative;
   display: flex;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where hovering sidebar navigation entries shows the hyperlink hand instead of the regular arrow. This affects page navigation, sessions, new-session actions, settings, and Inbox navigation.

## Why This Change Was Made

The global `a[href]` rule outranks component cursor declarations. Sidebar navigation now has one semantic CSS rule at matching specificity, while true hyperlinks and explicit new-tab/window actions retain the pointer. Anchors and their click handlers are unchanged, preserving keyboard and modifier/middle-click behavior. The obsolete session-row cursor declaration and contradictory settings comment are removed.

The broad link rule came from [the earlier button cursor change](https://github.com/openclaw/openclaw/pull/126153), authored and merged by @steipete. This completes that existing policy for app-navigation anchors; no new dependency, configuration, or runtime path is introduced.

## User Impact

Sidebar app controls use the arrow consistently. Actual hyperlinks and explicit new-tab/window controls still use the hand. Drag, text, zoom, wait, and disabled cursors remain unchanged.

## Evidence

AI-assisted implementation, with independent source review and a clean required autoreview (default P0 scope).

- Reproduction: all three existing computed-style browser tests failed before the CSS fix, reporting `pointer` instead of `default` for sidebar entries.
- `node scripts/run-vitest.mjs ui/src/styles/cursor-policy.browser.test.ts ui/src/styles/cursor-policy.node.test.ts ui/src/lib/navigation-click.test.ts ui/src/components/settings-sidebar.test.ts` — 23 tests passed, including browser-tab, native-host markers, and genuine Chromium installed-window modes.
- `node scripts/check-changed.mjs -- ui/src/styles/layout.css ui/src/styles/cursor-policy.browser.test.ts` — passed (format, guards, dead exports, i18n, core-test/UI typechecks, lint).
- `pnpm ui:build` — passed, including finalized-sidecar and UI performance-budget checks.
- `./node_modules/.bin/stylelint --config config/stylelint.config.mjs ui/src/styles/layout.css` — passed.
- `./node_modules/.bin/oxfmt --check ui/src/styles/layout.css ui/src/styles/cursor-policy.browser.test.ts` and `git diff --check` — passed.
- Live Chromium against a real isolated loopback Gateway, with its own state and all channel plugins disabled: main/settings sidebar cursors changed from `pointer` to `default`; primary click navigated to Automations; Command-click still opened Home in a new tab. No mocked Gateway or provider was used.
- Production CSS: +20/-3 (net +17); tests: +39/-2. The added selector list explicitly distinguishes app-navigation owners from real links, including links without a new-tab target. A broad sidebar descendant/URL-prefix rule would erase that distinction. The shared rule absorbs the previous ineffective session-row cursor declaration.

Screenshots below are from the real running UI. The lower-right badge is a proof annotation reporting the hovered element's measured computed CSS cursor; it is not product UI. Playwright screenshots do not capture the OS mouse cursor.

| Surface | Before | After |
| --- | --- | --- |
| Sidebar | ![Before sidebar](https://github.com/user-attachments/assets/414539d9-337e-44ab-94d1-5e15b789f91a) | ![After sidebar](https://github.com/user-attachments/assets/72029e43-664c-4ffa-bd06-c87d9b18afd8) |
| Settings | ![Before settings](https://github.com/user-attachments/assets/8b06c466-9602-4c09-8eb2-5a2f65da70a9) | ![After settings](https://github.com/user-attachments/assets/28b55daa-2362-4c7b-94b9-4536eb8323fd) |
