### PR TITLE
fix(gateway): allow write-scoped plugin Talk actions

### DIFF
--- a/docs/gateway/operator-scopes.md
+++ b/docs/gateway/operator-scopes.md
@@ -223,6 +223,10 @@ dispatch so authorization failures have one canonical structured response:
 - The top-level `fs.listDir` RPC needs `operator.write` for Gateway-host
   requests and `operator.admin` when `nodeId` targets a node. Its handler limits
   non-admin Gateway-host browsing to configured agent workspaces.
+- `plugins.sessionAction` requires every scope declared in the selected action's
+  `requiredScopes`; omitted or empty lists default to `operator.write`.
+  `operator.write` satisfies `operator.read` and `operator.talk`. Other scopes
+  require an exact match, or `operator.admin`.
 - `sessions.create` needs `operator.write` for ordinary creation, including a
   `projectId`, and `operator.admin` for incognito sessions or any `execNode`
   request. For non-admin callers, the handler limits `cwd` to configured agent

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -206,9 +206,9 @@ function findMissingOperatorScope(
   requiredScopes: readonly OperatorScope[],
   scopes: readonly string[],
 ): OperatorScope | undefined {
-  return requiredScopes.find((scope) => {
-    return !scopes.includes(scope) && !(scope === READ_SCOPE && scopes.includes(WRITE_SCOPE));
-  });
+  return requiredScopes.find(
+    (scope) => !authorizeOperatorScopesForRequiredScope(scope, scopes).allowed,
+  );
 }
 
 /** Returns the narrowest known operator scopes needed to call a gateway method. */

--- a/src/gateway/server-methods/plugin-host-hooks.ts
+++ b/src/gateway/server-methods/plugin-host-hooks.ts
@@ -21,7 +21,8 @@ import {
   type JsonSchemaValidationError,
   type JsonSchemaValue,
 } from "../../plugins/schema-validator.js";
-import { ADMIN_SCOPE, READ_SCOPE, WRITE_SCOPE } from "../operator-scopes.js";
+import { authorizeOperatorScopesForRequiredScope } from "../method-scopes.js";
+import { WRITE_SCOPE } from "../operator-scopes.js";
 import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
 import { resolveStoredSessionKeyForAgentStore } from "../session-store-key.js";
 import type { GatewayRequestHandlers } from "./types.js";
@@ -161,18 +162,14 @@ export const pluginHostHookHandlers: GatewayRequestHandlers = {
       return;
     }
     const scopes = Array.isArray(client?.connect.scopes) ? client.connect.scopes : [];
-    const hasAdmin = scopes.includes(ADMIN_SCOPE);
     const requiredScopes =
       registration.action.requiredScopes && registration.action.requiredScopes.length > 0
         ? registration.action.requiredScopes
         : [WRITE_SCOPE];
-    // Plugin actions default to write access, while read-only actions can opt
-    // down. Admin bypasses all checks and write includes read for UI callers.
+    // Recheck the selected registration after async router admission, using the same
+    // scope implications so the two authorization gates cannot diverge.
     const missingScope = requiredScopes.find(
-      (scope) =>
-        !hasAdmin &&
-        !scopes.includes(scope) &&
-        !(scope === READ_SCOPE && scopes.includes(WRITE_SCOPE)),
+      (scope) => !authorizeOperatorScopesForRequiredScope(scope, scopes).allowed,
     );
     if (missingScope) {
       respond(false, undefined, missingScopeErrorShape({ missingScope, requiredScopes }));

--- a/src/plugins/contracts/session-actions.contract.test.ts
+++ b/src/plugins/contracts/session-actions.contract.test.ts
@@ -5,12 +5,23 @@ import {
   createPluginRegistryFixture,
   registerTestPlugin,
 } from "openclaw/plugin-sdk/plugin-test-contracts";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { APPROVALS_SCOPE, READ_SCOPE, WRITE_SCOPE } from "../../gateway/operator-scopes.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ADMIN_SCOPE,
+  APPROVALS_SCOPE,
+  PAIRING_SCOPE,
+  QUESTIONS_SCOPE,
+  READ_SCOPE,
+  TALK_SCOPE,
+  TALK_SECRETS_SCOPE,
+  WRITE_SCOPE,
+  type OperatorScope,
+} from "../../gateway/operator-scopes.js";
 import { handleGatewayRequest } from "../../gateway/server-methods.js";
 import { pluginHostHookHandlers } from "../../gateway/server-methods/plugin-host-hooks.js";
 import type { GatewayClient, RespondFn } from "../../gateway/server-methods/types.js";
 import { onAgentEvent, resetAgentEventsForTest } from "../../infra/agent-events.js";
