### PR TITLE
fix(plugins): native imports fail after source dependency pruning

### DIFF
--- a/docs/plugins/dependency-resolution.md
+++ b/docs/plugins/dependency-resolution.md
@@ -220,6 +220,31 @@ On npm 11.15 and earlier, omit `--allow-scripts=openclaw`. Plugin dependency
 convergence remains intentionally script-disabled and continues to use the
 `--ignore-scripts` commands above.
 
+### Native imports from a standalone source build
+
+To import an already-built `extensions/<package>/dist` directly with Node,
+explicitly prepare its host link from the source checkout root:
+
+```bash
+node scripts/lib/plugin-npm-runtime-build.mjs --prepare-native-import extensions/<package>
+```
+
+This requires existing root SDK output in `dist/plugin-sdk` and the selected
+package's standalone runtime output. If the package output is missing, build
+it first with `node scripts/lib/plugin-npm-runtime-build.mjs extensions/<package>`.
+The preparation command does not rebuild either output or execute plugin code.
+It only links the checkout as `node_modules/openclaw` for a real immediate
+source package that declares `openclaw` in `peerDependencies` or `dependencies`.
+It does not install third-party dependencies; those must already be available
+through the pnpm workspace.
+
+Preparation refuses symlinked package paths, unsafe manifests, and conflicting
+dependency paths instead of reporting success. Ordinary package builds remain
+artifact-only. Postinstall and root build preparation still remove source
+plugin-local `node_modules`, including this link; rerun the explicit preparation
+command afterward when needed. Runtime loading never performs this setup or
+runs a package manager.
+
 ## Legacy cleanup
 
 Older OpenClaw versions generated bundled-plugin dependency roots at startup

--- a/scripts/lib/plugin-npm-runtime-build.mts
+++ b/scripts/lib/plugin-npm-runtime-build.mts
@@ -438,12 +438,101 @@ export async function buildPluginNpmRuntime(params: PluginNpmRuntimeBuildParams)
   };
 }
 
