### PR TITLE
fix(transcripts): preserve captures with oversized export names

### DIFF
--- a/docs/cli/transcripts.md
+++ b/docs/cli/transcripts.md
@@ -63,6 +63,14 @@ occurs on more than one day, for example `openclaw transcripts show
 2026-05-22/standup`. Default session ids include a timestamp and random
 suffix; give a session a fixed id only when that id is unique within the day.
 
+If the filesystem-safe export name exceeds 255 bytes, OpenClaw shortens it
+to a prefix plus a deterministic SHA-256 hash of the complete original session
+ID. Only the derived export name and its selector change; the raw session ID,
+provider stop handle, and stored notes stay intact. Names that already fit
+remain unchanged. Use the selector printed by `list` for the shortened name.
+For existing sessions with oversized stored names, run `openclaw doctor --fix`
+to repair their derived selectors without changing stored notes.
+
 ## Output
 
 `list` prints one tab-separated line per session: selector, start time, title,

--- a/src/agents/tools/transcripts-tool.session-id.test.ts
+++ b/src/agents/tools/transcripts-tool.session-id.test.ts
@@ -1,0 +1,332 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
+import type { DB } from "../../state/openclaw-state-db.generated.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
+import type { TranscriptSourceProvider } from "../../transcripts/provider-types.js";
+import { TranscriptsStore } from "../../transcripts/store.js";
+import { summarizeTranscripts } from "../../transcripts/summary.js";
+import { createTranscriptsTool } from "./transcripts-tool.js";
+
+const { getTranscriptSourceProviderMock } = vi.hoisted(() => ({
+  getTranscriptSourceProviderMock: vi.fn(),
+}));
+vi.mock("../../transcripts/provider-registry.js", () => ({
+  getTranscriptSourceProvider: getTranscriptSourceProviderMock,
+  listTranscriptSourceProviders: () => [],
+}));
+
+const tempDirs = createTempDirTracker();
+const pendingStops = new Map<ReturnType<typeof createTranscriptsTool>, Set<string>>();
+const note = "Keep the captured notes.";
+
+function createHarness() {
+  const stateDir = tempDirs.make("openclaw-transcript-ids-");
+  const databaseOptions = { env: { ...process.env, OPENCLAW_STATE_DIR: stateDir } };
+  const start = vi.fn<NonNullable<TranscriptSourceProvider["start"]>>(async (request) => {
+    await request.onUtterance({ text: note, final: true });
+    return { ok: true, session: request.session };
+  });
+  const stop = vi.fn<NonNullable<TranscriptSourceProvider["stop"]>>(async (request) => ({
+    ok: true,
+    sessionId: request.sessionId,
+  }));
+  const importTranscript = vi.fn<NonNullable<TranscriptSourceProvider["importTranscript"]>>(
+    async () => [{ text: note }],
+  );
+  getTranscriptSourceProviderMock.mockReturnValue({
+    id: "room-audio",
+    name: "Room Audio",
+    sourceKinds: ["live-audio", "posthoc-transcript"],
+    start,
+    stop,
+    importTranscript,
+  } satisfies TranscriptSourceProvider);
+  const tool = createTranscriptsTool({ stateDir, caller: { kind: "operator", source: "local" } });
+  const active = new Set<string>();
+  pendingStops.set(tool, active);
+  return {
+    stateDir,
+    databaseOptions,
+    store: new TranscriptsStore(path.join(stateDir, "transcripts"), databaseOptions),
+    tool,
+    active,
+    start,
+    stop,
+    importTranscript,
+  };
+}
+
+async function capture(
+  harness: ReturnType<typeof createHarness>,
+  action: "start" | "import",
+  sessionId: string | undefined,
+) {
+  const result = await harness.tool.execute(action, {
+    action,
+    sessionId,
+    providerId: "room-audio",
+    transcript: note,
+  });
+  const handle = asOptionalRecord(result.details)?.sessionId;
+  if (typeof handle !== "string") {
+    throw new Error("Expected a transcript session handle");
+  }
+  // Only successful starts own cleanup; failed admission must retain its original error.
+  if (action === "start") {
+    harness.active.add(handle);
+  }
+  expect(asOptionalRecord(result.details)?.summaryExportError).toBeUndefined();
+  return handle;
+}
+
+afterEach(async () => {
+  try {
+    for (const [tool, handles] of pendingStops) {
+      for (const sessionId of handles) {
+        await tool.execute("cleanup", { action: "stop", sessionId });
+      }
+    }
+  } finally {
+    pendingStops.clear();
+    getTranscriptSourceProviderMock.mockReset();
+    vi.useRealTimers();
+    closeOpenClawStateDatabaseForTest();
+    tempDirs.cleanup();
+  }
+});
+
+describe("transcripts bounded export names", () => {
+  const oversizedIds = [
+    { label: "256 safe bytes", sessionId: "notes-0-" + "x".repeat(248) },
+    { label: "908 safe bytes", sessionId: "notes-0-" + "x".repeat(900) },
+    { label: "2208 safe bytes", sessionId: "notes-0-" + "x".repeat(2200) },
+    { label: "258 encoded bytes", sessionId: "x".repeat(85) + "." },
+    { label: "overlong encoded device name", sessionId: "CON." + "x".repeat(100) },
+  ];
+  const ordinaryIds = [
+    { label: "generated", sessionId: undefined, slug: undefined },
+    { label: "punctuation", sessionId: "notes: room/one", slug: "notes-room-one" },
+    { label: "255 safe bytes", sessionId: "x".repeat(255), slug: "x".repeat(255) },
+    { label: "255 encoded bytes", sessionId: "x".repeat(84) + ".", slug: "%78".repeat(84) + "%2E" },
+    { label: "2208 opaque characters", sessionId: "notes-0-" + "?".repeat(2200), slug: "notes-0" },
+    { label: "dot", sessionId: ".", slug: "%2E" },
+    { label: "dot-dot", sessionId: "..", slug: "%2E%2E" },
+    { label: "device", sessionId: "CON", slug: "%43%4F%4E" },
+  ];
+  const cases = [
+    ...oversizedIds.flatMap(({ label, sessionId }) =>
+      [false, true].flatMap((exportParentExists) =>
+        (["start", "import"] as const).map((action) => ({
+          label,
+          sessionId,
+          action,
+          exportParentExists,
+          shortened: true,
+          slug: undefined,
+        })),
+      ),
+    ),
+    ...ordinaryIds.map(({ label, sessionId, slug }) => ({
+      label,
+      sessionId,
+      slug,
+      action: "start" as const,
+      exportParentExists: true,
+      shortened: false,
+    })),
+  ];
+
+  it.each(cases)(
+    "$action round-trips $label with export parent=$exportParentExists",
+    async ({ sessionId, slug, shortened, exportParentExists, action }) => {
+      const harness = createHarness();
+      const { stateDir, store, tool, start, stop, importTranscript, active } = harness;
+      if (exportParentExists) {
+        await fs.mkdir(path.join(stateDir, "transcripts", new Date().toISOString().slice(0, 10)), {
+          recursive: true,
+        });
+      }
+      const handle = await capture(harness, action, sessionId);
+      expect(
+        sessionId === undefined ? handle.startsWith("transcript-") : handle === sessionId,
+      ).toBe(true);
+      const providerSession =
+        action === "start"
+          ? start.mock.calls[0]?.[0].session
+          : importTranscript.mock.calls[0]?.[0].session;
+      expect(providerSession?.sessionId === handle).toBe(true);
+      if (action === "start") {
+        const stopped = await tool.execute("stop", { action: "stop", sessionId: handle });
+        active.delete(handle);
+        expect(asOptionalRecord(stopped.details)?.summaryExportError).toBeUndefined();
+        expect(stop.mock.calls[0]?.[0].sessionId === handle).toBe(true);
+      }
+      closeOpenClawStateDatabaseForTest();
+      const summarized = await tool.execute("summarize", {
+        action: "summarize",
+        sessionId: handle,
+      });
+      expect(asOptionalRecord(summarized.details)?.summaryExportError).toBeUndefined();
+      const entry = await store.readSessionEntry(handle);
+      expect(entry?.session.sessionId === handle).toBe(true);
+      expect(entry?.session.stoppedAt).toBeTruthy();
+      const exportedSlug = path.basename(entry!.sessionDir);
+      expect(Buffer.byteLength(exportedSlug)).toBeLessThanOrEqual(255);
+      if (shortened) {
+        expect(exportedSlug).toMatch(/^[a-zA-Z0-9._%-]+-[a-f0-9]{64}$/);
+        expect(exportedSlug.endsWith(`-${createHash("sha256").update(handle).digest("hex")}`)).toBe(
+          true,
+        );
+      } else {
+        expect(exportedSlug).toBe(slug ?? handle);
+      }
+      expect(entry!.selector).toBe(`${entry!.session.startedAt.slice(0, 10)}/${exportedSlug}`);
+      expect((await store.readSession(entry!.selector))?.sessionId === handle).toBe(true);
+      expect((await store.readSession(exportedSlug))?.sessionId === handle).toBe(true);
+      const artifacts = await store.materializeSessionArtifacts(entry!.selector, "all");
+      expect(
+        JSON.parse(await fs.readFile(artifacts.metadataPath, "utf8")).sessionId === handle,
+      ).toBe(true);
+      expect(await fs.readFile(artifacts.summaryPath, "utf8")).toContain(note);
+      expect(await fs.readFile(artifacts.transcriptPath, "utf8")).toContain(note);
+      expect((await store.readSummary(entry!.session)).summary?.sessionId === handle).toBe(true);
+    },
+  );
+
+  it("separates IDs with identical safe prefixes and different discarded punctuation", async () => {
+    const harness = createHarness();
+    const ids = ["?", "!"].map((suffix) => "notes-" + "x".repeat(900) + suffix);
+    for (const sessionId of ids) {
+      await capture(harness, "import", sessionId);
+    }
+    closeOpenClawStateDatabaseForTest();
+    const entries = await harness.store.listSessionEntries();
+    expect(new Set(entries.map((entry) => entry.selector)).size).toBe(2);
+    expect(entries.every((entry) => path.basename(entry.sessionDir).startsWith("notes-"))).toBe(
+      true,
+    );
+    for (const entry of entries) {
+      const artifacts = await harness.store.materializeSessionArtifacts(entry.selector, "all");
+      expect(
+        JSON.parse(await fs.readFile(artifacts.metadataPath, "utf8")).sessionId ===
+          entry.session.sessionId,
+      ).toBe(true);
+    }
+  });
+
+  it("keeps an older dated handle separate from an active next-day capture", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-07-01T10:00:00.000Z"));
+    const harness = createHarness();
+    const sessionId = "notes-" + "x".repeat(900);
+    await capture(harness, "import", sessionId);
+    const older = (await harness.store.listSessionEntries())[0]!;
+    vi.setSystemTime(new Date("2026-07-02T10:00:00.000Z"));
+    await capture(harness, "start", sessionId);
+    const current = (await harness.store.listSessionEntries())[0]!;
+    await harness.tool.execute("old-stop", { action: "stop", sessionId: older.selector });
+    expect(harness.stop).not.toHaveBeenCalled();
+    const result = await harness.tool.execute("current-stop", {
+      action: "stop",
+      sessionId: current.selector,
+    });
+    harness.active.delete(sessionId);
+    expect(harness.stop.mock.calls[0]?.[0].sessionId === sessionId).toBe(true);
+    expect(asOptionalRecord(result.details)?.summaryExportError).toBeUndefined();
+    closeOpenClawStateDatabaseForTest();
+    for (const entry of [older, current]) {
+      expect((await harness.store.readSession(entry.selector))?.startedAt).toBe(
+        entry.session.startedAt,
+      );
+      await expect(
+        harness.store.materializeSessionArtifacts(entry.selector, "all"),
+      ).resolves.toMatchObject({ hasSummary: true });
+    }
+  });
+
+  it("preserves historical overlong identities and existing notes during finalization", async () => {
+    const { store, databaseOptions } = createHarness();
+    const sessionId = "notes-0-" + "x".repeat(2200);
+    const session = {
+      sessionId,
+      startedAt: "2026-07-01T10:00:00.000Z",
+      source: { providerId: "room-audio" },
+    };
+    const selector = `2026-07-01/${sessionId}`;
+    await store.listSessionEntries();
+    const { db } = openOpenClawStateDatabase(databaseOptions);
+    const queries =
+      getNodeSqliteKysely<Pick<DB, "meeting_transcript_sessions" | "meeting_transcript_summaries">>(
+        db,
+      );
+    // Pre-fix admission could persist an overlong projection before an export failed.
+    executeSqliteQuerySync(
+      db,
+      queries.insertInto("meeting_transcript_sessions").values({
+        session_id: sessionId,
+        started_at: session.startedAt,
+        selector,
+        session_slug: sessionId,
+        export_key: selector,
+        provider_id: session.source.providerId,
+        source_json: JSON.stringify(session.source),
+        title: null,
+        stopped_at: null,
+        metadata_json: null,
+        export_manifest_json: "{}",
+        export_pending_json: "[]",
+        next_utterance_seq: 0,
+        created_at_ms: 0,
+        updated_at_ms: 0,
+      }),
+    );
+    await store.appendUtteranceForSession(session, { text: note, final: true });
+    const summary = summarizeTranscripts({ session, utterances: [{ text: note, final: true }] });
+    await store.writeSummary(summary, session);
+    const markdown = "# Preserved historical notes\n\nCustom formatting stays intact.\n";
+    executeSqliteQuerySync(
+      db,
+      queries
+        .updateTable("meeting_transcript_summaries")
+        .set({ markdown })
+        .where("session_id", "=", sessionId),
+    );
+    closeOpenClawStateDatabaseForTest();
+
+    await store.writeSession({ ...session, stoppedAt: "2026-07-01T11:00:00.000Z" });
+    closeOpenClawStateDatabaseForTest();
+    const entry = await store.readSessionEntry(sessionId);
+    expect(entry?.session.sessionId === sessionId).toBe(true);
+    expect(entry?.session.startedAt).toBe(session.startedAt);
+    expect(entry?.session.stoppedAt).toBe("2026-07-01T11:00:00.000Z");
+    expect(entry!.selector).toBe(`2026-07-01/${path.basename(entry!.sessionDir)}`);
+    expect((await store.readSession(entry!.selector))?.sessionId === sessionId).toBe(true);
+    expect(await store.readSummary(session)).toEqual({ summary, markdown });
+    expect(
+      (await store.readUtterancesForSession(session)).map((utterance) => utterance.text),
+    ).toEqual([note]);
+    const artifacts = await store.materializeSessionArtifacts(entry!.selector, "all");
+    expect(await fs.readFile(artifacts.summaryPath, "utf8")).toBe(markdown);
+    expect(JSON.parse(await fs.readFile(artifacts.summaryJsonPath, "utf8"))).toEqual(summary);
+    const reopened = openOpenClawStateDatabase(databaseOptions).db;
+    const row = executeSqliteQuerySync(
+      reopened,
+      getNodeSqliteKysely<Pick<DB, "meeting_transcript_sessions">>(reopened)
+        .selectFrom("meeting_transcript_sessions")
+        .select(["session_slug", "export_key"])
+        .where("session_id", "=", sessionId),
+    ).rows[0];
+    expect(row).toEqual({
+      session_slug: path.basename(artifacts.sessionDir),
+      export_key: entry!.selector.toLowerCase(),
+    });
+  });
+});

