### PR TITLE
refactor(media): consolidate automatic provider selection

### DIFF
--- a/src/media-understanding/defaults.test.ts
+++ b/src/media-understanding/defaults.test.ts
@@ -1,6 +1,7 @@
 // Media-understanding defaults tests keep bundled provider metadata priorities,
 // default models, and native document support aligned with manifests.
 import { describe, expect, it, vi } from "vitest";
+import type { MediaUnderstandingCapability, MediaUnderstandingProvider } from "./types.js";
 
 const mediaMetadataPlugins = vi.hoisted(() => [
   {
@@ -112,6 +113,43 @@ import {
 } from "./defaults.js";
 
 describe("resolveDefaultMediaModel", () => {
+  it.each<MediaUnderstandingCapability>(["image", "audio", "video"])(
+    "uses supplied %s registry defaults before configured models",
+    (capability) => {
+      const providerRegistry = new Map<string, MediaUnderstandingProvider>([
+        ["google", { id: "google", defaultModels: { [capability]: "  registry-model  " } }],
+        ["blank", { id: "blank", defaultModels: { [capability]: " \t " } }],
+      ]);
+      const models = [" GEMINI ", "blank", "missing"].map((providerId) =>
+        resolveDefaultMediaModel({
+          capability,
+          providerId,
+          providerRegistry,
+          cfg: {
+            models: {
+              providers: {
+                google: {
+                  baseUrl: "https://example.invalid",
+                  models: [
+                    {
+                      id: "configured-image",
+                      name: "configured",
+                      input: ["image"],
+                      reasoning: false,
+                      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                      maxTokens: 1024,
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        }),
+      );
+      expect(models).toEqual(["registry-model", undefined, undefined]);
+    },
+  );
+
   it("resolves bundled audio defaults from provider metadata", () => {
     expect(resolveDefaultMediaModel({ providerId: "mistral", capability: "audio" })).toBe(
       "voxtral-mini-latest",
@@ -169,6 +207,42 @@ describe("resolveDefaultMediaModel", () => {
 });
 
 describe("resolveAutoMediaKeyProviders", () => {
+  it.each<MediaUnderstandingCapability>(["image", "audio", "video"])(
+    "orders %s priorities without conflating declared capabilities and runtime hooks",
+    (capability) => {
+      const hooks = {
+        describeImage: async () => ({ text: "image" }),
+        transcribeAudio: async () => ({ text: "audio" }),
+        describeVideo: async () => ({ text: "video" }),
+      };
+      const providers: MediaUnderstandingProvider[] = [
+        { id: "z-tie", capabilities: [capability], autoPriority: { [capability]: 2 } },
+        { id: "a-tie", capabilities: [capability], autoPriority: { [capability]: 2 } },
+        { id: "zero", capabilities: [capability], autoPriority: { [capability]: 0 } },
+        { id: "negative", capabilities: [capability], autoPriority: { [capability]: -2 } },
+        { id: "nan", capabilities: [capability], autoPriority: { [capability]: Number.NaN } },
+        { id: "infinity", capabilities: [capability], autoPriority: { [capability]: Infinity } },
+        { id: "declared-empty", capabilities: [], autoPriority: { [capability]: -10 }, ...hooks },
+        { id: "hook-only", autoPriority: { [capability]: 1 }, ...hooks },
+        { id: "no-hook", autoPriority: { [capability]: -20 } },
+        { id: "gemini", capabilities: [capability], autoPriority: { [capability]: 3 } },
+        { id: "google", capabilities: [capability], autoPriority: { [capability]: 4 } },
+      ];
+      const providerRegistry = new Map(providers.map((provider) => [provider.id, provider]));
+
+      expect(resolveAutoMediaKeyProviders({ capability, providerRegistry })).toEqual([
+        "negative",
+        "zero",
+        "hook-only",
+        "a-tie",
+        "z-tie",
+        "google",
+        "google",
+      ]);
+      expect([...providerRegistry.values()]).toEqual(providers);
+    },
+  );
+
   it("keeps the bundled audio fallback order", () => {
     expect(resolveAutoMediaKeyProviders({ capability: "audio" })).toEqual([
       "openai",

--- a/src/media-understanding/defaults.ts
+++ b/src/media-understanding/defaults.ts
@@ -2,7 +2,6 @@
 // metadata, and capability declarations.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
-import { providerSupportsCapability } from "../../packages/media-understanding-common/src/provider-supports.js";
 import { resolveRuntimeConfigCacheKey } from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
@@ -10,6 +9,8 @@ import { buildMediaUnderstandingManifestMetadataRegistry } from "./manifest-meta
 import {
   normalizeMediaExecutionProviderId,
   normalizeMediaProviderId,
+  resolveAutoMediaKeyProvidersFromRegistry,
+  resolveDefaultMediaModelFromRegistry,
 } from "./provider-registry.js";
 import type { MediaUnderstandingCapability, MediaUnderstandingProvider } from "./types.js";
 export {
@@ -56,15 +57,6 @@ function resolveDefaultRegistry(cfg?: OpenClawConfig, workspaceDir?: string) {
   }
   const registry = buildMediaUnderstandingManifestMetadataRegistry(cfg, workspaceDir);
   return cacheConfigRegistry(cacheKey, registry);
-}
-
-function providerHasDeclaredCapability(
-  provider: MediaUnderstandingProvider | undefined,
-  capability: MediaUnderstandingCapability,
-): boolean {
-  return (
-    provider?.capabilities?.includes(capability) ?? providerSupportsCapability(provider, capability)
-  );
 }
 
 function resolveConfiguredImageProviderModel(params: {
@@ -161,14 +153,11 @@ export function resolveDefaultMediaModel(params: {
   }
   const registry =
     params.providerRegistry ?? resolveDefaultRegistry(params.cfg, params.workspaceDir);
-  const provider = registry.get(normalizeMediaProviderId(params.providerId));
-  const manifestDefaultModel = normalizeOptionalString(
-    provider?.defaultModels?.[params.capability],
-  );
-  if (manifestDefaultModel) {
-    return manifestDefaultModel;
-  }
-  return undefined;
+  return resolveDefaultMediaModelFromRegistry({
+    providerId: params.providerId,
+    capability: params.capability,
+    providerRegistry: registry,
+  });
 }
 
 /** Resolves auto-discovery provider order for a media capability using manifest priorities. */
@@ -180,27 +169,10 @@ export function resolveAutoMediaKeyProviders(params: {
 }): string[] {
   const registry =
     params.providerRegistry ?? resolveDefaultRegistry(params.cfg, params.workspaceDir);
-  type AutoProviderEntry = {
-    provider: MediaUnderstandingProvider;
-    priority: number;
-  };
-  const prioritized = [...registry.values()]
-    .filter((provider) => providerHasDeclaredCapability(provider, params.capability))
-    .map((provider): AutoProviderEntry | null => {
-      const priority = provider.autoPriority?.[params.capability];
-      return typeof priority === "number" && Number.isFinite(priority)
-        ? { provider, priority }
-        : null;
-    })
-    .filter((entry): entry is AutoProviderEntry => entry !== null)
-    .toSorted((left, right) => {
-      if (left.priority !== right.priority) {
-        return left.priority - right.priority;
-      }
-      return left.provider.id.localeCompare(right.provider.id);
-    })
-    .map((entry) => normalizeMediaProviderId(entry.provider.id))
-    .filter(Boolean);
+  const prioritized = resolveAutoMediaKeyProvidersFromRegistry({
+    capability: params.capability,
+    providerRegistry: registry,
+  });
   if (params.providerRegistry || params.capability !== "image") {
     return prioritized;
   }

--- a/src/media-understanding/provider-registry.ts
+++ b/src/media-understanding/provider-registry.ts
@@ -1,9 +1,51 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeMediaProviderId } from "../../packages/media-understanding-common/src/provider-id.js";
+import { providerSupportsCapability } from "../../packages/media-understanding-common/src/provider-supports.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { resolvePluginCapabilityProviders } from "../plugins/capability-provider-runtime.js";
 import { resolveImageCapableConfigProviderIds } from "./config-provider-models.js";
 import { describeImageWithModel, describeImagesWithModel } from "./image-runtime.js";
-import type { MediaUnderstandingProvider } from "./types.js";
+import type { MediaUnderstandingCapability, MediaUnderstandingProvider } from "./types.js";
+
+export function resolveDefaultMediaModelFromRegistry(params: {
+  providerId: string;
+  capability: MediaUnderstandingCapability;
+  providerRegistry: Map<string, MediaUnderstandingProvider>;
+}): string | undefined {
+  const provider = params.providerRegistry.get(normalizeMediaProviderId(params.providerId));
+  return normalizeOptionalString(provider?.defaultModels?.[params.capability]);
+}
+
+export function resolveAutoMediaKeyProvidersFromRegistry(params: {
+  capability: MediaUnderstandingCapability;
+  providerRegistry: Map<string, MediaUnderstandingProvider>;
+}): string[] {
+  type AutoProviderEntry = {
+    provider: MediaUnderstandingProvider;
+    priority: number;
+  };
+  return [...params.providerRegistry.values()]
+    .filter(
+      (provider) =>
+        provider.capabilities?.includes(params.capability) ??
+        providerSupportsCapability(provider, params.capability),
+    )
+    .map((provider): AutoProviderEntry | null => {
+      const priority = provider.autoPriority?.[params.capability];
+      return typeof priority === "number" && Number.isFinite(priority)
+        ? { provider, priority }
+        : null;
+    })
+    .filter((entry): entry is AutoProviderEntry => entry !== null)
+    .toSorted((left, right) => {
+      if (left.priority !== right.priority) {
+        return left.priority - right.priority;
+      }
+      return left.provider.id.localeCompare(right.provider.id);
+    })
+    .map((entry) => normalizeMediaProviderId(entry.provider.id))
+    .filter(Boolean);
+}
 
 function mergeProviderIntoRegistry(
   registry: Map<string, MediaUnderstandingProvider>,

--- a/src/media-understanding/runner.auto-selection.test.ts
+++ b/src/media-understanding/runner.auto-selection.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import type { OpenClawConfig } from "../config/types.js";
+import { buildMediaUnderstandingRegistry } from "./provider-registry.js";
+import { resolveAutoImageModel, runCapability } from "./runner.js";
+import { clearMediaUnderstandingBinaryCacheForTests } from "./runner.test-support.js";
+import { withAudioFixture, withVideoFixture } from "./runner.test-utils.js";
+import type { MediaUnderstandingProvider } from "./types.js";
+
+const selection = vi.hoisted(() => {
+  const providers: MediaUnderstandingProvider[] = [];
+  return {
+    providers,
+    auth: vi.fn<(params: { provider: string }) => Promise<boolean>>(),
+  };
+});
+
+vi.mock("../agents/model-auth.js", async () => {
+  const { createAvailableModelAuthMockModule } = await import("./runner.test-mocks.js");
+  return {
+    ...createAvailableModelAuthMockModule(),
+    hasAvailableAuthForProvider: selection.auth,
+  };
+});
+
+vi.mock("../plugins/capability-provider-runtime.js", () => ({
+  resolvePluginCapabilityProviders: () => selection.providers,
+}));
+
+vi.mock("../agents/prepared-model-catalog.js", () => ({
+  loadProviderScopedThinkingCatalog: async () => [],
+  loadPreparedModelCatalog: async () => [],
+}));
+
+beforeEach(() => {
+  selection.providers.length = 0;
+  selection.auth.mockReset().mockResolvedValue(true);
+  clearMediaUnderstandingBinaryCacheForTests();
+});
+
+afterEach(() => {
+  selection.providers.length = 0;
+  selection.auth.mockReset();
+  clearMediaUnderstandingBinaryCacheForTests();
+});
+
+describe("automatic media selection", () => {
+  it.each([
+    { capability: "image", route: "active", model: "after-auth", provider: "google" },
+    { capability: "image", route: "key", model: "before-auth", provider: "GEMINI" },
+    { capability: "video", route: "active", model: "after-auth", provider: "google" },
+    { capability: "video", route: "key", model: "before-auth", provider: "google" },
+  ] as const)(
+    "preserves $capability $route model capture and provider identity",
+    async (scenario) => {
+      const entered = createDeferred();
+      const available = createDeferred<boolean>();
+      const calls: string[] = [];
+      selection.auth.mockImplementation(async ({ provider }) => {
+        calls.push(provider);
+        if (scenario.route === "key" && calls.length === 1) {
+          return false;
+        }
+        entered.resolve();
+        return available.promise;
+      });
+      selection.providers.push({
+        id: "google",
+        capabilities: ["image", "video"],
+        describeImage: async ({ model }) => ({ text: "image", model }),
+        describeVideo: async ({ model }) => ({ text: "video", model }),
+      });
+      const activeModel = { provider: " GEMINI ", model: "before-auth" };
+      const cfg: OpenClawConfig = {};
+      let outcome: { provider?: string; model?: string } | null = null;
+      if (scenario.capability === "image") {
+        const pending = resolveAutoImageModel({ cfg, activeModel });
+        await entered.promise;
+        activeModel.model = "after-auth";
+        available.resolve(true);
+        outcome = await pending;
+      } else {
+        await withVideoFixture("media-selection-timing", async ({ ctx, media, cache }) => {
+          const pending = runCapability({
+            capability: "video",
+            cfg,
+            ctx,
+            media,
+            attachments: cache,
+            activeModel,
+            providerRegistry: buildMediaUnderstandingRegistry(),
+          });
+          await entered.promise;
+          activeModel.model = "after-auth";
+          available.resolve(true);
+          const result = await pending;
+          expect(result.decision.outcome).toBe("success");
+          expect(result.outputs).toHaveLength(1);
+          outcome = result.outputs[0] ?? null;
+        });
+      }
+      expect(outcome).toMatchObject({ model: scenario.model, provider: scenario.provider });
+      expect(calls).toEqual(scenario.route === "key" ? ["google", "GEMINI"] : ["google"]);
+    },
+  );
+
+  it.each(["provider-transcription", undefined])(
+    "key-selected audio ignores the chat model with provider default %s",
+    async (model) => {
+      let attempts = 0;
+      selection.auth.mockImplementation(async () => ++attempts > 1);
+      const seenModels: Array<string | undefined> = [];
+      const provider: MediaUnderstandingProvider = {
+        id: "selection-audio",
+        capabilities: ["audio"],
+        defaultModels: { audio: model },
+        transcribeAudio: async (request) => {
+          seenModels.push(request.model);
+          return { text: "transcript", model: request.model };
+        },
+      };
+      await withAudioFixture("media-selection-key-audio", async ({ ctx, media, cache }) => {
+        const result = await runCapability({
+          capability: "audio",
+          cfg: {},
+          ctx,
+          media,
+          attachments: cache,
+          providerRegistry: new Map([[provider.id, provider]]),
+          activeModel: { provider: provider.id, model: "chat-only-model" },
+        });
+        expect(result.decision.outcome).toBe("success");
+        expect(seenModels).toEqual([model]);
+        expect(attempts).toBe(2);
+      });
+    },
+  );
+
+  it("retains the final key-provider pass after unavailable local audio", async () => {
+    const calls: string[] = [];
+    selection.auth.mockImplementation(async ({ provider }) => {
+      calls.push(provider);
+      return calls.length === 4;
+    });
+    const providers = ["first", "second"].map(
+      (id, priority): MediaUnderstandingProvider => ({
+        id,
+        capabilities: ["audio"],
+        autoPriority: { audio: priority },
+        defaultModels: { audio: `${id}-transcription` },
+        transcribeAudio: async ({ model }) => ({ text: id, model }),
+      }),
+    );
+    await withAudioFixture("media-selection-second-pass", async ({ ctx, media, cache }) => {
+      const result = await runCapability({
+        capability: "audio",
+        cfg: {},
+        ctx,
+        media,
+        attachments: cache,
+        providerRegistry: new Map(providers.map((provider) => [provider.id, provider])),
+      });
+      expect(calls).toEqual(["first", "second", "first", "second"]);
+      expect(result.outputs).toEqual([
+        {
+          kind: "audio.transcription",
+          attachmentIndex: 0,
+          provider: "second",
+          model: "second-transcription",
+          text: "second",
+        },
+      ]);
+      expect(result.decision.outcome).toBe("success");
+    });
+  });
+});

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -50,6 +50,8 @@ import { resolveOpenAiAudioAuthModelApi } from "./openai-audio-api.js";
 import {
   buildMediaUnderstandingRegistry,
   getMediaUnderstandingProvider,
+  resolveAutoMediaKeyProvidersFromRegistry,
+  resolveDefaultMediaModelFromRegistry,
 } from "./provider-registry.js";
 import {
   resolveModelEntries,
@@ -193,46 +195,6 @@ function resolveCatalogImageModelId(params: {
   return normalizeOptionalString((autoEntry ?? matches[0])?.id);
 }
 
-function resolveDefaultMediaModelFromRegistry(params: {
-  providerId: string;
-  capability: MediaUnderstandingCapability;
-  providerRegistry: ProviderRegistry;
-}): string | undefined {
-  const provider = params.providerRegistry.get(normalizeMediaProviderId(params.providerId));
-  return normalizeOptionalString(provider?.defaultModels?.[params.capability]);
-}
-
-function resolveAutoMediaKeyProvidersFromRegistry(params: {
-  capability: MediaUnderstandingCapability;
-  providerRegistry: ProviderRegistry;
-}): string[] {
-  type AutoProviderEntry = {
-    provider: MediaUnderstandingProvider;
-    priority: number;
-  };
-  return [...params.providerRegistry.values()]
-    .filter(
-      (provider) =>
-        provider.capabilities?.includes(params.capability) ??
-        providerSupportsCapability(provider, params.capability),
-    )
-    .map((provider): AutoProviderEntry | null => {
-      const priority = provider.autoPriority?.[params.capability];
-      return typeof priority === "number" && Number.isFinite(priority)
-        ? { provider, priority }
-        : null;
-    })
-    .filter((entry): entry is AutoProviderEntry => entry !== null)
-    .toSorted((left, right) => {
-      if (left.priority !== right.priority) {
-        return left.priority - right.priority;
-      }
-      return left.provider.id.localeCompare(right.provider.id);
-    })
-    .map((entry) => normalizeMediaProviderId(entry.provider.id))
-    .filter(Boolean);
-}
-
 async function explicitImageModelVisionStatus(params: {
   cfg: OpenClawConfig;
   agentId?: string;
@@ -372,65 +334,12 @@ async function resolveKeyEntry(params: {
   capability: MediaUnderstandingCapability;
   activeModel?: ActiveMediaModel;
 }): Promise<MediaUnderstandingModelConfig | null> {
-  const { cfg, agentId, agentDir, workspaceDir, providerRegistry, capability } = params;
-  const checkProvider = async (
+  const { cfg, providerRegistry, capability } = params;
+  const checkProvider = (
     providerId: string,
     model?: string,
-  ): Promise<MediaUnderstandingModelConfig | null> => {
-    const provider = getMediaUnderstandingProvider(providerId, providerRegistry);
-    if (!provider) {
-      return null;
-    }
-    if (capability === "audio" && !provider.transcribeAudio) {
-      return null;
-    }
-    if (capability === "image" && !provider.describeImage) {
-      return null;
-    }
-    if (capability === "video" && !provider.describeVideo) {
-      return null;
-    }
-    if (
-      !(await hasProviderAuthAvailable({
-        capability,
-        provider: providerId,
-        cfg,
-        agentDir,
-        workspaceDir,
-      }))
-    ) {
-      return null;
-    }
-    // The supplied model can belong to the active chat route. Audio providers
-    // use their own default or stay model-less; explicit media entries bypass this auto path.
-    const resolvedModel =
-      capability === "image"
-        ? await resolveAutoImageModelId({
-            cfg,
-            agentId,
-            providerId,
-            providerRegistry,
-            explicitModel: model,
-            agentDir,
-            workspaceDir,
-          })
-        : capability === "audio"
-          ? resolveDefaultMediaModelFromRegistry({
-              providerId,
-              capability: "audio",
-              providerRegistry,
-            })
-          : (model ??
-            resolveDefaultMediaModelFromRegistry({
-              providerId,
-              capability: "video",
-              providerRegistry,
-            }));
-    if (capability === "image" && !resolvedModel) {
-      return null;
-    }
-    return { type: "provider" as const, provider: providerId, model: resolvedModel };
-  };
+  ): Promise<MediaUnderstandingModelConfig | null> =>
+    resolveAutoProviderModelEntry(params, providerId, () => model);
 
   const activeProvider = params.activeModel?.provider?.trim();
   if (activeProvider) {
@@ -649,17 +558,23 @@ async function resolveActiveModelEntry(params: {
   if (!providerId) {
     return null;
   }
+  return await resolveAutoProviderModelEntry(params, providerId, () => params.activeModel?.model);
+}
+
+async function resolveAutoProviderModelEntry(
+  params: {
+    cfg: OpenClawConfig;
+    agentId?: string;
+    agentDir?: string;
+    workspaceDir?: string;
+    providerRegistry: ProviderRegistry;
+    capability: MediaUnderstandingCapability;
+  },
+  providerId: string,
+  readModel: () => string | undefined,
+): Promise<MediaUnderstandingModelConfig | null> {
   const provider = getMediaUnderstandingProvider(providerId, params.providerRegistry);
-  if (!provider) {
-    return null;
-  }
-  if (params.capability === "audio" && !provider.transcribeAudio) {
-    return null;
-  }
-  if (params.capability === "image" && !provider.describeImage) {
-    return null;
-  }
-  if (params.capability === "video" && !provider.describeVideo) {
+  if (!providerSupportsCapability(provider, params.capability)) {
     return null;
   }
   const hasAuth = await hasProviderAuthAvailable({
@@ -672,6 +587,8 @@ async function resolveActiveModelEntry(params: {
   if (!hasAuth) {
     return null;
   }
+  // Active selection reads its model after auth; key selection captures it before auth.
+  // Audio uses its provider default instead of the active chat model in either path.
   let model: string | undefined;
   if (params.capability === "image") {
     model = await resolveAutoImageModelId({
@@ -679,7 +596,7 @@ async function resolveActiveModelEntry(params: {
       agentId: params.agentId,
       providerId,
       providerRegistry: params.providerRegistry,
-      explicitModel: params.activeModel?.model,
+      explicitModel: readModel(),
       agentDir: params.agentDir,
       workspaceDir: params.workspaceDir,
     });
@@ -691,7 +608,7 @@ async function resolveActiveModelEntry(params: {
     });
   } else {
     model =
-      params.activeModel?.model ??
+      readModel() ??
       resolveDefaultMediaModelFromRegistry({
         providerId,
         capability: "video",


### PR DESCRIPTION
## What Problem This Solves

Media auto-selection duplicated its provider priority/default-model policy between the configuration defaults and the runtime runner. Active-model selection and API-key selection also repeated the same eligibility, authentication, and model-resolution flow. Those copies made behavior-preserving maintenance unnecessarily error-prone.

## Why This Change Was Made

The existing provider registry becomes the single owner of registry-only priority and default-model lookup. The runner shares its provider eligibility/authentication/model-selection flow; configuration and manifest caching remain in the defaults owner. No new abstraction layer, dependency, configuration key, protocol, schema version, or public SDK export is introduced.

The two callers deliberately retain different timing and identity contracts: active selection normalizes its execution provider and reads the model after authentication; key selection retains its trimmed provider identity and captures its model before authentication. Audio still uses its provider default rather than the chat model, and the final key-provider pass after unavailable local audio remains intact.

Production LOC: **+80/-149 (net -69)**. Preservation tests: **+250/-0**. Pure moves cancel in that count.

## User Impact

No intended user-visible change. Existing media selection, configured-image insertion, regional provider aliases, priority ordering, native-vision bypass, authentication, and operator output are preserved. This is an internal cleanup; no changelog entry is needed.

## Evidence

- Fresh Linux Node 24.19.0 / pinned pnpm 11.22.0, with independent frozen dependency installs for the original production code and the candidate. The same preservation tests passed **88/88 on each side**, including active/key model-read timing and audio's final key pass.
- Complete candidate **28-stage changed-file gate**, SDK exports/surface checks, and both normal **15-stage builds** passed. No checks were disabled. All 34,436 source entries were checked before and after each command.
- Actual built audio/video CLI and public image SDK calls exercised automatic model selection, real WAV/MP4/PNG transport, streamed responses, and operator-visible output against owned loopback HTTP endpoints. Parsed requests and results matched between baseline and candidate. This is not external-provider availability or semantic speech/vision-recognition proof.
- An independently authored source-blind validator passed all **12 contract outcomes** across both builds, including fresh response markers and invalid-model rejection before any HTTP request.
- Both public runtime export lists matched. All **69 reachable emitted declaration files were byte-identical**; a separate TypeScript AST walk verified the complete local import closure.
- [Clean-machine proof run](https://github.com/openclaw/openclaw/actions/runs/33138443444). The owned proof trees and process groups were removed, the lease reports completed, and its local connection/key/claim files are absent. Full logs and the hash-bound 172-file evidence collection are retained locally.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33142467949) completed successfully for `9aeedbac84660851602d233b7af1a0233603957f`: 161 passed jobs, 18 intentional skips, required `openclaw/ci-gate` passed. All three pre-commit Codex review passes and all three separate published-head passes finished with no actionable findings. Source, index, patch and review-runtime cleanup were independently checked.

The first environment attempt lacked FFmpeg; installation and a separately recorded rerun resolved it without changing product source. The first independent validator misparsed ordinary SDK diagnostic stdout; only its own result framing was corrected before the successful run. Both failed attempts remain recorded as failures. Existing dependency build warnings were not suppressed.

Current-main composition through `7573b91727c8f9acb0c1ee611749698b92181436` is conflict-free and retains the exact five-file patch and afterimages. Native preparation, merge and actual-squash/ancestry verification remain separate steps; this text does not claim the PR is merged.

## Named Follow-ups

The existing auto-audio test titled “prefers provider keys over auto-detected local whisper” sets its mock-binary PATH outside a fixture that clears PATH. It does not actually prove a competing local binary is available; fixing that fixture and asserting discoverability is separate follow-up work. The new final-key-pass case tests unavailable local audio and makes no competing-binary claim. A private single-caller forwarding helper in `runner.entries.ts` can also be removed separately. Neither is included in this change's line count.
