### PR TITLE
fix(auth): keep explicit-root operations isolated through activation and rollback

### DIFF
--- a/docs/auth-credential-semantics.md
+++ b/docs/auth-credential-semantics.md
@@ -61,6 +61,8 @@ Non-portable profiles remain available through the shared read-through base unle
 
 `openclaw agent exec` preserves the original shared-store root when switching to temporary run state. Its bounded credential scope reads portable `api_key` and `token` profiles from that shared store without persisting copies; the configured agent's local profiles still win. Shared OAuth profiles are excluded from this temporary scope, even with `copyToAgents: true`, so the run does not acquire another refresh owner. `--auth-env-only` disables stored credential access entirely.
 
+Auth writes that explicitly select a state directory, including isolated QA staging, use that directory's shared store for ownership and OAuth deduplication. Their runtime publication and rollback retain the same owner; another process-local state root is not an inherited base. An unrelated outer database may be older, newer, or unreadable without blocking an isolated write, but an unreadable or newer database in the selected target still fails closed. Writes without an explicit state directory retain the normal ambient state and agent-directory configuration.
+
 ## Config-only auth routes
 
 `auth.profiles` entries with `mode: "aws-sdk"` are routing metadata, not stored credentials. They are valid when the target provider uses `models.providers.<id>.auth: "aws-sdk"`, the route the plugin-owned Amazon Bedrock setup writes. These profile ids may appear in `auth.order` and session overrides even when no matching entry exists in the credential store.

--- a/extensions/qa-lab/src/providers/shared/auth-store.test.ts
+++ b/extensions/qa-lab/src/providers/shared/auth-store.test.ts
@@ -14,6 +14,7 @@ import {
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTempDirHarness } from "../../temp-dir.test-helper.js";
 import { readQaAuthProfiles, writeQaAuthProfiles } from "./auth-store.js";
+import { stageQaMockAuthProfiles } from "./mock-auth.js";
 
 const tempDirs = createTempDirHarness();
 
