### PR TITLE
fix: avoid rebuilding package-local plugin memory artifacts

### DIFF
--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -230,6 +230,10 @@ If `pnpm test` flakes on a loaded host, rerun once before treating it as a regre
 - `pnpm test:perf:groups --full-suite --allow-failures --output .artifacts/test-perf/baseline-before.json`: runs every full-suite Vitest leaf config serially and writes grouped duration data plus per-config JSON/log artifacts. Full-suite reports isolate files by default so retained module graphs and GC pauses from earlier files are not charged to later assertions; pass `-- --no-isolate` only when intentionally profiling shared-worker accumulation. `pnpm test:perf:groups:compare .artifacts/test-perf/baseline-before.json .artifacts/test-perf/after-agent.json` compares grouped reports after a performance-focused change.
 - Full, extension, and include-pattern shard runs update local timing data in `.artifacts/vitest-shard-timings.json`; later whole-config runs use those timings to balance slow and fast shards. Include-pattern CI shards append the shard name to the timing key, which keeps filtered shard timings visible without replacing whole-config timing data. Set `OPENCLAW_TEST_PROJECTS_TIMINGS=0` to ignore the local timing artifact.
 
+`pnpm test:extensions:memory` profiles built plugin index entries from `dist/extensions` (including nested `dist` output) and package-local `extensions/<id>/dist` output; TypeScript source entries are excluded. Root artifacts take precedence when both builds exist. Selecting an already-built plugin with `--extension <id>` reuses its output without requiring unrelated plugin builds; build the plugin package first if its output is not supplied by `pnpm build`.
+
+Native imports also need the plugin's declared dependencies and a resolvable `openclaw` host package. The profiler does not install or link dependencies: missing dependencies remain import failures in the JSON report and cause a nonzero exit.
+
 ## Benchmarks
 
 <Accordion title="Model latency (scripts/bench-model.ts)">

--- a/scripts/ensure-extension-memory-build.mts
+++ b/scripts/ensure-extension-memory-build.mts
@@ -2,9 +2,10 @@
 
 // Ensures memory extension runtime entries are built before checks.
 import { spawnSync } from "node:child_process";
