### PR TITLE
fix(cron): preserve newer runtime state on CRUD

### DIFF
--- a/src/cron/service/ops-mutations.ts
+++ b/src/cron/service/ops-mutations.ts
@@ -235,6 +235,7 @@ async function persistUpdatedJob(params: {
       ? cronRunReceiptOwnerMutationHooks({ state, jobId: nextJob.id })
       : undefined,
   });
+  const committedJob = findJobOrThrow(state, nextJob.id);
   if (!cronSchedulingInputsEqual(previousJob, nextJob)) {
     // Mark only committed edits; a failed SQLite write cannot retire the run's
     // schedule ownership, and idempotent re-saves must not create a new claim.
@@ -255,11 +256,12 @@ async function persistUpdatedJob(params: {
   }
   armTimer(state);
   emit(state, {
-    jobId: nextJob.id,
+    jobId: committedJob.id,
     action: "updated",
-    job: nextJob,
-    nextRunAtMs: nextJob.state.nextRunAtMs,
+    job: committedJob,
+    nextRunAtMs: committedJob.state.nextRunAtMs,
   });
+  return committedJob;
 }
 
 function declarativeFields(job: CronStoredJob, includeEnabled: boolean) {
@@ -384,8 +386,13 @@ export async function add(
         scheduleChanged: !isDeepStrictEqual(existing.schedule, nextJob.schedule),
         explicitTriggerState: normalizedInput.state,
       });
-      await persistUpdatedJob({ state, snapshot, previousJob: existing, nextJob });
-      return { ...nextJob, created: false, updated: true, job: nextJob };
+      const committedJob = await persistUpdatedJob({
+        state,
+        snapshot,
+        previousJob: existing,
+        nextJob,
+      });
+      return { ...committedJob, created: false, updated: true, job: committedJob };
     }
 
     if (normalizedId && state.store?.jobs.some((job) => job.id === normalizedId)) {
@@ -532,8 +539,7 @@ async function updateLoadedJob(params: {
       patch.payload !== undefined && Object.hasOwn(patch.payload, "toolsAllow"),
   });
   const snapshot = snapshotStoreForRollback(state);
-  await persistUpdatedJob({ state, snapshot, previousJob: job, nextJob });
-  return nextJob;
+  return await persistUpdatedJob({ state, snapshot, previousJob: job, nextJob });
 }
 
 /** Updates a cron job patch in-place, recomputes affected schedule state, and persists it. */

