### PR TITLE
refactor(workers): streamline worker lifetime handling

### DIFF
--- a/src/gateway/worker-environments/node-launch-adapter.test.ts
+++ b/src/gateway/worker-environments/node-launch-adapter.test.ts
@@ -371,27 +371,6 @@ describe("node worker launch adapter", () => {
     expect(invoke).not.toHaveBeenCalled();
   });
 
-  it("launches once, polls status, and returns the exact completed receipt", async () => {
-    const input = launchInput();
-    const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(async (request) =>
-      request.command === "worker.launch.v1"
-        ? wire(receipt(input, "running"))
-        : wire(receipt(input, "completed")),
-    );
-    const adapter = createNodeWorkerLaunchAdapter({
-      getTransport: () => transportWith(invoke),
-      sleep: async () => {},
-    });
-
-    await expect(adapter.launch(launchRequest(input))).resolves.toEqual(
-      receipt(input, "completed"),
-    );
-    expect(invoke.mock.calls.map(([request]) => request.command)).toEqual([
-      "worker.launch.v1",
-      "worker.status.v1",
-    ]);
-  });
-
   it("reacquires the node and replays the identical launch after ambiguous disconnect", async () => {
     const input = launchInput();
     let launchCalls = 0;

--- a/src/gateway/worker-environments/node-launch-adapter.ts
+++ b/src/gateway/worker-environments/node-launch-adapter.ts
@@ -27,6 +27,7 @@ import type {
   NodeWorkerSupervisorNodeProof,
   NodeWorkerSupervisorTransport,
 } from "../node-registry-private.js";
+import { raceNodeWorkerOperation } from "./node-worker-abort.js";
 import { WorkerRunnerCapacityError, WorkerRunnerUnavailableError } from "./tunnel-contract.js";
 
 const DEFAULT_RPC_TIMEOUT_MS = 30_000;
@@ -167,26 +168,6 @@ function signalError(signal: AbortSignal, fallback: string): Error {
   return signal.reason instanceof Error ? signal.reason : new Error(fallback);
 }
 
-function raceWithSignal<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
-  if (signal.aborted) {
-    return Promise.reject(signalError(signal, "node worker operation aborted"));
-  }
-  return new Promise<T>((resolve, reject) => {
-    const onAbort = () => reject(signalError(signal, "node worker operation aborted"));
-    signal.addEventListener("abort", onAbort, { once: true });
-    void operation.then(
-      (value) => {
-        signal.removeEventListener("abort", onAbort);
-        resolve(value);
-      },
-      (error: unknown) => {
-        signal.removeEventListener("abort", onAbort);
-        reject(error instanceof Error ? error : new Error("node worker operation failed"));
-      },
-    );
-  });
-}
-
 function createDeadline(params: {
   now: () => number;
   timeoutMs: number;
@@ -228,7 +209,7 @@ export function createNodeWorkerLaunchAdapter(options: NodeWorkerLaunchAdapterOp
   }): Promise<NodeWorkerSupervisorNodeProof> => {
     let nodes: readonly NodeWorkerSupervisorNodeProof[];
     try {
-      nodes = await raceWithSignal(params.transport.listCurrentNodes(), params.signal);
+      nodes = await raceNodeWorkerOperation(params.transport.listCurrentNodes(), params.signal);
     } catch (error) {
       if (params.signal.aborted) {
         throw error;
@@ -322,7 +303,7 @@ export function createNodeWorkerLaunchAdapter(options: NodeWorkerLaunchAdapterOp
         isDispatchAuthorized: params.isAuthorized,
         ...(params.onDispatchReady ? { onDispatchReady: params.onDispatchReady } : {}),
       });
-      const result = await raceWithSignal(operation, signal);
+      const result = await raceNodeWorkerOperation(operation, signal);
       if (!result.ok) {
         const code = result.error?.code ?? "UNAVAILABLE";
         if (code === NODE_WORKER_CAPACITY_EXHAUSTED_ERROR_CODE) {
@@ -362,7 +343,7 @@ export function createNodeWorkerLaunchAdapter(options: NodeWorkerLaunchAdapterOp
     if (remainingMs <= 0 || params.deadline.signal.aborted) {
       throw params.deadline.signal.reason ?? new Error("node worker operation timed out");
     }
-    await raceWithSignal(
+    await raceNodeWorkerOperation(
       sleep(Math.min(params.delayMs, remainingMs), params.deadline.signal),
       params.deadline.signal,
     );

--- a/src/gateway/worker-environments/node-worker-abort.ts
+++ b/src/gateway/worker-environments/node-worker-abort.ts
@@ -1,0 +1,21 @@
+export function raceNodeWorkerOperation<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
+  const abortError = () =>
+    signal.reason instanceof Error ? signal.reason : new Error("node worker operation aborted");
+  if (signal.aborted) {
+    return Promise.reject(abortError());
+  }
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(abortError());
+    signal.addEventListener("abort", onAbort, { once: true });
+    void operation.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error instanceof Error ? error : new Error("node worker operation failed"));
+      },
+    );
+  });
+}

--- a/src/gateway/worker-environments/node-worker-tunnel.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.ts
@@ -28,6 +28,8 @@ import type {
   NodeWorkerSupervisorNodeProof,
   NodeWorkerSupervisorTransport,
 } from "../node-registry-private.js";
+import type { createNodeWorkerLaunchAdapter } from "./node-launch-adapter.js";
+import { raceNodeWorkerOperation } from "./node-worker-abort.js";
 import { nodeWorkerGatewayNamespace } from "./node-worker-gateway-namespace.js";
 import {
   createNodeWorkerWorkspaceActions,
@@ -40,7 +42,6 @@ import {
   WorkerTunnelOwnerDisconnectedError,
   type WorkerTunnelStopReason,
   type WorkerTunnelStatus,
-  type WorkerTurnLaunchRequest,
   type WorkerTurnTunnelHandle,
   type WorkerWorkspaceCommand,
 } from "./tunnel-contract.js";
@@ -60,24 +61,6 @@ const RETRYABLE_TRANSPORT_CODES = new Set([
   "UNAVAILABLE",
 ]);
 
-type NodeWorkerLaunch = (request: {
-  deviceId: string;
-  input: {
-    environmentSession: 1;
-    launchId: string;
-    gatewayNamespace: string;
-    expectedBundleHash: string;
-    placementGeneration: number;
-    descriptor: WorkerTurnLaunchRequest["plan"];
-  };
-  isDispatchAuthorized: () => boolean;
-  isCancellationAuthorized: () => boolean;
-  timeoutMs: number;
-  credentialExpiresAtMs?: number;
-  signal?: AbortSignal;
-  onDispatchReady?: () => void;
-}) => Promise<Exclude<NodeWorkerSupervisorReceipt, { state: "pending" | "running" }>>;
-
 export type NodeWorkerWorkspaceBindingResolver = (binding: {
   environmentId: string;
   ownerEpoch: number;
@@ -89,7 +72,7 @@ type NodeWorkerTunnelManagerOptions = {
   getEnvironment: (environmentId: string) => WorkerEnvironmentRecord | undefined;
   listEnvironments: () => readonly WorkerEnvironmentRecord[];
   getTransport: () => NodeWorkerSupervisorTransport | undefined;
-  launchNodeWorker: NodeWorkerLaunch;
+  launchNodeWorker: ReturnType<typeof createNodeWorkerLaunchAdapter>["launch"];
   validateWorkerTurn: (claim: WorkerSessionTurnClaim) => boolean;
   workspaceTransfer: NodeWorkspaceTransferService;
 };
@@ -111,7 +94,6 @@ type NodeEnvironmentOwner = Omit<NodeWorkerTunnelStartRequest, "expectedBuild"> 
 type NodeTunnelEntry = NodeEnvironmentOwner & {
   expectedBuild: WorkerAdmissionHandshake;
   abortController: AbortController;
-  gatewayNamespace: string;
   handle?: WorkerTurnTunnelHandle;
   initialization?: Promise<void>;
   launchTasks: Set<Promise<unknown>>;
@@ -157,28 +139,6 @@ function payloadJson(value: string | null | undefined): unknown {
   }
 }
 
-function raceWithSignal<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
-  const abortError = () =>
-    signal.reason instanceof Error ? signal.reason : new Error("node worker operation aborted");
-  if (signal.aborted) {
-    return Promise.reject(abortError());
-  }
-  return new Promise<T>((resolve, reject) => {
-    const onAbort = () => reject(abortError());
-    signal.addEventListener("abort", onAbort, { once: true });
-    void operation.then(
-      (value) => {
-        signal.removeEventListener("abort", onAbort);
-        resolve(value);
-      },
-      (error: unknown) => {
-        signal.removeEventListener("abort", onAbort);
-        reject(error instanceof Error ? error : new Error("node worker operation failed"));
-      },
-    );
-  });
-}
-
 /** Owns node-channel handles without treating the persistent machine as a disposable lease. */
 export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOptions) {
   const entries = new Map<string, NodeTunnelEntry>();
@@ -213,7 +173,7 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
     if (!transport) {
       throw new Error("device worker node transport is unavailable");
     }
-    const node = (await raceWithSignal(transport.listCurrentNodes(), signal)).find(
+    const node = (await raceNodeWorkerOperation(transport.listCurrentNodes(), signal)).find(
       (candidate) => candidate.nodeId === entry.deviceId,
     );
     if (!node) {
@@ -226,7 +186,6 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
 
   const runWorkspaceCommand = async (
     entry: NodeTunnelEntry,
-    generation: number,
     command: WorkerWorkspaceCommand & { resetWorkspace?: boolean },
   ): Promise<NodeWorkerWorkspaceExecResult> => {
     const commandTimeoutMs = command.timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS;
@@ -244,7 +203,7 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
       gatewayNamespace,
       environmentId: entry.environmentId,
       sessionId: entry.sessionId,
-      generation,
+      generation: entry.ownerEpoch,
       argv: [...command.argv],
       ...(command.input === undefined ? {} : { input: command.input }),
       timeoutMs: commandTimeoutMs,
@@ -318,7 +277,7 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
       isOwnerCurrent: () => isLiveEntry(entry),
       restoredWorkspace,
       workspaceTransfer: options.workspaceTransfer,
-      runWorkspaceCommand: (command) => runWorkspaceCommand(entry, entry.ownerEpoch, command),
+      runWorkspaceCommand: (command) => runWorkspaceCommand(entry, command),
     });
     const handle: WorkerTurnTunnelHandle = {
       ...workspaceActions,
@@ -435,7 +394,7 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
             signal,
             isDispatchAuthorized: () => stopping && retiredEntries.has(entry),
           });
-          const result = await raceWithSignal(operation, signal);
+          const result = await raceNodeWorkerOperation(operation, signal);
           if (!result.ok) {
             throw new Error(
               `node worker environment stop failed (${result.error?.code ?? "UNAVAILABLE"})`,
@@ -544,7 +503,6 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
       void readiness.promise.catch(() => undefined);
       const entry: NodeTunnelEntry = {
         ...request,
-        gatewayNamespace,
         abortController: new AbortController(),
         launchTasks: new Set(),
         readiness,
@@ -561,7 +519,7 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
           return;
         }
         const restoredWorkspace = resolveWorkspaceBinding
-          ? await raceWithSignal(
+          ? await raceNodeWorkerOperation(
               resolveWorkspaceBinding({
                 environmentId: request.environmentId,
                 ownerEpoch: request.ownerEpoch,

--- a/src/gateway/worker-environments/provider-lifecycle.ts
+++ b/src/gateway/worker-environments/provider-lifecycle.ts
@@ -521,30 +521,14 @@ export function createWorkerProviderLifecycle(options: WorkerProviderLifecycleOp
       await finishDestroy(record, provider).catch(() => undefined);
       return;
     }
-    if (!record.sshEndpoint) {
+    if (!record.sshEndpoint || record.state === "attached") {
       if (
         currentBundle &&
         (!record.bootstrapReceipt ||
           !verifyWorkerAdmissionHandshake(record.bootstrapReceipt, currentBundle))
       ) {
-        // A stale node environment cannot be upgraded in place because its credential and
-        // placement ownership bind the old build. Retire it; reprovisioning reuses the installed
-        // content-addressed bundle without another transfer.
-        await finishDestroy(requestStaleWorkerDestroy(record, store), provider).catch(
-          () => undefined,
-        );
-      }
-      return;
-    }
-    if (record.state === "attached") {
-      if (
-        currentBundle &&
-        (!record.bootstrapReceipt ||
-          !verifyWorkerAdmissionHandshake(record.bootstrapReceipt, currentBundle))
-      ) {
-        // A new Gateway build rejects the old worker at admission. This is expected lifecycle
-        // teardown, not a bootstrap failure. `leaseId` above came from this record, so provider
-        // inspection and destruction share the same durable lease identity.
+        // Attached and node-backed environments bind placement authority to the admitted build.
+        // Retire stale owners; only unattached SSH leases can bootstrap a replacement in place.
         await finishDestroy(requestStaleWorkerDestroy(record, store), provider).catch(
           () => undefined,
         );

--- a/src/gateway/worker-environments/tunnel-contract.ts
+++ b/src/gateway/worker-environments/tunnel-contract.ts
@@ -103,7 +103,7 @@ export type WorkerWorkspaceQuiescence = {
   resume(): Promise<void>;
 };
 
-export type WorkerTurnLaunchRequest = {
+type WorkerTurnLaunchRequest = {
   plan: WorkerLaunchPlan;
   turnClaim: WorkerSessionTurnClaim;
   timeoutMs?: number;

--- a/src/gateway/worker-environments/worker-turn-launcher-claim-admission.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher-claim-admission.test.ts
@@ -5,7 +5,7 @@ import type { SpawnResult } from "../../process/exec.js";
 import { completeWorkerLaunchDescriptor } from "../../worker/launch-descriptor.js";
 import { completeReclaimedWorkspaceTeardown } from "./placement-teardown.js";
 import { createWorkerSessionPlacementGate } from "./placement-worker-gate.js";
-import type { WorkerTurnLaunchRequest } from "./tunnel-contract.js";
+import type { WorkerTurnTunnelHandle } from "./tunnel-contract.js";
 import {
   ENVIRONMENT_ID,
   MANIFEST_REF,
@@ -188,7 +188,7 @@ describe("worker turn launcher claim admission", () => {
     let launchCount = 0;
     const stopTunnel = vi.fn(async () => {});
     const destroy = vi.fn(async () => attachedEnvironment());
-    const launchTurn = vi.fn(async (request: WorkerTurnLaunchRequest): Promise<SpawnResult> => {
+    const launchTurn = vi.fn<WorkerTurnTunnelHandle["launchTurn"]>(async (request) => {
       request.onDispatchReady?.();
       launchCount += 1;
       if (launchCount === 1) {
@@ -329,7 +329,7 @@ describe("worker turn launcher claim admission", () => {
       killed: false;
       termination: "exit";
     }>();
-    const launchTurn = vi.fn((request: WorkerTurnLaunchRequest) => {
+    const launchTurn = vi.fn<WorkerTurnTunnelHandle["launchTurn"]>((request) => {
       request.onDispatchReady?.();
       commandStarted.resolve();
       return commandFinished.promise;

--- a/src/gateway/worker-environments/worker-turn-launcher-reclaimed-placement.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher-reclaimed-placement.test.ts
@@ -19,9 +19,8 @@ import {
   sweepStaleRunContexts,
 } from "../../infra/agent-run-registry.js";
 import { getCommandLaneSnapshot, setCommandLaneConcurrency } from "../../process/command-queue.js";
-import type { SpawnResult } from "../../process/exec.js";
 import { createWorkerSessionPlacementGate } from "./placement-worker-gate.js";
-import type { WorkerTurnLaunchRequest } from "./tunnel-contract.js";
+import type { WorkerTurnTunnelHandle } from "./tunnel-contract.js";
 import {
   ENVIRONMENT_ID,
   MANIFEST_REF,
@@ -109,7 +108,7 @@ describe("worker turn launcher reclaimed placement", () => {
       }
       return active;
     };
-    const launchTurn = vi.fn(async (request: WorkerTurnLaunchRequest): Promise<SpawnResult> => {
+    const launchTurn = vi.fn<WorkerTurnTunnelHandle["launchTurn"]>(async (request) => {
       request.onDispatchReady?.();
       workerStarted.resolve();
       await resumeWorker.promise;

--- a/src/node-host/invoke-worker-supervisor.test.ts
+++ b/src/node-host/invoke-worker-supervisor.test.ts
@@ -27,10 +27,7 @@ import type { NodeWorkerBundleInstallerControl } from "./node-worker-bundle-inst
 import { NodeWorkerCapacityExhaustedError } from "./node-worker-capacity.js";
 import type { NodeWorkerLaunchReceipt } from "./node-worker-launch-store.js";
 import type { NodeWorkerSupervisorControl } from "./node-worker-supervisor-contract.js";
-import {
-  testWorkerLaunchInput,
-  writeNodeWorkerFixture,
-} from "./node-worker-supervisor.test-support.js";
+import { testWorkerLaunchInput } from "./node-worker-supervisor.test-support.js";
 import { NodeWorkerWorkspaceRuntime } from "./node-worker-workspace.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -40,8 +37,7 @@ afterEach(() => {
 });
 
 function launchInput() {
-  const fixture = writeNodeWorkerFixture(tempDirs.make("node-worker-invoke-"));
-  return testWorkerLaunchInput(fixture.workspaceDir, "launch-1", "wait");
+  return testWorkerLaunchInput(path.resolve("workspace"), "launch-1", "wait");
 }
 
 function mismatchedLaunchInput() {
@@ -82,26 +78,18 @@ function cancelInput(receipt: NodeWorkerLaunchReceipt) {
   };
 }
 
-function supervisorWith(receipt: NodeWorkerLaunchReceipt): NodeWorkerSupervisorControl {
+function supervisorWith(receipt: NodeWorkerLaunchReceipt) {
   return {
-    launch: vi.fn(async () => receipt),
-    status: vi.fn(async () => receipt),
-    retainWorkspaces: vi.fn(async () => ({ applied: true, deleted: 0, hasMore: false })),
-    cancel: vi.fn(async () => receipt),
-    stopEnvironment: vi.fn(async () => {}),
-  };
-}
-
-type SupervisorMocks = {
-  launch: ReturnType<typeof vi.fn>;
-  status: ReturnType<typeof vi.fn>;
-  retainWorkspaces: ReturnType<typeof vi.fn>;
-  cancel: ReturnType<typeof vi.fn>;
-  stopEnvironment: ReturnType<typeof vi.fn>;
-};
-
-function supervisorMocks(supervisor: NodeWorkerSupervisorControl): SupervisorMocks {
-  return supervisor as unknown as SupervisorMocks;
+    launch: vi.fn<NodeWorkerSupervisorControl["launch"]>().mockResolvedValue(receipt),
+    status: vi.fn<NodeWorkerSupervisorControl["status"]>().mockResolvedValue(receipt),
+    retainWorkspaces: vi
+      .fn<NodeWorkerSupervisorControl["retainWorkspaces"]>()
+      .mockResolvedValue({ applied: true, deleted: 0, hasMore: false }),
+    cancel: vi.fn<NodeWorkerSupervisorControl["cancel"]>().mockResolvedValue(receipt),
+    stopEnvironment: vi
+      .fn<NodeWorkerSupervisorControl["stopEnvironment"]>()
+      .mockResolvedValue(undefined),
+  } satisfies NodeWorkerSupervisorControl;
 }
 
 async function invokePrivate(params: {
@@ -164,9 +152,9 @@ describe("node-host worker supervisor commands", () => {
       supervisor,
     });
 
-    expect(supervisorMocks(supervisor).stopEnvironment).toHaveBeenCalledExactlyOnceWith(owner);
+    expect(supervisor.stopEnvironment).toHaveBeenCalledExactlyOnceWith(owner);
     expect(result).toMatchObject({ ok: true, payloadJSON: "null" });
-    supervisorMocks(supervisor).stopEnvironment.mockRejectedValueOnce(new Error("still running"));
+    supervisor.stopEnvironment.mockRejectedValueOnce(new Error("still running"));
     const failed = await invokePrivate({
       command: NODE_WORKER_ENVIRONMENT_STOP_COMMAND,
       paramsJSON: JSON.stringify(owner),
@@ -207,16 +195,15 @@ describe("node-host worker supervisor commands", () => {
       supervisor,
     });
 
-    const mocks = supervisorMocks(supervisor);
-    expect(mocks[method].mock.calls).toHaveLength(1);
+    expect(supervisor[method].mock.calls).toHaveLength(1);
     if (method === "launch") {
-      expect(mocks.launch.mock.calls[0]?.[1]).toEqual({
+      expect(supervisor.launch.mock.calls[0]?.[1]).toEqual({
         kind: "websocket",
         url: "wss://gateway.example/tenant/__openclaw__/worker",
       });
     }
     if (method === "cancel") {
-      expect(mocks.cancel.mock.calls[0]?.[0]).toEqual(cancelInput(receipt));
+      expect(supervisor.cancel.mock.calls[0]?.[0]).toEqual(cancelInput(receipt));
     }
     expect(pluginHandle).not.toHaveBeenCalled();
     expect(result?.ok).toBe(true);
@@ -443,7 +430,7 @@ describe("node-host worker supervisor commands", () => {
       supervisor,
     });
 
-    expect(supervisorMocks(supervisor).retainWorkspaces).toHaveBeenCalledWith(retain, undefined);
+    expect(supervisor.retainWorkspaces).toHaveBeenCalledWith(retain, undefined);
     expect(pluginHandle).not.toHaveBeenCalled();
     expect(JSON.parse(result?.payloadJSON ?? "{}")).toEqual({
       applied: true,
@@ -543,11 +530,11 @@ describe("node-host worker supervisor commands", () => {
   it("does not prune bundles when the retain snapshot is stale", async () => {
     const input = launchInput();
     const supervisor = supervisorWith(fullReceipt(input));
-    supervisor.retainWorkspaces = vi.fn(async () => ({
+    supervisor.retainWorkspaces.mockResolvedValue({
       applied: false,
       deleted: 0,
       hasMore: false,
-    }));
+    });
     const retainBundles = vi.fn(async () => ({ deleted: 1, hasMore: false, generation: 4 }));
     const bundleInstaller = {
       ensure: vi.fn(),
@@ -592,7 +579,7 @@ describe("node-host worker supervisor commands", () => {
       },
     });
 
-    expect(supervisorMocks(supervisor).launch.mock.calls[0]?.[1]).toEqual({
+    expect(supervisor.launch.mock.calls[0]?.[1]).toEqual({
       kind: "websocket",
       url: "wss://gateway.example/tenant/__openclaw__/worker",
       tlsFingerprint: "aa".repeat(32),
@@ -795,10 +782,9 @@ describe("node-host worker supervisor commands", () => {
     const { result } = await invokePrivate({ command, paramsJSON: raw, supervisor });
 
     expect(result).toMatchObject({ ok: false, error: { code: "INVALID_REQUEST" } });
-    const mocks = supervisorMocks(supervisor);
-    expect(mocks.launch.mock.calls).toHaveLength(0);
-    expect(mocks.status.mock.calls).toHaveLength(0);
-    expect(mocks.cancel.mock.calls).toHaveLength(0);
+    expect(supervisor.launch.mock.calls).toHaveLength(0);
+    expect(supervisor.status.mock.calls).toHaveLength(0);
+    expect(supervisor.cancel.mock.calls).toHaveLength(0);
   });
 
   it("fails closed when a durable terminal receipt is inconsistent", async () => {
@@ -825,7 +811,7 @@ describe("node-host worker supervisor commands", () => {
   it("returns a bounded generic error without leaking supervisor details", async () => {
     const leaked = `/private/path/${"secret".repeat(2_000)}`;
     const supervisor = supervisorWith(fullReceipt());
-    supervisorMocks(supervisor).status.mockRejectedValueOnce(new Error(leaked));
+    supervisor.status.mockRejectedValueOnce(new Error(leaked));
 
     const { result } = await invokePrivate({
       command: NODE_WORKER_SUPERVISOR_STATUS_COMMAND,
@@ -842,9 +828,7 @@ describe("node-host worker supervisor commands", () => {
   it("preserves a terminal capacity result across node invoke", async () => {
     const input = launchInput();
     const supervisor = supervisorWith(fullReceipt(input));
-    supervisorMocks(supervisor).launch.mockRejectedValueOnce(
-      new NodeWorkerCapacityExhaustedError(10_000),
-    );
+    supervisor.launch.mockRejectedValueOnce(new NodeWorkerCapacityExhaustedError(10_000));
 
     const { result } = await invokePrivate({
       command: NODE_WORKER_SUPERVISOR_LAUNCH_COMMAND,

--- a/src/node-host/node-worker-launch.ts
+++ b/src/node-host/node-worker-launch.ts
@@ -1,4 +1,5 @@
 import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import type { WorkerLaunchDescriptor } from "../worker/launch-descriptor.js";
 import type { NodeWorkerCapacity } from "./node-worker-capacity.js";
 import type { NodeWorkerContainerEngine } from "./node-worker-container-engine.js";
@@ -25,7 +26,6 @@ import {
 import type { NodeWorkerLaunchInput } from "./node-worker-supervisor-contract.js";
 import {
   createNodeWorkerActiveTurn,
-  createNodeWorkerJournalGate,
   nodeWorkerEnvironmentBinding,
   type NodeWorkerActiveOwnership,
   type NodeWorkerRunningChild,
@@ -71,6 +71,15 @@ export async function startNodeWorkerChild(
   for (const value of sensitiveValues) {
     registerSecretValueForRedaction(value);
   }
+  const finishFailed = (errorText: string) =>
+    context.capacity.finish({
+      launchId: params.input.launchId,
+      planHash: params.planHash,
+      supervisor: params.supervisor,
+      worker: null,
+      state: "failed",
+      errorText,
+    });
   let adapter: NodeWorkerChildAdapter;
   let container: NodeWorkerContainerIdentity | undefined;
   try {
@@ -93,14 +102,9 @@ export async function startNodeWorkerChild(
     adapter = prepared.adapter;
     container = prepared.container;
   } catch (error) {
-    return context.capacity.finish({
-      launchId: params.input.launchId,
-      planHash: params.planHash,
-      supervisor: params.supervisor,
-      worker: null,
-      state: "failed",
-      errorText: sanitizeNodeWorkerDiagnostic(error, "node worker spawn failed", scrubber.scrub),
-    });
+    return finishFailed(
+      sanitizeNodeWorkerDiagnostic(error, "node worker spawn failed", scrubber.scrub),
+    );
   }
   if (!adapter.pid) {
     if (container) {
@@ -108,14 +112,7 @@ export async function startNodeWorkerChild(
     }
     adapter.kill("SIGKILL");
     adapter.dispose();
-    return context.capacity.finish({
-      launchId: params.input.launchId,
-      planHash: params.planHash,
-      supervisor: params.supervisor,
-      worker: null,
-      state: "failed",
-      errorText: "node worker spawn did not return a process id",
-    });
+    return finishFailed("node worker spawn did not return a process id");
   }
   let worker: NodeWorkerProcessIdentity;
   try {
@@ -127,20 +124,15 @@ export async function startNodeWorkerChild(
     adapter.kill("SIGKILL");
     await adapter.wait().catch(() => undefined);
     adapter.dispose();
-    return context.capacity.finish({
-      launchId: params.input.launchId,
-      planHash: params.planHash,
-      supervisor: params.supervisor,
-      worker: null,
-      state: "failed",
-      errorText: sanitizeNodeWorkerDiagnostic(
+    return finishFailed(
+      sanitizeNodeWorkerDiagnostic(
         error,
         "node worker process identity unavailable",
         scrubber.scrub,
       ),
-    });
+    );
   }
-  const { journalReady, releaseJournal } = createNodeWorkerJournalGate();
+  const { promise: journalReady, resolve: releaseJournal } = createDeferredCore();
   const active = {
     state: "running",
     binding: nodeWorkerEnvironmentBinding(params.input),
@@ -151,7 +143,6 @@ export async function startNodeWorkerChild(
     gatewayNamespace: params.input.gatewayNamespace,
     launchId: params.input.launchId,
     planHash: params.planHash,
-    releaseJournal,
     scrubber,
     connectionFailure,
     supervisor: params.supervisor,
@@ -171,28 +162,23 @@ export async function startNodeWorkerChild(
       ...(container ? { container } : {}),
     });
   } catch (error) {
-    active.releaseJournal();
+    releaseJournal();
     if (container) {
       await context.stopChild(active, "interrupted");
       context.active.delete(active.launchId);
-      context.capacity.finish({
-        launchId: active.launchId,
-        planHash: active.planHash,
-        supervisor: params.supervisor,
-        worker: null,
-        state: "failed",
-        errorText: sanitizeNodeWorkerDiagnostic(
+      finishFailed(
+        sanitizeNodeWorkerDiagnostic(
           error,
           "node worker container identity could not be persisted",
           scrubber.scrub,
         ),
-      });
+      );
     } else {
       await context.stopChild(active, "interrupted").catch(() => undefined);
     }
     throw error;
   }
-  active.releaseJournal();
+  releaseJournal();
   if (running.state === "cancelled" || running.state === "interrupted") {
     await context.stopChild(active, running.state);
     return context.store.get(active.launchId) ?? running;

--- a/src/node-host/node-worker-supervisor-ownership.ts
+++ b/src/node-host/node-worker-supervisor-ownership.ts
@@ -81,7 +81,6 @@ export type NodeWorkerRunningChild = NodeWorkerActiveBase & {
   adapter: NodeWorkerChildAdapter;
   done: Promise<void>;
   journalReady: Promise<void>;
-  releaseJournal: () => void;
   scrubber: NodeWorkerCredentialScrubber;
   connectionFailure: { errorText?: string };
   turn?: NodeWorkerActiveTurn;
@@ -130,25 +129,4 @@ export function nodeWorkerReceiptMatchesOwner(
     receipt.container?.containerId === container?.containerId &&
     receipt.container?.engineTarget === container?.engineTarget
   );
-}
-
-/** Delay result observation until the launch's exact owner has been journaled. */
-export function createNodeWorkerJournalGate(): {
-  journalReady: Promise<void>;
-  releaseJournal: () => void;
-} {
-  let released = false;
-  let resolveReady!: () => void;
-  const journalReady = new Promise<void>((resolve) => {
-    resolveReady = resolve;
-  });
-  return {
-    journalReady,
-    releaseJournal: () => {
-      if (!released) {
-        released = true;
-        resolveReady();
-      }
-    },
-  };
 }

--- a/src/node-host/node-worker-supervisor.container.test.ts
+++ b/src/node-host/node-worker-supervisor.container.test.ts
@@ -15,6 +15,7 @@ import {
   fakeEngineSource,
   stdioWorkerSource,
 } from "./node-worker-supervisor.container.test-support.js";
+import { waitForNodeWorkerTerminal as waitForTerminal } from "./node-worker-supervisor.fixture.test-support.js";
 import { createNodeWorkerSupervisor } from "./node-worker-supervisor.js";
 import {
   testNodeWorkerEnvironmentIdentity,
@@ -150,19 +151,6 @@ function containerFixture(
   };
 }
 
-async function waitForTerminal(
-  supervisor: ReturnType<typeof createNodeWorkerSupervisor>,
-  launchId: string,
-) {
-  await vi.waitFor(
-    async () => {
-      expect((await supervisor.status(launchId))?.state).not.toMatch(/^(?:pending|running)$/u);
-    },
-    { timeout: 5_000 },
-  );
-  return await supervisor.status(launchId);
-}
-
 async function waitForWorkerStarted(workspaceDir: string): Promise<void> {
   await vi.waitFor(
     () => expect(fs.existsSync(path.join(workspaceDir, "worker-started"))).toBe(true),
@@ -226,7 +214,7 @@ describe("node worker supervisor container isolation", () => {
       });
       const completed = await waitForTerminal(fixture.supervisor, input.launchId);
       expect(completed).toMatchObject({ state: "completed" });
-      expect(JSON.parse(completed?.resultJson ?? "null")).toEqual({
+      expect(JSON.parse(completed.resultJson ?? "null")).toEqual({
         status: "completed",
         transcriptLeafId: "leaf-1",
         transcriptNextSeq: 2,
@@ -297,12 +285,12 @@ describe("node worker supervisor container isolation", () => {
       await fixture.supervisor.launch(input, endpoint);
       const failed = await waitForTerminal(fixture.supervisor, input.launchId);
       expect(failed).toMatchObject({ state: "failed" });
-      expect(failed?.errorText).toContain(
+      expect(failed.errorText).toContain(
         "worker admission deadline exceeded after 9 attempts to gateway.example:443: connect failed: Opening handshake has timed out",
       );
-      expect(failed?.errorText).not.toContain(input.descriptor.admission.credential);
-      expect(Buffer.byteLength(failed?.errorText ?? "", "utf8")).toBeLessThanOrEqual(4_096);
-      expect((await fixture.supervisor.status(input.launchId))?.errorText).toBe(failed?.errorText);
+      expect(failed.errorText).not.toContain(input.descriptor.admission.credential);
+      expect(Buffer.byteLength(failed.errorText ?? "", "utf8")).toBeLessThanOrEqual(4_096);
+      expect((await fixture.supervisor.status(input.launchId))?.errorText).toBe(failed.errorText);
     } finally {
       await fixture.supervisor.close();
     }
@@ -329,7 +317,7 @@ describe("node worker supervisor container isolation", () => {
         fs.readFileSync(path.join(fixture.workspaceDir, `${first.launchId}.fixture.json`), "utf8"),
       ) as { pid: number };
       const worker = requireNodeWorkerProcessIdentity(originalWorker.pid);
-      expect(completed?.state).toBe("completed");
+      expect(completed.state).toBe("completed");
       expect(store.get(first.launchId)).toMatchObject({
         state: "running",
         container: running.container,
@@ -343,7 +331,7 @@ describe("node worker supervisor container isolation", () => {
         worker: running.worker,
         container: running.container,
       });
-      expect((await waitForTerminal(fixture.supervisor, next.launchId))?.state).toBe("completed");
+      expect((await waitForTerminal(fixture.supervisor, next.launchId)).state).toBe("completed");
       expect(
         JSON.parse(
           fs.readFileSync(path.join(fixture.workspaceDir, `${next.launchId}.fixture.json`), "utf8"),

--- a/src/node-host/node-worker-supervisor.fixture.test-support.ts
+++ b/src/node-host/node-worker-supervisor.fixture.test-support.ts
@@ -1,0 +1,29 @@
+import { expect, vi } from "vitest";
+import { createNodeWorkerSupervisor } from "./node-worker-supervisor.js";
+import { writeNodeWorkerFixture } from "./node-worker-supervisor.test-support.js";
+
+export function createNodeWorkerSupervisorFixture(
+  root: string,
+  options: Parameters<typeof createNodeWorkerSupervisor>[0] = {},
+) {
+  const fixture = writeNodeWorkerFixture(root);
+  const { bundleRoot, env } = fixture;
+  return { ...fixture, supervisor: createNodeWorkerSupervisor({ bundleRoot, env, ...options }) };
+}
+
+export async function waitForNodeWorkerTerminal(
+  supervisor: ReturnType<typeof createNodeWorkerSupervisor>,
+  launchId: string,
+) {
+  await vi.waitFor(
+    async () => {
+      expect((await supervisor.status(launchId))?.state).not.toMatch(/^(?:pending|running)$/u);
+    },
+    { timeout: 5_000 },
+  );
+  const receipt = await supervisor.status(launchId);
+  if (!receipt) {
+    throw new Error(`missing launch receipt ${launchId}`);
+  }
+  return receipt;
+}

--- a/src/node-host/node-worker-supervisor.lifetime.test.ts
+++ b/src/node-host/node-worker-supervisor.lifetime.test.ts
@@ -9,14 +9,17 @@ import {
   inspectNodeWorkerProcessIdentity,
   requireNodeWorkerProcessIdentity,
 } from "./node-worker-process-identity.js";
-import { createNodeWorkerSupervisor } from "./node-worker-supervisor.js";
+import {
+  createNodeWorkerSupervisorFixture,
+  waitForNodeWorkerTerminal as waitForTerminal,
+} from "./node-worker-supervisor.fixture.test-support.js";
+import type { createNodeWorkerSupervisor } from "./node-worker-supervisor.js";
 import {
   TEST_WORKER_ENDPOINT,
   TEST_WORKER_SOURCE,
   testNodeWorkerEnvironmentIdentity,
   testNodeWorkerLaunchIdentity,
   testWorkerLaunchInput,
-  writeNodeWorkerFixture,
 } from "./node-worker-supervisor.test-support.js";
 import { NodeWorkerTurnStore } from "./node-worker-turn-store.js";
 
@@ -30,17 +33,8 @@ afterEach(() => {
   closeOpenClawStateDatabaseForTest();
 });
 
-function fixture(
-  options: {
-    capacity?: number;
-    capacityWaitMs?: number;
-    onCapacityChanged?: (capacity: { total: number; available: number }) => void;
-  } = {},
-) {
-  const root = tempDirs.make("node-worker-supervisor-");
-  const { bundleRoot, env, stateDir, workspaceDir } = writeNodeWorkerFixture(root);
-  const supervisor = createNodeWorkerSupervisor({ bundleRoot, env, ...options });
-  return { bundleRoot, env, root, stateDir, supervisor, workspaceDir };
+function fixture(options: Parameters<typeof createNodeWorkerSupervisor>[0] = {}) {
+  return createNodeWorkerSupervisorFixture(tempDirs.make("node-worker-supervisor-"), options);
 }
 
 function launchInput(workspaceDir: string, launchId: string, prompt = "success") {
@@ -48,20 +42,6 @@ function launchInput(workspaceDir: string, launchId: string, prompt = "success")
   input.descriptor.admission.environmentId = `environment-${launchId}`;
   input.descriptor.admission.sessionId = `session-${launchId}`;
   return input;
-}
-
-async function waitForTerminal(supervisor: NodeWorkerSupervisor, launchId: string) {
-  await vi.waitFor(
-    async () => {
-      expect((await supervisor.status(launchId))?.state).not.toMatch(/^(?:pending|running)$/u);
-    },
-    { timeout: 5_000 },
-  );
-  const receipt = await supervisor.status(launchId);
-  if (!receipt) {
-    throw new Error(`missing launch receipt ${launchId}`);
-  }
-  return receipt;
 }
 
 describe("node worker environment lifetime", () => {

--- a/src/node-host/node-worker-supervisor.test.ts
+++ b/src/node-host/node-worker-supervisor.test.ts
@@ -18,6 +18,10 @@ import {
   inspectNodeWorkerProcessIdentity,
   requireNodeWorkerProcessIdentity,
 } from "./node-worker-process-identity.js";
+import {
+  createNodeWorkerSupervisorFixture,
+  waitForNodeWorkerTerminal as waitForTerminal,
+} from "./node-worker-supervisor.fixture.test-support.js";
 import { createNodeWorkerSupervisor } from "./node-worker-supervisor.js";
 import {
   TEST_WORKER_CREDENTIAL,
@@ -40,17 +44,8 @@ afterEach(() => {
   closeOpenClawStateDatabaseForTest();
 });
 
-function fixture(
-  options: {
-    capacity?: number;
-    capacityWaitMs?: number;
-    onCapacityChanged?: (capacity: { total: number; available: number }) => void;
-  } = {},
-) {
-  const root = tempDirs.make("node-worker-supervisor-");
-  const { bundleRoot, env, stateDir, workspaceDir } = writeNodeWorkerFixture(root);
-  const supervisor = createNodeWorkerSupervisor({ bundleRoot, env, ...options });
-  return { bundleRoot, env, root, stateDir, supervisor, workspaceDir };
+function fixture(options: Parameters<typeof createNodeWorkerSupervisor>[0] = {}) {
+  return createNodeWorkerSupervisorFixture(tempDirs.make("node-worker-supervisor-"), options);
 }
 
 function launchInput(workspaceDir: string, launchId: string, prompt = "success") {
@@ -58,20 +53,6 @@ function launchInput(workspaceDir: string, launchId: string, prompt = "success")
   input.descriptor.admission.environmentId = `environment-${launchId}`;
   input.descriptor.admission.sessionId = `session-${launchId}`;
   return input;
-}
-
-async function waitForTerminal(supervisor: NodeWorkerSupervisor, launchId: string) {
-  await vi.waitFor(
-    async () => {
-      expect((await supervisor.status(launchId))?.state).not.toMatch(/^(?:pending|running)$/u);
-    },
-    { timeout: 5_000 },
-  );
-  const receipt = await supervisor.status(launchId);
-  if (!receipt) {
-    throw new Error(`missing launch receipt ${launchId}`);
-  }
-  return receipt;
 }
 
 describe("node worker supervisor", () => {
@@ -688,29 +669,6 @@ describe("node worker supervisor", () => {
 
     expect(fs.existsSync(exitedPath)).toBe(true);
     expect(terminal.state).toBe("failed");
-    await supervisor.close();
-  });
-
-  it.each([
-    ["cancel", "cancelled"],
-    ["close", "interrupted"],
-  ] as const)("records %s while awaiting the owned child", async (operation, state) => {
-    const { supervisor, workspaceDir } = fixture();
-    const input = launchInput(workspaceDir, `${operation}-launch`, "wait");
-    expect(await supervisor.launch(input, TEST_WORKER_ENDPOINT)).toMatchObject({
-      state: "running",
-    });
-
-    if (operation === "cancel") {
-      await supervisor.cancel(testNodeWorkerLaunchIdentity(input));
-    } else {
-      await supervisor.close();
-    }
-
-    expect(await supervisor.status(input.launchId)).toMatchObject({
-      state,
-      worker: { pid: expect.any(Number), startTime: expect.any(Number) },
-    });
     await supervisor.close();
   });
 

--- a/src/worker/worker-command.runtime.test.ts
+++ b/src/worker/worker-command.runtime.test.ts
@@ -128,6 +128,15 @@ function managedHarness() {
   };
 }
 
+function gatedCommandHarness(mode: "standalone" | "managed") {
+  if (mode === "standalone") {
+    return { input: commandInput(), output: new PassThrough() };
+  }
+  const { input, output, turn } = managedHarness();
+  turn();
+  return { input, output, managed: true };
+}
+
 describe("worker command lifetime gate", () => {
   beforeEach(() => {
     vi.mocked(runWorkerDescriptor).mockReset();
@@ -220,82 +229,80 @@ describe("worker command lifetime gate", () => {
     );
   });
 
-  it("does not enter the worker runtime before the explicit start message", async () => {
-    const output = new PassThrough();
-    const lifetime = lifetimeHarness();
-    const running = runWorkerCommand({
-      input: commandInput(),
-      output,
-      lifetime: lifetime.contract,
-    });
+  it.each(["standalone", "managed"] as const)(
+    "does not enter the worker runtime before the explicit start message (%s)",
+    async (mode) => {
+      const harness = gatedCommandHarness(mode);
+      const lifetime = lifetimeHarness();
+      const running = runWorkerCommand({ ...harness, lifetime: lifetime.contract });
 
-    await new Promise((resolve) => {
-      setImmediate(resolve);
-    });
-    expect(runWorkerDescriptor).not.toHaveBeenCalled();
-    lifetime.open();
-
-    await running;
-    expect(runWorkerDescriptor).toHaveBeenCalledOnce();
-    expect(lifetime.terminateOwnedTree).not.toHaveBeenCalled();
-    expect(lifetime.dispose).toHaveBeenCalledOnce();
-  });
-
-  it("exits without starting when IPC disconnects before the start message", async () => {
-    const output = new PassThrough();
-    const lifetime = lifetimeHarness();
-    const running = runWorkerCommand({
-      input: commandInput(),
-      output,
-      lifetime: lifetime.contract,
-    });
-
-    lifetime.disconnectBeforeStart();
-
-    await running;
-    expect(runWorkerDescriptor).not.toHaveBeenCalled();
-    expect(lifetime.terminateOwnedTree).not.toHaveBeenCalled();
-    expect(lifetime.dispose).toHaveBeenCalledOnce();
-  });
-
-  it("aborts the real worker path and terminates its owned tree on IPC disconnect", async () => {
-    const output = new PassThrough();
-    let runtimeSignal: AbortSignal | undefined;
-    vi.mocked(runWorkerDescriptor).mockImplementation(async (_descriptor, options) => {
-      const signal = options?.signal;
-      if (!signal) {
-        throw new Error("expected worker lifetime abort signal");
-      }
-      runtimeSignal = signal;
-      return await new Promise<never>((_, reject) => {
-        signal.addEventListener(
-          "abort",
-          () => {
-            const reason = signal.reason;
-            reject(reason instanceof Error ? reason : new Error("worker interrupted"));
-          },
-          { once: true },
-        );
+      await new Promise((resolve) => {
+        setImmediate(resolve);
       });
-    });
-    const lifetime = lifetimeHarness();
-    lifetime.terminateOwnedTree.mockImplementation(() => {
-      expect(runtimeSignal?.aborted).toBe(true);
-    });
-    const running = runWorkerCommand({
-      input: commandInput(),
-      output,
-      lifetime: lifetime.contract,
-    });
-    lifetime.open();
-    await vi.waitFor(() => expect(runWorkerDescriptor).toHaveBeenCalledOnce());
+      expect(runWorkerDescriptor).not.toHaveBeenCalled();
+      expect(harness.input.readableLength > 0).toBe(mode === "managed");
+      lifetime.open();
 
-    lifetime.disconnectAfterStart();
+      await running;
+      expect(runWorkerDescriptor).toHaveBeenCalledOnce();
+      expect(lifetime.terminateOwnedTree).not.toHaveBeenCalled();
+      expect(lifetime.dispose).toHaveBeenCalledOnce();
+    },
+  );
 
-    await expect(running).rejects.toThrow("worker supervisor lifetime ended");
-    expect(lifetime.terminateOwnedTree).toHaveBeenCalledOnce();
-    expect(lifetime.dispose).toHaveBeenCalledOnce();
-  });
+  it.each(["standalone", "managed"] as const)(
+    "exits without starting when IPC disconnects before the start message (%s)",
+    async (mode) => {
+      const harness = gatedCommandHarness(mode);
+      const lifetime = lifetimeHarness();
+      const running = runWorkerCommand({ ...harness, lifetime: lifetime.contract });
+
+      lifetime.disconnectBeforeStart();
+
+      await running;
+      expect(runWorkerDescriptor).not.toHaveBeenCalled();
+      expect(lifetime.terminateOwnedTree).not.toHaveBeenCalled();
+      expect(lifetime.dispose).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each(["standalone", "managed"] as const)(
+    "aborts the worker path and terminates its owned tree on IPC disconnect (%s)",
+    async (mode) => {
+      const harness = gatedCommandHarness(mode);
+      let runtimeSignal: AbortSignal | undefined;
+      vi.mocked(runWorkerDescriptor).mockImplementation(async (_descriptor, options) => {
+        const signal = options?.signal;
+        if (!signal) {
+          throw new Error("expected worker lifetime abort signal");
+        }
+        runtimeSignal = signal;
+        return await new Promise<never>((_, reject) => {
+          signal.addEventListener(
+            "abort",
+            () => {
+              const reason = signal.reason;
+              reject(reason instanceof Error ? reason : new Error("worker interrupted"));
+            },
+            { once: true },
+          );
+        });
+      });
+      const lifetime = lifetimeHarness();
+      lifetime.terminateOwnedTree.mockImplementation(() => {
+        expect(runtimeSignal?.aborted).toBe(true);
+      });
+      const running = runWorkerCommand({ ...harness, lifetime: lifetime.contract });
+      lifetime.open();
+      await vi.waitFor(() => expect(runWorkerDescriptor).toHaveBeenCalledOnce());
+
+      lifetime.disconnectAfterStart();
+
+      await expect(running).rejects.toThrow("worker supervisor lifetime ended");
+      expect(lifetime.terminateOwnedTree).toHaveBeenCalledOnce();
+      expect(lifetime.dispose).toHaveBeenCalledOnce();
+    },
+  );
 
   it("retains state across turns and cancels only the exact active turn", async () => {
     const harness = managedHarness();
@@ -351,17 +358,6 @@ describe("worker command lifetime gate", () => {
     ).toEqual(["/tmp/openclaw-managed-worker-state", "/tmp/openclaw-managed-worker-state"]);
     expect(managedRuntime.close).toHaveBeenCalledOnce();
     expect(lifetime.dispose).toHaveBeenCalledOnce();
-  });
-
-  it("closes a retained environment when the managed input ends", async () => {
-    const harness = managedHarness();
-    managedRuntime.backgroundCount = 1;
-    const running = runWorkerCommand({ ...harness, managed: true });
-    harness.turn();
-    await vi.waitFor(() => expect(harness.results).toHaveLength(1));
-    harness.input.end();
-    await running;
-    expect(managedRuntime.close).toHaveBeenCalledOnce();
   });
 
   it.each(["owner", "output"] as const)(

--- a/src/worker/worker-command.runtime.ts
+++ b/src/worker/worker-command.runtime.ts
@@ -278,22 +278,9 @@ export async function runWorkerCommand(options: RunWorkerCommandOptions): Promis
     options.lifetime.terminateOwnedTree();
   };
   try {
-    if (options.managed) {
-      if (!(await (options.lifetime?.started ?? Promise.resolve(true)))) {
-        return;
-      }
-      options.lifetime?.signal.addEventListener("abort", stopForLifetime, { once: true });
-      if (options.lifetime?.signal.aborted) {
-        stopForLifetime();
-      }
-      process.once("SIGINT", stop);
-      process.once("SIGTERM", stop);
-      await runManagedWorkerCommand(options, abortController.signal);
-      return;
-    }
     const [descriptor, started] = await Promise.all([
-      readLaunchDescriptor(options.input),
-      options.lifetime?.started ?? Promise.resolve(true),
+      options.managed ? undefined : readLaunchDescriptor(options.input),
+      options.lifetime?.started ?? true,
     ]);
     if (!started) {
       return;
@@ -304,6 +291,10 @@ export async function runWorkerCommand(options: RunWorkerCommandOptions): Promis
     }
     process.once("SIGINT", stop);
     process.once("SIGTERM", stop);
+    if (!descriptor) {
+      await runManagedWorkerCommand(options, abortController.signal);
+      return;
+    }
     const result = await runWorkerDescriptor(descriptor, {
       signal: abortController.signal,
       ...(options.lifetime

--- a/src/worker/worker.runtime.test.ts
+++ b/src/worker/worker.runtime.test.ts
@@ -626,38 +626,18 @@ class FakeWorkerGateway {
     terminal: "done" | "error" = "done",
   ): void {
     const chunk = "x".repeat(40);
-    this.send(socket, {
-      type: "event",
-      event: "worker.inference.event",
-      payload: {
-        ...this.identity(identity),
-        seq: 1,
-        event: {
-          type: "start",
-          resolvedModel: { api: "openai-responses", ...MODEL_REF },
-          timestamp: Date.now(),
-        },
-      },
-    } satisfies WorkerInferenceEventFrame);
-    this.send(socket, {
-      type: "event",
-      event: "worker.inference.event",
-      payload: {
-        ...this.identity(identity),
-        seq: 2,
-        event: { type: "text_start", contentIndex: 0 },
-      },
-    } satisfies WorkerInferenceEventFrame);
+    this.sendInferenceEvent(socket, identity, 1, {
+      type: "start",
+      resolvedModel: { api: "openai-responses", ...MODEL_REF },
+      timestamp: Date.now(),
+    });
+    this.sendInferenceEvent(socket, identity, 2, { type: "text_start", contentIndex: 0 });
     for (let index = 0; index < chunkCount; index += 1) {
-      this.send(socket, {
-        type: "event",
-        event: "worker.inference.event",
-        payload: {
-          ...this.identity(identity),
-          seq: index + 3,
-          event: { type: "text_delta", contentIndex: 0, delta: chunk },
-        },
-      } satisfies WorkerInferenceEventFrame);
+      this.sendInferenceEvent(socket, identity, index + 3, {
+        type: "text_delta",
+        contentIndex: 0,
+        delta: chunk,
+      });
     }
     const text = chunk.repeat(chunkCount);
     if (terminal === "error") {
@@ -677,37 +657,17 @@ class FakeWorkerGateway {
   }
 
   private sendEmptyTerminalTurn(socket: WebSocket, identity: WorkerInferenceStartParams): void {
-    this.send(socket, {
-      type: "event",
-      event: "worker.inference.event",
-      payload: {
-        ...this.identity(identity),
-        seq: 1,
-        event: {
-          type: "start",
-          resolvedModel: { api: "openai-responses", ...MODEL_REF },
-          timestamp: Date.now(),
-        },
-      },
-    } satisfies WorkerInferenceEventFrame);
-    this.send(socket, {
-      type: "event",
-      event: "worker.inference.event",
-      payload: {
-        ...this.identity(identity),
-        seq: 2,
-        event: { type: "text_start", contentIndex: 0 },
-      },
-    } satisfies WorkerInferenceEventFrame);
-    this.send(socket, {
-      type: "event",
-      event: "worker.inference.event",
-      payload: {
-        ...this.identity(identity),
-        seq: 3,
-        event: { type: "text_delta", contentIndex: 0, delta: "discarded draft" },
-      },
-    } satisfies WorkerInferenceEventFrame);
+    this.sendInferenceEvent(socket, identity, 1, {
+      type: "start",
+      resolvedModel: { api: "openai-responses", ...MODEL_REF },
+      timestamp: Date.now(),
+    });
+    this.sendInferenceEvent(socket, identity, 2, { type: "text_start", contentIndex: 0 });
+    this.sendInferenceEvent(socket, identity, 3, {
+      type: "text_delta",
+      contentIndex: 0,
+      delta: "discarded draft",
+    });
     this.sendTerminal(socket, identity, 4, assistantMessage([], "stop"));
   }
 
@@ -716,51 +676,18 @@ class FakeWorkerGateway {
     identity: WorkerInferenceStartParams,
     stopReason: "stop" | "length" = "stop",
   ): void {
-    const events: WorkerInferenceEventFrame[] = [
-      {
-        type: "event",
-        event: "worker.inference.event",
-        payload: {
-          ...this.identity(identity),
-          seq: 1,
-          event: {
-            type: "start",
-            resolvedModel: { api: "openai-responses", ...MODEL_REF },
-            timestamp: Date.now(),
-          },
-        },
-      },
-      {
-        type: "event",
-        event: "worker.inference.event",
-        payload: {
-          ...this.identity(identity),
-          seq: 2,
-          event: { type: "text_start", contentIndex: 0 },
-        },
-      },
-      {
-        type: "event",
-        event: "worker.inference.event",
-        payload: {
-          ...this.identity(identity),
-          seq: 3,
-          event: { type: "text_delta", contentIndex: 0, delta: "worker reply" },
-        },
-      },
-      {
-        type: "event",
-        event: "worker.inference.event",
-        payload: {
-          ...this.identity(identity),
-          seq: 4,
-          event: { type: "text_end", contentIndex: 0 },
-        },
-      },
-    ];
-    for (const event of events) {
-      this.send(socket, event);
-    }
+    this.sendInferenceEvent(socket, identity, 1, {
+      type: "start",
+      resolvedModel: { api: "openai-responses", ...MODEL_REF },
+      timestamp: Date.now(),
+    });
+    this.sendInferenceEvent(socket, identity, 2, { type: "text_start", contentIndex: 0 });
+    this.sendInferenceEvent(socket, identity, 3, {
+      type: "text_delta",
+      contentIndex: 0,
+      delta: "worker reply",
+    });
+    this.sendInferenceEvent(socket, identity, 4, { type: "text_end", contentIndex: 0 });
     this.sendTerminal(
       socket,
       identity,
@@ -812,51 +739,23 @@ class FakeWorkerGateway {
   ): void {
     const { args, toolCallId, toolName } = tool;
     const encodedArgs = JSON.stringify(args);
-    const events: WorkerInferenceEventFrame[] = [
-      {
-        type: "event",
-        event: "worker.inference.event",
-        payload: {
-          ...this.identity(identity),
-          seq: 1,
-          event: {
-            type: "start",
-            resolvedModel: { api: "openai-responses", ...MODEL_REF },
-            timestamp: Date.now(),
-          },
-        },
-      },
-      {
-        type: "event",
-        event: "worker.inference.event",
-        payload: {
-          ...this.identity(identity),
-          seq: 2,
-          event: { type: "toolcall_start", contentIndex: 0, id: toolCallId, toolName },
-        },
-      },
-      {
-        type: "event",
-        event: "worker.inference.event",
-        payload: {
-          ...this.identity(identity),
-          seq: 3,
-          event: { type: "toolcall_delta", contentIndex: 0, delta: encodedArgs },
-        },
-      },
-      {
-        type: "event",
-        event: "worker.inference.event",
-        payload: {
-          ...this.identity(identity),
-          seq: 4,
-          event: { type: "toolcall_end", contentIndex: 0 },
-        },
-      },
-    ];
-    for (const event of events) {
-      this.send(socket, event);
-    }
+    this.sendInferenceEvent(socket, identity, 1, {
+      type: "start",
+      resolvedModel: { api: "openai-responses", ...MODEL_REF },
+      timestamp: Date.now(),
+    });
+    this.sendInferenceEvent(socket, identity, 2, {
+      type: "toolcall_start",
+      contentIndex: 0,
+      id: toolCallId,
+      toolName,
+    });
+    this.sendInferenceEvent(socket, identity, 3, {
+      type: "toolcall_delta",
+      contentIndex: 0,
+      delta: encodedArgs,
+    });
+    this.sendInferenceEvent(socket, identity, 4, { type: "toolcall_end", contentIndex: 0 });
     this.sendTerminal(
       socket,
       identity,
@@ -866,6 +765,20 @@ class FakeWorkerGateway {
         "toolUse",
       ),
     );
+  }
+
+  private sendInferenceEvent(
+    socket: WebSocket,
+    identity: WorkerInferenceStartParams,
+    seq: number,
+    event: WorkerInferenceEventFrame["payload"]["event"],
+  ): void {
+    const frame: WorkerInferenceEventFrame = {
+      type: "event",
+      event: "worker.inference.event",
+      payload: { ...this.identity(identity), seq, event },
+    };
+    this.send(socket, frame);
   }
 
   private sendTerminal(


### PR DESCRIPTION
Related: #130733

## What Problem This Solves

The worker lifetime repair left duplicated startup, abort, retirement, and test scaffolding that made its ownership rules harder to follow. This is the requested follow-up cleanup, with no intended user-visible behavior change.

## Why This Change Was Made

Use one startup gate for managed and standalone workers, reuse the existing deferred primitive for journal readiness, consolidate identical node-operation abort races and stale-build retirement branches, and derive launch signatures from their owning contract. Physical environment lifetime remains separate from per-turn authority; cleanup ordering, exact owner checks, and diagnostics stay intact.

The test-audit pass shares fixtures and typed mocks, removes unnecessary fixture writes, and removes four redundant cases only where stronger retained coverage proves the same contract. Existing startup/disconnect cases now cover both worker modes. Real-process descendant termination and retained-owner EOF cleanup remain covered.

## User Impact

No config, schema, protocol, dependency, or public API changes. Background processes still survive completed replies and are cleaned up when their environment ends.

Production LOC: **+66/-167 (net -101)**. Tests/support: **+222/-396 (net -174)**, including both new shared helpers.

## Evidence

- The complete cleanup passed **352 focused tests across 15 files**, covering node supervision, process lifetime, managed/standalone commands, worker runtime, launch/tunnel ownership, reconciliation, teardown, and claim admission.
- Production and test typechecks, targeted lint/format checks, all three unused-export scans, and the selected repository boundary checks passed. An initial unused-type-export failure was fixed and the checks rerun successfully.
- Reviewed the owning startup/observation paths, callers, sibling implementations, and current main. Direct Codex source inspection at `b68acc4d4b56fdfa1d5b6a2c36102c66876e0c46`: `codex-rs/core/src/unified_exec/process_manager.rs:535-568,820-838` and `codex-rs/exec-server/src/server/session_registry.rs`.

The patch is unchanged after refreshing onto main at `153a6f59bf820f79e94e6d14b25f292f2e504646`. A fresh Codex autoreview completed with no P0 findings. The additional 97-case smoke run on this refreshed base passed 96 cases but timed out waiting for the first managed background-turn result (30 seconds) under heavy local host load. The same three-file run then passed all 97 tests unchanged, in the same order (121.72 seconds of Vitest execution versus 344.88 seconds in the saturated run); no assertion or timeout was relaxed. Exact-head hosted CI and the required `openclaw/ci-gate` [passed](https://github.com/openclaw/openclaw/actions/runs/33143241625) for `23b60e1a46177b5f250a263133b0a98485d8a2cb`. Follow-up noted: the cold managed-runtime fixture can exceed its result deadline under severe machine saturation. The real-process tests are local runtime proof, not a new authenticated provider run; the prior repair's live proof remains linked from #130733.