-import { existsSync, readdirSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { resolvePluginRootPublicSurfacePath } from "../src/plugins/public-surface-runtime.js";
 import {
   collectBundledPluginBuildEntries,
   NON_PACKAGED_BUNDLED_PLUGIN_DIRS,
@@ -16,10 +17,8 @@ const DEFAULT_BUILD_TIMEOUT_MS = 10 * 60 * 1000;
 
 type ExtensionMemoryBuildParams = {
   env?: NodeJS.ProcessEnv;
-  existsSync?: (path: string) => boolean;
   killSignal?: NodeJS.Signals;
   nodeExecPath?: string;
-  readdirSync?: (path: string) => string[];
   requiredExtensionIds?: string[];
   rootDir?: string;
   spawnSync?: (
@@ -59,35 +58,51 @@ function collectExpectedExtensionMemoryEntryIds(rootDir: string, env: NodeJS.Pro
   }
 }
 
-/**
- * Reports whether built memory extension entries exist.
- */
+/** Discovers built index entries for readiness checks and RSS profiling. */
+export function findBuiltExtensionMemoryEntries(rootDir: string = repoRoot) {
+  const entries = new Map<string, string>();
+  // Prefer canonical root output over package-local builds; source-only entries
+  // returned by the public-surface resolver must never enter a built-RSS run.
+  for (const extensionsDir of [
+    path.join(rootDir, "dist", "extensions"),
+    path.join(rootDir, "extensions"),
+  ]) {
+    let extensionIds: string[];
+    try {
+      extensionIds = readdirSync(extensionsDir);
+    } catch {
+      continue;
+    }
+    for (const dir of extensionIds) {
+      if (entries.has(dir)) {
+        continue;
+      }
+      const file = resolvePluginRootPublicSurfacePath({
+        pluginRoot: path.join(extensionsDir, dir),
+        artifactBasename: "index.js",
+      });
+      if (file && /\.[cm]?js$/u.test(file)) {
+        entries.set(dir, file);
+      }
+    }
+  }
+  return [...entries]
+    .map(([dir, file]) => ({ dir, file }))
+    .toSorted((a, b) => a.dir.localeCompare(b.dir));
+}
+
+/** Reports whether all required built memory extension entries exist. */
 export function hasBuiltExtensionMemoryEntries(params: ExtensionMemoryBuildParams = {}) {
   const rootDir = params.rootDir ?? repoRoot;
-  const exists = params.existsSync ?? existsSync;
-  const readDir = params.readdirSync ?? readdirSync;
-  const extensionsDir = path.join(rootDir, "dist", "extensions");
-  if (!exists(extensionsDir)) {
-    return false;
-  }
-  let extensionIds: string[];
-  try {
-    extensionIds = readDir(extensionsDir);
-  } catch {
-    return false;
-  }
+  const builtIds = new Set(findBuiltExtensionMemoryEntries(rootDir).map((entry) => entry.dir));
   const requiredExtensionIds =
     (params.requiredExtensionIds?.length ?? 0) > 0
       ? params.requiredExtensionIds
       : collectExpectedExtensionMemoryEntryIds(rootDir, params.env ?? process.env);
   if (!requiredExtensionIds || requiredExtensionIds.length === 0) {
-    return extensionIds.some((extensionId) =>
-      exists(path.join(extensionsDir, extensionId, "index.js")),
-    );
+    return builtIds.size > 0;
   }
-  return requiredExtensionIds.every((extensionId) =>
-    exists(path.join(extensionsDir, extensionId, "index.js")),
-  );
+  return requiredExtensionIds.every((id) => builtIds.has(id));
 }
 
 /**
@@ -95,15 +110,7 @@ export function hasBuiltExtensionMemoryEntries(params: ExtensionMemoryBuildParam
  */
 export function ensureExtensionMemoryBuild(params: ExtensionMemoryBuildParams = {}) {
   const rootDir = params.rootDir ?? repoRoot;
-  if (
-    hasBuiltExtensionMemoryEntries({
-      rootDir,
-      existsSync: params.existsSync,
-      readdirSync: params.readdirSync,
-      requiredExtensionIds: params.requiredExtensionIds,
-      env: params.env,
-    })
-  ) {
+  if (hasBuiltExtensionMemoryEntries(params)) {
     return { built: false };
   }
 
@@ -112,7 +119,7 @@ export function ensureExtensionMemoryBuild(params: ExtensionMemoryBuildParams = 
   const buildScript = path.join(rootDir, "scripts", "build-all.mts");
 
   console.error(
-    "[extension-memory-build] dist/extensions missing; running cliStartup build profile",
+    "[extension-memory-build] required built plugin entries missing; running cliStartup build profile",
   );
   const result = spawn(nodeExecPath, ["--import", "tsx", buildScript, "cliStartup"], {
     cwd: rootDir,

--- a/scripts/profile-extension-memory.mts
+++ b/scripts/profile-extension-memory.mts
@@ -2,15 +2,22 @@
 
 // Profiles peak RSS for built bundled plugin entrypoints and emits a JSON
 // report suitable for extension memory budget review.
-import { spawn, type ChildProcessByStdio } from "node:child_process";
+import {
+  spawn,
+  type ChildProcessByStdio,
+  type SpawnOptionsWithStdioTuple,
+} from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { Readable } from "node:stream";
 import { pathToFileURL } from "node:url";
 import pMap from "p-map";
-import { ensureExtensionMemoryBuild } from "./ensure-extension-memory-build.mts";
+import {
+  ensureExtensionMemoryBuild,
+  findBuiltExtensionMemoryEntries,
+} from "./ensure-extension-memory-build.mts";
 import { stripLeadingPackageManagerSeparator } from "./lib/arg-utils.mts";
 import { formatErrorMessage } from "./lib/error-format.mts";
 import { parsePositiveInt } from "./lib/numeric-options.mjs";
@@ -35,7 +42,6 @@ type RunCaseResult = {
   stdout: string;
   timedOut: boolean;
 };
-type ExtensionEntry = { dir: string; file: string };
 type CaseChild = ChildProcessByStdio<null, Readable, Readable>;
 
 const PARENT_SIGNAL_EXIT_CODES = new Map<ParentSignal, number>([
@@ -232,7 +238,11 @@ export async function runCase({
   body: string;
   timeoutMs: number;
   shutdownGraceMs?: number | undefined;
-  spawnImpl?: typeof spawn | undefined;
+  spawnImpl?: (
+    command: string,
+    args: string[],
+    options: SpawnOptionsWithStdioTuple<"ignore", "pipe", "pipe">,
+  ) => CaseChild;
 }): Promise<RunCaseResult> {
   return await new Promise<RunCaseResult>((resolve) => {
     const child = spawnImpl(
@@ -433,23 +443,6 @@ function buildImportBody(entryFiles: string[], label: string): string {
   return `${imports}\nconsole.log(${JSON.stringify(label)});\nprocess.exit(0);\n`;
 }
 
-function findExtensionEntries(repoRoot: string): ExtensionEntry[] {
-  const extensionsDir = path.join(repoRoot, "dist", "extensions");
-  if (!existsSync(extensionsDir)) {
-    throw new Error("dist/extensions not found. Run pnpm build first.");
-  }
-
-  const entries = readdirSync(extensionsDir)
-    .map((dir) => ({ dir, file: path.join(extensionsDir, dir, "index.js") }))
-    .filter((entry) => existsSync(entry.file))
-    .toSorted((a, b) => a.dir.localeCompare(b.dir));
-
-  if (entries.length === 0) {
-    throw new Error("No built bundled plugin entrypoints found in the dist plugin tree");
-  }
-  return entries;
-}
-
 async function main(): Promise<void> {
   const options = parseArgs(process.argv.slice(2));
   const repoRoot = process.cwd();
@@ -457,7 +450,12 @@ async function main(): Promise<void> {
     rootDir: repoRoot,
     requiredExtensionIds: options.extensions,
   });
-  const allEntries = findExtensionEntries(repoRoot);
+  const allEntries = findBuiltExtensionMemoryEntries(repoRoot);
+  if (allEntries.length === 0) {
+    throw new Error(
+      "No built plugin entrypoints found in root or package-local output. Run pnpm build or build the plugin package first.",
+    );
+  }
   const selectedEntries =
     options.extensions.length === 0
       ? allEntries

--- a/test/scripts/ensure-extension-memory-build.test.ts
+++ b/test/scripts/ensure-extension-memory-build.test.ts
@@ -19,6 +19,12 @@ function makeTempRoot(): string {
   return root;
 }
 
+function writeFixture(root: string, relativePath: string, body = "export {};\n") {
+  const file = path.join(root, relativePath);
+  mkdirSync(path.dirname(file), { recursive: true });
+  writeFileSync(file, body, "utf8");
+}
+
 afterEach(() => {
   for (const root of tempRoots.splice(0)) {
     rmSync(root, { recursive: true, force: true });
@@ -26,55 +32,63 @@ afterEach(() => {
 });
 
 describe("ensure-extension-memory-build", () => {
-  it("detects existing built extension entrypoints", () => {
+  it.each([
+    "dist/extensions/external/index.js",
+    "dist/extensions/external/dist/index.js",
+    "extensions/external/dist/index.js",
+  ])("reuses selected built entry %s without building unrelated plugins", (entry) => {
     const root = makeTempRoot();
-    mkdirSync(path.join(root, "dist", "extensions", "telegram"), { recursive: true });
-    writeFileSync(
-      path.join(root, "dist", "extensions", "telegram", "index.js"),
-      "export {};\n",
-      "utf8",
-    );
+    writeFixture(root, entry);
+    writeFixture(root, "extensions/internal/openclaw.plugin.json", '{"id":"internal"}');
+    writeFixture(root, "extensions/internal/index.ts");
+    writeFixture(root, "extensions/external/index.ts", 'throw new Error("source imported");');
 
     expect(
-      hasBuiltExtensionMemoryEntries({ rootDir: root, requiredExtensionIds: ["telegram"] }),
+      hasBuiltExtensionMemoryEntries({ rootDir: root, requiredExtensionIds: ["external"] }),
     ).toBe(true);
-  });
-
-  it("rejects partial built extension entrypoint sets", () => {
-    const root = makeTempRoot();
-    mkdirSync(path.join(root, "dist", "extensions", "discord"), { recursive: true });
-    writeFileSync(
-      path.join(root, "dist", "extensions", "discord", "index.js"),
-      "export {};\n",
-      "utf8",
-    );
-
-    expect(
-      hasBuiltExtensionMemoryEntries({
-        rootDir: root,
-        requiredExtensionIds: ["discord", "telegram"],
-      }),
-    ).toBe(false);
-  });
-
-  it("skips the build profile when extension entrypoints already exist", () => {
-    const root = makeTempRoot();
-    mkdirSync(path.join(root, "dist", "extensions", "discord"), { recursive: true });
-    writeFileSync(
-      path.join(root, "dist", "extensions", "discord", "index.js"),
-      "export {};\n",
-      "utf8",
-    );
 
     const result = ensureExtensionMemoryBuild({
       rootDir: root,
-      requiredExtensionIds: ["discord"],
+      requiredExtensionIds: ["external"],
       spawnSync: () => {
         throw new Error("unexpected build");
       },
     });
 
     expect(result).toEqual({ built: false });
+  });
+
+  it.each([
+    ["dist/extensions/external/index.js", ["external", "internal"]],
+    ["extensions/external/dist/index.js", ["external", "internal"]],
+    ["extensions/external/index.ts", ["external"]],
+    ["extensions/external/dist/api.js", ["external"]],
+  ])("builds when %s does not satisfy required ids %j", (entry, requiredExtensionIds) => {
+    const root = makeTempRoot();
+    writeFixture(root, entry);
+    const params = { rootDir: root, requiredExtensionIds };
+    expect(hasBuiltExtensionMemoryEntries(params)).toBe(false);
+    expect(ensureExtensionMemoryBuild({ ...params, spawnSync: () => ({ status: 0 }) })).toEqual({
+      built: true,
+    });
+  });
+
+  it("requires all expected bundled entries by default even when local output exists", () => {
+    const root = makeTempRoot();
+    for (const id of ["internal-a", "internal-b", "external"]) {
+      writeFixture(root, `extensions/${id}/openclaw.plugin.json`, JSON.stringify({ id }));
+      writeFixture(root, `extensions/${id}/index.ts`);
+    }
+    writeFixture(
+      root,
+      "extensions/external/package.json",
+      JSON.stringify({ openclaw: { build: { bundledDist: false } } }),
+    );
+    writeFixture(root, "extensions/external/dist/index.js");
+    writeFixture(root, "dist/extensions/internal-a/index.js");
+    expect(hasBuiltExtensionMemoryEntries({ rootDir: root, env: {} })).toBe(false);
+    writeFixture(root, "dist/extensions/internal-b/index.js");
+    expect(hasBuiltExtensionMemoryEntries({ rootDir: root, env: {} })).toBe(true);
   });
 
   it("runs the cliStartup build profile when extension entrypoints are missing", () => {

--- a/test/scripts/profile-extension-memory.test.ts
+++ b/test/scripts/profile-extension-memory.test.ts
@@ -1,7 +1,15 @@
 // Profile Extension Memory tests cover profile extension memory script behavior.
 import { spawn, spawnSync } from "node:child_process";
-import { EventEmitter } from "node:events";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { EventEmitter, once } from "node:events";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -9,6 +17,8 @@ import { describe, expect, it } from "vitest";
 import { parseArgs, runCase } from "../../scripts/profile-extension-memory.mts";
 
 const SCRIPT_PATH = path.resolve("scripts/profile-extension-memory.mts");
+const TSX_PRELOAD = path.resolve("scripts/tsx.mjs");
+const SOURCE_TSCONFIG_PATH = path.resolve("tsconfig.json");
 
 async function waitForCondition(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
   const started = Date.now();
@@ -33,9 +43,11 @@ function isProcessAlive(pid: number): boolean {
 }
 
 function runProfileExtensionMemory(args: string[], cwd = process.cwd()) {
-  return spawnSync(process.execPath, [SCRIPT_PATH, ...args], {
+  return spawnSync(process.execPath, ["--import", TSX_PRELOAD, SCRIPT_PATH, ...args], {
     cwd,
     encoding: "utf8",
+    // Fixture cwd controls artifacts; source imports still need the repository's aliases.
+    env: { ...process.env, TSX_TSCONFIG_PATH: SOURCE_TSCONFIG_PATH },
   });
 }
 
@@ -126,6 +138,95 @@ describe("scripts/profile-extension-memory", () => {
       expect(result.stderr).toContain(`[extension-memory] ${args[0]} requires a value`);
       expect(result.stderr).not.toContain("dist/extensions");
       expect(result.stderr).not.toContain("at ");
+    }
+  });
+
+  it.each([
+    {
+      name: "package-local output without a root dist tree",
+      files: ["extensions/external/dist/index.js"],
+      selected: ["external"],
+      expected: [{ dir: "external", file: "extensions/external/dist/index.js" }],
+    },
+    {
+      name: "nested output in the root plugin tree",
+      files: ["dist/extensions/external/dist/index.js"],
+      selected: ["external"],
+      expected: [{ dir: "external", file: "dist/extensions/external/dist/index.js" }],
+    },
+    ...[true, false].map((selected) => ({
+      name: `mixed internal and external output (${selected ? "selected" : "default"})`,
+      files: ["dist/extensions/internal/index.js", "extensions/external/dist/index.js"],
+      selected: selected ? ["internal", "external"] : [],
+      expected: [
+        { dir: "external", file: "extensions/external/dist/index.js" },
+        { dir: "internal", file: "dist/extensions/internal/index.js" },
+      ],
+    })),
+    ...["index.js", "dist/index.js"].map((rootEntry) => ({
+      name: `one canonical root ${rootEntry} when both builds exist`,
+      files: [`dist/extensions/external/${rootEntry}`, "extensions/external/dist/index.js"],
+      selected: ["external", "external"],
+      expected: [{ dir: "external", file: `dist/extensions/external/${rootEntry}` }],
+    })),
+    {
+      name: "source-only plugins excluded from default enumeration",
+      files: ["dist/extensions/internal/index.js"],
+      selected: [],
+      expected: [{ dir: "internal", file: "dist/extensions/internal/index.js" }],
+    },
+  ])("profiles $name", ({ files, selected, expected }) => {
+    const root = realpathSync(mkdtempSync(path.join(tmpdir(), "openclaw-extension-memory-test-")));
+    try {
+      for (const relativeFile of [
+        ...files,
+        "extensions/external/index.ts",
+        "extensions/internal/index.ts",
+        "extensions/source-only/index.ts",
+      ]) {
+        const file = path.join(root, relativeFile);
+        mkdirSync(path.dirname(file), { recursive: true });
+        writeFileSync(
+          file,
+          file.endsWith(".ts") ? 'throw new Error("source imported");\n' : "export {};\n",
+          "utf8",
+        );
+      }
+      const reportPath = path.join(root, "report.json");
+      const result = runProfileExtensionMemory(
+        [
+          ...selected.flatMap((id) => ["--extension", id]),
+          "--concurrency",
+          "1",
+          "--json",
+          reportPath,
+        ],
+        root,
+      );
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stderr).not.toContain("cliStartup");
+      const report = JSON.parse(readFileSync(reportPath, "utf8"));
+      expect(report.selectedExtensions).toEqual(expected.map(({ dir }) => dir));
+      expect(report.results).toEqual(
+        expected.map(({ dir, file }) =>
+          expect.objectContaining({
+            dir,
+            file: path.join(root, file),
+            status: "ok",
+            maxRssMb: expect.any(Number),
+          }),
+        ),
+      );
+      expect(report.combined).toMatchObject({ status: "ok", maxRssMb: expect.any(Number) });
+      expect(report.counts).toEqual({
+        totalEntries: expected.length,
+        ok: expected.length,
+        fail: 0,
+        timeout: 0,
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
     }
   });
 
@@ -295,40 +396,68 @@ describe("scripts/profile-extension-memory", () => {
       try {
         writeFileSync(hookPath, "", "utf8");
         const descendantScript = [
+          "import { writeFileSync } from 'node:fs';",
           "process.on('SIGTERM', () => {});",
           "setInterval(() => {}, 1000);",
+          `writeFileSync(${JSON.stringify(descendantPidPath)}, String(process.pid));`,
         ].join("");
         const body = [
           "const childProcess = await import('node:child_process');",
-          "const fs = await import('node:fs');",
-          "const descendant = childProcess.spawn(process.execPath, [",
+          "childProcess.spawn(process.execPath, [",
           "  '--input-type=module',",
           `  '--eval', ${JSON.stringify(descendantScript)},`,
           "], { stdio: 'ignore' });",
-          `fs.writeFileSync(${JSON.stringify(descendantPidPath)}, String(descendant.pid));`,
           "setInterval(() => {}, 1000);",
         ].join("\n");
-        const resultPromise = runCase({
-          body,
-          env: process.env,
-          hookPath,
-          name: "timeout-descendant",
-          repoRoot: root,
-          shutdownGraceMs: 100,
-          timeoutMs: 250,
+        const child = spawn(
+          process.execPath,
+          ["--import", hookPath, "--input-type=module", "--eval", body],
+          { cwd: root, detached: true, env: process.env, stdio: ["ignore", "pipe", "pipe"] },
+        );
+        const childClosed = new Promise<void>((resolve) => {
+          child.once("close", () => resolve());
         });
+        try {
+          await once(child, "spawn");
+          await waitForCondition(() => {
+            if (!existsSync(descendantPidPath)) {
+              return false;
+            }
+            descendantPid = Number.parseInt(readFileSync(descendantPidPath, "utf8"), 10);
+            return Number.isInteger(descendantPid) && descendantPid > 0;
+          });
+          expect(Number.isInteger(descendantPid)).toBe(true);
+          expect(isProcessAlive(descendantPid)).toBe(true);
 
-        await waitForCondition(() => existsSync(descendantPidPath));
-        descendantPid = Number.parseInt(readFileSync(descendantPidPath, "utf8"), 10);
-        expect(Number.isInteger(descendantPid)).toBe(true);
-        expect(isProcessAlive(descendantPid)).toBe(true);
-
-        await expect(resultPromise).resolves.toMatchObject({
-          name: "timeout-descendant",
-          signal: "SIGKILL",
-          timedOut: true,
-        });
-        await waitForCondition(() => !isProcessAlive(descendantPid));
+          // Start the timeout only once a real descendant exists, independent of host startup load.
+          const resultPromise = runCase({
+            body,
+            env: process.env,
+            hookPath,
+            name: "timeout-descendant",
+            repoRoot: root,
+            shutdownGraceMs: 100,
+            timeoutMs: 250,
+            spawnImpl: () => child,
+          });
+          await expect(resultPromise).resolves.toMatchObject({
+            name: "timeout-descendant",
+            signal: "SIGKILL",
+            timedOut: true,
+          });
+          await waitForCondition(() => !isProcessAlive(descendantPid));
+        } finally {
+          if (child.pid) {
+            try {
+              process.kill(-child.pid, "SIGKILL");
+            } catch (error) {
+              if (!(error instanceof Error && "code" in error && error.code === "ESRCH")) {
+                throw error;
+              }
+            }
+          }
+          await childClosed;
+        }
       } finally {
         if (descendantPid && isProcessAlive(descendantPid)) {
           process.kill(descendantPid, "SIGKILL");
@@ -380,7 +509,7 @@ describe("scripts/profile-extension-memory", () => {
           ].join("\n"),
           "utf8",
         );
-        const runner = spawn(process.execPath, [runnerPath], {
+        const runner = spawn(process.execPath, ["--import", TSX_PRELOAD, runnerPath], {
           stdio: "ignore",
         });
 


### PR DESCRIPTION
Closes #131531 (package-local profiler discovery and unnecessary rebuilds).

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where developers profiling an already-built standalone plugin would trigger an unnecessary `cliStartup` rebuild and still fail to select the compiled entry when it lived in package-local output rather than the flat root-dist layout. Unfiltered reports also silently omitted these entries, and the unnecessary smaller rebuild could replace completed private-QA artifacts.

## Why This Change Was Made

Readiness and profiling now share one built-entry discovery flow that delegates artifact choice to the existing public plugin resolver. It recognizes flat root-dist, nested plugin-local dist, and source-checkout package-local output, preserves root-artifact precedence, deduplicates/sorts IDs, and excludes TypeScript source results. The existing default expected-build inventory and explicit-selection completeness checks remain intact.

This deletes the duplicate root-only enumeration instead of adding plugin-name exceptions, artifact symlinks, loader fallbacks, settings, or dependencies. Plugin runtime/installation policy, build profiles, timeouts, and the report schema are unchanged.

The existing timeout-cleanup test also now waits for a real descendant's readiness before starting its unchanged 250 ms timeout; it no longer confuses slow process startup with cleanup failure. Its existing subprocess seam is typed to the actual ignore/pipe/pipe invocation rather than all Node spawn overloads.

## User Impact

Developers can select existing package-local compiled plugin entries without rebuilding unrelated artifacts. Default profiling includes those built entries, and missing native dependencies remain explicit import failures rather than being hidden by a source fallback.

The fresh full root build does not itself supply WhatsApp's index under current build-ownership policy; its existing standalone package builder supplies the package-local artifact. This PR does not change that policy or claim to fix the separate Doctor cold-start investigation.

## Evidence

Local proof ran against main baseline `60c1dc35becf066b3e2da379a85abed5b07f2ce9` plus this candidate. The affected profiler/build-entry owners remained unchanged when main was rechecked at `629a47e3cc20a9f8b6d19c105f840b8a693ec4aa`. Exact-head CI passed on `b9a6097a7f69210335389fa9e97f0d2bea6fd848`: [pull_request run 33142845760](https://github.com/openclaw/openclaw/actions/runs/33142845760), attempt 1, and [required openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33142845760/job/98758953898) succeeded. The repository CI watcher completed `GREEN`.

- Seven new discovery/readiness regressions failed on pre-fix production code: false readiness, unnecessary build attempts, and omission from default enumeration.
- Final focused tests: **45 passed**. They cover package-only output without root dist, nested output, selected/default mixed layouts, precedence/deduplication, source exclusion, partial required sets, reports, failures, and child cleanup.
- Build-selection, standalone-build, and performance-report sibling tests: **59 passed**. Total: **104 tests in seven files**.
- Changed-file formatting, script/test-root typechecks, targeted lint, and selected repository guards passed. The final documentation-only clarification also passed formatting and `git diff --check`.
- A complete `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build` passed, including 64 external plugin builds, 48 control-plane module/Doctor-closure checks, and 147 public SDK subpath checks.
- The canonical standalone WhatsApp builder added 68 package-local files while preserving all 15,461 pre-existing QA artifacts.
- Real scoped and mixed-layout profiler runs selected `extensions/whatsapp/dist/index.js` without invoking a rebuild. All **15,529 artifact hashes, sizes, timestamps, and symlink targets remained identical** before/after. Inventory SHA-256: `0d43b5a4efd79a9ee02b0bd86e958ceef83b03fc1cead85476210f610e603e8d`.
- Real `memory-core` profiling from root dist passed.
- AI-assisted implementation; fresh independent pre-commit Codex autoreview exited 0 with no actionable findings at its default P0 threshold. This does not claim broader-priority review coverage. No agent transcript is included.

Focused commands:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/ensure-extension-memory-build.test.ts test/scripts/profile-extension-memory.test.ts src/plugins/public-surface-runtime.test.ts --reporter=verbose
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/build-external-plugin-local-dist.test.ts test/scripts/bundled-plugin-build-entries.test.ts test/scripts/check-plugin-npm-runtime-builds.test.ts test/scripts/openclaw-performance-source-summary.test.ts --reporter=verbose
```

```bash
node scripts/check-changed.mjs -- scripts/ensure-extension-memory-build.mts scripts/profile-extension-memory.mts test/scripts/ensure-extension-memory-build.test.ts test/scripts/profile-extension-memory.test.ts docs/reference/test.md
```

```bash
OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build
```

```bash
node scripts/lib/plugin-npm-runtime-build.mjs extensions/whatsapp
```

```bash
OPENCLAW_LOCAL_CHECK=0 node --import tsx scripts/profile-extension-memory.mts --extension whatsapp --skip-combined --concurrency 1
```

### Explicit native-import proof gap

The actual WhatsApp report selects the correct package-local artifact and proves no rebuild, but its native import then fails with `ERR_MODULE_NOT_FOUND` for the `openclaw` host package. Repository source-checkout postinstall deliberately removes plugin-local `node_modules`; a normal frozen offline dependency installation does not restore that host peer. The full workspace dependency set was restored after the scoped install attempt, and the import was retried with the same result.

That pre-existing dependency-setup boundary is recorded separately, not silently fixed through a symlink or TypeScript loader in this PR. A successful WhatsApp native import or Doctor cold-start repair is **not** claimed. The changed discovery/no-rebuild boundary is covered by both real profiler observations and successful native-CLI fixture imports.

### Scope and size

Production/tooling: **+62/-57 (net +5)**. The executable discovery refactor is net -3; eight erased type lines narrow the pre-existing child-spawn dependency to its actual stdio contract. Tests: **+205/-62**. Docs: **+4/-0**. No runtime plugin resolver, manifest, package/dependency file, configuration, schema, or persistence contract changes.

Provenance: the automatic root-only readiness check was authored and committed by @vincentkoc in [4ce3c3e](https://github.com/openclaw/openclaw/commit/4ce3c3e36c1a04abf4c29cf21c96ab8cd5fb4c61) on May 28, 2026; GitHub exposes no associated PR. The old layout assumption was carried through the TypeScript migration. The canonical public resolver is the appropriate owner to reuse; a second artifact policy or plugin-specific exception would perpetuate the mismatch.


### ClawSweeper review disposition

The [published review](https://github.com/openclaw/openclaw/pull/131538#issuecomment-5448758803) found no introduced code or security defect. Its live help check failed before OpenClaw ran because `pnpm` was absent in the review environment. The exact command `pnpm test:extensions:memory -- --help` succeeds in the prepared source checkout (exit 0):

```text
Usage: node --import tsx scripts/profile-extension-memory.mts [options]
```

The pending-CI request is resolved by successful exact-head CI run 33142845760 and its required gate. The size request is covered above: executable refactoring is net -3, with eight erased type lines narrowing the existing spawn contract; the shared finder remains the sole discovery flow. Maintainer review has accepted this focused discovery/no-rebuild boundary and its explicitly separate native-import limitation.

For the optional after-fix real-setup Rank-up move, these are redacted selections from the saved actual profiler reports (paths made repository-relative):

```json
{"profile":"internal","entries":[{"dir":"memory-core","file":"dist/extensions/memory-core/index.js","status":"ok"}]}
{"profile":"standalone","entries":[{"dir":"whatsapp","file":"extensions/whatsapp/dist/index.js","status":"fail"}]}
{"profile":"mixed","entries":[{"dir":"memory-core","file":"dist/extensions/memory-core/index.js","status":"ok"},{"dir":"whatsapp","file":"extensions/whatsapp/dist/index.js","status":"fail"}]}
```

The standalone failure is the recorded `ERR_MODULE_NOT_FOUND` for the `openclaw` host peer, not a discovery failure. No rebuild occurred; the before/final inventories contain the same 15,529 artifact records and compare equal. Successful WhatsApp native import remains unproven. No recording is added because this is a terminal artifact-selection repair with real report and preservation evidence, not a UI change. No source changes or redundant re-review request were made.
