### PR TITLE
fix: keep test progress visible in agent runs

### DIFF
--- a/test/vitest-reporters-config.test.ts
+++ b/test/vitest-reporters-config.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { spawnNodeEvalSync } from "../src/test-utils/node-process.js";
+import { DEFAULT_VITEST_TEST_TIMEOUT_MS } from "./vitest/vitest.timeouts.ts";
+
+const reporterConfigs = [
+  "vitest.config.ts",
+  "test/vitest/vitest.cli-process.config.ts",
+  "test/vitest/vitest.ui.config.ts",
+  "test/vitest/vitest.ui-e2e.config.ts",
+  "test/vitest/vitest.e2e.config.ts",
+  "ui/vitest.config.ts",
+  "ui/vitest.node.config.ts",
+];
+
+type ReporterEntry = [string, Record<string, unknown>];
+type ReporterResolution = {
+  defaults: Array<{ config: string; reporters: ReporterEntry[]; cli: ReporterEntry[] }>;
+  custom: ReporterEntry[];
+  customCli: ReporterEntry[];
+  injectedPty: ReporterEntry[];
+};
+
+describe("Vitest reporter contracts", () => {
+  it.each(["false", "true"])(
+    "reports completed agent tests and preserves overrides with GITHUB_ACTIONS=%s",
+    (githubActions) => {
+      // Resolve in a fresh process: shared config and std-env capture their environment on import.
+      // This starts no test workers and leaves the enclosing Vitest module/cache ownership alone.
+      const result = spawnNodeEvalSync(
+        `
+          import path from "node:path";
+          import { parseCLI, resolveConfig } from "vitest/node";
+          import { sharedVitestConfig } from "./test/vitest/vitest.shared.config.ts";
+          import { createTuiPtyVitestConfig } from "./test/vitest/vitest.tui-pty.config.ts";
+          const defaults = [];
+          for (const config of ${JSON.stringify(reporterConfigs)}) {
+            const root = config.startsWith("ui/") ? path.resolve("ui") : process.cwd();
+            const options = { root, config: path.resolve(config) };
+            const normal = await resolveConfig(options);
+            const cli = parseCLI(["vitest", "--reporter=json"]).options;
+            const override = await resolveConfig({ ...cli, ...options });
+            defaults.push({ config, reporters: normal.vitestConfig.reporters, cli: override.vitestConfig.reporters });
+          }
+          const customConfig = {
+            ...sharedVitestConfig,
+            test: {
+              ...sharedVitestConfig.test,
+              reporters: [["json", { outputFile: "custom-report.json" }]],
+            },
+          };
+          const custom = await resolveConfig({ config: false }, customConfig);
+          const customCli = await resolveConfig({
+            ...parseCLI(["vitest", "--reporter=json", "--reporter=json"]).options,
+            config: false,
+          }, customConfig);
+          const injectedPty = await resolveConfig({ config: false }, createTuiPtyVitestConfig({
+            GITHUB_ACTIONS: process.env.GITHUB_ACTIONS === "true" ? "false" : "true",
+          }));
+          console.log("REPORTER_RESOLUTION " + JSON.stringify({
+            defaults,
+            custom: custom.vitestConfig.reporters,
+            customCli: customCli.vitestConfig.reporters,
+            injectedPty: injectedPty.vitestConfig.reporters,
+          }));
+        `,
+        {
+          imports: ["tsx"],
+          env: { ...process.env, AI_AGENT: "vitest-reporter-test", GITHUB_ACTIONS: githubActions },
+          timeout: DEFAULT_VITEST_TEST_TIMEOUT_MS,
+        },
+      );
+      expect(result.error, result.stderr).toBeUndefined();
+      expect(result.signal, result.stderr).toBeNull();
+      expect(result.status, result.stderr).toBe(0);
+      const report = result.stdout
+        .split("\n")
+        .find((line) => line.startsWith("REPORTER_RESOLUTION "));
+      expect(report, result.stdout).toBeDefined();
+      const resolved = JSON.parse(
+        report!.slice("REPORTER_RESOLUTION ".length),
+      ) as ReporterResolution;
+      const expected = githubActions === "true" ? ["verbose", "github-actions"] : ["verbose"];
+      for (const { config, reporters, cli } of resolved.defaults) {
+        expect(
+          reporters.map(([name]) => name),
+          config,
+        ).toEqual(expected);
+        expect(cli, `${config} CLI override`).toEqual([["json", {}]]);
+      }
+      expect(resolved.defaults).toHaveLength(reporterConfigs.length);
+      expect(resolved.custom).toEqual([["json", { outputFile: "custom-report.json" }]]);
+      expect(resolved.customCli).toEqual(resolved.custom);
+      expect(resolved.injectedPty.map(([name]) => name)).toEqual(
+        githubActions === "true" ? ["verbose"] : ["verbose", "github-actions"],
+      );
+    },
+  );
+});

