### PR TITLE
fix: release captured chat responses on cancellation

### DIFF
--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -322,7 +322,7 @@ Use `isLoopbackHost(host)` when a plugin must accept only the local machine. It 
     | `plugin-sdk/collection-runtime` | Small bounded cache helpers |
     | `plugin-sdk/diagnostic-runtime` | Diagnostic flag, event, trace-context, and low-cardinality dimension normalization helpers |
     | `plugin-sdk/error-runtime` | Error graph, formatting, unknown-value coercion, shared error classification helpers, `PlatformMessageNotDispatchedError`, `isApprovalNotFoundError` |
-    | `plugin-sdk/fetch-runtime` | Private-local after July 2026; Wrapped fetch, proxy, EnvHttpProxyAgent option, and pinned lookup helpers |
+    | `plugin-sdk/fetch-runtime` | Private-local after July 2026; Wrapped fetch, proxy, EnvHttpProxyAgent option, and pinned lookup helpers. `responseWithRelease` takes a release owner: `transport` can abort retained capture branches during cancellation; `after-body` keeps deadlines and abort listeners active until cancellation settles. |
     | `plugin-sdk/proxy-capture` | Debug proxy capture configuration, SQLite-backed capture storage, HTTP/WebSocket capture events, and capture lifecycle helpers |
     | `plugin-sdk/runtime-fetch` | Private-local after July 2026; Dispatcher-aware runtime fetch without proxy/guarded-fetch imports |
     | `plugin-sdk/inline-image-data-url-runtime` | Private-local after July 2026; Inline image data URL sanitizer and signature sniffing helpers without the broad media runtime surface |

--- a/extensions/mattermost/src/mattermost/client.fetch-timeout.test.ts
+++ b/extensions/mattermost/src/mattermost/client.fetch-timeout.test.ts
@@ -1,6 +1,8 @@
+import { setImmediate as nextTurn } from "node:timers/promises";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 // Mattermost tests cover real REST client timeout behavior.
 import { withServer } from "openclaw/plugin-sdk/test-env";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   createMattermostClient,
   createMattermostDirectChannelWithRetry,
