### PR TITLE
fix: preserve ordering for nested session writes

### DIFF
--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -1465,10 +1465,10 @@ describe("session accessor seam", () => {
       messages: [
         {
           message: { role: "user", content: "rotate-hello", timestamp: Date.now() },
-          shouldAppend: async () => {
+          shouldAppend: () => {
             // Simulate a concurrent reset rotating the session id between target
-            // resolution and the transcript append.
-            await replaceSessionEntry(
+            // resolution and the transcript append. Sync writers bypass the process queue.
+            replaceSessionEntrySync(
               { sessionKey: scope.sessionKey, storePath },
               { sessionId: "new-rotate-session", updatedAt: Date.now() },
             );
@@ -1512,8 +1512,8 @@ describe("session accessor seam", () => {
       messages: [
         {
           message: { role: "user", content: "default-rotate-hello", timestamp: Date.now() },
-          shouldAppend: async () => {
-            await replaceSessionEntry(
+          shouldAppend: () => {
+            replaceSessionEntrySync(
               { sessionKey: scope.sessionKey, storePath: expectedStorePath },
               { sessionId: "new-default-rotate", updatedAt: Date.now() },
             );
@@ -1637,8 +1637,8 @@ describe("session accessor seam", () => {
       messages: [
         {
           message: { role: "user", content: "durable-fallback-hello", timestamp: Date.now() },
-          shouldAppend: async () => {
-            await replaceSessionEntry(
+          shouldAppend: () => {
+            replaceSessionEntrySync(
               { sessionKey: scope.sessionKey, storePath },
               { sessionId: "new-durable-fallback", updatedAt: Date.now() },
             );

--- a/src/config/sessions/session-accessor.transcript-turn-initialization.test.ts
+++ b/src/config/sessions/session-accessor.transcript-turn-initialization.test.ts
@@ -11,6 +11,7 @@ import {
   loadTranscriptEvents,
   persistSessionTranscriptTurn,
   replaceSessionEntry,
+  replaceSessionEntrySync,
   type SessionTranscriptTurnPersistOptions,
 } from "./session-accessor.js";
 import { loadTranscriptEventsSync } from "./session-accessor.sqlite-read.js";
@@ -178,9 +179,10 @@ describe("first transcript turn initialization", () => {
         messages: [
           {
             message: { role: "user", content: operation.objective },
-            shouldAppend: async () => {
+            shouldAppend: () => {
               if (timing === "during preparation") {
-                await replaceSessionEntry(scope(), competing);
+                // Direct/cross-process writers bypass the process-local queue.
+                replaceSessionEntrySync(scope(), competing);
               }
               return true;
             },

--- a/src/sessions/session-lifecycle-admission.test.ts
+++ b/src/sessions/session-lifecycle-admission.test.ts
@@ -718,8 +718,6 @@ it("serializes lifecycle mutation and work admission across identity aliases", a
       await releaseMutation.promise;
     },
   });
-  await mutationStarted.promise;
-
   let admitted = false;
   const admission = beginSessionWorkAdmission({
     scope: "store-a",
@@ -728,16 +726,20 @@ it("serializes lifecycle mutation and work admission across identity aliases", a
       admitted = true;
     },
   });
-  await Promise.resolve();
-  expect(admitted).toBe(false);
+  try {
+    await mutationStarted.promise;
+    expect(admitted).toBe(false);
 
-  releaseMutation.resolve();
-  await mutation;
-  const admissionLease = await admission;
-  expect(admitted).toBe(true);
-  expect(isSessionWorkAdmissionActive("store-a", ["agent:main:child", "session-1"])).toBe(true);
-
-  admissionLease.release();
+    releaseMutation.resolve();
+    await mutation;
+    await admission;
+    expect(admitted).toBe(true);
+    expect(isSessionWorkAdmissionActive("store-a", ["agent:main:child", "session-1"])).toBe(true);
+  } finally {
+    releaseMutation.resolve();
+    await mutation;
+    (await admission).release();
+  }
   expect(isSessionWorkAdmissionActive("store-a", ["session-1"])).toBe(false);
 });
 

--- a/src/shared/store-writer-queue.test.ts
+++ b/src/shared/store-writer-queue.test.ts
@@ -34,6 +34,37 @@ it("retains each queued writer's caller context through async and reentrant work
   expect(queues.size).toBe(0);
 });
 
+it("queues ordinary nested writes behind the active writer", async () => {
+  const queues = new Map<string, StoreWriterQueue>();
+  const order: string[] = [];
+  let nested: Promise<unknown> | undefined;
+
+  const outer = runQueuedStoreWrite({
+    queues,
+    storePath: "nested-store",
+    label: "outer",
+    fn: async () => {
+      order.push("outer:start");
+      nested = runQueuedStoreWrite({
+        queues,
+        storePath: "nested-store",
+        label: "inner",
+        fn: async () => {
+          order.push("inner");
+          return "inner-result";
+        },
+      });
+      order.push("outer:end");
+      return "outer-result";
+    },
+  });
+
+  await expect(outer).resolves.toBe("outer-result");
+  expect(order).toEqual(["outer:start", "outer:end", "inner"]);
+  await expect(nested).resolves.toBe("inner-result");
+  expect(queues.size).toBe(0);
+});
+
 it("shares reentrant writer context across duplicate module instances", async () => {
   const first = await importFreshModule<typeof import("./store-writer-queue.js")>(
     import.meta.url,

--- a/src/shared/store-writer-queue.ts
+++ b/src/shared/store-writer-queue.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import { createDeferredCore } from "./deferred.js";
 import { resolveGlobalSingleton } from "./global-singleton.js";
 
 /** Pending exclusive store write plus the promise hooks for its caller. */
@@ -82,45 +83,37 @@ async function drainStoreWriterQueue(queues: StoreWriterQueues, storePath: strin
     await queue.drainPromise;
     return;
   }
-  queue.drainPromise = (async () => {
-    // Publish the active drain before invoking a task's synchronous prologue.
-    // A nested enqueue must observe this promise instead of starting a second drain.
-    await Promise.resolve();
-    try {
-      while (queue.pending.length > 0) {
-        const task = queue.pending.shift();
-        if (!task) {
-          continue;
-        }
-        let result: unknown;
-        let failed: unknown;
-        let hasFailure = false;
-        try {
-          result = await task.fn();
-        } catch (err) {
-          hasFailure = true;
-          failed = err;
-        }
-        if (hasFailure) {
-          task.reject(failed);
-          continue;
-        }
-        task.resolve(result);
+  const drain = createDeferredCore();
+  // Publish ownership before the first writer can enqueue more work, without
+  // yielding its place to a competing lifecycle admission on an idle lane.
+  queue.drainPromise = drain.promise;
+  try {
+    while (queue.pending.length > 0) {
+      const task = queue.pending.shift();
+      if (!task) {
+        continue;
       }
-    } finally {
-      queue.drainPromise = null;
-      if (queue.pending.length === 0) {
-        queues.delete(storePath);
-      } else {
-        // Late enqueues after the loop drained run in a fresh microtask so this
-        // drainPromise can settle before the next writer batch starts.
-        queueMicrotask(() => {
-          void drainStoreWriterQueue(queues, storePath);
-        });
+      let result: unknown;
+      let failed: unknown;
+      let hasFailure = false;
+      try {
+        result = await task.fn();
+      } catch (err) {
+        hasFailure = true;
+        failed = err;
       }
+      if (hasFailure) {
+        task.reject(failed);
+        continue;
+      }
+      task.resolve(result);
     }
-  })();
-  await queue.drainPromise;
+  } finally {
+    queue.drainPromise = null;
+    // No enqueue can interleave with this synchronous empty-queue cleanup.
+    queues.delete(storePath);
+    drain.resolve();
+  }
 }
 
 /** Runs one store write after prior writes for the same store path have finished. */

--- a/src/shared/store-writer-queue.ts
+++ b/src/shared/store-writer-queue.ts
@@ -83,6 +83,9 @@ async function drainStoreWriterQueue(queues: StoreWriterQueues, storePath: strin
     return;
   }
   queue.drainPromise = (async () => {
+    // Publish the active drain before invoking a task's synchronous prologue.
+    // A nested enqueue must observe this promise instead of starting a second drain.
+    await Promise.resolve();
     try {
       while (queue.pending.length > 0) {
         const task = queue.pending.shift();


### PR DESCRIPTION
Closes #131113.

## What Problem This Solves

Fixes an issue where a session write that queues another ordinary write can run both callbacks at once. The nested callback can modify the store before the first writer finishes, violating the queue’s serialization guarantee.

## Why This Change Was Made

Publish the shared drain promise before invoking the first callback, using the existing deferred helper. The drain now runs directly in its async owner and settles after synchronous queue cleanup. This preserves the initial writer’s execution order as well as caller context and explicitly requested reentrancy. The old async IIFE and unreachable late-enqueue restart branch are removed.

A first-microtask delay prevents the overlapping drain but changes session lifecycle ordering: an admission invoked after an idle-lane mutation can overtake that mutation. The strengthened existing alias-ordering regression reproduces that behavior on the previous PR head; immediate ownership publication fixes both cases.

The contributor’s nested-write regression and direct-writer SQLite race fixtures are retained. Predicate preparation and authoritative transaction checks remain inside their current owners. No schema, migration, stored representation, configuration, or protocol changes are included. Production code is four lines smaller; tests gain 35 net lines.

## User Impact

Nested session writes remain ordered. Session reset/compaction and work admission keep their existing ordering, and explicitly reentrant calls continue to run within their active owner.

Thanks @Grynn for the report and @gaoanze888 for the original repair and regression coverage.

## Evidence

- Original owner on main: the real Node callback trace is `outer:start → child → outer:end`; the fixed owner produces `outer:start → outer:end → child` while the outer callback waits on an explicit gate.
- Previous PR head `cdba527`: the strengthened lifecycle alias test fails because admission ran before the earlier mutation completed. The final candidate passes it.
- Final frozen candidate: 177 passing tests across the store writer, lifecycle admission/pending cancellation, SQLite session accessor, and first transcript-turn initialization suites. This includes caller-context isolation, duplicate runtime chunks, explicit reentrancy, cancellation/finalization, same-session ownership changes, idempotent replay, and direct SQLite race fixtures.
- Managed Codex autoreview: no accepted P0 findings. An independent owner/lifecycle review also found no actionable defect.
- Local changed gate: formatting, repository guards, and the core production typecheck passed. The broad core-test typecheck stopped at the unchanged `src/worker/worker.runtime.test.ts:10` import of `sharp`, which is absent from the local dependency install. That import is identical at the PR merge base and has already been removed on current main. Changed-file lint and the config/CLI test typecheck also passed. The remaining shared/session test graph reports only the same unchanged `sharp` import error. The integrated PR CI now passes the core-test graph; its tested merge has no remaining `sharp` import in that worker test.

- [Hosted CI](https://github.com/openclaw/openclaw/actions/runs/33528090724) passed for PR head `43448515b3213f9ff986c3753e6117c0fbd2f47b`, including all selected tests, types, guards, lint and build. One initial job failed before tests while downloading pnpm; its targeted retry and the [required CI gate](https://github.com/openclaw/openclaw/actions/runs/33528090724/job/99935982686) both passed.
- The [fresh ClawSweeper review](https://github.com/openclaw/openclaw/pull/131456#issuecomment-5448038841) found no actionable defect. Its remaining CI step is complete.

These are actual Node/SQLite owner-boundary executions with temporary fixtures, not an authenticated channel or full Gateway smoke run. The change is confined to the shared in-process drain and regression fixtures.
