### PR TITLE
fix(outbound): preserve delivery uncertainty across completion, custody, and routing

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3194,7 +3194,6 @@ src/infra/outbound/current-conversation-bindings.ts	1
 src/infra/outbound/deliver-channel.ts	4
 src/infra/outbound/deliver-payload.ts	1
 src/infra/outbound/deliver-prepare.ts	1
-src/infra/outbound/deliver-queue-execute.ts	2
 src/infra/outbound/deliver-queue-state.ts	1
 src/infra/outbound/delivery-queue-media-spool.ts	2
 src/infra/outbound/delivery-queue-media-staging.ts	2

--- a/docs/plugins/sdk-channel-outbound.md
+++ b/docs/plugins/sdk-channel-outbound.md
@@ -157,6 +157,12 @@ the aggregate receipt omits `threadId`. Channels with read receipts or
 device-delivery state should track those facts through a separate
 channel-specific path.
 
+A logical payload completes only when every planned or returned send unit has
+delivery identity. An aggregate receipt can cover several physical sends;
+receipt counts alone do not establish completion. If one chunk or media send
+returns no identity, earlier identified sends remain evidence, but the full
+payload is not reported as delivered or mirrored as complete.
+
 If a channel adapter can prove that retrying a failure cannot duplicate a
 recipient-visible send and no finalization-capable call began, throw
 `new PlatformMessageNotDispatchedError("...", { cause: error })` from
@@ -200,13 +206,27 @@ Runtime send helpers also live on `channel-outbound`:
 | Outcome          | Meaning                                                                                 |
 | ---------------- | --------------------------------------------------------------------------------------- |
 | `sent`           | at least one visible platform message was accepted by the platform send path            |
-| `suppressed`     | no platform message should be treated as missing                                        |
+| `suppressed`     | no platform receipt was produced; inspect the reason for suppression or uncertainty     |
 | `partial_failed` | at least one platform message was accepted before a later payload or side effect failed |
 | `failed`         | no platform receipt was produced                                                        |
 
 Use `payloadOutcomes` when a batch mixes sent, suppressed, and failed
 payloads. Do not infer hook cancellation from an empty legacy
 direct-delivery result.
+
+`adapter_returned_no_identity` means the adapter may have sent the message;
+it is not a hook veto. Ordinary and reusable batches retain queue custody as
+`unknown_after_send` when any send remains unidentified, including when a later
+send is rejected before dispatch. Completion cannot use an earlier receipt to
+settle the whole batch. Hook cancellation before sending keeps its existing
+suppression behavior.
+
+Core routing checks recipient-reached evidence for every result status before
+choosing a fallback sender. Plugin callers must likewise inspect every payload
+outcome before retrying, including on a `failed` result.
+A `failed` result can carry `sentBeforeError` in `payloadOutcomes` despite having
+no message ID. Routed replies preserve this distinction with `ok: false` and
+`delivered: true`: delivery failed, but a second send could duplicate it.
 
 When a transport creates a thread during its first successful send, the
 outbound adapter may implement `adoptTargetFromDelivery(...)`. Return the

--- a/src/auto-reply/reply/dispatch-acp-delivery.test.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.test.ts
@@ -1067,32 +1067,31 @@ describe("createAcpDispatchDeliveryCoordinator", () => {
     await expect(coordinator.resolveAccumulatedDeliveredTranscriptText()).resolves.toBe("");
   });
 
