### PR TITLE
fix: recognize newly installed skill and Gmail dependencies

### DIFF
--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -398,6 +398,10 @@ metadata:
   At least one binary must exist on `PATH`.
 </ParamField>
 
+Fresh dependency checks detect binaries installed into directories already on
+`PATH`. This does not refresh an existing session's skill snapshot; see
+[Snapshots and refresh](/tools/skills#snapshots-and-refresh).
+
 <ParamField path="requires.env" type="string[]">
   Each env var must exist in the process or be provided via config.
 </ParamField>

--- a/src/hooks/config.test.ts
+++ b/src/hooks/config.test.ts
@@ -1,5 +1,8 @@
+import fs from "node:fs";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { withTempDirSync } from "../test-helpers/temp-dir.js";
 import { withEnv } from "../test-utils/env.js";
 import { shouldIncludeHook } from "./config.js";
 import { buildWorkspaceHookStatus } from "./hooks-status.js";
@@ -41,6 +44,24 @@ function evaluate(config?: OpenClawConfig) {
   const status = buildWorkspaceHookStatus("/tmp", { entries: [entry], config }).hooks[0];
   return { runtimeIncluded, status };
 }
+
+it("includes a hook after an accepted binary is installed on unchanged PATH", () => {
+  withTempDirSync({ prefix: "openclaw-hook-binary-" }, (binDir) => {
+    const binaryEntry: HookEntry = {
+      ...entry,
+      metadata: { events: ["command:new"], requires: { anyBins: ["fixture-hook-tool"] } },
+    };
+    withEnv({ PATH: binDir }, () => {
+      const included = () => shouldIncludeHook({ entry: binaryEntry });
+      expect(included()).toBe(false);
+      const executable = path.join(binDir, "fixture-hook-tool");
+      fs.writeFileSync(executable, "#!/bin/sh\nexit 0\n");
+      fs.chmodSync(executable, 0o755);
+      expect(process.env.PATH).toBe(binDir);
+      expect(included()).toBe(true);
+    });
+  });
+});
 
 describe("hook environment requirements", () => {
   it.each([

--- a/src/hooks/gmail-setup-utils.test.ts
+++ b/src/hooks/gmail-setup-utils.test.ts
@@ -2,8 +2,10 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { withEnvAsync } from "../test-utils/env.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { withMockedPlatform } from "../test-utils/vitest-spies.js";
 const itUnix = process.platform === "win32" ? it.skip : it;
 const runCommandWithTimeoutMock = vi.fn();
 
@@ -19,6 +21,57 @@ beforeEach(() => {
 async function loadGmailSetupUtils() {
   return await import("./gmail-setup-utils.js");
 }
+
+describe("ensureDependency binary availability", () => {
+  afterEach(() => runCommandWithTimeoutMock.mockReset());
+
+  it.each([true, false])(
+    "checks the installed executable when installer creates it: %s",
+    async (createsBinary) => {
+      const { ensureDependency } = await loadGmailSetupUtils();
+      await withOpenClawTestState({ label: "dependency-probe" }, async (state) => {
+        const binDir = state.path("bin");
+        await fs.mkdir(binDir);
+        const writeExecutable = async (name: string) => {
+          const executable = path.join(binDir, name);
+          await fs.writeFile(executable, "#!/bin/sh\nexit 0\n");
+          await fs.chmod(executable, 0o755);
+        };
+        await writeExecutable("brew");
+        await withEnvAsync({ PATH: binDir, XDG_CONFIG_HOME: state.path("config") }, () =>
+          withMockedPlatform("darwin", async () => {
+            runCommandWithTimeoutMock.mockImplementation(async (argv: string[]) => {
+              expect(argv).toEqual(["brew", "install", "fixture-probe-formula"]);
+              if (createsBinary) {
+                await writeExecutable("fixture-gmail-tool");
+              }
+              return {
+                stdout: "",
+                stderr: "",
+                code: 0,
+                signal: null,
+                killed: false,
+                termination: "exit",
+              };
+            });
+
+            const install = () => ensureDependency("fixture-gmail-tool", ["fixture-probe-formula"]);
+            if (createsBinary) {
+              await expect(install()).resolves.toBeUndefined();
+              await expect(install()).resolves.toBeUndefined();
+            } else {
+              await expect(install()).rejects.toThrow(
+                "fixture-gmail-tool still not available after brew install",
+              );
+            }
+            expect(process.env.PATH).toBe(binDir);
+            expect(runCommandWithTimeoutMock).toHaveBeenCalledTimes(1);
+          }),
+        );
+      });
+    },
+  );
+});
 
 describe("runGcloud interpreter resolution", () => {
   itUnix(

--- a/src/shared/config-eval.test.ts
+++ b/src/shared/config-eval.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { withTempDirSync } from "../test-helpers/temp-dir.js";
 import { mockProcessPlatform } from "../test-utils/vitest-spies.js";
 import {
   evaluateRuntimeEligibility,
@@ -9,21 +10,13 @@ import {
   isConfigPathTruthyWithDefaults,
 } from "./config-eval.js";
 
-const originalPath = process.env.PATH;
-const originalPathExt = process.env.PATHEXT;
-
 function setPlatform(platform: NodeJS.Platform): void {
   mockProcessPlatform(platform);
 }
 
 afterEach(() => {
   vi.restoreAllMocks();
-  process.env.PATH = originalPath;
-  if (originalPathExt === undefined) {
-    delete process.env.PATHEXT;
-  } else {
-    process.env.PATHEXT = originalPathExt;
-  }
+  vi.unstubAllEnvs();
 });
 
 describe("config-eval helpers", () => {
@@ -108,7 +101,7 @@ describe("config-eval helpers", () => {
 
   it("caches binary lookups until PATH changes", () => {
     setPlatform("linux");
-    process.env.PATH = ["/missing/bin", "/found/bin"].join(path.delimiter);
+    vi.stubEnv("PATH", ["/missing/bin", "/found/bin"].join(path.delimiter));
     const accessSpy = vi.spyOn(fs, "accessSync").mockImplementation((candidate) => {
       if (String(candidate) === path.join("/found/bin", "tool")) {
         return undefined;
@@ -120,7 +113,7 @@ describe("config-eval helpers", () => {
     expect(hasBinary("tool")).toBe(true);
     expect(accessSpy).toHaveBeenCalledTimes(2);
 
-    process.env.PATH = "/other/bin";
+    vi.stubEnv("PATH", "/other/bin");
     accessSpy.mockClear();
     accessSpy.mockImplementation(() => {
       throw new Error("missing");
@@ -130,11 +123,11 @@ describe("config-eval helpers", () => {
     expect(accessSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("checks PATHEXT candidates on Windows", () => {
+  it("checks PATHEXT candidates and invalidates cached hits when PATHEXT changes", () => {
     setPlatform("win32");
     const toolsDir = path.join(path.sep, "tools");
-    process.env.PATH = toolsDir;
-    process.env.PATHEXT = ".EXE;.CMD";
+    vi.stubEnv("PATH", toolsDir);
+    vi.stubEnv("PATHEXT", ".EXE;.CMD");
     const plainCandidate = path.join(toolsDir, "tool");
     const exeCandidate = path.join(toolsDir, "tool.EXE");
     const cmdCandidate = path.join(toolsDir, "tool.CMD");
@@ -151,7 +144,36 @@ describe("config-eval helpers", () => {
       exeCandidate,
       cmdCandidate,
     ]);
+
+    vi.stubEnv("PATHEXT", ".EXE");
+    expect(hasBinary("tool")).toBe(false);
+    vi.stubEnv("PATHEXT", ".CMD");
+    expect(hasBinary("tool")).toBe(true);
   });
+
+  it.each([
+    { platform: "linux", suffix: "" },
+    { platform: "darwin", suffix: "" },
+    { platform: "win32", suffix: ".CMD" },
+  ] as const)(
+    "finds a newly installed binary on unchanged $platform PATH",
+    ({ platform, suffix }) => {
+      withTempDirSync({ prefix: "openclaw-binary-probe-" }, (binDir) => {
+        setPlatform(platform);
+        vi.stubEnv("PATH", binDir);
+        vi.stubEnv("PATHEXT", ".EXE;.CMD");
+        expect(hasBinary("fixture-tool")).toBe(false);
+
+        const executable = path.join(binDir, `fixture-tool${suffix}`);
+        fs.writeFileSync(executable, "#!/bin/sh\nexit 0\n");
+        fs.chmodSync(executable, 0o755);
+
+        expect(process.env.PATH).toBe(binDir);
+        expect(process.env.PATHEXT).toBe(".EXE;.CMD");
+        expect(hasBinary("fixture-tool")).toBe(true);
+      });
+    },
+  );
 });
 
 describe("runtime requirements through eligibility", () => {

--- a/src/shared/config-eval.ts
+++ b/src/shared/config-eval.ts
@@ -169,21 +169,20 @@ function windowsPathExtensions(): string[] {
 
 let cachedHasBinaryPath: string | undefined;
 let cachedHasBinaryPathExt: string | undefined;
-const hasBinaryCache = new Map<string, boolean>();
+// Installs can create binaries under unchanged PATH/PATHEXT, so cache only successful probes.
+const hasBinaryCache = new Set<string>();
 
 /** Checks PATH for an executable binary, including PATHEXT candidates on Windows. */
 export function hasBinary(bin: string): boolean {
   const pathEnv = process.env.PATH ?? "";
   const pathExt = process.platform === "win32" ? (process.env.PATHEXT ?? "") : "";
   if (cachedHasBinaryPath !== pathEnv || cachedHasBinaryPathExt !== pathExt) {
-    // PATH/PATHEXT changes invalidate all cached binary probes; keeping stale misses
-    // would make newly installed tools invisible until process restart.
     cachedHasBinaryPath = pathEnv;
     cachedHasBinaryPathExt = pathExt;
     hasBinaryCache.clear();
   }
   if (hasBinaryCache.has(bin)) {
-    return hasBinaryCache.get(bin)!;
+    return true;
   }
 
   const parts = pathEnv.split(path.delimiter).filter(Boolean);
@@ -193,13 +192,12 @@ export function hasBinary(bin: string): boolean {
       const candidate = path.join(part, bin + ext);
       try {
         fs.accessSync(candidate, fs.constants.X_OK);
-        hasBinaryCache.set(bin, true);
+        hasBinaryCache.add(bin);
         return true;
       } catch {
         // keep scanning
       }
     }
   }
-  hasBinaryCache.set(bin, false);
   return false;
 }

--- a/src/skills/lifecycle/install-cache-freshness.test.ts
+++ b/src/skills/lifecycle/install-cache-freshness.test.ts
@@ -1,0 +1,115 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { withEnvAsync } from "../../test-utils/env.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import type { SkillEntry, SkillInstallSpec } from "../types.js";
+import { installSkill } from "./install.js";
+import { skillsInstallTesting } from "./install.test-support.js";
+
+const { runCommandWithTimeoutMock } = vi.hoisted(() => ({
+  runCommandWithTimeoutMock: vi.fn<typeof import("../../process/exec.js").runCommandWithTimeout>(),
+}));
+
+vi.mock("../../process/exec.js", () => ({
+  runCommandWithTimeout: runCommandWithTimeoutMock,
+}));
+
+vi.mock("../../plugins/install-security-scan.js", () => ({
+  evaluateSkillInstallPolicy: vi.fn(async () => undefined),
+}));
+
+afterEach(() => {
+  skillsInstallTesting.setDepsForTest();
+  runCommandWithTimeoutMock.mockReset();
+  vi.restoreAllMocks();
+});
+
+describe.each(["uv", "go"] as const)("%s bootstrap cache freshness", (kind) => {
+  it.each([0, 1])("reuses the prerequisite after the first recipe exits %i", async (firstCode) => {
+    await withOpenClawTestState({ label: "skill-bootstrap-probe" }, async (state) => {
+      vi.spyOn(os, "homedir").mockReturnValue(state.home);
+      const prefix = path.join(state.home, ".local");
+      const binDir = path.join(prefix, "bin");
+      await fs.mkdir(binDir, { recursive: true });
+      const writeExecutable = async (name: string) => {
+        const executable = path.join(binDir, name);
+        await fs.writeFile(executable, "#!/bin/sh\nexit 0\n");
+        await fs.chmod(executable, 0o755);
+      };
+      await writeExecutable("brew");
+
+      const entries: SkillEntry[] = ["first", "second"].map((name) => {
+        const filePath = path.join(state.workspaceDir, name, "SKILL.md");
+        const spec: SkillInstallSpec =
+          kind === "uv"
+            ? { kind, package: `fixture-${name}` }
+            : { kind, module: `example.com/fixture-${name}@latest` };
+        return {
+          skill: {
+            name,
+            description: "Binary probe fixture",
+            filePath,
+            baseDir: path.dirname(filePath),
+            source: "openclaw-workspace",
+            sourceInfo: { path: filePath, source: "test", scope: "temporary", origin: "top-level" },
+            disableModelInvocation: false,
+          },
+          frontmatter: {},
+          metadata: { install: [{ id: "deps", ...spec }] },
+        };
+      });
+      skillsInstallTesting.setDepsForTest({ loadWorkspaceSkills: () => entries });
+
+      let bootstraps = 0;
+      let recipes = 0;
+      await withEnvAsync({ PATH: binDir }, async () => {
+        runCommandWithTimeoutMock.mockImplementation(async (argv, options) => {
+          let stdout = "";
+          let code = 0;
+          let stderr = "";
+          if (argv[0] === "brew" && argv[1] === "install" && argv[2] === kind) {
+            bootstraps += 1;
+            await writeExecutable(kind);
+          } else if (argv[0] === "brew" && argv[1] === "--prefix") {
+            stdout = prefix;
+          } else {
+            const name = recipes === 0 ? "first" : "second";
+            expect(argv).toEqual(
+              kind === "uv"
+                ? ["uv", "tool", "install", `fixture-${name}`]
+                : ["go", "install", `example.com/fixture-${name}@latest`],
+            );
+            await fs.access(path.join(binDir, kind), fs.constants.X_OK);
+            if (kind === "go") {
+              expect(options).toMatchObject({ env: { PATH: binDir, GOBIN: binDir } });
+            }
+            code = recipes++ === 0 ? firstCode : 0;
+            stdout = `recipe ${name}`;
+            stderr = code === 0 ? "" : "fixture recipe failed";
+          }
+          return { code, stdout, stderr, signal: null, killed: false, termination: "exit" };
+        });
+
+        for (const [index, skillName] of ["first", "second"].entries()) {
+          const code = index === 0 ? firstCode : 0;
+          const result = await installSkill({
+            workspaceDir: state.workspaceDir,
+            skillName,
+            installId: "deps",
+          });
+          expect(result).toMatchObject({
+            ok: code === 0,
+            code,
+            stdout: `recipe ${skillName}`,
+            stderr: code === 0 ? "" : "fixture recipe failed",
+          });
+          expect(process.env.PATH).toBe(binDir);
+        }
+        expect(recipes).toBe(2);
+        expect(bootstraps).toBe(1);
+      });
+    });
+  });
+});

--- a/src/skills/loading/config-binary.test.ts
+++ b/src/skills/loading/config-binary.test.ts
@@ -1,0 +1,35 @@
+import fs from "node:fs";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { withTempDirSync } from "../../test-helpers/temp-dir.js";
+import { withEnv } from "../../test-utils/env.js";
+import type { SkillEntry } from "../types.js";
+import { shouldIncludeSkill } from "./config.js";
+
+it("includes a skill after its required binary is installed on unchanged PATH", () => {
+  withTempDirSync({ prefix: "openclaw-skill-binary-" }, (binDir) => {
+    const filePath = path.join(binDir, "SKILL.md");
+    const entry: SkillEntry = {
+      skill: {
+        name: "fixture-skill",
+        description: "Requires a binary",
+        filePath,
+        baseDir: binDir,
+        source: "openclaw-workspace",
+        sourceInfo: { path: filePath, source: "test", scope: "temporary", origin: "top-level" },
+        disableModelInvocation: false,
+      },
+      frontmatter: {},
+      metadata: { requires: { bins: ["fixture-skill-tool"] } },
+    };
+    withEnv({ PATH: binDir }, () => {
+      const included = () => shouldIncludeSkill({ entry, bundledAllowlist: undefined });
+      expect(included()).toBe(false);
+      const executable = path.join(binDir, "fixture-skill-tool");
+      fs.writeFileSync(executable, "#!/bin/sh\nexit 0\n");
+      fs.chmodSync(executable, 0o755);
+      expect(process.env.PATH).toBe(binDir);
+      expect(included()).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/21094 — successful skill installs remain marked as missing.
Follow-up to https://github.com/openclaw/openclaw/pull/21116 — the earlier positive-only cache fix was closed unmerged for inactivity and does not allow maintainer edits.

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled through the same-repository branch.

</details>

## What Problem This Solves

Fixes an issue where users setting up Gmail would get “still not available after brew install” even though installation succeeded and the executable was present. The same stale result kept newly installed skill dependencies ineligible and caused repeated Go/uv prerequisite bootstraps within one process when PATH did not change.

## Why This Change Was Made

The shared `hasBinary()` owner cached both hits and misses until PATH/PATHEXT changed. Installing a file into an existing PATH directory changes neither value, so the next check reused the stale miss. Cache only successful probes, using a `Set` instead of a boolean `Map`; retain successful-lookup reuse, PATH/PATHEXT invalidation, and existing platform search semantics.

This fixes all callers at the probe owner rather than adding invalidation calls to individual installers. Installer-only invalidation would miss external installs and prerequisite success followed by recipe failure; a TTL would merely delay visibility. Existing session skill snapshots and the separate executable-path idle-TTL resolver are intentionally unchanged. Gmail diagnostics formatting is not part of this change.

The cache was introduced in https://github.com/openclaw/openclaw/commit/76e4e9d17653d8ce296edff992ce65d2adbe4b38 and is reachable from stable `v2026.2.14`. The affected production owners remain unchanged on current `main` compared with the reproduced baseline.

## User Impact

Fresh dependency checks recognize binaries installed into directories already on PATH without requiring a process restart or a PATH edit. Gmail dependency setup no longer reports a false installation failure, and later skill installs reuse successfully installed Go/uv prerequisites even if an earlier final recipe failed.

Missing probes now intentionally perform filesystem work again; successful probes remain cached. No new configuration, dependency, refresh API, or migration is introduced. Production LOC: +4/-6 (net -2). Tests: +261/-15 (net +246). Documentation: +4.

Thanks to @heyrtl for the earlier positive-only cache proposal and @DannyDesert for the original skill-install report. AI-assisted implementation and verification; no agent transcripts attached.

## Evidence

Ten regression cases failed on pre-fix code for the intended stale-cache reason and pass with the repair. Coverage uses the real probe and temporary executable files, with only installation commands faked:

- Miss → executable creation → hit with unchanged PATH/PATHEXT, including platform-mocked Windows suffix probing; cached-hit reuse and environment invalidation remain covered.
- `ensureDependency()` succeeds when the fake installer creates the binary, does not reinstall on its next call, and still rejects exit zero without an executable.
- Consecutive Go/uv installs bootstrap only once, whether the first final recipe succeeds or fails. The final test fixtures were rerun against the original production file to verify the four bootstrap failures before restoring the repair.
- Skill and hook eligibility become true after a previously missing executable appears.

A separate real subprocess reproduction used only a temporary fake `brew`, a fake dependency executable, and isolated HOME/state/config. Before: the installer exited zero and the executable existed, but `ensureDependency()` threw `fixture-gmail-tool still not available after brew install`. After: setup succeeded with unchanged PATH, and two calls invoked the fake installer exactly once. No real package-manager operation ran.

Focused and sibling verification: 138 distinct tests passed across ten files, with two existing native-Windows skips. The final shared-worker regression run passed 68 tests:

```bash
OPENCLAW_TEST_PROJECTS_PARALLEL=1 OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/shared/config-eval.test.ts src/hooks/gmail-setup-utils.test.ts src/hooks/config.test.ts src/skills/lifecycle/install-cache-freshness.test.ts src/skills/loading/config-binary.test.ts src/skills/lifecycle/install-fallback.test.ts
```

Additional sibling suites passed:

```bash
OPENCLAW_TEST_PROJECTS_PARALLEL=1 node scripts/run-vitest.mjs src/skills/lifecycle/install-fallback.test.ts src/skills/loading/skills.test.ts src/hooks/hooks-status.test.ts src/infra/executable-path.test.ts src/infra/resolve-system-bin.test.ts
```

All 28 selected changed-code stages completed successfully, including production/test typechecks, changed-file lint, dead exports, architecture guards, formatting, and whitespace validation:

```bash
node scripts/check-changed.mjs -- src/shared/config-eval.ts src/shared/config-eval.test.ts src/hooks/gmail-setup-utils.test.ts src/hooks/config.test.ts src/skills/lifecycle/install-cache-freshness.test.ts src/skills/loading/config-binary.test.ts docs/tools/skills.md
```

The initial baseline Gmail test encountered a cold-import timeout; an unchanged retry passed. Temporary-home resolution and typed fake-process termination metadata were corrected in the new fixtures, then reverified without raising timeouts or weakening assertions. Independent Codex autoreview passed; fresh pre-commit review and exact-head CI are checked again before landing.

CI history: [the original run](https://github.com/openclaw/openclaw/actions/runs/33151452555) failed on an unchanged main-branch gateway test importing a private helper. [PR #131627](https://github.com/openclaw/openclaw/pull/131627) repaired that test in [871b18df](https://github.com/openclaw/openclaw/commit/871b18dff5039484e86c76d282699a8defcb1654). This branch was rebased onto repaired main; the entire seven-file patch, all seven file blobs, and contributor credit are unchanged. CI for the refreshed head replaces the old failed merge snapshot; the old run was not rerun.

Rebase sanity passed all 41 tests across the five changed test files and the repaired gateway rollback test (six files, four serial shards), with no retries. This remains fixture-only proof, with no real Gateway or installation. The full changed-code gate and clean independent autoreview were reused for the byte-identical patch; fresh exact-head CI remains required before landing.

Proof limits: native Windows, a running dashboard/Gateway, real installs, and authenticated Gmail/cloud flows were intentionally not exercised because the operator explicitly prohibited those operations. Safe fake-executable and isolated real-subprocess proof covers the changed owner boundary; it is not authenticated Gmail or dashboard proof. Existing session snapshots are not automatically refreshed by fresh binary probes. See https://docs.openclaw.ai/tools/skills#gating.
