### PR TITLE
fix(config): accept supported model pins outside curated catalogs

### DIFF
--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -142,7 +142,7 @@ openclaw config set channels.whatsapp.groups '["*"]' --strict-json
 
 `config get <path> --json` prints the redacted value as JSON instead of terminal-formatted text.
 
-When a write changes `agents.defaults.model` or a per-agent `agents.entries.*.model`, OpenClaw resolves each changed primary or fallback through the configured provider catalogs before writing. Unknown model references are rejected without changing the active config; run `openclaw models list` to see available models.
+When a write changes `agents.defaults.model` or a per-agent `agents.entries.*.model`, OpenClaw resolves each changed primary or fallback through the configured catalogs and the selected provider's model resolver before writing. Provider-supported exact `provider/model` pins are accepted even when absent from the curated picker; validation does not replace the selected model. Unknown model references are rejected without changing the active config. Run `openclaw models list` to browse the picker, or check the provider's documentation for an exact model ID. Successful validation does not prove that your account can call the model.
 
 <Note>
 Object assignment replaces the target path by default. Protected paths that commonly hold user-added entries refuse replacements that would remove existing entries unless you pass `--replace`: `agents.defaults.models`, `agents.entries`, `models.providers`, `models.providers.<id>`, `models.providers.<id>.models`, `plugins.entries`, and `auth.profiles`.

