### PR TITLE
fix: expired Talk voice confirmations accumulate and slow every confirmation check

### DIFF
--- a/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
@@ -34,6 +34,7 @@ import {
   authorizeClientVoiceConfirmation,
   bindAuthorizedClientVoiceConfirmation,
   checkClientVoiceToolConfirmationPolicy,
+  deactivateClientVoiceConfirmationSession,
   noteClientVoiceConfirmationUtterance,
 } from "../talk/client-voice-confirmation.js";
 import { resetClientVoiceConfirmationStateForTest } from "../talk/client-voice-confirmation.test-support.js";
@@ -148,9 +149,8 @@ function installVoiceRunBinding(runId: string): void {
   vi.spyOn(clientVoiceSession, "isClientVoiceSessionConfirmable").mockReturnValue(true);
 }
 
-function approveVoiceToolParams(runId: string, toolParams: unknown): void {
+function authorizeVoiceToolParams(runId: string, toolParams: unknown, now = Date.now()) {
   const voiceSessionId = `voice-${runId}`;
-  const now = Date.now();
   const challenge = checkClientVoiceToolConfirmationPolicy({
     agentId: "main",
     voiceSessionId,
@@ -179,6 +179,11 @@ function approveVoiceToolParams(runId: string, toolParams: unknown): void {
     confirmationId,
     now: now + 2,
   });
+  return { confirmationId, grant, voiceSessionId };
+}
+
+function approveVoiceToolParams(runId: string, toolParams: unknown): void {
+  const { grant } = authorizeVoiceToolParams(runId, toolParams);
   bindAuthorizedClientVoiceConfirmation({ grant, runId });
 }
 
@@ -196,6 +201,7 @@ describe("before_tool_call hook integration", () => {
   afterEach(() => {
     setActivePluginRegistry(createEmptyPluginRegistry());
     resetClientVoiceConfirmationStateForTest();
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -2013,6 +2019,100 @@ describe("before_tool_call adapter and client tool integration", () => {
 
       expect(hook.didObserveAbort()).toBe(true);
       expect(execute).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(
+    (["wrapped", "adapter", "client-hosted"] as const).flatMap((pathKind) =>
+      (["supersession", "refusal", "close", "expiry"] as const).map(
+        (invalidator) => [pathKind, invalidator] as const,
+      ),
+    ),
+  )(
+    "blocks invalidated voice grants through the %s path after %s",
+    async (pathKind, invalidator) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(100);
+      const runId = `run-voice-invalidated-${pathKind}-${invalidator}`;
+      const toolParams = { action: "send", to: "target-a", message: "cancelled body" };
+      installVoiceRunBinding(runId);
+      const { grant, voiceSessionId } = authorizeVoiceToolParams(runId, toolParams, 100);
+      vi.setSystemTime(103);
+
+      if (invalidator === "supersession") {
+        checkClientVoiceToolConfirmationPolicy({
+          agentId: "main",
+          voiceSessionId,
+          runId,
+          toolName: "message",
+          toolParams: { ...toolParams, message: "successor body" },
+          isConfirmable: () => true,
+          now: 103,
+        });
+      } else if (invalidator === "refusal") {
+        noteClientVoiceConfirmationUtterance({
+          agentId: "main",
+          voiceSessionId,
+          text: "no",
+          timestamp: 103,
+        });
+      } else if (invalidator === "close") {
+        deactivateClientVoiceConfirmationSession("main", voiceSessionId);
+      } else {
+        vi.advanceTimersByTime(120_001);
+      }
+
+      expect(bindAuthorizedClientVoiceConfirmation({ grant, runId })).toBe(false);
+
+      const dispatch = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
+      const hookContext = { runId, agentId: "main", sessionKey: "agent:main:voice" };
+      const definition =
+        pathKind === "client-hosted"
+          ? expectDefined(
+              toClientToolDefinitions(
+                [
+                  {
+                    type: "function",
+                    function: {
+                      name: "message",
+                      description: "client-hosted message tool",
+                      parameters: { type: "object", properties: {} },
+                    },
+                  },
+                ],
+                dispatch,
+                hookContext,
+              )[0],
+              "client-hosted invalidated voice tool definition",
+            )
+          : expectDefined(
+              toToolDefinitions(
+                [
+                  pathKind === "wrapped"
+                    ? wrapToolWithBeforeToolCallHook(
+                        asAgentTool({ name: "message", execute: dispatch }),
+                        hookContext,
+                      )
+                    : asAgentTool({ name: "message", execute: dispatch }),
+                ],
+                hookContext,
+              )[0],
+              `${pathKind} invalidated voice tool definition`,
+            );
+
+      const result = await definition.execute(
+        `call-voice-invalidated-${pathKind}-${invalidator}`,
+        toolParams,
+        undefined,
+        undefined,
+        {} as ExtensionContext,
+      );
+
+      expect(result.details).toMatchObject({
+        status: "blocked",
+        deniedReason: "client-voice-confirmation",
+      });
+      expect(dispatch).not.toHaveBeenCalled();
     },
   );
 

--- a/src/gateway/server-methods/talk.test.ts
+++ b/src/gateway/server-methods/talk.test.ts
@@ -3,13 +3,18 @@
  */
 
 import { expectDefined } from "@openclaw/normalization-core";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { normalizeResolvedSecretInputString } from "../../config/types.secrets.js";
 import { setActiveDegradedSecretOwners } from "../../secrets/runtime-degraded-state.js";
 import { ensureProfileForEmail } from "../../state/user-profiles.js";
+import {
+  checkClientVoiceToolConfirmationPolicy,
+  noteClientVoiceConfirmationUtterance,
+} from "../../talk/client-voice-confirmation.js";
+import { resetClientVoiceConfirmationStateForTest } from "../../talk/client-voice-confirmation.test-support.js";
 import { REALTIME_VOICE_DESCRIBE_VIEW_TOOL_NAME } from "../../talk/describe-view-tool.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { buildTalkRealtimeConfig } from "./talk-shared.js";
@@ -334,6 +339,8 @@ beforeEach(() => {
     );
   });
 });
+
+afterEach(() => resetClientVoiceConfirmationStateForTest());
 
 function markTalkOwnerCold(ownerId: string): void {
   setActiveDegradedSecretOwners([
@@ -2729,6 +2736,67 @@ describe("talk.client.toolCall handler", () => {
 
     expectRespondOk(respond, { runId: "run-active" });
     finishRun?.();
+  });
+
+  it("keeps the started run registered when refusal invalidates a detached confirmation", async () => {
+    const now = Date.now();
+    const challenge = checkClientVoiceToolConfirmationPolicy({
+      agentId: "main",
+      voiceSessionId: "voice-test",
+      runId: "run-original",
+      toolName: "message",
+      toolParams: { action: "send", message: "cancelled action" },
+      now,
+    });
+    if (challenge.allowed) {
+      throw new Error("expected voice confirmation challenge");
+    }
+    const confirmationId = challenge.reason.match(/VOICE_CONFIRMATION_REQUIRED:([^\s]+)/)?.[1];
+    if (!confirmationId) {
+      throw new Error("missing voice confirmation id");
+    }
+    noteClientVoiceConfirmationUtterance({
+      agentId: "main",
+      voiceSessionId: "voice-test",
+      text: "yes",
+      timestamp: now + 1,
+    });
+    mocks.chatSend.mockImplementationOnce(
+      async ({
+        respond,
+      }: {
+        respond: (ok: boolean, result?: unknown, error?: unknown) => void;
+      }) => {
+        noteClientVoiceConfirmationUtterance({
+          agentId: "main",
+          voiceSessionId: "voice-test",
+          text: "no",
+          timestamp: now + 3,
+        });
+        respond(true, { runId: "run-stale-confirmation" }, undefined);
+      },
+    );
+    const respond = vi.fn();
+
+    await callTalkHandler("talk.client.toolCall", {
+      params: {
+        sessionKey: "main",
+        voiceSessionId: "voice-test",
+        callId: "call-stale-confirmation",
+        name: "openclaw_agent_consult",
+        args: { question: "Do it", confirmationId },
+      },
+      respond,
+      context: { getRuntimeConfig: () => ({}) as OpenClawConfig },
+    });
+
+    expect(mocks.registerClientVoiceConsultRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        voiceSessionId: "voice-test",
+        runId: "run-stale-confirmation",
+      }),
+    );
+    expectRespondOk(respond, { runId: "run-stale-confirmation" });
   });
 
   it("passes configured consult thinking and fast-mode overrides to chat.send", async () => {

--- a/src/gateway/talk-client-gateway-control.agent-consult.test.ts
+++ b/src/gateway/talk-client-gateway-control.agent-consult.test.ts
@@ -1,6 +1,13 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
+import {
+  authorizeClientVoiceConfirmation,
+  checkClientVoiceToolConfirmationPolicy,
+  deactivateClientVoiceConfirmationSession,
+  noteClientVoiceConfirmationUtterance,
+} from "../talk/client-voice-confirmation.js";
+import { resetClientVoiceConfirmationStateForTest } from "../talk/client-voice-confirmation.test-support.js";
 
 type ConsultParams = Parameters<
   typeof import("../talk/agent-consult-runtime.js").consultRealtimeVoiceAgent
@@ -91,6 +98,8 @@ describe("Talk client agent consult admission", () => {
       return { text: "done" };
     });
   });
+
+  afterEach(() => resetClientVoiceConfirmationStateForTest());
 
   it("runs through a Talk-owned gateway admission and closes it after success", async () => {
     await expect(createRunner().runPrompt({ prompt: "check" })).resolves.toEqual({ text: "done" });
@@ -191,5 +200,50 @@ describe("Talk client agent consult admission", () => {
     );
     expect(mocks.prepareAgentRunAdmission).not.toHaveBeenCalled();
     expect(mocks.runEmbeddedAgentCore).not.toHaveBeenCalled();
+  });
+
+  it("continues the admitted run when close invalidates confirmation before registration", async () => {
+    const now = Date.now();
+    const challenge = checkClientVoiceToolConfirmationPolicy({
+      agentId: "researcher",
+      voiceSessionId: "voice-session",
+      runId: "run-original",
+      toolName: "message",
+      toolParams: { action: "send", message: "cancelled action" },
+      now,
+    });
+    if (challenge.allowed) {
+      throw new Error("expected voice confirmation challenge");
+    }
+    const confirmationId = challenge.reason.match(/VOICE_CONFIRMATION_REQUIRED:([^\s]+)/)?.[1];
+    if (!confirmationId) {
+      throw new Error("missing voice confirmation id");
+    }
+    noteClientVoiceConfirmationUtterance({
+      agentId: "researcher",
+      voiceSessionId: "voice-session",
+      text: "yes",
+      timestamp: now + 1,
+    });
+    authorizeClientVoiceConfirmation({
+      agentId: "researcher",
+      voiceSessionId: "voice-session",
+      confirmationId,
+      now: now + 2,
+    });
+    mocks.consultRealtimeVoiceAgent.mockImplementationOnce(async (params: ConsultParams) => {
+      deactivateClientVoiceConfirmationSession("researcher", "voice-session");
+      params.onRunStarted?.({ runId: "run-talk", sessionId: "session-talk", timeoutMs: 1 });
+      await params.agentRuntime.runEmbeddedAgent(coreParams);
+      return { text: "done" };
+    });
+    const registerRun = vi.fn();
+
+    await expect(
+      createRunner(registerRun).runArgs({ question: "check", confirmationId }),
+    ).resolves.toEqual({ text: "done" });
+    expect(registerRun).toHaveBeenCalledWith({ runId: "run-talk" });
+    expect(mocks.runEmbeddedAgentCore).toHaveBeenCalledOnce();
+    expect(mocks.close).toHaveBeenCalledOnce();
   });
 });

--- a/src/gateway/talk-realtime-relay.test.ts
+++ b/src/gateway/talk-realtime-relay.test.ts
@@ -17,6 +17,13 @@ import type { OpenClawConfig } from "../config/types.js";
 import type { RealtimeVoiceProviderPlugin } from "../plugins/types.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  authorizeClientVoiceConfirmation,
+  bindAuthorizedClientVoiceConfirmation,
+  checkClientVoiceToolConfirmationPolicy,
+  noteClientVoiceConfirmationUtterance,
+} from "../talk/client-voice-confirmation.js";
+import { resetClientVoiceConfirmationStateForTest } from "../talk/client-voice-confirmation.test-support.js";
 import { clientVoiceSessionTesting } from "../talk/client-voice-session.test-support.js";
 import type {
   RealtimeVoiceBridge,
@@ -214,6 +221,7 @@ describe("talk realtime gateway relay", () => {
       [...drainingRelaySessions].map((session) => session.voiceSessionClose ?? Promise.resolve()),
     );
     vi.useRealTimers();
+    resetClientVoiceConfirmationStateForTest();
     embeddedRunTesting.resetActiveEmbeddedRuns();
   });
 
@@ -225,6 +233,67 @@ describe("talk realtime gateway relay", () => {
       createBridge: () => makeRelayTransport(),
     };
   }
+
+  it("settles relay-owned registrations after refusal invalidates a detached grant", async () => {
+    const provider = createIdleRelayProvider();
+    const fixture = createAbortableRelayRunFixture(provider, { register: false });
+    const voiceSessionId = fixture.session.relaySessionId;
+    const now = Date.now();
+    const challenge = checkClientVoiceToolConfirmationPolicy({
+      agentId: "main",
+      voiceSessionId,
+      runId: "run-1",
+      toolName: "message",
+      toolParams: { action: "send", message: "cancelled action" },
+      now,
+    });
+    if (challenge.allowed) {
+      throw new Error("expected voice confirmation challenge");
+    }
+    const confirmationId = challenge.reason.match(/VOICE_CONFIRMATION_REQUIRED:([^\s]+)/)?.[1];
+    if (!confirmationId) {
+      throw new Error("missing voice confirmation id");
+    }
+    noteClientVoiceConfirmationUtterance({
+      agentId: "main",
+      voiceSessionId,
+      text: "yes",
+      timestamp: now + 1,
+    });
+    const grant = authorizeClientVoiceConfirmation({
+      agentId: "main",
+      voiceSessionId,
+      confirmationId,
+      now: now + 2,
+    });
+    noteClientVoiceConfirmationUtterance({
+      agentId: "main",
+      voiceSessionId,
+      text: "no",
+      timestamp: now + 3,
+    });
+
+    registerTalkRealtimeRelayAgentRun({
+      relaySessionId: fixture.session.relaySessionId,
+      connId: "conn-1",
+      sessionKey: "main",
+      runId: "run-1",
+      callId: "call-1",
+    });
+    expect(bindAuthorizedClientVoiceConfirmation({ grant, runId: "run-1" })).toBe(false);
+    const relay = relaySessions.get(fixture.session.relaySessionId);
+    expect(relay?.activeAgentRuns.size).toBe(1);
+    expect(relay?.activeAgentToolCalls.size).toBe(1);
+
+    await submitTalkRealtimeRelayToolResult({
+      relaySessionId: fixture.session.relaySessionId,
+      connId: "conn-1",
+      callId: "call-1",
+      result: { blocked: true },
+    });
+    expect(relay?.activeAgentRuns.size).toBe(0);
+    expect(relay?.activeAgentToolCalls.size).toBe(0);
+  });
 
   it("closes only realtime relays owned by the disconnected connection", async () => {
     const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);

--- a/src/talk/client-voice-confirmation-lifecycle.test.ts
+++ b/src/talk/client-voice-confirmation-lifecycle.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  emitTrustedDiagnosticEvent,
+  waitForDiagnosticEventsDrained,
+} from "../infra/diagnostic-events.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import {
+  authorizeClientVoiceConfirmation,
+  bindAuthorizedClientVoiceConfirmation,
+  checkClientVoiceToolConfirmationPolicy,
+  noteClientVoiceConfirmationUtterance,
+} from "./client-voice-confirmation.js";
+import {
+  resetClientVoiceConfirmationStateForTest,
+  snapshotClientVoiceConfirmationStateForTest,
+} from "./client-voice-confirmation.test-support.js";
+import {
+  closeClientVoiceSession,
+  createOrResumeClientVoiceSession,
+  registerClientVoiceConsultRun,
+  resolveClientVoiceRunBinding,
+} from "./client-voice-session.js";
+import { clientVoiceSessionTesting } from "./client-voice-session.test-support.js";
+
+const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+let tempDir: string;
+
+function registerRun(
+  agentId: string,
+  voiceSessionId: string,
+  sessionKey: string,
+  runId: string,
+): void {
+  registerClientVoiceConsultRun({
+    agentId,
+    sessionKey,
+    voiceSessionId,
+    runId,
+  });
+}
+
+function bindGrant(agentId: string, voiceSessionId: string, runId: string, message: string): void {
+  const requestedAt = Date.now();
+  const blocked = checkClientVoiceToolConfirmationPolicy({
+    agentId,
+    voiceSessionId,
+    runId,
+    toolName: "message",
+    toolParams: { action: "send", message },
+    now: requestedAt,
+  });
+  if (blocked.allowed) {
+    throw new Error("expected a pending voice confirmation");
+  }
+  const confirmationId = blocked.reason.match(/VOICE_CONFIRMATION_REQUIRED:([^\s]+)/)?.[1];
+  if (!confirmationId) {
+    throw new Error("expected a voice confirmation id");
+  }
+  noteClientVoiceConfirmationUtterance({
+    agentId,
+    voiceSessionId,
+    text: "yes",
+    timestamp: requestedAt + 1,
+  });
+  const grant = authorizeClientVoiceConfirmation({
+    agentId,
+    voiceSessionId,
+    confirmationId,
+    now: requestedAt + 2,
+  });
+  bindAuthorizedClientVoiceConfirmation({ grant, runId });
+}
+
+async function completeRun(runId: string): Promise<void> {
+  emitTrustedDiagnosticEvent({
+    type: "run.completed",
+    runId,
+    durationMs: 5,
+    outcome: "completed",
+  });
+  await waitForDiagnosticEventsDrained();
+}
+
+describe("client voice confirmation lifecycle", () => {
+  beforeEach(() => {
+    tempDir = tempDirs.make("openclaw-voice-confirmation-");
+    setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
+  });
+
+  afterEach(() => {
+    clientVoiceSessionTesting.reset();
+    resetClientVoiceConfirmationStateForTest();
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    envSnapshot.restore();
+  });
+
+  it("keeps a live run's grant after close and releases it on completion", async () => {
+    const sessionKey = "agent:main:active";
+    const voiceSessionId = createOrResumeClientVoiceSession({
+      agentId: "main",
+      sessionKey,
+      origin: "client",
+    });
+    registerRun("main", voiceSessionId, sessionKey, "run-active");
+    bindGrant("main", voiceSessionId, "run-active", "confirmed action");
+
+    await closeClientVoiceSession({
+      agentId: "main",
+      sessionKey,
+      voiceSessionId,
+      config: {},
+    });
+
+    expect(resolveClientVoiceRunBinding("run-active")).toMatchObject({ voiceSessionId });
+    expect(snapshotClientVoiceConfirmationStateForTest().approvedGrants).toBe(1);
+
+    await completeRun("run-active");
+    expect(resolveClientVoiceRunBinding("run-active")).toBeUndefined();
+    expect(snapshotClientVoiceConfirmationStateForTest().approvedGrants).toBe(0);
+  });
+
+  it("releases only the prior scope's grant when a run binding is replaced", async () => {
+    const firstAgentId = "agent-a";
+    const firstMessage = "first action";
+    const firstSessionKey = "agent:agent-a:first";
+    const firstVoiceSessionId = createOrResumeClientVoiceSession({
+      agentId: firstAgentId,
+      sessionKey: firstSessionKey,
+      origin: "client",
+      voiceSessionId: "voice-first",
+    });
+    registerRun(firstAgentId, firstVoiceSessionId, firstSessionKey, "run-shared");
+    bindGrant(firstAgentId, firstVoiceSessionId, "run-shared", firstMessage);
+    await closeClientVoiceSession({
+      agentId: firstAgentId,
+      sessionKey: firstSessionKey,
+      voiceSessionId: firstVoiceSessionId,
+      config: {},
+    });
+
+    const replacementAgentId = "agent-b";
+    const unrelatedSessionKey = "agent:agent-b:unrelated";
+    const unrelatedVoiceSessionId = createOrResumeClientVoiceSession({
+      agentId: replacementAgentId,
+      sessionKey: unrelatedSessionKey,
+      origin: "client",
+      voiceSessionId: "voice-unrelated",
+    });
+    registerRun(replacementAgentId, unrelatedVoiceSessionId, unrelatedSessionKey, "run-unrelated");
+    bindGrant(replacementAgentId, unrelatedVoiceSessionId, "run-unrelated", "unrelated action");
+    expect(snapshotClientVoiceConfirmationStateForTest().approvedGrants).toBe(2);
+
+    const replacementSessionKey = "agent:agent-b:replacement";
+    const replacementVoiceSessionId = createOrResumeClientVoiceSession({
+      agentId: replacementAgentId,
+      sessionKey: replacementSessionKey,
+      origin: "client",
+      voiceSessionId: "voice-replacement",
+    });
+    registerRun(replacementAgentId, replacementVoiceSessionId, replacementSessionKey, "run-shared");
+
+    expect(resolveClientVoiceRunBinding("run-shared")).toMatchObject({
+      voiceSessionId: replacementVoiceSessionId,
+    });
+    expect(resolveClientVoiceRunBinding("run-unrelated")).toMatchObject({
+      voiceSessionId: unrelatedVoiceSessionId,
+    });
+    expect(snapshotClientVoiceConfirmationStateForTest().approvedGrants).toBe(1);
+    expect(
+      checkClientVoiceToolConfirmationPolicy({
+        agentId: firstAgentId,
+        voiceSessionId: firstVoiceSessionId,
+        runId: "run-shared",
+        toolName: "message",
+        toolParams: { action: "send", message: firstMessage },
+      }).allowed,
+    ).toBe(false);
+
+    await completeRun("run-unrelated");
+    expect(snapshotClientVoiceConfirmationStateForTest().approvedGrants).toBe(0);
+  });
+});

--- a/src/talk/client-voice-confirmation-lifecycle.test.ts
+++ b/src/talk/client-voice-confirmation-lifecycle.test.ts
@@ -44,6 +44,11 @@ function registerRun(
 }
 
 function bindGrant(agentId: string, voiceSessionId: string, runId: string, message: string): void {
+  const grant = authorizeGrant(agentId, voiceSessionId, runId, message);
+  expect(bindAuthorizedClientVoiceConfirmation({ grant, runId })).toBe(true);
+}
+
+function authorizeGrant(agentId: string, voiceSessionId: string, runId: string, message: string) {
   const requestedAt = Date.now();
   const blocked = checkClientVoiceToolConfirmationPolicy({
     agentId,
@@ -72,7 +77,7 @@ function bindGrant(agentId: string, voiceSessionId: string, runId: string, messa
     confirmationId,
     now: requestedAt + 2,
   });
-  bindAuthorizedClientVoiceConfirmation({ grant, runId });
+  return grant;
 }
 
 async function completeRun(runId: string): Promise<void> {
@@ -121,6 +126,37 @@ describe("client voice confirmation lifecycle", () => {
 
     await completeRun("run-active");
     expect(resolveClientVoiceRunBinding("run-active")).toBeUndefined();
+    expect(snapshotClientVoiceConfirmationStateForTest().approvedGrants).toBe(0);
+  });
+
+  it("keeps completion ownership after a close invalidates a detached grant", async () => {
+    const sessionKey = "agent:main:stale-bind";
+    const voiceSessionId = createOrResumeClientVoiceSession({
+      agentId: "main",
+      sessionKey,
+      origin: "client",
+    });
+    const grant = authorizeGrant("main", voiceSessionId, "run-stale-bind", "cancelled action");
+
+    await closeClientVoiceSession({
+      agentId: "main",
+      sessionKey,
+      voiceSessionId,
+      config: {},
+    });
+    registerRun("main", voiceSessionId, sessionKey, "run-stale-bind");
+
+    expect(
+      bindAuthorizedClientVoiceConfirmation({
+        grant,
+        runId: "run-stale-bind",
+      }),
+    ).toBe(false);
+    expect(resolveClientVoiceRunBinding("run-stale-bind")).toMatchObject({ voiceSessionId });
+    expect(snapshotClientVoiceConfirmationStateForTest().approvedGrants).toBe(0);
+
+    await completeRun("run-stale-bind");
+    expect(resolveClientVoiceRunBinding("run-stale-bind")).toBeUndefined();
     expect(snapshotClientVoiceConfirmationStateForTest().approvedGrants).toBe(0);
   });
 

--- a/src/talk/client-voice-confirmation.test-support.ts
+++ b/src/talk/client-voice-confirmation.test-support.ts
@@ -2,6 +2,16 @@ import "./client-voice-confirmation.js";
 
 type ClientVoiceConfirmationTestApi = {
   resetClientVoiceConfirmationStateForTest(): void;
+  snapshotClientVoiceConfirmationStateForTest(): ClientVoiceConfirmationStateSnapshot;
+};
+
+export type ClientVoiceConfirmationStateSnapshot = {
+  scopeOwners: number;
+  pendingChallenges: number;
+  recentUtterances: number;
+  approvedRuns: number;
+  approvedGrants: number;
+  expiryOwners: number;
 };
 
 function getTestApi(): ClientVoiceConfirmationTestApi {
@@ -12,4 +22,8 @@ function getTestApi(): ClientVoiceConfirmationTestApi {
 
 export function resetClientVoiceConfirmationStateForTest(): void {
   getTestApi().resetClientVoiceConfirmationStateForTest();
+}
+
+export function snapshotClientVoiceConfirmationStateForTest(): ClientVoiceConfirmationStateSnapshot {
+  return getTestApi().snapshotClientVoiceConfirmationStateForTest();
 }

--- a/src/talk/client-voice-confirmation.test.ts
+++ b/src/talk/client-voice-confirmation.test.ts
@@ -178,11 +178,143 @@ describe("client voice confirmation", () => {
       authorizeClientVoiceConfirmation({ voiceSessionId: "voice-1", confirmationId, now: 103 })
         .fingerprint,
     ).toBe(first.fingerprint);
-    bindAuthorizedClientVoiceConfirmation({ grant: first, runId: "run-approved" });
+    expect(
+      bindAuthorizedClientVoiceConfirmation({ grant: first, runId: "run-approved", now: 103 }),
+    ).toBe(true);
+    expect(
+      bindAuthorizedClientVoiceConfirmation({ grant: first, runId: "run-duplicate", now: 104 }),
+    ).toBe(false);
     // After binding the run, the challenge is consumed and cannot re-authorize.
     expect(() =>
       authorizeClientVoiceConfirmation({ voiceSessionId: "voice-1", confirmationId, now: 104 }),
     ).toThrow("missing, expired, or belongs to another action");
+  });
+
+  it.each(["supersession", "refusal", "close", "expiry"] as const)(
+    "rejects a held grant after %s without mutating confirmation state",
+    (invalidator) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(100);
+      const confirmationId = block({
+        voiceSessionId: "voice-1",
+        toolParams: { action: "send", message: "original" },
+        now: 100,
+      });
+      noteClientVoiceConfirmationUtterance({
+        voiceSessionId: "voice-1",
+        text: "yes",
+        timestamp: 101,
+      });
+      const grant = authorizeClientVoiceConfirmation({
+        voiceSessionId: "voice-1",
+        confirmationId,
+        now: 102,
+      });
+      vi.setSystemTime(103);
+
+      let successorId: string | undefined;
+      if (invalidator === "supersession") {
+        successorId = block({
+          voiceSessionId: "voice-1",
+          toolParams: { action: "send", message: "successor" },
+          now: 103,
+        });
+      } else if (invalidator === "refusal") {
+        noteClientVoiceConfirmationUtterance({
+          voiceSessionId: "voice-1",
+          text: "no",
+          timestamp: 103,
+        });
+      } else if (invalidator === "close") {
+        deactivateClientVoiceConfirmationSession("main", "voice-1");
+      } else {
+        vi.setSystemTime(120_101);
+      }
+      const beforeBind = snapshotClientVoiceConfirmationStateForTest();
+
+      expect(
+        bindAuthorizedClientVoiceConfirmation({
+          grant,
+          runId: `run-${invalidator}`,
+        }),
+      ).toBe(false);
+      expect(snapshotClientVoiceConfirmationStateForTest()).toEqual(beforeBind);
+
+      if (successorId) {
+        expect(beforeBind).toMatchObject({
+          scopeOwners: 1,
+          pendingChallenges: 1,
+          recentUtterances: 0,
+          approvedRuns: 0,
+          approvedGrants: 0,
+          expiryOwners: 1,
+        });
+        noteClientVoiceConfirmationUtterance({
+          voiceSessionId: "voice-1",
+          text: "yes",
+          timestamp: 104,
+        });
+        expect(
+          authorizeClientVoiceConfirmation({
+            voiceSessionId: "voice-1",
+            confirmationId: successorId,
+            now: 105,
+          }).confirmationId,
+        ).toBe(successorId);
+      }
+    },
+  );
+
+  it.each([
+    ["agent", { agentId: "other-agent" }],
+    ["session", { voiceSessionId: "other-session" }],
+    ["confirmation id", { confirmationId: "other-confirmation" }],
+    ["fingerprint", { fingerprint: "other-fingerprint" }],
+    ["expiry", { expiresAt: 999 }],
+  ] as const)("rejects a grant with a mismatched %s without mutating state", (_label, patch) => {
+    const confirmationId = block({ voiceSessionId: "voice-1", now: 100 });
+    noteClientVoiceConfirmationUtterance({
+      voiceSessionId: "voice-1",
+      text: "yes",
+      timestamp: 101,
+    });
+    const grant = authorizeClientVoiceConfirmation({
+      voiceSessionId: "voice-1",
+      confirmationId,
+      now: 102,
+    });
+    const beforeBind = snapshotClientVoiceConfirmationStateForTest();
+
+    expect(
+      bindAuthorizedClientVoiceConfirmation({
+        grant: { ...grant, ...patch },
+        runId: "run-mismatched",
+        now: 103,
+      }),
+    ).toBe(false);
+    expect(snapshotClientVoiceConfirmationStateForTest()).toEqual(beforeBind);
+  });
+
+  it("binds at the inclusive TTL boundary", () => {
+    const confirmationId = block({ voiceSessionId: "voice-1", now: 100 });
+    noteClientVoiceConfirmationUtterance({
+      voiceSessionId: "voice-1",
+      text: "yes",
+      timestamp: 101,
+    });
+    const grant = authorizeClientVoiceConfirmation({
+      voiceSessionId: "voice-1",
+      confirmationId,
+      now: 102,
+    });
+
+    expect(
+      bindAuthorizedClientVoiceConfirmation({
+        grant,
+        runId: "run-expiry-boundary",
+        now: grant.expiresAt,
+      }),
+    ).toBe(true);
   });
 
   it("binds approval to the exact tool fingerprint", () => {
@@ -201,7 +333,7 @@ describe("client voice confirmation", () => {
       confirmationId,
       now: 102,
     });
-    bindAuthorizedClientVoiceConfirmation({ grant, runId: "run-approved" });
+    bindAuthorizedClientVoiceConfirmation({ grant, runId: "run-approved", now: 102 });
 
     expect(
       checkClientVoiceToolConfirmationPolicy({
@@ -290,7 +422,7 @@ describe("client voice confirmation", () => {
       confirmationId,
       now: 102,
     });
-    bindAuthorizedClientVoiceConfirmation({ grant, runId: "run-approved" });
+    bindAuthorizedClientVoiceConfirmation({ grant, runId: "run-approved", now: 102 });
 
     expect(
       checkClientVoiceToolConfirmationPolicy({
@@ -362,7 +494,7 @@ describe("client voice confirmation", () => {
       confirmationId: second,
       now: 102,
     });
-    bindAuthorizedClientVoiceConfirmation({ grant, runId: "run-2" });
+    bindAuthorizedClientVoiceConfirmation({ grant, runId: "run-2", now: 102 });
     expect(() =>
       authorizeClientVoiceConfirmation({
         voiceSessionId: "voice-1",
@@ -390,7 +522,7 @@ describe("client voice confirmation", () => {
       confirmationId,
       now: 102,
     });
-    bindAuthorizedClientVoiceConfirmation({ grant, runId: "run-approved" });
+    bindAuthorizedClientVoiceConfirmation({ grant, runId: "run-approved", now: 102 });
 
     expect(
       consumeClientVoiceToolConfirmationPolicy({
@@ -495,7 +627,7 @@ describe("client voice confirmation", () => {
       confirmationId,
       now: 102,
     });
-    bindAuthorizedClientVoiceConfirmation({ grant, runId: "run-live" });
+    bindAuthorizedClientVoiceConfirmation({ grant, runId: "run-live", now: 102 });
 
     deactivateClientVoiceConfirmationSession("main", "voice-1", ["run-live"]);
     expect(
@@ -508,12 +640,11 @@ describe("client voice confirmation", () => {
       }),
     ).toEqual({ allowed: true });
 
-    bindAuthorizedClientVoiceConfirmation({ grant, runId: "run-done" });
-    releaseClientVoiceConfirmationRun("main", "voice-1", "run-done");
+    releaseClientVoiceConfirmationRun("main", "voice-1", "run-live");
     expect(
       consumeClientVoiceToolConfirmationPolicy({
         voiceSessionId: "voice-1",
-        runId: "run-done",
+        runId: "run-live",
         toolName: "message",
         toolParams,
         now: 104,

--- a/src/talk/client-voice-confirmation.test.ts
+++ b/src/talk/client-voice-confirmation.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   authorizeClientVoiceConfirmation as authorizeClientVoiceConfirmationForTest,
   bindAuthorizedClientVoiceConfirmation,
@@ -8,7 +8,10 @@ import {
   noteClientVoiceConfirmationUtterance as noteClientVoiceConfirmationUtteranceForTest,
   releaseClientVoiceConfirmationRun,
 } from "./client-voice-confirmation.js";
-import { resetClientVoiceConfirmationStateForTest } from "./client-voice-confirmation.test-support.js";
+import {
+  resetClientVoiceConfirmationStateForTest,
+  snapshotClientVoiceConfirmationStateForTest,
+} from "./client-voice-confirmation.test-support.js";
 
 function authorizeClientVoiceConfirmation(
   params: Omit<Parameters<typeof authorizeClientVoiceConfirmationForTest>[0], "agentId">,
@@ -64,7 +67,10 @@ function block(params: {
 }
 
 describe("client voice confirmation", () => {
-  afterEach(() => resetClientVoiceConfirmationStateForTest());
+  afterEach(() => {
+    resetClientVoiceConfirmationStateForTest();
+    vi.useRealTimers();
+  });
 
   it("does not pause a concurrent non-voice run sharing the session key", () => {
     block({ voiceSessionId: "voice-1", runId: "voice-run" });
@@ -217,14 +223,31 @@ describe("client voice confirmation", () => {
     ).toEqual({ allowed: true });
   });
 
-  it("rejects expired confirmations", () => {
+  it("prunes an abandoned confirmation when its TTL expires", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
     const confirmationId = block({ voiceSessionId: "voice-1", now: 1_000 });
     noteClientVoiceConfirmationUtterance({
       voiceSessionId: "voice-1",
       text: "confirm",
       timestamp: 1_001,
     });
+    expect(snapshotClientVoiceConfirmationStateForTest()).toMatchObject({
+      scopeOwners: 1,
+      pendingChallenges: 1,
+      recentUtterances: 1,
+      expiryOwners: 1,
+    });
 
+    vi.advanceTimersByTime(120_001);
+    expect(snapshotClientVoiceConfirmationStateForTest()).toEqual({
+      scopeOwners: 0,
+      pendingChallenges: 0,
+      recentUtterances: 0,
+      approvedRuns: 0,
+      approvedGrants: 0,
+      expiryOwners: 0,
+    });
     expect(() =>
       authorizeClientVoiceConfirmation({
         voiceSessionId: "voice-1",
@@ -346,7 +369,7 @@ describe("client voice confirmation", () => {
         confirmationId: first,
         now: 103,
       }),
-    ).toThrow("explicit spoken confirmation");
+    ).toThrow("missing, expired");
   });
 
   it("binds an approved fingerprint to its follow-up run", () => {
@@ -401,6 +424,10 @@ describe("client voice confirmation", () => {
       runId: "run-1",
       toolParams: { action: "send", message: "newer" },
       now: 110,
+    });
+    expect(snapshotClientVoiceConfirmationStateForTest()).toMatchObject({
+      scopeOwners: 1,
+      pendingChallenges: 1,
     });
     noteClientVoiceConfirmationUtterance({
       voiceSessionId: "voice-1",
@@ -495,7 +522,15 @@ describe("client voice confirmation", () => {
   });
 
   it("isolates same-named voice sessions across agents", () => {
-    const blocked = checkClientVoiceToolConfirmationPolicyForTest({
+    const blockedA = checkClientVoiceToolConfirmationPolicyForTest({
+      agentId: "agent-a",
+      voiceSessionId: "shared-id",
+      runId: "run-a",
+      toolName: "message",
+      toolParams: { action: "send", message: "A" },
+      now: 100,
+    });
+    const blockedB = checkClientVoiceToolConfirmationPolicyForTest({
       agentId: "agent-b",
       voiceSessionId: "shared-id",
       runId: "run-b",
@@ -503,24 +538,39 @@ describe("client voice confirmation", () => {
       toolParams: { action: "send", message: "B" },
       now: 100,
     });
-    expect(blocked.allowed).toBe(false);
-    if (blocked.allowed) {
+    expect(blockedA.allowed).toBe(false);
+    expect(blockedB.allowed).toBe(false);
+    if (blockedA.allowed || blockedB.allowed) {
       throw new Error("expected confirmation request");
     }
+    expect(snapshotClientVoiceConfirmationStateForTest()).toMatchObject({
+      scopeOwners: 2,
+      pendingChallenges: 2,
+    });
     noteClientVoiceConfirmationUtteranceForTest({
       agentId: "agent-a",
+      voiceSessionId: "shared-id",
+      text: "no",
+      timestamp: 101,
+    });
+    expect(snapshotClientVoiceConfirmationStateForTest()).toMatchObject({
+      scopeOwners: 1,
+      pendingChallenges: 1,
+    });
+    noteClientVoiceConfirmationUtteranceForTest({
+      agentId: "agent-b",
       voiceSessionId: "shared-id",
       text: "yes",
       timestamp: 101,
     });
 
-    expect(() =>
+    expect(
       authorizeClientVoiceConfirmationForTest({
         agentId: "agent-b",
         voiceSessionId: "shared-id",
-        confirmationId: confirmationIdFrom(blocked.reason),
+        confirmationId: confirmationIdFrom(blockedB.reason),
         now: 102,
-      }),
-    ).toThrow("explicit spoken confirmation");
+      }).confirmationId,
+    ).toBe(confirmationIdFrom(blockedB.reason));
   });
 });

--- a/src/talk/client-voice-confirmation.ts
+++ b/src/talk/client-voice-confirmation.ts
@@ -7,14 +7,9 @@ const CONFIRMATION_TTL_MS = 2 * 60_000;
 
 type PendingVoiceConfirmation = {
   confirmationId: string;
-  agentId: string;
-  voiceSessionId: string;
   runId?: string;
   fingerprint: string;
-  toolName: string;
   createdAt: number;
-  /** Monotonic tiebreaker: same-millisecond challenges must still have one newest. */
-  seq: number;
   expiresAt: number;
 };
 
@@ -31,13 +26,106 @@ export type ClientVoiceConfirmationGrant = {
   expiresAt: number;
 };
 
-const pendingConfirmations = new Map<string, PendingVoiceConfirmation>();
-let confirmationSeq = 0;
-const approvedFingerprints = new Map<string, Map<string, Map<string, number>>>();
-const recentUserUtterances = new Map<string, RecentVoiceUserUtterance>();
+type ConfirmationScopeState = {
+  pending?: PendingVoiceConfirmation;
+  recentUtterance?: RecentVoiceUserUtterance;
+  approvedByRun: Map<string, Map<string, number>>;
+  pendingExpiryTimer?: ReturnType<typeof setTimeout>;
+};
+
+const confirmationScopes = new Map<string, ConfirmationScopeState>();
 
 function confirmationScopeKey(agentId: string, voiceSessionId: string): string {
   return `${agentId}\0${voiceSessionId}`;
+}
+
+function clearPendingExpiryTimer(state: ConfirmationScopeState): void {
+  if (!state.pendingExpiryTimer) {
+    return;
+  }
+  clearTimeout(state.pendingExpiryTimer);
+  delete state.pendingExpiryTimer;
+}
+
+function clearPendingConfirmation(state: ConfirmationScopeState): void {
+  clearPendingExpiryTimer(state);
+  delete state.pending;
+  delete state.recentUtterance;
+}
+
+function cleanupConfirmationScope(scopeKey: string, state: ConfirmationScopeState): void {
+  if (state.pending || state.recentUtterance || state.approvedByRun.size > 0) {
+    return;
+  }
+  if (confirmationScopes.get(scopeKey) === state) {
+    confirmationScopes.delete(scopeKey);
+  }
+}
+
+function pruneExpiredPendingConfirmation(
+  scopeKey: string,
+  state: ConfirmationScopeState,
+  now: number,
+): void {
+  if (state.pending && state.pending.expiresAt < now) {
+    clearPendingConfirmation(state);
+  }
+  cleanupConfirmationScope(scopeKey, state);
+}
+
+function schedulePendingConfirmationExpiry(
+  scopeKey: string,
+  state: ConfirmationScopeState,
+  now: number,
+): void {
+  const pending = state.pending;
+  if (!pending) {
+    clearPendingExpiryTimer(state);
+    cleanupConfirmationScope(scopeKey, state);
+    return;
+  }
+  clearPendingExpiryTimer(state);
+  // The scope owns one current challenge and one timer. Supersession cancels
+  // both together, while expiry remains inclusive at expiresAt.
+  state.pendingExpiryTimer = setTimeout(
+    () => {
+      delete state.pendingExpiryTimer;
+      if (confirmationScopes.get(scopeKey) !== state || state.pending !== pending) {
+        return;
+      }
+      const current = Date.now();
+      if (pending.expiresAt < current) {
+        clearPendingConfirmation(state);
+        cleanupConfirmationScope(scopeKey, state);
+      } else {
+        schedulePendingConfirmationExpiry(scopeKey, state, current);
+      }
+    },
+    Math.max(1, pending.expiresAt - now + 1),
+  );
+  state.pendingExpiryTimer.unref?.();
+}
+
+function getPrunedConfirmationScope(
+  scopeKey: string,
+  now: number,
+): ConfirmationScopeState | undefined {
+  const state = confirmationScopes.get(scopeKey);
+  if (!state) {
+    return undefined;
+  }
+  pruneExpiredPendingConfirmation(scopeKey, state, now);
+  return confirmationScopes.get(scopeKey);
+}
+
+function getOrCreateConfirmationScope(scopeKey: string): ConfirmationScopeState {
+  const existing = confirmationScopes.get(scopeKey);
+  if (existing) {
+    return existing;
+  }
+  const state: ConfirmationScopeState = { approvedByRun: new Map() };
+  confirmationScopes.set(scopeKey, state);
+  return state;
 }
 
 function stableToolFingerprint(toolName: string, params: unknown): string {
@@ -92,7 +180,7 @@ function requiresHighImpactVoiceConfirmation(toolName: string, params: unknown):
 }
 
 function resolveApprovedFingerprint(
-  voiceSessionId: string,
+  scopeKey: string,
   runId: string | undefined,
   fingerprint: string,
   now: number,
@@ -101,15 +189,27 @@ function resolveApprovedFingerprint(
   if (!runId) {
     return false;
   }
-  const approvedByRun = approvedFingerprints.get(voiceSessionId);
-  const approved = approvedByRun?.get(runId);
+  const state = confirmationScopes.get(scopeKey);
+  const approved = state?.approvedByRun.get(runId);
   const expiresAt = approved?.get(fingerprint);
   if (!expiresAt || expiresAt < now) {
     approved?.delete(fingerprint);
+    if (approved?.size === 0) {
+      state?.approvedByRun.delete(runId);
+    }
+    if (state) {
+      cleanupConfirmationScope(scopeKey, state);
+    }
     return false;
   }
   if (consume) {
     approved?.delete(fingerprint);
+    if (approved?.size === 0) {
+      state?.approvedByRun.delete(runId);
+    }
+    if (state) {
+      cleanupConfirmationScope(scopeKey, state);
+    }
   }
   return true;
 }
@@ -121,23 +221,22 @@ export function noteClientVoiceConfirmationUtterance(params: {
   text: string;
   timestamp: number;
 }): void {
-  recentUserUtterances.set(confirmationScopeKey(params.agentId, params.voiceSessionId), {
-    text: params.text,
-    timestamp: params.timestamp,
-  });
+  const scopeKey = confirmationScopeKey(params.agentId, params.voiceSessionId);
+  const state = getPrunedConfirmationScope(scopeKey, params.timestamp);
+  if (!state?.pending) {
+    return;
+  }
   // A spoken refusal kills the outstanding challenge: a later unrelated "yes"
   // must not resurrect an action the user already declined.
-  if (REFUSAL_PATTERN.test(normalizeUtterance(params.text))) {
-    for (const [confirmationId, confirmation] of pendingConfirmations) {
-      if (
-        confirmation.agentId === params.agentId &&
-        confirmation.voiceSessionId === params.voiceSessionId &&
-        confirmation.createdAt < params.timestamp
-      ) {
-        pendingConfirmations.delete(confirmationId);
-      }
-    }
+  if (
+    REFUSAL_PATTERN.test(normalizeUtterance(params.text)) &&
+    state.pending.createdAt < params.timestamp
+  ) {
+    clearPendingConfirmation(state);
+    cleanupConfirmationScope(scopeKey, state);
+    return;
   }
+  state.recentUtterance = { text: params.text, timestamp: params.timestamp };
 }
 
 type ClientVoiceToolConfirmationPolicyParams = {
@@ -177,28 +276,26 @@ function resolveClientVoiceToolConfirmationPolicy(
   if (resolveApprovedFingerprint(scopeKey, params.runId, fingerprint, now, consume)) {
     return { allowed: true };
   }
-  const existing = [...pendingConfirmations.values()].find(
-    (entry) =>
-      entry.voiceSessionId === params.voiceSessionId &&
-      entry.agentId === params.agentId &&
-      entry.runId === params.runId &&
-      entry.fingerprint === fingerprint &&
-      entry.expiresAt >= now,
-  );
+  const state = getPrunedConfirmationScope(scopeKey, now) ?? getOrCreateConfirmationScope(scopeKey);
+  const pending = state.pending;
+  const existing =
+    pending && pending.runId === params.runId && pending.fingerprint === fingerprint
+      ? pending
+      : undefined;
+  if (!existing) {
+    clearPendingConfirmation(state);
+  }
   const confirmation =
     existing ??
     ({
       confirmationId: randomUUID(),
-      agentId: params.agentId,
-      voiceSessionId: params.voiceSessionId,
       ...(params.runId ? { runId: params.runId } : {}),
       fingerprint,
-      toolName: params.toolName,
       createdAt: now,
-      seq: ++confirmationSeq,
       expiresAt: now + CONFIRMATION_TTL_MS,
     } satisfies PendingVoiceConfirmation);
-  pendingConfirmations.set(confirmation.confirmationId, confirmation);
+  state.pending = confirmation;
+  schedulePendingConfirmationExpiry(scopeKey, state, now);
   return {
     allowed: false,
     reason:
@@ -255,29 +352,19 @@ export function authorizeClientVoiceConfirmation(params: {
   confirmationId: string;
   now?: number;
 }): ClientVoiceConfirmationGrant {
-  const confirmation = pendingConfirmations.get(params.confirmationId);
   const now = params.now ?? Date.now();
-  if (
-    !confirmation ||
-    confirmation.agentId !== params.agentId ||
-    confirmation.voiceSessionId !== params.voiceSessionId ||
-    confirmation.expiresAt < now
-  ) {
+  const scopeKey = confirmationScopeKey(params.agentId, params.voiceSessionId);
+  const state = getPrunedConfirmationScope(scopeKey, now);
+  const confirmation = state?.pending;
+  if (!confirmation) {
     throw new Error("voice confirmation is missing, expired, or belongs to another action");
   }
   // A bare "yes" can only answer the question the model asked last; authorizing an
   // older challenge would let the model swap in a different pending action.
-  for (const entry of pendingConfirmations.values()) {
-    if (
-      entry.agentId === params.agentId &&
-      entry.voiceSessionId === params.voiceSessionId &&
-      entry.seq > confirmation.seq
-    ) {
-      throw new Error("a newer confirmation request supersedes this one; ask again");
-    }
+  if (confirmation.confirmationId !== params.confirmationId) {
+    throw new Error("a newer confirmation request supersedes this one; ask again");
   }
-  const scopeKey = confirmationScopeKey(params.agentId, params.voiceSessionId);
-  const affirmation = recentUserUtterances.get(scopeKey);
+  const affirmation = state.recentUtterance;
   if (
     !affirmation ||
     affirmation.timestamp <= confirmation.createdAt ||
@@ -303,14 +390,16 @@ export function bindAuthorizedClientVoiceConfirmation(params: {
   runId: string;
 }): void {
   const scopeKey = confirmationScopeKey(params.grant.agentId, params.grant.voiceSessionId);
-  const approvedByRun = approvedFingerprints.get(scopeKey) ?? new Map();
-  const approved = approvedByRun.get(params.runId) ?? new Map<string, number>();
+  const state = getOrCreateConfirmationScope(scopeKey);
+  const approved = state.approvedByRun.get(params.runId) ?? new Map<string, number>();
   approved.set(params.grant.fingerprint, params.grant.expiresAt);
-  approvedByRun.set(params.runId, approved);
-  approvedFingerprints.set(scopeKey, approvedByRun);
+  state.approvedByRun.set(params.runId, approved);
   // Consume now that the run exists: one spoken affirmation authorizes one action.
-  pendingConfirmations.delete(params.grant.confirmationId);
-  recentUserUtterances.delete(scopeKey);
+  if (state.pending?.confirmationId === params.grant.confirmationId) {
+    clearPendingConfirmation(state);
+  }
+  delete state.recentUtterance;
+  cleanupConfirmationScope(scopeKey, state);
 }
 
 /**
@@ -324,24 +413,18 @@ export function deactivateClientVoiceConfirmationSession(
   liveRunIds: readonly string[] = [],
 ): void {
   const scopeKey = confirmationScopeKey(agentId, voiceSessionId);
-  recentUserUtterances.delete(scopeKey);
-  const approvedByRun = approvedFingerprints.get(scopeKey);
-  if (approvedByRun) {
-    const live = new Set(liveRunIds);
-    for (const runId of approvedByRun.keys()) {
-      if (!live.has(runId)) {
-        approvedByRun.delete(runId);
-      }
-    }
-    if (approvedByRun.size === 0) {
-      approvedFingerprints.delete(scopeKey);
+  const state = confirmationScopes.get(scopeKey);
+  if (!state) {
+    return;
+  }
+  clearPendingConfirmation(state);
+  const live = new Set(liveRunIds);
+  for (const runId of state.approvedByRun.keys()) {
+    if (!live.has(runId)) {
+      state.approvedByRun.delete(runId);
     }
   }
-  for (const [confirmationId, confirmation] of pendingConfirmations) {
-    if (confirmation.agentId === agentId && confirmation.voiceSessionId === voiceSessionId) {
-      pendingConfirmations.delete(confirmationId);
-    }
-  }
+  cleanupConfirmationScope(scopeKey, state);
 }
 
 /** Drop a completed run's surviving grants once its lifecycle ends. */
@@ -351,25 +434,48 @@ export function releaseClientVoiceConfirmationRun(
   runId: string,
 ): void {
   const scopeKey = confirmationScopeKey(agentId, voiceSessionId);
-  const approvedByRun = approvedFingerprints.get(scopeKey);
-  if (!approvedByRun) {
+  const state = confirmationScopes.get(scopeKey);
+  if (!state) {
     return;
   }
-  approvedByRun.delete(runId);
-  if (approvedByRun.size === 0) {
-    approvedFingerprints.delete(scopeKey);
-  }
+  state.approvedByRun.delete(runId);
+  cleanupConfirmationScope(scopeKey, state);
 }
 
 /** Test-only reset for process-global state. */
 function resetClientVoiceConfirmationStateForTest(): void {
-  pendingConfirmations.clear();
-  approvedFingerprints.clear();
-  recentUserUtterances.clear();
+  for (const state of confirmationScopes.values()) {
+    clearPendingExpiryTimer(state);
+  }
+  confirmationScopes.clear();
+}
+
+function snapshotClientVoiceConfirmationStateForTest() {
+  const snapshot = {
+    scopeOwners: confirmationScopes.size,
+    pendingChallenges: 0,
+    recentUtterances: 0,
+    approvedRuns: 0,
+    approvedGrants: 0,
+    expiryOwners: 0,
+  };
+  for (const state of confirmationScopes.values()) {
+    snapshot.pendingChallenges += state.pending ? 1 : 0;
+    snapshot.recentUtterances += state.recentUtterance ? 1 : 0;
+    snapshot.approvedRuns += state.approvedByRun.size;
+    for (const approved of state.approvedByRun.values()) {
+      snapshot.approvedGrants += approved.size;
+    }
+    snapshot.expiryOwners += state.pendingExpiryTimer ? 1 : 0;
+  }
+  return snapshot;
 }
 
 if (process.env.VITEST || process.env.NODE_ENV === "test") {
   (globalThis as Record<PropertyKey, unknown>)[
     Symbol.for("openclaw.clientVoiceConfirmationTestApi")
-  ] = { resetClientVoiceConfirmationStateForTest };
+  ] = {
+    resetClientVoiceConfirmationStateForTest,
+    snapshotClientVoiceConfirmationStateForTest,
+  };
 }

--- a/src/talk/client-voice-confirmation.ts
+++ b/src/talk/client-voice-confirmation.ts
@@ -384,22 +384,37 @@ export function authorizeClientVoiceConfirmation(params: {
   };
 }
 
-/** Bind a validated spoken grant to the one follow-up run and consume the challenge. */
+/**
+ * Bind a validated spoken grant to the one follow-up run and consume the
+ * challenge. Invalidated detached grants return false without disrupting the
+ * admitted run; final tool policy then blocks because no approval was created.
+ */
 export function bindAuthorizedClientVoiceConfirmation(params: {
   grant: ClientVoiceConfirmationGrant;
   runId: string;
-}): void {
+  now?: number;
+}): boolean {
+  const now = params.now ?? Date.now();
   const scopeKey = confirmationScopeKey(params.grant.agentId, params.grant.voiceSessionId);
-  const state = getOrCreateConfirmationScope(scopeKey);
+  const state = confirmationScopes.get(scopeKey);
+  const pending = state?.pending;
+  if (
+    !state ||
+    !pending ||
+    pending.expiresAt < now ||
+    pending.confirmationId !== params.grant.confirmationId ||
+    pending.fingerprint !== params.grant.fingerprint ||
+    pending.expiresAt !== params.grant.expiresAt
+  ) {
+    return false;
+  }
   const approved = state.approvedByRun.get(params.runId) ?? new Map<string, number>();
-  approved.set(params.grant.fingerprint, params.grant.expiresAt);
+  approved.set(pending.fingerprint, pending.expiresAt);
   state.approvedByRun.set(params.runId, approved);
   // Consume now that the run exists: one spoken affirmation authorizes one action.
-  if (state.pending?.confirmationId === params.grant.confirmationId) {
-    clearPendingConfirmation(state);
-  }
-  delete state.recentUtterance;
+  clearPendingConfirmation(state);
   cleanupConfirmationScope(scopeKey, state);
+  return true;
 }
 
 /**

--- a/src/talk/client-voice-session.ts
+++ b/src/talk/client-voice-session.ts
@@ -296,6 +296,20 @@ export function registerClientVoiceConsultRun(params: {
     },
     { agentId: params.agentId },
   );
+  const previousBinding = voiceSessionByRunId.get(params.runId);
+  if (
+    previousBinding &&
+    (previousBinding.agentId !== params.agentId ||
+      previousBinding.voiceSessionId !== params.voiceSessionId)
+  ) {
+    // A run ID has one authoritative voice scope. Replacing it must retire the
+    // prior scope's post-close grant or completion can no longer find that owner.
+    releaseClientVoiceConfirmationRun(
+      previousBinding.agentId,
+      previousBinding.voiceSessionId,
+      params.runId,
+    );
+  }
   voiceSessionByRunId.set(params.runId, {
     agentId: params.agentId,
     voiceSessionId: params.voiceSessionId,


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

Fixes #129216

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes two related Talk confirmation lifecycle failures:

1. Long-lived processes retained expired and superseded challenges, causing confirmation checks to scan increasingly large process-global state.
2. A grant validated before awaited consult startup could still bind after a refusal, session close, superseding challenge, or expiry, allowing the cancelled high-impact action to retain approval.

## Why This Change Was Made

Pending confirmations belong to one agent/voice-session scope with one current challenge and expiry timer. Expiry and supersession prune owner-local state without global scans.

Bind now compares the detached grant with the exact current pending confirmation before any mutation: agent/session scope, confirmation ID, fingerprint, and expiry must match, and the inclusive TTL must still be live. Invalidated grants return `false`, create no approval, and leave confirmation state unchanged. Returning `false` preserves existing Talk run registration and completion ownership; final wrapped, adapter, and client-hosted policy blocks the action because no approval exists.

There are no protocol, configuration, persistence, confirmation-policy, Gateway, relay, or voice-session production changes.

## User Impact

Talk confirmation memory and latency remain bounded over the process lifetime. A refusal, close, superseding request, or expiry during consult startup now reliably cancels the detached approval, while retries before the first valid bind and already-bound live-run behavior remain unchanged.

## Evidence

### Linked artifacts

- [Correction commit `dda823f2108`](https://github.com/openclaw/openclaw/commit/dda823f2108b17f2f4691d6491300991875ce088)
- [Exact-SHA Blacksmith Testbox run `33143901889`](https://github.com/openclaw/openclaw/actions/runs/33143901889)
- [Issue reproduction and original measurements](https://github.com/openclaw/openclaw/issues/129216)

Testbox identity:

- Provider: `blacksmith-testbox`
- Lease: `tbx_01m13cbdmvst2b0sj883jpkzwf`
- Slug: `quick-lobster-f252`
- Testbox head: `dda823f2108b17f2f4691d6491300991875ce088`
- Exact commit match: yes
- Test command: exit 0 in 7m47.430s
- Pinned changed gate: exit 0 in 11m43.977s
- Lease cleanup: stopped

<details>
<summary>Real Testbox terminal results</summary>

```text
$ pnpm test src/talk/client-voice-confirmation.test.ts src/talk/client-voice-confirmation-lifecycle.test.ts
TESTBOX_HEAD=dda823f2108b17f2f4691d6491300991875ce088

Test Files  2 passed (2)
Tests       36 passed (36)
[test] passed 1 Vitest shard in 13.17s

$ pnpm test src/agents/agent-tools.before-tool-call.integration.e2e.test.ts -- -t "blocks invalidated voice grants"

Test Files  1 passed (1)
Tests       12 passed | 62 skipped (74)
[test] passed 1 Vitest shard in 331.90s

$ pnpm test src/gateway/talk-client-gateway-control.agent-consult.test.ts src/gateway/server-methods/talk.test.ts src/gateway/talk-realtime-relay.test.ts -- -t "continues the admitted run|keeps the started run registered|settles relay-owned registrations"

Test Files  3 passed (3)
Tests       3 passed | 171 skipped (174)
[test] passed 1 Vitest shard in 44.24s

$ pnpm check:changed --base 3fbfa2602c2ac246d9200d6ef34d5b20cb3b38c3 --head HEAD

TESTBOX_PINNED_GATE_HEAD=dda823f2108b17f2f4691d6491300991875ce088
[check:changed] lanes=core, coreTests
Import cycle check: 0 runtime value cycle(s).
blacksmith run summary ... exit=0
```

</details>

### Before/after retention and timing

Runtime: Node `v26.6.0` on `darwin-arm64`; TTL 120,000 ms; five samples per point, reporting medians.

| Seeded challenges | Base seed ms | Fixed seed ms | Base 1,000-check ms | Fixed 1,000-check ms |
| ---: | ---: | ---: | ---: | ---: |
| 0 | 0.00 | 0.00 | 13.78 | 7.87 |
| 1,000 | 9.00 | 5.36 | 16.63 | 5.40 |
| 2,000 | 25.10 | 9.64 | 22.05 | 4.84 |
| 4,000 | 75.42 | 19.54 | 34.38 | 4.81 |
| 8,000 | 246.95 | 38.99 | 58.09 | 4.77 |

At 8,000 seeded challenges, the base retained 8,000 pending challenge objects; the bounded implementation retained one current challenge.

### Stale-grant reproduction

Before the correction, all four authorize → invalidate → bind cases failed their expected rejection:

- supersession
- refusal
- session close
- TTL expiry

The same pre-fix behavior also failed 12 final-consumer cases across wrapped, adapter, and client-hosted execution because stale bind was accepted.

### Test changes

Added:

- Four state-preserving invalidation cases: supersession, refusal, close, expiry.
- Five exact-grant mismatch cases: agent, session, confirmation ID, fingerprint, expiry.
- Inclusive TTL-boundary bind case.
- Twelve final-consumer cases across wrapped, adapter, and client-hosted paths.
- Real completion settlement after close invalidates a detached grant.
- Browser, `talk.client`, and relay-owned handoff settlement cases.

Modified:

- Retry test now proves first bind succeeds and second bind of the consumed grant is rejected.
- Live-run test no longer rebinds an already-consumed grant; it releases the actual bound run.
- Integration setup shares one authorization helper and keeps fake time active through final consumption.

Deleted:

- No test declaration.
- Removed the old test behavior that accepted a second stale bind.

### Verification

- Exact-SHA Blacksmith Testbox:
  - 36 focused confirmation/lifecycle tests passed.
  - 12 invalidated-grant final-consumer tests passed.
  - 3 browser/client/relay handoff tests passed.
  - Pinned `pnpm check:changed` passed for the seven-file correction.
- Local exact-head proof matched the Testbox selection.
- Advisory autoreview: clean.
- Independent bounded delegate review: clean.
- Workloop source review found no remaining source blocker; ignored-artifact staging failed in three initiating snapshots, so the authorized direct-review fallback was used for proof verification and the orchestration lock was released.

Correction delta: production +23 / -8, net +15; tests +472 / -14, net +458.
