### PR TITLE
fix(models): keep model listings consistent after manifest changes

### DIFF
--- a/src/commands/models/list.manifest-catalog.snapshot.test.ts
+++ b/src/commands/models/list.manifest-catalog.snapshot.test.ts
@@ -1,0 +1,326 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { clearPluginMetadataLifecycleCaches } from "../../plugins/plugin-metadata-lifecycle.js";
+import { loadPluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.js";
+import {
+  createColdPluginFixture,
+  isColdPluginRuntimeLoaded,
+} from "../../plugins/test-helpers/cold-plugin-fixtures.js";
+import {
+  createSyncSuiteTempRootTracker,
+  mkdirSafeDir,
+} from "../../plugins/test-helpers/fs-fixtures.js";
+import {
+  loadManifestCatalogRowsForList,
+  loadStaticManifestCatalogRowsForList,
+  resolveManifestCatalogCoverageForList,
+} from "./list.manifest-catalog.js";
+
+const tempRoots = createSyncSuiteTempRootTracker("manifest-catalog");
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  clearPluginMetadataLifecycleCaches();
+  tempRoots.cleanup();
+});
+
+function prepareFixture() {
+  const root = fs.realpathSync(tempRoots.makeTempDir());
+  const bundled = path.join(root, "bundled");
+  const workspaceDir = path.join(root, "workspace");
+  const declarations = [
+    ["catalog-owner", "fixture-provider", bundled],
+    ["fixture-direct", "fixture-direct", bundled],
+    ["disabled-owner", "fixture-disabled", bundled],
+    ["workspace-owner", "fixture-workspace", path.join(workspaceDir, ".openclaw/extensions")],
+  ] as const;
+  const fixtures = declarations.map(([pluginId, providerId, parent]) => {
+    const rootDir = path.join(parent, pluginId);
+    mkdirSafeDir(rootDir);
+    return createColdPluginFixture({
+      rootDir,
+      pluginId,
+      providerId,
+      packageName: `@example/${pluginId}`,
+      manifest: {
+        channels: [],
+        channelConfigs: {},
+        providerAuthChoices: [],
+        modelCatalog: {
+          providers: {
+            [providerId]: {
+              api: "openai-completions",
+              baseUrl: "https://canonical.example.invalid/v1",
+              models: [{ id: "tiny-model", name: "Tiny model", contextWindow: 8192 }],
+            },
+          },
+          discovery: { [providerId]: "static" },
+          ...(pluginId === "catalog-owner"
+            ? {
+                aliases: {
+                  // A competing declaration must not displace same-name convention rows.
+                  "fixture-direct": { provider: providerId },
+                  "fixture-alias": {
+                    provider: providerId,
+                    api: "openai-responses",
+                    baseUrl: "https://alias.example.invalid/v1",
+                  },
+                },
+              }
+            : {}),
+        },
+      },
+    });
+  });
+  const cfg: OpenClawConfig = {
+    models: { catalogRefresh: { enabled: false } },
+    plugins: {
+      entries: Object.fromEntries(
+        fixtures.map(({ pluginId }) => [pluginId, { enabled: pluginId !== "disabled-owner" }]),
+      ),
+    },
+  };
+  const env: NodeJS.ProcessEnv = {
+    HOME: path.join(root, "home"),
+    OPENCLAW_HOME: path.join(root, "home"),
+    OPENCLAW_STATE_DIR: path.join(root, "state"),
+    OPENCLAW_CONFIG_PATH: path.join(root, "state/openclaw.json"),
+    OPENCLAW_BUNDLED_PLUGINS_DIR: bundled,
+    OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+    OPENCLAW_DISABLE_BUNDLED_SOURCE_OVERLAYS: "1",
+    VITEST: "true",
+  };
+  const metadataSnapshot = loadPluginMetadataSnapshot({
+    config: cfg,
+    env,
+    workspaceDir,
+    allowCurrent: false,
+    preferPersisted: false,
+  });
+  expect(metadataSnapshot.plugins.map((plugin) => plugin.id).toSorted()).toEqual(
+    fixtures.map((fixture) => fixture.pluginId).toSorted(),
+  );
+  expect(metadataSnapshot.workspaceDir).toBe(workspaceDir);
+  expect(metadataSnapshot.byPluginId.get("workspace-owner")?.origin).toBe("workspace");
+  expect(metadataSnapshot.byPluginId.get("catalog-owner")?.origin).toBe("bundled");
+  expect(metadataSnapshot.diagnostics.filter((diagnostic) => diagnostic.level === "error")).toEqual(
+    [],
+  );
+  const manifestPaths = fixtures.map((fixture) =>
+    path.join(fixture.rootDir, "openclaw.plugin.json"),
+  );
+  return { cfg, env, workspaceDir, metadataSnapshot, fixtures, manifestPaths };
+}
+
+// Count actual filesystem work, including manifest reads through pinned descriptors.
+// All spies call through; a parse-cache hit still opens a file but reads no bytes.
+function observeManifestIo(manifestPaths: string[]) {
+  const manifests = new Set(manifestPaths);
+  const descriptors = new Map<number, string>();
+  const opens: string[] = [];
+  const reads: string[] = [];
+  const originalOpen = fs.openSync;
+  const originalRead = fs.readFileSync;
+  const originalClose = fs.closeSync;
+  const openSpy = vi.spyOn(fs, "openSync").mockImplementation((...args) => {
+    const fd = originalOpen(...args);
+    const file = args[0] instanceof URL ? fileURLToPath(args[0]) : String(args[0]);
+    if (manifests.has(file)) {
+      descriptors.set(fd, file);
+      opens.push(path.basename(path.dirname(file)));
+    }
+    return fd;
+  });
+  const readSpy = vi.spyOn(fs, "readFileSync").mockImplementation((...args) => {
+    const result = originalRead(...args);
+    const file = typeof args[0] === "number" ? descriptors.get(args[0]) : String(args[0]);
+    if (file && manifests.has(file)) {
+      reads.push(path.basename(path.dirname(file)));
+    }
+    return result;
+  });
+  const closeSpy = vi.spyOn(fs, "closeSync").mockImplementation((fd) => {
+    descriptors.delete(fd);
+    return originalClose(fd);
+  });
+  return {
+    opens,
+    reads,
+    stop() {
+      openSpy.mockRestore();
+      readSpy.mockRestore();
+      closeSpy.mockRestore();
+    },
+  };
+}
+
+function withoutManifestIo<T>(fixture: ReturnType<typeof prepareFixture>, run: () => T) {
+  const io = observeManifestIo(fixture.manifestPaths);
+  let output: T;
+  try {
+    output = run();
+  } finally {
+    io.stop();
+  }
+  expect(fixture.fixtures.some(isColdPluginRuntimeLoaded)).toBe(false);
+  expect.soft(io.reads).toEqual([]);
+  expect.soft(io.opens).toEqual([]);
+  return output;
+}
+
+function coverage(fixture: ReturnType<typeof prepareFixture>) {
+  const result = resolveManifestCatalogCoverageForList({
+    ...fixture,
+    providerIds: new Set([
+      " FIXTURE-PROVIDER ",
+      "fixture-alias",
+      "fixture-direct",
+      "fixture-workspace",
+      "fixture-disabled",
+      "missing",
+      " ",
+    ]),
+  });
+  return {
+    owned: [...result.ownedProviderIds].toSorted(),
+    complete: [...result.completeProviderIds].toSorted(),
+  };
+}
+
+const expectedCoverage = {
+  owned: ["fixture-alias", "fixture-direct", "fixture-provider", "fixture-workspace"],
+  complete: ["fixture-alias", "fixture-direct", "fixture-provider"],
+};
+
+describe("model-list prepared manifest snapshot", () => {
+  it("resolves coverage from the prepared snapshot without manifest I/O", () => {
+    const fixture = prepareFixture();
+    expect(withoutManifestIo(fixture, () => coverage(fixture))).toEqual(expectedCoverage);
+  });
+
+  it.each([
+    ["all", loadManifestCatalogRowsForList],
+    ["static", loadStaticManifestCatalogRowsForList],
+  ] as const)("loads %s provider and alias rows without manifest I/O", (_selection, loadRows) => {
+    const fixture = prepareFixture();
+    for (const providerFilter of [
+      " FIXTURE-PROVIDER ",
+      " FIXTURE-ALIAS ",
+      "fixture-direct",
+      "fixture-disabled",
+    ]) {
+      const rows = withoutManifestIo(fixture, () =>
+        loadRows({ ...fixture, providerFilter }).map(({ ref, api, baseUrl }) => ({
+          ref,
+          api,
+          baseUrl,
+        })),
+      );
+      const provider = providerFilter.trim().toLowerCase();
+      expect(rows).toEqual(
+        provider === "fixture-disabled"
+          ? []
+          : [
+              {
+                ref: `${provider}/tiny-model`,
+                api: provider === "fixture-alias" ? "openai-responses" : "openai-completions",
+                baseUrl: `https://${provider === "fixture-alias" ? "alias" : "canonical"}.example.invalid/v1`,
+              },
+            ],
+      );
+    }
+  });
+
+  it.each([
+    { mutation: "change", first: "coverage" },
+    { mutation: "change", first: "alias" },
+    { mutation: "remove", first: "coverage" },
+    { mutation: "remove", first: "alias" },
+  ] as const)(
+    "keeps prepared ownership and rows after $mutation, reading $first first",
+    ({ mutation, first }) => {
+      const fixture = prepareFixture();
+      const owner = fixture.metadataSnapshot.byPluginId.get("catalog-owner");
+      if (!owner) {
+        throw new Error("missing fixture catalog owner");
+      }
+      if (mutation === "remove") {
+        fs.unlinkSync(owner.manifestPath);
+      } else {
+        fs.writeFileSync(
+          owner.manifestPath,
+          JSON.stringify({
+            id: owner.id,
+            configSchema: { type: "object" },
+            providers: [],
+          }),
+        );
+      }
+      for (const surface of first === "coverage" ? ["coverage", "alias"] : ["alias", "coverage"]) {
+        const result = withoutManifestIo(fixture, () =>
+          surface === "coverage"
+            ? coverage(fixture)
+            : loadManifestCatalogRowsForList({ ...fixture, providerFilter: "fixture-alias" }).map(
+                (row) => row.ref,
+              ),
+        );
+        expect
+          .soft(result)
+          .toEqual(surface === "coverage" ? expectedCoverage : ["fixture-alias/tiny-model"]);
+      }
+      const broad = withoutManifestIo(fixture, () =>
+        loadManifestCatalogRowsForList(fixture).map((row) => row.ref),
+      );
+      expect(broad).toEqual([
+        "fixture-direct/tiny-model",
+        "fixture-disabled/tiny-model",
+        "fixture-provider/tiny-model",
+        "fixture-workspace/tiny-model",
+      ]);
+    },
+  );
+
+  it.each<[string, NonNullable<OpenClawConfig["plugins"]>, string, boolean]>([
+    ["global disable", { enabled: false }, "fixture-alias", false],
+    ["denylist", { deny: ["catalog-owner"] }, "fixture-alias", false],
+    ["restrictive allowlist", { allow: ["fixture-direct"] }, "fixture-alias", false],
+    ["allowlisted owner", { allow: ["catalog-owner"] }, "fixture-alias", true],
+    ["entry disable", { entries: { "catalog-owner": { enabled: false } } }, "fixture-alias", false],
+    ["entry enable", { entries: { "catalog-owner": { enabled: true } } }, "fixture-alias", true],
+    ["index-disabled owner", {}, "fixture-disabled", false],
+    [
+      "explicit reenable",
+      { entries: { "disabled-owner": { enabled: true } } },
+      "fixture-disabled",
+      true,
+    ],
+  ])(
+    "applies current config to prepared ownership and rows: %s",
+    (_label, plugins, provider, enabled) => {
+      const fixture = prepareFixture();
+      const params = {
+        ...fixture,
+        cfg: { ...fixture.cfg, plugins: { ...fixture.cfg.plugins, ...plugins } },
+      };
+      withoutManifestIo(fixture, () => {
+        const result = resolveManifestCatalogCoverageForList({
+          ...params,
+          providerIds: new Set([provider]),
+        });
+        expect(result.ownedProviderIds).toEqual(new Set(enabled ? [provider] : []));
+        expect(result.completeProviderIds).toEqual(result.ownedProviderIds);
+        for (const loadRows of [
+          loadManifestCatalogRowsForList,
+          loadStaticManifestCatalogRowsForList,
+        ]) {
+          expect(loadRows({ ...params, providerFilter: provider }).map((row) => row.ref)).toEqual(
+            enabled ? [`${provider}/tiny-model`] : [],
+          );
+        }
+      });
+    },
+  );
+});