--- a/test/vitest/vitest.e2e.config.ts
+++ b/test/vitest/vitest.e2e.config.ts
@@ -36,7 +36,6 @@ export function createE2EVitestConfig(env: Record<string, string | undefined> = 
     test: {
       ...baseTest,
       maxWorkers: e2eWorkers,
-      reporters: ["verbose"],
       silent: !verboseE2E,
       globalSetup: [resolveRepoRootPath("test/vitest/vitest.e2e.global-setup.ts")],
       setupFiles: [

--- a/test/vitest/vitest.shared.config.ts
+++ b/test/vitest/vitest.shared.config.ts
@@ -469,6 +469,8 @@ export const sharedVitestConfig = {
   },
   test: {
     dir: repoRoot,
+    // Emit completed cases even under agent detection so healthy runs feed the output watchdog.
+    reporters: ["verbose", ...(process.env.GITHUB_ACTIONS === "true" ? ["github-actions"] : [])],
     testTimeout: DEFAULT_VITEST_TEST_TIMEOUT_MS,
     // 180s on every platform: GitHub-hosted 4-core fallback runners (Blacksmith
     // outage breaker) push e2e beforeAll hooks past 120s; Windows always needed it.

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -10,6 +10,7 @@ import {
   jsdomOptimizedDeps,
   nonIsolatedRunnerPath,
   resolveDefaultVitestPool,
+  sharedVitestConfig,
 } from "../test/vitest/vitest.shared.config.ts";
 import { uiIsolatedTestFiles } from "../test/vitest/vitest.ui-isolated-paths.mjs";
 import { controlUiLocaleModulesPlugin } from "./config/control-ui-locales.ts";
@@ -152,6 +153,7 @@ export default defineConfig({
   },
   test: {
     ...sharedUiTestConfig,
+    reporters: sharedVitestConfig.test.reporters,
     projects: [
       defineProject({
         plugins: [controlUiLocaleModulesPlugin()],

--- a/ui/vitest.node.config.ts
+++ b/ui/vitest.node.config.ts
@@ -1,12 +1,16 @@
 // Control UI config module wires vitest behavior.
 import { defineConfig } from "vitest/config";
-import { resolveDefaultVitestPool } from "../test/vitest/vitest.shared.config.ts";
+import {
+  resolveDefaultVitestPool,
+  sharedVitestConfig,
+} from "../test/vitest/vitest.shared.config.ts";
 import { controlUiLocaleModulesPlugin } from "./config/control-ui-locales.ts";
 
 // Node-only tests for pure logic (no Playwright/browser dependency).
 export default defineConfig({
   plugins: [controlUiLocaleModulesPlugin()],
   test: {
+    reporters: sharedVitestConfig.test.reporters,
     isolate: false,
     pool: resolveDefaultVitestPool(),
     testTimeout: 120_000,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where developers running tests inside an agent session could have a healthy, long-running suite terminated by the no-output watchdog because successful test cases produced no progress output.

## Why This Change Was Made

Vitest's automatic agent reporter suppresses successful cases. The shared test configuration now explicitly selects the existing verbose reporter and retains GitHub Actions annotations. Both standalone UI configurations reuse that policy, and generic E2E removes its redundant reporter override. PTY keeps its existing injected-environment policy.

Explicit CLI and custom-config reporters still take precedence, including JSON reporter options. This changes neither test deadlines nor watchdog behavior, strips no environment markers, and introduces no custom reporter or new configuration option.

## User Impact

Developers and CI agents see real completed-test progress by default, so successful work remains visible to the existing silence watchdog. There is no product-runtime or visual UI change.

## Evidence

All local proof used Node 24.20.0, pnpm 11.22.0, the default heap, and an independent frozen dependency install.

- Actual-output RED/GREEN: `pnpm test test/vitest-light-paths.test.ts`, without a reporter argument. Before the repair, all five underlying tests passed but the enclosing assertion failed because completed-case names were absent. Afterward, the same assertion passed with all five names visible.
- The new public Vitest resolver regression failed twice before the repair and passed twice afterward. It covers seven actual config entry points, both GitHub Actions states, explicit CLI JSON replacement, custom JSON options, repeated CLI reporter normalization, and PTY's injected environment.
- Four existing sibling suites passed: 129 tests across `test/vitest-ui-package-config.test.ts`, `test/vitest-projects-config.test.ts`, `test/vitest-ui-e2e-config.test.ts`, and `test/vitest-scoped-config.test.ts`, including the full-suite ownership audit.
- The full changed-code gate passed both before commit and on committed head `f9985c39a8a22dd2c138afc5a8b13d0e6d86d884`: guards, formatting, dead-code scans, core-test/UI/test-root typechecks, core lint, and script lint; no skip flags.
- Independent Codex review completed with no actionable P0 findings.

Separately, the original frozen-source full UI diagnostic completed naturally with only `--reporter=verbose` added: 300/302 files and 1,169/1,171 tests passed in 1,997.67 seconds under the unchanged 300-second silence watchdog. The two remaining failures are the transcript-focused-row gap assertion and the team-secrets allowed-hosts locator. This is progress-output evidence, **not** a claim that full UI is green or that this repaired commit has completed a full UI run.

Source-history context: the shared test block was carried forward from `2b900b576c4fbb7ef2e4f8b90af07c2f14d8e9ca` (2026-04-03; author and committer Peter Steinberger). The installed Vitest 4.1.11 dependency arrived in #129941 (`1605dbd3efef1c10da95c4a9bbb51a19a9d07865`; code author Peter Steinberger, Git committer GitHub). Neither fact establishes the first affected release or introducing PR; merger and automation-trigger attribution are not established. Existing scoped verbose/GitHub Actions policy in #117405 and verbose E2E policy in #124401 informed the shared repair.

Production runtime LOC: 0. Test-tooling/config LOC: +9/-2; regression test: +98/-0. The growth is the shared reporter policy plus its two standalone UI consumers; the duplicate generic E2E policy is removed.
