### PR TITLE
fix(ui): always declare the JetBrains Mono face for code spans

### DIFF
--- a/ui/src/app/theme-fonts.test.ts
+++ b/ui/src/app/theme-fonts.test.ts
@@ -32,12 +32,14 @@ describe("typeface presentation", () => {
     ["beacon", ["atkinson-hyperlegible", "atkinson-hyperlegible"]],
     ["phosphor", ["jetbrains-mono", "jetbrains-mono"]],
     ["custom", ["system", "system"]],
-  ] as const)("loads only %s's default faces", (theme, [ui, chat]) => {
+  ] as const)("loads %s's default faces plus the shared mono face", (theme, [ui, chat]) => {
     const faces = resolveTypefaces(theme);
     expect(faces).toEqual({ ui, chat });
     syncTypefaceStylesheets(faces);
+    // The mono face is always declared: base.css --mono promises JetBrains
+    // Mono for code spans on every theme; its woff2 still downloads lazily.
     expect(hrefs()).toEqual(
-      [...new Set([ui, chat])]
+      [...new Set([ui, chat, "jetbrains-mono"])]
         .filter((face) => face !== "system")
         .map((face) => `/fonts/${face}.css`),
     );
@@ -45,11 +47,11 @@ describe("typeface presentation", () => {
 
   it("loads overrides once, retaining them without fetching for system or custom defaults", () => {
     syncTypefaceStylesheets(resolveTypefaces("dash", "system", "system"));
-    expect(hrefs()).toEqual([]);
+    expect(hrefs()).toEqual(["/fonts/jetbrains-mono.css"]);
     const faces = resolveTypefaces("dash", "geist", "lora");
     expect(faces).toEqual({ ui: "geist", chat: "lora" });
     syncTypefaceStylesheets(faces);
-    expect(hrefs()).toEqual(["/fonts/geist.css", "/fonts/lora.css"]);
+    expect(hrefs()).toEqual(["/fonts/jetbrains-mono.css", "/fonts/geist.css", "/fonts/lora.css"]);
     expect(resolveTypefaces("custom", "lora")).toEqual({ ui: "lora", chat: "system" });
     const loaded = fontLinks();
     for (const next of [

--- a/ui/src/app/typography.ts
+++ b/ui/src/app/typography.ts
@@ -89,6 +89,10 @@ export function syncTypefaceStylesheets(faces: TypefacePair): void {
   }
   loadTypefaceStylesheet(faces.ui);
   loadTypefaceStylesheet(faces.chat);
+  // base.css --mono names JetBrains Mono for every theme's code spans, but only
+  // the @font-face declaration here makes that true; the woff2 itself downloads
+  // lazily on the first rendered code glyph, so this costs one small stylesheet.
+  loadTypefaceStylesheet("jetbrains-mono");
 }
 
 export function loadTypefaceSpecimens(): void {

--- a/ui/src/e2e/theme-typography.e2e.test.ts
+++ b/ui/src/e2e/theme-typography.e2e.test.ts
@@ -170,7 +170,9 @@ suite.define(() => {
       "Stored in this browser only",
     );
     await page.evaluate(() => document.fonts.ready);
-    expect(new Set(fontRequests())).toEqual(new Set(["dm-sans.css 200", "fraunces.css 200"]));
+    expect(new Set(fontRequests())).toEqual(
+      new Set(["dm-sans.css 200", "fraunces.css 200", "jetbrains-mono.css 200"]),
+    );
     const families = () =>
       preview.evaluate((panel) => ({
         ui: getComputedStyle(panel.querySelector(".settings-typography-preview__caption")!)
@@ -289,13 +291,17 @@ suite.define(() => {
         };
       });
 
-      expect(report.linkHrefs).toEqual(faces.map((face) => `/fonts/${face}.css`));
+      // Every theme also declares the mono face: base.css --mono names
+      // JetBrains Mono for code spans regardless of the active family.
+      const expectedFaces = [...new Set([...faces, "jetbrains-mono"])];
+      expect(report.linkHrefs).toEqual(expectedFaces.map((face) => `/fonts/${face}.css`));
       expect(report.bodyFontFamily).toBe(body);
       expect(report.chatFontFamily).toBe(chat);
       // Serif chat faces opt out of the app-wide `antialiased` thinning
       // (applyChatFontSmoothing) so their hairlines stay crisp.
       expect(report.chatFontSmoothing).toBe(chatSmoothing);
-      expect(new Set(report.loaded)).toEqual(new Set([body, chat]));
+      // Mono glyphs on the page pull the always-declared JetBrains Mono face.
+      expect(new Set(report.loaded)).toEqual(new Set([body, chat, "JetBrains Mono"]));
       expect(themeRequests.every((entry) => entry.endsWith(" 200"))).toBe(true);
 
       await captureTypography(page, `${theme}-chat-dark`);


### PR DESCRIPTION
## What Problem This Solves

Code spans and blocks on six of the seven built-in themes have never rendered in JetBrains Mono, despite `--font-mono`'s stack naming it first: `base.css --mono` has listed "JetBrains Mono" since the Phosphor landing (#130232), but only Phosphor's font bundle actually declared the `@font-face`. Every other theme silently fell back to the system mono stack — a token promising a face the page never loads. The font-picker landing (#131275) documented this as a known tradeoff; this closes it.

## Why This Change Was Made

`syncTypefaceStylesheets` now declares the mono face unconditionally alongside the active interface/chat faces (one line in `ui/src/app/typography.ts`). `@font-face` semantics keep this cheap: the stylesheet itself is a ~1 KB fetch, and the woff2 downloads lazily only when a mono glyph actually renders. No startup-JS impact; the font stylesheet is outside the JS gzip ratchet.

## User Impact

Code in chat, terminals, and settings renders in actual JetBrains Mono on every theme, matching what the token has claimed all along. No visible change on Phosphor (already mono) or for users without code on screen.

## Evidence

- `theme-fonts.test.ts` 18/18: every theme's sync now links its face pair plus `jetbrains-mono.css` (deduped on Phosphor); system/custom still fetch no ui/chat face.
- `theme-typography.e2e.test.ts` 17/17 Chromium: per-theme loaded-family assertions now include JetBrains Mono (real `document.fonts` proof that the face loads when mono glyphs render).
- `check:changed` green; codex autoreview clean on the production change.
- Production delta: +4 lines (one call + invariant comment).

## Main-heal (superseded upstream)

While this PR was in flight, `main`'s core test typecheck lane broke (#131545 un-exported `startGatewayChannelFromActiveRegistry` but left its test importing it). This branch briefly carried the heal — a test rewrite against the exported `rollbackStoppedGatewayChannels` surface — but #131627 landed the equivalent fix on `main` first, so the commit was dropped and this PR is back to the 4-line mono-face change plus its test updates.