### PR TITLE
test: isolate Gateway reload and Gemini auth fixtures

### DIFF
--- a/extensions/google/cli-backend-auth.test.ts
+++ b/extensions/google/cli-backend-auth.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { CliBackendAuthProfilePreparationError } from "openclaw/plugin-sdk/cli-backend";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
-import { withTempDir } from "openclaw/plugin-sdk/test-env";
+import { captureEnv, withTempDir } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it, vi } from "vitest";
 import { buildGoogleGeminiCliBackend } from "./cli-backend.js";
 
@@ -256,24 +256,27 @@ describe("google gemini cli backend auth bridge", () => {
         'GOOGLE_GENAI_USE_VERTEXAI="true"\nGOOGLE_APPLICATION_CREDENTIALS="./credentials.json"\n',
       );
 
-      const originalGeminiCliHome = process.env.GEMINI_CLI_HOME;
+      const env = captureEnv(["GEMINI_CLI_HOME", "GOOGLE_APPLICATION_CREDENTIALS"]);
       process.env.GEMINI_CLI_HOME = ambientHome;
-      const prepared = await buildGoogleGeminiCliBackend().prepareExecution?.({
-        workspaceDir,
-        provider: "google-gemini-cli",
-        modelId: "gemini-3.1-flash-preview",
-        toolAvailability: { native: [], openClaw: [] },
-        isolatedCompletionModelId: "gemini-3.1-flash-preview",
-        isolatedCompletionSystemPrompt: "Return only JSON.",
-      } as GeminiPrepareContext);
+      // Process credentials override dotenv; this fixture exercises the file-only path.
+      delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+      let prepared: GeminiPreparedExecution | null | undefined;
       try {
+        prepared = await buildGoogleGeminiCliBackend().prepareExecution?.({
+          workspaceDir,
+          provider: "google-gemini-cli",
+          modelId: "gemini-3.1-flash-preview",
+          toolAvailability: { native: [], openClaw: [] },
+          isolatedCompletionModelId: "gemini-3.1-flash-preview",
+          isolatedCompletionSystemPrompt: "Return only JSON.",
+        } as GeminiPrepareContext);
         await stageGeminiPreparedExecution(prepared);
         expect(prepared?.env?.GOOGLE_GENAI_USE_VERTEXAI).toBe("true");
         expect(prepared?.env?.GOOGLE_APPLICATION_CREDENTIALS).toBe(
           path.join(workspaceDir, "credentials.json"),
         );
       } finally {
-        restoreEnv("GEMINI_CLI_HOME", originalGeminiCliHome);
+        env.restore();
         await prepared?.cleanup?.();
       }
     });

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -5179,45 +5179,53 @@ describe("gateway Gmail hot reload handlers", () => {
   });
 
   it("keeps committed config after a Gmail watcher follow-up fails", async () => {
-    vi.useFakeTimers();
-    const writeListenerRef = createConfigWriteListenerRef();
-    const initialConfig = createGmailConfig("old@example.com");
-    const nextConfig: OpenClawConfig = {
-      ...createGmailConfig("next@example.com"),
-      models: { providers: {} },
-    };
-    const logReload = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
-    activateSecretsRuntimeSnapshot(makePreparedSecretsSnapshot(initialConfig));
-    hoisted.startGmailWatcherWithLogs.mockRejectedValueOnce(new Error("start failed"));
-    const reloader = startManagedGatewayConfigReloader({
-      initialConfig,
-      readSnapshot: vi.fn(async () => createValidConfigSnapshot(nextConfig, "hash-next")) as never,
-      subscribeToWrites: captureConfigWriteListener(writeListenerRef),
-      logReload,
+    await withGatewayRestartSignal(async (signalSpy) => {
+      vi.useFakeTimers();
+      const writeListenerRef = createConfigWriteListenerRef();
+      const initialConfig = createGmailConfig("old@example.com");
+      const nextConfig: OpenClawConfig = {
+        ...createGmailConfig("next@example.com"),
+        models: { providers: {} },
+      };
+      const logReload = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+      activateSecretsRuntimeSnapshot(makePreparedSecretsSnapshot(initialConfig));
+      hoisted.startGmailWatcherWithLogs.mockRejectedValueOnce(new Error("start failed"));
+      const reloader = startManagedGatewayConfigReloader({
+        initialConfig,
+        readSnapshot: vi.fn(async () =>
+          createValidConfigSnapshot(nextConfig, "hash-next"),
+        ) as never,
+        subscribeToWrites: captureConfigWriteListener(writeListenerRef),
+        logReload,
+      });
+      try {
+        const registeredWriteListener = writeListenerRef.current;
+        if (!registeredWriteListener) {
+          throw new Error("Expected config write listener to be registered");
+        }
+
+        registeredWriteListener(
+          createConfigWriteNotification(
+            nextConfig,
+            "hash-next",
+            1,
+            "runtime-hash-next",
+            "source-hash-next",
+          ),
+        );
+        await vi.runAllTimersAsync();
+
+        expect(hoisted.refreshContextWindowCache).toHaveBeenCalledTimes(1);
+        expect(hoisted.refreshContextWindowCache).toHaveBeenCalledWith(nextConfig);
+        expect(logReload.warn).toHaveBeenCalledWith(
+          "gmail watcher reload failed after config commit: start failed; restarting gateway",
+        );
+        expect(logReload.error).not.toHaveBeenCalled();
+        expect(signalSpy).toHaveBeenCalledOnce();
+      } finally {
+        await reloader.stop();
+      }
     });
-    const registeredWriteListener = writeListenerRef.current;
-    if (!registeredWriteListener) {
-      throw new Error("Expected config write listener to be registered");
-    }
-
-    registeredWriteListener(
-      createConfigWriteNotification(
-        nextConfig,
-        "hash-next",
-        1,
-        "runtime-hash-next",
-        "source-hash-next",
-      ),
-    );
-    await vi.runAllTimersAsync();
-
-    expect(hoisted.refreshContextWindowCache).toHaveBeenCalledTimes(1);
-    expect(hoisted.refreshContextWindowCache).toHaveBeenCalledWith(nextConfig);
-    expect(logReload.warn).toHaveBeenCalledWith(
-      "gmail watcher reload failed after config commit: start failed; restarting gateway",
-    );
-    expect(logReload.error).not.toHaveBeenCalled();
-    await reloader.stop();
   });
 
   it("does not start a Gmail restart after the managed reloader stops before hot reload applies", async () => {
@@ -5390,7 +5398,6 @@ describe("gateway plugin hot reload handlers", () => {
   });
 
   it("publishes candidate env before cron, plugin, and channel replacements start", async () => {
-    vi.useFakeTimers();
     const envKey = "OPENCLAW_TEST_HOT_RELOAD_SERVICE_ENV";
     const targetEnv: NodeJS.ProcessEnv = { [envKey]: "old" };
     const initialConfig = {
@@ -5451,34 +5458,47 @@ describe("gateway plugin hot reload handlers", () => {
     );
     const reloader = startManagedGatewayConfigReloader({
       initialConfig,
-      readSnapshot: vi.fn() as never,
+      readSnapshot: vi.fn(async () => createValidConfigSnapshot(nextConfig, "hot-env")),
       subscribeToWrites: captureConfigWriteListener(writeListenerRef, false),
       startChannel: vi.fn(async () => {
         events.push(`channel:${targetEnv[envKey]}`);
       }),
       reloadPlugins,
     });
-    const listener = writeListenerRef.current;
-    if (!listener) {
-      throw new Error("Expected config write listener to be registered");
+    try {
+      const listener = writeListenerRef.current;
+      if (!listener) {
+        throw new Error("Expected config write listener to be registered");
+      }
+      const application = createRuntimeConfigWriteApplication();
+      listener(
+        attachRuntimeConfigWriteApplication(
+          createConfigWriteNotification(
+            nextConfig,
+            "hot-env",
+            1,
+            "runtime-hot-env",
+            "source-hot-env",
+            {
+              preparedCandidate: { runtimeConfig: nextConfig, compareConfig, runtimeEnv },
+            },
+          ),
+          application,
+        ),
+      );
+      await expect(application.result).resolves.toBe("applied");
+
+      expect(events).toEqual([
+        "cron-build:candidate:old",
+        "lookup:candidate:old",
+        "cron:candidate",
+        "plugin:candidate",
+        "channel:candidate",
+      ]);
+      expect(targetEnv[envKey]).toBe("candidate");
+    } finally {
+      await reloader.stop();
     }
-
-    listener(
-      createConfigWriteNotification(nextConfig, "hot-env", 1, "runtime-hot-env", "source-hot-env", {
-        preparedCandidate: { runtimeConfig: nextConfig, compareConfig, runtimeEnv },
-      }),
-    );
-    await vi.runAllTimersAsync();
-
-    expect(events).toEqual([
-      "cron-build:candidate:old",
-      "lookup:candidate:old",
-      "cron:candidate",
-      "plugin:candidate",
-      "channel:candidate",
-    ]);
-    expect(targetEnv[envKey]).toBe("candidate");
-    await reloader.stop();
   });
 
   it("keeps mixed reload state old until the plugin replacement commit", async () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves two Gateway reload test-fixture failures found while verifying the current-main missing-export repair, and preserves this PR's existing host-independent Gemini fixture repair. This is explicitly maintainer-requested broken-main repair and bounded sibling cleanup.

The missing-export repair itself landed concurrently in #131627 as `871b18dff5039484e86c76d282699a8defcb1654`. This PR has been rebased onto that canonical fix and leaves its rollback test byte-for-byte unchanged; it does not duplicate the repair.

## Why This Change Was Made

The Gmail failure test emitted a restart signal without clearing its unconsumed token, causing later tests to coalesce instead of emit. It now uses the existing `withGatewayRestartSignal` fixture, asserts actual emission, and always stops its reloader.

The environment-publication test drained every fake timer even after all five expected service events completed. A captured callback proved the remaining timer was recurring maintenance. The test now awaits the existing config-write application receipt with real timers, supplies a valid snapshot fixture, and always stops its reloader. All event-order assertions remain; there is no timeout increase, retry, weaker assertion, new mock, or production/storage change.

The Gemini dotenv fixture captures/restores both environment variables and clears inherited `GOOGLE_APPLICATION_CREDENTIALS` while testing file-only resolution. The adjacent test still covers process-precedence behavior.

The canonical missing-export provenance is #131545 (code/PR author and merger @steipete) intentionally internalizing the helper, followed seven minutes later by #118157 (commit author Ayaan Gazali, PR author @ayaangazali, merger @steipete) adding a stale test import. #131627 correctly tests the exported rollback operation with the real channel manager and keeps the helper private.

## User Impact

No runtime or public API change. Developers get meaningful, independent reload fixtures and deterministic dotenv-path coverage. No changelog entry is needed for these internal test repairs. No live Gateway, provider call, real credential, dependency, version, snapshot, protocol, schema, or SQLite implementation was changed.

Production LOC: **+0/-0**. Tests: **+94/-71 (net +23)** in two existing files; most churn moves existing assertions under guaranteed cleanup. No new test case or production seam.

## Evidence

Fresh main `4bbb3660dfb00d54e493e917756c329573bb786b` reproduced all three missing-export failures. The original shuffled Gateway trio had **6 failures / 349 tests** at seed 828: three import failures and three restart-token follow-on failures. This PR's first head fixed the import but still reproduced **3 failures / 349 tests**. Seed 829 independently exposed the environment-publication timer loop; that case failed alone too.

After fixture repair, the Gateway trio passes **349/349 at seeds 828 and 829**, including repeat proof after rebasing onto the canonical #131627 fix:

```bash
pnpm test src/gateway/server-reload-channel-restart.test.ts src/gateway/server-reload-handlers.test.ts src/gateway/server-channels.test.ts --maxWorkers=1 --sequence.shuffle --sequence.seed=828 --reporter=verbose
pnpm test src/gateway/server-reload-channel-restart.test.ts src/gateway/server-reload-handlers.test.ts src/gateway/server-channels.test.ts --maxWorkers=1 --sequence.shuffle --sequence.seed=829 --reporter=verbose
```

A reversible `preserveManualStop: true` to `false` owner fault failed all three rollback cases; production bytes were restored exactly. The environment-publication case passes alone using its application receipt, retaining all five service-order assertions.

The Gemini dotenv case failed on unmodified main with a synthetic inherited path. Both backend auth and isolated-completion files pass **46 tests** with the same synthetic input:

```bash
GOOGLE_APPLICATION_CREDENTIALS=/tmp/openclaw-fixture-only-adc.json pnpm test extensions/google/cli-backend-auth.test.ts extensions/google/cli-backend-isolated.test.ts --maxWorkers=1 --reporter=verbose
```

The complete changed-file gate passed for the original three-file superset: formatting, guards, all three Knip scans, core and plugin test types, and both lint lanes. Conflict resolution only removed the duplicate rollback edit; both retained file blobs exactly match the checked and reviewed version. Deslop found no additional cleanup. Fresh Codex autoreviews of the handler commit and whole-PR diff reported no actionable findings at the configured P0 threshold.

```bash
pnpm check:changed -- extensions/google/cli-backend-auth.test.ts src/gateway/server-reload-channel-restart.test.ts src/gateway/server-reload-handlers.test.ts
```

Candidate: `60d7cf6c6a35f7a024b0cf3c7cb5bcacf046ce65`, based on `871b18dff5039484e86c76d282699a8defcb1654`. The earlier [CI run 33153600809](https://github.com/openclaw/openclaw/actions/runs/33153600809) belongs to the pre-conflict head, not this candidate. Canonical repair [CI 33152936793](https://github.com/openclaw/openclaw/actions/runs/33152936793) is independently verified successful at its exact head. Final [CI 33154122327](https://github.com/openclaw/openclaw/actions/runs/33154122327) completed successfully for exact candidate `60d7cf6c6a35f7a024b0cf3c7cb5bcacf046ce65`. Native review artifacts, mandatory hosted preparation, and native merge all completed without changing that head.

Proof is deterministic local test execution, not a live Gateway or Google API run. Production is unchanged. AI-assisted with Codex.

### Landing verification

Merged through `scripts/pr merge-run` as [717cb7cb](https://github.com/openclaw/openclaw/commit/717cb7cb413e3afb9399161b044e6885cb2dc3c1). Reconstructed the merge of actual parent `3234bb295d173a9cdcbd22ae0ec9548b07ae68b6` and reviewed head: expected and landed trees both equal `259edfd415cb5267a9cfc1c608236fc53309511c`. Exactly the two intended test files changed, and both blobs match the reviewed candidate. Native worktree, temporary refs, operation lock, processes, and remote task branch are gone; unrelated worktrees/processes were preserved.

The latest ClawSweeper comment at landing was the fresh exact-head review-started notice, with no published findings or rank-up moves; it was explicitly recorded as pending, not clean, in the [premerge proof](https://github.com/openclaw/openclaw/pull/131625#issuecomment-5450154975). Independent autoreview and exact-head CI/native gates were complete. The visible checkout was returned to clean latest main, and the repaired three-case test passed again there.
