### PR TITLE
fix(ui): keep command palette usable when results refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI command palette:** keep keyboard selection and Enter usable when reconnects or catalog refreshes replace search results, preserving the selected command while it remains available.
 - **Control UI Gateway labels:** keep the discovered machine name through recovery initialization and refresh open folder-browser labels when name discovery finishes.
 - **Android settings:** keep form fields and actions reachable above the keyboard, and respect bottom system insets without duplicating navigation padding.
 - **Nextcloud Talk diagnostics:** redact reflected credentials before displaying send, reaction, and bot-preflight errors, and suppress incomplete error bodies. (#119976) Thanks @xialonglee.

--- a/ui/src/components/command-palette-catalog-search.ts
+++ b/ui/src/components/command-palette-catalog-search.ts
@@ -336,7 +336,8 @@ export async function loadCommandPaletteCatalogItems(params: {
         .join(" "),
     })),
     ...(models?.models ?? []).map((model) => ({
-      id: `model-${model.provider}-${model.id}`,
+      // Both IDs can contain separators; selection needs a lossless pair.
+      id: `model-${JSON.stringify([model.provider, model.id])}`,
       label: model.name || model.id,
       icon: "brain" as const,
       category: "models" as const,

--- a/ui/src/components/command-palette.test.ts
+++ b/ui/src/components/command-palette.test.ts
@@ -134,15 +134,26 @@ function findPaletteOption(palette: CommandPalette, label: string, exact = false
 
 describe("CommandPalette lifecycle", () => {
   let restoreDialogPolyfill: () => void;
+  let scrollIntoViewDescriptor: PropertyDescriptor | undefined;
 
   beforeEach(() => {
     vi.useFakeTimers();
     restoreDialogPolyfill = installDialogPolyfill();
+    scrollIntoViewDescriptor = Object.getOwnPropertyDescriptor(Element.prototype, "scrollIntoView");
+    Object.defineProperty(Element.prototype, "scrollIntoView", {
+      configurable: true,
+      value: vi.fn(),
+    });
   });
 
   afterEach(() => {
     document.body.replaceChildren();
     restoreDialogPolyfill();
+    if (scrollIntoViewDescriptor) {
+      Object.defineProperty(Element.prototype, "scrollIntoView", scrollIntoViewDescriptor);
+    } else {
+      delete (Element.prototype as Partial<Element>).scrollIntoView;
+    }
     vi.useRealTimers();
     vi.restoreAllMocks();
   });
@@ -521,6 +532,147 @@ describe("CommandPalette lifecycle", () => {
       await palette.updateComplete;
       expect(palette.querySelector('[aria-selected="true"]')).toBe(items[expectedIndex]);
     }
+  });
+
+  it.each(["retain", "navigate"])(
+    "keeps selection actionable when a chosen session disappears and returns (%s)",
+    async (interaction) => {
+      const { gateway, setConnected } = createGateway(true);
+      const { palette } = await mountPalette(
+        createContext(
+          gateway,
+          vi.fn(async () => ({
+            ...createSessionResult("agent:main:qa-0", "Agent QA 0"),
+            count: 10,
+            sessions: Array.from(
+              { length: 10 },
+              (_, index) =>
+                createSessionResult(`agent:main:qa-${index}`, `Agent QA ${index}`).sessions[0]!,
+            ),
+          })),
+        ),
+      );
+      await enterQuery(palette, "agent");
+      await vi.advanceTimersByTimeAsync(50);
+      await palette.updateComplete;
+      const session = findPaletteOption(palette, "Agent QA 9")!;
+      const sessionText = session.textContent;
+      session.dispatchEvent(new MouseEvent("mouseenter"));
+      await palette.updateComplete;
+
+      setConnected(false);
+      await palette.updateComplete;
+      expect(findPaletteOption(palette, "Agent QA 9")).toBeUndefined();
+      const first = palette.querySelector('[role="option"]');
+      expect(palette.querySelector('[aria-selected="true"]')).toBe(first);
+      const input = palette.querySelector("input")!;
+      expect(document.getElementById(input.getAttribute("aria-activedescendant")!)).toBe(first);
+      if (interaction === "navigate") {
+        input.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+        await palette.updateComplete;
+      }
+      const offlineSelection = palette.querySelector('[aria-selected="true"]')?.textContent;
+
+      setConnected(true);
+      await palette.updateComplete;
+      await vi.advanceTimersByTimeAsync(50);
+      await palette.updateComplete;
+      const active = palette.querySelector('[aria-selected="true"]');
+      expect(active?.textContent).toEqual(
+        interaction === "retain" ? sessionText : offlineSelection,
+      );
+      input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+      expect(palette.isOpen).toBe(false);
+      if (interaction === "retain") {
+        expect(palette.onSelectSession).toHaveBeenCalledWith("agent:main:qa-9");
+      } else {
+        expect(palette.onSelectSession).not.toHaveBeenCalled();
+        expect(palette.onNavigate).toHaveBeenCalledOnce();
+      }
+    },
+  );
+
+  it.each(["removed", "retained"])(
+    "resolves the selected catalog item after a shrinking refresh (%s)",
+    async (selection) => {
+      const { gateway } = createGateway(true);
+      const context = createContext(
+        gateway,
+        vi.fn(async () => null),
+      );
+      const roster = {
+        defaultId: "a",
+        mainKey: "main",
+        scope: "per-sender" as const,
+        agents: [
+          { id: "a", name: "Review Alpha" },
+          { id: "b", name: "Review Bravo" },
+          { id: "c", name: "Review Charlie" },
+        ],
+      };
+      const refresh = createDeferred<typeof roster>();
+      const ensureList = vi.fn().mockResolvedValueOnce(roster).mockReturnValueOnce(refresh.promise);
+      const { palette } = await mountPalette({
+        ...context,
+        agents: { ...context.agents, ensureList },
+      });
+      await enterQuery(palette, "review");
+      await vi.advanceTimersByTimeAsync(50);
+      await palette.updateComplete;
+      vi.setSystemTime(Date.now() + 30_001);
+      const input = palette.querySelector("input")!;
+      input.value = "review ";
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      await vi.advanceTimersByTimeAsync(50);
+      await palette.updateComplete;
+      for (let i = 0; i < 2; i++) {
+        input.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+        await palette.updateComplete;
+      }
+      expect(palette.querySelector('[aria-selected="true"]')?.textContent).toContain(
+        "Review Charlie",
+      );
+      refresh.resolve({
+        ...roster,
+        agents: selection === "removed" ? roster.agents.slice(0, 1) : roster.agents.slice(2),
+      });
+      await vi.waitFor(() => expect(palette.querySelectorAll('[role="option"]')).toHaveLength(1));
+      await palette.updateComplete;
+      const remaining = palette.querySelector('[role="option"]');
+      expect(palette.querySelector('[aria-selected="true"]')).toBe(remaining);
+      expect(document.getElementById(input.getAttribute("aria-activedescendant")!)).toBe(remaining);
+      input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+      expect(palette.onNavigate).toHaveBeenCalledWith("agents", {
+        pathname: `/settings/agents/${selection === "removed" ? "a" : "c"}`,
+      });
+      expect(palette.isOpen).toBe(false);
+    },
+  );
+
+  it("distinguishes model choices with hyphenated provider and model IDs", async () => {
+    const { gateway } = createGateway(true, {
+      methods: ["models.list"],
+      request: vi.fn(async () => ({
+        models: [
+          { provider: "qa", id: "custom-model", name: "Needle Alpha" },
+          { provider: "qa-custom", id: "model", name: "Needle Bravo" },
+        ],
+      })) as GatewayBrowserClient["request"],
+    });
+    const { palette } = await mountPalette(
+      createContext(
+        gateway,
+        vi.fn(async () => null),
+      ),
+    );
+    await enterQuery(palette, "needle");
+    await vi.advanceTimersByTimeAsync(50);
+    await palette.updateComplete;
+    palette
+      .querySelector("input")!
+      .dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+    await palette.updateComplete;
+    expect(palette.querySelector('[aria-selected="true"]')?.textContent).toContain("Needle Bravo");
   });
 
   it.each(["agent:main:topic:thread", "agent:main:topic:\ud800"])(

--- a/ui/src/components/command-palette.ts
+++ b/ui/src/components/command-palette.ts
@@ -57,7 +57,7 @@ type CommandPaletteProps = {
   basePath: string;
   open: boolean;
   query: string;
-  activeIndex: number;
+  activeId: string | null;
   sessionItems: readonly PaletteItem[];
   catalogItems: readonly PaletteItem[];
   sessionSearchFailed: boolean;
@@ -65,7 +65,7 @@ type CommandPaletteProps = {
   sessionSearchIncomplete: boolean;
   onToggle: () => void;
   onQueryChange: (query: string) => void;
-  onActiveIndexChange: (index: number) => void;
+  onActiveIdChange: (id: string) => void;
   onNavigate?: ApplicationContext<RouteId>["navigate"];
   onSelectSession?: (sessionKey: string) => void;
   onSlashCommand?: (command: string) => void;
@@ -73,16 +73,6 @@ type CommandPaletteProps = {
   custodianAvailable: boolean;
   onInputRef: (element: Element | undefined) => void;
 };
-
-function filteredItems(props: CommandPaletteProps): PaletteItem[] {
-  // Keyboard selection and ARIA focus follow the same category order as the visible rows.
-  return groupItems(
-    filterCommandPaletteItems({
-      ...props,
-      includeSlashCommands: Boolean(props.onSlashCommand),
-    }),
-  ).flatMap(([, items]) => items);
-}
 
 function groupItems(items: PaletteItem[]): Array<[string, PaletteItem[]]> {
   const map = new Map<string, PaletteItem[]>();
@@ -131,26 +121,30 @@ function scrollActiveIntoView() {
   });
 }
 
-function handleKeydown(e: KeyboardEvent, props: CommandPaletteProps) {
-  const items = filteredItems(props);
+function handleKeydown(
+  e: KeyboardEvent,
+  props: CommandPaletteProps,
+  items: PaletteItem[],
+  activeIndex: number,
+) {
   if (items.length === 0 && (e.key === "ArrowDown" || e.key === "ArrowUp" || e.key === "Enter")) {
     return;
   }
   switch (e.key) {
     case "ArrowDown":
       e.preventDefault();
-      props.onActiveIndexChange((props.activeIndex + 1) % items.length);
+      props.onActiveIdChange(items[(activeIndex + 1) % items.length]!.id);
       scrollActiveIntoView();
       break;
     case "ArrowUp":
       e.preventDefault();
-      props.onActiveIndexChange((props.activeIndex - 1 + items.length) % items.length);
+      props.onActiveIdChange(items[(activeIndex - 1 + items.length) % items.length]!.id);
       scrollActiveIntoView();
       break;
     case "Enter":
       e.preventDefault();
       {
-        const item = items[props.activeIndex];
+        const item = items[activeIndex];
         if (item) {
           selectItem(item, props);
         }
@@ -182,10 +176,17 @@ function renderCommandPalette(props: CommandPaletteProps) {
   if (!props.open) {
     return nothing;
   }
-  const items = filteredItems(props);
-  const grouped = groupItems(items);
-  const activeItem = items[props.activeIndex];
-  const activeOptionId = activeItem ? getOptionId(props.activeIndex) : nothing;
+  const grouped = groupItems(
+    filterCommandPaletteItems({ ...props, includeSlashCommands: Boolean(props.onSlashCommand) }),
+  );
+  const items = grouped.flatMap(([, entries]) => entries);
+  // Preserve explicit selection through transient result changes, but only
+  // highlight and execute current rows; an absent choice selects the first row.
+  const activeIndex = Math.max(
+    0,
+    items.findIndex((item) => item.id === props.activeId),
+  );
+  const activeOptionId = items[activeIndex] ? getOptionId(activeIndex) : nothing;
   const paletteLabel = t("palette.placeholder");
 
   return html`
@@ -198,7 +199,7 @@ function renderCommandPalette(props: CommandPaletteProps) {
       <div
         class="cmd-palette"
         @click=${(e: Event) => e.stopPropagation()}
-        @keydown=${(e: KeyboardEvent) => handleKeydown(e, props)}
+        @keydown=${(e: KeyboardEvent) => handleKeydown(e, props, items, activeIndex)}
       >
         <label id=${paletteDialogLabelId} class="cmd-palette__label" for=${paletteInputId}
           >${paletteLabel}</label
@@ -215,10 +216,7 @@ function renderCommandPalette(props: CommandPaletteProps) {
           aria-expanded="true"
           placeholder=${paletteLabel}
           .value=${props.query}
-          @input=${(e: Event) => {
-            props.onQueryChange((e.target as HTMLInputElement).value);
-            props.onActiveIndexChange(0);
-          }}
+          @input=${(e: Event) => props.onQueryChange((e.target as HTMLInputElement).value)}
         />
         <div id=${paletteListboxId} class="cmd-palette__results" role="listbox">
           ${props.sessionSearchPartial || props.sessionSearchIncomplete
@@ -248,7 +246,7 @@ function renderCommandPalette(props: CommandPaletteProps) {
                   </div>
                   ${groupedItems.map((item) => {
                     const globalIndex = items.indexOf(item);
-                    const isActive = globalIndex === props.activeIndex;
+                    const isActive = globalIndex === activeIndex;
                     return html`
                       <div
                         id=${getOptionId(globalIndex)}
@@ -259,7 +257,7 @@ function renderCommandPalette(props: CommandPaletteProps) {
                           e.stopPropagation();
                           selectItem(item, props);
                         }}
-                        @mouseenter=${() => props.onActiveIndexChange(globalIndex)}
+                        @mouseenter=${() => props.onActiveIdChange(item.id)}
                       >
                         <span class="nav-item__icon">${icons[item.icon]}</span>
                         <span>${item.label}</span>
@@ -294,7 +292,7 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
   private context?: ApplicationContext<RouteId>;
   @state() private open = false;
   @state() private query = "";
-  @state() private activeIndex = 0;
+  @state() private activeId: string | null = null;
   @state() private sessionItems: readonly PaletteItem[] = [];
   @state() private catalogItems: readonly PaletteItem[] = [];
   @state() private sessionSearchFailed = false;
@@ -334,7 +332,7 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
     document.removeEventListener("keydown", this.handleGlobalKeydown);
     this.open = false;
     this.query = "";
-    this.activeIndex = 0;
+    this.activeId = null;
     this.clearSessionSearch();
     this.clearCatalogSearch();
     this.sessionSearchSource = undefined;
@@ -344,7 +342,7 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
   openPalette() {
     this.open = true;
     this.query = "";
-    this.activeIndex = 0;
+    this.activeId = null;
     this.clearSessionSearch();
   }
 
@@ -444,17 +442,9 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
   }
 
   private scheduleSessionSearch(query: string) {
-    if (this.sessionSearchTimer !== null) {
-      globalThis.clearTimeout(this.sessionSearchTimer);
-      this.sessionSearchTimer = null;
-    }
     // Invalidate the previous query immediately so late responses cannot
     // repopulate selectable stale rows during the debounce window.
-    this.sessionSearchId += 1;
-    this.sessionItems = [];
-    this.sessionSearchFailed = false;
-    this.sessionSearchPartial = false;
-    this.sessionSearchIncomplete = false;
+    this.clearSessionSearch();
     const search = normalizeOptionalString(query);
     if (!this.open || !search || search.length < SESSION_SEARCH_MIN_CHARS) {
       return;
@@ -614,7 +604,6 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
               ? transcriptSearchSnippet(transcriptHit.snippet)
               : formatRelativeTimestamp(row.updatedAt, { fallback: "" }),
         }));
-      this.activeIndex = 0;
     } catch {
       // Session search is best-effort; navigation commands stay usable. But a
       // failed search must not render as "No results" — that reads as a
@@ -643,7 +632,7 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
       basePath: this.context?.basePath ?? "",
       open: this.open,
       query: this.query,
-      activeIndex: this.activeIndex,
+      activeId: this.activeId,
       sessionItems: this.sessionItems,
       catalogItems: [
         ...toCommandPaletteItems(
@@ -661,11 +650,11 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
       onToggle: this.togglePalette,
       onQueryChange: (query) => {
         this.query = query;
-        this.activeIndex = 0;
+        this.activeId = null;
         this.scheduleSessionSearch(query);
       },
-      onActiveIndexChange: (index) => {
-        this.activeIndex = index;
+      onActiveIdChange: (id) => {
+        this.activeId = id;
       },
       onNavigate: this.onNavigate,
       onSelectSession: this.onSelectSession,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users navigating the Control UI command palette would lose the highlighted result and get no response from Enter when a reconnect or catalog refresh removed earlier search results. Delayed search replies could also replace an explicitly selected command with a different result.

## Why This Change Was Made

The palette stored a row index independently of asynchronously changing results. It now retains the chosen item's identity and resolves selection against the current visible rows, choosing the first row when that item is absent. Rendering, accessibility focus, arrow keys, and Enter share one ordered result snapshot. Explicit query changes and opening the palette reset selection; result refreshes preserve surviving choices.

This removes duplicate filtering/grouping, duplicate query resets, and duplicate search invalidation. Model choices use a lossless provider/model identity because both fields can contain hyphens. No configuration, persistence, authentication, protocol, or routing contract changes.

Production: **+36/-46 (net −10)**. Tests: **+152**. Changelog: **+1**.

## User Impact

The palette remains keyboard-accessible while the Gateway reconnects or its catalogs change. Enter always acts on a currently visible choice. Existing agent routes, category order, session search, and permission filtering remain unchanged.

## Evidence

- Four new component regressions failed on the original code for missing selection: reconnect with retained intent, reconnect after explicit navigation, a removed catalog choice, and a surviving catalog choice moving to an earlier row. All pass after the repair.
- **39 tests across three files passed**, including model-ID collisions, encoded agent routes, category keyboard order, raw session-key ARIA collisions, stale connection results, search notices, and subscription lifecycle controls.
- Production UI build and unchanged bundle budgets passed. Fresh structured Codex review reported no actionable findings at its P0 threshold; independent owner-level review reported no actionable findings.
- **Real Chrome and a normal built Gateway with ephemeral loopback state:** before the change, removing catalog results left six visible rows unselected, removed `aria-activedescendant`, and made Enter inert. After rebuilding and verifying the served asset changed, an explicitly selected command survived reconnect; after a later disconnect removed the selected catalog item, the first current row became selected and Enter closed the palette and opened Agents. No mock Gateway or browser state injection was used.
- Full changed-file checks and separate UI-test type checks passed. Ten sequential shuffled runs passed **390 test executions across 30 file executions**, with no failures. [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33141418324) and the required `openclaw/ci-gate` completed successfully on `79e2de15429d9ede32972e453791453a4176587f`.

Before: visible choices, no selection, Enter does nothing.

![Before: palette loses selection after disconnect](https://github.com/user-attachments/assets/379fd986-933e-4c01-a961-dce4730f0317)

After: the first current choice is selected and Enter opens it.

![After: palette keeps a valid selection after disconnect](https://github.com/user-attachments/assets/e1766e23-d650-4517-a0ba-7fb1813e3ebf)

The captures contain only synthetic/static product UI. One intermediate live attempt was repeated because Gateway shutdown was still draining an active setup request; it was not counted as disconnect proof. The final run waited for actual socket closure and a clean Gateway exit. Slow setup activation/resource growth and opaque shutdown-drain progress are recorded as separate follow-up work, not attributed to this selection repair.

Provenance: the index ownership predates catalog search. Catalog refresh made this path visible in #128356 (`798c21af7b96`, authored by @clawsweeper, merged by @VACInc on 2026-08-24); this does not attribute every older selection-lifecycle issue to that PR.
