### PR TITLE
fix(ui): keep typed input in the selected dialog field

### DIFF
--- a/ui/src/components/modal-dialog.browser.test.ts
+++ b/ui/src/components/modal-dialog.browser.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getRenderedModalDialog } from "../test-helpers/modal-dialog.ts";
+import "./modal-dialog.ts";
+
+const browserMode = "__vitest_browser__" in globalThis;
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.append(container);
+});
+
+afterEach(() => {
+  container.remove();
+});
+
+async function mountModal(host = container, variant = "", autofocus = true) {
+  const modal = document.createElement("openclaw-modal-dialog");
+  modal.label = "Edit details";
+  modal.className = variant;
+  modal.style.setProperty("--wa-transition-normal", "150ms");
+  const name = document.createElement("input");
+  name.autofocus = autofocus;
+  name.value = "Original name";
+  name.setAttribute("aria-label", "Name");
+  const notes = document.createElement("textarea");
+  notes.setAttribute("aria-label", "Notes");
+  modal.append(name, notes);
+  modal.addEventListener("modal-cancel", (event) => {
+    if (event.target === modal) {
+      modal.hide();
+    }
+  });
+  host.append(modal);
+  const rendered = await getRenderedModalDialog(host);
+  await Promise.all(rendered.dialog.getAnimations().map((animation) => animation.finished));
+  return { ...rendered, name, notes };
+}
+
+describe.runIf(browserMode)("modal native focus ownership", () => {
+  it.each(["", "palette", "drawer"])(
+    "preserves selected content through chrome focus and retained reopen (%s)",
+    async (variant) => {
+      const { userEvent } = await import("vitest/browser");
+      const trigger = document.createElement("button");
+      trigger.textContent = "Open editor";
+      container.append(trigger);
+      trigger.focus();
+      const { modal, dialog, name, notes } = await mountModal(container, variant);
+      expect(document.activeElement).toBe(name);
+
+      notes.focus();
+      // Web Awesome's opening frame calls this real native method. It must not
+      // redirect text after the operator has already selected slotted content.
+      dialog.focus();
+      expect(document.activeElement).toBe(notes);
+      await userEvent.keyboard("First draft");
+      expect(notes.value).toBe("First draft");
+      expect(name.value).toBe("Original name");
+
+      await userEvent.keyboard("{Escape}");
+      await expect.poll(() => dialog.open).toBe(false);
+      await expect.poll(() => document.activeElement).toBe(trigger);
+      expect(modal.isConnected).toBe(true);
+
+      modal.show();
+      await expect.poll(() => dialog.open).toBe(true);
+      await expect.poll(() => document.activeElement).toBe(name);
+      notes.focus();
+      dialog.focus();
+      expect(document.activeElement).toBe(notes);
+      await userEvent.keyboard(" continued");
+      expect(notes.value).toBe("First draft continued");
+      expect(name.value).toBe("Original name");
+      expect(
+        modal.shadowRoot?.querySelector("wa-dialog")?.shadowRoot?.querySelector("dialog"),
+      ).toBe(dialog);
+    },
+  );
+
+  it("keeps nested modal focus and dismissal inside the owning layer", async () => {
+    const { userEvent } = await import("vitest/browser");
+    const outer = await mountModal();
+    outer.notes.focus();
+    const nestedHost = document.createElement("div");
+    outer.modal.append(nestedHost);
+    const inner = await mountModal(nestedHost);
+    expect(document.activeElement).toBe(inner.name);
+
+    inner.notes.focus();
+    inner.dialog.focus();
+    expect(document.activeElement).toBe(inner.notes);
+    await userEvent.keyboard("Nested draft");
+    expect(inner.notes.value).toBe("Nested draft");
+    expect(outer.notes.value).toBe("");
+
+    await userEvent.keyboard("{Escape}");
+    await expect.poll(() => inner.dialog.open).toBe(false);
+    await expect.poll(() => document.activeElement).toBe(outer.notes);
+    expect(outer.dialog.open).toBe(true);
+    outer.dialog.focus();
+    expect(document.activeElement).toBe(outer.notes);
+  });
+
+  it("preserves selected content after showing inside a shadow root", async () => {
+    const { userEvent } = await import("vitest/browser");
+    const shadow = container.attachShadow({ mode: "open" });
+    const host = document.createElement("div");
+    shadow.append(host);
+    const { dialog, webAwesomeDialog, name, notes } = await mountModal(host);
+    expect(shadow.activeElement).toBe(name);
+
+    notes.focus();
+    dialog.focus();
+    expect(shadow.activeElement).toBe(notes);
+    webAwesomeDialog.dispatchEvent(new CustomEvent("wa-after-show", { bubbles: true }));
+    expect(shadow.activeElement).toBe(notes);
+    await userEvent.keyboard("Shadow draft");
+    expect(notes.value).toBe("Shadow draft");
+    expect(name.value).toBe("Original name");
+  });
+
+  it("leaves native chrome focused when there is no autofocus target or displaced field", async () => {
+    const { modal, dialog } = await mountModal(container, "", false);
+    expect(dialog.matches(":focus")).toBe(true);
+    expect(document.activeElement).toBe(modal);
+    expect(dialog.getAttribute("aria-label")).toBe("Edit details");
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+  });
+});

