### PR TITLE
fix(agents): guarded macOS file tools reject trusted workspace aliases

### DIFF
--- a/docs/gateway/permission-modes.md
+++ b/docs/gateway/permission-modes.md
@@ -24,6 +24,8 @@ A permission mode can be set on any session. When a session has a recorded `sess
 
 Managed worktree sessions use the worktree checkout as `sessionRoot`. A nested working directory remains the runtime `cwd`, so relative paths start there while filesystem containment covers the whole checkout.
 
+File tools recognize aliases of the session's trusted root and working directory, including absolute paths using those aliases. This does not expand the boundary: unrelated external symlinks pointing inward remain denied, as do symlinks and raw `symlink/..` traversal that escape the root. `read-only` sessions still omit mutation tools.
+
 A new managed worktree session defaults to `workspace` when no mode is specified. Other sessions with no recorded mode keep the existing config-driven behavior.
 
 ## Policy precedence and clamping

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -534,11 +534,6 @@ function normalizeReadResultDetails(
   return { ...result, details: { kind: "text", content: text } };
 }
 
-/** Wrap a file tool so path params stay inside the workspace root. */
-export function wrapToolWorkspaceRootGuard(tool: AnyAgentTool, root: string): AnyAgentTool {
-  return wrapToolWorkspaceRootGuardWithOptions(tool, root);
-}
-
 function mapContainerPathToWorkspaceRoot(params: {
   filePath: string;
   root: string;

--- a/src/agents/agent-tools.session-permissions.test.ts
+++ b/src/agents/agent-tools.session-permissions.test.ts
@@ -13,7 +13,246 @@ vi.mock("../infra/shell-env.js", async () => {
   return { ...mod, getShellPathFromLoginShell: () => null };
 });
 
+const fileToolCases = [
+  {
+    name: "write",
+    initial: undefined,
+    expected: "changed\n",
+    args: (target: string) => ({ path: target, content: "changed\n" }),
+  },
+  {
+    name: "read",
+    initial: "original\n",
+    expected: "original\n",
+    args: (target: string) => ({ path: target }),
+  },
+  {
+    name: "edit",
+    initial: "original\n",
+    expected: "changed\n",
+    args: (target: string) => ({
+      path: target,
+      edits: [{ oldText: "original", newText: "changed" }],
+    }),
+  },
+  {
+    name: "apply_patch",
+    initial: "original\n",
+    expected: "changed\n",
+    args: (target: string) => ({
+      input: `*** Begin Patch\n*** Update File: ${target}\n@@\n-original\n+changed\n*** End Patch`,
+    }),
+  },
+];
+
+async function withAliasedWorkspace(
+  run: (paths: { parent: string; root: string; alias: string }) => Promise<void>,
+) {
+  await withTempDir("openclaw-permission-alias-", async (dir) => {
+    const parent = await fs.realpath(dir);
+    const root = path.join(parent, "workspace");
+    const alias = path.join(parent, "workspace-alias");
+    await fs.mkdir(path.join(root, "packages", "app"), { recursive: true });
+    await fs.symlink(root, alias, "dir");
+    await expect(fs.realpath(alias)).resolves.toBe(root);
+    await run({ parent, root, alias });
+  });
+}
+
 describe("session permission filesystem tools", () => {
+  describe.runIf(process.platform !== "win32")(
+    "guarded canonical root with alias workspace",
+    () => {
+      describe.each([
+        { name: "relative path", cwdSuffix: "", absolute: false },
+        { name: "absolute alias path", cwdSuffix: "", absolute: true },
+        { name: "relative path from nested cwd", cwdSuffix: "packages/app", absolute: false },
+        { name: "absolute alias path from nested cwd", cwdSuffix: "packages/app", absolute: true },
+      ])("$name", ({ cwdSuffix, absolute }) => {
+        it.each(fileToolCases)("allows $name within the same directory", async (testCase) => {
+          await withAliasedWorkspace(async ({ root, alias }) => {
+            const cwd = path.join(alias, cwdSuffix);
+            const tools = createOpenClawCodingTools({
+              workspaceDir: alias,
+              cwd,
+              sessionPermissionPolicy: { root, mode: "guarded" },
+            });
+            const tool = tools.find((entry) => entry.name === testCase.name);
+            if (!tool) {
+              throw new Error(`expected ${testCase.name} tool`);
+            }
+            const target = absolute
+              ? path.join(alias, "proof.txt")
+              : path.relative(cwd, path.join(alias, "proof.txt"));
+            // The canonical spelling is a control for the same tool and arguments;
+            // only the workspace alias should distinguish the regression call.
+            for (const input of [path.join(root, "control.txt"), target]) {
+              const canonicalTarget = path.join(
+                root,
+                input === target ? "proof.txt" : "control.txt",
+              );
+              if (testCase.initial !== undefined) {
+                await fs.writeFile(canonicalTarget, testCase.initial, "utf8");
+              }
+              const result = await tool.execute(`alias-${testCase.name}`, testCase.args(input));
+              if (testCase.name === "read") {
+                expect(getTextContent(result)).toContain(testCase.expected);
+              }
+              await expect(fs.readFile(canonicalTarget, "utf8")).resolves.toBe(testCase.expected);
+            }
+          });
+        });
+      });
+
+      it.each(["relative", "absolute"])("allows %s alias reads in read-only mode", async (form) => {
+        await withAliasedWorkspace(async ({ root, alias }) => {
+          await fs.writeFile(path.join(root, "proof.txt"), "original\n", "utf8");
+          const tools = createOpenClawCodingTools({
+            workspaceDir: alias,
+            cwd: alias,
+            sessionPermissionPolicy: { root, mode: "read-only" },
+          });
+          const names = tools.map((tool) => tool.name);
+          for (const name of ["write", "edit", "apply_patch"]) {
+            expect(names).not.toContain(name);
+          }
+          const readTool = tools.find((tool) => tool.name === "read");
+          if (!readTool) {
+            throw new Error("expected read tool");
+          }
+          const target = form === "relative" ? "proof.txt" : path.join(alias, "proof.txt");
+          expect(getTextContent(await readTool.execute("alias-read-only", { path: target }))).toBe(
+            "original\n",
+          );
+        });
+      });
+
+      it("denies unrelated external aliases pointing into the root", async () => {
+        await withAliasedWorkspace(async ({ parent, root, alias }) => {
+          const inside = path.join(root, "proof.txt");
+          await fs.writeFile(inside, "original\n", "utf8");
+          const tools = createOpenClawCodingTools({
+            workspaceDir: alias,
+            cwd: alias,
+            sessionPermissionPolicy: { root, mode: "guarded" },
+          });
+          for (const untrusted of [path.join(parent, "external-alias"), `${alias}-untrusted`]) {
+            await fs.symlink(root, untrusted, "dir");
+            const target = path.join(untrusted, "proof.txt");
+            await expect(fs.realpath(target)).resolves.toBe(inside);
+            for (const testCase of fileToolCases) {
+              const tool = tools.find((entry) => entry.name === testCase.name);
+              if (!tool) {
+                throw new Error(`expected ${testCase.name} tool`);
+              }
+              await expect(
+                tool.execute(`inward-${testCase.name}`, testCase.args(target)),
+              ).rejects.toThrow(/escapes sandbox root/i);
+              await expect(fs.readFile(inside, "utf8")).resolves.toBe("original\n");
+            }
+          }
+        });
+      });
+
+      it.each([false, true])(
+        "keeps missing daily memory optional with alias=%s",
+        async (aliased) => {
+          await withAliasedWorkspace(async ({ root, alias }) => {
+            const tools = createOpenClawCodingTools({
+              workspaceDir: aliased ? alias : root,
+              sessionPermissionPolicy: { root, mode: "guarded" },
+            });
+            const { readTool } = expectReadWriteEditTools(tools);
+            const result = await readTool.execute("missing-daily-memory", {
+              path: "memory/2026-08-27.md",
+            });
+            expect(result.details).toMatchObject({ kind: "not_found", optional: true });
+          });
+        },
+      );
+
+      it("retains patch creation parent checks through trusted aliases", async () => {
+        await withAliasedWorkspace(async ({ root, alias }) => {
+          await fs.mkdir(path.join(root, "real"));
+          await fs.symlink(path.join(root, "real"), path.join(root, "link"), "dir");
+          const tools = createOpenClawCodingTools({
+            workspaceDir: alias,
+            cwd: alias,
+            sessionPermissionPolicy: { root, mode: "guarded" },
+          });
+          const patch = tools.find((tool) => tool.name === "apply_patch");
+          if (!patch) {
+            throw new Error("expected apply_patch tool");
+          }
+          for (const target of [
+            path.join(root, "link/new.txt"),
+            path.join(alias, "link/new.txt"),
+          ]) {
+            await expect(
+              patch.execute("alias-patch-parent", {
+                input: `*** Begin Patch\n*** Add File: ${target}\n+created\n*** End Patch`,
+              }),
+            ).rejects.toThrow(/Path alias under sandbox root/i);
+          }
+          await expect(fs.readdir(path.join(root, "real"))).resolves.toEqual([]);
+          await patch.execute("alias-patch-create", {
+            input: `*** Begin Patch\n*** Add File: ${alias}/new/proof.txt\n+created\n*** End Patch`,
+          });
+          await expect(fs.readFile(path.join(root, "new", "proof.txt"), "utf8")).resolves.toBe(
+            "created\n",
+          );
+        });
+      });
+
+      it.each(["outside path", "symlink target", "raw symlink/.. traversal"])(
+        "denies %s without changing either target",
+        async (escapeKind) => {
+          await withAliasedWorkspace(async ({ parent, root, alias }) => {
+            const outsideDir = path.join(parent, "outside");
+            const outside = path.join(outsideDir, "proof.txt");
+            const decoy = path.join(root, "sub", "outside", "proof.txt");
+            await fs.mkdir(outsideDir);
+            await fs.mkdir(path.dirname(decoy), { recursive: true });
+            await fs.writeFile(outside, "original\n", "utf8");
+            await fs.writeFile(decoy, "original\n", "utf8");
+            await fs.symlink(outside, path.join(root, "escape.txt"));
+            await fs.symlink("..", path.join(root, "sub", "up"), "dir");
+            // Native traversal leaves the root, although lexical normalization
+            // points at the in-root decoy. Keep the raw '..' bytes in tool input.
+            const relativeEscape =
+              escapeKind === "outside path"
+                ? "../outside/proof.txt"
+                : escapeKind === "symlink target"
+                  ? "escape.txt"
+                  : "sub/up/../outside/proof.txt";
+            const canonicalInput = `${root}/${relativeEscape}`;
+            await expect(fs.readFile(canonicalInput, "utf8")).resolves.toBe("original\n");
+            await expect(fs.realpath(canonicalInput)).resolves.toBe(outside);
+            const tools = createOpenClawCodingTools({
+              workspaceDir: alias,
+              cwd: alias,
+              sessionPermissionPolicy: { root, mode: "guarded" },
+            });
+            for (const testCase of fileToolCases) {
+              const tool = tools.find((entry) => entry.name === testCase.name);
+              if (!tool) {
+                throw new Error(`expected ${testCase.name} tool`);
+              }
+              for (const input of [canonicalInput, relativeEscape]) {
+                await expect(
+                  tool.execute(`escape-${testCase.name}`, testCase.args(input)),
+                ).rejects.toThrow(/(?:escapes|outside) sandbox root/i);
+                await expect(fs.readFile(outside, "utf8")).resolves.toBe("original\n");
+                await expect(fs.readFile(decoy, "utf8")).resolves.toBe("original\n");
+              }
+            }
+            await expect(fs.readlink(path.join(root, "escape.txt"))).resolves.toBe(outside);
+          });
+        },
+      );
+    },
+  );
+
   it.each(["guarded", "workspace"] as const)(
     "separates a nested session cwd from its %s permission boundary",
     async (mode) => {

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -318,13 +318,13 @@ async function assertPatchParentPath(rawFilePath: string, options: ApplyPatchOpt
   if (!parent || parent === ".") {
     return;
   }
-  await assertSandboxPath({
+  const checked = await assertSandboxPath({
     filePath: parent,
     cwd: options.cwd,
     root: options.root ?? options.cwd,
   });
   await assertNoExistingParentAliases({
-    parentPath: resolvePathFromInput(parent, options.cwd),
+    parentPath: checked.resolved,
     rootPath: options.root ?? options.cwd,
   });
 }

--- a/src/agents/core-coding-tools.ts
+++ b/src/agents/core-coding-tools.ts
@@ -11,7 +11,6 @@ import {
   resolveAdaptiveReadMaxBytes,
   type SkillInstructionDeliveryCache,
   wrapReadToolWithSkillContent,
-  wrapToolWorkspaceRootGuard,
   wrapToolWorkspaceRootGuardWithOptions,
 } from "./agent-tools.read.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
@@ -59,11 +58,10 @@ function guardHostWorkspaceTool(
   tool: AnyAgentTool,
   options: Pick<CoreCodingToolsOptions, "codingRoot" | "containmentRoot">,
 ): AnyAgentTool {
-  return path.resolve(options.containmentRoot) === path.resolve(options.codingRoot)
-    ? wrapToolWorkspaceRootGuard(tool, options.codingRoot)
-    : wrapToolWorkspaceRootGuardWithOptions(tool, options.containmentRoot, {
-        resolutionCwd: options.codingRoot,
-      });
+  return wrapToolWorkspaceRootGuardWithOptions(tool, options.containmentRoot, {
+    resolutionCwd: options.codingRoot,
+    normalizeGuardedPathParams: true,
+  });
 }
 
 type CoreCodingToolsOptions = {
@@ -126,7 +124,7 @@ export function createCoreCodingTools(options: CoreCodingToolsOptions): AnyAgent
   if (options.includeBaseCodingTools) {
     const baseToolNames = new Set(options.baseToolNames ?? ["read", "edit", "write"]);
     if (baseToolNames.has("read")) {
-      const wrapped = sandboxRoot
+      const read = sandboxRoot
         ? createSandboxedReadTool({
             root: sandboxRoot,
             bridge: sandboxFsBridge!,
@@ -135,20 +133,13 @@ export function createCoreCodingTools(options: CoreCodingToolsOptions): AnyAgent
             modelHasVision: options.modelHasVision,
             createTool: options.baseToolFactories?.createReadTool,
           })
-        : createOpenClawReadTool(
-            (options.baseToolFactories?.createReadTool ?? createReadTool)(options.codingRoot, {
-              maxBytes: resolveAdaptiveReadMaxBytes(options),
-              modelHasVision: options.modelHasVision,
-            }),
-            {
-              modelContextWindowTokens: options.modelContextWindowTokens,
-              imageSanitization: options.imageSanitization,
-              cwd: options.codingRoot,
-            },
-          );
+        : (options.baseToolFactories?.createReadTool ?? createReadTool)(options.codingRoot, {
+            maxBytes: resolveAdaptiveReadMaxBytes(options),
+            modelHasVision: options.modelHasVision,
+          });
       const guarded = options.workspaceOnly
         ? wrapToolWorkspaceRootGuardWithOptions(
-            wrapped,
+            read,
             sandboxRoot ?? options.containmentRoot,
             sandboxRoot
               ? {
@@ -156,11 +147,24 @@ export function createCoreCodingTools(options: CoreCodingToolsOptions): AnyAgent
                   containerWorkdir: sandbox.containerWorkdir,
                   bridge: sandboxFsBridge,
                 }
-              : { additionalRoots: skillReadRoots, resolutionCwd: options.codingRoot },
+              : {
+                  additionalRoots: skillReadRoots,
+                  resolutionCwd: options.codingRoot,
+                  normalizeGuardedPathParams: true,
+                },
           )
-        : wrapped;
+        : read;
+      // Relative read semantics (including optional daily journals) run before
+      // the guard forwards its checked absolute path to the filesystem reader.
+      const wrapped = sandboxRoot
+        ? guarded
+        : createOpenClawReadTool(guarded, {
+            modelContextWindowTokens: options.modelContextWindowTokens,
+            imageSanitization: options.imageSanitization,
+            cwd: options.codingRoot,
+          });
       base.push(
-        wrapReadToolWithSkillContent(guarded, options.skillsSnapshot?.resolvedSkills, {
+        wrapReadToolWithSkillContent(wrapped, options.skillsSnapshot?.resolvedSkills, {
           modelContextWindowTokens: options.modelContextWindowTokens,
           imageSanitization: options.imageSanitization,
           cwd: options.codingRoot,

--- a/src/agents/sandbox-paths.test.ts
+++ b/src/agents/sandbox-paths.test.ts
@@ -119,6 +119,14 @@ describe("resolveSandboxPath", () => {
 });
 
 describe("assertSandboxPath", () => {
+  it("expands file reference prefixes only once", async () => {
+    await withSandboxRoot(async (root) => {
+      await expect(
+        assertSandboxPath({ filePath: "@@notes.txt", cwd: root, root }),
+      ).resolves.toMatchObject({ relative: "@notes.txt" });
+    });
+  });
+
   it.runIf(process.platform !== "win32")(
     "rejects symlink-then-dot-dot traversal for existing and new files",
     async () => {
@@ -202,10 +210,46 @@ describe("assertSandboxPath", () => {
       await expect(
         assertSandboxPath({ filePath: linkedRoot, cwd: linkedRoot, root: linkedRoot }),
       ).resolves.toMatchObject({ relative: "" });
+      await expect(
+        assertSandboxPath({
+          filePath: path.join(realRoot, "nested", "new.txt"),
+          cwd: realRoot,
+          root: linkedRoot,
+        }),
+      ).resolves.toEqual({
+        resolved: path.join(linkedRoot, "nested", "new.txt"),
+        relative: path.join("nested", "new.txt"),
+      });
     } finally {
       await fs.rm(parent, { recursive: true, force: true });
     }
   });
+
+  it.runIf(process.platform !== "win32")(
+    "does not trust unrelated ancestors of a cwd alias pointing deeper into the root",
+    async () => {
+      await withSandboxRoot(async (dir) => {
+        const parent = await fs.realpath(dir);
+        const root = path.join(parent, "workspace");
+        const unrelated = path.join(parent, "unrelated");
+        const cwd = path.join(unrelated, "cwd");
+        await fs.mkdir(path.join(root, "nested"), { recursive: true });
+        await fs.mkdir(unrelated);
+        await fs.symlink(path.join(root, "nested"), cwd);
+        await fs.writeFile(path.join(root, "proof.txt"), "inside");
+        const externalInput = path.join(unrelated, "proof.txt");
+        await fs.symlink(path.join(root, "proof.txt"), externalInput);
+        await expect(fs.realpath(externalInput)).resolves.toBe(path.join(root, "proof.txt"));
+        await expect(assertSandboxPath({ filePath: cwd, cwd, root })).resolves.toEqual({
+          resolved: path.join(root, "nested"),
+          relative: "nested",
+        });
+        await expect(assertSandboxPath({ filePath: externalInput, cwd, root })).rejects.toThrow(
+          /escapes sandbox root/i,
+        );
+      });
+    },
+  );
 
   it.runIf(process.platform !== "win32")(
     "preserves final-symlink unlink policy through a root alias",
@@ -227,6 +271,37 @@ describe("assertSandboxPath", () => {
             allowFinalSymlinkForUnlink: true,
           }),
         ).resolves.toMatchObject({ relative: "link" });
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "checks raw absolute parents before a path enters the declared root",
+    async () => {
+      await withSandboxRoot(async (dir) => {
+        const parent = await fs.realpath(dir);
+        const root = path.join(parent, "workspace");
+        const outside = path.join(parent, "outside", "workspace");
+        await fs.mkdir(root);
+        await fs.mkdir(outside, { recursive: true });
+        await fs.mkdir(path.join(parent, "outside", "deep"));
+        await fs.mkdir(path.join(parent, "plain"));
+        await fs.symlink(path.join(parent, "outside", "deep"), path.join(parent, "jump"));
+        await fs.writeFile(path.join(root, "proof.txt"), "inside");
+        await fs.writeFile(path.join(outside, "proof.txt"), "outside");
+        const escaped = `${parent}/jump/../workspace/proof.txt`;
+        await expect(fs.readFile(escaped, "utf8")).resolves.toBe("outside");
+        expect(path.resolve(escaped)).toBe(path.join(root, "proof.txt"));
+        await expect(assertSandboxPath({ filePath: escaped, cwd: root, root })).rejects.toThrow(
+          /(?:resolves outside|escapes) sandbox root/i,
+        );
+        await expect(
+          assertSandboxPath({
+            filePath: `${parent}/plain/../workspace/proof.txt`,
+            cwd: root,
+            root,
+          }),
+        ).resolves.toMatchObject({ relative: "proof.txt" });
       });
     },
   );

--- a/src/agents/sandbox-paths.ts
+++ b/src/agents/sandbox-paths.ts
@@ -110,6 +110,7 @@ async function assertRawParentWithinRoot(params: {
   filePath: string;
   cwd: string;
   root: string;
+  rootCanonical: string;
 }): Promise<{ rootCanonical: string; targetCanonical: string }> {
   // Win32 resolves reparse-point/.. paths lexically, so it has no equivalent escape.
   // Avoid adding another realpath to this hot path on Windows, where it is expensive.
@@ -134,10 +135,8 @@ async function assertRawParentWithinRoot(params: {
   const rawParent = hasTrailingSeparator ? rawAbsolute : path.dirname(rawAbsolute);
   const finalSegment = hasTrailingSeparator ? "." : path.basename(rawAbsolute);
   const rootResolved = path.resolve(params.root);
-  const [rootCanonical, parentCanonical] = await Promise.all([
-    resolveRawPathViaExistingAncestor(rootResolved),
-    resolveRawPathViaExistingAncestor(rawParent),
-  ]);
+  const { rootCanonical } = params;
+  const parentCanonical = await resolveRawPathViaExistingAncestor(rawParent);
   const targetCanonical =
     path.resolve(rawAbsolute) === rootResolved
       ? await resolveRawPathViaExistingAncestor(rawAbsolute)
@@ -157,20 +156,67 @@ export async function assertSandboxPath(params: {
   allowFinalSymlinkForUnlink?: boolean;
   allowFinalHardlinkForUnlink?: boolean;
 }) {
-  const resolved = resolveSandboxPath(params);
+  const root = path.resolve(params.root);
+  const cwd = path.resolve(params.cwd);
+  let rootCanonical = root;
+  let resolutionCwd = cwd;
+  let filePath = params.filePath;
+  const expanded = expandPath(filePath);
+  if (process.platform !== "win32" && !isWindowsDrivePath(expanded)) {
+    const rootPromise = resolveRawPathViaExistingAncestor(root);
+    const [canonicalRoot, canonicalCwd] = await Promise.all([
+      rootPromise,
+      cwd === root ? rootPromise : resolveRawPathViaExistingAncestor(cwd),
+    ]);
+    rootCanonical = canonicalRoot;
+    resolutionCwd = path.resolve(root, path.relative(rootCanonical, canonicalCwd));
+    // Only caller-owned prefixes may change spelling. Canonicalizing the input
+    // itself would admit unrelated external links pointing into the workspace.
+    const prefixes: [string, string][] = [
+      [cwd, resolutionCwd],
+      [root, root],
+      [rootCanonical, root],
+    ];
+    if (path.isAbsolute(expanded) && isPathInside(rootCanonical, canonicalCwd)) {
+      const rootAlias = path.resolve(cwd, path.relative(canonicalCwd, rootCanonical));
+      // Cwd may itself link deeper into the root; its ancestors are trusted only
+      // after proving the candidate has the recorded root's canonical identity.
+      if (
+        !prefixes.some(([prefix]) => prefix === rootAlias) &&
+        (await resolveRawPathViaExistingAncestor(rootAlias)) === rootCanonical
+      ) {
+        prefixes.push([rootAlias, root]);
+      }
+    }
+    for (const [prefix, replacement] of prefixes.toSorted((a, b) => b[0].length - a[0].length)) {
+      if (expanded === prefix) {
+        filePath = replacement;
+        break;
+      }
+      const prefixWithSeparator = prefix.endsWith(path.sep) ? prefix : `${prefix}${path.sep}`;
+      if (expanded.startsWith(prefixWithSeparator)) {
+        // Preserve raw '..' and trailing separators for the path guards below.
+        const separator = replacement.endsWith(path.sep) ? "" : path.sep;
+        filePath = `${replacement}${separator}${expanded.slice(prefixWithSeparator.length)}`;
+        break;
+      }
+    }
+  }
+  const normalized = { filePath, cwd: resolutionCwd, root, rootCanonical };
+  const resolved = resolveSandboxPath(normalized);
   const policy: PathAliasPolicy = {
     allowFinalSymlinkForUnlink: params.allowFinalSymlinkForUnlink,
     allowFinalHardlinkForUnlink: params.allowFinalHardlinkForUnlink,
   };
   await assertNoPathAliasEscape({
     absolutePath: resolved.resolved,
-    rootPath: params.root,
+    rootPath: root,
     boundaryLabel: "sandbox root",
     policy,
   });
-  // The alias guard owns its specific symlink/hardlink errors; this closes the raw
-  // symlink-then-`..` gap that lexical normalization hides from that guard.
-  const rawTarget = await assertRawParentWithinRoot(params);
+  // Also check raw parents: absolute input can enter the root only after a
+  // symlink/.. prefix outside it, which the alias guard normalizes away.
+  const rawTarget = await assertRawParentWithinRoot(normalized);
   if (path.resolve(rawTarget.targetCanonical) !== path.resolve(resolved.resolved)) {
     await assertNoPathAliasEscape({
       absolutePath: rawTarget.targetCanonical,


### PR DESCRIPTION
Closes #131422 — guarded file tools reject macOS workspace aliases inside the session root.

## What Problem This Solves

Fixes an issue where users reading, writing, editing, or applying patches inside a guarded macOS workspace receive `Path escapes sandbox root` when the configured workspace uses `/tmp/...` but the session records canonical `/private/tmp/...`. Both relative paths and equivalent absolute alias paths fail despite referring to the same directory. Absolute workspace aliases above a nested working directory also fail at the shared tool boundary.

## Why This Change Was Made

Session creation correctly records a canonical `sessionRoot`. The repair reconciles trusted root/cwd spellings in the shared `assertSandboxPath` owner before lexical admission, forwards the checked path into host file operations, and reuses that checked result for patch-parent validation. Only caller-owned prefixes and identity-verified workspace ancestors are translated; untrusted suffixes and trailing separators remain available to the existing alias and native raw-parent checks.

Canonicalizing arbitrary input would admit unrelated external links pointing inward, while canonicalizing only cwd would leave absolute aliases broken. The existing filesystem dependency cannot replace OpenClaw's narrower admission policy or its raw `symlink/..` check. Relative optional-journal interpretation remains before path absolutization. The redundant simple guard wrapper is removed.

Production LOC: **+83/-38 (net +45)**. Tests: **+314/-0**. Docs: **+2/-0**. Growth implements identity-verified trusted-prefix translation, including the workspace ancestor above nested cwd; removing that verification would widen trust. Existing abstractions and guard options are reused. No dependency, config/env option, storage/schema, protocol, or provider-runtime change.

## User Impact

Guarded file tools accept relative and absolute paths through trusted workspace aliases without asking users to weaken permission modes or rewrite workspace paths. Outside paths, escaping symlinks, unrelated external aliases pointing inward, raw traversal escapes, and hardlink restrictions remain enforced. Read-only sessions still omit mutation tools, and patch creation-parent restrictions remain intact.

The [permission-mode documentation](https://docs.openclaw.ai/gateway/permission-modes) now describes trusted aliases and the unchanged boundary.

Release-note context: Fix guarded macOS file tools rejecting trusted workspace aliases, including absolute paths from nested working directories, while preserving filesystem containment and read-only restrictions (#131422).

## Evidence

**Reviewed head:** `5ed12faf0899335a94cba73f9ce3f14fd74a6c7e`.

**Exact-head CI: green.** [CI run 33136480160](https://github.com/openclaw/openclaw/actions/runs/33136480160) completed successfully, including both Windows Node test lanes and the required `openclaw/ci-gate`.

**Native macOS real-Gateway proof: passed, exit 0.** The isolated fixture ran the real built Gateway, authenticated `sessions.create`/`agent` RPCs, OpenClaw runtime loop, real read/write/edit/apply_patch tools, and native filesystem. Only provider responses were deterministic local fixtures; this is not a live external-model claim. All session-creation responses and final session-list rows recorded `/private/tmp/<fixture>/workspace`, while the configured/runtime workspace retained `/tmp/<fixture>/workspace`.

| Real Gateway scenario | Observed result |
| --- | --- |
| Relative and absolute-alias write/read/edit/patch-update, plus patch creation/read | 14 successful tool calls; canonical filesystem bytes independently verified |
| Outside-root read/write/edit/patch | Four visible containment denials; outside bytes unchanged |
| Escaping-symlink read/write/edit/patch | Four visible symlink denials; link and outside target unchanged |
| Unrelated external alias pointing inward | Read denied |
| Read-only session | Absolute-alias read passed; mutation tools absent |
| Unsupported operator `cwd` argument | Exact reserved-cwd admission error; zero provider/tool calls and no filesystem mutation |

Every one of the 24 executed file-tool results matched between stored session history and UI-facing chat history. All owned Gateway/provider processes, ports, fixtures and isolated state were cleaned up.

The runtime was the successful CI `dist-runtime-build` artifact **9672332007**, SHA256 `edd376b31397a7587425a91f05e0f1f9ead9c301ba1584e21cb72d468ef4d9fa`. Its build commit `ffe0cc6bd241b7e08af252a73e3301e1338cc5e9` is the verified merge of this exact PR head into `6f59c0a3fe5794706e24f5bcfd7711e2851ef02b`. It ran natively on macOS with Node 26.7.0 and existing local dependencies: combined-main runtime proof, not a head-only or locally compiled artifact.

Task-only harness commands:

```bash
node --check .artifacts/guarded-alias-landing/gateway-proof.mts
```

```bash
node --import tsx .artifacts/guarded-alias-landing/gateway-proof.mts
```

**Failing-before regression and sibling proof:** initial alias regression produced 12 failures/7 passes before the production repair. Expanded coverage produced 15 failures/59 passes. The nested-cwd absolute-alias row failed for all four tools before its follow-up fix, while the unrelated-ancestor denial control passed. The final combined owner/sibling run passed **275 tests, 2 skipped, across 13 files**:

```bash
node scripts/run-vitest.mjs src/agents/agent-tools.session-permissions.test.ts src/agents/sandbox-paths.test.ts src/agents/sandbox-paths.windows-drive-resolve.test.ts src/agents/apply-patch.test.ts src/agents/apply-patch.symlink-alias.test.ts src/agents/agent-tools.workspace-paths.test.ts src/agents/agent-tools.read.workspace-root-guard.test.ts src/agents/code-mode.skills.test.ts src/agents/agent-tools.unicode-read-workspace.test.ts src/agents/agent-tools.memory-flush-append-write.test.ts src/agents/agent-tools.read.workspace-root-lazy.test.ts src/agents/bash-tools.exec-workdir.test.ts src/agents/sandbox-media-paths.test.ts
```

The prior full changed-file gate passed. The final follow-up reran actual focused lint, core and agents-root test typechecks, formatting, whitespace and docs-list checks. The unmodified source hashes were reverified after publication and Gateway proof. Fresh independent **P0–P2 Codex autoreview was clean**; a separate complete source/dependency/history/current-main review also found no blocking defect. Installed fs-safe contracts were inspected directly. Codex path utilities were inspected at `codex-rs/utils/absolute-path/src/lib.rs:184–224` and `:679–731`; no Codex runtime behavior changes here.

**Proof limits and unsuccessful preparation attempts:** a full local build was interrupted for host resource pressure, not counted as a pass. Two Gateway preparations timed out at 60 seconds before any session/tool execution. The final fixture allowed 180 seconds for preparation only; actual readiness was 105.490 seconds and total harness duration 231.559 seconds, within the unchanged 300-second watchdog and 120-second per-turn deadlines. This proves containment, not startup performance. An earlier broad harness incorrectly supplied operator `agent.cwd`; the public API reserves that field for plugin-owned subagent runs. It was corrected to an explicit admission-denial control. Positive nested-cwd file behavior is proven by the real-filesystem owner regressions, not claimed as a Gateway subagent-flow test.

Normal Control UI loaded the real allowed-session results, and a captured frame was inspected. A file-link overlay intercepted the tool-disclosure click, so the denied-view capture and before/after screenshot pair were not completed; no visual pair is claimed or attached. The definitive evidence is the real Gateway/filesystem result matrix above.

**ClawSweeper review follow-through:** the latest review found no code/security defect and requested exact-head CI plus native alias admission/inward-alias denial evidence. Both are now present. Its terminal proof failed waiting 30 seconds for a test-title string, not on a reported test assertion; the completed 275-test run, green CI and real Gateway trace supersede that incomplete observation. The rank-up request for after-fix real-setup terminal/log evidence is satisfied by the recorded results above. No stale-base rebase was needed: current-main read/patch queue changes were checked, static integration was clean, and the CI merge runtime was exercised.

Named follow-up, not a reproduced regression here: independently reproduce mixed host spellings in sandbox-bridge mount selection and relative-suffix calculation (`src/agents/sandbox/fs-paths.ts`). That pre-existing path is unchanged.

AI-assisted implementation and independent review; maintainer-owned validation and landing.
