### PR TITLE
fix(plugins): preserve read errors before registry recovery

### DIFF
--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -407,6 +407,8 @@ For runtime hook debugging:
 
 Plugin install metadata is machine-managed state, not user config. Installs and updates write it to the shared SQLite state database under the active OpenClaw state directory. The `config_machine_state` value keyed by `plugins.installedIndex` stores durable `installRecords` metadata, including records for broken or missing plugin manifests, plus a manifest-derived cold registry cache used by `openclaw plugins update`, uninstall, diagnostics, and the cold plugin registry.
 
+An unreadable index is not invalid data. Permission, lock, and other read errors stop fallback, migration, and refresh with the original error. Restore database access, then rerun `openclaw plugins registry` to inspect the state before attempting repair. Do not delete the `plugins.installedIndex` row unless inspection succeeds and confirms invalid install records; a failed read alone does not justify deletion.
+
 `plugins.installs` is a retired authored-config surface. Runtime and update commands read only the SQLite machine-state plugin index. Run `openclaw doctor --fix` to import legacy config records into the index and remove the retired key before normal runtime use.
 
 ## Uninstall

--- a/src/commands/doctor/shared/plugin-registry-migration.test.ts
+++ b/src/commands/doctor/shared/plugin-registry-migration.test.ts
@@ -16,6 +16,7 @@ import {
   cleanupTrackedTempDirs,
   makeTrackedTempDir,
 } from "../../../plugins/test-helpers/fs-fixtures.js";
+import * as stateDbReadOnly from "../../../state/openclaw-state-db-readonly.js";
 import { runOpenClawStateWriteTransaction } from "../../../state/openclaw-state-db.js";
 import { migratePluginRegistryForInstall } from "./plugin-registry-migration.js";
 const tempDirs: string[] = [];
