### PR TITLE
test(ui): avoid duplicate settings layout reloads

### DIFF
--- a/ui/src/e2e/chat-composer-capability-menu.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-capability-menu.e2e.test.ts
@@ -182,17 +182,17 @@ function webSearchItem(menu: import("playwright").Locator) {
   return menu.locator('wa-dropdown-item[value="toggle-web-search"]');
 }
 
-/* The shared title tooltip (components/tooltip-title.ts) lifts a hovered or
-   focused element's `title` into its overlay and blanks the attribute until
-   the pointer leaves, so dropdown rows race a raw getAttribute("title") read.
-   Read the lifted description when the attribute is blank. */
+// The shared tooltip moves active title hints onto the row or its nested link.
+// Read the reason from the element that owns that accessible description.
 function disabledReason(item: import("playwright").Locator) {
   return item.evaluate((element) => {
     const title = element.getAttribute("title");
     if (title) {
       return title;
     }
-    const describedBy = element.getAttribute("aria-describedby");
+    const describedBy =
+      element.getAttribute("aria-describedby") ??
+      element.querySelector("[aria-describedby]")?.getAttribute("aria-describedby");
     const description = describedBy ? element.ownerDocument.getElementById(describedBy) : null;
     return description?.textContent?.trim() ?? "";
   });
@@ -621,6 +621,7 @@ suite.define(() => {
         .toBe(true);
       const browse = menu.getByRole("menuitem", { name: "Browse connectors" });
       await expect.poll(() => browse.isDisabled()).toBe(true);
+      await browse.hover();
       await expect.poll(() => disabledReason(browse)).toContain("Admin access");
       const addServer = menu.getByRole("menuitem", { name: /Add MCP server/ });
       await expect.poll(() => addServer.isDisabled()).toBe(true);

--- a/ui/src/e2e/settings-layout.e2e.test.ts
+++ b/ui/src/e2e/settings-layout.e2e.test.ts
@@ -245,45 +245,7 @@ suite.define(() => {
     }
   });
 
-  it("binds every settings row subtitle directly to its title", async () => {
-    await suite.withPage(
-      { colorScheme: "dark", locale: "en-US", viewport: { height: 900, width: 1440 } },
-      async ({ page }) => {
-        await installMockGateway(page);
-        let auditedPairCount = 0;
-
-        for (const route of settingsRowRoutes) {
-          const pathname = pathForRoute(route);
-          await page.goto(new URL(pathname, suite.server.baseUrl).toString());
-          await waitForControlUiRoute(page, {
-            pathname,
-            routeId: route,
-          });
-
-          const titleDescriptionPairs = page.locator(
-            ".settings-row__text > .settings-row__title + .settings-row__desc",
-          );
-          const gaps = await titleDescriptionPairs.evaluateAll((descriptions) =>
-            descriptions.map((description) => {
-              const title = description.previousElementSibling;
-              if (!(title instanceof HTMLElement)) {
-                throw new Error("settings row description is missing its title");
-              }
-              const titleBox = title.getBoundingClientRect();
-              const descriptionBox = description.getBoundingClientRect();
-              return Math.round(descriptionBox.y - titleBox.y - titleBox.height);
-            }),
-          );
-          auditedPairCount += gaps.length;
-          expect(gaps, `${route} title/subtitle gaps`).toEqual(gaps.map(() => 0));
-        }
-
-        expect(auditedPairCount).toBeGreaterThan(0);
-      },
-    );
-  });
-
-  it("keeps settings introductions, section headings, and Learn more links on one layout system", async () => {
+  it("keeps settings rows, introductions, section headings, and Learn more links on one layout system", async () => {
     const context = await suite.browser.newContext({
       colorScheme: "dark",
       locale: "en-US",
@@ -298,13 +260,33 @@ suite.define(() => {
         await mkdir(proofDir, { recursive: true });
       }
 
-      const routes = new Set([...introRoutes, ...learnMoreRoutes, ...sectionAlignmentRoutes]);
-      for (const route of routes) {
-        await page.goto(`${suite.server.baseUrl}settings/${route}`);
+      let auditedPairCount = 0;
+      for (const route of settingsRowRoutes) {
+        const pathname = pathForRoute(route);
+        // Reload each route so earlier lazy styles cannot hide missing or misordered CSS.
+        await page.goto(new URL(pathname, suite.server.baseUrl).toString());
         await waitForControlUiRoute(page, {
-          pathname: `/settings/${route}`,
+          pathname,
           routeId: route,
         });
+
+        const titleDescriptionPairs = page.locator(
+          ".settings-row__text > .settings-row__title + .settings-row__desc",
+        );
+        const gaps = await titleDescriptionPairs.evaluateAll((descriptions) =>
+          descriptions.map((description) => {
+            const title = description.previousElementSibling;
+            if (!(title instanceof HTMLElement)) {
+              throw new Error("settings row description is missing its title");
+            }
+            const titleBox = title.getBoundingClientRect();
+            const descriptionBox = description.getBoundingClientRect();
+            return Math.round(descriptionBox.y - titleBox.y - titleBox.height);
+          }),
+        );
+        auditedPairCount += gaps.length;
+        expect(gaps, `${route} title/subtitle gaps`).toEqual(gaps.map(() => 0));
+
         if ((introRoutes as readonly string[]).includes(route)) {
           const title = page.locator(".page-title");
           const subtitle = page.locator(".page-subtitle");
@@ -355,6 +337,8 @@ suite.define(() => {
           ).toBe("none");
         }
       }
+
+      expect(auditedPairCount).toBeGreaterThan(0);
 
       for (const guidanceLink of settingsGuidanceLinks) {
         await page.goto(`${suite.server.baseUrl}settings/${guidanceLink.route}`);


### PR DESCRIPTION
## What Problem This Solves

The settings layout E2E file visits 27 routes to audit row spacing, then starts a separate browser context and reloads ten of those same routes for introduction, heading, and link assertions. Those duplicate app and mocked-Gateway boots add measurable time to the serial Chromium lane.

Related: #131423 (row spacing), #131200 (settings alignment), #131295 (guidance links), #131421 (Communications). This is a maintainer-requested, AI-assisted test-performance change; it does not change product behavior.

## Why This Change Was Made

Run both unchanged assertion sets after the same real document navigation for each of the existing 27 routes. The older layout test keeps ownership of its context and teardown. Its two guidance-link cases and eight responsive cases remain unchanged, and the Communications interaction test remains separate with its distinct config/schema fixture. All 14 proof screenshot names and capture conditions are preserved.

Every route still uses `page.goto` and the existing route-ready check. SPA navigation is unsuitable: lazy stylesheet ordering must be tested without styles retained from earlier routes. The nonempty row audit remains. No mocks, retries, timeout constants, route entries, production files, dependencies, baselines, or snapshots change.

The combined case retains the older layout context's `serviceWorkers: "block"`, also used by the sibling route-CSS test. Ordinary E2E builds execute in Vitest's process (`NODE_ENV=test`), and Vite derives `PROD` from `NODE_ENV === "production"`; `ui/src/main.ts` therefore unregisters rather than registers workers in this lane. Instrumented before/after runs observed no worker registrations, controllers, context workers, or worker-served responses on all 86 documents. The dedicated production-worker E2E path remains separate. Moving the row audit into the existing manual context changes its local default Playwright timeout from the suite helper's 10s to 30s; CI was already 30s. Route-ready and assertion-poll budgets are unchanged, and close errors remain visible.

Production LOC: **0**. Primary performance test: **+27/-43, net -16**. Including the bounded tooltip test repair below: **+33/-48, net -15**, two test files.

## User Impact

No visible UI or operator behavior changes. Developers keep the same browser assertions while the complete settings-layout file runs about two seconds faster. This is a scoped file result, not an extrapolated whole-suite claim.

## Evidence

The untouched checkout was clean at `629a47e3cc20a9f8b6d19c105f840b8a693ec4aa`. Qualification used one Blacksmith Testbox, `tbx_01m139yw17zat6vaq2xxbtqvvj`, Node 24.19.0, pnpm 11.22.0, and system Chromium: https://github.com/openclaw/openclaw/actions/runs/33141864667

The first untouched warmup (26.95s) and pre-edit sample (21.41s) established the baseline before editing. The comparison then excluded a warmup for each variant and ran eight order-balanced AB/BA pairs serially, with one worker, a distinct filesystem module cache per sample, import diagnostics, and `/usr/bin/time -v`. Each run rebuilt and served the normal bundled UI and ran the entire test file with proof capture off.

| Median metric | Before | After | Improvement |
|---|---:|---:|---:|
| Scoped wall | 18.681s | 16.612s | 2.070s / 11.08% |
| Vitest duration | 18.185s | 16.115s | 2.070s |
| Test body | 12.435s | 10.165s | 2.270s / 18.25% |
| Import | 195.5ms | 190.5ms | 5ms |
| CPU user / system | 21.050 / 3.615s | 18.825 / 3.105s | 2.225 / 0.510s |
| Max RSS | 1,647,440 KiB | 1,615,116 KiB | 1.96% |
| CPU utilization | 130.5% | 131.0% | similar |

All eight pairs improved; even the smallest improvement was 0.695s. Median paired improvement was 2.437s. Both the 0.5-second and 3% acceptance thresholds are met.

<details>
<summary>Every measured pair</summary>

| Pair/order | Before wall | After wall | Saved |
|---|---:|---:|---:|
| 1 / AB | 20.356s | 16.801s | 3.555s |
| 2 / BA | 20.289s | 18.248s | 2.041s |
| 3 / AB | 17.960s | 16.762s | 1.198s |
| 4 / BA | 18.206s | 16.461s | 1.745s |
| 5 / AB | 19.292s | 16.430s | 2.862s |
| 6 / BA | 18.271s | 15.439s | 2.832s |
| 7 / AB | 19.092s | 15.926s | 3.165s |
| 8 / BA | 17.541s | 16.846s | 0.695s |

</details>

Temporary per-instance instrumentation confirmed contexts/pages **3→2**, real documents **48→38**, Gateway connects **48→38**, and mock sockets **48→38**. Every document had a distinct ID. The 27-route row audit observed the same **46 title/description pairs**, with identical gap results. The suite still starts one browser and one bundled app server; it starts no real Gateway process.

Reversible fault proof on the candidate caught the original row-gap regression (`0→2px`), introduction margin drift (`2→12px`), underlined Learn more links, a missing lazy settings stylesheet import, and missing Labs route registration. A document-only 17px row-gap contaminant was cleared by real reloads; a temporary SPA-navigation mutation retained it and failed the unchanged assertion. Each production file was restored and SHA-256 checked byte-for-byte; the restored candidate passed.

Commands used:

```sh
# Full-file benchmark; SAMPLE is unique for every before/after run.
/usr/bin/time -v env \
  OPENCLAW_CAPTURE_UI_PROOF=0 \
  OPENCLAW_VITEST_IMPORT_DURATIONS=1 \
  OPENCLAW_VITEST_PRINT_IMPORT_BREAKDOWN=1 \
  OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/ui-reload-bench/cache-SAMPLE \
  node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner \
  ui/src/e2e/settings-layout.e2e.test.ts --maxWorkers=1 --reporter=verbose

# Explicit capture mode, unchanged original and candidate.
OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner \
  ui/src/e2e/settings-layout.e2e.test.ts --maxWorkers=1

# Complete changed gate, routed locally.
OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs -- \
  ui/src/e2e/settings-layout.e2e.test.ts
```

The complete changed gate, formatting, diff checks, independent assertion/route audit, deslop, and fresh isolated Codex autoreview passed. Browser siblings, shuffled/reversed order, capture inspection, exact-head CI, and cleanup are recorded in the final proof update below.

Focused Chromium verification passed: the changed file plus route-CSS and Appearance defaults (10 tests), the same group shuffled with seed 827 (10), and reversed 27-route order with shuffled test order seed 271 (2). Focused router/path/mock-Gateway unit coverage passed (54), as did E2E sharding configuration tests (4).

All 14 before/after capture pairs are pixel-identical and were visually inspected. These remain layout fixtures: the generic Gateway mock intentionally supplies minimal data, so existing approvals errors, unavailable schemas, and empty/loading payload surfaces appear identically before and after. This proof does not claim populated-data or live-Gateway behavior. A separately scoped fixture-enrichment follow-up could provide valid payloads for those surfaces without changing this consolidation.

Remote cleanup found zero active Chromium processes; the task Testbox is stopped. An initial changed-gate launcher unexpectedly allocated a second lease; it was stopped, its orphaned launcher terminated, and the complete gate rerun locally. Benchmark samples never used that second lease.

<details>
<summary>Inspected before/after captures (all 14 pairs)</summary>

![Settings layout before and after comparison](https://github.com/user-attachments/assets/ba2991f4-dff7-4ef7-b11b-a3bde2b6a054)

![Settings layout before and after comparison](https://github.com/user-attachments/assets/71375408-a459-4ec6-8dd7-0963c2aeb93a)

![Settings layout before and after comparison](https://github.com/user-attachments/assets/8cbf4b1a-f91c-4a30-ba3e-3c4a8f999fe3)

![Settings layout before and after comparison](https://github.com/user-attachments/assets/dc495823-9e09-4ba0-88b0-a8f6744b2c47)

![Settings layout before and after comparison](https://github.com/user-attachments/assets/8b10ae30-b728-45bc-85b0-7ab97bc50253)

![Settings layout before and after comparison](https://github.com/user-attachments/assets/721cd33d-4320-499b-8197-c9933e0266b6)

![Settings layout before and after comparison](https://github.com/user-attachments/assets/35bb3ec6-3bb0-4d91-b037-df96d7362671)

</details>


### ClawSweeper proof follow-through

The latest review found no code defects. Its terminal observer ended before the final test output. A fresh-cache real Chromium run of the identical full-file command completed on the reviewed head: 2/2 tests, exit 0, 20.27s Vitest / 21.06s wall, with unchanged timeouts and assertions. [Completed terminal proof and rank-up response](https://github.com/openclaw/openclaw/pull/131537#issuecomment-5448692537). All 14 original before/after PNG pairs are byte-identical. The initial CI failures are documented in the [CI investigation](https://github.com/openclaw/openclaw/pull/131537#issuecomment-5448630816). Their upstream repairs have now landed and are included in the refreshed base; the new exact-head run is linked below.


### CI refresh and bounded tooltip test repair

Head `8834113d400962c7f2f07e5fca8ce7757408c3cf` is rebased onto `e2dd590a3ec27d9b6a1c278d547129db73be8a2c`, incorporating #131541's direct-summary selector and #131471's native-title/accessible-description assertion repair. Those changes are not duplicated in this PR. [Exact-head CI 33144594430](https://github.com/openclaw/openclaw/actions/runs/33144594430) passed, including required openclaw/ci-gate.

The investigation exposed one remaining test flake in the newly landed tooltip helper: Browse connectors is a disabled custom-element wrapper, but its nested link owns `aria-describedby`. Hovering suppresses the wrapper's title, so a wrapper-only lookup returns an empty reason. This PR follows the description to that nested owner and adds one real hover before the existing Admin access assertion. All expected strings, disabled checks, deferred loads, forbidden mutations, and permitted mutations remain. This companion change is test-only (+6/-5); the benchmarked settings-layout source bytes are unchanged.

The exact permanent hover step failed with the pre-fix helper and passed with the repaired helper. A broader temporary Chromium probe exercised all seven reason assertions before hover, during hover, and after pointer-away (three cases passed). Reverting the nested lookup failed the Admin access assertion; removing the active Loading reason still failed its unchanged assertion. Every temporary edit was restored.

Both originally failing files plus settings-layout passed together: 15/15 tests. The same three files on the refreshed base passed with shuffled seed 829: 15/15 in 36.91s. Tooltip/composer owner tests: 55/55. The complete changed gate for both changed files, formatting, diff/LOC checks, deslop, and a fresh isolated Codex review all passed. No production, dependency, baseline, snapshot, configuration, or changelog changes.

### Capture proof refreshed on the new base

Both original and consolidated full-file runs with `OPENCLAW_CAPTURE_UI_PROOF=1` passed on base `e2dd590a3ec`. All 14 screenshot names remain, all 14 before/after pairs are pixel-identical, and all pairs were visually inspected. These refreshed comparisons supplement the Blacksmith captures above; the same documented generic-mock fixture limitations apply.

![Refreshed settings layout before and after, pair sheet 1](https://github.com/user-attachments/assets/f06e8a97-bd05-4123-baf5-f697f5aea099)

![Refreshed settings layout before and after, pair sheet 2](https://github.com/user-attachments/assets/f4234753-a86f-4a3f-926f-b523c2c0b908)

![Refreshed settings layout before and after, pair sheet 3](https://github.com/user-attachments/assets/aaf7a8b5-0910-4f04-8aa2-61a2bcbc4e93)

![Refreshed settings layout before and after, pair sheet 4](https://github.com/user-attachments/assets/d90625b4-1bcf-4c64-a45b-11e0bd3b0edd)

![Refreshed settings layout before and after, pair sheet 5](https://github.com/user-attachments/assets/be22f602-2202-4a63-b1f9-7c1ba93dcd97)

![Refreshed settings layout before and after, pair sheet 6](https://github.com/user-attachments/assets/777c330a-adb8-4fff-8262-9818d081a3d6)

![Refreshed settings layout before and after, pair sheet 7](https://github.com/user-attachments/assets/147281a7-f9e6-451b-a5b3-655ec384695d)


### Final landing state

Merged through native scripts/pr as [2169669140f1](https://github.com/openclaw/openclaw/commit/2169669140f17e01833aec48f8510d641a6c41cb). Prepare retained tested head 8834113d400, with green exact-head CI and no additional push. The final combined autoreview had no actionable findings. A post-merge real Chromium run of settings-layout, capability-menu, and config-form-guidance passed all 15 tests on the merged commit (41.71s). The requested checkout is clean main, matching freshly fetched origin/main at that merge. Both Testboxes are stopped; native temporary worktree/branches and the remote feature branch are removed. [Landing proof](https://github.com/openclaw/openclaw/pull/131537#issuecomment-5448855990), [native completion](https://github.com/openclaw/openclaw/pull/131537#issuecomment-5448859523).
