### PR TITLE
fix: worktree tasks inherit configured permission defaults

### DIFF
--- a/docs/gateway/permission-modes.md
+++ b/docs/gateway/permission-modes.md
@@ -26,7 +26,7 @@ Managed worktree sessions use the worktree checkout as `sessionRoot`. A nested w
 
 File tools recognize aliases of the session's trusted root and working directory, including absolute paths using those aliases. This does not expand the boundary: unrelated external symlinks pointing inward remain denied, as do symlinks and raw `symlink/..` traversal that escape the root. `read-only` sessions still omit mutation tools.
 
-A new managed worktree session defaults to `workspace` when no mode is specified. Other sessions with no recorded mode keep the existing config-driven behavior.
+New sessions, including managed worktree sessions, inherit the configured global or per-agent tool/exec policy when no mode is specified. Creating a worktree pins the working directory without selecting a permission mode. Explicit modes and modes already saved on existing sessions remain unchanged.
 
 ## Policy precedence and clamping
 

--- a/docs/start/why-openclaw.md
+++ b/docs/start/why-openclaw.md
@@ -253,7 +253,7 @@ Since the comparison snapshot, Hermes has added [optional persistent local Pytho
 Each enterprise configuration item links to its reference:
 
 - Sandbox on: `agents.defaults.sandbox.mode: "all"` with the [`openshell`](/gateway/openshell) or [`docker`](/gateway/sandboxing) backend; `workspaceAccess: "ro"` unless the agent owns the workspace.
-- Select [`guarded` or `workspace`](/gateway/permission-modes) per session; `full` requires `operator.admin`. Managed worktree sessions default to `workspace`; other sessions without a mode use configured tool/exec policy.
+- Select [`guarded` or `workspace`](/gateway/permission-modes) per session; `full` requires `operator.admin`. Sessions without a mode, including managed worktree sessions, use configured tool/exec policy.
 - Front the gateway with [Tailscale](/gateway/tailscale) or an [identity-aware proxy](/gateway/trusted-proxy-auth); define [`gateway.roles`](/gateway/operator-scopes) with a deny-all default; leave DM policy on [pairing](/channels/pairing).
 - Everything behind [SecretRefs](/gateway/secrets); run `openclaw secrets audit --check` against your config in CI.
 - Enable [message auditing](/gateway/audit); export [OpenTelemetry](/gateway/opentelemetry) to your SIEM with operator-owned retention and monitoring for dropped data.

--- a/src/gateway/server-methods/sessions-create.ts
+++ b/src/gateway/server-methods/sessions-create.ts
@@ -549,7 +549,7 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
           : undefined,
       spawnedCwd: p.worktree === true ? undefined : sessionCwd,
       sessionRoot: p.worktree === true ? undefined : sessionRoot,
-      permissionMode: p.permissionMode ?? (p.worktree === true ? "workspace" : undefined),
+      permissionMode: p.permissionMode,
       ...(p.toolOverrides !== undefined ? { toolOverrides: p.toolOverrides } : {}),
       prepareLifecycle,
       onLifecycleCleanupError: (error) => {

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -1753,7 +1753,8 @@ test("sessions.create provisions and reuses a session worktree for later runs", 
     const worktree = created.payload?.worktree;
     expect(worktree?.branch).toBe("openclaw/release-planning");
     expect(created.payload?.entry.spawnedCwd).toBe(worktree?.path);
-    expect(created.payload?.entry.permissionMode).toBe("workspace");
+    expect(created.payload?.entry.permissionMode).toBeUndefined();
+    expect(loadSessionEntry({ sessionKey: key, storePath })?.permissionMode).toBeUndefined();
     expect(created.payload?.entry.sessionRoot).toBe(worktree?.path);
     worktreeId = worktree?.id;
     expect(findLiveRegistryWorktreeByOwner(process.env, "session", key)).toMatchObject({
@@ -2387,6 +2388,7 @@ test("sessions.create maps worktree options and preserves a nested workspace cwd
         worktree: true,
         worktreeName: "target-task",
         worktreeBaseRef: "base-branch",
+        permissionMode: "workspace",
       },
       { client: { connect: { scopes: ["operator.admin"] } } as never },
     );
@@ -3013,6 +3015,7 @@ test("sessions.create reset-in-place detaches the prior worktree permission boun
         parentSessionKey: "main",
         emitCommandHooks: true,
         worktree: true,
+        permissionMode: "workspace",
       },
       { client: { connect: { scopes: ["operator.admin"] } } as never },
     );


### PR DESCRIPTION
Closes #131536

## What Problem This Solves

Fixes an issue where users creating a managed worktree task would unexpectedly get Workspace sandboxing and approval review even when their Gateway was configured for full/YOLO execution. Choosing Git isolation silently selected a different permission policy.

## Why This Change Was Made

Session creation now forwards an optional permission mode unchanged, using the same configuration-driven path as ordinary sessions. The worktree still owns its checkout and recorded session root. This removes the forced Workspace default without introducing a new setting or materializing a Full override that would bypass approval-file floors.

The previous default was introduced intentionally in #124909, authored and merged by @steipete. This is the maintainer-requested correction to that default. The implementation is AI-assisted with Codex.

## User Impact

New worktree tasks inherit global/per-agent execution policy unless a permission mode is explicitly selected. Explicit Read-only, Guarded, Workspace, and Full choices retain their semantics; Full still requires `operator.admin`. Existing saved modes are preserved because stored automatic and explicit Workspace choices cannot be distinguished safely. No state migration, configuration option, or protocol change is required.

## Evidence

The regression test failed before the production change with `expected 'workspace' to be undefined`. It checks the created response and persisted session mode while retaining the real managed-worktree lifecycle and subsequent Gateway agent request. Existing nested-workspace and reset tests now request Workspace explicitly so they continue proving an actual selected boundary.

Source review covered the creation caller, session persistence/reset, explicit-mode authorization, parent-mode forwarding, Codex policy resolution, and the core tool policy path. Direct upstream Codex inspection at `124e560b9357746b6a7e2bba1fd244115fd9cc5a` covered `codex-rs/core/src/config/mod.rs:3628`, `codex-rs/core/src/tools/sandboxing.rs:195`, and `codex-rs/core/src/guardian/review.rs:722`.

Focused Gateway proof passed all four relevant cases:

```text
node scripts/run-vitest.mjs src/gateway/server.sessions.create.test.ts -t 'provisions and reuses a session worktree|maps worktree options|reset-in-place detaches|requires admin for full permission mode'
4 passed; 118 unrelated cases skipped
```

The same inherited-mode regression failed on the pre-fix code. Structured Codex autoreview completed with no actionable findings. The Codex session-policy suite passed all 24 cases. Changed guards, formatting, dead-export checks, core typecheck, and the full build passed. Core test typechecking passed after an isolated frozen-lockfile install resolved an older shared `pako` dependency; the shared root install was left unchanged. A broader local sweep was interrupted after five minutes without output and is not counted as passing evidence. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33143443738) passed for `c9b568946409d05b6ab3046efd79bbd5500ab946`.

Live proof used the complete built Gateway with isolated state, a separate loopback port, and a synthetic Git repository. A real `sessions.create` call created `openclaw/permission-inheritance-smoke`, returned no `entry.permissionMode`, and retained the worktree as `sessionRoot`. The rendered task showed Permissions: Default and its configured-policy description. This checks real creation and rendering, not a model/tool execution: the isolated state had no available model. Initial setup caused event-loop delays and one handshake timeout; the bounded retry succeeded. The attached screenshot contains only synthetic fixture content. The before state is captured by the failing regression, not a rendered screenshot; the available browser API supports screenshots but not video recording.

Production delta: +1/-1. Test delta: +4/-1. Documentation: two default descriptions corrected.
