### PR TITLE
fix(ui): hide historical metadata while assistant turns run

### DIFF
--- a/ui/src/e2e/chat-flow.streaming.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.streaming.e2e.test.ts
@@ -16,21 +16,28 @@ import {
 const suite = createChatFlowE2eSuite();
 
 suite.define(() => {
-  it("reveals an active stream footer after a mobile tap", async () => {
-    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+  it.each([
+    { label: "desktop hover", mobile: false, viewport: { height: 900, width: 1280 } },
+    { label: "mobile tap", mobile: true, viewport: { height: 844, width: 390 } },
+  ])("shows turn metadata only after completion on $label", async ({ mobile, viewport }) => {
     const context = await suite.newBrowserContext({
-      hasTouch: true,
-      isMobile: true,
+      hasTouch: mobile,
+      isMobile: mobile,
       locale: "en-US",
       serviceWorkers: "block",
-      viewport: { height: 844, width: 390 },
+      viewport,
     });
     const page = await context.newPage();
-    const gateway = await installMockGateway(page);
+    const gateway = await installMockGateway(page, {
+      historyMessages: [
+        { role: "assistant", content: "Earlier completed reply.", timestamp: Date.now() - 60_000 },
+      ],
+    });
 
     try {
       await page.goto(`${suite.server.baseUrl}chat`);
-      await page.locator(".agent-chat__composer-combobox textarea").fill("show stream metadata");
+      await page.getByText("Earlier completed reply.").waitFor();
+      await page.locator(".agent-chat__composer-combobox textarea").fill("show turn metadata");
       await page.getByRole("button", { name: "Send message" }).click();
       const sendRequest = await gateway.waitForRequest("chat.send");
       const runId = requireString(
@@ -51,37 +58,48 @@ suite.define(() => {
       });
 
       const activeStream = page.locator(".chat-bubble.streaming");
-      await activeStream.waitFor({ state: "visible", timeout: 10_000 });
-      const footer = activeStream
-        .locator(
-          "xpath=ancestor::*[contains(concat(' ', normalize-space(@class), ' '), ' chat-group ')][1]",
-        )
-        .locator(".chat-group-footer");
-      await footer.waitFor({ state: "attached", timeout: 10_000 });
-      const presentation = () =>
-        footer.evaluate((element) => {
-          const style = getComputedStyle(element);
-          return { opacity: style.opacity, pointerEvents: style.pointerEvents };
-        });
-      await expect.poll(presentation).toEqual({ opacity: "0", pointerEvents: "none" });
+      await activeStream.waitFor({ state: "visible" });
+      const activeGroup = page.locator(".chat-group.assistant").last();
+      const reveal = async () => {
+        if (mobile) {
+          await activeGroup.locator(".chat-bubble").last().tap();
+        } else {
+          await activeGroup.hover();
+        }
+      };
+      await reveal();
+      expect(await activeGroup.locator(".chat-group-footer").count()).toBe(0);
+      expect(
+        await page.locator(".chat-group.assistant").first().locator(".chat-group-footer").count(),
+      ).toBe(1);
 
-      if (artifactDir) {
-        await mkdir(artifactDir, { recursive: true });
-        await page.screenshot({
-          fullPage: true,
-          path: path.join(artifactDir, "active-stream-metadata-resting.png"),
-        });
-      }
+      // Settled commentary is still part of an active turn while a tool runs.
+      await gateway.emitGatewayEvent("agent", {
+        data: {
+          args: { path: "README.md" },
+          name: "read",
+          phase: "start",
+          toolCallId: "footer-read",
+        },
+        runId,
+        seq: 1,
+        sessionKey: "main",
+        stream: "tool",
+        ts: Date.now(),
+      });
+      await page.locator(".chat-working-indicator").waitFor({ state: "visible" });
+      await reveal();
+      expect(await activeGroup.locator(".chat-group-footer").count()).toBe(0);
 
-      await activeStream.tap();
-      await expect.poll(presentation).toEqual({ opacity: "1", pointerEvents: "auto" });
-
-      if (artifactDir) {
-        await page.screenshot({
-          fullPage: true,
-          path: path.join(artifactDir, "active-stream-metadata-revealed.png"),
-        });
-      }
+      await gateway.emitChatFinal({ runId, text: "The turn is complete." });
+      await activeGroup.getByText("The turn is complete.", { exact: true }).waitFor();
+      await reveal();
+      const footer = activeGroup.locator(".chat-group-footer");
+      await expect
+        .poll(() => footer.evaluate((element) => getComputedStyle(element).opacity))
+        .toBe("1");
+      expect(await footer.locator(".chat-sender-name").textContent()).toBe("OpenClaw");
+      expect(await footer.locator(".chat-group-timestamp").count()).toBe(1);
     } finally {
       await suite.closeBrowserContext(context);
     }

--- a/ui/src/pages/chat/components/chat-message-group.ts
+++ b/ui/src/pages/chat/components/chat-message-group.ts
@@ -492,12 +492,9 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
     }
   }
   const lastMessageIndex = group.messages.length - 1;
-  const runFrameActive = ownsRunFrame && Boolean(group.isStreaming || opts.activeContinuation);
-  const footerActionDetails = runFrameActive
-    ? null
-    : ownsRunFrame
-      ? (messageActionDetails[0] ?? null)
-      : (messageActionDetails[lastMessageIndex] ?? null);
+  const footerActionDetails = ownsRunFrame
+    ? (messageActionDetails[0] ?? null)
+    : (messageActionDetails[lastMessageIndex] ?? null);
   const footerActionMessageKey = ownsRunFrame
     ? opts.frameActionOwner?.key
     : group.messages[lastMessageIndex]?.key;
@@ -597,7 +594,7 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
             ? renderTurnRecapRow(opts.turnRecap, { presentation: "continuation" })
             : nothing}
       </div>
-      ${normalizedRole === "tool"
+      ${normalizedRole === "tool" || group.isStreaming || opts.activeContinuation
         ? nothing
         : html`<div
             class="chat-group-footer ${persistUserIdentity

--- a/ui/src/pages/chat/components/chat-message-stream.ts
+++ b/ui/src/pages/chat/components/chat-message-stream.ts
@@ -118,6 +118,9 @@ export function renderStreamGroup(parts: StreamGroupPart[], opts: StreamGroupOpt
   // is only the reading indicator has no timestamp and therefore no footer.
   const streamStarts = parts.flatMap((part) => (part.kind === "stream" ? [part.startedAt] : []));
   const footerStartedAt = streamStarts.length > 0 ? Math.min(...streamStarts) : null;
+  const active = parts.some(
+    (part) => part.kind === "reading-indicator" || (part.kind === "stream" && part.isStreaming),
+  );
   // While the agent works with nothing streamed yet the run is pure claw: no
   // avatar next to it - the punching pincer is the whole signal. The avatar
   // arrives with the first stream part unless the presentation opts out.
@@ -138,7 +141,7 @@ export function renderStreamGroup(parts: StreamGroupPart[], opts: StreamGroupOpt
     <div class=${groupClass} data-chat-row-key=${parts[0]?.key ?? nothing}>
       ${avatar}
       <div class="chat-group-messages">${renderStreamGroupParts(parts, opts, "standalone")}</div>
-      ${footerStartedAt !== null
+      ${footerStartedAt !== null && !active
         ? html`
             <div class="chat-group-footer">
               <div class="chat-group-footer__meta">

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -1511,7 +1511,7 @@ describe("grouped chat rendering", () => {
     expect(container.querySelector(".msg-meta__tokens")?.textContent).toBe("↑214.5k");
   });
 
-  it("renders relative labels while preserving absolute message and streaming timestamps", () => {
+  it("renders relative labels while preserving absolute message and settled stream timestamps", () => {
     vi.useFakeTimers();
     const timestamp = Date.UTC(2026, 3, 24, 18, 30);
     vi.setSystemTime(timestamp + 5 * 60 * 1000);
@@ -1528,9 +1528,9 @@ describe("grouped chat rendering", () => {
         {
           kind: "stream",
           key: `stream:${timestamp}`,
-          text: "Working",
+          text: "Done",
           startedAt: timestamp,
-          isStreaming: true,
+          isStreaming: false,
         },
       ]),
       container,
@@ -1567,7 +1567,7 @@ describe("grouped chat rendering", () => {
     );
   });
 
-  it("uses the earliest segment timestamp for a multi-segment stream footer", () => {
+  it("uses the earliest segment timestamp for a settled multi-segment stream footer", () => {
     const container = document.createElement("div");
 
     render(
@@ -1580,7 +1580,7 @@ describe("grouped chat rendering", () => {
           startedAt: 10,
           isStreaming: false,
         },
-        { kind: "stream", key: "stream:s:live", text: "third", startedAt: 30, isStreaming: true },
+        { kind: "stream", key: "stream-seg:s:2", text: "third", startedAt: 30, isStreaming: false },
       ]),
       container,
     );
@@ -1711,6 +1711,7 @@ describe("grouped chat rendering", () => {
     expect(container.querySelector(".chat-working-indicator__status")?.textContent).toContain(
       "Working…",
     );
+    expect(container.querySelector(".chat-group-footer")).toBeNull();
 
     renderAssistantMessage(container, message, {
       turnRecap: { runtimeMs: 5_000, outputTokens: 42 },
@@ -1722,6 +1723,7 @@ describe("grouped chat rendering", () => {
       "Done in 5 seconds",
     );
     expect(container.querySelector(".chat-tasks-status__claw")).toBeNull();
+    expect(container.querySelector(".chat-group-footer")).not.toBeNull();
   });
 
   it.each([
@@ -1835,7 +1837,7 @@ describe("grouped chat rendering", () => {
     expect(group?.classList.contains("chat-group--working")).toBe(false);
     expect(group?.classList.contains("chat-group--with-footer")).toBe(true);
     expect(container.querySelectorAll(".chat-avatar.assistant")).toHaveLength(0);
-    expect(container.querySelectorAll(".chat-group-footer")).toHaveLength(1);
+    expect(container.querySelector(".chat-group-footer")).toBeNull();
     expect(container.querySelectorAll(".chat-working-indicator")).toHaveLength(1);
     expect(container.querySelectorAll(".chat-reading-indicator")).toHaveLength(1);
   });

--- a/ui/src/pages/chat/components/chat-transcript-render.test.ts
+++ b/ui/src/pages/chat/components/chat-transcript-render.test.ts
@@ -169,7 +169,7 @@ describe("chat transcript rendering", () => {
     transcript.hostDisconnected();
   });
 
-  it("reveals touched metadata across stored and live groups within one transcript", async () => {
+  it("keeps live metadata absent while revealing stored metadata within each transcript", async () => {
     const firstTranscript = createTestTranscript();
     const secondTranscript = createTestTranscript();
     const firstContainer = document.body.appendChild(document.createElement("div"));
@@ -207,6 +207,7 @@ describe("chat transcript rendering", () => {
     touchPointerUp(streamBubble);
     expect(storedGroup.classList.contains("chat-group--meta-revealed")).toBe(false);
     expect(streamGroup.classList.contains("chat-group--meta-revealed")).toBe(true);
+    expect(streamGroup.querySelector(".chat-group-footer")).toBeNull();
 
     touchPointerUp(requireElement(secondGroup, ".chat-bubble"));
     expect(secondGroup.classList.contains("chat-group--meta-revealed")).toBe(true);


### PR DESCRIPTION
Closes #131416 — running Control UI turns reveal misleading historical metadata.

<details>
<summary>Additional instructions</summary>

Maintainers can update this repository-owned branch.

</details>

## What Problem This Solves

Fixes an issue where users hovering or tapping a still-running Control UI assistant turn would see historical author/time metadata beside its live working indicator. A label such as “Assistant · 14m ago” made ongoing work look stale or finished.

## Why This Change Was Made

The message-group renderer already receives turn-local streaming/continuation state, but previously used it only to hide actions. The footer now follows that same lifecycle, and the standalone stream renderer applies the equivalent rule. This removes the redundant actions-only branch rather than adding another policy layer.

Existing grid/gutter classes remain unchanged, including avatar-hidden shared transcripts. No session-wide busy flag, timer heuristic, provider special case, configuration, or protocol change. CSS-only hiding was rejected because inactive metadata/actions should not be present during the active turn.

## User Impact

Running turns show live activity and elapsed duration without the misleading author/time footer. Normal metadata returns on completion; earlier completed replies retain theirs. Desktop hover and mobile tap follow the same rule.

## Evidence

- Pre-fix: both desktop-hover and mobile-tap E2E regressions failed because the active group still contained a footer. Two focused renderer regressions also failed at that boundary.
- Fixed: all **12** streaming browser E2E cases passed, including live text → settled commentary/tool work → completed reply, with older completed metadata preserved.
- Fixed: **238** focused rendering, transcript, and run-grouping tests passed.
- Fresh Autoreview: no accepted/actionable findings.
- Full `pnpm build` and the changed formatting, type, lint, and architecture checks passed.
- Real isolated Gateway proof completed with ordinary browser sends, OpenAI Luna, and actual tool execution; no mocks or injected state. All screenshots and video frames inspected.
- Exact-head CI is green: https://github.com/openclaw/openclaw/actions/runs/33136846074. Refreshed branch includes the existing typography-picker test repair from main; 238 focused tests and 29 streaming/typography browser tests pass.

Commands:

```sh
node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-message.test.ts ui/src/pages/chat/components/chat-transcript-render.test.ts ui/src/pages/chat/chat-agent-run-grouping.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.streaming.e2e.test.ts
node scripts/check-changed.mjs -- ui/src/e2e/chat-flow.streaming.e2e.test.ts ui/src/pages/chat/components/chat-message-group.ts ui/src/pages/chat/components/chat-message-stream.ts ui/src/pages/chat/components/chat-message.test.ts ui/src/pages/chat/components/chat-transcript-render.test.ts
pnpm build
```

Production LOC: **+8/-8 (net 0)**. Tests: **+65/-44 (net +21)**.

Owner/caller/sibling evidence: `chat-transcript-projection.ts` attaches active continuation to its specific group; `chat-agent-run-frame.ts` projects the frame outcome into shell streaming state; `chat-thread-build.ts` distinguishes live streams, settled segments, and pending-versus-terminal questions; both footer renderers preserve settled timestamps. Current main retains the reported behavior. The stable `v2026.7.1-2` standalone renderer also renders that active footer.

Codex dependency inspection (read directly, no runtime changes): `codex-rs/app-server-protocol/src/protocol/v2/turn.rs:32`, `thread_data.rs:355`, and `codex-rs/protocol/src/models.rs:909` at `5f49aba876922d6f2f55caa153bbb0ed1b46feba` distinguish turn completion from interim commentary and message timestamps.

Provenance: actions-only suppression was carried forward by #126278 (one-run/one-response rendering; authored and merged by @vyctorbrzezowski, 2026-08-23). The unconditional standalone footer predates that change and was carried forward by #113363 (renderer split; authored and merged by @steipete, 2026-07-24); this is not a claim that either refactor first introduced the older behavior.

AI-assisted implementation; reviewed and tested against the actual rendering boundaries.

## Live screenshot and video proof

Real isolated Gateway; same conversation, preserved pre-fix and rebuilt fixed UI bundles. Active live duration/Stop remains visible; the historic footer disappears only while running.

### Before: hovered running turn exposes historical metadata

![Before: hovered running turn exposes historical metadata](https://github.com/user-attachments/assets/376c3584-77b9-4cb0-a758-2a9197d4a3ce)

### After: hovered running turn has no metadata footer

![After: hovered running turn has no metadata footer](https://github.com/user-attachments/assets/0f963930-ec28-4cbb-9a43-587ee6533662)

### After completion: metadata and reply/copy actions restored

![After completion: metadata and reply/copy actions restored](https://github.com/user-attachments/assets/e14fb795-b086-42b6-8967-d63c1f7507cd)

### Live running-to-completed flow

https://github.com/user-attachments/assets/7f490e97-c152-430e-8e07-f20ffc3fb7ee

Named follow-up (unrelated, not changed here): fresh shared-auth writer bootstrap captures a database kind before its transaction owner initializes the shared store; investigate `src/agents/auth-profiles/sqlite.ts` with `shared-store-bootstrap.ts` and a fresh-store regression.
