### PR TITLE
refactor(macos): reuse daily usage cost totals serialization

### DIFF
--- a/apps/macos/Sources/OpenClaw/UsageCostData.swift
+++ b/apps/macos/Sources/OpenClaw/UsageCostData.swift
@@ -14,68 +14,25 @@ struct GatewayCostUsageDay: Codable {
     let date: String
     private let totals: GatewayCostUsageTotals
 
-    var input: Int {
-        self.totals.input
-    }
-
-    var output: Int {
-        self.totals.output
-    }
-
-    var cacheRead: Int {
-        self.totals.cacheRead
-    }
-
-    var cacheWrite: Int {
-        self.totals.cacheWrite
-    }
-
-    var totalTokens: Int {
-        self.totals.totalTokens
-    }
-
     var totalCost: Double {
         self.totals.totalCost
     }
 
-    var missingCostEntries: Int {
-        self.totals.missingCostEntries
-    }
-
     private enum CodingKeys: String, CodingKey {
         case date
-        case input
-        case output
-        case cacheRead
-        case cacheWrite
-        case totalTokens
-        case totalCost
-        case missingCostEntries
     }
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         self.date = try c.decode(String.self, forKey: .date)
-        self.totals = try GatewayCostUsageTotals(
-            input: c.decode(Int.self, forKey: .input),
-            output: c.decode(Int.self, forKey: .output),
-            cacheRead: c.decode(Int.self, forKey: .cacheRead),
-            cacheWrite: c.decode(Int.self, forKey: .cacheWrite),
-            totalTokens: c.decode(Int.self, forKey: .totalTokens),
-            totalCost: c.decode(Double.self, forKey: .totalCost),
-            missingCostEntries: c.decode(Int.self, forKey: .missingCostEntries))
+        // Daily rows flatten the totals contract beside date, not under a nested key.
+        self.totals = try GatewayCostUsageTotals(from: decoder)
     }
 
     func encode(to encoder: Encoder) throws {
         var c = encoder.container(keyedBy: CodingKeys.self)
         try c.encode(self.date, forKey: .date)
-        try c.encode(self.input, forKey: .input)
-        try c.encode(self.output, forKey: .output)
-        try c.encode(self.cacheRead, forKey: .cacheRead)
-        try c.encode(self.cacheWrite, forKey: .cacheWrite)
-        try c.encode(self.totalTokens, forKey: .totalTokens)
-        try c.encode(self.totalCost, forKey: .totalCost)
-        try c.encode(self.missingCostEntries, forKey: .missingCostEntries)
+        try self.totals.encode(to: encoder)
     }
 }
 
