### PR TITLE
fix(memory): ignore vector debt for FTS-only indexes

### DIFF
--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -568,10 +568,10 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
           if (!shouldSyncMemory) {
             this.clearMemoryRetryState();
           }
-          const vectorIndexComplete = this.vector.available === true;
           const syncProvider = this.syncProviderGeneration
             ? this.syncProviderGeneration.provider
             : this.provider;
+          const vectorIndexComplete = syncProvider === null || this.vector.available === true;
           const nextMeta: MemoryIndexMeta = {
             model: syncProvider?.model ?? "fts-only",
             provider: syncProvider?.id ?? "none",

--- a/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
+++ b/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
@@ -641,6 +641,28 @@ describe("memory manager FTS-only reindex", () => {
     expect(countChunksContaining("Alpha topic")).toBeGreaterThan(0);
   });
 
+  it("ignores persisted vector rebuild debt after reopening an FTS-only index", async () => {
+    const memoryManager = await createManager({ provider: "none" });
+    const db = Reflect.get(memoryManager, "db") as DatabaseSync;
+    db.prepare(
+      `INSERT INTO memory_index_meta (key, value) VALUES ('memory_vector_rebuild_v1', '1')`,
+    ).run();
+
+    await memoryManager.sync({ force: true });
+    await memoryManager.close();
+    manager = null;
+    await closeAllMemorySearchManagers();
+    await closeAllMemoryIndexManagers();
+
+    const reopened = await createManager({ provider: "none", purpose: "status" });
+    expect(reopened.status()).toMatchObject({
+      dirty: false,
+      vector: { enabled: false, index: { state: "empty" } },
+      custom: { indexIdentity: { status: "valid" } },
+    });
+    expect(countChunksContaining("Alpha topic")).toBeGreaterThan(0);
+  });
+
   it("still initializes configured providers when vector storage is disabled", async () => {
     const memoryManager = await createManager({ provider: "auto", vectorEnabled: false });
 


### PR DESCRIPTION
## Problem

An FTS-only memory index could retain `memory_vector_rebuild_v1=1` from an earlier semantic index. A forced rebuild indexed every file and reopened with valid FTS metadata, but status still reported the disabled vector index as incomplete.

## Root cause

The shadow publisher marked vector state clean only when a vector store was available. A completed FTS-only generation intentionally has no vector store, so it could never settle old vector rebuild debt.

## Fix

- Use the frozen sync generation to decide whether the published index expects vectors.
- Mark a successfully published FTS-only generation clean because it expects zero vector rows.
- Keep missing, orphaned, or incomplete semantic vector indexes fail-closed.
- Add a close/reopen regression that seeds persisted rebuild debt and preserves searchable FTS content.

## Proof

**Live CLI:** Two isolated Linux runs used the same disposable config and real CLI flow: index one memory file, persist rebuild debt, force-reindex, close, and reopen status. Exact current main `16b0c1f251c79234f0a8285ea37f64493341b04a` retained marker `1` and returned `vectorState=incomplete`. This head published marker `clean` and returned `vectorState=empty`. Both retained one file, one chunk, and `indexIdentity=valid`.

**Focused tests:** The new regression and vector-state unit cases pass. The two semantic sibling cases that caught the first implementation also pass: pre-marker orphan vectors still force rebuild, and incremental cleanup still preserves semantic rebuild debt. Combined result: 4 files, 81 tests passed.

**Local gates:** focused format and Oxlint, changed-scope repository ratchets, plugin boundaries, database-first, dead-export, and import-cycle checks passed. Hosted CI owns typecheck and build for this host.

## Change size

- Production: +1 / -1, net 0
- Tests: +22 / -0
- No config or schema change

## Maintainer decision

Ayaan Zaidi explicitly requested this repair and instructed it to land after the `prreview` and `landpr` gates. Merge after exact-head checks pass.
