### PR TITLE
fix(web-fetch): honor cancellation before caching or returning provider results

### DIFF
--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -1136,6 +1136,12 @@ catalog, API-key auth, and dynamic model resolution.
         original expiry. Reads return a payload marked `cached: true`, or
         `undefined` on a miss. The reader's `ttlMs` argument is optional:
         existing one-argument calls continue to use the stored expiry alone.
+
+        Both tool definitions accept `execute(args, context?)`, where the optional
+        context carries `signal?: AbortSignal`. Forward that signal to network
+        requests and check cancellation after asynchronous work. Existing
+        one-argument implementations remain valid; OpenClaw rejects late fetch
+        results after cancellation before publishing them to its fetch cache.
       </Tab>
     </Tabs>
 

--- a/docs/tools/web-fetch.md
+++ b/docs/tools/web-fetch.md
@@ -101,10 +101,12 @@ Fast cache hits and quick network responses finish before the timer fires, so
 they never show a progress line. Canceling the call clears the timer. The
 progress line is channel UI state only and never contains fetched page content.
 
-Cancellation also reaches the fallback provider. Already-canceled calls reject
-even when a cached result exists. If cancellation occurs during fetching,
-fallback processing, or connection cleanup, OpenClaw rejects the call instead
-of returning success or adding a result to the fetch cache.
+OpenClaw passes cancellation to fallback providers. Providers that honor the
+signal can stop their requests; core rejects late results even when a provider
+ignores cancellation. Already-canceled calls reject even when a cached result
+exists. If cancellation occurs during fetching, fallback processing, or
+connection cleanup, OpenClaw rejects the call instead of returning success or
+adding a result to the fetch cache.
 
 ## Config
 

--- a/docs/tools/web-fetch.md
+++ b/docs/tools/web-fetch.md
@@ -101,6 +101,10 @@ Fast cache hits and quick network responses finish before the timer fires, so
 they never show a progress line. Canceling the call clears the timer. The
 progress line is channel UI state only and never contains fetched page content.
 
