### PR TITLE
perf(cli): reclaim startup-memory headroom on status and validation paths

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3619,7 +3619,7 @@ src/plugins/runtime/runtime-llm.runtime.ts	5
 src/plugins/runtime/runtime-plugin-boundary.ts	2
 src/plugins/runtime/runtime-taskflow.ts	1
 src/plugins/runtime/runtime-web-channel-plugin.ts	4
-src/plugins/schema-validator.ts	7
+src/plugins/schema-validator.ts	6
 src/plugins/sdk-alias.ts	3
 src/plugins/services.ts	1
 src/plugins/session-catalog-history-import.ts	2

--- a/packages/normalization-core/src/json-schema.ts
+++ b/packages/normalization-core/src/json-schema.ts
@@ -1,5 +1,6 @@
 // Browser-safe JSON Schema normalization and value checks shared by core and Control UI.
-import { Value } from "typebox/value";
+import { Guard } from "typebox/guard";
+import { Check } from "typebox/schema";
 import { isRecord } from "./record-coerce.js";
 
 type JsonSchemaObject = Record<string, unknown>;
@@ -269,7 +270,7 @@ export function jsonSchemaValuesEqual(left: unknown, right: unknown): boolean {
     return false;
   }
   try {
-    return Value.Equal(left, right);
+    return Guard.IsDeepEqual(left, right);
   } catch {
     return false;
   }
@@ -281,7 +282,7 @@ export function isJsonSchemaValueValid(schema: JsonSchemaValue, value: unknown):
     return false;
   }
   try {
-    return Value.Check(normalizeJsonSchemaForTypeBox(schema) as never, value);
+    return Check(normalizeJsonSchemaForTypeBox(schema) as never, value);
   } catch {
     return false;
   }

--- a/src/commands/status-runtime-shared.ts
+++ b/src/commands/status-runtime-shared.ts
@@ -2,83 +2,18 @@
 // Heavy modules stay lazily loaded so fast status output avoids security/provider/gateway costs.
 
 import type { Result } from "@openclaw/normalization-core/result";
-import {
-  resolveAmbientOwnerAgentId,
-  resolveConfiguredAgentId,
-} from "../agents/agent-scope-config.js";
-import { resolveAgentDir } from "../agents/agent-scope.js";
-import { resolveAgentHarnessPolicy } from "../agents/harness/policy.js";
-import { resolveModelAuthLabel } from "../agents/model-auth-label.js";
-import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
-import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../agents/openai-routing.js";
 import type { OpenClawConfig } from "../config/types.js";
 import type { HeartbeatEventPayload } from "../infra/heartbeat-events.js";
-import { normalizeAgentId } from "../routing/session-key.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
-import {
-  buildCodexSyntheticUsageAuth,
-  mergeUsageSummaries,
-  shouldUseCodexSyntheticUsageForRuntime,
-  resolveUsageCredentialType,
-} from "../status/codex-synthetic-usage.js";
 import type { HealthSummary } from "./health.js";
+import type { StatusUsageSummaryOptions } from "./status-usage.runtime.js";
 import { getDaemonStatusSummary, getNodeDaemonStatusSummary } from "./status.daemon.js";
 
-const providerUsageLoader = createLazyImportLoader(() => import("../infra/provider-usage.js"));
+const statusUsageModuleLoader = createLazyImportLoader(() => import("./status-usage.runtime.js"));
 const securityAuditModuleLoader = createLazyImportLoader(
   () => import("../security/audit.runtime.js"),
 );
 const gatewayCallModuleLoader = createLazyImportLoader(() => import("../gateway/call.js"));
