### PR TITLE
fix(tooling): keep Control UI baseline hints off shared tsx caches

### DIFF
--- a/scripts/check-control-ui-performance.mts
+++ b/scripts/check-control-ui-performance.mts
@@ -274,7 +274,7 @@ export function formatControlUiPerformanceReport(
       startupBudgetBaseline.startupJsGzipBytes
   ) {
     lines.push(
-      `  hint: startup JS gzip is more than ${STARTUP_JS_BASELINE_RATCHET_BYTES} B below the ${startupBudgetBaseline.startupJsGzipBytes} B baseline; lower it with node --import tsx scripts/check-control-ui-performance.mts --update-baseline --reason "<reason>"`,
+      `  hint: startup JS gzip is more than ${STARTUP_JS_BASELINE_RATCHET_BYTES} B below the ${startupBudgetBaseline.startupJsGzipBytes} B baseline; lower it with ${baselineUpdateCommand()}`,
     );
   }
   if (violations.length > 0) {
@@ -287,7 +287,7 @@ export function formatControlUiPerformanceReport(
 }
 
 function baselineUpdateCommand(): string {
-  return 'node --import tsx scripts/check-control-ui-performance.mts --update-baseline --reason "<reason>"';
+  return 'node --import ./scripts/tsx.mjs scripts/check-control-ui-performance.mts --update-baseline --reason "<reason>"';
 }
 
 function isIsoDate(value: string): boolean {

--- a/test/scripts/control-ui-performance.test.ts
+++ b/test/scripts/control-ui-performance.test.ts
@@ -13,13 +13,17 @@ import {
 } from "../../scripts/check-control-ui-performance.mts";
 
 const tempDirs: string[] = [];
-const tsxImport = import.meta.resolve("tsx");
+const tsxImport = new URL("../../scripts/tsx.mjs", import.meta.url).href;
+const baselineUpdateCommand =
+  'node --import ./scripts/tsx.mjs scripts/check-control-ui-performance.mts --update-baseline --reason "<reason>"';
 
 function runControlUiPerformanceCli(scriptPath: string, args: string[], cwd: string) {
+  const env = { ...process.env };
+  delete env.TSX_DISABLE_CACHE;
   return spawnSync(
     process.execPath,
     ["--import", tsxImport, fs.realpathSync(scriptPath), ...args],
-    { cwd, encoding: "utf8" },
+    { cwd, env, encoding: "utf8", timeout: 10_000 },
   );
 }
 
@@ -38,6 +42,39 @@ function createDistFixture() {
     fs.writeFileSync(`${assetPath}.br`, Buffer.alloc(sizes.brotliBytes));
   };
   return { distDir, writeAsset };
+}
+
+function createCliFixture() {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-control-ui-budget-cli-"));
+  tempDirs.push(rootDir);
+  const scriptsDir = path.join(rootDir, "scripts");
+  const configDir = path.join(rootDir, "config");
+  const distDir = path.join(rootDir, "dist/control-ui");
+  const assetsDir = path.join(distDir, "assets");
+  fs.mkdirSync(scriptsDir, { recursive: true });
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.mkdirSync(assetsDir, { recursive: true });
+  const scriptPath = path.join(scriptsDir, "check-control-ui-performance.mts");
+  fs.copyFileSync(path.resolve("scripts/check-control-ui-performance.mts"), scriptPath);
+  fs.writeFileSync(
+    path.join(scriptsDir, "tsx.mjs"),
+    `await import(${JSON.stringify(tsxImport)});\n`,
+  );
+  fs.writeFileSync(
+    path.join(distDir, "index.html"),
+    '<script type="module" src="./assets/index-a.js"></script>\n' +
+      '<link rel="stylesheet" href="./assets/index-c.css">\n',
+  );
+  for (const [file, sizes] of [
+    ["index-a.js", { rawBytes: 100, gzipBytes: 65, brotliBytes: 50 }],
+    ["index-c.css", { rawBytes: 50, gzipBytes: 15, brotliBytes: 12 }],
+  ] as const) {
+    const assetPath = path.join(assetsDir, file);
+    fs.writeFileSync(assetPath, Buffer.alloc(sizes.rawBytes));
+    fs.writeFileSync(`${assetPath}.gz`, Buffer.alloc(sizes.gzipBytes));
+    fs.writeFileSync(`${assetPath}.br`, Buffer.alloc(sizes.brotliBytes));
+  }
+  return { rootDir, scriptPath, configDir, distDir };
 }
 
 function createMetrics(startupJsGzipBytes: number) {
@@ -308,7 +345,9 @@ describe("Control UI performance budgets", () => {
         looseBudgets,
         startupBaseline(14_097),
       ),
-    ).toContain("hint: startup JS gzip is more than 4096 B below the 14097 B baseline");
+    ).toContain(
+      `hint: startup JS gzip is more than 4096 B below the 14097 B baseline; lower it with ${baselineUpdateCommand}`,
+    );
   });
 
   it("fails closed when the startup baseline is malformed", () => {
@@ -325,6 +364,9 @@ describe("Control UI performance budgets", () => {
 
     expect(() => runControlUiPerformanceCheck(distDir, looseBudgets, baselinePath)).toThrow(
       /Cannot read Control UI startup budget baseline .*--update-baseline/u,
+    );
+    expect(() => runControlUiPerformanceCheck(distDir, looseBudgets, baselinePath)).toThrow(
+      `Regenerate it with ${baselineUpdateCommand}.`,
     );
   });
 
@@ -381,31 +423,7 @@ describe("Control UI performance budgets", () => {
   });
 
   it("updates the baseline from generated or explicitly measured metrics", () => {
-    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-control-ui-budget-cli-"));
-    tempDirs.push(rootDir);
-    const scriptsDir = path.join(rootDir, "scripts");
-    const configDir = path.join(rootDir, "config");
-    const distDir = path.join(rootDir, "dist/control-ui");
-    const assetsDir = path.join(distDir, "assets");
-    fs.mkdirSync(scriptsDir, { recursive: true });
-    fs.mkdirSync(configDir, { recursive: true });
-    fs.mkdirSync(assetsDir, { recursive: true });
-    const scriptPath = path.join(scriptsDir, "check-control-ui-performance.mts");
-    fs.copyFileSync(path.resolve("scripts/check-control-ui-performance.mts"), scriptPath);
-    fs.writeFileSync(
-      path.join(distDir, "index.html"),
-      '<script type="module" src="./assets/index-a.js"></script>\n' +
-        '<link rel="stylesheet" href="./assets/index-c.css">\n',
-    );
-    for (const [file, sizes] of [
-      ["index-a.js", { rawBytes: 100, gzipBytes: 65, brotliBytes: 50 }],
-      ["index-c.css", { rawBytes: 50, gzipBytes: 15, brotliBytes: 12 }],
-    ] as const) {
-      const assetPath = path.join(assetsDir, file);
-      fs.writeFileSync(assetPath, Buffer.alloc(sizes.rawBytes));
-      fs.writeFileSync(`${assetPath}.gz`, Buffer.alloc(sizes.gzipBytes));
-      fs.writeFileSync(`${assetPath}.br`, Buffer.alloc(sizes.brotliBytes));
-    }
+    const { rootDir, scriptPath, configDir, distDir } = createCliFixture();
 
     const result = runControlUiPerformanceCli(scriptPath, ["--update-baseline"], rootDir);
 
@@ -459,6 +477,47 @@ describe("Control UI performance budgets", () => {
         fs.readFileSync(path.join(configDir, "control-ui-startup-budget-baseline.json"), "utf8"),
       ),
     ).toMatchObject({ startupJsGzipBytes: 321, reason: "explicit measurement" });
+  });
+
+  it.each([
+    { name: "lowering", baseline: JSON.stringify(startupBaseline(5_000)), exitCode: 0 },
+    { name: "malformed", baseline: '{"startupJsGzipBytes":"not-a-number"}\n', exitCode: 1 },
+    { name: "missing", baseline: null, exitCode: 1 },
+  ])("executes the $name baseline hint with the canonical preload", ({ baseline, exitCode }) => {
+    const { rootDir, scriptPath, configDir } = createCliFixture();
+    const baselinePath = path.join(configDir, "control-ui-startup-budget-baseline.json");
+    if (baseline !== null) {
+      fs.writeFileSync(baselinePath, baseline);
+    }
+    const report = runControlUiPerformanceCli(scriptPath, [], rootDir);
+    expect(report.status, report.stderr).toBe(exitCode);
+    const output = exitCode === 0 ? report.stdout : report.stderr;
+    const command = output.match(/node --import [^\r\n]*?--reason "<reason>"/u)?.[0];
+    // Never spawn an old raw-tsx hint: it could access the host's shared cache.
+    expect(command).toBe(baselineUpdateCommand);
+
+    const reason = "fixture hint update";
+    const args = command!
+      .slice("node ".length)
+      .split(" ")
+      .map((arg) => (arg === '"<reason>"' ? reason : arg));
+    const env = { ...process.env };
+    delete env.TSX_DISABLE_CACHE;
+    const beforeDate = new Date().toISOString().slice(0, 10);
+    const update = spawnSync(process.execPath, args, {
+      cwd: rootDir,
+      env,
+      encoding: "utf8",
+      timeout: 10_000,
+    });
+    expect(update.status, update.stderr).toBe(0);
+    expect(update.stdout).toBe(
+      `Updated config/control-ui-startup-budget-baseline.json to 65 B (${reason}).\n`,
+    );
+    const expectedBytes = [beforeDate, new Date().toISOString().slice(0, 10)].map(
+      (updatedAt) => `${JSON.stringify({ startupJsGzipBytes: 65, reason, updatedAt }, null, 2)}\n`,
+    );
+    expect(expectedBytes).toContain(fs.readFileSync(baselinePath, "utf8"));
   });
 
   it("fails when a compressed sidecar is missing", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers following the Control UI performance checker's baseline-update guidance could bypass the repository's tooling startup policy and access tsx's shared disk cache. Both the size-reduction hint and missing/malformed-baseline recovery hint emitted a raw tsx launch command.

## Why This Change Was Made

Both hints now use the existing `baselineUpdateCommand()` and the canonical `--import ./scripts/tsx.mjs` preload. The preload sets the established cache policy before tsx initializes, retaining its in-process transform cache without indexing or expiring another checkout's disk cache. This removes duplicated command text instead of adding a second policy implementation.

The change is limited to the hint producer and its tests. It does not change performance budgets, committed baselines, baseline-update semantics, dependencies, or the separate standalone UI validator launch path.

Related context: https://github.com/openclaw/openclaw/pull/130924 (canonical tooling preload and shared-tsx-cache startup repair).

## User Impact

Developers can copy either baseline-update hint and get the same cache-safe tooling startup behavior as maintained repository commands, without pre-setting `TSX_DISABLE_CACHE` in their shell. No OpenClaw runtime or visual Control UI behavior changes.

## Evidence

- Read the checker, CLI entrypoint, canonical preload/cache-policy owner, sibling UI launcher, relevant tests and scoped guides, current `main`, and the installed tsx 4.23.12 cache implementation. The dependency chooses an in-memory `Map` when `TSX_DISABLE_CACHE` is set; its disk implementation otherwise indexes and expires the shared cache.
- Tests-first reproduction: `node scripts/run-vitest.mjs test/scripts/control-ui-performance.test.ts` produced **5 intended failures / 15 passes** before the production fix. The new tests reject raw-tsx hints before attempting execution. After the two-line fix, the same command produced **20 passes**.
- Real CLI/shell proof copied the checker into owned temporary fixtures and exercised missing, malformed, and lowerable baseline cases. Both emitted commands executed successfully against only synthetic fixture data. Six diagnostic/update processes started with ambient `TSX_DISABLE_CACHE` absent; the canonical preload set it to `1`. A preloaded filesystem guard recorded **zero attempted tsx-cache operations**. Its negative control blocked an operation on an owned nonexistent path before filesystem access. Temporary/cache environment settings and the repository baseline were unchanged; no fixture `node_modules` was created. All fixtures were removed after child exit.
- `node scripts/check-changed.mjs -- scripts/check-control-ui-performance.mts test/scripts/control-ui-performance.test.ts` passed formatting, script/test-root typechecks, targeted lint, and selected guards.
- `git diff --check` passed. Isolated Codex blocking review returned no findings.
- Production LOC: **+2/-2 (net 0)**. Tests: **+87/-28 (net +59)**; existing CLI fixture setup is reused and budget/ratchet coverage is preserved.

AI-assisted; implementation, emitted-command behavior, and dependency/cache ownership were independently inspected and verified. No actual baseline/budget update or shared-cache read, cleanup, or relocation was used as proof.
