### PR TITLE
refactor(slack): centralize outbound send preparation

### DIFF
--- a/extensions/slack/src/channel.outbound-preparation.test.ts
+++ b/extensions/slack/src/channel.outbound-preparation.test.ts
@@ -1,0 +1,188 @@
+import { createMessageReceiptFromOutboundResults } from "openclaw/plugin-sdk/channel-outbound";
+import type { OutboundDeliveryResult } from "openclaw/plugin-sdk/channel-send-result";
+import type { OpenClawConfig, SlackAccountConfig } from "openclaw/plugin-sdk/config-contracts";
+import { describe, expect, it, vi } from "vitest";
+import { slackPlugin } from "./channel.js";
+import { registerSlackInstallationState } from "./installation-identity-state.js";
+
+type SlackSend = typeof import("./send.runtime.js").sendMessageSlack;
+
+const sendMethods = [
+  { kind: "text", send: slackPlugin.outbound!.sendText! },
+  { kind: "media", send: slackPlugin.outbound!.sendMedia! },
+  { kind: "payload", send: slackPlugin.outbound!.sendPayload! },
+] as const;
+
+function createContext(
+  account: SlackAccountConfig = {
+    mode: "http",
+    postAs: "user",
+    userToken: "test-user-token",
+  },
+) {
+  const cfg: OpenClawConfig = { channels: { slack: { accounts: { work: account } } } };
+  return { cfg, accountId: "work", to: "channel:C123", text: "hello", payload: { text: "hello" } };
+}
+
+function createNativeSender() {
+  let part = 0;
+  return vi.fn<SlackSend>(async (_to, _text, options) => {
+    await options.onPlatformSendDispatch?.();
+    const messageId = `171.00${++part}`;
+    const result = {
+      messageId,
+      channelId: "C123",
+      receipt: createMessageReceiptFromOutboundResults({
+        results: [{ channel: "slack", messageId }],
+        kind: options.mediaUrl ? "media" : "text",
+      }),
+    };
+    await options.onDeliveryResult?.(result);
+    return result;
+  });
+}
+
+describe("Slack public outbound preparation", () => {
+  it.each(sendMethods)(
+    "preserves token, custody, and receipts for $kind",
+    async ({ kind, send }) => {
+      const ctx = createContext();
+      const originalConfig = structuredClone(ctx.cfg);
+      const nativeSend = createNativeSender();
+      const order: string[] = [];
+      const progress: OutboundDeliveryResult[] = [];
+      const result = await send({
+        ...ctx,
+        ...(kind === "media" ? { mediaUrl: "https://example.invalid/image.png" } : {}),
+        payload: { text: "hello", presentation: { blocks: [{ type: "divider" }] } },
+        deliveryQueueId: "queue-1",
+        deps: { slack: nativeSend },
+        onPlatformSendDispatch: async () => {
+          order.push("dispatch");
+        },
+        onDeliveryResult: (delivery) => {
+          order.push("receipt");
+          progress.push(delivery);
+        },
+      });
+
+      expect(nativeSend).toHaveBeenCalledOnce();
+      const options = nativeSend.mock.calls[0]![2];
+      expect(options.cfg).toBe(ctx.cfg);
+      expect(options.accountId).toBe("work");
+      expect(options.token).toBe("test-user-token");
+      expect(options.deliveryQueueId).toBe(kind === "text" ? "queue-1" : undefined);
+      expect(order).toEqual(["dispatch", "receipt"]);
+      expect(progress).toMatchObject([
+        { channel: "slack", messageId: "171.001", target: { kind: "channel", id: "C123" } },
+      ]);
+      expect(result).toMatchObject({
+        channel: "slack",
+        messageId: "171.001",
+        target: { kind: "channel", id: "C123" },
+        receipt: { platformMessageIds: ["171.001"] },
+      });
+      expect(ctx.cfg).toEqual(originalConfig);
+    },
+  );
+
+  it.each(sendMethods)(
+    "rejects active SecretRefs before an injected $kind send",
+    async ({ send }) => {
+      const nativeSend = createNativeSender();
+      const ctx = createContext({
+        mode: "http",
+        botToken: { source: "exec", provider: "default", id: "fixture-slack-token" },
+      });
+
+      await expect(send({ ...ctx, deps: { slack: nativeSend } })).rejects.toThrow(
+        "channels.slack.accounts.work.botToken",
+      );
+      expect(nativeSend).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(sendMethods.filter(({ kind }) => kind !== "text"))(
+    "rejects bare Enterprise targets before an injected $kind send",
+    async ({ send }) => {
+      const nativeSend = createNativeSender();
+      const installation = registerSlackInstallationState("work", "enterprise");
+      try {
+        await expect(send({ ...createContext(), deps: { slack: nativeSend } })).rejects.toThrow(
+          "unsupported_enterprise_slack_delivery",
+        );
+        expect(nativeSend).not.toHaveBeenCalled();
+      } finally {
+        installation.release();
+      }
+    },
+  );
+
+  it.each(["implicit", "explicit"] as const)(
+    "preserves %s first-mode replies without resurrecting a consumed fallback thread",
+    async (source) => {
+      const nativeSend = createNativeSender();
+      const progress: OutboundDeliveryResult[] = [];
+      const result = await slackPlugin.outbound!.sendPayload!({
+        ...createContext(),
+        payload: {
+          text: "caption",
+          mediaUrls: ["https://example.invalid/1.png", "https://example.invalid/2.png"],
+        },
+        replyToId: "internal-message-id",
+        threadId: "1712345678.123456",
+        replyToMode: "first",
+        replyToIdSource: source,
+        deps: { slack: nativeSend },
+        onDeliveryResult: (delivery) => {
+          progress.push(delivery);
+        },
+      });
+
+      expect(nativeSend.mock.calls.map((call) => call[2].threadTs)).toEqual([
+        "1712345678.123456",
+        source === "explicit" ? "1712345678.123456" : undefined,
+      ]);
+      expect(nativeSend.mock.calls.map(([, text]) => text)).toEqual(["caption", ""]);
+      expect(progress.map(({ messageId }) => messageId)).toEqual(["171.001", "171.002"]);
+      expect(result).toMatchObject({ channel: "slack", messageId: "171.002" });
+    },
+  );
+
+  it.each([{ postAs: "user" as const }, { userTokenReadOnly: false }])(
+    "keeps the selected sender and write token throughout payload fanout: %j",
+    async (identity) => {
+      const account: SlackAccountConfig = {
+        mode: "http",
+        userToken: "test-first-token",
+        ...identity,
+      };
+      const nativeSend = createNativeSender();
+      const replacementSend = createNativeSender();
+      const deps = { slack: nativeSend };
+      const firstSend = nativeSend.getMockImplementation()!;
+      nativeSend.mockImplementationOnce(async (...args) => {
+        account.userToken = "test-replacement-token";
+        deps.slack = replacementSend;
+        return await firstSend(...args);
+      });
+
+      const result = await slackPlugin.outbound!.sendPayload!({
+        ...createContext(account),
+        deps,
+        payload: {
+          text: "done",
+          mediaUrls: ["https://example.invalid/image.png"],
+          presentation: { blocks: [{ type: "divider" }] },
+        },
+      });
+
+      expect(nativeSend.mock.calls.map((call) => call[2].token)).toEqual([
+        "test-first-token",
+        "test-first-token",
+      ]);
+      expect(replacementSend).not.toHaveBeenCalled();
+      expect(result.receipt?.platformMessageIds).toEqual(["171.001", "171.002"]);
+    },
+  );
+});

--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -1172,13 +1172,17 @@ describe("slackPlugin outbound", () => {
       identity: { name: "Pulse", emoji: "📟" },
     });
 
-    expectRecordFields(requireMockCallArg(sendMessageSlackMock, 0, 2), "send options", {
-      identity: {
-        username: "Pulse",
-        iconUrl: undefined,
-        iconEmoji: "📟",
-      },
-    });
+    expect(sendMessageSlackMock).toHaveBeenCalledWith(
+      "C123",
+      "heartbeat alert",
+      expect.objectContaining({
+        identity: {
+          username: "Pulse",
+          iconUrl: undefined,
+          iconEmoji: "📟",
+        },
+      }),
+    );
   });
 
   it("forwards partial-send progress through the registered Slack sender", async () => {
@@ -1576,41 +1580,52 @@ describe("slackPlugin outbound", () => {
     });
 
     expect(sendSlack).toHaveBeenCalledTimes(3);
-    expect(requireMockCallArgValue(sendSlack, 0, 0)).toBe("C999");
-    expect(requireMockCallArgValue(sendSlack, 0, 1)).toBe("");
-    expectRecordFields(requireMockCallArg(sendSlack, 0, 2), "first media options", {
+    expect(sendSlack).toHaveBeenNthCalledWith(1, "C999", "", {
+      cfg,
+      threadTs: undefined,
+      accountId: "default",
       mediaUrl: "https://example.com/1.png",
+      mediaAccess: undefined,
       mediaLocalRoots: ["/tmp/media"],
+      mediaReadFile: undefined,
     });
-    expect(requireMockCallArgValue(sendSlack, 1, 0)).toBe("C999");
-    expect(requireMockCallArgValue(sendSlack, 1, 1)).toBe("");
-    expectRecordFields(requireMockCallArg(sendSlack, 1, 2), "second media options", {
+    expect(sendSlack).toHaveBeenNthCalledWith(2, "C999", "", {
+      cfg,
+      threadTs: undefined,
+      accountId: "default",
       mediaUrl: "https://example.com/2.png",
+      mediaAccess: undefined,
       mediaLocalRoots: ["/tmp/media"],
+      mediaReadFile: undefined,
     });
-    expect(requireMockCallArgValue(sendSlack, 2, 0)).toBe("C999");
-    expect(requireMockCallArgValue(sendSlack, 2, 1)).toBe("hello\n\nBlock body");
-    expect(requireMockCallArg(sendSlack, 2, 2).blocks).toEqual([
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: "hello",
-          verbatim: true,
+    expect(sendSlack).toHaveBeenNthCalledWith(3, "C999", "hello\n\nBlock body", {
+      cfg,
+      threadTs: undefined,
+      accountId: "default",
+      authoredTextPlacement: "blocks",
+      blocks: [
+        {
+          type: "section",
+          text: { type: "mrkdwn", text: "hello", verbatim: true },
         },
-      },
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: "Block body",
+        {
+          type: "section",
+          text: { type: "mrkdwn", text: "Block body" },
         },
-      },
-    ]);
+      ],
+    });
     expect(result).toMatchObject({
       channel: "slack",
       messageId: "m-final",
-      receipt: { platformMessageIds: ["m-media-1", "m-media-2", "m-final"] },
+      receipt: {
+        platformMessageIds: ["m-media-1", "m-media-2", "m-final"],
+        primaryPlatformMessageId: "m-media-1",
+        parts: [
+          { index: 0, platformMessageId: "m-media-1" },
+          { index: 1, platformMessageId: "m-media-2" },
+          { index: 2, platformMessageId: "m-final" },
+        ],
+      },
     });
   });
 

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -12,7 +12,6 @@ import {
 import {
   createChannelMessageAdapterFromOutbound,
   createRuntimeOutboundDelegates,
-  resolveOutboundSendDep,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { createPairingPrefixStripper } from "openclaw/plugin-sdk/channel-pairing";
 import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk/channel-send-result";
@@ -164,8 +163,6 @@ function shouldTreatSlackDeliveredTextAsVisible(params: {
   );
 }
 
-type SlackSendFn = typeof import("./send.runtime.js").sendMessageSlack;
-
 const loadSlackDirectoryConfigModule = createLazyRuntimeModule(
   () => import("./directory-config.js"),
 );
@@ -183,30 +180,6 @@ const loadSlackProbeModule = createLazyRuntimeModule(() => import("./probe.js"))
 const loadSlackMonitorModule = createLazyRuntimeModule(() => import("./monitor.js"));
 
 const loadSlackDirectoryLiveModule = createLazyRuntimeModule(() => import("./directory-live.js"));
-
-async function resolveSlackSendContext(params: {
-  cfg: Parameters<typeof resolveSlackAccount>[0]["cfg"];
-  accountId?: string;
-  to: string;
-  deps?: { [channelId: string]: unknown };
-  replyToId?: string | number | null;
-  threadId?: string | number | null;
-}) {
-  // params.cfg is the scoped channel-dispatch config; channel credentials are
-  // expected to be resolved from this snapshot. Strict mode
-  // is intentional so boot-time misconfigurations surface loudly. See #68237.
-  const account = resolveSlackAccount({ cfg: params.cfg, accountId: params.accountId });
-  const target = parseSlackTarget(params.to, { defaultKind: "channel" });
-  assertSlackDetachedTargetAllowed(account.accountId, target?.teamId);
-  const send =
-    resolveOutboundSendDep<SlackSendFn>(params.deps, "slack") ??
-    (await loadSlackSendRuntime()).sendMessageSlack;
-  const token = resolveSlackOperationToken(account, "write");
-  const botToken = account.botToken?.trim();
-  const tokenOverride = token && token !== botToken ? token : undefined;
-  const threadTsValue = resolveSlackThreadTsValue(params);
-  return { send, threadTsValue, tokenOverride, to: params.to };
-}
 
 async function setSlackHeartbeatThreadStatus(params: {
   cfg: OpenClawConfig;
@@ -249,25 +222,6 @@ async function setSlackHeartbeatThreadStatus(params: {
   } catch (error) {
     logVerbose(`slack heartbeat status update failed: ${formatSlackError(error)}`);
   }
-}
-
-function withSlackSendOverride(params: {
-  deps?: { [channelId: string]: unknown } | null;
-  send: SlackSendFn;
-  tokenOverride?: string;
-}) {
-  return {
-    ...params.deps,
-    slack: async (
-      to: Parameters<SlackSendFn>[0],
-      text: Parameters<SlackSendFn>[1],
-      opts: Parameters<SlackSendFn>[2],
-    ) =>
-      await params.send(to, text, {
-        ...opts,
-        ...(params.tokenOverride ? { token: params.tokenOverride } : {}),
-      }),
-  };
 }
 
 function resolveSlackRouteTarget(raw: string) {
@@ -511,72 +465,16 @@ const slackChannelOutbound: ChannelOutboundAdapter = {
     },
   }),
   sendPayload: async (ctx) => {
-    const { send, threadTsValue, tokenOverride, to } = await resolveSlackSendContext({
-      cfg: ctx.cfg,
-      accountId: ctx.accountId ?? undefined,
-      to: ctx.to,
-      deps: ctx.deps,
-      replyToId: ctx.replyToId,
-      threadId: ctx.threadId,
-    });
     const { slackOutbound } = await loadSlackOutboundAdapterModule();
-    return await slackOutbound.sendPayload!({
-      ...ctx,
-      to,
-      replyToId: threadTsValue,
-      threadId: null,
-      deliveryQueueId: undefined,
-      deps: withSlackSendOverride({
-        deps: ctx.deps,
-        send,
-        tokenOverride,
-      }),
-    });
+    return await slackOutbound.sendPayload!(ctx);
   },
   sendText: async (ctx) => {
-    const { send, threadTsValue, tokenOverride, to } = await resolveSlackSendContext({
-      cfg: ctx.cfg,
-      accountId: ctx.accountId ?? undefined,
-      to: ctx.to,
-      deps: ctx.deps,
-      replyToId: ctx.replyToId,
-      threadId: ctx.threadId,
-    });
     const { slackOutbound } = await loadSlackOutboundAdapterModule();
-    return await slackOutbound.sendText!({
-      ...ctx,
-      to,
-      replyToId: threadTsValue,
-      threadId: null,
-      deps: withSlackSendOverride({
-        deps: ctx.deps,
-        send,
-        tokenOverride,
-      }),
-    });
+    return await slackOutbound.sendText!(ctx);
   },
   sendMedia: async (ctx) => {
-    const { send, threadTsValue, tokenOverride, to } = await resolveSlackSendContext({
-      cfg: ctx.cfg,
-      accountId: ctx.accountId ?? undefined,
-      to: ctx.to,
-      deps: ctx.deps,
-      replyToId: ctx.replyToId,
-      threadId: ctx.threadId,
-    });
     const { slackOutbound } = await loadSlackOutboundAdapterModule();
-    return await slackOutbound.sendMedia!({
-      ...ctx,
-      to,
-      replyToId: threadTsValue,
-      threadId: null,
-      deliveryQueueId: undefined,
-      deps: withSlackSendOverride({
-        deps: ctx.deps,
-        send,
-        tokenOverride,
-      }),
-    });
+    return await slackOutbound.sendMedia!(ctx);
   },
 };
 

--- a/extensions/slack/src/outbound-adapter.test.ts
+++ b/extensions/slack/src/outbound-adapter.test.ts
@@ -75,82 +75,6 @@ describe("slackOutbound", () => {
     });
   });
 
-  it("sends payload media first, then finalizes with blocks", async () => {
-    sendMessageSlackMock
-      .mockResolvedValueOnce({ messageId: "m-media-1" })
-      .mockResolvedValueOnce({ messageId: "m-media-2" })
-      .mockResolvedValueOnce({ messageId: "m-final" });
-
-    const result = await slackOutbound.sendPayload!({
-      cfg,
-      to: "C123",
-      text: "",
-      payload: {
-        text: "final text",
-        mediaUrls: ["https://example.com/1.png", "https://example.com/2.png"],
-        presentation: {
-          blocks: [
-            {
-              type: "text",
-              text: "Block body",
-            },
-          ],
-        },
-      },
-      mediaLocalRoots: ["/tmp/workspace"],
-      accountId: "default",
-    });
-
-    expect(sendMessageSlackMock).toHaveBeenCalledTimes(3);
-    expect(sendMessageSlackMock).toHaveBeenNthCalledWith(1, "C123", "", {
-      cfg,
-      threadTs: undefined,
-      accountId: "default",
-      mediaUrl: "https://example.com/1.png",
-      mediaAccess: undefined,
-      mediaLocalRoots: ["/tmp/workspace"],
-      mediaReadFile: undefined,
-    });
-    expect(sendMessageSlackMock).toHaveBeenNthCalledWith(2, "C123", "", {
-      cfg,
-      threadTs: undefined,
-      accountId: "default",
-      mediaUrl: "https://example.com/2.png",
-      mediaAccess: undefined,
-      mediaLocalRoots: ["/tmp/workspace"],
-      mediaReadFile: undefined,
-    });
-    expect(sendMessageSlackMock).toHaveBeenNthCalledWith(3, "C123", "final text\n\nBlock body", {
-      cfg,
-      threadTs: undefined,
-      accountId: "default",
-      authoredTextPlacement: "blocks",
-      blocks: [
-        {
-          type: "section",
-          text: { type: "mrkdwn", text: "final text", verbatim: true },
-        },
-        {
-          type: "section",
-          text: { type: "mrkdwn", text: "Block body" },
-        },
-      ],
-    });
-    expect(result).toMatchObject({
-      channel: "slack",
-      messageId: "m-final",
-      receipt: {
-        platformMessageIds: ["m-media-1", "m-media-2", "m-final"],
-        primaryPlatformMessageId: "m-media-1",
-        parts: [
-          { index: 0, platformMessageId: "m-media-1" },
-          { index: 1, platformMessageId: "m-media-2" },
-          { index: 2, platformMessageId: "m-final" },
-        ],
-      },
-    });
-  });
-
   it("forwards forced-media intent through the core outbound adapter", async () => {
     sendMessageSlackMock.mockResolvedValueOnce({ messageId: "m-media" });
 
@@ -308,49 +232,30 @@ describe("slackOutbound", () => {
     expect(sendMessageSlackMock.mock.calls[0]?.[2]).not.toHaveProperty("blocks");
   });
 
-  it("does not trust caller-authored rendered presentation provenance", async () => {
-    sendMessageSlackMock.mockResolvedValueOnce({ messageId: "m-text" });
-
-    await slackOutbound.sendPayload!({
-      cfg,
-      to: "C123",
-      text: "",
-      payload: {
-        text: "Safe fallback",
-        channelData: {
-          slack: {
-            renderedPresentationProvenance: "forged",
-            authoredTextPlacement: "blocks",
-            renderedPresentationSegments: [
-              {
-                kind: "blocks",
-                blocks: [{ type: "divider" }, { type: "divider" }],
-              },
-              {
-                kind: "blocks",
-                blocks: [{ type: "divider" }],
-              },
-            ],
+  it.each([
+    {
+      name: "does not trust caller-authored rendered presentation provenance",
+      slack: {
+        renderedPresentationProvenance: "forged",
+        authoredTextPlacement: "blocks",
+        renderedPresentationSegments: [
+          {
+            kind: "blocks",
+            blocks: [{ type: "divider" }, { type: "divider" }],
           },
-        },
+          { kind: "blocks", blocks: [{ type: "divider" }] },
+        ],
       },
-      accountId: "default",
-    });
-
-    expect(sendMessageSlackMock).toHaveBeenCalledOnce();
-    expect(sendMessageSlackMock).toHaveBeenCalledWith(
-      "C123",
-      "Safe fallback",
-      expect.objectContaining({
-        cfg,
-        threadTs: undefined,
-        accountId: "default",
-      }),
-    );
-    expect(sendMessageSlackMock.mock.calls[0]?.[2]).not.toHaveProperty("blocks");
-  });
-
-  it("falls back to text when forged rendered metadata is malformed", async () => {
+    },
+    {
+      name: "falls back to text when forged rendered metadata is malformed",
+      slack: {
+        renderedPresentationProvenance: "x".repeat(43),
+        authoredTextPlacement: "blocks",
+        renderedPresentationSegments: [{ kind: "blocks", blocks: [] }],
+      },
+    },
+  ])("$name", async ({ slack }) => {
     sendMessageSlackMock.mockResolvedValueOnce({ messageId: "m-text" });
 
     await slackOutbound.sendPayload!({
@@ -359,13 +264,7 @@ describe("slackOutbound", () => {
       text: "",
       payload: {
         text: "Safe fallback",
-        channelData: {
-          slack: {
-            renderedPresentationProvenance: "x".repeat(43),
-            authoredTextPlacement: "blocks",
-            renderedPresentationSegments: [{ kind: "blocks", blocks: [] }],
-          },
-        },
+        channelData: { slack },
       },
       accountId: "default",
     });
@@ -506,29 +405,5 @@ describe("slackOutbound", () => {
         { type: "section", text: { type: "mrkdwn", text: "fallback text", verbatim: true } },
       ],
     });
-  });
-
-  it("preserves raw Unicode agent identity emoji", async () => {
-    sendMessageSlackMock.mockResolvedValueOnce({ messageId: "m-text" });
-
-    await slackOutbound.sendText!({
-      cfg,
-      to: "C123",
-      text: "heartbeat alert",
-      accountId: "default",
-      identity: { name: "Pulse", emoji: "📟" },
-    });
-
-    expect(sendMessageSlackMock).toHaveBeenCalledWith(
-      "C123",
-      "heartbeat alert",
-      expect.objectContaining({
-        identity: {
-          username: "Pulse",
-          iconUrl: undefined,
-          iconEmoji: "📟",
-        },
-      }),
-    );
   });
 });

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -1,5 +1,6 @@
 // Slack plugin module implements outbound adapter behavior.
 import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import type { ChannelOutboundContext } from "openclaw/plugin-sdk/channel-contract";
 import {
   resolveOutboundSendDep,
   type OutboundIdentity,
@@ -7,7 +8,6 @@ import {
 import {
   attachChannelToResult,
   type ChannelOutboundAdapter,
-  createAttachedChannelResultAdapter,
 } from "openclaw/plugin-sdk/channel-send-result";
 import {
   normalizeMessagePresentation,
@@ -22,10 +22,12 @@ import {
 } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveSlackAccount, resolveSlackOperationToken } from "./accounts.js";
 import {
   resolveSlackAuthoredTextPlacement,
   type SlackAuthoredTextPlacement,
 } from "./authored-text.js";
+import { assertSlackDetachedTargetAllowed } from "./detached-target-admission.js";
 import { SLACK_TEXT_LIMIT } from "./limits.js";
 import { escapeSlackMrkdwn } from "./monitor/mrkdwn.js";
 import { SLACK_PRESENTATION_CAPABILITIES } from "./presentation.js";
@@ -49,9 +51,12 @@ type SlackSendFn = typeof import("./send.runtime.js").sendMessageSlack;
 
 function toSlackOutboundResult<T extends { channelId?: string }>(result: T) {
   const { channelId, ...delivery } = result;
-  return channelId === undefined
-    ? delivery
-    : { ...delivery, target: { kind: "channel" as const, id: channelId } };
+  return attachChannelToResult(
+    "slack",
+    channelId === undefined
+      ? delivery
+      : { ...delivery, target: { kind: "channel" as const, id: channelId } },
+  );
 }
 
 type SlackOutboundChannelData = Record<string, unknown> & {
@@ -187,93 +192,64 @@ function readSlackAuthoredTextPlacement(value: unknown): SlackAuthoredTextPlacem
   return value === "none" || value === "blocks" || value === "outside-blocks" ? value : undefined;
 }
 
-async function sendSlackOutboundMessage(params: {
-  cfg: NonNullable<NonNullable<Parameters<SlackSendFn>[2]>["cfg"]>;
-  to: string;
-  text: string;
-  mediaUrl?: string;
-  forceDocument?: boolean;
-  mediaAccess?: {
-    localRoots?: readonly string[];
-    readFile?: (filePath: string) => Promise<Buffer>;
-  };
-  mediaLocalRoots?: readonly string[];
-  mediaReadFile?: (filePath: string) => Promise<Buffer>;
-  blocks?: NonNullable<Parameters<SlackSendFn>[2]>["blocks"];
-  authoredTextPlacement?: SlackAuthoredTextPlacement;
-  nativeDataFallbackBaseText?: string;
-  textIsSlackPlainText?: boolean;
-  accountId?: string | null;
-  deps?: { [channelId: string]: unknown } | null;
-  replyToId?: string | null;
-  threadId?: string | number | null;
-  identity?: OutboundIdentity;
-  deliveryQueueId?: Parameters<
-    NonNullable<ChannelOutboundAdapter["sendText"]>
-  >[0]["deliveryQueueId"];
-  onPlatformSendDispatch?: Parameters<
-    NonNullable<ChannelOutboundAdapter["sendText"]>
-  >[0]["onPlatformSendDispatch"];
-  onDeliveryResult?: Parameters<
-    NonNullable<ChannelOutboundAdapter["sendText"]>
-  >[0]["onDeliveryResult"];
-}) {
-  const send =
-    resolveOutboundSendDep<SlackSendFn>(params.deps, "slack") ??
-    (await loadSlackSendRuntime()).sendMessageSlack;
-  const slackIdentity = resolveSlackSendIdentity(params.identity);
-  const threadTs = resolveSlackThreadTsValue({
-    replyToId: params.replyToId,
-    threadId: params.threadId,
-  });
-  const sendOptions: NonNullable<Parameters<SlackSendFn>[2]> & {
-    authoredTextPlacement?: SlackAuthoredTextPlacement;
-  } = {
-    cfg: params.cfg,
-    threadTs,
-    accountId: params.accountId ?? undefined,
-    ...(params.mediaUrl
-      ? {
-          mediaUrl: params.mediaUrl,
-          mediaAccess: params.mediaAccess,
-          mediaLocalRoots: params.mediaLocalRoots,
-          mediaReadFile: params.mediaReadFile,
-          ...(params.forceDocument ? { forceDocument: true } : {}),
-        }
-      : {}),
-    ...(params.blocks ? { blocks: params.blocks } : {}),
-    ...(params.authoredTextPlacement
-      ? { authoredTextPlacement: params.authoredTextPlacement }
-      : {}),
-    ...(Object.hasOwn(params, "nativeDataFallbackBaseText")
-      ? { nativeDataFallbackBaseText: params.nativeDataFallbackBaseText }
-      : {}),
-    ...(params.textIsSlackPlainText ? { textIsSlackPlainText: true } : {}),
-    ...(slackIdentity ? { identity: slackIdentity } : {}),
-    ...(params.deliveryQueueId ? { deliveryQueueId: params.deliveryQueueId } : {}),
-    ...(params.onPlatformSendDispatch
-      ? { onPlatformSendDispatch: params.onPlatformSendDispatch }
-      : {}),
-    ...(params.onDeliveryResult
-      ? {
-          onDeliveryResult: async (progress) => {
-            await params.onDeliveryResult?.(
-              attachChannelToResult("slack", toSlackOutboundResult(progress)),
-            );
-          },
-        }
-      : {}),
-  };
-  const result = await send(params.to, params.text, sendOptions);
-  return result;
-}
+type SlackOutboundSendParams = ChannelOutboundContext &
+  Pick<
+    Parameters<SlackSendFn>[2],
+    "blocks" | "authoredTextPlacement" | "nativeDataFallbackBaseText" | "textIsSlackPlainText"
+  >;
 
-function createSlackAttachedSendAdapter() {
-  return createAttachedChannelResultAdapter({
-    channel: "slack",
-    sendText: async (ctx) => toSlackOutboundResult(await sendSlackOutboundMessage(ctx)),
-    sendMedia: async (ctx) => toSlackOutboundResult(await sendSlackOutboundMessage(ctx)),
-  });
+async function prepareSlackOutboundSend(ctx: ChannelOutboundContext) {
+  // Sends require the scoped runtime snapshot, including resolved active credentials.
+  // Admission also applies to injected senders, before any platform work begins.
+  const account = resolveSlackAccount({ cfg: ctx.cfg, accountId: ctx.accountId });
+  const target = parseSlackTarget(ctx.to, { defaultKind: "channel" });
+  assertSlackDetachedTargetAllowed(account.accountId, target?.teamId);
+  const send =
+    resolveOutboundSendDep<SlackSendFn>(ctx.deps, "slack") ??
+    (await loadSlackSendRuntime()).sendMessageSlack;
+  const token = resolveSlackOperationToken(account, "write");
+  const botToken = account.botToken?.trim();
+  const tokenOverride = token && token !== botToken ? token : undefined;
+  return async (params: SlackOutboundSendParams) => {
+    const slackIdentity = resolveSlackSendIdentity(params.identity);
+    const threadTs = resolveSlackThreadTsValue(params);
+    const sendOptions: Parameters<SlackSendFn>[2] = {
+      cfg: params.cfg,
+      ...(tokenOverride ? { token: tokenOverride } : {}),
+      threadTs,
+      accountId: params.accountId ?? undefined,
+      ...(params.mediaUrl
+        ? {
+            mediaUrl: params.mediaUrl,
+            mediaAccess: params.mediaAccess,
+            mediaLocalRoots: params.mediaLocalRoots,
+            mediaReadFile: params.mediaReadFile,
+            ...(params.forceDocument ? { forceDocument: true } : {}),
+          }
+        : {}),
+      ...(params.blocks ? { blocks: params.blocks } : {}),
+      ...(params.authoredTextPlacement
+        ? { authoredTextPlacement: params.authoredTextPlacement }
+        : {}),
+      ...(Object.hasOwn(params, "nativeDataFallbackBaseText")
+        ? { nativeDataFallbackBaseText: params.nativeDataFallbackBaseText }
+        : {}),
+      ...(params.textIsSlackPlainText ? { textIsSlackPlainText: true } : {}),
+      ...(slackIdentity ? { identity: slackIdentity } : {}),
+      ...(params.deliveryQueueId ? { deliveryQueueId: params.deliveryQueueId } : {}),
+      ...(params.onPlatformSendDispatch
+        ? { onPlatformSendDispatch: params.onPlatformSendDispatch }
+        : {}),
+      ...(params.onDeliveryResult
+        ? {
+            onDeliveryResult: async (progress) => {
+              await params.onDeliveryResult?.(toSlackOutboundResult(progress));
+            },
+          }
+        : {}),
+    };
+    return await send(params.to, params.text, sendOptions);
+  };
 }
 
 export const slackOutbound: ChannelOutboundAdapter = {
@@ -289,12 +265,21 @@ export const slackOutbound: ChannelOutboundAdapter = {
       : null;
   },
   sendPayload: async (ctx) => {
+    const send = await prepareSlackOutboundSend(ctx);
+    const preparedCtx = {
+      ...ctx,
+      replyToId: resolveSlackThreadTsValue(ctx),
+      // Keeping the fallback thread would resurrect an implicit reply consumed by fanout.
+      threadId: null,
+      // Only text sends can reconcile an unknown send with one provider marker.
+      deliveryQueueId: undefined,
+    };
     const payload = {
-      ...ctx.payload,
+      ...preparedCtx.payload,
       text:
         resolveLegacyInteractiveTextFallback({
-          text: ctx.payload.text,
-          interactive: ctx.payload.interactive,
+          text: preparedCtx.payload.text,
+          interactive: preparedCtx.payload.interactive,
         }) ?? "",
     };
     const slackData = payload.channelData?.slack as SlackOutboundChannelData | undefined;
@@ -306,10 +291,12 @@ export const slackOutbound: ChannelOutboundAdapter = {
       resolution = resolveSlackOutboundBlockResolution(payload);
     }
     if (resolution.segments.length === 0) {
+      const sendPart = async (part: ChannelOutboundContext) =>
+        toSlackOutboundResult(await send(part));
       return await sendTextMediaPayload({
         channel: "slack",
-        ctx: { ...ctx, payload },
-        adapter: slackOutbound,
+        ctx: { ...preparedCtx, payload },
+        adapter: { sendText: sendPart, sendMedia: sendPart },
       });
     }
     const mediaUrls = resolvePayloadMediaUrls(payload);
@@ -318,46 +305,40 @@ export const slackOutbound: ChannelOutboundAdapter = {
       segments: resolution.segments,
       text: payload.text,
     });
-    const useSingleDeliveryMarker = mediaUrls.length === 0 && deliveryMessages.length === 1;
     const sentResults: Awaited<ReturnType<SlackSendFn>>[] = [];
-    return attachChannelToResult(
-      "slack",
-      toSlackOutboundResult(
-        await sendPayloadMediaSequenceAndFinalize({
-          text: "",
-          mediaUrls,
-          send: async ({ text, mediaUrl }) =>
-            await sendSlackOutboundMessage({
-              ...ctx,
-              text,
-              mediaUrl,
-              deliveryQueueId: useSingleDeliveryMarker ? ctx.deliveryQueueId : undefined,
-            }),
-          onResult: (result) => {
-            sentResults.push(result);
-          },
-          finalize: async () => {
-            for (const message of deliveryMessages) {
-              sentResults.push(
-                await sendSlackOutboundMessage({
-                  ...ctx,
-                  text: message.text,
-                  ...(message.blocks ? { blocks: message.blocks } : {}),
-                  ...(message.authoredTextPlacement
-                    ? { authoredTextPlacement: message.authoredTextPlacement }
-                    : {}),
-                  ...(message.nativeDataFallbackBaseText
-                    ? { nativeDataFallbackBaseText: message.nativeDataFallbackBaseText }
-                    : {}),
-                  ...(message.textIsSlackPlainText ? { textIsSlackPlainText: true } : {}),
-                  deliveryQueueId: useSingleDeliveryMarker ? ctx.deliveryQueueId : undefined,
-                }),
-              );
-            }
-            return mergeSlackSendResults(sentResults);
-          },
-        }),
-      ),
+    return toSlackOutboundResult(
+      await sendPayloadMediaSequenceAndFinalize({
+        text: "",
+        mediaUrls,
+        send: async ({ text, mediaUrl }) =>
+          await send({
+            ...preparedCtx,
+            text,
+            mediaUrl,
+          }),
+        onResult: (result) => {
+          sentResults.push(result);
+        },
+        finalize: async () => {
+          for (const message of deliveryMessages) {
+            sentResults.push(
+              await send({
+                ...preparedCtx,
+                text: message.text,
+                ...(message.blocks ? { blocks: message.blocks } : {}),
+                ...(message.authoredTextPlacement
+                  ? { authoredTextPlacement: message.authoredTextPlacement }
+                  : {}),
+                ...(message.nativeDataFallbackBaseText
+                  ? { nativeDataFallbackBaseText: message.nativeDataFallbackBaseText }
+                  : {}),
+                ...(message.textIsSlackPlainText ? { textIsSlackPlainText: true } : {}),
+              }),
+            );
+          }
+          return mergeSlackSendResults(sentResults);
+        },
+      }),
     );
   },
   afterDeliverPayload: async ({ cfg, target, payload, results }) => {
@@ -426,5 +407,12 @@ export const slackOutbound: ChannelOutboundAdapter = {
       },
     });
   },
-  ...createSlackAttachedSendAdapter(),
+  sendText: async (ctx) => {
+    const send = await prepareSlackOutboundSend(ctx);
+    return toSlackOutboundResult(await send(ctx));
+  },
+  sendMedia: async (ctx) => {
+    const send = await prepareSlackOutboundSend(ctx);
+    return toSlackOutboundResult(await send({ ...ctx, deliveryQueueId: undefined }));
+  },
 };


### PR DESCRIPTION
## What Problem This Solves

Slack outbound delivery split message preparation between the channel entry point and the outbound adapter. Sender selection, token overrides, reply targeting, and text-only reconciliation markers therefore depended on duplicated private call shapes. The public entry point performed preparation that direct private-adapter tests did not exercise.

## Why This Change Was Made

The outbound adapter is now the single preparation owner. The channel passes the original delivery inputs directly, and preparation selects the sender and token override once. Per-fragment reply targeting, dispatch, and progress callbacks remain child-specific, while `deliveryQueueId` continues to mark only text reconciliation. The old private production helpers and dependency-injection wrapper are removed. Overlapping tests are consolidated at the public entry point, while distinct private presentation and security tests are retained.

Retaining both preparation layers would preserve the violated ownership boundary, while moving Slack-specific preparation into a generic cross-plugin abstraction would broaden policy without another consumer. The adapter-local owner is the narrow canonical flow.

## User Impact

No intended user-visible behavior, public API, configuration, protocol, dependency, or Slack policy changes. Sender selection, token overrides, per-fragment reply fanout and callbacks, text-only reconciliation markers, custody propagation, and delivery receipts retain their existing behavior through one canonical owner.

## Evidence

- Source-blind pre-change baseline: 8/8 public calls passed with OS confinement. M4 intentionally mutates its own synthetic config/dependency inputs to prove sender and token pinning; this is fixture-owned mutation, not a production-input immutability claim.
- Final focused owner and sibling proof: 232 tests passed.
- Complete changed-file gate: exit 0.
- Fresh isolated P0 Codex review: no findings, 0.96 confidence.
- Exact committed-head full build: exit 0 in 6m52.8s with all three head stamps matching `71630047b94903e6cddf449479bb79ee784047cb`.
- Source-blind candidate comparison: 8/8 public calls passed with exact baseline output and transport parity after accounting only for expected candidate identity and private-path fields; zero redaction failures.
- Source audit covered the public channel entry, outbound adapter, native send queueing, custody/receipt propagation, and the retained presentation and security test boundaries.
- Behavior proof uses a local injected Slack transport through the public entry point; it is source-blind but not live Slack, and uses no live credentials, network, or API.
- Production LOC: net -114. Tests: net +78. Total: net -36.
