### PR TITLE
fix(ci): isolate Windows managed handoff process probes

### DIFF
--- a/src/infra/update-managed-service-handoff-command.test.ts
+++ b/src/infra/update-managed-service-handoff-command.test.ts
@@ -9,6 +9,8 @@ import { parseDevUpdateTargetEnv, type DevUpdateTarget } from "./update-dev-targ
 import { signalMockManagedUpdateHandoffReady } from "./update-managed-service-handoff.test-support.js";
 
 const spawnMock = vi.hoisted(() => vi.fn());
+const getFileLockProcessStartTimeMock = vi.hoisted(() => vi.fn((_pid: number) => 17));
+const forceKillChildProcessTreeMock = vi.hoisted(() => vi.fn());
 const tempDirs = new Set<string>();
 const mockedHandoffLeaseCleanups = new Set<() => void>();
 const MOCK_INSTALL_ROOT = path.join(os.tmpdir(), `openclaw-handoff-command-${process.pid}`);
@@ -40,7 +42,20 @@ vi.mock("node:child_process", async () => {
   });
 });
 
+vi.mock("../shared/pid-alive.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../shared/pid-alive.js")>()),
+  getFileLockProcessStartTime: getFileLockProcessStartTimeMock,
+}));
+
+vi.mock("../process/child-process-tree.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../process/child-process-tree.js")>()),
+  forceKillChildProcessTree: forceKillChildProcessTreeMock,
+}));
+
 beforeEach(() => {
+  getFileLockProcessStartTimeMock.mockReset();
+  getFileLockProcessStartTimeMock.mockReturnValue(17);
+  forceKillChildProcessTreeMock.mockReset();
   spawnMock.mockReset();
   spawnMock.mockImplementation(createReadyChild);
 });
@@ -82,6 +97,7 @@ async function startHandoffAndReadCommand(params: {
     ...(params.devTarget ? { devTarget: params.devTarget } : {}),
     ...(params.env ? { env: params.env } : {}),
   });
+  expect(forceKillChildProcessTreeMock).not.toHaveBeenCalled();
   const spawnCall = spawnMock.mock.calls[0] as unknown as
     | [string, string[], { env?: NodeJS.ProcessEnv }]
     | undefined;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Windows CI managed-service handoff command test could fail before checking its serialization contract when the real PowerShell process-start probe returned no identity.

The observed failure was `managed update handoff process start identity is unavailable` in Windows job https://github.com/openclaw/openclaw/actions/runs/33145904885/job/98767003401. Cleanup then reached the test's broad spawn mock, which treated `taskkill` arguments as a handoff params path and emitted a secondary `ENOENT`.

## Why This Change Was Made

The command test now provides deterministic process-start identity and isolates the production process-tree cleanup boundary. Production remains fail-closed when a real handoff process identity is unavailable; the test asserts that cleanup is never reached during successful command serialization.

The existing tracked-target environment test remains the regression proof. No timeout, retry, production behavior, or process-identity policy changed.

## User Impact

No product runtime change. Windows CI can test managed handoff command serialization without depending on a real one-second PowerShell process probe.

Production LOC: **+0/-0**. Tests: **+16/-0**.

## Evidence

- Before: Windows job https://github.com/openclaw/openclaw/actions/runs/33145904885/job/98767003401 failed in `src/infra/update-managed-service-handoff-command.test.ts`.
- Root cause: strict parent/launcher identity checks in `src/infra/update-managed-service-handoff.ts` correctly fail closed, but this unit test supplied a fake child while retaining the real platform process-start probe.
- `node scripts/run-vitest.mjs src/infra/update-managed-service-handoff-command.test.ts` - 5/5 passed.
- Formatting, conflict-marker, assertion-safety, dependency, deprecation, plugin-boundary, wrapper, and package-patch changed-file gates passed.
- `git diff --check` passed.
- The changed-file dead-export stage could not resolve sparse-excluded Control UI files in the Codex worktree; no changed-file diagnostic was reported before that infrastructure stop.
- Mandatory autoreview was attempted twice and failed before review with Codex API HTTP 401. An independent read-only Sol audit and plan review found no production change necessary and approved this one-file test-harness repair.

Provenance: the strict identity checks and retained broad command-test mock converged in #128212 on August 24, 2026. This PR changes only the test boundary exposed by that Windows run.

AI-assisted: yes.
