### PR TITLE
fix(codex): gate /codex binding behind the host inspection check

### DIFF
--- a/extensions/codex/src/command-handlers.ts
+++ b/extensions/codex/src/command-handlers.ts
@@ -76,6 +76,7 @@ export type { CodexCommandDepsOverride } from "./command-handler-deps.js";
 
 const CODEX_HOST_INSPECTION_SUBCOMMANDS = new Set([
   "account",
+  "binding",
   "mcp",
   "sessions",
   "skills",

--- a/extensions/codex/src/command-host-inspection-gate.test.ts
+++ b/extensions/codex/src/command-host-inspection-gate.test.ts
@@ -1,0 +1,43 @@
+import type { PluginCommandContext } from "openclaw/plugin-sdk/plugin-entry";
+import { describe, expect, it } from "vitest";
+import {
+  CODEX_HOST_INSPECTION_AUTH_ERROR,
+  CODEX_NATIVE_EXECUTION_AUTH_ERROR,
+} from "./command-authorization.js";
+import { handleCodexSubcommand } from "./command-handlers.js";
+
+function ctxFor(args: string, senderIsOwner: boolean): PluginCommandContext {
+  return {
+    args,
+    senderIsOwner,
+    gatewayClientScopes: undefined,
+    config: {},
+  } as unknown as PluginCommandContext;
+}
+
+async function replyFor(args: string, senderIsOwner: boolean): Promise<string> {
+  const result = await handleCodexSubcommand(ctxFor(args, senderIsOwner), {
+    deps: {} as never,
+  });
+  return typeof result.text === "string" ? result.text : "";
+}
+
+describe("codex host inspection gate", () => {
+  // Every subcommand that reports host state is gated. `binding` reports the bound
+  // workspace directory, the same class of value `sessions` reports through
+  // `session.cwd` (node-cli-sessions.ts), so it belongs in the same set.
+  it.each(["account", "binding", "mcp", "sessions", "skills", "status", "threads"])(
+    "refuses /codex %s from a sender that is neither owner nor operator.admin",
+    async (subcommand) => {
+      await expect(replyFor(subcommand, false)).resolves.toBe(CODEX_HOST_INSPECTION_AUTH_ERROR);
+    },
+  );
+
+  it("still refuses native control subcommands with their own message", async () => {
+    await expect(replyFor("stop", false)).resolves.toBe(CODEX_NATIVE_EXECUTION_AUTH_ERROR);
+  });
+
+  it("leaves subcommands that report no host state open", async () => {
+    await expect(replyFor("help", false)).resolves.not.toBe(CODEX_HOST_INSPECTION_AUTH_ERROR);
+  });
+});


### PR DESCRIPTION
AI-assisted: implemented with an AI coding agent; reviewed and validated by the author.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

`/codex binding` reports the bound workspace directory to any sender the channel accepts,
while every other `/codex` subcommand that reports host state is owner-gated.

`extensions/codex/src/command-handlers.ts:77` lists the gated set:

```ts
const CODEX_HOST_INSPECTION_SUBCOMMANDS = new Set([
  "account",
  "mcp",
  "sessions",
  "skills",
  "status",
  "threads",
]);
```

`binding` is absent, so it skips the check at `:100` and answers everyone:

```ts
// extensions/codex/src/command-handler-bindings.ts:261-269
return [
  "Codex conversation binding:",
  `- Thread: ${formatCodexDisplayText(threadBinding?.threadId ?? "unknown")}`,
  `- Workspace: ${formatCodexDisplayText(data.workspaceDir)}`,
  `- Model: ${formatCodexDisplayText(threadBinding?.model ?? "default")}`,
  `- Fast: ${isCodexFastServiceTier(threadBinding?.serviceTier) ? "on" : "off"}`,
  `- Permissions: ${formatPermissionsMode(permissionMode)}`,
  ...
```

The CLI-node branch of the same function emits the same thing (`:239`,
`` `- Workspace: ${formatCodexDisplayText(data.cwd ?? "unknown")}` ``).

## Why This Change Was Made

**`sessions` is gated for emitting exactly this value.** Its formatter puts `session.cwd`
into the reply:

```ts
// extensions/codex/src/node-cli-sessions.ts:179
const details = [session.cwd, session.updatedAt].filter(...)
```

So two subcommands surface a host filesystem path; one is in
`CODEX_HOST_INSPECTION_SUBCOMMANDS` and one is not. That is the whole of it — the set already
encodes the intent, `binding` was left out of it.

`binding` also reports the session's permission mode, which is state `status` covers for the
host and `permissions` is gated for changing (`command-handler-actions.ts:422` additionally
requires `operator.admin` for `yolo`).

## Fix

Add `binding` to the existing set. Production change is **+1/-0**:

```diff
 const CODEX_HOST_INSPECTION_SUBCOMMANDS = new Set([
   "account",
+  "binding",
   "mcp",
   "sessions",
   "skills",
   "status",
   "threads",
 ]);
```

No new gate, no new message, no new configuration: the subcommand now takes the same path
`sessions` and `status` already take, and returns the same
`CODEX_HOST_INSPECTION_AUTH_ERROR` string.

**Alternative considered.** Redacting only the workspace line for non-owners would keep
`binding` readable for everyone. It was not taken because it invents a third behaviour for a
set that currently has exactly two, and because the permission mode on the same reply is host
state as well. If maintainers prefer the redaction shape, the gate list is the wrong place and
this PR should be closed in favour of that.

## User Impact

A sender who is neither the owner nor `operator.admin` now gets
`"Only an owner or operator.admin can inspect Codex host state."` from `/codex binding`,
the same answer they already get from `/codex status`. Owners and `operator.admin` clients
see no change. Single-operator deployments see no change, because the only sender is the
owner.

## Evidence

**New test** (`extensions/codex/src/command-host-inspection-gate.test.ts`, `+43/-0`). It
drives `handleCodexSubcommand` with `senderIsOwner: false` and no gateway scopes, once per
gated subcommand, and separately pins that native-control subcommands keep their own distinct
message and that `help` stays open:

```ts
it.each(["account", "binding", "mcp", "sessions", "skills", "status", "threads"])(
  "refuses /codex %s from a sender that is neither owner nor operator.admin",
  async (subcommand) => {
    await expect(replyFor(subcommand, false)).resolves.toBe(CODEX_HOST_INSPECTION_AUTH_ERROR);
  },
);
```

**Pre-fix failure is the intended one, and isolated.** With the test applied and the
`command-handlers.ts` hunk reverted, exactly the `binding` case fails while the other six
gated subcommands still pass:

```
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  extensions/codex/src/command-host-inspection-gate.test.ts >
       codex host inspection gate >
       refuses /codex binding from a sender that is neither owner nor operator.admin

      Tests  1 failed | 8 passed (9)
```

**With the fix applied:**

```
node scripts/run-vitest.mjs extensions/codex/src/command-host-inspection-gate.test.ts
      Tests  9 passed (9)
```

`oxfmt --check` and `oxlint` are clean on both files.
`node scripts/run-tsgo.mjs -p tsconfig.core.json` exits 0.
`tsconfig.extensions.json` reports three errors, all in `extensions/imap`
(`imapflow` / `mailparser` module resolution and one implicit `any`); they reproduce on a
clean checkout with this branch's changes removed, so they are pre-existing and untouched here.

```
git diff --numstat origin/main...HEAD
 1       0       extensions/codex/src/command-handlers.ts
43       0       extensions/codex/src/command-host-inspection-gate.test.ts
```

**Reproducible with git alone:**

```
git grep -n "CODEX_HOST_INSPECTION_SUBCOMMANDS" -- extensions/codex/    # the set and its use
git grep -n "Workspace: " -- extensions/codex/src/command-handler-bindings.ts
git grep -n "session.cwd" -- extensions/codex/src/node-cli-sessions.ts   # the gated peer
```

**Proof boundary.** Validation is at the handler level: the gate runs before any dependency
is touched, so the test needs no app-server, no binding store, and no filesystem. Delivery is
unchanged — the refusal is the same string the six existing gated subcommands already return.
