### PR TITLE
fix(doctor): keep auth repair in the selected installation

### DIFF
--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -295,8 +295,8 @@ function listAuthProfileSqliteMigrationCandidates(
   return listAuthProfileRepairCandidates(cfg, env).map((candidate) => ({
     agentDir: candidate.agentDir,
     authPath: candidate.authPath,
-    statePath: resolveAuthStatePath(candidate.agentDir),
-    legacyPath: resolveLegacyAuthStorePath(candidate.agentDir),
+    statePath: resolveAuthStatePath(path.dirname(candidate.authPath)),
+    legacyPath: resolveLegacyAuthStorePath(path.dirname(candidate.authPath)),
   }));
 }
 
@@ -1270,7 +1270,9 @@ export async function maybeMigrateAuthProfileJsonStoresToSqlite(params: {
         }),
       );
       const expectedStateSha256 = digestAuthProfileMigrationValue(
-        readPersistedAuthProfileStateRaw(candidate.agentDir),
+        candidate.agentDir
+          ? readPersistedAuthProfileStateRaw(candidate.agentDir)
+          : readPersistedSharedAuthProfileStateRaw(env),
       );
       const canonicalSourceCarriesState = canonicalStore
         ? hasAuthProfileState(coerceAuthProfileState(canonicalStore))

--- a/src/commands/doctor-auth-legacy-paths.ts
+++ b/src/commands/doctor-auth-legacy-paths.ts
@@ -17,20 +17,6 @@ export type AuthProfileRepairCandidate = {
   authPath: string;
 };
 
