### PR TITLE
fix(tui): retain reset confirmation after history refresh

### DIFF
--- a/docs/web/tui.md
+++ b/docs/web/tui.md
@@ -136,6 +136,8 @@ Session lifecycle:
 - `/settings`
 - `/exit` (or `/quit`)
 
+When the current session is reset, the TUI confirms it after refreshing the transcript, including resets initiated by another client.
+
 Local mode only:
 
 - `/auth [provider]` opens the provider auth/login flow inside the TUI.

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -1,5 +1,6 @@
 // Covers TUI event handler routing for keyboard and backend events.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import * as failoverClassifier from "../agents/failover/classify.js";
 import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../shared/assistant-error-format.js";
 import { createEventHandlers } from "./tui-event-handlers.js";
@@ -1733,6 +1734,77 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     });
 
     expect(chatLog.startTool).not.toHaveBeenCalled();
+  });
+
+  it("reports only the latest reset after all queued history reloads settle", async () => {
+    const first = createDeferred<TuiHistoryLoadResult>();
+    const second = createDeferred<TuiHistoryLoadResult>();
+    const { state, chatLog, loadHistory, handleSessionsChangedEvent, dispose } =
+      createHandlersHarness({ state: { activeChatRunId: null } });
+    loadHistory.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+    try {
+      handleSessionsChangedEvent({ reason: "reset", sessionId: "session-1", updatedAt: 20 });
+      handleSessionsChangedEvent({ reason: "reset", sessionId: "session-1", updatedAt: 30 });
+      expect(loadHistory).toHaveBeenCalledTimes(1);
+      first.resolve({ loaded: true, runOutcome: { state: "completed" } });
+      await vi.waitFor(() => expect(loadHistory).toHaveBeenCalledTimes(2));
+      expect(chatLog.addSystem).not.toHaveBeenCalled();
+
+      state.activeChatRunId = "newly-adopted-run";
+      second.resolve({ loaded: true, runOutcome: { state: "active", runId: "newly-adopted-run" } });
+      await vi.waitFor(() =>
+        expect(chatLog.addSystem).toHaveBeenCalledExactlyOnceWith("session agent:main:main reset"),
+      );
+      expect(state.activeChatRunId).toBe("newly-adopted-run");
+    } finally {
+      dispose();
+    }
+  });
+
+  it.each(["session", "global agent", "new lifecycle", "dispose"])(
+    "discards a reset receipt retired by %s while history loads",
+    async (retirement) => {
+      const history = createDeferred<TuiHistoryLoadResult>();
+      const { state, chatLog, loadHistory, handleSessionsChangedEvent, dispose } =
+        createHandlersHarness({
+          state: {
+            currentSessionKey: retirement === "global agent" ? "global" : "agent:main:main",
+            activeChatRunId: null,
+          },
+        });
+      loadHistory.mockReturnValueOnce(history.promise);
+      handleSessionsChangedEvent({ reason: "reset", agentId: "main", sessionId: "session-1" });
+      if (retirement === "session") {
+        state.currentSessionKey = "agent:main:other";
+      } else if (retirement === "global agent") {
+        state.currentAgentId = "work";
+      } else if (retirement === "new lifecycle") {
+        handleSessionsChangedEvent({ reason: "new", sessionId: "replacement" });
+      } else {
+        dispose();
+      }
+      history.resolve({ loaded: true, runOutcome: { state: "completed" } });
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(chatLog.addSystem).not.toHaveBeenCalled();
+      dispose();
+    },
+  );
+
+  it("reports an observed reset even when its history reload fails", async () => {
+    const { chatLog, loadHistory, handleSessionsChangedEvent, dispose } = createHandlersHarness({
+      state: { activeChatRunId: null },
+    });
+    loadHistory.mockRejectedValueOnce(new Error("history unavailable"));
+    try {
+      handleSessionsChangedEvent({ reason: "reset", sessionId: "session-1" });
+      await vi.waitFor(() =>
+        expect(chatLog.addSystem).toHaveBeenCalledExactlyOnceWith("session agent:main:main reset"),
+      );
+    } finally {
+      dispose();
+    }
   });
 
   it("reloads the selected session for an identity-only legacy batch invalidation", () => {

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -379,23 +379,6 @@ export function createEventHandlers(context: EventHandlerContext) {
     tui.requestRender();
   };
 
-  const collectTrackedSessionRunIds = () => {
-    const runIds = new Set(sessionRuns.keys());
-    if (state.activeChatRunId) {
-      runIds.add(state.activeChatRunId);
-    }
-    const pendingRunId = getPendingSubmitAcceptedRunId(state);
-    if (pendingRunId) {
-      runIds.add(pendingRunId);
-    }
-    const finalizedRunIds = new Set(finalizedRuns.keys());
-    const displayedRunIds = new Set(finalizedRunsWithDisplay.keys());
-    for (const runId of finalizedRunIds) {
-      runIds.add(runId);
-    }
-    return { runIds, finalizedRunIds, displayedRunIds };
-  };
-
   const handleSessionsChangedEvent = (payload: unknown) => {
     if (!payload || typeof payload !== "object") {
       return;
@@ -416,7 +399,7 @@ export function createEventHandlers(context: EventHandlerContext) {
       }
       // Legacy atomic batches expose no replayable message identity. Refresh
       // their authoritative history without resetting the current run or stream.
-      runCoordinator.queueHistoryReload();
+      void runCoordinator.queueHistoryReload();
       return;
     }
 
@@ -428,7 +411,11 @@ export function createEventHandlers(context: EventHandlerContext) {
           const displayedRunIds = finalizedRunsWithDisplay.has(persistedRunId)
             ? [persistedRunId]
             : [];
-          runCoordinator.queueHistoryReload([persistedRunId], [persistedRunId], displayedRunIds);
+          void runCoordinator.queueHistoryReload(
+            [persistedRunId],
+            [persistedRunId],
+            displayedRunIds,
+          );
         } else {
           void refreshSessionInfo?.();
         }
@@ -446,7 +433,7 @@ export function createEventHandlers(context: EventHandlerContext) {
       nextSessionId !== null &&
       state.currentSessionId !== nextSessionId;
     if (evt.reason === "new" && !replacesKnownSession) {
-      const { runIds, displayedRunIds } = collectTrackedSessionRunIds();
+      const { runIds, displayedRunIds } = runCoordinator.collectTrackedSessionRunIds();
       if (runIds.size > 0) {
         if (nextSessionId) {
           state.currentSessionId = nextSessionId;
@@ -462,17 +449,14 @@ export function createEventHandlers(context: EventHandlerContext) {
             pendingNewSessionRunIds.add(runId);
           }
         }
-        runCoordinator.queueHistoryReload(persistedRunIds, persistedRunIds, displayedRunIds);
+        void runCoordinator.queueHistoryReload(persistedRunIds, persistedRunIds, displayedRunIds);
         tui.requestRender();
         return;
       }
     }
 
-    const {
-      runIds: reloadingRunIds,
-      finalizedRunIds,
-      displayedRunIds,
-    } = collectTrackedSessionRunIds();
+    const { runIds, finalizedRunIds, displayedRunIds } =
+      runCoordinator.collectTrackedSessionRunIds();
     state.sessionGeneration = (state.sessionGeneration ?? 0) + 1;
     // Reduce the old epoch before adopting its replacement ID; otherwise the
     // canonical reducer correctly rejects the reset as a foreign session.
@@ -491,11 +475,27 @@ export function createEventHandlers(context: EventHandlerContext) {
       state.sessionInfo.updatedAt = evt.updatedAt;
     }
     getTuiSessionProjection(state);
-    if (reloadingRunIds.size > 0) {
-      runCoordinator.queueHistoryReload(reloadingRunIds, finalizedRunIds, displayedRunIds);
-    } else {
-      runCoordinator.queueHistoryReload();
-    }
+    const selection = { sessionKey: state.currentSessionKey, agentId: state.currentAgentId };
+    const generation = state.sessionGeneration;
+    const historyReload = runCoordinator.queueHistoryReload(
+      runIds.size > 0 ? runIds : undefined,
+      finalizedRunIds,
+      displayedRunIds,
+    );
+    // The reset event can retire its own RPC acknowledgement. Its authoritative
+    // receipt belongs after the last queued history rebuild, which clears chat.
+    void historyReload.then((current) => {
+      if (
+        current &&
+        evt.reason === "reset" &&
+        generation === state.sessionGeneration &&
+        matchesSelectedTuiSession(state, selection) &&
+        selection.agentId === state.currentAgentId
+      ) {
+        chatLog.addSystem(`session ${state.currentSessionKey} reset`);
+        tui.requestRender();
+      }
+    });
     tui.requestRender();
   };
 
@@ -739,9 +739,9 @@ export function createEventHandlers(context: EventHandlerContext) {
       type: "transportGap",
       scope: readTuiSessionProjectionScope(state),
     });
-    const { runIds, displayedRunIds } = collectTrackedSessionRunIds();
+    const { runIds, displayedRunIds } = runCoordinator.collectTrackedSessionRunIds();
     if (runIds.size === 0) {
-      runCoordinator.queueHistoryReload();
+      void runCoordinator.queueHistoryReload();
       return;
     }
     // A dropped final cannot distinguish a finished run from a still-streaming

--- a/src/tui/tui-run-lifecycle.ts
+++ b/src/tui/tui-run-lifecycle.ts
@@ -83,7 +83,7 @@ export function createTuiRunLifecycle(context: TuiRunLifecycleContext) {
       return;
     }
     runCoordinator.pendingHistoryRefresh = false;
-    runCoordinator.queueHistoryReload();
+    void runCoordinator.queueHistoryReload();
   };
 
   const clearStreamingWatchdog = () => {
@@ -141,7 +141,7 @@ export function createTuiRunLifecycle(context: TuiRunLifecycleContext) {
         state.activityStatus = "idle";
         setActivityStatus("idle");
         runCoordinator.pendingHistoryRefresh = false;
-        runCoordinator.queueHistoryReload();
+        void runCoordinator.queueHistoryReload();
         tui.requestRender();
         return;
       }
@@ -380,7 +380,7 @@ export function createTuiRunLifecycle(context: TuiRunLifecycleContext) {
       return;
     }
     runCoordinator.pendingHistoryRefresh = false;
-    runCoordinator.queueHistoryReload();
+    void runCoordinator.queueHistoryReload();
   };
 
   const renderTerminalRunError = (params: {

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { ChatLog } from "./components/chat-log.js";
 import type { TuiBackend } from "./tui-backend.js";
+import { createCommandHandlers } from "./tui-command-handlers.js";
 import { createEventHandlers } from "./tui-event-handlers.js";
 import {
   makeChatLog,
@@ -2151,6 +2152,103 @@ describe("tui session actions", () => {
     expect(clearAll).toHaveBeenCalled();
     expect(addSystem).toHaveBeenCalledWith("session agent:main:new");
   });
+
+  it.each(["none", "before adoption", "during refresh", "after acknowledgement"])(
+    "keeps the reset acknowledgement with a notification %s",
+    async (notification) => {
+      const state = createBaseState({
+        currentSessionId: "same-session",
+        sessionGeneration: 4,
+        historyLoaded: true,
+        sessionInfo: { updatedAt: 10, totalTokens: 42 },
+      });
+      const entry = { sessionId: "same-session", updatedAt: 20, totalTokens: 0 };
+      const result = { ok: true, key: state.currentSessionKey, entry };
+      const chatLog = makeChatLog();
+      chatLog.addUser("before reset");
+      const tui = makeTui();
+      const btw = createBtwPresenter();
+      const setActivityStatus = (text: string) => {
+        state.activityStatus = text;
+      };
+      const refreshStarted = createDeferred();
+      const refreshResult = createDeferred<TuiSessionList>();
+      const resetResponse = createDeferred<typeof result>();
+      const client = makeTuiBackend({
+        resetSession: vi.fn(() => resetResponse.promise),
+        listSessions: vi.fn(() => {
+          refreshStarted.resolve();
+          return refreshResult.promise;
+        }),
+        loadHistory: vi.fn(async () => ({
+          messages: [],
+          sessionInfo: { key: result.key, ...entry },
+        })),
+      });
+      const actions = createTestSessionActions({ client, chatLog, tui, btw, state });
+      const histories: Array<Promise<TuiHistoryLoadResult>> = [];
+      const events = createEventHandlers({
+        chatLog,
+        tui,
+        btw,
+        state,
+        setActivityStatus,
+        loadHistory: () => {
+          const history = actions.loadHistory();
+          histories.push(history);
+          return history;
+        },
+        refreshSessionInfo: actions.refreshSessionInfo,
+      });
+      const commands = createCommandHandlers({
+        client,
+        chatLog,
+        tui,
+        state,
+        opts: {},
+        deliverDefault: false,
+        openOverlay: (component) => tui.showOverlay(component),
+        closeOverlay: () => tui.hideOverlay(),
+        setActivityStatus,
+        formatSessionKey: (key) => key,
+        requestExit: vi.fn(),
+        ...actions,
+      });
+      const notify = () =>
+        events.handleSessionsChangedEvent({
+          sessionKey: result.key,
+          agentId: "main",
+          reason: "reset",
+          ...entry,
+        });
+      try {
+        const resetting = commands.handleCommand("/reset");
+        resetResponse.resolve(result);
+        if (notification === "before adoption") {
+          notify();
+        } else {
+          await refreshStarted.promise;
+          if (notification === "during refresh") {
+            notify();
+          }
+        }
+        refreshResult.resolve(makeTuiSessionList({ sessions: [{ key: result.key, ...entry }] }));
+        await resetting;
+        if (notification === "after acknowledgement") {
+          notify();
+        }
+        await Promise.all(histories);
+        await vi.waitFor(() => {
+          const rendered = chatLog.render(120).join("\n");
+          expect(rendered).not.toContain("before reset");
+          expect(rendered.match(/session agent:main:main reset/g)).toHaveLength(1);
+        });
+        expect(commands.resolveMessageAdmission("after reset")).toEqual({ status: "allowed" });
+      } finally {
+        events.dispose();
+      }
+    },
+  );
 
   it("fences pre-reset history and session-info reads when reset commits", async () => {
     const history = createDeferred<unknown>();

--- a/src/tui/tui-session-run-coordinator.test.ts
+++ b/src/tui/tui-session-run-coordinator.test.ts
@@ -1,5 +1,6 @@
 // Covers bounded TUI run ownership and transcript persistence coordination.
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { createTuiRunIdTracker, TuiSessionRunCoordinator } from "./tui-session-run-coordinator.js";
 import type { ChatEvent, TuiHistoryLoadResult, TuiStateAccess } from "./tui-types.js";
 
@@ -205,9 +206,9 @@ describe("TuiSessionRunCoordinator", () => {
       message: { content: [{ type: "text", text: "persisted reply" }] },
     };
 
-    coordinator.queueHistoryReload(["run-first"], ["run-first"]);
+    void coordinator.queueHistoryReload(["run-first"], ["run-first"]);
     coordinator.deferHistoryRunEvent(deferredEvent);
-    coordinator.queueHistoryReload();
+    void coordinator.queueHistoryReload();
     expect(loadHistory).toHaveBeenCalledTimes(1);
 
     resolveHistory?.(completedHistory);
@@ -220,6 +221,32 @@ describe("TuiSessionRunCoordinator", () => {
     expect(replayHistoryRunEvent).toHaveBeenCalledWith(deferredEvent);
 
     resolveHistory?.(completedHistory);
+  });
+
+  it.each([false, true])("awaits the complete history drain across a reset: %s", async (reset) => {
+    const first = createDeferred<TuiHistoryLoadResult>();
+    const second = createDeferred<TuiHistoryLoadResult>();
+    const reads = vi
+      .fn<() => Promise<TuiHistoryLoadResult>>()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    const { coordinator, loadHistory } = createCoordinator({ loadHistory: reads });
+    const settled = vi.fn();
+    const firstDrain = coordinator.queueHistoryReload();
+    void firstDrain.then(settled);
+    if (reset) {
+      coordinator.clear();
+    }
+    const secondDrain = coordinator.queueHistoryReload();
+    void secondDrain.then(settled);
+    expect(loadHistory).toHaveBeenCalledTimes(1);
+
+    first.resolve(completedHistory);
+    await vi.waitFor(() => expect(loadHistory).toHaveBeenCalledTimes(2));
+    expect(settled).not.toHaveBeenCalled();
+    second.resolve(completedHistory);
+    await expect(Promise.all([firstDrain, secondDrain])).resolves.toEqual([!reset, true]);
+    expect(settled).toHaveBeenCalledTimes(2);
   });
 
   it("does not finalize a gap-recovery run when authoritative history fails", async () => {
@@ -295,7 +322,7 @@ describe("TuiSessionRunCoordinator", () => {
         }),
     });
 
-    coordinator.queueHistoryReload(["run-stale"], ["run-stale"]);
+    void coordinator.queueHistoryReload(["run-stale"], ["run-stale"]);
     coordinator.clear();
     resolveHistory?.(completedHistory);
 

--- a/src/tui/tui-session-run-coordinator.ts
+++ b/src/tui/tui-session-run-coordinator.ts
@@ -1,4 +1,5 @@
 // Owns bounded TUI run state, transcript persistence, and serialized history reloads.
+import { createTuiRefreshCoalescer } from "./coalesced-refresh.js";
 import { TuiStreamAssembler } from "./tui-stream-assembler.js";
 import { getPendingSubmitAcceptedRunId, hasPendingSubmit } from "./tui-submit-state.js";
 import type { ChatEvent, TuiHistoryLoadResult, TuiStateAccess } from "./tui-types.js";
@@ -68,7 +69,9 @@ export class TuiSessionRunCoordinator {
   private readonly confirmedStreamRunIds = new Set<string>();
   private readonly retiredOrphanRunIds = new Map<string, number>();
   private rejectUnconfirmedRuns = false;
-  private historyReloadInFlight = false;
+  private readonly historyReloadRunner = createTuiRefreshCoalescer(() =>
+    this.drainHistoryReloadQueue(),
+  );
   private historyReloadQueued = false;
   private historyReloadGeneration = 0;
 
@@ -233,6 +236,24 @@ export class TuiSessionRunCoordinator {
     this.pruneRunMap(this.persistedTerminalRunIds);
   }
 
+  collectTrackedSessionRunIds() {
+    const runIds = new Set(this.sessionRuns.keys());
+    const state = this.context.state;
+    if (state.activeChatRunId) {
+      runIds.add(state.activeChatRunId);
+    }
+    const pendingRunId = getPendingSubmitAcceptedRunId(state);
+    if (pendingRunId) {
+      runIds.add(pendingRunId);
+    }
+    const finalizedRunIds = new Set(this.finalizedRuns.keys());
+    const displayedRunIds = new Set(this.finalizedRunsWithDisplay.keys());
+    for (const runId of finalizedRunIds) {
+      runIds.add(runId);
+    }
+    return { runIds, finalizedRunIds, displayedRunIds };
+  }
+
   routeSessionMessageRefresh(projected: boolean): boolean {
     if (projected) {
       return true;
@@ -241,7 +262,7 @@ export class TuiSessionRunCoordinator {
       this.pendingHistoryRefresh = true;
       return true;
     }
-    this.queueHistoryReload();
+    void this.queueHistoryReload();
     return false;
   }
 
@@ -284,8 +305,8 @@ export class TuiSessionRunCoordinator {
     return result;
   }
 
-  private drainHistoryReloadQueue(): void {
-    if (this.historyReloadInFlight || !this.historyReloadQueued || !this.context.loadHistory) {
+  private async drainHistoryReloadQueue(): Promise<void> {
+    if (!this.historyReloadQueued || !this.context.loadHistory) {
       return;
     }
 
@@ -300,7 +321,6 @@ export class TuiSessionRunCoordinator {
       }
     }
     this.historyReloadQueued = false;
-    this.historyReloadInFlight = true;
 
     const finishReload = (result: TuiHistoryLoadResult) => {
       if (generation !== this.historyReloadGeneration) {
@@ -330,19 +350,19 @@ export class TuiSessionRunCoordinator {
       }
     };
 
-    void this.loadHistoryPreservingTerminalErrors()
-      .then(finishReload, () => finishReload({ loaded: false }))
-      .finally(() => {
-        this.historyReloadInFlight = false;
-        this.drainHistoryReloadQueue();
-      });
+    await this.loadHistoryPreservingTerminalErrors().then(finishReload, () =>
+      finishReload({ loaded: false }),
+    );
   }
 
+  /** Settle the complete queue and report whether this caller's session owner survived. */
   queueHistoryReload(
     runIds?: Iterable<string>,
     historyOwnedRunIds: Iterable<string> = [],
     displayedRunIds: Iterable<string> = [],
-  ): void {
+  ): Promise<boolean> {
+    const generation = this.historyReloadGeneration;
+    const isCurrent = () => generation === this.historyReloadGeneration;
     const historyOwned = new Set(historyOwnedRunIds);
     const displayed = new Set(displayedRunIds);
     const queuedRunIds = runIds ?? [];
@@ -353,8 +373,7 @@ export class TuiSessionRunCoordinator {
           this.noteFinalizedRun(runId, { displayedFinal: true });
         }
       }
-      void this.context.refreshSessionInfo?.();
-      return;
+      return (this.context.refreshSessionInfo?.() ?? Promise.resolve()).then(isCurrent, isCurrent);
     }
 
     if (runIds === undefined) {
@@ -372,7 +391,11 @@ export class TuiSessionRunCoordinator {
       }
       this.historyReloadRuns.set(runId, reload);
     }
-    this.drainHistoryReloadQueue();
+    // An empty persistence barrier must not defer the first real reload.
+    if (!this.historyReloadQueued && !this.historyReloadRunner.isRunning()) {
+      return Promise.resolve(isCurrent());
+    }
+    return this.historyReloadRunner.run().then(isCurrent);
   }
 
   queueGapHistoryReload(runIds: Iterable<string>, displayedRunIds: Iterable<string> = []): void {
@@ -382,7 +405,7 @@ export class TuiSessionRunCoordinator {
     }
     const trackedRunIds = Array.from(runIds);
     if (trackedRunIds.length === 0) {
-      this.queueHistoryReload();
+      void this.queueHistoryReload();
       return;
     }
     for (const runId of trackedRunIds) {
@@ -390,7 +413,7 @@ export class TuiSessionRunCoordinator {
       reload.flags |= HISTORY_RELOAD_GAP_RECOVERY;
       this.historyReloadRuns.set(runId, reload);
     }
-    this.queueHistoryReload(trackedRunIds, trackedRunIds, displayedRunIds);
+    void this.queueHistoryReload(trackedRunIds, trackedRunIds, displayedRunIds);
   }
 
   clear(): void {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users resetting a TUI session would receive no visible confirmation when the Gateway's reset notification overlapped the command's session refresh. A later notification could also erase an acknowledgement already rendered.

## Why This Change Was Made

The reset response and notification both legitimately advance the selected session generation. The command's stale-incarnation guard then suppresses its acknowledgement, while the notification rebuilds the transcript without presenting an outcome. Keep that guard: it prevents delayed operations from changing a replacement conversation.

The authoritative reset notification now presents its own confirmation after the complete history-refresh queue drains. The coordinator reuses the existing TUI refresh coalescer and reports whether the waiting owner survived; agent, key, and generation checks discard retired receipts. This replaces the coordinator's separate in-flight/recursive-drain bookkeeping. Tracked-run snapshots move unchanged into that same owner. Empty persistence barriers still leave the first real reload immediate.

Same-ID deduplication is deliberately not used: the reset service preserves existing session IDs. There are no protocol, configuration, persistence, authorization, or dependency changes.

Provenance: the missing event receipt was made visible by the correct incarnation guard in #129681 (`c07d0e495f0f`, August 26, 2026; code author, PR author, and merger @steipete). This repair retains that protection.

## User Impact

The TUI shows a single reset confirmation after its transcript settles, including resets initiated by another client. Queued rebuilds, newer resets, conversation changes, and disposal cannot publish an old confirmation into the current conversation. Existing run finalization, history errors, and newly adopted active runs retain their behavior.

Release-note context: TUI reset confirmations survive overlapping session notifications and transcript refreshes.

## Evidence

On unchanged main `629a47e3cc20`, an integrated test using the real command handler, session-action owner, event handler, and rendered ChatLog passed without the notification and failed when the same-session reset notification arrived during refresh. The failing viewport contained only the session heading, not the reset confirmation; the eventual-assertion variant failed as well.

The repaired four owner suites pass **530 tests**:

```sh
node scripts/run-vitest.mjs src/tui/tui-event-handlers.test.ts src/tui/tui-session-run-coordinator.test.ts src/tui/tui-session-actions.test.ts src/tui/tui-command-handlers.test.ts
```

The full changed-file gate passes, including core and core-test types, lint, and all scoped guards; formatting also passes. Independent Codex review of the final diff plus complete owner/caller source reported no actionable findings at its P0 reporting threshold. Earlier lint findings were corrected before the final green gate.

Coverage includes notification-before-adoption, notification-during-refresh, delayed notification after acknowledgement, repeated resets across deferred queued history, same-key global-agent changes, replacement selections, new lifecycle invalidation, disposal, failed history, and active-run preservation. An existing immediate-reload test caught an empty-queue regression during refactoring; it is fixed without changing that test or its timing assertion.

Production LOC: **+76/-53 (net +23)**, including the unchanged tracked-run snapshot move. Tests: **+200/-3**. Documentation: **+2/-0**. The production growth supplies the missing user-visible event receipt and scoped queue completion; the existing coalescer replaces the separate scheduling path.

Proof boundary: these are deterministic owner-boundary and rendered-component tests, not a new native PTY or authenticated Gateway run. The earlier native PTY/auth-child/shell diagnostic holds remain in force, so the historical full-run failure is not claimed as re-executed or completely resolved. No new native recording was collected.

Exact-head hosted [CI run 33144231258](https://github.com/openclaw/openclaw/actions/runs/33144231258) completed successfully for `a12a5bc00290c95f80a99827ab1e8b771d19f47a`. Native main-baseline/PR-head review guards and artifact validation passed. Latest ClawSweeper read contains a review-start placeholder, not completed findings or Rank-up moves; independent review and the actual CI result are recorded above.
