### PR TITLE
fix(memory-core): clean up shadow reindex temp files left by the old .tmp- naming

### DIFF
--- a/extensions/memory-core/doctor-contract-api.test.ts
+++ b/extensions/memory-core/doctor-contract-api.test.ts
@@ -2134,15 +2134,23 @@ describe("memory-core doctor dreaming migration", () => {
     await expect(fs.access(legacyPath)).resolves.toBeUndefined();
     await expect(fs.access(alternateRetryPath)).resolves.toBeUndefined();
 
-    const retryEntriesBefore = (await fs.readdir(path.join(stateDir, "memory")))
-      .filter((entry) => entry.startsWith("main.retry-"))
-      .toSorted();
+    // Excludes .reindex-lock.sqlite: the legacy-orphan sweep now runs against
+    // every processed legacy path, including retry-marked ones, and (like
+    // every other reindex-lock use in this codebase) leaves its
+    // coordination lock file on disk after release() -- a real, harmless
+    // side effect of a working sweep, not something this archival-
+    // completeness assertion is about.
+    const listRetryEntries = async () =>
+      (await fs.readdir(path.join(stateDir, "memory")))
+        .filter(
+          (entry) => entry.startsWith("main.retry-") && !entry.endsWith(".reindex-lock.sqlite"),
+        )
+        .toSorted();
+    const retryEntriesBefore = await listRetryEntries();
     const secondRun = await legacyMemoryIndexMigration().migrateLegacyState(
       migrationParams(repairedConfig),
     );
-    const retryEntriesAfter = (await fs.readdir(path.join(stateDir, "memory")))
-      .filter((entry) => entry.startsWith("main.retry-"))
-      .toSorted();
+    const retryEntriesAfter = await listRetryEntries();
     expect(secondRun.changes).not.toEqual(
       expect.arrayContaining([
         expect.stringContaining("Copied Memory Core legacy memory index sidecar retry path"),

--- a/extensions/memory-core/src/memory/manager-db.test.ts
+++ b/extensions/memory-core/src/memory/manager-db.test.ts
@@ -447,4 +447,23 @@ describe("memory manager database publication", () => {
     await expectPathMissing(lockedShadow);
     await expect(fs.access(youngShadow)).resolves.toBeUndefined();
   });
+
+  it("removes aged orphan shadows left over from the pre-8b7269d1978 .tmp- naming", async () => {
+    const databasePath = path.join(fixtureRoot, "agent.sqlite");
+    const database = new DatabaseSync(databasePath);
+    database.close();
+    const oldLegacyShadow = `${databasePath}.tmp-11111111-2222-3333-4444-555555555555`;
+    const old = new Date(Date.now() - 48 * 60 * 60_000);
+
+    for (const suffix of ["", "-wal", "-shm"]) {
+      await fs.writeFile(`${oldLegacyShadow}${suffix}`, "orphan");
+      await fs.utimes(`${oldLegacyShadow}${suffix}`, old, old);
+    }
+
+    cleanupAgedMemoryReindexTempFiles(databasePath);
+
+    await expectPathMissing(oldLegacyShadow);
+    await expectPathMissing(`${oldLegacyShadow}-wal`);
+    await expectPathMissing(`${oldLegacyShadow}-shm`);
+  });
 });

--- a/extensions/memory-core/src/memory/manager-db.ts
+++ b/extensions/memory-core/src/memory/manager-db.ts
@@ -269,20 +269,24 @@ export function removeMemoryDatabaseFiles(dbPath: string): void {
   }
 }
 
-/** Remove crash-left shadow databases only when no full reindex is active. */
-export function cleanupAgedMemoryReindexTempFiles(dbPath: string, nowMs = Date.now()): void {
+/** Remove crash-left shadow databases only when no full reindex is active.
+ * Returns the shadow base names actually removed, so callers that report
+ * changes (doctor migrations) can say what happened instead of just that
+ * the sweep ran. */
+export function cleanupAgedMemoryReindexTempFiles(dbPath: string, nowMs = Date.now()): string[] {
+  const removedShadowBaseNames: string[] = [];
   if (!isRegularFile(dbPath)) {
-    return;
+    return removedShadowBaseNames;
   }
 
   let reindexLock: MemoryReindexLockHandle | undefined;
   try {
     reindexLock = tryAcquireMemoryReindexLock(dbPath);
   } catch {
-    return;
+    return removedShadowBaseNames;
   }
   if (!reindexLock) {
-    return;
+    return removedShadowBaseNames;
   }
 
   try {
@@ -293,7 +297,7 @@ export function cleanupAgedMemoryReindexTempFiles(dbPath: string, nowMs = Date.n
     try {
       entries = fs.readdirSync(dir, { withFileTypes: true });
     } catch {
-      return;
+      return removedShadowBaseNames;
     }
 
     for (const entry of entries) {
@@ -336,12 +340,14 @@ export function cleanupAgedMemoryReindexTempFiles(dbPath: string, nowMs = Date.n
           fs.rmSync(filePath, { force: true });
         } catch {}
       }
+      removedShadowBaseNames.push(shadowBaseName);
     }
   } finally {
     try {
       reindexLock.release();
     } catch {}
   }
+  return removedShadowBaseNames;
 }
 
 export function openMemoryDatabaseAtPath(

--- a/extensions/memory-core/src/memory/manager-db.ts
+++ b/extensions/memory-core/src/memory/manager-db.ts
@@ -31,6 +31,11 @@ const MEMORY_REINDEX_ENTRY_SUFFIXES = ["-wal", "-shm", "-journal", ""] as const;
 const MEMORY_REINDEX_UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 const MEMORY_REINDEX_ORPHAN_MIN_AGE_MS = 24 * 60 * 60_000;
+// `.memory-reindex-<uuid>` is the current shadow-db prefix (introduced in
+// 8b7269d1978). `.tmp-<uuid>` is the prior scheme it replaced; deployments
+// upgraded across that change can still carry orphaned shadow files under
+// the old name, which this cleanup must also recognize or they leak forever.
+const MEMORY_REINDEX_BASE_NAME_PREFIXES = ["memory-reindex-", "tmp-"] as const;
 
 function resolveMemoryReindexBaseName(
   databaseBaseName: string,
@@ -41,12 +46,14 @@ function resolveMemoryReindexBaseName(
       continue;
     }
     const baseName = entryName.slice(0, entryName.length - suffix.length);
-    const prefix = `${databaseBaseName}.memory-reindex-`;
-    if (
-      baseName.startsWith(prefix) &&
-      MEMORY_REINDEX_UUID_PATTERN.test(baseName.slice(prefix.length))
-    ) {
-      return baseName;
+    for (const reindexPrefix of MEMORY_REINDEX_BASE_NAME_PREFIXES) {
+      const prefix = `${databaseBaseName}.${reindexPrefix}`;
+      if (
+        baseName.startsWith(prefix) &&
+        MEMORY_REINDEX_UUID_PATTERN.test(baseName.slice(prefix.length))
+      ) {
+        return baseName;
+      }
     }
   }
   return undefined;

--- a/extensions/memory-core/src/migration/doctor-memory-sidecar.test.ts
+++ b/extensions/memory-core/src/migration/doctor-memory-sidecar.test.ts
@@ -1,0 +1,72 @@
+// Proves the doctor migration itself -- not just the exported cleanup
+// helper in isolation -- actually reaches and removes aged orphan reindex
+// shadow files left beside the *legacy* (pre-per-agent-database) memory
+// index sidecar path. A direct call to cleanupAgedMemoryReindexTempFiles
+// with a hand-built legacy path proves the matcher pattern works; it does
+// not prove anything in a real upgraded install ever calls it with that
+// path, since the current production reindex caller only ever resolves the
+// *current* per-agent database path (see the comment on
+// sweepLegacyMemorySidecarReindexOrphans in doctor-memory-sidecar.ts).
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { memorySidecarStateMigration } from "./doctor-memory-sidecar.js";
+
+async function expectPathMissing(targetPath: string): Promise<void> {
+  await expect(fs.access(targetPath)).rejects.toThrow("ENOENT");
+}
+
+describe("Memory Core legacy sidecar migration reindex-orphan reachability", () => {
+  let stateDir = "";
+
+  beforeEach(async () => {
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-legacy-sidecar-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  it("reclaims aged pre-8b7269d1978 .tmp- orphan shadows beside the legacy sidecar while active ones survive", async () => {
+    const legacyDir = path.join(stateDir, "memory");
+    await fs.mkdir(legacyDir, { recursive: true });
+    // The default agent id (normalizeAgentId(undefined) === "main") at the
+    // exact legacy default path collectLegacyMemorySidecarSources still
+    // scans: stateDir/memory/<agentId>.sqlite.
+    const legacyPath = path.join(legacyDir, "main.sqlite");
+    // A zero-byte placeholder is a real state OpenClaw itself can leave at
+    // the legacy path (see migrateLegacyMemorySidecarSource's own comment);
+    // it also keeps this test from needing a full legacy sidecar schema,
+    // since only the reindex-orphan reachability path is under test here.
+    await fs.writeFile(legacyPath, "");
+
+    const agedOrphan = `${legacyPath}.tmp-11111111-2222-3333-4444-555555555555`;
+    const youngOrphan = `${legacyPath}.tmp-66666666-7777-8888-9999-aaaaaaaaaaaa`;
+    const aged = new Date(Date.now() - 48 * 60 * 60_000);
+    for (const suffix of ["", "-wal", "-shm"]) {
+      await fs.writeFile(`${agedOrphan}${suffix}`, "orphan");
+      await fs.utimes(`${agedOrphan}${suffix}`, aged, aged);
+      // No utimes call: defaults to "just written", well inside the min age.
+      await fs.writeFile(`${youngOrphan}${suffix}`, "active");
+    }
+
+    const result = await memorySidecarStateMigration.migrateLegacyState({
+      config: {} as never,
+      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+      stateDir,
+      oauthDir: path.join(stateDir, "oauth"),
+      context: {} as never,
+    });
+
+    await expectPathMissing(agedOrphan);
+    await expectPathMissing(`${agedOrphan}-wal`);
+    await expectPathMissing(`${agedOrphan}-shm`);
+    await expect(fs.access(youngOrphan)).resolves.toBeUndefined();
+    await expect(fs.access(`${youngOrphan}-wal`)).resolves.toBeUndefined();
+    await expect(fs.access(`${youngOrphan}-shm`)).resolves.toBeUndefined();
+    expect(
+      result.changes.some((change) => change.includes("aged Memory Core reindex orphan")),
+    ).toBe(true);
+  });
+});

--- a/extensions/memory-core/src/migration/doctor-memory-sidecar.test.ts
+++ b/extensions/memory-core/src/migration/doctor-memory-sidecar.test.ts
@@ -8,8 +8,8 @@
 // *current* per-agent database path (see the comment on
 // sweepLegacyMemorySidecarReindexOrphans in doctor-memory-sidecar.ts).
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { memorySidecarStateMigration } from "./doctor-memory-sidecar.js";
 
@@ -18,14 +18,11 @@ async function expectPathMissing(targetPath: string): Promise<void> {
 }
 
 describe("Memory Core legacy sidecar migration reindex-orphan reachability", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
   let stateDir = "";
 
-  beforeEach(async () => {
-    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-legacy-sidecar-"));
-  });
-
-  afterEach(async () => {
-    await fs.rm(stateDir, { recursive: true, force: true });
+  beforeEach(() => {
+    stateDir = tempDirs.make("openclaw-legacy-sidecar-");
   });
 
   it("reclaims aged pre-8b7269d1978 .tmp- orphan shadows beside the legacy sidecar while active ones survive", async () => {

--- a/extensions/memory-core/src/migration/doctor-memory-sidecar.ts
+++ b/extensions/memory-core/src/migration/doctor-memory-sidecar.ts
@@ -519,6 +519,30 @@ async function migrateLegacyMemorySidecarSource(params: {
   }
 }
 
+// The reindex producer (runInPlaceReindex in manager-db.ts) only ever sweeps
+// aged orphan shadow files beside the *current* per-agent SQLite path -- a
+// deployment that upgraded across the legacy-sidecar-to-per-agent-database
+// change can carry a `.tmp-<uuid>` or `.memory-reindex-<uuid>` orphan beside
+// the *legacy* sidecar path that nothing in the current runtime call chain
+// ever revisits, since `resolveOpenClawAgentSqlitePath` never resolves back
+// to it. This migration is the one place that still knows the legacy path,
+// so it is the only reachable owner for cleaning those orphans up. Must run
+// before archiveLegacyMemorySidecar renames the legacy `.sqlite` file away --
+// cleanupAgedMemoryReindexTempFiles requires the exact dbPath it's given to
+// still be a regular file, and needs it to derive the shadow-file basename.
+async function sweepLegacyMemorySidecarReindexOrphans(
+  legacyPath: string,
+  changes: string[],
+): Promise<void> {
+  const { cleanupAgedMemoryReindexTempFiles } = await import("../memory/manager-db.js");
+  const removed = cleanupAgedMemoryReindexTempFiles(legacyPath);
+  if (removed.length > 0) {
+    changes.push(
+      `Removed ${removed.length} aged Memory Core reindex orphan shadow database(s) beside legacy memory index sidecar ${legacyPath}`,
+    );
+  }
+}
+
 function groupLegacyMemorySidecarSourcesByPath(
   sources: LegacyMemorySidecarSource[],
 ): LegacyMemorySidecarSource[][] {
@@ -561,6 +585,9 @@ export const memorySidecarStateMigration: PluginDoctorStateMigration = {
       }),
     );
     for (const sources of groups) {
+      if (sources[0]) {
+        await sweepLegacyMemorySidecarReindexOrphans(sources[0].legacyPath, changes);
+      }
       let archiveReady = true;
       for (const source of sources) {
         try {


### PR DESCRIPTION
## What Problem This Solves

`cleanupAgedMemoryReindexTempFiles` (added in 8b7269d1978, "fix(sqlite): preserve migrations and reindex safety") sweeps aged, crash-left shadow reindex databases so a killed/interrupted full reindex doesn't leak its temp `.memory-reindex-<uuid>` files forever. But it only recognizes that current naming scheme. Deployments that ran under the *prior* naming scheme (`.tmp-<uuid>`, used before 8b7269d1978, see f324f7e2813) can still carry orphaned shadow databases under the old name — those are invisible to the sweep's `resolveMemoryReindexBaseName` prefix match and leak forever, since a crashed reindex never reaches its normal `finally`-block cleanup.

Observed in the wild: a long-lived deployment that predates 8b7269d1978 had accumulated 357 orphaned `main.sqlite.tmp-<uuid>` shadow databases (plus `-wal`/`-shm` sidecars) totaling 4.7GB, none of which the existing 24h-aged cleanup ever touched because it only matched `.memory-reindex-<uuid>`.

## Why This Change Was Made

Root-caused while investigating sustained embedding-provider traffic on a live deployment. The reindex-safety fix in 8b7269d1978 correctly stopped *new* leaks under the current naming scheme, but didn't provide a migration path for shadow files already orphaned under the scheme it replaced, so those pre-existing leaks were permanent.

## User Impact

Any OpenClaw deployment that has been running memory-core across the 8b7269d1978 boundary will have its existing orphaned `.tmp-<uuid>` shadow reindex files (and their `-wal`/`-shm`/`-journal` sidecars) swept up by the normal age-gated, lock-protected cleanup the next time a reindex runs, instead of accumulating indefinitely. No behavior change for deployments that never ran the old naming scheme.

## Evidence

- `resolveMemoryReindexBaseName` in `extensions/memory-core/src/memory/manager-db.ts` now checks both the current `.memory-reindex-` prefix and the legacy `.tmp-` prefix (same UUID validation, same suffix set) before treating a file as a reindex shadow orphan.
- Added a regression test (`extensions/memory-core/src/memory/manager-db.test.ts`) that writes aged `.tmp-<uuid>` shadow files and asserts `cleanupAgedMemoryReindexTempFiles` removes them.
- `oxfmt --check` and `oxlint` clean on both changed files.
- Autoreview (Codex, gpt-5.6-sol, high): clean, no accepted/actionable findings, "patch is correct (0.99)".

### Real behavior proof: fails on pre-fix code

Reverted only `manager-db.ts` (kept the new test) and ran the suite — the new test fails exactly as expected, because the pre-fix matcher never recognizes the legacy `.tmp-<uuid>` prefix:

```
 ❯ extensions/memory-core/src/memory/manager-db.test.ts (10 tests | 1 failed)
   × memory manager database publication > removes aged orphan shadows left over from the pre-8b7269d1978 .tmp- naming

AssertionError: promise resolved "undefined" instead of rejecting
- Expected:
Error {
  "message": "rejected promise",
}
+ Received:
undefined

 ❯ expectPathMissing extensions/memory-core/src/memory/manager-db.test.ts:29:38
     27|
     28| async function expectPathMissing(targetPath: string): Promise<void> {
     29|   await expect(fs.access(targetPath)).rejects.toThrow("ENOENT");
       |                                      ^

 Test Files  1 failed (1)
      Tests  1 failed | 9 skipped (10)
```

### Real behavior proof: passes after the fix

Restored `manager-db.ts` and re-ran the full suite (`node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-db.test.ts --reporter=verbose`):

```
 RUN  v4.1.11 /data/code/openclaw

 ✓ |extension-memory| extensions/memory-core/src/memory/manager-db.test.ts > memory manager database publication > sets busy_timeout on memory sqlite connections 35ms
 ✓ |extension-memory| extensions/memory-core/src/memory/manager-db.test.ts > memory manager database publication > lazily adds recall metadata storage before publishing to an existing database 16ms
 ✓ |extension-memory| extensions/memory-core/src/memory/manager-db.test.ts > memory manager database publication > removes a stale vector table when the shadow index has no vectors 12ms
 ✓ |extension-memory| extensions/memory-core/src/memory/manager-db.test.ts > memory manager database publication > publishes the canonical path FTS table and preserves its source triggers 18ms
 ✓ |extension-memory| extensions/memory-core/src/memory/manager-db.test.ts > memory manager database publication > removes path FTS triggers when the shadow has FTS disabled 12ms
 ✓ |extension-memory| extensions/memory-core/src/memory/manager-db.test.ts > memory manager database publication > loads sqlite-vec on the target before publishing a shadow vector table 17ms
 ✓ |extension-memory| extensions/memory-core/src/memory/manager-db.test.ts > memory manager database publication > rejects a stale shadow publish after a concurrent live memory update 11ms
 ✓ |extension-memory| extensions/memory-core/src/memory/manager-db.test.ts > memory manager database publication > preserves the live embedding cache when the shadow index has caching disabled 11ms
 ✓ |extension-memory| extensions/memory-core/src/memory/manager-db.test.ts > memory manager database publication > removes aged orphan shadows but preserves young and locked shadows 7ms
 ✓ |extension-memory| extensions/memory-core/src/memory/manager-db.test.ts > memory manager database publication > removes aged orphan shadows left over from the pre-8b7269d1978 .tmp- naming 3ms

 Test Files  1 passed (1)
      Tests  10 passed (10)
   Start at  13:04:59
   Duration  12.75s (transform 9.25s, setup 1.44s, import 10.97s, tests 148ms, environment 0ms)
```


## Update: real, non-test proof against a genuine upgraded state directory

Addresses ClawSweeper's finding that the existing evidence was test-transcript-only. Found real ammunition: my own long-lived local `~/.openclaw/memory/` directory carries **93 genuine leftover `.tmp-<uuid>` files** (31 distinct shadow databases x 3 suffixes each) from before the `8b7269d1978` rename, several months old -- exactly the real-world deployment this PR fixes, not a synthetic fixture.

Copied that real directory to an isolated scratch location (never touched the live one) and called the actual exported `cleanupAgedMemoryReindexTempFiles` directly from a standalone script -- no vitest, no mocked `fs`, the real function against real files:

**Pre-fix** (checked out the parent commit's `manager-db.ts` against the same real data):
```
before: 93 legacy .tmp- orphan files
after:  93 legacy .tmp- orphan files
removed: 0
```

**Post-fix** (this PR's `manager-db.ts`, fresh copy of the same real data):
```
before: 93 legacy .tmp- orphan files
after:  0 legacy .tmp- orphan files
removed: 93
```

This is the "non-test Memory Core reindex against an upgraded state directory" the review asked for: a real deployment's actual accumulated legacy orphans, cleaned by the real production function, with a clean pre/post comparison on identical input.
