### PR TITLE
fix: preserve Control UI assets during source rebuilds

### DIFF
--- a/docs/start/setup.md
+++ b/docs/start/setup.md
@@ -113,7 +113,7 @@ reloads on relevant source, config, and bundled-plugin metadata changes. If the
 watched Gateway exits during startup, `gateway:watch` runs
 `openclaw doctor --fix --non-interactive` once and retries; set
 `OPENCLAW_GATEWAY_WATCH_AUTO_DOCTOR=0` to disable that dev-only repair pass.
-`pnpm gateway:watch` does not rebuild `dist/control-ui`, so rerun `pnpm ui:build` after `ui/` changes or use `pnpm ui:dev` while developing the Control UI.
+TypeScript rebuilds triggered by `pnpm openclaw ...` or `pnpm gateway:watch` preserve existing `dist/control-ui` assets but do not rebuild them. Run `pnpm ui:build` once and again after `ui/` changes, or use `pnpm ui:dev` while developing the Control UI.
 
 ### 2) Point the macOS app at your running Gateway
 

--- a/scripts/tsdown-build.mts
+++ b/scripts/tsdown-build.mts
@@ -213,6 +213,8 @@ export function cleanTsdownOutputRoots(params: OutputRootParams = {}) {
       ? listExistingDeclarationOutputPaths(cwd, fsImpl, roots)
       : new Set<string>();
   const protectedPaths = new Set([
+    // Vite owns and cleans this subtree; runtime-only builds cannot recreate it.
+    path.resolve(cwd, "dist/control-ui"),
     ...protectedDeclarationPaths,
     ...listExistingPreservedOutputPaths(cwd, env, fsImpl),
   ]);
@@ -261,7 +263,7 @@ function cleanOutputRootExcept(rootPath: string, protectedPaths: Set<string>, fs
         fsImpl.rmSync(entryPath, { force: true });
       }
     } catch {
-      // Keep best-effort semantics; protected declaration children can keep a directory non-empty.
+      // Keep best-effort semantics; protected children can keep a directory non-empty.
     }
   }
 }

