### PR TITLE
fix(cron): deliver late one-shot output with a lateness annotation instead of discarding it

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch-policy.stale-annotation.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch-policy.stale-annotation.test.ts
@@ -1,0 +1,47 @@
+// Lateness-annotation invariants for stale one-shot deliveries (#131491).
+import { expect, it } from "vitest";
+import {
+  getReplyPayloadMetadata,
+  setReplyPayloadMetadata,
+  type ReplyPayload,
+} from "../../auto-reply/reply-payload.js";
+import { prependStaleCronDeliveryNotice } from "./delivery-dispatch-policy.js";
+
+const NOTICE = "⏰ Late automation run: scheduled for X, started 240m late.";
+
+it("preserves WeakMap payload metadata on the annotated clone", async () => {
+  const report: ReplyPayload = { text: "Morning report." };
+  // Speech facts live in WeakMap metadata; a bare spread would drop them and
+  // downstream TTS would speak the visible text instead of the authored speech.
+  setReplyPayloadMetadata(report, { ttsExplicit: true });
+
+  const [annotated] = prependStaleCronDeliveryNotice([report], NOTICE);
+
+  expect(annotated?.text).toBe(`${NOTICE}\n\nMorning report.`);
+  expect(getReplyPayloadMetadata(annotated!)).toMatchObject({ ttsExplicit: true });
+});
+
+it("keeps linked fallback payloads equal to the annotated source", async () => {
+  const report: ReplyPayload = { text: "Morning report." };
+  // Channel batch normalizers (e.g. Telegram buttons) merge a metadata-only
+  // payload into its source only while payload.text, fallbackText.text, and
+  // the source text stay equal; a drifted trio sends an unannotated duplicate.
+  const buttons: ReplyPayload = {
+    text: "Morning report.",
+    fallbackText: { text: "Morning report.", replacesPayloadIndex: 0 },
+    channelData: { telegram: { buttons: [[{ text: "Open", url: "https://x" }]] } },
+  };
+
+  const [annotated, linked] = prependStaleCronDeliveryNotice([report, buttons], NOTICE);
+
+  const annotatedText = `${NOTICE}\n\nMorning report.`;
+  expect(annotated?.text).toBe(annotatedText);
+  expect(linked?.text).toBe(annotatedText);
+  expect(linked?.fallbackText).toEqual({ text: annotatedText, replacesPayloadIndex: 0 });
+});
+
+it("leads with the notice for media-only batches without touching payloads", async () => {
+  const media: ReplyPayload = { mediaUrls: ["https://example.com/a.png"] };
+  const result = prependStaleCronDeliveryNotice([media], NOTICE);
+  expect(result).toEqual([{ text: NOTICE }, media]);
+});

--- a/src/cron/isolated-agent/delivery-dispatch-policy.ts
+++ b/src/cron/isolated-agent/delivery-dispatch-policy.ts
@@ -190,23 +190,66 @@ export function logCronDeliveryErrorDeferred(message: string): void {
   });
 }
 