@@ -68,6 +70,85 @@ async function withHangingMattermostServer(
 }
 
 describe("Mattermost REST client fetch timeout", () => {
+  it("closes an abandoned guarded response before its request deadline", async () => {
+    const closed = createDeferred<void>();
+    const parent = new AbortController();
+    let cancellation: Promise<void> | undefined;
+    try {
+      await withServer(
+        (request, response) => {
+          request.socket.once("close", () => closed.resolve());
+          response.write("unfinished");
+        },
+        async (baseUrl) => {
+          const client = createMattermostClient({
+            baseUrl,
+            botToken: "bot-token",
+            allowPrivateNetwork: true,
+            timeoutMs: 5_000,
+          });
+          const response = await client.fetchImpl(`${client.apiBaseUrl}/users/me`, {
+            signal: parent.signal,
+          });
+          const reader = response.body?.getReader();
+          if (!reader) {
+            throw new Error("expected response body");
+          }
+          try {
+            expect((await reader.read()).value?.byteLength).toBeGreaterThan(0);
+            cancellation = reader.cancel(new Error("consumer stopped"));
+            expect(await settleWithin(Promise.all([cancellation, closed.promise]), 1_000)).toEqual({
+              status: "resolved",
+            });
+            expect(parent.signal.aborted).toBe(false);
+          } finally {
+            reader.releaseLock();
+          }
+        },
+      );
+    } finally {
+      await cancellation;
+    }
+  });
+
+  it.each(["timeout", "caller"] as const)(
+    "keeps custom-fetch %s active during held cancellation",
+    async (source) => {
+      vi.useFakeTimers();
+      const cancelGate = createDeferred<void>();
+      const parent = new AbortController();
+      let observedSignal: AbortSignal | undefined;
+      const client = createMattermostClient({
+        baseUrl: "https://mattermost.example",
+        botToken: "bot-token",
+        timeoutMs: 50,
+        fetchImpl: async (_input, init) => {
+          observedSignal = init?.signal ?? undefined;
+          return new Response(new ReadableStream({ cancel: () => cancelGate.promise }));
+        },
+      });
+      const response = await client.fetchImpl(`${client.apiBaseUrl}/users/me`, {
+        signal: parent.signal,
+      });
+      const cancellation = response.body?.cancel();
+      try {
+        await nextTurn();
+        expect(observedSignal?.aborted).toBe(false);
+        if (source === "timeout") {
+          await vi.advanceTimersByTimeAsync(50);
+        } else {
+          parent.abort(new Error("caller stopped"));
+        }
+        expect(observedSignal?.aborted).toBe(true);
+      } finally {
+        cancelGate.resolve();
+        await cancellation;
+        expect(vi.getTimerCount()).toBe(0);
+        vi.useRealTimers();
+      }
+    },
+  );
+
   it("rejects a hanging real loopback request at the configured client timeout", async () => {
     await withHangingMattermostServer(async (server) => {
       const client = createMattermostClient({

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -199,7 +199,7 @@ export function createMattermostClient(params: {
       signal: requestInit.signal ?? undefined,
       timeoutMs,
     });
-    return responseWithRelease(response, release);
+    return responseWithRelease(response, { kind: "transport", release });
   };
 
   const timedExternalFetchImpl:
@@ -224,7 +224,7 @@ export function createMattermostClient(params: {
           const response = await externalFetchImpl(input, { ...requestInit, signal });
           // Match guarded production fetches: retain cancellation and the
           // request deadline until the custom response body is consumed.
-          return responseWithRelease(response, async () => cleanup());
+          return responseWithRelease(response, { kind: "after-body", release: cleanup });
         } catch (error) {
           cleanup();
           throw error;

--- a/extensions/msteams/src/attachments/shared.ts
+++ b/extensions/msteams/src/attachments/shared.ts
@@ -669,7 +669,7 @@ async function safeFetch(params: {
       auditContext: "msteams.attachment",
       timeoutMs: params.timeoutMs ?? MSTEAMS_REQUEST_TIMEOUT_MS,
     });
-    return responseWithRelease(guarded.response, guarded.release);
+    return responseWithRelease(guarded.response, { kind: "transport", release: guarded.release });
   }
 
   try {

--- a/extensions/msteams/src/graph.test.ts
+++ b/extensions/msteams/src/graph.test.ts
@@ -1,4 +1,5 @@
 // Msteams tests cover graph plugin behavior.
+import { setImmediate as nextTurn } from "node:timers/promises";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
@@ -432,31 +433,56 @@ describe("msteams graph helpers", () => {
     );
   });
 
-  it("releases a successful bodyful DELETE response", async () => {
-    const upstreamCancel = vi.fn();
-    const release = vi.fn(async () => undefined);
-    const response = new Response(
-      new ReadableStream<Uint8Array>({
-        start(controller) {
-          controller.enqueue(new TextEncoder().encode("deleted"));
-        },
-        cancel: upstreamCancel,
-      }),
-    );
-    fetchWithSsrFGuardMock.mockResolvedValueOnce({
-      response,
-      finalUrl: "https://graph.microsoft.com/v1.0/chats/chat-1/messages/msg-1",
-      release,
-    });
+  it.each([false, true])(
+    "releases a successful bodyful DELETE response (capture=%s)",
+    async (capture) => {
+      const upstreamCancel = vi.fn();
+      let stopSource = () => {};
+      const release = vi.fn(async () => {
+        stopSource();
+        return undefined;
+      });
+      const response = new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("deleted"));
+            stopSource = () => controller.error(new Error("request released"));
+          },
+          cancel: upstreamCancel,
+        }),
+      );
+      const captured = capture
+        ? response
+            .clone()
+            .arrayBuffer()
+            .catch(() => undefined)
+        : undefined;
+      fetchWithSsrFGuardMock.mockResolvedValueOnce({
+        response,
+        finalUrl: "https://graph.microsoft.com/v1.0/chats/chat-1/messages/msg-1",
+        release,
+      });
 
-    await deleteGraphRequest({
-      token: graphToken,
-      path: "/chats/chat-1/messages/msg-1",
-    });
+      const deletion = deleteGraphRequest({
+        token: graphToken,
+        path: "/chats/chat-1/messages/msg-1",
+      });
 
-    expect(upstreamCancel).toHaveBeenCalledTimes(1);
-    expect(release).toHaveBeenCalledTimes(1);
-  });
+      try {
+        await nextTurn();
+        expect(release).toHaveBeenCalledTimes(1);
+        await deletion;
+        expect(response.body?.locked).toBe(false);
+        if (!capture) {
+          expect(upstreamCancel).toHaveBeenCalledTimes(1);
+        }
+      } finally {
+        stopSource();
+        await deletion;
+        await captured;
+      }
+    },
+  );
 
   it("resolves Graph tokens through the SDK auth provider", async () => {
     const { getAccessToken } = mockGraphTokenResolution();

--- a/extensions/msteams/src/graph.ts
+++ b/extensions/msteams/src/graph.ts
@@ -81,7 +81,7 @@ async function requestGraph(params: {
       );
     }
     releaseInFinally = false;
-    return responseWithRelease(response, release);
+    return responseWithRelease(response, { kind: "transport", release });
   } finally {
     if (releaseInFinally) {
       await release();

--- a/extensions/telegram/src/bot.fetch-abort.test.ts
+++ b/extensions/telegram/src/bot.fetch-abort.test.ts
@@ -1,5 +1,7 @@
 // Telegram tests cover bot.fetch abort plugin behavior.
+import { setImmediate as nextTurn } from "node:timers/promises";
 import { toErrorObject as toLintErrorObject } from "openclaw/plugin-sdk/error-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { describe, expect, it, vi } from "vitest";
 import { isTelegramPollingNetworkError, TelegramRequestNotStartedError } from "./network-errors.js";
 
@@ -73,51 +75,73 @@ describe("createTelegramBot fetch abort", () => {
     expect(observedSignal.aborted).toBe(true);
   });
 
-  it("keeps the getChat deadline active until its response body settles", async () => {
-    vi.useFakeTimers();
-    let observedSignal: AbortSignal | undefined;
-    let bodyController: ReadableStreamDefaultController<Uint8Array> | undefined;
-    const fetchSpy = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
-      observedSignal = init?.signal ?? undefined;
-      return new Response(
-        new ReadableStream<Uint8Array>({
-          start(controller) {
-            bodyController = controller;
-            observedSignal?.addEventListener(
-              "abort",
-              () => controller.error(observedSignal?.reason),
-              { once: true },
-            );
-          },
-        }),
-        { headers: { "content-type": "application/json" }, status: 200 },
-      );
-    });
-    const { clientFetch } = createWrappedTelegramClientFetch(fetchSpy as typeof fetch);
+  it.each(["read", "cancel"] as const)(
+    "keeps the getChat deadline active during body %s",
+    async (phase) => {
+      vi.useFakeTimers();
+      const cancelGate = createDeferred<void>();
+      let observedSignal: AbortSignal | undefined;
+      let bodyController: ReadableStreamDefaultController<Uint8Array> | undefined;
+      const fetchSpy = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        observedSignal = init?.signal ?? undefined;
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              bodyController = controller;
+              observedSignal?.addEventListener(
+                "abort",
+                () => controller.error(observedSignal?.reason),
+                { once: true },
+              );
+            },
+            cancel: () => cancelGate.promise,
+          }),
+          { headers: { "content-type": "application/json" }, status: 200 },
+        );
+      });
+      const { clientFetch } = createWrappedTelegramClientFetch(fetchSpy as typeof fetch);
 
-    const response = (await clientFetch(
-      "https://api.telegram.org/bot123456:ABC/getChat",
-    )) as Response;
-    const body = response.json();
-    void body.catch(() => undefined);
+      const response = (await clientFetch(
+        "https://api.telegram.org/bot123456:ABC/getChat",
+      )) as Response;
+      let settled = false;
+      const body = (phase === "read" ? response.json() : response.body!.cancel()).finally(() => {
+        settled = true;
+      });
+      void body.catch(() => undefined);
 
-    try {
-      await vi.advanceTimersByTimeAsync(15_000);
+      try {
+        await nextTurn();
+        await vi.advanceTimersByTimeAsync(15_000);
 
-      expect(observedSignal?.aborted).toBe(true);
-      await expect(body).rejects.toThrow("Telegram getchat timed out after 15000ms");
-    } finally {
-      if (!observedSignal?.aborted) {
-        bodyController?.error(new Error("test cleanup"));
+        expect(observedSignal?.aborted).toBe(true);
+        expect(observedSignal?.reason).toEqual(
+          new Error("Telegram getchat timed out after 15000ms"),
+        );
+        if (phase === "read") {
+          await expect(body).rejects.toThrow("Telegram getchat timed out after 15000ms");
+        } else {
+          expect(settled).toBe(false);
+        }
+      } finally {
+        if (!observedSignal?.aborted) {
+          bodyController?.error(new Error("test cleanup"));
+        }
+        cancelGate.resolve();
+        await body.catch(() => undefined);
+        vi.useRealTimers();
       }
-      await body.catch(() => undefined);
-      vi.useRealTimers();
-    }
-  });
+    },
+  );
 
