### PR TITLE
fix(meetings): keep realtime audio alive during provider recovery

### DIFF
--- a/docs/plugins/meeting-plugins.md
+++ b/docs/plugins/meeting-plugins.md
@@ -34,6 +34,8 @@ The three plugins share the same modes:
 
 Use `transcribe` when the agent only needs meeting text. Use `agent` for normal OpenClaw reasoning and tools. Use `bidi` when low-latency direct voice is more important than routing each turn through the regular agent.
 
+In `bidi` mode, recoverable provider diagnostics are logged without stopping the audio bridge. Providers that support reconnecting own that recovery. Terminal provider closure, exhausted recovery, failed initial setup, and local audio-transport failures still stop the bridge; leaving the meeting also stops it.
+
 The bounded live transcript remains available only in `transcribe` mode. In all
 three modes, browser joins also persist completed caption rows and a derived
 summary to the shared state database. Leaving the meeting finalizes visible

--- a/extensions/google/realtime-voice-meeting.test.ts
+++ b/extensions/google/realtime-voice-meeting.test.ts
@@ -1,0 +1,216 @@
+import { LiveServerMessage, type LiveConnectParameters, type Session } from "@google/genai";
+import {
+  startMeetingRealtimeEngine,
+  type MeetingRealtimeAudioEngineHandle,
+  type MeetingRealtimeAudioTransport,
+} from "openclaw/plugin-sdk/meeting-runtime";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildGoogleRealtimeVoiceProvider } from "./realtime-voice-provider.js";
+
+function createSdkSession() {
+  return {
+    close: vi.fn(),
+    sendRealtimeInput: vi.fn<Session["sendRealtimeInput"]>(),
+    sendClientContent: vi.fn(),
+    sendToolResponse: vi.fn(),
+  };
+}
+
+const { connectMock } = vi.hoisted(() => ({
+  connectMock:
+    vi.fn<(params: LiveConnectParameters) => Promise<ReturnType<typeof createSdkSession>>>(),
+}));
+vi.mock("./google-genai-runtime.js", () => ({
+  createGoogleGenAI: () => ({ live: { connect: connectMock } }),
+}));
+
+type Connection = { params: LiveConnectParameters; session: ReturnType<typeof createSdkSession> };
+const connections: Connection[] = [];
+let meeting: MeetingRealtimeAudioEngineHandle | undefined;
+const input = Buffer.alloc(960, 1);
+const output = Buffer.alloc(960, 2);
+
+function currentConnection() {
+  const connection = connections.at(-1);
+  if (!connection) {
+    throw new Error("Expected Google Live connection");
+  }
+  return connection;
+}
+
+function receive(message: Partial<LiveServerMessage>, connection = currentConnection()) {
+  connection.params.callbacks.onmessage(Object.assign(new LiveServerMessage(), message));
+}
+
+function remoteClose() {
+  currentConnection().params.callbacks.onclose?.(
+    new CloseEvent("close", { code: 1011, reason: "temporary upstream close", wasClean: false }),
+  );
+}
+
+function receiveAudio(connection = currentConnection()) {
+  receive(
+    {
+      serverContent: {
+        modelTurn: {
+          parts: [
+            { inlineData: { mimeType: "audio/pcm;rate=24000", data: output.toString("base64") } },
+          ],
+        },
+      },
+    },
+    connection,
+  );
+}
+
+async function startMeeting() {
+  const transport = {
+    onFatal: vi.fn(),
+    startInput: vi.fn<MeetingRealtimeAudioTransport["startInput"]>(),
+    clearOutput: vi.fn(async () => {}),
+    writeOutput: vi.fn<MeetingRealtimeAudioTransport["writeOutput"]>(async () => {}),
+    stop: vi.fn(async () => {}),
+    dispose: vi.fn(async () => {}),
+  } satisfies MeetingRealtimeAudioTransport;
+  const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  meeting = await startMeetingRealtimeEngine({
+    config: {
+      chrome: { audioFormat: "pcm16-24khz" },
+      realtime: {
+        strategy: "bidi",
+        provider: "google",
+        providers: { google: { apiKey: "test-key" } },
+      },
+    },
+    fullConfig: {},
+    runtime: {} as never,
+    platform: {
+      displayName: "Test Meeting",
+      logScope: "[meeting-test]",
+      sessionIdPrefix: "meeting-test",
+    },
+    meetingSessionId: "meeting-1",
+    providers: [buildGoogleRealtimeVoiceProvider()],
+    transport,
+    logger,
+    consultAgent: async () => ({ text: "unused" }),
+    handleToolCall: async () => {},
+    tools: [],
+  });
+  const onInput = transport.startInput.mock.calls[0]?.[0];
+  if (!onInput) {
+    throw new Error("Expected meeting audio capture");
+  }
+  expect(meeting.getHealth()).toMatchObject({
+    providerConnected: true,
+    realtimeReady: true,
+    bridgeClosed: false,
+  });
+  onInput(input);
+  expect(currentConnection().session.sendRealtimeInput).toHaveBeenCalledOnce();
+  return { handle: meeting, transport, logger, onInput };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+  connections.length = 0;
+  connectMock.mockReset().mockImplementation(async (params) => {
+    const connection = { params, session: createSdkSession() };
+    connections.push(connection);
+    // The SDK delivers open and setupComplete before returning its Session.
+    params.callbacks.onopen?.();
+    receive({ setupComplete: {} }, connection);
+    return connection.session;
+  });
+});
+
+afterEach(async () => {
+  try {
+    await meeting?.stop();
+    expect(vi.getTimerCount()).toBe(0);
+  } finally {
+    meeting = undefined;
+    vi.useRealTimers();
+  }
+});
+
+afterAll(() => {
+  vi.doUnmock("./google-genai-runtime.js");
+  vi.resetModules();
+});
+
+describe("Google Live meeting recovery", () => {
+  it.each([
+    { name: "close without a resume handle", reconnect: true, resume: false },
+    { name: "close with a resume handle", reconnect: true, resume: true },
+    { name: "goAway while connected", reconnect: false, resume: false },
+  ])("keeps meeting audio alive after $name", async ({ reconnect, resume }) => {
+    const { handle, transport, logger, onInput } = await startMeeting();
+    if (resume) {
+      receive({ sessionResumptionUpdate: { resumable: true, newHandle: "resume-1" } });
+    }
+    if (reconnect) {
+      remoteClose();
+    } else {
+      receive({ goAway: { timeLeft: "30s" } });
+    }
+    expect(handle.getHealth().bridgeClosed).toBe(false);
+    expect(logger.warn).toHaveBeenCalledOnce();
+    expect(handle.getHealth().recentTalkEvents.map((event) => event.type)).toContain(
+      "session.error",
+    );
+
+    onInput(input);
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(connectMock).toHaveBeenCalledTimes(reconnect ? 2 : 1);
+    expect(currentConnection().params.config?.sessionResumption).toEqual(
+      resume ? { handle: "resume-1" } : {},
+    );
+    expect(handle.getHealth()).toMatchObject({
+      providerConnected: true,
+      realtimeReady: true,
+      bridgeClosed: false,
+    });
+    onInput(input);
+    expect(currentConnection().session.sendRealtimeInput).toHaveBeenCalledTimes(reconnect ? 2 : 3);
+    expect(currentConnection().session.sendRealtimeInput).toHaveBeenLastCalledWith({
+      audio: { data: Buffer.alloc(640, 1).toString("base64"), mimeType: "audio/pcm;rate=16000" },
+    });
+    receiveAudio();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(transport.writeOutput).toHaveBeenCalledExactlyOnceWith(output);
+    expect(transport.stop).not.toHaveBeenCalled();
+    expect(transport.dispose).not.toHaveBeenCalled();
+  });
+
+  it("disposes the meeting only when provider recovery is exhausted", async () => {
+    const { handle, transport, onInput } = await startMeeting();
+    const original = currentConnection();
+    connectMock.mockRejectedValue(new Error("upstream unavailable"));
+    remoteClose();
+    for (const delay of [250, 500]) {
+      await vi.advanceTimersByTimeAsync(delay);
+      expect(handle.getHealth().bridgeClosed).toBe(false);
+      expect(transport.stop).not.toHaveBeenCalled();
+    }
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(connectMock).toHaveBeenCalledTimes(4);
+    expect(handle.getHealth()).toMatchObject({
+      providerConnected: false,
+      realtimeReady: false,
+      bridgeClosed: true,
+    });
+    expect(
+      handle.getHealth().recentTalkEvents.filter((event) => event.type === "session.closed"),
+    ).toHaveLength(1);
+    expect(transport.stop).toHaveBeenCalledOnce();
+    expect(transport.dispose).toHaveBeenCalledOnce();
+    onInput(input);
+    receiveAudio(original);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(original.session.sendRealtimeInput).toHaveBeenCalledOnce();
+    expect(transport.writeOutput).not.toHaveBeenCalled();
+  });
+});