--- a/src/infra/state-migrations.meeting-transcripts-detection.ts
+++ b/src/infra/state-migrations.meeting-transcripts-detection.ts
@@ -1,8 +1,9 @@
-// Doctor detection for legacy meeting transcript files and interrupted imports.
+// Doctor detection for legacy meeting transcript files, projections, and interrupted imports.
 import fs from "node:fs";
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import { TRANSCRIPT_PATH_SEGMENT_MAX_BYTES } from "../transcripts/store-artifacts.js";
 import { openNodeSqliteDatabase } from "./node-sqlite.js";
 import {
   hasMatchingRecordedTranscriptArtifact,
@@ -22,6 +23,7 @@ type MeetingTranscriptMigrationDetectionState = {
   exportOwnership: Map<string, MeetingTranscriptExportOwnership>;
   exportOwnershipByFoldedSelector: Map<string, MeetingTranscriptExportOwnership[]>;
   pendingImportCount: number;
+  hasOversizedSessionSlugs: boolean;
 };
 
 const TRANSCRIPT_ARTIFACT_NAMES = new Set([
@@ -119,6 +121,7 @@ export function detectLegacyMeetingTranscripts(params: {
     env: { ...(params.env ?? process.env), OPENCLAW_STATE_DIR: params.stateDir },
   });
   const pendingImportCount = databaseState.pendingImportCount;
+  const needsDatabaseRepair = pendingImportCount > 0 || databaseState.hasOversizedSessionSlugs;
   try {
     const rootStat = fs.lstatSync(sourceDir);
     if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) {
@@ -167,12 +170,12 @@ export function detectLegacyMeetingTranscripts(params: {
     });
     return {
       sourceDir,
-      hasLegacy: hasSource || pendingImportCount > 0,
+      hasLegacy: hasSource || needsDatabaseRepair,
       pendingImportCount,
     };
   } catch (error) {
     if (isRecord(error) && error.code === "ENOENT") {
-      return { sourceDir, hasLegacy: pendingImportCount > 0, pendingImportCount };
+      return { sourceDir, hasLegacy: needsDatabaseRepair, pendingImportCount };
     }
     throw error;
   }
@@ -187,6 +190,7 @@ export function readMeetingTranscriptMigrationDetectionState(params: {
       exportOwnership: new Map(),
       exportOwnershipByFoldedSelector: new Map(),
       pendingImportCount: 0,
+      hasOversizedSessionSlugs: false,
     };
   }
   const database = openNodeSqliteDatabase(databasePath, { readOnly: true });
@@ -201,13 +205,16 @@ export function readMeetingTranscriptMigrationDetectionState(params: {
     );
     const exportOwnership = new Map<string, MeetingTranscriptExportOwnership>();
     const exportOwnershipByFoldedSelector = new Map<string, MeetingTranscriptExportOwnership[]>();
+    let hasOversizedSessionSlugs = false;
     if (tables.has("meeting_transcript_sessions")) {
       const rows = database
         .prepare(
-          "SELECT session_id, started_at, selector, export_manifest_json, export_pending_json FROM meeting_transcript_sessions",
+          "SELECT session_id, started_at, selector, session_slug, export_manifest_json, export_pending_json FROM meeting_transcript_sessions",
         )
         .all();
       for (const row of rows) {
+        hasOversizedSessionSlugs ||=
+          String(row.session_slug).length > TRANSCRIPT_PATH_SEGMENT_MAX_BYTES;
         const selector = String(row.selector);
         const parsed = JSON.parse(String(row.export_manifest_json)) as unknown;
         if (isRecord(parsed)) {
@@ -237,6 +244,7 @@ export function readMeetingTranscriptMigrationDetectionState(params: {
       exportOwnership,
       exportOwnershipByFoldedSelector,
       pendingImportCount: typeof pendingRow?.count === "number" ? pendingRow.count : 0,
+      hasOversizedSessionSlugs,
     };
   } finally {
     database.close();

--- a/src/infra/state-migrations.meeting-transcripts-projections.test.ts
+++ b/src/infra/state-migrations.meeting-transcripts-projections.test.ts
@@ -1,0 +1,298 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import { safeTranscriptPathSegment } from "../transcripts/store-artifacts.js";
+import { TranscriptsStore } from "../transcripts/store.js";
+import { summarizeTranscripts } from "../transcripts/summary.js";
+import { acquireGatewayLock } from "./gateway-lock.js";
+import { executeSqliteQuerySync } from "./kysely-sync.js";
+import { migrationDb } from "./state-migrations.meeting-transcripts-database.js";
+import {
+  detectLegacyMeetingTranscripts,
+  migrateLegacyMeetingTranscripts,
+} from "./state-migrations.meeting-transcripts.js";
+import {
+  recordLegacyMigrationRun,
+  recordLegacyMigrationSource,
+} from "./state-migrations.receipts.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => closeOpenClawStateDatabaseForTest());
+
+function createHarness() {
+  const stateDir = tempDirs.make("openclaw-transcript-projections-");
+  const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+  const root = path.join(stateDir, "transcripts");
+  const store = new TranscriptsStore(root, { env });
+  const detect = () =>
+    detectLegacyMeetingTranscripts({ stateDir, env, doctorOnlyStateMigrations: true });
+  const database = () => openOpenClawStateDatabase({ env }).db;
+  return {
+    stateDir,
+    env,
+    root,
+    store,
+    detect,
+    database,
+    migrate: () => migrateLegacyMeetingTranscripts({ stateDir, env, detected: detect() }),
+    snapshot: () => {
+      const db = database();
+      const queries = migrationDb(db);
+      return {
+        sessions: executeSqliteQuerySync(
+          db,
+          queries.selectFrom("meeting_transcript_sessions").selectAll().orderBy("session_id"),
+        ).rows,
+        utterances: executeSqliteQuerySync(
+          db,
+          queries
+            .selectFrom("meeting_transcript_utterances")
+            .selectAll()
+            .orderBy("session_id")
+            .orderBy("sequence"),
+        ).rows,
+        summaries: executeSqliteQuerySync(
+          db,
+          queries.selectFrom("meeting_transcript_summaries").selectAll().orderBy("session_id"),
+        ).rows,
+        runs: executeSqliteQuerySync(
+          db,
+          queries.selectFrom("migration_runs").selectAll().orderBy("id"),
+        ).rows,
+        sources: executeSqliteQuerySync(
+          db,
+          queries.selectFrom("migration_sources").selectAll().orderBy("source_key"),
+        ).rows,
+      };
+    },
+  };
+}
+
+async function seedSession(
+  harness: ReturnType<typeof createHarness>,
+  sessionId: string,
+  options: { historicalSlug?: string; export?: boolean } = {},
+) {
+  const session = {
+    sessionId,
+    startedAt: "2026-07-01T10:00:00.000Z",
+    stoppedAt: "2026-07-01T10:30:00.000Z",
+    source: { providerId: "manual-transcript", channelId: "room" },
+    title: "Stored notes",
+    metadata: { retained: true },
+  };
+  await harness.store.writeSession(session);
+  const utterance = { text: "Preserve this note.", final: true, metadata: { retained: true } };
+  await harness.store.appendUtteranceForSession(session, utterance);
+  const summary = summarizeTranscripts({ session, utterances: [utterance] });
+  await harness.store.writeSummary(summary, session);
+  const markdown = "# User-edited notes\n\nKeep  spacing and **formatting**.\n";
+  const db = harness.database();
+  const queries = migrationDb(db);
+  executeSqliteQuerySync(
+    db,
+    queries
+      .updateTable("meeting_transcript_summaries")
+      .set({ markdown })
+      .where("session_id", "=", sessionId),
+  );
+  const artifacts = options.export
+    ? await harness.store.materializeSessionArtifacts(session, "all")
+    : undefined;
+  if (options.historicalSlug) {
+    // Model the durable projection written before bounded filenames, without
+    // constructing an impossible filesystem path or rewriting any note content.
+    const selector = `2026-07-01/${options.historicalSlug}`;
+    executeSqliteQuerySync(
+      db,
+      queries
+        .updateTable("meeting_transcript_sessions")
+        .set({
+          selector,
+          session_slug: options.historicalSlug,
+          export_key: selector.toLowerCase(),
+          export_pending_json: '[ "transcript.jsonl" ]',
+        })
+        .where("session_id", "=", sessionId),
+    );
+  }
+  return { session, summary, markdown, artifacts };
+}
+
+describe("meeting transcript Doctor oversized projections", () => {
+  it.each([
+    {
+      label: "safe",
+      sessionId: "notes-" + "x".repeat(2200),
+      historicalSlug: "notes-" + "x".repeat(2200),
+    },
+    { label: "encoded", sessionId: "x".repeat(85) + ".", historicalSlug: "%78".repeat(85) + "%2E" },
+  ])(
+    "detects and repairs $label rows without an export root",
+    async ({ sessionId, historicalSlug }) => {
+      const harness = createHarness();
+      const seeded = await seedSession(harness, sessionId, { historicalSlug });
+      await seedSession(harness, "ordinary:notes");
+      const before = harness.snapshot();
+      await expect(fs.stat(harness.root)).rejects.toMatchObject({ code: "ENOENT" });
+      expect(detectLegacyMeetingTranscripts({ stateDir: harness.stateDir }).hasLegacy).toBe(false);
+      expect(harness.detect()).toMatchObject({ hasLegacy: true, pendingImportCount: 0 });
+      expect(harness.snapshot()).toEqual(before);
+
+      const result = await harness.migrate();
+      expect(result.warnings).toEqual([]);
+      expect(result.changes).toEqual([expect.stringMatching(/1.*oversized/i)]);
+      closeOpenClawStateDatabaseForTest();
+      const slug = safeTranscriptPathSegment(sessionId);
+      const expected = structuredClone(before);
+      Object.assign(
+        expected.sessions.find((row) => row.session_id === sessionId)!,
+        {
+          selector: `2026-07-01/${slug}`,
+          session_slug: slug,
+          export_key: `2026-07-01/${slug}`.toLowerCase(),
+        },
+      );
+      expect(harness.snapshot()).toEqual(expected);
+      await expect(fs.stat(harness.root)).rejects.toMatchObject({ code: "ENOENT" });
+      expect(harness.detect().hasLegacy).toBe(false);
+      await expect(harness.migrate()).resolves.toEqual({ changes: [], warnings: [] });
+      const entry = await harness.store.readSessionEntry(`2026-07-01/${slug}`);
+      expect(entry?.session).toEqual(seeded.session);
+      expect(await harness.store.readSummary(seeded.session)).toEqual({
+        summary: seeded.summary,
+        markdown: seeded.markdown,
+      });
+    },
+  );
+
+  it("recognizes bounded exports after repair without archiving or changing export bookkeeping", async () => {
+    const harness = createHarness();
+    const sessionId = "notes-" + "x".repeat(908);
+    const seeded = await seedSession(harness, sessionId, {
+      historicalSlug: sessionId,
+      export: true,
+    });
+    const before = harness.snapshot();
+    const fileNames = await fs.readdir(seeded.artifacts!.sessionDir);
+    const contents = await Promise.all(
+      fileNames.map((name) => fs.readFile(path.join(seeded.artifacts!.sessionDir, name), "utf8")),
+    );
+    const result = await harness.migrate();
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toEqual([expect.stringMatching(/1.*oversized/i)]);
+    const after = harness.snapshot();
+    expect(after.utterances).toEqual(before.utterances);
+    expect(after.summaries).toEqual(before.summaries);
+    expect(after.sessions[0]).toEqual({
+      ...before.sessions[0],
+      selector: `2026-07-01/${path.basename(seeded.artifacts!.sessionDir)}`,
+      session_slug: path.basename(seeded.artifacts!.sessionDir),
+      export_key: `2026-07-01/${path.basename(seeded.artifacts!.sessionDir)}`.toLowerCase(),
+    });
+    expect(
+      (await fs.readdir(harness.stateDir)).filter((name) => name.startsWith("transcripts.")),
+    ).toEqual([]);
+    expect(
+      await Promise.all(
+        fileNames.map((name) => fs.readFile(path.join(seeded.artifacts!.sessionDir, name), "utf8")),
+      ),
+    ).toEqual(contents);
+    expect(harness.detect().hasLegacy).toBe(false);
+    await expect(harness.migrate()).resolves.toEqual({ changes: [], warnings: [] });
+    expect(harness.snapshot()).toEqual(after);
+  });
+
+  it("rolls back all projection repairs when a bounded selector already has another owner", async () => {
+    const harness = createHarness();
+    const ids = ["a", "z"].map((prefix) => prefix + "x".repeat(300));
+    for (const sessionId of ids) {
+      await seedSession(harness, sessionId, { historicalSlug: sessionId });
+    }
+    await seedSession(harness, safeTranscriptPathSegment(ids[1]!));
+    const before = harness.snapshot();
+    const result = await harness.migrate();
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toEqual([expect.stringMatching(/UNIQUE constraint failed.*selector/i)]);
+    closeOpenClawStateDatabaseForTest();
+    expect(harness.snapshot()).toEqual(before);
+    expect(harness.detect().hasLegacy).toBe(true);
+    await expect(fs.stat(harness.root)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("does not create state when no database or legacy exports exist", async () => {
+    const harness = createHarness();
+    expect(harness.detect().hasLegacy).toBe(false);
+    await expect(harness.migrate()).resolves.toEqual({ changes: [], warnings: [] });
+    expect(await fs.readdir(harness.stateDir)).toEqual([]);
+  });
+
+  it("keeps committed repair messages and receipts when pending import recovery cannot finish", async () => {
+    const harness = createHarness();
+    const sessionId = "notes-" + "x".repeat(300);
+    await seedSession(harness, sessionId, { historicalSlug: sessionId });
+    recordLegacyMigrationRun(harness.database(), {
+      runId: "pending-import",
+      startedAt: 1,
+      finishedAt: null,
+      status: "imported",
+      reportJson: JSON.stringify({
+        format: "meeting-transcripts-files-v1",
+        archiveRoot: `${harness.root}.migrated-pending`,
+        canonicalRelativeDirs: [],
+      }),
+    });
+    recordLegacyMigrationSource(harness.database(), {
+      sourceKey: "pending-source",
+      migrationKind: "meeting-transcripts-files-v1",
+      sourcePath: path.join(harness.root, "2026-07-01", "legacy"),
+      targetTable: "meeting_transcript_sessions",
+      sourceSha256: "a".repeat(64),
+      sourceSizeBytes: 1,
+      sourceRecordCount: 1,
+      runId: "pending-import",
+      status: "imported",
+      importedAt: 1,
+      reportJson: "{}",
+    });
+    const before = harness.snapshot();
+    const result = await harness.migrate();
+    expect(result.changes).toEqual([expect.stringMatching(/1.*oversized/i)]);
+    expect(result.warnings).toEqual([expect.stringContaining("neither source tree nor archive")]);
+    const after = harness.snapshot();
+    expect(after.runs).toEqual(before.runs);
+    expect(after.sources).toEqual(before.sources);
+    expect(after.sessions[0]?.session_slug).toBe(safeTranscriptPathSegment(sessionId));
+    expect(harness.detect()).toMatchObject({ hasLegacy: true, pendingImportCount: 1 });
+    expect((await harness.migrate()).changes).toEqual([]);
+    expect(harness.snapshot()).toEqual(after);
+  });
+
+  it("requires exclusive state ownership before repairing projections", async () => {
+    const harness = createHarness();
+    const sessionId = "notes-" + "x".repeat(300);
+    await seedSession(harness, sessionId, { historicalSlug: sessionId });
+    const before = harness.snapshot();
+    const lock = await acquireGatewayLock({ allowInTests: true, env: harness.env });
+    if (!lock) {
+      throw new Error("expected test Gateway lock");
+    }
+    try {
+      const result = await harness.migrate();
+      expect(result.changes).toEqual([]);
+      expect(result.warnings).toEqual([
+        expect.stringContaining("exclusive state ownership is unavailable"),
+      ]);
+      expect(harness.snapshot()).toEqual(before);
+    } finally {
+      await lock.release();
+    }
+    expect((await harness.migrate()).warnings).toEqual([]);
+    expect(harness.detect().hasLegacy).toBe(false);
+  });
+});

--- a/src/infra/state-migrations.meeting-transcripts.test.ts
+++ b/src/infra/state-migrations.meeting-transcripts.test.ts
@@ -196,6 +196,42 @@ describe("meeting transcript Doctor migration", () => {
     });
   });
 
+  it.runIf(process.platform !== "win32")(
+    "imports legacy notes whose portable encoded export name is oversized",
+    async () => {
+      const stateDir = tempDirs.make("openclaw-meeting-transcripts-doctor-");
+      const sessionId = "x".repeat(85) + ".";
+      await seedLegacySession({ stateDir, sessionId });
+      const detected = detectLegacyMeetingTranscripts({
+        stateDir,
+        doctorOnlyStateMigrations: true,
+      });
+      const result = await migrateLegacyMeetingTranscripts({
+        detected,
+        env: databaseEnv(stateDir),
+        stateDir,
+      });
+      expect(result.warnings).toEqual([]);
+      closeOpenClawStateDatabaseForTest();
+      const store = new TranscriptsStore(path.join(stateDir, "transcripts"), {
+        env: databaseEnv(stateDir),
+      });
+      const entry = await store.readSessionEntry(sessionId);
+      expect(entry?.session.sessionId).toBe(sessionId);
+      const artifacts = await store.materializeSessionArtifacts(entry!.selector, "all");
+      expect(Buffer.byteLength(path.basename(artifacts.sessionDir))).toBeLessThanOrEqual(255);
+      expect(await fs.readFile(artifacts.summaryPath, "utf8")).toBe(
+        "# Design review\n\nFirst line.\n",
+      );
+      expect((await store.readUtterancesForSession(entry!.session)).map((row) => row.text)).toEqual(
+        ["First line", "Second line"],
+      );
+      expect(
+        detectLegacyMeetingTranscripts({ stateDir, doctorOnlyStateMigrations: true }).hasLegacy,
+      ).toBe(false);
+    },
+  );
+
   it("imports shipped dot-only session layouts into reserved SQLite selectors", async () => {
     const stateDir = tempDirs.make("openclaw-meeting-transcripts-doctor-");
     for (const sessionId of [".", "..", "session"]) {

--- a/src/infra/state-migrations.meeting-transcripts.ts
+++ b/src/infra/state-migrations.meeting-transcripts.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-// Doctor-only import for the retired meeting-capture JSON/JSONL store.
+// Doctor-only repair of transcript projections and the retired JSON/JSONL store.
 import fsSync from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
@@ -8,6 +8,13 @@ import {
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
 import { ensureMeetingTranscriptsSchema } from "../transcripts/sqlite-schema.js";
+import {
+  safeTranscriptPathSegment,
+  TRANSCRIPT_PATH_SEGMENT_MAX_BYTES,
+  transcriptSessionExportKey,
+  transcriptSessionSelector,
+} from "../transcripts/store-artifacts.js";
+import { sessionFromRow } from "../transcripts/store-sqlite.js";
 import { TranscriptsStore } from "../transcripts/store.js";
 import { acquireGatewayLock } from "./gateway-lock.js";
 import { executeSqliteQuerySync, executeSqliteQueryTakeFirstSync } from "./kysely-sync.js";
@@ -412,6 +419,46 @@ export async function migrateLegacyMeetingTranscripts(params: {
     await validateMeetingTranscriptRoot(detected.sourceDir, { allowMissing: true });
     const databaseOptions = { env: { ...env, OPENCLAW_STATE_DIR: params.stateDir } };
     ensureMeetingTranscriptsSchema(databaseOptions);
+    // Repair only oversized ASCII projections before classifying exports. Keep
+    // identity/content intact; a selector conflict rolls back the entire repair.
+    const repaired = runOpenClawStateWriteTransaction(
+      ({ db: database }) => {
+        const db = migrationDb(database);
+        const rows = executeSqliteQuerySync(
+          database,
+          db
+            .selectFrom("meeting_transcript_sessions")
+            .selectAll()
+            .where(({ fn, eb }) =>
+              eb(fn<number>("length", ["session_slug"]), ">", TRANSCRIPT_PATH_SEGMENT_MAX_BYTES),
+            )
+            .orderBy("session_id"),
+        ).rows;
+        for (const row of rows) {
+          const session = sessionFromRow(row);
+          executeSqliteQuerySync(
+            database,
+            db
+              .updateTable("meeting_transcript_sessions")
+              .set({
+                selector: transcriptSessionSelector(session),
+                session_slug: safeTranscriptPathSegment(session.sessionId),
+                export_key: transcriptSessionExportKey(session),
+              })
+              .where("session_id", "=", row.session_id)
+              .where("started_at", "=", row.started_at),
+          );
+        }
+        return rows.length;
+      },
+      databaseOptions,
+      { operationLabel: "meeting-transcripts.oversized-projections" },
+    );
+    if (repaired > 0) {
+      recoveryChanges.push(
+        `Repaired ${repaired} oversized meeting transcript export name${repaired === 1 ? "" : "s"} in SQLite`,
+      );
+    }
     const store = new TranscriptsStore(detected.sourceDir, databaseOptions);
     const resumed = await resumePendingImports({
       env,
@@ -421,7 +468,7 @@ export async function migrateLegacyMeetingTranscripts(params: {
       stageDatabase: stage,
     });
     if (resumed) {
-      return resumed;
+      return { changes: [...recoveryChanges, ...resumed.changes], warnings: resumed.warnings };
     }
     const now = params.now?.() ?? Date.now();
     const relativeDirs = await listLegacyMeetingTranscriptArtifactDirs(detected.sourceDir);

--- a/src/transcripts/store-artifacts.ts
+++ b/src/transcripts/store-artifacts.ts
@@ -6,6 +6,8 @@ import { removePathWithinRoot } from "../infra/fs-safe-remove.js";
 import { writeExternalFileWithinRoot } from "../infra/fs-safe.js";
 import type { TranscriptSessionDescriptor } from "./provider-types.js";
 
+export const TRANSCRIPT_PATH_SEGMENT_MAX_BYTES = 255;
+
 export const TRANSCRIPT_EXPORT_FILE_NAMES = new Set([
   "metadata.json",
   "summary.json",
@@ -14,7 +16,7 @@ export const TRANSCRIPT_EXPORT_FILE_NAMES = new Set([
 ]);
 
 export function safeTranscriptPathSegment(value: string): string {
-  const segment = value.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+  let segment = value.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
   if (segment === ".") {
     return "%2E";
   }
@@ -25,11 +27,17 @@ export function safeTranscriptPathSegment(value: string): string {
     return "session";
   }
   if (segment.endsWith(".") || /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\..*)?$/iu.test(segment)) {
-    return Buffer.from(segment, "utf8")
+    segment = Buffer.from(segment, "utf8")
       .toString("hex")
       .match(/.{2}/gu)!
       .map((byte) => `%${byte.toUpperCase()}`)
       .join("");
+  }
+  // Portable encoding is ASCII and can expand the slug. Bound the final bytes,
+  // hashing the complete raw ID to distinguish IDs with discarded suffixes.
+  if (segment.length > TRANSCRIPT_PATH_SEGMENT_MAX_BYTES) {
+    const suffix = `-${sha256Hex(value)}`;
+    return `${segment.slice(0, TRANSCRIPT_PATH_SEGMENT_MAX_BYTES - suffix.length)}${suffix}`;
   }
   return segment;
 }
@@ -47,9 +55,16 @@ export function transcriptSessionSelector(session: TranscriptSessionDescriptor):
   return `${dateSegment(session.startedAt)}/${safeTranscriptPathSegment(session.sessionId)}`;
 }
 
-export function legacyTranscriptSessionSelector(session: TranscriptSessionDescriptor): string {
+export function legacyTranscriptSessionSelector(
+  session: TranscriptSessionDescriptor,
+): string | undefined {
   const date = dateSegment(session.startedAt);
   const segment = legacyTranscriptPathSegment(session.sessionId);
+  // An oversized component could never hold legacy files; probing it would
+  // reject otherwise valid captures with ENAMETOOLONG before persistence.
+  if (segment.length > TRANSCRIPT_PATH_SEGMENT_MAX_BYTES) {
+    return undefined;
+  }
   // The shipped sanitizer allowed dot components: `.` collapsed to the date
   // directory and `..` collapsed to the transcript root.
   if (segment === ".") {

--- a/src/transcripts/store.ts
+++ b/src/transcripts/store.ts
@@ -325,19 +325,19 @@ export class TranscriptsStore {
       }))
     ) {
       await this.assertExportDestinationOwned(session);
-      const legacySessionDir = path.join(
-        this.exportRootDir,
-        legacyTranscriptSessionSelector(session),
-      );
-      const legacyOwner = await this.readSession(legacyTranscriptSessionSelector(session));
-      const legacyPathIsCanonical =
-        legacyOwner !== undefined &&
-        path.resolve(this.sessionDir(legacyOwner)) === path.resolve(legacySessionDir);
-      if (
-        path.resolve(legacySessionDir) !== path.resolve(this.sessionDir(session)) &&
-        !legacyPathIsCanonical
-      ) {
-        await this.assertExportDestinationOwned(session, legacySessionDir);
+      const legacySelector = legacyTranscriptSessionSelector(session);
+      if (legacySelector !== undefined) {
+        const legacySessionDir = path.join(this.exportRootDir, legacySelector);
+        const legacyOwner = await this.readSession(legacySelector);
+        const legacyPathIsCanonical =
+          legacyOwner !== undefined &&
+          path.resolve(this.sessionDir(legacyOwner)) === path.resolve(legacySessionDir);
+        if (
+          path.resolve(legacySessionDir) !== path.resolve(this.sessionDir(session)) &&
+          !legacyPathIsCanonical
+        ) {
+          await this.assertExportDestinationOwned(session, legacySessionDir);
+        }
       }
     }
     const sessionValues = {


### PR DESCRIPTION
Related: #112910 (SQLite meeting-transcript storage), #130860 (ongoing Discord capture lifecycle work; independent of this repair).

## What Problem This Solves

Fixes an issue where users starting or importing meeting transcripts with long session IDs would encounter `ENAMETOOLONG` or fail to export their saved summaries. Portable encoding can also make an otherwise short ID exceed the filesystem component limit. A later cleanup attempt could obscure the original failure with a session-not-found error.

The exact synthetic reproduction is `"notes-0-" + "x".repeat(2200)`. No real meeting content or operator data is included.

## Why This Change Was Made

The canonical transcript filename helper bounds the final ASCII export component to 255 bytes, retaining a readable prefix and the full SHA-256 of the original session ID. Existing names that fit remain byte-for-byte unchanged. The store skips impossible oversized legacy-path probes while retaining ownership checks for valid legacy paths.

The maintainer-approved Doctor repair updates only `selector`, `session_slug`, and `export_key` for historical oversized projections, under the existing exclusive maintenance lock and synchronous transaction. Selector collisions roll back the entire repair. Raw identities, provider metadata, notes, summaries, export bookkeeping, and the SQLite schema/version remain unchanged. Repair precedes export classification so bounded exports are not mistaken for legacy state.

This keeps normalization at the filename producer instead of rejecting otherwise usable opaque IDs or masking filesystem errors downstream. No new dependency, runtime fallback reader, or parallel migration framework is added.

## User Impact

Long-ID capture/import, stop, summary, reopen, and export flows retain the original session ID and durable notes. Operators can use the selector printed by `openclaw transcripts list`; `openclaw doctor --fix` repairs old oversized derived names. See the [transcripts guide](https://docs.openclaw.ai/cli/transcripts).

Release-note context: Meeting transcripts now shorten oversized export names without changing session identity or stored notes, and Doctor repairs historical oversized selectors.

AI-assisted.

## Evidence

Verified candidate: `0b78e9e46418c680e8e0798f5b8073075bcc229a`. Exact-head [CI run 33141078446](https://github.com/openclaw/openclaw/actions/runs/33141078446) is green, including the [build-artifacts job](https://github.com/openclaw/openclaw/actions/runs/33141078446/job/98751987357).

### Real before/after and persisted-state upgrade

Ran the actual built CLI on macOS / Node 24.20.0 with isolated HOME, state, config, workspace, and profile. Real authenticated `openai/gpt-5.6-luna` turns used OpenClaw Code Mode to construct the IDs programmatically and invoke the stock `manual-transcript` provider. No mocked model/provider, production test seam, operator-state copy, or live gateway modification was used.

The pre-fix build reported `a454c10`; the candidate reported `0b78e9e`.

| Case | Observed before | Observed after |
| --- | --- | --- |
| Exact 2,208-character safe ID | `ENAMETOOLONG`; no session row created | Import, stop, and summarize all succeed with the full raw ID; 255-byte export component |
| 256-character safe ID | Session, utterance, and summary persisted; export failed | Actual candidate Doctor repairs the persisted row; fresh CLI export succeeds |
| Normal 14-character ID | Import/export succeeds | Row and stored notes remain unchanged |
| Two 2,211-character IDs sharing their prefix | Not exercised live before | Distinct 255-byte export names; each metadata file retains its full ID and its own note |
| Trailing-dot ID: 86 raw characters, 258 encoded bytes | Covered by failing-before regression | Live import and export succeed with a 255-byte derived name |
| Opaque 2,207-character ID | Existing sanitizer behavior covered by regression | Full raw ID retained; existing six-byte `opaque` slug preserved, without hashing |

Doctor ran against the state created by the real pre-fix executable—not a hand-written historical row. Independent read-only SQLite comparisons proved exactly one transcript row changed and exactly three fields changed: `selector`, `session_slug`, and `export_key`. All other session fields, raw IDs, source metadata, timestamps, manifests, pending records, utterances, summary JSON, and stored Markdown remained byte-identical. A second actual Doctor run left all transcript rows identical.

The after-fix model turn made seven real transcript calls: five imports, then stop and summarize using the exact full 2,208-character ID. All seven reported success with no summary-export error; runtime telemetry recorded seven bridge calls and zero tool failures. Persisted tool events independently confirmed the five-import, stop, summarize sequence and seven successful execution results. Independent filesystem/SQLite checks verified all five cases and preservation of both pre-existing sessions.

Four additional fresh CLI processes ran `transcripts list --json`, `transcripts show <full-raw-id> --json`, `transcripts path <returned-qualified-selector> --dir --json`, and `transcripts show <historical-raw-id> --json`. They reopened all seven sessions, resolved both raw and qualified handles, materialized the artifacts, and preserved historical summary content. Exports retain the existing final-newline contract; stored summary bytes were independently rechecked unchanged.

```json
{
  "candidate": "0b78e9e46418c680e8e0798f5b8073075bcc229a",
  "realTranscriptCalls": 7,
  "toolFailures": 0,
  "exactRawIdLength": 2208,
  "exportComponentBytes": 255,
  "sharedPrefixPathsDistinct": true,
  "doctorRepairedRows": 1,
  "doctorChangedFields": ["selector", "session_slug", "export_key"],
  "storedNotesAndSummariesByteIdentical": true,
  "doctorIdempotent": true,
  "freshCliReadbackProcesses": 4,
  "rawAndQualifiedHandlesResolved": true
}
```

The substantive CLI commands below used the same isolated environment and pinned config. Prompt files contained the synthetic ID expressions and ordinary transcript-tool calls described above. Provider credentials and raw agent transcripts are omitted.

```bash
node openclaw.mjs --profile transcript-id-proof agent --local --agent main --session-id transcript-proof-before --model openai/gpt-5.6-luna --thinking low --timeout 300 --json --message-file baseline-confirm.md
```

```bash
node openclaw.mjs --profile transcript-id-proof doctor --fix --non-interactive --no-workspace-suggestions
```

```bash
node openclaw.mjs --profile transcript-id-proof agent --local --agent main --session-id transcript-proof-after --model openai/gpt-5.6-luna --thinking low --timeout 600 --json --message-file candidate.md
```

Proof scope: real local operator turns and the stock manual transcript provider, not live audio recording or a joined meeting. The live-provider start/stop argument boundary remains covered by regression tests. Direct HTTP tool invocation was not used to bypass operator-turn admission. Real-Chrome UI capture was attempted but the extension relay timed out creating the proof tab; no screenshot/video or visual verification is claimed. This change does not modify UI layout.

### Regression and integration checks

- Original filename code failed 23 of 31 lifecycle cases; all eight ordinary-name controls passed. The repaired lifecycle suite passed all 31, including 255/256-byte boundaries, encoding expansion, full-ID hash separation, cross-day identity, and historical finalization.
- Doctor regressions failed before repair, then passed all seven cases: absent export root, preservation, idempotence, collision rollback, pending-import receipts, and exclusive ownership. The existing Doctor suite passed 26 tests with two platform skips, including legacy trailing-dot import/export.
- After rebasing onto current main, all 48 bounded-ID and existing transcript-tool tests passed; targeted lint, formatting, and whitespace checks passed. Main already contained the equivalent startup-readiness fix in #131344, so it adds no diff here. The historical test uses main's current `writeSession` flow, not the removed `updateStopped` helper.
- Changed guards, core and core-test typechecks, lint, formatting, and remaining planned guards passed across the original run and its continuation. An initial test-only `Promise.withResolvers` compatibility error was corrected before integration. No baseline, dependency, or ignore edits were made.
- Fresh isolated Codex autoreview of the final combined diff found no actionable P0 findings; no wider review threshold is claimed.

```bash
node scripts/run-vitest.mjs src/agents/tools/transcripts-tool.session-id.test.ts src/agents/tools/transcripts-tool.test.ts
```

```bash
node scripts/run-vitest.mjs src/infra/state-migrations.meeting-transcripts-projections.test.ts
```

```bash
node scripts/run-vitest.mjs src/infra/state-migrations.meeting-transcripts.test.ts
```

### Build evidence and separate follow-up

The local full `pnpm build` completed runtime compilation, declarations, packaging, SDK checks, UI, and build identity, but its final `write-cli-startup-metadata` phase timed out rendering source `nodes --help` at the unchanged 120-second limit. One metadata-only retry failed identically. **The local full build is not claimed green.**

Read-only diagnosis traced the cost to Teams/Zoom CLI metadata importing the broad meeting-runtime SDK. These implicated sources are byte-identical to current main `648d0c43c85cbc9d90eea57f4acb7658383eb768`; this PR does not change them. On the loaded local host, the trace recorded 1,403 Jiti cache writes before timeout. Separately, the exact-head hosted build completed the same metadata generation in 12.2 seconds and passed. Landing relies on that verified hosted build plus the successful local runtime/upgrade evidence, not a timeout increase, skipped guard, or copied metadata.

The lightweight Teams/Zoom metadata repair is recorded as a separate follow-up. Related #131503 addresses repeated plugin preparation but does not remove this dependency; #127757 independently records the timeout. No unrelated metadata refactor is folded into this transcript repair.

### Review decisions and scope

The latest completed ClawSweeper review found no correctness or security defect and requested real upgrade proof, bounded production growth, and a maintainer proof decision. An earlier terminal check lacked `pnpm`; the latest completed review at 05:08 UTC successfully ran `pnpm openclaw transcripts --help` on the exact candidate. That help check is supplemental; the real upgrade and model-driven transcript proof above cover the changed behavior. The real before/after and exact-head persisted-state proof above address the proof request and rank-up move; the complete exact-head CI build supplies the build evidence.

Production LOC: **+92/-22 (net +70)**; tests: **+666/-0**; docs: **+8/-0**. Net +15 runtime lines implement bounded naming and impossible-path handling; net +55 reuse the existing Doctor detection, exclusive lock, transaction, and warning flow for all-or-nothing projection repair. No new store, fallback reader, general migration framework, or schema/version change is introduced.

Provenance: the unbounded canonical sanitizer was introduced by #112910, authored and merged by @steipete on 2026-07-23 (`a2be4efb63129d049822ae0d855f233407f2bfd6`). #130860 is related capture context, not an equivalent filename fix. Gitcrawl-first and targeted live searches found no equivalent repair.

Known separate follow-up: raw IDs beginning with `YYYY-MM-DD/` can be interpreted as qualified selectors after restart. That pre-existing ambiguity is outside this filename repair.