@@ -148,6 +149,57 @@ function insertStalePersistedIndexRow(stateDir: string, installRecordsJson = "{}
 }
 
 describe("plugin registry install migration", () => {
+  it.each([1, 2])(
+    "stops migration with the original error when required read %s fails",
+    async (failedRead) => {
+      const stateDir = makeTempDir();
+      const records = { authoritative: { source: "npm", spec: "authoritative@1.0.0" } };
+      insertStalePersistedIndexRow(stateDir, JSON.stringify(records));
+      const error = Object.assign(new Error("database is locked"), {
+        code: "ERR_SQLITE_ERROR",
+        errcode: 5,
+      });
+      const read = stateDbReadOnly.withExistingOpenClawStateDatabaseReadOnly;
+      const readSpy = vi.spyOn(stateDbReadOnly, "withExistingOpenClawStateDatabaseReadOnly");
+      if (failedRead === 2) {
+        readSpy.mockImplementationOnce(read);
+      }
+      readSpy.mockImplementationOnce(() => {
+        throw error;
+      });
+      const readConfig = vi.fn(() => ({}));
+      await expect
+        .soft(
+          migratePluginRegistryForInstall({
+            stateDir,
+            readConfig,
+            candidates: [],
+            env: hermeticEnv(),
+          }),
+        )
+        .rejects.toBe(error);
+      expect.soft(readConfig).not.toHaveBeenCalled();
+      readSpy.mockRestore();
+      const row = runOpenClawStateWriteTransaction(
+        ({ db }) =>
+          db
+            .prepare(
+              "SELECT value_json, updated_at_ms FROM config_machine_state WHERE state_key = 'plugins.installedIndex'",
+            )
+            .get(),
+        { env: { OPENCLAW_STATE_DIR: stateDir } },
+      );
+      expect(row).toMatchObject({ updated_at_ms: 123 });
+      const restored = await migratePluginRegistryForInstall({
+        stateDir,
+        readConfig,
+        candidates: [],
+        env: hermeticEnv(),
+      });
+      expect(requireMigratedIndex(restored).installRecords).toEqual(records);
+    },
+  );
+
   it("short-circuits when a current registry file already exists", async () => {
     const stateDir = makeTempDir();
     const filePath = resolveInstalledPluginIndexStorePath({ stateDir });

--- a/src/plugins/installed-plugin-index-read-state.test.ts
+++ b/src/plugins/installed-plugin-index-read-state.test.ts
@@ -1,0 +1,205 @@
+// Preserves read failures separately from absent or malformed plugin index state.
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { requireNodeSqlite } from "../infra/node-sqlite.js";
+import * as stateDbReadOnly from "../state/openclaw-state-db-readonly.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  runOpenClawStateWriteTransaction,
+} from "../state/openclaw-state-db.js";
+import { inspectPersistedInstalledPluginIndexInstallRecordsSync } from "./installed-plugin-index-record-state.js";
+import { readPersistedInstalledPluginIndexInstallRecords } from "./installed-plugin-index-records.js";
+import {
+  refreshPersistedInstalledPluginIndex,
+  refreshPersistedInstalledPluginIndexWithLeaseSync,
+} from "./installed-plugin-index-store-write.js";
+import {
+  readPersistedInstalledPluginIndex,
+  readPersistedInstalledPluginIndexSync,
+  resolveInstalledPluginIndexStorePath,
+} from "./installed-plugin-index-store.js";
+import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
+
+const tempDirs: string[] = [];
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  cleanupTrackedTempDirs(tempDirs);
+});
+function makeTempDir() {
+  return makeTrackedTempDir("openclaw-installed-plugin-index-read-state", tempDirs);
+}
+
+function insertPersistedIndexRow(stateDir: string, valueJson: string): void {
+  runOpenClawStateWriteTransaction(
+    ({ db }) => {
+      db.prepare(
+        "INSERT INTO config_machine_state (state_key, value_json, updated_at_ms) VALUES ('plugins.installedIndex', ?, 123)",
+      ).run(valueJson);
+    },
+    { env: { OPENCLAW_STATE_DIR: stateDir } },
+  );
+}
+
+function readPersistedIndexRow(filePath: string): { value_json: string; updated_at_ms: number } {
+  const { DatabaseSync } = requireNodeSqlite();
+  const db = new DatabaseSync(filePath, { readOnly: true });
+  try {
+    return db
+      .prepare(
+        "SELECT value_json, updated_at_ms FROM config_machine_state WHERE state_key = 'plugins.installedIndex'",
+      )
+      .get() as { value_json: string; updated_at_ms: number };
+  } finally {
+    db.close();
+  }
+}
+
+describe("installed plugin index read state", () => {
+  it("preserves the original read error through both full-index readers", async () => {
+    const stateDir = makeTempDir();
+    const error = Object.assign(new Error("plugin index read denied"), { code: "EACCES" });
+    const readSpy = vi.spyOn(stateDbReadOnly, "withExistingOpenClawStateDatabaseReadOnly");
+    for (const read of [readPersistedInstalledPluginIndexSync, readPersistedInstalledPluginIndex]) {
+      readSpy.mockImplementationOnce(() => {
+        throw error;
+      });
+      await expect
+        .soft(
+          Promise.resolve().then(() => read({ stateDir })),
+          read.name,
+        )
+        .rejects.toBe(error);
+    }
+    readSpy.mockRestore();
+  });
+
+  it.each(["database", "table", "row"])(
+    "preserves genuine missing %s without creating state",
+    async (missing) => {
+      const stateDir = makeTempDir();
+      const filePath = resolveInstalledPluginIndexStorePath({ stateDir });
+      if (missing !== "database") {
+        fs.mkdirSync(path.dirname(filePath), { recursive: true });
+        const { DatabaseSync } = requireNodeSqlite();
+        const db = new DatabaseSync(filePath);
+        if (missing === "row") {
+          db.exec(
+            "CREATE TABLE config_machine_state (state_key TEXT PRIMARY KEY, value_json TEXT NOT NULL, updated_at_ms INTEGER NOT NULL) STRICT",
+          );
+        }
+        db.close();
+      }
+      const before = missing === "database" ? undefined : fs.readFileSync(filePath);
+      expect(inspectPersistedInstalledPluginIndexInstallRecordsSync({ stateDir })).toEqual({
+        status: "missing",
+      });
+      await expect(
+        readPersistedInstalledPluginIndexInstallRecords({ stateDir }),
+      ).resolves.toBeNull();
+      await expect(readPersistedInstalledPluginIndex({ stateDir })).resolves.toBeNull();
+      expect(missing === "database" ? fs.existsSync(filePath) : fs.readFileSync(filePath)).toEqual(
+        before ?? false,
+      );
+    },
+  );
+
+  it.each([
+    { reason: "manual", leased: false },
+    { reason: "manual", leased: true },
+    { reason: "policy-changed", leased: false },
+    { reason: "policy-changed", leased: true },
+  ] as const)(
+    "stops $reason refresh before mutation after one failed read (leased=$leased)",
+    async ({ reason, leased }) => {
+      const stateDir = makeTempDir();
+      const installRecords = {
+        authoritative: { source: "npm", spec: "authoritative@1.0.0" },
+      } as const;
+      const valueJson = JSON.stringify({
+        revision: 123,
+        index: {
+          version: 1,
+          hostContractVersion: "2026.4.25",
+          compatRegistryVersion: "compat-v1",
+          migrationVersion: 1,
+          policyHash: "policy-hash",
+          generatedAtMs: 123,
+          installRecords,
+          plugins: [],
+          diagnostics: [],
+        },
+      });
+      insertPersistedIndexRow(stateDir, valueJson);
+      const filePath = resolveInstalledPluginIndexStorePath({ stateDir });
+      closeOpenClawStateDatabaseForTest();
+      const error = Object.assign(new Error("plugin index read denied"), { code: "EACCES" });
+      const readSpy = vi
+        .spyOn(stateDbReadOnly, "withExistingOpenClawStateDatabaseReadOnly")
+        .mockImplementationOnce(() => {
+          throw error;
+        });
+      const lease = { assertOwnedInTransaction: vi.fn() };
+      const params = {
+        reason,
+        stateDir,
+        candidates: [],
+        env: { OPENCLAW_VERSION: "2026.4.25", VITEST: "true" },
+        ...(reason === "policy-changed" ? { installRecords } : {}),
+      };
+      const refresh = async () =>
+        leased
+          ? refreshPersistedInstalledPluginIndexWithLeaseSync({ ...params, lease })
+          : refreshPersistedInstalledPluginIndex(params);
+      await expect.soft(Promise.resolve().then(refresh)).rejects.toBe(error);
+      expect.soft(lease.assertOwnedInTransaction).not.toHaveBeenCalled();
+      expect
+        .soft(readPersistedIndexRow(filePath))
+        .toEqual({ value_json: valueJson, updated_at_ms: 123 });
+      readSpy.mockRestore();
+      await refresh();
+      expect((await readPersistedInstalledPluginIndex({ stateDir }))?.installRecords).toEqual(
+        installRecords,
+      );
+      const persisted = JSON.parse(readPersistedIndexRow(filePath).value_json) as {
+        revision: number;
+      };
+      expect(persisted.revision).toBeGreaterThan(123);
+    },
+  );
+
+  it.each([
+    { label: "malformed JSON", valueJson: "{", recordStatus: "invalid" },
+    { label: "missing records", valueJson: '{"revision":123,"index":{}}', recordStatus: "invalid" },
+    {
+      label: "malformed records",
+      valueJson: '{"revision":123,"index":{"installRecords":{"demo":{"source":"bogus"}}}}',
+      recordStatus: "invalid",
+    },
+    {
+      label: "invalid index metadata",
+      valueJson:
+        '{"revision":123,"index":{"version":999,"installRecords":{"demo":{"source":"npm"}}}}',
+      recordStatus: "valid",
+    },
+    {
+      label: "missing revision",
+      valueJson: '{"index":{"installRecords":{"demo":{"source":"npm"}}}}',
+      recordStatus: "valid",
+    },
+  ] as const)(
+    "keeps record parsing independent of full-index parsing: $label",
+    async ({ valueJson, recordStatus }) => {
+      const stateDir = makeTempDir();
+      insertPersistedIndexRow(stateDir, valueJson);
+      const records = recordStatus === "valid" ? { demo: { source: "npm" } } : null;
+      expect(inspectPersistedInstalledPluginIndexInstallRecordsSync({ stateDir }).status).toBe(
+        recordStatus,
+      );
+      await expect(readPersistedInstalledPluginIndexInstallRecords({ stateDir })).resolves.toEqual(
+        records,
+      );
+      await expect(readPersistedInstalledPluginIndex({ stateDir })).resolves.toBeNull();
+    },
+  );
+});

--- a/src/plugins/installed-plugin-index-record-state.ts
+++ b/src/plugins/installed-plugin-index-record-state.ts
@@ -3,52 +3,21 @@ import {
   inspectPluginInstallRecordMap,
   type PluginInstallRecordMapState,
 } from "../config/plugin-install-record-map.js";
-import { isSqliteSchemaVersionError } from "../infra/sqlite-user-version.js";
-import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
-import {
-  resolveInstalledPluginIndexStateDatabaseOptions,
-  type InstalledPluginIndexStoreOptions,
-} from "./installed-plugin-index-store-path.js";
+import { readPersistedInstalledPluginIndexRowSync } from "./installed-plugin-index-row.js";
+import type { InstalledPluginIndexStoreOptions } from "./installed-plugin-index-store-path.js";
 
 export function inspectPersistedInstalledPluginIndexInstallRecordsSync(
   options: InstalledPluginIndexStoreOptions = {},
 ): PluginInstallRecordMapState {
-  if (options.filePath?.endsWith(".json")) {
+  const row = readPersistedInstalledPluginIndexRowSync(options);
+  if (!row) {
     return { status: "missing" };
   }
-  try {
-    return (
-      withExistingOpenClawStateDatabaseReadOnly(({ db }) => {
-        const hasTable = db
-          .prepare(
-            `SELECT 1
-             FROM sqlite_master
-            WHERE type = 'table' AND name = 'config_machine_state'`,
-          )
-          .get();
-        if (!hasTable) {
-          return { status: "missing" };
-        }
-        const row = db
-          .prepare("SELECT value_json FROM config_machine_state WHERE state_key = ?")
-          // SAFETY: config_machine_state.value_json is TEXT NOT NULL under STRICT.
-          .get("plugins.installedIndex") as { value_json: string } | undefined;
-        if (!row) {
-          return { status: "missing" };
-        }
-        const value = safeParseJson(row.value_json) as
-          | { index?: { installRecords?: unknown } }
-          | undefined;
-        const installRecords = value?.index?.installRecords;
-        return installRecords === undefined
-          ? { status: "invalid" }
-          : inspectPluginInstallRecordMap(installRecords);
-      }, resolveInstalledPluginIndexStateDatabaseOptions(options)) ?? { status: "missing" }
-    );
-  } catch (error) {
-    if (isSqliteSchemaVersionError(error)) {
-      throw error;
-    }
-    return { status: "invalid" };
-  }
+  const value = safeParseJson(row.value_json) as
+    | { index?: { installRecords?: unknown } }
+    | undefined;
+  const installRecords = value?.index?.installRecords;
+  return installRecords === undefined
+    ? { status: "invalid" }
+    : inspectPluginInstallRecordMap(installRecords);
 }

--- a/src/plugins/installed-plugin-index-records.test.ts
+++ b/src/plugins/installed-plugin-index-records.test.ts
@@ -12,6 +12,7 @@ import {
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
+import * as stateDbReadOnly from "../state/openclaw-state-db-readonly.js";
 import {
   closeOpenClawStateDatabaseForTest,
   runOpenClawStateWriteTransaction,
@@ -23,11 +24,13 @@ import {
   resolvePluginNpmGenerationProjectDir,
   resolvePluginNpmProjectDir,
 } from "./install-paths.js";
+import { inspectPersistedInstalledPluginIndexInstallRecordsSync } from "./installed-plugin-index-record-state.js";
 import {
   clearLoadInstalledPluginIndexInstallRecordsCache,
   loadInstalledPluginIndexInstallRecords,
   loadInstalledPluginIndexInstallRecordsSync,
   readPersistedInstalledPluginIndexInstallRecords,
+  readPersistedInstalledPluginIndexInstallRecordsSync,
   recordPluginInstallInRecords,
   removePluginInstallRecordFromRecords,
   resolveInstalledPluginIndexRecordsStorePath,
@@ -107,6 +110,50 @@ afterEach(() => {
 });
 
 describe("plugin index install records store", () => {
+  it.each([
+    { code: "EACCES" },
+    { code: "ERR_SQLITE_ERROR", errcode: 5, errstr: "database is locked" },
+    { code: "ERR_SQLITE_ERROR", errcode: 6, errstr: "database table is locked" },
+  ])("preserves read errors without recovery or cache poisoning: %j", async (details) => {
+    const stateDir = tempDirs.make("openclaw-plugin-index-records-");
+    const records = { authoritative: { source: "npm", spec: "authoritative@1.0.0" } } as const;
+    await writePersistedInstalledPluginIndexInstallRecords(records, { stateDir, candidates: [] });
+    writeManagedNpmPlugin({
+      stateDir,
+      packageName: "recoverable",
+      pluginId: "recoverable",
+      version: "1.0.0",
+    });
+    const error = Object.assign(new Error("plugin index read failed"), details);
+    const readSpy = vi.spyOn(stateDbReadOnly, "withExistingOpenClawStateDatabaseReadOnly");
+    const scanSpy = vi.spyOn(fs, "readdirSync");
+    for (const read of [
+      inspectPersistedInstalledPluginIndexInstallRecordsSync,
+      readPersistedInstalledPluginIndexInstallRecordsSync,
+      readPersistedInstalledPluginIndexInstallRecords,
+      loadInstalledPluginIndexInstallRecordsSync,
+      loadInstalledPluginIndexInstallRecords,
+    ]) {
+      readSpy.mockImplementationOnce(() => {
+        throw error;
+      });
+      await expect
+        .soft(
+          Promise.resolve().then(() => read({ stateDir })),
+          read.name,
+        )
+        .rejects.toBe(error);
+    }
+    expect(scanSpy).not.toHaveBeenCalled();
+    readSpy.mockRestore();
+    scanSpy.mockRestore();
+
+    const restored = await loadInstalledPluginIndexInstallRecords({ stateDir });
+    expect(restored.authoritative).toEqual(records.authoritative);
+    expect(restored.recoverable).toMatchObject({ source: "npm", spec: "recoverable@1.0.0" });
+    expect(loadInstalledPluginIndexInstallRecordsSync({ stateDir })).toEqual(restored);
+  });
+
   it("writes machine-managed install records outside config", async () => {
     const stateDir = tempDirs.make("openclaw-plugin-index-records-");
     const candidate = createPluginCandidate(stateDir, "twitch");

--- a/src/plugins/installed-plugin-index-row.ts
+++ b/src/plugins/installed-plugin-index-row.ts
@@ -1,0 +1,26 @@
+import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
+import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
+import {
+  resolveInstalledPluginIndexStateDatabaseOptions,
+  type InstalledPluginIndexStoreOptions,
+} from "./installed-plugin-index-store-path.js";
+
+/** Read failures must escape before either projection can authorize recovery or rebuilding. */
+export function readPersistedInstalledPluginIndexRowSync(
+  options: InstalledPluginIndexStoreOptions,
+): { value_json: string } | undefined {
+  if (options.filePath?.endsWith(".json")) {
+    return undefined;
+  }
+  return withExistingOpenClawStateDatabaseReadOnly(({ db }) => {
+    if (!tableExists(db, "config_machine_state")) {
+      return undefined;
+    }
+    return (
+      db
+        .prepare("SELECT value_json FROM config_machine_state WHERE state_key = ?")
+        // SAFETY: config_machine_state.value_json is TEXT NOT NULL under STRICT.
+        .get("plugins.installedIndex") as { value_json: string } | undefined
+    );
+  }, resolveInstalledPluginIndexStateDatabaseOptions(options));
+}

--- a/src/plugins/installed-plugin-index-store.ts
+++ b/src/plugins/installed-plugin-index-store.ts
@@ -6,14 +6,10 @@ import {
   parsePluginInstallRecordMap,
   PluginInstallRecordSchema,
 } from "../config/plugin-install-record-map.js";
-import { isSqliteSchemaVersionError } from "../infra/sqlite-user-version.js";
-import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import { safeParseWithSchema } from "../utils/zod-parse.js";
 import { recordInstalledPluginIndexInstallOwner } from "./installed-plugin-index-install-owner.js";
-import {
-  resolveInstalledPluginIndexStateDatabaseOptions,
-  type InstalledPluginIndexStoreOptions,
-} from "./installed-plugin-index-store-path.js";
+import { readPersistedInstalledPluginIndexRowSync } from "./installed-plugin-index-row.js";
+import type { InstalledPluginIndexStoreOptions } from "./installed-plugin-index-store-path.js";
 import {
   extractPluginInstallRecordsFromInstalledPluginIndex,
   INSTALLED_PLUGIN_INDEX_VERSION,
@@ -181,6 +177,12 @@ export function readInstalledPluginIndexRow(
     .prepare("SELECT value_json FROM config_machine_state WHERE state_key = ?")
     // SAFETY: config_machine_state.value_json is TEXT NOT NULL under STRICT.
     .get(INSTALLED_PLUGIN_INDEX_STATE_KEY) as { value_json: string } | undefined;
+  return parsePersistedInstalledPluginIndexRow(row);
+}
+
+function parsePersistedInstalledPluginIndexRow(
+  row: { value_json: string } | undefined,
+): PersistedInstalledPluginIndexValue | undefined {
   if (!row) {
     return undefined;
   }
@@ -197,27 +199,6 @@ export function readInstalledPluginIndexRow(
   return value as PersistedInstalledPluginIndexValue;
 }
 
-function readPersistedInstalledPluginIndexFromSqlite(
-  options: InstalledPluginIndexStoreOptions = {},
-): InstalledPluginIndex | null {
-  if (options.filePath?.endsWith(".json")) {
-    return null;
-  }
-  try {
-    return (
-      withExistingOpenClawStateDatabaseReadOnly(
-        ({ db }) => parseInstalledPluginIndexSqliteRow(readInstalledPluginIndexRow(db)),
-        resolveInstalledPluginIndexStateDatabaseOptions(options),
-      ) ?? null
-    );
-  } catch (error) {
-    if (isSqliteSchemaVersionError(error)) {
-      throw error;
-    }
-    return null;
-  }
-}
-
 export async function readPersistedInstalledPluginIndex(
   options: InstalledPluginIndexStoreOptions = {},
 ): Promise<InstalledPluginIndex | null> {
@@ -227,5 +208,7 @@ export async function readPersistedInstalledPluginIndex(
 export function readPersistedInstalledPluginIndexSync(
   options: InstalledPluginIndexStoreOptions = {},
 ): InstalledPluginIndex | null {
-  return readPersistedInstalledPluginIndexFromSqlite(options);
+  return parseInstalledPluginIndexSqliteRow(
+    parsePersistedInstalledPluginIndexRow(readPersistedInstalledPluginIndexRowSync(options)),
+  );
 }


### PR DESCRIPTION
Closes #131327 — plugin-state read failures misreported as invalid or missing records.

## What Problem This Solves

Fixes an issue where operators inspecting or repairing plugin state received invalid-record and row-deletion guidance when the database could not actually be read. The sibling full-index reader reported the same failures as an absent index, allowing a transient failed read to select a rebuild with empty install records.

The original isolated EACCES reproduction fails on current-main baseline `ecb6acff90057a31b482f54146ea87e984e06cbc`. A real-SQLite regression fixture additionally demonstrates a manual refresh overwriting its synthetic authoritative records after one injected read failure. This is synthetic-state proof, not a claim of observed production data loss.

## Why This Change Was Made

Both projections now share a light read-only row boundary that propagates original errors and explicitly recognizes genuine missing database/table/row state. Removed the two broad catches and redundant SQLite forwarding function; kept install-record parsing independent of full-index parsing so intact records remain recoverable when derived metadata is malformed.

The persistence-recovery contract was [explicitly accepted before implementation](https://github.com/openclaw/openclaw/issues/131327#issuecomment-5448052086). No schema/version, representation, migration format, retention, transaction, writer, rollback, or successful-cache lifecycle changes. A failed authoritative read cannot authorize fallback, migration, or a persisted refresh. Malformed-envelope and missing-revision behavior remains unchanged. A code revert requires no data migration, but would restore the misleading classifications.

Best-fix judgment: repair the read owner, not runtime/Doctor diagnostics. An error-code allowlist would omit other real failures; a new unavailable-result layer adds no needed caller capability; routing records through full-index validation would break record salvage.

Production LOC: **+48/-70 (net -22)**. Tests: **+304/-0**. Docs: **+2/-0**. The new row module replaces duplicated reader policy; no test-only production seam or dependency was added.

Provenance: original catch-to-null in [#88794 — SQLite plugin-index persistence](https://github.com/openclaw/openclaw/pull/88794), authored and merged by @steipete; invalid-record classification in [#121045 — install-record recovery](https://github.com/openclaw/openclaw/pull/121045), authored and merged by @vincentkoc. [#125493 — newer-schema error preservation](https://github.com/openclaw/openclaw/pull/125493), authored and merged by @steipete, exempted schema errors but retained the remaining catch behavior. Blame and live merge metadata checked. Older stable tags contain catch-to-null behavior; the supplied current-main stat-injection reproduction was not run against a stable binary.

## User Impact

Permission and lock failures remain permission and lock failures. Operators can restore database access and retry without being told to delete unread records. Genuine absence, invalid-record guidance after successful inspection, newer-schema refusal, and successful recovery remain supported. Updated the [plugin state documentation](https://docs.openclaw.ai/cli/plugins#plugin-index).

AI-assisted repair and review; reporter and maintainer: @steipete.

## Evidence

Rebased onto `629a47e3cc20a9f8b6d19c105f840b8a693ec4aa` to resolve conflicts with [#131417 — keep write machinery out of metadata reads](https://github.com/openclaw/openclaw/pull/131417). The writer module remains unchanged; the new regression suite imports refresh functions from its current owner. The approved read-error semantics are unchanged. All **163 tests across 9 files** pass again, the original four-path EACCES reproduction and real SQLite owner lock probe pass again, and fresh isolated Codex autoreview is clean. Full build and built CLI proof below were completed before this module-split rebase; exact-head hosted [CI run 33141896737](https://github.com/openclaw/openclaw/actions/runs/33141896737) passed on `39b7447d49cd07d4986d0b85e6e6a1a3df284eca`, including the required `openclaw/ci-gate`. The complete changed-file gate also passed again after rebase.

- Original EACCES reproduction: before, four denied reads became `invalid`, a replacement runtime error, `null`, and Doctor row-deletion guidance. After, all four propagate the exact original error; no misleading classification or deletion guidance. The lead independently reran this probe.
- Regression proof before production edits: Doctor 2 failing cases and plugin error/rebuild cases fail for the reported behavior. After moving the new store cases into their final focused suite, replay against baseline production: **5 failed, 8 passed**; preservation cases intentionally already passed. Ordinary and leased manual refresh previously replaced synthetic records with `{}` and advanced revision; policy refresh also wrote after a failed required read.
- Final focused and sibling proof: **163 tests passed across 9 files**, covering sync/async readers, EACCES, BUSY/LOCKED, cache failure-then-success ordering, no managed-npm recovery after read failure, both Doctor preflight reads, exact stored JSON/revision/timestamp preservation, ordinary/leased/policy refresh, genuine absence, malformed data, newer-schema refusal, prototype-safe records, generation precedence, discovery, and metadata lifecycle.
- Real SQLite owner proof: an isolated database held under `BEGIN EXCLUSIVE` returns actual `ERR_SQLITE_ERROR` / `errcode: 5` / `database is locked` through full-index, runtime-record, and Doctor reads; the row remains unchanged; all succeed after unlocking.
- Supplemental built CLI proof: isolated `node openclaw.mjs plugins registry --json` exits 1 with `SQLite read-only worker database is locked`, leaves exact row bytes/revision untouched, then exits 0 after unlock and preserves authoritative records. **Limit:** this CLI lock is caught by earlier shared-state bootstrap, not the changed plugin reader; changed-owner proof is the real SQLite probe and regression suite above. No operator Gateway or live state was touched.
- `pnpm build`: passed, including CLI bootstrap/import checks and SDK exports; no ineffective-dynamic-import warning.
- Final changed gate: passed formatting, ratchets, dead-export checks, production/test typechecking, changed-file lint, database-first/schema guards, zero runtime import cycles, and remaining scoped guards. Initial fixture type and test-file length failures were corrected without suppressions or production changes.
- Fresh Codex autoreview of the final diff: clean, no accepted/actionable findings.

Focused test command:

```bash
node scripts/run-vitest.mjs src/plugins/installed-plugin-index-records.test.ts src/plugins/installed-plugin-index-store.test.ts src/plugins/installed-plugin-index-read-state.test.ts src/commands/doctor/shared/plugin-registry-migration.test.ts src/plugins/installed-plugin-index-store.install-record-map.test.ts src/plugins/installed-plugin-index-generation-precedence.test.ts src/plugins/plugin-registry-inspection.test.ts src/plugins/plugin-registry-snapshot.test.ts src/plugins/manifest-metadata-scan.test.ts
```

Changed gate:

```bash
node scripts/check-changed.mjs -- docs/cli/plugins.md src/plugins/installed-plugin-index-record-state.ts src/plugins/installed-plugin-index-row.ts src/plugins/installed-plugin-index-store.ts src/plugins/installed-plugin-index-records.test.ts src/plugins/installed-plugin-index-read-state.test.ts src/commands/doctor/shared/plugin-registry-migration.test.ts
```

Dependency contract checked directly: [Node 26.7.0 SQLite get](https://github.com/nodejs/node/blob/v26.7.0/src/node_sqlite.cc#L3011) distinguishes `SQLITE_DONE` from errors; [SQLite error construction](https://github.com/nodejs/node/blob/v26.7.0/src/node_sqlite.cc#L208) retains result codes; [SQLite BUSY/LOCKED](https://www.sqlite.org/rescode.html#busy) describe concurrency failures rather than malformed data.