-  it.each(["shutdown", "request"] as const)(
-    "keeps %s cancellation attached while a response body is being read",
-    async (cancellationSource) => {
+  it.each(
+    (["shutdown", "request"] as const).flatMap((cancellationSource) =>
+      (["read", "cancel"] as const).map((phase) => ({ cancellationSource, phase })),
+    ),
+  )(
+    "keeps $cancellationSource attached during body $phase",
+    async ({ cancellationSource, phase }) => {
+      const cancelGate = createDeferred<void>();
       let observedSignal: AbortSignal | undefined;
       const fetchSpy = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
         observedSignal = init?.signal ?? undefined;
@@ -130,6 +154,7 @@ describe("createTelegramBot fetch abort", () => {
                 { once: true },
               );
             },
+            cancel: () => cancelGate.promise,
           }),
         );
       });
@@ -138,14 +163,29 @@ describe("createTelegramBot fetch abort", () => {
       const response = (await clientFetch("https://api.telegram.org/bot123456:ABC/getChat", {
         signal: request.signal,
       })) as Response;
-      const body = response.text();
+      let settled = false;
+      const body = (phase === "read" ? response.text() : response.body!.cancel()).finally(() => {
+        settled = true;
+      });
       void body.catch(() => undefined);
 
-      const cancellation = cancellationSource === "shutdown" ? shutdown : request;
-      cancellation.abort(new Error(`${cancellationSource} cancelled`));
+      try {
+        await nextTurn();
+        const cancellation = cancellationSource === "shutdown" ? shutdown : request;
+        const reason = new Error(`${cancellationSource} cancelled`);
+        cancellation.abort(reason);
 
-      expect(observedSignal?.aborted).toBe(true);
-      await expect(body).rejects.toThrow(`${cancellationSource} cancelled`);
+        expect(observedSignal?.reason).toBe(reason);
+        if (phase === "read") {
+          await expect(body).rejects.toBe(reason);
+        } else {
+          expect(settled).toBe(false);
+        }
+      } finally {
+        cancelGate.resolve();
+        shutdown.abort();
+        await body.catch(() => undefined);
+      }
     },
   );
 

