### PR TITLE
fix(worktrees): allow five minutes for checkout

### DIFF
--- a/docs/concepts/managed-worktrees.md
+++ b/docs/concepts/managed-worktrees.md
@@ -67,7 +67,7 @@ The resulting managed worktree is owned by the session, and every agent run in t
 
 If **New session** reports `git worktree add failed`, read the termination reason and the final Git error lines. `Preparing worktree` and `Updating files` are progress, not the cause of failure. Error messages collapse carriage-return progress redraws and bound the diagnostic tail so it cannot flood the banner.
 
-`timed out after 120 seconds` means the Git command reached OpenClaw's execution limit. Check repository access and available disk space on the Gateway host. A signal or nonzero exit status alone does not establish a timeout; use any accompanying `fatal:` or `error:` detail to investigate. An output-limit error means the command exceeded its output capture limit.
+`timed out after 300 seconds` means a worktree checkout reached its five-minute limit. Other Git commands report `timed out after 120 seconds` at their two-minute limit. Check repository access and available disk space on the Gateway host. A signal or nonzero exit status alone does not establish a timeout; use any accompanying `fatal:` or `error:` detail to investigate. An output-limit error means the command exceeded its output capture limit.
 
 Before another creation attempt, inspect `git -C <repo-root> worktree list` and `git -C <repo-root> branch --list 'openclaw/*'` for partial state. A failed creation does not guarantee that its checkout and branch were removed. Do not delete a checkout or branch without checking whether it contains work you need.
 

--- a/docs/concepts/managed-worktrees.md
+++ b/docs/concepts/managed-worktrees.md
@@ -21,6 +21,8 @@ The repository fingerprint is the first 16 hexadecimal characters of a SHA-256 h
 
 OpenClaw creates branch `openclaw/<name>` at the requested base ref. Without a base ref, it fetches `origin`, uses the remote default branch when available, and falls back to local `HEAD` when the repository is offline or has no usable remote.
 
+Each `git worktree add` checkout during creation or snapshot restore has a five-minute timeout, including a creation retry from local `HEAD`. Other managed-worktree Git commands keep their two-minute timeout. The separate `.openclaw/worktree-setup.sh` step also keeps its own two-minute timeout.
+
 ## Provision ignored files
 
 Add `.worktreeinclude` at the source repository root to copy selected ignored, untracked files into a new worktree. The file uses gitignore-pattern syntax, one pattern per line, with `#` comments:

