### PR TITLE
fix(maintainers): preserve source coauthors in squash merges

### DIFF
--- a/scripts/pr-lib/merge.sh
+++ b/scripts/pr-lib/merge.sh
@@ -227,6 +227,71 @@ merge_verify() {
   echo "merge-verify passed for PR #$pr"
 }
 
+prepare_squash_merge_body() {
+  local pr="$1" source_head="${LOCAL_PREP_HEAD_SHA:-$PREP_HEAD_SHA}"
+  local main_sha source_trailers
+  main_sha=$(git rev-parse --verify refs/remotes/origin/main) || return 1
+  # GraphQL publication can collapse local fixups. Preserve their reviewed
+  # trailers, excluding main's ancestry, rather than inspecting current HEAD.
+  source_trailers=$(git -c trailer.separators=: -c trailer.co-authored-by.key=Co-authored-by log --reverse \
+    --no-show-signature --no-notes --no-color --no-decorate --encoding=UTF-8 \
+    --format='%(trailers:key=Co-authored-by,only,unfold)' "$main_sha..$source_head") || return 1
+  [ -n "$source_trailers" ] || return 0
+
+  local repo_nwo preview
+  repo_nwo=$(gh repo view --json nameWithOwner --jq .nameWithOwner) || return 1
+  preview=$(gh_plain api graphql \
+    -f 'query=query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){headRefOid isMergeQueueEnabled viewerMergeBodyText(mergeType:SQUASH)}}}' \
+    -f owner="${repo_nwo%/*}" -f name="${repo_nwo#*/}" -F number="$pr") || return 1
+  if ! printf '%s\n' "$preview" | jq -e --arg head "$PREP_HEAD_SHA" '
+    .data.repository.pullRequest | .headRefOid == $head and
+      (.viewerMergeBodyText | type == "string") and .isMergeQueueEnabled == false
+  ' >/dev/null; then
+    echo "Cannot preserve squash credit: require a current-head message from a non-queue PR. Refresh prepare evidence and check the merge queue policy." >&2
+    return 1
+  fi
+
+  local body_file envelope original_trailers final_trailers message trailer
+  body_file=$(mktemp .local/merge-body.XXXXXX) || return 1
+  # Git parses complete commit messages; a body containing only trailers needs
+  # a temporary subject. Keep all authors in one terminal trailer block.
+  envelope=$'OpenClaw merge message\n\n'
+  printf '%s' "$envelope" > "$body_file" || return 1
+  printf '%s\n' "$preview" | jq -r '.data.repository.pullRequest.viewerMergeBodyText' >> "$body_file" || return 1
+  original_trailers=$(git -c trailer.separators=: -c trailer.co-authored-by.key=Co-authored-by interpret-trailers \
+    --parse --no-divider "$body_file") || return 1
+  # Mutating interpret-trailers runs configured trailer commands. Parse only,
+  # then append missing values without rewriting the server's existing text.
+  message=$(printf '%s\n' "$preview" | jq -r '.data.repository.pullRequest.viewerMergeBodyText') || return 1
+  while [[ "$message" == *$'\n'* ]] && [[ "${message##*$'\n'}" != *[!$' \t\r']* ]]; do
+    message="${message%$'\n'*}"
+  done
+  local known_trailers="$original_trailers" separator=$'\n\n'
+  [ -z "$original_trailers" ] || separator=$'\n'
+  while IFS= read -r trailer; do
+    [ -n "$trailer" ] || continue
+    if ! printf '%s\n' "$known_trailers" | grep -Fxq -- "$trailer"; then
+      [ -z "$message" ] || message+="$separator"
+      message+="$trailer"
+      known_trailers+=$'\n'"$trailer"
+      separator=$'\n'
+    fi
+  done <<< "$source_trailers"
+  printf '%s%s\n' "$envelope" "$message" > "$body_file" || return 1
+  final_trailers=$(git -c trailer.separators=: -c trailer.co-authored-by.key=Co-authored-by interpret-trailers \
+    --parse --no-divider "$body_file") || return 1
+  while IFS= read -r trailer; do
+    [ -n "$trailer" ] || continue
+    if ! printf '%s\n' "$final_trailers" | grep -Fxq -- "$trailer"; then
+      echo "Cannot preserve squash credit: the final message lost a source or preview trailer." >&2
+      return 1
+    fi
+  done <<< "$original_trailers
+$source_trailers"
+  printf '%s\n' "$message" > "$body_file" || return 1
+  printf '%s\n' "$body_file"
+}
+
 merge_run() {
   local pr="$1"
   local auto_merge_requested="${2:-false}"
@@ -335,6 +400,13 @@ merge_run() {
     exit 2
   fi
 
+  local merge_args=(--match-head-commit "$PREP_HEAD_SHA")
+  if [ "$merge_method" = "squash" ]; then
+    local merge_body_file
+    merge_body_file=$(prepare_squash_merge_body "$pr") || return 1
+    [ -z "$merge_body_file" ] || merge_args+=(--body-file "$merge_body_file")
+  fi
+
   local merge_submitted=false
   local state=""
   # Auto-merge is only a post-verification landing strategy. Keep every
@@ -391,7 +463,7 @@ merge_run() {
       if gh_plain pr merge "$pr" \
         --auto \
         --squash \
-        --match-head-commit "$PREP_HEAD_SHA" \
+        "${merge_args[@]}" \
         >.local/merge-output.log 2>&1
       then
         auto_meta=$(read_pr_view_json "$pr" "state,headRefOid,mergeable,mergeStateStatus,autoMergeRequest") || exit 1
@@ -453,7 +525,7 @@ merge_run() {
       if ! gh_plain pr merge "$pr" \
         --admin \
         "$merge_flag" \
-        --match-head-commit "$PREP_HEAD_SHA" \
+        "${merge_args[@]}" \
         >.local/merge-output.log 2>&1
       then
         print_relevant_log_excerpt .local/merge-output.log
@@ -462,7 +534,7 @@ merge_run() {
     else
       if ! gh_plain pr merge "$pr" \
         "$merge_flag" \
-        --match-head-commit "$PREP_HEAD_SHA" \
+        "${merge_args[@]}" \
         >.local/merge-output.log 2>&1
       then
         print_relevant_log_excerpt .local/merge-output.log

--- a/test/scripts/pr-merge.test.ts
+++ b/test/scripts/pr-merge.test.ts
@@ -30,6 +30,17 @@ type MergeScenario = {
   remoteReadError?: string;
   remoteRefsJson?: string;
   reviewArtifacts?: "valid" | "invalid";
+  sourceMessages?: string[];
+  previewBody?: string | null;
+  previewHead?: string;
+  previewQueue?: boolean;
+  previewError?: boolean;
+  sourceReadError?: boolean;
+  mergeMethod?: "squash" | "rebase";
+  configuredTrailer?: boolean;
+  signedSource?: boolean;
+  bodyWriteError?: boolean;
+  trailerSeparators?: string;
 };
 
 function runMerge(scenario: MergeScenario = {}) {
@@ -43,6 +54,77 @@ function runMerge(scenario: MergeScenario = {}) {
   const commentBody = join(root, "comment-body");
   const lifecycle = join(root, "lifecycle.log");
   const rgCalls = join(root, "rg-calls.log");
+  const mergeBody = join(root, "consumed-merge-body");
+  const sourceRepo = join(root, "source");
+  const trailerMarker = join(root, "trailer-command-called");
+  let localHead = headSha;
+  if (scenario.sourceMessages) {
+    mkdirSync(sourceRepo);
+    const git = (args: string[]) => {
+      const result = spawnSync(
+        "git",
+        [
+          "-c",
+          "user.name=Fixture",
+          "-c",
+          "user.email=fixture@example.com",
+          "-c",
+          "commit.gpgsign=false",
+          "-c",
+          "core.hooksPath=/dev/null",
+          ...args,
+        ],
+        { cwd: sourceRepo, encoding: "utf8" },
+      );
+      if (result.status !== 0) {
+        throw new Error(`Git fixture failed: ${result.stderr}`);
+      }
+      return result.stdout.trim();
+    };
+    git(["init", "-q"]);
+    git([
+      "commit",
+      "--allow-empty",
+      "-qm",
+      "Main change\n\nCo-authored-by: Main Only <main@example.com>",
+    ]);
+    git(["update-ref", "refs/remotes/origin/main", git(["rev-parse", "HEAD"])]);
+    if (scenario.signedSource) {
+      const key = join(root, "fixture-signing-key");
+      const generated = spawnSync("ssh-keygen", ["-q", "-t", "ed25519", "-N", "", "-f", key]);
+      expect(generated.status, generated.stderr.toString()).toBe(0);
+      const allowedSigners = join(root, "allowed-signers");
+      writeFileSync(allowedSigners, `fixture@example.com ${readFileSync(`${key}.pub`, "utf8")}`);
+      git(["config", "gpg.format", "ssh"]);
+      git(["config", "user.signingKey", key]);
+      git(["config", "gpg.ssh.allowedSignersFile", allowedSigners]);
+    }
+    for (const message of scenario.sourceMessages) {
+      git([
+        "-c",
+        `commit.gpgsign=${scenario.signedSource ?? false}`,
+        "commit",
+        "--allow-empty",
+        "-qm",
+        message,
+      ]);
+    }
+    localHead = git(["rev-parse", "HEAD"]);
+    if (scenario.signedSource) {
+      git(["verify-commit", localHead]);
+      git(["notes", "add", "-m", "Unrelated operator note", localHead]);
+      git(["config", "log.showSignature", "true"]);
+      git(["config", "color.ui", "always"]);
+      git(["config", "log.decorate", "full"]);
+      git(["config", "i18n.logOutputEncoding", "ISO-8859-1"]);
+    }
+    git([
+      "commit",
+      "--allow-empty",
+      "-qm",
+      "Unprepared change\n\nCo-authored-by: Unprepared <unprepared@example.com>",
+    ]);
+  }
   mkdirSync(bin, { recursive: true });
   mkdirSync(localDir, { recursive: true });
   writeFileSync(
@@ -63,7 +145,7 @@ process.exit(new RegExp(pattern, flags).test(readFileSync(file, "utf8")) ? 0 : 1
     join(localDir, "prep.env"),
     [
       `PREP_HEAD_SHA=${headSha}`,
-      `LOCAL_PREP_HEAD_SHA=${headSha}`,
+      `LOCAL_PREP_HEAD_SHA=${localHead}`,
       `LAST_VERIFIED_HEAD_SHA=${usesCrabboxBypass ? headSha : ""}`,
       `FULL_GATES_HEAD_SHA=${usesCrabboxBypass ? headSha : ""}`,
       `GATES_MODE=${usesCrabboxBypass ? "remote_crabbox_aws" : "full"}`,
@@ -215,10 +297,33 @@ repo_root() { printf '%s\\n' "$OPENCLAW_TEST_ROOT"; }
 remove_worktree_if_present() { printf 'worktree-cleanup %s\\n' "$*" >> "$OPENCLAW_TEST_LIFECYCLE"; }
 delete_local_branch_if_safe() { printf 'branch-cleanup %s\\n' "$*" >> "$OPENCLAW_TEST_LIFECYCLE"; }
 sleep() { :; }
+mktemp() {
+  if [ "$OPENCLAW_TEST_BODY_WRITE_ERROR" = "true" ] && [[ "\${1-}" = .local/merge-body.* ]]; then
+    echo 'body artifact unavailable' >&2
+    return 1
+  fi
+  command mktemp "$@"
+}
 pr_meta_json() {
   printf '%s\\n' '{"state":"OPEN","isDraft":false,"headRefOid":"${headSha}"}'
 }
 git() {
+  case "\${1-}" in
+    log|rev-parse|interpret-trailers|-c)
+      if [ "$OPENCLAW_TEST_SOURCE_READ_ERROR" = "true" ] && [[ " $* " = *" log "* ]]; then
+        echo 'source object unavailable' >&2
+        return 1
+      fi
+      if [[ " $* " = *" interpret-trailers "* ]]; then
+        command git "$@"
+      elif [ -d "$OPENCLAW_TEST_SOURCE_REPO" ]; then
+        command git -C "$OPENCLAW_TEST_SOURCE_REPO" "$@"
+      elif [ "\${1-}" = "rev-parse" ]; then
+        printf '%s\\n' '${baseSha}'
+      fi
+      return
+      ;;
+  esac
   if [ "\${1-}" = "merge-base" ]; then
     if [ "$OPENCLAW_TEST_MERGE_STATE_STATUS" = "BEHIND" ]; then
       return 1
@@ -283,6 +388,13 @@ gh_route() {
       esac
       ;;
     "pr merge")
+      local previous="" arg
+      for arg in "$@"; do
+        if [ "$previous" = "--body-file" ]; then
+          cat "$arg" > "$OPENCLAW_TEST_MERGE_BODY"
+        fi
+        previous="$arg"
+      done
       case " $* " in
         *" --disable-auto "*)
           printf 'disabled\\n' > "$OPENCLAW_TEST_AUTO_STATE"
@@ -318,6 +430,13 @@ gh_route() {
         esac
       done
       case "$*" in
+        *"viewerMergeBodyText"*)
+          if [ "$OPENCLAW_TEST_PREVIEW_ERROR" = "true" ]; then
+            echo 'preview unavailable' >&2
+            return 1
+          fi
+          printf '%s\\n' "$OPENCLAW_TEST_MERGE_PREVIEW"
+          ;;
         "api user")
           printf '%s\\n' '{"login":"maintainer"}'
           ;;
@@ -396,6 +515,25 @@ merge_run 123 "$OPENCLAW_TEST_AUTO_REQUESTED"
     encoding: "utf8",
     env: {
       ...process.env,
+      ...(scenario.configuredTrailer
+        ? {
+            GIT_CONFIG_COUNT: "2",
+            GIT_CONFIG_KEY_0: "trailer.audit.key",
+            GIT_CONFIG_VALUE_0: "Unrequested-Metadata",
+            GIT_CONFIG_KEY_1: "trailer.audit.command",
+            GIT_CONFIG_VALUE_1:
+              'printf invoked > "$OPENCLAW_TEST_TRAILER_MARKER"; printf "unrequested value"',
+          }
+        : {}),
+      OPENCLAW_TEST_TRAILER_MARKER: trailerMarker,
+      ...(scenario.trailerSeparators
+        ? {
+            GIT_CONFIG_COUNT: "1",
+            GIT_CONFIG_KEY_0: "trailer.separators",
+            GIT_CONFIG_VALUE_0: scenario.trailerSeparators,
+          }
+        : {}),
+      OPENCLAW_TEST_BODY_WRITE_ERROR: String(scenario.bodyWriteError ?? false),
       OPENCLAW_TEST_AUTO_CALLED: autoCalled,
       OPENCLAW_TEST_AUTO_ERROR:
         scenario.autoError ?? "GraphQL: Pull request auto merge is not allowed for this repository",
@@ -417,6 +555,25 @@ merge_run 123 "$OPENCLAW_TEST_AUTO_REQUESTED"
       OPENCLAW_TEST_LANDED_SHA: landedSha,
       OPENCLAW_TEST_LIFECYCLE: lifecycle,
       OPENCLAW_TEST_MERGE_SCRIPT: mergeScript,
+      OPENCLAW_TEST_MERGE_BODY: mergeBody,
+      OPENCLAW_TEST_SOURCE_REPO: sourceRepo,
+      OPENCLAW_TEST_SOURCE_READ_ERROR: String(scenario.sourceReadError ?? false),
+      OPENCLAW_TEST_PREVIEW_ERROR: String(scenario.previewError ?? false),
+      OPENCLAW_PR_MERGE_METHOD: scenario.mergeMethod ?? "squash",
+      OPENCLAW_TEST_MERGE_PREVIEW: JSON.stringify({
+        data: {
+          repository: {
+            pullRequest: {
+              headRefOid: scenario.previewHead ?? headSha,
+              isMergeQueueEnabled: scenario.previewQueue ?? false,
+              viewerMergeBodyText:
+                scenario.previewBody === undefined
+                  ? "Server description\n\nCo-authored-by: Maintainer <maintainer@example.com>\n\n"
+                  : scenario.previewBody,
+            },
+          },
+        },
+      }),
       OPENCLAW_TEST_MERGE_STATE_STATUS: scenario.mergeStateStatus ?? "BEHIND",
       OPENCLAW_TEST_POST_AUTO_META: postAutoMeta,
       OPENCLAW_TEST_PRE_AUTO_META: preAutoMeta,
@@ -443,10 +600,147 @@ merge_run 123 "$OPENCLAW_TEST_AUTO_REQUESTED"
     commentBody: existsSync(commentBody) ? readFileSync(commentBody, "utf8") : "",
     lifecycle: existsSync(lifecycle) ? readFileSync(lifecycle, "utf8") : "",
     rgCalls: existsSync(rgCalls) ? readFileSync(rgCalls, "utf8") : "",
+    mergeBody: existsSync(mergeBody) ? readFileSync(mergeBody, "utf8") : null,
+    trailerCommandCalled: existsSync(trailerMarker),
   };
 }
 
 describePosix("scripts/pr merge-run", () => {
+  it("preserves canonical GitHub trailers despite configured separators", () => {
+    const credit = "Co-authored-by: Contributor <contributor@example.com>";
+    const result = runMerge({ sourceMessages: [`Repair\n\n${credit}`], trailerSeparators: "%" });
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.mergeBody).toBe(
+      `Server description\n\nCo-authored-by: Maintainer <maintainer@example.com>\n${credit}\n`,
+    );
+  });
+
+  it("does not execute configured trailer commands or add unrelated metadata", () => {
+    const credit = "Co-authored-by: Contributor <contributor@example.com>";
+    const result = runMerge({ sourceMessages: [`Repair\n\n${credit}`], configuredTrailer: true });
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.trailerCommandCalled).toBe(false);
+    expect(result.mergeBody).toContain(credit);
+    expect(result.mergeBody).not.toContain("Unrequested-Metadata");
+  });
+
+  it("preserves source coauthors with the server authors in one parsed trailer block", () => {
+    const credit = "Co-authored-by: 唐梓夷0668001293 <tang.ziyi@example.com>";
+    const result = runMerge({
+      sourceMessages: [
+        `Owner repair\n\n${credit}`,
+        `Second repair\n\n${credit}\nCo-authored-by: Another Contributor <another@example.com>`,
+      ],
+    });
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.mergeBody, "the merge must consume an explicit attribution body").not.toBeNull();
+    expect(result.mergeBody).toContain("Server description");
+    const parsed = spawnSync("git", ["interpret-trailers", "--parse", "--no-divider"], {
+      encoding: "utf8",
+      input: `Synthetic subject\n\n${result.mergeBody ?? ""}`,
+    });
+    expect(parsed.status, parsed.stderr).toBe(0);
+    expect(parsed.stdout.trim().split("\n")).toEqual([
+      "Co-authored-by: Maintainer <maintainer@example.com>",
+      credit,
+      "Co-authored-by: Another Contributor <another@example.com>",
+    ]);
+    expect(result.mergeBody).not.toContain("Main Only");
+    expect(result.mergeBody).not.toContain("Unprepared");
+    expect(result.calls).toContain(`--match-head-commit ${headSha}`);
+  });
+
+  it("extracts only UTF-8 credit from signed commits despite configured log presentation", () => {
+    const credit = "Co-authored-by: Élodie <elodie@example.com>";
+    const result = runMerge({ sourceMessages: [`Repair\n\n${credit}`], signedSource: true });
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.mergeBody).toBe(
+      `Server description\n\nCo-authored-by: Maintainer <maintainer@example.com>\n${credit}\n`,
+    );
+  });
+
+  it.each([
+    "",
+    "Server description",
+    "Co-authored-by: Maintainer <maintainer@example.com>",
+    "Server description\n\nCo-authored-by: Maintainer <maintainer@example.com>\n\n \t\n",
+    "Server description\n\n---\n\nMore context\n\nCo-authored-by: Maintainer <maintainer@example.com>",
+  ])("preserves the preview and its parsed trailers for body %j", (previewBody) => {
+    const credit = "Co-authored-by: Contributor <contributor@example.com>";
+    const result = runMerge({ sourceMessages: [`Repair\n\n${credit}`], previewBody });
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    const preview = previewBody.trimEnd();
+    const separator = !preview ? "" : preview.includes("Co-authored-by:") ? "\n" : "\n\n";
+    expect(result.mergeBody).toBe(`${preview}${separator}${credit}\n`);
+  });
+
+  it("does not duplicate an existing trailer or mistake prose for a trailer", () => {
+    const credit = "Co-authored-by: Contributor <contributor@example.com>";
+    const previewBody = `Quoted example: ${credit}\n\nNot a trailer.`;
+    const present = runMerge({ sourceMessages: [`Repair\n\n${credit}`], previewBody: credit });
+    expect(present.status, present.stderr).toBe(0);
+    expect(present.mergeBody).toBe(`${credit}\n`);
+    const prose = runMerge({ sourceMessages: [`Repair\n\n${credit}`], previewBody });
+    expect(prose.status, prose.stderr).toBe(0);
+    expect(prose.mergeBody).toBe(`${previewBody}\n\n${credit}\n`);
+  });
+
+  it.each<MergeScenario>([
+    { previewError: true },
+    { previewBody: null },
+    { previewHead: "b".repeat(40) },
+    { previewQueue: true },
+    { sourceReadError: true },
+    { bodyWriteError: true },
+  ])("refuses before merge when attribution evidence is unavailable: %j", (failure) => {
+    const result = runMerge({
+      sourceMessages: ["Repair\n\nCo-authored-by: Contributor <contributor@example.com>"],
+      ...failure,
+    });
+    expect(result.status).toBe(1);
+    expect(result.calls).not.toContain("pr merge");
+    expect(result.mergeBody).toBeNull();
+  });
+
+  it.each<MergeScenario>([
+    { auto: true },
+    { auto: true, existingAutoMethod: "MERGE" },
+    { auto: true, autoResult: "unavailable" },
+    { crabboxBypass: "valid", mergeStateStatus: "CLEAN" },
+  ])("passes the verified body to every existing squash submission route: %j", (route) => {
+    const credit = "Co-authored-by: Contributor <contributor@example.com>";
+    const result = runMerge({ sourceMessages: [`Repair\n\n${credit}`], ...route });
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.mergeBody).toContain(credit);
+    const submissions = result.calls
+      .split("\n")
+      .filter((line) => line.startsWith("plain pr merge "));
+    expect(submissions.length).toBeGreaterThan(0);
+    for (const submission of submissions) {
+      if (submission.includes("--disable-auto")) {
+        expect(submission).not.toContain("--body-file");
+      } else {
+        expect(submission).toContain(`--match-head-commit ${headSha} --body-file `);
+      }
+    }
+  });
+
+  it("keeps no-credit and rebase submissions free of a squash body override", () => {
+    for (const scenario of [
+      { sourceMessages: ["Ordinary repair"] },
+      {
+        sourceMessages: ["Repair\n\nCo-authored-by: Contributor <contributor@example.com>"],
+        mergeMethod: "rebase" as const,
+      },
+    ]) {
+      const result = runMerge(scenario);
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(result.mergeBody).toBeNull();
+      expect(result.calls).not.toContain("viewerMergeBodyText");
+      expect(result.calls).not.toContain("--body-file");
+    }
+  });
+
   it("refuses to merge when review artifact validation fails", () => {
     const result = runMerge({ reviewArtifacts: "invalid" });
 


### PR DESCRIPTION
Related: #119388
Prior attempt: #124115 (author-closed; this change does not reopen or copy it).

## What Problem This Solves

Fixes an issue where maintainers could lose an original contributor's `Co-authored-by` trailer when landing a rewritten PR through the native squash workflow. The prepared source commit retained the credit, but GitHub's generated squash message omitted it. The native merge command accepted that default message.

## Why This Change Was Made

The merge owner now preserves exact source coauthors alongside GitHub's existing message and authors. It reads the verified local prepared lineage, excludes main's ancestry, and supplies one head-bound body to the existing squash submission paths. Git parses the trailers in read-only mode; the implementation does not infer identities, run configured trailer commands, change merge methods, or weaken review/CI/head checks.

Missing authors join the existing terminal trailer block, with a final parse verifying that both original and added trailers remain actual trailers. Merge queues are refused when an explicit attribution body is needed because [GitHub's auto-merge input contract](https://docs.github.com/en/enterprise-cloud@latest/graphql/reference/pulls#enablepullrequestautomergeinput) says a required queue ignores that body. No configuration or public flag is added.

The earlier #124115 proposal also concerned attribution, but synthesized identities and changed author/body and queue behavior. This repair keeps the current server message and the exact names/emails already present in reviewed source commits. The missing explicit-body behavior is already present in the oldest retained history snapshot, [e357203](https://github.com/openclaw/openclaw/commit/e357203be5721f55434e7fc9891268e5c6afdd38) (2026-07-12; authored by Vincent Koc, committed by GitHub). That shallow-history boundary does not establish who originally introduced it; #114702 and later transport/admin changes carried the behavior forward.

## User Impact

Contributors retain their original credit when a maintainer rewrites and squash-merges a PR. There is no OpenClaw product-runtime change. Maintainer tooling is +75/-3 (net +72); the growth implements the missing message-ownership contract and shares the optional body arguments across the three existing submission sites. Tests and test support are +295/-1.

## Evidence

Reviewed and tested source: [a0d2d5b](https://github.com/openclaw/openclaw/commit/a0d2d5b66c65d55c10ecd9e67d53752b4b4b1ff6).

- Captured the original missing-body failure before implementation, then additional failing regressions for configured trailer-command execution and nonstandard trailer separators before correcting those cases.
- The full merge-owner suite passes: 60 tests, including real temporary Git graphs, a verified SSH-signed fixture, Unicode credit, exclusion of main and unprepared HEAD, body-only/empty/Markdown/trailing-blank cases, deduplication, failure-before-mutation, and the existing merge/auto-merge/refusal paths.
- A read-only check against GitHub's actual #119388 prepared head confirmed the generated private body retained the server message and both its existing author and the exact original contributor trailer. It did not submit a merge or run merge verification; final landed-message verification remains separate.
- [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33145902609) and the required `openclaw/ci-gate` are green on a0d2d5b. The hosted merge-owner file passed all 60 cases, including the new credit regressions; hosted test-root type checking and formatting passed.
- Formatting, Bash syntax, and diff checks pass. Local exact-test-file type-aware lint reached its 120-second bound while preparing package artifacts, before lint ran; it remains incomplete. Hosted scripts lint passed but does not cover that test file, so it is not presented as a replacement.
- Both fresh mandatory reviews completed with no accepted/actionable findings on the frozen patch. Final landed-message verification remains separate; this is not a landing claim.