--- a/src/commands/models/list.manifest-catalog.test.ts
+++ b/src/commands/models/list.manifest-catalog.test.ts
@@ -109,6 +109,7 @@ describe("loadStaticManifestCatalogRowsForList", () => {
       index,
       manifestRegistry,
       plugins: manifestRegistry.plugins,
+      byPluginId: new Map(manifestRegistry.plugins.map((plugin) => [plugin.id, plugin])),
     });
 
     expect(
@@ -133,6 +134,7 @@ describe("loadStaticManifestCatalogRowsForList", () => {
       index: { plugins: [], diagnostics: [] },
       manifestRegistry,
       plugins: manifestRegistry.plugins,
+      byPluginId: new Map(manifestRegistry.plugins.map((plugin) => [plugin.id, plugin])),
     });
 
     expect(
@@ -152,6 +154,7 @@ describe("loadStaticManifestCatalogRowsForList", () => {
       index: { plugins: [], diagnostics: [] },
       manifestRegistry,
       plugins: manifestRegistry.plugins,
+      byPluginId: new Map(manifestRegistry.plugins.map((plugin) => [plugin.id, plugin])),
     };
 
     expect(
@@ -174,6 +177,7 @@ describe("loadStaticManifestCatalogRowsForList", () => {
       index: { plugins: [], diagnostics: [] },
       manifestRegistry,
       plugins: manifestRegistry.plugins,
+      byPluginId: new Map(manifestRegistry.plugins.map((plugin) => [plugin.id, plugin])),
     };
     mocks.getRemoteModelCatalogProviderOverlay.mockReturnValue({
       models: [{ id: "gpt-refreshed", name: "Refreshed GPT" }],
@@ -201,6 +205,7 @@ describe("loadStaticManifestCatalogRowsForList", () => {
         diagnostics: [],
       },
       plugins: [moonshotPlugin],
+      byPluginId: new Map([[moonshotPlugin.id, moonshotPlugin]]),
     };
 
     expect(
@@ -229,17 +234,20 @@ describe("resolveManifestCatalogCoverageForList", () => {
 
   it("marks only static non-augment owners as complete", async () => {
     const { resolveManifestCatalogCoverageForList } = await import("./list.manifest-catalog.js");
+    const plugins = [
+      anthropicRuntimeAugmentPlugin,
+      moonshotPlugin,
+      openrouterPlugin,
+      openaiRuntimePlugin,
+    ];
     const metadataSnapshot = {
       index: { plugins: [], diagnostics: [] },
       manifestRegistry: {
-        plugins: [
-          anthropicRuntimeAugmentPlugin,
-          moonshotPlugin,
-          openrouterPlugin,
-          openaiRuntimePlugin,
-        ],
+        plugins,
         diagnostics: [],
       },
+      plugins,
+      byPluginId: new Map(plugins.map((plugin) => [plugin.id, plugin])),
     };
 
     const coverage = resolveManifestCatalogCoverageForList({
@@ -267,6 +275,8 @@ describe("resolveManifestCatalogCoverageForList", () => {
         plugins: [externalPlugin],
         diagnostics: [],
       },
+      plugins: [externalPlugin],
+      byPluginId: new Map([[externalPlugin.id, externalPlugin]]),
     };
     mocks.resolvePluginContributionOwners.mockReturnValue(["external-moonshot"]);
     mocks.getPluginRecord.mockReturnValue(undefined);
@@ -289,6 +299,8 @@ describe("resolveManifestCatalogCoverageForList", () => {
         plugins: [openaiRuntimePlugin],
         diagnostics: [],
       },
+      plugins: [openaiRuntimePlugin],
+      byPluginId: new Map([[openaiRuntimePlugin.id, openaiRuntimePlugin]]),
     };
 
     const coverage = resolveManifestCatalogCoverageForList({

--- a/src/commands/models/list.manifest-catalog.ts
+++ b/src/commands/models/list.manifest-catalog.ts
@@ -64,11 +64,11 @@ function resolveConventionModelCatalogPluginIds(params: {
 
 function resolveDeclaredModelCatalogPluginIds(params: {
   cfg: OpenClawConfig;
-  index: PluginRegistrySnapshot;
+  snapshot: PluginMetadataSnapshot;
   providerFilter: string;
 }): readonly string[] {
   return resolvePluginContributionOwners({
-    index: params.index,
+    lookUpTable: params.snapshot,
     config: params.cfg,
     contribution: "modelCatalogProviders",
     matches: params.providerFilter,
@@ -77,19 +77,19 @@ function resolveDeclaredModelCatalogPluginIds(params: {
 
 function resolveModelCatalogPluginIdsForProvider(params: {
   cfg: OpenClawConfig;
-  index: PluginRegistrySnapshot;
+  snapshot: PluginMetadataSnapshot;
   provider: string;
 }): readonly string[] {
   return [
     ...new Set([
       ...resolveConventionModelCatalogPluginIds({
         cfg: params.cfg,
-        index: params.index,
+        index: params.snapshot.index,
         providerFilter: params.provider,
       }),
       ...resolveDeclaredModelCatalogPluginIds({
         cfg: params.cfg,
-        index: params.index,
+        snapshot: params.snapshot,
         providerFilter: params.provider,
       }),
     ]),
@@ -115,9 +115,6 @@ export function resolveManifestCatalogCoverageForList(params: {
       config: params.cfg,
       env: params.env ?? process.env,
     });
-  const pluginsById = new Map(
-    snapshot.manifestRegistry.plugins.map((plugin) => [plugin.id, plugin]),
-  );
   const ownedProviderIds = new Set<string>();
   const completeProviderIds = new Set<string>();
   for (const rawProvider of params.providerIds) {
@@ -127,7 +124,7 @@ export function resolveManifestCatalogCoverageForList(params: {
     }
     const pluginIds = resolveModelCatalogPluginIdsForProvider({
       cfg: params.cfg,
-      index: snapshot.index,
+      snapshot,
       provider,
     });
     if (pluginIds.length === 0) {
@@ -135,7 +132,7 @@ export function resolveManifestCatalogCoverageForList(params: {
     }
     ownedProviderIds.add(provider);
     const complete = pluginIds.every((pluginId) => {
-      const plugin = pluginsById.get(pluginId);
+      const plugin = snapshot.byPluginId.get(pluginId);
       if (!plugin) {
         return false;
       }
@@ -174,7 +171,6 @@ function loadManifestCatalogRowsForListSelection(params: {
       config: params.cfg,
       env: params.env ?? process.env,
     });
-  const index = snapshot.index;
   if (!providerFilter) {
     return planManifestCatalogRowsForPluginIds({
       cfg: params.cfg,
@@ -187,7 +183,7 @@ function loadManifestCatalogRowsForListSelection(params: {
     registry: snapshot.manifestRegistry,
     pluginIds: resolveConventionModelCatalogPluginIds({
       cfg: params.cfg,
-      index,
+      index: snapshot.index,
       providerFilter,
     }),
     providerFilter,
@@ -201,7 +197,7 @@ function loadManifestCatalogRowsForListSelection(params: {
     registry: snapshot.manifestRegistry,
     pluginIds: resolveDeclaredModelCatalogPluginIds({
       cfg: params.cfg,
-      index,
+      snapshot,
       providerFilter,
     }),
     providerFilter,

--- a/src/plugins/plugin-registry.test.ts
+++ b/src/plugins/plugin-registry.test.ts
@@ -5,6 +5,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 // Covers plugin registry assembly, contribution lookup, and reset behavior.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { recordPluginCandidateInstallOwner } from "./candidate-install-owner.js";
 import type { PluginCandidate } from "./discovery.js";
@@ -399,6 +400,30 @@ describe("plugin registry facade", () => {
         matches: "tools",
       }),
     ).toEqual(["demo"]);
+
+    const policies: Array<[OpenClawConfig["plugins"], boolean]> = [
+      [undefined, true],
+      [{ enabled: false }, false],
+      [{ deny: ["demo"] }, false],
+      [{ allow: ["other"] }, false],
+      [{ allow: ["demo"] }, true],
+      [{ entries: { demo: { enabled: false } } }, false],
+      [{ entries: { demo: { enabled: true } } }, true],
+    ];
+    for (const matches of ["demo-alias", (id: string) => id === "demo-alias"]) {
+      for (const [plugins, enabled] of policies) {
+        const params = {
+          lookUpTable,
+          ...(plugins ? { config: { plugins } } : {}),
+          contribution: "modelCatalogProviders" as const,
+          matches,
+        };
+        expect(resolvePluginContributionOwners(params)).toEqual(enabled ? ["demo"] : []);
+        expect(resolvePluginContributionOwners({ ...params, includeDisabled: true })).toEqual([
+          "demo",
+        ]);
+      }
+    }
   });
 
   it("normalizes plugin config ids through registry contribution aliases", () => {


### PR DESCRIPTION
Closes #131517

AI-assisted repair. I reviewed the ownership path, the reproduction, and the resulting behavior.

<details>
<summary>Additional instructions</summary>

This branch is in the upstream repository and remains editable by maintainers.

</details>

## What Problem This Solves

Fixes an issue where users listing models could get provider ownership and alias rows inconsistent with the prepared catalog when a plugin manifest changed or disappeared after metadata preparation. Even unchanged warm lookups unnecessarily reopened manifests: the parse cache avoided content reads, but ownership was still reconstructed separately from the rows.

## Why This Change Was Made

Carry the already prepared metadata snapshot through the model-list ownership helpers into the existing contribution resolver, and use its existing plugin map for completeness checks. This removes the index-only reconstruction path from this flow without adding a cache, fallback, dependency, configuration option, or schema change. The generic resolver remains unchanged and continues to own current enablement filtering.

Best-fix judgment: retain the canonical prepared owner. A direct owner-map read would bypass configuration filtering; a new cache or generic cold-path rewrite would duplicate an existing seam. Production LOC: **+9/-13, net -4**. Tests: **+369/-6, net +363**, including the real-filesystem regression.

## User Impact

Model-list coverage and provider/alias rows remain consistent with the same prepared catalog, including after manifest mutation or removal during the flow. Current allow/deny/enablement behavior, alias transport overrides, convention-first row precedence, static versus runtime completeness, external-plugin handling, and replace mode remain intact. Broad disabled-plugin inventory behavior is unchanged; this repair does not make a new policy decision about inventory versus enabled views.

Release-note surface: `models list` preserves prepared catalog ownership and aliases without redundant manifest reopening.

## Evidence

The original instrumented regression failed **7 tests / 1 pass**, then passed **all 8 unchanged** after the production fix, before test cleanup. The permanent suite covers 15 cases using real discovery, parsing, snapshot preparation, contribution resolution, and row planning. Call-through filesystem spies and throwing runtime fixtures observe the boundary rather than replacing its behavior.

| Fixture operation | Before successful opens / content reads | After |
| --- | ---: | ---: |
| Warm coverage: 6 nonblank providers, 3 enabled plugins | 18 / 0 | 0 / 0 |
| Warm declared-provider or alias rows, either selection | 3 / 0 | 0 / 0 |
| Changed manifest, coverage first | 18 / 1 | 0 / 0 |
| Changed manifest, alias first | 3 / 1 | 0 / 0 |
| Removed manifest, coverage | 12 / 0 | 0 / 0 |
| Removed manifest, alias rows | 2 / 0 | 0 / 0 |
| Broad rows / existing resolver control | 0 / 0 | 0 / 0 |

All 22 post-fix observations have zero subsequent successful manifest opens/content reads and no runtime marker. Changing/removing the manifest retains the original owners and alias rows in both execution orders. These are filesystem API observations, **not** physical-disk, latency, RSS, or CI-memory claims.

Focused sibling proof: **7 files / 88 tests passed**. The changed-file wrapper completed **all 28 selected checks**, including production/core-test typechecks, focused lint, zero-entry dead-export scans, and zero import cycles. No gate bypass, baseline change, or test retry was used for that final validation.

```sh
node scripts/run-vitest.mjs src/commands/models/list.manifest-catalog.snapshot.test.ts --reporter=verbose
node scripts/run-vitest.mjs src/commands/models/list.manifest-catalog.snapshot.test.ts src/commands/models/list.manifest-catalog.test.ts src/commands/models/list.scoped-catalog.test.ts src/model-catalog/manifest-planner.test.ts src/plugins/plugin-registry.test.ts src/plugins/plugin-lookup-table.test.ts src/plugins/plugin-registry-contributions.current-snapshot.test.ts
node scripts/check-changed.mjs -- src/commands/models/list.manifest-catalog.ts src/commands/models/list.manifest-catalog.test.ts src/commands/models/list.manifest-catalog.snapshot.test.ts src/plugins/plugin-registry.test.ts
git diff --check
pnpm build
```

The first local build failed in startup-metadata generation while an overlapping CLI invocation triggered its normal dirty-tree rebuild. The serial `pnpm build` retry passed all stages, including startup metadata, without source edits, limit changes, or bypasses. No ineffective-dynamic-import warnings were reported.

Real isolated dist-backed CLI smoke passed on macOS 27.0 / Node 24.20.0 through the normal `pnpm openclaw` wrapper. The five commands ran serially in one fresh temporary home/state/config/workspace, a minimal environment, no credentials, and hosted catalog refresh disabled only in that temporary config. No VITEST or test-only trust flags were used.

```sh
pnpm openclaw models list --json
pnpm openclaw models list --provider cerebras --json
pnpm openclaw models list --all --provider cerebras --json
pnpm openclaw models list --all --provider z.ai --json
pnpm openclaw models list --all --json
```

Observed: configured view = exactly `cerebras/gpt-oss-120b`; both Cerebras filtered views = the 3 manifest rows; `z.ai` resolves to 6 canonical `zai/*` rows including `zai/glm-5.2`; broad inventory = 267 rows including both providers. Scoped rows were not missing and did not claim authentication. The fresh 15-case regression sanity run also passed.

Independent isolated Codex autoreview of the frozen patch and supplied owner/caller contracts completed successfully with no P0 findings. Direct source inspection covered the model-list entry point and scoped caller, manifest catalog helper/planner, metadata snapshot owner, contribution resolver and its enablement boundary. Current `main` has no intervening edits in those critical production owners at the pre-publication check.

History: the filtered index-only handoff is present in stable `v2026.7.1-2` by source inspection, not stable execution. The true introduction predates the available shallow boundary and is unknown. Coverage carried it forward in commit `5ae401d9084f76ef4908b584bfff44962fa271f4`. Related: #112752 scoped provider-filtered discovery; it is already merged and does not repair this snapshot handoff.

Proof limits: the fixture proves between-snapshot mutation/removal and the no-runtime boundary. The isolated built CLI proves ordinary operator-visible listing, not an authenticated provider call, restart, cross-platform run, or installed-package test. Existing tests cover external owners/runtime augmentation/replace behavior, including mocked sibling cases. Follow-up policy question, intentionally unchanged: unfiltered disabled inventory versus enabled provider-filtered views.
