### PR TITLE
fix: gateway status normalizes runtime inspection errors

### DIFF
--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -836,7 +836,7 @@ describe("gatherDaemonStatus", () => {
     expect((status.service.runtime as { detail?: string }).detail).toBe("19001");
   });
 
-  it("bounds all service-manager reads and still emits JSON after they time out", async () => {
+  it("renders Gateway-specific recovery in text and JSON after service reads time out", async () => {
     serviceIsLoaded.mockImplementationOnce(async (args?: { timeoutMs?: number }) => {
       if (args?.timeoutMs === undefined) {
         return await new Promise<boolean>(() => {});
@@ -847,7 +847,7 @@ describe("gatherDaemonStatus", () => {
       if (opts?.timeoutMs === undefined) {
         return await new Promise<{ status: string }>(() => {});
       }
-      throw new Error("systemctl show timed out");
+      throw new Error("錯誤: 系統找不到指定的檔案。");
     });
 
     const status = await gatherStatus({
@@ -868,7 +868,11 @@ describe("gatherDaemonStatus", () => {
     expect(status.service.loaded).toBeNull();
     expect(status.service.runtime).toEqual({
       status: "unknown",
-      detail: "Error: systemctl show timed out",
+      detail: "service runtime inspection failed; retry with openclaw gateway status --deep",
+      inspectionFailure: {
+        code: "service-runtime-inspection-failed",
+        detail: "錯誤: 系統找不到指定的檔案。",
+      },
     });
 
     const writeJson = vi.spyOn(defaultRuntime, "writeJson").mockImplementation(() => {});
@@ -888,7 +892,11 @@ describe("gatherDaemonStatus", () => {
           },
           runtime: {
             status: "unknown",
-            detail: "Error: systemctl show timed out",
+            detail: "service runtime inspection failed; retry with openclaw gateway status --deep",
+            inspectionFailure: {
+              code: "service-runtime-inspection-failed",
+              detail: "錯誤: 系統找不到指定的檔案。",
+            },
           },
         },
       });
@@ -903,7 +911,10 @@ describe("gatherDaemonStatus", () => {
       const output = log.mock.calls.flat().join("\n");
       expect(output).toContain("Service: LaunchAgent (unknown)");
       expect(output).not.toContain("Service: LaunchAgent (not loaded)");
-      expect(output).toContain("Runtime: unknown (Error: systemctl show timed out)");
+      expect(output).toContain(
+        "Runtime: unknown (service runtime inspection failed; retry with openclaw gateway status --deep)",
+      );
+      expect(output).not.toContain("系統找不到指定的檔案");
     } finally {
       log.mockRestore();
       error.mockRestore();

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -796,7 +796,12 @@ export async function gatherDaemonStatus(
       notLoadedText: service.notLoadedText,
       targetRole: serviceTargetsProbe ? "target" : "diagnostic-only",
       command,
-      runtime,
+      runtime: runtime?.inspectionFailure
+        ? {
+            ...runtime,
+            detail: `${runtime.detail}; retry with openclaw gateway status --deep`,
+          }
+        : runtime,
       configAudit,
       ...(command
         ? {

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -400,7 +400,10 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
     defaultRuntime.error(errorText(`Retry: ${formatCliCommand("openclaw gateway status --deep")}`));
     spacer();
   }
-  const systemdUnavailableDetail = serviceInspectionDetail ?? service.runtime?.detail;
+  const systemdUnavailableDetail =
+    serviceInspectionDetail ??
+    service.runtime?.inspectionFailure?.detail ??
+    service.runtime?.detail;
   const systemdUnavailable =
     process.platform === "linux" &&
     (serviceInspectionDetail !== undefined || rpc?.ok !== true) &&

--- a/src/commands/doctor-format.test.ts
+++ b/src/commands/doctor-format.test.ts
@@ -58,6 +58,22 @@ describe("buildGatewayRuntimeHints", () => {
     expect(hints.join("\n")).not.toContain("systemd user services are unavailable");
   });
 
+  it("classifies systemd recovery from structured inspection diagnostics", () => {
+    const hints = buildGatewayRuntimeHints(
+      {
+        status: "unknown",
+        detail: "service runtime inspection failed; retry with openclaw status --deep",
+        inspectionFailure: {
+          code: "service-runtime-inspection-failed",
+          detail: "systemctl --user unavailable: Failed to connect to bus",
+        },
+      },
+      { platform: "linux", env: {} },
+    );
+
+    expect(hints.some((hint) => hint.includes("systemd user services are unavailable"))).toBe(true);
+  });
+
   it.each([
     {
       env: { OPENCLAW_PROFILE: "blue" },

--- a/src/commands/doctor-format.ts
+++ b/src/commands/doctor-format.ts
@@ -51,11 +51,12 @@ export function buildGatewayRuntimeHints(
       return null;
     }
   })();
-  if (platform === "linux" && isSystemdUnavailableDetail(runtime.detail)) {
+  const systemdDetail = runtime.inspectionFailure?.detail ?? runtime.detail;
+  if (platform === "linux" && isSystemdUnavailableDetail(systemdDetail)) {
     hints.push(
       ...renderSystemdUnavailableHints({
         wsl: isWSLEnv(env),
-        kind: classifySystemdUnavailableDetail(runtime.detail),
+        kind: classifySystemdUnavailableDetail(systemdDetail),
         env,
       }),
     );

--- a/src/commands/status.daemon.real-summary.test.ts
+++ b/src/commands/status.daemon.real-summary.test.ts
@@ -1,0 +1,57 @@
+// Status daemon real-summary tests cover the shared service-state path for node services.
+import { expect, it, vi } from "vitest";
+import { createMockGatewayService } from "../daemon/service.test-helpers.js";
+import { formatStatusServiceValue } from "./status-all/format.js";
+
+const mocks = vi.hoisted(() => ({
+  resolveNodeService: vi.fn(),
+}));
+
+vi.mock("../daemon/node-service.js", () => ({
+  resolveNodeService: mocks.resolveNodeService,
+}));
+
+const { getNodeDaemonStatusSummary } = await import("./status.daemon.js");
+
+it("renders root-status recovery guidance for a rejected node runtime", async () => {
+  mocks.resolveNodeService.mockReturnValue(
+    createMockGatewayService({
+      label: "systemd user",
+      loadedText: "enabled",
+      notLoadedText: "disabled",
+      readRuntime: vi.fn(async () => {
+        throw new Error("node service manager unavailable");
+      }),
+    }),
+  );
+
+  const summary = await getNodeDaemonStatusSummary();
+
+  expect(summary.runtime).toEqual({
+    status: "unknown",
+    detail: "service runtime inspection failed; retry with openclaw status --deep",
+    inspectionFailure: {
+      code: "service-runtime-inspection-failed",
+      detail: "node service manager unavailable",
+    },
+  });
+  expect(formatStatusServiceValue(summary)).toBe(
+    "systemd user disabled (inspection failed: service runtime inspection failed; retry with openclaw status --deep) · unknown",
+  );
+});
+
+it("preserves legitimate node runtime detail", async () => {
+  mocks.resolveNodeService.mockReturnValue(
+    createMockGatewayService({
+      readRuntime: vi.fn(async () => ({
+        status: "unknown",
+        detail: "node process state is inconclusive",
+      })),
+    }),
+  );
+
+  const summary = await getNodeDaemonStatusSummary();
+
+  expect(summary.runtime?.detail).toBe("node process state is inconclusive");
+  expect(summary.runtimeShort).toBe("unknown (node process state is inconclusive)");
+});

--- a/src/commands/status.daemon.ts
+++ b/src/commands/status.daemon.ts
@@ -27,6 +27,9 @@ async function buildDaemonStatusSummary(
   const service = serviceLabel === "gateway" ? resolveGatewayService() : resolveNodeService();
   const fallbackLabel = serviceLabel === "gateway" ? "Daemon" : "Node";
   const summary = await readServiceStatusSummary(service, fallbackLabel, timeoutMs);
+  const runtime = summary.runtime?.inspectionFailure
+    ? { ...summary.runtime, detail: `${summary.runtime.detail}; retry with openclaw status --deep` }
+    : summary.runtime;
   const loaded =
     summary.loadState.status === "unknown" ? null : summary.loadState.status === "loaded";
   return {
@@ -37,8 +40,8 @@ async function buildDaemonStatusSummary(
     managedByOpenClaw: summary.managedByOpenClaw,
     externallyManaged: summary.externallyManaged,
     loadedText: summary.loadedText,
-    runtime: summary.runtime,
-    runtimeShort: formatDaemonRuntimeShort(summary.runtime),
+    runtime,
+    runtimeShort: formatDaemonRuntimeShort(runtime),
     layout: summary.layout,
     wrapperPath: summary.wrapperPath,
   };

--- a/src/commands/status.format.ts
+++ b/src/commands/status.format.ts
@@ -6,6 +6,7 @@ import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text
 import { formatCliCommand } from "../cli/command-format.js";
 import type { BestEffortConfigSnapshot } from "../config/io.js";
 import { formatConfigIssueLines } from "../config/issue-format.js";
+import type { GatewayServiceRuntime } from "../daemon/service-runtime.js";
 import { getSystemdCgroupHygieneSummary } from "../daemon/service-runtime.js";
 import { formatDurationPrecise } from "../infra/format-time/format-duration.ts";
 import { formatRuntimeStatusWithDetails } from "../infra/runtime-status.ts";
@@ -118,19 +119,12 @@ function resolvePromptCacheStats(
 }
 
 /** Formats daemon runtime status plus launchd/systemd details into one compact string. */
-export const formatDaemonRuntimeShort = (runtime?: {
-  status?: string;
-  pid?: number;
-  state?: string;
-  systemd?: { killMode?: string; tasksCurrent?: number; memoryCurrent?: number };
-  detail?: string;
-  missingUnit?: boolean;
-}) => {
+export const formatDaemonRuntimeShort = (runtime?: GatewayServiceRuntime) => {
   if (!runtime) {
     return null;
   }
   const details: string[] = [];
-  const detail = runtime.detail?.replace(/\s+/g, " ").trim() || "";
+  const detail = runtime.inspectionFailure ? "" : runtime.detail?.replace(/\s+/g, " ").trim() || "";
   const noisyLaunchctlDetail =
     runtime.missingUnit === true &&
     normalizeLowercaseStringOrEmpty(detail).includes("could not find service");

--- a/src/commands/status.service-summary.test.ts
+++ b/src/commands/status.service-summary.test.ts
@@ -111,8 +111,16 @@ describe("readServiceStatusSummary", () => {
       expect(formatStatusServiceValue(summary)).toBe(
         probe === "load"
           ? "systemd unknown (inspection failed: Error: service manager permission denied) · stopped"
-          : "systemd disabled (inspection failed: Error: service manager permission denied) · unknown",
+          : probe === "runtime"
+            ? "systemd disabled (inspection failed: service runtime inspection failed) · unknown"
+            : "systemd disabled (inspection failed: Error: service manager permission denied) · unknown",
       );
+      if (probe === "runtime") {
+        expect(summary.runtime?.inspectionFailure).toEqual({
+          code: "service-runtime-inspection-failed",
+          detail: "service manager permission denied",
+        });
+      }
     },
   );
 

--- a/src/daemon/schtasks-runtime.ts
+++ b/src/daemon/schtasks-runtime.ts
@@ -31,7 +31,10 @@ import {
   shouldManageGatewayListenerPort,
   terminateGatewayProcessTree,
 } from "./schtasks-process.js";
-import type { GatewayServiceRuntime } from "./service-runtime.js";
+import {
+  createServiceRuntimeInspectionFailure,
+  type GatewayServiceRuntime,
+} from "./service-runtime.js";
 import type {
   GatewayServiceCommandConfig,
   GatewayServiceEnv,
@@ -538,7 +541,7 @@ export async function readScheduledTaskRuntime(
     if (await isStartupEntryInstalled(env)) {
       return resolveFallbackRuntime(env);
     }
-    return { status: "unknown", detail: String(err) };
+    return createServiceRuntimeInspectionFailure(err);
   }
   const taskName = resolveTaskName(env);
   const res = await execSchtasks(["/Query", "/TN", taskName, "/V", "/FO", "LIST"]);
@@ -548,11 +551,9 @@ export async function readScheduledTaskRuntime(
     }
     const detail = (res.stderr || res.stdout).trim();
     const missing = probeScheduledTaskExists(taskName) === false;
-    return {
-      status: missing ? "stopped" : "unknown",
-      ...(!missing && detail ? { detail } : {}),
-      missingUnit: missing,
-    };
+    return missing
+      ? { status: "stopped", missingUnit: true }
+      : { ...createServiceRuntimeInspectionFailure(detail), missingUnit: false };
   }
   const parsed = parseSchtasksQuery(res.stdout || "");
   const derived = deriveScheduledTaskRuntimeStatus(parsed);

--- a/src/daemon/schtasks.startup-fallback.test.ts
+++ b/src/daemon/schtasks.startup-fallback.test.ts
@@ -96,6 +96,9 @@ const {
   uninstallScheduledTask,
 } = await import("./schtasks.js");
 const { launchFallbackTaskScript, removeStartupEntries } = await import("./schtasks-runtime.js");
+const { createMockGatewayService } = await import("./service.test-helpers.js");
+const { readServiceStatusSummary } = await import("../commands/status.service-summary.js");
+const { formatStatusServiceValue } = await import("../commands/status-all/format.js");
 
 function createSpawnChild(error?: Error): ChildProcess {
   const child = new EventEmitter() as ChildProcess;
@@ -509,7 +512,22 @@ describe("Windows startup fallback", () => {
     });
   });
 
-  it("keeps unexpected scheduled-task query failures visible", async () => {
+  it("normalizes a localized schtasks availability failure", async () => {
+    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+      schtasksResponses.push({ code: 1, stdout: "", stderr: "错误: 拒绝访问。" });
+
+      await expect(readScheduledTaskRuntime(env)).resolves.toEqual({
+        status: "unknown",
+        detail: "service runtime inspection failed",
+        inspectionFailure: {
+          code: "service-runtime-inspection-failed",
+          detail: "schtasks unavailable: 错误: 拒绝访问。",
+        },
+      });
+    });
+  });
+
+  it("normalizes unexpected scheduled-task failures through the shared status summary", async () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
       const detail = "Zugriff verweigert";
       schtasksResponses.push(
@@ -518,11 +536,29 @@ describe("Windows startup fallback", () => {
       );
       spawnSync.mockReturnValue(makeSpawnSyncResult({ status: 1, stdout: "-2147024891" }));
 
-      await expect(readScheduledTaskRuntime(env)).resolves.toEqual({
+      const summary = await readServiceStatusSummary(
+        createMockGatewayService({
+          label: "Scheduled Task",
+          loadedText: "registered",
+          notLoadedText: "missing",
+          readRuntime: () => readScheduledTaskRuntime(env),
+        }),
+        "Daemon",
+      );
+
+      expect(summary.runtime).toEqual({
         status: "unknown",
-        detail,
+        detail: "service runtime inspection failed",
+        inspectionFailure: {
+          code: "service-runtime-inspection-failed",
+          detail,
+        },
         missingUnit: false,
       });
+      expect(formatStatusServiceValue(summary)).toBe(
+        "Scheduled Task missing (inspection failed: service runtime inspection failed) · unknown",
+      );
+      expect(formatStatusServiceValue(summary)).not.toContain(detail);
     });
   });
 

--- a/src/daemon/service-runtime.ts
+++ b/src/daemon/service-runtime.ts
@@ -1,5 +1,7 @@
 /** Shared daemon runtime status types and systemd cgroup hygiene helpers. */
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 
 /** systemd supervision fields used to spot unhealthy or given-up gateway service state. */
 type GatewayServiceSystemdRuntime = {
@@ -25,6 +27,11 @@ export type GatewayServiceRuntime = {
   lastRunResult?: string;
   lastRunTime?: string;
   detail?: string;
+  /** Bounded platform detail for classifiers/debug JSON; never render as the primary status. */
+  inspectionFailure?: {
+    code: "service-runtime-inspection-failed";
+    detail: string;
+  };
   cachedLabel?: boolean;
   missingUnit?: boolean;
   missingSupervision?: boolean;
@@ -37,6 +44,24 @@ export type GatewayServiceRuntime = {
   };
   systemd?: GatewayServiceSystemdRuntime;
 };
+
+const SERVICE_RUNTIME_INSPECTION_ERROR_MAX_CHARS = 500;
+const SERVICE_RUNTIME_INSPECTION_FAILED_DETAIL = "service runtime inspection failed";
+
+/** Keeps native probe failures bounded and diagnostic-only for status presentation owners. */
+export function createServiceRuntimeInspectionFailure(error: unknown): GatewayServiceRuntime {
+  const rawDetail = error instanceof Error ? error.message : String(error);
+  return {
+    status: "unknown",
+    detail: SERVICE_RUNTIME_INSPECTION_FAILED_DETAIL,
+    inspectionFailure: {
+      code: "service-runtime-inspection-failed",
+      detail:
+        truncateUtf16Safe(sanitizeForLog(rawDetail), SERVICE_RUNTIME_INSPECTION_ERROR_MAX_CHARS) ||
+        "unknown error",
+    },
+  };
+}
 
 const SYSTEMD_TASKS_CURRENT_WARNING_THRESHOLD = 200;
 const SYSTEMD_MEMORY_CURRENT_WARNING_BYTES = 2 * 1024 * 1024 * 1024;

--- a/src/daemon/service.test.ts
+++ b/src/daemon/service.test.ts
@@ -315,13 +315,13 @@ describe("readGatewayServiceState", () => {
     });
   });
 
-  it("preserves runtime probe failures as an explicit unknown state", async () => {
+  it("normalizes localized runtime probe failures at the service boundary", async () => {
     const readCommand = vi.fn(async () => null);
     const service = createService({
       isLoaded: vi.fn(async () => true),
       readCommand,
       readRuntime: vi.fn(async () => {
-        throw new Error("systemctl show timed out");
+        throw new Error("錯誤: 系統找不到指定的檔案。");
       }),
     });
 
@@ -331,8 +331,27 @@ describe("readGatewayServiceState", () => {
     expect(state.running).toBe(false);
     expect(state.runtime).toEqual({
       status: "unknown",
-      detail: "Error: systemctl show timed out",
+      detail: "service runtime inspection failed",
+      inspectionFailure: {
+        code: "service-runtime-inspection-failed",
+        detail: "錯誤: 系統找不到指定的檔案。",
+      },
     });
+  });
+
+  it("bounds structured runtime inspection diagnostics", async () => {
+    const service = createService({
+      readRuntime: vi.fn(async () => {
+        throw new Error("錯".repeat(600));
+      }),
+    });
+
+    const state = await readGatewayServiceState(service);
+
+    expect(state.runtime?.inspectionFailure).toMatchObject({
+      code: "service-runtime-inspection-failed",
+    });
+    expect(state.runtime?.inspectionFailure?.detail).toHaveLength(500);
   });
 
   it("preserves loaded-state probe failures as an explicit unknown state", async () => {

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -31,7 +31,10 @@ import {
 } from "./schtasks.js";
 import { mergeGatewayServiceEnv } from "./service-env-merge.js";
 import { resolveServiceEntrypoint } from "./service-layout.js";
-import type { GatewayServiceRuntime } from "./service-runtime.js";
+import {
+  createServiceRuntimeInspectionFailure,
+  type GatewayServiceRuntime,
+} from "./service-runtime.js";
 import type {
   GatewayServiceCommandConfig,
   GatewayServiceControlArgs,
@@ -110,7 +113,6 @@ type ReadGatewayServiceStateArgs = GatewayServiceEnvArgs & {
 const TEMP_PROGRAM_ROOTS = [os.tmpdir(), "/tmp", "/private/tmp", "/var/tmp"].map((entry) =>
   path.resolve(entry),
 );
-
 function pathIsSameOrChild(candidate: string, parent: string): boolean {
   return candidate === parent || candidate.startsWith(`${parent}${path.sep}`);
 }
@@ -213,10 +215,9 @@ export async function readGatewayServiceState(
       ? true
       : (service.hasInstalledDefinition?.({ env, timeoutMs }).catch(() => false) ?? false),
     readGatewayServiceLoadState(service, { env, timeoutMs }),
-    service.readRuntime(env, { timeoutMs }).catch((error: unknown) => ({
-      status: "unknown" as const,
-      detail: String(error),
-    })),
+    service
+      .readRuntime(env, { timeoutMs })
+      .catch((error: unknown) => createServiceRuntimeInspectionFailure(error)),
     // Update policy needs definition authority; ordinary status/start reads do not.
     args.requireEffective
       ? service


### PR DESCRIPTION
Closes #131445

AI-assisted: yes (Codex)

## What Problem This Solves

Operators could see raw, localized service-manager exceptions as the primary Runtime status when native runtime inspection failed. Windows made this worse: `readScheduledTaskRuntime` converted some failed `schtasks` probes into fulfilled `unknown` results, bypassing the shared rejection normalizer. The normalized result also embedded a root-status command even when rendered by `openclaw gateway status`.

## Why This Change Was Made

The shared daemon runtime owner now builds one typed, bounded, command-neutral inspection-failure result for both rejected probes and adapter-owned fulfilled failures:

```text
service runtime inspection failed
```

Windows Scheduled Task availability/query failures use that canonical result; proven missing tasks and legitimate runtime explanations retain their existing meanings. The sanitized native diagnostic remains available only under the typed `service-runtime-inspection-failed` field, capped at 500 UTF-16 code units.

Recovery guidance is added only where the target is known:

- `openclaw gateway status` text and JSON: `openclaw gateway status --deep`
- aggregate Gateway and Node status: `openclaw status --deep`

Root cause: normalization existed only around `service.readRuntime` rejection, but the Windows adapter owned failure states that it returned as successful values. Recovery guidance then lived in the shared normalized fact, which cannot know whether Gateway-only or aggregate status is presenting it.

Removed paths: adapter-owned probe failures no longer leak arbitrary host text into the primary Runtime line, structured failures no longer repeat the same detail in compact summaries, and shared service state no longer embeds a command from one presentation surface.

Production LOC: +61 / -31 (net +30); test LOC: +159 / -12 (net +147). The target-aware follow-up is +12 / -5 production (net +7) and test-neutral; the growth is the two explicit presentation mappings while the shared normalized owner shrinks. The overall production growth is the typed diagnostic contract and bounded sanitizer required to retain support detail without leaking it as primary output.

## User Impact

Failed Gateway and Node runtime inspection now gives a recovery command that matches the command the operator ran. Localized Windows errors are absent from human status output but remain bounded in structured diagnostics for support. Legitimate runtime details such as an inconclusive process state are still preserved.

## Evidence

Pre-fix focused reproductions failed in the affected paths:

- a German `schtasks` query failure reached status as raw `Zugriff verweigert`
- a rejected Node runtime probe rendered Gateway-only guidance
- direct Gateway text and JSON rendered the broader `openclaw status --deep` command

Exact-head validation after the repair:

- `node scripts/run-vitest.mjs src/daemon/service.test.ts src/daemon/schtasks.startup-fallback.test.ts src/cli/daemon-cli/status.gather.test.ts src/commands/status.daemon.real-summary.test.ts src/commands/status.service-summary.test.ts src/commands/doctor-format.test.ts` — 182 passed
- earlier broader focused run including schtasks, status print, and formatting siblings — 309 passed, 1 platform-only skip
- `node scripts/check-changed.mjs` — passed (formatting, core/test types, lint, dead exports, import cycles, architecture, and repository guards)
- Autoreview (`gpt-5.6-sol`, high) — clean, no accepted/actionable findings

Coverage includes localized Scheduled Task availability and query failures, the adapter-to-service normalization boundary, direct Gateway text and JSON, real Node aggregate output, single rendering of recovery guidance, and preservation of legitimate runtime detail.

Live Windows proof is not feasible from this macOS development host. The focused tests exercise the production Windows adapter with non-English failures, and exact-head Windows CI provides the platform-native proof.
