### PR TITLE
fix(delivery): preserve retry budget when producer claims expire

### DIFF
--- a/docs/concepts/retry.md
+++ b/docs/concepts/retry.md
@@ -50,6 +50,17 @@ Discord and Telegram channel retry timings are built in and are not configurable
 - Retries apply per request (message send, media upload, reaction, poll, sticker).
 - Composite flows do not retry completed steps.
 
+### Durable outbound delivery
+
+The durable outbound queue has a separate delivery-attempt budget. When a
+delivery uses a producer claim, reservation checks the exact owner and its lease
+before charging an attempt. An expired or replaced claim does not spend the
+remaining budget; recovery can acquire a fresh claim before retrying.
+
+Lease expiry does not erase evidence that a send already started. Those entries
+still require reconciliation before replay, and an unreplaced owner can record a
+late result without authorizing another send.
+
 ## Related
 
 - [Model failover](/concepts/model-failover)

--- a/src/infra/delivery-queue-sqlite-claim.test.ts
+++ b/src/infra/delivery-queue-sqlite-claim.test.ts
@@ -1,14 +1,125 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   claimDeliveryQueueEntryPlatformSend,
+  createInitialDeliveryProducerClaim,
   dispatchDeliveryQueueEntryPlatformSend,
+  promoteDeliveryQueueEntryPlatformSend,
+  renewDeliveryQueueEntryPlatformSendLease,
+  transitionOwnedDeliveryQueueEntry,
 } from "./delivery-queue-sqlite-claim.js";
