### PR TITLE
fix(ui): preserve durable turn order after live finals

### DIFF
--- a/packages/gateway-client/src/session-projection.test.ts
+++ b/packages/gateway-client/src/session-projection.test.ts
@@ -238,6 +238,64 @@ describe("session transcript projection", () => {
     expect(state.messages).toEqual([persisted]);
   });
 
+  it("reorders a provisional final when older durable neighbors arrive first", () => {
+    const synthetic = createMessage("assistant", "current final");
+    const previous = createMessage("assistant", "previous final", {
+      id: "previous-final",
+      seq: 370,
+      runId: "previous-run",
+    });
+    const prompt = createMessage("user", "current prompt", {
+      id: "current-user",
+      seq: 371,
+    });
+    const persisted = createMessage("assistant", "current final", {
+      id: "current-final",
+      seq: 372,
+      runId: "current-run",
+    });
+    let state = projectLiveSessionMessage(createSessionProjection(primaryScope), synthetic, {
+      runId: "current-run",
+    });
+    state = projectLiveSessionMessage(state, previous, { runId: "previous-run" });
+    state = projectLiveSessionMessage(state, prompt);
+    state = projectLiveSessionMessage(state, persisted, { runId: "current-run" });
+
+    expect(state.messages).toEqual([previous, prompt, persisted]);
+  });
+
+  it("keeps older durable neighbors before a late prompt and its provisional final", () => {
+    const runId = "current-run";
+    const synthetic = createMessage("assistant", "current final");
+    const previous = createMessage("assistant", "previous final", {
+      id: "previous-final",
+      seq: 370,
+      runId: "previous-run",
+    });
+    const prompt = createMessage("user", "current prompt", {
+      id: "current-user",
+      seq: 371,
+      idempotencyKey: `${runId}:user`,
+    });
+    const persisted = createMessage("assistant", "current final", {
+      id: "current-final",
+      seq: 372,
+      runId,
+    });
+    let state = reduceSessionProjection(createSessionProjection(primaryScope), {
+      type: "runTerminal",
+      runId,
+      status: "completed",
+      message: synthetic,
+    });
+    state = projectLiveSessionMessage(state, synthetic, { runId });
+    state = projectLiveSessionMessage(state, previous, { runId: "previous-run" });
+    state = projectLiveSessionMessage(state, prompt, { clientRunId: runId });
+    state = projectLiveSessionMessage(state, persisted, { runId });
+
+    expect(state.messages).toEqual([previous, prompt, persisted]);
+  });
+
   it("does not promote a provisional final into same-run Codex commentary", () => {
     const commentary = createMessage("assistant", "commentary", {
       id: "commentary-1",

--- a/packages/gateway-client/src/session-projection.ts
+++ b/packages/gateway-client/src/session-projection.ts
@@ -322,14 +322,43 @@ function insertEntry(
           const candidate = entry.identity?.sequence;
           return candidate !== undefined && candidate !== null && candidate > sequence;
         });
-  if (nextIndex < 0 && incoming.identity?.role === "user" && incoming.identity.runId) {
+  if (sequence !== undefined && sequence !== null && nextIndex < 0) {
+    nextIndex = entries.length;
+  }
+  if (incoming.identity?.role === "user" && incoming.identity.runId) {
     const runId = incoming.identity.runId;
     const terminalMessage = runs?.[runId]?.message;
-    nextIndex = entries.findIndex(
+    const terminalIndex = entries.findIndex(
       (entry) =>
         entry.identity?.role === "assistant" &&
         (entry.identity.runId === runId || entry.message === terminalMessage),
     );
+    const terminalEntry = entries[terminalIndex];
+    if (
+      terminalEntry &&
+      sequence !== undefined &&
+      sequence !== null &&
+      nextIndex >= 0 &&
+      terminalIndex < nextIndex
+    ) {
+      // A live final may overtake its durable prompt. Move the pair together so
+      // the causal repair cannot leapfrog older sequenced transcript rows.
+      const withoutTerminal = entries.filter((_, index) => index !== terminalIndex);
+      const sequenceIndex = withoutTerminal.findIndex((entry) => {
+        const candidate = entry.identity?.sequence;
+        return candidate !== undefined && candidate !== null && candidate > sequence;
+      });
+      const promptIndex = sequenceIndex < 0 ? withoutTerminal.length : sequenceIndex;
+      return [
+        ...withoutTerminal.slice(0, promptIndex),
+        incoming,
+        terminalEntry,
+        ...withoutTerminal.slice(promptIndex),
+      ];
+    }
+    if (terminalIndex >= 0 && (nextIndex < 0 || terminalIndex < nextIndex)) {
+      nextIndex = terminalIndex;
+    }
   }
   return nextIndex < 0
     ? [...entries, incoming]
@@ -362,7 +391,11 @@ export function projectLiveSessionMessage(
     // durable row would lose the ID every later snapshot reconciles against.
     return state;
   }
-  if (existing?.pending && incoming.identity.sequence !== null) {
+  if (
+    existing &&
+    incoming.identity.sequence !== null &&
+    (existing.pending || existing.identity?.sequence === null)
+  ) {
     const sequence = incoming.identity.sequence;
     const violatesOrder = state.entries.some(
       ({ identity }, index) =>

--- a/ui/src/e2e/chat-live-final-order.e2e.test.ts
+++ b/ui/src/e2e/chat-live-final-order.e2e.test.ts
@@ -1,0 +1,164 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import {
+  createChatFlowE2eSuite,
+  installMockGateway,
+  requireRecord,
+} from "./chat-flow.test-support.ts";
+
+const suite = createChatFlowE2eSuite();
+
+suite.define(() => {
+  it("keeps durable turns ordered when a live final arrives before transcript events", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const currentRunId = "current-run";
+    const previousPrompt = "What happened before this run?";
+    const currentPrompt = "Why did this request fail?";
+    const currentFinal = "The control layer failed before the retry.";
+    const durableMessages = [
+      {
+        __openclaw: { id: "previous-user", seq: 369 },
+        content: [{ text: previousPrompt, type: "text" }],
+        role: "user",
+        timestamp: Date.now(),
+      },
+      {
+        __openclaw: { id: "current-user", seq: 371 },
+        content: [{ text: currentPrompt, type: "text" }],
+        role: "user",
+        timestamp: Date.now(),
+      },
+      {
+        __openclaw: { id: "current-final", runId: currentRunId, seq: 372 },
+        content: [{ text: currentFinal, type: "text" }],
+        role: "assistant",
+        timestamp: Date.now(),
+      },
+    ];
+    const historyDelta = {
+      deltaCursor: "after-final",
+      kind: "delta",
+      messages: [
+        {
+          message: durableMessages[0],
+          messageId: "previous-user",
+          messageSeq: 369,
+          sessionKey: "main",
+        },
+        {
+          message: durableMessages[1],
+          messageId: "current-user",
+          messageSeq: 371,
+          sessionKey: "main",
+        },
+        {
+          message: durableMessages[2],
+          messageId: "current-final",
+          messageSeq: 372,
+          runId: currentRunId,
+          sessionKey: "main",
+        },
+      ],
+      sessionInfo: {
+        activeRunIds: [],
+        hasActiveRun: false,
+        key: "main",
+        kind: "direct",
+        status: "done",
+        updatedAt: Date.now(),
+      },
+    };
+
+    try {
+      const gateway = await installMockGateway(page, {
+        deferredMethods: ["chat.history"],
+        methodResponses: {
+          "chat.startup": {
+            deltaCursor: "before-final",
+            messages: [],
+            sessionId: "control-ui-e2e-session",
+            sessionInfo: {
+              activeRunIds: [],
+              hasActiveRun: false,
+              key: "main",
+              kind: "direct",
+              status: "done",
+              updatedAt: Date.now(),
+            },
+          },
+        },
+      });
+
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
+      await gateway.emitGatewayEvent("chat", {
+        deltaText: "Checking request state...",
+        message: {
+          content: [{ text: "Checking request state...", type: "text" }],
+          role: "assistant",
+          timestamp: Date.now(),
+        },
+        runId: currentRunId,
+        seq: 1,
+        sessionKey: "main",
+        state: "delta",
+      });
+      await gateway.emitChatFinal({ runId: currentRunId, text: currentFinal });
+      await page.locator(".chat-thread-inner").getByText(currentFinal, { exact: true }).waitFor();
+      await gateway.emitGatewayEvent("session.message", {
+        activeRunIds: [],
+        hasActiveRun: false,
+        message: durableMessages[1],
+        messageId: "current-user",
+        messageSeq: 371,
+        session: {
+          activeRunIds: [],
+          hasActiveRun: false,
+          key: "main",
+          kind: "direct",
+          status: "done",
+          updatedAt: Date.now(),
+        },
+        sessionKey: "main",
+      });
+      await gateway.waitForRequest("chat.history");
+      await gateway.resolveDeferred("chat.history", historyDelta);
+      await expect
+        .poll(async () =>
+          (await gateway.getRequests("chat.history")).some(
+            (request) => requireRecord(request.params).cursor === "before-final",
+          ),
+        )
+        .toBe(true);
+
+      const artifactDir = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
+      if (artifactDir) {
+        await mkdir(artifactDir, { recursive: true });
+        await page.screenshot({
+          path: path.join(artifactDir, "live-final-transcript-order.png"),
+          fullPage: true,
+        });
+      }
+      const visibleTexts = [previousPrompt, currentPrompt, currentFinal];
+      await expect
+        .poll(() =>
+          page.locator(".chat-thread-inner").evaluate((thread, texts) => {
+            const rows = Array.from(thread.querySelectorAll(".chat-bubble"));
+            return texts.map((text) => rows.findIndex((row) => row.textContent?.includes(text)));
+          }, visibleTexts),
+        )
+        .toEqual([0, 1, 2]);
+      await expect
+        .poll(() => page.locator(".chat-group.assistant", { hasText: currentFinal }).count())
+        .toBe(1);
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- relocate a provisional live terminal message when its durable transcript sequence arrives
- keep a late durable prompt and its same-run terminal message together without leapfrogging older sequenced rows
- cover the reducer transition and the full mocked-Gateway Control UI event order

## Root cause

`chat.final` can reach the Control UI before the corresponding durable `session.message` rows. The shared session projection reducer correctly matched the later durable assistant row to the provisional final, but replaced it in place unless the old entry was marked `pending`. A normal live provisional entry therefore kept its stale array index even after receiving an authoritative sequence.

The reducer's prompt-before-terminal repair had a related edge: when the prompt arrived after its provisional terminal, it could move the pair ahead of older durable rows. The canonical owner is `packages/gateway-client/src/session-projection.ts`; storage, Gateway history, and rendering order were already correct.

## Fix

- treat an unsequenced live projection like a pending projection when an authoritative sequence promotes it
- insert sequenced rows at their natural durable position even when no later sequence exists
- when repairing a same-run prompt/final inversion, move the pair together at the prompt's sequence position

No protocol, config, storage, bundle, or public API changes. The insertion path remains O(n) with no new I/O or persistent memory. Production delta is +36/-3 lines; the growth encodes the shared ordering invariant at its owner. Tests add 222 lines. No production paths were removed.

## Evidence

- Current canonical base control: the browser regression fails with visible row indices `[1, 2, 0]` instead of `[0, 1, 2]`; the final reply remains above both durable prompts.
- Proposed head: the same browser regression passes with `[0, 1, 2]` and exactly one final reply.
- Exact focused command on `a1d0fd3504c8edc9790c79a149e5fa568501da9d`:

  ```text
  $ node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-live-final-order.e2e.test.ts
  Test Files  1 passed (1)
       Tests  1 passed (1)
  ```

- Shared reducer suite: 70/70 passed, including older durable neighbors and late same-run prompts.
- Blacksmith Testbox `pnpm check:changed`: passed in 13m01s, including core/core-test typechecks, type-aware lint, max-lines, import-cycle, state, format, and policy guards: https://github.com/openclaw/openclaw/actions/runs/33147121591
- Final exact-head autoreview: clean, no accepted or actionable findings (0.97 confidence).
- Source-blind behavior validation: primary visible ordering contract passed; auxiliary metadata and replay claims remain supported by reducer tests rather than the visual capture.

ClawSweeper's live command did not report a test assertion failure: its 30-second output deadline expired after Playwright downloaded FFmpeg and printed the Vitest `RUN` banner, before this test printed its result. The exact test subsequently passes through the repository wrapper above. Sanitized red and green browser captures were also inspected locally; the configured proof publisher had no artifact backend, so they are not linked here.

The repeated required-check failure is confined to the untouched `chat-transcript-disclosure-anchor.e2e.test.ts` pointer-interruption case. That same test passes in isolation on this exact head (7/7 in 41.67s) and passed in the same shard on the neighboring same-base PR #128803. It does not exercise the changed durable-event insertion path.

## Release note

Control UI replies no longer appear above the prompts that triggered them when live final and durable transcript events arrive out of order.
