### PR TITLE
fix(openshell): sort upload roots by path length to prevent parent clearing child workspace

### DIFF
--- a/extensions/openshell/src/backend.exec-workdir.test.ts
+++ b/extensions/openshell/src/backend.exec-workdir.test.ts
@@ -380,7 +380,7 @@ describe("openshell backend exec workdir validation", () => {
       workspace: "/sandbox/primary",
       agent: "/sandbox",
       target: "/sandbox/primary/host-only",
-      exists: false,
+      exists: true,
     },
     {
       workspace: "/sandbox",
@@ -645,5 +645,76 @@ describe("openshell backend exec workdir validation", () => {
         token: secondExec.finalizeToken,
       });
     }
+  });
+
+  it.each([
+    {
+      label: "agent root is parent of workspace root (nested)",
+      remoteWorkspaceDir: "/sandbox/agent/project",
+      remoteAgentWorkspaceDir: "/sandbox/agent",
+      expectedClearOrder: ["/sandbox/agent", "/sandbox/agent/project"],
+    },
+    {
+      label: "disjoint roots are unaffected by sort",
+      remoteWorkspaceDir: "/sandbox",
+      remoteAgentWorkspaceDir: "/agent",
+      expectedClearOrder: ["/agent", "/sandbox"],
+    },
+  ])("clears upload roots by ascending path length: $label", async (scenario) => {
+    vi.stubEnv("OPENAI_API_KEY", "fixture");
+    vi.stubEnv("ANTHROPIC_API_KEY", "fixture");
+    vi.stubEnv("LANG", "en_US.UTF-8");
+    vi.stubEnv("NODE_ENV", "test");
+    const workspace = await tempWorkspace({
+      rootDir: resolvePreferredOpenClawTmpDir(),
+      prefix: "openclaw-openshell-overlap-",
+    });
+    tempWorkspaces.push(workspace);
+    const agentWorkspace = await tempWorkspace({
+      rootDir: resolvePreferredOpenClawTmpDir(),
+      prefix: "openclaw-openshell-overlap-agent-",
+    });
+    tempWorkspaces.push(agentWorkspace);
+
+    const backend = await createOpenShellBackendFixture({
+      scopeKey: `agent:overlap:${scenario.label}`,
+      workspaceDir: workspace.dir,
+      agentWorkspaceDir: agentWorkspace.dir,
+      workspaceAccess: "ro",
+      remoteWorkspaceDir: scenario.remoteWorkspaceDir,
+      remoteAgentWorkspaceDir: scenario.remoteAgentWorkspaceDir,
+    });
+
+    const execSpec = await backend.buildExecSpec({
+      command: "pwd",
+      workdir: scenario.remoteWorkspaceDir,
+      env: {},
+      usePty: false,
+    });
+
+    // The clear calls go through runSshSandboxCommand with a shell-escaped
+    // remoteCommand containing "rm -rf" and the root path in single quotes.
+    const clearCalls = sdkMocks.runSshSandboxCommand.mock.calls
+      .map(([params]) => String(params.remoteCommand))
+      .filter((cmd) => cmd.includes("rm -rf"));
+
+    const clearedRoots = clearCalls.map((cmd) => {
+      for (const expected of scenario.expectedClearOrder) {
+        if (cmd.includes(`'${expected}'`)) {
+          return expected;
+        }
+      }
+      return null;
+    });
+
+    expect(clearedRoots).toHaveLength(scenario.expectedClearOrder.length);
+    expect(clearedRoots).toEqual(scenario.expectedClearOrder);
+
+    await backend.finalizeExec?.({
+      status: "completed",
+      exitCode: 0,
+      timedOut: false,
+      token: execSpec.finalizeToken,
+    });
   });
 });

--- a/extensions/openshell/src/backend.ts
+++ b/extensions/openshell/src/backend.ts
@@ -540,8 +540,10 @@ class OpenShellSandboxBackendImpl {
     }
     // Later uploads replace overlapping roots. Their ancestors are created by mkdirp,
     // while descendants must be real directories in the symlink-free upload source.
+    // Iterate in reverse of syncWorkspaceToRemote's ascending upload order so the
+    // last-uploaded (most specific) root is checked first.
     let createdAncestor = false;
