### PR TITLE
fix(onboard): probe remote gateways with saved TLS pins and validate trusted proxies

### DIFF
--- a/docs/cli/configure.md
+++ b/docs/cli/configure.md
@@ -38,9 +38,9 @@ Selecting `gateway`, `daemon`, or `health` (or running the full wizard with no `
 
 For **Trusted Proxy** auth, enter comma-separated IPv4 or IPv6 addresses or CIDR ranges, such as `10.0.0.1, ::1, 10.0.0.0/24`. The wizard rejects malformed addresses and empty entries before saving; surrounding whitespace is ignored.
 
-For **Trusted Proxy** auth, entering a loopback proxy address shows a security warning and asks for explicit consent before setting `gateway.auth.trustedProxy.allowLoopback`. Declining leaves it unset and warns that loopback proxy requests will be rejected at runtime. See [Trusted proxy auth](/gateway/trusted-proxy-auth#configure-with-the-wizard) for the trust requirements.
+For **Trusted Proxy** auth, entering an address or CIDR that matches a loopback source shows a security warning and asks for explicit consent before setting `gateway.auth.trustedProxy.allowLoopback`. Declining leaves it unset and warns that loopback proxy requests will be rejected at runtime. See [Trusted proxy auth](/gateway/trusted-proxy-auth#configure-with-the-wizard) for the trust requirements.
 
-Reconfiguring trusted-proxy mode defaults the loopback prompt to the existing opt-in and preserves `deviceAutoApprove` unchanged. An explicit refusal revokes loopback consent; without a loopback address, the existing setting is retained.
+Reconfiguring trusted-proxy mode defaults the loopback prompt to the existing opt-in and preserves `deviceAutoApprove` unchanged. An explicit refusal revokes loopback consent; without a matching loopback source, the existing setting is retained.
 
 ## Model section
 

--- a/docs/cli/configure.md
+++ b/docs/cli/configure.md
@@ -36,6 +36,8 @@ Selecting `gateway`, `daemon`, or `health` (or running the full wizard with no `
 
 ## Gateway section
 
+For **Trusted Proxy** auth, enter comma-separated IPv4 or IPv6 addresses or CIDR ranges, such as `10.0.0.1, ::1, 10.0.0.0/24`. The wizard rejects malformed addresses and empty entries before saving; surrounding whitespace is ignored.
+
 For **Trusted Proxy** auth, entering a loopback proxy address shows a security warning and asks for explicit consent before setting `gateway.auth.trustedProxy.allowLoopback`. Declining leaves it unset and warns that loopback proxy requests will be rejected at runtime. See [Trusted proxy auth](/gateway/trusted-proxy-auth#configure-with-the-wizard) for the trust requirements.
 
 Reconfiguring trusted-proxy mode defaults the loopback prompt to the existing opt-in and preserves `deviceAutoApprove` unchanged. An explicit refusal revokes loopback consent; without a loopback address, the existing setting is retained.

--- a/docs/gateway/remote.md
+++ b/docs/gateway/remote.md
@@ -83,6 +83,9 @@ Accepting a discovered direct connection selects direct transport. Choosing a
 discovered SSH tunnel clears saved transport settings for the suggested loopback
 URL, which may now reach a different host; start the displayed tunnel manually.
 
+The onboarding and configure readiness checks use the saved TLS fingerprint for
+that same endpoint. Probing a different URL does not inherit its certificate pin.
+
 Host-key verification is strict by default (`gateway.remote.sshHostKeyPolicy: "strict"`). Set it to `"openssh"` to delegate to your effective OpenSSH config instead; review your user and system SSH settings before enabling it.
 
 For a Gateway already reachable on a trusted LAN or Tailnet, use direct mode:

--- a/docs/gateway/trusted-proxy-auth.md
+++ b/docs/gateway/trusted-proxy-auth.md
@@ -144,9 +144,9 @@ Any local process that can connect to the Gateway can impersonate a loopback rev
 
 ### Configure with the wizard
 
-Run `openclaw configure --section gateway` and select **Trusted Proxy**. Entering a loopback proxy address (including a CIDR with a loopback base address) shows the security warning above and asks whether to allow loopback authentication. The default is **No** for a new configuration. **Yes** saves `gateway.auth.trustedProxy.allowLoopback: true`; **No** leaves it unset and warns that loopback proxy requests will fail with `trusted_proxy_loopback_source`, with a link back to this page.
+Run `openclaw configure --section gateway` and select **Trusted Proxy**. Entering an address or CIDR that matches a loopback source under the Gateway's runtime rules shows the security warning above and asks whether to allow loopback authentication. This includes ranges containing loopback, even when their base address is not loopback. The default is **No** for a new configuration. **Yes** saves `gateway.auth.trustedProxy.allowLoopback: true`; **No** leaves it unset and warns that loopback proxy requests will fail with `trusted_proxy_loopback_source`, with a link back to this page.
 
-When reconfiguring an existing trusted-proxy setup, the prompt defaults to the existing `allowLoopback` opt-in. Choosing **No** revokes it. If no entered proxy address is loopback, the wizard leaves the existing value unchanged. Same-mode reconfiguration also preserves `deviceAutoApprove` verbatim; device enrollment policy is not changed by this prompt. Switching from another auth mode does not restore dormant trusted-proxy opt-ins.
+When reconfiguring an existing trusted-proxy setup, the prompt defaults to the existing `allowLoopback` opt-in. Choosing **No** revokes it. If no entered address or range matches a loopback source, the wizard leaves the existing value unchanged. Same-mode reconfiguration also preserves `deviceAutoApprove` verbatim; device enrollment policy is not changed by this prompt. Switching from another auth mode does not restore dormant trusted-proxy opt-ins.
 
 ## Per-identity scope grants
 

--- a/packages/net-policy/src/ip.test.ts
+++ b/packages/net-policy/src/ip.test.ts
@@ -31,13 +31,28 @@ describe("shared ip helpers", () => {
     expect(isLegacyIpv4Literal("example.com")).toBe(false);
   });
 
-  it("matches both IPv4 and IPv6 CIDRs", () => {
-    expect(isIpInCidr("10.42.0.59", "10.42.0.0/24")).toBe(true);
-    expect(isIpInCidr("10.43.0.59", "10.42.0.0/24")).toBe(false);
-    expect(isIpInCidr("2001:db8::1234", "2001:db8::/32")).toBe(true);
-    expect(isIpInCidr("2001:db9::1234", "2001:db8::/32")).toBe(false);
-    expect(isIpInCidr("::ffff:127.0.0.1", "127.0.0.1")).toBe(true);
-    expect(isIpInCidr("127.0.0.1", "::ffff:127.0.0.2")).toBe(false);
+  it.each([
+    ["10.42.0.59", "10.42.0.0/24", true],
+    ["10.43.0.59", "10.42.0.0/24", false],
+    ["2001:db8::1234", "2001:db8::/32", true],
+    ["2001:db9::1234", "2001:db8::/32", false],
+    ["::ffff:127.0.0.1", "127.0.0.1", true],
+    ["127.0.0.1", "::ffff:127.0.0.2", false],
+    ["127.0.0.1", "127.1/8", true],
+    ["127.0.0.1", "127.1", false],
+    ["10.42.0.59", " 10.42.0.0/24 ", true],
+    ["10.42.0.59", "10.42.0.0/33", false],
+    ["2001:db8::1", "2001:db8::/129", false],
+    ["10.42.0.59", "junk", false],
+    ["10.42.0.59", "", false],
+    ["junk", "10.42.0.0/24", false],
+    ["10.42.0.59", "2001:db8::/32", false],
+    ["fe80::1%eth0", "fe80::1%eth1", false],
+    ["fe80::1%eth0", "fe80::1%eth0", true],
+    ["fe80::1%eth0", "fe80::1%eth1/128", true],
+    ["::ffff:127.0.0.1", "::ffff:127.0.0.1/128", true],
+  ])("matches %s against %s: %s", (ip, range, expected) => {
+    expect(isIpInCidr(ip, range)).toBe(expected);
   });
 
   it("extracts embedded IPv4 for transition prefixes", () => {

--- a/packages/net-policy/src/ip.ts
+++ b/packages/net-policy/src/ip.ts
@@ -360,40 +360,46 @@ export function extractEmbeddedIpv4FromIpv6(address: ipaddr.IPv6): ipaddr.IPv4 |
   return undefined;
 }
 
+/** Parses the exact-IP and CIDR forms accepted by runtime address matching. */
+export function parseIpAddressOrCidr(
+  raw: string | undefined,
+): [ParsedIpAddress, number?] | undefined {
+  const candidate = normalizeOptionalString(raw);
+  if (!candidate) {
+    return undefined;
+  }
+  if (!candidate.includes("/")) {
+    const exact = parseCanonicalIpAddress(candidate);
+    return exact ? [exact] : undefined;
+  }
+  try {
+    return ipaddr.parseCIDR(candidate);
+  } catch {
+    return undefined;
+  }
+}
+
 /** Checks an IP literal against an exact IP or CIDR range, normalizing mapped IPv4. */
 export function isIpInCidr(ip: string, cidr: string): boolean {
   const normalizedIp = parseCanonicalIpAddress(ip);
-  if (!normalizedIp) {
+  const range = parseIpAddressOrCidr(cidr);
+  if (!normalizedIp || !range) {
     return false;
   }
-  const candidate = cidr.trim();
-  if (!candidate) {
-    return false;
-  }
+  const [baseAddress, prefixLength] = range;
   const comparableIp = normalizeIpv4MappedAddress(normalizedIp);
-  if (!candidate.includes("/")) {
-    const exact = parseCanonicalIpAddress(candidate);
-    if (!exact) {
-      return false;
-    }
-    const comparableExact = normalizeIpv4MappedAddress(exact);
+  const comparableBase = normalizeIpv4MappedAddress(baseAddress);
+  if (prefixLength === undefined) {
     return (
-      comparableIp.kind() === comparableExact.kind() &&
-      comparableIp.toString() === comparableExact.toString()
+      comparableIp.kind() === comparableBase.kind() &&
+      comparableIp.toString() === comparableBase.toString()
     );
   }
-
-  try {
-    const [baseAddress, prefixLength] = ipaddr.parseCIDR(candidate);
-    const comparableBase = normalizeIpv4MappedAddress(baseAddress);
-    if (isIpv4Address(comparableIp) && isIpv4Address(comparableBase)) {
-      return comparableIp.match([comparableBase, prefixLength]);
-    }
-    if (isIpv6Address(comparableIp) && isIpv6Address(comparableBase)) {
-      return comparableIp.match([comparableBase, prefixLength]);
-    }
-    return false;
-  } catch {
-    return false;
+  if (isIpv4Address(comparableIp) && isIpv4Address(comparableBase)) {
+    return comparableIp.match([comparableBase, prefixLength]);
   }
+  if (isIpv6Address(comparableIp) && isIpv6Address(comparableBase)) {
+    return comparableIp.match([comparableBase, prefixLength]);
+  }
+  return false;
 }

--- a/src/commands/configure.gateway.test.ts
+++ b/src/commands/configure.gateway.test.ts
@@ -4,6 +4,7 @@ import { Socket } from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { authorizeHttpGatewayConnect, resolveGatewayAuth } from "../gateway/auth.js";
+import { isTrustedProxyAddress } from "../gateway/net.js";
 import type { RuntimeEnv } from "../runtime.js";
 
 const mocks = vi.hoisted(() => ({
@@ -252,6 +253,11 @@ describe("promptGatewayConfig", () => {
     ["127.0.0.0/8", "127.0.0.1"],
     ["::1/128", "::1"],
     ["127.1/8", "127.0.0.1"],
+    ["127.42.0.0/16", "127.42.0.1"],
+    ["126.0.0.0/7", "127.0.0.1"],
+    ["::/127", "::1"],
+    ["::/0", "::1"],
+    ["::ffff:127.0.0.2/128", "127.0.0.2"],
     [" 127.0.0.1 , \t::1/128 ", "::1"],
   ])("accepts runtime auth after consent for loopback proxy %s", async (proxies, remoteAddress) => {
     vi.stubEnv("OPENCLAW_LOCALE", "en");
@@ -275,6 +281,21 @@ describe("promptGatewayConfig", () => {
       user: "operator@example.test",
     });
   });
+
+  it.each(["126.0.0.0/8", "::/128", "::2/127", "::ffff:0:0/96", "::1%LO0"])(
+    "does not ask for loopback consent when runtime cannot match loopback through %s",
+    async (proxies) => {
+      const result = await runTrustedProxyPrompt({
+        textQueue: ["18789", "x-forwarded-user", "", "", proxies],
+      });
+      expect(mocks.confirm).not.toHaveBeenCalled();
+      expect(result.config.gateway?.auth?.trustedProxy?.allowLoopback).toBeUndefined();
+      for (const peer of ["127.0.0.1", "::1", "::1%LO0"]) {
+        expect(isTrustedProxyAddress(peer, result.config.gateway?.trustedProxies)).toBe(false);
+        expect(await authorizeConfiguredProxy(result.config, peer)).toMatchObject({ ok: false });
+      }
+    },
+  );
 
   it.each([
     ["en", "Any local process", "Allow loopback", "will be rejected"],

--- a/src/commands/configure.gateway.test.ts
+++ b/src/commands/configure.gateway.test.ts
@@ -212,6 +212,38 @@ describe("promptGatewayConfig", () => {
   });
 
   it.each([
+    ["10.42.0.1", true],
+    ["2001:db8::1", true],
+    ["10.42.0.0/24", true],
+    ["2001:db8::/32", true],
+    ["127.1/8", true],
+    [" 10.42.0.1 , \t2001:db8::/32 ", true],
+    ["junk", false],
+    ["10.42.0.999", false],
+    ["2001:db8::gg", false],
+    ["10.42.0.0/33", false],
+    ["2001:db8::/129", false],
+    ["10.42.0.0/-1", false],
+    ["10.42.0.0/nope", false],
+    ["10.42.0.1, junk", false],
+    ["", false],
+    [" \t ", false],
+    [",", false],
+    ["10.42.0.1, ", false],
+  ])("validates trusted proxy input %j (valid=%s)", async (input, valid) => {
+    await runTrustedProxyPrompt({
+      textQueue: ["18789", "x-forwarded-user", "", "", "10.42.0.1"],
+    });
+    const prompt = mocks.text.mock.calls.find(
+      ([options]) => options.message === "Trusted proxy IPs (comma-separated)",
+    )?.[0];
+    expect(prompt?.validate).toBeTypeOf("function");
+    expect(prompt.validate(input)).toEqual(
+      valid ? undefined : expect.stringMatching(/IPv4.*IPv6.*CIDR/),
+    );
+  });
+
+  it.each([
     ["127.0.0.1", "127.0.0.1"],
     ["127.0.0.2", "127.0.0.2"],
     ["::1", "::1"],
@@ -219,6 +251,8 @@ describe("promptGatewayConfig", () => {
     ["10.0.0.1, 127.0.0.1", "127.0.0.1"],
     ["127.0.0.0/8", "127.0.0.1"],
     ["::1/128", "::1"],
+    ["127.1/8", "127.0.0.1"],
+    [" 127.0.0.1 , \t::1/128 ", "::1"],
   ])("accepts runtime auth after consent for loopback proxy %s", async (proxies, remoteAddress) => {
     vi.stubEnv("OPENCLAW_LOCALE", "en");
     const result = await runTrustedProxyPrompt({
@@ -226,6 +260,10 @@ describe("promptGatewayConfig", () => {
       confirmResult: true,
     });
     expect(result.config.gateway?.auth?.trustedProxy?.allowLoopback).toBe(true);
+    const prompt = mocks.text.mock.calls.find(
+      ([options]) => options.message === "Trusted proxy IPs (comma-separated)",
+    )?.[0];
+    expect(prompt.validate(proxies)).toBeUndefined();
     expect(mocks.confirm).toHaveBeenCalledWith(expect.objectContaining({ initialValue: false }));
     expect(mocks.note).toHaveBeenCalledWith(
       expect.stringContaining("Any local process"),

--- a/src/commands/configure.gateway.ts
+++ b/src/commands/configure.gateway.ts
@@ -1,4 +1,5 @@
 // Configure wizard Gateway port, bind, auth, and Tailscale prompts.
+import { parseIpAddressOrCidr } from "@openclaw/net-policy/ip";
 import { validateDottedDecimalIPv4Input } from "@openclaw/net-policy/ipv4";
 import {
   normalizeOptionalString,
@@ -305,12 +306,10 @@ export async function promptGatewayConfig(
       await text({
         message: "Trusted proxy IPs (comma-separated)",
         placeholder: "10.0.1.10,192.168.1.5",
-        validate: (value) => {
-          if (!normalizeOptionalString(value)) {
-            return "At least one trusted proxy IP is required";
-          }
-          return undefined;
-        },
+        validate: (value) =>
+          (value ?? "").split(",").every((address) => parseIpAddressOrCidr(address))
+            ? undefined
+            : "Enter comma-separated IPv4 or IPv6 addresses or CIDR ranges (e.g. 10.0.0.1, ::1, 10.0.0.0/24); no empty entries.",
       }),
       runtime,
       1,
@@ -320,8 +319,12 @@ export async function promptGatewayConfig(
     const existingProxy =
       cfg.gateway?.auth?.mode === "trusted-proxy" ? cfg.gateway.auth.trustedProxy : undefined;
     let allowLoopback = existingProxy?.allowLoopback;
-    // Classify CIDR base addresses with the same loopback rules as runtime auth.
-    if (trustedProxies.some((address) => isLoopbackAddress(address.split("/")[0]))) {
+    // Parse CIDR bases before classification so runtime-accepted aliases still require consent.
+    if (
+      trustedProxies.some((address) =>
+        isLoopbackAddress(parseIpAddressOrCidr(address)?.[0].toString()),
+      )
+    ) {
       const title = t("wizard.gateway.trustedProxyLoopbackTitle");
       note(t("wizard.gateway.trustedProxyLoopbackWarning"), title);
       allowLoopback =

--- a/src/commands/configure.gateway.ts
+++ b/src/commands/configure.gateway.ts
@@ -19,7 +19,7 @@ import {
   TAILSCALE_EXPOSURE_OPTIONS,
   TAILSCALE_MISSING_BIN_NOTE_LINES,
 } from "../gateway/gateway-config-prompts.shared.js";
-import { isLoopbackAddress } from "../gateway/net.js";
+import { isLoopbackAddress, isTrustedProxyAddress } from "../gateway/net.js";
 import { findTailscaleBinary } from "../infra/tailscale.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveDefaultSecretProviderAlias } from "../secrets/ref-contract.js";
@@ -319,11 +319,15 @@ export async function promptGatewayConfig(
     const existingProxy =
       cfg.gateway?.auth?.mode === "trusted-proxy" ? cfg.gateway.auth.trustedProxy : undefined;
     let allowLoopback = existingProxy?.allowLoopback;
-    // Parse CIDR bases before classification so runtime-accepted aliases still require consent.
+    // The base covers subnets within loopback; representative peers cover ranges containing it.
+    // Use runtime matching too, including its mapped IPv4 and exact IPv6 zone semantics.
     if (
-      trustedProxies.some((address) =>
-        isLoopbackAddress(parseIpAddressOrCidr(address)?.[0].toString()),
-      )
+      trustedProxies.some((address) => {
+        const base = parseIpAddressOrCidr(address)?.[0].toString();
+        return [base, "127.0.0.1", "::1"].some(
+          (peer) => isLoopbackAddress(peer) && isTrustedProxyAddress(peer, [address]),
+        );
+      })
     ) {
       const title = t("wizard.gateway.trustedProxyLoopbackTitle");
       note(t("wizard.gateway.trustedProxyLoopbackWarning"), title);

--- a/src/commands/configure.wizard.gateway.test.ts
+++ b/src/commands/configure.wizard.gateway.test.ts
@@ -343,42 +343,45 @@ describe("runConfigureWizard", () => {
     });
   });
 
-  it("keeps startup gateway hint probes bounded", async () => {
-    setupBaseWizardState({
-      gateway: {
-        mode: "local",
-        remote: {
-          url: "wss://gateway.example.test",
-          token: "token",
-          edgeAuth: { "X-Edge-Auth": "test-secret" },
+  it.each([{ edgeAuth: { "X-Edge-Auth": "test-secret" } }, { tlsFingerprint: "ab".repeat(32) }])(
+    "keeps startup gateway hint probes bounded with remote trust: %j",
+    async (trust) => {
+      setupBaseWizardState({
+        gateway: {
+          mode: "local",
+          remote: {
+            url: "wss://gateway.example.test",
+            token: "token",
+            ...trust,
+          },
         },
-      },
-    });
-    await withEnvAsync({ OPENCLAW_GATEWAY_PASSWORD: "env-password" }, async () => {
-      await runConfigureWizard({ command: "configure", sections: ["gateway"] }, createRuntime());
-    });
+      });
+      await withEnvAsync({ OPENCLAW_GATEWAY_PASSWORD: "env-password" }, async () => {
+        await runConfigureWizard({ command: "configure", sections: ["gateway"] }, createRuntime());
+      });
 
-    const probeRequests = mocks.probeGatewayReachable.mock.calls.map(([request]) =>
-      requireRecord(request, "probe request"),
-    );
-    const localProbe = probeRequests.find((request) => request.url === "ws://127.0.0.1:18789");
-    const remoteProbe = probeRequests.find(
-      (request) => request.url === "wss://gateway.example.test",
-    );
-    expect(localProbe?.timeoutMs).toBe(300);
-    expect(remoteProbe).toEqual({
-      url: "wss://gateway.example.test",
-      config: expect.objectContaining({
-        gateway: expect.objectContaining({
-          remote: expect.objectContaining({
-            edgeAuth: { "X-Edge-Auth": "test-secret" },
+      const probeRequests = mocks.probeGatewayReachable.mock.calls.map(([request]) =>
+        requireRecord(request, "probe request"),
+      );
+      const localProbe = probeRequests.find((request) => request.url === "ws://127.0.0.1:18789");
+      const remoteProbe = probeRequests.find(
+        (request) => request.url === "wss://gateway.example.test",
+      );
+      expect(localProbe?.timeoutMs).toBe(300);
+      expect(remoteProbe).toEqual({
+        url: "wss://gateway.example.test",
+        config: expect.objectContaining({
+          gateway: expect.objectContaining({
+            remote: expect.objectContaining({
+              ...trust,
+            }),
           }),
         }),
-      }),
-      token: "token",
-      timeoutMs: 300,
-    });
-  });
+        token: "token",
+        timeoutMs: 300,
+      });
+    },
+  );
 
   it("ignores blank gateway env credentials when probing the local gateway", async () => {
     setupBaseWizardState({

--- a/src/commands/configure.wizard.gateway.test.ts
+++ b/src/commands/configure.wizard.gateway.test.ts
@@ -233,6 +233,7 @@ describe("runConfigureWizard", () => {
           url: "wss://gateway.example.test",
           token: { source: "env", provider: "default", id: "MISSING_REMOTE_TOKEN" },
           password: remotePassword,
+          tlsFingerprint: "ab".repeat(32),
         },
       },
       secrets: { providers: { default: { source: "env" } } },
@@ -243,6 +244,9 @@ describe("runConfigureWizard", () => {
 
     await runConfigureWizard({ command: "configure", sections: ["health"] }, createRuntime());
 
+    expect(mocks.waitForGatewayReachable).toHaveBeenCalledWith(
+      expect.objectContaining({ url: remoteConfig.gateway?.remote?.url, config: remoteConfig }),
+    );
     expect(mocks.healthCommand).toHaveBeenCalledWith(
       expect.objectContaining({
         config: remoteConfig,

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -518,7 +518,7 @@ export async function runConfigureWizard(
             });
             return probeGatewayReachable({
               url: remoteUrl,
-              ...(baseConfig.gateway?.remote?.edgeAuth ? { config: baseConfig } : {}),
+              config: baseConfig,
               token: remoteProbeAuth.auth.token,
               ...(remoteProbeAuth.auth.password ? { password: remoteProbeAuth.auth.password } : {}),
               timeoutMs: GATEWAY_HINT_PROBE_TIMEOUT_MS,

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -161,6 +161,7 @@ async function runGatewayHealthCheck(params: {
   try {
     const gatewayProbe = await waitForGatewayReachable({
       url: wsUrl,
+      ...(probeMode === "remote" ? { config: params.cfg } : {}),
       token,
       password,
       ...(params.daemonSetupOutcome === "succeeded"

--- a/src/commands/onboard-helpers.remote-probe.test.ts
+++ b/src/commands/onboard-helpers.remote-probe.test.ts
@@ -2,7 +2,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ConnectErrorDetailCodes } from "../../packages/gateway-protocol/src/connect-error-details.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { probeGatewayConfiguredModel, probeGatewayReachable } from "./onboard-helpers.js";
+import {
+  probeGatewayConfiguredModel,
+  probeGatewayReachable,
+  waitForGatewayReachable,
+} from "./onboard-helpers.js";
 
 const mocks = vi.hoisted(() => ({ probeGateway: vi.fn() }));
 
@@ -44,7 +48,10 @@ describe("probeGatewayReachable", () => {
     });
   });
 
-  it("forwards configured remote edge auth to the gateway probe", async () => {
+  it.each([
+    ["single probe", probeGatewayReachable],
+    ["polling", waitForGatewayReachable],
+  ] as const)("forwards remote trust through %s", async (_name, probe) => {
     mocks.probeGateway.mockResolvedValueOnce({ ok: true, configSnapshot: null });
     const config: OpenClawConfig = {
       gateway: {
@@ -52,11 +59,12 @@ describe("probeGatewayReachable", () => {
         remote: {
           url: "wss://gateway.example",
           edgeAuth: { "X-Edge-Auth": "test-secret" },
+          tlsFingerprint: "ab".repeat(32),
         },
       },
     };
 
-    await expect(probeGatewayReachable({ url: "wss://gateway.example", config })).resolves.toEqual({
+    await expect(probe({ url: "wss://gateway.example", config })).resolves.toEqual({
       ok: true,
     });
     expect(mocks.probeGateway).toHaveBeenCalledWith(

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -421,28 +421,24 @@ export async function probeGatewayConfiguredModel(
 }
 
 /** Polls gateway reachability until success or deadline. */
-export async function waitForGatewayReachable(params: {
-  url: string;
-  token?: string;
-  password?: string;
-  /** Total time to wait before giving up. */
-  deadlineMs?: number;
-  /** Per-probe timeout (each probe makes a full gateway health request). */
-  probeTimeoutMs?: number;
-  /** Delay between probes. */
-  pollMs?: number;
-}): Promise<{ ok: boolean; detail?: string }> {
-  const deadlineMs = params.deadlineMs ?? 15_000;
-  const pollMs = resolveTimerTimeoutMs(params.pollMs ?? 400, 400, 0);
-  const probeTimeoutMs = params.probeTimeoutMs ?? 1500;
+export async function waitForGatewayReachable(
+  params: Omit<OnboardingGatewayProbeParams, "timeoutMs"> & {
+    /** Total time to wait before giving up. */
+    deadlineMs?: number;
+    /** Per-probe timeout for the hello-only readiness check. */
+    probeTimeoutMs?: number;
+    /** Delay between probes. */
+    pollMs?: number;
+  },
+): Promise<{ ok: boolean; detail?: string }> {
+  const { deadlineMs = 15_000, pollMs = 400, probeTimeoutMs = 1500, ...probeParams } = params;
+  const pollDelayMs = resolveTimerTimeoutMs(pollMs, 400, 0);
   const startedAt = Date.now();
   let lastDetail: string | undefined;
 
   while (Date.now() - startedAt < deadlineMs) {
     const probe = await probeGatewayReachable({
-      url: params.url,
-      token: params.token,
-      password: params.password,
+      ...probeParams,
       timeoutMs: probeTimeoutMs,
     });
     if (probe.ok) {
@@ -453,7 +449,7 @@ export async function waitForGatewayReachable(params: {
     if (remainingMs <= 0) {
       break;
     }
-    await sleep(Math.min(pollMs, remainingMs));
+    await sleep(Math.min(pollDelayMs, remainingMs));
   }
 
   return { ok: false, detail: lastDetail };

--- a/src/gateway/probe.tls.test.ts
+++ b/src/gateway/probe.tls.test.ts
@@ -4,9 +4,11 @@ import type { AddressInfo, Socket } from "node:net";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { WebSocketServer } from "ws";
 import { TEST_TLS_CERT_PEM, TEST_TLS_KEY_PEM } from "../../test/helpers/tls-fixture.js";
+import { waitForGatewayReachable } from "../commands/onboard-helpers.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resetSecretRedactionRegistryForTest } from "../logging/secret-redaction-registry.test-support.js";
 import { createSuiteTempRootTracker, withTestDir } from "../test-helpers/temp-dir.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { resolveGatewayClientBootstrap } from "./client-bootstrap.js";
 import {
   buildMinimalGatewayHelloOkPayload,
@@ -169,6 +171,20 @@ describe("Gateway probe TLS trust", () => {
 
   it.each([
     { name: "saved pin", savedPin: fingerprint, ok: true },
+    { name: "probe URL whitespace", savedPin: fingerprint, urlVariant: "whitespace", ok: true },
+    {
+      name: "identical uppercase scheme",
+      savedPin: fingerprint,
+      urlVariant: "same-case",
+      ok: true,
+    },
+    {
+      name: "case-changed endpoint",
+      savedPin: fingerprint,
+      urlVariant: "different-case",
+      ok: false,
+      error: "certificate",
+    },
     { name: "saved pin in local mode", savedPin: fingerprint, local: true, ok: true },
     { name: "saved pin with whitespace", savedPin: ` sha256:${fingerprint} `, ok: true },
     {
@@ -201,19 +217,27 @@ describe("Gateway probe TLS trust", () => {
     },
   ])(
     "enforces $name before sending Gateway credentials",
-    async ({ savedPin, explicitPin, local, changed, ok, error }) => {
+    async ({ savedPin, explicitPin, local, changed, urlVariant, ok, error }) => {
       const before = {
         receivedBytes: gateway.observed.receivedBytes,
         edgeAuthHeaders: gateway.observed.edgeAuthHeaders.length,
         connectFrames: gateway.observed.connectFrames,
       };
+      const probeUrl =
+        urlVariant === "whitespace"
+          ? ` ${url} `
+          : urlVariant?.endsWith("case")
+            ? url.replace("wss:", "WSS:")
+            : url;
+      const savedUrl =
+        urlVariant === "same-case" ? probeUrl : changed ? `${url}/other` : ` ${url} `;
       const result = await probeGateway({
-        url,
+        url: probeUrl,
         config: {
           gateway: {
             mode: local ? "local" : "remote",
             remote: {
-              url: changed ? `${url}/other` : ` ${url} `,
+              url: savedUrl,
               tlsFingerprint: savedPin,
               edgeAuth: { "X-Test-Edge-Auth": edgeAuthValue },
             },
@@ -244,4 +268,22 @@ describe("Gateway probe TLS trust", () => {
       }
     },
   );
+
+  it("retains saved TLS trust through the health readiness polling path", async () => {
+    const before = gateway.observed.connectFrames;
+    const result = await withEnvAsync(
+      { OPENCLAW_STATE_DIR: await tempDirs.make("polling-state") },
+      () =>
+        waitForGatewayReachable({
+          url,
+          config: { gateway: { mode: "remote", remote: { url, tlsFingerprint: fingerprint } } },
+          token: "test-probe-token",
+          deadlineMs: 2_000,
+          probeTimeoutMs: 2_000,
+        }),
+    );
+    expect(result).toEqual({ ok: true });
+    await gateway.drain();
+    expect(gateway.observed.connectFrames - before).toBe(1);
+  });
 });

--- a/src/gateway/probe.tls.test.ts
+++ b/src/gateway/probe.tls.test.ts
@@ -1,12 +1,12 @@
 import { X509Certificate } from "node:crypto";
 import { createServer } from "node:https";
 import type { AddressInfo, Socket } from "node:net";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { WebSocketServer } from "ws";
 import { TEST_TLS_CERT_PEM, TEST_TLS_KEY_PEM } from "../../test/helpers/tls-fixture.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resetSecretRedactionRegistryForTest } from "../logging/secret-redaction-registry.test-support.js";
-import { withTestDir } from "../test-helpers/temp-dir.js";
+import { createSuiteTempRootTracker, withTestDir } from "../test-helpers/temp-dir.js";
 import { resolveGatewayClientBootstrap } from "./client-bootstrap.js";
 import {
   buildMinimalGatewayHelloOkPayload,
@@ -20,7 +20,9 @@ import { probeGateway } from "./probe.js";
 const correctPin = new X509Certificate(TEST_TLS_CERT_PEM).fingerprint256
   .replaceAll(":", "")
   .toLowerCase();
+const fingerprint = new X509Certificate(TEST_TLS_CERT_PEM).fingerprint256;
 const wrongPin = "00".repeat(32);
+const tempDirs = createSuiteTempRootTracker({ prefix: "openclaw-probe-tls-" });
 const edgeAuthValue = "synthetic-probe-edge-auth";
 
 async function startTlsProbeGateway() {
@@ -148,4 +150,98 @@ describe("probeGateway TLS", () => {
       }
     });
   });
+});
+
+describe("Gateway probe TLS trust", () => {
+  let gateway: Awaited<ReturnType<typeof startTlsProbeGateway>>;
+  let url: string;
+
+  beforeAll(async () => {
+    await tempDirs.setup();
+    gateway = await startTlsProbeGateway();
+    url = `${gateway.url}/gateway`;
+  });
+
+  afterAll(async () => {
+    await gateway.close();
+    await tempDirs.cleanup();
+  });
+
+  it.each([
+    { name: "saved pin", savedPin: fingerprint, ok: true },
+    { name: "saved pin in local mode", savedPin: fingerprint, local: true, ok: true },
+    { name: "saved pin with whitespace", savedPin: ` sha256:${fingerprint} `, ok: true },
+    {
+      name: "wrong saved pin",
+      savedPin: wrongPin,
+      ok: false,
+      error: "fingerprint mismatch",
+    },
+    { name: "malformed saved pin", savedPin: "invalid", ok: false, error: "SHA-256 fingerprint" },
+    {
+      name: "changed endpoint",
+      savedPin: fingerprint,
+      changed: true,
+      ok: false,
+      error: "certificate",
+    },
+    { name: "no saved pin", ok: false, error: "certificate" },
+    {
+      name: "explicit pin override",
+      savedPin: wrongPin,
+      explicitPin: fingerprint,
+      ok: true,
+    },
+    {
+      name: "wrong explicit pin",
+      savedPin: fingerprint,
+      explicitPin: wrongPin,
+      ok: false,
+      error: "fingerprint mismatch",
+    },
+  ])(
+    "enforces $name before sending Gateway credentials",
+    async ({ savedPin, explicitPin, local, changed, ok, error }) => {
+      const before = {
+        receivedBytes: gateway.observed.receivedBytes,
+        edgeAuthHeaders: gateway.observed.edgeAuthHeaders.length,
+        connectFrames: gateway.observed.connectFrames,
+      };
+      const result = await probeGateway({
+        url,
+        config: {
+          gateway: {
+            mode: local ? "local" : "remote",
+            remote: {
+              url: changed ? `${url}/other` : ` ${url} `,
+              tlsFingerprint: savedPin,
+              edgeAuth: { "X-Test-Edge-Auth": edgeAuthValue },
+            },
+          },
+        },
+        tlsFingerprint: explicitPin,
+        auth: { token: "test-probe-token" },
+        timeoutMs: 2_000,
+        detailLevel: "none",
+        env: { OPENCLAW_STATE_DIR: await tempDirs.make("state") },
+      });
+
+      await gateway.drain();
+
+      expect(result.ok, result.error ?? undefined).toBe(ok);
+      expect(gateway.observed.connectFrames - before.connectFrames).toBe(ok ? 1 : 0);
+      if (ok) {
+        expect(gateway.observed.receivedBytes).toBeGreaterThan(before.receivedBytes);
+        expect(gateway.observed.edgeAuthHeaders.slice(before.edgeAuthHeaders)).toEqual([
+          edgeAuthValue,
+        ]);
+      } else {
+        expect.soft(gateway.observed.receivedBytes - before.receivedBytes).toBe(0);
+        expect.soft(gateway.observed.edgeAuthHeaders.slice(before.edgeAuthHeaders)).toEqual([]);
+      }
+      if (error) {
+        expect(result.error).toContain(error);
+      }
+    },
+  );
 });

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -425,7 +425,12 @@ export async function probeGateway(opts: {
       token: opts.auth?.token,
       password: opts.auth?.password,
       edgeAuthHeaders,
-      tlsFingerprint: opts.tlsFingerprint,
+      // Saved pins belong to the exact configured endpoint, not an overridden probe URL.
+      tlsFingerprint:
+        opts.tlsFingerprint ||
+        (opts.url.trim() === opts.config?.gateway?.remote?.url?.trim()
+          ? opts.config?.gateway?.remote?.tlsFingerprint
+          : undefined),
       preauthHandshakeTimeoutMs: opts.preauthHandshakeTimeoutMs,
       env: opts.env,
       scopes: [READ_SCOPE],

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -1048,6 +1048,7 @@ describe("runSetupWizard", () => {
 
       expect(probeGatewayReachable).toHaveBeenCalledWith({
         url: "wss://flag.example.com:18789",
+        config: expect.any(Object),
         token: remoteKey === "token" ? remoteCredential : undefined,
         ...(remoteKey === "password" ? { password: remoteCredential } : {}),
       });
@@ -1096,37 +1097,41 @@ describe("runSetupWizard", () => {
 
     expect(probeGatewayReachable).toHaveBeenCalledWith({
       url: "wss://gateway.example.test",
+      config: expect.any(Object),
       token: undefined,
       password: remotePassword,
     });
   });
 
-  it("passes configured remote edge auth to the setup reachability probe", async () => {
-    const config: OpenClawConfig = {
-      gateway: {
-        mode: "remote",
-        remote: {
-          url: "wss://gateway.example.test",
-          edgeAuth: { "X-Edge-Auth": "test-secret" },
+  it.each([{ edgeAuth: { "X-Edge-Auth": "test-secret" } }, { tlsFingerprint: "ab".repeat(32) }])(
+    "passes remote trust settings to the setup reachability probe: %j",
+    async (trust) => {
+      const config: OpenClawConfig = {
+        gateway: {
+          mode: "remote",
+          remote: {
+            url: "wss://gateway.example.test",
+            ...trust,
+          },
         },
-      },
-    };
-    readConfigFileSnapshot.mockResolvedValueOnce(configSnapshot(config));
+      };
+      readConfigFileSnapshot.mockResolvedValueOnce(configSnapshot(config));
 
-    await runSetupWizard(
-      { acceptRisk: true, flow: "advanced", mode: "remote" },
-      createRuntime(),
-      buildWizardPrompter({}),
-    );
+      await runSetupWizard(
+        { acceptRisk: true, flow: "advanced", mode: "remote" },
+        createRuntime(),
+        buildWizardPrompter({}),
+      );
 
-    expect(probeGatewayReachable).toHaveBeenCalledWith({
-      url: "wss://gateway.example.test",
-      config: expect.objectContaining({
-        gateway: config.gateway,
-      }),
-      token: undefined,
-    });
-  });
+      expect(probeGatewayReachable).toHaveBeenCalledWith({
+        url: "wss://gateway.example.test",
+        config: expect.objectContaining({
+          gateway: config.gateway,
+        }),
+        token: undefined,
+      });
+    },
+  );
 
   it("keeps a configured remote token authoritative over an environment password", async () => {
     readConfigFileSnapshot.mockResolvedValueOnce(
@@ -1156,6 +1161,7 @@ describe("runSetupWizard", () => {
 
     expect(probeGatewayReachable).toHaveBeenCalledWith({
       url: "wss://gateway.example.test",
+      config: expect.any(Object),
       token: "resolved-remote-token",
     });
   });
@@ -1190,6 +1196,7 @@ describe("runSetupWizard", () => {
 
     expect(probeGatewayReachable).toHaveBeenCalledWith({
       url: "wss://gateway.example.test",
+      config: expect.any(Object),
       token: "ambient-token",
     });
   });
@@ -1210,6 +1217,7 @@ describe("runSetupWizard", () => {
             token: { source: "env", provider: "default", id: "STORED_GATEWAY_TOKEN" },
             password: { source: "env", provider: "default", id: "STORED_GATEWAY_PASSWORD" },
             edgeAuth: { "X-Edge-Auth": "test-secret" },
+            tlsFingerprint: "ab".repeat(32),
           },
         },
       },
@@ -1241,6 +1249,7 @@ describe("runSetupWizard", () => {
           remote: expect.objectContaining({
             url: "wss://stored.example.com:18789",
             edgeAuth: { "X-Edge-Auth": "test-secret" },
+            tlsFingerprint: "ab".repeat(32),
           }),
         }),
       }),
@@ -1254,6 +1263,7 @@ describe("runSetupWizard", () => {
             token: undefined,
             password: undefined,
             edgeAuth: { "X-Edge-Auth": "test-secret" },
+            tlsFingerprint: "ab".repeat(32),
           },
         }),
       }),
@@ -1282,10 +1292,9 @@ describe("runSetupWizard", () => {
     );
 
     expect(validateGatewayWebSocketUrl).toHaveBeenCalledWith("ws://public.example");
-    expect(probeGatewayReachable).not.toHaveBeenCalledWith({
-      url: "ws://public.example",
-      token: remoteToken,
-    });
+    expect(probeGatewayReachable).not.toHaveBeenCalledWith(
+      expect.objectContaining({ url: "ws://public.example" }),
+    );
   });
 
   it("auto-enables the bundled session-memory hook without showing the hooks screen", async () => {

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -423,7 +423,7 @@ async function runSetupWizardOnce(
   const remoteProbe = remoteUrl
     ? await onboardHelpers.probeGatewayReachable({
         url: remoteUrl,
-        ...(baseConfig.gateway?.remote?.edgeAuth ? { config: baseConfig } : {}),
+        config: baseConfig,
         token: remoteProbeAuth?.auth.token,
         ...(remoteProbeAuth?.auth.password ? { password: remoteProbeAuth.auth.password } : {}),
       })


### PR DESCRIPTION
> [!IMPORTANT]
> **review-required: TLS trust + auth-config surface.** Prepared under the auto-QA campaign; onboarding TLS trust and trusted-proxy validation are review-required, so this stays a draft for maintainer review.

## What Problem This Solves

Two onboarding/configure-wizard hardening gaps found by deep-review passes:

1. **Readiness probes ignored saved TLS pins** (`src/gateway/probe.ts`): after configuring a pinned self-signed remote gateway (pin preserved by the TLS-pin work in #131042), the wizard's own readiness probe built its connection without forwarding that pin, so it failed to verify — or trusted differently than the runtime would. The probe now forwards the saved pin, but only for the exact configured URL (trim-normalized): a different host, port, path, query, or case cannot acquire another endpoint's pin, and a mid-wizard URL override cannot relabel an old pin onto its new target. The same fix also repairs `configure --section health`, whose readiness poll discarded all connection inputs except URL/token/password.
2. **Trusted-proxy prompt accepted malformed IP/CIDR** (`src/commands/configure.gateway.ts`): the prompt only rejected blank input, so a malformed address could be written to config that the runtime then silently never matches. It now validates every entry with the *same* canonical parser the runtime uses (`parseIpAddressOrCidr`, extracted from the existing `isIpInCidr` implementation in `packages/net-policy`), rejecting junk with an actionable message. This also fixes a connected loopback-consent miss: the runtime accepts `127.1/8`, but the old string-split+canonical-IP path missed its loopback identity, so consent wasn't prompted.

## Why This Change Was Made

Both fixes land at the producer: pin selection at the probe connection producer (one place, so status/daemon/future callers stay consistent), and address validation via the runtime's own parser (no second regex that could diverge from matching semantics). The parser extraction is behavior-preserving — verified against installed ipaddr.js 2.5.0 with a 19,950-combination parity probe (zero mismatches, zero throws) and confirmed byte-identical by the deep review.

The consent predicate now checks the parsed base plus IPv4/IPv6 loopback representatives through both runtime loopback classification and `isTrustedProxyAddress`, covering subnets within loopback and ranges containing it (`126.0.0.0/7`, `::/127`, `::/0`) without substituting hand-rolled CIDR arithmetic for runtime semantics.

## User Impact

Configuring a pinned remote gateway through the wizard now verifies readiness with the runtime's exact trust; a malformed trusted-proxy entry is rejected at the prompt with guidance instead of silently never matching; loopback consent is asked whenever the entry actually matches loopback.

## Evidence

- Production **net +15** (exact-endpoint trust binding + shared runtime parser + consent/readiness alignment); tests net +236; docs +5. No config option, schema, or persistence change.
- Failing-first: three containing-range consent cases, a scoped-address over-consent, the remote-health config loss, and ten malformed trusted-proxy inputs each reproduced then fixed; real self-signed TLS fixture proves rejected trust sends no connect frames.
- Rebased onto current main (which includes the landed TLS pin-before-upgrade fix #131435); the shared `probe.tls.test.ts` was union-merged with the transport PR's cases — **48 TLS/worker tests green including the zero-byte exposure assertions**, proving pin forwarding does not reintroduce pre-pin bytes.
- 19,950-combination ipaddr.js parity probe; post-rebase focused suites green; changed-file gate exit 0; two Codex autoreviews clean.
- Named follow-ups (not here): local-listener generated-certificate readiness (`waitForGatewayReachable` carries no pins); bootstrap environment-override pin contract vs exact-target diagnostics; mapped-IPv4 CIDR prefix interpretation.
