### PR TITLE
fix(memory): forget diary claims after session backfill

### DIFF
--- a/docs/cli/memory.md
+++ b/docs/cli/memory.md
@@ -227,6 +227,10 @@ reason `forgotten`. Repeating the purge does not remove the exclusion, and
 removing an admission-policy rule does not undo it. Future sessions with new
 IDs are not excluded by a previous purge.
 
+New session-backfill diary facts and reflections carry entry markers and
+source origins, including REM previews and diary blocks left by a failed apply.
+Forgetting removes each matching line, including transformed or combined claims;
+unrelated lines remain. Historical unmarked backfill text has no reconstructed lineage.
 Exact corpus quotations in dream diaries such as `DREAMS.md` and
 `memory/dreaming/**/*.md` can be removed as whole lines. Untracked paraphrases
 cannot be reliably attributed and remain.
@@ -348,7 +352,7 @@ openclaw memory session-backfill --agent <id> --rollback [--json]
 | `--to YYYY-MM-DD`           |              | Include messages on or before this day in the dreaming timezone.                                              |
 | `--limit-days <n>`          | `92`         | Process at most this many hash-untracked days, oldest first.                                                  |
 | `--archive-files <path...>` |              | Also inspect foreign transcript files as untrusted input; embedded owner metadata is not accepted.            |
-| `--rem`                     |              | Write deterministic grounded per-day previews to `DREAMS.md` only.                                            |
+| `--rem`                     |              | Write deterministic grounded per-day previews to `DREAMS.md` and retain their source-origin records.          |
 | `--apply`                   | preview only | Drain all bounded batches, stage trusted candidates, and write reversible `DREAMS.md` diary blocks.           |
 | `--rollback`                |              | Remove all grounded backfill candidates and shared backfill diary blocks, including `rem-backfill` artifacts. |
 | `--json`                    |              | Print machine-readable per-day counts and top candidates.                                                     |
@@ -373,6 +377,11 @@ candidates. It writes only the session corpus under `memory/.dreams/`, short-ter
 staging state, and reversible diary entries in `DREAMS.md`. It never writes
 `MEMORY.md` or `USER.md`; durable promotion remains a separate `memory promote`
 or dreaming decision. `--rem` and `--apply` are mutually exclusive.
+
+Both writing modes record diary origins before publishing text, so a later
+apply failure does not leave untraceable diary quotations. REM keeps only the
+diary and its origin bookkeeping: it does not retain a session corpus, stage
+candidates, advance ingestion cursors, or call a model.
 
 Backfill rollback is intentionally shared with `memory rem-backfill`: both
 commands use the same grounded-only staging class and diary markers. Run

--- a/docs/concepts/memory-provenance.md
+++ b/docs/concepts/memory-provenance.md
@@ -96,6 +96,11 @@ automatic expiry; long revision histories can retain growing origin sets.
 
 When backfill coalesces the same claim from several sessions, it retains every
 source origin without counting the repeated claim as extra evidence.
+Session-backfill diary lines also carry markers tied to source origins before
+publication. This includes REM facts, reflections, and combined claims, even
+when displayed citations are shortened or a later apply step fails. Forgetting
+any contributing session removes the whole marked line, not unrelated diary
+lines. Earlier unmarked backfill diaries do not gain lineage retroactively.
 
 Coverage is not universal. Handwritten notes, direct agent edits, and entries
 staged before lineage tracking may lack entry origins. The report's

--- a/extensions/memory-core/src/rem-evidence.test.ts
+++ b/extensions/memory-core/src/rem-evidence.test.ts
@@ -1,0 +1,38 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { previewGroundedRemMarkdown } from "./rem-evidence.js";
+import { createMemoryCoreTestHarness } from "./test-helpers.js";
+
+const harness = createMemoryCoreTestHarness();
+
+describe("grounded REM evidence", () => {
+  it("retains every reflection source while bounding displayed citations", async () => {
+    const workspaceDir = await harness.createTempWorkspace("rem-reflection-origins-");
+    const inputPath = path.join(workspaceDir, "memory", "2026-02-01.md");
+    await fs.mkdir(path.dirname(inputPath));
+    await fs.writeFile(
+      inputPath,
+      ["Alice", "Bob", "Carol", "Drew"]
+        .map((person) => `## ${person}\n${person} lives in a quiet seaside town.\n`)
+        .join("\n"),
+    );
+    const preview = await previewGroundedRemMarkdown({ workspaceDir, inputPaths: [inputPath] });
+    const file = preview.files[0]!;
+    const reflection = file.reflections.find(({ text }) =>
+      text.includes("More than one active relationship"),
+    );
+    expect(reflection).toBeDefined();
+    expect(reflection!.refs).toEqual([
+      "memory/2026-02-01.md:2",
+      "memory/2026-02-01.md:5",
+      "memory/2026-02-01.md:8",
+      "memory/2026-02-01.md:11",
+    ]);
+    const rendered = file.renderedMarkdown
+      .split("\n")
+      .find((line) => line.includes(reflection!.text));
+    expect(rendered).toContain("memory/2026-02-01.md:8");
+    expect(rendered).not.toContain("memory/2026-02-01.md:11");
+  });
+});

--- a/extensions/memory-core/src/rem-evidence.ts
+++ b/extensions/memory-core/src/rem-evidence.ts
@@ -674,6 +674,23 @@ function addReflection(
   reflections.push({ text: normalized, refs });
 }
 
