### PR TITLE
fix(skills): allow foreground repair after explicit invocation

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -431,6 +431,7 @@ vi.mock("../skills/discovery/chat-commands.runtime.js", () => ({
   listSkillCommandsForWorkspace: (params: unknown) =>
     state.listSkillCommandsForWorkspaceMock(params),
   resolveEffectiveAgentSkillFilter: () => undefined,
+  skillCommandsToExplicitSelections: () => [],
 }));
 
 vi.mock("../config/runtime-snapshot.js", () => ({

--- a/src/agents/agent-tools.before-tool-call.diagnostics.ts
+++ b/src/agents/agent-tools.before-tool-call.diagnostics.ts
@@ -35,6 +35,7 @@ import {
   resolveSkillTelemetrySource,
   resolveSkillTelemetrySourceValue,
 } from "../skills/loading/source.js";
+import { recordRunSkillUsage } from "../skills/runtime/run-usage.js";
 import type { SkillSnapshot, SkillTelemetrySource } from "../skills/types.js";
 import { isPlainObject, truncateUtf16Safe } from "../utils.js";
 import { buildAdjustedParamsKey } from "./agent-tools.before-tool-call.state.js";
@@ -55,6 +56,7 @@ import {
 } from "./tool-result-error.js";
 import { getToolTerminalPresentation } from "./tool-terminal-presentation.js";
 import type { AnyAgentTool } from "./tools/common.js";
+import { getGatewayToolCallerIdentity } from "./tools/gateway-caller-context.js";
 import { canonicalizePath } from "./utils/paths.js";
 
 export const beforeToolCallLog = createSubsystemLogger("agents/tools");
@@ -438,6 +440,17 @@ export function emitSkillUsedDiagnostic(params: {
     },
     params.match.skillFile ? { skillUsage: { skillFile: params.match.skillFile } } : undefined,
   );
+}
+
+export function recordSkillUsageMatch(params: { ctx?: HookContext; match: SkillUsageMatch }): void {
+  recordRunSkillUsage({
+    runId: params.ctx?.runId,
+    operationalRunInstance: getGatewayToolCallerIdentity()?.operationalRunInstance,
+    name: params.match.skillName,
+    source: params.match.skillSource,
+    activation: params.match.activation,
+    ...(params.match.skillFile ? { skillFile: params.match.skillFile } : {}),
+  });
 }
 
 export function emitToolBlockedSecurityEvent(params: {

--- a/src/agents/agent-tools.before-tool-call.wrapper.ts
+++ b/src/agents/agent-tools.before-tool-call.wrapper.ts
@@ -14,7 +14,6 @@ import {
 } from "../infra/diagnostic-trace-context.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { getPluginToolMeta } from "../plugins/tool-metadata.js";
-import { recordRunSkillUsage } from "../skills/runtime/run-usage.js";
 import { copyBeforeToolCallWrapperMetadata } from "./agent-tool-metadata.js";
 import {
   captureAgentToolExecutionBudget,
@@ -32,6 +31,7 @@ import {
   findSkillUsageMatch,
   prepareToolTerminalPresentation,
   reconcileLoopCallExecutionParams,
+  recordSkillUsageMatch,
   recordLoopOutcome,
   rememberPendingTerminalPresentation,
   resolveToolDiagnosticIdentity,
@@ -583,13 +583,7 @@ export function wrapToolWithBeforeToolCallHook(
           ctx,
         });
         if (skillMatch) {
-          recordRunSkillUsage({
-            runId: ctx?.runId,
-            name: skillMatch.skillName,
-            source: skillMatch.skillSource,
-            activation: skillMatch.activation,
-            ...(skillMatch.skillFile ? { skillFile: skillMatch.skillFile } : {}),
-          });
+          recordSkillUsageMatch({ ctx, match: skillMatch });
         }
         if (hookOptions.emitDiagnostics) {
           if (skillMatch) {

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -770,6 +770,9 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
       ? {
           agentId: executionAgentId,
           sessionKey: executionSessionKey.trim(),
+          ...(options.operationalRunInstance
+            ? { operationalRunInstance: options.operationalRunInstance }
+            : {}),
           ...(options.abortSignal ? { approvalSignals: [options.abortSignal] } : {}),
           turnSourceChannel: resolveGatewayMessageChannel(
             options.messageChannel ?? options.messageProvider,

--- a/src/agents/cli-runner.before-agent-reply-cron.test.ts
+++ b/src/agents/cli-runner.before-agent-reply-cron.test.ts
@@ -12,6 +12,8 @@ import {
   type DiagnosticEventPayload,
 } from "../infra/diagnostic-events.js";
 import type { HookRunner } from "../plugins/hooks.js";
+import { bindWorkspaceSkillUsage } from "../skills/runtime/run-usage.js";
+import type { OperationalRunInstanceRef } from "./admitted-run-context.js";
 import { wrapRunWithTestPreparedAdmission } from "./admitted-run-context.test-support.js";
 import { getOrCreateSessionMcpRuntime } from "./agent-bundle-mcp-manager.test-support.js";
 import { testing as cliBackendsTesting } from "./cli-backends.test-support.js";
@@ -141,10 +143,20 @@ async function captureRejectedClaudeRun(
   return { error, events };
 }
 
-function makeStubContext(params: typeof baseRunParams & { trigger?: string }) {
+async function makeStubContext(
+  params: typeof baseRunParams & {
+    trigger?: string;
+    preparedRunAdmission?: {
+      admit: (runtimeKind: "embedded") => Promise<{
+        operationalRunInstance: OperationalRunInstanceRef;
+      }>;
+    };
+  },
+) {
   // Stub only the prepared context shape runCliAgent needs after the hook gate.
+  const admittedRunContext = await params.preparedRunAdmission?.admit("embedded");
   return {
-    params,
+    params: { ...params, admittedRunContext },
     started: Date.now(),
     workspaceDir: params.workspaceDir,
     modelId: params.model,
@@ -155,7 +167,7 @@ function makeStubContext(params: typeof baseRunParams & { trigger?: string }) {
     backendResolved: {},
     preparedBackend: { backend: { sessionMode: "none" } },
     reusableCliSession: { mode: "none" },
-  } as unknown;
+  };
 }
 
 beforeEach(() => {
@@ -168,9 +180,18 @@ beforeEach(() => {
   executePreparedCliRunMock.mockReset();
   executePreparedCliRunMock.mockResolvedValue({ text: "" });
   prepareCliRunContextMock.mockReset();
-  prepareCliRunContextMock.mockImplementation(async (params) =>
-    makeStubContext(params as typeof baseRunParams & { trigger?: string }),
-  );
+  prepareCliRunContextMock.mockImplementation(async (params) => {
+    return await makeStubContext(
+      params as typeof baseRunParams & {
+        trigger?: string;
+        preparedRunAdmission?: {
+          admit: (runtimeKind: "embedded") => Promise<{
+            operationalRunInstance: OperationalRunInstanceRef;
+          }>;
+        };
+      },
+    );
+  });
   closeCliSessionMock.mockReset();
   closeMcpLoopbackServerMock.mockReset();
   retireSessionMcpRuntimeForSessionKeyMock.mockReset();
@@ -201,6 +222,47 @@ afterEach(() => {
 });
 
 describe("runCliAgent before_agent_reply seam", () => {
+  it("arms only the selected workspace skill for the prepared CLI run", async () => {
+    const selectedSkillFile = "/tmp/test-workspace/skills/selected/SKILL.md";
+    const unselectedSkillFile = "/tmp/test-workspace/skills/unselected/SKILL.md";
+    let operationalRunInstance: OperationalRunInstanceRef | undefined;
+    executePreparedCliRunMock.mockImplementationOnce(async (context) => {
+      operationalRunInstance = (
+        context as {
+          params: { admittedRunContext: { operationalRunInstance: OperationalRunInstanceRef } };
+        }
+      ).params.admittedRunContext.operationalRunInstance;
+      expect(
+        bindWorkspaceSkillUsage({ operationalRunInstance, skillFile: selectedSkillFile })?.(),
+      ).toBe(true);
+      expect(
+        bindWorkspaceSkillUsage({ operationalRunInstance, skillFile: unselectedSkillFile }),
+      ).toBeUndefined();
+      return { text: "done" };
+    });
+
+    await runCliAgent({
+      ...baseRunParams,
+      explicitSkillSelections: [{ name: "selected", path: selectedSkillFile }],
+      skillsSnapshot: {
+        prompt: "",
+        skills: [],
+        skillCommandUsagePaths: [
+          {
+            readPath: selectedSkillFile,
+            skillFile: selectedSkillFile,
+            skillName: "selected",
+            skillSource: "workspace",
+          },
+        ],
+      },
+    });
+
+    expect(
+      bindWorkspaceSkillUsage({ operationalRunInstance, skillFile: selectedSkillFile }),
+    ).toBeUndefined();
+  });
+
   it.each([
     ["claude-cli", "user"],
     ["google-gemini-cli", "cron"],
@@ -211,7 +273,7 @@ describe("runCliAgent before_agent_reply seam", () => {
       profiles: { [profileId]: { type: "api_key", provider, key: "secret" } },
     } as const;
     prepareCliRunContextMock.mockImplementationOnce(async (params) => ({
-      ...(makeStubContext(params as typeof baseRunParams & { trigger?: string }) as object),
+      ...(await makeStubContext(params as typeof baseRunParams & { trigger?: string })),
       effectiveAuthProfileId: profileId,
       authProfileStore: store,
       agentDir: "/tmp/agent",
@@ -302,18 +364,21 @@ describe("runCliAgent before_agent_reply seam", () => {
         [profileId]: { cooldownUntil: Date.now() + 60_000, cooldownReason: "session_expired" },
       },
     };
-    prepareCliRunContextMock.mockImplementationOnce(async (params) => ({
-      ...(makeStubContext(params as typeof baseRunParams & { trigger?: string }) as object),
-      effectiveAuthProfileId: profileId,
-      authProfileStore: store,
-      agentDir: "/tmp/agent",
-      openClawHistoryPrompt: "history",
-      reusableCliSession: { mode: "reuse", sessionId: "stale-session" },
-      params: {
-        ...(params as typeof baseRunParams),
-        onBeforeFreshCliSessionRetry: vi.fn(async () => true),
-      },
-    }));
+    prepareCliRunContextMock.mockImplementationOnce(async (params) => {
+      const context = await makeStubContext(params as typeof baseRunParams & { trigger?: string });
+      return {
+        ...context,
+        effectiveAuthProfileId: profileId,
+        authProfileStore: store,
+        agentDir: "/tmp/agent",
+        openClawHistoryPrompt: "history",
+        reusableCliSession: { mode: "reuse", sessionId: "stale-session" },
+        params: {
+          ...context.params,
+          onBeforeFreshCliSessionRetry: vi.fn(async () => true),
+        },
+      };
+    });
     executePreparedCliRunMock
       .mockRejectedValueOnce(
         new FailoverError("stale session", {
@@ -348,7 +413,7 @@ describe("runCliAgent before_agent_reply seam", () => {
       persistBlocked: vi.fn(async (message) => ({ message })),
     } as unknown as NonNullable<Parameters<typeof runCliAgent>[0]["userTurnTranscriptRecorder"]>;
     prepareCliRunContextMock.mockImplementationOnce(async (params) => ({
-      ...(makeStubContext(params as typeof baseRunParams & { trigger?: string }) as object),
+      ...(await makeStubContext(params as typeof baseRunParams & { trigger?: string })),
       effectiveAuthProfileId: profileId,
       authProfileStore: store,
       agentDir: "/tmp/agent",
@@ -384,7 +449,7 @@ describe("runCliAgent before_agent_reply seam", () => {
   ])("does not settle selected-profile health for local failure %#", async (error) => {
     const profileId = "claude-cli:selected";
     prepareCliRunContextMock.mockImplementationOnce(async (params) => ({
-      ...(makeStubContext(params as typeof baseRunParams & { trigger?: string }) as object),
+      ...(await makeStubContext(params as typeof baseRunParams & { trigger?: string })),
       effectiveAuthProfileId: profileId,
       authProfileStore: {
         version: 1,

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -47,7 +47,6 @@ import {
   resolveCliSourceReplyMirror,
   settleCliBackendOutcome,
   settleCliPreparationError,
-  settlePreparedCliRun,
 } from "./cli-runner/cli-run-settlement.js";
 import {
   buildCliHookAssistantMessage,
@@ -73,6 +72,7 @@ import {
   loadCliSessionContextEngineMessages,
   loadCliSessionHistoryMessages,
 } from "./cli-runner/session-history.js";
+import { settlePreparedCliRunWithSkillUsage } from "./cli-runner/skill-usage.js";
 import type { PreparedCliRunContext, RunCliAgentParams } from "./cli-runner/types.js";
 import { claudeCliSessionTranscriptHasContent as claudeCliSessionTranscriptHasContentImpl } from "./command/attempt-execution.helpers.js";
 import type { EmbeddedAgentRunResult } from "./embedded-agent-runner.js";
@@ -83,7 +83,6 @@ import {
   runAgentHarnessLlmInputHook,
   runAgentHarnessLlmOutputHook,
 } from "./harness/lifecycle-hook-helpers.js";
-import { recordExplicitSkillSelectionsForRun } from "./skill-selection-usage.js";
 
 const log = createSubsystemLogger("agents/cli-runner");
 const cliRunnerDeps = cliRunSettlementDeps;
@@ -236,12 +235,7 @@ async function runCliAgentInternal(
     await settleCliPreparationError(error, params);
     throw error;
   }
-  recordExplicitSkillSelectionsForRun({
-    operationalRunInstance: context.params.admittedRunContext.operationalRunInstance,
-    selections: context.params.explicitSkillSelections,
-    skillsSnapshot: context.params.skillsSnapshot,
-  });
-  return await settlePreparedCliRun({
+  return await settlePreparedCliRunWithSkillUsage({
     context,
     diagnosticLifecycle,
     run: async () => await runPreparedCliAgent(context, diagnosticLifecycle),

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -83,6 +83,7 @@ import {
   runAgentHarnessLlmInputHook,
   runAgentHarnessLlmOutputHook,
 } from "./harness/lifecycle-hook-helpers.js";
+import { recordExplicitSkillSelectionsForRun } from "./skill-selection-usage.js";
 
 const log = createSubsystemLogger("agents/cli-runner");
 const cliRunnerDeps = cliRunSettlementDeps;
@@ -235,6 +236,11 @@ async function runCliAgentInternal(
     await settleCliPreparationError(error, params);
     throw error;
   }
+  recordExplicitSkillSelectionsForRun({
+    operationalRunInstance: context.params.admittedRunContext.operationalRunInstance,
+    selections: context.params.explicitSkillSelections,
+    skillsSnapshot: context.params.skillsSnapshot,
+  });
   return await settlePreparedCliRun({
     context,
     diagnosticLifecycle,

--- a/src/agents/cli-runner/cli-run-settlement.ts
+++ b/src/agents/cli-runner/cli-run-settlement.ts
@@ -3,6 +3,10 @@ import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
+  discardRunSkillUsage,
+  discardRunWorkspaceSkillUsage,
+} from "../../skills/runtime/run-usage.js";
+import {
   externalCliDiscoveryForProviderAuth,
   loadAuthProfileStoreForRuntime,
   markAuthProfileFailure,
@@ -176,6 +180,8 @@ export async function settlePreparedCliRun(params: {
   } catch (error) {
     runError = error;
   }
+  discardRunSkillUsage(runParams.runId);
+  discardRunWorkspaceSkillUsage(runParams.admittedRunContext.operationalRunInstance);
   const terminalRunError = runError;
   let cleanupError: unknown;
   const recordCleanupError = (error: unknown) => {

--- a/src/agents/cli-runner/cli-run-settlement.ts
+++ b/src/agents/cli-runner/cli-run-settlement.ts
@@ -2,10 +2,7 @@ import { setReplyPayloadMetadata, type ReplyPayload } from "../../auto-reply/rep
 import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
-import {
-  discardRunSkillUsage,
-  discardRunWorkspaceSkillUsage,
-} from "../../skills/runtime/run-usage.js";
+import { discardRunSkillUsageForOperationalRun } from "../../skills/runtime/run-usage.js";
 import {
   externalCliDiscoveryForProviderAuth,
   loadAuthProfileStoreForRuntime,
@@ -180,8 +177,7 @@ export async function settlePreparedCliRun(params: {
   } catch (error) {
     runError = error;
   }
-  discardRunSkillUsage(runParams.runId);
-  discardRunWorkspaceSkillUsage(runParams.admittedRunContext.operationalRunInstance);
+  discardRunSkillUsageForOperationalRun(runParams.admittedRunContext.operationalRunInstance);
   const terminalRunError = runError;
   let cleanupError: unknown;
   const recordCleanupError = (error: unknown) => {

--- a/src/agents/cli-runner/skill-usage.ts
+++ b/src/agents/cli-runner/skill-usage.ts
@@ -1,0 +1,15 @@
+import { recordExplicitSkillSelectionsForRun } from "../skill-selection-usage.js";
+import { settlePreparedCliRun } from "./cli-run-settlement.js";
+
+/** Records exact explicit selections for the lifetime owned by CLI settlement. */
+export async function settlePreparedCliRunWithSkillUsage(
+  params: Parameters<typeof settlePreparedCliRun>[0],
+): ReturnType<typeof settlePreparedCliRun> {
+  const { context } = params;
+  recordExplicitSkillSelectionsForRun({
+    operationalRunInstance: context.params.admittedRunContext.operationalRunInstance,
+    selections: context.params.explicitSkillSelections,
+    skillsSnapshot: context.params.skillsSnapshot,
+  });
+  return await settlePreparedCliRun(params);
+}

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -42,7 +42,7 @@ import type { PluginHookChannelContext } from "../../plugins/hook-types.js";
 import type { SpawnSecretInput } from "../../process/supervisor/types.js";
 import type { InputProvenance } from "../../sessions/input-provenance.js";
 import type { UserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
-import type { SkillSnapshot } from "../../skills/types.js";
+import type { ExplicitSkillSelection, SkillSnapshot } from "../../skills/types.js";
 import type { SkillWorkshopProposalRevisionConstraint } from "../../skills/workshop/types.js";
 import type { AdmittedRunContext, PreparedAgentRunAdmission } from "../admitted-run-context.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
@@ -238,6 +238,7 @@ export type RunCliAgentParams = {
   /** Ordered facts represented by attachment text in the current prompt. */
   media?: MediaFact[];
   skillsSnapshot?: SkillSnapshot;
+  explicitSkillSelections?: ExplicitSkillSelection[];
   messageChannel?: string;
   messageProvider?: string;
   /** Capabilities declared by the gateway client that originated this run. */

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -603,6 +603,7 @@ describe("CLI attempt execution", () => {
     sessionKey?: string;
     body?: string;
     transcriptBody?: string;
+    explicitSkillSelections?: RunAgentAttemptParams["explicitSkillSelections"];
     providerOverride?: string;
     modelOverride?: string;
     isFallbackRetry?: boolean;
@@ -655,6 +656,7 @@ describe("CLI attempt execution", () => {
       workspaceDir: tmpDir,
       body: overrides?.body ?? "stream gate",
       transcriptBody: overrides?.transcriptBody,
+      explicitSkillSelections: overrides?.explicitSkillSelections,
       isFallbackRetry: overrides?.isFallbackRetry ?? false,
       fallbackRuntimeState: overrides?.fallbackRuntimeState,
       timeoutMs: overrides?.timeoutMs ?? 1_000,
@@ -822,6 +824,21 @@ describe("CLI attempt execution", () => {
     expect(onExecutionStarted).toHaveBeenCalledTimes(1);
   });
 
+  it("forwards CLI-resolved explicit skill selections to embedded dispatch", async () => {
+    const explicitSkillSelections = [
+      {
+        name: "receipt-proof",
+        path: path.join(tmpDir, "skills", "receipt-proof", "SKILL.md"),
+      },
+    ];
+    const embedded = await runOpenClawEmbeddedAttemptForTest({
+      runId: "embedded-explicit-skill-selection",
+      explicitSkillSelections,
+    });
+
+    expect(embedded.explicitSkillSelections).toEqual(explicitSkillSelections);
+  });
+
   it("forwards authoritative channel type to embedded runs with opaque session keys", async () => {
     const embedded = await runOpenClawEmbeddedAttemptForTest({
       runId: "embedded-opaque-channel",
@@ -871,6 +888,7 @@ describe("CLI attempt execution", () => {
     sessionStore: Record<string, SessionEntry>;
     body: string;
     runId: string;
+    explicitSkillSelections?: RunAgentAttemptParams["explicitSkillSelections"];
     cwd?: string;
     onExecutionStarted?: () => void;
     onAgentEvent?: RunAgentAttemptParams["onAgentEvent"];
@@ -885,6 +903,7 @@ describe("CLI attempt execution", () => {
       cwd: params.cwd,
       body: params.body,
       classifyResult: params.classifyResult,
+      explicitSkillSelections: params.explicitSkillSelections,
       runId: params.runId,
       opts: { onExecutionStarted: params.onExecutionStarted },
       ...(params.onAgentEvent ? { onAgentEvent: params.onAgentEvent } : {}),
@@ -926,6 +945,31 @@ describe("CLI attempt execution", () => {
       });
     },
   );
+
+  it("forwards frozen explicit skill selections to the configured CLI runtime", async () => {
+    const sessionKey = "agent:main:direct:cli-explicit-skill";
+    const sessionEntry = makeSessionEntry("session-cli-explicit-skill");
+    const sessionStore = { [sessionKey]: sessionEntry };
+    const explicitSkillSelections = [
+      {
+        name: "receipt-proof",
+        path: path.join(tmpDir, "skills", "receipt-proof", "SKILL.md"),
+      },
+    ];
+    await writeSessionStoreSeed(sessionStore);
+    runCliAgentMock.mockResolvedValueOnce(makeCliResult("selected"));
+
+    await runClaudeCliAttempt({
+      sessionKey,
+      sessionEntry,
+      sessionStore,
+      body: "use the selected skill",
+      runId: "run-cli-explicit-skill",
+      explicitSkillSelections,
+    });
+
+    expect(firstRunCliAgentArg().explicitSkillSelections).toEqual(explicitSkillSelections);
+  });
 
   it.each(["assistant_output_started", "tool_execution_started"] as const)(
     "keeps CLI admission separate from observed %s",
@@ -1105,6 +1149,7 @@ describe("CLI attempt execution", () => {
       cfg,
       body: opts.message,
       transcriptBody: opts.message,
+      explicitSkillSelections: undefined,
       configuredThinkingCatalog: [],
       normalizedSpawned: {},
       agentCfg: undefined,

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -51,7 +51,7 @@ import {
   type UserTurnInput,
   type UserTurnTranscriptRecorder,
 } from "../../sessions/user-turn-transcript.js";
-import type { SkillSnapshot } from "../../skills/types.js";
+import type { ExplicitSkillSelection, SkillSnapshot } from "../../skills/types.js";
 import {
   getGeneratedMediaTaskIdsForSessionKey,
   hasNewGeneratedMediaTaskForSessionKey,
@@ -580,6 +580,7 @@ export function runAgentAttempt(params: {
   cwd?: string;
   body: string;
   transcriptBody?: string;
+  explicitSkillSelections?: ExplicitSkillSelection[];
   isFallbackRetry: boolean;
   preserveCliSessionBinding?: boolean;
   classifyResult?: (result: EmbeddedAgentRunResult) => ModelFallbackResultClassification;
@@ -1134,6 +1135,7 @@ export function runAgentAttempt(params: {
             imageOrder: params.opts.imageOrder,
             media: params.opts.media,
             skillsSnapshot: params.skillsSnapshot,
+            explicitSkillSelections: params.explicitSkillSelections,
             ...toolContext,
             streamParams: params.opts.streamParams,
             // Completion relays can carry the trusted source only in their
@@ -1332,6 +1334,7 @@ export function runAgentAttempt(params: {
     skillsSnapshot: params.skillsSnapshot,
     prompt: effectivePrompt,
     transcriptPrompt: continuationTranscriptBody,
+    explicitSkillSelections: params.explicitSkillSelections,
     // CLI-origin retries cannot rely on transcript replay: orphan-user repair
     // removes the persisted CLI turn before the embedded prompt is submitted.
     images: shouldForwardImagesToEmbedded ? params.opts.images : undefined,

--- a/src/agents/command/prepare.ts
+++ b/src/agents/command/prepare.ts
@@ -24,6 +24,7 @@ import {
   AGENT_HARNESS_MODEL_RUN_FORBIDDEN_MESSAGE,
   resolveAgentHarnessSessionContextError,
 } from "../../sessions/agent-harness-session-key.js";
+import type { ExplicitSkillSelection } from "../../skills/types.js";
 import { resolveUserPath } from "../../utils.js";
 import { isDeliverableMessageChannel, resolveMessageChannel } from "../../utils/message-channel.js";
 import { resolveAgentRuntimeConfig } from "../agent-runtime-config.js";
@@ -373,12 +374,14 @@ export async function prepareAgentCommandExecution(
     });
     const runId = opts.runId?.trim() || sessionId;
     let promptMessage = message;
+    let explicitSkillSelections: ExplicitSkillSelection[] | undefined;
     if (!isRawModelRun && (message.includes("$") || message.trimStart().startsWith("/"))) {
       const {
         expandExplicitSkillReferences,
         hasSkillReferenceCandidate,
         listSkillCommandsForWorkspace,
         resolveEffectiveAgentSkillFilter,
+        skillCommandsToExplicitSelections,
       } = await import("../../skills/discovery/chat-commands.runtime.js");
       const hasExplicitSkillCandidate =
         message.trimStart().startsWith("/") || hasSkillReferenceCandidate(message);
@@ -405,6 +408,8 @@ export async function prepareAgentCommandExecution(
         if (expansion.error) {
           throw new Error(expansion.error);
         }
+        const selections = skillCommandsToExplicitSelections(expansion.skills);
+        explicitSkillSelections = selections.length > 0 ? selections : undefined;
         promptMessage = expansion.body;
       }
     }
@@ -420,6 +425,7 @@ export async function prepareAgentCommandExecution(
       opts: commandOpts,
       body,
       transcriptBody,
+      explicitSkillSelections,
       cfg,
       configuredThinkingCatalog,
       normalizedSpawned,

--- a/src/agents/command/run-embedded-attempt.ts
+++ b/src/agents/command/run-embedded-attempt.ts
@@ -65,7 +65,6 @@ export async function runEmbeddedAgentAttempt(params: RunEmbeddedAgentAttemptPar
     cfg,
     body,
     transcriptBody,
-    explicitSkillSelections,
     sessionId,
     sessionKey,
     sessionStore,
@@ -481,7 +480,7 @@ export async function runEmbeddedAgentAttempt(params: RunEmbeddedAgentAttemptPar
               cwd,
               body,
               transcriptBody,
-              explicitSkillSelections,
+              explicitSkillSelections: params.prepared.explicitSkillSelections,
               isFallbackRetry: runOptions.isFallbackRetry,
               classifyResult: runOptions.classifyResult,
               preserveCliSessionBinding:

--- a/src/agents/command/run-embedded-attempt.ts
+++ b/src/agents/command/run-embedded-attempt.ts
@@ -65,6 +65,7 @@ export async function runEmbeddedAgentAttempt(params: RunEmbeddedAgentAttemptPar
     cfg,
     body,
     transcriptBody,
+    explicitSkillSelections,
     sessionId,
     sessionKey,
     sessionStore,
@@ -480,6 +481,7 @@ export async function runEmbeddedAgentAttempt(params: RunEmbeddedAgentAttemptPar
               cwd,
               body,
               transcriptBody,
+              explicitSkillSelections,
               isFallbackRetry: runOptions.isFallbackRetry,
               classifyResult: runOptions.classifyResult,
               preserveCliSessionBinding:

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
@@ -3,6 +3,11 @@ import { createDeferred } from "../../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { getAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
 import {
+  bindWorkspaceSkillUsage,
+  consumeRunSkillUsage,
+  discardRunWorkspaceSkillUsage,
+} from "../../skills/runtime/run-usage.js";
+import {
   prepareSystemAgentRunAdmission,
   type AdmittedRunContext,
 } from "../admitted-run-context.js";
@@ -189,12 +194,16 @@ function makeDispatchInput(
 describe("embedded run retry dispatch", () => {
   let admission: ReturnType<typeof prepareSystemAgentRunAdmission>;
   beforeEach(async () => {
+    consumeRunSkillUsage("run-1");
     mocks.runAttempt.mockReset().mockResolvedValue({ terminal: { kind: "ok" } });
     mocks.settleRequesterAfterSessionSpawns.mockReset();
     admission = prepareSystemAgentRunAdmission({}, "run-1", "main", "dispatch-test");
     admittedRunContext = await admission.admit("plugin-harness", "dispatch-test");
   });
-  afterEach(() => admission.close());
+  afterEach(() => {
+    discardRunWorkspaceSkillUsage(admittedRunContext.operationalRunInstance);
+    admission.close();
+  });
 
   it.each([undefined, "global", "agent:main:policy"])(
     "dispatches a global plugin attempt with its prepared owner (%s)",
@@ -223,6 +232,64 @@ describe("embedded run retry dispatch", () => {
       expect(mocks.runAttempt).toHaveBeenCalledTimes(1);
       expect(mocks.runAttempt.mock.calls[0]?.[0]).toEqual(result.preparedAttempt);
       expect(mocks.runAttempt.mock.calls[0]?.[1]).toBeUndefined();
+    },
+  );
+
+  it.each(["openclaw", "codex", "third-party"])(
+    "records only snapshot-matched explicit skill selections for the admitted %s run",
+    async (agentHarnessId) => {
+      const skillFile = "/tmp/workspace/skills/release/SKILL.md";
+      const bundledSkillFile = "/tmp/bundled/skills/lint/SKILL.md";
+      const input = makeDispatchInput({}, createEmbeddedRunReplayState());
+      input.preparedRuntime.snapshot().agentHarness.id = agentHarnessId;
+      input.runInput.runParams.explicitSkillSelections = [
+        { name: "release_alias", path: skillFile },
+        { name: "bundled_lint", path: bundledSkillFile },
+        { name: "unmatched", path: "/tmp/workspace/skills/unmatched/SKILL.md" },
+      ];
+      input.runInput.runParams.skillsSnapshot = {
+        prompt: "",
+        skills: [],
+        skillCommandUsagePaths: [
+          {
+            readPath: skillFile,
+            skillFile,
+            skillName: "release",
+            skillSource: "workspace",
+          },
+          {
+            readPath: bundledSkillFile,
+            skillFile: bundledSkillFile,
+            skillName: "lint",
+            skillSource: "bundled",
+          },
+        ],
+      };
+
+      await prepareAndDispatchEmbeddedRunAttempt(input);
+      await prepareAndDispatchEmbeddedRunAttempt(input);
+
+      expect(
+        bindWorkspaceSkillUsage({
+          operationalRunInstance: admittedRunContext.operationalRunInstance,
+          skillFile,
+        })?.(),
+      ).toBe(true);
+      expect(
+        bindWorkspaceSkillUsage({
+          operationalRunInstance: admittedRunContext.operationalRunInstance,
+          skillFile: bundledSkillFile,
+        }),
+      ).toBeUndefined();
+      expect(consumeRunSkillUsage("run-1")).toEqual([
+        { name: "release", source: "workspace", activation: "command", skillFile },
+        {
+          name: "lint",
+          source: "bundled",
+          activation: "command",
+          skillFile: bundledSkillFile,
+        },
+      ]);
     },
   );
 

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
@@ -19,6 +19,7 @@ import { buildAgentRuntimePlan } from "../../runtime-plan/build.js";
 import { resolveSessionPermissionExecMode } from "../../session-permission-exec-mode.js";
 import { resolveSessionPlacementSandbox } from "../../session-placement-admission.js";
 import { resolveSessionSkillResourceSnapshot } from "../../session-placement-skill-resources.js";
+import { recordExplicitSkillSelectionsForRun } from "../../skill-selection-usage.js";
 import { createToolTerminalObserver } from "../../tool-terminal-outcome.js";
 import {
   createAdmittedGatewayToolCallerIdentity,
@@ -664,9 +665,14 @@ export async function prepareAndDispatchEmbeddedRunAttempt(input: {
     turnSourceAccountId: params.agentAccountId,
     turnSourceThreadId: params.currentThreadTs,
   });
-  const rawAttempt = await withGatewayToolCallerIdentity(callerIdentity, () =>
-    runEmbeddedAttemptWithBackend(attemptParams, nativeSessionRuntime),
-  )
+  const rawAttempt = await withGatewayToolCallerIdentity(callerIdentity, () => {
+    recordExplicitSkillSelectionsForRun({
+      operationalRunInstance: attemptParams.admittedRunContext.operationalRunInstance,
+      selections: params.explicitSkillSelections,
+      skillsSnapshot: params.skillsSnapshot,
+    });
+    return runEmbeddedAttemptWithBackend(attemptParams, nativeSessionRuntime);
+  })
     .catch((err: unknown): never => {
       throw input.getPostCompactionAbortError() ?? err;
     })

--- a/src/agents/embedded-agent-runner/run/run-settlement.ts
+++ b/src/agents/embedded-agent-runner/run/run-settlement.ts
@@ -1,6 +1,10 @@
 /** Publishes committed run accounting before retiring its runtime resources. */
 import { incrementCompactionCount } from "../../../auto-reply/reply/session-updates.js";
 import { formatErrorMessage } from "../../../infra/errors.js";
+import {
+  discardRunSkillUsage,
+  discardRunWorkspaceSkillUsage,
+} from "../../../skills/runtime/run-usage.js";
 import { getAdmittedRunDelegatedAuthority } from "../../admitted-run-context.js";
 import { retireSessionMcpRuntime } from "../../agent-bundle-mcp-tools.js";
 import type { ContextEngineLogicalTurnLease } from "../../harness/context-engine-logical-turn.js";
@@ -36,6 +40,8 @@ export async function settleEmbeddedRun(input: {
 }): Promise<void> {
   const { runInput, runtime, compaction, ownedContextEngineLease } = input;
   const params = runInput.runParams;
+  discardRunSkillUsage(params.runId);
+  discardRunWorkspaceSkillUsage(runtime.admittedRunContext.operationalRunInstance);
   // Publish committed bookkeeping before cleanup can throw or cancellation closes the caller.
   // A returned model/session id is never a substitute for the accepted host target.
   const committed = compaction.session.committedCompactionSuccessor;

--- a/src/agents/skill-selection-usage.test.ts
+++ b/src/agents/skill-selection-usage.test.ts
@@ -1,0 +1,140 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  claimAgentRunDelegatedAuthority,
+  releaseAgentRunDelegatedAuthority,
+} from "../infra/agent-run-registry.js";
+import {
+  bindWorkspaceSkillUsage,
+  discardRunSkillUsage,
+  discardRunWorkspaceSkillUsage,
+} from "../skills/runtime/run-usage.js";
+import type { SkillSnapshot, SkillUsagePath } from "../skills/types.js";
+import { createOperationalRunInstanceRef } from "./admitted-run-context.js";
+import { recordExplicitSkillSelectionsForRun } from "./skill-selection-usage.js";
+
+function snapshotWithCommands(commands: SkillUsagePath[]): SkillSnapshot {
+  return { prompt: "", skills: [], skillCommandUsagePaths: commands };
+}
+
+function workspaceCommand(
+  readPath: string,
+  skillFile = readPath,
+  skillName = "demo",
+): SkillUsagePath {
+  return { readPath, skillFile, skillName, skillSource: "workspace" };
+}
+
+describe("explicit skill selection usage", () => {
+  it("records only the exact selected workspace skill file", () => {
+    const runId = "explicit-selection";
+    const operationalRunInstance = createOperationalRunInstanceRef(runId);
+    const authority = claimAgentRunDelegatedAuthority(operationalRunInstance);
+    const selectedFile = path.resolve("workspace/skills/selected/SKILL.md");
+    const otherFile = path.resolve("workspace/skills/other/SKILL.md");
+    try {
+      recordExplicitSkillSelectionsForRun({
+        operationalRunInstance,
+        selections: [{ name: "shared", path: selectedFile }],
+        skillsSnapshot: snapshotWithCommands([
+          workspaceCommand(selectedFile, selectedFile, "shared"),
+          workspaceCommand(otherFile, otherFile, "shared"),
+        ]),
+      });
+
+      expect(bindWorkspaceSkillUsage({ operationalRunInstance, skillFile: selectedFile })?.()).toBe(
+        true,
+      );
+      expect(
+        bindWorkspaceSkillUsage({ operationalRunInstance, skillFile: otherFile }),
+      ).toBeUndefined();
+    } finally {
+      discardRunSkillUsage(runId);
+      discardRunWorkspaceSkillUsage(operationalRunInstance);
+      releaseAgentRunDelegatedAuthority(authority);
+    }
+  });
+
+  it("fails closed for relative or ambiguous command paths", () => {
+    const runId = "ambiguous-selection";
+    const operationalRunInstance = createOperationalRunInstanceRef(runId);
+    const authority = claimAgentRunDelegatedAuthority(operationalRunInstance);
+    const sharedPath = path.resolve("workspace/skills/shared/SKILL.md");
+    const firstFile = path.resolve("workspace/skills/first/SKILL.md");
+    const secondFile = path.resolve("workspace/skills/second/SKILL.md");
+    try {
+      recordExplicitSkillSelectionsForRun({
+        operationalRunInstance,
+        selections: [
+          { name: "relative", path: "skills/relative/SKILL.md" },
+          { name: "ambiguous", path: sharedPath },
+        ],
+        skillsSnapshot: snapshotWithCommands([
+          workspaceCommand(sharedPath, firstFile, "first"),
+          workspaceCommand(sharedPath, secondFile, "second"),
+        ]),
+      });
+
+      expect(
+        bindWorkspaceSkillUsage({ operationalRunInstance, skillFile: firstFile }),
+      ).toBeUndefined();
+      expect(
+        bindWorkspaceSkillUsage({ operationalRunInstance, skillFile: secondFile }),
+      ).toBeUndefined();
+    } finally {
+      discardRunSkillUsage(runId);
+      discardRunWorkspaceSkillUsage(operationalRunInstance);
+      releaseAgentRunDelegatedAuthority(authority);
+    }
+  });
+
+  it("does not lend a receipt to a replacement admission with the same run id", () => {
+    const runId = "reused-run-id";
+    const firstRun = createOperationalRunInstanceRef(runId);
+    const firstAuthority = claimAgentRunDelegatedAuthority(firstRun);
+    const skillFile = path.resolve("workspace/skills/demo/SKILL.md");
+    recordExplicitSkillSelectionsForRun({
+      operationalRunInstance: firstRun,
+      selections: [{ name: "demo", path: skillFile }],
+      skillsSnapshot: snapshotWithCommands([workspaceCommand(skillFile)]),
+    });
+    const firstGuard = bindWorkspaceSkillUsage({ operationalRunInstance: firstRun, skillFile });
+    expect(firstGuard?.()).toBe(true);
+
+    const replacementRun = createOperationalRunInstanceRef(runId);
+    const replacementAuthority = claimAgentRunDelegatedAuthority(replacementRun);
+    try {
+      expect(firstGuard?.()).toBe(false);
+      expect(
+        bindWorkspaceSkillUsage({ operationalRunInstance: replacementRun, skillFile }),
+      ).toBeUndefined();
+    } finally {
+      discardRunSkillUsage(runId);
+      discardRunWorkspaceSkillUsage(firstRun);
+      discardRunWorkspaceSkillUsage(replacementRun);
+      releaseAgentRunDelegatedAuthority(firstAuthority);
+      releaseAgentRunDelegatedAuthority(replacementAuthority);
+    }
+  });
+
+  it("does not authorize non-workspace skill selections", () => {
+    const runId = "bundled-selection";
+    const operationalRunInstance = createOperationalRunInstanceRef(runId);
+    const authority = claimAgentRunDelegatedAuthority(operationalRunInstance);
+    const skillFile = path.resolve("bundled/skills/demo/SKILL.md");
+    try {
+      recordExplicitSkillSelectionsForRun({
+        operationalRunInstance,
+        selections: [{ name: "demo", path: skillFile }],
+        skillsSnapshot: snapshotWithCommands([
+          { ...workspaceCommand(skillFile), skillSource: "bundled" },
+        ]),
+      });
+      expect(bindWorkspaceSkillUsage({ operationalRunInstance, skillFile })).toBeUndefined();
+    } finally {
+      discardRunSkillUsage(runId);
+      discardRunWorkspaceSkillUsage(operationalRunInstance);
+      releaseAgentRunDelegatedAuthority(authority);
+    }
+  });
+});

--- a/src/agents/skill-selection-usage.ts
+++ b/src/agents/skill-selection-usage.ts
@@ -1,0 +1,64 @@
+import path from "node:path";
+import { recordRunSkillUsage } from "../skills/runtime/run-usage.js";
+import type { ExplicitSkillSelection, SkillSnapshot, SkillUsagePath } from "../skills/types.js";
+import type { OperationalRunInstanceRef } from "./admitted-run-context.js";
+import { canonicalizePath } from "./utils/paths.js";
+
+function comparableSkillPath(value: string): string | undefined {
+  const trimmed = value.trim();
+  if (!path.isAbsolute(trimmed)) {
+    return undefined;
+  }
+  const resolved = canonicalizePath(path.resolve(trimmed));
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
+function indexUnambiguousSkillCommands(
+  paths: readonly SkillUsagePath[],
+): Map<string, SkillUsagePath> {
+  const commandsByPath = new Map<string, SkillUsagePath>();
+  const ambiguousPaths = new Set<string>();
+  for (const command of paths) {
+    const selectionPath = comparableSkillPath(command.readPath);
+    if (!selectionPath) {
+      continue;
+    }
+    if (commandsByPath.has(selectionPath)) {
+      commandsByPath.delete(selectionPath);
+      ambiguousPaths.add(selectionPath);
+      continue;
+    }
+    if (!ambiguousPaths.has(selectionPath)) {
+      commandsByPath.set(selectionPath, command);
+    }
+  }
+  return commandsByPath;
+}
+
+/** Records core-resolved explicit skill commands against the admitted run. */
+export function recordExplicitSkillSelectionsForRun(params: {
+  operationalRunInstance?: OperationalRunInstanceRef;
+  selections?: readonly ExplicitSkillSelection[];
+  skillsSnapshot?: SkillSnapshot;
+}): void {
+  if (!params.operationalRunInstance || !params.selections?.length) {
+    return;
+  }
+  const skillsByPath = indexUnambiguousSkillCommands(
+    params.skillsSnapshot?.skillCommandUsagePaths ?? [],
+  );
+  for (const selection of params.selections) {
+    const selectedPath = comparableSkillPath(selection.path);
+    const command = selectedPath ? skillsByPath.get(selectedPath) : undefined;
+    if (!command) {
+      continue;
+    }
+    recordRunSkillUsage({
+      operationalRunInstance: params.operationalRunInstance,
+      name: command.skillName,
+      source: command.skillSource,
+      activation: "command",
+      skillFile: command.skillFile,
+    });
+  }
+}

--- a/src/agents/tools/skill-workshop-tool-patch.ts
+++ b/src/agents/tools/skill-workshop-tool-patch.ts
@@ -1,12 +1,14 @@
 import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { sha256Hex } from "../../infra/crypto-digest.js";
-import { hasRunWorkspaceSkillUsage } from "../../skills/runtime/run-usage.js";
+import { bindWorkspaceSkillUsage } from "../../skills/runtime/run-usage.js";
 import { stripProposalFrontmatterForSkill } from "../../skills/workshop/frontmatter.js";
-import { findUniqueSkillPatchSpan } from "../../skills/workshop/service.js";
+import { composeSkillBodyPatch, findUniqueSkillPatchSpan } from "../../skills/workshop/service.js";
 import type { SkillWorkshopPreparedPatch } from "../../skills/workshop/types.js";
 import { readWritableWorkshopSkill } from "../../skills/workshop/workspace-skill-read.js";
+import type { OperationalRunInstanceRef } from "../admitted-run-context.js";
 import { readToolStringParam, ToolInputError, type AnyAgentTool } from "./common.js";
+import { getGatewayToolCallerIdentity } from "./gateway-caller-context.js";
 
 type WritableSkillPatchTarget = Awaited<ReturnType<typeof readWritableWorkshopSkill>>;
 
@@ -176,21 +178,42 @@ export function resolveSkillPatchAuthorization(params: {
   return redeemPreparedSkillPatch(params);
 }
 
-export function assertSkillPatchRunUsage(params: {
+function assertSkillPatchRunUsage(params: {
   skill: WritableSkillPatchTarget;
   foregroundRepair: boolean;
-  runId?: string;
-}): void {
-  if (
-    params.foregroundRepair &&
-    !hasRunWorkspaceSkillUsage({
-      runId: params.runId,
-      name: params.skill.skillKey,
-      skillFile: params.skill.skillFile,
-    })
-  ) {
-    throw new ToolInputError(
-      `skill "${params.skill.skillName}" was not used in this run and cannot be repaired autonomously`,
-    );
+  operationalRunInstance?: OperationalRunInstanceRef;
+}): () => void {
+  const isAuthorized = params.foregroundRepair
+    ? bindWorkspaceSkillUsage({
+        operationalRunInstance: params.operationalRunInstance,
+        skillFile: params.skill.skillFile,
+      })
+    : undefined;
+  const assertAuthorized = () => {
+    if (params.foregroundRepair && isAuthorized?.() !== true) {
+      throw new ToolInputError(
+        `skill "${params.skill.skillName}" was not used in this run and cannot be repaired autonomously`,
+      );
+    }
+  };
+  assertAuthorized();
+  return assertAuthorized;
+}
+
+export function prepareAuthorizedSkillPatch(params: {
+  skill: WritableSkillPatchTarget;
+  foregroundRepair: boolean;
+  patch: ReturnType<typeof readSkillPatchText>;
+}): () => void {
+  const assertAuthorized = assertSkillPatchRunUsage({
+    skill: params.skill,
+    foregroundRepair: params.foregroundRepair,
+    operationalRunInstance: getGatewayToolCallerIdentity()?.operationalRunInstance,
+  });
+  try {
+    composeSkillBodyPatch(stripProposalFrontmatterForSkill(params.skill.content), params.patch);
+  } catch (error) {
+    throw new ToolInputError(error instanceof Error ? error.message : String(error));
   }
+  return assertAuthorized;
 }

--- a/src/agents/tools/skill-workshop-tool.test-support.ts
+++ b/src/agents/tools/skill-workshop-tool.test-support.ts
@@ -1,5 +1,17 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  claimAgentRunDelegatedAuthority,
+  releaseAgentRunDelegatedAuthority,
+  type AgentRunDelegatedAuthority,
+} from "../../infra/agent-run-registry.js";
+import { discardRunWorkspaceSkillUsage } from "../../skills/runtime/run-usage.js";
 import { readSkillProposalRecord as readSkillProposalRecordImpl } from "../../skills/workshop/store.js";
+import {
+  createOperationalRunInstanceRef,
+  type OperationalRunInstanceRef,
+} from "../admitted-run-context.js";
+import type { AnyAgentTool } from "./common.js";
+import { wrapToolWithGatewayCallerIdentity } from "./gateway-caller-context.js";
 
 const workshopConfig: OpenClawConfig = {};
 
@@ -13,4 +25,37 @@ export function readSkillWorkshopTestProposalRecord(
     {},
     { config: workshopConfig },
   );
+}
+
+export function createTrackedSkillWorkshopRunAuthorities(): {
+  admit: (runId: string) => OperationalRunInstanceRef;
+  bind: (tool: AnyAgentTool, operationalRunInstance: OperationalRunInstanceRef) => AnyAgentTool;
+  cleanup: () => void;
+} {
+  const entries: Array<{
+    operationalRunInstance: OperationalRunInstanceRef;
+    authority: AgentRunDelegatedAuthority;
+  }> = [];
+  return {
+    admit: (runId) => {
+      const operationalRunInstance = createOperationalRunInstanceRef(runId);
+      entries.push({
+        operationalRunInstance,
+        authority: claimAgentRunDelegatedAuthority(operationalRunInstance),
+      });
+      return operationalRunInstance;
+    },
+    bind: (tool, operationalRunInstance) =>
+      wrapToolWithGatewayCallerIdentity(tool, {
+        agentId: "main",
+        sessionKey: "skill-workshop-test",
+        operationalRunInstance,
+      }),
+    cleanup: () => {
+      for (const entry of entries.splice(0)) {
+        discardRunWorkspaceSkillUsage(entry.operationalRunInstance);
+        releaseAgentRunDelegatedAuthority(entry.authority);
+      }
+    },
+  };
 }

--- a/src/agents/tools/skill-workshop-tool.test.ts
+++ b/src/agents/tools/skill-workshop-tool.test.ts
@@ -16,11 +16,15 @@ import { createTrackedTempDirs } from "../../test-utils/tracked-temp-dirs.js";
 import { createOpenClawTools } from "../openclaw-tools.js";
 import { listCoreToolSections } from "../tool-catalog.js";
 import { createSkillWorkshopTool as createSkillWorkshopToolImpl } from "./skill-workshop-tool.js";
-import { readSkillWorkshopTestProposalRecord } from "./skill-workshop-tool.test-support.js";
+import {
+  createTrackedSkillWorkshopRunAuthorities,
+  readSkillWorkshopTestProposalRecord,
+} from "./skill-workshop-tool.test-support.js";
 
 const tempDirs = createTrackedTempDirs();
 let testState: OpenClawTestState;
 let stateDir = "";
+const runAuthorities = createTrackedSkillWorkshopRunAuthorities();
 const createSkillWorkshopTool = (
   options: Omit<Parameters<typeof createSkillWorkshopToolImpl>[0], "config" | "agentId"> & {
     config?: Parameters<typeof createSkillWorkshopToolImpl>[0]["config"];
@@ -63,6 +67,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  runAuthorities.cleanup();
   await testState.cleanup();
   await tempDirs.cleanup();
 });
@@ -697,13 +702,17 @@ describe("skill_workshop tool", () => {
     async (mode) => {
       const workspaceDir = await tempDirs.make(`openclaw-skill-workshop-repair-${mode}-`);
       const runId = `repair-${mode}`;
+      const operationalRunInstance = runAuthorities.admit(runId);
       const skillName = `weather-planner-${mode}`;
-      const tool = createSkillWorkshopTool({
-        workspaceDir,
-        config: { skills: { workshop: { autonomous: { mode } } } },
-        agentId: "main",
-        origin: { agentId: "main", runId },
-      });
+      const tool = runAuthorities.bind(
+        createSkillWorkshopTool({
+          workspaceDir,
+          config: { skills: { workshop: { autonomous: { mode } } } },
+          agentId: "main",
+          origin: { agentId: "main", runId },
+        }),
+        operationalRunInstance,
+      );
       const created = await tool.execute("repair-create", {
         action: "create",
         name: skillName,
@@ -735,6 +744,7 @@ describe("skill_workshop tool", () => {
       );
       recordRunSkillUsage({
         runId,
+        operationalRunInstance,
         name: skillName,
         source: "workspace",
         activation: "read",
@@ -772,14 +782,18 @@ describe("skill_workshop tool", () => {
   it("matches an aliased used-skill receipt by canonical file", async () => {
     const workspaceDir = await tempDirs.make("openclaw-skill-workshop-repair-alias-");
     const runId = "repair-alias";
+    const operationalRunInstance = runAuthorities.admit(runId);
     const skillName = "canonical-skill-key";
     const skillFile = workshopSkillPath(skillName, "SKILL.md");
-    const tool = createSkillWorkshopTool({
-      workspaceDir,
-      config: { skills: { workshop: { autonomous: { mode: "auto" } } } },
-      agentId: "main",
-      origin: { agentId: "main", runId },
-    });
+    const tool = runAuthorities.bind(
+      createSkillWorkshopTool({
+        workspaceDir,
+        config: { skills: { workshop: { autonomous: { mode: "auto" } } } },
+        agentId: "main",
+        origin: { agentId: "main", runId },
+      }),
+      operationalRunInstance,
+    );
     const created = await tool.execute("alias-create", {
       action: "create",
       name: skillName,
@@ -793,6 +807,7 @@ describe("skill_workshop tool", () => {
     await tool.execute("alias-read", { action: "read", skill_name: skillName });
     recordRunSkillUsage({
       runId,
+      operationalRunInstance,
       name: "frontmatter-skill-name",
       source: "workspace",
       activation: "read",

--- a/src/agents/tools/skill-workshop-tool.ts
+++ b/src/agents/tools/skill-workshop-tool.ts
@@ -56,8 +56,8 @@ import {
 } from "./skill-workshop-tool-helpers.js";
 import { createLibrarySkillWorkshopTool } from "./skill-workshop-tool-library.js";
 import {
-  assertSkillPatchRunUsage,
   executePrepareSkillPatch,
+  prepareAuthorizedSkillPatch,
   readSkillPatchText,
   resolveSkillPatchAuthorization,
 } from "./skill-workshop-tool-patch.js";
@@ -394,6 +394,7 @@ export function createSkillWorkshopTool(options: SkillWorkshopToolOptions): AnyA
       }
       let expectedCurrentContentHash: string | undefined;
       let currentSkillContent: string | undefined;
+      let assertPatchMutationAuthorized: (() => void) | undefined;
       const patchOldString = action === "patch" ? readSkillPatchText(params).oldString : undefined;
       const requiresRead = action === "patch" || (action === "update" && options.updateProposals);
       if (requiresRead) {
@@ -440,19 +441,11 @@ export function createSkillWorkshopTool(options: SkillWorkshopToolOptions): AnyA
         }
         expectedCurrentContentHash = readHash ?? preparedHash ?? contentHash;
         if (action === "patch") {
-          assertSkillPatchRunUsage({
+          assertPatchMutationAuthorized = prepareAuthorizedSkillPatch({
             skill: target,
             foregroundRepair,
-            runId: options.origin?.runId,
+            patch: readSkillPatchText(params),
           });
-          try {
-            composeSkillBodyPatch(
-              stripProposalFrontmatterForSkill(target.content),
-              readSkillPatchText(params),
-            );
-          } catch (error) {
-            throw new ToolInputError(error instanceof Error ? error.message : String(error));
-          }
         }
       }
 
@@ -529,7 +522,12 @@ export function createSkillWorkshopTool(options: SkillWorkshopToolOptions): AnyA
             expectedCurrentContentHash,
             // A patch may only change its exact span, never description or support files.
             ...(action === "patch"
-              ? { composePatch: readSkillPatchText(params) }
+              ? {
+                  composePatch: readSkillPatchText(params),
+                  ...(assertPatchMutationAuthorized
+                    ? { assertMutationAuthorized: assertPatchMutationAuthorized }
+                    : {}),
+                }
               : {
                   description: readToolStringParam(params, "description"),
                   content: requireProposalContent(proposalContent),
@@ -601,6 +599,9 @@ export function createSkillWorkshopTool(options: SkillWorkshopToolOptions): AnyA
             proposalId: proposal.record.id,
             expectedRevisionHash: proposal.revisionHash,
             reason: "Foreground repair of a used skill",
+            ...(assertPatchMutationAuthorized
+              ? { assertMutationAuthorized: assertPatchMutationAuthorized }
+              : {}),
           });
           return actionResult(applied.record, {
             contentText: `Repaired used skill ${applied.record.target.skillName} through proposal ${applied.record.id}.`,

--- a/src/config/sessions/session-accessor.sqlite-session-row.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-session-row.test.ts
@@ -378,6 +378,14 @@ describe("SQLite session row persistence", () => {
         source: "# Demo\n\n" + "runtime skill content ".repeat(100),
       }),
     ];
+    const skillCommandUsagePaths = [
+      {
+        readPath: "/skills/demo/SKILL.md",
+        skillFile: "/skills/demo/SKILL.md",
+        skillName: "demo",
+        skillSource: "workspace" as const,
+      },
+    ];
     const entry: InternalSessionEntry = {
       sessionId: "runtime-skills-session",
       updatedAt: 42,
@@ -391,6 +399,7 @@ describe("SQLite session row persistence", () => {
         skills: [{ name: "demo" }],
         skillFilter: ["demo"],
         resolvedSkills,
+        skillCommandUsagePaths,
         version: 7,
       },
     };
@@ -415,5 +424,6 @@ describe("SQLite session row persistence", () => {
       version: 7,
     });
     expect(entry.skillsSnapshot?.resolvedSkills).toBe(resolvedSkills);
+    expect(entry.skillsSnapshot?.skillCommandUsagePaths).toBe(skillCommandUsagePaths);
   });
 });

--- a/src/config/sessions/session-prompt-types.ts
+++ b/src/config/sessions/session-prompt-types.ts
@@ -1,4 +1,5 @@
 import type { Skill } from "../../skills/loading/skill-contract.js";
+import type { SkillUsagePath } from "../../skills/types.js";
 
 export type SessionSkillPromptRef = {
   version: 1;
@@ -25,5 +26,7 @@ export type SessionSkillSnapshot = {
    * src/skills/runtime/embedded-run-entries.ts rebuilds it from disk.
    */
   resolvedSkills?: Skill[];
+  /** Runtime-only exact identities for eligible user-invocable skill commands. */
+  skillCommandUsagePaths?: SkillUsagePath[];
   version?: number;
 };

--- a/src/config/sessions/store-entry-shape.ts
+++ b/src/config/sessions/store-entry-shape.ts
@@ -189,10 +189,14 @@ export function projectCanonicalSessionEntryShape(value: Record<string, unknown>
 /** Removes the runtime-only skill catalog without mutating the live session snapshot. */
 export function stripRuntimeOnlySessionSkillsFields(entry: SessionEntry): SessionEntry {
   const snapshot = entry.skillsSnapshot;
-  if (snapshot?.resolvedSkills === undefined) {
+  if (snapshot?.resolvedSkills === undefined && snapshot?.skillCommandUsagePaths === undefined) {
     return entry;
   }
-  const { resolvedSkills: _drop, ...skillsSnapshot } = snapshot;
+  const {
+    resolvedSkills: _dropResolvedSkills,
+    skillCommandUsagePaths: _dropSkillCommandUsagePaths,
+    ...skillsSnapshot
+  } = snapshot;
   return { ...entry, skillsSnapshot };
 }
 

--- a/src/skills/discovery/chat-commands.runtime.ts
+++ b/src/skills/discovery/chat-commands.runtime.ts
@@ -5,5 +5,6 @@ export {
   hasSkillReferenceCandidate,
   listSkillCommandsForAgents,
   listSkillCommandsForWorkspace,
+  skillCommandsToExplicitSelections,
 } from "./chat-commands.js";
 export { resolveEffectiveAgentSkillFilter } from "./agent-filter.js";

--- a/src/skills/discovery/chat-commands.ts
+++ b/src/skills/discovery/chat-commands.ts
@@ -25,6 +25,7 @@ export {
   hasSkillReferenceCandidate,
   listReservedChatSlashCommandNames,
   resolveSkillCommandInvocation,
+  skillCommandsToExplicitSelections,
 } from "./chat-command-invocation.js";
 
 export function listSkillCommandsForWorkspace(params: {

--- a/src/skills/discovery/command-identity.test.ts
+++ b/src/skills/discovery/command-identity.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { createFixtureSkillEntry } from "../test-support/test-helpers.js";
+import { resolveSkillCommandUsagePaths } from "./command-identity.js";
+
+describe("resolveSkillCommandUsagePaths", () => {
+  it("keeps exact identities for user-invocable skills hidden from the model prompt", () => {
+    const hidden = createFixtureSkillEntry("hidden-command", {
+      invocation: { userInvocable: true, disableModelInvocation: true },
+    });
+    const unavailable = createFixtureSkillEntry("not-invocable", {
+      invocation: { userInvocable: false, disableModelInvocation: false },
+    });
+
+    expect(resolveSkillCommandUsagePaths([hidden, unavailable])).toEqual([
+      {
+        readPath: hidden.skill.filePath,
+        skillFile: hidden.skill.filePath,
+        skillName: "hidden-command",
+        skillSource: "workspace",
+      },
+    ]);
+  });
+});

--- a/src/skills/discovery/command-identity.ts
+++ b/src/skills/discovery/command-identity.ts
@@ -1,0 +1,18 @@
+// Skill command identities bind admitted command paths to frozen workspace skill metadata.
+import { canonicalizePath } from "../../agents/utils/paths.js";
+import { resolveSkillTelemetrySource } from "../loading/source.js";
+import type { SkillEntry, SkillUsagePath } from "../types.js";
+import { filterUserInvocableSkillEntries } from "./skill-index.js";
+
+export function resolveSkillCommandUsagePath(entry: SkillEntry): SkillUsagePath {
+  return {
+    readPath: canonicalizePath(entry.skill.filePath),
+    skillFile: entry.skill.filePath,
+    skillName: entry.skill.name,
+    skillSource: resolveSkillTelemetrySource(entry.skill),
+  };
+}
+
+export function resolveSkillCommandUsagePaths(entries: readonly SkillEntry[]): SkillUsagePath[] {
+  return filterUserInvocableSkillEntries(entries).map(resolveSkillCommandUsagePath);
+}

--- a/src/skills/discovery/command-specs.ts
+++ b/src/skills/discovery/command-specs.ts
@@ -3,13 +3,11 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
 } from "@openclaw/normalization-core/string-coerce";
-import { canonicalizePath } from "../../agents/utils/paths.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createDedupeCache } from "../../infra/dedupe.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { loadEnabledClaudeBundleCommands } from "../../plugins/bundle-commands.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
-import { resolveSkillTelemetrySource } from "../loading/source.js";
 import { filterWorkspaceSkills, loadVisibleSkills } from "../loading/workspace-skill-loader.js";
 import type {
   SkillEligibilityContext,
@@ -18,6 +16,7 @@ import type {
   SkillSnapshot,
 } from "../types.js";
 import { resolveEffectiveAgentSkillFilter } from "./agent-filter.js";
+import { resolveSkillCommandUsagePath } from "./command-identity.js";
 import { sanitizeSkillCommandName, SKILL_COMMAND_MAX_LENGTH } from "./command-name.js";
 import { filterUserInvocableSkillEntries, isSkillPromptVisible } from "./skill-index.js";
 
@@ -110,6 +109,7 @@ export function buildWorkspaceSkillCommandSpecs(
 
   const specs: SkillCommandSpec[] = [];
   for (const entry of userInvocable) {
+    const identity = resolveSkillCommandUsagePath(entry);
     const rawName = entry.skill.name;
     const base = sanitizeSkillCommandName(rawName);
     if (base !== rawName) {
@@ -175,11 +175,11 @@ export function buildWorkspaceSkillCommandSpecs(
     specs.push({
       name: unique,
       displayName: entry.skill.displayName ?? rawName,
-      skillFile: canonicalizePath(entry.skill.filePath),
-      skillName: rawName,
+      skillFile: identity.readPath,
+      skillName: identity.skillName,
       description,
       modelVisible: isSkillPromptVisible(entry),
-      skillSource: resolveSkillTelemetrySource(entry.skill),
+      skillSource: identity.skillSource,
       ...(dispatch ? { dispatch } : {}),
     });
   }

--- a/src/skills/lifecycle/workspace-skill-write.test.ts
+++ b/src/skills/lifecycle/workspace-skill-write.test.ts
@@ -19,6 +19,45 @@ afterEach(async () => {
 });
 
 describe("workspace skill mutations", () => {
+  it("revalidates run authority immediately before the atomic file write", async () => {
+    const workspaceDir = await fs.realpath(
+      await tempDirs.make("openclaw-workspace-skill-revoked-write-"),
+    );
+    const skillDir = path.join(workspaceDir, "skills", "revoked-write");
+    const skillFile = path.join(skillDir, "SKILL.md");
+    const supportFile = path.join(skillDir, "references", "proof.md");
+    const mutation = await prepareWorkspaceSkillMutation({
+      skillsRoot: workspaceDir,
+      skillDir,
+      skillFile,
+      content: "# Revoked Write\n",
+      supportFiles: [{ path: "references/proof.md", content: "must not be written\n" }],
+      mode: "create",
+    });
+    let authorized = true;
+    let checks = 0;
+
+    await expect(
+      applyWorkspaceSkillMutation(mutation, {
+        assertMutationAuthorized: () => {
+          checks += 1;
+          if (checks === 1) {
+            queueMicrotask(() => {
+              authorized = false;
+            });
+          }
+          if (!authorized) {
+            throw new Error("run authority closed before write");
+          }
+        },
+      }),
+    ).rejects.toThrow("run authority closed before write");
+
+    expect(checks).toBe(2);
+    await expect(fs.access(supportFile)).rejects.toThrow();
+    await expect(fs.access(skillFile)).rejects.toThrow();
+  });
+
   it("removes support files when the activating SKILL.md write fails", async () => {
     const workspaceDir = await fs.realpath(
       await tempDirs.make("openclaw-workspace-skill-write-failure-"),

--- a/src/skills/lifecycle/workspace-skill-write.ts
+++ b/src/skills/lifecycle/workspace-skill-write.ts
@@ -31,6 +31,17 @@ type PreparedWorkspaceSkillFileMutation = {
   proposedContentHash: string;
 };
 
+type WorkspaceSkillMutationWriter = (
+  file: PreparedWorkspaceSkillFileMutation,
+  overwrite: boolean,
+  assertMutationAuthorized?: () => void,
+) => Promise<void>;
+
+type WorkspaceSkillMutationApplyOptions = {
+  writeFile?: WorkspaceSkillMutationWriter;
+  assertMutationAuthorized?: () => void;
+};
+
 export type PreparedWorkspaceSkillMutation = {
   mode: "create" | "update";
   skillsRoot: string;
@@ -228,20 +239,31 @@ export async function prepareWorkspaceSkillRestoration(params: {
 
 export async function applyWorkspaceSkillMutation(
   mutation: PreparedWorkspaceSkillMutation,
-  writeFile: (
-    file: PreparedWorkspaceSkillFileMutation,
-    overwrite: boolean,
-  ) => Promise<void> = writeWorkspaceSkillFile,
+  options: WorkspaceSkillMutationApplyOptions | WorkspaceSkillMutationWriter = {},
 ): Promise<void> {
+  const writeFile =
+    typeof options === "function" ? options : (options.writeFile ?? writeWorkspaceSkillFile);
+  const assertMutationAuthorized =
+    typeof options === "function" ? undefined : options.assertMutationAuthorized;
   const written: PreparedWorkspaceSkillFileMutation[] = [];
   const writtenSupportPaths: string[] = [];
   try {
     for (const file of mutation.supportFiles) {
-      await writePreparedWorkspaceFile(file, mutation.mode === "update", writeFile);
+      await writePreparedWorkspaceFile(
+        file,
+        mutation.mode === "update",
+        writeFile,
+        assertMutationAuthorized,
+      );
       written.push(file);
       writtenSupportPaths.push(file.path);
     }
-    await writePreparedWorkspaceFile(mutation.skillFile, mutation.mode === "update", writeFile);
+    await writePreparedWorkspaceFile(
+      mutation.skillFile,
+      mutation.mode === "update",
+      writeFile,
+      assertMutationAuthorized,
+    );
   } catch (error) {
     try {
       await restorePreparedWorkspaceFiles(written.toReversed());
@@ -319,10 +341,12 @@ function normalizeSupportFiles(
 async function writePreparedWorkspaceFile(
   file: PreparedWorkspaceSkillFileMutation,
   overwrite: boolean,
-  writeFile: (file: PreparedWorkspaceSkillFileMutation, overwrite: boolean) => Promise<void>,
+  writeFile: WorkspaceSkillMutationWriter,
+  assertMutationAuthorized?: () => void,
 ): Promise<void> {
   try {
-    await writeFile(file, overwrite);
+    assertMutationAuthorized?.();
+    await writeFile(file, overwrite, assertMutationAuthorized);
   } catch (error) {
     // fs-safe commits writes atomically, but its post-write identity check can
     // reject after commit. Restore only our exact bytes; preserve external edits.
@@ -345,8 +369,10 @@ async function writePreparedWorkspaceFile(
 async function writeWorkspaceSkillFile(
   file: PreparedWorkspaceSkillFileMutation,
   overwrite: boolean,
+  assertMutationAuthorized?: () => void,
 ): Promise<void> {
   const targetRoot = await root(file.rootDir);
+  assertMutationAuthorized?.();
   await targetRoot.write(file.relativePath, file.content, {
     encoding: "utf8",
     mkdir: true,

--- a/src/skills/loading/workspace-skill-prompt.ts
+++ b/src/skills/loading/workspace-skill-prompt.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import { resolveEffectiveAgentSkillsLimits } from "../discovery/agent-filter.js";
+import { resolveSkillCommandUsagePaths } from "../discovery/command-identity.js";
 import { filterPromptVisibleSkillEntries } from "../discovery/skill-index.js";
 import type { SkillEligibilityContext, SkillEntry, SkillSnapshot } from "../types.js";
 import { WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION } from "../types.js";
@@ -80,6 +81,7 @@ export function buildSkillSnapshot(
       ? { nodeSkillsEligibility: opts.eligibility.nodeSkills }
       : {}),
     resolvedSkills,
+    skillCommandUsagePaths: resolveSkillCommandUsagePaths(eligible),
     version: opts?.snapshotVersion,
     promptFormatVersion: WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION,
   };

--- a/src/skills/runtime/run-usage.ts
+++ b/src/skills/runtime/run-usage.ts
@@ -1,3 +1,8 @@
+import {
+  getActiveAgentRunDelegatedAuthority,
+  validateAgentRunDelegatedAuthority,
+  type AgentRunDelegatedAuthority,
+} from "../../infra/agent-run-registry.js";
 import { pruneMapToMaxSize } from "../../infra/map-size.js";
 import type { SkillTelemetrySource } from "../types.js";
 
@@ -11,10 +16,24 @@ export type RunSkillUsage = Readonly<{
 }>;
 
 const skillUsageByRun = new Map<string, Map<string, RunSkillUsage>>();
+type RunSkillUsageInstance = Readonly<{ instanceId: string; runId: string }>;
+const workspaceSkillUsageByAuthority = new WeakMap<
+  AgentRunDelegatedAuthority,
+  Map<string, RunSkillUsage>
+>();
+
+function runSkillUsageKey(usage: RunSkillUsage): string {
+  return `${usage.source}\u0000${usage.name}\u0000${usage.activation}`;
+}
 
 /** Records the skills the foreground run demonstrably invoked or read. */
-export function recordRunSkillUsage(params: RunSkillUsage & { runId?: string }): void {
-  const runId = params.runId;
+export function recordRunSkillUsage(
+  params: RunSkillUsage & {
+    runId?: string;
+    operationalRunInstance?: RunSkillUsageInstance;
+  },
+): void {
+  const runId = params.runId ?? params.operationalRunInstance?.runId;
   if (!runId) {
     return;
   }
@@ -25,29 +44,51 @@ export function recordRunSkillUsage(params: RunSkillUsage & { runId?: string }):
     activation: params.activation,
     ...(params.skillFile ? { skillFile: params.skillFile } : {}),
   };
-  usage.set(`${record.source}\u0000${record.name}\u0000${record.activation}`, record);
+  usage.set(runSkillUsageKey(record), record);
   skillUsageByRun.set(runId, usage);
   pruneMapToMaxSize(skillUsageByRun, MAX_TRACKED_SKILL_USAGE_RUNS);
+
+  const operationalRunInstance = params.operationalRunInstance;
+  const delegatedAuthority = operationalRunInstance
+    ? getActiveAgentRunDelegatedAuthority(operationalRunInstance)
+    : undefined;
+  if (
+    record.source !== "workspace" ||
+    !record.skillFile ||
+    !operationalRunInstance ||
+    operationalRunInstance.runId !== runId ||
+    !delegatedAuthority
+  ) {
+    return;
+  }
+  const authorityUsage = workspaceSkillUsageByAuthority.get(delegatedAuthority) ?? new Map();
+  if (!authorityUsage.has(record.skillFile)) {
+    authorityUsage.set(record.skillFile, record);
+  }
+  workspaceSkillUsageByAuthority.set(delegatedAuthority, authorityUsage);
 }
 
-/** Checks whether this run demonstrably used one writable workspace skill. */
-export function hasRunWorkspaceSkillUsage(params: {
-  runId: string | undefined;
-  name: string;
+/** Binds one used workspace skill to the exact delegated authority that admitted it. */
+export function bindWorkspaceSkillUsage(params: {
+  operationalRunInstance: RunSkillUsageInstance | undefined;
   skillFile: string;
-}): boolean {
-  if (!params.runId) {
-    return false;
+}): (() => boolean) | undefined {
+  const operationalRunInstance = params.operationalRunInstance;
+  const delegatedAuthority = operationalRunInstance
+    ? getActiveAgentRunDelegatedAuthority(operationalRunInstance)
+    : undefined;
+  if (!delegatedAuthority) {
+    return undefined;
   }
-  for (const usage of skillUsageByRun.get(params.runId)?.values() ?? []) {
-    if (
-      usage.source === "workspace" &&
-      (usage.skillFile === params.skillFile || (!usage.skillFile && usage.name === params.name))
-    ) {
-      return true;
-    }
+  const usage = workspaceSkillUsageByAuthority.get(delegatedAuthority)?.get(params.skillFile);
+  if (!usage) {
+    return undefined;
   }
-  return false;
+  return () =>
+    getActiveAgentRunDelegatedAuthority(delegatedAuthority.operationalRunInstance) ===
+      delegatedAuthority &&
+    validateAgentRunDelegatedAuthority(delegatedAuthority) &&
+    workspaceSkillUsageByAuthority.get(delegatedAuthority)?.get(params.skillFile) === usage;
 }
 
 /** Transfers one completed run's usage receipt to its terminal side effects. */
@@ -56,6 +97,25 @@ export function consumeRunSkillUsage(runId: string | undefined): RunSkillUsage[]
     return [];
   }
   const usage = skillUsageByRun.get(runId);
-  skillUsageByRun.delete(runId);
+  discardRunSkillUsage(runId);
   return usage ? [...usage.values()] : [];
+}
+
+/** Revokes any usage receipts that remain when the logical run settles. */
+export function discardRunSkillUsage(runId: string | undefined): void {
+  if (runId) {
+    skillUsageByRun.delete(runId);
+  }
+}
+
+/** Revokes only the repair receipts owned by one exact admitted execution. */
+export function discardRunWorkspaceSkillUsage(
+  operationalRunInstance: RunSkillUsageInstance | undefined,
+): void {
+  const delegatedAuthority = operationalRunInstance
+    ? getActiveAgentRunDelegatedAuthority(operationalRunInstance)
+    : undefined;
+  if (delegatedAuthority) {
+    workspaceSkillUsageByAuthority.delete(delegatedAuthority);
+  }
 }

--- a/src/skills/runtime/run-usage.ts
+++ b/src/skills/runtime/run-usage.ts
@@ -119,3 +119,11 @@ export function discardRunWorkspaceSkillUsage(
     workspaceSkillUsageByAuthority.delete(delegatedAuthority);
   }
 }
+
+/** Revokes both telemetry and exact-authority receipts for one execution. */
+export function discardRunSkillUsageForOperationalRun(
+  operationalRunInstance: RunSkillUsageInstance,
+): void {
+  discardRunSkillUsage(operationalRunInstance.runId);
+  discardRunWorkspaceSkillUsage(operationalRunInstance);
+}

--- a/src/skills/runtime/snapshot-hydration.test.ts
+++ b/src/skills/runtime/snapshot-hydration.test.ts
@@ -21,6 +21,7 @@ describe("hydrateResolvedSkills", () => {
       prompt: "p",
       skills: [{ name: "x" }],
       resolvedSkills: [makeFixtureSkill("x", 100)],
+      skillCommandUsagePaths: [],
       version: 1,
     };
     let buildCalls = 0;
@@ -47,6 +48,7 @@ describe("hydrateResolvedSkills", () => {
         prompt: "DIFFERENT-PROMPT",
         skills: [{ name: "y" }],
         resolvedSkills: rebuiltSkills,
+        skillCommandUsagePaths: [],
         version: 99,
       };
     });
@@ -56,6 +58,7 @@ describe("hydrateResolvedSkills", () => {
     expect(result.skillFilter).toEqual(["x"]);
     expect(result.version).toBe(7);
     expect(result.resolvedSkills).toBe(rebuiltSkills);
+    expect(result.skillCommandUsagePaths).toEqual([]);
   });
 
   it("treats an empty resolvedSkills array as populated", () => {
@@ -63,6 +66,7 @@ describe("hydrateResolvedSkills", () => {
       prompt: "",
       skills: [],
       resolvedSkills: [],
+      skillCommandUsagePaths: [],
       version: 1,
     };
     let buildCalls = 0;

--- a/src/skills/runtime/snapshot-hydration.ts
+++ b/src/skills/runtime/snapshot-hydration.ts
@@ -1,21 +1,28 @@
 // Snapshot hydration helpers merge saved runtime skill snapshots into live state.
 type SnapshotWithRuntimeSkills = {
   resolvedSkills?: unknown;
+  skillCommandUsagePaths?: unknown;
 };
 
 type SnapshotRebuild<T extends SnapshotWithRuntimeSkills> = {
   resolvedSkills?: T["resolvedSkills"];
+  skillCommandUsagePaths?: T["skillCommandUsagePaths"];
 };
 
-// resolvedSkills is runtime-only: session persistence keeps the lightweight
-// catalog/prompt, while consumers that need concrete SKILL.md paths hydrate it
+// Resolved paths are runtime-only: session persistence keeps the lightweight
+// catalog/prompt, while consumers that need concrete SKILL.md paths hydrate them
 // from a fresh workspace scan.
 export function hydrateResolvedSkills<T extends SnapshotWithRuntimeSkills>(
   snapshot: T,
   rebuild: () => SnapshotRebuild<T>,
 ): T {
-  if (snapshot.resolvedSkills !== undefined) {
+  if (snapshot.resolvedSkills !== undefined && snapshot.skillCommandUsagePaths !== undefined) {
     return snapshot;
   }
-  return { ...snapshot, resolvedSkills: rebuild().resolvedSkills };
+  const rebuilt = rebuild();
+  return {
+    ...snapshot,
+    resolvedSkills: snapshot.resolvedSkills ?? rebuilt.resolvedSkills,
+    skillCommandUsagePaths: snapshot.skillCommandUsagePaths ?? rebuilt.skillCommandUsagePaths,
+  };
 }

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -145,6 +145,8 @@ export type SkillSnapshot = {
   /** Effective node-exec eligibility used to select connected node-hosted skills. */
   nodeSkillsEligibility?: SkillEligibilityContext["nodeSkills"];
   resolvedSkills?: Skill[];
+  /** Runtime-only identities for every eligible user-invocable skill command. */
+  skillCommandUsagePaths?: SkillUsagePath[];
   /** Present only when a session merges skills from distinct agent and execution roots. */
   skillRoots?: {
     agentWorkspaceDir: string;

--- a/src/skills/workshop/apply-transition.ts
+++ b/src/skills/workshop/apply-transition.ts
@@ -251,6 +251,7 @@ export async function applySkillProposalTransition(
             })
           : undefined;
       const rollback = createSkillProposalRollbackFromMutation(record, mutation);
+      input.assertMutationAuthorized?.();
       await writeSkillProposalRollback({
         proposalId: record.id,
         rollback,
@@ -258,7 +259,12 @@ export async function applySkillProposalTransition(
       });
 
       try {
-        await applyWorkspaceSkillMutation(mutation);
+        await applyWorkspaceSkillMutation(
+          mutation,
+          input.assertMutationAuthorized
+            ? { assertMutationAuthorized: input.assertMutationAuthorized }
+            : {},
+        );
       } catch (error) {
         // A rejected filesystem write may have partially changed its target
         // before throwing. Keep recovery facts unless the full bundle is

--- a/src/skills/workshop/service-propose.ts
+++ b/src/skills/workshop/service-propose.ts
@@ -259,6 +259,9 @@ async function createPendingSkillProposal(
     ...(goal ? { goal } : {}),
     ...(evidence ? { evidence } : {}),
   };
+  const assertMutationAuthorized =
+    "skillName" in input ? input.assertMutationAuthorized : undefined;
+  assertMutationAuthorized?.();
   const event = await writeSkillProposal({
     record,
     content,
@@ -270,6 +273,7 @@ async function createPendingSkillProposal(
       type: "created",
       actor: input.eventActor,
     }),
+    assertMutationAuthorized,
     store: { ...(input.env ? { env: input.env } : {}), agentId },
   });
   await dispatchSkillProposalChanged({

--- a/src/skills/workshop/service.test.ts
+++ b/src/skills/workshop/service.test.ts
@@ -184,6 +184,43 @@ function createSkillProposalRollback(params: {
 }
 
 describe("skill workshop proposals", () => {
+  it("does not persist an update when authority closes during proposal staging", async () => {
+    const workspaceDir = await makeWorkspace();
+    const skillDir = path.join(workshopSkillsDir(), "revoked-proposal");
+    const skillFile = path.join(skillDir, "SKILL.md");
+    await writeSkill({
+      dir: skillDir,
+      name: "revoked-proposal",
+      description: "Keep the original skill when proposal authority closes",
+      body: "# Revoked Proposal\n\nOriginal body.\n",
+    });
+    let authorized = true;
+    let checks = 0;
+
+    await expect(
+      proposeUpdateSkill({
+        workspaceDir,
+        skillName: "revoked-proposal",
+        content: "# Revoked Proposal\n\nForbidden replacement.\n",
+        assertMutationAuthorized: () => {
+          checks += 1;
+          if (checks === 1) {
+            queueMicrotask(() => {
+              authorized = false;
+            });
+          }
+          if (!authorized) {
+            throw new Error("run authority closed during proposal staging");
+          }
+        },
+      }),
+    ).rejects.toThrow("run authority closed during proposal staging");
+
+    expect(checks).toBe(2);
+    await expect(listSkillProposals({ workspaceDir })).resolves.toMatchObject({ proposals: [] });
+    await expect(fs.readFile(skillFile, "utf8")).resolves.toContain("Original body.");
+  });
+
   it("uses one Workshop target across session workspaces", async () => {
     const firstWorkspaceDir = await fs.realpath(await makeWorkspace());
     const secondWorkspaceDir = await fs.realpath(await makeWorkspace());

--- a/src/skills/workshop/service.test.ts
+++ b/src/skills/workshop/service.test.ts
@@ -217,7 +217,7 @@ describe("skill workshop proposals", () => {
     ).rejects.toThrow("run authority closed during proposal staging");
 
     expect(checks).toBe(2);
-    await expect(listSkillProposals({ workspaceDir })).resolves.toMatchObject({ proposals: [] });
+    await expect(listSkillProposals()).resolves.toMatchObject({ proposals: [] });
     await expect(fs.readFile(skillFile, "utf8")).resolves.toContain("Original body.");
   });
 

--- a/src/skills/workshop/store.ts
+++ b/src/skills/workshop/store.ts
@@ -254,6 +254,7 @@ export async function writeSkillProposal(params: {
   ownerAgentId: string;
   maxPending: number;
   event: NewSkillProposalEvent;
+  assertMutationAuthorized?: () => void;
   store?: SkillWorkshopStoreOptions;
 }): Promise<SkillProposalEvent> {
   assertProposalId(params.record.id);
@@ -262,6 +263,7 @@ export async function writeSkillProposal(params: {
   await stageSkillProposalGeneration(params);
 
   try {
+    params.assertMutationAuthorized?.();
     return runOpenClawStateWriteTransaction(
       ({ db }) => {
         const kysely = getNodeSqliteKysely<SkillWorkshopDatabase>(db);

--- a/src/skills/workshop/types.ts
+++ b/src/skills/workshop/types.ts
@@ -154,6 +154,8 @@ export type SkillProposalUpdateInput = {
   composePatch?: { oldString: string; newString: string };
   /** Refuse composition when the service's own read hashes differently (reviewer receipt). */
   expectedCurrentContentHash?: string;
+  /** Runtime-only final authority check invoked at the proposal persistence boundary. */
+  assertMutationAuthorized?: () => void;
   supportFiles?: SkillProposalSupportFileInput[];
   createdBy?: SkillProposalSource;
   autonomousCapture?: boolean;
@@ -189,6 +191,8 @@ export type SkillProposalActionInput = {
   expectedRevisionHash?: string;
   correlationId?: string;
   reason?: string;
+  /** Runtime-only final authority check invoked at the live artifact persistence boundary. */
+  assertMutationAuthorized?: () => void;
 };
 
 export type SkillProposalEvaluateInput = {


### PR DESCRIPTION
Closes #131162

Supersedes #131176, which was closed before the native-selection and repair-authority invariant was fully addressed.

Related dependency decision: openclaw/fs-safe#251

AI-assisted: yes. Codex helped trace both runtimes, reconcile the design with current `main`, implement the fix and regressions, and perform P0-P2 review. The author reviewed the final behavior and security boundary.

## What Problem This Solves

With native Codex, OpenClaw can explicitly select and load a workspace skill while foreground Skill Workshop repair still rejects that skill as “not used in this run.” Selection and repair authorization are separate facts, and native selection does not produce the exact run-scoped receipt Workshop requires.

## Why This Change Was Made

This uses the current core-owned `SkillUsagePath` identity and a narrowly scoped runtime receipt rather than a harness-specific authorization API.

- The frozen skill snapshot retains runtime-only command identities for user-invocable skills, including model-hidden skills.
- Embedded and configured CLI owners record only exact, absolute, unambiguous workspace-skill selections, before sandbox path rewriting.
- Receipts live in a `WeakMap` keyed by the exact active `AgentRunDelegatedAuthority` and exact `skillFile`.
- Workshop rechecks the bound authority after proposal staging, before SQLite persistence, and again before entering each workspace write.
- Run settlement discards the receipt.

Reused run IDs, same-name neighbors, bundled skills, stale or replacement authorities, and settled runs cannot borrow a receipt. No schema, config, transcript, or serialized snapshot format changes; runtime-only command identity metadata is stripped before persistence and rebuilt during hydration.

The current head does not claim to close the remaining dependency-internal publication race. OpenClaw pins `@openclaw/fs-safe` 0.8.5, whose Root writer queues and stages after the last application-level assertion. openclaw/fs-safe#251 owns the proposed generic synchronous publication assertion; its current review requires maintainer/security approval before a fix PR. The consumer integration and queued-revocation proof must follow an approved release and OpenClaw pin update.

## User Impact

Foreground repair can recognize the exact workspace skill explicitly invoked in the current admitted run. Unselected, ambiguous, non-workspace, neighboring, stale, replacement-authority, and post-settlement cases fail closed before OpenClaw enters the write path.

Final merge remains gated on publication-time revocation inside the filesystem dependency and agents/skills-owner acceptance of invocation-based repair authority. No migration or operator action is required by the current head.

## Evidence

Exact pushed head: `3e232c6ec3b1723b288be3802db998de973f2868`

PR merge base: `dd7a21a49ad738f112c06e1b29c175f33f1d35c9`.

Current upstream comparison: `dfc9678a5168b5a866ad698617ad3677596e6e84` (`main` captured 2026-09-09). GitHub and a local merge-tree both report the PR cleanly mergeable. Since the prior compatibility base, upstream changed only two PR-touched paths; both reconcile without conflict and do not replace the explicit-selection receipt.

Focused regressions cover:

- selected versus unselected and same-name/different-file skills;
- relative/ambiguous paths and bundled-skill denial;
- same-`runId` replacement authority and post-settlement denial;
- embedded and configured CLI propagation, including retry dispatch;
- runtime snapshot hydration and persistence stripping;
- authority closure during proposal staging and immediately before workspace I/O.

Validation on the exact candidate:

- focused compatibility suite: 13 passed, 167 skipped, 0 failed;
- `pnpm check:changed`: passed, including production/test types, lint, formatting, import-cycle, boundary, persistence, and policy guards;
- `git diff --check`: passed;
- full local hotfix integration stack: 15 focused files / 460 tests passed, and the full build passed;
- hosted CI run `34389862108`: `openclaw/ci-gate` succeeded; current rollup is 163 successful, 43 skipped, 1 neutral, 0 failed, and 0 pending checks on this exact head.

The remaining proof gap is deliberately explicit: existing real Gateway and CLI/MCP evidence does not revoke authority after `fs-safe` has queued a write but before publication. That proof becomes possible only after the dependency contract is approved, released, and pinned.

The `merge-risk: security-boundary` label remains appropriate. Agents/skills-owner acceptance of invocation-based repair authority and filesystem-owner acceptance of the publication fence are maintainer decisions, not claims this PR attempts to bypass.
