### PR TITLE
fix: recover active sessions across repeated gateway restarts

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -190,7 +190,6 @@ extensions/codex/src/app-server/dynamic-tools.ts	6
 extensions/codex/src/app-server/effective-mcp-catalog.ts	1
 extensions/codex/src/app-server/elicitation-bridge.ts	1
 extensions/codex/src/app-server/event-projector-reasoning.ts	1
-extensions/codex/src/app-server/event-projector-snapshot.ts	2
 extensions/codex/src/app-server/event-projector-tool-items.ts	1
 extensions/codex/src/app-server/event-projector-tool-transcript.ts	4
 extensions/codex/src/app-server/event-projector-values.ts	2

--- a/docs/concepts/session.md
+++ b/docs/concepts/session.md
@@ -182,6 +182,20 @@ Opt into automatic resets globally, then override them per chat type or channel:
 
 `resetByType` supports `direct`, `group`, and `thread`. Doctor migrates legacy `dm` entries to `direct` and `session.idleMinutes` to `session.reset.idleMinutes`; the schema rejects both retired forms.
 
+## Gateway restart recovery
+
+When a Gateway restart interrupts an active turn, OpenClaw tries to continue
+the existing session automatically. Three attempts that fail to start a backend
+turn exhaust the recovery budget. Once a real backend turn starts,
+the budget refreshes, so a later Gateway restart does not consume the old allowance.
+Accepting, queueing, or preparing a resume request alone does not refresh it.
+CLI backends that do not report turn acceptance refresh the budget only after
+observed assistant output or tool activity; silent startup does not refresh it.
+
+If automatic recovery is exhausted, the transcript remains available. Use
+**Resume in new session** in WebChat, or `/new` or `/reset` in other channels,
+to start a replacement session.
+
 ## Where state lives
 
 - **Runtime session rows:** `~/.openclaw/agents/<agentId>/agent/openclaw-agent.sqlite`

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -1490,6 +1490,8 @@ The Codex harness changes the low-level embedded agent executor only.
   channel history, search, `/new`, `/reset`, and future model or harness
   switching, but does not replace Codex compaction with an OpenClaw or
   context-engine summarizer.
+  Completed commentary and tool activity are saved during the turn rather than
+  waiting for its final answer, preserving completed work across Gateway interruption.
 - Media generation, media understanding, TTS, approvals, and messaging-tool
   output continue through the matching OpenClaw provider/model settings.
 - `tool_result_persist` applies to OpenClaw-owned transcript tool results,