@@ -89,7 +46,6 @@ struct GatewayCostUsageSummary: Codable {
 enum CostUsageFormatting {
     static func formatUsd(_ value: Double?) -> String? {
         guard let value, value.isFinite else { return nil }
-        if value >= 1 { return String(format: "$%.2f", value) }
         if value >= 0.01 { return String(format: "$%.2f", value) }
         return String(format: "$%.4f", value)
     }

--- a/apps/macos/Tests/OpenClawIPCTests/UsageCostDataTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/UsageCostDataTests.swift
@@ -1,0 +1,150 @@
+import Foundation
+import Testing
+@testable import OpenClaw
+
+struct UsageCostDataTests {
+    private static let fields = [
+        "date", "input", "output", "cacheRead", "cacheWrite", "totalTokens", "totalCost", "missingCostEntries",
+    ]
+
+    private var row: [String: Any] {
+        [
+            "date": "2026-08-27",
+            "input": 11,
+            "output": 7,
+            "cacheRead": 3,
+            "cacheWrite": 2,
+            "totalTokens": 23,
+            "totalCost": 0.125,
+            "missingCostEntries": 1,
+        ]
+    }
+
+    @Test func `summary round trip preserves flat daily totals and ignores extra fields`() throws {
+        var row = self.row
+        row["futureCostField"] = ["value": 42]
+        let data = try JSONSerialization.data(withJSONObject: [
+            "updatedAt": 1234.5,
+            "days": 1,
+            "daily": [row],
+            "totals": row,
+            "futureSummaryField": true,
+        ])
+        let summary = try JSONDecoder().decode(GatewayCostUsageSummary.self, from: data)
+        let day = try #require(summary.daily.first)
+        #expect(day.date == "2026-08-27")
+        #expect(day.totalCost == 0.125)
+        #expect(summary.totals.missingCostEntries == 1)
+
+        let encoded = try JSONEncoder().encode(summary)
+        let object = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        let daily = try #require(object["daily"] as? [[String: Any]])
+        let encodedDay = try #require(daily.first)
+        #expect(NSDictionary(dictionary: encodedDay) == NSDictionary(dictionary: self.row))
+        #expect(object["updatedAt"] as? Double == 1234.5)
+        #expect(object["days"] as? Int == 1)
+        #expect(Set(object.keys) == ["updatedAt", "days", "daily", "totals"])
+        let totals = try #require(object["totals"] as? [String: Any])
+        #expect(Set(totals.keys) == Set(Self.fields.dropFirst()))
+    }
+
+    @Test(arguments: ["0", "-0", "-0.125"])
+    func `zero and negative costs survive the flat wire format`(_ cost: String) throws {
+        let data = Data("""
+        {"date":"","input":0,"output":0,"cacheRead":0,"cacheWrite":0,
+         "totalTokens":0,"totalCost":\(cost),"missingCostEntries":0}
+        """.utf8)
+        let day = try JSONDecoder().decode(GatewayCostUsageDay.self, from: data)
+        let expected = try #require(Double(cost))
+        #expect(day.date.isEmpty)
+        #expect(day.totalCost.bitPattern == expected.bitPattern)
+        let decoded = try JSONDecoder().decode(GatewayCostUsageDay.self, from: JSONEncoder().encode(day))
+        #expect(decoded.totalCost.bitPattern == expected.bitPattern)
+    }
+
+    enum InvalidField: CaseIterable {
+        case missing, null, wrongType
+    }
+
+    @Test(arguments: Self.fields, InvalidField.allCases)
+    func `every flat field is required with its original type`(_ field: String, _ invalid: InvalidField) throws {
+        var row = self.row
+        switch invalid {
+        case .missing: row.removeValue(forKey: field)
+        case .null: row[field] = NSNull()
+        case .wrongType: row[field] = false
+        }
+        let data = try JSONSerialization.data(withJSONObject: [
+            "updatedAt": 0, "days": 1, "daily": [row], "totals": self.row,
+        ])
+        do {
+            _ = try JSONDecoder().decode(GatewayCostUsageSummary.self, from: data)
+            Issue.record("Accepted invalid required field \(field)")
+        } catch let DecodingError.keyNotFound(key, context) {
+            #expect(invalid == .missing)
+            #expect(key.stringValue == field)
+            #expect(context.codingPath.map(\.stringValue) == ["daily", "Index 0"])
+        } catch let DecodingError.valueNotFound(_, context) {
+            #expect(invalid == .null)
+            #expect(context.codingPath.map(\.stringValue) == ["daily", "Index 0", field])
+        } catch let DecodingError.typeMismatch(_, context) {
+            #expect(invalid == .wrongType)
+            #expect(context.codingPath.map(\.stringValue) == ["daily", "Index 0", field])
+        }
+    }
+
+    @Test(arguments: Self.fields.indices)
+    func `date then totals declaration order determines the first decoding failure`(_ index: Int) throws {
+        var row = self.row
+        for field in Self.fields[index...] {
+            row.removeValue(forKey: field)
+        }
+        let data = try JSONSerialization.data(withJSONObject: row)
+        do {
+            _ = try JSONDecoder().decode(GatewayCostUsageDay.self, from: data)
+            Issue.record("Accepted missing required fields")
+        } catch let DecodingError.keyNotFound(key, context) {
+            #expect(key.stringValue == Self.fields[index])
+            #expect(context.codingPath.isEmpty)
+        }
+    }
+
+    @Test(arguments: ["NaN", "Infinity", "-Infinity"])
+    func `nonfinite daily costs fail encoding at the flat totalCost path`(_ cost: String) throws {
+        var row = self.row
+        row["totalCost"] = cost
+        let decoder = JSONDecoder()
+        decoder.nonConformingFloatDecodingStrategy = .convertFromString(
+            positiveInfinity: "Infinity", negativeInfinity: "-Infinity", nan: "NaN")
+        let data = try JSONSerialization.data(withJSONObject: [
+            "updatedAt": 0, "days": 2, "daily": [self.row, row], "totals": self.row,
+        ])
+        let summary = try decoder.decode(GatewayCostUsageSummary.self, from: data)
+        do {
+            _ = try JSONEncoder().encode(summary)
+            Issue.record("Encoded a nonfinite daily cost")
+        } catch let EncodingError.invalidValue(_, context) {
+            #expect(context.codingPath.map(\.stringValue) == ["daily", "Index 1", "totalCost"])
+        }
+    }
+
+    @Test(arguments: [
+        (nil, nil),
+        (Double.nan, nil),
+        (Double.infinity, nil),
+        (-Double.infinity, nil),
+        (-1.25, "$-1.2500"),
+        (-0.0, "$-0.0000"),
+        (0.0, "$0.0000"),
+        (0.0001, "$0.0001"),
+        (0.01.nextDown, "$0.0100"),
+        (0.01, "$0.01"),
+        (0.01.nextUp, "$0.01"),
+        (1.0.nextDown, "$1.00"),
+        (1.0, "$1.00"),
+        (1.0.nextUp, "$1.00"),
+    ] as [(Double?, String?)])
+    func `USD precision follows the one-cent boundary`(_ value: Double?, _ expected: String?) {
+        #expect(CostUsageFormatting.formatUsd(value) == expected)
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

The macOS usage-cost model repeats the totals wire contract in daily rows, with unused accessors and a duplicate currency-formatting branch. This is a maintainer-requested, behavior-preserving cleanup; no user-facing defect or new capability is claimed.

## Why This Change Was Made

Daily rows keep their date and delegate the same flat JSON fields to the existing totals model. The usage menu still reads the retained date and total-cost accessors. This removes the second field-by-field encoder/decoder and unused daily accessors without changing the Gateway payload, validation errors, precision thresholds, or app UI.

Production: **+3/-47, net -44 lines**. Tests: **+150 lines**, counted separately. No dependency, configuration, persistence, protocol, or public API change.

## User Impact

None intended. Usage totals and daily cost history retain their existing behavior. The internal models remain private to the macOS executable.

## Evidence

Fresh local macOS proof on base `a33c8a5c0ec6de63882ca60f92284aef31d0faa1`, with Node 24.19.0, pinned pnpm 11.22.0, Xcode 26.6 / Swift 6.3.3, and owned installed dependencies:

- The same six native tests / 53 cases passed before and after the production change: flat summary/day round trips; all required fields and types; first-error order and coding paths; negative zero; non-finite encoding errors; currency precision boundaries.
- `xcrun swift test --package-path apps/macos --scratch-path <owned-build> --manifest-cache none --disable-automatic-resolution --filter UsageCostDataTests` passed on both versions.
- The full optimized `OpenClaw` product build passed using `swift build` with the same isolated scratch path and pinned resolution.
- Pinned SwiftLint and SwiftFormat passed. Fresh-index Periphery 3.8.0 strict scan returned no findings.
- `node scripts/check-changed.mjs --timed -- apps/macos/Sources/OpenClaw/UsageCostData.swift apps/macos/Tests/OpenClawIPCTests/UsageCostDataTests.swift` passed all 13 stages, including seven macOS-related test shards (508 tests).
- Complete tracked-source checks before and after each phase verified the intended two-file scope and unchanged dependency inputs. Accepted isolated Codex precommit review found no actionable issues; the exact reviewed source, test, and ten owner/caller/server context files were preserved.
- [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33151505857) passed for `c3d0e4d58c90d4ed3c5fde9448a02b33c3626475`. A separate isolated Codex review of that published head completed with no findings, with source and index unchanged.

Earlier Linux attempts timed out before tests and are not counted as passing evidence. The successful native proof above was rerun on the newer assembled app. The first published-review dry run stopped before contacting the reviewer because retained log carriage returns were normalized; preserving the original bytes fixed the preparation error, followed by a successful dry run and one successful review.

This bounded internal refactor was not tested by launching the signed app or contacting a live Gateway; no live UI proof is claimed. The actual app-module behavior tests and native product build cover the changed serialization and formatting owner. No view or interaction code changes.

AI-assisted with Codex. Native artifact validation, hosted-gate preparation, and normal merge completed successfully on the unchanged head, without rebase, push, or bypass. Merged as [ae8ae2e8](https://github.com/openclaw/openclaw/commit/ae8ae2e8460bfe3c5fa64a4f45667cdcd9a655e9). The entire landed tree matches the tested patch composed with its actual parent; both changed files and modes match the reviewed source exactly.

The completed ClawSweeper review's unavailable-Xcode attempt and pending-CI snapshot are addressed in the [native terminal proof and Rank-up response](https://github.com/openclaw/openclaw/pull/131618#issuecomment-5449946931). Its failed environment attempt remains recorded; the successful macOS tests are separate evidence.
