### PR TITLE
fix(gateway): restore rollback manual-stop regression checks

### DIFF
--- a/src/gateway/server-reload-channel-restart.test.ts
+++ b/src/gateway/server-reload-channel-restart.test.ts
@@ -1,11 +1,11 @@
-import { afterEach, expect, it } from "vitest";
+import { afterEach, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import { resetGatewayWorkAdmission } from "../process/gateway-work-admission.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import { createChannelManager, type ChannelManager } from "./server-channels.js";
-import { startGatewayChannelFromActiveRegistry } from "./server-reload-channel-restart.js";
+import { rollbackStoppedGatewayChannels } from "./server-reload-channel-restart.js";
 
 let manager: ChannelManager | undefined;
 afterEach(async () => {
@@ -16,7 +16,7 @@ afterEach(async () => {
 });
 
 it.each(["idle", "stopped", "racing"] as const)(
-  "automatic reload preserves %s manual stops while explicit starts resume",
+  "automatic rollback preserves %s manual stops while explicit starts resume",
   async (state) => {
     const starts: string[] = [];
     const configuring = createDeferred();
@@ -59,14 +59,19 @@ it.each(["idle", "stopped", "racing"] as const)(
     if (state !== "racing") {
       await manager.stopChannel("discord", "manual");
     }
-    const reload = startGatewayChannelFromActiveRegistry(manager, "discord");
+    const rollback = rollbackStoppedGatewayChannels(
+      { startChannel: manager.startChannel, logChannels: { info: vi.fn(), error: vi.fn() } },
+      new Set(["discord"]),
+      new Map(),
+      "cancelled plugin reload",
+    );
     if (state === "racing") {
       await configuring.promise;
       await manager.stopChannel("discord", "manual");
       blockConfiguration = false;
       releaseConfiguration.resolve();
     }
-    await reload;
+    await expect(rollback).resolves.toEqual([]);
     expect(manager.isManuallyStopped("discord", "manual")).toBe(true);
     expect(manager.getRuntimeSnapshot().channelAccounts.discord?.manual?.running).toBe(false);
     expect(starts).toEqual(state === "stopped" ? ["manual", "running"] : ["running"]);


### PR DESCRIPTION
## What Problem This Solves

Repairs the main-branch test/type-check failure after the concurrent landings of #118157 and #131545. The reload refactor correctly made `startGatewayChannelFromActiveRegistry` private, but the new manual-stop regression still imported it. Main CI reports TS2459 and all three lifecycle cases fail with `startGatewayChannelFromActiveRegistry is not a function`.

## Why This Change Was Made

Move the existing regression to `rollbackStoppedGatewayChannels`, the public operation used by the real hot-reload rollback path. Keep the actual channel manager and idle, previously stopped, and racing-stop cases; also assert that rollback reports no failed targets. Do not restore a test-only production export or change runtime behavior.

## User Impact

Test-only repair. The media-limit and manual-stop behavior already landed remains unchanged. Production LOC: +0/-0. Tests: +10/-5 in one existing file. No new API, configuration, dependency, schema, timeout, or weaker assertion.

## Evidence

- Main CI [33150343145](https://github.com/openclaw/openclaw/actions/runs/33150343145): type-check job 98780851241 reports TS2459; test job 98780852167 records the three exact runtime failures. Logs were fetched and retained once.
- The same three failures were reproduced locally at merged commit `0bb870a40a6dca25642473356c36592e8d0cf31e` before editing. Fresh main `8d51e415d6a14ae7b6d1023fc9661e4bc1e9c725` still has the same test and private helper.
- `node scripts/run-vitest.mjs src/gateway/server-reload-channel-restart.test.ts src/gateway/server-reload-handlers.test.ts src/gateway/config-reload.test.ts`: **462 passed in 3 files**, including all three repaired real-manager lifecycle cases.
- Independent isolated Codex autoreview: no accepted/actionable findings.
- `node scripts/check-changed.mjs -- src/gateway/server-reload-channel-restart.test.ts`: passed, including formatting, full core-test type shards, lint, boundary/ratchet checks, and all three dead-code scans.
- Exact-head [CI 33152936793](https://github.com/openclaw/openclaw/actions/runs/33152936793): **success** at `31a574e532c6b2b976a99aeb4a6ac1c90cd0bad6`, including the formerly failing test/type-check paths.
- Native review artifacts and hosted-CI preparation passed without changing the tested head. Current-main review at `150eb9a924c0ca74dde48e10b44dc2d5ca251081` confirms the defect remains; the affected production owner/caller/manager files are unchanged from the tested branch.

The real producer/caller chain was inspected: `server-reload-hot.ts` calls the public rollback operation, which retains the private start helper and its `preserveManualStop: true` option. The real manager's manual-stop and explicit-start behavior remains the assertion boundary. This is not a new runtime change requiring another external-channel test.

AI-assisted maintainer repair with Codex. Regression provenance: #131545 (author/merger @steipete, 2026-08-28 07:00 UTC) made the helper private; #118157 (contributor @ayaangazali, maintainer integration/merge @steipete, 07:07 UTC) added the test that still imported it. Neither standalone head failed this combination; the merged-main interaction is repaired here.
