### PR TITLE
fix(ui): suppress overdue jobs when scheduler is disabled

### DIFF
--- a/ui/src/components/sidebar-attention-items.test.ts
+++ b/ui/src/components/sidebar-attention-items.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import type { CronJob } from "../api/types.ts";
+import { buildSidebarAttentionEntries } from "./sidebar-attention-items.ts";
+
+function cronJob(id: string): CronJob {
+  return {
+    id,
+    name: id,
+    enabled: true,
+    createdAtMs: 0,
+    updatedAtMs: 0,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "isolated",
+    wakeMode: "now",
+    payload: { kind: "agentTurn", message: "test" },
+    state: { lastRunStatus: "error" },
+  };
+}
+
+function cronItems(cronJobs: readonly CronJob[], now = 0, cronSchedulerEnabled = true) {
+  return buildSidebarAttentionEntries({
+    cronJobs,
+    cronSchedulerEnabled,
+    modelAuthStatus: null,
+    now,
+  });
+}
+
+describe("automation attention", () => {
+  it("lists each failed job as direct automation navigation", () => {
+    const primary = cronJob("primary");
+    primary.name = "Nightly backup";
+    primary.state = { lastRunStatus: "error", lastError: "  disk full  " };
+    const reason = cronJob("reason-id");
+    reason.name = "";
+    reason.state = {
+      lastRunStatus: "error",
+      lastError: "   ",
+      lastErrorReason: "timeout",
+    };
+    const unknown = cronJob("unknown-id");
+
+    const failed = cronItems([primary, reason, unknown]).filter(
+      (item) => item.kind === "cronFailed",
+    );
+
+    expect(failed.map((item) => item.label)).toEqual(["Nightly backup", "reason-id", "unknown-id"]);
+    expect(failed.every((item) => item.action.kind === "navigate")).toBe(true);
+    expect(
+      failed.every((item) => item.action.kind !== "navigate" || item.action.routeId === "cron"),
+    ).toBe(true);
+  });
+
+  it("does not flag an actively running job as overdue", () => {
+    // The gateway leaves nextRunAtMs past-due during execution; runningAtMs is
+    // the recorded fact that a run is in flight (agentTurn runs may take up to
+    // an hour, far beyond the 5-minute overdue grace).
+    const running = cronJob("running-id");
+    running.state = { lastRunStatus: "ok", nextRunAtMs: 1, runningAtMs: 2 };
+    const stalled = cronJob("stalled-id");
+    stalled.state = { lastRunStatus: "ok", nextRunAtMs: 2 };
+
+    const overdue = cronItems([running, stalled], 300_003).find(
+      (item) => item.kind === "cronOverdue",
+    );
+
+    expect(overdue?.label).toBe("stalled-id");
+  });
+
+  it("does not flag an enabled overdue job while the scheduler is disabled", () => {
+    const overdue = cronJob("overdue-id");
+    overdue.state = { lastRunStatus: "ok", nextRunAtMs: 1 };
+
+    expect(cronItems([overdue], 300_002, false)).not.toContainEqual(
+      expect.objectContaining({ kind: "cronOverdue" }),
+    );
+  });
+
+  it("shows automation owners only when the caller supplies an all-agent owner map", () => {
+    const item = buildSidebarAttentionEntries({
+      cronJobs: [cronJob("writer-job")],
+      cronSchedulerEnabled: true,
+      cronOwnerByJobId: new Map([["writer-job", "Writer"]]),
+      modelAuthStatus: null,
+      now: 0,
+    })[0];
+
+    expect(item?.meta?.context).toBe("Writer");
+  });
+
+  it("orders failed before overdue and newest first within each group", () => {
+    const failedJob = cronJob("failed");
+    failedJob.state = { lastRunStatus: "error", lastRunAtMs: 200 };
+    const olderFailedJob = cronJob("older-failed");
+    olderFailedJob.state = { lastRunStatus: "error", lastRunAtMs: 100 };
+    const overdueJob = cronJob("overdue");
+    overdueJob.state = { lastRunStatus: "ok", nextRunAtMs: 2 };
+    const olderOverdueJob = cronJob("older-overdue");
+    olderOverdueJob.state = { lastRunStatus: "ok", nextRunAtMs: 1 };
+
+    const items = cronItems(
+      [olderOverdueJob, olderFailedJob, overdueJob, failedJob],
+      300_003,
+    ).filter((item) => item.kind === "cronFailed" || item.kind === "cronOverdue");
+
+    expect(items.map((item) => item.label)).toEqual([
+      "failed",
+      "older-failed",
+      "overdue",
+      "older-overdue",
+    ]);
+  });
+});

