### PR TITLE
fix(gateway-client): verify TLS pin before websocket upgrade

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1562,7 +1562,6 @@ packages/gateway-client/src/gateway-origin-scope.ts	1
 packages/gateway-client/src/pending-request.ts	2
 packages/gateway-client/src/protocol-client.ts	1
 packages/gateway-client/src/scope-upgrade.ts	4
-packages/gateway-client/src/websocket-transport.ts	3
 packages/gateway-protocol/src/clawhub-trust-error-details.ts	1
 packages/gateway-protocol/src/client-info.ts	4
 packages/gateway-protocol/src/connect-error-details.ts	12

--- a/packages/gateway-client/src/client.tls.test.ts
+++ b/packages/gateway-client/src/client.tls.test.ts
@@ -1,0 +1,177 @@
+import { X509Certificate } from "node:crypto";
+import { createServer as createHttpServer, type IncomingHttpHeaders } from "node:http";
+import { createServer as createHttpsServer } from "node:https";
+import {
+  connect,
+  createServer as createTcpServer,
+  type AddressInfo,
+  type Server,
+  type Socket,
+} from "node:net";
+import { installGlobalProxy, type ProxylineHandle } from "@openclaw/proxyline";
+import { afterEach, describe, expect, it } from "vitest";
+import { WebSocketServer } from "ws";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { TEST_TLS_CERT_PEM, TEST_TLS_KEY_PEM } from "../../../test/helpers/tls-fixture.js";
+import { GatewayClient, type GatewayClientCloseInfo } from "./client.js";
+
+const fingerprint = new X509Certificate(TEST_TLS_CERT_PEM).fingerprint256;
+const servers: Server[] = [];
+const sockets = new Set<Socket>();
+const clients: GatewayClient[] = [];
+let proxy: ProxylineHandle | undefined;
+
+async function listen(server: Server): Promise<number> {
+  servers.push(server);
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  return (server.address() as AddressInfo).port;
+}
+
+afterEach(async () => {
+  for (const client of clients.splice(0)) {
+    await client.stopAndWait();
+  }
+  proxy?.stop();
+  proxy = undefined;
+  for (const socket of sockets) {
+    socket.destroy();
+  }
+  for (const server of servers.splice(0).toReversed()) {
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  }
+});
+
+async function startProxy(targetPort: number) {
+  const server = createHttpServer();
+  let tunnels = 0;
+  server.on("connect", (_request, downstream, head) => {
+    tunnels++;
+    const upstream = connect(targetPort, "127.0.0.1", () => {
+      downstream.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+      upstream.write(head);
+      downstream.pipe(upstream).pipe(downstream);
+    });
+    sockets.add(upstream);
+    upstream.once("close", () => sockets.delete(upstream));
+    downstream.on("error", () => upstream.destroy());
+    upstream.on("error", () => downstream.destroy());
+    downstream.once("close", () => upstream.destroy());
+    upstream.once("close", () => downstream.destroy());
+  });
+  const port = await listen(server);
+  proxy = installGlobalProxy({ mode: "managed", proxyUrl: `http://127.0.0.1:${port}` });
+  return () => tunnels;
+}
+
+describe.each([false, true])("Gateway TLS upgrade (managed proxy: %s)", (managed) => {
+  it.each([
+    { name: "wrong pin", pin: "ab".repeat(32), expectHeader: false, urlAuth: false },
+    { name: "wrong pin with Expect", pin: "ab".repeat(32), expectHeader: true, urlAuth: false },
+    { name: "wrong pin with URL auth", pin: "ab".repeat(32), expectHeader: false, urlAuth: true },
+    {
+      name: "wrong pin with Expect and URL auth",
+      pin: "ab".repeat(32),
+      expectHeader: true,
+      urlAuth: true,
+    },
+    { name: "correct pin", pin: fingerprint, expectHeader: true, urlAuth: true },
+    { name: "CA validation without a pin", pin: undefined, expectHeader: true, urlAuth: true },
+  ])("validates $name before upgrade", async ({ pin, expectHeader, urlAuth }) => {
+    const server = createHttpsServer({ key: TEST_TLS_KEY_PEM, cert: TEST_TLS_CERT_PEM });
+    let httpBytes = 0;
+    let upgrades = 0;
+    let headers: IncomingHttpHeaders | undefined;
+    server.on("secureConnection", (socket) => {
+      socket.on("data", (chunk: Buffer) => {
+        httpBytes += chunk.length;
+      });
+    });
+    const wss = new WebSocketServer({ server });
+    const outcome = createDeferred<Error | "open">();
+    const closed = createDeferred<GatewayClientCloseInfo | undefined>();
+    wss.on("connection", (_socket, request) => {
+      upgrades++;
+      headers = request.headers;
+      if (pin === fingerprint) {
+        outcome.resolve("open");
+      }
+    });
+    const port = await listen(server);
+    const tunnels = managed ? await startProxy(port) : undefined;
+    const client = new GatewayClient({
+      url: `wss://${urlAuth ? "fixture:synthetic-password@" : ""}127.0.0.1:${port}`,
+      tlsFingerprint: pin,
+      deviceIdentity: null,
+      edgeAuthHeaders: {
+        "X-Test-Edge-Auth": "synthetic-test-edge-token",
+        ...(expectHeader ? { eXpEcT: "100-continue" } : {}),
+      },
+      onConnectError: outcome.resolve,
+      onClose: (_code, _reason, info) => closed.resolve(info),
+    });
+    clients.push(client);
+    client.start();
+    const result = await outcome.promise;
+    await client.stopAndWait();
+    await expect.poll(() => sockets.size).toBe(0);
+    if (pin === fingerprint) {
+      expect(result).toBe("open");
+      expect(httpBytes).toBeGreaterThan(0);
+      expect(upgrades).toBe(1);
+      expect(headers).toMatchObject({
+        "x-test-edge-auth": "synthetic-test-edge-token",
+        expect: "100-continue",
+        authorization: `Basic ${Buffer.from("fixture:synthetic-password").toString("base64")}`,
+      });
+    } else {
+      expect(result).toBeInstanceOf(Error);
+      expect(String(result)).toMatch(pin ? /tls fingerprint mismatch/i : /certificate/i);
+      expect(httpBytes).toBe(0);
+      expect(upgrades).toBe(0);
+      expect(await closed.promise).toMatchObject({
+        phase: "pre-hello",
+        socketOpened: false,
+        transportValidated: false,
+        connectRequestSent: false,
+      });
+    }
+    expect(tunnels?.() ?? 0).toBe(managed ? 1 : 0);
+    await new Promise<void>((resolve) => {
+      wss.close(() => resolve());
+    });
+  });
+
+  it.each(["timeout", "cancel"])("cleans up a stalled TLS handshake on %s", async (action) => {
+    const accepted = createDeferred();
+    const server = createTcpServer((socket) => {
+      socket.on("data", () => accepted.resolve());
+    });
+    const port = await listen(server);
+    const tunnels = managed ? await startProxy(port) : undefined;
+    const failed = createDeferred<Error>();
+    const client = new GatewayClient({
+      url: `wss://127.0.0.1:${port}`,
+      tlsFingerprint: fingerprint,
+      deviceIdentity: null,
+      preauthHandshakeTimeoutMs: 100,
+      onConnectError: failed.resolve,
+    });
+    clients.push(client);
+    client.start();
+    await accepted.promise;
+    if (action === "timeout") {
+      expect(String(await failed.promise)).toMatch(/timed out/i);
+    }
+    await client.stopAndWait();
+    await expect.poll(() => sockets.size).toBe(0);
+    expect(tunnels?.() ?? 0).toBe(managed ? 1 : 0);
+  });
+});

