### PR TITLE
Feat/add new model

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1259,7 +1259,7 @@ extensions/telegram/src/thread-bindings.ts	2
 extensions/telegram/src/topic-name-cache.ts	3
 extensions/telegram/src/update-offset-store.ts	1
 extensions/telegram/src/webhook.ts	1
-extensions/tencent/stream.ts	5
+extensions/tencent/stream.ts	4
 extensions/tlon/src/channel.runtime.ts	3
 extensions/tlon/src/channel.ts	2
 extensions/tlon/src/monitor/approval-runtime.ts	2

--- a/docs/providers/tencent.md
+++ b/docs/providers/tencent.md
@@ -1,12 +1,12 @@
 ---
-summary: "Tencent Cloud TokenHub and TokenPlan setup for hy3"
+summary: "Tencent Cloud TokenHub and TokenPlan setup for hy4-preview"
 title: "Tencent Cloud (TokenHub / TokenPlan)"
 read_when:
-  - You want to use Tencent hy3 with OpenClaw
+  - You want to use Tencent hy4-preview with OpenClaw
   - You need the TokenHub or TokenPlan API key setup
 ---
 
-Install the official Tencent Cloud provider plugin to access Tencent Hy3 through two endpoints — TokenHub (`tencent-tokenhub`) and TokenPlan (`tencent-tokenplan`) — using an OpenAI-compatible API.
+Install the official Tencent Cloud provider plugin to access Tencent Hunyuan chat models (`hy4-preview`, `hy3`) through two endpoints — TokenHub (`tencent-tokenhub`) and TokenPlan (`tencent-tokenplan`) — using an OpenAI-compatible API.
 
 | Property                  | Value                                                 |
 | ------------------------- | ----------------------------------------------------- |
@@ -22,13 +22,13 @@ Install the official Tencent Cloud provider plugin to access Tencent Hy3 through
 | TokenHub base URL         | `https://tokenhub.tencentmaas.com/v1`                 |
 | TokenHub global base URL  | `https://tokenhub-intl.tencentmaas.com/v1` (override) |
 | TokenPlan base URL        | `https://api.lkeap.cloud.tencent.com/plan/v3`         |
-| Default model             | `tencent-tokenhub/hy3`                                |
+| Default model             | `tencent-tokenhub/hy4-preview`                        |
 
 ## Quick start
 
 <Steps>
   <Step title="Create a Tencent API key">
-    Create an API key for Tencent Cloud TokenHub and TokenPlan. If you choose a limited access scope for the key, include **hy3** (and **hy3 preview** if you plan to use it on TokenHub) in the allowed models.
+    Create an API key for Tencent Cloud TokenHub and TokenPlan. If you choose a limited access scope for the key, include **hy4 preview** (and **hy3** / **hy3 preview** if you plan to use them on TokenHub) in the allowed models.
   </Step>
   <Step title="Run onboarding">
     <CodeGroup>
@@ -97,17 +97,15 @@ openclaw onboard --non-interactive \
 
 ## Built-in catalog
 
-| Model ref                      | Name                   | Input | Context | Max output | Notes                      |
-| ------------------------------ | ---------------------- | ----- | ------- | ---------- | -------------------------- |
-| `tencent-tokenhub/hy3-preview` | hy3 preview (TokenHub) | text  | 256,000 | 128,000    | deprecated; use `hy3`      |
-| `tencent-tokenhub/hy3`         | hy3 (TokenHub)         | text  | 256,000 | 128,000    | reasoning-enabled; current |
-| `tencent-tokenplan/hy3`        | hy3 (TokenPlan)        | text  | 256,000 | 128,000    | reasoning-enabled; current |
+| Model ref                       | Name                    | Input | Context   | Max output | Notes                          |
+| ------------------------------- | ----------------------- | ----- | --------- | ---------- | ------------------------------ |
+| `tencent-tokenhub/hy4-preview`  | hy4 preview (TokenHub)  | text  | 1,024,000 | 64,000     | reasoning-enabled; **default** |
+| `tencent-tokenhub/hy3`          | hy3 (TokenHub)          | text  | 256,000   | 128,000    | reasoning-enabled; previous GA |
+| `tencent-tokenhub/hy3-preview`  | hy3 preview (TokenHub)  | text  | 256,000   | 128,000    | deprecated; use `hy4-preview`  |
+| `tencent-tokenplan/hy4-preview` | hy4 preview (TokenPlan) | text  | 1,024,000 | 64,000     | reasoning-enabled; **default** |
+| `tencent-tokenplan/hy3`         | hy3 (TokenPlan)         | text  | 256,000   | 128,000    | reasoning-enabled; previous GA |
 
-hy3 is Tencent Hunyuan's large MoE language model for reasoning, long-context instruction following, code, and agent workflows. Tencent's OpenAI-compatible examples use `hy3` as the model id and support standard chat-completions tool calling plus `reasoning_effort`.
-
-<Tip>
-  The model id is `hy3`. Do not confuse it with Tencent's `HY-3D-*` models, which are 3D generation APIs and are not the OpenClaw chat model configured by this provider.
-</Tip>
+`hy4-preview` is Tencent Hunyuan's large MoE language model for reasoning, long-context instruction following, code, and agent workflows. Tencent's OpenAI-compatible examples use `hy4-preview` as the model id and support standard chat-completions tool calling plus `reasoning_effort`.
 
 ## Advanced configuration
 

--- a/docs/providers/tencent.md
+++ b/docs/providers/tencent.md
@@ -107,6 +107,20 @@ openclaw onboard --non-interactive \
 
 `hy4-preview` is Tencent Hunyuan's large MoE language model for reasoning, long-context instruction following, code, and agent workflows. Tencent's OpenAI-compatible examples use `hy4-preview` as the model id and support standard chat-completions tool calling plus `reasoning_effort`.
 
+## Existing TokenHub configurations
+
+Fresh onboarding selects `hy4-preview` on both endpoints. Existing TokenHub
+configurations follow a separate migration policy: when a TokenHub model
+allowlist is configured, `openclaw doctor --fix` changes a deprecated
+`tencent-tokenhub/hy3-preview` primary to `tencent-tokenhub/hy3`, not Hy4.
+This applies to string and object primary settings and preserves fallbacks,
+custom aliases, and unrelated settings. Explicit `hy3` and `hy4-preview`
+primaries stay unchanged.
+
+The catalog recommendation for `hy3-preview` remains `hy4-preview`, but it is
+not the Doctor migration destination. Moving to Hy4 is an explicit choice:
+review its different pricing and verify model access for the selected endpoint.
+
 ## Advanced configuration
 
 <AccordionGroup>