+function coalesceGroundedRemItems<T extends GroundedRemPreviewItem>(
+  items: T[],
+  keyFor = (text: string) => text,
+): T[] {
+  const byText = new Map<string, T>();
+  for (const item of items) {
+    const key = keyFor(item.text);
+    const existing = byText.get(key);
+    // Equal claims share text, not identity; preserve sources before output caps and rendering.
+    byText.set(
+      key,
+      existing ? { ...existing, refs: uniqueStrings([...existing.refs, ...item.refs]) } : item,
+    );
+  }
+  return [...byText.values()];
+}
+
 function isOperatorRuleSummary(summary: SectionSummary): boolean {
   return (
     /process improvements?/i.test(summary.title) || REM_OPERATOR_RULE_SIGNAL_RE.test(summary.text)
@@ -700,9 +717,10 @@ function findStrongestSummary(
   return strongest;
 }
 
-function previewGroundedRemForFile(params: {
+export function previewGroundedRemForFile(params: {
   relPath: string;
   content: string;
+  formatItem?: (line: string, refs: readonly string[]) => string;
 }): GroundedRemFilePreview {
   const sections = parseMarkdownSections(params.content);
   const sectionScores = sections.map((section) => ({
@@ -734,14 +752,14 @@ function previewGroundedRemForFile(params: {
     }));
   });
 
-  const memoryImplications = summaries
-    .filter((summary) => summary.scores.preference > 0 || isOperatorRuleSummary(summary))
-    .map((summary) => ({
-      text: summary.text.replace(/^[^:]+:\s*/, ""),
-      refs: summary.refs,
-    }))
-    .filter((item, index, items) => items.findIndex((entry) => entry.text === item.text) === index)
-    .slice(0, REM_SUMMARY_MEMORY_LIMIT);
+  const memoryImplications = coalesceGroundedRemItems(
+    summaries
+      .filter((summary) => summary.scores.preference > 0 || isOperatorRuleSummary(summary))
+      .map((summary) => ({
+        text: summary.text.replace(/^[^:]+:\s*/, ""),
+        refs: summary.refs,
+      })),
+  ).slice(0, REM_SUMMARY_MEMORY_LIMIT);
 
   const candidateSnippets: CandidateSnippetSummary[] = sections.flatMap((section) => {
     if (REM_BLOCKED_SECTION_RE.test(section.title)) {
@@ -767,37 +785,31 @@ function previewGroundedRemForFile(params: {
     );
   });
 
-  const candidates = candidateSnippets
-    .toSorted((left, right) => {
+  const candidates = coalesceGroundedRemItems(
+    candidateSnippets.toSorted((left, right) => {
       const leanRank = { likely_durable: 0, unclear: 1, likely_situational: 2 };
       const leanDelta = leanRank[left.lean] - leanRank[right.lean];
       if (leanDelta !== 0) {
         return leanDelta;
       }
       return right.score - left.score;
-    })
-    .filter(
-      (candidate, index, items) =>
-        items.findIndex((entry) => entry.text === candidate.text) === index,
-    )
-    .slice(0, 4);
+    }),
+  ).slice(0, 4);
 
-  const durableImplications = candidateSnippets
-    .filter((candidate) => candidate.lean === "likely_durable" || candidate.score >= 4)
-    .filter(
-      (candidate, index, items) =>
-        items.findIndex((entry) => entry.text === candidate.text) === index,
-    )
+  const durableImplications = coalesceGroundedRemItems(
+    candidateSnippets.filter(
+      (candidate) => candidate.lean === "likely_durable" || candidate.score >= 4,
+    ),
+  )
     .toSorted((left, right) => right.score - left.score)
     .slice(0, REM_SUMMARY_MEMORY_LIMIT)
     .map((candidate) => ({ text: candidate.text, refs: candidate.refs }));
 
-  const candidateDrivenImplications = candidateSnippets
-    .filter((candidate) => candidate.lean !== "likely_situational" && candidate.score >= 2.2)
-    .filter(
-      (candidate, index, items) =>
-        items.findIndex((entry) => entry.text === candidate.text) === index,
-    )
+  const candidateDrivenImplications = coalesceGroundedRemItems(
+    candidateSnippets.filter(
+      (candidate) => candidate.lean !== "likely_situational" && candidate.score >= 2.2,
+    ),
+  )
     .toSorted((left, right) => right.score - left.score)
     .slice(0, REM_SUMMARY_MEMORY_LIMIT)
     .map((candidate) => ({ text: candidate.text, refs: candidate.refs }));
@@ -809,19 +821,12 @@ function previewGroundedRemForFile(params: {
         ? candidateDrivenImplications
         : memoryImplications;
 
-  const facts: GroundedRemPreviewItem[] = [];
-  const usedFactTexts = new Set<string>();
-  for (const summary of factSummaries.toSorted((left, right) => right.score - left.score)) {
-    const key = summary.text.toLowerCase();
-    if (usedFactTexts.has(key)) {
-      continue;
-    }
-    usedFactTexts.add(key);
-    facts.push({ text: summary.text, refs: summary.refs });
-    if (facts.length >= REM_SUMMARY_FACT_LIMIT) {
-      break;
-    }
-  }
+  const facts: GroundedRemPreviewItem[] = coalesceGroundedRemItems(
+    factSummaries.toSorted((left, right) => right.score - left.score),
+    (text) => text.toLowerCase(),
+  )
+    .slice(0, REM_SUMMARY_FACT_LIMIT)
+    .map(({ text, refs }) => ({ text, refs }));
   if (facts.length === 0 && monitoringSignal < 3) {
     const bestFor = (metric: keyof SectionSummary["scores"]) =>
       summaries
@@ -832,25 +837,19 @@ function previewGroundedRemForFile(params: {
           }
           return right.scores.overall - left.scores.overall;
         })[0];
-    for (const summary of [
-      bestFor("preference"),
-      bestFor("routing"),
-      bestFor("externalization"),
-      ...summaries.toSorted((left, right) => right.scores.overall - left.scores.overall),
-    ]) {
-      if (!summary) {
-        continue;
-      }
-      const key = summary.text.toLowerCase();
-      if (usedFactTexts.has(key)) {
-        continue;
-      }
-      usedFactTexts.add(key);
-      facts.push({ text: summary.text, refs: summary.refs });
-      if (facts.length >= REM_SUMMARY_FACT_LIMIT) {
-        break;
-      }
-    }
+    facts.push(
+      ...coalesceGroundedRemItems(
+        [
+          bestFor("preference"),
+          bestFor("routing"),
+          bestFor("externalization"),
+          ...summaries.toSorted((left, right) => right.scores.overall - left.scores.overall),
+        ].filter((summary): summary is SectionSummary => summary !== undefined),
+        (text) => text.toLowerCase(),
+      )
+        .slice(0, REM_SUMMARY_FACT_LIMIT)
+        .map(({ text, refs }) => ({ text, refs })),
+    );
   }
 
   const reflections: GroundedRemPreviewItem[] = [];
@@ -899,7 +898,7 @@ function previewGroundedRemForFile(params: {
       reflections,
       seenReflections,
       "A stable rule or preference was stated explicitly, which suggests operating choices are being made legible instead of left implicit.",
-      effectiveMemoryImplications.flatMap((item) => item.refs).slice(0, 3),
+      effectiveMemoryImplications.flatMap((item) => item.refs),
     );
   }
   if (multiRelationshipContext) {
@@ -907,7 +906,7 @@ function previewGroundedRemForFile(params: {
       reflections,
       seenReflections,
       "More than one active relationship thread appears in the same day, which means person-memory matters operationally: who each person is should be kept separate from the transient date or venue details attached to them.",
-      relationshipFacts.flatMap((item) => item.refs).slice(0, 3),
+      relationshipFacts.flatMap((item) => item.refs),
     );
   }
   if (
@@ -940,8 +939,7 @@ function previewGroundedRemForFile(params: {
   if (!multiRelationshipContext && facts.length > 0 && buildSignal >= 2) {
     const buildRefs = facts
       .filter((item) => REM_BUILD_SIGNAL_RE.test(item.text))
-      .flatMap((item) => item.refs)
-      .slice(0, 3);
+      .flatMap((item) => item.refs);
     if (buildRefs.length > 0) {
       addReflection(
         reflections,
@@ -964,8 +962,7 @@ function previewGroundedRemForFile(params: {
   if (!multiRelationshipContext && facts.length > 0 && logisticsSignal >= 2) {
     const logisticsRefs = facts
       .filter((item) => REM_LOGISTICS_SIGNAL_RE.test(item.text))
-      .flatMap((item) => item.refs)
-      .slice(0, 3);
+      .flatMap((item) => item.refs);
     if (logisticsRefs.length > 0) {
       addReflection(
         reflections,
@@ -998,38 +995,37 @@ function previewGroundedRemForFile(params: {
         : Math.min(REM_SUMMARY_REFLECTION_LIMIT, facts.length + 1);
   const visibleReflections = reflections.slice(0, reflectionLimit);
 
-  const renderedLines: string[] = [];
-  renderedLines.push("## What Happened");
-  if (facts.length === 0) {
-    renderedLines.push("1. No grounded facts were extracted.");
-  } else {
-    for (const [index, fact] of facts.entries()) {
-      renderedLines.push(`${index + 1}. ${fact.text} [${fact.refs.join(", ")}]`);
-    }
-  }
-  renderedLines.push("");
-  renderedLines.push("## Reflections");
-  if (visibleReflections.length === 0) {
-    renderedLines.push("1. No grounded reflections emerged from this note yet.");
-  } else {
-    for (const [index, reflection] of visibleReflections.entries()) {
-      renderedLines.push(`${index + 1}. ${reflection.text} [${reflection.refs.join(", ")}]`);
-    }
-  }
-  if (candidates.length > 0) {
-    renderedLines.push("");
-    renderedLines.push("## Candidates");
-    for (const candidate of candidates) {
-      renderedLines.push(`- [${candidate.lean}] ${candidate.text} [${candidate.refs.join(", ")}]`);
-    }
-  }
-  if (effectiveMemoryImplications.length > 0) {
-    renderedLines.push("");
-    renderedLines.push("## Possible Lasting Updates");
-    for (const implication of effectiveMemoryImplications) {
-      renderedLines.push(`- ${implication.text} [${implication.refs.join(", ")}]`);
-    }
-  }
+  const renderItem = (item: GroundedRemPreviewItem, prefix: string) => {
+    // Citation display stays bounded; deletion lineage keeps every contributing ref.
+    const refs = item.refs.slice(0, 3);
+    const line = `${prefix} ${item.text} [${refs.join(", ")}]`;
+    return params.formatItem?.(line, item.refs) ?? line;
+  };
+  const renderedLines = [
+    "## What Happened",
+    ...(facts.length
+      ? facts.map((fact, index) => renderItem(fact, `${index + 1}.`))
+      : ["1. No grounded facts were extracted."]),
+    "",
+    "## Reflections",
+    ...(visibleReflections.length
+      ? visibleReflections.map((reflection, index) => renderItem(reflection, `${index + 1}.`))
+      : ["1. No grounded reflections emerged from this note yet."]),
+    ...(candidates.length
+      ? [
+          "",
+          "## Candidates",
+          ...candidates.map((candidate) => renderItem(candidate, `- [${candidate.lean}]`)),
+        ]
+      : []),
+    ...(effectiveMemoryImplications.length
+      ? [
+          "",
+          "## Possible Lasting Updates",
+          ...effectiveMemoryImplications.map((implication) => renderItem(implication, "-")),
+        ]
+      : []),
+  ];
 
   return {
     path: params.relPath,

--- a/extensions/memory-core/src/session-backfill.test.ts
+++ b/extensions/memory-core/src/session-backfill.test.ts
@@ -11,6 +11,8 @@ import {
   upsertSessionEntry,
 } from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
+import { openOpenClawAgentDatabase } from "openclaw/plugin-sdk/sqlite-runtime";
+import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { writeBackfillDiaryEntries } from "./dreaming-narrative.js";
 import {
@@ -18,6 +20,7 @@ import {
   SESSION_BACKFILL_REWIND_NAMESPACE,
 } from "./dreaming-state.js";
 import { listMemoryEntryOrigins, recordMemorySessionTombstones } from "./memory-entry-origins.js";
+import { forgetMemoryEntries } from "./memory-forget.js";
 import {
   markSessionBackfillRewindBaseline,
   resetSessionBackfillIngestionState,
@@ -261,7 +264,7 @@ describe("runSessionBackfill", () => {
     expect(result.stagedEntries).toBe(1);
     expect(entries).toHaveLength(1);
     expect(
-      listMemoryEntryOrigins({ agentId: "main" }).map((origin) => ({
+      listMemoryEntryOrigins({ agentId: "main", entryKeys: [entries[0]!.key] }).map((origin) => ({
         entryKey: origin.entryKey,
         sessionId: origin.sessionId,
         originClass: origin.originClass,
@@ -666,6 +669,157 @@ describe("runSessionBackfill", () => {
     expect(dreams).toContain("Owner prefers dark mode for all editors");
     expect(dreams).not.toContain("No grounded facts were extracted");
     expect(dreams.match(/openclaw:dreaming:backfill-entry/g)).toHaveLength(2);
+  });
+
+  it.each(["rem", "apply", "failed-apply"] as const)(
+    "forgets published %s diary facts after reopening without removing unrelated facts",
+    async (mode) => {
+      const workspaceDir = await createIsolatedWorkspace(`forget-${mode}-`);
+      const cfg = { agents: { defaults: { workspace: workspaceDir }, list: [{ id: "main" }] } };
+      const diaryPath = path.join(workspaceDir, "DREAMS.md");
+      const operatorNote = "Keep this unrelated operator note.";
+      await fs.writeFile(diaryPath, `# Dream Diary\n${operatorNote}\n`);
+      for (const [sessionId, content] of [
+        ["target", "Owner prefers **cobalt lanterns**; always use green tea."],
+        ["retained", "Owner prefers silver ribbons for invitations."],
+      ]) {
+        await seedCanonicalTranscript(sessionId!, [
+          { role: "user", content: content!, timestamp: "2026-02-01T10:00:00.000Z", owner: true },
+        ]);
+      }
+      const corpusParent = path.join(workspaceDir, "memory", ".dreams");
+      if (mode === "failed-apply") {
+        await fs.mkdir(path.dirname(corpusParent), { recursive: true });
+        await fs.writeFile(corpusParent, "block the corpus write");
+      }
+      const backfill = runSessionBackfill({
+        agentId: "main",
+        workspaceDir,
+        rem: mode === "rem",
+        apply: mode !== "rem",
+        timezone: "UTC",
+      });
+      if (mode === "failed-apply") {
+        await expect(backfill).rejects.toThrow();
+        await fs.unlink(corpusParent);
+      } else {
+        await backfill;
+      }
+      const before = await fs.readFile(diaryPath, "utf8");
+      expect(before).toContain("cobalt lanterns");
+      expect(before).toContain("silver ribbons");
+      if (mode === "rem") {
+        expect(before).not.toContain("**cobalt lanterns**");
+        expect(await readShortTermRecallEntries({ workspaceDir })).toEqual([]);
+        expect((await dreamingTestState.readSessionIngestionState(workspaceDir)).files).toEqual({});
+        await expect(fs.stat(corpusParent)).rejects.toMatchObject({ code: "ENOENT" });
+        const origins = listMemoryEntryOrigins({ agentId: "main" });
+        expect(origins.every(({ entryKey }) => before.includes(entryKey))).toBe(true);
+        const repeated = await runSessionBackfill({
+          agentId: "main",
+          workspaceDir,
+          rem: true,
+          timezone: "UTC",
+        });
+        expect(repeated.writtenDiaryEntries).toBe(0);
+        expect(listMemoryEntryOrigins({ agentId: "main" })).toEqual(origins);
+      }
+      closeOpenClawAgentDatabasesForTest();
+      const preview = await forgetMemoryEntries({
+        cfg,
+        agentId: "main",
+        sessionIds: ["target"],
+        dryRun: true,
+      });
+      expect(await fs.readFile(diaryPath, "utf8")).toBe(before);
+      const report = await forgetMemoryEntries({ cfg, agentId: "main", sessionIds: ["target"] });
+      expect(report.artifacts).toEqual(preview.artifacts);
+      const after = await fs.readFile(diaryPath, "utf8");
+      expect.soft(after).not.toContain("cobalt lanterns");
+      expect.soft(after).not.toContain("green tea");
+      expect(after).toContain("silver ribbons");
+      expect(after).toContain(operatorNote);
+      expect(report.refusals).toEqual([]);
+      const repeated = await forgetMemoryEntries({ cfg, agentId: "main", sessionIds: ["target"] });
+      expect(Object.values(repeated.artifacts).every((count) => count === 0)).toBe(true);
+    },
+  );
+
+  it("retains both origins when diary publication deduplicates identical apply blocks", async () => {
+    const workspaceDir = await createIsolatedWorkspace("diary-dedupe-");
+    const cfg = { agents: { defaults: { workspace: workspaceDir }, list: [{ id: "main" }] } };
+    for (const sessionId of ["first", "second"]) {
+      await seedCanonicalTranscript(sessionId, [
+        {
+          role: "user",
+          content: "Owner prefers cobalt lanterns.",
+          timestamp: "2026-02-01T10:00:00.000Z",
+          owner: true,
+        },
+      ]);
+      const applied = await runSessionBackfill({
+        agentId: "main",
+        workspaceDir,
+        apply: true,
+        timezone: "UTC",
+      });
+      expect(applied.writtenDiaryEntries).toBe(sessionId === "first" ? 1 : 0);
+    }
+    const diaryPath = path.join(workspaceDir, "DREAMS.md");
+    expect(await fs.readFile(diaryPath, "utf8")).toContain("cobalt lanterns");
+    const report = await forgetMemoryEntries({ cfg, agentId: "main", sessionIds: ["second"] });
+    expect(report.mixedLineageEntryKeys.length).toBeGreaterThan(0);
+    expect(await fs.readFile(diaryPath, "utf8")).not.toContain("cobalt lanterns");
+  });
+
+  it("keeps all origins of a coalesced REM claim while preserving independent facts", async () => {
+    const workspaceDir = await createIsolatedWorkspace("rem-coalesced-");
+    const cfg = { agents: { defaults: { workspace: workspaceDir }, list: [{ id: "main" }] } };
+    for (const [sessionId, item] of [
+      ["first", "cobalt lanterns"],
+      ["second", "silver ribbons"],
+    ] as const) {
+      await seedCanonicalTranscript(sessionId, [
+        {
+          role: "user",
+          content: `Owner prefers ${item}; always use green tea.`,
+          timestamp: "2026-02-01T10:00:00.000Z",
+          owner: true,
+        },
+      ]);
+    }
+    await runSessionBackfill({ agentId: "main", workspaceDir, rem: true, timezone: "UTC" });
+    const diaryPath = path.join(workspaceDir, "DREAMS.md");
+    const before = await fs.readFile(diaryPath, "utf8");
+    expect(before).toContain("- [likely_durable] always use green tea.");
+    const report = await forgetMemoryEntries({ cfg, agentId: "main", sessionIds: ["second"] });
+    const after = await fs.readFile(diaryPath, "utf8");
+    expect(report.mixedLineageEntryKeys.length).toBeGreaterThan(0);
+    expect(after).toContain("cobalt lanterns");
+    expect(after).not.toContain("silver ribbons");
+    expect(after).not.toContain("- [likely_durable] always use green tea.");
+  });
+
+  it("does not publish a diary when reserving its origins fails", async () => {
+    const workspaceDir = await createIsolatedWorkspace("diary-origin-failure-");
+    await seedCanonicalTranscript("target", [
+      {
+        role: "user",
+        content: "Owner prefers cobalt lanterns.",
+        timestamp: "2026-02-01T10:00:00.000Z",
+        owner: true,
+      },
+    ]);
+    const diaryPath = path.join(workspaceDir, "DREAMS.md");
+    await fs.writeFile(diaryPath, "Keep this operator note.\n");
+    openOpenClawAgentDatabase({ agentId: "main" }).db.exec(`
+      CREATE TRIGGER reject_diary_origin BEFORE INSERT ON memory_entry_origins
+      BEGIN SELECT RAISE(ABORT, 'injected diary origin failure'); END;
+    `);
+    await expect(
+      runSessionBackfill({ agentId: "main", workspaceDir, rem: true, timezone: "UTC" }),
+    ).rejects.toThrow("injected diary origin failure");
+    expect(await fs.readFile(diaryPath, "utf8")).toBe("Keep this operator note.\n");
   });
 
   it("stages idempotently, converges duplicate facts, and rolls back staged artifacts", async () => {

--- a/extensions/memory-core/src/session-backfill.ts
+++ b/extensions/memory-core/src/session-backfill.ts
@@ -1,13 +1,15 @@
-import fs from "node:fs/promises";
 import path from "node:path";
 import { listSessionTranscriptCorpusEntriesForAgent } from "openclaw/plugin-sdk/memory-core-host-engine-sessions";
 import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
-import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import type { SessionIngestionFileState } from "./dreaming-ingestion-state.js";
 import { removeBackfillDiaryEntries, writeBackfillDiaryEntries } from "./dreaming-narrative.js";
-import { listMemorySessionTombstones } from "./memory-entry-origins.js";
+import {
+  listMemorySessionTombstones,
+  recordMemoryEntryOrigins,
+  type MemoryEntryOrigin,
+} from "./memory-entry-origins.js";
 import { withMemoryWorkspaceLock } from "./memory-workspace-lock.js";
-import { previewGroundedRemMarkdown } from "./rem-evidence.js";
+import { previewGroundedRemForFile } from "./rem-evidence.js";
 import type {
   SessionBackfillDay,
   SessionBackfillExecution,
@@ -26,7 +28,6 @@ import {
   SESSION_INGESTION_MAX_MESSAGES_PER_SWEEP,
   SESSION_INGESTION_MIN_MESSAGES_PER_FILE,
   SESSION_INGESTION_SCORE,
-  SESSION_CORPUS_RELATIVE_DIR,
   appendSessionCorpusLines,
   foreignSessionIngestionSource,
   mergeTrackedMessageHashes,
@@ -42,6 +43,7 @@ import {
   type SessionAdmissionPolicy,
   type SessionEntryOrigin,
 } from "./session-ingestion.js";
+import { buildPromotionMarker, hashMemoryContent } from "./short-term-promotion-memory-write.js";
 import {
   readShortTermRecallEntries,
   recordGroundedShortTermCandidates,
@@ -64,10 +66,8 @@ export type MemorySessionBackfillOptions = {
   json?: boolean;
 };
 
-type SessionBackfillCandidate = SessionIngestionCandidate;
-
 type SessionBackfillScan = {
-  candidates: SessionBackfillCandidate[];
+  candidates: SessionIngestionCandidate[];
   contentHash: string;
   lineCount: number;
   mtimeMs: number;
@@ -129,8 +129,8 @@ async function listSessionBackfillSources(params: {
 }
 
 function compareSessionBackfillCandidates(
-  a: SessionBackfillCandidate,
-  b: SessionBackfillCandidate,
+  a: SessionIngestionCandidate,
+  b: SessionIngestionCandidate,
 ): number {
   if (a.day !== b.day) {
     return a.day.localeCompare(b.day);
@@ -152,7 +152,7 @@ async function collectSessionBackfillCandidates(params: {
   to?: string;
   timezone?: string;
 }) {
-  const candidates: SessionBackfillCandidate[] = [];
+  const candidates: SessionIngestionCandidate[] = [];
   const scans: SessionBackfillScan[] = [];
   const perFileCap = Math.min(
     SESSION_INGESTION_MAX_MESSAGES_PER_FILE,
@@ -201,7 +201,7 @@ async function collectSessionBackfillCandidates(params: {
   const selected = candidates
     .toSorted(compareSessionBackfillCandidates)
     .slice(0, SESSION_INGESTION_MAX_MESSAGES_PER_SWEEP);
-  const byDay = new Map<string, SessionBackfillCandidate[]>();
+  const byDay = new Map<string, SessionIngestionCandidate[]>();
   for (const candidate of selected) {
     const bucket = byDay.get(candidate.day) ?? [];
     bucket.push(candidate);
@@ -213,7 +213,7 @@ async function collectSessionBackfillCandidates(params: {
 function mergeSessionBackfillFileProgress(params: {
   current: Record<string, SessionIngestionFileState>;
   scans: SessionBackfillScan[];
-  selectedDays: Array<{ candidates: SessionBackfillCandidate[] }>;
+  selectedDays: Array<{ candidates: SessionIngestionCandidate[] }>;
 }): Record<string, SessionIngestionFileState> {
   const selectedHashes = new Set(
     params.selectedDays.flatMap((day) => day.candidates.map((candidate) => candidate.hash)),
@@ -239,7 +239,7 @@ function mergeSessionBackfillFileProgress(params: {
   return files;
 }
 
-function summarizeDay(day: string, candidates: SessionBackfillCandidate[]): SessionBackfillDay {
+function summarizeDay(day: string, candidates: SessionIngestionCandidate[]): SessionBackfillDay {
   return {
     day,
     candidateCount: candidates.length,
@@ -247,66 +247,72 @@ function summarizeDay(day: string, candidates: SessionBackfillCandidate[]): Sess
   };
 }
 
-function buildSummaryDiaryLines(day: SessionBackfillDay): string[] {
-  return [
-    `Session backfill found ${day.candidateCount} trusted candidate${day.candidateCount === 1 ? "" : "s"}.`,
-    ...day.topCandidates.map((candidate) => `- ${candidate}`),
-  ];
-}
-
-function groundedMarkdownToDiaryLines(markdown: string): string[] {
-  return markdown
-    .split(/\r?\n/)
-    .map((line) => line.replace(/^##\s+/, "").trimEnd())
-    .filter((line, index, lines) => !(line.length === 0 && lines[index - 1]?.length === 0));
-}
-
-async function buildRemDiaryEntries(params: {
-  days: Array<{ day: string; candidates: SessionBackfillCandidate[] }>;
-}): Promise<Array<{ isoDay: string; sourcePath: string; bodyLines: string[] }>> {
-  const scratchDir = await fs.mkdtemp(
-    path.join(resolvePreferredOpenClawTmpDir(), "openclaw-session-backfill-"),
-  );
-  try {
-    const entries: Array<{ isoDay: string; sourcePath: string; bodyLines: string[] }> = [];
-    for (const day of params.days) {
-      const results = await appendSessionCorpusLines({
-        workspaceDir: scratchDir,
-        day: day.day,
-        lines: day.candidates,
-      });
-      if (results.length === 0) {
-        continue;
+function buildSessionBackfillDiaryEntries(params: {
+  agentId: string;
+  days: Array<{ day: string; candidates: SessionIngestionCandidate[] }>;
+  rem?: boolean;
+}) {
+  const origins: MemoryEntryOrigin[] = [];
+  const markLine = (day: string, line: string, sources: SessionIngestionCandidate[]) => {
+    // Diary dedupe keeps identical day/text blocks; their marker must accumulate every source.
+    const entryKey = `memory:session-backfill:${hashMemoryContent(JSON.stringify([day, line]))}`;
+    for (const source of sources) {
+      const origin = source.sessionOrigin;
+      if (origin) {
+        origins.push({
+          entryKey,
+          ...origin,
+          sessionKey: origin.sessionKey ?? null,
+          originClass: source.provenance.originClass,
+          observedAt: source.provenance.observedAt,
+        });
       }
-      const corpusPath = path.join(scratchDir, SESSION_CORPUS_RELATIVE_DIR, `${day.day}.txt`);
-      const inputPath = path.join(scratchDir, "memory", `${day.day}.md`);
-      const corpus = await fs.readFile(corpusPath, "utf-8");
-      await fs.writeFile(inputPath, `## Session transcript\n\n${corpus}`);
-      const preview = await previewGroundedRemMarkdown({
-        workspaceDir: scratchDir,
-        inputPaths: [inputPath],
-      });
-      const file = preview.files.at(0);
-      const hasGroundedContent = Boolean(
-        file &&
-        (file.facts.length > 0 ||
-          file.reflections.length > 0 ||
-          file.memoryImplications.length > 0 ||
-          file.candidates.length > 0),
-      );
-      entries.push({
-        isoDay: day.day,
-        sourcePath: results[0]?.path ?? `memory/.dreams/session-corpus/${day.day}.txt`,
-        bodyLines:
-          hasGroundedContent && file
-            ? groundedMarkdownToDiaryLines(file.renderedMarkdown)
-            : buildSummaryDiaryLines(summarizeDay(day.day, day.candidates)),
-      });
     }
-    return entries;
-  } finally {
-    await fs.rm(scratchDir, { recursive: true, force: true });
-  }
+    return `${buildPromotionMarker(entryKey)}\n${line}`;
+  };
+  const entries = params.days.map(({ day, candidates }) => {
+    let bodyLines: string[] | undefined;
+    if (params.rem) {
+      const relPath = `memory/${day}.md`;
+      const file = previewGroundedRemForFile({
+        relPath,
+        content: `## Session transcript\n\n${candidates.map((candidate) => candidate.rendered).join("\n")}\n`,
+        formatItem: (line, refs) =>
+          markLine(
+            day,
+            line,
+            candidates.filter((_, index) =>
+              refs.some((ref) => {
+                // The virtual markdown input has a heading and blank line before its candidates.
+                const [start, end = start] = ref
+                  .slice(relPath.length + 1)
+                  .split("-")
+                  .map(Number);
+                return index + 3 >= start! && index + 3 <= end!;
+              }),
+            ),
+          ),
+      });
+      if (
+        file.facts.length ||
+        file.reflections.length ||
+        file.memoryImplications.length ||
+        file.candidates.length
+      ) {
+        bodyLines = file.renderedMarkdown.replace(/^##\s+/gm, "").split("\n");
+      }
+    }
+    bodyLines ??= [
+      `Session backfill found ${candidates.length} trusted candidate${candidates.length === 1 ? "" : "s"}.`,
+      ...candidates
+        .slice(0, TOP_CANDIDATE_LIMIT)
+        .map((candidate) => markLine(day, `- ${candidate.snippet}`, [candidate])),
+    ];
+    return { isoDay: day, sourcePath: `memory/.dreams/session-corpus/${day}.txt`, bodyLines };
+  });
+  // Reserve lineage before publication, even when subsequent corpus/staging work fails.
+  recordMemoryEntryOrigins({ agentId: params.agentId, origins });
+  return entries;
 }
 
 function coalesceBackfillClaims(
@@ -337,7 +343,7 @@ function coalesceBackfillClaims(
 
 async function applySessionBackfillDays(params: {
   workspaceDir: string;
-  days: Array<{ day: string; candidates: SessionBackfillCandidate[] }>;
+  days: Array<{ day: string; candidates: SessionIngestionCandidate[] }>;
   nowMs: number;
   timezone?: string;
 }): Promise<number> {
@@ -475,13 +481,11 @@ async function executeSessionBackfillBatchCore(
   let stagedEntries = 0;
 
   if (selectedDays.length > 0 && (params.rem || params.apply)) {
-    const diaryEntries = params.rem
-      ? await buildRemDiaryEntries({ days: selectedDays })
-      : selectedDays.map((entry) => ({
-          isoDay: entry.day,
-          sourcePath: `memory/.dreams/session-corpus/${entry.day}.txt`,
-          bodyLines: buildSummaryDiaryLines(summarizeDay(entry.day, entry.candidates)),
-        }));
+    const diaryEntries = buildSessionBackfillDiaryEntries({
+      agentId: params.agentId,
+      days: selectedDays,
+      rem: params.rem,
+    });
     const diary = await writeBackfillDiaryEntries({
       workspaceDir,
       entries: diaryEntries,


### PR DESCRIPTION
Closes #131608.

## What Problem This Solves

Fixes an issue where forgetting a session could leave its derived claims in `DREAMS.md` after `memory session-backfill --rem`, or after `--apply` published the diary and then failed while creating the session corpus. Those diary lines had no deletion lineage; matching the original quote could not reliably remove rewritten or atomized claims.

## Why This Change Was Made

The backfill producer now records each published claim's contributing session origins before writing the diary, under the existing workspace lock and through the existing SQLite origin owner. The diary uses the existing promotion marker, so the canonical forget path can remove derived claims without another text-matching fallback. Identical claims accumulate all contributing sessions, including across separate backfill calls.

REM rendering now accepts its already-constructed content directly. This removes the temporary corpus, temporary markdown file, readback, and cleanup pipeline. A shared coalescer preserves every source when equal claims merge; only displayed citations are capped. No schema, store, configuration option, dependency, model call, or second deletion path is added. This is the bounded producer repair accepted in #131608.

## User Impact

For newly backfilled entries, forgetting a session removes its marked derivatives even when REM rewrites the original text or later apply work failed. Unrelated session claims and operator notes remain. Dry-run previews the same removal without changing diary bytes; repeated forgetting remains idempotent.

Production LOC: +178/-178, net **0**. Tests: +193/-1, net +192. Docs: +15/-1, net +14. The docs explicitly distinguish new lineage-backed entries from historical unmarked diaries, which this change cannot retroactively attribute.

## Evidence

- The pre-fix source reproduced retained session derivatives in REM and interrupted-apply cases; normal apply is a positive control.
- Real SQLite owner tests cover transformed markdown and atomized claims, mixed session origins, identical claims from separate calls, origin-write failure before publication, dry-run, database reopen, repeat forget, and unrelated notes.
- A separate four-source reflection probe through the existing file-preview entry point failed on the baseline because it retained only three source references. The repaired preview retains all four while displaying three citations.
- Full changed-file checks passed. The expanded focused run passed 136 cases and hit one cold-import timeout in an unchanged CLI test; the complete CLI suite then passed all 99 cases in its original order, with no timeout, mock, or assertion changes.
- Final Codex autoreview reported no accepted/actionable findings at its P0-only threshold; independent owner-boundary review also found no actionable issue.
- Real built CLI proof passed at `4068c0ea16dedb04263686cf1524ace92e355af2` on Blacksmith Testbox `tbx_01m13nd968dkxmsz0e76mhygc9`: 12 CLI invocations across REM, injected apply failure, and normal apply. Each scenario verified both selected canaries were published then removed, unrelated session/operator content survived, dry-run reported the same artifacts without changing bytes, and repeat forget made no further changes. No model or external channel was involved.
- [Testbox workflow 33152795927](https://github.com/openclaw/openclaw/actions/runs/33152795927) dispatched workflow source `4bbb3660dfb00d54e493e917756c329573bb786b`; the tested source was the distinct candidate SHA above. All 34,520 tracked file blobs and modes matched before install/build, after build/proof, and at cleanup. The downloaded evidence archive independently matched SHA256 `53a6712af542bdef6a9a5dc545b3ef5589375732a34347f013afaccd7980512b`; no owned Node processes remained.
- The independent main test-import failure landed in #131627 at `871b18dff5039484e86c76d282699a8defcb1654`; redundant #131631 was closed. This branch was rebased with an identical repair patch and identical changed-file bytes. [Final-head CI33154870108](https://github.com/openclaw/openclaw/actions/runs/33154870108) passed on attempt2 at `2bce095b0e56ebd579fd50600bbe1a9d9fe86a11`. Attempt1 timed out during SDK declaration preparation before plugin compilation; a normal failed-check rerun passed without source, timeout, or assertion changes. The initial pre-rebase ready run was cancelled by a later skipped same-head event. Both tooling limitations remain recorded.
- The12-call built CLI proof was repeated successfully on the exact final head: [Testbox33154951566](https://github.com/openclaw/openclaw/actions/runs/33154951566), lease `tbx_01m13q9ck9abppxt591xjv7f84`. All34,537 tracked blobs/modes matched at five checkpoints; downloaded archiveSHA256 `d6b31a66d6ae87d88df64de9e0e315733d8ecaed16568dbe1cce521530e0f936` was independently verified. Workflow source was `0a068cf3f1ef4c45988c7f6a947caacc134478b7`, distinct from the tested source. No owned process remained; leasecompleted. Fresh final-head Codex autoreview is clean at P0 threshold.

Remaining limitation: rollback or failed publication can retain conservative origin bookkeeping. Reference-aware origin garbage collection needs a separate accepted retention design; deleting those rows opportunistically could orphan copied or restored marked artifacts. No automatic retention or schema change is introduced here.

AI-assisted implementation with Codex. All proof uses synthetic workspaces; no operator sessions or provider credentials.

Maintainer proof decision: the ClawSweeper help-only attempt stopped during the build before reaching the CLI. The complete built CLI run above finished successfully and exercises the actual requested operation, including all three backfill modes. Its rank-up request for after-fix terminal evidence is addressed by these observed receipts:

```text
Built CLI invocations: 12; proof exit: 0
REM: selected derivatives removed; unrelated session/operator notes retained; 6 marked entries removed
Interrupted apply: selected derivatives removed; unrelated notes retained; 1 marked entry removed
Normal apply: selected derivatives removed; unrelated notes retained; 1 marked entry and 1 corpus line removed
All modes: dry-run artifact counts matched removal; repeated forget changed no diary bytes
All tracked source guards matched; remaining owned Node processes: 0
Testbox cleanup: completed
```

Storage compatibility: this writes the existing `memory_entry_origins` row shape and existing promotion-marker format. Schema version, tables, indexes, reader contracts, and vector/embedding metadata are unchanged; no migration or alternate reader is needed. Existing forget parsing accepts the opaque entry keys used here. Historical unmarked diary content remains explicitly outside this repair's attribution guarantee. Required CI is green on the final head; no checks were bypassed.
