### PR TITLE
fix(ui): confirm skill proposal mutations

### DIFF
--- a/ui/src/e2e/skill-workshop-proposal-confirmation.e2e.test.ts
+++ b/ui/src/e2e/skill-workshop-proposal-confirmation.e2e.test.ts
@@ -1,0 +1,110 @@
+import { chromium, type Browser } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const updatedAt = "2026-08-29T12:00:00.000Z";
+const revisionHash = "a".repeat(64);
+
+function pendingProposal() {
+  return {
+    createdAt: updatedAt,
+    description: "Clean inbox triage",
+    id: "proposal-1",
+    kind: "create",
+    scanState: "clean",
+    skillKey: "inbox-cleaner",
+    skillName: "Inbox Cleaner",
+    status: "pending",
+    title: "Inbox Cleaner",
+    updatedAt,
+  };
+}
+
+function pendingManifest() {
+  return {
+    schema: "openclaw.skill-workshop.proposals-manifest.v1",
+    updatedAt,
+    proposals: [pendingProposal()],
+  };
+}
+
+function pendingInspect() {
+  return {
+    content: "Review unread mail and archive low-priority threads.",
+    record: {
+      ...pendingProposal(),
+      proposedVersion: "v1",
+      target: { skillKey: "inbox-cleaner", skillName: "Inbox Cleaner" },
+    },
+    revisionHash,
+    supportFiles: [],
+  };
+}
+
+describeControlUiE2e("Skill Workshop proposal confirmation mocked Gateway E2E", () => {
+  let browser: Browser;
+  let server: ControlUiE2eServer;
+
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
+    }
+    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("does not report success when refresh leaves an applied proposal pending", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      featureMethods: [
+        "skills.proposals.apply",
+        "skills.proposals.inspect",
+        "skills.proposals.list",
+      ],
+      methodResponses: {
+        "skills.proposals.apply": { ok: true },
+        "skills.proposals.inspect": pendingInspect(),
+        "skills.proposals.list": pendingManifest(),
+      },
+    });
+
+    try {
+      const response = await page.goto(`${server.baseUrl}skills/workshop`);
+      expect(response?.status()).toBe(200);
+      await gateway.waitForRequest("skills.proposals.list");
+      await page.locator("#skill-workshop-mode-tab-board").click();
+      const applyButton = page.locator(".sw-action-bar .sw-btn--primary");
+      await applyButton.waitFor();
+      await applyButton.click();
+      await gateway.waitForRequest("skills.proposals.apply");
+
+      await expect
+        .poll(async () => page.locator(".sw-error").textContent())
+        .toContain("did not confirm");
+      expect(await page.locator(".sw-action-toast").count()).toBe(0);
+      expect(await page.locator(".sw-action-bar .sw-btn--primary").count()).toBe(1);
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3853,6 +3853,8 @@ export const en: TranslationMap = {
     },
     notices: {
       applied: "Applied",
+      statusNotConfirmed:
+        "The Gateway did not confirm that the proposal is {status}. Refresh and try again.",
       proposalChanged: "Proposal changed. Review the updated draft before choosing another action.",
       rejected: "Rejected",
       revisionRequested: "Revision requested",

--- a/ui/src/pages/skill-workshop/proposals.test.ts
+++ b/ui/src/pages/skill-workshop/proposals.test.ts
@@ -319,6 +319,31 @@ describe("Skill Workshop proposal RPCs", () => {
     },
   );
 
+  it("does not show success when refresh leaves an applied proposal pending", async () => {
+    const { state, context, request } = createFixture(
+      {
+        skillWorkshopProposals: [proposal()],
+        skillWorkshopSelectedKey: "proposal-1",
+      },
+      { assistantAgentId: "reviewer" },
+      ["skills.proposals.apply", "skills.proposals.list", "skills.proposals.inspect"],
+    );
+    request.mockImplementation(async (method: string) => {
+      if (method === "skills.proposals.list") {
+        return manifest("pending");
+      }
+      if (method === "skills.proposals.inspect") {
+        return inspectResult("pending");
+      }
+      return {};
+    });
+
+    await runSkillWorkshopLifecycleAction(state, context, "apply", proposalDecision());
+
+    expect(state.skillWorkshopActionNotice).toBeNull();
+    expect(state.skillWorkshopError).toContain("did not confirm");
+  });
+
   it.each(["apply", "reject"] as const)(
     "%s refuses to act without the reviewed revision hash",
     async (action) => {

--- a/ui/src/pages/skill-workshop/proposals.ts
+++ b/ui/src/pages/skill-workshop/proposals.ts
@@ -360,10 +360,11 @@ async function refreshAfterMutation(
   state: SkillWorkshopState,
   context: SkillWorkshopContext,
   proposalId: string,
-): Promise<void> {
+): Promise<SkillWorkshopProposal | undefined> {
   state.skillWorkshopLoaded = false;
   await loadSkillWorkshopProposals(state, context, { force: true });
   await loadSkillWorkshopProposalDetail(state, context, proposalId, { force: true });
+  return state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId);
 }
 
 function markSkillWorkshopRevisionChanged(
@@ -412,11 +413,14 @@ export async function runSkillWorkshopLifecycleAction(
       expectedRevisionHash,
     };
     await client.request(method, requestParams);
-    await refreshAfterMutation(state, context, proposalId);
-    const updated = state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId);
+    const updated = await refreshAfterMutation(state, context, proposalId);
+    const expectedStatus = action === "apply" ? "applied" : "rejected";
+    if (updated?.status !== expectedStatus) {
+      throw new Error(t("skillWorkshop.notices.statusNotConfirmed", { status: expectedStatus }));
+    }
     showActionNotice(
       state,
-      updated ?? previous,
+      updated,
       t(action === "apply" ? "skillWorkshop.notices.applied" : "skillWorkshop.notices.rejected"),
     );
   } catch (err) {


### PR DESCRIPTION
Closes #131330

## What Problem This Solves

The Control UI Skill Workshop could show `Applied` after a successful apply RPC even when the required refresh still reported the proposal as `pending` or failed to confirm the target state. The UI then disagreed with the authoritative proposal record and the generated skill files.

## Root Cause

`runSkillWorkshopLifecycleAction()` awaited the mutation RPC and refresh requests, but treated any completed refresh as success. It called `showActionNotice(..., "Applied")` without checking that the refreshed proposal had reached the expected terminal status.

## Fix

- Return the refreshed target proposal from `refreshAfterMutation()`.
- Require `applied` after an apply action and `rejected` after a reject action.
- Keep the action notice unset and surface a localized verification error when the refreshed state does not confirm the requested transition.
- Preserve existing revision-conflict and refresh-failure handling.

## User Impact

The Workshop no longer reports a successful terminal action until the Gateway refresh confirms the authoritative proposal status. A pending or unavailable refresh is shown as an error, so operators can retry instead of assuming the skill change is active.

## Evidence

Exact head: `1f295bc21`.

- New regression: successful apply RPC followed by a pending list/inspect refresh produces no success notice and sets the confirmation error.
- Existing apply/reject, revision-conflict, scope, and page lifecycle tests continue to run.
- Focused new regression: `1/1` passed.
- `control-ui-i18n: verify`: passed.
- `oxlint`, formatting, and `git diff --check`: passed.
- `pnpm check:changed` passed all UI guards, i18n, formatting, dependency, boundary, dead-code, and production checks. Its core-test typecheck reaches unrelated current-main UI helper errors involving missing `jsdom` declarations and implicit-any event parameters.

## Scope And Risk

Only the UI acknowledgement boundary changes. Gateway mutation contracts, proposal persistence, revision handling, and CLI behavior are unchanged. A successful action remains visible through the existing refreshed proposal state; only unconfirmed terminal notices are suppressed.

AI-assisted implementation; I reviewed the Skill Workshop UI action controller, Gateway mutation/refresh sequence, proposal status model, locale catalog, and focused regression output.