--- a/packages/gateway-client/src/client.ts
+++ b/packages/gateway-client/src/client.ts
@@ -560,14 +560,8 @@ export class GatewayClient {
     this.transportValidated = false;
     let upgradeError: GatewayClientRequestError | undefined;
     ws.on("open", () => {
-      handlers.open();
-      const tlsError = transport.validateSocket(ws);
-      if (tlsError) {
-        handlers.error(tlsError);
-        ws.close(1008, tlsError.message);
-        return;
-      }
       this.transportValidated = true;
+      handlers.open();
     });
     ws.on("message", (data) => handlers.message(rawDataToString(data)));
     ws.on("close", (code, reason) => {

--- a/packages/gateway-client/src/websocket-transport.ts
+++ b/packages/gateway-client/src/websocket-transport.ts
@@ -128,56 +128,63 @@ export function resolveGatewayWebSocketTransport(params: {
   }
   const options: ClientOptions = { ...params.options };
   if (usesTls && expectedFingerprint) {
-    options.rejectUnauthorized = false;
-    const headers = { ...options.headers };
-    const deferredHeaders = Object.entries(headers).filter(
-      ([key]) => key.toLowerCase() === "expect",
-    );
-    for (const [key] of deferredHeaders) {
-      delete headers[key];
-    }
-    options.headers = headers;
-    options.finishRequest = (request) => {
-      request.once("socket", (socket) => {
-        if (!(socket instanceof TLSSocket)) {
-          request.destroy(new GatewayWebSocketTlsPinError("gateway tls fingerprint unavailable"));
-          return;
-        }
-        const validatePin = () => {
-          if (request.destroyed) {
-            return;
-          }
-          const canonicalFingerprint = normalizeTlsFingerprint(
-            socket.getPeerCertificate()?.fingerprint256,
-          );
-          const fingerprint = canonicalFingerprint ? normalize(canonicalFingerprint) : "";
-          if (!fingerprint || fingerprint !== normalize(expectedFingerprint)) {
-            request.destroy(
-              new GatewayWebSocketTlsPinError(
-                fingerprint
-                  ? "gateway tls fingerprint mismatch"
-                  : "gateway tls fingerprint unavailable",
-              ),
-            );
-            return;
-          }
-          // Validate pin before upgrade, including deferred Expect headers.
-          for (const [key, value] of deferredHeaders) {
-            if (value !== undefined) {
-              request.setHeader(key, value);
-            }
-          }
-          request.end();
-        };
-        // SAFETY: Node TLS sockets track secureConnecting; proxy sockets may already be secure.
-        if ((socket as TLSSocket & { secureConnecting: boolean }).secureConnecting) {
-          socket.once("secureConnect", validatePin);
-          request.once("close", () => socket.off("secureConnect", validatePin));
-        } else {
-          validatePin();
-        }
-      });
-    };
+    applyGatewayWebSocketTlsPin(options, expectedFingerprint, normalize);
   }
   return { options };
+}
+
+// The enrolled auxiliary streams share pin enforcement without inheriting URL policy.
+export function applyGatewayWebSocketTlsPin(
+  options: ClientOptions,
+  expectedFingerprint: string,
+  normalize = normalizeTlsFingerprint,
+): void {
+  options.rejectUnauthorized = false;
+  const headers = { ...options.headers };
+  const deferredHeaders = Object.entries(headers).filter(([key]) => key.toLowerCase() === "expect");
+  for (const [key] of deferredHeaders) {
+    delete headers[key];
+  }
+  options.headers = headers;
+  options.finishRequest = (request) => {
+    request.once("socket", (socket) => {
+      if (!(socket instanceof TLSSocket)) {
+        request.destroy(new GatewayWebSocketTlsPinError("gateway tls fingerprint unavailable"));
+        return;
+      }
+      const validatePin = () => {
+        if (request.destroyed) {
+          return;
+        }
+        const canonicalFingerprint = normalizeTlsFingerprint(
+          socket.getPeerCertificate()?.fingerprint256,
+        );
+        const fingerprint = canonicalFingerprint ? normalize(canonicalFingerprint) : "";
+        if (!fingerprint || fingerprint !== normalize(expectedFingerprint)) {
+          request.destroy(
+            new GatewayWebSocketTlsPinError(
+              fingerprint
+                ? "gateway tls fingerprint mismatch"
+                : "gateway tls fingerprint unavailable",
+            ),
+          );
+          return;
+        }
+        // Validate pin before upgrade, including deferred Expect headers.
+        for (const [key, value] of deferredHeaders) {
+          if (value !== undefined) {
+            request.setHeader(key, value);
+          }
+        }
+        request.end();
+      };
+      // SAFETY: Node TLS sockets track secureConnecting; proxy sockets may already be secure.
+      if ((socket as TLSSocket & { secureConnecting: boolean }).secureConnecting) {
+        socket.once("secureConnect", validatePin);
+        request.once("close", () => socket.off("secureConnect", validatePin));
+      } else {
+        validatePin();
+      }
+    });
+  };
 }

--- a/packages/gateway-client/src/websocket-transport.ts
+++ b/packages/gateway-client/src/websocket-transport.ts
@@ -1,6 +1,7 @@
+import { TLSSocket } from "node:tls";
 import { isLoopbackIpAddress, type ParsedIpAddress } from "@openclaw/net-policy/ip";
 import { isWssUrl } from "@openclaw/net-policy/url-protocol";
-import type { ClientOptions, CertMeta, WebSocket } from "ws";
+import type { ClientOptions } from "ws";
 import {
   normalizeTlsFingerprint,
   parseGatewayIpAddress,
@@ -81,23 +82,15 @@ function isSecureWebSocketUrl(rawUrl: string, options?: { allowPrivateWs?: boole
 }
 
 export class GatewayWebSocketTransportConfigurationError extends Error {}
-
-type FingerprintCheckingClientOptions = Omit<ClientOptions, "checkServerIdentity"> & {
-  checkServerIdentity?: (servername: string, cert: CertMeta) => Error | undefined;
-};
-
-type GatewayWebSocketTransport = {
-  options: ClientOptions;
-  validateSocket(socket: WebSocket): Error | null;
-};
+export class GatewayWebSocketTlsPinError extends Error {}
 
 export function resolveGatewayWebSocketTransport(params: {
   url: string;
   tlsFingerprint?: string;
   env?: NodeJS.ProcessEnv;
-  options: Omit<ClientOptions, "checkServerIdentity" | "rejectUnauthorized">;
+  options: Omit<ClientOptions, "checkServerIdentity" | "rejectUnauthorized" | "finishRequest">;
   normalizeTlsFingerprint?: (fingerprint: string | undefined) => string;
-}): GatewayWebSocketTransport {
+}): { options: ClientOptions } {
   const usesTls = isWssUrl(params.url);
   if (params.tlsFingerprint && !usesTls) {
     throw new GatewayWebSocketTransportConfigurationError(
@@ -133,54 +126,58 @@ export function resolveGatewayWebSocketTransport(params: {
       "gateway tls fingerprint must be a SHA-256 fingerprint",
     );
   }
-  const options: FingerprintCheckingClientOptions = { ...params.options };
+  const options: ClientOptions = { ...params.options };
   if (usesTls && expectedFingerprint) {
     options.rejectUnauthorized = false;
-    options.checkServerIdentity = (_hostValue: string, cert: CertMeta) => {
-      const fingerprintValue =
-        typeof cert === "object" && cert && "fingerprint256" in cert
-          ? ((cert as { fingerprint256?: string }).fingerprint256 ?? "")
-          : "";
-      const canonicalFingerprint = normalizeTlsFingerprint(
-        typeof fingerprintValue === "string" ? fingerprintValue : "",
-      );
-      const fingerprint = canonicalFingerprint ? normalize(canonicalFingerprint) : "";
-      const expected = normalize(expectedFingerprint);
-      if (!fingerprint) {
-        return new Error("Missing server TLS fingerprint");
-      }
-      if (fingerprint !== expected) {
-        return new Error("Server TLS fingerprint mismatch");
-      }
-      return undefined;
+    const headers = { ...options.headers };
+    const deferredHeaders = Object.entries(headers).filter(
+      ([key]) => key.toLowerCase() === "expect",
+    );
+    for (const [key] of deferredHeaders) {
+      delete headers[key];
+    }
+    options.headers = headers;
+    options.finishRequest = (request) => {
+      request.once("socket", (socket) => {
+        if (!(socket instanceof TLSSocket)) {
+          request.destroy(new GatewayWebSocketTlsPinError("gateway tls fingerprint unavailable"));
+          return;
+        }
+        const validatePin = () => {
+          if (request.destroyed) {
+            return;
+          }
+          const canonicalFingerprint = normalizeTlsFingerprint(
+            socket.getPeerCertificate()?.fingerprint256,
+          );
+          const fingerprint = canonicalFingerprint ? normalize(canonicalFingerprint) : "";
+          if (!fingerprint || fingerprint !== normalize(expectedFingerprint)) {
+            request.destroy(
+              new GatewayWebSocketTlsPinError(
+                fingerprint
+                  ? "gateway tls fingerprint mismatch"
+                  : "gateway tls fingerprint unavailable",
+              ),
+            );
+            return;
+          }
+          // Validate pin before upgrade, including deferred Expect headers.
+          for (const [key, value] of deferredHeaders) {
+            if (value !== undefined) {
+              request.setHeader(key, value);
+            }
+          }
+          request.end();
+        };
+        // SAFETY: Node TLS sockets track secureConnecting; proxy sockets may already be secure.
+        if ((socket as TLSSocket & { secureConnecting: boolean }).secureConnecting) {
+          socket.once("secureConnect", validatePin);
+          request.once("close", () => socket.off("secureConnect", validatePin));
+        } else {
+          validatePin();
+        }
+      });
     };
   }
-
-  return {
-    options: options as ClientOptions,
-    validateSocket: (socket) => {
-      if (!params.tlsFingerprint) {
-        return null;
-      }
-      const expected = expectedFingerprint ? normalize(expectedFingerprint) : "";
-      if (!expected) {
-        return new Error("gateway tls fingerprint missing");
-      }
-      const rawSocket = (
-        socket as WebSocket & {
-          _socket?: { getPeerCertificate?: () => { fingerprint256?: string } };
-        }
-      )["_socket"];
-      if (!rawSocket || typeof rawSocket.getPeerCertificate !== "function") {
-        return new Error("gateway tls fingerprint unavailable");
-      }
-      const cert = rawSocket.getPeerCertificate();
-      const canonicalFingerprint = normalizeTlsFingerprint(cert?.fingerprint256 ?? "");
-      const fingerprint = canonicalFingerprint ? normalize(canonicalFingerprint) : "";
-      if (!fingerprint) {
-        return new Error("gateway tls fingerprint unavailable");
-      }
-      return fingerprint === expected ? null : new Error("gateway tls fingerprint mismatch");
-    },
-  };
+  return { options };
 }

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -18,9 +18,6 @@ import type { DeviceIdentity } from "../infra/device-identity.js";
 import { captureEnv } from "../test-utils/env.js";
 import type { GatewayClientOptions } from "./client.js";
 
-const TLS_FINGERPRINT = "ab".repeat(32);
-const DIFFERENT_TLS_FINGERPRINT = "cd".repeat(32);
-
 function waitForFast<T>(
   callback: () => T | Promise<T>,
   options: { timeout?: number; interval?: number } = {},
@@ -99,7 +96,6 @@ class MockWebSocket {
   autoCloseOnClose = true;
   readyState = MockWebSocket.CONNECTING;
   readonly options: unknown;
-  _socket?: { getPeerCertificate: () => { fingerprint256?: string } };
 
   constructor(_url: string, options?: unknown) {
     this.options = options;
@@ -107,13 +103,6 @@ class MockWebSocket {
     for (const observer of wsConstructorObservers) {
       observer(_url, options);
     }
-  }
-
-  setPeerFingerprint(fingerprint256: string): void {
-    Object.defineProperty(this, "_socket", {
-      configurable: true,
-      value: { getPeerCertificate: () => ({ fingerprint256 }) },
-    });
   }
 
   on(event: "open", handler: WsEventHandlers["open"]): void;
@@ -794,35 +783,6 @@ describe("GatewayClient close handling", () => {
     expect(onClose).toHaveBeenCalledWith(1008, "unauthorized: signature invalid", {
       phase: "pre-hello",
       socketOpened: false,
-      transportValidated: false,
-      connectRequestSent: false,
-      transientPreHelloCleanClose: false,
-    });
-    client.stop();
-  });
-
-  it("marks an opened TLS transport unvalidated when fingerprint verification fails", () => {
-    const onClose = vi.fn();
-    const onConnectError = vi.fn();
-    const client = new GatewayClient({
-      url: "wss://127.0.0.1:18789",
-      tlsFingerprint: TLS_FINGERPRINT,
-      onClose,
-      onConnectError,
-    });
-
-    client.start();
-    const ws = getLatestWs();
-    ws.setPeerFingerprint(DIFFERENT_TLS_FINGERPRINT);
-    ws.emitOpen();
-
-    expect(onConnectError).toHaveBeenCalledWith(
-      expect.objectContaining({ message: "gateway tls fingerprint mismatch" }),
-    );
-    expect(onClose).toHaveBeenCalledWith(1008, "gateway tls fingerprint mismatch", {
-      connectError: expect.objectContaining({ message: "gateway tls fingerprint mismatch" }),
-      phase: "pre-hello",
-      socketOpened: true,
       transportValidated: false,
       connectRequestSent: false,
       transientPreHelloCleanClose: false,

--- a/src/gateway/probe.tls.test.ts
+++ b/src/gateway/probe.tls.test.ts
@@ -1,0 +1,151 @@
+import { X509Certificate } from "node:crypto";
+import { createServer } from "node:https";
+import type { AddressInfo, Socket } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { WebSocketServer } from "ws";
+import { TEST_TLS_CERT_PEM, TEST_TLS_KEY_PEM } from "../../test/helpers/tls-fixture.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resetSecretRedactionRegistryForTest } from "../logging/secret-redaction-registry.test-support.js";
+import { withTestDir } from "../test-helpers/temp-dir.js";
+import { resolveGatewayClientBootstrap } from "./client-bootstrap.js";
+import {
+  buildMinimalGatewayHelloOkPayload,
+  closeMinimalGatewayServer,
+  parseMinimalGatewayRequestFrame,
+  sendMinimalGatewayConnectChallenge,
+  sendMinimalGatewayResponse,
+} from "./minimal-gateway.test-helpers.js";
+import { probeGateway } from "./probe.js";
+
+const correctPin = new X509Certificate(TEST_TLS_CERT_PEM).fingerprint256
+  .replaceAll(":", "")
+  .toLowerCase();
+const wrongPin = "00".repeat(32);
+const edgeAuthValue = "synthetic-probe-edge-auth";
+
+async function startTlsProbeGateway() {
+  const server = createServer({ key: TEST_TLS_KEY_PEM, cert: TEST_TLS_CERT_PEM });
+  const wss = new WebSocketServer({ server });
+  const sockets = new Set<Socket>();
+  const closedSockets: Promise<void>[] = [];
+  const observed = { receivedBytes: 0, edgeAuthHeaders: [] as unknown[], connectFrames: 0 };
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    closedSockets.push(
+      new Promise<void>((resolve) => {
+        socket.once("close", () => {
+          sockets.delete(socket);
+          resolve();
+        });
+      }),
+    );
+  });
+  server.on("secureConnection", (socket) => {
+    socket.on("data", (chunk: Buffer) => {
+      observed.receivedBytes += chunk.byteLength;
+    });
+  });
+  wss.on("connection", (ws, request) => {
+    observed.edgeAuthHeaders.push(request.headers["x-test-edge-auth"]);
+    sendMinimalGatewayConnectChallenge(ws);
+    ws.on("message", (raw) => {
+      const frame = parseMinimalGatewayRequestFrame(raw);
+      if (frame.type !== "req" || frame.method !== "connect" || !frame.id) {
+        return;
+      }
+      observed.connectFrames += 1;
+      sendMinimalGatewayResponse(
+        ws,
+        frame.id,
+        buildMinimalGatewayHelloOkPayload({
+          auth: { role: "operator", scopes: ["operator.read"] },
+        }),
+      );
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  return {
+    url: `wss://127.0.0.1:${(server.address() as AddressInfo).port}`,
+    observed,
+    drain: async () => Promise.all(closedSockets),
+    close: async () => {
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+      await closeMinimalGatewayServer(wss);
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    },
+  };
+}
+
+afterEach(() => {
+  resetSecretRedactionRegistryForTest();
+});
+
+describe("probeGateway TLS", () => {
+  it.each([
+    { name: "saved pin", savedPin: wrongPin, explicitPin: undefined, outcome: "mismatch" },
+    { name: "explicit pin", savedPin: correctPin, explicitPin: wrongPin, outcome: "mismatch" },
+    { name: "matching pin", savedPin: correctPin, explicitPin: undefined, outcome: "connected" },
+    { name: "CA validation", savedPin: undefined, explicitPin: undefined, outcome: "untrusted" },
+  ])("validates $name before upgrade", async ({ savedPin, explicitPin, outcome }) => {
+    await withTestDir({ prefix: "openclaw-probe-tls-" }, async (stateDir) => {
+      const gateway = await startTlsProbeGateway();
+      try {
+        const env = { OPENCLAW_STATE_DIR: stateDir };
+        const config: OpenClawConfig = {
+          gateway: {
+            mode: "remote",
+            remote: {
+              url: gateway.url,
+              token: "synthetic-probe-token",
+              tlsFingerprint: savedPin,
+              edgeAuth: { "X-Test-Edge-Auth": edgeAuthValue },
+            },
+          },
+        };
+        const bootstrap = await resolveGatewayClientBootstrap({
+          config,
+          authPolicy: "probe",
+          explicitTlsFingerprint: explicitPin,
+          env,
+        });
+        expect(bootstrap.tlsFingerprint).toBe(explicitPin ?? savedPin);
+        const result = await probeGateway({
+          url: bootstrap.url,
+          auth: bootstrap.auth,
+          tlsFingerprint: bootstrap.tlsFingerprint,
+          config,
+          timeoutMs: 2_000,
+          includeDetails: false,
+          env,
+        });
+        await gateway.drain();
+
+        if (outcome === "connected") {
+          expect(result.ok).toBe(true);
+          expect(result.error).toBeNull();
+          expect(gateway.observed.receivedBytes).toBeGreaterThan(0);
+          expect(gateway.observed.edgeAuthHeaders).toEqual([edgeAuthValue]);
+          expect(gateway.observed.connectFrames).toBe(1);
+          return;
+        }
+        expect(result.ok).toBe(false);
+        expect(result.connectLatencyMs).toBeNull();
+        expect(result.error).toMatch(
+          outcome === "mismatch" ? /fingerprint mismatch/i : /certificate|self.signed/i,
+        );
+        expect.soft(gateway.observed.receivedBytes).toBe(0);
+        expect.soft(gateway.observed.edgeAuthHeaders).toEqual([]);
+        expect(gateway.observed.connectFrames).toBe(0);
+      } finally {
+        await gateway.close();
+      }
+    });
+  });
+});

--- a/src/node-host/node-stream-transport.test.ts
+++ b/src/node-host/node-stream-transport.test.ts
@@ -1,0 +1,140 @@
+import { X509Certificate } from "node:crypto";
+import { createServer as createHttpServer } from "node:http";
+import { createServer as createHttpsServer } from "node:https";
+import net, { type AddressInfo } from "node:net";
+import { rawDataToString } from "@openclaw/gateway-client/websocket-data";
+import { installGlobalProxy } from "@openclaw/proxyline";
+import { describe, expect, it } from "vitest";
+import { WebSocketServer } from "ws";
+import { TEST_TLS_CERT_PEM, TEST_TLS_KEY_PEM } from "../../test/helpers/tls-fixture.js";
+import { runNodeStreamTransport } from "./node-stream-transport.js";
+
+const fingerprint = new X509Certificate(TEST_TLS_CERT_PEM).fingerprint256;
+
+describe.each([false, true])("node stream TLS (managed proxy: %s)", (managed) => {
+  it.each([
+    { streamName: "desktop", correctPin: true, tls: true },
+    { streamName: "portal", correctPin: true, tls: true },
+    { streamName: "desktop", correctPin: false, tls: true },
+    { streamName: "portal", correctPin: false, tls: true },
+    { streamName: "desktop", correctPin: false, tls: false },
+    { streamName: "portal", correctPin: false, tls: false },
+  ])(
+    "validates $streamName before attaching (correct pin: $correctPin, TLS: $tls)",
+    async ({ streamName, correctPin, tls }) => {
+      const sockets = new Set<net.Socket>();
+      const servers: net.Server[] = [];
+      const track = (socket: net.Socket) => {
+        sockets.add(socket);
+        socket.once("close", () => sockets.delete(socket));
+      };
+      const listen = async (server: net.Server) => {
+        servers.push(server);
+        server.on("connection", track);
+        await new Promise<void>((resolve) => {
+          server.listen(0, "127.0.0.1", resolve);
+        });
+        return (server.address() as AddressInfo).port;
+      };
+      const localPort = await listen(
+        net.createServer((socket) => {
+          socket.on("data", (chunk) => socket.write(chunk));
+        }),
+      );
+      const gateway = tls
+        ? createHttpsServer({ key: TEST_TLS_KEY_PEM, cert: TEST_TLS_CERT_PEM })
+        : createHttpServer();
+      let bytes = 0;
+      gateway.on(tls ? "secureConnection" : "connection", (socket: net.Socket) => {
+        socket.on("data", (chunk: Buffer) => {
+          bytes += chunk.length;
+        });
+      });
+      const wss = new WebSocketServer({ server: gateway });
+      const frames: string[] = [];
+      const accessHeaders: unknown[] = [];
+      wss.on("connection", (ws, request) => {
+        accessHeaders.push(request.headers["cf-access-client-secret"]);
+        ws.on("message", (data) => {
+          frames.push(rawDataToString(data));
+          if (frames.length === 1) {
+            ws.send(Buffer.from("stream-echo"));
+          }
+        });
+      });
+      const gatewayPort = await listen(gateway);
+      const proxyServer = createHttpServer();
+      let tunnels = 0;
+      proxyServer.on("connect", (_request, downstream, head) => {
+        tunnels++;
+        const upstream = net.connect(gatewayPort, "127.0.0.1", () => {
+          downstream.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+          upstream.write(head);
+          downstream.pipe(upstream).pipe(downstream);
+        });
+        track(upstream);
+        downstream.on("error", () => upstream.destroy());
+        upstream.on("error", () => downstream.destroy());
+        downstream.once("close", () => upstream.destroy());
+        upstream.once("close", () => downstream.destroy());
+      });
+      const proxyPort = managed ? await listen(proxyServer) : undefined;
+      const proxy = managed
+        ? installGlobalProxy({ mode: "managed", proxyUrl: `http://127.0.0.1:${proxyPort}` })
+        : undefined;
+      const controller = new AbortController();
+      let failure: unknown;
+      const running = runNodeStreamTransport({
+        gatewayUrl: `${tls ? "wss" : "ws"}://127.0.0.1:${gatewayPort}`,
+        gatewayTlsFingerprint: correctPin ? fingerprint : "ab".repeat(32),
+        gatewayCloudflareAccess: {
+          clientId: "fixture-client-id",
+          clientSecret: "fixture-client-secret",
+        },
+        attachPath: `/node-${streamName}/attach?ticket=fixture`,
+        expectedAttachPath: `/node-${streamName}/attach`,
+        port: localPort,
+        metadata: { ok: true },
+        streamName,
+        signal: controller.signal,
+        connectAfterGatewayAttach: streamName === "portal",
+      }).catch((error: unknown) => {
+        failure = error;
+      });
+      try {
+        if (correctPin) {
+          await expect.poll(() => frames).toEqual([JSON.stringify({ ok: true }), "stream-echo"]);
+          expect(failure).toBeUndefined();
+          expect(accessHeaders).toEqual(["fixture-client-secret"]);
+        } else {
+          await expect.poll(() => failure).toBeInstanceOf(Error);
+          expect(String(failure)).toMatch(/fingerprint (?:mismatch|unavailable)/i);
+        }
+        controller.abort();
+        await running;
+        await expect.poll(() => sockets.size).toBe(0);
+        if (!correctPin) {
+          expect(bytes).toBe(0);
+          expect(frames).toEqual([]);
+          expect(accessHeaders).toEqual([]);
+        }
+        expect(tunnels).toBe(managed ? 1 : 0);
+      } finally {
+        controller.abort();
+        await running;
+        proxy?.stop();
+        for (const socket of sockets) {
+          socket.destroy();
+        }
+        await new Promise<void>((resolve) => {
+          wss.close(() => resolve());
+        });
+        for (const server of servers.toReversed()) {
+          await new Promise<void>((resolve) => {
+            server.close(() => resolve());
+          });
+        }
+      }
+    },
+  );
+});

--- a/src/node-host/node-stream-transport.ts
+++ b/src/node-host/node-stream-transport.ts
@@ -1,11 +1,10 @@
 import net from "node:net";
-import { TLSSocket } from "node:tls";
 import { WebSocket, type ClientOptions, type RawData } from "ws";
-import { normalizeTlsFingerprint } from "../../packages/gateway-client/src/client-address-utils.js";
 import {
   buildCloudflareAccessHeaders,
   type CloudflareAccessCredentials,
 } from "../../packages/gateway-client/src/cloudflare-access.js";
+import { applyGatewayWebSocketTlsPin } from "../../packages/gateway-client/src/websocket-transport.js";
 
 const MAX_PAYLOAD_BYTES = 1024 * 1024;
 const PAUSE_BUFFERED_BYTES = 4 * 1024 * 1024;
@@ -40,63 +39,18 @@ function attachWebSocketUrl(params: {
   return url.toString();
 }
 
-function assertTlsSocketFingerprint(socket: TLSSocket, expectedRaw: string): void {
-  const expected = normalizeTlsFingerprint(expectedRaw);
-  const actual = normalizeTlsFingerprint(socket.getPeerCertificate().fingerprint256 ?? "");
-  if (!expected || !actual || actual !== expected) {
-    throw new Error("gateway TLS fingerprint mismatch");
-  }
-}
-
-function createPinnedRequestFinisher(
-  expected: string,
-): NonNullable<ClientOptions["finishRequest"]> {
-  return (request) => {
-    request.once("socket", (socket) => {
-      if (!(socket instanceof TLSSocket)) {
-        request.destroy(new Error("gateway TLS fingerprint mismatch"));
-        return;
-      }
-      socket.once("secureConnect", () => {
-        try {
-          assertTlsSocketFingerprint(socket, expected);
-          request.end();
-        } catch (error) {
-          request.destroy(error instanceof Error ? error : new Error(String(error)));
-        }
-      });
-    });
-  };
-}
-
 function websocketOptions(
-  url: string,
   tlsFingerprint?: string,
   cloudflareAccess?: CloudflareAccessCredentials,
 ): ClientOptions {
-  const edgeHeaders = cloudflareAccess
-    ? { headers: buildCloudflareAccessHeaders(cloudflareAccess) }
-    : {};
-  if (!url.startsWith("wss:") || !tlsFingerprint?.trim()) {
-    return { maxPayload: MAX_PAYLOAD_BYTES, ...edgeHeaders };
-  }
-  return {
+  const options: ClientOptions = {
     maxPayload: MAX_PAYLOAD_BYTES,
-    ...edgeHeaders,
-    rejectUnauthorized: false,
-    finishRequest: createPinnedRequestFinisher(tlsFingerprint),
+    ...(cloudflareAccess ? { headers: buildCloudflareAccessHeaders(cloudflareAccess) } : {}),
   };
-}
-
-function assertGatewayTlsFingerprint(socket: TLSSocket | undefined, expectedRaw?: string): void {
-  if (!expectedRaw?.trim()) {
-    return;
+  if (tlsFingerprint?.trim()) {
+    applyGatewayWebSocketTlsPin(options, tlsFingerprint);
   }
-  const expected = normalizeTlsFingerprint(expectedRaw);
-  const actual = normalizeTlsFingerprint(socket?.getPeerCertificate().fingerprint256 ?? "");
-  if (!expected || !actual || actual !== expected) {
-    throw new Error("gateway TLS fingerprint mismatch");
-  }
+  return options;
 }
 
 async function waitForSocketConnect(socket: net.Socket): Promise<void> {
@@ -213,14 +167,8 @@ export async function runNodeStreamTransport(params: {
   const wsUrl = attachWebSocketUrl(params);
   const ws = new WebSocket(
     wsUrl,
-    websocketOptions(wsUrl, params.gatewayTlsFingerprint, params.gatewayCloudflareAccess),
+    websocketOptions(params.gatewayTlsFingerprint, params.gatewayCloudflareAccess),
   );
-  let gatewayTlsSocket: TLSSocket | undefined;
-  ws.once("upgrade", (response) => {
-    if (response.socket instanceof TLSSocket) {
-      gatewayTlsSocket = response.socket;
-    }
-  });
   let aborted: boolean = params.signal.aborted;
   let resolveAbort!: () => void;
   const abort = new Promise<void>((resolve) => {
@@ -254,7 +202,6 @@ export async function runNodeStreamTransport(params: {
     if (aborted) {
       return;
     }
-    assertGatewayTlsFingerprint(gatewayTlsSocket, params.gatewayTlsFingerprint);
     ws.pause();
     const splice = createNodeStreamSplice({ socket, ws, streamName: params.streamName });
     await sendAttachMetadata(ws, params.metadata);

--- a/src/worker/worker-connection-admission.ts
+++ b/src/worker/worker-connection-admission.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { rawDataToString } from "@openclaw/gateway-client/websocket-data";
 import { Value } from "typebox/value";
 import { WebSocket, type RawData } from "ws";
+import { GatewayWebSocketTlsPinError } from "../../packages/gateway-client/src/websocket-transport.js";
 import {
   type WorkerAdmissionResponseFrame,
   WorkerAdmissionResponseFrameSchema,
@@ -117,21 +118,17 @@ export function connectWorkerConnectionAttempt(
       if (!admitted) {
         const kind = opened ? "admission interrupted" : "connect failed";
         rejectAttempt(
-          new WorkerConnectionInterruptedError(
-            `${kind}: ${toWorkerConnectionError(error).message}`,
-          ),
+          error instanceof GatewayWebSocketTlsPinError
+            ? new WorkerConnectionEndpointError(error.message)
+            : new WorkerConnectionInterruptedError(
+                `${kind}: ${toWorkerConnectionError(error).message}`,
+              ),
         );
       }
     });
     socket.on("open", () => {
       if (!options.isCurrentGeneration() || options.isTerminal()) {
         socket.close();
-        return;
-      }
-      const tlsError = target.validateSocket(socket);
-      if (tlsError) {
-        rejectAttempt(new WorkerConnectionEndpointError(tlsError.message));
-        socket.close(1008, tlsError.message);
         return;
       }
       options.onAdmitting();

--- a/src/worker/worker-connection-endpoint.test.ts
+++ b/src/worker/worker-connection-endpoint.test.ts
@@ -1,37 +1,12 @@
-import { describe, expect, it, vi } from "vitest";
-import type { CertMeta, WebSocket } from "ws";
-import { GatewayClient } from "../gateway/client.js";
+import { describe, expect, it } from "vitest";
 import {
   parseWorkerConnectionEndpoint,
   resolveWorkerConnectionTarget,
   type WorkerConnectionEndpoint,
 } from "./worker-connection-endpoint.js";
 
-const wsMockState = vi.hoisted(() => ({ options: undefined as ClientSocketOptions | undefined }));
-
-type ClientSocketOptions = {
-  checkServerIdentity?: (hostname: string, cert: CertMeta) => Error | undefined;
-};
-
-vi.mock("ws", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("ws")>();
-  return {
-    ...actual,
-    WebSocket: class MockWebSocket {
-      on = vi.fn();
-      close = vi.fn();
-      send = vi.fn();
-
-      constructor(_url: unknown, options: ClientSocketOptions) {
-        wsMockState.options = options;
-      }
-    },
-  };
-});
-
-function getClientSocketOptions(): ClientSocketOptions | undefined {
-  return wsMockState.options;
-}
+const fingerprint = "ab".repeat(32);
+const colonFingerprint = (fingerprint.match(/.{2}/gu)?.join(":") ?? "").toUpperCase();
 
 describe("worker connection endpoint", () => {
   it("resolves Unix sockets through the existing ws+unix carrier", () => {
@@ -47,92 +22,18 @@ describe("worker connection endpoint", () => {
     });
   });
 
-  it("applies the canonical TLS pin policy to public worker URLs", () => {
-    const fingerprint = "ab".repeat(32);
+  it.each([
+    `sha256:${fingerprint.toUpperCase()}`,
+    fingerprint.toUpperCase(),
+    colonFingerprint,
+    `ShA256:${colonFingerprint}`,
+  ])("normalizes the worker TLS pin %s", (tlsFingerprint) => {
     const endpoint = parseWorkerConnectionEndpoint({
       kind: "websocket",
       url: "wss://gateway.example/tenant/__openclaw__/worker",
-      tlsFingerprint: fingerprint,
+      tlsFingerprint,
     });
-    expect(endpoint).toBeDefined();
-
-    const target = resolveWorkerConnectionTarget(endpoint!);
-    expect(target.options.headers).toBeUndefined();
-    const checkServerIdentity = (hostname: string, cert: CertMeta) =>
-      target.options.checkServerIdentity?.(hostname, cert);
-    expect(target.options.rejectUnauthorized).toBe(false);
-    expect(
-      checkServerIdentity("gateway.example", {
-        fingerprint256: fingerprint,
-      } as unknown as CertMeta),
-    ).toBeUndefined();
-    expect(
-      checkServerIdentity("gateway.example", {
-        fingerprint256: "cd".repeat(32),
-      } as unknown as CertMeta),
-    ).toEqual(new Error("Server TLS fingerprint mismatch"));
-
-    const socket = {
-      _socket: { getPeerCertificate: () => ({ fingerprint256: fingerprint }) },
-    } as unknown as WebSocket;
-    expect(target.validateSocket(socket)).toBeNull();
-  });
-
-  it("keeps node-host and worker TLS pin forms in parity", () => {
-    const fingerprint = "ab".repeat(32);
-    const presentedFingerprint = (fingerprint.match(/.{2}/gu)?.join(":") ?? "").toUpperCase();
-    const certificate = { fingerprint256: presentedFingerprint } as unknown as CertMeta;
-    const acceptedPins = [
-      `sha256:${fingerprint.toUpperCase()}`,
-      fingerprint.toUpperCase(),
-      presentedFingerprint,
-      `ShA256:${presentedFingerprint}`,
-    ];
-
-    for (const tlsFingerprint of acceptedPins) {
-      wsMockState.options = undefined;
-      new GatewayClient({ url: "wss://gateway.example.com", tlsFingerprint }).start();
-      const nodeHostOptions = getClientSocketOptions();
-      const workerEndpoint = parseWorkerConnectionEndpoint({
-        kind: "websocket",
-        url: "wss://gateway.example.com/__openclaw__/worker",
-        tlsFingerprint,
-      });
-      expect(workerEndpoint).toMatchObject({ tlsFingerprint: fingerprint });
-      const worker = resolveWorkerConnectionTarget(workerEndpoint!);
-      const socket = {
-        _socket: { getPeerCertificate: () => ({ fingerprint256: presentedFingerprint }) },
-      } as unknown as WebSocket;
-
-      expect(
-        nodeHostOptions?.checkServerIdentity?.("gateway.example.com", certificate),
-      ).toBeUndefined();
-      expect(
-        worker.options.checkServerIdentity?.("gateway.example.com", certificate),
-      ).toBeUndefined();
-      expect(worker.validateSocket(socket)).toBeNull();
-    }
-
-    const wrongPin = "cd".repeat(32);
-    wsMockState.options = undefined;
-    new GatewayClient({ url: "wss://gateway.example.com", tlsFingerprint: wrongPin }).start();
-    const nodeHostOptions = getClientSocketOptions();
-    const worker = resolveWorkerConnectionTarget({
-      kind: "websocket",
-      url: "wss://gateway.example.com/__openclaw__/worker",
-      tlsFingerprint: wrongPin,
-    });
-
-    expect(nodeHostOptions?.checkServerIdentity?.("gateway.example.com", certificate)).toEqual(
-      new Error("Server TLS fingerprint mismatch"),
-    );
-    expect(worker.options.checkServerIdentity?.("gateway.example.com", certificate)).toEqual(
-      new Error("Server TLS fingerprint mismatch"),
-    );
-    const socket = {
-      _socket: { getPeerCertificate: () => ({ fingerprint256: presentedFingerprint }) },
-    } as unknown as WebSocket;
-    expect(worker.validateSocket(socket)).toEqual(new Error("gateway tls fingerprint mismatch"));
+    expect(endpoint).toMatchObject({ tlsFingerprint: fingerprint });
   });
 
   it("carries the closed Cloudflare Access credential pair to the worker upgrade", () => {

--- a/src/worker/worker-connection-endpoint.ts
+++ b/src/worker/worker-connection-endpoint.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import type { ClientOptions, WebSocket } from "ws";
+import type { ClientOptions } from "ws";
 import { normalizeTlsFingerprint } from "../../packages/gateway-client/src/client-address-utils.js";
 import {
   buildCloudflareAccessHeaders,
@@ -127,7 +127,6 @@ export function parseWorkerConnectionEndpoint(
 type WorkerConnectionTarget = {
   url: string;
   options: ClientOptions;
-  validateSocket(socket: WebSocket): Error | null;
 };
 
 export function resolveWorkerConnectionTarget(
@@ -138,7 +137,6 @@ export function resolveWorkerConnectionTarget(
     return {
       url: `ws+unix://${endpoint.socketPath}:/`,
       options: {},
-      validateSocket: () => null,
     };
   }
   if (endpoint.cloudflareAccess && new URL(endpoint.url).protocol !== "wss:") {

--- a/src/worker/worker-connection.test.ts
+++ b/src/worker/worker-connection.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter, once } from "node:events";
+import { createServer as createHttpsServer } from "node:https";
 import net from "node:net";
 import { rawDataToString } from "@openclaw/gateway-client/websocket-data";
 import { describe, expect, it, vi } from "vitest";
@@ -17,6 +18,7 @@ import type {
   WorkerInferenceEventFrame,
   WorkerInferenceTerminalFrame,
 } from "../../packages/gateway-protocol/src/schema/worker-inference.js";
+import { TEST_TLS_CERT_PEM, TEST_TLS_KEY_PEM } from "../../test/helpers/tls-fixture.js";
 import {
   toWorkerConnectionError,
   WorkerAdmissionDeadlineExceededError,
@@ -142,6 +144,83 @@ function installThrowingThenHealthyListeners(connection: ReturnType<typeof creat
 }
 
 describe("worker connection endpoint failures", () => {
+  it("rejects a TLS pin mismatch before upgrade without retrying admission", async () => {
+    const server = createHttpsServer({ key: TEST_TLS_KEY_PEM, cert: TEST_TLS_CERT_PEM });
+    const websocketServer = new WebSocketServer({ server });
+    const peers = new Set<net.Socket>();
+    let connections = 0;
+    let httpBytes = 0;
+    let connectFrames = 0;
+    let resolvePeerClosed!: () => void;
+    const peerClosed = new Promise<void>((resolve) => {
+      resolvePeerClosed = resolve;
+    });
+    server.on("connection", (peer) => {
+      connections += 1;
+      peers.add(peer);
+      peer.once("close", () => {
+        peers.delete(peer);
+        resolvePeerClosed();
+      });
+    });
+    server.on("secureConnection", (peer) => {
+      peer.on("data", (data: Buffer) => {
+        httpBytes += data.length;
+      });
+    });
+    websocketServer.on("connection", (socket) => {
+      socket.on("message", () => {
+        connectFrames += 1;
+      });
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("test gateway did not allocate a TCP port");
+    }
+    const connection = createWorkerConnection({
+      endpoint: {
+        kind: "websocket",
+        url: `wss://127.0.0.1:${address.port}${WORKER_PUBLIC_INGRESS_PATH}`,
+        tlsFingerprint: "ab".repeat(32),
+        cloudflareAccess: { clientId: "fixture-client-id", clientSecret: "fixture-client-secret" },
+      },
+      connectParams: FRAME_CONNECT_PARAMS,
+      admissionTimeoutMs: 1_000,
+      admissionDeadlineMs: 3_000,
+      reconnectBackoff: { initialMs: 10, maxMs: 10, factor: 1, jitter: 0 },
+    });
+    const states: WorkerConnectionState["kind"][] = [];
+    connection.onStateChange((state) => states.push(state.kind));
+
+    try {
+      const error = await connection.start().catch((cause: unknown) => cause);
+      await peerClosed;
+      expect(error).toBeInstanceOf(WorkerConnectionEndpointError);
+      expect(error).toMatchObject({ message: "gateway tls fingerprint mismatch" });
+      expect(states).toEqual(["connecting", "failed"]);
+      await expect(connection.waitForExit()).resolves.toEqual({ kind: "failed", error });
+      expect(connections).toBe(1);
+      expect(httpBytes).toBe(0);
+      expect(connectFrames).toBe(0);
+    } finally {
+      await connection.stop();
+      for (const socket of websocketServer.clients) {
+        socket.terminate();
+      }
+      for (const peer of peers) {
+        peer.destroy();
+      }
+      await new Promise<void>((resolve) => {
+        websocketServer.close(() => resolve());
+      });
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
   it.each([
     "connect failure",
     "no hello",


### PR DESCRIPTION
## What Problem This Solves

When connecting to a Gateway with TLS certificate pinning, the client validated the pin only *after* the WebSocket opened. Because pinning sets `rejectUnauthorized: false` (Node skips `checkServerIdentity` once chain verification has already failed), the HTTP Upgrade request — including any configured edge-auth headers — was written to the destination socket before the pin was checked. A wrong or self-signed endpoint therefore received request bytes (and edge-auth header material) before the mismatch aborted the connection.

## Why This Change Was Made

The pin must be verified on the actual destination TLS socket before any HTTP bytes leave the client. The fix moves validation into the existing `ws` `finishRequest` seam: perform the TLS handshake, verify the SHA-256 pin on the secure socket, and only then call `request.end()`. `Expect` headers are withheld from request construction (Node can flush them early). The same gate covers managed CONNECT proxy sockets (which arrive already-secure via `@openclaw/proxyline`). A typed `GatewayWebSocketTlsPinError` preserves the mismatch identity across the request→WebSocket error boundary, and worker admission maps it to the existing *terminal* endpoint error so a pin mismatch never becomes a retry loop; ordinary pre-open failures stay retryable. An open event now means the transport already validated, so the post-open check in `client.ts` is deleted — one canonical flow.

A deep-context review found and fixed a second instance of the same flaw: `src/node-host/node-stream-transport.ts` (desktop/portal streams) had its own request finisher waiting unconditionally for `secureConnect`, so managed-CONNECT streams leaked the same pre-pin bytes. It now shares the extracted `applyGatewayWebSocketTlsPin` helper.

Contracts verified against installed sources: `ws` 8.21.3 (request construction/error forwarding/redirect defaults), `@openclaw/proxyline` 0.3.7 (CONNECT socket delivered only after `secureConnect`), and Node v26.5.0 + v24.19.0 built-in `_http_client`/`_http_outgoing`/`internal/tls/wrap` (Expect flush timing, chain-check/callback ordering).

## User Impact

Pinned Gateway connections that fail the pin now send zero application bytes to the untrusted endpoint — no edge-auth headers, no Upgrade. Correct-pin, no-pin (CA-validated), and trusted-CA connections behave exactly as before. No config, dependency, schema, or protocol change.

## Evidence

- Production **net -60** (the transport change mostly relocates existing code); tests net +408; assertion baseline shrinks by one.
- Byte-exposure proof, before → after on unchanged base: 309–390 decrypted bytes across direct, direct+Expect, direct+URL-auth, managed-CONNECT, probe, bootstrap, and worker-admission flows → **0 bytes, 0 upgrades** after, with correct-pin controls still upgrading.
- Adversarial sweep: **52 scenarios on Node 26 and 52 on Node 24** — IPv4/IPv6/hostname-SNI, correct/wrong pins, URL auth + Expect, subprotocol and per-message-deflate negotiation, unsolicited 100-Continue, 20 extra mismatches per direct/proxy route. Every rejected destination: zero application bytes, zero upgrades, all tracked sockets drained to zero.
- Slowloris trickle (one byte / 20 ms partial TLS record): both pinned and unpinned paths time out and drain; managed-CONNECT stall (10 timeout + 10 cancellation) drains all peers.
- Fresh currently-valid local CA cert: no-pin and correct-pin upgrade, wrong-pin rejects with zero bytes, both Node versions.
- 600 tests across 38 files green; core + all 14 test-typecheck graphs pass; changed-file type-aware lint on all 11 files; Knip zero entries; two independent Codex autoreviews clean. Worker pin-mismatch-stays-terminal regression included.
- Follow-up (not here): remove the superseded mismatch-only `client.watchdog.test.ts` inline HTTPS setup, now covered by the stronger direct/proxy TLS suite.
