### PR TITLE
fix(code-mode): stop oversized searches from reporting no matches

### DIFF
--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -665,6 +665,12 @@ type ToolCatalog = {
 };
 ```
 
+`catalog.search(...)` returns a frozen array of callable handles, or an empty
+array when no tools match. If the matching callable names exceed the output
+budget, search rejects with guidance to narrow the query or lower `limit`.
+It never silently substitutes an empty or partial match list. A narrower search
+remains available after the error.
+
 Paired Gateway nodes are available through the `nodes` global:
 
 ```typescript
@@ -897,7 +903,9 @@ type CodeModeOutput = { type: "text"; text: string } | { type: "json"; value: un
 
 Rules: output order matches guest calls. Nested tool results, cumulative guest
 output, and the final value share the `maxOutputBytes` serialized UTF-8 budget.
-When a successful result exceeds the budget, OpenClaw returns a bounded value
+Catalog search rejects when its callable-name array cannot fit this budget;
+narrow the query or lower `limit` and retry. For other successful results that
+exceed the budget, OpenClaw returns a bounded value
 with `truncated: true`, a UTF-8-safe `prefix`, `omittedBytes`, and guidance to
 rerun with narrower arguments. Treat that marker as a successful partial result:
 reduce the search scope, paginate, select fewer files, or return a smaller

--- a/src/agents/code-mode-bridge.ts
+++ b/src/agents/code-mode-bridge.ts
@@ -584,11 +584,14 @@ export async function runBridgeRequest(params: {
         break;
       }
     }
-    return {
-      id: params.request.id,
-      ok: true,
-      value: boundCodeModeValue(value, params.maxOutputBytes),
-    };
+    value = boundCodeModeValue(value, params.maxOutputBytes);
+    // Search must remain a callable-name array; a truncation marker erases discovery.
+    if (params.request.method === "search" && !Array.isArray(value)) {
+      throw new ToolInputError(
+        "Search results exceed the output budget. Narrow the query or lower the limit.",
+      );
+    }
+    return { id: params.request.id, ok: true, value };
   } catch (error) {
     const settled: SettledBridgeRequest = {
       id: params.request.id,

--- a/src/agents/code-mode-controller-source.ts
+++ b/src/agents/code-mode-controller-source.ts
@@ -269,7 +269,7 @@ export const CODE_MODE_CONTROLLER_SOURCE = String.raw`
   const catalog = Object.freeze({
     search: async (query, options) => {
       const matches = await request("search", [query, options]);
-      return Object.freeze((Array.isArray(matches) ? matches : []).map((name) =>
+      return Object.freeze(matches.map((name) =>
         callableHandles.get(String(name))
       ).filter(Boolean));
     },

--- a/src/agents/code-mode.search.test.ts
+++ b/src/agents/code-mode.search.test.ts
@@ -1,0 +1,123 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, describe, expect, it } from "vitest";
+import { consumeRepairableCodeModeFailure } from "./code-mode-repair-provenance.js";
+import {
+  applyCodeModeCatalog,
+  createCodeModeTools,
+  runCodeModeScriptHeadless,
+} from "./code-mode.js";
+import {
+  pluginTool,
+  resetCodeModeTestState,
+  runUntilCompleted,
+  testing,
+} from "./code-mode.test-support.js";
+import { createToolSearchCatalogRef } from "./tool-search.js";
+
+describe.each(["interactive", "headless"] as const)("Code Mode %s search", (mode) => {
+  afterEach(resetCodeModeTestState);
+
+  function setup(maxOutputBytes = 1_024, maxSearchLimit = 50) {
+    const catalogRef = createToolSearchCatalogRef();
+    const config = { tools: { codeMode: { enabled: true, maxOutputBytes, maxSearchLimit } } };
+    const ctx = { config, catalogRef };
+    const tools = createCodeModeTools(ctx);
+    const targets = Array.from({ length: 50 }, (_, index) =>
+      pluginTool(
+        `shipment_${String(index).padStart(2, "0")}_${"long_name_".repeat(5)}`,
+        "Find shipment",
+      ),
+    );
+    applyCodeModeCatalog({ tools: [...tools, ...targets], config, catalogRef });
+    const run = async (code: string) =>
+      mode === "headless"
+        ? await runCodeModeScriptHeadless({ ctx, code })
+        : await runUntilCompleted({
+            execTool: expectDefined(tools[0], "exec"),
+            waitTool: expectDefined(tools[1], "wait"),
+            code,
+          });
+    return { run, targets };
+  }
+
+  it("rejects overflowing search results and leaves narrowed discovery callable", async () => {
+    const { run, targets } = setup();
+    const overflow = await run(
+      'return (await catalog.search("shipment", { limit: 50 })).map(tool => tool.callableName);',
+    );
+    expect(overflow, JSON.stringify(overflow)).toMatchObject({
+      status: "failed",
+      error: expect.stringMatching(/search.*narrow.*limit/i),
+    });
+    for (const target of targets) {
+      expect(target.execute).not.toHaveBeenCalled();
+    }
+    if (mode === "interactive") {
+      expect(consumeRepairableCodeModeFailure(overflow)).toBe(true);
+    }
+
+    const narrowed = await run(`
+      const matches = await catalog.search("shipment", { limit: 1 });
+      if (!Object.isFrozen(matches) || matches.length !== 1) throw new Error("invalid handles");
+      return await matches[0]({ value: "ship" });
+    `);
+    expect(narrowed).toMatchObject({
+      status: "completed",
+      value: { name: targets[0]?.name, input: { value: "ship" } },
+    });
+    expect(targets[0]?.execute).toHaveBeenCalledOnce();
+    for (const target of targets.slice(1)) {
+      expect(target.execute).not.toHaveBeenCalled();
+    }
+    expect(testing.activeRuns.size).toBe(0);
+    expect(testing.resumingRunIds.size).toBe(0);
+  });
+
+  it.each([
+    {
+      name: "genuine no-match",
+      query: "zzzz_missing_tool",
+      options: "{ limit: 50 }",
+      bytes: 1_024,
+      max: 50,
+      count: 0,
+    },
+    {
+      name: "default output budget",
+      query: "shipment",
+      options: "{ limit: 50 }",
+      bytes: 65_536,
+      max: 50,
+      count: 50,
+    },
+    {
+      name: "omitted limit clamp",
+      query: "shipment",
+      options: "undefined",
+      bytes: 1_024,
+      max: 3,
+      count: 3,
+    },
+    {
+      name: "explicit limit clamp",
+      query: "shipment",
+      options: "{ limit: 50 }",
+      bytes: 1_024,
+      max: 3,
+      count: 3,
+    },
+  ])("preserves $name", async ({ query, options, bytes, max, count }) => {
+    const { run, targets } = setup(bytes, max);
+    const result = await run(`
+      const matches = await catalog.search(${JSON.stringify(query)}, ${options});
+      return { count: matches.length, frozen: Object.isFrozen(matches), callable: matches.every(tool => typeof tool === "function") };
+    `);
+    expect(result).toMatchObject({
+      status: "completed",
+      value: { count, frozen: true, callable: true },
+    });
+    for (const target of targets) {
+      expect(target.execute).not.toHaveBeenCalled();
+    }
+  });
+});


### PR DESCRIPTION
Closes #131551 — Code Mode catalog search silently loses oversized match sets.

## What Problem This Solves

Fixes an issue where agents could report that no tool was available even though tools matched their Code Mode search. With a supported smaller output budget, an oversized match list became a successful empty array, allowing a task to end with a false “no tools found” conclusion.

## Why This Change Was Made

Enforce the search result's array-or-error contract at the existing host serialization boundary. If the matching callable names cannot fit the byte budget, search now rejects with guidance to narrow the query or lower the limit. Remove the guest's silent non-array-to-empty fallback. The existing bound helper still runs once; ordinary oversized successful tool results retain their truncation markers.

The non-array fallback came from the callable catalog rewrite, #126262, authored and merged by @steipete on August 20, 2026. Earlier bounded successful tool output in #122924 remains intentional and is preserved. This is the producer repair, not a downstream interpretation of marker-shaped data. No new serializer, error-provenance exemption, configuration, dependency, storage, schema, protocol, or budget is added.

## User Impact

Search overflow is now distinguishable from a genuine no-match result. Agents can narrow discovery and complete the task instead of silently abandoning it. Existing metadata-only recovery supplies the next provider turn; prior potentially mutating calls retain their existing containment. Genuine empty searches, search-limit clamping, callable handles, effective tool visibility, MCP exclusion, and ordinary result truncation remain unchanged.

## Evidence

Production LOC: **+9/-6 (net +3)**. Tests: **+123/-0**. Docs: **+9/-1 (net +8)**. The three production lines express the missing search contract within the existing result-bound owner; no new helper or alternate execution path is needed.

Fresh pre-fix tests reproduced `completed` with `value: []` in both real QuickJS execution surfaces: **2 intended failures, 8 controls passed**. After the repair, **94 focused tests passed**. Coverage includes interactive and headless overflow, genuine no-match, default output budget, omitted/explicit limit clamping, narrowed exact-once invocation, policy/shadowing/MCP siblings, successful ordinary truncation, and existing recovery containment. The exact scoped changed gate, `pnpm build`, and fresh isolated Codex autoreview passed; the review reported no actionable P0 findings.

Real-flow proof used the actual Control UI composer, an isolated built Gateway, the OpenClaw agent loop and QuickJS, a deterministic AIMock provider, and a local fixture plugin with 50 matching tools. Fixture receipts were collected independently from provider output and public history.

| Observation | Before | After |
| --- | --- | --- |
| UI submissions | 1 | 1 |
| Provider turns | 2 | 3 |
| Initial search | Successful false-empty result | Actionable search-limit error |
| Public `exec` calls/results | 1/1 | 2/2 |
| Independent action receipts | 0 | Exactly 1 |
| Final response | No shipment tools found | Shipment recorded once after narrowing |

The overflow was **uncaught inside the guest cell**. The normal agent loop delivered the failure to the provider, accepted a separate narrowed `exec`, and delivered its successful result. This is not just a manually driven or guest-level catch/retry sequence. Public tool IDs/pairing, lifecycle starts, telemetry, terminal outcome, and the receipt independently agree. Runtime deadlines and byte limits were unchanged; owned Gateway/browser/mock/receipt services and temporary state were removed after each run.

Focused tests:

```bash
node scripts/run-vitest.mjs src/agents/code-mode.search.test.ts src/agents/code-mode.guest.test.ts src/agents/code-mode.bridge.test.ts src/agents/code-mode.limits.test.ts src/agents/code-mode.mcp.test.ts src/agents/code-mode.agent-loop.test.ts
```

Scoped checks:

```bash
node scripts/check-changed.mjs -- src/agents/code-mode-bridge.ts src/agents/code-mode-controller-source.ts src/agents/code-mode.search.test.ts docs/tools/code-mode.md
```

Build:

```bash
pnpm build
```

Proof limits: the packaged before run used an older build whose implicated bridge/controller/execution/state/runtime/search/outcome owners were verified unchanged from the current source base. Exact-current-source pre-fix regressions were captured independently. The after build includes the recorded dirty patch and was hash-checked after proof. The provider is deterministic AIMock, not a live frontier model; the public model label in the UI selector is not evidence of a real model call. This proves the OpenClaw QuickJS path, not native Codex. Standard dependency/build warnings are retained in the local report; no build retry or weakened gate was needed.

### Inspected visual proof

Before: existing matches become a successful empty array.

![Before: oversized search incorrectly reports completed with an empty match list](https://github.com/user-attachments/assets/d9e6b793-6d57-4788-b4a7-f26a493dd94c)

After: the same wide search reports the limit and the available correction.

![After: visible search overflow error with narrowing guidance](https://github.com/user-attachments/assets/111d770e-cbdc-4d5f-940b-21a8fe19d9fb)

After correction: one action receipt and successful completion. The expanded result is partially above the viewport; the error capture and independent receipt/history checks cover the full sequence.

![After: narrowed discovery completes with one action receipt](https://github.com/user-attachments/assets/58b5bcc6-2b68-426c-9523-efeeae7bb4d5)

Recorded flow, 3.88 seconds. The parent independently reran the same assertions with Playwright video recording, inspected the whole timeline and full-resolution error/completion frames, and verified all owned processes and ports closed. Pause the brief error state for detail; the screenshots above are easier to read.

https://github.com/user-attachments/assets/2f89f989-9e02-4851-bbf2-0614a846111a

AI-assisted implementation and verification with Codex; maintainer reviewed and accepted the scoped repair.