+async function preparePluginNativeImport(params: PluginNpmRuntimeBuildParams) {
+  // Source setup is opt-in; publication and root builds must remain artifact-only.
+  const { readRootJsonObjectSync } = await import("../../src/infra/json-files.js");
+  const { linkOpenClawPeerDependencies, resolveOpenClawHostDependency } =
+    await import("../../src/plugins/plugin-peer-link.js");
+  const { isSourceCheckoutRoot } = await import("../postinstall-bundled-plugins.mjs");
+  const repoRoot = fs.realpathSync(params.repoRoot ?? ".");
+  const hostManifest = readRootJsonObjectSync({
+    rootDir: repoRoot,
+    relativePath: "package.json",
+    boundaryLabel: "OpenClaw source checkout",
+  });
+  if (
+    !hostManifest.ok ||
+    hostManifest.value.name !== "openclaw" ||
+    !isSourceCheckoutRoot({ packageRoot: repoRoot })
+  ) {
+    throw new Error("Native-import preparation must run from an OpenClaw source checkout root.");
+  }
+  const packageDir = path.resolve(repoRoot, params.packageDir);
+  if (
+    path.dirname(packageDir) !== path.join(repoRoot, "extensions") ||
+    !fs.lstatSync(packageDir, { throwIfNoEntry: false })?.isDirectory() ||
+    fs.realpathSync(packageDir) !== packageDir
+  ) {
+    throw new Error(
+      "Select a real immediate extensions/<package> directory in this checkout; symlinked packages are not supported.",
+    );
+  }
+  const manifest = readRootJsonObjectSync({
+    rootDir: packageDir,
+    relativePath: "package.json",
+    boundaryLabel: "selected source plugin package",
+  });
+  if (!manifest.ok) {
+    throw new Error(
+      `Could not safely read ${packageDir}/package.json; use a regular file containing a JSON object.`,
+    );
+  }
+  const dependency = resolveOpenClawHostDependency(manifest.value);
+  if (!dependency) {
+    throw new Error(
+      `${params.packageDir} does not declare openclaw in peerDependencies or dependencies; no host link to prepare.`,
+    );
+  }
+  if (
+    !fs.statSync(path.join(repoRoot, "dist/plugin-sdk"), { throwIfNoEntry: false })?.isDirectory()
+  ) {
+    throw new Error("Host SDK output is missing; build OpenClaw before preparing native imports.");
+  }
+  const runtimeFormat = resolveRuntimeBuildFormat(manifest.value);
+  const outDir = path.join(packageDir, "dist");
+  for (const entry of collectPluginSourceEntries(manifest.value)) {
+    const output = path.resolve(packageDir, toPackageRuntimeEntry(entry, runtimeFormat));
+    const relative = path.relative(outDir, output);
+    if (
+      relative.startsWith(`..${path.sep}`) ||
+      relative === ".." ||
+      path.isAbsolute(relative) ||
+      !fs.statSync(output, { throwIfNoEntry: false })?.isFile()
+    ) {
+      throw new Error(
+        `Missing package-local runtime output for ${entry}; run node scripts/lib/plugin-npm-runtime-build.mjs ${params.packageDir} first.`,
+      );
+    }
+  }
+  const result = await linkOpenClawPeerDependencies({
+    installedDir: packageDir,
+    hostRoot: repoRoot,
+    peerDependencies: { openclaw: dependency.spec },
+    logger: { warn: (message) => console.error(message) },
+  });
+  if (result.skipped > 0) {
+    throw new Error(
+      `Could not prepare ${params.packageDir}: inspect node_modules/openclaw and the warning above; move conflicting paths aside and rerun --prepare-native-import.`,
+    );
+  }
+  console.error(
+    `[plugin-npm-runtime-build] prepared ${path.basename(packageDir)} host link for native imports (artifacts unchanged)`,
+  );
+}
+
 function usage() {
-  return "usage: node scripts/lib/plugin-npm-runtime-build.mjs <package-dir>";
+  return (
+    "usage: node scripts/lib/plugin-npm-runtime-build.mjs <package-dir> [--prepare-native-import]\n" +
+    "  --prepare-native-import  Prepare an already-built source package without rebuilding artifacts; run from the checkout root."
+  );
 }
 
 function readPackageDirArg(argv: string[]) {
-  const args = argv[0] === "--" ? argv.slice(1) : argv;
+  const args = argv[0] === "--" ? argv.slice(1) : [...argv];
+  const prepareIndex = args.indexOf("--prepare-native-import");
+  if (prepareIndex !== -1) {
+    args.splice(prepareIndex, 1);
+  }
   const packageDir = args[0];
   if (packageDir === "--help" || packageDir === "-h") {
     return { help: true, packageDir: "" };
@@ -455,7 +544,7 @@ function readPackageDirArg(argv: string[]) {
   if (extraArg) {
     throw new Error(`unexpected plugin npm runtime build argument: ${extraArg}`);
   }
-  return { packageDir };
+  return prepareIndex === -1 ? { packageDir } : { packageDir, prepareNativeImport: true };
 }
 
 /** @internal Directly tested script implementation detail. */
@@ -471,7 +560,9 @@ if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
       process.exit(0);
     }
     const { packageDir } = args;
-    const result = await buildPluginNpmRuntime({ packageDir });
+    const result = args.prepareNativeImport
+      ? await preparePluginNativeImport({ packageDir })
+      : await buildPluginNpmRuntime({ packageDir });
     if (result) {
       console.error(
         `[plugin-npm-runtime-build] built ${result.pluginDir} runtime (${result.sourceEntries.length} entries)`,

--- a/src/plugins/plugin-peer-link.ts
+++ b/src/plugins/plugin-peer-link.ts
@@ -352,17 +352,21 @@ export async function linkOpenClawPeerDependencies(params: {
   installedDir: string;
   peerDependencies: Record<string, string>;
   logger: PluginPeerLinkLogger;
+  /** Explicit source setup uses its selected checkout instead of the running host. */
+  hostRoot?: string;
 }): Promise<{ repaired: number; skipped: number }> {
   const peers = Object.keys(params.peerDependencies).filter((name) => name === "openclaw");
   if (peers.length === 0) {
     return { repaired: 0, skipped: 0 };
   }
 
-  const hostRoot = resolveOpenClawPackageRootSync({
-    argv1: process.argv[1],
-    moduleUrl: import.meta.url,
-    cwd: process.cwd(),
-  });
+  const hostRoot =
+    params.hostRoot ??
+    resolveOpenClawPackageRootSync({
+      argv1: process.argv[1],
+      moduleUrl: import.meta.url,
+      cwd: process.cwd(),
+    });
   if (!hostRoot) {
     params.logger.warn?.(
       "Could not locate openclaw package root to symlink peerDependencies; plugin may fail to resolve openclaw at runtime.",

--- a/test/scripts/plugin-npm-runtime-build-args.test.ts
+++ b/test/scripts/plugin-npm-runtime-build-args.test.ts
@@ -34,6 +34,24 @@ describe("plugin npm runtime build args", () => {
     });
   });
 
+  it("selects preparation without compilation only when explicitly requested", () => {
+    for (const args of [
+      ["--prepare-native-import", "extensions/slack"],
+      ["extensions/slack", "--prepare-native-import"],
+      ["--", "--prepare-native-import", "extensions/slack"],
+    ]) {
+      expect(parseSingleBuildArgs(args)).toEqual({
+        packageDir: "extensions/slack",
+        prepareNativeImport: true,
+      });
+    }
+    expect(() => parseSingleBuildArgs(["--prepare-native-import"])).toThrow(/usage:/u);
+    expect(() => parseSingleBuildArgs(["--prepare-native-import", "--unknown"])).toThrow(/usage:/u);
+    expect(() =>
+      parseSingleBuildArgs(["--prepare-native-import", "extensions/slack", "extra"]),
+    ).toThrow(/unexpected/u);
+  });
+
   it("rejects missing or option-looking package targets", () => {
     expect(() => parseBulkBuildArgs(["--package"])).toThrow("missing value for --package");
     expect(() => parseBulkBuildArgs(["--package", "--package", "extensions/slack"])).toThrow(

--- a/test/scripts/plugin-npm-runtime-native-import.test.ts
+++ b/test/scripts/plugin-npm-runtime-native-import.test.ts
@@ -1,0 +1,267 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { pruneBundledPluginSourceNodeModules } from "../../scripts/postinstall-bundled-plugins.mjs";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const cli = path.resolve(import.meta.dirname, "../../scripts/lib/plugin-npm-runtime-build.mjs");
+
+function writeFile(root: string, relative: string, content: string) {
+  const target = path.join(root, relative);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, content);
+}
+
+function fixture(format = "esm", declaration = "peerDependencies") {
+  const root = tempDirs.make("openclaw-native-import-");
+  fs.mkdirSync(path.join(root, "src"));
+  writeFile(root, "pnpm-workspace.yaml", "packages:\n  - extensions/*\n");
+  // Setup runs source tooling with workspace aliases; native children below do not load tsx.
+  writeFile(
+    root,
+    "tsconfig.json",
+    JSON.stringify({ extends: path.resolve(import.meta.dirname, "../../tsconfig.json") }),
+  );
+  writeFile(
+    root,
+    "package.json",
+    JSON.stringify({
+      name: "openclaw",
+      version: "1.0.0",
+      type: "module",
+      exports: { "./plugin-sdk/fixture": "./dist/plugin-sdk/fixture.js" },
+    }),
+  );
+  writeFile(root, "dist/plugin-sdk/fixture.js", 'export const host = "host";\n');
+  writeFile(
+    root,
+    "node_modules/fixture-dep/package.json",
+    JSON.stringify({ name: "fixture-dep", main: "index.cjs" }),
+  );
+  writeFile(root, "node_modules/fixture-dep/index.cjs", 'exports.thirdParty = "third-party";\n');
+  const packageDir = path.join(root, "extensions/demo");
+  writeFile(
+    packageDir,
+    "package.json",
+    JSON.stringify({
+      name: "@openclaw/demo",
+      version: "1.0.0",
+      type: "module",
+      optionalDependencies: { "fixture-dep": "1.0.0" },
+      [declaration]: { openclaw: "*" },
+      openclaw: {
+        extensions: ["./index.ts"],
+        build: { runtimeFormat: format },
+        release: { publishToNpm: true },
+      },
+    }),
+  );
+  writeFile(
+    packageDir,
+    "index.ts",
+    [
+      'import { host } from "openclaw/plugin-sdk/fixture";',
+      'import { thirdParty } from "fixture-dep";',
+      'import { writeFileSync } from "node:fs";',
+      'writeFileSync("executed", "yes");',
+      "export const answer = `${host} ${thirdParty}`;",
+    ].join("\n"),
+  );
+  const entry = `./extensions/demo/dist/index.${format === "cjs" ? "cjs" : "js"}`;
+  writeFile(root, entry, 'throw new Error("Preparation must not execute plugin code");\n');
+  return { root, packageDir, entry };
+}
+
+function runCli(root: string, args: string[]) {
+  return spawnSync(process.execPath, [cli, ...args], { cwd: root, encoding: "utf8" });
+}
+
+function nativeImport(root: string, entry: string, format: string) {
+  const env = { ...process.env };
+  delete env.NODE_OPTIONS;
+  delete env.NODE_PATH;
+  return spawnSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "-e",
+      format === "cjs"
+        ? `import { createRequire } from "node:module"; console.log(createRequire(import.meta.url)(${JSON.stringify(entry)}).answer);`
+        : `console.log((await import(${JSON.stringify(entry)})).answer);`,
+    ],
+    { cwd: root, encoding: "utf8", env },
+  );
+}
+
+function snapshot(root: string, directories: string[]) {
+  return Object.fromEntries(
+    directories
+      .flatMap((directory) => {
+        const target = path.join(root, directory);
+        return [
+          directory,
+          ...fs
+            .readdirSync(target, { recursive: true })
+            .map((name) => path.join(directory, String(name))),
+        ];
+      })
+      .map((relative) => {
+        const target = path.join(root, relative);
+        const stat = fs.statSync(target, { bigint: true });
+        return [
+          relative,
+          {
+            mtime: stat.mtimeNs,
+            hash: stat.isFile()
+              ? createHash("sha256").update(fs.readFileSync(target)).digest("hex")
+              : null,
+          },
+        ];
+      }),
+  );
+}
+
+describe("explicit source native-import preparation", () => {
+  it.each([
+    ["esm", "peerDependencies"],
+    ["cjs", "peerDependencies"],
+    ["esm", "dependencies"],
+    ["cjs", "dependencies"],
+  ])(
+    "prepares pruned %s output with an actual %s host without rebuilding",
+    (format, declaration) => {
+      const { root, packageDir, entry } = fixture(format, declaration);
+      fs.mkdirSync(path.join(packageDir, "node_modules"));
+      fs.symlinkSync(root, path.join(packageDir, "node_modules/openclaw"), "junction");
+      pruneBundledPluginSourceNodeModules({ extensionsDir: path.join(root, "extensions") });
+
+      const compiled = runCli(root, ["extensions/demo"]);
+      expect(compiled.status, compiled.stderr).toBe(0);
+      expect(fs.existsSync(path.join(packageDir, "node_modules"))).toBe(false);
+      const missing = nativeImport(root, entry, format);
+      expect(missing.status).not.toBe(0);
+      expect(missing.stderr).toMatch(/Cannot find (?:package|module) 'openclaw/u);
+
+      writeFile(packageDir, "node_modules/keep/marker", "unrelated local contents");
+      const directories = [
+        "dist",
+        "extensions/demo/dist",
+        "node_modules",
+        "extensions/demo/node_modules/keep",
+      ];
+      const before = snapshot(root, directories);
+      const prepared = runCli(root, ["--prepare-native-import", "extensions/demo"]);
+      expect(prepared.status, prepared.stderr).toBe(0);
+      expect(fs.existsSync(path.join(root, "executed"))).toBe(false);
+      const link = path.join(packageDir, "node_modules/openclaw");
+      expect(fs.realpathSync(link)).toBe(root);
+      const linkBefore = fs.lstatSync(link, { bigint: true });
+      const repeated = runCli(root, ["extensions/demo", "--prepare-native-import"]);
+      expect(repeated.status, repeated.stderr).toBe(0);
+      expect(fs.lstatSync(link, { bigint: true }).mtimeNs).toBe(linkBefore.mtimeNs);
+      expect(snapshot(root, directories)).toEqual(before);
+
+      const loaded = nativeImport(root, entry, format);
+      expect(loaded.status, loaded.stderr).toBe(0);
+      expect(loaded.stdout.trim()).toBe("host third-party");
+      expect(fs.readFileSync(path.join(root, "executed"), "utf8")).toBe("yes");
+      expect(snapshot(root, directories)).toEqual(before);
+    },
+  );
+
+  it.each(["devDependencies", "optionalDependencies"])(
+    "does not infer a host declaration from %s or publication metadata",
+    (declaration) => {
+      const { root, packageDir } = fixture("esm", declaration);
+      const result = runCli(root, ["--prepare-native-import", "extensions/demo"]);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toMatch(/does not declare openclaw/u);
+      expect(fs.existsSync(path.join(packageDir, "node_modules"))).toBe(false);
+    },
+  );
+
+  it.each([
+    "outside package",
+    "nested package",
+    "symlinked package",
+    "symlinked extensions",
+    "symlinked manifest",
+    "invalid manifest",
+    "wrong host",
+    "not source",
+    "missing host output",
+    "missing plugin output",
+    "symlinked node_modules",
+    "unrelated host directory",
+  ])("rejects %s without changing artifacts or unrelated contents", (scenario) => {
+    const { root, packageDir } = fixture();
+    const outside = tempDirs.make("openclaw-native-import-outside-");
+    writeFile(outside, "marker", "keep");
+    let selected = "extensions/demo";
+    let expected = /real immediate extensions/u;
+    switch (scenario) {
+      case "outside package":
+        selected = outside;
+        break;
+      case "nested package":
+        selected = "extensions/demo/nested";
+        break;
+      case "symlinked package":
+        fs.renameSync(packageDir, path.join(outside, "demo"));
+        fs.symlinkSync(path.join(outside, "demo"), packageDir, "junction");
+        break;
+      case "symlinked extensions":
+        fs.renameSync(path.join(root, "extensions"), path.join(outside, "extensions"));
+        fs.symlinkSync(path.join(outside, "extensions"), path.join(root, "extensions"), "junction");
+        break;
+      case "symlinked manifest":
+        fs.renameSync(path.join(packageDir, "package.json"), path.join(outside, "package.json"));
+        fs.symlinkSync(path.join(outside, "package.json"), path.join(packageDir, "package.json"));
+        expected = /safely read.*package.json/u;
+        break;
+      case "invalid manifest":
+        writeFile(packageDir, "package.json", "[]");
+        expected = /safely read.*package.json/u;
+        break;
+      case "wrong host":
+        writeFile(root, "package.json", JSON.stringify({ name: "unrelated" }));
+        expected = /source checkout root/u;
+        break;
+      case "not source":
+        fs.rmdirSync(path.join(root, "src"));
+        expected = /source checkout root/u;
+        break;
+      case "missing host output":
+        fs.rmSync(path.join(root, "dist"), { recursive: true });
+        expected = /Host SDK output is missing/u;
+        break;
+      case "missing plugin output":
+        fs.rmSync(path.join(packageDir, "dist"), { recursive: true });
+        expected = /run node scripts\/lib\/plugin-npm-runtime-build.mjs/u;
+        break;
+      case "symlinked node_modules":
+        fs.symlinkSync(outside, path.join(packageDir, "node_modules"), "junction");
+        expected = /not a real directory/u;
+        break;
+      case "unrelated host directory":
+        writeFile(
+          packageDir,
+          "node_modules/openclaw/package.json",
+          JSON.stringify({ name: "unrelated" }),
+        );
+        writeFile(packageDir, "node_modules/openclaw/marker", "keep");
+        expected = /already exists and is not a symlink/u;
+        break;
+    }
+    const before = snapshot(root, ["."]);
+    const outsideBefore = snapshot(outside, ["."]);
+    const result = runCli(root, ["--prepare-native-import", selected]);
+    expect(result.status, result.stderr).toBe(1);
+    expect(result.stderr).toMatch(expected);
+    expect(snapshot(root, ["."])).toEqual(before);
+    expect(snapshot(outside, ["."])).toEqual(outsideBefore);
+  });
+});


### PR DESCRIPTION
Closes #131611

## What Problem This Solves

Fixes an issue where developers importing a standalone source-checkout plugin artifact with native Node would receive `ERR_MODULE_NOT_FOUND` for `openclaw` after source postinstall or root build preparation pruned the plugin-local workspace host link. The standalone package build succeeds, but its external SDK imports remain unresolved.

## Why This Change Was Made

Add an explicit `--prepare-native-import` operation to the existing package-build tool. It validates a real immediate source package, its actual declared host dependency, and existing built outputs, then reuses the guarded host-peer linker with the selected checkout root. It does not compile, execute plugin code, install third-party packages, modify discovery, or change Doctor.

Compilation remains artifact-only, including publication and external root-build callers. Source pruning remains intentional and unchanged; managed plugin install/update ownership and default host resolution are unchanged. Automatic pruning exemptions, runtime repair, artifact symlinks, host bundling, and loader aliases were rejected because they would move or weaken these existing boundaries.

Production/tooling LOC: +104/-9 (net +95). Tests: +285/-0. Docs: +25/-0. The production addition supplies the missing explicit source-setup boundary and its ownership checks; the existing guarded linker is reused rather than duplicated. The only added operator surface is one opt-in repository-tool CLI flag; there is no new config key, environment variable, or default behavior.

## User Impact

With existing root SDK and standalone plugin output, run from the source checkout root:

```bash
node scripts/lib/plugin-npm-runtime-build.mjs --prepare-native-import extensions/whatsapp
```

The selected plugin's declared host dependency can then resolve through ordinary native Node imports. Re-run explicit preparation after source postinstall/root build preparation removes the link. Third-party dependencies remain the pnpm workspace's responsibility. Unsafe or unrelated conflicting paths fail without being overwritten.

Documentation is updated alongside the existing [dependency ownership guide](https://docs.openclaw.ai/plugins/dependency-resolution).

## Evidence

Published head: `1c537579398c90325443e910f672cae41a1865c6`, based on canonical gateway-test repair [#131627](https://github.com/openclaw/openclaw/pull/131627), merge `871b18dff5039484e86c76d282699a8defcb1654`. This mechanical base refresh resolves the shared-main stale-import failure seen in [prior CI run 33151647123](https://github.com/openclaw/openclaw/actions/runs/33151647123). All five reviewed-file SHA-256 hashes and the repair patch remain byte-identical; no gateway fix was duplicated in this PR.

Focused integration on this head passed all three cases with `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/server-reload-channel-restart.test.ts`. [Exact-head CI run 33154210874](https://github.com/openclaw/openclaw/actions/runs/33154210874) passed (166 successful jobs, 17 skipped), including the required [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33154210874/job/98795890842). Both formerly failing lanes passed: [core test types](https://github.com/openclaw/openclaw/actions/runs/33154210874/job/98793157074) and [compact Node tests](https://github.com/openclaw/openclaw/actions/runs/33154210874/job/98793159008). Native review artifacts record `READY FOR /prepare-pr`, with no actionable source findings and valid issue validation. Preparation and merge have not run; the current maintainer proof decision is recorded below.

Local source proof at `629a47e3cc20a9f8b6d19c105f840b8a693ec4aa`, Node 24.20.0 on macOS 27.0:

- Before the production repair, regression tests confirmed missing-host native ESM/CommonJS imports and failed because the preparation operation did not exist (5 failed, 4 passed).
- 34 focused tests passed: preparation, argument parsing, declared peer/direct host dependencies, idempotence, ownership/symlink guards, unrelated-content preservation, and the existing managed host-link contract.
- 67 existing sibling tests passed: source/postinstall pruning, standalone compiler checks, external staging, root staging, and runtime artifact selection.
- All classified checks passed, including formatting, type checks, targeted lint, dead exports, and import-cycle/boundary guards.
- Fresh plain-Node imports passed for WhatsApp's entrypoint, setup entry, runtime API, root-built memory-core, and the original memory-core-then-WhatsApp order. Native subprocesses had no loader/alias setup.
- All 15,529 preserved build-artifact hashes and nanosecond mtimes stayed identical through explicit preparation and native imports. Rebuilding only WhatsApp from the source snapshot left all 15,461 other artifacts unchanged; preparation/import again preserved the resulting 15,529-artifact inventory. No root-QA rebuild was used for either proof.

Focused commands:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/plugin-npm-runtime-native-import.test.ts test/scripts/plugin-npm-runtime-build-args.test.ts src/plugins/plugin-peer-link.test.ts
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/postinstall-bundled-plugins.test.ts test/scripts/check-plugin-npm-runtime-builds.test.ts test/scripts/build-external-plugin-local-dist.test.ts src/plugins/plugin-runtime-artifact-resolution.test.ts src/plugins/stage-bundled-plugin-runtime.test.ts
```

```bash
node scripts/check-changed.mjs -- scripts/lib/plugin-npm-runtime-build.mts src/plugins/plugin-peer-link.ts test/scripts/plugin-npm-runtime-native-import.test.ts test/scripts/plugin-npm-runtime-build-args.test.ts docs/plugins/dependency-resolution.md
```

```bash
node --input-type=module -e 'await import("./dist/extensions/memory-core/index.js"); await import("./extensions/whatsapp/dist/index.js")'
```

The preserved host SDK/QA artifacts originated from source snapshot `60c1dc35becf066b3e2da379a85abed5b07f2ce9`; only the standalone WhatsApp artifact was rebuilt from `629a47e3cc20a9f8b6d19c105f840b8a693ec4aa`. This is not a clean full build of the rebased head.

The synthetic source fixture inherits the repository's source-tooling tsconfig; its native import/require subprocesses remain loader-free. This is native artifact-loading proof, not authenticated WhatsApp messaging proof. The profiler's separate entry-discovery repair remains outside this change.

AI-assisted implementation and independent Codex autoreview; no agent transcripts or private artifacts are published.

### Maintainer proof decision and fresh real-artifact capture

The [completed ClawSweeper review](https://github.com/openclaw/openclaw/pull/131615#issuecomment-5450273663) reports no code/security findings. Its command exited successfully with **18 passed tests**; the failed `expect_output` matched a long test title that the terminal split as `peerD` / `ependencies`. That is a terminal-output matching false negative, not a native-import test failure. No test names, assertions, terminal-width settings, or runtime loader behavior were changed to satisfy the matcher.

To address the real-behavior request and the rank-up move directly, I repeated the real source-checkout flow at code head `1c537579398c90325443e910f672cae41a1865c6`, using the existing actual WhatsApp and host SDK artifacts—not the synthetic test fixture. I ran canonical source postinstall, observed a fresh native import exit 1 with missing `openclaw`, then ran:

```bash
node scripts/lib/plugin-npm-runtime-build.mjs --prepare-native-import extensions/whatsapp
```

Fresh plain-Node subprocesses then imported the real entrypoint, setup entry, runtime API, memory-core, and the original memory-core-then-WhatsApp sequence. Native probes used isolated home/config/state paths with `NODE_OPTIONS` and `NODE_PATH` absent.

Condensed terminal results, with local paths and repeated inventory formatting omitted:

```text
BEFORE: fresh native import exited 1 with ERR_MODULE_NOT_FOUND for openclaw
[plugin-npm-runtime-build] prepared whatsapp host link for native imports (artifacts unchanged)
whatsapp: ok (exit 0, 810ms)
whatsapp-setup: ok (exit 0, 350ms)
whatsapp-runtime: ok (exit 0, 18873ms)
memory-core: ok (exit 0, 9395ms)
mixed-memory-then-whatsapp: ok (exit 0, 9569ms)
count: 15529
changedCount: 0
AFTER: all five native import scenarios passed; no root-QA build or artifact rewrite
```

The full artifact inventory digest was identical before and after: `3079607a6ed3b41cf053a5d1f155ad4ffba6d9851dd356dccc6c649abaea8757`. The comparison includes file SHA-256 values and nanosecond mtimes, plus symlink targets and mtimes. Host artifacts remain from `60c1dc35becf066b3e2da379a85abed5b07f2ce9`, standalone output from `629a47e3cc20a9f8b6d19c105f840b8a693ec4aa`, and the preparation code exercised here is the exact current PR head. This deliberately proves the already-built-artifact contract without rebuilding root QA output; it is not an authenticated messaging claim or a fresh full-root build claim.

All four before-merge items are resolved:

- **Real behavior proof and rank-up move:** satisfied by the fresh real-artifact before/after capture above, in addition to the passing native ESM/CommonJS regression suite. The terminal substring false negative is rejected as a product failure and recorded separately for the proof-runner owner.
- **Production/tooling growth:** retain the bounded +95-line explicit setup boundary. Its checkout/package/declaration/output checks preserve ownership while reusing the existing guarded linker. Folding this into ordinary compilation, pruning exemptions, or runtime loading would change the intentionally preserved policy. No config key, environment variable, dependency, or default behavior was added.
- **Exact-head CI wait:** resolved by successful [CI 33154210874](https://github.com/openclaw/openclaw/actions/runs/33154210874), 166 successful jobs and 17 manifest-selected skips, with [the required gate](https://github.com/openclaw/openclaw/actions/runs/33154210874/job/98795890842) successful on this exact head.
- **Next step to await CI:** complete; the former shared-main test failure was repaired by [PR #131627 — rollback regression checks](https://github.com/openclaw/openclaw/pull/131627), and this head incorporates that canonical repair without duplicating it.

**Decision: proof is satisfied; proceed with the reviewed explicit source-setup design. No behavior-proof waiver or code change is needed.** All five reviewed source hashes remain unchanged. Native preparation and merge still perform their normal exact-head checks.