--- a/src/cli/config-model-validation.runtime.test.ts
+++ b/src/cli/config-model-validation.runtime.test.ts
@@ -1,0 +1,287 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveModelAsync } from "../agents/embedded-agent-runner/model.js";
+import {
+  acquireReadOnlyPreparedModelRuntime,
+  prepareModelRuntimeSnapshot,
+  PreparedModelRuntimeOwnerNotPublishedError,
+} from "../agents/prepared-model-runtime.js";
+import { resetPreparedModelRuntimeSnapshotsForTest } from "../agents/prepared-model-runtime.test-support.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  clearPluginLoaderCache,
+  loadOpenClawPlugins,
+  writePlugin,
+} from "../plugins/loader.test-fixtures.js";
+import {
+  withOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import { checkTouchedTextModelRefs } from "./config-model-validation.js";
+
+const primary = "pin-alpha/exact-supported";
+const fallback = "pin-beta/exact-supported";
+const providerIds = ["pin-alpha", "pin-beta", "pin-unrelated"];
+
+function clearRuntimeState() {
+  resetPreparedModelRuntimeSnapshotsForTest();
+  clearPluginLoaderCache();
+}
+
+async function withProviderFixtures(
+  run: (fixture: {
+    config: OpenClawConfig;
+    state: OpenClawTestState;
+    imported: (provider: string) => boolean;
+  }) => Promise<void>,
+) {
+  await withOpenClawTestState(
+    {
+      label: "config-model-runtime",
+      env: {
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+        OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+      },
+    },
+    async (state) => {
+      const imported = (provider: string) => fs.existsSync(state.path(`${provider}.imported`));
+      const plugins = providerIds.map((id) => {
+        const plugin = writePlugin({
+          id,
+          dir: state.path("plugins", id),
+          body: `
+const fs = require("node:fs");
+fs.writeFileSync(${JSON.stringify(state.path(`${id}.imported`))}, "loaded");
+module.exports = {
+  id: ${JSON.stringify(id)},
+  register(api) {
+    api.registerProvider({
+      id: ${JSON.stringify(id)},
+      label: ${JSON.stringify(id)},
+      auth: [],
+      resolveDynamicModel({ modelId }) {
+        if (modelId === "resolution-error") {
+          throw new Error("fixture dynamic resolution failed");
+        }
+        if (modelId !== "exact-supported") return undefined;
+        return {
+          id: modelId,
+          name: modelId,
+          provider: ${JSON.stringify(id)},
+          api: "openai-completions",
+          baseUrl: "https://provider.invalid/v1",
+          reasoning: false,
+          input: ["text"],
+          contextWindow: 32000,
+          maxTokens: 4096,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        };
+      },
+    });
+  },
+};`,
+        });
+        fs.writeFileSync(
+          path.join(plugin.dir, "openclaw.plugin.json"),
+          JSON.stringify({
+            id,
+            configSchema: { type: "object", additionalProperties: false, properties: {} },
+            providers: [id],
+            modelCatalog: { providers: { [id]: { models: [{ id: "catalog-model" }] } } },
+          }),
+        );
+        return plugin;
+      });
+      const config: OpenClawConfig = {
+        agents: {
+          defaults: { workspace: state.workspaceDir, model: { primary } },
+          entries: { main: { default: true } },
+        },
+        plugins: {
+          allow: [...providerIds],
+          load: { paths: plugins.map((plugin) => plugin.file) },
+          entries: Object.fromEntries(providerIds.map((id) => [id, { enabled: true }])),
+        },
+      };
+      try {
+        await run({ config, state, imported });
+      } finally {
+        clearRuntimeState();
+      }
+    },
+  );
+}
+
+describe("config model validation with provider runtime", () => {
+  beforeEach(() => {
+    clearRuntimeState();
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      throw new Error("Unexpected network request during config model validation");
+    });
+  });
+
+  afterEach(() => {
+    try {
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    } finally {
+      vi.restoreAllMocks();
+      clearRuntimeState();
+    }
+  });
+
+  afterAll(cleanupPluginLoaderFixturesForTest);
+
+  it("resolves an uncataloged fixture pin when its provider runtime is prepared", async () => {
+    await withProviderFixtures(async ({ config, state, imported }) => {
+      const lease = await acquireReadOnlyPreparedModelRuntime({
+        config,
+        agentId: "main",
+        agentDir: state.agentDir(),
+        workspaceDir: state.workspaceDir,
+        loadRuntimePlugins: true,
+        runtimePluginSelections: [{ provider: "pin-alpha", modelId: "exact-supported" }],
+      });
+      try {
+        const prepared = lease.snapshot;
+        expect(prepared.modelCatalog.entries).not.toContainEqual(
+          expect.objectContaining({ provider: "pin-alpha", id: "exact-supported" }),
+        );
+        const result = await resolveModelAsync(
+          "pin-alpha",
+          "exact-supported",
+          state.agentDir(),
+          config,
+          {
+            ...prepared.createStores(),
+            agentId: "main",
+            workspaceDir: state.workspaceDir,
+            preparedModelRuntime: prepared,
+          },
+        );
+        expect(result.error).toBeUndefined();
+        expect(result.model).toMatchObject({ provider: "pin-alpha", id: "exact-supported" });
+        expect(imported("pin-alpha")).toBe(true);
+        expect(imported("pin-beta")).toBe(false);
+        expect(imported("pin-unrelated")).toBe(false);
+      } finally {
+        lease.release();
+      }
+    });
+  });
+
+  it("accepts a fresh supported exact primary without changing the input or loading unrelated plugins", async () => {
+    await withProviderFixtures(async ({ config, imported }) => {
+      const original = structuredClone(config);
+      expect(providerIds.some(imported)).toBe(false);
+
+      const result = await checkTouchedTextModelRefs({
+        config,
+        touchedPaths: [["agents", "defaults", "model", "primary"]],
+      });
+
+      expect(config).toEqual(original);
+      expect(imported("pin-unrelated")).toBe(false);
+      expect(result).toEqual({ refsChecked: 1, refsTotal: 1, errors: [] });
+    });
+  });
+
+  it.each([
+    { modelId: "unsupported", refsChecked: 1, error: "Unknown model: pin-alpha/unsupported" },
+    {
+      modelId: "resolution-error",
+      refsChecked: 0,
+      error: "Unable to validate model reference: fixture dynamic resolution failed",
+    },
+  ])(
+    "rejects $modelId and releases its isolated runtime owner",
+    async ({ modelId, refsChecked, error }) => {
+      await withProviderFixtures(async ({ config, state, imported }) => {
+        config.agents!.defaults!.model = { primary: `pin-alpha/${modelId}` };
+
+        const result = await checkTouchedTextModelRefs({
+          config,
+          touchedPaths: [["agents", "defaults", "model", "primary"]],
+        });
+
+        expect(result).toEqual({
+          refsChecked,
+          refsTotal: 1,
+          errors: [expect.stringContaining(error)],
+        });
+        expect(imported("pin-unrelated")).toBe(false);
+        await expect(
+          prepareModelRuntimeSnapshot({
+            config,
+            agentId: "main",
+            agentDir: state.agentDir(),
+            workspaceDir: state.workspaceDir,
+            readOnly: true,
+            loadRuntimePlugins: true,
+            runtimePluginSelections: [{ provider: "pin-alpha", modelId, agentId: "main" }],
+          }),
+        ).rejects.toBeInstanceOf(PreparedModelRuntimeOwnerNotPublishedError);
+      });
+    },
+  );
+
+  it("validates distinct primary and fallback providers for every inheriting agent in one operation", async () => {
+    await withProviderFixtures(async ({ config, state, imported }) => {
+      config.agents!.defaults!.model = { primary, fallbacks: [fallback] };
+      config.agents!.entries!.ops = { workspace: state.workspaceDir };
+      const original = structuredClone(config);
+
+      const result = await checkTouchedTextModelRefs({
+        config,
+        touchedPaths: [["agents", "defaults", "model"]],
+      });
+
+      expect(config).toEqual(original);
+      expect(imported("pin-unrelated")).toBe(false);
+      expect(result).toEqual({ refsChecked: 4, refsTotal: 4, errors: [] });
+    });
+  });
+
+  it.each(["disabled", "denied", "not allowed"] as const)(
+    "rejects a %s provider even when an ambient registry has its hook",
+    async (policy) => {
+      await withProviderFixtures(async ({ config, state, imported }) => {
+        const ambient = loadOpenClawPlugins({
+          config,
+          workspaceDir: state.workspaceDir,
+          onlyPluginIds: ["pin-alpha"],
+          activate: true,
+        });
+        expect(ambient.providers).toContainEqual(
+          expect.objectContaining({
+            provider: expect.objectContaining({
+              id: "pin-alpha",
+              resolveDynamicModel: expect.any(Function),
+            }),
+          }),
+        );
+        const blocked = structuredClone(config);
+        if (policy === "disabled") {
+          blocked.plugins!.entries!["pin-alpha"] = { enabled: false };
+        } else if (policy === "denied") {
+          blocked.plugins!.deny = ["pin-alpha"];
+        } else {
+          blocked.plugins!.allow = ["pin-beta", "pin-unrelated"];
+        }
+
+        const result = await checkTouchedTextModelRefs({
+          config: blocked,
+          touchedPaths: [["agents", "defaults", "model", "primary"]],
+        });
+
+        expect(result).toEqual({
+          refsChecked: 1,
+          refsTotal: 1,
+          errors: [expect.stringContaining("Unknown model: pin-alpha/exact-supported")],
+        });
+        expect(imported("pin-unrelated")).toBe(false);
+      });
+    },
+  );
+});

