### PR TITLE
test(ci): avoid repeated workflow parsing

### DIFF
--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -94,9 +94,11 @@ type WorkflowStep = {
   "working-directory"?: string;
 };
 
-function readCiWorkflow() {
-  return parse(readFileSync(".github/workflows/ci.yml", "utf8"));
-}
+const readCiWorkflow = (() => {
+  // The checked-in workflow is fixed for this suite; clones keep fixture mutations local.
+  const workflow = parse(readFileSync(".github/workflows/ci.yml", "utf8"));
+  return () => structuredClone(workflow);
+})();
 
 function evaluateWorkflowExpression(
   expression: unknown,
@@ -1656,6 +1658,17 @@ ${actionRun}`;
 }
 
 describe("ci workflow guards", () => {
+  it("isolates mutations between workflow fixtures", () => {
+    const workflow = readCiWorkflow();
+    const expected = structuredClone(workflow);
+
+    workflow.jobs.preflight.steps[0].name = "mutated fixture";
+    workflow.jobs.preflight.steps.pop();
+    delete workflow.jobs["ci-gate"];
+
+    expect(readCiWorkflow()).toEqual(expected);
+  });
+
   it("gates frozen runtime-pair compatibility on the trusted suite outcome", () => {
     const workflow = readReleaseChecksWorkflow();
     const laneJob = workflow.jobs.qa_lab_runtime_pair_lane_release_checks;


### PR DESCRIPTION
## What Problem This Solves

The CI workflow guard suite repeatedly parses the same 243 KB workflow while checking unrelated invariants. This maintainer-requested test-performance change reduces the full-file median wall time by **1.675 seconds (9.21%)**, without removing any existing assertion or subprocess execution.

## Why This Change Was Made

The suite now parses the checked-in workflow once into a private fixture and returns an independent `structuredClone` on every call. No caller receives the cached object. This retains YAML alias identity within each document while isolating nested mutations between callers. The added test mutates a nested step, removes an array element, and deletes a job before requesting another fixture.

All original bytes outside the helper replacement and additive regression are unchanged. Fixture subprocess working directories, environment, shell transformations, source reads outside this helper, and test ordering are unchanged. Parsing still uses the existing YAML defaults. Invalid YAML now fails during collection, and parser warnings are emitted once per file.

## User Impact

No product/runtime behavior changes. Developers and CI spend less time running the same workflow checks. Production LOC: **+0/-0**. Tests: **+16/-3**. No workflow, dependency, baseline, snapshot, changelog, protocol, or storage changes. AI-assisted; reviewed with Codex.

## Evidence

Baseline: `23a681efa6fc0e264e562c4249d8906c0785b5e4`. One Blacksmith Testbox, Node 24.19.0, pnpm 11.22.0, one worker. Baseline/candidate warmups excluded. Eight alternating AB/BA full-file pairs, with a distinct module-cache path per invocation and import diagnostics enabled. All samples retained; candidate faster in **8/8 pairs**, minimum paired improvement **1.33 seconds**.

| Pair | Order | Baseline wall (s) | Candidate wall (s) |
| --- | --- | ---: | ---: |
| 1 | AB | 18.12 | 16.69 |
| 2 | BA | 17.81 | 16.48 |
| 3 | AB | 18.31 | 16.52 |
| 4 | BA | 18.25 | 16.35 |
| 5 | AB | 18.02 | 16.42 |
| 6 | BA | 18.01 | 16.54 |
| 7 | AB | 22.68 | 16.50 |
| 8 | BA | 23.16 | 18.22 |

| Median metric | Baseline | Candidate |
| --- | ---: | ---: |
| Wall | 18.185 s | 16.510 s |
| Vitest | 14.530 s | 12.815 s |
| Test body | 14.000 s | 12.235 s |
| Import | 0.3345 s | 0.3750 s |
| Import breakdown self / total | 0.277 / 0.594 s | 0.3155 / 0.6415 s |
| CPU user / system | 17.885 / 2.745 s | 16.005 / 2.575 s |
| Peak RSS | 826,756 KiB | 757,922 KiB |
| Tests passed | 141 | 142 |

The last two baseline samples were slower; they remain in the report. The median, all-pairs improvement, and minimum paired gain support acceptance without relying on those outliers. Import time rises slightly because the one parse moves into collection. Mean wall time was 19.295 → 16.715 seconds; it is not the acceptance statistic.

Per-sample command (with a unique `<sample>`):

```sh
/usr/bin/time -v env \
  OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 \
  OPENCLAW_VITEST_MAX_WORKERS=1 \
  OPENCLAW_VITEST_IMPORT_DURATIONS=1 \
  OPENCLAW_VITEST_PRINT_IMPORT_BREAKDOWN=1 \
  OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/ci-guards-perf/<sample> \
  pnpm test test/scripts/ci-workflow-guards.test.ts --maxWorkers=1 --reporter=verbose
```

Separate instrumented full-file diagnostics, excluded from timing, confirmed helper parses **143 → 1**; total suite YAML parses **568 → 426**; canonical CI source reads **161 → 19**; total suite reads **961 → 819**. Four independent CI parses and 18 independent source reads remain. Direct subprocess dispatches remain exactly **606** (413 `execFileSync`, 192 `spawnSync`, one `spawn`). The candidate makes two extra clone calls for the new regression.

Reversible fault proof:

- The new isolation test passes with the original fresh-parse helper and fails with both a shared return object and a shallow copy.
- Temporarily accepting `failure` in the workflow's selected-lane gate makes the existing real-Bash test fail on both baseline and candidate; all other tests pass.
- Duplicate top-level YAML keys fail with the same `YAMLParseError` on both versions. A source-extracted helper probe also confirms exact parsed values, preserved aliases and cross-call isolation; substituting JSON cloning loses alias identity and is detected.
- Exact workflow/test bytes restored and the full 142-test candidate suite rerun successfully. Workflow SHA256: `9a2c9598e94ef708e86e7d1ca226ffa9e072dad23f12c9c6e825fe5818d3fd7d`.

Testbox allocation: https://github.com/openclaw/openclaw/actions/runs/33146375482. This run owns hydration/lease lifetime; the measured command results are recorded above, not inferred from the lease workflow conclusion.

Focused owner/sibling proof: two shuffled, non-isolated single-worker runs (seeds `31813` and `8272026`) each passed **3 files / 233 tests**:

```sh
pnpm test test/scripts/ci-workflow-guards.test.ts \
  test/scripts/ci-changed-node-test-plan.test.ts \
  src/scripts/ci-changed-scope.test.ts \
  --maxWorkers=1 --isolate=false --sequence.shuffle --sequence.seed=<seed> --reporter=verbose
```

Test audit retained every existing workflow contract and executable check. Deslop required no changes. Fresh Codex autoreview completed with no actionable findings.

Complete changed gate passed on the same Testbox:

```sh
OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 \
  node scripts/check-changed.mjs -- test/scripts/ci-workflow-guards.test.ts
```

This included changed-file formatting, `tsgo:test:root`, scripts lint, and the classifier-selected repository guards. `git diff --check` passed. No runtime/package build is required for this test fixture change.

The branch was refreshed onto `533319b6753f4367581a59dc26b9c6d2fd19d66d` after qualification. Incoming main changes include a new CI step and unrelated assertion cleanup; those are retained unchanged. The two reviewed edits remain identical. Benchmark numbers describe the frozen baseline above; exact-head CI validates the refreshed branch.

Final head proof: `3523ee99cd91534843854fb7930b02291a8ed2e0` passed all 142 tests after rebase on macOS with `CI=1 OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts --maxWorkers=1 --reporter=verbose`. [Exact-head CI run 33147507810](https://github.com/openclaw/openclaw/actions/runs/33147507810) completed successfully, including `openclaw/ci-gate`; no rerun was required. The initial draft run was intentionally skipped. Both task-created Testboxes are stopped and raw proof logs are retained locally.
