### PR TITLE
fix(ios): stop Watch approval snapshot timing flakes

### DIFF
--- a/apps/ios/Tests/NodeAppModelInvokeTests.swift
+++ b/apps/ios/Tests/NodeAppModelInvokeTests.swift
@@ -4417,6 +4417,14 @@ private final class TimingOutDeviceStatusService: DeviceStatusServicing {
         NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState()
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
         let (watchService, appModel) = makeWatchModel()
+        let (snapshotEvents, snapshotEventContinuation) = AsyncStream.makeStream(
+            of: OpenClawWatchExecApprovalSnapshotMessage.self)
+        defer { snapshotEventContinuation.finish() }
+        watchService.syncExecApprovalSnapshotHandler = { message in
+            snapshotEventContinuation.yield(message)
+            return watchService.nextSendResult
+        }
+        var snapshots = snapshotEvents.makeAsyncIterator()
         let futureExpiryMs = Int64(Date().timeIntervalSince1970 * 1000) + 60000
         try appModel._test_presentExecApprovalPrompt(
             #require(
@@ -4429,29 +4437,14 @@ private final class TimingOutDeviceStatusService: DeviceStatusServicing {
             "approval-watch-snapshot",
             commandText: "echo from watch",
             agentID: nil))
-        let initialSnapshotPublished = await waitForMainActorWork {
-            watchService.sentExecApprovalSnapshots.contains { snapshot in
-                snapshot.requestId == nil &&
-                    snapshot.approvals.map(\.id) == ["approval-watch-snapshot"]
-            }
-        }
-        try #require(initialSnapshotPublished)
+        let initialSnapshot = try #require(await snapshots.next())
+        #expect(initialSnapshot.requestId == nil)
+        #expect(initialSnapshot.approvals.map(\.id) == ["approval-watch-snapshot"])
 
         appModel.setScenePhase(.background)
-        let snapshotCount = watchService.sentExecApprovalSnapshots.count
         watchService.emitExecApprovalSnapshotRequest(
             makeWatchApprovalSnapshotRequest("snapshot-1", sentAt: 111))
-        let correlatedSnapshotPublished = await waitForMainActorWork {
-            watchService.sentExecApprovalSnapshots.dropFirst(snapshotCount).contains { snapshot in
-                snapshot.requestId == "snapshot-1" &&
-                    snapshot.requestGatewayStableID == "test-gateway"
-            }
-        }
-        try #require(correlatedSnapshotPublished)
-
-        let snapshot = try #require(watchService.sentExecApprovalSnapshots
-            .dropFirst(snapshotCount)
-            .first { $0.requestId == "snapshot-1" })
+        let snapshot = try #require(await snapshots.next())
         #expect(snapshot.approvals.map(\.id) == ["approval-watch-snapshot"])
         #expect(snapshot.requestId == "snapshot-1")
         #expect(snapshot.requestGatewayStableID == "test-gateway")


### PR DESCRIPTION
Closes #131446

## What Problem This Solves

Fixes an issue where iOS release validation could fail intermittently while checking that a background Watch approval snapshot request publishes cached approvals. The production callback is intentionally asynchronous, but the test treated a fixed two-second polling window as proof that publication completed.

## Why This Change Was Made

The test now consumes the actual snapshot-send events emitted by its existing mock transport through an `AsyncStream`. It awaits both the initial cache publication and the correlated background response directly, without increasing a timeout, retrying, skipping, or changing production behavior.

## User Impact

There is no runtime behavior change. Maintainers get deterministic iOS release validation for the Watch approval snapshot flow.

## Evidence

- Before: [beta.3 Full Release Validation failure](https://github.com/openclaw/openclaw/actions/runs/32350263557/job/96367975248) from the fixed polling deadline.
- Control: [the same release candidate passing in another run](https://github.com/openclaw/openclaw/actions/runs/32279847769), confirming timing sensitivity rather than a product regression.
- Exact-head CI at `72fa4f0ffadd2a1e44afa5306d8ce7e554b8ceec`: [run 33140262780](https://github.com/openclaw/openclaw/actions/runs/33140262780) passed, including `ios-build`, the iPhone + Watch screenshot job, the screenshot evidence reducer, and `openclaw/ci-gate`.
- `PATH="$PWD/.build/swift-tools:$PATH" pnpm check:changed` — passed, including the repository Swift lint lane.
- `swiftformat --lint apps/ios/Tests/NodeAppModelInvokeTests.swift --config config/swiftformat` — passed.
- `xcrun swiftc -frontend -parse apps/ios/Tests/NodeAppModelInvokeTests.swift` — passed.
- Autoreview: clean, no accepted/actionable findings.
- Production LOC: `+0/-0`; test LOC: `+12/-19`.

The exact-head hosted Apple lanes now provide the simulator/device-family proof that was unavailable in the original local environment.

AI-assisted: yes.