+Cancellation also reaches the fallback provider. If the provider finishes after
+the call is canceled, OpenClaw rejects that result instead of returning success
+or adding it to the fetch cache.
+
 ## Config
 
 ```json5

--- a/docs/tools/web-fetch.md
+++ b/docs/tools/web-fetch.md
@@ -101,9 +101,10 @@ Fast cache hits and quick network responses finish before the timer fires, so
 they never show a progress line. Canceling the call clears the timer. The
 progress line is channel UI state only and never contains fetched page content.
 
-Cancellation also reaches the fallback provider. If the provider finishes after
-the call is canceled, OpenClaw rejects that result instead of returning success
-or adding it to the fetch cache.
+Cancellation also reaches the fallback provider. Already-canceled calls reject
+even when a cached result exists. If cancellation occurs during fetching,
+fallback processing, or connection cleanup, OpenClaw rejects the call instead
+of returning success or adding a result to the fetch cache.
 
 ## Config
 

--- a/extensions/firecrawl/src/firecrawl-fetch-provider.ts
+++ b/extensions/firecrawl/src/firecrawl-fetch-provider.ts
@@ -16,7 +16,8 @@ export function createFirecrawlWebFetchProvider(): WebFetchProviderPlugin {
     createTool: ({ config }) => ({
       description: "Fetch a page using Firecrawl.",
       parameters: {},
-      execute: async (args) => {
+      execute: async (args, executionContext) => {
+        executionContext?.signal?.throwIfAborted();
         const url = typeof args.url === "string" ? args.url : "";
         const extractMode = args.extractMode === "text" ? "text" : "markdown";
         const maxChars = readPositiveIntegerParam(args, "maxChars");
@@ -32,6 +33,7 @@ export function createFirecrawlWebFetchProvider(): WebFetchProviderPlugin {
           extractMode,
           access: "keyless",
           maxChars,
+          ...(executionContext?.signal ? { signal: executionContext.signal } : {}),
           ...(proxy ? { proxy } : {}),
           ...(storeInCache !== undefined ? { storeInCache } : {}),
         });

--- a/extensions/firecrawl/src/firecrawl-tools.test.ts
+++ b/extensions/firecrawl/src/firecrawl-tools.test.ts
@@ -875,30 +875,33 @@ describe("firecrawl tools", () => {
     });
   });
 
-  it.each(["paid", "free"] as const)(
-    "forwards exact cancellation through the registered %s web-search provider",
+  it.each(["paid", "free", "fetch"] as const)(
+    "forwards exact cancellation through the registered %s web provider",
     async (kind) => {
       const provider =
         kind === "paid"
           ? createFirecrawlWebSearchProvider()
-          : createFirecrawlFreeWebSearchProvider();
+          : kind === "free"
+            ? createFirecrawlFreeWebSearchProvider()
+            : createFirecrawlWebFetchProvider();
       const tool = provider.createTool({ config: { test: true } } as never);
       expect(tool).not.toBeNull();
       const controller = new AbortController();
+      const run = kind === "fetch" ? runFirecrawlScrape : runFirecrawlSearch;
+      const args =
+        kind === "fetch"
+          ? { url: "https://example.com/cancellation" }
+          : { query: `${kind} cancellation` };
 
-      await tool!.execute({ query: `${kind} cancellation` }, { signal: controller.signal });
+      await tool!.execute(args, { signal: controller.signal });
 
-      expect(runFirecrawlSearch).toHaveBeenCalledWith(
-        expect.objectContaining({ signal: controller.signal }),
-      );
+      expect(run).toHaveBeenCalledWith(expect.objectContaining({ signal: controller.signal }));
 
       const reason = new Error(`${kind} provider cancelled`);
       controller.abort(reason);
-      runFirecrawlSearch.mockClear();
-      await expect(
-        tool!.execute({ query: `${kind} cancelled` }, { signal: controller.signal }),
-      ).rejects.toBe(reason);
-      expect(runFirecrawlSearch).not.toHaveBeenCalled();
+      run.mockClear();
+      await expect(tool!.execute(args, { signal: controller.signal })).rejects.toBe(reason);
+      expect(run).not.toHaveBeenCalled();
     },
   );
 

--- a/src/agents/tools/web-fetch.signal.test.ts
+++ b/src/agents/tools/web-fetch.signal.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import type { WebFetchProviderToolDefinition } from "../../plugin-sdk/provider-web-fetch.js";
+import { withFetchPreconnect } from "../../test-utils/fetch-mock.js";
+import { createWebFetchTool } from "./web-fetch.js";
+
+const { resolveWebFetchDefinition } = vi.hoisted(() => ({
+  resolveWebFetchDefinition: vi.fn(),
+}));
+vi.mock("../../web-fetch/runtime.js", () => ({ resolveWebFetchDefinition }));
+vi.mock("../../web-fetch/content-extractors.runtime.js", () => ({
+  extractReadableContent: vi.fn(async () => null),
+}));
+
+describe("web_fetch provider cancellation", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resolveWebFetchDefinition.mockReset();
+  });
+
+  it.each(["network-error", "http-error", "empty-readability", "disabled-readability"])(
+    "rejects late provider success without caching after %s",
+    async (fallback) => {
+      vi.stubGlobal(
+        "fetch",
+        withFetchPreconnect(
+          vi.fn(async () => {
+            if (fallback === "network-error") {
+              throw new Error("network failed");
+            }
+            return new Response("<html><body>Upstream content</body></html>", {
+              status: fallback === "http-error" ? 503 : 200,
+              headers: { "content-type": "text/html" },
+            });
+          }),
+        ),
+      );
+      const controller = new AbortController();
+      const reason = new Error("parent run cancelled");
+      const started = createDeferred();
+      const pending = createDeferred<Record<string, unknown>>();
+      const execute = vi
+        .fn<WebFetchProviderToolDefinition["execute"]>()
+        .mockImplementationOnce(async () => {
+          started.resolve();
+          return pending.promise;
+        })
+        .mockResolvedValue({ text: "fresh provider body" });
+      resolveWebFetchDefinition.mockReturnValue({
+        provider: { id: "test-fetch" },
+        definition: { execute },
+      });
+      const tool = createWebFetchTool({
+        config: {
+          tools: {
+            web: {
+              fetch: { cacheTtlMinutes: 1, readability: fallback !== "disabled-readability" },
+            },
+          },
+        },
+      })!;
+      const args = { url: `https://example.com/cancel-provider-${fallback}` };
+      const outcome = Promise.allSettled([tool.execute("cancelled", args, controller.signal)]);
+      await started.promise;
+      controller.abort(reason);
+      pending.resolve({ text: "stale provider body" });
+      const [cancelled] = await outcome;
+      const fresh = await tool.execute("fresh", args);
+      const cached = await tool.execute("cached", args);
+
+      // Soft assertions retain both the late-success and cache-poisoning evidence.
+      expect.soft(cancelled).toEqual({ status: "rejected", reason });
+      expect.soft(fresh.details).not.toHaveProperty("cached");
+      expect
+        .soft(fresh.details)
+        .toMatchObject({ text: expect.stringContaining("fresh provider body") });
+      expect.soft(execute).toHaveBeenCalledTimes(2);
+      expect
+        .soft(execute.mock.calls[0])
+        .toEqual([
+          { ...args, extractMode: "markdown", maxChars: 20_000 },
+          { signal: controller.signal },
+        ]);
+      expect(cached.details).toMatchObject({
+        cached: true,
+        text: expect.stringContaining("fresh provider body"),
+      });
+    },
+  );
+});

