### PR TITLE
fix(code-mode): correct MCP array union declarations

### DIFF
--- a/src/agents/code-mode-mcp-api.ts
+++ b/src/agents/code-mode-mcp-api.ts
@@ -140,7 +140,7 @@ function schemaType(schema: unknown): string {
     case "boolean":
       return "boolean";
     case "array":
-      return `${schemaType(schema.items)}[]`;
+      return `Array<${schemaType(schema.items)}>`;
     case "object":
       return renderInlineObjectType(schema);
     case "null":

--- a/src/agents/code-mode-namespaces.test.ts
+++ b/src/agents/code-mode-namespaces.test.ts
@@ -74,6 +74,69 @@ describe("Code Mode MCP namespace model", () => {
     );
   });
 
+  it.each([
+    {
+      name: "enum",
+      items: { type: "string", enum: ["red", "blue"] },
+      declaration: 'Array<"red" | "blue">',
+    },
+    {
+      name: "anyOf",
+      items: { anyOf: [{ type: "string" }, { type: "number" }] },
+      declaration: "Array<string | number>",
+    },
+    {
+      name: "oneOf",
+      items: { oneOf: [{ type: "boolean" }, { type: "null" }] },
+      declaration: "Array<boolean | null>",
+    },
+    {
+      name: "multiple types",
+      items: { type: ["string", "null"] },
+      declaration: "Array<string | null>",
+    },
+    {
+      name: "nested array",
+      items: { type: "array", items: { type: "string", enum: ["red", "blue"] } },
+      declaration: 'Array<Array<"red" | "blue">>',
+    },
+    {
+      name: "simple array",
+      items: { type: "string" },
+      declaration: "Array<string>",
+    },
+    {
+      name: "object",
+      items: { type: "object", properties: { id: { type: "string" } }, required: ["id"] },
+      declaration: "Array<{ id: string }>",
+    },
+  ])("preserves $name item grouping in MCP API declarations", async ({ items, declaration }) => {
+    const parameters = {
+      type: "object",
+      properties: { values: { type: "array", items } },
+      required: ["values"],
+    };
+    const runtime = createCodeModeNamespaceRuntime([
+      mcpCatalogEntry({ id: "github__read_file", parameters }),
+    ]);
+    const executeTool = vi.fn();
+    const api = await runtime.invoke(
+      "mcp",
+      ["github", "$api"],
+      ["readFile", { schema: true }],
+      executeTool,
+    );
+
+    expect(runtime.apiFiles.find((file) => file.path === "mcp/github.d.ts")?.content).toContain(
+      `values: ${declaration};`,
+    );
+    expect(api).toMatchObject({
+      header: expect.stringContaining(`values: ${declaration};`),
+      schemas: { readFile: parameters },
+    });
+    expect(executeTool).not.toHaveBeenCalled();
+  });
+
   it.each(["constructor", "toString", "__proto__"])(
     "does not satisfy required MCP argument %s from Object.prototype",
     async (key) => {

--- a/src/agents/code-mode.mcp.test.ts
+++ b/src/agents/code-mode.mcp.test.ts
@@ -53,6 +53,7 @@ describe("Code Mode MCP namespace", () => {
           repo: { type: "string", description: "Repository 名称" },
           title: { type: "string", description: "Issue title\nShown in tracker" },
           body: { type: "string", default: "" },
+          labels: { type: "array", items: { type: "string", enum: ["red", "blue"] } },
         },
         required: ["owner", "repo", "title"],
       },
@@ -83,6 +84,7 @@ describe("Code Mode MCP namespace", () => {
           owner: "openclaw",
           repo: "openclaw",
           title: "Ship it",
+          labels: ["red", "blue"],
         });
         const createdPayload = JSON.parse(created.content[0].text);
         const searchHits = await catalog.search("github create issue", { limit: 5 });
@@ -117,6 +119,7 @@ describe("Code Mode MCP namespace", () => {
           repo: "openclaw",
           title: "Ship it",
           body: "",
+          labels: ["red", "blue"],
         },
       },
       leakedInternalDetails: false,
@@ -147,6 +150,8 @@ describe("Code Mode MCP namespace", () => {
     expect(value.apiHeader).toContain("@param title Issue title Shown in tracker");
     expect(value.apiHeader).not.toContain("@param title Issue title\n");
     expect(value.apiHeader).toContain("title: string;");
+    expect(value.apiHeader).toContain('labels?: Array<"red" | "blue">;');
+    expect(value.serverFileContent).toContain('labels?: Array<"red" | "blue">;');
     expect(githubCreate.execute).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
Closes #131476 — Code Mode MCP array-union declarations have incorrect precedence.

## What Problem This Solves

Fixes an issue where agents using Code Mode's MCP declarations could be guided toward invalid arguments when an array's item schema contained a union. For example, an array of `"red"` or `"blue"` was advertised as `"red" | "blue"[]`: that accepts scalar `"red"` but rejects an array containing `"red"`. Both `API.read("mcp/<server>.d.ts")` and `MCP.<server>.$api()` were affected.

## Why This Change Was Made

Use `Array<...>` in the existing recursive MCP schema renderer, matching the compact schema-hint renderer's established grouping. Both declaration surfaces already share this owner, so one expression repairs enum, `anyOf`, `oneOf`, multi-type, and nested-array item grouping without a new helper, downstream workaround, or alternate path. Actual MCP schemas and validation are unchanged.

The incorrect expression was introduced in the typed MCP API work, #88678 (authored and merged by @steipete on May 31, 2026), and carried into the renderer extraction in #115459. It is also present in stable tag `v2026.7.1-2`; that is tagged-source evidence, not a run of the historical binary.

## User Impact

Code Mode now advertises array arguments that agree with the MCP server's schema, including arrays mixing valid enum or union members. The existing namespace, call shape, permissions, and output behavior remain unchanged. No dependency, configuration, SQLite, protocol, or budget changes are included. The existing Code Mode documentation already describes these inferred declarations; this restores that documented contract.

## Evidence

Production LOC: **+1/-1 (net 0)**. Tests: **+68/-0**. Three files; no new production abstraction or test-only production seam.

- Fresh regression run before the production edit: **8 failed, 19 passed**. The failures showed the incorrect declarations, including the existing real QuickJS MCP test reaching its fixture executor and then failing on `labels?: "red" | "blue"[]`.
- After the repair: **40 focused tests passed** across the namespace, real Code Mode/QuickJS MCP, and compact schema-hint suites. The table covers enum, `anyOf`, `oneOf`, multi-type, nested, simple, and object arrays on both declaration surfaces.
- An unchanged independent TypeScript compiler/MCP SDK schema-validation probe went from **22 mismatches in 60 checks** to **zero mismatches in all 60**. It includes valid arrays, scalar rejection, invalid element rejection, and simple/object controls.
- Real local MCP transport proof: the SDK server advertised `z.array(z.enum(["red", "blue"]))`; OpenClaw's stdio transport, namespace dispatcher, and built QuickJS worker completed eight exec/resume legs and six calls. Four valid arrays were accepted; scalar `"red"` and `["green"]` were rejected by server validation. Both declaration surfaces returned the same corrected header and unchanged schema. The owned fixture process was closed and its exit verified.
- The full scoped changed gate and `pnpm build` passed. No assertions, timeouts, baselines, or limits were weakened.

Focused regression command:

```bash
node scripts/run-vitest.mjs src/agents/code-mode-namespaces.test.ts src/agents/code-mode.mcp.test.ts src/agents/tool-schema-hints.test.ts
```

Scoped gate:

```bash
node scripts/check-changed.mjs -- src/agents/code-mode-mcp-api.ts src/agents/code-mode-namespaces.test.ts src/agents/code-mode.mcp.test.ts
```

Build:

```bash
pnpm build
```

Proof limits: the first standalone source-worker transport attempt exceeded its configured timeout. Its failed log was retained; the built-worker driver then passed with the same timeout and assertions. The source-startup cost was not diagnosed by this declaration repair. The transport proof is a real local MCP process, not an authenticated external provider or full Gateway/model-loop run. There is no Control UI change. Native Codex's freeform-source/V8 path is separate from this OpenClaw JSON-exec/QuickJS declaration owner.

AI-assisted implementation and verification with Codex; maintainer reviewed and accepted the scoped repair.
