### PR TITLE
fix(ui): keep selected agent after app restart

### DIFF
--- a/ui/src/app/agent-selection.test.ts
+++ b/ui/src/app/agent-selection.test.ts
@@ -1,13 +1,20 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { AgentsListResult } from "../api/types.ts";
 import { createAgentSelectionCapability, selectApplicationSession } from "./agent-selection.ts";
 
-function createGateway(assistantAgentId: string | null = "Main") {
+function createGateway(
+  assistantAgentId: string | null = "Main",
+  initialGatewayUrl = "ws://gateway-a.test",
+) {
   let snapshot = { client: null as GatewayBrowserClient | null, assistantAgentId };
+  let gatewayUrl = initialGatewayUrl;
   const listeners = new Set<(next: typeof snapshot) => void>();
   return {
     gateway: {
+      get connection() {
+        return { gatewayUrl };
+      },
       get snapshot() {
         return snapshot;
       },
@@ -18,6 +25,12 @@ function createGateway(assistantAgentId: string | null = "Main") {
     },
     publish(next: typeof snapshot) {
       snapshot = next;
+      for (const listener of listeners) {
+        listener(snapshot);
+      }
+    },
+    switchGateway(nextGatewayUrl: string) {
+      gatewayUrl = nextGatewayUrl;
       for (const listener of listeners) {
         listener(snapshot);
       }
@@ -48,6 +61,73 @@ function createRoster() {
 }
 
 describe("agent selection", () => {
+  it("restores a persisted selection before the Gateway default arrives", () => {
+    const harness = createGateway(null);
+    const persistence = {
+      load: () => "OpenClaw",
+      save: vi.fn(),
+    };
+    const selection = createAgentSelectionCapability(
+      harness.gateway,
+      createRoster().roster,
+      persistence,
+    );
+
+    harness.publish({
+      client: { request() {} } as unknown as GatewayBrowserClient,
+      assistantAgentId: "Dummy",
+    });
+
+    expect(selection.state).toEqual({ selectedId: "openclaw", scopeId: "openclaw" });
+    expect(persistence.save).not.toHaveBeenCalled();
+  });
+
+  it("persists explicit selections and clears a removed agent", () => {
+    const harness = createGateway("Dummy");
+    const roster = createRoster();
+    roster.publish({
+      defaultId: "dummy",
+      mainKey: "main",
+      scope: "global",
+      agents: [
+        { id: "dummy", kind: "agent" },
+        { id: "openclaw", kind: "agent" },
+      ],
+    });
+    const persistence = { load: () => null, save: vi.fn() };
+    const selection = createAgentSelectionCapability(harness.gateway, roster.roster, persistence);
+
+    selection.set("OpenClaw");
+    expect(persistence.save).toHaveBeenLastCalledWith("ws://gateway-a.test", "openclaw");
+
+    roster.publish({
+      defaultId: "dummy",
+      mainKey: "main",
+      scope: "global",
+      agents: [{ id: "dummy", kind: "agent" }],
+    });
+    expect(selection.state).toEqual({ selectedId: "dummy", scopeId: "dummy" });
+    expect(persistence.save).toHaveBeenLastCalledWith("ws://gateway-a.test", null);
+  });
+
+  it("restores selection independently when the Gateway changes", () => {
+    const harness = createGateway("Dummy");
+    const persistence = {
+      load: (gatewayUrl: string) =>
+        gatewayUrl === "wss://gateway-b.test" ? "Research" : "OpenClaw",
+      save: vi.fn(),
+    };
+    const selection = createAgentSelectionCapability(
+      harness.gateway,
+      createRoster().roster,
+      persistence,
+    );
+
+    expect(selection.state.selectedId).toBe("openclaw");
+    harness.switchGateway("wss://gateway-b.test");
+    expect(selection.state).toEqual({ selectedId: "research", scopeId: "research" });
+  });
+
   it("keeps page scope separate from the concrete chat agent", () => {
     const harness = createGateway();
     const roster = createRoster();

--- a/ui/src/app/agent-selection.ts
+++ b/ui/src/app/agent-selection.ts
@@ -2,10 +2,18 @@ import type { AgentsListResult } from "../api/types.ts";
 import { normalizeAgentId, parseAgentSessionKey } from "../lib/sessions/session-key.ts";
 
 type AgentSelectionGateway = {
+  readonly connection: {
+    gatewayUrl: string;
+  };
   readonly snapshot: {
     assistantAgentId: string | null;
   };
   subscribe: (listener: (snapshot: AgentSelectionGateway["snapshot"]) => void) => () => void;
+};
+
+type AgentSelectionPersistence = {
+  load: (gatewayUrl: string) => string | null;
+  save: (gatewayUrl: string, selectedAgentId: string | null) => void;
 };
 
 type AgentSelectionRoster = {
@@ -45,6 +53,7 @@ export function selectApplicationSession(params: {
 export function createAgentSelectionCapability(
   gateway: AgentSelectionGateway,
   roster: AgentSelectionRoster,
+  persistence?: AgentSelectionPersistence,
 ): AgentSelectionCapability {
   const reconcileSelectedId = (value: string | null): string | null => {
     const selectedId = value?.trim() ? normalizeAgentId(value) : null;
@@ -66,18 +75,25 @@ export function createAgentSelectionCapability(
     );
     return isSystem ? null : scopeId;
   };
-  const initialId = gateway.snapshot.assistantAgentId
-    ? normalizeAgentId(gateway.snapshot.assistantAgentId)
-    : null;
+  let gatewayUrl = gateway.connection.gatewayUrl;
+  const persistedId = persistence?.load(gatewayUrl)?.trim();
+  const initialId = persistedId
+    ? normalizeAgentId(persistedId)
+    : gateway.snapshot.assistantAgentId
+      ? normalizeAgentId(gateway.snapshot.assistantAgentId)
+      : null;
   const initialSelectedId = reconcileSelectedId(initialId);
   let state: AgentSelectionState = {
     selectedId: initialSelectedId,
     scopeId: resolveScopeId(initialSelectedId),
   };
-  let assistantAgentId = initialId;
-  // Construction has no explicit-selection input: a roster repair still follows
-  // hello until a navigation or picker action establishes explicit ownership.
-  let followsGatewayDefault = true;
+  let assistantAgentId = gateway.snapshot.assistantAgentId
+    ? normalizeAgentId(gateway.snapshot.assistantAgentId)
+    : null;
+  let followsGatewayDefault = !persistedId || initialSelectedId !== normalizeAgentId(persistedId);
+  if (persistedId && followsGatewayDefault) {
+    persistence?.save(gatewayUrl, null);
+  }
   const listeners = new Set<(next: AgentSelectionState) => void>();
 
   const publish = (next: AgentSelectionState) => {
@@ -101,6 +117,18 @@ export function createAgentSelectionCapability(
       : null;
     const assistantChanged = nextAssistantAgentId !== assistantAgentId;
     assistantAgentId = nextAssistantAgentId;
+    const nextGatewayUrl = gateway.connection.gatewayUrl;
+    if (nextGatewayUrl !== gatewayUrl) {
+      gatewayUrl = nextGatewayUrl;
+      const nextPersistedId = persistence?.load(gatewayUrl)?.trim();
+      followsGatewayDefault = !nextPersistedId;
+      const selectedId = nextPersistedId ? normalizeAgentId(nextPersistedId) : nextAssistantAgentId;
+      // AgentCapability subscribes first and clears the old roster on a
+      // connection change, so a target Gateway's saved id is not judged
+      // against the previous Gateway's agents.
+      publish({ selectedId, scopeId: selectedId });
+      return;
+    }
     // A reconnect publishes a transient null before hello. Keep the last
     // implicit default selected until the next authoritative default arrives.
     if (assistantChanged && followsGatewayDefault && nextAssistantAgentId) {
@@ -112,6 +140,7 @@ export function createAgentSelectionCapability(
     // synchronous subscriber may establish a new explicit owner during publish.
     if (!followsGatewayDefault && reconcileSelectedId(state.selectedId) !== state.selectedId) {
       followsGatewayDefault = true;
+      persistence?.save(gatewayUrl, null);
     }
     if (followsGatewayDefault && assistantAgentId) {
       publish({
@@ -133,7 +162,8 @@ export function createAgentSelectionCapability(
       // scope field lets page controls expose all agents without losing the
       // concrete agent required by chat and new-session flows.
       // Establish ownership before publish notifies synchronous subscribers.
-      followsGatewayDefault = reconcileSelectedId(selectedId) !== selectedId;
+      followsGatewayDefault = !selectedId || reconcileSelectedId(selectedId) !== selectedId;
+      persistence?.save(gatewayUrl, followsGatewayDefault ? null : selectedId);
       publish({ selectedId, scopeId: selectedId });
     },
     setScope(agentId) {

--- a/ui/src/app/bootstrap-location.ts
+++ b/ui/src/app/bootstrap-location.ts
@@ -1,13 +1,14 @@
 import type { RouteLocation } from "@openclaw/uirouter";
+import type { AgentsListResult } from "../api/types.ts";
 import { pathForRoute } from "../app-route-paths.ts";
 import { routeIdFromPath } from "../app-routes.ts";
 import { pathForSession } from "../app-session-path-builder.ts";
 import type { BoardFace } from "../lib/board/settings.ts";
 import {
+  normalizeAgentId,
   parseAgentSessionKey,
   resolveUiConfiguredMainKey,
   resolveUiDefaultAgentId,
-  type UiSessionDefaultsHost,
 } from "../lib/sessions/session-key.ts";
 import { isDefaultChatLanding } from "../pages/model-setup/first-run.ts";
 import type { ApplicationGateway } from "./context.ts";
@@ -17,6 +18,20 @@ type ReleasedSessionQuery = {
   face: BoardFace;
   sessionKey: string;
 };
+
+function resolvePersistedAgentId(
+  selectedAgentId: string | null | undefined,
+  agentsList: AgentsListResult | null,
+): string | null {
+  const selectedId = selectedAgentId?.trim();
+  if (!selectedId || !agentsList) {
+    return null;
+  }
+  const normalizedId = normalizeAgentId(selectedId);
+  return agentsList.agents.some((agent) => normalizeAgentId(agent.id) === normalizedId)
+    ? normalizedId
+    : null;
+}
 
 function releasedSessionQuery(
   location: RouteLocation,
@@ -47,7 +62,7 @@ async function normalizeReleasedSessionQueryLocation(params: {
   location: RouteLocation;
   basePath: string;
   gateway: Pick<ApplicationGateway, "snapshot" | "subscribe">;
-  agentsList: () => UiSessionDefaultsHost["agentsList"];
+  agentsList: () => AgentsListResult | null;
   selectedAgentId?: string | null;
   signal: AbortSignal;
 }): Promise<RouteLocation | null> {
@@ -68,7 +83,9 @@ async function normalizeReleasedSessionQueryLocation(params: {
     hello: params.gateway.snapshot.hello,
   };
   const agentId =
-    parsed?.agentId ?? (params.selectedAgentId?.trim() || resolveUiDefaultAgentId(defaults));
+    parsed?.agentId ??
+    (resolvePersistedAgentId(params.selectedAgentId, defaults.agentsList) ||
+      resolveUiDefaultAgentId(defaults));
   const mainKey = resolveUiConfiguredMainKey(defaults);
   const pathname = released.sessionKey
     ? pathForSession(released.face, agentId, released.sessionKey, params.basePath, {
@@ -109,7 +126,7 @@ export async function resolveInitialApplicationLocation(params: {
   basePath: string;
   sessionKey: string;
   gateway: Pick<ApplicationGateway, "snapshot" | "subscribe">;
-  agentsList: () => UiSessionDefaultsHost["agentsList"];
+  agentsList: () => AgentsListResult | null;
   selectedAgentId?: string | null;
   signal: AbortSignal;
 }): Promise<RouteLocation> {
@@ -133,7 +150,8 @@ export async function resolveInitialApplicationLocation(params: {
     params.location,
     params.basePath,
     params.sessionKey.trim() || params.gateway.snapshot.sessionKey,
-    params.selectedAgentId?.trim() || resolveUiDefaultAgentId(defaults),
+    resolvePersistedAgentId(params.selectedAgentId, defaults.agentsList) ||
+      resolveUiDefaultAgentId(defaults),
     resolveUiConfiguredMainKey(defaults),
   );
 }

--- a/ui/src/app/bootstrap-location.ts
+++ b/ui/src/app/bootstrap-location.ts
@@ -48,6 +48,7 @@ async function normalizeReleasedSessionQueryLocation(params: {
   basePath: string;
   gateway: Pick<ApplicationGateway, "snapshot" | "subscribe">;
   agentsList: () => UiSessionDefaultsHost["agentsList"];
+  selectedAgentId?: string | null;
   signal: AbortSignal;
 }): Promise<RouteLocation | null> {
   const released = releasedSessionQuery(params.location, params.basePath);
@@ -66,7 +67,8 @@ async function normalizeReleasedSessionQueryLocation(params: {
     agentsList: params.agentsList(),
     hello: params.gateway.snapshot.hello,
   };
-  const agentId = parsed?.agentId ?? resolveUiDefaultAgentId(defaults);
+  const agentId =
+    parsed?.agentId ?? (params.selectedAgentId?.trim() || resolveUiDefaultAgentId(defaults));
   const mainKey = resolveUiConfiguredMainKey(defaults);
   const pathname = released.sessionKey
     ? pathForSession(released.face, agentId, released.sessionKey, params.basePath, {
@@ -108,6 +110,7 @@ export async function resolveInitialApplicationLocation(params: {
   sessionKey: string;
   gateway: Pick<ApplicationGateway, "snapshot" | "subscribe">;
   agentsList: () => UiSessionDefaultsHost["agentsList"];
+  selectedAgentId?: string | null;
   signal: AbortSignal;
 }): Promise<RouteLocation> {
   const releasedLocation = await normalizeReleasedSessionQueryLocation(params);
@@ -130,7 +133,7 @@ export async function resolveInitialApplicationLocation(params: {
     params.location,
     params.basePath,
     params.sessionKey.trim() || params.gateway.snapshot.sessionKey,
-    resolveUiDefaultAgentId(defaults),
+    params.selectedAgentId?.trim() || resolveUiDefaultAgentId(defaults),
     resolveUiConfiguredMainKey(defaults),
   );
 }

--- a/ui/src/app/bootstrap.agent-selection.test.ts
+++ b/ui/src/app/bootstrap.agent-selection.test.ts
@@ -48,6 +48,42 @@ it("routes a canonical global session through its persisted agent owner", async 
   expect(subscribe).not.toHaveBeenCalled();
 });
 
+it("falls back when the persisted agent is absent from the Gateway roster", async () => {
+  await expect(
+    resolveInitialApplicationLocation({
+      location: { pathname: "/chat", search: "", hash: "" },
+      basePath: "",
+      sessionKey: "global",
+      selectedAgentId: "removed",
+      gateway: {
+        snapshot: {
+          phase: "connected",
+          client: {},
+          sessionKey: "global",
+          hello: {
+            snapshot: {
+              sessionDefaults: {
+                defaultAgentId: "dummy",
+                mainKey: "main",
+                mainSessionKey: "global",
+                scope: "global",
+              },
+            },
+          },
+        },
+        subscribe: vi.fn(() => () => undefined),
+      } as unknown as ApplicationContext<RouteId>["gateway"],
+      agentsList: () => ({
+        defaultId: "dummy",
+        mainKey: "main",
+        scope: "global",
+        agents: [{ id: "dummy", kind: "agent" }],
+      }),
+      signal: new AbortController().signal,
+    }),
+  ).resolves.toEqual({ pathname: "/chat/dummy", search: "", hash: "" });
+});
+
 it.each([
   { name: "saved target agent", selectedAgentId: "research" },
   { name: "unsaved target agent", selectedAgentId: undefined },

--- a/ui/src/app/bootstrap.agent-selection.test.ts
+++ b/ui/src/app/bootstrap.agent-selection.test.ts
@@ -1,0 +1,99 @@
+import { gatewayOriginScope } from "@openclaw/gateway-client/browser";
+import { expect, it, vi } from "vitest";
+import type { RouteId } from "../app-routes.ts";
+import { resolveInitialApplicationLocation } from "./bootstrap-location.ts";
+import { bootstrapApplication } from "./bootstrap.ts";
+import type { ApplicationContext } from "./context.ts";
+import { loadGatewaySessionSelection, loadSettings, saveSettings } from "./settings.ts";
+
+it("routes a canonical global session through its persisted agent owner", async () => {
+  const subscribe = vi.fn(() => () => undefined);
+
+  await expect(
+    resolveInitialApplicationLocation({
+      location: { pathname: "/chat", search: "", hash: "" },
+      basePath: "",
+      sessionKey: "global",
+      selectedAgentId: "openclaw",
+      gateway: {
+        snapshot: {
+          phase: "connected",
+          client: {},
+          sessionKey: "global",
+          hello: {
+            snapshot: {
+              sessionDefaults: {
+                defaultAgentId: "dummy",
+                mainKey: "main",
+                mainSessionKey: "global",
+                scope: "global",
+              },
+            },
+          },
+        },
+        subscribe,
+      } as unknown as ApplicationContext<RouteId>["gateway"],
+      agentsList: () => ({
+        defaultId: "dummy",
+        mainKey: "main",
+        scope: "global",
+        agents: [
+          { id: "dummy", kind: "agent" },
+          { id: "openclaw", kind: "agent" },
+        ],
+      }),
+      signal: new AbortController().signal,
+    }),
+  ).resolves.toEqual({ pathname: "/chat/openclaw", search: "", hash: "" });
+  expect(subscribe).not.toHaveBeenCalled();
+});
+
+it.each([
+  { name: "saved target agent", selectedAgentId: "research" },
+  { name: "unsaved target agent", selectedAgentId: undefined },
+])("hydrates the $name during native Gateway handoff", ({ selectedAgentId }) => {
+  const previousSettings = loadSettings();
+  const previousUrl = window.location.href;
+  const targetGatewayUrl = `wss://native-${selectedAgentId ?? "unset"}.example`;
+  const targetSettingsKey = `openclaw.control.settings.v1:${gatewayOriginScope(targetGatewayUrl)}`;
+  let runtime: ReturnType<typeof bootstrapApplication> | undefined;
+
+  try {
+    saveSettings({
+      ...previousSettings,
+      gatewayUrl: targetGatewayUrl,
+      sessionKey: "global",
+      lastActiveSessionKey: "global",
+      selectedAgentId,
+    });
+    saveSettings({
+      ...previousSettings,
+      sessionKey: "agent:dummy:main",
+      lastActiveSessionKey: "agent:dummy:main",
+      selectedAgentId: "dummy",
+    });
+    window["__OPENCLAW_NATIVE_CONTROL_AUTH__"] = {
+      gatewayUrl: targetGatewayUrl,
+      token: "native-token",
+    };
+    window.history.replaceState({}, "", "/settings/appearance");
+
+    runtime = bootstrapApplication({
+      sessionPathBuilderReady: new Promise<void>(() => {}),
+    });
+
+    expect(runtime.context.gateway.connection.gatewayUrl).toBe(targetGatewayUrl);
+    expect(runtime.context.gateway.snapshot.sessionKey).toBe("global");
+    expect(loadGatewaySessionSelection(targetGatewayUrl)).toEqual({
+      sessionKey: "global",
+      lastActiveSessionKey: "global",
+      ...(selectedAgentId ? { selectedAgentId } : {}),
+    });
+  } finally {
+    runtime?.stop();
+    delete window["__OPENCLAW_NATIVE_CONTROL_AUTH__"];
+    localStorage.removeItem(targetSettingsKey);
+    window.history.replaceState({}, "", previousUrl);
+    saveSettings(previousSettings);
+  }
+});

--- a/ui/src/app/bootstrap.test.ts
+++ b/ui/src/app/bootstrap.test.ts
@@ -230,7 +230,7 @@ describe("normalizeInitialApplicationLocation", () => {
         snapshot: { phase: "connecting", client: null, hello: null },
         subscribe,
       } as unknown as ApplicationContext<RouteId>["gateway"],
-      agentsList: () => ({ defaultId: "main", mainKey: "main", agents: [] }),
+      agentsList: () => ({ defaultId: "main", mainKey: "main", scope: "global", agents: [] }),
       signal: new AbortController().signal,
     });
 
@@ -334,7 +334,7 @@ describe("normalizeInitialApplicationLocation", () => {
       basePath: "",
       sessionKey: "agent:main:main",
       gateway,
-      agentsList: () => ({ defaultId: "main", mainKey: "main", agents: [] }),
+      agentsList: () => ({ defaultId: "main", mainKey: "main", scope: "global", agents: [] }),
       signal: new AbortController().signal,
     });
     let currentLocation: RouteLocation = initialLocation;

--- a/ui/src/app/bootstrap.ts
+++ b/ui/src/app/bootstrap.ts
@@ -1,3 +1,4 @@
+import { gatewayOriginScope } from "@openclaw/gateway-client/browser";
 import {
   parseControlUiFocusLocation,
   type ControlUiFocusLocation,
@@ -56,6 +57,7 @@ import { createApplicationOverlays } from "./overlays.ts";
 import { isBrowserPanelAvailable } from "./panel-availability.ts";
 import { createApplicationPlacementStartup } from "./session-placement-startup.ts";
 import {
+  loadGatewaySessionSelection,
   loadSettings,
   patchSettings,
   persistSessionToken,
@@ -296,6 +298,18 @@ export function bootstrapApplication(
     ? resolvePageGatewaySettings(persistedSettings)
     : persistedSettings;
   const startup = resolveApplicationStartupSettings(initialSettings, startupLocation);
+  const startupTargetSelection =
+    gatewayOriginScope(startup.settings.gatewayUrl) ===
+    gatewayOriginScope(initialSettings.gatewayUrl)
+      ? null
+      : loadGatewaySessionSelection(startup.settings.gatewayUrl);
+  const settings = startupTargetSelection
+    ? {
+        ...startup.settings,
+        ...startupTargetSelection,
+        selectedAgentId: startupTargetSelection.selectedAgentId,
+      }
+    : startup.settings;
   if (
     startup.location.pathname !== startupLocation.pathname ||
     startup.location.search !== startupLocation.search ||
@@ -306,9 +320,9 @@ export function bootstrapApplication(
   }
   if (startup.changed) {
     if (documentMode) {
-      persistSessionToken(startup.settings.gatewayUrl, startup.settings.token);
+      persistSessionToken(settings.gatewayUrl, settings.token);
     } else {
-      saveSettings(startup.settings);
+      saveSettings(settings);
     }
   }
   let applicationLocation = normalizeLegacyTerminalViewLocation(startup.location, basePath);
@@ -340,7 +354,6 @@ export function bootstrapApplication(
           setSessionPathBuilder(contract.buildControlUiSessionPath);
         }));
 
-  const settings = startup.settings;
   const gateway = createApplicationGateway(
     settings,
     startup.password ?? "",
@@ -375,6 +388,7 @@ export function bootstrapApplication(
               sessionKey: settings.sessionKey,
               gateway,
               agentsList: () => agents.state.agentsList,
+              selectedAgentId: settings.selectedAgentId,
               signal: startupLifecycle.signal,
             }),
         )
@@ -387,7 +401,20 @@ export function bootstrapApplication(
     throw error;
   });
   const agentIdentity = createAgentIdentityCapability(gateway);
-  const agentSelection = createAgentSelectionCapability(gateway, agents);
+  const agentSelection = createAgentSelectionCapability(
+    gateway,
+    agents,
+    startsApplicationRouter
+      ? {
+          load: (gatewayUrl) => loadGatewaySessionSelection(gatewayUrl).selectedAgentId ?? null,
+          save: (gatewayUrl, selectedAgentId) => {
+            if (gateway.connection.gatewayUrl === gatewayUrl) {
+              patchSettings({ selectedAgentId: selectedAgentId ?? undefined });
+            }
+          },
+        }
+      : undefined,
+  );
   const channels = createChannelCapability(gateway);
   const scopeUpgrade = createScopeUpgradeCapability(gateway);
   const config = createApplicationConfigCapability({

--- a/ui/src/app/gateway-store.test.ts
+++ b/ui/src/app/gateway-store.test.ts
@@ -336,6 +336,45 @@ describe("createApplicationGateway connection phase", () => {
     expect(gateway.snapshot.phase).toBe("connecting");
   });
 
+  it("restores the newly selected Gateway's saved agent", () => {
+    const otherGateway = "wss://other-gateway.example.test";
+    localStorage.setItem(
+      `openclaw.control.settings.v1:${otherGateway}`,
+      JSON.stringify({
+        gatewayUrl: otherGateway,
+        sessionsByGateway: {
+          [otherGateway]: {
+            sessionKey: "global",
+            lastActiveSessionKey: "global",
+            selectedAgentId: "research",
+          },
+        },
+      }),
+    );
+    const { gateway } = createStore({
+      settings: { ...loadSettings(), selectedAgentId: "openclaw" },
+    });
+
+    gateway.connect({ gatewayUrl: otherGateway });
+
+    expect(gateway.snapshot.sessionKey).toBe("global");
+    expect(loadSettings()).toMatchObject({
+      sessionKey: "global",
+      lastActiveSessionKey: "global",
+      selectedAgentId: "research",
+    });
+  });
+
+  it("does not carry an agent selection into an unsaved Gateway", () => {
+    const { gateway } = createStore({
+      settings: { ...loadSettings(), selectedAgentId: "openclaw" },
+    });
+
+    gateway.connect({ gatewayUrl: "wss://fresh-gateway.example.test" });
+
+    expect(loadSettings().selectedAgentId).toBeUndefined();
+  });
+
   it("advances the connection revision only when credentials change", () => {
     const { gateway, current } = createStore();
     gateway.start();

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -31,7 +31,12 @@ import type {
   ApplicationGatewaySnapshot,
 } from "./context.ts";
 import { resolveControlUiAuthHeader } from "./control-ui-auth.ts";
-import { loadSettings, patchSettings, persistSessionToken } from "./settings.ts";
+import {
+  loadGatewaySessionSelection,
+  loadSettings,
+  patchSettings,
+  persistSessionToken,
+} from "./settings.ts";
 import { scheduleStaleChunkReload } from "./stale-chunk-reload.ts";
 import { readPresenceEntries, resolveSelfPresenceUser } from "./user-profile.ts";
 
@@ -337,10 +342,6 @@ export function createApplicationGateway(
       connectionRevision += 1;
       void clearStoredChatSnapshots();
     }
-    const hasRequestedSessionKey = requestedSessionKey !== undefined;
-    const nextSessionKey = hasRequestedSessionKey
-      ? requestedSessionKey.trim()
-      : snapshot.sessionKey;
     // Only a gateway URL that differs from the current connection counts as an
     // explicit selection. The login gate always resubmits its prefilled URL, so
     // treating any override as a selection would let an ephemeral approval
@@ -348,6 +349,13 @@ export function createApplicationGateway(
     const gatewayUrlChanged =
       connectionOverrides.gatewayUrl !== undefined &&
       connectionOverrides.gatewayUrl !== connection.gatewayUrl;
+    const targetSelection = gatewayUrlChanged
+      ? loadGatewaySessionSelection(nextConnection.gatewayUrl)
+      : null;
+    const hasRequestedSessionKey = requestedSessionKey !== undefined;
+    const nextSessionKey = hasRequestedSessionKey
+      ? requestedSessionKey.trim()
+      : (targetSelection?.sessionKey ?? snapshot.sessionKey);
     // A different Gateway has no established session to keep mounted on failure.
     // Accepted tradeoff: a restart pill armed for the previous gateway may
     // linger across a mid-restart gateway switch until the next hello or the
@@ -375,7 +383,8 @@ export function createApplicationGateway(
               sessionKey: nextSessionKey,
               lastActiveSessionKey: nextSessionKey,
             }
-          : {}),
+          : (targetSelection ?? {})),
+        ...(targetSelection ? { selectedAgentId: targetSelection.selectedAgentId } : {}),
       },
       persistConnectionSettings || gatewayUrlChanged,
     );

--- a/ui/src/app/settings.node.test.ts
+++ b/ui/src/app/settings.node.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../test-helpers/settings-node.ts";
 import { createStorageMock } from "../test-helpers/storage.ts";
 import {
+  loadGatewaySessionSelection,
   loadSettings,
   persistSessionToken,
   resolvePageGatewaySettings,
@@ -355,6 +356,7 @@ describe("loadSettings default gateway URL derivation", () => {
       token: "",
       sessionKey: "agent:test_old:main",
       lastActiveSessionKey: "agent:test_old:main",
+      selectedAgentId: " OpenClaw ",
       theme: "claw",
       themeMode: "system",
       chatShowThinking: true,
@@ -368,6 +370,12 @@ describe("loadSettings default gateway URL derivation", () => {
     expect(settings.gatewayUrl).toBe(gwUrl);
     expect(settings.sessionKey).toBe("agent:test_old:main");
     expect(settings.lastActiveSessionKey).toBe("agent:test_old:main");
+    expect(settings.selectedAgentId).toBe("openclaw");
+    expect(loadGatewaySessionSelection(gwUrl)).toEqual({
+      sessionKey: "agent:test_old:main",
+      lastActiveSessionKey: "agent:test_old:main",
+      selectedAgentId: "openclaw",
+    });
   });
 
   it("caps persisted session scopes to the most recent gateways", () => {

--- a/ui/src/app/settings.ts
+++ b/ui/src/app/settings.ts
@@ -1,5 +1,6 @@
 import { gatewayOriginScope } from "@openclaw/gateway-client/browser";
 import { safeParseJson } from "@openclaw/normalization-core";
+import { normalizeAgentId } from "@openclaw/normalization-core/agent-id";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeUniqueTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
@@ -49,11 +50,12 @@ function currentGatewaySelectionKeyForPage(pageUrl: string): string {
 type ScopedSessionSelection = {
   sessionKey: string;
   lastActiveSessionKey: string;
+  selectedAgentId?: string;
 };
 
 type PersistedUiSettings = Omit<
   UiSettings,
-  "token" | "sessionKey" | "lastActiveSessionKey" | "navCollapsed"
+  "token" | "sessionKey" | "lastActiveSessionKey" | "selectedAgentId" | "navCollapsed"
 > & {
   token?: never;
   sessionKey?: string;
@@ -199,6 +201,7 @@ export type UiSettings = {
   token: string;
   sessionKey: string;
   lastActiveSessionKey: string;
+  selectedAgentId?: string;
   theme: ThemeName;
   themeMode: ThemeMode;
   accent?: string;
@@ -354,10 +357,14 @@ function resolveScopedSessionSelection(
   const scoped = parsed.sessionsByGateway?.[scope];
   const scopedSessionKey = normalizeOptionalString(scoped?.sessionKey);
   const scopedLastActiveSessionKey = normalizeOptionalString(scoped?.lastActiveSessionKey);
+  const scopedSelectedAgentId = normalizeOptionalString(scoped?.selectedAgentId);
   if (scopedSessionKey && scopedLastActiveSessionKey) {
     return {
       sessionKey: scopedSessionKey,
       lastActiveSessionKey: scopedLastActiveSessionKey,
+      ...(scopedSelectedAgentId
+        ? { selectedAgentId: normalizeAgentId(scopedSelectedAgentId) }
+        : {}),
     };
   }
 
@@ -509,6 +516,7 @@ export function loadSettings(): UiSettings {
       token: loadSessionToken(gatewayUrl),
       sessionKey: scopedSessionSelection.sessionKey,
       lastActiveSessionKey: scopedSessionSelection.lastActiveSessionKey,
+      selectedAgentId: scopedSessionSelection.selectedAgentId,
       theme: theme === "custom" && !customTheme ? "claw" : theme,
       themeMode: mode,
       accent: normalizeAccentColor(parsed.accent),
@@ -657,6 +665,9 @@ function persistSettings(next: UiSettings, options: { selectGateway?: boolean } 
         {
           sessionKey: next.sessionKey,
           lastActiveSessionKey: next.lastActiveSessionKey,
+          ...(normalizeOptionalString(next.selectedAgentId)
+            ? { selectedAgentId: normalizeAgentId(next.selectedAgentId) }
+            : {}),
         },
       ],
     ].slice(-MAX_SCOPED_SESSION_ENTRIES),

--- a/ui/src/e2e/agent-selection-persistence.e2e.test.ts
+++ b/ui/src/e2e/agent-selection-persistence.e2e.test.ts
@@ -1,0 +1,198 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import type { BrowserContext, Page } from "playwright";
+import { expect, it } from "vitest";
+import {
+  controlUiBundledGatewayUrl,
+  controlUiBundledSettingsStorageKey,
+  installMockGateway,
+  type ControlUiMockGatewayScenario,
+  type MockGatewayControls,
+  waitForControlUiRoute,
+} from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI agent selection persistence",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not available at ${executablePath}`,
+});
+
+const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const proofDir = path.join(
+  process.cwd(),
+  ".artifacts",
+  "control-ui-e2e",
+  "agent-selection-persistence",
+);
+
+const agentsList = {
+  agents: [
+    { id: "dummy", identity: { name: "Dummy" }, kind: "agent", name: "Dummy" },
+    { id: "openclaw", identity: { name: "OpenClaw" }, kind: "agent", name: "OpenClaw" },
+  ],
+  defaultId: "dummy",
+  mainKey: "main",
+  scope: "global",
+};
+
+const scenario: ControlUiMockGatewayScenario = {
+  assistantAgentId: "dummy",
+  assistantName: "Dummy",
+  defaultAgentId: "dummy",
+  sessionKey: "global",
+  sessionScope: "global",
+  methodResponses: {
+    "agent.identity.get": {
+      cases: [
+        {
+          match: { agentId: "dummy" },
+          response: { agentId: "dummy", avatar: "", emoji: "D", name: "Dummy" },
+        },
+        {
+          match: { agentId: "openclaw" },
+          response: { agentId: "openclaw", avatar: "", emoji: "O", name: "OpenClaw" },
+        },
+      ],
+    },
+    "agents.list": agentsList,
+    "chat.startup": {
+      agentsList,
+      messages: [],
+      metadata: { models: [] },
+      sessionId: "control-ui-agent-selection-persistence",
+      thinkingLevel: null,
+    },
+    "sessions.list": {
+      count: 1,
+      defaults: {},
+      path: "",
+      sessions: [{ key: "global", kind: "global", updatedAt: 1 }],
+      ts: 1,
+    },
+  },
+};
+
+async function screenshot(page: Page, name: string) {
+  if (!captureUiProof) {
+    return;
+  }
+  await mkdir(proofDir, { recursive: true });
+  await page.waitForTimeout(600);
+  await page.screenshot({
+    animations: "disabled",
+    fullPage: true,
+    path: path.join(proofDir, name),
+  });
+}
+
+async function selectedAgentName(page: Page): Promise<string> {
+  const text =
+    (await page.locator("openclaw-app-sidebar .sidebar-agent-card__name").textContent()) ?? "";
+  return text.trim();
+}
+
+async function hasOpenClawStartup(gateway: MockGatewayControls): Promise<boolean> {
+  return (await gateway.getRequests("chat.startup")).some((request) => {
+    const params = request.params as
+      | { agentId?: unknown; limit?: unknown; sessionKey?: unknown }
+      | undefined;
+    return (
+      params?.agentId === "openclaw" &&
+      params.sessionKey === "agent:openclaw:main" &&
+      params.limit === 100
+    );
+  });
+}
+
+async function persistCanonicalGlobalSession(page: Page): Promise<void> {
+  await page.evaluate(
+    ({ gatewayUrl, settingsKey }) => {
+      const settings = JSON.parse(localStorage.getItem(settingsKey) ?? "{}") as {
+        sessionsByGateway?: Record<string, { lastActiveSessionKey?: string; sessionKey?: string }>;
+      };
+      const session = settings.sessionsByGateway?.[gatewayUrl];
+      if (!session) {
+        throw new Error("Bundled Gateway session selection was not persisted");
+      }
+      session.sessionKey = "global";
+      session.lastActiveSessionKey = "global";
+      localStorage.setItem(settingsKey, JSON.stringify(settings));
+    },
+    {
+      gatewayUrl: controlUiBundledGatewayUrl(suite.server.baseUrl),
+      settingsKey: controlUiBundledSettingsStorageKey(suite.server.baseUrl),
+    },
+  );
+}
+
+async function openPage(
+  context: BrowserContext,
+): Promise<{ gateway: MockGatewayControls; page: Page }> {
+  const page = await context.newPage();
+  const gateway = await installMockGateway(page, scenario);
+  await page.goto(`${suite.server.baseUrl}chat`);
+  await page.locator("openclaw-app-sidebar").waitFor();
+  return { gateway, page };
+}
+
+suite.define(() => {
+  it("restores the selected agent when a fresh shell reopens the canonical global session", async () => {
+    if (captureUiProof) {
+      await mkdir(proofDir, { recursive: true });
+    }
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1440 },
+      ...(captureUiProof
+        ? { recordVideo: { dir: proofDir, size: { height: 900, width: 1440 } } }
+        : {}),
+    });
+    try {
+      const first = await openPage(context);
+      const firstPage = first.page;
+      const sidebar = firstPage.locator("openclaw-app-sidebar");
+      await first.gateway.waitForRequest("chat.startup");
+      await expect.poll(() => selectedAgentName(firstPage)).toBe("Dummy");
+      await screenshot(firstPage, "01-default-agent.png");
+
+      await sidebar.getByRole("button", { name: /Switch agent/ }).click();
+      await sidebar
+        .locator("wa-dropdown.sidebar-agent-menu")
+        .getByRole("menuitemradio", { name: "OpenClaw" })
+        .click();
+      await waitForControlUiRoute(firstPage, { pathname: "/chat/openclaw", routeId: "chat" });
+      await expect.poll(() => selectedAgentName(firstPage)).toBe("OpenClaw");
+      await expect
+        .poll(() => firstPage.getByRole("heading", { name: "OpenClaw" }).isVisible())
+        .toBe(true);
+      await screenshot(firstPage, "02-selected-openclaw.png");
+
+      // The macOS host reopens the Gateway's canonical session key. Unlike the
+      // browser-only route alias, `global` cannot encode which agent owns it.
+      await persistCanonicalGlobalSession(firstPage);
+
+      await firstPage.close();
+      const reopened = await openPage(context);
+      const reopenedPage = reopened.page;
+      await reopened.gateway.waitForRequest("chat.startup");
+      await reopenedPage.waitForTimeout(1_500);
+      await screenshot(reopenedPage, "03-reopened-agent.png");
+
+      await waitForControlUiRoute(reopenedPage, {
+        pathname: "/chat/openclaw",
+        routeId: "chat",
+      });
+      await expect.poll(() => hasOpenClawStartup(reopened.gateway)).toBe(true);
+      await expect.poll(() => selectedAgentName(reopenedPage)).toBe("OpenClaw");
+      await expect
+        .poll(() => reopenedPage.getByRole("heading", { name: "OpenClaw" }).isVisible())
+        .toBe(true);
+      await screenshot(reopenedPage, "04-verified-reopened-agent.png");
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+});

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -358,6 +358,7 @@ export type ControlUiMockGatewayScenario = {
   /** Operator scopes returned by the mocked connect handshake. */
   operatorScopes?: string[];
   sessionKey?: string;
+  sessionScope?: "agent" | "global";
   /** Initial gateway-owned custom group catalog (sessions.groups.*), in order. */
   sessionGroups?: string[];
   /** Optional New Session defaults keyed by custom group name. */
@@ -936,6 +937,7 @@ function normalizeScenario(
     sessionInfo: scenario.sessionInfo ?? null,
     sessionArchiveFiltering: scenario.sessionArchiveFiltering ?? false,
     sessionKey,
+    sessionScope: scenario.sessionScope ?? "agent",
     sessionGroups: scenario.sessionGroups ?? [],
     sessionGroupDefaults: scenario.sessionGroupDefaults ?? {},
     terminalEnabled: scenario.terminalEnabled ?? false,
@@ -1764,7 +1766,7 @@ function installControlUiMockGateway(
               mainKey: "main",
               mainSessionKey: scenario.sessionKey,
               modelConfigured: Boolean(scenario.agentModel),
-              scope: "agent",
+              scope: scenario.sessionScope,
             },
           },
           type: "hello-ok",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who selected a non-default agent in the Control UI would return to the Gateway default agent after restarting the macOS app or reopening a fresh UI document.

## Why This Change Was Made

The selected agent now persists beside the existing session selection in the browser-local, per-Gateway settings tuple. Startup and runtime Gateway switches restore that tuple atomically, invalid saved agents fall back to the Gateway default, and standalone approval/focus documents remain non-persistent.

## User Impact

A user who selects an agent such as `openclaw` will return to that agent after reopening the app. Different Gateways retain independent selections, while an agent removed from a Gateway safely resets to its default.

## Evidence

- [Before/after red-green recordings](https://github.com/openclaw/openclaw/pull/131549#issuecomment-5455093764)
- Red on current `main`: the two-agent Control UI test selects `openclaw`, opens a fresh document on the canonical `global` session, and settles at `/chat/dummy` with Dummy in both the picker and chat identity.
- Green on this branch: the same flow settles at `/chat/openclaw`, issues the OpenClaw-owned startup request, and shows OpenClaw in both UI surfaces.
- Stale-agent red/green: bootstrap initially routed a persisted removed agent to `/chat/removed`; the focused regression now proves fallback to `/chat/dummy` from the authoritative Gateway roster.
- Focused tests: 137 assertions passed across selection, bootstrap/native handoff, scoped settings, and Gateway switching.
- Playwright E2E: 1 passed, exercising a fresh page in the same persistent browser context.
- Changed-file gates: format, dead-export scan, core/UI typechecks, lint, i18n, and policy checks passed.
- Production delta: +122 lines / -24 lines. The growth establishes the missing per-Gateway persistence and startup/switch ownership boundary, including authoritative stale-agent validation; no config, server state, or SQLite surface was added.
