### PR TITLE
fix(agents): write settings.json atomically via temp file and rename

### DIFF
--- a/src/agents/sessions/settings-storage.test.ts
+++ b/src/agents/sessions/settings-storage.test.ts
@@ -9,7 +9,11 @@ import { SettingsManager } from "./settings-manager.js";
 import { FileSettingsStorage } from "./settings-storage.js";
 
 const fixtures = createFixtureLifetime();
-afterEach(() => fixtures.cleanup());
+afterEach(async () => {
+  vi.restoreAllMocks();
+  syncBuiltinESMExports();
+  await fixtures.cleanup();
+});
 
 describe("FileSettingsStorage", () => {
   it("preserves provider retry settings across an upgraded settings write", async () => {
@@ -35,6 +39,108 @@ describe("FileSettingsStorage", () => {
     const stored = JSON.parse(readFileSync(settingsPath, "utf8"));
     expect(stored.retry.provider).toEqual({ maxRetries: 7, timeoutMs: 1_000 });
   });
+
+  it("keeps the original settings when a write fails partway", () => {
+    const root = fixtures.createTempDir("openclaw-settings-partial-write-");
+    const agentDir = join(root, "agent");
+    const settingsPath = join(agentDir, "settings.json");
+    const original = JSON.stringify({ packages: ["npm:@openclaw/keep"] });
+    const replacement = JSON.stringify({ packages: ["npm:@openclaw/replacement"] });
+    mkdirSync(agentDir);
+    fs.writeFileSync(settingsPath, original);
+
+    const writeFileSync = fs.writeFileSync;
+    vi.spyOn(fs, "writeFileSync").mockImplementation((target, data, options) => {
+      if (data === replacement) {
+        writeFileSync(target, replacement.slice(0, replacement.length / 2), options as never);
+        throw Object.assign(new Error("disk full"), { code: "ENOSPC" });
+      }
+      return writeFileSync(target, data, options as never);
+    });
+    syncBuiltinESMExports();
+
+    expect(() =>
+      new FileSettingsStorage(root, agentDir).withLock("global", () => replacement),
+    ).toThrow("disk full");
+    expect(readFileSync(settingsPath, "utf8")).toBe(original);
+    expect(fs.readdirSync(agentDir).filter((entry) => entry.endsWith(".tmp"))).toEqual([]);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "preserves existing settings and parent directory modes",
+    () => {
+      const root = fixtures.createTempDir("openclaw-settings-modes-");
+      const agentDir = join(root, "agent");
+      const settingsPath = join(agentDir, "settings.json");
+      mkdirSync(agentDir, { mode: 0o751 });
+      fs.writeFileSync(settingsPath, "{}", { mode: 0o640 });
+
+      new FileSettingsStorage(root, agentDir).withLock("global", () =>
+        JSON.stringify({ packages: ["npm:@openclaw/new"] }),
+      );
+
+      expect(fs.statSync(settingsPath).mode & 0o777).toBe(0o640);
+      expect(fs.statSync(agentDir).mode & 0o777).toBe(0o751);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")("uses the current umask when creating settings", () =>
+    fixtures.run(async () => {
+      const root = fixtures.createTempDir("openclaw-settings-umask-");
+      const agentDir = join(root, "agent");
+      const result = await runNodeScript(
+        [
+          "--import",
+          new URL("../../../scripts/tsx.mjs", import.meta.url).href,
+          "--input-type=module",
+          "--eval",
+          String.raw`
+              import { statSync } from "node:fs";
+              import { join } from "node:path";
+              const [moduleUrl, root, agentDir] = process.argv.slice(1);
+              const { FileSettingsStorage } = await import(moduleUrl);
+              process.umask(0o077);
+              new FileSettingsStorage(root, agentDir).withLock("global", () => "{}");
+              console.log(statSync(join(agentDir, "settings.json")).mode & 0o777);
+            `,
+          new URL("./settings-storage.ts", import.meta.url).href,
+          root,
+          agentDir,
+        ],
+        process.env,
+        10_000,
+        { requireProcessTreeExit: true },
+      );
+
+      expect(result, result.stderr).toMatchObject({ error: undefined, status: 0 });
+      expect(result.stdout.trim()).toBe(String(0o600));
+    }),
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "preserves a settings symlink chain under a symlinked parent",
+    () => {
+      const root = fixtures.createTempDir("openclaw-settings-symlinks-");
+      const realAgentDir = join(root, "real-agent");
+      const linkedAgentDir = join(root, "linked-agent");
+      const settingsPath = join(realAgentDir, "settings.json");
+      const intermediatePath = join(realAgentDir, "settings-target-link.json");
+      const targetPath = join(realAgentDir, "operator-settings.json");
+      const replacement = JSON.stringify({ packages: ["npm:@openclaw/new"] });
+      mkdirSync(realAgentDir);
+      fs.writeFileSync(targetPath, JSON.stringify({ packages: ["npm:@openclaw/old"] }));
+      fs.symlinkSync(targetPath, intermediatePath);
+      fs.symlinkSync(intermediatePath, settingsPath);
+      fs.symlinkSync(realAgentDir, linkedAgentDir);
+
+      new FileSettingsStorage(root, linkedAgentDir).withLock("global", () => replacement);
+
+      expect(fs.lstatSync(linkedAgentDir).isSymbolicLink()).toBe(true);
+      expect(fs.lstatSync(settingsPath).isSymbolicLink()).toBe(true);
+      expect(fs.lstatSync(intermediatePath).isSymbolicLink()).toBe(true);
+      expect(readFileSync(targetPath, "utf8")).toBe(replacement);
+    },
+  );
 
   it("loads missing settings without creating their directories", () => {
     const root = fixtures.createTempDir("openclaw-settings-read-");

--- a/src/agents/sessions/settings-storage.ts
+++ b/src/agents/sessions/settings-storage.ts
@@ -1,6 +1,8 @@
-import { existsSync, lstatSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, lstatSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
 import { acquireFileLockSyncWithRetry } from "../../infra/file-lock-sync.js";
+import { resolveJsonSaveTarget } from "../../infra/json-file.js";
+import { replaceFileAtomicSync } from "../../infra/replace-file.js";
 import type { Transport } from "../../llm/types.js";
 import { CONFIG_DIR_NAME } from "../config.js";
 
@@ -128,6 +130,24 @@ export interface SettingsError {
   error: Error;
 }
 
+function replaceSettingsFile(path: string, content: string): void {
+  const savePath = resolveJsonSaveTarget(path);
+  const saveDir = realpathSync(dirname(savePath));
+  const canonicalSavePath = join(saveDir, basename(savePath));
+
+  // The atomic helper enforces explicit modes. Carry the existing parent mode
+  // and Node's writeFile creation mode forward so replacement changes no permissions.
+  // Keep rename failures fail-closed: copy fallback can expose a partial destination.
+  replaceFileAtomicSync({
+    filePath: canonicalSavePath,
+    content,
+    dirMode: statSync(saveDir).mode & 0o7777,
+    mode: 0o666 & ~process.umask(),
+    preserveExistingMode: true,
+    tempPrefix: basename(canonicalSavePath),
+  });
+}
+
 export class FileSettingsStorage implements SettingsStorage {
   private paths: Record<SettingsScope, string>;
 
@@ -166,7 +186,7 @@ export class FileSettingsStorage implements SettingsStorage {
       const current = existsSync(path) ? readFileSync(path, "utf-8") : undefined;
       const next = fn(current);
       if (next !== undefined) {
-        writeFileSync(path, next, "utf-8");
+        replaceSettingsFile(path, next);
       }
     } finally {
       release();

--- a/src/infra/json-file.ts
+++ b/src/infra/json-file.ts
@@ -21,13 +21,23 @@ function resolveJsonSymlinkTarget(pathname: string): string | undefined {
   return path.resolve(path.dirname(pathname), fs.readlinkSync(pathname));
 }
 
-function resolveJsonSaveTarget(pathname: string): string {
-  const target = resolveJsonSymlinkTarget(pathname);
-  if (!target) {
-    return pathname;
+export function resolveJsonSaveTarget(pathname: string): string {
+  let currentPath = pathname;
+  const visited = new Set<string>();
+  while (fs.lstatSync(currentPath, { throwIfNoEntry: false })?.isSymbolicLink()) {
+    const normalizedPath = path.resolve(currentPath);
+    if (visited.has(normalizedPath)) {
+      throw Object.assign(new Error(`Too many symlink levels while resolving ${pathname}`), {
+        code: "ELOOP",
+      });
+    }
+    visited.add(normalizedPath);
+    currentPath = path.resolve(path.dirname(currentPath), fs.readlinkSync(currentPath));
   }
-  fs.statSync(path.dirname(target));
-  return target;
+  if (visited.size > 0) {
+    fs.statSync(path.dirname(currentPath));
+  }
+  return currentPath;
 }
 
 export function writeJsonTarget(pathname: string, data: unknown): void {


### PR DESCRIPTION
## Summary

Save agent settings through a same-directory atomic replacement so an interrupted write cannot expose or leave partial JSON.

## What Problem This Solves

`FileSettingsStorage.withLock()` wrote the final `settings.json` path directly. Node truncates that file before it writes the new payload. A process stop, quota, or disk-full error could therefore destroy the only complete settings copy.

## Fix

- Keep the current lock-first read, merge, and write owner unchanged.
- Stage the complete payload beside the resolved target and rename it into place.
- Resolve full final-link chains and symlinked parent directories before replacement.
- Preserve the existing file and parent modes.
- Use Node's prior `0666 & ~umask` creation mode for a new file.
- Fail closed on rename errors because copy fallback can expose a partial destination.

## Evidence

- Current main `d5912c2a0d14`: real kernel file-size limits left invalid 5120-byte and 7168-byte prefixes in the final settings path.
- Repaired head `89c58dab6e9c`: the same limits left the original 35-byte valid file unchanged.
- The repaired head preserved a symlinked parent, a two-link final chain, file mode `0600`, parent mode `0751`, and restrictive-umask creation mode `0600`.
- The anti-cheat probe varied both the payload marker and kernel limit.

### Exact-head terminal trace

```text
baseline d5912c2a0d14
limit=5KiB child=1 original=35 after=5120 preserved=false parseable=false
limit=7KiB child=1 original=35 after=7168 preserved=false parseable=false
RED: interrupted writes exposed partial settings.json

head 89c58dab6e9c
limit=5KiB child=1 original=35 after=35 preserved=true parseable=true
limit=7KiB child=1 original=35 after=35 preserved=true parseable=true
symlink-parent=true final-link=true intermediate-link=true target-updated=true
file-mode=0600 parent-mode=0751 restrictive-umask-file-mode=0600
GREEN: interrupted writes preserved settings; symlink and permission contracts held
```

## Validation

- `src/agents/sessions/settings-storage.test.ts`: 15 passed.
- `src/infra/json-file.test.ts`: 11 passed.
- `src/agents/sessions/settings-manager.test.ts`: 6 passed.
- Targeted format, lint, ratchet, dead-export, import-cycle, and repository guards passed.
