### PR TITLE
test(ui): scope advanced disclosure summary selectors

### DIFF
--- a/ui/src/e2e/config-form-guidance.e2e.test.ts
+++ b/ui/src/e2e/config-form-guidance.e2e.test.ts
@@ -204,7 +204,7 @@ suite.define(() => {
         await expect.poll(() => disclosure.count()).toBe(1);
         await expect.poll(() => disclosure.getAttribute("open")).toBeNull();
         await expect
-          .poll(() => disclosure.locator("summary").textContent())
+          .poll(() => disclosure.locator(":scope > summary").textContent())
           .toContain("Advanced settings");
         await expect
           .poll(() => page.getByText("Show Advanced Settings", { exact: true }).count())
@@ -219,7 +219,7 @@ suite.define(() => {
           });
         }
 
-        await disclosure.locator("summary").click();
+        await disclosure.locator(":scope > summary").click();
         await expect.poll(() => disclosure.getAttribute("open")).not.toBeNull();
 
         if (captureUiProofEnabled) {
@@ -230,7 +230,7 @@ suite.define(() => {
           });
         }
 
-        await disclosure.locator("summary").click();
+        await disclosure.locator(":scope > summary").click();
         await expect.poll(() => disclosure.getAttribute("open")).toBeNull();
         await page.waitForTimeout(750);
         expect(await gateway.getRequests("config.patch")).toHaveLength(0);


### PR DESCRIPTION
Related: #131421. Maintainer CI repair required to validate #119388.

## What Problem This Solves

Resolves a problem where the Control UI advanced-settings E2E check fails when it tries to close a disclosure containing nested object settings. This current-main failure also blocks otherwise unrelated PR validation.

## Why This Change Was Made

The check must click the summary belonging to the outer disclosure, not every descendant summary. Opening the advanced fields legitimately renders a nested Prefs disclosure, making the old selector ambiguous. All three uses now select the outer disclosure's direct-child summary.

The nested fixture, strict locator resolution, initial-closed/open/closed sequence, and assertions that no configuration writes occur are unchanged. There are no production changes, timeout increases, skipped tests, or first-match shortcuts.

## User Impact

No product behavior or appearance change. The existing browser check can validate opening and closing advanced settings without confusing nested controls.

## Evidence

- Before: [CI 33141092161, UI E2E job 98752003883](https://github.com/openclaw/openclaw/actions/runs/33141092161/job/98752003883) executed 94 passing tests and one failure. The second disclosure click failed because the selector resolved to both the outer Advanced settings summary and the nested object summary. The affected test and renderers are unchanged between that run's main baseline and this branch's base.
- Provenance: the three descendant-summary selectors were introduced in [#131421](https://github.com/openclaw/openclaw/pull/131421), authored and merged by Patrick Erichsen (@Patrick-Erichsen), commit [f6e38796923a](https://github.com/openclaw/openclaw/commit/f6e38796923a888b68b89c38fc8846175522826e).
- Local checks passed: `git diff --check` and `node_modules/.bin/oxfmt --check ui/src/e2e/config-form-guidance.e2e.test.ts`.
- Reviewed the complete test, shared disclosure and nested-object renderers, suite lifecycle, and installed Playwright 1.62.1 selector implementation. Fresh Codex P0–P2 autoreview and a separately invoked independent P0–P3 review both completed with no findings.
- After: [exact-head CI 33143118814](https://github.com/openclaw/openclaw/actions/runs/33143118814) passed, including the required CI gate, type and lint checks. [Native Chromium job 98758255690](https://github.com/openclaw/openclaw/actions/runs/33143118814/job/98758255690) explicitly passed all three tests in this file: transform-input branches, the browser-local advanced disclosure, and quiet Notifications autosave. The complete shard passed 101 tests across 23 files. This uses the production UI against the mocked Gateway WebSocket harness, not a live provider session.
- Executed merge: `522ba50d3525e0b53e03b3c76ff8cb9a1c69684f`, combining candidate `3af26749e690f59ed7e9eeb9f302ece711dce05b` with main `2058fd7e91a7abbbfa924107a9e73c5f692adce0`. The initial draft run was intentionally skipped; after marking ready, the normal CI run above supplied the passing proof. No test rerun, timeout change or assertion weakening was needed.

Production LOC: 0. Tests: +3/-3. AI-assisted maintainer repair.
