### PR TITLE
fix(openshell): unblock hosted E2E gateway authentication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3264,7 +3264,7 @@ jobs:
               fi
               ;;
             test-types)
-              # The github/hybrid planner profile moves the 14 serial core-test
+              # The github/hybrid planner profile moves the bounded core-test
               # graphs (~70% of this lane) into the dedicated hosted stripes
               # job; this row keeps the extensions/root/scripts tail. Targets
               # without stripe support run the whole lane here.
@@ -3344,9 +3344,9 @@ jobs:
           node --import tsx scripts/run-oxlint-shards.mts \
             --only=core --split-core --core-stripe=${{ matrix.stripe }}/5 --threads=1
 
-  # The github/hybrid planner profile stripes the 14 serial core test-type
+  # The github/hybrid planner profile stripes the bounded core test-type
   # graphs (~34-42s per graph on either runner class; tsgo saturates a machine
-  # per graph) across four jobs; the check-test-types row keeps the
+  # per graph) across five jobs; the check-test-types row keeps the
   # extensions/root/scripts tail. All-Blacksmith mode keeps the single
   # 16-vCPU test-types job.
   check-test-types-hosted-core-shard:

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -1172,9 +1172,6 @@ jobs:
             else
               result=1
             fi
-            if [[ "$result" -ne 0 && -f "$fixture_root/gateway.log" ]]; then
-              tail -n 120 "$fixture_root/gateway.log" >&2
-            fi
             rm -rf "$fixture_root"
             exit "$result"
           }
@@ -1202,9 +1199,9 @@ jobs:
           network_name = "$gateway_name"
           grpc_endpoint = "https://host.openshell.internal:$gateway_port"
           TOML
-          openshell-gateway --config "$fixture_root/gateway.toml" \
+          RUST_LOG=info openshell-gateway --config "$fixture_root/gateway.toml" \
             --bind-address 0.0.0.0 --port "$gateway_port" \
-            > "$fixture_root/gateway.log" 2>&1 &
+            > "$RUNNER_TEMP/$gateway_name.raw.log" 2>&1 &
           gateway_pid=$!
           run_owned openshell gateway add --local --name "$gateway_name" "https://127.0.0.1:$gateway_port"
           ready_deadline=$((SECONDS + 60))
@@ -1224,6 +1221,67 @@ jobs:
           run_owned timeout --foreground 20s openshell --gateway "$gateway_name" sandbox list
           echo "OpenShell bootstrap passed: owned gateway and protected whoami/sandbox list."
           run_owned ${{ matrix.command }}
+
+      - name: Redact OpenShell gateway log
+        if: |
+          always() && inputs.include_repo_e2e &&
+          (inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id) &&
+          matrix.suite_id == 'openshell-e2e'
+        shell: bash
+        run: |
+          set -euo pipefail
+          umask 077
+          log_base="$RUNNER_TEMP/openshell-e2e-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          trap 'rm -f "$log_base.raw.log" "$log_base.redacted.tmp"' EXIT
+          trap 'exit 130' INT
+          trap 'exit 143' TERM
+          # Logging runs after owned-process/PKI cleanup, never extending its
+          # cancellation grace. Only this bounded, redacted file may be uploaded.
+          if timeout --foreground --kill-after=1s 5s node --input-type=module - \
+            "$log_base.raw.log" > "$log_base.redacted.tmp" 2>/dev/null <<'NODE'
+          import fs from "node:fs";
+          import { stripVTControlCharacters } from "node:util";
+          import { redactSensitiveText } from "./dist/plugin-sdk/logging-core.js";
+          const fd = fs.openSync(process.argv[2], "r");
+          try {
+            const size = fs.fstatSync(fd).size;
+            const start = Math.max(0, size - 1024 * 1024);
+            const buffer = Buffer.alloc(size - start);
+            const bytes = fs.readSync(fd, buffer, 0, buffer.length, start);
+            let text = buffer.subarray(0, bytes).toString("utf8");
+            if (start > 0) {
+              const newline = text.indexOf("\n");
+              text = newline < 0 ? "" : text.slice(newline + 1);
+            }
+            text = text.slice(0, text.lastIndexOf("\n") + 1);
+            // v0.0.109 logs SSH bearer UUIDs as session_id/object.id, not token.
+            // Remove full values before canonical redaction, including in spans.
+            text = stripVTControlCharacters(text).replace(
+              /[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}/gi, "[redacted-uuid]",
+            );
+            process.stdout.write(redactSensitiveText(text, { mode: "tools" }));
+          } finally {
+            fs.closeSync(fd);
+          }
+          NODE
+          then
+            mv "$log_base.redacted.tmp" "$log_base.log"
+            tail -n 120 "$log_base.log"
+          else
+            echo "OpenShell gateway log omitted: source or canonical redaction unavailable."
+          fi
+
+      - name: Upload redacted OpenShell gateway log
+        if: |
+          always() && inputs.include_repo_e2e &&
+          (inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id) &&
+          matrix.suite_id == 'openshell-e2e'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: openshell-gateway-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/openshell-e2e-${{ github.run_id }}-${{ github.run_attempt }}.log
+          if-no-files-found: ignore
+          retention-days: 7
 
   validate_docker_e2e:
     needs:

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -1094,18 +1094,8 @@ jobs:
           (inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id)
         env:
           NODE_OPTIONS: --max-old-space-size=8192
+          OPENCLAW_BUILD_PRIVATE_QA: "1"
         run: pnpm build
-
-      - name: Configure suite-specific env
-        if: inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id
-        shell: bash
-        run: |
-          set -euo pipefail
-          case "${{ matrix.suite_id }}" in
-            openshell-e2e)
-              echo "OPENCLAW_E2E_OPENSHELL_CONFIG_HOME=$HOME/.config" >> "$GITHUB_ENV"
-              ;;
-          esac
 
       - name: Install OpenShell CLI
         if: |
@@ -1114,95 +1104,126 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          export OPENSHELL_VERSION=v0.0.109
-          installer_path="$(mktemp "${RUNNER_TEMP}/openshell-install.XXXXXX")"
-          trap 'rm -f "$installer_path"' EXIT
+          # The installer also starts a systemd gateway. Install only the verified
+          # package so the E2E shell below is the sole gateway lifecycle owner.
+          package_path="$(mktemp "${RUNNER_TEMP}/openshell.XXXXXX.deb")"
+          trap 'rm -f "$package_path"' EXIT
           curl -LsSf --connect-timeout 10 --max-time 120 \