--- a/src/cli/config-model-validation.ts
+++ b/src/cli/config-model-validation.ts
@@ -14,7 +14,6 @@ import {
   resolveConfiguredModelRef,
   resolveModelRefFromString,
 } from "../agents/model-selection-shared.js";
-import type { loadPreparedModelCatalogOwnerSnapshot } from "../agents/prepared-model-catalog.js";
 import {
   containsEnvVarReference,
   type EnvSubstitutionWarning,
@@ -387,22 +386,18 @@ async function createRuntimeModelRefResolver(): Promise<ConfigModelRefResolver> 
     import("../agents/agent-scope.js"),
     import("../agents/model-selection.js"),
   ]);
-  const preparedByAgent = new Map<
-    string,
-    Awaited<ReturnType<typeof loadPreparedModelCatalogOwnerSnapshot>>
-  >();
   let modelModules:
     | Promise<
         [
           typeof import("../agents/embedded-agent-runner/model.js"),
-          typeof import("../agents/prepared-model-catalog.js"),
+          typeof import("../agents/prepared-model-runtime.js"),
         ]
       >
     | undefined;
   const loadModelModules = () =>
     (modelModules ??= Promise.all([
       import("../agents/embedded-agent-runner/model.js"),
-      import("../agents/prepared-model-catalog.js"),
+      import("../agents/prepared-model-runtime.js"),
     ]));
 
   return async ({ config, ref }) => {
@@ -412,8 +407,9 @@ async function createRuntimeModelRefResolver(): Promise<ConfigModelRefResolver> 
     if (!resolvedRef) {
       return `Unknown model: ${ref.value}`;
     }
+    const { provider, model } = resolvedRef;
     // CLI backends validate their own ids and do not require a roster-owned catalog.
-    if (modelSelection.isCliProvider(resolvedRef.provider, config)) {
+    if (modelSelection.isCliProvider(provider, config)) {
       return undefined;
     }
     const targetAgentId =
@@ -422,38 +418,33 @@ async function createRuntimeModelRefResolver(): Promise<ConfigModelRefResolver> 
       agentScope.resolveDefaultAgentId(config);
     const agentDir = agentScope.resolveAgentDir(config, targetAgentId);
     const workspaceDir = agentScope.resolveAgentWorkspaceDir(config, targetAgentId);
-    const [modelRuntime, preparedCatalog] = await loadModelModules();
+    const [modelRuntime, preparedRuntime] = await loadModelModules();
 
-    let prepared = preparedByAgent.get(targetAgentId);
-    if (!prepared) {
-      prepared = await preparedCatalog.loadPreparedModelCatalogOwnerSnapshot({
-        agentId: targetAgentId,
-        agentDir,
-        config,
-        readOnly: true,
-        workspaceDir,
-      });
-      preparedByAgent.set(targetAgentId, prepared);
-    }
-    const stores = prepared.createStores();
-    const resolution = await modelRuntime.resolveModelAsync(
-      resolvedRef.provider,
-      resolvedRef.model,
+    // Exact pins need provider hooks in their generation; a catalog-only snapshot cannot load them.
+    const lease = await preparedRuntime.acquireReadOnlyPreparedModelRuntime({
+      agentId: targetAgentId,
       agentDir,
       config,
-      {
+      workspaceDir,
+      loadRuntimePlugins: true,
+      runtimePluginSelections: [{ provider, modelId: model, agentId: targetAgentId }],
+    });
+    try {
+      const stores = lease.snapshot.createStores();
+      const resolution = await modelRuntime.resolveModelAsync(provider, model, agentDir, config, {
+        ...stores,
         agentId: targetAgentId,
         allowBundledStaticCatalogFallback: true,
-        authStorage: stores.authStorage,
         ...(ref.authProfileId ? { authProfileId: ref.authProfileId } : {}),
-        modelRegistry: stores.modelRegistry,
-        preparedModelRuntime: prepared,
+        preparedModelRuntime: lease.snapshot,
         workspaceDir,
-      },
-    );
-    return resolution.model
-      ? undefined
-      : (resolution.error ?? `Unknown model: ${resolvedRef.provider}/${resolvedRef.model}`);
+      });
+      return resolution.model
+        ? undefined
+        : (resolution.error ?? `Unknown model: ${provider}/${model}`);
+    } finally {
+      lease.release();
+    }
   };
 }
 


