### PR TITLE
fix(ui): avoid standalone validator startup stalls

### DIFF
--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -82,8 +82,10 @@ reconcile dependencies before the remote wrapper starts.
 Maintained JavaScript tooling wrappers and root package commands use tsx's
 in-process transform cache. They skip its shared disk cache before the loader
 starts, and child tooling inherits that policy. This does not relocate or clean
-temporary directories, Node or Vitest caches, or other global caches. Raw external
-`tsx` and `node --import tsx` invocations outside these launchers are unchanged.
+temporary directories, Node or Vitest caches, or other global caches. Standalone
+`pnpm ui:build` keeps native startup and applies the same preload to its post-build
+validators; it does not require `TSX_DISABLE_CACHE` in the invoking shell. Raw
+external `tsx` and `node --import tsx` invocations outside these launchers are unchanged.
 
 Test wrapper runs end with a short `[test] passed|failed|skipped ... in ...` summary; Vitest's own duration line stays the per-shard detail.
 

--- a/scripts/ui.mts
+++ b/scripts/ui.mts
@@ -460,7 +460,7 @@ export function runUiCli(argv: string[] = process.argv.slice(2)): void {
       runSpawnCallSync(
         resolveSpawnCall(
           process.execPath,
-          ["--import", "tsx", path.join(repoRoot, "scripts", validator)],
+          ["--import", new URL("./tsx.mjs", import.meta.url).href, path.join(here, validator)],
           buildEnv,
           { cwd: repoRoot },
         ),

--- a/test/scripts/ui.test.ts
+++ b/test/scripts/ui.test.ts
@@ -293,10 +293,160 @@ describe("scripts/ui windows spawn behavior", () => {
     expect(output).not.toContain("Control UI performance");
   });
 
-  it.each(["check-control-ui-precompressed-assets.mts", "check-control-ui-performance.mts"])(
-    "keeps %s in the canonical build wrapper",
-    (validator) => {
-      expect(fs.readFileSync("scripts/ui.mts", "utf8")).toContain(validator);
+  it.each([
+    { noPnpm: false, failValidator: null },
+    { noPnpm: true, failValidator: null },
+    { noPnpm: false, failValidator: "check-control-ui-precompressed-assets.mts" },
+    { noPnpm: true, failValidator: "check-control-ui-performance.mts" },
+  ])(
+    "keeps standalone UI validators off disk caches (noPnpm=$noPnpm, failure=$failValidator)",
+    ({ noPnpm, failValidator }) => {
+      const tempDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-ui-cache-")));
+      const tempRoot = path.join(tempDir, "temp");
+      const cacheRoots = ["tsx", `tsx-${process.geteuid?.() ?? os.userInfo().username}`].map(
+        (name) => path.join(tempRoot, name),
+      );
+      const accessLog = path.join(tempDir, "cache-access.log");
+      const guard = path.join(tempDir, "cache-guard.cjs");
+      const capture = path.join(tempDir, "capture-ui-children.cjs");
+      const fixture = path.join(tempDir, "validator.mts");
+      const pnpm = path.join(tempDir, "pnpm.cjs");
+      const validators = [
+        "check-control-ui-precompressed-assets.mts",
+        "check-control-ui-performance.mts",
+      ];
+
+      try {
+        for (const cacheRoot of cacheRoots) {
+          fs.mkdirSync(cacheRoot, { recursive: true });
+          fs.writeFileSync(path.join(cacheRoot, "0-sentinel"), "keep");
+        }
+        // Record before throwing: tsx catches some cache errors, so exit status alone
+        // cannot prove that the loader left the cache untouched.
+        fs.writeFileSync(
+          guard,
+          `
+const fs = require("node:fs");
+const path = require("node:path");
+const roots = ${JSON.stringify(cacheRoots)};
+function guardAccess(target, operation) {
+  const resolved = path.resolve(String(target));
+  if (roots.some(root => resolved === root || resolved.startsWith(root + path.sep))) {
+    fs.appendFileSync(${JSON.stringify(accessLog)}, operation + "\\n");
+    throw new Error("Unexpected tsx disk cache access: " + operation);
+  }
+}
+for (const operation of ["readdirSync", "readFileSync", "writeFileSync", "openSync"]) {
+  const original = fs[operation];
+  fs[operation] = function(target, ...args) {
+    guardAccess(target, operation);
+    return original.call(this, target, ...args);
+  };
+}
+for (const operation of ["readdir", "readFile", "writeFile", "open", "unlink", "rm", "rmdir", "access"]) {
+  const original = fs.promises[operation];
+  fs.promises[operation] = async function(target, ...args) {
+    guardAccess(target, operation);
+    return original.call(this, target, ...args);
+  };
+}
+require("node:module").syncBuiltinESMExports();
+`,
+        );
+        fs.writeFileSync(pnpm, 'throw new Error("build must be intercepted");\n');
+        fs.writeFileSync(
+          fixture,
+          `
+enum Transformed { Value = "transformed" }
+const validator = process.argv[2];
+console.log(JSON.stringify({ validator, transformed: Transformed.Value }));
+process.exitCode = validator === ${JSON.stringify(failValidator)} ? 17 : 0;
+`,
+        );
+        // Run the native launcher, intercept only the build, then replay each real
+        // validator command/environment with a tiny transform-required entrypoint.
+        fs.writeFileSync(
+          capture,
+          `
+const assert = require("node:assert/strict");
+const childProcess = require("node:child_process");
+const path = require("node:path");
+const spawnSync = childProcess.spawnSync;
+const validators = ${JSON.stringify(validators)};
+assert.equal(process.env.TSX_DISABLE_CACHE, undefined);
+childProcess.spawnSync = function(command, args, options) {
+  if (args[0] === ${JSON.stringify(noPnpm ? path.resolve("node_modules/vite/bin/vite.js") : pnpm)}) {
+    assert.deepEqual(args.slice(1), ${JSON.stringify(noPnpm ? ["build"] : ["run", "build"])});
+    return { status: 0 };
+  }
+  const validator = path.basename(args.at(-1));
+  if (!validators.includes(validator)) throw new Error("Unexpected UI subprocess");
+  assert.equal(options.env.TSX_DISABLE_CACHE, undefined);
+  return spawnSync(command, [...args.slice(0, -1), ${JSON.stringify(fixture)}, validator], options);
+};
+require("node:module").syncBuiltinESMExports();
+`,
+        );
+        const env: NodeJS.ProcessEnv = {
+          ...process.env,
+          TMPDIR: tempRoot,
+          TMP: tempRoot,
+          TEMP: tempRoot,
+          XDG_CACHE_HOME: path.join(tempDir, "xdg-cache"),
+          NODE_COMPILE_CACHE: path.join(tempDir, "node-cache"),
+          NODE_OPTIONS: `--require ${JSON.stringify(guard)}`,
+          OPENCLAW_BUILD_ALL_NO_PNPM: noPnpm ? "1" : "0",
+          OPENCLAW_BUILD_TIMESTAMP: "2026-08-27T00:00:00.000Z",
+          GIT_COMMIT: "a".repeat(40),
+          npm_execpath: pnpm,
+        };
+        delete env.TSX_DISABLE_CACHE;
+        delete env.TSX_TSCONFIG_PATH;
+        delete env.PNPM_CONFIG_MODULES_DIR;
+        delete env.npm_config_modules_dir;
+
+        if (!noPnpm && failValidator === null) {
+          const control = spawnSync(process.execPath, ["--import", "tsx", fixture, "control"], {
+            cwd: path.resolve("."),
+            encoding: "utf8",
+            env,
+            timeout: 10_000,
+          });
+          expect(control.error).toBeUndefined();
+          expect(fs.readFileSync(accessLog, "utf8")).toContain("readdirSync");
+          fs.unlinkSync(accessLog);
+        }
+        const result = spawnSync(
+          process.execPath,
+          ["--require", capture, "scripts/ui.js", "build"],
+          {
+            cwd: path.resolve("."),
+            encoding: "utf8",
+            env,
+            timeout: 10_000,
+          },
+        );
+        expect(result.error).toBeUndefined();
+        expect(fs.existsSync(accessLog), result.stderr).toBe(false);
+        expect(result.status, result.stderr).toBe(failValidator ? 17 : 0);
+        const expectedValidators = failValidator
+          ? validators.slice(0, validators.indexOf(failValidator) + 1)
+          : validators;
+        expect(
+          result.stdout
+            .trim()
+            .split("\n")
+            .map((line) => JSON.parse(line)),
+        ).toEqual(
+          expectedValidators.map((validator) => ({ validator, transformed: "transformed" })),
+        );
+        for (const cacheRoot of cacheRoots) {
+          expect(fs.readdirSync(cacheRoot)).toEqual(["0-sentinel"]);
+          expect(fs.readFileSync(path.join(cacheRoot, "0-sentinel"), "utf8")).toBe("keep");
+        }
+      } finally {
+        fs.rmSync(tempDir, { force: true, recursive: true });
+      }
     },
   );
 

--- a/test/scripts/ui.test.ts
+++ b/test/scripts/ui.test.ts
@@ -11,6 +11,7 @@ import {
   resolveSpawnCall,
   shouldUseCmdExeForCommand,
 } from "../../scripts/ui.mts";
+import { mergeProcessEnv } from "../../src/infra/process-env.js";
 import { normalizeControlUiBuildInfo } from "../../ui/src/build-info-normalizers.ts";
 // writeFileSync creates the file before its content lands, so an existence
 // poll can observe an empty file on loaded runners; wait for bytes instead.
@@ -374,6 +375,7 @@ const path = require("node:path");
 const spawnSync = childProcess.spawnSync;
 const validators = ${JSON.stringify(validators)};
 assert.equal(process.env.TSX_DISABLE_CACHE, undefined);
+assert.equal(process.env.npm_execpath, ${JSON.stringify(pnpm)});
 childProcess.spawnSync = function(command, args, options) {
   if (args[0] === ${JSON.stringify(noPnpm ? path.resolve("node_modules/vite/bin/vite.js") : pnpm)}) {
     assert.deepEqual(args.slice(1), ${JSON.stringify(noPnpm ? ["build"] : ["run", "build"])});
@@ -387,23 +389,26 @@ childProcess.spawnSync = function(command, args, options) {
 require("node:module").syncBuiltinESMExports();
 `,
         );
-        const env: NodeJS.ProcessEnv = {
-          ...process.env,
-          TMPDIR: tempRoot,
-          TMP: tempRoot,
-          TEMP: tempRoot,
-          XDG_CACHE_HOME: path.join(tempDir, "xdg-cache"),
-          NODE_COMPILE_CACHE: path.join(tempDir, "node-cache"),
-          NODE_OPTIONS: `--require ${JSON.stringify(guard)}`,
-          OPENCLAW_BUILD_ALL_NO_PNPM: noPnpm ? "1" : "0",
-          OPENCLAW_BUILD_TIMESTAMP: "2026-08-27T00:00:00.000Z",
-          GIT_COMMIT: "a".repeat(40),
-          npm_execpath: pnpm,
-        };
-        delete env.TSX_DISABLE_CACHE;
-        delete env.TSX_TSCONFIG_PATH;
-        delete env.PNPM_CONFIG_MODULES_DIR;
-        delete env.npm_config_modules_dir;
+        // A spread can retain NPM_EXECPATH, which wins over npm_execpath on Windows.
+        const env = mergeProcessEnv([
+          process.env,
+          {
+            TMPDIR: tempRoot,
+            TMP: tempRoot,
+            TEMP: tempRoot,
+            XDG_CACHE_HOME: path.join(tempDir, "xdg-cache"),
+            NODE_COMPILE_CACHE: path.join(tempDir, "node-cache"),
+            NODE_OPTIONS: `--require ${JSON.stringify(guard)}`,
+            OPENCLAW_BUILD_ALL_NO_PNPM: noPnpm ? "1" : "0",
+            OPENCLAW_BUILD_TIMESTAMP: "2026-08-27T00:00:00.000Z",
+            GIT_COMMIT: "a".repeat(40),
+            npm_execpath: pnpm,
+            TSX_DISABLE_CACHE: undefined,
+            TSX_TSCONFIG_PATH: undefined,
+            PNPM_CONFIG_MODULES_DIR: undefined,
+            npm_config_modules_dir: undefined,
+          },
+        ]);
 
         if (!noPnpm && failValidator === null) {
           const control = spawnSync(process.execPath, ["--import", "tsx", fixture, "control"], {


### PR DESCRIPTION
Closes #131468 — [standalone UI build validators bypass the tsx startup-cache policy](https://github.com/openclaw/openclaw/issues/131468).

Related: [centralized tooling bootstrap repair](https://github.com/openclaw/openclaw/pull/130924) and [native UI startup repair](https://github.com/openclaw/openclaw/pull/130927). The cache condition was originally investigated during the [seven-day dependency refresh](https://github.com/openclaw/openclaw/pull/130653).

## What Problem This Solves

Fixes an issue where developers running standalone `pnpm ui:build` could finish Vite and then experience long pauses before post-build validation when unrelated work had accumulated a large shared tsx transform cache. The native UI launcher avoided tsx at startup, but its two validator children still invoked raw tsx without establishing the repository's cache policy.

## Why This Change Was Made

Route both validator children through the existing `scripts/tsx.mjs` preload, using a file URL rooted at the owning script. The existing bootstrap sets tsx's supported in-process cache policy before importing the loader; no second environment policy or new wrapper is added. The native UI entrypoint, child cwd/build identity, both validators, and failure propagation remain unchanged.

The pinned tsx 4.23.12 cache implementation synchronously enumerates its entire shared directory on first transformation before scheduling expiry. `TSX_DISABLE_CACHE` selects an in-process `Map`. The [upstream cache source](https://github.com/privatenumber/tsx/blob/ed9d33046a135de13a35fdfce12368b79d1b1518/src/utils/transform/cache.ts#L48-L90) and installed ESM/CJS source were directly inspected. This patch reuses the existing dependency contract; it does not patch tsx or try to repair its host-wide cache algorithm.

## User Impact

Standalone UI builds no longer require an ambient `TSX_DISABLE_CACHE` setting to keep their post-build validators independent of shared-cache size. This brings them under the existing [maintained-tooling cache contract](https://docs.openclaw.ai/reference/test).

No application UI appearance, runtime configuration, performance budget, dependency, timeout, shared cache, Node/Vitest cache policy, or operator service changes. There is no screenshot requirement for this build-launcher-only repair: the rendered UI is unchanged.

## Evidence

### Failing-before / passing-after child-boundary regression

The new table-driven regression replaces two validator-name source assertions. It starts the actual native UI launcher with the cache-disable flag absent, intercepts only the build, and faithfully replays each produced validator command/environment against a tiny transform-required enum fixture. It records cache access before throwing so swallowed dependency errors cannot produce false passes. A raw-tsx control proves that the guard detects enumeration; current and legacy cache sentinels remain unchanged after the repaired launches.

Coverage includes normal pnpm and no-pnpm builds, both validators, first-validator failure, second-validator failure, exit-17 propagation, and stopping the validator sequence on failure.

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/ui.test.ts -t 'keeps standalone UI validators off disk caches'
```

Before the one-line production edit: **4 failed** on recorded `readdirSync` in `FileCache.getDiskCacheIndex`. After: **4 passed**. This regression is child-boundary proof, not a full build.

### Related tests and scoped checks

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/ui.test.ts test/scripts/direct-run-entrypoints.test.ts test/scripts/pnpm-runner.test.ts
```

**77 tests passed across 3 files**, including the canonical bootstrap, inherited raw-tsx descendants, changed-cwd forks, toolchain hydration, platform/quoting, help, and signal behavior.

```bash
node scripts/check-changed.mjs -- scripts/ui.mts test/scripts/ui.test.ts docs/reference/test.md
```

Passed, including formatting, scripts/test-root type checks, script lint/erasability, dependency checks, and selected guards. `git diff --check` is clean.

### Windows fixture correction

The first [exact-head CI run](https://github.com/openclaw/openclaw/actions/runs/33140360665) failed two normal-pnpm fixture cases in the [Windows test lane](https://github.com/openclaw/openclaw/actions/runs/33140360665/job/98749723324), before either validator ran. The no-pnpm cases passed. The runner reported Node **22.23.2** and pnpm **11.22.0**.

The fixture's spread-based child environment allowed inherited casing variants such as `NPM_EXECPATH` to shadow `npm_execpath` under [Node's documented Windows key precedence](https://nodejs.org/download/release/v22.23.2/docs/api/child_process.html). The test now uses the existing `mergeProcessEnv([process.env, overrides])` owner to apply overrides/removals case-insensitively on Windows, with an explicit child assertion for the fixture pnpm path. Production code and all cache/failure assertions are unchanged; no platform skip, retry, or timeout increase was added.

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/ui.test.ts test/scripts/direct-run-entrypoints.test.ts test/scripts/pnpm-runner.test.ts src/infra/process-env.test.ts
```

**84 tests passed across four files** after the correction. The test-only changed gate also passed. Fresh independent Codex review of that correction is clean at the default P0 reporting threshold. Commit `42b1ceb57ed9f31f0611ee787eb763aed164540b` changes only the test fixture. Its [exact-head CI run](https://github.com/openclaw/openclaw/actions/runs/33141537386) is **green**, including both Windows test lanes and the required `openclaw/ci-gate`. The [Windows test-1 log](https://github.com/openclaw/openclaw/actions/runs/33141537386/job/98753380139) confirms all four validator regression cases actually ran and passed. No same-budget blind retry or test skip was used to turn the first failure green.

### Actual standalone UI build

```bash
pnpm ui:build
```

The real build—not the intercepted test—passed on Node 24.20.0 in **84.65 seconds**, with Vite taking **56.96 seconds**. It ran with the cache-disable flag absent, task-owned temporary storage, and an inherited filesystem instrumentation guard. Both actual validators exited zero; **774 finalized sidecars** were verified. Startup JS was **345545 bytes**, below the unchanged **346100-byte** enforcement limit; all other budgets passed.

The guard observed **zero tsx disk-cache accesses**. Sentinel contents/inventory were unchanged and no legacy cache directory was created. The native UI launcher started and ended without setting the cache flag. Each validator started with the flag absent and exited with the existing preload's in-process policy enabled. The proof used source base `16b0c1f251c79234f0a8285ea37f64493341b04a` plus the original repair, subsequently committed as `3bdea690b245c43f96df6bf4f20bb474248705d0`; the transferred patch ID was verified identical. The later Windows fixture correction changes tests only, so this remains proof of the unchanged production launcher—not a claim that the full build was repeated after the test edit.

### Review and scope

Independent Codex autoreview covered the original repair and the subsequent Windows fixture correction, with no accepted/actionable findings at the default **P0** reporting threshold. The lead separately inspected both diffs, root-cause/dependency contracts, regression logs, and actual build instrumentation/results. No all-priority review or full-repository local test run is claimed.

Production/tooling **+1/-1 (net 0)**; tests **+159/-4 (net +155)**; docs **+4/-2**. No new production seam, helper, fallback, or configuration option. The manual baseline-update command hints were fixed independently in [the companion tooling repair](https://github.com/openclaw/openclaw/pull/131516). The upstream bounded-cache repair remains a separate follow-up.

AI-assisted implementation and independent review. No agent transcripts included.