-import { loadDeliveryQueueEntry, upsertDeliveryQueueEntry } from "./delivery-queue-sqlite.js";
+import {
+  deleteDeliveryQueueEntry,
+  loadDeliveryQueueEntry,
+  reserveDeliveryQueueEntryAttempt,
+  updateDeliveryQueueEntry,
+  upsertDeliveryQueueEntry,
+} from "./delivery-queue-sqlite.js";
 import { installDeliveryQueueTmpDirHooks } from "./outbound/delivery-queue.test-helpers.js";
 
 describe("delivery queue SQLite dispatch ownership", () => {
   const { tmpDir } = installDeliveryQueueTmpDirHooks();
   const queueName = "test-dispatch-owner";
+
+  it.each(["producer_claimed", "send_attempt_started", "unknown_after_send"] as const)(
+    "preserves the retry budget when a %s claim expires before reservation",
+    (recoveryState) => {
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(new Date("2026-08-28T10:00:00.000Z"));
+        const initialClaim = createInitialDeliveryProducerClaim();
+        const params = { queueName, id: "expiring-reservation", stateDir: tmpDir() };
+        const claimed = { ...params, claimId: initialClaim.producerClaimId };
+        const reservation = {
+          ...params,
+          maxAttempts: 2,
+          expectedPlatformSendAttemptId: claimed.claimId,
+        };
+        upsertDeliveryQueueEntry({
+          ...params,
+          entry: { id: params.id, enqueuedAt: Date.now(), retryCount: 0, ...initialClaim },
+        });
+        if (recoveryState !== "producer_claimed") {
+          expect(dispatchDeliveryQueueEntryPlatformSend(claimed)).toBe(true);
+          if (recoveryState === "unknown_after_send") {
+            updateDeliveryQueueEntry(queueName, params.id, params.stateDir, (entry) => ({
+              ...entry,
+              recoveryState,
+            }));
+          }
+          expect(promoteDeliveryQueueEntryPlatformSend(claimed)).toBe(false);
+        }
+        expect(reserveDeliveryQueueEntryAttempt(reservation)).toEqual({
+          status: "reserved",
+          attemptCount: 1,
+        });
+
+        vi.setSystemTime(initialClaim.availableAt);
+        expect(() => reserveDeliveryQueueEntryAttempt(reservation)).toThrow("claim was lost");
+        expect(loadDeliveryQueueEntry(queueName, params.id, params.stateDir)?.attemptCount).toBe(1);
+        expect(renewDeliveryQueueEntryPlatformSendLease(claimed)).toBeUndefined();
+        expect(dispatchDeliveryQueueEntryPlatformSend(claimed)).toBe(false);
+        if (recoveryState === "producer_claimed") {
+          const replacement = claimDeliveryQueueEntryPlatformSend(params);
+          expect(replacement).toEqual(expect.any(String));
+          expect(() => reserveDeliveryQueueEntryAttempt(reservation)).toThrow("claim was lost");
+          expect(
+            reserveDeliveryQueueEntryAttempt({
+              ...reservation,
+              expectedPlatformSendAttemptId: replacement,
+            }),
+          ).toEqual({ status: "reserved", attemptCount: 2 });
+        } else {
+          // Expiry forbids more work, but the exact owner may settle an observed outcome.
+          expect(
+            transitionOwnedDeliveryQueueEntry(
+              { ...params, platformSendAttemptId: claimed.claimId },
+              () => deleteDeliveryQueueEntry(queueName, params.id, params.stateDir),
+            ),
+          ).toBe(true);
+          expect(loadDeliveryQueueEntry(queueName, params.id, params.stateDir)).toBeNull();
+        }
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("reserves unclaimed rows and non-renewable platform attempts without adding a lease", () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-08-28T10:00:00.000Z"));
+      const params = { queueName, id: "unleased-reservation", stateDir: tmpDir() };
+      upsertDeliveryQueueEntry({
+        ...params,
+        entry: { id: params.id, enqueuedAt: Date.now(), retryCount: 0 },
+      });
+      expect(reserveDeliveryQueueEntryAttempt({ ...params, maxAttempts: 2 })).toEqual({
+        status: "reserved",
+        attemptCount: 1,
+      });
+      const claimId = claimDeliveryQueueEntryPlatformSend(params);
+      if (!claimId) {
+        throw new Error("test invariant: unclaimed delivery must acquire a producer");
+      }
+      const claimed = { ...params, claimId };
+      expect(dispatchDeliveryQueueEntryPlatformSend(claimed)).toBe(true);
+      vi.advanceTimersByTime(30_001);
+      expect(
+        reserveDeliveryQueueEntryAttempt({
+          ...params,
+          maxAttempts: 2,
+          expectedPlatformSendAttemptId: claimId,
+        }),
+      ).toEqual({ status: "reserved", attemptCount: 2 });
+      expect(renewDeliveryQueueEntryPlatformSendLease(claimed)).toBeUndefined();
+      expect(dispatchDeliveryQueueEntryPlatformSend(claimed)).toBe(true);
+      expect(
+        loadDeliveryQueueEntry(queueName, params.id, params.stateDir)?.availableAt,
+      ).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 
   it("atomically promotes dispatch ownership and rejects expired or replaced claims", () => {
     vi.useFakeTimers();

--- a/src/infra/delivery-queue-sqlite-claim.ts
+++ b/src/infra/delivery-queue-sqlite-claim.ts
@@ -4,6 +4,7 @@ import {
   upsertDeliveryQueueEntry,
   type DeliveryQueueEntryState,
 } from "./delivery-queue-sqlite.js";
+import { hasLiveDeliveryQueueClaim } from "./delivery-queue-sqlite.types.js";
 import { generateSecureUuid } from "./secure-random.js";
 import { runSqliteImmediateTransactionSync } from "./sqlite-transaction.js";
 
@@ -161,18 +162,10 @@ export function renewDeliveryQueueEntryPlatformSendLease(
     () => {
       const entry = loadDeliveryQueueEntry(params.queueName, params.id, params.stateDir);
       const now = Date.now();
-      const exactOwner =
-        entry?.recoveryState === "producer_claimed"
-          ? entry.producerClaimId === params.claimId
-          : (entry?.recoveryState === "send_attempt_started" ||
-              entry?.recoveryState === "unknown_after_send") &&
-            entry.platformSendAttemptId === params.claimId;
       if (
         !entry ||
         entry.requiresProducerClaim !== true ||
-        !exactOwner ||
-        typeof entry.availableAt !== "number" ||
-        entry.availableAt <= now
+        !hasLiveDeliveryQueueClaim(entry, params.claimId, now)
       ) {
         return undefined;
       }
@@ -202,9 +195,7 @@ export function promoteDeliveryQueueEntryPlatformSend(
 ): boolean {
   return transitionDeliveryQueueEntryPlatformSend(params, "promote", (entry, now) =>
     entry.recoveryState === "producer_claimed" &&
-    entry.producerClaimId === params.claimId &&
-    typeof entry.availableAt === "number" &&
-    entry.availableAt > now
+    hasLiveDeliveryQueueClaim(entry, params.claimId, now)
       ? {
           ...entry,
           // Only an explicitly leased owner keeps its cross-process fence;
@@ -231,18 +222,7 @@ export function dispatchDeliveryQueueEntryPlatformSend(
   },
 ): boolean {
   return transitionDeliveryQueueEntryPlatformSend(params, "dispatch", (entry, now) => {
-    const producerOwned =
-      entry.recoveryState === "producer_claimed" &&
-      entry.producerClaimId === params.claimId &&
-      typeof entry.availableAt === "number" &&
-      entry.availableAt > now;
-    const attemptOwned =
-      (entry.recoveryState === "send_attempt_started" ||
-        entry.recoveryState === "unknown_after_send") &&
-      entry.platformSendAttemptId === params.claimId &&
-      (entry.requiresProducerClaim !== true ||
-        (typeof entry.availableAt === "number" && entry.availableAt > now));
-    if (!producerOwned && !attemptOwned) {
+    if (!hasLiveDeliveryQueueClaim(entry, params.claimId, now)) {
       return undefined;
     }
     return {
@@ -251,7 +231,7 @@ export function dispatchDeliveryQueueEntryPlatformSend(
       // atomically; later batch dispatches retain stronger unknown-after-send evidence.
       availableAt:
         entry.requiresProducerClaim === true
-          ? producerOwned
+          ? entry.recoveryState === "producer_claimed"
             ? now + PLATFORM_SEND_OWNER_LEASE_MS
             : entry.availableAt
           : undefined,

--- a/src/infra/delivery-queue-sqlite.ts
+++ b/src/infra/delivery-queue-sqlite.ts
@@ -20,6 +20,7 @@ import {
 } from "./delivery-queue-sqlite-bound.js";
 import type { DeliveryQueueEntryState } from "./delivery-queue-sqlite.types.js";
 import {
+  hasLiveDeliveryQueueClaim,
   inferDeliveryQueueFailureRetention,
   parseDeliveryQueueCompletionRetention,
   projectDeliveryQueueTerminalEntry,
@@ -315,8 +316,7 @@ export function reserveDeliveryQueueEntryAttempt(params: {
       }
       if (
         params.expectedPlatformSendAttemptId &&
-        current.platformSendAttemptId !== params.expectedPlatformSendAttemptId &&
-        current.producerClaimId !== params.expectedPlatformSendAttemptId
+        !hasLiveDeliveryQueueClaim(current, params.expectedPlatformSendAttemptId, Date.now())
       ) {
         throw new Error(`Delivery platform claim was lost: ${params.id}`);
       }

--- a/src/infra/delivery-queue-sqlite.types.ts
+++ b/src/infra/delivery-queue-sqlite.types.ts
@@ -105,6 +105,21 @@ export type DeliveryQueueEntryState = {
   recoveryState?: string;
 };
 
+/** Additional work needs a live claim; settling an observed outcome only needs exact ownership. */
+export function hasLiveDeliveryQueueClaim(
+  entry: DeliveryQueueEntryState,
+  claimId: string,
+  now: number,
+): boolean {
+  const unexpired = typeof entry.availableAt === "number" && entry.availableAt > now;
+  return entry.recoveryState === "producer_claimed"
+    ? entry.producerClaimId === claimId && unexpired
+    : (entry.recoveryState === "send_attempt_started" ||
+        entry.recoveryState === "unknown_after_send") &&
+        entry.platformSendAttemptId === claimId &&
+        (entry.requiresProducerClaim !== true || unexpired);
+}
+
 /** Strip a terminal queue row to the producer policy needed for admission. */
 export function projectDeliveryQueueTerminalEntry(
   entry: Pick<DeliveryQueueEntryState, "id" | "retryCount">,


### PR DESCRIPTION
Closes #127390. The exhausted-row recovery portion already landed in #131380; this repairs the remaining expiry-before-reservation path.

## What Problem This Solves

Fixes an issue where queued outbound messages could lose their remaining retry budget when a paused producer resumed after its lease expired. Reservation charged an attempt, dispatch correctly refused the stale owner, and the replacement owner then found the budget exhausted without a send.

## Why This Change Was Made

Reservation compared only the claim token. Renewal, promotion, and dispatch already checked the token, lifecycle phase, and live lease. One shared owner predicate now defines eligibility for additional work, and reservation applies it inside the existing SQLite transaction before changing the budget.

Terminal settlement intentionally keeps its separate exact-owner contract: an unreplaced owner can record an observed late result after expiry, but cannot authorize another send. Non-renewable platform attempts and tokenless initial reservation retain their existing behavior. This is the maintainer-requested bounded custody repair recorded in #127390, not a new lease policy, schema, store, configuration option, timeout, or retry increase.

## User Impact

An expired or replaced claimed owner cannot spend another delivery attempt. A fresh owner can use the preserved budget; entries with send-started evidence still require reconciliation before replay.

Production LOC: +22/-27, net **-5**. Tests: +112/-1, net +111. Docs: +11. The refactor removes duplicate lease/phase decisions and documents the distinction between durable delivery attempts and per-request retries.

## Evidence

- Before the fix, three real-SQLite regressions failed for producer, send-started, and unknown-after-send claims at the exact expiry boundary. Existing active-owner control passed.
- A separate canonical outbound probe used actual SQLite and a real 30-second lease. Expired producer/platform reservations consumed the only attempt; dispatch refused both, and a replacement found the budget exhausted.
- After the fix, 121 tests across six owner/sibling suites passed on current locked dependencies: `node scripts/run-vitest.mjs src/infra/delivery-queue-sqlite-claim.test.ts src/infra/delivery-queue-sqlite.test.ts src/infra/outbound/delivery-queue.storage.test.ts src/infra/outbound/delivery-queue.producer-recovery.test.ts src/infra/outbound/delivery-queue-lease.test.ts src/infra/outbound/deliver.queue-integration.test.ts`.
- Controls cover active/replacement fencing, exact-deadline rejection without budget mutation, renewal and promotion differences, late settlement, unclaimed entries, and non-renewable attempts.
- Codex autoreview completed with no accepted/actionable findings at its P0-only threshold. This is not a claim that lower-priority issues cannot exist.
- Full changed-file checks passed. The real built Gateway comparison passed on Blacksmith Testbox `tbx_01m13m0x51a8900k1swcdyreaj`, using actual lease expiry, canonical SQLite owner APIs, the qa-channel HTTP bus, and the existing mock provider. Baseline `345b2235e3c0b2f702bc1ccf06ce42a397dc0991` charged the last attempt, refused dispatch, sent zero targets, and settled failed. Candidate `d2d89cae52a3a2c694e353e1f65ad6eece7deb2c` rejected the stale reservation without charging, recovered exactly one target after Gateway restart, and removed the successful row. Both sent one independent control, with no duplicate in the bounded quiet window. This is real Gateway/channel-harness proof, not authenticated external-channel proof.
- [Testbox workflow33151272426](https://github.com/openclaw/openclaw/actions/runs/33151272426) dispatched workflow source `8d51e415d6a14ae7b6d1023fc9661e4bc1e9c725`; the two tested sources are the distinct SHAs above. All34,519 tracked file blobs and modes matched before install/build, after build/proof, and at cleanup for each checkout. The independently verified archive SHA256 is `c39f705b6a1d8e07b989b8be12f74a5cd35745ffb02345578e3787014f369694`. No owned Node processes remained.
- The first baseline run reproduced the bug but failed during harness artifact preservation outside the permitted repository root. The fixture destination was corrected, and both sources were rebuilt and rerun successfully; no production code, assertions, or timeouts changed.
- Main’s private-helper test import was independently fixed by #131627 at `871b18dff5039484e86c76d282699a8defcb1654`; our redundant #131631 was closed. Rebase preserved the repair patch and every changed-file byte. [Final-head CI33154822445](https://github.com/openclaw/openclaw/actions/runs/33154822445) passed at `4283757ffb84b623bb192544955fbe7425f19e4c`. This resolves ClawSweeper’s remaining CI request.
- The built Gateway proof was repeated successfully on that exact final head: [Testbox33154910798](https://github.com/openclaw/openclaw/actions/runs/33154910798), lease `tbx_01m13q895z2wkzrqkfk36frjt9`. It again preserved zero spent attempts and delivered target/control exactly once with success settlement. All34,536 tracked blobs/modes matched at five checkpoints; archiveSHA256 `a0b9ac220bcb47ec083d58d33efec13978bad7fa8549fd72997a53f6eca87011` independently verified. Workflow dispatch source was `0a068cf3f1ef4c45988c7f6a947caacc134478b7`, distinct from tested source. No owned process remained and the lease is completed. Fresh final-head Codex autoreview is clean at its P0 threshold.

Provenance: `50dee059a2542816637c2036de123d773b683f06` introduced identity-only reservation; `371c03c0b319e08d9b5b2f450a4cc0a3f9479297` introduced renewable producer leases; `2d75a2d32814c2396f0b8e7d049794ff0d645f22` established the dispatch predicate reused here. No stable-release regression boundary is claimed.

AI-assisted implementation with Codex. Synthetic test state only; no operator state or channel credentials used.
