### PR TITLE
fix(ui): crisp serif chat prose and correct Control UI font serving

### DIFF
--- a/src/gateway/control-ui-static.ts
+++ b/src/gateway/control-ui-static.ts
@@ -40,6 +40,7 @@ const CONTROL_UI_STATIC_ASSET_EXTENSIONS = new Set([
   ".txt",
   ".wasm",
   ".webmanifest",
+  ".woff2",
 ]);
 
 export function isControlUiStaticAssetExtension(extension: string): boolean {
@@ -91,6 +92,8 @@ function contentTypeForExtension(ext: string): string {
       return "application/wasm";
     case ".webmanifest":
       return "application/manifest+json; charset=utf-8";
+    case ".woff2":
+      return "font/woff2";
     default:
       return "application/octet-stream";
   }
@@ -225,7 +228,7 @@ function setControlUiEncodingHeaders(
 function setControlUiFileHeaders(
   res: ServerResponse,
   filePath: string,
-  options?: { immutable?: boolean; encoding?: ControlUiContentEncoding },
+  options?: { immutable?: boolean; encoding?: ControlUiContentEncoding; lastModifiedMs?: number },
 ) {
   const extension = path.extname(filePath).toLowerCase();
   res.setHeader("Content-Type", contentTypeForExtension(extension));
@@ -233,13 +236,51 @@ function setControlUiFileHeaders(
     "Cache-Control",
     options?.immutable ? CONTROL_UI_IMMUTABLE_CACHE_CONTROL : "no-cache",
   );
+  if (options?.lastModifiedMs !== undefined) {
+    res.setHeader("Last-Modified", new Date(options.lastModifiedMs).toUTCString());
+  }
   setControlUiEncodingHeaders(res, extension, options?.encoding ?? "identity");
+}
+
+/**
+ * `no-cache` responses without a validator force a full re-download on every
+ * revisit; fonts and theme CSS are the heavy unhashed assets that hit this.
+ * HTTP-dates carry whole-second precision, so compare on floored seconds.
+ */
+export function isControlUiFileUnmodified(req: IncomingMessage, lastModifiedMs: number): boolean {
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    return false;
+  }
+  const header = req.headers?.["if-modified-since"];
+  const since = typeof header === "string" ? Date.parse(header) : Number.NaN;
+  return Number.isFinite(since) && Math.floor(lastModifiedMs / 1000) * 1000 <= since;
+}
+
+export function respondControlUiNotModified(
+  res: ServerResponse,
+  options: { immutable?: boolean; lastModifiedMs: number },
+) {
+  res.statusCode = 304;
+  // A 304 repeats the caching headers of the 200 it stands in for so caches
+  // refresh their freshness metadata alongside the validator.
+  res.setHeader(
+    "Cache-Control",
+    options.immutable ? CONTROL_UI_IMMUTABLE_CACHE_CONTROL : "no-cache",
+  );
+  res.setHeader("Last-Modified", new Date(options.lastModifiedMs).toUTCString());
+  res.setHeader("Vary", "Accept-Encoding");
+  res.end();
 }
 
 export function respondHeadForControlUiFile(
   res: ServerResponse,
   filePath: string,
-  options?: { immutable?: boolean; encoding?: ControlUiContentEncoding; contentLength?: number },
+  options?: {
+    immutable?: boolean;
+    encoding?: ControlUiContentEncoding;
+    contentLength?: number;
+    lastModifiedMs?: number;
+  },
 ) {
   res.statusCode = 200;
   setControlUiFileHeaders(res, filePath, options);
@@ -278,7 +319,7 @@ export async function serveControlUiAsset(
   res: ServerResponse,
   filePath: string,
   body: Buffer,
-  options?: { immutable?: boolean; encoding?: ControlUiContentEncoding },
+  options?: { immutable?: boolean; encoding?: ControlUiContentEncoding; lastModifiedMs?: number },
 ) {
   setControlUiFileHeaders(res, filePath, options);
   res.end(body);

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -3588,6 +3588,35 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
+  it("clamps future filesystem mtimes so validators cannot postdate the response", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const fontsDir = path.join(tmp, "fonts");
+        await fs.mkdir(fontsDir, { recursive: true });
+        const fontPath = path.join(fontsDir, "lora-latin.woff2");
+        await fs.writeFile(fontPath, Buffer.from("wOF2-mock-bytes"));
+        const future = new Date(Date.now() + 60 * 60 * 1000);
+        await fs.utimes(fontPath, future, future);
+
+        const { res, setHeader } = await runControlUiRequest({
+          url: "/fonts/lora-latin.woff2",
+          method: "GET",
+          rootPath: tmp,
+          rootKind: "bundled",
+        });
+
+        expect(res.statusCode).toBe(200);
+        const lastModified = setHeader.mock.calls.find(([name]) => name === "Last-Modified")?.[1];
+        expect(typeof lastModified).toBe("string");
+        const emitted = Date.parse(lastModified as string);
+        // A future validator would 304 later replacements; it must never
+        // postdate the response, only trail it by clock/floor slack.
+        expect(emitted).toBeLessThanOrEqual(Date.now());
+        expect(emitted).toBeLessThan(future.getTime());
+      },
+    });
+  });
+
   it("returns 404 for missing font files instead of the SPA index", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -3522,6 +3522,86 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
+  it("serves theme fonts with the woff2 content type and a validator", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const fontsDir = path.join(tmp, "fonts");
+        await fs.mkdir(fontsDir, { recursive: true });
+        const fontPath = path.join(fontsDir, "lora-latin.woff2");
+        await fs.writeFile(fontPath, Buffer.from("wOF2-mock-bytes"));
+        const stat = await fs.stat(fontPath);
+
+        const { res, end, setHeader, handled } = await runControlUiRequest({
+          url: "/fonts/lora-latin.woff2",
+          method: "GET",
+          rootPath: tmp,
+          rootKind: "bundled",
+        });
+
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(200);
+        expect(setHeader).toHaveBeenCalledWith("Content-Type", "font/woff2");
+        expect(setHeader).toHaveBeenCalledWith("Cache-Control", "no-cache");
+        expect(setHeader).toHaveBeenCalledWith(
+          "Last-Modified",
+          new Date(stat.mtimeMs).toUTCString(),
+        );
+        expect(responseBody(end)).toBe("wOF2-mock-bytes");
+      },
+    });
+  });
+
+  it("answers conditional revalidation with 304 instead of a re-download", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const fontsDir = path.join(tmp, "fonts");
+        await fs.mkdir(fontsDir, { recursive: true });
+        const fontPath = path.join(fontsDir, "lora-latin.woff2");
+        await fs.writeFile(fontPath, Buffer.from("wOF2-mock-bytes"));
+        const stat = await fs.stat(fontPath);
+
+        const fresh = await runControlUiRequest({
+          url: "/fonts/lora-latin.woff2",
+          method: "GET",
+          rootPath: tmp,
+          rootKind: "bundled",
+          headers: { "if-modified-since": new Date(stat.mtimeMs).toUTCString() },
+        });
+        expect(fresh.res.statusCode).toBe(304);
+        expect(fresh.setHeader).toHaveBeenCalledWith("Cache-Control", "no-cache");
+        expect(fresh.setHeader).toHaveBeenCalledWith(
+          "Last-Modified",
+          new Date(stat.mtimeMs).toUTCString(),
+        );
+        expect(firstEndCallLength(fresh.end)).toBe(0);
+
+        const stale = await runControlUiRequest({
+          url: "/fonts/lora-latin.woff2",
+          method: "GET",
+          rootPath: tmp,
+          rootKind: "bundled",
+          headers: { "if-modified-since": new Date(stat.mtimeMs - 5_000).toUTCString() },
+        });
+        expect(stale.res.statusCode).toBe(200);
+        expect(responseBody(stale.end)).toBe("wOF2-mock-bytes");
+      },
+    });
+  });
+
+  it("returns 404 for missing font files instead of the SPA index", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const { res, end, handled } = await runControlUiRequest({
+          url: "/fonts/missing.woff2",
+          method: "GET",
+          rootPath: tmp,
+          rootKind: "bundled",
+        });
+        expectNotFoundResponse({ handled, res, end });
+      },
+    });
+  });
+
   it("returns 406 when no available asset representation is acceptable", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -1054,7 +1054,10 @@ export async function handleControlUiHttpRequest(
       );
       return true;
     }