-  it("does not retry routed ACP text after a partial delivery failure", async () => {
-    deliveryMocks.routeReply.mockResolvedValueOnce({
-      ok: false,
-      delivered: true,
-      messageId: "visible-1",
-      error: "later chunk failed",
-    });
-    const coordinator = createAcpDispatchDeliveryCoordinator({
-      cfg: createAcpTestConfig(),
-      ctx: buildTestCtx({
-        Provider: "visiblechat",
-        Surface: "visiblechat",
-        SessionKey: "agent:codex-acp:session-1",
-      }),
-      dispatcher: createDispatcher(),
-      inboundAudio: false,
-      shouldRouteToOriginating: true,
-      originatingChannel: "visiblechat",
-      originatingTo: "channel:thread-1",
-    });
+  it.each([false, true])(
+    "does not retry recipient-reached ACP failures (identityless TTS: %s)",
+    async (identitylessTts) => {
+      const payload = identitylessTts
+        ? {
+            text: "hello",
+            mediaUrl: "https://example.com/reply.mp3",
+            ttsSupplement: { spokenText: "hello", visibleTextAlreadyDelivered: false },
+          }
+        : { text: "hello" };
+      deliveryMocks.routeReply.mockResolvedValueOnce({
+        ok: false,
+        delivered: true,
+        messageId: identitylessTts ? undefined : "visible-1",
+        error: "later chunk failed",
+      });
+      const coordinator = createVisibleChatAcpCoordinator(createAcpTestConfig());
 
-    const delivered = await coordinator.deliver("final", { text: "hello" }, { skipTts: true });
+      const delivered = await coordinator.deliver("final", payload, { skipTts: true });
 
-    expect(delivered).toBe(true);
-    expect(coordinator.getRoutedCounts().final).toBe(1);
-  });
+      expect(delivered).toBe(true);
+      expect(deliveryMocks.routeReply).toHaveBeenCalledTimes(1);
+      expect(coordinator.getRoutedCounts().final).toBe(1);
+    },
+  );
 
   it("treats hook-suppressed routed ACP block text as handled", async () => {
     deliveryMocks.routeReply.mockResolvedValueOnce({

--- a/src/auto-reply/reply/route-reply.delivery-uncertainty.integration.test.ts
+++ b/src/auto-reply/reply/route-reply.delivery-uncertainty.integration.test.ts
@@ -1,16 +1,25 @@
 // Exercises retry safety through the real router, durable sender, and SQLite queue.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelOutboundAdapter } from "../../channels/plugins/types.public.js";
+import { PlatformMessageNotDispatchedError } from "../../infra/outbound/deliver-types.js";
 import {
   installDeliveryQueueTmpDirHooks,
   loadPendingDeliveries,
 } from "../../infra/outbound/delivery-queue.test-helpers.js";
+import {
+  initializeGlobalHookRunner,
+  resetGlobalHookRunner,
+} from "../../plugins/hook-runner-global.js";
+import { addTestHook } from "../../plugins/hooks.test-helpers.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
 import type { ReplyPayload } from "../types.js";
+import { createAcpDispatchDeliveryCoordinator } from "./dispatch-acp-delivery.js";
 import { deliverFollowupDecision } from "./followup-delivery.js";
 import type { AdmittedFollowupTurn } from "./followup-turn-admission.js";
 import { routeReply } from "./route-reply.js";
+import { buildTestCtx } from "./test-ctx.js";
+import { createAcpTestReplyDispatcher } from "./test-fixtures/acp-runtime.js";
 import {
   createMockFollowupRun,
   createMockReplyOperation,
@@ -25,104 +34,166 @@ vi.mock("../../agents/runtime-plan/build.js", () => ({
 }));
 
 const channels = ["telegram", "discord", "slack", "matrix"] as const;
+const scenarios = [
+  "accepted_without_receipt",
+  "not_dispatched",
+  "hook_veto",
+  "identified",
+] as const;
 type TestChannel = (typeof channels)[number];
+type Scenario = (typeof scenarios)[number];
+type SendKind = "text" | "media";
 
-describe("routed delivery uncertainty", () => {
+function createFollowupTurn(channel: TestChannel): AdmittedFollowupTurn {
+  return {
+    runId: "uncertain-followup",
+    queued: createMockFollowupRun({
+      originatingChannel: channel,
+      originatingTo: "recipient",
+      run: { messageProvider: channel },
+    }),
+    operation: createMockReplyOperation().replyOperation,
+    config: {},
+    session: {
+      kind: "detached",
+      current: () => undefined,
+      publish: () => undefined,
+      adopt: () => undefined,
+    },
+    sendPolicy: "allow",
+    preflightCompactionApplied: false,
+  };
+}
+
+describe.each(channels)("routed %s delivery uncertainty", (channel) => {
   const fixtures = installDeliveryQueueTmpDirHooks();
-  const accepted: string[] = [];
+  const attempts: SendKind[] = [];
+  const accepted: SendKind[] = [];
   const payload = { text: "recipient accepted this reply" };
+  let scenario: Scenario;
+  let acceptFallbackText: boolean;
+  const messageSendingHook = vi.fn(() => (scenario === "hook_veto" ? { cancel: true } : undefined));
 
   beforeEach(() => {
     vi.stubEnv("OPENCLAW_STATE_DIR", fixtures.tmpDir());
+    attempts.length = 0;
     accepted.length = 0;
-    setActivePluginRegistry(
-      createTestRegistry(
-        channels.map((channel) => {
-          const sendText: NonNullable<ChannelOutboundAdapter["sendText"]> = async ({
-            text,
-            onPlatformSendDispatch,
-          }) => {
-            await onPlatformSendDispatch?.();
-            // The recipient accepts the send, but the connection drops before
-            // the adapter can return an identity to the durable sender.
-            accepted.push(text);
-            throw new Error("connection lost after recipient accepted reply");
-          };
-          return {
-            pluginId: channel,
-            source: "test",
-            plugin: createOutboundTestPlugin({
-              id: channel,
-              outbound: { deliveryMode: "direct", sendText },
-            }),
-          };
+    scenario = "accepted_without_receipt";
+    acceptFallbackText = false;
+    messageSendingHook.mockClear();
+    const send = async (
+      kind: SendKind,
+      { onPlatformSendDispatch }: Parameters<NonNullable<ChannelOutboundAdapter["sendText"]>>[0],
+    ) => {
+      attempts.push(kind);
+      const outcome = kind === "text" && acceptFallbackText ? "identified" : scenario;
+      if (outcome === "not_dispatched") {
+        // Permanent media/payload rejection retires the original queue intent;
+        // the caller can still try its distinct text/dispatcher fallback.
+        throw new PlatformMessageNotDispatchedError("rejected before recipient delivery", {
+          cause: undefined,
+          retryable: false,
+        });
+      }
+      await onPlatformSendDispatch?.();
+      accepted.push(kind);
+      if (outcome === "accepted_without_receipt") {
+        throw new Error("connection lost after recipient accepted reply");
+      }
+      return { channel, messageId: `${kind}-message` };
+    };
+    const registry = createTestRegistry([
+      {
+        pluginId: channel,
+        source: "test",
+        plugin: createOutboundTestPlugin({
+          id: channel,
+          outbound: {
+            deliveryMode: "direct",
+            sendText: (context) => send("text", context),
+            sendMedia: (context) => send("media", context),
+          },
         }),
-      ),
-    );
+      },
+    ]);
+    addTestHook({
+      registry,
+      pluginId: "delivery-policy",
+      hookName: "message_sending",
+      handler: messageSendingHook,
+    });
+    setActivePluginRegistry(registry);
+    initializeGlobalHookRunner(registry);
   });
 
   afterEach(() => {
+    resetGlobalHookRunner();
     resetPluginRuntimeStateForTest();
     setActivePluginRegistry(createTestRegistry());
     vi.unstubAllEnvs();
   });
 
-  async function expectRetainedCustody(channel: TestChannel) {
-    expect(await loadPendingDeliveries(fixtures.tmpDir())).toEqual([
-      expect.objectContaining({
-        channel,
-        recoveryState: "unknown_after_send",
-        retryCount: 1,
-      }),
-    ]);
-    expect(accepted).toEqual([payload.text]);
+  async function expectCustody() {
+    expect(await loadPendingDeliveries(fixtures.tmpDir())).toEqual(
+      scenario === "accepted_without_receipt"
+        ? [
+            expect.objectContaining({
+              channel,
+              recoveryState: "unknown_after_send",
+              retryCount: 1,
+            }),
+          ]
+        : [],
+    );
   }
 
-  it.each(channels)(
-    "keeps %s routing failures non-retryable without a receipt",
-    async (channel) => {
-      const result = await routeReply({
-        payload,
-        channel,
-        to: "recipient",
-        cfg: {},
-        replyKind: "final",
-        mirror: false,
-      });
+  function expectTextAttempt() {
+    expect(attempts).toEqual(scenario === "hook_veto" ? [] : ["text"]);
+    expect(accepted).toEqual(
+      scenario === "accepted_without_receipt" || scenario === "identified" ? ["text"] : [],
+    );
+    if (scenario === "hook_veto") {
+      expect(messageSendingHook).toHaveBeenCalledOnce();
+    }
+  }
 
-      await expectRetainedCustody(channel);
-      expect(result).toMatchObject({
-        ok: false,
-        delivered: true,
-        error: `Failed to route reply to ${channel}: connection lost after recipient accepted reply`,
-      });
-      expect(result.messageId).toBeUndefined();
-    },
-  );
+  it.each(scenarios)("projects %s without conflating delivery and suppression", async (outcome) => {
+    scenario = outcome;
+    const result = await routeReply({
+      payload,
+      channel,
+      to: "recipient",
+      cfg: {},
+      replyKind: "final",
+      mirror: false,
+    });
 
-  it.each(channels)(
-    "does not dispatch a second %s follow-up after identity loss",
-    async (channel) => {
+    await expectCustody();
+    expectTextAttempt();
+    expect(result).toMatchObject({
+      ok: outcome === "identified" || outcome === "hook_veto",
+      delivered: outcome === "identified" || outcome === "accepted_without_receipt",
+    });
+    expect(result.suppressed).toBe(outcome === "hook_veto" ? true : undefined);
+    expect(result.messageId).toBe(outcome === "identified" ? "text-message" : undefined);
+    if (outcome === "hook_veto") {
+      expect(result.reason).toBe("cancelled_by_message_sending_hook");
+      expect(result.ambiguous).toBeUndefined();
+    } else if (outcome !== "identified") {
+      expect(result.error).toContain(
+        outcome === "not_dispatched"
+          ? "rejected before recipient delivery"
+          : "connection lost after recipient accepted reply",
+      );
+    }
+  });
+
+  it.each(scenarios)(
+    "dispatches a second follow-up only when %s is proven not sent",
+    async (outcome) => {
+      scenario = outcome;
       const onBlockReply = vi.fn(async (_payload: ReplyPayload) => {});
-      const turn: AdmittedFollowupTurn = {
-        runId: "uncertain-followup",
-        queued: createMockFollowupRun({
-          originatingChannel: channel,
-          originatingTo: "recipient",
-          run: { messageProvider: channel },
-        }),
-        operation: createMockReplyOperation().replyOperation,
-        config: {},
-        session: {
-          kind: "detached",
-          current: () => undefined,
-          publish: () => undefined,
-          adopt: () => undefined,
-        },
-        sendPolicy: "allow",
-        preflightCompactionApplied: false,
-      };
-
+      const turn = createFollowupTurn(channel);
       await deliverFollowupDecision({
         decision: { kind: "deliver", payloads: [payload] },
         turn,
@@ -136,8 +207,48 @@ describe("routed delivery uncertainty", () => {
         runFollowup: vi.fn(async () => {}),
       });
 
-      await expectRetainedCustody(channel);
-      expect(onBlockReply).not.toHaveBeenCalled();
+      await expectCustody();
+      expectTextAttempt();
+      if (outcome === "not_dispatched") {
+        expect(onBlockReply).toHaveBeenCalledExactlyOnceWith(payload);
+      } else {
+        expect(onBlockReply).not.toHaveBeenCalled();
+      }
+    },
+  );
+
+  it.each(["accepted_without_receipt", "not_dispatched"] as const)(
+    "gates actual routed ACP media-to-text fallback after %s",
+    async (outcome) => {
+      scenario = outcome;
+      acceptFallbackText = true;
+      const dispatcher = createAcpTestReplyDispatcher();
+      const coordinator = createAcpDispatchDeliveryCoordinator({
+        cfg: {},
+        ctx: buildTestCtx({ Provider: channel, Surface: channel }),
+        dispatcher,
+        inboundAudio: false,
+        shouldRouteToOriginating: true,
+        originatingChannel: channel,
+        originatingTo: "recipient",
+      });
+      await expect(
+        coordinator.deliver(
+          "final",
+          {
+            ...payload,
+            mediaUrl: "https://example.com/reply.mp3",
+            ttsSupplement: { spokenText: payload.text, visibleTextAlreadyDelivered: false },
+          },
+          { skipTts: true },
+        ),
+      ).resolves.toBe(true);
+
+      await expectCustody();
+      expect(attempts).toEqual(outcome === "not_dispatched" ? ["media", "text"] : ["media"]);
+      expect(accepted).toEqual(outcome === "not_dispatched" ? ["text"] : ["media"]);
+      expect(coordinator.getRoutedCounts().final).toBe(1);
+      expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
     },
   );
 });

--- a/src/auto-reply/reply/route-reply.delivery-uncertainty.integration.test.ts
+++ b/src/auto-reply/reply/route-reply.delivery-uncertainty.integration.test.ts
@@ -1,0 +1,143 @@
+// Exercises retry safety through the real router, durable sender, and SQLite queue.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelOutboundAdapter } from "../../channels/plugins/types.public.js";
+import {
+  installDeliveryQueueTmpDirHooks,
+  loadPendingDeliveries,
+} from "../../infra/outbound/delivery-queue.test-helpers.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
+import type { ReplyPayload } from "../types.js";
+import { deliverFollowupDecision } from "./followup-delivery.js";
+import type { AdmittedFollowupTurn } from "./followup-turn-admission.js";
+import { routeReply } from "./route-reply.js";
+import {
+  createMockFollowupRun,
+  createMockReplyOperation,
+  createMockTypingController,
+} from "./test-helpers.js";
+
+vi.mock("../../agents/runtime-plan/build.js", () => ({
+  buildAgentRuntimeDeliveryPlan: () => ({
+    isSilentPayload: () => false,
+    resolveFollowupRoute: () => undefined,
+  }),
+}));
+
+const channels = ["telegram", "discord", "slack", "matrix"] as const;
+type TestChannel = (typeof channels)[number];
+
+describe("routed delivery uncertainty", () => {
+  const fixtures = installDeliveryQueueTmpDirHooks();
+  const accepted: string[] = [];
+  const payload = { text: "recipient accepted this reply" };
+
+  beforeEach(() => {
+    vi.stubEnv("OPENCLAW_STATE_DIR", fixtures.tmpDir());
+    accepted.length = 0;
+    setActivePluginRegistry(
+      createTestRegistry(
+        channels.map((channel) => {
+          const sendText: NonNullable<ChannelOutboundAdapter["sendText"]> = async ({
+            text,
+            onPlatformSendDispatch,
+          }) => {
+            await onPlatformSendDispatch?.();
+            // The recipient accepts the send, but the connection drops before
+            // the adapter can return an identity to the durable sender.
+            accepted.push(text);
+            throw new Error("connection lost after recipient accepted reply");
+          };
+          return {
+            pluginId: channel,
+            source: "test",
+            plugin: createOutboundTestPlugin({
+              id: channel,
+              outbound: { deliveryMode: "direct", sendText },
+            }),
+          };
+        }),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    resetPluginRuntimeStateForTest();
+    setActivePluginRegistry(createTestRegistry());
+    vi.unstubAllEnvs();
+  });
+
+  async function expectRetainedCustody(channel: TestChannel) {
+    expect(await loadPendingDeliveries(fixtures.tmpDir())).toEqual([
+      expect.objectContaining({
+        channel,
+        recoveryState: "unknown_after_send",
+        retryCount: 1,
+      }),
+    ]);
+    expect(accepted).toEqual([payload.text]);
+  }
+
+  it.each(channels)(
+    "keeps %s routing failures non-retryable without a receipt",
+    async (channel) => {
+      const result = await routeReply({
+        payload,
+        channel,
+        to: "recipient",
+        cfg: {},
+        replyKind: "final",
+        mirror: false,
+      });
+
+      await expectRetainedCustody(channel);
+      expect(result).toMatchObject({
+        ok: false,
+        delivered: true,
+        error: `Failed to route reply to ${channel}: connection lost after recipient accepted reply`,
+      });
+      expect(result.messageId).toBeUndefined();
+    },
+  );
+
+  it.each(channels)(
+    "does not dispatch a second %s follow-up after identity loss",
+    async (channel) => {
+      const onBlockReply = vi.fn(async (_payload: ReplyPayload) => {});
+      const turn: AdmittedFollowupTurn = {
+        runId: "uncertain-followup",
+        queued: createMockFollowupRun({
+          originatingChannel: channel,
+          originatingTo: "recipient",
+          run: { messageProvider: channel },
+        }),
+        operation: createMockReplyOperation().replyOperation,
+        config: {},
+        session: {
+          kind: "detached",
+          current: () => undefined,
+          publish: () => undefined,
+          adopt: () => undefined,
+        },
+        sendPolicy: "allow",
+        preflightCompactionApplied: false,
+      };
+
+      await deliverFollowupDecision({
+        decision: { kind: "deliver", payloads: [payload] },
+        turn,
+        defaults: {
+          defaultModel: "claude",
+          typingMode: "never",
+          typing: createMockTypingController(),
+          opts: { onBlockReply },
+        },
+        runId: turn.runId,
+        runFollowup: vi.fn(async () => {}),
+      });
+
+      await expectRetainedCustody(channel);
+      expect(onBlockReply).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -382,14 +382,15 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
             }
           : undefined,
     });
-    if (send.status === "failed") {
-      throw send.error;
-    }
-    if (send.status === "partial_failed") {
-      const delivery = summarizeVisibleRouteReplyDelivery(send.results);
+    if (send.status === "failed" || send.status === "partial_failed") {
+      const delivery = summarizeVisibleRouteReplyDelivery(
+        send.status === "partial_failed" ? send.results : [],
+      );
       return {
         ok: false,
-        delivered: delivery.delivered,
+        // A lost receipt is still retry-unsafe. Preserve the dispatch evidence
+        // so follow-up and ACP callers cannot send a duplicate fallback.
+        delivered: durableMessageBatchMayHaveReachedRecipient(send),
         error: `Failed to route reply to ${channel}: ${formatErrorMessage(send.error)}`,
         messageId: delivery.messageId,
       };

--- a/src/infra/delivery-recovery.shared.ts
+++ b/src/infra/delivery-recovery.shared.ts
@@ -7,6 +7,7 @@ import { computeBackoffSchedule } from "../../packages/retry/src/index.js";
 import { sleep } from "../utils/sleep.js";
 import { collectErrorGraphCandidates, extractErrorCode } from "./errors.js";
 import {
+  isOutboundDeliveryError,
   isPlatformMessageNotDispatchedError,
   isPlatformMessageRejectedError,
   type PlatformMessageNotDispatchedError,
@@ -131,6 +132,10 @@ function nestedErrorCandidates(current: Record<string, unknown>): unknown[] {
 export function isProvenDeliveryNotSentError(err: unknown): boolean {
   let foundNotSentProof = false;
   for (const candidate of collectErrorGraphCandidates(err, nestedErrorCandidates)) {
+    // A later unit's no-send proof cannot erase an earlier ambiguous send.
+    if (isOutboundDeliveryError(candidate) && candidate.sentBeforeError) {
+      return false;
+    }
     const code = extractErrorCode(candidate)?.trim().toUpperCase();
     if (isPlatformMessageNotDispatchedError(candidate) || isProvenPreConnectCandidate(candidate)) {
       foundNotSentProof = true;

--- a/src/infra/jsonl-socket.test.ts
+++ b/src/infra/jsonl-socket.test.ts
@@ -26,9 +26,10 @@ function acceptDoneValue(msg: unknown): number | null | undefined {
   return value.type === "done" ? (value.value ?? null) : undefined;
 }
 
+// Short prefixes leave room for the wrapper's temp namespace under macOS' socket path limit.
 describe.runIf(process.platform !== "win32")("requestJsonlSocket", () => {
   it("ignores malformed and non-accepted lines until one is accepted", async () => {
-    await withTestDir({ prefix: "openclaw-jsonl-socket-" }, async (dir) => {
+    await withTestDir({ prefix: "oc-js-" }, async (dir) => {
       const socketPath = path.join(dir, "socket.sock");
       const server = net.createServer((socket) => {
         socket.on("data", () => {
@@ -58,7 +59,7 @@ describe.runIf(process.platform !== "win32")("requestJsonlSocket", () => {
   });
 
   it("half-closes the write side after sending the request line", async () => {
-    await withTestDir({ prefix: "openclaw-jsonl-socket-" }, async (dir) => {
+    await withTestDir({ prefix: "oc-js-" }, async (dir) => {
       const socketPath = path.join(dir, "socket.sock");
       let receivedBuffer: string | null = null;
       const server = net.createServer((socket) => {
@@ -93,7 +94,7 @@ describe.runIf(process.platform !== "win32")("requestJsonlSocket", () => {
   });
 
   it("returns null on timeout and on socket errors", async () => {
-    await withTestDir({ prefix: "openclaw-jsonl-socket-" }, async (dir) => {
+    await withTestDir({ prefix: "oc-js-" }, async (dir) => {
       const socketPath = path.join(dir, "socket.sock");
       const server = net.createServer(() => {
         // Intentionally never reply.
@@ -128,7 +129,7 @@ describe.runIf(process.platform !== "win32")("requestJsonlSocket", () => {
   });
 
   it("returns null when the socket closes without an accepted response", async () => {
-    await withTestDir({ prefix: "openclaw-jsonl-socket-" }, async (dir) => {
+    await withTestDir({ prefix: "oc-js-" }, async (dir) => {
       const socketPath = path.join(dir, "socket.sock");
       const server = net.createServer((socket) => {
         socket.on("data", () => {

--- a/src/infra/outbound/deliver-core.ts
+++ b/src/infra/outbound/deliver-core.ts
@@ -151,6 +151,7 @@ export async function deliverOutboundPayloadsCore(
   const { resolveCurrentReplyTo, applyReplyToConsumption } = createReplyToDeliveryPolicy({
     reply,
   });
+  const sendIdentities: boolean[] = [];
 
   const sendTextChunks = async (
     sendHandler: ChannelHandler,
@@ -177,8 +178,10 @@ export async function deliverOutboundPayloadsCore(
       }
       throwIfAborted(abortSignal);
       const resultIndex = results.length;
-      await recordIdentifiedDeliveryResult(
-        await sendHandler.sendText(unit.text, withPreparedTarget(unit.overrides)),
+      sendIdentities.push(
+        await recordIdentifiedDeliveryResult(
+          await sendHandler.sendText(unit.text, withPreparedTarget(unit.overrides)),
+        ),
       );
       adoptSuccessfulResultsSince(resultIndex);
     }
@@ -199,13 +202,7 @@ export async function deliverOutboundPayloadsCore(
     params.onPayloadDeliveryOutcome?.(outcome);
   }
   const deliveredMirrorPayloads: NormalizedOutboundPayload[] = [];
-  const recordDeliveredPayload = (
-    payloadSummary: NormalizedOutboundPayload,
-    deliveredResults: readonly OutboundDeliveryResult[],
-  ): void => {
-    if (deliveredResults.length === 0) {
-      return;
-    }
+  const recordDeliveredPayload = (payloadSummary: NormalizedOutboundPayload): void => {
     // Post-send observers are bookkeeping only. Never turn an identified
     // platform delivery into a retryable failure if an observer misbehaves.
     try {
@@ -228,6 +225,7 @@ export async function deliverOutboundPayloadsCore(
     const payloadIndex = preparedEntry.sourceIndex;
     activeSourceIndex = payloadIndex;
     const payload = preparedEntry.payload;
+    sendIdentities.length = 0;
     const payloadResultStartIndex = results.length;
     let effectivePayload: typeof payload | null | undefined;
     let payloadSummary = buildPayloadSummary(payload);
@@ -367,26 +365,17 @@ export async function deliverOutboundPayloadsCore(
           effectivePayload,
           withPreparedTarget(applySendReplyToConsumption(sendOverrides)),
         );
-        await recordIdentifiedDeliveryResult(delivery);
+        sendIdentities.push(await recordIdentifiedDeliveryResult(delivery));
         adoptSuccessfulResultsSince(beforeCount);
-        const deliveredResults = results.slice(beforeCount);
-        if (deliveredResults.length === 0) {
-          completeDeliveryDiagnostics(0);
-          recordPayloadOutcome(
-            suppressedPayloadOutcome({
-              index: payloadIndex,
-              reason: "adapter_returned_no_identity",
-            }),
-          );
-          continue;
-        }
       } else if (payloadSummary.mediaUrls.length === 0) {
         if (deliveryHandler.sendFormattedText) {
-          await recordIdentifiedDeliveryResults(
-            await deliveryHandler.sendFormattedText(
-              payloadSummary.text,
-              withPreparedTarget(applySendReplyToConsumption(sendOverrides)),
-            ),
+          sendIdentities.push(
+            ...(await recordIdentifiedDeliveryResults(
+              await deliveryHandler.sendFormattedText(
+                payloadSummary.text,
+                withPreparedTarget(applySendReplyToConsumption(sendOverrides)),
+              ),
+            )),
           );
           adoptSuccessfulResultsSince(beforeCount);
         } else {
@@ -437,6 +426,7 @@ export async function deliverOutboundPayloadsCore(
                 withPreparedTarget(unit.overrides),
               );
           const recorded = await recordIdentifiedDeliveryResult(delivery);
+          sendIdentities.push(recorded);
           adoptSuccessfulResultsSince(resultIndex);
           if (recorded) {
             mediaMessageIds.first ??= delivery.messageId;
@@ -446,13 +436,16 @@ export async function deliverOutboundPayloadsCore(
       }
 
       const deliveredResults = results.slice(beforeCount);
-      if (deliveredResults.length > 0) {
+      // One aggregate receipt can cover many sends. Completion requires identity
+      // for every returned unit, not merely one surviving receipt or matching counts.
+      const payloadComplete = sendIdentities.length > 0 && sendIdentities.every(Boolean);
+      if (payloadComplete) {
         recordPayloadOutcome({
           index: payloadIndex,
           status: "sent",
           results: deliveredResults,
         });
-        recordDeliveredPayload(mirroredPayload, deliveredResults);
+        recordDeliveredPayload(mirroredPayload);
       } else {
         recordPayloadOutcome(
           suppressedPayloadOutcome({
@@ -468,7 +461,7 @@ export async function deliverOutboundPayloadsCore(
         ? mediaMessageIds.last
         : deliveredResults.at(-1)?.messageId;
       recordMessageSentEvent({
-        success: deliveredResults.length > 0,
+        success: payloadComplete,
         content: payloadSummary.hookContent ?? payloadSummary.text,
         messageId: lastMessageId,
       });
@@ -504,7 +497,7 @@ export async function deliverOutboundPayloadsCore(
         index: payloadIndex,
         status: "failed",
         error: err,
-        sentBeforeError: failedPayloadResults.length > 0,
+        sentBeforeError: failedPayloadResults.length > 0 || sendIdentities.includes(false),
         stage: "platform_send",
         results: failedPayloadResults,
       });

--- a/src/infra/outbound/deliver-queue-execute.ts
+++ b/src/infra/outbound/deliver-queue-execute.ts
@@ -164,8 +164,6 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
     }
     return persistQueuedPostSendState({
       queueId,
-      queuePolicy,
-      ...(producerClaimId ? { producerClaimId } : {}),
       ...(producerClaimId ? { expectedPlatformSendAttemptId: producerClaimId } : {}),
     });
   };
@@ -245,9 +243,13 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
     },
     onPlatformSendDispatch: async () => {
       params.abortSignal?.throwIfAborted();
-      // Once any payload returns an identity, unknown-after-send protects the whole batch.
-      // A later payload dispatch must not regress that durable evidence to attempt-started.
-      if (platformQueueId && queuedPreSendState !== "acked" && queuedPostSendState === undefined) {
+      // A failed progress marker may mean claim loss. Revalidate before another
+      // send; the dispatch owner preserves any stronger unknown-after-send state.
+      if (
+        platformQueueId &&
+        queuedPreSendState !== "acked" &&
+        (queuedPostSendState === undefined || queuedPostSendState === "unmarked")
+      ) {
         try {
           if (producerClaimId) {
             await markDeliveryPlatformSendDispatched(
@@ -406,19 +408,21 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
           queuedPostSendState ??
           (partialSendEvidence ? await persistOwnedPostSendState() : undefined);
         const error = "partial delivery failure (bestEffort)";
-        if (postSendState === undefined || postSendState === "marked") {
+        if (postSendState !== "acked" && postSendState !== "failed") {
           const recordFailure =
-            !partialSendEvidence && partialFailuresAreProvenNotSent
-              ? failDeliveryBeforePlatformSend
-              : failDelivery;
+            postSendState === "unmarked"
+              ? failDeliveryAfterPlatformSend
+              : !partialSendEvidence && partialFailuresAreProvenNotSent
+                ? failDeliveryBeforePlatformSend
+                : failDelivery;
           await recordOwnedQueueFailure(recordFailure, error).catch((err: unknown) => {
             log.warn(
               `failed to mark queued delivery ${queueId} as failed after partial failure; continuing best-effort delivery: ${formatErrorMessage(err)}`,
             );
           });
         } else if (postSendState === "acked") {
-          // Direct ack is the fallback when the post-send marker cannot be
-          // written. Once the row is gone, recovery cannot run these hooks.
+          // A best-effort pre-send ack removed custody before provider I/O.
+          // Recovery cannot run observers for that retired row.
           await runCommitHooksAfterAck();
           emitTerminals(() =>
             failedOutboundAuditTerminals({
@@ -560,7 +564,7 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
         if (sendEvidence) {
           try {
             queuedPostSendState ??= await persistOwnedPostSendState();
-            if (queuedPostSendState === "marked") {
+            if (queuedPostSendState === "marked" || queuedPostSendState === "unmarked") {
               await recordOwnedQueueFailure(failDeliveryAfterPlatformSend, formatErrorMessage(err));
               queuedPostSendState = "failed";
             }
@@ -570,10 +574,6 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
             log.warn(
               `failed to preserve queued delivery ${queueId} post-send evidence: ${formatErrorMessage(persistErr)}`,
             );
-          }
-          await runCommitHooksAfterAck();
-          if (queuedPostSendState === "acked") {
-            emitFailedTerminals(platformSendFailureStage);
           }
         } else {
           const permanentRejection = findPlatformMessageRejectedError(err);

--- a/src/infra/outbound/deliver-queue-execute.ts
+++ b/src/infra/outbound/deliver-queue-execute.ts
@@ -1,6 +1,5 @@
 // Owns queued delivery execution, custody transitions, and terminal cleanup.
 import type { AuditMessageFailureStage } from "../../audit/audit-event-types.js";
-import { hasTrustedMessageAuditListeners } from "../../audit/message-audit-events.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import {
@@ -10,9 +9,11 @@ import {
 import { formatErrorMessage } from "../errors.js";
 import type { DeliverOutboundPayloadsParams, PlatformSendRoute } from "./deliver-contracts.js";
 import { deliverOutboundPayloadsCore } from "./deliver-core.js";
+import { toOutboundDeliveryError } from "./deliver-hooks.js";
 import { OUTBOUND_DELIVERY_LOG_SCOPE } from "./deliver-log.js";
 import {
   createQueuedDeliveryOwner,
+  hasUnconfirmedOutboundSends,
   isDeliveryAbortError,
   persistQueuedPostSendState,
   persistQueuedPreSendState,
@@ -57,7 +58,12 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
   // follows the normal abort cleanup path through the combined signal.
   const throwIfProducerLeaseLost = (): void => {
     if (producerLeaseSignal?.aborted) {
-      throw producerLeaseSignal.reason;
+      throw toOutboundDeliveryError({
+        error: producerLeaseSignal.reason,
+        results: deliveredResults,
+        payloadOutcomes,
+        stage: "queue",
+      });
     }
   };
   const payloadCount = params.preparedBatch?.sourcePayloadCount ?? params.payloads.length;
@@ -69,16 +75,8 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
   let lastPayloadError: unknown;
   let partialFailuresAreProvenNotSent = true;
   const ownsAuditTerminal = params.deliveryQueueId === undefined;
-  const auditPayloadOutcomes =
-    ownsAuditTerminal && hasTrustedMessageAuditListeners()
-      ? ([] as OutboundPayloadDeliveryOutcome[])
-      : undefined;
-  const reusableProducerClaimId = params.reusePendingDeliveryIntent ? producerClaimId : undefined;
-  // Reusable producer custody must observe ambiguous adapter outcomes even when
-  // no audit listener is installed; audit subscriptions are not delivery proof.
-  const stablePayloadOutcomes = reusableProducerClaimId
-    ? ([] as OutboundPayloadDeliveryOutcome[])
-    : undefined;
+  // Custody accounting must not depend on producer reuse or audit subscriptions.
+  const payloadOutcomes: OutboundPayloadDeliveryOutcome[] = [];
   const queuePolicy = params.queuePolicy ?? "best_effort";
   const platformQueueId = queueId ?? params.deliveryQueueId;
   const platformQueuePolicy = queueId ? queuePolicy : (params.queuePolicy ?? "required");
@@ -167,7 +165,7 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
     return persistQueuedPostSendState({
       queueId,
       queuePolicy,
-      ...(reusableProducerClaimId ? { producerClaimId: reusableProducerClaimId } : {}),
+      ...(producerClaimId ? { producerClaimId } : {}),
       ...(producerClaimId ? { expectedPlatformSendAttemptId: producerClaimId } : {}),
     });
   };
@@ -292,22 +290,17 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
       partialFailuresAreProvenNotSent &&= isProvenDeliveryNotSentError(err);
       params.onError?.(err, payload);
     },
-    ...(params.onPayloadDeliveryOutcome || auditPayloadOutcomes || stablePayloadOutcomes
-      ? {
-          onPayloadDeliveryOutcome: (outcome: OutboundPayloadDeliveryOutcome) => {
-            if (
-              outcome.status === "failed" &&
-              platformDispatchedPayloads.has(outcome.index) &&
-              !isProvenDeliveryNotSentError(outcome.error)
-            ) {
-              outcome.sentBeforeError = true;
-            }
-            auditPayloadOutcomes?.push(outcome);
-            stablePayloadOutcomes?.push(outcome);
-            params.onPayloadDeliveryOutcome?.(outcome);
-          },
-        }
-      : {}),
+    onPayloadDeliveryOutcome: (outcome) => {
+      if (
+        outcome.status === "failed" &&
+        platformDispatchedPayloads.has(outcome.index) &&
+        !isProvenDeliveryNotSentError(outcome.error)
+      ) {
+        outcome.sentBeforeError = true;
+      }
+      payloadOutcomes.push(outcome);
+      params.onPayloadDeliveryOutcome?.(outcome);
+    },
     onDeliveryResult: async (result) => {
       deliveredResults.push(result);
       if (queueId && queuedPostSendState === undefined) {
@@ -347,23 +340,36 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
     deliveredResults = results;
     throwIfProducerLeaseLost();
     platformResultsReturned = true;
-    if (
-      queueId &&
-      results.length > 0 &&
-      stablePayloadOutcomes?.some(
-        (outcome) =>
-          outcome.status === "suppressed" && outcome.reason === "adapter_returned_no_identity",
-      )
-    ) {
-      const error = "platform send returned no delivery identity for part of the delivery batch";
-      await recordOwnedQueueFailure(failDeliveryAfterPlatformSend, error);
-      queuedPostSendState = "failed";
-      throw new OutboundDeliveryError(error, {
-        cause: new Error(error),
-        results,
-        payloadOutcomes: stablePayloadOutcomes,
-        stage: "platform_send",
-      });
+    const unconfirmedSends = hasUnconfirmedOutboundSends({
+      results,
+      payloadOutcomes,
+      platformSendStarted,
+    });
+    if (unconfirmedSends) {
+      const error =
+        results.length > 0
+          ? "platform send returned no delivery identity for part of the delivery batch"
+          : "platform send returned no delivery identity";
+      if (queueId && queuedPostSendState !== "acked") {
+        await recordOwnedQueueFailure(failDeliveryAfterPlatformSend, error);
+        queuedPostSendState = "failed";
+      }
+      await settleDeliveryCompletion(undefined);
+      // A retained row leaves terminal observers to recovery. A best-effort
+      // pre-send ack removed that owner, so the live path still owes observers.
+      if (results.length === 0 && queuedPostSendState === "failed") {
+        return results;
+      }
+      // Recovery receives complete accounting and owns its failure transition;
+      // live callers need an error so surviving receipts cannot mean success.
+      if (results.length > 0 && params.deliveryQueueId === undefined) {
+        throw new OutboundDeliveryError(error, {
+          cause: new Error(error),
+          results,
+          payloadOutcomes,
+          stage: "platform_send",
+        });
+      }
     }
     if (!queueId) {
       await settleDeliveryCompletion(results.at(-1));
@@ -376,13 +382,13 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
           ? failedOutboundAuditTerminals({
               payloadCount,
               results,
-              payloadOutcomes: auditPayloadOutcomes ?? [],
+              payloadOutcomes,
               failureStage: "platform_send",
             })
           : completedOutboundAuditTerminals({
               payloadCount,
               results,
-              payloadOutcomes: auditPayloadOutcomes ?? [],
+              payloadOutcomes,
             }),
       );
       return results;
@@ -391,6 +397,9 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
       if (hadPartialFailure) {
         const partialSendEvidence =
           results.length > 0 ||
+          payloadOutcomes.some(
+            (outcome) => outcome.status === "failed" && outcome.sentBeforeError,
+          ) ||
           (platformDispatchedPayloads.size > 0 && !partialFailuresAreProvenNotSent) ||
           (lastPayloadError instanceof OutboundDeliveryError && lastPayloadError.sentBeforeError);
         const postSendState =
@@ -415,7 +424,7 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
             failedOutboundAuditTerminals({
               payloadCount,
               results,
-              payloadOutcomes: auditPayloadOutcomes ?? [],
+              payloadOutcomes,
               failureStage: "platform_send",
             }),
           );
@@ -429,18 +438,6 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
               ? "acked"
               : undefined);
         await settleDeliveryCompletion(results.at(-1));
-        if (results.length === 0 && postSendState === "marked") {
-          // The provider was invoked but returned no recipient-visible identity;
-          // never convert that ambiguous platform outcome into a success receipt.
-          await recordOwnedQueueFailure(
-            failDeliveryAfterPlatformSend,
-            "platform send returned no delivery identity",
-          );
-          queuedPostSendState = "failed";
-          // Durable custody remains with recovery. Publishing a terminal here
-          // would make a later reconciliation reuse the same audit identity.
-          return results;
-        }
         const acked =
           postSendState === "acked"
             ? true
@@ -490,7 +487,7 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
             completedOutboundAuditTerminals({
               payloadCount,
               results,
-              payloadOutcomes: auditPayloadOutcomes ?? [],
+              payloadOutcomes,
             }),
           );
         }
@@ -507,21 +504,21 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
       queuedPreSendState === "marked" ||
       queuedPostSendState === "marked" ||
       (err instanceof OutboundDeliveryError && err.sentBeforeError) ||
-      stablePayloadOutcomes?.some((outcome) => outcome.status === "sent") === true;
+      payloadOutcomes.some((outcome) => outcome.status === "sent");
     // Every terminal below reports the same failed batch; only the stage differs.
     const emitFailedTerminals = (failureStage: AuditMessageFailureStage) =>
       emitTerminals(() =>
         failedOutboundAuditTerminals({
           payloadCount,
           results: deliveredResults,
-          payloadOutcomes: auditPayloadOutcomes ?? [],
+          payloadOutcomes,
           failureStage,
         }),
       );
     const platformSendFailureStage: AuditMessageFailureStage =
       err instanceof OutboundDeliveryError ? err.stage : "platform_send";
     if (queueId) {
-      if (queuedPreSendState === "acked") {
+      if (queuedPostSendState === "acked") {
         // Best-effort fallback removed durable custody before provider I/O.
         // This process is now the only owner that can publish terminal observers.
         await runCommitHooksAfterAck();
@@ -589,7 +586,7 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
                 producerClaimId !== undefined &&
                 (deliveredResults.length > 0 ||
                   queuedPostSendState === "marked" ||
-                  stablePayloadOutcomes?.some((outcome) => outcome.status === "sent"));
+                  payloadOutcomes.some((outcome) => outcome.status === "sent"));
               if (ambiguousStableRejection) {
                 await recordOwnedQueueFailure(
                   failDeliveryAfterPlatformSend,
@@ -679,7 +676,15 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
       flushMessageSentEvents();
       emitFailedTerminals(platformSendFailureStage);
     }
-    throw err;
+    if (deliveredResults.length === 0 && payloadOutcomes.length === 0) {
+      throw err;
+    }
+    throw toOutboundDeliveryError({
+      error: err,
+      results: deliveredResults,
+      payloadOutcomes,
+      stage: "queue",
+    });
   }
 }
 

--- a/src/infra/outbound/deliver-queue-state.ts
+++ b/src/infra/outbound/deliver-queue-state.ts
@@ -2,7 +2,11 @@
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { formatErrorMessage } from "../errors.js";
 import type { OutboundDeliveryQueuePolicy, PlatformSendRoute } from "./deliver-contracts.js";
-import { OutboundDeliveryError } from "./deliver-types.js";
+import {
+  OutboundDeliveryError,
+  type OutboundDeliveryResult,
+  type OutboundPayloadDeliveryOutcome,
+} from "./deliver-types.js";
 import {
   ackDelivery,
   failDelivery,
@@ -25,6 +29,23 @@ export type QueuedPostSendState = "marked" | "acked" | "failed";
 export type QueuedPreSendState = "marked" | "acked";
 
 type QueuedDeliveryFailureRecorder = typeof failDelivery | typeof failDeliveryAfterPlatformSend;
+
+/** A surviving receipt cannot settle a batch that also contains an unidentified send. */
+export function hasUnconfirmedOutboundSends(params: {
+  results: readonly OutboundDeliveryResult[];
+  payloadOutcomes: readonly OutboundPayloadDeliveryOutcome[];
+  platformSendStarted: boolean;
+}): boolean {
+  return (
+    params.payloadOutcomes.some(
+      (outcome) =>
+        outcome.status === "suppressed" && outcome.reason === "adapter_returned_no_identity",
+    ) ||
+    (params.results.length === 0 &&
+      params.platformSendStarted &&
+      !params.payloadOutcomes.some((outcome) => outcome.status === "failed"))
+  );
+}
 
 /** Keeps live and recovered queue transitions on the same producer claim. */
 export function createQueuedDeliveryOwner(params: {

--- a/src/infra/outbound/deliver-queue-state.ts
+++ b/src/infra/outbound/deliver-queue-state.ts
@@ -24,7 +24,7 @@ export const isDeliveryAbortError = (err: unknown): boolean =>
   (err instanceof OutboundDeliveryError &&
     isAbortError((err as Error & { cause?: unknown }).cause));
 
-export type QueuedPostSendState = "marked" | "acked" | "failed";
+export type QueuedPostSendState = "marked" | "unmarked" | "acked" | "failed";
 
 export type QueuedPreSendState = "marked" | "acked";
 
@@ -129,20 +129,10 @@ export async function persistQueuedPreSendState(params: {
 
 export async function persistQueuedPostSendState(params: {
   queueId: string;
-  queuePolicy: OutboundDeliveryQueuePolicy;
   stateDir?: string;
-  producerClaimId?: string;
   expectedPlatformSendAttemptId?: string | null;
-  retainSpoolArtifacts?: boolean;
-  onPostSendMarkerError?: (error: unknown) => void;
-}): Promise<QueuedPostSendState> {
-  const expectedPlatformSendAttemptId =
-    params.producerClaimId ?? params.expectedPlatformSendAttemptId;
-  const owner = createQueuedDeliveryOwner({
-    queueId: params.queueId,
-    stateDir: params.stateDir,
-    expectedPlatformSendAttemptId,
-  });
+}): Promise<"marked" | "unmarked"> {
+  const expectedPlatformSendAttemptId = params.expectedPlatformSendAttemptId;
   try {
     if (expectedPlatformSendAttemptId !== undefined) {
       await markDeliveryPlatformOutcomeUnknown(
@@ -157,32 +147,12 @@ export async function persistQueuedPostSendState(params: {
     }
     return "marked";
   } catch (markErr: unknown) {
-    if (params.producerClaimId) {
-      // A bounded batch may still contain identityless later payloads. Its
-      // intermediate state must never become a premature success receipt.
-      await failDeliveryAfterPlatformSend(
-        params.queueId,
-        `post-send state persistence failed: ${formatErrorMessage(markErr)}`,
-        params.stateDir,
-        params.producerClaimId,
-      );
-      return "failed";
-    }
-    params.onPostSendMarkerError?.(markErr);
+    // Progress is not settlement: ack would erase an unfinished batch, and
+    // failure would release its live lease. Keep the dispatch fence until the
+    // owner can ack complete success or persist the settled failure.
     log.warn(
-      `failed to mark queued delivery ${params.queueId} as platform-outcome-unknown; falling back to direct ack (${params.queuePolicy}): ${formatErrorMessage(markErr)}`,
+      `failed to mark queued delivery ${params.queueId} as platform-outcome-unknown; deferring settlement until the batch finishes: ${formatErrorMessage(markErr)}`,
     );
-    try {
-      // The platform already returned a result. If state marking is unavailable,
-      // deleting the intent is safer than leaving it replayable.
-      await owner.ack(params.retainSpoolArtifacts ? { retainSpoolArtifacts: true } : undefined);
-      return "acked";
-    } catch (ackErr: unknown) {
-      const error = `post-send state persistence failed: marker=${formatErrorMessage(markErr)}; ack=${formatErrorMessage(ackErr)}`;
-      // Keep the evidence in the same canonical row if both primary state
-      // transitions fail; a generic failure update would make it replayable.
-      await owner.fail(failDeliveryAfterPlatformSend, error);
-      return "failed";
-    }
+    return "unmarked";
   }
 }

--- a/src/infra/outbound/deliver-queue.lease-integration.test.ts
+++ b/src/infra/outbound/deliver-queue.lease-integration.test.ts
@@ -511,9 +511,12 @@ describe("delivery producer lease integration", () => {
       });
       await vi.advanceTimersByTimeAsync(10_001);
 
-      const rejected = expect(blocked.delivery).rejects.toThrow(
-        `Delivery platform claim was lost: ${deliveryIntentId}`,
-      );
+      const rejected = expect(blocked.delivery).rejects.toMatchObject({
+        name: "OutboundDeliveryError",
+        message: `Delivery platform claim was lost: ${deliveryIntentId}`,
+        sentBeforeError: true,
+        results: [{ channel: "matrix", messageId: `${deliveryIntentId}-message` }],
+      });
       blocked.releaseProvider();
       await rejected;
 

--- a/src/infra/outbound/deliver-types.ts
+++ b/src/infra/outbound/deliver-types.ts
@@ -133,7 +133,9 @@ export class OutboundDeliveryError extends Error {
     this.sentBeforeError =
       this.results.length > 0 ||
       this.payloadOutcomes.some(
-        (outcome) => outcome.status === "failed" && outcome.sentBeforeError,
+        (outcome) =>
+          (outcome.status === "failed" && outcome.sentBeforeError) ||
+          (outcome.status === "suppressed" && outcome.reason === "adapter_returned_no_identity"),
       );
     this.stage = options.stage ?? "unknown";
   }

--- a/src/infra/outbound/deliver.queue-dispatch-evidence.integration.test.ts
+++ b/src/infra/outbound/deliver.queue-dispatch-evidence.integration.test.ts
@@ -152,4 +152,65 @@ describe("queued delivery dispatch evidence", () => {
       recoveryState: "unknown_after_send",
     });
   });
+
+  it.each([
+    { chunked: true, bestEffort: false },
+    { chunked: true, bestEffort: true },
+    { chunked: false, bestEffort: false },
+    { chunked: false, bestEffort: true },
+  ])(
+    "keeps earlier identity loss when a later send is rejected ($chunked/$bestEffort)",
+    async ({ chunked, bestEffort }) => {
+      vi.stubEnv("OPENCLAW_STATE_DIR", tmpDir);
+      setActivePluginRegistry(
+        createTestRegistry([
+          {
+            pluginId: "matrix",
+            source: "test",
+            plugin: createOutboundTestPlugin({
+              id: "matrix",
+              outbound: {
+                ...matrixOutboundForQueueTest,
+                ...(chunked
+                  ? { chunker: (text: string) => text.split(" "), textChunkLimit: 6 }
+                  : {}),
+              },
+            }),
+          },
+        ]),
+      );
+      const sendMatrix = vi
+        .fn()
+        .mockResolvedValueOnce({ messageId: "" })
+        .mockRejectedValueOnce(
+          new PlatformMessageNotDispatchedError("later unit rejected", { cause: undefined }),
+        );
+      const outcomes: OutboundPayloadDeliveryOutcome[] = [];
+      try {
+        await deliverOutboundPayloads({
+          cfg: {},
+          channel: "matrix",
+          to: "!room:example",
+          payloads: chunked ? [{ text: "first second" }] : [{ text: "first" }, { text: "second" }],
+          deps: { matrix: sendMatrix },
+          queuePolicy: "required",
+          bestEffort,
+          onPayloadDeliveryOutcome: (outcome) => outcomes.push(outcome),
+        }).catch((error: unknown) => {
+          expect(error).toMatchObject({ message: "later unit rejected" });
+        });
+        expect(sendMatrix.mock.calls.map((call) => call[1])).toEqual(["first", "second"]);
+        expect(await loadPendingDeliveries(tmpDir)).toEqual([
+          expect.objectContaining({ recoveryState: "unknown_after_send" }),
+        ]);
+        if (chunked) {
+          expect(outcomes).toEqual([
+            expect.objectContaining({ status: "failed", sentBeforeError: true }),
+          ]);
+        }
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    },
+  );
 });

--- a/src/infra/outbound/deliver.queue-integration.test.ts
+++ b/src/infra/outbound/deliver.queue-integration.test.ts
@@ -646,46 +646,51 @@ describe("deliverOutboundPayloads queue integration: mid-batch failure with send
     expect(sendMatrix).toHaveBeenCalledOnce();
   });
 
-  it("never completes live Matrix batches when any platform send lacks an identity", async () => {
-    process.env.OPENCLAW_STATE_DIR = tmpDir;
-    const sendMatrix = vi
-      .fn()
-      .mockResolvedValueOnce({ messageId: "confirmed-live-message" })
-      .mockResolvedValueOnce({});
-    const deliveryIntentId = "cron-direct-delivery:v1:live-matrix-partial-no-identity";
-    const params = {
-      cfg: {} as OpenClawConfig,
-      channel: "matrix" as const,
-      to: "!room:example",
-      payloads: [{ text: "confirmed recipient message" }, { text: "ambiguous message" }],
-      deps: { matrix: sendMatrix },
-      queuePolicy: "required" as const,
-      deliveryIntentId,
-      completionRetention: boundedCronCompletionRetention,
-      reusePendingDeliveryIntent: true,
-    };
+  it.each([false, true])(
+    "never completes live Matrix batches with missing identity (reuse=%s)",
+    async (reusePendingDeliveryIntent) => {
+      process.env.OPENCLAW_STATE_DIR = tmpDir;
+      const sendMatrix = vi
+        .fn()
+        .mockResolvedValueOnce({ messageId: "confirmed-live-message" })
+        .mockResolvedValueOnce({});
+      const deliveryIntentId = "cron-direct-delivery:v1:live-matrix-partial-no-identity";
+      const params = {
+        cfg: {} as OpenClawConfig,
+        channel: "matrix" as const,
+        to: "!room:example",
+        payloads: [{ text: "confirmed recipient message" }, { text: "ambiguous message" }],
+        deps: { matrix: sendMatrix },
+        queuePolicy: "required" as const,
+        deliveryIntentId,
+        completionRetention: boundedCronCompletionRetention,
+        reusePendingDeliveryIntent,
+      };
 
-    await expect(deliverOutboundPayloads(params)).rejects.toThrow(
-      "platform send returned no delivery identity for part of the delivery batch",
-    );
-    expect(sendMatrix).toHaveBeenCalledTimes(2);
-    expect((await loadPendingDeliveries(tmpDir))[0]).toMatchObject({
-      id: deliveryIntentId,
-      recoveryState: "unknown_after_send",
-      retryCount: 1,
-    });
-    expect(
-      getDeliveryQueueEntryStatus(OUTBOUND_DELIVERY_QUEUE_NAME, deliveryIntentId, tmpDir),
-    ).toBe("pending");
+      await expect(deliverOutboundPayloads(params)).rejects.toThrow(
+        "platform send returned no delivery identity for part of the delivery batch",
+      );
+      expect(sendMatrix).toHaveBeenCalledTimes(2);
+      expect((await loadPendingDeliveries(tmpDir))[0]).toMatchObject({
+        id: deliveryIntentId,
+        recoveryState: "unknown_after_send",
+        retryCount: 1,
+      });
+      expect(
+        getDeliveryQueueEntryStatus(OUTBOUND_DELIVERY_QUEUE_NAME, deliveryIntentId, tmpDir),
+      ).toBe("pending");
 
-    await expect(deliverOutboundPayloads(params)).rejects.toThrow(
-      `Stable delivery intent is already queued: ${deliveryIntentId}`,
-    );
-    expect(sendMatrix).toHaveBeenCalledTimes(2);
-    expect(
-      getDeliveryQueueEntryStatus(OUTBOUND_DELIVERY_QUEUE_NAME, deliveryIntentId, tmpDir),
-    ).not.toBe("completed");
-  });
+      if (reusePendingDeliveryIntent) {
+        await expect(deliverOutboundPayloads(params)).rejects.toThrow(
+          `Stable delivery intent is already queued: ${deliveryIntentId}`,
+        );
+      }
+      expect(sendMatrix).toHaveBeenCalledTimes(2);
+      expect(
+        getDeliveryQueueEntryStatus(OUTBOUND_DELIVERY_QUEUE_NAME, deliveryIntentId, tmpDir),
+      ).not.toBe("completed");
+    },
+  );
 
   it.each(["abort", "permanent rejection"] as const)(
     "never creates a successful stable receipt after platform %s",

--- a/src/infra/outbound/deliver.queue-marker.integration.test.ts
+++ b/src/infra/outbound/deliver.queue-marker.integration.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { createMessageReceiptFromOutboundResults } from "../../channels/message/receipt.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
+import { getDeliveryQueueEntryStatus, updateDeliveryQueueEntry } from "../delivery-queue-sqlite.js";
+import { PlatformMessageNotDispatchedError } from "./deliver-types.js";
+import { deliverOutboundPayloads } from "./deliver.js";
+import { drainMatrixReconnect } from "./deliver.queue-integration.test-support.js";
+import { OUTBOUND_DELIVERY_QUEUE_NAME } from "./delivery-queue-media-staging.js";
+import * as queueStorage from "./delivery-queue-storage.js";
+import { installDeliveryQueueTmpDirHooks, readQueuedEntry } from "./delivery-queue.test-helpers.js";
+
+describe("delivery ownership after intermediate marker failure", () => {
+  const fixtures = installDeliveryQueueTmpDirHooks();
+  let clock = Date.parse("2026-08-02T10:00:00.000Z");
+  beforeEach(() => {
+    vi.stubEnv("OPENCLAW_STATE_DIR", fixtures.tmpDir());
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+    resetPluginRuntimeStateForTest();
+    setActivePluginRegistry(createTestRegistry());
+  });
+
+  it.each([
+    { recovery: false, outcome: "identified" },
+    { recovery: true, outcome: "identified" },
+    { recovery: false, outcome: "identityless" },
+    { recovery: true, outcome: "identityless" },
+    { recovery: false, outcome: "rejected" },
+    { recovery: true, outcome: "rejected" },
+  ])(
+    "keeps the lease until $outcome settlement (recovery=$recovery)",
+    async ({ recovery, outcome }) => {
+      vi.useFakeTimers();
+      vi.setSystemTime((clock += 60_000));
+      const secondEntered = createDeferred();
+      const releaseSecond = createDeferred();
+      const accepted: string[] = [];
+      setActivePluginRegistry(
+        createTestRegistry([
+          {
+            pluginId: "matrix",
+            source: "test",
+            plugin: createOutboundTestPlugin({
+              id: "matrix",
+              outbound: {
+                deliveryMode: "direct",
+                sendText: async ({ text, onPlatformSendDispatch }) => {
+                  await onPlatformSendDispatch?.();
+                  if (text === "second") {
+                    secondEntered.resolve();
+                    await releaseSecond.promise;
+                    if (outcome === "rejected") {
+                      throw new PlatformMessageNotDispatchedError("second send rejected", {
+                        cause: undefined,
+                      });
+                    }
+                  }
+                  accepted.push(text);
+                  return {
+                    channel: "matrix",
+                    messageId: text === "second" && outcome === "identityless" ? "" : text,
+                  };
+                },
+              },
+            }),
+          },
+        ]),
+      );
+      vi.spyOn(queueStorage, "markDeliveryPlatformOutcomeUnknown").mockRejectedValueOnce(
+        new Error("marker unavailable"),
+      );
+      const id = "marker-failure-batch";
+      const params = {
+        cfg: {},
+        channel: "matrix",
+        to: "!room:example",
+        payloads: [{ text: "first" }, { text: "second" }],
+        queuePolicy: "required" as const,
+        bestEffort: true,
+      };
+      if (recovery) {
+        await queueStorage.enqueueDeliveryOnce(
+          { ...params, requiresProducerClaim: true },
+          id,
+          fixtures.tmpDir(),
+        );
+      }
+      const sending = recovery
+        ? drainMatrixReconnect({ stateDir: fixtures.tmpDir(), deliver: deliverOutboundPayloads })
+        : deliverOutboundPayloads({ ...params, deliveryIntentId: id });
+      // Install rejection handling before advancing the heartbeat.
+      const settled = sending.then(
+        (value) => ({ value }),
+        (error: unknown) => ({ error }),
+      );
+      try {
+        await Promise.race([
+          secondEntered.promise,
+          settled.then(() => {
+            throw new Error("batch settled before its second send");
+          }),
+        ]);
+        await vi.advanceTimersByTimeAsync(10_001);
+        expect(readQueuedEntry(fixtures.tmpDir(), id).availableAt).toBeGreaterThan(Date.now());
+        expect(readQueuedEntry(fixtures.tmpDir(), id).retryCount).toBe(0);
+        releaseSecond.resolve();
+        const result = await settled;
+        if (outcome === "identified") {
+          expect(result).not.toHaveProperty("error");
+          expect(
+            getDeliveryQueueEntryStatus(OUTBOUND_DELIVERY_QUEUE_NAME, id, fixtures.tmpDir()),
+          ).toBeUndefined();
+          expect(accepted).toEqual(["first", "second"]);
+        } else {
+          expect(readQueuedEntry(fixtures.tmpDir(), id)).toMatchObject({
+            recoveryState: "unknown_after_send",
+            retryCount: 1,
+          });
+          expect(accepted).toEqual(outcome === "identityless" ? ["first", "second"] : ["first"]);
+        }
+      } finally {
+        releaseSecond.resolve();
+        await settled;
+      }
+    },
+  );
+
+  it("rechecks claim ownership before another send after a marker failure", async () => {
+    const accepted: string[] = [];
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "matrix",
+            outbound: {
+              deliveryMode: "direct",
+              sendText: async ({ text, onPlatformSendDispatch }) => {
+                await onPlatformSendDispatch?.();
+                accepted.push(text);
+                return { channel: "matrix", messageId: text };
+              },
+            },
+          }),
+        },
+      ]),
+    );
+    vi.spyOn(queueStorage, "markDeliveryPlatformOutcomeUnknown").mockImplementationOnce(
+      async (id) => {
+        updateDeliveryQueueEntry(OUTBOUND_DELIVERY_QUEUE_NAME, id, fixtures.tmpDir(), (entry) => ({
+          ...entry,
+          platformSendAttemptId: "replacement-owner",
+        }));
+        throw new Error("marker lost its owner");
+      },
+    );
+    await expect(
+      deliverOutboundPayloads({
+        cfg: {},
+        channel: "matrix",
+        to: "!room:example",
+        payloads: [{ text: "first" }, { text: "second" }],
+        queuePolicy: "required",
+        deliveryIntentId: "replaced-marker-owner",
+      }),
+    ).rejects.toMatchObject({ sentBeforeError: true });
+    expect(accepted).toEqual(["first"]);
+    expect(readQueuedEntry(fixtures.tmpDir(), "replaced-marker-owner")).toMatchObject({
+      platformSendAttemptId: "replacement-owner",
+      retryCount: 0,
+    });
+  });
+
+  it("completes a receipt-only aggregate after several physical sends", async () => {
+    const ids = ["first", "second"];
+    const onDeliveredPayload = vi.fn();
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "matrix",
+            outbound: {
+              deliveryMode: "direct",
+              sendText: async ({ onDeliveryResult, onPlatformSendDispatch }) => {
+                for (const messageId of ids) {
+                  await onPlatformSendDispatch?.();
+                  await onDeliveryResult?.({ channel: "matrix", messageId });
+                }
+                return {
+                  channel: "matrix",
+                  messageId: "",
+                  receipt: createMessageReceiptFromOutboundResults({
+                    results: ids.map((messageId) => ({ messageId })),
+                  }),
+                };
+              },
+            },
+          }),
+        },
+      ]),
+    );
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "matrix",
+      to: "!room:example",
+      payloads: [{ text: "two physical sends" }],
+      queuePolicy: "required",
+      deliveryIntentId: "aggregate-success",
+      onDeliveredPayload,
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0]?.receipt?.platformMessageIds).toEqual(ids);
+    expect(onDeliveredPayload).toHaveBeenCalledOnce();
+    expect(
+      getDeliveryQueueEntryStatus(
+        OUTBOUND_DELIVERY_QUEUE_NAME,
+        "aggregate-success",
+        fixtures.tmpDir(),
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/src/infra/outbound/deliver.queue-symmetry.integration.test.ts
+++ b/src/infra/outbound/deliver.queue-symmetry.integration.test.ts
@@ -1,0 +1,168 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
+import { getDeliveryQueueEntryStatus } from "../delivery-queue-sqlite.js";
+import {
+  PlatformMessageNotDispatchedError,
+  type OutboundDeliveryResult,
+  type OutboundPayloadDeliveryOutcome,
+} from "./deliver-types.js";
+import {
+  drainMatrixReconnect,
+  matrixOutboundForQueueTest,
+} from "./deliver.queue-integration.test-support.js";
+import { OUTBOUND_DELIVERY_QUEUE_NAME } from "./delivery-queue-media-staging.js";
+import type { DeliverFn } from "./delivery-queue-recovery.js";
+import { enqueueDelivery } from "./delivery-queue-storage.js";
+import {
+  installDeliveryQueueTmpDirHooks,
+  loadPendingDeliveries,
+} from "./delivery-queue.test-helpers.js";
+
+let deliverOutboundPayloads: typeof import("./deliver.js").deliverOutboundPayloads;
+
+beforeAll(async () => {
+  ({ deliverOutboundPayloads } = await import("./deliver.js"));
+});
+
+describe.each(["live", "recovery"] as const)("ordinary %s batch custody", (entryPoint) => {
+  const fixtures = installDeliveryQueueTmpDirHooks();
+
+  beforeEach(() => {
+    vi.stubEnv("OPENCLAW_STATE_DIR", fixtures.tmpDir());
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: createOutboundTestPlugin({ id: "matrix", outbound: matrixOutboundForQueueTest }),
+        },
+      ]),
+    );
+  });
+
+  afterEach(() => {
+    resetPluginRuntimeStateForTest();
+    setActivePluginRegistry(createTestRegistry());
+    vi.unstubAllEnvs();
+  });
+
+  it.each(["identified", "identityless-tail", "not-dispatched"] as const)(
+    "settles a %s batch from the same platform evidence",
+    async (outcome) => {
+      const stateDir = fixtures.tmpDir();
+      const payloads = [{ text: "first" }, { text: "second" }];
+      const sendMatrix = vi.fn(async (_to: string, text: string) => {
+        if (outcome === "not-dispatched") {
+          throw new PlatformMessageNotDispatchedError("transport rejected before dispatch", {
+            cause: undefined,
+          });
+        }
+        return { messageId: outcome === "identityless-tail" && text === "second" ? "" : text };
+      });
+      const outcomes: OutboundPayloadDeliveryOutcome[] = [];
+      const platformStarted = vi.fn();
+      let results: OutboundDeliveryResult[] = [];
+      const deliver = vi.fn<DeliverFn>(async (params) => {
+        results = await deliverOutboundPayloads({
+          ...params,
+          deps: { matrix: sendMatrix },
+          onPlatformSendStart: async (route, sourceIndex) => {
+            platformStarted();
+            await params.onPlatformSendStart?.(route, sourceIndex);
+          },
+          onPayloadDeliveryOutcome: (payloadOutcome) => {
+            outcomes.push(payloadOutcome);
+            params.onPayloadDeliveryOutcome?.(payloadOutcome);
+          },
+        });
+        return results;
+      });
+      const delivery = {
+        channel: "matrix" as const,
+        to: "!room:example",
+        payloads,
+        queuePolicy: "required" as const,
+        bestEffort: outcome === "not-dispatched",
+      };
+      let queueId: string | undefined;
+      if (entryPoint === "live") {
+        const sending = deliver({
+          ...delivery,
+          cfg: {},
+          onDeliveryIntent: ({ id }) => {
+            queueId = id;
+          },
+        });
+        if (outcome === "identityless-tail") {
+          await expect(sending).rejects.toMatchObject({
+            name: "OutboundDeliveryError",
+            sentBeforeError: true,
+            results: [{ channel: "matrix", messageId: "first" }],
+          });
+        } else {
+          await sending;
+        }
+      } else {
+        queueId = await enqueueDelivery({ ...delivery, requiresProducerClaim: true }, stateDir);
+        await drainMatrixReconnect({ deliver, stateDir });
+      }
+
+      const id = expectDefined(queueId, "ordinary batch must acquire queue custody");
+      expect(sendMatrix.mock.calls.map((call) => call[1])).toEqual(["first", "second"]);
+      // Real nested recovery must receive send-start even when the transport
+      // later proves no dispatch; a DB-only marker fixture misses this branch.
+      expect(platformStarted).toHaveBeenCalledTimes(2);
+      if (outcome === "identified") {
+        expect(results.map((result) => result.messageId)).toEqual(["first", "second"]);
+        expect(outcomes.map((result) => result.status)).toEqual(["sent", "sent"]);
+        expect(await loadPendingDeliveries(stateDir)).toEqual([]);
+        expect(
+          getDeliveryQueueEntryStatus(OUTBOUND_DELIVERY_QUEUE_NAME, id, stateDir),
+        ).toBeUndefined();
+        return;
+      }
+
+      const pending = await loadPendingDeliveries(stateDir);
+      expect(pending).toEqual([expect.objectContaining({ id, retryCount: 1 })]);
+      expect(getDeliveryQueueEntryStatus(OUTBOUND_DELIVERY_QUEUE_NAME, id, stateDir)).toBe(
+        "pending",
+      );
+      if (outcome === "identityless-tail") {
+        expect(pending[0]?.recoveryState).toBe("unknown_after_send");
+        expect(outcomes).toEqual([
+          expect.objectContaining({ index: 0, status: "sent" }),
+          { index: 1, status: "suppressed", reason: "adapter_returned_no_identity" },
+        ]);
+        await drainMatrixReconnect({ deliver, stateDir });
+        expect(sendMatrix).toHaveBeenCalledTimes(2);
+        expect(getDeliveryQueueEntryStatus(OUTBOUND_DELIVERY_QUEUE_NAME, id, stateDir)).not.toBe(
+          "completed",
+        );
+        return;
+      }
+
+      expect(results).toEqual([]);
+      expect(pending[0]?.recoveryState).toBeUndefined();
+      expect(pending[0]?.platformSendStartedAt).toBeUndefined();
+      expect(outcomes).toEqual([
+        expect.objectContaining({ index: 0, status: "failed", sentBeforeError: false }),
+        expect.objectContaining({ index: 1, status: "failed", sentBeforeError: false }),
+      ]);
+      sendMatrix.mockImplementation(async (_to, text) => ({ messageId: text }));
+      await drainMatrixReconnect({ deliver, stateDir });
+      expect(sendMatrix.mock.calls.map((call) => call[1])).toEqual([
+        "first",
+        "second",
+        "first",
+        "second",
+      ]);
+      expect(results.map((result) => result.messageId)).toEqual(["first", "second"]);
+      expect(await loadPendingDeliveries(stateDir)).toEqual([]);
+      expect(
+        getDeliveryQueueEntryStatus(OUTBOUND_DELIVERY_QUEUE_NAME, id, stateDir),
+      ).toBeUndefined();
+    },
+  );
+});

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -1810,6 +1810,89 @@ describe("deliverOutboundPayloads", () => {
     expect(queueWarn).toContain("queue offline");
   });
 
+  it.each([
+    { boundary: "enqueue failure", identifiedPrefix: true },
+    { boundary: "pre-send acknowledgement", identifiedPrefix: true },
+    { boundary: "uncertainty persistence failure", identifiedPrefix: true },
+    { boundary: "uncertainty persistence failure", identifiedPrefix: false },
+  ])(
+    "preserves identity loss across $boundary (identified prefix: $identifiedPrefix)",
+    async ({ boundary, identifiedPrefix }) => {
+      if (boundary === "enqueue failure") {
+        queueMocks.enqueueDelivery.mockRejectedValueOnce(new Error("queue offline"));
+      } else if (boundary === "pre-send acknowledgement") {
+        queueMocks.markDeliveryPlatformSendAttemptStarted.mockRejectedValueOnce(
+          new Error("pre-send marker offline"),
+        );
+        queueMocks.failDeliveryAfterPlatformSend.mockRejectedValue(new Error("queue row is gone"));
+      } else {
+        queueMocks.failDeliveryAfterPlatformSend.mockRejectedValueOnce(
+          new Error("queue update offline"),
+        );
+      }
+      hookMocks.runner.hasHooks.mockImplementation((hookName) => hookName === "message_sent");
+      const sendMatrix = vi.fn().mockResolvedValue({ messageId: "" });
+      if (identifiedPrefix) {
+        sendMatrix.mockResolvedValueOnce({ messageId: "confirmed" });
+      }
+      const payloads = identifiedPrefix
+        ? [{ text: "confirmed prefix" }, { text: "uncertain tail" }]
+        : [{ text: "uncertain send" }];
+      const events: TrustedMessageAuditEvent[] = [];
+      const unsubscribe = onTrustedMessageAuditEvent((event) => events.push(event));
+      let failure: unknown;
+      try {
+        failure = await deliverMatrix({
+          payloads,
+          deps: { matrix: sendMatrix },
+          queuePolicy: "best_effort",
+          deliveryCompletion: {
+            kind: "pending-final",
+            deliveryId: "uncertain-delivery",
+            intentId: "uncertain-intent",
+            sessionId: "uncertain-session",
+            sessionKey: "agent:main:matrix:direct:uncertain",
+            storePath: "/tmp/sessions.json",
+          },
+        }).catch((error: unknown) => error);
+      } finally {
+        unsubscribe();
+      }
+
+      expect(sendMatrix).toHaveBeenCalledTimes(payloads.length);
+      expect(failure).toMatchObject({
+        name: "OutboundDeliveryError",
+        results: identifiedPrefix ? [{ channel: "matrix", messageId: "confirmed" }] : [],
+        payloadOutcomes: [
+          ...(identifiedPrefix ? [{ index: 0, status: "sent" }] : []),
+          {
+            index: identifiedPrefix ? 1 : 0,
+            status: "suppressed",
+            reason: "adapter_returned_no_identity",
+          },
+        ],
+        ...(identifiedPrefix ? { sentBeforeError: true } : {}),
+      });
+      expect(completionMocks.completeDurableDelivery).not.toHaveBeenCalled();
+      expect(completionMocks.suppressDurableDelivery).not.toHaveBeenCalled();
+      const terminalOutcomes = events
+        .filter((event) => event.action === "message.outbound.finished")
+        .map((event) => event.outcome);
+      if (boundary === "uncertainty persistence failure") {
+        expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
+        expect(hookMocks.runner.runMessageSent).not.toHaveBeenCalled();
+        expect(terminalOutcomes).toEqual([]);
+      } else {
+        expect(queueMocks.ackDelivery).toHaveBeenCalledTimes(
+          boundary === "pre-send acknowledgement" ? 1 : 0,
+        );
+        expect(queueMocks.failDeliveryAfterPlatformSend).not.toHaveBeenCalled();
+        expect(hookMocks.runner.runMessageSent).toHaveBeenCalledTimes(payloads.length);
+        expect(terminalOutcomes).toEqual(["sent", "unknown"]);
+      }
+    },
+  );
+
   it("emits one message_sent failure per payload when batch preparation fails", async () => {
     hookMocks.runner.hasHooks.mockImplementation(
       (hookName?: string) => hookName === "message_sent" || hookName === "reply_payload_sending",
@@ -2377,7 +2460,7 @@ describe("deliverOutboundPayloads", () => {
     );
   });
 
-  it("directly acks a sent delivery when the post-send unknown marker cannot be written", async () => {
+  it("retains custody when the post-send unknown marker cannot be written", async () => {
     queueMocks.markDeliveryPlatformOutcomeUnknown.mockRejectedValueOnce(
       new Error("unknown marker offline"),
     );
@@ -2390,11 +2473,15 @@ describe("deliverOutboundPayloads", () => {
     });
 
     expect(sendMatrix).toHaveBeenCalled();
-    expect(queueMocks.ackDelivery).toHaveBeenCalledWith("mock-queue-id");
+    expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
+    expect(queueMocks.failDeliveryAfterPlatformSend).toHaveBeenCalledWith(
+      "mock-queue-id",
+      expect.stringContaining("post-send state persistence failed"),
+    );
     expect(queueMocks.failDelivery).not.toHaveBeenCalled();
   });
 
-  it("runs sent-result commit hooks when marker fallback ack precedes a partial failure", async () => {
+  it("defers commit hooks when marker persistence fails before a partial failure", async () => {
     queueMocks.markDeliveryPlatformOutcomeUnknown.mockRejectedValueOnce(
       new Error("unknown marker offline"),
     );
@@ -2416,28 +2503,8 @@ describe("deliverOutboundPayloads", () => {
     });
 
     expect(results).toHaveLength(1);
-    expect(queueMocks.ackDelivery).toHaveBeenCalledTimes(1);
-    expect(afterCommit).toHaveBeenCalledTimes(1);
-    expect(queueMocks.failDelivery).not.toHaveBeenCalled();
-  });
-
-  it("retains unknown-after-send evidence when both the marker and direct ack fail", async () => {
-    queueMocks.markDeliveryPlatformOutcomeUnknown.mockRejectedValueOnce(
-      new Error("unknown marker offline"),
-    );
-    queueMocks.ackDelivery.mockRejectedValueOnce(new Error("ack offline"));
-    const sendMatrix = vi.fn().mockResolvedValue({ messageId: "m1" });
-
-    await deliverMatrix({
-      payloads: [{ text: "hi" }],
-      deps: { matrix: sendMatrix },
-      queuePolicy: "required",
-    });
-
-    expect(queueMocks.failDeliveryAfterPlatformSend).toHaveBeenCalledWith(
-      "mock-queue-id",
-      expect.stringContaining("marker=unknown marker offline; ack=ack offline"),
-    );
+    expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
+    expect(afterCommit).not.toHaveBeenCalled();
     expect(queueMocks.failDelivery).not.toHaveBeenCalled();
   });
 
@@ -5490,7 +5557,7 @@ describe("deliverOutboundPayloads", () => {
     expect(mocks.appendAssistantMessageToSessionTranscript).not.toHaveBeenCalled();
   });
 
-  it("does not reuse a previous payload message id for a suppressed text send", async () => {
+  it("does not reuse a previous payload message id for an identityless text send", async () => {
     hookMocks.runner.hasHooks.mockReturnValue(true);
     const sendText = vi
       .fn()
@@ -5498,31 +5565,36 @@ describe("deliverOutboundPayloads", () => {
       .mockResolvedValueOnce({ channel: "matrix", messageId: "" });
     setTestOutbound({ sendText });
 
-    const results = await deliverMatrix({
-      to: "!room:1",
-      payloads: [{ text: "first" }, { text: "second" }],
-    });
+    const onMessageSentEvent = vi.fn();
+    await expect(
+      deliverMatrix({
+        to: "!room:1",
+        onMessageSentEvent,
+        payloads: [{ text: "first" }, { text: "second" }],
+      }),
+    ).rejects.toMatchObject({ results: [{ channel: "matrix", messageId: "mx-1" }] });
 
-    expect(results).toStrictEqual([{ channel: "matrix", messageId: "mx-1" }]);
-    expect(hookMocks.runner.runMessageSent).toHaveBeenCalledTimes(2);
-    expect(hookMocks.runner.runMessageSent).toHaveBeenNthCalledWith(
+    expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
+    expect(hookMocks.runner.runMessageSent).not.toHaveBeenCalled();
+    expect(onMessageSentEvent).toHaveBeenCalledTimes(2);
+    expect(onMessageSentEvent).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
         content: "first",
         success: true,
         messageId: "mx-1",
       }),
-      expect.objectContaining({ channelId: "matrix" }),
+      0,
     );
-    expect(hookMocks.runner.runMessageSent).toHaveBeenNthCalledWith(
+    expect(onMessageSentEvent).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
         content: "second",
         success: false,
       }),
-      expect.objectContaining({ channelId: "matrix" }),
+      1,
     );
-    expect(hookMocks.runner.runMessageSent.mock.calls[1]?.[0]).not.toHaveProperty("messageId");
+    expect(onMessageSentEvent.mock.calls[1]?.[0]?.messageId).toBeUndefined();
   });
 
   it("emits message_sent success for sendPayload deliveries", async () => {

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -5455,7 +5455,7 @@ describe("deliverOutboundPayloads", () => {
     expect(sendText).not.toHaveBeenCalled();
   });
 
-  it("does not count no-op sendPayload results as delivered", async () => {
+  it("keeps identityless sendPayload results uncertain when required pinning cannot finish", async () => {
     hookMocks.runner.hasHooks.mockReturnValue(true);
     const sendText = vi.fn();
     const pinDeliveredMessage = vi.fn<OutboundPinDeliveredMessage>();
@@ -5465,23 +5465,23 @@ describe("deliverOutboundPayloads", () => {
       { sendText, sendTextOnlyErrorPayloads: true, pinDeliveredMessage, afterDeliverPayload },
     );
 
-    const results = await deliverMatrix({
-      to: "!room:1",
-      payloads: [
-        {
+    await expect(
+      deliverMatrix({
+        to: "!room:1",
+        payloads: [
+          {
+            text: "provider exploded",
+            isError: true,
+            delivery: { pin: { enabled: true, required: true } },
+          },
+        ],
+        mirror: {
+          sessionKey: "agent:main:main",
+          agentId: "main",
           text: "provider exploded",
-          isError: true,
-          delivery: { pin: { enabled: true, required: true } },
         },
-      ],
-      mirror: {
-        sessionKey: "agent:main:main",
-        agentId: "main",
-        text: "provider exploded",
-      },
-    });
-
-    expect(results).toStrictEqual([]);
+      }),
+    ).rejects.toThrow("no delivered message id was returned");
     expect(sendPayload).toHaveBeenCalledTimes(1);
     expect(sendText).not.toHaveBeenCalled();
     expect(pinDeliveredMessage).not.toHaveBeenCalled();

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -2460,7 +2460,7 @@ describe("deliverOutboundPayloads", () => {
     );
   });
 
-  it("retains custody when the post-send unknown marker cannot be written", async () => {
+  it("acks a fully identified batch after an intermediate marker failure", async () => {
     queueMocks.markDeliveryPlatformOutcomeUnknown.mockRejectedValueOnce(
       new Error("unknown marker offline"),
     );
@@ -2473,11 +2473,8 @@ describe("deliverOutboundPayloads", () => {
     });
 
     expect(sendMatrix).toHaveBeenCalled();
-    expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
-    expect(queueMocks.failDeliveryAfterPlatformSend).toHaveBeenCalledWith(
-      "mock-queue-id",
-      expect.stringContaining("post-send state persistence failed"),
-    );
+    expect(queueMocks.ackDelivery).toHaveBeenCalledExactlyOnceWith("mock-queue-id");
+    expect(queueMocks.failDeliveryAfterPlatformSend).not.toHaveBeenCalled();
     expect(queueMocks.failDelivery).not.toHaveBeenCalled();
   });
 
@@ -2503,8 +2500,13 @@ describe("deliverOutboundPayloads", () => {
     });
 
     expect(results).toHaveLength(1);
+    expect(messageSendText).toHaveBeenCalledTimes(2);
     expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
     expect(afterCommit).not.toHaveBeenCalled();
+    expect(queueMocks.failDeliveryAfterPlatformSend).toHaveBeenCalledWith(
+      "mock-queue-id",
+      "partial delivery failure (bestEffort)",
+    );
     expect(queueMocks.failDelivery).not.toHaveBeenCalled();
   });
 

--- a/src/infra/outbound/deliver.unit-identity.integration.test.ts
+++ b/src/infra/outbound/deliver.unit-identity.integration.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sendDurableMessageBatchCore } from "../../channels/message/send.js";
+import type { ChannelOutboundAdapter } from "../../channels/plugins/types.public.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
+import { getDeliveryQueueEntryStatus } from "../delivery-queue-sqlite.js";
+import { boundedCronCompletionRetention } from "./deliver.queue-integration.test-support.js";
+import { OUTBOUND_DELIVERY_QUEUE_NAME } from "./delivery-queue-media-staging.js";
+import {
+  installDeliveryQueueTmpDirHooks,
+  loadPendingDeliveries,
+} from "./delivery-queue.test-helpers.js";
+
+describe("queued payload send-unit identity accounting", () => {
+  const fixtures = installDeliveryQueueTmpDirHooks();
+
+  beforeEach(() => {
+    vi.stubEnv("OPENCLAW_STATE_DIR", fixtures.tmpDir());
+  });
+
+  afterEach(() => {
+    resetPluginRuntimeStateForTest();
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    vi.unstubAllEnvs();
+  });
+
+  it.each(["text", "formatted text", "media", "formatted media", "media text fallback"])(
+    "keeps custody when a %s payload loses its second send identity",
+    async (kind) => {
+      const accepted: string[] = [];
+      const send = async (text: string, dispatch?: () => Promise<void>) => {
+        await dispatch?.();
+        accepted.push(text);
+        return { channel: "matrix" as const, messageId: accepted.length === 1 ? "confirmed" : "" };
+      };
+      const outbound: ChannelOutboundAdapter = {
+        deliveryMode: "direct",
+        textChunkLimit: 6,
+        chunker: (text) => text.split(" "),
+        sendText: ({ text, onPlatformSendDispatch }) => send(text, onPlatformSendDispatch),
+        ...(kind === "formatted text"
+          ? {
+              sendFormattedText: async ({ text, onPlatformSendDispatch }) => {
+                const results = [];
+                for (const chunk of text.split(" ")) {
+                  results.push(await send(chunk, onPlatformSendDispatch));
+                }
+                return results;
+              },
+            }
+          : {}),
+        ...(kind === "media" || kind === "formatted media"
+          ? {
+              sendMedia: ({ mediaUrl, onPlatformSendDispatch }) =>
+                send(mediaUrl!, onPlatformSendDispatch),
+            }
+          : {}),
+        ...(kind === "formatted media"
+          ? {
+              sendFormattedMedia: ({ mediaUrl, onPlatformSendDispatch }) =>
+                send(mediaUrl!, onPlatformSendDispatch),
+            }
+          : {}),
+      };
+      setActivePluginRegistry(
+        createTestRegistry([
+          {
+            pluginId: "matrix",
+            source: "test",
+            plugin: createOutboundTestPlugin({ id: "matrix", outbound }),
+          },
+        ]),
+      );
+      const mediaUrls = ["https://example.com/first.png", "https://example.com/second.png"];
+      const deliveryIntentId = "cron-direct-delivery:v1:mixed-unit-identity";
+      const onDeliveredPayload = vi.fn();
+      const onMessageSentEvent = vi.fn();
+      const params = {
+        cfg: {},
+        channel: "matrix" as const,
+        to: "!room:example",
+        payloads: [{ text: "first second", ...(kind.includes("media") ? { mediaUrls } : {}) }],
+        durability: "required" as const,
+        deliveryIntentId,
+        completionRetention: boundedCronCompletionRetention,
+        reusePendingDeliveryIntent: true,
+        onDeliveredPayload,
+        onMessageSentEvent,
+      };
+
+      const result = await sendDurableMessageBatchCore(params);
+
+      expect(accepted).toEqual(
+        kind === "media" || kind === "formatted media" ? mediaUrls : ["first", "second"],
+      );
+      expect(result).toMatchObject({
+        status: "partial_failed",
+        results: [{ messageId: "confirmed" }],
+        payloadOutcomes: [
+          { index: 0, status: "suppressed", reason: "adapter_returned_no_identity" },
+        ],
+      });
+      expect(onDeliveredPayload).not.toHaveBeenCalled();
+      expect(onMessageSentEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ success: false }),
+        0,
+      );
+      expect((await loadPendingDeliveries(fixtures.tmpDir()))[0]).toMatchObject({
+        id: deliveryIntentId,
+        recoveryState: "unknown_after_send",
+      });
+      expect(
+        getDeliveryQueueEntryStatus(
+          OUTBOUND_DELIVERY_QUEUE_NAME,
+          deliveryIntentId,
+          fixtures.tmpDir(),
+        ),
+      ).toBe("pending");
+
+      await sendDurableMessageBatchCore(params);
+      expect(accepted).toHaveLength(2);
+    },
+  );
+});

--- a/src/infra/outbound/delivery-completion.integration.test.ts
+++ b/src/infra/outbound/delivery-completion.integration.test.ts
@@ -93,74 +93,92 @@ describe("pending-final durable delivery completion", () => {
     expect(await loadPendingDeliveries(tmpDir)).toEqual([]);
   });
 
-  it("keeps an uncertainty notice owed when a live send returns no delivery identity", async () => {
-    process.env.OPENCLAW_STATE_DIR = tmpDir;
-    const sessionKey = "agent:main:matrix:direct:unknown-live";
-    const storePath = path.join(tmpDir, "sessions.json");
-    const deliveryId = "pending-final-unknown-live";
-    const completion = {
-      kind: "pending-final" as const,
-      deliveryId,
-      intentId: "pending-final-intent-unknown-live",
-      sessionId: "session-unknown-live",
-      sessionKey,
-      storePath,
-    };
-    const context = { channel: "matrix", to: "!room:example" };
-    await replaceSessionEntry(
-      { sessionKey, storePath },
-      {
-        sessionId: completion.sessionId,
-        status: "running",
-        updatedAt: Date.now(),
-        pendingFinalDelivery: {
-          kind: "replayable",
-          text: "delivery identity may have been lost",
-          context,
-          createdAt: Date.now(),
-          intentId: completion.intentId,
-          deliveries: [{ id: deliveryId, state: "prepared" }],
+  it.each([false, true])(
+    "keeps an uncertainty notice owed after identity loss (confirmed prefix=%s)",
+    async (confirmedPrefix) => {
+      process.env.OPENCLAW_STATE_DIR = tmpDir;
+      const sessionKey = "agent:main:matrix:direct:unknown-live";
+      const storePath = path.join(tmpDir, "sessions.json");
+      const deliveryId = "pending-final-unknown-live";
+      const completion = {
+        kind: "pending-final" as const,
+        deliveryId,
+        intentId: "pending-final-intent-unknown-live",
+        sessionId: "session-unknown-live",
+        sessionKey,
+        storePath,
+      };
+      const context = { channel: "matrix", to: "!room:example" };
+      await replaceSessionEntry(
+        { sessionKey, storePath },
+        {
+          sessionId: completion.sessionId,
+          status: "running",
+          updatedAt: Date.now(),
+          pendingFinalDelivery: {
+            kind: "replayable",
+            text: "delivery identity may have been lost",
+            context,
+            createdAt: Date.now(),
+            intentId: completion.intentId,
+            deliveries: [{ id: deliveryId, state: "prepared" }],
+          },
         },
-      },
-    );
-    const sendMatrix = vi.fn().mockResolvedValue({});
-    const auditEvents: TrustedMessageAuditEvent[] = [];
-    const unsubscribe = onTrustedMessageAuditEvent((event) => auditEvents.push(event));
+      );
+      const sendMatrix = vi.fn().mockResolvedValue({ messageId: "" });
+      if (confirmedPrefix) {
+        sendMatrix.mockResolvedValueOnce({ messageId: "confirmed-prefix" });
+      }
+      const auditEvents: TrustedMessageAuditEvent[] = [];
+      const unsubscribe = onTrustedMessageAuditEvent((event) => auditEvents.push(event));
 
-    try {
-      await expect(
-        deliverOutboundPayloads({
+      try {
+        const sending = deliverOutboundPayloads({
           cfg: {} as OpenClawConfig,
           channel: "matrix",
           to: "!room:example",
-          payloads: [{ text: "delivery identity may have been lost" }],
+          payloads: [
+            ...(confirmedPrefix ? [{ text: "confirmed prefix" }] : []),
+            { text: "delivery identity may have been lost" },
+          ],
           deps: { matrix: sendMatrix },
           queuePolicy: "required",
           deliveryIntentId: deliveryId,
           deliveryCompletion: completion,
-        }),
-      ).resolves.toEqual([]);
-    } finally {
-      unsubscribe();
-    }
+        });
+        if (confirmedPrefix) {
+          await expect(sending).rejects.toThrow(
+            "platform send returned no delivery identity for part of the delivery batch",
+          );
+        } else {
+          await expect(sending).resolves.toEqual([]);
+        }
+      } finally {
+        unsubscribe();
+      }
 
-    expect((await loadPendingDeliveries(tmpDir))[0]).toMatchObject({
-      id: deliveryId,
-      recoveryState: "unknown_after_send",
-    });
-    expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
-      pendingFinalDelivery: {
-        deliveries: [{ id: deliveryId, state: "unknown" }],
-      },
-      pendingDeliveryNotice: {
-        intentId: completion.intentId,
-        state: "owed",
-        context,
-      },
-    });
-    expect(auditEvents.map((event) => event.outcome)).toEqual(["queued", "platform_started"]);
-    expect(auditEvents).not.toContainEqual(
-      expect.objectContaining({ action: "message.outbound.finished" }),
-    );
-  });
+      expect((await loadPendingDeliveries(tmpDir))[0]).toMatchObject({
+        id: deliveryId,
+        recoveryState: "unknown_after_send",
+      });
+      expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
+        pendingFinalDelivery: {
+          deliveries: [{ id: deliveryId, state: "unknown" }],
+        },
+        pendingDeliveryNotice: {
+          intentId: completion.intentId,
+          state: "owed",
+          context,
+        },
+      });
+      expect(auditEvents.map((event) => event.outcome)).toEqual(
+        confirmedPrefix
+          ? ["queued", "queued", "platform_started", "platform_started"]
+          : ["queued", "platform_started"],
+      );
+      expect(auditEvents).not.toContainEqual(
+        expect.objectContaining({ action: "message.outbound.finished" }),
+      );
+    },
+  );
 });

--- a/src/infra/outbound/delivery-completion.integration.test.ts
+++ b/src/infra/outbound/delivery-completion.integration.test.ts
@@ -41,57 +41,65 @@ describe("pending-final durable delivery completion", () => {
     setActivePluginRegistry(createEmptyPluginRegistry());
   });
 
-  it("suppresses a second stable caller after the exact pending final was delivered", async () => {
-    process.env.OPENCLAW_STATE_DIR = tmpDir;
-    const sessionKey = "agent:main:matrix:direct:123";
-    const storePath = path.join(tmpDir, "sessions.json");
-    const deliveryId = "pending-final-delivery-1";
-    const completion = {
-      kind: "pending-final" as const,
-      deliveryId,
-      intentId: "pending-final-intent-1",
-      sessionId: "session-1",
-      sessionKey,
-      storePath,
-    };
-    await replaceSessionEntry(
-      { sessionKey, storePath },
-      {
+  it.each([1, 2])(
+    "settles %s identified payloads before suppressing a second stable caller",
+    async (payloadCount) => {
+      process.env.OPENCLAW_STATE_DIR = tmpDir;
+      const sessionKey = "agent:main:matrix:direct:123";
+      const storePath = path.join(tmpDir, "sessions.json");
+      const deliveryId = "pending-final-delivery-1";
+      const completion = {
+        kind: "pending-final" as const,
+        deliveryId,
+        intentId: "pending-final-intent-1",
         sessionId: "session-1",
-        status: "running",
-        updatedAt: Date.now(),
-        pendingFinalDelivery: {
-          kind: "replayable",
-          text: "deliver once",
-          createdAt: Date.now(),
-          intentId: completion.intentId,
-          deliveries: [{ id: deliveryId, state: "prepared" }],
+        sessionKey,
+        storePath,
+      };
+      await replaceSessionEntry(
+        { sessionKey, storePath },
+        {
+          sessionId: "session-1",
+          status: "running",
+          updatedAt: Date.now(),
+          pendingFinalDelivery: {
+            kind: "replayable",
+            text: "deliver once",
+            createdAt: Date.now(),
+            intentId: completion.intentId,
+            deliveries: [{ id: deliveryId, state: "prepared" }],
+          },
         },
-      },
-    );
-    const sendMatrix = vi.fn().mockResolvedValue({ messageId: "matrix-message-1" });
-    const params = {
-      cfg: {} as OpenClawConfig,
-      channel: "matrix" as const,
-      to: "!room:example",
-      payloads: [{ text: "deliver once" }],
-      deps: { matrix: sendMatrix },
-      queuePolicy: "required" as const,
-      deliveryIntentId: deliveryId,
-      deliveryCompletion: completion,
-    };
+      );
+      const payloads = Array.from({ length: payloadCount }, (_, index) => ({
+        text: `deliver ${index}`,
+      }));
+      const sendMatrix = vi.fn(async (_to: string, text: string) => ({
+        messageId: `matrix-${text}`,
+      }));
+      const params = {
+        cfg: {} as OpenClawConfig,
+        channel: "matrix" as const,
+        to: "!room:example",
+        payloads,
+        deps: { matrix: sendMatrix },
+        queuePolicy: "required" as const,
+        deliveryIntentId: deliveryId,
+        deliveryCompletion: completion,
+      };
 
-    await expect(deliverOutboundPayloads(params)).resolves.toMatchObject([
-      { messageId: "matrix-message-1" },
-    ]);
-    expect(loadSessionEntry({ sessionKey, storePath })?.pendingFinalDelivery?.deliveries).toEqual([
-      { id: deliveryId, state: "delivered" },
-    ]);
+      await expect(deliverOutboundPayloads(params)).resolves.toMatchObject(
+        payloads.map(({ text }) => ({ messageId: `matrix-${text}` })),
+      );
+      expect(loadSessionEntry({ sessionKey, storePath })?.pendingFinalDelivery?.deliveries).toEqual(
+        [{ id: deliveryId, state: "delivered" }],
+      );
 
-    await expect(deliverOutboundPayloads(params)).resolves.toEqual([]);
-    expect(sendMatrix).toHaveBeenCalledOnce();
-    expect(await loadPendingDeliveries(tmpDir)).toEqual([]);
-  });
+      await expect(deliverOutboundPayloads(params)).resolves.toEqual([]);
+      expect(sendMatrix).toHaveBeenCalledTimes(payloadCount);
+      expect(await loadPendingDeliveries(tmpDir)).toEqual([]);
+    },
+  );
 
   it.each([false, true])(
     "keeps an uncertainty notice owed after identity loss (confirmed prefix=%s)",

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -660,24 +660,13 @@ function isPermanentDeliveryError(error: string): boolean {
 
 async function persistRecoveredPostSendState(opts: {
   entry: QueuedDelivery;
-  log: RecoveryLogger;
   stateDir?: string;
   producerClaimId?: string;
 }): Promise<QueuedPostSendState> {
-  // Recovery keeps its media lease until the adapter settles, even if the
-  // canonical post-send marker has to finalize the queue with a direct ack.
   return persistQueuedPostSendState({
     queueId: opts.entry.id,
-    queuePolicy: opts.entry.queuePolicy ?? "best_effort",
     stateDir: opts.stateDir,
-    producerClaimId: opts.producerClaimId,
     expectedPlatformSendAttemptId: recoveryPlatformAttemptId(opts.entry, opts.producerClaimId),
-    retainSpoolArtifacts: true,
-    onPostSendMarkerError: (error) => {
-      opts.log.warn(
-        `Delivery entry ${opts.entry.id} failed to persist post-send state; falling back to direct ack: ${formatErrorMessage(error)}`,
-      );
-    },
   });
 }
 
@@ -878,7 +867,6 @@ async function drainQueuedEntry(opts: {
         collectResults([deliveryResult]);
         postSendState ??= await persistRecoveredPostSendState({
           entry,
-          log: opts.log,
           stateDir: opts.stateDir,
           ...(producerClaimId ? { producerClaimId } : {}),
         });
@@ -918,22 +906,19 @@ async function drainQueuedEntry(opts: {
       if (results.length > 0 || failedOutcomes.some((outcome) => outcome.sentBeforeError)) {
         postSendState ??= await persistRecoveredPostSendState({
           entry,
-          log: opts.log,
           stateDir: opts.stateDir,
           ...(producerClaimId ? { producerClaimId } : {}),
         });
         opts.log.warn(
           `Delivery entry ${entry.id} partially sent before best-effort recovery failed; preserving unknown_after_send`,
         );
-        if (postSendState === "acked") {
-          await runCommitHooksAfterAck();
-          emitQueuedAuditTerminals(entry, () =>
-            failedOutboundAuditTerminals({
-              payloadCount: queuedPayloadCount(entry),
-              results: deliveredResults,
-              payloadOutcomes,
-              failureStage: "platform_send",
-            }),
+        if (postSendState === "unmarked") {
+          await recordRecoveredFailure(
+            failDeliveryAfterPlatformSend,
+            entry,
+            errMsg,
+            opts.stateDir,
+            producerClaimId,
           );
         }
       } else {
@@ -958,17 +943,10 @@ async function drainQueuedEntry(opts: {
       results.length > 0
         ? await persistRecoveredPostSendState({
             entry,
-            log: opts.log,
             stateDir: opts.stateDir,
             ...(producerClaimId ? { producerClaimId } : {}),
           })
         : undefined;
-    if (postSendState === "failed") {
-      const errMsg = "recovered send completed but queue finalization failed";
-      opts.onFailed?.(entry, errMsg);
-      opts.log.warn(`Delivery entry ${entry.id} ${errMsg}; preserving unknown_after_send`);
-      return "failed";
-    }
     if (postSendState !== "acked") {
       try {
         await (results.length === 0 && typeof entry.completionRetention === "object"
@@ -1031,10 +1009,18 @@ async function drainQueuedEntry(opts: {
       try {
         postSendState ??= await persistRecoveredPostSendState({
           entry,
-          log: opts.log,
           stateDir: opts.stateDir,
           ...(producerClaimId ? { producerClaimId } : {}),
         });
+        if (postSendState === "unmarked") {
+          await recordRecoveredFailure(
+            failDeliveryAfterPlatformSend,
+            entry,
+            errMsg,
+            opts.stateDir,
+            producerClaimId,
+          );
+        }
       } catch (persistErr) {
         // Never overwrite concrete send evidence with a generic retry state.
         opts.log.error(

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -26,6 +26,7 @@ import { OUTBOUND_DELIVERY_LOG_SCOPE } from "./deliver-log.js";
 import { buildPayloadSummary } from "./deliver-payload.js";
 import {
   createQueuedDeliveryOwner,
+  hasUnconfirmedOutboundSends,
   persistQueuedPostSendState,
   type QueuedPostSendState,
 } from "./deliver-queue-state.js";
@@ -884,11 +885,7 @@ async function drainQueuedEntry(opts: {
       },
     });
     const results = isOutboundDeliveryResultArray(result) ? result : [];
-    const adapterReturnedNoIdentity = payloadOutcomes.some(
-      (outcome) =>
-        outcome.status === "suppressed" && outcome.reason === "adapter_returned_no_identity",
-    );
-    if (adapterReturnedNoIdentity || (results.length === 0 && platformSendStarted)) {
+    if (hasUnconfirmedOutboundSends({ results, payloadOutcomes, platformSendStarted })) {
       const error = "recovered platform send returned no delivery identity";
       await recordRecoveredFailure(
         failDeliveryAfterPlatformSend,

--- a/src/infra/outbound/delivery-queue.recovery.test.ts
+++ b/src/infra/outbound/delivery-queue.recovery.test.ts
@@ -1396,14 +1396,14 @@ describe("delivery-queue recovery", () => {
   it.each([
     ["marks a recovered send unknown before ack so ack failure cannot make it replayable", "ack"],
     ["keeps a recovered zero-result delivery retryable when ack fails", "zero-result-ack"],
-    ["directly acks a recovered send when its post-send marker fails", "marker"],
+    ["acks a completed recovered batch when its post-send marker fails", "marker"],
     ["retains unknown-after-send when recovered-send marking and ack both fail", "marker-and-ack"],
   ])("%s", async (_, mode) => {
     const id = await enqueueRecoveryDelivery();
     const markerFails = mode === "marker" || mode === "marker-and-ack";
     const ackFails = mode === "ack" || mode === "zero-result-ack" || mode === "marker-and-ack";
     let recoveryStateAtAck: string | undefined;
-    const { summary, log } = await runRecoveryWithStorageOverrides({
+    const { summary } = await runRecoveryWithStorageOverrides({
       overrides: (actual) => ({
         ...(markerFails
           ? {
@@ -1434,7 +1434,6 @@ describe("delivery-queue recovery", () => {
       expect(summary).toEqual(RECOVERY_SUMMARY.recovered);
       expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
       expect(readOutboundQueueStatus(tmpDir(), id)).toBeUndefined();
-      expectMockMessageContaining(log.warn, "falling back to direct ack");
       return;
     }
     if (mode === "ack") {
@@ -1448,14 +1447,9 @@ describe("delivery-queue recovery", () => {
       recoveryState: mode === "zero-result-ack" ? undefined : "unknown_after_send",
       ...(mode === "ack" ? {} : { retryCount: 1 }),
     });
-    await runIf(markerFails, () =>
-      expect(pending?.lastError).toContain("marker=post-send state db locked"),
-    );
-    expect(pending?.lastError).toContain(
-      mode === "marker-and-ack" ? "ack=ack state db locked" : "ack state db locked",
-    );
+    expect(pending?.lastError).toContain("ack state db locked");
   });
-  it("retains later media until an early recovery ack finishes the batch", async () => {
+  it("retains custody and later media until the recovered batch finishes", async () => {
     const spoolDir = path.join(tmpDir(), "delivery-queue-media");
     const firstArtifact = path.join(spoolDir, "00000000-0000-4000-8000-000000000001.ogg");
     const secondArtifact = path.join(spoolDir, "00000000-0000-4000-8000-000000000002.ogg");
@@ -1472,6 +1466,7 @@ describe("delivery-queue recovery", () => {
     const secondResult = { channel: "demo-channel-a", messageId: "m2" };
     const deliver = vi.fn(async (params: Parameters<DeliverFn>[0]) => {
       await params.onDeliveryResult?.(firstResult);
+      expect(await loadPendingDeliveries(tmpDir())).toHaveLength(1);
       await pruneOrphanedDeliveryQueueMedia({ stateDir: tmpDir() });
       expect(await fs.readFile(secondArtifact, "utf8")).toBe("second-audio");
       await params.onDeliveryResult?.(secondResult);
@@ -1508,7 +1503,7 @@ describe("delivery-queue recovery", () => {
     expect(JSON.stringify(auditEvents)).not.toContain("secret");
     expect(JSON.stringify(auditEvents)).not.toContain("provider rejected send");
   });
-  it("runs recovered commit hooks when marker fallback ack precedes a partial failure", async () => {
+  it("defers recovered commit hooks when a failed marker precedes a partial failure", async () => {
     await enqueueRecoveryDelivery({
       payloads: [{ text: "first" }, { text: "second" }],
       bestEffort: true,
@@ -1546,8 +1541,10 @@ describe("delivery-queue recovery", () => {
       },
     });
     expect(summary).toMatchObject({ recovered: 0, failed: 1 });
-    expect(afterCommit).toHaveBeenCalledTimes(1);
-    expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
+    expect(afterCommit).not.toHaveBeenCalled();
+    expect(await loadPendingDeliveries(tmpDir())).toEqual([
+      expect.objectContaining({ recoveryState: "unknown_after_send", retryCount: 1 }),
+    ]);
   });
   it("replays stored delivery options during recovery", async () => {
     const storedOptions = {


### PR DESCRIPTION
> [!IMPORTANT]
> **review-required: delivery uncertainty + custody semantics.** Prepared under the auto-QA campaign from a channel-delivery audit (findings C2/C3/C4). Changes shared delivery completion, queue custody, and routing retry-safety, so this stays a draft for maintainer review.

## What Problem This Solves

Three linked defects let an uncertain send silently become success — or, in the worst case, cause a **double delivery**:

- **C2 (P1):** a payload with one identified chunk and one identityless chunk was reported fully delivered. `deliver-results.ts` correctly rejected the identityless unit, but core ignored that accounting at the text/formatted/media boundaries and treated any surviving receipt as whole-payload success — losing the tail's uncertainty and (in reusable mode) blocking retry.
- **C3 (P1):** an *ordinary* mixed batch (payload 0 sent, payload 1 `adapter_returned_no_identity`) settled completion from the last identified receipt and released custody, while the recovery path kept custody — so live and recovery disagreed.
- **C4 (P1, double-send):** the reply router threw a failed durable result and unconditionally returned `delivered:false`, discarding the `sentBeforeError` evidence that the recipient may have accepted the first send. Follow-up then re-dispatched the same payload to a recipient who already received it.

## Why This Change Was Made

One invariant: every planned or returned send unit contributes to logical completion; a surviving receipt cannot erase an identityless sibling, release uncertain custody, settle completion, or authorize another sender. Genuine pre-send hook vetoes stay distinct from identityless uncertainty. Fixes land per boundary — core unit-accounting (C2), queue custody with a single live/recovery uncertainty predicate (C3), and router retry-safety via the existing recipient-reached guard (C4). Follow-up and ACP already respect `delivered:true`, so neither needed a second policy.

A deep-context review then caught a lifecycle defect in C3's marker-failure path — passing every producer claim to the progress-marker helper could clear the lease before remaining payloads settled, making live delivery lose its heartbeat, stopping nested recovery before its second send, or even skipping acknowledgment on a fully successful batch (the older unclaimed path had the opposite early-ack bug). The follow-up makes progress recording nonterminal for both paths (a process-local `unmarked` state, never persisted) with ownership revalidation on later dispatch.

## User Impact

An incompletely acknowledged message is reported uncertain and keeps recovery custody instead of a false success; a recipient who may have received a reply is not sent it a second time; a genuinely delivered message still completes, acks, and deletes its one-shot exactly as before.

## Evidence

- Production **net −20** (core −5, queue/recovery consolidation, router +1, then the review's −44 lifecycle simplification); tests large positive; no schema/table/index/retention/config/public-result-field change (`delivery_queue_entries` schema untouched; `unmarked` is process-local).
- Adversarial evidence in all six required directions: fully-delivered success stays success (deletes custody, suppresses a second stable caller); hook veto stays `suppressed` with zero transport attempts across Telegram/Discord/Slack/Matrix; C4 makes only one transport attempt after acceptance-with-lost-receipt while a permanent pre-dispatch rejection still triggers the intended fallback; live/recovery symmetry proven both directions; six failing-first marker/lifecycle tests then green; plugin-agnostic (no hardcoded adapter receipt counts).
- **13 canonical CI shard plans, 21,809 tests** passed locally (macOS/Node 26); post-rebase focused outbound/queue/router suites green. Two rounds of Codex autoreview clean at P0.
- Residual for reviewer (both pre-existing/separate, not regressions): a retryable routed no-send result can leave a retryable queue row while follow-up/ACP chooses fallback (a distinct retry-ownership contract C4 doesn't close); adapter-local malformed successful responses (Matrix empty IDs, Discord manufactured "unknown") deserve a separate producer-boundary validation pass. Hosted Linux/Node 24 CI is the landing owner's proof.