-    for (const root of roots.toReversed()) {
+    for (const root of roots.toSorted((a, b) => a.remote.length - b.remote.length).toReversed()) {
       if (!isRemotePathInside(root.remote, normalized)) {
         createdAncestor ||= isRemotePathInside(normalized, root.remote);
         continue;
@@ -963,7 +965,11 @@ class OpenShellSandboxBackendImpl {
   }
 
   private async syncWorkspaceToRemote(): Promise<void> {
-    for (const root of this.workspaceUploadRoots()) {
+    // Sort by remote path length ascending so that a parent (shorter) root is
+    // cleared and uploaded before any nested child (longer) root, preventing
+    // the parent clear from deleting a child workspace that was just uploaded.
+    const roots = this.workspaceUploadRoots().toSorted((a, b) => a.remote.length - b.remote.length);
+    for (const root of roots) {
       await this.runRemoteShellScriptInternal({
         script: 'mkdir -p -- "$1" && find "$1" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +',
         args: [root.remote],


### PR DESCRIPTION
Closes #131258

## What Problem This Solves

When an OpenShell mirror sandbox has the agent workspace root nested inside the primary workspace root (e.g. `remoteWorkspaceDir: /sandbox/agent/project` and `remoteAgentWorkspaceDir: /sandbox/agent`), the system uploaded the primary workspace first, then cleared the agent root — deleting the just-uploaded primary workspace. Commands could not find their working directory and failed before execution.

This PR sorts upload roots by ascending path length so the parent root is always cleared and uploaded before any nested child, preventing the parent clear from deleting a child workspace that was just uploaded.

- Problem: `syncWorkspaceToRemote()` iterated `workspaceUploadRoots()` in fixed order `[workspace, agent]`. When the agent root was a parent of the workspace root, the agent clear (`find ... rm -rf`) deleted the workspace that was just uploaded.
- Solution: Sort roots by ascending `remote` path length before iterating, so shorter (parent) paths are cleared and uploaded first.
- What changed: `extensions/openshell/src/backend.ts` — `syncWorkspaceToRemote()` sorts roots ascending; `validateMirrorWorkdir()` iterates in the reverse of that order (descending) to keep its publication-order simulation consistent with the actual upload sequence.
- What did NOT change: `workspaceUploadRoots()` return order (other callers unaffected), `syncSkillsWorkspaceToRemote()`, remote-mode behavior, config schema, no new API or configuration surface.

## Why This Change Was Made

The ascending sort ensures a parent directory is always cleared and uploaded before its nested children. This is the minimal fix at the shared `syncWorkspaceToRemote()` boundary — all three call sites (`buildExecSpec`, `maybeSeedRemoteWorkspace`, and the mirror exec path) pass through this single function.

`validateMirrorWorkdir()` checks the local host upload source to predict which root "wins" overlapping regions after upload. It previously used `toReversed()` on the unsorted roots array, assuming the natural order `[workspace, agent]` meant agent was uploaded last. The ascending sort inverts this, so `validateMirrorWorkdir` now sorts ascending then reverses, matching the new upload order. Without this update, workdir validation would check the wrong root first and return false negatives for nested configurations.

Path length is a safe proxy for parenthood here because `remoteWorkspaceDir` and `remoteAgentWorkspaceDir` are pre-normalized via `normalizeOpenShellRemotePath` (`config.ts`), and a genuine parent is always shorter than its descendant. The same length-based ordering is already used by `resolveWorkdirValidationRoot()` and `resolveRemoteTarget()` in this file.

Alternative considered: a topological sort using `isRemotePathInside` would be more explicit, but adds complexity for only two managed roots. The length-based sort is consistent with existing patterns in the same file.

Risk: Non-overlapping configurations (the default `/sandbox` and `/agent`) experience a harmless reorder with no behavioral change. Overlapping configurations where the workspace root is the parent (reverse-nesting) are also fixed by the same sort.

## User Impact

OpenShell mirror-mode operators with previously configured overlapping workspace roots (accepted for upgrade compatibility) can now execute commands without the working directory being deleted during preparation. Default non-overlapping configurations are unaffected.

## Evidence

All 146 OpenShell extension tests pass, including the new regression tests and the updated overlapping-upload validation tests.

**Clear/upload order verification (new regression tests):**

```
input variant                              => clear order (mock captured)
──────────────────────────────────────────────────────────────────────────
agent=/sandbox/agent (parent)              => ['/sandbox/agent', '/sandbox/agent/project']
workspace=/sandbox/agent/project (child)      parent cleared first ✅

workspace=/sandbox (disjoint)              => ['/agent', '/sandbox']
agent=/agent                                  harmless reorder, no nesting ✅
```

```
$ npx vitest run extensions/openshell/src/backend.exec-workdir.test.ts -t "clears upload roots" --reporter=verbose
 ✓ clears upload roots by ascending path length: 'agent root is parent of workspace root (nested)' 681ms
 ✓ clears upload roots by ascending path length: 'disjoint roots are unaffected by sort' 399ms
 Test Files  1 passed (1)
      Tests  2 passed | 31 skipped (33)
```

**validateMirrorWorkdir consistency (updated existing tests):**

```
$ npx vitest run extensions/openshell/src/backend.exec-workdir.test.ts -t "resolves overlapping" --reporter=verbose
 ✓ resolves overlapping uploads in publication order: '/sandbox/agent-only' 45ms
 ✓ resolves overlapping uploads in publication order: '/sandbox/primary/host-only' 6ms
 ✓ resolves overlapping uploads in publication order: '/sandbox/nested' 6ms
 Test Files  1 passed (1)
```

The `/sandbox/primary/host-only` scenario was updated from `exists: false` to `exists: true` because the ascending sort means the workspace root (child) is now uploaded last and wins the overlap — which is the correct behavior: the primary workspace content should survive when the agent root is its parent.

**Pre-fix regression confirmation:** Reverting only `backend.ts` (keeping test changes) causes the nested clear-order test and the `/sandbox/primary/host-only` validation test to fail, confirming both changes guard the bug.

**Full suite:**

```
$ npx vitest run extensions/openshell/
 Test Files  7 passed (7)
      Tests  146 passed (146)
```

What was not tested: No live OpenShell gateway or Docker sandbox was used. The tests use mocked SSH/CLI transports to verify the clear/upload ordering logic. A real OpenShell E2E test would require a connected gateway and Docker environment.

## AI Assistance

- AI-assisted: Yes
- Tools: Codex (gpt-5.6-sol)
- Prompts / session excerpts: Available on request
- Confirmed understanding of code changes: Yes — the ascending sort in `syncWorkspaceToRemote` ensures parent roots are cleared before children; the matching sort+reverse in `validateMirrorWorkdir` keeps the local-source validation consistent with the actual upload order
- autoreview: N/A