--- a/src/cron/service/ops-mutations.ts
+++ b/src/cron/service/ops-mutations.ts
@@ -69,6 +69,8 @@ import {
 import { armTimer } from "./timer.js";
 
 const RETRY_ADD_AFTER_SESSION_CLEANUP = new Error("retry add after session cleanup");
+const ensureLoadedForMutation = (state: CronServiceState) =>
+  ensureLoaded(state, { skipRecompute: true, forceReload: !state.deps.cronEnabled });
 
 async function resolveConfiguredChannelsForValidation(
   state: CronServiceState,
@@ -312,7 +314,7 @@ export async function add(
         `cron declarationKey namespace "${systemOwnedDeclarationNamespace}" is system-owned; jobs cannot be created with it`,
       );
     }
-    await ensureLoaded(state, { skipRecompute: true });
+    await ensureLoadedForMutation(state);
     const agentId = resolveEffectiveJobAgentId(input, resolveCurrentDefaultAgentId(state));
     if (state.deps.isAgentAvailable?.(agentId) === false) {
       throw new Error(`cron job agent is unavailable: ${agentId}`);
@@ -462,7 +464,7 @@ export async function removeStaleJobFamily(
   family: { declarationKey: string; name: string; ownerPluginTag: string },
 ): Promise<number> {
   return await locked(state, async () => {
-    await ensureLoaded(state, { skipRecompute: true });
+    await ensureLoadedForMutation(state);
     return removeStaleCronJobFamilyRows(state.deps.storePath, family);
   });
 }
@@ -481,7 +483,7 @@ async function updateLoadedJob(params: {
   if (patch.payload && isSystemOwnedCronPayloadKind(patch.payload.kind)) {
     throw new Error("system-owned payloads cannot be patched by cron clients");
   }
-  await ensureLoaded(state, { skipRecompute: true });
+  await ensureLoadedForMutation(state);
   const job = findJobOrThrow(state, id);
   // Existing monitors are config-driven: any patch (disable, reschedule,
   // repurpose) would silently diverge from its owner until the next reconcile,
@@ -577,7 +579,7 @@ export async function remove(
   const result = await locked(state, async () => {
     warnIfDisabled(state, "remove");
     const previousStore = state.store;
-    await ensureLoaded(state, { skipRecompute: true });
+    await ensureLoadedForMutation(state);
     if (!state.store) {
       return { ok: false, removed: false } as const;
     }
@@ -641,7 +643,7 @@ export async function remove(
   const cleanup = async () => {
     try {
       const shouldRemove = await locked(state, async () => {
-        await ensureLoaded(state, { skipRecompute: true });
+        await ensureLoadedForMutation(state);
         return !state.store?.jobs.some((job) => job.id === id);
       });
       if (shouldRemove) {
@@ -674,7 +676,7 @@ export async function removeAgentJobsTransactional<T>(
 ): Promise<T> {
   return await locked(state, async () => {
     warnIfDisabled(state, "remove agent jobs");
-    await ensureLoaded(state, { skipRecompute: true });
+    await ensureLoadedForMutation(state);
     const id = normalizeOptionalAgentId(agentId);
     if (!id || !state.store) {
       return await commit();

--- a/src/cron/service/store.test.ts
+++ b/src/cron/service/store.test.ts
@@ -6,9 +6,11 @@ import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
 } from "../../state/openclaw-state-db.js";
+import { CronService } from "../service.js";
 import { setupCronServiceSuite } from "../service.test-harness.js";
 import * as cronStoreModule from "../store.js";
 import { loadCronStore, saveCronStore } from "../store.js";
+import { cronStoreKey } from "../store/key.js";
 import {
   claimCronRunReceiptInDatabase,
   CronRunReceiptConflictError,
@@ -75,6 +77,68 @@ describe("cron service store seam coverage", () => {
     vi.restoreAllMocks();
   });
 
+  it("reloads scheduler-disabled mutations and preserves newer runtime rows", async () => {
+    const { storePath } = await makeStorePath();
+    const jobA = createReloadCronJob({
+      id: "runtime-owner",
+      name: "runtime owner",
+      state: { nextRunAtMs: STORE_TEST_NOW + 60_000 },
+    });
+    const jobB = createReloadCronJob({ id: "manager-edit", name: "manager edit" });
+    await saveCronStore(storePath, { version: 1, jobs: [jobA, jobB] });
+
+    const manager = new CronService({
+      storePath,
+      cronEnabled: false,
+      log: logger,
+      nowMs: () => STORE_TEST_NOW + 10_000,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+    await manager.list({ includeDisabled: true });
+
+    const externalNextRunAtMs = STORE_TEST_NOW + 900_000;
+    const externalUpdatedAtMs = STORE_TEST_NOW + 8_000;
+    const database = openOpenClawStateDatabase().db;
+    const storeKey = cronStoreKey(storePath);
+    database
+      .prepare(
+        "UPDATE cron_jobs SET job_json = json_set(job_json, '$.description', ?), updated_at = ? WHERE store_key = ? AND job_id = ?",
+      )
+      .run("external description", externalUpdatedAtMs, storeKey, jobB.id);
+
+    await manager.updateWithPrecondition(jobB.id, { name: "manager renamed" }, () => {
+      // Runs after the disabled-service force reload but before its full save,
+      // matching a scheduler process that advances runtime concurrently.
+      database
+        .prepare(
+          "UPDATE cron_jobs SET state_json = ?, runtime_updated_at_ms = ? WHERE store_key = ? AND job_id = ?",
+        )
+        .run(
+          JSON.stringify({
+            nextRunAtMs: externalNextRunAtMs,
+            lastRunAtMs: STORE_TEST_NOW + 7_000,
+          }),
+          externalUpdatedAtMs,
+          storeKey,
+          jobA.id,
+        );
+    });
+
+    const persisted = await loadCronStore(storePath);
+    const persistedA = persisted.jobs.find((job) => job.id === jobA.id);
+    const persistedB = persisted.jobs.find((job) => job.id === jobB.id);
+    expect(persistedA?.state).toMatchObject({
+      nextRunAtMs: externalNextRunAtMs,
+      lastRunAtMs: STORE_TEST_NOW + 7_000,
+    });
+    expect(persistedA?.updatedAtMs).toBe(externalUpdatedAtMs);
+    expect(persistedB).toMatchObject({
+      name: "manager renamed",
+      description: "external description",
+    });
+  });
   it("does not drain post-persist notifications when there is no store to write", async () => {
     const { storePath } = await makeStorePath();
     const state = createStoreTestState(storePath);

--- a/src/cron/service/store.test.ts
+++ b/src/cron/service/store.test.ts
@@ -163,7 +163,7 @@ describe("cron service store seam coverage", () => {
     const externalUpdatedAtMs = STORE_TEST_NOW + 12_000;
     const database = openOpenClawStateDatabase().db;
     const storeKey = cronStoreKey(storePath);
-    await manager.updateWithPrecondition(job.id, { name: "after rename" }, () => {
+    const updated = await manager.updateWithPrecondition(job.id, { name: "after rename" }, () => {
       database
         .prepare(
           "UPDATE cron_jobs SET state_json = ?, runtime_updated_at_ms = ? WHERE store_key = ? AND job_id = ?",
@@ -179,6 +179,15 @@ describe("cron service store seam coverage", () => {
         );
     });
 
+    expect(updated).toMatchObject({
+      name: "after rename",
+      updatedAtMs: externalUpdatedAtMs,
+      state: {
+        nextRunAtMs: externalNextRunAtMs,
+        lastRunAtMs: STORE_TEST_NOW + 7_000,
+      },
+    });
+
     const persisted = (await loadCronStore(storePath)).jobs.find((entry) => entry.id === job.id);
     expect(persisted).toMatchObject({
       name: "after rename",
@@ -192,6 +201,62 @@ describe("cron service store seam coverage", () => {
       .prepare("SELECT runtime_updated_at_ms FROM cron_jobs WHERE store_key = ? AND job_id = ?")
       .get(storeKey, job.id) as { runtime_updated_at_ms?: unknown } | undefined;
     expect(persistedRuntime?.runtime_updated_at_ms).toBe(externalUpdatedAtMs);
+  });
+
+  it("does not restore trigger-owned state after a trigger definition changes", async () => {
+    const { storePath } = await makeStorePath();
+    const job = createReloadCronJob({
+      id: "trigger-owner-edit",
+      trigger: { script: "return true" },
+      state: {
+        nextRunAtMs: STORE_TEST_NOW + 60_000,
+        triggerState: { owner: "old-trigger" },
+        triggerEvalCount: 3,
+      },
+    });
+    await saveCronStore(storePath, { version: 1, jobs: [job] });
+
+    const manager = new CronService({
+      storePath,
+      cronEnabled: false,
+      log: logger,
+      nowMs: () => STORE_TEST_NOW + 10_000,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+    await manager.list({ includeDisabled: true });
+
+    const database = openOpenClawStateDatabase().db;
+    const storeKey = cronStoreKey(storePath);
+    const updated = await manager.updateWithPrecondition(
+      job.id,
+      { trigger: { script: "return false" } },
+      () => {
+        database
+          .prepare(
+            "UPDATE cron_jobs SET state_json = ?, runtime_updated_at_ms = ? WHERE store_key = ? AND job_id = ?",
+          )
+          .run(
+            JSON.stringify({
+              nextRunAtMs: STORE_TEST_NOW + 900_000,
+              triggerState: { owner: "old-trigger" },
+              triggerEvalCount: 9,
+            }),
+            STORE_TEST_NOW + 12_000,
+            storeKey,
+            job.id,
+          );
+      },
+    );
+
+    expect(updated.trigger).toEqual({ script: "return false" });
+    expect(updated.state.triggerState).toBeUndefined();
+    expect(updated.state.triggerEvalCount).toBeUndefined();
+    const persisted = (await loadCronStore(storePath)).jobs.find((entry) => entry.id === job.id);
+    expect(persisted?.trigger).toEqual({ script: "return false" });
+    expect(persisted?.state.triggerState).toBeUndefined();
+    expect(persisted?.state.triggerEvalCount).toBeUndefined();
   });
 
   it("does not drain post-persist notifications when there is no store to write", async () => {

--- a/src/cron/service/store.test.ts
+++ b/src/cron/service/store.test.ts
@@ -139,6 +139,61 @@ describe("cron service store seam coverage", () => {
       description: "external description",
     });
   });
+  it("preserves newer runtime state for schedule-identical target updates", async () => {
+    const { storePath } = await makeStorePath();
+    const job = createReloadCronJob({
+      id: "same-job-edit",
+      name: "before rename",
+      state: { nextRunAtMs: STORE_TEST_NOW + 60_000 },
+    });
+    await saveCronStore(storePath, { version: 1, jobs: [job] });
+
+    const manager = new CronService({
+      storePath,
+      cronEnabled: false,
+      log: logger,
+      nowMs: () => STORE_TEST_NOW + 10_000,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+    await manager.list({ includeDisabled: true });
+
+    const externalNextRunAtMs = STORE_TEST_NOW + 900_000;
+    const externalUpdatedAtMs = STORE_TEST_NOW + 12_000;
+    const database = openOpenClawStateDatabase().db;
+    const storeKey = cronStoreKey(storePath);
+    await manager.updateWithPrecondition(job.id, { name: "after rename" }, () => {
+      database
+        .prepare(
+          "UPDATE cron_jobs SET state_json = ?, runtime_updated_at_ms = ? WHERE store_key = ? AND job_id = ?",
+        )
+        .run(
+          JSON.stringify({
+            nextRunAtMs: externalNextRunAtMs,
+            lastRunAtMs: STORE_TEST_NOW + 7_000,
+          }),
+          externalUpdatedAtMs,
+          storeKey,
+          job.id,
+        );
+    });
+
+    const persisted = (await loadCronStore(storePath)).jobs.find((entry) => entry.id === job.id);
+    expect(persisted).toMatchObject({
+      name: "after rename",
+      updatedAtMs: externalUpdatedAtMs,
+      state: {
+        nextRunAtMs: externalNextRunAtMs,
+        lastRunAtMs: STORE_TEST_NOW + 7_000,
+      },
+    });
+    const persistedRuntime = database
+      .prepare("SELECT runtime_updated_at_ms FROM cron_jobs WHERE store_key = ? AND job_id = ?")
+      .get(storeKey, job.id) as { runtime_updated_at_ms?: unknown } | undefined;
+    expect(persistedRuntime?.runtime_updated_at_ms).toBe(externalUpdatedAtMs);
+  });
+
   it("does not drain post-persist notifications when there is no store to write", async () => {
     const { storePath } = await makeStorePath();
     const state = createStoreTestState(storePath);

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -314,7 +314,13 @@ export async function persist(state: CronServiceState, opts?: PersistOptions) {
       : undefined;
   const stateOnly = !quarantine && opts?.stateOnly === true;
   try {
-    const saveOptions = quarantine ? { quarantine } : stateOnly ? { stateOnly: true } : undefined;
+    const saveOptions = quarantine
+      ? { quarantine }
+      : stateOnly
+        ? { stateOnly: true }
+        : state.deps.cronEnabled
+          ? undefined
+          : { preserveNewerRuntime: true };
     if (opts?.transactionHooks) {
       await saveCronJobsStoreWithTransactionHooks(
         state.deps.storePath,

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -34,7 +34,7 @@ import type {
   LoadedCronStore,
   QuarantinedCronConfigJob,
 } from "./store/types.js";
-import type { CronStoreFile } from "./types.js";
+import type { CronStoredJob, CronStoreFile } from "./types.js";
 export type {
   CronConfigJobRuntimeEntry,
   CronQuarantinedJob,
@@ -266,6 +266,7 @@ export async function saveCronJobsStore(
   if (!stateOnly) {
     assertCronStoreCanPersist(store);
   }
+  let committedJobs: CronStoredJob[] | undefined;
   runOpenClawStateWriteTransaction((database) => {
     opts?.transactionHooks?.beforeWrite?.(database.db);
     if (opts?.quarantine?.entries.length) {
@@ -287,8 +288,13 @@ export async function saveCronJobsStore(
       preserveNewerRuntime: opts?.preserveNewerRuntime,
     });
     replaceCronRuntimeAuthorityRows({ db: database.db, storeKey, jobs: normalizedJobs });
+    committedJobs = normalizedJobs;
     opts?.transactionHooks?.afterWrite?.(database.db);
   });
+  if (committedJobs) {
+    // Keep service responses and events aligned with the canonical rows that won the commit.
+    store.jobs = committedJobs;
+  }
   // Timeout outcomes may commit before their runner settles. Only after this
   // commit may a deferred receipt terminal request become externally visible.
   opts?.transactionHooks?.afterCommit?.();

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -238,6 +238,7 @@ type SaveCronStoreOptions = {
 };
 
 type SaveCronJobsStoreOptions = SaveCronStoreOptions & {
+  preserveNewerRuntime?: boolean;
   quarantine?: {
     entries: readonly (QuarantinedCronConfigJob | CronQuarantinedJob)[];
     nowMs: number;
@@ -282,7 +283,9 @@ export async function saveCronJobsStore(
       opts?.transactionHooks?.afterWrite?.(database.db);
       return;
     }
-    const normalizedJobs = replaceCronRows(database.db, storeKey, store);
+    const normalizedJobs = replaceCronRows(database.db, storeKey, store, {
+      preserveNewerRuntime: opts?.preserveNewerRuntime,
+    });
     replaceCronRuntimeAuthorityRows({ db: database.db, storeKey, jobs: normalizedJobs });
     opts?.transactionHooks?.afterWrite?.(database.db);
   });

--- a/src/cron/store/row-codec.ts
+++ b/src/cron/store/row-codec.ts
@@ -350,7 +350,8 @@ export function upsertCronJobRow(
   if (
     opts?.preserveNewerRuntime === true &&
     existing &&
-    existing.job_json === values.job_json &&
+    typeof existing.schedule_identity === "string" &&
+    existing.schedule_identity === values.schedule_identity &&
     existingRuntimeJob !== null &&
     normalizeCronJobForSqlite(existingRuntimeJob) !== null &&
     existingRuntimeUpdatedAt !== undefined &&

--- a/src/cron/store/row-codec.ts
+++ b/src/cron/store/row-codec.ts
@@ -285,6 +285,7 @@ export function replaceCronRows(
   db: DatabaseSync,
   storeKey: string,
   store: CronStoreFile,
+  opts?: { preserveNewerRuntime?: boolean },
 ): CronStoredJob[] {
   const existingRows = executeSqliteQuerySync(
     db,
@@ -295,7 +296,11 @@ export function replaceCronRows(
   ).rows;
   const normalizedJobs: CronStoredJob[] = [];
   for (const [index, job] of store.jobs.entries()) {
-    normalizedJobs.push(upsertCronJobRow(db, storeKey, job, index));
+    normalizedJobs.push(
+      upsertCronJobRow(db, storeKey, job, index, {
+        preserveNewerRuntime: opts?.preserveNewerRuntime,
+      }),
+    );
   }
   const nextJobIds = new Set(normalizedJobs.map((job) => job.id));
   for (const row of existingRows) {
@@ -321,12 +326,46 @@ export function upsertCronJobRow(
   storeKey: string,
   job: CronStoredJob,
   sortOrder: number,
+  opts?: { preserveNewerRuntime?: boolean },
 ): CronStoredJob {
   const normalized = normalizeCronJobForSqlite(job);
   if (!normalized) {
     throw new Error(`Cannot persist invalid cron job ${job.id}`);
   }
-  const values = bindCronJobRow(storeKey, normalized, sortOrder);
+  let values = bindCronJobRow(storeKey, normalized, sortOrder);
+  let preservedRuntime = false;
+  const existing = executeSqliteQuerySync(
+    db,
+    getCronStoreKysely(db)
+      .selectFrom("cron_jobs")
+      .selectAll()
+      .where("store_key", "=", storeKey)
+      .where("job_id", "=", normalized.id),
+  ).rows[0];
+  const existingRuntimeJob = existing
+    ? rowToCronJob(existing, tryParseJsonObject(existing.job_json) ?? {})
+    : null;
+  const existingRuntimeUpdatedAt = normalizeNumber(existing?.runtime_updated_at_ms ?? null);
+  const incomingRuntimeUpdatedAt = normalizeNumber(values.runtime_updated_at_ms ?? null);
+  if (
+    opts?.preserveNewerRuntime === true &&
+    existing &&
+    existing.job_json === values.job_json &&
+    existingRuntimeJob !== null &&
+    normalizeCronJobForSqlite(existingRuntimeJob) !== null &&
+    existingRuntimeUpdatedAt !== undefined &&
+    incomingRuntimeUpdatedAt !== undefined &&
+    existingRuntimeUpdatedAt > incomingRuntimeUpdatedAt
+  ) {
+    values = {
+      ...values,
+      updated_at: Math.max(existing.updated_at ?? 0, values.updated_at ?? 0),
+      state_json: existing.state_json,
+      runtime_updated_at_ms: existing.runtime_updated_at_ms,
+      schedule_identity: existing.schedule_identity,
+    };
+    preservedRuntime = true;
+  }
   executeSqliteQuerySync(
     db,
     getCronStoreKysely(db)
@@ -334,6 +373,18 @@ export function upsertCronJobRow(
       .values(values)
       .onConflict((conflict) => conflict.columns(["store_key", "job_id"]).doUpdateSet(values)),
   );
+  if (preservedRuntime) {
+    const preservedState = tryParseJsonObject(values.state_json ?? "");
+    return preservedState
+      ? {
+          ...normalized,
+          updatedAtMs:
+            normalizeNumber(values.runtime_updated_at_ms ?? null) ?? normalized.updatedAtMs,
+          // SAFETY: values.state_json was parsed by the same object codec used for persisted state.
+          state: preservedState as CronJobState,
+        }
+      : normalized;
+  }
   return normalized;
 }
 

--- a/src/cron/store/row-codec.ts
+++ b/src/cron/store/row-codec.ts
@@ -1,5 +1,6 @@
 /** Converts cron jobs between public store shape and normalized SQLite rows. */
 import type { DatabaseSync } from "node:sqlite";
+import { isDeepStrictEqual } from "node:util";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { executeSqliteQuerySync } from "../../infra/kysely-sync.js";
@@ -320,6 +321,16 @@ export function replaceCronRows(
   return normalizedJobs;
 }
 
+function cronRuntimeStateOwnerMatches(previous: CronStoredJob, next: CronStoredJob): boolean {
+  if (!isDeepStrictEqual(previous.trigger, next.trigger)) {
+    return false;
+  }
+  if (previous.payload.kind !== "script" && next.payload.kind !== "script") {
+    return true;
+  }
+  return isDeepStrictEqual(previous.payload, next.payload);
+}
+
 /** Upserts one persisted cron row without rewriting unrelated jobs in its store partition. */
 export function upsertCronJobRow(
   db: DatabaseSync,
@@ -354,6 +365,7 @@ export function upsertCronJobRow(
     existing.schedule_identity === values.schedule_identity &&
     existingRuntimeJob !== null &&
     normalizeCronJobForSqlite(existingRuntimeJob) !== null &&
+    cronRuntimeStateOwnerMatches(existingRuntimeJob, normalized) &&
     existingRuntimeUpdatedAt !== undefined &&
     incomingRuntimeUpdatedAt !== undefined &&
     existingRuntimeUpdatedAt > incomingRuntimeUpdatedAt


### PR DESCRIPTION
Closes #131401

## What Problem This Solves

A scheduler-disabled Gateway sharing the cron SQLite store could retain a stale in-memory snapshot and overwrite newer runtime state written by the scheduler Gateway during an unrelated CRUD mutation. This could move `nextRunAtMs` backwards and make a completed occurrence eligible again.

## Root Cause

Cron mutations used the process-local store revision to decide whether the in-memory snapshot was current. A write from another Gateway process does not update that local revision map. The disabled management service could therefore persist every row from its stale snapshot, including stale `state_json` and `runtime_updated_at_ms` for unrelated jobs.

## Fix

- Force a store reload before mutations when `cron.enabled` is false, so scheduler-disabled CRUD sees cross-process config changes.
- During ordinary full saves, compare each existing row's canonical config JSON and runtime timestamp inside the SQLite write transaction.
- When the existing row has the same config but a newer valid runtime timestamp, preserve its current runtime state and timestamp while applying the requested config mutation.
- Keep quarantine/repair saves and direct row-codec callers on their existing overwrite semantics.

## User Impact

Updating one cron job through a scheduler-disabled management Gateway no longer replays stale runtime state for unrelated jobs. Newer scheduler state remains durable, while the requested CRUD change and cross-process config updates are retained.

## Evidence

Exact head: `1b8971770`.

- Cross-process stale-write regression passed: a disabled `CronService` loads an old A/B snapshot, an external SQLite writer advances A and changes B description, then the disabled service updates B; final storage retains A's newer `nextRunAtMs`/`lastRunAtMs`, B's external description, and B's requested name.
- Cron service/store and row-codec regression suite: `123 passed`; 2 existing quarantine tests fail identically on the clean `origin/main` baseline and are unrelated to this change.
- Targeted mutation/store checks passed, including core production typecheck, formatting, lint, dependency guards, boundary checks, dead-code scan, and import-cycle checks.
- `git diff --check`: passed.

## Scope And Risk

The reload behavior is limited to CRUD/mutation operations on scheduler-disabled services. Runtime preservation is enabled only for ordinary full saves from that management path, not state-only timer writes, quarantine repairs, or low-level direct upserts. Config changes still replace the target job; preservation applies only when the existing and incoming canonical config JSON match.

AI-assisted implementation; I reviewed the cron service mutation lock, cross-process revision behavior, SQLite cron row codec, runtime/config column ownership, quarantine paths, and focused stale-write regression output.