-    const lastModifiedMs = safeFile.mtimeMs;
+    // Filesystem clocks may lead this host; validators cannot postdate message
+    // origination or a future date would 304 later replacements (mirrors
+    // resolveByteResponse in http-byte-range.ts).
+    const lastModifiedMs = Math.floor(Math.min(safeFile.mtimeMs, Date.now()) / 1_000) * 1_000;
     if (isControlUiFileUnmodified(req, lastModifiedMs)) {
       fs.closeSync(safeFile.fd);
       respondControlUiNotModified(res, { immutable: immutableAsset, lastModifiedMs });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -72,6 +72,7 @@ import {
 } from "./control-ui-routing.js";
 import { normalizeControlUiBasePath } from "./control-ui-shared.js";
 import {
+  isControlUiFileUnmodified,
   isControlUiPrecompressedAssetExtension,
   isControlUiStaticAssetExtension,
   readAndCloseControlUiFile,
@@ -79,6 +80,7 @@ import {
   resolveControlUiHtmlEncoding,
   resolveOpenedControlUiRepresentation,
   respondControlUiNotAcceptable,
+  respondControlUiNotModified,
   respondHeadForControlUiFile,
   sendControlUiHtmlBody,
   serveControlUiAsset,
@@ -709,7 +711,7 @@ function resolveSafeControlUiFile(
   rootReal: string,
   filePath: string,
   rejectHardlinks: boolean,
-): { path: string; fd: number; size: number } | null {
+): { path: string; fd: number; size: number; mtimeMs: number } | null {
   const opened = openRootFileSync({
     absolutePath: filePath,
     rootPath: rootReal,
@@ -729,7 +731,7 @@ function resolveSafeControlUiFile(
       fallback: () => null,
     });
   }
-  return { path: opened.path, fd: opened.fd, size: opened.stat.size };
+  return { path: opened.path, fd: opened.fd, size: opened.stat.size, mtimeMs: opened.stat.mtimeMs };
 }
 
 function isSafeRelativePath(relPath: string) {
@@ -1052,6 +1054,12 @@ export async function handleControlUiHttpRequest(
       );
       return true;
     }
+    const lastModifiedMs = safeFile.mtimeMs;
+    if (isControlUiFileUnmodified(req, lastModifiedMs)) {
+      fs.closeSync(safeFile.fd);
+      respondControlUiNotModified(res, { immutable: immutableAsset, lastModifiedMs });
+      return true;
+    }
     const representation = resolveOpenedControlUiRepresentation({
       req,
       sourceFile: safeFile,
@@ -1069,6 +1077,7 @@ export async function handleControlUiHttpRequest(
           immutable: immutableAsset,
           encoding: representation.encoding,
           contentLength: representation.bodyFile.size,
+          lastModifiedMs,
         });
         return true;
       } finally {
@@ -1079,6 +1088,7 @@ export async function handleControlUiHttpRequest(
     await serveControlUiAsset(res, representation.contentPath, body, {
       immutable: immutableAsset,
       encoding: representation.encoding,
+      lastModifiedMs,
     });
     return true;
   }

--- a/ui/src/app/bootstrap.ts
+++ b/ui/src/app/bootstrap.ts
@@ -71,7 +71,12 @@ import {
 } from "./startup-settings.ts";
 import { startThemeTransition } from "./theme-transition.ts";
 import { resolveTheme, syncThemePaletteStylesheet, type ThemeMode } from "./theme.ts";
-import { applyTypefaceOverrides, resolveTypefaces, syncTypefaceStylesheets } from "./typography.ts";
+import {
+  applyChatFontSmoothing,
+  applyTypefaceOverrides,
+  resolveTypefaces,
+  syncTypefaceStylesheets,
+} from "./typography.ts";
 import { createWebPushCapability } from "./web-push.ts";
 
 function applyThemePresentation(settings: ReturnType<typeof loadSettings>): void {
@@ -89,8 +94,10 @@ function applyThemePresentation(settings: ReturnType<typeof loadSettings>): void
   root.classList.toggle("wa-dark", root.dataset.themeMode === "dark");
   root.style.colorScheme = root.dataset.themeMode;
   root.style.setProperty("--control-ui-text-scale", `${(settings.textScale ?? 100) / 100}`);
-  syncTypefaceStylesheets(resolveTypefaces(settings.theme, settings.fontUi, settings.fontChat));
+  const typefaces = resolveTypefaces(settings.theme, settings.fontUi, settings.fontChat);
+  syncTypefaceStylesheets(typefaces);
   applyTypefaceOverrides(settings.fontUi, settings.fontChat);
+  applyChatFontSmoothing(typefaces.chat);
   syncCustomThemeStyleTag(settings.customTheme);
   applyControlUiAccent(settings.accent);
   syncControlUiSystemChrome();

--- a/ui/src/app/theme-fonts.test.ts
+++ b/ui/src/app/theme-fonts.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  applyChatFontSmoothing,
   applyTypefaceOverrides,
   loadTypefaceSpecimens,
   normalizeTypefaceOverride,
@@ -19,6 +20,7 @@ describe("typeface presentation", () => {
       link.remove();
     }
     applyTypefaceOverrides();
+    applyChatFontSmoothing("system");
   });
 
   it.each([
@@ -93,4 +95,16 @@ describe("typeface presentation", () => {
       expect(normalizeTypefaceOverride(value)).toBeUndefined();
     },
   );
+
+  it("opts chat prose into auto smoothing only while the resolved chat face is a serif", () => {
+    const style = document.documentElement.style;
+    for (const serif of ["lora", "fraunces"] as const) {
+      applyChatFontSmoothing(serif);
+      expect(style.getPropertyValue("--chat-font-smoothing")).toBe("auto");
+    }
+    for (const nonSerif of ["instrument-sans", "jetbrains-mono", "system"] as const) {
+      applyChatFontSmoothing(nonSerif);
+      expect(style.getPropertyValue("--chat-font-smoothing")).toBe("");
+    }
+  });
 });

--- a/ui/src/app/typography.ts
+++ b/ui/src/app/typography.ts
@@ -107,3 +107,15 @@ export function applyTypefaceOverrides(ui?: TypefaceId, chat?: TypefaceId): void
     }
   }
 }
+
+/* Serif hairlines at chat size need macOS stem darkening; the app-wide
+   `antialiased` smoothing (base.css body) thins them into gray smear, so serif
+   chat faces opt chat prose back into `auto` (.chat-text consumes the
+   variable). Sans and mono faces keep the inherited app default. */
+export function applyChatFontSmoothing(chat: TypefaceId): void {
+  if (TYPEFACE_METADATA[chat].kind === "serif") {
+    document.documentElement.style.setProperty("--chat-font-smoothing", "auto");
+  } else {
+    document.documentElement.style.removeProperty("--chat-font-smoothing");
+  }
+}

--- a/ui/src/e2e/chat-composer-capability-menu.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-capability-menu.e2e.test.ts
@@ -182,6 +182,22 @@ function webSearchItem(menu: import("playwright").Locator) {
   return menu.locator('wa-dropdown-item[value="toggle-web-search"]');
 }
 
+/* The shared title tooltip (components/tooltip-title.ts) lifts a hovered or
+   focused element's `title` into its overlay and blanks the attribute until
+   the pointer leaves, so dropdown rows race a raw getAttribute("title") read.
+   Read the lifted description when the attribute is blank. */
+function disabledReason(item: import("playwright").Locator) {
+  return item.evaluate((element) => {
+    const title = element.getAttribute("title");
+    if (title) {
+      return title;
+    }
+    const describedBy = element.getAttribute("aria-describedby");
+    const description = describedBy ? element.ownerDocument.getElementById(describedBy) : null;
+    return description?.textContent?.trim() ?? "";
+  });
+}
+
 suite.define(() => {
   it("renders the root stack, proxies attachments, patches sparse overrides, and clears the pill", async () => {
     await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
@@ -551,7 +567,7 @@ suite.define(() => {
       await gateway.resolveDeferred("tools.effective", effectiveToolsResponse());
       const listIssues = menu.locator('wa-dropdown-item[value="mcp-tool:0"]');
       await expect.poll(() => listIssues.isDisabled()).toBe(true);
-      await expect.poll(() => listIssues.getAttribute("title")).toBe("Loading…");
+      await expect.poll(() => disabledReason(listIssues)).toBe("Loading…");
       await listIssues.evaluate((item) => {
         item
           .closest("wa-dropdown")
@@ -592,12 +608,12 @@ suite.define(() => {
       const menu = composer.locator("wa-dropdown.agent-chat__capability-menu");
       const clear = menu.locator('wa-dropdown-item[value="clear-overrides"]');
       await expect.poll(() => clear.isDisabled()).toBe(true);
-      await expect.poll(() => clear.getAttribute("title")).toContain("operator.admin access");
+      await expect.poll(() => disabledReason(clear)).toContain("operator.admin access");
       await expect.poll(() => webSearchItem(menu).isDisabled()).toBe(true);
       await menu.getByRole("menuitem", { name: /^Skills/ }).click();
       const docs = menu.getByRole("menuitem", { name: /^Docs/ });
       await expect.poll(() => docs.isDisabled()).toBe(true);
-      await expect.poll(() => docs.getAttribute("title")).toContain("operator.admin access");
+      await expect.poll(() => disabledReason(docs)).toContain("operator.admin access");
       await menu.getByRole("menuitem", { name: "Back" }).click();
       await menu.getByRole("menuitem", { name: /^Connectors/ }).click();
       await expect
@@ -605,10 +621,10 @@ suite.define(() => {
         .toBe(true);
       const browse = menu.getByRole("menuitem", { name: "Browse connectors" });
       await expect.poll(() => browse.isDisabled()).toBe(true);
-      await expect.poll(() => browse.getAttribute("title")).toContain("Admin access");
+      await expect.poll(() => disabledReason(browse)).toContain("Admin access");
       const addServer = menu.getByRole("menuitem", { name: /Add MCP server/ });
       await expect.poll(() => addServer.isDisabled()).toBe(true);
-      await expect.poll(() => addServer.getAttribute("title")).toContain("Admin access");
+      await expect.poll(() => disabledReason(addServer)).toContain("Admin access");
     });
   });
 
@@ -634,7 +650,7 @@ suite.define(() => {
       const menu = composer.locator("wa-dropdown.agent-chat__capability-menu");
       const webSearch = webSearchItem(menu);
       await expect.poll(() => webSearch.isDisabled()).toBe(true);
-      await expect.poll(() => webSearch.getAttribute("title")).toBe("Loading…");
+      await expect.poll(() => disabledReason(webSearch)).toBe("Loading…");
       await webSearch.evaluate((item) => {
         item
           .closest("wa-dropdown")
@@ -650,7 +666,7 @@ suite.define(() => {
         }),
       );
       await expect.poll(() => webSearchItem(menu).isDisabled()).toBe(true);
-      await expect.poll(() => webSearchItem(menu).getAttribute("title")).toBe("Loading…");
+      await expect.poll(() => disabledReason(webSearchItem(menu))).toBe("Loading…");
       expect(await gateway.getRequests("sessions.patch")).toHaveLength(0);
 
       await gateway.resolveDeferred("config.get", configResponse({}, false));

--- a/ui/src/e2e/theme-typography.e2e.test.ts
+++ b/ui/src/e2e/theme-typography.e2e.test.ts
@@ -176,9 +176,12 @@ suite.define(() => {
           .fontFamily,
         code: getComputedStyle(panel.querySelector("code")!).fontFamily,
       }));
+    const chatSmoothing = () =>
+      page.evaluate(() => document.documentElement.style.getPropertyValue("--chat-font-smoothing"));
     const initial = await families();
     expect(initial.ui).toContain("DM Sans");
     expect(initial.chat).toContain("Fraunces");
+    expect(await chatSmoothing()).toBe("auto");
     if (captureUiProof) {
       await preview.scrollIntoViewIfNeeded();
     }
@@ -190,8 +193,13 @@ suite.define(() => {
     await clickPickerOption(ui, "geist");
     await expect.poll(async () => (await families()).ui).toContain("Geist");
     expect((await families()).chat).toContain("Fraunces");
+    await selectPickerOption(chat, "geist");
+    await expect.poll(async () => (await families()).chat).toContain("Geist");
+    // A sans chat override on a serif theme drops the serif smoothing opt-in.
+    await expect.poll(chatSmoothing).toBe("");
     await selectPickerOption(chat, "lora");
     await expect.poll(async () => (await families()).chat).toContain("Lora");
+    await expect.poll(chatSmoothing).toBe("auto");
     await expect
       .poll(() =>
         page.evaluate(() =>
@@ -221,21 +229,22 @@ suite.define(() => {
   });
 
   it.each([
-    ["claw", "Instrument Sans", "Instrument Sans", ["instrument-sans"]],
-    ["knot", "Geist", "Geist", ["geist"]],
-    ["dash", "DM Sans", "Fraunces", ["dm-sans", "fraunces"]],
-    ["absolutely", "Space Grotesk", "Lora", ["space-grotesk", "lora"]],
-    ["tide", "IBM Plex Sans", "IBM Plex Sans", ["ibm-plex-sans"]],
+    ["claw", "Instrument Sans", "Instrument Sans", ["instrument-sans"], "antialiased"],
+    ["knot", "Geist", "Geist", ["geist"], "antialiased"],
+    ["dash", "DM Sans", "Fraunces", ["dm-sans", "fraunces"], "auto"],
+    ["absolutely", "Space Grotesk", "Lora", ["space-grotesk", "lora"], "auto"],
+    ["tide", "IBM Plex Sans", "IBM Plex Sans", ["ibm-plex-sans"], "antialiased"],
     [
       "beacon",
       "Atkinson Hyperlegible Next",
       "Atkinson Hyperlegible Next",
       ["atkinson-hyperlegible"],
+      "antialiased",
     ],
-    ["phosphor", "JetBrains Mono", "JetBrains Mono", ["jetbrains-mono"]],
+    ["phosphor", "JetBrains Mono", "JetBrains Mono", ["jetbrains-mono"], "antialiased"],
   ] as const)(
     "paints %s chrome and chat prose in its own faces",
-    async (theme, body, chat, faces) => {
+    async (theme, body, chat, faces, chatSmoothing) => {
       const { themeRequests, gateway, page } = await openThemedChat(theme, "dark");
       await page.goto(`${suite.server.baseUrl}chat`);
       await renderAssistantProse(gateway, page);
@@ -248,6 +257,9 @@ suite.define(() => {
           (value.split(",")[0] ?? "").trim().replace(/^["']|["']$/gu, "");
         return {
           chatFontFamily: lastChat ? primary(getComputedStyle(lastChat).fontFamily) : null,
+          chatFontSmoothing: lastChat
+            ? getComputedStyle(lastChat).getPropertyValue("-webkit-font-smoothing")
+            : null,
           bodyFontFamily: primary(getComputedStyle(document.body).fontFamily),
           linkHrefs: [...document.querySelectorAll('link[id^="openclaw-typeface-"]')].map((link) =>
             link.getAttribute("href"),
@@ -259,6 +271,9 @@ suite.define(() => {
       expect(report.linkHrefs).toEqual(faces.map((face) => `/fonts/${face}.css`));
       expect(report.bodyFontFamily).toBe(body);
       expect(report.chatFontFamily).toBe(chat);
+      // Serif chat faces opt out of the app-wide `antialiased` thinning
+      // (applyChatFontSmoothing) so their hairlines stay crisp.
+      expect(report.chatFontSmoothing).toBe(chatSmoothing);
       expect(new Set(report.loaded)).toEqual(new Set([body, chat]));
       expect(themeRequests.every((entry) => entry.endsWith(" 200"))).toBe(true);
 

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -25,6 +25,13 @@
   color: var(--chat-text);
   overflow-wrap: anywhere;
   word-break: break-word;
+  /* Serif chat faces need macOS stem darkening to stay crisp at chat size:
+     the app-wide `antialiased` (base.css body) thins their hairlines into
+     gray smear. applyChatFontSmoothing (app/typography.ts) sets `auto` when
+     the resolved chat typeface is a serif; unset falls back to the inherited
+     app-wide smoothing. */
+  -webkit-font-smoothing: var(--chat-font-smoothing, inherit);
+  -moz-osx-font-smoothing: var(--chat-font-smoothing, inherit);
 }
 
 .chat-message-disclosure {


### PR DESCRIPTION
## What Problem This Solves

Serif chat prose (Lora on Absolutely, Fraunces on Dash) renders visibly soft/"blurry" compared to the sidebar, as reported against a live stable deployment. Two independent causes:

1. **Rendering:** the app-wide `-webkit-font-smoothing: antialiased` (base.css `body`) disables macOS stem darkening. Serif hairlines at 14px land under one device pixel and wash into gray smear — dramatic at 1× displays and in downscaled captures, visible as thin/gray text at 2×. Sans chrome survives it; serif chat prose does not.
2. **Serving:** the gateway static server never learned about fonts when per-theme typefaces landed: `.woff2` served as `application/octet-stream`, a *missing* font file fell through to the SPA index instead of 404 (HTML bytes as a font body), and fonts/theme CSS shipped `Cache-Control: no-cache` with **no validator** — every page load re-downloaded every font in full, guaranteeing a Georgia/Times fallback flash in chat prose per load.

## Why This Change Was Made

- `applyChatFontSmoothing` in `ui/src/app/typography.ts` opts chat prose back into `auto` smoothing whenever the **resolved chat typeface** is a serif — covering theme defaults *and* the new font-picker overrides from #131275 (a serif picked on a sans theme gets crisp rendering; a sans picked on a serif theme keeps the app default). Policy lives in one place, keyed on the typeface `kind` metadata; `.chat-text` consumes the `--chat-font-smoothing` property with an inherited fallback. An A/B matrix across smoothing modes, weights 400–500, sizes, and candidate faces (Literata, Source Serif 4, Georgia) at DPR 1 and 2 showed this is the only variant that restores crispness without changing metrics, glyphs, or layout.
- `src/gateway/control-ui-static.ts` gains the `font/woff2` MIME mapping, `.woff2` in the 404-not-SPA extension set, and `Last-Modified`/`If-Modified-Since` → 304 revalidation for file-backed responses, so unhashed statics (fonts, theme CSS) revalidate instead of re-downloading. Hashed `assets/` keep `immutable` caching unchanged.

## User Impact

Serif chat themes read crisp instead of washed-out, on both Retina and 1× displays, including with per-user font overrides. Cold loads stop flashing the Times/Georgia fallback on every navigation, and revisits stop re-downloading ~40 KB per font file. No layout, size, or glyph changes; sans/mono chat faces render exactly as before.

## Evidence

- Regression tests: 3 new gateway HTTP tests (woff2 MIME + validator, conditional 304, missing-font 404) — each verified failing on pre-fix code; 156/156 suite green. `theme-typography` e2e asserts computed chat smoothing per theme and across picker override flips (serif→auto, sans/mono→antialiased); 17/17 green. Unit coverage for `applyChatFontSmoothing` in `theme-fonts.test.ts`.
- Live gateway probe (isolated dev gateway on the built dist): `GET /fonts/lora-latin.woff2` → `200 font/woff2` + `Last-Modified`; conditional GET → `304`; `/fonts/missing.woff2` → `404`; theme CSS → `304`; hashed asset → `public, max-age=31536000, immutable` unchanged.
- Stable-server verification: deployed woff2 bytes are valid (`wOF2` magic); the pre-fix deployment serves `application/octet-stream` + `no-cache` with no validator, matching the diagnosis.
- Before/after screenshots below: real Control UI (mocked gateway, Absolutely-dark), same page, 1× rendering — only the stroke rendering changes. At 2× the change is a subtle ink enrichment.
- Production LOC +84/−7 (gateway conditional-revalidation capability + 12-line smoothing seam); tests +116/−7.

## Review follow-up: validator clamp

ClawSweeper's review flagged that `safeFile.mtimeMs` was emitted and compared unbounded: a future filesystem mtime would issue a future `Last-Modified`, and a later replacement whose mtime trails that cached date would 304 forever. Fixed by clamping the validator to response origination at the single capture site (mirroring `resolveByteResponse` in `http-byte-range.ts`), with a regression test that fails pre-clamp (future-mtime file must never emit a future validator).

## Flaky-test fix (opportunistic, blocking this landing)

`checks-ui-e2e (3/14)` failed twice on this PR's first head in `chat-composer-capability-menu.e2e.test.ts` ("blocks tool mutations…", `expected '' to be 'Loading…'`). Root cause is not this PR: the shared title tooltip introduced by #131335 (590c7d65bd0, 2026-08-27) lifts a hovered/focused element's `title` into its overlay and blanks the attribute until pointer-leave, so the test's raw `getAttribute("title")` polls race the lift on loaded runners (reproduced locally 2/4 under 4-way contention with diagnostics showing `title=""` plus `aria-describedby="openclaw-tooltip-…"`; app bundle proven identical across pass/fail bisect states). Fixed here with a `disabledReason` helper that reads the title or the lifted `aria-describedby` text — 4/4 green under the same contention. Other e2e files with title assertions are a named follow-up sweep.

![ui-before-dpr1](https://github.com/user-attachments/assets/7ae55521-ed9e-4a6f-a364-044056d709dd)

![ui-after-dpr1](https://github.com/user-attachments/assets/2dd8e85f-2c74-44e0-8f6c-a415611f2ea1)
