### PR TITLE
fix(ui): keep new automations internal by default

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -383,8 +383,8 @@ select it to open the owning Approvals page.
   <Accordion title="Automations panel notes">
     - Selecting a row opens a full-page detail view with an Active/Paused switch and Run now in the header (run-if-due, clone, and remove in its menu); the Settings tab edits the automation inline (prompt, details, frequency, advanced overrides) and the Run history tab shows that automation's runs.
     - Starter automations under the table prefill the create form with an editable prompt and schedule.
-    - For isolated tasks, delivery defaults to announce summary; switch to none for internal-only runs.
-    - Channel/target fields appear when announce is selected.
+    - New isolated tasks default to internal-only delivery. Select announce explicitly to send a summary to a channel.
+    - Channel/target fields appear when announce is selected; provide an explicit destination when the channel requires one.
     - Webhook mode uses `delivery.mode = "webhook"` with `delivery.to` set to a valid HTTP(S) webhook URL.
     - For main-session tasks, webhook and none delivery modes are available.
     - Advanced edit controls include delete-after-run, clear agent override, cron exact/stagger options, agent model/thinking overrides, and best-effort delivery toggles.

--- a/ui/src/e2e/cron-select-values.e2e.test.ts
+++ b/ui/src/e2e/cron-select-values.e2e.test.ts
@@ -78,9 +78,8 @@ suite.define(() => {
             String((element as HTMLElement & { value?: string }).value),
           ),
         ).toBe("minutes");
-        // Control: delivery mode's default is also its first option.
-        expect(await pickerValue("wa-select#cron-delivery-mode")).toBe("announce");
-        expect(await pickerValue("wa-select#cron-delivery-channel")).toBe("last");
+        expect(await pickerValue("wa-select#cron-delivery-mode")).toBe("none");
+        expect(await page.locator("wa-select#cron-delivery-channel").count()).toBe(0);
 
         await action.click();
         await page.getByRole("option", { name: "Post to main timeline", exact: true }).click();

--- a/ui/src/lib/cron/index.test.ts
+++ b/ui/src/lib/cron/index.test.ts
@@ -575,19 +575,14 @@ describe("cron controller", () => {
     });
   });
 
