### PR TITLE
fix: SQLite-only gateways re-enter legacy session migration discovery at startup

### DIFF
--- a/src/config/sessions/startup-migration.registry-recovery.test.ts
+++ b/src/config/sessions/startup-migration.registry-recovery.test.ts
@@ -72,6 +72,87 @@ it("does not create a missing configured agent database during startup maintenan
   expect(sweepOrphanSessionStoreTemps).toHaveBeenCalledWith({ storePath });
 });
 
+it("enters directory-dependent migration only for a real legacy sessions directory", async () => {
+  const root = fs.realpathSync.native(tempDirs.make("openclaw-startup-legacy-dir-gate-"));
+  const stateDir = path.join(root, "state");
+  const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+  const cfg: OpenClawConfig = {
+    agents: { entries: { ops: { default: true } } },
+  };
+  await replaceSessionEntry(
+    { agentId: "ops", env, sessionKey: "agent:ops:main" },
+    { sessionId: "sqlite-only", updatedAt: 1 },
+  );
+  closeOpenClawAgentDatabasesForTest();
+
+  const migrateLegacyMainSessionKeys = vi.fn(async () => ({
+    armed: false,
+    changes: [],
+    complete: false,
+    ledgerComplete: false,
+    legacyAgentId: "main",
+    mainKey: "main",
+    outcomes: [{ kind: "not-armed" as const }],
+    warnings: [],
+  }));
+  const migrateOrphanedSessionKeys = vi.fn<
+    NonNullable<
+      NonNullable<
+        Parameters<typeof runSessionStartupMigration>[0]["deps"]
+      >["migrateOrphanedSessionKeys"]
+    >
+  >(async ({ legacySessionSurfaces }) => {
+    if (typeof legacySessionSurfaces === "function") {
+      legacySessionSurfaces();
+    }
+    return { changes: [], warnings: [] };
+  });
+  const prepareLegacySessionSurfaces = vi.fn(() => EMPTY_LEGACY_SESSION_SURFACES);
+  const resolveAllAgentSessionStoreTargetsSync = vi.fn(() => []);
+  const log = { info: vi.fn(), warn: vi.fn() };
+  const run = () =>
+    runSessionStartupMigration({
+      cfg,
+      env,
+      log,
+      deps: {
+        migrateLegacyMainSessionKeys,
+        migrateOrphanedSessionKeys,
+        prepareLegacySessionSurfaces,
+        resolveAllAgentSessionStoreTargetsSync,
+        sweepOrphanSessionStoreTemps: vi.fn(async () => 0),
+      },
+    });
+
+  const statSync = vi.spyOn(fs, "statSync").mockImplementationOnce(() => {
+    throw Object.assign(new Error("permission denied"), { code: "EACCES" });
+  });
+  try {
+    await expect(run()).resolves.toBe(false);
+  } finally {
+    statSync.mockRestore();
+  }
+  expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("permission denied"));
+  expect(migrateLegacyMainSessionKeys).toHaveBeenCalledOnce();
+  expect(migrateOrphanedSessionKeys).not.toHaveBeenCalled();
+  expect(prepareLegacySessionSurfaces).not.toHaveBeenCalled();
+  expect(resolveAllAgentSessionStoreTargetsSync).not.toHaveBeenCalled();
+
+  await expect(run()).resolves.toBe(false);
+  expect(migrateLegacyMainSessionKeys).toHaveBeenCalledTimes(2);
+  expect(migrateOrphanedSessionKeys).not.toHaveBeenCalled();
+  expect(prepareLegacySessionSurfaces).not.toHaveBeenCalled();
+  expect(resolveAllAgentSessionStoreTargetsSync).not.toHaveBeenCalled();
+
+  fs.mkdirSync(path.join(stateDir, "agents", "ops", "sessions"));
+
+  await expect(run()).resolves.toBe(true);
+  expect(migrateLegacyMainSessionKeys).toHaveBeenCalledTimes(3);
+  expect(migrateOrphanedSessionKeys).toHaveBeenCalledOnce();
+  expect(prepareLegacySessionSurfaces).toHaveBeenCalledOnce();
+  expect(resolveAllAgentSessionStoreTargetsSync).toHaveBeenCalledOnce();
+});
+
 it("re-registers durable lineage children before configured-only runtime reads", async () => {
   const root = fs.realpathSync.native(tempDirs.make("openclaw-startup-registry-recovery-"));
   const stateDir = path.join(root, "state");

--- a/src/config/sessions/startup-migration.ts
+++ b/src/config/sessions/startup-migration.ts
@@ -53,14 +53,14 @@ export async function runSessionStartupMigration(params: {
   const resolveTargets =
     params.deps?.resolveAllAgentSessionStoreTargetsSync ?? resolveAllAgentSessionStoreTargetsSync;
   let targets: ReturnType<typeof resolveTargets> | undefined;
-  let hasLegacySessionDirectories = true;
+  let hasLegacySessionDirectories = Boolean(params.cfg.session?.store);
   try {
-    if (
-      !params.cfg.session?.store &&
-      (await resolveAgentSessionDirs(resolveStateDir(env))).length === 0
-    ) {
-      hasLegacySessionDirectories = false;
-    } else {
+    if (!hasLegacySessionDirectories) {
+      hasLegacySessionDirectories = (await resolveAgentSessionDirs(resolveStateDir(env))).some(
+        (sessionsDir) => fs.statSync(sessionsDir, { throwIfNoEntry: false })?.isDirectory(),
+      );
+    }
+    if (hasLegacySessionDirectories) {
       targets = resolveTargets(params.cfg, { env });
     }
   } catch (err) {


### PR DESCRIPTION
Fixes #129217

## What Problem This Solves

Fixes an issue where operators running fully migrated SQLite session state
would repeatedly enter legacy session migration discovery during Gateway
startup. An agent SQLite database under `agents/<id>/agent` caused startup to
treat the synthesized, nonexistent `agents/<id>/sessions` path as legacy state,
which triggered unnecessary directory scans, plugin legacy-surface loading, and
SQLite import preparation.

## Why This Change Was Made

Startup now treats synthesized session paths as candidates and enables
directory-dependent legacy migration only after its caller verifies that at
least one path is an actual directory. Automatic discovery errors do not count
as proof of legacy state. Explicit `session.store` configuration still enters
the migration path, genuine legacy directories retain existing behavior, and
legacy-main-key migration remains independent of this gate.

The shared session-directory synthesis helper is unchanged because other
callers intentionally derive agent roots or SQLite database paths from those
candidates.

## User Impact

SQLite-only Gateways no longer initialize legacy migration and plugin surfaces
on every startup when no legacy sessions directory exists. Installations with
explicit session-store configuration or real legacy session directories keep
their existing migration behavior.

## Evidence

Base revision:
`8a9202a392476d6fe24bb8d845cab0eae7bfad57`

The reproduction created a real
`agents/sqlite-only/agent/openclaw-agent.sqlite` through the production session
accessor and left `agents/sqlite-only/sessions` absent.

Before:

- 8 state-scoped filesystem operations
- 1 legacy target-discovery call
- 1 orphan-migration call
- 1 plugin legacy-surface preparation call
- 1 startup SQLite import call
- ESM translation of `legacy-session-surfaces.ts` and
  `doctor-session-sqlite.ts`

After:

- 3 state-scoped filesystem operations
- 0 legacy target-discovery calls
- 0 orphan-migration calls
- 0 plugin legacy-surface preparation calls
- 0 startup SQLite import calls
- no ESM translation of either legacy import module
- legacy-main migration still called once

Regression proof on the pre-fix production file failed only:

```text
enters directory-dependent migration only for a real legacy sessions directory
AssertionError: expected true to be false
```

Final Blacksmith Testbox proof used lease
`tbx_01m132bqt6ahgm6mqh10t2r4m4` and a disposable clone pinned to the exact
base with `pnpm install --frozen-lockfile`:

- `pnpm test src/config/sessions/startup-migration.registry-recovery.test.ts`
  passed 4/4 tests.
- `pnpm test src/config/sessions/legacy-main-session-migration.startup.test.ts`
  passed 2/2 tests.
- `pnpm test src/gateway/server-startup-secret-owner-isolation.test.ts` passed
  31/31 tests, including explicit `session.store` migration/import coverage.
- `pnpm check:changed` passed all selected `core` and `coreTests` checks.

Test changes:

- Added: one gate test covering discovery failure, SQLite-only absence, and a
  genuine legacy sessions directory.
- Modified: none.
- Deleted: none.

Independent technical review found the implementation consistent with the
requested behavior. A stale post-fix evidence revision was corrected by
rerunning the seeded probe at exact commit `6f26f43e591`, which recorded zero
legacy import resolutions. The subsequent Workloop review could not complete
because reviewer infrastructure repeatedly rejected its own structured review
state, so no pull request was created.
