### PR TITLE
refactor(file-transfer): centralize directory read preparation

### DIFF
--- a/extensions/file-transfer/src/node-host/dir-fetch.stream-errors.test.ts
+++ b/extensions/file-transfer/src/node-host/dir-fetch.stream-errors.test.ts
@@ -84,25 +84,6 @@ describe("dir.fetch process wrapper", () => {
     );
   });
 
-  it("rejects oversized preflight-only requests using the encoded tar limit", async () => {
-    runCommandBufferedMock.mockResolvedValueOnce(
-      commandResult({
-        code: null,
-        termination: "output-limit",
-        outputLimitStream: "stdout",
-      }),
-    );
-
-    await expect(
-      handleDirFetch({ path: tmpRoot, maxBytes: 1024, preflightOnly: true }),
-    ).resolves.toMatchObject({
-      ok: false,
-      code: "TREE_TOO_LARGE",
-      message: "tarball exceeded 1024 byte limit during preflight",
-    });
-    expect(runCommandBufferedMock).toHaveBeenCalledOnce();
-  });
-
   it("rejects preflight-only requests once filesystem listing crosses the entry cap", async () => {
     await Promise.all(
       Array.from({ length: 5001 }, (_, index) =>
@@ -120,19 +101,30 @@ describe("dir.fetch process wrapper", () => {
     expect(runCommandBufferedMock).not.toHaveBeenCalled();
   });
 
-  it("preserves filesystem classification when a preflight tar race removes the directory", async () => {
-    runCommandBufferedMock.mockImplementationOnce(async () => {
-      await fs.rm(tmpRoot, { recursive: true, force: true });
-      return commandResult({ code: 1 });
-    });
+  it.each([true, false])(
+    "reclassifies a removed directory only for preflight=%s",
+    async (preflightOnly) => {
+      if (!preflightOnly) {
+        runCommandBufferedMock.mockResolvedValueOnce(
+          commandResult({ stdout: Buffer.from("1\tproject\n") }),
+        );
+      }
+      runCommandBufferedMock.mockImplementationOnce(async () => {
+        await fs.rm(tmpRoot, { recursive: true, force: true });
+        return commandResult({ code: 1 });
+      });
 
-    await expect(
-      handleDirFetch({ path: tmpRoot, maxBytes: 1024, preflightOnly: true }),
-    ).resolves.toMatchObject({
-      ok: false,
-      code: "NOT_FOUND",
-    });
-  });
+      await expect(
+        handleDirFetch({ path: tmpRoot, maxBytes: 1024, preflightOnly }),
+      ).resolves.toMatchObject({
+        ok: false,
+        code: preflightOnly ? "NOT_FOUND" : "READ_ERROR",
+        message: preflightOnly ? expect.stringContaining("stat failed:") : "tar command failed",
+        canonicalPath: tmpRoot,
+      });
+      expect(runCommandBufferedMock).toHaveBeenCalledTimes(preflightOnly ? 1 : 2);
+    },
+  );
 
   it("fails tar entry listing closed on wrapper errors", async () => {
     runCommandBufferedMock
@@ -149,40 +141,57 @@ describe("dir.fetch process wrapper", () => {
     });
   });
 
-  it.each([
-    {
-      label: "output cap",
-      result: commandResult({
-        code: null,
-        termination: "output-limit",
-        outputLimitStream: "stdout",
-      }),
-      message: "tarball exceeded 1024 byte limit mid-stream",
-    },
-    {
-      label: "timeout",
-      result: commandResult({ code: null, termination: "timeout" }),
-      message: "tar command exceeded 60s wall-clock timeout",
-    },
-    {
-      label: "launch error",
-      result: new Error("spawn failed"),
-      message: "tar command failed",
-    },
-  ])("classifies $label failures through handleDirFetch", async ({ result, message }) => {
-    runCommandBufferedMock.mockResolvedValueOnce(
-      commandResult({ stdout: Buffer.from("1\tproject\n") }),
-    );
-    if (result instanceof Error) {
-      runCommandBufferedMock.mockRejectedValueOnce(result);
-    } else {
-      runCommandBufferedMock.mockResolvedValueOnce(result);
-    }
+  describe.each([true, false])("archive failures with preflight=%s", (preflightOnly) => {
+    it.each([
+      {
+        label: "output cap",
+        result: commandResult({
+          code: null,
+          termination: "output-limit",
+          outputLimitStream: "stdout",
+        }),
+        code: "TREE_TOO_LARGE",
+        message: `tarball exceeded 1024 byte limit ${preflightOnly ? "during preflight" : "mid-stream"}`,
+      },
+      {
+        label: "timeout",
+        result: commandResult({ code: null, termination: "timeout" }),
+        code: "READ_ERROR",
+        message: "tar command exceeded 60s wall-clock timeout (slow filesystem or symlink loop?)",
+      },
+      {
+        label: "changed canonical path",
+        result: commandResult({ code: 78 }),
+        code: "CANONICAL_PATH_CHANGED",
+        message: "canonical path differs from the authorized target",
+      },
+      {
+        label: "launch error",
+        result: new Error("spawn failed"),
+        code: "READ_ERROR",
+        message: "tar command failed",
+      },
+    ])("classifies $label failures through handleDirFetch", async ({ result, code, message }) => {
+      if (!preflightOnly) {
+        runCommandBufferedMock.mockResolvedValueOnce(
+          commandResult({ stdout: Buffer.from("1\tproject\n") }),
+        );
+      }
+      if (result instanceof Error) {
+        runCommandBufferedMock.mockRejectedValueOnce(result);
+      } else {
+        runCommandBufferedMock.mockResolvedValueOnce(result);
+      }
 
-    const response = await handleDirFetch({ path: tmpRoot, maxBytes: 1024 });
-    expect(response).toMatchObject({ ok: false, code: expect.any(String) });
-    if (!response.ok) {
-      expect(response.message).toContain(message);
-    }
+      await expect(
+        handleDirFetch({ path: tmpRoot, maxBytes: 1024, preflightOnly }),
+      ).resolves.toEqual({
+        ok: false,
+        code,
+        message,
+        canonicalPath: tmpRoot,
+      });
+      expect(runCommandBufferedMock).toHaveBeenCalledTimes(preflightOnly ? 1 : 2);
+    });
   });
 });

--- a/extensions/file-transfer/src/node-host/dir-fetch.ts
+++ b/extensions/file-transfer/src/node-host/dir-fetch.ts
@@ -6,7 +6,6 @@ import { runCommandBuffered } from "openclaw/plugin-sdk/process-runtime";
 import { root as fsRoot } from "openclaw/plugin-sdk/security-runtime";
 import {
   matchesFileIdentity,
-  readPathBinding,
   type FileIdentity,
   type PathBinding,
 } from "../shared/path-binding.js";
@@ -14,8 +13,7 @@ import { createTarArchive } from "./dir-fetch-archive.js";
 import {
   classifyFsSafeReadError,
   readAbsolutePath,
-  rejectCanonicalPathChange,
-  resolveCanonicalReadPath,
+  resolveBoundReadDirectory,
   statRequiredDirectory,
 } from "./path-errors.js";
 
@@ -166,57 +164,27 @@ export async function handleDirFetch(params: DirFetchParams): Promise<DirFetchRe
   }
 
   const maxBytes = clampMaxBytes(params.maxBytes);
-  const includeDotfiles = params.includeDotfiles === true;
   const followSymlinks = params.followSymlinks === true;
   const preflightOnly = params.preflightOnly === true;
 
-  const canonical = await resolveCanonicalReadPath({
+  const directory = await resolveBoundReadDirectory({
     requestedPath,
     followSymlinks,
     classifyError: classifyFsError,
     notFoundMessage: "directory not found",
+    expectedCanonicalPath: params.expectedCanonicalPath,
+    expectedBinding: params.expectedBinding,
   });
-  if (typeof canonical !== "string") {
-    return canonical;
-  }
-
-  const canonicalPathChange = rejectCanonicalPathChange(params.expectedCanonicalPath, canonical);
-  if (canonicalPathChange) {
-    return canonicalPathChange;
-  }
-
-  const directory = await statRequiredDirectory(canonical, classifyFsError);
   if (!directory.ok) {
     return directory;
   }
-  const expectedBinding = readPathBinding(params.expectedBinding);
-  if (params.expectedBinding !== undefined && expectedBinding?.kind !== "existing") {
-    return {
-      ok: false,
-      code: "CANONICAL_PATH_CHANGED",
-      message: "filesystem identity differs from the authorized target",
-      canonicalPath: canonical,
-    };
-  }
-  if (
-    expectedBinding?.kind === "existing" &&
-    (expectedBinding.device !== directory.identity.device ||
-      expectedBinding.inode !== directory.identity.inode)
-  ) {
-    return {
-      ok: false,
-      code: "CANONICAL_PATH_CHANGED",
-      message: "filesystem identity differs from the authorized target",
-      canonicalPath: canonical,
-    };
-  }
-  const boundIdentity: FileIdentity =
-    expectedBinding?.kind === "existing" ? expectedBinding : directory.identity;
+  const { canonicalPath: canonical, identity } = directory;
 
+  let preflightEntries: string[] | undefined;
   if (preflightOnly) {
     let entries: string[] | "TOO_MANY";
     try {
-      entries = await listTreeEntries(canonical, 5000, boundIdentity);
+      entries = await listTreeEntries(canonical, 5000, identity);
     } catch (err) {
       const errorCode = err && typeof err === "object" && "code" in err ? err.code : undefined;
       const code =
@@ -237,65 +205,8 @@ export async function handleDirFetch(params: DirFetchParams): Promise<DirFetchRe
       };
     }
 
-    const tarBuffer = await createTarArchive(
-      canonical,
-      canonical,
-      boundIdentity.device,
-      boundIdentity.inode,
-      maxBytes,
-    );
-    if (tarBuffer === "TOO_LARGE") {
-      return {
-        ok: false,
-        code: "TREE_TOO_LARGE",
-        message: `tarball exceeded ${maxBytes} byte limit during preflight`,
-        canonicalPath: canonical,
-      };
-    }
-    if (tarBuffer === "TIMEOUT") {
-      return {
-        ok: false,
-        code: "READ_ERROR",
-        message: "tar command exceeded 60s wall-clock timeout (slow filesystem or symlink loop?)",
-        canonicalPath: canonical,
-      };
-    }
-    if (tarBuffer === "CANONICAL_PATH_CHANGED") {
-      return {
-        ok: false,
-        code: "CANONICAL_PATH_CHANGED",
-        message: "canonical path differs from the authorized target",
-        canonicalPath: canonical,
-      };
-    }
-    if (tarBuffer === "ERROR") {
-      const currentDirectory = await statRequiredDirectory(canonical, classifyFsError);
-      if (!currentDirectory.ok) {
-        return currentDirectory;
-      }
-      return {
-        ok: false,
-        code: "READ_ERROR",
-        message: "tar command failed",
-        canonicalPath: canonical,
-      };
-    }
-    return {
-      ok: true,
-      path: canonical,
-      tarBase64: "",
-      tarBytes: 0,
-      sha256: "",
-      fileCount: entries.length,
-      entries,
-      preflightOnly: true,
-      binding: { kind: "existing", ...directory.identity },
-    };
-  }
-
-  // Preflight size check using du
-  const withinBudget = await preflightDu(canonical, maxBytes);
-  if (!withinBudget) {
+    preflightEntries = entries;
+  } else if (!(await preflightDu(canonical, maxBytes))) {
     return {
       ok: false,
       code: "TREE_TOO_LARGE",
@@ -304,24 +215,13 @@ export async function handleDirFetch(params: DirFetchParams): Promise<DirFetchRe
     };
   }
 
-  // Build tar args. Shell out to /usr/bin/tar for portability.
-  // -cz: create + gzip
-  // -C <dir>: change to directory so paths in archive are relative
-  // .: include everything from that directory
-  // v1: includeDotfiles is accepted in the API but not enforced. BSD tar's
-  // --exclude pattern matching is unreliable for dotfiles (every plausible
-  // pattern except "*/.*" collapses the archive on macOS). Reliable filtering
-  // requires a `find ! -name '.*' | tar -T -` pipeline; deferred to v2.
-  // For now we always archive everything in the directory.
-  void includeDotfiles;
-  // Capture tar output with a hard byte cap and a wall-clock timeout.
-  // SIGTERM if the byte cap is exceeded; SIGKILL if the timeout fires
-  // (covers tar hanging on a slow filesystem or symlink loop).
+  // includeDotfiles is reserved; both modes archive everything. Preflight must
+  // still build the capped archive so approval cannot accept an oversized tree.
   const tarBuffer = await createTarArchive(
     canonical,
     canonical,
-    boundIdentity.device,
-    boundIdentity.inode,
+    identity.device,
+    identity.inode,
     maxBytes,
   );
 
@@ -329,7 +229,7 @@ export async function handleDirFetch(params: DirFetchParams): Promise<DirFetchRe
     return {
       ok: false,
       code: "TREE_TOO_LARGE",
-      message: `tarball exceeded ${maxBytes} byte limit mid-stream`,
+      message: `tarball exceeded ${maxBytes} byte limit ${preflightOnly ? "during preflight" : "mid-stream"}`,
       canonicalPath: canonical,
     };
   }
@@ -350,11 +250,33 @@ export async function handleDirFetch(params: DirFetchParams): Promise<DirFetchRe
     };
   }
   if (tarBuffer === "ERROR") {
+    // Preflight preserves filesystem error classification after a tar race;
+    // actual fetch reports the archive failure without another path lookup.
+    if (preflightOnly) {
+      const currentDirectory = await statRequiredDirectory(canonical, classifyFsError);
+      if (!currentDirectory.ok) {
+        return currentDirectory;
+      }
+    }
     return {
       ok: false,
       code: "READ_ERROR",
       message: "tar command failed",
       canonicalPath: canonical,
+    };
+  }
+
+  if (preflightEntries) {
+    return {
+      ok: true,
+      path: canonical,
+      tarBase64: "",
+      tarBytes: 0,
+      sha256: "",
+      fileCount: preflightEntries.length,
+      entries: preflightEntries,
+      preflightOnly: true,
+      binding: { kind: "existing", ...identity },
     };
   }
 
@@ -379,6 +301,6 @@ export async function handleDirFetch(params: DirFetchParams): Promise<DirFetchRe
     sha256,
     fileCount: entries.length,
     entries,
-    binding: { kind: "existing", ...directory.identity },
+    binding: { kind: "existing", ...identity },
   };
 }

