### PR TITLE
fix(ui): keep Workshop suggestions consistent after actions

### DIFF
--- a/ui/src/e2e/skill-workshop-collection.e2e.test.ts
+++ b/ui/src/e2e/skill-workshop-collection.e2e.test.ts
@@ -219,7 +219,13 @@ describe("Workshop current collection", () => {
           "skills.proposals.inspect",
           fixture.responses["skills.proposals.inspect"],
         );
-        await gateway.resolveDeferred(method, {});
+        const record = inspect.response.record;
+        await gateway.resolveDeferred(
+          method,
+          action === "Apply"
+            ? { record, targetSkillFile: `skills/${record.target.skillKey}/SKILL.md` }
+            : record,
+        );
         await expect.poll(() => page.locator(".sw-row").count()).toBe(remaining);
         const notice = page.locator(".sw-action-toast");
         await expect

--- a/ui/src/e2e/skill-workshop-revision-integrity.e2e.test.ts
+++ b/ui/src/e2e/skill-workshop-revision-integrity.e2e.test.ts
@@ -249,7 +249,16 @@ suite.define(() => {
         });
 
         await setProposalRevision(gateway, H2, status);
-        await gateway.resolveDeferred(method, {});
+        // The action RPC returns the committed terminal record (apply wraps it
+        // in { record, targetSkillFile }, reject returns the record itself), so
+        // the UI's completion authority confirms the action and refreshes.
+        const actionRecord = proposalInspect(H2, status).record;
+        await gateway.resolveDeferred(
+          method,
+          method === "skills.proposals.apply"
+            ? { record: actionRecord, targetSkillFile: `skills/${SKILL_KEY}/SKILL.md` }
+            : actionRecord,
+        );
         await gateway.waitForRequest("skills.proposals.list", { after: secondListCount });
         await gateway.waitForRequest("skills.proposals.inspect", { after: secondInspectCount });
         await page

--- a/ui/src/e2e/skill-workshop-revision-integrity.e2e.test.ts
+++ b/ui/src/e2e/skill-workshop-revision-integrity.e2e.test.ts
@@ -181,22 +181,30 @@ suite.define(() => {
       action: "Apply",
       method: "skills.proposals.apply",
       status: "applied",
+      width: 1280,
     },
     {
       action: "Reject",
       method: "skills.proposals.reject",
       status: "rejected",
+      width: 1280,
+    },
+    {
+      action: "Reject",
+      method: "skills.proposals.reject",
+      status: "rejected",
+      width: 390,
     },
   ] as const)(
-    "refreshes H2 and requires a second explicit $action after stale H1",
-    async ({ action, method, status }) => {
+    "refreshes H2 and requires a second explicit $action after stale H1 at $width px",
+    async ({ action, method, status, width }) => {
       const label = action.toLowerCase();
       const caseDir = path.join(artifactDir, label);
       await mkdir(caseDir, { recursive: true });
       const context = await suite.newBrowserContext({
         locale: "en-US",
         serviceWorkers: "block",
-        viewport,
+        viewport: { ...viewport, width },
       });
       const page = await context.newPage();
       try {
@@ -230,6 +238,29 @@ suite.define(() => {
           fullPage: true,
           path: path.join(caseDir, "02-stale-h2-review-required.png"),
         });
+
+        if (width === 390) {
+          const noticeSize = await page.locator(".sw-action-toast").evaluate((element) => ({
+            clientWidth: element.clientWidth,
+            scrollWidth: element.scrollWidth,
+          }));
+          expect(noticeSize.scrollWidth).toBeLessThanOrEqual(noticeSize.clientWidth);
+          const messageBounds = await page.getByText(staleMessage).evaluate((element) => {
+            const range = document.createRange();
+            range.selectNodeContents(element);
+            const bounds = range.getBoundingClientRect();
+            return {
+              left: bounds.left,
+              right: bounds.right,
+              top: bounds.top,
+              bottom: bounds.bottom,
+            };
+          });
+          expect(messageBounds.left).toBeGreaterThanOrEqual(0);
+          expect(messageBounds.right).toBeLessThanOrEqual(width);
+          expect(messageBounds.top).toBeGreaterThanOrEqual(0);
+          expect(messageBounds.bottom).toBeLessThanOrEqual(viewport.height);
+        }
 
         await proveNoReplayAcrossReconnect(page, gateway, method, actionCount + 1);
 

--- a/ui/src/e2e/skill-workshop-revision-integrity.e2e.test.ts
+++ b/ui/src/e2e/skill-workshop-revision-integrity.e2e.test.ts
@@ -246,7 +246,16 @@ suite.define(() => {
         });
 
         await setProposalRevision(gateway, H2, status);
-        await gateway.resolveDeferred(method, {});
+        // The action RPC returns the committed terminal record (apply wraps it
+        // in { record, targetSkillFile }, reject returns the record itself), so
+        // the UI's completion authority confirms the action and refreshes.
+        const actionRecord = proposalInspect(H2, status).record;
+        await gateway.resolveDeferred(
+          method,
+          method === "skills.proposals.apply"
+            ? { record: actionRecord, targetSkillFile: `skills/${SKILL_KEY}/SKILL.md` }
+            : actionRecord,
+        );
         await gateway.waitForRequest("skills.proposals.list", { after: secondListCount });
         await expect.poll(() => page.locator(".sw-row").count()).toBe(0);
         await expect
@@ -332,11 +341,20 @@ suite.define(() => {
         proposalId: missing.id,
         expectedRevisionHash: H2_HASH,
       });
+      const rejectedRecord = {
+        ...proposalInspect(H2, "rejected").record,
+        id: missing.id,
+        kind: missing.kind,
+        title: missing.title,
+      };
       await gateway.setMethodResponse("skills.proposals.list", {
         ...validManifest,
-        proposals: [...validManifest.proposals, { ...missing, status: "rejected" }],
+        proposals: [
+          ...validManifest.proposals,
+          { ...missing, status: "rejected", updatedAt: rejectedRecord.updatedAt },
+        ],
       });
-      await gateway.resolveDeferred("skills.proposals.reject", {});
+      await gateway.resolveDeferred("skills.proposals.reject", rejectedRecord);
       await page.getByText(H1.body, { exact: true }).waitFor();
       await expect.poll(() => page.locator(".sw-action-toast").textContent()).toContain("Rejected");
       expect(await page.locator(".sw-error").count()).toBe(0);

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3853,6 +3853,8 @@ export const en: TranslationMap = {
     },
     notices: {
       applied: "Applied",
+      confirmUnconfirmed:
+        "The proposal status did not confirm as expected after the action. Refresh the workshop and check before retrying.",
       proposalChanged: "Proposal changed. Review the updated draft before choosing another action.",
       rejected: "Rejected",
       revisionRequested: "Revision requested",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3735,6 +3735,8 @@ export const en: TranslationMap & {
     },
     notices: {
       applied: "Applied",
+      confirmUnconfirmed:
+        "The proposal status did not confirm as expected after the action. Refresh the workshop and check before retrying.",
       proposalChanged:
         "Suggestion changed. Review the updated draft before choosing another action.",
       rejected: "Rejected",

--- a/ui/src/pages/skill-workshop/page-types.ts
+++ b/ui/src/pages/skill-workshop/page-types.ts
@@ -1,4 +1,5 @@
 import type { SkillWorkshopRevisionAdmissionOutcome } from "../../app/skill-workshop-revision-admissions.ts";
+import type { SkillWorkshopProposalDecision } from "../../lib/skill-workshop/index.ts";
 import type { SkillWorkshopState } from "./proposals.ts";
 import type { SkillWorkshopSelfLearning } from "./self-learning.ts";
 import type { SkillWorkshopPageContext } from "./source-scope.ts";
@@ -16,6 +17,7 @@ export type SkillWorkshopRenderContext = {
   context: SkillWorkshopPageContext;
   revisionRecoveryActive: boolean;
   workshopAgentName: string;
+  onLifecycleAction: (action: "apply" | "reject", decision: SkillWorkshopProposalDecision) => void;
   onEvaluate: (proposalId: string) => void;
   onRevisionSubmit: (proposalId: string) => void;
   selfLearning: SkillWorkshopSelfLearning | null;

--- a/ui/src/pages/skill-workshop/page-view.ts
+++ b/ui/src/pages/skill-workshop/page-view.ts
@@ -14,7 +14,6 @@ import { canCallWorkshopAdminMethod, resolveWorkshopAccess } from "./access.ts";
 import { renderSkillWorkshopHeaderControls, setSkillWorkshopMode } from "./header-controls.ts";
 import type { SkillWorkshopRenderContext } from "./page-types.ts";
 import {
-  runSkillWorkshopLifecycleAction,
   selectSkillWorkshopInstalledSkill,
   selectSkillWorkshopProposal,
   type SkillWorkshopState,
@@ -30,6 +29,7 @@ export function renderSkillWorkshopPage(
     context,
     revisionRecoveryActive,
     workshopAgentName,
+    onLifecycleAction,
     onEvaluate,
     onRevisionSubmit,
     selfLearning,
@@ -206,9 +206,7 @@ export function renderSkillWorkshopPage(
                 ) {
                   return;
                 }
-                void runSkillWorkshopLifecycleAction(state, context, "apply", decision).finally(
-                  requestUpdate,
-                );
+                onLifecycleAction("apply", decision);
                 requestUpdate();
               },
               onEvaluate: (key) => {
@@ -239,9 +237,7 @@ export function renderSkillWorkshopPage(
                 ) {
                   return;
                 }
-                void runSkillWorkshopLifecycleAction(state, context, "reject", decision).finally(
-                  requestUpdate,
-                );
+                onLifecycleAction("reject", decision);
                 requestUpdate();
               },
               onRevisionDraftChange: (draft) => {

--- a/ui/src/pages/skill-workshop/proposal-actions.test.ts
+++ b/ui/src/pages/skill-workshop/proposal-actions.test.ts
@@ -4,11 +4,6 @@ import { createDeferred } from "../../../../test/helpers/promise.js";
 import { GatewayRequestError } from "../../api/gateway.ts";
 import type { SkillWorkshopProposal } from "../../lib/skill-workshop/index.ts";
 import {
-  requestSkillWorkshopRevision,
-  runSkillWorkshopEvaluation,
-  runSkillWorkshopLifecycleAction,
-} from "./proposal-actions.ts";
-import {
   clearNoticeTimer,
   createFixture,
   inspectResult,
@@ -19,7 +14,12 @@ import {
   recordFrom,
   REVISION_HASH,
   UPDATED_REVISION_HASH,
-} from "./proposals.test-support.ts";
+} from "../../test-helpers/skill-workshop-proposal-fixture.ts";
+import {
+  requestSkillWorkshopRevision,
+  runSkillWorkshopEvaluation,
+  runSkillWorkshopLifecycleAction,
+} from "./proposal-actions.ts";
 import {
   loadSkillWorkshopProposals,
   selectSkillWorkshopProposal,

--- a/ui/src/pages/skill-workshop/proposal-actions.test.ts
+++ b/ui/src/pages/skill-workshop/proposal-actions.test.ts
@@ -1,0 +1,942 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import { GatewayRequestError } from "../../api/gateway.ts";
+import type { SkillWorkshopProposal } from "../../lib/skill-workshop/index.ts";
+import {
+  requestSkillWorkshopRevision,
+  runSkillWorkshopEvaluation,
+  runSkillWorkshopLifecycleAction,
+} from "./proposal-actions.ts";
+import {
+  clearNoticeTimer,
+  createFixture,
+  inspectResult,
+  ISO_NOW,
+  manifest,
+  proposal,
+  proposalDecision,
+  recordFrom,
+  REVISION_HASH,
+  UPDATED_REVISION_HASH,
+} from "./proposals.test-support.ts";
+import {
+  loadSkillWorkshopProposals,
+  selectSkillWorkshopProposal,
+  type SkillWorkshopState,
+} from "./proposals.ts";
+
+function mutationResponse(
+  action: "apply" | "reject",
+  status: SkillWorkshopProposal["status"],
+): unknown {
+  const record = recordFrom(status);
+  return action === "apply" ? { record, targetSkillFile: "skills/inbox-cleaner/SKILL.md" } : record;
+}
+
+function terminalStatusFor(action: "apply" | "reject"): SkillWorkshopProposal["status"] {
+  return action === "apply" ? "applied" : "rejected";
+}
+
+// Asserts the leak-free invariant shared by every in-flight agent-scope switch
+// case: neither the notice nor the originating terminal row nor the
+// unconfirmed-status error may surface in the new agent's workspace.
+function expectNoLeak(state: SkillWorkshopState, action: "apply" | "reject"): void {
+  const terminalStatus = terminalStatusFor(action);
+  expect(state.skillWorkshopActionNotice).toBeNull();
+  expect(
+    state.skillWorkshopProposals.some(
+      (item) => item.key === "proposal-1" && item.status === terminalStatus,
+    ),
+  ).toBe(false);
+  expect(state.skillWorkshopError ?? "").not.toContain("did not confirm as expected");
+}
+
+describe("Skill Workshop proposal lifecycle actions", () => {
+  it.each([
+    ["apply", "skills.proposals.apply", "applied"],
+    ["reject", "skills.proposals.reject", "rejected"],
+  ] as const)(
+    "%s sends the selected agent id and refreshes that agent scope",
+    async (action, method, status) => {
+      const { state, context, request } = createFixture(
+        {
+          skillWorkshopProposals: [proposal()],
+          skillWorkshopSelectedKey: "proposal-1",
+        },
+        { assistantAgentId: "reviewer" },
+        [method, "skills.proposals.list", "skills.proposals.inspect"],
+      );
+      request.mockImplementation(async (calledMethod: string) => {
+        if (calledMethod === method) {
+          return mutationResponse(action, status);
+        }
+        if (calledMethod === "skills.proposals.list") {
+          return manifest(status);
+        }
+        if (calledMethod === "skills.proposals.inspect") {
+          return inspectResult(status);
+        }
+        return {};
+      });
+
+      try {
+        await runSkillWorkshopLifecycleAction(state, context, action, proposalDecision());
+      } finally {
+        clearNoticeTimer(state);
+      }
+
+      expect(request).toHaveBeenNthCalledWith(1, method, {
+        agentId: "reviewer",
+        expectedRevisionHash: REVISION_HASH,
+        proposalId: "proposal-1",
+      });
+      expect(request).toHaveBeenNthCalledWith(2, "skills.proposals.list", {
+        agentId: "reviewer",
+      });
+      expect(request.mock.calls.map(([calledMethod]) => calledMethod)).toEqual([
+        method,
+        "skills.proposals.list",
+      ]);
+    },
+  );
+
+  it.each(
+    (
+      [
+        ["shows the terminal notice from the authoritative mutation record", "success", "ok"],
+        [
+          "withholds the success notice when the mutation record is not terminal",
+          "unconfirmed",
+          "ok",
+        ],
+        ["keeps the authoritative success notice when the refresh fails", "success", "fails"],
+        ["withholds success for an absent action record", "absent", "ok"],
+        ["withholds success for another proposal's action record", "wrong-id", "ok"],
+      ] as const
+    ).flatMap(([name, outcome, refresh]) =>
+      (["apply", "reject"] as const).map((action) => ({ name, action, outcome, refresh })),
+    ),
+  )("$name ($action)", async ({ action, outcome, refresh }) => {
+    const method = `skills.proposals.${action}`;
+    const terminal = terminalStatusFor(action);
+    const mutationStatus: SkillWorkshopProposal["status"] =
+      outcome === "unconfirmed" ? "pending" : terminal;
+    const { state, context, request } = createFixture(
+      { skillWorkshopProposals: [proposal()], skillWorkshopSelectedKey: "proposal-1" },
+      {},
+      [method, "skills.proposals.list", "skills.proposals.inspect"],
+    );
+    request.mockImplementation(async (calledMethod: string) => {
+      if (calledMethod === method) {
+        if (outcome === "absent") {
+          return action === "apply" ? { targetSkillFile: "skills/inbox-cleaner/SKILL.md" } : null;
+        }
+        if (outcome === "wrong-id") {
+          const record = { ...recordFrom(terminal), id: "another-proposal" };
+          return action === "apply" ? { record, targetSkillFile: "skills/other/SKILL.md" } : record;
+        }
+        return mutationResponse(action, mutationStatus);
+      }
+      if (calledMethod === "skills.proposals.list") {
+        if (refresh === "fails") {
+          throw new Error("refresh failed");
+        }
+        return manifest(mutationStatus);
+      }
+      if (calledMethod === "skills.proposals.inspect") {
+        if (refresh === "fails") {
+          throw new Error("refresh inspect failed");
+        }
+        return inspectResult(mutationStatus);
+      }
+      return {};
+    });
+
+    try {
+      await runSkillWorkshopLifecycleAction(state, context, action, proposalDecision());
+    } finally {
+      clearNoticeTimer(state);
+    }
+
+    if (outcome !== "success") {
+      expect(state.skillWorkshopActionNotice?.label).not.toBe(
+        action === "apply" ? "Applied" : "Rejected",
+      );
+      expect(state.skillWorkshopError).toContain("did not confirm as expected");
+      expect(state.skillWorkshopProposals[0]?.status).toBe("pending");
+      expect(state.skillWorkshopProposals).toHaveLength(1);
+      return;
+    }
+    expect(state.skillWorkshopActionNotice?.label).toBe(
+      action === "apply" ? "Applied" : "Rejected",
+    );
+    expect(state.skillWorkshopProposals[0]?.status).toBe(terminal);
+    if (refresh === "ok") {
+      expect(state.skillWorkshopError).toBeNull();
+    } else {
+      expect(state.skillWorkshopError ?? "").not.toContain("did not confirm as expected");
+    }
+  });
+
+  it.each(
+    (["apply", "reject"] as const).flatMap((action) =>
+      (["success", "failure"] as const).map((refresh) => ({ action, refresh })),
+    ),
+  )(
+    "$action publishes its complete receipt before a held $refresh refresh",
+    async ({ action, refresh }) => {
+      const updatedAt = "2026-06-16T12:05:00.000Z";
+      const terminal = terminalStatusFor(action);
+      const evaluation: NonNullable<SkillWorkshopProposal["evaluation"]> = {
+        id: "evaluation-reviewed",
+        proposedVersion: "v7",
+        revisionHash: REVISION_HASH,
+        trigger: "manual",
+        startedAt: ISO_NOW,
+        completedAt: ISO_NOW,
+        outcomes: [],
+      };
+      const reviewed = proposal({
+        body: "Review every unread thread. Confirm recipients before archiving.",
+        version: 7,
+        evaluation,
+        supportFiles: [
+          { path: "references/review.md", size: "15 B", contents: "Check recipients" },
+          { path: "scripts/review.sh", size: "18 B", contents: "review --dry-run" },
+        ],
+      });
+      const { state, context, request } = createFixture(
+        {
+          skillWorkshopAgentId: "research",
+          skillWorkshopProposals: [reviewed],
+          skillWorkshopSelectedKey: reviewed.key,
+        },
+        {},
+        [`skills.proposals.${action}`, "skills.proposals.list", "skills.proposals.inspect"],
+      );
+      const list = createDeferred<ReturnType<typeof manifest>>();
+      const record = {
+        ...recordFrom(terminal),
+        proposedVersion: "v7",
+        updatedAt,
+        evaluation: { ...evaluation, id: "evaluation-confirmed" },
+      };
+      request.mockImplementation(async (method) => {
+        if (method === `skills.proposals.${action}`) {
+          return action === "apply"
+            ? { record, targetSkillFile: "skills/inbox-cleaner/SKILL.md" }
+            : record;
+        }
+        if (method === "skills.proposals.list") {
+          return list.promise;
+        }
+        throw new Error("inspection unavailable after confirmation");
+      });
+      const onProgress = vi.fn();
+      const actionPromise = runSkillWorkshopLifecycleAction(
+        state,
+        context,
+        action,
+        proposalDecision(),
+        { onProgress },
+      );
+      try {
+        await vi.waitFor(() =>
+          expect(request).toHaveBeenCalledWith("skills.proposals.list", { agentId: "research" }),
+        );
+        expect(state.skillWorkshopProposals[0]).toMatchObject({
+          status: terminal,
+          body: reviewed.body,
+          bodyLoaded: true,
+          supportFiles: reviewed.supportFiles,
+          version: 7,
+          revisionHash: REVISION_HASH,
+          updatedAt: Date.parse(updatedAt),
+          evaluation: { id: "evaluation-confirmed", revisionHash: REVISION_HASH },
+        });
+        expect(state.skillWorkshopActionNotice?.label).toBe(
+          action === "apply" ? "Applied" : "Rejected",
+        );
+        expect(onProgress).toHaveBeenCalled();
+        if (refresh === "failure") {
+          list.reject(new Error("receipt refresh unavailable"));
+        } else {
+          const current = manifest(terminal);
+          current.proposals[0]!.updatedAt = updatedAt;
+          list.resolve(current);
+        }
+        await actionPromise;
+        expect(state.skillWorkshopProposals[0]).toMatchObject({
+          status: terminal,
+          body: reviewed.body,
+          bodyLoaded: true,
+          supportFiles: reviewed.supportFiles,
+          version: 7,
+          revisionHash: REVISION_HASH,
+          evaluation: { id: "evaluation-confirmed" },
+        });
+        expect(state.skillWorkshopActionNotice?.label).toBe(
+          action === "apply" ? "Applied" : "Rejected",
+        );
+        if (refresh === "failure") {
+          expect(state.skillWorkshopError).toContain("receipt refresh unavailable");
+        }
+      } finally {
+        list.resolve(manifest(terminal));
+        await actionPromise;
+        clearNoticeTimer(state);
+      }
+    },
+  );
+
+  it.each(["pending", "error"] as const)(
+    "ignores an earlier list's %s result while the action refresh owns loading and selection",
+    async (outcome) => {
+      const oldList = createDeferred<ReturnType<typeof manifest>>();
+      const newList = createDeferred<ReturnType<typeof manifest>>();
+      const second = proposal({ key: "proposal-2", name: "Second suggestion" });
+      const { state, context, request } = createFixture(
+        {
+          skillWorkshopAgentId: "research",
+          skillWorkshopProposals: [proposal(), second],
+          skillWorkshopSelectedKey: "proposal-1",
+        },
+        {},
+        ["skills.proposals.apply", "skills.proposals.list", "skills.proposals.inspect"],
+      );
+      let listCount = 0;
+      request.mockImplementation(async (method) => {
+        if (method === "skills.proposals.apply") {
+          return mutationResponse("apply", "applied");
+        }
+        if (method === "skills.proposals.list") {
+          listCount += 1;
+          return listCount === 1 ? oldList.promise : newList.promise;
+        }
+        throw new Error("unexpected inspection");
+      });
+      const oldLoad = loadSkillWorkshopProposals(state, context, { force: true });
+      const action = runSkillWorkshopLifecycleAction(state, context, "apply", proposalDecision());
+      try {
+        await vi.waitFor(() => expect(listCount).toBe(2));
+        await selectSkillWorkshopProposal(state, context, "proposal-2");
+        if (outcome === "pending") {
+          oldList.resolve(manifest("pending"));
+        } else {
+          oldList.reject(new Error("retired list failure"));
+        }
+        await oldLoad;
+        expect(state.skillWorkshopProposals.find((item) => item.key === "proposal-1")?.status).toBe(
+          "applied",
+        );
+        expect(state.skillWorkshopSelectedKey).toBe("proposal-2");
+        expect(state.skillWorkshopLoading).toBe(true);
+        expect(state.skillWorkshopError).toBeNull();
+        newList.reject(new Error("current list failure"));
+        await action;
+        expect(state.skillWorkshopLoading).toBe(false);
+        expect(state.skillWorkshopError).toContain("current list failure");
+        expect(state.skillWorkshopSelectedKey).toBe("proposal-2");
+        expect(state.skillWorkshopActionNotice?.label).toBe("Applied");
+      } finally {
+        oldList.resolve(manifest());
+        newList.resolve(manifest("applied"));
+        await Promise.all([oldLoad, action]);
+        clearNoticeTimer(state);
+      }
+    },
+  );
+
+  it.each(["pending", "error"] as const)(
+    "ignores an earlier detail's %s result after confirmation while a newer selection loads",
+    async (outcome) => {
+      const oldDetail = createDeferred<ReturnType<typeof inspectResult>>();
+      const newDetail = createDeferred<ReturnType<typeof inspectResult>>();
+      const { state, context, request } = createFixture(
+        {
+          skillWorkshopAgentId: "research",
+          skillWorkshopProposals: [proposal({ bodyLoaded: false })],
+          skillWorkshopSelectedKey: "proposal-1",
+        },
+        {},
+        ["skills.proposals.reject", "skills.proposals.list", "skills.proposals.inspect"],
+      );
+      request.mockImplementation(async (method, payload) => {
+        if (method === "skills.proposals.reject") {
+          return mutationResponse("reject", "rejected");
+        }
+        if (method === "skills.proposals.list") {
+          const current = manifest("rejected");
+          current.proposals.push({ ...manifest().proposals[0]!, id: "proposal-2" });
+          return current;
+        }
+        return (payload as { proposalId: string }).proposalId === "proposal-1"
+          ? oldDetail.promise
+          : newDetail.promise;
+      });
+      const oldSelection = selectSkillWorkshopProposal(state, context, "proposal-1");
+      const action = runSkillWorkshopLifecycleAction(state, context, "reject", proposalDecision());
+      try {
+        await vi.waitFor(() => expect(state.skillWorkshopInspectingKey).toBe("proposal-2"));
+        if (outcome === "pending") {
+          oldDetail.resolve(inspectResult("pending"));
+        } else {
+          oldDetail.reject(new Error("retired inspection failure"));
+        }
+        await oldSelection;
+        expect(state.skillWorkshopProposals.find((item) => item.key === "proposal-1")?.status).toBe(
+          "rejected",
+        );
+        expect(state.skillWorkshopSelectedKey).toBe("proposal-2");
+        expect(state.skillWorkshopInspectingKey).toBe("proposal-2");
+        expect(state.skillWorkshopError).toBeNull();
+        newDetail.reject(new Error("current inspection failure"));
+        await action;
+        expect(state.skillWorkshopInspectingKey).toBeNull();
+        expect(state.skillWorkshopError).toContain("current inspection failure");
+        expect(state.skillWorkshopActionNotice?.label).toBe("Rejected");
+      } finally {
+        oldDetail.resolve(inspectResult());
+        newDetail.resolve({
+          ...inspectResult(),
+          record: { ...inspectResult().record, id: "proposal-2" },
+        });
+        await Promise.all([oldSelection, action]);
+        clearNoticeTimer(state);
+      }
+    },
+  );
+
+  it("a controller without page scope retains its receipt when disconnected before refresh", async () => {
+    const method = "skills.proposals.apply";
+    const { state, context, request, snapshot } = createFixture(
+      {
+        skillWorkshopProposals: [proposal()],
+        skillWorkshopSelectedKey: "proposal-1",
+      },
+      {},
+      [method, "skills.proposals.list", "skills.proposals.inspect"],
+    );
+    let connectionDropped = false;
+    request.mockImplementation(async (calledMethod: string) => {
+      if (calledMethod === method) {
+        // The apply RPC returns the committed applied record, then the gateway
+        // connection drops before the refresh, so both loaders silently early-
+        // return and the merged applied row is preserved.
+        connectionDropped = true;
+        snapshot.phase = "reconnecting";
+        return mutationResponse("apply", "applied");
+      }
+      if (calledMethod === "skills.proposals.list") {
+        expect(connectionDropped).toBe(false);
+        return manifest("pending");
+      }
+      if (calledMethod === "skills.proposals.inspect") {
+        return inspectResult("pending");
+      }
+      return {};
+    });
+
+    try {
+      await runSkillWorkshopLifecycleAction(state, context, "apply", proposalDecision());
+    } finally {
+      clearNoticeTimer(state);
+    }
+
+    expect(request).toHaveBeenCalledWith(method, {
+      agentId: "research",
+      expectedRevisionHash: REVISION_HASH,
+      proposalId: "proposal-1",
+    });
+    expect(state.skillWorkshopActionNotice?.label).toBe("Applied");
+    expect(state.skillWorkshopProposals[0]?.status).toBe("applied");
+    expect(state.skillWorkshopError).toBeNull();
+  });
+
+  it.each(
+    (
+      [
+        ["does not publish the terminal result across an in-flight scope switch", "success", false],
+        [
+          "does not publish the terminal result across a scope switch with a dropped connection",
+          "success",
+          true,
+        ],
+        [
+          "does not write the unconfirmed-status error across an in-flight scope switch",
+          "unconfirmed",
+          false,
+        ],
+        [
+          "does not show the revision-changed notice across an in-flight scope switch",
+          "revision",
+          false,
+        ],
+        [
+          "does not write the generic action error across an in-flight scope switch",
+          "generic",
+          false,
+        ],
+      ] as const
+    ).flatMap(([name, mode, disconnect]) =>
+      (["apply", "reject"] as const).map((action) => ({ name, action, mode, disconnect })),
+    ),
+  )("$name ($action)", async ({ action, mode, disconnect }) => {
+    const method = `skills.proposals.${action}`;
+    const terminal = terminalStatusFor(action);
+    const { state, context, request, snapshot } = createFixture(
+      {
+        skillWorkshopAgentId: "research",
+        skillWorkshopProposals: [proposal()],
+        skillWorkshopSelectedKey: "proposal-1",
+      },
+      {},
+      [method, "skills.proposals.list", "skills.proposals.inspect"],
+    );
+    const deferred = createDeferred<ReturnType<typeof mutationResponse>>();
+    request.mockImplementation(async (calledMethod: string) => {
+      if (calledMethod === method) {
+        return deferred.promise;
+      }
+      if (disconnect) {
+        return {};
+      }
+      if (calledMethod === "skills.proposals.list") {
+        // After the switch the new scope's list has no proposal-1, so any
+        // appearing applied row would only come from an unscoped leak.
+        return mode === "success"
+          ? { schema: manifest().schema, updatedAt: manifest().updatedAt, proposals: [] }
+          : manifest("pending");
+      }
+      if (calledMethod === "skills.proposals.inspect") {
+        if (mode === "success") {
+          throw new Error("proposal not in scope");
+        }
+        return inspectResult("pending");
+      }
+      return {};
+    });
+
+    let actionPromise: Promise<void>;
+    try {
+      actionPromise = runSkillWorkshopLifecycleAction(state, context, action, proposalDecision());
+      // The mutation is in flight when the explicitly selected agent changes
+      // (and, optionally, the connection drops before the refresh can run).
+      snapshot.assistantAgentId = "ops";
+      if (disconnect) {
+        snapshot.phase = "reconnecting";
+      }
+      if (mode === "revision") {
+        deferred.reject(
+          new GatewayRequestError({
+            code: "INVALID_REQUEST",
+            message: "Skill proposal revision changed",
+            details: {
+              code: "SKILL_PROPOSAL_REVISION_CHANGED",
+              currentRevisionHash: UPDATED_REVISION_HASH,
+              expectedRevisionHash: REVISION_HASH,
+            },
+          }),
+        );
+      } else if (mode === "generic") {
+        deferred.reject(new Error(`${action} failed`));
+      } else {
+        deferred.resolve(mutationResponse(action, mode === "unconfirmed" ? "pending" : terminal));
+      }
+      await actionPromise;
+    } finally {
+      clearNoticeTimer(state);
+    }
+
+    expect(request).toHaveBeenCalledWith(method, {
+      agentId: "research",
+      expectedRevisionHash: REVISION_HASH,
+      proposalId: "proposal-1",
+    });
+    const calledMethods = request.mock.calls.map(([calledMethod]) => calledMethod);
+    expect(calledMethods).not.toContain("skills.proposals.list");
+    expect(calledMethods).not.toContain("skills.proposals.inspect");
+    expectNoLeak(state, action);
+    if (mode === "generic") {
+      expect(state.skillWorkshopError).toBeNull();
+    }
+  });
+
+  it.each(["apply", "reject"] as const)(
+    "%s refuses to act without the reviewed revision hash",
+    async (action) => {
+      const method = `skills.proposals.${action}`;
+      const { state, context, request } = createFixture(
+        { skillWorkshopProposals: [proposal({ revisionHash: null })] },
+        {},
+        [method],
+      );
+
+      await runSkillWorkshopLifecycleAction(state, context, action, proposalDecision(null));
+
+      expect(request).not.toHaveBeenCalled();
+      expect(state.skillWorkshopError).toBe(
+        "The current suggestion revision could not be identified.",
+      );
+    },
+  );
+
+  it.each([
+    ["apply", "skills.proposals.apply"],
+    ["reject", "skills.proposals.reject"],
+  ] as const)(
+    "%s refreshes a changed proposal without replaying the stale decision",
+    async (action, method) => {
+      const updatedAt = "2026-06-16T12:01:00.000Z";
+      const updatedManifest = manifest();
+      updatedManifest.updatedAt = updatedAt;
+      updatedManifest.proposals[0] = {
+        ...updatedManifest.proposals[0]!,
+        description: "Clean inbox triage with an explicit archive review",
+        updatedAt,
+      };
+      const updatedInspect = inspectResult();
+      updatedInspect.record = {
+        ...updatedInspect.record,
+        description: "Clean inbox triage with an explicit archive review",
+        proposedVersion: "v2",
+        updatedAt,
+      };
+      updatedInspect.revisionHash = UPDATED_REVISION_HASH;
+      updatedInspect.content = "Review unread mail, confirm archive candidates, then archive.";
+      const { state, context, request } = createFixture(
+        {
+          skillWorkshopAgentId: "reviewer",
+          skillWorkshopProposals: [proposal()],
+          skillWorkshopSelectedKey: "proposal-1",
+        },
+        { assistantAgentId: "reviewer" },
+        [method, "skills.proposals.list", "skills.proposals.inspect"],
+      );
+      let stale = true;
+      let committed = false;
+      request.mockImplementation(async (calledMethod: string) => {
+        if (calledMethod === method) {
+          if (stale) {
+            stale = false;
+            throw new GatewayRequestError({
+              code: "INVALID_REQUEST",
+              message: "Skill proposal revision changed",
+              details: {
+                code: "SKILL_PROPOSAL_REVISION_CHANGED",
+                currentRevisionHash: UPDATED_REVISION_HASH,
+                expectedRevisionHash: REVISION_HASH,
+              },
+            });
+          }
+          committed = true;
+          const record = {
+            ...recordFrom(terminalStatusFor(action)),
+            proposedVersion: "v2",
+            updatedAt,
+          };
+          return action === "apply"
+            ? { record, targetSkillFile: "skills/inbox-cleaner/SKILL.md" }
+            : record;
+        }
+        if (calledMethod === "skills.proposals.list") {
+          return committed
+            ? {
+                ...updatedManifest,
+                proposals: updatedManifest.proposals.map((entry) => ({
+                  ...entry,
+                  status: terminalStatusFor(action),
+                })),
+              }
+            : updatedManifest;
+        }
+        if (calledMethod === "skills.proposals.inspect") {
+          return updatedInspect;
+        }
+        return {};
+      });
+
+      await runSkillWorkshopLifecycleAction(state, context, action, proposalDecision());
+
+      const actionCalls = () =>
+        request.mock.calls.filter(([calledMethod]) => calledMethod === method);
+      expect(actionCalls()).toEqual([
+        [
+          method,
+          {
+            agentId: "reviewer",
+            expectedRevisionHash: REVISION_HASH,
+            proposalId: "proposal-1",
+          },
+        ],
+      ]);
+      expect(state.skillWorkshopProposals[0]).toMatchObject({
+        body: "Review unread mail, confirm archive candidates, then archive.",
+        revisionHash: UPDATED_REVISION_HASH,
+        version: 2,
+      });
+      expect(state.skillWorkshopActionNotice).toMatchObject({
+        key: "proposal-1",
+        label: "Suggestion changed. Review the updated draft before choosing another action.",
+      });
+      expect(state.skillWorkshopActionNoticeTimer).toBeNull();
+      expect(state.skillWorkshopError).toBeNull();
+
+      try {
+        await runSkillWorkshopLifecycleAction(
+          state,
+          context,
+          action,
+          proposalDecision(UPDATED_REVISION_HASH),
+        );
+      } finally {
+        clearNoticeTimer(state);
+      }
+
+      expect(actionCalls()).toHaveLength(2);
+      expect(actionCalls()[1]).toEqual([
+        method,
+        {
+          agentId: "reviewer",
+          expectedRevisionHash: UPDATED_REVISION_HASH,
+          proposalId: "proposal-1",
+        },
+      ]);
+      expect(state.skillWorkshopProposals[0]).toMatchObject({
+        status: terminalStatusFor(action),
+        revisionHash: UPDATED_REVISION_HASH,
+        version: 2,
+      });
+      expect(state.skillWorkshopActionNotice?.label).toBe(
+        action === "apply" ? "Applied" : "Rejected",
+      );
+    },
+  );
+
+  it("evaluates the freshly inspected revision and merges the attributed result", async () => {
+    const evaluation = {
+      id: "evaluation-1",
+      proposedVersion: "v1",
+      revisionHash: REVISION_HASH,
+      trigger: "manual",
+      startedAt: ISO_NOW,
+      completedAt: ISO_NOW,
+      outcomes: [
+        {
+          pluginId: "quality-plugin",
+          pluginVersion: "1.2.3",
+          evaluatorId: "quality",
+          status: "completed",
+          result: {
+            summary: "One blocking issue.",
+            decision: "block",
+            decisionReason: "The draft needs a rollback step.",
+          },
+        },
+      ],
+    } as const;
+    const baseInspect = inspectResult();
+    const evaluatedInspect = {
+      ...baseInspect,
+      record: { ...baseInspect.record, evaluation },
+    };
+    const evaluateResult = {
+      record: evaluatedInspect.record,
+      evaluation,
+    };
+    let inspectCalls = 0;
+    const { state, context, request } = createFixture(
+      {
+        skillWorkshopAgentId: "research",
+        skillWorkshopProposals: [proposal({ revisionHash: "c".repeat(64) })],
+        skillWorkshopSelectedKey: "proposal-1",
+      },
+      {},
+      ["skills.proposals.inspect", "skills.proposals.evaluate"],
+    );
+    request.mockImplementation(async (method: string) => {
+      if (method === "skills.proposals.inspect") {
+        inspectCalls += 1;
+        return inspectCalls === 1 ? inspectResult() : evaluatedInspect;
+      }
+      if (method === "skills.proposals.evaluate") {
+        return evaluateResult;
+      }
+      return {};
+    });
+
+    try {
+      await expect(runSkillWorkshopEvaluation(state, context, "proposal-1")).resolves.toBe(true);
+    } finally {
+      clearNoticeTimer(state);
+    }
+
+    expect(request).toHaveBeenNthCalledWith(1, "skills.proposals.inspect", {
+      agentId: "research",
+      proposalId: "proposal-1",
+    });
+    expect(request).toHaveBeenNthCalledWith(2, "skills.proposals.evaluate", {
+      agentId: "research",
+      proposalId: "proposal-1",
+      expectedRevisionHash: REVISION_HASH,
+    });
+    expect(request).toHaveBeenNthCalledWith(3, "skills.proposals.inspect", {
+      agentId: "research",
+      proposalId: "proposal-1",
+    });
+    expect(state.skillWorkshopProposals[0]?.evaluation?.outcomes[0]).toMatchObject({
+      pluginId: "quality-plugin",
+      evaluatorId: "quality",
+      status: "completed",
+      result: { decision: "block" },
+    });
+    const evaluated = state.skillWorkshopProposals[0]!;
+    expect(evaluated.revisionHash).toBe(REVISION_HASH);
+    expect(evaluated.body).toBe("Review unread mail and archive low-priority threads.");
+    expect(evaluated.supportFiles).toEqual([]);
+    expect(evaluated.slug).toBe("inbox-cleaner");
+  });
+
+  it("does not evaluate after the initiating source changes during inspection", async () => {
+    const detail = createDeferred<ReturnType<typeof inspectResult>>();
+    const { state, context, request } = createFixture(
+      {
+        skillWorkshopAgentId: "research",
+        skillWorkshopProposals: [proposal({ body: "", bodyLoaded: false })],
+      },
+      {},
+      ["skills.proposals.inspect", "skills.proposals.evaluate"],
+    );
+    let current = true;
+    request.mockImplementation((method: string) =>
+      method === "skills.proposals.inspect" ? detail.promise : Promise.resolve({}),
+    );
+
+    const evaluation = runSkillWorkshopEvaluation(state, context, "proposal-1", () => current);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1));
+    current = false;
+    detail.resolve(inspectResult());
+
+    await expect(evaluation).resolves.toBe(false);
+    expect(request).not.toHaveBeenCalledWith("skills.proposals.evaluate", expect.anything());
+  });
+
+  it("drops an inspected evaluation that belongs to a different revision", async () => {
+    const baseInspect = inspectResult();
+    const { state, context, request } = createFixture(
+      { skillWorkshopProposals: [proposal({ body: "", bodyLoaded: false })] },
+      {},
+      ["skills.proposals.inspect"],
+    );
+    request.mockResolvedValue({
+      ...baseInspect,
+      record: {
+        ...baseInspect.record,
+        evaluation: {
+          id: "evaluation-stale",
+          proposedVersion: "v0",
+          revisionHash: "c".repeat(64),
+          trigger: "manual",
+          startedAt: ISO_NOW,
+          completedAt: ISO_NOW,
+          outcomes: [],
+        },
+      },
+    });
+
+    await selectSkillWorkshopProposal(state, context, "proposal-1");
+
+    expect(state.skillWorkshopProposals[0]?.revisionHash).toBe(REVISION_HASH);
+    expect(state.skillWorkshopProposals[0]?.evaluation).toBeUndefined();
+  });
+
+  it("rejects an evaluation response for a different revision", async () => {
+    const baseInspect = inspectResult();
+    const mismatchedEvaluation = {
+      id: "evaluation-stale",
+      proposedVersion: "v0",
+      revisionHash: "c".repeat(64),
+      trigger: "manual",
+      startedAt: ISO_NOW,
+      completedAt: ISO_NOW,
+      outcomes: [],
+    } as const;
+    const { state, context, request } = createFixture(
+      {
+        skillWorkshopAgentId: "research",
+        skillWorkshopProposals: [proposal()],
+      },
+      {},
+      ["skills.proposals.inspect", "skills.proposals.evaluate"],
+    );
+    request.mockImplementation(async (method: string) =>
+      method === "skills.proposals.inspect"
+        ? baseInspect
+        : {
+            record: { ...baseInspect.record, evaluation: mismatchedEvaluation },
+            evaluation: mismatchedEvaluation,
+          },
+    );
+
+    await expect(runSkillWorkshopEvaluation(state, context, "proposal-1")).resolves.toBe(false);
+
+    expect(state.skillWorkshopError).toBe("The suggestion revision changed during evaluation.");
+    expect(state.skillWorkshopProposals[0]?.evaluation).toBeUndefined();
+  });
+
+  it("loads legacy inspect responses but refuses revision-sensitive evaluation", async () => {
+    const { revisionHash: _revisionHash, ...legacyInspect } = inspectResult();
+    const { state, context, request } = createFixture(
+      {
+        skillWorkshopAgentId: "research",
+        skillWorkshopProposals: [proposal()],
+      },
+      {},
+      ["skills.proposals.inspect", "skills.proposals.evaluate"],
+    );
+    request.mockResolvedValue(legacyInspect);
+
+    await expect(runSkillWorkshopEvaluation(state, context, "proposal-1")).resolves.toBe(false);
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith("skills.proposals.inspect", {
+      agentId: "research",
+      proposalId: "proposal-1",
+    });
+    expect(state.skillWorkshopError).toBe(
+      "The current suggestion revision could not be identified.",
+    );
+    expect(state.skillWorkshopProposals[0]?.revisionHash).toBeNull();
+  });
+
+  it("preserves the loaded proposal agent for originless revisions", async () => {
+    const { state, context } = createFixture(
+      {
+        skillWorkshopAgentId: "research",
+        skillWorkshopProposals: [proposal()],
+        skillWorkshopRevisionDraft: "Tighten the trigger.",
+      },
+      {},
+      ["skills.proposals.requestRevision"],
+    );
+    const sendRevisionRequest = vi.fn(async () => ({
+      id: "revision-1",
+      sessionKey: "agent:research:workshop",
+      status: "admitted" as const,
+    }));
+
+    try {
+      await requestSkillWorkshopRevision(state, context, "proposal-1", sendRevisionRequest);
+    } finally {
+      clearNoticeTimer(state);
+    }
+
+    expect(sendRevisionRequest).toHaveBeenCalledWith(
+      "Tighten the trigger.",
+      expect.objectContaining({ key: "proposal-1" }),
+      "research",
+      REVISION_HASH,
+    );
+  });
+});

--- a/ui/src/pages/skill-workshop/proposal-actions.ts
+++ b/ui/src/pages/skill-workshop/proposal-actions.ts
@@ -1,0 +1,370 @@
+import {
+  readSkillProposalRevisionChangedError,
+  type SkillsProposalApplyResult,
+  type SkillsProposalRecordResult,
+} from "@openclaw/gateway-protocol";
+import type { SkillWorkshopRevisionAdmissionOutcome } from "../../app/skill-workshop-revision-admissions.ts";
+import { t } from "../../i18n/index.ts";
+import { formatUiError } from "../../lib/format-error.ts";
+import { canCallGatewayMethod } from "../../lib/gateway-methods.ts";
+import type {
+  SkillWorkshopAction,
+  SkillWorkshopProposal,
+  SkillWorkshopProposalDecision,
+} from "../../lib/skill-workshop/index.ts";
+import {
+  proposalFromActionRecord,
+  proposalFromEvaluation,
+  type SkillProposalEvaluateResult,
+} from "./proposal-records.ts";
+import {
+  invalidateSkillWorkshopReads,
+  loadedSkillWorkshopAgentParams,
+  loadSkillWorkshopProposalDetail,
+  loadSkillWorkshopProposals,
+  mergeProposal,
+  resolveSkillWorkshopAgentId,
+  type SkillWorkshopContext,
+  type SkillWorkshopLoadOptions,
+} from "./proposals.ts";
+import type { SkillWorkshopState } from "./state.ts";
+
+const SKILL_WORKSHOP_NOTICE_MS = 2800;
+
+function clearActionNoticeTimer(state: SkillWorkshopState): void {
+  if (state.skillWorkshopActionNoticeTimer) {
+    globalThis.clearTimeout(state.skillWorkshopActionNoticeTimer);
+    state.skillWorkshopActionNoticeTimer = null;
+  }
+}
+
+function showActionNotice(
+  state: SkillWorkshopState,
+  proposal: SkillWorkshopProposal | undefined,
+  label: string,
+  options?: { persistent?: boolean },
+): void {
+  if (!proposal) {
+    return;
+  }
+  clearActionNoticeTimer(state);
+  state.skillWorkshopActionNotice = {
+    key: proposal.key,
+    label,
+    slug: proposal.slug || proposal.name,
+  };
+  if (options?.persistent) {
+    return;
+  }
+  state.skillWorkshopActionNoticeTimer = globalThis.setTimeout(() => {
+    if (state.skillWorkshopActionNotice?.key === proposal.key) {
+      state.skillWorkshopActionNotice = null;
+    }
+    state.skillWorkshopActionNoticeTimer = null;
+  }, SKILL_WORKSHOP_NOTICE_MS);
+}
+
+async function refreshAfterMutation(
+  state: SkillWorkshopState,
+  context: SkillWorkshopContext,
+  proposalId: string,
+  options?: SkillWorkshopLoadOptions,
+): Promise<void> {
+  if (options?.isCurrent?.() === false) {
+    return;
+  }
+  state.skillWorkshopLoaded = false;
+  await loadSkillWorkshopProposals(state, context, { ...options, force: true });
+  if (options?.isCurrent?.() === false) {
+    return;
+  }
+  if (
+    state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId)?.status ===
+    "pending"
+  ) {
+    await loadSkillWorkshopProposalDetail(state, context, proposalId, { ...options, force: true });
+  }
+}
+
+function markSkillWorkshopRevisionChanged(
+  state: SkillWorkshopState,
+  proposalId: string,
+  fallback?: SkillWorkshopProposal,
+): void {
+  showActionNotice(
+    state,
+    state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId) ?? fallback,
+    t("skillWorkshop.notices.proposalChanged"),
+    { persistent: true },
+  );
+}
+
+export async function runSkillWorkshopLifecycleAction(
+  state: SkillWorkshopState,
+  context: SkillWorkshopContext,
+  action: Extract<SkillWorkshopAction, "apply" | "reject">,
+  decision: SkillWorkshopProposalDecision,
+  options?: Pick<SkillWorkshopLoadOptions, "isCurrent" | "onProgress">,
+): Promise<void> {
+  const { proposalId, expectedRevisionHash } = decision;
+  const method = action === "apply" ? "skills.proposals.apply" : "skills.proposals.reject";
+  if (!canCallGatewayMethod(context.gateway.snapshot, method, "operator.admin")) {
+    return;
+  }
+  const snapshot = context.gateway.snapshot;
+  const client = snapshot.client;
+  if (!client || snapshot.phase !== "connected" || state.skillWorkshopActionBusy) {
+    return;
+  }
+  const requestAgentId = loadedSkillWorkshopAgentParams(state, context).agentId;
+  const isCurrentAction = () =>
+    options?.isCurrent?.() !== false &&
+    context.gateway.snapshot.client === client &&
+    resolveSkillWorkshopAgentId(context) === requestAgentId;
+  if (!isCurrentAction()) {
+    return;
+  }
+  const previous = state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId);
+  if (action === "apply" && previous?.degradedState) {
+    state.skillWorkshopError = t("skillWorkshop.detail.draftMissing");
+    return;
+  }
+  if (!expectedRevisionHash) {
+    clearActionNoticeTimer(state);
+    state.skillWorkshopActionNotice = null;
+    state.skillWorkshopError = t("skillWorkshop.evaluation.errors.revisionHashUnavailable");
+    return;
+  }
+  const busy = { key: proposalId, action };
+  state.skillWorkshopActionBusy = busy;
+  state.skillWorkshopActionNotice = null;
+  state.skillWorkshopError = null;
+  state.skillWorkshopAgentId ??= requestAgentId;
+  const refreshOptions = { isCurrent: isCurrentAction, onProgress: options?.onProgress };
+  try {
+    const requestParams = { agentId: requestAgentId, proposalId, expectedRevisionHash };
+    const record =
+      action === "apply"
+        ? (await client.request<SkillsProposalApplyResult>(method, requestParams))?.record
+        : await client.request<SkillsProposalRecordResult>(method, requestParams);
+    if (!isCurrentAction()) {
+      return;
+    }
+    if (
+      !record ||
+      record.id !== proposalId ||
+      record.status !== (action === "apply" ? "applied" : "rejected")
+    ) {
+      state.skillWorkshopError = t("skillWorkshop.notices.confirmUnconfirmed");
+      return;
+    }
+    invalidateSkillWorkshopReads(state);
+    const confirmed = proposalFromActionRecord(record, previous);
+    mergeProposal(state, confirmed);
+    showActionNotice(
+      state,
+      confirmed,
+      t(action === "apply" ? "skillWorkshop.notices.applied" : "skillWorkshop.notices.rejected"),
+    );
+    options?.onProgress?.();
+    await refreshAfterMutation(state, context, proposalId, refreshOptions);
+  } catch (err) {
+    if (!isCurrentAction()) {
+      return;
+    }
+    if (readSkillProposalRevisionChangedError(err)) {
+      invalidateSkillWorkshopReads(state);
+      await refreshAfterMutation(state, context, proposalId, refreshOptions);
+      if (isCurrentAction()) {
+        markSkillWorkshopRevisionChanged(state, proposalId, previous);
+      }
+    } else {
+      state.skillWorkshopError = formatUiError(err);
+    }
+  } finally {
+    if (state.skillWorkshopActionBusy === busy) {
+      state.skillWorkshopActionBusy = null;
+    }
+  }
+}
+
+export async function runSkillWorkshopEvaluation(
+  state: SkillWorkshopState,
+  context: SkillWorkshopContext,
+  proposalId: string,
+  isCurrent: () => boolean = () => true,
+): Promise<boolean> {
+  if (
+    !canCallGatewayMethod(context.gateway.snapshot, "skills.proposals.evaluate", "operator.admin")
+  ) {
+    return false;
+  }
+  const snapshot = context.gateway.snapshot;
+  const client = snapshot.client;
+  if (!client || snapshot.phase !== "connected" || state.skillWorkshopActionBusy) {
+    return false;
+  }
+  const previous = state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId);
+  if (!previous || previous.status !== "pending") {
+    return false;
+  }
+  const requestAgentId = loadedSkillWorkshopAgentParams(state, context).agentId;
+  if (state.skillWorkshopAgentId === null) {
+    state.skillWorkshopAgentId = requestAgentId;
+  }
+  state.skillWorkshopActionBusy = { key: proposalId, action: "evaluate" };
+  state.skillWorkshopActionNotice = null;
+  state.skillWorkshopError = null;
+  try {
+    const loaded = await loadSkillWorkshopProposalDetail(state, context, proposalId, {
+      force: true,
+    });
+    if (
+      !loaded ||
+      !isCurrent() ||
+      state.skillWorkshopAgentId !== requestAgentId ||
+      !canCallGatewayMethod(context.gateway.snapshot, "skills.proposals.evaluate", "operator.admin")
+    ) {
+      return false;
+    }
+    const current = state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId);
+    if (current?.degradedState) {
+      throw new Error(t("skillWorkshop.detail.draftMissing"));
+    }
+    if (!current || current.status !== "pending" || !current.revisionHash) {
+      throw new Error(t("skillWorkshop.evaluation.errors.revisionHashUnavailable"));
+    }
+    const result = await client.request<SkillProposalEvaluateResult>("skills.proposals.evaluate", {
+      agentId: requestAgentId,
+      proposalId,
+      expectedRevisionHash: current.revisionHash,
+    });
+    if (!isCurrent() || state.skillWorkshopAgentId !== requestAgentId) {
+      return false;
+    }
+    if (result.evaluation.revisionHash !== current.revisionHash) {
+      throw new Error(t("skillWorkshop.evaluation.errors.revisionChanged"));
+    }
+    mergeProposal(state, proposalFromEvaluation(result, current));
+    await loadSkillWorkshopProposalDetail(state, context, proposalId, { force: true });
+    showActionNotice(
+      state,
+      state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId) ?? previous,
+      t("skillWorkshop.actions.evaluated"),
+    );
+    return true;
+  } catch (err) {
+    if (state.skillWorkshopAgentId === requestAgentId) {
+      state.skillWorkshopError = formatUiError(err);
+    }
+    return false;
+  } finally {
+    if (
+      state.skillWorkshopActionBusy?.key === proposalId &&
+      state.skillWorkshopActionBusy.action === "evaluate"
+    ) {
+      state.skillWorkshopActionBusy = null;
+    }
+  }
+}
+
+export async function requestSkillWorkshopRevision(
+  state: SkillWorkshopState,
+  context: SkillWorkshopContext,
+  proposalId: string,
+  sendRevisionRequest: (
+    instructions: string,
+    proposal: SkillWorkshopProposal,
+    agentId: string,
+    expectedRevisionHash?: string,
+  ) => Promise<SkillWorkshopRevisionAdmissionOutcome>,
+  isCurrent: () => boolean = () => true,
+): Promise<SkillWorkshopRevisionAdmissionOutcome | null> {
+  if (
+    !canCallGatewayMethod(
+      context.gateway.snapshot,
+      "skills.proposals.requestRevision",
+      "operator.admin",
+    )
+  ) {
+    return null;
+  }
+  if (state.skillWorkshopActionBusy) {
+    return null;
+  }
+  const proposal = state.skillWorkshopProposals.find((item) => item.key === proposalId);
+  const instructions = state.skillWorkshopRevisionDraft.trim();
+  if (!proposal || !instructions) {
+    return null;
+  }
+  if (proposal.degradedState) {
+    state.skillWorkshopError = t("skillWorkshop.detail.draftMissing");
+    return null;
+  }
+  const proposalAgentId = loadedSkillWorkshopAgentParams(state, context).agentId;
+  if (state.skillWorkshopAgentId === null) {
+    state.skillWorkshopAgentId = proposalAgentId;
+  }
+  state.skillWorkshopActionBusy = { key: proposalId, action: "revise" };
+  state.skillWorkshopActionNotice = null;
+  state.skillWorkshopError = null;
+  try {
+    if (
+      !isCurrent() ||
+      state.skillWorkshopAgentId !== proposalAgentId ||
+      !canCallGatewayMethod(
+        context.gateway.snapshot,
+        "skills.proposals.requestRevision",
+        "operator.admin",
+      )
+    ) {
+      return null;
+    }
+    const currentProposal =
+      state.skillWorkshopProposals.find((item) => item.key === proposalId) ?? proposal;
+    const outcome = await sendRevisionRequest(
+      instructions,
+      currentProposal,
+      proposalAgentId,
+      currentProposal.revisionHash ?? undefined,
+    );
+    if (outcome.status === "revision-changed") {
+      if (isCurrent() && state.skillWorkshopAgentId === proposalAgentId) {
+        await refreshAfterMutation(state, context, proposalId);
+        state.skillWorkshopRevisionKey = null;
+        state.skillWorkshopRevisionDraft = "";
+        markSkillWorkshopRevisionChanged(state, proposalId, proposal);
+      }
+      return outcome;
+    }
+    if (outcome.status === "retryable-failed") {
+      if (isCurrent() && state.skillWorkshopAgentId === proposalAgentId) {
+        state.skillWorkshopError = t("skillWorkshop.revision.notAdmitted", {
+          error: outcome.error,
+        });
+      }
+      return outcome;
+    }
+    if (!isCurrent() || state.skillWorkshopAgentId !== proposalAgentId) {
+      return outcome;
+    }
+    state.skillWorkshopRevisionKey = null;
+    state.skillWorkshopRevisionDraft = "";
+    showActionNotice(state, proposal, t("skillWorkshop.notices.revisionRequested"));
+    return outcome;
+  } catch (err) {
+    if (isCurrent()) {
+      state.skillWorkshopError = t("skillWorkshop.revision.notAdmitted", {
+        error: formatUiError(err),
+      });
+    }
+    return null;
+  } finally {
+    if (
+      state.skillWorkshopActionBusy?.key === proposalId &&
+      state.skillWorkshopActionBusy.action === "revise"
+    ) {
+      state.skillWorkshopActionBusy = null;
+    }
+  }
+}

--- a/ui/src/pages/skill-workshop/proposal-records.ts
+++ b/ui/src/pages/skill-workshop/proposal-records.ts
@@ -41,7 +41,7 @@ type SkillProposalOrigin = {
   messageId?: string;
 };
 
-type SkillProposalRecord = {
+export type SkillProposalRecord = {
   id: string;
   kind: SkillProposalKind;
   status: SkillProposalStatus;
@@ -174,13 +174,29 @@ export function proposalFromManifest(
   };
 }
 
+function proposalBaseFromRecord(record: SkillProposalRecord) {
+  const updatedAt = parseDateMs(record.updatedAt);
+  const createdAt = parseDateMs(record.createdAt);
+  return {
+    key: record.id,
+    kind: record.kind,
+    slug: record.target.skillKey,
+    name: record.title || record.target.skillName,
+    oneLine: record.description,
+    status: record.status,
+    version: proposedVersionNumber(record.proposedVersion),
+    createdAt,
+    updatedAt,
+    recencyGroup: recencyGroup(updatedAt || createdAt),
+    ageLabel: compactAgeLabel(updatedAt || createdAt),
+  };
+}
+
 export function proposalFromInspect(
   result: SkillProposalInspectResult,
   previous: SkillWorkshopProposal | undefined,
 ): SkillWorkshopProposal {
   const record = result.record;
-  const updatedAt = parseDateMs(record.updatedAt);
-  const createdAt = parseDateMs(record.createdAt);
   const revisionHash = result.revisionHash?.trim() || null;
   const evaluation =
     record.evaluation?.revisionHash === revisionHash
@@ -189,22 +205,12 @@ export function proposalFromInspect(
         ? previous.evaluation
         : undefined;
   return {
-    key: record.id,
-    kind: record.kind,
-    slug: record.target.skillKey,
-    name: record.title || record.target.skillName,
-    oneLine: record.description,
+    ...proposalBaseFromRecord(record),
     body: stripProposalFrontmatter(result.content),
     bodyLoaded: true,
-    status: record.status,
     ...(record.origin ? { origin: record.origin } : {}),
-    version: proposedVersionNumber(record.proposedVersion),
     revisionHash,
     ...(evaluation ? { evaluation } : {}),
-    createdAt,
-    updatedAt,
-    recencyGroup: recencyGroup(updatedAt || createdAt),
-    ageLabel: compactAgeLabel(updatedAt || createdAt),
     supportFiles: supportFilesFromInspect(result),
     isNew: previous?.isNew ?? false,
   };
@@ -215,30 +221,46 @@ export function proposalFromEvaluation(
   previous: SkillWorkshopProposal,
 ): SkillWorkshopProposal {
   const record = result.record;
-  const updatedAt = parseDateMs(record.updatedAt);
-  const createdAt = parseDateMs(record.createdAt);
   return {
-    key: record.id,
-    kind: record.kind,
-    slug: record.target.skillKey,
-    name: record.title || record.target.skillName,
-    oneLine: record.description,
+    ...proposalBaseFromRecord(record),
     body: previous.body,
     bodyLoaded: previous.bodyLoaded,
-    status: record.status,
     ...(record.origin
       ? { origin: record.origin }
       : previous.origin
         ? { origin: previous.origin }
         : {}),
-    version: proposedVersionNumber(record.proposedVersion),
     revisionHash: result.evaluation.revisionHash,
     evaluation: result.evaluation,
-    createdAt,
-    updatedAt,
-    recencyGroup: recencyGroup(updatedAt || createdAt),
-    ageLabel: compactAgeLabel(updatedAt || createdAt),
     supportFiles: previous.supportFiles,
     isNew: previous.isNew,
+  };
+}
+
+// Builds the proposal row from the authoritative apply/reject RPC result
+// record. The mutation record carries the terminal status and record-sourced
+// fields, but not the transcript body/revision hash, so those UI-derived
+// fields are preserved from the pre-action row when one exists.
+export function proposalFromApplyRecord(
+  record: SkillProposalRecord,
+  previous: SkillWorkshopProposal | undefined,
+): SkillWorkshopProposal {
+  return {
+    ...proposalBaseFromRecord(record),
+    body: previous?.body ?? "",
+    bodyLoaded: previous?.bodyLoaded ?? false,
+    ...(record.origin
+      ? { origin: record.origin }
+      : previous?.origin
+        ? { origin: previous.origin }
+        : {}),
+    revisionHash: previous?.revisionHash ?? null,
+    ...(record.evaluation
+      ? { evaluation: record.evaluation }
+      : previous?.evaluation
+        ? { evaluation: previous.evaluation }
+        : {}),
+    supportFiles: previous?.supportFiles ?? [],
+    isNew: previous?.isNew ?? false,
   };
 }

--- a/ui/src/pages/skill-workshop/proposal-records.ts
+++ b/ui/src/pages/skill-workshop/proposal-records.ts
@@ -167,13 +167,29 @@ export function proposalFromManifest(
   };
 }
 
+function proposalBaseFromRecord(record: SkillProposalRecord) {
+  const updatedAt = parseDateMs(record.updatedAt);
+  const createdAt = parseDateMs(record.createdAt);
+  return {
+    key: record.id,
+    kind: record.kind,
+    slug: record.target.skillKey,
+    name: record.title || record.target.skillName,
+    oneLine: record.description,
+    status: record.status,
+    version: proposedVersionNumber(record.proposedVersion),
+    createdAt,
+    updatedAt,
+    recencyGroup: recencyGroup(updatedAt || createdAt),
+    ageLabel: compactAgeLabel(updatedAt || createdAt),
+  };
+}
+
 export function proposalFromInspect(
   result: SkillProposalInspectResult,
   previous: SkillWorkshopProposal | undefined,
 ): SkillWorkshopProposal {
   const record = result.record;
-  const updatedAt = parseDateMs(record.updatedAt);
-  const createdAt = parseDateMs(record.createdAt);
   const revisionHash = result.revisionHash?.trim() || null;
   const evaluation =
     record.evaluation?.revisionHash === revisionHash
@@ -182,22 +198,12 @@ export function proposalFromInspect(
         ? previous.evaluation
         : undefined;
   return {
-    key: record.id,
-    kind: record.kind,
-    slug: record.target.skillKey,
-    name: record.title || record.target.skillName,
-    oneLine: record.description,
+    ...proposalBaseFromRecord(record),
     body: stripProposalFrontmatter(result.content),
     bodyLoaded: true,
-    status: record.status,
     ...(record.origin ? { origin: record.origin } : {}),
-    version: proposedVersionNumber(record.proposedVersion),
     revisionHash,
     ...(evaluation ? { evaluation } : {}),
-    createdAt,
-    updatedAt,
-    recencyGroup: recencyGroup(updatedAt || createdAt),
-    ageLabel: compactAgeLabel(updatedAt || createdAt),
     supportFiles: supportFilesFromInspect(result),
   };
 }
@@ -207,29 +213,42 @@ export function proposalFromEvaluation(
   previous: SkillWorkshopProposal,
 ): SkillWorkshopProposal {
   const record = result.record;
-  const updatedAt = parseDateMs(record.updatedAt);
-  const createdAt = parseDateMs(record.createdAt);
   return {
-    key: record.id,
-    kind: record.kind,
-    slug: record.target.skillKey,
-    name: record.title || record.target.skillName,
-    oneLine: record.description,
+    ...proposalBaseFromRecord(record),
     body: previous.body,
     bodyLoaded: previous.bodyLoaded,
-    status: record.status,
     ...(record.origin
       ? { origin: record.origin }
       : previous.origin
         ? { origin: previous.origin }
         : {}),
-    version: proposedVersionNumber(record.proposedVersion),
     revisionHash: result.evaluation.revisionHash,
     evaluation: result.evaluation,
-    createdAt,
-    updatedAt,
-    recencyGroup: recencyGroup(updatedAt || createdAt),
-    ageLabel: compactAgeLabel(updatedAt || createdAt),
     supportFiles: previous.supportFiles,
+  };
+}
+
+// Terminal actions keep the reviewed draft; the record owns lifecycle metadata.
+export function proposalFromActionRecord(
+  record: SkillProposalRecord,
+  previous: SkillWorkshopProposal | undefined,
+): SkillWorkshopProposal {
+  return {
+    ...proposalBaseFromRecord(record),
+    body: previous?.body ?? "",
+    bodyLoaded: previous?.bodyLoaded ?? false,
+    ...(record.origin
+      ? { origin: record.origin }
+      : previous?.origin
+        ? { origin: previous.origin }
+        : {}),
+    revisionHash: previous?.revisionHash ?? null,
+    ...(record.evaluation
+      ? { evaluation: record.evaluation }
+      : previous?.evaluation
+        ? { evaluation: previous.evaluation }
+        : {}),
+    supportFiles: previous?.supportFiles ?? [],
+    degradedState: previous?.degradedState,
   };
 }

--- a/ui/src/pages/skill-workshop/proposals.test-support.ts
+++ b/ui/src/pages/skill-workshop/proposals.test-support.ts
@@ -1,0 +1,167 @@
+import { vi } from "vitest";
+import type { ApplicationGatewaySnapshot } from "../../app/context.ts";
+import type { SkillWorkshopProposal } from "../../lib/skill-workshop/index.ts";
+import { createTestGatewayClient } from "../../test-helpers/gateway-client.ts";
+import { gatewayHelloForMethods } from "../../test-helpers/gateway-methods.ts";
+import {
+  createSkillWorkshopState,
+  type SkillWorkshopContext,
+  type SkillWorkshopState,
+} from "./proposals.ts";
+
+type TestRequest = (method: string, payload?: unknown) => Promise<unknown>;
+
+export const ISO_NOW = "2026-06-16T12:00:00.000Z";
+const DRAFT_HASH = "a".repeat(64);
+export const REVISION_HASH = "b".repeat(64);
+export const UPDATED_REVISION_HASH = "c".repeat(64);
+
+export function createFixture(
+  overrides: Partial<SkillWorkshopState> = {},
+  snapshotOverrides: Partial<ApplicationGatewaySnapshot> = {},
+  methods: string[] = ["skills.proposals.list", "skills.proposals.inspect"],
+): {
+  state: SkillWorkshopState;
+  context: SkillWorkshopContext;
+  request: ReturnType<typeof vi.fn<TestRequest>>;
+  snapshot: ApplicationGatewaySnapshot;
+} {
+  const request = vi.fn<TestRequest>();
+  const snapshot: ApplicationGatewaySnapshot = {
+    client: createTestGatewayClient(request),
+    phase: "connected",
+    offlineStable: false,
+    canvasPluginSurfaceUrl: null,
+    hello: gatewayHelloForMethods(methods),
+    assistantAgentId: "research",
+    sessionKey: "global",
+    lastError: null,
+    lastErrorCode: null,
+    ...snapshotOverrides,
+  };
+  const context: SkillWorkshopContext = {
+    agentSelection: {
+      get state() {
+        return { selectedId: snapshot.assistantAgentId, scopeId: snapshot.assistantAgentId };
+      },
+    },
+    gateway: {
+      get snapshot() {
+        return snapshot;
+      },
+      connection: { gatewayUrl: "", token: "", bootstrapToken: "", password: "" },
+      connectionRevision: 0,
+      eventLog: [],
+      eventLogRevision: 0,
+      connect: vi.fn(),
+      setSessionKey: vi.fn(),
+      start: vi.fn(),
+      stop: vi.fn(),
+      subscribe: vi.fn(() => () => {}),
+      subscribeEventLog: vi.fn(() => () => {}),
+      subscribeEvents: vi.fn(() => () => {}),
+    },
+  };
+  return {
+    state: { ...createSkillWorkshopState(), skillWorkshopMode: "suggestions", ...overrides },
+    context,
+    request,
+    snapshot,
+  };
+}
+
+export function manifest(status: SkillWorkshopProposal["status"] = "pending") {
+  return {
+    schema: "openclaw.skill-workshop.proposals-manifest.v1",
+    installedSkills: [],
+    updatedAt: ISO_NOW,
+    proposals: [
+      {
+        id: "proposal-1",
+        kind: "create",
+        status,
+        title: "Inbox Cleaner",
+        description: "Clean inbox triage",
+        skillName: "Inbox Cleaner",
+        skillKey: "inbox-cleaner",
+        createdAt: ISO_NOW,
+        updatedAt: ISO_NOW,
+        scanState: "clean",
+        revisionHash: REVISION_HASH,
+      },
+    ],
+  };
+}
+
+export function inspectResult(status: SkillWorkshopProposal["status"] = "pending") {
+  return {
+    record: {
+      id: "proposal-1",
+      kind: "create",
+      status,
+      title: "Inbox Cleaner",
+      description: "Clean inbox triage",
+      createdAt: ISO_NOW,
+      updatedAt: ISO_NOW,
+      proposedVersion: "v1",
+      draftHash: DRAFT_HASH,
+      target: {
+        skillName: "Inbox Cleaner",
+        skillKey: "inbox-cleaner",
+      },
+    },
+    revisionHash: REVISION_HASH,
+    content: "Review unread mail and archive low-priority threads.",
+    supportFiles: [],
+  };
+}
+
+export function proposal(overrides: Partial<SkillWorkshopProposal> = {}): SkillWorkshopProposal {
+  return {
+    key: "proposal-1",
+    kind: "update",
+    slug: "inbox-cleaner",
+    name: "Inbox Cleaner",
+    oneLine: "Clean inbox triage",
+    body: "Review unread mail.",
+    status: "pending",
+    version: 1,
+    revisionHash: REVISION_HASH,
+    createdAt: Date.parse(ISO_NOW),
+    updatedAt: Date.parse(ISO_NOW),
+    recencyGroup: "today",
+    ageLabel: "now",
+    supportFiles: [],
+    bodyLoaded: true,
+    ...overrides,
+  };
+}
+
+export function proposalDecision(expectedRevisionHash: string | null = REVISION_HASH) {
+  return { proposalId: "proposal-1", expectedRevisionHash };
+}
+
+// The mutation RPC returns the authoritative terminal record: apply wraps it
+// in `{ record, targetSkillFile }`, reject returns the bare record.
+export function recordFrom(status: SkillWorkshopProposal["status"]) {
+  return {
+    id: "proposal-1",
+    kind: "create",
+    status,
+    title: "Inbox Cleaner",
+    description: "Clean inbox triage",
+    createdAt: ISO_NOW,
+    updatedAt: ISO_NOW,
+    proposedVersion: "v1",
+    draftHash: DRAFT_HASH,
+    origin: { agentId: "research", sessionKey: "main" },
+    target: { skillName: "Inbox Cleaner", skillKey: "inbox-cleaner" },
+  };
+}
+
+export function clearNoticeTimer(state: SkillWorkshopState): void {
+  if (state.skillWorkshopActionNoticeTimer) {
+    globalThis.clearTimeout(state.skillWorkshopActionNoticeTimer);
+    state.skillWorkshopActionNoticeTimer = null;
+  }
+}

--- a/ui/src/pages/skill-workshop/proposals.test.ts
+++ b/ui/src/pages/skill-workshop/proposals.test.ts
@@ -142,11 +142,55 @@ function proposalDecision(expectedRevisionHash: string | null = REVISION_HASH) {
   return { proposalId: "proposal-1", expectedRevisionHash };
 }
 
+// The mutation RPC returns the authoritative terminal record: apply wraps it
+// in `{ record, targetSkillFile }`, reject returns the bare record.
+function recordFrom(status: SkillWorkshopProposal["status"]): Record<string, unknown> {
+  return {
+    id: "proposal-1",
+    kind: "create",
+    status,
+    title: "Inbox Cleaner",
+    description: "Clean inbox triage",
+    createdAt: ISO_NOW,
+    updatedAt: ISO_NOW,
+    proposedVersion: "v1",
+    draftHash: DRAFT_HASH,
+    origin: { agentId: "research", sessionKey: "main" },
+    target: { skillName: "Inbox Cleaner", skillKey: "inbox-cleaner" },
+  };
+}
+
+function mutationResponse(
+  action: "apply" | "reject",
+  status: SkillWorkshopProposal["status"],
+): unknown {
+  const record = recordFrom(status);
+  return action === "apply" ? { record, targetSkillFile: "skills/inbox-cleaner/SKILL.md" } : record;
+}
+
 function clearNoticeTimer(state: SkillWorkshopState): void {
   if (state.skillWorkshopActionNoticeTimer) {
     globalThis.clearTimeout(state.skillWorkshopActionNoticeTimer);
     state.skillWorkshopActionNoticeTimer = null;
   }
+}
+
+function terminalStatusFor(action: "apply" | "reject"): SkillWorkshopProposal["status"] {
+  return action === "apply" ? "applied" : "rejected";
+}
+
+// Asserts the leak-free invariant shared by every in-flight agent-scope switch
+// case: neither the notice nor the originating terminal row nor the
+// unconfirmed-status error may surface in the new agent's workspace.
+function expectNoLeak(state: SkillWorkshopState, action: "apply" | "reject"): void {
+  const terminalStatus = terminalStatusFor(action);
+  expect(state.skillWorkshopActionNotice).toBeNull();
+  expect(
+    state.skillWorkshopProposals.some(
+      (item) => item.key === "proposal-1" && item.status === terminalStatus,
+    ),
+  ).toBe(false);
+  expect(state.skillWorkshopError ?? "").not.toContain("did not confirm as expected");
 }
 
 describe("Skill Workshop proposal RPCs", () => {
@@ -269,6 +313,12 @@ describe("Skill Workshop proposal RPCs", () => {
       proposalId: "proposal-1",
     });
     expect(state.skillWorkshopSelectedKey).toBe("proposal-1");
+    const inspected = state.skillWorkshopProposals[0]!;
+    expect(inspected.bodyLoaded).toBe(true);
+    expect(inspected.body).toBe("Review unread mail and archive low-priority threads.");
+    expect(inspected.slug).toBe("inbox-cleaner");
+    expect(inspected.name).toBe("Inbox Cleaner");
+    expect(inspected.version).toBe(1);
   });
 
   it.each([
@@ -287,7 +337,7 @@ describe("Skill Workshop proposal RPCs", () => {
       );
       request.mockImplementation(async (calledMethod: string) => {
         if (calledMethod === method) {
-          return {};
+          return mutationResponse(action, status);
         }
         if (calledMethod === "skills.proposals.list") {
           return manifest(status);
@@ -318,6 +368,231 @@ describe("Skill Workshop proposal RPCs", () => {
       });
     },
   );
+
+  it.each(
+    (
+      [
+        ["shows the terminal notice from the authoritative mutation record", "success", "ok"],
+        [
+          "withholds the success notice when the mutation record is not terminal",
+          "unconfirmed",
+          "ok",
+        ],
+        ["keeps the authoritative success notice when the refresh fails", "success", "fails"],
+      ] as const
+    ).flatMap(([name, outcome, refresh]) =>
+      (["apply", "reject"] as const).map((action) => ({ name, action, outcome, refresh })),
+    ),
+  )("$name ($action)", async ({ action, outcome, refresh }) => {
+    const method = `skills.proposals.${action}`;
+    const terminal = terminalStatusFor(action);
+    const mutationStatus: SkillWorkshopProposal["status"] =
+      outcome === "unconfirmed" ? "pending" : terminal;
+    const { state, context, request } = createFixture(
+      { skillWorkshopProposals: [proposal()], skillWorkshopSelectedKey: "proposal-1" },
+      {},
+      [method, "skills.proposals.list", "skills.proposals.inspect"],
+    );
+    request.mockImplementation(async (calledMethod: string) => {
+      if (calledMethod === method) {
+        return mutationResponse(action, mutationStatus);
+      }
+      if (calledMethod === "skills.proposals.list") {
+        if (refresh === "fails") {
+          throw new Error("refresh failed");
+        }
+        return manifest(mutationStatus);
+      }
+      if (calledMethod === "skills.proposals.inspect") {
+        if (refresh === "fails") {
+          throw new Error("refresh inspect failed");
+        }
+        return inspectResult(mutationStatus);
+      }
+      return {};
+    });
+
+    try {
+      await runSkillWorkshopLifecycleAction(state, context, action, proposalDecision());
+    } finally {
+      clearNoticeTimer(state);
+    }
+
+    if (outcome === "unconfirmed") {
+      expect(state.skillWorkshopActionNotice?.label).not.toBe(
+        action === "apply" ? "Applied" : "Rejected",
+      );
+      expect(state.skillWorkshopError).toContain("did not confirm as expected");
+      expect(state.skillWorkshopProposals[0]?.status).toBe("pending");
+      return;
+    }
+    expect(state.skillWorkshopActionNotice?.label).toBe(
+      action === "apply" ? "Applied" : "Rejected",
+    );
+    expect(state.skillWorkshopProposals[0]?.status).toBe(terminal);
+    if (refresh === "ok") {
+      expect(state.skillWorkshopError).toBeNull();
+    } else {
+      expect(state.skillWorkshopError ?? "").not.toContain("did not confirm as expected");
+    }
+  });
+
+  it("apply keeps the authoritative success notice when the connection drops before refresh", async () => {
+    const method = "skills.proposals.apply";
+    const { state, context, request, snapshot } = createFixture(
+      {
+        skillWorkshopProposals: [proposal()],
+        skillWorkshopSelectedKey: "proposal-1",
+      },
+      {},
+      [method, "skills.proposals.list", "skills.proposals.inspect"],
+    );
+    let connectionDropped = false;
+    request.mockImplementation(async (calledMethod: string) => {
+      if (calledMethod === method) {
+        // The apply RPC returns the committed applied record, then the gateway
+        // connection drops before the refresh, so both loaders silently early-
+        // return and the merged applied row is preserved.
+        connectionDropped = true;
+        snapshot.phase = "reconnecting";
+        return mutationResponse("apply", "applied");
+      }
+      if (calledMethod === "skills.proposals.list") {
+        expect(connectionDropped).toBe(false);
+        return manifest("pending");
+      }
+      if (calledMethod === "skills.proposals.inspect") {
+        return inspectResult("pending");
+      }
+      return {};
+    });
+
+    try {
+      await runSkillWorkshopLifecycleAction(state, context, "apply", proposalDecision());
+    } finally {
+      clearNoticeTimer(state);
+    }
+
+    expect(request).toHaveBeenCalledWith(method, {
+      agentId: "research",
+      expectedRevisionHash: REVISION_HASH,
+      proposalId: "proposal-1",
+    });
+    expect(state.skillWorkshopActionNotice?.label).toBe("Applied");
+    expect(state.skillWorkshopProposals[0]?.status).toBe("applied");
+    expect(state.skillWorkshopError).toBeNull();
+  });
+
+  it.each(
+    (
+      [
+        ["does not publish the terminal result across an in-flight scope switch", "success", false],
+        [
+          "does not publish the terminal result across a scope switch with a dropped connection",
+          "success",
+          true,
+        ],
+        [
+          "does not write the unconfirmed-status error across an in-flight scope switch",
+          "unconfirmed",
+          false,
+        ],
+        [
+          "does not show the revision-changed notice across an in-flight scope switch",
+          "revision",
+          false,
+        ],
+        [
+          "does not write the generic action error across an in-flight scope switch",
+          "generic",
+          false,
+        ],
+      ] as const
+    ).flatMap(([name, mode, disconnect]) =>
+      (["apply", "reject"] as const).map((action) => ({ name, action, mode, disconnect })),
+    ),
+  )("$name ($action)", async ({ action, mode, disconnect }) => {
+    const method = `skills.proposals.${action}`;
+    const terminal = terminalStatusFor(action);
+    const { state, context, request, snapshot } = createFixture(
+      {
+        skillWorkshopAgentId: "research",
+        skillWorkshopProposals: [proposal()],
+        skillWorkshopSelectedKey: "proposal-1",
+      },
+      {},
+      [method, "skills.proposals.list", "skills.proposals.inspect"],
+    );
+    const deferred = createDeferred<ReturnType<typeof mutationResponse>>();
+    request.mockImplementation(async (calledMethod: string) => {
+      if (calledMethod === method) {
+        return deferred.promise;
+      }
+      if (disconnect) {
+        return {};
+      }
+      if (calledMethod === "skills.proposals.list") {
+        // After the switch the new scope's list has no proposal-1, so any
+        // appearing applied row would only come from an unscoped leak.
+        return mode === "success"
+          ? { schema: manifest().schema, updatedAt: manifest().updatedAt, proposals: [] }
+          : manifest("pending");
+      }
+      if (calledMethod === "skills.proposals.inspect") {
+        if (mode === "success") {
+          throw new Error("proposal not in scope");
+        }
+        return inspectResult("pending");
+      }
+      return {};
+    });
+
+    let actionPromise: Promise<void>;
+    try {
+      actionPromise = runSkillWorkshopLifecycleAction(state, context, action, proposalDecision());
+      // The mutation is in flight when the session-derived agent scope changes
+      // (and, optionally, the connection drops before the refresh can run).
+      snapshot.sessionKey = "agent:ops:main";
+      if (disconnect) {
+        snapshot.phase = "reconnecting";
+      }
+      if (mode === "revision") {
+        deferred.reject(
+          new GatewayRequestError({
+            code: "INVALID_REQUEST",
+            message: "Skill proposal revision changed",
+            details: {
+              code: "SKILL_PROPOSAL_REVISION_CHANGED",
+              currentRevisionHash: UPDATED_REVISION_HASH,
+              expectedRevisionHash: REVISION_HASH,
+            },
+          }),
+        );
+      } else if (mode === "generic") {
+        deferred.reject(new Error(`${action} failed`));
+      } else {
+        deferred.resolve(mutationResponse(action, mode === "unconfirmed" ? "pending" : terminal));
+      }
+      await actionPromise;
+    } finally {
+      clearNoticeTimer(state);
+    }
+
+    expect(request).toHaveBeenCalledWith(method, {
+      agentId: "research",
+      expectedRevisionHash: REVISION_HASH,
+      proposalId: "proposal-1",
+    });
+    if (disconnect) {
+      const calledMethods = request.mock.calls.map(([calledMethod]) => calledMethod);
+      expect(calledMethods).not.toContain("skills.proposals.list");
+      expect(calledMethods).not.toContain("skills.proposals.inspect");
+    }
+    expectNoLeak(state, action);
+    if (mode === "generic") {
+      expect(state.skillWorkshopError).toBeNull();
+    }
+  });
 
   it.each(["apply", "reject"] as const)(
     "%s refuses to act without the reviewed revision hash",
@@ -522,6 +797,11 @@ describe("Skill Workshop proposal RPCs", () => {
       status: "completed",
       result: { decision: "block" },
     });
+    const evaluated = state.skillWorkshopProposals[0]!;
+    expect(evaluated.revisionHash).toBe(REVISION_HASH);
+    expect(evaluated.body).toBe("Review unread mail and archive low-priority threads.");
+    expect(evaluated.supportFiles).toEqual([]);
+    expect(evaluated.slug).toBe("inbox-cleaner");
   });
 
   it("does not evaluate after the initiating source changes during inspection", async () => {

--- a/ui/src/pages/skill-workshop/proposals.test.ts
+++ b/ui/src/pages/skill-workshop/proposals.test.ts
@@ -1,24 +1,30 @@
 // @vitest-environment node
-// Control UI tests cover skill workshop controller behavior.
+// Control UI tests cover skill workshop reads and evaluation.
 import { describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
-import { GatewayRequestError } from "../../api/gateway.ts";
-import type { ApplicationGatewaySnapshot } from "../../app/context.ts";
 import type { SkillWorkshopProposal } from "../../lib/skill-workshop/index.ts";
 import { gatewayHelloForMethods } from "../../test-helpers/gateway-methods.ts";
 import {
-  createSkillWorkshopState,
-  loadSkillWorkshopProposals,
   requestSkillWorkshopRevision,
   runSkillWorkshopEvaluation,
   runSkillWorkshopLifecycleAction,
+} from "./proposal-actions.ts";
+import {
+  clearNoticeTimer,
+  createFixture,
+  inspectResult,
+  ISO_NOW,
+  manifest,
+  proposal,
+  proposalDecision,
+  recordFrom,
+  REVISION_HASH,
+} from "./proposals.test-support.ts";
+import {
+  loadSkillWorkshopProposals,
   selectSkillWorkshopProposal,
   selectSkillWorkshopInstalledSkill,
-  type SkillWorkshopContext,
-  type SkillWorkshopState,
 } from "./proposals.ts";
-
-type TestRequest = (method: string, payload?: unknown) => Promise<unknown>;
 
 vi.mock("../../lib/skill-workshop/diff-worker.ts", async () => {
   const { computeSkillWorkshopDiff } = await import("../../lib/skill-workshop/diff.ts");
@@ -28,143 +34,6 @@ vi.mock("../../lib/skill-workshop/diff-worker.ts", async () => {
     ),
   };
 });
-
-const ISO_NOW = "2026-06-16T12:00:00.000Z";
-const DRAFT_HASH = "a".repeat(64);
-const REVISION_HASH = "b".repeat(64);
-const UPDATED_REVISION_HASH = "c".repeat(64);
-
-function createFixture(
-  overrides: Partial<SkillWorkshopState> = {},
-  snapshotOverrides: Partial<ApplicationGatewaySnapshot> = {},
-  methods: string[] = ["skills.proposals.list", "skills.proposals.inspect"],
-): {
-  state: SkillWorkshopState;
-  context: SkillWorkshopContext;
-  request: ReturnType<typeof vi.fn<TestRequest>>;
-  snapshot: ApplicationGatewaySnapshot;
-} {
-  const request = vi.fn<TestRequest>();
-  const snapshot: ApplicationGatewaySnapshot = {
-    client: { request } as unknown as ApplicationGatewaySnapshot["client"],
-    phase: "connected",
-    offlineStable: false,
-    canvasPluginSurfaceUrl: null,
-    hello: gatewayHelloForMethods(methods),
-    assistantAgentId: "research",
-    sessionKey: "global",
-    lastError: null,
-    lastErrorCode: null,
-    ...snapshotOverrides,
-  };
-  const context: SkillWorkshopContext = {
-    agentSelection: {
-      get state() {
-        return { selectedId: snapshot.assistantAgentId, scopeId: snapshot.assistantAgentId };
-      },
-    },
-    gateway: {
-      get snapshot() {
-        return snapshot;
-      },
-      connection: { gatewayUrl: "", token: "", bootstrapToken: "", password: "" },
-      connectionRevision: 0,
-      eventLog: [],
-      eventLogRevision: 0,
-      connect: vi.fn(),
-      setSessionKey: vi.fn(),
-      start: vi.fn(),
-      stop: vi.fn(),
-      subscribe: vi.fn(() => () => {}),
-      subscribeEventLog: vi.fn(() => () => {}),
-      subscribeEvents: vi.fn(() => () => {}),
-    },
-  };
-  return {
-    state: { ...createSkillWorkshopState(), skillWorkshopMode: "suggestions", ...overrides },
-    context,
-    request,
-    snapshot,
-  };
-}
-
-function manifest(status: SkillWorkshopProposal["status"] = "pending") {
-  return {
-    schema: "openclaw.skill-workshop.proposals-manifest.v1",
-    installedSkills: [],
-    updatedAt: ISO_NOW,
-    proposals: [
-      {
-        id: "proposal-1",
-        kind: "create",
-        status,
-        title: "Inbox Cleaner",
-        description: "Clean inbox triage",
-        skillName: "Inbox Cleaner",
-        skillKey: "inbox-cleaner",
-        createdAt: ISO_NOW,
-        updatedAt: ISO_NOW,
-        scanState: "clean",
-        revisionHash: REVISION_HASH,
-      },
-    ],
-  };
-}
-
-function inspectResult(status: SkillWorkshopProposal["status"] = "pending") {
-  return {
-    record: {
-      id: "proposal-1",
-      kind: "create",
-      status,
-      title: "Inbox Cleaner",
-      description: "Clean inbox triage",
-      createdAt: ISO_NOW,
-      updatedAt: ISO_NOW,
-      proposedVersion: "v1",
-      draftHash: DRAFT_HASH,
-      target: {
-        skillName: "Inbox Cleaner",
-        skillKey: "inbox-cleaner",
-      },
-    },
-    revisionHash: REVISION_HASH,
-    content: "Review unread mail and archive low-priority threads.",
-    supportFiles: [],
-  };
-}
-
-function proposal(overrides: Partial<SkillWorkshopProposal> = {}): SkillWorkshopProposal {
-  return {
-    key: "proposal-1",
-    kind: "update",
-    slug: "inbox-cleaner",
-    name: "Inbox Cleaner",
-    oneLine: "Clean inbox triage",
-    body: "Review unread mail.",
-    status: "pending",
-    version: 1,
-    revisionHash: REVISION_HASH,
-    createdAt: Date.parse(ISO_NOW),
-    updatedAt: Date.parse(ISO_NOW),
-    recencyGroup: "today",
-    ageLabel: "now",
-    supportFiles: [],
-    bodyLoaded: true,
-    ...overrides,
-  };
-}
-
-function proposalDecision(expectedRevisionHash: string | null = REVISION_HASH) {
-  return { proposalId: "proposal-1", expectedRevisionHash };
-}
-
-function clearNoticeTimer(state: SkillWorkshopState): void {
-  if (state.skillWorkshopActionNoticeTimer) {
-    globalThis.clearTimeout(state.skillWorkshopActionNoticeTimer);
-    state.skillWorkshopActionNoticeTimer = null;
-  }
-}
 
 describe("Skill Workshop proposal RPCs", () => {
   it("reads current installed content and compares only its own applied proposals", async () => {
@@ -354,6 +223,7 @@ describe("Skill Workshop proposal RPCs", () => {
         hello: gatewayHelloForMethods(
           [
             "skills.proposals.apply",
+            "skills.proposals.reject",
             "skills.proposals.evaluate",
             "skills.proposals.requestRevision",
           ],
@@ -363,6 +233,7 @@ describe("Skill Workshop proposal RPCs", () => {
     );
 
     await runSkillWorkshopLifecycleAction(state, context, "apply", proposalDecision());
+    await runSkillWorkshopLifecycleAction(state, context, "reject", proposalDecision());
     await expect(runSkillWorkshopEvaluation(state, context, "proposal-1")).resolves.toBe(false);
     await expect(requestSkillWorkshopRevision(state, context, "proposal-1", vi.fn())).resolves.toBe(
       null,
@@ -470,7 +341,7 @@ describe("Skill Workshop proposal RPCs", () => {
             expectedRevisionHash: REVISION_HASH,
           });
           status = "rejected";
-          return {};
+          return { ...recordFrom("rejected"), kind };
         }
         throw new Error(`Unexpected request: ${method}`);
       });
@@ -539,371 +410,12 @@ describe("Skill Workshop proposal RPCs", () => {
       proposalId: "proposal-1",
     });
     expect(state.skillWorkshopSelectedKey).toBe("proposal-1");
-  });
-
-  it.each([
-    ["apply", "skills.proposals.apply", "applied"],
-    ["reject", "skills.proposals.reject", "rejected"],
-  ] as const)(
-    "%s sends the selected agent id and refreshes that agent scope",
-    async (action, method, status) => {
-      const { state, context, request } = createFixture(
-        {
-          skillWorkshopProposals: [proposal()],
-          skillWorkshopSelectedKey: "proposal-1",
-        },
-        { assistantAgentId: "reviewer" },
-        [method, "skills.proposals.list", "skills.proposals.inspect"],
-      );
-      request.mockImplementation(async (calledMethod: string) => {
-        if (calledMethod === method) {
-          return {};
-        }
-        if (calledMethod === "skills.proposals.list") {
-          return manifest(status);
-        }
-        if (calledMethod === "skills.proposals.inspect") {
-          return inspectResult(status);
-        }
-        return {};
-      });
-
-      try {
-        await runSkillWorkshopLifecycleAction(state, context, action, proposalDecision());
-      } finally {
-        clearNoticeTimer(state);
-      }
-
-      expect(request).toHaveBeenNthCalledWith(1, method, {
-        agentId: "reviewer",
-        expectedRevisionHash: REVISION_HASH,
-        proposalId: "proposal-1",
-      });
-      expect(request).toHaveBeenNthCalledWith(2, "skills.proposals.list", {
-        agentId: "reviewer",
-      });
-      expect(request.mock.calls.map(([calledMethod]) => calledMethod)).toEqual([
-        method,
-        "skills.proposals.list",
-      ]);
-    },
-  );
-
-  it.each(["apply", "reject"] as const)(
-    "%s refuses to act without the reviewed revision hash",
-    async (action) => {
-      const method = `skills.proposals.${action}`;
-      const { state, context, request } = createFixture(
-        { skillWorkshopProposals: [proposal({ revisionHash: null })] },
-        {},
-        [method],
-      );
-
-      await runSkillWorkshopLifecycleAction(state, context, action, proposalDecision(null));
-
-      expect(request).not.toHaveBeenCalled();
-      expect(state.skillWorkshopError).toBe(
-        "The current suggestion revision could not be identified.",
-      );
-    },
-  );
-
-  it.each([
-    ["apply", "skills.proposals.apply"],
-    ["reject", "skills.proposals.reject"],
-  ] as const)(
-    "%s refreshes a changed proposal without replaying the stale decision",
-    async (action, method) => {
-      const updatedAt = "2026-06-16T12:01:00.000Z";
-      const updatedManifest = manifest();
-      updatedManifest.updatedAt = updatedAt;
-      updatedManifest.proposals[0] = {
-        ...updatedManifest.proposals[0]!,
-        description: "Clean inbox triage with an explicit archive review",
-        updatedAt,
-      };
-      const updatedInspect = inspectResult();
-      updatedInspect.record = {
-        ...updatedInspect.record,
-        description: "Clean inbox triage with an explicit archive review",
-        proposedVersion: "v2",
-        updatedAt,
-      };
-      updatedInspect.revisionHash = UPDATED_REVISION_HASH;
-      updatedInspect.content = "Review unread mail, confirm archive candidates, then archive.";
-      const { state, context, request } = createFixture(
-        {
-          skillWorkshopAgentId: "reviewer",
-          skillWorkshopProposals: [proposal()],
-          skillWorkshopSelectedKey: "proposal-1",
-        },
-        { assistantAgentId: "reviewer" },
-        [method, "skills.proposals.list", "skills.proposals.inspect"],
-      );
-      let stale = true;
-      request.mockImplementation(async (calledMethod: string) => {
-        if (calledMethod === method) {
-          if (stale) {
-            stale = false;
-            throw new GatewayRequestError({
-              code: "INVALID_REQUEST",
-              message: "Skill proposal revision changed",
-              details: {
-                code: "SKILL_PROPOSAL_REVISION_CHANGED",
-                currentRevisionHash: UPDATED_REVISION_HASH,
-                expectedRevisionHash: REVISION_HASH,
-              },
-            });
-          }
-          return {};
-        }
-        if (calledMethod === "skills.proposals.list") {
-          return updatedManifest;
-        }
-        if (calledMethod === "skills.proposals.inspect") {
-          return updatedInspect;
-        }
-        return {};
-      });
-
-      await runSkillWorkshopLifecycleAction(state, context, action, proposalDecision());
-
-      const actionCalls = () =>
-        request.mock.calls.filter(([calledMethod]) => calledMethod === method);
-      expect(actionCalls()).toEqual([
-        [
-          method,
-          {
-            agentId: "reviewer",
-            expectedRevisionHash: REVISION_HASH,
-            proposalId: "proposal-1",
-          },
-        ],
-      ]);
-      expect(state.skillWorkshopProposals[0]).toMatchObject({
-        body: "Review unread mail, confirm archive candidates, then archive.",
-        revisionHash: UPDATED_REVISION_HASH,
-        version: 2,
-      });
-      expect(state.skillWorkshopActionNotice).toMatchObject({
-        key: "proposal-1",
-        label: "Suggestion changed. Review the updated draft before choosing another action.",
-      });
-      expect(state.skillWorkshopActionNoticeTimer).toBeNull();
-      expect(state.skillWorkshopError).toBeNull();
-
-      try {
-        await runSkillWorkshopLifecycleAction(
-          state,
-          context,
-          action,
-          proposalDecision(UPDATED_REVISION_HASH),
-        );
-      } finally {
-        clearNoticeTimer(state);
-      }
-
-      expect(actionCalls()).toHaveLength(2);
-      expect(actionCalls()[1]).toEqual([
-        method,
-        {
-          agentId: "reviewer",
-          expectedRevisionHash: UPDATED_REVISION_HASH,
-          proposalId: "proposal-1",
-        },
-      ]);
-    },
-  );
-
-  it("evaluates the freshly inspected revision and merges the attributed result", async () => {
-    const evaluation = {
-      id: "evaluation-1",
-      proposedVersion: "v1",
-      revisionHash: REVISION_HASH,
-      trigger: "manual",
-      startedAt: ISO_NOW,
-      completedAt: ISO_NOW,
-      outcomes: [
-        {
-          pluginId: "quality-plugin",
-          pluginVersion: "1.2.3",
-          evaluatorId: "quality",
-          status: "completed",
-          result: {
-            summary: "One blocking issue.",
-            decision: "block",
-            decisionReason: "The draft needs a rollback step.",
-          },
-        },
-      ],
-    } as const;
-    const baseInspect = inspectResult();
-    const evaluatedInspect = {
-      ...baseInspect,
-      record: { ...baseInspect.record, evaluation },
-    };
-    const evaluateResult = {
-      record: evaluatedInspect.record,
-      evaluation,
-    };
-    let inspectCalls = 0;
-    const { state, context, request } = createFixture(
-      {
-        skillWorkshopAgentId: "research",
-        skillWorkshopProposals: [proposal({ revisionHash: "c".repeat(64) })],
-        skillWorkshopSelectedKey: "proposal-1",
-      },
-      {},
-      ["skills.proposals.inspect", "skills.proposals.evaluate"],
-    );
-    request.mockImplementation(async (method: string) => {
-      if (method === "skills.proposals.inspect") {
-        inspectCalls += 1;
-        return inspectCalls === 1 ? inspectResult() : evaluatedInspect;
-      }
-      if (method === "skills.proposals.evaluate") {
-        return evaluateResult;
-      }
-      return {};
-    });
-
-    try {
-      await expect(runSkillWorkshopEvaluation(state, context, "proposal-1")).resolves.toBe(true);
-    } finally {
-      clearNoticeTimer(state);
-    }
-
-    expect(request).toHaveBeenNthCalledWith(1, "skills.proposals.inspect", {
-      agentId: "research",
-      proposalId: "proposal-1",
-    });
-    expect(request).toHaveBeenNthCalledWith(2, "skills.proposals.evaluate", {
-      agentId: "research",
-      proposalId: "proposal-1",
-      expectedRevisionHash: REVISION_HASH,
-    });
-    expect(request).toHaveBeenNthCalledWith(3, "skills.proposals.inspect", {
-      agentId: "research",
-      proposalId: "proposal-1",
-    });
-    expect(state.skillWorkshopProposals[0]?.evaluation?.outcomes[0]).toMatchObject({
-      pluginId: "quality-plugin",
-      evaluatorId: "quality",
-      status: "completed",
-      result: { decision: "block" },
-    });
-  });
-
-  it("does not evaluate after the initiating source changes during inspection", async () => {
-    const detail = createDeferred<ReturnType<typeof inspectResult>>();
-    const { state, context, request } = createFixture(
-      {
-        skillWorkshopAgentId: "research",
-        skillWorkshopProposals: [proposal({ body: "", bodyLoaded: false })],
-      },
-      {},
-      ["skills.proposals.inspect", "skills.proposals.evaluate"],
-    );
-    let current = true;
-    request.mockImplementation((method: string) =>
-      method === "skills.proposals.inspect" ? detail.promise : Promise.resolve({}),
-    );
-
-    const evaluation = runSkillWorkshopEvaluation(state, context, "proposal-1", () => current);
-    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1));
-    current = false;
-    detail.resolve(inspectResult());
-
-    await expect(evaluation).resolves.toBe(false);
-    expect(request).not.toHaveBeenCalledWith("skills.proposals.evaluate", expect.anything());
-  });
-
-  it("drops an inspected evaluation that belongs to a different revision", async () => {
-    const baseInspect = inspectResult();
-    const { state, context, request } = createFixture(
-      { skillWorkshopProposals: [proposal({ body: "", bodyLoaded: false })] },
-      {},
-      ["skills.proposals.inspect"],
-    );
-    request.mockResolvedValue({
-      ...baseInspect,
-      record: {
-        ...baseInspect.record,
-        evaluation: {
-          id: "evaluation-stale",
-          proposedVersion: "v0",
-          revisionHash: "c".repeat(64),
-          trigger: "manual",
-          startedAt: ISO_NOW,
-          completedAt: ISO_NOW,
-          outcomes: [],
-        },
-      },
-    });
-
-    await selectSkillWorkshopProposal(state, context, "proposal-1");
-
-    expect(state.skillWorkshopProposals[0]?.revisionHash).toBe(REVISION_HASH);
-    expect(state.skillWorkshopProposals[0]?.evaluation).toBeUndefined();
-  });
-
-  it("rejects an evaluation response for a different revision", async () => {
-    const baseInspect = inspectResult();
-    const mismatchedEvaluation = {
-      id: "evaluation-stale",
-      proposedVersion: "v0",
-      revisionHash: "c".repeat(64),
-      trigger: "manual",
-      startedAt: ISO_NOW,
-      completedAt: ISO_NOW,
-      outcomes: [],
-    } as const;
-    const { state, context, request } = createFixture(
-      {
-        skillWorkshopAgentId: "research",
-        skillWorkshopProposals: [proposal()],
-      },
-      {},
-      ["skills.proposals.inspect", "skills.proposals.evaluate"],
-    );
-    request.mockImplementation(async (method: string) =>
-      method === "skills.proposals.inspect"
-        ? baseInspect
-        : {
-            record: { ...baseInspect.record, evaluation: mismatchedEvaluation },
-            evaluation: mismatchedEvaluation,
-          },
-    );
-
-    await expect(runSkillWorkshopEvaluation(state, context, "proposal-1")).resolves.toBe(false);
-
-    expect(state.skillWorkshopError).toBe("The suggestion revision changed during evaluation.");
-    expect(state.skillWorkshopProposals[0]?.evaluation).toBeUndefined();
-  });
-
-  it("loads legacy inspect responses but refuses revision-sensitive evaluation", async () => {
-    const { revisionHash: _revisionHash, ...legacyInspect } = inspectResult();
-    const { state, context, request } = createFixture(
-      {
-        skillWorkshopAgentId: "research",
-        skillWorkshopProposals: [proposal()],
-      },
-      {},
-      ["skills.proposals.inspect", "skills.proposals.evaluate"],
-    );
-    request.mockResolvedValue(legacyInspect);
-
-    await expect(runSkillWorkshopEvaluation(state, context, "proposal-1")).resolves.toBe(false);
-
-    expect(request).toHaveBeenCalledTimes(1);
-    expect(request).toHaveBeenCalledWith("skills.proposals.inspect", {
-      agentId: "research",
-      proposalId: "proposal-1",
-    });
-    expect(state.skillWorkshopError).toBe(
-      "The current suggestion revision could not be identified.",
-    );
-    expect(state.skillWorkshopProposals[0]?.revisionHash).toBeNull();
+    const inspected = state.skillWorkshopProposals[0]!;
+    expect(inspected.bodyLoaded).toBe(true);
+    expect(inspected.body).toBe("Review unread mail and archive low-priority threads.");
+    expect(inspected.slug).toBe("inbox-cleaner");
+    expect(inspected.name).toBe("Inbox Cleaner");
+    expect(inspected.version).toBe(1);
   });
 
   it("loads the explicitly selected agent even when the last chat belongs to another agent", async () => {
@@ -937,6 +449,7 @@ describe("Skill Workshop proposal RPCs", () => {
 
   it("clears stale proposals when the agent changes during an in-flight reload", async () => {
     const researchList = createDeferred<ReturnType<typeof manifest>>();
+    const opsList = createDeferred<ReturnType<typeof manifest>>();
     const { state, context, request, snapshot } = createFixture({
       skillWorkshopAgentId: "research",
       skillWorkshopLoaded: true,
@@ -948,21 +461,23 @@ describe("Skill Workshop proposal RPCs", () => {
       }
       return (payload as { agentId?: string }).agentId === "research"
         ? researchList.promise
-        : manifest();
+        : opsList.promise;
     });
 
     const researchReload = loadSkillWorkshopProposals(state, context, { force: true });
     snapshot.assistantAgentId = "ops";
-    await loadSkillWorkshopProposals(state, context);
+    const opsReload = loadSkillWorkshopProposals(state, context);
 
     expect(state.skillWorkshopAgentId).toBe("ops");
     expect(state.skillWorkshopProposals).toEqual([]);
 
     researchList.resolve(manifest());
     await researchReload;
-    await vi.waitFor(() => {
-      expect(state.skillWorkshopLoaded).toBe(true);
-    });
+    expect(state.skillWorkshopProposals).toEqual([]);
+    expect(state.skillWorkshopLoading).toBe(true);
+    opsList.resolve(manifest());
+    await opsReload;
+    expect(state.skillWorkshopLoaded).toBe(true);
 
     expect(state.skillWorkshopAgentId).toBe("ops");
     expect(request).toHaveBeenCalledWith("skills.proposals.list", { agentId: "ops" });
@@ -990,36 +505,6 @@ describe("Skill Workshop proposal RPCs", () => {
     expect(state.skillWorkshopProposals[0]?.body).toBe("Ops proposal.");
     expect(state.skillWorkshopInspectingKey).toBe("proposal-1");
     expect(state.skillWorkshopSelectedKey).toBeNull();
-  });
-
-  it("preserves the loaded proposal agent for originless revisions", async () => {
-    const { state, context } = createFixture(
-      {
-        skillWorkshopAgentId: "research",
-        skillWorkshopProposals: [proposal()],
-        skillWorkshopRevisionDraft: "Tighten the trigger.",
-      },
-      {},
-      ["skills.proposals.requestRevision"],
-    );
-    const sendRevisionRequest = vi.fn(async () => ({
-      id: "revision-1",
-      sessionKey: "agent:research:workshop",
-      status: "admitted" as const,
-    }));
-
-    try {
-      await requestSkillWorkshopRevision(state, context, "proposal-1", sendRevisionRequest);
-    } finally {
-      clearNoticeTimer(state);
-    }
-
-    expect(sendRevisionRequest).toHaveBeenCalledWith(
-      "Tighten the trigger.",
-      expect.objectContaining({ key: "proposal-1" }),
-      "research",
-      REVISION_HASH,
-    );
   });
 
   it("ignores a superseded selection and keeps its error out of the pane", async () => {

--- a/ui/src/pages/skill-workshop/proposals.test.ts
+++ b/ui/src/pages/skill-workshop/proposals.test.ts
@@ -5,11 +5,6 @@ import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { SkillWorkshopProposal } from "../../lib/skill-workshop/index.ts";
 import { gatewayHelloForMethods } from "../../test-helpers/gateway-methods.ts";
 import {
-  requestSkillWorkshopRevision,
-  runSkillWorkshopEvaluation,
-  runSkillWorkshopLifecycleAction,
-} from "./proposal-actions.ts";
-import {
   clearNoticeTimer,
   createFixture,
   inspectResult,
@@ -19,7 +14,12 @@ import {
   proposalDecision,
   recordFrom,
   REVISION_HASH,
-} from "./proposals.test-support.ts";
+} from "../../test-helpers/skill-workshop-proposal-fixture.ts";
+import {
+  requestSkillWorkshopRevision,
+  runSkillWorkshopEvaluation,
+  runSkillWorkshopLifecycleAction,
+} from "./proposal-actions.ts";
 import {
   loadSkillWorkshopProposals,
   selectSkillWorkshopProposal,

--- a/ui/src/pages/skill-workshop/proposals.ts
+++ b/ui/src/pages/skill-workshop/proposals.ts
@@ -20,12 +20,14 @@ import {
 } from "../../lib/skill-workshop/index.ts";
 import {
   parseDateMs,
+  proposalFromApplyRecord,
   proposalFromEvaluation,
   proposalFromInspect,
   proposalFromManifest,
   type SkillProposalEvaluateResult,
   type SkillProposalInspectResult,
   type SkillProposalManifest,
+  type SkillProposalRecord,
 } from "./proposal-records.ts";
 import { createSkillWorkshopHistoryScanState, type SkillWorkshopState } from "./state.ts";
 export {
@@ -66,6 +68,15 @@ function loadedSkillWorkshopAgentParams(
   return {
     agentId: state.skillWorkshopAgentId ?? skillWorkshopAgentParams(context).agentId,
   };
+}
+
+// The live session-resolved agent is still the one that dispatched the
+// action. Uses the live read (skillWorkshopAgentParams) rather than the cached
+// state.skillWorkshopAgentId, because a disconnected follow-up refresh does not
+// rebase that cache; the live read catches an in-flight scope switch whether
+// or not the refresh ran.
+function isStillRequestAgent(context: SkillWorkshopContext, requestAgentId: string): boolean {
+  return skillWorkshopAgentParams(context).agentId === requestAgentId;
 }
 
 function resetSkillWorkshopAgentScope(state: SkillWorkshopState, agentId: string): void {
@@ -379,6 +390,11 @@ function markSkillWorkshopRevisionChanged(
   );
 }
 
+type SkillProposalApplyResult = {
+  record: SkillProposalRecord;
+  targetSkillFile: string;
+};
+
 export async function runSkillWorkshopLifecycleAction(
   state: SkillWorkshopState,
   context: SkillWorkshopContext,
@@ -405,25 +421,61 @@ export async function runSkillWorkshopLifecycleAction(
   state.skillWorkshopActionBusy = { key: proposalId, action };
   state.skillWorkshopActionNotice = null;
   state.skillWorkshopError = null;
+  const requestAgentId = loadedSkillWorkshopAgentParams(state, context).agentId;
   try {
     const requestParams = {
-      ...loadedSkillWorkshopAgentParams(state, context),
+      agentId: requestAgentId,
       proposalId,
       expectedRevisionHash,
     };
-    await client.request(method, requestParams);
+    if (state.skillWorkshopAgentId === null) {
+      state.skillWorkshopAgentId = requestAgentId;
+    }
+    // The mutation RPC returns the authoritative terminal record (apply wraps
+    // it in `{ record, targetSkillFile }`, reject returns the record itself),
+    // so it is the completion authority. The follow-up refresh is only
+    // synchronization and cannot itself confirm the action completed.
+    const result = await client.request<SkillProposalApplyResult | SkillProposalRecord>(
+      method,
+      requestParams,
+    );
+    const record = result && "record" in result ? result.record : result;
+    if (!record || record.status !== (action === "apply" ? "applied" : "rejected")) {
+      if (!isStillRequestAgent(context, requestAgentId)) {
+        return;
+      }
+      if (!state.skillWorkshopError) {
+        state.skillWorkshopError = t("skillWorkshop.notices.confirmUnconfirmed");
+      }
+      return;
+    }
+    // The follow-up refresh only synchronizes rendering; the authoritative
+    // RPC record is applied afterward so it always wins over any refresh
+    // staleness and the visible row matches the success notice. Body/revision
+    // are preserved from the pre-action row since the mutation record does not
+    // carry them.
     await refreshAfterMutation(state, context, proposalId);
-    const updated = state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId);
+    // Publish only while the live session-resolved agent is still the one that
+    // dispatched the action; a disconnected refresh does not rebase the cached scope.
+    if (!isStillRequestAgent(context, requestAgentId)) {
+      return;
+    }
+    const existing = state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId);
+    mergeProposal(state, proposalFromApplyRecord(record, existing ?? previous));
+    const updated =
+      state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId) ?? previous;
     showActionNotice(
       state,
-      updated ?? previous,
+      updated,
       t(action === "apply" ? "skillWorkshop.notices.applied" : "skillWorkshop.notices.rejected"),
     );
   } catch (err) {
     if (readSkillProposalRevisionChangedError(err)) {
       await refreshAfterMutation(state, context, proposalId);
-      markSkillWorkshopRevisionChanged(state, proposalId, previous);
-    } else {
+      if (isStillRequestAgent(context, requestAgentId)) {
+        markSkillWorkshopRevisionChanged(state, proposalId, previous);
+      }
+    } else if (isStillRequestAgent(context, requestAgentId)) {
       state.skillWorkshopError = formatUiError(err);
     }
   } finally {

--- a/ui/src/pages/skill-workshop/proposals.ts
+++ b/ui/src/pages/skill-workshop/proposals.ts
@@ -1,12 +1,7 @@
-// Control UI controller manages skill workshop gateway state.
-import { readSkillProposalRevisionChangedError } from "@openclaw/gateway-protocol";
 import { stripFrontmatterBlock } from "../../../../packages/markdown-core/src/frontmatter.js";
 import type { AgentSelectionCapability } from "../../app/agent-selection.ts";
 import type { ApplicationGateway } from "../../app/context.ts";
-import type { SkillWorkshopRevisionAdmissionOutcome } from "../../app/skill-workshop-revision-admissions.ts";
-import { t } from "../../i18n/index.ts";
 import { formatUiError } from "../../lib/format-error.ts";
-import { canCallGatewayMethod } from "../../lib/gateway-methods.ts";
 import {
   normalizeAgentId,
   parseAgentSessionKey,
@@ -16,18 +11,14 @@ import { compareSkillWorkshopInstructions } from "../../lib/skill-workshop/diff-
 import {
   filterSkillWorkshopProposals,
   changedSkillWorkshopVersion,
-  type SkillWorkshopAction,
   type SkillWorkshopInstalledSkill,
   type SkillWorkshopInstalledSelection,
   type SkillWorkshopProposal,
-  type SkillWorkshopProposalDecision,
 } from "../../lib/skill-workshop/index.ts";
 import {
   parseDateMs,
-  proposalFromEvaluation,
   proposalFromInspect,
   proposalFromManifest,
-  type SkillProposalEvaluateResult,
   type SkillProposalInspectResult,
   type SkillProposalManifest,
 } from "./proposal-records.ts";
@@ -39,8 +30,26 @@ export {
   type SkillWorkshopState,
 } from "./state.ts";
 
-const SKILL_WORKSHOP_NOTICE_MS = 2800;
-type SkillWorkshopLoadOptions = { force?: boolean; onProgress?: () => void };
+export type SkillWorkshopLoadOptions = {
+  force?: boolean;
+  onProgress?: () => void;
+  isCurrent?: () => boolean;
+};
+
+const readGenerationByState = new WeakMap<SkillWorkshopState, number>();
+
+function readGeneration(state: SkillWorkshopState): number {
+  return readGenerationByState.get(state) ?? 0;
+}
+
+// A confirmed mutation retires reads that could still contain the previous draft.
+export function invalidateSkillWorkshopReads(state: SkillWorkshopState): void {
+  readGenerationByState.set(state, readGeneration(state) + 1);
+  state.skillWorkshopLoaded = false;
+  state.skillWorkshopLoading = false;
+  state.skillWorkshopInspectingKey = null;
+  inspectRequestsByState.delete(state);
+}
 
 export type SkillWorkshopContext = {
   gateway: ApplicationGateway;
@@ -64,7 +73,7 @@ export function resolveSkillWorkshopAgentId(context: SkillWorkshopContext): stri
   return skillWorkshopAgentParams(context).agentId;
 }
 
-function loadedSkillWorkshopAgentParams(
+export function loadedSkillWorkshopAgentParams(
   state: SkillWorkshopState,
   context: SkillWorkshopContext,
 ): { agentId: string } {
@@ -74,8 +83,8 @@ function loadedSkillWorkshopAgentParams(
 }
 
 function resetSkillWorkshopAgentScope(state: SkillWorkshopState, agentId: string): void {
+  invalidateSkillWorkshopReads(state);
   state.skillWorkshopAgentId = agentId;
-  state.skillWorkshopLoaded = false;
   state.skillWorkshopProposals = [];
   state.skillWorkshopInstalledSkills = [];
   state.skillWorkshopInstalledName = null;
@@ -85,11 +94,10 @@ function resetSkillWorkshopAgentScope(state: SkillWorkshopState, agentId: string
   state.skillWorkshopRevisionDraft = "";
   state.skillWorkshopFilePreviewKey = null;
   state.skillWorkshopFilePreviewQuery = "";
-  inspectRequestsByState.delete(state);
   selectionRequestByState.delete(state);
 }
 
-function mergeProposal(state: SkillWorkshopState, proposal: SkillWorkshopProposal): void {
+export function mergeProposal(state: SkillWorkshopState, proposal: SkillWorkshopProposal): void {
   const proposals = state.skillWorkshopProposals;
   const index = proposals.findIndex((item) => item.key === proposal.key);
   if (index < 0) {
@@ -101,39 +109,6 @@ function mergeProposal(state: SkillWorkshopState, proposal: SkillWorkshopProposa
     proposal,
     ...proposals.slice(index + 1),
   ];
-}
-
-function clearActionNoticeTimer(state: SkillWorkshopState): void {
-  if (state.skillWorkshopActionNoticeTimer) {
-    globalThis.clearTimeout(state.skillWorkshopActionNoticeTimer);
-    state.skillWorkshopActionNoticeTimer = null;
-  }
-}
-
-function showActionNotice(
-  state: SkillWorkshopState,
-  proposal: SkillWorkshopProposal | undefined,
-  label: string,
-  options?: { persistent?: boolean },
-): void {
-  if (!proposal) {
-    return;
-  }
-  clearActionNoticeTimer(state);
-  state.skillWorkshopActionNotice = {
-    key: proposal.key,
-    label,
-    slug: proposal.slug || proposal.name,
-  };
-  if (options?.persistent) {
-    return;
-  }
-  state.skillWorkshopActionNoticeTimer = globalThis.setTimeout(() => {
-    if (state.skillWorkshopActionNotice?.key === proposal.key) {
-      state.skillWorkshopActionNotice = null;
-    }
-    state.skillWorkshopActionNoticeTimer = null;
-  }, SKILL_WORKSHOP_NOTICE_MS);
 }
 
 export async function selectSkillWorkshopInstalledSkill(
@@ -158,7 +133,12 @@ async function loadInstalledSkill(
 ): Promise<void> {
   const { client, phase } = context.gateway.snapshot;
   const agentId = loadedSkillWorkshopAgentParams(state, context).agentId;
-  if (!client || phase !== "connected" || (skill.read && !options?.force)) {
+  if (
+    !client ||
+    phase !== "connected" ||
+    (skill.read && !options?.force) ||
+    options?.isCurrent?.() === false
+  ) {
     return;
   }
   // Each inventory row owns its read. Replacing inventory or retrying revokes old results.
@@ -168,6 +148,7 @@ async function loadInstalledSkill(
   };
   skill.read = loading;
   const isCurrentRead = () =>
+    options?.isCurrent?.() !== false &&
     state.skillWorkshopInstalledSkills.includes(skill) &&
     skill.read === loading &&
     state.skillWorkshopAgentId === agentId &&
@@ -265,7 +246,7 @@ export async function loadSkillWorkshopProposals(
 ): Promise<void> {
   const snapshot = context.gateway.snapshot;
   const client = snapshot.client;
-  if (!client || snapshot.phase !== "connected") {
+  if (!client || snapshot.phase !== "connected" || options?.isCurrent?.() === false) {
     return;
   }
   const requestAgentId = skillWorkshopAgentParams(context).agentId;
@@ -278,13 +259,19 @@ export async function loadSkillWorkshopProposals(
   if (state.skillWorkshopLoaded && !options?.force) {
     return;
   }
+  const generation = readGeneration(state);
+  const isCurrentRead = () =>
+    readGeneration(state) === generation &&
+    options?.isCurrent?.() !== false &&
+    context.gateway.snapshot.client === client &&
+    skillWorkshopAgentParams(context).agentId === requestAgentId;
   state.skillWorkshopLoading = true;
   state.skillWorkshopError = null;
   try {
     const result = await client.request<SkillProposalManifest>("skills.proposals.list", {
       agentId: requestAgentId,
     });
-    if (skillWorkshopAgentParams(context).agentId !== requestAgentId) {
+    if (!isCurrentRead()) {
       return;
     }
     const previousByKey = new Map(
@@ -303,10 +290,13 @@ export async function loadSkillWorkshopProposals(
       const installed = state.skillWorkshopInstalledSkills;
       await Promise.all(
         installed.map((skill) =>
-          loadInstalledSkill(state, context, skill, { onProgress: options?.onProgress }),
+          loadInstalledSkill(state, context, skill, {
+            onProgress: options?.onProgress,
+            isCurrent: options?.isCurrent,
+          }),
         ),
       );
-      if (state.skillWorkshopInstalledSkills === installed) {
+      if (isCurrentRead() && state.skillWorkshopInstalledSkills === installed) {
         state.skillWorkshopInstalledName ??=
           (installed.find((skill) => changedSkillWorkshopVersion(skill.read)) ?? installed[0])
             ?.name ?? null;
@@ -331,16 +321,24 @@ export async function loadSkillWorkshopProposals(
       if (!selectionRequestByState.has(state)) {
         markSkillWorkshopSelectionRequest(state, selectedKey);
       }
-      await loadSkillWorkshopProposalDetail(state, context, selectedKey);
+      await loadSkillWorkshopProposalDetail(state, context, selectedKey, {
+        isCurrent: options?.isCurrent,
+      });
     }
   } catch (err) {
-    if (skillWorkshopAgentParams(context).agentId === requestAgentId) {
+    if (isCurrentRead()) {
       state.skillWorkshopError = formatUiError(err);
     }
   } finally {
-    state.skillWorkshopLoading = false;
-    if (skillWorkshopAgentParams(context).agentId !== requestAgentId) {
-      void loadSkillWorkshopProposals(state, context, { force: true });
+    if (readGeneration(state) === generation) {
+      state.skillWorkshopLoading = false;
+      if (
+        options?.isCurrent?.() !== false &&
+        context.gateway.snapshot.client === client &&
+        skillWorkshopAgentParams(context).agentId !== requestAgentId
+      ) {
+        void loadSkillWorkshopProposals(state, context, { ...options, force: true });
+      }
     }
   }
 }
@@ -378,11 +376,19 @@ async function inspectSkillWorkshopProposal(
   client: SkillWorkshopGatewayClient,
   proposalId: string,
   existing: SkillWorkshopProposal | undefined,
+  options?: SkillWorkshopLoadOptions,
 ): Promise<boolean> {
   const requestAgentId = loadedSkillWorkshopAgentParams(state, context).agentId;
   if (state.skillWorkshopAgentId === null) {
     state.skillWorkshopAgentId = requestAgentId;
   }
+  const generation = readGeneration(state);
+  const isCurrentRead = () =>
+    readGeneration(state) === generation &&
+    options?.isCurrent?.() !== false &&
+    context.gateway.snapshot.client === client &&
+    state.skillWorkshopAgentId === requestAgentId &&
+    skillWorkshopAgentParams(context).agentId === requestAgentId;
   state.skillWorkshopInspectingKey = proposalId;
   state.skillWorkshopError = null;
   try {
@@ -391,7 +397,7 @@ async function inspectSkillWorkshopProposal(
       "skills.proposals.inspect",
       requestParams,
     );
-    if (state.skillWorkshopAgentId !== requestAgentId) {
+    if (!isCurrentRead()) {
       return false;
     }
     mergeProposal(state, proposalFromInspect(result, existing));
@@ -399,32 +405,26 @@ async function inspectSkillWorkshopProposal(
   } catch (err) {
     // Only the revision the operator is waiting on may publish an error; a
     // superseded click stays quiet.
-    if (
-      state.skillWorkshopAgentId === requestAgentId &&
-      isLatestSkillWorkshopSelection(state, proposalId)
-    ) {
+    if (isCurrentRead() && isLatestSkillWorkshopSelection(state, proposalId)) {
       state.skillWorkshopError = formatUiError(err);
     }
     return false;
   } finally {
-    if (
-      state.skillWorkshopAgentId === requestAgentId &&
-      state.skillWorkshopInspectingKey === proposalId
-    ) {
+    if (isCurrentRead() && state.skillWorkshopInspectingKey === proposalId) {
       state.skillWorkshopInspectingKey = null;
     }
   }
 }
 
-function loadSkillWorkshopProposalDetail(
+export function loadSkillWorkshopProposalDetail(
   state: SkillWorkshopState,
   context: SkillWorkshopContext,
   proposalId: string,
-  options?: { force?: boolean },
+  options?: SkillWorkshopLoadOptions,
 ): Promise<boolean> {
   const snapshot = context.gateway.snapshot;
   const client = snapshot.client;
-  if (!client || snapshot.phase !== "connected") {
+  if (!client || snapshot.phase !== "connected" || options?.isCurrent?.() === false) {
     return Promise.resolve(false);
   }
   const existing = state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId);
@@ -442,6 +442,7 @@ function loadSkillWorkshopProposalDetail(
     client,
     proposalId,
     existing,
+    options,
   ).finally(() => {
     if (requests.get(proposalId) === request) {
       requests.delete(proposalId);
@@ -465,274 +466,4 @@ export async function selectSkillWorkshopProposal(
     }
   }
   state.skillWorkshopSelectedKey = proposalId;
-}
-
-async function refreshAfterMutation(
-  state: SkillWorkshopState,
-  context: SkillWorkshopContext,
-  proposalId: string,
-): Promise<void> {
-  state.skillWorkshopLoaded = false;
-  await loadSkillWorkshopProposals(state, context, { force: true });
-  if (
-    state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId)?.status ===
-    "pending"
-  ) {
-    await loadSkillWorkshopProposalDetail(state, context, proposalId, { force: true });
-  }
-}
-
-function markSkillWorkshopRevisionChanged(
-  state: SkillWorkshopState,
-  proposalId: string,
-  fallback?: SkillWorkshopProposal,
-): void {
-  showActionNotice(
-    state,
-    state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId) ?? fallback,
-    t("skillWorkshop.notices.proposalChanged"),
-    { persistent: true },
-  );
-}
-
-export async function runSkillWorkshopLifecycleAction(
-  state: SkillWorkshopState,
-  context: SkillWorkshopContext,
-  action: Extract<SkillWorkshopAction, "apply" | "reject">,
-  decision: SkillWorkshopProposalDecision,
-): Promise<void> {
-  const { proposalId, expectedRevisionHash } = decision;
-  const method = action === "apply" ? "skills.proposals.apply" : "skills.proposals.reject";
-  if (!canCallGatewayMethod(context.gateway.snapshot, method, "operator.admin")) {
-    return;
-  }
-  const snapshot = context.gateway.snapshot;
-  const client = snapshot.client;
-  if (!client || snapshot.phase !== "connected" || state.skillWorkshopActionBusy) {
-    return;
-  }
-  const previous = state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId);
-  if (action === "apply" && previous?.degradedState) {
-    state.skillWorkshopError = t("skillWorkshop.detail.draftMissing");
-    return;
-  }
-  if (!expectedRevisionHash) {
-    clearActionNoticeTimer(state);
-    state.skillWorkshopActionNotice = null;
-    state.skillWorkshopError = t("skillWorkshop.evaluation.errors.revisionHashUnavailable");
-    return;
-  }
-  state.skillWorkshopActionBusy = { key: proposalId, action };
-  state.skillWorkshopActionNotice = null;
-  state.skillWorkshopError = null;
-  try {
-    const requestParams = {
-      ...loadedSkillWorkshopAgentParams(state, context),
-      proposalId,
-      expectedRevisionHash,
-    };
-    await client.request(method, requestParams);
-    await refreshAfterMutation(state, context, proposalId);
-    const updated = state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId);
-    showActionNotice(
-      state,
-      updated ?? previous,
-      t(action === "apply" ? "skillWorkshop.notices.applied" : "skillWorkshop.notices.rejected"),
-    );
-  } catch (err) {
-    if (readSkillProposalRevisionChangedError(err)) {
-      await refreshAfterMutation(state, context, proposalId);
-      markSkillWorkshopRevisionChanged(state, proposalId, previous);
-    } else {
-      state.skillWorkshopError = formatUiError(err);
-    }
-  } finally {
-    if (
-      state.skillWorkshopActionBusy?.key === proposalId &&
-      state.skillWorkshopActionBusy.action === action
-    ) {
-      state.skillWorkshopActionBusy = null;
-    }
-  }
-}
-
-export async function runSkillWorkshopEvaluation(
-  state: SkillWorkshopState,
-  context: SkillWorkshopContext,
-  proposalId: string,
-  isCurrent: () => boolean = () => true,
-): Promise<boolean> {
-  if (
-    !canCallGatewayMethod(context.gateway.snapshot, "skills.proposals.evaluate", "operator.admin")
-  ) {
-    return false;
-  }
-  const snapshot = context.gateway.snapshot;
-  const client = snapshot.client;
-  if (!client || snapshot.phase !== "connected" || state.skillWorkshopActionBusy) {
-    return false;
-  }
-  const previous = state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId);
-  if (!previous || previous.status !== "pending") {
-    return false;
-  }
-  const requestAgentId = loadedSkillWorkshopAgentParams(state, context).agentId;
-  if (state.skillWorkshopAgentId === null) {
-    state.skillWorkshopAgentId = requestAgentId;
-  }
-  state.skillWorkshopActionBusy = { key: proposalId, action: "evaluate" };
-  state.skillWorkshopActionNotice = null;
-  state.skillWorkshopError = null;
-  try {
-    const loaded = await loadSkillWorkshopProposalDetail(state, context, proposalId, {
-      force: true,
-    });
-    if (
-      !loaded ||
-      !isCurrent() ||
-      state.skillWorkshopAgentId !== requestAgentId ||
-      !canCallGatewayMethod(context.gateway.snapshot, "skills.proposals.evaluate", "operator.admin")
-    ) {
-      return false;
-    }
-    const current = state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId);
-    if (current?.degradedState) {
-      throw new Error(t("skillWorkshop.detail.draftMissing"));
-    }
-    if (!current || current.status !== "pending" || !current.revisionHash) {
-      throw new Error(t("skillWorkshop.evaluation.errors.revisionHashUnavailable"));
-    }
-    const result = await client.request<SkillProposalEvaluateResult>("skills.proposals.evaluate", {
-      agentId: requestAgentId,
-      proposalId,
-      expectedRevisionHash: current.revisionHash,
-    });
-    if (!isCurrent() || state.skillWorkshopAgentId !== requestAgentId) {
-      return false;
-    }
-    if (result.evaluation.revisionHash !== current.revisionHash) {
-      throw new Error(t("skillWorkshop.evaluation.errors.revisionChanged"));
-    }
-    mergeProposal(state, proposalFromEvaluation(result, current));
-    await loadSkillWorkshopProposalDetail(state, context, proposalId, { force: true });
-    showActionNotice(
-      state,
-      state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId) ?? previous,
-      t("skillWorkshop.actions.evaluated"),
-    );
-    return true;
-  } catch (err) {
-    if (state.skillWorkshopAgentId === requestAgentId) {
-      state.skillWorkshopError = formatUiError(err);
-    }
-    return false;
-  } finally {
-    if (
-      state.skillWorkshopActionBusy?.key === proposalId &&
-      state.skillWorkshopActionBusy.action === "evaluate"
-    ) {
-      state.skillWorkshopActionBusy = null;
-    }
-  }
-}
-
-export async function requestSkillWorkshopRevision(
-  state: SkillWorkshopState,
-  context: SkillWorkshopContext,
-  proposalId: string,
-  sendRevisionRequest: (
-    instructions: string,
-    proposal: SkillWorkshopProposal,
-    agentId: string,
-    expectedRevisionHash?: string,
-  ) => Promise<SkillWorkshopRevisionAdmissionOutcome>,
-  isCurrent: () => boolean = () => true,
-): Promise<SkillWorkshopRevisionAdmissionOutcome | null> {
-  if (
-    !canCallGatewayMethod(
-      context.gateway.snapshot,
-      "skills.proposals.requestRevision",
-      "operator.admin",
-    )
-  ) {
-    return null;
-  }
-  if (state.skillWorkshopActionBusy) {
-    return null;
-  }
-  const proposal = state.skillWorkshopProposals.find((item) => item.key === proposalId);
-  const instructions = state.skillWorkshopRevisionDraft.trim();
-  if (!proposal || !instructions) {
-    return null;
-  }
-  if (proposal.degradedState) {
-    state.skillWorkshopError = t("skillWorkshop.detail.draftMissing");
-    return null;
-  }
-  const proposalAgentId = loadedSkillWorkshopAgentParams(state, context).agentId;
-  if (state.skillWorkshopAgentId === null) {
-    state.skillWorkshopAgentId = proposalAgentId;
-  }
-  state.skillWorkshopActionBusy = { key: proposalId, action: "revise" };
-  state.skillWorkshopActionNotice = null;
-  state.skillWorkshopError = null;
-  try {
-    if (
-      !isCurrent() ||
-      state.skillWorkshopAgentId !== proposalAgentId ||
-      !canCallGatewayMethod(
-        context.gateway.snapshot,
-        "skills.proposals.requestRevision",
-        "operator.admin",
-      )
-    ) {
-      return null;
-    }
-    const currentProposal =
-      state.skillWorkshopProposals.find((item) => item.key === proposalId) ?? proposal;
-    const outcome = await sendRevisionRequest(
-      instructions,
-      currentProposal,
-      proposalAgentId,
-      currentProposal.revisionHash ?? undefined,
-    );
-    if (outcome.status === "revision-changed") {
-      if (isCurrent() && state.skillWorkshopAgentId === proposalAgentId) {
-        await refreshAfterMutation(state, context, proposalId);
-        state.skillWorkshopRevisionKey = null;
-        state.skillWorkshopRevisionDraft = "";
-        markSkillWorkshopRevisionChanged(state, proposalId, proposal);
-      }
-      return outcome;
-    }
-    if (outcome.status === "retryable-failed") {
-      if (isCurrent() && state.skillWorkshopAgentId === proposalAgentId) {
-        state.skillWorkshopError = t("skillWorkshop.revision.notAdmitted", {
-          error: outcome.error,
-        });
-      }
-      return outcome;
-    }
-    if (!isCurrent() || state.skillWorkshopAgentId !== proposalAgentId) {
-      return outcome;
-    }
-    state.skillWorkshopRevisionKey = null;
-    state.skillWorkshopRevisionDraft = "";
-    showActionNotice(state, proposal, t("skillWorkshop.notices.revisionRequested"));
-    return outcome;
-  } catch (err) {
-    if (isCurrent()) {
-      state.skillWorkshopError = t("skillWorkshop.revision.notAdmitted", {
-        error: formatUiError(err),
-      });
-    }
-    return null;
-  } finally {
-    if (
-      state.skillWorkshopActionBusy?.key === proposalId &&
-      state.skillWorkshopActionBusy.action === "revise"
-    ) {
-      state.skillWorkshopActionBusy = null;
-    }
-  }
 }

--- a/ui/src/pages/skill-workshop/skill-workshop-page.test.ts
+++ b/ui/src/pages/skill-workshop/skill-workshop-page.test.ts
@@ -1,5 +1,7 @@
 import type { RouteLoaderOptions } from "@openclaw/uirouter";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import { GatewayRequestError } from "../../api/gateway.ts";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { SessionsListResult } from "../../api/types.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
@@ -73,6 +75,196 @@ afterEach(() => {
 });
 
 describe("SkillWorkshopPage lifecycle", () => {
+  it.each(["apply", "reject"] as const)(
+    "%s removes the pending actions and paints success while refresh is still waiting",
+    async (action) => {
+      const refresh = createDeferred<unknown>();
+      const request = vi.fn(async (method: string) => {
+        if (method === "skills.proposals.list") {
+          return refresh.promise;
+        }
+        const record = {
+          id: "proposal-receipt",
+          kind: "create",
+          status: action === "apply" ? "applied" : "rejected",
+          title: "Inbox review",
+          description: "Review unread threads",
+          createdAt: "2026-09-01T10:00:00.000Z",
+          updatedAt: "2026-09-01T10:01:00.000Z",
+          proposedVersion: "v3",
+          draftHash: "b".repeat(64),
+          target: { skillName: "Inbox review", skillKey: "inbox-review" },
+        };
+        return action === "apply"
+          ? { record, targetSkillFile: "skills/inbox-review/SKILL.md" }
+          : record;
+      });
+      const loaded = createSkillWorkshopState();
+      loaded.skillWorkshopAgentId = "research";
+      loaded.skillWorkshopLoaded = true;
+      loaded.skillWorkshopProposals = [
+        createProposal({
+          key: "proposal-receipt",
+          slug: "inbox-review",
+          name: "Inbox review",
+          body: "Review unread threads before archiving.",
+          version: 3,
+          revisionHash: "a".repeat(64),
+        }),
+      ];
+      loaded.skillWorkshopSelectedKey = "proposal-receipt";
+      const page = document.createElement(
+        "openclaw-skill-workshop-page",
+      ) as SkillWorkshopPageTestElement;
+      page.data = skillWorkshopRouteData(loaded);
+      page.context = createContext(request, {
+        methods: [
+          `skills.proposals.${action}`,
+          "skills.proposals.list",
+          "skills.proposals.inspect",
+        ],
+      });
+      document.body.append(page);
+      await settleLitElement(page);
+      const selector = action === "apply" ? ".sw-btn--primary" : ".sw-btn--danger";
+      const button = page.querySelector<HTMLButtonElement>(`.sw-action-bar ${selector}`);
+      expect(button).not.toBeNull();
+      expect(button?.disabled).toBe(false);
+      button?.click();
+      try {
+        await waitForSkillWorkshop(() =>
+          expect(callsFor(request, "skills.proposals.list")).toHaveLength(1),
+        );
+        await settleLitElement(page);
+        expect(page.querySelector(".sw-action-toast")?.textContent).toContain(
+          action === "apply" ? "Applied" : "Rejected",
+        );
+        expect(page.querySelector(".sw-action-bar")).toBeNull();
+        expect(page.state?.skillWorkshopLoading).toBe(true);
+        refresh.reject(new Error("refresh unavailable"));
+        await waitForSkillWorkshop(() => expect(page.state?.skillWorkshopLoading).toBe(false));
+        await settleLitElement(page);
+        expect(page.querySelector(".sw-action-toast")?.textContent).toContain(
+          action === "apply" ? "Applied" : "Rejected",
+        );
+        expect(page.querySelector(".sw-action-bar")).toBeNull();
+        expect(page.querySelector(".sw-error")?.textContent).toContain("refresh unavailable");
+      } finally {
+        refresh.resolve(emptyWorkshopManifest());
+        if (page.state?.skillWorkshopActionNoticeTimer) {
+          clearTimeout(page.state.skillWorkshopActionNoticeTimer);
+        }
+      }
+    },
+  );
+
+  it.each(
+    (["apply", "reject"] as const).flatMap((action) =>
+      (["success", "error", "revision"] as const).map((outcome) => ({ action, outcome })),
+    ),
+  )(
+    "ignores late $action $outcome after the selected agent changes A → B → A",
+    async ({ action, outcome }) => {
+      const mutation = createDeferred<unknown>();
+      const listeners = new Set<() => void>();
+      const request = vi.fn(async (method: string) =>
+        method === `skills.proposals.${action}` ? mutation.promise : emptyWorkshopManifest(),
+      );
+      const context = createContext(request, {
+        methods: [
+          `skills.proposals.${action}`,
+          "skills.proposals.list",
+          "skills.proposals.inspect",
+        ],
+        agentSelectionSubscribe: (listener) => {
+          listeners.add(listener);
+          return () => listeners.delete(listener);
+        },
+      });
+      let selectedId = "research";
+      const selection = context.agentSelection.state;
+      Object.defineProperty(context.agentSelection, "state", {
+        get: () => ({ ...selection, selectedId, scopeId: selectedId }),
+      });
+      const loaded = createSkillWorkshopState();
+      loaded.skillWorkshopAgentId = "research";
+      loaded.skillWorkshopLoaded = true;
+      loaded.skillWorkshopProposals = [
+        createProposal({
+          key: "proposal-scope",
+          name: "Scoped suggestion",
+          revisionHash: "a".repeat(64),
+        }),
+      ];
+      loaded.skillWorkshopSelectedKey = "proposal-scope";
+      const page = document.createElement(
+        "openclaw-skill-workshop-page",
+      ) as SkillWorkshopPageTestElement;
+      page.data = skillWorkshopRouteData(loaded);
+      page.context = context;
+      document.body.append(page);
+      await settleLitElement(page);
+      const selector = action === "apply" ? ".sw-btn--primary" : ".sw-btn--danger";
+      const button = page.querySelector<HTMLButtonElement>(`.sw-action-bar ${selector}`);
+      expect(button).not.toBeNull();
+      button?.click();
+      await waitForSkillWorkshop(() =>
+        expect(callsFor(request, `skills.proposals.${action}`)).toHaveLength(1),
+      );
+      for (const agentId of ["ops", "research"]) {
+        selectedId = agentId;
+        for (const listener of listeners) {
+          listener();
+        }
+        await waitForSkillWorkshop(() => expect(page.state?.skillWorkshopAgentId).toBe(agentId));
+        await waitForSkillWorkshop(() => expect(page.state?.skillWorkshopLoaded).toBe(true));
+        await settleLitElement(page);
+      }
+      expect(callsFor(request, "skills.proposals.list")).toHaveLength(2);
+      if (outcome === "success") {
+        const record = {
+          id: "proposal-scope",
+          kind: "create",
+          status: action === "apply" ? "applied" : "rejected",
+          title: "Scoped suggestion",
+          description: "Review the selected agent",
+          createdAt: "2026-09-01T10:00:00.000Z",
+          updatedAt: "2026-09-01T10:01:00.000Z",
+          proposedVersion: "v1",
+          draftHash: "b".repeat(64),
+          target: { skillName: "Scoped suggestion", skillKey: "scoped-suggestion" },
+        };
+        mutation.resolve(
+          action === "apply"
+            ? { record, targetSkillFile: "skills/scoped-suggestion/SKILL.md" }
+            : record,
+        );
+      } else if (outcome === "error") {
+        mutation.reject(new Error("late action failure"));
+      } else {
+        mutation.reject(
+          new GatewayRequestError({
+            code: "INVALID_REQUEST",
+            message: "Skill proposal revision changed",
+            details: {
+              code: "SKILL_PROPOSAL_REVISION_CHANGED",
+              currentRevisionHash: "b".repeat(64),
+              expectedRevisionHash: "a".repeat(64),
+            },
+          }),
+        );
+      }
+      await mutation.promise.catch(() => undefined);
+      await settleLitElement(page);
+      expect(page.state?.skillWorkshopProposals).toEqual([]);
+      expect(page.state?.skillWorkshopActionNotice).toBeNull();
+      expect(page.state?.skillWorkshopError).toBeNull();
+      expect(callsFor(request, "skills.proposals.list")).toHaveLength(2);
+      expect(callsFor(request, "skills.proposals.inspect")).toHaveLength(0);
+      expect(page.querySelector(".sw-action-toast, .sw-error")).toBeNull();
+    },
+  );
+
   it("renders a completed skill read after a repeated same-agent notification", async () => {
     localStorage.setItem("openclaw:control-ui:skill-workshop-mode:v1", "skills");
     const skill = {

--- a/ui/src/pages/skill-workshop/skill-workshop-page.ts
+++ b/ui/src/pages/skill-workshop/skill-workshop-page.ts
@@ -6,6 +6,7 @@ import "../../components/tooltip.ts";
 import { t } from "../../i18n/index.ts";
 import { readSessionMethodAccess } from "../../lib/session-method-access.ts";
 import { sessionNavigationTarget } from "../../lib/sessions/route-navigation.ts";
+import type { SkillWorkshopProposalDecision } from "../../lib/skill-workshop/index.ts";
 import { generateUUID } from "../../lib/uuid.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
@@ -16,11 +17,14 @@ import { SKILL_WORKSHOP_LEARNING_PROMPT } from "./learning-prompt.ts";
 import type { SkillWorkshopRevisionRequest } from "./page-types.ts";
 import { renderSkillWorkshopPage } from "./page-view.ts";
 import {
+  requestSkillWorkshopRevision,
+  runSkillWorkshopEvaluation,
+  runSkillWorkshopLifecycleAction,
+} from "./proposal-actions.ts";
+import {
   createSkillWorkshopState,
   loadSkillWorkshopProposals,
   resolveSkillWorkshopAgentId,
-  requestSkillWorkshopRevision,
-  runSkillWorkshopEvaluation,
   type SkillWorkshopRouteData,
   type SkillWorkshopState,
 } from "./proposals.ts";
@@ -202,6 +206,20 @@ class SkillWorkshopPage extends OpenClawLightDomElement {
       proposal,
       proposalAgentId,
     });
+  };
+
+  private readonly handleLifecycleAction = (
+    scope: SkillWorkshopSourceScope,
+    action: "apply" | "reject",
+    decision: SkillWorkshopProposalDecision,
+  ) => {
+    if (!this.isCurrentSourceScope(scope)) {
+      return;
+    }
+    void runSkillWorkshopLifecycleAction(scope.state, scope.context, action, decision, {
+      isCurrent: () => this.isCurrentSourceScope(scope),
+      onProgress: this.requestPageUpdate,
+    }).finally(this.requestPageUpdate);
   };
 
   private readonly handleEvaluation = (proposalId: string) => {
@@ -480,21 +498,24 @@ class SkillWorkshopPage extends OpenClawLightDomElement {
   }
 
   override render() {
-    return this.state && this.context
+    const scope = this.captureSourceScope();
+    return scope
       ? renderSkillWorkshopPage(
-          this.state,
+          scope.state,
           {
-            context: this.context,
+            context: scope.context,
             revisionRecoveryActive: this.revisionRecovery.active,
             workshopAgentName:
-              this.context.agentIdentity.get(this.state.skillWorkshopAgentId)?.name?.trim() ?? "",
+              scope.context.agentIdentity.get(scope.state.skillWorkshopAgentId)?.name?.trim() ?? "",
+            onLifecycleAction: (action, decision) =>
+              this.handleLifecycleAction(scope, action, decision),
             onEvaluate: this.handleEvaluation,
             onRevisionSubmit: this.handleRevisionSubmit,
             selfLearning: resolveSelfLearning(
-              this.context.runtimeConfig,
+              scope.context.runtimeConfig,
               this.selfLearningBusy,
               this.selfLearningError,
-              canCallWorkshopAdminMethod(this.context.gateway.snapshot, "config.patch"),
+              canCallWorkshopAdminMethod(scope.context.gateway.snapshot, "config.patch"),
             ),
             onSelfLearningToggle: this.handleSelfLearningToggle,
             learningBusy: this.learningBusy,

--- a/ui/src/styles/skill-workshop.css
+++ b/ui/src/styles/skill-workshop.css
@@ -1245,6 +1245,10 @@
 
   .sw-action-toast {
     position: fixed;
+    width: max-content;
+    flex-wrap: wrap;
+    overflow-wrap: anywhere;
+    white-space: normal;
   }
 
   .sw-hub-panel,

--- a/ui/src/styles/skill-workshop.css
+++ b/ui/src/styles/skill-workshop.css
@@ -1243,6 +1243,10 @@
     overflow-y: auto;
   }
 
+  .sw-action-toast {
+    position: fixed;
+  }
+
   .sw-hub-panel,
   #skill-workshop-mode-panel,
   .sw-hub-panel::part(base),

--- a/ui/src/test-helpers/skill-workshop-proposal-fixture.ts
+++ b/ui/src/test-helpers/skill-workshop-proposal-fixture.ts
@@ -1,13 +1,13 @@
 import { vi } from "vitest";
-import type { ApplicationGatewaySnapshot } from "../../app/context.ts";
-import type { SkillWorkshopProposal } from "../../lib/skill-workshop/index.ts";
-import { createTestGatewayClient } from "../../test-helpers/gateway-client.ts";
-import { gatewayHelloForMethods } from "../../test-helpers/gateway-methods.ts";
+import type { ApplicationGatewaySnapshot } from "../app/context.ts";
+import type { SkillWorkshopProposal } from "../lib/skill-workshop/index.ts";
 import {
   createSkillWorkshopState,
   type SkillWorkshopContext,
   type SkillWorkshopState,
-} from "./proposals.ts";
+} from "../pages/skill-workshop/proposals.ts";
+import { createTestGatewayClient } from "./gateway-client.ts";
+import { gatewayHelloForMethods } from "./gateway-methods.ts";
 
 type TestRequest = (method: string, payload?: unknown) => Promise<unknown>;
 


### PR DESCRIPTION
Related: #131330

## What Problem This Solves

Fixes an issue where applying or rejecting a Skill Workshop suggestion could show a success notice while the same suggestion stayed pending and actionable after its refresh failed. An older list response could also restore the pending view after a completed action.

## Why This Change Was Made

The UI now consumes the Gateway's committed action record, updates the suggestion and displays its notice before synchronization. It keeps the reviewed content and ignores older reads and results from a page scope that has been replaced. On phones, the notice stays in the viewport as the next document loads, and long messages wrap inside the screen. An absent, mismatched or nonterminal response shows an explicit unconfirmed-state error.

The existing mutation handlers now share a separate module so the controllers and their focused tests stay within the repository's file limits. The Gateway remains the mutation authority.

## User Impact

Completed suggestions lose their pending action buttons promptly. A failed refresh remains visible without undoing a confirmed action. Switching agents, including switching away and back, does not display a late acknowledgement from the previous page scope. Revision checks, read-only restrictions and missing-draft Reject remain intact. Long revision warnings and target names remain readable on narrow screens.

## Evidence

- Pinned baseline `e8e68e84e4559ed2bb0455335267c800e1fa5aca`: real browser Apply and Reject committed through the Gateway, but a controlled read failure left pending actions beside the success notice. Separate store and target-file readback confirmed persistence.
- Candidate `e8917f249d93affddcaa30f394d6464782f24f7b`: real browser normal, failed-refresh, delayed-list, agent-switch, stale-to-fresh revision and reconnect controls; genuine action replies stayed unchanged. A signed read-only client could list proposals and received `FORBIDDEN` for Apply and Reject.
- Malformed response controls were explicit transport faults after real commits. They test the unconfirmed-state UI and do not establish a persistence defect.
- Independent browser acceptance completed 23 public UI/service scenarios, including a new suggestion surviving an older held list after switching away and back, support preview, manual evaluation and settled installed content. Its one locator failure was corrected and retained.
- 98 focused controller/page/sibling tests passed. The four relevant existing browser tests passed; the video case first stopped on a missing Playwright encoder, then passed after installing that dependency and rerunning only that case.
- Final source `4fc6d86b9b5e64a00c7769b307bf56c79c956200` also corrects the CI fixtures to return real-shaped action records and keep synthetic test copy in the existing test-helper scope. All 12 collection cases passed, followed by all seven affected confirmation/revision cases after the final mobile wrapping correction. The new mobile revision test fails before that fix on real rendered text overflow.
- Independent mobile acceptance identified and retained the clipped revision warning. All four final independent checks passed: that full warning, a long unbroken target name, delayed document loading, and evaluation with the support preview open. Source checks, native hooks, and UI build checks passed.

The original long-lived-client missing-file incident in #131330 remains unproved. This PR addresses the confirmed-action UI inconsistency and leaves that broader report open.

| Before | After |
| --- | --- |
| A real committed Apply or Reject could leave the suggestion and enabled actions beside its success notice after refresh failure. | The committed suggestion loses its pending actions before synchronization; a refresh error does not undo it. |

Before/after captures were inspected and retained with the full proof. GitHub returned attachment URLs that remained unavailable, so broken media links are omitted.
