### PR TITLE
fix: prevent Barnacle from closing core skill runtime PRs

### DIFF
--- a/scripts/github/barnacle-auto-response.mjs
+++ b/scripts/github/barnacle-auto-response.mjs
@@ -436,6 +436,31 @@ function isInfraLikeFile(filename) {
   );
 }
 
+function isStandaloneSkillSubmission(files) {
+  // Auto-close only whole submissions; rename sources stop core files from
+  // acquiring the destructive skill label by moving under a new skill root.
+  const addedSkillRoots = files
+    .filter(
+      (file) => file.status === "added" && /^skills\/(?:[^/]+\/)+SKILL\.md$/i.test(file.filename),
+    )
+    .map((file) => file.filename.slice(0, -"SKILL.md".length).toLowerCase());
+  const isInAddedSkillRoot = (filename) => {
+    const normalizedFilename = filename.toLowerCase();
+    return addedSkillRoots.some((root) => normalizedFilename.startsWith(root));
+  };
+
+  return (
+    addedSkillRoots.length > 0 &&
+    files.every(
+      (file) =>
+        isInAddedSkillRoot(file.filename) &&
+        (file.status !== "renamed" ||
+          (typeof file.previous_filename === "string" &&
+            isInAddedSkillRoot(file.previous_filename))),
+    )
+  );
+}
+
 function surfacesForFile(filename) {
   const surfaces = new Set();
   if (/\.generated\/|generated|\.snap$/i.test(filename)) {
@@ -551,10 +576,7 @@ export function classifyPullRequestCandidateLabels(pullRequest, files) {
     labelsToAdd.push(candidateLabels.externalPluginCandidate);
   }
 
-  const addsBundledSkill = files.some(
-    (file) => file.status === "added" && /^skills\/(?:[^/]+\/)+SKILL\.md$/i.test(file.filename),
-  );
-  if (addsBundledSkill) {
+  if (isStandaloneSkillSubmission(files)) {
     labelsToAdd.push(skillCloseLabel);
   }
 

--- a/test/scripts/barnacle-auto-response.test.ts
+++ b/test/scripts/barnacle-auto-response.test.ts
@@ -43,10 +43,11 @@ function prContextBody(evidence: string, overrides: Record<string, string> = {})
   ].join("\n");
 }
 
-function file(filename: string, status = "modified") {
+function file(filename: string, status = "modified", previousFilename?: string) {
   return {
     filename,
     status,
+    ...(previousFilename ? { previous_filename: previousFilename } : {}),
   };
 }
 
@@ -282,39 +283,56 @@ describe("barnacle-auto-response", () => {
     ]);
   });
 
