### PR TITLE
fix(ui): show one pull-request icon per sidebar session

### DIFF
--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -88,7 +88,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
 
   readonly sessionProjection = new SidebarSessionProjection();
   readonly sessionData = new SessionDataController(this);
-  private readonly sessionPullRequestIndicators = new SessionPullRequestIndicatorsController(this, {
+  readonly sessionPullRequests = new SessionPullRequestIndicatorsController(this, {
     getConnected: () => this.connected,
     getRows: () =>
       mergeAdoptedSessionPullRequestRows({
@@ -207,10 +207,6 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     if (this.sessionProjection.promoteCreatedSession(sessionKey)) {
       this.requestUpdate();
     }
-  }
-
-  sessionPullRequestIndicatorState(sessionKey: string, worktreeId: string) {
-    return this.sessionPullRequestIndicators.state(sessionKey, worktreeId);
   }
 
   override updated(changedProperties: PropertyValues<this>) {

--- a/ui/src/components/app-sidebar-session-pr-indicators.test.ts
+++ b/ui/src/components/app-sidebar-session-pr-indicators.test.ts
@@ -91,63 +91,83 @@ describe("SessionPullRequestIndicatorsController", () => {
     expect(host.requestUpdate).not.toHaveBeenCalled();
   });
 
-  it("subscribes visible rows and keeps the last indicator through backoff", async () => {
-    vi.useFakeTimers();
-    const host = new TestHost();
-    const harness = createGatewayHarness();
-    const row = {
-      key: "agent:main:demo",
-      isChild: false,
-      worktreeId: "wt-demo",
-    } as SidebarRecentSession;
-    const controller = new SessionPullRequestIndicatorsController(host, {
-      getConnected: () => true,
-      getRows: () => [row],
-      getSelectedAgentId: () => "main",
-      getGateway: () => harness.gateway,
-      getSessions: () => undefined,
-    });
+  it.each(["open", "draft", "merged", "closed"] as const)(
+    "subscribes visible rows and keeps the %s summary through backoff",
+    async (state) => {
+      vi.useFakeTimers();
+      const host = new TestHost();
+      const harness = createGatewayHarness();
+      const row = {
+        key: "agent:main:demo",
+        isChild: false,
+        worktreeId: "wt-demo",
+      } as SidebarRecentSession;
+      const controller = new SessionPullRequestIndicatorsController(host, {
+        getConnected: () => true,
+        getRows: () => [row],
+        getSelectedAgentId: () => "main",
+        getGateway: () => harness.gateway,
+        getSessions: () => undefined,
+      });
 
-    controller.hostConnected();
-    controller.hostUpdated();
-    await vi.advanceTimersByTimeAsync(0);
-    await Promise.resolve();
-    expect(harness.request).toHaveBeenCalledWith(SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD, {
-      sessionKeys: [row.key],
-    });
+      controller.hostConnected();
+      controller.hostUpdated();
+      await vi.advanceTimersByTimeAsync(0);
+      await Promise.resolve();
+      expect(harness.request).toHaveBeenCalledWith(SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD, {
+        sessionKeys: [row.key],
+      });
 
-    harness.emit({
-      sessions: {
-        [row.key]: {
-          pullRequests: [
-            {
-              number: 1,
-              owner: "openclaw",
-              repo: "openclaw",
-              branch: "feature/demo",
-              title: "Demo",
-              url: "https://example.test/pr/1",
-              state: "open",
-            },
-          ],
-          rateLimited: true,
-          status: "rate-limited",
+      harness.emit({
+        sessions: {
+          [row.key]: {
+            pullRequests: [
+              { number: 2, state: state === "closed" ? "closed" : "merged" },
+              {
+                number: 1,
+                owner: "openclaw",
+                repo: "openclaw",
+                branch: "feature/demo",
+                title: "Demo",
+                url: "https://example.test/pr/1",
+                state,
+              },
+            ],
+            rateLimited: true,
+            status: "rate-limited",
+          },
         },
-      },
-    });
-    expect(controller.state(row.key, row.worktreeId ?? "")).toBe("open");
+      });
+      expect(controller.summary(row.key, row.worktreeId ?? "")).toEqual({
+        numbers: [1, 2],
+        state,
+      });
 
-    harness.emit({
-      sessions: {
-        [row.key]: {
-          pullRequests: [],
-          rateLimited: true,
-          status: "rate-limited",
+      harness.emit({
+        sessions: {
+          [row.key]: {
+            pullRequests: [],
+            rateLimited: true,
+            status: "rate-limited",
+          },
         },
-      },
-    });
-    expect(controller.state(row.key, row.worktreeId ?? "")).toBe("open");
-  });
+      });
+      expect(controller.summary(row.key, row.worktreeId ?? "")).toEqual({
+        numbers: [1, 2],
+        state,
+      });
+
+      harness.emit({
+        sessions: {
+          [row.key]: { pullRequests: [], rateLimited: false, status: "ready" },
+        },
+      });
+      expect(
+        controller.summary(row.key, row.worktreeId ?? "", { numbers: [99], state }),
+      ).toBeUndefined();
+      controller.hostDisconnected();
+    },
+  );
 
   it("clears alias indicators when the selected agent changes", async () => {
     vi.useFakeTimers();
@@ -184,13 +204,16 @@ describe("SessionPullRequestIndicatorsController", () => {
         },
       },
     });
-    expect(controller.state(row.key, row.worktreeId ?? "")).toBe("open");
+    expect(controller.summary(row.key, row.worktreeId ?? "")).toEqual({
+      numbers: [1],
+      state: "open",
+    });
 
     selectedAgentId = "work";
     controller.hostUpdated();
     await vi.advanceTimersByTimeAsync(0);
 
-    expect(controller.state(row.key, row.worktreeId ?? "")).toBe("none");
+    expect(controller.summary(row.key, row.worktreeId ?? "")).toBeUndefined();
   });
 
   it("clears a structural session's indicator while replacement data is pending", async () => {
@@ -227,11 +250,14 @@ describe("SessionPullRequestIndicatorsController", () => {
         },
       },
     });
-    expect(controller.state(row.key, row.worktreeId ?? "")).toBe("open");
+    expect(controller.summary(row.key, row.worktreeId ?? "")).toEqual({
+      numbers: [1],
+      state: "open",
+    });
 
     harness.emit({ sessionKey: row.key, agentId: "main", reason: "rewind" }, "sessions.changed");
 
-    expect(controller.state(row.key, row.worktreeId ?? "")).toBe("none");
+    expect(controller.summary(row.key, row.worktreeId ?? "")).toBeUndefined();
     expect(setPullRequestSummary).toHaveBeenCalledExactlyOnceWith(row.key, undefined, epoch);
   });
 });

--- a/ui/src/components/app-sidebar-session-pr-indicators.ts
+++ b/ui/src/components/app-sidebar-session-pr-indicators.ts
@@ -1,8 +1,10 @@
 import type { ReactiveController, ReactiveControllerHost } from "lit";
+import type { SessionCatalogPullRequestSummary } from "../../../packages/gateway-protocol/src/schema/sessions-catalog.js";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { ApplicationGateway } from "../app/gateway.ts";
 import { isGatewayMethodAdvertised } from "../lib/gateway-methods.ts";
 import {
+  summarizeSessionPullRequests,
   scopedSessionPullRequestKey,
   SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD,
   sessionPullRequestsForGateway,
@@ -11,13 +13,9 @@ import {
 import type { SessionCapability } from "../lib/sessions/index.ts";
 import { parseAgentSessionKey } from "../lib/sessions/session-key.ts";
 import type { SidebarRecentSession } from "./app-sidebar-session-types.ts";
-import {
-  resolveSessionPullRequestIndicatorState,
-  type SessionPullRequestIndicatorState,
-} from "./session-menu-work.ts";
 
 type IndicatorEntry = {
-  state: SessionPullRequestIndicatorState;
+  summary: SessionCatalogPullRequestSummary | undefined;
   worktreeId: string;
 };
 
@@ -61,9 +59,14 @@ export class SessionPullRequestIndicatorsController implements ReactiveControlle
     this.reset(false);
   }
 
-  state(sessionKey: string, worktreeId: string): SessionPullRequestIndicatorState {
+  summary(
+    sessionKey: string,
+    worktreeId: string,
+    initial?: SessionCatalogPullRequestSummary,
+  ): SessionCatalogPullRequestSummary | undefined {
     const entry = this.states.get(sessionKey);
-    return entry?.worktreeId === worktreeId ? entry.state : "none";
+    // A ready empty snapshot is authoritative; only seed a row before its first snapshot.
+    return entry?.worktreeId === worktreeId ? entry.summary : initial;
   }
 
   private scheduleRefresh(): void {
@@ -141,12 +144,16 @@ export class SessionPullRequestIndicatorsController implements ReactiveControlle
       if (snapshot.status !== "ready" && snapshot.pullRequests.length === 0) {
         continue;
       }
+      const current = this.states.get(session.key);
       const entry = {
-        state: resolveSessionPullRequestIndicatorState(snapshot.pullRequests),
+        summary: summarizeSessionPullRequests(snapshot.pullRequests, current?.summary),
         worktreeId: session.worktreeId,
       };
-      const current = this.states.get(session.key);
-      if (current?.state !== entry.state || current.worktreeId !== entry.worktreeId) {
+      if (
+        !current ||
+        current.summary !== entry.summary ||
+        current.worktreeId !== entry.worktreeId
+      ) {
         this.states.set(session.key, entry);
         changed = true;
       }

--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -27,6 +27,7 @@ import type {
   CatalogBackingSessionDisplay,
   CatalogSessionMenuRequest,
 } from "./app-sidebar-session-catalogs.ts";
+import type { SessionPullRequestIndicatorsController } from "./app-sidebar-session-pr-indicators.ts";
 import type { SidebarSessionProjection } from "./app-sidebar-session-projection.ts";
 import {
   rowDemandsVisibility,
@@ -41,7 +42,6 @@ import {
   describeSessionTrailingState,
   renderSessionLeadingState,
 } from "./session-leading-indicator.ts";
-import type { SessionPullRequestIndicatorState } from "./session-menu-work.ts";
 import type { SessionOrganizerController } from "./session-organizer-controller.ts";
 import { renderSessionRowBadges } from "./session-row-badges.ts";
 import { renderSidebarSessionSubtitle } from "./session-row-subtitle.ts";
@@ -104,10 +104,7 @@ export interface SessionListHost {
     options?: ApplicationNavigationOptions,
   ) => void;
 
-  sessionPullRequestIndicatorState(
-    sessionKey: string,
-    worktreeId: string,
-  ): SessionPullRequestIndicatorState;
+  readonly sessionPullRequests: Pick<SessionPullRequestIndicatorsController, "summary">;
   mainSessionRow(): { key: string } | null;
   isSessionChildrenExpanded(session: SidebarRecentSession): boolean;
   isSessionChildrenFullyShown(sessionKey: string): boolean;
@@ -181,9 +178,10 @@ export function renderRecentSession(params: {
     narrationLine: host.sidebarNarrationLines.get(session.key),
     observerDigest: host.sidebarObserverDigests.get(session.key) ?? null,
   });
-  const pullRequestState = session.worktreeId
-    ? host.sessionPullRequestIndicatorState(session.key, session.worktreeId)
-    : "none";
+  const initialPullRequest = session.pullRequest ?? display?.pullRequest;
+  const pullRequest = session.worktreeId
+    ? host.sessionPullRequests.summary(session.key, session.worktreeId, initialPullRequest)
+    : initialPullRequest;
   const ownerAttribution =
     host.sessionsStatusFilter === "archived"
       ? "archived"
@@ -222,7 +220,6 @@ export function renderRecentSession(params: {
   const { running, leadingIndicator, trailingIndicator, renderedOwnerId } =
     renderSessionLeadingState(
       session,
-      pullRequestState,
       ownerActor,
       ownerAttribution,
       ownerViewing,
@@ -234,7 +231,7 @@ export function renderRecentSession(params: {
     ? running && session.unread
       ? t("sessionsView.unread")
       : ""
-    : describeSessionTrailingState(session, pullRequestState);
+    : describeSessionTrailingState(session);
   const hasTrail = session.isChild && (session.runtimeMs != null || session.startedAt != null);
   const metaId = hasTrail ? sidebarSessionMetaId(session.key) : undefined;
   const stateId = trailingDescription ? sidebarSessionStateId(session.key) : undefined;
@@ -307,7 +304,7 @@ export function renderRecentSession(params: {
           label,
           session.archived === true,
           session.forkSource !== undefined,
-          session.pullRequest ?? display.pullRequest,
+          pullRequest,
         ]),
         marqueeLabelTemplate,
       )
@@ -381,7 +378,7 @@ export function renderRecentSession(params: {
               ${renderSessionRowBadges({
                 ...session,
                 hasComposerDraft: session.hasComposerDraft === true,
-                pullRequest: session.pullRequest ?? display?.pullRequest,
+                pullRequest,
                 hasApproval: sessionHasPendingApproval(
                   host.sessionData.approvalBadgeSnapshot(),
                   session.key,

--- a/ui/src/components/session-glyph.ts
+++ b/ui/src/components/session-glyph.ts
@@ -1,7 +1,7 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { t } from "../i18n/index.ts";
 
-export type SessionGlyphContent = TemplateResult | typeof nothing;
+type SessionGlyphContent = TemplateResult | typeof nothing;
 
 /**
  * Persistent artwork in the sidebar's leading slot (owner avatar, page icon,

--- a/ui/src/components/session-leading-indicator.ts
+++ b/ui/src/components/session-leading-indicator.ts
@@ -1,19 +1,13 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { t } from "../i18n/index.ts";
 import type { SidebarRecentSession } from "./app-sidebar-session-types.ts";
-import { icons } from "./icons.ts";
 import {
   renderSessionAttentionIcon,
   renderSessionState,
   sessionHasRunningWork,
 } from "./session-attention-presentation.ts";
-import {
-  renderSessionGlyph,
-  renderSessionUnreadBadge,
-  type SessionGlyphContent,
-} from "./session-glyph.ts";
+import { renderSessionGlyph, renderSessionUnreadBadge } from "./session-glyph.ts";
 import { resolveSessionIconGlyph } from "./session-icon-glyph-registry.ts";
-import type { SessionPullRequestIndicatorState } from "./session-menu-work.ts";
 import { renderSessionOwnerChip, type SessionCreatedActor } from "./session-owner-chip.ts";
 
 type SessionAvatarAuth = {
@@ -29,64 +23,6 @@ function ensureChannelAvatarElement(): void {
   channelAvatarElementLoad ??= import("./channel-avatar.ts");
 }
 
-function renderGlyphBadge(
-  session: SidebarRecentSession,
-  pullRequestState: SessionPullRequestIndicatorState,
-): SessionGlyphContent {
-  if (session.unread && !session.hasActiveRun) {
-    return renderSessionUnreadBadge();
-  }
-  if (pullRequestState === "none") {
-    return nothing;
-  }
-  const label =
-    pullRequestState === "open" ? t("sessionsView.openPullRequest") : t("chat.pullRequests.merged");
-  return html`<span
-    class="session-glyph__badge sidebar-session-pr-indicator--${pullRequestState}"
-    data-session-pr-state=${pullRequestState}
-    role="img"
-    aria-label=${label}
-    title=${label}
-  ></span>`;
-}
-
-function pullRequestStateLabel(
-  pullRequestState: Exclude<SessionPullRequestIndicatorState, "none">,
-) {
-  return pullRequestState === "open"
-    ? t("sessionsView.openPullRequest")
-    : t("chat.pullRequests.merged");
-}
-
-function renderPullRequestIndicator(
-  pullRequestState: SessionPullRequestIndicatorState,
-  showTitle = true,
-) {
-  if (pullRequestState === "none") {
-    return nothing;
-  }
-  const label = pullRequestStateLabel(pullRequestState);
-  return html`<span
-    class="sidebar-session-pr-indicator sidebar-session-pr-indicator--${pullRequestState}"
-    data-session-pr-state=${pullRequestState}
-    role="img"
-    aria-label=${label}
-    title=${showTitle ? label : nothing}
-    >${pullRequestState === "open" ? icons.gitPullRequest : icons.gitMerge}</span
-  >`;
-}
-
-function renderSessionTrailingState(
-  session: SidebarRecentSession,
-  pullRequestState: SessionPullRequestIndicatorState,
-) {
-  const sessionState = renderSessionState(session, false);
-  if (pullRequestState === "none" && sessionState === nothing) {
-    return nothing;
-  }
-  return html`${renderPullRequestIndicator(pullRequestState, false)} ${sessionState}`;
-}
-
 function renderPersistentSessionIcon(icon: string) {
   const glyph = resolveSessionIconGlyph(icon);
   return glyph
@@ -94,17 +30,13 @@ function renderPersistentSessionIcon(icon: string) {
     : html`<span class="session-glyph__emoji" aria-hidden="true">${icon}</span>`;
 }
 
-export function describeSessionTrailingState(
-  session: SidebarRecentSession,
-  pullRequestState: SessionPullRequestIndicatorState,
-) {
+export function describeSessionTrailingState(session: SidebarRecentSession) {
   const runningLabel =
     session.hasActiveRun && session.status === "queued"
       ? t("sessionsView.statusQueued")
       : t("sessionsView.activeRun");
   return [
     session.forkSource ? t("sessionsView.forkedSession") : "",
-    pullRequestState === "none" ? "" : pullRequestStateLabel(pullRequestState),
     sessionHasRunningWork(session) ? runningLabel : "",
     session.unread ? t("sessionsView.unread") : "",
   ]
@@ -114,7 +46,6 @@ export function describeSessionTrailingState(
 
 export function renderSessionLeadingState(
   session: SidebarRecentSession,
-  pullRequestState: SessionPullRequestIndicatorState,
   ownerActor: SessionCreatedActor | null | undefined,
   attribution: "created" | "owned" | "archived",
   ownerViewing?: boolean,
@@ -128,9 +59,7 @@ export function renderSessionLeadingState(
   renderedOwnerId?: string;
 } {
   const running = sessionHasRunningWork(session);
-  const trailingIndicator = session.isChild
-    ? nothing
-    : renderSessionTrailingState(session, pullRequestState);
+  const trailingIndicator = session.isChild ? nothing : renderSessionState(session, false);
   // Transient attention always outranks the persistent decorative icon.
   if (session.isChild) {
     if (session.attention.kind !== "none") {
@@ -139,7 +68,7 @@ export function renderSessionLeadingState(
         leadingIndicator: renderSessionGlyph({
           content: renderSessionAttentionIcon(session.attention),
           running,
-          badge: renderGlyphBadge(session, pullRequestState),
+          badge: session.unread && !session.hasActiveRun ? renderSessionUnreadBadge() : nothing,
         }),
         trailingIndicator,
       };
@@ -150,7 +79,7 @@ export function renderSessionLeadingState(
         leadingIndicator: renderSessionGlyph({
           content: renderPersistentSessionIcon(session.icon),
           running,
-          badge: renderGlyphBadge(session, pullRequestState),
+          badge: session.unread && !session.hasActiveRun ? renderSessionUnreadBadge() : nothing,
         }),
         trailingIndicator,
       };
@@ -167,29 +96,14 @@ export function renderSessionLeadingState(
           ></openclaw-channel-avatar>`,
           running,
           circular: true,
-          badge: renderGlyphBadge(session, pullRequestState),
+          badge: session.unread && !session.hasActiveRun ? renderSessionUnreadBadge() : nothing,
         }),
         trailingIndicator,
       };
     }
-    if (running) {
-      return {
-        running,
-        leadingIndicator: renderSessionState(session),
-        trailingIndicator,
-      };
-    }
-    if (pullRequestState !== "none") {
-      return {
-        running,
-        leadingIndicator: renderPullRequestIndicator(pullRequestState),
-        trailingIndicator,
-      };
-    }
-    const sessionState = renderSessionState(session);
     return {
       running,
-      leadingIndicator: sessionState,
+      leadingIndicator: renderSessionState(session),
       trailingIndicator,
     };
   }

--- a/ui/src/components/session-menu-work.test.ts
+++ b/ui/src/components/session-menu-work.test.ts
@@ -5,10 +5,7 @@ import {
   clearNativeGatewayTestState,
   setNativeGatewayTestState,
 } from "../test-helpers/native-gateways.ts";
-import {
-  fetchSessionMenuWork,
-  resolveSessionPullRequestIndicatorState,
-} from "./session-menu-work.ts";
+import { fetchSessionMenuWork } from "./session-menu-work.ts";
 
 function pullRequest(overrides: Partial<ControlUiSessionPullRequest>): ControlUiSessionPullRequest {
   return {
@@ -43,31 +40,6 @@ describe("isLoopbackHostname", () => {
     ["127.0.0.1.evil.com", false],
   ])("classifies %s as loopback: %s", (hostname, expected) => {
     expect(isLoopbackHostname(hostname)).toBe(expected);
-  });
-});
-
-describe("session pull request indicators", () => {
-  it.each([
-    {
-      name: "prioritizes an active PR over merged history",
-      pullRequests: [
-        pullRequest({ number: 1, state: "merged" }),
-        pullRequest({ number: 2, state: "draft" }),
-      ],
-      expected: "open",
-    },
-    {
-      name: "shows merged history",
-      pullRequests: [pullRequest({ state: "merged" })],
-      expected: "merged",
-    },
-    {
-      name: "ignores closed history",
-      pullRequests: [pullRequest({ state: "closed" })],
-      expected: "none",
-    },
-  ] as const)("$name", ({ pullRequests, expected }) => {
-    expect(resolveSessionPullRequestIndicatorState(pullRequests)).toBe(expected);
   });
 });
 

--- a/ui/src/components/session-menu-work.ts
+++ b/ui/src/components/session-menu-work.ts
@@ -22,8 +22,6 @@ type SessionMenuWorkResult = {
   worktreePath: string | null;
 };
 
-export type SessionPullRequestIndicatorState = "none" | "open" | "merged";
-
 // Menu offers a single Open PR action; prefer the PR a maintainer most
 // likely wants: active first, merged history next, closed last.
 const PR_STATE_ORDER = ["open", "draft", "merged", "closed"] as const;
@@ -38,15 +36,6 @@ function pickSessionMenuPullRequestUrl(
     }
   }
   return null;
-}
-
-export function resolveSessionPullRequestIndicatorState(
-  pullRequests: readonly ControlUiSessionPullRequest[],
-): SessionPullRequestIndicatorState {
-  if (pullRequests.some(({ state }) => state === "open" || state === "draft")) {
-    return "open";
-  }
-  return pullRequests.some(({ state }) => state === "merged") ? "merged" : "none";
 }
 
 async function loadPullRequestUrl(params: SessionMenuWorkParams): Promise<string | null> {

--- a/ui/src/components/session-row-badges.ts
+++ b/ui/src/components/session-row-badges.ts
@@ -148,7 +148,7 @@ export function renderSessionRowBadges(params: {
     ${pullRequestLabel
       ? renderSessionRowBadge(
           pullRequestLabel,
-          icons.gitPullRequest,
+          pullRequestState === "merged" ? icons.gitMerge : icons.gitPullRequest,
           "session-row-badge--pull-request",
           0,
           pullRequestState,

--- a/ui/src/e2e/session-management.trailing-state.e2e.test.ts
+++ b/ui/src/e2e/session-management.trailing-state.e2e.test.ts
@@ -319,7 +319,7 @@ suite.define(() => {
       const pullRequestRow = page.locator(`[data-session-key="${pullRequestKey}"]`);
       await plainRow.waitFor({ state: "visible", timeout: 10_000 });
       await expect
-        .poll(() => pullRequestRow.locator("[data-session-pr-state='merged']").isVisible())
+        .poll(() => pullRequestRow.locator("[data-pull-request-state='merged']").isVisible())
         .toBe(true);
 
       const dotInsetFromRowRight = async (row: typeof plainRow) => {
@@ -472,17 +472,24 @@ suite.define(() => {
         .toBe(true);
       await expect.poll(() => state.locator('[aria-label="Forked session"]').count()).toBe(0);
       await expect
-        .poll(() => state.locator("[data-session-pr-state='open']").isVisible())
+        .poll(() => row.locator("[data-pull-request-state='open']").isVisible())
         .toBe(true);
       await expect.poll(() => state.locator(".session-run-spinner").isVisible()).toBe(true);
       await expect.poll(() => state.locator(".session-unread-dot").count()).toBe(0);
+      const prIcon = row.locator("[data-pull-request-state='open'] svg");
+      expect(
+        await prIcon.evaluate((icon) => {
+          const { width, height } = icon.getBoundingClientRect();
+          return { width, height };
+        }),
+      ).toEqual({ width: 12, height: 12 });
       const stateLayout = await row.evaluate((element) => {
         const endcap = element.querySelector<HTMLElement>(
           ".sidebar-recent-session__details-endcap",
         );
         const atoms = Array.from(
           element.querySelectorAll<HTMLElement>(
-            ".session-row-state :is([data-session-pr-state='open'], .session-run-spinner)",
+            ".sidebar-recent-session__details-endcap :is([data-pull-request-state='open'], .session-run-spinner)",
           ),
         );
         if (!endcap || atoms.length !== 2) {

--- a/ui/src/lib/session-pull-requests.ts
+++ b/ui/src/lib/session-pull-requests.ts
@@ -1,5 +1,7 @@
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
+import type { SessionCatalogPullRequestSummary } from "../../../packages/gateway-protocol/src/schema/sessions-catalog.js";
 import type {
+  ControlUiSessionPullRequest,
   ControlUiSessionPullRequestSnapshot,
   ControlUiSessionPullRequestsChanged,
 } from "../../../src/gateway/control-ui-contract.js";
@@ -17,6 +19,27 @@ import {
   parseAgentSessionKey,
   uiSessionEventMatches,
 } from "./sessions/session-key.ts";
+
+export function summarizeSessionPullRequests(
+  pullRequests: readonly ControlUiSessionPullRequest[],
+  previous?: SessionCatalogPullRequestSummary,
+): SessionCatalogPullRequestSummary | undefined {
+  // Keep active work ahead of newer merged/closed history, as the sidebar and PR menu do.
+  const current =
+    pullRequests.find(({ state }) => state === "open") ??
+    pullRequests.find(({ state }) => state === "draft") ??
+    pullRequests.find(({ state }) => state === "merged") ??
+    pullRequests[0];
+  if (!current) {
+    return undefined;
+  }
+  const numbers = [...new Set(pullRequests.map((pullRequest) => pullRequest.number))]
+    .slice(0, 20)
+    .toSorted((left, right) => left - right);
+  return previous?.state === current.state && previous.numbers.join(",") === numbers.join(",")
+    ? previous
+    : { numbers, state: current.state };
+}
 
 export const SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD = "controlUi.sessionPullRequests.subscribe";
 

--- a/ui/src/pages/chat/chat-pane-session.ts
+++ b/ui/src/pages/chat/chat-pane-session.ts
@@ -11,6 +11,7 @@ import { clampText } from "../../lib/format.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { readSessionMethodAccess } from "../../lib/session-method-access.ts";
 import {
+  summarizeSessionPullRequests,
   scopedSessionPullRequestKey,
   SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD,
   sessionPullRequestsForGateway,
@@ -31,7 +32,6 @@ import {
   catalogRawResult,
   catalogRawString,
   nativeHistoryMessageIdentity,
-  summarizeSessionPullRequests,
 } from "./chat-pane-shared.ts";
 import { ChatPaneTaskSuggestions } from "./chat-pane-task-suggestions.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";

--- a/ui/src/pages/chat/chat-pane-shared.ts
+++ b/ui/src/pages/chat/chat-pane-shared.ts
@@ -1,6 +1,4 @@
 import { asNullableRecord as catalogRawRecord } from "@openclaw/normalization-core/record-coerce";
-import type { SessionCatalogPullRequestSummary } from "../../../../packages/gateway-protocol/src/index.js";
-import type { ControlUiSessionPullRequest } from "../../../../src/gateway/control-ui-contract.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { createDockPanelLayout } from "../../components/dock-panel-layout.ts";
@@ -246,22 +244,6 @@ export const NEW_SESSION_LIST_LOADING_MESSAGE =
   "Session list is still refreshing. Try New Chat again in a moment.";
 export const NEW_SESSION_CREATE_FAILED_MESSAGE =
   "New Chat could not create a new thread. Try again in a moment.";
-
-export function summarizeSessionPullRequests(
-  pullRequests: readonly ControlUiSessionPullRequest[],
-  previous?: SessionCatalogPullRequestSummary,
-): SessionCatalogPullRequestSummary | undefined {
-  const current = pullRequests[0];
-  if (!current) {
-    return undefined;
-  }
-  const numbers = [...new Set(pullRequests.map((pullRequest) => pullRequest.number))]
-    .slice(0, 20)
-    .toSorted((left, right) => left - right);
-  return previous?.state === current.state && previous.numbers.join(",") === numbers.join(",")
-    ? previous
-    : { numbers, state: current.state };
-}
 
 export function keyboardEventPathMatches(event: KeyboardEvent, selector: string): boolean {
   return event

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -5621,13 +5621,6 @@ td.data-table-key-col {
   pointer-events: none;
 }
 
-/* The 16px PR glyph inks 1px beyond its 14px track. Inset only that glyph so
-   the other trailing atoms keep their shared axis inside the clipped endcap. */
-.session-row-state [data-session-pr-state] {
-  position: relative;
-  left: 1px;
-}
-
 .sidebar-session-fork-indicator {
   display: inline-flex;
   margin-right: 4px;
@@ -5672,7 +5665,7 @@ td.data-table-key-col {
 }
 
 .session-row-badge--pull-request[data-pull-request-state="merged"] {
-  color: var(--accent);
+  color: var(--pr-merged);
 }
 
 .session-row-badge--cloud[data-placement-state="failed"],

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -4319,24 +4319,6 @@ html:not(.openclaw-native-macos):not(.openclaw-native-nav):not(.openclaw-native-
   font-size: 6px;
 }
 
-.sidebar-session-pr-indicator--open {
-  color: var(--ok);
-}
-
-.sidebar-session-pr-indicator--merged {
-  color: var(--pr-merged);
-}
-
-.sidebar-session-pr-indicator svg {
-  width: 16px;
-  height: 16px;
-  fill: none;
-  stroke: currentColor;
-  stroke-width: 1.7px;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-}
-
 .sidebar-recent-session__text {
   display: flex;
   flex: 1 1 auto;

--- a/ui/src/test-helpers/app-sidebar-cases/session-indicators.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-indicators.ts
@@ -368,9 +368,10 @@ describe("AppSidebar session indicators", () => {
     await waitForFast(() =>
       expect(sidebar.querySelectorAll(".sidebar-recent-session--child")).toHaveLength(4),
     );
-    Object.assign(sidebar, {
-      sessionPullRequestIndicatorState: (key: string) =>
-        key === mergedPullRequestKey ? "merged" : "open",
+    sessions.sessions.setPullRequestSummary(openPullRequestKey, { numbers: [1], state: "open" });
+    sessions.sessions.setPullRequestSummary(mergedPullRequestKey, {
+      numbers: [2],
+      state: "merged",
     });
     sidebar.requestUpdate();
     await sidebar.updateComplete;
@@ -378,12 +379,12 @@ describe("AppSidebar session indicators", () => {
     await waitForFast(() => {
       expect(
         sidebar.querySelector(
-          `[data-session-key="${openPullRequestKey}"] [data-session-pr-state="open"]`,
+          `[data-session-key="${openPullRequestKey}"] [data-pull-request-state="open"]`,
         ),
       ).not.toBeNull();
       expect(
         sidebar.querySelector(
-          `[data-session-key="${mergedPullRequestKey}"] [data-session-pr-state="merged"]`,
+          `[data-session-key="${mergedPullRequestKey}"] [data-pull-request-state="merged"]`,
         ),
       ).not.toBeNull();
     });
@@ -395,7 +396,7 @@ describe("AppSidebar session indicators", () => {
     const runningLead = runningRow?.querySelector(".sidebar-session-indicator");
     expect(pinnedLead).not.toBeNull();
     expect(pinnedLead?.innerHTML).toBe(runningLead?.innerHTML);
-    expect(pinnedLead?.querySelector("[data-session-pr-state]")).toBeNull();
+    expect(pinnedLead?.querySelector("[data-pull-request-state]")).toBeNull();
     expect(pinnedRow?.querySelector(".session-row-state")).toBeNull();
 
     const attentionLead = sidebar.querySelector(
@@ -404,7 +405,7 @@ describe("AppSidebar session indicators", () => {
     expect(attentionLead?.querySelector('[data-session-attention="agent"]')).not.toBeNull();
     expect(attentionLead?.querySelector(".session-glyph__ring")).not.toBeNull();
     expect(attentionLead?.querySelector(".session-glyph__badge--unread")).toBeNull();
-    expect(attentionLead?.querySelector('[data-session-pr-state="open"]')).not.toBeNull();
+    expect(attentionLead?.querySelector("[data-pull-request-state]")).toBeNull();
     const attentionLink = sidebar.querySelector(
       `[data-session-key="${openPullRequestKey}"] .sidebar-recent-session__link`,
     );
@@ -487,9 +488,18 @@ describe("AppSidebar session indicators", () => {
     });
 
     await waitForFast(() => {
-      expect(sidebar.querySelector('[data-session-pr-state="open"]')).not.toBeNull();
-      expect(sidebar.querySelector('[data-session-pr-state="merged"]')).not.toBeNull();
+      expect(sidebar.querySelector('[data-pull-request-state="open"]')).not.toBeNull();
+      expect(sidebar.querySelector('[data-pull-request-state="merged"]')).not.toBeNull();
     });
+    // Opening chat hydrates its detailed summary from the same pushed snapshot.
+    // It must not add a second PR icon beside the sidebar's existing indicator.
+    sessions.sessions.setPullRequestSummary(keys.openPullRequest, { numbers: [1], state: "open" });
+    await sidebar.updateComplete;
+    expect(
+      sidebar.querySelectorAll(
+        `[data-session-key="${keys.openPullRequest}"] :is([data-session-pr-state], [data-pull-request-state])`,
+      ),
+    ).toHaveLength(1);
     const plain = sidebar.querySelector(`[data-session-key="${keys.plain}"]`);
     expectEmptyLead(plain);
     expect(plain?.querySelector(".session-row-state")).toBeNull();
@@ -534,10 +544,10 @@ describe("AppSidebar session indicators", () => {
     );
 
     const openPullRequestIcon = sidebar.querySelector(
-      `[data-session-key="${keys.openPullRequest}"] [data-session-pr-state="open"] svg`,
+      `[data-session-key="${keys.openPullRequest}"] [data-pull-request-state="open"] svg`,
     );
     const mergedPullRequestIcon = sidebar.querySelector(
-      `[data-session-key="${keys.mergedPullRequest}"] [data-session-pr-state="merged"] svg`,
+      `[data-session-key="${keys.mergedPullRequest}"] [data-pull-request-state="merged"] svg`,
     );
     expect(openPullRequestIcon).not.toBeNull();
     expect(mergedPullRequestIcon).not.toBeNull();
@@ -546,19 +556,20 @@ describe("AppSidebar session indicators", () => {
     for (const key of [keys.openPullRequest, keys.mergedPullRequest]) {
       const row = sidebar.querySelector(`[data-session-key="${key}"]`);
       expectEmptyLead(row);
-      expect(row?.querySelector(".session-row-state [data-session-pr-state]")).not.toBeNull();
+      expect(row?.querySelector(".session-row-badges [data-pull-request-state]")).not.toBeNull();
       expect(row?.querySelector("a")?.hasAttribute("title")).toBe(false);
-      expect(row?.querySelector("[data-session-pr-state]")?.hasAttribute("title")).toBe(false);
+      expect(row?.querySelector("[data-pull-request-state]")?.hasAttribute("title")).toBe(false);
     }
 
     const openPullRequestRow = result.sessions.find((row) => row.key === keys.openPullRequest);
     if (!openPullRequestRow) {
       throw new Error("expected open PR session");
     }
+    sessions.sessions.setPullRequestSummary(keys.openPullRequest, undefined);
     openPullRequestRow.worktree = undefined;
     sessions.publishList({ result });
     await waitForFast(() => {
-      expect(sidebar.querySelector('[data-session-pr-state="open"]')).toBeNull();
+      expect(sidebar.querySelector('[data-pull-request-state="open"]')).toBeNull();
       expectEmptyLead(sidebar.querySelector(`[data-session-key="${keys.openPullRequest}"]`));
     });
   });


### PR DESCRIPTION
Closes #131486

## What Problem This Solves

Fixes an issue where users opening a worktree session with a pull request see two differently sized PR-status icons in its sidebar row. Chat summary hydration adds a second icon beside the sidebar's existing worktree indicator.

## Why This Change Was Made

The sidebar now resolves one detailed PR summary and renders it through the existing shared badge. The separate coarse-state renderer, extra glyph styling, and obsolete size-offset rule are removed. Catalog-only, adopted, and child rows share that badge; active PRs outrank merged/closed history, and an authoritative empty snapshot clears stale initial summaries.

## User Impact

One consistently sized 12px PR badge per row, with PR numbers and state in the tooltip. Open stays green, merged stays purple with the merge glyph, and draft/closed state remains available. Running and unread indicators remain independent. No configuration, persistence, or Gateway protocol changes.

## Evidence

### Live before / after

Same selected worktree session and real GitHub PR, through an isolated running Gateway. No mocked HTTP or WebSocket responses. Sanitized session metadata only; no conversation transcripts. Both captures were visually inspected.

| Before: duplicate 12px + 16px icons | After: one 12px badge |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/1faa723e-ec2a-4daa-9497-bdf919a89c25" width="260" alt="Before: two green PR icons in the selected sidebar row"> | <img src="https://github.com/user-attachments/assets/92232176-83ff-443a-8dc8-e2a197a035a2" width="260" alt="After: one green PR icon in the selected sidebar row"> |

Measured selected-row indicators: **2 → 1**. Tooltip remains `#131488 · Open`; merged badges retain the purple merge glyph.

- Pre-fix owner-boundary regression reproduced two PR indicators after summary hydration; fixed regression passes.
- 385 focused tests passed across sidebar, PR snapshot lifecycle, summary lifecycle, badges, and catalog paths; 7 additional chat PR integration tests passed.
- Six real-Chromium layout tests passed: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-management.trailing-state.e2e.test.ts`.
- UI build, UI typecheck, targeted lint, changed stylesheet checks, formatting, and `git diff --check` passed.
- Fresh autoreview completed cleanly after final semantic edits.
- Full `pnpm build` and `node scripts/check-changed.mjs` passed.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/33139763872 (cf86393fb230e6a1cc9649e8687ce89177f6e405).

Architectural owner: sidebar PR snapshot projection + shared row badges. A CSS-only hide or retaining the coarse renderer would preserve duplicate rendering or lose PR numbers/draft/closed state.

Production LOC: +61/-178 (net -117). Tests/test support: +118/-102 (net +16). Shared summarization was moved, not duplicated.

AI-assisted.
