### PR TITLE
fix(slack): stop leaking consumed media into card and text sends

### DIFF
--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -266,8 +266,10 @@ export const slackOutbound: ChannelOutboundAdapter = {
   },
   sendPayload: async (ctx) => {
     const send = await prepareSlackOutboundSend(ctx);
+    // Media belongs to each media unit, never to subsequent card or text sends.
+    const { mediaUrl: _mediaUrl, ...commonCtx } = ctx;
     const preparedCtx = {
-      ...ctx,
+      ...commonCtx,
       replyToId: resolveSlackThreadTsValue(ctx),
       // Keeping the fallback thread would resurrect an implicit reply consumed by fanout.
       threadId: null,

--- a/extensions/slack/src/outbound-delivery.test.ts
+++ b/extensions/slack/src/outbound-delivery.test.ts
@@ -12,8 +12,13 @@ import {
   type PluginHookRegistration,
 } from "openclaw/plugin-sdk/channel-test-helpers";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSlackSendTestClient } from "./blocks.test-helpers.js";
+import * as clientDelivery from "./client-delivery.js";
 import { slackOutbound } from "./outbound-adapter.js";
+import { sendMessageSlack } from "./send.js";
+import { clearSlackThreadParticipationCache } from "./sent-thread-cache.js";
 
 const sendMessageSlackMock = vi.hoisted(() => vi.fn());
 
@@ -53,8 +58,72 @@ describe("slack outbound shared hook wiring", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
+    clearSlackThreadParticipationCache();
     resetGlobalHookRunner();
     resetPluginRuntimeStateForTest();
+  });
+
+  describe.each([
+    {
+      name: "raw blocks",
+      content: { channelData: { slack: { blocks: [{ type: "divider" }] } } },
+      expectedText: "Caption",
+      hasBlocks: true,
+    },
+    {
+      name: "oversized presentation fallback",
+      content: { text: undefined, presentation: { title: "x".repeat(151), blocks: [] } },
+      expectedText: "x".repeat(151),
+      hasBlocks: false,
+    },
+  ])("media followed by $name", ({ content, expectedText, hasBlocks }) => {
+    it.each([
+      { name: "mediaUrl", media: { mediaUrl: "https://example.com/a.png" } },
+      { name: "singleton mediaUrls", media: { mediaUrls: ["https://example.com/a.png"] } },
+      {
+        name: "mediaUrls list",
+        media: { mediaUrls: ["https://example.com/a.png", "https://example.com/b.png"] },
+      },
+    ])("uploads $name only once before finalization", async ({ media }) => {
+      const mediaUrls = media.mediaUrls ?? [media.mediaUrl];
+      const client = createSlackSendTestClient();
+      const upload = vi
+        .spyOn(clientDelivery, "uploadSlackFile")
+        .mockImplementation(async (opts) => {
+          await opts.onPlatformSendDispatch?.();
+          return `F${mediaUrls.indexOf(opts.mediaUrl) + 1}`;
+        });
+      sendMessageSlackMock.mockImplementation(
+        async (to: string, text: string, opts: Parameters<typeof sendMessageSlack>[2]) =>
+          await sendMessageSlack(to, text, { ...opts, client }),
+      );
+      const payload: ReplyPayload = { text: "Caption", ...media, ...content };
+
+      const result = await sendDurableMessageBatch({
+        cfg,
+        channel: "slack",
+        to: "C123",
+        payloads: [payload],
+        accountId: "default",
+        replyToId: "1712000000.000001",
+      });
+
+      expect(upload.mock.calls.map(([opts]) => opts.mediaUrl)).toEqual(mediaUrls);
+      assert(result.status === "sent", "error" in result ? String(result.error) : result.status);
+      expect(sendMessageSlackMock).toHaveBeenCalledTimes(mediaUrls.length + 1);
+      const finalOptions = sendMessageSlackMock.mock.calls.at(-1)?.[2];
+      expect(finalOptions).not.toHaveProperty("mediaUrl");
+      expect(Boolean(finalOptions.blocks)).toBe(hasBlocks);
+      expect(client.chat.postMessage).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ text: expectedText, thread_ts: "1712000000.000001" }),
+      );
+      expect(upload.mock.calls.every(([opts]) => opts.threadTs === "1712000000.000001")).toBe(true);
+      expect(result.results[0]?.receipt?.parts.map((part) => part.platformMessageId)).toEqual([
+        ...mediaUrls.map((_url, index) => `F${index + 1}`),
+        "171234.567",
+      ]);
+    });
   });
 
   it("fires message_sending once with shared routing fields", async () => {

--- a/extensions/slack/src/outbound-payload.test-harness.ts
+++ b/extensions/slack/src/outbound-payload.test-harness.ts
@@ -25,7 +25,8 @@ export function createSlackOutboundPayloadHarness(params: {
   const ctx = {
     cfg: {},
     to: "C12345",
-    text: "",
+    text: params.payload.text ?? "",
+    mediaUrl: params.payload.mediaUrl,
     payload: params.payload,
     deps: {
       sendSlack,

--- a/extensions/slack/src/outbound-payload.test.ts
+++ b/extensions/slack/src/outbound-payload.test.ts
@@ -857,6 +857,7 @@ describe("slackOutbound sendPayload", () => {
     const controlsSent = sentSlackMessage(sendMock, 1);
     expect(controlsSent.to).toBe(to);
     expect(controlsSent.text).toBe("Approval required\n\nAllow");
+    expect(controlsSent.options).not.toHaveProperty("mediaUrl");
     expect(controlsSent.options.blocks?.map((block) => block.type)).toEqual(["section", "actions"]);
     expect(result.channel).toBe("slack");
     expect(result.messageId).toBe("sl-controls");


### PR DESCRIPTION
## What Problem This Solves

When a Slack reply pairs a single image with a caption, card, or controls, the follow-up card/text send inherited the already-consumed media URL. That caused one of two visible failures: a card/blocks send was rejected ("blocks with mediaUrl") so the caption/card/controls were **never delivered**, or a plain-text presentation fallback took the upload branch again and **uploaded the same file twice**.

## Why This Change Was Made

Core supplies two representations with different jobs: `payload.mediaUrl(s)` is the logical attachment set, while top-level `ctx.mediaUrl` is a singleton transport alias (`compactPreparedPayload` normalizes a one-item list into it; `deliver-channel.ts:420` copies it into the adapter context). Slack owns the split between the attachment send and the subsequent card/text sends, and it was spreading the whole context — alias included — into the finalization calls. The fix destructures that consumed alias out of the common finalization context at the Slack fanout owner (`outbound-adapter.ts`), so card/text sends can't inherit it. The media unit itself is unaffected: structured media resolves the full URL list from `payload` and supplies each URL explicitly, and multi-attachment payloads never carried the singleton alias. This brings Slack to parity with Telegram/Discord, which already build separate media/non-media options.

## User Impact

A captioned image, an image with a card, or an image with interactive controls now delivers both the file and the accompanying content, with no duplicate upload.

## Evidence

- Plugin-local, no SDK/config/persistence change; a single-line destructure at the fanout owner plus corrected test coverage.
- Failing-first: **5 failed / 36 passed** pre-fix — raw-blocks cases rejected after upload, singleton oversized-title cases recording `[A,A]` uploads instead of `[A]`; all green after.
- The existing test harness masked this by omitting the top-level `ctx.mediaUrl` the real caller supplies; the new `outbound-delivery.test.ts` runs real durable preparation + adapter fanout + `sendMessageSlack` (mocking only the external upload/API), asserting exactly one upload per source URL, media-free finalization, visible card/text delivery, thread preservation, and in-order receipt IDs across raw blocks, oversized-title fallback, singleton `mediaUrl`, singleton `mediaUrls`, and two-item lists.
- Deep review confirmed every structured finalization path (raw blocks, portable cards, interactive controls, oversized-title fallback, mixed block/text, question-completion) is media-free and found no other stale-media branch; full Slack suite + changed-file gate exit 0; two Codex autoreviews clean.