--- a/extensions/telegram/src/client-fetch.ts
+++ b/extensions/telegram/src/client-fetch.ts
@@ -213,7 +213,7 @@ export function createTelegramClientFetch(params: {
         }
         // grammY consumes JSON after fetch resolves; keep its deadline and
         // cancellation linked until the response body settles.
-        return responseWithRelease(response, releaseRequest);
+        return responseWithRelease(response, { kind: "after-body", release: releaseRequest });
       } catch (err) {
         await releaseRequest();
         if (requestTimedOut && timeoutError) {

--- a/src/infra/net/fetch-guard.release.test.ts
+++ b/src/infra/net/fetch-guard.release.test.ts
@@ -1,6 +1,7 @@
 import type { ServerResponse } from "node:http";
 import type { Dispatcher } from "undici";
 import { describe, expect, it } from "vitest";
+import { responseWithRelease } from "../../plugin-sdk/fetch-runtime.js";
 import { createBoundedProviderBinaryStream } from "../../plugin-sdk/provider-binary-stream.js";
 import { withServer } from "../../plugin-sdk/test-helpers/http-test-server.js";
 import { captureHttpExchange } from "../../proxy-capture/runtime.js";
@@ -27,7 +28,7 @@ async function withinDeadline<T>(operation: Promise<T>): Promise<T> {
 }
 
 describe("guarded request release", () => {
-  it.each(["unread", "prefix", "overflow", "wrapped", "binary"] as const)(
+  it.each(["unread", "prefix", "overflow", "wrapped", "response", "binary"] as const)(
     "ends only the %s request while a captured sibling keeps its pooled transport",
     async (readerKind) => {
       const abandonedClosed = createDeferredCore();
@@ -111,11 +112,17 @@ describe("guarded request release", () => {
 
             abandonedOperation = (async () => {
               const reason = new Error("body limit reached");
-              if (readerKind === "wrapped") {
-                const wrapped = wrapGuardedBodyStream({
-                  body: abandoned.response.body!,
-                  cleanup: abandoned.release,
-                });
+              if (readerKind === "wrapped" || readerKind === "response") {
+                const wrapped =
+                  readerKind === "response"
+                    ? responseWithRelease(abandoned.response, {
+                        kind: "transport",
+                        release: abandoned.release,
+                      }).body!
+                    : wrapGuardedBodyStream({
+                        body: abandoned.response.body!,
+                        cleanup: abandoned.release,
+                      });
                 const reader = wrapped.getReader();
                 try {
                   expect((await reader.read()).value?.byteLength).toBeGreaterThan(0);

--- a/src/plugin-sdk/fetch-runtime.test.ts
+++ b/src/plugin-sdk/fetch-runtime.test.ts
@@ -2,6 +2,7 @@
  * Tests plugin SDK fetch runtime helpers and fixture path behavior.
  */
 import path from "node:path";
+import { setImmediate as nextTurn } from "node:timers/promises";
 import { pathToFileURL } from "node:url";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
@@ -42,14 +43,17 @@ describe("plugin SDK fetch runtime", () => {
     expect(importProbeOutput.trim()).toBe("ok");
   });
 
-  it.each([204, 205, 304])(
+  it.each([200, 204, 205, 304])(
     "returns the original response for null-body status %s",
     async (status) => {
       const response = new Response(null, { status });
       let releaseCount = 0;
 
-      const wrapped = responseWithRelease(response, async () => {
-        releaseCount += 1;
+      const wrapped = responseWithRelease(response, {
+        kind: "transport",
+        release: async () => {
+          releaseCount += 1;
+        },
       });
 
       expect(wrapped).toBe(response);
@@ -57,68 +61,204 @@ describe("plugin SDK fetch runtime", () => {
     },
   );
 
-  it("closes downstream EOF before awaiting release", async () => {
-    const releaseGate = createDeferred();
-    const releaseFinished = createDeferred();
-    const wrapped = responseWithRelease(new Response("complete"), async () => {
-      await releaseGate.promise;
-      releaseFinished.resolve();
+  it("observes null-body cleanup rejection without replacing the response", async () => {
+    const response = new Response(null);
+    const release = vi.fn(async () => {
+      throw new Error("cleanup failed");
     });
-    const reader = wrapped.body?.getReader();
-    if (!reader) {
-      throw new Error("expected wrapped response body");
-    }
-
-    await expect(reader.read()).resolves.toMatchObject({ done: false });
-    const eof = reader.read();
-    let eofSettled = false;
-    void eof.then(() => {
-      eofSettled = true;
-    });
-    await new Promise<void>((resolve) => {
-      setImmediate(resolve);
-    });
-
-    expect(eofSettled).toBe(true);
-    await expect(eof).resolves.toEqual({ done: true, value: undefined });
-    releaseGate.resolve();
-    await releaseFinished.promise;
+    expect(responseWithRelease(response, { kind: "transport", release })).toBe(response);
+    await nextTurn();
+    expect(release).toHaveBeenCalledOnce();
   });
 
-  it("awaits upstream cancellation before release", async () => {
-    const pullStarted = createDeferred();
-    const cancelGate = createDeferred();
-    const release = vi.fn(async () => {});
-    const reason = new Error("consumer stopped");
-    const upstreamCancel = vi.fn(async () => {
-      await cancelGate.promise;
-    });
+  it.each(["transport", "after-body"] as const)(
+    "exposes EOF before %s cleanup settles",
+    async (kind) => {
+      const releaseGate = createDeferred();
+      const releaseFinished = createDeferred();
+      const release = vi.fn(async () => {
+        await releaseGate.promise;
+        releaseFinished.resolve();
+      });
+      const response = new Response("complete", {
+        status: 201,
+        statusText: "Created",
+        headers: { "x-fixture": "preserved" },
+      });
+      const wrapped = responseWithRelease(response, { kind, release });
+      const reader = wrapped.body?.getReader();
+      if (!reader) {
+        throw new Error("expected wrapped response body");
+      }
+
+      await expect(reader.read()).resolves.toEqual({
+        done: false,
+        value: new TextEncoder().encode("complete"),
+      });
+      const eof = reader.read();
+      let eofSettled = false;
+      void eof.then(() => {
+        eofSettled = true;
+      });
+      await nextTurn();
+
+      expect(eofSettled).toBe(true);
+      expect(response.body?.locked).toBe(false);
+      expect(wrapped.status).toBe(201);
+      expect(wrapped.statusText).toBe("Created");
+      expect(wrapped.headers.get("x-fixture")).toBe("preserved");
+      expect(release).toHaveBeenCalledOnce();
+      await expect(eof).resolves.toEqual({ done: true, value: undefined });
+      releaseGate.resolve();
+      await releaseFinished.promise;
+      reader.releaseLock();
+    },
+  );
+
+  it.each(
+    (["transport", "after-body"] as const).flatMap((kind) =>
+      [false, true].flatMap((releaseFails) =>
+        [false, true].map((cancelFails) => ({ kind, releaseFails, cancelFails })),
+      ),
+    ),
+  )(
+    "joins held $kind cancellation (releaseFails=$releaseFails, cancelFails=$cancelFails)",
+    async ({ kind, releaseFails, cancelFails }) => {
+      const pullStarted = createDeferred();
+      const cancelGate = createDeferred();
+      const releaseGate = createDeferred();
+      const releaseError = new Error("cleanup failed");
+      const release = vi.fn(async () => {
+        if (releaseFails) {
+          throw releaseError;
+        }
+        await releaseGate.promise;
+      });
+      const reason = new Error("consumer stopped");
+      const upstreamCancel = vi.fn(async () => {
+        await cancelGate.promise;
+        if (cancelFails) {
+          throw new Error("source cancellation failed");
+        }
+      });
+      const response = new Response(
+        new ReadableStream<Uint8Array>({
+          pull() {
+            pullStarted.resolve();
+          },
+          cancel: upstreamCancel,
+        }),
+      );
+      const wrapped = responseWithRelease(response, { kind, release });
+      const reader = wrapped.body?.getReader();
+      if (!reader) {
+        throw new Error("expected wrapped response body");
+      }
+      const read = reader.read();
+      await pullStarted.promise;
+
+      let settled = false;
+      const cancellation = reader
+        .cancel(reason)
+        .then(
+          () => undefined,
+          (error: unknown) => error,
+        )
+        .finally(() => {
+          settled = true;
+        });
+      try {
+        await nextTurn();
+        expect(upstreamCancel).toHaveBeenCalledWith(reason);
+        expect(release).toHaveBeenCalledTimes(kind === "transport" ? 1 : 0);
+        expect(settled).toBe(false);
+        expect(response.body?.locked).toBe(false);
+        await expect(read).resolves.toEqual({ done: true, value: undefined });
+        cancelGate.resolve();
+        await nextTurn();
+        expect(release).toHaveBeenCalledOnce();
+        expect(settled).toBe(releaseFails);
+        releaseGate.resolve();
+        expect(await cancellation).toBe(releaseFails ? releaseError : undefined);
+        await reader.cancel("already closed");
+        expect(release).toHaveBeenCalledOnce();
+      } finally {
+        cancelGate.resolve();
+        releaseGate.resolve();
+        await cancellation;
+        reader.releaseLock();
+      }
+    },
+  );
+
+  it.each([false, true])(
+    "preserves read-error precedence (releaseFails=%s)",
+    async (releaseFails) => {
+      const sourceError = new Error("source failed");
+      const releaseError = new Error("cleanup failed");
+      const release = vi.fn(() => {
+        if (releaseFails) {
+          throw releaseError;
+        }
+      });
+      const response = new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.error(sourceError);
+          },
+        }),
+      );
+      const wrapped = responseWithRelease(response, { kind: "transport", release });
+      await expect(wrapped.text()).rejects.toBe(releaseFails ? releaseError : sourceError);
+      expect(response.body?.locked).toBe(false);
+      expect(release).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("releases a captured transport without waiting for the retained clone", async () => {
+    const releaseGate = createDeferred();
+    const sourceController = createDeferred<ReadableStreamDefaultController<Uint8Array>>();
     const response = new Response(
       new ReadableStream<Uint8Array>({
-        pull() {
-          pullStarted.resolve();
+        start(controller) {
+          sourceController.resolve(controller);
+          controller.enqueue(new TextEncoder().encode("prefix"));
         },
-        cancel: upstreamCancel,
       }),
     );
-    const wrapped = responseWithRelease(response, release);
+    const upstreamController = await sourceController.promise;
+    const captured = response
+      .clone()
+      .arrayBuffer()
+      .catch(() => undefined);
+    const release = vi.fn(async () => {
+      upstreamController.error(new Error("request transport released"));
+      await releaseGate.promise;
+    });
+    const wrapped = responseWithRelease(response, { kind: "transport", release });
     const reader = wrapped.body?.getReader();
     if (!reader) {
       throw new Error("expected wrapped response body");
     }
-    const read = reader.read();
-    await pullStarted.promise;
-
-    const cancellation = reader.cancel(reason);
-    await new Promise<void>((resolve) => {
-      setImmediate(resolve);
+    await expect(reader.read()).resolves.toMatchObject({ done: false });
+    let settled = false;
+    const cancellation = reader.cancel("consumer stopped").finally(() => {
+      settled = true;
     });
-    expect(upstreamCancel).toHaveBeenCalledWith(reason);
-    expect(release).not.toHaveBeenCalled();
-
-    cancelGate.resolve();
-    await cancellation;
-    await expect(read).resolves.toEqual({ done: true, value: undefined });
-    expect(release).toHaveBeenCalledTimes(1);
+    try {
+      await nextTurn();
+      expect(release).toHaveBeenCalledOnce();
+      expect(settled).toBe(false);
+      expect(response.body?.locked).toBe(false);
+      releaseGate.resolve();
+      await cancellation;
+      await expect(reader.read()).resolves.toEqual({ done: true, value: undefined });
+    } finally {
+      upstreamController.error(new Error("test cleanup"));
+      releaseGate.resolve();
+      await cancellation;
+      await captured;
+      reader.releaseLock();
+    }
   });
 });

--- a/src/plugin-sdk/fetch-runtime.ts
+++ b/src/plugin-sdk/fetch-runtime.ts
@@ -26,62 +26,62 @@ export { createPinnedLookup } from "../infra/net/ssrf.js";
 export type { PinnedDispatcherPolicy } from "../infra/net/ssrf.js";
 export { withTrustedEnvProxyGuardedFetchMode } from "../infra/net/fetch-guard.js";
 
-const NULL_BODY_STATUSES = new Set([101, 103, 204, 205, 304]);
-
-export function responseWithRelease(response: Response, release: () => Promise<void>): Response {
-  let released = false;
-  // Upstream cancellation closes pending reads before its async cleanup settles.
-  // Coordinate both paths so neither can release the transport early.
-  let canceling: Promise<void> | undefined;
-  const releaseOnce = async () => {
-    if (released) {
-      return;
-    }
-    released = true;
-    await release();
-  };
-
-  if (!response.body || NULL_BODY_STATUSES.has(response.status)) {
-    void releaseOnce();
+export function responseWithRelease(
+  response: Response,
+  owner: { kind: "transport" | "after-body"; release: () => Promise<void> | void },
+): Response {
+  if (!response.body) {
+    void Promise.resolve()
+      .then(owner.release)
+      .catch(() => undefined);
     return response;
   }
 
   const reader = response.body.getReader();
+  let completion: Promise<void> | undefined;
+  // Publish completion before callbacks: cancellation closes pending reads
+  // before its underlying cleanup settles, so pull must join the same work.
+  const finalize = (cancel?: () => Promise<void>) =>
+    (completion ??= Promise.resolve().then(async () => {
+      const cancellation = cancel?.().catch(() => undefined);
+      reader.releaseLock();
+      const cleanup = (async () => {
+        // Transport release aborts retained capture tees; deadline/listener
+        // cleanup must instead stay armed until body cancellation settles.
+        if (owner.kind === "after-body") {
+          await cancellation;
+        }
+        await owner.release();
+      })();
+      const [, released] = await Promise.allSettled([cancellation, cleanup]);
+      if (released.status === "rejected") {
+        throw released.reason;
+      }
+    }));
   const body = new ReadableStream<Uint8Array>({
     async pull(controller) {
       try {
         const next = await reader.read();
-        if (canceling) {
-          await canceling;
-          await releaseOnce();
+        if (completion) {
+          return await completion;
+        }
+        if (!next.done) {
+          controller.enqueue(next.value);
           return;
         }
-        if (next.done) {
-          controller.close();
-          await releaseOnce();
-          return;
-        }
-        controller.enqueue(next.value);
+        controller.close();
       } catch (error) {
-        if (canceling) {
-          await canceling;
-          await releaseOnce();
-          return;
+        if (!completion) {
+          await finalize();
+          throw error;
         }
-        await releaseOnce();
-        throw error;
       }
+      await finalize();
     },
-    async cancel(reason) {
-      canceling = reader.cancel(reason).catch(() => undefined);
-      await canceling;
-      await releaseOnce();
+    cancel(reason) {
+      return finalize(() => reader.cancel(reason));
     },
   });
 
-  return new Response(body, {
-    status: response.status,
-    statusText: response.statusText,
-    headers: response.headers,
-  });
+  return new Response(body, response);
 }


### PR DESCRIPTION
Closes #131278

AI-assisted implementation and validation.

## What Problem This Solves

Fixes an issue where cancelling a Mattermost or Microsoft Teams response can remain pending until a request/capture deadline when HTTP debug capture retains another branch of the response body. The reproduced request keeps its socket and reader alive after the consumer asks to cancel. Normal EOF remains a passing control; this is delayed cleanup, not an unbounded hang or data-loss claim.

## Why This Change Was Made

The shared response wrapper used one cancellation-before-release order for two different owners. A guarded transport must be released while cancellation is pending, because that release terminates the retained capture branch. A deadline/listener owner must instead remain armed until cancellation finishes. Releasing every callback early would regress Telegram and custom Mattermost fetches.

The repair makes that distinction explicit in the private-local fetch helper and gives cancellation, EOF and read failure one memoized completion owner. It removes the separate release/cancellation bookkeeping and redundant null-status table, updates every production caller, and preserves cleanup-error precedence while waiting for both cancellation and cleanup. There is no new operator setting, dependency, compatibility overload or public SDK export.

Production LOC: **+46/-46 (net 0)** across five files. Tests: **+422/-128** across five files. Documentation: **+1/-1**.

Provenance: the shared ordering was introduced by #117855, merged August 2, 2026 at `ac28f4d558e5f2b1fc45fab4849dac8b157279f1` (code author, PR author and merger: @steipete). This preserves the later bounded-capture contract from #119706 and Telegram's response-body deadline contract from #118144.

## User Impact

Explicit cancellation releases the affected request without cancelling the parent or a sibling request. Telegram and custom-fetch deadlines continue to cover body cancellation. Successful response payloads and status metadata are preserved.

## Evidence

Before/after proof uses the actual Mattermost guarded client, pinned Undici 8.10.0, a loopback TCP server and the real HTTP-capture path with an in-memory sink. On baseline `6ac108f5633ef989809664d1742750da0ec535a8`, captured cancellation was still pending after 1003 ms, with the socket open, request signal live and source reader locked. With this repair, the unchanged probe completed captured cancellation and socket release in 11 ms, before fixture teardown; the parent remained live and the source reader was unlocked. EOF retained the complete eight-byte payload. Those timings are observations, not performance guarantees. This is real local transport proof, not an authenticated Mattermost or Teams deployment.

The retained regression tests cover native stream/clone cancellation, delayed and rejected cleanup, read-error precedence, null-body identity, guarded captured TCP/pool ownership, Graph DELETE response disposal, and Telegram/custom-Mattermost caller/deadline cancellation. They introduce no test-only production seam. The owner and Graph regressions failed against the baseline before the repair.

- Focused owner and sibling suite: 193 passing tests across nine files on Node 26.7.0.
- Node 24.19.0 compatibility: 30 passing shared-helper/guard tests.
- After correcting four test fixtures to use the existing `createDeferred` helper instead of a Promise API absent from the test TypeScript library: plugin test typecheck passed, then all 29 affected Mattermost/Telegram tests passed again. No compiler configuration was broadened.
- Fresh Codex autoreview returned no findings at its configured P0 threshold. A separate independent owner/dependency-contract review also found no actionable correctness issue; the automated threshold is not an all-priority review claim.

The normal build completed all compilation, 64 external-plugin builds, bootstrap/import guards, runtime postbuild, all 147 SDK subpaths and UI/performance checks, then failed at the final CLI startup metadata stage (`nodes --help` exceeded its unchanged 120-second deadline). After isolated diagnosis, the exact final stage passed with normal concurrency and the same deadline; generated root, nodes, browser, secrets and all seven subcommand help records were inspected. This is a recovered final stage, not a claim that the original build exited successfully. No source change, timeout increase, skipped build phase or synthetic metadata was used.

The full unchanged changed-file gate passed after the dependency-layout recovery described below, serialized with build/install work. This includes full SDK declaration preparation, all core/plugin production and test type checks, both targeted lint lanes, three clean Knip scans, doctor contracts, and the storage, import-cycle, webhook and pairing guards. Both affected doctor-contract files also passed separately (five tests) immediately after restoring the pinned dependencies.

### Current-main composition

The repair is now rebased to `17bcc4c66023d45c5699eb2e3587e1e2767b042c` on `6d2644a7019d4710007b1452312e9e91f2aa2871`, consuming the landed watcher-handoff prerequisite #131515. All eleven changed-file blobs, stable patch ID, and range-diff are identical to the original repair. The rebase had no conflicts and changed no dependency version or lockfile.

The rebased candidate passed **264 tests across nine files**: guarded TCP release, shared helper, Mattermost client/deadlines, Telegram fetch/abort, and Teams Graph/deadlines/attachment disposal. Fresh isolated Codex autoreview reported no actionable findings at its configured P0 threshold. Exact-head [CI33146415693](https://github.com/openclaw/openclaw/actions/runs/33146415693) passed, with all 188 jobs terminal and the required `openclaw/ci-gate` successful. The new native Telegram proof below remains incomplete; this is not a merge-ready claim.

Direct dependency inspection supplements the earlier review's missing dependency-tree access: pinned Undici 8.10.0 `lib/web/fetch/body.js:277-296` tees cloned bodies; `lib/web/fetch/index.js:106-151,2025-2066` aborts the exact request controller/connection; `lib/dispatcher/dispatcher-base.js:59-161` distinguishes graceful close from destroy. Node 26.7.0's actual built-in byte-tee cancellation at `internal/webstreams/readablestream:2183-2198` returns a shared deferred until both branches cancel. The Gateway's per-hop release aborts that request before returning its pool lease, while the wrapper preserves after-body deadline ownership. This is source evidence plus the recorded TCP reproduction, not a new authenticated channel run.

**Historical failed gate retained:** [CI run 33136377200](https://github.com/openclaw/openclaw/actions/runs/33136377200) failed twice in QA Smoke CI part 5 during memory-dreaming config restoration. Both attempts tested merge `aa7c018beb277ae1b5a61e783edb6364c0199b36` against main `6f59c0a3fe5794706e24f5bcfd7711e2851ef02b`, already containing #131180. The logs record a canceled config reload and unsuccessful application receipt, but not its exact watcher/epoch trigger. #131515 independently reproduced and repaired the pre-commit watcher handoff on main. The newly rebased head's CI now passes; no retry or old evidence is relabeled as success, and this does not retroactively establish the missing watcher trace. The remaining post-commit completion work in #131545 is a separate repair.

### New native Telegram proof: blocked, not a regression verdict

[Mantis33146448999](https://github.com/openclaw/openclaw/actions/runs/33146448999) built baseline `d535a526a930df7511ad6eaaa0dfb0782903c8fd` and synthetic candidate `799950aa7eb490971a8d78647d4466bdf236e3ad` (parents that baseline and PR head `17bcc4c`). Both lanes recorded native user turns but no bot/provider response; repeated `getUpdates` calls completed successfully without delivering those turns. The intended status/streaming differential therefore could not be established. A diagnostic chat lookup returned HTTP403 without preserving the service's explanation, so the exact fixture/access cause is still under investigation. This is not evidence that the response-release change regressed Telegram.

The agent reported `blocked`, but the subsequent collector rejected its overlong `scenario` field. No trusted artifact bundle was uploaded. The workflow cleanup and private-state removal completed, and the credential broker returned an actual successful release acknowledgment; these do not fill every missing per-process observation. The historical successful Telegram run below remains separate evidence.

Named follow-ups: **Mantis producer/collector report-contract mismatch and failed-collection artifact retention** (the prompt omits the validator's text bounds and the runner checks only file existence), and **shared native Telegram proof-fixture ingress readiness**. The exact collector supports advisory preflight against mirrored terminal facts/media; that will be used without weakening trusted post-fence collection. Neither a blocked fixture nor a shorter report is a passing channel proof.

The follow-up [diagnostic33148778412](https://github.com/openclaw/openclaw/actions/runs/33148778412) established the current fixture blocker directly. Exact baseline `b0d40bf63651e9e7ae27201251fcb6992849994d` and synthetic candidate `9cec771c582ebf7ac04735e2ba79ea8708e192ed` both authenticated successfully with `getMe`, but `getChat` and `getChatMember` returned the actual service description: `Forbidden: bot is not a member of the supergroup chat`. The membership query used the real `getMe` bot identity; both lanes had the same configured-target digest and allowlist entry. Every recorded Bot API request was non-injected. No proof turn was sent and no provider request occurred, so this is a shared fixture-membership blocker, not candidate equivalence or a regression verdict.

This diagnostic produced a valid bounded blocked report, passed trusted collection, uploaded [artifact9677056253](https://github.com/openclaw/openclaw/actions/runs/33148778412/artifacts/9677056253), and [published its result](https://github.com/openclaw/openclaw/pull/131433#issuecomment-5449327121). Both lane cleanup-error arrays are empty; workflow cleanup/private-state removal succeeded, and the broker returned an actual successful lease-release acknowledgment. The workflow correctly failed its final behavior gate because the outcome was blocked. No membership, role, or permission changes were made, and the supported controls expose no membership-provisioning command. Native non-regression proof remains required after the QA fixture owner restores the configured bot's membership; this PR remains open and unmerged. The prior collection failure is retained separately, not relabeled as fixed product behavior.

[Real Telegram QA run 33136377066](https://github.com/openclaw/openclaw/actions/runs/33136377066), attempt 1, passed both status and streaming scenarios against exact head `dc2323423f9f51616973c1fb81945e1e545f72dd`; its remote candidate build also passed. The status reply identified the candidate and the streaming result contained `QA-TELEGRAM-STREAM-SINGLE-OK`. This uses real Telegram transport with a mocked model, not live-provider, DM/forum, or authenticated Mattermost/Teams proof.

Evidence limitations are retained: the artifact exposes scenario reply details and the runner's one-final-message assertion, but not an independent raw message-count/edit history. Its screenshot is an HTML QA report, not a Telegram chat capture, so it is not attached as chat proof. The source-blind evidence validator passed the behavior checks but rejected evidence completeness because explicit bot-lease/observer/Gateway cleanup acknowledgments were absent. The desktop lease has an explicit release acknowledgment; code inspection separately confirms the suite awaits cleanup before publishing success, but that inference is not a substitute for the missing black-box receipts. No observed leak or product failure is inferred from the missing records.

<details>
<summary>Local validation commands</summary>

Run from the candidate checkout. The focused suite used Node 26.7.0; the compatibility recheck used Node 24.19.0.

```sh
env -u OPENCLAW_TESTBOX OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs \
  src/plugin-sdk/fetch-runtime.test.ts src/infra/net/fetch-guard.release.test.ts \
  extensions/mattermost/src/mattermost/client.fetch-timeout.test.ts \
  extensions/telegram/src/bot.fetch-abort.test.ts \
  extensions/telegram/src/bot.forum-ingress.response-body-timeout.integration.test.ts \
  extensions/msteams/src/graph.test.ts extensions/msteams/src/attachments/shared.test.ts \
  extensions/msteams/src/attachments/bot-framework.test.ts extensions/msteams/src/attachments/remote-media.test.ts

env -u OPENCLAW_TESTBOX OPENCLAW_VITEST_MAX_WORKERS=2 \
  OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-r13-node24-vitest-cache \
  /opt/homebrew/opt/node@24/bin/node scripts/run-vitest.mjs \
  src/plugin-sdk/fetch-runtime.test.ts src/infra/net/fetch-guard.release.test.ts

pnpm build
# Recovery of its failed final stage, after diagnosis:
TSX_DISABLE_CACHE=1 node --import tsx scripts/write-cli-startup-metadata.ts
```

The changed gate uses `node scripts/check-changed.mjs --base 6ac108f5633ef989809664d1742750da0ec535a8 --` with exactly the eleven changed files, two Vitest workers, and a fresh post-build task cache. Build, install restoration and the final changed gate are serialized.

</details>

Named tooling follow-up: **build-to-development dependency topology and Vitest transform invalidation**. The default build prunes plugin-local `node_modules` through `pruneBundledPluginSourceNodeModules`; Vitest's persistent cache still contains resolved paths into those removed directories because its integrity check sees the unchanged lockfile. Clearing only that cache is insufficient: the root `@noble/ciphers` instance is 2.1.1 while Reef's lockfile-owned instance is 2.3.0. pnpm 11.22's optimistic-repeat-install path also reports this layout current even with `--force`; its source checks that optimization before the force path. A per-command `--optimistic-repeat-install=false` frozen reinstall restored the missing packages, and the actual Reef-resolved `ciphers` and `curves` versions were verified as 2.3.0. This repair does not change build tooling, repository settings or dependency versions. The follow-up should reconcile the build/development dependency owner and cache invalidation, with a build-then-test regression at the pinned versions.

Resolved startup follow-up: **isolate meeting CLI metadata from realtime runtime imports**. Inspected main snapshot `9a7de4daa8102a77c1b4280a2bf4a4d55ec2177c` contains [#131719](https://github.com/openclaw/openclaw/pull/131719), merged as [60dcc53827489d833953da76d9010f8ddef6832b](https://github.com/openclaw/openclaw/commit/60dcc53827489d833953da76d9010f8ddef6832b). Teams and Zoom metadata now use their lightweight CLI-output owners instead of importing the broad meeting runtime; both public metadata tests reject a broad meeting-runtime import and preserve output-mode registration. This follow-up is source/ancestry-verified, not a fresh runtime benchmark or an independent review of the entire dependency PR. The historical trace and its limits remain recorded below; no duplicate repair is needed.

Historical startup finding: A fresh isolated built `nodes --help` trace spent 23.7 of 31.5 seconds loading Teams meeting CLI metadata through the broad `MeetingPlatformAdapter` runtime; Zoom shares that import graph. This is an observed import cost, not proof that it alone caused the earlier 120-second failures. Move shared descriptor/metadata construction to a focused lightweight owner, preserving both meeting output-mode behavior and discovery of external node-command augmenters. Do not narrow discovery to Canvas: the shipped SDK permits node-command registration without optional activation hints. This transport PR leaves that separate import boundary unchanged.