### PR DESCRIPTION
Closes #131489 (fresh configuration rejects provider-supported exact model pins outside the curated catalog).

## What Problem This Solves

Fixes an issue where users setting a supported exact primary or fallback model through `openclaw config set` receive `Unknown model` when that model is absent from the curated picker catalog. Reproduced on main `365df5496dd67652f32f6addf1312c789c794020` with a fresh isolated setup and `anthropic/claude-sonnet-4-6`.

This is separate from #131276 (long-history migration memory/performance repair). Existing saved-config/Doctor preservation is not the failing path, and no upgraded provider-turn failure is claimed. Anthropic's [public lifecycle documentation](https://platform.claude.com/docs/en/about-claude/model-deprecations) lists this exact model as Active; it is not retired.

## Why This Change Was Made

Validation was taking a catalog-only read-only snapshot, then asking the embedded resolver to resolve a model requiring a provider hook. The immutable-generation guard correctly refused to load a provider outside that captured generation. The validator now uses the existing selected-provider read-only runtime preparation seam, holds its lease through resolution, and releases it in `finally`.

The incomplete agent-only snapshot cache is removed rather than extended: primary/fallback references can select different providers or runtimes for the same agent. No generation-authority bypass, broad eager plugin loading, provider-specific exception, catalog-row restoration, selected-model replacement, new config/env option, schema change, or dependency change is introduced. The existing permissive `models set` command contract is unchanged.

