### PR TITLE
fix(agents): expose queued session status

### DIFF
--- a/packages/gateway-protocol/src/schema/sessions-row.ts
+++ b/packages/gateway-protocol/src/schema/sessions-row.ts
@@ -16,6 +16,15 @@ export const SessionPermissionModeSchema = Type.Union([
   Type.Literal("full"),
 ]);
 
+export const SessionRunStatusSchema = Type.Union([
+  Type.Literal("queued"),
+  Type.Literal("running"),
+  Type.Literal("done"),
+  Type.Literal("failed"),
+  Type.Literal("killed"),
+  Type.Literal("timeout"),
+]);
+
 export const SessionToolOverridesSchema = closedObject({
   mcpServers: Type.Optional(Type.Record(Type.String({ minLength: 1 }), Type.Boolean())),
   mcpToolsDeny: Type.Optional(
@@ -84,16 +93,7 @@ export const SessionRowSchema = Type.Object(
     markedUnreadAt: Type.Optional(Type.Number()),
     lastActivityAt: Type.Optional(Type.Number()),
     lastInteractionAt: Type.Optional(Type.Number()),
-    status: Type.Optional(
-      Type.Union([
-        Type.Literal("queued"),
-        Type.Literal("running"),
-        Type.Literal("done"),
-        Type.Literal("failed"),
-        Type.Literal("killed"),
-        Type.Literal("timeout"),
-      ]),
-    ),
+    status: Type.Optional(SessionRunStatusSchema),
     lastRunError: Type.Optional(Type.String()),
     /** Exact run that produced the latest terminal lifecycle projection. */
     lastRunId: Type.Optional(NonEmptyString),
@@ -170,6 +170,6 @@ export const SessionRowSchema = Type.Object(
 export type SessionCreatedActor = Static<typeof SessionCreatedActorSchema>;
 export type SessionPermissionMode = Static<typeof SessionPermissionModeSchema>;
 export type SessionOwner = Static<typeof SessionOwnerSchema>;
+export type SessionRunStatus = Static<typeof SessionRunStatusSchema>;
 export type SessionToolOverrides = Static<typeof SessionToolOverridesSchema>;
 export type SessionRow = Static<typeof SessionRowSchema>;
-export type SessionRunStatus = NonNullable<SessionRow["status"]>;

--- a/src/agents/tools/sessions-list-tool.test.ts
+++ b/src/agents/tools/sessions-list-tool.test.ts
@@ -370,7 +370,7 @@ describe("sessions-list-tool", () => {
           model: "openai/gpt-5.4-mini",
           contextTokens: 20_000,
           totalTokens: 1_200,
-          status: "done",
+          status: "queued",
           abortedLastRun: false,
           childSessions: ["agent:main:subagent:grandchild"],
         },
@@ -396,7 +396,7 @@ describe("sessions-list-tool", () => {
       linkedDetails.sessionLinkRule,
     );
     expect(compactToolOutputHint(tool.outputSchema)).toBe(
-      '{ count: number; sessions: Array<{ agentId: string; archived: boolean; channel: string; key: string; kind: "main" | "group" | "cron" | "hook" | "node" | "other"; pinned: boolean; abortedLastRun?: boolean; category?: string; childSessions?: Array<string>; contextTokens?: number; derivedTitle?: string; displayName?: string; label?: string; lastMessagePreview?: string; messages?: Array<unknown>; model?: string; parentSessionKey?: string; sessionId?: string; stateVersion?: number; status?: "running" | "done" | "failed" | "killed" | "timeout"; totalTokens?: number; updatedAt?: number }>; sessionLinkRule?: string; visibility?: { mode: "self" | "tree" | "agent"; restricted: true; warning: string } }',
+      '{ count: number; sessions: Array<{ agentId: string; archived: boolean; channel: string; key: string; kind: "main" | "group" | "cron" | "hook" | "node" | "other"; pinned: boolean; abortedLastRun?: boolean; category?: string; childSessions?: Array<string>; contextTokens?: number; derivedTitle?: string; displayName?: string; label?: string; lastMessagePreview?: string; messages?: Array<unknown>; model?: string; parentSessionKey?: string; sessionId?: string; stateVersion?: number; status?: "queued" | "running" | "done" | "failed" | "killed" | "timeout"; totalTokens?: number; updatedAt?: number }>; sessionLinkRule?: string; visibility?: { mode: "self" | "tree" | "agent"; restricted: true; warning: string } }',
     );
     expect(result.details).toEqual({
       count: 1,
@@ -420,7 +420,7 @@ describe("sessions-list-tool", () => {
           model: "openai/gpt-5.4-mini",
           contextTokens: 20_000,
           totalTokens: 1_200,
-          status: "done",
+          status: "queued",
           abortedLastRun: false,
           childSessions: ["agent:main:subagent:grandchild"],
         },

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -6,7 +6,11 @@
 import { readStringValue } from "@openclaw/normalization-core/string-coerce";
 import pMap from "p-map";
 import { Type } from "typebox";
-import type { SessionRunStatus } from "../../../packages/gateway-protocol/src/schema/sessions-row.js";
+import { Value } from "typebox/value";
+import {
+  SessionRunStatusSchema,
+  type SessionRunStatus,
+} from "../../../packages/gateway-protocol/src/schema/sessions-row.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { readSessionTitleFieldsFromTranscriptAsync } from "../../gateway/session-transcript-title-reader.js";
@@ -84,15 +88,7 @@ const SessionListRowOutputSchema = Type.Object(
     model: Type.Optional(Type.String()),
     contextTokens: Type.Optional(Type.Number()),
     totalTokens: Type.Optional(Type.Number()),
-    status: Type.Optional(
-      Type.Union([
-        Type.Literal("running"),
-        Type.Literal("done"),
-        Type.Literal("failed"),
-        Type.Literal("killed"),
-        Type.Literal("timeout"),
-      ]),
-    ),
+    status: Type.Optional(SessionRunStatusSchema),
     abortedLastRun: Type.Optional(Type.Boolean()),
     childSessions: Type.Optional(Type.Array(Type.String())),
     messages: Type.Optional(Type.Array(Type.Unknown())),
@@ -128,13 +124,7 @@ type GatewayCaller = AgentToolGatewayRequestCaller;
 const SESSIONS_LIST_TRANSCRIPT_FIELD_ROWS = 100;
 
 function readSessionRunStatus(value: unknown): SessionRunStatus | undefined {
-  return value === "running" ||
-    value === "done" ||
-    value === "failed" ||
-    value === "killed" ||
-    value === "timeout"
-    ? value
-    : undefined;
+  return Value.Check(SessionRunStatusSchema, value) ? value : undefined;
 }
 
 /** Creates the sessions-list tool with gateway-backed listing and local transcript enrichment. */


### PR DESCRIPTION
## What Problem This Solves

The `sessions_list` agent tool dropped the Gateway's valid `queued` run status. An admitted run waiting for a concurrency slot therefore reached the model with no `status`, making queued work indistinguishable from a session with no active run.

Fixes #131012.

## Why This Change Was Made

The Gateway already owns this fact. Its session-row contract includes `queued`, the active-run projector emits it for admitted work that has not started, and `sessions.list` returns it unchanged.

The loss occurred in the agent-tool projection. Its output schema and runtime narrowing used separate five-value allowlists that omitted `queued`.

This repair makes the Gateway protocol's `SessionRunStatusSchema` the single runtime owner for all three boundaries: the Gateway row, the model-facing output schema, and the agent-tool narrowing check. It also folds `queued` into the existing complete row-contract test instead of adding a duplicate fixture.

Existing-solutions preflight: no plugin, library, or external service can repair an internal projection mismatch. Reusing the existing Gateway status schema is the complete solution.

## User Impact

When an agent lists a child session that is admitted but waiting for a concurrency slot, the returned row now includes `status: "queued"`. The agent can distinguish waiting work from idle work and avoid duplicate dispatch or an incorrect status report.

Production scope is net -10 lines. Test scope is net 0 lines. There are no configuration, environment-variable, storage, migration, dependency, compatibility, scheduling, or security changes.

## Evidence

The same live contract ran against exact current main and the exact proposed head. It used a real Gateway process, the real agent CLI, two agent turns under `agents.defaults.maxConcurrent=1`, and the repository's mock OpenAI-compatible provider. The first turn occupied the slot, the second was admitted and queued, and the first model response invoked the real `sessions_list` tool.

Before, on `69913572f4a84a79de1004a3a91fa87ced9cb95d`:

```json
{
  "gatewayQueuedRow": { "status": "queued" },
  "sessionsListToolQueuedRow": { "status": "missing" },
  "providerRequestCount": 3
}
```

After, on `b224bdba9143881b6d2f6ceb7858eeb3e6ffb0ea`:

```json
{
  "gatewayQueuedRow": { "status": "queued" },
  "sessionsListToolQueuedRow": { "status": "queued" },
  "providerRequestCount": 3
}
```

The provider request log contained the real `sessions_list` function output, so cached or hard-coded success text could not satisfy the proof. Both agent turns completed, and the active turn recorded one successful `sessions_list` call.

Focused validation:

```text
packages/gateway-protocol/src/index.test.ts: 61 passed
src/agents/tools/sessions-list-tool.test.ts: 30 passed
oxfmt --check: passed
focused Oxlint: passed
changed-scope repository ratchets and architecture guards: passed
exact-main and exact-head builds: passed
git diff --check: passed
```

Hosted exact-head CI and the immutable local ClawSweeper gate run after this stable push.
