### PR TITLE
refactor: share OpenAI memory embedding orchestration

### DIFF
--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -1240,6 +1240,13 @@ catalog, API-key auth, and dynamic model resolution.
         memory search. The retired memory-specific registrar and manifest
         contract are no longer accepted.
 
+        OpenAI-compatible endpoints can use `createRemoteEmbeddingProvider`
+        from `openclaw/plugin-sdk/memory-core-host-engine-embeddings`. Its optional
+        `buildRequestFields(kind)` callback returns extra JSON fields for
+        `"query"` or `"document"` requests, such as `dimensions` or `input_type`.
+        The shared factory always supplies the client's `model` and the original
+        `input` array after those fields, preserving response-count validation.
+
         Providers that accept model aliases can expose
         `normalizeModel(options): string`. Memory uses this synchronous hook for
         both creation options and cold index identity checks. Keep it configuration-only:

--- a/extensions/openai/embedding-provider.test.ts
+++ b/extensions/openai/embedding-provider.test.ts
@@ -1,213 +1,381 @@
-// Openai tests cover embedding provider plugin behavior.
+// Exercise the provider, shared factory, and guarded HTTP transport together.
+import { once } from "node:events";
+import { createServer, type Server, type ServerResponse } from "node:http";
 import type { MemoryEmbeddingProviderCreateOptions } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createOpenAiEmbeddingProvider } from "./embedding-provider.js";
 
-const DEFAULT_MOCK_CLIENT = {
-  baseUrl: "https://embeddings.example/v1",
-  headers: { Authorization: "Bearer test" },
-  model: "text-embedding-3-small",
+type EmbeddingBody = {
+  model: string;
+  input: string[];
+  dimensions?: number;
+  input_type?: string;
+};
+type CapturedRequest = {
+  url: string | undefined;
+  authorization: string | undefined;
+  alias: string | string[] | undefined;
+  body: EmbeddingBody;
+  response: ServerResponse;
+  closed: boolean;
 };
 
-const mocks = vi.hoisted(() => ({
-  fetchRemoteEmbeddingVectors: vi.fn(async () => [[1, 0]]),
-  resolveRemoteEmbeddingClient: vi.fn(async () => ({ ...DEFAULT_MOCK_CLIENT })),
-}));
+const servers: Server[] = [];
 
-vi.mock("openclaw/plugin-sdk/memory-core-host-engine-embeddings", () => ({
-  fetchRemoteEmbeddingVectors: mocks.fetchRemoteEmbeddingVectors,
-  resolveEmbeddingEndpointUrl: (baseUrl: string, endpoint: string) => `${baseUrl}/${endpoint}`,
-  resolveRemoteEmbeddingClient: mocks.resolveRemoteEmbeddingClient,
-}));
+function respondWithEmbeddings(request: CapturedRequest): void {
+  request.response.writeHead(200, { "content-type": "application/json" });
+  request.response.end(
+    JSON.stringify({
+      data: request.body.input
+        .map((text, index) => ({ index, embedding: [text.length, index + 1] }))
+        .toReversed(),
+    }),
+  );
+}
 
-import { createOpenAiEmbeddingProvider } from "./embedding-provider.js";
+async function startEmbeddingServer(onRequest = respondWithEmbeddings) {
+  const requests: CapturedRequest[] = [];
+  const server = createServer((request, response) => {
+    void (async () => {
+      try {
+        const chunks: Buffer[] = [];
+        for await (const chunk of request) {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        }
+        const captured: CapturedRequest = {
+          url: request.url,
+          authorization: request.headers.authorization,
+          alias: request.headers["x-alias"],
+          body: JSON.parse(Buffer.concat(chunks).toString("utf8")) as EmbeddingBody,
+          response,
+          closed: false,
+        };
+        response.once("close", () => {
+          captured.closed = true;
+        });
+        requests.push(captured);
+        onRequest(captured);
+      } catch (error) {
+        response.writeHead(500).end(String(error));
+      }
+    })();
+  });
+  servers.push(server);
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("expected loopback TCP address");
+  }
+  return { baseUrl: `http://127.0.0.1:${address.port}/tenant/v1`, requests };
+}
 
 function createOptions(
   overrides: Partial<MemoryEmbeddingProviderCreateOptions> = {},
 ): MemoryEmbeddingProviderCreateOptions {
   return {
-    config: {} as MemoryEmbeddingProviderCreateOptions["config"],
+    config: {},
     provider: "openai",
     model: "text-embedding-3-small",
     fallback: "none",
     ...overrides,
+    remote: { apiKey: "fixture-openai-key", ...overrides.remote },
   };
 }
 