--- a/extensions/codex/src/app-server/event-projector-assistant.ts
+++ b/extensions/codex/src/app-server/event-projector-assistant.ts
@@ -12,6 +12,7 @@ import {
 import { shouldClearTerminalPresentationForNativeItem } from "./event-projector-items.js";
 import { extractRawAssistantText, readItemString } from "./event-projector-values.js";
 import type { CodexThreadItem, JsonObject } from "./protocol.js";
+import type { CodexTranscriptCheckpointEntry } from "./transcript-checkpoint.js";
 
 type AgentEvent = Parameters<NonNullable<EmbeddedRunAttemptParams["onAgentEvent"]>>[0];
 type AnswerCandidateStatus = "candidate" | "superseded" | "selected";
@@ -51,12 +52,17 @@ export class CodexAssistantProjection {
   // replay it as the enclosing turn's terminal answer if Codex emits no coda.
   private persistedAssistantBoundary = false;
   private readonly persistableAssistantBarrierItemIds = new Set<string>();
+  private readonly completedAssistantItemIds = new Set<string>();
 
   constructor(
     private readonly params: EmbeddedRunAttemptParams,
     private readonly emitAgentEvent: (event: AgentEvent) => void,
     private readonly matchesToolProgressEcho: (text: string) => boolean,
     private readonly nextTranscriptTimestamp: () => number,
+    private readonly checkpointCommentary?: (
+      itemId: string,
+      entry: CodexTranscriptCheckpointEntry,
+    ) => void,
   ) {}
 
   hasCompletedTerminalAssistantText(completedItemIds: ReadonlySet<string>): boolean {
@@ -202,6 +208,9 @@ export class CodexAssistantProjection {
     itemId: string | undefined,
     activeItemIds: ReadonlySet<string>,
   ): { itemId: string; message: AssistantMessage; text: string } | undefined {
+    if (itemId && item?.type === "agentMessage") {
+      this.completedAssistantItemIds.add(itemId);
+    }
     this.noteNativeWorkBarrier(item);
     this.rememberAssistantPhase(item);
     if (
@@ -248,6 +257,9 @@ export class CodexAssistantProjection {
   recordSnapshotItem(
     item: CodexThreadItem,
   ): { itemId: string; message: AssistantMessage; text: string } | undefined {
+    if (item.type === "agentMessage") {
+      this.completedAssistantItemIds.add(item.id);
+    }
     this.rememberAssistantPhase(item);
     if (item.type === "agentMessage" && typeof item.text === "string") {
       this.rememberAssistantItem(item.id);
@@ -321,6 +333,7 @@ export class CodexAssistantProjection {
     if (phase) {
       this.assistantPhaseByItem.set(itemId, phase);
     }
+    this.completedAssistantItemIds.add(itemId);
     this.rememberAssistantItem(itemId);
     this.assistantTextByItem.set(itemId, text);
     // Empty raw finals prove an actual stop; retain that fact without publishing fake output.
@@ -363,21 +376,17 @@ export class CodexAssistantProjection {
 
   collectCommentaryMessages(): Array<{ itemId: string; message: AssistantMessage }> {
     return this.assistantItemOrder.flatMap((itemId) => {
-      if (!this.isCommentaryAssistantItem(itemId)) {
-        return [];
-      }
-      const text = this.assistantTextByItem.get(itemId)?.trim();
-      const timestamp = this.assistantTimestampByItem.get(itemId);
-      if (!text || timestamp === undefined) {
-        return [];
-      }
-      return [
-        {
-          itemId,
-          message: buildAssistantCommentaryMessage(this.params, text, itemId, timestamp),
-        },
-      ];
+      const message = this.readCommentaryMessage(itemId);
+      return message ? [{ itemId, message }] : [];
     });
+  }
+
+  private readCommentaryMessage(itemId: string): AssistantMessage | undefined {
+    const text = this.assistantTextByItem.get(itemId)?.trim();
+    const timestamp = this.assistantTimestampByItem.get(itemId);
+    return this.isCommentaryAssistantItem(itemId) && text && timestamp !== undefined
+      ? buildAssistantCommentaryMessage(this.params, text, itemId, timestamp)
+      : undefined;
   }
 
   collectAsyncMessages(): Array<{ itemId: string; message: AssistantMessage }> {
@@ -709,11 +718,19 @@ export class CodexAssistantProjection {
   }
 
   private rememberAssistantItem(itemId: string): void {
-    if (!itemId || this.assistantItemOrder.includes(itemId)) {
+    if (!itemId) {
       return;
     }
-    this.assistantItemOrder.push(itemId);
-    this.assistantTimestampByItem.set(itemId, this.nextTranscriptTimestamp());
+    if (!this.assistantTimestampByItem.has(itemId)) {
+      this.assistantItemOrder.push(itemId);
+      this.assistantTimestampByItem.set(itemId, this.nextTranscriptTimestamp());
+    }
+    if (this.isCommentaryAssistantItem(itemId)) {
+      this.checkpointCommentary?.(itemId, {
+        read: () => this.readCommentaryMessage(itemId),
+        ready: () => this.completedAssistantItemIds.has(itemId),
+      });
+    }
   }
 
   private createAsyncDelivery(

--- a/extensions/codex/src/app-server/event-projector-snapshot.ts
+++ b/extensions/codex/src/app-server/event-projector-snapshot.ts
@@ -5,33 +5,10 @@ import type {
 import { projectAgentHarnessTranscriptMessageForDisplay } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
 import { asDateTimestampMs } from "openclaw/plugin-sdk/number-runtime";
-import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { CodexAssistantProjection } from "./event-projector-assistant.js";
+import { applyCodexTranscriptTaint } from "./transcript-mirror-attestation.js";
 import { attachCodexMirrorIdentity } from "./upstream-prompt-provenance.js";
 import { promptSnapshot } from "./user-prompt-message.js";
-
-type TurnTaintMetadata = { resultContentSource?: "network"; turnTainted?: true };
-const CODEX_META_KEY = "__openclaw";
-
-function readTurnTaintMetadata(message: AgentMessage): TurnTaintMetadata | undefined {
-  const metadata = CODEX_META_KEY in message ? message[CODEX_META_KEY] : undefined;
-  return asOptionalRecord(metadata) as TurnTaintMetadata | undefined;
-}
-
-export function applyCodexTranscriptTaint(
-  message: AgentMessage,
-  state: { tainted: boolean },
-): AgentMessage {
-  if (message.role === "user") {
-    state.tainted = false;
-    return message;
-  }
-  const metadata = readTurnTaintMetadata(message);
-  state.tainted ||= metadata?.turnTainted === true || metadata?.resultContentSource === "network";
-  return message.role === "assistant" && state.tainted
-    ? ({ ...message, __openclaw: { ...metadata, turnTainted: true } } as AgentMessage)
-    : message;
-}
 
 export function buildCodexMessagesSnapshot(params: {
   runParams: EmbeddedRunAttemptParams;

--- a/extensions/codex/src/app-server/event-projector-snapshot.ts
+++ b/extensions/codex/src/app-server/event-projector-snapshot.ts
@@ -18,19 +18,19 @@ function readTurnTaintMetadata(message: AgentMessage): TurnTaintMetadata | undef
   return asOptionalRecord(metadata) as TurnTaintMetadata | undefined;
 }
 
-function applyStickyTurnTaint(messages: readonly AgentMessage[]): AgentMessage[] {
-  let tainted = false;
-  return messages.map((message) => {
-    if (message.role === "user") {
-      tainted = false;
-      return message;
-    }
-    const metadata = readTurnTaintMetadata(message);
-    tainted ||= metadata?.turnTainted === true || metadata?.resultContentSource === "network";
-    return message.role === "assistant" && tainted
-      ? ({ ...message, __openclaw: { ...metadata, turnTainted: true } } as AgentMessage)
-      : message;
-  });
+export function applyCodexTranscriptTaint(
+  message: AgentMessage,
+  state: { tainted: boolean },
+): AgentMessage {
+  if (message.role === "user") {
+    state.tainted = false;
+    return message;
+  }
+  const metadata = readTurnTaintMetadata(message);
+  state.tainted ||= metadata?.turnTainted === true || metadata?.resultContentSource === "network";
+  return message.role === "assistant" && state.tainted
+    ? ({ ...message, __openclaw: { ...metadata, turnTainted: true } } as AgentMessage)
+    : message;
 }
 
 export function buildCodexMessagesSnapshot(params: {
@@ -80,10 +80,11 @@ export function buildCodexMessagesSnapshot(params: {
       ),
     );
   }
-  return applyStickyTurnTaint(messages).map((message) =>
+  const taint = { tainted: false };
+  return messages.map((message) =>
     projectAgentHarnessTranscriptMessageForDisplay({
       hidden: params.runParams.trigger === "memory",
-      message,
+      message: applyCodexTranscriptTaint(message, taint),
     }),
   );
 }

--- a/extensions/codex/src/app-server/event-projector-tool-transcript.ts
+++ b/extensions/codex/src/app-server/event-projector-tool-transcript.ts
@@ -45,6 +45,7 @@ import {
 import { readCodexMirroredSessionHistoryMessages } from "./session-history.js";
 import { sanitizeCodexToolArguments } from "./tool-progress-normalization.js";
 import type { CodexTrajectoryRecorder } from "./trajectory.js";
+import type { CodexTranscriptCheckpointEntry } from "./transcript-checkpoint.js";
 import { attachCodexMirrorIdentity } from "./upstream-prompt-provenance.js";
 
 const ZERO_USAGE: Usage = {
@@ -149,6 +150,7 @@ export class CodexToolTranscriptProjection {
   private readonly nativeMcpAppResultDetailsAttempted = new Set<string>();
   private readonly approvalReviewsByCallId = new Map<string, ToolApprovalReviewState>();
   private readonly rawNativeToolOutputByCallId = new Map<string, string>();
+  private readonly pendingRawPatchOutputIds = new Set<string>();
   private readonly codeModeNativePatchInputsByCallId = new Map<string, string>();
 
   constructor(
@@ -161,6 +163,7 @@ export class CodexToolTranscriptProjection {
       nativePostToolUseRelayEnabled?: boolean;
       prepareNativeMcpAppResultDetails?: (item: CodexThreadItem) => Promise<unknown>;
       trajectoryRecorder?: CodexTrajectoryRecorder | null;
+      checkpointMessage?: (entry: CodexTranscriptCheckpointEntry) => void;
     } = {},
   ) {}
 
@@ -333,6 +336,7 @@ export class CodexToolTranscriptProjection {
         }
       }
       if (args) {
+        this.pendingRawPatchOutputIds.add(callId);
         this.recordToolCall({ id: callId, name: "apply_patch", arguments: args });
       }
       return;
@@ -344,6 +348,7 @@ export class CodexToolTranscriptProjection {
     ) {
       return;
     }
+    this.pendingRawPatchOutputIds.delete(callId);
     const text =
       typeof item.output === "string"
         ? item.output
@@ -601,12 +606,12 @@ export class CodexToolTranscriptProjection {
     this.callIds.add(params.id);
     this.namesById.set(params.id, params.name);
     this.progress.recordTranscriptCall(params);
-    this.messages.push(
-      attachCodexMirrorIdentity(
-        this.createToolCallMessage(params),
-        `${this.turnId}:tool:${params.id}:call`,
-      ),
+    const message = attachCodexMirrorIdentity(
+      this.createToolCallMessage(params),
+      `${this.turnId}:tool:${params.id}:call`,
     );
+    this.messages.push(message);
+    this.options.checkpointMessage?.({ read: () => message });
   }
 
   private recordToolResult(params: ToolTranscriptResultInput): void {
@@ -615,12 +620,17 @@ export class CodexToolTranscriptProjection {
     }
     this.resultIds.add(params.id);
     this.progress.recordTranscriptResult(params);
-    this.messages.push(
-      attachCodexMirrorIdentity(
-        this.createToolResultMessage(params),
-        `${this.turnId}:tool:${params.id}:result`,
-      ),
+    const message = attachCodexMirrorIdentity(
+      this.createToolResultMessage(params),
+      `${this.turnId}:tool:${params.id}:result`,
     );
+    this.messages.push(message);
+    this.options.checkpointMessage?.({
+      read: () => message,
+      // A linked raw patch output enriches FileChange after item/completed.
+      // Keep that result mutable only until the promised raw output arrives.
+      ready: () => !this.pendingRawPatchOutputIds.has(params.id),
+    });
   }
 
   private recordMissingToolError(

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -57,13 +57,13 @@ import {
   type JsonValue,
 } from "./protocol.js";
 import { formatCodexUsageLimitErrorMessage } from "./rate-limits.js";
+import { CodexTranscriptCheckpoint } from "./transcript-checkpoint.js";
 import { createCodexUsageLimitPromptError } from "./usage-limit-error.js";
 
 export { shouldEmitTranscriptToolProgress } from "./event-projector-tool-progress.js";
 
-type ApprovalFailure = Exclude<BeforeToolCallFailureDisposition, "blocked">;
-
 export class CodexAppServerEventProjector {
+  readonly transcriptCheckpoint: CodexTranscriptCheckpoint;
   private readonly asyncDeliveryProjection: CodexAsyncDeliveryProjection;
   private readonly assistantProjection: CodexAssistantProjection;
   private readonly reasoningProjection: CodexReasoningProjection;
@@ -90,7 +90,6 @@ export class CodexAppServerEventProjector {
   private contextTokensSource: "runtime" | "runtime-configured" | "resolved" | undefined;
   private readonly responseCompletions = new CodexResponseCompletionProjection();
   private completedCompactionCount = 0;
-  private lastTranscriptTimestamp = 0;
   private pendingSteeringAssistantBoundaryItemId: string | undefined;
 
   constructor(
@@ -99,6 +98,7 @@ export class CodexAppServerEventProjector {
     private readonly turnId: string,
     private readonly options: CodexAppServerEventProjectorOptions = {},
   ) {
+    this.transcriptCheckpoint = new CodexTranscriptCheckpoint(params, threadId, turnId);
     this.asyncDeliveryProjection = new CodexAsyncDeliveryProjection(
       params,
       threadId,
@@ -128,11 +128,12 @@ export class CodexAppServerEventProjector {
       threadId,
       turnId,
       this.toolProgressProjection,
-      () => this.nextTranscriptTimestamp(),
+      this.transcriptCheckpoint.nextTimestamp,
       {
         nativePostToolUseRelayEnabled: options.nativePostToolUseRelayEnabled,
         prepareNativeMcpAppResultDetails: options.prepareNativeMcpAppResultDetails,
         trajectoryRecorder: options.trajectoryRecorder,
+        checkpointMessage: this.transcriptCheckpoint.enqueue,
       },
     );
     this.eventProjection = new CodexEventProjection(
@@ -147,20 +148,14 @@ export class CodexAppServerEventProjector {
       params,
       (event) => this.emitAgentEvent(event),
       (text) => this.toolProgressProjection.matchesEcho(text),
-      () => this.nextTranscriptTimestamp(),
+      this.transcriptCheckpoint.nextTimestamp,
+      this.transcriptCheckpoint.enqueueCommentary,
     );
     this.reasoningProjection = new CodexReasoningProjection(
       params,
       (event) => this.emitAgentEvent(event),
       options.onNativePlanUpdate,
     );
-  }
-
-  private nextTranscriptTimestamp(): number {
-    // Commentary and tool mirrors share this clock so equal wall-clock values
-    // still preserve the app-server receipt order in the durable transcript.
-    this.lastTranscriptTimestamp = Math.max(Date.now(), this.lastTranscriptTimestamp + 1);
-    return this.lastTranscriptTimestamp;
   }
 
   getCompletedTurnStatus(): CodexTurn["status"] | undefined {
@@ -236,7 +231,7 @@ export class CodexAppServerEventProjector {
 
   recordNativeToolApprovalFailure(
     toolCallId: string,
-    disposition: ApprovalFailure,
+    disposition: Exclude<BeforeToolCallFailureDisposition, "blocked">,
     approvalKind?: CodexApprovalKind,
   ): void {
     this.nativeToolLifecycleProjector.recordApprovalFailureDisposition(toolCallId, disposition);
@@ -300,9 +295,11 @@ export class CodexAppServerEventProjector {
         break;
       case "item/started":
         await this.handleItemStarted(params);
+        await this.transcriptCheckpoint.flush();
         break;
       case "item/completed":
         await this.handleItemCompleted(params);
+        await this.transcriptCheckpoint.flush();
         break;
       case "item/commandExecution/outputDelta":
         this.toolProgressProjection.handleOutputDelta(params, "bash");
@@ -353,6 +350,7 @@ export class CodexAppServerEventProjector {
         break;
       case "rawResponseItem/completed":
         await this.handleRawResponseItemCompleted(params);
+        await this.transcriptCheckpoint.flush();
         break;
       case "model/rerouted":
         this.eventProjection.handleModelRerouted(params);
@@ -566,7 +564,7 @@ export class CodexAppServerEventProjector {
         threadId: this.threadId,
         turnId: this.turnId,
         itemId,
-        timestamp: this.nextTranscriptTimestamp(),
+        timestamp: this.transcriptCheckpoint.nextTimestamp(),
       });
       this.eventProjection.emitCompactionEnd(itemId, true);
     }

--- a/extensions/codex/src/app-server/run-attempt-cleanup.ts
+++ b/extensions/codex/src/app-server/run-attempt-cleanup.ts
@@ -150,6 +150,9 @@ export async function cleanupCodexAttempt(
     );
     await runCleanupStep("codex-turn-watch-clear", () => turnWatches.clearAllTimers());
     await runCleanupStep("codex-route-release", releaseCurrentRoute);
+    await runCleanupStep("codex-transcript-checkpoint", () =>
+      activeTurn.activeProjector.transcriptCheckpoint.flush(true),
+    );
     await runCleanupStep(
       "codex-shared-client-release",
       releaseSharedClientLeaseAndRetireOneShotClient,

--- a/extensions/codex/src/app-server/run-attempt-server-requests.ts
+++ b/extensions/codex/src/app-server/run-attempt-server-requests.ts
@@ -227,7 +227,10 @@ export function createCodexAttemptServerRequestController(
         { include: DYNAMIC_TOOL_TERMINAL_DIAGNOSTIC_TYPES },
       );
       try {
-        const { execution } = openClawDynamicToolExecutions.claim(call, () => {
+        const { execution } = openClawDynamicToolExecutions.claim(call, async () => {
+          // Publish the execution claim before persistence yields, so a replay
+          // cannot become another owner of this call's progress or result.
+          await projector?.transcriptCheckpoint.flush();
           emitDynamicToolStartedDiagnostic({
             call,
             agentId: sessionAgentId,
@@ -235,7 +238,7 @@ export function createCodexAttemptServerRequestController(
             sessionId: params.sessionId,
             sessionKey: params.sessionKey,
           });
-          return handleDynamicToolCallWithTimeout({
+          const response = await handleDynamicToolCallWithTimeout({
             call,
             toolBridge,
             signal,
@@ -259,6 +262,14 @@ export function createCodexAttemptServerRequestController(
               });
             },
           });
+          recordCodexDynamicToolResult(
+            projector,
+            call,
+            response,
+            toCodexDynamicToolProtocolResponse(response),
+          );
+          await projector?.transcriptCheckpoint.flush();
+          return response;
         });
         const response = await execution;
         const protocolResponse = toCodexDynamicToolProtocolResponse(response);
@@ -282,7 +293,6 @@ export function createCodexAttemptServerRequestController(
           success: protocolResponse.success,
           contentItems: protocolResponse.contentItems,
         });
-        recordCodexDynamicToolResult(projector, call, response, protocolResponse);
         if (protocolResponse.success && call.tool === "progress_card") {
           const progressCardInput = response.executedArguments ?? call.arguments;
           await projector?.recordDynamicProgressCardUpdate(progressCardInput);

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -970,35 +970,6 @@ function fastProgressEventSummaries(onAgentEvent: ReturnType<typeof vi.fn>) {
     .map((event) => event.data?.summary);
 }
 
-type ElicitationRequestHandler = (request: {
-  id: string;
-  method: string;
-  params?: unknown;
-}) => Promise<unknown>;
-
-function installElicitationClient(request: ReturnType<typeof vi.fn>) {
-  const state: {
-    handleRequest?: ElicitationRequestHandler;
-    notify: (notification: CodexServerNotification) => Promise<void>;
-  } = { notify: async () => undefined };
-  setCodexAppServerClientFactoryForTest(
-    async () =>
-      ({
-        ...mockClientRuntimeMethods(),
-        request,
-        addNotificationHandler: (handler: typeof state.notify) => {
-          state.notify = handler;
-          return () => undefined;
-        },
-        addRequestHandler: (handler: ElicitationRequestHandler) => {
-          state.handleRequest = handler;
-          return () => undefined;
-        },
-      }) as never,
-  );
-  return state;
-}
-
 async function completeStartedRun(
   run: Promise<unknown>,
   waitForMethod: ReturnType<typeof createStartedThreadHarness>["waitForMethod"],
@@ -5629,7 +5600,7 @@ describe("runCodexAppServerAttempt", () => {
       }
       return {};
     });
-    const elicitation = installElicitationClient(request);
+    const elicitation = createAppServerHarness(request);
     const params = createRunParams();
     await attachSqliteSessionTarget(
       params,
@@ -5645,12 +5616,9 @@ describe("runCodexAppServerAttempt", () => {
         },
       },
     });
-    await vi.waitFor(() => expect(elicitation.handleRequest).toBeTypeOf("function"));
     // The keyed router only accepts turn-scoped requests once the turn is bound.
-    await vi.waitFor(() =>
-      expect(request.mock.calls.map(([method]) => method)).toContain("turn/start"),
-    );
-    const result = await elicitation.handleRequest?.({
+    await elicitation.waitForMethod("turn/start");
+    const result = await elicitation.handleServerRequest({
       id: "request-elicitation-1",
       method: "mcpServer/elicitation/request",
       params: {
@@ -5711,16 +5679,13 @@ describe("runCodexAppServerAttempt", () => {
         response: { action: "decline", content: null, _meta: null },
       });
     const request = createGoogleCalendarRequest();
-    const elicitation = installElicitationClient(request);
+    const elicitation = createAppServerHarness(request);
     const params = createParams(sessionFile, workspaceDir);
     params.agentDir = agentDir;
     const run = runCodexAppServerAttempt(params, { pluginConfig });
-    await vi.waitFor(() => expect(elicitation.handleRequest).toBeTypeOf("function"));
     // The keyed router only accepts turn-scoped requests once the turn is bound.
-    await vi.waitFor(() =>
-      expect(request.mock.calls.map(([method]) => method)).toContain("turn/start"),
-    );
-    const result = await elicitation.handleRequest?.({
+    await elicitation.waitForMethod("turn/start");
+    const result = await elicitation.handleServerRequest({
       id: "request-elicitation-1",
       method: "mcpServer/elicitation/request",
       params: {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1761,6 +1761,11 @@ describe("runCodexAppServerAttempt", () => {
     const workspaceDir = path.join(tempDir, "workspace-tool-events");
     const harness = createStartedThreadHarness();
     const params = createParams(sessionFile, workspaceDir);
+    await attachSqliteSessionTarget(
+      params,
+      path.join(tempDir, "tool-event-sessions.json"),
+      "tool-event-session",
+    );
     const onRunAgentEvent = vi.fn();
     params.timeoutMs = 60_000;
     params.onAgentEvent = onRunAgentEvent;
@@ -1787,6 +1792,9 @@ describe("runCodexAppServerAttempt", () => {
       contentItems: [{ type: "inputText", text: "Unknown OpenClaw tool: python" }],
     });
     expect(replayedResponse).toEqual(firstResponse);
+    expect((await readTranscriptMessagesByIdentity(params)).map((message) => message.role)).toEqual(
+      ["user", "assistant", "toolResult"],
+    );
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await run;
     expect(onRunAgentEvent).toHaveBeenCalledWith({
@@ -1864,44 +1872,192 @@ describe("runCodexAppServerAttempt", () => {
     }
   });
 
-  it("mirrors the Codex prompt into the transcript when the turn starts", async () => {
-    const sessionFile = path.join(tempDir, "session-early-prompt.jsonl");
-    const storePath = path.join(tempDir, "sessions-early-prompt.json");
-    const workspaceDir = path.join(tempDir, "workspace-early-prompt");
-    const harness = createStartedThreadHarness();
-    const params = createParams(sessionFile, workspaceDir);
-    await attachSqliteSessionTarget(params, storePath, "session-early-prompt");
-    params.prompt = "external channel prompt";
-    const onUserMessagePersisted = vi.fn();
-    params.onUserMessagePersisted = onUserMessagePersisted;
-    const run = runCodexAppServerAttempt(params);
-    await harness.waitForMethod("turn/start");
-    await vi.waitFor(async () => {
-      expect(await readTranscriptMessagesByIdentity(params)).toContainEqual(
-        expect.objectContaining({
-          role: "user",
-          content: "external channel prompt",
-          idempotencyKey: "codex-app-server:thread-1:turn-1:prompt",
+  it.each(["completed", "interrupted", "disconnected"] as const)(
+    "persists completed Codex work before a %s turn ends",
+    async (outcome) => {
+      const sessionFile = path.join(tempDir, "session-early-prompt.jsonl");
+      const storePath = path.join(tempDir, "sessions-early-prompt.json");
+      const workspaceDir = path.join(tempDir, "workspace-early-prompt");
+      const harness = createStartedThreadHarness();
+      const params = createParams(sessionFile, workspaceDir);
+      await attachSqliteSessionTarget(params, storePath, "session-early-prompt");
+      params.prompt = "external channel prompt";
+      const onUserMessagePersisted = vi.fn();
+      params.onUserMessagePersisted = onUserMessagePersisted;
+      const run = runCodexAppServerAttempt(params);
+      await harness.waitForMethod("turn/start");
+      await vi.waitFor(async () => {
+        expect(await readTranscriptMessagesByIdentity(params)).toContainEqual(
+          expect.objectContaining({
+            role: "user",
+            content: "external channel prompt",
+            idempotencyKey: "codex-app-server:thread-1:turn-1:prompt",
+          }),
+        );
+      });
+      await vi.waitFor(() => {
+        expect(onUserMessagePersisted).toHaveBeenCalledWith(
+          expect.objectContaining({
+            role: "user",
+            content: "external channel prompt",
+            idempotencyKey: "codex-app-server:thread-1:turn-1:prompt",
+          }),
+        );
+      });
+      const messagesBeforeCompletion = await readTranscriptMessagesByIdentity(params);
+      expect(messagesBeforeCompletion.some((message) => message.role === "assistant")).toBe(false);
+      const commentary = {
+        type: "agentMessage",
+        id: "progress-1",
+        phase: "commentary",
+        text: "I found the owning lifecycle.",
+      };
+      await harness.notify(itemNotification("item/started", commentary));
+      await harness.notify({
+        method: "item/agentMessage/delta",
+        params: { threadId: "thread-1", turnId: "turn-1", itemId: commentary.id, delta: "I found" },
+      });
+      const command = {
+        type: "commandExecution",
+        id: "command-1",
+        command: "pwd",
+        cwd: workspaceDir,
+        status: "inProgress",
+      };
+      await harness.notify(itemNotification("item/started", command));
+      expect(await readTranscriptMessagesByIdentity(params)).toEqual(messagesBeforeCompletion);
+      await harness.notify(itemNotification("item/completed", commentary));
+      await harness.notify(
+        itemNotification("item/completed", {
+          ...command,
+          status: "completed",
+          aggregatedOutput: workspaceDir,
+          exitCode: 0,
         }),
       );
-    });
-    await vi.waitFor(() => {
-      expect(onUserMessagePersisted).toHaveBeenCalledWith(
-        expect.objectContaining({
-          role: "user",
-          content: "external channel prompt",
-          idempotencyKey: "codex-app-server:thread-1:turn-1:prompt",
+      const workBeforeCompletion = await readTranscriptMessagesByIdentity(params);
+      expect(workBeforeCompletion.map((message) => message.role)).toEqual([
+        "user",
+        "assistant",
+        "assistant",
+        "toolResult",
+      ]);
+      expect(JSON.stringify(workBeforeCompletion)).toContain(commentary.text);
+      expect(JSON.stringify(workBeforeCompletion)).toContain(workspaceDir);
+      if (outcome === "disconnected") {
+        harness.close(new Error("test transport disconnected"));
+      } else {
+        await harness.notify(turnCompleted({ id: "turn-1", status: outcome }));
+      }
+      await run;
+      const messagesAfterCompletion = await readTranscriptMessagesByIdentity(params);
+      expect(messagesAfterCompletion.filter((message) => message.role === "user")).toHaveLength(1);
+      for (const message of workBeforeCompletion) {
+        expect(
+          messagesAfterCompletion.filter(
+            (candidate) => candidate.idempotencyKey === message.idempotencyKey,
+          ),
+        ).toEqual([message]);
+      }
+      expect(onUserMessagePersisted).toHaveBeenCalledTimes(1);
+    },
+  );
+  it.each([true, false])(
+    "checkpoints raw patch output and network provenance with commentary persistence %s",
+    async (persistCommentary) => {
+      const params = createParams(
+        path.join(tempDir, "checkpoint.jsonl"),
+        path.join(tempDir, "workspace"),
+      );
+      await attachSqliteSessionTarget(
+        params,
+        path.join(tempDir, "checkpoint-sessions.json"),
+        "checkpoint-session",
+      );
+      params.config = {
+        ...params.config,
+        ui: { prefs: { chatPersistCommentary: persistCommentary } },
+      };
+      const harness = createStartedThreadHarness();
+      const run = runCodexAppServerAttempt(params);
+      await harness.waitForMethod("turn/start");
+      const patchId = "patch-1";
+      await harness.notify(
+        rawItemCompleted({
+          type: "custom_tool_call",
+          call_id: patchId,
+          name: "apply_patch",
+          input: "*** Begin Patch\n*** Add File: example.txt\n+saved\n*** End Patch\n",
         }),
       );
-    });
-    const messagesBeforeCompletion = await readTranscriptMessagesByIdentity(params);
-    expect(messagesBeforeCompletion.some((message) => message.role === "assistant")).toBe(false);
-    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
-    await run;
-    const messagesAfterCompletion = await readTranscriptMessagesByIdentity(params);
-    expect(messagesAfterCompletion.filter((message) => message.role === "user")).toHaveLength(1);
-    expect(onUserMessagePersisted).toHaveBeenCalledTimes(1);
-  });
+      await harness.notify(
+        itemNotification("item/completed", {
+          type: "fileChange",
+          id: patchId,
+          status: "completed",
+          changes: [{ path: "example.txt", kind: { type: "add" } }],
+        }),
+      );
+      const beforeRawOutput = await readTranscriptMessagesByIdentity(params);
+      expect(beforeRawOutput.map((message) => message.role)).toEqual(["user", "assistant"]);
+      await harness.notify(
+        itemNotification("item/completed", {
+          type: "webSearch",
+          id: "search-1",
+          status: "completed",
+          query: "saved file",
+        }),
+      );
+      expect(await readTranscriptMessagesByIdentity(params)).toEqual(beforeRawOutput);
+      await harness.notify(
+        rawItemCompleted({
+          type: "custom_tool_call_output",
+          call_id: patchId,
+          output: "Success. Updated the following files:\nA example.txt",
+        }),
+      );
+      await harness.notify(
+        itemNotification("item/completed", {
+          type: "agentMessage",
+          id: "network-commentary",
+          phase: "commentary",
+          text: "The search confirms the result.",
+        }),
+      );
+      const checkpoint = await readTranscriptMessagesByIdentity(params);
+      expect(checkpoint.map((message) => message.role)).toEqual([
+        "user",
+        "assistant",
+        "toolResult",
+        "assistant",
+        "toolResult",
+        ...(persistCommentary ? ["assistant"] : []),
+      ]);
+      expect(JSON.stringify(checkpoint[2])).toContain("Success. Updated the following files:");
+      expect(checkpoint[4]).toMatchObject({ __openclaw: { resultContentSource: "network" } });
+      if (persistCommentary) {
+        expect(checkpoint[5]).toMatchObject({ __openclaw: { turnTainted: true } });
+      }
+      await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+      const result = await run;
+      const finalMessages = await readTranscriptMessagesByIdentity(params);
+      for (const message of checkpoint) {
+        expect(
+          finalMessages.filter((candidate) => candidate.idempotencyKey === message.idempotencyKey),
+        ).toEqual([message]);
+      }
+      if (persistCommentary) {
+        expect(
+          result.messagesSnapshot.find(
+            (message) => readMirrorIdentity(message) === "turn-1:commentary:network-commentary",
+          ),
+        ).toMatchObject({
+          __openclaw: { turnTainted: true },
+        });
+      }
+    },
+  );
+
   it("does not mirror the Codex prompt early when user message persistence is suppressed", async () => {
     const sessionFile = path.join(tempDir, "session-suppressed-early-prompt.jsonl");
     const storePath = path.join(tempDir, "sessions-suppressed-early-prompt.json");

--- a/extensions/codex/src/app-server/transcript-checkpoint.ts
+++ b/extensions/codex/src/app-server/transcript-checkpoint.ts
@@ -5,7 +5,7 @@ import {
   type AgentMessage,
   type EmbeddedRunAttemptParamsV2,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
-import { applyCodexTranscriptTaint } from "./event-projector-snapshot.js";
+import { applyCodexTranscriptTaint } from "./transcript-mirror-attestation.js";
 import { codexTranscriptMirrorRuntime } from "./transcript-mirror.js";
 import { attachCodexMirrorIdentity } from "./upstream-prompt-provenance.js";
 

--- a/extensions/codex/src/app-server/transcript-checkpoint.ts
+++ b/extensions/codex/src/app-server/transcript-checkpoint.ts
@@ -1,0 +1,114 @@
+import {
+  embeddedAgentLog,
+  formatErrorMessage,
+  projectAgentHarnessTranscriptMessageForDisplay,
+  type AgentMessage,
+  type EmbeddedRunAttemptParamsV2,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
+import { applyCodexTranscriptTaint } from "./event-projector-snapshot.js";
+import { codexTranscriptMirrorRuntime } from "./transcript-mirror.js";
+import { attachCodexMirrorIdentity } from "./upstream-prompt-provenance.js";
+
+export type CodexTranscriptCheckpointEntry = {
+  read: () => AgentMessage | undefined;
+  ready?: () => boolean;
+};
+
+/** Commits completed work in receipt order without waiting for the enclosing turn. */
+export class CodexTranscriptCheckpoint {
+  private readonly pending: CodexTranscriptCheckpointEntry[] = [];
+  private readonly commentaryItemIds = new Set<string>();
+  private lastTimestamp = 0;
+  private writing = Promise.resolve();
+  private tainted = false;
+  private closed = false;
+
+  constructor(
+    private readonly params: EmbeddedRunAttemptParamsV2,
+    private readonly threadId: string,
+    private readonly turnId: string,
+  ) {}
+
+  nextTimestamp = (): number => {
+    // Commentary and tool mirrors share this clock so equal wall-clock values
+    // still preserve the app-server receipt order in the durable transcript.
+    this.lastTimestamp = Math.max(Date.now(), this.lastTimestamp + 1);
+    return this.lastTimestamp;
+  };
+
+  enqueueCommentary = (itemId: string, entry: CodexTranscriptCheckpointEntry): void => {
+    if (
+      this.params.config?.ui?.prefs?.chatPersistCommentary === false ||
+      this.commentaryItemIds.has(itemId)
+    ) {
+      return;
+    }
+    this.commentaryItemIds.add(itemId);
+    this.enqueue({
+      ...entry,
+      read: () => {
+        const message = entry.read();
+        return message
+          ? attachCodexMirrorIdentity(message, `${this.turnId}:commentary:${itemId}`)
+          : undefined;
+      },
+    });
+  };
+
+  enqueue = (entry: CodexTranscriptCheckpointEntry): void => {
+    if (this.params.sessionTarget && !this.closed) {
+      this.pending.push(entry);
+    }
+  };
+
+  flush(close = false): Promise<void> {
+    if (this.closed) {
+      return this.writing;
+    }
+    this.closed = close;
+    this.writing = this.writing.then(async () => {
+      // An unfinished commentary item or linked raw patch output owns its place
+      // in history. Later work cannot overtake it; teardown records what arrived.
+      const blocked = close ? -1 : this.pending.findIndex((entry) => entry.ready?.() === false);
+      const count = blocked < 0 ? this.pending.length : blocked;
+      if (count === 0) {
+        return;
+      }
+      const taint = { tainted: this.tainted };
+      const messages = this.pending.slice(0, count).flatMap((entry) => {
+        const message = entry.read();
+        return message
+          ? [
+              projectAgentHarnessTranscriptMessageForDisplay({
+                hidden: this.params.trigger === "memory",
+                message: applyCodexTranscriptTaint(message, taint),
+              }),
+            ]
+          : [];
+      });
+      try {
+        await codexTranscriptMirrorRuntime.mirror({
+          ...this.params.sessionTarget,
+          sessionId: this.params.sessionId,
+          cwd: this.params.workspaceDir,
+          messages,
+          idempotencyScope: `codex-app-server:${this.threadId}`,
+          runId: this.params.runId,
+          runMirrorIdentityPrefix: `${this.turnId}:`,
+          config: this.params.config,
+        });
+        this.pending.splice(0, count);
+        this.tainted = taint.tainted;
+      } catch (error) {
+        // Keep the pending prefix for the next observed boundary/final mirror.
+        // Persistence failure must not turn completed tool work into a retry.
+        embeddedAgentLog.warn("failed to checkpoint codex app-server transcript", {
+          runId: this.params.runId,
+          sessionId: this.params.sessionId,
+          error: formatErrorMessage(error),
+        });
+      }
+    });
+    return this.writing;
+  }
+}

--- a/extensions/codex/src/app-server/transcript-mirror-attestation.ts
+++ b/extensions/codex/src/app-server/transcript-mirror-attestation.ts
@@ -22,6 +22,7 @@ export function applyCodexTranscriptTaint(
   const metadata = asOptionalRecord(existing);
   state.tainted ||= metadata?.turnTainted === true || metadata?.resultContentSource === "network";
   return message.role === "assistant" && state.tainted
+    // SAFETY: Preserve the assistant variant and add only provider metadata.
     ? ({ ...message, __openclaw: { ...metadata, turnTainted: true } } as AgentMessage)
     : message;
 }

--- a/extensions/codex/src/app-server/transcript-mirror-attestation.ts
+++ b/extensions/codex/src/app-server/transcript-mirror-attestation.ts
@@ -22,8 +22,7 @@ export function applyCodexTranscriptTaint(
   const metadata = asOptionalRecord(existing);
   state.tainted ||= metadata?.turnTainted === true || metadata?.resultContentSource === "network";
   return message.role === "assistant" && state.tainted
-    // SAFETY: Preserve the assistant variant and add only provider metadata.
-    ? ({ ...message, __openclaw: { ...metadata, turnTainted: true } } as AgentMessage)
+    ? ({ ...message, __openclaw: { ...metadata, turnTainted: true } } as AgentMessage) // SAFETY: Only provider metadata changes.
     : message;
 }
 

--- a/extensions/codex/src/app-server/transcript-mirror-attestation.ts
+++ b/extensions/codex/src/app-server/transcript-mirror-attestation.ts
@@ -10,6 +10,22 @@ const MIRROR_SOURCE_FINGERPRINT_META_KEY = "mirrorSourceFingerprint" as const;
 const CODEX_APP_SERVER_MIRROR_ORIGIN = "codex-app-server" as const;
 const CODEX_META_KEY = "__openclaw";
 
+export function applyCodexTranscriptTaint(
+  message: AgentMessage,
+  state: { tainted: boolean },
+): AgentMessage {
+  if (message.role === "user") {
+    state.tainted = false;
+    return message;
+  }
+  const existing = CODEX_META_KEY in message ? message[CODEX_META_KEY] : undefined;
+  const metadata = asOptionalRecord(existing);
+  state.tainted ||= metadata?.turnTainted === true || metadata?.resultContentSource === "network";
+  return message.role === "assistant" && state.tainted
+    ? ({ ...message, __openclaw: { ...metadata, turnTainted: true } } as AgentMessage)
+    : message;
+}
+
 export function attachCodexMirrorAttestation(
   message: AgentMessage,
   sourceFingerprint?: string,

--- a/src/agents/agent-command-execution-identity.test.ts
+++ b/src/agents/agent-command-execution-identity.test.ts
@@ -1,8 +1,16 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import {
   configureExecutionIdentityAdmissionSink,
   type ExecutionIdentityAdmissionWork,
 } from "../audit/execution-identity-admission.js";
+import { loadSessionEntry, replaceSessionEntry } from "../config/sessions/session-accessor.js";
+import { getAgentEventLifecycleGeneration } from "../infra/agent-events.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { attachAgentCommandAdmissionFacts } from "./agent-command-admission-facts.js";
 import {
   readAgentCommandExecutionIdentitySpawnFacts,
@@ -12,6 +20,7 @@ import {
   prepareAgentCommandExecutionIdentity,
   sanitizePublicAgentCommandIngressOpts,
 } from "./agent-command-execution-identity.js";
+import { createAgentAttemptLifecycleCallbacks } from "./command/attempt-callbacks.js";
 import type { AgentCommandIngressOpts } from "./command/types.js";
 
 let cleanupSink: (() => void) | undefined;
@@ -43,6 +52,146 @@ describe("sanitizePublicAgentCommandIngressOpts", () => {
 });
 
 describe("Gateway agent command execution identity", () => {
+  it.each(
+    [false, true].flatMap((audit) =>
+      [
+        "started",
+        "startup-failed",
+        "closed-before-admission",
+        "closed-before-start",
+        "stale-attempt",
+      ].map((outcome) => ({ audit, outcome })),
+    ),
+  )("registers a real recovery turn without a foreground lease: %j", async ({ audit, outcome }) => {
+    const stateDir = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-recovery-admission-")),
+    );
+    const admittedCallback = createDeferred();
+    const releaseCallback = createDeferred();
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    const storePath = path.join(stateDir, "agents", "main", "sessions", "sessions.json");
+    const sessionKey = "agent:main:main";
+    const sessionEntry = {
+      sessionId: "recovery-session",
+      updatedAt: 100,
+      status: "running" as const,
+      abortedLastRun: false,
+      lifecycleRunId: "recovery-run",
+      restartRecoveryRuns: [{ runId: "recovery-run", lifecycleGeneration }],
+      mainRestartRecovery: { cycleId: "recovery-cycle", revision: 4, chargedAttempts: 3 },
+    };
+    cleanupSink = configureExecutionIdentityAdmissionSink(() => true);
+    let prepared: ReturnType<typeof prepareAgentCommandExecutionIdentity> | undefined;
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+        await replaceSessionEntry({ sessionKey, storePath }, sessionEntry);
+        prepared = prepareAgentCommandExecutionIdentity({
+          opts: {
+            message: "continue interrupted work",
+            mainRestartRecoveryAdmitted: true,
+            mainRestartRecoveryAttempt: 3,
+            onAdmittedRunContext: async () => {
+              admittedCallback.resolve();
+              await releaseCallback.promise;
+            },
+          },
+          prepared: {
+            cfg: { logging: { audit: { enabled: audit, executionIdentity: audit } } },
+            runId: "recovery-run",
+            sessionAgentId: "main",
+            sessionId: sessionEntry.sessionId,
+            sessionKey,
+            storePath,
+            sessionEntry,
+          },
+          ingress: { kind: "system", boundary: "restart-recovery", state: "present" },
+          lifecycleGeneration,
+        });
+        const callbacks = createAgentAttemptLifecycleCallbacks(
+          {
+            currentTurnUserMessagePersisted: false,
+            lifecycleFinishing: false,
+            lifecycleEnded: false,
+          },
+          prepared.onRuntimeTurnStarted,
+        );
+        const admission = prepared.admit("embedded");
+        const settled = admission.catch(() => undefined);
+        await admittedCallback.promise;
+        expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
+          mainRestartRecovery: { chargedAttempts: 3 },
+        });
+        expect(loadSessionEntry({ sessionKey, storePath })).not.toHaveProperty(
+          "mainRestartRecovery.startedAttempt",
+        );
+        if (outcome === "closed-before-admission") {
+          prepared.close();
+        }
+        releaseCallback.resolve();
+        await settled;
+        if (outcome === "closed-before-admission") {
+          await expect(admission).rejects.toThrow("closed during admission");
+          await callbacks.onAgentEvent({ stream: "lifecycle", data: { phase: "start" } });
+          expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
+            mainRestartRecovery: sessionEntry.mainRestartRecovery,
+          });
+          expect(loadSessionEntry({ sessionKey, storePath })).not.toHaveProperty(
+            "mainRestartRecovery.startedAttempt",
+          );
+          return;
+        }
+        const context = await admission;
+        await expect(prepared.admit("embedded")).resolves.toBe(context);
+        // A selected/authenticated runtime can still stall before turn/start.
+        expect(loadSessionEntry({ sessionKey, storePath })).not.toHaveProperty(
+          "mainRestartRecovery.startedAttempt",
+        );
+        if (audit) {
+          expect(loadSessionEntry({ sessionKey, storePath })).toHaveProperty(
+            "mainRestartRecovery.executionIdentity",
+            context.executionIdentityToken,
+          );
+        }
+        if (outcome === "closed-before-start") {
+          prepared.close();
+        } else if (outcome === "stale-attempt") {
+          await replaceSessionEntry(
+            { sessionKey, storePath },
+            {
+              ...sessionEntry,
+              mainRestartRecovery: { ...sessionEntry.mainRestartRecovery, chargedAttempts: 4 },
+            },
+          );
+        }
+        await callbacks.onAgentEvent({
+          stream: "lifecycle",
+          data: {
+            phase: outcome === "startup-failed" ? "error" : "start",
+          },
+        });
+        if (outcome !== "started") {
+          expect(loadSessionEntry({ sessionKey, storePath })).not.toHaveProperty(
+            "mainRestartRecovery.startedAttempt",
+          );
+          return;
+        }
+        await callbacks.onAgentEvent({ stream: "lifecycle", data: { phase: "start" } });
+        expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
+          mainRestartRecovery: {
+            chargedAttempts: 3,
+            startedAttempt: 3,
+            ...(audit ? { executionIdentity: context.executionIdentityToken } : {}),
+          },
+        });
+      });
+    } finally {
+      prepared?.close();
+      releaseCallback.resolve();
+      closeOpenClawAgentDatabasesForTest();
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
   it("runs owner binding only after the awaited admission callback settles", async () => {
     const events: string[] = [];
     const prepared = prepareAgentCommandExecutionIdentity({

--- a/src/agents/agent-command-execution-identity.ts
+++ b/src/agents/agent-command-execution-identity.ts
@@ -192,6 +192,9 @@ export function prepareAgentCommandExecutionIdentity(params: {
     : preparedAdmission;
   return Object.freeze({
     ...admission,
+    // Observational events do not await consumers. Finish their recovery write
+    // before releasing the admission; explicit close remains immediate.
+    finish: () => Promise.resolve(turnRegistration).finally(admission.close),
     onRuntimeTurnStarted: (): Promise<void> | undefined => {
       if (!recovery || !isActive()) {
         return undefined;

--- a/src/agents/agent-command-execution-identity.ts
+++ b/src/agents/agent-command-execution-identity.ts
@@ -1,15 +1,15 @@
-import type {
-  ExecutionIdentityAdmissionFacts,
-  ExecutionIdentityAdmissionToken,
-} from "../audit/execution-identity-admission.js";
+import type { ExecutionIdentityAdmissionFacts } from "../audit/execution-identity-admission.js";
 import { executionIdentitySpawnAdmission } from "../audit/execution-identity-spawn-admission.js";
 import { withPostAdmissionExecutionOwnerBinding } from "../audit/execution-owner-binding.js";
+import type { InternalSessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   createOperationalRunInstanceRef,
+  getAdmittedRunDelegatedAuthority,
   prepareAgentRunAdmission,
+  type AdmittedRunContext,
   type OperationalRunInstanceRef,
 } from "./admitted-run-context.js";
 import {
@@ -27,6 +27,7 @@ import type {
   AgentCommandOpts,
 } from "./command/types.js";
 import { commitMainSessionRecovery } from "./main-session-recovery/main-session-recovery-store.js";
+import type { MainSessionRecoveryCommand } from "./main-session-recovery/main-session-recovery-types.js";
 
 export type AgentCommandAdmissionIngress = ExecutionIdentityAdmissionFacts["ingress"];
 
@@ -85,34 +86,30 @@ function prepareAgentCommandRunAdmissionWithSpawnFacts(
   });
 }
 
-async function bindAgentCommandRecoveryExecutionIdentity(params: {
-  attempt: number;
-  cycleId: string;
-  lifecycleGeneration: string;
-  runId: string;
-  sessionId: string;
+async function commitAgentCommandRecoveryState(params: {
+  command: Extract<
+    MainSessionRecoveryCommand,
+    {
+      kind: "bind_admitted_execution_identity" | "register_recovery_turn";
+    }
+  >;
   sessionKey: string;
   storePath: string;
-  token: ExecutionIdentityAdmissionToken;
-}): Promise<string | undefined> {
+  isActive: () => boolean;
+}): Promise<void> {
   try {
     const bound = await commitMainSessionRecovery({
-      command: {
-        kind: "bind_admitted_execution_identity",
-        attempt: params.attempt,
-        cycleId: params.cycleId,
-        lifecycleGeneration: params.lifecycleGeneration,
-        runId: params.runId,
-        sessionId: params.sessionId,
-        token: params.token,
-      },
-      expectedSessionId: params.sessionId,
+      command: params.command,
+      expectedSessionId: params.command.sessionId,
       requireWriteSuccess: true,
+      shouldContinue: params.isActive,
       target: { sessionKey: params.sessionKey, storePath: params.storePath },
     });
-    return bound.transition.kind === "rejected" ? bound.transition.reason : undefined;
+    if (bound.transition.kind === "rejected") {
+      log.warn(`failed to ${params.command.kind}: ${bound.transition.reason}`);
+    }
   } catch (error) {
-    return formatErrorMessage(error);
+    log.warn(`failed to ${params.command.kind}: ${formatErrorMessage(error)}`);
   }
 }
 
@@ -124,6 +121,7 @@ export function prepareAgentCommandExecutionIdentity(params: {
     sessionAgentId: string;
     sessionId: string;
     sessionKey?: string;
+    sessionEntry?: InternalSessionEntry;
     storePath?: string;
   };
   ingress: AgentCommandAdmissionIngress;
@@ -136,6 +134,31 @@ export function prepareAgentCommandExecutionIdentity(params: {
   if (admissionFacts) {
     attachAgentCommandAdmissionFacts(operationalRunInstance, admissionFacts);
   }
+  const cycleId = prepared.sessionEntry?.mainRestartRecovery?.cycleId;
+  const recovery =
+    opts.mainRestartRecoveryAdmitted === true &&
+    opts.mainRestartRecoveryAttempt !== undefined &&
+    cycleId &&
+    prepared.sessionKey &&
+    prepared.storePath
+      ? {
+          owner: {
+            attempt: opts.mainRestartRecoveryAttempt,
+            cycleId,
+            lifecycleGeneration: params.lifecycleGeneration,
+            runId: prepared.runId,
+            sessionId: prepared.sessionId,
+          },
+          sessionKey: prepared.sessionKey,
+          storePath: prepared.storePath,
+        }
+      : undefined;
+  let admittedContext: AdmittedRunContext | undefined;
+  let turnRegistration: Promise<void> | undefined;
+  const isActive = () =>
+    admittedContext !== undefined &&
+    !opts.abortSignal?.aborted &&
+    getAdmittedRunDelegatedAuthority(admittedContext) !== undefined;
   const admissionParams: Parameters<typeof prepareAgentCommandRunAdmission>[0] = {
     admission: opts.executionIdentityAdmission,
     agentId: prepared.sessionAgentId,
@@ -145,38 +168,43 @@ export function prepareAgentCommandExecutionIdentity(params: {
     runId: prepared.runId,
     onAdmitted: async (admittedRunContext) => {
       await opts.onAdmittedRunContext?.(admittedRunContext);
-      if (
-        opts.mainRestartRecoveryAdmitted !== true ||
-        opts.mainRestartRecoveryAttempt === undefined ||
-        !opts.mainRestartRecoveryOwnerLease ||
-        !admittedRunContext.executionIdentityToken ||
-        !prepared.sessionKey ||
-        !prepared.storePath
-      ) {
+      admittedContext = admittedRunContext;
+      if (!recovery || !admittedRunContext.executionIdentityToken) {
         return;
       }
-      const bindingFailure = await bindAgentCommandRecoveryExecutionIdentity({
-        attempt: opts.mainRestartRecoveryAttempt,
-        cycleId: opts.mainRestartRecoveryOwnerLease.cycleId,
-        lifecycleGeneration: params.lifecycleGeneration,
-        runId: prepared.runId,
-        sessionId: prepared.sessionId,
-        sessionKey: prepared.sessionKey,
-        storePath: prepared.storePath,
-        token: admittedRunContext.executionIdentityToken,
+      await commitAgentCommandRecoveryState({
+        ...recovery,
+        command: {
+          kind: "bind_admitted_execution_identity",
+          ...recovery.owner,
+          token: admittedRunContext.executionIdentityToken,
+        },
+        isActive,
       });
-      if (bindingFailure) {
-        log.warn(`failed to bind restart recovery execution identity: ${bindingFailure}`);
-      }
     },
   };
   const spawnFacts = readAgentCommandExecutionIdentitySpawnFacts(opts);
   const preparedAdmission = spawnFacts
     ? prepareAgentCommandRunAdmissionWithSpawnFacts(admissionParams, spawnFacts)
     : executionIdentity.prepare(admissionParams);
-  return opts.onPostAdmittedRunContext
+  const admission = opts.onPostAdmittedRunContext
     ? withPostAdmissionExecutionOwnerBinding(preparedAdmission, opts.onPostAdmittedRunContext)
     : preparedAdmission;
+  return Object.freeze({
+    ...admission,
+    onRuntimeTurnStarted: (): Promise<void> | undefined => {
+      if (!recovery || !isActive()) {
+        return undefined;
+      }
+      // Auth/runtime preparation is not backend acceptance. This closure is
+      // invoked only by the admitted turn's lifecycle or observed CLI activity.
+      return (turnRegistration ??= commitAgentCommandRecoveryState({
+        ...recovery,
+        command: { kind: "register_recovery_turn", ...recovery.owner },
+        isActive,
+      }));
+    },
+  });
 }
 
 export function sanitizePublicAgentCommandIngressOpts(

--- a/src/agents/agent-command.live-model-switch.test-helpers.ts
+++ b/src/agents/agent-command.live-model-switch.test-helpers.ts
@@ -1,8 +1,8 @@
-import type { SessionEntry } from "../config/sessions.js";
+import type { InternalSessionEntry } from "../config/sessions.js";
 import { normalizeLegacySessionEntryDelivery } from "../infra/state-migrations.legacy-session-store.js";
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
 
-export type CommandSessionEntryFixture = Partial<SessionEntry> & {
+export type CommandSessionEntryFixture = Partial<InternalSessionEntry> & {
   channel?: string;
   deliveryContext?: DeliveryContext;
   lastThreadId?: string | number;
@@ -10,18 +10,18 @@ export type CommandSessionEntryFixture = Partial<SessionEntry> & {
 
 export function createCommandSessionEntry(
   overrides: CommandSessionEntryFixture = {},
-): SessionEntry {
+): InternalSessionEntry {
   return normalizeLegacySessionEntryDelivery({
     sessionId: "session-1",
     updatedAt: 1,
     ...overrides,
-  } as SessionEntry);
+  } as InternalSessionEntry);
 }
 
 export function createCommandSessionFixture(
   overrides: CommandSessionEntryFixture = {},
   sessionKey = "agent:main:main",
-): { entry: SessionEntry; store: Record<string, SessionEntry> } {
+): { entry: InternalSessionEntry; store: Record<string, InternalSessionEntry> } {
   const entry = createCommandSessionEntry({
     skillsSnapshot: { prompt: "", skills: [], version: 0 },
     ...overrides,

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -1,18 +1,34 @@
 /** Tests live model switching behavior in active agent command sessions. */
 
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { expectDefined, toStringifiedError } from "@openclaw/normalization-core";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { setReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
 import type { SessionEntry } from "../config/sessions.js";
+import { loadSessionEntry, replaceSessionEntry } from "../config/sessions/session-accessor.js";
+import {
+  resolveSqliteScope,
+  runExclusiveSqliteSessionWrite,
+} from "../config/sessions/session-accessor.sqlite-scope.js";
 import {
   createUserTurnTranscriptRecorder,
   type UserTurnTranscriptRecorder,
 } from "../sessions/user-turn-transcript.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import {
   deliveryContextFromSession,
   normalizeSessionDeliveryState,
 } from "../utils/delivery-context.shared.js";
+import {
+  getAdmittedRunDelegatedAuthority,
+  type AdmittedRunContext,
+  type PreparedAgentRunAdmission,
+} from "./admitted-run-context.js";
 import {
   buildTestAllowedModelSet,
   type CommandSessionEntryFixture,
@@ -294,9 +310,19 @@ vi.mock("./command/session.js", () => ({
 
 vi.mock("./command/types.js", () => ({}));
 
-// Recovery ownership has dedicated store-backed coverage. This command suite
-// uses an intentionally synthetic session resolver with no durable store path.
+// Claim ownership has dedicated store-backed coverage. Keep real recovery commits
+// so command teardown can be tested against the canonical session writer queue.
 vi.mock("./main-session-recovery/main-session-recovery-store.js", () => ({
+  commitMainSessionRecovery: async (
+    ...args: Parameters<
+      typeof import("./main-session-recovery/main-session-recovery-store.js").commitMainSessionRecovery
+    >
+  ) => {
+    const actual = await vi.importActual<
+      typeof import("./main-session-recovery/main-session-recovery-store.js")
+    >("./main-session-recovery/main-session-recovery-store.js");
+    return actual.commitMainSessionRecovery(...args);
+  },
   claimMainSessionRecoveryOwner: vi.fn(async () => ({ kind: "not_required" })),
   inspectMainSessionRecoveryRequired: vi.fn(async () => ({ kind: "not_required" })),
   releaseMainSessionRecoveryOwner: vi.fn(async () => undefined),
@@ -1295,6 +1321,107 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
 
     expect(state.runAgentAttemptMock).toHaveBeenCalledTimes(1);
   });
+
+  it.each(["completed", "failed"] as const)(
+    "persists a detached recovery start before closing a %s command",
+    async (outcome) => {
+      const stateDir = await fs.realpath(
+        await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-command-recovery-start-")),
+      );
+      try {
+        await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+          const sessionKey = "agent:default:main";
+          const storePath = path.join(stateDir, "agents", "default", "sessions", "sessions.json");
+          const runId = "recovery-run";
+          const { entry } = setupStoredSession(
+            {
+              status: "running",
+              lifecycleRunId: runId,
+              restartRecoveryRuns: [{ runId, lifecycleGeneration: "test-generation" }],
+              mainRestartRecovery: { cycleId: "recovery-cycle", revision: 4, chargedAttempts: 3 },
+            },
+            storePath,
+            sessionKey,
+          );
+          state.resolvedSessionKeyMock = sessionKey;
+          await replaceSessionEntry({ sessionKey, storePath }, entry);
+          const started = createDeferred();
+          const releaseWriter = createDeferred();
+          let writer: Promise<void> | undefined;
+          let registration: Promise<void> | undefined;
+          let context: AdmittedRunContext | undefined;
+          let commandSettled = false;
+          const failure = new Error("runtime failed after accepting the recovery turn");
+          setupSingleAttemptFallback();
+          state.runAgentAttemptMock.mockImplementationOnce(
+            async (params: {
+              preparedRunAdmission: PreparedAgentRunAdmission;
+              onAgentEvent: (event: {
+                stream: string;
+                data: Record<string, unknown>;
+              }) => void | Promise<void>;
+            }) => {
+              context = await params.preparedRunAdmission.admit("embedded");
+              writer = runExclusiveSqliteSessionWrite(
+                resolveSqliteScope({ sessionKey, storePath }),
+                async () => await releaseWriter.promise,
+              );
+              // Real CLI, Pi, and Codex event producers do not await this callback.
+              registration = Promise.resolve(
+                params.onAgentEvent({ stream: "lifecycle", data: { phase: "start" } }),
+              );
+              started.resolve();
+              if (outcome === "failed") {
+                throw failure;
+              }
+              return makeSuccessResult("anthropic", "claude");
+            },
+          );
+          const command = agentCommand({
+            message: "continue interrupted work",
+            sessionKey,
+            runId,
+            mainRestartRecoveryAdmitted: true,
+            mainRestartRecoveryAttempt: 3,
+          }).then(
+            () => {
+              commandSettled = true;
+              return undefined;
+            },
+            (error: unknown) => {
+              commandSettled = true;
+              return error;
+            },
+          );
+          try {
+            await started.promise;
+            // Let the runner's resolved/rejected promise reach command teardown
+            // while the earlier SQLite writer still holds the registration.
+            await new Promise<void>((resolve) => {
+              setImmediate(resolve);
+            });
+            expect(commandSettled).toBe(false);
+            const admitted = expectDefined(context, "recovery admission");
+            expect(getAdmittedRunDelegatedAuthority(admitted)).toBeDefined();
+            releaseWriter.resolve();
+            expect(await command).toBe(outcome === "failed" ? failure : undefined);
+            expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
+              mainRestartRecovery: { chargedAttempts: 3, startedAttempt: 3 },
+            });
+            expect(getAdmittedRunDelegatedAuthority(admitted)).toBeUndefined();
+          } finally {
+            releaseWriter.resolve();
+            await writer;
+            await registration;
+            await command;
+          }
+        });
+      } finally {
+        closeOpenClawAgentDatabasesForTest();
+        await fs.rm(stateDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("forwards the auth profile bound to the configured default model", async () => {
     state.runtimeConfigMock = {

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -187,7 +187,7 @@ async function agentCommandInternal(
   }
 
   let sessionWorkAdmission: Awaited<ReturnType<typeof beginSessionWorkAdmission>> | undefined;
-  let preparedRunAdmission: ReturnType<typeof executionIdentity.prepare> | undefined;
+  let preparedRunAdmission: ReturnType<typeof prepareAgentCommandExecutionIdentity> | undefined;
   try {
     assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
     const sessionStoreRuntime =

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -546,7 +546,7 @@ async function agentCommandInternal(
       return finalized.deliveryResult;
     });
   } finally {
-    preparedRunAdmission?.close();
+    await preparedRunAdmission?.finish();
     sessionWorkAdmission?.release();
     if (internalModelRunTargets) {
       // Compaction may rotate a private session identity. Remove every owned

--- a/src/agents/command/attempt-callbacks.test.ts
+++ b/src/agents/command/attempt-callbacks.test.ts
@@ -26,7 +26,7 @@ describe("createAgentAttemptLifecycleCallbacks", () => {
     expect(state.lifecycleEnded).toBe(false);
   });
 
-  it("tracks terminal lifecycle phases", () => {
+  it("tracks terminal lifecycle phases", async () => {
     const state = {
       currentTurnUserMessagePersisted: false,
       lifecycleFinishing: false,
@@ -34,14 +34,14 @@ describe("createAgentAttemptLifecycleCallbacks", () => {
     };
     const callbacks = createAgentAttemptLifecycleCallbacks(state);
 
-    callbacks.onAgentEvent({ stream: "lifecycle", data: { phase: "start" } });
+    await callbacks.onAgentEvent({ stream: "lifecycle", data: { phase: "start" } });
     expect(state.lifecycleEnded).toBe(false);
 
-    callbacks.onAgentEvent({ stream: "lifecycle", data: { phase: "end" } });
+    await callbacks.onAgentEvent({ stream: "lifecycle", data: { phase: "end" } });
     expect(state.lifecycleEnded).toBe(true);
   });
 
-  it("retains deferred lifecycle errors without marking the attempt terminal", () => {
+  it("retains deferred lifecycle errors without marking the attempt terminal", async () => {
     const state: AgentAttemptLifecycleState = {
       currentTurnUserMessagePersisted: false,
       lifecycleFinishing: false,
@@ -49,7 +49,7 @@ describe("createAgentAttemptLifecycleCallbacks", () => {
     };
     const callbacks = createAgentAttemptLifecycleCallbacks(state);
 
-    callbacks.onAgentEvent({
+    await callbacks.onAgentEvent({
       stream: "lifecycle",
       data: { phase: "finishing", error: "provider failed" },
     });
@@ -59,7 +59,7 @@ describe("createAgentAttemptLifecycleCallbacks", () => {
     expect(state.lifecycleEnded).toBe(false);
   });
 
-  it("replaces a failed candidate lifecycle when a retry starts", () => {
+  it("replaces a failed candidate lifecycle when a retry starts", async () => {
     const state: AgentAttemptLifecycleState = {
       currentTurnUserMessagePersisted: true,
       lifecycleError: "provider failed",
@@ -68,7 +68,7 @@ describe("createAgentAttemptLifecycleCallbacks", () => {
     };
     const callbacks = createAgentAttemptLifecycleCallbacks(state);
 
-    callbacks.onAgentEvent({ stream: "lifecycle", data: { phase: "start" } });
+    await callbacks.onAgentEvent({ stream: "lifecycle", data: { phase: "start" } });
 
     expect(state).toEqual({
       currentTurnUserMessagePersisted: true,

--- a/src/agents/command/attempt-callbacks.ts
+++ b/src/agents/command/attempt-callbacks.ts
@@ -19,9 +19,12 @@ type AgentAttemptLifecycleEvent = {
 };
 
 /** Creates callbacks that update lifecycle flags for persistence decisions. */
-export function createAgentAttemptLifecycleCallbacks(state: AgentAttemptLifecycleState): {
+export function createAgentAttemptLifecycleCallbacks(
+  state: AgentAttemptLifecycleState,
+  onRuntimeTurnStarted?: () => void | Promise<void>,
+): {
   onUserMessagePersisted: (message: Extract<AgentMessage, { role: "user" }>) => void;
-  onAgentEvent: (evt: AgentAttemptLifecycleEvent) => void;
+  onAgentEvent: (evt: AgentAttemptLifecycleEvent) => void | Promise<void>;
 } {
   return {
     onUserMessagePersisted: () => {
@@ -37,7 +40,7 @@ export function createAgentAttemptLifecycleCallbacks(state: AgentAttemptLifecycl
         state.lifecycleError = undefined;
         state.lifecycleFinishing = false;
         state.lifecycleEnded = false;
-        return;
+        return onRuntimeTurnStarted?.();
       }
       if (typeof evt.data.error === "string" && evt.data.error.trim()) {
         state.lifecycleError = evt.data.error;

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -38,6 +38,7 @@ import type { EmbeddedAgentRunResult } from "../embedded-agent.js";
 import { FailoverError } from "../failover-error.js";
 import type { ModelFallbackAttemptProvenance } from "../model-fallback.types.js";
 import { attachToolAllowlistIntersection } from "../tool-policy.js";
+import { createAgentAttemptLifecycleCallbacks } from "./attempt-callbacks.js";
 import {
   persistAcpTurnTranscript,
   persistCliTurnTranscript,
@@ -828,6 +829,7 @@ describe("CLI attempt execution", () => {
     runId: string;
     cwd?: string;
     onExecutionStarted?: () => void;
+    onAgentEvent?: RunAgentAttemptParams["onAgentEvent"];
   }) {
     await runAgentAttempt({
       providerOverride: "claude-cli",
@@ -839,31 +841,53 @@ describe("CLI attempt execution", () => {
       body: params.body,
       runId: params.runId,
       opts: { onExecutionStarted: params.onExecutionStarted },
+      ...(params.onAgentEvent ? { onAgentEvent: params.onAgentEvent } : {}),
       agentDir,
       sessionStore: params.sessionStore,
       storePath,
     });
   }
 
-  it("forwards execution admission callbacks to the CLI runtime", async () => {
-    const sessionKey = "agent:main:direct:cli-execution-started";
-    const sessionEntry = makeSessionEntry("session-cli-execution-started");
-    const sessionStore = { [sessionKey]: sessionEntry };
-    await writeSessionStoreSeed(sessionStore);
-    const onExecutionStarted = vi.fn();
-    runCliAgentMock.mockResolvedValueOnce(makeCliResult("started"));
+  it.each(["assistant_output_started", "tool_execution_started"] as const)(
+    "keeps CLI admission separate from observed %s",
+    async (phase) => {
+      const sessionKey = "agent:main:direct:cli-execution-started";
+      const sessionEntry = makeSessionEntry("session-cli-execution-started");
+      const sessionStore = { [sessionKey]: sessionEntry };
+      await writeSessionStoreSeed(sessionStore);
+      const onExecutionStarted = vi.fn();
+      const onRuntimeTurnStarted = vi.fn();
+      const callbacks = createAgentAttemptLifecycleCallbacks(
+        {
+          currentTurnUserMessagePersisted: false,
+          lifecycleFinishing: false,
+          lifecycleEnded: false,
+        },
+        onRuntimeTurnStarted,
+      );
+      runCliAgentMock.mockResolvedValueOnce(makeCliResult("started"));
 
-    await runClaudeCliAttempt({
-      sessionKey,
-      sessionEntry,
-      sessionStore,
-      body: "start",
-      runId: "run-cli-execution-started",
-      onExecutionStarted,
-    });
+      await runClaudeCliAttempt({
+        sessionKey,
+        sessionEntry,
+        sessionStore,
+        body: "start",
+        runId: "run-cli-execution-started",
+        onExecutionStarted,
+        onAgentEvent: callbacks.onAgentEvent,
+      });
 
-    expect(firstRunCliAgentArg().onExecutionStarted).toBe(onExecutionStarted);
-  });
+      expect(firstRunCliAgentArg().onExecutionStarted).toBe(onExecutionStarted);
+      const observePhase = firstRunCliAgentArg().onExecutionPhase;
+      if (typeof observePhase !== "function") {
+        throw new Error("CLI execution phase observer is missing");
+      }
+      observePhase({ phase: "process_spawned" });
+      expect(onRuntimeTurnStarted).not.toHaveBeenCalled();
+      observePhase({ phase });
+      expect(onRuntimeTurnStarted).toHaveBeenCalledOnce();
+    },
+  );
 
   it("forwards authoritative group type to CLI runs with opaque session keys", async () => {
     const sessionKey = "agent:main:opaque:binding";

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -531,7 +531,7 @@ export function runAgentAttempt(params: {
     stream: string;
     data?: Record<string, unknown>;
     sessionKey?: string;
-  }) => void;
+  }) => void | Promise<void>;
   deferTerminalLifecycle?: boolean;
   authProfileProvider: string;
   sessionStore?: Record<string, SessionEntry>;
@@ -554,6 +554,13 @@ export function runAgentAttempt(params: {
     authProfileIdSource?: "auto" | "user";
   }) => void;
 }) {
+  const onRuntimeActivity = (info: { phase: string }) => {
+    // CLI preparation and child launch do not prove a native turn. Parsed
+    // assistant/tool activity does, even when the backend omits lifecycle events.
+    if (info.phase === "assistant_output_started" || info.phase === "tool_execution_started") {
+      void params.onAgentEvent({ stream: "lifecycle", data: { phase: "start" } });
+    }
+  };
   const sessionAuthProfileId = params.sessionEntry?.authProfileOverride?.trim();
   const sessionAuthProfileSource = resolveSessionAuthProfileOverrideSource(params.sessionEntry);
   // An explicit session choice owns the conversation. Otherwise the profile
@@ -952,6 +959,7 @@ export function runAgentAttempt(params: {
             runId: params.runId,
             lifecycleGeneration: params.lifecycleGeneration,
             onExecutionStarted: params.opts.onExecutionStarted,
+            onExecutionPhase: onRuntimeActivity,
             lane: params.opts.lane,
             extraSystemPrompt: params.opts.extraSystemPrompt,
             inputProvenance: params.opts.inputProvenance,
@@ -1259,6 +1267,7 @@ export function runAgentAttempt(params: {
     disableTools,
     allowEmptyAssistantReplyAsSilent: isSubagentLane || isSubagentAnnounceHandoff,
     onAgentEvent: params.onAgentEvent,
+    onExecutionPhase: onRuntimeActivity,
     deferTerminalLifecycle: params.deferTerminalLifecycle,
     suppressNextUserMessagePersistence: params.suppressPromptPersistenceOnRetry === true,
     userTurnTranscriptRecorder: params.userTurnTranscriptRecorder,

--- a/src/agents/command/run-embedded-attempt.ts
+++ b/src/agents/command/run-embedded-attempt.ts
@@ -15,7 +15,7 @@ import {
 } from "../../tasks/task-status-access.js";
 import { createTrajectoryRuntimeRecorder } from "../../trajectory/runtime.js";
 import { resolveMessageChannel } from "../../utils/message-channel.js";
-import type { PreparedAgentRunAdmission } from "../admitted-run-context.js";
+import type { prepareAgentCommandExecutionIdentity } from "../agent-command-execution-identity.js";
 import {
   clearAutoFallbackPrimaryProbeSelection,
   entryMatchesAutoFallbackPrimaryProbe,
@@ -65,7 +65,7 @@ const log = createSubsystemLogger("agents/agent-command");
 const MAX_LIVE_SWITCH_RETRIES = 5;
 
 export async function runEmbeddedAgentAttempt(params: {
-  preparedRunAdmission: PreparedAgentRunAdmission;
+  preparedRunAdmission: ReturnType<typeof prepareAgentCommandExecutionIdentity>;
   prepared: PreparedAgentCommandExecution;
   opts: AgentCommandOpts;
   sessionEntry?: SessionEntry;
@@ -158,7 +158,10 @@ export async function runEmbeddedAgentAttempt(params: {
     lifecycleFinishing: false,
     lifecycleEnded: false,
   };
-  const attemptLifecycleCallbacks = createAgentAttemptLifecycleCallbacks(attemptLifecycleState);
+  const attemptLifecycleCallbacks = createAgentAttemptLifecycleCallbacks(
+    attemptLifecycleState,
+    params.preparedRunAdmission.onRuntimeTurnStarted,
+  );
   const transcriptMedia = params.opts.transcriptMedia ?? [];
   const hasTranscriptMedia = transcriptMedia.length > 0;
   const suppressUserTurnPersistence =

--- a/src/agents/main-session-recovery/main-session-recovery-state.execution-identity.test.ts
+++ b/src/agents/main-session-recovery/main-session-recovery-state.execution-identity.test.ts
@@ -60,6 +60,82 @@ function claimForeground(entry: SessionEntry) {
 }
 
 describe("main session recovery execution identity state", () => {
+  it.each([false, true])(
+    "refreshes the budget only after a runtime turn starts (audit=%s)",
+    (audit) => {
+      const entry = interruptedEntry();
+      for (let attempt = 1; attempt <= 7; attempt++) {
+        const view = observe(entry, "generation-1");
+        if (view.status !== "recoverable") {
+          throw new Error("expected a recoverable session");
+        }
+        expect(view.nextAttempt).toBe(attempt);
+        expect(
+          transitionMainSessionRecovery(entry, {
+            kind: "prepare_attempt",
+            attempt,
+            lifecycleGeneration: "generation-1",
+            now: 200 + attempt,
+            observation: view.observation,
+            runId: "recovery-1",
+            executionIdentity: { state: audit ? "enabled" : "disabled" },
+          }).kind,
+        ).toBe("reserved");
+        expect(
+          transitionMainSessionRecovery(entry, {
+            kind: "admit_recovery",
+            lifecycleGeneration: "generation-1",
+            now: 300 + attempt,
+            runId: "recovery-1",
+            sessionId: "session-1",
+          }).kind,
+        ).toBe("admitted_recovery");
+        if (attempt <= 4) {
+          const registration = {
+            kind: "register_recovery_turn" as const,
+            attempt,
+            cycleId: "cycle-1",
+            lifecycleGeneration: "generation-1",
+            runId: "recovery-1",
+            sessionId: "session-1",
+          };
+          if (audit) {
+            transitionMainSessionRecovery(entry, {
+              ...registration,
+              kind: "bind_admitted_execution_identity",
+              token: executionIdentity("recovery-1"),
+            });
+          }
+          expect(transitionMainSessionRecovery(entry, registration).kind).toBe("applied");
+          expect(transitionMainSessionRecovery(entry, registration).kind).toBe("no_change");
+        }
+        transitionMainSessionRecovery(entry, {
+          kind: "mark_admitted_recovery_interrupted",
+          lifecycleGeneration: "generation-1",
+          now: 400 + attempt,
+          runId: "recovery-1",
+          sessionId: "session-1",
+        });
+      }
+      expect(observe(entry, "generation-1")).toMatchObject({ status: "exhausted" });
+      expect(entry.mainRestartRecovery).toMatchObject({ chargedAttempts: 7, startedAttempt: 4 });
+      expect(entry.mainRestartRecovery?.executionIdentity).toEqual(
+        audit ? executionIdentity("recovery-1") : undefined,
+      );
+      expect(
+        transitionMainSessionRecovery(entry, {
+          kind: "register_recovery_turn",
+          attempt: 4,
+          cycleId: "cycle-1",
+          lifecycleGeneration: "generation-1",
+          runId: "recovery-1",
+          sessionId: "session-1",
+        }),
+      ).toEqual({ kind: "rejected", reason: "stale_reservation" });
+      expect(observe(entry, "generation-1")).toMatchObject({ status: "exhausted" });
+    },
+  );
+
   it("keeps reservation identity-free and cancellation leaves no identity state", () => {
     const entry = interruptedEntry();
     const prepared = transitionMainSessionRecovery(entry, {

--- a/src/agents/main-session-recovery/main-session-recovery-state.ts
+++ b/src/agents/main-session-recovery/main-session-recovery-state.ts
@@ -53,6 +53,12 @@ function createCycle(cycleId: string): MainRestartRecoveryState {
   };
 }
 
+export function getMainSessionRecoveryRetryCount(
+  state: MainRestartRecoveryState | undefined,
+): number {
+  return state ? state.chargedAttempts - (state.startedAttempt ?? 0) : 0;
+}
+
 function matchesObservation(
   entry: SessionEntry,
   observation: MainSessionRecoveryObservation,
@@ -271,12 +277,13 @@ function inspectMainSessionRecovery(params: {
   if (state.reservation) {
     return { status: "blocked" };
   }
-  if (state.chargedAttempts >= MAX_RECOVERY_RETRIES) {
+  const retryCount = getMainSessionRecoveryRetryCount(state);
+  if (retryCount >= MAX_RECOVERY_RETRIES) {
     return {
       status: "exhausted",
       observation,
       reason:
-        `main-session restart recovery blocked after ${state.chargedAttempts} charged automatic resume attempts; ` +
+        `main-session restart recovery blocked after ${retryCount} automatic attempts without a started runtime turn; ` +
         MAIN_RESTART_RECOVERY_REMEDIATION_HINT,
     };
   }
@@ -454,13 +461,14 @@ export function transitionMainSessionRecovery(
         },
       };
     }
-    case "bind_admitted_execution_identity": {
+    case "bind_admitted_execution_identity":
+    case "register_recovery_turn": {
       const state = entry.mainRestartRecovery;
       if (
         !state ||
         state.cycleId !== command.cycleId ||
-        // Recovery may reuse its public run id. The charged attempt is the
-        // durable admission fence that rejects delayed binds from older work.
+        // Keep attempt identity monotonic across successful starts. Resetting the
+        // counter itself would let delayed admission callbacks match newer work.
         state.chargedAttempts !== command.attempt ||
         entry.sessionId !== command.sessionId ||
         entry.lifecycleRunId !== command.runId ||
@@ -471,15 +479,22 @@ export function transitionMainSessionRecovery(
       ) {
         return { kind: "rejected", reason: "stale_reservation" };
       }
-      if (state.executionIdentity) {
-        return JSON.stringify(state.executionIdentity) === JSON.stringify(command.token)
-          ? { kind: "no_change" }
-          : { kind: "rejected", reason: "stale_reservation" };
+      if (command.kind === "register_recovery_turn") {
+        if (state.startedAttempt === command.attempt) {
+          return { kind: "no_change" };
+        }
+        updateRecoveryState(entry, state, { startedAttempt: command.attempt });
+      } else {
+        if (state.executionIdentity) {
+          return JSON.stringify(state.executionIdentity) === JSON.stringify(command.token)
+            ? { kind: "no_change" }
+            : { kind: "rejected", reason: "stale_reservation" };
+        }
+        if (command.token.runId !== command.runId) {
+          return { kind: "rejected", reason: "stale_reservation" };
+        }
+        updateRecoveryState(entry, state, { executionIdentity: command.token });
       }
-      if (command.token.runId !== command.runId) {
-        return { kind: "rejected", reason: "stale_reservation" };
-      }
-      updateRecoveryState(entry, state, { executionIdentity: command.token });
       return { kind: "applied" };
     }
     case "cancel_reservation":
@@ -586,7 +601,7 @@ export function transitionMainSessionRecovery(
       if (state.tombstone) {
         return { kind: "rejected", reason: "already_tombstoned" };
       }
-      if (state.chargedAttempts >= MAX_RECOVERY_RETRIES) {
+      if (getMainSessionRecoveryRetryCount(state) >= MAX_RECOVERY_RETRIES) {
         // The final charge fences foreground work until the scheduler commits
         // the matching tombstone. Admitting here can race that reconciliation.
         return { kind: "rejected", reason: "recovery_exhausted" };

--- a/src/agents/main-session-recovery/main-session-recovery-types.ts
+++ b/src/agents/main-session-recovery/main-session-recovery-types.ts
@@ -99,6 +99,11 @@ export type MainSessionRecoveryCommand =
       cycleId: string;
       token: MainSessionRecoveryExecutionIdentity;
     } & RecoveryRunOwner)
+  | ({
+      kind: "register_recovery_turn";
+      attempt: number;
+      cycleId: string;
+    } & RecoveryRunOwner)
   | {
       kind: "cancel_reservation" | "abandon_reservation";
       reservation: MainSessionRecoveryReservation;

--- a/src/agents/main-session-recovery/main-session-restart-recovery-marking.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery-marking.ts
@@ -1,10 +1,8 @@
 import { randomUUID } from "node:crypto";
-import path from "node:path";
 import { resolveStateDir } from "../../config/paths.js";
-import {
-  type InternalSessionEntry as SessionEntry,
-  type RestartRecoveryRun,
-  resolveAllAgentSessionStoreTargetsSync,
+import type {
+  InternalSessionEntry as SessionEntry,
+  RestartRecoveryRun,
 } from "../../config/sessions.js";
 import { applySessionEntryReplacements } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -19,7 +17,6 @@ import {
   listActiveEmbeddedRunSessionIds,
   listActiveEmbeddedRunSessionKeys,
 } from "../embedded-agent-runner/run-state.js";
-import { resolveAgentSessionDirs } from "../session-dirs.js";
 import {
   isMainRestartRecoveryAggregateTerminalOnly,
   isMainRestartRecoveryCandidate,
@@ -27,6 +24,7 @@ import {
   transitionMainSessionRecovery,
 } from "./main-session-recovery-state.js";
 import {
+  discoverRestartRecoveryStorePaths,
   hasCurrentProcessOwner,
   mainSessionRecoveryLog,
   normalizeFiniteTimestamp,
@@ -117,28 +115,21 @@ export async function markRestartAbortedMainSessions(params: {
   }
 
   const storePaths = new Set<string>();
-  const env =
-    params.stateDir === undefined
-      ? process.env
-      : { ...process.env, OPENCLAW_STATE_DIR: params.stateDir };
-  const stateDir = resolveStateDir(env);
-  const configs = [params.cfg, ...(params.additionalCfgs ?? [])].filter(
-    (cfg): cfg is OpenClawConfig => Boolean(cfg),
-  );
-  for (const cfg of configs) {
+  const stateDir = params.stateDir ?? resolveStateDir(process.env);
+  const configs = [params.cfg, ...(params.additionalCfgs ?? [])].filter(Boolean);
+  for (const cfg of configs.length > 0 ? configs : [undefined]) {
     try {
-      for (const target of resolveAllAgentSessionStoreTargetsSync(cfg, { env })) {
-        storePaths.add(path.resolve(target.storePath));
+      for (const storePath of await discoverRestartRecoveryStorePaths({ cfg, stateDir })) {
+        storePaths.add(storePath);
       }
     } catch (err) {
+      if (!cfg) {
+        throw err;
+      }
       mainSessionRecoveryLog.warn(
         `failed to resolve configured session stores for restart marker: ${String(err)}`,
       );
     }
-  }
-
-  for (const sessionsDir of await resolveAgentSessionDirs(stateDir)) {
-    storePaths.add(path.join(sessionsDir, "sessions.json"));
   }
 
   for (const storePath of activeAdmissions.keys()) {

--- a/src/agents/main-session-recovery/main-session-restart-recovery-runtime.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery-runtime.ts
@@ -10,6 +10,7 @@ import {
   beginSessionWorkAdmission,
   cancelSessionWorkAdmissionHandoff,
 } from "../../sessions/session-lifecycle-admission.js";
+import { getMainSessionRecoveryRetryCount } from "./main-session-recovery-state.js";
 import { markStartupOrphanedMainSessionsForRecovery } from "./main-session-restart-recovery-marking.js";
 import {
   DEFAULT_RECOVERY_DELAY_MS,
@@ -248,8 +249,9 @@ export function scheduleRestartAbortedMainSessionRecoveryAfterOwnerRelease(param
       }
       if (
         finalAttempt &&
-        stillPending?.mainRestartRecovery?.chargedAttempts === MAX_RECOVERY_RETRIES &&
-        !stillPending.mainRestartRecovery.reservation
+        getMainSessionRecoveryRetryCount(stillPending?.mainRestartRecovery) ===
+          MAX_RECOVERY_RETRIES &&
+        !stillPending?.mainRestartRecovery?.reservation
       ) {
         // The last ambiguous dispatch consumed the final durable charge. One
         // exact observation tombstones exhaustion without dispatching again.

--- a/src/agents/main-session-recovery/main-session-restart-recovery-shared.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery-shared.ts
@@ -88,7 +88,7 @@ export function hasCurrentProcessOwner(params: {
   return params.activeSessionIds.size === 0 && params.activeSessionKeys.has(params.sessionKey);
 }
 
-export async function resolveRestartRecoveryStorePaths(params: {
+export async function discoverRestartRecoveryStorePaths(params: {
   cfg?: OpenClawConfig;
   stateDir?: string;
 }): Promise<string[]> {
@@ -121,9 +121,17 @@ export async function resolveRestartRecoveryStorePaths(params: {
       storePaths.add(path.join(sessionsDir, "sessions.json"));
     }
   }
-  // Agent databases also hold auth and model-catalog state. Enter the writer
-  // lane only when the session owner proves that a running row may need repair.
-  return [...storePaths]
-    .filter((storePath) => hasSessionEntriesByStatusReadOnly({ env, storePath }, ["running"]))
-    .toSorted((a, b) => a.localeCompare(b));
+  return [...storePaths].toSorted((a, b) => a.localeCompare(b));
+}
+
+export async function resolveRestartRecoveryStorePaths(
+  params: Parameters<typeof discoverRestartRecoveryStorePaths>[0],
+): Promise<string[]> {
+  const stateDir = params.stateDir ?? resolveStateDir(process.env);
+  const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+  // Startup recovery needs running rows; shutdown must also mark queued turns
+  // whose session still carries a prior terminal status.
+  return (await discoverRestartRecoveryStorePaths(params)).filter((storePath) =>
+    hasSessionEntriesByStatusReadOnly({ env, storePath }, ["running"]),
+  );
 }

--- a/src/agents/main-session-recovery/main-session-restart-recovery-store.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery-store.ts
@@ -26,6 +26,7 @@ import {
   listActiveEmbeddedRunSessionKeys,
 } from "../embedded-agent-runner/run-state.js";
 import {
+  getMainSessionRecoveryRetryCount,
   isMainRestartRecoveryAggregateTerminalOnly,
   isMainRestartRecoveryCandidate,
 } from "./main-session-recovery-state.js";
@@ -409,8 +410,8 @@ export async function recoverStore(params: {
           storePath: params.storePath,
         });
         if (
-          current?.mainRestartRecovery?.chargedAttempts === MAX_RECOVERY_RETRIES &&
-          !current.mainRestartRecovery.reservation
+          getMainSessionRecoveryRetryCount(current?.mainRestartRecovery) === MAX_RECOVERY_RETRIES &&
+          !current?.mainRestartRecovery?.reservation
         ) {
           params.onExhaustedTarget?.({
             canonicalSessionKey: dispatchSessionKey,

--- a/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
@@ -70,6 +70,7 @@ import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db
 import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { buildCurrentRunRestartRecoveryClaim } from "../agent-command-restart-recovery.js";
+import { beginAgentDeletion } from "../agent-lifecycle-registry.js";
 import { deliverAgentCommandResult } from "../command/delivery.js";
 import { setActiveEmbeddedRunLifecycleGeneration } from "../embedded-agent-runner/run-state.js";
 import {
@@ -694,6 +695,55 @@ describe("main-session-restart-recovery", () => {
 
     expect(storePaths).toContain(path.join(configuredSessionsDir, "sessions.json"));
     expect(storePaths).not.toContain(path.join(staleSessionsDir, "sessions.json"));
+  });
+
+  it("marks an admitted custom-store turn after a deleted agent leaves its directory behind", async () => {
+    await withEnvAsync({ OPENCLAW_STATE_DIR: tmpDir }, async () => {
+      const staleSessionsDir = await makeSessionsDir("retired-probe");
+      await writeMainSession({
+        sessionsDir: staleSessionsDir,
+        sessionKey: "agent:retired-probe:main",
+      });
+      closeOpenClawAgentDatabasesForTest();
+      const deletion = beginAgentDeletion({
+        agentId: "retired-probe",
+        agentDir: path.join(tmpDir, "agents", "retired-probe", "agent"),
+        workspaceDir: path.join(tmpDir, "workspace-retired-probe"),
+        sessionsDir: staleSessionsDir,
+        deleteFiles: false,
+      });
+      const storePath = path.join(tmpDir, "active-custom-store", "sessions.json");
+      const sessionKey = "agent:main:custom";
+      let admission: Awaited<ReturnType<typeof beginSessionWorkAdmission>> | undefined;
+      try {
+        await writeStorePath(storePath, {
+          [sessionKey]: runningSessionEntry("custom-session"),
+        });
+        admission = await beginSessionWorkAdmission({
+          scope: storePath,
+          identities: [sessionKey, "custom-session"],
+          assertAllowed: () => undefined,
+        });
+
+        await expect(
+          markRestartAbortedMainSessions({
+            cfg: { agents: { list: [{ id: "main", default: true }] } },
+            stateDir: tmpDir,
+            activeRuns: [],
+          }),
+        ).resolves.toEqual({ marked: 1, skipped: 0 });
+        expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
+          sessionId: "custom-session",
+          abortedLastRun: true,
+          restartRecoveryForceSafeTools: true,
+        });
+      } finally {
+        admission?.release();
+        deletion.rollback();
+        closeOpenClawAgentDatabasesForTest();
+        closeOpenClawStateDatabaseForTest();
+      }
+    });
   });
 
   it("keeps a configured fixed store when its path carries a retired owner id", async () => {

--- a/src/config/sessions/main-session-recovery.types.ts
+++ b/src/config/sessions/main-session-recovery.types.ts
@@ -5,6 +5,8 @@ export type MainRestartRecoveryState = {
   revision: number;
   /** Attempts charged when their reservation is persisted, before dispatch. */
   chargedAttempts: number;
+  /** Last attempt observed starting a backend turn; later startup failures get a fresh budget. */
+  startedAttempt?: number;
   /** Private safe token for one recovered outer turn; raw identity refs never enter session state. */
   executionIdentity?: {
     tokenVersion: 1;

--- a/src/config/sessions/session-snapshot-merge.test.ts
+++ b/src/config/sessions/session-snapshot-merge.test.ts
@@ -382,6 +382,29 @@ describe("session snapshot merge", () => {
     expect(mergeSessionSnapshotChanges({ initial, next, current })).toEqual(current);
   });
 
+  it("projects a runtime admission without losing its refreshed recovery budget", () => {
+    const initialRecovery: SessionEntry = {
+      ...initial,
+      mainRestartRecovery: { cycleId: "cycle-1", revision: 4, chargedAttempts: 3 },
+    };
+    const next: SessionEntry = {
+      ...initialRecovery,
+      mainRestartRecovery: {
+        ...initialRecovery.mainRestartRecovery!,
+        revision: 5,
+        startedAttempt: 3,
+      },
+    };
+
+    const merged = mergeSessionSnapshotChanges({
+      initial: initialRecovery,
+      next,
+      current: initialRecovery,
+    });
+
+    expect(merged.mainRestartRecovery).toEqual(next.mainRestartRecovery);
+  });
+
   it("preserves the recovery aggregate when a restart marker wins a stale healthy clear", () => {
     const initialRecovery: SessionEntry = {
       ...initial,

--- a/src/config/sessions/session-snapshot-merge.ts
+++ b/src/config/sessions/session-snapshot-merge.ts
@@ -63,6 +63,7 @@ function mainSessionRecoveryTransactionChanged(before: SessionEntry, after: Sess
     !isDeepStrictEqual(before.restartRecoveryRuns, after.restartRecoveryRuns) ||
     beforeState?.cycleId !== afterState?.cycleId ||
     beforeState?.chargedAttempts !== afterState?.chargedAttempts ||
+    beforeState?.startedAttempt !== afterState?.startedAttempt ||
     !isDeepStrictEqual(beforeState?.reservation, afterState?.reservation) ||
     !isDeepStrictEqual(beforeState?.tombstone, afterState?.tombstone)
   );
@@ -90,6 +91,7 @@ function mainSessionRecoveryCycleStateUnchanged(
   return (
     beforeState.cycleId === afterState.cycleId &&
     beforeState.chargedAttempts === afterState.chargedAttempts &&
+    beforeState.startedAttempt === afterState.startedAttempt &&
     isDeepStrictEqual(beforeState.reservation, afterState.reservation) &&
     isDeepStrictEqual(beforeState.tombstone, afterState.tombstone)
   );

--- a/src/gateway/agent-turn/agent-session-persist.ts
+++ b/src/gateway/agent-turn/agent-session-persist.ts
@@ -1,7 +1,10 @@
 import { randomUUID } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
-import { transitionMainSessionRecovery } from "../../agents/main-session-recovery/main-session-recovery-state.js";
+import {
+  getMainSessionRecoveryRetryCount,
+  transitionMainSessionRecovery,
+} from "../../agents/main-session-recovery/main-session-recovery-state.js";
 import type { MainSessionRecoveryOwnerLease } from "../../agents/main-session-recovery/main-session-recovery-store.js";
 import { MAX_RECOVERY_RETRIES } from "../../agents/main-session-recovery/main-session-restart-recovery-shared.js";
 import {
@@ -210,7 +213,7 @@ export async function persistAgentSessionPhase(params: {
               (internalFreshEntry.mainRestartRecovery?.tombstone ||
                 (internalFreshEntry.status === "running" &&
                   internalFreshEntry.abortedLastRun === true &&
-                  (internalFreshEntry.mainRestartRecovery?.chargedAttempts ?? 0) >=
+                  getMainSessionRecoveryRetryCount(internalFreshEntry.mainRestartRecovery) >=
                     MAX_RECOVERY_RETRIES))
             ) {
               restartRecoveryReservationConflict =

--- a/ui/src/pages/chat/chat-history-cursor.test.ts
+++ b/ui/src/pages/chat/chat-history-cursor.test.ts
@@ -150,71 +150,96 @@ describe("chat history cursor revalidation", () => {
     ).toBe("cursor-2");
   });
 
-  it("restores active commentary and tools with an empty cached delta", async () => {
-    const cached = message("user", "cached", "cached-user", 1);
-    const handler = vi.fn(async (_params?: unknown) => ({
-      kind: "delta",
-      messages: [],
-      deltaCursor: "cursor-2",
-      sessionInfo: {
-        key: "main",
-        kind: "direct",
-        sessionId: "session-cursor",
-        updatedAt: 2,
-        hasActiveRun: true,
-        activeRunIds: ["run-live"],
-        status: "running",
-      },
-      inFlightRun: {
-        runId: "run-live",
-        text: "",
-        startedAt: 900,
-        events: [
-          {
-            runId: "run-live",
-            seq: 1,
-            stream: "item",
-            ts: 900,
-            sessionKey: "main",
-            data: {
-              kind: "preamble",
-              itemId: "preamble-restored",
-              progressText: "Checking the workspace",
+  it.each([
+    { kind: "delta", persistedRunId: undefined },
+    { kind: "delta", persistedRunId: "run-live" },
+    { kind: "delta", persistedRunId: "run-other" },
+    { kind: "full", persistedRunId: "run-live" },
+  ] as const)(
+    "restores active commentary once from $kind history with persisted owner $persistedRunId",
+    async ({ kind, persistedRunId }) => {
+      const cached = message("user", "cached", "cached-user", 1);
+      const commentary = {
+        ...message("assistant", "Checking the workspace", "persisted-commentary", 2),
+        __openclaw: { id: "persisted-commentary", seq: 2, runId: persistedRunId },
+        openclawStreamFallback: {
+          itemId: "preamble-restored",
+          replacementText: "Checking the workspace",
+          source: "segment",
+        },
+      };
+      const cachedMessages = persistedRunId ? [cached, commentary] : [cached];
+      const handler = vi.fn(async (_params?: unknown) => ({
+        ...(kind === "delta"
+          ? { kind: "delta", messages: [], deltaCursor: "cursor-2" }
+          : { messages: cachedMessages }),
+        sessionInfo: {
+          key: "main",
+          kind: "direct",
+          sessionId: "session-cursor",
+          updatedAt: 2,
+          hasActiveRun: true,
+          activeRunIds: ["run-live"],
+          status: "running",
+        },
+        inFlightRun: {
+          runId: "run-live",
+          text: "",
+          startedAt: 900,
+          events: [
+            {
+              runId: "run-live",
+              seq: 1,
+              stream: "item",
+              ts: 900,
+              sessionKey: "main",
+              data: {
+                kind: "preamble",
+                itemId: "preamble-restored",
+                progressText: "Checking the workspace",
+              },
             },
-          },
-          {
-            runId: "run-live",
-            seq: 2,
-            stream: "tool",
-            ts: 1_000,
-            sessionKey: "main",
-            data: {
-              toolCallId: "call-restored",
-              name: "read",
-              phase: "start",
-              args: { path: "README.md" },
+            {
+              runId: "run-live",
+              seq: 2,
+              stream: "tool",
+              ts: 1_000,
+              sessionKey: "main",
+              data: {
+                toolCallId: "call-restored",
+                name: "read",
+                phase: "start",
+                args: { path: "README.md" },
+              },
             },
-          },
-        ],
-      },
-    }));
-    const state = createState(handler);
-    seedCachedHistory(state, [cached], "cursor-1");
+          ],
+        },
+      }));
+      const state = createState(handler);
+      if (kind === "delta") {
+        seedCachedHistory(state, cachedMessages, "cursor-1");
+      }
 
-    await loadHistoryWithBrowserTimers(state);
+      await loadHistoryWithBrowserTimers(state);
 
-    expect(state.chatRunId).toBe("run-live");
-    expect(state.chatStreamSegments).toContainEqual(
-      expect.objectContaining({
-        itemId: "preamble-restored",
-        runId: "run-live",
-        text: "Checking the workspace",
-      }),
-    );
-    expect(state.chatToolMessages).toContainEqual(
-      expect.objectContaining({ runId: "run-live", toolCallId: "call-restored" }),
-    );
-  });
+      expect(state.chatRunId).toBe("run-live");
+      if (persistedRunId === "run-live") {
+        expect(state.chatStreamSegments).toEqual([]);
+      } else {
+        expect(state.chatStreamSegments).toContainEqual(
+          expect.objectContaining({
+            itemId: "preamble-restored",
+            runId: "run-live",
+            text: "Checking the workspace",
+          }),
+        );
+      }
+      expect(state.chatMessages).toEqual(cachedMessages);
+      expect(state.chatToolMessages).toContainEqual(
+        expect.objectContaining({ runId: "run-live", toolCallId: "call-restored" }),
+      );
+    },
+  );
 
   it("clears a rejected cursor before falling back to a full tail fetch", async () => {
     const cached = message("user", "cached", "cached-user", 1);

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -139,44 +139,51 @@ describe("canonical session message recovery", () => {
     });
   });
 
-  it("retires live commentary when its durable row arrives during an active run", () => {
-    const runId = "active-run";
-    const itemId = "commentary-1";
-    const text = "Checking the workspace.";
-    const { state } = createSessionEventState({
-      connected: false,
-      chatMessages: [],
-      chatRunId: runId,
-      chatStream: null,
-      chatStreamSegments: [{ text, ts: 1, runId, itemId }],
-      chatToolMessages: [],
-    });
+  it.each(["active-run", undefined])(
+    "retires durable mirrored commentary owned by %s",
+    (ownerRunId) => {
+      const runId = "active-run";
+      const itemId = "commentary-1";
+      const text = "Checking the workspace.";
+      const { state } = createSessionEventState({
+        connected: false,
+        chatMessages: [],
+        chatRunId: runId,
+        chatStream: null,
+        chatStreamSegments: [{ text, ts: 1, runId, itemId }],
+        chatToolMessages: [],
+      });
 
-    applySessionMessagePayload(
-      state,
-      {
-        sessionKey: state.sessionKey,
-        messageId: "commentary-message-1",
-        messageSeq: 1,
-        message: {
-          role: "assistant",
-          content: [{ type: "text", text }],
-          idempotencyKey: `codex-app-server:thread:turn:commentary:${itemId}`,
-          timestamp: 1,
-          openclawStreamFallback: {
-            replacementText: text,
-            source: "segment",
-            itemId,
+      applySessionMessagePayload(
+        state,
+        {
+          sessionKey: state.sessionKey,
+          messageId: "commentary-message-1",
+          messageSeq: 1,
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text }],
+            idempotencyKey: `codex-app-server:thread:turn:commentary:${itemId}`,
+            __openclaw: {
+              mirrorOrigin: "codex-app-server",
+              ...(ownerRunId ? { runId: ownerRunId } : {}),
+            },
+            timestamp: 1,
+            openclawStreamFallback: {
+              replacementText: text,
+              source: "segment",
+              itemId,
+            },
           },
         },
-      },
-      true,
-      { kind: "history-delta" },
-    );
+        true,
+        { kind: "history-delta" },
+      );
 
-    expect(state.chatStreamSegments).toEqual([]);
-    expect(renderedTranscript(state)).toEqual([{ role: "assistant", text }]);
-  });
+      expect(state.chatStreamSegments).toEqual([]);
+      expect(renderedTranscript(state)).toEqual([{ role: "assistant", text }]);
+    },
+  );
 
   it("retires the complete transient projection when the durable terminal arrives", () => {
     const runId = "active-run";

--- a/ui/src/pages/chat/chat-thread-run-identity.ts
+++ b/ui/src/pages/chat/chat-thread-run-identity.ts
@@ -23,13 +23,20 @@ export function transcriptRunId(message: unknown): string | undefined {
   );
 }
 
-export function isKeyedAssistantStreamFallbackMessage(message: unknown): boolean {
+export function readAssistantStreamSegmentIdentity(
+  message: unknown,
+): { itemId: string; runId?: string } | undefined {
   const record = asRecord(message);
   if (normalizeLowercaseStringOrEmpty(record?.role) !== "assistant") {
-    return false;
+    return undefined;
   }
   const fallback = asRecord(record?.openclawStreamFallback);
-  return typeof fallback?.itemId === "string" && fallback.itemId.trim().length > 0;
+  const itemId = normalizeOptionalString(fallback?.itemId);
+  return itemId ? { itemId, ...optionalRunIdentity(transcriptRunId(message)) } : undefined;
+}
+
+export function isKeyedAssistantStreamFallbackMessage(message: unknown): boolean {
+  return readAssistantStreamSegmentIdentity(message) !== undefined;
 }
 
 export function optionalRunIdentity(value: unknown): { runId: string } | undefined {

--- a/ui/src/pages/chat/stream-segment-pruning.ts
+++ b/ui/src/pages/chat/stream-segment-pruning.ts
@@ -1,4 +1,3 @@
-import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   advanceAccumulatedStreamText,
@@ -7,6 +6,7 @@ import {
   trimAccumulatedStreamPrefix,
   type ChatStreamSegment,
 } from "../../lib/chat/chat-types.ts";
+import { readAssistantStreamSegmentIdentity } from "./chat-thread-run-identity.ts";
 import { streamCausalInterval, type StreamCausalBoundaryState } from "./stream-causal-boundary.ts";
 import {
   hasAssistantStreamPartReplacement,
@@ -74,14 +74,17 @@ export function prunePersistedAssistantStreamSegments(
   state: StreamCausalBoundaryState,
   message: unknown,
 ): void {
-  const fallback = asNullableRecord(asNullableRecord(message)?.openclawStreamFallback);
-  const itemId = normalizeOptionalString(fallback?.itemId);
-  if (!itemId || !state.chatStreamSegments) {
+  const identity = readAssistantStreamSegmentIdentity(message);
+  if (!identity || !state.chatStreamSegments) {
     return;
   }
-  const replacedIndexes = state.chatStreamSegments.flatMap((segment, index) =>
-    normalizeOptionalString(segment.itemId) === itemId ? [index] : [],
-  );
+  const replacedIndexes = state.chatStreamSegments.flatMap((segment, index) => {
+    const runId = normalizeOptionalString(segment.runId);
+    // Client-materialized commentary can be untagged; known run ownership
+    // must still prevent a reused item id from pruning a sibling run.
+    const sameRun = !identity.runId || !runId || identity.runId === runId;
+    return normalizeOptionalString(segment.itemId) === identity.itemId && sameRun ? [index] : [];
+  });
   discardStreamSegmentIndexes(state, replacedIndexes);
 }
 

--- a/ui/src/pages/chat/tool-stream-fallback.node.test.ts
+++ b/ui/src/pages/chat/tool-stream-fallback.node.test.ts
@@ -5,6 +5,7 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { SessionsListResult } from "../../api/types.ts";
 import { createSessionCapability } from "../../lib/sessions/index.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
+import { prunePersistedAssistantStreamSegments } from "./stream-segment-pruning.ts";
 import {
   agentEvent,
   createHost,
@@ -381,6 +382,43 @@ describe("app-tool-stream fallback lifecycle handling", () => {
     expect(host.chatStream).toBeNull();
     vi.useRealTimers();
   });
+
+  it.each(["run-1", "run-2", undefined])(
+    "replaces only the commentary owned by persisted run %s",
+    (runId) => {
+      const state = createHost({
+        chatStreamSegments: [
+          { itemId: "shared-item", runId: "run-1", text: "First run", ts: 1 },
+          { itemId: "shared-item", runId: "run-2", text: "Second run", ts: 2 },
+        ],
+      });
+      const originalSegments = [...state.chatStreamSegments];
+      const persisted = {
+        role: "assistant",
+        content: "Completed progress",
+        __openclaw: { id: "persisted-commentary", seq: 3, ...(runId ? { runId } : {}) },
+        openclawStreamFallback: { itemId: "shared-item", source: "segment" },
+      };
+      prunePersistedAssistantStreamSegments(state, persisted);
+      expect(state.chatStreamSegments).toEqual(
+        runId ? originalSegments.filter((segment) => segment.runId !== runId) : [],
+      );
+      if (runId) {
+        state.chatMessages = [persisted];
+        handleAgentEvent(
+          state,
+          agentEvent(runId, 4, "item", {
+            kind: "preamble",
+            itemId: "shared-item",
+            progressText: "Completed progress",
+          }),
+        );
+        expect(state.chatStreamSegments).toEqual(
+          originalSegments.filter((segment) => segment.runId !== runId),
+        );
+      }
+    },
+  );
 
   it.each([
     { progressText: "Another run's commentary", name: "replace" },

--- a/ui/src/pages/chat/tool-stream.ts
+++ b/ui/src/pages/chat/tool-stream.ts
@@ -26,6 +26,7 @@ import { formatUnknownText, truncateText } from "../../lib/format.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
 import { uiSessionEventMatches } from "../../lib/sessions/session-key.ts";
 import type { ChatRunStartupState } from "./chat-run-startup.ts";
+import { readAssistantStreamSegmentIdentity } from "./chat-thread-run-identity.ts";
 import { rolloverChatStream } from "./stream-causal-boundary.ts";
 import { buildToolStreamIdentity } from "./tool-stream-identity.ts";
 
@@ -80,6 +81,7 @@ export type ToolStreamHost = {
   agentsList?: { defaultId?: string | null } | null;
   hello?: { snapshot?: unknown } | null;
   chatRunId: string | null;
+  chatMessages?: unknown[];
   chatRunUsageById?: Map<string, number>;
   chatStream: string | null;
   chatStreamStartedAt: number | null;
@@ -864,6 +866,20 @@ function handlePreambleProgressEvent(host: ToolStreamHost, payload: AgentEventPa
   // Preambles belong to the visible run; a sibling run must never replace,
   // clear, or persist its commentary into this transcript.
   if (!resolveAcceptedSession(host, payload, { allowSessionScopedWhenIdle: true }).accepted) {
+    return true;
+  }
+  const persisted =
+    progress.itemId &&
+    host.chatMessages?.some((message) => {
+      const identity = readAssistantStreamSegmentIdentity(message);
+      return identity?.itemId === progress.itemId && identity?.runId === payload.runId;
+    });
+  if (persisted) {
+    // A history snapshot or delayed live event can follow the durable row.
+    // Its exact run/item owner already renders the commentary.
+    host.chatStreamSegments = host.chatStreamSegments.filter(
+      (segment) => segment.itemId !== progress.itemId || segment.runId !== payload.runId,
+    );
     return true;
   }
   if (progress.itemId && !progress.text.trim()) {


### PR DESCRIPTION
Closes #131523

## What Problem This Solves

Fixes an issue where users running long WebChat tasks could lose automatic continuation after repeated Gateway restarts, even when earlier recoveries had successfully resumed work. Completed Codex commentary and tool results could also disappear from WebChat after abrupt teardown because they had not yet been mirrored from the native turn.

## Why This Change Was Made

Recovery now records the last attempt that reached a real backend turn start and counts failed starts since that point. The attempt identifier remains monotonic, and registration revalidates the exact session, recovery cycle, attempt, lifecycle generation, cancellation state, and live execution authority. Gateway admission, authentication setup, and CLI process launch do not refresh the allowance. Audit provenance remains optional and separate. Command teardown joins the pending registration before closing its exact admission, including when the runtime fails after starting; observational runtime events remain non-blocking and explicit cancellation stays immediate.

The Codex plugin checkpoints completed commentary and observed tool records through the existing SQLite transcript mirror during the turn. One ordered queue preserves message order and stable mirror identities, waits for linked raw patch results, and keeps dynamic-tool replay attached to the original execution claim. Final answers remain finalizer-owned. The Control UI reconciles persisted and streamed commentary by run/item identity in either arrival order.

Shutdown recovery marking now uses the configured agent roster and active admissions, removing the duplicate directory scan that could open a deleted agent's leftover store and abort marking unrelated active sessions. No configuration, dependency, protocol, or SQLite schema change is introduced.

## User Impact

Healthy recoveries no longer spend a lifetime allowance for the whole recovery cycle. Three consecutive starts that never reach backend acceptance still stop automatically with a visible recovery outcome. Completed Codex work survives restart and appears once after reload. This does not retroactively recover an already-exhausted session or promise that a native Codex thread ID remains unchanged.

## Evidence

Local verification passed 1,356 distinct tests across recovery, command lifecycle, Codex projection/mirroring, and Control UI history. The final helper reorganization passed all 150 `run-attempt.test.ts` integration tests, plugin typechecks, and lint. Core/UI/plugin typechecks, all changed-file check stages, the source Gateway build, and the Control UI build passed. The combined check initially found return-style and file-size lint violations; those were corrected and the affected stages rerun. Fresh Codex autoreview found no actionable P0 findings. A clean rebase preserved the patch exactly (`git range-diff`); all 182 post-rebase recovery tests passed.

The first hosted CI run exposed a type-only dependency cycle and missing awaits in callback tests; these were corrected. An existing history fixture now matches the mirror metadata emitted by the producer, including owned and unowned history. The callback and UI reruns passed 128 tests, architecture checking reports zero cycles, and all 13 tests in the settings/capability-menu Chromium E2E files passed. The E2E repairs keep the same assertions while targeting the outer disclosure and reading the shared accessible tooltip; the latter reuses only the test fix from commit `ec1fb32396a5924d5e0e27a5144746afe571c19b` in #131471, without its typography changes. Both E2E repairs subsequently landed independently in #131471 and #131541; rebasing onto main removed them from this PR's diff, retaining the canonical main versions. The focused Codex rerun passed all 18 projector files, but two run-attempt elicitation tests hit their separate one-second handler wait. Those tests now reuse the canonical app-server harness, deleting the duplicate client fixture and preserving their routing assertions; all 150 run-attempt tests then passed in their original order. Together with the 266 passing projector tests, all 416 selected Codex tests are covered. Fresh bounded P0 autoreview of the complete correction batch reported no actionable findings. All 14 UI E2E shards and the real-Gateway UI lane passed on the rebased head in CI run 33144359451; the earlier service-worker failure did not recur, so #131439 is no longer a prerequisite for this landing. That separate PR remains outside this change. The assertion ratchet then required a SAFETY comment on the moved helper and removal of its old unused baseline entry; the local ratchet and fresh bounded P0 review pass after that metadata-only correction.

ClawSweeper identified a real detached-write teardown race: the callback could return before registration reached a busy SQLite writer, allowing command cleanup to close its authority. A regression through the actual command owner holds the real writer and reproduces both completed/failed command paths before the fix. The owner now joins that memoized write before its existing synchronous close. All 143 command/admission tests pass, including both new cases and existing closed/stale/pre-start fences. Shutdown retains the existing ordering of registration, queued recovery marking, then abort. The final comment layout also passes both formatting and the assertion ratchet; the previous CI run's docs/lint failures were both that formatting issue.

The following CI run found the new core command fixture still used public `SessionEntry`, which excludes internal recovery fields. The fixture now uses `InternalSessionEntry`; the full agents-root test typecheck passes locally, emitted JavaScript is byte-identical, and bounded P0 review is clean.

[Exact-head CI run 33146321519](https://github.com/openclaw/openclaw/actions/runs/33146321519) and the required `openclaw/ci-gate` are green on `e1254a38cbc7b87c16ede16231086eb8557f766b` (attempt 2). Attempt 1 passed all sibling jobs, but the real-Gateway settings test timed out finding Raw during a second navigation after successfully saving and validating the exact 64-bit string. The affected auth/settings step passed on one unchanged diagnostic rerun; this does not establish or repair the timing failure's cause. The relevant settings implementation is unchanged from its preceding passing build. Follow-up: capture the final route, DOM, and page errors for failures in this config-readback navigation; current logs do not establish the cause.

The real isolated Gateway and Chrome Control UI were exercised with a synthetic Codex app-server. Accepted proof runs used dummy authentication, isolated HOME/state/workspace, a disabled observer, and an OS sandbox blocking external network/auth access. They made zero outbound model calls and did not modify an operator Gateway. This is backend-fixture proof through the real Gateway/UI, not live-provider inference.

```json
{
  "healthyRecoveryCycles": 4,
  "chargedAndStarted": [[1,1],[2,2],[3,3],[4,4]],
  "sameOpenClawSession": true,
  "completedWorkSetsRetained": 5,
  "startsInterruptedBeforeAcceptance": 3,
  "extraNativeRequestAfterExhaustion": false,
  "visibleExhaustionOutcome": true,
  "commentaryAndToolResultsAfterReload": "exactly once",
  "outboundModelCalls": 0
}
```

Before: the installed baseline loses the first turn's completed progress/tool history after restart.

![Before: earlier completed work missing after restart](https://github.com/user-attachments/assets/fa43b679-3be4-4d74-ad76-f3530cff3550)

Intermediate UI reproduction: incremental persistence exposed duplicate current commentary on reload.

![Before UI reconciliation: duplicate commentary](https://github.com/user-attachments/assets/ae23956a-7f64-49bc-ba38-3474ce4e4944)

After: both completed progress messages and expanded tool results survive recovery and appear once.

![After: retained progress and tool results without duplicates](https://github.com/user-attachments/assets/75b7596f-a0b2-4787-a40e-f2c3c44554ee)

The browser control interface did not provide video recording, so screenshots and DOM assertions document the flow. The final behavior-neutral helper relocation followed these captures and was covered by the integration rerun. A separate observation remains outside this fix: after abrupt SIGKILL, the original synthetic send can remain shown as a “Waiting for reconnect” draft; this PR does not change draft-queue semantics.

<details>
<summary>Commands, ownership, and dependency evidence</summary>

Representative verification commands:

```sh
node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-support.config.ts src/agents/main-session-recovery/main-session-restart-recovery.test.ts src/agents/main-session-recovery/main-session-recovery-state.execution-identity.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-codex.config.ts extensions/codex/src/app-server/run-attempt.test.ts
node scripts/run-tsgo.mjs -p tsconfig.extensions.json
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json
node --import ./scripts/tsx.mjs scripts/build-all.mts qaRuntime
OPENCLAW_BUILD_ALL_NO_PNPM=1 node scripts/ui.js build
git diff --check
```

The lifecycle tests cover audit enabled/disabled, startup failure, cancellation, stale attempts, and closed authority. Shared callback tests cover embedded runtimes and CLI activity; CLI process spawn alone does not count as a started turn. Transcript coverage includes interrupted turns, dynamic-tool replay, raw patch results, commentary preferences, and hidden/tainted output. UI tests cover persisted-first and streamed-first arrival, delayed events, full/cached history reload, and sibling runs sharing an item ID.

The lead directly inspected upstream Codex source at `18b9e7fd9e3f6670cc4f300338e44050b2c301e4`: `codex-rs/app-server/src/request_processors/turn_processor.rs:627` (native turn acceptance), `codex-rs/app-server/src/bespoke_event_handling.rs:161` (turn-start event), and `codex-rs/core/src/session/mod.rs:3241` (persisted response items before raw-item emission).

Best-fix judgment: refresh at the real turn owner, not Gateway admission; preserve completed records at the event producer, not via a post-crash reconstruction path; use roster-aware shutdown discovery, not swallowed deleted-store errors. Resetting the attempt identifier itself would weaken stale-callback fencing. Increasing the retry cap or finalizer timeout would leave the defects intact.

Production LOC: +428/-181 (net +247). Tests/test support: +841/-201 (net +640). Documentation: +16; assertion-baseline metadata: -1. Production growth supplies incremental durable transcript persistence and exact started-turn registration through existing owners; no parallel store or new policy surface is added.

Provenance: the lifetime recovery cap originates in #96230, authored by @zhangguiping-xydt and merged by @steipete on 2026-07-17, and was carried forward by @steipete in #117383. The finalizer-only mirror is visible in commit `323a9fbe29b4645ea6284391fd99a1504ebd9b07` (2026-07-13, @steipete); that refactor is evidence of the existing architecture, not proof of its first introduction. The duplicate shutdown directory scan is blamed to commit `1dcb35b204d6` (2026-07-25, @steipete).

</details>

AI-assisted with Codex.
