### PR TITLE
test(ui): await profile appearance refresh completion

### DIFF
--- a/ui/src/app/app-shell-gateway.test.ts
+++ b/ui/src/app/app-shell-gateway.test.ts
@@ -10,10 +10,15 @@ import { resetServerUiPrefsSync } from "./server-prefs.ts";
 import { loadSettings, patchSettings } from "./settings.ts";
 
 function createProfileAppearanceGateway(profileId: string | null) {
-  const request = vi.fn(async () => ({
-    status: "ok",
-    entries: { "ui.accent": "#336699" },
-  }));
+  const pendingResponses: Array<(accent: string) => void> = [];
+  const request = vi.fn(
+    () =>
+      new Promise<{ status: string; entries: { "ui.accent": string } }>((resolve) => {
+        pendingResponses.push((accent) =>
+          resolve({ status: "ok", entries: { "ui.accent": accent } }),
+        );
+      }),
+  );
   const client = {
     gatewayUrl: "ws://profile.test",
     request,
@@ -61,6 +66,17 @@ function createProfileAppearanceGateway(profileId: string | null) {
     syncSidebarWorkboard: vi.fn(),
   } as unknown as ShellGatewayHost;
   return {
+    completeProfileAppearance(this: void, accent = "#336699") {
+      const respond = pendingResponses.shift();
+      expect(respond, "pending users.prefs.get response").toBeDefined();
+      // Config reconciliation can also refresh the theme. Arm this only when
+      // releasing this request, after any synchronous reconciliation has finished.
+      const refreshed = new Promise<void>((resolve) => {
+        refreshTheme.mockImplementationOnce(resolve);
+      });
+      respond!(accent);
+      return refreshed;
+    },
     context,
     host,
     owner: new ShellGatewayOwner(host),
@@ -96,13 +112,19 @@ describe("ShellGatewayOwner profile appearance integration", () => {
   });
 
   it("loads profile appearance when authenticated presence appears on an existing connection", async () => {
-    const { owner, request, snapshot } = createProfileAppearanceGateway(null);
+    const { completeProfileAppearance, context, owner, refreshTheme, request, snapshot } =
+      createProfileAppearanceGateway(null);
     owner.synchronizeGateway(snapshot);
     snapshot.selfUser = { id: "profile-owner" };
 
     owner.synchronizeGateway(snapshot);
 
-    await vi.waitFor(() => expect(loadSettings().accent).toBe("#336699"));
+    owner.reconcileServerUiPrefs(context.runtimeConfig);
+    expect(refreshTheme).toHaveBeenCalledOnce();
+    expect(loadSettings().accent).toBe("#ff0000");
+    await completeProfileAppearance();
+    expect(refreshTheme).toHaveBeenCalledTimes(2);
+    expect(loadSettings().accent).toBe("#336699");
     expect(request).toHaveBeenCalledOnce();
     // Derived from the wire contract so new appearance keys extend the
     // request without silently invalidating this expectation.
@@ -113,18 +135,22 @@ describe("ShellGatewayOwner profile appearance integration", () => {
 
   it("republishes profile provenance even when its appearance matches the browser mirror", async () => {
     patchSettings({ accent: "#336699" });
-    const { owner, refreshTheme, snapshot } = createProfileAppearanceGateway("profile-owner");
+    const { completeProfileAppearance, owner, refreshTheme, snapshot } =
+      createProfileAppearanceGateway("profile-owner");
 
     owner.synchronizeGateway(snapshot);
 
-    await vi.waitFor(() => expect(refreshTheme).toHaveBeenCalledOnce());
+    await completeProfileAppearance();
+    expect(refreshTheme).toHaveBeenCalledOnce();
     expect(loadSettings().accent).toBe("#336699");
   });
 
   it("reuses cached profile preferences across unrelated gateway config snapshots", async () => {
-    const { context, owner, request, snapshot } = createProfileAppearanceGateway("profile-owner");
+    const { completeProfileAppearance, context, owner, request, snapshot } =
+      createProfileAppearanceGateway("profile-owner");
     owner.synchronizeGateway(snapshot);
-    await vi.waitFor(() => expect(loadSettings().accent).toBe("#336699"));
+    await completeProfileAppearance();
+    expect(loadSettings().accent).toBe("#336699");
     request.mockClear();
     const configState = context.runtimeConfig.state as {
       configSnapshot: { config: unknown };
@@ -140,13 +166,13 @@ describe("ShellGatewayOwner profile appearance integration", () => {
   });
 
   it("refreshes only matching profile-change events and republishes the resolved appearance", async () => {
-    const { owner, refreshTheme, request, snapshot } =
+    const { completeProfileAppearance, owner, refreshTheme, request, snapshot } =
       createProfileAppearanceGateway("profile-owner");
     owner.synchronizeGateway(snapshot);
-    await vi.waitFor(() => expect(loadSettings().accent).toBe("#336699"));
+    await completeProfileAppearance();
+    expect(loadSettings().accent).toBe("#336699");
     request.mockClear();
     refreshTheme.mockClear();
-    request.mockResolvedValueOnce({ status: "ok", entries: { "ui.accent": "#224466" } });
 
     owner.handleGatewayEvent({
       type: "event",
@@ -161,7 +187,8 @@ describe("ShellGatewayOwner profile appearance integration", () => {
       payload: { profileId: "profile-owner", keys: ["ui.accent"] },
     });
 
-    await vi.waitFor(() => expect(loadSettings().accent).toBe("#224466"));
+    await completeProfileAppearance("#224466");
+    expect(loadSettings().accent).toBe("#224466");
     expect(request).toHaveBeenCalledOnce();
     expect(refreshTheme).toHaveBeenCalledOnce();
   });


### PR DESCRIPTION
## What Problem This Solves

The shell's five profile-appearance completion observations spend about 250 ms polling after their mocked requests have already completed. This maintainer-requested test-performance change removes that avoidable wait without changing application behavior.

## Why This Change Was Made

The existing fixture now queues each asynchronous `users.prefs.get` response. It arms a completion promise on the existing `theme.refresh` mock immediately before releasing that response. The assertions still exercise the real shell, profile-preference loading, normalization, settings persistence, and cache owners; there is no production seam or timer-interval change.

Config reconciliation can also refresh the theme. The identity-appearance case now deliberately reconciles config while its profile response is held, verifies that first refresh and gateway accent, then releases the profile response and verifies its separate refresh and persisted accent. The fixture has no runtime-config subscriptions or pending preference writes that could deliver an unrelated later refresh.

## User Impact

No product behavior changes. Developers get a faster focused shell test run with all five existing cases and assertions retained. Production context/client/profile/source fencing is unchanged. Production LOC: +0/-0; tests: +41/-14 (net +27).

## Evidence

Benchmark: one task-owned Blacksmith Testbox, Linux Node 24, one Vitest worker, distinct per-variant module caches, excluded warmups, eight order-balanced baseline/candidate pairs. Measured `/usr/bin/time -v pnpm test ui/src/app/app-shell-gateway.test.ts --maxWorkers=1 --reporter=verbose --reporter=json`, with import-duration diagnostics enabled. Source baseline: `f1e996068d8dd03c2c577a9fb37a19995ffdc1f7`.

| Median metric | Baseline | Candidate |
| --- | ---: | ---: |
| Command wall | 1.480 s | 1.257 s |
| Vitest duration | 0.834 s | 0.586 s |
| Test bodies | 265 ms | 12 ms |
| Import duration | 151.5 ms | 148 ms |
| Maximum RSS | 452,280 KiB | 455,330 KiB |
| User / system CPU | 1.370 / 0.200 s | 1.385 / 0.205 s |

Wall improves **223 ms / 15.1%**. All eight pairs improve: 279, 259, 300, 195, 218, 252, 171, and 109 ms. All samples pass five tests. Separate instrumentation confirms five profile requests in either variant; theme refreshes increase from five to six solely because of the additional config-reconciliation proof. These are scoped timings, not a claimed full-suite speedup.

Four reversible production faults fail the optimized tests: suppressing profile preference application, reversing profile-event matching, bypassing profile-source cache reuse, and removing same-value/no-op republishing. Production files are restored byte for byte and the clean candidate passes afterward. The application fault completes the request but leaves the gateway accent instead of applying the profile accent.

Focused shell/server-prefs/theme tests and shuffled shared-order proof pass 117 tests across two UI lanes:

```sh
pnpm test ui/src/app/app-shell-gateway.test.ts ui/src/app/app-host.server-prefs.test.ts ui/src/app/server-prefs.test.ts ui/src/app/server-prefs.profile.test.ts ui/src/app/server-prefs.read-only.test.ts ui/src/app/theme.test.ts ui/src/app/theme-fonts.test.ts --maxWorkers=1 --reporter=verbose
# Repeat with --sequence.shuffle --sequence.seed=271828
```

Testbox environment: https://github.com/openclaw/openclaw/actions/runs/33135053158 (`tbx_01m13229dfvnwjqbd7rwd94566`). SSH benchmark/fault results above are the command evidence; the workflow link identifies hydration and lease ownership, not a separate hosted CI verdict.

The first full changed gate passed all checks except unbound-method lint on the destructured fixture helper. Adding the erased `this: void` annotation fixes that declaration; TypeScript emitted JavaScript is byte-identical to the benchmarked candidate. Focused tests pass afterward.

Complete final changed gate passes: `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 pnpm check:changed` (all guards, dead-export scans, UI i18n, core test types, and changed-file lint; the existing variable selects local execution). Formatting, diff checks, deslop, and fresh Codex autoreview pass; review used the skill default P0 scope.

AI-assisted with Codex. No UI screenshots or live Gateway run: only test synchronization changes; production and rendered behavior are untouched.