--- a/extensions/tencent/config-compat.test.ts
+++ b/extensions/tencent/config-compat.test.ts
@@ -12,37 +12,47 @@ const REPAIRED_ALLOWLIST_CHANGE =
   `${TENCENT_TOKENHUB_HY3_MODEL_REF}, ${TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF}.`;
 
 describe("Tencent config compatibility", () => {
-  it("promotes hy4-preview to primary for old deprecated-preview defaults", () => {
+  it.each(["string", "object"])("migrates a %s hy3-preview primary to hy3", (shape) => {
     const config = {
+      gateway: { port: 18790 },
       agents: {
         defaults: {
-          model: {
-            primary: TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF,
-            fallbacks: ["openai/gpt-5.5"],
-          },
+          model:
+            shape === "string"
+              ? TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF
+              : {
+                  primary: TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF,
+                  fallbacks: ["openai/gpt-5.5"],
+                },
+          maxConcurrent: 2,
           models: {
             [TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF]: {
               alias: "Preview",
+              params: { temperature: 0.4 },
             },
+            "openai/gpt-5.5": { alias: "Other" },
           },
         },
       },
     } as OpenClawConfig;
 
+    const original = structuredClone(config);
     const result = migrateTencentTokenHubModelDefaults(config);
 
     expect(result.changes).toEqual([
       REPAIRED_ALLOWLIST_CHANGE,
-      `Changed Tencent TokenHub primary default from ${TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF} to ${TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF}.`,
+      `Changed Tencent TokenHub primary default from ${TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF} to ${TENCENT_TOKENHUB_HY3_MODEL_REF}.`,
     ]);
     expect(result.config.agents?.defaults?.model).toEqual({
-      primary: TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF,
-      fallbacks: ["openai/gpt-5.5"],
+      primary: TENCENT_TOKENHUB_HY3_MODEL_REF,
+      ...(shape === "object" ? { fallbacks: ["openai/gpt-5.5"] } : {}),
     });
     expect(result.config.agents?.defaults?.models).toEqual({
       [TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF]: {
         alias: "Preview",
+        params: { temperature: 0.4 },
       },
+      "openai/gpt-5.5": { alias: "Other" },
       [TENCENT_TOKENHUB_HY3_MODEL_REF]: {
         alias: "Hy3 (TokenHub)",
       },
@@ -50,9 +60,13 @@ describe("Tencent config compatibility", () => {
         alias: "Hy4 preview (TokenHub)",
       },
     });
-    expect(config.agents?.defaults?.models).not.toHaveProperty(
-      TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF,
-    );
+    expect(result.config.gateway).toEqual(config.gateway);
+    expect(result.config.agents?.defaults?.maxConcurrent).toBe(2);
+    expect(config).toEqual(original);
+    expect(migrateTencentTokenHubModelDefaults(result.config)).toEqual({
+      config: result.config,
+      changes: [],
+    });
   });
 
   it("backfills the allowlist without touching a working hy3 primary", () => {
@@ -65,7 +79,7 @@ describe("Tencent config compatibility", () => {
           model: { primary: TENCENT_TOKENHUB_HY3_MODEL_REF },
           models: {
             [TENCENT_TOKENHUB_HY3_MODEL_REF]: {
-              alias: "Hy3 (TokenHub)",
+              alias: "Custom Hy3",
             },
             [TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF]: {
               alias: "Hy3 preview (TokenHub)",
@@ -83,7 +97,7 @@ describe("Tencent config compatibility", () => {
     });
     expect(result.config.agents?.defaults?.models).toEqual({
       [TENCENT_TOKENHUB_HY3_MODEL_REF]: {
-        alias: "Hy3 (TokenHub)",
+        alias: "Custom Hy3",
       },
       [TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF]: {
         alias: "Hy3 preview (TokenHub)",
@@ -94,33 +108,40 @@ describe("Tencent config compatibility", () => {
     });
   });
 
-  it("adds the remaining TokenHub models for hy3-only intermediate configs", () => {
-    const config = {
-      agents: {
-        defaults: {
-          model: TENCENT_TOKENHUB_HY3_MODEL_REF,
-          models: {
-            [TENCENT_TOKENHUB_HY3_MODEL_REF]: {},
+  it.each([
+    TENCENT_TOKENHUB_HY3_MODEL_REF,
+    TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF,
+    "openai/gpt-5.5",
+  ])(
+    "preserves an explicit string primary %s while repairing the allowlist",
+    (primary) => {
+      const config = {
+        agents: {
+          defaults: {
+            model: primary,
+            models: {
+              [TENCENT_TOKENHUB_HY3_MODEL_REF]: {},
+            },
           },
         },
-      },
-    } as OpenClawConfig;
+      } as OpenClawConfig;
 
-    const result = migrateTencentTokenHubModelDefaults(config);
+      const result = migrateTencentTokenHubModelDefaults(config);
 
-    expect(result.config.agents?.defaults?.model).toBe(TENCENT_TOKENHUB_HY3_MODEL_REF);
-    expect(result.config.agents?.defaults?.models).toEqual({
-      [TENCENT_TOKENHUB_HY3_MODEL_REF]: {
-        alias: "Hy3 (TokenHub)",
-      },
-      [TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF]: {
-        alias: "Hy3 preview (TokenHub)",
-      },
-      [TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF]: {
-        alias: "Hy4 preview (TokenHub)",
-      },
-    });
-  });
+      expect(result.config.agents?.defaults?.model).toBe(primary);
+      expect(result.config.agents?.defaults?.models).toEqual({
+        [TENCENT_TOKENHUB_HY3_MODEL_REF]: {
+          alias: "Hy3 (TokenHub)",
+        },
+        [TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF]: {
+          alias: "Hy3 preview (TokenHub)",
+        },
+        [TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF]: {
+          alias: "Hy4 preview (TokenHub)",
+        },
+      });
+    },
+  );
 
   it("repairs configs that only pinned hy4-preview", () => {
     const config = {
@@ -170,28 +191,31 @@ describe("Tencent config compatibility", () => {
     expect(result).toEqual({ config, changes: [] });
   });
 
-  it("does not report changes after TokenHub defaults are already repaired", () => {
-    const config = {
-      agents: {
-        defaults: {
-          model: { primary: TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF },
-          models: {
-            [TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF]: {
-              alias: "Hy4 preview (TokenHub)",
-            },
-            [TENCENT_TOKENHUB_HY3_MODEL_REF]: {
-              alias: "Hy3 (TokenHub)",
-            },
-            [TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF]: {
-              alias: "Hy3 preview (TokenHub)",
+  it.each([TENCENT_TOKENHUB_HY3_MODEL_REF, TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF])(
+    "preserves custom aliases after defaults are repaired for %s",
+    (primary) => {
+      const config = {
+        agents: {
+          defaults: {
+            model: { primary },
+            models: {
+              [TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF]: {
+                alias: "My Hy4",
+              },
+              [TENCENT_TOKENHUB_HY3_MODEL_REF]: {
+                alias: "My Hy3",
+              },
+              [TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF]: {
+                alias: "My preview",
+              },
             },
           },
         },
-      },
-    } as OpenClawConfig;
+      } as OpenClawConfig;
 
-    const result = migrateTencentTokenHubModelDefaults(config);
+      const result = migrateTencentTokenHubModelDefaults(config);
 
-    expect(result).toEqual({ config, changes: [] });
-  });
+      expect(result).toEqual({ config, changes: [] });
+    },
+  );
 });

--- a/extensions/tencent/config-compat.test.ts
+++ b/extensions/tencent/config-compat.test.ts
@@ -3,20 +3,25 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { describe, expect, it } from "vitest";
 import { migrateTencentTokenHubModelDefaults } from "./config-compat.js";
 
-const TENCENT_TOKENHUB_DEFAULT_MODEL_REF = "tencent-tokenhub/hy3";
-const TENCENT_TOKENHUB_PREVIEW_MODEL_REF = "tencent-tokenhub/hy3-preview";
+const TENCENT_TOKENHUB_HY3_MODEL_REF = "tencent-tokenhub/hy3";
+const TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF = "tencent-tokenhub/hy3-preview";
+const TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF = "tencent-tokenhub/hy4-preview";
+
+const REPAIRED_ALLOWLIST_CHANGE =
+  `Updated Tencent TokenHub agent model defaults to include ${TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF}, ` +
+  `${TENCENT_TOKENHUB_HY3_MODEL_REF}, ${TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF}.`;
 
 describe("Tencent config compatibility", () => {
-  it("adds the stable TokenHub model and makes it primary for old preview defaults", () => {
+  it("promotes hy4-preview to primary for old deprecated-preview defaults", () => {
     const config = {
       agents: {
         defaults: {
           model: {
-            primary: TENCENT_TOKENHUB_PREVIEW_MODEL_REF,
+            primary: TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF,
             fallbacks: ["openai/gpt-5.5"],
           },
           models: {
-            [TENCENT_TOKENHUB_PREVIEW_MODEL_REF]: {
+            [TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF]: {
               alias: "Preview",
             },
           },
@@ -27,31 +32,44 @@ describe("Tencent config compatibility", () => {
     const result = migrateTencentTokenHubModelDefaults(config);
 
     expect(result.changes).toEqual([
-      `Updated Tencent TokenHub agent model defaults to include ${TENCENT_TOKENHUB_DEFAULT_MODEL_REF} and ${TENCENT_TOKENHUB_PREVIEW_MODEL_REF}.`,
-      `Changed Tencent TokenHub primary default from ${TENCENT_TOKENHUB_PREVIEW_MODEL_REF} to ${TENCENT_TOKENHUB_DEFAULT_MODEL_REF}.`,
+      REPAIRED_ALLOWLIST_CHANGE,
+      `Changed Tencent TokenHub primary default from ${TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF} to ${TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF}.`,
     ]);
     expect(result.config.agents?.defaults?.model).toEqual({
-      primary: TENCENT_TOKENHUB_DEFAULT_MODEL_REF,
+      primary: TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF,
       fallbacks: ["openai/gpt-5.5"],
     });
     expect(result.config.agents?.defaults?.models).toEqual({
-      [TENCENT_TOKENHUB_PREVIEW_MODEL_REF]: {
+      [TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF]: {
         alias: "Preview",
       },
-      [TENCENT_TOKENHUB_DEFAULT_MODEL_REF]: {
+      [TENCENT_TOKENHUB_HY3_MODEL_REF]: {
         alias: "Hy3 (TokenHub)",
       },
+      [TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF]: {
+        alias: "Hy4 preview (TokenHub)",
+      },
     });
-    expect(config.agents?.defaults?.models).not.toHaveProperty(TENCENT_TOKENHUB_DEFAULT_MODEL_REF);
+    expect(config.agents?.defaults?.models).not.toHaveProperty(
+      TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF,
+    );
   });
 
-  it("adds the preview TokenHub model for hy3-only intermediate configs", () => {
+  it("backfills the allowlist without touching a working hy3 primary", () => {
+    // hy3 is GA while hy4-preview is a preview that also needs the API key's
+    // allowed-model scope to cover hy4, so a live hy3 primary must survive the
+    // migration untouched.
     const config = {
       agents: {
         defaults: {
-          model: TENCENT_TOKENHUB_DEFAULT_MODEL_REF,
+          model: { primary: TENCENT_TOKENHUB_HY3_MODEL_REF },
           models: {
-            [TENCENT_TOKENHUB_DEFAULT_MODEL_REF]: {},
+            [TENCENT_TOKENHUB_HY3_MODEL_REF]: {
+              alias: "Hy3 (TokenHub)",
+            },
+            [TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF]: {
+              alias: "Hy3 preview (TokenHub)",
+            },
           },
         },
       },
@@ -59,12 +77,77 @@ describe("Tencent config compatibility", () => {
 
     const result = migrateTencentTokenHubModelDefaults(config);
 
-    expect(result.config.agents?.defaults?.model).toBe(TENCENT_TOKENHUB_DEFAULT_MODEL_REF);
+    expect(result.changes).toEqual([REPAIRED_ALLOWLIST_CHANGE]);
+    expect(result.config.agents?.defaults?.model).toEqual({
+      primary: TENCENT_TOKENHUB_HY3_MODEL_REF,
+    });
     expect(result.config.agents?.defaults?.models).toEqual({
-      [TENCENT_TOKENHUB_DEFAULT_MODEL_REF]: {
+      [TENCENT_TOKENHUB_HY3_MODEL_REF]: {
         alias: "Hy3 (TokenHub)",
       },
-      [TENCENT_TOKENHUB_PREVIEW_MODEL_REF]: {
+      [TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF]: {
+        alias: "Hy3 preview (TokenHub)",
+      },
+      [TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF]: {
+        alias: "Hy4 preview (TokenHub)",
+      },
+    });
+  });
+
+  it("adds the remaining TokenHub models for hy3-only intermediate configs", () => {
+    const config = {
+      agents: {
+        defaults: {
+          model: TENCENT_TOKENHUB_HY3_MODEL_REF,
+          models: {
+            [TENCENT_TOKENHUB_HY3_MODEL_REF]: {},
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = migrateTencentTokenHubModelDefaults(config);
+
+    expect(result.config.agents?.defaults?.model).toBe(TENCENT_TOKENHUB_HY3_MODEL_REF);
+    expect(result.config.agents?.defaults?.models).toEqual({
+      [TENCENT_TOKENHUB_HY3_MODEL_REF]: {
+        alias: "Hy3 (TokenHub)",
+      },
+      [TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF]: {
+        alias: "Hy3 preview (TokenHub)",
+      },
+      [TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF]: {
+        alias: "Hy4 preview (TokenHub)",
+      },
+    });
+  });
+
+  it("repairs configs that only pinned hy4-preview", () => {
+    const config = {
+      agents: {
+        defaults: {
+          model: { primary: TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF },
+          models: {
+            [TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF]: {},
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = migrateTencentTokenHubModelDefaults(config);
+
+    expect(result.changes).toEqual([REPAIRED_ALLOWLIST_CHANGE]);
+    expect(result.config.agents?.defaults?.model).toEqual({
+      primary: TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF,
+    });
+    expect(result.config.agents?.defaults?.models).toEqual({
+      [TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF]: {
+        alias: "Hy4 preview (TokenHub)",
+      },
+      [TENCENT_TOKENHUB_HY3_MODEL_REF]: {
+        alias: "Hy3 (TokenHub)",
+      },
+      [TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF]: {
         alias: "Hy3 preview (TokenHub)",
       },
     });
@@ -91,12 +174,15 @@ describe("Tencent config compatibility", () => {
     const config = {
       agents: {
         defaults: {
-          model: { primary: TENCENT_TOKENHUB_DEFAULT_MODEL_REF },
+          model: { primary: TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF },
           models: {
-            [TENCENT_TOKENHUB_DEFAULT_MODEL_REF]: {
+            [TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF]: {
+              alias: "Hy4 preview (TokenHub)",
+            },
+            [TENCENT_TOKENHUB_HY3_MODEL_REF]: {
               alias: "Hy3 (TokenHub)",
             },
-            [TENCENT_TOKENHUB_PREVIEW_MODEL_REF]: {
+            [TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF]: {
               alias: "Hy3 preview (TokenHub)",
             },
           },

--- a/extensions/tencent/config-compat.test.ts
+++ b/extensions/tencent/config-compat.test.ts
@@ -112,36 +112,33 @@ describe("Tencent config compatibility", () => {
     TENCENT_TOKENHUB_HY3_MODEL_REF,
     TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF,
     "openai/gpt-5.5",
-  ])(
-    "preserves an explicit string primary %s while repairing the allowlist",
-    (primary) => {
-      const config = {
-        agents: {
-          defaults: {
-            model: primary,
-            models: {
-              [TENCENT_TOKENHUB_HY3_MODEL_REF]: {},
-            },
+  ])("preserves an explicit string primary %s while repairing the allowlist", (primary) => {
+    const config = {
+      agents: {
+        defaults: {
+          model: primary,
+          models: {
+            [TENCENT_TOKENHUB_HY3_MODEL_REF]: {},
           },
         },
-      } as OpenClawConfig;
+      },
+    } as OpenClawConfig;
 
-      const result = migrateTencentTokenHubModelDefaults(config);
+    const result = migrateTencentTokenHubModelDefaults(config);
 
-      expect(result.config.agents?.defaults?.model).toBe(primary);
-      expect(result.config.agents?.defaults?.models).toEqual({
-        [TENCENT_TOKENHUB_HY3_MODEL_REF]: {
-          alias: "Hy3 (TokenHub)",
-        },
-        [TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF]: {
-          alias: "Hy3 preview (TokenHub)",
-        },
-        [TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF]: {
-          alias: "Hy4 preview (TokenHub)",
-        },
-      });
-    },
-  );
+    expect(result.config.agents?.defaults?.model).toBe(primary);
+    expect(result.config.agents?.defaults?.models).toEqual({
+      [TENCENT_TOKENHUB_HY3_MODEL_REF]: {
+        alias: "Hy3 (TokenHub)",
+      },
+      [TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF]: {
+        alias: "Hy3 preview (TokenHub)",
+      },
+      [TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF]: {
+        alias: "Hy4 preview (TokenHub)",
+      },
+    });
+  });
 
   it("repairs configs that only pinned hy4-preview", () => {
     const config = {

--- a/extensions/tencent/config-compat.ts
+++ b/extensions/tencent/config-compat.ts
@@ -5,12 +5,10 @@ const TENCENT_TOKENHUB_HY3_MODEL_REF = "tencent-tokenhub/hy3";
 const TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF = "tencent-tokenhub/hy3-preview";
 const TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF = "tencent-tokenhub/hy4-preview";
 
-// Deliberately a hardcoded snapshot rather than a manifest read: this
-// migration rewrites configs users already own, so it must stay pinned to the
-// default-model change it was written for. Reading `defaultModel` from the
-// manifest would let every future default rotation silently rewrite user
-// configs again.
-const TENCENT_TOKENHUB_MIGRATION_TARGET_MODEL_REF = TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF;
+// Legacy Hy3 preview configs migrate to Hy3, not the fresh-onboarding default.
+// Pin this independently of the manifest: a default rotation must not silently
+// upgrade existing users to Hy4 with different pricing and model access.
+const TENCENT_TOKENHUB_MIGRATION_TARGET_MODEL_REF = TENCENT_TOKENHUB_HY3_MODEL_REF;
 
 // Ordered so the repaired allowlist matches onboard.ts's alias order.
 const TENCENT_TOKENHUB_MANAGED_MODEL_REFS = [

--- a/extensions/tencent/config-compat.ts
+++ b/extensions/tencent/config-compat.ts
@@ -1,21 +1,38 @@
 // Tencent config compatibility repairs shipped TokenHub model allowlists.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 
-const TENCENT_TOKENHUB_DEFAULT_MODEL_REF = "tencent-tokenhub/hy3";
-const TENCENT_TOKENHUB_PREVIEW_MODEL_REF = "tencent-tokenhub/hy3-preview";
+const TENCENT_TOKENHUB_HY3_MODEL_REF = "tencent-tokenhub/hy3";
+const TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF = "tencent-tokenhub/hy3-preview";
+const TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF = "tencent-tokenhub/hy4-preview";
 
-const TOKENHUB_DEFAULT_ALIAS = "Hy3 (TokenHub)";
-const TOKENHUB_PREVIEW_ALIAS = "Hy3 preview (TokenHub)";
+// Deliberately a hardcoded snapshot rather than a manifest read: this
+// migration rewrites configs users already own, so it must stay pinned to the
+// default-model change it was written for. Reading `defaultModel` from the
+// manifest would let every future default rotation silently rewrite user
+// configs again.
+const TENCENT_TOKENHUB_MIGRATION_TARGET_MODEL_REF = TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF;
+
+// Ordered so the repaired allowlist matches onboard.ts's alias order.
+const TENCENT_TOKENHUB_MANAGED_MODEL_REFS = [
+  TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF,
+  TENCENT_TOKENHUB_HY3_MODEL_REF,
+  TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF,
+] as const;
+
+type TencentTokenHubManagedModelRef = (typeof TENCENT_TOKENHUB_MANAGED_MODEL_REFS)[number];
+
+const TENCENT_TOKENHUB_MODEL_ALIASES: Record<TencentTokenHubManagedModelRef, string> = {
+  [TENCENT_TOKENHUB_HY4_PREVIEW_MODEL_REF]: "Hy4 preview (TokenHub)",
+  [TENCENT_TOKENHUB_HY3_MODEL_REF]: "Hy3 (TokenHub)",
+  [TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF]: "Hy3 preview (TokenHub)",
+};
 
 type AgentDefaults = NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]>;
 type AgentDefaultModel = AgentDefaults["model"];
 type AgentModelEntry = NonNullable<AgentDefaults["models"]>[string];
 
 function isTokenHubModelMapConfigured(models: Record<string, AgentModelEntry>): boolean {
-  return (
-    Object.hasOwn(models, TENCENT_TOKENHUB_DEFAULT_MODEL_REF) ||
-    Object.hasOwn(models, TENCENT_TOKENHUB_PREVIEW_MODEL_REF)
-  );
+  return TENCENT_TOKENHUB_MANAGED_MODEL_REFS.some((ref) => Object.hasOwn(models, ref));
 }
 
 function withDefaultAlias(entry: AgentModelEntry | undefined, alias: string): AgentModelEntry {
@@ -29,13 +46,24 @@ function needsDefaultAlias(entry: AgentModelEntry | undefined): boolean {
   return entry?.alias === undefined;
 }
 
+function needsModelRepair(
+  models: Record<string, AgentModelEntry>,
+  ref: TencentTokenHubManagedModelRef,
+): boolean {
+  return !Object.hasOwn(models, ref) || needsDefaultAlias(models[ref]);
+}
+
+// Only the deprecated hy3-preview ref is migrated. hy3 is a GA model, and
+// hy4-preview is a preview that additionally requires the API key's
+// allowed-model scope to cover hy4, so silently moving a working hy3 primary
+// onto it would break live setups with err_code=401006.
 function migrateDefaultModel(model: AgentDefaultModel): {
   model: AgentDefaultModel;
   changed: boolean;
 } {
-  if (model === TENCENT_TOKENHUB_PREVIEW_MODEL_REF) {
+  if (model === TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF) {
     return {
-      model: { primary: TENCENT_TOKENHUB_DEFAULT_MODEL_REF },
+      model: { primary: TENCENT_TOKENHUB_MIGRATION_TARGET_MODEL_REF },
       changed: true,
     };
   }
@@ -43,12 +71,12 @@ function migrateDefaultModel(model: AgentDefaultModel): {
     model &&
     typeof model === "object" &&
     "primary" in model &&
-    model.primary === TENCENT_TOKENHUB_PREVIEW_MODEL_REF
+    model.primary === TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF
   ) {
     return {
       model: {
         ...model,
-        primary: TENCENT_TOKENHUB_DEFAULT_MODEL_REF,
+        primary: TENCENT_TOKENHUB_MIGRATION_TARGET_MODEL_REF,
       },
       changed: true,
     };
@@ -65,28 +93,18 @@ export function migrateTencentTokenHubModelDefaults(cfg: OpenClawConfig): {
     return { config: cfg, changes: [] };
   }
 
-  const needsDefaultRepair =
-    !Object.hasOwn(existingModels, TENCENT_TOKENHUB_DEFAULT_MODEL_REF) ||
-    needsDefaultAlias(existingModels[TENCENT_TOKENHUB_DEFAULT_MODEL_REF]);
-  const needsPreviewRepair =
-    !Object.hasOwn(existingModels, TENCENT_TOKENHUB_PREVIEW_MODEL_REF) ||
-    needsDefaultAlias(existingModels[TENCENT_TOKENHUB_PREVIEW_MODEL_REF]);
+  const needsModelMapRepair = TENCENT_TOKENHUB_MANAGED_MODEL_REFS.some((ref) =>
+    needsModelRepair(existingModels, ref),
+  );
   const migratedModel = migrateDefaultModel(cfg.agents?.defaults?.model);
-  if (!needsDefaultRepair && !needsPreviewRepair && !migratedModel.changed) {
+  if (!needsModelMapRepair && !migratedModel.changed) {
     return { config: cfg, changes: [] };
   }
 
-  const nextModels = {
-    ...existingModels,
-    [TENCENT_TOKENHUB_DEFAULT_MODEL_REF]: withDefaultAlias(
-      existingModels[TENCENT_TOKENHUB_DEFAULT_MODEL_REF],
-      TOKENHUB_DEFAULT_ALIAS,
-    ),
-    [TENCENT_TOKENHUB_PREVIEW_MODEL_REF]: withDefaultAlias(
-      existingModels[TENCENT_TOKENHUB_PREVIEW_MODEL_REF],
-      TOKENHUB_PREVIEW_ALIAS,
-    ),
-  };
+  const nextModels = { ...existingModels };
+  for (const ref of TENCENT_TOKENHUB_MANAGED_MODEL_REFS) {
+    nextModels[ref] = withDefaultAlias(existingModels[ref], TENCENT_TOKENHUB_MODEL_ALIASES[ref]);
+  }
 
   const nextConfig: OpenClawConfig = {
     ...cfg,
@@ -101,11 +119,11 @@ export function migrateTencentTokenHubModelDefaults(cfg: OpenClawConfig): {
   };
 
   const changes = [
-    `Updated Tencent TokenHub agent model defaults to include ${TENCENT_TOKENHUB_DEFAULT_MODEL_REF} and ${TENCENT_TOKENHUB_PREVIEW_MODEL_REF}.`,
+    `Updated Tencent TokenHub agent model defaults to include ${TENCENT_TOKENHUB_MANAGED_MODEL_REFS.join(", ")}.`,
   ];
   if (migratedModel.changed) {
     changes.push(
-      `Changed Tencent TokenHub primary default from ${TENCENT_TOKENHUB_PREVIEW_MODEL_REF} to ${TENCENT_TOKENHUB_DEFAULT_MODEL_REF}.`,
+      `Changed Tencent TokenHub primary default from ${TENCENT_TOKENHUB_HY3_PREVIEW_MODEL_REF} to ${TENCENT_TOKENHUB_MIGRATION_TARGET_MODEL_REF}.`,
     );
   }
 

--- a/extensions/tencent/index.test.ts
+++ b/extensions/tencent/index.test.ts
@@ -118,7 +118,7 @@ describe("tencent provider plugin", () => {
       label,
       hint: `Hy via ${label} Gateway`,
       kind: "api_key",
-      starterModel: `${providerId}/hy3`,
+      starterModel: `${providerId}/hy4-preview`,
       wizard: {
         choiceId,
         choiceLabel: label,
@@ -138,6 +138,7 @@ describe("tencent provider plugin", () => {
           flagValue: "tokenhub-test-key",
           envVar: "TOKENHUB_API_KEY",
           aliases: {
+            "tencent-tokenhub/hy4-preview": { alias: "Hy4 preview (TokenHub)" },
             "tencent-tokenhub/hy3": { alias: "Hy3 (TokenHub)" },
             "tencent-tokenhub/hy3-preview": { alias: "Hy3 preview (TokenHub)" },
           },
@@ -147,7 +148,10 @@ describe("tencent provider plugin", () => {
           choiceId: "tokenplan-api-key",
           flagValue: "tokenplan-test-key",
           envVar: "TOKENPLAN_API_KEY",
-          aliases: { "tencent-tokenplan/hy3": { alias: "Hy3 (TokenPlan)" } },
+          aliases: {
+            "tencent-tokenplan/hy4-preview": { alias: "Hy4 preview (TokenPlan)" },
+            "tencent-tokenplan/hy3": { alias: "Hy3 (TokenPlan)" },
+          },
         },
       ] as const
     ).flatMap((provider) =>
@@ -190,7 +194,7 @@ describe("tencent provider plugin", () => {
           ? manifest.modelCatalog.providers[providerId].models.map((model) => model.id)
           : [],
       );
-      expect(config?.agents?.defaults?.model).toEqual({ primary: `${providerId}/hy3` });
+      expect(config?.agents?.defaults?.model).toEqual({ primary: `${providerId}/hy4-preview` });
       expect(config?.agents?.defaults?.models).toEqual(aliases);
     },
   );
@@ -246,7 +250,7 @@ describe("tencent provider plugin", () => {
     expect(hy4Preview?.contextWindow).toBe(1_024_000);
     expect(hy4Preview?.maxTokens).toBe(64_000);
     expect(hy4Preview?.compat?.supportsReasoningEffort).toBe(true);
-    // hy4-preview shares hy3's two-rung ladder — it does NOT accept `low`.
+    // OpenClaw exposes none/high; raw low acceptance does not prove a distinct low mode.
     expect(hy4Preview?.compat?.supportedReasoningEfforts).toEqual(["none", "high"]);
 
     const hy3Preview = catalogProvider.models?.find((m) => m.id === "hy3-preview");
@@ -286,7 +290,7 @@ describe("tencent provider plugin", () => {
     expect(hy4Preview?.contextWindow).toBe(1_024_000);
     expect(hy4Preview?.maxTokens).toBe(64_000);
     expect(hy4Preview?.compat?.supportsReasoningEffort).toBe(true);
-    // hy4-preview shares hy3's two-rung ladder — it does NOT accept `low`.
+    // OpenClaw exposes none/high; raw low acceptance does not prove a distinct low mode.
     expect(hy4Preview?.compat?.supportedReasoningEfforts).toEqual(["none", "high"]);
   });
 
@@ -458,10 +462,9 @@ describe("tencent provider plugin", () => {
       baseUrl: "https://api.lkeap.cloud.tencent.com/plan/v3",
     });
 
-    // hy4-preview accepts `none` and `high` only, so every intermediate rung
-    // has to reach the gateway as `high` and every off-ish request as `none`.
-    // Leaving a rung unmapped lets the model default to thinking and answer
-    // with reasoning only, which surfaces as an incomplete turn.
+    // Preserve OpenClaw's none/high policy: intermediate efforts become high
+    // and off becomes none. Raw API acceptance of low alone does not establish
+    // a distinct low reasoning mode.
     const expected: Record<string, string> = {
       off: "none",
       none: "none",

--- a/extensions/tencent/index.test.ts
+++ b/extensions/tencent/index.test.ts
@@ -34,7 +34,7 @@ async function getTokenPlanProvider() {
 
 function hyReasoningModel(params: {
   provider: "tencent-tokenhub" | "tencent-tokenplan";
-  id: "hy3" | "hy3-preview";
+  id: "hy3" | "hy3-preview" | "hy4-preview";
   baseUrl: string;
   supportedReasoningEfforts?: string[];
 }): OpenAICompletionsModel {
@@ -232,12 +232,22 @@ describe("tencent provider plugin", () => {
     const modelIds = catalogProvider.models?.map((m) => m.id);
     expect(modelIds).toContain("hy3");
     expect(modelIds).toContain("hy3-preview");
+    expect(modelIds).toContain("hy4-preview");
 
     const hy3 = catalogProvider.models?.find((m) => m.id === "hy3");
     expect(hy3?.reasoning).toBe(true);
     expect(hy3?.maxTokens).toBe(128_000);
     expect(hy3?.compat?.supportsReasoningEffort).toBe(true);
-    expect(hy3?.compat?.supportedReasoningEfforts).toEqual(["none", "low", "high"]);
+    // hy3 (GA) exposes only the two-rung ladder — it does NOT accept `low`.
+    expect(hy3?.compat?.supportedReasoningEfforts).toEqual(["none", "high"]);
+
+    const hy4Preview = catalogProvider.models?.find((m) => m.id === "hy4-preview");
+    expect(hy4Preview?.reasoning).toBe(true);
+    expect(hy4Preview?.contextWindow).toBe(1_024_000);
+    expect(hy4Preview?.maxTokens).toBe(64_000);
+    expect(hy4Preview?.compat?.supportsReasoningEffort).toBe(true);
+    // hy4-preview shares hy3's two-rung ladder — it does NOT accept `low`.
+    expect(hy4Preview?.compat?.supportedReasoningEfforts).toEqual(["none", "high"]);
 
     const hy3Preview = catalogProvider.models?.find((m) => m.id === "hy3-preview");
     expect(hy3Preview?.reasoning).toBe(true);
@@ -250,7 +260,7 @@ describe("tencent provider plugin", () => {
     >;
     expect(manifestRows.find((model) => model.id === "hy3-preview")).toMatchObject({
       status: "deprecated",
-      replacedBy: "hy3",
+      replacedBy: "hy4-preview",
     });
   });
 
@@ -262,13 +272,22 @@ describe("tencent provider plugin", () => {
     expect(catalogProvider.baseUrl).toBe("https://api.lkeap.cloud.tencent.com/plan/v3");
 
     const modelIds = catalogProvider.models?.map((m) => m.id);
-    expect(modelIds).toEqual(["hy3"]);
+    expect(modelIds).toEqual(["hy3", "hy4-preview"]);
 
     const hy3 = catalogProvider.models?.find((m) => m.id === "hy3");
     expect(hy3?.reasoning).toBe(true);
     expect(hy3?.maxTokens).toBe(128_000);
     expect(hy3?.compat?.supportsReasoningEffort).toBe(true);
-    expect(hy3?.compat?.supportedReasoningEfforts).toEqual(["none", "low", "high"]);
+    // hy3 (GA) exposes only the two-rung ladder — it does NOT accept `low`.
+    expect(hy3?.compat?.supportedReasoningEfforts).toEqual(["none", "high"]);
+
+    const hy4Preview = catalogProvider.models?.find((m) => m.id === "hy4-preview");
+    expect(hy4Preview?.reasoning).toBe(true);
+    expect(hy4Preview?.contextWindow).toBe(1_024_000);
+    expect(hy4Preview?.maxTokens).toBe(64_000);
+    expect(hy4Preview?.compat?.supportsReasoningEffort).toBe(true);
+    // hy4-preview shares hy3's two-rung ladder — it does NOT accept `low`.
+    expect(hy4Preview?.compat?.supportedReasoningEfforts).toEqual(["none", "high"]);
   });
 
   it("injects reasoning_effort into TokenPlan hy3 chat-completions payload", async () => {
@@ -423,5 +442,60 @@ describe("tencent provider plugin", () => {
 
     expect(minimalPayload?.reasoning_effort).toBe("low");
     expect(mediumPayload?.reasoning_effort).toBe("low");
+  });
+
+  it("collapses hy4-preview onto its two-rung ladder on both endpoints", async () => {
+    const tokenHubProvider = await getTokenHubProvider();
+    const tokenPlanProvider = await getTokenPlanProvider();
+    const tokenHubModel = hyReasoningModel({
+      provider: "tencent-tokenhub",
+      id: "hy4-preview",
+      baseUrl: "https://tokenhub.tencentmaas.com/v1",
+    });
+    const tokenPlanModel = hyReasoningModel({
+      provider: "tencent-tokenplan",
+      id: "hy4-preview",
+      baseUrl: "https://api.lkeap.cloud.tencent.com/plan/v3",
+    });
+
+    // hy4-preview accepts `none` and `high` only, so every intermediate rung
+    // has to reach the gateway as `high` and every off-ish request as `none`.
+    // Leaving a rung unmapped lets the model default to thinking and answer
+    // with reasoning only, which surfaces as an incomplete turn.
+    const expected: Record<string, string> = {
+      off: "none",
+      none: "none",
+      minimal: "high",
+      low: "high",
+      medium: "high",
+      high: "high",
+      xhigh: "high",
+    };
+    for (const [provider, model] of [
+      [tokenHubProvider, tokenHubModel],
+      [tokenPlanProvider, tokenPlanModel],
+    ] as const) {
+      for (const [reasoning, rung] of Object.entries(expected)) {
+        expect(
+          captureTencentPayload({ provider, model, reasoning })?.reasoning_effort,
+          `${(model as { provider: string }).provider}/hy4-preview ${reasoning}`,
+        ).toBe(rung);
+      }
+    }
+
+    // hy3-preview keeps its three-rung ladder and stays on shared handling.
+    const hy3PreviewModel = hyReasoningModel({
+      provider: "tencent-tokenhub",
+      id: "hy3-preview",
+      baseUrl: "https://tokenhub.tencentmaas.com/v1",
+      supportedReasoningEfforts: ["none", "low", "high"],
+    });
+    expect(
+      captureTencentPayload({
+        provider: tokenHubProvider,
+        model: hy3PreviewModel,
+        reasoning: "low",
+      })?.reasoning_effort,
+    ).toBe("low");
   });
 });

--- a/extensions/tencent/onboard.test.ts
+++ b/extensions/tencent/onboard.test.ts
@@ -16,11 +16,14 @@ describe("Tencent onboarding", () => {
     expect(config.models?.providers?.["tencent-tokenhub"]?.models.map((model) => model.id)).toEqual(
       manifest.modelCatalog.providers["tencent-tokenhub"].models.map((model) => model.id),
     );
+    expect(TOKENHUB_DEFAULT_MODEL_REF).toBe("tencent-tokenhub/hy4-preview");
     expect(resolveAgentModelPrimaryValue(config.agents?.defaults?.model)).toBe(
       TOKENHUB_DEFAULT_MODEL_REF,
     );
+    // Each ref carries its own alias; none may piggyback on the default ref.
     expect(config.agents?.defaults?.models).toEqual({
-      [TOKENHUB_DEFAULT_MODEL_REF]: { alias: "Hy3 (TokenHub)" },
+      "tencent-tokenhub/hy4-preview": { alias: "Hy4 preview (TokenHub)" },
+      "tencent-tokenhub/hy3": { alias: "Hy3 (TokenHub)" },
       "tencent-tokenhub/hy3-preview": { alias: "Hy3 preview (TokenHub)" },
     });
   });
@@ -31,11 +34,13 @@ describe("Tencent onboarding", () => {
     expect(
       config.models?.providers?.["tencent-tokenplan"]?.models.map((model) => model.id),
     ).toEqual(manifest.modelCatalog.providers["tencent-tokenplan"].models.map((model) => model.id));
+    expect(TOKENPLAN_DEFAULT_MODEL_REF).toBe("tencent-tokenplan/hy4-preview");
     expect(resolveAgentModelPrimaryValue(config.agents?.defaults?.model)).toBe(
       TOKENPLAN_DEFAULT_MODEL_REF,
     );
     expect(config.agents?.defaults?.models).toEqual({
-      [TOKENPLAN_DEFAULT_MODEL_REF]: { alias: "Hy3 (TokenPlan)" },
+      "tencent-tokenplan/hy4-preview": { alias: "Hy4 preview (TokenPlan)" },
+      "tencent-tokenplan/hy3": { alias: "Hy3 (TokenPlan)" },
     });
   });
 

--- a/extensions/tencent/onboard.ts
+++ b/extensions/tencent/onboard.ts
@@ -10,7 +10,13 @@ import {
 } from "./models.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 
-const TOKENHUB_PREVIEW_MODEL_REF = `${TOKENHUB_PROVIDER_ID}/hy3-preview`;
+// Every model gets its own explicit ref constant. Do NOT reuse
+// TOKENHUB_DEFAULT_MODEL_REF as the carrier for a specific model's alias:
+// that ref tracks the manifest's `defaultModel`, so pinning an alias to it
+// silently mislabels whichever model becomes the default next.
+const TOKENHUB_HY3_MODEL_REF = `${TOKENHUB_PROVIDER_ID}/hy3`;
+const TOKENHUB_HY3_PREVIEW_MODEL_REF = `${TOKENHUB_PROVIDER_ID}/hy3-preview`;
+const TOKENHUB_HY4_PREVIEW_MODEL_REF = `${TOKENHUB_PROVIDER_ID}/hy4-preview`;
 export const TOKENHUB_DEFAULT_MODEL_REF = readManifestProviderDefaultModelRef(
   manifest,
   TOKENHUB_PROVIDER_ID,
@@ -24,12 +30,15 @@ export const { applyConfig: applyTokenHubConfig } = createModelCatalogPresetAppl
     baseUrl: TOKENHUB_BASE_URL,
     catalogModels: cfg.models?.mode === "replace" ? structuredClone(TOKENHUB_MODEL_CATALOG) : [],
     aliases: [
-      { modelRef: TOKENHUB_DEFAULT_MODEL_REF, alias: "Hy3 (TokenHub)" },
-      { modelRef: TOKENHUB_PREVIEW_MODEL_REF, alias: "Hy3 preview (TokenHub)" },
+      { modelRef: TOKENHUB_HY4_PREVIEW_MODEL_REF, alias: "Hy4 preview (TokenHub)" },
+      { modelRef: TOKENHUB_HY3_MODEL_REF, alias: "Hy3 (TokenHub)" },
+      { modelRef: TOKENHUB_HY3_PREVIEW_MODEL_REF, alias: "Hy3 preview (TokenHub)" },
     ],
   }),
 });
 
+const TOKENPLAN_HY3_MODEL_REF = `${TOKENPLAN_PROVIDER_ID}/hy3`;
+const TOKENPLAN_HY4_PREVIEW_MODEL_REF = `${TOKENPLAN_PROVIDER_ID}/hy4-preview`;
 export const TOKENPLAN_DEFAULT_MODEL_REF = readManifestProviderDefaultModelRef(
   manifest,
   TOKENPLAN_PROVIDER_ID,
@@ -42,6 +51,9 @@ export const { applyConfig: applyTokenPlanConfig } = createModelCatalogPresetApp
     api: "openai-completions",
     baseUrl: TOKENPLAN_BASE_URL,
     catalogModels: cfg.models?.mode === "replace" ? structuredClone(TOKENPLAN_MODEL_CATALOG) : [],
-    aliases: [{ modelRef: TOKENPLAN_DEFAULT_MODEL_REF, alias: "Hy3 (TokenPlan)" }],
+    aliases: [
+      { modelRef: TOKENPLAN_HY4_PREVIEW_MODEL_REF, alias: "Hy4 preview (TokenPlan)" },
+      { modelRef: TOKENPLAN_HY3_MODEL_REF, alias: "Hy3 (TokenPlan)" },
+    ],
   }),
 });

--- a/extensions/tencent/openclaw.plugin.json
+++ b/extensions/tencent/openclaw.plugin.json
@@ -15,13 +15,13 @@
       "tencent-tokenhub": {
         "baseUrl": "https://tokenhub.tencentmaas.com/v1",
         "api": "openai-completions",
-        "defaultModel": "hy3",
+        "defaultModel": "hy4-preview",
         "models": [
           {
             "id": "hy3-preview",
             "name": "Hy3 preview (TokenHub)",
             "status": "deprecated",
-            "replacedBy": "hy3",
+            "replacedBy": "hy4-preview",
             "reasoning": true,
             "input": ["text"],
             "contextWindow": 256000,
@@ -77,7 +77,20 @@
             "compat": {
               "supportsUsageInStreaming": true,
               "supportsReasoningEffort": true,
-              "supportedReasoningEfforts": ["none", "low", "high"]
+              "supportedReasoningEfforts": ["none", "high"]
+            }
+          },
+          {
+            "id": "hy4-preview",
+            "name": "Hy4 preview (TokenHub)",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 1024000,
+            "maxTokens": 64000,
+            "compat": {
+              "supportsUsageInStreaming": true,
+              "supportsReasoningEffort": true,
+              "supportedReasoningEfforts": ["none", "high"]
             }
           }
         ]
@@ -85,7 +98,7 @@
       "tencent-tokenplan": {
         "baseUrl": "https://api.lkeap.cloud.tencent.com/plan/v3",
         "api": "openai-completions",
-        "defaultModel": "hy3",
+        "defaultModel": "hy4-preview",
         "models": [
           {
             "id": "hy3",
@@ -97,7 +110,20 @@
             "compat": {
               "supportsUsageInStreaming": true,
               "supportsReasoningEffort": true,
-              "supportedReasoningEfforts": ["none", "low", "high"]
+              "supportedReasoningEfforts": ["none", "high"]
+            }
+          },
+          {
+            "id": "hy4-preview",
+            "name": "Hy4 preview (TokenPlan)",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 1024000,
+            "maxTokens": 64000,
+            "compat": {
+              "supportsUsageInStreaming": true,
+              "supportsReasoningEffort": true,
+              "supportedReasoningEfforts": ["none", "high"]
             }
           }
         ]
@@ -124,7 +150,8 @@
     "compatibilityMigrationPaths": [
       "models.providers.tencent-tokenhub",
       "agents.defaults.models.tencent-tokenhub/hy3",
-      "agents.defaults.models.tencent-tokenhub/hy3-preview"
+      "agents.defaults.models.tencent-tokenhub/hy3-preview",
+      "agents.defaults.models.tencent-tokenhub/hy4-preview"
     ]
   },
   "providerAuthChoices": [

--- a/extensions/tencent/openclaw.plugin.json
+++ b/extensions/tencent/openclaw.plugin.json
@@ -87,6 +87,12 @@
             "input": ["text"],
             "contextWindow": 1024000,
             "maxTokens": 64000,
+            "cost": {
+              "input": 0.834,
+              "output": 2.501,
+              "cacheRead": 0.042,
+              "cacheWrite": 0
+            },
             "compat": {
               "supportsUsageInStreaming": true,
               "supportsReasoningEffort": true,
@@ -120,6 +126,12 @@
             "input": ["text"],
             "contextWindow": 1024000,
             "maxTokens": 64000,
+            "cost": {
+              "input": 0.834,
+              "output": 2.501,
+              "cacheRead": 0.042,
+              "cacheWrite": 0
+            },
             "compat": {
               "supportsUsageInStreaming": true,
               "supportsReasoningEffort": true,

--- a/extensions/tencent/stream.ts
+++ b/extensions/tencent/stream.ts
@@ -14,7 +14,16 @@ const TENCENT_PROVIDER_IDS: ReadonlySet<string> = new Set([
 type StreamModel = Parameters<StreamFn>[0];
 type StreamOptions = Parameters<StreamFn>[2];
 
-const TENCENT_REASONING_EFFORT_MAP: Readonly<Record<string, string>> = Object.freeze({
+// hy3 (GA) is the only Tencent model with a verified two-rung effort ladder:
+// the gateway accepts `none` and `high` exclusively, so intermediate rungs must
+// collapse upward before dispatch.
+//
+// Scope this map to hy3 ONLY. Do not add new model ids here on the assumption
+// that they behave the same — an unverified collapse silently upgrades a `low`
+// request to `high` (extra thinking tokens and latency, no diagnostic). If a
+// future model turns out to need its own rewrite, give it its own map keyed on
+// that model id.
+const TENCENT_TWO_RUNG_EFFORT_MAP: Readonly<Record<string, string>> = Object.freeze({
   off: "none",
   none: "none",
   minimal: "high",
@@ -24,7 +33,9 @@ const TENCENT_REASONING_EFFORT_MAP: Readonly<Record<string, string>> = Object.fr
   xhigh: "high",
 });
 
-const TOKENHUB_HY3_PREVIEW_REASONING_EFFORTS = new Set(["none", "low", "high"]);
+// Keyed on the model id rather than the provider: hy3 behaves identically on
+// TokenHub and TokenPlan.
+const TENCENT_TWO_RUNG_MODEL_IDS: ReadonlySet<string> = new Set(["hy3"]);
 
 function resolveRequestedEffort(
   thinkingLevel: OpenAICompatibleThinkingLevel,
@@ -43,18 +54,15 @@ function mapEffortForTencent(model: StreamModel, effort: string | undefined): st
   if (!effort) {
     return undefined;
   }
-  if (
-    (model as { provider?: unknown }).provider === TOKENHUB_PROVIDER_ID &&
-    (model as { id?: unknown }).id === "hy3-preview"
-  ) {
-    if (effort === "off") {
-      return "none";
-    }
-    // Preview supports low directly. Leave unsupported requests to the shared
-    // model fallback that already normalized the underlying payload.
-    return TOKENHUB_HY3_PREVIEW_REASONING_EFFORTS.has(effort) ? effort : undefined;
+  const modelId = (model as { id?: unknown }).id;
+  if (typeof modelId === "string" && TENCENT_TWO_RUNG_MODEL_IDS.has(modelId)) {
+    return TENCENT_TWO_RUNG_EFFORT_MAP[effort];
   }
-  return TENCENT_REASONING_EFFORT_MAP[effort];
+  // Every other Tencent model (hy3-preview, hy4-preview, …) is left untouched:
+  // returning undefined makes the wrapper skip the payload patch entirely, so
+  // the shared OpenClaw effort handling — which already normalized the payload
+  // against the model's declared supportedReasoningEfforts — stays in control.
+  return undefined;
 }
 
 function isTencentCompletionsCall(model: StreamModel): boolean {

--- a/src/plugins/setup-registry.migrations.test.ts
+++ b/src/plugins/setup-registry.migrations.test.ts
@@ -71,15 +71,16 @@ describe("bundled setup config migrations", () => {
     });
 
     expect(result.changes).toEqual([
-      "Updated Tencent TokenHub agent model defaults to include tencent-tokenhub/hy3 and tencent-tokenhub/hy3-preview.",
-      "Changed Tencent TokenHub primary default from tencent-tokenhub/hy3-preview to tencent-tokenhub/hy3.",
+      "Updated Tencent TokenHub agent model defaults to include tencent-tokenhub/hy4-preview, tencent-tokenhub/hy3, tencent-tokenhub/hy3-preview.",
+      "Changed Tencent TokenHub primary default from tencent-tokenhub/hy3-preview to tencent-tokenhub/hy4-preview.",
     ]);
     expect(result.config.agents?.defaults?.model).toEqual({
-      primary: "tencent-tokenhub/hy3",
+      primary: "tencent-tokenhub/hy4-preview",
     });
     expect(Object.keys(result.config.agents?.defaults?.models ?? {}).toSorted()).toEqual([
       "tencent-tokenhub/hy3",
       "tencent-tokenhub/hy3-preview",
+      "tencent-tokenhub/hy4-preview",
     ]);
   });
 

--- a/src/plugins/setup-registry.migrations.test.ts
+++ b/src/plugins/setup-registry.migrations.test.ts
@@ -72,10 +72,10 @@ describe("bundled setup config migrations", () => {
 
     expect(result.changes).toEqual([
       "Updated Tencent TokenHub agent model defaults to include tencent-tokenhub/hy4-preview, tencent-tokenhub/hy3, tencent-tokenhub/hy3-preview.",
-      "Changed Tencent TokenHub primary default from tencent-tokenhub/hy3-preview to tencent-tokenhub/hy4-preview.",
+      "Changed Tencent TokenHub primary default from tencent-tokenhub/hy3-preview to tencent-tokenhub/hy3.",
     ]);
     expect(result.config.agents?.defaults?.model).toEqual({
-      primary: "tencent-tokenhub/hy4-preview",
+      primary: "tencent-tokenhub/hy3",
     });
     expect(Object.keys(result.config.agents?.defaults?.models ?? {}).toSorted()).toEqual([
       "tencent-tokenhub/hy3",


### PR DESCRIPTION
## What Problem This Solves

The bundled Tencent plugin only shipped `hy3` and the `hy3-preview`.

## Why This Change Was Made

`hy4-preview` is available on both Tencent endpoints (TokenHub and TokenPlan).

## User Impact

New catalog rows on both endpoints:

| Model ref | Context | Max output | Catalog reasoning efforts |
| --- | --- | --- | --- |
| `tencent-tokenhub/hy4-preview` | 1,024,000 | 64,000 | `none`, `high` |
| `tencent-tokenplan/hy4-preview` | 1,024,000 | 64,000 | `none`, `high` |

The provider default moves from `hy3` to `hy4-preview` on both endpoints, and `hy3-preview`'s `replacedBy` now points at `hy4-preview`. `hy3` stays in the catalog and keeps working; existing configs that pin it are untouched. Configs still on the deprecated TokenHub `hy3-preview` primary are migrated to **`hy3`** (not Hy4) by `openclaw doctor --fix`, because pricing differs.

If an API key uses a limited access scope, `hy4-preview` must be added to the allowed models — the docs quick start now says so.

## Evidence

### Landed — September 8, 2026

**MERGED September 8, 2026 at 08:40:13 UTC** via the native guarded prepare/merge workflow. Landed commit: [3574bb1336452adc1358d7428f2a0209140848e1](https://github.com/openclaw/openclaw/commit/3574bb1336452adc1358d7428f2a0209140848e1). Exact source head `949ef636c1ceac5204947bda5f2860fb56d06db5`; required `openclaw/ci-gate` and CI run 34204101175 succeeded. Final main ancestry, original author and hxy91819 credit were verified.

Post-merge housekeeping: contributor fork branch deletion was denied by GitHub; left intact. Public model catalog still has the older Hy3 defaults; manual catalog-only refresh was attempted but GitHub returned HTTP 403 (repository admin rights required). The existing catalog schedule remains unchanged. These are explicitly pending propagation/cleanup items, not an unmerged PR.

Current head: `949ef636c1ceac5204947bda5f2860fb56d06db5`, rebased onto `8ac88a1a335aa5f6ec467e539f6bbce3df478d84` to resolve the real main conflict. Retains main's discovery-first ordinary/merge setup and full replace-mode catalogs on both Tencent endpoints. Registered-auth expectations now match the accepted Hy4 fresh default; legacy preview still migrates to Hy3.

New candidate proof (committed tree `c81195c94c00dd6c8f78d6707e303d9e5892b2bb` matches the checked candidate):

- `CI=1 OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test extensions/tencent src/plugins/setup-registry.migrations.test.ts` — **33 Tencent + 3 registry tests PASS**; ordinary/replace onboarding and registered auth covered on both providers. Tests preceded formatter-only reflow.
- `pnpm build` — **PASS**.
- Full classified changed-check plan — **PASS, exit 0**, including final formatted candidate.
- Built CLI isolated catalogs expose Hy4 on both providers; disposable state removed.
- Fresh isolated autoreview of base-to-index/working-tree candidate — **exit 0, no accepted/actionable P0 findings** at the configured scope. Not a substitute for runtime tests.
- Git diff checks, published-tree equality and required human attribution verified.

Authenticated Tencent calls below were run by the owner on `9767d5c`, **not newly run on this rebased SHA**. Migration, stream wrapper, model builder and provider catalog builder are byte-identical; new discovery/auth integration is covered by the tests above. Shared-main changes are not claimed byte-identical. Raw native `low` acceptance still does not establish a distinct low mode. Exact-head CI/native merge gates subsequently passed, and the PR was merged as recorded above.

### Owner authenticated evidence — `9767d5c`

Head `9767d5c59d801a4fce8ee6c4074e7a6e4385a344`. Isolated worktree + isolated state. Node 24.15.0. Focused tests: `pnpm test extensions/tencent src/plugins/setup-registry.migrations.test.ts` — 25 + 2 passed. `pnpm build` passed. Secrets redacted.

### Live TUI (`openclaw configure --section model`)

TokenHub — real wizard, then default `tencent-tokenhub/hy4-preview`, `baseUrl` `https://tokenhub.tencentmaas.com/v1`:

```
◆  Tencent Cloud auth method
│  ● Tencent TokenHub
│  ○ Tencent TokenPlan
◇  Tencent Cloud auth method
│  Tencent TokenHub
◆  Enter Tencent TokenHub API key
◆  Models in /model picker (multi-select)
│  ◼ tencent-tokenhub/hy3-preview (Hy3 preview (TokenHub) · ctx 256k · reasoning · alias: Hy3 preview (TokenHub))
│  ◼ tencent-tokenhub/hy3
│  ◼ tencent-tokenhub/hy4-preview
│  3 items selected
└  Configuration updated.
```

TokenPlan — same flow, default `tencent-tokenplan/hy4-preview`, `baseUrl` `https://api.lkeap.cloud.tencent.com/plan/v3`:

```
◆  Tencent Cloud auth method
│  ○ Tencent TokenHub
│  ● Tencent TokenPlan
◇  Tencent Cloud auth method
│  Tencent TokenPlan
◆  Enter Tencent TokenPlan API key
◆  Models in /model picker (multi-select)
│  ◼ tencent-tokenplan/hy3 (Hy3 (TokenPlan) · ctx 256k · reasoning · alias: Hy3 (TokenPlan))
│  ◼ tencent-tokenplan/hy4-preview
│  2 items selected
└  Configuration updated.
```

`openclaw models list` after TUI (hy4 tagged `default`):

```
tencent-tokenhub/hy4-preview     text  1024k  default,configured,alias:Hy4 preview (TokenHub)
tencent-tokenplan/hy4-preview    text  1024k  default,configured,alias:Hy4 preview (TokenPlan)
```

### Live `hy4-preview` chat/completions

All eight POSTs HTTP 200, content `OK`. Catalog still declares only `none`/`high`; the vendor also accepted native `low`.

| endpoint | omitted | none | low | high |
| --- | ---: | ---: | ---: | ---: |
| TokenHub | 63 rtok / 2381ms | 0 / 1028ms | 88 / 2756ms | 36 / 3667ms |
| TokenPlan | 99 / 5035ms | 0 / 729ms | 47 / 1490ms | 88 / 4585ms |

`openclaw agent --local --json --thinking off|low|high` on both providers: HTTP 200, visible text `OK`.

New-process reload (TUI-written state, second process, `--thinking high`):

| endpoint | command | provider/model | http | text | usage |
| --- | --- | --- | --- | --- | --- |
| TokenHub | `openclaw agent --local --json --model tencent-tokenhub/hy4-preview --thinking high` | `tencent-tokenhub/hy4-preview` | 200 / 2179ms | `OK` | in 147 / out 346 / cacheRead 32832 / rtok 343 / total 33325 |
| TokenPlan | `openclaw agent --local --json --model tencent-tokenplan/hy4-preview --thinking high` | `tencent-tokenplan/hy4-preview` | 200 / 1714ms | `OK` | in 258 / out 3 / cacheRead 32768 / rtok 0 / total 33029 |

Intercepted outgoing Chat Completions JSON (undici `fetch` spy, no secrets). Hy4 catalog is `none`/`high`; OpenClaw `--thinking low` is sent as `high` on both endpoints:

| OpenClaw `--thinking` | outgoing `reasoning_effort` | TokenHub | TokenPlan |
| --- | --- | --- | --- |
| off | `none` | 200 / OK | 200 / OK |
| low | `high` | 200 / OK | 200 / OK |
| high | `high` | 200 / OK | 200 / OK |

Raw vendor POSTs still accept native `low` (see table above). OpenClaw does not send `low` for hy4.

### Doctor (existing users — migration persistence only)

Isolated `openclaw doctor --fix --non-interactive --yes`, then a second process (idempotent). **This is migration persistence, not a full Doctor health-check pass.** Those seeds had no gateway auth, so Doctor also printed `GatewayCredentialsRequiredError`; that does not undo the persisted JSON below.

| Seed | Persisted primary |
| --- | --- |
| string `hy3-preview` + custom alias/params + unrelated `openai/gpt-5.5` / port / maxConcurrent | **`hy3`** (extras kept; allowlist gained hy3+hy4) |
| object `hy3-preview` + fallbacks | **`hy3`** (fallbacks kept) |
| explicit `hy3` alias `Custom Hy3` | unchanged `hy3` |
| explicit `hy4-preview` alias `My Hy4` | unchanged `hy4-preview` |

The historical conflict was resolved by the landing candidate above; its hosted CI and native landing gates are tracked separately from this owner-run evidence.


## Worked on by

- @hxy91819

---
[View the OpenClaw team session](https://team.openclaw.ai/chat/roboclaw/dashboard/94e646a1-9e42-4829-a0a2-830f155cd2bc)