@@ -84,7 +85,7 @@ describe("QA auth profile store", () => {
   });
 
   it.each(["future", "invalid"] as const)(
-    "stages concurrent isolated profiles without reading %s outer state",
+    "stages concurrent isolated profiles and config without reading %s outer state",
     async (outerKind) => {
       const hostStateDir = await tempDirs.makeTempDir("openclaw-qa-auth-unreadable-host-");
       const hostDatabasePath = path.join(hostStateDir, "state", "openclaw.sqlite");
@@ -104,25 +105,31 @@ describe("QA auth profile store", () => {
       vi.stubEnv("OPENCLAW_STATE_DIR", hostStateDir);
       vi.stubEnv("OPENCLAW_AGENT_DIR", path.join(hostStateDir, "relocated-agent"));
 
-      await Promise.all(
+      const configs = await Promise.all(
         qaRoots.map((stateDir, index) =>
-          writeQaAuthProfiles({
-            agentId: "qa",
+          stageQaMockAuthProfiles({
+            cfg: {},
+            agentIds: ["qa"],
             stateDir,
-            profiles: {
-              [`qa-${index}`]: {
-                type: "api_key",
-                provider: "openai",
-                key: `qa-placeholder-${index}`,
-              },
-            },
+            providers: [index === 0 ? "openai" : "anthropic"],
           }),
         ),
       );
 
       for (const [index, stateDir] of qaRoots.entries()) {
+        const provider = index === 0 ? "openai" : "anthropic";
+        const profileId = `qa-mock-${provider}`;
         const store = readQaAuthProfiles(path.join(stateDir, "agents", "qa", "agent"));
-        expect(Object.keys(store.profiles)).toEqual([`qa-${index}`]);
+        expect(Object.keys(store.profiles)).toEqual([profileId]);
+        expect(configs[index]?.auth).toEqual({
+          profiles: {
+            [profileId]: {
+              provider,
+              mode: "api_key",
+              displayName: `QA mock ${provider} credential`,
+            },
+          },
+        });
       }
       expect(await fs.readFile(hostDatabasePath)).toEqual(hostBefore);
       expect(process.env.OPENCLAW_STATE_DIR).toBe(hostStateDir);

--- a/extensions/qa-lab/src/providers/shared/auth-store.test.ts
+++ b/extensions/qa-lab/src/providers/shared/auth-store.test.ts
@@ -83,6 +83,84 @@ describe("QA auth profile store", () => {
     });
   });
 
+  it.each(["future", "invalid"] as const)(
+    "stages concurrent isolated profiles without reading %s outer state",
+    async (outerKind) => {
+      const hostStateDir = await tempDirs.makeTempDir("openclaw-qa-auth-unreadable-host-");
+      const hostDatabasePath = path.join(hostStateDir, "state", "openclaw.sqlite");
+      await fs.mkdir(path.dirname(hostDatabasePath), { recursive: true });
+      if (outerKind === "future") {
+        const database = new DatabaseSync(hostDatabasePath);
+        database.exec("PRAGMA user_version = 999");
+        database.close();
+      } else {
+        await fs.writeFile(hostDatabasePath, "not a SQLite database");
+      }
+      const hostBefore = await fs.readFile(hostDatabasePath);
+      const qaRoots = await Promise.all([
+        tempDirs.makeTempDir("openclaw-qa-auth-first-"),
+        tempDirs.makeTempDir("openclaw-qa-auth-second-"),
+      ]);
+      vi.stubEnv("OPENCLAW_STATE_DIR", hostStateDir);
+      vi.stubEnv("OPENCLAW_AGENT_DIR", path.join(hostStateDir, "relocated-agent"));
+
+      await Promise.all(
+        qaRoots.map((stateDir, index) =>
+          writeQaAuthProfiles({
+            agentId: "qa",
+            stateDir,
+            profiles: {
+              [`qa-${index}`]: {
+                type: "api_key",
+                provider: "openai",
+                key: `qa-placeholder-${index}`,
+              },
+            },
+          }),
+        ),
+      );
+
+      for (const [index, stateDir] of qaRoots.entries()) {
+        const store = readQaAuthProfiles(path.join(stateDir, "agents", "qa", "agent"));
+        expect(Object.keys(store.profiles)).toEqual([`qa-${index}`]);
+      }
+      expect(await fs.readFile(hostDatabasePath)).toEqual(hostBefore);
+      expect(process.env.OPENCLAW_STATE_DIR).toBe(hostStateDir);
+      expect(process.env.OPENCLAW_AGENT_DIR).toBe(path.join(hostStateDir, "relocated-agent"));
+    },
+  );
+
+  it.each(["future", "invalid"] as const)(
+    "still refuses an explicit %s target auth database",
+    async (targetKind) => {
+      const { agentDir, agentId, stateDir } = await createQaAuthState();
+      await fs.mkdir(agentDir, { recursive: true });
+      const databasePath = path.join(agentDir, "openclaw-agent.sqlite");
+      if (targetKind === "future") {
+        const database = new DatabaseSync(databasePath);
+        database.exec("PRAGMA user_version = 999");
+        database.close();
+      } else {
+        await fs.writeFile(databasePath, "not a SQLite database");
+      }
+      const before = await fs.readFile(databasePath);
+      await expect(
+        writeQaAuthProfiles({
+          agentId,
+          stateDir,
+          profiles: {
+            "qa-mock-openai": {
+              type: "api_key",
+              provider: "openai",
+              key: "qa-mock-not-a-real-key",
+            },
+          },
+        }),
+      ).rejects.toThrow("unreadable");
+      expect(await fs.readFile(databasePath)).toEqual(before);
+    },
+  );
+
   it("writes new auth profiles to SQLite without creating legacy JSON", async () => {
     const { agentDir, agentId, stateDir } = await createQaAuthState();
 

--- a/extensions/qa-lab/src/providers/shared/mock-auth.ts
+++ b/extensions/qa-lab/src/providers/shared/mock-auth.ts
@@ -34,7 +34,7 @@ export function applyQaMockAuthProfileConfig(params: {
  * In mock provider modes the qa suite runs against an embedded mock server
  * instead of a real provider API. The mock does not validate credentials, but
  * the agent auth layer still needs a matching `api_key` auth profile in
- * `auth-profiles.json` before it will route the request through
+ * the canonical SQLite auth store before it will route the request through
  * `providerBaseUrl`. Without this staging step, every scenario fails with
  * `FailoverError: No API key found for provider "openai"` before the mock
  * server ever sees a request.

--- a/src/agents/auth-profiles/legacy-source-diagnostic.ts
+++ b/src/agents/auth-profiles/legacy-source-diagnostic.ts
@@ -1,14 +1,20 @@
+import fs from "node:fs";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { shortenHomePath } from "../../utils.js";
 import {
   listLegacyAuthProfileSources,
+  resolveLegacyAuthProfileSourceCandidates,
   type LegacyAuthProfileSource,
   type LegacyAuthProfileSourceKind,
 } from "./legacy-source-files.js";
 import { resolveSharedAuthStorePath } from "./path-resolve.js";
 import { resolveSharedMainAuthAgentDir } from "./shared-main-dir.js";
-import { inspectPersistedAuthProfileStoreRaw, resolveAuthProfileDatabasePath } from "./sqlite.js";
+import {
+  inspectPersistedAuthProfileStoreRaw,
+  inspectPersistedSharedAuthProfileStoreRaw,
+  resolveAuthProfileDatabasePath,
+} from "./sqlite.js";
 
 export {
   listLegacyAuthProfileArchives,
@@ -38,10 +44,13 @@ export function hasLegacyAuthProfileCredentialSource(agentDir?: string): boolean
  * has not archived yet, not unmigrated credentials: failing runtime closed there
  * would strand a working store over a file nothing reads.
  */
-function hasMigratedAuthProfileCredentials(agentDir?: string): boolean {
+function hasMigratedAuthProfileCredentials(agentDir?: string, env?: NodeJS.ProcessEnv): boolean {
   let inspection: ReturnType<typeof inspectPersistedAuthProfileStoreRaw>;
   try {
-    inspection = inspectPersistedAuthProfileStoreRaw(agentDir);
+    inspection =
+      !agentDir && env
+        ? inspectPersistedSharedAuthProfileStoreRaw(env)
+        : inspectPersistedAuthProfileStoreRaw(agentDir);
   } catch {
     // An unreadable store is handled by its own canonical error; treat it as
     // "cannot serve credentials" so the legacy source stays fail-closed.
@@ -105,8 +114,15 @@ export class AuthProfileMigrationRequiredError extends Error {
   readonly ownerId: string;
   readonly sourceKinds: LegacyAuthProfileSourceKind[];
 
-  constructor(params: { agentDir?: string; sources: readonly LegacyAuthProfileSource[] }) {
-    const ownerId = shortenHomePath(resolveAuthProfileOwnerPath(params.agentDir));
+  constructor(params: {
+    databasePath?: string;
+    agentDir?: string;
+    env?: NodeJS.ProcessEnv;
+    sources: readonly LegacyAuthProfileSource[];
+  }) {
+    const ownerId = shortenHomePath(
+      params.databasePath ?? resolveAuthProfileOwnerPath(params.agentDir, params.env),
+    );
     const sourceKinds = [...new Set(params.sources.map((source) => source.kind))].toSorted();
     super(
       `Auth profile store ${ownerId} requires legacy credential migration; run ${AUTH_PROFILE_MIGRATION_COMMAND}.`,
@@ -121,9 +137,9 @@ export class AuthProfileStoreUnreadableError extends Error {
   readonly code = "AUTH_PROFILE_STORE_UNREADABLE" as const;
   readonly action = AUTH_PROFILE_MIGRATION_COMMAND;
 
-  constructor(agentDir?: string, env?: NodeJS.ProcessEnv) {
+  constructor(databasePath: string) {
     super(
-      `Auth profile store ${shortenHomePath(resolveAuthProfileOwnerPath(agentDir, env))} is unreadable; run ${AUTH_PROFILE_MIGRATION_COMMAND}.`,
+      `Auth profile store ${shortenHomePath(databasePath)} is unreadable; run ${AUTH_PROFILE_MIGRATION_COMMAND}.`,
     );
     this.name = "AuthProfileStoreUnreadableError";
   }
@@ -133,13 +149,16 @@ const migrationRequiredByDatabase = new Map<string, AuthProfileMigrationRequired
 const warnedLegacySourceDatabases = new Set<string>();
 
 export function warnLegacyAuthProfileSourcesIgnored(params: {
+  databasePath?: string;
   agentDir?: string;
+  env?: NodeJS.ProcessEnv;
   sources: readonly LegacyAuthProfileSource[];
 }): void {
   if (params.sources.length === 0) {
     return;
   }
-  const databasePath = resolveAuthProfileOwnerPath(params.agentDir);
+  const databasePath =
+    params.databasePath ?? resolveAuthProfileOwnerPath(params.agentDir, params.env);
   if (warnedLegacySourceDatabases.has(databasePath)) {
     return;
   }
@@ -155,39 +174,64 @@ export function warnLegacyAuthProfileSourcesIgnored(params: {
 export function markAuthProfileMigrationRequired(
   agentDir: string | undefined,
   error: AuthProfileMigrationRequiredError,
+  env?: NodeJS.ProcessEnv,
 ): void {
-  const databasePath = resolveAuthProfileOwnerPath(agentDir);
+  const databasePath = resolveAuthProfileOwnerPath(agentDir, env);
   migrationRequiredByDatabase.set(databasePath, error);
 }
 
-export function clearAuthProfileMigrationRequired(agentDir?: string): void {
-  const databasePath = resolveAuthProfileOwnerPath(agentDir);
+export function clearAuthProfileMigrationRequired(
+  agentDir?: string,
+  env?: NodeJS.ProcessEnv,
+): void {
+  const databasePath = resolveAuthProfileOwnerPath(agentDir, env);
   migrationRequiredByDatabase.delete(databasePath);
 }
 
-export function assertAuthProfileMigrationReady(agentDir?: string): void {
-  const databasePath = resolveAuthProfileOwnerPath(agentDir);
+/** Publication must honor a recorded refusal without rediscovering an ambient owner. */
+export function assertAuthProfileMigrationStateAtDatabasePath(databasePath: string): void {
   const error = migrationRequiredByDatabase.get(databasePath);
   if (error) {
     // The activated secrets snapshot for this owner is empty. Only an explicit
     // lifecycle clear/reload may remove the error and publish migrated SQLite rows.
     throw error;
   }
+}
+
+export function assertAuthProfileMigrationCandidates(params: {
+  databasePath: string;
+  candidates: readonly LegacyAuthProfileSource[];
+  hasCredentials: () => boolean;
+}): void {
+  assertAuthProfileMigrationStateAtDatabasePath(params.databasePath);
   // Older shipped processes and restores can recreate these three fixed files
   // after startup, so this credential boundary deliberately rechecks their names.
-  const sources = listLegacyAuthProfileSources({ agentDir }).filter(isCredentialSource);
+  const sources = params.candidates.filter(
+    (source) => isCredentialSource(source) && fs.existsSync(source.path),
+  );
   if (sources.length === 0) {
     return;
   }
   // The store read only happens once a retired file actually exists, so the
   // healthy majority keeps the plain name check on this hot path.
-  if (hasMigratedAuthProfileCredentials(agentDir)) {
-    warnLegacyAuthProfileSourcesIgnored({ agentDir, sources });
+  if (params.hasCredentials()) {
+    warnLegacyAuthProfileSourcesIgnored({ databasePath: params.databasePath, sources });
     return;
   }
-  const migrationError = new AuthProfileMigrationRequiredError({ agentDir, sources });
-  markAuthProfileMigrationRequired(agentDir, migrationError);
+  const migrationError = new AuthProfileMigrationRequiredError({
+    databasePath: params.databasePath,
+    sources,
+  });
+  migrationRequiredByDatabase.set(params.databasePath, migrationError);
   throw migrationError;
+}
+
+export function assertAuthProfileMigrationReady(agentDir?: string, env?: NodeJS.ProcessEnv): void {
+  assertAuthProfileMigrationCandidates({
+    databasePath: resolveAuthProfileOwnerPath(agentDir, env),
+    candidates: resolveLegacyAuthProfileSourceCandidates({ agentDir, env }),
+    hasCredentials: () => hasMigratedAuthProfileCredentials(agentDir, env),
+  });
 }
 
 export function clearAuthProfileMigrationDiagnostics(): void {

--- a/src/agents/auth-profiles/legacy-source-files.ts
+++ b/src/agents/auth-profiles/legacy-source-files.ts
@@ -26,8 +26,8 @@ function resolveLegacySourceAgentDir(
   return agentDir ? resolveUserPath(agentDir) : resolveSharedMainAuthAgentDir(env);
 }
 
-/** Detects retired auth files by name only; runtime code must never read their contents. */
-export function listLegacyAuthProfileSources(params: {
+/** Capture the fixed legacy candidates before the producer's environment can change. */
+export function resolveLegacyAuthProfileSourceCandidates(params: {
   agentDir?: string;
   env?: NodeJS.ProcessEnv;
 }): LegacyAuthProfileSource[] {
@@ -41,7 +41,17 @@ export function listLegacyAuthProfileSources(params: {
   if (path.resolve(agentDir) === path.resolve(sharedMainDir)) {
     candidates.push({ kind: "legacy-oauth", path: resolveLegacyOAuthPath(params.env) });
   }
-  return candidates.filter((candidate) => fs.existsSync(candidate.path));
+  return candidates;
+}
+
+/** Detects retired auth files by name only; runtime code must never read their contents. */
+export function listLegacyAuthProfileSources(params: {
+  agentDir?: string;
+  env?: NodeJS.ProcessEnv;
+}): LegacyAuthProfileSource[] {
+  return resolveLegacyAuthProfileSourceCandidates(params).filter((candidate) =>
+    fs.existsSync(candidate.path),
+  );
 }
 
 export function listLegacyAuthProfileArchives(params: {

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -43,7 +43,7 @@ import { suggestOAuthProfileIdForLegacyDefault } from "./repair.js";
 import {
   getRuntimeAuthProfileStoreSnapshotCore,
   hasRuntimeAuthProfileStoreSnapshot,
-  setRuntimeAuthProfileStoreSnapshot,
+  updateRuntimeAuthProfileStoreSnapshot,
 } from "./runtime-snapshots.js";
 import {
   loadAuthProfileStoreForSecretsRuntime,
@@ -543,7 +543,7 @@ export async function resolveApiKeyForProfile(
           if (Object.keys(snapshot.lastGood).length === 0) {
             snapshot.lastGood = undefined;
           }
-          setRuntimeAuthProfileStoreSnapshot(snapshot, params.agentDir);
+          updateRuntimeAuthProfileStoreSnapshot(snapshot, params.agentDir);
         }
       }
       if (clearedLastGood) {

--- a/src/agents/auth-profiles/path-resolve.ts
+++ b/src/agents/auth-profiles/path-resolve.ts
@@ -14,6 +14,18 @@ const SHARED_AUTH_STORE_OWNERSHIP_CACHE_LIMIT = 256;
 
 export type SharedAuthStoreOwnership = { location: "legacy-main" } | { location: "state-db" };
 
+/** Pure producer facts; capturing a supplied runtime snapshot must not open SQLite. */
+export type AuthProfileOwnerScope = { stateDir: string; sharedMainDir: string };
+
+export function captureAuthProfileOwnerScope(
+  env: NodeJS.ProcessEnv = process.env,
+): AuthProfileOwnerScope {
+  return {
+    stateDir: path.resolve(resolveStateDir(env)),
+    sharedMainDir: path.resolve(resolveSharedMainAuthAgentDir(env)),
+  };
+}
+
 // Explicit env callers can address another state root in the same process.
 // Pin each root once so later row changes require an owner-controlled restart.
 const sharedAuthStoreOwnershipByDatabasePath = new Map<string, SharedAuthStoreOwnership>();

--- a/src/agents/auth-profiles/persisted.ts
+++ b/src/agents/auth-profiles/persisted.ts
@@ -12,6 +12,7 @@ import { asBoolean } from "../../utils/boolean.js";
 import { AUTH_STORE_VERSION, authProfilesLog } from "./constants.js";
 import { hasUsableOAuthCredential } from "./credential-state.js";
 import { isLegacyOAuthRef } from "./legacy-oauth-ref.js";
+import { AuthProfileStoreUnreadableError } from "./legacy-source-diagnostic.js";
 import {
   hasOAuthIdentity,
   isSafeToAdoptMainStoreOAuthIdentity,
@@ -23,16 +24,14 @@ import {
   setRuntimeExternalCliProfileIds,
 } from "./runtime-external-profile-references.js";
 import {
+  inspectAuthProfileJsonCellReadOnly,
+  readPersistedAuthProfileStateRaw,
   readPersistedAuthProfileStoreRaw,
   readPersistedSharedAuthProfileStateRaw,
   readPersistedSharedAuthProfileStoreRaw,
   type AuthProfileDatabase,
 } from "./sqlite.js";
-import {
-  coerceAuthProfileState,
-  loadPersistedAuthProfileState,
-  mergeAuthProfileState,
-} from "./state.js";
+import { coerceAuthProfileState, mergeAuthProfileState } from "./state.js";
 import type {
   AuthProfileCredential,
   AuthProfileSecretsStore,
@@ -790,42 +789,61 @@ export function applyLegacyAuthStore(store: AuthProfileStore, legacy: LegacyAuth
   }
 }
 
-/** Loads the persisted auth profile store and merges runtime state. */
-export function loadPersistedAuthProfileStore(
-  agentDir?: string,
-  options?: LoadPersistedAuthProfileStoreOptions,
+function mergePersistedAuthProfileState(
+  raw: unknown,
+  readState: () => unknown,
 ): AuthProfileStore | null {
-  const raw = readPersistedAuthProfileStoreRaw(agentDir, options?.database);
-  const store = coercePersistedAuthProfileStore(raw);
-  if (!store) {
-    return null;
-  }
-  const merged = {
-    ...store,
-    ...mergeAuthProfileState(
-      coerceAuthProfileState(raw),
-      loadPersistedAuthProfileState(agentDir, options?.database),
-    ),
-  };
-  return merged;
-}
-
-/** Load the shared auth store from an explicit state root. */
-export function loadPersistedSharedAuthProfileStore(
-  env: NodeJS.ProcessEnv,
-): AuthProfileStore | null {
-  const raw = readPersistedSharedAuthProfileStoreRaw(env);
   const store = coercePersistedAuthProfileStore(raw);
   if (!store) {
     return null;
   }
   return {
     ...store,
-    ...mergeAuthProfileState(
-      coerceAuthProfileState(raw),
-      coerceAuthProfileState(readPersistedSharedAuthProfileStateRaw(env)),
-    ),
+    ...mergeAuthProfileState(coerceAuthProfileState(raw), coerceAuthProfileState(readState())),
   };
+}
+
+/** Loads the persisted auth profile store and merges runtime state. */
+export function loadPersistedAuthProfileStore(
+  agentDir?: string,
+  options?: LoadPersistedAuthProfileStoreOptions,
+): AuthProfileStore | null {
+  return mergePersistedAuthProfileState(
+    readPersistedAuthProfileStoreRaw(agentDir, options?.database),
+    () => readPersistedAuthProfileStateRaw(agentDir, options?.database),
+  );
+}
+
+/** Read an already selected owner without rediscovering an environment or opening a writer. */
+export function loadPersistedAuthProfileStoreAtDatabasePath(
+  databasePath: string,
+  kind: "agent" | "shared-state",
+): AuthProfileStore | null {
+  const target = { path: databasePath, kind };
+  const credentials = inspectAuthProfileJsonCellReadOnly(target, "store");
+  if (credentials.status === "missing") {
+    return null;
+  }
+  if (credentials.status === "unreadable") {
+    throw new AuthProfileStoreUnreadableError(databasePath);
+  }
+  const state = inspectAuthProfileJsonCellReadOnly(target, "state");
+  const store = mergePersistedAuthProfileState(credentials.raw, () =>
+    state.status === "readable" ? state.raw : null,
+  );
+  if (!store) {
+    throw new AuthProfileStoreUnreadableError(databasePath);
+  }
+  return store;
+}
+
+/** Load the shared auth store from an explicit state root. */
+export function loadPersistedSharedAuthProfileStore(
+  env: NodeJS.ProcessEnv,
+): AuthProfileStore | null {
+  return mergePersistedAuthProfileState(readPersistedSharedAuthProfileStoreRaw(env), () =>
+    readPersistedSharedAuthProfileStateRaw(env),
+  );
 }
 
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/auth-profiles/profiles.test.ts
+++ b/src/agents/auth-profiles/profiles.test.ts
@@ -37,7 +37,7 @@ import {
   getRuntimeAuthProfileStoreCredentialMutationToken,
   getRuntimeAuthProfileStoreCredentialsRevision,
   getRuntimeAuthProfileStoreStateMutationToken,
-  listRuntimeAuthProfileStoreSnapshots,
+  listOwnedRuntimeAuthProfileStoreSnapshots,
   replaceRuntimeAuthProfileStoreSnapshots,
 } from "./runtime-snapshots.js";
 import {
@@ -1004,7 +1004,7 @@ describe("promoteAuthProfileInOrder", () => {
         });
 
         expect(committed.publishRuntimeSnapshots()).toBe(true);
-        expect(listRuntimeAuthProfileStoreSnapshots()).toEqual([
+        expect(listOwnedRuntimeAuthProfileStoreSnapshots()).toEqual([
           expect.objectContaining({
             databasePath,
             store: expect.objectContaining({
@@ -1017,7 +1017,7 @@ describe("promoteAuthProfileInOrder", () => {
 
         restoreAuthProfileStorePersistenceSnapshot(snapshot, committed.owned);
 
-        expect(listRuntimeAuthProfileStoreSnapshots()).toEqual([
+        expect(listOwnedRuntimeAuthProfileStoreSnapshots()).toEqual([
           expect.objectContaining({
             databasePath,
             store: expect.objectContaining({

--- a/src/agents/auth-profiles/runtime-materializations.ts
+++ b/src/agents/auth-profiles/runtime-materializations.ts
@@ -118,10 +118,6 @@ export function getPreparedRuntimeAuthMaterializations(
   return materializations.get(ownerKey(agentDir)) ?? [];
 }
 
-export function clearRuntimeAuthMaterializations(agentDir?: string): void {
-  materializations.delete(ownerKey(agentDir));
-}
-
 /** Clears materializations for an already resolved canonical auth database owner. */
 export function clearRuntimeAuthMaterializationsAtDatabasePath(databasePath: string): void {
   materializations.delete(databasePath);

--- a/src/agents/auth-profiles/runtime-snapshot-owner.ts
+++ b/src/agents/auth-profiles/runtime-snapshot-owner.ts
@@ -1,0 +1,302 @@
+/** Canonical owner identity and nonpublishing auth snapshot composition. */
+import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
+import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
+import { cloneAuthProfileStore } from "./clone.js";
+import { AUTH_STORE_VERSION } from "./constants.js";
+import {
+  assertAuthProfileMigrationCandidates,
+  assertAuthProfileMigrationStateAtDatabasePath,
+} from "./legacy-source-diagnostic.js";
+import {
+  resolveLegacyAuthProfileSourceCandidates,
+  type LegacyAuthProfileSource,
+} from "./legacy-source-files.js";
+import { shouldUseMainOwnerForLocalOAuthCredential } from "./ownership.js";
+import {
+  resolveSharedAuthStoreOwnership,
+  resolveSharedAuthStorePath,
+  type AuthProfileOwnerScope,
+} from "./path-resolve.js";
+import {
+  loadPersistedAuthProfileStoreAtDatabasePath,
+  mergeAuthProfileStores,
+} from "./persisted.js";
+import { setRuntimeExternalCliProfileIds } from "./runtime-external-profile-references.js";
+import { resolveAuthProfileDatabasePath, type AuthProfileStoreOwner } from "./sqlite.js";
+import type { AuthProfileStore, RuntimeAuthProfileStore } from "./types.js";
+
+export function createEmptyAuthProfileStore(): AuthProfileStore {
+  return { version: AUTH_STORE_VERSION, profiles: {} };
+}
+
+export function stripRuntimeExternalProfileMetadata(store: AuthProfileStore): AuthProfileStore {
+  const stripped = { ...store };
+  delete stripped.runtimeExternalProfileIds;
+  delete stripped.runtimeExternalProfileIdsAuthoritative;
+  setRuntimeExternalCliProfileIds(stripped, []);
+  return stripped;
+}
+
+export function markRuntimePersistedProfiles(
+  store: AuthProfileStore,
+  persistedStore: AuthProfileStore = store,
+): AuthProfileStore {
+  const profileIds = Object.entries(persistedStore.profiles)
+    .flatMap(([profileId, credential]) =>
+      isDeepStrictEqual(store.profiles[profileId], credential) ? [profileId] : [],
+    )
+    .toSorted();
+  return {
+    ...store,
+    runtimePersistedProfileIds: profileIds.length > 0 ? profileIds : undefined,
+  };
+}
+
+export function setRuntimeLocalProfileMetadata(
+  store: AuthProfileStore,
+  localProfileIds: Iterable<string>,
+  runtimeInheritsMainState = false,
+): RuntimeAuthProfileStore {
+  return {
+    ...store,
+    runtimeLocalProfileIds: [...new Set(localProfileIds)].toSorted(),
+    ...(runtimeInheritsMainState ? { runtimeInheritsMainState: true } : {}),
+  };
+}
+
+export function runtimeStoreInheritsMainState(
+  store: AuthProfileStore,
+  localStore: AuthProfileStore,
+): boolean {
+  const state = ({ order, lastGood, usageStats }: AuthProfileStore) => ({
+    order,
+    lastGood,
+    usageStats,
+  });
+  return !isDeepStrictEqual(state(store), state(localStore));
+}
+
+export function listRuntimeLocalProfileIds(
+  store: RuntimeAuthProfileStore,
+  mainStore?: AuthProfileStore,
+): string[] {
+  if (store.runtimeLocalProfileIds) {
+    return store.runtimeLocalProfileIds;
+  }
+  return Object.entries(store.profiles).flatMap(([profileId, credential]) =>
+    mainStore &&
+    shouldUseMainOwnerForLocalOAuthCredential({
+      local: credential,
+      main: mainStore.profiles[profileId],
+    })
+      ? []
+      : [profileId],
+  );
+}
+
+export function mergeLocalAuthProfileStoreWithInheritedStore(
+  localStore: AuthProfileStore,
+  inheritedStore: AuthProfileStore,
+): RuntimeAuthProfileStore {
+  // Preserve local ownership so later publication never retains another owner's inherited rows.
+  const merged = mergeAuthProfileStores(inheritedStore, localStore, {
+    preserveBaseRuntimeExternalProfiles: true,
+  });
+  return setRuntimeLocalProfileMetadata(
+    stripRuntimeExternalProfileMetadata(merged),
+    listRuntimeLocalProfileIds(localStore, inheritedStore),
+    runtimeStoreInheritsMainState(merged, localStore),
+  );
+}
+
+/** Compose the selected durable owner without publishing or discovering an ambient environment. */
+export function loadRuntimeAuthProfileOwnerSnapshot(
+  owner: AuthProfileStoreOwner,
+  options: {
+    candidates?: RuntimeAuthProfileLegacyCandidates;
+    inheritedStore?: AuthProfileStore;
+  } = {},
+): RuntimeAuthProfileStore {
+  // Only lifecycle clear owns a recorded migration refusal; a committed write cannot bypass it.
+  assertAuthProfileMigrationStateAtDatabasePath(owner.databasePath);
+  assertAuthProfileMigrationStateAtDatabasePath(owner.sharedDatabasePath);
+  const isShared = owner.databasePath === owner.sharedDatabasePath;
+  const sharedKind = owner.location === "state-db" ? "shared-state" : "agent";
+  const sharedStore = isShared
+    ? undefined
+    : (options.inheritedStore ??
+      markRuntimePersistedProfiles(
+        loadPersistedAuthProfileStoreAtDatabasePath(owner.sharedDatabasePath, sharedKind) ??
+          createEmptyAuthProfileStore(),
+      ));
+  if (options.candidates && sharedStore) {
+    // Check committed shared facts before a fallible local read can enter publication recovery.
+    assertAuthProfileMigrationCandidates({
+      databasePath: owner.sharedDatabasePath,
+      candidates: options.candidates.shared,
+      hasCredentials: () => Object.keys(sharedStore.profiles).length > 0,
+    });
+  }
+  const localStore = markRuntimePersistedProfiles(
+    loadPersistedAuthProfileStoreAtDatabasePath(
+      owner.databasePath,
+      isShared ? sharedKind : "agent",
+    ) ?? createEmptyAuthProfileStore(),
+  );
+  if (options.candidates) {
+    assertAuthProfileMigrationCandidates({
+      databasePath: owner.databasePath,
+      candidates: isShared ? options.candidates.shared : options.candidates.local,
+      hasCredentials: () => Object.keys(localStore.profiles).length > 0,
+    });
+  }
+  return sharedStore
+    ? mergeLocalAuthProfileStoreWithInheritedStore(localStore, sharedStore)
+    : setRuntimeLocalProfileMetadata(localStore, listRuntimeLocalProfileIds(localStore));
+}
+
+export type RuntimeAuthProfileLegacyCandidates = {
+  local: LegacyAuthProfileSource[];
+  shared: LegacyAuthProfileSource[];
+};
+
+/** Diagnostic source facts never participate in canonical ownership decisions. */
+export function captureRuntimeAuthProfileLegacyCandidates(
+  agentDir?: string,
+  env: NodeJS.ProcessEnv = process.env,
+): RuntimeAuthProfileLegacyCandidates {
+  return {
+    local: resolveLegacyAuthProfileSourceCandidates({ agentDir, env }),
+    shared: resolveLegacyAuthProfileSourceCandidates({ env }),
+  };
+}
+
+export function cloneRuntimeAuthProfileLegacyCandidates(
+  candidates?: RuntimeAuthProfileLegacyCandidates,
+): RuntimeAuthProfileLegacyCandidates | undefined {
+  return (
+    candidates && {
+      local: candidates.local.map((source) => ({ ...source })),
+      shared: candidates.shared.map((source) => ({ ...source })),
+    }
+  );
+}
+
+/** Core lifecycle receipt; the public SDK snapshot shape intentionally stays unchanged. */
+export type OwnedRuntimeAuthProfileStoreSnapshotEntry = {
+  databasePath: string;
+  agentDir: string;
+  store: RuntimeAuthProfileStore;
+  owner: RuntimeAuthSharedOwner;
+  legacyCandidates?: RuntimeAuthProfileLegacyCandidates;
+};
+
+export function prepareRuntimeAuthProfileStoreSnapshots(
+  entries: Array<{ databasePath?: string; agentDir?: string; store: AuthProfileStore }>,
+  env: NodeJS.ProcessEnv = process.env,
+): OwnedRuntimeAuthProfileStoreSnapshotEntry[] {
+  if (entries.length === 0) {
+    return [];
+  }
+  const owner = captureRuntimeAuthSharedOwner(env);
+  return entries.map((entry) => {
+    const databasePath =
+      entry.databasePath ??
+      (entry.agentDir ? resolveAuthProfileDatabasePath(entry.agentDir) : owner.sharedDatabasePath);
+    return {
+      databasePath,
+      agentDir: path.dirname(databasePath),
+      store: cloneAuthProfileStore(entry.store),
+      owner: cloneRuntimeAuthSharedOwner(owner),
+      legacyCandidates: captureRuntimeAuthProfileLegacyCandidates(
+        databasePath === owner.sharedDatabasePath
+          ? undefined
+          : (entry.agentDir ?? path.dirname(databasePath)),
+        env,
+      ),
+    };
+  });
+}
+
+export type RuntimeAuthSharedOwner =
+  | ({ kind: "resolved" } & Pick<AuthProfileStoreOwner, "sharedDatabasePath" | "location">)
+  | { kind: "unresolved"; scope: AuthProfileOwnerScope };
+
+export function cloneRuntimeAuthSharedOwner(owner: RuntimeAuthSharedOwner): RuntimeAuthSharedOwner {
+  return owner.kind === "unresolved" ? { ...owner, scope: { ...owner.scope } } : { ...owner };
+}
+
+export function captureRuntimeAuthSharedOwner(
+  env: NodeJS.ProcessEnv = process.env,
+): Extract<RuntimeAuthSharedOwner, { kind: "resolved" }> {
+  return {
+    kind: "resolved",
+    sharedDatabasePath: resolveSharedAuthStorePath(env),
+    location: resolveSharedAuthStoreOwnership(env).location,
+  };
+}
+
+export function runtimeAuthProfileSnapshotSharesOwner(
+  snapshot: RuntimeAuthSharedOwner,
+  owner: Pick<AuthProfileStoreOwner, "location" | "sharedDatabasePath">,
+): boolean {
+  if (snapshot.kind === "resolved") {
+    return snapshot.sharedDatabasePath === owner.sharedDatabasePath;
+  }
+  // Resolve forward from captured cold facts and the known producer's storage
+  // location; never open the cold scope or infer ownership from directory ancestry.
+  const candidate =
+    owner.location === "state-db"
+      ? resolveOpenClawStateSqlitePath({ OPENCLAW_STATE_DIR: snapshot.scope.stateDir })
+      : path.join(snapshot.scope.sharedMainDir, "openclaw-agent.sqlite");
+  return candidate === owner.sharedDatabasePath;
+}
+
+export function runtimeAuthSharedOwnerRebound(
+  previous: RuntimeAuthSharedOwner,
+  next: RuntimeAuthSharedOwner,
+): boolean {
+  return next.kind === "resolved"
+    ? !runtimeAuthProfileSnapshotSharesOwner(previous, next)
+    : !isDeepStrictEqual(previous, next);
+}
+
+export function runtimeAuthCredentialState(
+  entries: Iterable<[string, RuntimeAuthProfileStore]>,
+): Array<readonly [string, AuthProfileStore["profiles"]]> {
+  return Array.from(entries)
+    .filter(([, store]) => Object.keys(store.profiles).length > 0)
+    .map(([key, store]) => [key, store.profiles] as const)
+    .toSorted(([left], [right]) => left.localeCompare(right));
+}
+
+export function runtimeAuthOwnerState(
+  store: RuntimeAuthProfileStore | undefined,
+):
+  | Pick<
+      RuntimeAuthProfileStore,
+      | "order"
+      | "profiles"
+      | "runtimePersistedProfileIds"
+      | "runtimeExternalProfileIds"
+      | "runtimeExternalProfileIdsAuthoritative"
+      | "runtimeExternalCliProfileIds"
+      | "runtimeLocalProfileIds"
+      | "runtimeInheritsMainState"
+    >
+  | undefined {
+  if (!store) {
+    return undefined;
+  }
+  return {
+    order: store.order,
+    profiles: store.profiles,
+    runtimePersistedProfileIds: store.runtimePersistedProfileIds,
+    runtimeExternalProfileIds: store.runtimeExternalProfileIds,
+    runtimeExternalProfileIdsAuthoritative: store.runtimeExternalProfileIdsAuthoritative,
+    runtimeExternalCliProfileIds: store.runtimeExternalCliProfileIds,
+    runtimeLocalProfileIds: store.runtimeLocalProfileIds,
+    runtimeInheritsMainState: store.runtimeInheritsMainState,
+  };
+}

--- a/src/agents/auth-profiles/runtime-snapshots.test.ts
+++ b/src/agents/auth-profiles/runtime-snapshots.test.ts
@@ -18,7 +18,7 @@ import {
   getPreparedRuntimeAuthProfileStoreSnapshotCore,
   getRuntimeAuthProfileStoreSnapshotCore,
   getRuntimeAuthProfileStoreCredentialsRevision,
-  listRuntimeAuthProfileStoreSnapshots,
+  listOwnedRuntimeAuthProfileStoreSnapshots,
   noteRuntimeAuthProfileStorePersistedMutation,
   registerRuntimeAuthProfileStoreMutationListener,
   replaceRuntimeAuthProfileStoreSnapshots,
@@ -79,7 +79,7 @@ describe("runtime auth profile snapshots", () => {
       },
     ]);
     try {
-      expect(listRuntimeAuthProfileStoreSnapshots()).toEqual([
+      expect(listOwnedRuntimeAuthProfileStoreSnapshots()).toMatchObject([
         {
           databasePath,
           agentDir: path.dirname(databasePath),

--- a/src/agents/auth-profiles/runtime-snapshots.ts
+++ b/src/agents/auth-profiles/runtime-snapshots.ts
@@ -5,17 +5,47 @@ import path from "node:path";
  */
 import { isDeepStrictEqual } from "node:util";
 import { cloneAuthProfileStore } from "./clone.js";
-import { resolveSharedAuthStorePath } from "./path-resolve.js";
+import {
+  captureAuthProfileOwnerScope,
+  resolveSharedAuthStorePath,
+  type AuthProfileOwnerScope,
+} from "./path-resolve.js";
 import { mergeAuthProfileStores } from "./persisted.js";
 import {
   clearAllRuntimeAuthMaterializations,
-  clearRuntimeAuthMaterializations,
   clearRuntimeAuthMaterializationsAtDatabasePath,
 } from "./runtime-materializations.js";
-import { closeAuthProfileReadPool, resolveAuthProfileDatabasePath } from "./sqlite.js";
+import {
+  captureRuntimeAuthProfileLegacyCandidates,
+  cloneRuntimeAuthProfileLegacyCandidates,
+  captureRuntimeAuthSharedOwner,
+  cloneRuntimeAuthSharedOwner,
+  runtimeAuthProfileSnapshotSharesOwner,
+  runtimeAuthSharedOwnerRebound,
+  runtimeAuthCredentialState as credentialState,
+  runtimeAuthOwnerState as ownerState,
+  type RuntimeAuthSharedOwner,
+  type RuntimeAuthProfileLegacyCandidates,
+  type OwnedRuntimeAuthProfileStoreSnapshotEntry,
+} from "./runtime-snapshot-owner.js";
+import {
+  closeAuthProfileReadPool,
+  resolveAuthProfileDatabasePath,
+  type AuthProfileStoreOwner,
+  type PreparedAuthProfileStoreOwner,
+} from "./sqlite.js";
 import type { AuthProfileStore, RuntimeAuthProfileStore } from "./types.js";
 
-const runtimeAuthStoreSnapshots = new Map<string, RuntimeAuthProfileStore>();
+type OwnedRuntimeSnapshot = {
+  store: RuntimeAuthProfileStore;
+  owner: RuntimeAuthSharedOwner;
+  legacyCandidates?: RuntimeAuthProfileLegacyCandidates;
+};
+const runtimeAuthStoreSnapshots = new Map<string, OwnedRuntimeSnapshot>();
+
+function runtimeStoreEntries(): Array<[string, RuntimeAuthProfileStore]> {
+  return Array.from(runtimeAuthStoreSnapshots, ([key, entry]) => [key, entry.store]);
+}
 type RuntimeAuthProfileStoreMutationListener = (event: {
   agentDir?: string;
   affectsInheritedStores: boolean;
@@ -36,6 +66,11 @@ type RuntimeAuthProfileStoreSnapshotEntry = {
   agentDir?: string;
   store: RuntimeAuthProfileStore;
 };
+
+export {
+  prepareRuntimeAuthProfileStoreSnapshots,
+  type OwnedRuntimeAuthProfileStoreSnapshotEntry,
+} from "./runtime-snapshot-owner.js";
 
 type PersistedMutationRecord = {
   credentialRevision: number;
@@ -125,69 +160,47 @@ function getPersistedMutationRecord(ownerKey: string): PersistedMutationRecord |
   return persistedMutationRecords.get(ownerKey);
 }
 
-function credentialState(
-  entries: Iterable<[string, RuntimeAuthProfileStore]>,
-): Array<readonly [string, AuthProfileStore["profiles"]]> {
-  return Array.from(entries)
-    .filter(([, store]) => Object.keys(store.profiles).length > 0)
-    .map(([key, store]) => [key, store.profiles] as const)
-    .toSorted(([left], [right]) => left.localeCompare(right));
-}
-
-function ownerState(
-  store: RuntimeAuthProfileStore | undefined,
-):
-  | Pick<
-      RuntimeAuthProfileStore,
-      | "order"
-      | "profiles"
-      | "runtimePersistedProfileIds"
-      | "runtimeExternalProfileIds"
-      | "runtimeExternalProfileIdsAuthoritative"
-      | "runtimeExternalCliProfileIds"
-      | "runtimeLocalProfileIds"
-      | "runtimeInheritsMainState"
-    >
-  | undefined {
-  if (!store) {
-    return undefined;
-  }
-  return {
-    order: store.order,
-    profiles: store.profiles,
-    runtimePersistedProfileIds: store.runtimePersistedProfileIds,
-    runtimeExternalProfileIds: store.runtimeExternalProfileIds,
-    runtimeExternalProfileIdsAuthoritative: store.runtimeExternalProfileIdsAuthoritative,
-    runtimeExternalCliProfileIds: store.runtimeExternalCliProfileIds,
-    runtimeLocalProfileIds: store.runtimeLocalProfileIds,
-    runtimeInheritsMainState: store.runtimeInheritsMainState,
-  };
-}
-
-function replaceChangesOwner(entries: RuntimeAuthProfileStoreSnapshotEntry[]): boolean {
-  const next = new Map(
-    entries.map((entry) => [resolveRuntimeSnapshotEntryKey(entry), entry.store] as const),
-  );
-  const currentState = Array.from(
-    runtimeAuthStoreSnapshots,
-    ([key, store]) => [key, ownerState(store)] as const,
+function snapshotOwnershipState(entries: Iterable<[string, OwnedRuntimeSnapshot]>) {
+  return Array.from(
+    entries,
+    ([key, entry]) =>
+      [
+        key,
+        {
+          state: ownerState(entry.store),
+          owner: entry.owner,
+          legacyCandidates: entry.legacyCandidates,
+        },
+      ] as const,
   ).toSorted(([left], [right]) => left.localeCompare(right));
-  const nextState = Array.from(next, ([key, store]) => [key, ownerState(store)] as const).toSorted(
-    ([left], [right]) => left.localeCompare(right),
+}
+
+function replaceChangesOwner(entries: OwnedRuntimeAuthProfileStoreSnapshotEntry[]): boolean {
+  const next = new Map(entries.map((entry) => [entry.databasePath, entry] as const));
+  return !isDeepStrictEqual(
+    snapshotOwnershipState(runtimeAuthStoreSnapshots),
+    snapshotOwnershipState(next),
   );
-  return !isDeepStrictEqual(currentState, nextState);
 }
 
 function replaceChangesCredentials(entries: RuntimeAuthProfileStoreSnapshotEntry[]): boolean {
   const next = new Map(
     entries.map((entry) => [resolveRuntimeSnapshotEntryKey(entry), entry.store] as const),
   );
-  return !isDeepStrictEqual(credentialState(runtimeAuthStoreSnapshots), credentialState(next));
+  return !isDeepStrictEqual(credentialState(runtimeStoreEntries()), credentialState(next));
 }
 
-function recordChangedSnapshotRevisions(entries: RuntimeAuthProfileStoreSnapshotEntry[]): boolean {
+function recordChangedSnapshotRevisions(
+  entries: OwnedRuntimeAuthProfileStoreSnapshotEntry[],
+): boolean {
   const next = new Map(
-    entries.map((entry) => [resolveRuntimeSnapshotEntryKey(entry), entry.store] as const),
+    entries.map(
+      (entry) =>
+        [
+          entry.databasePath,
+          { store: entry.store, owner: entry.owner, legacyCandidates: entry.legacyCandidates },
+        ] as const,
+    ),
   );
   const keys = new Set([...runtimeAuthStoreSnapshots.keys(), ...next.keys()]);
   let changed = false;
@@ -249,8 +262,29 @@ export function registerRuntimeAuthProfileStoreMutationListener(
 export function getRuntimeAuthProfileStoreSnapshotCore(
   agentDir?: string,
 ): RuntimeAuthProfileStore | undefined {
-  const store = runtimeAuthStoreSnapshots.get(resolveRuntimeStoreKey(agentDir));
+  return getRuntimeAuthProfileStoreSnapshotAtDatabasePath(resolveRuntimeStoreKey(agentDir));
+}
+
+export function getRuntimeAuthProfileStoreSnapshotAtDatabasePath(
+  databasePath: string,
+): RuntimeAuthProfileStore | undefined {
+  const store = runtimeAuthStoreSnapshots.get(databasePath)?.store;
   return store ? cloneAuthProfileStore(store) : undefined;
+}
+
+export function getOwnedRuntimeAuthProfileStoreSnapshotAtDatabasePath(
+  databasePath: string,
+): OwnedRuntimeAuthProfileStoreSnapshotEntry | undefined {
+  const entry = runtimeAuthStoreSnapshots.get(databasePath);
+  return (
+    entry && {
+      databasePath,
+      agentDir: path.dirname(databasePath),
+      store: cloneAuthProfileStore(entry.store),
+      owner: cloneRuntimeAuthSharedOwner(entry.owner),
+      legacyCandidates: cloneRuntimeAuthProfileLegacyCandidates(entry.legacyCandidates),
+    }
+  );
 }
 
 /**
@@ -274,17 +308,24 @@ export function getPreparedRuntimeAuthProfileStoreSnapshotCore(
   return requested ?? inherited;
 }
 
-/** Lists cloned snapshots while preserving their canonical database identity. */
-export function listRuntimeAuthProfileStoreSnapshots(): Array<{
-  databasePath: string;
-  agentDir: string;
-  store: RuntimeAuthProfileStore;
-}> {
-  return Array.from(runtimeAuthStoreSnapshots, ([key, store]) => ({
-    databasePath: key,
-    agentDir: path.dirname(key),
-    store: cloneAuthProfileStore(store),
+/** Lists cloned snapshots with their canonical database identity and producer ownership. */
+export function listOwnedRuntimeAuthProfileStoreSnapshots(): OwnedRuntimeAuthProfileStoreSnapshotEntry[] {
+  return Array.from(runtimeAuthStoreSnapshots, ([databasePath, entry]) => ({
+    databasePath,
+    agentDir: path.dirname(databasePath),
+    store: cloneAuthProfileStore(entry.store),
+    owner: cloneRuntimeAuthSharedOwner(entry.owner),
+    legacyCandidates: cloneRuntimeAuthProfileLegacyCandidates(entry.legacyCandidates),
   }));
+}
+
+/** Select derived snapshots by their producer's shared owner, never directory shape. */
+export function listRuntimeAuthProfileStoreSnapshotsForSharedOwner(owner: AuthProfileStoreOwner) {
+  return listOwnedRuntimeAuthProfileStoreSnapshots().filter(
+    (entry) =>
+      entry.databasePath !== owner.sharedDatabasePath &&
+      runtimeAuthProfileSnapshotSharesOwner(entry.owner, owner),
+  );
 }
 
 /** Returns true when a runtime snapshot exists for an agent dir. */
@@ -309,7 +350,43 @@ export function hasAnyRuntimeAuthProfileStoreSource(agentDir?: string): boolean 
 export function replaceRuntimeAuthProfileStoreSnapshots(
   entries: Array<{ databasePath?: string; agentDir?: string; store: AuthProfileStore }>,
 ): void {
-  const credentialsChanged = replaceChangesCredentials(entries);
+  const prepared = entries.map((entry): OwnedRuntimeAuthProfileStoreSnapshotEntry => {
+    const databasePath = resolveRuntimeSnapshotEntryKey(entry);
+    return {
+      databasePath,
+      agentDir: path.dirname(databasePath),
+      store: cloneAuthProfileStore(entry.store),
+      owner: cloneRuntimeAuthSharedOwner(
+        runtimeAuthStoreSnapshots.get(databasePath)?.owner ?? {
+          kind: "unresolved",
+          scope: captureAuthProfileOwnerScope(),
+        },
+      ),
+      legacyCandidates: cloneRuntimeAuthProfileLegacyCandidates(
+        runtimeAuthStoreSnapshots.get(databasePath)?.legacyCandidates ??
+          captureRuntimeAuthProfileLegacyCandidates(
+            entry.agentDir ?? (entry.databasePath ? path.dirname(databasePath) : undefined),
+          ),
+      ),
+    };
+  });
+  replaceOwnedRuntimeAuthProfileStoreSnapshots(prepared);
+}
+
+export function replaceOwnedRuntimeAuthProfileStoreSnapshots(
+  entries: OwnedRuntimeAuthProfileStoreSnapshotEntry[],
+): void {
+  // Cold producer facts are enough to fence stale preparation; do not open SQLite
+  // merely to avoid conservative invalidation for an irrelevant relocation.
+  const reboundKeys = new Set(
+    entries
+      .filter((entry) => {
+        const previous = runtimeAuthStoreSnapshots.get(entry.databasePath);
+        return previous && runtimeAuthSharedOwnerRebound(previous.owner, entry.owner);
+      })
+      .map((entry) => entry.databasePath),
+  );
+  const credentialsChanged = replaceChangesCredentials(entries) || reboundKeys.size > 0;
   const ownerChanged = replaceChangesOwner(entries);
   if (credentialsChanged) {
     runtimeAuthStoreCredentialsRevision += 1;
@@ -318,17 +395,28 @@ export function replaceRuntimeAuthProfileStoreSnapshots(
     entries.map((entry) => [resolveRuntimeSnapshotEntryKey(entry), entry.store] as const),
   );
   for (const key of new Set([...runtimeAuthStoreSnapshots.keys(), ...next.keys()])) {
-    if (authProfilesChanged(runtimeAuthStoreSnapshots.get(key), next.get(key))) {
+    if (
+      reboundKeys.has(key) ||
+      authProfilesChanged(runtimeAuthStoreSnapshots.get(key)?.store, next.get(key))
+    ) {
       clearRuntimeAuthMaterializationsAtDatabasePath(key);
     }
   }
   recordChangedSnapshotRevisions(entries);
+  const nextOwned = entries.map((entry) => {
+    const key = resolveRuntimeSnapshotEntryKey(entry);
+    return [
+      key,
+      {
+        store: cloneAuthProfileStore(entry.store),
+        owner: cloneRuntimeAuthSharedOwner(entry.owner),
+        legacyCandidates: cloneRuntimeAuthProfileLegacyCandidates(entry.legacyCandidates),
+      },
+    ] as const;
+  });
   runtimeAuthStoreSnapshots.clear();
-  for (const entry of entries) {
-    runtimeAuthStoreSnapshots.set(
-      resolveRuntimeSnapshotEntryKey(entry),
-      cloneAuthProfileStore(entry.store),
-    );
+  for (const [key, entry] of nextOwned) {
+    runtimeAuthStoreSnapshots.set(key, entry);
   }
   if (ownerChanged) {
     notifyRuntimeAuthStoreMutation();
@@ -338,7 +426,7 @@ export function replaceRuntimeAuthProfileStoreSnapshots(
 /** Clears all runtime auth profile snapshots. */
 export function clearRuntimeAuthProfileStoreSnapshots(): void {
   const snapshotsChanged = runtimeAuthStoreSnapshots.size > 0;
-  const credentialsChanged = credentialState(runtimeAuthStoreSnapshots).length > 0;
+  const credentialsChanged = credentialState(runtimeStoreEntries()).length > 0;
   if (credentialsChanged) {
     runtimeAuthStoreCredentialsRevision += 1;
   }
@@ -357,8 +445,17 @@ export function clearRuntimeAuthProfileStoreSnapshots(): void {
 
 /** Clears one runtime auth-profile snapshot without disturbing other active agents. */
 export function clearRuntimeAuthProfileStoreSnapshotCore(agentDir?: string): boolean {
-  const key = resolveRuntimeStoreKey(agentDir);
-  const store = runtimeAuthStoreSnapshots.get(key);
+  return clearRuntimeAuthProfileStoreSnapshotAtDatabasePath(
+    resolveRuntimeStoreKey(agentDir),
+    agentDir,
+  );
+}
+
+export function clearRuntimeAuthProfileStoreSnapshotAtDatabasePath(
+  key: string,
+  agentDir?: string,
+): boolean {
+  const store = runtimeAuthStoreSnapshots.get(key)?.store;
   if (!store) {
     return false;
   }
@@ -377,27 +474,39 @@ function setRuntimeAuthProfileStoreSnapshotAtKey(
   store: RuntimeAuthProfileStore,
   key: string,
   agentDir: string | undefined,
+  owner: RuntimeAuthSharedOwner,
+  legacyCandidates?: RuntimeAuthProfileLegacyCandidates,
 ): void {
+  const previous = runtimeAuthStoreSnapshots.get(key);
+  const sharedOwnerChanged =
+    !isDeepStrictEqual(previous?.owner, owner) ||
+    !isDeepStrictEqual(previous?.legacyCandidates, legacyCandidates);
   const credentialsChanged = !isDeepStrictEqual(
     credentialState(
-      runtimeAuthStoreSnapshots.has(key) ? [[key, runtimeAuthStoreSnapshots.get(key)!]] : [],
+      runtimeAuthStoreSnapshots.has(key) ? [[key, runtimeAuthStoreSnapshots.get(key)!.store]] : [],
     ),
     credentialState([[key, store]]),
   );
-  if (credentialsChanged) {
+  const sharedOwnerRebound = previous && runtimeAuthSharedOwnerRebound(previous.owner, owner);
+  if (credentialsChanged || sharedOwnerRebound) {
     runtimeAuthStoreCredentialsRevision += 1;
   }
-  const previousStore = runtimeAuthStoreSnapshots.get(key);
-  if (authProfilesChanged(previousStore, store)) {
+  const previousStore = previous?.store;
+  if (sharedOwnerRebound || authProfilesChanged(previousStore, store)) {
     clearRuntimeAuthMaterializationsAtDatabasePath(key);
   }
-  const ownerChanged = !isDeepStrictEqual(ownerState(previousStore), ownerState(store));
-  const snapshotChanged = !isDeepStrictEqual(previousStore, store);
+  const ownerChanged =
+    sharedOwnerChanged || !isDeepStrictEqual(ownerState(previousStore), ownerState(store));
+  const snapshotChanged = sharedOwnerChanged || !isDeepStrictEqual(previousStore, store);
   if (snapshotChanged) {
     advanceRuntimeAuthStoreSnapshotsRevision();
     runtimeAuthStoreSnapshotRevisions.set(key, runtimeAuthStoreSnapshotsRevision);
   }
-  runtimeAuthStoreSnapshots.set(key, cloneAuthProfileStore(store));
+  runtimeAuthStoreSnapshots.set(key, {
+    store: cloneAuthProfileStore(store),
+    owner: cloneRuntimeAuthSharedOwner(owner),
+    legacyCandidates: cloneRuntimeAuthProfileLegacyCandidates(legacyCandidates),
+  });
   if (ownerChanged) {
     notifyRuntimeAuthStoreMutation(agentDir);
   }
@@ -408,16 +517,76 @@ export function setRuntimeAuthProfileStoreSnapshot(
   store: RuntimeAuthProfileStore,
   agentDir?: string,
 ): void {
-  setRuntimeAuthProfileStoreSnapshotAtKey(store, resolveRuntimeStoreKey(agentDir), agentDir);
+  setRuntimeAuthProfileStoreSnapshotAtKey(
+    store,
+    resolveRuntimeStoreKey(agentDir),
+    agentDir,
+    captureRuntimeAuthSharedOwner(),
+    captureRuntimeAuthProfileLegacyCandidates(agentDir),
+  );
+}
+
+/** Restore the captured runtime owner independently of the persistence transaction. */
+export function restoreOwnedRuntimeAuthProfileStoreSnapshot(
+  entry: OwnedRuntimeAuthProfileStoreSnapshotEntry,
+  agentDir?: string,
+): void {
+  setRuntimeAuthProfileStoreSnapshotAtKey(
+    entry.store,
+    entry.databasePath,
+    agentDir,
+    entry.owner,
+    entry.legacyCandidates,
+  );
+}
+
+/** Materialization changes contents, not the existing producer's shared ownership. */
+export function updateRuntimeAuthProfileStoreSnapshot(
+  store: RuntimeAuthProfileStore,
+  agentDir?: string,
+): void {
+  const key = resolveRuntimeStoreKey(agentDir);
+  const owner = runtimeAuthStoreSnapshots.get(key)?.owner ?? captureRuntimeAuthSharedOwner();
+  setRuntimeAuthProfileStoreSnapshotAtKey(
+    store,
+    key,
+    agentDir,
+    owner,
+    runtimeAuthStoreSnapshots.get(key)?.legacyCandidates ??
+      captureRuntimeAuthProfileLegacyCandidates(agentDir),
+  );
 }
 
 /** Stores a cloned snapshot under an already resolved canonical database owner. */
 export function setRuntimeAuthProfileStoreSnapshotAtDatabasePath(
   store: RuntimeAuthProfileStore,
   databasePath: string,
-  agentDir?: string,
+  agentDir: string | undefined,
+  owner: AuthProfileStoreOwner | PreparedAuthProfileStoreOwner,
+  legacyCandidates?: RuntimeAuthProfileLegacyCandidates,
 ): void {
-  setRuntimeAuthProfileStoreSnapshotAtKey(store, databasePath, agentDir);
+  const existing = runtimeAuthStoreSnapshots.get(databasePath);
+  const candidates =
+    "env" in owner
+      ? captureRuntimeAuthProfileLegacyCandidates(
+          databasePath === owner.sharedDatabasePath ? undefined : agentDir,
+          owner.env,
+        )
+      : (legacyCandidates ??
+        (existing && runtimeAuthProfileSnapshotSharesOwner(existing.owner, owner)
+          ? existing.legacyCandidates
+          : undefined));
+  setRuntimeAuthProfileStoreSnapshotAtKey(
+    store,
+    databasePath,
+    agentDir,
+    {
+      kind: "resolved",
+      sharedDatabasePath: owner.sharedDatabasePath,
+      location: owner.location,
+    },
+    candidates,
+  );
 }
 
 /**
@@ -434,6 +603,7 @@ export function noteRuntimeAuthProfileStorePersistedMutation(
     stateChanged: boolean;
     profileIds: Iterable<string>;
   },
+  owner?: AuthProfileStoreOwner,
 ): void {
   if (!mutation.credentialsChanged && !mutation.profileSetChanged && !mutation.stateChanged) {
     return;
@@ -442,9 +612,9 @@ export function noteRuntimeAuthProfileStorePersistedMutation(
   if (mutation.credentialsChanged) {
     runtimeAuthStoreCredentialsRevision += 1;
   }
-  const ownerKey = resolveRuntimeStoreKey(agentDir);
+  const ownerKey = owner?.databasePath ?? resolveRuntimeStoreKey(agentDir);
   if (mutation.credentialsChanged || mutation.profileSetChanged) {
-    clearRuntimeAuthMaterializations(agentDir);
+    clearRuntimeAuthMaterializationsAtDatabasePath(ownerKey);
   }
   const record = getOrCreatePersistedMutationRecord(ownerKey);
   if (mutation.profileSetChanged) {
@@ -462,13 +632,14 @@ export function noteRuntimeAuthProfileStorePersistedMutation(
     record.stateRevision = persistedMutationRevision;
     record.stateRevisionKnown = true;
   }
-  const mainKey = resolveRuntimeStoreKey(undefined);
+  const mainKey = owner?.sharedDatabasePath ?? resolveRuntimeStoreKey(undefined);
   if (ownerKey !== mainKey || (!mutation.credentialsChanged && !mutation.profileSetChanged)) {
     return;
   }
   let deletedDerivedSnapshot = false;
-  for (const key of runtimeAuthStoreSnapshots.keys()) {
-    if (key !== mainKey) {
+  const sharedOwner = owner ?? captureRuntimeAuthSharedOwner();
+  for (const [key, entry] of runtimeAuthStoreSnapshots) {
+    if (key !== mainKey && runtimeAuthProfileSnapshotSharesOwner(entry.owner, sharedOwner)) {
       runtimeAuthStoreSnapshots.delete(key);
       runtimeAuthStoreSnapshotRevisions.delete(key);
       deletedDerivedSnapshot = true;
@@ -487,6 +658,10 @@ export type RuntimeAuthProfileStoreMutationToken = {
   known: boolean;
 };
 
+export type RuntimeAuthProfileStoreMutationOwner =
+  | { kind: "resolved"; databasePath: string; sharedDatabasePath: string }
+  | { kind: "unresolved"; databasePath: string; scope: AuthProfileOwnerScope };
+
 function combineMutationTokens(
   tokens: RuntimeAuthProfileStoreMutationToken[],
 ): RuntimeAuthProfileStoreMutationToken {
@@ -500,16 +675,23 @@ function combineMutationTokens(
 export function getRuntimeAuthProfileStoreCredentialMutationToken(
   agentDir?: string,
   profileId?: string,
-  options?: { includeMain?: boolean },
+  options?: { includeMain?: boolean; owner?: RuntimeAuthProfileStoreMutationOwner },
 ): RuntimeAuthProfileStoreMutationToken {
-  const requestedKey = resolveRuntimeStoreKey(agentDir);
+  const requestedKey = options?.owner?.databasePath ?? resolveRuntimeStoreKey(agentDir);
   if (!profileId) {
     const record = getPersistedMutationRecord(requestedKey);
     return record
       ? { revision: record.credentialRevision, known: record.credentialRevisionKnown }
       : { revision: evictedOwnerMutationFloor, known: evictedOwnerMutationFloor === 0 };
   }
-  const mainKey = resolveRuntimeStoreKey(undefined);
+  if (options?.includeMain && options.owner?.kind === "unresolved") {
+    return { revision: 0, known: false };
+  }
+  const mainKey = !options?.includeMain
+    ? requestedKey
+    : options.owner?.kind === "resolved"
+      ? options.owner.sharedDatabasePath
+      : resolveRuntimeStoreKey(undefined);
   const keys =
     requestedKey === mainKey || options?.includeMain !== true
       ? [requestedKey]
@@ -531,8 +713,9 @@ export function getRuntimeAuthProfileStoreCredentialMutationToken(
 /** Persisted token for profile-id additions and removals in one owner store. */
 export function getRuntimeAuthProfileStoreProfileSetMutationToken(
   agentDir?: string,
+  databasePath?: string,
 ): RuntimeAuthProfileStoreMutationToken {
-  const ownerKey = resolveRuntimeStoreKey(agentDir);
+  const ownerKey = databasePath ?? resolveRuntimeStoreKey(agentDir);
   const record = getPersistedMutationRecord(ownerKey);
   return record
     ? { revision: record.profileSetRevision, known: record.profileSetRevisionKnown }
@@ -542,10 +725,17 @@ export function getRuntimeAuthProfileStoreProfileSetMutationToken(
 /** Persisted mutation token for non-secret selection state in one owner store. */
 export function getRuntimeAuthProfileStoreStateMutationToken(
   agentDir?: string,
-  options?: { includeMain?: boolean },
+  options?: { includeMain?: boolean; owner?: RuntimeAuthProfileStoreMutationOwner },
 ): RuntimeAuthProfileStoreMutationToken {
-  const requestedKey = resolveRuntimeStoreKey(agentDir);
-  const mainKey = resolveRuntimeStoreKey(undefined);
+  const requestedKey = options?.owner?.databasePath ?? resolveRuntimeStoreKey(agentDir);
+  if (options?.includeMain && options.owner?.kind === "unresolved") {
+    return { revision: 0, known: false };
+  }
+  const mainKey = !options?.includeMain
+    ? requestedKey
+    : options.owner?.kind === "resolved"
+      ? options.owner.sharedDatabasePath
+      : resolveRuntimeStoreKey(undefined);
   const keys =
     requestedKey === mainKey || options?.includeMain !== true
       ? [requestedKey]

--- a/src/agents/auth-profiles/sqlite.ts
+++ b/src/agents/auth-profiles/sqlite.ts
@@ -7,6 +7,7 @@ import fs from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { safeParseJson } from "@openclaw/normalization-core";
+import { resolveStateDir } from "../../config/paths.js";
 import { sha256HexPrefixCore } from "../../infra/crypto-digest.js";
 import {
   clearNodeSqliteKyselyCacheForDatabase,
@@ -37,7 +38,11 @@ import {
 } from "../../state/openclaw-state-db.js";
 import { resolveUserPath } from "../../utils.js";
 import { resolveRegisteredAgentIdForDir } from "../agent-dir-registry.js";
-import { resolveSharedAuthStoreOwnership, resolveSharedAuthStorePath } from "./path-resolve.js";
+import {
+  resolveSharedAuthStoreOwnership,
+  resolveSharedAuthStorePath,
+  type SharedAuthStoreOwnership,
+} from "./path-resolve.js";
 import { prepareFreshSharedAuthStoreWrite } from "./shared-store-bootstrap.js";
 
 type AgentAuthProfileDatabase = Pick<
@@ -46,6 +51,43 @@ type AgentAuthProfileDatabase = Pick<
 >;
 type SharedAuthProfileDatabase = Pick<OpenClawStateKyselyDatabase, "config_machine_state">;
 export type AuthProfileDatabase = OpenClawAgentDatabase | OpenClawStateDatabase;
+
+/** Internal prepared ownership, carried through commit publication and compensation. */
+export type AuthProfileStoreOwner = {
+  databasePath: string;
+  sharedDatabasePath: string;
+  location: SharedAuthStoreOwnership["location"];
+};
+
+export type PreparedAuthProfileStoreOwner = AuthProfileStoreOwner & { env: NodeJS.ProcessEnv };
+
+export function resolveAuthProfileStoreOwner(
+  database: AuthProfileDatabase,
+  env: NodeJS.ProcessEnv = process.env,
+): AuthProfileStoreOwner | PreparedAuthProfileStoreOwner {
+  const prepared = authProfileTransactions.get(database)?.owner;
+  if (prepared) {
+    return prepared;
+  }
+  // A supplied shared connection already names its owner; ambient discovery can
+  // select another database (or fail on it) before this connection is ever used.
+  if (!("agentId" in database)) {
+    return { databasePath: database.path, sharedDatabasePath: database.path, location: "state-db" };
+  }
+  return {
+    ...prepareAuthProfileSharedOwner(env),
+    databasePath: database.path,
+  };
+}
+
+function prepareAuthProfileSharedOwner(env: NodeJS.ProcessEnv) {
+  const preparedEnv = { ...env, OPENCLAW_STATE_DIR: resolveStateDir(env) };
+  return {
+    env: preparedEnv,
+    sharedDatabasePath: resolveSharedAuthStorePath(preparedEnv),
+    location: resolveSharedAuthStoreOwnership(preparedEnv).location,
+  };
+}
 
 type AuthProfileDatabaseTarget =
   | { kind: "agent"; agentId: string; path: string; env: NodeJS.ProcessEnv }
@@ -95,7 +137,10 @@ function deleteSharedAuthKvCell(db: DatabaseSync, stateKey: string): void {
 }
 const AUTH_PROFILE_READ_HANDLE_CAP = 8;
 const authProfileReadDatabases = new Map<string, DatabaseSync>();
-const sharedAuthPostCommitPublications = new WeakMap<OpenClawStateDatabase, Array<() => void>>();
+const authProfileTransactions = new WeakMap<
+  AuthProfileDatabase,
+  { owner: PreparedAuthProfileStoreOwner; publications: Array<() => void> }
+>();
 let unregisterReadHandleExitClose: (() => void) | null = null;
 
 type AuthProfileReadPoolCloseScope =
@@ -110,7 +155,7 @@ export function deferAuthProfilePostCommitPublication(
   if ("agentId" in database) {
     return deferOpenClawAgentPostCommitPublication(database, publish);
   }
-  const publications = sharedAuthPostCommitPublications.get(database);
+  const publications = authProfileTransactions.get(database)?.publications;
   if (!publications) {
     return false;
   }
@@ -377,8 +422,8 @@ function acquireAuthProfileReadDatabase(
   return { status: "readable", db };
 }
 
-function inspectAuthProfileJsonCellReadOnly(
-  databaseTarget: AuthProfileDatabaseTarget,
+export function inspectAuthProfileJsonCellReadOnly(
+  databaseTarget: Pick<AuthProfileDatabaseTarget, "kind" | "path">,
   target: "store" | "state",
 ): PersistedAuthProfileStoreInspection {
   if (databaseTarget.kind === "shared-state") {
@@ -386,7 +431,7 @@ function inspectAuthProfileJsonCellReadOnly(
       return (
         withExistingOpenClawStateDatabaseReadOnly(
           ({ db }) => inspectAuthProfileJsonCell(db, target, "shared-state"),
-          { env: databaseTarget.env, path: databaseTarget.path },
+          { path: databaseTarget.path },
         ) ?? { status: "missing", reason: "database" }
       );
     } catch {
@@ -415,7 +460,6 @@ export function inspectPersistedAuthProfileStoreRaw(
   agentDir?: string,
   database?: Pick<AuthProfileDatabase, "db">,
 ): PersistedAuthProfileStoreInspection {
-  const databaseTarget = resolveAuthProfileDatabaseOptions(agentDir);
   if (database) {
     return inspectAuthProfileJsonCell(
       database.db,
@@ -423,7 +467,7 @@ export function inspectPersistedAuthProfileStoreRaw(
       resolveAuthProfileDatabaseKind(agentDir, database),
     );
   }
-  return inspectAuthProfileJsonCellReadOnly(databaseTarget, "store");
+  return inspectAuthProfileJsonCellReadOnly(resolveAuthProfileDatabaseOptions(agentDir), "store");
 }
 
 /** Distinguishes an absent auth-state row from state that could not be read. */
@@ -431,7 +475,6 @@ export function inspectPersistedAuthProfileStateRaw(
   agentDir?: string,
   database?: Pick<AuthProfileDatabase, "db">,
 ): PersistedAuthProfileStoreInspection {
-  const databaseTarget = resolveAuthProfileDatabaseOptions(agentDir);
   if (database) {
     return inspectAuthProfileJsonCell(
       database.db,
@@ -439,7 +482,7 @@ export function inspectPersistedAuthProfileStateRaw(
       resolveAuthProfileDatabaseKind(agentDir, database),
     );
   }
-  return inspectAuthProfileJsonCellReadOnly(databaseTarget, "state");
+  return inspectAuthProfileJsonCellReadOnly(resolveAuthProfileDatabaseOptions(agentDir), "state");
 }
 
 /** Inspect the shared store for an explicit state root without projecting it to an agent dir. */
@@ -467,7 +510,6 @@ export function readPersistedAuthProfileStoreRaw(
   agentDir?: string,
   database?: AuthProfileDatabase,
 ): unknown {
-  const databaseTarget = resolveAuthProfileDatabaseOptions(agentDir);
   if (database) {
     if (resolveAuthProfileDatabaseKind(agentDir, database) === "shared-state") {
       return parseJsonCell(readSharedAuthKvCell(database.db, SHARED_STORE_STATE_KEY));
@@ -481,7 +523,10 @@ export function readPersistedAuthProfileStoreRaw(
     );
     return parseJsonCell(row?.store_json);
   }
-  const result = inspectAuthProfileJsonCellReadOnly(databaseTarget, "store");
+  const result = inspectAuthProfileJsonCellReadOnly(
+    resolveAuthProfileDatabaseOptions(agentDir),
+    "store",
+  );
   return result.status === "readable" ? result.raw : null;
 }
 
@@ -490,7 +535,6 @@ export function readPersistedAuthProfileStateRaw(
   agentDir?: string,
   database?: AuthProfileDatabase,
 ): unknown {
-  const databaseTarget = resolveAuthProfileDatabaseOptions(agentDir);
   if (database) {
     if (resolveAuthProfileDatabaseKind(agentDir, database) === "shared-state") {
       return parseJsonCell(readSharedAuthKvCell(database.db, SHARED_STATE_STATE_KEY));
@@ -504,7 +548,10 @@ export function readPersistedAuthProfileStateRaw(
     );
     return parseJsonCell(row?.state_json);
   }
-  const result = inspectAuthProfileJsonCellReadOnly(databaseTarget, "state");
+  const result = inspectAuthProfileJsonCellReadOnly(
+    resolveAuthProfileDatabaseOptions(agentDir),
+    "state",
+  );
   return result.status === "readable" ? result.raw : null;
 }
 
@@ -632,16 +679,19 @@ export function writePersistedAuthProfileStateRaw(
 /** Runs an auth-profile database write transaction for store/state updates. */
 export function runAuthProfileWriteTransaction<T>(
   agentDir: string | undefined,
-  operation: (database: AuthProfileDatabase) => T,
+  operation: (database: AuthProfileDatabase, owner: PreparedAuthProfileStoreOwner) => T,
   options: {
     env?: NodeJS.ProcessEnv;
     sharedStoreWrite?: boolean;
     stateDir?: string;
   } = {},
 ): T {
-  const env =
-    options.env ??
-    (options.stateDir ? { ...process.env, OPENCLAW_STATE_DIR: options.stateDir } : process.env);
+  const env = {
+    ...(options.env ?? process.env),
+    ...(!options.env && options.stateDir
+      ? { OPENCLAW_STATE_DIR: options.stateDir, OPENCLAW_AGENT_DIR: undefined }
+      : {}),
+  };
   const sharedStoreWrite = prepareFreshSharedAuthStoreWrite({
     agentDir,
     allowExplicitMain: options.sharedStoreWrite === true,
@@ -651,32 +701,54 @@ export function runAuthProfileWriteTransaction<T>(
     sharedStoreWrite ? undefined : agentDir,
     env,
   );
+  // Shared-owner discovery may inspect another database; complete it before BEGIN.
+  const sharedOwner = prepareAuthProfileSharedOwner(env);
   if (databaseTarget.kind === "agent") {
-    return runOpenClawAgentWriteTransaction(operation, databaseTarget);
+    return runOpenClawAgentWriteTransaction((database) => {
+      const previous = authProfileTransactions.get(database);
+      const context = previous ?? {
+        owner: { ...sharedOwner, databasePath: database.path },
+        publications: [],
+      };
+      authProfileTransactions.set(database, context);
+      try {
+        return operation(database, context.owner);
+      } finally {
+        if (!previous) {
+          authProfileTransactions.delete(database);
+        }
+      }
+    }, databaseTarget);
   }
 
   const database = openOpenClawStateDatabase({ env, path: databaseTarget.path });
   const enteredNestedTransaction = database.db.isTransaction;
-  const publications: Array<() => void> | undefined = enteredNestedTransaction
-    ? sharedAuthPostCommitPublications.get(database)
-    : [];
-  const publicationStart = publications?.length ?? 0;
-  if (!enteredNestedTransaction && publications) {
-    sharedAuthPostCommitPublications.set(database, publications);
+  const previous = authProfileTransactions.get(database);
+  const context = previous ?? {
+    owner: { ...sharedOwner, databasePath: database.path },
+    publications: [],
+  };
+  const publicationStart = context.publications.length;
+  if (!enteredNestedTransaction) {
+    authProfileTransactions.set(database, context);
   }
   let result: T;
   try {
-    result = runOpenClawStateWriteTransaction(operation, { env, database });
+    const owner = context.owner;
+    result = runOpenClawStateWriteTransaction((transaction) => operation(transaction, owner), {
+      env,
+      database,
+    });
   } catch (error) {
-    publications?.splice(publicationStart);
+    context.publications.splice(publicationStart);
     throw error;
   } finally {
-    if (!enteredNestedTransaction && publications) {
-      sharedAuthPostCommitPublications.delete(database);
+    if (!enteredNestedTransaction) {
+      authProfileTransactions.delete(database);
     }
   }
   if (!enteredNestedTransaction) {
-    for (const publish of publications ?? []) {
+    for (const publish of context.publications) {
       publish();
     }
   }

--- a/src/agents/auth-profiles/store-owner-publication.test.ts
+++ b/src/agents/auth-profiles/store-owner-publication.test.ts
@@ -1,0 +1,641 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { prepareSecretsRuntimeFastPathSnapshot } from "../../secrets/runtime-fast-path.js";
+import { activateSecretsRuntimeSnapshotState } from "../../secrets/runtime-state.js";
+import { openOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
+import { withEnv } from "../../test-utils/env.js";
+import {
+  assertAuthProfileMigrationReady,
+  AuthProfileMigrationRequiredError,
+  markAuthProfileMigrationRequired,
+} from "./legacy-source-diagnostic.js";
+import { loadPersistedSharedAuthProfileStore } from "./persisted.js";
+import {
+  getRuntimeAuthProfileStoreCredentialMutationToken,
+  getRuntimeAuthProfileStoreStateMutationToken,
+  replaceRuntimeAuthProfileStoreSnapshots,
+  setRuntimeAuthProfileStoreSnapshot,
+} from "./runtime-snapshots.js";
+import {
+  resolveAuthProfileDatabasePath,
+  runAuthProfileWriteTransaction,
+  writePersistedAuthProfileStoreRaw,
+} from "./sqlite.js";
+import { createAuthOwnerTestFixtures } from "./store-state-owner.test-support.js";
+import {
+  captureAuthProfileStorePersistenceSnapshot,
+  ensureAuthProfileStoreWithoutExternalProfiles,
+  loadAuthProfileStoreWithoutExternalProfiles,
+  restoreAuthProfileStorePersistenceSnapshot,
+  saveAuthProfileStore,
+  saveAuthProfileStoreIfPersistenceSnapshotMatches,
+  updateAuthProfileStoreWithLock,
+  withAuthProfileStoreAgentDir,
+} from "./store.js";
+import type { AuthProfileCredential } from "./types.js";
+import { persistAuthProfileBatch } from "./upsert-with-lock.js";
+
+const { tempDirs, saveOptions, apiKey, store, snapshotAt, unreadableOuter, seedRoot } =
+  createAuthOwnerTestFixtures();
+
+describe("auth publication owner receipts", () => {
+  it.each(["prepare", "activate"] as const)(
+    "requires a recorded migration diagnosis discovered at %s before empty-owner activation",
+    async (discoveredAt) => {
+      const { prepareSecretsRuntimeSnapshot } = await import("../../secrets/runtime.js");
+      const first = await seedRoot("first");
+      const second = await seedRoot("second");
+      const agentDir = tempDirs.make("openclaw-auth-owner-empty-activation-");
+      await updateAuthProfileStoreWithLock({
+        stateDir: first.stateDir,
+        saveOptions,
+        updater: (current) => {
+          current.profiles = {};
+          return true;
+        },
+      });
+      withEnv(second.env, () =>
+        setRuntimeAuthProfileStoreSnapshot(
+          loadAuthProfileStoreWithoutExternalProfiles(agentDir),
+          agentDir,
+        ),
+      );
+      const legacyPath = path.join(agentDir, "auth.json");
+      if (discoveredAt === "prepare") {
+        fs.writeFileSync(legacyPath, "{}");
+      }
+      const snapshot = await prepareSecretsRuntimeSnapshot({
+        config: {},
+        env: first.env,
+        agentDirs: [agentDir],
+        allowUnavailableSecretOwners: true,
+        loadAuthStore: () =>
+          withEnv(first.env, () => loadAuthProfileStoreWithoutExternalProfiles(agentDir)),
+      });
+      expect(snapshot.authStores[0]?.store.profiles).toEqual({});
+      const activate = () =>
+        activateSecretsRuntimeSnapshotState({
+          snapshot,
+          refreshContext: null,
+          refreshHandler: null,
+        });
+      if (discoveredAt === "prepare") {
+        expect(snapshot.degradedOwners).toHaveLength(1);
+        expect(activate).not.toThrow();
+        expect(snapshotAt(resolveAuthProfileDatabasePath(agentDir))?.profiles).toEqual({});
+      } else {
+        expect(snapshot.degradedOwners).toEqual([]);
+        fs.writeFileSync(legacyPath, "{}");
+        expect(activate).toThrow("requires legacy credential migration");
+        expect(snapshotAt(resolveAuthProfileDatabasePath(agentDir))?.profiles.shared).toEqual(
+          apiKey("second"),
+        );
+      }
+    },
+  );
+
+  it.each(["update", "capture"] as const)(
+    "honors an explicit state root over the enclosing scope during %s",
+    async (operation) => {
+      const first = await seedRoot("first");
+      const second = await seedRoot("second");
+      await withAuthProfileStoreAgentDir(first.agentDir, second.stateDir, async () => {
+        if (operation === "update") {
+          await updateAuthProfileStoreWithLock({
+            agentDir: first.agentDir,
+            stateDir: first.stateDir,
+            saveOptions,
+            updater: (current) => {
+              current.profiles = { local: apiKey("updated-local") };
+              return true;
+            },
+          });
+        } else {
+          const snapshot = captureAuthProfileStorePersistenceSnapshot(first.agentDir, {
+            stateDir: first.stateDir,
+          });
+          const committed = saveAuthProfileStoreIfPersistenceSnapshotMatches({
+            snapshot,
+            agentDir: first.agentDir,
+            store: { version: 1, profiles: { local: apiKey("updated-local") } },
+            options: saveOptions,
+          });
+          expect(committed.publishRuntimeSnapshots()).toBe(true);
+        }
+      });
+      expect(snapshotAt(first.agentPath)?.profiles).toEqual({
+        local: apiKey("updated-local"),
+        shared: apiKey("first"),
+      });
+      expect(snapshotAt(second.agentPath)?.profiles.shared).toEqual(apiKey("second"));
+    },
+  );
+
+  it("retains inherited persisted provenance after an ordinary local rebuild", async () => {
+    const root = await seedRoot("original");
+    withEnv(root.env, () =>
+      saveAuthProfileStore(
+        { version: 1, profiles: { local: apiKey("updated-local") } },
+        root.agentDir,
+        saveOptions,
+      ),
+    );
+    expect(snapshotAt(root.agentPath)?.runtimePersistedProfileIds).toEqual(["local", "shared"]);
+  });
+
+  it.each([
+    { unreadableLocal: false, populated: false },
+    { unreadableLocal: true, populated: false },
+    { unreadableLocal: false, populated: true },
+    { unreadableLocal: true, populated: true },
+  ])(
+    "validates committed shared migration facts with unreadableLocal=$unreadableLocal populated=$populated",
+    async ({ unreadableLocal, populated }) => {
+      const root = await seedRoot("original");
+      const oauthDir = tempDirs.make("openclaw-auth-owner-late-oauth-");
+      const env = { ...root.env, OPENCLAW_OAUTH_DIR: oauthDir };
+      withEnv(env, () =>
+        setRuntimeAuthProfileStoreSnapshot(
+          loadAuthProfileStoreWithoutExternalProfiles(root.agentDir),
+          root.agentDir,
+        ),
+      );
+      if (unreadableLocal) {
+        writePersistedAuthProfileStoreRaw({ version: 1, profiles: "invalid" }, root.agentDir);
+      }
+      const legacyPath = path.join(oauthDir, "oauth.json");
+      fs.writeFileSync(legacyPath, "{}");
+      withEnv(env, () =>
+        saveAuthProfileStore(
+          { version: 1, profiles: populated ? { shared: apiKey("updated") } : {} },
+          undefined,
+          saveOptions,
+        ),
+      );
+      fs.unlinkSync(legacyPath);
+      // The removed file cannot make this assertion discover the refusal itself.
+      if (populated) {
+        expect(() => assertAuthProfileMigrationReady(undefined, env)).not.toThrow();
+        expect(snapshotAt(root.agentPath)?.profiles.shared).toEqual(apiKey("updated"));
+      } else {
+        expect(() => assertAuthProfileMigrationReady(undefined, env)).toThrow(
+          "requires legacy credential migration",
+        );
+        expect(snapshotAt(root.agentPath)).toBeUndefined();
+      }
+    },
+  );
+
+  it.each(["credentials", "state"] as const)(
+    "records committed %s changes and evicts derived snapshots when migration refuses publication",
+    async (kind) => {
+      const first = await seedRoot("first");
+      const second = await seedRoot("second");
+      const readToken =
+        kind === "credentials"
+          ? getRuntimeAuthProfileStoreCredentialMutationToken
+          : getRuntimeAuthProfileStoreStateMutationToken;
+      const before = withEnv(first.env, () => readToken().revision);
+      markAuthProfileMigrationRequired(
+        undefined,
+        new AuthProfileMigrationRequiredError({
+          env: first.env,
+          sources: [],
+        }),
+        first.env,
+      );
+      const next =
+        kind === "credentials"
+          ? store("updated-first")
+          : {
+              ...store("first"),
+              order: { openai: ["shared"] },
+            };
+      withEnv(second.env, () =>
+        saveAuthProfileStore(
+          next,
+          undefined,
+          saveOptions,
+          openOpenClawStateDatabase({ env: first.env }),
+        ),
+      );
+      expect(loadPersistedSharedAuthProfileStore(first.env)).toMatchObject(next);
+      expect(snapshotAt(first.agentPath)).toBeUndefined();
+      expect(withEnv(first.env, () => readToken().revision)).toBeGreaterThan(before);
+      expect(snapshotAt(second.agentPath)?.profiles.shared).toEqual(apiKey("second"));
+      expect(() => assertAuthProfileMigrationReady(undefined, first.env)).toThrow(
+        "requires legacy credential migration",
+      );
+    },
+  );
+
+  it("does not restore a credential snapshot over a newer migration refusal", async () => {
+    const root = await seedRoot("original");
+    const baseline = captureAuthProfileStorePersistenceSnapshot(root.agentDir, { env: root.env });
+    const committed = saveAuthProfileStoreIfPersistenceSnapshotMatches({
+      snapshot: baseline,
+      agentDir: root.agentDir,
+      store: { version: 1, profiles: { local: apiKey("temporary") } },
+      options: saveOptions,
+    });
+    expect(committed.publishRuntimeSnapshots()).toBe(true);
+    markAuthProfileMigrationRequired(
+      root.agentDir,
+      new AuthProfileMigrationRequiredError({
+        agentDir: root.agentDir,
+        env: root.env,
+        sources: [],
+      }),
+      root.env,
+    );
+    restoreAuthProfileStorePersistenceSnapshot(baseline, committed.owned, root.agentDir);
+    expect(snapshotAt(root.agentPath)).toBeUndefined();
+    expect(() => assertAuthProfileMigrationReady(root.agentDir, root.env)).toThrow(
+      "requires legacy credential migration",
+    );
+  });
+
+  it.each([
+    { refusedOwner: "child", newer: false, stateOnly: false },
+    { refusedOwner: "child", newer: true, stateOnly: false },
+    { refusedOwner: "shared", newer: false, stateOnly: false },
+    { refusedOwner: "shared", newer: false, stateOnly: true },
+  ])(
+    "isolates $refusedOwner rollback refusal with newer=$newer stateOnly=$stateOnly",
+    async ({ refusedOwner, newer, stateOnly }) => {
+      const root = await seedRoot("original");
+      const healthyAgentDir = tempDirs.make("openclaw-auth-owner-healthy-sibling-");
+      const healthyPath = resolveAuthProfileDatabasePath(healthyAgentDir);
+      withEnv(root.env, () =>
+        setRuntimeAuthProfileStoreSnapshot(
+          loadAuthProfileStoreWithoutExternalProfiles(healthyAgentDir),
+          healthyAgentDir,
+        ),
+      );
+      const unrelated = await seedRoot("unrelated");
+      const baseline = captureAuthProfileStorePersistenceSnapshot(undefined, { env: root.env });
+      const committed = saveAuthProfileStoreIfPersistenceSnapshotMatches({
+        snapshot: baseline,
+        store: stateOnly
+          ? { ...store("original"), usageStats: { shared: { lastUsed: 99 } } }
+          : store("temporary"),
+        options: saveOptions,
+      });
+      expect(committed.publishRuntimeSnapshots()).toBe(true);
+      if (newer) {
+        const current = snapshotAt(root.agentPath);
+        if (!current) {
+          throw new Error("missing child runtime snapshot");
+        }
+        current.usageStats = { shared: { lastUsed: 123 } };
+        withEnv(root.env, () => setRuntimeAuthProfileStoreSnapshot(current, root.agentDir));
+      }
+      const refusedDir = refusedOwner === "child" ? root.agentDir : undefined;
+      markAuthProfileMigrationRequired(
+        refusedDir,
+        new AuthProfileMigrationRequiredError({ agentDir: refusedDir, env: root.env, sources: [] }),
+        root.env,
+      );
+      restoreAuthProfileStorePersistenceSnapshot(baseline, committed.owned);
+      expect(loadPersistedSharedAuthProfileStore(root.env)?.profiles.shared).toEqual(
+        apiKey("original"),
+      );
+      expect(snapshotAt(root.agentPath)).toBeUndefined();
+      if (refusedOwner === "child") {
+        expect(snapshotAt(root.sharedPath)?.profiles.shared).toEqual(apiKey("original"));
+        expect(snapshotAt(healthyPath)?.profiles.shared).toEqual(apiKey("original"));
+      } else {
+        expect(snapshotAt(root.sharedPath)).toBeUndefined();
+        expect(snapshotAt(healthyPath)).toBeUndefined();
+      }
+      expect(snapshotAt(unrelated.sharedPath)?.profiles.shared).toEqual(apiKey("unrelated"));
+      expect(snapshotAt(unrelated.agentPath)?.profiles.shared).toEqual(apiKey("unrelated"));
+      expect(() => assertAuthProfileMigrationReady(refusedDir, root.env)).toThrow(
+        "requires legacy credential migration",
+      );
+    },
+  );
+
+  it.each([
+    { file: "auth.json", populated: false, refused: true },
+    { file: "auth.json", populated: true, refused: false },
+    { file: "auth-state.json", populated: false, refused: false },
+  ])(
+    "preserves late $file migration semantics with populated=$populated",
+    async ({ file, populated, refused }) => {
+      const root = await seedRoot("original");
+      fs.writeFileSync(path.join(root.agentDir, file), "{}");
+      withEnv(root.env, () =>
+        saveAuthProfileStore(
+          {
+            version: 1,
+            profiles: populated ? { local: apiKey("updated-local") } : {},
+          },
+          root.agentDir,
+          saveOptions,
+        ),
+      );
+      if (refused) {
+        expect(snapshotAt(root.agentPath)).toBeUndefined();
+        expect(() => assertAuthProfileMigrationReady(root.agentDir, root.env)).toThrow(
+          "requires legacy credential migration",
+        );
+      } else {
+        expect(snapshotAt(root.agentPath)?.profiles.shared).toEqual(apiKey("original"));
+        expect(() => assertAuthProfileMigrationReady(root.agentDir, root.env)).not.toThrow();
+      }
+    },
+  );
+
+  it("retains a prepared owner's relocated legacy OAuth discovery during local rebuild", async () => {
+    const root = await seedRoot("original");
+    const oauthDir = tempDirs.make("openclaw-auth-owner-legacy-oauth-");
+    const env = { ...root.env, OPENCLAW_OAUTH_DIR: oauthDir };
+    withEnv(env, () => {
+      saveAuthProfileStore({ version: 1, profiles: {} }, undefined, saveOptions);
+      setRuntimeAuthProfileStoreSnapshot(
+        loadAuthProfileStoreWithoutExternalProfiles(root.agentDir),
+        root.agentDir,
+      );
+      fs.writeFileSync(path.join(oauthDir, "oauth.json"), "{}");
+      saveAuthProfileStore(
+        { version: 1, profiles: { local: apiKey("updated-local") } },
+        root.agentDir,
+        saveOptions,
+      );
+    });
+    expect(snapshotAt(root.agentPath)).toBeUndefined();
+    expect(() => assertAuthProfileMigrationReady(undefined, env)).toThrow(
+      "requires legacy credential migration",
+    );
+  });
+
+  it.each(
+    (["transaction", "connection"] as const).flatMap((source) =>
+      (["readable", "future", "invalid"] as const).map((outer) => ({ source, outer })),
+    ),
+  )(
+    "preserves the selected shared owner for a supplied $source under a $outer ambient root",
+    async ({ source, outer }) => {
+      const first = await seedRoot("first");
+      const second = await seedRoot("second");
+      const save = () => {
+        if (source === "transaction") {
+          runAuthProfileWriteTransaction(
+            undefined,
+            (database) =>
+              saveAuthProfileStore(store("updated-first"), undefined, saveOptions, database),
+            { stateDir: first.stateDir },
+          );
+        } else {
+          saveAuthProfileStore(
+            store("updated-first"),
+            undefined,
+            saveOptions,
+            openOpenClawStateDatabase({ env: first.env }),
+          );
+        }
+      };
+      if (outer === "readable") {
+        withEnv(second.env, save);
+      } else {
+        const assertOuterUnchanged = unreadableOuter(outer);
+        save();
+        assertOuterUnchanged();
+      }
+      expect(loadPersistedSharedAuthProfileStore(first.env)?.profiles.shared).toEqual(
+        apiKey("updated-first"),
+      );
+      expect(snapshotAt(first.sharedPath)?.profiles.shared).toEqual(apiKey("updated-first"));
+      expect(snapshotAt(first.agentPath)?.profiles.shared).toEqual(apiKey("updated-first"));
+      expect(loadPersistedSharedAuthProfileStore(second.env)?.profiles.shared).toEqual(
+        apiKey("second"),
+      );
+      expect(snapshotAt(second.agentPath)?.profiles.shared).toEqual(apiKey("second"));
+    },
+  );
+
+  it.each(["ordinary", "supplied"] as const)(
+    "does not relabel another owner's resolved credentials during %s publication",
+    async (publication) => {
+      const first = await seedRoot("first");
+      const second = await seedRoot("second");
+      const sharedRef = {
+        type: "api_key",
+        provider: "openai",
+        keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+      } satisfies AuthProfileCredential;
+      for (const root of [first, second]) {
+        await persistAuthProfileBatch({
+          stateDir: root.stateDir,
+          profiles: [{ profileId: "shared", credential: sharedRef }],
+        });
+      }
+      withEnv(first.env, () => {
+        const current = loadAuthProfileStoreWithoutExternalProfiles(first.agentDir);
+        current.profiles.shared = { ...sharedRef, key: "fixture-first-resolved" };
+        current.profiles.external = {
+          type: "oauth",
+          provider: "anthropic",
+          access: "fixture-first-access",
+          refresh: "fixture-first-refresh",
+          expires: Date.now() + 60_000,
+        };
+        current.runtimeExternalProfileIds = ["external"];
+        setRuntimeAuthProfileStoreSnapshot(current, first.agentDir);
+      });
+      withEnv(second.env, () => {
+        const next = loadAuthProfileStoreWithoutExternalProfiles(first.agentDir);
+        if (publication === "ordinary") {
+          saveAuthProfileStore(next, first.agentDir, saveOptions);
+        } else {
+          runAuthProfileWriteTransaction(first.agentDir, (database) => {
+            saveAuthProfileStore(next, first.agentDir, saveOptions, database);
+          });
+        }
+      });
+      expect(snapshotAt(first.agentPath)?.profiles.shared).toEqual(sharedRef);
+      expect(snapshotAt(first.agentPath)?.profiles.external).toBeUndefined();
+    },
+  );
+
+  it("keeps the original shared owner after a bounded temporary-state exec save", async () => {
+    const original = await seedRoot("original");
+    const temporary = tempDirs.make("openclaw-auth-owner-bounded-temp-");
+    withEnv({ ...original.env, OPENCLAW_STATE_DIR: temporary }, () => {
+      withAuthProfileStoreAgentDir(original.agentDir, original.stateDir, () => {
+        const current = ensureAuthProfileStoreWithoutExternalProfiles();
+        saveAuthProfileStore(current, undefined, saveOptions);
+      });
+    });
+    await persistAuthProfileBatch({
+      stateDir: original.stateDir,
+      profiles: [{ profileId: "shared", credential: apiKey("updated-original") }],
+    });
+    expect(snapshotAt(original.agentPath)?.profiles.shared).toEqual(apiKey("updated-original"));
+  });
+
+  it("retains shared OAuth in the owner snapshot but excludes it from bounded exec", async () => {
+    const original = await seedRoot("original");
+    const oauth = {
+      type: "oauth",
+      provider: "openai",
+      access: "fixture-shared-access",
+      refresh: "fixture-shared-refresh",
+      expires: Date.now() + 3_600_000,
+    } satisfies AuthProfileCredential;
+    await persistAuthProfileBatch({
+      stateDir: original.stateDir,
+      profiles: [{ profileId: "shared-oauth", credential: oauth }],
+    });
+    expect(snapshotAt(original.agentPath)?.profiles["shared-oauth"]).toEqual(oauth);
+    const temporary = tempDirs.make("openclaw-auth-owner-bounded-oauth-");
+    withEnv({ ...original.env, OPENCLAW_STATE_DIR: temporary }, () => {
+      withAuthProfileStoreAgentDir(original.agentDir, original.stateDir, () => {
+        const current = ensureAuthProfileStoreWithoutExternalProfiles();
+        expect(current.profiles["shared-oauth"]).toBeUndefined();
+        saveAuthProfileStore(current, undefined, saveOptions);
+        expect(
+          ensureAuthProfileStoreWithoutExternalProfiles().profiles["shared-oauth"],
+        ).toBeUndefined();
+      });
+    });
+    expect(snapshotAt(original.agentPath)?.profiles["shared-oauth"]).toEqual(oauth);
+  });
+
+  it("preserves an independently newer runtime owner with identical credential bytes", async () => {
+    const first = await seedRoot("first");
+    const second = await seedRoot("second");
+    const third = await seedRoot("second");
+    withEnv(second.env, () =>
+      setRuntimeAuthProfileStoreSnapshot(
+        loadAuthProfileStoreWithoutExternalProfiles(first.agentDir),
+        first.agentDir,
+      ),
+    );
+    const originalRuntime = snapshotAt(first.agentPath);
+    if (!originalRuntime) {
+      throw new Error("missing second-owner runtime");
+    }
+    const baseline = captureAuthProfileStorePersistenceSnapshot(first.agentDir, {
+      stateDir: first.stateDir,
+    });
+    const committed = saveAuthProfileStoreIfPersistenceSnapshotMatches({
+      snapshot: baseline,
+      agentDir: first.agentDir,
+      stateDir: first.stateDir,
+      store: { version: 1, profiles: { local: apiKey("temporary-local") } },
+      options: saveOptions,
+    });
+    expect(committed.publishRuntimeSnapshots()).toBe(true);
+    withEnv(third.env, () => setRuntimeAuthProfileStoreSnapshot(originalRuntime, first.agentDir));
+    restoreAuthProfileStorePersistenceSnapshot(baseline, committed.owned, first.agentDir, {
+      stateDir: first.stateDir,
+    });
+    expect(snapshotAt(first.agentPath)?.profiles).toEqual(originalRuntime.profiles);
+    await persistAuthProfileBatch({
+      stateDir: third.stateDir,
+      profiles: [{ profileId: "shared", credential: apiKey("updated-third") }],
+    });
+    expect(snapshotAt(first.agentPath)?.profiles.shared).toEqual(apiKey("updated-third"));
+  });
+
+  it("restores the captured runtime owner separately from the persistence transaction owner", async () => {
+    const first = await seedRoot("first");
+    const second = await seedRoot("second");
+    withEnv(second.env, () =>
+      setRuntimeAuthProfileStoreSnapshot(
+        loadAuthProfileStoreWithoutExternalProfiles(first.agentDir),
+        first.agentDir,
+      ),
+    );
+    const baseline = captureAuthProfileStorePersistenceSnapshot(first.agentDir, {
+      stateDir: first.stateDir,
+    });
+    const committed = saveAuthProfileStoreIfPersistenceSnapshotMatches({
+      snapshot: baseline,
+      agentDir: first.agentDir,
+      stateDir: first.stateDir,
+      store: { version: 1, profiles: { local: apiKey("temporary-local") } },
+      options: saveOptions,
+    });
+    expect(committed.publishRuntimeSnapshots()).toBe(true);
+    restoreAuthProfileStorePersistenceSnapshot(baseline, committed.owned, first.agentDir, {
+      stateDir: first.stateDir,
+    });
+    expect(snapshotAt(first.agentPath)?.profiles.shared).toEqual(apiKey("second"));
+    await persistAuthProfileBatch({
+      stateDir: second.stateDir,
+      profiles: [{ profileId: "shared", credential: apiKey("updated-second") }],
+    });
+    expect(snapshotAt(first.agentPath)?.profiles.shared).toEqual(apiKey("updated-second"));
+  });
+
+  it.each(["publish", "compensate"] as const)(
+    "reconciles two legacy roots sharing one relocated database during %s",
+    (operation) => {
+      const sharedDir = tempDirs.make("openclaw-auth-owner-aliased-legacy-");
+      const roots = ["first", "second"].map(() => ({
+        agentDir: tempDirs.make("openclaw-auth-owner-aliased-agent-"),
+        env: {
+          ...process.env,
+          OPENCLAW_STATE_DIR: tempDirs.make("openclaw-auth-owner-aliased-root-"),
+          OPENCLAW_AGENT_DIR: sharedDir,
+        },
+      }));
+      writePersistedAuthProfileStoreRaw(store("original"), sharedDir);
+      for (const root of roots) {
+        withEnv(root.env, () =>
+          setRuntimeAuthProfileStoreSnapshot(
+            loadAuthProfileStoreWithoutExternalProfiles(root.agentDir),
+            root.agentDir,
+          ),
+        );
+      }
+      const first = roots[0]!;
+      const second = roots[1]!;
+      const baseline = captureAuthProfileStorePersistenceSnapshot(undefined, { env: first.env });
+      const committed = saveAuthProfileStoreIfPersistenceSnapshotMatches({
+        snapshot: baseline,
+        store: store("candidate"),
+        options: saveOptions,
+      });
+      expect(committed.publishRuntimeSnapshots()).toBe(true);
+      if (operation === "compensate") {
+        withEnv(second.env, () =>
+          setRuntimeAuthProfileStoreSnapshot(
+            loadAuthProfileStoreWithoutExternalProfiles(second.agentDir),
+            second.agentDir,
+          ),
+        );
+        restoreAuthProfileStorePersistenceSnapshot(baseline, committed.owned);
+      }
+      expect(snapshotAt(resolveAuthProfileDatabasePath(second.agentDir))?.profiles.shared).toEqual(
+        apiKey(operation === "publish" ? "candidate" : "original"),
+      );
+    },
+  );
+
+  it("activates a valid prepared owner without reopening an unrelated public cold scope", async () => {
+    const first = await seedRoot("first");
+    const coldAgentDir = tempDirs.make("openclaw-auth-owner-unrelated-cold-");
+    const assertOuterUnchanged = unreadableOuter("future");
+    replaceRuntimeAuthProfileStoreSnapshots([{ agentDir: coldAgentDir, store: store("cold") }]);
+    const prepared = prepareSecretsRuntimeFastPathSnapshot({
+      config: {},
+      env: first.env,
+      agentDirs: [first.agentDir],
+      loadAuthStore: () =>
+        withEnv(first.env, () => loadAuthProfileStoreWithoutExternalProfiles(first.agentDir)),
+    });
+    if (!prepared) {
+      throw new Error("missing prepared snapshot");
+    }
+    expect(() =>
+      activateSecretsRuntimeSnapshotState({ ...prepared, refreshHandler: null }),
+    ).not.toThrow();
+    expect(snapshotAt(first.agentPath)?.profiles.shared).toEqual(apiKey("first"));
+    assertOuterUnchanged();
+  });
+});

--- a/src/agents/auth-profiles/store-state-owner.test-support.ts
+++ b/src/agents/auth-profiles/store-state-owner.test-support.ts
@@ -1,0 +1,98 @@
+import fs from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, expect, vi } from "vitest";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { clearSecretsRuntimeSnapshotState } from "../../secrets/runtime-state.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { withEnv } from "../../test-utils/env.js";
+import { clearAuthProfileMigrationDiagnostics } from "./legacy-source-diagnostic.js";
+import { resolveSharedAuthStorePath } from "./path-resolve.js";
+import {
+  clearRuntimeAuthProfileStoreSnapshots,
+  getOwnedRuntimeAuthProfileStoreSnapshotAtDatabasePath,
+  setRuntimeAuthProfileStoreSnapshot,
+} from "./runtime-snapshots.js";
+import { resolveAuthProfileDatabasePath } from "./sqlite.js";
+import { loadAuthProfileStoreWithoutExternalProfiles } from "./store.js";
+import type { AuthProfileCredential, AuthProfileStore } from "./types.js";
+import { persistAuthProfileBatch } from "./upsert-with-lock.js";
+
+export function createAuthOwnerTestFixtures() {
+  const tempDirs = createTempDirTracker();
+  const saveOptions = { filterExternalAuthProfiles: false, syncExternalCli: false };
+  const apiKey = (key: string): AuthProfileCredential => ({
+    type: "api_key",
+    provider: "openai",
+    key,
+  });
+  const store = (key: string): AuthProfileStore => ({
+    version: 1,
+    profiles: { shared: apiKey(key) },
+  });
+
+  function snapshotAt(databasePath: string) {
+    return getOwnedRuntimeAuthProfileStoreSnapshotAtDatabasePath(databasePath)?.store;
+  }
+
+  afterEach(() => {
+    clearSecretsRuntimeSnapshotState();
+    clearRuntimeAuthProfileStoreSnapshots();
+    clearAuthProfileMigrationDiagnostics();
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    vi.unstubAllEnvs();
+    tempDirs.cleanup();
+  });
+
+  function unreadableOuter(kind: "future" | "invalid") {
+    const stateDir = tempDirs.make("openclaw-auth-owner-outer-");
+    const databasePath = path.join(stateDir, "state", "openclaw.sqlite");
+    fs.mkdirSync(path.dirname(databasePath), { recursive: true });
+    if (kind === "future") {
+      const database = new DatabaseSync(databasePath);
+      database.exec("PRAGMA user_version = 999");
+      database.close();
+    } else {
+      fs.writeFileSync(databasePath, "invalid SQLite fixture");
+    }
+    const original = fs.readFileSync(databasePath);
+    const relocated = path.join(stateDir, "unrelated-relocated-agent");
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    vi.stubEnv("OPENCLAW_AGENT_DIR", relocated);
+    return () => {
+      expect(fs.readFileSync(databasePath)).toEqual(original);
+      expect(process.env.OPENCLAW_STATE_DIR).toBe(stateDir);
+      expect(process.env.OPENCLAW_AGENT_DIR).toBe(relocated);
+      expect(fs.existsSync(relocated)).toBe(false);
+    };
+  }
+
+  async function seedRoot(key: string) {
+    const stateDir = tempDirs.make("openclaw-auth-owner-root-");
+    // Deliberately outside the state root: directory ancestry cannot identify inheritance.
+    const agentDir = tempDirs.make("openclaw-auth-owner-custom-agent-");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir, OPENCLAW_AGENT_DIR: undefined };
+    await persistAuthProfileBatch({
+      stateDir,
+      profiles: [{ profileId: "shared", credential: apiKey(key) }],
+    });
+    await persistAuthProfileBatch({
+      stateDir,
+      agentDir,
+      profiles: [{ profileId: "local", credential: apiKey(`${key}-local`) }],
+    });
+    const sharedPath = resolveSharedAuthStorePath(env);
+    const agentPath = resolveAuthProfileDatabasePath(agentDir);
+    withEnv(env, () => {
+      setRuntimeAuthProfileStoreSnapshot(loadAuthProfileStoreWithoutExternalProfiles());
+      setRuntimeAuthProfileStoreSnapshot(
+        loadAuthProfileStoreWithoutExternalProfiles(agentDir),
+        agentDir,
+      );
+    });
+    return { stateDir, agentDir, sharedPath, agentPath, env };
+  }
+  return { tempDirs, saveOptions, apiKey, store, snapshotAt, unreadableOuter, seedRoot };
+}

--- a/src/agents/auth-profiles/store-state-owner.test.ts
+++ b/src/agents/auth-profiles/store-state-owner.test.ts
@@ -1,0 +1,678 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { prepareSecretsRuntimeFastPathSnapshot } from "../../secrets/runtime-fast-path.js";
+import {
+  activateSecretsRuntimeSnapshotState,
+  getActiveSecretsRuntimeSnapshotState,
+  getActiveSecretsRuntimeSnapshotRevisionState,
+  graftActiveSecretsRuntimeAuthState,
+  restoreSecretsRuntimeSnapshotStateIfCurrent,
+} from "../../secrets/runtime-state.js";
+import { withEnv } from "../../test-utils/env.js";
+import { resolveSharedAuthStorePath } from "./path-resolve.js";
+import { loadPersistedAuthProfileStore, loadPersistedSharedAuthProfileStore } from "./persisted.js";
+import {
+  getRuntimeAuthProfileStoreCredentialsRevision,
+  listOwnedRuntimeAuthProfileStoreSnapshots,
+  prepareRuntimeAuthProfileStoreSnapshots,
+  replaceOwnedRuntimeAuthProfileStoreSnapshots,
+  setRuntimeAuthProfileStoreSnapshot,
+  replaceRuntimeAuthProfileStoreSnapshots,
+} from "./runtime-snapshots.js";
+import { resolveAuthProfileDatabasePath, writePersistedAuthProfileStoreRaw } from "./sqlite.js";
+import { createAuthOwnerTestFixtures } from "./store-state-owner.test-support.js";
+import {
+  captureAuthProfileStorePersistenceSnapshot,
+  loadAuthProfileStoreWithoutExternalProfiles,
+  restoreAuthProfileStorePersistenceSnapshot,
+  saveAuthProfileStoreIfPersistenceSnapshotMatches,
+  updateAuthProfileStoreWithLock,
+} from "./store.js";
+import type { AuthProfileCredential, AuthProfileStore } from "./types.js";
+import { persistAuthProfileBatch } from "./upsert-with-lock.js";
+
+const { tempDirs, saveOptions, apiKey, store, snapshotAt, unreadableOuter, seedRoot } =
+  createAuthOwnerTestFixtures();
+
+describe("explicit auth state ownership", () => {
+  it.each(["shared", "local", "mixed", "mixed-live", "cleared-local"] as const)(
+    "preserves $0 bookkeeping ownership across shared-root activation",
+    async (bookkeepingOwner) => {
+      const first = await seedRoot("first");
+      const second = await seedRoot("second");
+      const agentDir = first.agentDir;
+      const localBookkeeping = bookkeepingOwner !== "shared";
+      const profileId = localBookkeeping ? "local" : "shared";
+      const updateBookkeeping = async (root: typeof first, lastUsed: number) => {
+        await updateAuthProfileStoreWithLock({
+          stateDir: root.stateDir,
+          agentDir: localBookkeeping ? agentDir : undefined,
+          saveOptions,
+          updater: (current) => {
+            current.usageStats = { [profileId]: { lastUsed, cooldownUntil: lastUsed + 60_000 } };
+            return true;
+          },
+        });
+      };
+      const targetHasSharedState = !["shared", "local"].includes(bookkeepingOwner);
+      if (targetHasSharedState) {
+        await updateAuthProfileStoreWithLock({
+          stateDir: first.stateDir,
+          saveOptions,
+          updater: (current) => {
+            const sharedProfileId = bookkeepingOwner === "cleared-local" ? "local" : "shared";
+            if (bookkeepingOwner === "cleared-local") {
+              current.profiles.local = apiKey("shared-local");
+            }
+            current.usageStats = { [sharedProfileId]: { lastUsed: 30, cooldownUntil: 60_030 } };
+            return true;
+          },
+        });
+        const sharedProfileId = bookkeepingOwner === "cleared-local" ? "local" : "shared";
+        expect(
+          loadPersistedSharedAuthProfileStore(first.env)?.usageStats?.[sharedProfileId]?.lastUsed,
+        ).toBe(30);
+      }
+      await updateBookkeeping(first, 10);
+      if (bookkeepingOwner === "shared") {
+        await updateBookkeeping(second, 20);
+      } else if (bookkeepingOwner === "mixed-live") {
+        await updateAuthProfileStoreWithLock({
+          stateDir: second.stateDir,
+          saveOptions,
+          updater: (current) => {
+            current.usageStats = { shared: { lastUsed: 40 } };
+            return true;
+          },
+        });
+      }
+      withEnv(second.env, () =>
+        setRuntimeAuthProfileStoreSnapshot(
+          loadAuthProfileStoreWithoutExternalProfiles(agentDir),
+          agentDir,
+        ),
+      );
+      const prepared = prepareSecretsRuntimeFastPathSnapshot({
+        config: {},
+        env: first.env,
+        agentDirs: [agentDir],
+        loadAuthStore: () =>
+          withEnv(first.env, () => loadAuthProfileStoreWithoutExternalProfiles(agentDir)),
+      });
+      if (!prepared) {
+        throw new Error("missing prepared snapshot");
+      }
+      expect(prepared.snapshot.authStores[0]?.store?.runtimeInheritsMainState === true).toBe(
+        bookkeepingOwner === "shared" ||
+          bookkeepingOwner === "mixed" ||
+          bookkeepingOwner === "mixed-live",
+      );
+      if (localBookkeeping) {
+        if (bookkeepingOwner === "cleared-local") {
+          await updateAuthProfileStoreWithLock({
+            stateDir: second.stateDir,
+            agentDir,
+            saveOptions,
+            updater: (current) => {
+              delete current.usageStats;
+              return true;
+            },
+          });
+        } else {
+          await updateBookkeeping(second, 20);
+        }
+        expect(getRuntimeAuthProfileStoreCredentialsRevision()).toBe(
+          prepared.snapshot.authStoreCredentialsRevision,
+        );
+        expect(snapshotAt(first.agentPath)?.runtimeInheritsMainState === true).toBe(
+          bookkeepingOwner === "mixed-live",
+        );
+      }
+      activateSecretsRuntimeSnapshotState({ ...prepared, refreshHandler: null });
+      const expectedLastUsed =
+        bookkeepingOwner === "cleared-local" ? 30 : localBookkeeping ? 20 : 10;
+      expect(snapshotAt(first.agentPath)?.usageStats?.[profileId]).toEqual({
+        lastUsed: expectedLastUsed,
+        cooldownUntil: expectedLastUsed + 60_000,
+      });
+      if (targetHasSharedState) {
+        const sharedProfileId = bookkeepingOwner === "cleared-local" ? "local" : "shared";
+        expect(snapshotAt(first.agentPath)?.usageStats?.[sharedProfileId]).toEqual({
+          lastUsed: 30,
+          cooldownUntil: 60_030,
+        });
+        expect(snapshotAt(first.agentPath)?.runtimeInheritsMainState).toBe(true);
+      }
+    },
+  );
+
+  it("keeps known public snapshot owners across an unrelated outer overlay update", async () => {
+    const first = await seedRoot("first");
+    const second = await seedRoot("second");
+    const assertOuterUnchanged = unreadableOuter("future");
+    replaceRuntimeAuthProfileStoreSnapshots(
+      listOwnedRuntimeAuthProfileStoreSnapshots().map((entry) => {
+        if (entry.databasePath === first.agentPath) {
+          entry.store.usageStats = { shared: { lastUsed: 123 } };
+        }
+        return entry;
+      }),
+    );
+    await updateAuthProfileStoreWithLock({
+      stateDir: second.stateDir,
+      saveOptions,
+      updater: (current) => {
+        current.profiles.shared = apiKey("updated-second");
+        return true;
+      },
+    });
+    expect(snapshotAt(second.agentPath)?.profiles.shared).toEqual(apiKey("updated-second"));
+    expect(snapshotAt(first.agentPath)?.profiles.shared).toEqual(apiKey("first"));
+    assertOuterUnchanged();
+  });
+
+  it.each(["rollback", "newer", "newer-same", "graft"] as const)(
+    "preserves shared-root authority through %s on one agent database",
+    async (mode) => {
+      const currentKey = mode === "newer-same" ? "second" : "third";
+      const [first, second, third] = await Promise.all([
+        seedRoot("first"),
+        seedRoot("second"),
+        seedRoot(currentKey),
+      ]);
+      const agentDir = tempDirs.make("openclaw-auth-owner-rebound-agent-");
+      if (mode === "rollback") {
+        await persistAuthProfileBatch({
+          stateDir: first.stateDir,
+          agentDir,
+          profiles: [{ profileId: "local", credential: apiKey("stable-local") }],
+        });
+        for (const [root, lastUsed] of [
+          [first, 10],
+          [second, 20],
+        ] as const) {
+          await updateAuthProfileStoreWithLock({
+            stateDir: root.stateDir,
+            saveOptions,
+            updater: (current) => {
+              current.usageStats = { shared: { lastUsed } };
+              return true;
+            },
+          });
+        }
+      }
+      const prepare = (root: typeof first) => {
+        const prepared = prepareSecretsRuntimeFastPathSnapshot({
+          config: {},
+          env: root.env,
+          agentDirs: [agentDir],
+          loadAuthStore: () =>
+            withEnv(root.env, () => loadAuthProfileStoreWithoutExternalProfiles(agentDir)),
+        });
+        if (!prepared) {
+          throw new Error("missing prepared snapshot");
+        }
+        return prepared;
+      };
+      const activate = (root: typeof first) => {
+        const prepared = prepare(root);
+        activateSecretsRuntimeSnapshotState({ ...prepared, refreshHandler: null });
+      };
+      activate(first);
+      const baseline = getActiveSecretsRuntimeSnapshotState()!;
+      activate(second);
+      const owned = getActiveSecretsRuntimeSnapshotState()!;
+      const revision = getActiveSecretsRuntimeSnapshotRevisionState();
+      const expected = mode === "rollback" ? first : third;
+      if (mode === "rollback") {
+        await updateAuthProfileStoreWithLock({
+          stateDir: second.stateDir,
+          agentDir,
+          saveOptions,
+          updater: (current) => {
+            current.usageStats = { local: { lastUsed: 25 } };
+            return true;
+          },
+        });
+      }
+      if (mode !== "rollback") {
+        withEnv(third.env, () => setRuntimeAuthProfileStoreSnapshot(store(currentKey), agentDir));
+      }
+      vi.stubEnv("OPENCLAW_STATE_DIR", third.stateDir);
+      if (mode === "graft") {
+        const prepared = prepare(first);
+        graftActiveSecretsRuntimeAuthState(prepared.snapshot);
+        activateSecretsRuntimeSnapshotState({ ...prepared, refreshHandler: null });
+      } else {
+        expect(
+          restoreSecretsRuntimeSnapshotStateIfCurrent({
+            snapshot: baseline,
+            ownedSnapshot: owned,
+            expectedRevision: revision,
+            refreshContext: null,
+            refreshHandler: null,
+          }),
+        ).toBe(true);
+      }
+      expect(snapshotAt(resolveAuthProfileDatabasePath(agentDir))?.profiles.shared).toEqual(
+        apiKey(mode === "rollback" ? "first" : currentKey),
+      );
+      if (mode === "rollback") {
+        expect(
+          snapshotAt(resolveAuthProfileDatabasePath(agentDir))?.usageStats?.local?.lastUsed,
+        ).toBe(25);
+        expect(
+          snapshotAt(resolveAuthProfileDatabasePath(agentDir))?.usageStats?.shared?.lastUsed,
+        ).toBe(10);
+      }
+      await updateAuthProfileStoreWithLock({
+        stateDir: expected.stateDir,
+        saveOptions,
+        updater: (current) => {
+          current.profiles.shared = apiKey("updated-owner");
+          return true;
+        },
+      });
+      expect(snapshotAt(resolveAuthProfileDatabasePath(agentDir))?.profiles.shared).toEqual(
+        apiKey("updated-owner"),
+      );
+    },
+  );
+
+  it("rejects a prepared snapshot after a scope-only owner transition", async () => {
+    const first = await seedRoot("same");
+    const second = await seedRoot("same");
+    const agentDir = tempDirs.make("openclaw-auth-owner-stale-preparation-");
+    withEnv(first.env, () => setRuntimeAuthProfileStoreSnapshot(store("same"), agentDir));
+    const prepared = prepareSecretsRuntimeFastPathSnapshot({
+      config: {},
+      env: first.env,
+      agentDirs: [agentDir],
+      loadAuthStore: () => store("same"),
+    });
+    if (!prepared) {
+      throw new Error("missing prepared snapshot");
+    }
+    withEnv(second.env, () => setRuntimeAuthProfileStoreSnapshot(store("same"), agentDir));
+    expect(() =>
+      activateSecretsRuntimeSnapshotState({ ...prepared, refreshHandler: null }),
+    ).toThrow("stale");
+  });
+
+  it("hydrates a complete cold worker snapshot without reading unrelated outer SQLite", () => {
+    const agentDir = tempDirs.make("openclaw-auth-owner-cold-worker-");
+    const assertOuterUnchanged = unreadableOuter("future");
+    expect(() =>
+      replaceRuntimeAuthProfileStoreSnapshots([{ agentDir, store: store("hydrated") }]),
+    ).not.toThrow();
+    expect(snapshotAt(resolveAuthProfileDatabasePath(agentDir))?.profiles.shared).toEqual(
+      apiKey("hydrated"),
+    );
+    expect(fs.readdirSync(agentDir)).toEqual([]);
+    assertOuterUnchanged();
+  });
+
+  it("retains a removed snapshot owner through secrets activation rollback", async () => {
+    const first = await seedRoot("first");
+    const second = await seedRoot("second");
+    const captured = withEnv(first.env, () => {
+      const activate = (authStores: Array<{ agentDir: string; store: AuthProfileStore }>) => {
+        activateSecretsRuntimeSnapshotState({
+          snapshot: {
+            sourceConfig: {},
+            config: {},
+            authStores: prepareRuntimeAuthProfileStoreSnapshots(authStores),
+            authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
+            warnings: [],
+            webTools: {
+              search: { providerSource: "none", diagnostics: [] },
+              fetch: { providerSource: "none", diagnostics: [] },
+              diagnostics: [],
+            },
+          },
+          refreshContext: null,
+          refreshHandler: null,
+        });
+      };
+      activate([
+        {
+          agentDir: first.agentDir,
+          store: loadAuthProfileStoreWithoutExternalProfiles(first.agentDir),
+        },
+      ]);
+      const baseline = getActiveSecretsRuntimeSnapshotState();
+      activate([]);
+      const owned = getActiveSecretsRuntimeSnapshotState();
+      if (!baseline || !owned) {
+        throw new Error("missing activated secrets snapshot");
+      }
+      return { baseline, owned, revision: getActiveSecretsRuntimeSnapshotRevisionState() };
+    });
+    expect(snapshotAt(first.agentPath)).toBeUndefined();
+    vi.stubEnv("OPENCLAW_STATE_DIR", second.stateDir);
+    expect(
+      restoreSecretsRuntimeSnapshotStateIfCurrent({
+        snapshot: captured.baseline,
+        ownedSnapshot: captured.owned,
+        expectedRevision: captured.revision,
+        refreshContext: null,
+        refreshHandler: null,
+      }),
+    ).toBe(true);
+    expect(snapshotAt(first.agentPath)?.profiles.shared).toEqual(apiKey("first"));
+    await updateAuthProfileStoreWithLock({
+      stateDir: first.stateDir,
+      saveOptions,
+      updater: (current) => {
+        current.profiles.shared = apiKey("updated-first");
+        return true;
+      },
+    });
+    expect(snapshotAt(first.agentPath)?.profiles.shared).toEqual(apiKey("updated-first"));
+    expect(loadPersistedSharedAuthProfileStore(second.env)?.profiles.shared).toEqual(
+      apiKey("second"),
+    );
+  });
+
+  it("preserves ambient agent relocation for writes without an explicit state root", async () => {
+    const stateDir = tempDirs.make("openclaw-auth-owner-ambient-");
+    const agentDir = tempDirs.make("openclaw-auth-owner-relocated-");
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    vi.stubEnv("OPENCLAW_AGENT_DIR", agentDir);
+    writePersistedAuthProfileStoreRaw(store("initial"), agentDir);
+    setRuntimeAuthProfileStoreSnapshot(loadAuthProfileStoreWithoutExternalProfiles());
+    await updateAuthProfileStoreWithLock({
+      saveOptions,
+      updater: (current) => {
+        current.profiles.shared = apiKey("updated");
+        return true;
+      },
+    });
+    expect(resolveSharedAuthStorePath()).toBe(resolveAuthProfileDatabasePath(agentDir));
+    expect(loadPersistedAuthProfileStore(agentDir)?.profiles.shared).toEqual(apiKey("updated"));
+    expect(snapshotAt(resolveAuthProfileDatabasePath(agentDir))?.profiles.shared).toEqual(
+      apiKey("updated"),
+    );
+    expect(fs.existsSync(path.join(stateDir, "agents", "main", "agent"))).toBe(false);
+  });
+
+  it("ignores agent relocation when the selected shared owner is the state database", async () => {
+    const root = await seedRoot("first");
+    const relocated = tempDirs.make("openclaw-auth-owner-irrelevant-relocation-");
+    withEnv({ ...root.env, OPENCLAW_AGENT_DIR: relocated }, () => {
+      setRuntimeAuthProfileStoreSnapshot(
+        loadAuthProfileStoreWithoutExternalProfiles(root.agentDir),
+        root.agentDir,
+      );
+    });
+    await updateAuthProfileStoreWithLock({
+      stateDir: root.stateDir,
+      saveOptions,
+      updater: (current) => {
+        current.profiles.shared = apiKey("updated");
+        return true;
+      },
+    });
+    expect(snapshotAt(root.agentPath)?.profiles.shared).toEqual(apiKey("updated"));
+    expect(fs.readdirSync(relocated)).toEqual([]);
+  });
+
+  it("keeps same-root legacy shared owners separate across agent relocation", () => {
+    const stateDir = tempDirs.make("openclaw-auth-owner-legacy-root-");
+    const roots = ["first", "second"].map((key) => {
+      const sharedDir = tempDirs.make("openclaw-auth-owner-legacy-shared-");
+      const agentDir = tempDirs.make("openclaw-auth-owner-legacy-derived-");
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir, OPENCLAW_AGENT_DIR: sharedDir };
+      withEnv(env, () => {
+        writePersistedAuthProfileStoreRaw(store(key), sharedDir);
+        setRuntimeAuthProfileStoreSnapshot(loadAuthProfileStoreWithoutExternalProfiles());
+        setRuntimeAuthProfileStoreSnapshot(
+          loadAuthProfileStoreWithoutExternalProfiles(agentDir),
+          agentDir,
+        );
+      });
+      return { env, agentDir, sharedDir };
+    });
+    const first = roots[0]!;
+    const second = roots[1]!;
+    const before = captureAuthProfileStorePersistenceSnapshot(undefined, { env: first.env });
+    const committed = withEnv(second.env, () =>
+      saveAuthProfileStoreIfPersistenceSnapshotMatches({
+        snapshot: before,
+        store: store("updated-first"),
+        options: saveOptions,
+      }),
+    );
+    expect(committed.publishRuntimeSnapshots()).toBe(true);
+    expect(snapshotAt(resolveAuthProfileDatabasePath(first.agentDir))?.profiles.shared).toEqual(
+      apiKey("updated-first"),
+    );
+    expect(snapshotAt(resolveAuthProfileDatabasePath(second.agentDir))?.profiles.shared).toEqual(
+      apiKey("second"),
+    );
+    expect(loadPersistedAuthProfileStore(second.sharedDir)?.profiles.shared).toEqual(
+      apiKey("second"),
+    );
+  });
+
+  it("rejects a save whose explicit state root disagrees with the captured owner", async () => {
+    const root = await seedRoot("first");
+    const otherStateDir = tempDirs.make("openclaw-auth-owner-mismatch-");
+    const baseline = captureAuthProfileStorePersistenceSnapshot(undefined, {
+      stateDir: root.stateDir,
+    });
+    expect(() =>
+      saveAuthProfileStoreIfPersistenceSnapshotMatches({
+        snapshot: baseline,
+        stateDir: otherStateDir,
+        store: store("must-not-write"),
+        options: saveOptions,
+      }),
+    ).toThrow("owner");
+    expect(loadPersistedSharedAuthProfileStore(root.env)?.profiles.shared).toEqual(apiKey("first"));
+    expect(fs.readdirSync(otherStateDir)).toEqual([]);
+  });
+
+  it("rejects rollback whose explicit state root disagrees with the committed owner", async () => {
+    const root = await seedRoot("first");
+    const otherStateDir = tempDirs.make("openclaw-auth-owner-mismatch-");
+    const baseline = captureAuthProfileStorePersistenceSnapshot(undefined, {
+      stateDir: root.stateDir,
+    });
+    const committed = saveAuthProfileStoreIfPersistenceSnapshotMatches({
+      snapshot: baseline,
+      stateDir: root.stateDir,
+      store: store("committed"),
+      options: saveOptions,
+    });
+    expect(() =>
+      restoreAuthProfileStorePersistenceSnapshot(baseline, committed.owned, undefined, {
+        stateDir: otherStateDir,
+      }),
+    ).toThrow("owner");
+    expect(loadPersistedSharedAuthProfileStore(root.env)?.profiles.shared).toEqual(
+      apiKey("committed"),
+    );
+    expect(fs.readdirSync(otherStateDir)).toEqual([]);
+  });
+
+  it("refreshes only the selected root when the outer root is readable", async () => {
+    const first = await seedRoot("first");
+    const second = await seedRoot("second");
+    withEnv(first.env, () => {
+      setRuntimeAuthProfileStoreSnapshot(loadAuthProfileStoreWithoutExternalProfiles());
+      setRuntimeAuthProfileStoreSnapshot(
+        loadAuthProfileStoreWithoutExternalProfiles(first.agentDir),
+        first.agentDir,
+      );
+    });
+    const otherSnapshots = listOwnedRuntimeAuthProfileStoreSnapshots().filter(
+      (entry) =>
+        entry.databasePath === second.sharedPath || entry.databasePath === second.agentPath,
+    );
+    vi.stubEnv("OPENCLAW_STATE_DIR", second.stateDir);
+    await updateAuthProfileStoreWithLock({
+      stateDir: first.stateDir,
+      saveOptions,
+      updater: (current) => {
+        current.profiles.shared = apiKey("updated-first");
+        return true;
+      },
+    });
+    expect(snapshotAt(first.sharedPath)?.profiles.shared).toEqual(apiKey("updated-first"));
+    expect(snapshotAt(first.agentPath)?.profiles).toMatchObject({
+      shared: apiKey("updated-first"),
+      local: apiKey("first-local"),
+    });
+    expect(
+      listOwnedRuntimeAuthProfileStoreSnapshots().filter(
+        (entry) =>
+          entry.databasePath === second.sharedPath || entry.databasePath === second.agentPath,
+      ),
+    ).toEqual(otherSnapshots);
+  });
+
+  it.each(["future", "invalid"] as const)(
+    "publishes and compensates only the selected root under %s outer state",
+    async (kind) => {
+      const first = await seedRoot("first");
+      const second = await seedRoot("second");
+      const otherSnapshots = listOwnedRuntimeAuthProfileStoreSnapshots().filter(
+        (entry) =>
+          entry.databasePath === second.sharedPath || entry.databasePath === second.agentPath,
+      );
+      const assertOuterUnchanged = unreadableOuter(kind);
+      const baseline = captureAuthProfileStorePersistenceSnapshot(undefined, {
+        stateDir: first.stateDir,
+      });
+      const committed = saveAuthProfileStoreIfPersistenceSnapshotMatches({
+        snapshot: baseline,
+        stateDir: first.stateDir,
+        store: store("temporary"),
+        options: saveOptions,
+      });
+      expect(loadPersistedSharedAuthProfileStore(first.env)?.profiles.shared).toEqual(
+        apiKey("temporary"),
+      );
+      expect(snapshotAt(first.sharedPath)?.profiles.shared).toEqual(apiKey("first"));
+      expect(committed.publishRuntimeSnapshots()).toBe(true);
+      expect(snapshotAt(first.sharedPath)?.profiles.shared).toEqual(apiKey("temporary"));
+      const derived = snapshotAt(first.agentPath);
+      expect(derived?.profiles).toMatchObject({
+        shared: apiKey("temporary"),
+        local: apiKey("first-local"),
+      });
+      if (!derived) {
+        throw new Error("missing first-root derived snapshot");
+      }
+      derived.profiles.external = {
+        type: "token",
+        provider: "anthropic",
+        token: "runtime-only-fixture",
+      };
+      derived.runtimeExternalProfileIds = ["external"];
+      replaceOwnedRuntimeAuthProfileStoreSnapshots(
+        listOwnedRuntimeAuthProfileStoreSnapshots().map((entry) => {
+          if (entry.databasePath === first.agentPath) {
+            entry.store = derived;
+          }
+          return entry;
+        }),
+      );
+
+      restoreAuthProfileStorePersistenceSnapshot(baseline, committed.owned);
+
+      expect(loadPersistedSharedAuthProfileStore(first.env)?.profiles.shared).toEqual(
+        apiKey("first"),
+      );
+      expect(snapshotAt(first.sharedPath)?.profiles.shared).toEqual(apiKey("first"));
+      expect(snapshotAt(first.agentPath)?.profiles).toEqual({
+        shared: apiKey("first"),
+        local: apiKey("first-local"),
+        external: derived.profiles.external,
+      });
+      expect(
+        listOwnedRuntimeAuthProfileStoreSnapshots().filter(
+          (entry) =>
+            entry.databasePath === second.sharedPath || entry.databasePath === second.agentPath,
+        ),
+      ).toEqual(otherSnapshots);
+      expect(loadPersistedSharedAuthProfileStore(second.env)?.profiles.shared).toEqual(
+        apiKey("second"),
+      );
+      assertOuterUnchanged();
+    },
+  );
+
+  it("keeps concurrent batch compensation bound to its captured shared owner", async () => {
+    const roots = await Promise.all([seedRoot("first"), seedRoot("second")]);
+    const assertOuterUnchanged = unreadableOuter("future");
+    const receipts = await Promise.all(
+      roots.map(({ stateDir }) =>
+        persistAuthProfileBatch({
+          stateDir,
+          profiles: [{ profileId: "attempt", credential: apiKey(stateDir) }],
+        }),
+      ),
+    );
+    const [firstReceipt, secondReceipt] = receipts;
+    if (!firstReceipt || !secondReceipt) {
+      throw new Error("missing batch compensation receipts");
+    }
+    firstReceipt.rollback();
+    expect(loadPersistedSharedAuthProfileStore(roots[0].env)?.profiles.attempt).toBeUndefined();
+    expect(loadPersistedSharedAuthProfileStore(roots[1].env)?.profiles.attempt).toEqual(
+      apiKey(roots[1].stateDir),
+    );
+    expect(snapshotAt(roots[1].agentPath)?.profiles.attempt).toEqual(apiKey(roots[1].stateDir));
+    secondReceipt.rollback();
+    secondReceipt.rollback();
+    for (const root of roots) {
+      expect(loadPersistedSharedAuthProfileStore(root.env)?.profiles.attempt).toBeUndefined();
+      expect(snapshotAt(root.agentPath)?.profiles.attempt).toBeUndefined();
+    }
+    assertOuterUnchanged();
+  });
+
+  it("deduplicates OAuth against the selected shared owner, not an unrelated ambient owner", async () => {
+    const first = await seedRoot("first");
+    const second = await seedRoot("second");
+    const oauth: AuthProfileCredential = {
+      type: "oauth",
+      provider: "anthropic",
+      access: "test-access",
+      refresh: "test-refresh",
+      expires: Date.now() + 600_000,
+    };
+    await persistAuthProfileBatch({
+      stateDir: second.stateDir,
+      profiles: [{ profileId: "oauth", credential: oauth }],
+    });
+    vi.stubEnv("OPENCLAW_STATE_DIR", second.stateDir);
+    await persistAuthProfileBatch({
+      stateDir: first.stateDir,
+      agentDir: first.agentDir,
+      profiles: [{ profileId: "oauth", credential: oauth }],
+    });
+    expect(loadPersistedAuthProfileStore(first.agentDir)?.profiles.oauth).toEqual(oauth);
+    await persistAuthProfileBatch({
+      stateDir: first.stateDir,
+      profiles: [{ profileId: "oauth", credential: oauth }],
+    });
+    const freshAgentDir = tempDirs.make("openclaw-auth-owner-fresh-agent-");
+    await updateAuthProfileStoreWithLock({
+      stateDir: first.stateDir,
+      agentDir: freshAgentDir,
+      saveOptions,
+      updater: (current) => {
+        current.profiles.oauth = oauth;
+        return true;
+      },
+    });
+    expect(loadPersistedAuthProfileStore(freshAgentDir)?.profiles.oauth).toBeUndefined();
+    // Existing local ownership is intentionally preserved, not retroactively deduplicated.
+    expect(loadPersistedAuthProfileStore(first.agentDir)?.profiles.oauth).toEqual(oauth);
+    expect(loadPersistedSharedAuthProfileStore(first.env)?.profiles.oauth).toEqual(oauth);
+  });
+});

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -4,7 +4,9 @@
  * profiles, and external CLI overlays while keeping save paths local.
  */
 import { AsyncLocalStorage } from "node:async_hooks";
+import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
+import { resolveStateDir } from "../../config/paths.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { isSecretRef } from "../../config/types.secrets.js";
 import { isSqliteLockError } from "../../infra/sqlite-transaction.js";
@@ -22,6 +24,7 @@ import {
   AuthProfileMigrationRequiredError,
   AuthProfileStoreUnreadableError,
   assertAuthProfileMigrationReady,
+  assertAuthProfileMigrationStateAtDatabasePath,
   clearAuthProfileMigrationRequired,
   listLegacyAuthProfileSources,
   markAuthProfileMigrationRequired,
@@ -43,6 +46,7 @@ import {
 import {
   buildPersistedAuthProfileSecretsStore,
   loadPersistedAuthProfileStore,
+  loadPersistedAuthProfileStoreAtDatabasePath,
   loadPersistedSharedAuthProfileStore,
   mergeAuthProfileStores,
 } from "./persisted.js";
@@ -53,16 +57,34 @@ import {
   setRuntimeExternalCliProfileIds,
 } from "./runtime-external-profile-references.js";
 import {
+  captureRuntimeAuthProfileLegacyCandidates,
+  createEmptyAuthProfileStore,
+  listRuntimeLocalProfileIds,
+  loadRuntimeAuthProfileOwnerSnapshot,
+  markRuntimePersistedProfiles,
+  mergeLocalAuthProfileStoreWithInheritedStore,
+  runtimeAuthProfileSnapshotSharesOwner,
+  runtimeStoreInheritsMainState,
+  setRuntimeLocalProfileMetadata,
+  stripRuntimeExternalProfileMetadata,
+} from "./runtime-snapshot-owner.js";
+import {
   clearRuntimeAuthProfileStoreSnapshotCore,
+  clearRuntimeAuthProfileStoreSnapshotAtDatabasePath,
   getPreparedRuntimeAuthProfileStoreSnapshotCore,
   getRuntimeAuthProfileStoreSnapshotCore,
+  getRuntimeAuthProfileStoreSnapshotAtDatabasePath,
+  getOwnedRuntimeAuthProfileStoreSnapshotAtDatabasePath,
   getRuntimeAuthProfileStoreSnapshotRevision,
   getRuntimeAuthProfileStoreSnapshotRevisionAtDatabasePath,
   noteRuntimeAuthProfileStorePersistedMutation,
-  listRuntimeAuthProfileStoreSnapshots,
-  replaceRuntimeAuthProfileStoreSnapshots,
+  listOwnedRuntimeAuthProfileStoreSnapshots,
+  listRuntimeAuthProfileStoreSnapshotsForSharedOwner,
+  restoreOwnedRuntimeAuthProfileStoreSnapshot,
   setRuntimeAuthProfileStoreSnapshot,
+  updateRuntimeAuthProfileStoreSnapshot,
   setRuntimeAuthProfileStoreSnapshotAtDatabasePath,
+  type OwnedRuntimeAuthProfileStoreSnapshotEntry,
 } from "./runtime-snapshots.js";
 import {
   deferAuthProfilePostCommitPublication,
@@ -72,10 +94,13 @@ import {
   readPersistedAuthProfileStoreRaw,
   readPersistedAuthProfileStateRaw,
   resolveAuthProfileDatabasePath as resolveAgentAuthPath,
+  resolveAuthProfileStoreOwner,
   runAuthProfileWriteTransaction,
   writePersistedAuthProfileStateRaw,
   writePersistedAuthProfileStoreRaw,
   type AuthProfileDatabase,
+  type AuthProfileStoreOwner,
+  type PreparedAuthProfileStoreOwner,
 } from "./sqlite.js";
 import { buildPersistedAuthProfileState, loadPersistedAuthProfileState } from "./state.js";
 import type { AuthProfileStore, RuntimeAuthProfileStore } from "./types.js";
@@ -104,13 +129,9 @@ type SaveAuthProfileStoreOptions = {
 const INLINE_OAUTH_TOKEN_FIELDS = ["access", "refresh", "idToken"] as const;
 type AuthProfileRuntimeMode =
   | { kind: "env-only" }
-  | { kind: "agent-dir"; agentDir: string; sharedStore?: AuthProfileStore };
+  | { kind: "agent-dir"; agentDir: string; sharedStore?: AuthProfileStore; env: NodeJS.ProcessEnv };
 
 const authProfileRuntimeMode = new AsyncLocalStorage<AuthProfileRuntimeMode>();
-
-function createEmptyAuthProfileStore(): AuthProfileStore {
-  return { version: AUTH_STORE_VERSION, profiles: {} };
-}
 
 /** Run a bounded operation without persisted or external CLI auth profiles. */
 export function withEnvOnlyAuthProfileStore<T>(run: () => T): T {
@@ -128,7 +149,7 @@ export function withAuthProfileStoreAgentDir<T>(
   if (resolveSharedAuthStoreOwnership(env).location === "state-db") {
     const shared = loadPersistedSharedAuthProfileStore(env);
     if (!shared && inspectPersistedSharedAuthProfileStoreRaw(env).status !== "missing") {
-      throw new AuthProfileStoreUnreadableError(undefined, env);
+      throw new AuthProfileStoreUnreadableError(resolveSharedAuthPath(env));
     }
     sharedStore = shared ?? createEmptyAuthProfileStore();
   }
@@ -143,7 +164,12 @@ export function withAuthProfileStoreAgentDir<T>(
     );
     pruneAuthProfileStoreReferences(sharedStore, new Set(Object.keys(sharedStore.profiles)));
   }
-  return authProfileRuntimeMode.run({ kind: "agent-dir", agentDir, sharedStore }, run);
+  return authProfileRuntimeMode.run({ kind: "agent-dir", agentDir, sharedStore, env }, run);
+}
+
+function getScopedAuthProfileEnv(): NodeJS.ProcessEnv | undefined {
+  const mode = authProfileRuntimeMode.getStore();
+  return mode?.kind === "agent-dir" ? mode.env : undefined;
 }
 
 function getScopedSharedAuthStore(): AuthProfileStore | undefined {
@@ -277,10 +303,9 @@ function publishRuntimeSnapshotsAfterCommit(
     }
     return converged;
   } catch (err) {
-    replaceRuntimeAuthProfileStoreSnapshot(
-      undefined,
-      publication.agentDir,
+    clearRuntimeAuthProfileStoreSnapshotAtDatabasePath(
       publication.databasePath,
+      publication.agentDir,
     );
     authProfilesLog.warn("auth profile store committed but runtime snapshot publication failed", {
       err,
@@ -316,14 +341,23 @@ function resolvePersistedLoadOptions(
 function loadPersistedAuthProfileStores(
   agentDir?: string,
   database?: AuthProfileDatabase,
+  owner?: AuthProfileStoreOwner,
 ): PersistedAuthProfileStores {
   const localStore = loadPersistedAuthProfileStore(agentDir, database ? { database } : undefined);
-  const localAuthPath = agentDir ? resolveAgentAuthPath(agentDir) : resolveSharedAuthPath();
-  const isMainStore = localAuthPath === resolveSharedAuthPath();
+  const localAuthPath =
+    owner?.databasePath ?? (agentDir ? resolveAgentAuthPath(agentDir) : resolveSharedAuthPath());
+  const isMainStore = localAuthPath === (owner?.sharedDatabasePath ?? resolveSharedAuthPath());
   return {
     isMainStore,
     localStore,
-    mainStore: isMainStore ? localStore : loadPersistedAuthProfileStore(),
+    mainStore: isMainStore
+      ? localStore
+      : owner
+        ? loadPersistedAuthProfileStoreAtDatabasePath(
+            owner.sharedDatabasePath,
+            owner.location === "state-db" ? "shared-state" : "agent",
+          )
+        : loadPersistedAuthProfileStore(),
   };
 }
 
@@ -483,42 +517,47 @@ function maybeSyncPersistedExternalCliAuthProfiles(params: {
   let publishRuntimeSnapshots: RuntimeSnapshotPublication | undefined;
   let result: ExternalCliSyncResult;
   try {
-    result = runAuthProfileWriteTransaction(params.agentDir, (database) => {
-      const latestStore = loadPersistedAuthProfileStore(params.agentDir, {
-        ...resolvePersistedLoadOptions(params.options),
-        database,
-      }) ?? {
-        version: AUTH_STORE_VERSION,
-        profiles: {},
-      };
-      let changed = false;
-      for (const [profileId, credential] of changedProfiles) {
-        const previous = params.store.profiles[profileId];
-        const latest = latestStore.profiles[profileId];
-        if (!isDeepStrictEqual(latest, previous)) {
-          authProfilesLog.debug(
-            "skipped persisted external cli auth sync for concurrently changed profile",
-            {
-              profileId,
-            },
-          );
-          continue;
-        }
-        latestStore.profiles[profileId] = credential;
-        changed = true;
-      }
-      if (changed) {
-        publishRuntimeSnapshots = saveAuthProfileStoreInTransaction(
-          latestStore,
-          params.agentDir,
-          {
-            filterExternalAuthProfiles: false,
-          },
+    result = runAuthProfileWriteTransaction(
+      params.agentDir,
+      (database, owner) => {
+        const latestStore = loadPersistedAuthProfileStore(params.agentDir, {
+          ...resolvePersistedLoadOptions(params.options),
           database,
-        );
-      }
-      return { store: latestStore, cacheable: true };
-    });
+        }) ?? {
+          version: AUTH_STORE_VERSION,
+          profiles: {},
+        };
+        let changed = false;
+        for (const [profileId, credential] of changedProfiles) {
+          const previous = params.store.profiles[profileId];
+          const latest = latestStore.profiles[profileId];
+          if (!isDeepStrictEqual(latest, previous)) {
+            authProfilesLog.debug(
+              "skipped persisted external cli auth sync for concurrently changed profile",
+              {
+                profileId,
+              },
+            );
+            continue;
+          }
+          latestStore.profiles[profileId] = credential;
+          changed = true;
+        }
+        if (changed) {
+          publishRuntimeSnapshots = saveAuthProfileStoreInTransaction(
+            latestStore,
+            params.agentDir,
+            {
+              filterExternalAuthProfiles: false,
+            },
+            database,
+            owner,
+          );
+        }
+        return { store: latestStore, cacheable: true };
+      },
+      { env: getScopedAuthProfileEnv() },
+    );
   } catch (err) {
     authProfilesLog.warn(
       "skipped persisted external cli auth sync because auth store write failed",
@@ -534,6 +573,7 @@ function maybeSyncPersistedExternalCliAuthProfiles(params: {
 }
 
 function shouldKeepProfileInLocalStore(params: {
+  owner: AuthProfileStoreOwner;
   store: AuthProfileStore;
   profileId: string;
   credential: AuthProfileStore["profiles"][string];
@@ -580,9 +620,9 @@ function shouldKeepProfileInLocalStore(params: {
         profiles: params.externalProfiles(),
       });
     }
-    const runtimeCredential = getRuntimeAuthProfileStoreSnapshot(params.agentDir)?.profiles[
-      params.profileId
-    ];
+    const runtimeCredential = getRuntimeAuthProfileStoreSnapshotAtDatabasePath(
+      params.owner.databasePath,
+    )?.profiles[params.profileId];
     if (!runtimeCredential || isDeepStrictEqual(runtimeCredential, params.credential)) {
       return false;
     }
@@ -649,6 +689,7 @@ function pruneAuthProfileStoreReferences(
 }
 
 function buildLocalAuthProfileStoreForSave(params: {
+  owner: AuthProfileStoreOwner;
   store: AuthProfileStore;
   agentDir?: string;
   options?: SaveAuthProfileStoreOptions;
@@ -664,6 +705,7 @@ function buildLocalAuthProfileStoreForSave(params: {
   localStore.profiles = Object.fromEntries(
     Object.entries(localStore.profiles).filter(([profileId, credential]) =>
       shouldKeepProfileInLocalStore({
+        owner: params.owner,
         store: params.store,
         profileId,
         credential,
@@ -735,30 +777,8 @@ function buildAuthProfileStoreWithoutExternalProfiles(params: {
   return stripRuntimeExternalProfileMetadata(mergeAuthProfileStores(persistedStore, localStore));
 }
 
-function stripRuntimeExternalProfileMetadata(store: AuthProfileStore): AuthProfileStore {
-  const stripped = { ...store };
-  delete stripped.runtimeExternalProfileIds;
-  delete stripped.runtimeExternalProfileIdsAuthoritative;
-  setRuntimeExternalCliProfileIds(stripped, []);
-  return stripped;
-}
-
-function markRuntimePersistedProfiles(
-  store: AuthProfileStore,
-  persistedStore: AuthProfileStore = store,
-): AuthProfileStore {
-  const profileIds = Object.entries(persistedStore.profiles)
-    .flatMap(([profileId, credential]) =>
-      isDeepStrictEqual(store.profiles[profileId], credential) ? [profileId] : [],
-    )
-    .toSorted();
-  return {
-    ...store,
-    runtimePersistedProfileIds: profileIds.length > 0 ? profileIds : undefined,
-  };
-}
-
 function buildRuntimeAuthProfileStoreForSave(params: {
+  owner: AuthProfileStoreOwner;
   store: AuthProfileStore;
   agentDir?: string;
   options?: SaveAuthProfileStoreOptions;
@@ -773,87 +793,20 @@ function buildRuntimeAuthProfileStoreForSave(params: {
   });
 }
 
-function setRuntimeLocalProfileMetadata(
-  store: AuthProfileStore,
-  localProfileIds: Iterable<string>,
-  runtimeInheritsMainState = false,
-): RuntimeAuthProfileStore {
-  return {
-    ...store,
-    runtimeLocalProfileIds: [...new Set(localProfileIds)].toSorted(),
-    ...(runtimeInheritsMainState ? { runtimeInheritsMainState: true } : {}),
-  };
-}
-
-function runtimeStoreInheritsMainState(
-  store: AuthProfileStore,
-  localStore: AuthProfileStore,
-): boolean {
-  const state = ({ order, lastGood, usageStats }: AuthProfileStore) => ({
-    order,
-    lastGood,
-    usageStats,
-  });
-  return !isDeepStrictEqual(state(store), state(localStore));
-}
-
-function mergeLocalAuthProfileStoreWithInheritedStore(
-  localStore: AuthProfileStore,
-  inheritedStore: AuthProfileStore,
-): RuntimeAuthProfileStore {
-  // Keep local ownership explicit after merging so later shared-store
-  // publication can reconstruct this owner without retaining inherited rows.
-  const merged = mergeAuthProfileStores(inheritedStore, localStore, {
-    preserveBaseRuntimeExternalProfiles: true,
-  });
-  return setRuntimeLocalProfileMetadata(
-    stripRuntimeExternalProfileMetadata(merged),
-    listRuntimeLocalProfileIds(localStore, inheritedStore),
-    runtimeStoreInheritsMainState(merged, localStore),
-  );
-}
-
-function refreshDerivedRuntimeAuthProfileStoreSnapshot(
-  derived: {
-    databasePath: string;
-    agentDir: string;
-    store: RuntimeAuthProfileStore;
-  },
-  committedSharedStore: AuthProfileStore,
+function convergeRuntimeAuthProfileStoreSnapshot(
+  databasePath: string,
+  agentDir: string | undefined,
+  operation: () => void,
 ): boolean {
   try {
-    rebuildRuntimeAuthProfileStoreSnapshot(
-      derived.agentDir,
-      derived.store,
-      undefined,
-      derived.databasePath,
-      committedSharedStore,
-      derived.store.runtimeLocalProfileIds,
-    );
+    operation();
     return true;
   } catch (err) {
-    replaceRuntimeAuthProfileStoreSnapshot(undefined, derived.agentDir, derived.databasePath);
-    authProfilesLog.warn("derived auth profile snapshot convergence failed", { err });
+    // A refused owner must not interrupt convergence of healthy sibling snapshots.
+    clearRuntimeAuthProfileStoreSnapshotAtDatabasePath(databasePath, agentDir);
+    authProfilesLog.warn("auth profile snapshot convergence failed", { err });
     return false;
   }
-}
-
-function listRuntimeLocalProfileIds(
-  store: RuntimeAuthProfileStore,
-  mainStore?: AuthProfileStore,
-): string[] {
-  if (store.runtimeLocalProfileIds) {
-    return store.runtimeLocalProfileIds;
-  }
-  return Object.entries(store.profiles).flatMap(([profileId, credential]) =>
-    mainStore &&
-    shouldUseMainOwnerForLocalOAuthCredential({
-      local: credential,
-      main: mainStore.profiles[profileId],
-    })
-      ? []
-      : [profileId],
-  );
 }
 
 function setRuntimeExternalProfileMetadata(params: {
@@ -1014,12 +967,16 @@ export async function updateAuthProfileStoreWithLock(params: {
   try {
     store = runAuthProfileWriteTransaction(
       agentDir,
-      (database) => {
-        const loadedStore = loadAuthProfileStoreForAgent(agentDir, {
-          database,
-          readOnly: true,
-          syncExternalCli: false,
-        });
+      (database, owner) => {
+        const loadedStore = loadAuthProfileStoreForAgent(
+          agentDir,
+          {
+            database,
+            readOnly: true,
+            syncExternalCli: false,
+          },
+          owner.env,
+        );
         const shouldSave = params.updater(loadedStore);
         if (shouldSave) {
           publishRuntimeSnapshots = saveAuthProfileStoreInTransaction(
@@ -1027,11 +984,16 @@ export async function updateAuthProfileStoreWithLock(params: {
             agentDir,
             params.saveOptions,
             database,
+            owner,
           );
         }
         return loadedStore;
       },
-      { sharedStoreWrite: params.sharedStoreWrite, stateDir: params.stateDir },
+      {
+        sharedStoreWrite: params.sharedStoreWrite,
+        stateDir: params.stateDir,
+        env: params.stateDir ? undefined : getScopedAuthProfileEnv(),
+      },
     );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -1064,40 +1026,57 @@ export function loadAuthProfileStore(): AuthProfileStore {
 function loadAuthProfileStoreForAgent(
   agentDir?: string,
   options?: LoadAuthProfileStoreOptions,
+  env?: NodeJS.ProcessEnv,
 ): AuthProfileStore {
   if (isEnvOnlyAuthProfileRuntime()) {
     return createEmptyAuthProfileStore();
   }
   const effectiveAgentDir = resolveRuntimeAuthProfileAgentDir(agentDir);
   const effectiveOptions = resolveRuntimeAuthProfileLoadOptions(options);
-  assertAuthProfileMigrationReady(effectiveAgentDir);
-  const store = loadPersistedAuthProfileStore(
-    effectiveAgentDir,
-    resolvePersistedLoadOptions(effectiveOptions),
-  );
+  assertAuthProfileMigrationReady(effectiveAgentDir, env);
+  const store =
+    !effectiveAgentDir && env && !effectiveOptions?.database
+      ? loadPersistedSharedAuthProfileStore(env)
+      : loadPersistedAuthProfileStore(
+          effectiveAgentDir,
+          resolvePersistedLoadOptions(effectiveOptions),
+        );
   if (
     !store &&
-    inspectPersistedAuthProfileStoreRaw(effectiveAgentDir, effectiveOptions?.database).status !==
-      "missing"
+    (!effectiveAgentDir && env && !effectiveOptions?.database
+      ? inspectPersistedSharedAuthProfileStoreRaw(env)
+      : inspectPersistedAuthProfileStoreRaw(effectiveAgentDir, effectiveOptions?.database)
+    ).status !== "missing"
   ) {
-    throw new AuthProfileStoreUnreadableError(effectiveAgentDir);
+    throw new AuthProfileStoreUnreadableError(
+      effectiveOptions?.database?.path ??
+        (effectiveAgentDir ? resolveAgentAuthPath(effectiveAgentDir) : resolveSharedAuthPath(env)),
+    );
   }
-  const legacySources = listLegacyAuthProfileSources({ agentDir: effectiveAgentDir });
+  const legacySources = listLegacyAuthProfileSources({
+    agentDir: effectiveAgentDir,
+    env,
+  });
   const credentialSources = legacySources.filter((source) => source.kind !== "auth-state");
   // A populated canonical store owns credentials; retired files beside it are
   // unarchived bytes. An empty or absent store still requires migration.
   if (credentialSources.length > 0 && (!store || Object.keys(store.profiles).length === 0)) {
     const migrationError = new AuthProfileMigrationRequiredError({
       agentDir: effectiveAgentDir,
+      env,
       sources: credentialSources,
     });
     if (store) {
-      markAuthProfileMigrationRequired(effectiveAgentDir, migrationError);
+      markAuthProfileMigrationRequired(effectiveAgentDir, migrationError, env);
     }
     throw migrationError;
   }
-  warnLegacyAuthProfileSourcesIgnored({ agentDir: effectiveAgentDir, sources: legacySources });
-  clearAuthProfileMigrationRequired(effectiveAgentDir);
+  warnLegacyAuthProfileSourcesIgnored({
+    agentDir: effectiveAgentDir,
+    env,
+    sources: legacySources,
+  });
+  clearAuthProfileMigrationRequired(effectiveAgentDir, env);
   const synced = maybeSyncPersistedExternalCliAuthProfiles({
     store: store ?? createEmptyAuthProfileStore(),
     agentDir: effectiveAgentDir,
@@ -1246,7 +1225,7 @@ export function ensureAuthProfileStore(
     // model and chat metadata generations converge without reopening credential sources.
     const materialized = mergeRuntimeExternalProfileState({ next: store, existing: runtimeStore });
     if (!isDeepStrictEqual(materialized, runtimeStore)) {
-      setRuntimeAuthProfileStoreSnapshot(materialized, effectiveAgentDir);
+      updateRuntimeAuthProfileStoreSnapshot(materialized, effectiveAgentDir);
     }
     return store;
   }
@@ -1427,17 +1406,20 @@ function saveAuthProfileStoreInTransaction(
   agentDir: string | undefined,
   options: SaveAuthProfileStoreOptions | undefined,
   database: AuthProfileDatabase,
+  owner: AuthProfileStoreOwner | PreparedAuthProfileStoreOwner,
   publishFromSuppliedStore = false,
 ): RuntimeSnapshotPublication {
   // Shared-state rows are global: never scope their persistence or runtime snapshots to an
   // agent, or shared credentials are published and cached as agent-local state.
   const persistenceAgentDir = "agentId" in database ? agentDir : undefined;
-  const savedAuthPath = persistenceAgentDir
-    ? resolveAgentAuthPath(persistenceAgentDir)
-    : database.path;
-  const mainAuthPath = persistenceAgentDir ? resolveSharedAuthPath() : database.path;
+  const savedAuthPath = owner.databasePath;
+  const mainAuthPath = owner.sharedDatabasePath;
   const savesMainStore = savedAuthPath === mainAuthPath;
-  const loadedPersistedStores = loadPersistedAuthProfileStores(persistenceAgentDir, database);
+  const loadedPersistedStores = loadPersistedAuthProfileStores(
+    persistenceAgentDir,
+    database,
+    owner,
+  );
   const persistedStores: PersistedAuthProfileStores = {
     ...loadedPersistedStores,
     localStore: loadedPersistedStores.localStore ?? {
@@ -1447,6 +1429,7 @@ function saveAuthProfileStoreInTransaction(
     },
   };
   const localStore = buildLocalAuthProfileStoreForSave({
+    owner,
     store,
     agentDir: persistenceAgentDir,
     options,
@@ -1477,6 +1460,7 @@ function saveAuthProfileStoreInTransaction(
   const suppliedRuntimeStore = publishFromSuppliedStore
     ? markRuntimePersistedProfiles(
         buildRuntimeAuthProfileStoreForSave({
+          owner,
           store,
           agentDir: persistenceAgentDir,
           options,
@@ -1501,52 +1485,74 @@ function saveAuthProfileStoreInTransaction(
     // Main-store publication invalidates derived stores. Capture the latest
     // overlays at the publication edge so post-commit refreshes are retained.
     const derivedSnapshots = savesMainStore
-      ? listRuntimeAuthProfileStoreSnapshots().filter(
-          (entry) => entry.databasePath !== mainAuthPath,
-        )
+      ? listRuntimeAuthProfileStoreSnapshotsForSharedOwner(owner)
       : [];
     if (credentialsChanged || stateChanged) {
-      noteRuntimeAuthProfileStorePersistedMutation(persistenceAgentDir, {
-        credentialsChanged,
-        profileSetChanged,
-        stateChanged,
-        profileIds: changedProfileIds,
-      });
+      noteRuntimeAuthProfileStorePersistedMutation(
+        persistenceAgentDir,
+        {
+          credentialsChanged,
+          profileSetChanged,
+          stateChanged,
+          profileIds: changedProfileIds,
+        },
+        owner,
+      );
+    }
+    try {
+      assertAuthProfileMigrationStateAtDatabasePath(savedAuthPath);
+    } catch (error) {
+      // A refused materialization does not undo committed mutation facts. State-only
+      // writes need explicit eviction too; credential mutation already invalidates them.
+      for (const derived of derivedSnapshots) {
+        clearRuntimeAuthProfileStoreSnapshotAtDatabasePath(derived.databasePath, derived.agentDir);
+      }
+      throw error;
     }
     if (suppliedRuntimeStore) {
-      const existing = getRuntimeAuthProfileStoreSnapshot(persistenceAgentDir);
+      const existing = getOwnedRuntimeAuthProfileStoreSnapshotAtDatabasePath(savedAuthPath);
       if (existing) {
-        setRuntimeAuthProfileStoreSnapshot(
-          materializeRuntimeAuthProfileStoreSnapshot(suppliedRuntimeStore, existing),
+        const materialized = runtimeAuthProfileSnapshotSharesOwner(existing.owner, owner)
+          ? materializeRuntimeAuthProfileStoreSnapshot(suppliedRuntimeStore, existing.store)
+          : suppliedRuntimeStore;
+        setRuntimeAuthProfileStoreSnapshotAtDatabasePath(
+          materialized,
+          savedAuthPath,
           persistenceAgentDir,
+          owner,
         );
       }
-      if (savesMainStore && (credentialsChanged || stateChanged)) {
-        let converged = true;
-        for (const derived of derivedSnapshots) {
-          converged =
-            refreshDerivedRuntimeAuthProfileStoreSnapshot(derived, committedSharedStore!) &&
-            converged;
-        }
-        return converged;
+      if (!credentialsChanged && !stateChanged) {
+        return true;
       }
-      return true;
-    }
-    if (savesMainStore) {
-      const existing = getRuntimeAuthProfileStoreSnapshot(persistenceAgentDir);
+    } else if (savesMainStore) {
+      const existing = getOwnedRuntimeAuthProfileStoreSnapshotAtDatabasePath(savedAuthPath);
       if (existing) {
-        setRuntimeAuthProfileStoreSnapshot(
-          materializeRuntimeAuthProfileStoreSnapshot(committedSharedStore!, existing),
+        setRuntimeAuthProfileStoreSnapshotAtDatabasePath(
+          runtimeAuthProfileSnapshotSharesOwner(existing.owner, owner)
+            ? materializeRuntimeAuthProfileStoreSnapshot(committedSharedStore!, existing.store)
+            : committedSharedStore!,
+          savedAuthPath,
           persistenceAgentDir,
+          owner,
         );
       }
     } else {
-      refreshRuntimeAuthProfileStoreSnapshot(persistenceAgentDir);
+      refreshRuntimeAuthProfileStoreSnapshot(persistenceAgentDir, owner);
     }
     let converged = true;
     for (const derived of derivedSnapshots) {
       converged =
-        refreshDerivedRuntimeAuthProfileStoreSnapshot(derived, committedSharedStore!) && converged;
+        convergeRuntimeAuthProfileStoreSnapshot(derived.databasePath, derived.agentDir, () =>
+          rebuildRuntimeAuthProfileStoreSnapshot(
+            derived.agentDir,
+            derived,
+            { ...owner, databasePath: derived.databasePath },
+            undefined,
+            committedSharedStore,
+            derived.store.runtimeLocalProfileIds,
+          ),
+        ) && converged;
     }
     return converged;
   };
@@ -1566,52 +1572,69 @@ export function saveAuthProfileStore(
 ): void {
   const effectiveAgentDir = resolveRuntimeAuthProfileAgentDir(agentDir);
   if (database) {
-    const publishRuntimeSnapshots = saveAuthProfileStoreInTransaction(
+    // Retain a prepared transaction owner, or use a shared connection's canonical identity.
+    saveAuthProfileStoreWithPreparedOwner(
       store,
       effectiveAgentDir,
       options,
       database,
-      true,
+      resolveAuthProfileStoreOwner(database, getScopedAuthProfileEnv()),
     );
-    const publishAfterCommit = () => {
-      publishRuntimeSnapshotsAfterCommit(publishRuntimeSnapshots);
-    };
-    if (!deferAuthProfilePostCommitPublication(database, publishAfterCommit)) {
-      // A supplied connection outside the transaction wrapper autocommits each write.
-      publishAfterCommit();
-    }
     return;
   }
   let publishRuntimeSnapshots: RuntimeSnapshotPublication | undefined;
   runAuthProfileWriteTransaction(
     effectiveAgentDir,
-    (transactionDatabase) => {
+    (transactionDatabase, owner) => {
       publishRuntimeSnapshots = saveAuthProfileStoreInTransaction(
         store,
         effectiveAgentDir,
         options,
         transactionDatabase,
+        owner,
       );
     },
-    { sharedStoreWrite: options?.sharedStoreWrite },
+    { sharedStoreWrite: options?.sharedStoreWrite, env: getScopedAuthProfileEnv() },
   );
   publishRuntimeSnapshotsAfterCommit(publishRuntimeSnapshots);
 }
 
+/** Core transaction callers carry the owner already selected before opening SQLite. */
+export function saveAuthProfileStoreWithPreparedOwner(
+  store: AuthProfileStore,
+  agentDir: string | undefined,
+  options: SaveAuthProfileStoreOptions | undefined,
+  database: AuthProfileDatabase,
+  owner: AuthProfileStoreOwner | PreparedAuthProfileStoreOwner,
+): void {
+  const publish = saveAuthProfileStoreInTransaction(
+    store,
+    agentDir,
+    options,
+    database,
+    owner,
+    true,
+  );
+  const publishAfterCommit = () => {
+    publishRuntimeSnapshotsAfterCommit(publish);
+  };
+  if (!deferAuthProfilePostCommitPublication(database, publishAfterCommit)) {
+    publishAfterCommit();
+  }
+}
+
 type AuthProfileStorePersistenceSnapshot = {
+  owner: PreparedAuthProfileStoreOwner;
   credentialsRaw: unknown;
   stateRaw: unknown;
   runtimeCaptured: boolean;
   runtimeRevision?: number;
   runtimeRevisionAtSaveEdge?: number;
   runtimeRevisionBeforePublication?: number;
-  runtimeStore?: AuthProfileStore;
-  derivedRuntimeStores?: Array<{
-    databasePath: string;
-    agentDir: string;
-    store: AuthProfileStore;
-    runtimeRevision?: number;
-  }>;
+  runtimeEntry?: OwnedRuntimeAuthProfileStoreSnapshotEntry;
+  derivedRuntimeStores?: Array<
+    OwnedRuntimeAuthProfileStoreSnapshotEntry & { runtimeRevision: number }
+  >;
   derivedRuntimeRevisionsAtSaveEdge?: Array<{
     databasePath: string;
     agentDir: string;
@@ -1629,34 +1652,45 @@ type CommittedAuthProfileStoreSave = {
   publishRuntimeSnapshots: () => boolean;
 };
 
+function assertAuthProfilePersistenceOwner(
+  owner: PreparedAuthProfileStoreOwner,
+  agentDir: string | undefined,
+  stateDir?: string,
+): void {
+  if (
+    stateDir &&
+    path.resolve(resolveStateDir({ ...owner.env, OPENCLAW_STATE_DIR: stateDir })) !==
+      path.resolve(resolveStateDir(owner.env))
+  ) {
+    throw new Error("explicit auth state directory does not match the captured owner");
+  }
+  const requestedPath = agentDir ? resolveAgentAuthPath(agentDir) : owner.sharedDatabasePath;
+  if (requestedPath !== owner.databasePath) {
+    throw new Error("auth profile persistence snapshot belongs to another owner");
+  }
+}
+
 function captureRuntimeAuthProfileStorePersistenceSnapshot(
-  agentDir?: string,
-  canonicalDatabasePath?: string,
+  owner: AuthProfileStoreOwner,
 ): Pick<
   AuthProfileStorePersistenceSnapshot,
-  "runtimeCaptured" | "runtimeRevision" | "runtimeStore" | "derivedRuntimeStores"
+  "runtimeCaptured" | "runtimeRevision" | "runtimeEntry" | "derivedRuntimeStores"
 > {
-  const capturedAuthPath =
-    canonicalDatabasePath ?? (agentDir ? resolveAgentAuthPath(agentDir) : resolveSharedAuthPath());
-  const mainAuthPath =
-    agentDir === undefined && canonicalDatabasePath
-      ? canonicalDatabasePath
-      : resolveSharedAuthPath();
+  const capturedAuthPath = owner.databasePath;
+  const mainAuthPath = owner.sharedDatabasePath;
   return {
     runtimeCaptured: true,
     runtimeRevision: getRuntimeAuthProfileStoreSnapshotRevisionAtDatabasePath(capturedAuthPath),
-    runtimeStore: getRuntimeAuthProfileStoreSnapshot(agentDir),
+    runtimeEntry: getOwnedRuntimeAuthProfileStoreSnapshotAtDatabasePath(capturedAuthPath),
     derivedRuntimeStores:
       capturedAuthPath === mainAuthPath
-        ? listRuntimeAuthProfileStoreSnapshots()
-            .filter((entry) => entry.databasePath !== mainAuthPath)
-            .map(({ agentDir: derivedAgentDir, databasePath, store }) => ({
-              databasePath,
-              agentDir: derivedAgentDir,
-              store,
-              runtimeRevision:
-                getRuntimeAuthProfileStoreSnapshotRevisionAtDatabasePath(databasePath),
-            }))
+        ? listRuntimeAuthProfileStoreSnapshotsForSharedOwner(owner).map((entry) =>
+            Object.assign(entry, {
+              runtimeRevision: getRuntimeAuthProfileStoreSnapshotRevisionAtDatabasePath(
+                entry.databasePath,
+              ),
+            }),
+          )
         : [],
   };
 }
@@ -1671,8 +1705,8 @@ function recordRuntimeAuthProfileStoreOwnership(
   if (runtime.runtimeRevision !== undefined) {
     owned.runtimeRevision = runtime.runtimeRevision;
   }
-  if (runtime.runtimeStore !== undefined) {
-    owned.runtimeStore = runtime.runtimeStore;
+  if (runtime.runtimeEntry !== undefined) {
+    owned.runtimeEntry = runtime.runtimeEntry;
   }
   if (runtime.derivedRuntimeStores !== undefined) {
     owned.derivedRuntimeStores = runtime.derivedRuntimeStores;
@@ -1703,46 +1737,59 @@ function recordRuntimeAuthProfileStorePublicationEdge(
 }
 
 function replaceRuntimeAuthProfileStoreSnapshot(
-  store: AuthProfileStore | undefined,
+  entry: OwnedRuntimeAuthProfileStoreSnapshotEntry | undefined,
   agentDir: string | undefined,
-  databasePath: string,
+  owner: AuthProfileStoreOwner,
 ): void {
-  if (store) {
-    setRuntimeAuthProfileStoreSnapshotAtDatabasePath(store, databasePath, agentDir);
+  if (entry) {
+    assertAuthProfileMigrationStateAtDatabasePath(entry.databasePath);
+    if (entry.owner.kind === "resolved") {
+      assertAuthProfileMigrationStateAtDatabasePath(entry.owner.sharedDatabasePath);
+    }
+    restoreOwnedRuntimeAuthProfileStoreSnapshot(entry, agentDir);
     return;
   }
-  replaceRuntimeAuthProfileStoreSnapshots(
-    listRuntimeAuthProfileStoreSnapshots().filter((entry) => entry.databasePath !== databasePath),
-  );
+  clearRuntimeAuthProfileStoreSnapshotAtDatabasePath(owner.databasePath, agentDir);
 }
 
-function refreshRuntimeAuthProfileStoreSnapshot(agentDir?: string): void {
-  const existing = getRuntimeAuthProfileStoreSnapshot(agentDir);
+function refreshRuntimeAuthProfileStoreSnapshot(
+  agentDir: string | undefined,
+  owner: AuthProfileStoreOwner,
+): void {
+  const existing = getOwnedRuntimeAuthProfileStoreSnapshotAtDatabasePath(owner.databasePath);
   if (!existing) {
     return;
   }
-  rebuildRuntimeAuthProfileStoreSnapshot(agentDir, existing);
+  rebuildRuntimeAuthProfileStoreSnapshot(agentDir, existing, owner);
 }
 
 function rebuildRuntimeAuthProfileStoreSnapshot(
   agentDir: string | undefined,
-  existing: AuthProfileStore,
+  existing: OwnedRuntimeAuthProfileStoreSnapshotEntry,
+  owner: AuthProfileStoreOwner | PreparedAuthProfileStoreOwner,
   predecessor?: AuthProfileStore,
-  databasePath?: string,
   inheritedStore?: AuthProfileStore,
   capturedLocalProfileIds?: Iterable<string>,
 ): void {
+  const isShared = owner.databasePath === owner.sharedDatabasePath;
+  const candidates =
+    "env" in owner
+      ? captureRuntimeAuthProfileLegacyCandidates(isShared ? undefined : agentDir, owner.env)
+      : runtimeAuthProfileSnapshotSharesOwner(existing.owner, owner)
+        ? existing.legacyCandidates
+        : undefined;
   let refreshed: AuthProfileStore;
   try {
-    refreshed = loadAuthProfileStoreWithoutExternalProfiles(agentDir);
+    // Publication reads the complete canonical owner, never a bounded run's
+    // portable-only view or a shared base selected from the current environment.
+    refreshed = loadRuntimeAuthProfileOwnerSnapshot(owner, { candidates, inheritedStore });
   } catch (err) {
-    if (!inheritedStore) {
+    if (!inheritedStore || err instanceof AuthProfileMigrationRequiredError) {
       throw err;
     }
-    // Persisted shared state is already committed. Recover only local profiles
-    // proven by this snapshot so deleted inherited credentials cannot survive.
+    // Preserve only proven local rows when the committed shared store cannot be reread.
     const localProfileIds = new Set(capturedLocalProfileIds);
-    const localStore = cloneAuthProfileStore(existing);
+    const localStore = cloneAuthProfileStore(existing.store);
     localStore.profiles = Object.fromEntries(
       Object.entries(localStore.profiles).filter(([profileId]) => localProfileIds.has(profileId)),
     );
@@ -1753,9 +1800,20 @@ function rebuildRuntimeAuthProfileStoreSnapshot(
       { err },
     );
   }
+  if (!runtimeAuthProfileSnapshotSharesOwner(existing.owner, owner)) {
+    // Resolved secrets and external profiles belong to their producer, not just a matching ref.
+    setRuntimeAuthProfileStoreSnapshotAtDatabasePath(
+      refreshed,
+      owner.databasePath,
+      agentDir,
+      owner,
+      candidates,
+    );
+    return;
+  }
   const currentMaterialized = preserveResolvedSecretBackedCredentials({
     next: refreshed,
-    existing,
+    existing: existing.store,
   });
   const materialized = predecessor
     ? preserveResolvedSecretBackedCredentials({
@@ -1763,30 +1821,36 @@ function rebuildRuntimeAuthProfileStoreSnapshot(
         existing: predecessor,
       })
     : currentMaterialized;
-  const rebuilt = mergeRuntimeExternalProfileReferences({ next: materialized, existing });
-  if (databasePath) {
-    setRuntimeAuthProfileStoreSnapshotAtDatabasePath(rebuilt, databasePath, agentDir);
-  } else {
-    setRuntimeAuthProfileStoreSnapshot(rebuilt, agentDir);
-  }
+  const rebuilt = mergeRuntimeExternalProfileReferences({
+    next: materialized,
+    existing: existing.store,
+  });
+  setRuntimeAuthProfileStoreSnapshotAtDatabasePath(
+    rebuilt,
+    owner.databasePath,
+    agentDir,
+    owner,
+    candidates,
+  );
 }
 
 /** Capture both persisted auth rows under one database lock. */
 export function captureAuthProfileStorePersistenceSnapshot(
   agentDir?: string,
-  options: { stateDir?: string } = {},
+  options: { stateDir?: string; env?: NodeJS.ProcessEnv } = {},
 ): AuthProfileStorePersistenceSnapshot {
   const effectiveAgentDir = resolveRuntimeAuthProfileAgentDir(agentDir);
   return runAuthProfileWriteTransaction(
     effectiveAgentDir,
-    (database) => {
+    (database, owner) => {
       return {
+        owner,
         credentialsRaw: readPersistedAuthProfileStoreRaw(effectiveAgentDir, database),
         stateRaw: readPersistedAuthProfileStateRaw(effectiveAgentDir, database),
-        ...captureRuntimeAuthProfileStorePersistenceSnapshot(effectiveAgentDir, database.path),
+        ...captureRuntimeAuthProfileStorePersistenceSnapshot(owner),
       };
     },
-    options,
+    { ...options, env: options.env ?? (options.stateDir ? undefined : getScopedAuthProfileEnv()) },
   );
 }
 
@@ -1802,15 +1866,14 @@ export function saveAuthProfileStoreIfPersistenceSnapshotMatches(params: {
   stateDir?: string;
 }): CommittedAuthProfileStoreSave {
   const agentDir = resolveRuntimeAuthProfileAgentDir(params.agentDir);
+  assertAuthProfilePersistenceOwner(params.snapshot.owner, agentDir, params.stateDir);
   let publishRuntimeSnapshots: RuntimeSnapshotPublication | undefined;
-  const owned: AuthProfileStorePersistenceSnapshot = {
-    credentialsRaw: null,
-    stateRaw: null,
-    runtimeCaptured: false,
-  };
-  runAuthProfileWriteTransaction(
+  const owned = runAuthProfileWriteTransaction(
     agentDir,
-    (database) => {
+    (database, owner) => {
+      if (params.snapshot.owner.databasePath !== database.path) {
+        throw new Error("auth profile persistence snapshot belongs to another database");
+      }
       const currentCredentials = readPersistedAuthProfileStoreRaw(agentDir, database);
       const currentState = readPersistedAuthProfileStateRaw(agentDir, database);
       if (
@@ -1819,12 +1882,8 @@ export function saveAuthProfileStoreIfPersistenceSnapshotMatches(params: {
       ) {
         throw new Error("auth profile store changed after secrets apply captured it");
       }
-      const runtimeAtSaveEdge = captureRuntimeAuthProfileStorePersistenceSnapshot(
-        agentDir,
-        database.path,
-      );
-      owned.runtimeRevisionAtSaveEdge = runtimeAtSaveEdge.runtimeRevision;
-      owned.derivedRuntimeRevisionsAtSaveEdge = runtimeAtSaveEdge.derivedRuntimeStores?.flatMap(
+      const runtimeAtSaveEdge = captureRuntimeAuthProfileStorePersistenceSnapshot(owner);
+      const derivedRuntimeRevisionsAtSaveEdge = runtimeAtSaveEdge.derivedRuntimeStores?.flatMap(
         (entry) =>
           typeof entry.runtimeRevision === "number"
             ? [
@@ -1841,11 +1900,18 @@ export function saveAuthProfileStoreIfPersistenceSnapshotMatches(params: {
         agentDir,
         params.options,
         database,
+        owner,
       );
-      owned.credentialsRaw = readPersistedAuthProfileStoreRaw(agentDir, database);
-      owned.stateRaw = readPersistedAuthProfileStateRaw(agentDir, database);
+      return {
+        owner,
+        credentialsRaw: readPersistedAuthProfileStoreRaw(agentDir, database),
+        stateRaw: readPersistedAuthProfileStateRaw(agentDir, database),
+        runtimeCaptured: false,
+        runtimeRevisionAtSaveEdge: runtimeAtSaveEdge.runtimeRevision,
+        derivedRuntimeRevisionsAtSaveEdge,
+      } satisfies AuthProfileStorePersistenceSnapshot;
     },
-    params.stateDir ? { stateDir: params.stateDir } : {},
+    { env: params.snapshot.owner.env },
   );
   return {
     owned,
@@ -1855,27 +1921,17 @@ export function saveAuthProfileStoreIfPersistenceSnapshotMatches(params: {
       }
       const publication = publishRuntimeSnapshots;
       return publishRuntimeSnapshotsAfterCommit({
-        ...(publication.agentDir ? { agentDir: publication.agentDir } : {}),
-        databasePath: publication.databasePath,
+        ...publication,
         publish: () => {
+          const owner = owned.owner;
           recordRuntimeAuthProfileStorePublicationEdge(
             owned,
-            captureRuntimeAuthProfileStorePersistenceSnapshot(
-              agentDir,
-              params.stateDir && agentDir === undefined
-                ? resolveSharedAuthPath({ ...process.env, OPENCLAW_STATE_DIR: params.stateDir })
-                : undefined,
-            ),
+            captureRuntimeAuthProfileStorePersistenceSnapshot(owner),
           );
           const converged = publication.publish();
           recordRuntimeAuthProfileStoreOwnership(
             owned,
-            captureRuntimeAuthProfileStorePersistenceSnapshot(
-              params.agentDir,
-              params.stateDir && params.agentDir === undefined
-                ? resolveSharedAuthPath({ ...process.env, OPENCLAW_STATE_DIR: params.stateDir })
-                : undefined,
-            ),
+            captureRuntimeAuthProfileStorePersistenceSnapshot(owner),
           );
           return converged;
         },
@@ -1885,6 +1941,7 @@ export function saveAuthProfileStoreIfPersistenceSnapshotMatches(params: {
 }
 
 function reconcileRuntimeAuthProfileStorePersistenceSnapshot(params: {
+  owner: AuthProfileStoreOwner;
   snapshot: AuthProfileStorePersistenceSnapshot;
   owned: AuthProfileStorePersistenceSnapshot;
   agentDir?: string;
@@ -1892,69 +1949,94 @@ function reconcileRuntimeAuthProfileStorePersistenceSnapshot(params: {
   stateOwned: boolean;
   credentialsRestored: boolean;
   stateRestored: boolean;
-  currentRuntimeStores: Array<{
-    databasePath: string;
-    agentDir: string;
-    store: AuthProfileStore;
-    runtimeRevision: number;
-  }>;
+  currentRuntimeStores: Array<
+    OwnedRuntimeAuthProfileStoreSnapshotEntry & { runtimeRevision: number }
+  >;
   currentRuntimeRevision: number;
-}): void {
+}): boolean {
   if (!params.snapshot.runtimeCaptured || !params.owned.runtimeCaptured) {
-    return;
+    return true;
   }
   const rowsFullyOwned = params.credentialsOwned && params.stateOwned;
   const rowsRestored = params.credentialsRestored || params.stateRestored;
   const reconcileOne = (
     databasePath: string,
     agentDir: string | undefined,
-    snapshotStore: AuthProfileStore | undefined,
+    snapshotEntry: OwnedRuntimeAuthProfileStoreSnapshotEntry | undefined,
     snapshotRuntimeRevision: number | undefined,
     runtimeRevisionAtSaveEdge: number | undefined,
     runtimeRevisionBeforePublication: number | undefined,
-    ownedStore: AuthProfileStore | undefined,
+    ownedEntry: OwnedRuntimeAuthProfileStoreSnapshotEntry | undefined,
     ownedRuntimeRevision: number | undefined,
-    currentStore: AuthProfileStore | undefined,
+    currentEntry: OwnedRuntimeAuthProfileStoreSnapshotEntry | undefined,
     currentRuntimeRevision: number,
-  ) => {
-    const runtimeGenerationOwned =
-      typeof snapshotRuntimeRevision === "number" &&
-      typeof runtimeRevisionAtSaveEdge === "number" &&
-      typeof runtimeRevisionBeforePublication === "number" &&
-      typeof ownedRuntimeRevision === "number" &&
-      snapshotRuntimeRevision === runtimeRevisionAtSaveEdge &&
-      runtimeRevisionAtSaveEdge === runtimeRevisionBeforePublication &&
-      currentRuntimeRevision === ownedRuntimeRevision;
-    if (rowsFullyOwned && runtimeGenerationOwned && isDeepStrictEqual(currentStore, ownedStore)) {
-      replaceRuntimeAuthProfileStoreSnapshot(snapshotStore, agentDir, databasePath);
-    } else if (rowsRestored && currentStore) {
-      // Current overlays win, while the predecessor can still supply materialized
-      // values for final keyRefs that the candidate temporarily removed.
-      rebuildRuntimeAuthProfileStoreSnapshot(agentDir, currentStore, snapshotStore, databasePath);
-    }
-  };
+  ) =>
+    convergeRuntimeAuthProfileStoreSnapshot(databasePath, agentDir, () => {
+      const runtimeGenerationOwned =
+        typeof snapshotRuntimeRevision === "number" &&
+        typeof runtimeRevisionAtSaveEdge === "number" &&
+        typeof runtimeRevisionBeforePublication === "number" &&
+        typeof ownedRuntimeRevision === "number" &&
+        snapshotRuntimeRevision === runtimeRevisionAtSaveEdge &&
+        runtimeRevisionAtSaveEdge === runtimeRevisionBeforePublication &&
+        currentRuntimeRevision === ownedRuntimeRevision;
+      if (
+        rowsFullyOwned &&
+        runtimeGenerationOwned &&
+        isDeepStrictEqual(currentEntry?.store, ownedEntry?.store) &&
+        isDeepStrictEqual(currentEntry?.owner, ownedEntry?.owner)
+      ) {
+        replaceRuntimeAuthProfileStoreSnapshot(snapshotEntry, agentDir, {
+          ...params.owner,
+          databasePath,
+        });
+      } else if (rowsRestored && currentEntry) {
+        // Current overlays win, while the predecessor can still supply materialized
+        // values. A newer runtime owner is independent of the transaction being undone.
+        const runtimeOwner =
+          currentEntry.owner.kind === "resolved"
+            ? currentEntry.owner
+            : runtimeAuthProfileSnapshotSharesOwner(currentEntry.owner, params.owner)
+              ? params.owner
+              : undefined;
+        if (!runtimeOwner) {
+          return;
+        }
+        const owner = {
+          databasePath,
+          sharedDatabasePath: runtimeOwner.sharedDatabasePath,
+          location: runtimeOwner.location,
+        };
+        rebuildRuntimeAuthProfileStoreSnapshot(
+          agentDir,
+          currentEntry,
+          owner,
+          snapshotEntry && runtimeAuthProfileSnapshotSharesOwner(snapshotEntry.owner, runtimeOwner)
+            ? snapshotEntry.store
+            : undefined,
+        );
+      }
+    });
 
-  const restoredAuthPath = params.agentDir
-    ? resolveAgentAuthPath(params.agentDir)
-    : resolveSharedAuthPath();
-  const mainAuthPath = resolveSharedAuthPath();
+  const restoredAuthPath = params.owner.databasePath;
+  const mainAuthPath = params.owner.sharedDatabasePath;
   const currentRuntimeStores = new Map(
     params.currentRuntimeStores.map((entry) => [entry.databasePath, entry]),
   );
-  reconcileOne(
+  let converged = reconcileOne(
     restoredAuthPath,
     params.agentDir,
-    params.snapshot.runtimeStore,
+    params.snapshot.runtimeEntry,
     params.snapshot.runtimeRevision,
     params.owned.runtimeRevisionAtSaveEdge,
     params.owned.runtimeRevisionBeforePublication,
-    params.owned.runtimeStore,
+    params.owned.runtimeEntry,
     params.owned.runtimeRevision,
-    currentRuntimeStores.get(restoredAuthPath)?.store,
+    currentRuntimeStores.get(restoredAuthPath),
     params.currentRuntimeRevision,
   );
   if (restoredAuthPath !== mainAuthPath) {
-    return;
+    return converged;
   }
   const snapshotDerived = new Map(
     (params.snapshot.derivedRuntimeStores ?? []).map((entry) => [entry.databasePath, entry]),
@@ -1980,19 +2062,21 @@ function reconcileRuntimeAuthProfileStorePersistenceSnapshot(params: {
     }
     const snapshotEntry = snapshotDerived.get(pathname);
     const ownedEntry = ownedDerived.get(pathname);
-    reconcileOne(
-      pathname,
-      currentEntry.agentDir,
-      snapshotEntry?.store,
-      snapshotEntry?.runtimeRevision,
-      saveEdgeDerivedRevisions.get(pathname),
-      publicationEdgeDerivedRevisions.get(pathname),
-      ownedEntry?.store,
-      ownedEntry?.runtimeRevision,
-      currentEntry.store,
-      currentEntry.runtimeRevision,
-    );
+    converged =
+      reconcileOne(
+        pathname,
+        currentEntry.agentDir,
+        snapshotEntry,
+        snapshotEntry?.runtimeRevision,
+        saveEdgeDerivedRevisions.get(pathname),
+        publicationEdgeDerivedRevisions.get(pathname),
+        ownedEntry,
+        ownedEntry?.runtimeRevision,
+        currentEntry,
+        currentEntry.runtimeRevision,
+      ) && converged;
   }
+  return converged;
 }
 
 /** Restore each persisted row and runtime snapshot only while apply still owns it. */
@@ -2002,6 +2086,13 @@ export function restoreAuthProfileStorePersistenceSnapshot(
   agentDir?: string,
   options: { stateDir?: string } = {},
 ): void {
+  assertAuthProfilePersistenceOwner(owned.owner, agentDir, options.stateDir);
+  if (
+    snapshot.owner.databasePath !== owned.owner.databasePath ||
+    snapshot.owner.sharedDatabasePath !== owned.owner.sharedDatabasePath
+  ) {
+    throw new Error("auth profile rollback snapshots belong to different owners");
+  }
   let credentialsOwned = false;
   let stateOwned = false;
   let credentialsRestored = false;
@@ -2009,7 +2100,10 @@ export function restoreAuthProfileStorePersistenceSnapshot(
   let publishRuntimeSnapshots: RuntimeSnapshotPublication | undefined;
   runAuthProfileWriteTransaction(
     agentDir,
-    (database) => {
+    (database, owner) => {
+      if (owned.owner.databasePath !== database.path) {
+        throw new Error("auth profile rollback belongs to another database");
+      }
       const existingRaw = readPersistedAuthProfileStoreRaw(agentDir, database);
       const existingState = readPersistedAuthProfileStateRaw(agentDir, database);
       credentialsOwned = isDeepStrictEqual(existingRaw, owned.credentialsRaw);
@@ -2045,31 +2139,41 @@ export function restoreAuthProfileStorePersistenceSnapshot(
       }
       publishRuntimeSnapshots = {
         ...(agentDir ? { agentDir } : {}),
-        databasePath: agentDir ? resolveAgentAuthPath(agentDir) : database.path,
+        databasePath: owner.databasePath,
         publish: () => {
           // Main credential mutation lineage invalidates derived snapshots. Capture
           // them first so exact-owned entries can restore and newer entries rebuild.
-          const currentRuntimeStores = listRuntimeAuthProfileStoreSnapshots().map(
-            ({ agentDir: runtimeAgentDir, databasePath, store }) => ({
-              databasePath,
-              agentDir: runtimeAgentDir,
-              store,
-              runtimeRevision:
-                getRuntimeAuthProfileStoreSnapshotRevisionAtDatabasePath(databasePath),
+          const currentRuntimeStores = [
+            ...listOwnedRuntimeAuthProfileStoreSnapshots().filter(
+              (entry) => entry.databasePath === owner.databasePath,
+            ),
+            ...(owner.databasePath === owner.sharedDatabasePath
+              ? listRuntimeAuthProfileStoreSnapshotsForSharedOwner(owner)
+              : []),
+          ].map((entry) =>
+            Object.assign(entry, {
+              runtimeRevision: getRuntimeAuthProfileStoreSnapshotRevisionAtDatabasePath(
+                entry.databasePath,
+              ),
             }),
           );
-          const currentRuntimePath = agentDir ? resolveAgentAuthPath(agentDir) : database.path;
+          const currentRuntimePath = owner.databasePath;
           const currentRuntimeRevision =
             getRuntimeAuthProfileStoreSnapshotRevisionAtDatabasePath(currentRuntimePath);
           if (credentialsRestored || stateRestored) {
-            noteRuntimeAuthProfileStorePersistedMutation(agentDir, {
-              credentialsChanged: credentialsRestored,
-              profileSetChanged: credentialsRestored && profileSetChanged,
-              stateChanged: stateRestored,
-              profileIds: credentialsRestored ? changedProfileIds : [],
-            });
+            noteRuntimeAuthProfileStorePersistedMutation(
+              agentDir,
+              {
+                credentialsChanged: credentialsRestored,
+                profileSetChanged: credentialsRestored && profileSetChanged,
+                stateChanged: stateRestored,
+                profileIds: credentialsRestored ? changedProfileIds : [],
+              },
+              owner,
+            );
           }
-          reconcileRuntimeAuthProfileStorePersistenceSnapshot({
+          return reconcileRuntimeAuthProfileStorePersistenceSnapshot({
+            owner,
             snapshot,
             owned,
             agentDir,
@@ -2080,11 +2184,10 @@ export function restoreAuthProfileStorePersistenceSnapshot(
             currentRuntimeStores,
             currentRuntimeRevision,
           });
-          return true;
         },
       };
     },
-    options,
+    { env: owned.owner.env },
   );
   publishRuntimeSnapshotsAfterCommit(publishRuntimeSnapshots);
 }

--- a/src/agents/auth-profiles/upsert-with-lock.ts
+++ b/src/agents/auth-profiles/upsert-with-lock.ts
@@ -11,7 +11,7 @@ import {
   writePersistedAuthProfileStateRaw,
 } from "./sqlite.js";
 import { buildPersistedAuthProfileState } from "./state.js";
-import { saveAuthProfileStore, updateAuthProfileStoreWithLock } from "./store.js";
+import { saveAuthProfileStoreWithPreparedOwner, updateAuthProfileStoreWithLock } from "./store.js";
 import type { AuthProfileCredential, AuthProfileStore } from "./types.js";
 import { resetAuthProfileFailureState } from "./usage-state.js";
 
@@ -54,9 +54,9 @@ export async function persistAuthProfileBatch(
   const appliedProfiles = new Map<string, AuthProfileCredential>();
   let storeWasAbsent = false;
   let stateWasAbsent = false;
-  runAuthProfileWriteTransaction(
+  const preparedOwner = runAuthProfileWriteTransaction(
     params.agentDir,
-    (database) => {
+    (database, owner) => {
       storeWasAbsent =
         inspectPersistedAuthProfileStoreRaw(params.agentDir, database).status === "missing";
       stateWasAbsent =
@@ -83,13 +83,15 @@ export async function persistAuthProfileBatch(
         }
       }
       if (appliedProfiles.size > 0) {
-        saveAuthProfileStore(
+        saveAuthProfileStoreWithPreparedOwner(
           next,
           params.agentDir,
           { filterExternalAuthProfiles: false, syncExternalCli: false },
           database,
+          owner,
         );
       }
+      return owner;
     },
     { sharedStoreWrite: true, stateDir: params.stateDir },
   );
@@ -102,7 +104,10 @@ export async function persistAuthProfileBatch(
       }
       runAuthProfileWriteTransaction(
         params.agentDir,
-        (database) => {
+        (database, owner) => {
+          if (database.path !== preparedOwner.databasePath) {
+            throw new Error("auth profile batch rollback belongs to another owner");
+          }
           const current = loadPersistedAuthProfileStore(params.agentDir, { database });
           if (!current) {
             return;
@@ -144,11 +149,12 @@ export async function persistAuthProfileBatch(
               }
             }
           }
-          saveAuthProfileStore(
+          saveAuthProfileStoreWithPreparedOwner(
             current,
             params.agentDir,
             { filterExternalAuthProfiles: false, syncExternalCli: false },
             database,
+            owner,
           );
           if (storeWasAbsent && Object.keys(current.profiles).length === 0) {
             deletePersistedAuthProfileStoreRaw(params.agentDir, database);
@@ -157,7 +163,7 @@ export async function persistAuthProfileBatch(
             writePersistedAuthProfileStateRaw(null, params.agentDir, database);
           }
         },
-        { sharedStoreWrite: true, stateDir: params.stateDir },
+        { sharedStoreWrite: true, env: preparedOwner.env },
       );
       rolledBack = true;
     },

--- a/src/agents/sessions/auth-storage.ts
+++ b/src/agents/sessions/auth-storage.ts
@@ -36,7 +36,7 @@ import {
 import { loadPersistedAuthProfileState } from "../auth-profiles/state.js";
 import {
   loadAuthProfileStoreForSecretsRuntime,
-  saveAuthProfileStore,
+  saveAuthProfileStoreWithPreparedOwner,
 } from "../auth-profiles/store.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
 import { getAgentDir } from "../config.js";
@@ -275,7 +275,9 @@ function loadSqliteAuthStorageStore(
   if (inspection.status === "missing") {
     const stateInspection = inspectPersistedAuthProfileStateRaw(agentDir, database);
     if (stateInspection.status === "unreadable") {
-      throw new AuthProfileStoreUnreadableError(agentDir);
+      throw new AuthProfileStoreUnreadableError(
+        database?.path ?? resolveAuthProfileDatabasePath(agentDir),
+      );
     }
     return {
       version: AUTH_STORE_VERSION,
@@ -285,7 +287,9 @@ function loadSqliteAuthStorageStore(
   }
   const store = loadPersistedAuthProfileStore(agentDir, database ? { database } : undefined);
   if (inspection.status === "unreadable" || !store) {
-    throw new AuthProfileStoreUnreadableError(agentDir);
+    throw new AuthProfileStoreUnreadableError(
+      database?.path ?? resolveAuthProfileDatabasePath(agentDir),
+    );
   }
   return store;
 }
@@ -312,12 +316,12 @@ class SqliteAuthStorageBackend implements AuthStorageBackend {
     assertAuthProfileMigrationReady(this.agentDir);
     const snapshots = this.resolveMaterializedRuntimeStores();
     assertAuthProfileMigrationReady(this.agentDir);
-    return runAuthProfileWriteTransaction(this.agentDir, (database) => {
+    return runAuthProfileWriteTransaction(this.agentDir, (database, owner) => {
       const store = loadSqliteAuthStorageStore(this.agentDir, database);
       const materializedData = projectAuthoritativeAuthStorageData(store, snapshots);
       const { result, next } = fn(JSON.stringify(materializedData));
       if (next !== undefined) {
-        saveAuthProfileStore(
+        saveAuthProfileStoreWithPreparedOwner(
           applyAuthStorageData(store, JSON.parse(next) as AuthStorageData, materializedData),
           this.agentDir,
           {
@@ -326,6 +330,7 @@ class SqliteAuthStorageBackend implements AuthStorageBackend {
             syncExternalCli: false,
           },
           database,
+          owner,
         );
       }
       return result;
@@ -348,7 +353,7 @@ class SqliteAuthStorageBackend implements AuthStorageBackend {
           return result;
         }
         assertAuthProfileMigrationReady(this.agentDir);
-        runAuthProfileWriteTransaction(this.agentDir, (database) => {
+        runAuthProfileWriteTransaction(this.agentDir, (database, owner) => {
           const authoritative = loadSqliteAuthStorageStore(this.agentDir, database);
           if (!isDeepStrictEqual(authoritative.profiles, initialRaw.profiles)) {
             throw new AuthStoragePersistenceError(
@@ -356,7 +361,7 @@ class SqliteAuthStorageBackend implements AuthStorageBackend {
               undefined,
             );
           }
-          saveAuthProfileStore(
+          saveAuthProfileStoreWithPreparedOwner(
             applyAuthStorageData(authoritative, JSON.parse(next) as AuthStorageData, initialData),
             this.agentDir,
             {
@@ -365,6 +370,7 @@ class SqliteAuthStorageBackend implements AuthStorageBackend {
               syncExternalCli: false,
             },
             database,
+            owner,
           );
         });
         return result;

--- a/src/commands/agents.commands.add.ts
+++ b/src/commands/agents.commands.add.ts
@@ -78,7 +78,7 @@ function emptyBindingResult(config: Parameters<typeof applyAgentBindings>[0]): A
 function loadReadablePersistedAuthProfileStore(agentDir: string): AuthProfileStore | null {
   const store = loadPersistedAuthProfileStore(agentDir);
   if (!store && inspectPersistedAuthProfileStoreRaw(agentDir).status !== "missing") {
-    throw new AuthProfileStoreUnreadableError(agentDir);
+    throw new AuthProfileStoreUnreadableError(resolveAuthProfileDatabasePath(agentDir));
   }
   return store;
 }

--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -44,7 +44,7 @@ import {
   type AuthProfileDatabase,
 } from "../agents/auth-profiles/sqlite.js";
 import { coerceAuthProfileState } from "../agents/auth-profiles/state.js";
-import { saveAuthProfileStore } from "../agents/auth-profiles/store.js";
+import { saveAuthProfileStoreWithPreparedOwner } from "../agents/auth-profiles/store.js";
 import type {
   AuthProfileCredential,
   AuthProfileState,
@@ -820,7 +820,7 @@ function migrateLockedLegacyOAuthFile(params: {
   });
   const loaded = runAuthProfileWriteTransaction(
     undefined,
-    (database) => {
+    (database, owner) => {
       const authoritative = loadAuthProfileMigrationTargetStore(
         undefined,
         loadPersistedAuthProfileStore,
@@ -829,7 +829,7 @@ function migrateLockedLegacyOAuthFile(params: {
       if (!isDeepStrictEqual(authoritative, existing)) {
         throw new Error("canonical auth profile store changed during legacy OAuth migration");
       }
-      saveAuthProfileStore(
+      saveAuthProfileStoreWithPreparedOwner(
         next,
         undefined,
         {
@@ -840,6 +840,7 @@ function migrateLockedLegacyOAuthFile(params: {
           syncExternalCli: false,
         },
         database,
+        owner,
       );
       const verified = loadPersistedAuthProfileStore(undefined, { database });
       const verificationFailure = formatMissingAuthProfileSqliteVerification({
@@ -1167,7 +1168,7 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
           assertAuthProfileMigrationSourcesUnchanged(candidate, sourceReceipts);
           verifiedStore = runAuthProfileWriteTransaction(
             transactionAgentDir,
-            (database) => {
+            (database, owner) => {
               const authoritative = loadAuthProfileMigrationTargetStore(
                 candidate.agentDir,
                 loadMigratedStore,
@@ -1178,7 +1179,7 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
               if (!isDeepStrictEqual(authoritative, existing)) {
                 throw new Error("canonical auth profile store changed during legacy migration");
               }
-              saveAuthProfileStore(
+              saveAuthProfileStoreWithPreparedOwner(
                 next,
                 candidate.agentDir,
                 {
@@ -1188,6 +1189,7 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
                   syncExternalCli: false,
                 },
                 database,
+                owner,
               );
               const loaded = loadMigratedStore(candidate.agentDir, { database });
               const persistedStores = {

--- a/src/commands/onboard-auth.test.ts
+++ b/src/commands/onboard-auth.test.ts
@@ -9,6 +9,8 @@ import {
   setupAuthTestEnv,
 } from "../../test/helpers/auth-wizard.js";
 import { ensureAuthProfileStore } from "../agents/auth-profiles/store.js";
+import { resolveProviderIdForAuth } from "../agents/provider-auth-aliases.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { OAuthCredentials } from "../llm/utils/oauth/types.js";
 import {
   applyAuthProfileConfig,
@@ -35,13 +37,13 @@ vi.mock("../config/paths.js", async (importOriginal) => ({
 }));
 
 vi.mock("../agents/provider-auth-aliases.js", () => ({
-  resolveProviderIdForAuth: (provider: string) => {
+  resolveProviderIdForAuth: vi.fn((provider: string) => {
     const normalized = provider.trim().toLowerCase();
     if (normalized === "z.ai" || normalized === "z-ai") {
       return "zai";
     }
     return normalized;
-  },
+  }),
 }));
 
 vi.mock("../secrets/provider-env-vars.js", () => ({
@@ -420,24 +422,92 @@ describe("upsertApiKeyProfile", () => {
 });
 
 describe("applyAuthProfileConfig", () => {
-  it("promotes the newly selected profile to the front of auth.order", () => {
+  const configOnlyCases: {
+    name: string;
+    cfg: OpenClawConfig;
+    preferProfileFirst?: boolean;
+  }[] = [
+    { name: "first profile", cfg: {} },
+    {
+      name: "same-mode profiles",
+      cfg: { auth: { profiles: { old: { provider: "z.ai", mode: "api_key" } } } },
+    },
+    {
+      name: "replacing the only other mode",
+      cfg: { auth: { profiles: { selected: { provider: "z.ai", mode: "oauth" } } } },
+    },
+    {
+      name: "disabled promotion with an empty order",
+      cfg: { auth: { profiles: { old: { provider: "z.ai", mode: "oauth" } }, order: {} } },
+      preferProfileFirst: false,
+    },
+  ];
+  it.each(configOnlyCases)(
+    "adds $name without requiring plugin discovery when order cannot change",
+    ({ cfg, ...options }) => {
+      const lookup = vi.mocked(resolveProviderIdForAuth).mockImplementation(() => {
+        throw new Error("plugin discovery unavailable");
+      });
+      try {
+        const next = applyAuthProfileConfig(cfg, {
+          profileId: "selected",
+          provider: "z-ai",
+          mode: "api_key",
+          preferProfileFirst: options.preferProfileFirst,
+        });
+        expect(next).toEqual({
+          ...cfg,
+          auth: {
+            ...cfg.auth,
+            profiles: {
+              ...cfg.auth?.profiles,
+              selected: { provider: "z-ai", mode: "api_key" },
+            },
+          },
+        });
+      } finally {
+        lookup.mockReset();
+      }
+    },
+  );
+
+  it.each([
+    {
+      order: ["anthropic:default"],
+      prefer: true,
+      expected: ["anthropic:work", "anthropic:default"],
+    },
+    {
+      order: ["anthropic:default"],
+      prefer: false,
+      expected: ["anthropic:default", "anthropic:work"],
+    },
+    {
+      order: ["anthropic:default", "anthropic:work", "anthropic:default"],
+      prefer: false,
+      expected: ["anthropic:default", "anthropic:work"],
+    },
+    { order: [], prefer: true, expected: ["anthropic:work"] },
+    { order: [], prefer: false, expected: ["anthropic:work"] },
+  ])("updates explicit order $order with promotion=$prefer", ({ order, prefer, expected }) => {
     const next = applyAuthProfileConfig(
       {
         auth: {
           profiles: {
             "anthropic:default": { provider: "anthropic", mode: "api_key" },
           },
-          order: { anthropic: ["anthropic:default"] },
+          order: { anthropic: order, unrelated: ["unrelated:default"] },
         },
       },
       {
         profileId: "anthropic:work",
         provider: "anthropic",
         mode: "oauth",
+        preferProfileFirst: prefer,
       },
     );
 
-    expect(next.auth?.order?.anthropic).toEqual(["anthropic:work", "anthropic:default"]);
+    expect(next.auth?.order).toEqual({ anthropic: expected, unrelated: ["unrelated:default"] });
   });
 
   it("creates provider order when switching from legacy oauth to api_key without explicit order", () => {
@@ -457,6 +527,24 @@ describe("applyAuthProfileConfig", () => {
     );
 
     expect(next.auth?.order?.kilocode).toEqual(["kilocode:default", "kilocode:legacy"]);
+  });
+
+  it.each([
+    { provider: "z.ai", expected: ["zai:new", "legacy", "same-mode"] },
+    { provider: "unrelated", expected: undefined },
+  ])("groups mixed modes only for canonical peers of $provider", ({ provider, expected }) => {
+    const next = applyAuthProfileConfig(
+      {
+        auth: {
+          profiles: {
+            legacy: { provider, mode: "oauth" },
+            "same-mode": { provider: "z-ai", mode: "api_key" },
+          },
+        },
+      },
+      { profileId: "zai:new", provider: "zai", mode: "api_key" },
+    );
+    expect(next.auth?.order).toEqual(expected ? { zai: expected } : undefined);
   });
 
   it("repairs aliased auth.order keys instead of duplicating them", () => {

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -7,7 +7,10 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
-import { getRuntimeAuthProfileStoreCredentialsRevision } from "../agents/auth-profiles/runtime-snapshots.js";
+import {
+  getRuntimeAuthProfileStoreCredentialsRevision,
+  prepareRuntimeAuthProfileStoreSnapshots,
+} from "../agents/auth-profiles/runtime-snapshots.js";
 import { addSession, markBackgrounded, markExited } from "../agents/bash-process-registry.js";
 import { createProcessSessionFixture } from "../agents/bash-process-registry.test-helpers.js";
 import { resetProcessRegistryForTests } from "../agents/bash-process-registry.test-support.js";
@@ -454,16 +457,18 @@ function createRecordedChannelHandlers(events: string[]) {
 
 function makePreparedSecretsSnapshot(
   config: OpenClawConfig,
-  overrides: Partial<PreparedSecretsRuntimeSnapshot> = {},
+  overrides: Omit<Partial<PreparedSecretsRuntimeSnapshot>, "authStores"> & {
+    authStores?: Parameters<typeof prepareRuntimeAuthProfileStoreSnapshots>[0];
+  } = {},
 ): PreparedSecretsRuntimeSnapshot {
   return {
     sourceConfig: config,
     config,
-    authStores: [],
     authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
     warnings: [],
     webTools: createEmptyRuntimeWebToolsMetadata(),
     ...overrides,
+    authStores: prepareRuntimeAuthProfileStoreSnapshots(overrides.authStores ?? []),
   };
 }
 
@@ -5008,12 +5013,12 @@ describe("gateway Gmail hot reload handlers", () => {
     const initialSnapshot = makePreparedSecretsSnapshot(initialConfig);
     const refreshedSnapshot: PreparedSecretsRuntimeSnapshot = {
       ...initialSnapshot,
-      authStores: [
+      authStores: prepareRuntimeAuthProfileStoreSnapshots([
         {
           agentDir: "/tmp/refreshed-agent",
           store: { version: 1, profiles: {} },
         },
-      ],
+      ]),
     };
     activateSecretsRuntimeSnapshot(initialSnapshot);
     const initialSnapshotRevision = getActiveSecretsRuntimeSnapshotRevision();

--- a/src/gateway/server-startup-config.secrets.test.ts
+++ b/src/gateway/server-startup-config.secrets.test.ts
@@ -9,6 +9,7 @@ import { loadAuthProfileStoreWithoutExternalProfiles } from "../agents/auth-prof
 import {
   getRuntimeAuthProfileStoreCredentialsRevision,
   getRuntimeAuthProfileStoreSnapshotCore,
+  prepareRuntimeAuthProfileStoreSnapshots,
   setRuntimeAuthProfileStoreSnapshot,
 } from "../agents/auth-profiles/runtime-snapshots.js";
 import { writePersistedAuthProfileStoreRaw } from "../agents/auth-profiles/sqlite.js";
@@ -1235,7 +1236,7 @@ describe("gateway startup config secret preflight", () => {
     const initial = preparedSnapshot(gatewayTokenConfig({}));
     const candidate: PreparedSecretsRuntimeSnapshot = {
       ...preparedSnapshotWithGatewayToken(initial.sourceConfig, "candidate-token"),
-      authStores: [
+      authStores: prepareRuntimeAuthProfileStoreSnapshots([
         {
           agentDir,
           store: {
@@ -1251,7 +1252,7 @@ describe("gateway startup config secret preflight", () => {
             },
           },
         },
-      ],
+      ]),
     };
     const activateRuntimeSecretsSnapshot = vi.fn(activateSecretsRuntimeSnapshotForTest);
     const activateRuntimeSecrets = runtimeSecretsActivatorForTest({
@@ -2820,12 +2821,12 @@ describe("gateway startup config secret preflight", () => {
       agentDir,
     );
     const active = preparedSnapshot(gatewayTokenConfig({}));
-    active.authStores = [
+    active.authStores = prepareRuntimeAuthProfileStoreSnapshots([
       {
         agentDir,
         store: { version: 1, profiles: { "openai:default": credential } },
       },
-    ];
+    ]);
     active.authStoreCredentialsRevision = getRuntimeAuthProfileStoreCredentialsRevision();
     activateSecretsRuntimeSnapshotState({
       snapshot: active,

--- a/src/plugins/provider-auth-helpers.ts
+++ b/src/plugins/provider-auth-helpers.ts
@@ -153,7 +153,6 @@ export function applyAuthProfileConfig(
     preferProfileFirst?: boolean;
   },
 ): OpenClawConfig {
-  const normalizedProvider = resolveProviderIdForAuth(params.provider, { config: cfg });
   const profiles = {
     ...cfg.auth?.profiles,
     [params.profileId]: {
@@ -164,73 +163,56 @@ export function applyAuthProfileConfig(
     },
   };
 
-  const configuredProviderProfiles = Object.entries(cfg.auth?.profiles ?? {})
-    .filter(
-      ([, profile]) =>
-        resolveProviderIdForAuth(profile.provider, { config: cfg }) === normalizedProvider,
-    )
-    .map(([profileId, profile]) => ({ profileId, mode: profile.mode }));
-
-  // Maintain `auth.order` when it already exists. Additionally, if we detect
-  // mixed auth modes for the same provider, keep the newly selected profile first.
-  const matchingProviderOrderEntries = Object.entries(cfg.auth?.order ?? {}).filter(
-    ([providerId]) => resolveProviderIdForAuth(providerId, { config: cfg }) === normalizedProvider,
-  );
-  const existingProviderOrder =
-    matchingProviderOrderEntries.length > 0
-      ? uniqueStrings(matchingProviderOrderEntries.flatMap(([, order]) => order))
-      : undefined;
+  const next = { ...cfg, auth: { ...cfg.auth, profiles } };
+  const configuredProfiles = Object.entries(cfg.auth?.profiles ?? {});
+  const orderEntries = Object.entries(cfg.auth?.order ?? {});
   const preferProfileFirst = params.preferProfileFirst ?? true;
-  const reorderedProviderOrder =
-    existingProviderOrder && preferProfileFirst
-      ? [
-          params.profileId,
-          ...existingProviderOrder.filter((profileId) => profileId !== params.profileId),
-        ]
-      : existingProviderOrder;
-  const hasMixedConfiguredModes = configuredProviderProfiles.some(
-    ({ profileId, mode }) => profileId !== params.profileId && mode !== params.mode,
-  );
-  const derivedProviderOrder =
-    existingProviderOrder === undefined && preferProfileFirst && hasMixedConfiguredModes
-      ? [
-          params.profileId,
-          ...configuredProviderProfiles
-            .map(({ profileId }) => profileId)
-            .filter((profileId) => profileId !== params.profileId),
-        ]
-      : undefined;
-  const baseOrder =
-    matchingProviderOrderEntries.length > 0
-      ? Object.fromEntries(
-          Object.entries(cfg.auth?.order ?? {}).filter(
-            ([providerId]) =>
-              resolveProviderIdForAuth(providerId, { config: cfg }) !== normalizedProvider,
-          ),
-        )
-      : cfg.auth?.order;
-  const order =
-    existingProviderOrder !== undefined
-      ? {
-          ...baseOrder,
-          [normalizedProvider]: reorderedProviderOrder?.includes(params.profileId)
-            ? reorderedProviderOrder
-            : [...(reorderedProviderOrder ?? []), params.profileId],
-        }
-      : derivedProviderOrder
-        ? {
-            ...baseOrder,
-            [normalizedProvider]: derivedProviderOrder,
-          }
-        : baseOrder;
-  return {
-    ...cfg,
-    auth: {
-      ...cfg.auth,
-      profiles,
-      ...(order ? { order } : {}),
-    },
-  };
+  // Aliases only affect ordering. A config-only profile insertion must not
+  // discover plugins (and open their state database) when order cannot change.
+  if (
+    orderEntries.length === 0 &&
+    (!preferProfileFirst ||
+      !configuredProfiles.some(
+        ([profileId, profile]) => profileId !== params.profileId && profile.mode !== params.mode,
+      ))
+  ) {
+    return next;
+  }
+
+  const normalizedProvider = resolveProviderIdForAuth(params.provider, { config: cfg });
+  const matchesProvider = (provider: string) =>
+    resolveProviderIdForAuth(provider, { config: cfg }) === normalizedProvider;
+  const matchingOrderEntries = orderEntries.filter(([provider]) => matchesProvider(provider));
+  let providerOrder: string[] | undefined;
+  if (matchingOrderEntries.length > 0) {
+    const existingOrder = uniqueStrings(matchingOrderEntries.flatMap(([, order]) => order));
+    providerOrder = preferProfileFirst
+      ? [params.profileId, ...existingOrder.filter((profileId) => profileId !== params.profileId)]
+      : existingOrder.includes(params.profileId)
+        ? existingOrder
+        : [...existingOrder, params.profileId];
+  } else if (preferProfileFirst) {
+    const peers = configuredProfiles.filter(([, profile]) => matchesProvider(profile.provider));
+    if (
+      peers.some(
+        ([profileId, profile]) => profileId !== params.profileId && profile.mode !== params.mode,
+      )
+    ) {
+      providerOrder = [
+        params.profileId,
+        ...peers
+          .map(([profileId]) => profileId)
+          .filter((profileId) => profileId !== params.profileId),
+      ];
+    }
+  }
+  if (providerOrder) {
+    next.auth.order = {
+      ...Object.fromEntries(orderEntries.filter(([provider]) => !matchesProvider(provider))),
+      [normalizedProvider]: providerOrder,
+    };
+  }
+  return next;
 }
 
 /** Returns true when config still names a removed auth profile. */

--- a/src/secrets/apply.test.ts
+++ b/src/secrets/apply.test.ts
@@ -21,6 +21,7 @@ import {
 } from "../agents/auth-profiles/sqlite.js";
 import {
   getRuntimeAuthProfileStoreSnapshot,
+  loadAuthProfileStoreWithoutExternalProfiles,
   saveAuthProfileStore,
 } from "../agents/auth-profiles/store.js";
 import { testing as storeTesting } from "../agents/auth-profiles/store.test-support.js";
@@ -689,6 +690,62 @@ describe("secrets apply", () => {
       provider: "default",
       id: "OPENAI_API_KEY",
     });
+  });
+
+  it("preserves relocated shared inheritance when applying an agent SecretRef", async () => {
+    const sharedDir = path.join(fixture.rootDir, "relocated-shared");
+    const agentDir = path.join(fixture.rootDir, "ops-agent");
+    fixture.env.OPENCLAW_AGENT_DIR = sharedDir;
+    vi.stubEnv("OPENCLAW_STATE_DIR", fixture.stateDir);
+    vi.stubEnv("OPENCLAW_AGENT_DIR", sharedDir);
+    noteCommittedSharedAuthStoreOwnership({ location: "legacy-main" }, fixture.env);
+    const shared: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "openai:inherited": { type: "api_key", provider: "openai", key: "fake-inherited" },
+      },
+    };
+    const local: AuthProfileStore = {
+      version: 1,
+      profiles: { "openai:local": { type: "api_key", provider: "openai", key: "fake-local" } },
+    };
+    registerResolvedAgentDir({ agentId: "ops", agentDir });
+    await writeJsonFile(resolveAuthProfileDatabasePath(sharedDir), shared);
+    await writeJsonFile(resolveAuthProfileDatabasePath(agentDir), local);
+    await writeJsonFile(fixture.configPath, { agents: { entries: { ops: { agentDir } } } });
+    replaceRuntimeAuthProfileStoreSnapshots([
+      { agentDir, store: loadAuthProfileStoreWithoutExternalProfiles(agentDir) },
+    ]);
+    expect(getRuntimeAuthProfileStoreSnapshot(agentDir)?.profiles["openai:inherited"]).toEqual(
+      shared.profiles["openai:inherited"],
+    );
+    await runSecretsApply({
+      plan: createPlan({
+        targets: [
+          {
+            type: "auth-profiles.api_key.key",
+            path: "profiles.openai:local.key",
+            pathSegments: ["profiles", "openai:local", "key"],
+            agentId: "ops",
+            ref: OPENAI_API_KEY_ENV_REF,
+          },
+        ],
+        options: {
+          scrubEnv: false,
+          scrubAuthProfilesForProviderTargets: false,
+          scrubLegacyAuthJson: false,
+        },
+      }),
+      env: fixture.env,
+      write: true,
+    });
+    expect(readPersistedAuthProfileStoreRaw(agentDir)).toMatchObject({
+      profiles: { "openai:local": { keyRef: OPENAI_API_KEY_ENV_REF } },
+    });
+    expect(readPersistedAuthProfileStoreRaw(sharedDir)).toEqual(shared);
+    const runtime = getRuntimeAuthProfileStoreSnapshot(agentDir);
+    expect(runtime?.profiles["openai:inherited"]).toEqual(shared.profiles["openai:inherited"]);
+    expect(runtime?.profiles["openai:default"]).toBeUndefined();
   });
 
   it("rolls back committed auth rows when runtime publication fails", async () => {

--- a/src/secrets/apply.ts
+++ b/src/secrets/apply.ts
@@ -68,6 +68,7 @@ type AuthStoreSnapshot = {
 };
 
 type ProjectedState = {
+  authStoreEnv: NodeJS.ProcessEnv;
   nextConfig: OpenClawConfig;
   configSnapshot: ConfigFileSnapshot;
   configPath: string;
@@ -293,6 +294,10 @@ async function projectPlanState(params: {
   const options = normalizeSecretsPlanOptions(params.plan.options);
   const nextConfig = structuredClone(snapshot.config);
   const stateDir = resolveStateDir(params.env, os.homedir);
+  const authStoreEnv = {
+    ...params.env,
+    OPENCLAW_STATE_DIR: stateDir,
+  };
   const changedFiles = new Set<string>();
   const warnings: string[] = [];
   const configPath = resolveUserPath(snapshot.path);
@@ -353,6 +358,7 @@ async function projectPlanState(params: {
 
   return {
     nextConfig,
+    authStoreEnv,
     configSnapshot: snapshot,
     configPath,
     configWriteOptions: writeOptions,
@@ -894,7 +900,9 @@ export async function runSecretsApply(params: {
         target,
         persistence: captureAuthProfileStorePersistenceSnapshot(
           target.kind === "agent" ? target.agentDir : undefined,
-          target.kind === "shared" ? { stateDir: target.stateDir } : {},
+          {
+            env: target.kind === "shared" ? target.env : projected.authStoreEnv,
+          },
         ),
       });
     }

--- a/src/secrets/runtime-auth-refresh-failure.test.ts
+++ b/src/secrets/runtime-auth-refresh-failure.test.ts
@@ -263,9 +263,10 @@ describe("secrets runtime snapshot auth refresh failure", () => {
       );
       expect(candidate.authStores[0]?.store.profiles[profileId]).toMatchObject({
         type: "api_key",
+        provider: "openai",
         keyRef: OPENAI_FILE_KEY_REF,
-        key: undefined,
       });
+      expect(candidate.authStores[0]?.store.profiles[profileId]).not.toHaveProperty("key");
     });
   });
 });

--- a/src/secrets/runtime-auth-store-inline-refs.test.ts
+++ b/src/secrets/runtime-auth-store-inline-refs.test.ts
@@ -137,11 +137,19 @@ describe("secrets runtime snapshot inline auth-store refs", () => {
         }),
       ]),
     );
-    expect(snapshot.authStores[0]?.store.profiles[profileId]).toHaveProperty("key", undefined);
-    expect(snapshot.authStores[0]?.store.profiles[tokenProfileId]).toHaveProperty(
-      "token",
-      undefined,
-    );
+    const profiles = snapshot.authStores[0]?.store.profiles;
+    expect(profiles?.[profileId]).toMatchObject({
+      type: "api_key",
+      provider: "openai",
+      keyRef: { source: "env", provider: "default", id: "MISSING_MISMATCHED_KEY" },
+    });
+    expect(profiles?.[profileId]).not.toHaveProperty("key");
+    expect(profiles?.[tokenProfileId]).toMatchObject({
+      type: "token",
+      provider: "github-copilot",
+      tokenRef: { source: "env", provider: "default", id: "MISSING_MISMATCHED_TOKEN" },
+    });
+    expect(profiles?.[tokenProfileId]).not.toHaveProperty("token");
   });
 
   it("isolates a failed profile ref while materializing an eligible sibling profile", async () => {
@@ -179,8 +187,11 @@ describe("secrets runtime snapshot inline auth-store refs", () => {
     ]);
     const profiles = snapshot.authStores[0]?.store.profiles;
     expect(profiles?.[coldProfileId]).toMatchObject({
+      type: "api_key",
+      provider: "openai",
       keyRef: { source: "env", provider: "default", id: "MISSING_OPENAI_PROFILE_KEY" },
     });
+    expect(profiles?.[coldProfileId]).not.toHaveProperty("key");
     expect(profiles?.[healthyProfileId]).toMatchObject({ key: "anthropic-runtime-key" });
   });
 
@@ -222,8 +233,10 @@ describe("secrets runtime snapshot inline auth-store refs", () => {
       ]),
     );
     expect(snapshot.authStores[0]?.store.profiles[profileId]).toMatchObject({
-      key: undefined,
+      type: "api_key",
+      provider: "openai",
       keyRef: { source: "file", provider: "clawrouter_key", id: "value" },
     });
+    expect(snapshot.authStores[0]?.store.profiles[profileId]).not.toHaveProperty("key");
   });
 });

--- a/src/secrets/runtime-degradation-attribution.test.ts
+++ b/src/secrets/runtime-degradation-attribution.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.ts";
+import { prepareRuntimeAuthProfileStoreSnapshots } from "../agents/auth-profiles/runtime-snapshots.js";
 import type { SecretRef } from "../config/types.secrets.js";
 import { resolveAuthProfileSecretOwnerId } from "./runtime-auth-profile-owner.js";
 import { listSecretResolutionErrorOwners } from "./runtime-degraded-state.js";
@@ -61,7 +62,7 @@ function attachAuthOwner(params: {
     params.snapshot.sourceConfig = params.sourceConfig;
     params.snapshot.config = params.sourceConfig;
   }
-  params.snapshot.authStores = [
+  params.snapshot.authStores = prepareRuntimeAuthProfileStoreSnapshots([
     {
       agentDir: params.agentDir,
       store: {
@@ -76,7 +77,7 @@ function attachAuthOwner(params: {
         },
       },
     },
-  ];
+  ]);
   const owner = {
     ownerKind: "account" as const,
     ownerId,

--- a/src/secrets/runtime-fast-path.ts
+++ b/src/secrets/runtime-fast-path.ts
@@ -3,7 +3,10 @@ import { existsSync } from "node:fs";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { listAgentIds, resolveAgentDir } from "../agents/agent-scope-config.js";
 import { resolveSharedAuthStorePath } from "../agents/auth-profiles/path-resolve.js";
-import { getRuntimeAuthProfileStoreCredentialsRevision } from "../agents/auth-profiles/runtime-snapshots.js";
+import {
+  getRuntimeAuthProfileStoreCredentialsRevision,
+  prepareRuntimeAuthProfileStoreSnapshots,
+} from "../agents/auth-profiles/runtime-snapshots.js";
 import { resolveAuthProfileDatabasePath } from "../agents/auth-profiles/sqlite.js";
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import { resolveLegacyInheritedAuthAgentDir } from "../agents/legacy-inherited-auth-dir.js";
@@ -257,7 +260,7 @@ export function prepareSecretsRuntimeFastPathSnapshot(params: {
   const snapshot = {
     sourceConfig,
     config: resolvedConfig,
-    authStores,
+    authStores: prepareRuntimeAuthProfileStoreSnapshots(authStores, runtimeEnv),
     authStoreCredentialsRevision,
     warnings: [],
     degradedOwners: [],

--- a/src/secrets/runtime-state.test.ts
+++ b/src/secrets/runtime-state.test.ts
@@ -8,6 +8,7 @@ import {
   getRuntimeAuthProfileStoreCredentialsRevision,
   getRuntimeAuthProfileStoreSnapshotCore,
   noteRuntimeAuthProfileStorePersistedMutation,
+  prepareRuntimeAuthProfileStoreSnapshots,
   setRuntimeAuthProfileStoreSnapshot,
 } from "../agents/auth-profiles/runtime-snapshots.js";
 import { testing as runtimeSnapshotsTesting } from "../agents/auth-profiles/runtime-snapshots.test-support.js";
@@ -15,7 +16,7 @@ import {
   ensureAuthProfileStoreWithoutExternalProfiles,
   saveAuthProfileStore,
 } from "../agents/auth-profiles/store.js";
-import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
+import type { AuthProfileStore, RuntimeAuthProfileStore } from "../agents/auth-profiles/types.js";
 import {
   createConfigResolutionFacts,
   getAuthoredConfigSecretRef,
@@ -79,8 +80,8 @@ describe("secret store references", () => {
 
 type PreparedSnapshotOverrides = Omit<
   Partial<PreparedSecretsRuntimeSnapshot>,
-  "authStoreCredentialsRevision" | "webTools"
->;
+  "authStoreCredentialsRevision" | "webTools" | "authStores"
+> & { authStores?: Array<{ agentDir: string; store: RuntimeAuthProfileStore }> };
 
 function preparedSnapshot(
   overrides: PreparedSnapshotOverrides = {},
@@ -88,7 +89,6 @@ function preparedSnapshot(
   return {
     sourceConfig: {},
     config: {},
-    authStores: [],
     authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
     warnings: [],
     webTools: {
@@ -97,6 +97,7 @@ function preparedSnapshot(
       diagnostics: [],
     },
     ...overrides,
+    authStores: prepareRuntimeAuthProfileStoreSnapshots(overrides.authStores ?? []),
   };
 }
 

--- a/src/secrets/runtime-state.ts
+++ b/src/secrets/runtime-state.ts
@@ -1,16 +1,21 @@
 /** Holds active secrets runtime snapshots, refresh context, and cleanup hooks. */
 import { isDeepStrictEqual } from "node:util";
+import { AuthProfileMigrationRequiredError } from "../agents/auth-profiles/legacy-source-diagnostic.js";
+import { loadRuntimeAuthProfileOwnerSnapshot } from "../agents/auth-profiles/runtime-snapshot-owner.js";
 import {
   clearRuntimeAuthProfileStoreSnapshots,
-  getRuntimeAuthProfileStoreSnapshotCore,
   getRuntimeAuthProfileStoreCredentialMutationToken,
   getRuntimeAuthProfileStoreCredentialsRevision,
   getRuntimeAuthProfileStoreProfileSetMutationToken,
   getRuntimeAuthProfileStoreStateMutationToken,
-  listRuntimeAuthProfileStoreSnapshots,
-  replaceRuntimeAuthProfileStoreSnapshots,
+  listOwnedRuntimeAuthProfileStoreSnapshots,
+  replaceOwnedRuntimeAuthProfileStoreSnapshots,
 } from "../agents/auth-profiles/runtime-snapshots.js";
-import type { RuntimeAuthProfileStoreMutationToken } from "../agents/auth-profiles/runtime-snapshots.js";
+import type {
+  OwnedRuntimeAuthProfileStoreSnapshotEntry,
+  RuntimeAuthProfileStoreMutationOwner,
+  RuntimeAuthProfileStoreMutationToken,
+} from "../agents/auth-profiles/runtime-snapshots.js";
 import type {
   AuthProfileCredential,
   AuthProfileStore,
@@ -49,7 +54,7 @@ import type { RuntimeWebToolsMetadata } from "./runtime-web-tools.types.js";
 export type PreparedSecretsRuntimeSnapshot = {
   sourceConfig: OpenClawConfig;
   config: OpenClawConfig;
-  authStores: Array<{ agentDir: string; store: RuntimeAuthProfileStore }>;
+  authStores: OwnedRuntimeAuthProfileStoreSnapshotEntry[];
   authStoreCredentialsRevision: number;
   warnings: SecretResolverWarning[];
   degradedOwners?: DegradedSecretOwner[];
@@ -141,7 +146,11 @@ let activeSnapshotLineageAuthMutations: Record<
       baseline: StoreMutationLineage;
       candidate: StoreMutationLineage;
     };
-    state: { token: RuntimeAuthProfileStoreMutationToken; includeMain: boolean };
+    state: {
+      token: RuntimeAuthProfileStoreMutationToken;
+      includeMain: boolean;
+      databaseOwner: RuntimeAuthProfileStoreMutationOwner;
+    };
     profiles: Record<
       string,
       {
@@ -161,9 +170,11 @@ const preparedSnapshotRefreshContext = new WeakMap<
 type ProfileOwner = "absent" | "external" | "inherited" | "local";
 type ProfileOwnerMutationLineage = {
   owner: ProfileOwner;
+  databaseOwner: RuntimeAuthProfileStoreMutationOwner;
   token: RuntimeAuthProfileStoreMutationToken;
 };
 type StoreMutationLineage = {
+  databaseOwner: RuntimeAuthProfileStoreMutationOwner;
   mainProfileSetToken?: RuntimeAuthProfileStoreMutationToken;
   token: RuntimeAuthProfileStoreMutationToken;
 };
@@ -233,10 +244,7 @@ function cloneSnapshot(snapshot: PreparedSecretsRuntimeSnapshot): PreparedSecret
   return {
     sourceConfig: cloneConfigWithResolutionFacts(snapshot.sourceConfig),
     config: cloneConfigWithResolutionFacts(snapshot.config),
-    authStores: snapshot.authStores.map((entry) => ({
-      agentDir: entry.agentDir,
-      store: structuredClone(entry.store),
-    })),
+    authStores: structuredClone(snapshot.authStores),
     authStoreCredentialsRevision: snapshot.authStoreCredentialsRevision,
     warnings: snapshot.warnings.map((warning) => ({ ...warning })),
     degradedOwners: (snapshot.degradedOwners ?? []).map(cloneDegradedSecretOwner),
@@ -247,19 +255,51 @@ function cloneSnapshot(snapshot: PreparedSecretsRuntimeSnapshot): PreparedSecret
 
 function mergeLiveAuthStoreBookkeeping(
   authStores: PreparedSecretsRuntimeSnapshot["authStores"],
+  degradedOwners: readonly DegradedSecretOwner[] = [],
 ): PreparedSecretsRuntimeSnapshot["authStores"] {
+  const liveEntries = new Map(
+    listOwnedRuntimeAuthProfileStoreSnapshots().map((entry) => [entry.databasePath, entry]),
+  );
   return authStores.map((entry) => {
-    const live = getRuntimeAuthProfileStoreSnapshotCore(entry.agentDir);
+    const live = liveEntries.get(entry.databasePath);
     if (!live) {
       return entry;
     }
+    let bookkeeping = entry.store;
+    if (isDeepStrictEqual(snapshotMutationOwner(entry), snapshotMutationOwner(live))) {
+      bookkeeping = live.store;
+    } else if (entry.owner.kind === "resolved" && live.owner.kind === "resolved") {
+      // Effective state cannot separate old inherited values from local overrides or clears.
+      // Recompose only at this owner-transition boundary; cold snapshots remain IO-free.
+      try {
+        bookkeeping = loadRuntimeAuthProfileOwnerSnapshot(
+          { databasePath: entry.databasePath, ...entry.owner },
+          { candidates: entry.legacyCandidates },
+        );
+      } catch (error) {
+        // Preparation deliberately publishes an empty owner when migration isolation degrades it.
+        if (
+          !(error instanceof AuthProfileMigrationRequiredError) ||
+          Object.keys(entry.store.profiles).length > 0 ||
+          !degradedOwners.some(
+            (owner) =>
+              owner.ownerKind === "route" &&
+              owner.ownerId === error.ownerId &&
+              owner.degradationState === "cold",
+          )
+        ) {
+          throw error;
+        }
+      }
+    }
     return {
-      agentDir: entry.agentDir,
+      ...entry,
       store: {
         ...entry.store,
-        order: live.order,
-        lastGood: live.lastGood,
-        usageStats: live.usageStats,
+        order: bookkeeping.order,
+        lastGood: bookkeeping.lastGood,
+        usageStats: bookkeeping.usageStats,
+        runtimeInheritsMainState: bookkeeping.runtimeInheritsMainState,
       },
     };
   });
@@ -279,15 +319,18 @@ function captureProfileOwnerMutationLineage(
   agentDir: string,
   store: RuntimeAuthProfileStore | undefined,
   profileId: string,
+  databaseOwner: RuntimeAuthProfileStoreMutationOwner,
 ): ProfileOwnerMutationLineage {
   const owner = profileOwner(store, profileId);
   return {
     owner,
+    databaseOwner,
     token:
       owner === "external"
         ? { revision: 0, known: true }
         : getRuntimeAuthProfileStoreCredentialMutationToken(agentDir, profileId, {
             includeMain: owner === "absent" || owner === "inherited",
+            owner: databaseOwner,
           }),
   };
 }
@@ -295,34 +338,59 @@ function captureProfileOwnerMutationLineage(
 function captureStoreMutationLineage(
   agentDir: string,
   store: RuntimeAuthProfileStore | undefined,
+  databaseOwner: RuntimeAuthProfileStoreMutationOwner,
 ): StoreMutationLineage {
   const includeMain =
     !store ||
     Object.keys(store.profiles).length === 0 ||
     Object.keys(store.profiles).some((profileId) => profileOwner(store, profileId) === "inherited");
   return {
+    databaseOwner,
     ...(includeMain
-      ? { mainProfileSetToken: getRuntimeAuthProfileStoreProfileSetMutationToken() }
+      ? {
+          mainProfileSetToken: readSharedProfileSetMutationToken(databaseOwner),
+        }
       : {}),
-    token: getRuntimeAuthProfileStoreCredentialMutationToken(agentDir),
+    token: getRuntimeAuthProfileStoreCredentialMutationToken(agentDir, undefined, {
+      owner: databaseOwner,
+    }),
   };
+}
+
+function snapshotMutationOwner(
+  entry: OwnedRuntimeAuthProfileStoreSnapshotEntry,
+): RuntimeAuthProfileStoreMutationOwner {
+  return entry.owner.kind === "resolved"
+    ? {
+        kind: "resolved",
+        databasePath: entry.databasePath,
+        sharedDatabasePath: entry.owner.sharedDatabasePath,
+      }
+    : { kind: "unresolved", databasePath: entry.databasePath, scope: { ...entry.owner.scope } };
+}
+
+function readSharedProfileSetMutationToken(
+  owner: RuntimeAuthProfileStoreMutationOwner,
+): RuntimeAuthProfileStoreMutationToken {
+  // Cold SDK snapshots have no selected shared store; observing lineage must not open one.
+  return owner.kind === "resolved"
+    ? getRuntimeAuthProfileStoreProfileSetMutationToken(undefined, owner.sharedDatabasePath)
+    : { revision: 0, known: false };
 }
 
 function captureAuthStoreMutationLineage(
   baselineAuthStores: PreparedSecretsRuntimeSnapshot["authStores"],
   candidateAuthStores: PreparedSecretsRuntimeSnapshot["authStores"],
 ): typeof activeSnapshotLineageAuthMutations {
-  const baseline = Object.fromEntries(
-    baselineAuthStores.map((entry) => [entry.agentDir, entry.store]),
-  );
-  const candidate = Object.fromEntries(
-    candidateAuthStores.map((entry) => [entry.agentDir, entry.store]),
-  );
+  const baseline = Object.fromEntries(baselineAuthStores.map((entry) => [entry.agentDir, entry]));
+  const candidate = Object.fromEntries(candidateAuthStores.map((entry) => [entry.agentDir, entry]));
   const agentDirs = new Set([...Object.keys(baseline), ...Object.keys(candidate)]);
   return Object.fromEntries(
     [...agentDirs].map((agentDir) => {
-      const baselineStore = baseline[agentDir];
-      const candidateStore = candidate[agentDir];
+      const baselineStore = baseline[agentDir]?.store;
+      const candidateStore = candidate[agentDir]?.store;
+      const baselineOwner = snapshotMutationOwner(baseline[agentDir] ?? candidate[agentDir]!);
+      const candidateOwner = snapshotMutationOwner(candidate[agentDir] ?? baseline[agentDir]!);
       const effectiveStore = candidateStore ?? baselineStore;
       const profileIds = new Set([
         ...Object.keys(baselineStore?.profiles ?? {}),
@@ -332,21 +400,33 @@ function captureAuthStoreMutationLineage(
         agentDir,
         {
           store: {
-            baseline: captureStoreMutationLineage(agentDir, baselineStore),
-            candidate: captureStoreMutationLineage(agentDir, candidateStore),
+            baseline: captureStoreMutationLineage(agentDir, baselineStore, baselineOwner),
+            candidate: captureStoreMutationLineage(agentDir, candidateStore, candidateOwner),
           },
           state: {
             token: getRuntimeAuthProfileStoreStateMutationToken(agentDir, {
               includeMain: effectiveStore?.runtimeInheritsMainState === true,
+              owner: candidateOwner,
             }),
+            databaseOwner: candidateOwner,
             includeMain: effectiveStore?.runtimeInheritsMainState === true,
           },
           profiles: Object.fromEntries(
             [...profileIds].map((profileId) => [
               profileId,
               {
-                baseline: captureProfileOwnerMutationLineage(agentDir, baselineStore, profileId),
-                candidate: captureProfileOwnerMutationLineage(agentDir, candidateStore, profileId),
+                baseline: captureProfileOwnerMutationLineage(
+                  agentDir,
+                  baselineStore,
+                  profileId,
+                  baselineOwner,
+                ),
+                candidate: captureProfileOwnerMutationLineage(
+                  agentDir,
+                  candidateStore,
+                  profileId,
+                  candidateOwner,
+                ),
               },
             ]),
           ),
@@ -515,35 +595,6 @@ function preserveResolvedAuthStoreSecretValues(
   return next;
 }
 
-function preserveLiveAuthStoreBookkeeping(
-  restored: Record<string, AuthProfileStore>,
-  current: Record<string, AuthProfileStore>,
-): Record<string, AuthProfileStore> {
-  const next = structuredClone(restored);
-  for (const [agentDir, store] of Object.entries(next)) {
-    const currentStore = current[agentDir];
-    if (!currentStore) {
-      continue;
-    }
-    if (currentStore.order === undefined) {
-      delete store.order;
-    } else {
-      store.order = structuredClone(currentStore.order);
-    }
-    if (currentStore.lastGood === undefined) {
-      delete store.lastGood;
-    } else {
-      store.lastGood = structuredClone(currentStore.lastGood);
-    }
-    if (currentStore.usageStats === undefined) {
-      delete store.usageStats;
-    } else {
-      store.usageStats = structuredClone(currentStore.usageStats);
-    }
-  }
-  return next;
-}
-
 function credentialSecretRef(credential: AuthProfileCredential | undefined): SecretRef | null {
   if (credential?.type === "api_key" && isSecretRef(credential.keyRef)) {
     return credential.keyRef;
@@ -591,12 +642,13 @@ function compareMutationTokens(
 function readProfileOwnerMutationToken(
   agentDir: string,
   profileId: string,
-  owner: ProfileOwner,
+  lineage: ProfileOwnerMutationLineage,
 ): RuntimeAuthProfileStoreMutationToken {
-  return owner === "external"
+  return lineage.owner === "external"
     ? { revision: 0, known: true }
     : getRuntimeAuthProfileStoreCredentialMutationToken(agentDir, profileId, {
-        includeMain: owner === "absent" || owner === "inherited",
+        includeMain: lineage.owner === "absent" || lineage.owner === "inherited",
+        owner: lineage.databaseOwner,
       });
 }
 
@@ -621,19 +673,21 @@ function getProfileMutationDecision(params: {
       status: "mutated",
     };
   }
-  const ownerChanged = captured.baseline.owner !== captured.candidate.owner;
+  const ownerChanged =
+    captured.baseline.owner !== captured.candidate.owner ||
+    !isDeepStrictEqual(captured.baseline.databaseOwner, captured.candidate.databaseOwner);
   const relevant = ownerChanged ? captured.baseline : captured.candidate;
   return {
     baselineOwner: captured.baseline.owner,
     candidateOwner: captured.candidate.owner,
     candidateStatus: compareMutationTokens(
       captured.candidate.token,
-      readProfileOwnerMutationToken(params.agentDir, params.profileId, captured.candidate.owner),
+      readProfileOwnerMutationToken(params.agentDir, params.profileId, captured.candidate),
     ),
     ownerChanged,
     status: compareMutationTokens(
       relevant.token,
-      readProfileOwnerMutationToken(params.agentDir, params.profileId, relevant.owner),
+      readProfileOwnerMutationToken(params.agentDir, params.profileId, relevant),
     ),
   };
 }
@@ -645,6 +699,7 @@ function mergeRollbackAuthStoreCredentials(
   restored: Record<string, AuthProfileStore>,
   configs: [OpenClawConfig, OpenClawConfig, OpenClawConfig],
   mutationLineage: typeof activeSnapshotLineageAuthMutations,
+  snapshotOwners: Record<string, RuntimeAuthProfileStoreMutationOwner>,
 ): Record<string, AuthProfileStore> {
   const next = structuredClone(restored);
   const agentDirs = new Set([
@@ -658,14 +713,17 @@ function mergeRollbackAuthStoreCredentials(
     const candidateStore = candidate[agentDir];
     const currentStore = current[agentDir];
     const currentStoreMutationStatus = (lineage: StoreMutationLineage | undefined) => {
+      const databaseOwner = lineage?.databaseOwner ?? snapshotOwners[agentDir]!;
       const ownerStatus = compareMutationTokens(
         lineage?.token ?? { revision: 0, known: true },
-        getRuntimeAuthProfileStoreCredentialMutationToken(agentDir),
+        getRuntimeAuthProfileStoreCredentialMutationToken(agentDir, undefined, {
+          owner: databaseOwner,
+        }),
       );
       const mainProfileSetStatus = lineage?.mainProfileSetToken
         ? compareMutationTokens(
             lineage.mainProfileSetToken,
-            getRuntimeAuthProfileStoreProfileSetMutationToken(),
+            readSharedProfileSetMutationToken(databaseOwner),
           )
         : "unchanged";
       return ownerStatus === "mutated" || mainProfileSetStatus === "mutated"
@@ -684,6 +742,7 @@ function mergeRollbackAuthStoreCredentials(
       mutationLineage[agentDir]?.state.token ?? { revision: 0, known: true },
       getRuntimeAuthProfileStoreStateMutationToken(agentDir, {
         includeMain: mutationLineage[agentDir]?.state.includeMain === true,
+        owner: mutationLineage[agentDir]?.state.databaseOwner ?? snapshotOwners[agentDir]!,
       }),
     );
     const profileOwnerMutated = Object.keys(baselineStore?.profiles ?? {}).some((profileId) => {
@@ -904,9 +963,9 @@ export function activateSecretsRuntimeSnapshotState(params: {
   }
   const next = cloneSnapshot(params.snapshot);
   if (params.mergeLiveAuthBookkeeping !== false) {
-    next.authStores = mergeLiveAuthStoreBookkeeping(next.authStores);
+    next.authStores = mergeLiveAuthStoreBookkeeping(next.authStores, next.degradedOwners);
   }
-  const activationAuthStores = structuredClone(listRuntimeAuthProfileStoreSnapshots());
+  const activationAuthStores = listOwnedRuntimeAuthProfileStoreSnapshots();
   const previousLineageAuthStores = activeSnapshotLineageAuthStores;
   const activationAuthMutations = captureAuthStoreMutationLineage(
     activationAuthStores,
@@ -917,7 +976,7 @@ export function activateSecretsRuntimeSnapshotState(params: {
     ? cloneSecretsRuntimeRefreshContext(params.refreshContext)
     : null;
   setRuntimeConfigSnapshot(next.config, params.runtimeSourceConfig ?? next.sourceConfig);
-  replaceRuntimeAuthProfileStoreSnapshots(next.authStores);
+  replaceOwnedRuntimeAuthProfileStoreSnapshots(next.authStores);
   next.authStoreCredentialsRevision = getRuntimeAuthProfileStoreCredentialsRevision();
   const previousLineageStartRevision = activeSnapshotLineageStartRevision;
   activeSnapshot = next;
@@ -973,14 +1032,31 @@ export function restoreSecretsRuntimeSnapshotStateIfCurrent(
   if (!activeSnapshot || activeSnapshotLineageStartRevision !== params.expectedRevision) {
     return false;
   }
+  const currentEntries = listOwnedRuntimeAuthProfileStoreSnapshots();
+  // A later owner is outside this activation's rollback authority, even when its bytes match.
+  const independentEntries = currentEntries.filter((entry) => {
+    const captured = activeSnapshotLineageAuthMutations[entry.agentDir];
+    return (
+      captured &&
+      !isDeepStrictEqual(snapshotMutationOwner(entry), captured.store.candidate.databaseOwner)
+    );
+  });
+  const independentKeys = new Set(independentEntries.map((entry) => entry.agentDir));
+  const rollbackEntries = (entries: OwnedRuntimeAuthProfileStoreSnapshotEntry[]) =>
+    entries.filter((entry) => !independentKeys.has(entry.agentDir));
   const baselineAuthStores = Object.fromEntries(
-    activeSnapshotLineageAuthStores.map((entry) => [entry.agentDir, entry.store]),
+    rollbackEntries(activeSnapshotLineageAuthStores).map((entry) => [entry.agentDir, entry.store]),
   );
   const candidateAuthStores = Object.fromEntries(
-    params.ownedSnapshot.authStores.map((entry) => [entry.agentDir, entry.store]),
+    rollbackEntries(params.ownedSnapshot.authStores).map((entry) => [entry.agentDir, entry.store]),
   );
   const currentAuthStores = Object.fromEntries(
-    listRuntimeAuthProfileStoreSnapshots().map((entry) => [entry.agentDir, entry.store]),
+    rollbackEntries(currentEntries).map((entry) => [entry.agentDir, entry.store]),
+  );
+  const restoredEntries = new Map(
+    [...currentEntries, ...params.ownedSnapshot.authStores, ...activeSnapshotLineageAuthStores].map(
+      (entry) => [entry.agentDir, entry],
+    ),
   );
   const mergedAuthStores = mergeRollbackAuthStoreCredentials(
     baselineAuthStores,
@@ -992,19 +1068,19 @@ export function restoreSecretsRuntimeSnapshotStateIfCurrent(
     >,
     [params.snapshot.sourceConfig, params.ownedSnapshot.sourceConfig, activeSnapshot.sourceConfig],
     activeSnapshotLineageAuthMutations,
+    Object.fromEntries(
+      Array.from(restoredEntries, ([agentDir, entry]) => [agentDir, snapshotMutationOwner(entry)]),
+    ),
   );
   const currentCredentialsRevision = getRuntimeAuthProfileStoreCredentialsRevision();
-  const restoredAuthStores = preserveLiveAuthStoreBookkeeping(
-    preserveResolvedAuthStoreSecretValues(
-      baselineAuthStores,
-      candidateAuthStores,
-      mergedAuthStores,
-      currentAuthStores,
-      params.snapshot.sourceConfig,
-      params.ownedSnapshot.sourceConfig,
-      activeSnapshot.sourceConfig,
-    ),
+  const restoredAuthStores = preserveResolvedAuthStoreSecretValues(
+    baselineAuthStores,
+    candidateAuthStores,
+    mergedAuthStores,
     currentAuthStores,
+    params.snapshot.sourceConfig,
+    params.ownedSnapshot.sourceConfig,
+    activeSnapshot.sourceConfig,
   );
   const restoredSourceConfig = mergeRollbackValue(
     params.snapshot.sourceConfig,
@@ -1025,9 +1101,15 @@ export function restoreSecretsRuntimeSnapshotStateIfCurrent(
       ...params.snapshot,
       sourceConfig: restoredSourceConfig,
       config: restoredConfig,
-      authStores: Object.entries(restoredAuthStores)
-        .map(([agentDir, store]) => ({ agentDir, store }))
-        .toSorted((left, right) => left.agentDir.localeCompare(right.agentDir)),
+      authStores: mergeLiveAuthStoreBookkeeping(
+        [
+          ...Object.entries(restoredAuthStores).map(([agentDir, store]) =>
+            Object.assign({}, restoredEntries.get(agentDir)!, { store }),
+          ),
+          ...independentEntries,
+        ],
+        params.snapshot.degradedOwners,
+      ).toSorted((left, right) => left.agentDir.localeCompare(right.agentDir)),
       authStoreCredentialsRevision: currentCredentialsRevision,
     },
     mergeLiveAuthBookkeeping: false,
@@ -1044,7 +1126,7 @@ export function getActiveSecretsRuntimeSnapshotState(): PreparedSecretsRuntimeSn
     return null;
   }
   const snapshot = cloneSnapshot(activeSnapshot);
-  snapshot.authStores = listRuntimeAuthProfileStoreSnapshots();
+  snapshot.authStores = listOwnedRuntimeAuthProfileStoreSnapshots();
   snapshot.authStoreCredentialsRevision = getRuntimeAuthProfileStoreCredentialsRevision();
   if (activeRefreshContext) {
     preparedSnapshotRefreshContext.set(
@@ -1094,7 +1176,7 @@ function advanceSecretsRuntimeSourceSnapshot(sourceConfig: OpenClawConfig): void
     activeSnapshot.sourceConfig = sourceConfig;
     activeSnapshotRevision += 1;
     activeSnapshotLineageStartRevision = activeSnapshotRevision;
-    activeSnapshotLineageAuthStores = structuredClone(listRuntimeAuthProfileStoreSnapshots());
+    activeSnapshotLineageAuthStores = listOwnedRuntimeAuthProfileStoreSnapshots();
     activeSnapshotLineageAuthMutations = captureAuthStoreMutationLineage(
       activeSnapshotLineageAuthStores,
       activeSnapshotLineageAuthStores,
@@ -1155,10 +1237,10 @@ export function getLiveSecretsRuntimeAuthStores(): PreparedSecretsRuntimeSnapsho
   if (!activeSnapshot) {
     return [];
   }
-  return activeSnapshot.authStores.flatMap((entry) => {
-    const store = getRuntimeAuthProfileStoreSnapshotCore(entry.agentDir);
-    return store ? [{ agentDir: entry.agentDir, store }] : [];
-  });
+  const activeKeys = new Set(activeSnapshot.authStores.map((entry) => entry.databasePath));
+  return listOwnedRuntimeAuthProfileStoreSnapshots().filter((entry) =>
+    activeKeys.has(entry.databasePath),
+  );
 }
 
 /**

--- a/src/secrets/runtime.fast-path.test.ts
+++ b/src/secrets/runtime.fast-path.test.ts
@@ -134,7 +134,7 @@ describe("secrets runtime fast path", () => {
 
     expect(runtimePrepareImportMock).not.toHaveBeenCalled();
     expect(requireGatewayAuth(snapshot).token).toBe("plain-startup-token");
-    expect(snapshot.authStores).toEqual([
+    expect(snapshot.authStores.map(({ agentDir, store }) => ({ agentDir, store }))).toEqual([
       {
         agentDir: "/tmp/openclaw-agent-main",
         store: emptyAuthStore(),
@@ -563,7 +563,12 @@ describe("secrets runtime fast path", () => {
       });
 
       expect(fastPath).not.toBeNull();
-      expect(fastPath!.snapshot.authStores).toEqual([{ agentDir, store: emptyAuthStore() }]);
+      expect(
+        fastPath!.snapshot.authStores.map(({ agentDir: storeAgentDir, store }) => ({
+          agentDir: storeAgentDir,
+          store,
+        })),
+      ).toEqual([{ agentDir, store: emptyAuthStore() }]);
       activateSecretsRuntimeSnapshotState({
         snapshot: fastPath!.snapshot,
         refreshContext: fastPath!.refreshContext,

--- a/src/secrets/runtime.ts
+++ b/src/secrets/runtime.ts
@@ -11,7 +11,10 @@ import {
   clearAuthProfileMigrationDiagnostics,
   markAuthProfileMigrationRequired,
 } from "../agents/auth-profiles/legacy-source-diagnostic.js";
-import { getRuntimeAuthProfileStoreCredentialsRevision } from "../agents/auth-profiles/runtime-snapshots.js";
+import {
+  getRuntimeAuthProfileStoreCredentialsRevision,
+  prepareRuntimeAuthProfileStoreSnapshots,
+} from "../agents/auth-profiles/runtime-snapshots.js";
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import {
   cloneConfigWithResolutionFacts,
@@ -219,7 +222,7 @@ export async function prepareSecretsRuntimeSnapshot(params: {
     const snapshot = {
       sourceConfig,
       config: resolvedConfig,
-      authStores,
+      authStores: prepareRuntimeAuthProfileStoreSnapshots(authStores, runtimeEnv),
       authStoreCredentialsRevision,
       warnings: [],
       degradedOwners: migrationDegradedOwners,
@@ -336,7 +339,7 @@ export async function prepareSecretsRuntimeSnapshot(params: {
   const snapshot = {
     sourceConfig,
     config: resolvedConfig,
-    authStores,
+    authStores: prepareRuntimeAuthProfileStoreSnapshots(authStores, runtimeEnv),
     authStoreCredentialsRevision,
     warnings: context.warnings,
     degradedOwners: [


### PR DESCRIPTION
Closes #131366.

## What Problem This Solves

Fixes an issue where an explicitly selected auth state root could still inherit, deduplicate, publish, or roll back against a different process-local store. In particular, isolated QA startup could fail because the unrelated outer database was newer or unreadable, and a successful write could lose its inherited runtime credentials after secrets apply.

## Why This Change Was Made

The auth persistence owner now prepares and carries its canonical local/shared database identity through the transaction, runtime publication, and compensation. Supplied SQLite connections are authoritative; readers do not rediscover an ambient owner before using them. The existing runtime snapshot lifecycle retains that identity and its producer-captured legacy-source facts, rather than reconstructing an environment from directory ancestry.

Shared-store publication and rollback reconcile each derived owner independently. Migration refusals still clear the affected snapshots and remain latched, but a refused child no longer interrupts restoration of healthy siblings. Compensation respects newer runtime generations and unrelated roots. Explicit state selection wins over an ambient scoped environment; secrets apply preserves an explicitly supplied shared-store relocation.

Secrets activation and rollback now use the same bookkeeping composition. When a resolved shared owner changes, the canonical reader recomposes the selected shared state and durable agent-local overrides instead of copying another owner's effective snapshot. This preserves newer local cooldown/order state, reveals the selected shared fallback after a local clear, and keeps already-resolved credentials intact. The legacy-migration exception is retained only for the exact owner already diagnosed as cold/degraded during preparation; newly discovered migration failures cannot silently activate a healthy-looking empty target.

No configuration option, environment variable, SQLite schema, persisted format, or public plugin SDK contract is added. This is not the cross-repository atomic-write work tracked in #119679, and it does not replace the separate TUI ownership refresh in #130349.

The compiled-Gateway probe also exposed unnecessary plugin discovery after the auth rows were staged: config-only profile insertion eagerly resolved aliases even when profile ordering could not change. The shared config helper now resolves aliases only for an existing order or possible mixed-mode promotion. Its ordering flow is smaller while preserving canonical alias merging, explicit empty orders, disabled promotion, and unrelated provider entries. It neither changes the caller's environment nor suppresses selected-store errors.

## User Impact

Explicit-root operations use the selected root consistently without inspecting unrelated auth databases. Normal ambient operations retain their configured state and shared-agent relocation. Invalid or newer selected targets still fail closed, OAuth ownership rules remain intact, and a failed transaction or secrets activation cannot restore a stale or refused credential owner.

## Evidence

Actual failing reproductions were captured before the corresponding fixes: supplied-connection writes with readable/newer/invalid outer stores; explicit-state versus scoped-environment precedence; shared-store relocation through secrets apply; late legacy-source discovery; and rollback refusal ordering. The final rollback table initially failed three cases, with the shared credential-change control already passing.

Additional failing reproductions cover mixed local/shared bookkeeping, clearing a local override, rollback after newer local updates, and late migration failure versus an already diagnosed degraded owner. The canonical-composition focused run passed 169 tests in five files before the final two migration-diagnostic regressions were added.

The final independent Codex review is clean (no actionable P0–P2 findings). The final regression run passed 572 tests in 15 files: 280 Gateway, 127 secrets, 156 auth/session, and nine QA auth-store tests. The runner logged a delayed worker termination after a passing runtime-snapshots file; the worker subsequently exited, and an unchanged focused rerun passed all 12 tests without the warning. The full changed-file check passed, including all selected types, lint, dead-code, schema, ownership, and architecture guards. No heap, isolation, timeout, or assertion weakening was used.

The core ownership candidate `720df608ab7de7876cecc529eed7874789aea190` passed the full private-QA build, but its compiled-Gateway probe failed before startup on the config-projection leak described above. That failed result is retained, not counted as live success. The follow-up captured four config-only failures and two real-store staging failures before repair; afterward, 128 tests in four files pass (one existing skip), including the QA gateway-child suite. Independent Codex review of the follow-up is clean; all selected changed-file checks and its full private-QA build pass.

Actual compiled-Gateway proof at `0830a83c18ea3f9789f545d1d07c316ed9b091e5` passed both future-schema and invalid outer database scenarios on August 28, 2026. Each began with a fresh isolated home and generated synthetic state, started the compiled Gateway and controlled mock OpenAI provider, completed an `agent`/`agent.wait` turn with its exact marker, and verified the selected schema-v13 database's integrity. The outer database, config, environment selection, and absent relocated-agent directory stayed unchanged. Both Gateway PIDs exited, all four listeners closed, and the built runtime graph remained identical before/after (12,446 files, SHA-256 `3b624a783c12241239de3e7fee2c9baee1a355188af7589bf6240d656bdbd767`). This proves the actual Gateway/mock-provider path, not an authenticated upstream model.

```json
{"head":"0830a83c18ea3f9789f545d1d07c316ed9b091e5","compiledGateway":true,"provider":"controlled mock OpenAI","futureOuter":"pass","invalidOuter":"pass","exactReplyMarkers":2,"outerStateUnchanged":true,"targetIntegrity":"ok","gatewayProcessesStopped":2,"listenersClosed":4,"runtimeGraphUnchanged":true}
```

Provenance: the explicit shared-owner seam was introduced by Peter Steinberger in #123349 (`d2dad76ecde4bb3e811b9d03ed9932dc61044b8a`, August 14) and carried through #126783. The eager config alias lookup predates the available July 12 shallow-history boundary; its original introducer is unknown.

Production delta against the integrated main baseline is +1574/-735 (net +839); tests and test support are +1708/-34 (net +1674); documentation is +2. Gross additions include existing composition helpers moved without changing their behavior. Net growth records previously missing ownership and lifecycle facts and supplies canonical-path persistence reads; it replaces ambient rediscovery, duplicate snapshot ownership projection, and separate activation/rollback bookkeeping paths rather than adding another persistence store. The config-projection follow-up removes 18 production lines. The larger regression surface covers independent transaction, migration, publication, compensation, and consumer boundaries.

Named follow-up: separately establish Doctor plan/apply root consistency before claiming cross-root Doctor behavior is repaired.

The first hosted CI run ([33141435403](https://github.com/openclaw/openclaw/actions/runs/33141435403)) found three assertion mismatches in the full secrets shard: tests required an own `key: undefined` property, while the existing canonical JSON clone omits undefined fields. The underlying cold credential was correctly absent. All three failures reproduced locally. Test-only commit `4153632052a018e01a7662b151f8dd1bd0198316` now verifies the retained profile type, provider and SecretRef and explicitly rejects a credential property, including the token sibling and adjacent cold/healthy-profile case. Eleven focused tests and all 842 tests in the complete 76-file secrets shard pass; independent Codex review and all selected test-delta checks are clean. Exact-head [CI33142358153](https://github.com/openclaw/openclaw/actions/runs/33142358153) completed successfully. The diff from built/live-tested `0830a83` contains only these two test files; production and the runtime dependency graph are unchanged.