--- a/src/agents/worktrees/git.test.ts
+++ b/src/agents/worktrees/git.test.ts
@@ -18,7 +18,8 @@ describe("Git checkout discovery", () => {
     const root = tempDirs.make("openclaw-git-error-");
     const result = await runGit(path.join(root, "missing"), ["status"]);
 
-    expectTypeOf(result).toEqualTypeOf<SpawnResult>();
+    expectTypeOf(result).toMatchTypeOf<SpawnResult>();
+    expect(result.timeoutMs).toBe(120_000);
     expect(result.code).toBe(128);
     expect(result).toMatchObject({ termination: "exit", signal: null });
     const message = commandError("git status", result).message;

--- a/src/agents/worktrees/git.ts
+++ b/src/agents/worktrees/git.ts
@@ -38,7 +38,7 @@ export function gitEnvironment(env?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
 export async function runGit(
   cwd: string,
   args: string[],
-  options: { env?: NodeJS.ProcessEnv; input?: string | Uint8Array } = {},
+  options: { env?: NodeJS.ProcessEnv; input?: string | Uint8Array; timeoutMs?: number } = {},
 ): Promise<GitResult> {
   return await executeGitCommand(cwd, args, { ...options, env: gitEnvironment(options.env) });
 }
@@ -50,7 +50,7 @@ export function commandError(command: string, result: GitResult): Error {
 export async function requireGit(
   cwd: string,
   args: string[],
-  options: { env?: NodeJS.ProcessEnv; input?: string | Uint8Array } = {},
+  options: { env?: NodeJS.ProcessEnv; input?: string | Uint8Array; timeoutMs?: number } = {},
 ): Promise<string> {
   return await requireGitCommand(cwd, args, { ...options, env: gitEnvironment(options.env) });
 }

--- a/src/agents/worktrees/service.test.ts
+++ b/src/agents/worktrees/service.test.ts
@@ -4,7 +4,18 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance,
+} from "vitest";
+import * as commandRunner from "../../process/exec-runner.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import {
   deleteRegistryWorktree,
@@ -19,6 +30,25 @@ import { IDLE_GC_MS, ManagedWorktreeService } from "./service.js";
 import { materializeManagedWorktreeFixture } from "./service.test-support.js";
 
 const execFileAsync = promisify(execFile);
+
+function expectCheckoutTimeouts(
+  commandSpy: MockInstance<typeof commandRunner.runCommandWithTimeout>,
+  checkoutBases: string[],
+) {
+  const gitCommands = commandSpy.mock.calls
+    .filter(([argv]) => argv[0] === "git")
+    .map(([argv, options]) => ({
+      checkout: argv[3] === "worktree" && argv[4] === "add",
+      base: argv.at(-1),
+      timeoutMs: typeof options === "number" ? options : options.timeoutMs,
+    }));
+  expect(gitCommands.filter((command) => command.checkout)).toEqual(
+    checkoutBases.map((base) => ({ checkout: true, base, timeoutMs: 300_000 })),
+  );
+  expect(
+    new Set(gitCommands.filter((command) => !command.checkout).map((command) => command.timeoutMs)),
+  ).toEqual(new Set([120_000]));
+}
 
 async function git(cwd: string, ...args: string[]): Promise<string> {
   const { stdout } = await execFileAsync("git", ["-C", cwd, ...args], {
@@ -129,6 +159,7 @@ describe("ManagedWorktreeService", () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     for (const record of listRegistryWorktrees(env)) {
       finalizeWorktreeRemovalRows(env, record.id);
       deleteRegistryWorktree(env, record.id);
@@ -138,6 +169,7 @@ describe("ManagedWorktreeService", () => {
 
   it("creates from origin HEAD and returns the existing live named worktree", async () => {
     await addRemote(root, repo);
+    const commandSpy = vi.spyOn(commandRunner, "runCommandWithTimeout");
     const created = await service.create({ repoRoot: repo, name: "remote-task" });
     const repeated = await service.create({ repoRoot: repo, name: "remote-task" });
 
@@ -146,6 +178,7 @@ describe("ManagedWorktreeService", () => {
     expect(created.path).toContain(path.join("worktrees", created.repoFingerprint, "remote-task"));
     expect(await git(created.path, "branch", "--show-current")).toBe(created.branch);
     expect(repeated).toEqual(created);
+    expectCheckoutTimeouts(commandSpy, ["origin/main"]);
   });
 
   it("reads registry records without retiring a temporarily unavailable worktree", async () => {
@@ -420,9 +453,11 @@ describe("ManagedWorktreeService", () => {
     );
     const remoteCommit = await git(repo, "commit-tree", tree, "-p", "HEAD", "-m", "bad remote");
     await git(repo, "push", "--force", "origin", `${remoteCommit}:refs/heads/main`);
+    const commandSpy = vi.spyOn(commandRunner, "runCommandWithTimeout");
     const created = await service.create({ repoRoot: repo, name: "stale-remote" });
     expect(created.baseRef).toBe("HEAD");
     expect(await git(created.path, "rev-parse", "HEAD")).toBe(await git(repo, "rev-parse", "HEAD"));
+    expectCheckoutTimeouts(commandSpy, ["origin/main", "HEAD"]);
   });
 
   it("preserves a pre-existing branch when a managed name collides", async () => {
@@ -498,10 +533,16 @@ describe("ManagedWorktreeService", () => {
       '#!/bin/sh\nprintf "%s\\n%s\\n" "$OPENCLAW_SOURCE_TREE_PATH" "$OPENCLAW_WORKTREE_PATH" > setup-paths.txt\n',
       { mode: 0o755 },
     );
+    const commandSpy = vi.spyOn(commandRunner, "runCommandWithTimeout");
     const created = await service.create({ repoRoot: repo, name: "setup", baseRef: "HEAD" });
     expect(
       (await fs.readFile(path.join(created.path, "setup-paths.txt"), "utf8")).split("\n"),
     ).toEqual([repo, created.path, ""]);
+    expect(
+      commandSpy.mock.calls
+        .filter(([argv]) => argv[0] === script)
+        .map(([, options]) => (typeof options === "number" ? options : options.timeoutMs)),
+    ).toEqual([120_000]);
   });
 
   it("does not execute repository hooks or setup scripts when setup is disabled", async () => {
@@ -587,7 +628,9 @@ describe("ManagedWorktreeService", () => {
     await fs.writeFile(path.join(repo, "provisioned.env"), "new source value\n");
 
     now += IDLE_GC_MS + 1;
+    const commandSpy = vi.spyOn(commandRunner, "runCommandWithTimeout");
     const restored = await service.restore({ id: created.id });
+    expectCheckoutTimeouts(commandSpy, [removed.snapshotRef!]);
     expect(restored.removedAt).toBeUndefined();
     expect(restored.lastActiveAt).toBe(now);
     expect((await service.gc()).removed).toEqual([]);

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -73,6 +73,8 @@ const WORKTREE_CREATE_LEASE_SCOPE = "core:managed-worktrees:create";
 const WORKTREE_OWNER_LEASE_SCOPE = "core:managed-worktrees:owner";
 const WORKTREE_CREATE_LEASE_MS = 60_000;
 const WORKTREE_CREATE_LEASE_WAIT_MS = 5 * 60_000;
+// Materializing a checkout gets extra time without extending other Git commands or setup.
+const WORKTREE_CHECKOUT_TIMEOUT_MS = 300_000;
 
 /** Removal aborted because snapshot loss was not permitted. */
 export class WorktreeSnapshotError extends Error {
@@ -739,7 +741,9 @@ export class ManagedWorktreeService {
     let recordBase = base.recordRef;
     const runRepositorySetup = params.runSetupScript !== false;
     const worktreeAddArgs = () => ["worktree", "add", "-b", branch, "--", worktreePath, gitBase];
-    let added = await runGit(repository.repoRoot, worktreeAddArgs());
+    let added = await runGit(repository.repoRoot, worktreeAddArgs(), {
+      timeoutMs: WORKTREE_CHECKOUT_TIMEOUT_MS,
+    });
     if (added.code !== 0 && base.remote) {
       if (!(await canResetFailedWorktreeAdd(repository.repoRoot, worktreePath, branch, added))) {
         throw commandError("git worktree add", added);
@@ -747,7 +751,9 @@ export class ManagedWorktreeService {
       await resetFailedWorktreeAdd(repository.repoRoot, worktreePath, branch);
       gitBase = "HEAD";
       recordBase = "HEAD";
-      added = await runGit(repository.repoRoot, worktreeAddArgs());
+      added = await runGit(repository.repoRoot, worktreeAddArgs(), {
+        timeoutMs: WORKTREE_CHECKOUT_TIMEOUT_MS,
+      });
     }
     if (added.code !== 0) {
       throw commandError("git worktree add", added);
@@ -1065,13 +1071,11 @@ export class ManagedWorktreeService {
     }
     const parent = await requireGit(record.repoRoot, ["rev-parse", `${record.snapshotRef}^`]);
     await fs.mkdir(path.dirname(record.path), { recursive: true });
-    await requireGit(record.repoRoot, [
-      "worktree",
-      "add",
-      "--detach",
-      record.path,
-      record.snapshotRef,
-    ]);
+    await requireGit(
+      record.repoRoot,
+      ["worktree", "add", "--detach", record.path, record.snapshotRef],
+      { timeoutMs: WORKTREE_CHECKOUT_TIMEOUT_MS },
+    );
     let branchCreated = false;
     let restoredProvisionedPaths: string[];
     try {

--- a/src/gateway/control-ui-session-prs.test.ts
+++ b/src/gateway/control-ui-session-prs.test.ts
@@ -438,6 +438,7 @@ describe("loadControlUiSessionPullRequests", () => {
       signal: null,
       killed: false,
       termination: "exit" as const,
+      timeoutMs: 120_000,
     }));
     const load = (sessionKey: string, refresh = false) =>
       loadControlUiSessionPullRequests(

--- a/src/infra/git-exec.test.ts
+++ b/src/infra/git-exec.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import * as processExec from "../process/exec.js";
 import type { SpawnResult } from "../process/exec.js";
-import { requireGitCommand, requireGitCommandBuffer, requireGitCommandRaw } from "./git-exec.js";
+import {
+  createGitCommandError,
+  executeGitCommand,
+  requireGitCommand,
+  requireGitCommandBuffer,
+  requireGitCommandRaw,
+} from "./git-exec.js";
 
 afterEach(() => vi.restoreAllMocks());
 
@@ -14,6 +20,27 @@ const failure = {
   killed: false,
   termination: "exit",
 } satisfies SpawnResult;
+
+it.each([
+  { timeoutMs: undefined, seconds: 120 },
+  { timeoutMs: 300_000, seconds: 300 },
+])("reports the applied $seconds-second Git timeout", async ({ timeoutMs, seconds }) => {
+  const commandSpy = vi.spyOn(processExec, "runCommandWithTimeout").mockResolvedValue({
+    ...failure,
+    termination: "timeout",
+    code: 124,
+  });
+  const args = ["worktree", "add"];
+  const result = await executeGitCommand("/repo", args, { timeoutMs });
+  const label = `timed out after ${seconds} seconds`;
+  expect(createGitCommandError("git worktree add", result).message).toContain(label);
+  await expect(requireGitCommand("/repo", args, { timeoutMs })).rejects.toThrow(label);
+  expect(
+    commandSpy.mock.calls.map(([, options]) =>
+      typeof options === "number" ? options : options.timeoutMs,
+    ),
+  ).toEqual([seconds * 1000, seconds * 1000]);
+});
 
 describe.each([
   ["text", requireGitCommand],

--- a/src/infra/git-exec.ts
+++ b/src/infra/git-exec.ts
@@ -8,19 +8,24 @@ export async function executeGitCommand(
   cwd: string,
   args: string[],
   options: { env?: NodeJS.ProcessEnv; input?: string | Uint8Array; timeoutMs?: number } = {},
-): Promise<SpawnResult> {
-  return await runCommandWithTimeout(["git", "-C", cwd, ...args], {
-    timeoutMs: options.timeoutMs ?? GIT_TIMEOUT_MS,
+): Promise<SpawnResult & { timeoutMs: number }> {
+  const timeoutMs = options.timeoutMs ?? GIT_TIMEOUT_MS;
+  const result = await runCommandWithTimeout(["git", "-C", cwd, ...args], {
+    timeoutMs,
     env: options.env,
     input: options.input,
   });
+  return { ...result, timeoutMs };
 }
 
 export function createGitCommandError(
   command: string,
-  result: SpawnResult | Awaited<ReturnType<typeof runCommandBuffered>>,
+  result: (SpawnResult | Awaited<ReturnType<typeof runCommandBuffered>>) & { timeoutMs?: number },
 ): Error {
-  const error = createCommandError(command, result, { timeoutMs: GIT_TIMEOUT_MS });
+  // Buffered Git uses the fixed default; text results carry their applied budget.
+  const error = createCommandError(command, result, {
+    timeoutMs: result.timeoutMs ?? GIT_TIMEOUT_MS,
+  });
   if (result.termination === "timeout") {
     error.message += "\nCheck repository access and disk space.";
   }

--- a/src/infra/git-exec.ts
+++ b/src/infra/git-exec.ts
@@ -7,10 +7,10 @@ export const GIT_TIMEOUT_MS = 120_000;
 export async function executeGitCommand(
   cwd: string,
   args: string[],
-  options: { env?: NodeJS.ProcessEnv; input?: string | Uint8Array } = {},
+  options: { env?: NodeJS.ProcessEnv; input?: string | Uint8Array; timeoutMs?: number } = {},
 ): Promise<SpawnResult> {
   return await runCommandWithTimeout(["git", "-C", cwd, ...args], {
-    timeoutMs: GIT_TIMEOUT_MS,
+    timeoutMs: options.timeoutMs ?? GIT_TIMEOUT_MS,
     env: options.env,
     input: options.input,
   });
@@ -30,7 +30,7 @@ export function createGitCommandError(
 export async function requireGitCommand(
   cwd: string,
   args: string[],
-  options: { env?: NodeJS.ProcessEnv; input?: string | Uint8Array } = {},
+  options: { env?: NodeJS.ProcessEnv; input?: string | Uint8Array; timeoutMs?: number } = {},
 ): Promise<string> {
   const result = await executeGitCommand(cwd, args, options);
   if (result.code !== 0) {

--- a/src/snapshot/git-backup.test.ts
+++ b/src/snapshot/git-backup.test.ts
@@ -37,6 +37,7 @@ vi.mock("../infra/git-exec.js", async (importOriginal) => {
           signal: null,
           killed: false,
           termination: "exit",
+          timeoutMs: args[2]?.timeoutMs ?? actual.GIT_TIMEOUT_MS,
         };
       }
       return await actual.executeGitCommand(...args);

--- a/ui/src/pages/activity/session-activity-view.test.ts
+++ b/ui/src/pages/activity/session-activity-view.test.ts
@@ -67,14 +67,14 @@ describe("session activity semantics", () => {
 
   it("renders agent-owned session and people images without replacing human pictures", async () => {
     setAvatarGatewayOrigin("https://gateway.example.test");
-    vi.spyOn(globalThis, "fetch").mockImplementation(
-      async (input) =>
-        new Response(new Uint8Array([1, 2, 3]), {
-          headers: {
-            "content-type": String(input).endsWith("/avatar/research") ? "image/jpeg" : "image/png",
-          },
-        }),
-    );
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = input instanceof Request ? input.url : input.toString();
+      return new Response(new Uint8Array([1, 2, 3]), {
+        headers: {
+          "content-type": url.endsWith("/avatar/research") ? "image/jpeg" : "image/png",
+        },
+      });
+    });
     // Identify each image by its content type, not the order concurrent fetches finish.
     vi.spyOn(URL, "createObjectURL").mockImplementation((blob) =>
       "type" in blob && blob.type === "image/png" ? "blob:human" : "blob:agent",

--- a/ui/src/pages/activity/session-activity-view.test.ts
+++ b/ui/src/pages/activity/session-activity-view.test.ts
@@ -68,14 +68,17 @@ describe("session activity semantics", () => {
   it("renders agent-owned session and people images without replacing human pictures", async () => {
     setAvatarGatewayOrigin("https://gateway.example.test");
     vi.spyOn(globalThis, "fetch").mockImplementation(
-      async () =>
+      async (input) =>
         new Response(new Uint8Array([1, 2, 3]), {
-          headers: { "content-type": "image/png" },
+          headers: {
+            "content-type": String(input).endsWith("/avatar/research") ? "image/jpeg" : "image/png",
+          },
         }),
     );
-    vi.spyOn(URL, "createObjectURL")
-      .mockReturnValueOnce("blob:human")
-      .mockReturnValueOnce("blob:agent");
+    // Identify each image by its content type, not the order concurrent fetches finish.
+    vi.spyOn(URL, "createObjectURL").mockImplementation((blob) =>
+      "type" in blob && blob.type === "image/png" ? "blob:human" : "blob:agent",
+    );
     const agent = {
       type: "agent" as const,
       id: "research",


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/131363 (readable Git failure diagnostics) and https://github.com/openclaw/openclaw/pull/131420 (shared setup/Git diagnostics and cleanup failures).

## What Problem This Solves

Resolves a problem where creating or restoring a managed worktree is limited to the same two-minute budget as ordinary Git metadata commands. A large or slow checkout can still be making progress when that deadline expires. The maintainer explicitly selected a five-minute checkout budget.

The motivating New Session screenshot showed checkout progress stopping before completion, but its error header was cropped and the session later succeeded. This PR does not claim that the original incident's termination cause was conclusively recovered.

## Why This Change Was Made

The managed-worktree owner now gives each `git worktree add` subprocess five minutes: initial creation, the existing local-HEAD fallback, and snapshot restoration. Existing Git wrappers accept the narrow internal timeout override; other Git commands and the repository setup script retain their two-minute deadlines. No public configuration or environment variable is added.

The applied timeout travels with the Git result so the recently landed diagnostics report `timed out after 300 seconds` for checkout rather than incorrectly reporting the default 120 seconds. The rebase onto pinned main `16b0c1f251c79234f0a8285ea37f64493341b04a` integrates the overlapping shared formatter extraction from #131420. Git now passes its recorded budget to the upstream generic `createCommandError` helper; the helper itself is unchanged. Upstream bounded diagnostics, setup/cleanup repairs, tests, and docs are preserved, as are Git hook/filesystem-monitor suppression, fallback, and persistence semantics.

## User Impact

Managed-worktree checkout has more time to finish, without extending every Git operation or changing agent-run timeouts. The limit is per checkout attempt, not a five-minute deadline for the entire multi-step session-creation flow. Timeout errors report the budget actually applied. The [managed-worktree guide](https://docs.openclaw.ai/concepts/managed-worktrees) documents both limits.

## Evidence

- Before the policy change, the real-Git creation, fallback, and restoration regressions failed because the process boundary received 120,000 ms instead of 300,000 ms. All four focused policy cases passed afterward, including the unchanged setup-script budget.
- After integrating current-main diagnostics, the new 300-second error-message regression failed with the old `timed out after 120 seconds` text and passed after recording the applied budget.
- `node scripts/run-vitest.mjs src/process/command-error.test.ts src/infra/git-exec.test.ts src/agents/worktrees/git.test.ts src/agents/worktrees/service.test.ts src/agents/worktrees/service.hooks.test.ts` — 84 tests passed across five files on rebased head `d835716a15eeb8293a4fb4a7458149cfb7cfb09b` (4 shared formatter, 37 Git diagnostics, 43 agent/worktree tests). Service tests execute real Git for creation, fallback, restore, and hook suppression; a pass-through process spy checks applied deadlines without five-minute sleeps.
- Earlier sibling worktree proof: seven files, 60 passed and one existing platform skip, including provisioning, names, branches, and canonical paths.
- Rebase range-diff confirms the checkout-policy commit is patch-identical; only the diagnostics integration changes to call the generic shared formatter with the recorded budget. The final scope is ten files after correcting two sibling test fixtures and one unrelated CI avatar-fixture race. Targeted formatting and `git diff --check` passed. Local changed checks passed formatting, source guards, dead-export scans, and core typechecking; the long-running repository-wide core-test typecheck was interrupted, so that local command is not reported as fully passed. Required exact-head hosted CI remains the landing gate.
- CI on the initial head found the old setup-error helper accepting the now-more-specific Git result type. Integrating the upstream shared formatter removes that mixed-type helper. The rebased production core typecheck passed.
- CI run 33138811425 then identified two sibling test mocks missing `timeoutMs` (snapshot backup and session PR chips). Both fixtures now return the canonical result shape without weakening production types. `node scripts/run-vitest.mjs src/snapshot/git-backup.test.ts src/gateway/control-ui-session-prs.test.ts` passed all 38 tests. Both owning type graphs passed via `node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.other.json --builders 1` and `node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.gateway-root.json --builders 1`.
- CI run 33139658891 exposed an unrelated activity-avatar test race in `ui/src/pages/activity/session-activity-view.test.ts`: mock blob URLs were assigned by fetch completion order. The fixture now identifies human and agent images by distinct MIME types, preserving every assertion and changing no UI production code. Replaying the original `core-runtime-media-ui-2` group through `scripts/ci-run-node-test-shard.mts` with the exact CI include list and two-worker setting passed 4,339 tests across 247 files (33 existing test skips, six skipped files). A subsequent lint finding was fixed by correctly extracting URLs from `Request` inputs as well as strings/URLs. `node scripts/run-oxlint.mjs --type-aware --tsconfig config/tsconfig/oxlint.core.json ui/src/pages/activity/session-activity-view.test.ts` and all nine focused activity tests then passed.
- A broader process test run hit an unrelated inherited-pipe timing assertion; its exact isolated rerun passed unchanged. This is recorded as a separate follow-up, not hidden by changing a timeout or weakening the test.
- Fresh Codex autoreviews covered the policy, diagnostics integration, rebased branch, and final two-line fixture correction; all exited 0 without accepted/actionable findings in their P0 scope.

Production LOC: +27/-18 (net +9). Tests: +87/-11 (net +76). The production growth isolates the checkout policy from the shared default and carries its applied budget into diagnostics. No dependency, config, schema, or protocol changes.

No UI rendering code changes. The original live failure is no longer present; proof is at the real managed-worktree/Git owner boundary and the timeout-reporting boundary. No operator gateway was modified or restarted.

AI-assisted implementation and review.
