### PR TITLE
fix(tui): keep finished runs idle after reconnect

### DIFF
--- a/docs/web/tui.md
+++ b/docs/web/tui.md
@@ -226,6 +226,7 @@ Tips:
 ## History + streaming
 
 - On connect, the TUI loads the latest history (default 200 messages).
+- Reconnect and event-gap recovery reconcile active runs with history, retaining concurrent and newly observed runs without reviving runs that exact history has excluded.
 - Streaming responses update in place until finalized.
 - Messages sent to the same session from another client appear automatically.
 - The TUI also listens to agent tool events for richer tool cards.

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -729,11 +729,6 @@ export function createEventHandlers(context: EventHandlerContext) {
     tui.requestRender();
   };
 
-  // True once any event for this runId has been seen, even before sendChat
-  // resolves. Lets the optimistic-submit path know an accepted run already
-  // registered so it does not re-arm a draft the abort path would then drop.
-  const isRunObserved = (runId: string) => sessionRuns.has(runId);
-
   const reconcileHistoryAfterGap = () => {
     reduceTuiSessionProjection(state, {
       type: "transportGap",
@@ -758,7 +753,9 @@ export function createEventHandlers(context: EventHandlerContext) {
     pauseStreamingWatchdog,
     reconnectStreamingWatchdog,
     consumeCompletedRunForPendingSend: (runId: string) => completedRuns.delete(runId),
-    isRunObserved,
+    // Events can register before sendChat resolves; do not re-arm their draft.
+    isRunObserved: (runId: string) => sessionRuns.has(runId),
+    captureHistoryRunMembership: () => runCoordinator.captureHistoryRunMembership(),
     reconcileHistoryAfterGap,
     flushPendingHistoryRefreshIfIdle,
     dispose,

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -15,7 +15,7 @@ import {
   waitForSynchronizedFrameRows,
   type FixtureLogEntry,
 } from "./tui-pty-harness-fixture-test-support.js";
-import { exerciseTuiReconnectOutcomes } from "./tui-pty-reconnect-test-support.js";
+import { registerTuiReconnectTests } from "./tui-pty-reconnect-test-support.js";
 import {
   exerciseStreamingRendering,
   exerciseToolCardRendering,
@@ -247,11 +247,11 @@ describe.sequential("TUI PTY harness", () => {
     STARTUP_TEST_TIMEOUT_MS,
   );
 
-  it(
-    "reconciles active, replacement, and terminal runs after reconnect history",
-    () => exerciseTuiReconnectOutcomes(35_000),
-    45_000,
-  );
+  registerTuiReconnectTests({
+    startupTimeoutMs: STARTUP_TIMEOUT_MS,
+    testTimeoutMs: TEST_TIMEOUT_MS,
+    startupTestTimeoutMs: STARTUP_TEST_TIMEOUT_MS,
+  });
 
   it.each([{ failures: 1 }, { failures: 2 }, { failures: 3 }, { failures: 4 }])(
     "recovers session subscription after $failures startup failures",

--- a/src/tui/tui-pty-reconnect-fixture-test-support.ts
+++ b/src/tui/tui-pty-reconnect-fixture-test-support.ts
@@ -3,19 +3,37 @@ export const TUI_PTY_RECONNECT_FIXTURE = {
   variables: `
       const disconnectReason = process.env.OPENCLAW_TUI_PTY_DISCONNECT_REASON;
       const reconnectOutcome = process.env.OPENCLAW_TUI_PTY_RECONNECT_OUTCOME;
-      const replacementReconnect = reconnectOutcome === "replacement" || reconnectOutcome === "appeared";
+      const reconnectMembership = process.env.OPENCLAW_TUI_PTY_RECONNECT_MEMBERSHIP;
+      const replacementReconnect = ["replacement", "appeared", "gap"].includes(reconnectOutcome);
       let disconnectPending = disconnectReason === undefined
         ? 0
         : Number(process.env.OPENCLAW_TUI_PTY_DISCONNECT_COUNT ?? 1);
       let reconnectHistoryReady = false;
       let reconnectRunId = "run-reconnect-fixture";
+      let reconnectSessionKey = "agent:main:main";
       let replacementReconnectHistoryLoads = 0;
   `,
   disconnect: `
         emitDisconnect() {
+          if (disconnectPending === 0 && reconnectMembership) {
+            this.onEvent?.({
+              event: "chat",
+              payload: {
+                runId: "run-reconnect-replacement",
+                sessionKey: reconnectSessionKey,
+                seq: 2,
+                state: "final",
+                message: { role: "assistant", content: "PTY_REPLACEMENT_FINAL" },
+              },
+            });
+          }
           if (disconnectPending <= 0 || disconnectReason === undefined) return;
           disconnectPending -= 1;
           reconnectHistoryReady = true;
+          if (reconnectOutcome === "gap") {
+            this.onGap?.({ expected: 2, received: 3 });
+            return;
+          }
           record("disconnect");
           this.onDisconnected?.(disconnectReason);
           setTimeout(() => this.onConnected?.(), 50);
@@ -24,11 +42,13 @@ export const TUI_PTY_RECONNECT_FIXTURE = {
   sendChat: `
           if (reconnectOutcome && opts.message === "reconnect terminal proof") {
             reconnectRunId = runId;
+            reconnectSessionKey = opts.sessionKey;
             queueMicrotask(() => this.onEvent?.({
               event: "chat",
               payload: {
                 runId,
                 sessionKey: opts.sessionKey,
+                seq: 1,
                 state: "delta",
                 message: { role: "assistant", content: "PTY_RECONNECT_PARTIAL" },
               },
@@ -54,7 +74,7 @@ export const TUI_PTY_RECONNECT_FIXTURE = {
               record("replacementReconnectHistory", {
                 attempt: replacementReconnectHistoryLoads,
               });
-              if (replacementReconnectHistoryLoads > 1) {
+              if (replacementReconnectHistoryLoads > 1 && !reconnectMembership) {
                 return {
                   sessionInfo: { ...sessionEntry(sessionKey), status: "done" },
                   messages: [{ role: "assistant", content: "PTY_RECONNECT_RECOVERED" }],
@@ -63,6 +83,11 @@ export const TUI_PTY_RECONNECT_FIXTURE = {
             }
             const sessionInfo = {
               ...sessionEntry(sessionKey),
+              ...(reconnectMembership === "replacement"
+                ? { activeRunIds: ["run-reconnect-replacement"] }
+                : reconnectMembership === "concurrent"
+                  ? { activeRunIds: [reconnectRunId, "run-reconnect-replacement"] }
+                  : {}),
               ...(reconnectOutcome === "interrupted"
                 ? { status: "killed", abortedLastRun: true }
                 : reconnectOutcome === "failed"

--- a/src/tui/tui-pty-reconnect-test-support.ts
+++ b/src/tui/tui-pty-reconnect-test-support.ts
@@ -1,4 +1,4 @@
-import { expect } from "vitest";
+import { expect, it } from "vitest";
 import { sleep } from "../utils/sleep.js";
 import {
   startTuiFixture,
@@ -12,7 +12,55 @@ const RECONNECT_CASES = [
   { outcome: "active", marker: "PTY_RECONNECT_PARTIAL", activity: "streaming" },
 ] as const;
 
-export async function exerciseTuiReconnectOutcomes(timeoutMs: number): Promise<void> {
+export function registerTuiReconnectTests(timeouts: {
+  startupTimeoutMs: number;
+  testTimeoutMs: number;
+  startupTestTimeoutMs: number;
+}): void {
+  it(
+    "reconciles active, replacement, and terminal runs after reconnect history",
+    () => exerciseTuiReconnectOutcomes(35_000),
+    45_000,
+  );
+  it.each(
+    ["reconnect", "gap"].flatMap((recovery) => [
+      { recovery, membership: "replacement", activity: "idle" },
+      { recovery, membership: "concurrent", activity: "running" },
+      { recovery, membership: "unknown", activity: "running" },
+    ]),
+  )(
+    "reconciles $membership run membership before a replacement finishes after $recovery",
+    async ({ recovery, membership, activity }) => {
+      const fixture = await startTuiFixture({
+        env: {
+          OPENCLAW_TUI_PTY_DISCONNECT_REASON: "fixture transport loss",
+          OPENCLAW_TUI_PTY_RECONNECT_OUTCOME: recovery === "gap" ? "gap" : "replacement",
+          OPENCLAW_TUI_PTY_RECONNECT_MEMBERSHIP: membership,
+        },
+      });
+      try {
+        await fixture.run.waitForOutput("local ready", timeouts.startupTimeoutMs);
+        await fixture.run.write("reconnect terminal proof\r", { delay: false });
+        await fixture.run.waitForOutput("PTY_RECONNECT_PARTIAL", timeouts.testTimeoutMs);
+        await fixture.run.write("/gateway-status\r", { delay: false });
+        await fixture.run.waitForOutput("PTY_RECONNECT_REPLACEMENT", timeouts.testTimeoutMs);
+        await fixture.run.write("/gateway-status\r", { delay: false });
+        await waitForSynchronizedFrameRows(
+          fixture.run,
+          (rows) =>
+            rows.some((row) => row.includes("PTY_REPLACEMENT_FINAL")) &&
+            rows.some((row) => row.includes(`| ${activity}`) || row.includes(`${activity} •`)),
+          timeouts.testTimeoutMs,
+        );
+      } finally {
+        await fixture.cleanup();
+      }
+    },
+    timeouts.startupTestTimeoutMs,
+  );
+}
+
+async function exerciseTuiReconnectOutcomes(timeoutMs: number): Promise<void> {
   await Promise.all([
     ...RECONNECT_CASES.map(async ({ outcome, marker, activity }) => {
       const fixture = await startTuiFixture({

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -1472,87 +1472,159 @@ describe("tui session actions", () => {
     expect(setActivityStatus).toHaveBeenLastCalledWith("streaming");
   });
 
-  it("retires the previous session run before adopting and finalizing a restored run", async () => {
-    vi.useFakeTimers();
-    try {
-      const previousSessionKey = "agent:main:previous";
-      const nextSessionKey = "agent:main:next";
-      const previousRunId = "run-previous";
-      const nextRunId = "run-next";
-      const state = createBaseState({
-        currentSessionKey: previousSessionKey,
-        currentSessionId: "session-previous",
-        historyLoaded: true,
-      });
-      const chatLog = new ChatLog();
-      const addPendingSystem = vi.spyOn(chatLog, "addPendingSystem");
-      const tui = makeTui();
-      const setActivityStatus = vi.fn((status: string) => {
-        state.activityStatus = status;
-      });
-      let loadSelectedHistory: () => Promise<TuiHistoryLoadResult> = async () => ({
-        loaded: false,
-      });
-      const handlers = createEventHandlers({
-        chatLog,
-        btw: createBtwPresenter(),
-        tui,
-        state,
-        setActivityStatus,
-        loadHistory: () => loadSelectedHistory(),
-        streamingWatchdogMs: 100,
-      });
-      handlers.handleChatEvent({
-        runId: previousRunId,
-        sessionKey: previousSessionKey,
-        seq: 1,
-        state: "delta",
-        message: { role: "assistant", content: [{ type: "text", text: "old partial" }] },
-      });
-      expect(state.activeChatRunId).toBe(previousRunId);
+  it.each([
+    {
+      description: "a different session",
+      sameSession: false,
+      activeRunIds: undefined,
+      preservesOld: false,
+    },
+    {
+      description: "a same-session replacement with exact active runs",
+      sameSession: true,
+      activeRunIds: ["run-next"],
+      preservesOld: false,
+    },
+    {
+      description: "a same-session concurrent run",
+      sameSession: true,
+      activeRunIds: ["run-previous", "run-next"],
+      preservesOld: true,
+    },
+    {
+      description: "a same-session run with unknown active membership",
+      sameSession: true,
+      activeRunIds: undefined,
+      preservesOld: true,
+    },
+    {
+      description: "a same-session run with null active membership",
+      sameSession: true,
+      activeRunIds: null,
+      preservesOld: true,
+    },
+    {
+      description: "a same-session run with malformed active membership",
+      sameSession: true,
+      activeRunIds: ["run-next", 42],
+      preservesOld: true,
+    },
+  ])(
+    "reconciles previous run ownership when restoring $description",
+    async ({ sameSession, activeRunIds, preservesOld }) => {
+      vi.useFakeTimers();
+      try {
+        const previousSessionKey = "agent:main:previous";
+        const nextSessionKey = sameSession ? previousSessionKey : "agent:main:next";
+        const previousRunId = "run-previous";
+        const nextRunId = "run-next";
+        const state = createBaseState({
+          currentSessionKey: previousSessionKey,
+          currentSessionId: "session-previous",
+          historyLoaded: true,
+        });
+        const chatLog = new ChatLog();
+        const addPendingSystem = vi.spyOn(chatLog, "addPendingSystem");
+        const tui = makeTui();
+        const setActivityStatus = vi.fn((status: string) => {
+          state.activityStatus = status;
+        });
+        let loadSelectedHistory: () => Promise<TuiHistoryLoadResult> = async () => ({
+          loaded: false,
+        });
+        const handlers = createEventHandlers({
+          chatLog,
+          btw: createBtwPresenter(),
+          tui,
+          state,
+          setActivityStatus,
+          loadHistory: () => loadSelectedHistory(),
+          streamingWatchdogMs: 100,
+        });
+        handlers.handleChatEvent({
+          runId: previousRunId,
+          sessionKey: previousSessionKey,
+          seq: 1,
+          state: "delta",
+          message: { role: "assistant", content: [{ type: "text", text: "old partial" }] },
+        });
+        expect(state.activeChatRunId).toBe(previousRunId);
 
-      const actions = createTestSessionActions({
-        client: makeTuiBackend({
-          listSessions: vi.fn(),
-          loadHistory: vi.fn().mockResolvedValue({
-            sessionId: "session-next",
-            sessionInfo: {
-              key: nextSessionKey,
-              sessionId: "session-next",
-              updatedAt: 1,
-            },
-            messages: [],
-            inFlightRun: { runId: nextRunId, text: "new partial" },
+        const actions = createTestSessionActions({
+          client: makeTuiBackend({
+            listSessions: vi.fn(),
+            loadHistory: vi.fn().mockResolvedValue({
+              sessionId: sameSession ? "session-previous" : "session-next",
+              sessionInfo: {
+                key: nextSessionKey,
+                sessionId: sameSession ? "session-previous" : "session-next",
+                activeRunIds,
+                updatedAt: 1,
+              },
+              messages: [],
+              inFlightRun: { runId: nextRunId, text: "new partial" },
+            }),
           }),
-        }),
-        chatLog,
-        state,
-        tui,
-        setActivityStatus,
-        invalidateRunOwnership: handlers.dispose,
-      });
-      loadSelectedHistory = actions.loadHistory;
+          chatLog,
+          state,
+          tui,
+          setActivityStatus,
+          invalidateRunOwnership: handlers.dispose,
+        });
+        loadSelectedHistory = async () => {
+          const reconcileMembership = handlers.captureHistoryRunMembership();
+          const result = await actions.loadHistory();
+          if (result.loaded) {
+            reconcileMembership(result.activeRunIds);
+          }
+          return result;
+        };
 
-      await actions.setSession(nextSessionKey);
-      expect(state.activeChatRunId).toBe(nextRunId);
+        if (sameSession) {
+          handlers.pauseStreamingWatchdog();
+          handlers.reconnectStreamingWatchdog();
+          const recovered = await loadSelectedHistory();
+          expect(recovered.loaded).toBe(true);
+          if (recovered.loaded) {
+            handlers.reconnectStreamingWatchdog(recovered.runOutcome);
+          }
+        } else {
+          await actions.setSession(nextSessionKey);
+        }
+        expect(state.activeChatRunId).toBe(nextRunId);
 
-      handlers.handleChatEvent({
-        runId: nextRunId,
-        sessionKey: nextSessionKey,
-        seq: 2,
-        state: "final",
-        message: { role: "assistant", content: [{ type: "text", text: "new final" }] },
-      });
+        handlers.handleChatEvent({
+          runId: nextRunId,
+          sessionKey: nextSessionKey,
+          seq: 2,
+          state: "final",
+          message: { role: "assistant", content: [{ type: "text", text: "new final" }] },
+        });
 
-      expect(state.activeChatRunId).toBeNull();
-      expect(setActivityStatus).toHaveBeenLastCalledWith("idle");
-      vi.advanceTimersByTime(101);
-      expect(addPendingSystem).not.toHaveBeenCalled();
-      handlers.dispose();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
+        expect(state.activeChatRunId).toBe(preservesOld ? previousRunId : null);
+        expect(setActivityStatus).toHaveBeenLastCalledWith(preservesOld ? "running" : "idle");
+        vi.advanceTimersByTime(101);
+        expect(addPendingSystem).toHaveBeenCalledTimes(preservesOld ? 1 : 0);
+        if (sameSession && !preservesOld) {
+          handlers.handleChatEvent({
+            runId: previousRunId,
+            sessionKey: previousSessionKey,
+            seq: 3,
+            state: "final",
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "late complete reply" }],
+            },
+          });
+          expect(chatLog.render(120).join("\n")).toContain("late complete reply");
+          expect(state.activeChatRunId).toBeNull();
+        }
+        handlers.dispose();
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it.each(["agent:main:main", "main"])(
     "preserves run ownership when reselecting the same session as %s",

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -473,7 +473,9 @@ export function createSessionActions(context: SessionActionContext) {
         messages?: unknown[];
         sessionId?: string;
         sessionInfo?: SessionInfoEntry &
-          Partial<Pick<SessionEntry, "abortedLastRun" | "lastRunError" | "status">>;
+          Partial<Pick<SessionEntry, "abortedLastRun" | "lastRunError" | "status">> & {
+            activeRunIds?: unknown;
+          };
         defaults?: SessionInfoDefaults;
         thinkingLevel?: string;
         fastMode?: FastMode;
@@ -633,7 +635,14 @@ export function createSessionActions(context: SessionActionContext) {
           : status === "killed" || sessionInfo?.abortedLastRun === true
             ? ({ state: "interrupted" } as const)
             : ({ state: "completed" } as const);
-      return { loaded: true, runOutcome };
+      const activeRunIds = sessionInfo?.activeRunIds;
+      return {
+        loaded: true,
+        runOutcome,
+        ...(Array.isArray(activeRunIds) && activeRunIds.every((id) => typeof id === "string")
+          ? { activeRunIds }
+          : {}),
+      };
     } catch (err) {
       if (isCurrentLoad() && !isAbortError(err)) {
         chatLog.addSystem(`history failed: ${formatTuiErrorMessage(err)}`);

--- a/src/tui/tui-session-run-coordinator.test.ts
+++ b/src/tui/tui-session-run-coordinator.test.ts
@@ -189,6 +189,50 @@ describe("TuiSessionRunCoordinator", () => {
     expect(coordinator.resolveMostRecentPromotableRun()).toBe("run-pending");
   });
 
+  it.each(["sending", "accepted"] as const)(
+    "retires only unchanged history observations and preserves a %s submit",
+    (phase) => {
+      vi.useFakeTimers();
+      try {
+        const { coordinator } = createCoordinator({
+          state: {
+            activeChatRunId: "run-visible",
+            pendingSubmit: { phase, runId: "run-pending", draftText: "pending" },
+          },
+        });
+        for (const runId of ["run-old", "run-reobserved", "run-visible", "run-pending"]) {
+          coordinator.noteSessionRun(runId, { protectStream: true });
+        }
+        const reconcile = coordinator.captureHistoryRunMembership();
+        // The clock intentionally does not advance: timestamps are not revisions.
+        coordinator.noteSessionRun("run-reobserved", { protectStream: true });
+        coordinator.noteSessionRun("run-new");
+        reconcile([]);
+
+        expect([...coordinator.sessionRuns.keys()]).toEqual([
+          "run-reobserved",
+          "run-visible",
+          "run-pending",
+          "run-new",
+        ]);
+        expect(coordinator.finalizedRuns.has("run-old")).toBe(false);
+        expect(coordinator.persistedTerminalRunIds.has("run-old")).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("does not let an old session history retire a reset session's run", () => {
+    const { coordinator } = createCoordinator();
+    coordinator.noteSessionRun("run-reused", { protectStream: true });
+    const reconcile = coordinator.captureHistoryRunMembership();
+    coordinator.clear();
+    coordinator.noteSessionRun("run-reused", { protectStream: true });
+    reconcile([]);
+    expect(coordinator.resolveMostRecentPromotableRun()).toBe("run-reused");
+  });
+
   it("serializes queued reloads and replays a gated terminal event", async () => {
     let resolveHistory: ((result: TuiHistoryLoadResult) => void) | undefined;
     const { coordinator, loadHistory, finalizeHistoryOwnedRun, replayHistoryRunEvent } =
@@ -252,6 +296,93 @@ describe("TuiSessionRunCoordinator", () => {
       result: completedHistory,
       previouslyDisplayed: false,
     });
+  });
+
+  it.each([
+    { membership: "exact", activeRunIds: ["run-first", "run-second"] },
+    { membership: "unknown", activeRunIds: undefined },
+  ])("keeps concurrent runs after a gap with $membership membership", async ({ activeRunIds }) => {
+    const { coordinator, finalizeHistoryOwnedRun } = createCoordinator({
+      loadHistory: async () => ({
+        ...activeHistory("run-second"),
+        ...(activeRunIds ? { activeRunIds } : {}),
+      }),
+    });
+
+    coordinator.queueGapHistoryReload(["run-first", "run-second"]);
+
+    await vi.waitFor(() => expect(coordinator.isHistoryReloadingRun("run-first")).toBe(false));
+    expect(finalizeHistoryOwnedRun).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { tracked: true, observation: "delta" },
+    { tracked: false, observation: "delta" },
+    { tracked: true, observation: "lifecycle" },
+    { tracked: false, observation: "lifecycle" },
+  ])(
+    "preserves newer $observation without finalizing older history (tracked=$tracked)",
+    async ({ tracked, observation }) => {
+      let resolveHistory: ((result: TuiHistoryLoadResult) => void) | undefined;
+      const { coordinator, finalizeHistoryOwnedRun, replayHistoryRunEvent } = createCoordinator({
+        loadHistory: () =>
+          new Promise((resolve) => {
+            resolveHistory = resolve;
+          }),
+      });
+      if (tracked) {
+        coordinator.noteSessionRun("run-live", { protectStream: true });
+      }
+      const reconcile = coordinator.captureHistoryRunMembership();
+      coordinator.queueGapHistoryReload(["run-live"]);
+      const delta: ChatEvent = {
+        runId: "run-live",
+        sessionKey: "agent:main:main",
+        seq: 2,
+        state: "delta",
+        message: { role: "assistant", content: "still running" },
+      };
+      if (observation === "delta") {
+        coordinator.deferHistoryRunEvent(delta);
+      } else {
+        coordinator.noteSessionRun("run-live", { protectStream: true });
+      }
+      reconcile([]);
+      if (tracked) {
+        expect(coordinator.sessionRuns.has("run-live")).toBe(true);
+      }
+      resolveHistory?.(completedHistory);
+
+      await vi.waitFor(() => expect(coordinator.isHistoryReloadingRun("run-live")).toBe(false));
+      if (observation === "delta") {
+        expect(replayHistoryRunEvent).toHaveBeenCalledWith(delta);
+      }
+      expect(finalizeHistoryOwnedRun).not.toHaveBeenCalled();
+    },
+  );
+
+  it("allows a later queued history to supersede a delta from the previous reload", async () => {
+    let resolveHistory: ((result: TuiHistoryLoadResult) => void) | undefined;
+    const { coordinator, loadHistory, finalizeHistoryOwnedRun } = createCoordinator({
+      loadHistory: () =>
+        new Promise((resolve) => {
+          resolveHistory = resolve;
+        }),
+    });
+    coordinator.queueGapHistoryReload(["run-live"]);
+    coordinator.queueGapHistoryReload(["run-live"]);
+    coordinator.deferHistoryRunEvent({
+      runId: "run-live",
+      sessionKey: "agent:main:main",
+      seq: 2,
+      state: "delta",
+      message: { role: "assistant", content: "before the next snapshot" },
+    });
+    resolveHistory?.(completedHistory);
+    await vi.waitFor(() => expect(loadHistory).toHaveBeenCalledTimes(2));
+    expect(finalizeHistoryOwnedRun).not.toHaveBeenCalled();
+    resolveHistory?.(completedHistory);
+    await vi.waitFor(() => expect(finalizeHistoryOwnedRun).toHaveBeenCalledTimes(1));
   });
 
   it.each([

--- a/src/tui/tui-session-run-coordinator.ts
+++ b/src/tui/tui-session-run-coordinator.ts
@@ -40,6 +40,8 @@ type TuiHistoryReloadRun = {
   deferredEvent?: ChatEvent;
 };
 
+type SessionRunObservation = { seenAt: number };
+
 type TuiSessionRunCoordinatorContext = {
   state: TuiStateAccess;
   loadHistory?: () => Promise<TuiHistoryLoadResult>;
@@ -52,7 +54,7 @@ type TuiSessionRunCoordinatorContext = {
 
 /** Keeps one session's run, persistence, and transcript ownership together. */
 export class TuiSessionRunCoordinator {
-  readonly sessionRuns = new Map<string, number>();
+  readonly sessionRuns = new Map<string, SessionRunObservation>();
   readonly finalizedRuns = new Map<string, number>();
   readonly finalizedRunsWithDisplay = new Map<string, number>();
   readonly pendingNewSessionRunIds = new Set<string>();
@@ -82,7 +84,10 @@ export class TuiSessionRunCoordinator {
     });
   }
 
-  private pruneRunMap(runs: Map<string, number>, protectActiveRun = false): void {
+  private pruneRunMap(
+    runs: Map<string, number> | Map<string, SessionRunObservation>,
+    protectActiveRun = false,
+  ): void {
     if (runs.size <= MAX_TRACKED_RUNS) {
       return;
     }
@@ -93,11 +98,14 @@ export class TuiSessionRunCoordinator {
         runId !== getPendingSubmitAcceptedRunId(this.context.state) &&
         !this.confirmedStreamRunIds.has(runId));
 
-    for (const [runId, seenAt] of runs) {
+    for (const [runId, observation] of runs) {
       if (runs.size <= RETAINED_TRACKED_RUNS) {
         break;
       }
-      if (seenAt < keepUntil && canRemove(runId)) {
+      if (
+        (typeof observation === "number" ? observation : observation.seenAt) < keepUntil &&
+        canRemove(runId)
+      ) {
         runs.delete(runId);
       }
     }
@@ -136,7 +144,7 @@ export class TuiSessionRunCoordinator {
         }
       }
     }
-    this.sessionRuns.set(runId, Date.now());
+    this.sessionRuns.set(runId, { seenAt: Date.now() });
     this.pruneRunMap(this.sessionRuns, true);
   }
 
@@ -161,7 +169,7 @@ export class TuiSessionRunCoordinator {
     let nextSeenAt = -1;
     let unconfirmedRunId: string | undefined;
     let unconfirmedSeenAt = -1;
-    for (const [runId, seenAt] of this.sessionRuns) {
+    for (const [runId, { seenAt }] of this.sessionRuns) {
       if (runId !== pendingRunId && !this.confirmedStreamRunIds.has(runId)) {
         if (seenAt > unconfirmedSeenAt) {
           unconfirmedRunId = runId;
@@ -179,10 +187,43 @@ export class TuiSessionRunCoordinator {
     return nextRunId ?? unconfirmedRunId;
   }
 
-  dropSessionRun(runId: string): void {
+  private forgetSessionRun(runId: string): boolean {
     this.sessionRuns.delete(runId);
     const completedConfirmedRun = this.confirmedStreamRunIds.delete(runId);
     this.streamAssembler.drop(runId);
+    return completedConfirmedRun;
+  }
+
+  captureHistoryRunMembership(): (activeRunIds?: readonly string[]) => void {
+    const generation = this.historyReloadGeneration;
+    const observations = Array.from(this.sessionRuns, ([runId, observation]) => ({
+      runId,
+      observation,
+      deferredEvent: this.historyReloadRuns.get(runId)?.deferredEvent,
+    }));
+    return (activeRunIds) => {
+      if (!activeRunIds || generation !== this.historyReloadGeneration) {
+        return;
+      }
+      const active = new Set(activeRunIds);
+      // Exact membership can retire older observations, never events received
+      // during the RPC. Object identity also distinguishes same-clock deltas.
+      for (const { runId, observation, deferredEvent } of observations) {
+        if (
+          !active.has(runId) &&
+          runId !== this.context.state.activeChatRunId &&
+          runId !== this.context.state.pendingSubmit?.runId &&
+          this.sessionRuns.get(runId) === observation &&
+          this.historyReloadRuns.get(runId)?.deferredEvent === deferredEvent
+        ) {
+          this.forgetSessionRun(runId);
+        }
+      }
+    };
+  }
+
+  dropSessionRun(runId: string): void {
+    const completedConfirmedRun = this.forgetSessionRun(runId);
     if (completedConfirmedRun && this.confirmedStreamRunIds.size === 0) {
       this.rejectUnconfirmedRuns = true;
       const activeRunId = this.context.state.activeChatRunId;
@@ -193,8 +234,7 @@ export class TuiSessionRunCoordinator {
         if (candidateRunId === activeRunId || candidateRunId === pendingRunId) {
           continue;
         }
-        this.sessionRuns.delete(candidateRunId);
-        this.streamAssembler.drop(candidateRunId);
+        this.forgetSessionRun(candidateRunId);
         this.retiredOrphanRunIds.set(candidateRunId, Date.now());
       }
       this.pruneRunMap(this.retiredOrphanRunIds);
@@ -292,10 +332,20 @@ export class TuiSessionRunCoordinator {
     const generation = this.historyReloadGeneration;
     // Snapshot each run's flags before awaiting; an overlapping gap owns the
     // next drain and must not inherit or erase this drain's finalization.
-    const reloads: Array<{ runId: string; flags: number }> = [];
+    const reloads: Array<{
+      runId: string;
+      flags: number;
+      deferredEvent?: ChatEvent;
+      observation?: SessionRunObservation;
+    }> = [];
     for (const [runId, reload] of this.historyReloadRuns) {
       if (reload.flags & HISTORY_RELOAD_QUEUED) {
-        reloads.push({ runId, flags: reload.flags });
+        reloads.push({
+          runId,
+          flags: reload.flags,
+          deferredEvent: reload.deferredEvent,
+          observation: this.sessionRuns.get(runId),
+        });
         reload.flags = 0;
       }
     }
@@ -306,7 +356,7 @@ export class TuiSessionRunCoordinator {
       if (generation !== this.historyReloadGeneration) {
         return;
       }
-      for (const { runId, flags } of reloads) {
+      for (const { runId, flags, deferredEvent, observation } of reloads) {
         const current = this.historyReloadRuns.get(runId);
         if (!current || current.flags & HISTORY_RELOAD_QUEUED) {
           continue;
@@ -316,12 +366,26 @@ export class TuiSessionRunCoordinator {
         const historyOwned = Boolean(flags & HISTORY_RELOAD_OWNED);
         const previouslyDisplayed = Boolean(flags & HISTORY_RELOAD_DISPLAYED);
         const gapRecovery = Boolean(flags & HISTORY_RELOAD_GAP_RECOVERY);
+        // The newest stream cannot exclude peers when exact membership is
+        // unknown. Non-gap reloads have a separate per-run persistence barrier.
         const restoredInFlight =
           result.loaded &&
-          result.runOutcome.state === "active" &&
-          result.runOutcome.runId === runId;
+          (result.activeRunIds?.includes(runId) ??
+            (result.runOutcome.state === "active" &&
+              (gapRecovery || result.runOutcome.runId === runId)));
+        // Lifecycle starts apply immediately; chat deltas wait for replay. Both
+        // can supersede this RPC, but not when inherited from an earlier reload.
+        const observedDuringReload =
+          gapRecovery &&
+          ((this.sessionRuns.has(runId) && this.sessionRuns.get(runId) !== observation) ||
+            (deferred?.state === "delta" && deferred !== deferredEvent));
 
-        if (historyOwned && !restoredInFlight && (result.loaded || !gapRecovery)) {
+        if (
+          historyOwned &&
+          !restoredInFlight &&
+          !observedDuringReload &&
+          (result.loaded || !gapRecovery)
+        ) {
           this.context.finalizeHistoryOwnedRun({ runId, result, previouslyDisplayed });
         }
         if (deferred && (!result.loaded || historyOwned || restoredInFlight)) {

--- a/src/tui/tui-types.ts
+++ b/src/tui/tui-types.ts
@@ -39,7 +39,7 @@ export type TuiHistoryRunOutcome =
   | { state: "failed"; errorMessage: string };
 
 export type TuiHistoryLoadResult =
-  | { loaded: true; runOutcome: TuiHistoryRunOutcome }
+  | { loaded: true; runOutcome: TuiHistoryRunOutcome; activeRunIds?: string[] }
   | { loaded: false };
 
 export type ChatEvent = {

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -1463,8 +1463,10 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
   } = sessionActions;
   const loadHistory = async (reconcileReconnect = false) => {
     const activeRunAtStart = state.activeChatRunId;
+    const reconcileMembership = captureHistoryRunMembership();
     const result = await loadHistorySnapshot();
     if (result.loaded) {
+      reconcileMembership(result.activeRunIds);
       // History can adopt a newer run before returning; terminal outcomes
       // still belong only to the unchanged run captured before the request.
       const recoveredRunId =
@@ -1502,6 +1504,7 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
     reconnectStreamingWatchdog,
     consumeCompletedRunForPendingSend,
     isRunObserved,
+    captureHistoryRunMembership,
     reconcileHistoryAfterGap,
     flushPendingHistoryRefreshIfIdle,
     dispose: disposeEventHandlers,


### PR DESCRIPTION
Closes #131484. Related follow-up: #131485.

## What Problem This Solves

Fixes an issue where TUI users see a finished conversation return to “running” when reconnect history adopts a replacement run and that replacement later finishes. The same history-ownership mismatch can prematurely finalize a concurrent run during event-gap recovery.

## Why This Change Was Made

History exposes two different facts: `inFlightRun` is the newest visible stream, while `sessionInfo.activeRunIds`, when present, is complete exact membership. The TUI discarded the latter and retained superseded coordinator entries. This change carries exact membership to the run coordinator and retires only unchanged, older observations. Missing or malformed membership remains unknown.

The coordinator keeps one lifecycle path. Snapshot retirement removes membership and stream buffers without fabricating completion, persistence, or display facts and without triggering terminal-only orphan cleanup. Immutable observations and existing deferred-event identities protect activity received while history is in flight, including immediate lifecycle starts, deferred deltas, session resets, and overlapping queued reloads. Pending submits and legitimate concurrent work remain eligible; late complete replies can still display.

No Gateway wire, provider, configuration, dependency, or persistent-store changes.

Release-note context stays in this PR; `CHANGELOG.md` remains unchanged. The remaining TUI patch is byte-for-byte identical to the reviewed repair before its mechanical rebase onto current main.

An earlier CI run exposed an unrelated existing avatar test-order defect. A bounded test-only repair was reproduced, reviewed, and validated here. Before landing, #131522 independently fixed the same fixture on main by mapping image identity through the request's MIME type. The resulting real conflict was resolved by keeping main's fix and dropping our redundant avatar commit. This PR now changes only the eleven TUI/docs files; there is no avatar test or production UI diff.

## User Impact

Reconnect recovery returns to idle after the actual remaining work finishes, rather than reviving a stale busy indicator. Event-gap recovery preserves all known active runs and cannot use an older snapshot to erase newly observed activity.

## Evidence

**Exact-head CI:** current head `b7ba439eecedf21a9118188b68b58fb5652cb578` passed [CI 33144266380](https://github.com/openclaw/openclaw/actions/runs/33144266380), attempt 1, including required `openclaw/ci-gate`. The watcher exited 0 and fresh REST readback verified the exact head and completed/success conclusion. Earlier pending-CI checkpoints below are historical.

**New-main composition:** #131557 landed during final validation and changed the same history-reload queue to coalesced, awaitable settlement. Merge was held for integrated proof. Applying this unchanged PR to main `2169669140f17e01833aec48f8510d641a6c41cb` produced no conflicts; the complete staged tree `fa5711bde750b34557234d0a839280e57d3570f9` exactly matched Git's synthetic merge. On that composed tree, **1,433 TUI tests across 46 files**, owning TUI types, changed lint/format, and a fresh integrated Codex review passed. Source inspection verified that each coalescer rerun takes fresh observation/event snapshots and that reset generations still fence both membership reconciliation and queue completion.

Final pre-merge refresh reached main `39e01c49d0d619201985c86de73f46afe8399256`. All TUI files, the history handler and active-run membership producer, and dependencies remain unchanged from the composed proof base. Nearby Gateway changes add workspace startup phases and admitted workspace preparation; their inspected diffs do not change the history membership or terminal reconciliation contract.

The composed tree also passed all six real-terminal membership cases plus `/reset` on macOS. The older multi-scenario reconnect test initially hit its existing 45-second deadline; an isolated unchanged rerun passed in **40.231 seconds**, with that same deadline. The first attempt remains a failed verification attempt (7 passed, 1 timed out), not an all-green run. No source, assertion, timeout, retry policy, or dependency change was made. This is additional real TUI/PTY controlled-backend proof, not live Gateway/model proof. The published PR head and exact-head CI remain unchanged.

An additional isolated original-order probe passed through the actual event, coordinator, lifecycle, session-history and ChatLog owners: gap history H1 pending with an old deferred terminal event → reset → fresh lifecycle reusing the old run ID → replacement history H2. H1 neither replayed its stale terminal event nor retired the fresh peer; H2 released the new peer delta, emitted the reset confirmation exactly once after settlement, and preserved promotion until both fresh runs finished idle. Two history calls and six source fingerprints were independently verified. This probe uses controlled responses and an inert terminal; it does not execute the `runTui` membership wrapper or constitute additional E2E proof.

- Unmodified production baseline: the real `runTui()` PTY regression failed the replacement-only case and passed concurrent/unknown-membership controls. Final candidate: all six replacement/concurrent/unknown cases pass through reconnect and event-gap recovery on clean Linux Blacksmith Testbox.
- Independent owner regressions reproduced premature gap finalization for concurrent membership and newer delta/lifecycle observations before their corresponding repair.
- Final full TUI unit suite: 1,421 passed across 46 files. TUI-owning test type shard and changed-file lint passed.
- [Initial exact-head CI 33139683932](https://github.com/openclaw/openclaw/actions/runs/33139683932) passed on `46e5207bcc31ffa0cc7509fff6289b5e17faa5ae`, attempt 1. [Bookkeeping-head CI 33140712475](https://github.com/openclaw/openclaw/actions/runs/33140712475) completed with one failed test job plus the aggregate CI gate. The failure was the existing avatar fixture's expected `blob:human` / received `blob:agent` assertion in `session-activity-view.test.ts`; no other job failed. The repair head requires its own green exact-head CI before landing.
- Avatar CI repair: the unchanged positional object-URL mock deterministically failed with agent-newest ordering and passed the human-newest control. The request/Blob-keyed fixture passes both orders. Final focused activity/avatar proof: 53 tests across 4 files; separately routed isolated facepile sibling: 13 tests. Owning UI-pages test type shard, changed lint, formatting, diff check, and UI i18n verification all passed. Fresh isolated Codex review completed with no actionable findings.
- Pre-rebase head `e484c9a8fb72afffee513d58696095e2c19f88fc` passed [CI 33141723668](https://github.com/openclaw/openclaw/actions/runs/33141723668), attempt 1, including the avatar shard and required CI gate. Current head `b7ba439eecedf21a9118188b68b58fb5652cb578` rebases the unchanged TUI repair onto main `153a6f59bf820f79e94e6d14b25f292f2e504646`, preserving #131522's avatar fix and dropping the redundant local repair. The complete eleven-file TUI diff is binary-identical to reviewed head `d8337e0b9d7212b40d68b8fa91d02d6a2fa961d7` against its original base. Fresh composed proof passed: **1,421 TUI tests plus 52 avatar/activity tests**, owning TUI types, changed lint, formatting, and diff check. A fresh full-branch Codex review completed with no actionable findings. Current-head CI remains required before landing.
- Isolated Codex autoreview: terminal success, no actionable findings at the repository's default P0 threshold. Independent source challenge found the lifecycle-start race, which was reproduced and repaired before the final review.
- Broader Linux PTY/real-backend run: 67 passed, 2 failed. Real Gateway restart, cross-client delivery, follow-up queue, and embedded-backend steering passed. The two failures were the ANSI-safety scenario's 25-second aggregate deadline and the synthetic account-limit case's two-second output deadline; narrower diagnosis is retained separately. This is not an all-green broad run.
- The full local changed-code gate passed production types and source test shards, then failed in unrelated UI tests because this linked dependency installation lacks `@types/jsdom`. Dependencies were not reconciled or modified. All remaining static guards passed separately; hosted exact-head CI is required before landing.

The targeted reproduction uses a real terminal and real `runTui()` loop with a controlled backend; it does not prove live Gateway transport or model execution. Separate broader proof exercises the real embedded/Gateway backends with only the external model endpoint mocked.

Focused proof can be reproduced with:

```sh
node scripts/run-vitest.mjs run --config test/vitest/vitest.tui.config.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts -t 'run membership before a replacement finishes'
node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.plugins-platform.json --builders 1
```

The final Linux PTY proof used [Testbox run 33138593084](https://github.com/openclaw/openclaw/actions/runs/33138593084), with the delegated command returning exit 0 (6 passed, 63 intentionally filtered). The lease was stopped after proof; its Actions cleanup status is not the test verdict.

### Published review follow-through

The latest [published ClawSweeper review](https://github.com/openclaw/openclaw/pull/131487#issuecomment-5448419058), updated for exact `b7ba439e`, found no source correctness or security defect. Its live probe failed a 30-second `expect_output` step before observing the selected membership-case output; it did not produce a completed test verdict. The earlier `e484c9a8` attempt observed replacement/reconnect pass in 7,360 ms but timed out waiting for the final `Test Files` summary. Both partial attempts remain failed verification attempts, not passing complete runs. The review's pending-CI concern is resolved by completed exact-head CI above; its real-setup request is addressed by the completed Linux and composed macOS terminal runs, recorded frames, and original-order owner probe, with their distinct scopes stated explicitly.

A fresh clean-Linux [Testbox run 33142248850](https://github.com/openclaw/openclaw/actions/runs/33142248850) reran the identical six-case filter on exact head `e484c9a8fb72afffee513d58696095e2c19f88fc`, verified remotely before the command. All six cases passed with their original timeouts: reconnect replacement/concurrent/unknown in 4,349/4,104/4,237 ms; gap replacement/concurrent/unknown in 4,887/4,773/4,380 ms. Final result: **6 passed, 79 intentionally skipped, exit 0**; Vitest duration 43.12 seconds, complete delegated command 99.91 seconds. The lease completed and the provider confirmed it was already stopped. No timeout, retry, assertion, or production change was made for this rerun.

Rank-up response: after-fix real-terminal evidence is supplied above and in the before/after recorded frames below. This exercises the actual TUI/PTY with a controlled backend; it is not represented as live Gateway/model execution. Direct source/docs and completed terminal proof were independently inspected. The owner-boundary production growth is justified below. The protected maintainer-label decision is handled under the explicit maintainer-directed autonomous fix-and-land request, not automated cleanup. The separate follow-ups remain open; the rebased head's exact CI has now completed successfully.

Before/after frames below are monochrome renderings of recorded Linux PTY text from the real terminal loop, not native-pixel screenshots. Both display the replacement's final reply; before returns to `running`, after remains `idle`. Only public fixture content is shown.

![Before: final reply visible but the TUI returns to running](https://github.com/user-attachments/assets/ecd02676-a7f9-4e52-9e77-41c16fe245f7)

![After: the final reply remains visible and the TUI stays idle](https://github.com/user-attachments/assets/26166a76-93bd-411d-8bb8-5c471bd68143)

Production LOC: +97/-24 (net +73). Tests/test support: +362/-86 (net +276, including moved reconnect test registration). The production increase implements the previously missing complete-membership reconciliation and request-order fences inside the existing coordinator. Replacing per-run timestamps with immutable observations absorbs the freshness check into the owner; a smaller “different in-flight run means old run ended” guard is invalid for concurrent runs. Snapshot retirement reuses the factored removal primitive instead of duplicating terminal cleanup or adding another run-state store.

Provenance: the newest-snapshot-only gap decision was carried by #125898 (code author, PR author, and merger: @steipete, 2026-08-18). The broader stale-membership path predates the available shallow history; this is not a claim that #125898 introduced all symptoms.

Avatar fixture provenance: introduced by #131316, commit `7aee87c0db11b451208ac337232f1f5ef3d47650` (code author Peter Steinberger; PR author and merger @steipete, 2026-08-28 UTC). Independent wall-clock reads could reverse activity recency, while the mock assigned image names by completion order. Main's #131522 removes that order coupling at the fixture boundary; our duplicate fix was intentionally dropped.

The separate timing-sensitive PTY issue #127237 remains open. No timeout increase, retry, production test flag, or authentication-path workaround is included.

Known separate follow-up #131485: history with `hasActiveRun: true` but no `inFlightRun` is still classified as completed by the existing adapter. That needs an unidentified-but-nonterminal internal outcome and lifecycle follow-through; this PR does not claim to repair that representation gap.
