### PR TITLE
fix(browser): return selector no-match snapshots promptly

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -92,7 +92,7 @@ extensions/browser/src/browser/pw-tools-core.interactions.actions.ts	2
 extensions/browser/src/browser/pw-tools-core.interactions.content.ts	1
 extensions/browser/src/browser/pw-tools-core.interactions.execution.ts	4
 extensions/browser/src/browser/pw-tools-core.interactions.navigation.ts	3
-extensions/browser/src/browser/pw-tools-core.snapshot.ts	2
+extensions/browser/src/browser/pw-tools-core.snapshot.ts	1
 extensions/browser/src/browser/pw-tools-core.state.ts	3
 extensions/browser/src/browser/routes/agent.act.normalize.ts	2
 extensions/browser/src/browser/routes/agent.act.shared.ts	3

--- a/docs/tools/browser-control.md
+++ b/docs/tools/browser-control.md
@@ -310,7 +310,7 @@ Snapshot flags at a glance:
 - `--format aria`: accessibility tree with `axN` refs. When Playwright is available, OpenClaw binds refs with backend DOM ids to the live page so follow-up actions can use them; otherwise treat the output as inspection-only.
 - `--efficient` (or `--mode efficient`): compact role snapshot preset. Set `browser.snapshotDefaults.mode: "efficient"` to make this the default (see [Gateway configuration](/gateway/configuration-reference#browser)).
 - `--interactive`, `--compact`, `--depth`, `--selector` force a role snapshot with `ref=e12` refs. `--frame "<iframe>"` scopes role snapshots to an iframe.
-- A selector-scoped snapshot is a point-in-time observation: if no element matches when the snapshot is requested, it returns `(empty)` immediately instead of waiting for the snapshot timeout. Use `openclaw browser wait "<selector>"` when the page is expected to add the element later.
+- A selector-scoped snapshot is a point-in-time observation: if no element matches when the snapshot is requested, it returns an empty snapshot immediately instead of waiting for the snapshot timeout. Use `openclaw browser wait "<selector>"` when the page is expected to add the element later.
 - `--selector` does not change the behavior of page-wide or frame-scoped transport failures; those still use the configured snapshot timeout and diagnostics.
 - With Playwright, `--labels` adds a screenshot with overlayed ref labels
   (prints `MEDIA:<path>`) plus an `annotations` array with each ref's bounding

--- a/docs/tools/browser-control.md
+++ b/docs/tools/browser-control.md
@@ -310,6 +310,8 @@ Snapshot flags at a glance:
 - `--format aria`: accessibility tree with `axN` refs. When Playwright is available, OpenClaw binds refs with backend DOM ids to the live page so follow-up actions can use them; otherwise treat the output as inspection-only.
 - `--efficient` (or `--mode efficient`): compact role snapshot preset. Set `browser.snapshotDefaults.mode: "efficient"` to make this the default (see [Gateway configuration](/gateway/configuration-reference#browser)).
 - `--interactive`, `--compact`, `--depth`, `--selector` force a role snapshot with `ref=e12` refs. `--frame "<iframe>"` scopes role snapshots to an iframe.
+- A selector-scoped snapshot is a point-in-time observation: if no element matches when the snapshot is requested, it returns `(empty)` immediately instead of waiting for the snapshot timeout. Use `openclaw browser wait "<selector>"` when the page is expected to add the element later.
+- `--selector` does not change the behavior of page-wide or frame-scoped transport failures; those still use the configured snapshot timeout and diagnostics.
 - With Playwright, `--labels` adds a screenshot with overlayed ref labels
   (prints `MEDIA:<path>`) plus an `annotations` array with each ref's bounding
   box. On `screenshot`, Playwright-backed labels work with `--full-page`,

--- a/extensions/browser/src/browser/pw-role-snapshot.chromium.test.ts
+++ b/extensions/browser/src/browser/pw-role-snapshot.chromium.test.ts
@@ -36,7 +36,9 @@ describe.runIf(process.env.OPENCLAW_BROWSER_SNAPSHOT_E2E === "1")(
       );
       try {
         const page = context.pages()[0] ?? (await context.newPage());
-        await page.setContent('<main><button id="present">Present</button></main>');
+        await page.setContent(
+          '<main><button id="present">Present</button><a href="https://example.test/docs">Docs</a></main>',
+        );
         const session = await context.newCDPSession(page);
         const { targetInfo } = await session.send("Target.getTargetInfo");
         await session.detach();
@@ -47,6 +49,7 @@ describe.runIf(process.env.OPENCLAW_BROWSER_SNAPSHOT_E2E === "1")(
           ...target,
           selector: "#missing",
           timeoutMs: 30_000,
+          urls: true,
         });
         const elapsedMs = performance.now() - startedAt;
         const present = await snapshotRoleViaPlaywright({
@@ -55,10 +58,21 @@ describe.runIf(process.env.OPENCLAW_BROWSER_SNAPSHOT_E2E === "1")(
           timeoutMs: 30_000,
         });
 
+        const refFree = await snapshotRoleViaPlaywright({
+          ...target,
+          selector: "main",
+          options: { maxDepth: 0 },
+          timeoutMs: 30_000,
+          urls: true,
+        });
+
         expect(missing.snapshot).toBe("(empty)");
+        expect(missing.snapshot).not.toContain("https://example.test/docs");
         expect(missing.refs).toEqual({});
         expect(elapsedMs).toBeLessThan(1_000);
         expect(present.snapshot).toContain('button "Present"');
+        expect(refFree.refs).toEqual({});
+        expect(refFree.snapshot).toContain("https://example.test/docs");
       } finally {
         await closePlaywrightBrowserConnection({ cdpUrl });
         await context.close();

--- a/extensions/browser/src/browser/pw-role-snapshot.chromium.test.ts
+++ b/extensions/browser/src/browser/pw-role-snapshot.chromium.test.ts
@@ -22,6 +22,49 @@ const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 describe.runIf(process.env.OPENCLAW_BROWSER_SNAPSHOT_E2E === "1")(
   "Chromium snapshot-to-action name fidelity",
   () => {
+    it("returns selector no-match snapshots without waiting for the snapshot timeout", async () => {
+      const rootDir = tempDirs.make("openclaw-snapshot-selector-absence-");
+      const port = await getFreePort();
+      const cdpUrl = `http://127.0.0.1:${port}`;
+      const context = await getPlaywrightCore().chromium.launchPersistentContext(
+        path.join(rootDir, "profile"),
+        {
+          headless: true,
+          executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
+          args: [`--remote-debugging-port=${port}`],
+        },
+      );
+      try {
+        const page = context.pages()[0] ?? (await context.newPage());
+        await page.setContent('<main><button id="present">Present</button></main>');
+        const session = await context.newCDPSession(page);
+        const { targetInfo } = await session.send("Target.getTargetInfo");
+        await session.detach();
+        const target = { cdpUrl, targetId: targetInfo.targetId };
+
+        const startedAt = performance.now();
+        const missing = await snapshotRoleViaPlaywright({
+          ...target,
+          selector: "#missing",
+          timeoutMs: 30_000,
+        });
+        const elapsedMs = performance.now() - startedAt;
+        const present = await snapshotRoleViaPlaywright({
+          ...target,
+          selector: "#present",
+          timeoutMs: 30_000,
+        });
+
+        expect(missing.snapshot).toBe("(empty)");
+        expect(missing.refs).toEqual({});
+        expect(elapsedMs).toBeLessThan(1_000);
+        expect(present.snapshot).toContain('button "Present"');
+      } finally {
+        await closePlaywrightBrowserConnection({ cdpUrl });
+        await context.close();
+      }
+    }, 30_000);
+
     it("resolves encoded and omitted names, raw AX names, and native frame refs", async () => {
       const rootDir = tempDirs.make("openclaw-snapshot-labels-");
       const port = await getFreePort();

--- a/extensions/browser/src/browser/pw-role-snapshot.test.ts
+++ b/extensions/browser/src/browser/pw-role-snapshot.test.ts
@@ -104,6 +104,15 @@ describe("pw-role-snapshot", () => {
     expect(result.refs).toEqual({ f1e1: { role: "button", name: "Real" } });
   });
 
+  it.each([
+    ["role", buildRoleSnapshotFromAriaSnapshot],
+    ["AI", buildRoleSnapshotFromAiSnapshot],
+  ] as const)("keeps an explicit empty result for compact %s snapshots", (_mode, build) => {
+    const result = build("", { compact: true });
+    expect(result.snapshot).toBe("(empty)");
+    expect(result.refs).toEqual({});
+  });
+
   it("adds refs for interactive elements", () => {
     const aria = [
       '- heading "Example" [level=1]',

--- a/extensions/browser/src/browser/pw-role-snapshot.ts
+++ b/extensions/browser/src/browser/pw-role-snapshot.ts
@@ -332,10 +332,11 @@ function compactTree(tree: string) {
     finishEntry();
   }
 
-  return entries
+  const compacted = entries
     .filter((entry) => entry.keep)
     .map((entry) => entry.line)
     .join("\n");
+  return compacted || "(empty)";
 }
 
 function processLine(

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.test.ts
@@ -218,6 +218,35 @@ describe("pw-tools-core aria snapshot storage", () => {
     expect(storeRoleRefsForTarget).not.toHaveBeenCalled();
   });
 
+  it("returns an empty snapshot immediately when a selector matches no elements", async () => {
+    const ariaSnapshot = vi.fn(async () => {
+      throw new Error("ariaSnapshot should not wait for a selector with no matches");
+    });
+    const locator = {
+      count: vi.fn(async () => 0),
+      ariaSnapshot,
+    };
+    const page = {
+      locator: vi.fn(() => locator),
+      mainFrame: vi.fn(() => ({ id: "main-frame" })),
+      on: vi.fn(),
+      off: vi.fn(),
+    };
+    getPageForTargetId.mockResolvedValue(page);
+
+    const mod = await import("./pw-tools-core.snapshot.js");
+    const result = await mod.snapshotRoleViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      targetId: "tab-1",
+      selector: "#missing",
+    });
+
+    expect(result.snapshot).toBe("(empty)");
+    expect(result.refs).toEqual({});
+    expect(locator.count).toHaveBeenCalledOnce();
+    expect(ariaSnapshot).not.toHaveBeenCalled();
+  });
+
   it("stores frame-scoped refs with the exact captured frame", async () => {
     const ariaSnapshot = vi.fn(async () => '- button "Save"');
     const frame = { id: "frame-1", locator: vi.fn(() => ({ ariaSnapshot })) };

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.test.ts
@@ -280,6 +280,61 @@ describe("pw-tools-core aria snapshot storage", () => {
     expect(page.evaluate).toHaveBeenCalledOnce();
   });
 
+  it("times out a stalled selector probe without publishing late refs", async () => {
+    const mod = await import("./pw-tools-core.snapshot.js");
+    const pendingCount = Promise.withResolvers<number>();
+    const ariaSnapshot = vi.fn(async () => '- button "Late"');
+    const page = {
+      ...makeAriaSnapshotPage(ariaSnapshot),
+      locator: vi.fn(() => ({ count: () => pendingCount.promise, ariaSnapshot })),
+    };
+    getPageForTargetId.mockResolvedValue(page);
+    vi.useFakeTimers();
+    try {
+      const promise = mod.snapshotRoleViaPlaywright({
+        cdpUrl: "http://127.0.0.1:9222",
+        targetId: "tab-1",
+        selector: "#present",
+        timeoutMs: 750,
+      });
+      const rejected = expect(promise).rejects.toThrow(/timed out/);
+      await vi.advanceTimersByTimeAsync(750);
+      await rejected;
+      pendingCount.resolve(1);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(ariaSnapshot).not.toHaveBeenCalled();
+      expect(storeRoleRefsForTarget).not.toHaveBeenCalled();
+      expect(page.off).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("shares the capture timeout between selector lookup and snapshot", async () => {
+    const mod = await import("./pw-tools-core.snapshot.js");
+    const pendingCount = Promise.withResolvers<number>();
+    const ariaSnapshot = vi.fn(async () => '- button "Present"');
+    getPageForTargetId.mockResolvedValue({
+      ...makeAriaSnapshotPage(ariaSnapshot),
+      locator: () => ({ count: () => pendingCount.promise, ariaSnapshot }),
+    });
+    vi.useFakeTimers();
+    try {
+      const promise = mod.snapshotRoleViaPlaywright({
+        cdpUrl: "http://127.0.0.1:9222",
+        targetId: "tab-1",
+        selector: "#present",
+        timeoutMs: 750,
+      });
+      await vi.advanceTimersByTimeAsync(500);
+      pendingCount.resolve(1);
+      await promise;
+      expect(ariaSnapshot).toHaveBeenCalledWith({ timeout: 250 });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("stores frame-scoped refs with the exact captured frame", async () => {
     const ariaSnapshot = vi.fn(async () => '- button "Save"');
     const frame = { id: "frame-1", locator: vi.fn(() => ({ ariaSnapshot })) };

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.test.ts
@@ -218,9 +218,9 @@ describe("pw-tools-core aria snapshot storage", () => {
     expect(storeRoleRefsForTarget).not.toHaveBeenCalled();
   });
 
-  it("returns an empty snapshot immediately when a selector matches no elements", async () => {
+  it("returns selector no-match snapshots without collecting URLs", async () => {
     const ariaSnapshot = vi.fn(async () => {
-      throw new Error("ariaSnapshot should not wait for a selector with no matches");
+      throw new Error("ariaSnapshot should not run for a selector with no matches");
     });
     const locator = {
       count: vi.fn(async () => 0),
@@ -231,6 +231,7 @@ describe("pw-tools-core aria snapshot storage", () => {
       mainFrame: vi.fn(() => ({ id: "main-frame" })),
       on: vi.fn(),
       off: vi.fn(),
+      evaluate: vi.fn(async () => [{ text: "link", url: "https://example.test" }]),
     };
     getPageForTargetId.mockResolvedValue(page);
 
@@ -239,12 +240,14 @@ describe("pw-tools-core aria snapshot storage", () => {
       cdpUrl: "http://127.0.0.1:9222",
       targetId: "tab-1",
       selector: "#missing",
+      urls: true,
     });
 
     expect(result.snapshot).toBe("(empty)");
-    expect(result.refs).toEqual({});
+    expect(result.snapshot).not.toContain("Links:");
     expect(locator.count).toHaveBeenCalledOnce();
     expect(ariaSnapshot).not.toHaveBeenCalled();
+    expect(page.evaluate).not.toHaveBeenCalled();
   });
 
   it("stores frame-scoped refs with the exact captured frame", async () => {

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.test.ts
@@ -250,6 +250,36 @@ describe("pw-tools-core aria snapshot storage", () => {
     expect(page.evaluate).not.toHaveBeenCalled();
   });
 
+  it("keeps URLs for valid snapshots whose depth filter removes every ref", async () => {
+    const locator = {
+      count: vi.fn(async () => 1),
+      ariaSnapshot: vi.fn(async () => '- main:\n  - link "Docs"'),
+    };
+    const page = {
+      locator: vi.fn(() => locator),
+      mainFrame: vi.fn(() => ({ id: "main-frame" })),
+      on: vi.fn(),
+      off: vi.fn(),
+      evaluate: vi.fn(async () => [{ text: "Docs", url: "https://example.test/docs" }]),
+    };
+    getPageForTargetId.mockResolvedValue(page);
+
+    const mod = await import("./pw-tools-core.snapshot.js");
+    const result = await mod.snapshotRoleViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      targetId: "tab-1",
+      selector: "main",
+      options: { maxDepth: 0 },
+      urls: true,
+    });
+
+    expect(result.refs).toEqual({});
+    expect(result.snapshot).toContain("- main:");
+    expect(result.snapshot).toContain("https://example.test/docs");
+    expect(locator.count).toHaveBeenCalledOnce();
+    expect(page.evaluate).toHaveBeenCalledOnce();
+  });
+
   it("stores frame-scoped refs with the exact captured frame", async () => {
     const ariaSnapshot = vi.fn(async () => '- button "Save"');
     const frame = { id: "frame-1", locator: vi.fn(() => ({ ariaSnapshot })) };

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.test.ts
@@ -1,4 +1,5 @@
 // Browser tests cover pw tools core.snapshot plugin behavior.
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const getPageForTargetId = vi.fn();
@@ -282,7 +283,7 @@ describe("pw-tools-core aria snapshot storage", () => {
 
   it("times out a stalled selector probe without publishing late refs", async () => {
     const mod = await import("./pw-tools-core.snapshot.js");
-    const pendingCount = Promise.withResolvers<number>();
+    const pendingCount = createDeferred<number>();
     const ariaSnapshot = vi.fn(async () => '- button "Late"');
     const page = {
       ...makeAriaSnapshotPage(ariaSnapshot),
@@ -312,7 +313,7 @@ describe("pw-tools-core aria snapshot storage", () => {
 
   it("shares the capture timeout between selector lookup and snapshot", async () => {
     const mod = await import("./pw-tools-core.snapshot.js");
-    const pendingCount = Promise.withResolvers<number>();
+    const pendingCount = createDeferred<number>();
     const ariaSnapshot = vi.fn(async () => '- button "Present"');
     getPageForTargetId.mockResolvedValue({
       ...makeAriaSnapshotPage(ariaSnapshot),

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.ts
@@ -345,10 +345,9 @@ async function finalizeRoleSnapshotViaPlaywright(params: {
   stats: { lines: number; chars: number; refs: number; interactive: number };
   newElements?: number;
 }> {
-  const snapshot =
-    params.urls && Object.keys(params.built.refs).length > 0
-      ? appendSnapshotUrls(params.built.snapshot, await collectSnapshotUrls(params.page))
-      : params.built.snapshot;
+  const snapshot = params.urls
+    ? appendSnapshotUrls(params.built.snapshot, await collectSnapshotUrls(params.page))
+    : params.built.snapshot;
   if (params.isFrameCurrent) {
     assertSnapshotFrameCurrent(params.isFrameCurrent);
   }
@@ -452,10 +451,10 @@ export async function snapshotRoleViaPlaywright(opts: {
         : selector
           ? page.locator(selector)
           : page.locator(":root");
-      const ariaSnapshot =
-        selector && (await locator.count()) === 0
-          ? ""
-          : await locator.ariaSnapshot({ timeout: ariaSnapshotTimeout });
+      const selectorMatched = !selector || (await locator.count()) > 0;
+      const ariaSnapshot = selectorMatched
+        ? await locator.ariaSnapshot({ timeout: ariaSnapshotTimeout })
+        : "";
       const built = buildRoleSnapshotFromAriaSnapshot(ariaSnapshot ?? "", opts.options);
       return await finalizeRoleSnapshotViaPlaywright({
         page,
@@ -466,7 +465,7 @@ export async function snapshotRoleViaPlaywright(opts: {
         isFrameCurrent,
         built,
         mode: "role",
-        urls: opts.urls,
+        urls: opts.urls && selectorMatched,
         maxChars: opts.maxChars,
         delta: opts.delta,
       });

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.ts
@@ -451,7 +451,10 @@ export async function snapshotRoleViaPlaywright(opts: {
         : selector
           ? page.locator(selector)
           : page.locator(":root");
-      const ariaSnapshot = await locator.ariaSnapshot({ timeout: ariaSnapshotTimeout });
+      const ariaSnapshot =
+        selector && (await locator.count()) === 0
+          ? ""
+          : await locator.ariaSnapshot({ timeout: ariaSnapshotTimeout });
       const built = buildRoleSnapshotFromAriaSnapshot(ariaSnapshot ?? "", opts.options);
       return await finalizeRoleSnapshotViaPlaywright({
         page,

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.ts
@@ -7,7 +7,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { truncateUtf16Safe, withTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { Frame, Page } from "playwright-core";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import { ACT_MAX_VIEWPORT_DIMENSION, resolveBrowserNavigationTimeoutMs } from "./act-policy.js";
@@ -218,24 +218,9 @@ export async function snapshotAriaViaPlaywright(opts: {
       };
     },
   });
-  const res = (await (ariaTimeoutMs === undefined
-    ? collectAxTree
-    : (() => {
-        let timer: ReturnType<typeof setTimeout> | undefined;
-        const timeout = new Promise<never>((_, reject) => {
-          timer = setTimeout(() => {
-            reject(new Error(`Aria snapshot via Playwright timed out after ${ariaTimeoutMs}ms.`));
-          }, ariaTimeoutMs);
-          timer.unref?.();
-        });
-        return Promise.race([collectAxTree, timeout]).finally(() => {
-          if (timer) {
-            clearTimeout(timer);
-          }
-        });
-      })())) as {
-    nodes?: RawAXNode[];
-  };
+  const res = await withTimeout(collectAxTree, ariaTimeoutMs ?? 0, {
+    message: `Aria snapshot via Playwright timed out after ${ariaTimeoutMs}ms.`,
+  });
   const nodes = Array.isArray(res?.nodes) ? res.nodes : [];
   const formatted = formatAriaSnapshot(nodes, limit);
   await storeAriaSnapshotRefsViaPlaywright({
@@ -444,16 +429,20 @@ export async function snapshotRoleViaPlaywright(opts: {
     page,
     frame: frame ?? page.mainFrame(),
     run: async (isFrameCurrent) => {
-      const locator = frame
-        ? selector
-          ? frame.locator(selector)
-          : frame.locator(":root")
-        : selector
-          ? page.locator(selector)
-          : page.locator(":root");
-      const selectorMatched = !selector || (await locator.count()) > 0;
+      const snapshotScope = frame ?? page;
+      const locator = snapshotScope.locator(selector || ":root");
+      const captureDeadline = performance.now() + ariaSnapshotTimeout;
+      // Count has no timeout; both capture stages share one budget before refs are published.
+      const selectorMatched =
+        !selector ||
+        (await withTimeout(locator.count(), ariaSnapshotTimeout, "Role snapshot selector")) > 0;
       const ariaSnapshot = selectorMatched
-        ? await locator.ariaSnapshot({ timeout: ariaSnapshotTimeout })
+        ? await locator.ariaSnapshot({
+            // A zero Playwright timeout disables its deadline.
+            timeout: selector
+              ? Math.max(1, captureDeadline - performance.now())
+              : ariaSnapshotTimeout,
+          })
         : "";
       const built = buildRoleSnapshotFromAriaSnapshot(ariaSnapshot ?? "", opts.options);
       return await finalizeRoleSnapshotViaPlaywright({

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.ts
@@ -345,9 +345,10 @@ async function finalizeRoleSnapshotViaPlaywright(params: {
   stats: { lines: number; chars: number; refs: number; interactive: number };
   newElements?: number;
 }> {
-  const snapshot = params.urls
-    ? appendSnapshotUrls(params.built.snapshot, await collectSnapshotUrls(params.page))
-    : params.built.snapshot;
+  const snapshot =
+    params.urls && Object.keys(params.built.refs).length > 0
+      ? appendSnapshotUrls(params.built.snapshot, await collectSnapshotUrls(params.page))
+      : params.built.snapshot;
   if (params.isFrameCurrent) {
     assertSnapshotFrameCurrent(params.isFrameCurrent);
   }


### PR DESCRIPTION
Fixes #131232.

## What Problem This Solves

Fixes an issue where users requesting a browser snapshot for a selector that matches nothing wait for Playwright's full timeout and receive an error instead of an empty result. A compact empty snapshot could also disappear into a blank response.

## Why This Change Was Made

The role-snapshot owner now records whether the requested selector matched before capturing its accessibility tree. That fact controls URL collection; a valid snapshot that has no refs after filtering still keeps its requested URLs. Selector lookup and capture share the snapshot budget, and a timed-out lookup cannot publish late refs. Empty snapshots use the existing formatter and ref lifecycle, including an explicit compact empty result.

The same owner reuses the SDK timeout helper for raw accessibility snapshots and consolidates page/frame locator construction. This removes the duplicate timer implementation and selector branches. The shared helper keeps its bounded timer alive until settlement, unlike the former unreferenced raw-ARIA timer. No config, authentication, or persistence contract changes.

## User Impact

A missing selector promptly returns an empty snapshot and clears previous actionable refs. Existing matches, frame selection, and URL-bearing ref-free results remain supported. Invalid selectors, unavailable frames, and closed pages still fail. Use the documented browser wait command when waiting for a selector to appear. Thanks @gaoanze888 for the original fix.

## Evidence

Final head `a7af0a00c86a2c47b718e7174cee3f5b3ea5feed` is based on repaired main `be5e79ca4713c33a11ccd56b2d728c19f0779f3d`. A fresh credential-isolated AWS run with Node 24.19, pnpm 12.1 and real Chromium passed on that exact head: [proof run](https://crabbox.openclaw.ai/portal/runs/run_27d132b36855). The test helper and assertion-baseline corrections are included in this run; production owner bytes remain unchanged from the reviewed repair.

- Restoring the original capture path reproduces the 700 ms selector timeout. The candidate returns `(empty)` in 3 ms with no refs or unrelated URLs.
- The supported browser HTTP control server returns HTTP 200 with `(empty)` and no refs for no match. A matching `main` snapshot with depth zero also returns 200 and no refs, while retaining the Docs URL.
- Present selectors, page-wide snapshots, existing-frame selectors, compact emptiness, stale-ref retirement, and real invalid-selector/absent-frame/closed-page errors pass.
- Reversing the deadline and compact fixes makes all four new regression cases fail; restoring the candidate passes 72 unit tests. A separate Chromium/route run passes 45 tests. Formatting passes for all six source/test/docs files, as do the extension test typecheck and the assertion-safety ratchet.

Production LOC: +22/-29 (net -7). Tests: +184/-0. Documentation: +2/-0. Internal assertion baseline: one count reduced from 2 to 1. Independent source review and committed-head Codex autoreview found no remaining accepted/actionable findings.

Required exact-head integration CI: [run 33300073015](https://github.com/openclaw/openclaw/actions/runs/33300073015), completed successfully. The earlier unrelated main import failure was repaired by #133155; subsequent CI caught test-library typing and a now-lower assertion count, both corrected and verified in the final proof. The old failed merge run is not being reused. The final AWS lease has been released.

Latest ClawSweeper review follow-through (exact head, 07:57 UTC): required CI is green. Its dependency-inspection limitation is covered by direct maintainer inspection of installed `@openclaw/fs-safe@0.5.6` `dist/timing.js:10-14` and `docs/timing.md`: zero/non-finite timeouts simply await the original promise; positive deadlines clear their timer and do not cancel underlying work. Its docs-inventory limitation is covered by a successful `pnpm docs:list` run from the trusted baseline, which lists `tools/browser-control.md`; the changed browser documentation was read directly. These were reviewer-environment gaps, with no remaining code finding.

Follow-up outside this repair: selector-scoped role refs do not retain their subtree selector during later role lookup, so same-name elements outside the subtree can still cause ambiguous action targeting.
