### PR TITLE
fix(copilot): own BYOK response stream lifecycles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Control UI command palette:** keep keyboard selection and Enter usable when reconnects or catalog refreshes replace search results, preserving the selected command while it remains available.
+- **Copilot BYOK streaming:** handle upstream response errors and cancel both streams on client disconnect or proxy shutdown, preventing unhandled stream errors from crashing the host.
 - **Control UI Gateway labels:** keep the discovered machine name through recovery initialization and refresh open folder-browser labels when name discovery finishes.
 - **Android settings:** keep form fields and actions reachable above the keyboard, and respect bottom system insets without duplicating navigation padding.
 - **Nextcloud Talk diagnostics:** redact reflected credentials before displaying send, reaction, and bot-preflight errors, and suppress incomplete error bodies. (#119976) Thanks @xialonglee.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,6 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Control UI command palette:** keep keyboard selection and Enter usable when reconnects or catalog refreshes replace search results, preserving the selected command while it remains available.
-- **Copilot BYOK streaming:** handle upstream response errors and cancel both streams on client disconnect or proxy shutdown, preventing unhandled stream errors from crashing the host.
 - **Control UI Gateway labels:** keep the discovered machine name through recovery initialization and refresh open folder-browser labels when name discovery finishes.
 - **Android settings:** keep form fields and actions reachable above the keyboard, and respect bottom system insets without duplicating navigation padding.
 - **Nextcloud Talk diagnostics:** redact reflected credentials before displaying send, reaction, and bot-preflight errors, and suppress incomplete error bodies. (#119976) Thanks @xialonglee.

--- a/extensions/copilot/src/byok-proxy.test.ts
+++ b/extensions/copilot/src/byok-proxy.test.ts
@@ -239,13 +239,13 @@ describe("createCopilotByokProxy", () => {
   it.each(["upstream error", "client disconnect", "proxy shutdown"] as const)(
     "releases an active response stream after %s",
     async (interruption) => {
-      const source = Promise.withResolvers<ReadableStreamDefaultController<Uint8Array>>();
+      let source: ReadableStreamDefaultController<Uint8Array> | undefined;
       const cancel = vi.fn();
       const release = vi.fn(async () => undefined);
       let upstreamSignal: AbortSignal | undefined;
       const body = new ReadableStream<Uint8Array>({
         start(controller) {
-          source.resolve(controller);
+          source = controller;
           controller.enqueue(new TextEncoder().encode("data: first\n\n"));
         },
         cancel,
@@ -283,7 +283,9 @@ describe("createCopilotByokProxy", () => {
           () => true,
         );
         if (interruption === "upstream error") {
-          (await source.promise).error(new Error("upstream stream interrupted"));
+          expectDefined(source, "upstream response controller").error(
+            new Error("upstream stream interrupted"),
+          );
         } else if (interruption === "client disconnect") {
           disconnect.abort();
         } else {

--- a/extensions/copilot/src/byok-proxy.test.ts
+++ b/extensions/copilot/src/byok-proxy.test.ts
@@ -1,4 +1,6 @@
 // Copilot BYOK proxy tests verify SDK-local transport is guarded outbound fetch.
+import { expectDefined } from "@openclaw/normalization-core";
+import type { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createCopilotByokProxy } from "./byok-proxy.js";
 import { resolveCopilotProvider } from "./provider-bridge.js";
@@ -233,6 +235,76 @@ describe("createCopilotByokProxy", () => {
     expect(upstreamSignal?.aborted).toBe(true);
     await responsePromise;
   });
+
+  it.each(["upstream error", "client disconnect", "proxy shutdown"] as const)(
+    "releases an active response stream after %s",
+    async (interruption) => {
+      const source = Promise.withResolvers<ReadableStreamDefaultController<Uint8Array>>();
+      const cancel = vi.fn();
+      const release = vi.fn(async () => undefined);
+      let upstreamSignal: AbortSignal | undefined;
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          source.resolve(controller);
+          controller.enqueue(new TextEncoder().encode("data: first\n\n"));
+        },
+        cancel,
+      });
+      ssrfRuntimeMock.fetchWithSsrFGuard
+        .mockImplementationOnce(async ({ init }: Parameters<typeof fetchWithSsrFGuard>[0]) => {
+          upstreamSignal = init?.signal ?? undefined;
+          return { response: new Response(body), release };
+        })
+        .mockResolvedValueOnce({
+          response: new Response("healthy"),
+          release: vi.fn(async () => undefined),
+        });
+      const proxy = expectDefined(
+        await createCopilotByokProxy(
+          resolveCopilotProvider({
+            model: {
+              provider: "custom-proxy",
+              api: "openai-responses",
+              id: "proxy-model",
+              baseUrl: "https://proxy.example/v1",
+            },
+          }),
+        ),
+        "BYOK proxy",
+      );
+      const endpoint = `${proxy.provider.provider?.baseUrl}/responses`;
+      const disconnect = new AbortController();
+      try {
+        const response = await fetch(endpoint, { signal: disconnect.signal });
+        const reader = expectDefined(response.body, "proxy response body").getReader();
+        expect((await reader.read()).done).toBe(false);
+        const interrupted = reader.read().then(
+          () => false,
+          () => true,
+        );
+        if (interruption === "upstream error") {
+          (await source.promise).error(new Error("upstream stream interrupted"));
+        } else if (interruption === "client disconnect") {
+          disconnect.abort();
+        } else {
+          await proxy.close();
+        }
+        await vi.waitFor(() => expect(release).toHaveBeenCalledTimes(1));
+        expect(await interrupted).toBe(true);
+        expect(upstreamSignal?.aborted).toBe(true);
+        if (interruption !== "upstream error") {
+          expect(cancel).toHaveBeenCalledTimes(1);
+        }
+        if (interruption !== "proxy shutdown") {
+          expect(await (await fetch(endpoint)).text()).toBe("healthy");
+        }
+        reader.releaseLock();
+      } finally {
+        disconnect.abort();
+        await proxy.close();
+      }
+    },
+  );
 
   it("accepts Azure SDK paths that are rebuilt from the proxy origin", async () => {
     ssrfRuntimeMock.fetchWithSsrFGuard.mockResolvedValue({

--- a/extensions/copilot/src/byok-proxy.ts
+++ b/extensions/copilot/src/byok-proxy.ts
@@ -2,7 +2,7 @@
 import { randomBytes } from "node:crypto";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { Readable } from "node:stream";
-import { finished } from "node:stream/promises";
+import { pipeline } from "node:stream/promises";
 import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import type { ResolvedCopilotProvider } from "./provider-bridge.js";
@@ -140,10 +140,10 @@ async function handleProxyRequest(
       res.end();
       return;
     }
-    await finished(
-      Readable.fromWeb(guarded.response.body as unknown as NodeReadableStream<Uint8Array>).pipe(
-        res,
-      ),
+    // Own errors and cancellation on both streams so interrupted responses cannot crash the host.
+    await pipeline(
+      Readable.fromWeb(guarded.response.body as unknown as NodeReadableStream<Uint8Array>),
+      res,
     );
   } catch (error) {
     if (res.destroyed || res.writableEnded) {


### PR DESCRIPTION
## Summary

Fixes #131544.

Fix a process crash in the Copilot plugin's BYOK response proxy. An upstream body failure, client disconnect, or proxy shutdown could emit an unhandled error on the Node readable stream and terminate the host process.

The owner is `extensions/copilot/src/byok-proxy.ts`. `finished(Readable.fromWeb(body).pipe(res))` observes only the destination returned by `pipe`; the source's error and cancellation lifecycle remains unowned. Replace that split flow with `pipeline(Readable.fromWeb(body), res)`, which owns errors and destruction on both streams and reaches the existing guarded-fetch release boundary. Keep the explicit Web-to-Node adapter so downstream cancellation destroys and cancels the upstream reader even when the source does not observe an AbortSignal.

No new retry, timeout, configuration, request-size limit, dependency, or storage path. The buffered request body, 307/308 replay, SSRF/DNS policy, header normalization, and Azure routing remain unchanged. This does not resolve the separate request-intake policy question in #99064.

## Evidence

- Pre-fix targeted regression: 3 failures, 10 existing controls passed, and one unhandled source error. The added cases cover upstream response interruption, client disconnect, and proxy shutdown through actual loopback HTTP streams.
- Three independent fault-injection child probes crashed before and exited cleanly after; upstream-error and client-disconnect cases also completed a subsequent healthy request. Those probes use fixture upstream responses, not a live vendor failure.
- Post-fix proxy/provider-bridge suite: 27 tests passed, including existing binary 307/308 replay and routing/auth controls.
- Authenticated live before/after on Node 24.20.0 and Undici 8.10.0: actual OpenAI `gpt-5.6-luna` HTTP 200 SSE through the actual proxy, followed by deliberate local client cancellation. Before: isolated child crashed with an unhandled AbortError (exit 1). After: upstream abort observed, process remained responsive, clean proxy shutdown, exit 0, no stderr.
- Normal live flow: actual Copilot SDK 1.0.11 / CLI 1.0.80 through the fixed proxy to OpenAI, one HTTP 200 SSE request, 12 assistant deltas, one idle event, exact fresh nonce, no tool permissions, and clean shutdown.
- Live proof is local isolated functional proof, not a full Gateway or clean-machine run. Exactly three authenticated inference requests across baseline/candidate/SDK checks; no retries. Disposable state removed and credential window closed. Source/dependency hashes remained stable throughout.

Candidate proxy SHA256: `64738e85ba6e4567f7832b845b053f4b7338b0fc91aeed7afaa2de8c4da915a4` (baseline `b60e7b94012be8894a41c38a13ff78052616f476384d93802fad6ca016a51aa7`).

## Architecture and scope

Production LOC: +5/-5 (net 0). Tests: +74/-0. Release-note context is recorded here and in the commit; normal PRs leave release-owned `CHANGELOG.md` generation to release automation. Removed the separate destination-only completion wait; Node's canonical pipeline now owns forwarding and teardown. No shared/core provider policy changes.

Direct dependency evidence: Node's [pipe implementation](https://github.com/nodejs/node/blob/v26.7.0/lib/internal/streams/readable.js), [Web stream adapter](https://github.com/nodejs/node/blob/v26.7.0/lib/internal/webstreams/adapters.js), and [pipeline implementation](https://github.com/nodejs/node/blob/v26.7.0/lib/internal/streams/pipeline.js); installed Node 24 and 26 implementations were also inspected. The same broken response block exists in stable `v2026.7.1-2` (source inspection, not an executed stable build).

Alternatives rejected: a source-only error listener leaves cleanup split between streams; direct Web-stream iteration does not provide the same Node destroy/cancel ownership; request caps or retries address different contracts and cannot fix this crash.

Provenance: #96345 (`bfffc77bfc86f24572696db3613285c9e68031d9`), authored and merged by @vincentkoc on June 24, added the broken response composition. This was verified from the immutable added source and current PR metadata, not the local shallow blame boundary.

An upstream body error before its first chunk can surface as a transport failure, not an HTTP 502: pipeline destroys the destination socket. The executed new regressions cover failures after the first chunk; pre-fetch error handling is unchanged.

## Remaining validation

Fresh Codex autoreview completed with no actionable findings at its default P0 threshold. Independent owner-boundary review found no actionable correctness issue and verified Node error/cancellation contracts, the unchanged caller/guard paths, and the source-bound live receipts. Every local changed-file static step passed after the test-target correction below. CI run 33144060172 passed on head `37949496453374e8343d99ffe3ed8a3ad59fb4fc`: 101 successes, 17 skips, zero failures.

The first changed-file static run caught a test-only TypeScript-target mismatch in `Promise.withResolvers`. The fixture now captures the synchronously supplied stream controller directly; the unchanged 27-test suite and extension-test typecheck both pass. No target/configuration or production-code change was needed.

Native prepare then enforced the current release-only changelog policy. The follow-up removes only this PR's changelog-file entry, retaining the release-note context above; production and tests remain byte-identical. No guard override or release action was used.

Final head `cee74fa5a10828505e4d145efe6cf068c0378406` passed [CI run 33145268897](https://github.com/openclaw/openclaw/actions/runs/33145268897): 41 successes, 18 skips, zero failures. Native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 131546` passed on that exact head, using its own successful CI and Workflow Sanity runs without prior-head CI reuse. All eight live-bound source files and the corrected regression test remain byte-identical to the reviewed candidate.