-  it("classifies only an added bundled skill for the ClawHub close", () => {
-    for (const filename of [
-      "src/skills/loading/plugin-skills.test.ts",
-      "src/skills/workspace.ts",
-      "skills/weather/SKILL.md",
+  it("classifies only changes confined to newly added ordinary skill roots for the ClawHub close", () => {
+    for (const files of [
+      [file("src/skills/loading/plugin-skills.test.ts")],
+      [file("src/skills/workspace.ts")],
+      [file("skills/weather/SKILL.md")],
+      [file("custodian-skills/weather/SKILL.md", "added")],
+      [file("skills/weather/SKILL.md", "added"), file("src/skills/workspace.ts")],
+      [
+        file("skills/weather/SKILL.md", "added"),
+        file("skills/weather/runtime.ts", "renamed", "src/skills/runtime.ts"),
+      ],
     ]) {
       expect(
-        classifyPullRequestCandidateLabels(pr("Fix linked skill behavior", "Fixes #127931"), [
-          file(filename),
-        ]),
+        classifyPullRequestCandidateLabels(pr("Fix linked skill behavior", "Fixes #127931"), files),
       ).not.toContain("r: skill");
     }
 
-    for (const filename of [
-      "skills/weather-helper/SKILL.md",
-      "skills/group/weather-helper/SKILL.md",
+    for (const files of [
+      [
+        file("skills/weather-helper/SKILL.md", "added"),
+        file("skills/weather-helper/references/usage.md", "added"),
+      ],
+      [
+        file("skills/Group/Weather-Helper/skill.md", "added"),
+        file("skills/Group/Weather-Helper/scripts/check.mjs", "added"),
+      ],
+      [
+        file("skills/weather-helper/SKILL.md", "added"),
+        file("skills/weather-helper/README.md", "added"),
+        file("skills/group/calendar-helper/SKILL.md", "added"),
+        file("skills/group/calendar-helper/assets/icon.svg", "added"),
+      ],
     ]) {
-      expect(
-        classifyPullRequestCandidateLabels(pr("Add weather helper skill"), [
-          file(filename, "added"),
-        ]),
-      ).toContain("r: skill");
+      expect(classifyPullRequestCandidateLabels(pr("Add weather helper skill"), files)).toContain(
+        "r: skill",
+      );
     }
   });
 
-  it("removes a stale automated skill close label from a core test-only PR", async () => {
-    const { calls, github } = barnacleGithub([file("src/skills/loading/plugin-skills.test.ts")]);
+  it("removes a stale automated skill close label from a mixed skill and core PR", async () => {
+    const { calls, github } = barnacleGithub([
+      file("skills/weather-helper/SKILL.md", "added"),
+      file("src/skills/loading/plugin-skills.test.ts"),
+    ]);
 
     await runBarnacleAutoResponse({
       github,
       context: barnacleContext(
         {
-          title: "Fix Windows symlink typing",
+          title: "Add a skill and fix Windows symlink typing",
           body: "Fixes #127931",
         },
         ["r: skill"],
@@ -334,8 +352,11 @@ describe("barnacle-auto-response", () => {
     expect(calls.update).toStrictEqual([]);
   });
 
-  it("closes a newly added bundled skill deterministically", async () => {
-    const { calls, github } = barnacleGithub([file("skills/weather-helper/SKILL.md", "added")]);
+  it("closes a newly added ordinary skill and its assets deterministically", async () => {
+    const { calls, github } = barnacleGithub([
+      file("skills/weather-helper/SKILL.md", "added"),
+      file("skills/weather-helper/references/usage.md", "added"),
+    ]);
 
     await runBarnacleAutoResponse({
       github,


### PR DESCRIPTION
## What Problem This Solves

Barnacle's current classifier closes any PR that adds a `skills/**/SKILL.md`, even when that PR also changes core code or moves a core file into the new skill root. The destructive `r: skill` decision should apply only to a complete ordinary-skill submission.

## Root Cause and Fix

The classifier used `files.some(...)`, so one new manifest was enough to label the entire PR for automatic closure.

This change keeps one classifier owner in Barnacle and requires every changed path to be contained by one or more newly added ordinary `skills/**/SKILL.md` roots. It preserves grouped layouts, validates both paths for renames, and excludes the release-owned `custodian-skills/**` library. Existing manual maintainer overrides and duplicate-event suppression remain unchanged.

Maintainer policy decision: use this narrower whole-submission boundary rather than #132225's any-manifest boundary.

## Evidence

- Pre-fix on current main: focused suite failed 2 tests (mixed PR and rename escape), with 45 passing.
- Fixed head: `node scripts/run-vitest.mjs test/scripts/barnacle-auto-response.test.ts` — 47/47 passed.
- Real GitHub REST fixture, exact production script from `6f2ba484538838ae8ea792c2d5d290a40d7c90c6` (SHA-256 `6de49b8cb1adc61eb1e0ecdf6e2b7a4d21cf8fac9f16de85343f668430843150`):
  - [Mixed skill/core PR](https://github.com/Patrick-Erichsen/openclaw-barnacle-fixture-131619-maintainer/pull/3#issuecomment-5487863707) stayed open and lost `r: skill` ([passing run](https://github.com/Patrick-Erichsen/openclaw-barnacle-fixture-131619-maintainer/actions/runs/33462441000)).
  - [Confined ordinary-skill PR](https://github.com/Patrick-Erichsen/openclaw-barnacle-fixture-131619-maintainer/pull/4#issuecomment-5487863696) retained `r: skill`, received the ClawHub response, and closed ([passing run](https://github.com/Patrick-Erichsen/openclaw-barnacle-fixture-131619-maintainer/actions/runs/33462444741)).

Both fixture PRs were authored by `github-actions[bot]`; the runs asserted final PR state, label state, comments, and label-removal timeline through real GitHub API mutations. The fixture uses only its repository-scoped `GITHUB_TOKEN` and does not exercise OpenClaw's unchanged GitHub App token wiring.

## Scope

- Production/tooling: +26/-4 (net +22), required to own the destructive whole-diff and rename-source boundary.
- Tests: +43/-22 (net +21).
- No runtime, config, dependency, or persistence changes.

ClawSweeper rank-up moves addressed: the maintainer policy decision is recorded here, the branch is consolidated onto current main's classifier, and the real GitHub fixture was rerun against this exact head.
