### PR TITLE
fix(cron): notify owner when a one-shot automation exhausts retries

### DIFF
--- a/src/cron/service/auto-disable.ts
+++ b/src/cron/service/auto-disable.ts
@@ -83,3 +83,27 @@ export function maybeAutoDisableCronJobAfterRunFailure(params: {
     consecutiveErrors,
   });
 }
+
+/**
+ * Routes a terminal one-shot disable (permanent error, exhausted retries, or
+ * exhausted disabled-heartbeat retries) through the canonical auto-disable owner
+ * so a durable autoDisabled reason and post-persist owner notification are
+ * emitted, instead of silently clearing the schedule. Mirrors
+ * maybeAutoDisableCronJobAfterRunFailure for the one-shot terminal paths.
+ *
+ * @returns true when the canonical owner recorded the transition and queued its
+ *   recovery notification; false when it declined (e.g. system-owned job, or the
+ *   job was already disabled).
+ */
+export function autoDisableOneShotCronJobTerminalError(params: {
+  state: CronServiceState;
+  job: CronJob;
+  atMs: number;
+  consecutiveErrors: number;
+  deferredNotifications?: DeferredCronNotifications;
+}): boolean {
+  return autoDisableCronJob({
+    ...params,
+    reason: "consecutive-failures",
+  });
+}

--- a/src/cron/service/timer-outcomes.ts
+++ b/src/cron/service/timer-outcomes.ts
@@ -7,7 +7,10 @@ import { resolveCronRunErrorReason } from "../run-error-reason.js";
 import { cronSchedulingInputsEqual } from "../schedule-identity.js";
 import { computeNextRunAtMs } from "../schedule.js";
 import type { CronJob, CronRunStatus } from "../types.js";
