### PR TITLE
test(gateway-client): drain TLS sockets without polling

### DIFF
--- a/packages/gateway-client/src/client.tls.test.ts
+++ b/packages/gateway-client/src/client.tls.test.ts
@@ -18,15 +18,33 @@ import { GatewayClient, type GatewayClientCloseInfo } from "./client.js";
 const fingerprint = new X509Certificate(TEST_TLS_CERT_PEM).fingerprint256;
 const servers: Server[] = [];
 const sockets = new Set<Socket>();
+let socketDrain = createDeferred();
 const clients: GatewayClient[] = [];
 let proxy: ProxylineHandle | undefined;
 
+function trackSocket(socket: Socket) {
+  if (sockets.size === 0) {
+    socketDrain = createDeferred();
+  }
+  sockets.add(socket);
+  socket.once("close", () => {
+    sockets.delete(socket);
+    if (sockets.size === 0) {
+      socketDrain.resolve();
+    }
+  });
+}
+
+async function waitForSocketDrain() {
+  // Recheck after waking: a new accepted socket can start another drain generation.
+  while (sockets.size > 0) {
+    await socketDrain.promise;
+  }
+}
+
 async function listen(server: Server): Promise<number> {
   servers.push(server);
-  server.on("connection", (socket) => {
-    sockets.add(socket);
-    socket.once("close", () => sockets.delete(socket));
-  });
+  server.on("connection", trackSocket);
   await new Promise<void>((resolve) => {
     server.listen(0, "127.0.0.1", resolve);
   });
@@ -47,6 +65,7 @@ afterEach(async () => {
       server.close(() => resolve());
     });
   }
+  await waitForSocketDrain();
 });
 
 async function startProxy(targetPort: number) {
@@ -59,8 +78,7 @@ async function startProxy(targetPort: number) {
       upstream.write(head);
       downstream.pipe(upstream).pipe(downstream);
     });
-    sockets.add(upstream);
-    upstream.once("close", () => sockets.delete(upstream));
+    trackSocket(upstream);
     downstream.on("error", () => upstream.destroy());
     upstream.on("error", () => downstream.destroy());
     downstream.once("close", () => upstream.destroy());
@@ -121,7 +139,7 @@ describe.each([false, true])("Gateway TLS upgrade (managed proxy: %s)", (managed
     client.start();
     const result = await outcome.promise;
     await client.stopAndWait();
-    await expect.poll(() => sockets.size).toBe(0);
+    await waitForSocketDrain();
     if (pin === fingerprint) {
       expect(result).toBe("open");
       expect(httpBytes).toBeGreaterThan(0);
@@ -171,7 +189,7 @@ describe.each([false, true])("Gateway TLS upgrade (managed proxy: %s)", (managed
       expect(String(await failed.promise)).toMatch(/timed out/i);
     }
     await client.stopAndWait();
-    await expect.poll(() => sockets.size).toBe(0);
+    await waitForSocketDrain();
     expect(tunnels?.() ?? 0).toBe(managed ? 1 : 0);
   });
 });

