### PR TITLE
fix(imessage): preserve non-Homebrew imsg during setup

### DIFF
--- a/extensions/imessage/src/install-imsg.test.ts
+++ b/extensions/imessage/src/install-imsg.test.ts
@@ -61,13 +61,25 @@ describe("installIMessageCli", () => {
     });
   });
 
-  it("updates imsg through Homebrew when requested", async () => {
+  it("updates imsg when its Homebrew formula is installed", async () => {
     setProcessPlatform("darwin");
     await withTempDir("openclaw-imsg-brew-", async (brewPrefix) => {
-      await fs.mkdir(path.join(brewPrefix, "bin"), { recursive: true });
-      await fs.writeFile(path.join(brewPrefix, "bin", "imsg"), "");
+      const cellar = path.join(brewPrefix, "Cellar");
+      const formulaCliPath = path.join(cellar, "imsg", "0.13.1", "bin", "imsg");
+      const cliPath = path.join(brewPrefix, "bin", "imsg");
+      await fs.mkdir(path.dirname(formulaCliPath), { recursive: true });
+      await fs.mkdir(path.dirname(cliPath), { recursive: true });
+      await fs.writeFile(formulaCliPath, "");
+      await fs.symlink(formulaCliPath, cliPath);
       resolveBrewExecutableMock.mockReturnValue("/opt/homebrew/bin/brew");
       runPluginCommandWithTimeoutMock
+        .mockResolvedValueOnce({
+          code: 0,
+          stdout: "steipete/tap/imsg\n",
+          stderr: "",
+        })
+        .mockResolvedValueOnce({ code: 0, stdout: `${cliPath}\n`, stderr: "" })
+        .mockResolvedValueOnce({ code: 0, stdout: `${cellar}\n`, stderr: "" })
         .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" })
         .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" })
         .mockResolvedValueOnce({ code: 0, stdout: `${brewPrefix}\n`, stderr: "" })
@@ -79,17 +91,70 @@ describe("installIMessageCli", () => {
 
       expect(result).toEqual({
         ok: true,
-        cliPath: path.join(brewPrefix, "bin", "imsg"),
+        cliPath,
         version: "0.13.1",
       });
-      expect(runPluginCommandWithTimeoutMock).toHaveBeenNthCalledWith(1, {
+      expect(runPluginCommandWithTimeoutMock).toHaveBeenNthCalledWith(4, {
         argv: ["/opt/homebrew/bin/brew", "update"],
         timeoutMs: 5 * 60_000,
       });
-      expect(runPluginCommandWithTimeoutMock).toHaveBeenNthCalledWith(2, {
+      expect(runPluginCommandWithTimeoutMock).toHaveBeenNthCalledWith(5, {
         argv: ["/opt/homebrew/bin/brew", "upgrade", "imsg"],
         timeoutMs: 15 * 60_000,
       });
+    });
+  });
+
+  it("preserves detected imsg when Homebrew does not own it", async () => {
+    setProcessPlatform("darwin");
+    resolveBrewExecutableMock.mockReturnValue("/opt/homebrew/bin/brew");
+    runPluginCommandWithTimeoutMock.mockResolvedValue({
+      code: 0,
+      stdout: "wget\n",
+      stderr: "",
+    });
+
+    const result = await installIMessageCli({ log: vi.fn() } as unknown as RuntimeEnv, {
+      upgrade: true,
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(runPluginCommandWithTimeoutMock).toHaveBeenCalledTimes(1);
+    expect(runPluginCommandWithTimeoutMock).toHaveBeenCalledWith({
+      argv: ["/opt/homebrew/bin/brew", "list", "--formula", "--full-name"],
+      timeoutMs: 10_000,
+    });
+  });
+
+  it("preserves a PATH imsg that shadows an installed Homebrew formula", async () => {
+    setProcessPlatform("darwin");
+    await withTempDir("openclaw-imsg-shadow-", async (tmpDir) => {
+      const cliPath = path.join(tmpDir, "local", "bin", "imsg");
+      const cellar = path.join(tmpDir, "Cellar");
+      await fs.mkdir(path.dirname(cliPath), { recursive: true });
+      await fs.writeFile(cliPath, "");
+      await fs.mkdir(path.join(cellar, "imsg"), { recursive: true });
+      resolveBrewExecutableMock.mockReturnValue("/opt/homebrew/bin/brew");
+      runPluginCommandWithTimeoutMock
+        .mockResolvedValueOnce({
+          code: 0,
+          stdout: "steipete/tap/imsg\n",
+          stderr: "",
+        })
+        .mockResolvedValueOnce({ code: 0, stdout: `${cliPath}\n`, stderr: "" })
+        .mockResolvedValueOnce({ code: 0, stdout: `${cellar}\n`, stderr: "" });
+
+      const result = await installIMessageCli({ log: vi.fn() } as unknown as RuntimeEnv, {
+        upgrade: true,
+      });
+
+      expect(result).toEqual({ ok: true });
+      expect(runPluginCommandWithTimeoutMock.mock.calls).not.toContainEqual([
+        { argv: ["/opt/homebrew/bin/brew", "update"], timeoutMs: 5 * 60_000 },
+      ]);
+      expect(runPluginCommandWithTimeoutMock.mock.calls).not.toContainEqual([
+        { argv: ["/opt/homebrew/bin/brew", "upgrade", "imsg"], timeoutMs: 15 * 60_000 },
+      ]);
     });
   });
 

--- a/extensions/imessage/src/install-imsg.ts
+++ b/extensions/imessage/src/install-imsg.ts
@@ -14,10 +14,70 @@ type IMessageInstallResult = {
   error?: string;
 };
 
+const IMESSAGE_BREW_FORMULA = "steipete/tap/imsg";
+
+function isPathInside(parentPath: string, candidatePath: string): boolean {
+  const relative = path.relative(parentPath, candidatePath);
+  return (
+    relative.length > 0 &&
+    relative !== ".." &&
+    !relative.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relative)
+  );
+}
+
+async function resolveBrewManagedIMessageCliPath(
+  brewExe: string,
+  cliPath: string,
+): Promise<string | null> {
+  try {
+    const formulae = await runPluginCommandWithTimeout({
+      argv: [brewExe, "list", "--formula", "--full-name"],
+      timeoutMs: 10_000,
+    });
+    const installed = formulae.stdout
+      .split(/\r?\n/u)
+      .some((formula) => formula.trim() === IMESSAGE_BREW_FORMULA);
+    if (formulae.code !== 0 || !installed) {
+      return null;
+    }
+
+    let resolvedCliPath = cliPath;
+    if (!path.isAbsolute(resolvedCliPath)) {
+      const resolved = await runPluginCommandWithTimeout({
+        argv: ["/usr/bin/env", "which", resolvedCliPath],
+        timeoutMs: 10_000,
+      });
+      resolvedCliPath =
+        resolved.code === 0 ? (resolved.stdout.split(/\r?\n/u)[0]?.trim() ?? "") : "";
+    }
+    if (!resolvedCliPath) {
+      return null;
+    }
+
+    const cellar = await runPluginCommandWithTimeout({
+      argv: [brewExe, "--cellar"],
+      timeoutMs: 10_000,
+    });
+    if (cellar.code !== 0 || !cellar.stdout.trim()) {
+      return null;
+    }
+    const [realCliPath, realFormulaPath] = await Promise.all([
+      fs.realpath(resolvedCliPath),
+      fs.realpath(path.join(cellar.stdout.trim(), "imsg")),
+    ]);
+    // An installed receipt alone does not own a shadowing PATH wrapper. Only
+    // upgrade when the executable itself resolves into this formula's Cellar rack.
+    return isPathInside(realFormulaPath, realCliPath) ? resolvedCliPath : null;
+  } catch {
+    return null;
+  }
+}
+
 async function resolveBrewIMessageCliPath(brewExe: string): Promise<string | null> {
   try {
     const result = await runPluginCommandWithTimeout({
-      argv: [brewExe, "--prefix", "imsg"],
+      argv: [brewExe, "--prefix"],
       timeoutMs: 10_000,
     });
     if (result.code !== 0 || !result.stdout.trim()) {
@@ -33,7 +93,7 @@ async function resolveBrewIMessageCliPath(brewExe: string): Promise<string | nul
 
 export async function installIMessageCli(
   runtime: RuntimeEnv,
-  opts?: { upgrade?: boolean },
+  opts?: { upgrade?: boolean; cliPath?: string },
 ): Promise<IMessageInstallResult> {
   if (process.platform !== "darwin") {
     return {
@@ -52,6 +112,11 @@ export async function installIMessageCli(
 
   runtime.log(`${opts?.upgrade ? "Updating" : "Installing"} imsg via Homebrew (${brewExe})...`);
   if (opts?.upgrade) {
+    const managedCliPath = await resolveBrewManagedIMessageCliPath(brewExe, opts.cliPath ?? "imsg");
+    if (!managedCliPath) {
+      runtime.log("Keeping the detected imsg binary because Homebrew does not manage it.");
+      return { ok: true };
+    }
     const update = await runPluginCommandWithTimeout({
       argv: [brewExe, "update"],
       timeoutMs: 5 * 60_000,

--- a/extensions/imessage/src/setup-surface.ts
+++ b/extensions/imessage/src/setup-surface.ts
@@ -86,7 +86,10 @@ export const imessageSetupWizard: ChannelSetupWizard = {
     }
     try {
       await options?.beforePersistentEffect?.();
-      const result = await installIMessageCli(runtime, { upgrade: cliDetected });
+      const result = await installIMessageCli(runtime, {
+        upgrade: cliDetected,
+        cliPath: normalizedCliPath,
+      });
       if (result.ok && result.cliPath) {
         await prompter.note(`Installed imsg at ${result.cliPath}`, "iMessage");
         return {
@@ -94,6 +97,12 @@ export const imessageSetupWizard: ChannelSetupWizard = {
             cliPath: result.cliPath,
           },
         };
+      }
+      if (result.ok) {
+        await prompter.note(
+          `Using existing imsg at ${normalizedCliPath}; Homebrew does not manage this binary.`,
+          "iMessage",
+        );
       }
       if (!result.ok) {
         await prompter.note(result.error ?? "imsg install failed.", "iMessage");

--- a/extensions/imessage/src/status.test.ts
+++ b/extensions/imessage/src/status.test.ts
@@ -382,7 +382,10 @@ describe("imessage setup status", () => {
       message: "imsg not found. Install now?",
       initialValue: true,
     });
-    expect(installIMessageCliMock).toHaveBeenCalledWith(expect.anything(), { upgrade: false });
+    expect(installIMessageCliMock).toHaveBeenCalledWith(expect.anything(), {
+      upgrade: false,
+      cliPath: "imsg",
+    });
     expect(note).toHaveBeenCalledWith("Installed imsg at /opt/homebrew/bin/imsg", "iMessage");
     expect(result).toEqual({
       credentialValues: {
@@ -415,12 +418,34 @@ describe("imessage setup status", () => {
       message: "imsg detected. Reinstall/update now?",
       initialValue: false,
     });
-    expect(installIMessageCliMock).toHaveBeenCalledWith(expect.anything(), { upgrade: true });
+    expect(installIMessageCliMock).toHaveBeenCalledWith(expect.anything(), {
+      upgrade: true,
+      cliPath: "/opt/homebrew/bin/imsg",
+    });
     expect(result).toEqual({
       credentialValues: {
         cliPath: "/opt/homebrew/bin/imsg",
       },
     });
+  });
+
+  it("prepare preserves a detected PATH imsg that Homebrew does not manage", async () => {
+    setupToolsMocks.detectBinary.mockResolvedValueOnce(true);
+    installIMessageCliMock.mockResolvedValueOnce({ ok: true });
+    const confirm = vi.fn(async () => true);
+    const note = vi.fn(async () => {});
+
+    const result = await prepareIMessage({ platform: "darwin", confirm, note });
+
+    expect(installIMessageCliMock).toHaveBeenCalledWith(expect.anything(), {
+      upgrade: true,
+      cliPath: "imsg",
+    });
+    expect(note).toHaveBeenCalledWith(
+      "Using existing imsg at imsg; Homebrew does not manage this binary.",
+      "iMessage",
+    );
+    expect(result).toBeUndefined();
   });
 
   it("setup wizard proxy delegates imsg install preparation", async () => {


### PR DESCRIPTION
Source task: `01a045e8-d9eb-7bd0-abdf-097c5b55d319`

AI-assisted: yes. I reviewed the implementation and understand the ownership checks and setup behavior.

## What Problem This Solves

Fixes an issue where iMessage setup treated any detected `imsg` executable as Homebrew-owned. A PATH wrapper such as `~/.local/bin/imsg` therefore triggered `brew update && brew upgrade imsg`; Homebrew then tried to resolve the unrelated untrusted `steipete/tap/imsg` formula and setup failed.

## Why This Change Was Made

The iMessage installer now performs a read-only ownership check before either mutating Homebrew command: it reads installed formula receipts with unnamed `brew list --formula --full-name`, resolves the active executable, and requires its canonical path to be inside the installed `Cellar/imsg` rack. Non-Homebrew and shadowing binaries are preserved; genuine Homebrew installations still update and missing installations still use the existing install flow.

This stays local to the iMessage installer because the repository-wide audit found no other production caller that upgrades a PATH-detected target. Changing `resolveBrewExecutable` would incorrectly mix package-manager availability with formula ownership.

### Homebrew caller audit

| Production surface | Classification | Conclusion |
| --- | --- | --- |
| `src/infra/brew.ts`, `src/plugin-sdk/setup-tools.ts` | Homebrew availability only | Resolves a trusted brew executable; makes no formula claim. |
| `src/commands/onboard-skills.ts`, `src/skills/discovery/status.ts` | Homebrew availability only | Shows/selects recipes after dependency requirements are already known. |
| `src/skills/lifecycle/install.ts` | Missing-dependency installer | Uses `brew install` only for selected recipes or missing `uv`/`go`; no detected target is upgraded. |
| `extensions/signal/src/install-signal-cli.ts` | Explicit dependency install/replacement | Installs `signal-cli` only when setup selected that install route; it never upgrades a PATH-detected binary. |
| `extensions/imessage/src/setup-surface.ts`, `extensions/imessage/src/install-imsg.ts` | Incorrect PATH-presence ownership assumption | Fixed at the installer mutation seam. |
| `src/hooks/gmail-setup-utils.ts` | Missing-dependency installer | Existing `gcloud`, `gog`, or `tailscale` returns before brew install. |
| `src/cli/dns-cli.ts` | Explicit Homebrew-owned workflow | Operates on CoreDNS under the resolved brew prefix; no PATH-driven upgrade. |
| `scripts/install.sh`, `scripts/install-cli.sh` | Availability or missing-dependency installer | Formula installs follow missing command/version checks. |
| `scripts/docker/sandbox/Dockerfile.common` | Homebrew bootstrap | Installs Homebrew itself; no target ownership inference. |

No production `brew reinstall` caller exists. Guidance-only install strings and postinstall hints do not execute Homebrew.

## User Impact

Operators can keep a local or wrapped `imsg` on PATH and complete iMessage setup without OpenClaw attempting to update an unrelated Homebrew formula. Homebrew-managed users retain the current update behavior, and users missing `imsg` retain the existing opt-in install path. The ownership probe does not trust a tap or resolve a named formula.

## Evidence

### Before

Observed host state:

```text
command -v imsg
/Users/patrickerichsen/.local/bin/imsg

imsg --version
0.14.1

brew list --formula --full-name | rg '(^|/)imsg$'
# no match
```

Before command trace on `main`:

```text
detectBinary("imsg") => true
brew update
brew upgrade imsg
=> Refusing to load formula steipete/tap/imsg from untrusted tap
```

![Before: iMessage setup fails while trying to upgrade an unrelated untrusted Homebrew formula](https://github.com/user-attachments/assets/ec4d0a23-6b6b-44d9-84d8-c33c74bfec90)

### After

Regression trace for the same non-owned decision:

```text
brew list --formula --full-name
=> no steipete/tap/imsg receipt
result => { ok: true }
brew update calls => 0
brew upgrade calls => 0
setup => preserves existing imsg and continues
```

A second regression covers a PATH wrapper shadowing an installed formula; canonical-path containment still prevents update/upgrade. Positive coverage proves an installed receipt plus an executable inside `Cellar/imsg` continues through update/upgrade and returns the stable Homebrew link. Missing-install coverage remains unchanged.

Validation:

- Red: `pnpm test extensions/imessage/src/install-imsg.test.ts` — new non-Homebrew regression failed on pre-fix behavior (`1 failed, 4 passed`).
- Green focused: `pnpm test extensions/imessage/src/install-imsg.test.ts extensions/imessage/src/status.test.ts` — 40 passed.
- Green plugin: `pnpm test extensions/imessage` — 52 files, 1,181 tests passed.
- Green repository gate: `node scripts/check-changed.mjs`.
- Structured autoreview: clean after fixing its P1 stable-path finding.

Homebrew contract proof was inspected directly in Homebrew 6.0.20 source: unnamed `brew list --formula --full-name` walks installed keg receipts and does not resolve or trust a tap; unnamed `brew --cellar` only prints the Cellar root. Named install/upgrade/reinstall and dry-run paths can enter tap trust handling, so none is used as an ownership probe. The forbidden `brew install --dry-run steipete/tap/imsg` command was not run, and no tap trust was changed.

Production LOC: +77/-3 (net +74) | Tests: +98/-8. The production growth establishes the missing formula-receipt plus canonical executable ownership boundary and an explicit preserved-result outcome before destructive package-manager commands; no shared abstraction was added because no sibling caller shares the invariant.
