### PR TITLE
fix(ci): restore Crabbox publisher credentials

### DIFF
--- a/.github/workflows/pr-crabbox-gate-publisher.yml
+++ b/.github/workflows/pr-crabbox-gate-publisher.yml
@@ -39,6 +39,7 @@ jobs:
   publish:
     name: Validate AWS proof and publish gate
     runs-on: ubuntu-24.04
+    environment: qa-live-shared
     timeout-minutes: 10
     permissions:
       checks: write
@@ -80,8 +81,8 @@ jobs:
         env:
           CRABBOX_ACCESS_CLIENT_ID: ${{ secrets.CRABBOX_ACCESS_CLIENT_ID }}
           CRABBOX_ACCESS_CLIENT_SECRET: ${{ secrets.CRABBOX_ACCESS_CLIENT_SECRET }}
-          CRABBOX_COORDINATOR: ${{ secrets.CRABBOX_COORDINATOR }}
-          CRABBOX_COORDINATOR_TOKEN: ${{ secrets.CRABBOX_COORDINATOR_TOKEN }}
+          CRABBOX_COORDINATOR: ${{ secrets.CRABBOX_COORDINATOR || secrets.OPENCLAW_QA_MANTIS_CRABBOX_COORDINATOR }}
+          CRABBOX_COORDINATOR_TOKEN: ${{ secrets.CRABBOX_COORDINATOR_TOKEN || secrets.OPENCLAW_QA_MANTIS_CRABBOX_COORDINATOR_TOKEN }}
           GH_TOKEN: ${{ github.token }}
           GH_APP_TOKEN: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}
         run: node scripts/pr-crabbox-gate-publisher.mjs