Production LOC: +24/-33, net **-9**. Tests: +287. Documentation: one paragraph in the [Config CLI reference](https://docs.openclaw.ai/cli/config) distinguishes exact provider-supported pins from curated picker membership and account entitlement.

## User Impact

Supported exact pins can be saved even when the picker intentionally omits them. Primary and fallback validation remains scoped to the correct agent/provider generation. Unsupported IDs and disabled/denied/unallowed provider plugins remain rejected, without changing the active config. The picker remains curated, and exact pins are not automatically replaced.

Release-note context: config writes now accept provider-supported exact model pins absent from curated catalogs while preserving unknown-model rejection and plugin activation policy.

## Evidence

### Failing regression before the fix

The new test uses tiny real provider plugins with manifest ownership and curated catalogs that omit the accepted exact IDs. It exercises real config validation, plugin loading, prepared generations, and embedded model resolution—no injected resolver success. On unchanged production code, two acceptance cases fail with `Unknown model` (fresh primary and cross-provider primary/fallback inheritance), while explicit selected-provider preparation resolves the same fixture ID.

The passing regression also covers unsupported and throwing resolution with lease cleanup; disabled, denied, and unallowed providers despite an ambient loaded hook; unchanged input config; and an enabled unrelated plugin that must not load. Unexpected fetch requests fail the tests.

### Focused validation

189 tests passed across these commands:

```bash
node scripts/run-vitest.mjs src/cli/config-model-validation.runtime.test.ts src/cli/config-model-validation.test.ts src/cli/config-model-validation.env.test.ts src/agents/embedded-agent-runner/model.generation-scope.test.ts src/agents/runtime-plugins.test.ts src/agents/harness/runtime-plugin.test.ts extensions/anthropic/index.test.ts
```

```bash
OPENCLAW_E2E_SKIP_BUILD=1 node scripts/run-vitest.mjs src/commands/models.set.e2e.test.ts
```

The model-command suite owns its fixtures; the supported skip-build flag prevents an unrelated private-QA rebuild. It is command-handler contract proof, not a live provider turn.

Passed formatting, core/test typechecking, lint, boundaries, dead-export and import-cycle gates:

```bash
node scripts/check-changed.mjs -- docs/cli/config.md src/cli/config-model-validation.ts src/cli/config-model-validation.runtime.test.ts
```

Full build passed, with no `INEFFECTIVE_DYNAMIC_IMPORT` warning:

```bash
pnpm build
```

### Real isolated CLI before and after

The built launcher was run with fresh HOME/state/config paths, an explicit non-secret environment allowlist, and macOS sandbox network denial:

```bash
node openclaw.mjs config set agents.defaults.model.primary anthropic/claude-sonnet-4-6
```

Before: exit 1, `Unknown model: anthropic/claude-sonnet-4-6`, no config written.

After: exit 0, `Updated agents.defaults.model.primary. Change will apply without restarting the gateway.`, and the saved primary is exactly `anthropic/claude-sonnet-4-6`.

All nine offline CLI checks passed: fresh primary, unknown-ID rejection with byte-identical saved config, saved config validation, no-write dry-run, primary/fallback exact pins, per-agent exact pin, disabled-provider rejection without mutation, custom exact-case model/provider-row preservation, and fresh Anthropic catalog still containing six rows without Sonnet 4.6.

The isolated pnpm wrapper attempted package-manager bootstrap over the network, so real CLI proof uses the built `openclaw.mjs` launcher directly. No OpenClaw credentials were retrieved and no provider API request was made. Account entitlement and authenticated provider-turn behavior remain outside this proof.

AI-assisted. The fresh pre-commit Codex autoreview reported no actionable findings at its configured P0-only threshold. The clean rebase preserved the reviewed patch exactly (`git range-diff`); no behavioral edits were made after review. Hosted CI [run 33144765512](https://github.com/openclaw/openclaw/actions/runs/33144765512) completed successfully on exact head `420112250e8fc29ba036b291303fd93f92c4f44c`. Native review artifacts validated with zero findings; `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 131562` and `scripts/pr merge-run 131562` passed through the ordinary hosted-CI path without bypass. Merged as [fe721853d7f574a34158f22c2e9d8ce0973a499c](https://github.com/openclaw/openclaw/commit/fe721853d7f574a34158f22c2e9d8ce0973a499c); the landed production and regression-test files match the tested head.

### Related follow-up

Cold effective-tool inventory has an analogous unselected read-only acquisition path. It is recorded as a separate boundary-reproduction follow-up; its user-visible impact has not been proven and it is not included in this patch.

### Refreshed caller validation

Refreshed once onto `ec3a8343c5de4985308aa004588dcfc1f35db307` because #131369 changed the config mutation caller and roster normalization. Preserved its legacy-roster documentation paragraph. Candidate `420112250e8fc29ba036b291303fd93f92c4f44c` is patch-identical to the reviewed repair. All **329 tests passed** across:

```bash
node scripts/run-vitest.mjs src/cli/config-model-validation.runtime.test.ts src/cli/config-model-validation.test.ts src/cli/config-model-validation.env.test.ts src/cli/config-cli.test.ts src/cli/config-cli.integration.test.ts src/cli/config-cli.roster.integration.test.ts
```

Provenance: the catalog-only validator was introduced by #111571 (`8bec61bab1996c967468ff9be04645693a5f7375`, July 20, 2026); explicit prepared-generation propagation followed in #115527 (`83a3975eca9cd13be625ae1b90122f5de1db0a1d`, July 29, 2026). Both PRs were authored and merged by @steipete. These are ownership-path provenance, not a claim that either alone caused the later curated-catalog symptom.

Refreshed candidate proof also passed `pnpm build` (33m 31s, no `INEFFECTIVE_DYNAMIC_IMPORT`) and all nine offline built-CLI cases under the same fresh-state, non-secret environment allowlist and OS network denial described above. The picker still contains six Anthropic rows and omits Sonnet 4.6. No provider API or credential access was used.