--- a/extensions/file-transfer/src/node-host/dir-list.test.ts
+++ b/extensions/file-transfer/src/node-host/dir-list.test.ts
@@ -3,7 +3,8 @@ import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { handleDirFetch } from "./dir-fetch.js";
 import { createCanonicalDirListCommand } from "./dir-list-worker-command.js";
 import { handleDirList } from "./dir-list.js";
 
@@ -15,6 +16,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   await fs.rm(tmpRoot, { recursive: true, force: true });
 });
 
@@ -53,6 +55,79 @@ describe("handleDirList — fs errors", () => {
     const f = path.join(tmpRoot, "f.txt");
     await fs.writeFile(f, "x");
     await expectDirListError({ path: f }, "IS_FILE");
+  });
+});
+
+describe.each([
+  ["dir.list", handleDirList, "path not found", "PERMISSION_DENIED"],
+  ["dir.fetch", handleDirFetch, "directory not found", "READ_ERROR"],
+] as const)("%s — directory binding", (_command, handle, notFoundMessage, permissionCode) => {
+  it.each(["malformed", "write", "device", "inode"] as const)(
+    "rejects a %s binding before reading the directory",
+    async (kind) => {
+      const stats = await fs.stat(tmpRoot, { bigint: true });
+      const binding = { kind: "existing", device: String(stats.dev), inode: String(stats.ino) };
+      const expectedBinding = {
+        malformed: null,
+        write: {
+          kind: "write",
+          anchorPath: tmpRoot,
+          anchorDevice: binding.device,
+          anchorInode: binding.inode,
+        },
+        device: { ...binding, device: "different" },
+        inode: { ...binding, inode: "different" },
+      }[kind];
+      const readdir = vi.spyOn(fs, "readdir");
+
+      await expect(
+        handle({ path: tmpRoot, preflightOnly: true, expectedBinding }),
+      ).resolves.toEqual({
+        ok: false,
+        code: "CANONICAL_PATH_CHANGED",
+        message: "filesystem identity differs from the authorized target",
+        canonicalPath: tmpRoot,
+      });
+      expect(readdir).not.toHaveBeenCalled();
+    },
+  );
+
+  it("preserves path and directory errors before validating the binding", async () => {
+    const missing = path.join(tmpRoot, "missing");
+    await expect(handle({ path: missing, expectedBinding: null })).resolves.toEqual({
+      ok: false,
+      code: "NOT_FOUND",
+      message: notFoundMessage,
+    });
+    const file = path.join(tmpRoot, "file.txt");
+    await fs.writeFile(file, "keep");
+    await expect(handle({ path: file, expectedBinding: null })).resolves.toEqual({
+      ok: false,
+      code: "IS_FILE",
+      message: "path is not a directory",
+      canonicalPath: file,
+    });
+    await expect(
+      handle({ path: file, expectedCanonicalPath: tmpRoot, expectedBinding: null }),
+    ).resolves.toEqual({
+      ok: false,
+      code: "CANONICAL_PATH_CHANGED",
+      message: "canonical path differs from the authorized target",
+      canonicalPath: file,
+    });
+  });
+
+  it("retains the command's permission-error classification", async () => {
+    vi.spyOn(fs, "stat").mockRejectedValueOnce(
+      Object.assign(new Error("denied"), { code: "EACCES" }),
+    );
+
+    await expect(handle({ path: tmpRoot, expectedBinding: null })).resolves.toEqual({
+      ok: false,
+      code: permissionCode,
+      message: "stat failed: Error: denied",
+      canonicalPath: tmpRoot,
+    });
   });
 });
 
