### PR TITLE
fix(ui): keep running tools from failing on partial output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI tool progress:** keep error-shaped partial output running until the tool returns its result, with consistent status in collapsed rows, expanded cards, and side-panel details.
+
 - MCP Apps: let standalone operations finish across catalog refreshes within per-request server budgets, propagate App cancellation without cancelling shared catalog work, and reload restored history views without replaying interrupted operations. Thanks @tzy-17. (#119388)
 
 - **Control UI command palette:** keep keyboard selection and Enter usable when reconnects or catalog refreshes replace search results, preserving the selected command while it remains available.

--- a/ui/src/e2e/chat-transcript-disclosure-anchor.e2e.test.ts
+++ b/ui/src/e2e/chat-transcript-disclosure-anchor.e2e.test.ts
@@ -133,7 +133,7 @@ suite.define(() => {
         },
         async ({ page }) => {
           const gateway = await installMockGateway(page, {
-            deferredMethods: ["chat.message.get"],
+            heldMethods: ["chat.message.get"],
             historyMessages: Array.from({ length: 60 }, (_, index) => ({
               role: index % 2 === 0 ? "user" : "assistant",
               content:
@@ -144,7 +144,9 @@ suite.define(() => {
               __openclaw: {
                 id: `sizing-message-${index}`,
                 seq: index + 1,
-                ...(index === 1 ? { truncated: true, reason: "display-cap" } : {}),
+                ...(index === 1 || (interruption === "pointer" && index % 2 === 1)
+                  ? { truncated: true, reason: "display-cap" }
+                  : {}),
               },
             })),
           });
@@ -157,28 +159,29 @@ suite.define(() => {
           await expect.poll(() => thread.evaluate((element) => element.scrollTop)).toBe(0);
           await gateway.waitForRequest("chat.message.get");
           await waitForChatScrollIdle(page);
-          const bubble = page.locator('.chat-bubble[data-entry-id="sizing-message-1"]');
-          await bubble.waitFor({ state: "visible" });
-          const initial = await bubble.evaluate((element) => {
-            const row = element.closest<HTMLElement>(".chat-virtual-row")!;
-            return { key: row.dataset.virtualRowKey, height: row.offsetHeight };
-          });
+          await page
+            .locator('.chat-bubble[data-entry-id="sizing-message-1"]')
+            .waitFor({ state: "visible" });
           await page.screenshot({ path: path.join(artifactDir, "01-before-scroll.png") });
           await page.locator(".chat-scroll-to-bottom").click();
           await page.waitForFunction((pointerInterruption) => {
             const scroller = document.querySelector<HTMLElement>(
               ".chat-pane-cache__pane--active .chat-thread",
             );
-            const recoveredRow = scroller
-              ?.querySelector<HTMLElement>('.chat-bubble[data-entry-id="sizing-message-1"]')
-              ?.closest<HTMLElement>(".chat-virtual-row");
             return (
               scroller &&
               scroller.scrollTop > 0 &&
               (!pointerInterruption ||
-                (recoveredRow &&
-                  recoveredRow.getBoundingClientRect().bottom <=
-                    scroller.getBoundingClientRect().top))
+                Array.from(
+                  scroller.querySelectorAll<HTMLElement>(
+                    '.chat-bubble[data-entry-id^="sizing-message-"]',
+                  ),
+                ).some(
+                  (bubble) =>
+                    Number(bubble.dataset.entryId!.slice("sizing-message-".length)) % 2 === 1 &&
+                    bubble.closest(".chat-virtual-row")!.getBoundingClientRect().bottom <=
+                      scroller.getBoundingClientRect().top,
+                ))
             );
           }, interruption === "pointer");
           const during = await thread.evaluate((element) => ({
@@ -210,27 +213,64 @@ suite.define(() => {
             expect(interruptedOffset).toBeLessThan(during.max);
           }
           const interruptedAnchor = await captureTopVisibleVirtualRow(thread);
+          // Native smooth scrolling can pass the first message before the pointer
+          // arrives. Recover a still-mounted pending row above the settled reader.
+          const messageId =
+            interruption === "pointer"
+              ? await thread.evaluate((element) => {
+                  const top = element.getBoundingClientRect().top;
+                  const bubbles = Array.from(
+                    element.querySelectorAll<HTMLElement>(
+                      '.chat-bubble[data-entry-id^="sizing-message-"]',
+                    ),
+                  );
+                  const bubble = bubbles.findLast(
+                    (candidate) =>
+                      Number(candidate.dataset.entryId!.slice("sizing-message-".length)) % 2 ===
+                        1 &&
+                      candidate.closest(".chat-virtual-row")!.getBoundingClientRect().bottom <= top,
+                  );
+                  return bubble?.dataset.entryId ?? null;
+                })
+              : "sizing-message-1";
+          expect(messageId).not.toBeNull();
+          const recoveredIndex = Number(messageId!.slice("sizing-message-".length));
+          const nextMessageId = `sizing-message-${recoveredIndex + 1}`;
+          const bubble = page.locator(`.chat-bubble[data-entry-id="${messageId}"]`);
+          const requestMatcher = expect.objectContaining({
+            params: expect.objectContaining({ messageId }),
+          });
+          const pendingRequest = (await gateway.getRequests("chat.message.get")).findLast(
+            (request) => requestMatcher.asymmetricMatch(request),
+          );
+          expect(pendingRequest).toBeDefined();
+          const initial = await bubble.evaluate((element) => {
+            const row = element.closest<HTMLElement>(".chat-virtual-row")!;
+            return { key: row.dataset.virtualRowKey, height: row.offsetHeight };
+          });
           const fullText = Array.from(
             { length: 5 },
             (_, index) =>
               `Recovered paragraph ${index + 1}. ${"All wrapped lines must reserve space before the next user message. ".repeat(5)}`,
           ).join("\n\n");
-          await gateway.resolveDeferred("chat.message.get", {
+          await gateway.deliverLatest({
+            type: "res",
+            id: pendingRequest!.id,
             ok: true,
-            message: { role: "assistant", content: fullText },
+            payload: { ok: true, message: { role: "assistant", content: fullText } },
           });
           await bubble.getByText("Recovered paragraph 1.", { exact: false }).waitFor();
           await waitForChatScrollIdle(page);
           // Outlast virtual-core's five-second scroll reconciliation deadline:
           // the assertion protects durable geometry, not a transient resize frame.
-          const final = await bubble.evaluate(async (element) => {
+          const final = await bubble.evaluate(async (element, nextId) => {
             await new Promise<void>((resolve) => {
               setTimeout(resolve, 5_500);
             });
             const row = element.closest<HTMLElement>(".chat-virtual-row")!;
-            const next = row
-              .closest(".chat-thread")!
-              .querySelector('.chat-bubble[data-entry-id="sizing-message-2"]')!
+            const scroller = row.closest<HTMLElement>(".chat-thread")!;
+            const next = scroller
+              .querySelector(`.chat-bubble[data-entry-id="${nextId}"]`)!
               .closest<HTMLElement>(".chat-virtual-row")!;
             const rect = row.getBoundingClientRect();
             return {
@@ -240,8 +280,9 @@ suite.define(() => {
               bottom: rect.bottom,
               nextTop: next.getBoundingClientRect().top,
               gap: next.getBoundingClientRect().top - rect.bottom,
+              returnOffset: scroller.scrollTop + rect.top - scroller.getBoundingClientRect().top,
             };
-          });
+          }, nextMessageId);
           const finalAnchor = await captureTopVisibleVirtualRow(thread);
           await page.screenshot({ path: path.join(artifactDir, "02-after-interruption.png") });
           await fs.writeFile(
@@ -268,41 +309,51 @@ suite.define(() => {
           ).toBeLessThanOrEqual(1);
           // Leaving and returning must use the recovered size in the virtual
           // range too, not merely conceal stale cached geometry with DOM flow.
-          await page.locator(".chat-scroll-to-bottom").click();
-          await expect
-            .poll(() =>
-              thread.evaluate((element) =>
-                Math.abs(element.scrollHeight - element.clientHeight - element.scrollTop),
-              ),
-            )
-            .toBeLessThanOrEqual(2);
+          if (recoveredIndex < 30) {
+            await page.locator(".chat-scroll-to-bottom").click();
+            await expect
+              .poll(() =>
+                thread.evaluate((element) =>
+                  Math.abs(element.scrollHeight - element.clientHeight - element.scrollTop),
+                ),
+              )
+              .toBeLessThanOrEqual(2);
+            await page
+              .locator('.chat-bubble[data-entry-id="sizing-message-59"]')
+              .waitFor({ state: "visible" });
+          } else {
+            await thread.hover();
+            await page.mouse.wheel(0, -100_000);
+            await expect.poll(() => thread.evaluate((element) => element.scrollTop)).toBe(0);
+          }
           await expect.poll(() => bubble.count()).toBe(0);
-          await page
-            .getByText("Transcript message 59.", { exact: false })
-            .waitFor({ state: "visible" });
-          await thread.hover();
-          await page.mouse.wheel(0, -100_000);
+          await thread.evaluate((element, offset) => {
+            element.scrollTop = offset;
+          }, final.returnOffset);
           await bubble
             .getByText("Recovered paragraph 1.", { exact: false })
             .waitFor({ state: "visible" });
           await waitForChatScrollIdle(page);
-          const returned = await bubble.evaluate((element) => {
+          const returned = await bubble.evaluate((element, nextId) => {
             const row = element.closest<HTMLElement>(".chat-virtual-row")!;
             const next = row
               .closest(".chat-thread")!
-              .querySelector('.chat-bubble[data-entry-id="sizing-message-2"]')!
+              .querySelector(`.chat-bubble[data-entry-id="${nextId}"]`)!
               .closest<HTMLElement>(".chat-virtual-row")!;
             return {
               height: row.offsetHeight,
               gap: next.getBoundingClientRect().top - row.getBoundingClientRect().bottom,
             };
-          });
+          }, nextMessageId);
           expect(returned.height).toBe(final.height);
           expect(Math.abs(returned.gap)).toBeLessThanOrEqual(1);
           await page.screenshot({ path: path.join(artifactDir, "03-after-return.png") });
-          await thread.evaluate((element) => {
-            element.scrollTop = 300;
-          });
+          await thread.evaluate(
+            (element, offset) => {
+              element.scrollTop = offset;
+            },
+            final.returnOffset + Math.min(300, final.height / 2),
+          );
           await waitForChatScrollIdle(page);
           await page.screenshot({ path: path.join(artifactDir, "04-visible-adjacency.png") });
         },

--- a/ui/src/lib/chat/tool-cards.ts
+++ b/ui/src/lib/chat/tool-cards.ts
@@ -164,10 +164,9 @@ function isToolErrorOutput(outputText: string | undefined): boolean {
 }
 
 export function isToolCardError(card: ToolCard): boolean {
-  if (card.isError !== undefined) {
-    return card.isError;
-  }
-  return isToolErrorOutput(card.outputText);
+  // Progress can contain error-shaped text; only a result may imply failure.
+  const canInferFailure = card.live !== true || card.completed === true;
+  return card.isError ?? (canInferFailure && isToolErrorOutput(card.outputText));
 }
 
 export function resolveToolCardOutcome(

--- a/ui/src/pages/chat/components/chat-tool-cards.node.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.node.test.ts
@@ -1,7 +1,11 @@
 // @vitest-environment node
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { extractToolCardsCached as extractToolCards } from "../../../lib/chat/tool-cards.ts";
+import {
+  extractToolCardsCached as extractToolCards,
+  isToolCardError,
+  resolveToolCardOutcome,
+} from "../../../lib/chat/tool-cards.ts";
 import * as toolDisplay from "../../../lib/chat/tool-display.ts";
 
 function resolveToolDisplay({ name = "" }: Parameters<typeof toolDisplay.resolveToolDisplay>[0]) {
@@ -610,8 +614,7 @@ describe("isRunningToolCard", () => {
     expect(isRunningToolCard(liveCard, false)).toBe(false);
   });
 
-  it("derives a closed outcome from result presence and error state", async () => {
-    const { resolveToolCardOutcome } = await import("../../../lib/chat/tool-cards.ts");
+  it("derives a closed outcome from result presence and error state", () => {
     const call = { id: "t:call", name: "edit" } as const;
 
     expect(resolveToolCardOutcome(call, false)).toBe("unknown");
@@ -645,34 +648,41 @@ describe("isRunningToolCard", () => {
     expect(finished[0]).toMatchObject({ live: true, completed: true });
   });
 
-  it("keeps a live card running when partial update output emits a result block", () => {
-    // The stream emits toolresult blocks for partial `update` output; only
-    // resultReceived may complete a live card, or a running tool flips to
-    // "succeeded" (or "failed", if the partial text looks like an error).
-    const partial = extractToolCards({
-      role: "assistant",
-      toolCallId: "call-live",
-      __openclawToolStreamLive: true,
-      __openclawToolStreamResultReceived: false,
-      content: [
-        { type: "toolcall", name: "bash", arguments: { command: "sleep 5" } },
-        { type: "toolresult", name: "bash", text: '{"error": "partial text"}' },
-      ],
-    });
-    expect(partial).toHaveLength(1);
-    expect(partial[0]).toMatchObject({ live: true, completed: false });
-    expect(partial[0]?.outputText).toContain("partial text");
+  it.each(['{"error": "partial text"}', '{"status":"failed"}', "Tool not found", "partial text"])(
+    "keeps partial output %s nonterminal until the live result arrives",
+    (text) => {
+      // The stream emits toolresult blocks for partial `update` output; only
+      // resultReceived may complete a live card, or a running tool flips to
+      // "succeeded" (or "failed", if the partial text looks like an error).
+      const partial = extractToolCards({
+        role: "assistant",
+        toolCallId: "call-live",
+        __openclawToolStreamLive: true,
+        __openclawToolStreamResultReceived: false,
+        content: [
+          { type: "toolcall", name: "bash", arguments: { command: "sleep 5" } },
+          { type: "toolresult", name: "bash", text },
+        ],
+      });
+      expect(partial).toHaveLength(1);
+      expect(partial[0]).toMatchObject({ live: true, completed: false });
+      expect(partial[0]?.outputText).toBe(text);
+      expect(partial.map(isToolCardError)).toEqual([false]);
+      expect(partial.map((card) => resolveToolCardOutcome(card, true))).toEqual(["running"]);
+      expect(partial.map((card) => resolveToolCardOutcome(card, false))).toEqual(["unknown"]);
 
-    const done = extractToolCards({
-      role: "assistant",
-      toolCallId: "call-live",
-      __openclawToolStreamLive: true,
-      __openclawToolStreamResultReceived: true,
-      content: [
-        { type: "toolcall", name: "bash", arguments: { command: "sleep 5" } },
-        { type: "toolresult", name: "bash", text: "ok" },
-      ],
-    });
-    expect(done[0]).toMatchObject({ live: true, completed: true });
-  });
+      const done = extractToolCards({
+        role: "assistant",
+        toolCallId: "call-live",
+        __openclawToolStreamLive: true,
+        __openclawToolStreamResultReceived: true,
+        content: [
+          { type: "toolcall", name: "bash", arguments: { command: "sleep 5" } },
+          { type: "toolresult", name: "bash", text: "ok" },
+        ],
+      });
+      expect(done[0]).toMatchObject({ live: true, completed: true });
+      expect(done.map((card) => resolveToolCardOutcome(card, true))).toEqual(["succeeded"]);
+    },
+  );
 });

--- a/ui/src/pages/chat/components/chat-tool-cards.outcome.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.outcome.test.ts
@@ -2,11 +2,59 @@
 
 import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
+import type { ToolCard } from "../../../lib/chat/chat-types.ts";
 import { renderToolCard } from "./chat-tool-cards.ts";
 
 // Outcome presentation for tool cards: neutral collapsed rows, the expanded
 // outcome line, and the compact progress_card receipt.
 describe("tool-card outcomes", () => {
+  it.each(["exec", "lookup"])(
+    "keeps %s progress neutral across the row, expanded body, and sidebar until completion",
+    (name) => {
+      const container = document.createElement("div");
+      const onOpenSidebar = vi.fn();
+      const card: ToolCard = {
+        id: "progress",
+        name,
+        args: { command: "diagnostic" },
+        outputText: '{"error":"progress sample"}',
+        live: true,
+        completed: false,
+      };
+      const show = () =>
+        render(
+          renderToolCard(card, {
+            expanded: true,
+            onToggleExpanded: vi.fn(),
+            runActive: true,
+            onOpenSidebar,
+          }),
+          container,
+        );
+      show();
+      expect(container.querySelector(".chat-tool-row--running")).not.toBeNull();
+      expect(container.querySelector(".chat-tool-card--error")).toBeNull();
+      expect(container.querySelector(".chat-tool-card__outcome")?.textContent).toBe("Running");
+      expect(container.textContent).toContain(card.outputText);
+      container.querySelector<HTMLButtonElement>(".chat-tool-card__action-btn")?.click();
+      expect(onOpenSidebar).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining("### Tool output") }),
+      );
+      expect(onOpenSidebar.mock.calls[0]?.[0].content).not.toContain("### Tool error");
+
+      card.completed = true;
+      card.isError = false;
+      show();
+      expect(container.querySelector(".chat-tool-row--running")).toBeNull();
+      expect(container.querySelector(".chat-tool-card--error")).toBeNull();
+      expect(container.querySelector(".chat-tool-card__outcome")?.textContent).toBe("Completed");
+      card.isError = true;
+      show();
+      expect(container.querySelector(".chat-tool-card--error")).not.toBeNull();
+      expect(container.querySelector(".chat-tool-card__outcome")?.textContent).toBe("failed");
+    },
+  );
+
   it("renders error details with the failure outcome in the expanded body", () => {
     const container = document.createElement("div");
     render(


### PR DESCRIPTION
Related: #123510 (the earlier partial-output completion repair).

## What Problem This Solves

Fixes an issue where users watching a running tool in Control UI would see it marked **failed** as soon as partial output resembled an error, even though the command was still executing successfully. The false outcome also removed the running indicator and labeled side-panel progress as a tool error.

## Why This Change Was Made

The tool stream already records whether the final result arrived. The shared error classifier ignored that fact and inferred failure from unfinished output. It now limits inference to completed live results or historical output, while preserving explicit success/failure flags. This repairs collapsed rows, expanded cards, message-level failure presentation, and side-panel labels through their existing owner; no duplicate rendering policy, new state, fallback, configuration, or protocol change.

The earlier #123510 correctly preserved the completion marker but its regression only asserted that marker, leaving the displayed failure path untested. This PR extends that regression to actual outcomes and adds rendered command/generic-tool transitions and side-panel checks.

## User Impact

Partial output stays visible and a running tool stays **Running** until its result arrives. Explicit terminal errors still fail; explicit success still wins over error-shaped text; historical error inference remains unchanged. This is a bounded transient UI correction.

## Evidence

- Baseline: `dc4de544bbf8f061d9348fa247b03ad79f47fccf`; affected owners also identical on independently audited `0da947dbf0f410077f53fa01f0c8829e9733e1ca`.
- Before: actual exec-output → tool-event owner → card classifier probe reproduced all nine incorrect error/outcome assertions. Five regression cases failed on the pre-fix classifier, with 36 controls passing.
- After: 65 focused extraction/rendering/stream tests passed; broader 102-test suite passed under six shuffled seeds (612 executions), then the final test-import cleanup passed a seventh seed (102 tests). Full final changed gate passed, including formatting, lint, core/UI test types, UI types, dead exports, i18n, styles, and owner guards. Release-metadata, config-schema, config-doc baseline, and dependency-ownership checks passed unchanged.
- Real Chrome, normal built Gateway, isolated synthetic agent/workspace and own loopback port, `openai/gpt-5.6-luna`, explicitly selected OpenClaw runtime. Ordinary chat requested a harmless foreground command that prints `{"error":"progress sample"}`, waits, and exits zero. Before, expanded tool showed **failed** while the run remained active. After, the same flow showed **Running**, then successful completion. No injected tool frames, mock Gateway, or transcript fixture was used.
- Six real tool runs completed; a separate `chat.history` RPC returned all six final replies and six non-error tool results. UI bundle changed from `index-Bn6Vx1kU.js` to `index-CmDolN87.js`. The test Gateway exited cleanly in 491ms; its tab and isolated state were cleaned up.
- Independent owner review found no actionable issue. Fresh final structured Codex review exited zero with no findings at its configured P0 threshold. Exact-head hosted CI is reported before landing.
- Production LOC: +3/-4 (net -1). Tests: +91/-33 (net +58), strengthening existing extraction coverage plus rendered sibling transitions; release note adds one entry under the operator's standing changelog instruction.

Before — a still-running tool falsely reports failure:

![Before: partial error-shaped output marked failed](https://github.com/user-attachments/assets/f9fe2a2d-f06b-4b3c-a765-99d05618bcdd)

After — the same progress remains Running:

![After: partial error-shaped output remains Running](https://github.com/user-attachments/assets/1654001d-1188-47eb-95ce-601958490a46)

Provenance: the classifier was carried forward by `65e12328aa20` (July 4, code author @shakkernerd); the outcome resolver in #103821 (July 10, author/merger @steipete) evaluates it before running state. The connected partial-result repair #123510 (August 14, author/merger @steipete) fixed completion extraction but did not eliminate error inference. No claim that the July refactor originally introduced the predicate.

Known proof details: two intermediate test runs failed only because the new assertion used lowercase `running`/`completed` instead of the existing localized `Running`/`Completed`; corrected without changing production strings. Initial broader check caught a duplicate test import; removed. A first after screenshot clipped the status and was rejected; the attached recapture visibly includes Running. Browser selector waits that missed the short transient were not counted as passes.

Named follow-up: initial navigation to `/` on this synthetic Gateway with only a non-`main` default agent displayed `Unknown agent id "main"`; navigating to the real agent's Home route and reloading worked. The precise producer/ordering is not yet established. This separate observation is outside the tool-outcome invariant and remains recorded in the QA ledger.

AI-assisted QA and repair with Codex; the owning flow and evidence were independently checked.

### Review and CI follow-through

The August 28 07:53 UTC ClawSweeper review judged the runtime repair correct. Its proof attempt stopped on a mock welcome-text expectation before exercising this scenario, and its prepared pictures were identified as older redesign assets. I downloaded the two attachment URLs in this body, inspected those downloaded images directly, and verified they are byte-identical to the real Gateway captures: before SHA-256 `6466c9b58b4114af56847260c2a37feee886f6b7345bcfb7a5e22eb73ca3b668`; after `92ee94c285b9ee731ad55699f4f5355ecc1a78a4490cf22b5ad8cb7221bf90c3`. They show the expanded card changing from **failed** to **Running**, with the same error-shaped progress; the after image also shows the active-run footer. The six independent transcript results described above establish successful completion. This addresses the requested real-setup Rank-up move; the failed mock welcome-text step is not claimed as passing.

Changelog removal is intentionally not applied: the operator's standing instruction explicitly requires release notes for user-visible fixes. The entry remains under the native wrapper's documented changelog exception; no CI, approval, or proof gate is waived.

Initial hosted CI [33152560838](https://github.com/openclaw/openclaw/actions/runs/33152560838) failed on the main-composition private-helper import (core test types and Gateway tests) and one transcript pointer-recovery browser timeout. The existing test-only repair #131627 has now landed and is included in the refreshed local base. The browser timeout reproduced on an unchanged local second run (1 failed, 6 controls passed), after all 7 passed on the first run; its diagnosis and repair are below. Exact-head hosted CI remains required before landing; no failed check is being bypassed.

### Connected CI fixture repair

The transcript disclosure-anchor timeout is now traced to a test-owned row-identity assumption: after real smooth scrolling and pointer takeover, the captured viewport was at row 26 with only rows 20–38 mounted, yet the test released and waited for message 1. The timeout snapshot confirmed that message 1 remained unmounted. The test now holds candidate assistant recoveries, chooses a genuinely mounted pending assistant above the settled reader, and delivers only that message's captured request ID. It derives identity from the fixture message, not the virtualizer row index. No production scrolling behavior, timeout, retry, tolerance, or test-only export changes.

Both full seven-case browser runs passed with clean process teardown. One selected message 5, preserving reader row 7 at −2px; the other selected message 41, preserving reader row 43 at −44px. Both grew from 100px to 534px with zero adjacency gap and passed the far-edge unmount/remount checks, exercising both excursion directions. The original 5.5-second reconciliation wait remains intact. A deliberate temporary removal of pointer cancellation made the repaired test fail at its existing interruption assertion (`6894` reached the `6894` maximum); production was then restored byte-for-byte. The restored selected case passed and exited zero (with a nonfatal fork-worker termination warning); no temporary production edit remains. Refreshed tool-card/stream and Gateway rollback tests passed all 105 cases. The full combined five-file gate passed, including core/UI test types, UI types, lint, styles, i18n, dead exports and guards.

An intermediate release-all fixture correctly failed anchoring because it also expanded the reader's own message; the final fixture replies only to its chosen pending request and preserves the original single-message-growth contract. Independent owner/dependency review found no actionable issue. A fresh structured Codex review of the complete logical patch (original branch plus test follow-up) exited zero with no findings at its configured P0 reporting threshold. The test-only follow-up adds 91 and removes 40 lines; production remains net −1 across the PR.

Fixture provenance: #130758 introduced the interrupted-recovery test and its fixed message-1 assumption; #128803 strengthened the above-viewport precondition but retained that identity assumption. This is a bounded test repair discovered while validating the UI fix, not a claim of a new product scrolling repair.

Final source: `e50338bd2619285bec3c8f5410b43d901fea959a`, rebased onto `871b18dff5039484e86c76d282699a8defcb1654` to include #131627. The original tool-classifier and extraction/rendering test files are byte-identical to the earlier reviewed/live-tested head; the additional change is the fixture repair above. Complete PR delta: production +3/-4 (net −1), tests +182/-73 (net +109), changelog +2. Exact-head hosted [CI 33156706485](https://github.com/openclaw/openclaw/actions/runs/33156706485) completed successfully on this source, including all three previously failing jobs. No failed check was bypassed.

Latest actual ClawSweeper review (08:17 UTC, still reviewing the previous source) stopped its entry probe at `expect_text OpenClaw`, before the tool scenario. The real-Gateway evidence and inspected attachments above address that proof gap and the requested real-setup Rank-up move; neither failed reviewer setup is claimed as passing. The stale failed-CI concern is now resolved by the successful exact-head run. The expanded-scope re-review has been requested; its publisher is still pending as the native landing process starts.