-export function resolveCronDeliveryScheduledAtMs(params: {
-  job: CronJob;
-  runStartedAt: number;
-}): number {
+function resolveCronDeliveryScheduledAtMs(params: { job: CronJob; runStartedAt: number }): number {
   const scheduledAt = params.job.state?.nextRunAtMs;
   return hasScheduledNextRunAtMs(scheduledAt) ? scheduledAt : params.runStartedAt;
 }
 
-export function resolveCronDeliveryStartDelayMs(params: {
-  job: CronJob;
-  runStartedAt: number;
-}): number {
+function resolveCronDeliveryStartDelayMs(params: { job: CronJob; runStartedAt: number }): number {
   return params.runStartedAt - resolveCronDeliveryScheduledAtMs(params);
 }
 
-export function isStaleCronDelivery(params: { job: CronJob; runStartedAt: number }): boolean {
+function isStaleCronDelivery(params: { job: CronJob; runStartedAt: number }): boolean {
   return resolveCronDeliveryStartDelayMs(params) > STALE_CRON_DELIVERY_MAX_START_DELAY_MS;
+}
+
+/** Closed disposition for a delivery whose run started well past its schedule. */
+export type StaleCronDeliveryAction =
+  | { kind: "fresh" }
+  | { kind: "skip"; deliveryError: string; logMessage: string }
+  | { kind: "deliver-annotated"; notice: string; logMessage: string };
+
+/**
+ * Recurring schedules keep the stale skip: a newer run supersedes the delayed
+ * one, and delivering both would collide (#50092). Nothing supersedes a
+ * one-shot's output, so it delivers with a lateness annotation instead of
+ * being discarded as a false success (#131491).
+ */
+export function resolveStaleCronDeliveryAction(params: {
+  job: CronJob;
+  runStartedAt: number;
+}): StaleCronDeliveryAction {
+  if (!isStaleCronDelivery(params)) {
+    return { kind: "fresh" };
+  }
+  const scheduledAtMs = resolveCronDeliveryScheduledAtMs(params);
+  const scheduledAtIso = new Date(scheduledAtMs).toISOString();
+  const lateMinutes = Math.round(resolveCronDeliveryStartDelayMs(params) / 60_000);
+  const scheduleKind = params.job.schedule.kind;
+  if (scheduleKind !== "at" && scheduleKind !== "on-exit") {
+    const deliveryError = `skipping stale delivery scheduled at ${scheduledAtIso}, started ${lateMinutes}m late, current age ${Math.round((Date.now() - scheduledAtMs) / 60_000)}m`;
+    return { kind: "skip", deliveryError, logMessage: deliveryError };
+  }
+  return {
+    kind: "deliver-annotated",
+    notice: `⏰ Late automation run: scheduled for ${scheduledAtIso}, started ${lateMinutes}m late.`,
+    logMessage: `delivering stale run scheduled at ${scheduledAtIso}, started ${lateMinutes}m late`,
+  };
+}
+
+/** Prepends the lateness notice to the first text payload, or leads with it. */
+export function prependStaleCronDeliveryNotice(
+  payloads: ReplyPayload[],
+  notice: string,
+): ReplyPayload[] {
+  const firstTextIndex = payloads.findIndex((p) => p.text?.trim());
+  const firstTextPayload = payloads[firstTextIndex];
+  return firstTextIndex === -1 || !firstTextPayload
+    ? [{ text: notice }, ...payloads]
+    : payloads.with(firstTextIndex, {
+        ...firstTextPayload,
+        text: `${notice}\n\n${firstTextPayload.text}`,
+      });
 }
 
 export async function maybeApplyTtsToCronPayloads(params: {

--- a/src/cron/isolated-agent/delivery-dispatch-policy.ts
+++ b/src/cron/isolated-agent/delivery-dispatch-policy.ts
@@ -1,5 +1,5 @@
 /** Formatting, retry, and idempotency policy for direct cron delivery. */
-import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
+import { copyReplyPayloadMetadata, type ReplyPayload } from "../../auto-reply/reply-payload.js";
 import {
   SILENT_REPLY_TOKEN,
   startsWithSilentToken,
@@ -244,12 +244,30 @@ export function prependStaleCronDeliveryNotice(
 ): ReplyPayload[] {
   const firstTextIndex = payloads.findIndex((p) => p.text?.trim());
   const firstTextPayload = payloads[firstTextIndex];
-  return firstTextIndex === -1 || !firstTextPayload
-    ? [{ text: notice }, ...payloads]
-    : payloads.with(firstTextIndex, {
-        ...firstTextPayload,
-        text: `${notice}\n\n${firstTextPayload.text}`,
-      });
+  if (firstTextIndex === -1 || !firstTextPayload) {
+    // Media-only batches carry no fallbackText linkage (it needs a text
+    // source), so leading with the notice cannot break linked indices.
+    return [{ text: notice }, ...payloads];
+  }
+  const annotatedText = `${notice}\n\n${firstTextPayload.text}`;
+  return payloads.map((payload, index) => {
+    if (index === firstTextIndex) {
+      // Keep WeakMap speech/presentation facts on the annotated clone; TTS
+      // reads them immediately downstream (tagged mode skips synthesis, and
+      // always mode must speak the authored speech, not the notice).
+      return copyReplyPayloadMetadata(payload, { ...payload, text: annotatedText });
+    }
+    // Channel batch normalizers merge a metadata-only payload into its source
+    // only while payload.text, fallbackText.text, and the source text stay
+    // equal; annotating just the source would send an unannotated duplicate.
+    return payload.fallbackText?.replacesPayloadIndex === firstTextIndex
+      ? copyReplyPayloadMetadata(payload, {
+          ...payload,
+          text: annotatedText,
+          fallbackText: { ...payload.fallbackText, text: annotatedText },
+        })
+      : payload;
+  });
 }
 
 export async function maybeApplyTtsToCronPayloads(params: {

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -4287,12 +4287,24 @@ describe("dispatchCronDelivery — double-announce guard", () => {
   });
 
   describe("stale delivery (#131491)", () => {
-    it("delivers a late run with a lateness annotation instead of discarding it", async () => {
+    const setJobSchedule = (
+      params: Parameters<typeof dispatchCronDelivery>[0],
+      schedule: Record<string, unknown>,
+      nextRunAtMs: number,
+    ) => {
+      const job = params.job as { schedule?: unknown; state?: { nextRunAtMs?: number } };
+      job.schedule = schedule;
+      job.state = { nextRunAtMs };
+    };
+
+    it("delivers a late one-shot with a lateness annotation instead of discarding it", async () => {
       const runStartedAt = Date.now();
       const params = makeBaseParams({ synthesizedText: "lane results report", runStartedAt });
-      (params.job as { state?: { nextRunAtMs?: number } }).state = {
-        nextRunAtMs: runStartedAt - 4 * 60 * 60_000,
-      };
+      setJobSchedule(
+        params,
+        { kind: "at", at: new Date(runStartedAt - 4 * 60 * 60_000).toISOString() },
+        runStartedAt - 4 * 60 * 60_000,
+      );
 
       const state = await dispatchCronDelivery(params);
 
@@ -4305,12 +4317,27 @@ describe("dispatchCronDelivery — double-announce guard", () => {
       expect(state.deliveryError).toBeUndefined();
     });
 
-    it("does not annotate a run that starts within the staleness window", async () => {
+    it("keeps skipping stale recurring deliveries so a newer run supersedes them", async () => {
+      const runStartedAt = Date.now();
+      const params = makeBaseParams({ synthesizedText: "yesterday's briefing", runStartedAt });
+      setJobSchedule(params, { kind: "every", everyMs: 60_000 }, runStartedAt - 4 * 60 * 60_000);
+
+      const state = await dispatchCronDelivery(params);
+
+      expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+      expect(state.delivered).toBe(false);
+      expect(state.deliveryAttempted).toBe(true);
+      expect(state.deliveryError).toContain("skipping stale delivery");
+    });
+
+    it("does not annotate a one-shot that starts within the staleness window", async () => {
       const runStartedAt = Date.now();
       const params = makeBaseParams({ synthesizedText: "fresh report", runStartedAt });
-      (params.job as { state?: { nextRunAtMs?: number } }).state = {
-        nextRunAtMs: runStartedAt - 60_000,
-      };
+      setJobSchedule(
+        params,
+        { kind: "at", at: new Date(runStartedAt - 60_000).toISOString() },
+        runStartedAt - 60_000,
+      );
 
       const state = await dispatchCronDelivery(params);
 

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -2154,39 +2154,6 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     );
   });
 
-  it("retains a stale one-shot transcript without delivery or a fallback summary", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-18T17:00:00.000Z"));
-
-    const params = makeBaseParams({ synthesizedText: "Yesterday's morning briefing." });
-    params.agentSessionKey = "agent:main:cron:test-job";
-    params.job.deleteAfterRun = true;
-    params.beforeSessionDelete = vi.fn();
-    (params.job as { state?: { nextRunAtMs?: number } }).state = {
-      nextRunAtMs: Date.now() - (3 * 60 * 60_000 + 1),
-    };
-
-    const state = await dispatchCronDelivery(params);
-
-    const deliveryError = expect.stringContaining(
-      "scheduled at 2026-03-18T13:59:59.999Z, started 180m late",
-    );
-    expectResultFields(state.result, {
-      status: "ok",
-      delivered: false,
-      deliveryAttempted: true,
-      deliveryError,
-    });
-    expect(state.deliveryError).toEqual(deliveryError);
-    expect(deliverOutboundPayloads).not.toHaveBeenCalled();
-    expect(state.deliveryState.status).toBe("not-delivered");
-    expect(state.deliveryState.delivered).toBe(false);
-    expect(state.deliveryState.error).toEqual(deliveryError);
-    expect(state.deliveryState.deliverySuppressionReason).toBeUndefined();
-    expect(params.beforeSessionDelete).not.toHaveBeenCalled();
-    expect(callGateway).not.toHaveBeenCalled();
-  });
-
   it("still delivers when the run started on time but finished more than three hours later", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-18T17:00:00.000Z"));
@@ -4316,6 +4283,40 @@ describe("dispatchCronDelivery — double-announce guard", () => {
           expect.soft(result.deliveryError).toBeUndefined();
         }
       });
+    });
+  });
+
+  describe("stale delivery (#131491)", () => {
+    it("delivers a late run with a lateness annotation instead of discarding it", async () => {
+      const runStartedAt = Date.now();
+      const params = makeBaseParams({ synthesizedText: "lane results report", runStartedAt });
+      (params.job as { state?: { nextRunAtMs?: number } }).state = {
+        nextRunAtMs: runStartedAt - 4 * 60 * 60_000,
+      };
+
+      const state = await dispatchCronDelivery(params);
+
+      expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+      const payloads = outboundDeliveryCall(0).payloads as Array<{ text?: string }>;
+      expect(payloads[0]?.text).toMatch(/late/i);
+      expect(payloads[0]?.text).toContain("lane results report");
+      expect(state.delivered).toBe(true);
+      expect(state.deliveryAttempted).toBe(true);
+      expect(state.deliveryError).toBeUndefined();
+    });
+
+    it("does not annotate a run that starts within the staleness window", async () => {
+      const runStartedAt = Date.now();
+      const params = makeBaseParams({ synthesizedText: "fresh report", runStartedAt });
+      (params.job as { state?: { nextRunAtMs?: number } }).state = {
+        nextRunAtMs: runStartedAt - 60_000,
+      };
+
+      const state = await dispatchCronDelivery(params);
+
+      expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+      expectDeliveryCall(0, { payloads: [{ text: "fresh report" }] });
+      expect(state.delivered).toBe(true);
     });
   });
 });

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -243,15 +243,15 @@ export async function dispatchCronDelivery(
           ...params.telemetry,
         });
       }
+      // A late run still executed fully; discarding its deliverable recorded a
+      // false success and silently lost the operator's report (#131491).
+      // Deliver with an explicit lateness annotation instead — the guard's
+      // original anti-confusion goal (#50092) is met by labeling.
+      let staleAnnotatedPayloads = normalizedPayloads;
       if (
         params.deliveryRequested &&
-        isStaleCronDelivery({
-          job: params.job,
-          runStartedAt: params.runStartedAt,
-        })
+        isStaleCronDelivery({ job: params.job, runStartedAt: params.runStartedAt })
       ) {
-        deliveryAttempted = true;
-        const nowMs = Date.now();
         const scheduledAtMs = resolveCronDeliveryScheduledAtMs({
           job: params.job,
           runStartedAt: params.runStartedAt,
@@ -260,23 +260,26 @@ export async function dispatchCronDelivery(
           job: params.job,
           runStartedAt: params.runStartedAt,
         });
-        const deliveryError = `skipping stale delivery scheduled at ${new Date(scheduledAtMs).toISOString()}, started ${Math.round(startDelayMs / 60_000)}m late, current age ${Math.round((nowMs - scheduledAtMs) / 60_000)}m`;
-        recordDelivery("not-delivered", deliveryError);
-        await logCronDeliveryWarn(`[cron:${params.job.id}] ${deliveryError}`);
-        return params.withRunSession({
-          status: "ok",
-          summary,
-          outputText,
-          deliveryAttempted,
-          delivered: false,
-          deliveryError,
-          ...params.telemetry,
-        });
+        const scheduledAtIso = new Date(scheduledAtMs).toISOString();
+        const lateMinutes = Math.round(startDelayMs / 60_000);
+        const notice = `⏰ Late automation run: scheduled for ${scheduledAtIso}, started ${lateMinutes}m late.`;
+        await logCronDeliveryWarn(
+          `[cron:${params.job.id}] delivering stale run scheduled at ${scheduledAtIso}, started ${lateMinutes}m late`,
+        );
+        const firstTextIndex = normalizedPayloads.findIndex((p) => p.text?.trim());
+        const firstTextPayload = normalizedPayloads[firstTextIndex];
+        staleAnnotatedPayloads =
+          firstTextIndex === -1 || !firstTextPayload
+            ? [{ text: notice }, ...normalizedPayloads]
+            : normalizedPayloads.with(firstTextIndex, {
+                ...firstTextPayload,
+                text: `${notice}\n\n${firstTextPayload.text}`,
+              });
       }
       const payloadsForDelivery = (
         await maybeApplyTtsToCronPayloads({
           cfg: params.cfgWithAgentDefaults,
-          payloads: normalizedPayloads,
+          payloads: staleAnnotatedPayloads,
           delivery,
           agentId: params.agentId,
           ttsAuto: params.ttsAuto,

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -41,16 +41,15 @@ import {
   buildDirectCronDeliveryIdempotencyKey,
   DIRECT_CRON_DELIVERY_COMPLETION_RETENTION,
   isCompletedDirectCronDelivery,
-  isStaleCronDelivery,
   logCronDeliveryError,
   logCronDeliveryErrorDeferred,
   logCronDeliveryWarn,
   maybeApplyTtsToCronPayloads,
   normalizeSilentReplyText,
+  prependStaleCronDeliveryNotice,
   resolveCronDeliveryBestEffort,
-  resolveCronDeliveryScheduledAtMs,
   resolveDescendantSubagentFollowup,
-  resolveCronDeliveryStartDelayMs,
+  resolveStaleCronDeliveryAction,
   retryTransientDirectCronDelivery,
   waitForCompletedDirectCronDelivery,
 } from "./delivery-dispatch-policy.js";
@@ -243,38 +242,31 @@ export async function dispatchCronDelivery(
           ...params.telemetry,
         });
       }
-      // A late run still executed fully; discarding its deliverable recorded a
-      // false success and silently lost the operator's report (#131491).
-      // Deliver with an explicit lateness annotation instead — the guard's
-      // original anti-confusion goal (#50092) is met by labeling.
       let staleAnnotatedPayloads = normalizedPayloads;
-      if (
-        params.deliveryRequested &&
-        isStaleCronDelivery({ job: params.job, runStartedAt: params.runStartedAt })
-      ) {
-        const scheduledAtMs = resolveCronDeliveryScheduledAtMs({
-          job: params.job,
-          runStartedAt: params.runStartedAt,
+      const staleAction = params.deliveryRequested
+        ? resolveStaleCronDeliveryAction({ job: params.job, runStartedAt: params.runStartedAt })
+        : ({ kind: "fresh" } as const);
+      if (staleAction.kind !== "fresh") {
+        await logCronDeliveryWarn(`[cron:${params.job.id}] ${staleAction.logMessage}`);
+      }
+      if (staleAction.kind === "skip") {
+        deliveryAttempted = true;
+        recordDelivery("not-delivered", staleAction.deliveryError);
+        return params.withRunSession({
+          status: "ok",
+          summary,
+          outputText,
+          deliveryAttempted,
+          delivered: false,
+          deliveryError: staleAction.deliveryError,
+          ...params.telemetry,
         });
-        const startDelayMs = resolveCronDeliveryStartDelayMs({
-          job: params.job,
-          runStartedAt: params.runStartedAt,
-        });
-        const scheduledAtIso = new Date(scheduledAtMs).toISOString();
-        const lateMinutes = Math.round(startDelayMs / 60_000);
-        const notice = `⏰ Late automation run: scheduled for ${scheduledAtIso}, started ${lateMinutes}m late.`;
-        await logCronDeliveryWarn(
-          `[cron:${params.job.id}] delivering stale run scheduled at ${scheduledAtIso}, started ${lateMinutes}m late`,
+      }
+      if (staleAction.kind === "deliver-annotated") {
+        staleAnnotatedPayloads = prependStaleCronDeliveryNotice(
+          normalizedPayloads,
+          staleAction.notice,
         );
-        const firstTextIndex = normalizedPayloads.findIndex((p) => p.text?.trim());
-        const firstTextPayload = normalizedPayloads[firstTextIndex];
-        staleAnnotatedPayloads =
-          firstTextIndex === -1 || !firstTextPayload
-            ? [{ text: notice }, ...normalizedPayloads]
-            : normalizedPayloads.with(firstTextIndex, {
-                ...firstTextPayload,
-                text: `${notice}\n\n${firstTextPayload.text}`,
-              });
       }
       const payloadsForDelivery = (
         await maybeApplyTtsToCronPayloads({


### PR DESCRIPTION
## What Problem This Solves

Fixes #131491. A one-shot `agentTurn` cron job that fires more than three hours after its scheduled time (gateway down, job re-enabled late, restart catch-up) **executes fully** — model turns, tool calls, real spend — and then the stale-delivery guard in `dispatchCronDelivery` drops its deliverable:

```
[cron:<jobId>] skipping stale delivery scheduled at ..., started 1076m late, current age 1083m
```

The report the job existed to produce silently never arrives. This is the second half of the data-loss chain the issue documents (the retry-classification half is #131490 / PR #131590).

## Why This Change Was Made

The guard (from #50092) exists to avoid confusing operators with hours-old messages delivered as if fresh. That anti-confusion goal is met by **labeling** the output, not by discarding it — the issue's first-listed acceptable resolution, and the one aligned with the repo's product doctrine (an action that silently produces nothing is the worst bug class; the guard turned a completed run's deliverable into exactly that).

The stale skip is replaced with an explicit lateness annotation prepended to the first text payload (or added as a leading payload when the run produced only media):

> ⏰ Late automation run: scheduled for 2026-08-27T02:13:00.000Z, started 1076m late.

Delivery then proceeds through the normal path, so real outcomes are recorded at their owners (delivered/not-delivered, custody receipts, transcript mirroring) per the delivery-outcome truthfulness work that just landed in #131228. The warn log remains, reworded to `delivering stale run ...`. `isStaleCronDelivery` and the 3-hour threshold are unchanged — only the consequence changes from discard to annotate.

## User Impact

Late-fired one-shots (`at`/`on-exit` — the common recovery scenario: re-enabling a job days later, or catch-up after downtime) deliver their report with a clear "late" label instead of recording success while the operator receives nothing. Recurring jobs (`cron`/`every`/`stream`) are unchanged: their stale output stays suppressed with the recorded skip, because a newer run supersedes the delayed one and delivering both is the collision #50092 exists to prevent.

## Evidence

- New regression tests in `src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts` (`stale delivery (#131491)` block): a run with `state.nextRunAtMs` 4h in the past delivers exactly once with the lateness annotation prepended and the original report retained (`delivered: true`, no `deliveryError`); a run 1m late delivers unannotated. The delivering test fails on pre-fix code (`deliverOutboundPayloads` never called).
- The test asserting the old discard behavior (`skips stale cron deliveries while still suppressing fallback main summary`) is deleted per repo test doctrine; its surviving intent — no fallback main-session summary, `deliveryAttempted: true` — is covered by the new tests. The sibling `still delivers when the run started on time but finished more than three hours later` passes unchanged (the guard keys on start delay, not duration).
- Targeted runs: `delivery-dispatch.double-announce` (160/160), `isolated-agent.delivery-awareness` + `cron-delivery-outcomes.e2e` (171 total), full `src/cron/isolated-agent` directory (43 files, 678/678).
- `node scripts/check-changed.mjs` clean (format, oxlint incl. no-map-spread, tsgo core + test shards, import cycles, boundary guards).


### Recurring-scope fix (review finding)

Commit `47d4630aa8f` addresses the P1 review finding: annotated delivery is now scoped to one-shot schedules (`at`/`on-exit`) via a closed `StaleCronDeliveryAction` disposition in `delivery-dispatch-policy.ts`. Recurring `cron`/`every`/`stream` jobs keep the recorded stale skip — a newer run supersedes the delayed one, and delivering both is the collision #50092 suppressed. New regression case `keeps skipping stale recurring deliveries so a newer run supersedes them` covers the recurring path with an explicit `every` schedule on the fixture.

### Real behavior proof (mock-gateway harness)

Mock channel API (qa-channel synthetic bus via `openclaw qa ui`) + mock provider (`openclaw qa mock-openai`) + ephemeral gateway (isolated `OPENCLAW_STATE_DIR`, own port 45890, dist built from this PR head `47d4630aa8f`, config generated by qa-lab's `buildQaGatewayConfig`, provider mode `mock-openai`).

Scenario (the issue's exact recovery chain): a one-shot `agentTurn` job with announce delivery to `qa-channel:dm:qa-operator` was created, disabled, backdated 4 hours (schedule `at` + `state.nextRunAtMs`) with the gateway stopped, then re-enabled against a running gateway — `cron enable` fired it immediately with the original past schedule time, a 240-minute start delay (past the 3h staleness threshold).

```json
{
  "harness": "qa-channel bus + qa mock-openai + ephemeral gateway (port 45890)",
  "branchHead": "47d4630aa8f",
  "gatewayLog": "[cron:b4447d1e-...] delivering stale run scheduled at 2026-08-29T00:54:12.093Z, started 240m late",
  "channelMessageDelivered": "⏰ Late automation run: scheduled for 2026-08-29T00:54:12.093Z, started 240m late.\n\nQA-LATE-REENABLE-PROOF-OK overnight investigation report",
  "jobState": { "lastRunStatus": "ok", "lastDelivered": true, "lastDeliveryStatus": "delivered" },
  "verdict": "pass"
}
```

Observed operator-visible outcome: the late one-shot's report reached the real channel with the lateness annotation prepended and the delivery recorded as delivered — on current `main` this exact run logs `skipping stale delivery ...` and the operator receives nothing. (A startup catch-up variant of the same scenario was also exercised; catch-up re-arms `nextRunAtMs` near now, so the re-enable chain above is the path that actually reproduces the issue's stale fire, matching the reporter's sequence.)

