### PR TITLE
refactor(process): share supervisor completion state

### DIFF
--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -316,22 +316,96 @@ describe("createChildAdapter", () => {
     expect(child.listenerCount("close")).toBe(0);
   });
 
-  it("fails owned worker authority closed on child process errors", async () => {
-    const { child, disconnectMock } = createStubChild(7866);
-    spawnWithFallbackMock.mockResolvedValue({ child, usedFallback: false });
-    const adapter = await createChildAdapter({
-      argv: ["node", "worker"],
-      ownedWorker: true,
+  it.each([
+    { first: "error", waitBefore: true },
+    { first: "error", waitBefore: false },
+    { first: "close", waitBefore: true },
+    { first: "close", waitBefore: false },
+  ] as const)(
+    "keeps the first owned worker $first outcome (waitBefore=$waitBefore)",
+    async ({ first, waitBefore }) => {
+      const { child, disconnectMock, emitClose } = createStubChild(7866);
+      spawnWithFallbackMock.mockResolvedValue({ child, usedFallback: false });
+      const adapter = await createChildAdapter({
+        argv: ["node", "worker"],
+        ownedWorker: true,
+      });
+      const error = Object.assign(new Error("kill EPERM"), { code: "EPERM" });
+      const pending = Promise.allSettled(waitBefore ? [adapter.wait(), adapter.wait()] : []);
+
+      try {
+        if (first === "error") {
+          child.emit("error", error);
+          emitClose(0);
+        } else {
+          emitClose(0);
+          child.emit("error", error);
+        }
+        // Cross a turn before late waits so an unhandled eager rejection fails the test.
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        const outcomes = [
+          ...(await pending),
+          ...(await Promise.allSettled([adapter.wait(), adapter.wait()])),
+        ];
+        let firstResult: Awaited<ReturnType<typeof adapter.wait>> | undefined;
+        for (const outcome of outcomes) {
+          if (first === "error") {
+            expect(outcome.status).toBe("rejected");
+            if (outcome.status === "rejected") {
+              expect(outcome.reason).toBe(error);
+            }
+          } else {
+            expect(outcome).toStrictEqual({
+              status: "fulfilled",
+              value: { code: 0, signal: null },
+            });
+            if (outcome.status === "fulfilled") {
+              firstResult ??= outcome.value;
+              expect(outcome.value).toBe(firstResult);
+            }
+          }
+        }
+      } finally {
+        adapter.dispose();
+      }
+
+      expect(disconnectMock).toHaveBeenCalledOnce();
+      expect(child.listenerCount("error")).toBe(0);
+    },
+  );
+
+  it("preserves startup failure when a worker error arrives during secret delivery", async () => {
+    const { child, killMock } = createStubChild();
+    const deliveryError = new Error("secret delivery failed");
+    const secretStream = new Writable({
+      write(_chunk, _encoding, callback) {
+        child.emit("error", new Error("worker IPC failed"));
+        setImmediate(() => callback(deliveryError));
+      },
     });
-    const wait = adapter.wait();
-    const error = Object.assign(new Error("kill EPERM"), { code: "EPERM" });
+    Object.defineProperty(child, "stdio", {
+      value: [child.stdin, child.stdout, child.stderr, secretStream, null],
+      configurable: true,
+    });
+    spawnWithFallbackMock.mockResolvedValue({ child, usedFallback: false });
+    const transient = Buffer.from("synthetic-secret");
 
-    child.emit("error", error);
+    await expect(
+      createChildAdapter({
+        argv: ["node", "worker"],
+        ownedWorker: true,
+        secretInput: { fd: 3, createData: () => transient },
+      }),
+    ).rejects.toBe(deliveryError);
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
 
-    await expect(wait).rejects.toBe(error);
-    adapter.dispose();
-    expect(disconnectMock).toHaveBeenCalledOnce();
-    expect(child.listenerCount("error")).toBe(0);
+    expect(killMock).toHaveBeenCalledWith("SIGKILL");
+    expect(transient.equals(Buffer.alloc(transient.length))).toBe(true);
+    child.removeAllListeners();
   });
 
   it("writes secret input to an extra descriptor and zeroes the transient buffer", async () => {

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -5,6 +5,7 @@ import {
   resolveWindowsExecutablePath,
   resolveWindowsSpawnProgramCandidate,
 } from "../../../plugin-sdk/windows-spawn.js";
+import { createDeferredCore } from "../../../shared/deferred.js";
 import { onDecodedOutput } from "../../decoded-output.js";
 import { signalProcessTree } from "../../kill-tree.js";
 import { prepareOomScoreAdjustedSpawn } from "../../linux-oom-score.js";
@@ -224,13 +225,10 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
   const onStderr: ChildAdapter["onStderr"] = (listener, onRaw) =>
     onDecodedOutput(child.stderr, listener, onRaw);
 
-  let waitResult: { code: number | null; signal: NodeJS.Signals | null } | null = null;
-  let waitError: unknown;
-  let resolveWait:
-    | ((value: { code: number | null; signal: NodeJS.Signals | null }) => void)
-    | null = null;
-  let rejectWait: ((reason?: unknown) => void) | null = null;
-  let waitPromise: Promise<{ code: number | null; signal: NodeJS.Signals | null }> | null = null;
+  const completion = createDeferredCore<{ code: number | null; signal: NodeJS.Signals | null }>();
+  // Worker errors can precede wait(), including while secret delivery is still pending.
+  void completion.promise.catch(() => {});
+  let waitSettled = false;
   let forceKillWaitFallbackTimer: NodeJS.Timeout | null = null;
   let forcedWindowsCloseTimer: NodeJS.Timeout | null = null;
   let hardKillRequested = false;
@@ -257,33 +255,23 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
   };
 
   const settleWait = (value: { code: number | null; signal: NodeJS.Signals | null }) => {
-    if (waitResult || waitError !== undefined) {
+    if (waitSettled) {
       return;
     }
+    waitSettled = true;
     clearForceKillWaitFallback();
     clearForcedWindowsCloseTimer();
-    waitResult = value;
-    if (resolveWait) {
-      const resolve = resolveWait;
-      resolveWait = null;
-      rejectWait = null;
-      resolve(value);
-    }
+    completion.resolve(value);
   };
 
-  const rejectPendingWait = (error: unknown) => {
-    if (waitResult || waitError !== undefined) {
+  const rejectPendingWait = (error: Error) => {
+    if (waitSettled) {
       return;
     }
+    waitSettled = true;
     clearForceKillWaitFallback();
     clearForcedWindowsCloseTimer();
-    waitError = error;
-    if (rejectWait) {
-      const reject = rejectWait;
-      resolveWait = null;
-      rejectWait = null;
-      reject(error);
-    }
+    completion.reject(error);
   };
 
   const scheduleForceKillWaitFallback = (signal: NodeJS.Signals) => {
@@ -385,23 +373,7 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
     }
   }
 
-  const wait = async () => {
-    if (waitResult) {
-      return waitResult;
-    }
-    if (waitError !== undefined) {
-      throw toErrorObject(waitError, "Non-Error thrown");
-    }
-    if (!waitPromise) {
-      waitPromise = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
-        (resolve, reject) => {
-          resolveWait = resolve;
-          rejectWait = reject;
-        },
-      );
-    }
-    return waitPromise;
-  };
+  const wait = async () => await completion.promise;
 
   // The actual detachment of the spawned child can differ from `useDetached`:
   // when the detached spawn fails, `spawnWithFallback` retries with the

--- a/src/process/supervisor/adapters/pty.test.ts
+++ b/src/process/supervisor/adapters/pty.test.ts
@@ -246,21 +246,31 @@ describe("createPtyAdapter", () => {
     });
   });
 
-  it("resolves wait when exit fires before wait is called", async () => {
-    const stub = createStubPty();
-    spawnMock.mockReturnValue(stub);
+  it.each([true, false])(
+    "preserves the first PTY exit across waits (waitBefore=%s)",
+    async (waitBefore) => {
+      const stub = createStubPty();
+      spawnMock.mockReturnValue(stub);
 
-    const adapter = await createPtyAdapter({
-      shell: "bash",
-      args: ["-lc", "exit 3"],
-    });
+      const adapter = await createPtyAdapter({
+        shell: "bash",
+        args: ["-lc", "exit 3"],
+      });
 
-    expect(stub.onExit).toHaveBeenCalledTimes(1);
-    stub.emitExit({ exitCode: 3, signal: 0 });
-    await expect(adapter.wait()).resolves.toEqual({ code: 3, signal: null });
-    expect(adapter.stdin?.destroyed).toBe(true);
-    expect(adapter.stdin?.writable).toBe(false);
-  });
+      expect(stub.onExit).toHaveBeenCalledTimes(1);
+      const pending = waitBefore ? [adapter.wait(), adapter.wait()] : [];
+      stub.emitExit({ exitCode: 3, signal: 0 });
+      const result = await adapter.wait();
+      expect(result).toStrictEqual({ code: 3, signal: null });
+      expect(adapter.stdin?.destroyed).toBe(true);
+      expect(adapter.stdin?.writable).toBe(false);
+      stub.emitExit({ exitCode: 9, signal: 15 });
+      adapter.dispose();
+      for (const wait of [...pending, adapter.wait()]) {
+        await expect(wait).resolves.toBe(result);
+      }
+    },
+  );
 
   it("reports stdin as non-writable after EOF or dispose", async () => {
     const stub = createStubPty();
@@ -292,9 +302,13 @@ describe("createPtyAdapter", () => {
       args: ["-lc", "echo ok"],
     });
     adapter.onStdout(() => undefined);
+    const pending = adapter.wait();
 
     adapter.dispose();
 
+    const result = await pending;
+    expect(result).toStrictEqual({ code: null, signal: null });
+    await expect(adapter.wait()).resolves.toBe(result);
     expect(stub.disposeData).toHaveBeenCalledTimes(1);
     expect(stub.disposeExit).toHaveBeenCalledTimes(1);
   });

--- a/src/process/supervisor/adapters/pty.ts
+++ b/src/process/supervisor/adapters/pty.ts
@@ -1,5 +1,6 @@
 // PTY adapter wraps pseudo-terminal processes for the process supervisor.
 import type { IDisposable } from "@lydell/node-pty";
+import { createDeferredCore } from "../../../shared/deferred.js";
 import { signalPtySessionTree } from "../../kill-tree.js";
 import { prepareOomScoreAdjustedSpawn } from "../../linux-oom-score.js";
 import {
@@ -56,12 +57,11 @@ export async function createPtyAdapter(params: {
 
   let dataListener: IDisposable | null = null;
   let exitListener: IDisposable | null = null;
-  let waitResult: { code: number | null; signal: NodeJS.Signals | number | null } | null = null;
-  let resolveWait:
-    | ((value: { code: number | null; signal: NodeJS.Signals | number | null }) => void)
-    | null = null;
-  let waitPromise: Promise<{ code: number | null; signal: NodeJS.Signals | number | null }> | null =
-    null;
+  const completion = createDeferredCore<{
+    code: number | null;
+    signal: NodeJS.Signals | number | null;
+  }>();
+  let waitSettled = false;
   let forceKillWaitFallbackTimer: NodeJS.Timeout | null = null;
   let stdinDestroyed = false;
   let stdinEnded = false;
@@ -75,18 +75,14 @@ export async function createPtyAdapter(params: {
   };
 
   const settleWait = (value: { code: number | null; signal: NodeJS.Signals | number | null }) => {
-    if (waitResult) {
+    if (waitSettled) {
       return;
     }
+    waitSettled = true;
     clearForceKillWaitFallback();
     stdinDestroyed = true;
     stdinEnded = true;
-    waitResult = value;
-    if (resolveWait) {
-      const resolve = resolveWait;
-      resolveWait = null;
-      resolve(value);
-    }
+    completion.resolve(value);
   };
 
   const scheduleForceKillWaitFallback = (signal: NodeJS.Signals) => {
@@ -150,24 +146,7 @@ export async function createPtyAdapter(params: {
     // PTY gives a unified output stream.
   };
 
-  const wait = async () => {
-    if (waitResult) {
-      return waitResult;
-    }
-    if (!waitPromise) {
-      waitPromise = new Promise<{ code: number | null; signal: NodeJS.Signals | number | null }>(
-        (resolve) => {
-          resolveWait = resolve;
-          if (waitResult) {
-            const settled = waitResult;
-            resolveWait = null;
-            resolve(settled);
-          }
-        },
-      );
-    }
-    return waitPromise;
-  };
+  const wait = async () => await completion.promise;
 
   const kill = (signal: NodeJS.Signals = "SIGKILL") => {
     try {


### PR DESCRIPTION
## What Problem This Solves

The process supervisor's child-process and PTY adapters each maintained a second, handwritten completion state machine around terminal events and `wait()` calls. The duplicate implementations had to coordinate results, errors, promises, and late/repeated waiters independently, making first-terminal-outcome and cleanup behavior harder to keep aligned.

## Why This Change Was Made

Both adapters now use the existing shared deferred primitive as their single completion owner. A small settled guard preserves first-outcome-wins behavior, child errors are observed even before a caller waits, and every early, late, or repeated `wait()` consumes the same terminal promise. Adapter-specific force-kill timers, PTY stdin lifecycle, child disconnect, secret-buffer cleanup, and startup failure precedence remain local to their existing owners.

## User Impact

No intended user-visible behavior, public API, configuration, protocol, dependency, or platform policy changes. Child and PTY supervision retain their current exit, error, force-kill, disposal, and secret-delivery behavior through one shared completion mechanism.

## Evidence

- Focused child/PTY owner and sibling proof: 156 tests passed, including real service-lifecycle and anchored-shell coverage.
- Separate source-aware native probe: a real child exited with code 23 and a real PTY exited with code 7; early, late, and repeated waits returned the same terminal result identity.
- Complete exact four-path changed-file gate: exit 0.
- Fresh isolated P0 Codex review: no findings, 0.98 confidence.
- Exact committed-head full build: exit 0 in 29m17.4s, with the build stamp, runtime post-build stamp, and build-info commit all matching `dcdffbe582a4f83989e6fd41c5024ce36d45d041`.
- Production LOC: net -49. Tests: net +88.