--- a/ui/src/components/sidebar-attention-items.ts
+++ b/ui/src/components/sidebar-attention-items.ts
@@ -30,6 +30,7 @@ type SidebarAttentionContent = Omit<
 
 export function buildSidebarAttentionEntries(params: {
   cronJobs: readonly CronJob[];
+  cronSchedulerEnabled: boolean | null;
   cronOwnerByJobId?: ReadonlyMap<string, string>;
   modelAuthStatus: ModelAuthStatusResult | null;
   modelAuthAgentId?: string | null;
@@ -94,6 +95,7 @@ export function buildSidebarAttentionEntries(params: {
   const overdueCron = params.cronJobs
     .filter(
       (job) =>
+        params.cronSchedulerEnabled !== false &&
         job.enabled &&
         !isCronJobRunning(job) &&
         job.state?.nextRunAtMs != null &&

--- a/ui/src/components/sidebar-attention.test.ts
+++ b/ui/src/components/sidebar-attention.test.ts
@@ -72,21 +72,15 @@ type SidebarAttentionElement = HTMLElement & {
   updateComplete: Promise<boolean>;
   dismissPanel: () => boolean;
   cronJobs: CronJob[];
+  cronSchedulerEnabled: boolean | null;
   modelAuthStatus: ModelAuthStatusResult | null;
   loadedAtMs: number;
 };
 
-function cronItems(cronJobs: readonly CronJob[], now = 0) {
-  return buildSidebarAttentionEntries({
-    cronJobs,
-    modelAuthStatus: null,
-    now,
-  });
-}
-
 function authItems(agentId: string) {
   return buildSidebarAttentionEntries({
     cronJobs: [],
+    cronSchedulerEnabled: true,
     modelAuthStatus: {
       ts: 1,
       providers: [
@@ -103,82 +97,6 @@ function authItems(agentId: string) {
   }).filter((item) => item.kind === "modelAuthExpired");
 }
 
-describe("automation attention", () => {
-  it("lists each failed job as direct automation navigation", () => {
-    const primary = cronJob("primary");
-    primary.name = "Nightly backup";
-    primary.state = { lastRunStatus: "error", lastError: "  disk full  " };
-    const reason = cronJob("reason-id");
-    reason.name = "";
-    reason.state = {
-      lastRunStatus: "error",
-      lastError: "   ",
-      lastErrorReason: "timeout",
-    };
-    const unknown = cronJob("unknown-id");
-
-    const failed = cronItems([primary, reason, unknown]).filter(
-      (item) => item.kind === "cronFailed",
-    );
-
-    expect(failed.map((item) => item.label)).toEqual(["Nightly backup", "reason-id", "unknown-id"]);
-    expect(failed.every((item) => item.action.kind === "navigate")).toBe(true);
-    expect(
-      failed.every((item) => item.action.kind !== "navigate" || item.action.routeId === "cron"),
-    ).toBe(true);
-  });
-
-  it("does not flag an actively running job as overdue", () => {
-    // The gateway leaves nextRunAtMs past-due during execution; runningAtMs is
-    // the recorded fact that a run is in flight (agentTurn runs may take up to
-    // an hour, far beyond the 5-minute overdue grace).
-    const running = cronJob("running-id");
-    running.state = { lastRunStatus: "ok", nextRunAtMs: 1, runningAtMs: 2 };
-    const stalled = cronJob("stalled-id");
-    stalled.state = { lastRunStatus: "ok", nextRunAtMs: 2 };
-
-    const overdue = cronItems([running, stalled], 300_003).find(
-      (item) => item.kind === "cronOverdue",
-    );
-
-    expect(overdue?.label).toBe("stalled-id");
-  });
-
-  it("shows automation owners only when the caller supplies an all-agent owner map", () => {
-    const item = buildSidebarAttentionEntries({
-      cronJobs: [cronJob("writer-job")],
-      cronOwnerByJobId: new Map([["writer-job", "Writer"]]),
-      modelAuthStatus: null,
-      now: 0,
-    })[0];
-
-    expect(item?.meta?.context).toBe("Writer");
-  });
-
-  it("orders failed before overdue and newest first within each group", () => {
-    const failedJob = cronJob("failed");
-    failedJob.state = { lastRunStatus: "error", lastRunAtMs: 200 };
-    const olderFailedJob = cronJob("older-failed");
-    olderFailedJob.state = { lastRunStatus: "error", lastRunAtMs: 100 };
-    const overdueJob = cronJob("overdue");
-    overdueJob.state = { lastRunStatus: "ok", nextRunAtMs: 2 };
-    const olderOverdueJob = cronJob("older-overdue");
-    olderOverdueJob.state = { lastRunStatus: "ok", nextRunAtMs: 1 };
-
-    const items = cronItems(
-      [olderOverdueJob, olderFailedJob, overdueJob, failedJob],
-      300_003,
-    ).filter((item) => item.kind === "cronFailed" || item.kind === "cronOverdue");
-
-    expect(items.map((item) => item.label)).toEqual([
-      "failed",
-      "older-failed",
-      "overdue",
-      "older-overdue",
-    ]);
-  });
-});
-
 describe("model auth attention", () => {
   it("keeps identical provider warnings distinct across agents", () => {
     expect(authItems("main")[0]?.signature).toBe("agent:main\nopenai");
@@ -188,6 +106,7 @@ describe("model auth attention", () => {
   it("keeps a missing canonical route visible beside CLI OAuth", () => {
     const items = buildSidebarAttentionEntries({
       cronJobs: [],
+      cronSchedulerEnabled: true,
       modelAuthStatus: {
         ts: 1,
         providers: [
@@ -301,6 +220,29 @@ describe("sidebar attention refresh ownership", () => {
     await waitForFast(() => expect(element.querySelector(".sidebar-issues-panel")).not.toBeNull());
   });
 
+  it("keeps overdue jobs out of the Inbox while the scheduler is disabled", async () => {
+    const overdue = cronJob("overdue-id");
+    overdue.state = { lastRunStatus: "ok", nextRunAtMs: 1 };
+    vi.spyOn(Date, "now").mockReturnValue(300_002);
+    const request = vi.fn((method: string) => {
+      if (method === "cron.list") {
+        return Promise.resolve(cronListResponse([overdue]));
+      }
+      if (method === "cron.status") {
+        return Promise.resolve({ enabled: false, triggersEnabled: true, jobs: 1 });
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const harness = createGatewayHarness(mockClient(request));
+
+    const { element } = await mountAttention({ gateway: harness.gateway });
+
+    await waitForFast(() => expect(element.cronSchedulerEnabled).toBe(false));
+    expect(request).toHaveBeenCalledWith("cron.status", {});
+    expect(element.cronJobs.map((job) => job.id)).toEqual(["overdue-id"]);
+    expect(element.querySelector(".sidebar-issues-button__count")).toBeNull();
+  });
+
   it("does not let an obsolete open render steal focus from a later interaction", async () => {
     const { element, trigger } = await mountAttention();
     const rendered = deferred<boolean>();
@@ -366,6 +308,9 @@ describe("sidebar attention refresh ownership", () => {
       if (method === "cron.list") {
         return Promise.resolve(cronListResponse([]));
       }
+      if (method === "cron.status") {
+        return Promise.resolve({ enabled: true, triggersEnabled: true, jobs: 0 });
+      }
       if (
         method === "exec.approval.list" ||
         method === "plugin.approval.list" ||
@@ -427,6 +372,11 @@ describe("sidebar attention refresh ownership", () => {
     const secondAuth = deferred<unknown>();
     const responses = {
       "cron.list": [firstCron, secondCron, deferred<unknown>()],
+      "cron.status": [
+        Promise.resolve({ enabled: false, triggersEnabled: true, jobs: 1 }),
+        Promise.resolve({ enabled: true, triggersEnabled: true, jobs: 1 }),
+        Promise.resolve({ enabled: true, triggersEnabled: true, jobs: 0 }),
+      ],
       "models.authStatus": [firstAuth, secondAuth],
     };
     const request = vi.fn((method: keyof typeof responses, _params?: unknown) => {
@@ -434,7 +384,7 @@ describe("sidebar attention refresh ownership", () => {
       if (!response) {
         throw new Error(`Unexpected request: ${method}`);
       }
-      return response.promise;
+      return "promise" in response ? response.promise : response;
     });
     const client = { request } as unknown as GatewayBrowserClient;
     const snapshot = {
@@ -492,7 +442,7 @@ describe("sidebar attention refresh ownership", () => {
     const element = document.createElement("openclaw-sidebar-attention") as SidebarAttentionElement;
     provider.append(element);
     document.body.append(provider);
-    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(3));
     expect(request.mock.calls.find(([method]) => method === "models.authStatus")?.[1]).toEqual({
       agentId: "main",
     });
@@ -505,7 +455,7 @@ describe("sidebar attention refresh ownership", () => {
     for (const listener of selectionListeners) {
       listener();
     }
-    await waitForFast(() => expect(request).toHaveBeenCalledTimes(4));
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(6));
     expect(request.mock.calls.filter(([method]) => method === "models.authStatus")[1]?.[1]).toEqual(
       { agentId: "writer" },
     );
@@ -519,6 +469,7 @@ describe("sidebar attention refresh ownership", () => {
     secondAuth.resolve(currentAuth);
     await waitForFast(() => expect(element.loadedAtMs).toBe(200_000));
     expect(element.cronJobs.map((job) => job.id)).toEqual(["current"]);
+    expect(element.cronSchedulerEnabled).toBe(true);
     expect(element.modelAuthStatus).toBe(currentAuth);
     expect(localStorage.getItem(dismissalStoreKey(gateway.connection.gatewayUrl))).not.toBeNull();
 
@@ -532,6 +483,7 @@ describe("sidebar attention refresh ownership", () => {
     await element.updateComplete;
 
     expect(element.cronJobs.map((job) => job.id)).toEqual(["current"]);
+    expect(element.cronSchedulerEnabled).toBe(true);
     expect(element.modelAuthStatus).toBe(currentAuth);
     expect(element.loadedAtMs).toBe(200_000);
     expect(localStorage.getItem(dismissalStoreKey(gateway.connection.gatewayUrl))).not.toBeNull();
@@ -541,7 +493,7 @@ describe("sidebar attention refresh ownership", () => {
     for (const listener of selectionListeners) {
       listener();
     }
-    await waitForFast(() => expect(request).toHaveBeenCalledTimes(5));
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(8));
     expect(request.mock.calls.filter(([method]) => method === "models.authStatus")).toHaveLength(2);
     expect(element.modelAuthStatus).toBeNull();
   });
@@ -555,6 +507,11 @@ describe("sidebar attention refresh ownership", () => {
         Promise.resolve(cronListResponse([])),
         switchedCron.promise,
         Promise.resolve(cronListResponse([])),
+      ],
+      "cron.status": [
+        Promise.resolve({ enabled: true, triggersEnabled: true, jobs: 0 }),
+        Promise.resolve({ enabled: true, triggersEnabled: true, jobs: 0 }),
+        Promise.resolve({ enabled: true, triggersEnabled: true, jobs: 0 }),
       ],
       "models.authStatus": [
         Promise.resolve({ ts: 1, providers: [] }),
@@ -617,17 +574,17 @@ describe("sidebar attention refresh ownership", () => {
     const element = document.createElement("openclaw-sidebar-attention") as SidebarAttentionElement;
     provider.append(element);
     document.body.append(provider);
-    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(3));
 
     selectionState.selectedId = "writer";
     selectionState.scopeId = "writer";
     for (const listener of selectionListeners) {
       listener();
     }
-    await waitForFast(() => expect(request).toHaveBeenCalledTimes(4));
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(6));
     eventListener?.({ type: "event", event: "cron", payload: {} });
 
-    await waitForFast(() => expect(request).toHaveBeenCalledTimes(6));
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(9));
     await waitForFast(() => expect(element.modelAuthStatus).toBe(writerAuth));
     switchedCron.resolve(cronListResponse([]));
     switchedAuth.resolve({ ts: 3, providers: [] });
@@ -636,6 +593,10 @@ describe("sidebar attention refresh ownership", () => {
   it("opens top-mounted attention downward and clears stale live automation alerts", async () => {
     const responses = {
       "cron.list": [cronListResponse([cronJob("failed")]), cronListResponse([])],
+      "cron.status": [
+        { enabled: true, triggersEnabled: true, jobs: 1 },
+        { enabled: true, triggersEnabled: true, jobs: 0 },
+      ],
       "models.authStatus": [{ ts: 1, providers: [] }],
     };
     const request = vi.fn((method: keyof typeof responses) => {
@@ -913,6 +874,7 @@ describe("sidebar Inbox projection", () => {
   it("derives every tab count and dismiss control from one entry list", () => {
     const attention = buildSidebarAttentionEntries({
       cronJobs: [cronJob("failed-job")],
+      cronSchedulerEnabled: true,
       modelAuthStatus: null,
       now: 0,
     });

--- a/ui/src/components/sidebar-attention.ts
+++ b/ui/src/components/sidebar-attention.ts
@@ -14,7 +14,7 @@ import {
 import type { UpdateProgress } from "../app/update-confirmation.ts";
 import { t } from "../i18n/index.ts";
 import { normalizeAgentLabel } from "../lib/agents/display.ts";
-import { createInitialCronState, loadCronJobsPage } from "../lib/cron/index.ts";
+import { createInitialCronState, loadCronJobsPage, loadCronStatus } from "../lib/cron/index.ts";
 import { canCallGatewayMethod } from "../lib/gateway-methods.ts";
 import { loadModelAuthStatus } from "../lib/model-auth.ts";
 import { normalizeAgentId } from "../lib/sessions/session-key.ts";
@@ -68,6 +68,7 @@ class SidebarAttention extends OpenClawLightDomElement {
   private context?: ApplicationContext;
 
   @state() private cronJobs: CronJob[] = [];
+  @state() private cronSchedulerEnabled: boolean | null = null;
   @state() private modelAuthStatus: ModelAuthStatusResult | null = null;
   @state() private dismissed: SidebarAttentionDismissals = {};
   @state() private panelOpen = false;
@@ -116,9 +117,10 @@ class SidebarAttention extends OpenClawLightDomElement {
       const cron = createInitialCronState({ client, connected: true });
       cron.cronAgentId = agentScope.scopeId;
       const loads: Promise<unknown>[] = [
-        loadCronJobsPage(cron).then(() => {
+        Promise.all([loadCronJobsPage(cron), loadCronStatus(cron)]).then(() => {
           if (!signal.aborted) {
             this.cronJobs = cron.cronJobs;
+            this.cronSchedulerEnabled = cron.cronStatus?.enabled ?? null;
           }
         }),
       ];
@@ -327,6 +329,7 @@ class SidebarAttention extends OpenClawLightDomElement {
       this.loadedAgentScope = null;
       this.modelAuthAgentId = null;
       this.cronJobs = [];
+      this.cronSchedulerEnabled = null;
       this.modelAuthStatus = null;
       return;
     }
@@ -403,6 +406,7 @@ class SidebarAttention extends OpenClawLightDomElement {
   private buildAttentionEntries() {
     return buildSidebarAttentionEntries({
       cronJobs: this.cronJobs,
+      cronSchedulerEnabled: this.cronSchedulerEnabled,
       cronOwnerByJobId: this.cronOwnerByJobId(),
       modelAuthStatus: this.modelAuthStatus,
       modelAuthAgentId: this.modelAuthAgentId,

--- a/ui/src/test-helpers/app-sidebar.ts
+++ b/ui/src/test-helpers/app-sidebar.ts
@@ -128,6 +128,9 @@ export function createGatewayHarness(client: GatewayBrowserClient) {
     if (method === "cron.list") {
       return Promise.resolve({ jobs: [], total: 0 } as T);
     }
+    if (method === "cron.status") {
+      return Promise.resolve({ enabled: true, triggersEnabled: true, jobs: 0 } as T);
+    }
     if (method === "models.authStatus") {
       return Promise.resolve({ ts: 0, providers: [] } as T);
     }


### PR DESCRIPTION
Closes #131447

AI-assisted implementation; the author reviewed the source, behavior, and tests.

## What Problem This Solves

Fixes an issue where operators who intentionally disabled the global scheduler would still see enabled jobs labeled overdue in the persistent Control UI Inbox after their scheduled time passed. The Automations page correctly explained that scheduling was disabled, while the sidebar presented the same state as an execution failure.

## Why This Change Was Made

The sidebar now loads the canonical `cron.status.enabled` fact alongside its independent cron job snapshot and commits both results together. Its overdue projection is suppressed only when the scheduler is explicitly disabled; real failed-run alerts remain visible. Pure attention-builder tests moved into their own focused file so the existing component test stays below the max-lines ratchet.

The architectural owner is the sidebar refresh that supplies attention facts. This reuses the same Gateway status contract as the Automations page instead of inferring scheduler state from job timestamps or configuration.

## User Impact

Operators can intentionally pause the scheduler without the Inbox claiming that paused jobs are unexpectedly overdue. When scheduling is enabled or status is temporarily unknown, existing overdue detection remains unchanged.

## Evidence

- Before the fix, the focused regression emitted `cronOverdue` for an enabled job with a past `nextRunAtMs` while scheduler status was disabled.
- `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts ui/src/components/sidebar-attention-items.test.ts ui/src/components/sidebar-attention.test.ts` — 352 tests passed, including the 18 sidebar cases that exposed shared mock call-order interference in CI.
- `pnpm test:ui` — 799 files passed; 11,731 tests passed and 1 skipped.
- `node scripts/check-changed.mjs` — formatting, ratchets, dead-export scans, UI i18n, UI/test typechecks, and changed-file lint passed.
- Autoreview (`gpt-5.6-sol`, high reasoning) reported no accepted/actionable findings.
- Production LOC: +8 / -2 (net +6), required to load, retain, clear, and consume the canonical scheduler-enabled fact. Test/test-support LOC: +169 / -91, with most churn moving five pure builder cases out of the oversized component suite.
- Sibling behavior: failed cron alerts remain independent of scheduler enablement; running jobs and enabled/unknown scheduler overdue semantics retain focused coverage.

Visual proof gap: no screenshot is attached because the before/after state requires a scheduler-disabled Gateway fixture and this focused branch does not add a new browser scenario solely for evidence. The rendered Inbox boundary test exercises the actual custom element and verifies that no attention count appears for that state.