--- a/src/agents/tools/web-fetch.signal.test.ts
+++ b/src/agents/tools/web-fetch.signal.test.ts
@@ -1,8 +1,11 @@
+import assert from "node:assert/strict";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import type { WebFetchProviderToolDefinition } from "../../plugin-sdk/provider-web-fetch.js";
 import { withFetchPreconnect } from "../../test-utils/fetch-mock.js";
 import { createWebFetchTool } from "./web-fetch.js";
+import * as webGuardedFetch from "./web-guarded-fetch.js";
 
 const { resolveWebFetchDefinition } = vi.hoisted(() => ({
   resolveWebFetchDefinition: vi.fn(),
@@ -15,12 +18,17 @@ vi.mock("../../web-fetch/content-extractors.runtime.js", () => ({
 describe("web_fetch provider cancellation", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
     resolveWebFetchDefinition.mockReset();
   });
 
-  it.each(["network-error", "http-error", "empty-readability", "disabled-readability"])(
-    "rejects late provider success without caching after %s",
-    async (fallback) => {
+  it.each(
+    ["network-error", "http-error", "empty-readability", "disabled-readability"].flatMap(
+      (fallback) => ["success", "failure"].map((completion) => ({ fallback, completion })),
+    ),
+  )(
+    "rejects late provider $completion without caching after $fallback",
+    async ({ fallback, completion }) => {
       vi.stubGlobal(
         "fetch",
         withFetchPreconnect(
@@ -59,11 +67,15 @@ describe("web_fetch provider cancellation", () => {
           },
         },
       })!;
-      const args = { url: `https://example.com/cancel-provider-${fallback}` };
+      const args = { url: `https://example.com/cancel-provider-${fallback}-${completion}` };
       const outcome = Promise.allSettled([tool.execute("cancelled", args, controller.signal)]);
       await started.promise;
       controller.abort(reason);
-      pending.resolve({ text: "stale provider body" });
+      if (completion === "success") {
+        pending.resolve({ text: "stale provider body" });
+      } else {
+        pending.reject(new Error("provider cleanup failed"));
+      }
       const [cancelled] = await outcome;
       const fresh = await tool.execute("fresh", args);
       const cached = await tool.execute("cached", args);
@@ -85,6 +97,104 @@ describe("web_fetch provider cancellation", () => {
         cached: true,
         text: expect.stringContaining("fresh provider body"),
       });
+    },
+  );
+
+  it.each(["direct", "provider"])(
+    "rejects a pre-aborted %s cache hit without invalidating it",
+    async (source) => {
+      const fetch = vi.fn(async () => {
+        if (source === "provider") {
+          throw new Error("network failed");
+        }
+        return new Response("fresh direct body", { headers: { "content-type": "text/plain" } });
+      });
+      vi.stubGlobal("fetch", withFetchPreconnect(fetch));
+      const execute = vi.fn(async () => ({ text: "fresh provider body" }));
+      resolveWebFetchDefinition.mockReturnValue({
+        provider: { id: "test-fetch" },
+        definition: { execute },
+      });
+      const tool = createWebFetchTool({
+        config: { tools: { web: { fetch: { cacheTtlMinutes: 1 } } } },
+      })!;
+      const args = { url: `https://example.com/pre-aborted-cache-${source}` };
+      const fresh = await tool.execute("seed", args);
+      const reason = new Error("parent already cancelled");
+      const outcome = await Promise.allSettled([
+        tool.execute("cancelled", args, AbortSignal.abort(reason)),
+      ]);
+      const cached = await tool.execute("cached", args);
+
+      expect.soft(outcome).toEqual([{ status: "rejected", reason }]);
+      assert(isRecord(fresh.details));
+      expect(cached.details).toEqual({ ...fresh.details, cached: true });
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(execute).toHaveBeenCalledTimes(source === "provider" ? 1 : 0);
+    },
+  );
+
+  it.each(["direct", "http-error", "empty-readability", "disabled-readability"])(
+    "does not publish %s content if cancelled during guard release",
+    async (source) => {
+      const fetch = vi.fn(
+        async () =>
+          new Response("fresh direct body", {
+            status: source === "http-error" ? 503 : 200,
+            headers: { "content-type": source === "direct" ? "text/plain" : "text/html" },
+          }),
+      );
+      vi.stubGlobal("fetch", withFetchPreconnect(fetch));
+      const execute = vi.fn(async () => ({ text: "fresh provider body" }));
+      resolveWebFetchDefinition.mockReturnValue({
+        provider: { id: "test-fetch" },
+        definition: { execute },
+      });
+      const started = createDeferred();
+      const released = createDeferred();
+      const realGuard = webGuardedFetch.fetchWithWebToolsNetworkGuard;
+      vi.spyOn(webGuardedFetch, "fetchWithWebToolsNetworkGuard").mockImplementationOnce(
+        async (params) => {
+          const result = await realGuard(params);
+          return {
+            ...result,
+            release: async () => {
+              await result.release();
+              started.resolve();
+              await released.promise;
+            },
+          };
+        },
+      );
+      const tool = createWebFetchTool({
+        config: {
+          tools: {
+            web: {
+              fetch: {
+                cacheTtlMinutes: 1,
+                readability: source !== "disabled-readability",
+              },
+            },
+          },
+        },
+      })!;
+      const args = { url: `https://example.com/cancel-during-release-${source}` };
+      const controller = new AbortController();
+      const reason = new Error("cancelled during release");
+      const outcome = Promise.allSettled([tool.execute("cancelled", args, controller.signal)]);
+      await started.promise;
+      controller.abort(reason);
+      released.resolve();
+      const [cancelled] = await outcome;
+      const fresh = await tool.execute("fresh", args);
+      const cached = await tool.execute("cached", args);
+
+      expect.soft(cancelled).toEqual({ status: "rejected", reason });
+      expect.soft(fresh.details).not.toHaveProperty("cached");
+      expect.soft(fetch).toHaveBeenCalledTimes(2);
+      expect.soft(execute).toHaveBeenCalledTimes(source === "direct" ? 0 : 2);
+      assert(isRecord(fresh.details));
+      expect(cached.details).toEqual({ ...fresh.details, cached: true });
     },
   );
 });

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -554,7 +554,7 @@ function throwIfFetchAborted(signal: AbortSignal | undefined): void {
   if (!signal?.aborted) {
     return;
   }
-  // readResponseText may finish after an abort races with body reading. Recheck
+  // Async fetch, provider, and payload work can finish after an abort. Recheck
   // before wrapping, caching, or returning content from a canceled tool call.
   throw signal.reason instanceof Error ? signal.reason : new Error("aborted");
 }
@@ -702,14 +702,15 @@ async function maybeFetchProviderWebFetchPayload(
   },
 ): Promise<Record<string, unknown> | null> {
   const providerFallback = await params.resolveProviderFallback();
+  throwIfFetchAborted(params.signal);
   if (!providerFallback) {
     return null;
   }
-  const rawPayload = await providerFallback.definition.execute({
-    url: params.urlToFetch,
-    extractMode: params.extractMode,
-    maxChars: params.maxChars,
-  });
+  const rawPayload = await providerFallback.definition.execute(
+    { url: params.urlToFetch, extractMode: params.extractMode, maxChars: params.maxChars },
+    { signal: params.signal },
+  );
+  throwIfFetchAborted(params.signal);
   const payload = await buildWebFetchPayload({
     providerId: providerFallback.provider.id,
     payload: rawPayload,
@@ -718,6 +719,7 @@ async function maybeFetchProviderWebFetchPayload(
     maxChars: params.maxChars,
     tookMs: params.tookMs,
   });
+  throwIfFetchAborted(params.signal);
   writeCache(FETCH_CACHE, params.cacheKey, payload, params.cacheTtlMs);
   return payload;
 }
@@ -811,9 +813,7 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
 
   try {
     if (!res.ok) {
-      if (params.signal?.aborted) {
-        throw params.signal.reason instanceof Error ? params.signal.reason : new Error("aborted");
-      }
+      throwIfFetchAborted(params.signal);
       const payload = await maybeFetchProviderWebFetchPayload({
         ...params,
         urlToFetch: params.url,
@@ -875,6 +875,7 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
               tookMs: Date.now() - start,
             });
           } catch {
+            throwIfFetchAborted(params.signal);
             payload = null;
           }
           if (payload) {

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -762,8 +762,8 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
     return { ...cached.value, cached: true };
   }
 
-  // Surface the original failure: a fetch that rejected because of the abort already
-  // carries the caller's reason, and replacing it here would discard transport detail.
+  // Preserve the direct fetch's rejection; replacing it with signal.reason would
+  // discard the transport's own error detail.
   const payload = await fetchWebPayload(params);
   // Publish only after guard release: cancellation or cleanup failure must not
   // leave a successful cache entry for a call that never returned its content.

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -697,7 +697,6 @@ async function buildWebFetchPayload(params: {
 async function maybeFetchProviderWebFetchPayload(
   params: WebFetchRuntimeParams & {
     urlToFetch: string;
-    cacheKey: string;
     tookMs: number;
   },
 ): Promise<Record<string, unknown> | null> {
@@ -711,7 +710,7 @@ async function maybeFetchProviderWebFetchPayload(
     { signal: params.signal },
   );
   throwIfFetchAborted(params.signal);
-  const payload = await buildWebFetchPayload({
+  return await buildWebFetchPayload({
     providerId: providerFallback.provider.id,
     payload: rawPayload,
     requestedUrl: params.url,
@@ -719,12 +718,10 @@ async function maybeFetchProviderWebFetchPayload(
     maxChars: params.maxChars,
     tookMs: params.tookMs,
   });
-  throwIfFetchAborted(params.signal);
-  writeCache(FETCH_CACHE, params.cacheKey, payload, params.cacheTtlMs);
-  return payload;
 }
 
 async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string, unknown>> {
+  throwIfFetchAborted(params.signal);
   const ssrfPolicy = params.ssrfPolicy;
   const useTrustedEnvProxy = params.useTrustedEnvProxy;
   let parsedUrl: URL;
@@ -757,9 +754,24 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
     return { ...cached.value, cached: true };
   }
 
+  let payload: Record<string, unknown>;
+  try {
+    payload = await fetchWebPayload(params);
+  } catch (error) {
+    throwIfFetchAborted(params.signal);
+    throw error;
+  }
+  // Publish only after guard release: cancellation or cleanup failure must not
+  // leave a successful cache entry for a call that never returned its content.
+  throwIfFetchAborted(params.signal);
+  writeCache(FETCH_CACHE, cacheKey, payload, params.cacheTtlMs);
+  return payload;
+}
+
+async function fetchWebPayload(params: WebFetchRuntimeParams): Promise<Record<string, unknown>> {
   const start = Date.now();
   let res: Response;
-  let release: (() => Promise<void>) | null;
+  let release: () => Promise<void>;
   let finalUrl = params.url;
   try {
     const fetchWithWebToolsNetworkGuard = await loadWebGuardedFetch();
@@ -769,8 +781,8 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       timeoutSeconds: params.timeoutSeconds,
       signal: params.signal,
       lookupFn: params.lookupFn,
-      useEnvProxy: useTrustedEnvProxy,
-      policy: ssrfPolicy,
+      useEnvProxy: params.useTrustedEnvProxy,
+      policy: params.ssrfPolicy,
       capture: params.headers
         ? { sensitiveRequestHeaderNames: Object.keys(params.headers) }
         : undefined,
@@ -793,16 +805,12 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       );
     }
   } catch (error) {
-    if (error instanceof SsrFBlockedError) {
-      throw error;
-    }
-    if (params.signal?.aborted) {
+    if (error instanceof SsrFBlockedError || params.signal?.aborted) {
       throw error;
     }
     const payload = await maybeFetchProviderWebFetchPayload({
       ...params,
       urlToFetch: finalUrl,
-      cacheKey,
       tookMs: Date.now() - start,
     });
     if (payload) {
@@ -817,7 +825,6 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       const payload = await maybeFetchProviderWebFetchPayload({
         ...params,
         urlToFetch: params.url,
-        cacheKey,
         tookMs: Date.now() - start,
       });
       if (payload) {
@@ -871,12 +878,10 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
             payload = await maybeFetchProviderWebFetchPayload({
               ...params,
               urlToFetch: finalUrl,
-              cacheKey,
               tookMs: Date.now() - start,
             });
           } catch {
             throwIfFetchAborted(params.signal);
-            payload = null;
           }
           if (payload) {
             return payload;
@@ -901,7 +906,6 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
         const payload = await maybeFetchProviderWebFetchPayload({
           ...params,
           urlToFetch: finalUrl,
-          cacheKey,
           tookMs: Date.now() - start,
         });
         if (payload) {
@@ -921,7 +925,7 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       }
     }
 
-    const payload = await buildWebFetchPayload({
+    return await buildWebFetchPayload({
       payload: {
         finalUrl,
         status: res.status,
@@ -937,18 +941,13 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       maxChars: params.maxChars,
       tookMs: Date.now() - start,
     });
-    throwIfFetchAborted(params.signal);
-    writeCache(FETCH_CACHE, cacheKey, payload, params.cacheTtlMs);
-    return payload;
   } finally {
     if (!res.bodyUsed) {
       // Fallbacks and provider failures can abandon the upstream stream. Cancel
       // without awaiting so a stalled cancellation cannot block guard release.
       void res.body?.cancel().catch(() => undefined);
     }
-    if (release) {
-      await release();
-    }
+    await release();
   }
 }
 

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -705,10 +705,18 @@ async function maybeFetchProviderWebFetchPayload(
   if (!providerFallback) {
     return null;
   }
-  const rawPayload = await providerFallback.definition.execute(
-    { url: params.urlToFetch, extractMode: params.extractMode, maxChars: params.maxChars },
-    { signal: params.signal },
-  );
+  let rawPayload: unknown;
+  try {
+    rawPayload = await providerFallback.definition.execute(
+      { url: params.urlToFetch, extractMode: params.extractMode, maxChars: params.maxChars },
+      { signal: params.signal },
+    );
+  } catch (error) {
+    // A provider failure landing after cancellation must surface the caller's abort
+    // reason, not a late error from fallback work the caller already abandoned.
+    throwIfFetchAborted(params.signal);
+    throw error;
+  }
   throwIfFetchAborted(params.signal);
   return await buildWebFetchPayload({
     providerId: providerFallback.provider.id,
@@ -754,13 +762,9 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
     return { ...cached.value, cached: true };
   }
 
-  let payload: Record<string, unknown>;
-  try {
-    payload = await fetchWebPayload(params);
-  } catch (error) {
-    throwIfFetchAborted(params.signal);
-    throw error;
-  }
+  // Surface the original failure: a fetch that rejected because of the abort already
+  // carries the caller's reason, and replacing it here would discard transport detail.
+  const payload = await fetchWebPayload(params);
   // Publish only after guard release: cancellation or cleanup failure must not
   // leave a successful cache entry for a call that never returned its content.
   throwIfFetchAborted(params.signal);

--- a/src/plugins/web-provider-types.ts
+++ b/src/plugins/web-provider-types.ts
@@ -24,7 +24,10 @@ export type WebSearchProviderToolDefinition = {
 export type WebFetchProviderToolDefinition = {
   description: string;
   parameters: TSchema;
-  execute: (args: Record<string, unknown>) => Promise<Record<string, unknown>>;
+  execute: (
+    args: Record<string, unknown>,
+    context?: { signal?: AbortSignal },
+  ) => Promise<Record<string, unknown>>;
 };
 
 type WebSearchProviderContext = {


### PR DESCRIPTION
> [!IMPORTANT]
> **review-required: additive fetch-provider SDK surface.** Prepared under the auto-QA campaign; adds an optional execution-context argument to the fetch-provider SDK contract, so this stays a draft for maintainer review.

## What Problem This Solves

`web_fetch` could return a cached "success" for a request that was cancelled — a silent-failure-class bug (an aborted action producing a positive, cached result). The provider-fallback path at `web-fetch.ts:708` invoked the provider without the tool's AbortSignal and never rechecked cancellation before caching and returning, unlike the web-search sibling which passes the signal and rechecks after return.

A deep-context review then found the same invariant broken on three more core paths and fixed them in the same change:
1. **Pre-aborted cache hits** — a cached success was returned before any signal check.
2. **Late provider failure** — network-error, HTTP-error, and disabled-Readability fallbacks could replace the cancellation reason with a later provider/cleanup error.
3. **Cancellation during guard release** — both direct and fallback paths wrote the cache before the `finally` awaited guard release; an abort in that await still returned success and left content cached.

## Why This Change Was Made

Cancellation is owned by core `runWebFetch` (it holds the parent signal and the fetch cache); plugins own transport and must *receive* the signal, but core cannot assume every installed provider honors it. The fix threads the signal into the fetch-provider contract exactly as web-search already does (optional `context?: { signal?: AbortSignal }`, structurally equal to search's `WebSearchProviderToolExecutionContext`), and moves all cancellation precedence into core: a single synchronous abort-check-then-cache-publish section after the complete fetch/extraction/payload/cleanup lifecycle. This consolidates two branch-local cache writes into one and removes cache-key threading through all four fallback calls — an uncancelled cleanup failure still fails the call and can no longer seed a success cache entry.

## User Impact

A cancelled `web_fetch` (user abort, turn cancellation) now returns cancelled with the exact abort reason and never populates the cache with the aborted result; the next request re-fetches fresh. Uncancelled behavior, provider selection, output shape, SSRF policy, headers, and cache key/TTL are unchanged.

## Evidence

- Production **net small-positive** (core +1, provider contract +3, Firecrawl adapter +2, then the review's lifecycle consolidation); tests large positive; docs +10. No dependency, config, storage/schema, or CHANGELOG change.
- Failing-first grew from the worker's 4 cases to **9 failed / 5 passed** pre-fix (3 provider-rejection reason-loss, 2 pre-aborted cache-hit, 4 cleanup-race); **14/14 pass** after.
- SDK additivity: shipped `v2026.7.1` defines `execute(args)`; this adds only the optional context. A strict isolated tsgo compat probe (old/new assignment both directions, existing single-arg impl, both invocation forms, type-equality with search) passed; `pnpm plugin-sdk:surface:check` exit 0.
- Worker-named selection **470 tests / 21 files** green (fetch, search, Firecrawl, SSRF, cache partitioning, real guarded-HTTP cleanup); post-rebase signal + Firecrawl suites green.
- Live proof: real Firecrawl adapter/client against a loopback HTTP server observed socket closure, exact abort-reason identity, a successful fresh retry, and no dispatch for a pre-aborted request (2 requests total). Local transport behavior, not hosted-service or remote-work cancellation.