--- a/src/meeting-bot/realtime-engine.ts
+++ b/src/meeting-bot/realtime-engine.ts
@@ -582,6 +582,7 @@ export async function startMeetingRealtimeEngine(params: {
           harness,
         }),
       onError: (error) => {
+        // Provider errors may be recoverable; onClose owns terminal teardown.
         harness.emit({
           type: "session.error",
           payload: { message: formatErrorMessage(error) },
@@ -590,7 +591,6 @@ export async function startMeetingRealtimeEngine(params: {
         params.logger.warn(
           `${params.platform.logScope} ${realtimeLogScope} voice bridge failed: ${formatErrorMessage(error)}`,
         );
-        stopAfterFailure("voice bridge");
       },
       onClose: (reason) => {
         outputGenerationActive = false;


### PR DESCRIPTION
Closes #131437

<details>
<summary>Additional instructions</summary>

Allow edits from maintainers is enabled through this same-repository branch.

</details>

## What Problem This Solves

Fixes an issue where users in native realtime (`bidi`) meetings would lose working audio after a recoverable provider diagnostic. With Google Live, the first temporary connection loss reported a retry notice, but the meeting engine stopped and cancelled that retry before a second connection could occur. Even a `goAway` notice could stop a still-connected engine. The browser participant could remain in-call without working voice.

## Why This Change Was Made

Keep `onError` observable but nonterminal. The provider owns reconnection; the existing `onClose` callback, failed-start catch, explicit local stop, and audio-transport fatal handler retain cleanup ownership. This removes one unconditional stop call and adds an explanatory comment, rather than adding a provider-specific exception, error-string classifier, or competing retry loop.

The Google provider deliberately emits its diagnostic before arming recovery. The shared session wrapper forwards diagnostics unchanged and changes lifecycle phase on `onClose`. Discord logs `onError`; OpenAI and xAI also use it for nonterminal server/transcription errors. Installed Google SDK 2.18.0 callback/setup ordering and optional transcription-final fields were inspected directly. No provider terminal-callback, capture-ownership, configuration, schema, or dependency changes are included.

Provenance: the current line was carried forward by the [shared browser-meeting core extraction](https://github.com/openclaw/openclaw/pull/109755), authored and merged by @steipete. It was not newly introduced there: [Google/Meet realtime improvements](https://github.com/openclaw/openclaw/pull/77708), authored and merged by @scoootscooob, had already added diagnostic-before-retry behavior to a consumer that stopped on errors. The mismatch is also present in inspected stable-tag Meet source, including `v2026.7.1-2`.

## User Impact

Recoverable provider diagnostics no longer stop an established meeting audio bridge. Providers can complete their supported recovery flow, while diagnostics remain visible. Terminal closure, exhausted retries, initial setup failure, local transport failure, and explicit stop still clean up. The default transcription-plus-TTS `agent` mode is a different path and is unchanged.

Release-note context: keep native realtime meeting audio alive during provider recovery rather than cancelling the provider's retry on its first diagnostic.

Production LOC: **+1/-1 (net 0; one executable line removed)**. Tests: **+216/-0**. Docs: **+2/-0**.

## Evidence

**Permanent regression:** all four new composition tests fail before the production edit and pass afterward. They use the real Google provider → shared session/harness → meeting engine, mocking only SDK networking and the physical transport. Cases cover close with/without a resume handle, a live-connection `goAway` diagnostic, and cleanup only after retry exhaustion.

```bash
node scripts/run-vitest.mjs extensions/google/realtime-voice-meeting.test.ts --maxWorkers=1 --no-file-parallelism
```

**Owner/sibling proof:** 133 existing tests pass across the following five files; with the four new tests, the focused total is **137 passed across six files**.

```bash
node scripts/run-vitest.mjs src/meeting-bot/realtime-engine.test.ts src/talk/session-runtime.test.ts src/talk/realtime-session-harness.test.ts extensions/google/realtime-voice-provider.test.ts extensions/google-meet/src/realtime.process.test.ts --maxWorkers=1 --no-file-parallelism
```

Eight additional unchanged preservation controls passed after the fix, covering explicit disposal, pending setup before/after setup completion, late Session disposal, transport failure during setup, fatal malformed output, initial SDK rejection, and recovery/exhaustion through the shared bridge.

**Authenticated live before/after:** real Google SDK 2.18.0, `gemini-3.1-flash-live-preview`, real provider/shared bridge/meeting engine, and actual local command-pair subprocesses. The input is synthetic PCM silence; output is real provider PCM. Public `speak()` requests fixed synthetic phrases. The only fault is terminating the first established test-owned SDK WebSocket; no provider error/close callback or replacement connection is fabricated.

| Case | Unchanged engine | Fixed engine |
| --- | --- | --- |
| Resumption disabled | Initial speech succeeds; actual socket loss stops engine; only 1 SDK connection | 2 real connections; stays open; ready 618 ms after observed close; PCM grows 118,562 → 230,884 bytes |
| Default resumption | Initial speech succeeds; actual socket loss stops engine; only 1 SDK connection | 2 real connections; server-issued handle supplied to replacement; ready 859 ms after observed close; PCM grows 115,202 → 347,524 bytes |

Both baseline cases genuinely fail `Recoverable disconnect stopped the meeting engine`. Both fixed cases pass, with the SDK transcription containing the requested post-recovery phrase and real output-file growth. Explicit stop closes all captured sockets and all owned child processes, with zero test-forced cleanup and no connection/child/audio growth during the bounded three-second post-stop observation. The exact reproducible temporary live probe is included below; it is not shipped in routine test discovery.

**Review and static checks:** fresh isolated Codex autoreview is clean, with no accepted/actionable findings. Core production, all core-test shards, and plugin-test typechecks passed. An initial plugin-lint prerequisite timed out preparing SDK declarations; canonical preparation subsequently succeeded without a timeout change or gate bypass.

The complete final local changed gate **passed (exit 0)** after canonical SDK declaration preparation, including plugin lint, database-first, sidecar, import-cycle, and pairing/auth guards. [Exact-head CI run 33141759636](https://github.com/openclaw/openclaw/actions/runs/33141759636) also completed successfully on `23c25fa75de52728a5c6cb2a1aad0401d8ee0d38`.

```bash
node scripts/check-changed.mjs -- src/meeting-bot/realtime-engine.ts extensions/google/realtime-voice-meeting.test.ts docs/plugins/meeting-plugins.md
```

**Proof limits and non-goals:** this is live-provider plus real-process integration proof, not a Chrome meeting or hardware microphone/speaker recording. The browser relay timed out, so browser meeting screenshot/video proof was unavailable. Google supplied transcription text and generation completion without the optional `Transcription.finished` flag; the probe observes transcript content, completed generation, and real audio independently, without changing the separately owned final-callback path. The default resumed transcript repeated the pre-drop phrase before the requested new phrase; no exactly-once playback or server-memory-continuity claim is made. The first broad live-lane attempt stopped during imports, and an initial fixture revision stalled before fault injection on its incorrect finalized-transcript assumption; neither is counted as a lifecycle reproduction. Final before/after runs used identical probe bytes and unchanged budgets.

A separate tooling follow-up records declaration-timeout cleanup leaving a nested compiler process alive; it is not bundled into this meeting repair. No agent transcript, credentials, resume-handle values, or operator-state data are published.

AI-assisted implementation and validation.

<details>
<summary>Exact temporary authenticated live probe</summary>

Copy the following to `extensions/google/realtime-voice-meeting.live-probe.test.ts` only for the manual run, with `GEMINI_API_KEY` supplied securely. Remove the temporary copy afterward. SHA-256: `65ffd2f3ebdfffbc1c629fe2b2a091cabe37e302dd1f6f22f06a25c96d3709e5`. No production test seam is required.

```bash
env -u LIVE -u OPENCLAW_LIVE_TEST -u OPENCLAW_LIVE_GATEWAY -u OPENCLAW_LIVE_USE_REAL_HOME node scripts/run-vitest.mjs extensions/google/realtime-voice-meeting.live-probe.test.ts --pool=forks --isolate --maxWorkers=1 --no-file-parallelism --reporter=verbose
```

```typescript
/**
 * TEMPORARY live probe. Copy to extensions/google/ only after other Vitest runs finish.
 * Real Google SDK/provider/bridge/harness/meeting engine and local command-pair transport.
 * No gateway, microphone, browser, speaker device, or provider/protocol mock.
 * See the adjacent HANDOFF.md for the isolated runner command and evidence limits.
 */
import { spawn, type ChildProcess } from "node:child_process";
import { mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
import path from "node:path";
import type { Session } from "@google/genai";
import {
  createLocalMeetingRealtimeAudioTransport,
  startMeetingRealtimeEngine,
  type MeetingRealtimeAudioEngineHandle,
  type MeetingRealtimeAudioTransport,
} from "openclaw/plugin-sdk/meeting-runtime";
import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
import { describe, it, vi } from "vitest";
import { buildGoogleRealtimeVoiceProvider } from "./realtime-voice-provider.js";

const CASE_BUDGET_MS = 150_000;
const STAGE_TIMEOUT_MS = 45_000;
const STOP_OBSERVATION_MS = 3_000;
const MAX_PCM_BYTES = 8 * 1024 * 1024;
const BEFORE_MARKER = "Amber river before recovery";
const AFTER_MARKER = "Silver meadow after recovery";

type SocketAdapter = { readyState: number; terminate(): void };
type Connection = {
  index: number;
  resumptionEnabled: boolean;
  resumeHandlePassed: boolean;
  resumeHandlePresent: boolean;
  opened: boolean;
  setupCount: number;
  turnCompletes: number;
  outputTranscript: string;
  transcriptionFinished: number;
  closed: boolean;
  closeCode?: number;
  sdkErrorCount: number;
  rejected: boolean;
  pending: boolean;
  session?: Session;
};
type LiveObservation = {
  connections: Connection[];
  cleaning: boolean;
  afterCallback: (event: string, connection: Connection) => void;
};
const liveTap = vi.hoisted(() => ({ current: undefined as LiveObservation | undefined }));

// Only the SDK factory is wrapped. Every connect and callback still calls the real implementation.
vi.mock("./google-genai-runtime.js", async (importOriginal) => {
  const actual = await importOriginal<typeof import("./google-genai-runtime.js")>();
  return {
    ...actual,
    createGoogleGenAI: (...args: Parameters<typeof actual.createGoogleGenAI>) => {
      const ai = actual.createGoogleGenAI(...args);
      const realConnect = ai.live.connect.bind(ai.live);
      ai.live.connect = async (params) => {
        const observation = liveTap.current;
        if (!observation) {
          throw new Error("Live probe observation is not installed");
        }
        const connection: Connection = {
          index: observation.connections.length,
          resumptionEnabled: params.config?.sessionResumption !== undefined,
          resumeHandlePassed: Boolean(params.config?.sessionResumption?.handle),
          resumeHandlePresent: false,
          opened: false,
          setupCount: 0,
          turnCompletes: 0,
          outputTranscript: "",
          transcriptionFinished: 0,
          closed: false,
          sdkErrorCount: 0,
          rejected: false,
          pending: true,
        };
        observation.connections.push(connection);
        const callbacks = params.callbacks;
        try {
          const session = await realConnect({
            ...params,
            callbacks: {
              ...callbacks,
              onopen: () => {
                connection.opened = true;
                callbacks.onopen?.();
                observation.afterCallback("sdk.open", connection);
              },
              onmessage: (message) => {
                if (message.setupComplete) connection.setupCount += 1;
                if (message.serverContent?.turnComplete) connection.turnCompletes += 1;
                const transcript = message.serverContent?.outputTranscription;
                if (transcript?.text) {
                  connection.outputTranscript = (
                    connection.outputTranscript + transcript.text
                  ).slice(-2048);
                }
                if (transcript?.finished) connection.transcriptionFinished += 1;
                const update = message.sessionResumptionUpdate;
                if (update?.resumable === false) connection.resumeHandlePresent = false;
                else if (update?.resumable && update.newHandle)
                  connection.resumeHandlePresent = true;
                callbacks.onmessage(message);
                // Never retain raw SDK messages, URLs, handles, audio, or client objects in logs.
                if (message.setupComplete || update || message.serverContent?.turnComplete) {
                  observation.afterCallback("sdk.message", connection);
                }
              },
              onerror: (event) => {
                connection.sdkErrorCount += 1;
                callbacks.onerror?.(event);
                observation.afterCallback("sdk.error", connection);
              },
              onclose: (event) => {
                connection.closed = true;
                connection.closeCode = event.code;
                callbacks.onclose?.(event);
                // Snapshot after the real callback, on its original stack, before cleanup microtasks.
                observation.afterCallback("sdk.close", connection);
              },
            },
          });
          connection.session = session;
          if (observation.cleaning) session.close();
          return session;
        } catch (error) {
          connection.rejected = true;
          throw error;
        } finally {
          connection.pending = false;
        }
      };
      return ai;
    },
  };
});

class ProbeFailure extends Error {}
function requireProof(condition: unknown, message: string): asserts condition {
  if (!condition) throw new ProbeFailure(message);
}

// @google/genai 2.18.0 dist/node/index.mjs:14937-14940 stores Session.conn;
// :23901-23913 stores the real Node ws at conn.ws. This adapter never reads URL/headers.
function ownedSocket(session: Session): SocketAdapter {
  const adapter = session as unknown as { conn?: { ws?: SocketAdapter } };
  const ws = adapter.conn?.ws;
  requireProof(
    ws && typeof ws.terminate === "function" && typeof ws.readyState === "number",
    "Installed Google SDK no longer exposes the inspected test-owned Session socket",
  );
  return ws;
}

async function until(label: string, predicate: () => boolean, timeoutMs: number): Promise<void> {
  const deadline = Date.now() + timeoutMs;
  await new Promise<void>((resolve, reject) => {
    const check = () => {
      try {
        if (predicate()) {
          resolve();
          return;
        }
        if (Date.now() >= deadline) throw new ProbeFailure(`Timed out waiting for ${label}`);
        setTimeout(check, 25);
      } catch (error) {
        reject(error);
      }
    };
    // Every polling timer settles before this helper returns; there are no detached wait loops.
    check();
  });
}

async function bounded<T>(promise: Promise<T>, label: string, timeoutMs: number): Promise<T> {
  let timer: ReturnType<typeof setTimeout> | undefined;
  try {
    return await Promise.race([
      promise,
      new Promise<never>((_, reject) => {
        timer = setTimeout(
          () => reject(new ProbeFailure(`Timed out waiting for ${label}`)),
          timeoutMs,
        );
      }),
    ]);
  } finally {
    if (timer) clearTimeout(timer);
  }
}

const CHILD_LIFETIME = `
const parentPid = process.ppid;
const startedAt = Date.now();
const watchdog = setInterval(() => {
  if (process.ppid !== parentPid || Date.now() - startedAt > 180000) process.exit(82);
}, 1000);
process.on('SIGTERM', () => process.exit(0));
process.on('SIGINT', () => process.exit(0));
`;
const SILENCE_CHILD = `
${CHILD_LIFETIME}
const frame = Buffer.alloc(960); // 20ms mono PCM16 LE at 24kHz; never a device input.
let writable = true;
process.stdout.on('drain', () => { writable = true; });
process.stdout.on('error', () => process.exit(83));
const clock = setInterval(() => {
  if (writable) writable = process.stdout.write(frame);
}, 20);
process.on('exit', () => { clearInterval(clock); clearInterval(watchdog); });
`;
const OUTPUT_CHILD = `
const fs = require('node:fs');
${CHILD_LIFETIME}
const fd = fs.openSync(process.argv[1], 'a');
let bytes = 0;
process.stdin.on('data', (chunk) => {
  if (bytes + chunk.length > ${MAX_PCM_BYTES}) process.exit(84);
  fs.writeSync(fd, chunk);
  bytes += chunk.length;
});
process.stdin.on('end', () => process.exit(0));
process.stdin.on('error', () => process.exit(85));
process.on('exit', () => { clearInterval(watchdog); fs.closeSync(fd); });
`;

type ChildRecord = {
  role: "input" | "output";
  proc: ChildProcess;
  pcmFile?: string;
  error: boolean;
};
function exited(child: ChildRecord): boolean {
  return (
    child.proc.exitCode !== null ||
    child.proc.signalCode !== null ||
    (!child.proc.pid && child.error)
  );
}
function pidGone(pid: number | undefined): boolean {
  if (!pid) return true;
  try {
    process.kill(pid, 0);
    return false;
  } catch (error) {
    return (error as NodeJS.ErrnoException).code === "ESRCH";
  }
}
function normalizeWords(text: string): string {
  return text
    .toLowerCase()
    .replace(/[^a-z0-9]+/g, " ")
    .trim();
}
function wavFromPcm(pcm: Buffer): Buffer {
  const header = Buffer.alloc(44);
  header.write("RIFF", 0);
  header.writeUInt32LE(36 + pcm.length, 4);
  header.write("WAVEfmt ", 8);
  header.writeUInt32LE(16, 16);
  header.writeUInt16LE(1, 20);
  header.writeUInt16LE(1, 22);
  header.writeUInt32LE(24_000, 24);
  header.writeUInt32LE(48_000, 28);
  header.writeUInt16LE(2, 32);
  header.writeUInt16LE(16, 34);
  header.write("data", 36);
  header.writeUInt32LE(pcm.length, 40);
  return Buffer.concat([header, pcm]);
}

async function runLiveCase(resumption: "disabled" | "default"): Promise<void> {
  const artifactRoot = path.resolve(".artifacts/realtime-lifecycle-live");
  mkdirSync(artifactRoot, { recursive: true });
  const caseDir = mkdtempSync(path.join(artifactRoot, `${resumption}-`));
  const startAt = Date.now();
  const deadline = startAt + CASE_BUDGET_MS;
  const children: ChildRecord[] = [];
  const trace: Array<Record<string, unknown>> = [];
  const checkpoints: Record<string, unknown> = {};
  const logCounts = { debug: 0, info: 0, warn: 0, error: 0, console: 0 };
  let engine: MeetingRealtimeAudioEngineHandle | undefined;
  let startup: Promise<MeetingRealtimeAudioEngineHandle> | undefined;
  let transport: MeetingRealtimeAudioTransport | undefined;
  let failure: string | undefined;
  let stopObserved = false;
  let stoppedDuringDisconnectCallback = false;
  let dropInjected = false;
  let outputCount = 0;
  let forcedChildCleanup = 0;
  let forcedSocketCleanup = 0;
  let workerExitRequired = false;
  let apiKey = "";
  const record = (event: string, facts: Record<string, unknown> = {}) => {
    if (trace.length < 500) trace.push({ elapsedMs: Date.now() - startAt, event, ...facts });
  };
  const observation: LiveObservation = {
    connections: [],
    cleaning: false,
    afterCallback: (event, connection) => {
      const health = engine?.getHealth();
      if (
        dropInjected &&
        !observation.cleaning &&
        (event === "sdk.close" || event === "sdk.error")
      ) {
        stoppedDuringDisconnectCallback ||= health?.bridgeClosed === true;
      }
      record(event, {
        connection: connection.index,
        setupCount: connection.setupCount,
        resumeHandlePresent: connection.resumeHandlePresent,
        bridgeClosed: health?.bridgeClosed,
        providerConnected: health?.providerConnected,
        realtimeReady: health?.realtimeReady,
        diagnosticRecorded: health?.recentTalkEvents.some((item) => item.type === "session.error"),
        continuityResetRecorded: health?.recentRealtimeEvents?.some(
          (item) => item.type === "session.continuity.reset",
        ),
      });
    },
  };
  liveTap.current = observation;
  // SDK diagnostics can contain transport URLs or objects. Count, but never serialize them.
  const consoleSpies = ["debug", "info", "log", "warn", "error"] as const;
  const restoreConsole = consoleSpies.map((method) =>
    vi.spyOn(console, method).mockImplementation(() => {
      logCounts.console += 1;
    }),
  );
  const logger = {
    debug: () => {
      logCounts.debug += 1;
    },
    info: () => {
      logCounts.info += 1;
    },
    warn: () => {
      logCounts.warn += 1;
    },
    error: () => {
      logCounts.error += 1;
    },
  };
  const outputBytes = () =>
    children.reduce((sum, child) => sum + (child.pcmFile ? statSync(child.pcmFile).size : 0), 0);
  const hasFinalMarker = (marker: string) =>
    engine
      ?.getHealth()
      .recentRealtimeTranscript.some(
        (entry) =>
          entry.role === "assistant" && normalizeWords(entry.text).includes(normalizeWords(marker)),
      ) === true;
  const snapshot = () => {
    const health = engine?.getHealth();
    return {
      elapsedMs: Date.now() - startAt,
      bridgeClosed: health?.bridgeClosed,
      providerConnected: health?.providerConnected,
      realtimeReady: health?.realtimeReady,
      inputBytes: health?.lastInputBytes,
      outputBytes: outputBytes(),
      finalBeforeMarker: hasFinalMarker(BEFORE_MARKER),
      finalAfterMarker: hasFinalMarker(AFTER_MARKER),
      connectionCount: observation.connections.length,
    };
  };
  const remaining = () => {
    requireProof(Date.now() < deadline, "Live case exceeded its total 150-second budget");
    return Math.min(STAGE_TIMEOUT_MS, deadline - Date.now());
  };
  const requireRunning = () => {
    requireProof(
      engine && !engine.getHealth().bridgeClosed,
      "Recoverable disconnect stopped the meeting engine",
    );
    requireProof(
      !stoppedDuringDisconnectCallback,
      "Meeting stopped synchronously on a disconnect diagnostic",
    );
    requireProof(
      children.filter((child) => child.role === "input").every((child) => !exited(child)),
      "Synthetic input process exited before explicit stop",
    );
    const output = children.filter((child) => child.role === "output").at(-1);
    requireProof(output && !exited(output), "Current output process exited before explicit stop");
  };
  const waitRunning = (label: string, predicate: () => boolean) =>
    until(
      label,
      () => {
        requireRunning();
        return predicate();
      },
      remaining(),
    );
  const speakAndVerify = async (marker: string, connection: Connection) => {
    const before = outputBytes();
    const turns = connection.turnCompletes;
    engine!.speak(`Say exactly: ${marker}.`);
    // Transcription.finished is optional and independent of generation completion.
    // Observe all speech facts without asserting the separately owned final-callback contract.
    await waitRunning(
      "SDK spoken marker, completed generation, and real output-file growth",
      () =>
        outputBytes() > before + 960 &&
        connection.turnCompletes > turns &&
        normalizeWords(connection.outputTranscript).includes(normalizeWords(marker)),
    );
    const acceptedBytes = engine!.getHealth().lastOutputBytes;
    await waitRunning(
      "accepted output to drain through the real child",
      () => outputBytes() >= acceptedBytes,
    );
  };
  try {
    apiKey = process.env.GEMINI_API_KEY?.trim() ?? "";
    requireProof(apiKey, "GEMINI_API_KEY is missing: no live proof was run");
    requireProof(
      !["LIVE", "OPENCLAW_LIVE_TEST", "OPENCLAW_LIVE_GATEWAY"].some(
        (key) => process.env[key] === "1",
      ) && !process.env.OPENCLAW_LIVE_USE_REAL_HOME,
      "Use the documented env-unset runner command; live setup must not stage operator auth",
    );
    requireProof(
      Boolean(process.env.OPENCLAW_TEST_HOME) &&
        process.env.HOME === process.env.OPENCLAW_TEST_HOME &&
        !process.env.OPENCLAW_HOME &&
        !process.env.OPENCLAW_CONFIG_PATH,
      "The shared Vitest isolated HOME must be active before Google connects",
    );
    record("isolated-home-verified");
    transport = createLocalMeetingRealtimeAudioTransport({
      inputCommand: [process.execPath, "-e", SILENCE_CHILD],
      outputCommand: [process.execPath, "-e", OUTPUT_CHILD],
      audioFormat: "pcm16-24khz",
      bargeInRmsThreshold: 1_000,
      bargeInPeakThreshold: 3_000,
      bargeInCooldownMs: 500,
      logger,
      logScope: "[temporary-live-proof]",
      spawn: (command, args, options) => {
        const role = options.stdio[0] === "ignore" ? "input" : "output";
        const pcmFile =
          role === "output" ? path.join(caseDir, `output-${outputCount++}.pcm`) : undefined;
        if (pcmFile) writeFileSync(pcmFile, Buffer.alloc(0), { flag: "wx" });
        // Actual Node children; an empty environment keeps the API key out of audio subprocesses.
        const proc = spawn(command, pcmFile ? [...args, pcmFile] : args, { ...options, env: {} });
        const child: ChildRecord = { role, proc, pcmFile, error: false };
        children.push(child);
        proc.on("error", () => {
          child.error = true;
          record("child.error", { role });
        });
        proc.on("exit", (code, signal) =>
          record("child.exit", { role, pid: proc.pid, code, signal }),
        );
        record("child.spawn", { role, pid: proc.pid });
        return proc;
      },
    });
    startup = startMeetingRealtimeEngine({
      config: {
        chrome: { audioFormat: "pcm16-24khz" },
        realtime: {
          strategy: "bidi",
          provider: "google",
          providers: {
            google: { apiKey, ...(resumption === "disabled" ? { sessionResumption: false } : {}) },
          },
          instructions:
            "This is a synthetic audio integration test. Stay silent unless explicitly asked to speak. When asked to say exactly a phrase, say only that phrase once. Do not use tools.",
        },
      },
      fullConfig: {},
      // This bidi engine does not read runtime services; no host service or gateway is invoked.
      runtime: createPluginRuntimeMock(),
      providers: [buildGoogleRealtimeVoiceProvider()],
      platform: {
        displayName: "Synthetic live proof",
        logScope: "[temporary-live-proof]",
        sessionIdPrefix: "live-proof",
      },
      meetingSessionId: `synthetic-${resumption}`,
      transport,
      logger,
      tools: [],
      consultAgent: async () => {
        throw new ProbeFailure("Unexpected agent consult in bidi proof");
      },
      handleToolCall: async () => {
        throw new ProbeFailure("Unexpected tool call in tool-free proof");
      },
    });
    // A setup that completes during cleanup must not leave an adopted engine alive.
    void startup.then(
      (handle) => {
        if (observation.cleaning) void handle.stop().catch(() => {});
      },
      () => {},
    );
    engine = await bounded(startup, "initial Google setup", remaining());
    await waitRunning("initial ready, real SDK Session, and captured synthetic input", () => {
      const health = engine!.getHealth();
      return (
        health.providerConnected &&
        health.realtimeReady &&
        health.lastInputBytes > 0 &&
        observation.connections[0]?.session !== undefined
      );
    });
    const first = observation.connections[0]!;
    requireProof(
      observation.connections.length === 1 && first.setupCount === 1,
      "Initial setup was not a single real connection",
    );
    requireProof(
      first.resumptionEnabled === (resumption === "default") && !first.resumeHandlePassed,
      "Initial SDK config did not match the requested resumption case",
    );
    await speakAndVerify(BEFORE_MARKER, first);
    if (resumption === "default") {
      await waitRunning("an actual resumable Google handle", () => first.resumeHandlePresent);
    }
    checkpoints.beforeDrop = snapshot();
    const bytesBeforeDrop = outputBytes();
    const warningsBeforeDrop = logCounts.warn;
    const ws = ownedSocket(first.session!);
    requireProof(
      ws.readyState === 1,
      "Fault injection requires the established test-owned open socket",
    );
    dropInjected = true;
    record("socket.terminate", { connection: 0, handlePresent: first.resumeHandlePresent });
    ws.terminate(); // The sole network fault: actual socket loss; never invoke provider callbacks.
    await until("the real SDK close callback", () => first.closed, remaining());
    checkpoints.afterCloseCallback = snapshot();
    requireRunning();
    requireProof(
      logCounts.warn > warningsBeforeDrop,
      "Disconnect did not produce a visible meeting diagnostic",
    );
    requireProof(
      trace.some(
        (item) =>
          item.event === "sdk.close" && item.connection === 0 && item.diagnosticRecorded === true,
      ),
      "Disconnect diagnostic was not recorded by the real meeting harness",
    );
    if (resumption === "disabled") {
      requireProof(
        trace.some(
          (item) =>
            item.event === "sdk.close" &&
            item.connection === 0 &&
            item.continuityResetRecorded === true,
        ),
        "Non-resumable socket loss did not record provider continuity reset",
      );
    }
    const connectedReplacement = () =>
      observation.connections.find(
        (connection) =>
          connection.index > 0 &&
          connection.session &&
          connection.setupCount === 1 &&
          !connection.closed,
      );
    await waitRunning("replacement SDK setup and connected meeting", () => {
      const replacement = connectedReplacement();
      const health = engine!.getHealth();
      return Boolean(replacement && health.providerConnected && health.realtimeReady);
    });
    const replacement = connectedReplacement()!;
    requireProof(
      replacement.resumptionEnabled === (resumption === "default") &&
        replacement.resumeHandlePassed === (resumption === "default"),
      "Replacement SDK resumption-handle presence did not match the case",
    );
    checkpoints.afterReconnect = snapshot();
    await speakAndVerify(AFTER_MARKER, replacement);
    requireProof(
      outputBytes() > bytesBeforeDrop + 960,
      "Recovered speech did not reach the real output process",
    );
    checkpoints.afterSpeech = snapshot();

    observation.cleaning = true;
    await bounded(engine.stop(), "explicit meeting stop", 8_000);
    await until(
      "children exited and all captured SDK sockets closed",
      () =>
        children.every((child) => exited(child) && pidGone(child.proc.pid)) &&
        observation.connections.every(
          (connection) =>
            !connection.pending &&
            connection.session &&
            ownedSocket(connection.session).readyState === 3,
        ),
      5_000,
    );
    const stoppedConnections = observation.connections.length;
    const stoppedOutput = outputBytes();
    const stoppedChildren = children.length;
    const quietUntil = Date.now() + STOP_OBSERVATION_MS;
    // This bounded negative assertion spans the provider's entire 250/500/1000ms retry schedule.
    await until(
      "post-stop observation window",
      () => {
        requireProof(
          observation.connections.length === stoppedConnections,
          "Provider reconnected after explicit stop",
        );
        requireProof(
          children.length === stoppedChildren &&
            children.every((child) => exited(child) && pidGone(child.proc.pid)),
          "A command-pair child survived or restarted after stop",
        );
        requireProof(outputBytes() === stoppedOutput, "Audio output grew after explicit stop");
        requireProof(
          engine!.getHealth().bridgeClosed && !engine!.getHealth().providerConnected,
          "Meeting remained connected after stop",
        );
        return Date.now() >= quietUntil;
      },
      STOP_OBSERVATION_MS + 1_000,
    );
    stopObserved = true;
    checkpoints.afterStop = snapshot();
  } catch (error) {
    checkpoints.failure = snapshot();
    // Only fixture-authored messages are retained. SDK/provider errors may contain opaque handles.
    failure =
      error instanceof ProbeFailure
        ? error.message
        : "Unexpected production/SDK error; raw details withheld for credential safety";
  } finally {
    observation.cleaning = true;
    try {
      if (engine) await bounded(engine.stop(), "finally meeting stop", 8_000);
      if (transport) await bounded(transport.dispose(), "finally transport disposal", 5_000);
    } catch {
      failure ??= "Production cleanup did not complete within its bound";
    }
    try {
      await until(
        "graceful socket closure after cleanup",
        () =>
          observation.connections.every(
            (connection) =>
              !connection.pending &&
              (!connection.session || ownedSocket(connection.session).readyState === 3),
          ),
        5_000,
      );
    } catch {
      // The force-cleanup counters below keep an incomplete shutdown visible.
    }
    for (const connection of observation.connections) {
      if (!connection.session) continue;
      try {
        const ws = ownedSocket(connection.session);
        if (ws.readyState !== 3) {
          forcedSocketCleanup += 1;
          ws.terminate();
        }
      } catch {
        failure ??= "Could not close an owned SDK Session";
        workerExitRequired = true;
      }
    }
    for (const child of children) {
      if (!exited(child)) {
        forcedChildCleanup += 1;
        try {
          child.proc.kill("SIGKILL");
        } catch {
          failure ??= "Could not terminate a task-owned child";
          workerExitRequired = true;
        }
      }
    }
    try {
      await until(
        "final child/socket cleanup",
        () =>
          children.every((child) => exited(child) && pidGone(child.proc.pid)) &&
          observation.connections.every(
            (connection) =>
              !connection.pending &&
              (!connection.session || ownedSocket(connection.session).readyState === 3),
          ),
        5_000,
      );
    } catch {
      failure ??= "Owned resources remained pending after cleanup";
      workerExitRequired = true;
    }
    if (observation.connections.some((connection) => !connection.session && !connection.closed)) {
      // A rejected setup can also strand a socket which the SDK never returned to its caller.
      failure ??= "SDK did not return a Session or confirm closure";
      workerExitRequired = true;
    }
    if (forcedChildCleanup || forcedSocketCleanup)
      failure ??= "Explicit stop required test-forced resource cleanup";
    if (!stopObserved) failure ??= "Live proof did not reach verified explicit stop";
    try {
      for (const child of children) {
        if (!child.pcmFile) continue;
        const pcm = readFileSync(child.pcmFile);
        requireProof(pcm.length <= MAX_PCM_BYTES, "Output artifact exceeded its byte bound");
        writeFileSync(child.pcmFile.replace(/\.pcm$/, ".wav"), wavFromPcm(pcm));
      }
    } catch {
      failure ??= "Could not finalize bounded WAV artifacts; original PCM files retained";
    }
    const redactExactKey = (text: string) =>
      apiKey ? text.split(apiKey).join("[REDACTED]") : text;
    const report = {
      status: failure ? "failed" : "passed",
      scope: "live-google-provider-and-real-local-command-pair; no browser or hardware proof",
      resumption,
      workerPid: process.pid,
      elapsedMs: Date.now() - startAt,
      failure,
      markers: { before: BEFORE_MARKER, after: AFTER_MARKER },
      checkpoints,
      connections: observation.connections.map(({ session, ...connection }) => ({
        ...connection,
        returnedSession: Boolean(session),
        socketClosed: (() => {
          try {
            return session ? ownedSocket(session).readyState === 3 : null;
          } catch {
            return null;
          }
        })(),
      })),
      children: children.map((child) => ({
        role: child.role,
        pid: child.proc.pid,
        exitCode: child.proc.exitCode,
        signalCode: child.proc.signalCode,
        pidGone: pidGone(child.proc.pid),
        spawnError: child.error,
        outputFile: child.pcmFile && path.basename(child.pcmFile),
        outputBytes: child.pcmFile ? statSync(child.pcmFile).size : undefined,
      })),
      cleanup: {
        stopObserved,
        forcedChildCleanup,
        forcedSocketCleanup,
        workerExitRequired,
        postStopObservationMs: STOP_OBSERVATION_MS,
      },
      logCounts,
      trace,
    };
    try {
      writeFileSync(
        path.join(caseDir, "report.json"),
        redactExactKey(`${JSON.stringify(report, null, 2)}\n`),
      );
    } finally {
      liveTap.current = undefined;
      for (const spy of restoreConsole) spy.mockRestore();
      if (workerExitRequired) {
        // SDK 2.18.0 has no cancellation while Live.connect awaits setup and hides its Session.
        // Failing this dedicated fork closes those process-owned sockets; never continue or claim pass.
        process.stderr.write(
          "Live probe failed: pending SDK/resource cleanup; see local report.json.\n",
        );
        process.exit(1);
      }
    }
  }
  requireProof(!failure, failure ?? "Live proof failed");
}

describe.sequential("Google Live meeting recovery through real command-pair transport", () => {
  it.each(["disabled", "default"] as const)(
    "survives actual socket loss: resumption %s",
    async (resumption) => {
      await runLiveCase(resumption);
    },
    190_000,
  );
});
```

</details>
