### PR TITLE
fix(test): synchronize descendant watchdog readiness

### DIFF
--- a/test/helpers/process-wait.test.ts
+++ b/test/helpers/process-wait.test.ts
@@ -1,6 +1,9 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
 import fsSync from "node:fs";
 import { afterEach, expect, it, vi } from "vitest";
-import { waitForDead } from "./process-wait.js";
+import { isProcessAlive, waitForChildClose, waitForDead } from "./process-wait.js";
+import { withTestTimeout } from "./promise.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -17,4 +20,83 @@ it("stops waiting when a Linux process is a zombie", async () => {
   });
 
   await expect(waitForDead(42, 20)).resolves.toBeUndefined();
+});
+
+it("rejects when the process remains alive at the deadline", async () => {
+  await expect(waitForDead(process.pid, 20)).rejects.toThrow(`process still alive: ${process.pid}`);
+});
+
+it("rechecks process death after a worker stall crosses the polling deadline", async () => {
+  // A separate controller can reap the real child while this worker is stalled.
+  const controller = spawn(
+    process.execPath,
+    [
+      "-e",
+      `
+const { spawn } = require('node:child_process');
+const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000); process.send(process.pid);'], {
+  stdio: ['ignore', 'ignore', 'ignore', 'ipc'],
+});
+process.on('message', () => child.kill('SIGKILL'));
+child.once('message', pid => process.send(pid));
+child.once('close', (_code, signal) => {
+  if (signal !== 'SIGKILL') throw new Error('child was not killed');
+  process.disconnect();
+});
+`,
+    ],
+    { stdio: ["ignore", "ignore", "ignore", "ipc"] },
+  );
+  const closed = waitForChildClose(controller);
+  const nativeKill = process.kill.bind(process);
+  let childPid: number | undefined;
+  try {
+    const [pid] = await withTestTimeout(once(controller, "message"), 2_000, "child not ready");
+    if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) {
+      throw new Error("child did not publish a valid PID");
+    }
+    childPid = pid;
+    let observedAlive = false;
+    const killSpy = vi.spyOn(process, "kill").mockImplementation((target, signal) => {
+      const result = nativeKill(target, signal);
+      if (target === childPid && signal === 0 && !observedAlive) {
+        observedAlive = true;
+        controller.send("kill");
+        // Preserve the real live observation, but delay the next poll past its deadline.
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 2_100);
+      }
+      return result;
+    });
+    let waitError: unknown;
+    try {
+      await waitForDead(childPid, 2_000);
+    } catch (error) {
+      waitError = error;
+    } finally {
+      killSpy.mockRestore();
+    }
+    expect(observedAlive).toBe(true);
+    expect(() => nativeKill(pid, 0)).toThrow(expect.objectContaining({ code: "ESRCH" }));
+    expect(waitError).toBeUndefined();
+    await expect(closed).resolves.toEqual({ code: 0, signal: null });
+  } finally {
+    try {
+      if (controller.connected) {
+        controller.send("kill");
+      }
+      await closed;
+    } finally {
+      try {
+        if (controller.pid && isProcessAlive(controller.pid)) {
+          controller.kill("SIGKILL");
+          await waitForDead(controller.pid, 2_000);
+        }
+      } finally {
+        if (childPid !== undefined && isProcessAlive(childPid)) {
+          process.kill(childPid, "SIGKILL");
+          await waitForDead(childPid, 2_000);
+        }
+      }
+    }
+  }
 });

--- a/test/helpers/process-wait.ts
+++ b/test/helpers/process-wait.ts
@@ -44,7 +44,10 @@ export async function waitForDead(pid: number, timeoutMs: number): Promise<void>
     }
     await sleep(5);
   }