-
-function loadProviderUsage() {
-  return providerUsageLoader.load();
-}
-
-function loadSecurityAuditModule() {
-  return securityAuditModuleLoader.load();
-}
-
-function loadGatewayCallModule() {
-  return gatewayCallModuleLoader.load();
-}
-
-function shouldUseConfiguredCodexSyntheticUsage(params: {
-  config: OpenClawConfig;
-  agentDir: string;
-  agentId?: string;
-}): boolean {
-  const configuredDefault = resolveDefaultModelForAgent({
-    cfg: params.config,
-    agentId: params.agentId,
-    allowPluginNormalization: false,
-  });
-  const policy = resolveAgentHarnessPolicy({
-    config: params.config,
-    agentId: params.agentId,
-    provider: configuredDefault.provider,
-    modelId: configuredDefault.model,
-  });
-  if (
-    !shouldUseCodexSyntheticUsageForRuntime({
-      provider: configuredDefault.provider,
-      effectiveHarness: policy.runtime,
-    })
-  ) {
-    return false;
-  }
-  const authLabel = resolveModelAuthLabel({
-    provider: configuredDefault.provider,
-    acceptedProviderIds: listOpenAIAuthProfileProvidersForAgentRuntime({
-      provider: configuredDefault.provider,
-      harnessRuntime: policy.runtime,
-      config: params.config,
-    }),
-    cfg: params.config,
-    agentDir: params.agentDir,
-    includeExternalProfiles: false,
-  });
-  return resolveUsageCredentialType(authLabel) !== "api_key";
-}
 
 /** Runs the lightweight security audit used by status JSON/all output. */
 export async function resolveStatusSecurityAudit(params: {
@@ -86,7 +21,7 @@ export async function resolveStatusSecurityAudit(params: {
   sourceConfig: OpenClawConfig;
   timeoutMs?: number;
 }) {
-  const { runSecurityAudit } = await loadSecurityAuditModule();
+  const { runSecurityAudit } = await securityAuditModuleLoader.load();
   // The audit owns setup-backed capabilities; inventory projections can name
   // accounts without carrying their channel security adapters.
   return await runSecurityAudit({
@@ -100,60 +35,14 @@ export async function resolveStatusSecurityAudit(params: {
   });
 }
 
-type StatusUsageSummaryOptions = {
-  config: OpenClawConfig;
-  timeoutMs?: number;
-  agentId?: string;
-  agentDir?: string;
-};
-
-/** Loads provider usage for status output from an explicit or ambient system-agent scope. */
+/** Loads optional usage and its credential resolver only when requested. */
 export async function resolveStatusUsageSummary(params: StatusUsageSummaryOptions) {
-  const { loadProviderUsageSummary } = await loadProviderUsage();
-  const rawAgentId = params.agentId?.trim();
-  if (params.agentId !== undefined && !rawAgentId) {
-    throw new Error("--agent must not be blank");
-  }
-  const agentId = rawAgentId ? normalizeAgentId(rawAgentId) : undefined;
-  if (agentId) {
-    resolveConfiguredAgentId(params.config, agentId);
-  }
-  let resolvedAgentId = agentId;
-  let agentDir = params.agentDir;
-  if (!agentDir) {
-    resolvedAgentId ??= resolveAmbientOwnerAgentId(params.config, undefined, {
-      surface: "status usage credentials",
-      hint: "Set agents.defaults.systemAgent.agentId.",
-    });
-    agentDir = resolveAgentDir(params.config, resolvedAgentId);
-  }
-  const usage = await loadProviderUsageSummary({
-    timeoutMs: params.timeoutMs,
-    config: params.config,
-    agentDir,
-  });
-  if (
-    !shouldUseConfiguredCodexSyntheticUsage({
-      config: params.config,
-      agentDir,
-      agentId: resolvedAgentId,
-    })
-  ) {
-    return usage;
-  }
-  const codexUsage = await loadProviderUsageSummary({
-    timeoutMs: params.timeoutMs,
-    providers: ["openai"],
-    auth: [buildCodexSyntheticUsageAuth()],
-    config: params.config,
-    agentDir,
-  });
-  return mergeUsageSummaries(usage, codexUsage);
+  return (await statusUsageModuleLoader.load()).resolveStatusUsageSummary(params);
 }
 
-/** Exposes the lazily loaded provider-usage module for callers that need its helpers. */
+/** Exposes provider-usage formatting for callers that requested usage. */
 export async function loadStatusProviderUsageModule() {
-  return await loadProviderUsage();
+  return (await statusUsageModuleLoader.load()).loadStatusProviderUsageModule();
 }
 
 /** Calls gateway health and lets errors propagate to deep status callers. */
@@ -161,7 +50,7 @@ export async function resolveStatusGatewayHealth(params: {
   config: OpenClawConfig;
   timeoutMs?: number;
 }) {
-  const { callGateway } = await loadGatewayCallModule();
+  const { callGateway } = await gatewayCallModuleLoader.load();
   return await callGateway<HealthSummary>({
     method: "health",
     params: { probe: true },
@@ -186,7 +75,7 @@ export async function resolveStatusGatewayHealthSafe(params: {
     // Preserve the probe error so status-all can explain why health was not called.
     return { error: params.gatewayProbeError ?? "gateway unreachable" };
   }
-  const { callGateway } = await loadGatewayCallModule();
+  const { callGateway } = await gatewayCallModuleLoader.load();
   return await callGateway<HealthSummary>({
     method: "health",
     params: { probe: true },
@@ -213,7 +102,7 @@ export async function resolveStatusGatewayDiagnosticsSafe(params: {
   if (!params.gatewayReachable) {
     return { ok: false, error: "gateway unreachable" };
   }
-  const { callGateway } = await loadGatewayCallModule();
+  const { callGateway } = await gatewayCallModuleLoader.load();
   return await callGateway<unknown>({
     method: "diagnostics.stability",
     params: { limit: 1000, ...(params.type ? { type: params.type } : {}) },
@@ -235,7 +124,7 @@ async function resolveStatusLastHeartbeat(params: {
   if (!params.gatewayReachable) {
     return null;
   }
-  const { callGateway } = await loadGatewayCallModule();
+  const { callGateway } = await gatewayCallModuleLoader.load();
   return await callGateway<HeartbeatEventPayload | null>({
     method: "last-heartbeat",
     params: {},

--- a/src/commands/status-usage.runtime.ts
+++ b/src/commands/status-usage.runtime.ts
@@ -1,0 +1,115 @@
+// Optional status usage probes own credential and provider runtime imports.
+import {
+  resolveAmbientOwnerAgentId,
+  resolveConfiguredAgentId,
+} from "../agents/agent-scope-config.js";
+import { resolveAgentDir } from "../agents/agent-scope.js";
+import { resolveAgentHarnessPolicy } from "../agents/harness/policy.js";
+import { resolveModelAuthLabel } from "../agents/model-auth-label.js";
+import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
+import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../agents/openai-routing.js";
+import type { OpenClawConfig } from "../config/types.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+import { createLazyImportLoader } from "../shared/lazy-promise.js";
+import {
+  buildCodexSyntheticUsageAuth,
+  mergeUsageSummaries,
+  shouldUseCodexSyntheticUsageForRuntime,
+  resolveUsageCredentialType,
+} from "../status/codex-synthetic-usage.js";
+
+const providerUsageLoader = createLazyImportLoader(() => import("../infra/provider-usage.js"));
+
+function shouldUseConfiguredCodexSyntheticUsage(params: {
+  config: OpenClawConfig;
+  agentDir: string;
+  agentId?: string;
+}): boolean {
+  const configuredDefault = resolveDefaultModelForAgent({
+    cfg: params.config,
+    agentId: params.agentId,
+    allowPluginNormalization: false,
+  });
+  const policy = resolveAgentHarnessPolicy({
+    config: params.config,
+    agentId: params.agentId,
+    provider: configuredDefault.provider,
+    modelId: configuredDefault.model,
+  });
+  if (
+    !shouldUseCodexSyntheticUsageForRuntime({
+      provider: configuredDefault.provider,
+      effectiveHarness: policy.runtime,
+    })
+  ) {
+    return false;
+  }
+  const authLabel = resolveModelAuthLabel({
+    provider: configuredDefault.provider,
+    acceptedProviderIds: listOpenAIAuthProfileProvidersForAgentRuntime({
+      provider: configuredDefault.provider,
+      harnessRuntime: policy.runtime,
+      config: params.config,
+    }),
+    cfg: params.config,
+    agentDir: params.agentDir,
+    includeExternalProfiles: false,
+  });
+  return resolveUsageCredentialType(authLabel) !== "api_key";
+}
+
+export type StatusUsageSummaryOptions = {
+  config: OpenClawConfig;
+  timeoutMs?: number;
+  agentId?: string;
+  agentDir?: string;
+};
+
+/** Loads provider usage for status output from an explicit or ambient system-agent scope. */
+export async function resolveStatusUsageSummary(params: StatusUsageSummaryOptions) {
+  const { loadProviderUsageSummary } = await providerUsageLoader.load();
+  const rawAgentId = params.agentId?.trim();
+  if (params.agentId !== undefined && !rawAgentId) {
+    throw new Error("--agent must not be blank");
+  }
+  const agentId = rawAgentId ? normalizeAgentId(rawAgentId) : undefined;
+  if (agentId) {
+    resolveConfiguredAgentId(params.config, agentId);
+  }
+  let resolvedAgentId = agentId;
+  let agentDir = params.agentDir;
+  if (!agentDir) {
+    resolvedAgentId ??= resolveAmbientOwnerAgentId(params.config, undefined, {
+      surface: "status usage credentials",
+      hint: "Set agents.defaults.systemAgent.agentId.",
+    });
+    agentDir = resolveAgentDir(params.config, resolvedAgentId);
+  }
+  const usage = await loadProviderUsageSummary({
+    timeoutMs: params.timeoutMs,
+    config: params.config,
+    agentDir,
+  });
+  if (
+    !shouldUseConfiguredCodexSyntheticUsage({
+      config: params.config,
+      agentDir,
+      agentId: resolvedAgentId,
+    })
+  ) {
+    return usage;
+  }
+  const codexUsage = await loadProviderUsageSummary({
+    timeoutMs: params.timeoutMs,
+    providers: ["openai"],
+    auth: [buildCodexSyntheticUsageAuth()],
+    config: params.config,
+    agentDir,
+  });
+  return mergeUsageSummaries(usage, codexUsage);
+}
+
+/** Exposes the lazily loaded provider-usage module for callers that need its helpers. */
+export async function loadStatusProviderUsageModule() {
+  return await providerUsageLoader.load();
+}

--- a/src/commands/status.cold-imports.test.ts
+++ b/src/commands/status.cold-imports.test.ts
@@ -9,20 +9,22 @@ describe("status cold imports", () => {
     vi.resetModules();
   });
 
-  it("collects default runtime status without loading usage credentials", async () => {
+  it("isolates failed usage imports from default runtime status", async () => {
+    const usageImportFailure = new Error("usage credential resolution failed to load");
     vi.doMock("../agents/model-auth-label.js", () => {
-      throw new Error("default status must not import usage credential resolution");
+      throw usageImportFailure;
     });
     vi.doMock("./status.daemon.js", () => ({
       getDaemonStatusSummary: async () => ({ label: "gateway" }),
       getNodeDaemonStatusSummary: async () => ({ label: "node" }),
     }));
 
-    const { resolveStatusRuntimeSnapshot } = await import("./status-runtime-shared.js");
+    const { loadStatusProviderUsageModule, resolveStatusRuntimeSnapshot } =
+      await import("./status-runtime-shared.js");
+    const params = { config: {}, sourceConfig: {}, gatewayReachable: false };
+    const snapshot = await resolveStatusRuntimeSnapshot(params);
 
-    await expect(
-      resolveStatusRuntimeSnapshot({ config: {}, sourceConfig: {}, gatewayReachable: false }),
-    ).resolves.toEqual({
+    expect(snapshot).toEqual({
       securityAudit: undefined,
       usage: undefined,
       health: undefined,
@@ -30,6 +32,15 @@ describe("status cold imports", () => {
       gatewayService: { label: "gateway" },
       nodeService: { label: "node" },
     });
+
+    // Vitest wraps a failed module factory; both callers must preserve its cause.
+    await expect(resolveStatusRuntimeSnapshot({ ...params, usage: true })).rejects.toMatchObject({
+      cause: usageImportFailure,
+    });
+    await expect(loadStatusProviderUsageModule()).rejects.toMatchObject({
+      cause: usageImportFailure,
+    });
+    await expect(resolveStatusRuntimeSnapshot(params)).resolves.toEqual(snapshot);
   });
 
   it("keeps broad plugin status code behind the detailed status boundary", async () => {

--- a/src/commands/status.cold-imports.test.ts
+++ b/src/commands/status.cold-imports.test.ts
@@ -4,7 +4,32 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 describe("status cold imports", () => {
   afterEach(() => {
     vi.doUnmock("../plugins/status.js");
+    vi.doUnmock("../agents/model-auth-label.js");
+    vi.doUnmock("./status.daemon.js");
     vi.resetModules();
+  });
+
+  it("collects default runtime status without loading usage credentials", async () => {
+    vi.doMock("../agents/model-auth-label.js", () => {
+      throw new Error("default status must not import usage credential resolution");
+    });
+    vi.doMock("./status.daemon.js", () => ({
+      getDaemonStatusSummary: async () => ({ label: "gateway" }),
+      getNodeDaemonStatusSummary: async () => ({ label: "node" }),
+    }));
+
+    const { resolveStatusRuntimeSnapshot } = await import("./status-runtime-shared.js");
+
+    await expect(
+      resolveStatusRuntimeSnapshot({ config: {}, sourceConfig: {}, gatewayReachable: false }),
+    ).resolves.toEqual({
+      securityAudit: undefined,
+      usage: undefined,
+      health: undefined,
+      lastHeartbeat: null,
+      gatewayService: { label: "gateway" },
+      nodeService: { label: "node" },
+    });
   });
 
   it("keeps broad plugin status code behind the detailed status boundary", async () => {

--- a/src/plugins/schema-validator.test.ts
+++ b/src/plugins/schema-validator.test.ts
@@ -1,7 +1,15 @@
 /** Covers plugin schema validation for manifests and exported config schemas. */
 import { Format } from "typebox/format";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { validateJsonSchemaValue } from "./schema-validator.js";
+
+// Config validation is a CLI startup dependency; codecs and value transforms are not.
+vi.mock("typebox/compile", () => {
+  throw new Error("schema validation must not load the TypeBox value-transform compiler");
+});
+vi.mock("typebox/value", () => {
+  throw new Error("schema validation must not load TypeBox value transforms");
+});
 
 const jsonSchemaThenKeyword = ["the", "n"].join("");
 

--- a/src/plugins/schema-validator.ts
+++ b/src/plugins/schema-validator.ts
@@ -1,8 +1,8 @@
 import { normalizeJsonSchemaForTypeBox } from "@openclaw/normalization-core/json-schema";
 import { asOptionalObjectRecord } from "@openclaw/normalization-core/record-coerce";
 // Compiles plugin manifest schemas for validation without runtime loading.
-import { Compile, type Validator as TypeBoxValidator } from "typebox/compile";
 import { Format } from "typebox/format";
+import { Compile, type Validator as TypeBoxValidator } from "typebox/schema";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { appendAllowedValuesHint, summarizeAllowedValues } from "../config/allowed-values.js";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
@@ -157,7 +157,8 @@ function checkSchemaWithCurrentFormats(
   if (validate.Check(value)) {
     return null;
   }
-  return [...validate.Errors(value)] as TypeBoxValidationError[];
+  // The schema-only compiler returns [valid, errors], without loading value codecs.
+  return validate.Errors(value)[1];
 }
 
 function isDefaultActivatedConditionalFailure(params: {

--- a/src/shared/json-schema-defaults.ts
+++ b/src/shared/json-schema-defaults.ts
@@ -4,7 +4,7 @@ import {
   type JsonSchemaValue,
 } from "@openclaw/normalization-core/json-schema";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { Compile } from "typebox/compile";
+import { Compile } from "typebox/schema";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 
 type LocalRefResolution =


### PR DESCRIPTION
## What Problem This Solves

The startup-memory CI gate (`scripts/check-cli-startup-memory.mjs`) has been saturated on main — `status --json` sat right at its ceiling with a wide sample spread, so PRs coin-flipped the gate. This reclaims headroom on the measured startup paths instead of raising the ceiling.

## Why This Change Was Made

Two ownership fixes found by profiling the exact gate commands:

1. **Defer status usage runtime** (`status-usage.runtime.ts`): importing the shared status probes also loaded the model/credential/provider-usage graph even when `--usage` was not requested. The optional usage implementation now lives behind a lazy runtime boundary loaded only for usage requests. Every usage caller keeps its async contract; a failed lazy import rejects with the original cause (no empty-result substitution); non-usage paths keep identical order and error scopes. **Stable −19.29 MiB status RSS** across six samples.
2. **Trim schema validation imports** (`json-schema.ts`, `schema-validator.ts`): the JSON validation owners pulled the full TypeBox compiler/value barrels (codec/convert/create) they never call. Switched to the maintained public `typebox/schema` + `typebox/guard` entry points. **145 fewer TypeBox modules** (665→520), ~0.111 MiB less loaded source per command. Validation semantics verified byte-identical against installed TypeBox 1.3.16 (both compilers use `Build().Evaluate().Check`; the value-error helper unwraps the same `[valid, errors]` tuple). LLM-core (needs `Convert`) and gateway-protocol (mutable Ajv-style adapter) genuinely untouched.

## User Impact

No behavior change. `openclaw status` (with and without `--usage`), `plugins list`, and config validation return identical results; only startup memory drops.

## Evidence

- Production **net +6** (mostly moving 115 lines into the usage runtime owner); tests net +11; assertion baseline shrinks 7→6.
- Failing-first: status cold-import test failed at the eager `model-auth-label` import pre-fix; schema suite failed on the eager `typebox/value` import pre-fix; both green after.
- **8,184 byte-identical old/new validation comparisons** across 25 schemas × inputs × cached/defaults/error-limit paths; real built-CLI `status --json --usage` proof.
- Two independent Codex reviews clean at P0; post-rebase focused suites green; full changed-file gate exit 0.
- **Measurement caveat for reviewers:** all deltas are macOS; Linux CI absolute RSS was not measured locally, and this base already contains the harness/fast-path repair `f49d25052ef` that may itself have eased the original Linux saturation. This PR's own exact-head **Linux startup-memory CI run is the authoritative headroom proof** — see the gate result on this PR. No ceiling or benchmark-harness values were changed.
- Named follow-ups (not here): Zod construction graph, config-writer/cron import graph, and metadata/embedding activation graph remain separate owner-level reductions; a pre-existing build-scanner chunk-splitting gap for the `[INEFFECTIVE_DYNAMIC_IMPORT]` marker.
