### PR TITLE
fix(codex): persist every completed pre-steer assistant item in steering history

### DIFF
--- a/docs/plugins/codex-harness-runtime.md
+++ b/docs/plugins/codex-harness-runtime.md
@@ -340,6 +340,11 @@ default `messages.queue.mode: "steer"`, OpenClaw batches steer-mode chat
 messages for the configured quiet window and sends them as one `turn/steer`
 request in arrival order.
 
+When Codex confirms consumption, OpenClaw saves completed visible assistant
+items before the steered user message, including items before a tool or sleep
+handoff. Each item keeps its own identity so later steers do not duplicate it.
+This history prefix is separate from the turn's final-answer selection.
+
 Codex review and manual compaction turns can reject same-turn steering. In
 that case, OpenClaw waits for the active run to finish before starting the
 prompt. Use `/queue followup` or `/queue collect` when messages should queue

--- a/extensions/codex/src/app-server/event-projector-assistant.ts
+++ b/extensions/codex/src/app-server/event-projector-assistant.ts
@@ -410,6 +410,7 @@ export class CodexAssistantProjection {
 
   collectCompletedAssistantMessages(
     completedItemIds: ReadonlySet<string>,
+    options: AssistantMessageOptions,
   ): Array<{ itemId: string; message: AssistantMessage }> {
     // Steering history covers visible completed items even across final-answer
     // handoffs. Mirror identities deduplicate them across subsequent steers.
@@ -424,20 +425,9 @@ export class CodexAssistantProjection {
       ) {
         return [];
       }
-      const message = this.createAssistantMessage(text, {
-        tokenUsage: undefined,
-        aborted: false,
-        promptError: undefined,
-      });
-      return [
-        {
-          itemId,
-          message: {
-            ...message,
-            timestamp: this.assistantTimestampByItem.get(itemId) ?? message.timestamp,
-          },
-        },
-      ];
+      const message = this.createAssistantMessage(text, options);
+      const timestamp = this.assistantTimestampByItem.get(itemId) ?? message.timestamp;
+      return [{ itemId, message: { ...message, timestamp } }];
     });
   }
 

--- a/extensions/codex/src/app-server/event-projector-assistant.ts
+++ b/extensions/codex/src/app-server/event-projector-assistant.ts
@@ -408,31 +408,37 @@ export class CodexAssistantProjection {
     });
   }
 
