### PR TITLE
test(ui): require committed transcript focus placement

### DIFF
--- a/ui/src/e2e/chat-transcript-focus.e2e.test.ts
+++ b/ui/src/e2e/chat-transcript-focus.e2e.test.ts
@@ -61,64 +61,100 @@ suite.define(() => {
       .toBe(true);
     expect(await thread.locator(".chat-virtual-row").count()).toBeLessThan(30);
 
-    const checkPlacement = async (edge: "first" | "last", sparse: boolean) => {
+    const checkPlacement = async (
+      edge: "first" | "last",
+      sparse: boolean,
+      expectedRowKey: string,
+    ) => {
       // Focused outliers stay mounted, so text visibility can precede the new
-      // virtual range. Wait for placement, keeping the same geometry bounds.
+      // virtual range. Require the gap beside that outlier and the normal range
+      // covering the requested viewport, not the previous range plus its outlier.
       await vi.waitFor(async () => {
-        const placement = await thread.evaluate((element, placementEdge) => {
-          const rows = [...element.querySelectorAll<HTMLElement>(".chat-virtual-row")];
-          const sizer = element.querySelector<HTMLElement>(".chat-virtual-sizer")!;
-          const focused = document.activeElement?.closest<HTMLElement>(".chat-virtual-row");
-          const edgeRow = placementEdge === "first" ? rows[0]! : rows.at(-1)!;
-          const gaps = rows.slice(1).map((row, index) => ({
-            skipped: Number(row.dataset.index) - Number(rows[index]!.dataset.index) - 1,
-            pixels: row.getBoundingClientRect().top - rows[index]!.getBoundingClientRect().bottom,
-          }));
-          return {
-            focused: focused === edgeRow,
-            edgeDelta:
-              placementEdge === "first"
-                ? edgeRow.getBoundingClientRect().top - sizer.getBoundingClientRect().top
-                : sizer.getBoundingClientRect().bottom - edgeRow.getBoundingClientRect().bottom,
-            gaps,
-            count: rows.length,
-          };
-        }, edge);
+        const placement = await thread.evaluate(
+          (element, { edge: placementEdge, sparse: isSparse }) => {
+            const rows = [...element.querySelectorAll<HTMLElement>(".chat-virtual-row")];
+            const sizer = element
+              .querySelector<HTMLElement>(".chat-virtual-sizer")!
+              .getBoundingClientRect();
+            const focused = document.activeElement?.closest<HTMLElement>(".chat-virtual-row");
+            const edgeRow = placementEdge === "first" ? rows[0]! : rows.at(-1)!;
+            const normalRows = isSparse ? rows.filter((row) => row !== edgeRow) : rows;
+            const viewportTop = element.getBoundingClientRect().top + element.clientTop;
+            const viewportBottom = viewportTop + element.clientHeight;
+            const atStart = isSparse ? placementEdge === "last" : placementEdge === "first";
+            const gaps = rows.slice(1).map((row, index) => ({
+              skipped: Number(row.dataset.index) - Number(rows[index]!.dataset.index) - 1,
+              pixels: row.getBoundingClientRect().top - rows[index]!.getBoundingClientRect().bottom,
+            }));
+            return {
+              focused: focused === edgeRow,
+              focusedRowKey: focused?.dataset.virtualRowKey,
+              edgeDelta:
+                placementEdge === "first"
+                  ? edgeRow.getBoundingClientRect().top - sizer.top
+                  : sizer.bottom - edgeRow.getBoundingClientRect().bottom,
+              scrollEdgeDelta: atStart
+                ? element.scrollTop
+                : element.scrollHeight - element.clientHeight - element.scrollTop,
+              // Scroller padding is not missing transcript content.
+              uncovered: [
+                normalRows[0]!.getBoundingClientRect().top - Math.max(viewportTop, sizer.top),
+                Math.min(viewportBottom, sizer.bottom) -
+                  normalRows.at(-1)!.getBoundingClientRect().bottom,
+              ],
+              gaps,
+              count: rows.length,
+            };
+          },
+          { edge, sparse },
+        );
         expect(placement.focused).toBe(true);
+        expect(placement.focusedRowKey).toBe(expectedRowKey);
         expect(Math.abs(placement.edgeDelta)).toBeLessThanOrEqual(2);
         expect(placement.count).toBeLessThan(30);
         expect(placement.gaps.filter((gap) => gap.skipped > 0)).toHaveLength(sparse ? 1 : 0);
-        for (const gap of placement.gaps) {
+        for (const [index, gap] of placement.gaps.entries()) {
           if (gap.skipped > 0) {
+            expect(index).toBe(edge === "first" ? 0 : placement.gaps.length - 1);
             expect(gap.pixels).toBeGreaterThan(1000);
           } else {
+            expect(gap.skipped).toBe(0);
             expect(Math.abs(gap.pixels)).toBeLessThanOrEqual(1);
           }
         }
+        expect(Math.abs(placement.scrollEdgeDelta)).toBeLessThanOrEqual(1);
+        for (const pixels of placement.uncovered) {
+          expect(pixels).toBeLessThanOrEqual(2);
+        }
       });
     };
-    await checkPlacement("last", true);
+    await checkPlacement("last", true, focusedRowKey);
     await thread.evaluate((element) => {
       element.scrollTop = element.scrollHeight;
     });
     await page.getByText(/^focus retention message 200\n/).waitFor({ state: "visible" });
-    await checkPlacement("last", false);
+    await checkPlacement("last", false, focusedRowKey);
 
     await thread.evaluate((element) => {
       element.scrollTop = 0;
     });
     await page.getByText(/^focus retention message 1\n/).waitFor({ state: "visible" });
-    await thread.locator("button.chat-reply-btn").first().focus();
+    const firstAction = thread.locator("button.chat-reply-btn").first();
+    await firstAction.focus();
+    const firstRowKey = await firstAction.evaluate(
+      (element) => element.closest<HTMLElement>(".chat-virtual-row")?.dataset.virtualRowKey ?? "",
+    );
+    expect(firstRowKey).not.toBe("");
     await thread.evaluate((element) => {
       element.scrollTop = element.scrollHeight;
     });
     await page.getByText(/^focus retention message 200\n/).waitFor({ state: "visible" });
-    await checkPlacement("first", true);
+    await checkPlacement("first", true, firstRowKey);
     await thread.evaluate((element) => {
       element.scrollTop = 0;
     });
     await page.getByText(/^focus retention message 1\n/).waitFor({ state: "visible" });
-    await checkPlacement("first", false);
+    await checkPlacement("first", false, firstRowKey);
     await page.close();
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Resolves a false-positive in the transcript focus-retention E2E test: it could accept the previous mounted range before the offset observer and Lit committed the requested range.

A recorded browser diagnostic had `scrollTop = max = 24246`, cached offset `0`, focused row `0`, and mounted rows `0..10` plus `199`. The old `checkPlacement("first", true)` passed because focus was on the first mounted row, the mount count was bounded, and there was one large gap. But that gap was between rows `10` and `199`, not immediately after the focused outlier followed by the bottom range.

This is a distinct, maintainer-requested test-correctness follow-up. It does not reapply the already-landed people-cards work in https://github.com/openclaw/openclaw/pull/130664.

## Why This Change Was Made

Keep the repair at the test's assertion boundary. The checker now requires the exact focused row key, the sparse gap immediately beside that outlier on the correct side, consecutive non-gap row indexes, the requested native scroll edge, and a normal contiguous row block covering the visible transcript content. Scroller padding is excluded from the content coverage calculation.

The existing **1px adjacency, 2px edge, fewer-than-30 mounted rows, one >1000px sparse gap / zero nonsparse gaps, and all deadlines remain unchanged**. No private virtualizer state, exact overscan indexes, sleeps, retries, production seams, or production changes were added.

The separate old persistent zero-gap timeout (`skipped: 188`, `pixels: 22958`) remains unexplained and was not reproduced in 14 prior valid diagnostic invocations. This PR does **not** claim that this coverage weakness caused or fixes that timeout.

## User Impact

No runtime or visual behavior changes. Developers get a focus-retention test that cannot pass on the observed stale wrong-range state or a pair of pinned endpoints without a viewport range.

Production LOC: **+0/-0**. Test LOC: **+63/-27**, net **+36**, in one existing E2E file. AI-assisted; the assertion boundary, range/layout/controller, installed Lit adapter and virtual-core contracts were inspected directly.

## Evidence

### Red/green oracle proof

A local executable replay extracts the actual `checkPlacement` function rather than copying its predicate. It supplies the recorded DOM geometry plus explicit synthetic controls. The old checker incorrectly accepts all six invalid states; the strengthened checker rejects them and accepts all six valid states (**12/12 controls**):

| Control | Old checker | New checker |
| --- | --- | --- |
| Recorded `0..10 + 199`, focused `0`, requested bottom | Incorrectly accepts | Rejects gap at wrong position |
| Mirrored stale range | Incorrectly accepts | Rejects gap at wrong position |
| Only two pinned endpoints, top and bottom variants | Incorrectly accepts | Rejects missing viewport coverage |
| Correct cluster but wrong requested scroll edge, both variants | Incorrectly accepts | Rejects wrong edge |
| Committed focused-outlier range, both variants | Accepts | Accepts |
| Committed nonsparse range, both variants | Accepts | Accepts |
| Original 2px edge allowance, both variants | Accepts | Accepts |

This replay is deterministic oracle evidence, not a claim of browser layout simulation. The real Chromium E2E separately proves committed layout through the existing mocked Gateway flow.

### Passing focused checks

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-transcript-focus.e2e.test.ts` — final patch: **1 passed, 0 skipped**.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json ui/src/e2e/chat-transcript-focus.e2e.test.ts` — passed.
- `node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.ui-pages-e2e.json --builders 1` — passed.
- Installed `oxfmt` check, `git diff --check`, UI i18n verification, and test-temp report — passed.
- Fresh pre-commit Codex autoreview of the final diff — no actionable P0 findings.

Local proof used macOS, Node 24.20.0 and real Chromium with the mocked Gateway. No operator Gateway or live credentials were used. Screenshots are not required for this test-only change because no UI behavior or rendering changed.

### Known local aggregate limits

- The four-file disclosure/resize/focus/streaming run passed **20/21**, including focus. The unchanged disclosure pointer-interruption case timed out at line 189 waiting for the scroll-to-bottom affordance. It failed again in isolation at line 210 waiting for recovered text; that isolated command never executes the changed focus file. This is recorded as a separate follow-up, not repaired or attributed to this change.
- `node scripts/check-changed.mjs -- ui/src/e2e/chat-transcript-focus.e2e.test.ts` passed its preceding guards/format checks, then the production/full-tree Knip scans reached their existing 600s timeout. Targeted lint/types/i18n/temp checks were completed separately; no timeout was raised and the aggregate is not described as green.

Exact-head hosted [CI run 33138867699](https://github.com/openclaw/openclaw/actions/runs/33138867699) completed successfully for `f12a55b479207593a0c509e447086a4bd7dbd50e`: 57 jobs passed and 16 were skipped, including all 14 browser E2E shards, the real-gateway E2E job, `checks-ui`, and `check-dependencies`. Required GitHub Actions-owned [`openclaw/ci-gate` check 98746229361](https://github.com/openclaw/openclaw/actions/runs/33138867699/job/98746229361) passed. No submitted reviews or review requests at the pre-land check. The completed ClawSweeper review and its proof/Rank-up requests are addressed below. Local aggregate limits above remain unchanged. No changelog edit: test-only follow-up.

### Response to the completed ClawSweeper review

The [completed review](https://github.com/openclaw/openclaw/pull/131470#issuecomment-5448133165) found no introduced code or security defect. Its two remaining proof concerns are addressed here:

- **Completed real-browser evidence / Rank-up move:** the exact focused Chromium command listed above completed on the frozen patch with this inspected terminal summary:

  ```text
  Test Files  1 passed (1)
       Tests  1 passed (1)
    Duration  63.63s
  ```

  ClawSweeper's probe reported only that completion text was not visible within 30 seconds; its captured output contains the Vitest startup line, not a Vitest assertion failure. That probe does not establish a test failure. The separately recorded 63.63s completed run and the successful exact-head browser CI provide the requested after-fix behavior evidence. No deadline was raised, no source changed, and no screenshot or raw log upload is needed for this test-only repair.
- **Previously pending CI / dependency inspection:** exact-head run 33138867699 is now completed success, including all 14 browser E2E shards, real-gateway E2E, `checks-ui`, `check-dependencies`, and required gate 98746229361. The lead had directly inspected the installed dependency contracts. The landing pass also directly verified installed `@tanstack/virtual-core` 3.17.8 offset observation/cache/range calculation (`src/index.ts` 177-234, 833-889, 1407-1470, 2038-2111) and `@tanstack/lit-virtual` 3.13.37 `onChange` scheduling (`src/index.ts` 29-31). The assertion stays at the DOM boundary; no dependency API usage or production code changes.

The Rank-up request for after-fix terminal/linked proof is satisfied by the completed Chromium summary and the linked exact-head CI. This does not turn the known local Knip/pointer aggregates green or explain the old zero-gap timeout. The review is fresh, the head is unchanged, and no additional re-review is requested merely to refresh the rating.