-function addCandidate(
-  candidates: Map<string, AuthProfileRepairCandidate>,
-  agentDir: string | undefined,
-): void {
-  const authPath = resolveLegacyAuthProfilesPath(agentDir);
-  const key = path.resolve(authPath);
-  const existing = candidates.get(key);
-  // The shared-main store (undefined agentDir) owns its path: an agent-scoped
-  // alias resolving to the same file must not demote it to a per-agent import.
-  if (!existing || agentDir === undefined) {
-    candidates.set(key, { agentDir, authPath });
-  }
-}
-
 function listExistingAgentDirsFromState(env: NodeJS.ProcessEnv): string[] {
   const root = path.join(resolveStateDir(env), "agents");
   let entries: fs.Dirent[];
@@ -64,20 +50,32 @@ export function listAuthProfileRepairCandidates(
   env: NodeJS.ProcessEnv,
 ): AuthProfileRepairCandidate[] {
   const candidates = new Map<string, AuthProfileRepairCandidate>();
+  const addCandidate = (agentDir: string | undefined): void => {
+    // Retain the selected home's expanded directory for later SQLite writes too.
+    const resolvedAgentDir = agentDir ? resolveUserPath(agentDir, env) : undefined;
+    const authPath = resolveLegacyAuthProfilesPath(
+      resolvedAgentDir ?? resolveSharedMainAuthAgentDir(env),
+    );
+    const existing = candidates.get(authPath);
+    // Shared-main owns aliases of its source; do not demote it to a per-agent import.
+    if (!existing || agentDir === undefined) {
+      candidates.set(authPath, { agentDir: resolvedAgentDir, authPath });
+    }
+  };
   // The shared-main default store (undefined agentDir) must stay first so the
   // canonical location wins the per-path dedupe over agent-scoped aliases.
-  addCandidate(candidates, undefined);
-  addCandidate(candidates, resolveLegacyInheritedAuthAgentDir(cfg, env));
+  addCandidate(undefined);
+  addCandidate(resolveLegacyInheritedAuthAgentDir(cfg, env));
   const envAgentDir =
     readNonBlankString(env.OPENCLAW_AGENT_DIR) ?? readNonBlankString(env.PI_CODING_AGENT_DIR);
   if (envAgentDir) {
-    addCandidate(candidates, envAgentDir);
+    addCandidate(envAgentDir);
   }
   for (const agentId of listAgentIds(cfg)) {
-    addCandidate(candidates, resolveAgentDir(cfg, agentId, env));
+    addCandidate(resolveAgentDir(cfg, agentId, env));
   }
   for (const agentDir of listExistingAgentDirsFromState(env)) {
-    addCandidate(candidates, agentDir);
+    addCandidate(agentDir);
   }
   return [...candidates.values()];
 }

--- a/src/commands/doctor-auth-source-owner.test.ts
+++ b/src/commands/doctor-auth-source-owner.test.ts
@@ -1,0 +1,200 @@
+// Doctor must discover, import, verify, and archive auth sources from one selected owner.
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { clearAuthProfileMigrationDiagnostics } from "../agents/auth-profiles/legacy-source-diagnostic.js";
+import { loadPersistedAuthProfileStore } from "../agents/auth-profiles/persisted.js";
+import { clearRuntimeAuthProfileStoreSnapshots } from "../agents/auth-profiles/runtime-snapshots.js";
+import { closeAuthProfileReadPool } from "../agents/auth-profiles/sqlite.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import { maybeMigrateAuthProfileJsonStoresToSqlite } from "./doctor-auth-flat-profiles.js";
+
+const states: OpenClawTestState[] = [];
+const sourceNames = ["auth-profiles.json", "auth-state.json", "auth.json"] as const;
+const profileId = "owner-test:default";
+
+async function createOwners(env: Record<string, string | undefined> = {}) {
+  const create = async () => {
+    const state = await createOpenClawTestState({
+      prefix: "openclaw-doctor-auth-source-owner-",
+      layout: "split",
+      applyEnv: false,
+      env: {
+        OPENCLAW_AGENT_DIR: undefined,
+        PI_CODING_AGENT_DIR: undefined,
+        OPENCLAW_OAUTH_DIR: undefined,
+        ...env,
+      },
+    });
+    states.push(state);
+    return state;
+  };
+  const selected = await create();
+  const ambient = await create();
+  ambient.applyEnv();
+  return { selected, ambient };
+}
+
+function sourceValue(sourceName: (typeof sourceNames)[number], key: string, lastUsed: number) {
+  const credential = { type: "api_key", provider: "owner-test", key };
+  if (sourceName === "auth-state.json") {
+    return { version: 1, usageStats: { [profileId]: { lastUsed } } };
+  }
+  return sourceName === "auth.json"
+    ? { "owner-test": credential }
+    : { version: 1, profiles: { [profileId]: credential } };
+}
+
+function writeSource(agentDir: string, sourceName: string, value: unknown) {
+  fs.mkdirSync(agentDir, { recursive: true });
+  const sourcePath = path.join(agentDir, sourceName);
+  const bytes = `${JSON.stringify(value)}\n`;
+  fs.writeFileSync(sourcePath, bytes);
+  return { sourcePath, bytes };
+}
+
+function archivesFor(sourcePath: string) {
+  return fs
+    .readdirSync(path.dirname(sourcePath))
+    .filter((name) => name.startsWith(`${path.basename(sourcePath)}.migrated-`))
+    .map((name) => path.join(path.dirname(sourcePath), name));
+}
+
+afterEach(async () => {
+  clearRuntimeAuthProfileStoreSnapshots();
+  clearAuthProfileMigrationDiagnostics();
+  closeAuthProfileReadPool();
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  for (const state of states.splice(0).toReversed()) {
+    await state.cleanup();
+    expect(fs.existsSync(state.root)).toBe(false);
+  }
+});
+
+describe("Doctor auth migration source ownership", () => {
+  it("detects all three legacy siblings only in the explicitly selected state root", async () => {
+    const { selected, ambient } = await createOwners();
+    const selectedSources = sourceNames.map((name) =>
+      writeSource(selected.agentDir(), name, sourceValue(name, `fake-${randomUUID()}`, 20)),
+    );
+    const ambientSources = sourceNames.map((name) =>
+      writeSource(ambient.agentDir(), name, sourceValue(name, `fake-${randomUUID()}`, 10)),
+    );
+
+    const result = await maybeMigrateAuthProfileJsonStoresToSqlite({
+      cfg: {},
+      env: selected.env,
+      prompter: { confirmAutoFix: async () => false },
+    });
+
+    expect.soft(result).toEqual({
+      detected: selectedSources.map(({ sourcePath }) => sourcePath),
+      changes: [],
+      warnings: [],
+    });
+    for (const source of [...selectedSources, ...ambientSources]) {
+      expect(fs.readFileSync(source.sourcePath, "utf8")).toBe(source.bytes);
+      expect(archivesFor(source.sourcePath)).toEqual([]);
+    }
+    expect(loadPersistedAuthProfileStore(selected.agentDir())).toBeNull();
+    expect(loadPersistedAuthProfileStore(ambient.agentDir())).toBeNull();
+  });
+
+  it.each(sourceNames)("imports and archives only the selected %s source", async (sourceName) => {
+    const { selected, ambient } = await createOwners();
+    const selectedKey = `fake-selected-${randomUUID()}`;
+    const selectedSource = writeSource(
+      selected.agentDir(),
+      sourceName,
+      sourceValue(sourceName, selectedKey, 20),
+    );
+    const ambientSource = writeSource(
+      ambient.agentDir(),
+      sourceName,
+      sourceValue(sourceName, `fake-ambient-${randomUUID()}`, 10),
+    );
+
+    const result = await maybeMigrateAuthProfileJsonStoresToSqlite({
+      cfg: {},
+      env: selected.env,
+      prompter: { confirmAutoFix: async () => true },
+    });
+
+    expect
+      .soft(loadPersistedAuthProfileStore(selected.agentDir()))
+      .toMatchObject(
+        sourceName === "auth-state.json"
+          ? { usageStats: { [profileId]: { lastUsed: 20 } } }
+          : { profiles: { [profileId]: { key: selectedKey } } },
+      );
+    expect.soft(result.detected).toEqual([selectedSource.sourcePath]);
+    expect.soft(result.warnings).toEqual([]);
+    expect.soft(fs.existsSync(ambientSource.sourcePath)).toBe(true);
+    if (fs.existsSync(ambientSource.sourcePath)) {
+      expect.soft(fs.readFileSync(ambientSource.sourcePath, "utf8")).toBe(ambientSource.bytes);
+    }
+    expect.soft(archivesFor(ambientSource.sourcePath)).toEqual([]);
+    expect.soft(loadPersistedAuthProfileStore(ambient.agentDir())).toBeNull();
+    expect.soft(fs.existsSync(selectedSource.sourcePath)).toBe(false);
+    const selectedArchives = archivesFor(selectedSource.sourcePath);
+    expect.soft(selectedArchives).toHaveLength(1);
+    const [selectedArchive] = selectedArchives;
+    if (selectedArchive) {
+      expect.soft(fs.readFileSync(selectedArchive, "utf8")).toBe(selectedSource.bytes);
+    }
+    const receipts = openOpenClawStateDatabase({ env: selected.env })
+      .db.prepare("SELECT source_path, status, removed_source FROM migration_sources")
+      .all();
+    expect
+      .soft(receipts)
+      .toEqual([
+        { source_path: selectedSource.sourcePath, status: "completed", removed_source: 1 },
+      ]);
+  });
+
+  it.each(["OPENCLAW_AGENT_DIR", "PI_CODING_AGENT_DIR"] as const)(
+    "resolves a tilde %s relocation against the selected home before importing",
+    async (agentDirVariable) => {
+      const { selected, ambient } = await createOwners({ [agentDirVariable]: "~/relocated-auth" });
+      const selectedDir = path.join(selected.home, "relocated-auth");
+      const ambientDir = path.join(ambient.home, "relocated-auth");
+      const selectedKey = `fake-selected-${randomUUID()}`;
+      const selectedSource = writeSource(
+        selectedDir,
+        "auth-profiles.json",
+        sourceValue("auth-profiles.json", selectedKey, 20),
+      );
+      const ambientSource = writeSource(
+        ambientDir,
+        "auth-profiles.json",
+        sourceValue("auth-profiles.json", `fake-ambient-${randomUUID()}`, 10),
+      );
+
+      const result = await maybeMigrateAuthProfileJsonStoresToSqlite({
+        cfg: {},
+        env: selected.env,
+        prompter: { confirmAutoFix: async () => true },
+      });
+
+      expect.soft(loadPersistedAuthProfileStore(selectedDir)?.profiles[profileId]).toMatchObject({
+        key: selectedKey,
+      });
+      expect.soft(result.detected).toEqual([selectedSource.sourcePath]);
+      expect.soft(result.warnings).toEqual([]);
+      expect.soft(fs.existsSync(selectedSource.sourcePath)).toBe(false);
+      expect.soft(fs.existsSync(ambientSource.sourcePath)).toBe(true);
+      expect.soft(archivesFor(ambientSource.sourcePath)).toEqual([]);
+      expect.soft(loadPersistedAuthProfileStore(ambientDir)).toBeNull();
+    },
+  );
+});

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -2,7 +2,6 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { listAgentIds, tryResolveAmbientOwnerAgentId } from "../agents/agent-scope-config.js";
-import { resolveSharedMainAuthAgentDir } from "../agents/auth-profiles/shared-main-dir.js";
 import {
   discardLegacyRegistryWorktrees,
   hasLegacyRegistryWorktrees,
@@ -537,13 +536,12 @@ export async function detectLegacyStateMigrations(params: {
   const managedOutgoingImages = detectDoctorOwnedState(detectLegacyManagedOutgoingImages);
   const apns = detectDoctorOwnedState(detectLegacyApnsRegistrations);
   const deviceAuth = detectDoctorOwnedState(detectLegacyDeviceAuth);
-  const sharedAuthStore =
-    stateSchemaMigrations.length === 0
-      ? detectDoctorOwnedState(detectSharedAuthStoreMigration)
-      : {
-          sourcePath: path.join(resolveSharedMainAuthAgentDir(env), "openclaw-agent.sqlite"),
-          hasLegacy: false,
-        };
+  const sharedAuthStore = detectSharedAuthStoreMigration({
+    stateDir,
+    env,
+    doctorOnlyStateMigrations:
+      stateSchemaMigrations.length === 0 && params.doctorOnlyStateMigrations === true,
+  });
   const deviceIdentity = detectLegacyDeviceIdentity({
     stateDir,
     env,

--- a/src/infra/state-migrations.shared-auth-store.test.ts
+++ b/src/infra/state-migrations.shared-auth-store.test.ts
@@ -1,11 +1,13 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { OpenClawTestState } from "../test-utils/openclaw-test-state.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const ownerStates: OpenClawTestState[] = [];
 
 function makeStore(profileId: string, key: string) {
   return {
@@ -22,14 +24,23 @@ describe("shared auth store relocation", () => {
   });
 
   afterEach(async () => {
-    const [{ closeOpenClawAgentDatabasesForTest }, { closeOpenClawStateDatabaseForTest }] =
-      await Promise.all([
-        import("../state/openclaw-agent-db.js"),
-        import("../state/openclaw-state-db.js"),
-      ]);
+    const [
+      { closeAuthProfileReadPool },
+      { closeOpenClawAgentDatabasesForTest },
+      { closeOpenClawStateDatabaseForTest },
+    ] = await Promise.all([
+      import("../agents/auth-profiles/sqlite.js"),
+      import("../state/openclaw-agent-db.js"),
+      import("../state/openclaw-state-db.js"),
+    ]);
+    closeAuthProfileReadPool();
     closeOpenClawAgentDatabasesForTest();
     closeOpenClawStateDatabaseForTest();
     vi.unstubAllEnvs();
+    for (const state of ownerStates.splice(0).toReversed()) {
+      await state.cleanup();
+      expect(fs.existsSync(state.root)).toBe(false);
+    }
   });
 
   async function createFixture() {
@@ -176,6 +187,163 @@ describe("shared auth store relocation", () => {
         .prepare("SELECT value_json FROM config_machine_state WHERE state_key = 'auth.sharedStore'")
         .get(),
     ).toEqual({ value_json: JSON.stringify({ location: "state-db" }) });
+  });
+
+  it.each(["absolute", "tilde"] as const)(
+    "detects and relocates only the selected env's %s shared auth source",
+    async (pathStyle) => {
+      const { createOpenClawTestState } = await import("../test-utils/openclaw-test-state.js");
+      const createOwner = async () => {
+        const owner = await createOpenClawTestState({
+          prefix: "openclaw-shared-auth-source-owner-",
+          layout: "split",
+          applyEnv: false,
+          env: {
+            OPENCLAW_AGENT_DIR: undefined,
+            PI_CODING_AGENT_DIR: undefined,
+            OPENCLAW_OAUTH_DIR: undefined,
+          },
+        });
+        ownerStates.push(owner);
+        return owner;
+      };
+      const selected = await createOwner();
+      const ambient = await createOwner();
+      const selectedDir = path.join(selected.home, "relocated-auth");
+      const ambientDir = path.join(ambient.home, "relocated-auth");
+      const selectedEnv = {
+        ...selected.env,
+        OPENCLAW_AGENT_DIR: pathStyle === "tilde" ? "~/relocated-auth" : selectedDir,
+      };
+      const ambientEnv = {
+        ...ambient.env,
+        OPENCLAW_AGENT_DIR: pathStyle === "tilde" ? "~/relocated-auth" : ambientDir,
+      };
+      ambient.applyEnv();
+      vi.stubEnv("OPENCLAW_AGENT_DIR", ambientEnv.OPENCLAW_AGENT_DIR);
+      const [sqlite, migration, doctor, stateDb, { EMPTY_LEGACY_SESSION_SURFACES }] =
+        await Promise.all([
+          import("../agents/auth-profiles/sqlite.js"),
+          import("./state-migrations.shared-auth-store.js"),
+          import("./state-migrations.doctor.js"),
+          import("../state/openclaw-state-db.js"),
+          import("../plugins/legacy-session-surfaces.types.js"),
+        ]);
+      const profileId = "openai:source";
+      const selectedStore = makeStore(profileId, `fake-selected-${randomUUID()}`);
+      const ambientStore = makeStore(profileId, `fake-ambient-${randomUUID()}`);
+      const selectedState = { version: 1, usageStats: { [profileId]: { lastUsed: 20 } } };
+      const ambientState = { version: 1, usageStats: { [profileId]: { lastUsed: 10 } } };
+      for (const source of [
+        { agentDir: selectedDir, env: selectedEnv, store: selectedStore, state: selectedState },
+        { agentDir: ambientDir, env: ambientEnv, store: ambientStore, state: ambientState },
+      ]) {
+        sqlite.runAuthProfileWriteTransaction(
+          source.agentDir,
+          (database) => {
+            sqlite.writePersistedAuthProfileStoreRaw(source.store, source.agentDir, database);
+            sqlite.writePersistedAuthProfileStateRaw(source.state, source.agentDir, database);
+          },
+          { env: source.env },
+        );
+        expect(sqlite.readPersistedAuthProfileStoreRaw(source.agentDir)).toEqual(source.store);
+        expect(sqlite.readPersistedAuthProfileStateRaw(source.agentDir)).toEqual(source.state);
+      }
+
+      const detected = await doctor.detectLegacyStateMigrations({
+        cfg: { plugins: { enabled: false } },
+        env: selectedEnv,
+        homedir: () => selected.home,
+        doctorOnlyStateMigrations: true,
+        pluginSessionStoreAgentIds: [],
+        legacySessionSurfaces: EMPTY_LEGACY_SESSION_SURFACES,
+      });
+      expect(detected.stateDir).toBe(selected.stateDir);
+      expect(detected.stateSchema.hasLegacy).toBe(false);
+      const selectedSourcePath = sqlite.resolveAuthProfileDatabasePath(selectedDir);
+      expect.soft(detected.sharedAuthStore).toEqual({
+        sourcePath: selectedSourcePath,
+        hasLegacy: true,
+      });
+      const result = await migration.migrateSharedAuthStore({
+        detected: detected.sharedAuthStore,
+        stateDir: detected.stateDir,
+        env: selectedEnv,
+      });
+
+      expect.soft(result.warnings).toEqual([]);
+      expect
+        .soft(sqlite.readPersistedSharedAuthProfileStoreRaw(selectedEnv))
+        .toEqual(selectedStore);
+      expect
+        .soft(sqlite.readPersistedSharedAuthProfileStateRaw(selectedEnv))
+        .toEqual(selectedState);
+      expect.soft(sqlite.readPersistedAuthProfileStoreRaw(selectedDir)).toBeNull();
+      expect.soft(sqlite.readPersistedAuthProfileStateRaw(selectedDir)).toBeNull();
+      expect.soft(sqlite.readPersistedAuthProfileStoreRaw(ambientDir)).toEqual(ambientStore);
+      expect.soft(sqlite.readPersistedAuthProfileStateRaw(ambientDir)).toEqual(ambientState);
+      const receipts = stateDb
+        .openOpenClawStateDatabase({ env: selectedEnv })
+        .db.prepare("SELECT source_path, status, removed_source FROM migration_sources")
+        .all();
+      expect.soft(receipts).toHaveLength(2);
+      for (const receipt of receipts) {
+        expect.soft(receipt).toEqual({
+          source_path: selectedSourcePath,
+          status: "completed",
+          removed_source: 1,
+        });
+      }
+    },
+  );
+
+  it("defers shared auth inspection while the selected state schema needs repair", async () => {
+    const fixture = await createEmptyFixture(false);
+    const [doctor, { EMPTY_LEGACY_SESSION_SURFACES }, { resolveOpenClawStateSqlitePath }] =
+      await Promise.all([
+        import("./state-migrations.doctor.js"),
+        import("../plugins/legacy-session-surfaces.types.js"),
+        import("../state/openclaw-state-db.paths.js"),
+      ]);
+    const stateDatabasePath = resolveOpenClawStateSqlitePath(fixture.env);
+    fs.mkdirSync(path.dirname(stateDatabasePath), { recursive: true });
+    const legacyDatabase = new DatabaseSync(stateDatabasePath);
+    try {
+      legacyDatabase.exec(`
+        CREATE TABLE agent_databases (
+          agent_id TEXT PRIMARY KEY,
+          path TEXT NOT NULL,
+          schema_version INTEGER NOT NULL,
+          last_seen_at INTEGER NOT NULL,
+          size_bytes INTEGER
+        );
+        INSERT INTO agent_databases VALUES ('main', 'agent.sqlite', 1, 10, 20);
+      `);
+    } finally {
+      legacyDatabase.close();
+    }
+    const stateBytes = fs.readFileSync(stateDatabasePath);
+    const sourceBytes = "not a SQLite database";
+    fs.mkdirSync(path.dirname(fixture.sourcePath), { recursive: true });
+    fs.writeFileSync(fixture.sourcePath, sourceBytes);
+    const ambientStateDir = tempDirs.make("openclaw-shared-auth-pending-ambient-");
+    vi.stubEnv("OPENCLAW_STATE_DIR", ambientStateDir);
+    vi.stubEnv("OPENCLAW_AGENT_DIR", path.join(ambientStateDir, "relocated-auth"));
+
+    const detected = await doctor.detectLegacyStateMigrations({
+      cfg: { plugins: { enabled: false } },
+      env: fixture.env,
+      doctorOnlyStateMigrations: true,
+      pluginSessionStoreAgentIds: [],
+      legacySessionSurfaces: EMPTY_LEGACY_SESSION_SURFACES,
+    });
+
+    expect(detected.stateDir).toBe(fixture.stateDir);
+    expect(detected.stateSchema.hasLegacy).toBe(true);
+    expect(detected.sharedAuthStore).toEqual({ sourcePath: fixture.sourcePath, hasLegacy: false });
+    expect(fs.readFileSync(fixture.sourcePath, "utf8")).toBe(sourceBytes);
+    expect(fs.readFileSync(stateDatabasePath)).toEqual(stateBytes);
+    expect(fs.existsSync(resolveOpenClawStateSqlitePath())).toBe(false);
   });
 
   for (const crashState of [

--- a/src/infra/state-migrations.shared-auth-store.ts
+++ b/src/infra/state-migrations.shared-auth-store.ts
@@ -457,9 +457,10 @@ function finalizeMigration(params: {
 /** Detect relocation or unfinished cleanup only in the explicit Doctor repair path. */
 export function detectSharedAuthStoreMigration(params: {
   stateDir: string;
+  env?: NodeJS.ProcessEnv;
   doctorOnlyStateMigrations?: boolean;
 }): SharedAuthStoreMigrationDetection {
-  const env = { ...process.env, OPENCLAW_STATE_DIR: params.stateDir };
+  const env = { ...(params.env ?? process.env), OPENCLAW_STATE_DIR: params.stateDir };
   const sourcePath = path.join(resolveSharedMainAuthAgentDir(env), "openclaw-agent.sqlite");
   if (params.doctorOnlyStateMigrations !== true) {
     return { sourcePath, hasLegacy: false };


### PR DESCRIPTION
Closes #131560

AI-assisted maintainer repair with Codex.

## What Problem This Solves

Fixes an issue where callers repairing one OpenClaw installation through Doctor's explicit environment could import credentials or usage state from a different ambient installation, or archive and remove the wrong installation's legacy auth source. This requires the supplied environment to differ from `process.env`; the ordinary same-environment interactive flow is not claimed broken, and no production incident is claimed.

## Why This Change Was Made

Source discovery, home expansion, sibling-file selection, SQLite relocation, and post-commit verification now use the selected environment throughout the existing repair flow. Shared-main candidates retain shared ownership even when an agent path aliases the source. The existing relocation detector now owns the deferred-source result too, removing the duplicate path-selection branch while preserving pending-schema deferral and explicit `stateDir` precedence.

This repairs the owner boundary rather than temporarily changing `process.env` or adding a fallback import path. No new config option, schema version, credential format, or migration receipt format is introduced. Production delta: +30/-31 (net -1); regression tests: +374/-6.

## User Impact

Programmatic Doctor repair reliably operates on the selected installation, including `~`-relative auth directories. Declining repair leaves source files intact; accepting it migrates and verifies only the selected credentials/state before archiving or removing that source. The unrelated ambient installation remains unchanged.

Release-note context: Doctor auth repair no longer crosses explicitly supplied installation environments; fixes #131560. Discovered during the Buzz media/auth repair campaign.

## Evidence

- Before the fix, all six JSON ownership reproductions failed; both SQLite relocation reproductions also failed while nine existing controls passed. The fixtures use different selected/ambient synthetic credentials and usage timestamps, so a successful migration of the wrong data is a failure.
- After the repair, 18 focused JSON/SQLite ownership tests passed, plus 199 neighboring migration/auth tests across six files. Seventeen existing pending-schema tests also passed on the final source, including the new corrupt-source deferral case in the focused set. These overlapping runs are not summed as additional unique coverage.
- Normal isolated Codex review of the complete six-file effect reported no actionable findings.
- The complete six-file `node scripts/check-changed.mjs -- <changed paths>` gate passed, including formatting, production/test types, lint, database guards, and zero runtime import cycles. `pnpm build` passed at `8ca2e98f37da19c5e30215559d6cd97a8459426d`, including SDK exports and Control UI budgets.
- Eight isolated, actual compiled-runtime cases passed: decline all three JSON sources, import each JSON format, both tilde-directory variables, and absolute/tilde SQLite relocation through full Doctor state-migration detection and apply. Each child used distinct selected/ambient installations; credential/state bytes, completed receipts, selected-source archival/removal, idempotence, SQLite integrity, unchanged ambient trees/environments, and process exit were verified. The frozen 11,997-file runtime graph was identical before/after (SHA-256 `72ce2d6244a79dd045d8f031930f0ac9206e73aaa3e9273fefaf112d290e5508`). No live credentials, operator services, full service-repair CLI, or Vitest mocks were used.
- An initial broader fixture correctly caught empty process-cache directories under its ambient home. Source and a phase-by-phase runtime probe traced these to the existing private read-only SQLite snapshot cache, not auth-source selection. The final fixture separates process-owned `XDG_CACHE_HOME` from both installations, keeps the strict whole ambient-tree comparison, and independently verifies all snapshot data/child directories are cleaned. No production change, prewarming, ignore rule, or weakened credential assertion was used to resolve that fixture-scope mismatch.
- [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33147619601) completed successfully at `8ca2e98f37da19c5e30215559d6cd97a8459426d`; the live check rollup has no pending checks and the required CI gate passed.

Root cause and provenance: the JSON post-commit state read was introduced by #114033 (author and merger @steipete, 2026-07-26) and the environment-less discovery was carried forward by #123187 (author and merger @steipete, 2026-08-14). Both SQLite detector environment-drop sites were introduced by #123349 (author and merger @steipete, 2026-08-14). This PR follows the complete selected-owner invariant across both paths; the preexisting JSON helper's earliest introduction is not attributed to the extraction PR.