--- a/ui/src/components/modal-dialog.ts
+++ b/ui/src/components/modal-dialog.ts
@@ -192,8 +192,8 @@ export class OpenClawModalDialog extends OpenClawLitElement {
         without-header
         light-dismiss
         .label=${this.label}
-        @wa-show=${this.handleShow}
-        @wa-after-show=${this.handleAfterShow}
+        @focusin=${this.handleInitialFocus}
+        @wa-after-show=${this.handleInitialFocus}
         @wa-after-hide=${this.handleAfterHide}
         @wa-hide=${this.handleHide}
       >
@@ -260,31 +260,28 @@ export class OpenClawModalDialog extends OpenClawLitElement {
     }
   }
 
-  private handleAfterShow = (event?: Event) => {
-    if (event && event.target !== event.currentTarget) {
+  private handleInitialFocus = (event: Event) => {
+    if (event.target !== event.currentTarget) {
       return;
     }
     if (!this.isConnected) {
       return;
     }
-    // Both the scheduled show hook and wa-after-show land here, and the second
-    // arrives after the open animation. If focus already moved to a slotted
-    // field (user click, autofill, e2e input), refocusing the autofocus target
-    // would steal it mid-typing; `this` means focus sits on dialog chrome.
-    const active = document.activeElement;
+    // Late animation completion must not replace focus already inside the form.
+    const root = this.getRootNode();
+    const active =
+      root instanceof ShadowRoot ? root.activeElement : this.ownerDocument.activeElement;
     if (active instanceof HTMLElement && active !== this && this.contains(active)) {
       return;
     }
-    const autofocusTarget = this.querySelector<HTMLElement>("[autofocus]");
-    autofocusTarget?.focus({ preventScroll: true });
-  };
-
-  private handleShow = (event: Event) => {
-    if (event.target !== event.currentTarget) {
-      return;
-    }
-    // Web Awesome cannot see autofocus targets through this adapter's slot.
-    queueMicrotask(() => requestAnimationFrame(() => this.handleAfterShow()));
+    // Web Awesome's opening frame focuses its native dialog without seeing our
+    // slotted content. Restore the field it just displaced before input arrives.
+    const previous = event instanceof FocusEvent ? event.relatedTarget : null;
+    const target =
+      previous instanceof HTMLElement && this.contains(previous)
+        ? previous
+        : this.querySelector<HTMLElement>("[autofocus]");
+    target?.focus({ preventScroll: true });
   };
 
   private handleAfterHide = (event: Event) => {

--- a/ui/src/pages/workboard/view.test.ts
+++ b/ui/src/pages/workboard/view.test.ts
@@ -1136,7 +1136,6 @@ describe("renderWorkboard", () => {
       expect(launcher).toBeInstanceOf(HTMLButtonElement);
       launcher?.focus();
       launcher?.click();
-      await nextFrame();
 
       const modal = container.querySelector("openclaw-modal-dialog");
       const { dialog } = await getRenderedModalDialog(container);
@@ -1172,7 +1171,8 @@ describe("renderWorkboard", () => {
     try {
       renderInto(container, props);
       container.querySelector<HTMLButtonElement>(".workboard-toolbar__actions .primary")?.click();
-      await nextFrame();
+      const { dialog } = await getRenderedModalDialog(container);
+      expect(dialog.open).toBe(true);
 
       const select = container.querySelector<HTMLElement & { open: boolean }>(
         ".workboard-draft .workboard-select",
@@ -1211,7 +1211,6 @@ describe("renderWorkboard", () => {
       expect(launcher).toBeInstanceOf(HTMLButtonElement);
       launcher?.focus();
       launcher?.click();
-      await nextFrame();
 
       const modal = container.querySelector("openclaw-modal-dialog");
       const { dialog } = await getRenderedModalDialog(container);
@@ -1249,7 +1248,8 @@ describe("renderWorkboard", () => {
       );
       launcher?.focus();
       launcher?.click();
-      await nextFrame();
+      const { dialog } = await getRenderedModalDialog(container);
+      expect(dialog.open).toBe(true);
 
       const titleInput = container.querySelector<HTMLInputElement>(".workboard-draft__title");
       expect(document.activeElement).toBe(titleInput);
@@ -1286,7 +1286,8 @@ describe("renderWorkboard", () => {
       );
       launcher?.focus();
       launcher?.click();
-      await nextFrame();
+      const { dialog } = await getRenderedModalDialog(container);
+      expect(dialog.open).toBe(true);
 
       state.detailCardId = null;
       renderInto(container, props);


### PR DESCRIPTION
## What Problem This Solves

Related: #115168 (the earlier fix for focus theft after the opening animation).

Fixes an issue where users typing into a Control UI dialog could have their input redirected to another field when the dialog's opening focus callback ran after they selected a field. In the Secrets form, a controlled native-browser reproduction put Value input into Name, which changed the selected access mode and removed the allowed-hosts field.

## Why This Change Was Made

The shared modal adapter now handles native focus changes at the moment they occur, preserving the slotted field that was displaced. It removes the adapter's extra delayed focus callback and reads focus from the modal's own document or shadow root, while keeping Web Awesome responsible for opening, modality, animations, dismissal, and return focus. No Secrets classification, credential, configuration, storage, or dependency behavior changes.

Production LOC: +16/-19 (net -3). Tests: +136/-5. AI-assisted; independent Codex reviews of the modal repair and CI follow-up found no actionable findings (static P0 review, no test rerun).

Provenance: the deferred slotted-autofocus path came from #106865, authored and merged by @steipete on July 14, 2026; #115168, also authored and merged by @steipete on July 28, fixed the later animation callback but retained this first-frame gap. This identifies code history, not the unrecorded event ordering of the original full-suite failure.

## User Impact

Dialog input stays in the field the user selected, including ordinary dialogs, palettes, drawers, retained dialogs, nested dialogs, and dialogs inside shadow roots. Initial autofocus and normal close/return-focus behavior remain covered.

## Evidence

- Native Chromium regression against unmodified baseline `629a47e3cc20`: four selected-field focus cases failed; the no-autofocus control passed. A sixth case exposed late animation focus theft inside a real shadow root even after the early-focus repair. With the complete repair, all six pass. The permanent test uses real native focus, typed text, Escape, retained/nested dialogs, and the public animation-completion lifecycle event; it does not intercept timers or animation frames.
- Full owner and sibling validation: seven files, 63 tests passed, including existing modal, confirmation, input, responsive file-preview, image-lightbox, and Secrets view coverage. Image lightbox is an actual shadow-root modal caller with an autofocus control.
- CI follow-through: the [first run](https://github.com/openclaw/openclaw/actions/runs/33145292647) exposed the same Workboard initial-focus failure in both UI test routes. Its unchanged full file reproduced locally (97 passed, one failed): one animation frame did not mean the dialog was ready. Five opening checks now consistently use the existing modal-ready helper; all original focus/Escape/disconnection assertions remain, and the formerly under-synchronized cases additionally assert that the dialog is open. All 98 tests pass in both the root isolated and UI-owned routes. Production is unchanged by this follow-up.
- Final native owner/sibling rerun passes eight files, 64 tests: the prior 63 plus the real Workboard Chromium inert-background and opener-restoration test.
- Final test routing was verified separately: the root jsdom lane passes 15 existing modal tests and intentionally skips the six native-only cases; the native Chromium lane executes and passes all six. This uses the same browser-only registration as existing browser tests.
- The original three Secrets E2E cases all passed. A separate controlled native-frame diagnostic changed from one pass/one failure to two passes; the trace confirms the previous Value field is restored synchronously before text arrives. The instrumentation stays private and is not part of this patch.
- Scope limit: the controlled schedule proves the focus-ownership defect. The earlier full-suite failure had no focus trace, so this does not claim to reconstruct its historical execution order.
- Harness follow-up: the earlier five-case E2E/probe run passed and exited zero, but Vitest printed a fork-termination timeout warning for the Secrets worker afterward. The final 63-test owner/sibling run and a separate final run of the unchanged three Secrets E2E cases ended cleanly. This patch does not claim to fix worker teardown or explain the old shared-order warning.
- Final independent review: clean. Full changed-file gate passed for committed base `629a47e3cc20` → final head `dc74b888e01b`, including formatting, typechecking, lint, dependency/architecture guards, dead-code scans, and UI catalog checks.

Focused commands:

```sh
# From ui/; canonical wrapper, native Chromium plus owner/sibling tests.
node ../scripts/run-vitest.mjs run --config vitest.config.ts src/components/modal-dialog.browser.test.ts src/components/modal-dialog.test.ts src/components/confirm-dialog.test.ts src/components/input-dialog.test.ts src/components/file-preview-modal.browser.test.ts src/components/image-lightbox.test.ts src/pages/secrets/view.test.ts src/pages/workboard/view.browser.test.ts --reporter=verbose
# From repository root; complete Workboard file, original case order.
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-isolated.config.ts ui/src/pages/workboard/view.test.ts --reporter=verbose
# From repository root; unchanged full Secrets GUI file.
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/pages/secrets/secrets.e2e.test.ts --reporter=verbose
```

Controlled first-frame reproduction, synthetic data only. These show the first-frame repair; the final patch also includes the shadow-root completion fix covered above.

Before: typing intended for Value lands in Name and changes the form mode.

![Before: synthetic Value text redirected into Name](https://github.com/user-attachments/assets/4eaddf30-28e5-4d26-9a7e-0246d18d71cb)

After: Name stays unchanged, Value receives the text, and Protected secret plus Allowed hosts remain present.

![After: synthetic text stays in Value](https://github.com/user-attachments/assets/824ce8ab-6055-4cee-a21e-17488c2b2b0c)
