### PR TITLE
test: stop re-evaluating plugin module graphs for every test case

### DIFF
--- a/extensions/google/api.test.ts
+++ b/extensions/google/api.test.ts
@@ -1,11 +1,15 @@
 // Google tests cover api plugin behavior.
 import { describe, expect, it } from "vitest";
 import {
+  applyGoogleGeminiModelDefault,
+  GOOGLE_GEMINI_DEFAULT_MODEL,
   isGoogleGenerativeAiApi,
   isGoogleVertexBaseUrl,
   isGoogleVertexHostname,
+  normalizeAntigravityModelId,
   normalizeGoogleApiBaseUrl,
   normalizeGoogleGenerativeAiBaseUrl,
+  normalizeGoogleModelId,
   normalizeGoogleProviderConfig,
   parseGeminiAuth,
   resolveGoogleGenerativeAiHttpRequestConfig,
@@ -13,8 +17,23 @@ import {
   resolveGoogleGenerativeAiTransport,
   shouldNormalizeGoogleGenerativeAiProviderConfig,
 } from "./api.js";
+import {
+  normalizeAntigravityModelId as normalizeAntigravityModelIdDirect,
+  normalizeGoogleModelId as normalizeGoogleModelIdDirect,
+} from "./model-id.js";
+import {
+  applyGoogleGeminiModelDefault as applyGoogleGeminiModelDefaultDirect,
+  GOOGLE_GEMINI_DEFAULT_MODEL as GOOGLE_GEMINI_DEFAULT_MODEL_DIRECT,
+} from "./onboard.js";
 
 describe("google generative ai helpers", () => {
+  it("re-exports model normalization and default helpers", () => {
+    expect(normalizeAntigravityModelId).toBe(normalizeAntigravityModelIdDirect);
+    expect(normalizeGoogleModelId).toBe(normalizeGoogleModelIdDirect);
+    expect(applyGoogleGeminiModelDefault).toBe(applyGoogleGeminiModelDefaultDirect);
+    expect(GOOGLE_GEMINI_DEFAULT_MODEL).toBe(GOOGLE_GEMINI_DEFAULT_MODEL_DIRECT);
+  });
+
   it("detects the Google Generative AI transport id", () => {
     expect(isGoogleGenerativeAiApi("google-generative-ai")).toBe(true);
     expect(isGoogleGenerativeAiApi("google-gemini-cli")).toBe(false);

--- a/extensions/google/default-model.test.ts
+++ b/extensions/google/default-model.test.ts
@@ -1,7 +1,7 @@
 // Google tests cover default model plugin behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/provider-onboard";
 import { describe, expect, it } from "vitest";
-import { applyGoogleGeminiModelDefault, GOOGLE_GEMINI_DEFAULT_MODEL } from "./api.js";
+import { applyGoogleGeminiModelDefault, GOOGLE_GEMINI_DEFAULT_MODEL } from "./onboard.js";
 
 describe("google default model", () => {
   it("sets defaults when model is unset", () => {

--- a/extensions/google/model-id.test.ts
+++ b/extensions/google/model-id.test.ts
@@ -1,6 +1,6 @@
 // Google tests cover model id plugin behavior.
 import { describe, expect, it } from "vitest";
-import { normalizeAntigravityModelId, normalizeGoogleModelId } from "./api.js";
+import { normalizeAntigravityModelId, normalizeGoogleModelId } from "./model-id.js";
 
 describe("google model id helpers", () => {
   it.each(["gemini-3-pro", "gemini-3.1-pro", "gemini-3-1-pro"])(

--- a/extensions/xai/api.test.ts
+++ b/extensions/xai/api.test.ts
@@ -1,8 +1,18 @@
 // Xai tests cover api plugin behavior.
 import { describe, expect, it } from "vitest";
-import { resolveXaiForwardCompatModel, resolveXaiTransport, XAI_BASE_URL } from "./api.js";
+import {
+  normalizeXaiModelId,
+  resolveXaiForwardCompatModel,
+  resolveXaiTransport,
+  XAI_BASE_URL,
+} from "./api.js";
+import { normalizeXaiModelId as normalizeXaiModelIdDirect } from "./model-id.js";
 
 describe("xai api helpers", () => {
+  it("re-exports the model normalizer", () => {
+    expect(normalizeXaiModelId).toBe(normalizeXaiModelIdDirect);
+  });
+
   it("uses shared endpoint classification for native xAI transports", () => {
     expect(
       resolveXaiTransport({

--- a/extensions/xai/model-id.test.ts
+++ b/extensions/xai/model-id.test.ts
@@ -1,6 +1,6 @@
 // Xai tests cover model id plugin behavior.
 import { describe, expect, it } from "vitest";
-import { normalizeXaiModelId } from "./api.js";
+import { normalizeXaiModelId } from "./model-id.js";
 
 describe("normalizeXaiModelId", () => {
   it("normalizes family-specific aliases but preserves the global alias", () => {

--- a/src/plugin-sdk/webhook-targets.test.ts
+++ b/src/plugin-sdk/webhook-targets.test.ts
@@ -4,7 +4,7 @@
 import { EventEmitter } from "node:events";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createEmptyPluginRegistry } from "../plugins/registry.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createWebhookInFlightLimiter } from "./webhook-request-guards.js";
 import {

--- a/src/plugins/doctor-contract-registry.state-migrations.test.ts
+++ b/src/plugins/doctor-contract-registry.state-migrations.test.ts
@@ -1,7 +1,7 @@
 // Covers plugin doctor state-migration registry behavior.
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
 import {
   getRegistryJitiMocks,
@@ -39,9 +39,7 @@ afterEach(() => {
 });
 
 describe("doctor-contract-registry state migrations", () => {
-  beforeEach(async () => {
-    resetRegistryJitiMocks();
-    doctorContractWarnMock.mockReset();
+  beforeAll(async () => {
     vi.resetModules();
     ({ listPluginDoctorLegacyConfigRules, listPluginDoctorStateMigrationEntries } =
       await import("./doctor-contract-registry.js"));
@@ -49,6 +47,17 @@ describe("doctor-contract-registry state migrations", () => {
       clearPluginDoctorContractRegistryCache,
       setPluginDoctorContractRegistryModuleLoaderFactoryForTest,
     } = await import("./doctor-contract-registry.test-fixtures.js"));
+  });
+
+  beforeEach(() => {
+    resetRegistryJitiMocks();
+    doctorContractWarnMock.mockReset();
+    // Loaded once in beforeAll; afterEach guards the same binding optionally because it
+    // can fire when that import never completed. Fail loudly here instead of silently
+    // running a case against the real module loader.
+    if (!setPluginDoctorContractRegistryModuleLoaderFactoryForTest) {
+      throw new Error("doctor contract registry test fixtures were not loaded");
+    }
     setPluginDoctorContractRegistryModuleLoaderFactoryForTest(mocks.createJiti);
     clearPluginDoctorContractRegistryCache();
   });

--- a/src/plugins/doctor-contract-registry.test.ts
+++ b/src/plugins/doctor-contract-registry.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { withMockedPlatform } from "../test-utils/vitest-spies.js";
 import { resolvePluginDoctorContractArtifactPath } from "./doctor-contract-artifact.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
@@ -54,10 +54,7 @@ afterEach(() => {
 });
 
 describe("doctor-contract-registry module loader", () => {
-  beforeEach(async () => {
-    resetRegistryJitiMocks();
-    mocks.loadPluginManifestRegistry.mockReturnValue({ plugins: [], diagnostics: [] });
-    doctorContractWarnMock.mockReset();
+  beforeAll(async () => {
     vi.resetModules();
     ({
       applyPluginDoctorCompatibilityMigrations,
@@ -71,6 +68,18 @@ describe("doctor-contract-registry module loader", () => {
       clearPluginDoctorContractRegistryCache,
       setPluginDoctorContractRegistryModuleLoaderFactoryForTest,
     } = await import("./doctor-contract-registry.test-fixtures.js"));
+  });
+
+  beforeEach(() => {
+    resetRegistryJitiMocks();
+    mocks.loadPluginManifestRegistry.mockReturnValue({ plugins: [], diagnostics: [] });
+    doctorContractWarnMock.mockReset();
+    // Loaded once in beforeAll; afterEach guards the same binding optionally because it
+    // can fire when that import never completed. Fail loudly here instead of silently
+    // running a case against the real module loader.
+    if (!setPluginDoctorContractRegistryModuleLoaderFactoryForTest) {
+      throw new Error("doctor contract registry test fixtures were not loaded");
+    }
     setPluginDoctorContractRegistryModuleLoaderFactoryForTest(mocks.createJiti);
     clearPluginDoctorContractRegistryCache();
   });

--- a/src/plugins/hook-resolve-exec-env.test.ts
+++ b/src/plugins/hook-resolve-exec-env.test.ts
@@ -2,7 +2,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createHookRunner } from "./hooks.js";
 import { addStaticTestHooks, addTestHook } from "./hooks.test-fixtures.js";
-import { createEmptyPluginRegistry } from "./registry.js";
+import { createEmptyPluginRegistry } from "./registry-empty.js";
 import type { PluginHookResolveExecEnvContext } from "./types.js";
 
 const ctx: PluginHookResolveExecEnvContext = {

--- a/src/plugins/hooks.before-install.test.ts
+++ b/src/plugins/hooks.before-install.test.ts
@@ -2,7 +2,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createHookRunner } from "./hooks.js";
 import { addTestHook } from "./hooks.test-fixtures.js";
-import { createEmptyPluginRegistry, type PluginRegistry } from "./registry.js";
+import { createEmptyPluginRegistry } from "./registry-empty.js";
+import type { PluginRegistry } from "./registry.js";
 import type {
   PluginHookBeforeInstallContext,
   PluginHookBeforeInstallEvent,

--- a/src/plugins/hooks.before-tool-call.test.ts
+++ b/src/plugins/hooks.before-tool-call.test.ts
@@ -6,7 +6,8 @@ import { configureRuntimeActionDecisionSink } from "../audit/runtime-action-deci
 import { createHookRunner } from "./hooks.js";
 import { addStaticTestHooks } from "./hooks.test-fixtures.js";
 import { addTestHook } from "./hooks.test-helpers.js";
-import { createEmptyPluginRegistry, type PluginRegistry } from "./registry.js";
+import { createEmptyPluginRegistry } from "./registry-empty.js";
+import type { PluginRegistry } from "./registry.js";
 import type {
   PluginHookBeforeToolCallEvent,
   PluginHookBeforeToolCallResult,

--- a/src/plugins/hooks.correlation.test.ts
+++ b/src/plugins/hooks.correlation.test.ts
@@ -4,7 +4,8 @@ import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coerci
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createHookRunner } from "./hooks.js";
 import { addTestHook, TEST_PLUGIN_AGENT_CTX } from "./hooks.test-fixtures.js";
-import { createEmptyPluginRegistry, type PluginRegistry } from "./registry.js";
+import { createEmptyPluginRegistry } from "./registry-empty.js";
+import type { PluginRegistry } from "./registry.js";
 import type { PluginHookRegistration } from "./types.js";
 
 describe("hook correlation fields", () => {
@@ -116,7 +117,10 @@ describe("hook correlation fields", () => {
       {
         cwd: process.cwd(),
         encoding: "utf8",
-        timeout: 3_000,
+        // Boots tsx in a child process, so the deadline must cover compile time on a
+        // loaded machine. A tight bound kills the probe (status null) and fails the
+        // assertions below for a reason unrelated to the hook timeout under test.
+        timeout: 30_000,
       },
     );
     oneShotAgentEndProbe = {

--- a/src/plugins/hooks.phase-hooks.test.ts
+++ b/src/plugins/hooks.phase-hooks.test.ts
@@ -4,7 +4,8 @@ import { applyEmbeddedAttemptToolsAllow } from "../agents/embedded-agent-runner/
 import { readToolAllowlistIntersection } from "../agents/tool-policy.js";
 import { createHookRunner } from "./hooks.js";
 import { addStaticTestHooks } from "./hooks.test-fixtures.js";
-import { createEmptyPluginRegistry, type PluginRegistry } from "./registry.js";
+import { createEmptyPluginRegistry } from "./registry-empty.js";
+import type { PluginRegistry } from "./registry.js";
 import type {
   PluginHookBeforeModelResolveResult,
   PluginHookBeforePromptBuildResult,

--- a/src/plugins/hooks.security.test.ts
+++ b/src/plugins/hooks.security.test.ts
@@ -2,7 +2,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createHookRunner } from "./hooks.js";
 import { addStaticTestHooks } from "./hooks.test-fixtures.js";
-import { createEmptyPluginRegistry, type PluginRegistry } from "./registry.js";
+import { createEmptyPluginRegistry } from "./registry-empty.js";
+import type { PluginRegistry } from "./registry.js";
 import type { PluginHookBeforeToolCallResult, PluginHookMessageSendingResult } from "./types.js";
 
 const toolEvent = { toolName: "bash", params: { command: "echo hello" } };

--- a/src/utils/provider-utils.test.ts
+++ b/src/utils/provider-utils.test.ts
@@ -5,15 +5,9 @@ const { resolveProviderReasoningOutputModeWithPluginMock } = vi.hoisted(() => ({
   resolveProviderReasoningOutputModeWithPluginMock: vi.fn(),
 }));
 
-vi.mock("../plugins/provider-runtime.js", async () => {
-  const actual = await vi.importActual<typeof import("../plugins/provider-runtime.js")>(
-    "../plugins/provider-runtime.js",
-  );
-  return {
-    ...actual,
-    resolveProviderReasoningOutputModeWithPlugin: resolveProviderReasoningOutputModeWithPluginMock,
-  };
-});
+vi.mock("../plugins/provider-runtime.js", () => ({
+  resolveProviderReasoningOutputModeWithPlugin: resolveProviderReasoningOutputModeWithPluginMock,
+}));
 
 import { isReasoningTagProvider } from "./provider-utils.js";
 


### PR DESCRIPTION
## What Problem This Solves

Several plugin and provider test suites re-evaluated large module graphs they never
asserted against, so the suites were slower than the work they actually prove.

The dominant case: `doctor-contract-registry.test.ts` and its state-migrations sibling
called `vi.resetModules()` plus a dynamic re-import in `beforeEach`. With 54 cases
between them, that re-evaluated the whole doctor owner graph 54 times — setup policy,
migration adapters, config normalization, loader state, and native/SDK alias
resolution — including for cases that only collect provider IDs.

## Why This Change Was Made

The reset/import moves to `beforeAll`; every per-case mock reset, loader injection,
cache clear, and temp-dir cleanup stays exactly where it was. `setup-registry.test.ts`
already used this shape, so the pattern is proven in-tree rather than invented here.

The remaining changes narrow imports that pulled broad graphs in for static work:

- seven files reached `createEmptyPluginRegistry` through `registry.js`, dragging in the
  entire registry construction graph to call a function that builds empty arrays and
  maps. `registry-empty.js` is its real, dependency-free owner.
- three provider tests imported `api.js` and paid for transport-streaming, provider-auth,
  and image-generation SDK graphs in order to test pure string normalization.
- `provider-utils.test.ts` used `importActual()` to spread a runtime whose only used
  export it immediately replaced. `provider-utils.ts` imports exactly one value binding
  from `provider-runtime.js`; everything else is `import type` and erased at runtime, so
  the narrowed factory still covers every binding production touches.

Reading the barrel suites showed that **neither actually asserted the exports being
narrowed away from**, so this adds explicit re-export assertions in
`extensions/google/api.test.ts` and `extensions/xai/api.test.ts` rather than letting that
coverage lapse silently. Net coverage goes up.

## User Impact

None at runtime. Test-only change, **zero production LOC** — all 15 changed files are
`*.test.ts`. Contributors and CI get faster, less flaky plugin test suites.

## Evidence

`doctor-contract-registry.test.ts`, measured interleaved A/B to cancel drift, 33 tests
passing in every run. The relative gain is stable; the absolute saving depends on
whether Vitest's transform cache is warm, so both conditions are reported:

| Condition | Before | After | Gain |
| --- | ---: | ---: | ---: |
| Warm cache, quiet host (5 pairs, mean) | 3.76s | 2.48s | **-1.28s (-34%)** |
| Cold cache, loaded host (2 pairs, mean) | 29.7s | 18.2s | **-11.5s (-39%)** |

After was faster in 5/5 pairs in the warm-cache sample, so the direction is consistent
rather than noise. The cold-cache figure is the honest upper bound, not the typical
local case; CI runners start colder and more contended than a warm dev box, so the
real CI saving sits between the two rather than at either end. In the cold-cache run
import time also fell 508ms -> 136ms, which is the mechanism confirming itself: fewer
module-graph evaluations.

Verification:

- all 15 changed files: **215 tests, 4 shards, green** (re-run after rebase onto current main)
- `node scripts/check-changed.mjs` exit 0 (includes all four typecheck lanes)
- fresh Codex autoreview on the final tree: clean, no accepted/actionable findings

Unrelated flake fixed in passing, per the Pathfinder rule:
`hooks.correlation.test.ts` spawns a `node --import tsx` subprocess under a 3-second
deadline. Under load the child is killed and the assertion sees `status: null`. It failed
**3/3 on unmodified code** — confirmed before touching it — and passes **4/4** at 30s.
No assertion was weakened; only the harness deadline moved.

Not included: collapsing the six pairing-authorization gateway startups in
`server.device-pair-approve-authz.test.ts` into one. That is a real further win but is
medium-risk, because server reuse replaces full state-directory cleanup and needs
explicit pairing-record teardown to stay behavior-preserving. It belongs in its own change.