-            -o "$installer_path" \
-            https://raw.githubusercontent.com/NVIDIA/OpenShell/8d67250a5d17348eb96c4fa46226b06d8041f2ba/install.sh
-          sh "$installer_path"
+            -o "$package_path" \
+            https://github.com/NVIDIA/OpenShell/releases/download/v0.0.109/openshell_0.0.109-1_amd64.deb
+          printf '%s  %s\n' \
+            0364a21f279023a241d967309ebb0177dadb66bd792eeb3daf542283158ca40f \
+            "$package_path" | sha256sum --check -
+          sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y "$package_path"
           openshell --version
 
-      - name: Bootstrap OpenShell gateway
+      - name: Run ${{ matrix.label }}
         if: |
           (inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id) &&
           matrix.suite_id == 'openshell-e2e'
         shell: bash
         run: |
           set -euo pipefail
-          mtls_dir="$HOME/.config/openshell/gateways/openshell/mtls"
-          gateway_tls_dir="$RUNNER_TEMP/openshell-gateway-certs"
-          fallback_pid=""
-          if ! openshell --gateway openshell sandbox list >/dev/null 2>&1; then
-            rm -rf "$gateway_tls_dir"
-            openshell-gateway generate-certs \
-              --output-dir "$gateway_tls_dir" \
-              --server-san 127.0.0.1 \
-              --server-san localhost \
-              --server-san host.openshell.internal
-            rm -rf "$mtls_dir"
-            mkdir -p "$mtls_dir"
-            cp "$gateway_tls_dir/ca.crt" "$mtls_dir/ca.crt"
-            cp "$gateway_tls_dir/client/tls.crt" "$mtls_dir/tls.crt"
-            cp "$gateway_tls_dir/client/tls.key" "$mtls_dir/tls.key"
-            openshell gateway remove openshell >/dev/null 2>&1 || true
-            OPENSHELL_LOCAL_TLS_DIR="$gateway_tls_dir" nohup openshell-gateway \
-              --bind-address 0.0.0.0 \
-              --port 17670 \
-              --drivers docker \
-              --tls-cert "$gateway_tls_dir/server/tls.crt" \
-              --tls-key "$gateway_tls_dir/server/tls.key" \
-              --tls-client-ca "$mtls_dir/ca.crt" \
-              >"$RUNNER_TEMP/openshell-gateway.log" 2>&1 &
-            fallback_pid=$!
-            echo "OPENCLAW_OPENSHELL_FALLBACK_PID=$fallback_pid" >> "$GITHUB_ENV"
-            for _ in $(seq 1 30); do
-              if openshell gateway add --local --name openshell https://127.0.0.1:17670; then
-                break
+          umask 077
+          fixture_root="$(mktemp -d "${RUNNER_TEMP}/openshell-e2e.XXXXXX")"
+          gateway_name="openshell-e2e-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          gateway_port=17680
+          gateway_pid=""
+          command_pid=""
+          run_owned() {
+            # Async wait handles cancellation immediately; the process group
+            # includes pnpm's test-runner descendants in the same cleanup.
+            setsid "$@" &
+            command_pid=$!
+            wait "$command_pid"
+          }
+          cleanup() {
+            local result=$?
+            trap - EXIT
+            # Actions escalates cancellation after 7.5s, then kills the tree at
+            # 10s. Ignore repeat signals and keep the shared shutdown grace short.
+            trap '' INT TERM
+            local owned_pids=()
+            [[ -n "$gateway_pid" ]] && owned_pids+=("$gateway_pid")
+            [[ -n "$command_pid" ]] && owned_pids+=("-$command_pid")
+            if (( ${#owned_pids[@]} )); then
+              kill -TERM -- "${owned_pids[@]}" 2>/dev/null || true
+              for _ in $(seq 1 20); do
+                local alive=0
+                for pid in "${owned_pids[@]}"; do
+                  kill -0 -- "$pid" 2>/dev/null && alive=1
+                done
+                (( alive )) || break
+                sleep 0.2
+              done
+              for pid in "${owned_pids[@]}"; do
+                if kill -0 -- "$pid" 2>/dev/null; then
+                  kill -KILL -- "$pid" 2>/dev/null || true
+                  result=1
+                fi
+                wait "${pid#-}" 2>/dev/null || true
+              done
+            fi
+            local networks
+            if networks="$(timeout --foreground --kill-after=1s 1s docker network ls --format '{{.Name}}')"; then
+              if grep -Fxq -- "$gateway_name" <<< "$networks"; then
+                timeout --foreground --kill-after=1s 1s docker network rm "$gateway_name" || result=1
               fi
-              sleep 1
-            done
-            openshell gateway select openshell
-            for _ in $(seq 1 60); do
-              if openshell --gateway openshell sandbox list >/dev/null 2>&1; then
-                break
-              fi
-              sleep 1
-            done
-          fi
-          if [[ -z "$fallback_pid" ]]; then
-            echo "OPENCLAW_OPENSHELL_FALLBACK_PID=" >> "$GITHUB_ENV"
-          fi
-          openshell --gateway openshell sandbox list >/dev/null
-          openshell gateway list
-
-      - name: Validate suite credentials
-        if: inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id
-        shell: bash
-        run: |
-          set -euo pipefail
-          case "${{ matrix.suite_id }}" in
-            openshell-e2e)
-              ;;
-          esac
-
-      - name: Run ${{ matrix.label }}
-        if: |
-          (
-            (inputs.include_repo_e2e && matrix.requires_repo_e2e) ||
-            (inputs.include_live_suites && matrix.requires_live_suites)
-          ) &&
-          (inputs.live_suite_filter == '' || inputs.live_suite_filter == matrix.suite_id)
-        run: ${{ matrix.command }}
-
-      - name: Stop fallback OpenShell gateway
-        if: always() && matrix.suite_id == 'openshell-e2e'
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -n "${OPENCLAW_OPENSHELL_FALLBACK_PID:-}" ]]; then
-            kill "$OPENCLAW_OPENSHELL_FALLBACK_PID" 2>/dev/null || true
-          fi
+            else
+              result=1
+            fi
+            if [[ "$result" -ne 0 && -f "$fixture_root/gateway.log" ]]; then
+              tail -n 120 "$fixture_root/gateway.log" >&2
+            fi
+            rm -rf "$fixture_root"
+            exit "$result"
+          }
+          trap cleanup EXIT
+          trap 'exit 130' INT
+          trap 'exit 143' TERM
+          export XDG_CONFIG_HOME="$fixture_root/config"
+          export XDG_STATE_HOME="$fixture_root/state"
+          export OPENCLAW_E2E_OPENSHELL_CONFIG_HOME="$XDG_CONFIG_HOME"
+          # Local registration imports this bundle too; a server-only override
+          # would replace the CLI certificates with the package-managed bundle.
+          export OPENSHELL_LOCAL_TLS_DIR="$fixture_root/pki"
+          mkdir -p "$XDG_CONFIG_HOME" "$XDG_STATE_HOME"
+          run_owned openshell-gateway generate-certs --output-dir "$OPENSHELL_LOCAL_TLS_DIR" \
+            --server-san 127.0.0.1 --server-san localhost --server-san host.openshell.internal
+          cat > "$fixture_root/gateway.toml" <<TOML
+          [openshell]
+          version = 1
+          [openshell.gateway]
+          compute_drivers = ["docker"]
+          [openshell.gateway.mtls_auth]
+          enabled = true
+          [openshell.drivers.docker]
+          sandbox_namespace = "$gateway_name"
+          network_name = "$gateway_name"
+          grpc_endpoint = "https://host.openshell.internal:$gateway_port"
+          TOML
+          openshell-gateway --config "$fixture_root/gateway.toml" \
+            --bind-address 0.0.0.0 --port "$gateway_port" \
+            > "$fixture_root/gateway.log" 2>&1 &
+          gateway_pid=$!
+          run_owned openshell gateway add --local --name "$gateway_name" "https://127.0.0.1:$gateway_port"
+          ready_deadline=$((SECONDS + 60))
+          until run_owned timeout --foreground 5s openshell --gateway "$gateway_name" whoami \
+            > "$fixture_root/whoami.txt" 2> "$fixture_root/auth-error.txt"; do
+            kill -0 "$gateway_pid" 2>/dev/null || {
+              echo "OpenShell gateway exited before authenticated readiness." >&2
+              exit 1
+            }
+            if (( SECONDS >= ready_deadline )); then
+              cat "$fixture_root/auth-error.txt" >&2
+              exit 1
+            fi
+            sleep 1
+          done
+          kill -0 "$gateway_pid"
+          run_owned timeout --foreground 20s openshell --gateway "$gateway_name" sandbox list
+          echo "OpenShell bootstrap passed: owned gateway and protected whoami/sandbox list."
+          run_owned ${{ matrix.command }}
 
   validate_docker_e2e:
     needs:

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -6439,19 +6439,25 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
     expect(dockerResult.stdout).toContain("::error::docker_acceptance ended with failure");
   });
 