-  createCompletedAssistantBoundaryMessage(
+  collectCompletedAssistantMessages(
     completedItemIds: ReadonlySet<string>,
-    options: AssistantMessageOptions,
-  ): { itemId: string; message: AssistantMessage } | undefined {
-    const itemId = this.latestCompletedTerminalAssistantItemId;
-    const text = itemId ? this.assistantTextByItem.get(itemId)?.trim() : undefined;
-    const itemIndex = itemId ? this.assistantItemOrder.indexOf(itemId) : -1;
-    if (
-      !itemId ||
-      !completedItemIds.has(itemId) ||
-      itemIndex < this.persistableAssistantBarrier ||
-      !text ||
-      isSilentReplyPayloadText(text) ||
-      this.isToolProgressEchoText(itemId, text)
-    ) {
-      return undefined;
-    }
-    const message = this.createAssistantMessage(text, options);
-    return {
-      itemId,
-      message: {
-        ...message,
-        timestamp: this.assistantTimestampByItem.get(itemId) ?? message.timestamp,
-      },
-    };
+  ): Array<{ itemId: string; message: AssistantMessage }> {
+    // Steering history covers visible completed items even across final-answer
+    // handoffs. Mirror identities deduplicate them across subsequent steers.
+    return this.assistantItemOrder.flatMap((itemId) => {
+      const text = this.assistantTextByItem.get(itemId)?.trim();
+      if (
+        !completedItemIds.has(itemId) ||
+        this.isNonTerminalAssistantItem(itemId) ||
+        !text ||
+        isSilentReplyPayloadText(text) ||
+        this.isToolProgressEchoText(itemId, text)
+      ) {
+        return [];
+      }
+      const message = this.createAssistantMessage(text, {
+        tokenUsage: undefined,
+        aborted: false,
+        promptError: undefined,
+      });
+      return [
+        {
+          itemId,
+          message: {
+            ...message,
+            timestamp: this.assistantTimestampByItem.get(itemId) ?? message.timestamp,
+          },
+        },
+      ];
+    });
   }
 
   markAssistantBoundaryPersisted(itemId: string): void {

--- a/extensions/codex/src/app-server/event-projector-snapshot.test.ts
+++ b/extensions/codex/src/app-server/event-projector-snapshot.test.ts
@@ -5,6 +5,16 @@ import type {
 import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it } from "vitest";
 import { buildCodexMessagesSnapshot } from "./event-projector-snapshot.js";
+import {
+  buildEmptyToolTelemetry,
+  createProjector,
+  forCurrentTurn,
+  registerCodexEventProjectorTestLifecycle,
+  turnCompleted,
+} from "./event-projector.test-harness.js";
+import { readMirrorIdentity } from "./upstream-prompt-provenance.js";
+
+registerCodexEventProjectorTestLifecycle();
 
 function buildSnapshot(trigger: EmbeddedRunAttemptParams["trigger"]): AgentMessage[] {
   return buildCodexMessagesSnapshot({
@@ -58,5 +68,51 @@ describe("buildCodexMessagesSnapshot", () => {
     expect(messages.every((message) => (message as { display?: boolean }).display !== false)).toBe(
       true,
     );
+  });
+
+  it("retains distinct completed item identities across steers without replaying the terminal answer", async () => {
+    const projector = await createProjector();
+    for (const id of ["answer-a", "answer-b"]) {
+      await projector.handleNotification(
+        forCurrentTurn("item/completed", {
+          item: { type: "agentMessage", id, phase: "final_answer", text: "Same answer." },
+        }),
+      );
+    }
+    const sleep = { type: "sleep", id: "sleep", durationMs: 250 };
+    await projector.handleNotification(forCurrentTurn("item/started", { item: sleep }));
+    const pending = { type: "agentMessage", id: "pending", phase: "final_answer", text: "" };
+    await projector.handleNotification(forCurrentTurn("item/started", { item: pending }));
+    await projector.handleNotification(
+      forCurrentTurn("item/agentMessage/delta", {
+        itemId: pending.id,
+        delta: "Still writing.",
+      }),
+    );
+
+    const prefix = projector.buildSteeringTranscriptPrefix();
+    expect(prefix.map(readMirrorIdentity)).toEqual([
+      "turn-1:assistant:answer-a",
+      "turn-1:assistant:answer-b",
+    ]);
+    expect(prefix).toMatchObject([
+      { role: "assistant", content: [{ type: "text", text: "Same answer." }] },
+      { role: "assistant", content: [{ type: "text", text: "Same answer." }] },
+    ]);
+    projector.markSteeringTranscriptPersisted();
+    expect(projector.buildSteeringTranscriptPrefix()).toEqual(prefix);
+
+    // A late completion for the same handoff must not invalidate the later answer.
+    await projector.handleNotification(forCurrentTurn("item/completed", { item: sleep }));
+    const completed = { ...pending, text: "Still writing." };
+    await projector.handleNotification(forCurrentTurn("item/completed", { item: completed }));
+    expect(projector.buildSteeringTranscriptPrefix().map(readMirrorIdentity)).toEqual([
+      "turn-1:assistant:answer-a",
+      "turn-1:assistant:answer-b",
+      "turn-1:assistant:pending",
+    ]);
+    projector.markSteeringTranscriptPersisted();
+    await projector.handleNotification(turnCompleted([completed]));
+    expect(projector.buildResult(buildEmptyToolTelemetry()).assistantTexts).toEqual([]);
   });
 });

--- a/extensions/codex/src/app-server/event-projector-snapshot.ts
+++ b/extensions/codex/src/app-server/event-projector-snapshot.ts
@@ -17,9 +17,9 @@ export function buildCodexMessagesSnapshot(params: {
   reasoningText: string | undefined;
   asyncMessages: ReadonlyArray<{ itemId: string; message: AssistantMessage }>;
   commentaryMessages: ReadonlyArray<{ itemId: string; message: AssistantMessage }>;
+  assistantMessages?: ReadonlyArray<{ itemId: string; message: AssistantMessage }>;
   toolMessages: readonly AgentMessage[];
   lastAssistant: AssistantMessage | undefined;
-  lastAssistantIdentity?: string;
   createAssistantMirrorMessage: (title: string, text: string) => AssistantMessage;
 }): AgentMessage[] {
   const messages = promptSnapshot(params.runParams, params.turnId, params.upstreamUserText);
@@ -43,6 +43,9 @@ export function buildCodexMessagesSnapshot(params: {
   const visibleWorkMessages = [
     ...commentaryMessages,
     ...asyncMessages,
+    ...(params.assistantMessages ?? []).map(({ itemId, message }) =>
+      attachCodexMirrorIdentity(message, `${params.turnId}:assistant:${itemId}`),
+    ),
     ...params.toolMessages,
   ].toSorted(
     (left, right) =>
@@ -50,12 +53,7 @@ export function buildCodexMessagesSnapshot(params: {
   );
   messages.push(...visibleWorkMessages);
   if (params.lastAssistant) {
-    messages.push(
-      attachCodexMirrorIdentity(
-        params.lastAssistant,
-        params.lastAssistantIdentity ?? `${params.turnId}:assistant`,
-      ),
-    );
+    messages.push(attachCodexMirrorIdentity(params.lastAssistant, `${params.turnId}:assistant`));
   }
   const taint = { tainted: false };
   return messages.map((message) =>
@@ -80,9 +78,8 @@ export function buildCodexSteeringMessagesSnapshot(params: {
   const commentaryMessages = params.assistantProjection
     .collectCommentaryMessages()
     .filter(({ itemId }) => params.completedItemIds.has(itemId));
-  const assistantBoundary = params.assistantProjection.createCompletedAssistantBoundaryMessage(
+  const assistantMessages = params.assistantProjection.collectCompletedAssistantMessages(
     params.completedItemIds,
-    { tokenUsage: undefined, aborted: false, promptError: undefined },
   );
   const messages = buildCodexMessagesSnapshot({
     runParams: params.runParams,
@@ -91,16 +88,14 @@ export function buildCodexSteeringMessagesSnapshot(params: {
     reasoningText: undefined,
     asyncMessages,
     commentaryMessages,
+    assistantMessages,
     toolMessages: params.toolMessages,
-    lastAssistant: assistantBoundary?.message,
-    ...(assistantBoundary
-      ? { lastAssistantIdentity: `${params.turnId}:assistant:${assistantBoundary.itemId}` }
-      : {}),
+    lastAssistant: undefined,
     createAssistantMirrorMessage: (title, text) =>
       params.assistantProjection.createAssistantMirrorMessage(title, text),
   }).filter((message) => message.role !== "user");
   return {
     messages,
-    ...(assistantBoundary ? { assistantBoundaryItemId: assistantBoundary.itemId } : {}),
+    assistantBoundaryItemId: assistantMessages.at(-1)?.itemId,
   };
 }

--- a/extensions/codex/src/app-server/event-projector-snapshot.ts
+++ b/extensions/codex/src/app-server/event-projector-snapshot.ts
@@ -80,6 +80,7 @@ export function buildCodexSteeringMessagesSnapshot(params: {
     .filter(({ itemId }) => params.completedItemIds.has(itemId));
   const assistantMessages = params.assistantProjection.collectCompletedAssistantMessages(
     params.completedItemIds,
+    { tokenUsage: undefined, aborted: false, promptError: undefined },
   );
   const messages = buildCodexMessagesSnapshot({
     runParams: params.runParams,

--- a/extensions/codex/src/app-server/run-attempt.steering.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.steering.test.ts
@@ -9,7 +9,7 @@ import {
 import { describe, expect, it, vi } from "vitest";
 import type { CodexSteeringQueueOptions } from "./attempt-steering.js";
 import { readAttemptTerminal } from "./attempt-terminal.test-helper.js";
-import type { CodexServerNotification } from "./protocol.js";
+import type { CodexServerNotification, JsonObject } from "./protocol.js";
 import {
   createParams,
   createStartedThreadHarness,
@@ -197,147 +197,216 @@ describe("runCodexAppServerAttempt steering", () => {
     await run;
   });
 
-  it("accepts Gateway transcript-backed steering for the active Codex turn", async () => {
-    const { requests, waitForMethod, completeTurn, notify } = createStartedThreadHarness();
-    const params = createSteeringParams();
-    const storePath = path.join(tempDir, `${params.sessionId}.sqlite`);
-    const sessionTarget = {
-      agentId: "main",
-      sessionId: params.sessionId,
-      sessionKey: params.sessionKey!,
-      storePath,
-    };
-    params.taskSuggestionDeliveryMode = "gateway";
-    params.sessionTarget = sessionTarget;
-    await upsertSessionEntry({
-      agentId: "main",
-      sessionKey: params.sessionKey!,
-      storePath,
-      entry: {
-        sessionFile: params.sessionFile,
+  it.each(["none", "sleep", "dynamicToolCall", "commandExecution"])(
+    "persists every completed answer before Gateway steering across a %s barrier",
+    async (barrierType) => {
+      const { requests, waitForMethod, completeTurn, notify } = createStartedThreadHarness();
+      const params = createSteeringParams();
+      const storePath = path.join(tempDir, `${params.sessionId}.sqlite`);
+      const sessionTarget = {
+        agentId: "main",
         sessionId: params.sessionId,
-        updatedAt: Date.now(),
-      },
-    });
-    let steerPersisted = false;
-    const userTurnTranscriptRecorder = {
-      persistApproved: vi.fn(async () => {
-        if (steerPersisted) {
-          return undefined;
-        }
-        steerPersisted = true;
-        return await appendSessionTranscriptMessageByIdentity({
-          ...sessionTarget,
-          message: {
-            role: "user",
-            content: "steer this active turn",
-            timestamp: Date.now(),
-            idempotencyKey: `${params.runId}:steer:user`,
+        sessionKey: params.sessionKey!,
+        storePath,
+      };
+      params.taskSuggestionDeliveryMode = "gateway";
+      params.sessionTarget = sessionTarget;
+      await upsertSessionEntry({
+        agentId: "main",
+        sessionKey: params.sessionKey!,
+        storePath,
+        entry: {
+          sessionFile: params.sessionFile,
+          sessionId: params.sessionId,
+          updatedAt: Date.now(),
+        },
+      });
+      let steerPersisted = false;
+      const userTurnTranscriptRecorder = {
+        persistApproved: vi.fn(async () => {
+          if (steerPersisted) {
+            return undefined;
+          }
+          steerPersisted = true;
+          return await appendSessionTranscriptMessageByIdentity({
+            ...sessionTarget,
+            message: {
+              role: "user",
+              content: "steer this active turn",
+              timestamp: Date.now(),
+              idempotencyKey: `${params.runId}:steer:user`,
+            },
+          });
+        }),
+        hasPersisted: () => steerPersisted,
+      } as unknown as NonNullable<CodexSteeringQueueOptions["userTurnTranscriptRecorder"]>;
+
+      const run = runCodexAppServerAttempt(params, {
+        pluginConfig: { appServer: { mode: "yolo" } },
+      });
+      await waitForMethod("turn/start");
+      const onQueueAccepted = vi.fn();
+      await notify({
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            type: "agentMessage",
+            id: "pre-steer-commentary",
+            phase: "commentary",
+            text: "PRE-STEER-COMMENTARY",
+          },
+        },
+      });
+      for (const id of ["answer-a", "answer-b"]) {
+        await notify({
+          method: "item/started",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: { type: "agentMessage", id, phase: "final_answer", text: "" },
           },
         });
-      }),
-      hasPersisted: () => steerPersisted,
-    } as unknown as NonNullable<CodexSteeringQueueOptions["userTurnTranscriptRecorder"]>;
+        await notify({
+          method: "item/agentMessage/delta",
+          params: { threadId: "thread-1", turnId: "turn-1", itemId: id, delta: id },
+        });
+        await notify({
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: { type: "agentMessage", id, phase: "final_answer", text: id },
+          },
+        });
+      }
+      if (barrierType !== "none") {
+        const barrier: JsonObject =
+          barrierType === "commandExecution"
+            ? {
+                type: barrierType,
+                id: "barrier",
+                command: "true",
+                cwd: params.workspaceDir,
+                status: "inProgress",
+                commandActions: [],
+              }
+            : barrierType === "dynamicToolCall"
+              ? { type: barrierType, id: "barrier", tool: "memory_search", status: "inProgress" }
+              : { type: barrierType, id: "barrier", durationMs: 250 };
+        await notify({
+          method: "item/started",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: barrier,
+          },
+        });
+      }
 
-    const run = runCodexAppServerAttempt(params, {
-      pluginConfig: { appServer: { mode: "yolo" } },
-    });
-    await waitForMethod("turn/start");
-    const onQueueAccepted = vi.fn();
-    await notify({
-      method: "item/completed",
-      params: {
+      await vi.waitFor(() => {
+        expect(
+          activeRunRegistrationMocks.setActiveEmbeddedRun.mock.calls.findLast(
+            (call) => call[0] === params.sessionId,
+          )?.[1],
+        ).toMatchObject({ taskSuggestionDeliveryMode: "gateway" });
+      }, fastWait);
+
+      // This public queue returns immediate eligibility; the handle's delivery
+      // promise stays pending until the matching item/completed notification below.
+      await waitAndQueueActiveRunMessage(params.sessionId, "steer this active turn", {
+        debounceMs: 0,
+        isInboundUserMessage: true,
+        toolAuthorityFingerprint: params.toolAuthorityFingerprint,
+        taskSuggestionDeliveryMode: "gateway",
+        waitForTranscriptCommit: true,
+        onQueueAccepted,
+        userTurnTranscriptRecorder,
+      });
+      await vi.waitFor(
+        () => expect(requests.map((entry) => entry.method)).toContain("turn/steer"),
+        fastWait,
+      );
+      const steer = requests.find((entry) => entry.method === "turn/steer");
+      const clientUserMessageId = (steer?.params as { clientUserMessageId?: string } | undefined)
+        ?.clientUserMessageId;
+      if (!clientUserMessageId) {
+        throw new Error("turn/steer clientUserMessageId missing");
+      }
+      await vi.waitFor(() => expect(onQueueAccepted).toHaveBeenCalledWith(true), fastWait);
+
+      await notify({
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: { id: "steered-user-message", type: "userMessage", clientId: clientUserMessageId },
+        },
+      });
+      const readTextRows = async () =>
+        (await readSessionTranscriptEvents(sessionTarget)).flatMap((event) => {
+          const message = (
+            event as {
+              message?: {
+                role: string;
+                content: string | Array<{ type: string; text?: string }>;
+                __openclaw?: { mirrorIdentity?: string };
+              };
+            }
+          ).message;
+          if (!message || (message.role !== "assistant" && message.role !== "user")) {
+            return [];
+          }
+          const text =
+            typeof message.content === "string"
+              ? message.content
+              : message.content
+                  .flatMap((part) => (part.type === "text" ? [part.text] : []))
+                  .join("");
+          return text
+            ? [{ role: message.role, text, mirrorIdentity: message["__openclaw"]?.mirrorIdentity }]
+            : [];
+        });
+      const prefix = await readTextRows();
+      await notify({
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            type: "agentMessage",
+            id: "final-answer",
+            phase: "final_answer",
+            text: "Steering completed.",
+          },
+        },
+      });
+      await completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+      await run;
+
+      expect(steer?.params).toMatchObject({
         threadId: "thread-1",
-        turnId: "turn-1",
-        item: {
-          type: "agentMessage",
-          id: "pre-steer-commentary",
-          phase: "commentary",
+        expectedTurnId: "turn-1",
+        input: [{ type: "text", text: "steer this active turn" }],
+      });
+      expect(prefix).toEqual([
+        { role: "user", text: params.prompt, mirrorIdentity: "turn-1:prompt" },
+        {
+          role: "assistant",
           text: "PRE-STEER-COMMENTARY",
+          mirrorIdentity: "turn-1:commentary:pre-steer-commentary",
         },
-      },
-    });
-    await notify({
-      method: "item/completed",
-      params: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        item: {
-          type: "agentMessage",
-          id: "pre-steer-answer",
-          phase: "final_answer",
-          text: "PRE-STEER-ANSWER",
-        },
-      },
-    });
-
-    await vi.waitFor(() => {
-      expect(
-        activeRunRegistrationMocks.setActiveEmbeddedRun.mock.calls.findLast(
-          (call) => call[0] === params.sessionId,
-        )?.[1],
-      ).toMatchObject({ taskSuggestionDeliveryMode: "gateway" });
-    }, fastWait);
-
-    // This public queue returns immediate eligibility; the handle's delivery
-    // promise stays pending until the matching item/completed notification below.
-    await waitAndQueueActiveRunMessage(params.sessionId, "steer this active turn", {
-      debounceMs: 0,
-      isInboundUserMessage: true,
-      toolAuthorityFingerprint: params.toolAuthorityFingerprint,
-      taskSuggestionDeliveryMode: "gateway",
-      waitForTranscriptCommit: true,
-      onQueueAccepted,
-      userTurnTranscriptRecorder,
-    });
-    await vi.waitFor(
-      () => expect(requests.map((entry) => entry.method)).toContain("turn/steer"),
-      fastWait,
-    );
-    const steer = requests.find((entry) => entry.method === "turn/steer");
-    const clientUserMessageId = (steer?.params as { clientUserMessageId?: string } | undefined)
-      ?.clientUserMessageId;
-    if (!clientUserMessageId) {
-      throw new Error("turn/steer clientUserMessageId missing");
-    }
-    await vi.waitFor(() => expect(onQueueAccepted).toHaveBeenCalledWith(true), fastWait);
-
-    await notify({
-      method: "item/completed",
-      params: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        item: { id: "steered-user-message", type: "userMessage", clientId: clientUserMessageId },
-      },
-    });
-    await userTurnTranscriptRecorder.persistApproved();
-    await notify({
-      method: "item/completed",
-      params: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        item: {
-          type: "agentMessage",
-          id: "final-answer",
-          phase: "final_answer",
-          text: "Steering completed.",
-        },
-      },
-    });
-    await completeTurn({ threadId: "thread-1", turnId: "turn-1" });
-    await run;
-
-    expect(steer?.params).toMatchObject({
-      threadId: "thread-1",
-      expectedTurnId: "turn-1",
-      input: [{ type: "text", text: "steer this active turn" }],
-    });
-    const roles = (await readSessionTranscriptEvents(sessionTarget)).flatMap((event) => {
-      const message = (event as { message?: { role?: string } }).message;
-      return message?.role ? [message.role] : [];
-    });
-    expect(roles).toEqual(["user", "assistant", "assistant", "user", "assistant"]);
-  });
+        { role: "assistant", text: "answer-a", mirrorIdentity: "turn-1:assistant:answer-a" },
+        { role: "assistant", text: "answer-b", mirrorIdentity: "turn-1:assistant:answer-b" },
+        { role: "user", text: "steer this active turn", mirrorIdentity: undefined },
+      ]);
+      expect(await readTextRows()).toEqual([
+        ...prefix,
+        { role: "assistant", text: "Steering completed.", mirrorIdentity: "turn-1:assistant" },
+      ]);
+    },
+  );
 
   it("forwards queued text and images to the active app-server turn", async () => {
     const { requests, waitForMethod, completeTurn, notify } = createStartedThreadHarness();

--- a/ui/src/pages/chat/chat-history.inflight.test.ts
+++ b/ui/src/pages/chat/chat-history.inflight.test.ts
@@ -517,6 +517,106 @@ describe("chat history in-flight assistant recovery", () => {
     },
   );
 
+  it.each(["fresh adoption", "retained boundary", "fragmented history"])(
+    "keeps every item of the cumulative prefix after persisted history replacement: %s",
+    async (mode) => {
+      const history = activeHistory("active-run");
+      const savedTexts =
+        mode === "fragmented history" ? ["Before tool.", "Before steer."] : ["Before steer."];
+      const prefixText = savedTexts.join("");
+      const original = {
+        role: "user",
+        content: "Original prompt",
+        timestamp: 1,
+        __openclaw: { idempotencyKey: "active-run:user", seq: 1 },
+      };
+      const steer = {
+        role: "user",
+        content: "Steer prompt",
+        timestamp: savedTexts.length + 2,
+        __openclaw: {
+          id: "steer",
+          idempotencyKey: "steer-run:user",
+          seq: savedTexts.length + 2,
+          steerTargetRunId: "active-run",
+        },
+      };
+      history.messages = [
+        original,
+        ...savedTexts.map((content, index) => ({
+          role: "assistant",
+          content,
+          timestamp: index + 2,
+          __openclaw: {
+            runId: "active-run",
+            mirrorIdentity: `turn-1:assistant:answer-${index}`,
+            seq: index + 2,
+          },
+        })),
+        steer,
+      ];
+      history.inFlightRun!.text = `${prefixText} After steer.`;
+      const state = createState(history);
+      if (mode === "retained boundary") {
+        state.chatRunId = "active-run";
+        state.chatMessages = [original, steer];
+        handleChatGatewayEvent(state, {
+          sessionKey: "main",
+          runId: "active-run",
+          state: "delta",
+          message: { role: "assistant", content: history.inFlightRun!.text },
+        });
+        state.chatStreamSegments = [
+          {
+            text: prefixText,
+            ts: 2,
+            runId: "active-run",
+            boundaryRunId: "steer-run",
+          },
+        ];
+      }
+      await loadChatHistory(state);
+      expect(renderedText(state)).toEqual([
+        "Original prompt",
+        ...savedTexts,
+        "Steer prompt",
+        "After steer.",
+      ]);
+      handleChatGatewayEvent(state, {
+        sessionKey: "main",
+        runId: "active-run",
+        state: "delta",
+        deltaText: " Continued.",
+        message: {
+          role: "assistant",
+          content: `${prefixText} After steer. Continued.`,
+        },
+      });
+      expect(renderedText(state)).toEqual([
+        "Original prompt",
+        ...savedTexts,
+        "Steer prompt",
+        "After steer. Continued.",
+      ]);
+      expect(state.chatStream).toBe(`${prefixText} After steer. Continued.`);
+      handleChatGatewayEvent(state, {
+        sessionKey: "main",
+        runId: "active-run",
+        state: "final",
+        message: {
+          role: "assistant",
+          content: `${prefixText} After steer. Continued. Final suffix.`,
+        },
+      });
+      expect(renderedText(state)).toEqual([
+        "Original prompt",
+        ...savedTexts,
+        "Steer prompt",
+        "After steer. Continued. Final suffix.",
+      ]);
+    },
+  );
+
   it.each([true, undefined])(
     "rolls over a live steer with optional active-run publication (runActive=%s)",
     async (runActive) => {

--- a/ui/src/pages/chat/chat-history.inflight.test.ts
+++ b/ui/src/pages/chat/chat-history.inflight.test.ts
@@ -413,13 +413,23 @@ describe("chat history in-flight assistant recovery", () => {
   });
 
   it.each(
-    ["fresh adoption", "retained boundary"].flatMap((mode) =>
-      ["single row", "split rows", "split rows with commentary"].map((rows) => ({ mode, rows })),
+    ["idempotency", "Codex mirror"].flatMap((identity) =>
+      ["fresh adoption", "retained boundary"].flatMap((mode) =>
+        ["single row", "split rows", "split rows with commentary"].map((rows) => ({
+          identity,
+          mode,
+          rows,
+        })),
+      ),
     ),
   )(
-    "keeps the cumulative prefix after persisted history replacement: $mode, $rows",
-    async ({ mode, rows }) => {
+    "keeps the cumulative prefix after persisted history replacement: $identity, $mode, $rows",
+    async ({ identity, mode, rows }) => {
       const history = activeHistory("active-run");
+      const assistantIdentity = (seq: number) =>
+        identity === "Codex mirror"
+          ? { runId: "active-run", mirrorIdentity: `turn-1:assistant:answer-${seq}`, seq }
+          : { idempotencyKey: "active-run", seq };
       const prefix = rows === "single row" ? "Before steer." : "Before tool.Before steer.";
       const original = {
         role: "user",
@@ -447,7 +457,7 @@ describe("chat history in-flight assistant recovery", () => {
                 role: "assistant",
                 content: "Before tool.",
                 timestamp: 2,
-                __openclaw: { idempotencyKey: "active-run", seq: 2 },
+                __openclaw: assistantIdentity(2),
               },
             ]),
         ...(rows === "split rows with commentary"
@@ -470,7 +480,7 @@ describe("chat history in-flight assistant recovery", () => {
           role: "assistant",
           content: "Before steer.",
           timestamp: 4,
-          __openclaw: { idempotencyKey: "active-run", seq: 4 },
+          __openclaw: assistantIdentity(4),
         },
         steer,
       ];
@@ -512,106 +522,6 @@ describe("chat history in-flight assistant recovery", () => {
       });
       expect(renderedText(state)).toEqual([
         ...persistedText,
-        "After steer. Continued. Final suffix.",
-      ]);
-    },
-  );
-
-  it.each(["fresh adoption", "retained boundary", "fragmented history"])(
-    "keeps every item of the cumulative prefix after persisted history replacement: %s",
-    async (mode) => {
-      const history = activeHistory("active-run");
-      const savedTexts =
-        mode === "fragmented history" ? ["Before tool.", "Before steer."] : ["Before steer."];
-      const prefixText = savedTexts.join("");
-      const original = {
-        role: "user",
-        content: "Original prompt",
-        timestamp: 1,
-        __openclaw: { idempotencyKey: "active-run:user", seq: 1 },
-      };
-      const steer = {
-        role: "user",
-        content: "Steer prompt",
-        timestamp: savedTexts.length + 2,
-        __openclaw: {
-          id: "steer",
-          idempotencyKey: "steer-run:user",
-          seq: savedTexts.length + 2,
-          steerTargetRunId: "active-run",
-        },
-      };
-      history.messages = [
-        original,
-        ...savedTexts.map((content, index) => ({
-          role: "assistant",
-          content,
-          timestamp: index + 2,
-          __openclaw: {
-            runId: "active-run",
-            mirrorIdentity: `turn-1:assistant:answer-${index}`,
-            seq: index + 2,
-          },
-        })),
-        steer,
-      ];
-      history.inFlightRun!.text = `${prefixText} After steer.`;
-      const state = createState(history);
-      if (mode === "retained boundary") {
-        state.chatRunId = "active-run";
-        state.chatMessages = [original, steer];
-        handleChatGatewayEvent(state, {
-          sessionKey: "main",
-          runId: "active-run",
-          state: "delta",
-          message: { role: "assistant", content: history.inFlightRun!.text },
-        });
-        state.chatStreamSegments = [
-          {
-            text: prefixText,
-            ts: 2,
-            runId: "active-run",
-            boundaryRunId: "steer-run",
-          },
-        ];
-      }
-      await loadChatHistory(state);
-      expect(renderedText(state)).toEqual([
-        "Original prompt",
-        ...savedTexts,
-        "Steer prompt",
-        "After steer.",
-      ]);
-      handleChatGatewayEvent(state, {
-        sessionKey: "main",
-        runId: "active-run",
-        state: "delta",
-        deltaText: " Continued.",
-        message: {
-          role: "assistant",
-          content: `${prefixText} After steer. Continued.`,
-        },
-      });
-      expect(renderedText(state)).toEqual([
-        "Original prompt",
-        ...savedTexts,
-        "Steer prompt",
-        "After steer. Continued.",
-      ]);
-      expect(state.chatStream).toBe(`${prefixText} After steer. Continued.`);
-      handleChatGatewayEvent(state, {
-        sessionKey: "main",
-        runId: "active-run",
-        state: "final",
-        message: {
-          role: "assistant",
-          content: `${prefixText} After steer. Continued. Final suffix.`,
-        },
-      });
-      expect(renderedText(state)).toEqual([
-        "Original prompt",
-        ...savedTexts,
-        "Steer prompt",
         "After steer. Continued. Final suffix.",
       ]);
     },


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #131550. When a steer is consumed after a tool/sleep barrier in the Codex runtime, the steering transcript prefix persisted only the *latest* eligible completed assistant item — earlier completed items behind the barrier were never written as durable rows, while the gateway run buffer retained their text. After a reload or history refresh, the UI's persisted-prefix subtraction could not cover that text, so already-seen pre-steer output re-rendered below the operator's steering message (the residual "Codex tool-barrier" case documented in #131550).

## Why This Change Was Made

The barrier exclusion in `createCompletedAssistantBoundaryMessage` exists for **final-answer selection** (introduced 2e806ef; steering reused it in ce08e259) — it decides which item becomes the terminal reply, not which items are durable steering history. Those are different concerns with different correct answers. The steering path now uses `collectCompletedAssistantMessages`: every completed, terminal-eligible, visible assistant item in chronological order, each carrying its mirror identity (`<turnId>:assistant:<itemId>`) so repeats across subsequent steers deduplicate. Final-answer candidate selection, its exclusion tests, terminal-result handling, and the gateway buffer projection are byte-for-byte unchanged.

## User Impact

Steering a Codex-runtime session after tool use no longer loses pre-steer assistant output from durable history: after reloads and history refreshes, everything the operator saw before the steer stays above their steering message.

## Evidence

- Four parameterized regressions in `run-attempt.steering.test.ts` fail on unchanged production (no barrier loses A; sleep, dynamic-tool, and native-tool barriers lose A and B) and pass with the fix; snapshot-identity coverage extended in `event-projector-snapshot.test.ts`; UI history recovery covered in `chat-history.inflight.test.ts`.
- `pnpm test extensions/codex`: 4,411 passed (185 files); UI history suites green; `node scripts/check-changed.mjs` exit 0; Codex autoreview clean (no P0).
- Production LOC +39/−38 (net **+1**); tests +295/−149; docs +5.

## Follow-ups (UI consumer, out of this producer-only scope; repros + owners in the investigation notes)

- `stream-reconciliation.ts` `hasAssistantStreamReplacement` tests a single row for full coverage, so a retained combined segment covered by several split persisted rows renders duplicated text (repro: retained-boundary case with `Before tool.Before steer.` vs two rows).
- `stream-causal-boundary.ts` `resolveCumulativeAssistantTail` stops prefix coverage at an interleaved commentary row (probe: rows A → commentary → B with cumulative ABC returns tail BC instead of C).