--- a/scripts/pr-crabbox-gate-publisher.mjs
+++ b/scripts/pr-crabbox-gate-publisher.mjs
@@ -430,24 +430,30 @@ export async function runPublisher({
 }
 
 export function createJsonApi({
-  accessClientId,
-  accessClientSecret,
+  accessClientId = "",
+  accessClientSecret = "",
   baseUrl,
   token,
   fetchImpl = fetch,
 }) {
-  const base = new URL(baseUrl);
-  requiredString(accessClientId, "Crabbox Access client id");
-  requiredString(accessClientSecret, "Crabbox Access client secret");
-  requiredString(token, "Crabbox coordinator token");
+  const base = new URL(requiredString(baseUrl, "Crabbox coordinator URL"));
+  const hasAccess = Boolean(accessClientId);
+  if (hasAccess !== Boolean(accessClientSecret)) {
+    throw new Error("Crabbox Access client id and secret must be provided together");
+  }
+  const headers = {
+    Authorization: `Bearer ${requiredString(token, "Crabbox coordinator token")}`,
+    ...(hasAccess
+      ? {
+          "CF-Access-Client-Id": accessClientId,
+          "CF-Access-Client-Secret": accessClientSecret,
+        }
+      : {}),
+  };
   return {
     async request(requestPath, options = {}) {
       const response = await fetchImpl(new URL(requestPath, base), {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "CF-Access-Client-Id": accessClientId,
-          "CF-Access-Client-Secret": accessClientSecret,
-        },
+        headers,
         signal: AbortSignal.timeout(30_000),
       });
       if (!response.ok) {
@@ -488,8 +494,8 @@ async function main() {
   const event = JSON.parse(readFileSync(requiredEnv(process.env, "GITHUB_EVENT_PATH"), "utf8"));
   const brokerUrl = requiredEnv(process.env, "CRABBOX_COORDINATOR");
   const broker = createJsonApi({
-    accessClientId: requiredEnv(process.env, "CRABBOX_ACCESS_CLIENT_ID"),
-    accessClientSecret: requiredEnv(process.env, "CRABBOX_ACCESS_CLIENT_SECRET"),
+    accessClientId: process.env.CRABBOX_ACCESS_CLIENT_ID,
+    accessClientSecret: process.env.CRABBOX_ACCESS_CLIENT_SECRET,
     baseUrl: brokerUrl.endsWith("/") ? brokerUrl : `${brokerUrl}/`,
     token: requiredEnv(process.env, "CRABBOX_COORDINATOR_TOKEN"),
   });

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -10468,6 +10468,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     expect(workflow.permissions).toEqual({});
     expect(workflow.on).toHaveProperty("workflow_dispatch");
     expect(job["runs-on"]).toBe("ubuntu-24.04");
+    expect(job.environment).toBe("qa-live-shared");
     expect(job.permissions).toEqual({
       checks: "write",
       contents: "read",
@@ -10485,8 +10486,10 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       env: {
         CRABBOX_ACCESS_CLIENT_ID: "${{ secrets.CRABBOX_ACCESS_CLIENT_ID }}",
         CRABBOX_ACCESS_CLIENT_SECRET: "${{ secrets.CRABBOX_ACCESS_CLIENT_SECRET }}",
-        CRABBOX_COORDINATOR: "${{ secrets.CRABBOX_COORDINATOR }}",
-        CRABBOX_COORDINATOR_TOKEN: "${{ secrets.CRABBOX_COORDINATOR_TOKEN }}",
+        CRABBOX_COORDINATOR:
+          "${{ secrets.CRABBOX_COORDINATOR || secrets.OPENCLAW_QA_MANTIS_CRABBOX_COORDINATOR }}",
+        CRABBOX_COORDINATOR_TOKEN:
+          "${{ secrets.CRABBOX_COORDINATOR_TOKEN || secrets.OPENCLAW_QA_MANTIS_CRABBOX_COORDINATOR_TOKEN }}",
         GH_APP_TOKEN:
           "${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}",
         GH_TOKEN: "${{ github.token }}",

--- a/test/scripts/pr-crabbox-gate-publisher.test.ts
+++ b/test/scripts/pr-crabbox-gate-publisher.test.ts
@@ -605,7 +605,7 @@ describe("Crabbox gate publisher mutation boundary", () => {
 });
 
 describe("Crabbox broker authentication", () => {
-  it("requires and sends coordinator plus Cloudflare Access credentials", async () => {
+  it("sends bearer and complete Cloudflare Access credentials", async () => {
     const fetchImpl = vi.fn<typeof fetch>(async (_input, init) => {
       expect(init?.headers).toEqual({
         Authorization: "Bearer coordinator-token",
@@ -627,15 +627,52 @@ describe("Crabbox broker authentication", () => {
     await expect(api.request("/v1/runs/run_abc123")).resolves.toEqual({
       run: { id: "run_abc123" },
     });
-    expect(() =>
-      createJsonApi({
-        accessClientId: "",
-        accessClientSecret: "access-secret",
-        baseUrl: "https://broker.example/",
-        fetchImpl,
-        token: "coordinator-token",
-      }),
-    ).toThrow(/Access client id/u);
+  });
+
+  it("sends bearer-only authentication when Cloudflare Access is absent", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async (_input, init) => {
+      expect(init?.headers).toEqual({
+        Authorization: "Bearer coordinator-token",
+      });
+      return new Response('{"run":{"id":"run_abc123"}}', {
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+      });
+    });
+    const api = createJsonApi({
+      accessClientId: "",
+      accessClientSecret: "",
+      baseUrl: "https://broker.example/",
+      fetchImpl,
+      token: "coordinator-token",
+    });
+    await expect(api.request("/v1/runs/run_abc123")).resolves.toEqual({
+      run: { id: "run_abc123" },
+    });
+  });
+
+  it.each([
+    ["client secret", "access-id", ""],
+    ["client id", "", "access-secret"],
+  ])(
+    "rejects a Cloudflare Access half-pair missing %s",
+    (_label, accessClientId, accessClientSecret) => {
+      expect(() =>
+        createJsonApi({
+          accessClientId,
+          accessClientSecret,
+          baseUrl: "https://broker.example/",
+          token: "coordinator-token",
+        }),
+      ).toThrow(/must be provided together/u);
+    },
+  );
+
+  it.each([
+    ["coordinator URL", { baseUrl: "", token: "coordinator-token" }],
+    ["coordinator token", { baseUrl: "https://broker.example/", token: "" }],
+  ])("requires the %s", (_label, values) => {
+    expect(() => createJsonApi(values)).toThrow(/required/u);
   });
 });
 
@@ -645,7 +682,11 @@ describe("Crabbox gate workflow", () => {
       readFileSync(".github/workflows/pr-crabbox-gate-publisher.yml", "utf8"),
     ) as {
       jobs: {
-        publish: { permissions: Record<string, string>; steps: Array<Record<string, unknown>> };
+        publish: {
+          environment: string;
+          permissions: Record<string, string>;
+          steps: Array<Record<string, unknown>>;
+        };
       };
       on: { workflow_dispatch: { inputs: Record<string, unknown> } };
       permissions: Record<string, string>;
@@ -659,6 +700,7 @@ describe("Crabbox gate workflow", () => {
       "pr_number",
     ]);
     expect(workflow.permissions).toEqual({});
+    expect(workflow.jobs.publish.environment).toBe("qa-live-shared");
     expect(workflow.jobs.publish.permissions).toEqual({
       checks: "write",
       contents: "read",
@@ -675,8 +717,10 @@ describe("Crabbox gate workflow", () => {
       env: {
         CRABBOX_ACCESS_CLIENT_ID: "${{ secrets.CRABBOX_ACCESS_CLIENT_ID }}",
         CRABBOX_ACCESS_CLIENT_SECRET: "${{ secrets.CRABBOX_ACCESS_CLIENT_SECRET }}",
-        CRABBOX_COORDINATOR: "${{ secrets.CRABBOX_COORDINATOR }}",
-        CRABBOX_COORDINATOR_TOKEN: "${{ secrets.CRABBOX_COORDINATOR_TOKEN }}",
+        CRABBOX_COORDINATOR:
+          "${{ secrets.CRABBOX_COORDINATOR || secrets.OPENCLAW_QA_MANTIS_CRABBOX_COORDINATOR }}",
+        CRABBOX_COORDINATOR_TOKEN:
+          "${{ secrets.CRABBOX_COORDINATOR_TOKEN || secrets.OPENCLAW_QA_MANTIS_CRABBOX_COORDINATOR_TOKEN }}",
         GH_APP_TOKEN:
           "${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}",
         GH_TOKEN: "${{ github.token }}",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the protected-main Crabbox gate publisher received empty coordinator credentials, so an otherwise successful exact-head AWS proof could not publish its trusted check.

## Why This Change Was Made

The publisher job now owns the existing `qa-live-shared` environment and resolves the primary coordinator secret names before the established `OPENCLAW_QA_MANTIS_*` fallback names. The broker client still requires the coordinator URL and bearer token; Cloudflare Access service-token credentials are optional only as a complete pair, with half-configured pairs rejected.

The protected-main trigger, checkout binding, organization-admin validation, and minimal workflow permissions are unchanged.

## User Impact

Maintainers can publish a trusted `openclaw/crabbox-gate` from the existing bearer-only coordinator deployment. Deployments fronted by Cloudflare Access continue to send both Access headers.

## Evidence

- Exact head: `5a48d3e39a392db0bf644ad4839325d91ff10224`
- Tested branch base: `593c7ed65a01bf4454717b029a775aef40ae8f6d`
- Live PR base at evidence refresh: `9b51558d0c7ba49198420666baed2b933d7f9b1a`
- Patch-id: `bd41f4937e1a447960ef219c02f081fcf546d72b`
- `node scripts/run-vitest.mjs test/scripts/pr-crabbox-gate-publisher.test.ts test/scripts/ci-workflow-guards.test.ts`: 170 passed, 2 existing skips on the final lean head
- `actionlint .github/workflows/pr-crabbox-gate-publisher.yml`: passed
- `pnpm lint:scripts`: passed
- scoped `pnpm format:check`: passed
- `node scripts/check-changed.mjs --dry-run -- <four changed files>`: `testRoot,tooling`
- actual changed gate passed conflict, attribution, registry, extension, duplication, coercion, dependency, formatting, patch, and temp-file checks. Test-root typecheck remained blocked only by unrelated missing generated/shared checkout artifacts; no changed-file type errors remain.
- `pnpm check:workflows` was attempted twice and stopped before repository validation because the local Python package index does not contain pinned `pre-commit==4.6.2`; direct Actionlint and workflow guard tests pass.
- Autoreview was attempted; the Codex engine exited before returning a verdict.

LOC classification:

- Workflow + publisher tooling: `+22/-15`, net `+7`
- Publisher script alone: `+19/-13`, net `+6`
- Tests: `+62/-15`

Dependency contracts inspected directly:

- Crabbox `v0.46.0` (`8ba71f913bbe57285ae29af45ef0d8ec6712477d`): coordinator requests send bearer auth independently and add Cloudflare Access client headers only when both service-token values are present (`internal/cli/coordinator.go`).
- Codex `5f49aba876922d6f2f55caa153bbb0ed1b46feba`: explicit command environment values are merged after environment-policy construction, then non-inheritable launch credentials are removed (`codex-rs/exec-server/src/local_process.rs`, `codex-rs/protocol/src/shell_environment.rs`).

AI-assisted: yes. The implementation and proof were reviewed directly against the repository and released dependency source.

## Maintainer Decision

- Live organization membership: `vincentkoc` is `active` / `admin`.
- Live `qa-live-shared` secret inventory contains both primary and `OPENCLAW_QA_MANTIS_*` coordinator URL/token names. Secret values were not read.
- As organization owner, I confirm this protected publisher is intended to use that environment and the bearer-authenticated coordinator route. Released Crabbox `v0.46.0` independently applies bearer auth and only adds Cloudflare Access headers when a complete pair is configured.
- Exact direct broker proof `run_b0b4977c26be` used `https://crabbox.openclaw.ai` with `accessAuth` missing and broker auth configured, then reached `succeeded` / `released`.
- ClawSweeper reviewed exact head `5a48d3e39a392db0bf644ad4839325d91ff10224` with no implementation or security findings. Its operational owner decision is accepted.
- Rank-up move resolved: this body records the exact change, validation, LOC, dependency contracts, and remaining post-landing deployment exercise.

## Agent Transcript

<details>
<summary>Redacted task transcript</summary>

```text
[user]
Repair only the protected Crabbox publisher credential deployment: bind the job to qa-live-shared, use primary coordinator secrets with Mantis fallbacks, allow bearer-only broker auth, require Access credentials as a complete pair, update owning tests, validate, publish a draft PR, and land through the native squash flow.

[assistant]
Created a fresh GWT from origin/main, read the scoped repository and testing rules, and inspected Crabbox v0.46 plus the sibling Codex environment contract.

[assistant]
Implemented only the workflow, publisher, publisher tests, and workflow guard tests. The client requires coordinator URL and bearer auth, emits Access headers only for a complete pair, and rejects either half-pair.

[user]
Run a lean-code pass before landing; compress the publisher script to net no more than +10 operational LOC without changing behavior.

[assistant]
Collapsed optional Access normalization into empty-string defaults, one boolean parity check, and one conditional headers object. Final script delta is +19/-13 (net +6); focused proof remains 170 passed with 2 existing skips.
```

</details>