-  throw new Error(`process still alive: ${pid}`);
+  // A delayed worker wake can outlive both the deadline and the process.
+  if (isPidAlive(pid)) {
+    throw new Error(`process still alive: ${pid}`);
+  }
 }
 
 export function waitForChildClose(

--- a/test/helpers/process-watchdog.ts
+++ b/test/helpers/process-watchdog.ts
@@ -1,0 +1,22 @@
+import { vi } from "vitest";
+import { createDeferred } from "./promise.js";
+
+export function startProcessWatchdogFixture<T>(start: () => Promise<T>) {
+  const ready = createDeferred();
+  const schedule = globalThis.setTimeout;
+  // Release only after a child-owned PID confirms its signal handlers are installed.
+  // Gate only the initial watchdog, returning its native handle. Restore before
+  // yielding so readiness polling, grace timers, and concurrent tests stay real.
+  const timeoutSpy = vi
+    .spyOn(globalThis, "setTimeout")
+    .mockImplementationOnce((callback, ms, ...args) =>
+      schedule(() => {
+        void ready.promise.then(() => callback(...args));
+      }, ms),
+    );
+  try {
+    return { runPromise: start(), releaseTimeout: ready.resolve };
+  } finally {
+    timeoutSpy.mockRestore();
+  }
+}

--- a/test/scripts/managed-child-process.test.ts
+++ b/test/scripts/managed-child-process.test.ts
@@ -13,6 +13,8 @@ import {
   terminateManagedChild,
   waitForManagedProcessGroupExit,
 } from "../../scripts/lib/managed-child-process.mts";
+import { waitForDead, waitForPidFile } from "../helpers/process-wait.js";
+import { startProcessWatchdogFixture } from "../helpers/process-watchdog.js";
 import { createScriptTestHarness } from "./test-helpers.js";
 
 const { createTempDir } = createScriptTestHarness();
@@ -447,47 +449,65 @@ describe("managed-child-process", () => {
 import { spawn } from "node:child_process";
 import fs from "node:fs";
 
+process.on("SIGTERM", () => {});
+setInterval(() => {}, 1_000);
 spawn(process.execPath, [
   "-e",
   ${JSON.stringify(`
 const fs = require("node:fs");
 process.on("SIGTERM", () => {});
-setTimeout(() => process.exit(0), 5_000);
 setInterval(() => {}, 1000);
 ${publishReadyPidScript(1)}
 `)},
   process.argv[3],
 ], { stdio: "ignore" });
-process.on("SIGTERM", () => {});
-setInterval(() => {}, 1_000);
 ${publishReadyPidScript(2)}
 `,
       "utf8",
     );
 
+    const run = startProcessWatchdogFixture(() =>
+      runManagedCommand({
+        bin: process.execPath,
+        args: [childPath, childPidPath, descendantPidPath],
+        shell: false,
+        stdio: "ignore",
+        timeoutMs: 500,
+      }),
+    );
+    const timeoutAssertion = expect(run.runPromise).rejects.toMatchObject({ code: "ETIMEDOUT" });
+    const killSpy = vi.spyOn(process, "kill");
     let childPid = 0;
     let descendantPid = 0;
     try {
-      await expect(
-        runManagedCommand({
-          bin: process.execPath,
-          args: [childPath, childPidPath, descendantPidPath],
-          shell: false,
-          stdio: "ignore",
-          timeoutMs: 500,
-        }),
-      ).rejects.toMatchObject({ code: "ETIMEDOUT" });
-
-      childPid = Number(fs.readFileSync(childPidPath, "utf8"));
-      descendantPid = Number(fs.readFileSync(descendantPidPath, "utf8"));
+      childPid = await waitForPidFile(childPidPath, 2_000);
+      descendantPid = await waitForPidFile(descendantPidPath, 2_000);
+      expect(isProcessAlive(childPid)).toBe(true);
+      expect(isProcessAlive(descendantPid)).toBe(true);
+      run.releaseTimeout();
+      await timeoutAssertion;
+      if (process.platform !== "win32") {
+        expect(killSpy).toHaveBeenCalledWith(-childPid, "SIGKILL");
+      }
       expect(isProcessAlive(childPid)).toBe(false);
       expect(isProcessAlive(descendantPid)).toBe(false);
     } finally {
-      if (childPid && isProcessAlive(childPid)) {
-        process.kill(childPid, "SIGKILL");
-      }
-      if (descendantPid && isProcessAlive(descendantPid)) {
-        process.kill(descendantPid, "SIGKILL");
+      run.releaseTimeout();
+      try {
+        await timeoutAssertion;
+      } finally {
+        killSpy.mockRestore();
+        try {
+          if (childPid && isProcessAlive(childPid)) {
+            process.kill(childPid, "SIGKILL");
+            await waitForDead(childPid, 2_000);
+          }
+        } finally {
+          if (descendantPid && isProcessAlive(descendantPid)) {
+            process.kill(descendantPid, "SIGKILL");
+            await waitForDead(descendantPid, 2_000);
+          }
+        }
       }
     }
   });

--- a/test/scripts/resolve-openclaw-package-candidate.test.ts
+++ b/test/scripts/resolve-openclaw-package-candidate.test.ts
@@ -1,12 +1,12 @@
 // Resolve Openclaw Package Candidate tests cover resolve openclaw package candidate script behavior.
 import { execFile, spawn } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { access, chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { toErrorObject as toLintErrorObject } from "@openclaw/normalization-core/error-coercion";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   assertExpectedSha256ForTest,
   cleanupPackageSourceWorktreeForTest,
@@ -23,6 +23,13 @@ import {
   runCommandForTest,
   validateOpenClawPackageSpec,
 } from "../../scripts/resolve-openclaw-package-candidate.mts";
+import {
+  isProcessAlive,
+  waitForChildClose,
+  waitForDead,
+  waitForPidFile,
+} from "../helpers/process-wait.js";
+import { startProcessWatchdogFixture } from "../helpers/process-watchdog.js";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const tempDirs: string[] = [];
@@ -136,63 +143,6 @@ async function withArtifactFixtureCommands<T>(
     delete process.env.FAKE_GIT_LOG;
     delete process.env.FAKE_NODE_LOG;
   }
-}
-
-function isProcessAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function sleep(ms: number): Promise<void> {
-  await new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
-
-async function waitForFile(filePath: string, timeoutMs: number): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (existsSync(filePath)) {
-      return;
-    }
-    await sleep(5);
-  }
-  throw new Error(`timeout waiting for ${filePath}`);
-}
-
-async function waitForDead(pid: number, timeoutMs: number): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (!isProcessAlive(pid)) {
-      return;
-    }
-    await sleep(5);
-  }
-  throw new Error(`process still alive: ${pid}`);
-}
-
-async function waitForExit(
-  child: ReturnType<typeof spawn>,
-  timeoutMs: number,
-): Promise<{ signal: NodeJS.Signals | null; status: number | null }> {
-  return await new Promise((resolve, reject) => {
-    const timeout = setTimeout(
-      () => reject(new Error("timeout waiting for child exit")),
-      timeoutMs,
-    );
-    child.on("close", (status, signal) => {
-      clearTimeout(timeout);
-      resolve({ signal, status });
-    });
-    child.on("error", (error) => {
-      clearTimeout(timeout);
-      reject(error);
-    });
-  });
 }
 
 afterEach(async () => {
@@ -532,36 +482,44 @@ describe("resolve-openclaw-package-candidate", () => {
       return;
     }
 
-    const dir = await mkdtemp(path.join(tmpdir(), "openclaw-package-runner-timeout-"));
-    tempDirs.push(dir);
+    const dir = autoTempDirs.make("openclaw-package-runner-timeout-");
     const childPidPath = path.join(dir, "child.pid");
+    const childScript = [
+      "process.on('SIGTERM', () => {});",
+      "setInterval(() => {}, 1000);",
+      `require('node:fs').writeFileSync(${JSON.stringify(childPidPath)}, String(process.pid));`,
+    ].join("\n");
+    const parentScript = [
+      "const { spawn } = require('node:child_process');",
+      `spawn(process.execPath, ['-e', ${JSON.stringify(childScript)}], { stdio: 'ignore' });`,
+      "setInterval(() => {}, 1000);",
+    ].join("\n");
+    const run = startProcessWatchdogFixture(() =>
+      runCommandForTest(process.execPath, ["-e", parentScript], {
+        killAfterMs: 25,
+        timeoutMs: 500,
+      }),
+    );
+    const timeoutAssertion = expect(run.runPromise).rejects.toThrow(/timed out after 500ms/u);
+    const killSpy = vi.spyOn(process, "kill");
     let childPid: number | undefined;
-
     try {
-      const childScript = "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);";
-      const parentScript = [
-        "const { spawn } = require('node:child_process');",
-        "const fs = require('node:fs');",
-        `const child = spawn(process.execPath, ['-e', ${JSON.stringify(childScript)}], { stdio: 'ignore' });`,
-        "fs.writeFileSync(process.env.OPENCLAW_TEST_CHILD_PID, String(child.pid));",
-        "setInterval(() => {}, 1000);",
-      ].join("");
-
-      const timeoutAssertion = expect(
-        runCommandForTest(process.execPath, ["-e", parentScript], {
-          env: { ...process.env, OPENCLAW_TEST_CHILD_PID: childPidPath },
-          killAfterMs: 25,
-          timeoutMs: 500,
-        }),
-      ).rejects.toThrow(/timed out after 500ms/u);
-
-      await waitForFile(childPidPath, 2_000);
-      childPid = Number.parseInt(readFileSync(childPidPath, "utf8"), 10);
+      childPid = await waitForPidFile(childPidPath, 2_000);
+      expect(isProcessAlive(childPid)).toBe(true);
+      run.releaseTimeout();
       await timeoutAssertion;
+      expect(killSpy).toHaveBeenCalledWith(expect.any(Number), "SIGKILL");
       await waitForDead(childPid, 2_000);
     } finally {
-      if (childPid !== undefined && isProcessAlive(childPid)) {
-        process.kill(childPid, "SIGKILL");
+      run.releaseTimeout();
+      try {
+        await timeoutAssertion;
+      } finally {
+        killSpy.mockRestore();
+        if (childPid !== undefined && isProcessAlive(childPid)) {
+          process.kill(childPid, "SIGKILL");
+          await waitForDead(childPid, 2_000);
+        }
       }
     }
   });
@@ -571,36 +529,40 @@ describe("resolve-openclaw-package-candidate", () => {
       return;
     }
 
-    const dir = await mkdtemp(path.join(tmpdir(), "openclaw-package-runner-grace-"));
-    tempDirs.push(dir);
+    const dir = autoTempDirs.make("openclaw-package-runner-grace-");
     const childPidPath = path.join(dir, "child.pid");
     const cleanupPath = path.join(dir, "child.cleanup");
+    const childScript = [
+      "const fs = require('node:fs');",
+      "process.on('SIGTERM', () => {",
+      `  setTimeout(() => { fs.writeFileSync(${JSON.stringify(cleanupPath)}, 'clean'); process.exit(0); }, 75);`,
+      "});",
+      "setInterval(() => {}, 1000);",
+      `fs.writeFileSync(${JSON.stringify(childPidPath)}, String(process.pid));`,
+    ].join("\n");
+    const run = startProcessWatchdogFixture(() =>
+      runCommandForTest(process.execPath, ["-e", childScript], {
+        killAfterMs: Number.MAX_SAFE_INTEGER,
+        timeoutMs: 500,
+      }),
+    );
+    const timeoutAssertion = expect(run.runPromise).rejects.toThrow(/timed out after 500ms/u);
     let childPid: number | undefined;
-
     try {
-      const childScript = [
-        "const fs = require('node:fs');",
-        `fs.writeFileSync(${JSON.stringify(childPidPath)}, String(process.pid));`,
-        "process.on('SIGTERM', () => {",
-        `  setTimeout(() => { fs.writeFileSync(${JSON.stringify(cleanupPath)}, 'clean'); process.exit(0); }, 75);`,
-        "});",
-        "setInterval(() => {}, 1000);",
-      ].join("\n");
-
-      const timeoutAssertion = expect(
-        runCommandForTest(process.execPath, ["-e", childScript], {
-          killAfterMs: Number.MAX_SAFE_INTEGER,
-          timeoutMs: 500,
-        }),
-      ).rejects.toThrow(/timed out after 500ms/u);
-
-      await waitForFile(childPidPath, 2_000);
-      childPid = Number.parseInt(readFileSync(childPidPath, "utf8"), 10);
+      childPid = await waitForPidFile(childPidPath, 2_000);
+      run.releaseTimeout();
       await timeoutAssertion;
       expect(readFileSync(cleanupPath, "utf8")).toBe("clean");
+      await waitForDead(childPid, 2_000);
     } finally {
-      if (childPid !== undefined && isProcessAlive(childPid)) {
-        process.kill(childPid, "SIGKILL");
+      run.releaseTimeout();
+      try {
+        await timeoutAssertion;
+      } finally {
+        if (childPid !== undefined && isProcessAlive(childPid)) {
+          process.kill(childPid, "SIGKILL");
+          await waitForDead(childPid, 2_000);
+        }
       }
     }
   });
@@ -610,54 +572,51 @@ describe("resolve-openclaw-package-candidate", () => {
       return;
     }
 
-    const dir = await mkdtemp(path.join(tmpdir(), "openclaw-package-runner-timeout-clean-"));
-    tempDirs.push(dir);
+    const dir = autoTempDirs.make("openclaw-package-runner-timeout-clean-");
     const childPidPath = path.join(dir, "child.pid");
-    const readyPath = path.join(dir, "child.ready");
     const cleanupPath = path.join(dir, "child.cleanup");
-
     const childScript = [
       "const fs = require('node:fs');",
       "process.on('SIGTERM', () => {",
-      "  fs.writeFileSync(process.env.OPENCLAW_TEST_CHILD_CLEANUP, 'clean');",
-      "  setTimeout(() => process.exit(0), 25);",
+      "  setTimeout(() => {",
+      `    fs.writeFileSync(${JSON.stringify(cleanupPath)}, 'clean');`,
+      "    process.exit(0);",
+      "  }, 25);",
       "});",
-      "fs.writeFileSync(process.env.OPENCLAW_TEST_CHILD_READY, 'ready');",
       "setInterval(() => {}, 1000);",
-    ].join("");
+      `fs.writeFileSync(${JSON.stringify(childPidPath)}, String(process.pid));`,
+    ].join("\n");
     const parentScript = [
       "const { spawn } = require('node:child_process');",
-      "const fs = require('node:fs');",
-      `const child = spawn(process.execPath, ['-e', ${JSON.stringify(childScript)}], {`,
-      "  stdio: 'ignore',",
-      "  env: {",
-      "    ...process.env,",
-      "    OPENCLAW_TEST_CHILD_CLEANUP: process.env.OPENCLAW_TEST_CHILD_CLEANUP,",
-      "    OPENCLAW_TEST_CHILD_READY: process.env.OPENCLAW_TEST_CHILD_READY,",
-      "  },",
-      "});",
-      "fs.writeFileSync(process.env.OPENCLAW_TEST_CHILD_PID, String(child.pid));",
       "process.on('SIGTERM', () => process.exit(0));",
+      `spawn(process.execPath, ['-e', ${JSON.stringify(childScript)}], { stdio: 'ignore' });`,
       "setInterval(() => {}, 1000);",
-    ].join("");
-
-    const timeoutAssertion = expect(
+    ].join("\n");
+    const run = startProcessWatchdogFixture(() =>
       runCommandForTest(process.execPath, ["-e", parentScript], {
-        env: {
-          ...process.env,
-          OPENCLAW_TEST_CHILD_CLEANUP: cleanupPath,
-          OPENCLAW_TEST_CHILD_PID: childPidPath,
-          OPENCLAW_TEST_CHILD_READY: readyPath,
-        },
         killAfterMs: 250,
         timeoutMs: 250,
       }),
-    ).rejects.toThrow(/timed out after 250ms/u);
-
-    await waitForFile(readyPath, 2_000);
-    await timeoutAssertion;
-
-    expect(readFileSync(cleanupPath, "utf8")).toBe("clean");
+    );
+    const timeoutAssertion = expect(run.runPromise).rejects.toThrow(/timed out after 250ms/u);
+    let childPid: number | undefined;
+    try {
+      childPid = await waitForPidFile(childPidPath, 2_000);
+      run.releaseTimeout();
+      await timeoutAssertion;
+      expect(readFileSync(cleanupPath, "utf8")).toBe("clean");
+      await waitForDead(childPid, 2_000);
+    } finally {
+      run.releaseTimeout();
+      try {
+        await timeoutAssertion;
+      } finally {
+        if (childPid !== undefined && isProcessAlive(childPid)) {
+          process.kill(childPid, "SIGKILL");
+          await waitForDead(childPid, 2_000);
+        }
+      }
+    }
   });
 
   it("forwards external termination to package runner process groups", async () => {
@@ -665,52 +624,66 @@ describe("resolve-openclaw-package-candidate", () => {
       return;
     }
 
-    const dir = await mkdtemp(path.join(tmpdir(), "openclaw-package-runner-signal-"));
-    tempDirs.push(dir);
+    const dir = autoTempDirs.make("openclaw-package-runner-signal-");
     const childPidPath = path.join(dir, "child.pid");
+    const killPath = path.join(dir, "child.kill");
     const scriptUrl = pathToFileURL(
       path.resolve("scripts/resolve-openclaw-package-candidate.mts"),
     ).href;
+    const childScript = [
+      "process.on('SIGTERM', () => {});",
+      "setInterval(() => {}, 1000);",
+      `require('node:fs').writeFileSync(${JSON.stringify(childPidPath)}, String(process.pid));`,
+    ].join("\n");
+    const parentScript = [
+      "const { spawn } = require('node:child_process');",
+      `spawn(process.execPath, ['-e', ${JSON.stringify(childScript)}], { stdio: 'ignore' });`,
+      "setInterval(() => {}, 1000);",
+    ].join("\n");
+    const runnerScript = [
+      "import fs from 'node:fs';",
+      "const kill = process.kill.bind(process);",
+      "process.kill = (pid, signal) => {",
+      "  const result = kill(pid, signal);",
+      `  if (signal === 'SIGKILL') fs.writeFileSync(${JSON.stringify(killPath)}, signal);`,
+      "  return result;",
+      "};",
+      `const { runCommandForTest } = await import(${JSON.stringify(scriptUrl)});`,
+      `await runCommandForTest(process.execPath, ['-e', ${JSON.stringify(parentScript)}], { timeoutMs: 60000 });`,
+    ].join("\n");
+    const runner = spawn(process.execPath, ["--input-type=module", "-e", runnerScript], {
+      cwd: process.cwd(),
+      stdio: ["ignore", "ignore", "pipe"],
+    });
     let childPid: number | undefined;
-    let runnerPid: number | undefined;
-
     try {
-      const childScript = "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);";
-      const parentScript = [
-        "const { spawn } = require('node:child_process');",
-        "const fs = require('node:fs');",
-        `const child = spawn(process.execPath, ['-e', ${JSON.stringify(childScript)}], { stdio: 'ignore' });`,
-        "fs.writeFileSync(process.env.OPENCLAW_TEST_CHILD_PID, String(child.pid));",
-        "setInterval(() => {}, 1000);",
-      ].join("");
-      // Accelerate only the module-level 5s forwarded-signal failsafe in this disposable runner.
-      const runnerScript = [
-        "const realSetTimeout = globalThis.setTimeout;",
-        "globalThis.setTimeout = (callback, delay, ...args) =>",
-        "  realSetTimeout(callback, delay === 5000 ? 25 : delay, ...args);",
-        `const { runCommandForTest } = await import(${JSON.stringify(scriptUrl)});`,
-        `await runCommandForTest(process.execPath, ['-e', ${JSON.stringify(parentScript)}], { timeoutMs: 60000 });`,
-      ].join("\n");
-      const runner = spawn(process.execPath, ["--input-type=module", "-e", runnerScript], {
-        cwd: process.cwd(),
-        env: { ...process.env, OPENCLAW_TEST_CHILD_PID: childPidPath },
-        stdio: ["ignore", "ignore", "pipe"],
-      });
-      runnerPid = runner.pid;
-
-      await waitForFile(childPidPath, 2_000);
-      childPid = Number.parseInt(readFileSync(childPidPath, "utf8"), 10);
+      childPid = await waitForPidFile(childPidPath, 2_000);
+      expect(isProcessAlive(childPid)).toBe(true);
+      const closed = waitForChildClose(runner, 7_000);
       runner.kill("SIGTERM");
-      const result = await waitForExit(runner, 7_000);
-
-      expect(result).toEqual({ signal: null, status: 143 });
+      await expect(closed).resolves.toEqual({ signal: null, code: 143 });
+      expect(readFileSync(killPath, "utf8")).toBe("SIGKILL");
       await waitForDead(childPid, 2_000);
     } finally {
-      if (runnerPid !== undefined && isProcessAlive(runnerPid)) {
-        process.kill(runnerPid, "SIGKILL");
-      }
-      if (childPid !== undefined && isProcessAlive(childPid)) {
-        process.kill(childPid, "SIGKILL");
+      try {
+        if (runner.pid && isProcessAlive(runner.pid)) {
+          const closed = waitForChildClose(runner, 7_000);
+          // Let the runner clean its detached group even if readiness failed.
+          runner.kill("SIGTERM");
+          try {
+            await closed;
+          } finally {
+            if (isProcessAlive(runner.pid)) {
+              runner.kill("SIGKILL");
+              await waitForDead(runner.pid, 2_000);
+            }
+          }
+        }
+      } finally {
+        if (childPid !== undefined && isProcessAlive(childPid)) {
+          process.kill(childPid, "SIGKILL");
+          await waitForDead(childPid, 2_000);
+        }
       }
     }
   });

--- a/test/scripts/test-group-report.test.ts
+++ b/test/scripts/test-group-report.test.ts
@@ -25,6 +25,14 @@ import {
   spawnText,
 } from "../../scripts/test-group-report.mts";
 import { withEnv } from "../../src/test-utils/env.js";
+import {
+  isProcessAlive,
+  waitForChildClose,
+  waitForDead,
+  waitForFile,
+  waitForPidFile,
+} from "../helpers/process-wait.js";
+import { startProcessWatchdogFixture } from "../helpers/process-watchdog.js";
 import { cleanupTempDirs, makeTempDir } from "../helpers/temp-dir.js";
 
 const tempDirs = new Set<string>();
@@ -33,58 +41,6 @@ const tsxImport = import.meta.resolve("tsx");
 afterAll(() => {
   cleanupTempDirs(tempDirs);
 });
-
-function isProcessAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function sleep(ms: number): Promise<void> {
-  await new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
-
-async function waitForFile(filePath: string, timeoutMs: number): Promise<void> {
-  const deadlineAt = Date.now() + timeoutMs;
-  while (Date.now() < deadlineAt) {
-    if (fs.existsSync(filePath)) {
-      return;
-    }
-    await sleep(5);
-  }
-  throw new Error(`timed out waiting for ${filePath}`);
-}
-
-async function waitForDead(pid: number, timeoutMs: number): Promise<void> {
-  const deadlineAt = Date.now() + timeoutMs;
-  while (Date.now() < deadlineAt) {
-    if (!isProcessAlive(pid)) {
-      return;
-    }
-    await sleep(5);
-  }
-  throw new Error(`timed out waiting for pid ${pid} to exit`);
-}
-
-function waitForChildClose(
-  child: ReturnType<typeof spawn>,
-  timeoutMs = 5_000,
-): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
-  return new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      reject(new Error("child did not close before timeout"));
-    }, timeoutMs);
-    child.once("close", (code, signal) => {
-      clearTimeout(timeout);
-      resolve({ code, signal });
-    });
-  });
-}
 
 function writeGroupedReport(filePath: string) {
   fs.writeFileSync(
@@ -1140,40 +1096,38 @@ describe("scripts/test-group-report child process guard", () => {
 
     const tempDir = makeTempDir(tempDirs, "openclaw-test-group-report-");
     const childPidPath = path.join(tempDir, "child.pid");
-    const readyPath = path.join(tempDir, "child.ready");
     const cleanupPath = path.join(tempDir, "child.cleanup");
-    let childPid: number | undefined;
-    try {
-      const childScript = [
-        "const fs = require('node:fs');",
-        `fs.writeFileSync(${JSON.stringify(childPidPath)}, String(process.pid));`,
-        "process.on('SIGTERM', () => {",
-        "  setTimeout(() => {",
-        `    fs.writeFileSync(${JSON.stringify(cleanupPath)}, "clean");`,
-        "    process.exit(0);",
-        "  }, 25);",
-        "});",
-        `fs.writeFileSync(${JSON.stringify(readyPath)}, "ready");`,
-        "setInterval(() => {}, 1000);",
-      ].join("\n");
-      const parentScript = [
-        "const { spawn } = require('node:child_process');",
-        `spawn(process.execPath, ["--eval", ${JSON.stringify(childScript)}], { stdio: "ignore" });`,
-        "process.on('SIGTERM', () => process.exit(0));",
-        "setInterval(() => {}, 1000);",
-      ].join("\n");
-
-      const startedAt = Date.now();
-      const runPromise = spawnText(process.execPath, ["--eval", parentScript], {
+    const childScript = [
+      "const fs = require('node:fs');",
+      "process.on('SIGTERM', () => {",
+      "  setTimeout(() => {",
+      `    fs.writeFileSync(${JSON.stringify(cleanupPath)}, "clean");`,
+      "    process.exit(0);",
+      "  }, 25);",
+      "});",
+      "setInterval(() => {}, 1000);",
+      `fs.writeFileSync(${JSON.stringify(childPidPath)}, String(process.pid));`,
+    ].join("\n");
+    const parentScript = [
+      "const { spawn } = require('node:child_process');",
+      "process.on('SIGTERM', () => process.exit(0));",
+      `spawn(process.execPath, ["--eval", ${JSON.stringify(childScript)}], { stdio: "ignore" });`,
+      "setInterval(() => {}, 1000);",
+    ].join("\n");
+    const run = startProcessWatchdogFixture(() =>
+      spawnText(process.execPath, ["--eval", parentScript], {
         cwd: process.cwd(),
         env: process.env,
         killGraceMs: 250,
         timeoutMs: 250,
-      });
-
-      await waitForFile(readyPath, 2_000);
-      childPid = Number.parseInt(fs.readFileSync(childPidPath, "utf8"), 10);
-      const result = await runPromise;
+      }),
+    );
+    let childPid: number | undefined;
+    try {
+      childPid = await waitForPidFile(childPidPath, 2_000);
+      const startedAt = Date.now();
+      run.releaseTimeout();
+      const result = await run.runPromise;
 
       expect(result).toMatchObject({
         status: 1,
@@ -1184,10 +1138,15 @@ describe("scripts/test-group-report child process guard", () => {
       expect(Date.now() - startedAt).toBeLessThan(900);
       await waitForDead(childPid, 2_000);
     } finally {
-      if (childPid !== undefined && isProcessAlive(childPid)) {
-        process.kill(childPid, "SIGKILL");
+      run.releaseTimeout();
+      try {
+        await run.runPromise;
+      } finally {
+        if (childPid !== undefined && isProcessAlive(childPid)) {
+          process.kill(childPid, "SIGKILL");
+          await waitForDead(childPid, 2_000);
+        }
       }
-      fs.rmSync(tempDir, { recursive: true, force: true });
     }
   });
 

--- a/test/scripts/tsdown-build.test.ts
+++ b/test/scripts/tsdown-build.test.ts
@@ -28,7 +28,14 @@ import {
   resolveTsdownCleanOutputRoots,
   runTsdownBuildInvocation,
 } from "../../scripts/tsdown-build.mts";
-import { createDeferred } from "../helpers/promise.js";
+import {
+  isProcessAlive,
+  waitForChildClose,
+  waitForDead,
+  waitForFile,
+  waitForPidFile,
+} from "../helpers/process-wait.js";
+import { startProcessWatchdogFixture } from "../helpers/process-watchdog.js";
 import { createScriptTestHarness } from "./test-helpers.js";
 
 const { createTempDir } = createScriptTestHarness();
@@ -92,75 +99,6 @@ async function expectPathMissing(targetPath: string) {
     throw new Error("expected missing path error");
   }
   expect(Reflect.get(statError, "code")).toBe("ENOENT");
-}
-
-function isProcessAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function sleep(ms: number): Promise<void> {
-  await new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
-
-async function waitForFile(filePath: string, timeoutMs: number): Promise<void> {
-  const deadlineAt = Date.now() + timeoutMs;
-  while (Date.now() < deadlineAt) {
-    if (fs.existsSync(filePath)) {
-      return;
-    }
-    await sleep(5);
-  }
-  throw new Error(`timed out waiting for ${filePath}`);
-}
-
-// Pid files are written with plain writeFileSync, so an existence poll can
-// observe the open-truncate 0-byte window and parse NaN (the #109140 flake
-// class). Wait until the content parses to a real pid, not just for the file.
-async function waitForPidFile(filePath: string, timeoutMs: number): Promise<number> {
-  const deadlineAt = Date.now() + timeoutMs;
-  while (Date.now() < deadlineAt) {
-    if (fs.existsSync(filePath)) {
-      const pid = Number.parseInt(fs.readFileSync(filePath, "utf8"), 10);
-      if (Number.isInteger(pid) && pid > 0) {
-        return pid;
-      }
-    }
-    await sleep(5);
-  }
-  throw new Error(`timed out waiting for pid in ${filePath}`);
-}
-
-async function waitForDead(pid: number, timeoutMs: number): Promise<void> {
-  const deadlineAt = Date.now() + timeoutMs;
-  while (Date.now() < deadlineAt) {
-    if (!isProcessAlive(pid)) {
-      return;
-    }
-    await sleep(5);
-  }
-  throw new Error(`timed out waiting for pid ${pid} to exit`);
-}
-
-function waitForChildClose(
-  child: ReturnType<typeof spawn>,
-  timeoutMs = 5_000,
-): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
-  return new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      reject(new Error("child did not close before timeout"));
-    }, timeoutMs);
-    child.once("close", (code, signal) => {
-      clearTimeout(timeout);
-      resolve({ code, signal });
-    });
-  });
 }
 
 describe("resolveTsdownBuildInvocation", () => {
@@ -2277,44 +2215,28 @@ describe("runTsdownBuildInvocation", () => {
   }
 
   function startTimeoutFixture(parentScript: string, output: ReturnType<typeof createWriteSink>) {
-    const ready = createDeferred();
-    const schedule = globalThis.setTimeout;
-    // Keep the real watchdog delay, but hold its callback until the child is ready.
-    // Restore before yielding so grace and process-group polling use real timers.
-    const timeoutSpy = vi
-      .spyOn(globalThis, "setTimeout")
-      .mockImplementation((callback, ms, ...args) =>
-        schedule(() => {
-          void ready.promise.then(() => callback(...args));
-        }, ms),
-      );
-    try {
-      return {
-        runPromise: runTsdownBuildInvocation(
-          {
-            command: process.execPath,
-            args: ["-e", parentScript],
-            options: {
-              stdio: ["ignore", "pipe", "pipe"],
-              shell: false,
-              env: process.env,
-            },
+    return startProcessWatchdogFixture(() =>
+      runTsdownBuildInvocation(
+        {
+          command: process.execPath,
+          args: ["-e", parentScript],
+          options: {
+            stdio: ["ignore", "pipe", "pipe"],
+            shell: false,
+            env: process.env,
           },
-          {
-            stdout: output.sink,
-            stderr: output.sink,
-            env: {
-              ...process.env,
-              OPENCLAW_TSDOWN_HEARTBEAT_MS: "0",
-              OPENCLAW_TSDOWN_TIMEOUT_MS: "250",
-            },
+        },
+        {
+          stdout: output.sink,
+          stderr: output.sink,
+          env: {
+            ...process.env,
+            OPENCLAW_TSDOWN_HEARTBEAT_MS: "0",
+            OPENCLAW_TSDOWN_TIMEOUT_MS: "250",
           },
-        ),
-        releaseTimeout: ready.resolve,
-      };
-    } finally {
-      timeoutSpy.mockRestore();
-    }
+        },
+      ),
+    );
   }
 
   it("streams child output while preserving diagnostics for post-run checks", async () => {


### PR DESCRIPTION
Related: #130653 (seven-day dependency refresh, including the analogous tsdown readiness repair).

## What Problem This Solves

Resolves unreliable descendant-cleanup tests when a real watchdog fires before a subprocess installs its signal handler or publishes its PID. Parent-written PIDs and existence-only PID polling could also let stubborn-child cases pass without exercising SIGKILL.

The investigation additionally reproduced a false failure in the shared death-wait helper: after a worker stall crossed its deadline, it could report a process as still alive from an older observation even though a real controller had already killed and reaped it and native kill-zero returned ESRCH.

## Why This Change Was Made

Readiness is now published by the child after handler/keepalive installation. The fixtures use the existing PID-content wait helper and one shared version of the already-landed tsdown watchdog gate. Only the initial watchdog callback waits for readiness; interception is restored synchronously before yielding. Native watchdog delays, grace timers, polling intervals, process signals, and existing cleanup/escalation assertions remain real.

The same pattern repairs the independently failing managed-command fixture. Both child and descendant readiness are observed before releasing its unchanged 500 ms watchdog; its alternate self-expiry is removed so it cannot substitute for SIGKILL. Stubborn cases verify real force-kill and death, and failure paths release, join, and clean up their owned processes.

The shared death-wait helper now makes one fresh terminal liveness observation before reporting failure, matching the existing production process-group wait pattern. A real-process regression failed before this change and passed after it; a live-worker countercheck ensures genuinely live processes still reject. Duplicate process-wait implementations and the obsolete forwarded-signal timer override are removed. The standalone wrapper-lifetime test and existing tsdown timeout test bodies remain intact.

Production LOC: +0/-0. Tests: +343/-387; test support: +26/-1 (total +369/-388, net -19). The reduction comes from consolidating helpers, not deleting test cases. No dependency, production runtime, timeout budget, retry policy, or skip changes.

## User Impact

No application or configuration behavior changes. Maintainers get process-cleanup tests that synchronize on actual readiness, exercise real escalation, and do not report a stale liveness observation as current failure.

AI-assisted. Complete affected owners, callers, sibling tests, relevant history, and installed Node/Vitest timer contracts were inspected. No operator services were modified.

## Evidence

- Original focused baseline: 13 passed, two grace fixtures failed. Independent real-process probes demonstrated the handler-readiness races, package tests passing without a live-target SIGKILL, and an empty PID file falsely satisfying the old death wait.
- Initial repair: all 15 focused cases passed with `node scripts/run-vitest.mjs test/scripts/test-group-report.test.ts test/scripts/resolve-openclaw-package-candidate.test.ts -t 'child process guard|package runner|captured command|captured stdout' --reporter=verbose`.
- Five disposable copies of the actual repaired fixtures passed with a 650 ms pre-handler delay, beyond the unchanged 250/500 ms watchdogs, plus the two established tsdown timeout cases (seven total). The disposable 650 ms bootstrap-delay instrumentation is not part of the PR.
- A separate full diagnostic exposed managed-command ETIMEDOUT followed by missing `child.pid` after its 500 ms watchdog. The repaired managed fixture passed with both ready PIDs observed, real group SIGKILL recorded, and both PIDs reaching native ESRCH.
- The new stale-death regression failed on the original helper after its independent native-ESRCH assertion passed. It then passed after the fresh terminal observation. A separate controller performs real SIGKILL and reaping while the worker is stalled across the unchanged 2000 ms deadline; no liveness value or termination result is fabricated.
- The single naturally required post-repair full run passed **281 tests in five files** on Node 24.20.0/libuv 1.52.1, in the explicit order managed-child → process-wait → report → package-candidate → tsdown. It retained `isolate:false`, one worker, existing concurrent partitions, and inherited resets. This is labeled order-stress proof, not a replay of the lost original order.
- The subsequently added live-worker rejection countercheck passed, along with the zombie and real stale-death cases (all three helper cases).
- `node scripts/check-changed.mjs -- test/helpers/process-watchdog.ts test/helpers/process-wait.ts test/helpers/process-wait.test.ts test/scripts/test-group-report.test.ts test/scripts/resolve-openclaw-package-candidate.test.ts test/scripts/tsdown-build.test.ts test/scripts/managed-child-process.test.ts` passed all selected guards, formatting, test-root type checking, and script lint.
- Fresh Codex autoreview reported no accepted/actionable P0 findings. `git diff --check` passed. All production files remain unchanged.

### Current-head macOS proof and local timing limits

Exact-head [CI run 33143590287, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33143590287) passed on `4edb19c95d5c58b266c73f9915b758bbdaee5b51`, without reruns. Its Node coverage is Linux.

The one planned native macOS comparison on that same head passed **282/282 tests, zero failed/skipped/todo, with `--retry=0`**, in 13.50 seconds. Crabbox provider: `ssh`; static lease: `static_pr131481_4edb19c95d5c`; test run: `run_83e512e2214e` (no hosted run URL). Actual execution was Darwin arm64, Node 24.20.0/libuv 1.52.1, pnpm 11.22.0 and Vitest 4.1.11; Mach-O architecture and `sysctl.proc_translated=0` verified native execution. Dependencies were installed with the frozen lockfile in a task-owned workspace.

The comparison imported the repository's tooling config unchanged and overrode only `test.sequence.sequencer`, preserving the recorded failing order: tsdown → report → package-candidate → helper → managed. Resolved settings remained `isolate:false`, the existing non-isolated runner/setup, one worker, concurrency five, and all original timer/reset behavior. No transforms, preloads, extra resets, source edits, or deadline changes were used. Command: `node scripts/run-vitest.mjs run --config .artifacts/macos-comparison/fixed-order.config.mts --configLoader runner test/scripts/tsdown-build.test.ts test/scripts/test-group-report.test.ts test/scripts/resolve-openclaw-package-candidate.test.ts test/helpers/process-wait.test.ts test/scripts/managed-child-process.test.ts --retry=0 --reporter=verbose --reporter=json --outputFile=.artifacts/macos-comparison/evidence/test-results.json`.

Both previously failing tsdown cases passed: graceful cleanup in about 340 ms and external-SIGTERM descendant cleanup in about 287 ms. The result JSON and order record were independently inspected; all 15 recorded source/package/config/runner hashes matched before and after execution and the local reviewed head. Task processes were gone, the workspace was removed, and the static lease was released without cleanup signals or service changes.

This is a fixed-order environment comparison, not the ordinary unmodified-config command or a causal reconstruction. The alternate Mac had load around 4.3 on 16 CPUs, 39–40% memory free, four swap-ins and no swap-outs during the run; it was not idle or swap-free. Both hosts ran macOS 27.0/Darwin 27.0.0, but OS builds differed (26A5368g versus 26A5416b). Hardware, fresh dependencies/cache, `CI=1`, and isolated HOME/temp paths also differed.

A subsequent ordinary repository run on that same head, with Node 24.20.0/libuv 1.52.1 on Darwin arm64, finished **280 passed / 2 failed / 0 skipped**. It used `node scripts/run-vitest.mjs test/scripts/managed-child-process.test.ts test/helpers/process-wait.test.ts test/scripts/test-group-report.test.ts test/scripts/resolve-openclaw-package-candidate.test.ts test/scripts/tsdown-build.test.ts --retry=0 --reporter=verbose --reporter=json --outputFile=.artifacts/descendant-final-standard-results.json`, without a diagnostic config or preload. Actual execution order was tsdown → report → package-candidate → helper → managed. Tsdown failed on a missing graceful-cleanup marker and on the unchanged two-second startup-readiness deadline before external SIGTERM. All other selected cases passed, and an exact-fixture-marker process scan found no remaining owned Node processes.

The original host measured load averages around 200 on 32 logical CPUs with no swapping. This is an environment concern, **not a proven explanation** for those failures. The ordinary failure remains recorded; the single fixed-order comparison supplies independent native macOS proof without a local retry-to-green, deadline increase, assertion weakening, or operator-service change. The landing judgment is limited to the independently reproduced and repaired readiness/stale-observation defects, with the historical timing causes left unattributed.

### Historical observation and diagnostic limits

The initial broader run passed 279/280 and reported a two-second descendant-death timeout in the existing tsdown external-SIGTERM case. Its exact original worker order/runtime/PID state was not captured, so its precise cause remains unattributed. The independently reproduced stale-helper defect is not presented as a proven reconstruction of that historical occurrence.

A subsequent instrumented run observed the same-identity runnable descendant reaching ESRCH about 87 ms after runner close, without mock divergence or a zombie. The post-repair 281-test run observed the final tsdown descendant already ESRCH at close. These are actual process-state observations, not owner-side group-signal receipts.

An additional focused cold-cache diagnostic proved that its explicit owner preload ran, but the tsdown case then missed its unchanged two-second startup-readiness deadline before external SIGTERM was sent. That collection was **three helper passes / one startup failure** and is inconclusive for the intended owner TERM/KILL telemetry; it is not counted as passing termination proof. No deadline was widened, test retried for green, environment sanitation weakened, or speculative production drain/zombie repair added. The scoped repair now has independent red/green regressions, passing shared-worker proof, green exact-head CI, and the single fixed-order native macOS comparison above. The ordinary-run failures and incomplete owner-side diagnostic telemetry remain explicit; neither is claimed to have been causally reconstructed.

Separate follow-up: package-runner import-time signal-listener lifecycle. It is not used as an explanation for the fresh tsdown subprocess observation and is outside this test-only change.

