### PR TITLE
fix: cold inventories incorrectly quarantine provider-supported tools

### DIFF
--- a/src/agents/tools-effective-inventory.cold-provider.test.ts
+++ b/src/agents/tools-effective-inventory.cold-provider.test.ts
@@ -1,0 +1,371 @@
+import fs from "node:fs";
+import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core";
+import { describe, expect, it, vi } from "vitest";
+import { setRuntimeConfigSnapshot } from "../config/config.js";
+import { applySessionEntryLifecycleMutation } from "../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  createToolsEffectiveHandlers,
+  testing,
+} from "../gateway/server-methods/tools-effective.js";
+import type { GatewayRequestContext, RespondFn } from "../gateway/server-methods/types.js";
+import { planEffectiveModelCatalogRows } from "../model-catalog/index.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  resetPluginLoaderTestStateForTest,
+} from "../plugins/loader.test-fixtures.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import { resolveProviderRuntimePlugin } from "../plugins/provider-hook-runtime.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
+import { getPluginRuntimeGenerationRegistry } from "../plugins/runtime/generation-scope.js";
+import {
+  createColdPluginFixture,
+  isColdPluginRuntimeLoaded,
+} from "../plugins/test-helpers/cold-plugin-fixtures.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import {
+  withOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import { resolveModelAsync } from "./embedded-agent-runner/model.js";
+import { acquireReadOnlyPreparedModelRuntime } from "./prepared-model-runtime.js";
+import { resetPreparedModelRuntimeSnapshotsForTest } from "./prepared-model-runtime.test-support.js";
+import { resolveEffectiveToolInventoryRuntimeModelContextAsync } from "./tools-effective-inventory.js";
+import type { EffectiveToolInventoryResult } from "./tools-effective-inventory.types.js";
+import type { AnyAgentTool } from "./tools/common.js";
+
+// Shell, channel, media, and MCP factories are unrelated to model metadata. Keep
+// the real provider normalizer, schema quarantine, notices, and grouping below.
+vi.mock("./agent-tools.js", () => {
+  const execute = async () => {
+    throw new Error("Inventory must not execute tools");
+  };
+  return {
+    createOpenClawCodingTools: () =>
+      [
+        {
+          name: "healthy_tool",
+          label: "Healthy tool",
+          description: "A tool with a complete input schema.",
+          parameters: { type: "object", properties: {} },
+          execute,
+        },
+        {
+          name: "parameterless_tool",
+          label: "Parameterless tool",
+          description: "A parameterless tool normalized by the selected provider.",
+          parameters: undefined,
+          execute,
+        },
+      ] as unknown as AnyAgentTool[],
+  };
+});
+
+const provider = "cold-inventory-provider";
+const pluginId = "cold-inventory-plugin";
+const pinnedId = "chat-2026-08-17-pinned";
+const curatedId = "chat-latest";
+const throwingId = "chat-throws";
+
+function ownerCount() {
+  // Reuse the existing owner API without importing the harness that mocks preparation.
+  const api = (globalThis as Record<PropertyKey, unknown>)[
+    Symbol.for("openclaw.preparedModelRuntimeTestApi")
+  ] as { getPreparedModelRuntimeOwnerCountForTest(): number };
+  return api.getPreparedModelRuntimeOwnerCountForTest();
+}
+
+async function withColdFixture(run: (fixture: ReturnType<typeof createFixture>) => Promise<void>) {
+  await withOpenClawTestState(
+    { prefix: "openclaw-cold-inventory-", layout: "split" },
+    async (state) => {
+      const fixture = createFixture(state);
+      await withEnvAsync(
+        {
+          OPENCLAW_BUNDLED_PLUGINS_DIR: fixture.emptyBundledRoot,
+          OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+        },
+        async () => {
+          resetPreparedModelRuntimeSnapshotsForTest();
+          clearPluginMetadataLifecycleCaches();
+          testing.resetToolsEffectiveCacheForTest();
+          try {
+            expect(getPluginRuntimeGenerationRegistry()).toBeUndefined();
+            expect(ownerCount()).toBe(0);
+            expect(isColdPluginRuntimeLoaded(fixture.selected)).toBe(false);
+            await run(fixture);
+            expect(isColdPluginRuntimeLoaded(fixture.unrelated)).toBe(false);
+            expect(getPluginRuntimeGenerationRegistry()).toBeUndefined();
+            expect(ownerCount()).toBe(0);
+          } finally {
+            testing.resetToolsEffectiveCacheForTest();
+            resetPreparedModelRuntimeSnapshotsForTest();
+            clearPluginMetadataLifecycleCaches();
+            resetPluginLoaderTestStateForTest();
+            cleanupPluginLoaderFixturesForTest();
+          }
+        },
+      );
+    },
+  );
+}
+
+function createFixture(state: OpenClawTestState) {
+  const root = state.root;
+  const selectedRoot = path.join(root, "selected");
+  const unrelatedRoot = path.join(root, "unrelated");
+  const emptyBundledRoot = path.join(root, "empty-bundled");
+  const agentDir = state.agentDir();
+  const workspaceDir = state.workspaceDir;
+  for (const dir of [selectedRoot, unrelatedRoot, emptyBundledRoot, agentDir, workspaceDir]) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  const selected = createColdPluginFixture({
+    rootDir: selectedRoot,
+    pluginId,
+    providerId: provider,
+    manifest: {
+      channels: [],
+      channelConfigs: {},
+      providerAuthChoices: [],
+      modelCatalog: {
+        providers: {
+          [provider]: {
+            discovery: "static",
+            api: "openai-completions",
+            baseUrl: "https://inventory.invalid/v1",
+            models: [{ id: curatedId, name: "Curated chat", input: ["text"] }],
+          },
+        },
+      },
+    },
+  });
+  const unrelated = createColdPluginFixture({
+    rootDir: unrelatedRoot,
+    pluginId: "unrelated-inventory-plugin",
+    providerId: "unrelated-inventory-provider",
+    runtimeMessage: "Unrelated provider must stay cold",
+  });
+  fs.writeFileSync(
+    selected.runtimeSource,
+    `const fs = require("node:fs");
+fs.writeFileSync(${JSON.stringify(selected.runtimeMarker)}, "loaded", "utf8");
+module.exports = {
+  id: ${JSON.stringify(pluginId)},
+  register(api) {
+    api.registerProvider({
+      id: ${JSON.stringify(provider)}, label: "Cold inventory provider", auth: [],
+      async prepareDynamicModel(ctx) {
+        if (ctx.modelId === ${JSON.stringify(throwingId)}) throw new Error("Provider preparation failed");
+        if (ctx.modelId !== ${JSON.stringify(pinnedId)}) return;
+        return {
+          id: ctx.modelId, name: "Pinned chat", provider: ctx.provider,
+          api: "openai-completions", baseUrl: "https://inventory.invalid/v1",
+          reasoning: false, input: ["text"], contextWindow: 8192, maxTokens: 1024,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        };
+      },
+      normalizeToolSchemas(ctx) {
+        if (ctx.model?.api !== "openai-completions") return ctx.tools;
+        return ctx.tools.map(tool => tool.parameters === undefined
+          ? { ...tool, parameters: { type: "object", properties: {}, additionalProperties: false } }
+          : tool);
+      },
+    });
+  },
+};
+`,
+    "utf8",
+  );
+  const config: OpenClawConfig = {
+    agents: {
+      defaults: { model: { primary: `${provider}/${pinnedId}` }, workspace: workspaceDir },
+    },
+    plugins: {
+      load: { paths: [selectedRoot, unrelatedRoot] },
+      slots: { memory: "none" },
+      entries: { [pluginId]: { enabled: true }, "unrelated-inventory-plugin": { enabled: true } },
+    },
+  };
+  const input = { agentId: "main", agentDir, workspaceDir, config, readOnly: true };
+  const inventoryParams = {
+    cfg: config,
+    agentId: "main",
+    agentDir,
+    workspaceDir,
+    modelProvider: provider,
+    modelId: pinnedId,
+  };
+  return { state, selected, unrelated, emptyBundledRoot, config, input, inventoryParams };
+}
+
+function pickerIds(fixture: ReturnType<typeof createFixture>) {
+  const snapshot = resolvePluginMetadataSnapshot({
+    config: fixture.config,
+    workspaceDir: fixture.input.workspaceDir,
+  });
+  return planEffectiveModelCatalogRows({
+    registry: snapshot.manifestRegistry,
+    config: fixture.config,
+    providerFilter: provider,
+  }).entries.flatMap((entry) => entry.rows.map((row) => row.id));
+}
+
+describe("cold dynamic-model effective inventory", () => {
+  it("includes provider-supported tools through the default Gateway inventory path", async () => {
+    await withColdFixture(async (fixture) => {
+      expect(pickerIds(fixture)).toEqual([curatedId]);
+      expect(isColdPluginRuntimeLoaded(fixture.selected)).toBe(false);
+      setRuntimeConfigSnapshot(fixture.config);
+      const sessionKey = "agent:main:cold-inventory";
+      await applySessionEntryLifecycleMutation({
+        agentId: "main",
+        storePath: path.join(fixture.state.sessionsDir(), "sessions.json"),
+        upserts: [
+          {
+            sessionKey,
+            entry: {
+              sessionId: "cold-inventory-session",
+              updatedAt: 1,
+              providerOverride: provider,
+              modelOverride: pinnedId,
+              modelOverrideSource: "user",
+            },
+          },
+        ],
+        skipMaintenance: true,
+      });
+      const respond = vi.fn<RespondFn>();
+      const handler = expectDefined(
+        createToolsEffectiveHandlers()["tools.effective"],
+        "default tools.effective handler",
+      );
+      await handler({
+        params: { sessionKey },
+        respond,
+        context: { getRuntimeConfig: () => fixture.config } as GatewayRequestContext,
+        client: null,
+        req: { type: "req", id: "cold-inventory", method: "tools.effective" },
+        isWebchatConnect: () => false,
+      });
+      expect(respond).toHaveBeenCalledExactlyOnceWith(true, expect.any(Object), undefined);
+      const inventory = respond.mock.calls[0]?.[1] as EffectiveToolInventoryResult;
+      expect({
+        tools: inventory.groups.flatMap((group) => group.tools.map((tool) => tool.id)),
+        notices: inventory.notices,
+      }).toEqual({
+        tools: ["healthy_tool", "parameterless_tool"],
+        notices: undefined,
+      });
+      expect(isColdPluginRuntimeLoaded(fixture.selected)).toBe(true);
+      expect(fixture.config.agents?.defaults?.model).toEqual({
+        primary: `${provider}/${pinnedId}`,
+      });
+      expect(pickerIds(fixture)).toEqual([curatedId]);
+    });
+  });
+
+  it("keeps a catalog-only generation isolated after selected runtime preparation", async () => {
+    await withColdFixture(async (fixture) => {
+      const catalogLease = await acquireReadOnlyPreparedModelRuntime(fixture.input);
+      try {
+        const lease = await acquireReadOnlyPreparedModelRuntime({
+          ...fixture.input,
+          loadRuntimePlugins: true,
+          runtimePluginSelections: [{ provider, modelId: pinnedId, agentId: "main" }],
+        });
+        try {
+          expect(ownerCount()).toBe(2);
+          const resolve = (snapshot: typeof lease.snapshot) =>
+            resolveModelAsync(provider, pinnedId, fixture.input.agentDir, fixture.config, {
+              ...snapshot.createStores(),
+              agentId: "main",
+              workspaceDir: fixture.input.workspaceDir,
+              preparedModelRuntime: snapshot,
+            });
+          const resolved = await resolve(lease.snapshot);
+          expect(resolved.model).toMatchObject({
+            id: pinnedId,
+            provider,
+            api: "openai-completions",
+          });
+          expect(resolved.error).toBeUndefined();
+          // Loading B must not lend hooks to A: a generation miss remains authoritative.
+          const catalogResolved = await resolve(catalogLease.snapshot);
+          expect(catalogResolved.model).toBeUndefined();
+          expect(catalogResolved.error).toContain(`Unknown model: ${provider}/${pinnedId}`);
+          expect(isColdPluginRuntimeLoaded(fixture.selected)).toBe(true);
+          expect(pickerIds(fixture)).toEqual([curatedId]);
+        } finally {
+          lease.release();
+        }
+        expect(ownerCount()).toBe(1);
+      } finally {
+        catalogLease.release();
+      }
+    });
+  });
+
+  it.each([
+    { policy: "global disable", plugins: { enabled: false } },
+    { policy: "entry disable", plugins: { entries: { [pluginId]: { enabled: false } } } },
+    { policy: "deny", plugins: { deny: [pluginId] } },
+    { policy: "restrictive allow omission", plugins: { allow: ["unrelated-inventory-plugin"] } },
+  ])("honors $policy despite an ambient competing provider", async ({ plugins }) => {
+    await withColdFixture(async (fixture) => {
+      const config: OpenClawConfig = {
+        ...fixture.config,
+        plugins: { ...fixture.config.plugins, ...plugins },
+      };
+      const ambientHook = vi.fn(() => {
+        throw new Error("Ambient provider must not resolve the model");
+      });
+      const registry = createEmptyPluginRegistry();
+      registry.providers.push({
+        pluginId: "ambient-provider",
+        source: "test",
+        provider: {
+          id: provider,
+          label: "Ambient provider",
+          auth: [],
+          prepareDynamicModel: ambientHook,
+          resolveDynamicModel: ambientHook,
+        },
+      });
+      await withPluginRuntimeRegistryScope(registry, async () => {
+        expect(resolveProviderRuntimePlugin({ provider, config })).toMatchObject({
+          prepareDynamicModel: ambientHook,
+        });
+        await expect(
+          resolveEffectiveToolInventoryRuntimeModelContextAsync({
+            ...fixture.inventoryParams,
+            cfg: config,
+          }),
+        ).resolves.toEqual({});
+      });
+      expect(ambientHook).not.toHaveBeenCalled();
+      expect(isColdPluginRuntimeLoaded(fixture.selected)).toBe(false);
+    });
+  });
+
+  it.each([
+    { modelId: "chat-unknown", throws: false },
+    { modelId: throwingId, throws: true },
+  ])("releases the selected owner when resolving $modelId", async ({ modelId, throws }) => {
+    await withColdFixture(async (fixture) => {
+      const resolution = resolveEffectiveToolInventoryRuntimeModelContextAsync({
+        ...fixture.inventoryParams,
+        modelId,
+      });
+      if (throws) {
+        await expect(resolution).rejects.toThrow("Provider preparation failed");
+      } else {
+        await expect(resolution).resolves.toEqual({});
+      }
+      expect(isColdPluginRuntimeLoaded(fixture.selected)).toBe(true);
+    });
+  });
+});