+import type { PluginSessionActionContext } from "../host-hooks.js";
 import { createEmptyPluginRegistry } from "../registry-empty.js";
 import { createPluginRegistry } from "../registry.js";
 import { setActivePluginRegistry } from "../runtime.js";
@@ -484,132 +495,154 @@ describe("plugin session actions", () => {
     expect(throwsSecretError.message).toBe("plugin session action failed");
   });
 
-  it("authorizes session actions through the gateway by action-declared scopes", async () => {
-    const callApprovalAction = (params: {
-      actionId: string;
-      extra?: Record<string, unknown>;
-      scopes?: string[];
-    }): Promise<{ ok: boolean; payload?: unknown; error?: unknown }> =>
-      callRegisteredSessionActionThroughGatewayForTest({
-        pluginId: "approval-action-fixture",
-        actionId: params.actionId,
-        ...(params.extra ? { extra: params.extra } : {}),
-        ...(params.scopes ? { scopes: params.scopes } : {}),
+  describe("authorizes session actions through the gateway by action-declared scopes", () => {
+    const pluginId = "scope-action-fixture";
+    const actionScopes = {
+      approve: [APPROVALS_SCOPE],
+      view: [READ_SCOPE],
+      talk: [TALK_SCOPE],
+      "talk-approve": [TALK_SCOPE, APPROVALS_SCOPE],
+      "talk-secrets": [TALK_SECRETS_SCOPE],
+      admin: [ADMIN_SCOPE],
+      pairing: [PAIRING_SCOPE],
+      questions: [QUESTIONS_SCOPE],
+      "default-write": undefined,
+    } satisfies Record<string, OperatorScope[] | undefined>;
+    const handler = vi.fn(({ sessionKey }: PluginSessionActionContext) => ({
+      result: { accepted: true, ...(sessionKey ? { sessionKey } : {}) },
+      continueAgent: true,
+    }));
+
+    beforeEach(() => {
+      handler.mockClear();
+      const { registry } = registerActionFixture({
+        id: pluginId,
+        register(api) {
+          for (const [id, requiredScopes] of Object.entries(actionScopes)) {
+            api.registerSessionAction({ id, requiredScopes, handler });
+          }
+        },
       });
-    const handlerCalls: unknown[] = [];
-    const { registry } = registerActionFixture({
-      id: "approval-action-fixture",
-      name: "Approval Action Fixture",
-      register(api) {
-        api.registerSessionAction({
-          id: "approve",
-          requiredScopes: [APPROVALS_SCOPE],
-          handler: ({ client, sessionKey }) => {
-            handlerCalls.push({ scopes: client?.scopes ?? [], sessionKey });
-            return {
-              result: { approved: true, ...(sessionKey ? { sessionKey } : {}) },
-              continueAgent: true,
-            };
-          },
+      setActivePluginRegistry(registry.registry);
+    });
+
+    it.each<
+      [
+        name: string,
+        actionId: keyof typeof actionScopes,
+        scopes: OperatorScope[],
+        missingScope?: OperatorScope,
+      ]
+    >([
+      ["approvals admits a custom approval action", "approve", [APPROVALS_SCOPE]],
+      ["read cannot approve", "approve", [READ_SCOPE], APPROVALS_SCOPE],
+      ["write cannot approve", "approve", [WRITE_SCOPE], APPROVALS_SCOPE],
+      ["read admits a read action", "view", [READ_SCOPE]],
+      ["write satisfies read", "view", [WRITE_SCOPE]],
+      ["talk admits a talk action", "talk", [TALK_SCOPE]],
+      ["write satisfies talk", "talk", [WRITE_SCOPE]],
+      ["admin admits a talk action", "talk", [ADMIN_SCOPE]],
+      ["read cannot talk", "talk", [READ_SCOPE], TALK_SCOPE],
+      ["no scopes cannot talk", "talk", [], TALK_SCOPE],
+      [
+        "write reports missing approvals after satisfying talk",
+        "talk-approve",
+        [WRITE_SCOPE],
+        APPROVALS_SCOPE,
+      ],
+      [
+        "write and approvals satisfy talk and approvals",
+        "talk-approve",
+        [WRITE_SCOPE, APPROVALS_SCOPE],
+      ],
+      [
+        "talk and approvals satisfy both requirements",
+        "talk-approve",
+        [TALK_SCOPE, APPROVALS_SCOPE],
+      ],
+      ["admin satisfies both requirements", "talk-approve", [ADMIN_SCOPE]],
+      ["write cannot read talk secrets", "talk-secrets", [WRITE_SCOPE], TALK_SECRETS_SCOPE],
+      ["write cannot administer", "admin", [WRITE_SCOPE], ADMIN_SCOPE],
+      ["write cannot pair", "pairing", [WRITE_SCOPE], PAIRING_SCOPE],
+      ["write cannot answer questions", "questions", [WRITE_SCOPE], QUESTIONS_SCOPE],
+      ["write admits an action with default scopes", "default-write", [WRITE_SCOPE]],
+      ["talk cannot perform a default-write action", "default-write", [TALK_SCOPE], WRITE_SCOPE],
+      ["read cannot perform a default-write action", "default-write", [READ_SCOPE], WRITE_SCOPE],
+      ["no scopes cannot perform a default-write action", "default-write", [], WRITE_SCOPE],
+      ["admin admits an action with default scopes", "default-write", [ADMIN_SCOPE]],
+    ])("%s", async (_name, actionId, scopes, missingScope) => {
+      const response = await callRegisteredSessionActionThroughGatewayForTest({
+        pluginId,
+        actionId,
+        scopes,
+      });
+      const expectedResponse: HookResponse = missingScope
+        ? {
+            ok: false,
+            payload: undefined,
+            error: {
+              code: "FORBIDDEN",
+              message: `missing scope: ${missingScope}`,
+              details: {
+                code: "MISSING_SCOPE",
+                missingScope,
+                requiredScopes: actionScopes[actionId] ?? [WRITE_SCOPE],
+              },
+            },
+          }
+        : {
+            ok: true,
+            payload: { ok: true, result: { accepted: true }, continueAgent: true },
+            error: undefined,
+          };
+      expect({ response, handlerCalls: handler.mock.calls.length }).toEqual({
+        response: expectedResponse,
+        handlerCalls: missingScope ? 0 : 1,
+      });
+      if (!missingScope) {
+        expect(handler).toHaveBeenCalledWith({
+          pluginId,
+          actionId,
+          client: { connId: "test-client", scopes },
         });
-        api.registerSessionAction({
-          id: "view",
-          requiredScopes: [READ_SCOPE],
-          handler: ({ client }) => {
-            handlerCalls.push({ scopes: client?.scopes ?? [], action: "view" });
-            return { result: { visible: true }, continueAgent: false };
-          },
-        });
-      },
-    });
-    setActivePluginRegistry(registry.registry);
-
-    await expect(
-      callApprovalAction({
-        actionId: "approve",
-        scopes: [APPROVALS_SCOPE],
-      }),
-    ).resolves.toEqual({
-      ok: true,
-      payload: { ok: true, result: { approved: true }, continueAgent: true },
-      error: undefined,
+      }
     });
 
-    await expect(
-      callApprovalAction({
-        actionId: "view",
-        scopes: [WRITE_SCOPE],
-      }),
-    ).resolves.toEqual({
-      ok: true,
-      payload: { ok: true, result: { visible: true }, continueAgent: false },
-      error: undefined,
-    });
-
-    const missingApprovalScope = await callApprovalAction({
-      actionId: "approve",
-      scopes: [READ_SCOPE],
-    });
-    const missingApprovalScopeError = requireHookError(missingApprovalScope);
-    expect(missingApprovalScopeError).toEqual({
-      code: "FORBIDDEN",
-      message: `missing scope: ${APPROVALS_SCOPE}`,
-      details: {
-        code: "MISSING_SCOPE",
-        missingScope: APPROVALS_SCOPE,
-        requiredScopes: [APPROVALS_SCOPE],
-      },
-    });
-    expect(handlerCalls).toEqual([
-      { scopes: [APPROVALS_SCOPE], sessionKey: undefined },
-      { scopes: [WRITE_SCOPE], action: "view" },
-    ]);
-
-    await expect(
-      callApprovalAction({
-        actionId: "approve",
-        extra: { sessionKey: ` ${MAIN_SESSION_KEY} ` },
-        scopes: [APPROVALS_SCOPE],
-      }),
-    ).resolves.toEqual({
-      ok: true,
-      payload: {
+    it("normalizes session keys and rejects invalid params for approval-only callers", async () => {
+      await expect(
+        callRegisteredSessionActionThroughGatewayForTest({
+          pluginId,
+          actionId: "approve",
+          extra: { sessionKey: ` ${MAIN_SESSION_KEY} ` },
+          scopes: [APPROVALS_SCOPE],
+        }),
+      ).resolves.toEqual({
         ok: true,
-        result: { approved: true, sessionKey: MAIN_SESSION_KEY },
-        continueAgent: true,
-      },
-      error: undefined,
-    });
-
-    await expect(
-      callApprovalAction({
-        actionId: "view",
-        scopes: [READ_SCOPE],
-      }),
-    ).resolves.toEqual({
-      ok: true,
-      payload: { ok: true, result: { visible: true }, continueAgent: false },
-      error: undefined,
-    });
-
-    const blankPluginId = await callPluginSessionActionThroughGatewayForTest({
-      body: {
-        pluginId: "   ",
+        payload: {
+          ok: true,
+          result: { accepted: true, sessionKey: MAIN_SESSION_KEY },
+          continueAgent: true,
+        },
+        error: undefined,
+      });
+      expect(handler).toHaveBeenCalledWith({
+        pluginId,
         actionId: "approve",
-      },
-      scopes: [APPROVALS_SCOPE],
+        sessionKey: MAIN_SESSION_KEY,
+        agentId: "main",
+        client: { connId: "test-client", scopes: [APPROVALS_SCOPE] },
+      });
+
+      const blankPluginId = await callPluginSessionActionThroughGatewayForTest({
+        body: { pluginId: "   ", actionId: "approve" },
+        scopes: [APPROVALS_SCOPE],
+      });
+      expect(requireHookError(blankPluginId)).toEqual({
+        code: "INVALID_REQUEST",
+        message: "plugins.sessionAction pluginId and actionId must be non-empty",
+      });
+      expect(handler).toHaveBeenCalledTimes(1);
     });
-    const blankPluginIdError = requireHookError(blankPluginId);
-    expect(blankPluginIdError.code).toBe("INVALID_REQUEST");
-    expect(blankPluginIdError.message).toBe(
-      "plugins.sessionAction pluginId and actionId must be non-empty",
-    );
-    expect(handlerCalls).toEqual([
-      { scopes: [APPROVALS_SCOPE], sessionKey: undefined },
-      { scopes: [WRITE_SCOPE], action: "view" },
-      { scopes: [APPROVALS_SCOPE], sessionKey: MAIN_SESSION_KEY },
-      { scopes: [READ_SCOPE], action: "view" },
-    ]);
   });
 
   it("passes a defensive copy of client scopes to session action handlers", async () => {


### PR DESCRIPTION
Closes #131526

<details>
<summary>Additional instructions</summary>

Maintainer-editable branch in the canonical repository. AI-assisted implementation and validation.

</details>

## What Problem This Solves

Fixes an issue where write-only operators could not invoke a plugin session action requiring `operator.talk`, even though the documented scope contract and ordinary Talk RPCs permit that broader scope. Actions requiring both Talk and approvals also reported Talk as the wrong missing permission, or refused callers that already held write plus approvals.

## Why This Change Was Made

Dynamic method admission and the selected-action handler each retained a write-implies-read-only predicate. Both now reuse the existing Gateway scope checker instead of maintaining separate implication rules. The handler still rechecks the actual selected registration after asynchronous admission; changing only the router would leave the second denial intact.

This is the canonical owner-boundary fix, rather than another Talk special case or a client permission upgrade. The shared role-scope helper is intentionally unchanged because it also normalizes strings, which is a broader contract than this repair.

Provenance: the dedicated Talk scope arrived in [least-privilege voice-node pairing](https://github.com/openclaw/openclaw/pull/115712) on July 29, authored and merged by `@steipete` (GitHub is the recorded commit committer). That change updated the static/shared implication predicates but not the two action predicates. The divergence exists in the inspected beta; the inspected stable release predates the dedicated Talk scope.

Production LOC: **+8/-11 (net -3)**. Tests: **+153/-120 (net +33)**. Docs: **+4/-0**. No new dependency, public API, configuration, schema, protocol version, or compatibility path.

## User Impact

A client with `operator.write` can invoke registered Talk-scoped plugin actions without requesting extra permission. Every declared requirement must still be satisfied: write does not grant approvals, Talk secrets, pairing, questions, or admin. Talk-only clients still cannot invoke default-write actions. Original presented scopes are passed to the action unchanged, and omitted or empty requirements continue to default to write.

The [operator scope guide](https://docs.openclaw.ai/gateway/operator-scopes) now states the session-action contract explicitly. Named role ceilings, the separate UI retry repair, real permissions, deployment configuration, and operator gateways are not changed.

## Evidence

The regression uses actual plugin registration, real `handleGatewayRequest` dispatch, the core session-action handler, and action invocation counts. Neither scope authorization gate is mocked.

Before production edits, the expanded contract file had **3 failed / 30 passed**:

- Write → Talk: expected one action call and success; received zero calls and `FORBIDDEN / MISSING_SCOPE operator.talk`.
- Write → Talk + approvals: expected missing approvals; received missing Talk.
- Write + approvals → Talk + approvals: expected success; received missing Talk and zero calls.

After repair, the same file passes **33/33**, and focused owner/sibling proof passes **236 tests across five files**:

```bash
node scripts/run-vitest.mjs src/plugins/contracts/session-actions.contract.test.ts src/gateway/method-scopes.test.ts src/shared/operator-scope-compat.test.ts src/gateway/server-methods.plugin-gateway-dispatch.test.ts src/gateway/control-ui-plugin-tabs.test.ts
```

All four core/plugin production/test typecheck lanes, changed-core lint, formatting, and source/dependency/boundary scans completed successfully. Fresh isolated Codex autoreview reported no accepted/actionable findings.

The canonical full `pnpm build` passed, including SDK export and CLI bootstrap checks. The exact plugin-lint stage and every remaining changed-gate guard then passed, with zero runtime import cycles. The earlier plugin-lint SDK declaration-generation timeout is recorded, not hidden: build/cache warming and reduced host load preceded the successful run with the unchanged `300000ms` limit and no skip flags. The full changed wrapper was not rerun; its successful stages and the completed remaining stages cover the frozen four-file diff.

A real, isolated dist-backed Gateway passed **12 session-action cases and five static Talk authorization comparisons**. Two freshly paired Ed25519 device clients reauthenticated using only their issued device tokens and negotiated exactly `["operator.write"]` and `["operator.talk"]`. The invocation ledger contained exactly four authorized calls; every denied action remained uninvoked. Successful handlers received the unchanged negotiated scope list. Write-only → Talk succeeded, write-only → Talk + approvals reported missing approvals, and secrets/admin requirements remained forbidden. Talk-only could use Talk but not default-write actions. Static Talk comparisons reached real handler parameter validation where authorized; this is not a voice-provider success claim.

The live proof used disposable HOME/state/config, a loopback port, synthetic credentials, native pairing approvals, and the production handshake/dispatcher; no authorization mocks or operator Gateway/state were used. The first attempt hit the unchanged startup deadline under heavy load. A second attempt exposed an incorrect scratch assertion about stored token metadata (write canonically also stores read); only that assertion was corrected, while negotiated and action scopes remained exactly write-only. The final run passed with unchanged startup/RPC limits, and its process, port, and temporary state were verified cleaned up.

Local proof commands also included:

```bash
pnpm build
```

```bash
env -u OPENCLAW_OXLINT_SKIP_PREPARE -u OPENCLAW_PLUGIN_SDK_BOUNDARY_ROOT_SHIMS_TIMEOUT_MS node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions
```

```bash
node .artifacts/gateway-scope-policy/run-live-proof.mjs
```

The scratch live-proof driver and sanitized responses are retained as local proof artifacts, not committed product code. Hosted exact-head CI is required before landing.
