### PR TITLE
refactor(lobster): use resumed flow identity on failure

### DIFF
--- a/extensions/lobster/src/lobster-taskflow.test.ts
+++ b/extensions/lobster/src/lobster-taskflow.test.ts
@@ -196,6 +196,23 @@ describe("resumeManagedLobsterFlow", () => {
     expect(runner.run).not.toHaveBeenCalled();
   });
 
+  it("fails the resumed flow when the runner throws", async () => {
+    const taskFlow = createFakeTaskFlow();
+    const runner: LobsterRunner = {
+      run: vi.fn().mockRejectedValue(new Error("crashed")),
+    };
+
+    const result = expectManagedFlowFailure(
+      await resumeManagedLobsterFlow(createResumeFlowParams(taskFlow, runner)),
+    );
+
+    expect(result.error.message).toBe("crashed");
+    expect(taskFlow.fail).toHaveBeenCalledWith({
+      flowId: "flow-1",
+      expectedRevision: 5,
+    });
+  });
+
   it("returns to waiting when the resumed Lobster run needs approval again", async () => {
     const taskFlow = createFakeTaskFlow();
     const runner = createRunner({

--- a/extensions/lobster/src/lobster-taskflow.ts
+++ b/extensions/lobster/src/lobster-taskflow.ts
@@ -144,7 +144,6 @@ function applyEnvelopeToFlow(params: {
 async function executeManagedLobsterFlow(
   params: Pick<RunManagedLobsterFlowParams, "taskFlow" | "runner" | "runnerParams" | "waitingStep">,
   flow: FlowRecord,
-  failureFlowId = flow.flowId,
 ): Promise<ManagedLobsterFlowResult> {
   try {
     const envelope = await params.runner.run(params.runnerParams);
@@ -162,7 +161,7 @@ async function executeManagedLobsterFlow(
     const err = error instanceof Error ? error : new Error(String(error));
     try {
       const mutation = params.taskFlow.fail({
-        flowId: failureFlowId,
+        flowId: flow.flowId,
         expectedRevision: flow.revision,
       });
       return { ok: false, flow, mutation, error: err };
@@ -207,5 +206,5 @@ export async function resumeManagedLobsterFlow(
       error: new Error(`TaskFlow resume failed: ${resumed.code}`),
     };
   }
-  return await executeManagedLobsterFlow(params, resumed.flow, params.flowId);
+  return await executeManagedLobsterFlow(params, resumed.flow);
 }


### PR DESCRIPTION
## What Problem This Solves

Removes a redundant failure-flow identifier from managed Lobster resume execution, where the resumed TaskFlow record already owns the authoritative flow identity and revision.

## Why This Change Was Made

The shared execution path now uses `flow.flowId` for runner-rejection failure mutations and receives only `resumed.flow` after a successful resume. This keeps failure identity and revision on the same authoritative lifecycle record without changing run/resume parsing, fallback, credential, or TaskFlow ownership behavior.

## User Impact

No user-visible behavior changes. The managed Lobster resume path has a smaller identity surface and explicit regression coverage for runner rejection after revision advancement.

## Evidence

- Exact PR base: `a2c186ac75562e820bb7d59b80262b63a8036c6c`
- Exact head: `42b8f95d5cc979dd2dcf8816b59345620368b003`
- `node scripts/run-vitest.mjs extensions/lobster/src/lobster-taskflow.test.ts extensions/lobster/src/lobster-tool.test.ts extensions/lobster/src/lobster-runner.test.ts`: 3 files, 67 tests passed
- `node scripts/run-vitest.mjs src/tasks/task-flow-registry.test.ts`: 1 file, 10 tests passed
- `pnpm tsgo:extensions:test`: passed
- exact-file Oxlint and oxfmt checks: passed
- changed-file dry run: `extensions`, `extensionTests`
- protected publisher: `PR Crabbox gate #131499 / 42b8f95d5cc979dd2dcf8816b59345620368b003`, [workflow 33170924669](https://github.com/openclaw/openclaw/actions/runs/33170924669), trusted workflow SHA `ccbbaf2e2e57f53b3a2b086b3490d21fe40a7c9d`
- broker principal: bearer auth, `owner=unknown`, `org=openclaw`, `admin=false`; the trusted publisher required the resulting run to match that exact owner/org
- AWS/Linux proof: run `run_9e8eb5c1eb0f`, lease `cbx_0f55635630fb`, slug `silver-prawn`, public network, no hydration, no instance profile
- immutable plan SHA-256: `5781834bd9e1197b8f100260301e65924b51fbbef394b2729b7cb1cef807053d` (2 targets)
- trusted bootstrap SHA-256: `5cd52c255f6df752e74a6f913354107516de3fc002a5bcf19586e04ac13d5985`
- remote result: build passed, check passed, 43/43 PR-derived tests passed; state `succeeded`, phase `released`, exit `0`, untruncated, terminal command success followed by lease release, `leaseStopped=true`
- exact check: [`openclaw/crabbox-gate` 98852150395](https://github.com/openclaw/openclaw/runs/98852150395), completed/success on the exact head from GitHub Actions app `15368`
- safe stale-authority proof: [workflow 33172426257](https://github.com/openclaw/openclaw/actions/runs/33172426257) used the PR base as a deliberately mismatched head and failed with `pull request exact base, head, or head repository does not match` before provisioning; no Crabbox run/lease was created and the successful exact-head check was unchanged
- exact-head hosted checks: 57 passed, 46 skipped, 0 failed, 0 pending
- exact-head ClawSweeper: no findings, security none; focused live test passed
- independent Sol/high autoreview: exit 0, `findings=[]`, correctness `correct`, confidence `0.99`, no fallback
- production LOC: `+2/-3`, net `-1`
- tests LOC: `+17/-0`
- sibling Codex runner contract inspected: nonzero/signal process exits reject after preserving the exact exit result

Preserved invariants: separate run/resume validation and error order, flat schema, ordinary fallback, revision `0`, resume-only credential parsing while run ignores malformed resume-only credentials, and separate TaskFlow lifecycle owners.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted Codex session transcript</summary>

```text
[user]
Create a fresh branch from current main. In the Lobster TaskFlow owner, remove the redundant failureFlowId, use flow.flowId, pass only resumed.flow, and add the flow-1/revision-5 runner-rejection assertion. Preserve parsing and lifecycle invariants. Run the three targeted tests, changed-file dry run, commit, push, open a draft PR, and exercise the new Crabbox gate without merging.

[assistant]
Created the clean GWT from exact origin/main, read the scoped guides and relevant skills, reused the retained graph, inspected the Lobster owner/callers/tests/history, and directly checked the sibling Codex process-exit contract.

[assistant]
Applied the two-file owner-level refactor. The shared execution path now takes only the authoritative FlowRecord; runner rejection fails flow.flowId at flow.revision. Added resume rejection coverage for flow-1 at revision 5.

[assistant]
Focused proof passed: 3 test files and 67 tests, extension test typecheck, exact-file lint/format, changed-file dry run, and diff check. Production delta is net -1 line.
```

</details>
<!-- agent-transcript:end -->