-import { maybeAutoDisableCronJobAfterRunFailure } from "./auto-disable.js";
+import {
+  autoDisableOneShotCronJobTerminalError,
+  maybeAutoDisableCronJobAfterRunFailure,
+} from "./auto-disable.js";
 import {
   finalizeCronFailureNotifications,
   maybeEmitFailureAlert,
@@ -32,6 +35,7 @@ import { emitCronOutcomeEventForJob, recordCronOutcomeForJob } from "./timer-out
 import {
   applyTriggerEvaluationState,
   applyTriggerRunResult,
+  DEFAULT_MAX_TRANSIENT_RETRIES,
   resolveCronNextRunWithLowerBound,
   resolveDeliveryState,
   resolveDisabledHeartbeatOneShotRetryDecision,
@@ -253,14 +257,27 @@ export function applyJobResult(
             );
           }
         } else {
-          job.enabled = false;
-          job.state.nextRunAtMs = undefined;
+          autoDisableNotificationOwnsFailure =
+            autoDisableOneShotCronJobTerminalError({
+              state,
+              job,
+              atMs: result.endedAt,
+              consecutiveErrors: retryDecision.consecutiveSkipped,
+              deferredNotifications: opts?.deferredNotifications,
+            }) || autoDisableNotificationOwnsFailure;
+          if (job.enabled) {
+            // Canonical owner declined (e.g. system-owned job): keep the safety
+            // disable so an errant one-shot cannot remain scheduled.
+            job.enabled = false;
+            job.state.nextRunAtMs = undefined;
+          }
           state.deps.log.warn(
             {
               jobId: job.id,
               jobName: job.name,
               consecutiveSkipped: retryDecision.consecutiveSkipped,
               reason: retryDecision.reason,
+              autoDisabled: job.state.autoDisabled?.reason,
             },
             "cron: disabling one-shot job after disabled heartbeat retries",
           );
@@ -305,8 +322,30 @@ export function applyJobResult(
           // Note: deleteAfterRun:true only triggers on ok (see shouldDelete above),
           // so exhausted-retry jobs are disabled but intentionally kept in the store
           // to preserve the error state for inspection.
-          job.enabled = false;
-          job.state.nextRunAtMs = undefined;
+          //
+          // Route the disable through the canonical auto-disable owner only when the
+          // one-shot accumulated a genuine streak of failures (retry budget exceeded),
+          // so a durable autoDisabled reason and owner-recovery notification are
+          // emitted for repeated failures instead of silently parking the job. A
+          // single first-run permanent error still finalizes quietly (existing
+          // contract: main- and isolated-session one-shot errors are suppressed).
+          if (retryDecision.consecutiveErrors > DEFAULT_MAX_TRANSIENT_RETRIES) {
+            autoDisableNotificationOwnsFailure =
+              autoDisableOneShotCronJobTerminalError({
+                state,
+                job,
+                atMs: result.endedAt,
+                consecutiveErrors: retryDecision.consecutiveErrors,
+                deferredNotifications: opts?.deferredNotifications,
+              }) || autoDisableNotificationOwnsFailure;
+          }
+          if (job.enabled) {
+            // Canonical owner declined (e.g. system-owned job) or the disable was a
+            // first-run permanent error: keep the safety disable so an errant
+            // one-shot cannot remain scheduled or tight-loop.
+            job.enabled = false;
+            job.state.nextRunAtMs = undefined;
+          }
           state.deps.log.warn(
             {
               jobId: job.id,
@@ -315,6 +354,7 @@ export function applyJobResult(
               error: result.error,
               reason: retryDecision.reason,
               retryCategory: retryDecision.retryCategory,
+              autoDisabled: job.state.autoDisabled?.reason,
             },
             "cron: disabling one-shot job after error",
           );

--- a/src/cron/service/timer-trigger.ts
+++ b/src/cron/service/timer-trigger.ts
@@ -25,7 +25,7 @@ import type { CronTriggerEvalOutcome } from "./timer-execution-timeout.js";
 import { HEARTBEAT_SKIP_DISABLED } from "./timer-execution-timeout.js";
 
 /** Default max retries for cron jobs on transient errors (#24355). */
-const DEFAULT_MAX_TRANSIENT_RETRIES = 3;
+export const DEFAULT_MAX_TRANSIENT_RETRIES = 3;
 
 type TransientCronRetryDecision = {
   retryable: boolean;

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -260,6 +260,63 @@ describe("cron service timer regressions", () => {
     expect(runIsolatedAgentJob).toHaveBeenCalledTimes(4);
   });
 
+  it("#131490: exhausted one-shot records autoDisable reason and notifies its owner", async () => {
+    const store = timerRegressionFixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-08-28T09:00:00.000Z");
+
+    const cronJob = createIsolatedRegressionJob({
+      id: "oneshot-exhausted-notify",
+      name: "exhausted reminder",
+      scheduledAt,
+      schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+      payload: { kind: "agentTurn", message: "report lane results" },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
+
+    let now = scheduledAt;
+    const enqueueSystemEvent = vi.fn();
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent,
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn().mockResolvedValue({
+        status: "error",
+        error: "429 rate limit exceeded",
+      }),
+    });
+
+    for (let i = 0; i < 4; i += 1) {
+      await onTimer(state);
+      const job = requireJob(state, "oneshot-exhausted-notify");
+      if (i < 3) {
+        expect(job.enabled).toBe(true);
+        now = requireTimestamp(job.state.nextRunAtMs, "exhausted-notify retry next run") + 1;
+      } else {
+        expect(job.enabled).toBe(false);
+      }
+    }
+
+    const disabled = requireJob(state, "oneshot-exhausted-notify");
+    expect(disabled.state.autoDisabled).toMatchObject({
+      reason: "consecutive-failures",
+      consecutiveErrors: 4,
+    });
+    expect(disabled.state.nextRunAtMs).toBeUndefined();
+    // The canonical auto-disable owner queued an owner-recovery notification
+    // instead of silently parking the exhausted one-shot.
+    expect(enqueueSystemEvent).toHaveBeenCalled(
+      expect.stringContaining("was auto-disabled after 4 consecutive run failures"),
+      expect.objectContaining({
+        agentId: "main",
+        contextKey: "cron:oneshot-exhausted-notify:auto-disabled",
+      }),
+    );
+  });
+
   it("preserves every cadence after a transient recurring retry succeeds", () => {
     const scheduledAt = Date.parse("2026-05-29T02:28:00.000Z");
     const everyTwelveHoursMs = 12 * 60 * 60 * 1_000;


### PR DESCRIPTION
Closes #131490

## What Problem This Solves

Fixes an issue where a one-shot cron automation that keeps failing transiently is silently parked: after its retry budget is exhausted the job is disabled, but no durable autoDisabled reason is recorded and the owner is never told, so a transiently-flaky automation can appear to stop working without any signal. Operators would run openclaw automations list --all and find it disabled but have no record of why, and no recoverable notification.

## Why This Change Was Made

The one-shot terminal-error path disabled the job directly (enabled=false, cleared nextRunAtMs) without going through the scheduler's canonical auto-disable owner, so it skipped the durable autoDisabled record and the cron:{id}:auto-disabled owner-recovery system event that recurring jobs already emit after repeated failures. This change routes the one-shot's terminal disable through the same canonical owner, gated so only a genuine streak of consecutive failures (retry budget exceeded) emits the notification; a single first-run error still finalizes quietly, preserving the existing main-/isolated-session one-shot error contracts.

## User Impact

Operators with a repeatedly-failing one-shot automation now get the same recoverable signal as recurring jobs: a definitive autoDisabled.reason and an owner notification (“...was auto-disabled after N consecutive run failures... Fix the underlying cause, then run `openclaw automations enable <id>`”). The job is still kept disabled as before, never tight-looping.

## Evidence

Regression test added in `src/cron/service/timer.regression.test.ts` (#131490) proves the before-to-after state on the real cron scheduler path.

**Before (clean `main`, fix absent)** - the job's terminal disable is silent; the new assertion fails because `autoDisabled` is `undefined`:

```text
#131490: exhausted one-shot records autoDisable reason and notifies its owner
AssertionError: expected undefined to match object { Object (reason, consecutiveErrors) }
```

**After (this PR)** - the same scenario records the durable reason and queues the owner notification, and the regression test passes:

```text
Test Files  1 passed (1)
     Tests  1 passed | 69 skipped (70)
```

The observed post-fix state is `autoDisabled: { reason: "consecutive-failures", consecutiveErrors: 4 }` and `enqueueSystemEvent` receiving the owner message and `{ agentId: "main", contextKey: "cron:<id>:auto-disabled" }`.

Broader cron suites remain green with the change:

```text
# timer.regression + timer.batch-finalization + runs-one-shot-main-job-disables (6 files)
Test Files  6 passed (6)
     Tests  168 passed (168)
# timer-trigger, run-recovery, run-receipt-settlement, startup-run-repair.auto-disable,
# persists-delivered-status, ops.run-admission, retry-hint, timer.quiet-finalization, timer-execution.script-wake (9 files)
Test Files  9 passed (9)
     Tests  127 passed (127)
# delivery-dispatch.double-announce
Test Files  1 passed (1)
     Tests  159 passed (159)
```

`pnpm check:changed -- src/cron/service/auto-disable.ts src/cron/service/timer-outcomes.ts src/cron/service/timer-trigger.ts src/cron/service/timer.regression.test.ts` passes format, conflict-marker, max-lines, assertion-safety, changelog-attribution, and the other changed-file guards.

The `cron-delivery-outcomes.e2e.test.ts` lane requires an E2E node runtime (`scripts/run-node.mjs`) that is not provisioned in this local sandbox, so that lane is deferred to CI.

AI-assisted: DeepSeek - implemented and proof run manually.
