### PR TITLE
fix(openshell): preserve overlapping mirror workspaces during exec

### DIFF
--- a/extensions/openshell/src/backend.e2e.test.ts
+++ b/extensions/openshell/src/backend.e2e.test.ts
@@ -422,6 +422,8 @@ describe("openshell sandbox backend e2e", () => {
       const previousXdgCacheHome = process.env.XDG_CACHE_HOME;
       const workspaceDir = path.join(rootDir, "workspace");
       const mirrorWorkspaceDir = path.join(rootDir, "mirror");
+      const overlapWorkspaceDir = path.join(rootDir, "overlap-primary");
+      const overlapAgentWorkspaceDir = path.join(rootDir, "overlap-agent");
       const dockerfileDir = path.join(rootDir, "custom-image");
       const dockerfilePath = path.join(dockerfileDir, "Dockerfile");
       const denyPolicyPath = path.join(rootDir, "deny-policy.yaml");
@@ -492,6 +494,24 @@ describe("openshell sandbox backend e2e", () => {
         agentWorkspaceDir: mirrorWorkspaceDir,
         cfg: sandboxCfg,
       });
+      const overlapBackend = await createOpenShellSandboxBackendFactory({
+        pluginConfig: resolveOpenShellPluginConfig({
+          command: OPENCLAW_OPENSHELL_COMMAND,
+          gateway: gatewayName,
+          workspace: openShellWorkspace,
+          from: dockerfilePath,
+          autoProviders: false,
+          policy: denyPolicyPath,
+          remoteWorkspaceDir: "/sandbox/agent/project",
+          remoteAgentWorkspaceDir: "/sandbox/agent",
+        }),
+      })({
+        sessionKey: `session:openshell-e2e-overlap:${scopeSuffix}`,
+        scopeKey: `session:openshell-e2e-overlap:${scopeSuffix}`,
+        workspaceDir: overlapWorkspaceDir,
+        agentWorkspaceDir: overlapAgentWorkspaceDir,
+        cfg: { ...sandboxCfg, workspaceAccess: "ro" },
+      });
       const allowBackend = await createOpenShellSandboxBackendFactory({
         pluginConfig: { ...pluginConfig, policy: allowPolicyPath },
       })({
@@ -512,6 +532,8 @@ describe("openshell sandbox backend e2e", () => {
         }
         await fs.mkdir(workspaceDir, { recursive: true });
         await fs.mkdir(mirrorWorkspaceDir, { recursive: true });
+        await fs.mkdir(overlapWorkspaceDir, { recursive: true });
+        await fs.mkdir(overlapAgentWorkspaceDir, { recursive: true });
         await fs.mkdir(dockerfileDir, { recursive: true });
         const isolatedConfigHome = env.XDG_CONFIG_HOME;
         if (!isolatedConfigHome) {
@@ -535,6 +557,14 @@ describe("openshell sandbox backend e2e", () => {
           path.join(mirrorWorkspaceDir, "mirror-seed.txt"),
           "mirror-from-local\n",
           "utf8",
+        );
+        await fs.writeFile(
+          path.join(overlapWorkspaceDir, "primary-only.txt"),
+          "primary-preserved\n",
+        );
+        await fs.writeFile(
+          path.join(overlapAgentWorkspaceDir, "agent-only.txt"),
+          "agent-preserved\n",
         );
         for (const protectedDirectory of [".git", "hooks", "git-hooks"]) {
           const protectedPath = path.join(mirrorWorkspaceDir, protectedDirectory);
@@ -685,6 +715,22 @@ describe("openshell sandbox backend e2e", () => {
         expect(mirrorExecResult.stdout).toContain("mirror-from-local");
         expect((await fs.lstat(mirrorFifoPath)).isFIFO()).toBe(true);
         expect((await fs.lstat(mirrorSocketPath)).isSocket()).toBe(true);
+        if (stressMode === "mirror") {
+          await expect(
+            runBackendExec({
+              backend: overlapBackend,
+              command:
+                "cat primary-only.txt ../agent-only.txt && printf 'agent-remote\\n' > ../agent-only.txt",
+              timeoutMs: 2 * 60_000,
+            }),
+          ).resolves.toMatchObject({
+            code: 0,
+            stdout: "primary-preserved\nagent-preserved\n",
+          });
+          await expect(
+            fs.readFile(path.join(overlapAgentWorkspaceDir, "agent-only.txt"), "utf8"),
+          ).resolves.toBe("agent-preserved\n");
+        }
         for (const relativePath of hostLinks) {
           await expect(fs.readlink(path.join(mirrorWorkspaceDir, relativePath))).resolves.toBe(
             hostLinkTarget,
@@ -876,6 +922,7 @@ describe("openshell sandbox backend e2e", () => {
         for (const sandboxName of [
           backend.runtimeId,
           mirrorBackend.runtimeId,
+          overlapBackend.runtimeId,
           allowBackend.runtimeId,
         ]) {
           await runCommand({

--- a/extensions/openshell/src/backend.exec-workdir.test.ts
+++ b/extensions/openshell/src/backend.exec-workdir.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 // Openshell tests cover backend-owned exec workdir validation behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -338,12 +339,14 @@ describe("openshell backend exec workdir validation", () => {
       name: "missing materialized child",
       target: "/sandbox/.openclaw/sandbox-skills/skills/missing",
       expected: null,
+      workspaceFallback: true,
     },
     {
       name: "symlinked materialized source",
       target: "/sandbox/.openclaw/sandbox-skills/nested",
       expected: null,
       sourceLink: true,
+      workspaceFallback: true,
     },
   ])("validates the uploaded host directory for $name", async (scenario) => {
     const workspaceDir = await createWorkspace();
@@ -358,6 +361,11 @@ describe("openshell backend exec workdir validation", () => {
     }
     await fs.symlink(workspaceDir, path.join(workspaceDir, "link"), "junction");
     await fs.mkdir(path.join(skillsWorkspaceDir, "skills", "demo"), { recursive: true });
+    if (scenario.workspaceFallback) {
+      await fs.mkdir(path.join(workspaceDir, path.posix.relative("/sandbox", scenario.target)), {
+        recursive: true,
+      });
+    }
     if (scenario.sourceLink) {
       await fs.rm(skillsWorkspaceDir, { recursive: true });
       await fs.symlink(workspaceDir, skillsWorkspaceDir, "junction");
@@ -380,7 +388,7 @@ describe("openshell backend exec workdir validation", () => {
       workspace: "/sandbox/primary",
       agent: "/sandbox",
       target: "/sandbox/primary/host-only",
-      exists: false,
+      exists: true,
     },
     {
       workspace: "/sandbox",
@@ -404,6 +412,248 @@ describe("openshell backend exec workdir validation", () => {
       scenario.exists ? scenario.target : null,
     );
   });
+
+  it.runIf(process.platform !== "win32")(
+    "rejects a workdir omitted from the authoritative overlapping root",
+    async () => {
+      const workspaceDir = await createWorkspace();
+      const agentWorkspaceDir = await createWorkspace("agent");
+      await fs.mkdir(path.join(workspaceDir, "preserved"));
+      execFileSync("mkfifo", [path.join(agentWorkspaceDir, "preserved")]);
+      const backend = await createOpenShellBackendFixture({
+        workspaceDir,
+        agentWorkspaceDir,
+        scopeKey: "agent:overlap-special-file",
+        remoteWorkspaceDir: "/sandbox",
+        remoteAgentWorkspaceDir: "/sandbox",
+      });
+
+      await expect(backend.validateWorkdir?.("/sandbox/preserved")).resolves.toBeNull();
+    },
+  );
+
+  it.each([
+    {
+      name: "a later nested directory replaces an earlier file",
+      workspace: "/sandbox",
+      agent: "/sandbox/collision",
+      setup: async (workspaceDir: string) => {
+        await fs.writeFile(path.join(workspaceDir, "collision"), "file");
+      },
+      uploads: [
+        ["collision", "/sandbox/"],
+        ["primary-only", "/sandbox/"],
+        ["agent-only", "/sandbox/collision/"],
+      ],
+    },
+    {
+      name: "a deeper nested root replaces a blocking ancestor file",
+      workspace: "/sandbox",
+      agent: "/sandbox/collision/agent",
+      setup: async (workspaceDir: string) => {
+        await fs.writeFile(path.join(workspaceDir, "collision"), "file");
+      },
+      uploads: [
+        ["collision", "/sandbox/"],
+        ["primary-only", "/sandbox/"],
+        ["agent-only", "/sandbox/collision/agent/"],
+      ],
+    },
+    {
+      name: "a later file replaces an earlier nested directory",
+      workspace: "/sandbox/collision",
+      agent: "/sandbox",
+      setup: async (_workspaceDir: string, agentWorkspaceDir: string) => {
+        await fs.writeFile(path.join(agentWorkspaceDir, "collision"), "file");
+      },
+      uploads: [
+        ["agent-only", "/sandbox/"],
+        ["collision", "/sandbox/"],
+        ["primary-only", "/sandbox/collision/"],
+      ],
+    },
+  ])("composes overlapping roots when $name", async (scenario) => {
+    const workspaceDir = await createWorkspace();
+    const agentWorkspaceDir = await createWorkspace("agent");
+    await fs.writeFile(path.join(workspaceDir, "primary-only"), "primary");
+    await fs.writeFile(path.join(agentWorkspaceDir, "agent-only"), "agent");
+    await scenario.setup(workspaceDir, agentWorkspaceDir);
+    const backend = await createOpenShellBackendFixture({
+      workspaceDir,
+      agentWorkspaceDir,
+      scopeKey: `agent:overlap-cross-type:${scenario.name}`,
+      remoteWorkspaceDir: scenario.workspace,
+      remoteAgentWorkspaceDir: scenario.agent,
+    });
+
+    const exec = await backend.buildExecSpec({ command: "true", env: {}, usePty: false });
+    try {
+      const uploads = cliMocks.runOpenShellCli.mock.calls.flatMap(([params]) =>
+        params.args[0] === "sandbox" && params.args[1] === "upload"
+          ? [[path.basename(params.args.at(-2) ?? ""), params.args.at(-1)]]
+          : [],
+      );
+      expect(uploads).toEqual(scenario.uploads);
+    } finally {
+      await finalize(backend, exec.finalizeToken);
+    }
+  });
+
+  it.each([
+    {
+      workspace: "/sandbox/primary",
+      agent: "/sandbox",
+      uploads: [
+        ["agent-only", "/sandbox/"],
+        ["host-only", "/sandbox/primary/"],
+      ],
+    },
+    {
+      workspace: "/sandbox",
+      agent: "/sandbox/nested/agent",
+      uploads: [
+        ["host-only", "/sandbox/"],
+        ["agent-only", "/sandbox/nested/agent/"],
+      ],
+    },
+    {
+      workspace: "/sandbox",
+      agent: "/sandbox",
+      uploads: [
+        ["host-only", "/sandbox/"],
+        ["agent-only", "/sandbox/"],
+      ],
+    },
+    {
+      workspace: "/sandbox",
+      agent: "/sandbox/hooks",
+      uploads: [
+        ["host-only", "/sandbox/"],
+        ["agent-only", "/sandbox/hooks/"],
+      ],
+    },
+  ])(
+    "clears each overlapping root immediately before upload: $workspace -> $agent",
+    async (scenario) => {
+      const workspaceDir = await createWorkspace();
+      const agentWorkspaceDir = await createWorkspace("agent");
+      await fs.mkdir(path.join(workspaceDir, "host-only"));
+      await fs.mkdir(path.join(agentWorkspaceDir, "agent-only"));
+      const backend = await createOpenShellBackendFixture({
+        workspaceDir,
+        agentWorkspaceDir,
+        scopeKey: `agent:overlap-publication:${scenario.workspace}:${scenario.agent}`,
+        remoteWorkspaceDir: scenario.workspace,
+        remoteAgentWorkspaceDir: scenario.agent,
+      });
+
+      const exec = await backend.buildExecSpec({ command: "true", env: {}, usePty: false });
+      try {
+        const clearCallOrders = sdkMocks.runSshSandboxCommand.mock.calls.flatMap(
+          ([params], index) =>
+            String(params.remoteCommand).includes("find")
+              ? [sdkMocks.runSshSandboxCommand.mock.invocationCallOrder[index]!]
+              : [],
+        );
+        const uploadCalls = cliMocks.runOpenShellCli.mock.calls.flatMap(([params], index) =>
+          params.args[0] === "sandbox" && params.args[1] === "upload"
+            ? [{ params, order: cliMocks.runOpenShellCli.mock.invocationCallOrder[index]! }]
+            : [],
+        );
+        expect(clearCallOrders).toHaveLength(2);
+        expect(
+          [
+            ...clearCallOrders.map((order) => ({ label: "clear", order })),
+            ...uploadCalls.map(({ order }) => ({ label: "upload", order })),
+          ]
+            .toSorted((a, b) => a.order - b.order)
+            .map(({ label }) => label),
+        ).toEqual(["clear", "upload", "clear", "upload"]);
+        expect(
+          uploadCalls.map(({ params }) => [
+            path.basename(params.args.at(-2) ?? ""),
+            params.args.at(-1),
+          ]),
+        ).toEqual(scenario.uploads);
+      } finally {
+        await finalize(backend, exec.finalizeToken);
+      }
+    },
+  );
+
+  it.each([
+    {
+      name: "read-only containing agent root",
+      workspaceAccess: "ro" as const,
+      remoteWorkspaceDir: "/sandbox/agent/project",
+      remoteAgentWorkspaceDir: "/sandbox/agent",
+    },
+    {
+      name: "writable containing agent root",
+      workspaceAccess: "rw" as const,
+      remoteWorkspaceDir: "/sandbox/agent/project",
+      remoteAgentWorkspaceDir: "/sandbox/agent",
+    },
+    {
+      name: "equal read-only roots",
+      workspaceAccess: "ro" as const,
+      remoteWorkspaceDir: "/sandbox/shared",
+      remoteAgentWorkspaceDir: "/sandbox/shared",
+    },
+  ])(
+    "downloads the primary root without reconciling the $name",
+    async ({ name, workspaceAccess, remoteWorkspaceDir, remoteAgentWorkspaceDir }) => {
+      const workspaceDir = await createWorkspace();
+      const agentWorkspaceDir = await createWorkspace("agent");
+      await fs.writeFile(path.join(workspaceDir, "primary-only"), "local-primary");
+      await fs.writeFile(path.join(agentWorkspaceDir, "agent-only"), "local-agent");
+      await fs.mkdir(path.join(agentWorkspaceDir, "project"));
+      await fs.writeFile(
+        path.join(agentWorkspaceDir, "project", "agent-shadow.txt"),
+        "preserved-shadow",
+      );
+      cliMocks.runOpenShellCli.mockImplementation(async ({ args }) => {
+        if (args[1] === "download") {
+          const remote = args.at(-2);
+          const target = args.at(-1);
+          if (!target) {
+            throw new Error("Expected download target");
+          }
+          await fs.writeFile(
+            path.join(target, remote === remoteWorkspaceDir ? "primary-only" : "agent-only"),
+            remote === remoteWorkspaceDir ? "remote-primary" : "remote-agent",
+          );
+        }
+        return { code: 0, stdout: "", stderr: "" };
+      });
+      const backend = await createOpenShellBackendFixture({
+        workspaceDir,
+        agentWorkspaceDir,
+        scopeKey: `agent:overlap-download:${name}`,
+        workspaceAccess,
+        remoteWorkspaceDir,
+        remoteAgentWorkspaceDir,
+      });
+
+      const exec = await backend.buildExecSpec({ command: "true", env: {}, usePty: false });
+      await finalize(backend, exec.finalizeToken);
+
+      await expect(fs.readFile(path.join(agentWorkspaceDir, "agent-only"), "utf8")).resolves.toBe(
+        "local-agent",
+      );
+      await expect(fs.readFile(path.join(workspaceDir, "primary-only"), "utf8")).resolves.toBe(
+        "remote-primary",
+      );
+      await expect(
+        fs.readFile(path.join(agentWorkspaceDir, "project", "agent-shadow.txt"), "utf8"),
+      ).resolves.toBe("preserved-shadow");
+      expect(
+        cliMocks.runOpenShellCli.mock.calls.flatMap(([params]) =>
+          params.args[1] === "download" ? [params.args.at(-2)] : [],
+        ),
+      ).toEqual([remoteWorkspaceDir]);
+    },
+  );
 
   it("rejects an aborted file write after waiting for mirror publication", async () => {
     const workspaceDir = await createWorkspace();

--- a/extensions/openshell/src/backend.ts
+++ b/extensions/openshell/src/backend.ts
@@ -41,6 +41,12 @@ import {
   replaceDirectoryContents,
   stageDirectoryContents,
 } from "./mirror.js";
+import {
+  isOpenShellRemotePathInside,
+  orderOpenShellWorkspaceRoots,
+  resolveOpenShellWorkspaceRoot,
+  type OpenShellWorkspaceRoot,
+} from "./workspace-roots.js";
 
 type CreateOpenShellSandboxBackendFactoryParams = {
   pluginConfig: ResolvedOpenShellPluginConfig;
@@ -184,6 +190,7 @@ const ENSURE_OPEN_SHELL_REMOTE_REAL_DIRECTORY_SCRIPT = [
   "set -e",
   'target="$1"',
   'root="${2:-$1}"',
+  'replace_blocking="${3:-0}"',
   'case "$target" in /*) ;; *) echo "remote directory must be absolute: $target" >&2; exit 1 ;; esac',
   'case "$root" in /*) ;; *) echo "remote root must be absolute: $root" >&2; exit 1 ;; esac',
   'target="${target%/}"',
@@ -211,9 +218,15 @@ const ENSURE_OPEN_SHELL_REMOTE_REAL_DIRECTORY_SCRIPT = [
   '  if [ "$part" = "$relative" ]; then relative=""; else relative="${relative#*/}"; fi',
   '  [ -n "$part" ] || continue',
   '  if [ "$current" = "/" ]; then next="/$part"; else next="$current/$part"; fi',
-  '  if [ -L "$next" ]; then echo "unsafe remote directory symlink: $next" >&2; exit 1; fi',
+  '  if [ -L "$next" ]; then',
+  '    if [ "$replace_blocking" != "1" ]; then echo "unsafe remote directory symlink: $next" >&2; exit 1; fi',
+  '    rm -rf -- "$next"',
+  '  elif [ -e "$next" ] && [ ! -d "$next" ]; then',
+  '    if [ "$replace_blocking" != "1" ]; then echo "unsafe remote directory component: $next" >&2; exit 1; fi',
+  '    rm -rf -- "$next"',
+  "  fi",
   '  if [ -e "$next" ]; then',
-  '    if [ ! -d "$next" ]; then echo "unsafe remote directory component: $next" >&2; exit 1; fi',
+  '    [ -d "$next" ] || { echo "unsafe remote directory component: $next" >&2; exit 1; }',
   "  else",
   '    mkdir -- "$next"',
   "  fi",
@@ -513,12 +526,22 @@ class OpenShellSandboxBackendImpl {
   private resolveWorkdirValidationRoot(workdir: string): string {
     try {
       const normalized = normalizeRemotePath(workdir);
-      const roots = [
-        normalizeRemotePath(this.params.remoteAgentWorkspaceDir),
-        normalizeRemotePath(this.params.remoteWorkspaceDir),
-      ].toSorted((a, b) => b.length - a.length);
       return (
-        roots.find((root) => isRemotePathInside(root, normalized)) ?? this.params.remoteWorkspaceDir
+        resolveOpenShellWorkspaceRoot(
+          [
+            {
+              remote: normalizeRemotePath(this.params.remoteWorkspaceDir),
+              owner: "workspace",
+              value: undefined,
+            },
+            {
+              remote: normalizeRemotePath(this.params.remoteAgentWorkspaceDir),
+              owner: "agent",
+              value: undefined,
+            },
+          ],
+          normalized,
+        )?.remote ?? this.params.remoteWorkspaceDir
       );
     } catch {
       return this.params.remoteWorkspaceDir;
@@ -528,7 +551,7 @@ class OpenShellSandboxBackendImpl {
   private async validateMirrorWorkdir(workdir: string): Promise<string | null> {
     const normalized = normalizeRemotePath(workdir);
     const roots = this.workspaceUploadRoots();
-    if (!roots.some((root) => isRemotePathInside(root.remote, normalized))) {
+    if (!roots.some((root) => isOpenShellRemotePathInside(root.remote, normalized))) {
       return null;
     }
     const { cfg, skillsWorkspaceDir } = this.params.createParams;
@@ -536,15 +559,19 @@ class OpenShellSandboxBackendImpl {
       roots.push({
         remote: resolveRemoteMaterializedSkillsWorkspaceDir(this.params.remoteWorkspaceDir),
         local: skillsWorkspaceDir,
+        owner: "workspace",
       });
     }
-    // Later uploads replace overlapping roots. Their ancestors are created by mkdirp,
-    // while descendants must be real directories in the symlink-free upload source.
+    // Each configured root replaces its subtree. More-specific roots publish
+    // later; equal roots retain the historical agent-root precedence.
     let createdAncestor = false;
     for (const root of roots.toReversed()) {
-      if (!isRemotePathInside(root.remote, normalized)) {
-        createdAncestor ||= isRemotePathInside(normalized, root.remote);
+      if (!isOpenShellRemotePathInside(root.remote, normalized)) {
+        createdAncestor ||= isOpenShellRemotePathInside(normalized, root.remote);
         continue;
+      }
+      if (createdAncestor) {
+        return normalized;
       }
       const relative = path.posix.relative(root.remote, normalized);
       if (!relative) {
@@ -556,19 +583,19 @@ class OpenShellSandboxBackendImpl {
           (excluded) => excluded === normalizeLowercaseStringOrEmpty(parts[0]),
         )
       ) {
-        return createdAncestor ? normalized : null;
+        return null;
       }
       let local = root.local;
       for (const part of root.local === skillsWorkspaceDir ? ["", ...parts] : parts) {
         local = path.join(local, part);
         const stats = await fs.lstat(local).catch(() => null);
         if (!stats?.isDirectory()) {
-          return createdAncestor && (!stats || stats.isSymbolicLink()) ? normalized : null;
+          return null;
         }
       }
       return normalized;
     }
-    return null;
+    return createdAncestor ? normalized : null;
   }
 
   async finalizeExec(token?: PendingExec): Promise<void> {
@@ -754,14 +781,21 @@ class OpenShellSandboxBackendImpl {
   private resolveRemoteTarget(remotePath: string): { root: string; relativePath: string } {
     const normalized = normalizeRemotePath(remotePath);
     const roots = [
-      normalizeRemotePath(this.params.remoteWorkspaceDir),
-      normalizeRemotePath(this.params.remoteAgentWorkspaceDir),
-    ].toSorted((a, b) => b.length - a.length);
-    for (const root of roots) {
-      if (isRemotePathInside(root, normalized)) {
-        const relativePath = path.posix.relative(root, normalized);
-        return { root, relativePath: relativePath === "." ? "" : relativePath };
-      }
+      {
+        remote: normalizeRemotePath(this.params.remoteWorkspaceDir),
+        owner: "workspace" as const,
+        value: undefined,
+      },
+      {
+        remote: normalizeRemotePath(this.params.remoteAgentWorkspaceDir),
+        owner: "agent" as const,
+        value: undefined,
+      },
+    ];
+    const root = resolveOpenShellWorkspaceRoot(roots, normalized)?.remote;
+    if (root) {
+      const relativePath = path.posix.relative(root, normalized);
+      return { root, relativePath: relativePath === "." ? "" : relativePath };
     }
     throw new Error(`Remote path escapes OpenShell managed roots: ${remotePath}`);
   }
@@ -950,23 +984,42 @@ class OpenShellSandboxBackendImpl {
     );
   }
 
-  private workspaceUploadRoots(): Array<{ remote: string; local: string }> {
+  private workspaceUploadRoots(): Array<{
+    remote: string;
+    local: string;
+    owner: "workspace" | "agent";
+  }> {
     const { createParams, remoteWorkspaceDir, remoteAgentWorkspaceDir } = this.params;
-    const roots = [{ remote: remoteWorkspaceDir, local: createParams.workspaceDir }];
+    const roots: OpenShellWorkspaceRoot<string>[] = [
+      { remote: remoteWorkspaceDir, owner: "workspace", value: createParams.workspaceDir },
+    ];
     if (
       createParams.cfg.workspaceAccess !== "none" &&
       path.resolve(createParams.agentWorkspaceDir) !== path.resolve(createParams.workspaceDir)
     ) {
-      roots.push({ remote: remoteAgentWorkspaceDir, local: createParams.agentWorkspaceDir });
+      roots.push({
+        remote: remoteAgentWorkspaceDir,
+        owner: "agent",
+        value: createParams.agentWorkspaceDir,
+      });
     }
-    return roots;
+    return orderOpenShellWorkspaceRoots(roots).map(({ remote, owner, value: local }) => ({
+      remote,
+      local,
+      owner,
+    }));
   }
 
   private async syncWorkspaceToRemote(): Promise<void> {
-    for (const root of this.workspaceUploadRoots()) {
+    const roots = this.workspaceUploadRoots();
+    for (const [index, root] of roots.entries()) {
+      const containingRoot = roots
+        .slice(0, index)
+        .toReversed()
+        .find((candidate) => isOpenShellRemotePathInside(candidate.remote, root.remote));
       await this.runRemoteShellScriptInternal({
-        script: 'mkdir -p -- "$1" && find "$1" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +',
-        args: [root.remote],
+        script: `${ENSURE_OPEN_SHELL_REMOTE_REAL_DIRECTORY_SCRIPT}\nfind "$1" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +`,
+        args: [root.remote, containingRoot?.remote ?? root.remote, containingRoot ? "1" : "0"],
       });
       await this.uploadPathToRemote(root.local, root.remote);
     }
@@ -998,44 +1051,85 @@ class OpenShellSandboxBackendImpl {
   }
 
   private async syncWorkspaceFromRemote(): Promise<void> {
-    await withTempWorkspace(
-      { rootDir: resolveOpenShellTmpRoot(), prefix: "openclaw-openshell-sync-" },
-      async ({ dir: tmpDir }) => {
-        const result = await runOpenShellCli({
-          context: this.params.execContext,
-          args: [
-            "sandbox",
-            "download",
-            this.params.execContext.sandboxName,
-            this.params.remoteWorkspaceDir,
-            tmpDir,
-          ],
-          cwd: this.params.createParams.workspaceDir,
-        });
-        if (result.code !== 0) {
-          throw new Error(result.stderr.trim() || "openshell sandbox download failed");
-        }
-        await removeMaterializedSkillsFromDownloadedWorkspace(tmpDir);
-        const preservedSandboxSkills = await moveMaterializedSkillsShadowAside({
-          workspaceDir: this.params.createParams.workspaceDir,
-          tmpDir,
-        });
-        try {
-          await replaceDirectoryContents({
-            sourceDir: tmpDir,
-            targetDir: this.params.createParams.workspaceDir,
-            // Never sync trusted host hook directories or repository metadata from
-            // the remote sandbox.
-            excludeDirs: DEFAULT_OPEN_SHELL_MIRROR_EXCLUDE_DIRS,
-          });
-        } finally {
-          await restoreMaterializedSkillsShadow({
-            workspaceDir: this.params.createParams.workspaceDir,
-            preserved: preservedSandboxSkills,
-          });
-        }
-      },
+    const remoteSkillsWorkspaceDir = resolveRemoteMaterializedSkillsWorkspaceDir(
+      this.params.remoteWorkspaceDir,
     );
+    const roots = this.workspaceUploadRoots();
+    for (const [index, root] of roots.entries()) {
+      // The primary workspace is the mirror's canonical download target. Agent roots are
+      // host-owned inputs, including in rw mode, and historically never reconcile back.
+      if (root.owner === "agent") {
+        continue;
+      }
+      await withTempWorkspace(
+        { rootDir: resolveOpenShellTmpRoot(), prefix: "openclaw-openshell-sync-" },
+        async ({ dir: tmpDir }) => {
+          const result = await runOpenShellCli({
+            context: this.params.execContext,
+            args: ["sandbox", "download", this.params.execContext.sandboxName, root.remote, tmpDir],
+            cwd: this.params.createParams.workspaceDir,
+          });
+          if (result.code !== 0) {
+            throw new Error(result.stderr.trim() || "openshell sandbox download failed");
+          }
+          const preservedShadows: PreservedLocalShadow[] = [];
+          try {
+            for (const shadowedRoot of roots.slice(index + 1)) {
+              if (
+                root.remote === shadowedRoot.remote ||
+                !isOpenShellRemotePathInside(root.remote, shadowedRoot.remote)
+              ) {
+                continue;
+              }
+              const relativeParts = path.posix
+                .relative(root.remote, shadowedRoot.remote)
+                .split("/")
+                .filter(Boolean);
+              await removeDownloadedWorkspacePath(tmpDir, relativeParts);
+              const preserved = await moveLocalShadowAside({
+                workspaceDir: root.local,
+                tmpDir,
+                relativeParts,
+              });
+              if (preserved) {
+                preservedShadows.push(preserved);
+              }
+            }
+            const relativeSkillsPath = path.posix.relative(root.remote, remoteSkillsWorkspaceDir);
+            if (
+              relativeSkillsPath === "" ||
+              (!relativeSkillsPath.startsWith("../") && !path.posix.isAbsolute(relativeSkillsPath))
+            ) {
+              await removeDownloadedWorkspacePath(
+                tmpDir,
+                relativeSkillsPath.split("/").filter(Boolean),
+              );
+            }
+            if (root.owner === "workspace") {
+              const preserved = await moveLocalShadowAside({
+                workspaceDir: root.local,
+                tmpDir,
+                relativeParts: MATERIALIZED_SKILLS_REMOTE_PARTS,
+              });
+              if (preserved) {
+                preservedShadows.push(preserved);
+              }
+            }
+            await replaceDirectoryContents({
+              sourceDir: tmpDir,
+              targetDir: root.local,
+              // Never sync trusted host hook directories or repository metadata from
+              // the remote sandbox.
+              excludeDirs: DEFAULT_OPEN_SHELL_MIRROR_EXCLUDE_DIRS,
+            });
+          } finally {
+            for (const preserved of preservedShadows.toReversed()) {
+              await restoreLocalShadow({ workspaceDir: root.local, preserved });
+            }
+          }
+        },
+      );
+    }
   }
 
   private async uploadPathToRemote(localPath: string, remotePath: string): Promise<void> {
@@ -1051,8 +1145,7 @@ class OpenShellSandboxBackendImpl {
           targetDir: stagedRoot,
           excludeDirs: DEFAULT_OPEN_SHELL_MIRROR_EXCLUDE_DIRS,
         });
-        const stagedEntries = (await fs.readdir(stagedRoot)).toSorted();
-        for (const entry of stagedEntries) {
+        for (const entry of (await fs.readdir(stagedRoot)).toSorted()) {
           const result = await runOpenShellCli({
             context: this.params.execContext,
             args: buildOpenShellDirectoryUploadArgs({
@@ -1192,15 +1285,24 @@ function resolveRemoteMaterializedSkillsWorkspaceDir(remoteWorkspaceDir: string)
   return path.posix.join(root, ...MATERIALIZED_SKILLS_REMOTE_PARTS);
 }
 
-async function removeMaterializedSkillsFromDownloadedWorkspace(tmpDir: string): Promise<void> {
+async function removeDownloadedWorkspacePath(
+  tmpDir: string,
+  parts: readonly string[],
+): Promise<void> {
+  if (parts.length === 0) {
+    for (const entry of await fs.readdir(tmpDir)) {
+      await fs.rm(path.join(tmpDir, entry), { recursive: true, force: true });
+    }
+    return;
+  }
   let cursor = tmpDir;
-  for (const [index, part] of MATERIALIZED_SKILLS_REMOTE_PARTS.entries()) {
+  for (const [index, part] of parts.entries()) {
     const next = path.join(cursor, part);
     const stats = await fs.lstat(next).catch(() => null);
     if (!stats) {
       return;
     }
-    if (index === MATERIALIZED_SKILLS_REMOTE_PARTS.length - 1) {
+    if (index === parts.length - 1) {
       await fs.rm(next, { recursive: true, force: true });
       return;
     }
@@ -1212,11 +1314,18 @@ async function removeMaterializedSkillsFromDownloadedWorkspace(tmpDir: string): 
   }
 }
 
-async function moveMaterializedSkillsShadowAside(params: {
+type PreservedLocalShadow = {
+  preservedPath: string;
+  preserveRoot: string;
+  relativeParts: readonly string[];
+};
+
+async function moveLocalShadowAside(params: {
   workspaceDir: string;
   tmpDir: string;
-}): Promise<{ preservedPath: string; preserveRoot: string } | undefined> {
-  const shadowPath = path.join(params.workspaceDir, ...MATERIALIZED_SKILLS_REMOTE_PARTS);
+  relativeParts: readonly string[];
+}): Promise<PreservedLocalShadow | undefined> {
+  const shadowPath = path.join(params.workspaceDir, ...params.relativeParts);
   const parentStats = await fs.lstat(path.dirname(shadowPath)).catch(() => null);
   if (!parentStats?.isDirectory() || parentStats.isSymbolicLink()) {
     return undefined;
@@ -1228,25 +1337,22 @@ async function moveMaterializedSkillsShadowAside(params: {
   const preserveRoot = await fs.mkdtemp(
     path.join(path.dirname(params.tmpDir), "openclaw-openshell-preserve-"),
   );
-  const preservedPath = path.join(preserveRoot, "sandbox-skills");
+  const preservedPath = path.join(preserveRoot, "shadow");
   await movePathWithCopyFallback({ from: shadowPath, to: preservedPath });
-  return { preservedPath, preserveRoot };
+  return { preservedPath, preserveRoot, relativeParts: params.relativeParts };
 }
 
-async function restoreMaterializedSkillsShadow(params: {
+async function restoreLocalShadow(params: {
   workspaceDir: string;
-  preserved?: { preservedPath: string; preserveRoot: string };
+  preserved: PreservedLocalShadow;
 }): Promise<void> {
-  if (!params.preserved) {
-    return;
-  }
   let restored = false;
   try {
-    const shadowPath = path.join(params.workspaceDir, ...MATERIALIZED_SKILLS_REMOTE_PARTS);
+    const shadowPath = path.join(params.workspaceDir, ...params.preserved.relativeParts);
     const parentPath = path.dirname(shadowPath);
     const parentStats = await fs.lstat(parentPath).catch(() => null);
     if (parentStats?.isSymbolicLink()) {
-      throw new Error(`Refusing to restore sandbox skills through symlink parent: ${parentPath}`);
+      throw new Error(`Refusing to restore workspace shadow through symlink parent: ${parentPath}`);
     }
     if (parentStats && !parentStats.isDirectory()) {
       await fs.rm(parentPath, { recursive: true, force: true });
@@ -1277,11 +1383,4 @@ function normalizeRemotePath(remotePath: string): string {
   return normalized;
 }
 
-function isRemotePathInside(root: string, candidate: string): boolean {
-  const relative = path.posix.relative(root, candidate);
-  return (
-    relative === "" ||
-    (relative !== ".." && !relative.startsWith("../") && !path.posix.isAbsolute(relative))
-  );
-}
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/openshell/src/fs-bridge.ts
+++ b/extensions/openshell/src/fs-bridge.ts
@@ -10,6 +10,7 @@ import type {
 import { createWritableRenameTargetResolver } from "openclaw/plugin-sdk/sandbox";
 import { FsSafeError } from "openclaw/plugin-sdk/security-runtime";
 import type { OpenShellFsBridgeContext, OpenShellMirrorBackend } from "./backend.types.js";
+import { resolveOpenShellWorkspaceRoot, type OpenShellWorkspaceRoot } from "./workspace-roots.js";
 
 type ResolvedMountPath = SandboxResolvedPath & {
   mountHostRoot: string;
@@ -303,45 +304,81 @@ class OpenShellFsBridge implements SandboxFsBridge {
       }
     }
 
-    if (input.startsWith(`${workspaceContainerRoot}/`) || input === workspaceContainerRoot) {
-      const relative = path.posix.relative(workspaceContainerRoot, input) || "";
+    const containerMounts: OpenShellWorkspaceRoot<{
+      hostRoot: string;
+      writable: boolean;
+    }>[] = [
+      {
+        remote: workspaceContainerRoot,
+        owner: "workspace",
+        value: {
+          hostRoot: workspaceRoot,
+          writable: this.sandbox.workspaceAccess === "rw",
+        },
+      },
+      ...(hasAgentMount
+        ? [
+            {
+              remote: agentContainerRoot,
+              owner: "agent" as const,
+              value: {
+                hostRoot: agentRoot,
+                writable: this.sandbox.workspaceAccess === "rw",
+              },
+            },
+          ]
+        : []),
+    ];
+    const resolveContainerTarget = (containerPath: string): ResolvedMountPath | undefined => {
+      const containerMount = resolveOpenShellWorkspaceRoot(containerMounts, containerPath);
+      if (!containerMount) {
+        return undefined;
+      }
+      const relative = path.posix.relative(containerMount.remote, containerPath) || "";
       const hostPath = relative
-        ? path.resolve(workspaceRoot, ...relative.split("/"))
-        : workspaceRoot;
-      if (!isPathInside(workspaceRoot, hostPath)) {
+        ? path.resolve(containerMount.value.hostRoot, ...relative.split("/"))
+        : containerMount.value.hostRoot;
+      if (!isPathInside(containerMount.value.hostRoot, hostPath)) {
         throw new Error(`Sandbox path escapes allowed mounts; cannot access: ${input}`);
       }
       return {
         hostPath,
-        relativePath: relative,
+        relativePath:
+          containerMount.owner === "agent"
+            ? relative
+              ? containerMount.remote + "/" + relative
+              : containerMount.remote
+            : relative,
         containerPath: relative
-          ? path.posix.join(workspaceContainerRoot, relative)
-          : workspaceContainerRoot,
-        mountHostRoot: workspaceRoot,
-        writable: this.sandbox.workspaceAccess === "rw",
-        source: "workspace",
+          ? path.posix.join(containerMount.remote, relative)
+          : containerMount.remote,
+        mountHostRoot: containerMount.value.hostRoot,
+        writable: containerMount.value.writable,
+        source: containerMount.owner,
       };
-    }
-
-    if (
-      hasAgentMount &&
-      (input.startsWith(`${agentContainerRoot}/`) || input === agentContainerRoot)
-    ) {
-      const relative = path.posix.relative(agentContainerRoot, input) || "";
-      const hostPath = relative ? path.resolve(agentRoot, ...relative.split("/")) : agentRoot;
-      if (!isPathInside(agentRoot, hostPath)) {
+    };
+    const containerCwd = params.cwd?.replace(/\\/g, "/");
+    const cwdMount = containerCwd
+      ? resolveOpenShellWorkspaceRoot(containerMounts, containerCwd)
+      : undefined;
+    const containerInput = path.posix.isAbsolute(input)
+      ? input
+      : cwdMount || !params.cwd
+        ? path.posix.resolve(containerCwd ?? workspaceContainerRoot, input)
+        : undefined;
+    if (containerInput) {
+      const target = resolveContainerTarget(containerInput);
+      if (target) {
+        return target;
+      }
+      if (
+        cwdMount ||
+        containerMounts.some(
+          (mount) => input === mount.remote || input.startsWith(`${mount.remote}/`),
+        )
+      ) {
         throw new Error(`Sandbox path escapes allowed mounts; cannot access: ${input}`);
       }
-      return {
-        hostPath,
-        relativePath: relative ? agentContainerRoot + "/" + relative : agentContainerRoot,
-        containerPath: relative
-          ? path.posix.join(agentContainerRoot, relative)
-          : agentContainerRoot,
-        mountHostRoot: agentRoot,
-        writable: this.sandbox.workspaceAccess === "rw",
-        source: "agent",
-      };
     }
 
     const cwd = params.cwd ? path.resolve(params.cwd) : workspaceRoot;
@@ -361,16 +398,10 @@ class OpenShellFsBridge implements SandboxFsBridge {
 
     if (isPathInside(workspaceRoot, hostPath)) {
       const relative = path.relative(workspaceRoot, hostPath).split(path.sep).join(path.posix.sep);
-      return {
-        hostPath,
-        relativePath: relative,
-        containerPath: relative
-          ? path.posix.join(workspaceContainerRoot, relative)
-          : workspaceContainerRoot,
-        mountHostRoot: workspaceRoot,
-        writable: this.sandbox.workspaceAccess === "rw",
-        source: "workspace",
-      };
+      return expectResolvedContainerTarget(
+        resolveContainerTarget(path.posix.join(workspaceContainerRoot, relative)),
+        input,
+      );
     }
 
     if (skillsRoot && this.sandbox.workspaceAccess === "rw" && isPathInside(skillsRoot, hostPath)) {
@@ -391,20 +422,24 @@ class OpenShellFsBridge implements SandboxFsBridge {
 
     if (hasAgentMount && isPathInside(agentRoot, hostPath)) {
       const relative = path.relative(agentRoot, hostPath).split(path.sep).join(path.posix.sep);
-      return {
-        hostPath,
-        relativePath: relative ? `${agentContainerRoot}/${relative}` : agentContainerRoot,
-        containerPath: relative
-          ? path.posix.join(agentContainerRoot, relative)
-          : agentContainerRoot,
-        mountHostRoot: agentRoot,
-        writable: this.sandbox.workspaceAccess === "rw",
-        source: "agent",
-      };
+      return expectResolvedContainerTarget(
+        resolveContainerTarget(path.posix.join(agentContainerRoot, relative)),
+        input,
+      );
     }
 
     throw new Error(`Path escapes sandbox root (${workspaceRoot}): ${params.filePath}`);
   }
+}
+
+function expectResolvedContainerTarget(
+  target: ResolvedMountPath | undefined,
+  input: string,
+): ResolvedMountPath {
+  if (!target) {
+    throw new Error(`Sandbox path escapes allowed mounts; cannot access: ${input}`);
+  }
+  return target;
 }
 
 async function mkdirLocalRootPath(params: {

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -1683,5 +1683,66 @@ describe("openshell fs bridges", () => {
     expect(resolved.hostPath).toBe(path.join(agentWorkspaceDir, "note.txt"));
     expect(await bridge.readFile({ filePath: "/agent/note.txt" })).toEqual(Buffer.from("agent"));
   });
+
+  it.each([
+    {
+      name: "nested agent root",
+      workspaceRemote: "/sandbox",
+      agentRemote: "/sandbox/nested/agent",
+      target: "/sandbox/nested/agent/note.txt",
+      owner: "agent",
+    },
+    {
+      name: "nested primary root",
+      workspaceRemote: "/sandbox/agent/project",
+      agentRemote: "/sandbox/agent",
+      target: "/sandbox/agent/project/note.txt",
+      owner: "workspace",
+    },
+    {
+      name: "equal roots",
+      workspaceRemote: "/sandbox",
+      agentRemote: "/sandbox",
+      target: "/sandbox/note.txt",
+      owner: "workspace",
+    },
+    {
+      name: "relative path under a nested agent root",
+      workspaceRemote: "/sandbox",
+      agentRemote: "/sandbox/nested/agent",
+      target: "nested/agent/note.txt",
+      owner: "agent",
+    },
+    {
+      name: "relative path under equal roots",
+      workspaceRemote: "/sandbox",
+      agentRemote: "/sandbox",
+      target: "note.txt",
+      owner: "workspace",
+    },
+  ])("routes $name to the authoritative host workspace", async (scenario) => {
+    await using workspace = await createOpenShellTestWorkspace("fs");
+    await using agentWorkspace = await createOpenShellTestWorkspace("agent");
+    const backend = {
+      ...createMirrorBackendMock(),
+      remoteAgentWorkspaceDir: scenario.agentRemote,
+    };
+    const sandbox = createSandboxTestContext({
+      overrides: {
+        backendId: "openshell",
+        workspaceDir: workspace.dir,
+        agentWorkspaceDir: agentWorkspace.dir,
+        workspaceAccess: "ro",
+        containerWorkdir: scenario.workspaceRemote,
+      },
+    });
+
+    const { createOpenShellFsBridge } = await import("./fs-bridge.js");
+    const bridge = createOpenShellFsBridge({ sandbox, backend });
+    const resolved = bridge.resolvePath({ filePath: scenario.target });
+    expect(resolved.hostPath).toBe(
+      path.join(scenario.owner === "agent" ? agentWorkspace.dir : workspace.dir, "note.txt"),
+    );
+  });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/openshell/src/workspace-roots.ts
+++ b/extensions/openshell/src/workspace-roots.ts
@@ -1,0 +1,51 @@
+// OpenShell plugin module owns remote workspace-root precedence.
+import path from "node:path";
+
+export type OpenShellWorkspaceRoot<T = unknown> = {
+  remote: string;
+  owner: "workspace" | "agent";
+  value: T;
+};
+
+function remotePathDepth(remote: string): number {
+  return remote.split("/").filter(Boolean).length;
+}
+
+function workspaceRootOwnerOrder(owner: OpenShellWorkspaceRoot["owner"]): number {
+  return owner === "workspace" ? 0 : 1;
+}
+
+export function isOpenShellRemotePathInside(root: string, candidate: string): boolean {
+  const relative = path.posix.relative(root, candidate);
+  return (
+    relative === "" ||
+    (relative !== ".." && !relative.startsWith("../") && !path.posix.isAbsolute(relative))
+  );
+}
+
+export function orderOpenShellWorkspaceRoots<T>(
+  roots: readonly OpenShellWorkspaceRoot<T>[],
+): OpenShellWorkspaceRoot<T>[] {
+  // Outer roots publish first so a nested root can replace its full subtree.
+  // Equal roots preserve the historical agent-root-last precedence.
+  return roots.toSorted(
+    (a, b) =>
+      remotePathDepth(a.remote) - remotePathDepth(b.remote) ||
+      workspaceRootOwnerOrder(a.owner) - workspaceRootOwnerOrder(b.owner),
+  );
+}
+
+export function resolveOpenShellWorkspaceRoot<T>(
+  roots: readonly OpenShellWorkspaceRoot<T>[],
+  candidate: string,
+): OpenShellWorkspaceRoot<T> | undefined {
+  // The most-specific root owns nested paths. Exact ties retain the primary
+  // workspace mapping used before agent roots became independently writable.
+  return roots
+    .toSorted(
+      (a, b) =>
+        remotePathDepth(b.remote) - remotePathDepth(a.remote) ||
+        workspaceRootOwnerOrder(a.owner) - workspaceRootOwnerOrder(b.owner),
+    )
+    .find((root) => isOpenShellRemotePathInside(root.remote, candidate));
+}


### PR DESCRIPTION
Closes #131258

## What Problem This Solves

Fixes an issue where previously configured overlapping OpenShell mirror roots could erase the primary workspace before a command ran. The same overlap could also route file operations to a different local owner than publication used, fail on file/directory collisions, or overwrite a host-owned subtree while synchronizing the primary workspace back from the sandbox.

## Why This Change Was Made

OpenShell now uses one canonical workspace-root ownership model across upload publication, workdir validation, filesystem routing, and download reconciliation. Outer roots publish first, more-specific roots own overlapping remote paths, and blocking file/directory entries are replaced only at the nested-root boundary. Exact equal-root ties keep their shipped behavior: the agent root publishes last, while host filesystem operations continue to map to the primary workspace.

Mirror finalization preserves the shipped host boundary: only the primary workspace is downloaded, while any nested agent-root shadow is protected from that replacement. Agent workspaces remain host-owned inputs in both `ro` and `rw` modes, and equal-root configurations retain their historical primary download target.

The change stays inside the bundled OpenShell plugin. It adds no configuration, protocol, or Plugin SDK surface and preserves the documented upgrade compatibility for existing overlapping-root configurations.

## User Impact

Operators with legacy overlapping OpenShell roots can run commands without the configured workdir disappearing. Mirror-mode reads and writes consistently use the authoritative remote root, nested file/directory collisions are handled, primary-workspace changes return locally, and remote agent-root mutations do not overwrite the host agent workspace.

Default non-overlapping roots retain their existing behavior. `mode: "remote"` does not perform per-command host reconciliation; its one-time initial seed still benefits from the corrected publication ordering when legacy roots overlap.

## Evidence

### Live OpenShell + Podman behavior

Retested with a real local OpenShell 0.0.106 gateway backed by Podman, using the reported layout:

```text
remoteAgentWorkspaceDir=/sandbox/agent
remoteWorkspaceDir=/sandbox/agent/project
workspaceAccess=ro

Test Files  3 passed (3)
Tests       5 passed (5)
Duration    519.73s test body
```

The live overlap lane proved that:

- files from both the outer agent root and nested primary workspace remained readable after publication;
- the nested primary workdir survived command preparation;
- a command could mutate the outer agent root remotely through `../agent-only.txt` under the permissive E2E policy;
- finalization returned primary-workspace changes while the local agent workspace retained its original `agent-preserved` content.

Saved JSON result: `.artifacts/issue-131258/backend-e2e-agent-host-owned.json` (local review artifact)

```text
SHA-256 6e47603741e9833cf3359284554408595a897a31b3e05e07a191bfd560c3aec2
numTotalTestSuites=3
numPassedTestSuites=3
numTotalTests=5
numPassedTests=5
success=true
```

The live-tested nested-overlap tree was committed as `6cc839a78e2716dffb333aba095c29008e2cfe48`. The current head `db824b4583a53c715e5334af2dd6f5f219663d6d` is rebased onto `origin/main` `babb2fc7c13` and additionally restores primary-workspace filesystem ownership for exact equal-root ties. That compatibility correction is covered directly by absolute- and relative-path regression cases; both failed against the prior PR head by selecting the agent directory and pass on the current head by selecting the primary workspace.

### Focused verification

```text
Pre-fix compatibility regression: failed because remote-agent replaced local-agent
Focused overlapping-root suite on final head: 42 passed
Full OpenShell plugin suite: 146 passed
Extension production typecheck: passed
Extension test typecheck on final head: passed
Autoreview of the final compatibility delta through P1: clean, confidence 0.93
git diff --check: passed
Final branch relation after rebase: 1 ahead, 0 behind origin/main
```

The changed-file gate passed formatting, extension lint, production/test typechecks, boundary checks, dead-export checks, and completed architecture guards. It stopped only when the linked worktree's intentionally unreconciled dependency tree lacked `node_modules/playwright-core` for the unrelated runtime-sidecar loader guard.

Regression coverage includes both nesting directions, equal roots, disjoint roots, `ro` and `rw` agent workspaces, relative and absolute filesystem paths, excluded directories, file/directory collisions, blocking ancestors, primary-only remote-to-local reconciliation, and preservation of shadowed local subtrees.

### Review history

Local ClawSweeper findings drove removal of the earlier composite-staging design and alignment on one root-ownership model. Autoreview then found that downloading an outer primary root could overwrite a locally shadowed subtree; that finding was reproduced and fixed. A compatibility audit found that reconciling agent roots expanded shipped behavior and violated the read-only host boundary, so the patch preserves historical primary-only download semantics. ClawSweeper's exact-head review then found that equal-root filesystem routing had also changed from primary to agent ownership. Absolute and relative regressions reproduced that issue, the resolver now preserves primary ownership for exact ties without changing nested-root precedence or publication order, and final Autoreview found no P0/P1 issues.

## Agent Transcript

<details>
<summary>Redacted task transcript</summary>

```text
[user]
Fix #131258 in a new worktree from current origin/main, sign off the commit,
and review it thoroughly with Autoreview and ClawSweeper.

[assistant]
The reported clear-order failure reproduced at the OpenShell publication
boundary. Investigation expanded the invariant across publication, workdir
validation, filesystem routing, and primary-workspace reconciliation because
those paths must agree about which overlapping remote root owns a path.

[assistant]
ClawSweeper identified collision, staging, protected-path, and ownership edge
cases. The accepted findings were reproduced and fixed. The resulting design
removed composite staging and uses one outer-to-inner root order with the most
specific remote root authoritative.

[assistant]
Autoreview found that applying an outer-root download wholesale could delete a
locally shadowed subtree. The regression failed before the correction and
passed after preserving that subtree during primary-root reconciliation.

[user]
Are there any backward compatibility concerns with our change?

[assistant]
A compatibility audit found that the draft patch newly downloaded agent roots
into the host agent workspace, including under workspaceAccess=ro. That was
outside the issue scope and contradicted the documented host boundary.

[user]
Please fix that, agreed.

[assistant]
The patch now downloads only the primary workspace, preserves nested agent
shadows, and keeps agent workspaces host-owned in ro, rw, and equal-root cases.
The regression failed on the prior PR head, then passed after the fix. A real
OpenShell 0.0.106 + Podman run passed 5/5 and proved a remote agent mutation
does not return to the host agent workspace.

[assistant]
ClawSweeper found one remaining compatibility issue: exact equal-root paths
were now routed to the agent directory instead of the historical primary
workspace. Absolute and relative filesystem regressions failed on the prior
head, then passed after separating primary-first lookup ties from agent-last
publication order. Autoreview through P1 was clean at 0.93 confidence.
```

</details>
