### PR TITLE
perf(tasks): skip non-blocker history during restart inspection

### DIFF
--- a/src/tasks/task-registry-query.ts
+++ b/src/tasks/task-registry-query.ts
@@ -152,9 +152,10 @@ export function listTaskRecordPage(params: {
   };
 }
 
-export function listTaskRecords(): TaskRecord[] {
+export function listTaskRecords(filter?: (task: Readonly<TaskRecord>) => boolean): TaskRecord[] {
   ensureTaskRegistryReady();
-  return [...tasks.values()]
+  const records = [...tasks.values()];
+  return (filter ? records.filter(filter) : records)
     .map((task, insertionIndex) => Object.assign({}, cloneTaskRecord(task), { insertionIndex }))
     .toSorted(compareTasksNewestFirst)
     .map(({ insertionIndex: _, ...task }) => task);

--- a/src/tasks/task-registry.maintenance.issue-60299.test.ts
+++ b/src/tasks/task-registry.maintenance.issue-60299.test.ts
@@ -319,6 +319,8 @@ describe("task-registry maintenance issue #60299", () => {
       acpEntry: { sessionId: childSessionKey, updatedAt: Date.now() },
     });
 
+    expect(getInspectableActiveTaskRestartBlockers()).toEqual([]);
+    expectTaskStatus(currentTasks, task.taskId, "running");
     expectMaintenanceCounts(await runTaskRegistryMaintenance(), { reconciled: 1 });
     expectTaskStatus(currentTasks, task.taskId, "lost");
     expect(getInspectableActiveTaskRestartBlockers()).toHaveLength(0);
@@ -512,6 +514,8 @@ describe("task-registry maintenance issue #60299", () => {
       },
     });
 
+    expect(getInspectableActiveTaskRestartBlockers()).toEqual([]);
+    expectTaskStatus(currentTasks, task.taskId, "running");
     const reconciledTasks = reconcileInspectableTasks();
     expect(reconciledTasks).toHaveLength(1);
     expect(reconciledTasks[0]?.taskId).toBe(task.taskId);

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -828,12 +828,6 @@ export function inspectTasksReadOnly(): {
 
 configureTaskAuditTaskProvider(reconcileInspectableTasks);
 
-function isActiveTaskRestartBlockerStatus(
-  status: TaskStatus,
-): status is ActiveTaskRestartBlocker["status"] {
-  return status === "running";
-}
-
 function isTaskRestartBlocker(task: TaskRecord): task is TaskRecord & {
   status: ActiveTaskRestartBlocker["status"];
 } {
@@ -841,12 +835,16 @@ function isTaskRestartBlocker(task: TaskRecord): task is TaskRecord & {
   // work can survive a gateway restart and should not indefinitely block one.
   // Likewise, stale records that still say "running" but already have endedAt
   // are registry inconsistencies, not live restart blockers.
-  return isActiveTaskRestartBlockerStatus(task.status) && !task.endedAt;
+  return task.status === "running" && !task.endedAt;
 }
 
 export function getInspectableActiveTaskRestartBlockers(): ActiveTaskRestartBlocker[] {
+  taskRegistryMaintenanceRuntime.ensureTaskRegistryReady();
+  // Reconciliation can retire a blocker, never revive a non-blocker. Select first
+  // so frequent restart polls do not clone and sort retained terminal history.
+  const candidates = taskRegistryMaintenanceRuntime.listTaskRecords(isTaskRestartBlocker);
   const blockers: ActiveTaskRestartBlocker[] = [];
-  for (const task of reconcileInspectableTasks()) {
+  for (const task of reconcileTaskRecordsForOperatorInspection(candidates)) {
     if (!isTaskRestartBlocker(task)) {
       continue;
     }

--- a/src/tasks/task-registry.store.test.ts
+++ b/src/tasks/task-registry.store.test.ts
@@ -36,10 +36,15 @@ import {
   findTaskByRunId,
   getTaskById,
   listFreshTasksForOwnerKey,
+  listTaskRecords,
   markTaskTerminalById,
   reloadTaskRegistryFromStore,
   updateTaskNotifyPolicyById,
 } from "./task-registry.js";
+import {
+  getInspectableActiveTaskRestartBlockers,
+  resetTaskRegistryMaintenanceRuntimeForTests,
+} from "./task-registry.maintenance.js";
 import {
   configureTaskRegistryRuntime,
   type TaskRegistryObserverEvent,
@@ -189,6 +194,7 @@ describe("task-registry store runtime", () => {
     testState.applyEnv();
     resetTaskRegistryForTests({ persist: false });
     resetTaskFlowRegistryForTests({ persist: false });
+    resetTaskRegistryMaintenanceRuntimeForTests();
     loggingState.rawConsole = null;
     setLoggerOverride(null);
     resetLogger();
@@ -387,6 +393,61 @@ describe("task-registry store runtime", () => {
     expect(tasks.map((task) => task.taskId)).toEqual(["task-restored"]);
     expect(listTasksForOwnerKey).toHaveBeenCalledWith("agent:main:main");
     expect(loadSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not clone non-blocker details when inspecting restart blockers", () => {
+    const now = Date.now();
+    const active: TaskRecord = {
+      ...createStoredTask(),
+      runtime: "cli",
+      createdAt: now,
+      lastEventAt: now,
+      detail: ["active detail"],
+    };
+    const nonBlockerDetail = { history: "not needed for restart inspection" };
+    const storedTasks: TaskRecord[] = [
+      { ...active, taskId: "older", createdAt: now - 1_000 },
+      { ...active, taskId: "tie-first" },
+      ...(["queued", "succeeded", "failed", "timed_out", "cancelled", "lost"] as const).map(
+        (status) => Object.assign({}, active, { taskId: status, status, detail: nonBlockerDetail }),
+      ),
+      { ...active, taskId: "running-ended", endedAt: now, detail: nonBlockerDetail },
+      { ...active, taskId: "tie-last" },
+    ];
+    const saveSnapshot = vi.fn();
+    configureTaskRegistryRuntime({
+      store: {
+        loadSnapshot: () => ({
+          tasks: new Map(storedTasks.map((task) => [task.taskId, task])),
+          deliveryStates: new Map(),
+        }),
+        saveSnapshot,
+      },
+    });
+    // Restore before measuring: the hot query, not startup hydration, owns this assertion.
+    expect(getTaskById("older")?.taskId).toBe("older");
+    const clone = vi.spyOn(globalThis, "structuredClone");
+    try {
+      const blockers = getInspectableActiveTaskRestartBlockers();
+      expect(blockers.map((task) => task.taskId)).toEqual(["tie-last", "tie-first", "older"]);
+      expect(clone).not.toHaveBeenCalledWith(nonBlockerDetail);
+      blockers[0]!.title = "caller mutation";
+      expect(getInspectableActiveTaskRestartBlockers()[0]?.title).toBe(active.task);
+      expect(saveSnapshot).not.toHaveBeenCalled();
+    } finally {
+      clone.mockRestore();
+    }
+
+    const allTasks = listTaskRecords();
+    expect(allTasks).toHaveLength(storedTasks.length);
+    expect(allTasks[0]?.taskId).toBe("tie-last");
+    const returnedDetail = allTasks[0]?.detail;
+    expect(returnedDetail).toEqual(["active detail"]);
+    if (!Array.isArray(returnedDetail)) {
+      throw new Error("expected array task detail");
+    }
+    returnedDetail.push("caller mutation");
+    expect(listTaskRecords()[0]?.detail).toEqual(["active detail"]);
   });
 
   it("rejects invalid persisted task enum values", () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where restart inspection repeatedly copied and sorted retained task history even when those records could not block a restart. The synthetic regression selects three live blockers but, before this change, also clones detail objects from seven queued, terminal, or already-ended records.

## Why This Change Was Made

Apply the existing blocker predicate in the canonical in-memory task query before defensive copying and ordering. Reconcile the selected candidates afterward and retain the final blocker check: inspection may retire a running candidate, but it cannot revive an excluded non-blocker.

The public Plugin SDK `listTaskRecords()` wrapper remains zero-argument. This introduces no cache, index, schema, retention, configuration, or public API change. The query still scans the task map; the improvement removes unnecessary detail copies and sorting of non-blockers.

## User Impact

Restart inspection does less allocation and sorting as retained task history grows, while reporting the same live blockers in the same order. Reconciliation, expiry, cancellation, and returned-record isolation are preserved.

Release-note context: avoid cloning and sorting non-blocking task history during restart inspection.

## Evidence

AI-assisted, maintainer-requested bounded performance repair. All reproduction evidence uses synthetic records; no production state or live provider/channel calls are involved.

- **Red:** the new regression was run against the unchanged production implementation at `533319b6753f4367581a59dc26b9c6d2fd19d66d`. It failed because `structuredClone` received all seven non-blocker detail objects.
- **Green:** the same regression passes after selecting candidates before cloning. It also verifies creation-order ties, returned blocker isolation, and the unchanged full-list deep-copy behavior.
- Existing stale ACP and completed-cron cases now explicitly verify that blocker inspection reconciles the result without mutating the stored running record.
- **212 tests passed** across the three focused task-registry suites.
- Full scoped `check-changed` passed, including production/test typechecks, lint, formatting, dead exports, plugin boundaries, runtime import cycles, and schema/auth guards. `git diff --check` passed.
- Fresh isolated Codex autoreview reported no accepted/actionable blocking findings. Full unchanged reconciliation/types/callers and the public SDK wrapper were also inspected directly; the review bundle alone did not include all unchanged internals.
- **Production LOC:** +9/-10 (net -1). **Tests:** +65/-0.

Commands, run with Node 24.20.0:

```sh
node scripts/run-vitest.mjs src/tasks/task-registry.store.test.ts -t 'does not clone non-blocker details'
node scripts/run-vitest.mjs src/tasks/task-registry.store.test.ts src/tasks/task-registry.maintenance.issue-60299.test.ts src/tasks/task-registry.test.ts
node scripts/check-changed.mjs -- src/tasks/task-registry-query.ts src/tasks/task-registry.maintenance.ts src/tasks/task-registry.store.test.ts src/tasks/task-registry.maintenance.issue-60299.test.ts
git diff --check
```

### Main CI dependency

The PR head passed [CI run 33149662729](https://github.com/openclaw/openclaw/actions/runs/33149662729), but a subsequent cross-landing mismatch broke main in [run 33150343145](https://github.com/openclaw/openclaw/actions/runs/33150343145). #131545 (reload receipt ownership) made `startGatewayChannelFromActiveRegistry` private; #118157 (media-cap enforcement) subsequently added a test using the old import. The result was TS2459 in `check-test-types-core-3` and three matching runtime failures in `checks-node-compact-small-28`, also reproduced locally.

The main repair landed separately in #131627 (rollback manual-stop regression checks) as `871b18dff5039484e86c76d282699a8defcb1654`. Its [post-merge main CI run 33153759749](https://github.com/openclaw/openclaw/actions/runs/33153759749) passed. This performance PR retains its original four-file scope; the duplicate local test repair was withdrawn without publication rather than duplicating an active owner's work or bypassing red CI.
