### PR TITLE
fix(ios): avoid duplicate Markdown work while replies stream

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
@@ -1161,9 +1161,8 @@ private struct ChatAssistantTextBody: View {
 
 @MainActor
 private struct ChatStreamingAssistantTextBody: View {
-    let text: String
+    private let inputSnapshot: Snapshot
     let markdownVariant: ChatMarkdownVariant
-    let includesThinking: Bool
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var snapshot: Snapshot
@@ -1172,12 +1171,13 @@ private struct ChatStreamingAssistantTextBody: View {
     @State private var pendingUntil: TimeInterval?
 
     init(text: String, markdownVariant: ChatMarkdownVariant, includesThinking: Bool) {
-        self.text = text
         self.markdownVariant = markdownVariant
-        self.includesThinking = includesThinking
 
         let now = Date.timeIntervalSinceReferenceDate
         let snapshot = Snapshot(text: text, includesThinking: includesThinking)
+        // State retains its old value across updates. Reuse this prepared input
+        // when applying the delta instead of parsing the same Markdown again.
+        self.inputSnapshot = snapshot
         let location = snapshot.lastProseLocation
         let revealState = location.map {
             step(state: ChatStreamingRevealState(), newText: snapshot.prose(at: $0).plainText, now: now)
@@ -1198,17 +1198,19 @@ private struct ChatStreamingAssistantTextBody: View {
                 }
             }
         }
-        .onChange(of: self.text) { _, _ in
+        .onChange(of: self.inputSnapshot.sourceText) { _, _ in
             self.updateSnapshot()
         }
-        .onChange(of: self.includesThinking) { _, _ in
+        .onChange(of: self.inputSnapshot.includesThinking) { _, _ in
             self.updateSnapshot()
         }
         .onChange(of: self.reduceMotion) { _, reduceMotion in
             self.pendingUntil = reduceMotion ? nil : self.futureDeadline()
         }
         .onAppear {
-            if self.snapshot.sourceText != self.text || self.snapshot.includesThinking != self.includesThinking {
+            if self.snapshot.sourceText != self.inputSnapshot.sourceText ||
+                self.snapshot.includesThinking != self.inputSnapshot.includesThinking
+            {
                 self.updateSnapshot()
             }
         }
@@ -1254,7 +1256,7 @@ private struct ChatStreamingAssistantTextBody: View {
 
     private func updateSnapshot() {
         let now = Date.timeIntervalSinceReferenceDate
-        let nextSnapshot = Snapshot(text: self.text, includesThinking: self.includesThinking)
+        let nextSnapshot = self.inputSnapshot
         let nextLocation = nextSnapshot.lastProseLocation
         let nextRevealState: ChatStreamingRevealState
         if let nextLocation {


### PR DESCRIPTION
Related: #124759

## What Problem This Solves

Fixes an issue where users watching streaming replies in the Apple chat UI incur repeated Markdown preparation for the same update. This is one confirmed source of unnecessary main-actor work, not a claim that the broader reported iPhone interaction lag is resolved.

## Why This Change Was Made

The streaming text view eagerly prepared a snapshot in its initializer to seed SwiftUI State, then prepared the same input again when its retained view handled a text or reasoning-visibility change. Reuse that already-prepared input in the existing state transition. The rendered snapshot and reveal state still advance together; the first frame, reveal deadlines, Reduce Motion handling, and completed-message path are unchanged.

The canonical owner is `ChatStreamingAssistantTextBody` in the shared `OpenClawChatUI` package, used by iOS and macOS. This removes the second parser path and the duplicate raw input fields, without a new cache, wrapper, configuration, dependency, or persistence change. Production LOC: +10/-8 (net +2, entirely the two-line ownership comment; executable lines net-neutral). Tests: +0/-0.

Provenance: the eager initializer and retained-change reparse were introduced together in #100884, merged July 6, 2026 as `83f052772429c24e5770971b709296c814109ca5`. Code author, PR author, and human merger: @steipete; Git commit committer: GitHub. That feature's stated contract was to parse Markdown once per delta. SwiftUI's [State initialization documentation](https://developer.apple.com/documentation/SwiftUI/State) and the installed SDK interface corroborate that the eager initializer cannot be assumed to run only once.

## User Impact

Streaming text and reasoning-visibility changes prepare their Markdown once instead of twice; a simultaneous text/reasoning rewrite goes from three preparations to one. Unchanged sibling updates remain at zero preparations. No visual or animation behavior is intentionally changed.

## Evidence

A disposable diagnostic hosted the actual `ChatStreamingAssistantBubble` in a retained macOS `NSHostingView`, updated its real SwiftUI root, and instrumented `Snapshot.init`. Same original-order scenario on baseline and candidate:

| Input transition | Baseline preparations | Candidate preparations |
| --- | ---: | ---: |
| Initial content | 1 | 1 |
| Three unrelated sibling updates | 0 each | 0 each |
| Five appended text deltas | 2 each | 1 each |
| Hide reasoning | 2 | 1 |
| Rewrite text and show reasoning together | 3 | 1 |
| Settled sibling update | 0 | 0 |

The exact-count contract fails on baseline and passes on the candidate. Both native view runs complete successfully. Their final 1100×296 bitmaps are byte-identical (SHA-256 `5e16bf2ff5a7e4383b87328434115d32b447acfbc180ad8c9e19472d974d19ef`). Images contain synthetic test text only.

| Before | After |
| --- | --- |
| ![Baseline settled native streaming reply](https://github.com/user-attachments/assets/e8600a7e-b33d-4f8e-9a6a-da9e159aafbd) | ![Candidate settled native streaming reply](https://github.com/user-attachments/assets/0c55def3-8835-4a8e-a307-a71ca07d180d) |

The instrumentation and disposable host test were removed before publication. A permanent pure-output test cannot distinguish one identical parse from two; adding a production-only counter or a flaky wall-clock threshold would be worse than this exact-count manual reproduction. Existing semantic coverage was rerun on the trace-free source:

- `swift test --jobs 2 --skip-update --filter 'ChatStreamingRevealTests|ChatMarkdown.*Tests|AssistantTextParserTests|ChatStreamReplayTests'`: 168 tests in 7 suites passed.
- Repository changed-file gate passed on Blacksmith Testbox `tbx_01m138gmv7kz7vpydd8ffpd40p`: wrapper exit 0; [run](https://github.com/openclaw/openclaw/actions/runs/33140631083). The one-shot lease is confirmed completed. Linux skips SwiftLint; the pinned local all-app SwiftLint gate separately passed with zero violations across 344 macOS, 22 Swabble, and 365 iOS/shared files. Pinned targeted SwiftFormat also passed.
- Independent owner/caller/sibling review found no blocking source regression; structured Codex autoreview exited 0 with no accepted/actionable findings at its P0 threshold.

Retained failed attempts: the initial diagnostic did not compile because the SDK's Reduce Motion environment property is read-only; the corrected probe observed the host's actual setting (false). The initial local lint invocation rejected system SwiftLint 0.65.1; the unchanged gate passed with repository-pinned 0.65.0. Neither failed attempt is counted as proof.

Limits: this is real macOS shared-component lifecycle/rendering proof, not a physical-iPhone frame-rate measurement, a Release Instruments profile, or a live Reduce Motion-on run. No latency percentage is inferred from test duration. #124759 stays open for real-device profiling and other remaining rendering costs; #130615's earlier edit-row repair is separate. Thanks @VirPoe for the report that prompted this investigation.

### Review disposition

The [exact-head ClawSweeper review](https://github.com/openclaw/openclaw/pull/131513#issuecomment-5448455825) found no code/security defect and accepted the retained native-host proof. Its remaining before-merge requests are accounted for: retain the single prepared-snapshot flow and the lifecycle comment (production +10/-8; removing the two-line comment makes executable LOC net-neutral), and complete exact-head native CI before landing. This is the chosen owner-level repair, not a request to broaden the patch or claim the whole lag issue is fixed. No new behavior was pushed after that review.

Completed hosted Apple checks on `61a4c6aaad36e7891ffbee2d063fa93f0fc3a38f`: 1,477 shared-kit tests, 1,842 macOS app tests, 285 iOS lifecycle tests, and 13 Watch tests passed in [CI33141193298](https://github.com/openclaw/openclaw/actions/runs/33141193298). That first ready-for-review run completed successfully, including iPhone/iPad/Watch screenshots, the screenshot-evidence reducer, all Android lanes, and the required `openclaw/ci-gate`. No CI retry or post-review source change was needed. The initial draft run was skipped and is not counted as passing validation.