--- a/src/agents/tools-effective-inventory.runtime-model.test.ts
+++ b/src/agents/tools-effective-inventory.runtime-model.test.ts
@@ -68,22 +68,24 @@ describe("resolveEffectiveToolInventoryRuntimeModelContextAsync", () => {
   });
 
   it.each([
-    { owner: "request-owned", lease: runtimeMocks.requestLease },
-    { owner: "published", lease: runtimeMocks.publishedLease },
-  ])("prepares dynamic model context with a $owner runtime lease", async ({ lease }) => {
+    { owner: "request-owned", agentId: "main", lease: runtimeMocks.requestLease },
+    { owner: "published", agentId: "research", lease: runtimeMocks.publishedLease },
+  ])("prepares dynamic model context with a $owner runtime lease", async ({ lease, agentId }) => {
     runtimeMocks.acquire.mockResolvedValueOnce(lease);
     const { resolveEffectiveToolInventoryRuntimeModelContextAsync } =
       await import("./tools-effective-inventory.js");
     const cfg = makeOpenClawConfigFixture();
+    const agentDir = `/tmp/agents/${agentId}/agent`;
+    const workspaceDir = `/tmp/workspace-${agentId}`;
 
     await expect(
       resolveEffectiveToolInventoryRuntimeModelContextAsync({
         cfg,
-        agentId: "main",
-        agentDir: "/tmp/agents/main/agent",
-        workspaceDir: "/tmp/workspace-main",
-        modelProvider: "openai",
-        modelId: "chat-latest",
+        agentId,
+        agentDir,
+        workspaceDir,
+        modelProvider: " OpenAI ",
+        modelId: " chat-latest ",
       }),
     ).resolves.toMatchObject({
       modelApi: "openai-responses",
@@ -92,21 +94,23 @@ describe("resolveEffectiveToolInventoryRuntimeModelContextAsync", () => {
     expect(runtimeMocks.resolveModelAsync).toHaveBeenCalledWith(
       "openai",
       "chat-latest",
-      "/tmp/agents/main/agent",
+      agentDir,
       cfg,
       {
-        agentId: "main",
-        workspaceDir: "/tmp/workspace-main",
+        agentId,
+        workspaceDir,
         authStorage: lease.authStorage,
         modelRegistry: lease.modelRegistry,
         preparedModelRuntime: lease.snapshot,
       },
     );
     expect(runtimeMocks.acquire).toHaveBeenCalledWith({
-      agentId: "main",
-      agentDir: "/tmp/agents/main/agent",
+      agentId,
+      agentDir,
       config: cfg,
-      workspaceDir: "/tmp/workspace-main",
+      workspaceDir,
+      loadRuntimePlugins: true,
+      runtimePluginSelections: [{ provider: "openai", modelId: "chat-latest", agentId }],
     });
     expect(lease.release).toHaveBeenCalledTimes(1);
   });

--- a/src/agents/tools-effective-inventory.ts
+++ b/src/agents/tools-effective-inventory.ts
@@ -257,6 +257,9 @@ export async function resolveEffectiveToolInventoryRuntimeModelContextAsync(
     agentDir,
     config: params.cfg,
     workspaceDir,
+    // The selected provider owner must join the generation before dynamic hooks resolve.
+    loadRuntimePlugins: true,
+    runtimePluginSelections: [{ provider, modelId, agentId }],
   });
   try {
     const stores = lease.snapshot.createStores();


### PR DESCRIPTION
Closes #131599 — cold effective-tools inventory falsely quarantines provider-supported tools.
Related: #131489 — separately closed config-set validation of uncataloged exact pins; not fixed by this PR.

AI-assisted; the code and full affected owner/caller paths were manually reviewed, with a clean independent Codex autoreview (P0 scope).

<details>
<summary>Additional instructions</summary>

This is a same-repository branch that maintainers can update.

</details>

## What Problem This Solves

Fixes an issue where users inspecting effective tools would see a supported tool omitted and a false schema warning when a cold provider supports their exact model pin dynamically but does not list it in the curated model picker.

## Why This Change Was Made

The inventory's existing read-only prepared-runtime lease omitted selected-provider preparation, so the generation could not resolve dynamic metadata needed by the provider's schema normalizer. Pass the already-normalized provider, exact model ID, and target agent into that lease and opt into selected runtime preparation before resolving metadata; leave quarantine, generation isolation, cleanup, static early returns, and picker curation intact.

This reuses the existing generic owner contract. Broad eager loading, weakening the generation guard, adding a fallback resolver, or repopulating the picker would change the wrong boundary. No provider-specific production behavior or new loader, wrapper, guard, fallback, config/env surface, schema, dependency, or migration is added. No production path is removed.

Production LOC: **+3/-0 (net +3)** | Tests: **+389/-14**. Production growth is two existing input fields plus the ownership comment; a net-neutral refactor cannot supply these missing facts more simply without hiding them or moving selection policy into the wrong owner. Tests add a real cold-plugin/default-handler boundary and extend the existing lease contract coverage.

Provenance: the missing preparation inputs appear in `134dcac3c032d32bdf0f6e6a8fe25f4448b929e9` from #117723 (async effective metadata, code author Vincent Koc, PR author/merger @vincentkoc), carried forward by `0102fcb7dd5b` in #130007 (dynamic metadata propagation, author/merger @steipete). This is source provenance, not a claim that a stable first-bad release was established.

## User Impact

Cold effective-tools inspection retains tools that the selected provider can normalize and stops issuing the false unsupported-schema notice in that case. Exact model pins stay exact, curated picker entries remain curated, disabled/denied/unallowed plugins stay excluded, unrelated provider runtimes stay cold, and leases still release on success and failure.

Release-note context: fix false tool quarantine during cold effective-tools inspection for provider-supported exact pins outside the curated catalog.

## Evidence

Source baseline: `629a47e3cc20a9f8b6d19c105f840b8a693ec4aa`. Reviewed patch: `f43e6d5c9d5b8af0424ef8abc2bd848dcd34bc5e`. Parent checked current main `e171f2035bf2b84dd2ba6c57f06903f005484bc0` with no affected-path drift. macOS 26.6.2, Node 24.20.0.

The regression uses real plugin manifest discovery/runtime, real prepared lease and model resolution, real provider schema normalization/quarantine, real isolated SQLite session selection, and the **default** Gateway `tools.effective` handler. Only the unrelated `createOpenClawCodingTools` factory is mocked to two inert descriptors. There is no resolver/inventory injection. The generic schema finalizer legitimately leaves undefined parameters for provider normalization (`src/agents/agent-tools.schema.ts:69-74`).

Exact before/after command:

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/agents/tools-effective-inventory.cold-provider.test.ts --reporter=verbose -t 'includes provider-supported tools through the default Gateway inventory path'
```

With production bytes verified equal to the baseline (only the three repair lines absent), the final test failed as expected: **1 failed, 7 skipped**. The preceding assertion verified one successful RPC handler response; actual output was only `healthy_tool` plus `unsupported-tool-schema:parameterless_tool`. Restoring the exact three lines yields both `healthy_tool` and `parameterless_tool`, with no notices. The fixture supports `chat-2026-08-17-pinned` dynamically while its picker lists only `chat-latest`.

Final focused run:

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/agents/tools-effective-inventory.cold-provider.test.ts src/agents/tools-effective-inventory.runtime-model.test.ts --reporter=verbose
```

**15 passed across 2 files.** Controls cover global disable, entry disable, deny, restrictive allow omission with an ambient competing hook, exact unknown IDs, throwing preparation, owner release, ordered generation isolation, curated picker preservation, static no-dynamic-acquisition, and normalized selection with a non-default target agent.

Sibling run:

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/agents/tools-effective-inventory.test.ts src/gateway/server-methods/tools-effective.test.ts src/gateway/server-methods/tools-effective.global-agent.integration.test.ts src/auto-reply/reply/commands-info.test.ts src/auto-reply/reply/session-reset-prompt.test.ts src/auto-reply/reply/session-reset-prompt.runtime-model.test.ts src/agents/runtime-plugins.test.ts src/agents/prepared-model-runtime.plugin-context.test.ts src/agents/embedded-agent-runner/model.generation-scope.test.ts src/plugins/provider-runtime.test.ts --reporter=verbose
```

**193 passed across 10 files; 208 total across 12 files.**

```sh
node scripts/check-changed.mjs -- src/agents/tools-effective-inventory.ts src/agents/tools-effective-inventory.cold-provider.test.ts src/agents/tools-effective-inventory.runtime-model.test.ts
pnpm build
git diff --check
```

All passed: the full changed-file gate (497s) includes core/test typechecks, targeted lint and architecture guards; build (440s) has no ineffective dynamic import warning. An initial test-only no-map-spread lint finding was repaired without suppression and the before/after proof and full changed gate were rerun. Build emitted only existing dependency EVAL/performance warnings.

**Proof limits:** this is offline default-handler/real-plugin boundary evidence, not a running Gateway server, Control UI, live vendor, or PDF test. Live credential/provider calls and operator state access are explicitly prohibited for this task; no such behavior or stable-release first-bad is claimed. Static transport normalization may already load provider hooks; only the supported static no-dynamic-acquisition invariant is claimed. Exact-head hosted CI and native landing checks will be recorded before merge.

Landing checkpoint: [exact-head pull_request CI 33149180219](https://github.com/openclaw/openclaw/actions/runs/33149180219) completed successfully on attempt 1 for `f43e6d5c9d5b8af0424ef8abc2bd848dcd34bc5e` at 2026-08-28T06:59:25Z. The repository watcher returned `GREEN`, with zero pending checks. Native review artifacts validated, and `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 131601` passed hosted gates without changing the patch or rebasing it.

Review disposition: the independent Codex autoreview has no accepted/actionable P0 findings on the same bytes, alongside the parent manual owner/caller/test review. The latest [ClawSweeper comment](https://github.com/openclaw/openclaw/pull/131601#issuecomment-5449410807) is still a review-started placeholder as of this checkpoint; no findings or Rank-up moves have been published. This is not a claim of completed ClawSweeper review. Effective active main rules require the CI gate, not an independent approval; no bypass is requested. Offline proof limitations above remain unchanged.