-  it('sends delivery: { mode: "none" } explicitly in cron.add payload', async () => {
-    const { submit } = createCronSubmitHarness("job-none-add", {
-      form: {
-        name: "none delivery job",
-        everyAmount: "1",
-        everyUnit: "minutes",
-        wakeMode: "next-heartbeat",
-        payloadText: "run this",
-        deliveryMode: "none",
-      },
-    });
+  it('defaults a fresh cron.add to delivery: { mode: "none" }', async () => {
+    const request = createCronRequest("job-none-add");
+    const state = createStateWithRequest(request);
+    state.cronForm.name = "none delivery job";
+    state.cronForm.payloadText = "run this";
 
-    const { call } = await submit();
+    await addCronJob(state);
+    const call = findRequestCall(request.mock.calls, "cron.add");
 
     expect((call[1] as { delivery?: unknown } | undefined)?.delivery).toEqual({
       mode: "none",
@@ -693,8 +688,8 @@ describe("cron controller", () => {
     expect((call[1] as { delivery?: unknown } | undefined)?.delivery).toEqual({
       mode: "none",
     });
-    // After submit, form is reset to defaults (deliveryMode = "announce" from DEFAULT_CRON_FORM).
-    expect(state.cronForm.deliveryMode).toBe("announce");
+    // After submit, the form returns to the targetless internal-only default.
+    expect(state.cronForm.deliveryMode).toBe("none");
   });
 
   it("submits cron.update when editing an existing job", async () => {

--- a/ui/src/lib/cron/index.ts
+++ b/ui/src/lib/cron/index.ts
@@ -164,7 +164,7 @@ const DEFAULT_CRON_FORM: CronFormState = {
   payloadModel: "",
   payloadThinking: "",
   payloadLightContext: false,
-  deliveryMode: "announce",
+  deliveryMode: "none",
   deliveryChannel: "last",
   deliveryTo: "",
   deliveryAccountId: "",

--- a/ui/src/pages/cron/cron-page.test.ts
+++ b/ui/src/pages/cron/cron-page.test.ts
@@ -523,6 +523,7 @@ describe("CronPage editor state sync", () => {
         expect.objectContaining({
           name: "Agent-scoped task",
           agentId: scenario.expectedAgentId,
+          delivery: { mode: "none" },
         }),
       );
     });

--- a/ui/src/pages/cron/suggestions.ts
+++ b/ui/src/pages/cron/suggestions.ts
@@ -68,7 +68,6 @@ export function suggestionFormPatch(idea: CronSuggestion): Partial<CronFormState
     payloadText: t(idea.promptKey),
     payloadKind: "agentTurn",
     sessionTarget: "isolated",
-    deliveryMode: "announce",
     wakeMode: "now",
     deleteAfterRun: false,
     enabled: true,

--- a/ui/src/pages/cron/view.test.ts
+++ b/ui/src/pages/cron/view.test.ts
@@ -214,9 +214,9 @@ describe("cron view list pane", () => {
       payloadKind: "agentTurn",
       scheduleKind: "cron",
       cronExpr: "0 9 * * 1-5",
-      deliveryMode: "announce",
       name: "Repo pulse",
     });
+    expect(patch).not.toHaveProperty("deliveryMode");
     expect(String(patch.payloadText)).toContain("overnight activity");
   });
 
@@ -343,14 +343,14 @@ describe("cron view selects", () => {
       container.querySelectorAll<HTMLElement & { value: string }>("wa-select"),
     ).find((select) => select.querySelector('[slot="label"]')?.textContent === "Unit");
     expect(unit?.querySelector("wa-option[selected]")?.getAttribute("value")).toBe("minutes");
-    // Negative control: the delivery-mode default is also the first option, so
-    // this passes before and after the fix and proves the harness reads selects.
+    // The targetless create form keeps delivery internal until the operator
+    // explicitly selects a channel delivery mode.
     const delivery = getElement(
       container,
       "wa-select#cron-delivery-mode",
       HTMLElement,
     ) as HTMLElement & { value: string };
-    expect(delivery.querySelector("wa-option[selected]")?.getAttribute("value")).toBe("announce");
+    expect(delivery.querySelector("wa-option[selected]")?.getAttribute("value")).toBe("none");
   });
 
   it("shows persisted non-first values in jobs filters and runs sort", () => {

--- a/ui/src/test-helpers/cron.ts
+++ b/ui/src/test-helpers/cron.ts
@@ -28,7 +28,7 @@ export const DEFAULT_CRON_FORM: CronFormState = {
   payloadModel: "",
   payloadThinking: "",
   payloadLightContext: false,
-  deliveryMode: "announce",
+  deliveryMode: "none",
   deliveryChannel: "last",
   deliveryTo: "",
   deliveryAccountId: "",


### PR DESCRIPTION
Fixes #126543

## What Problem This Solves

Fixes an issue where users creating a targetless automation in the Control UI would implicitly request channel delivery. When the last channel was Telegram (or another channel requiring an explicit destination), the default path failed instead of completing the task internally.

Reported by @xialonglee.

## Why This Change Was Made

New Control UI automation forms now default to `delivery.mode: "none"`, and starter automation suggestions inherit that same form-owned default. Announce and webhook delivery remain explicit choices; the delivery resolver continues to reject ambiguous targets rather than guessing a recipient. Existing saved automations and the CLI's documented delivery default are unchanged.

The Control UI documentation now states this targetless-create contract and tells operators to select announce plus a required destination when they want channel delivery.

Production UI code is net -1 line (+1/-2). Tests and test support are net -4 lines (+15/-19); docs are net neutral (+2/-2).

## User Impact

Quick Create and starter automations run internally by default without depending on prior channel state. Operators who want a completion summary can explicitly select Announce summary and provide a destination when their channel requires one.

## Evidence

Before the fix, current `main` at `2058fd7e91a7` still initializes fresh forms with `deliveryMode: "announce"` and starter suggestions explicitly reapply `deliveryMode: "announce"`. The new regression therefore observed a fresh `cron.add` request containing an ambiguous announce payload:

```text
Expected: { mode: "none" }
Received: { mode: "announce", channel: undefined, to: undefined, ... }
```

After the fix:

- [Exact-head CI attempt 2](https://github.com/openclaw/openclaw/actions/runs/33141528483/attempts/2) — passed at `3b944d0f927e764f8a485b2d73f855760ea398a5`; the sole unrelated first-attempt E2E timing failure passed on rerun.
- [Mocked-Gateway browser E2E shard 4/14](https://github.com/openclaw/openclaw/actions/runs/33141528483/job/98753367789) — passed on the exact head. It boots the real Control UI route, clicks **New task**, reads the live `wa-select` value as `none`, and verifies the delivery-channel control is absent (`ui/src/e2e/cron-select-values.e2e.test.ts:61-82`).
- Focused local mocked-Gateway browser rerun: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/cron-select-values.e2e.test.ts` — 1/1 passed. This validates route boot, Gateway handshake, rendered form ownership, and interactive select state.
- Request-boundary regression: New task and starter-suggestion entry points submit `cron.add` with `delivery: { mode: "none" }` across selected/default/all-agent scopes (`ui/src/pages/cron/cron-page.test.ts:481-529`).
- Controller boundary: a fresh canonical form serializes explicit `delivery: { mode: "none" }` (`ui/src/lib/cron/index.test.ts:578-590`).
- `node scripts/run-vitest.mjs ui/src/lib/cron/index.test.ts ui/src/pages/cron/cron-page.test.ts ui/src/pages/cron/view.test.ts` — 188/188 passed.
- Earlier full validation remains green: 215 focused tests, 11,129 Control UI tests with 67 skipped, `pnpm ui:build`, `pnpm docs:check-mdx`, `node scripts/check-changed.mjs`, and autoreview with no accepted/actionable findings.

Visual capture was attempted through the required Codex in-app browser only. The mock server was available at `http://127.0.0.1:5199/cron`, but the Browser pane opener did not complete and browser discovery returned no registered browser after the documented recovery check. No Chrome, Computer Use, external browser, or operator Gateway was substituted. The exact-head mocked-Gateway Chromium E2E job above is the strongest supported real-flow artifact available in this session.