@@ -159,14 +234,21 @@ describe("handleDirList — happy path", () => {
 
   it("binds the canonical target before listing entries", async () => {
     await fs.writeFile(path.join(tmpRoot, "private.txt"), "secret");
+    const stats = await fs.stat(tmpRoot, { bigint: true });
+    const binding = { kind: "existing", device: String(stats.dev), inode: String(stats.ino) };
 
-    const preflight = await handleDirList({ path: tmpRoot, preflightOnly: true });
-    expect(preflight).toMatchObject({
+    const preflight = await handleDirList({
+      path: tmpRoot,
+      preflightOnly: true,
+      expectedBinding: { ...binding, extra: "not part of the binding" },
+    });
+    expect(preflight).toEqual({
       ok: true,
       path: tmpRoot,
       entries: [],
       truncated: false,
       preflight: true,
+      binding,
     });
 
     const changed = await handleDirList({

--- a/extensions/file-transfer/src/node-host/dir-list.ts
+++ b/extensions/file-transfer/src/node-host/dir-list.ts
@@ -2,13 +2,12 @@
 import path from "node:path";
 import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
 import { mimeFromExtension } from "../shared/mime.js";
-import { readPathBinding, type PathBinding } from "../shared/path-binding.js";
+import type { PathBinding } from "../shared/path-binding.js";
 import { listCanonicalDirectory } from "./dir-list-worker.js";
 import {
   classifyFsSafeReadError,
   readAbsolutePath,
-  rejectCanonicalPathChange,
-  resolveCanonicalReadPath,
+  resolveBoundReadDirectory,
   statRequiredDirectory,
 } from "./path-errors.js";
 
@@ -102,46 +101,18 @@ export async function handleDirList(params: DirListParams): Promise<DirListResul
 
   const followSymlinks = params.followSymlinks === true;
 
-  const canonical = await resolveCanonicalReadPath({
+  const directory = await resolveBoundReadDirectory({
     requestedPath,
     followSymlinks,
     classifyError: classifyFsError,
     notFoundMessage: "path not found",
+    expectedCanonicalPath: params.expectedCanonicalPath,
+    expectedBinding: params.expectedBinding,
   });
-  if (typeof canonical !== "string") {
-    return canonical;
-  }
-
-  const canonicalPathChange = rejectCanonicalPathChange(params.expectedCanonicalPath, canonical);
-  if (canonicalPathChange) {
-    return canonicalPathChange;
-  }
-  const directory = await statRequiredDirectory(canonical, classifyFsError);
   if (!directory.ok) {
     return directory;
   }
-  const expectedBinding = readPathBinding(params.expectedBinding);
-  if (params.expectedBinding !== undefined && expectedBinding?.kind !== "existing") {
-    return {
-      ok: false,
-      code: "CANONICAL_PATH_CHANGED",
-      message: "filesystem identity differs from the authorized target",
-      canonicalPath: canonical,
-    };
-  }
-  if (
-    expectedBinding?.kind === "existing" &&
-    (expectedBinding.device !== directory.identity.device ||
-      expectedBinding.inode !== directory.identity.inode)
-  ) {
-    return {
-      ok: false,
-      code: "CANONICAL_PATH_CHANGED",
-      message: "filesystem identity differs from the authorized target",
-      canonicalPath: canonical,
-    };
-  }
-  const boundIdentity = expectedBinding?.kind === "existing" ? expectedBinding : directory.identity;
+  const { canonicalPath: canonical, identity } = directory;
   if (params.preflightOnly === true) {
     return {
       ok: true,
@@ -149,15 +120,15 @@ export async function handleDirList(params: DirListParams): Promise<DirListResul
       entries: [],
       truncated: false,
       preflight: true,
-      binding: { kind: "existing", ...directory.identity },
+      binding: { kind: "existing", ...identity },
     };
   }
 
   const listing = await listCanonicalDirectory({
     directoryPath: canonical,
     expectedCanonicalPath: canonical,
-    expectedDevice: boundIdentity.device,
-    expectedInode: boundIdentity.inode,
+    expectedDevice: identity.device,
+    expectedInode: identity.inode,
     maxEntries,
     offset,
   });
@@ -207,6 +178,6 @@ export async function handleDirList(params: DirListParams): Promise<DirListResul
     entries,
     nextPageToken,
     truncated,
-    binding: { kind: "existing", ...directory.identity },
+    binding: { kind: "existing", ...identity },
   };
 }

--- a/extensions/file-transfer/src/node-host/path-errors.ts
+++ b/extensions/file-transfer/src/node-host/path-errors.ts
@@ -3,7 +3,7 @@ import type { BigIntStats } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { FsSafeError, resolveAbsolutePathForRead } from "openclaw/plugin-sdk/security-runtime";
-import { fileIdentity, type FileIdentity } from "../shared/path-binding.js";
+import { fileIdentity, readPathBinding, type FileIdentity } from "../shared/path-binding.js";
 
 type InvalidPathResult = {
   ok: false;
@@ -124,4 +124,49 @@ export async function statRequiredDirectory<Code extends string>(
     };
   }
   return { ok: true, identity: fileIdentity(stats) };
+}
+
+export async function resolveBoundReadDirectory<Code extends string>(input: {
+  requestedPath: string;
+  followSymlinks: boolean;
+  classifyError: (err: unknown) => Code;
+  notFoundMessage: string;
+  expectedCanonicalPath?: unknown;
+  expectedBinding?: unknown;
+}): Promise<
+  | { ok: true; canonicalPath: string; identity: FileIdentity }
+  | {
+      ok: false;
+      code: Code | "IS_FILE" | "CANONICAL_PATH_CHANGED";
+      message: string;
+      canonicalPath?: string;
+    }
+> {
+  const canonicalPath = await resolveCanonicalReadPath(input);
+  if (typeof canonicalPath !== "string") {
+    return canonicalPath;
+  }
+  const canonicalPathChange = rejectCanonicalPathChange(input.expectedCanonicalPath, canonicalPath);
+  if (canonicalPathChange) {
+    return canonicalPathChange;
+  }
+  const directory = await statRequiredDirectory(canonicalPath, input.classifyError);
+  if (!directory.ok) {
+    return directory;
+  }
+  const expectedBinding = readPathBinding(input.expectedBinding);
+  if (
+    input.expectedBinding !== undefined &&
+    (expectedBinding?.kind !== "existing" ||
+      expectedBinding.device !== directory.identity.device ||
+      expectedBinding.inode !== directory.identity.inode)
+  ) {
+    return {
+      ok: false,
+      code: "CANONICAL_PATH_CHANGED",
+      message: "filesystem identity differs from the authorized target",
+      canonicalPath,
+    };
+  }
+  return { ...directory, canonicalPath };
 }


### PR DESCRIPTION
## What Problem This Solves

File Transfer's directory listing and fetching repeated the same canonical-path and filesystem-identity preparation. Fetch also maintained separate copies of capped archive creation and error handling for preflight and actual transfer. Keeping those copies aligned made a sensitive owner boundary harder to maintain.

## Why This Change Was Made

Both directory commands now share preparation in the existing path module, and fetch has one capped archive path. Validation order and command-specific errors stay unchanged. The final worker checks still bind reads to the approved canonical path and device/inode; Gateway authorization, archive verification, file reads/writes, byte limits, and timeouts are unchanged.

## User Impact

No intended user-visible behavior, configuration, dependency, protocol, or public API change. Preflight still creates a capped archive before accepting a tree, and the existing `includeDotfiles` parameter still does not exclude dotfiles. This is a maintenance refactor, not a claim to fix a demonstrated production bug or make directory contents atomic during concurrent mutation.

## Evidence

- Original implementation: 136 tests passed across 13 files on macOS; two Linux-only worker cases skipped. Added characterization then passed against unchanged production code. Final matching local run: 153 passed, two Linux-only skips.
- Canonical source-test command: `node scripts/run-vitest.mjs extensions/file-transfer/src/node-host/dir-list.test.ts extensions/file-transfer/src/node-host/dir-fetch.test.ts extensions/file-transfer/src/node-host/dir-fetch.stream-errors.test.ts` (no forced Vitest config).
- Linux Testbox: 56 tests passed across the directory handlers, archive error cases, and real directory-fetch policy flow, including both Linux-only worker checks. Node 24.19.0 and GNU tar 1.35. All five patched-file hashes matched the reviewed local files. The hydrated workflow revision's relevant plugin, process, SDK, and dependency files matched the local base. [Run evidence](https://github.com/openclaw/openclaw/actions/runs/33142464266). The one-shot Testbox completed and stopped successfully; its backing Actions session can show cancellation during that cleanup.
- Independent isolated Codex review: no findings in the default P0 review scope.
- Full exact five-path changed-file checks: exit 0.
- Exact committed-head full build: exit 0 in 13m29s, with the build stamp, runtime post-build stamp, and build-info commit all matching `fa9e299b93ae9596d052ce887c0c92a026895c50`.
- Independent source-blind public plugin-entry validation: all 6 clauses, 418 assertions, and 49 requests passed against the exact built candidate. Independent tar extraction, dotfile, and anti-cheat checks passed; no base64 payload persisted, stderr was empty, and cleanup left no owned process. This is not live Gateway or paired-node transport proof.
- Independent gzip supplement: the built public entry produced `1f8b` gzip magic, Node gunzip succeeded, and independent extraction recovered the exact 28-byte fixture; 2/2 supplement requests passed with clean teardown.
- Production: +93/-155, net -62. Tests: +161/-70, net +91. Total: net +29; the added tests preserve binding/error precedence and both archive modes.
