### PR TITLE
test(ui): synchronize transcript pointer interruption

### DIFF
--- a/ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts
@@ -274,10 +274,20 @@ suite.define(() => {
       await streamingRow.waitFor();
       expect(await streamingRow.getAttribute("data-virtual-row-key")).not.toBe(workingRowKey);
       const steerBubble = page.locator(".chat-group.user", { hasText: steerText }).last();
-      const [steerBounds, streamingBounds] = await Promise.all([
-        steerBubble.boundingBox(),
-        streamingBubble.boundingBox(),
-      ]);
+      const steerElement = await steerBubble.elementHandle();
+      // Scrolling between separate protocol reads can make adjacent rows appear to overlap.
+      const [steerBounds, streamingBounds] = await streamingBubble.evaluate(
+        (streaming, steer) =>
+          [steer, streaming].map((element) => {
+            if (!element?.isConnected || element.getClientRects().length === 0) {
+              return null;
+            }
+            const { y, height } = element.getBoundingClientRect();
+            return { y, height };
+          }),
+        steerElement,
+      );
+      await steerElement?.dispose();
       expect(steerBounds).not.toBeNull();
       expect(streamingBounds).not.toBeNull();
       expect(streamingBounds!.y).toBeGreaterThanOrEqual(steerBounds!.y + steerBounds!.height - 1);

--- a/ui/src/e2e/chat-flow.history-recovery.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.history-recovery.e2e.test.ts
@@ -75,7 +75,12 @@ suite.define(() => {
         );
       await sessionLink(sessionB).click();
       await page.getByText(sessionBText, { exact: true }).waitFor({ timeout: 10_000 });
-      const historyRequestsBeforePeerDelete = (await gateway.getRequests("chat.history")).length;
+      const retainedHistoryRequests = async () =>
+        (await gateway.getRequests("chat.history")).filter(({ params }) => {
+          const { sessionKey } = requireRecord(params);
+          return sessionKey === sessionA || sessionKey === sessionB;
+        });
+      const historyRequestsBeforePeerDelete = (await retainedHistoryRequests()).length;
       const startupRequestsBeforePeerDelete = (await gateway.getRequests("chat.startup")).length;
       await page.evaluate(() => {
         window.addEventListener("storage", (event) => {
@@ -117,10 +122,10 @@ suite.define(() => {
 
       await sessionLink(sessionA).click();
       await page.getByText(sessionAText, { exact: true }).waitFor({ timeout: 10_000 });
-      await Promise.all([
-        expectRequestCountStable(gateway, "chat.history", historyRequestsBeforePeerDelete),
-        expectRequestCountStable(gateway, "chat.startup", startupRequestsBeforePeerDelete),
-      ]);
+      // Prefetch may warm C without reloading either retained pane. Request capture is
+      // append-only, so checking history after the startup window covers the same interval.
+      await expectRequestCountStable(gateway, "chat.startup", startupRequestsBeforePeerDelete);
+      expect(await retainedHistoryRequests()).toHaveLength(historyRequestsBeforePeerDelete);
     } finally {
       await suite.closeBrowserContext(context);
     }

--- a/ui/src/e2e/chat-transcript-disclosure-anchor.e2e.test.ts
+++ b/ui/src/e2e/chat-transcript-disclosure-anchor.e2e.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { expect, it } from "vitest";
 import {
   controlUiBundledSettingsStorageKey,
+  controlUiE2eWaitTimeoutMs,
   installMockGateway,
 } from "../test-helpers/control-ui-e2e.ts";
 import { chatThreadDistanceFromBottom, waitForChatScrollIdle } from "./chat-flow.test-support.ts";
@@ -113,16 +114,25 @@ async function showSplitDashboard(page: import("playwright").Page, sessionKey: s
 
 suite.define(() => {
   it.each([
-    { reducedMotion: "no-preference", interruption: "wheel" },
-    { reducedMotion: "reduce", interruption: "wheel" },
-    { reducedMotion: "no-preference", interruption: "pointer" },
+    { reducedMotion: "no-preference", interruption: "wheel", recoveryPosition: "within-viewport" },
+    { reducedMotion: "reduce", interruption: "wheel", recoveryPosition: "within-viewport" },
+    {
+      reducedMotion: "no-preference",
+      interruption: "synthetic-pointer",
+      recoveryPosition: "within-viewport",
+    },
+    {
+      reducedMotion: "no-preference",
+      interruption: "native-pointer",
+      recoveryPosition: "above-viewport",
+    },
   ] as const)(
-    "remeasures recovered assistant text after interrupted scrolling ($reducedMotion, $interruption)",
-    async ({ reducedMotion, interruption }) => {
+    "remeasures recovered assistant text after interrupted scrolling ($reducedMotion, $interruption, $recoveryPosition)",
+    async ({ reducedMotion, interruption, recoveryPosition }) => {
       const artifactDir = path.resolve(
         process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR ??
           ".artifacts/control-ui-e2e/virtual-sizing/after",
-        interruption === "wheel" ? reducedMotion : `${reducedMotion}-${interruption}`,
+        `${reducedMotion}-${interruption}-${recoveryPosition}`,
       );
       await fs.mkdir(artifactDir, { recursive: true });
       await suite.withPage(
@@ -144,7 +154,7 @@ suite.define(() => {
               __openclaw: {
                 id: `sizing-message-${index}`,
                 seq: index + 1,
-                ...(index === 1 || (interruption === "pointer" && index % 2 === 1)
+                ...(index === 1 || (interruption === "native-pointer" && index % 2 === 1)
                   ? { truncated: true, reason: "display-cap" }
                   : {}),
               },
@@ -163,31 +173,86 @@ suite.define(() => {
             .locator('.chat-bubble[data-entry-id="sizing-message-1"]')
             .waitFor({ state: "visible" });
           await page.screenshot({ path: path.join(artifactDir, "01-before-scroll.png") });
-          await page.locator(".chat-scroll-to-bottom").click();
-          await page.waitForFunction((pointerInterruption) => {
-            const scroller = document.querySelector<HTMLElement>(
-              ".chat-pane-cache__pane--active .chat-thread",
-            );
-            return (
-              scroller &&
-              scroller.scrollTop > 0 &&
-              (!pointerInterruption ||
-                Array.from(
-                  scroller.querySelectorAll<HTMLElement>(
-                    '.chat-bubble[data-entry-id^="sizing-message-"]',
-                  ),
-                ).some(
-                  (bubble) =>
-                    Number(bubble.dataset.entryId!.slice("sizing-message-".length)) % 2 === 1 &&
-                    bubble.closest(".chat-virtual-row")!.getBoundingClientRect().bottom <=
-                      scroller.getBoundingClientRect().top,
-                ))
-            );
-          }, interruption === "pointer");
-          const during = await thread.evaluate((element) => ({
-            top: element.scrollTop,
-            max: element.scrollHeight - element.clientHeight,
-          }));
+          let during: { top: number; max: number };
+          if (interruption === "synthetic-pointer") {
+            // Check native gutter hit testing separately from animation timing.
+            const pointer = await thread.evaluateHandle((element) => {
+              const observed = { trusted: false, scroller: false };
+              document.addEventListener(
+                "pointerdown",
+                (event) => {
+                  observed.trusted = event.isTrusted;
+                  observed.scroller = event.target === element;
+                },
+                { capture: true, once: true },
+              );
+              return observed;
+            });
+            const track = await thread.boundingBox();
+            expect(track).not.toBeNull();
+            await page.mouse.click(track!.x + track!.width - 3, track!.y + 20);
+            expect(await pointer.jsonValue()).toEqual({ trusted: true, scroller: true });
+            await pointer.dispose();
+            // Synthetic intent runs in the first positive native scroll callback;
+            // a Node round trip can outlive the fixed row's visible range.
+            // Smooth animation and production cancellation remain real.
+            during = await page
+              .locator(".chat-scroll-to-bottom")
+              .evaluate((button, waitTimeout) => {
+                const scroller = document.querySelector<HTMLElement>(
+                  ".chat-pane-cache__pane--active .chat-thread",
+                )!;
+                return new Promise<{ top: number; max: number }>((resolve, reject) => {
+                  const interrupt = (event: Event) => {
+                    if (!event.isTrusted || scroller.scrollTop <= 0) {
+                      return;
+                    }
+                    clearTimeout(timer);
+                    scroller.removeEventListener("scroll", interrupt);
+                    const position = {
+                      top: scroller.scrollTop,
+                      max: scroller.scrollHeight - scroller.clientHeight,
+                    };
+                    scroller.dispatchEvent(
+                      new PointerEvent("pointerdown", { bubbles: true, pointerType: "mouse" }),
+                    );
+                    resolve(position);
+                  };
+                  const timer = setTimeout(() => {
+                    scroller.removeEventListener("scroll", interrupt);
+                    reject(new Error("Native scrolling did not reach the interruption geometry"));
+                  }, waitTimeout);
+                  scroller.addEventListener("scroll", interrupt);
+                  (button as HTMLElement).click();
+                });
+              }, controlUiE2eWaitTimeoutMs);
+          } else {
+            await page.locator(".chat-scroll-to-bottom").click();
+            await page.waitForFunction((pointerInterruption) => {
+              const scroller = document.querySelector<HTMLElement>(
+                ".chat-pane-cache__pane--active .chat-thread",
+              );
+              return (
+                scroller &&
+                scroller.scrollTop > 0 &&
+                (!pointerInterruption ||
+                  Array.from(
+                    scroller.querySelectorAll<HTMLElement>(
+                      '.chat-bubble[data-entry-id^="sizing-message-"]',
+                    ),
+                  ).some(
+                    (bubble) =>
+                      Number(bubble.dataset.entryId!.slice("sizing-message-".length)) % 2 === 1 &&
+                      bubble.closest(".chat-virtual-row")!.getBoundingClientRect().bottom <=
+                        scroller.getBoundingClientRect().top,
+                  ))
+              );
+            }, interruption === "native-pointer");
+            during = await thread.evaluate((element) => ({
+              top: element.scrollTop,
+              max: element.scrollHeight - element.clientHeight,
+            }));
+          }
           if (reducedMotion === "no-preference") {
             expect(during.top).toBeLessThan(during.max);
           }
@@ -195,11 +260,13 @@ suite.define(() => {
             await thread.hover();
             await page.mouse.wheel(0, -100_000);
           } else {
-            const track = await thread.boundingBox();
-            expect(track).not.toBeNull();
-            // A real pointer press in the scroll gutter can take over without
-            // a wheel event or a changed offset.
-            await page.mouse.click(track!.x + track!.width - 3, track!.y + 20);
+            if (interruption === "native-pointer") {
+              const track = await thread.boundingBox();
+              expect(track).not.toBeNull();
+              // A real pointer press in the scroll gutter can take over without
+              // a wheel event or a changed offset.
+              await page.mouse.click(track!.x + track!.width - 3, track!.y + 20);
+            }
             await page.locator(".chat-scroll-to-bottom").waitFor({ state: "visible" });
             // Chromium can commit its last canceled animation offset after the
             // pointer action returns. Capture the reader before releasing text.
@@ -216,7 +283,7 @@ suite.define(() => {
           // Native smooth scrolling can pass the first message before the pointer
           // arrives. Recover a still-mounted pending row above the settled reader.
           const messageId =
-            interruption === "pointer"
+            interruption === "native-pointer"
               ? await thread.evaluate((element) => {
                   const top = element.getBoundingClientRect().top;
                   const bubbles = Array.from(
@@ -246,8 +313,19 @@ suite.define(() => {
           expect(pendingRequest).toBeDefined();
           const initial = await bubble.evaluate((element) => {
             const row = element.closest<HTMLElement>(".chat-virtual-row")!;
-            return { key: row.dataset.virtualRowKey, height: row.offsetHeight };
+            return {
+              key: row.dataset.virtualRowKey,
+              height: row.offsetHeight,
+              bottom: row.getBoundingClientRect().bottom,
+              viewportTop: row.closest(".chat-thread")!.getBoundingClientRect().top,
+            };
           });
+          if (interruption !== "wheel") {
+            expect(
+              initial.bottom <= initial.viewportTop,
+              `recovered row must remain mounted ${recoveryPosition}`,
+            ).toBe(recoveryPosition === "above-viewport");
+          }
           const fullText = Array.from(
             { length: 5 },
             (_, index) =>
@@ -293,13 +371,20 @@ suite.define(() => {
               2,
             ),
           );
-          if (interruption === "pointer") {
+          if (interruption !== "wheel") {
             // Growth above the reader legitimately adjusts scrollTop; the visible
             // row must stay anchored regardless of where the pointer stopped scrolling.
             expect(finalAnchor.key).toBe(interruptedAnchor.key);
             expect(
               Math.abs(finalAnchor.viewportTop - interruptedAnchor.viewportTop),
             ).toBeLessThanOrEqual(1);
+            if (interruption === "synthetic-pointer") {
+              expect(
+                Math.abs(
+                  (await thread.evaluate((element) => element.scrollTop)) - interruptedOffset,
+                ),
+              ).toBeLessThanOrEqual(1);
+            }
           }
           expect(final.key).toBe(initial.key);
           expect(final.height).toBeGreaterThan(initial.height);


### PR DESCRIPTION
## What Problem This Solves

The transcript recovery browser test could fail because its pointer arrived after the early assistant row had left the intended measured region. Observing an early smooth-scroll offset and then making more Playwright calls before pressing the gutter leaves a host-side gap: the row can unmount, or move entirely above the reader and legitimately trigger resize compensation that violates a raw scroll-offset assertion.

Related: [#130758 — keep chat messages separated after scroll interruptions](https://github.com/openclaw/openclaw/pull/130758), which introduced the recovery coverage. This is maintainer-requested, AI-assisted test work, not a production scrolling change.

Landing CI also exposed a separate assertion comparing steering-message and streaming-reply rectangles from independent protocol responses. Scrolling between those snapshots can manufacture apparent overlap while the elements remain adjacent. This PR includes that bounded atomic measurement correction, without implementing broader steering/runtime changes. A later CI gate exposed an aggregate history counter that also rejects legitimate prefetch for an unopened session; this PR now scopes that existing assertion to the retained sessions it protects.

## Why This Change Was Made

Preserve both recovery contracts in one four-case table: the two existing wheel motion modes, deterministic synthetic pointer recovery within the viewport, and main's genuine native pointer recovery above the viewport. The native case retains the repair from [#131622](https://github.com/openclaw/openclaw/pull/131622), building on [#128803](https://github.com/openclaw/openclaw/pull/128803). None of those PRs' runtime changes are part of this patch.

The native above-viewport case retains an actual Playwright mouse press on the gutter during smooth animation. After native arrival and settling, it chooses the last still-mounted pending assistant wholly above the viewport, delivers only that row's correlated full-message response, and uses main's generalized return-offset/unmount/cache checks. Native arrival is not claimed to be fully deterministic; dynamic row selection removes the fixed-row1 assumption.

The within-viewport case first uses a separate real gutter press to verify **trusted native hit testing** and the exact scroller target before animation. It then dispatches explicitly **synthetic** pointer intent synchronously from the first **trusted positive native scroll event**, before another Node round trip. Message1 must remain mounted and not wholly above the viewport. Actual Chromium smooth animation and production cancellation remain real. The previous synthetic above-viewport case is removed as duplicate coverage of the native case.

Both pointer cases reuse main's visible-row anchor helper and preserve reader key and viewport position within **1 px**. The within case additionally retains the original raw `scrollTop` bound of **1 px**; the native above case allows legitimate raw-offset compensation. Distinct artifact directories separate all four scenarios.

The steering check preserves its exact semantic locators and reads both rectangles synchronously in one browser evaluation. Detached or boxless elements still fail the original non-null assertions; the original **1 px** ordering inequality remains unchanged. Main's additional steering-history tests are preserved.

The retained-transcript test now counts `chat.history` requests only for retained sessions A and B. Unopened C may be prefetched independently. The existing global `chat.startup` stability check still spans the unchanged 500 ms window; checking the exact A/B history count afterward covers that same interval because request capture is append-only. All original 10-second visible waits remain. There is no fixture, helper, prefetch, storage, or lifecycle change.

Neither scrolling fixture invokes controller methods, mocks animation/clocks, assigns an interruption-time scroll offset, or adds a settling retry. Original row identity/growth, adjacency bounds, wait budgets, 5.5-second reconciliation horizon, and virtual unmount/revisit/cache checks remain. There are no runtime, dependency, configuration, baseline, focus-test, or changelog changes.

## User Impact

No production behavior or appearance change. Developers retain both within-viewport and above-viewport recovery coverage without false failures from automation latency or mixed-frame measurements. Missing cancellation, overlap, reversal, detached elements, missing layout boxes, and loss of the unrelated retained transcript still fail.

The deterministic pointer leg is **not** trusted pointer input during animation: trusted gutter routing and synthetic in-motion intent are separate proof legs. The steering fault probe demonstrates controlled adverse scheduling, not a captured replay of the original uninstrumented CI interleaving.

## Evidence

- **Original pointer failure:** an unchanged isolated case timed out after a trusted gutter pointer reached `scrollTop=5576` with rows38–56 mounted and message1 absent. A fresh baseline also failed the unchanged 1 px reader bound by455 px after a79→534 px recovery entirely above the reader.
- **Original pointer coverage:** repeated focused runs, the then-complete disclosure file7/7, and sibling run22/22 passed. Actual sibling order was disclosure → streaming → resize → focus. A dropped-pointer test-only fault failed the unchanged10-second bottom-button wait.
- **Final native/synthetic reconciliation:** focused pointer2/2 passed; the full disclosure file passed8/8 in58.13s. In the full run, synthetic interruption at offset3 recovered message1 from79→534 px with visible anchor `user:0` at24 unchanged and gap0. Native arrival during offset320 settled at1028 and selected message5 wholly above (bottom−170<=viewport top48), recovered100→534 px, and preserved `assistant:7` at−50 with gap0. Both completed unmount/remount/cache proof. Dropping only synthetic dispatch failed the original10-second bottom-button wait; exact source restoration was verified. Local captures were inspected; no media upload or integrated trusted-first-scroll claim.
- **Steering scheduling fault:** real native-scroll turns moved both adjacent elements59 px. Each same-turn pair had gap0; deliberately scheduling remote samples across those turns reproduced `54.875 >= 112.875` failing. The original uninstrumented two-call Mac comparison did not fail naturally in diagnostics; that limitation remains.
- **Steering negative controls:** actual temporary DOM overlap16 px and row reversal failed the original1 px inequality; detached steer, boxless steer, and boxless streaming failed the original non-null checks. The normal case passed. Temporary faults/probes were removed from test discovery.
- **History assertion proof:** controlled native-idle delivery sent `chat.history({sessionKey:"agent:main:session-c",limit:100})` after the baseline but before peer creation/deletion. A/B each retained one message and their cache entries; native scoped C invalidation removed only C. The original aggregate assertion failed expected0/got1. The scoped candidate passed both normal and delayed-prefetch controls. This is controlled scheduling evidence, not a capture of the original uninstrumented CI request identity/interleaving.
- **History negative control:** a temporary `Storage.setItem` fault changed the scoped invalidation payload to `{}`; the browser delivered the actual native storage event, both retained panes cleared, and the unchanged 10-second visible-A assertion failed. That injected fault is not a natural product defect. All temporary faults were removed.
- **Original CI order:** the unchanged test passed in the saved exact 23-file/88-test execution order on the pinned task tree. This was not full Linux/CI merge-tree parity and did not reproduce the original failure. A prior native shard selector chose different membership and was cancelled; its partial results are not proof. The successful order replay's teardown warning is recorded separately.
- **Final clean browser proof:** all three full files on head `8ccdd7eb5b0ad89c5bd0674a593e106e26101cf3` passed **26/26 in101.75s**, with no filters or skips. Real Chromium ran the bundled Control UI with the mocked Gateway. Earlier history-only8/8 and original CI-order88/88 remain supporting evidence, not reproduction of the original CI interleaving.
- **Unchanged real-Gateway auth proof:** the original auth transport file passed **3/3 in120.02s** in its isolated ephemeral real Gateway. Exact quoted64-bit identifier/prefix persistence, served bundle hash, and auth/origin contracts held. Observation-only instrumentation was restored exactly; there is no fourth-file repair. This pass does not explain the initial hosted Raw timeout.
- **Independent review:** fresh isolated Codex autoreview of each accepted semantic repair reported no accepted/actionable findings at the configured **P0 threshold**; the reviewers did not run tests. The latest mixed native/synthetic pointer resolution received a fresh independent review; atomic and history patches replayed with identical stable patch IDs. The final history candidate was reviewed against correctly labeled controlled evidence. No broader threshold claim is made. Parent source/evidence review accepted all three test repairs.
- **Static proof:** final full changed gate on all three files **passed**, including all14 core-test typecheck groups, guards, formatting, lint, Knip and UI i18n, without skip flags. Frozen source bytes are unchanged between these proofs, review and the new commit.

Commands below use Node24.20.0. Focused pointer proof:

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-transcript-disclosure-anchor.e2e.test.ts --testNamePattern=pointer --reporter=verbose
```

Original sibling proof:

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-transcript-disclosure-anchor.e2e.test.ts ui/src/e2e/chat-resize-anchor.e2e.test.ts ui/src/e2e/chat-transcript-focus.e2e.test.ts ui/src/e2e/chat-flow.streaming.e2e.test.ts --reporter=verbose
```

Final combined browser proof:

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.history-recovery.e2e.test.ts ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts ui/src/e2e/chat-transcript-disclosure-anchor.e2e.test.ts --reporter=verbose
```

Final combined static proof:

```bash
node scripts/check-changed.mjs --base 4ec40f190d4580dad0c5d4dc5d111400ef12a60c -- ui/src/e2e/chat-flow.history-recovery.e2e.test.ts ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts ui/src/e2e/chat-transcript-disclosure-anchor.e2e.test.ts
git diff --check
```

Production LOC: **0**. Tests: **+149/−49 (net+100)** across three files versus the reconciled main base. Local browser proof uses Node24.20.0 on macOS, real Chromium, the bundled Control UI harness and a mocked Gateway—not authenticated live providers or a live operator Gateway. No integrated deterministic trusted-pointer-during-animation or stale-size-specific mutation proof is claimed. The historical pointer line189 button timeout and older unrelated persistent zero-gap failure remain unattributed. No claim is made to repair the broader runtime behavior in #131550.

CI and reconciliation history:

1. [Run33142868664](https://github.com/openclaw/openclaw/actions/runs/33142868664) passed all seven original disclosure tests but failed unrelated advanced-disclosure selectors. [#131541 — scope advanced disclosure summary selectors](https://github.com/openclaw/openclaw/pull/131541) repaired that upstream and merged as [87b1787398bb](https://github.com/openclaw/openclaw/commit/87b1787398bb024c9c0bc72c3a77342bb12c490b); the earlier rebase preserved pointer bytes.
2. [Run33144310563](https://github.com/openclaw/openclaw/actions/runs/33144310563) passed that shard but failed the split steering-geometry comparison. That original assertion came from [7f5ae9249fdc](https://github.com/openclaw/openclaw/commit/7f5ae9249fdc7c2979e32869ed64201dab0186da), authored/committed by shakkernerd. The atomic correction addressed the missing same-snapshot invariant.
3. [Run33146962849](https://github.com/openclaw/openclaw/actions/runs/33146962849) succeeded completely at old head `0f122325e7d285b3f41767cbff4de7beff2f0be6`. While it ran, [#128803](https://github.com/openclaw/openclaw/pull/128803) merged [0fef6319fa84](https://github.com/openclaw/openclaw/commit/0fef6319fa84263c09a08e16b42c36c0759673fa), introducing the above-viewport pointer contract and a semantic conflict. Landing stopped rather than choosing one contract. The maintainer then approved the four-case reconciliation, followed by fresh independent review and local proof, before completing the rebase onto `39e01c49d0d619201985c86de73f46afe8399256`.

4. [Run33149662573](https://github.com/openclaw/openclaw/actions/runs/33149662573) failed at `420aa891600c9815d55ce8da7a3148baf48b2399`: only [UI shard4/14](https://github.com/openclaw/openclaw/actions/runs/33149662573/job/98778582297) and the aggregate gate failed; all jobs were terminal. The existing retained-transcript case expected0 requests and observed1. Maintainer-approved investigation established the aggregate measurement defect through the controlled prefetch and invalidation proof above, followed by the reviewed +10/−5 test-only correction. The assertion originated in [#131020](https://github.com/openclaw/openclaw/pull/131020), commit [78bf7a0d9d48](https://github.com/openclaw/openclaw/commit/78bf7a0d9d48eafe38e5614f980353f489eb9397). The original CI interleaving remains untraced; this is not a blind rerun or a runtime repair.

5. [Run33155909129 attempt1](https://github.com/openclaw/openclaw/actions/runs/33155909129/attempts/1) at head `e8e2042dcef47ddf18b9045a24d1fab304ea699c` failed only the real-Gateway job and aggregate (55 success,16 skipped,2 failure); all14 UI shards passed. The auth transport case timed out30000ms on its second Raw click after saving the exact64-bit value, reload and settings navigation. The unchanged local full auth suite later passed3/3; **the hosted timeout's cause remains unproven**. Initial local connection stall and diagnostic collection error are separately recorded, not product fixes.
6. [The already-running attempt2](https://github.com/openclaw/openclaw/actions/runs/33155909129/attempts/2) was adopted, not initiated by this session. Its actual initiator is unknown despite API actor/triggering_actor `steipete`. It failed MCP cancellation evidence (expected1 failed POST, observed0) before auth ran, so it does not clear the Raw failure. [#131690](https://github.com/openclaw/openclaw/pull/131690) subsequently merged the independent MCP test-owner repair as [4ef3b14275f4](https://github.com/openclaw/openclaw/commit/4ef3b14275f46ed7caf45ca60c4b774bd9a6ae9e), awaiting the existing exact failed-request count with the existing poll bound. Its [exact-head CI33158538181](https://github.com/openclaw/openclaw/actions/runs/33158538181) passed. No MCP code was copied or alternate PR taken over.
7. Concurrent main [#131622](https://github.com/openclaw/openclaw/pull/131622), [1deff1bac414](https://github.com/openclaw/openclaw/commit/1deff1bac414e9474182f0c386983f0d7d508433), added native pointer coverage and caused another pointer-only conflict. The maintainer approved preserving its native above-viewport case while retaining our deterministic within case. Fresh source review, independent review, negative control and full browser/static proof preceded the rebase continuation onto `4ec40f190d4580dad0c5d4dc5d111400ef12a60c`.

Current reviewed head: `8ccdd7eb5b0ad89c5bd0674a593e106e26101cf3`. [Fresh exact-head CI33161324807, attempt1](https://github.com/openclaw/openclaw/actions/runs/33161324807) is **terminal SUCCESS:57 successful jobs,16 skipped,0 failures**, including all14 UI shards, [real Gateway](https://github.com/openclaw/openclaw/actions/runs/33161324807/job/98816357189) and [aggregate gate](https://github.com/openclaw/openclaw/actions/runs/33161324807/job/98817647635). The preflight checkout log proves tested merge `611b3d8554930ec72b1f9577e061564edd34070c`, whose parents are `58a1a9be426b503b3e1f18d53af3a9615836d0bd` and the exact reviewed head; its ancestry and source include upstream MCP repair `4ef3b14275f46ed7caf45ca60c4b774bd9a6ae9e`. No extra retry or dispatch was requested by this session. Native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 131539` and `scripts/pr merge-run 131539` passed. The PR **merged at10:06:15Z on2026-08-28** as [90b7950ccdcff](https://github.com/openclaw/openclaw/commit/90b7950ccdcffbd9a87cec29d44951a9c9a5efce); its three landed files are byte-identical to the reviewed head, with the verified+149/−49 test-only delta. [Land-ready proof](https://github.com/openclaw/openclaw/pull/131539#issuecomment-5451184828) and [native completion](https://github.com/openclaw/openclaw/pull/131539#issuecomment-5451215283) record the gates. The cancelled ancillary label run is not a required CI job or proof of failure in this successful CI run.

History evidence provenance: the scratch files originally labeled natural were found to contain the controlled held-idle/release-idle capture. Only their correctly labeled controlled meaning is claimed here; the initial trace run is evidence of a pass, not preserved natural chronology or original CI request identity.

ClawSweeper follow-through: its latest durable review of the preceding head reported no actionable code/security findings, but required conflict resolution, failed-gate attribution and after-fix behavior proof. The reviewed reconciliation, diagnosed measurement defects, controls and terminal real-Chromium results above address the source/proof requests; fresh hosted CI now passed as recorded above. Its Chromium startup SIGABRT and earlier missing Playwright ffmpeg occurred in its reviewer environment, not as assertion failures in our successful runs. The optional Rank-up recording/artifact request is addressed with terminal commands/results and hosted CI links; media is omitted for this test-only change with no runtime/UI appearance change. The original Raw timeout remains an explicit limitation with a separate diagnostics follow-up, not a claimed fix. [One review-only refresh was requested](https://github.com/openclaw/openclaw/pull/131539#issuecomment-5451158943) after automatic dispatch had not yet updated the durable old-head review; queued publishing alone does not replace or delay actual code/proof/CI/native gates. Maintainer authorization to land these three reviewed repairs is explicit and conditional on green gates.
