### PR TITLE
fix(codex): block app-server runs denied by policy hooks

### DIFF
--- a/extensions/codex/src/app-server/attempt-results.ts
+++ b/extensions/codex/src/app-server/attempt-results.ts
@@ -7,7 +7,11 @@ import type {
   EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { CodexSystemPromptReport } from "./attempt-context.js";
-import { attemptTerminal, type EmbeddedRunAttemptResult } from "./attempt-terminal.js";
+import {
+  attemptTerminal,
+  type AttemptFailureSource,
+  type EmbeddedRunAttemptResult,
+} from "./attempt-terminal.js";
 import type { CodexAttemptTurnWatchTimeoutKind } from "./attempt-turn-watches.js";
 
 const CODEX_APP_SERVER_MISSING_TERMINAL_EVENT_USER_MESSAGE =
@@ -105,13 +109,14 @@ export function buildCodexTurnStartFailureResult(params: {
   params: EmbeddedRunAttemptParams;
   message: string;
   promptError?: unknown;
+  promptErrorSource?: AttemptFailureSource;
   messagesSnapshot: AgentMessage[];
   systemPromptReport: CodexSystemPromptReport;
 }): EmbeddedRunAttemptResult {
   return {
     terminal: attemptTerminal.normalize({
       promptError: params.promptError ?? params.message,
-      promptErrorSource: "prompt",
+      promptErrorSource: params.promptErrorSource ?? "prompt",
     }),
     sessionIdUsed: params.params.sessionId,
     messagesSnapshot: params.messagesSnapshot,

--- a/extensions/codex/src/app-server/run-attempt-turn-start.ts
+++ b/extensions/codex/src/app-server/run-attempt-turn-start.ts
@@ -2,6 +2,7 @@ import {
   embeddedAgentLog,
   formatErrorMessage,
   runAgentCleanupStep,
+  runAgentHarnessBeforeAgentRunHook,
   runAgentHarnessLlmInputHook,
   runAgentHarnessLlmOutputHook,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
@@ -72,83 +73,56 @@ export async function startCodexAttemptTurn(
   const { waitForActiveNativeTurnCompletion } = notifications;
   const { codexModelCallDiagnostics, startCodexTurn, buildLlmInputEvent } = requestRuntime;
   let turn: CodexTurnStartResponse | undefined;
-  try {
-    codexModelCallDiagnostics.emitStarted();
-    runAgentHarnessLlmInputHook({ event: buildLlmInputEvent(), ctx: hookContext, hookRunner });
-    turn = await startCodexTurn();
-  } catch (error) {
-    let turnStartError = error;
-    if (isCodexActiveCompactTurnError(turnStartError)) {
-      embeddedAgentLog.info(
-        "codex app-server turn/start blocked by active compact turn; waiting to retry",
-        { threadId: resourceState.thread.threadId },
+  let turnStartError: unknown;
+  // Gate once per attempt on the final prepared prompt before any turn/start.
+  // The internal compact/overflow retries below reuse the admitted prompt and
+  // must not re-run the hook; Codex only submits input on turn/start, so no
+  // model-visible work happens before this point.
+  const beforeAgentRunBlock = await runAgentHarnessBeforeAgentRunHook({
+    runId: params.runId,
+    event: {
+      prompt: turnState.codexTurnPromptText,
+      systemPrompt: prompt.buildRenderedCodexDeveloperInstructions(),
+      messages: historyState.messages,
+      channelId: hookContext.channelId,
+      accountId: params.agentAccountId,
+      senderId: params.senderId ?? undefined,
+      senderIsOwner: params.senderIsOwner,
+    },
+    ctx: hookContext,
+    hookRunner,
+  });
+  if (beforeAgentRunBlock) {
+    turnStartError = new Error(beforeAgentRunBlock.message);
+    try {
+      await params.userTurnTranscriptRecorder?.persistBlocked(
+        beforeAgentRunBlock.blockedUserMessage,
       );
-      const compactTurnCompleted = await waitForActiveNativeTurnCompletion();
-      if (compactTurnCompleted && !runAbortController.signal.aborted) {
-        void emitCodexAppServerEvent(params, {
-          stream: "codex_app_server.lifecycle",
-          data: {
-            phase: "turn_start_retry_after_compact",
-            threadId: resourceState.thread.threadId,
-          },
-        });
-        try {
-          turn = await startCodexTurn();
-        } catch (retryError) {
-          turnStartError = retryError;
-        }
-      }
+    } catch (error) {
+      embeddedAgentLog.warn("before_agent_run block: failed to persist redacted user message", {
+        error: formatErrorMessage(error),
+      });
     }
-    if (
-      turn === undefined &&
-      resourceState.thread.connectionScope !== "supervision" &&
-      shouldUseFreshCodexThreadAfterContextEngineOverflow({
-        error: turnStartError,
-        contextEngineActive: Boolean(activeContextEngine),
-        thread: resourceState.thread,
-      }) &&
-      resourceState.restartContextEngineCodexThread
-    ) {
-      embeddedAgentLog.warn(
-        "codex app-server context-engine turn overflowed on resume; retrying with fresh thread",
-        { threadId: resourceState.thread.threadId, error: formatErrorMessage(turnStartError) },
-      );
-      try {
-        const clearedBinding = await bindingStore.mutate(bindingIdentity, {
-          kind: "clear",
-          threadId: resourceState.thread.threadId,
-        });
-        if (!clearedBinding) {
-          embeddedAgentLog.warn(
-            "codex app-server preserved newer context-engine binding after resume overflow; skipping fresh retry",
-            { threadId: resourceState.thread.threadId, error: formatErrorMessage(turnStartError) },
-          );
-        } else {
-          resourceState.thread = await resourceState.restartContextEngineCodexThread();
-          const retryBinding = await bindingStore.read(bindingIdentity);
-          if (
-            retryBinding &&
-            retryBinding.threadId === resourceState.thread.threadId &&
-            retryBinding.contextEngine?.projection
-          ) {
-            await bindingStore.mutate(bindingIdentity, {
-              kind: "patch",
-              threadId: retryBinding.threadId,
-              patch: {
-                contextEngine: { ...retryBinding.contextEngine, projection: undefined },
-              },
-            });
-            embeddedAgentLog.info(
-              "codex app-server cleared stale context-engine projection after overflow retry",
-              {
-                threadId: resourceState.thread.threadId,
-                previousEpoch: retryBinding.contextEngine.projection.epoch,
-              },
-            );
-          }
+  } else {
+    try {
+      codexModelCallDiagnostics.emitStarted();
+      runAgentHarnessLlmInputHook({ event: buildLlmInputEvent(), ctx: hookContext, hookRunner });
+      turn = await startCodexTurn();
+    } catch (error) {
+      turnStartError = error;
+      if (isCodexActiveCompactTurnError(turnStartError)) {
+        embeddedAgentLog.info(
+          "codex app-server turn/start blocked by active compact turn; waiting to retry",
+          { threadId: resourceState.thread.threadId },
+        );
+        const compactTurnCompleted = await waitForActiveNativeTurnCompletion();
+        if (compactTurnCompleted && !runAbortController.signal.aborted) {
           void emitCodexAppServerEvent(params, {
             stream: "codex_app_server.lifecycle",
-            data: { phase: "thread_ready_retry", threadId: resourceState.thread.threadId },
+            data: {
+              phase: "turn_start_retry_after_compact",
+              threadId: resourceState.thread.threadId,
+            },
           });
           try {
             turn = await startCodexTurn();
@@ -156,39 +130,107 @@ export async function startCodexAttemptTurn(
             turnStartError = retryError;
           }
         }
-      } catch (retrySetupError) {
-        turnStartError = retrySetupError;
+      }
+      if (
+        turn === undefined &&
+        resourceState.thread.connectionScope !== "supervision" &&
+        shouldUseFreshCodexThreadAfterContextEngineOverflow({
+          error: turnStartError,
+          contextEngineActive: Boolean(activeContextEngine),
+          thread: resourceState.thread,
+        }) &&
+        resourceState.restartContextEngineCodexThread
+      ) {
+        embeddedAgentLog.warn(
+          "codex app-server context-engine turn overflowed on resume; retrying with fresh thread",
+          { threadId: resourceState.thread.threadId, error: formatErrorMessage(turnStartError) },
+        );
+        try {
+          const clearedBinding = await bindingStore.mutate(bindingIdentity, {
+            kind: "clear",
+            threadId: resourceState.thread.threadId,
+          });
+          if (!clearedBinding) {
+            embeddedAgentLog.warn(
+              "codex app-server preserved newer context-engine binding after resume overflow; skipping fresh retry",
+              {
+                threadId: resourceState.thread.threadId,
+                error: formatErrorMessage(turnStartError),
+              },
+            );
+          } else {
+            resourceState.thread = await resourceState.restartContextEngineCodexThread();
+            const retryBinding = await bindingStore.read(bindingIdentity);
+            if (
+              retryBinding &&
+              retryBinding.threadId === resourceState.thread.threadId &&
+              retryBinding.contextEngine?.projection
+            ) {
+              await bindingStore.mutate(bindingIdentity, {
+                kind: "patch",
+                threadId: retryBinding.threadId,
+                patch: {
+                  contextEngine: { ...retryBinding.contextEngine, projection: undefined },
+                },
+              });
+              embeddedAgentLog.info(
+                "codex app-server cleared stale context-engine projection after overflow retry",
+                {
+                  threadId: resourceState.thread.threadId,
+                  previousEpoch: retryBinding.contextEngine.projection.epoch,
+                },
+              );
+            }
+            void emitCodexAppServerEvent(params, {
+              stream: "codex_app_server.lifecycle",
+              data: { phase: "thread_ready_retry", threadId: resourceState.thread.threadId },
+            });
+            try {
+              turn = await startCodexTurn();
+            } catch (retryError) {
+              turnStartError = retryError;
+            }
+          }
+        } catch (retrySetupError) {
+          turnStartError = retrySetupError;
+        }
       }
     }
-    if (turn === undefined) {
-      const usageLimitError = await formatCodexTurnStartUsageLimitError({
-        client: resourceState.client,
-        error: turnStartError,
-        errorNotification: state.latestStartupErrorNotification,
-        rateLimitsRevisionBeforeTurnStart: state.rateLimitsRevisionBeforeLastTurnStart,
-        timeoutMs: appServer.requestTimeoutMs,
-        signal: runAbortController.signal,
-      });
-      const message = usageLimitError?.message ?? formatErrorMessage(turnStartError);
-      if (isInvalidCodexImagePayloadError(message)) {
-        await clearCodexBindingAfterInvalidImagePayload(bindingStore, bindingIdentity, {
-          phase: "turn_start",
-          threadId: resourceState.thread.threadId,
-          error: message,
+  }
+  if (turn === undefined) {
+    const usageLimitError = beforeAgentRunBlock
+      ? undefined
+      : await formatCodexTurnStartUsageLimitError({
+          client: resourceState.client,
+          error: turnStartError,
+          errorNotification: state.latestStartupErrorNotification,
+          rateLimitsRevisionBeforeTurnStart: state.rateLimitsRevisionBeforeLastTurnStart,
+          timeoutMs: appServer.requestTimeoutMs,
+          signal: runAbortController.signal,
         });
-      }
-      void emitCodexAppServerEvent(params, {
-        stream: "codex_app_server.lifecycle",
-        data: { phase: "turn_start_failed", error: message },
-      });
-      trajectoryRecorder?.recordEvent("session.ended", {
-        status: "error",
+    const message = usageLimitError?.message ?? formatErrorMessage(turnStartError);
+    if (isInvalidCodexImagePayloadError(message)) {
+      await clearCodexBindingAfterInvalidImagePayload(bindingStore, bindingIdentity, {
+        phase: "turn_start",
         threadId: resourceState.thread.threadId,
-        timedOut: state.timedOut,
-        aborted: runAbortController.signal.aborted,
-        promptError: message,
+        error: message,
       });
-      markTrajectoryEndRecorded();
+    }
+    void emitCodexAppServerEvent(params, {
+      stream: "codex_app_server.lifecycle",
+      data: { phase: "turn_start_failed", error: message },
+    });
+    trajectoryRecorder?.recordEvent("session.ended", {
+      status: "error",
+      threadId: resourceState.thread.threadId,
+      timedOut: state.timedOut,
+      aborted: runAbortController.signal.aborted,
+      promptError: message,
+    });
+    markTrajectoryEndRecorded();
+    // A hook block never reached the model: no llm_output or model-call error
+    // diagnostics, matching the embedded runner's blocked-attempt semantics.
+    if (!beforeAgentRunBlock) {
       runAgentHarnessLlmOutputHook({
         event: {
           runId: params.runId,
@@ -222,96 +264,105 @@ export async function startCodexAttemptTurn(
         formatError: formatErrorMessage,
       });
       codexModelCallDiagnostics.emitError(message, failureKind ? { failureKind } : {});
-      const messagesSnapshot = [
-        ...historyState.messages,
-        buildCodexUserPromptMessage({ ...runtimeParams, prompt: turnState.codexTurnPromptText }),
-      ];
-      await runCodexAgentEndHook(params, {
-        event: {
-          messages: messagesSnapshot,
-          success: false,
-          error: message,
-          durationMs: Date.now() - attemptStartedAt,
-        },
-        ctx: hookContext,
-        hookRunner,
-      });
-      const bindingReleased = isIncognitoSessionKey(params.sessionKey)
-        ? await bindingStore.mutate(bindingIdentity, {
-            kind: "clear",
-            threadId: resourceState.thread.threadId,
-          })
-        : true;
-      if (!state.timedOut && bindingReleased && !resourceState.startupClientUnsafe) {
-        const released = await unsubscribeCodexThreadBestEffort(resourceState.client, {
+    }
+    const messagesSnapshot = [
+      ...historyState.messages,
+      beforeAgentRunBlock
+        ? beforeAgentRunBlock.blockedUserMessage
+        : buildCodexUserPromptMessage({ ...runtimeParams, prompt: turnState.codexTurnPromptText }),
+    ];
+    await runCodexAgentEndHook(params, {
+      event: {
+        messages: messagesSnapshot,
+        success: false,
+        error: message,
+        durationMs: Date.now() - attemptStartedAt,
+      },
+      ctx: hookContext,
+      hookRunner,
+    });
+    const bindingReleased = isIncognitoSessionKey(params.sessionKey)
+      ? await bindingStore.mutate(bindingIdentity, {
+          kind: "clear",
           threadId: resourceState.thread.threadId,
-          timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
-        });
-        if (!released) {
-          // Detach the unsafe client before releasing this lease, but let sibling leases finish.
-          await runAgentCleanupStep({
-            runId: params.runId,
-            sessionId: params.sessionId,
-            step: "codex-retire-unsafe-startup-client",
-            log: embeddedAgentLog,
-            cleanup: async () => closeCodexStartupClientBestEffort(resourceState.client),
-          });
-        }
-      }
-      releaseCurrentRoute();
-      activateNativePreToolUseFailureFallback();
-      resourceState.nativeHookRelay?.unregister();
-      await releaseSandboxExecEnvironment();
-      await runAgentCleanupStep({
-        runId: params.runId,
-        sessionId: params.sessionId,
-        step: "codex-trajectory-flush-startup-failure",
-        log: embeddedAgentLog,
-        cleanup: async () => trajectoryRecorder?.flush(),
+        })
+      : true;
+    if (!state.timedOut && bindingReleased && !resourceState.startupClientUnsafe) {
+      const released = await unsubscribeCodexThreadBestEffort(resourceState.client, {
+        threadId: resourceState.thread.threadId,
+        timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
       });
-      params.abortSignal?.removeEventListener("abort", abortFromUpstream);
-      await releaseSharedClientLeaseAndRetireOneShotClient();
-      if (usageLimitError) {
-        await markCodexAuthProfileBlockedFromRateLimits({
-          params,
-          authProfileId: startupAuthProfileId,
-          rateLimits: usageLimitError.rateLimitsForProfile,
+      if (!released) {
+        // Detach the unsafe client before releasing this lease, but let sibling leases finish.
+        await runAgentCleanupStep({
+          runId: params.runId,
+          sessionId: params.sessionId,
+          step: "codex-retire-unsafe-startup-client",
+          log: embeddedAgentLog,
+          cleanup: async () => closeCodexStartupClientBestEffort(resourceState.client),
         });
-        return {
-          result: buildCodexTurnStartFailureResult({
+      }
+    }
+    releaseCurrentRoute();
+    activateNativePreToolUseFailureFallback();
+    resourceState.nativeHookRelay?.unregister();
+    await releaseSandboxExecEnvironment();
+    await runAgentCleanupStep({
+      runId: params.runId,
+      sessionId: params.sessionId,
+      step: "codex-trajectory-flush-startup-failure",
+      log: embeddedAgentLog,
+      cleanup: async () => trajectoryRecorder?.flush(),
+    });
+    params.abortSignal?.removeEventListener("abort", abortFromUpstream);
+    await releaseSharedClientLeaseAndRetireOneShotClient();
+    if (usageLimitError) {
+      await markCodexAuthProfileBlockedFromRateLimits({
+        params,
+        authProfileId: startupAuthProfileId,
+        rateLimits: usageLimitError.rateLimitsForProfile,
+      });
+      return {
+        result: buildCodexTurnStartFailureResult({
+          params,
+          message: usageLimitError.message,
+          promptError: createCodexUsageLimitPromptError(usageLimitError.message),
+          messagesSnapshot,
+          systemPromptReport,
+        }),
+      };
+    }
+    if (beforeAgentRunBlock) {
+      return {
+        result: buildCodexTurnStartFailureResult({
+          params,
+          message,
+          promptError: turnStartError,
+          promptErrorSource: "hook:before_agent_run",
+          messagesSnapshot,
+          systemPromptReport,
+        }),
+      };
+    }
+    if (isCodexContextRestartSelectionChangedError(turnStartError)) {
+      return {
+        result: {
+          ...buildCodexTurnStartFailureResult({
             params,
-            message: usageLimitError.message,
-            promptError: createCodexUsageLimitPromptError(usageLimitError.message),
+            message,
             messagesSnapshot,
             systemPromptReport,
           }),
-        };
-      }
-      if (isCodexContextRestartSelectionChangedError(turnStartError)) {
-        return {
-          result: {
-            ...buildCodexTurnStartFailureResult({
-              params,
-              message,
-              messagesSnapshot,
-              systemPromptReport,
-            }),
-            codexAppServerFailure: {
-              kind: "client_closed_before_turn_completed" as const,
-              transport: appServer.start.transport,
-              threadId: resourceState.thread.threadId,
-              replaySafe: true,
-            },
+          codexAppServerFailure: {
+            kind: "client_closed_before_turn_completed" as const,
+            transport: appServer.start.transport,
+            threadId: resourceState.thread.threadId,
+            replaySafe: true,
           },
-        };
-      }
-      throw turnStartError;
+        },
+      };
     }
-  }
-  if (!turn) {
-    activateNativePreToolUseFailureFallback();
-    await releaseSharedClientLeaseAndRetireOneShotClient();
-    throw new Error("codex app-server turn/start failed without an error");
+    throw turnStartError;
   }
   const authoritySourceRef = context.attemptTools.scheduledAppAuthoritySourceRef;
   if (resourceState.thread.pluginAppPolicyContext) {

--- a/extensions/codex/src/app-server/run-attempt.before-agent-run.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.before-agent-run.test.ts
@@ -1,0 +1,233 @@
+// Codex tests cover the before_agent_run gate parity for app-server run attempts.
+import path from "node:path";
+import { openFileBackedSessionManagerForTest } from "openclaw/plugin-sdk/agent-runtime-test-contracts";
+import { initializeGlobalHookRunner } from "openclaw/plugin-sdk/hook-runtime";
+import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { describe, expect, it, vi } from "vitest";
+import { readAttemptTerminal } from "./attempt-terminal.test-helper.js";
+import { CodexAppServerRpcError } from "./client.js";
+import {
+  assistantMessage,
+  createAppServerHarness,
+  createParams,
+  createStartedThreadHarness,
+  fastWait,
+  mockCall,
+  runCodexAppServerAttempt,
+  setupRunAttemptTestHooks,
+  tempDir,
+  turnStartResult,
+} from "./run-attempt-test-harness.js";
+
+setupRunAttemptTestHooks();
+
+describe("runCodexAppServerAttempt before_agent_run gate", () => {
+  const BLOCKED_TEXT =
+    "Your message could not be sent: The agent cannot read this message. (blocked by policy-plugin)";
+
+  function createBlockedRecorder() {
+    return {
+      message: undefined,
+      getAdmissionReceipt: () => undefined,
+      resolveMessage: async () => undefined,
+      persistBlocked: vi.fn(async () => undefined),
+      persistApproved: vi.fn(async () => undefined),
+      hasPersisted: () => false,
+      isBlocked: () => false,
+      markRuntimePersisted: vi.fn(),
+      markRuntimePersistencePending: vi.fn(),
+      markSentToProvider: vi.fn(),
+      hasRuntimePersistencePending: () => false,
+      waitForRuntimePersistence: async () => undefined,
+    };
+  }
+
+  function createHarnessCompletingTurns() {
+    const harnessRef: { current?: ReturnType<typeof createAppServerHarness> } = {};
+    const harness = createStartedThreadHarness(async (method) => {
+      if (method === "turn/start") {
+        // Pre-fix runs reach turn/start; complete it so the attempt settles
+        // and the gate assertions fail instead of hanging.
+        queueMicrotask(() => {
+          void harnessRef.current?.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+        });
+      }
+      return undefined;
+    });
+    harnessRef.current = harness;
+    return harness;
+  }
+
+  it("blocks the run before turn/start when before_agent_run blocks", async () => {
+    const beforeAgentRun = vi.fn(async () => ({
+      outcome: "block" as const,
+      reason: "matched secret prompt",
+      message: "The agent cannot read this message.",
+    }));
+    const llmInput = vi.fn();
+    const llmOutput = vi.fn();
+    const agentEnd = vi.fn();
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        { pluginId: "policy-plugin", hookName: "before_agent_run", handler: beforeAgentRun },
+        { hookName: "llm_input", handler: llmInput },
+        { hookName: "llm_output", handler: llmOutput },
+        { hookName: "agent_end", handler: agentEnd },
+      ]),
+    );
+    const sessionFile = path.join(tempDir, "before-agent-run-block.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace-before-agent-run-block");
+    const sessionManager = openFileBackedSessionManagerForTest(sessionFile, {
+      sessionId: "session-1",
+    });
+    sessionManager.appendMessage(assistantMessage("earlier context", Date.now()));
+    const harness = createHarnessCompletingTurns();
+    const recorder = createBlockedRecorder();
+    const params = createParams(sessionFile, workspaceDir, { prompt: "secret prompt" });
+    params.agentAccountId = "acct-1";
+    params.senderId = "user-42";
+    params.senderIsOwner = true;
+    params.userTurnTranscriptRecorder = recorder as never;
+
+    const result = await runCodexAppServerAttempt(params);
+
+    expect(harness.requests.map((request) => request.method)).not.toContain("turn/start");
+    expect(beforeAgentRun).toHaveBeenCalledTimes(1);
+    const [event, hookContext] = mockCall(beforeAgentRun, "before_agent_run") as [
+      {
+        prompt?: string;
+        systemPrompt?: string;
+        messages?: Array<{ role?: string }>;
+        accountId?: string;
+        senderId?: string;
+        senderIsOwner?: boolean;
+      },
+      { runId?: string; sessionId?: string; sessionKey?: string },
+    ];
+    expect(event.prompt).toContain("secret prompt");
+    expect(event.systemPrompt).toContain("You are a personal agent running inside OpenClaw.");
+    expect(event.messages?.some((message) => message.role === "assistant")).toBe(true);
+    expect(event.accountId).toBe("acct-1");
+    expect(event.senderId).toBe("user-42");
+    expect(event.senderIsOwner).toBe(true);
+    expect(hookContext.runId).toBe("run-1");
+    expect(hookContext.sessionKey).toBe("agent:main:session-1");
+
+    const terminal = readAttemptTerminal(result);
+    expect(terminal.promptErrorSource).toBe("hook:before_agent_run");
+    expect(
+      String((terminal.promptError as Error | undefined)?.message ?? terminal.promptError),
+    ).toBe(BLOCKED_TEXT);
+    expect(result.assistantTexts).toEqual([]);
+    expect(llmInput).not.toHaveBeenCalled();
+    expect(llmOutput).not.toHaveBeenCalled();
+    expect(agentEnd).toHaveBeenCalledTimes(1);
+    const [agentEndPayload] = mockCall(agentEnd, "agent_end") as [
+      { success?: boolean; error?: string; messages?: unknown[] },
+    ];
+    expect(agentEndPayload.success).toBe(false);
+    expect(agentEndPayload.error).toBe(BLOCKED_TEXT);
+    expect(JSON.stringify(agentEndPayload.messages)).not.toContain("secret prompt");
+    expect(JSON.stringify(agentEndPayload.messages)).toContain(BLOCKED_TEXT);
+    expect(recorder.persistBlocked).toHaveBeenCalledTimes(1);
+    const [blockedMessage] = recorder.persistBlocked.mock.calls[0] as unknown as [
+      { role?: string; idempotencyKey?: string; __openclaw?: { beforeAgentRunBlocked?: unknown } },
+    ];
+    expect(blockedMessage.role).toBe("user");
+    expect(blockedMessage.idempotencyKey).toBe("hook-block:before_agent_run:user:run-1");
+    expect(blockedMessage["__openclaw"]?.beforeAgentRunBlocked).toMatchObject({
+      blockedBy: "policy-plugin",
+    });
+  });
+
+  it("fails closed before turn/start when before_agent_run throws", async () => {
+    const llmInput = vi.fn();
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "before_agent_run",
+          handler: async () => {
+            throw new Error("hook exploded");
+          },
+        },
+        { hookName: "llm_input", handler: llmInput },
+      ]),
+    );
+    const sessionFile = path.join(tempDir, "before-agent-run-throw.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace-before-agent-run-throw");
+    const harness = createHarnessCompletingTurns();
+
+    const result = await runCodexAppServerAttempt(createParams(sessionFile, workspaceDir));
+
+    expect(harness.requests.map((request) => request.method)).not.toContain("turn/start");
+    expect(llmInput).not.toHaveBeenCalled();
+    const terminal = readAttemptTerminal(result);
+    expect(terminal.promptErrorSource).toBe("hook:before_agent_run");
+    expect(
+      String((terminal.promptError as Error | undefined)?.message ?? terminal.promptError),
+    ).toBe("Your message could not be sent: blocked by before_agent_run");
+  });
+
+  it("runs before_agent_run once across the active-compact turn/start retry", async () => {
+    const turnStartCallsAtHook: number[] = [];
+    const harnessRef: { current?: ReturnType<typeof createAppServerHarness> } = {};
+    const beforeAgentRun = vi.fn(async () => {
+      turnStartCallsAtHook.push(
+        harnessRef.current?.requests.filter((request) => request.method === "turn/start").length ??
+          -1,
+      );
+      return undefined;
+    });
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_agent_run", handler: beforeAgentRun }]),
+    );
+    const sessionFile = path.join(tempDir, "before-agent-run-retry.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace-before-agent-run-retry");
+    let turnStartCalls = 0;
+    const harness = createStartedThreadHarness(async (method) => {
+      if (method !== "turn/start") {
+        return undefined;
+      }
+      turnStartCalls += 1;
+      if (turnStartCalls === 1) {
+        queueMicrotask(() => {
+          void harnessRef.current?.notify({
+            method: "turn/completed",
+            params: {
+              threadId: "thread-1",
+              turnId: "compact-turn",
+              turn: { id: "compact-turn", status: "completed" },
+            },
+          });
+        });
+        throw new CodexAppServerRpcError(
+          {
+            message: "cannot steer a compact turn",
+            data: {
+              message: "cannot steer a compact turn",
+              codexErrorInfo: { activeTurnNotSteerable: { turnKind: "compact" } },
+              additionalDetails: null,
+            },
+          },
+          "turn/start",
+        );
+      }
+      return turnStartResult("turn-1");
+    });
+    harnessRef.current = harness;
+
+    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir));
+    await vi.waitFor(
+      () =>
+        expect(harness.requests.filter((request) => request.method === "turn/start")).toHaveLength(
+          2,
+        ),
+      fastWait,
+    );
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+
+    expect(beforeAgentRun).toHaveBeenCalledTimes(1);
+    expect(turnStartCallsAtHook).toEqual([0]);
+  });
+});

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -323,7 +323,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: shared channel-account logout config cleanup.
       // +1: descriptor-based allowFrom authentication classifier for channel security audits.
       // +1: downstream strength mappers need canonical ordering instead of duplicate rank tables.
-      4349,
+      // +1: shared fail-closed before_agent_run harness gate so Codex/CLI/embedded runtimes share one policy.
+      4350,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -423,7 +424,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: shared channel-account logout config cleanup.
       // +1: descriptor-based allowFrom authentication classifier for channel security audits.
       // +1: downstream strength mappers need canonical ordering instead of duplicate rank tables.
-      2585,
+      // +1: shared fail-closed before_agent_run harness gate so Codex/CLI/embedded runtimes share one policy.
+      2586,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -20,7 +20,6 @@ import {
   buildAgentHookContextChannelFields,
   buildAgentHookContextIdentityFields,
 } from "../plugins/hook-agent-context.js";
-import { resolveBlockMessage } from "../plugins/hook-decision-types.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import {
   loadAuthProfileStoreForRuntime,
@@ -79,6 +78,7 @@ import { bootstrapHarnessContextEngine } from "./harness/context-engine-lifecycl
 import { buildAgentHookContext } from "./harness/hook-context.js";
 import { buildAgentHookConversationMessages } from "./harness/hook-history.js";
 import {
+  runAgentHarnessBeforeAgentRunHook,
   runAgentHarnessLlmInputHook,
   runAgentHarnessLlmOutputHook,
 } from "./harness/lifecycle-hook-helpers.js";
@@ -624,63 +624,32 @@ export async function runPreparedCliAgent(
     };
 
     if (hasBeforeAgentRunHooks && hookRunner) {
-      let beforeRunResult:
-        | Awaited<ReturnType<NonNullable<typeof hookRunner>["runBeforeAgentRun"]>>
-        | undefined;
-      try {
-        beforeRunResult = await hookRunner.runBeforeAgentRun(
-          {
-            prompt: params.prompt,
-            systemPrompt: context.systemPrompt,
-            messages: buildAgentHookConversationMessages({
-              historyMessages,
-              currentTurnMessages: [],
-            }),
-            channelId: hookContext.channelId,
-            accountId: params.agentAccountId,
-            senderId: params.senderId ?? undefined,
-            senderIsOwner: params.senderIsOwner ?? undefined,
-          },
-          buildAgentHookContext(hookContext),
-        );
-      } catch {
-        const blockMessage = resolveBlockMessage(
-          { outcome: "block", reason: "before_agent_run hook failed" },
-          { blockedBy: "before_agent_run" },
-        );
-        await persistCliRunBlock(params, {
-          message: blockMessage,
-          pluginId: "before_agent_run",
-        });
+      const block = await runAgentHarnessBeforeAgentRunHook({
+        runId: params.runId,
+        event: {
+          prompt: params.prompt,
+          systemPrompt: context.systemPrompt,
+          messages: buildAgentHookConversationMessages({
+            historyMessages,
+            currentTurnMessages: [],
+          }),
+          channelId: hookContext.channelId,
+          accountId: params.agentAccountId,
+          senderId: params.senderId ?? undefined,
+          senderIsOwner: params.senderIsOwner ?? undefined,
+        },
+        ctx: buildAgentHookContext(hookContext),
+        hookRunner,
+      });
+      if (block) {
+        await persistCliRunBlock(params, block.blockedUserMessage);
         await runCliAgentEndHook(params, {
-          event: buildBlockedAgentEndEvent(blockMessage),
+          event: buildBlockedAgentEndEvent(block.message),
           ctx: hookContext,
           hookRunner,
         });
         return buildBlockedCliRunResult({
-          message: blockMessage,
-          context,
-          preparedContextAgentMeta,
-          sessionBindingDisabled,
-        });
-      }
-
-      const beforeRunDecision = beforeRunResult?.decision;
-      if (beforeRunDecision?.outcome === "block") {
-        const blockMessage = resolveBlockMessage(beforeRunDecision, {
-          blockedBy: beforeRunResult?.pluginId ?? "unknown",
-        });
-        await persistCliRunBlock(params, {
-          message: blockMessage,
-          pluginId: beforeRunResult?.pluginId ?? "unknown",
-        });
-        await runCliAgentEndHook(params, {
-          event: buildBlockedAgentEndEvent(blockMessage),
-          ctx: hookContext,
-          hookRunner,
-        });
-        return buildBlockedCliRunResult({
-          message: blockMessage,
+          message: block.message,
           context,
           preparedContextAgentMeta,
           sessionBindingDisabled,

--- a/src/agents/cli-runner/cli-run-transcript.ts
+++ b/src/agents/cli-runner/cli-run-transcript.ts
@@ -19,6 +19,7 @@ import {
   runHarnessContextEngineMaintenance,
 } from "../harness/context-engine-lifecycle.js";
 import { runAgentHarnessBeforeMessageWriteHook } from "../harness/hook-helpers.js";
+import type { AgentHarnessBeforeAgentRunBlock } from "../harness/lifecycle-hook-helpers.js";
 import type { AgentMessage } from "../runtime/index.js";
 import { SessionManager } from "../sessions/session-manager.js";
 import { buildAssistantMessage, buildUsageWithNoCost } from "../stream-message-shared.js";
@@ -238,21 +239,8 @@ async function notifyCliUserMessagePersisted(
 
 export async function persistCliRunBlock(
   params: RunCliAgentParams,
-  block: { message: string; pluginId: string },
+  redactedUserMessage: AgentHarnessBeforeAgentRunBlock["blockedUserMessage"],
 ): Promise<void> {
-  const nowMs = Date.now();
-  const redactedUserMessage = {
-    role: "user" as const,
-    content: [{ type: "text" as const, text: block.message }],
-    timestamp: nowMs,
-    idempotencyKey: `hook-block:before_agent_run:user:${params.runId}`,
-    __openclaw: {
-      beforeAgentRunBlocked: {
-        blockedBy: block.pluginId,
-        blockedAt: nowMs,
-      },
-    },
-  };
   try {
     const persisted = await params.userTurnTranscriptRecorder?.persistBlocked(redactedUserMessage);
     if (persisted) {

--- a/src/agents/embedded-agent-runner/run/attempt-before-agent-run.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-before-agent-run.ts
@@ -1,9 +1,12 @@
 /**
  * Runs the fail-closed before_agent_run gate and persists blocked turns.
  */
-import { resolveBlockMessage } from "../../../plugins/hook-decision-types.js";
 import type { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
 import { sanitizeCompactionReplayMessages } from "../../compaction-replay.js";
+import {
+  runAgentHarnessBeforeAgentRunHook,
+  type AgentHarnessBeforeAgentRunBlock,
+} from "../../harness/lifecycle-hook-helpers.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import { log } from "../logger.js";
 import { flushSessionManagerTranscript } from "./attempt-transcript-helpers.js";
@@ -44,81 +47,53 @@ export async function runEmbeddedAttemptBeforeAgentRun(input: {
     return undefined;
   }
 
-  const persistBlockedBeforeAgentRun = async (block: {
-    message: string;
-    pluginId: string;
-  }): Promise<boolean> => {
-    const idempotencyKey = `hook-block:before_agent_run:user:${input.attempt.runId}`;
-    if (sessionMessagesContainIdempotencyKey(input.activeSession.messages, idempotencyKey)) {
-      return true;
+  const persistBlockedBeforeAgentRun = async (
+    block: AgentHarnessBeforeAgentRunBlock,
+  ): Promise<void> => {
+    if (
+      sessionMessagesContainIdempotencyKey(
+        input.activeSession.messages,
+        block.blockedUserMessage.idempotencyKey,
+      )
+    ) {
+      return;
     }
-    const nowMs = Date.now();
-    const redactedUserMessage = {
-      role: "user" as const,
-      content: [{ type: "text" as const, text: block.message }],
-      timestamp: nowMs,
-      idempotencyKey,
-      __openclaw: {
-        beforeAgentRunBlocked: {
-          blockedBy: block.pluginId,
-          blockedAt: nowMs,
-        },
-      },
-    };
     try {
       await input.withOwnedTranscriptWrite(() => {
         input.sessionManager.appendMessage(
-          redactedUserMessage as Parameters<typeof input.sessionManager.appendMessage>[0],
+          block.blockedUserMessage as Parameters<typeof input.sessionManager.appendMessage>[0],
         );
         flushSessionManagerTranscript(input.sessionManager);
       });
       input.activeSession.agent.state.messages = sanitizeCompactionReplayMessages(
         input.sessionManager.buildSessionContext().messages,
       );
-      return true;
     } catch (err) {
       log.warn(
         `before_agent_run block: failed to persist redacted user message: ${
           (err as Error)?.message ?? String(err)
         }`,
       );
-      return false;
     }
   };
 
-  let beforeRunResult: Awaited<ReturnType<HookRunner["runBeforeAgentRun"]>> | undefined;
-  try {
-    beforeRunResult = await input.hookRunner.runBeforeAgentRun(
-      {
-        prompt: input.modelPrompt,
-        systemPrompt: input.systemPrompt,
-        /** Gives hooks an isolated message snapshot they cannot mutate in-session. */
-        messages: input.hookMessages.map((message) => structuredClone(message)),
-        channelId: input.hookContext.channelId,
-        accountId: input.attempt.agentAccountId ?? undefined,
-        senderId: input.attempt.senderId ?? undefined,
-        senderIsOwner: input.attempt.senderIsOwner ?? undefined,
-      },
-      input.hookContext,
-    );
-  } catch {
-    log.warn("before_agent_run hook failed; blocking request");
-    const blockedBy = "before_agent_run";
-    const message = resolveBlockMessage(
-      { outcome: "block", reason: "before_agent_run hook failed" },
-      { blockedBy },
-    );
-    await persistBlockedBeforeAgentRun({ message, pluginId: blockedBy });
-    return { blockedBy, promptError: new Error(message) };
-  }
-
-  const beforeRunDecision = beforeRunResult?.decision;
-  if (beforeRunDecision?.outcome !== "block") {
+  const block = await runAgentHarnessBeforeAgentRunHook({
+    runId: input.attempt.runId,
+    event: {
+      prompt: input.modelPrompt,
+      systemPrompt: input.systemPrompt,
+      messages: input.hookMessages,
+      channelId: input.hookContext.channelId,
+      accountId: input.attempt.agentAccountId ?? undefined,
+      senderId: input.attempt.senderId ?? undefined,
+      senderIsOwner: input.attempt.senderIsOwner ?? undefined,
+    },
+    ctx: input.hookContext,
+    hookRunner: input.hookRunner,
+  });
+  if (!block) {
     return undefined;
   }
-  const blockedBy = beforeRunResult?.pluginId ?? "unknown";
-  const message = resolveBlockMessage(beforeRunDecision, { blockedBy });
-  log.warn(`before_agent_run hook blocked by ${blockedBy}`);
-  await persistBlockedBeforeAgentRun({ message, pluginId: blockedBy });
-  return { blockedBy, promptError: new Error(message) };
+  await persistBlockedBeforeAgentRun(block);
+  return { blockedBy: block.blockedBy, promptError: new Error(block.message) };
 }

--- a/src/agents/harness/lifecycle-hook-helpers.ts
+++ b/src/agents/harness/lifecycle-hook-helpers.ts
@@ -8,15 +8,19 @@ import { createHash } from "node:crypto";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString as normalizeTrimmedString } from "@openclaw/normalization-core/string-coerce";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { resolveBlockMessage } from "../../plugins/hook-decision-types.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import type {
+  PluginHookAgentContext,
   PluginHookAgentEndEvent,
   PluginHookBeforeAgentFinalizeEvent,
   PluginHookBeforeAgentFinalizeResult,
+  PluginHookBeforeAgentRunEvent,
   PluginHookLlmInputEvent,
   PluginHookLlmOutputEvent,
 } from "../../plugins/hook-types.js";
 import type { VoidHookRunOptions } from "../../plugins/hooks.js";
+import type { PersistedUserTurnMessage } from "../../sessions/user-turn-transcript.types.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
 import { buildAgentHookContext, type AgentHarnessHookContext } from "./hook-context.js";
 
@@ -25,6 +29,10 @@ const FINALIZE_RETRY_BUDGET_KEY = Symbol.for("openclaw.pluginFinalizeRetryBudget
 const FINALIZE_RETRY_BUDGET_MAX_ENTRIES = 2048;
 
 type AgentHarnessHookRunner = ReturnType<typeof getGlobalHookRunner>;
+type BeforeAgentRunHookRunner = Pick<
+  NonNullable<AgentHarnessHookRunner>,
+  "hasHooks" | "runBeforeAgentRun"
+>;
 type FinalizeRetryBudget = Map<string, Map<string, number>>;
 
 /** Returns the current global hook runner for harness lifecycle hooks. */
@@ -63,6 +71,85 @@ function pruneFinalizeRetryBudget(budget: FinalizeRetryBudget): void {
 
 function buildFinalizeRetryInstructionKey(instruction: string): string {
   return `instruction:${createHash("sha256").update(instruction).digest("hex")}`;
+}
+
+/** Fail-closed before_agent_run outcome shared by every harness runtime. */
+export type AgentHarnessBeforeAgentRunBlock = {
+  blockedBy: string;
+  message: string;
+  /** Redacted user turn each runtime persists in place of the blocked prompt. */
+  blockedUserMessage: PersistedUserTurnMessage & { idempotencyKey: string };
+};
+
+function buildBeforeAgentRunBlock(params: {
+  runId: string;
+  blockedBy: string;
+  message: string;
+}): AgentHarnessBeforeAgentRunBlock {
+  const nowMs = Date.now();
+  return {
+    blockedBy: params.blockedBy,
+    message: params.message,
+    blockedUserMessage: {
+      role: "user",
+      content: [{ type: "text", text: params.message }],
+      timestamp: nowMs,
+      idempotencyKey: `hook-block:before_agent_run:user:${params.runId}`,
+      __openclaw: {
+        beforeAgentRunBlocked: { blockedBy: params.blockedBy, blockedAt: nowMs },
+      },
+    },
+  };
+}
+
+/**
+ * Runs the before_agent_run gate once for a prepared prompt. Hook failure and
+ * block decisions both fail closed; callers must persist `blockedUserMessage`
+ * and skip the provider call when a block is returned.
+ */
+export async function runAgentHarnessBeforeAgentRunHook(params: {
+  runId: string;
+  event: PluginHookBeforeAgentRunEvent;
+  ctx: PluginHookAgentContext;
+  hookRunner?: BeforeAgentRunHookRunner | null;
+}): Promise<AgentHarnessBeforeAgentRunBlock | undefined> {
+  const hookRunner = params.hookRunner ?? getGlobalHookRunner();
+  if (!hookRunner?.hasHooks("before_agent_run")) {
+    return undefined;
+  }
+  let result: Awaited<ReturnType<BeforeAgentRunHookRunner["runBeforeAgentRun"]>>;
+  try {
+    result = await hookRunner.runBeforeAgentRun(
+      {
+        ...params.event,
+        /** Gives hooks an isolated message snapshot they cannot mutate in-session. */
+        messages: params.event.messages.map((message) => structuredClone(message)),
+      },
+      params.ctx,
+    );
+  } catch {
+    log.warn("before_agent_run hook failed; blocking request");
+    const blockedBy = "before_agent_run";
+    return buildBeforeAgentRunBlock({
+      runId: params.runId,
+      blockedBy,
+      message: resolveBlockMessage(
+        { outcome: "block", reason: "before_agent_run hook failed" },
+        { blockedBy },
+      ),
+    });
+  }
+  const decision = result?.decision;
+  if (decision?.outcome !== "block") {
+    return undefined;
+  }
+  const blockedBy = result?.pluginId ?? "unknown";
+  log.warn(`before_agent_run hook blocked by ${blockedBy}`);
+  return buildBeforeAgentRunBlock({
+    runId: params.runId,
+    blockedBy,
+    message: resolveBlockMessage(decision, { blockedBy }),
+  });
 }
 
 /** Dispatches best-effort LLM input hooks for a harness attempt. */

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -548,6 +548,7 @@ export {
   getAgentHarnessHookRunner,
   runAgentHarnessBeforeAgentFinalizeHook,
   runAgentHarnessAgentEndHook,
+  runAgentHarnessBeforeAgentRunHook,
   runAgentHarnessLlmInputHook,
   runAgentHarnessLlmOutputHook,
 } from "../agents/harness/lifecycle-hook-helpers.js";


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Codex app-server runs could reach the provider even when a registered before_agent_run policy hook should block the request.

## Why This Change Was Made

Runs the shared fail-closed before_agent_run gate after the final prompt is prepared and before diagnostics, llm_input, or turn/start. Blocked attempts persist only the canonical redacted message, follow the normal cleanup path, and do not rerun the hook during compact-turn retries.

The same helper is used by Codex, CLI, and embedded harnesses to keep their gate behavior aligned.

## User Impact

Policy plugins can now reliably block Codex app-server requests before any model-visible work begins. Existing runs without a registered hook keep the previous turn-start behavior.

## Evidence

- Pre-fix regression test reached turn/start instead of invoking the gate.
- Codex regression test: 3/3 passed.
- Shared lifecycle and embedded gate suites: 34/34 passed.
- Plugin SDK surface check passed.
- Changed-file validation passed with node scripts/check-changed.mjs.
- git diff --check passed.