--- a/packages/gateway-client/src/client.watchdog.test.ts
+++ b/packages/gateway-client/src/client.watchdog.test.ts
@@ -203,8 +203,9 @@ describe("GatewayClient", () => {
   let httpsServer: ReturnType<typeof createHttpsServer> | null = null;
 
   afterEach(async () => {
-    vi.useRealTimers();
+    // Timer spies must restore their fake functions before the clock uninstalls them.
     vi.restoreAllMocks();
+    vi.useRealTimers();
     if (wss) {
       for (const client of wss.clients) {
         client.terminate();

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -289,6 +289,11 @@ beforeAll(async () => {
   await loadGatewayClientModule();
 });
 
+beforeEach(() => {
+  logDebugMock.mockClear();
+  logErrorMock.mockClear();
+});
+
 afterEach(() => {
   vi.useRealTimers();
 });
@@ -645,8 +650,6 @@ describe("GatewayClient request errors", () => {
   it("retries startup-unavailable connect failures without terminal callbacks", async () => {
     vi.useFakeTimers();
     wsInstances.length = 0;
-    logDebugMock.mockClear();
-    logErrorMock.mockClear();
     const onClose = vi.fn();
     const onConnectError = vi.fn();
     const client = new GatewayClient({
@@ -715,7 +718,6 @@ describe("GatewayClient close handling", () => {
     wsInstances.length = 0;
     clearDeviceAuthTokenMock.mockClear();
     clearDeviceAuthTokenMock.mockImplementation(() => undefined);
-    logDebugMock.mockClear();
   });
 
   it("clears stale token on device token mismatch close", () => {
@@ -1092,7 +1094,6 @@ describe("GatewayClient close handling", () => {
 describe("GatewayClient message dispatch", () => {
   beforeEach(() => {
     wsInstances.length = 0;
-    logDebugMock.mockClear();
   });
 
   it("keeps event callback errors inside message dispatch", () => {
@@ -1142,8 +1143,6 @@ describe("GatewayClient connect auth payload", () => {
     storeOriginDeviceTokenMock.mockReset();
     readLoggingConfigMock.mockReset();
     readLoggingConfigMock.mockReturnValue(undefined);
-    logDebugMock.mockClear();
-    logErrorMock.mockClear();
   });
 
   type ParsedConnectRequest = {


### PR DESCRIPTION
## What Problem This Solves

The real Gateway TLS tests repeatedly wait for a polling interval after their peer sockets have already closed. This adds about 0.8 seconds to the 16-case file. This is a maintainer-requested test-performance change; production behavior is unchanged.

## Why This Change Was Made

The fixture already owns every accepted socket and proxy upstream. Its real `close` callbacks now resolve a drain signal only when the tracked set is empty. Waiting rechecks the set after waking, so a new socket generation cannot escape the drain. Both validation and stalled-handshake tests still wait for their actual network outcome, then `stopAndWait()`, then peer/proxy cleanup. `afterEach` also drains after closing servers, because server-close callbacks can precede socket-close callbacks.

The required shuffled sibling run exposed an existing watchdog fixture bug on both macOS and unchanged Linux: restoring spies after restoring real timers could reinstall a frozen fake timer function. The adjacent cleanup now restores spies first. All watchdog assertions and deadlines remain unchanged. A second shuffle seed exposed stale expected error logs leaking from the auth suite into close tests. One file-level logger reset now replaces six scattered resets; all assertions are unchanged.

## User Impact

Faster, order-safe test validation. No runtime, configuration, protocol, storage, dependency, snapshot, or release changes. All real HTTPS/TLS handshakes, certificate/fingerprint validation, URL auth and edge/Expect headers, WebSocket upgrades, managed CONNECT tunnels, stalled TCP handshake timeout/cancellation, pre-hello close facts, and zero HTTP bytes on rejected validation remain covered.

## Evidence

One task-owned Blacksmith Testbox: [Linux network-scheduling proof](https://github.com/openclaw/openclaw/actions/runs/33138201535), lease `tbx_01m135mx9rq91dbq069qz1n1b1`. The wrapper result and timings establish command success; stopping an externally managed lease can mark the hosting workflow canceled.

Eight order-balanced full-file pairs (AB/BA alternating), excluded warmups, fresh module-cache path for every invocation, one Vitest worker, import diagnostics, and `/usr/bin/time -v`. Every measured invocation passed the same 16 tests. All samples, including the candidate outlier, are retained.

| Pair | Baseline wall | Candidate wall | Saved |
| --- | ---: | ---: | ---: |
| 1 | 5.98s | 5.07s | 0.91s |
| 2 | 5.95s | 4.89s | 1.06s |
| 3 | 5.90s | 5.09s | 0.81s |
| 4 | 5.86s | 4.94s | 0.92s |
| 5 | 5.84s | 6.17s | -0.33s |
| 6 | 5.96s | 5.22s | 0.74s |
| 7 | 6.06s | 5.47s | 0.59s |
| 8 | 5.95s | 5.43s | 0.52s |

| Median metric | Baseline | Candidate |
| --- | ---: | ---: |
| Wall | 5.950s | 5.155s |
| Vitest | 2.030s | 1.240s |
| Test body | 1.130s | 0.3155s |
| Imports | 0.126s | 0.1375s |
| Peak RSS | 510884 KiB | 512388 KiB |
| CPU user/system | 5.295/0.375s | 5.305/0.365s |

Median scoped wall improvement is **0.795s (13.36%)**; mean paired improvement is 0.6525s. Body times improve in every pair. The retained fifth candidate had a setup/CPU spike; no import or RSS improvement is claimed.

Benchmark command (use a distinct cache path for each invocation):

```sh
timeout 180 /usr/bin/time -v env \
  OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 \
  OPENCLAW_VITEST_MAX_WORKERS=1 \
  OPENCLAW_VITEST_IMPORT_DURATIONS=1 \
  OPENCLAW_VITEST_PRINT_IMPORT_BREAKDOWN=1 \
  OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/tls-close-sample-unique \
  pnpm test packages/gateway-client/src/client.tls.test.ts --maxWorkers=1 --reporter=verbose
```

Temporary network accounting outside measured runs independently observed **32 tracked/closed sockets, 8 CONNECT tunnels, zero remaining sockets before forced cleanup** for each variant. Two additional temporary real-TCP probes passed: socket admission while a waiter is pending and a new nonempty generation before continuation resumes.

Reversible faults were executed and restored byte-for-byte:

- Omit tracked socket removal in the close handler while keeping the empty-set condition. The managed wrong-pin case observes all three close callbacks but times out at drain at its bounded 2-second fault-test deadline; teardown also remains blocked as expected. No busy-loop starvation.
- Reverse the TLS fingerprint comparison in the transport. Both correct-pin cases fail the existing `result === "open"` assertion with a fingerprint-mismatch error.
- Restore the original bytes and rerun the full TLS file: 16/16 pass. An initial `-t` invocation was rejected by wrapper argument routing and is not counted as mutation evidence; actual faults used `--testNamePattern=...`.

The original seed-827 sibling command failed on unchanged code at the real watchdog reconnect test. With the cleanup-order repair, all **412 tests across 26 files** pass on Linux and macOS. The final three-file Linux run passes all 412 tests under each of seeds 828 and 827. The unchanged facade file separately reproduces the two seed-828 logger failures before repair (100 pass, 2 fail).

```sh
pnpm test packages/gateway-client src/gateway/client.test.ts \
  src/gateway/probe.tls.test.ts src/node-host/node-stream-transport.test.ts \
  --maxWorkers=1 --sequence.shuffle --sequence.seed=827
# Also run with --sequence.seed=828 on Linux.
pnpm check:changed -- packages/gateway-client/src/client.tls.test.ts \
  packages/gateway-client/src/client.watchdog.test.ts src/gateway/client.test.ts
```

Test audit: existing boundary tests protect cleanup, TLS validation, and reconnect behavior; leaked removal, broken validation, leaked fake timers, and stale logger history are demonstrated failures; no duplicate retained tests or test-only production seam were added. Production LOC **+0/-0**. Tests **+33/-15** (net +18). Deslop retains only two short lifecycle-order comments.

Related history: [TLS validation before upgrade](https://github.com/openclaw/openclaw/pull/131435). Named follow-ups, not included here: benchmark immutable-seed reuse in the new managed-worktree diagnostics fixture; audit timer-spy cleanup order in `event-loop-ready.test.ts` and `protocol-client.request.test.ts` (no failing consumer demonstrated in those files).

Fresh Codex autoreview found no actionable defects (supplied-bundle review; execution proof above was run separately). The complete three-file `pnpm check:changed` gate passed on Linux, including all global guards, formatting, dead-code scans, core-test typechecks, and typed lint. The Testbox was stopped after proof. Exact-head hosted CI will be recorded before landing. AI-assisted with Codex.