-  it("gives release build steps enough Node heap", () => {
+  it("gives release builds enough Node heap and special E2E its private QA runtime", () => {
     for (const workflowPath of [LIVE_E2E_WORKFLOW, RELEASE_CHECKS_WORKFLOW]) {
       const jobs = readWorkflow(workflowPath).jobs ?? {};
       for (const [jobName, job] of Object.entries(jobs)) {
         for (const step of job.steps ?? []) {
           if (step.run === "pnpm build") {
-            expect(step.env, `${workflowPath}:${jobName}:${step.name}`).toEqual({
-              NODE_OPTIONS: "--max-old-space-size=8192",
-            });
+            expect(step.env?.NODE_OPTIONS, `${workflowPath}:${jobName}:${step.name}`).toBe(
+              "--max-old-space-size=8192",
+            );
           }
         }
       }
     }
+    expect(
+      workflowStep(
+        workflowJob(LIVE_E2E_WORKFLOW, "validate_special_e2e"),
+        "Build dist for special E2E",
+      ),
+    ).toMatchObject({ run: "pnpm build", env: { OPENCLAW_BUILD_PRIVATE_QA: "1" } });
   });
 
   it("runs full release children from the trusted workflow ref", () => {

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -1213,7 +1213,36 @@ printf 'status=%s\\n' "$status"
     expect(workflow).toContain("reachable from an OpenClaw branch or release tag");
   });
 
-  it("downloads the OpenShell installer completely before execution", () => {
+  it.each([
+    {
+      name: "success",
+      curlExit: 0,
+      checksumExit: 0,
+      installExit: 0,
+      calls: "download\nverify\ninstall\nversion\n",
+    },
+    {
+      name: "partial download",
+      curlExit: 28,
+      checksumExit: 0,
+      installExit: 0,
+      calls: "download\n",
+    },
+    {
+      name: "checksum failure",
+      curlExit: 0,
+      checksumExit: 1,
+      installExit: 0,
+      calls: "download\nverify\n",
+    },
+    {
+      name: "install failure",
+      curlExit: 0,
+      checksumExit: 0,
+      installExit: 42,
+      calls: "download\nverify\ninstall\n",
+    },
+  ])("verifies the OpenShell package before installation and cleans it on $name", (scenario) => {
     const workflow = parse(readFileSync(LIVE_E2E_WORKFLOW_PATH, "utf8"));
     const steps = workflow.jobs.validate_special_e2e.steps as Array<{
       name?: string;
@@ -1224,14 +1253,92 @@ printf 'status=%s\\n' "$status"
       "OpenShell install step",
     );
     const run = expectDefined(installStep.run, "OpenShell install command");
-
-    expect(run).toContain('installer_path="$(mktemp "${RUNNER_TEMP}/openshell-install.XXXXXX")"');
-    expect(run).toContain("curl -LsSf --connect-timeout 10 --max-time 120 \\");
-    expect(run).toContain('-o "$installer_path"');
-    expect(run).toContain('sh "$installer_path"');
-    expect(run).toContain("trap 'rm -f \"$installer_path\"' EXIT");
-    expect(run.indexOf('-o "$installer_path"')).toBeLessThan(run.indexOf('sh "$installer_path"'));
-    expect(run).not.toContain("install.sh | sh");
+    const root = tempDirs.make("openclaw-openshell-package-");
+    const result = spawnSync(
+      "bash",
+      [
+        "--noprofile",
+        "--norc",
+        "-c",
+        `
+curl() {
+  printf '%s\\0' "$@" > "$RUNNER_TEMP/curl-args"
+  local output=""
+  while (( $# )); do
+    if [[ "$1" == -o ]]; then shift; output="$1"; fi
+    shift
+  done
+  printf '%s' "$output" > "$RUNNER_TEMP/package-path"
+  printf 'fixture package' > "$output"
+  printf 'download\\n' >> "$RUNNER_TEMP/calls"
+  return "$CURL_EXIT"
+}
+sha256sum() {
+  printf '%s\\0' "$@" > "$RUNNER_TEMP/checksum-args"
+  cat > "$RUNNER_TEMP/checksum-input"
+  printf 'verify\\n' >> "$RUNNER_TEMP/calls"
+  return "$CHECKSUM_EXIT"
+}
+sudo() {
+  printf '%s\\0' "$@" > "$RUNNER_TEMP/install-args"
+  local package
+  for package in "$@"; do :; done
+  cat "$package" > "$RUNNER_TEMP/installed-bytes"
+  printf 'install\\n' >> "$RUNNER_TEMP/calls"
+  return "$INSTALL_EXIT"
+}
+openshell() {
+  [[ "$*" == --version ]] || return 99
+  printf 'version\\n' >> "$RUNNER_TEMP/calls"
+}
+${run}`,
+      ],
+      {
+        encoding: "utf8",
+        timeout: 5_000,
+        env: {
+          PATH: process.env.PATH,
+          RUNNER_TEMP: root,
+          CURL_EXIT: String(scenario.curlExit),
+          CHECKSUM_EXIT: String(scenario.checksumExit),
+          INSTALL_EXIT: String(scenario.installExit),
+        },
+      },
+    );
+    expect(result.error).toBeUndefined();
+    expect(result.status, result.stderr).toBe(
+      scenario.curlExit || scenario.checksumExit || scenario.installExit,
+    );
+    expect(readFileSync(join(root, "calls"), "utf8")).toBe(scenario.calls);
+    const packagePath = readFileSync(join(root, "package-path"), "utf8");
+    expect(readNulSeparatedArgs(join(root, "curl-args"))).toEqual([
+      "-LsSf",
+      "--connect-timeout",
+      "10",
+      "--max-time",
+      "120",
+      "-o",
+      packagePath,
+      "https://github.com/NVIDIA/OpenShell/releases/download/v0.0.109/openshell_0.0.109-1_amd64.deb",
+    ]);
+    if (scenario.curlExit === 0) {
+      expect(readNulSeparatedArgs(join(root, "checksum-args"))).toEqual(["--check", "-"]);
+      expect(readFileSync(join(root, "checksum-input"), "utf8")).toBe(
+        `0364a21f279023a241d967309ebb0177dadb66bd792eeb3daf542283158ca40f  ${packagePath}\n`,
+      );
+    }
+    if (scenario.curlExit === 0 && scenario.checksumExit === 0) {
+      expect(readNulSeparatedArgs(join(root, "install-args"))).toEqual([
+        "env",
+        "DEBIAN_FRONTEND=noninteractive",
+        "apt-get",
+        "install",
+        "-y",
+        packagePath,
+      ]);
+      expect(readFileSync(join(root, "installed-bytes"), "utf8")).toBe("fixture package");
+    }
+    expect(existsSync(packagePath)).toBe(false);
   });
 
   it("prints package size audits for release smoke tarballs", () => {


### PR DESCRIPTION
Latest-review follow-through (2026-08-29 05:45 UTC, exact b6c5f1e): the refreshed ClawSweeper review accepts the hosted behavior proof and reports no blocking code finding. Maintainer acceptance is recorded through this explicitly requested native landing. The reviewer-side DNS limitation is resolved here by the direct immutable upstream checks and live tag mapping detailed below, not waived. This review has no separate Rank-up moves list. No semantic code change or new review request is needed.

Related: [hosted OpenShell bootstrap failure](https://github.com/openclaw/openclaw/issues/131134). The [parent fixture repair](https://github.com/openclaw/openclaw/pull/130465) is merged as `7494f22035139d2ba57c7a50685549afd332fc63`.

## What Problem This Solves

Repairs the hosted OpenShell E2E bootstrap's competing gateway and certificate ownership. The former fallback could start another gateway on the installer's port and register a different client certificate bundle before tests ran.

## Why This Change Was Made

One shell owns the checksum-verified package install, isolated gateway/PKI state, protected readiness checks, test command and bounded cleanup. Registration and the server share the existing TLS-bundle contract; mTLS remains enabled. The competing fallback and manual certificate-copy path are removed. Failure/cancellation stays visible, and retained log evidence is bounded and fail-closed redacted.

## User Impact

No product API, configuration, dependency version, sandbox policy, SDK or database change. This is the hosted CI half of the now-landed fixture repair, retaining its real mirror/remote and strict cleanup assertions.

## Evidence

Final-main proof is green for **b6c5f1ef8c22b7f20213dadb71f1c533c47197e3**. Parent #130465 is merged as [7494f22035139d2ba57c7a50685549afd332fc63](https://github.com/openclaw/openclaw/commit/7494f22035139d2ba57c7a50685549afd332fc63). This PR targets main and contains only the four child commits replayed from the explicit parent boundary; stable patch IDs, authors, author dates and messages are unchanged. No semantic repair or parent replay was added during this refresh.

[Normal CI 33232227396, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33232227396) succeeded, including required gate job 99047673495. Its actual build checkout/workflow was merge commit `6723453c398b67905eb2a89ac9674f8a404ed8ee` (child b6c5f1e into main `56c2083fbdd5cac62d69cae92bb71cc68e512412`). Startup JS gzip was **344318 B**, below the current 345290 B limit and original 347037 B recovery criterion. The main-owned baseline reduction is not this PR's work. Seven superseded old checks appeared as failures in the watcher before the final green result; this is not a claim that all historical checks passed.

[Hosted OpenShell 33232266674, attempt 1 / job 99047075564](https://github.com/openclaw/openclaw/actions/runs/33232266674/job/99047075564) used validation = tooling = actual checkout **b6c5f1ef8c22b7f20213dadb71f1c533c47197e3**. Checksum-verified v0.0.109 installation and protected `whoami` / `sandbox list` readiness passed. The declared `pnpm test:e2e:openshell` command runs `OPENCLAW_E2E_OPENSHELL=1` through `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts extensions/openshell/src/backend.e2e.test.ts`. All **5 cases passed without skips in 36.02s**: three discovery cases plus mirror stress 17.342s and remote stress 11.567s. The unchanged source retains eight-by-eight stress, all four cleanup identities, deny/allow controls, FIFO/socket checks and strict durable workspace teardown. Owned gateway/network cleanup completed; the later Docker cleanup reported zero resources removed, which is not a global host-inventory claim.

The uploaded redacted diagnostic artifact was inspected: 612501 bytes / 1772 lines, 2953 UUID-redaction markers and zero full UUID-shaped values. It covers 03:53:15.398736Z–03:53:20.754963Z only. It is bounded tail evidence, not proof of an error-free upstream control plane or an upstream SQL repair.

The earlier ClawSweeper review (2026-08-29 03:54 UTC, exact b6c5f1e) has no actionable code findings. Both remaining items and rank-up moves are now addressed: the exact-head hosted run is complete, and direct upstream inspection was possible here. Live tag `v0.0.109` resolves to [8d67250a5d17348eb96c4fa46226b06d8041f2ba](https://github.com/NVIDIA/OpenShell/commit/8d67250a5d17348eb96c4fa46226b06d8041f2ba). The [installer](https://github.com/NVIDIA/OpenShell/blob/8d67250a5d17348eb96c4fa46226b06d8041f2ba/install.sh#L696) starts the user service; [Debian postinst](https://github.com/NVIDIA/OpenShell/blob/8d67250a5d17348eb96c4fa46226b06d8041f2ba/deploy/deb/postinst.sh) does not. [Local TLS import](https://github.com/NVIDIA/OpenShell/blob/8d67250a5d17348eb96c4fa46226b06d8041f2ba/crates/openshell-cli/src/commands/gateway.rs#L612), registration at line 987, server defaults and the upstream Docker E2E owner confirm the shared bundle contract. The repair removes competing installer/fallback and manual certificate-copy ownership while retaining mTLS. The original managed-service authentication failure itself remains unexplained.

Prior whole-child managed reviews carry only across the verified identical patch. Prior local proof remains source-bound: 555 cohort tests, both changed gates and workflow checks passed. Final-head sanity passed `git diff --check 133a189ffa9254bfc5daa02d07c48e21d5311a9b HEAD`, direct `oxfmt --check` on the four changed files, and the approved fixed actionlint on both workflows. Current-main drift inspection found no changes to these four files after that frozen base. No broad rerun or new review is claimed for the mechanical replay.

Best-fix judgment: one isolated package/PKI/gateway/process owner repairs the confirmed lifecycle defects. Restarting the managed service or retaining a second fallback would preserve competing ownership. Application production +0/-0; workflow tooling +166/-87 (net +79); tests +126/-13. Tooling growth provides explicit ownership, cancellation and fail-closed bounded diagnostics. No configuration, dependency, schema, timeout, assertion, baseline or product sandbox-policy change. This proof does not certify the full release matrix or a release publication. Native preparation and landing follow separately.

<details>
<summary>Earlier source-bound evidence (historical)</summary>


**Final-main candidate:** `b6c5f1ef8c22b7f20213dadb71f1c533c47197e3` on frozen main `133a189ffa9254bfc5daa02d07c48e21d5311a9b`. After the parent squash, GitHub automatically retargeted this PR to `main`. The four child commits were then replayed explicitly with old parent boundary `4bd53eb3f7d185182570f1397e1480ae1449fb19`; no parent commits were replayed. All four retain identical stable patch IDs, authors, dates and messages. No new semantic code was added.

The complete OpenShell `validate_special_e2e` job is byte-identical to previously tested `db262026568259a8eee11cdc97d4cc35ab6a9984` (SHA256 `735a71cadd05ed86483bcabcecb48d62461f56035513b137c50076c5f46ce595`); the full installer-test file is also unchanged. New main-owned checkout ownership, release-job concurrency/scenario routing and unrelated workflow-test changes are retained, not attributed to this PR. The parent source and waiter repair are already on main.

**Previous exact-stack proof:** [run 33229463188/job 99039594239](https://github.com/openclaw/openclaw/actions/runs/33229463188/job/99039594239) passed all five OpenShell cases without skips in 38.17s at validation/tooling `db262026568259a8eee11cdc97d4cc35ab6a9984`, including protected readiness, mirror/remote stress and strict fixture cleanup. [Parent CI33229365791](https://github.com/openclaw/openclaw/actions/runs/33229365791) and [child CI33229384412](https://github.com/openclaw/openclaw/actions/runs/33229384412) passed; actual builds measured 344718/344591 B startup gzip, below both their 345947 B limit and the original 347037 B recovery criterion. These are historical source-bound results, not fresh final-main passes.

Prior local verification passed 555 cohort tests, both changed gates, workflow checks and the required independent reviews. New-head mechanical sanity passed `git diff --check`, targeted `oxfmt --check`, and the approved fixed actionlint on both workflows. OpenShell runtime/fixture and shared waiter source have no drift from the previously tested child. The mechanical replay carries only identical patch review; it does not claim a new broad review. Fresh exact-head normal CI and one final-main hosted OpenShell E2E run are required before native preparation/merge. The latest ClawSweeper parent-first/replay/final-target proof request is being followed, not waived.

**LOC:** production runtime +0/-0; workflow tooling +166/-87 (net +79); tests +126/-13. Existing tooling growth establishes one gateway/PKI/process owner and bounded diagnostics while deleting fallback ownership. No timeout, assertion, baseline, gzip budget, dependency override, schema or changelog change. Full release verification remains separately blocked.

<details>
<summary>Earlier source-bound evidence (historical)</summary>

Related: [hosted OpenShell bootstrap failure](https://github.com/openclaw/openclaw/issues/131134). Stacked on the [OpenShell fixture repair](https://github.com/openclaw/openclaw/pull/130465).

## What Problem This Solves

Repairs the hosted OpenShell E2E bootstrap's competing gateway and certificate ownership. The former fallback could start another gateway on the installer's port and then register a different client certificate bundle before the tests ran.

## Why This Change Was Made

One shell now owns the checksum-verified package install, isolated gateway/PKI state, protected readiness checks, test command and bounded cleanup. The server and registration share the existing TLS-bundle contract; mTLS remains enabled. The competing fallback and manual certificate-copy path are removed. Failure/cancellation remains visible, and log evidence is bounded and fail-closed redacted.

## User Impact

No product API, configuration, dependency version, sandbox policy, SDK or database change. This is the hosted CI half of the parent fixture repair and retains the same real mirror/remote assertions.

## Evidence

**Current stack:** child `db262026568259a8eee11cdc97d4cc35ab6a9984` above parent `4bd53eb3f7d185182570f1397e1480ae1449fb19`, on frozen main `5fc71d3994e3694c6bf03acdaa9cbc280469b152`. The three functional child commits retain identical patch IDs, authors, dates and messages after explicit-boundary replay. A final comment-only commit corrects three stale CI stripe descriptions; executable logic is unchanged, with focused formatting and fixed-actionlint validation. The complete hosted OpenShell job remains byte-identical to previously tested `2772958d7fae33060893b4d9ef753e31b20dd29f`.

The stack consumes the canonical main UI type-shard split from [132193](https://github.com/openclaw/openclaw/pull/132193), with unchanged 720-root cap and exact-once coverage. It does not republish our duplicate split or alter gzip budgets.

**New local proof:** 555 cohort tests passed (34 original-order runner/compiler checks, 65 process boundaries, 142 OpenShell cases, 314 child tooling cases); no failures or filtered skips. Parent and child changed gates passed, with five additional doctor-contract checks in the parent gate. The incomplete parent SDK declaration cache was regenerated through its owner and consumed by the real type/lint checks. Frozen installs relinked the already-declared acpx update; lifecycle hooks were deliberately disabled to avoid shared Git writes in that proof lane, so package-install lifecycle proof is not claimed. Workflow checks passed with the approved fixed actionlint, offline pinned zizmor and the unchanged composite-input guard; offline audits are not presented as a complete hosted result.

**Historical hosted recovery:** [run 33219252669/job99010148464](https://github.com/openclaw/openclaw/actions/runs/33219252669/job/99010148464) passed all five real OpenShell cases without skips in 35.50s on exact `2772958d7fae33060893b4d9ef753e31b20dd29f`, with protected readiness and strict workspace/network/container cleanup. Parent/combined gzip measured 345165/344946 B, below the original 347037 B criterion. Those results are historical until the new exact-source dispatch completes. Source inspection and bounded logs do not establish an upstream SQL repair or an error-free control plane.

**Parent-first gate:** this PR still targets `fix/openshell-allow-policy-path`, not main. After the parent squash lands, replay only the four child commits using the explicit parent boundary, retarget main, refresh native guards and obtain final-target CI/E2E proof. Main-bound native prepare/merge must not run while the PR targets its parent. A fresh combined dispatch and normal CI are required for this refreshed stack; neither preparation nor merge is claimed yet.

**LOC:** application production +0/-0; workflow tooling +166/-87 (net +79, including three comment replacements); tests +126/-13. Existing growth provides one gateway/PKI/process owner and bounded diagnostics while deleting fallback ownership. No new semantic code was added by this refresh. The parent's waiter repair is test-only and does not explain its earlier unrecorded spawn-timeout state. Full release verification remains separately blocked.

<details>
<summary>Earlier source-bound evidence and follow-ups (historical)</summary>

## Canonical-main stacked refresh — integrated proof pending

Child head `2772958d7fae33060893b4d9ef753e31b20dd29f` is based on parent `eb60af39465087c068b975c4328cc4cf3a6a05cd`. Explicit rebase --onto used old parent boundary `50c43924a6948b1fa93d70abade3fc4581bbcef1` and replayed **only three child commits**, all patch-identical. Parent commits were not replayed. Base remains `fix/openshell-allow-policy-path`. The complete hosted OpenShell job is byte-identical to old child; main's unrelated workflow changes are retained.

The refresh consumes canonical UI source repair [#132124](https://github.com/openclaw/openclaw/pull/132124), commit `5b605da389460fd035d9a2031064ed949303b14f`, through immutable server main `486d0757939b3c33f56ca49b8a04e919205bac03`. No UI implementation, baseline, compression, manifest, dependency, timeout, policy, schema or assertion change was made by this refresh. Main's independently owned Usage repair and later baseline changes are carried unchanged.

**UI recovery criterion:** old parent CI [33210106646](https://github.com/openclaw/openclaw/actions/runs/33210106646) built merge `1e510feb884da4ab9a3acf86f9541d32b31a56cd`, not branch head `50c43924…`. Its four startup gzip measurements were 347231–347263 B against **347037 B**. Cached canonical-repair [build proof](https://github.com/openclaw/openclaw/actions/runs/33212212671/job/98988058967) shows actual checkout/workflow `605ace5c5ffc17e07504fc5d2610ecbc9cabce15` and **345110 B** under that original limit. The new OpenShell CI must still supply its actual build source and gzip measurement below **347037 B**; green alone is not the recovery evidence. Selected main now has a separately owned 345371 B baseline / 345947 B enforcement; this refresh did not alter it.

**Prior proof remains historical:** [run 33210416671/job98982737606](https://github.com/openclaw/openclaw/actions/runs/33210416671/job/98982737606) passed 5/5 without skips in 45.35s at old validation=tooling `954f8878ceed78cef5ebcb108b58ef7fa76296a4`, with strict workspace cleanup, exact network removal and zero remaining containers. Its sanitized tail covers only ~7.245 seconds; three PushSandboxLogs gRPC 13 responses do not prove a SQL cause or an upstream repair. Main now changes physical host-path lease canonicalization in the OpenShell backend, so a fresh combined run is required despite unchanged fixture and workflow assertions.

**New integrated proof:** [Run 33219252669](https://github.com/openclaw/openclaw/actions/runs/33219252669) was dispatched once with requested validation=tooling `2772958d7fae33060893b4d9ef753e31b20dd29f`, exact filter `openshell-e2e`, configured Blacksmith backend, no provider or release-path suites. Run metadata confirms that workflow head; selected-ref verification and the result are pending. This phase does not wait for completion.

Local Node 24 verification passed **142/142 parent fixture/backend/mirror/core tests** (including main's symlink-alias lease case) and **307/307 child tooling tests**. Workflow checks passed with the approved fixed actionlint binary, zizmor and composite input guard; docs listing and commit-range diff checks passed. The combined seven-file changed gate also passed on the exact frozen-base/new-child tuple, including five doctor-contract tests, zero unused-export entries, typechecks and lint. No reinstall or node_modules edit. Prior managed Codex P0 reviews carry under the verified mechanical, patch-identical rebase; no new semantic repair or wider review scope is claimed.

All host/port/executable constraints, explicit host-IP replacement semantics, deny assertions, overlap and FIFO/socket behavior, stress counts, four cleanup owners and the original 120000ms cleanup deadline are unchanged. Direct NVIDIA v0.0.109 source inspection confirms the [four CIDRs](https://github.com/NVIDIA/OpenShell/blob/8d67250a5d17348eb96c4fa46226b06d8041f2ba/e2e/rust/tests/host_gateway_alias.rs#L288), [durable inventory](https://github.com/NVIDIA/OpenShell/blob/8d67250a5d17348eb96c4fa46226b06d8041f2ba/crates/openshell-server/src/grpc/sandbox.rs#L393), [strict workspace delete](https://github.com/NVIDIA/OpenShell/blob/8d67250a5d17348eb96c4fa46226b06d8041f2ba/crates/openshell-server/src/grpc/workspace.rs#L287), [package lifecycle](https://github.com/NVIDIA/OpenShell/blob/8d67250a5d17348eb96c4fa46226b06d8041f2ba/deploy/deb/postinst.sh), and [shared TLS import](https://github.com/NVIDIA/OpenShell/blob/8d67250a5d17348eb96c4fa46226b06d8041f2ba/crates/openshell-cli/src/commands/gateway.rs#L612) contracts. No production prune/recreate or upstream database fix is claimed.

**Normal CI:** [Run 33219236039](https://github.com/openclaw/openclaw/actions/runs/33219236039) is attached to `2772958d7fae33060893b4d9ef753e31b20dd29f`. Observed state: in_progress; conclusion: pending. No generic CI wait or blind old-source rerun was performed.

**Parent-first / ClawSweeper follow-through:** latest inspected review is August 28, 2026 ~21:22 UTC. Its post-parent main retarget and fresh CI/E2E request remains explicitly deferred, not waived. After parent squash lands, replay only child commits with explicit --onto landed-main `eb60af39465087c068b975c4328cc4cf3a6a05cd`, retarget main, refresh native source guards, and obtain final-main proof. Do not use main-bound native prepare/merge while this child targets its parent. No prepare/merge ran in this phase.

Production runtime +0/-0; workflow tooling +163/-84; tests +126/-13; incremental refresh delta zero. Existing tooling growth owns the single package/PKI/gateway lifecycle, cancellation cleanup and bounded diagnostics while deleting fallback ownership. Original full release 33154285571 remains blocked_complete; no original-package/full-release recovery is claimed.

## Historical evidence before this main-fix refresh

All earlier current/final/prepared claims below apply only to their named historical source.


Everything below describes its named older source; the current identities and status are above.

Related: #131134

Stacked on #130465 (`fix/openshell-allow-policy-path`). This PR's own diff is the workflow plus its two owning workflow-test repairs; #130465 retains its contributor credit and separate fixture review. Current candidate: `c2b5d4180e0be705bd495f94f66523564ee1bc01`, parent: `eca161714a3595dd54e3a9390061db9fa35b44bd` on main `2169669140f17e01833aec48f8510d641a6c41cb`. Previously proven combined candidate: `b01cfe26dc19276e208ffc34ae22301b2813ebcd`, parent: `95fc49794912176be2b55122ad75942e3a2411ea`.

## Hold: parent landing and final-target gates

The [final combined hosted run](https://github.com/openclaw/openclaw/actions/runs/33147687932/job/98772573742) passed all five tests on exact candidate `c2b5d4180e0be705bd495f94f66523564ee1bc01`, including real mirror/remote stress and strict workspace cleanup. [Exact-head normal CI](https://github.com/openclaw/openclaw/actions/runs/33147675231) passed, including the previously failing workflow-test shard and CI gate. The complete check rollup has no failure or pending check; two older canceled metadata jobs have newer success/skipped replacements. GitHub reports no required checks on this non-main child base, which does not establish final-main enforcement. The parent's main conflict is resolved, preserving main's FIFO/socket behavior and the existing explicit host-address replacement policy. All three child commits replayed unchanged and fresh whole-child P0–P2 review passed. This child is verified on its stacked base, not yet ready for direct landing: parent landing, child retargeting to main and final-target CI/native gates remain prerequisites.

## What Problem This Solves

The hosted OpenShell E2E lane can fail during gateway authentication before running its tests. Its fallback starts a second gateway on the installer's port, then local registration can overwrite its client certificates with a different package-managed bundle.

## Why This Change Was Made

Install the same pinned OpenShell v0.0.109 Debian package directly after verifying its published SHA256, without invoking the installer that starts a systemd service. One shell owns the gateway process, isolated config/state, shared TLS bundle, protected readiness checks, unchanged E2E command and cleanup. This removes the competing fallback and manual certificate-copy path. One interruptible child-command helper covers bootstrap and testing, including the test runner's process group. The initial build includes the existing private-QA target required by E2E global setup.

The installer has no supported skip-service option; the Debian post-install script reloads unit definitions without starting a service. Local registration and the server receive the same `OPENSHELL_LOCAL_TLS_DIR`, and mTLS remains enabled. Failure and cancellation terminate and reap the owned gateway and current command group, then remove fixture state. Repeated cancellation cannot interrupt teardown; its shared grace and Docker-client deadlines fit inside the runner's escalation window. Forced termination or failed network removal fails the job rather than claiming clean teardown.

Gateway evidence is retained only as a sanitized, bounded tail after process/PKI cleanup. The pinned upstream gateway can put SSH bearer UUIDs in `session_id` warnings and `object.id` spans, fields not recognized by the standard text redactor. Full UUID substitution precedes canonical redaction; partial boundary lines are dropped. Missing input, failed imports and redactor timeouts omit the artifact without a raw fallback. Only the exact sanitized file is uploaded, with seven-day retention. Its input is the last 1 MiB of complete log lines, not whole-run control-plane evidence.

## User Impact

No product API, configuration, dependency version, sandbox policy, SDK or database change. This is an internal CI fixture repair. This PR leaves the parent's tests and cleanup assertions unchanged. Workflow/tooling LOC: +163/-84 (net +79); production runtime: unchanged; tests: +126/-13. The two owning tests preserve the heap requirement, assert private-QA availability, and execute the actual install-step shell with command-boundary stand-ins for success and three failure paths. Growth provides explicit process-group ownership, interruptible waits and bounded cancellation cleanup while deleting the fallback path, plus fail-closed evidence retention outside the cleanup grace.

## Evidence

- Baseline: [run 33106165717](https://github.com/openclaw/openclaw/actions/runs/33106165717/job/98637332441) installed v0.0.109, reported the managed gateway connected, failed protected `sandbox list` with `missing authorization header`, and skipped E2E. The original managed-service authentication failure is not independently explained; the two fallback ownership defects are source-proven.
- The original bootstrap baseline `979e58ce69b2f630e859cf8124fc6fca8f90d053` contains that fallback. The v0.0.109 pin was carried forward by #130296 (authored and merged by @steipete); local history is shallow before the fallback, so its original introduction is not attributed here.
- Direct dependency inspection: [installer](https://github.com/NVIDIA/OpenShell/blob/8d67250a5d17348eb96c4fa46226b06d8041f2ba/install.sh), [Debian post-install](https://github.com/NVIDIA/OpenShell/blob/8d67250a5d17348eb96c4fa46226b06d8041f2ba/deploy/deb/postinst.sh), [TLS import and registration](https://github.com/NVIDIA/OpenShell/blob/8d67250a5d17348eb96c4fa46226b06d8041f2ba/crates/openshell-cli/src/commands/gateway.rs#L612), [server runtime defaults](https://github.com/NVIDIA/OpenShell/blob/8d67250a5d17348eb96c4fa46226b06d8041f2ba/crates/openshell-server/src/cli.rs#L560), and [upstream Docker E2E owner](https://github.com/NVIDIA/OpenShell/blob/8d67250a5d17348eb96c4fa46226b06d8041f2ba/e2e/with-docker-gateway.sh).
- Package SHA256 matches release metadata and the published checksum manifest: `0364a21f279023a241d967309ebb0177dadb66bd792eeb3daf542283158ca40f`.
- Local changed-surface checks passed: `node scripts/check-changed.mjs -- .github/workflows/openclaw-live-and-e2e-checks-reusable.yml test/scripts/package-acceptance-workflow.test.ts test/scripts/test-install-sh-docker.test.ts`. Workflow checks passed: `node --import ./scripts/tsx.mjs scripts/check-workflows.mts` (actionlint, zizmor, composite input guard), focused formatting and `git diff --check`.
- Independent Codex P0–P2 reviews of the whole owner diff and final exact stacked head found no actionable defects. All three child file blobs match the previously tested candidate after replay. Final E2E collection/parser proof passed three discovery cases, with the two live-disabled sandbox cases skipped locally. Those checks do not replace exact-head CI or hosted live proof.
- The previous candidate's [normal CI](https://github.com/openclaw/openclaw/actions/runs/33145295306/job/98764942522) found two stale assertions: whole-environment equality rejected the existing private-QA flag, and an installer test required the removed script path. Both owning files now pass 292/292 tests. The new executable install test covers success, partial download, checksum failure and install failure, asserting bounded arguments, checksum/install ordering, synthetic package bytes, original exit codes and temporary-package cleanup. These command-boundary stand-ins are not actual download/install proof; the real hosted run below provides that evidence.
- Linux shell lifecycle proof executes the extracted workflow with command-boundary stand-ins in a disposable container, not the real service. Initial cancellation and failed Docker-inventory cases failed before repair. All nine repaired cases pass: suite/auth cancellation, repeated signals during teardown, success/error preservation, forced termination, stuck Docker client, failed inventory and confirmed absence. Cleanup takes about 2.1–4.2 seconds, owned descendants are gone and an unrelated sentinel survives. Only the exact fixture network is removed.
- Log safety: the old failure/cancellation tail leaked a synthetic warning UUID in six of nine shell cases. The candidate suppresses all raw-output paths and retains nine passing lifecycle cases. Ten Node 24 Linux canaries exercise the actual post-step and built canonical redactor: full UUID removal, ANSI, both truncation boundaries, oversized input, missing log/module, throwing import, hung import and cancellation pass. Real imports took about one second; hung imports were killed in about six seconds, with raw/provisional files and owned workers gone. Earlier Mac Node 26 cold imports safely omitted some artifacts when they exceeded the unchanged five-second budget.
- [Prior bootstrap-only run 33138297530](https://github.com/openclaw/openclaw/actions/runs/33138297530/job/98743573684), exact `011bb93e110dd853a2ec26a8c0821d252689c292`: checksum, installation and protected readiness passed. All five tests ran: 3 passed / 2 failed at the allow-policy HTTP 403, before stress. This motivated the separately owned canonical fixture fix in #130465; it was not full integration proof.
- [Prior combined run 33144751236](https://github.com/openclaw/openclaw/actions/runs/33144751236/job/98763577222), exact `b01cfe26dc19276e208ffc34ae22301b2813ebcd`: protected readiness passed; all 5 tests passed in 99.79 seconds, including mirror 40.555 seconds and remote 49.607 seconds. Each mode reaches the source-enforced 8 waves × 8 concurrent workflows, 32 exec commands, 8 intentional exit-23 failures and exact 74 mirror / 72 remote file checks. Passing-test console output is suppressed, so these are asserted coverage counts, not printed stress telemetry. Both modes also pass failure recovery and strict cleanup; the owned network was removed and graceful gateway shutdown reported zero remaining Docker sandbox containers.
- [Final combined run 33147687932](https://github.com/openclaw/openclaw/actions/runs/33147687932/job/98772573742), exact `c2b5d4180e0be705bd495f94f66523564ee1bc01` on final parent `eca161714a3595dd54e3a9390061db9fa35b44bd`: real v0.0.109 checksum/install and protected readiness passed; all 5 tests passed in 88.43 seconds, mirror 36.184 seconds and remote 45.195 seconds. This includes main's FIFO/socket coverage, the default policy without a host-IP override, the same asserted stress counts above, failure recovery and strict cleanup for both workspaces. The exact owned network was removed; graceful gateway shutdown reported zero remaining sandbox containers.
- Cleanup is not inferred from sandbox-delete acknowledgements. The helper observes durable sandbox absence, then calls workspace delete without ignoring failure, and all cleanup errors fail the test. The pinned [workspace RPC](https://github.com/NVIDIA/OpenShell/blob/8d67250a5d17348eb96c4fa46226b06d8041f2ba/crates/openshell-server/src/grpc/workspace.rs#L287) checks blocking resources and awaits platform cleanup and CAS row deletion. Its [SQLite owner](https://github.com/NVIDIA/OpenShell/blob/8d67250a5d17348eb96c4fa46226b06d8041f2ba/crates/openshell-server/src/persistence/sqlite.rs#L250) returns false only after confirming the original row absent; version conflicts fail the RPC. Successful CLI completion therefore establishes deletion or confirmed absence, not necessarily a newly deleted row.

The [final sanitized artifact](https://github.com/openclaw/openclaw/actions/runs/33147687932/artifacts/9676576885) contains 612633 bytes / 1770 lines covering 06:29:59.022565Z–06:30:23.554561Z, only the final approximately 24.5 seconds; mirror cleanup is outside that tail. Its input is bounded to the last 1 MiB of complete lines. No full UUID-shaped value remains. Three `PushSandboxLogs` response spans report gRPC 13 / INTERNAL near remote teardown, adjacent to messages describing expected transport closure. Their 41–43 second duration is the lifetime of a client-streaming RPC, not evidence of slow SQL. The [pinned handler](https://github.com/NVIDIA/OpenShell/blob/8d67250a5d17348eb96c4fa46226b06d8041f2ba/crates/openshell-server/src/grpc/policy.rs#L3287) can map stream-read or initial lookup errors to INTERNAL; these spans do not independently establish the cause. This run proves the exercised behavior and strict cleanup, not an error-free upstream control plane or a fix for NVIDIA/OpenShell#2999. No dependency override, database workaround, test skip, host-IP override or timeout relaxation is introduced.


</details>

</details>

</details>
