### PR TITLE
fix(ui): terminal never opens after a Gateway update reloads the tab

### DIFF
--- a/ui/src/app/service-worker-refresh.runtime.test.ts
+++ b/ui/src/app/service-worker-refresh.runtime.test.ts
@@ -7,21 +7,60 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+function createReplacementWorker() {
+  let state: ServiceWorkerState = "installing";
+  const listeners = new Set<() => void>();
+  const worker = {
+    get state() {
+      return state;
+    },
+    addEventListener(_type: "statechange", listener: () => void) {
+      listeners.add(listener);
+    },
+    removeEventListener(_type: "statechange", listener: () => void) {
+      listeners.delete(listener);
+    },
+  } as unknown as ServiceWorker;
+  return {
+    worker,
+    activate() {
+      state = "activated";
+      for (const listener of listeners) {
+        listener();
+      }
+    },
+  };
+}
+
+/** Mirrors `ui/public/sw.js`: the activating worker announces the build it
+ * serves, then reports `activated`. */
+function createServiceWorkerContainer(
+  registration: ServiceWorkerRegistration,
+  controller: ServiceWorker | null,
+) {
+  const messageListeners = new Set<(event: MessageEvent) => void>();
+  return {
+    container: {
+      controller,
+      getRegistration: vi.fn(async () => registration),
+      addEventListener: (_type: "message", listener: (event: MessageEvent) => void) => {
+        messageListeners.add(listener);
+      },
+      removeEventListener: (_type: "message", listener: (event: MessageEvent) => void) => {
+        messageListeners.delete(listener);
+      },
+    } as unknown as ServiceWorkerContainer,
+    announce(version: string) {
+      for (const listener of messageListeners) {
+        listener({ data: { type: "sw-updated", version } } as MessageEvent);
+      }
+    },
+  };
+}
+
 describe("Control UI service-worker reconnect refresh", () => {
   it("keeps the reconnect fence pending while a replacement worker installs", async () => {
-    let state: ServiceWorkerState = "installing";
-    const listeners = new Set<() => void>();
-    const replacement = {
-      get state() {
-        return state;
-      },
-      addEventListener(_type: "statechange", listener: () => void) {
-        listeners.add(listener);
-      },
-      removeEventListener(_type: "statechange", listener: () => void) {
-        listeners.delete(listener);
-      },
-    } as unknown as ServiceWorker;
+    const replacement = createReplacementWorker();
     const registration: {
       active: ServiceWorker | null;
       installing: ServiceWorker | null;
@@ -32,19 +71,20 @@ describe("Control UI service-worker reconnect refresh", () => {
       installing: null,
       waiting: null,
       update: vi.fn(async () => {
-        registration.installing = replacement;
+        registration.installing = replacement.worker;
       }),
     };
-    const serviceWorker = {
-      getRegistration: vi.fn(async () => registration as unknown as ServiceWorkerRegistration),
-    } as unknown as ServiceWorkerContainer;
-    vi.stubGlobal("navigator", { serviceWorker });
+    const serviceWorker = createServiceWorkerContainer(
+      registration as unknown as ServiceWorkerRegistration,
+      null,
+    );
+    vi.stubGlobal("navigator", { serviceWorker: serviceWorker.container });
 
     const { refreshControlUiServiceWorker } = await import("./sw-refresh.runtime.ts");
     let settled = false;
-    const refresh = refreshControlUiServiceWorker().then((replacementActivated) => {
+    const refresh = refreshControlUiServiceWorker().then((documentRetired) => {
       settled = true;
-      return replacementActivated;
+      return documentRetired;
     });
     await vi.waitFor(() => expect(registration.update).toHaveBeenCalledOnce());
     await new Promise((resolve) => {
@@ -52,42 +92,24 @@ describe("Control UI service-worker reconnect refresh", () => {
     });
 
     expect(settled).toBe(false);
-    state = "activated";
-    for (const listener of listeners) {
-      listener();
-    }
+    serviceWorker.announce("next-build");
+    replacement.activate();
     await expect(refresh).resolves.toBe(true);
   });
 
   it("joins an already-installing replacement without starting a competing update", async () => {
-    let state: ServiceWorkerState = "installing";
-    const listeners = new Set<() => void>();
-    const replacement = {
-      get state() {
-        return state;
-      },
-      addEventListener(_type: "statechange", listener: () => void) {
-        listeners.add(listener);
-      },
-      removeEventListener(_type: "statechange", listener: () => void) {
-        listeners.delete(listener);
-      },
-    } as unknown as ServiceWorker;
+    const replacement = createReplacementWorker();
     const update = vi.fn(async () => {
       throw new Error("must not compete with the active install");
     });
     const registration = {
       active: {} as ServiceWorker,
-      installing: replacement,
+      installing: replacement.worker,
       waiting: null,
       update,
     } as unknown as ServiceWorkerRegistration;
-    vi.stubGlobal("navigator", {
-      serviceWorker: {
-        controller: registration.active,
-        getRegistration: vi.fn(async () => registration),
-      },
-    });
+    const serviceWorker = createServiceWorkerContainer(registration, registration.active);
+    vi.stubGlobal("navigator", { serviceWorker: serviceWorker.container });
 
     const { refreshControlUiServiceWorker } = await import("./sw-refresh.runtime.ts");
     const refresh = refreshControlUiServiceWorker();
@@ -96,11 +118,37 @@ describe("Control UI service-worker reconnect refresh", () => {
     });
     expect(update).not.toHaveBeenCalled();
 
-    state = "activated";
-    for (const listener of listeners) {
-      listener();
-    }
+    serviceWorker.announce("next-build");
+    replacement.activate();
     await expect(refresh).resolves.toBe(true);
+  });
+
+  it("releases the reconnect fence when the replacement serves this document's build", async () => {
+    // The document already reloaded onto the new bundle while its worker was
+    // still installing. That worker activating reloads nothing, so callers
+    // holding work back for a reload would wait for one that never comes.
+    const replacement = createReplacementWorker();
+    const registration = {
+      active: {} as ServiceWorker,
+      installing: replacement.worker,
+      waiting: null,
+      update: vi.fn(),
+    } as unknown as ServiceWorkerRegistration;
+    const serviceWorker = createServiceWorkerContainer(registration, registration.active);
+    vi.stubGlobal("navigator", { serviceWorker: serviceWorker.container });
+
+    const [{ refreshControlUiServiceWorker }, { CONTROL_UI_BUILD_INFO }] = await Promise.all([
+      import("./sw-refresh.runtime.ts"),
+      import("../build-info.ts"),
+    ]);
+    const refresh = refreshControlUiServiceWorker();
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    serviceWorker.announce(CONTROL_UI_BUILD_INFO.buildId);
+    replacement.activate();
+
+    await expect(refresh).resolves.toBe(false);
   });
 
   it("releases the reconnect fence when service workers are unavailable", async () => {

--- a/ui/src/app/sw-refresh.runtime.ts
+++ b/ui/src/app/sw-refresh.runtime.ts
@@ -1,3 +1,5 @@
+import { controlUiWorkerActivationRetires } from "../build-info.ts";
+
 function waitForReplacementWorker(worker: ServiceWorker): Promise<boolean> {
   if (worker.state === "activated" || worker.state === "redundant") {
     return Promise.resolve(worker.state === "activated");
@@ -16,9 +18,10 @@ function waitForReplacementWorker(worker: ServiceWorker): Promise<boolean> {
 }
 
 /**
- * Rechecks the incumbent worker after a Gateway reconnect. A deployment can
- * restart the Gateway without changing the package version, so the socket's
- * version handshake alone cannot retire an already-open document.
+ * Reports whether a service worker update retires this document, so callers can
+ * hold work back for the reload it is about to take. A deployment can restart
+ * the Gateway without changing the package version, so the socket's version
+ * handshake alone cannot retire an already-open document.
  */
 export async function refreshControlUiServiceWorker(): Promise<boolean> {
   const serviceWorker =
@@ -41,12 +44,34 @@ export async function refreshControlUiServiceWorker(): Promise<boolean> {
     registration.waiting ??
     (registration.active && registration.active !== incumbent ? registration.active : null);
   if (pendingReplacement) {
-    return waitForReplacementWorker(pendingReplacement);
+    return replacementRetiresDocument(serviceWorker, pendingReplacement);
   }
   await registration.update();
   const replacement =
     registration.installing ??
     registration.waiting ??
     (registration.active !== incumbent ? registration.active : null);
-  return replacement ? waitForReplacementWorker(replacement) : false;
+  return replacement ? replacementRetiresDocument(serviceWorker, replacement) : false;
+}
+
+async function replacementRetiresDocument(
+  serviceWorker: ServiceWorkerContainer,
+  worker: ServiceWorker,
+): Promise<boolean> {
+  // `activate` announces the served build before the worker reports `activated`
+  // (ui/public/sw.js), so listening from here catches the only signal that
+  // separates a replacement which reloads this document from one that does not.
+  // Activation alone cannot: a worker serving this document's own build
+  // activates whenever the document reloaded onto the new bundle first, and
+  // calling that a pending reload strands every fenced caller for good.
+  let retiresDocument = false;
+  const onWorkerMessage = (event: MessageEvent) => {
+    retiresDocument ||= controlUiWorkerActivationRetires(event.data);
+  };
+  serviceWorker.addEventListener("message", onWorkerMessage);
+  try {
+    return (await waitForReplacementWorker(worker)) && retiresDocument;
+  } finally {
+    serviceWorker.removeEventListener("message", onWorkerMessage);
+  }
 }

--- a/ui/src/build-info.ts
+++ b/ui/src/build-info.ts
@@ -1,4 +1,5 @@
 // Compile-time identity for the Control UI artifact.
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeControlUiBuildInfo } from "./build-info-normalizers.ts";
 import type { ControlUiBuildInfo } from "./build-info-types.ts";
 
@@ -27,6 +28,21 @@ export function reloadControlUiIfStale(identity: {
     return true;
   }
   return false;
+}
+
+/** Whether a service worker activation retires this document, so it has to
+ * reload onto the announced build. The announcement (`ui/public/sw.js`) is the
+ * only truthful view of which build controls the document: an update keeps the
+ * registered `sw.js?v=<registering build>` URL while serving new bytes, so a
+ * worker's `scriptURL` names the build that registered it, not the one it runs.
+ * A worker announcing this document's own build replaces nothing. */
+export function controlUiWorkerActivationRetires(message: unknown): boolean {
+  return (
+    isRecord(message) &&
+    message.type === "sw-updated" &&
+    typeof message.version === "string" &&
+    message.version !== CONTROL_UI_BUILD_INFO.buildId
+  );
 }
 
 /** Exact artifact comparison when both sides expose it. Configured roots opt

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -6,7 +6,7 @@ import {
   installMissingStylesheetRecovery,
   installStaleChunkReloadListener,
 } from "./app/stale-chunk-reload.ts";
-import { CONTROL_UI_BUILD_INFO } from "./build-info.ts";
+import { CONTROL_UI_BUILD_INFO, controlUiWorkerActivationRetires } from "./build-info.ts";
 
 type ViteImportMeta = ImportMeta & {
   readonly env?: {
@@ -25,7 +25,7 @@ if (isProd && "serviceWorker" in navigator) {
   const swUrl = new URL(inferControlUiPublicAssetPath("sw.js"), window.location.origin);
   swUrl.searchParams.set("v", currentControlUiBuildId);
   navigator.serviceWorker.addEventListener("message", (event) => {
-    if (event.data?.type === "sw-updated" && event.data.version !== currentControlUiBuildId) {
+    if (controlUiWorkerActivationRetires(event.data)) {
       window.location.reload();
     }
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators who open a terminal in the tab that a Gateway update just reloaded would have that terminal never open, and would eventually see "Reload this page to continue the terminal action" on a document that is already running the newest build. Every terminal action taken in that tab afterwards is refused the same way; only a manual reload recovers.

This is also the root cause behind the recurring `ui/src/e2e/service-worker-update.e2e.test.ts` failures — both the `page.waitForFunction` timeout and the `expected [] to have a length of 1` variant are the same stuck fence observed at different assertions.

## Why This Change Was Made

The Control UI held "is this document about to reload?" in two places that disagreed. `main.ts` reloads only when the service worker announces a build id different from the document's own, while `refreshControlUiServiceWorker()` reported the weaker "did any replacement worker activate?". The terminal panel's reconnect fence releases only on `false`, so whenever a worker activated carrying the build the document *already ran*, `main.ts` correctly declined to reload and nothing ever lifted the fence — `canRun()` stayed false, `captureTerminalOperation()` refused every operation, and the queued intent sat in `sessionStorage` unexecuted.

That state is the ordinary shape of a Gateway update: the tab detects the build mismatch at the handshake, reloads onto the new bundle, and that bundle's worker finishes installing a second or two later. Any reconnect landing in that window fenced the terminal permanently.

`controlUiWorkerActivationRetires()` now owns the rule in `build-info.ts`, beside the existing build-identity comparisons. `main.ts` reloads through it, and the refresh answers the question its only caller actually asks — *will this document be replaced?* — by listening for the worker's `activate` announcement, which `sw.js` posts before the worker reports `activated`. Activation alone cannot separate the two cases; the announcement names the build being served. A worker's `scriptURL` cannot substitute, because an update keeps the registering document's `?v=` while serving new bytes (the reason the `scriptURL` assertion was dropped in #126584).

Production delta is +43/-7, roughly half of it the two comments recording the ordering invariant.

## User Impact

Opening a terminal in the tab that a Gateway update just reloaded now works on the first try instead of hanging and asking for another reload. Terminal intents queued during a genuine update still wait for the reload and replay in the new document, unchanged.

## Evidence

- New regression test `releases the reconnect fence when the replacement serves this document's build` in `ui/src/app/service-worker-refresh.runtime.test.ts`. Verified failing on pre-fix code with `expected true to be false`, passing after; its three sibling tests pass either way, so it discriminates rather than over-fits.
- Full `ui` unit lane: 749 files, 11052 tests passed, 18 files / 67 tests skipped, 0 failures.
- `ui/src/e2e/service-worker-update.e2e.test.ts`: 2 passed.
- `pnpm check:changed` (tsgo core + UI, oxlint, oxfmt, Knip unused-export scans, Control UI i18n verify, coercion-helper guard, assertion-safety ratchet): exit 0.
- Root cause diagnosed from the `control-ui-e2e-timeout-1-1` artifact of run 33128001326. It shows a build-B document with an `activated` controller, `terminal.open` present without `catalog` (the generic restore) but never with it, and `pageEvents` recording one real navigation with only same-document routing afterwards. The test measures catalog opens before releasing the install gate and again at the end, and got 0 both times in that one document — `drain()` only refuses on `refreshPending || !host.canRun()`, and the test's own poll proves the panel was available and open.

No timeout was raised, no assertion weakened, and no retry added; the e2e file itself is untouched.