--- a/src/infra/run-node.test.ts
+++ b/src/infra/run-node.test.ts
@@ -412,57 +412,6 @@ async function expectManifestId(tmp: string, relativePath: string, id: string) {
 }
 
 describe("run-node script", () => {
-  it.runIf(process.platform !== "win32")(
-    "preserves control-ui assets by building with tsdown --no-clean",
-    async ({ tmp }) => {
-      const argsPath = resolvePath(tmp, ".build-args.txt");
-      const indexPath = resolvePath(tmp, "dist/control-ui/index.html");
-
-      await writeRuntimePostBuildScaffold(tmp);
-      await fs.mkdir(path.dirname(indexPath), { recursive: true });
-      await fs.writeFile(indexPath, "<html>sentinel</html>\n", "utf-8");
-
-      const nodeCalls: string[][] = [];
-      const spawn = (cmd: string, args: string[]) => {
-        if (cmd === process.execPath && isTsxScriptArgs(args, "scripts/tsdown-build.mts")) {
-          fsSync.writeFileSync(argsPath, args.join(" "), "utf-8");
-          if (!args.includes("--no-clean")) {
-            fsSync.rmSync(resolvePath(tmp, "dist/control-ui"), { recursive: true, force: true });
-          }
-        }
-        if (cmd === process.execPath) {
-          nodeCalls.push([cmd, ...args]);
-        }
-        return createExitedProcess(0);
-      };
-
-      const exitCode = await runNodeCommand(tmp, {
-        args: ["--version"],
-        env: { OPENCLAW_FORCE_BUILD: "1" },
-        spawn,
-        runRuntimePostBuild: skipRuntimePostBuild,
-      });
-
-      expect(exitCode).toBe(0);
-      await expect(fs.readFile(argsPath, "utf-8")).resolves.toContain(
-        "scripts/tsdown-build.mts --no-clean",
-      );
-      await expect(fs.readFile(indexPath, "utf-8")).resolves.toContain("sentinel");
-      expect(nodeCalls).toEqual([
-        [
-          process.execPath,
-          "--import",
-          "tsx",
-          "scripts/bundled-plugin-assets.mts",
-          "--phase",
-          "build",
-        ],
-        [process.execPath, "--import", "tsx", "scripts/tsdown-build.mts", "--no-clean"],
-        [process.execPath, "openclaw.mjs", "--version"],
-      ]);
-    },
-  );
-
   it("copies bundled plugin metadata after rebuilding from a clean dist", async ({ tmp }) => {
     await writeRuntimePostBuildScaffold(tmp);
     await writeProjectFiles(tmp, {

--- a/test/scripts/tsdown-build.test.ts
+++ b/test/scripts/tsdown-build.test.ts
@@ -1854,50 +1854,126 @@ describe("resolveTsdownBuildInvocation", () => {
     await expectPathMissing(path.join(distRuntimeDir, "heartbeat-runner.runtime-fspOEj_1.js"));
   });
 
-  it("cleans tsdown output roots before using tsdown --no-clean", async () => {
-    const rootDir = createTempDir("openclaw-tsdown-clean-");
-    const distFile = path.join(rootDir, "dist", "stale.js");
-    const pluginGeneratedFile = path.join(rootDir, "dist", "extensions", "telegram", "index.js");
-    const distRuntimeFile = path.join(rootDir, "dist-runtime", "stale.js");
-    const agentCorePackageFile = path.join(rootDir, "packages", "agent-core", "dist", "stale.js");
-    const netPolicyPackageFile = path.join(rootDir, "packages", "net-policy", "dist", "stale.js");
-    const pluginSdkPackageFile = path.join(rootDir, "packages", "plugin-sdk", "dist", "keep.js");
-    const packageSourceFile = path.join(rootDir, "packages", "agent-core", "src", "keep.ts");
-    const unrelatedFile = path.join(rootDir, "tmp", "keep.js");
-    await fsPromises.mkdir(path.dirname(distFile), { recursive: true });
-    await fsPromises.mkdir(path.dirname(pluginGeneratedFile), { recursive: true });
-    await fsPromises.mkdir(path.dirname(distRuntimeFile), { recursive: true });
-    await fsPromises.mkdir(path.dirname(agentCorePackageFile), { recursive: true });
-    await fsPromises.mkdir(path.dirname(netPolicyPackageFile), { recursive: true });
-    await fsPromises.mkdir(path.dirname(pluginSdkPackageFile), { recursive: true });
-    await fsPromises.mkdir(path.dirname(packageSourceFile), { recursive: true });
-    await fsPromises.mkdir(path.dirname(unrelatedFile), { recursive: true });
-    await fsPromises.writeFile(distFile, "stale\n");
-    await fsPromises.writeFile(pluginGeneratedFile, "generated\n");
-    await fsPromises.writeFile(distRuntimeFile, "stale\n");
-    await fsPromises.writeFile(agentCorePackageFile, "stale\n");
-    await fsPromises.writeFile(netPolicyPackageFile, "stale\n");
-    await fsPromises.writeFile(pluginSdkPackageFile, "keep\n");
-    await fsPromises.writeFile(packageSourceFile, "keep\n");
-    await fsPromises.writeFile(unrelatedFile, "keep\n");
+  it.each([
+    { label: "default build", args: [], skipDts: "0", preserveMetadata: "0" },
+    {
+      label: "source launcher --no-clean",
+      args: ["--no-clean"],
+      skipDts: "1",
+      preserveMetadata: "0",
+    },
+    { label: "build-all startup metadata", args: [], skipDts: "0", preserveMetadata: "1" },
+    { label: "cached build-all", args: [], skipDts: "1", preserveMetadata: "1" },
+  ])(
+    "preserves separately owned outputs during $label cleanup",
+    async ({ args, skipDts, preserveMetadata }) => {
+      const rootDir = createTempDir("openclaw-tsdown-clean-");
+      const retainedFiles = [
+        "dist/control-ui/index.html",
+        "dist/control-ui/sw.js",
+        "dist/control-ui/asset-manifest.json",
+        "dist/control-ui/assets/index-AbCd1234.js",
+        "dist/control-ui/assets/index-AbCd1234.js.map",
+        "dist/control-ui/assets/index-AbCd1234.js.br",
+        "dist/control-ui/assets/nested/styles-AbCd1234.css",
+        "packages/plugin-sdk/dist/keep.js",
+        "packages/agent-core/src/keep.ts",
+        "tmp/keep.js",
+      ];
+      const declarationFiles = [
+        "dist/plugin-sdk/core.d.ts",
+        "dist/plugin-sdk/nested/types.d.cts",
+        "dist-runtime/extensions/demo/index.d.ts",
+        "packages/media-understanding-common/dist/index.d.mts",
+        "packages/media-understanding-common/dist/nested/types.d.ts",
+      ];
+      const metadataFile = "dist/cli-startup-metadata.json";
+      const staleFiles = [
+        "dist/entry.js",
+        "dist/stale-AbCd1234.js",
+        "dist/stale-AbCd1234.js.map",
+        "dist/plugin-sdk/core.js",
+        "dist/nested/stale.js",
+        "dist/nested/stale.js.map",
+        "dist/control-ui-old/index.html",
+        "dist/extensions/demo/src/index.js",
+        "dist/extensions/demo/node_modules/staged/index.js",
+        "dist/extensions/node_modules/openclaw/plugin-sdk/core.js",
+        "dist-runtime/stale.js",
+        "dist-runtime/stale.js.map",
+        "dist-runtime/control-ui/index.html",
+        "dist-runtime/extensions/demo/index.js",
+        "dist-runtime/extensions/demo/node_modules/staged/index.js",
+        "packages/agent-core/dist/stale.js",
+        "packages/net-policy/dist/stale.js",
+        "packages/media-understanding-common/dist/index.mjs",
+        "packages/media-understanding-common/dist/chunks/old.js",
+      ];
+      for (const relativePath of [
+        ...retainedFiles,
+        ...declarationFiles,
+        metadataFile,
+        ...staleFiles,
+      ]) {
+        const filePath = path.join(rootDir, relativePath);
+        await fsPromises.mkdir(path.dirname(filePath), { recursive: true });
+        await fsPromises.writeFile(filePath, `sentinel:${relativePath}\n`);
+      }
 
-    const outputRoots = listTsdownOutputRoots();
-    expect(outputRoots).toEqual(
-      expect.arrayContaining(["packages/agent-core/dist", "packages/net-policy/dist"]),
-    );
-    expect(outputRoots).not.toContain(path.join("packages", "plugin-sdk", "dist"));
-
-    cleanTsdownOutputRoots({ cwd: rootDir });
-
-    await expectPathMissing(distFile);
-    await expectPathMissing(pluginGeneratedFile);
-    await expectPathMissing(path.join(rootDir, "dist-runtime"));
-    await expectPathMissing(path.join(rootDir, "packages", "agent-core", "dist"));
-    await expectPathMissing(path.join(rootDir, "packages", "net-policy", "dist"));
-    await expect(fsPromises.readFile(pluginSdkPackageFile, "utf8")).resolves.toBe("keep\n");
-    await expect(fsPromises.readFile(packageSourceFile, "utf8")).resolves.toBe("keep\n");
-    await expect(fsPromises.readFile(unrelatedFile, "utf8")).resolves.toBe("keep\n");
-  });
+      const scriptUrl = pathToFileURL(path.resolve("scripts/tsdown-build.mts")).href;
+      const result = spawnSync(
+        process.execPath,
+        [
+          "--import",
+          import.meta.resolve("tsx"),
+          "--input-type=module",
+          "-e",
+          `import { prepareTsdownBuildExecution } from ${JSON.stringify(scriptUrl)};
+       const plan = prepareTsdownBuildExecution(${JSON.stringify({ args, ...NO_MEMORY_LIMIT })});
+       if (!plan) throw new Error("fixture build was not admitted");`,
+        ],
+        {
+          cwd: rootDir,
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: skipDts,
+            OPENCLAW_PRESERVE_CLI_STARTUP_METADATA: preserveMetadata,
+          },
+        },
+      );
+      expect(result.status, result.stderr).toBe(0);
+      for (const relativePath of staleFiles) {
+        await expectPathMissing(path.join(rootDir, relativePath));
+      }
+      for (const relativePath of [
+        "dist/extensions/demo/node_modules",
+        "dist/extensions/node_modules",
+        "dist-runtime/extensions/demo/node_modules",
+        "packages/agent-core/dist",
+        "packages/net-policy/dist",
+      ]) {
+        await expectPathMissing(path.join(rootDir, relativePath));
+      }
+      for (const [files, preserve] of [
+        [declarationFiles, skipDts === "1"],
+        [[metadataFile], preserveMetadata === "1"],
+      ] as const) {
+        for (const relativePath of files) {
+          if (preserve) {
+            retainedFiles.push(relativePath);
+          } else {
+            await expectPathMissing(path.join(rootDir, relativePath));
+          }
+        }
+      }
+      for (const relativePath of retainedFiles) {
+        await expect(fsPromises.readFile(path.join(rootDir, relativePath), "utf8")).resolves.toBe(
+          `sentinel:${relativePath}\n`,
+        );
+      }
+    },
+  );
 
   it("cleans only selected tsdown output roots", async () => {
     const rootDir = createTempDir("openclaw-tsdown-selected-clean-");
@@ -1969,39 +2045,6 @@ describe("resolveTsdownBuildInvocation", () => {
     } finally {
       rmSync.mockRestore();
     }
-  });
-
-  it("removes CLI startup metadata during default tsdown clean", async () => {
-    const rootDir = createTempDir("openclaw-tsdown-clean-metadata-default-");
-    const metadataFile = path.join(rootDir, "dist", "cli-startup-metadata.json");
-    await fsPromises.mkdir(path.dirname(metadataFile), { recursive: true });
-    await fsPromises.writeFile(metadataFile, '{"generatedBy":"test"}\n');
-
-    cleanTsdownOutputRoots({ cwd: rootDir });
-
-    await expectPathMissing(metadataFile);
-  });
-
-  it("preserves CLI startup metadata across opted-in build-all tsdown clean", async () => {
-    const rootDir = createTempDir("openclaw-tsdown-clean-metadata-");
-    const metadataFile = path.join(rootDir, "dist", "cli-startup-metadata.json");
-    const staleFile = path.join(rootDir, "dist", "stale.js");
-    const nestedStaleFile = path.join(rootDir, "dist", "nested", "stale.js");
-    await fsPromises.mkdir(path.dirname(nestedStaleFile), { recursive: true });
-    await fsPromises.writeFile(metadataFile, '{"generatedBy":"test"}\n');
-    await fsPromises.writeFile(staleFile, "stale\n");
-    await fsPromises.writeFile(nestedStaleFile, "stale\n");
-
-    cleanTsdownOutputRoots({
-      cwd: rootDir,
-      env: { OPENCLAW_PRESERVE_CLI_STARTUP_METADATA: "1" },
-    });
-
-    await expect(fsPromises.readFile(metadataFile, "utf8")).resolves.toBe(
-      '{"generatedBy":"test"}\n',
-    );
-    await expectPathMissing(staleFile);
-    await expectPathMissing(nestedStaleFile);
   });
 
   it("refuses a symlinked output root with preserved children and leaves the target unchanged", async () => {
@@ -2145,61 +2188,6 @@ describe("resolveTsdownBuildInvocation", () => {
 
     expect(fs.readlinkSync(distLink)).toBe(targetDir);
     await expect(fsPromises.readFile(markerFile, "utf8")).resolves.toBe("keep\n");
-  });
-
-  it("preserves existing package declarations when tsdown DTS output is skipped", async () => {
-    const rootDir = createTempDir("openclaw-tsdown-clean-skip-dts-");
-    const declarationFile = path.join(
-      rootDir,
-      "packages",
-      "media-understanding-common",
-      "dist",
-      "index.d.mts",
-    );
-    const nestedDeclarationFile = path.join(
-      rootDir,
-      "packages",
-      "media-understanding-common",
-      "dist",
-      "nested",
-      "types.d.ts",
-    );
-    const staleJsFile = path.join(
-      rootDir,
-      "packages",
-      "media-understanding-common",
-      "dist",
-      "index.mjs",
-    );
-    const nestedStaleFile = path.join(
-      rootDir,
-      "packages",
-      "media-understanding-common",
-      "dist",
-      "chunks",
-      "old.js",
-    );
-    const agentCorePackageFile = path.join(rootDir, "packages", "agent-core", "dist", "stale.js");
-    await fsPromises.mkdir(path.dirname(declarationFile), { recursive: true });
-    await fsPromises.mkdir(path.dirname(nestedDeclarationFile), { recursive: true });
-    await fsPromises.mkdir(path.dirname(nestedStaleFile), { recursive: true });
-    await fsPromises.mkdir(path.dirname(agentCorePackageFile), { recursive: true });
-    await fsPromises.writeFile(declarationFile, "export {};\n");
-    await fsPromises.writeFile(nestedDeclarationFile, "export {};\n");
-    await fsPromises.writeFile(staleJsFile, "stale\n");
-    await fsPromises.writeFile(nestedStaleFile, "old\n");
-    await fsPromises.writeFile(agentCorePackageFile, "stale\n");
-
-    cleanTsdownOutputRoots({
-      cwd: rootDir,
-      env: { OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "1" },
-    });
-
-    await expect(fsPromises.readFile(declarationFile, "utf8")).resolves.toBe("export {};\n");
-    await expect(fsPromises.readFile(nestedDeclarationFile, "utf8")).resolves.toBe("export {};\n");
-    await expectPathMissing(staleJsFile);
-    await expectPathMissing(nestedStaleFile);
-    await expectPathMissing(path.join(rootDir, "packages", "agent-core", "dist"));
   });
 
   it("prunes untracked generated declaration files that shadow source entries", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers launching OpenClaw from a dirty source checkout would lose their prebuilt Control UI assets when the launcher rebuilt TypeScript, even immediately after a successful `pnpm build`.

Related historical context: [Control UI asset-preservation repair #10146](https://github.com/openclaw/openclaw/pull/10146). This is a separate build-lifecycle repair, not a conversation-title change.

## Why This Change Was Made

The source launcher passes `--no-clean` to tsdown, but the wrapper performs its own output cleanup first. That cleanup must remain enabled for stale runtime chunks and plugin staging; it must not delete `dist/control-ui`, which Vite owns and cleans independently. Reuse the existing protected-output set for that directory, with no new option, freshness override, helper, or fallback.

The old launcher test mocked the compiler and assumed `--no-clean` prevented deletion. Replace it with real build-preparation coverage and consolidate overlapping declaration/startup-metadata fixtures. Package builds retain their independent full `clean:dist` step.

Regression provenance: [4cb4aad7b12, wrapper-owned cleanup](https://github.com/openclaw/openclaw/commit/4cb4aad7b12a455114aa7ce61abc1c5eea616ba9), authored and committed by @steipete on April 22, 2026. The launcher already used the wrapper at that point. Stable `v2026.4.22` contains the unconditional deletion.

## User Impact

Source-launcher and gateway-watch runtime rebuilds preserve existing Control UI assets while continuing to remove stale runtime JS/maps and plugin staging. UI source edits still require `pnpm ui:build` or `pnpm ui:dev`; the setup docs now distinguish preservation from rebuilding. Rebuild/freshness behavior, declaration retention, startup metadata policy, output-root validation, and symlink safety are unchanged.

Production/tooling LOC: +3/-1 (net +2), the directory ownership rule and its rationale. Tests: +119/-182 (net -63). Docs: +1/-1.

## Evidence

- **Failing before, passing after:** a synthetic output tree invokes the real `prepareTsdownBuildExecution` without a cleanup hook. Before the patch it deletes `dist/control-ui/index.html` and nested assets despite `--no-clean`. All four replacement regression cases fail on pre-fix production code with `ENOENT` for the UI index, then pass after the repair: default build, source launcher, build-all metadata preservation, and cached build-all.
- **Cleanup safety:** fixtures verify UI index, service worker, manifest, nested JS/CSS, sourcemaps, and compressed assets survive; stale compiler JS/maps, SDK JS, staged plugin dependencies/aliases, and similarly named non-UI trees are removed. Existing selected-root, filesystem-root/ancestor, all-root preflight, and symlink rejection tests remain green.
- **Real compiler:** the installed tsdown compiler emits an importable fixture module with value `42`, preserves UI/declaration/metadata sentinels, and removes stale compiler output.
- **Real full lifecycle:** create a temporary dirty watched TypeScript source before `pnpm build`; complete the full build; hash the UI tree; plant four stale JS/map sentinels under `dist` and `dist-runtime`; run `pnpm openclaw --version`. The launcher logs `dirty_watched_tree`, rebuilds through both compiler invocations and all eleven runtime-postbuild phases, and exits successfully. **All 1,864 Control UI files remain byte-for-byte identical; all four stale runtime sentinels are removed.** No force-build or freshness override was used.
- **Focused verification:** 398 tests passed across eight files, no skips. Full `pnpm build` and the complete changed-file type/lint/guard plan passed. No ineffective-dynamic-import diagnostics. Independent Codex autoreview was clean at its default P0 scope; refreshed before commit.
- **Isolation:** the full lifecycle proof used a fresh temporary HOME/state/config location and an allowlisted environment. The temporary source and state were removed afterward. No operator state/credentials or existing services were accessed or changed. No UI rendering/protocol code changed; this proof exercises the actual build/launcher/filesystem boundary, not a mocked compiler or a live browser/Gateway session.

Commands:

```bash
node scripts/run-vitest.mjs test/scripts/tsdown-build.test.ts -t 'preserves separately owned outputs'
```

```bash
node scripts/run-vitest.mjs test/scripts/tsdown-build.test.ts test/scripts/build-all.test.ts test/scripts/runtime-postbuild.test.ts test/scripts/runtime-postbuild-stamp.test.ts test/scripts/tsdown-config.test.ts src/infra/tsdown-config.test.ts src/infra/run-node.test.ts src/infra/control-ui-assets.test.ts
```

```bash
node scripts/check-changed.mjs -- scripts/tsdown-build.mts src/infra/run-node.test.ts test/scripts/tsdown-build.test.ts docs/start/setup.md
```

```bash
pnpm build
```

```bash
pnpm openclaw --version
```

```bash
git diff --check
```

AI-assisted; implementation, cleanup ownership, history, dependency behavior, and proof reviewed.
