### PR TITLE
fix(ui): confirm disruptive plugin lifecycle changes

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3403,7 +3403,9 @@ export const en: TranslationMap = {
     remove: "Remove",
     removing: "Removing…",
     removeNamed: "Remove {name}",
-    removeConfirm: "Remove this plugin package and all of its entries?",
+    removeConfirmTitle: "Remove {name}?",
+    removeConfirmMessage:
+      "Removing this plugin package and all of its entries restarts the Gateway immediately and interrupts active sessions.",
     cancel: "Cancel",
     removedRestart: "Removed {name}. A Gateway restart is required to apply the change.",
     verifiedSource: "Verified source",
@@ -3434,6 +3436,9 @@ export const en: TranslationMap = {
     install: "Install",
     installing: "Installing…",
     installNamed: "Install {name}",
+    installConfirmTitle: "Install {name}?",
+    installConfirmMessage:
+      "Installing this plugin restarts the Gateway immediately and interrupts active sessions.",
     policyReviewTitle: "Security review needed",
     policyReviewBodyKnown: "Policy warnings: {count}. Not installed.",
     policyReviewBodyReason: "{reason} Not installed.",

--- a/ui/src/lib/plugins/index.ts
+++ b/ui/src/lib/plugins/index.ts
@@ -87,6 +87,7 @@ export async function runPluginConfigMutation<T>(
   runtimeConfig: Pick<RuntimeConfigCapability, "runExternalMutation">,
   expectedClient: GatewayBrowserClient,
   task: (client: GatewayBrowserClient) => Promise<T>,
+  options: { canDispatch?: () => boolean; dispatchError?: string } = {},
 ): Promise<{ value: T; refreshError: string | null }> {
   let taskError: Error | undefined;
   const mutation = await runtimeConfig.runExternalMutation(async (client) => {
@@ -100,7 +101,7 @@ export async function runPluginConfigMutation<T>(
       taskError = error instanceof Error ? error : new Error(String(error));
       throw taskError;
     }
-  });
+  }, options);
   if (!mutation.ok) {
     throw taskError ?? new Error(mutation.error);
   }

--- a/ui/src/pages/plugins/plugin-lifecycle-confirmation.ts
+++ b/ui/src/pages/plugins/plugin-lifecycle-confirmation.ts
@@ -1,0 +1,23 @@
+// Plugin code mutations restart the Gateway, so their UI entry points share one
+// confirmation contract before either lifecycle request can be dispatched.
+import { showConfirmDialog } from "../../components/confirm-dialog.ts";
+import { t } from "../../i18n/index.ts";
+import type { PluginInstallRequest } from "../../lib/plugins/index.ts";
+
+export function confirmPluginInstall(request: PluginInstallRequest): Promise<boolean> {
+  const name = request.source === "official" ? request.pluginId : request.packageName;
+  return showConfirmDialog({
+    title: t("pluginsPage.installConfirmTitle", { name }),
+    message: t("pluginsPage.installConfirmMessage"),
+    confirmLabel: t("pluginsPage.install"),
+  });
+}
+
+export function confirmPluginUninstall(name: string): Promise<boolean> {
+  return showConfirmDialog({
+    title: t("pluginsPage.removeConfirmTitle", { name }),
+    message: t("pluginsPage.removeConfirmMessage"),
+    confirmLabel: t("pluginsPage.remove"),
+    danger: true,
+  });
+}

--- a/ui/src/pages/plugins/plugins-consent-controller.ts
+++ b/ui/src/pages/plugins/plugins-consent-controller.ts
@@ -29,6 +29,11 @@ type PluginMutationSuccess<Result> = (
   isLatest: () => boolean,
 ) => Promise<void>;
 
+type PluginMutationOptions = {
+  confirm?: () => Promise<boolean>;
+  preserveMessageWhilePending?: boolean;
+};
+
 type PluginsConsentControllerHost = {
   gateway: GatewayPageController;
   getContext: () => ApplicationContext;
@@ -85,15 +90,25 @@ export class PluginsConsentController {
     rowKey: string,
     mutate: (client: GatewayBrowserClient) => Promise<Result>,
     onSuccess: PluginMutationSuccess<Result>,
+    options: PluginMutationOptions = {},
     onError: (error: unknown) => void = (error) => {
       this.host.setMessage(rowKey, { kind: "error", text: formatUiError(error) });
     },
-    options: { preserveMessageWhilePending?: boolean } = {},
   ): Promise<void> {
     const scope = this.host.gateway.capture();
     if (!scope || !this.host.canMutate() || this.host.isBusy(rowKey)) {
       return;
     }
+    if (
+      options.confirm &&
+      (!(await options.confirm()) ||
+        !this.host.gateway.isCurrent(scope) ||
+        !this.host.canMutate() ||
+        this.host.isBusy(rowKey))
+    ) {
+      return;
+    }
+    // Confirmation and request share the captured Gateway epoch and client.
     this.host.clearPageNotice();
     const mutationToken = ++this.mutationToken;
     this.mutationTokens.set(rowKey, mutationToken);
@@ -208,7 +223,11 @@ export class PluginsConsentController {
     }
   }
 
-  async install(request: PluginInstallRequest, installIdentity: string): Promise<void> {
+  async install(
+    request: PluginInstallRequest,
+    installIdentity: string,
+    confirm?: () => Promise<boolean>,
+  ): Promise<void> {
     // The server stages and inspects the requested artifact before asking for consent.
     // Catalog/search metadata cannot authorize that artifact's capabilities.
     await this.runMutation(
@@ -226,6 +245,7 @@ export class PluginsConsentController {
         );
         await this.host.refreshCatalogAfterMutation(client);
       },
+      { confirm, preserveMessageWhilePending: request.acknowledgeInstallPolicyWarning === true },
       (error) => {
         const consentDetails = readPluginCapabilityConsentError(error);
         if (consentDetails) {
@@ -247,7 +267,6 @@ export class PluginsConsentController {
         }
         this.host.setMessage(installIdentity, { kind: "error", text: formatUiError(error) });
       },
-      { preserveMessageWhilePending: request.acknowledgeInstallPolicyWarning === true },
     );
   }
 
@@ -273,6 +292,7 @@ export class PluginsConsentController {
           this.host.getContext().gateway.connect();
         }
       },
+      {},
       (error) => {
         const details = readPluginCapabilityConsentError(error);
         if (enabled && details) {

--- a/ui/src/pages/plugins/plugins-consent-controller.ts
+++ b/ui/src/pages/plugins/plugins-consent-controller.ts
@@ -3,6 +3,7 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { t } from "../../i18n/index.ts";
 import { formatUiError, formatUiExternalText } from "../../lib/format-error.ts";
+import type { GatewayConnectionScope } from "../../lib/gateway-connection-lifecycle.ts";
 import {
   inspectPlugin,
   readPluginCapabilityConsentError,
@@ -19,6 +20,7 @@ import {
 import type { GatewayPageController } from "../../lit/gateway-page-controller.ts";
 import type { PluginConsentIntent, PluginConsentState } from "./consent-dialog.ts";
 import { readPluginInstallPolicyWarning } from "./install-policy-warning.ts";
+import { confirmPluginInstall } from "./plugin-lifecycle-confirmation.ts";
 import { pluginRowKey, type PluginRowMessage } from "./view.ts";
 
 type PluginMutationSuccess<Result> = (
@@ -78,12 +80,16 @@ export class PluginsConsentController {
 
   private mutationToken = 0;
   private readonly mutationTokens = new Map<string, number>();
+  // Server reviews continue one confirmed install only while its Gateway epoch survives.
+  // Reconnect reset drops the scope before a surviving row warning can be acknowledged.
+  private readonly confirmedInstallScopes = new Map<string, GatewayConnectionScope>();
 
   constructor(private readonly host: PluginsConsentControllerHost) {}
 
   reset(): void {
     this.close();
     this.mutationTokens.clear();
+    this.confirmedInstallScopes.clear();
   }
 
   async runMutation<Result>(
@@ -91,7 +97,7 @@ export class PluginsConsentController {
     mutate: (client: GatewayBrowserClient) => Promise<Result>,
     onSuccess: PluginMutationSuccess<Result>,
     options: PluginMutationOptions = {},
-    onError: (error: unknown) => void = (error) => {
+    onError: (error: unknown, scope: GatewayConnectionScope) => void = (error) => {
       this.host.setMessage(rowKey, { kind: "error", text: formatUiError(error) });
     },
   ): Promise<void> {
@@ -131,7 +137,7 @@ export class PluginsConsentController {
       }
     } catch (error) {
       if (isCurrent()) {
-        onError(error);
+        onError(error, scope);
       }
     } finally {
       if (this.mutationTokens.get(rowKey) === mutationToken) {
@@ -224,11 +230,14 @@ export class PluginsConsentController {
     }
   }
 
-  async install(
-    request: PluginInstallRequest,
-    installIdentity: string,
-    confirm?: () => Promise<boolean>,
-  ): Promise<void> {
+  async install(request: PluginInstallRequest, installIdentity: string): Promise<void> {
+    const confirmedScope = this.confirmedInstallScopes.get(installIdentity);
+    this.confirmedInstallScopes.delete(installIdentity);
+    const isConfirmedContinuation =
+      (request.acknowledgeInstallPolicyWarning === true ||
+        request.acknowledgeCapabilities !== undefined) &&
+      confirmedScope &&
+      this.host.gateway.isCurrent(confirmedScope);
     // The server stages and inspects the requested artifact before asking for consent.
     // Catalog/search metadata cannot authorize that artifact's capabilities.
     await this.runMutation(
@@ -246,10 +255,14 @@ export class PluginsConsentController {
         );
         await this.host.refreshCatalogAfterMutation(client);
       },
-      { confirm, preserveMessageWhilePending: request.acknowledgeInstallPolicyWarning === true },
-      (error) => {
+      {
+        confirm: isConfirmedContinuation ? undefined : () => confirmPluginInstall(request),
+        preserveMessageWhilePending: request.acknowledgeInstallPolicyWarning === true,
+      },
+      (error, scope) => {
         const consentDetails = readPluginCapabilityConsentError(error);
         if (consentDetails) {
+          this.confirmedInstallScopes.set(installIdentity, scope);
           this.open(
             { kind: "install", request, installIdentity },
             consentDetails.pluginId,
@@ -259,6 +272,7 @@ export class PluginsConsentController {
         }
         const policyWarning = readPluginInstallPolicyWarning(error);
         if (policyWarning) {
+          this.confirmedInstallScopes.set(installIdentity, scope);
           this.host.setMessage(installIdentity, {
             kind: "warning",
             text: policyWarning.reason,

--- a/ui/src/pages/plugins/plugins-consent-controller.ts
+++ b/ui/src/pages/plugins/plugins-consent-controller.ts
@@ -108,7 +108,7 @@ export class PluginsConsentController {
     ) {
       return;
     }
-    // Confirmation and request share the captured Gateway epoch and client.
+    // Confirmation, config queue, and request share the captured Gateway epoch and client.
     this.host.clearPageNotice();
     const mutationToken = ++this.mutationToken;
     this.mutationTokens.set(rowKey, mutationToken);
@@ -124,6 +124,7 @@ export class PluginsConsentController {
         this.host.getContext().runtimeConfig,
         scope.client,
         mutate,
+        { canDispatch: () => isCurrent() && this.host.canMutate() },
       );
       if (isCurrent()) {
         await onSuccess(mutation.value, mutation.refreshError, scope.client, isCurrent, isLatest);

--- a/ui/src/pages/plugins/plugins-page.consent.test.ts
+++ b/ui/src/pages/plugins/plugins-page.consent.test.ts
@@ -48,6 +48,13 @@ async function mountDiscover(handler: Parameters<typeof createClient>[0]) {
   return { page, request, available };
 }
 
+async function confirmPendingPluginInstall() {
+  await waitForFast(() =>
+    expect(document.body.querySelector(".exec-approval-actions .btn.primary")).not.toBeNull(),
+  );
+  document.body.querySelector<HTMLButtonElement>(".exec-approval-actions .btn.primary")?.click();
+}
+
 describe("PluginsPage consent", () => {
   beforeEach(async () => {
     await i18n.setLocale("en");
@@ -122,6 +129,7 @@ describe("PluginsPage consent", () => {
       }
 
       await clickRowAction(page, row, "Install");
+      await confirmPendingPluginInstall();
 
       await waitForFast(() =>
         expect(request).toHaveBeenCalledWith("plugins.install", installRequest),
@@ -204,6 +212,7 @@ describe("PluginsPage consent", () => {
     });
 
     await clickRowAction(page, '[data-plugin-id="calendar-runtime"]', "Install");
+    await confirmPendingPluginInstall();
     await waitForFast(() =>
       expect(page.querySelector(".plugins-policy-review")?.textContent).toContain(
         "Review this plugin.",

--- a/ui/src/pages/plugins/plugins-page.lifecycle.test.ts
+++ b/ui/src/pages/plugins/plugins-page.lifecycle.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GatewayRequestError } from "../../api/gateway.ts";
 import { showConfirmDialog } from "../../components/confirm-dialog.ts";
 import { i18n } from "../../i18n/index.ts";
 import type {
@@ -10,11 +11,13 @@ import type {
 } from "../../lib/plugins/index.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import {
+  clickRowAction,
   createClient,
   createContext,
   createGateway,
   createPlugin,
   createPluginsRouteData,
+  createPluginsRouteLocation,
   createResult,
   createRuntimeConfigHarness,
   deferred,
@@ -95,7 +98,7 @@ describe("PluginsPage lifecycle confirmation", () => {
     const confirmation = deferred<boolean>();
     vi.mocked(showConfirmDialog).mockReturnValueOnce(confirmation.promise);
 
-    const install = page.install(request, "plugin:community-thing");
+    const install = page.consentController.install(request, "plugin:community-thing");
     await waitForFast(() => expect(showConfirmDialog).toHaveBeenCalledOnce());
     harness.emit(replacementClient, true);
     confirmation.resolve(true);
@@ -197,7 +200,7 @@ describe("PluginsPage lifecycle confirmation", () => {
       pluginId: "community-thing",
     } satisfies PluginInstallRequest;
 
-    const install = page.install(request, "plugin:community-thing");
+    const install = page.consentController.install(request, "plugin:community-thing");
     await config.queued;
     provider.setContext(
       createContext(replacementGateway.gateway, undefined, undefined, config.harness),
@@ -259,5 +262,76 @@ describe("PluginsPage lifecycle confirmation", () => {
     expect(gatewayRequest).not.toHaveBeenCalledWith("plugins.uninstall", {
       pluginId: "community-thing",
     });
+  });
+
+  it("reconfirms an install-policy retry after a same-client reconnect", async () => {
+    const available = createPlugin({
+      id: "community-thing",
+      name: "Community Thing",
+      origin: "global",
+      installed: false,
+      enabled: false,
+      state: "not-installed",
+      install: { source: "official", pluginId: "community-thing" },
+    });
+    let installCalls = 0;
+    const { client } = createClient(async (method, params) => {
+      if (method === "plugins.list") {
+        return createResult(available);
+      }
+      if (method !== "plugins.install") {
+        throw new Error(`Unexpected method ${method}`);
+      }
+      installCalls += 1;
+      if (!(params as PluginInstallRequest).acknowledgeInstallPolicyWarning) {
+        throw new GatewayRequestError({
+          code: "INVALID_REQUEST",
+          message: "install requires review",
+          details: {
+            installPolicyCode: "install_policy_warning_acknowledgement_required",
+            targetName: "community-thing",
+            targetType: "plugin",
+            requestMode: "install",
+            reason: "Review this plugin before installing it.",
+          },
+        });
+      }
+      return {
+        ok: true,
+        plugin: { ...available, installed: true },
+        restartRequired: true,
+      } satisfies PluginMutationResult;
+    });
+    const harness = createGateway(client);
+    const { page } = await mountPage(
+      createContext(harness.gateway),
+      createPluginsRouteData(
+        harness.gateway,
+        createResult(available),
+        createPluginsRouteLocation("/settings/plugins/discover"),
+      ),
+    );
+    const request = {
+      source: "official",
+      pluginId: "community-thing",
+    } satisfies PluginInstallRequest;
+
+    await page.consentController.install(request, "plugin:community-thing");
+    expect(installCalls).toBe(1);
+    expect(showConfirmDialog).toHaveBeenCalledOnce();
+    harness.emit(client, false);
+    harness.emit(client, true);
+    await waitForFast(() =>
+      expect(page.querySelector('[data-plugin-id="community-thing"]')).not.toBeNull(),
+    );
+    const confirmation = deferred<boolean>();
+    vi.mocked(showConfirmDialog).mockReturnValueOnce(confirmation.promise);
+
+    await clickRowAction(page, '[data-plugin-id="community-thing"]', "Install anyway");
+    await waitForFast(() => expect(showConfirmDialog).toHaveBeenCalledTimes(2));
+    expect(installCalls).toBe(1);
+
+    confirmation.resolve(true);
+    await waitForFast(() => expect(installCalls).toBe(2));
   });
 });

--- a/ui/src/pages/plugins/plugins-page.lifecycle.test.ts
+++ b/ui/src/pages/plugins/plugins-page.lifecycle.test.ts
@@ -16,6 +16,7 @@ import {
   createPlugin,
   createPluginsRouteData,
   createResult,
+  createRuntimeConfigHarness,
   deferred,
   mountPage,
   resetPluginsPageTestState,
@@ -30,6 +31,29 @@ describe("PluginsPage lifecycle confirmation", () => {
   });
 
   afterEach(resetPluginsPageTestState);
+
+  function createQueuedRuntimeConfig(client: ReturnType<typeof createClient>["client"]) {
+    const queued = deferred<void>();
+    const release = deferred<void>();
+    const harness = createRuntimeConfigHarness(
+      vi.fn(async () => undefined),
+      { configFormDirty: false, lastError: null },
+      () => client,
+    );
+    harness.runtimeConfig.runExternalMutation = async (task, options) => {
+      queued.resolve();
+      await release.promise;
+      if (options?.canDispatch && !options.canDispatch()) {
+        return {
+          ok: false,
+          reason: "unavailable",
+          error: options.dispatchError ?? "Mutation scope changed before dispatch.",
+        };
+      }
+      return { ok: true, value: await task(client), refresh: { ok: true } };
+    };
+    return { harness, queued: queued.promise, release };
+  }
 
   it("does not install on a replacement Gateway after confirmation started", async () => {
     const available = createPlugin({
@@ -131,6 +155,108 @@ describe("PluginsPage lifecycle confirmation", () => {
       pluginId: "community-thing",
     });
     expect(replacementRequest).not.toHaveBeenCalledWith("plugins.uninstall", {
+      pluginId: "community-thing",
+    });
+  });
+
+  it("does not install after its confirmed Gateway source changes while config writes drain", async () => {
+    const available = createPlugin({
+      id: "community-thing",
+      name: "Community Thing",
+      origin: "global",
+      installed: false,
+      enabled: false,
+      state: "not-installed",
+      install: { source: "official", pluginId: "community-thing" },
+    });
+    const { client, request: gatewayRequest } = createClient(async (method) => {
+      if (method === "plugins.install") {
+        return {
+          ok: true,
+          plugin: { ...available, installed: true },
+          restartRequired: true,
+        } satisfies PluginMutationResult;
+      }
+      throw new Error(`Unexpected method ${method}`);
+    });
+    const initialGateway = createGateway(client);
+    const replacementGateway = createGateway(client);
+    const config = createQueuedRuntimeConfig(client);
+    const initialContext = createContext(
+      initialGateway.gateway,
+      undefined,
+      undefined,
+      config.harness,
+    );
+    const { page, provider } = await mountPage(
+      initialContext,
+      createPluginsRouteData(initialGateway.gateway, createResult(available)),
+    );
+    const request = {
+      source: "official",
+      pluginId: "community-thing",
+    } satisfies PluginInstallRequest;
+
+    const install = page.install(request, "plugin:community-thing");
+    await config.queued;
+    provider.setContext(
+      createContext(replacementGateway.gateway, undefined, undefined, config.harness),
+    );
+    await page.updateComplete;
+    config.release.resolve();
+    await install;
+
+    expect(gatewayRequest).not.toHaveBeenCalledWith("plugins.install", request);
+  });
+
+  it("does not uninstall after its confirmed Gateway source changes while config writes drain", async () => {
+    const removable = createPlugin({
+      id: "community-thing",
+      name: "Community Thing",
+      origin: "global",
+      removable: true,
+      featured: false,
+    });
+    const result = {
+      plugins: [createPlugin(), removable],
+      diagnostics: [],
+      mutationAllowed: true,
+    } satisfies PluginListResult;
+    const { client, request: gatewayRequest } = createClient(async (method) => {
+      if (method === "plugins.uninstall") {
+        return {
+          ok: true,
+          pluginId: "community-thing",
+          restartRequired: true,
+          removed: ["install record"],
+        };
+      }
+      throw new Error(`Unexpected method ${method}`);
+    });
+    const initialGateway = createGateway(client);
+    const replacementGateway = createGateway(client);
+    const config = createQueuedRuntimeConfig(client);
+    const initialContext = createContext(
+      initialGateway.gateway,
+      undefined,
+      undefined,
+      config.harness,
+    );
+    const { page, provider } = await mountPage(
+      initialContext,
+      createPluginsRouteData(initialGateway.gateway, result),
+    );
+
+    const uninstall = page.uninstall("community-thing", "plugin:community-thing");
+    await config.queued;
+    provider.setContext(
+      createContext(replacementGateway.gateway, undefined, undefined, config.harness),
+    );
+    await page.updateComplete;
+    config.release.resolve();
+    await uninstall;
+
+    expect(gatewayRequest).not.toHaveBeenCalledWith("plugins.uninstall", {
       pluginId: "community-thing",
     });
   });

--- a/ui/src/pages/plugins/plugins-page.lifecycle.test.ts
+++ b/ui/src/pages/plugins/plugins-page.lifecycle.test.ts
@@ -1,0 +1,137 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { showConfirmDialog } from "../../components/confirm-dialog.ts";
+import { i18n } from "../../i18n/index.ts";
+import type {
+  PluginInstallRequest,
+  PluginListResult,
+  PluginMutationResult,
+} from "../../lib/plugins/index.ts";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
+import {
+  createClient,
+  createContext,
+  createGateway,
+  createPlugin,
+  createPluginsRouteData,
+  createResult,
+  deferred,
+  mountPage,
+  resetPluginsPageTestState,
+} from "./plugins-page.test-support.ts";
+
+vi.mock("../../components/confirm-dialog.ts", () => ({ showConfirmDialog: vi.fn() }));
+
+describe("PluginsPage lifecycle confirmation", () => {
+  beforeEach(async () => {
+    await i18n.setLocale("en");
+    vi.mocked(showConfirmDialog).mockReset().mockResolvedValue(true);
+  });
+
+  afterEach(resetPluginsPageTestState);
+
+  it("does not install on a replacement Gateway after confirmation started", async () => {
+    const available = createPlugin({
+      id: "community-thing",
+      name: "Community Thing",
+      origin: "global",
+      installed: false,
+      enabled: false,
+      state: "not-installed",
+      install: { source: "official", pluginId: "community-thing" },
+    });
+    const { client: initialClient, request: initialRequest } = createClient(async () => {
+      throw new Error("The initial Gateway must not receive a request while confirmation is open.");
+    });
+    const { client: replacementClient, request: replacementRequest } = createClient(
+      async (method) => {
+        if (method === "plugins.list") {
+          return createResult(available);
+        }
+        if (method === "plugins.install") {
+          return {
+            ok: true,
+            plugin: { ...available, installed: true },
+            restartRequired: true,
+          } satisfies PluginMutationResult;
+        }
+        throw new Error(`Unexpected replacement method ${method}`);
+      },
+    );
+    const harness = createGateway(initialClient);
+    const { page } = await mountPage(
+      createContext(harness.gateway),
+      createPluginsRouteData(harness.gateway, createResult(available)),
+    );
+    const request = {
+      source: "official",
+      pluginId: "community-thing",
+    } satisfies PluginInstallRequest;
+    const confirmation = deferred<boolean>();
+    vi.mocked(showConfirmDialog).mockReturnValueOnce(confirmation.promise);
+
+    const install = page.install(request, "plugin:community-thing");
+    await waitForFast(() => expect(showConfirmDialog).toHaveBeenCalledOnce());
+    harness.emit(replacementClient, true);
+    confirmation.resolve(true);
+    await install;
+
+    expect(initialRequest).not.toHaveBeenCalledWith("plugins.install", request);
+    expect(replacementRequest).not.toHaveBeenCalledWith("plugins.install", request);
+  });
+
+  it("does not uninstall on a replacement Gateway after confirmation started", async () => {
+    const removable = createPlugin({
+      id: "community-thing",
+      name: "Community Thing",
+      origin: "global",
+      removable: true,
+      featured: false,
+    });
+    const result = {
+      plugins: [createPlugin(), removable],
+      diagnostics: [],
+      mutationAllowed: true,
+    } satisfies PluginListResult;
+    const { client: initialClient, request: initialRequest } = createClient(async () => {
+      throw new Error("The initial Gateway must not receive a request while confirmation is open.");
+    });
+    const { client: replacementClient, request: replacementRequest } = createClient(
+      async (method) => {
+        if (method === "plugins.list") {
+          return result;
+        }
+        if (method === "plugins.uninstall") {
+          return {
+            ok: true,
+            pluginId: "community-thing",
+            restartRequired: true,
+            removed: ["install record"],
+          };
+        }
+        throw new Error(`Unexpected replacement method ${method}`);
+      },
+    );
+    const harness = createGateway(initialClient);
+    const { page } = await mountPage(
+      createContext(harness.gateway),
+      createPluginsRouteData(harness.gateway, result),
+    );
+    const confirmation = deferred<boolean>();
+    vi.mocked(showConfirmDialog).mockReturnValueOnce(confirmation.promise);
+
+    const uninstall = page.uninstall("community-thing", "plugin:community-thing");
+    await waitForFast(() => expect(showConfirmDialog).toHaveBeenCalledOnce());
+    harness.emit(replacementClient, true);
+    confirmation.resolve(true);
+    await uninstall;
+
+    expect(initialRequest).not.toHaveBeenCalledWith("plugins.uninstall", {
+      pluginId: "community-thing",
+    });
+    expect(replacementRequest).not.toHaveBeenCalledWith("plugins.uninstall", {
+      pluginId: "community-thing",
+    });
+  });
+});

--- a/ui/src/pages/plugins/plugins-page.test-support.ts
+++ b/ui/src/pages/plugins/plugins-page.test-support.ts
@@ -9,6 +9,7 @@ import type {
 import { t } from "../../i18n/index.ts";
 import type {
   PluginCatalogItem,
+  PluginInstallRequest,
   PluginListResult,
   PluginMutationResult,
   PluginSearchResult,
@@ -53,6 +54,7 @@ type TestPluginsPage = HTMLElement & {
   applyMutationResult: (result: PluginMutationResult) => void;
   consentController: Pick<PluginsConsentController, "install">;
   refreshCatalog: () => Promise<void>;
+  install: (request: PluginInstallRequest, installIdentity: string) => Promise<void>;
   updateEnabled: (pluginId: string, enabled: boolean, key?: string) => Promise<void>;
   uninstall: (pluginId: string, rowKey: string) => Promise<void>;
 };

--- a/ui/src/pages/plugins/plugins-page.test-support.ts
+++ b/ui/src/pages/plugins/plugins-page.test-support.ts
@@ -9,7 +9,6 @@ import type {
 import { t } from "../../i18n/index.ts";
 import type {
   PluginCatalogItem,
-  PluginInstallRequest,
   PluginListResult,
   PluginMutationResult,
   PluginSearchResult,
@@ -54,7 +53,6 @@ type TestPluginsPage = HTMLElement & {
   applyMutationResult: (result: PluginMutationResult) => void;
   consentController: Pick<PluginsConsentController, "install">;
   refreshCatalog: () => Promise<void>;
-  install: (request: PluginInstallRequest, installIdentity: string) => Promise<void>;
   updateEnabled: (pluginId: string, enabled: boolean, key?: string) => Promise<void>;
   uninstall: (pluginId: string, rowKey: string) => Promise<void>;
 };

--- a/ui/src/pages/plugins/plugins-page.test.ts
+++ b/ui/src/pages/plugins/plugins-page.test.ts
@@ -4,6 +4,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GatewayRequestError } from "../../api/gateway.ts";
 import type { ApplicationContext } from "../../app/context.ts";
+import { showConfirmDialog } from "../../components/confirm-dialog.ts";
 import { i18n } from "../../i18n/index.ts";
 import { createRuntimeConfigCapability } from "../../lib/config/runtime-config-capability.ts";
 import type {
@@ -30,6 +31,8 @@ import {
 } from "./plugins-page.test-support.ts";
 import type { PluginsRouteData } from "./plugins-page.ts";
 
+vi.mock("../../components/confirm-dialog.ts", () => ({ showConfirmDialog: vi.fn() }));
+
 function clickHubTab(page: HTMLElement, tab: "installed" | "discover" | "skills" | "workshop") {
   page
     .querySelector(`#plugins-tab-${tab}`)
@@ -39,6 +42,7 @@ function clickHubTab(page: HTMLElement, tab: "installed" | "discover" | "skills"
 describe("PluginsPage", () => {
   beforeEach(async () => {
     await i18n.setLocale("en");
+    vi.mocked(showConfirmDialog).mockReset().mockResolvedValue(true);
   });
 
   afterEach(resetPluginsPageTestState);
@@ -708,7 +712,7 @@ describe("PluginsPage", () => {
     await waitForFast(() => expect(page.busy["plugin:workboard"]).toBeUndefined());
   });
 
-  it("uninstalls a removable plugin after inline confirmation", async () => {
+  it("waits for uninstall restart confirmation and sends nothing when cancelled", async () => {
     const removable = createPlugin({
       id: "community-thing",
       name: "Community Thing",
@@ -742,12 +746,26 @@ describe("PluginsPage", () => {
       }),
     );
 
+    const confirmation = deferred<boolean>();
+    vi.mocked(showConfirmDialog).mockReturnValueOnce(confirmation.promise);
     await clickRowAction(page, '[data-plugin-id="community-thing"]', "Remove");
-    page
-      .querySelector<HTMLButtonElement>(
-        '[data-plugin-id="community-thing"] .plugins-remove-confirm .btn.danger',
-      )
-      ?.click();
+    await waitForFast(() => expect(showConfirmDialog).toHaveBeenCalledOnce());
+    expect(showConfirmDialog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Remove Community Thing?",
+        message:
+          "Removing this plugin package and all of its entries restarts the Gateway immediately and interrupts active sessions.",
+        confirmLabel: "Remove",
+        danger: true,
+      }),
+    );
+    expect(calls).not.toContainEqual(["plugins.uninstall", { pluginId: "community-thing" }]);
+
+    confirmation.resolve(false);
+    await confirmation.promise;
+    expect(calls).not.toContainEqual(["plugins.uninstall", { pluginId: "community-thing" }]);
+
+    await clickRowAction(page, '[data-plugin-id="community-thing"]', "Remove");
 
     await waitForFast(() =>
       expect(calls).toContainEqual(["plugins.uninstall", { pluginId: "community-thing" }]),

--- a/ui/src/pages/plugins/plugins-page.ts
+++ b/ui/src/pages/plugins/plugins-page.ts
@@ -655,16 +655,13 @@ class PluginsPage extends OpenClawLightDomElement {
       await this.consentController.install(request, installIdentity);
       return;
     }
-    if (await confirmPluginInstall(request)) {
-      await this.consentController.install(request, installIdentity);
-    }
+    await this.consentController.install(request, installIdentity, () =>
+      confirmPluginInstall(request),
+    );
   }
 
   private async uninstall(pluginId: string, rowKey: string): Promise<void> {
     const name = this.result?.plugins.find((plugin) => plugin.id === pluginId)?.name ?? pluginId;
-    if (!(await confirmPluginUninstall(name))) {
-      return;
-    }
     await this.consentController.runMutation(
       rowKey,
       (client) => uninstallPlugin(client, pluginId),
@@ -684,6 +681,7 @@ class PluginsPage extends OpenClawLightDomElement {
         }
         await this.refreshCatalogAfterMutation(client);
       },
+      { confirm: () => confirmPluginUninstall(name) },
     );
   }
 

--- a/ui/src/pages/plugins/plugins-page.ts
+++ b/ui/src/pages/plugins/plugins-page.ts
@@ -19,7 +19,6 @@ import { inspectPlugin } from "../../lib/plugins/capability-consent-error.ts";
 import {
   uninstallPlugin,
   type PluginCatalogItem,
-  type PluginInstallRequest,
   type PluginListResult,
   type PluginMutationResult,
   type PluginSearchResult,
@@ -31,7 +30,7 @@ import {
 } from "../../lit/gateway-page-controller.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { fetchPluginIconBlobUrl } from "./icon-loader.ts";
-import { confirmPluginInstall, confirmPluginUninstall } from "./plugin-lifecycle-confirmation.ts";
+import { confirmPluginUninstall } from "./plugin-lifecycle-confirmation.ts";
 import { PluginsConsentController } from "./plugins-consent-controller.ts";
 import { renderPluginsHubHeader } from "./plugins-hub-header.ts";
 import type { PluginsHubTab } from "./plugins-hub.ts";
@@ -648,18 +647,6 @@ class PluginsPage extends OpenClawLightDomElement {
     return this.consentController.updateEnabled(pluginId, enabled, key);
   }
 
-  private async install(request: PluginInstallRequest, installIdentity: string): Promise<void> {
-    // Policy acknowledgement is the continuation of an already confirmed install.
-    // Confirming again would split one operator action across two restart prompts.
-    if (request.acknowledgeInstallPolicyWarning) {
-      await this.consentController.install(request, installIdentity);
-      return;
-    }
-    await this.consentController.install(request, installIdentity, () =>
-      confirmPluginInstall(request),
-    );
-  }
-
   private async uninstall(pluginId: string, rowKey: string): Promise<void> {
     const name = this.result?.plugins.find((plugin) => plugin.id === pluginId)?.name ?? pluginId;
     await this.consentController.runMutation(
@@ -727,7 +714,8 @@ class PluginsPage extends OpenClawLightDomElement {
           onShowDetails: (pluginId) => void this.showDetails(pluginId),
           onSetEnabled: (pluginId, enabled, rowKey) =>
             void this.updateEnabled(pluginId, enabled, rowKey),
-          onInstall: (request, installIdentity) => void this.install(request, installIdentity),
+          onInstall: (request, installIdentity) =>
+            void this.consentController.install(request, installIdentity),
           onCancelConsent: () => this.consentController.close(),
           onConfirmConsent: () => this.consentController.confirm(),
           onRetryConsentInspection: () => void this.consentController.inspect(),

--- a/ui/src/pages/plugins/plugins-page.ts
+++ b/ui/src/pages/plugins/plugins-page.ts
@@ -19,6 +19,7 @@ import { inspectPlugin } from "../../lib/plugins/capability-consent-error.ts";
 import {
   uninstallPlugin,
   type PluginCatalogItem,
+  type PluginInstallRequest,
   type PluginListResult,
   type PluginMutationResult,
   type PluginSearchResult,
@@ -30,6 +31,7 @@ import {
 } from "../../lit/gateway-page-controller.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { fetchPluginIconBlobUrl } from "./icon-loader.ts";
+import { confirmPluginInstall, confirmPluginUninstall } from "./plugin-lifecycle-confirmation.ts";
 import { PluginsConsentController } from "./plugins-consent-controller.ts";
 import { renderPluginsHubHeader } from "./plugins-hub-header.ts";
 import type { PluginsHubTab } from "./plugins-hub.ts";
@@ -82,7 +84,6 @@ class PluginsPage extends OpenClawLightDomElement {
   @state() private debouncedSearchQuery = "";
   @state() private busy: Record<string, boolean> = {};
   @state() private messages: Record<string, PluginRowMessage> = {};
-  @state() private pendingRemoval: Record<string, boolean> = {};
   @state() private detail: {
     pluginId: string;
     inspection: PluginsInspectResult | null;
@@ -105,7 +106,6 @@ class PluginsPage extends OpenClawLightDomElement {
       this.result = null;
       this.error = null;
       this.messages = {};
-      this.pendingRemoval = {};
       this.pageNotice = null;
       this.mcpController.resetMessage();
     },
@@ -608,16 +608,6 @@ class PluginsPage extends OpenClawLightDomElement {
     this.messages = next;
   }
 
-  private setPendingRemoval(key: string, value: boolean) {
-    const next = { ...this.pendingRemoval };
-    if (value) {
-      next[key] = true;
-    } else {
-      delete next[key];
-    }
-    this.pendingRemoval = next;
-  }
-
   private applyMutationResult(result: PluginMutationResult) {
     this.invalidatePluginIcon(result.plugin.id);
     this.replaceResult(withPlugin(this.result, result.plugin), true);
@@ -658,12 +648,27 @@ class PluginsPage extends OpenClawLightDomElement {
     return this.consentController.updateEnabled(pluginId, enabled, key);
   }
 
+  private async install(request: PluginInstallRequest, installIdentity: string): Promise<void> {
+    // Policy acknowledgement is the continuation of an already confirmed install.
+    // Confirming again would split one operator action across two restart prompts.
+    if (request.acknowledgeInstallPolicyWarning) {
+      await this.consentController.install(request, installIdentity);
+      return;
+    }
+    if (await confirmPluginInstall(request)) {
+      await this.consentController.install(request, installIdentity);
+    }
+  }
+
   private async uninstall(pluginId: string, rowKey: string): Promise<void> {
+    const name = this.result?.plugins.find((plugin) => plugin.id === pluginId)?.name ?? pluginId;
+    if (!(await confirmPluginUninstall(name))) {
+      return;
+    }
     await this.consentController.runMutation(
       rowKey,
       (client) => uninstallPlugin(client, pluginId),
       async (result, refreshError, client, _isCurrent, isLatest) => {
-        this.setPendingRemoval(rowKey, false);
         // Removal hides its row, so keep the restart reminder on the page.
         if (isLatest()) {
           this.pageNotice = {
@@ -703,7 +708,6 @@ class PluginsPage extends OpenClawLightDomElement {
           searchError: this.searchError,
           busy: this.busy,
           messages: this.messages,
-          pendingRemoval: this.pendingRemoval,
           detailPluginId: this.detail?.pluginId ?? null,
           detailInspection: this.detail?.inspection ?? null,
           detailInspectionError: this.detail?.error ?? null,
@@ -725,14 +729,11 @@ class PluginsPage extends OpenClawLightDomElement {
           onShowDetails: (pluginId) => void this.showDetails(pluginId),
           onSetEnabled: (pluginId, enabled, rowKey) =>
             void this.updateEnabled(pluginId, enabled, rowKey),
-          onInstall: (request, installIdentity) =>
-            void this.consentController.install(request, installIdentity),
+          onInstall: (request, installIdentity) => void this.install(request, installIdentity),
           onCancelConsent: () => this.consentController.close(),
           onConfirmConsent: () => this.consentController.confirm(),
           onRetryConsentInspection: () => void this.consentController.inspect(),
           onDismissMessage: (rowKey) => this.setMessage(rowKey, null),
-          onRequestUninstall: (rowKey) => this.setPendingRemoval(rowKey, true),
-          onCancelUninstall: (rowKey) => this.setPendingRemoval(rowKey, false),
           onUninstall: (pluginId, rowKey) => void this.uninstall(pluginId, rowKey),
           onSearchClawHub: (query) => this.openClawHubSearch(query),
         })}

--- a/ui/src/pages/plugins/plugins.e2e.test.ts
+++ b/ui/src/pages/plugins/plugins.e2e.test.ts
@@ -31,6 +31,7 @@ const updateScreenshots = process.env.OPENCLAW_UPDATE_E2E_SCREENSHOTS === "1";
 const artifactDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/plugins");
 const desktopViewport = { height: 1000, width: 1440 };
 const mobileViewport = { height: 852, width: 393 };
+const restartWarningPattern = /restarts the Gateway immediately[\s\S]*interrupts active sessions/u;
 const pluginMethods = [
   "plugins.list",
   "plugins.inspect",
@@ -372,6 +373,12 @@ async function clickRowAction(page: Page, rowSelector: string, buttonName: strin
   await page.locator(rowSelector).getByRole("button", { name: buttonName, exact: true }).click();
 }
 
+async function confirmPluginLifecycle(page: Page, action: "Install" | "Remove"): Promise<void> {
+  const dialog = page.locator("openclaw-modal-dialog");
+  await dialog.waitFor({ state: "visible" });
+  await dialog.getByRole("button", { name: action, exact: true }).click();
+}
+
 async function captureScreenshot(page: Page, name: string): Promise<void> {
   if (!updateScreenshots) {
     return;
@@ -592,7 +599,22 @@ describeControlUiE2e("Control UI Plugins mocked Gateway E2E", () => {
       await captureScreenshot(page, "04-search-desktop.png");
 
       await gateway.deferNext("plugins.install");
+      const installCountBeforeConfirmation = (await gateway.getRequests("plugins.install")).length;
       await searchRow.getByRole("button", { name: "Install Calendar Plus", exact: true }).click();
+      const installRestartConfirm = page.locator("openclaw-modal-dialog");
+      await installRestartConfirm.waitFor({ state: "visible" });
+      expect(await installRestartConfirm.textContent()).toMatch(restartWarningPattern);
+      expect(await gateway.getRequests("plugins.install")).toHaveLength(
+        installCountBeforeConfirmation,
+      );
+      await installRestartConfirm.getByRole("button", { name: "Cancel", exact: true }).click();
+      await installRestartConfirm.waitFor({ state: "detached" });
+      expect(await gateway.getRequests("plugins.install")).toHaveLength(
+        installCountBeforeConfirmation,
+      );
+      await searchRow.getByRole("button", { name: "Install Calendar Plus", exact: true }).click();
+      await installRestartConfirm.waitFor({ state: "visible" });
+      await installRestartConfirm.getByRole("button", { name: "Install", exact: true }).click();
       const firstInstallRequest = await gateway.waitForRequest("plugins.install");
       expect(await page.locator("[data-plugin-consent]").count()).toBe(0);
       expect(requestParams(firstInstallRequest)).toEqual({
@@ -698,16 +720,25 @@ describeControlUiE2e("Control UI Plugins mocked Gateway E2E", () => {
       await calendarRow.waitFor({ state: "visible" });
       await captureScreenshot(page, "05-enabled-installed-desktop.png");
 
-      // Removable installs expose a confirm-guarded uninstall behind the trash button.
-      await clickRowAction(page, '[data-plugin-id="calendar-plus"]', "Remove Calendar Plus");
+      // Removable installs disclose the restart before the uninstall request.
       const uninstallCountBefore = (await gateway.getRequests("plugins.uninstall")).length;
+      await clickRowAction(page, '[data-plugin-id="calendar-plus"]', "Remove Calendar Plus");
+      const uninstallRestartConfirm = page.locator("openclaw-modal-dialog");
+      await uninstallRestartConfirm.waitFor({ state: "visible" });
+      expect(await uninstallRestartConfirm.textContent()).toMatch(restartWarningPattern);
+      expect(await gateway.getRequests("plugins.uninstall")).toHaveLength(uninstallCountBefore);
+      await uninstallRestartConfirm.getByRole("button", { name: "Cancel", exact: true }).click();
+      await uninstallRestartConfirm.waitFor({ state: "detached" });
+      expect(await gateway.getRequests("plugins.uninstall")).toHaveLength(uninstallCountBefore);
+      await clickRowAction(page, '[data-plugin-id="calendar-plus"]', "Remove Calendar Plus");
+      await uninstallRestartConfirm.waitFor({ state: "visible" });
       const listCountBeforeRemove = (await gateway.getRequests("plugins.list")).length;
       const configCountBeforeRemove = (await gateway.getRequests("config.get")).length;
       await gateway.deferNext("plugins.list");
       // Keep the authoritative config refresh on the workboard-enabled snapshot
       // so the conditional sidebar route assertion below stays meaningful.
       await gateway.deferNext("config.get");
-      await calendarRow.getByRole("button", { name: "Remove", exact: true }).click();
+      await uninstallRestartConfirm.getByRole("button", { name: "Remove", exact: true }).click();
       const uninstallRequest = await waitForNextRequest(
         gateway,
         "plugins.uninstall",
@@ -748,6 +779,7 @@ describeControlUiE2e("Control UI Plugins mocked Gateway E2E", () => {
       await reinstallRow
         .getByRole("button", { name: "Install Calendar Plus", exact: true })
         .click();
+      await confirmPluginLifecycle(page, "Install");
       const reinstallRequest = await waitForNextRequest(
         gateway,
         "plugins.install",
@@ -831,6 +863,7 @@ describeControlUiE2e("Control UI Plugins mocked Gateway E2E", () => {
 
       await gateway.deferNext("plugins.install");
       await row.getByRole("button", { name: "Install Lobster", exact: true }).click();
+      await confirmPluginLifecycle(page, "Install");
       expect(requestParams(await gateway.waitForRequest("plugins.install"))).toEqual({
         source: "clawhub",
         packageName: "@openclaw/lobster",
@@ -888,6 +921,7 @@ describeControlUiE2e("Control UI Plugins mocked Gateway E2E", () => {
       const installCountBeforeSecondAttempt = (await gateway.getRequests("plugins.install")).length;
       await gateway.deferNext("plugins.install");
       await row.getByRole("button", { name: "Install Lobster", exact: true }).click();
+      await confirmPluginLifecycle(page, "Install");
       await waitForNextRequest(gateway, "plugins.install", installCountBeforeSecondAttempt);
       await gateway.rejectDeferred("plugins.install", {
         code: "INVALID_REQUEST",

--- a/ui/src/pages/plugins/view.test.ts
+++ b/ui/src/pages/plugins/view.test.ts
@@ -48,7 +48,6 @@ function createProps(overrides: Partial<PluginsViewProps> = {}): PluginsViewProp
     searchError: null,
     busy: {},
     messages: {},
-    pendingRemoval: {},
     detailPluginId: null,
     detailInspection: null,
     detailInspectionError: null,
@@ -76,8 +75,6 @@ function createProps(overrides: Partial<PluginsViewProps> = {}): PluginsViewProp
     onConfirmConsent: () => undefined,
     onRetryConsentInspection: () => undefined,
     onDismissMessage: () => undefined,
-    onRequestUninstall: () => undefined,
-    onCancelUninstall: () => undefined,
     onUninstall: () => undefined,
     onAddConnector: () => undefined,
     onSearchClawHub: () => undefined,
@@ -286,7 +283,7 @@ describe("renderPlugins", () => {
 
   it("offers enable and remove through direct row actions", () => {
     const onSetEnabled = vi.fn();
-    const onRequestUninstall = vi.fn();
+    const onUninstall = vi.fn();
     const removableKey = pluginRowKey("community-thing");
     const plugins = [
       createPlugin(),
@@ -299,48 +296,18 @@ describe("renderPlugins", () => {
       }),
     ];
     const container = mount(
-      createProps({ result: createResult(plugins), onSetEnabled, onRequestUninstall }),
+      createProps({ result: createResult(plugins), onSetEnabled, onUninstall }),
     );
     const row = container.querySelector<HTMLElement>('[data-plugin-id="community-thing"]')!;
     actionButton(row, "Enable")?.click();
     expect(onSetEnabled).toHaveBeenCalledWith("community-thing", true, removableKey);
     actionButton(row, "Remove Community Thing")?.click();
-    expect(onRequestUninstall).toHaveBeenCalledWith(removableKey);
+    expect(onUninstall).toHaveBeenCalledWith("community-thing", removableKey);
 
     // Bundled plugins cannot be removed; the row still offers enable/disable.
     const bundledRow = container.querySelector<HTMLElement>('[data-plugin-id="workboard"]')!;
     expect(actionButton(bundledRow, "Remove")).toBeNull();
     expect(actionButton(bundledRow, "Enable")).not.toBeNull();
-  });
-
-  it("confirms removal before uninstalling", () => {
-    const onUninstall = vi.fn();
-    const onCancelUninstall = vi.fn();
-    const rowKey = pluginRowKey("community-thing");
-    const plugins = [
-      createPlugin({
-        id: "community-thing",
-        name: "Community Thing",
-        origin: "global",
-        removable: true,
-        featured: false,
-      }),
-    ];
-    const container = mount(
-      createProps({
-        result: createResult(plugins),
-        pendingRemoval: { [rowKey]: true },
-        onUninstall,
-        onCancelUninstall,
-      }),
-    );
-
-    const confirm = container.querySelector<HTMLElement>(".plugins-remove-confirm");
-    expect(normalizedText(confirm)).toContain("Remove this plugin package and all of its entries?");
-    confirm?.querySelector<HTMLButtonElement>(".btn.danger")?.click();
-    expect(onUninstall).toHaveBeenCalledWith("community-thing", rowKey);
-    confirm?.querySelectorAll<HTMLButtonElement>("button")[1]?.click();
-    expect(onCancelUninstall).toHaveBeenCalledWith(rowKey);
   });
 
   it("opens the detail overlay from a row and renders actions and metadata", () => {

--- a/ui/src/pages/plugins/view.ts
+++ b/ui/src/pages/plugins/view.ts
@@ -94,7 +94,6 @@ type PluginsViewProps = {
   searchError: string | null;
   busy: Readonly<Record<string, boolean>>;
   messages: Readonly<Record<string, PluginRowMessage>>;
-  pendingRemoval: Readonly<Record<string, boolean>>;
   detailPluginId: string | null;
   detailInspection: PluginsInspectResult | null;
   detailInspectionError: string | null;
@@ -122,8 +121,6 @@ type PluginsViewProps = {
   onConfirmConsent: () => void;
   onRetryConsentInspection: () => void;
   onDismissMessage: (rowKey: string) => void;
-  onRequestUninstall: (rowKey: string) => void;
-  onCancelUninstall: (rowKey: string) => void;
   onUninstall: (pluginId: string, rowKey: string) => void;
   onAddConnector: (suggestion: ConnectorSuggestion) => void;
   onSearchClawHub: (query: string) => void;
@@ -598,54 +595,12 @@ function renderInstallButton(
   `;
 }
 
-function renderRemoveConfirm(
-  plugin: PluginCatalogItem,
-  props: PluginsViewProps,
-  busy: boolean,
-  rowKey: string,
-) {
-  return html`
-    <span
-      class="plugins-remove-confirm"
-      role="alertdialog"
-      aria-label=${t("pluginsPage.removeNamed", { name: plugin.name })}
-    >
-      <span>${t("pluginsPage.removeConfirm")}</span>
-      <button
-        type="button"
-        class="btn btn--sm danger"
-        ?disabled=${busy || !props.canMutate}
-        @click=${(event: Event) => {
-          event.stopPropagation();
-          props.onUninstall(plugin.id, rowKey);
-        }}
-      >
-        ${busy ? t("pluginsPage.removing") : t("pluginsPage.remove")}
-      </button>
-      <button
-        type="button"
-        class="btn btn--sm"
-        ?disabled=${busy}
-        @click=${(event: Event) => {
-          event.stopPropagation();
-          props.onCancelUninstall(rowKey);
-        }}
-      >
-        ${t("pluginsPage.cancel")}
-      </button>
-    </span>
-  `;
-}
-
 function renderCatalogActions(
   plugin: PluginCatalogItem,
   props: PluginsViewProps,
   busy: boolean,
   rowKey: string,
 ) {
-  if (props.pendingRemoval[rowKey]) {
-    return renderRemoveConfirm(plugin, props, busy, rowKey);
-  }
   if (!plugin.installed) {
     const install = plugin.install;
     return install
@@ -664,7 +619,7 @@ function renderCatalogActions(
       onToggle: (enabled) => props.onSetEnabled(plugin.id, enabled, rowKey),
     })}
     ${plugin.removable
-      ? renderRemoveButton(props, busy, plugin.name, () => props.onRequestUninstall(rowKey))
+      ? renderRemoveButton(props, busy, plugin.name, () => props.onUninstall(plugin.id, rowKey))
       : nothing}
   `;
 }
@@ -1191,49 +1146,45 @@ function renderDetailOverlay(props: PluginsViewProps) {
             ${plugin.description || t("pluginsPage.optionalCapability")}
           </p>
           <div class="plugins-detail__actions">
-            ${props.pendingRemoval[key]
-              ? renderRemoveConfirm(plugin, props, busy, key)
-              : html`
-                  ${plugin.installed
-                    ? html`
-                        <button
-                          type="button"
-                          class="btn ${plugin.enabled ? "" : "primary"}"
-                          title=${props.mutationBlockedReason ?? ""}
-                          ?disabled=${!props.canMutate || busy}
-                          @click=${() => props.onSetEnabled(plugin.id, !plugin.enabled, key)}
-                        >
-                          ${busy
-                            ? t("pluginsPage.working")
-                            : plugin.enabled
-                              ? t("pluginsPage.disableAction")
-                              : t("pluginsPage.enableAction")}
-                        </button>
-                      `
-                    : plugin.install
-                      ? renderInstallButton(
-                          props,
-                          busy,
-                          plugin.name,
-                          plugin.install,
-                          resolveInstallIdentity(props, plugin.install),
-                        )
-                      : nothing}
-                  ${plugin.removable
-                    ? html`
-                        <button
-                          type="button"
-                          class="btn plugins-detail__remove"
-                          title=${props.mutationBlockedReason ?? ""}
-                          ?disabled=${!props.canMutate || busy}
-                          @click=${() => props.onRequestUninstall(key)}
-                        >
-                          <span aria-hidden="true">${icons.trash}</span>
-                          ${t("pluginsPage.remove")}
-                        </button>
-                      `
-                    : nothing}
-                `}
+            ${plugin.installed
+              ? html`
+                  <button
+                    type="button"
+                    class="btn ${plugin.enabled ? "" : "primary"}"
+                    title=${props.mutationBlockedReason ?? ""}
+                    ?disabled=${!props.canMutate || busy}
+                    @click=${() => props.onSetEnabled(plugin.id, !plugin.enabled, key)}
+                  >
+                    ${busy
+                      ? t("pluginsPage.working")
+                      : plugin.enabled
+                        ? t("pluginsPage.disableAction")
+                        : t("pluginsPage.enableAction")}
+                  </button>
+                `
+              : plugin.install
+                ? renderInstallButton(
+                    props,
+                    busy,
+                    plugin.name,
+                    plugin.install,
+                    resolveInstallIdentity(props, plugin.install),
+                  )
+                : nothing}
+            ${plugin.removable
+              ? html`
+                  <button
+                    type="button"
+                    class="btn plugins-detail__remove"
+                    title=${props.mutationBlockedReason ?? ""}
+                    ?disabled=${!props.canMutate || busy}
+                    @click=${() => props.onUninstall(plugin.id, key)}
+                  >
+                    <span aria-hidden="true">${icons.trash}</span>
+                    ${t("pluginsPage.remove")}
+                  </button>
+                `
+              : nothing}
           </div>
           ${plugin.error
             ? html`<div class="plugins-row-message plugins-row-message--error" role="alert">


### PR DESCRIPTION
Closes #130157

## What Problem This Solves

Fixes an issue where Control UI operators installing or removing plugin code would trigger an immediate Gateway restart without first being told that active sessions would be interrupted.

## Why This Change Was Made

Plugin install and uninstall now share the existing Control UI modal-confirmation pattern. The modal names the action, discloses the immediate Gateway restart and active-session interruption, and must resolve affirmatively before the lifecycle RPC is dispatched. Cancellation performs no mutation. The existing post-confirmation lifecycle and automatic restart behavior are unchanged.

The mutation owner captures the current Gateway client and connection epoch before opening the modal. After the asynchronous confirmation resolves, it revalidates that exact epoch, mutation permission, and row availability before dispatching through the captured client. A reconnect or Gateway source replacement therefore invalidates the confirmation instead of transferring operator consent to a different Gateway.

Server-driven install-policy and capability reviews retain that confirmed Gateway scope only while the same connection epoch remains current. An uninterrupted review continuation avoids duplicate restart prompts, while reconnect invalidation clears the retained scope so a surviving “Install anyway” action must obtain fresh confirmation. The final config-write queue fence rechecks the same scope and permission immediately before lifecycle RPC dispatch.

The obsolete inline uninstall-confirmation state and renderer were removed so there is one canonical confirmation path for catalog rows, search results, plugin details, and policy-review continuations.

## User Impact

Operators can choose a safe moment for a disruptive plugin install or removal. They see the restart impact before the request starts, cancelling leaves the Gateway untouched, and a reconnect requires fresh confirmation even when a prior server policy warning remains visible.

## Evidence

- Pre-fix replacement reproduction: deferred confirmations resolved after replacing the Gateway client dispatched `plugins.install` and `plugins.uninstall` to the replacement client. Both regressions fail before the epoch-bound repair and pass afterward.
- Final-dispatch reproduction: after confirmation, a queued config mutation followed by a same-client Gateway source replacement still dispatched both lifecycle RPCs. The install and uninstall regressions fail before the queue's existing `canDispatch` fence carries the captured scope/token/permission predicate, and pass afterward.
- Policy-continuation reproduction: confirm install → receive server install-policy warning → same-client disconnect/reconnect → click “Install anyway”. Before the repair the acknowledged retry dispatched without another restart prompt (`showConfirmDialog` expected twice, observed once); afterward it remains undispatched until fresh confirmation resolves.
- `node scripts/run-vitest.mjs ui/src/pages/plugins/plugins-page.test.ts ui/src/pages/plugins/plugins-page.lifecycle.test.ts ui/src/pages/plugins/plugins-page.consent.test.ts ui/src/pages/plugins/view.test.ts` — 72 tests passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/pages/plugins/plugins.e2e.test.ts ui/src/e2e/chat-composer-capability-menu.e2e.test.ts` — 16 browser E2E tests passed (6 plugin lifecycle, 10 current-`main` capability-menu), including install/uninstall modal text, request ordering, cancellation, policy-warning continuation, and responsive layouts.
- `pnpm --dir ui test --maxWorkers 3` — 799 files passed; 11,764 tests passed, 1 skipped, zero failures on current `main`.
- `pnpm lint` — passed.
- `pnpm check:changed` — passed, including formatting, UI/core typechecks, focused lint, i18n, dead-export, assertion, and changed-scope guards.
- Fresh autoreview at exact head: clean, no accepted/actionable P0/P1 findings (Codex `gpt-5.6-sol`, high reasoning; 0.93 confidence).
- Production LOC: +114 / -112 (net +2). The two net lines are the explanatory invariant for the retained Gateway-scope lifecycle state after moving confirmation ownership out of the page wrapper. Test/test-support LOC: +410 / -45 (net +365).

Visual-proof gap: the Codex app browser panel did not finish registering the local mock URL, so no app-browser screenshot was captured. The same built Control UI interaction was validated through the repository's Playwright mocked-Gateway E2E lane.

AI-assisted: yes. I reviewed the implementation and validation results.