-function expectFetchRemoteEmbeddingVectorsBody(body: Record<string, unknown>) {
-  expect(mocks.fetchRemoteEmbeddingVectors).toHaveBeenCalledWith({
-    url: "https://embeddings.example/v1/embeddings",
-    headers: { Authorization: "Bearer test" },
-    ssrfPolicy: undefined,
-    fetchImpl: undefined,
-    signal: undefined,
-    body,
-    errorPrefix: "openai embeddings failed",
-  });
-}
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+          server.closeAllConnections();
+        }),
+    ),
+  );
+});
 
-describe("OpenAI embedding provider", () => {
-  beforeEach(() => {
-    mocks.fetchRemoteEmbeddingVectors.mockClear();
-    mocks.resolveRemoteEmbeddingClient.mockClear();
-  });
-
-  it("sends queryInputType on query embeddings", async () => {
+describe("OpenAI embedding provider HTTP contract", () => {
+  it.each([
+    {
+      name: "query override",
+      options: { inputType: "passage", queryInputType: " query " },
+      kind: "query" as const,
+      expected: { input_type: "query" },
+    },
+    {
+      name: "document override",
+      options: { inputType: "query", documentInputType: " document " },
+      kind: "document" as const,
+      expected: { input_type: "document" },
+    },
+    {
+      name: "configured default",
+      options: { inputType: " passage " },
+      kind: undefined,
+      expected: { input_type: "passage" },
+    },
+    {
+      name: "unconfigured input type",
+      options: {},
+      kind: "document" as const,
+      expected: {},
+    },
+    {
+      name: "blank explicit query override",
+      options: { inputType: "passage", queryInputType: " " },
+      kind: "query" as const,
+      expected: {},
+    },
+    {
+      name: "dimensions",
+      options: { dimensions: 512 },
+      kind: "document" as const,
+      expected: { dimensions: 512 },
+    },
+    {
+      name: "other semantic types use the document payload",
+      options: { queryInputType: "query", documentInputType: "passage" },
+      kind: "semantic" as const,
+      expected: { input_type: "passage" },
+    },
+  ])("preserves $name", async ({ options, kind, expected }) => {
+    const server = await startEmbeddingServer();
     const { provider } = await createOpenAiEmbeddingProvider(
-      createOptions({ inputType: "passage", queryInputType: "query" }),
+      createOptions({
+        ...options,
+        remote: { baseUrl: `${server.baseUrl}/?tenant=beta#local` },
+      }),
     );
 
-    await provider.embed("hello", { inputType: "query" });
-
-    expectFetchRemoteEmbeddingVectorsBody({
+    await expect(provider.embed({ text: "hello" }, { inputType: kind })).resolves.toEqual([5, 1]);
+    expect(server.requests).toHaveLength(1);
+    expect(server.requests[0]).toMatchObject({
+      url: "/tenant/v1/embeddings?tenant=beta",
+      authorization: "Bearer fixture-openai-key",
+      body: { model: "text-embedding-3-small", input: ["hello"], ...expected },
+    });
+    expect(server.requests[0]?.body).toEqual({
       model: "text-embedding-3-small",
       input: ["hello"],
-      input_type: "query",
+      ...expected,
     });
   });
 
-  it("sends documentInputType on document batch embeddings", async () => {
+  it("keeps document batches in one request and restores indexed response order", async () => {
+    const server = await startEmbeddingServer();
     const { provider } = await createOpenAiEmbeddingProvider(
-      createOptions({ inputType: "query", documentInputType: "document" }),
+      createOptions({
+        documentInputType: "document",
+        remote: { baseUrl: server.baseUrl },
+      }),
     );
 
-    await provider.embedBatch(["doc one", "doc two"]);
-
-    expectFetchRemoteEmbeddingVectorsBody({
+    await expect(
+      provider.embedBatch(["first", { text: "second" }, "", { text: " \t" }]),
+    ).resolves.toEqual([
+      [5, 1],
+      [6, 2],
+      [0, 3],
+      [2, 4],
+    ]);
+    expect(server.requests).toHaveLength(1);
+    expect(server.requests[0]?.body).toEqual({
       model: "text-embedding-3-small",
-      input: ["doc one", "doc two"],
+      input: ["first", "second", "", " \t"],
       input_type: "document",
     });
+    await expect(provider.embedBatch([])).resolves.toEqual([]);
+    await expect(provider.embedBatch([], { inputType: "query" })).resolves.toEqual([]);
+    expect(server.requests).toHaveLength(1);
   });
 
-  it("omits input_type unless configured", async () => {
-    const { provider } = await createOpenAiEmbeddingProvider(createOptions());
-
-    await provider.embedBatch(["doc"]);
-
-    expectFetchRemoteEmbeddingVectorsBody({
-      model: "text-embedding-3-small",
-      input: ["doc"],
-    });
-  });
-
-  it("sends outputDimensionality as OpenAI dimensions", async () => {
-    const { provider } = await createOpenAiEmbeddingProvider(createOptions({ dimensions: 512 }));
-
-    await provider.embedBatch(["doc"]);
-
-    expectFetchRemoteEmbeddingVectorsBody({
-      model: "text-embedding-3-small",
-      input: ["doc"],
-      dimensions: 512,
-    });
-  });
-
-  it("forwards custom provider ids to the remote embedding client", async () => {
-    await createOpenAiEmbeddingProvider(createOptions({ provider: "bailian-embedding" }));
-
-    expect(mocks.resolveRemoteEmbeddingClient).toHaveBeenCalledWith(
-      expect.objectContaining({
-        provider: "bailian-embedding",
-      }),
+  it("reads mutable client payload fields per call while retaining endpoint and provider metadata", async () => {
+    const server = await startEmbeddingServer();
+    const { provider, client } = await createOpenAiEmbeddingProvider(
+      createOptions({ queryInputType: "query", remote: { baseUrl: server.baseUrl } }),
     );
-  });
+    await provider.embed("first", { inputType: "query" });
+    client.model = "updated-model";
+    client.queryInputType = " updated-query ";
+    client.outputDimensionality = 64;
+    client.headers = { ...client.headers, "x-alias": "updated" };
+    client.baseUrl = `${server.baseUrl}/unused`;
 
-  it("defaults the remote embedding client lookup to openai", async () => {
-    await createOpenAiEmbeddingProvider(createOptions({ provider: undefined }));
-
-    expect(mocks.resolveRemoteEmbeddingClient).toHaveBeenCalledWith(
-      expect.objectContaining({
-        provider: "openai",
-      }),
-    );
-  });
-
-  // --- openai/ prefix preservation ---
-
-  it("strips openai/ prefix when using native OpenAI API base URL", async () => {
-    mocks.resolveRemoteEmbeddingClient.mockResolvedValueOnce({
-      ...DEFAULT_MOCK_CLIENT,
-      baseUrl: "https://api.openai.com/v1",
-      model: "text-embedding-3-small",
-    });
-
-    const { provider } = await createOpenAiEmbeddingProvider(
-      createOptions({ model: "openai/text-embedding-3-small" }),
-    );
+    await provider.embed("second", { inputType: "query" });
 
     expect(provider.model).toBe("text-embedding-3-small");
-  });
-
-  it("strips openai/ prefix for semantically native URLs (uppercase hostname)", async () => {
-    mocks.resolveRemoteEmbeddingClient.mockResolvedValueOnce({
-      ...DEFAULT_MOCK_CLIENT,
-      baseUrl: "https://API.OPENAI.COM/v1",
-      model: "text-embedding-3-small",
-    });
-
-    const { provider } = await createOpenAiEmbeddingProvider(
-      createOptions({ model: "openai/text-embedding-3-small" }),
-    );
-
-    expect(provider.model).toBe("text-embedding-3-small");
-  });
-
-  it("preserves openai/ prefix for non-native OpenAI base URLs", async () => {
-    mocks.resolveRemoteEmbeddingClient.mockResolvedValueOnce({
-      ...DEFAULT_MOCK_CLIENT,
-      baseUrl: "https://router.requesty.ai/v1",
-      model: "text-embedding-3-small",
-    });
-
-    const { provider } = await createOpenAiEmbeddingProvider(
-      createOptions({ model: "openai/text-embedding-3-small" }),
-    );
-
-    expect(provider.model).toBe("openai/text-embedding-3-small");
-  });
-
-  it("provides maxInputTokens for qualified model with non-native base URL", async () => {
-    mocks.resolveRemoteEmbeddingClient.mockResolvedValueOnce({
-      ...DEFAULT_MOCK_CLIENT,
-      baseUrl: "https://router.requesty.ai/v1",
-      model: "text-embedding-3-small",
-    });
-
-    const { provider } = await createOpenAiEmbeddingProvider(
-      createOptions({ model: "openai/text-embedding-3-small" }),
-    );
-
     expect(provider.maxInputTokens).toBe(8192);
+    expect(server.requests.map(({ url, alias, body }) => ({ url, alias, body }))).toEqual([
+      {
+        url: "/tenant/v1/embeddings",
+        alias: undefined,
+        body: { model: "text-embedding-3-small", input: ["first"], input_type: "query" },
+      },
+      {
+        url: "/tenant/v1/embeddings",
+        alias: "updated",
+        body: {
+          model: "updated-model",
+          input: ["second"],
+          dimensions: 64,
+          input_type: "updated-query",
+        },
+      },
+    ]);
   });
 
-  it("preserves openai/ prefix in embedding request body for non-native base URLs", async () => {
-    mocks.resolveRemoteEmbeddingClient.mockResolvedValueOnce({
-      ...DEFAULT_MOCK_CLIENT,
-      baseUrl: "https://router.requesty.ai/v1",
-      model: "text-embedding-3-small",
-    });
+  it.each(["singleton", "query batch", "document batch"] as const)(
+    "rejects a pre-aborted %s without sending HTTP",
+    async (kind) => {
+      const server = await startEmbeddingServer();
+      const { provider } = await createOpenAiEmbeddingProvider(
+        createOptions({ remote: { baseUrl: server.baseUrl } }),
+      );
+      const controller = new AbortController();
+      controller.abort();
+      const options = {
+        signal: controller.signal,
+        inputType: kind === "document batch" ? ("document" as const) : ("query" as const),
+      };
+      const outcome =
+        kind === "singleton"
+          ? provider.embed("hello", options)
+          : provider.embedBatch(["first", "second"], options);
 
+      await expect(outcome).rejects.toMatchObject({ name: "AbortError" });
+      expect(server.requests).toHaveLength(0);
+    },
+  );
+
+  it("starts query requests concurrently and preserves input order despite reversed completion", async () => {
+    const server = await startEmbeddingServer(() => {});
+    const controller = new AbortController();
+    const { provider } = await createOpenAiEmbeddingProvider(
+      createOptions({ queryInputType: "query", remote: { baseUrl: server.baseUrl } }),
+    );
+    const outcome = provider
+      .embedBatch(["first", { text: "second" }], {
+        inputType: "query",
+        signal: controller.signal,
+      })
+      .then(
+        (value) => ({ value }),
+        (error: unknown) => ({ error }),
+      );
+    try {
+      // Both requests must reach HTTP before either response is released.
+      await vi.waitFor(() => expect(server.requests).toHaveLength(2));
+      const first = server.requests.find((request) => request.body.input[0] === "first");
+      const second = server.requests.find((request) => request.body.input[0] === "second");
+      expect(first).toBeDefined();
+      expect(second).toBeDefined();
+      if (!first || !second) {
+        throw new Error("missing query request");
+      }
+      expect(server.requests.map((request) => request.body.input_type)).toEqual(["query", "query"]);
+      respondWithEmbeddings(second);
+      await vi.waitFor(() => expect(second.closed).toBe(true));
+      respondWithEmbeddings(first);
+      await expect(outcome).resolves.toEqual({
+        value: [
+          [5, 1],
+          [6, 1],
+        ],
+      });
+    } finally {
+      controller.abort();
+      await outcome;
+    }
+  });
+
+  it.each(["cancel", "first request failure"] as const)(
+    "preserves query-batch %s and releases every guarded request",
+    async (mode) => {
+      const server = await startEmbeddingServer(() => {});
+      const controller = new AbortController();
+      const { provider } = await createOpenAiEmbeddingProvider(
+        createOptions({ remote: { baseUrl: server.baseUrl } }),
+      );
+      const outcome = provider
+        .embedBatch(["first", "second"], { inputType: "query", signal: controller.signal })
+        .then(
+          (value) => ({ value }),
+          (error: unknown) => ({ error }),
+        );
+      try {
+        await vi.waitFor(() => expect(server.requests).toHaveLength(2));
+        if (mode === "first request failure") {
+          server.requests[0]?.response.writeHead(503).end("fixture rejected");
+          await expect(outcome).resolves.toMatchObject({
+            error: { message: expect.stringContaining("openai embeddings failed: 503") },
+          });
+          // Promise.all rejects early; it must not cancel the still-running sibling.
+          expect(server.requests[1]?.closed).toBe(false);
+        }
+        controller.abort(new Error("fixture caller cancellation"));
+        await expect(outcome).resolves.toHaveProperty("error");
+        await vi.waitFor(() =>
+          expect(server.requests.every((request) => request.closed)).toBe(true),
+        );
+        expect(server.requests).toHaveLength(2);
+      } finally {
+        controller.abort();
+        await outcome;
+      }
+    },
+  );
+
+  it.each(["https://api.openai.com/v1", "https://API.OPENAI.COM/v1"])(
+    "strips the model prefix only for native endpoint %s",
+    async (baseUrl) => {
+      const { provider } = await createOpenAiEmbeddingProvider(
+        createOptions({ model: "openai/text-embedding-3-small", remote: { baseUrl } }),
+      );
+      expect(provider.model).toBe("text-embedding-3-small");
+      expect(provider.maxInputTokens).toBe(8192);
+    },
+  );
+
+  it("preserves qualified router models in metadata and request bodies", async () => {
+    const server = await startEmbeddingServer();
     const { provider } = await createOpenAiEmbeddingProvider(
       createOptions({
         model: "openai/text-embedding-3-small",
-        inputType: "query",
+        remote: { baseUrl: server.baseUrl },
       }),
     );
+    expect(provider.model).toBe("openai/text-embedding-3-small");
+    expect(provider.maxInputTokens).toBe(8192);
+    await provider.embed("hello", { inputType: "query" });
+    expect(server.requests[0]?.body.model).toBe("openai/text-embedding-3-small");
+  });
 
-    await provider.embed("test", { inputType: "query" });
+  it("uses the configured custom provider destination and headers", async () => {
+    const server = await startEmbeddingServer();
+    const { provider } = await createOpenAiEmbeddingProvider(
+      createOptions({
+        provider: "fixture-alias",
+        config: {
+          models: {
+            providers: {
+              "fixture-alias": {
+                baseUrl: server.baseUrl,
+                headers: { "x-alias": "selected" },
+                models: [],
+              },
+            },
+          },
+        },
+      }),
+    );
+    await provider.embed("hello");
+    expect(server.requests[0]?.alias).toBe("selected");
+  });
 
-    expect(mocks.fetchRemoteEmbeddingVectors).toHaveBeenCalledWith({
-      url: "https://router.requesty.ai/v1/embeddings",
-      headers: { Authorization: "Bearer test" },
-      ssrfPolicy: undefined,
-      fetchImpl: undefined,
-      signal: undefined,
-      body: {
-        model: "openai/text-embedding-3-small",
-        input: ["test"],
-        input_type: "query",
-      },
-      errorPrefix: "openai embeddings failed",
-    });
+  it("defaults the client provider lookup to OpenAI", async () => {
+    const { client } = await createOpenAiEmbeddingProvider(createOptions({ provider: undefined }));
+    expect(client.baseUrl).toBe("https://api.openai.com/v1");
+    expect(client.model).toBe("text-embedding-3-small");
   });
 });

--- a/extensions/openai/embedding-provider.test.ts
+++ b/extensions/openai/embedding-provider.test.ts
@@ -1,7 +1,10 @@
 // Exercise the provider, shared factory, and guarded HTTP transport together.
 import { once } from "node:events";
 import { createServer, type Server, type ServerResponse } from "node:http";
-import type { MemoryEmbeddingProviderCreateOptions } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
+import {
+  createRemoteEmbeddingProvider,
+  type MemoryEmbeddingProviderCreateOptions,
+} from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createOpenAiEmbeddingProvider } from "./embedding-provider.js";
 
@@ -96,6 +99,40 @@ afterEach(async () => {
 });
 
 describe("OpenAI embedding provider HTTP contract", () => {
+  it.each([
+    { name: "omitted", fields: { input_type: "document" } },
+    {
+      name: "overridden",
+      fields: { model: "other-model", input: ["shortened"], input_type: "document" },
+    },
+  ])("rejects short responses when callback fields have $name model/input", async ({ fields }) => {
+    const server = await startEmbeddingServer((request) => {
+      request.response.writeHead(200, { "content-type": "application/json" });
+      request.response.end(JSON.stringify({ data: [{ embedding: [1, 2] }] }));
+    });
+    const provider = createRemoteEmbeddingProvider({
+      id: "fixture",
+      client: {
+        baseUrl: server.baseUrl,
+        headers: {},
+        model: "fixture-model",
+        ssrfPolicy: { allowedHostnames: ["127.0.0.1"] },
+      },
+      errorPrefix: "fixture embeddings failed",
+      buildRequestFields: () => fields,
+    });
+
+    await expect(provider.embedBatch(["first", "second"])).rejects.toThrow(
+      "fixture embeddings failed: malformed JSON response",
+    );
+    expect(server.requests).toHaveLength(1);
+    expect(server.requests[0]?.body).toEqual({
+      model: "fixture-model",
+      input: ["first", "second"],
+      input_type: "document",
+    });
+  });
+
   it.each([
     {
       name: "query override",

--- a/extensions/openai/embedding-provider.ts
+++ b/extensions/openai/embedding-provider.ts
@@ -1,7 +1,6 @@
 // Openai provider module implements model/runtime integration.
 import {
-  fetchRemoteEmbeddingVectors,
-  resolveEmbeddingEndpointUrl,
+  createRemoteEmbeddingProvider,
   resolveRemoteEmbeddingClient,
   type MemoryEmbeddingProvider,
   type MemoryEmbeddingProviderCreateOptions,
@@ -50,70 +49,27 @@ export async function createOpenAiEmbeddingProvider(
   options: MemoryEmbeddingProviderCreateOptions,
 ): Promise<{ provider: MemoryEmbeddingProvider; client: OpenAiEmbeddingClient }> {
   const client = await resolveOpenAiEmbeddingClient(options);
-  const url = resolveEmbeddingEndpointUrl(client.baseUrl, "embeddings");
-
-  const resolveInputType = (kind: "query" | "document"): string | undefined => {
-    const explicit = kind === "query" ? client.queryInputType : client.documentInputType;
-    const value = explicit ?? client.inputType;
-    return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
-  };
-
-  const embedMany = async (
-    input: string[],
-    kind: "query" | "document",
-    signal?: AbortSignal,
-  ): Promise<number[][]> => {
-    if (input.length === 0) {
-      return [];
-    }
-    const inputType = resolveInputType(kind);
-    return await fetchRemoteEmbeddingVectors({
-      url,
-      headers: client.headers,
-      ssrfPolicy: client.ssrfPolicy,
-      fetchImpl: client.fetchImpl,
-      signal,
-      body: {
-        model: client.model,
-        input,
-        ...(typeof client.outputDimensionality === "number"
-          ? { dimensions: client.outputDimensionality }
-          : {}),
-        ...(inputType ? { input_type: inputType } : {}),
-      },
-      errorPrefix: "openai embeddings failed",
-    });
-  };
-
   return {
-    provider: {
+    provider: createRemoteEmbeddingProvider({
       id: "openai",
-      model: client.model,
-      ...(typeof OPENAI_MAX_INPUT_TOKENS[normalizeOpenAiModel(client.model)] === "number"
-        ? { maxInputTokens: OPENAI_MAX_INPUT_TOKENS[normalizeOpenAiModel(client.model)] }
-        : {}),
-      embed: async (input, optionsValue) => {
-        const text = typeof input === "string" ? input : input.text;
-        const [vec] = await embedMany(
-          [text],
-          optionsValue?.inputType === "query" ? "query" : "document",
-          optionsValue?.signal,
-        );
-        return vec ?? [];
+      client,
+      errorPrefix: "openai embeddings failed",
+      maxInputTokens: OPENAI_MAX_INPUT_TOKENS[normalizeOpenAiModel(client.model)],
+      buildRequestBody: (input, kind) => {
+        const explicit = kind === "query" ? client.queryInputType : client.documentInputType;
+        const value = explicit ?? client.inputType;
+        const inputType =
+          typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+        return {
+          model: client.model,
+          input,
+          ...(typeof client.outputDimensionality === "number"
+            ? { dimensions: client.outputDimensionality }
+            : {}),
+          ...(inputType ? { input_type: inputType } : {}),
+        };
       },
-      embedBatch: async (inputs, optionsLocal) => {
-        const texts = inputs.map((input) => (typeof input === "string" ? input : input.text));
-        if (optionsLocal?.inputType === "query") {
-          return await Promise.all(
-            texts.map(async (text) => {
-              const [vec] = await embedMany([text], "query", optionsLocal.signal);
-              return vec ?? [];
-            }),
-          );
-        }
-        return await embedMany(texts, "document", optionsLocal?.signal);
-      },
-    },
+    }),
     client,
   };
 }

--- a/extensions/openai/embedding-provider.ts
+++ b/extensions/openai/embedding-provider.ts
@@ -55,14 +55,12 @@ export async function createOpenAiEmbeddingProvider(
       client,
       errorPrefix: "openai embeddings failed",
       maxInputTokens: OPENAI_MAX_INPUT_TOKENS[normalizeOpenAiModel(client.model)],
-      buildRequestBody: (input, kind) => {
+      buildRequestFields: (kind) => {
         const explicit = kind === "query" ? client.queryInputType : client.documentInputType;
         const value = explicit ?? client.inputType;
         const inputType =
           typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
         return {
-          model: client.model,
-          input,
           ...(typeof client.outputDimensionality === "number"
             ? { dimensions: client.outputDimensionality }
             : {}),

--- a/packages/memory-host-sdk/src/host/embeddings-remote-provider.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-remote-provider.ts
@@ -27,11 +27,17 @@ export function createRemoteEmbeddingProvider(params: {
   maxInputTokens?: number;
   /** Keep query arrays in one request when the provider has no query/document wire distinction. */
   batchQueryInputs?: boolean;
+  /** Provider-owned payload fields; request grouping and transport stay shared. */
+  buildRequestBody?: (input: string[], kind: "query" | "document") => unknown;
 }): EmbeddingProvider {
   const { client } = params;
   const url = resolveEmbeddingEndpointUrl(client.baseUrl, "embeddings");
 
-  const embedMany = async (input: string[], signal?: AbortSignal): Promise<number[][]> => {
+  const embedMany = async (
+    input: string[],
+    signal?: AbortSignal,
+    kind: "query" | "document" = "document",
+  ): Promise<number[][]> => {
     if (input.length === 0) {
       return [];
     }
@@ -41,7 +47,9 @@ export function createRemoteEmbeddingProvider(params: {
       ssrfPolicy: client.ssrfPolicy,
       fetchImpl: client.fetchImpl,
       signal,
-      body: { model: client.model, input },
+      body: params.buildRequestBody
+        ? params.buildRequestBody(input, kind)
+        : { model: client.model, input },
       errorPrefix: params.errorPrefix,
     });
   };
@@ -52,17 +60,25 @@ export function createRemoteEmbeddingProvider(params: {
     ...(typeof params.maxInputTokens === "number" ? { maxInputTokens: params.maxInputTokens } : {}),
     embed: async (input, options) => {
       const text = typeof input === "string" ? input : input.text;
-      const [vec] = await embedMany([text], options?.signal);
+      const [vec] = await embedMany(
+        [text],
+        options?.signal,
+        options?.inputType === "query" ? "query" : "document",
+      );
       return vec ?? [];
     },
     embedBatch: async (inputs, options) => {
       const texts = inputs.map((input) => (typeof input === "string" ? input : input.text));
       if (options?.inputType === "query" && params.batchQueryInputs !== true) {
         return await Promise.all(
-          texts.map(async (text) => (await embedMany([text], options.signal))[0] ?? []),
+          texts.map(async (text) => (await embedMany([text], options.signal, "query"))[0] ?? []),
         );
       }
-      return await embedMany(texts, options?.signal);
+      return await embedMany(
+        texts,
+        options?.signal,
+        options?.inputType === "query" ? "query" : "document",
+      );
     },
   };
 }

--- a/packages/memory-host-sdk/src/host/embeddings-remote-provider.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-remote-provider.ts
@@ -27,8 +27,8 @@ export function createRemoteEmbeddingProvider(params: {
   maxInputTokens?: number;
   /** Keep query arrays in one request when the provider has no query/document wire distinction. */
   batchQueryInputs?: boolean;
-  /** Provider-owned payload fields; request grouping and transport stay shared. */
-  buildRequestBody?: (input: string[], kind: "query" | "document") => unknown;
+  /** Additional payload fields; model and input remain owned by the shared request path. */
+  buildRequestFields?: (kind: "query" | "document") => Record<string, unknown>;
 }): EmbeddingProvider {
   const { client } = params;
   const url = resolveEmbeddingEndpointUrl(client.baseUrl, "embeddings");
@@ -47,9 +47,11 @@ export function createRemoteEmbeddingProvider(params: {
       ssrfPolicy: client.ssrfPolicy,
       fetchImpl: client.fetchImpl,
       signal,
-      body: params.buildRequestBody
-        ? params.buildRequestBody(input, kind)
-        : { model: client.model, input },
+      body: {
+        ...params.buildRequestFields?.(kind),
+        model: client.model,
+        input,
+      },
       errorPrefix: params.errorPrefix,
     });
   };


### PR DESCRIPTION
## What Problem This Solves

OpenAI memory embeddings duplicated the shared request orchestration for query/document grouping, endpoint construction, transport and vector validation. Keeping the implementations aligned made provider behavior harder to maintain.

## Why This Change Was Made

The OpenAI provider now uses the existing remote embedding factory while keeping its dimensions and input-type additions. The factory owns canonical model/input fields and request grouping; its customization callback can add payload fields without replacing the requested inputs or bypassing vector-count validation. This addresses the earlier review finding about unrestricted request-body customization.

## User Impact

No intended behavior change. Query concurrency, document batching, cancellation, endpoint query parameters, mutable client settings, response order and error handling retain their existing contracts. The complete change removes 26 production code lines (28 physical lines); meaningful HTTP and cardinality coverage adds 221 test code lines.

## Evidence

- Both new cardinality regressions failed on the prior implementation: one returned vector incorrectly succeeded for two requested inputs. All 20 existing HTTP cases passed on that baseline.
- All 46 final focused cases passed across real loopback HTTP, shared-factory grouping and remote-vector validation suites.
- The complete selected gate passed all 33 checks, including four type lanes, all unused-export scans, typed lint and architecture guards.
- Normal pnpm build passed all 16 phases, including 90 plugin distributions, full SDK declarations and UI checks.
- Fresh full-candidate P2 review is clean. Final tree fb60a04466f9080ca87159c9dc5042f5cd62eeeb is the verified source.
- This proof uses real local HTTP, not an authenticated provider call; the external request contract is unchanged. The remote-fetch owner is untouched, preserving the separate Azure query-forwarding work in #139436.

## Compatibility and storage

The documented optional payload callback is the intended additive SDK contract. Existing callback-free Mistral, DeepInfra and LM Studio callers retain the same interface and defaults; the shared-factory grouping cases protect them. OpenAI retains the same model, dimensions and input-type fields. The two new regressions enforce canonical model/input precedence and result cardinality for the added customization path.

No persisted data model changes: this diff changes request construction, tests and documentation, with no schema, migration, store, retention, vector identity, embedding model/dimension default, or cache-key change. Returned vectors retain their existing ordering and validation. A database migration or upgrade conversion is therefore unnecessary. The automated path-based data-model flag does not identify an actual persistent-state change in this patch.
