### PR TITLE
fix(test): run explicitly requested untracked tests

### DIFF
--- a/test/vitest-unit-fast-config.test.ts
+++ b/test/vitest-unit-fast-config.test.ts
@@ -1,5 +1,9 @@
 // Vitest unit-fast config tests validate fast unit test project setup.
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { beforeAll, describe, expect, it } from "vitest";
 import { spawnNodeEvalSync } from "../src/test-utils/node-process.js";
 import { cliProcessTestFiles } from "./vitest/vitest.cli-process-paths.mjs";
@@ -90,7 +94,7 @@ describe("unit-fast vitest lane", () => {
           const stdout = [
             "src/agents/agent-tools.deferred-followup-guidance.test.ts",
             "src/hooks/frontmatter.test.ts",
-          ].join("\\n") + "\\n";
+          ].join("\\0") + "\\0";
           return {
             pid: 0,
             output: [null, stdout, ""],
@@ -163,6 +167,84 @@ describe("unit-fast vitest lane", () => {
     expect(Number(probeMatch?.[2])).toBeLessThan(20);
     expect(Number(probeMatch?.[3])).toBe(1);
     expect(Number(probeMatch?.[4])).toBe(0);
+  });
+
+  it("keeps untracked tests in their planned fast lane and execution include list", () => {
+    const cwd = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-untracked-")));
+    const pure = "src/hooks/pure.test.ts";
+    const stateful = "src/hooks/stateful.test.ts";
+    const quoted = "src/hooks/quoted-é.test.ts";
+    const ignored = "src/hooks/ignored.test.ts";
+    const moduleUrl = (file: string) => JSON.stringify(pathToFileURL(path.resolve(file)).href);
+    try {
+      fs.mkdirSync(path.join(cwd, "src/hooks"), { recursive: true });
+      fs.writeFileSync(path.join(cwd, ".gitignore"), `${ignored}\n`);
+      for (const file of [pure, quoted, ignored]) {
+        fs.writeFileSync(
+          path.join(cwd, file),
+          'import { it } from "vitest"; it("pure", () => {});',
+        );
+      }
+      fs.writeFileSync(
+        path.join(cwd, stateful),
+        'import { it } from "vitest"; import { check } from "./stateful.test-support.js"; it("helper", check);',
+      );
+      fs.writeFileSync(
+        path.join(cwd, "src/hooks/stateful.test-support.ts"),
+        'import { vi } from "vitest"; export const check = vi.fn();',
+      );
+      expect(spawnSync("git", ["init"], { cwd }).status).toBe(0);
+      expect(
+        spawnSync("git", ["ls-files", "--error-unmatch", "--", pure, stateful], { cwd }).status,
+      ).toBe(1);
+      // Fresh process: discovery snapshots must be taken after the fixture exists.
+      const result = spawnNodeEvalSync(
+        `
+        process.chdir(${JSON.stringify(cwd)});
+        const paths = await import(${moduleUrl("test/vitest/vitest.unit-fast-paths.mjs")});
+        const { createVitestRunSpecs, writeVitestIncludeFile } = await import(${moduleUrl("scripts/test-projects.test-support.mts")});
+        const { createUnitFastVitestConfig } = await import(${moduleUrl("test/vitest/vitest.unit-fast.config.ts")});
+        const { createUnitFastIsolatedVitestConfig } = await import(${moduleUrl("test/vitest/vitest.unit-fast-isolated.config.ts")});
+        const { createScopedVitestConfig } = await import(${moduleUrl("test/vitest/vitest.scoped-config.ts")});
+        const fs = await import("node:fs");
+        const specs = createVitestRunSpecs(${JSON.stringify([pure, stateful])}, { baseEnv: {} });
+        const factories = {
+          "test/vitest/vitest.unit-fast.config.ts": createUnitFastVitestConfig,
+          "test/vitest/vitest.unit-fast-isolated.config.ts": createUnitFastIsolatedVitestConfig,
+        };
+        try {
+          const runs = specs.map((spec) => {
+            writeVitestIncludeFile(spec.includeFilePath, spec.includePatterns);
+            return { config: spec.config, include: factories[spec.config](spec.env).test.include };
+          });
+          console.log(JSON.stringify({
+            inventory: paths.getUnitFastTestFiles(),
+            isolated: paths.getUnitFastIsolatedTestFiles(),
+            runs,
+            excluded: createScopedVitestConfig(["src/hooks/**/*.test.ts"], { env: {} }).test.exclude
+              .filter((file) => file.startsWith("src/hooks/")),
+            ignored: paths.resolveUnitFastTestIncludePattern(${JSON.stringify(ignored)}),
+          }));
+        } finally {
+          for (const spec of specs) fs.rmSync(spec.includeFilePath, { force: true });
+        }
+      `,
+        { imports: ["tsx"] },
+      );
+      expect(result.status, result.stderr).toBe(0);
+      expect(JSON.parse(result.stdout)).toEqual({
+        inventory: [pure, quoted, stateful],
+        isolated: [stateful],
+        runs: [
+          { config: "test/vitest/vitest.unit-fast.config.ts", include: [pure] },
+          { config: "test/vitest/vitest.unit-fast-isolated.config.ts", include: [stateful] },
+        ],
+        excluded: [pure, quoted, stateful],
+        ignored: null,
+      });
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
   });
 
   it("runs cache-friendly tests without the reset-heavy runner or runtime setup", () => {

--- a/test/vitest/vitest.commands-light-paths.d.mts
+++ b/test/vitest/vitest.commands-light-paths.d.mts
@@ -1,4 +1,3 @@
-export const commandsLightSourceFiles: string[];
 export const commandsLightTestFiles: string[];
 export function isCommandsLightTarget(file: string): boolean;
 export function resolveCommandsLightIncludePattern(file: string): string | null;

--- a/test/vitest/vitest.commands-light-paths.mjs
+++ b/test/vitest/vitest.commands-light-paths.mjs
@@ -91,9 +91,6 @@ const commandsLightIncludePatternByFile = new Map(
   ),
 );
 
-export const commandsLightSourceFiles = commandsLightEntries.flatMap(({ source }) =>
-  source ? [source] : [],
-);
 export const commandsLightTestFiles = commandsLightEntries.map(({ test }) => test);
 
 export function isCommandsLightTarget(file) {

--- a/test/vitest/vitest.plugin-sdk-paths.d.mts
+++ b/test/vitest/vitest.plugin-sdk-paths.d.mts
@@ -1,4 +1,3 @@
-export const pluginSdkLightSourceFiles: string[];
 export const pluginSdkLightTestFiles: string[];
 export function isPluginSdkLightTarget(file: string): boolean;
 export function resolvePluginSdkLightIncludePattern(file: string): string | null;

--- a/test/vitest/vitest.plugin-sdk-paths.mjs
+++ b/test/vitest/vitest.plugin-sdk-paths.mjs
@@ -45,7 +45,6 @@ const pluginSdkLightIncludePatternByFile = new Map(
   ]),
 );
 
-export const pluginSdkLightSourceFiles = pluginSdkLightEntries.map(({ source }) => source);
 export const pluginSdkLightTestFiles = pluginSdkLightEntries.map(({ test }) => test);
 
 export function isPluginSdkLightTarget(file) {

--- a/test/vitest/vitest.unit-fast-paths.mjs
+++ b/test/vitest/vitest.unit-fast-paths.mjs
@@ -3,11 +3,8 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { cliProcessTestFiles } from "./vitest.cli-process-paths.mjs";
-import {
-  commandsLightSourceFiles,
-  commandsLightTestFiles,
-} from "./vitest.commands-light-paths.mjs";
-import { pluginSdkLightSourceFiles, pluginSdkLightTestFiles } from "./vitest.plugin-sdk-paths.mjs";
+import { commandsLightTestFiles } from "./vitest.commands-light-paths.mjs";
+import { pluginSdkLightTestFiles } from "./vitest.plugin-sdk-paths.mjs";
 import { isToolingIsolatedTestFile } from "./vitest.tooling-isolated-paths.mjs";
 import { boundaryTestFiles, bundledPluginDependentUnitTestFiles } from "./vitest.unit-paths.mjs";
 
@@ -155,10 +152,6 @@ export const forcedUnitFastTestFiles = [
 const forcedUnitFastTestFileSet = new Set(forcedUnitFastTestFiles);
 const unitFastCandidateExactFiles = [...pluginSdkLightTestFiles, ...commandsLightTestFiles];
 const unitFastCandidateExactFileSet = new Set(unitFastCandidateExactFiles);
-const unitFastSourceExactFileSet = new Set([
-  ...pluginSdkLightSourceFiles,
-  ...commandsLightSourceFiles,
-]);
 const broadUnitFastCandidateGlobs = [
   "src/**/*.test.ts",
   "packages/**/*.test.ts",
@@ -345,17 +338,29 @@ function walkFiles(directory, files = []) {
 const walkedTestFilesByCwd = new Map();
 
 function collectRepoTestFilesFromGit(cwd) {
-  const result = spawnSync("git", ["ls-files", "--", "src", "packages", "test"], {
-    cwd,
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "ignore"],
-  });
+  // Planning, fast-lane includes, and scoped exclusions share this inventory.
+  // New working-tree tests must be present so explicit targets cannot become empty lanes.
+  const result = spawnSync(
+    "git",
+    [
+      "ls-files",
+      "--cached",
+      "--others",
+      "--exclude-standard",
+      "-z",
+      "--",
+      "src",
+      "packages",
+      "test",
+    ],
+    { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+  );
   if (result.status !== 0) {
     return null;
   }
   return result.stdout
-    .split("\n")
-    .map((file) => normalizeRepoPath(file.trim()))
+    .split("\0")
+    .map(normalizeRepoPath)
     .filter((file) => file.endsWith(".test.ts"));
 }
 
@@ -655,14 +660,6 @@ function getUnitFastIsolatedTestFileSet() {
   return cachedUnitFastIsolatedTestFileSet;
 }
 
-function isUnitFastTestFileOnDemand(file, cwd = process.cwd()) {
-  const normalized = normalizeRepoPath(file);
-  if (!isUnitFastCandidateFile(normalized)) {
-    return false;
-  }
-  return analyzeUnitFastTestFile(cwd, normalized).unitFast;
-}
-
 export function isUnitFastTestFile(file) {
   return getUnitFastTestFileSet().has(normalizeRepoPath(file));
 }
@@ -683,7 +680,7 @@ export function resolveUnitFastTestIncludePattern(file) {
   if (isUnitFastIsolatedTestFile(normalized)) {
     return null;
   }
-  if (isUnitFastTestFileOnDemand(normalized)) {
+  if (isUnitFastTestFile(normalized)) {
     return normalized;
   }
   const siblingTestFile = normalized.replace(/\.ts$/u, ".test.ts");
@@ -693,14 +690,7 @@ export function resolveUnitFastTestIncludePattern(file) {
   if (isUnitFastIsolatedTestFile(siblingTestFile)) {
     return null;
   }
-  if (isUnitFastTestFileOnDemand(siblingTestFile)) {
-    return siblingTestFile;
-  }
-  if (unitFastSourceExactFileSet.has(normalized)) {
-    const exactTestFile = normalized.replace(/\.ts$/u, ".test.ts");
-    return isUnitFastTestFileOnDemand(exactTestFile) ? exactTestFile : null;
-  }
-  return null;
+  return isUnitFastTestFile(siblingTestFile) ? siblingTestFile : null;
 }
 
 export function resolveUnitFastTimerTestIncludePattern(file) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers explicitly running a new, nonignored test before `git add` could receive a successful result without the test running. A test importing a stateful helper could also be planned for the regular fast lane instead of its isolated lane.

## Why This Change Was Made

The shared fast-test inventory read tracked Git files only, while target resolution separately classified files on demand. Discovery now uses Git's cached and nonignored untracked inventory with NUL-delimited paths, and regular target resolution uses that same inventory. Planning, fast-lane execution includes, and scoped exclusions therefore agree; the redundant on-demand classifier and exact-source fallback are removed, along with the source arrays and declarations that became unused.

This is a bounded, maintainer-requested test-tooling repair. Forcing a Vitest config or rejecting empty suites would leave the discovery and lane-ownership mismatch unfixed. AI-assisted; reviewed with Codex.

## User Impact

New nonignored tests can run before staging, in their appropriate regular or isolated fast lane. Git-ignored files remain outside this inventory, and Unicode paths are preserved. No product runtime behavior, setup, public configuration, dependency, or persistence changes.

## Evidence

The real wrapper was exercised with a temporary untracked target using `node scripts/run-vitest.mjs test/untracked-discovery-proof/sentinel.test.ts`. Git confirmed that the target was both untracked and nonignored. Before the fix it reported “No test files found” and exited 0; after the fix the same deliberately failing assertion ran in `unit-fast-isolated` and exited 1. With the assertion corrected, a pure target and a stateful-helper target both passed in their respective lanes.

The new regression uses a real temporary Git repository and a fresh process. It covers pure and stateful-helper tests, an ignored file, a Unicode filename, exact planned execution includes, and scoped exclusions. It failed against the original discovery owner (empty inventory/includes/exclusions and incorrect ignored-file resolution), then passed with the fix.

Validation distinguishes the original base from the rebased head:

- Original base: 607 tests across seven focused files passed, including all 14 inventory/config tests. The new regression failed before the owner fix and passed afterward.
- Rebased head `bb5852dd9d6f11dc6a3305da5886fa140f199c24`: the exact-once ownership audit passed all 23 tests, scoped `check-changed` passed, and the real wrapper sentinel proof above was repeated successfully. The patch is byte-identical to the independently reviewed diff; fresh Codex autoreview reported no actionable findings.
- The six-file tooling portion of the rebased aggregate hit the existing 900-second no-output watchdog twice, including the wrapper's built-in retry, and the aggregate exited 143. This is not a passing test result. The diagnostic run of the same six files with only `--reporter=verbose` added completed successfully: 601 tests in six files, including the new regression, passed in 656.30 seconds overall. Assertions, configuration, environment, and timeout settings were unchanged. Together with the 23-test ownership audit, 624 focused tests passed on this base. The two earlier watchdog failures remain failures. Hosted CI found two unused exports left behind by removing the fallback imports: `commandsLightSourceFiles` and `pluginSdkLightSourceFiles` ([failed check](https://github.com/openclaw/openclaw/actions/runs/33137319582/job/98740179582)). Their arrays and matching declarations have no remaining consumers; commit `5188730b25faa774bfff043f5b95e188664a3a6b` deletes the unused arrays and matching declarations (six lines total). Scoped checks for all six PR files and production/full-tree/script unused-export scans passed with zero findings. Fresh Codex autoreview of the cleanup plus original repair context found no actionable issues. The first CI run had no other failing job; [new exact-head CI run 33138450655 passed](https://github.com/openclaw/openclaw/actions/runs/33138450655), including the [required gate](https://github.com/openclaw/openclaw/actions/runs/33138450655/job/98745157857). No full-suite claim.

Focused command:

```sh
node scripts/run-vitest.mjs test/vitest-unit-fast-config.test.ts test/vitest-projects-config.test.ts test/vitest-scoped-config.test.ts test/scripts/test-projects.test.ts test/scripts/run-vitest.test.ts test/scripts/ci-node-test-plan.test.ts test/scripts/ci-changed-node-test-plan.test.ts
```

Passing changed-file gate:

```sh
node scripts/check-changed.mjs -- test/vitest-unit-fast-config.test.ts test/vitest/vitest.unit-fast-paths.mjs
```

The temp-directory reporter emitted an advisory for the regression's temporary repository; the fixture is cleaned in `finally`.

LOC: tooling +23/-39 (net -16, including two declaration lines); tests +83/-1 (net +82). No shipped product source changed. The test growth is the missing real-Git boundary regression, with no new test-only production seam.

Provenance limitation: the implicated tracked-only discovery line reaches the local shallow-history boundary, so the introducing commit/PR and merger are not established; no author attribution is inferred from that boundary.

Late review disposition: [ClawSweeper independently passed all 14 inventory/config tests and found no code or security defects](https://github.com/openclaw/openclaw/pull/131453#issuecomment-5448126144). Its review was published after merge submission; its CI and maintainer-review items were both satisfied before native landing. The [squash merge](https://github.com/openclaw/openclaw/commit/73de6752f0e3c59e0353d0ffdbbaac90214330de) contains exactly the six reviewed paths, with identical file contents.
