### PR TITLE
refactor(system-agent): unify operator handoffs and proposal lifecycle

### DIFF
--- a/docs/cli/openclaw.md
+++ b/docs/cli/openclaw.md
@@ -114,6 +114,8 @@ Changes delegated by a regular agent, including requests from messaging channels
 require approval in the OpenClaw operator UI. Replying "yes" in that chat cannot
 approve the change. Run `openclaw dashboard` on the Gateway host to review the
 pending approval, or run the change directly with `openclaw setup` there.
+Interactive setup and agent handoffs require a direct operator session;
+delegated chat cannot start a wizard, even when a model proposes it.
 
 Configured agents can ask OpenClaw to create another agent through their
 `openclaw` tool. The request enters the same typed create-agent operation and

--- a/src/agents/tools/system-agent-tool.test.ts
+++ b/src/agents/tools/system-agent-tool.test.ts
@@ -1,8 +1,8 @@
 // OpenClaw ring-zero tool tests: approval gating, action mapping, verification.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { hashSystemAgentOperation } from "../../system-agent/operator-approval.js";
 import {
   createSystemAgentTool,
-  hashSystemAgentOperation,
   resolveSystemAgentDirectiveTransition,
   resolveSystemAgentProposalTransition,
   type SystemAgentToolDirective,
@@ -452,6 +452,31 @@ describe("openclaw tool", () => {
     expect(directiveRef.current).toEqual({ kind: "open-setup", target: "gateway" });
 
     // Directives are host handoffs, never operation executions.
+    expect(mocks.executeSystemAgentOperation).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { action: "connect_channel", channel: "telegram" },
+    { action: "configure_skills" },
+    { action: "configure_search" },
+    { action: "configure_gateway" },
+    { action: "import_memory" },
+    { action: "configure_model_provider" },
+    { action: "open_agent" },
+    { action: "open_setup", target: "channels" },
+  ])("does not promise a delegated $action handoff", async (args) => {
+    const directiveRef: { current?: SystemAgentToolDirective } = {};
+    const tool = createSystemAgentTool({
+      surface: "gateway",
+      operatorApprovalOnly: true,
+      directiveRef,
+    });
+
+    const text = toolText(await tool.execute("delegated-navigation", args));
+
+    expect(text).toContain("cannot run from a delegated agent request");
+    expect(directiveRef.current).toBeUndefined();
+    expect(resolveSystemAgentDirectiveTransition({ args, resultText: text })).toBeNull();
     expect(mocks.executeSystemAgentOperation).not.toHaveBeenCalled();
   });
 

--- a/src/agents/tools/system-agent-tool.ts
+++ b/src/agents/tools/system-agent-tool.ts
@@ -4,16 +4,23 @@
  * per-run scope, and every action funnels through OpenClaw's typed operation
  * union with approval assertions and the audit log.
  */
-import { createHash } from "node:crypto";
-import { stableStringify } from "@openclaw/normalization-core";
 import { Type } from "typebox";
 import type { RuntimeEnv } from "../../runtime.js";
+import {
+  isSystemAgentNavigationOperation,
+  type SystemAgentNavigationOperation,
+} from "../../system-agent/operation-types.js";
 import {
   executeSystemAgentOperation,
   isPersistentSystemAgentOperation,
   SYSTEM_AGENT_OPERATOR_APPROVAL_HANDOFF,
+  SYSTEM_AGENT_OPERATOR_NAVIGATION_HANDOFF,
   type SystemAgentOperation,
 } from "../../system-agent/operations.js";
+import {
+  hashSystemAgentOperation,
+  type SystemAgentProposalRef,
+} from "../../system-agent/operator-approval.js";
 import { validateSystemAgentPluginInstallSpec } from "../../system-agent/plugin-install-spec.js";
 import { stringEnum } from "../schema/typebox.js";
 import { textResult, ToolInputError, readToolStringParam, type AnyAgentTool } from "./common.js";
@@ -35,7 +42,7 @@ export type SystemAgentToolOptions = {
    * its canonical hash here (host-owned, survives turns), and an armed turn
    * may execute only a call matching that hash. Cleared after use.
    */
-  proposalRef?: { current?: string; operation?: SystemAgentOperation };
+  proposalRef?: SystemAgentProposalRef;
   /**
    * Host handoff channel for actions the tool cannot perform itself
    * (interactive channel setup, external onboarding guidance, opening the
@@ -47,25 +54,8 @@ export type SystemAgentToolOptions = {
 
 /** Host directives the hosting chat engine handles after the turn. */
 export type SystemAgentToolDirective =
-  | { kind: "channel-setup"; channel: string }
-  | { kind: "skills-setup" }
-  | { kind: "search-setup" }
-  | { kind: "gateway-config-setup" }
-  | { kind: "memory-import" }
-  | { kind: "model-setup"; workspace?: string }
-  | { kind: "open-tui"; agentId?: string; workspace?: string }
-  | Extract<SystemAgentOperation, { kind: "open-setup" }>
+  | SystemAgentNavigationOperation
   | { kind: "approved-operation"; operation: SystemAgentOperation };
-
-type SystemAgentHostNavigationDirective = Exclude<
-  SystemAgentToolDirective,
-  { kind: "approved-operation" }
->;
-
-/** Canonical operation fingerprint used to bind "yes" to one exact mutation. */
-export function hashSystemAgentOperation(operation: SystemAgentOperation): string {
-  return createHash("sha256").update(stableStringify(operation)).digest("hex");
-}
 
 /** Result markers shared with out-of-process hosts (CLI MCP runs). */
 const SYSTEM_AGENT_NEEDS_APPROVAL_PREFIX = "needs-approval:";
@@ -94,43 +84,10 @@ export function resolveSystemAgentDirectiveTransition(params: {
     ) {
       return { kind: "approved-operation", operation };
     }
-    return directiveForOperation(operation);
+    return isSystemAgentNavigationOperation(operation) ? operation : null;
   } catch {
     return null;
   }
-}
-
-function directiveForOperation(
-  operation: SystemAgentOperation,
-): SystemAgentHostNavigationDirective | null {
-  if (operation.kind === "channel-setup") {
-    return { kind: "channel-setup", channel: operation.channel };
-  }
-  if (
-    operation.kind === "skills-setup" ||
-    operation.kind === "search-setup" ||
-    operation.kind === "gateway-config-setup" ||
-    operation.kind === "memory-import"
-  ) {
-    return operation;
-  }
-  if (operation.kind === "model-setup") {
-    return {
-      kind: "model-setup",
-      ...(operation.workspace ? { workspace: operation.workspace } : {}),
-    };
-  }
-  if (operation.kind === "open-tui") {
-    return {
-      kind: "open-tui",
-      ...(operation.agentId ? { agentId: operation.agentId } : {}),
-      ...(operation.workspace ? { workspace: operation.workspace } : {}),
-    };
-  }
-  if (operation.kind === "open-setup") {
-    return operation;
-  }
-  return null;
 }
 
 /**
@@ -420,8 +377,11 @@ export function createSystemAgentTool(options: SystemAgentToolOptions): AnyAgent
     execute: async (_toolCallId, args) => {
       const params = (args ?? {}) as Record<string, unknown>;
       const operation = operationForAction(params);
-      const directive = directiveForOperation(operation);
+      const directive = isSystemAgentNavigationOperation(operation) ? operation : null;
       if (directive) {
+        if (options.operatorApprovalOnly) {
+          return textResult(SYSTEM_AGENT_OPERATOR_NAVIGATION_HANDOFF, {});
+        }
         // Not a write: the host chat performs the interactive handoff after
         // this turn (the wizard itself collects explicit user answers).
         if (options.directiveRef && options.directiveRef.current?.kind !== "approved-operation") {

--- a/src/mcp/openclaw-tools-serve.test.ts
+++ b/src/mcp/openclaw-tools-serve.test.ts
@@ -1,6 +1,6 @@
 // OpenClaw MCP tools tests cover core tool server startup and registration.
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { hashSystemAgentOperation } from "../agents/tools/system-agent-tool.js";
+import { hashSystemAgentOperation } from "../system-agent/operator-approval.js";
 import {
   buildSystemAgentToolsMcpServerConfig,
   OPENCLAW_TOOLS_MCP_SYSTEM_AGENT_APPROVAL_ARMED_ENV,

--- a/src/system-agent/agent-turn.ts
+++ b/src/system-agent/agent-turn.ts
@@ -14,7 +14,7 @@ import { SYSTEM_AGENT_ID } from "./agent-id.js";
 import { SYSTEM_AGENT_SYSTEM_PROMPT } from "./assistant-prompts.js";
 import { SystemAgentInferenceUnavailableError } from "./inference-error.js";
 import type { SystemAgentConfiguredRoute } from "./inference-route.js";
-import type { SystemAgentOperation } from "./operations.js";
+import type { SystemAgentProposalRef } from "./operator-approval.js";
 import type { SystemAgentOverview } from "./overview.js";
 import {
   resolveSystemAgentExpectedAgentHarnessRuntimeArtifact,
@@ -64,7 +64,7 @@ export type SystemAgentSession = {
   /** Exact live-tested inference owner for this ephemeral conversation. */
   verifiedInference: SystemAgentVerifiedInferenceBinding;
   /** Host-owned pending-proposal fingerprint; see system-agent-tool.ts. */
-  proposalRef: { current?: string; operation?: SystemAgentOperation };
+  proposalRef: SystemAgentProposalRef;
   /** Native CLI continuity, bound to the exact configured model/auth owner route. */
   cliSession?: {
     routeKey: string;
@@ -221,7 +221,7 @@ function resolveSystemAgentCliToolAvailability(
  */
 async function mirrorSystemAgentToolStateFromEvents(params: {
   runId: string;
-  proposalRef: { current?: string; operation?: SystemAgentOperation };
+  proposalRef: SystemAgentProposalRef;
   directiveRef: { current?: SystemAgentTurnDirective };
 }): Promise<() => void> {
   const [

--- a/src/system-agent/chat-engine.test-support.ts
+++ b/src/system-agent/chat-engine.test-support.ts
@@ -401,7 +401,7 @@ export function fakeOverviewLoader(
 }
 
 export { expectDefined } from "@openclaw/normalization-core";
-export { hashSystemAgentOperation } from "../agents/tools/system-agent-tool.js";
+export { hashSystemAgentOperation } from "./operator-approval.js";
 export type { OpenClawConfig } from "../config/types.openclaw.js";
 export type { WizardPrompter } from "../wizard/prompts.js";
 export { runSystemAgentTurnWithDeps } from "./agent-turn.test-support.js";

--- a/src/system-agent/chat-engine.ts
+++ b/src/system-agent/chat-engine.ts
@@ -112,10 +112,6 @@ export class SystemAgentChatEngine {
     return this.router.propose(operation);
   }
 
-  hasPendingProposal(): boolean {
-    return this.router.hasPendingProposal();
-  }
-
   getPendingOperatorProposal(): { operation: SystemAgentOperation; hash: string } | null {
     return this.router.getPendingOperatorProposal();
   }

--- a/src/system-agent/chat-turn-router.approval.test.ts
+++ b/src/system-agent/chat-turn-router.approval.test.ts
@@ -28,7 +28,7 @@ function createRouterHarness(options: ConstructorParameters<typeof ChatTurnRoute
     verifiedInference,
     proposalRef: {},
   };
-  const router = new ChatTurnRouter(
+  return new ChatTurnRouter(
     options,
     { executeOperation: async () => ({ applied: true }) },
     session,
@@ -43,7 +43,6 @@ function createRouterHarness(options: ConstructorParameters<typeof ChatTurnRoute
       verifyConfigAfterWrite: async () => null,
     },
   );
-  return router;
 }
 
 describe("SystemAgentChatEngine approval", () => {
@@ -75,92 +74,69 @@ describe("SystemAgentChatEngine approval", () => {
     expect(describeSystemAgentPersistentOperation(proposal.operation)).toContain(
       "requested by agent research",
     );
+    expect(await router.resolveOperatorApproval("allow-once", unrecordedHash)).toBeNull();
+    expect(await router.resolveOperatorApproval("allow-once", proposal.hash)).not.toBeNull();
+    expect(router.getPendingOperatorProposal()).toBeNull();
   });
 
-  it("lets only an operator arm delegated persistent writes", async () => {
-    useTempStateDir();
-    const operation = { kind: "config-set" as const, path: "gateway.port", value: "19001" };
-    const proposalHash = hashSystemAgentOperation(operation);
-    const armed: boolean[] = [];
-    const observedInputs: string[] = [];
-    const runConfigSet = vi.fn(async () => {});
-    const engine = new SystemAgentChatEngine({
-      operatorApprovalOnly: true,
-      runAgentTurn: async (params) => {
-        armed.push(params.approvalArmed);
-        observedInputs.push(params.input);
-        if (observedInputs.length === 1) {
-          params.session.proposalRef.current = proposalHash;
-          params.session.proposalRef.operation = operation;
-        }
-        return { text: "Change ready." };
-      },
-      deps: { runConfigSet, loadOverview: fakeOverviewLoader() },
-    });
+  it.each(["allow-once", "deny", null] as const)(
+    "resolves delegated persistent writes only from the operator decision %s",
+    async (decision) => {
+      useTempStateDir();
+      const operation = { kind: "config-set" as const, path: "gateway.port", value: "19001" };
+      const proposalHash = hashSystemAgentOperation(operation);
+      const armed: boolean[] = [];
+      const observedInputs: string[] = [];
+      const runConfigSet = vi.fn(async () => {});
+      const engine = new SystemAgentChatEngine({
+        operatorApprovalOnly: true,
+        runAgentTurn: async (params) => {
+          armed.push(params.approvalArmed);
+          observedInputs.push(params.input);
+          if (observedInputs.length === 1) {
+            params.session.proposalRef.current = proposalHash;
+            params.session.proposalRef.operation = operation;
+          }
+          return { text: "Change ready." };
+        },
+        deps: { runConfigSet, loadOverview: fakeOverviewLoader() },
+      });
 
-    await engine.handle("Change port.");
-    const agentApproval = await engine.handle("yes");
+      await engine.handle("Change port.");
+      const agentApproval = await engine.handle("yes");
 
-    expect(agentApproval.text).toContain("Approval pending");
-    expect(armed).toEqual([false]);
-    expect(runConfigSet).not.toHaveBeenCalled();
+      expect(agentApproval.text).toContain("Approval pending");
+      expect(armed).toEqual([false]);
+      expect(runConfigSet).not.toHaveBeenCalled();
 
-    const wrongProposal = await engine.resolveOperatorApproval("allow-once", "wrong-hash");
-    expect(wrongProposal).toBeNull();
-    expect(runConfigSet).not.toHaveBeenCalled();
+      const wrongProposal = await engine.resolveOperatorApproval("allow-once", "wrong-hash");
+      expect(wrongProposal).toBeNull();
+      expect(runConfigSet).not.toHaveBeenCalled();
 
-    const applied = await engine.resolveOperatorApproval("allow-once", proposalHash);
-    const duplicate = await engine.resolveOperatorApproval("allow-once", proposalHash);
-    await engine.handle("what changed?");
+      const applied = await engine.resolveOperatorApproval(decision, proposalHash);
+      const duplicate = await engine.resolveOperatorApproval(decision, proposalHash);
+      await engine.handle("what changed?");
 
-    expect(armed).toEqual([false, false]);
-    expect(runConfigSet).toHaveBeenCalledOnce();
-    expect(runConfigSet).toHaveBeenCalledWith({
-      path: "gateway.port",
-      value: "19001",
-      cliOptions: {},
-    });
-    expect(applied?.text).toContain("[openclaw] done: config.set");
-    expect(duplicate).toBeNull();
-    expect(observedInputs[1]).toContain("[proposal-resolved]");
-    expect(observedInputs[1]).toContain("was approved");
-    expect(observedInputs[1]).not.toContain("host-seeded");
-  });
-
-  it("refuses delegated hosted-setup directives instead of starting wizards", async () => {
-    useTempStateDir();
-    const runChannelSetupWizard = vi.fn(async () => {});
-    const runSkillsSetupWizard = vi.fn(async () => {});
-    const runSearchSetupWizard = vi.fn(async () => {});
-    const runMemoryImportWizard = vi.fn(async () => ({
-      status: "nothing-to-import" as const,
-      providers: [],
-    }));
-    const engine = new SystemAgentChatEngine({
-      operatorApprovalOnly: true,
-      runAgentTurn: async () => ({
-        text: "Setting up.",
-        directive: { kind: "channel-setup", channel: "telegram" },
-      }),
-      runChannelSetupWizard,
-      runSkillsSetupWizard,
-      runSearchSetupWizard,
-      runMemoryImportWizard,
-      deps: { loadOverview: fakeOverviewLoader() },
-    });
-
-    const reply = await engine.handle("connect telegram");
-
-    expect(reply.text).toContain("human operator");
-    expect(reply.action).toBe("none");
-    expect((await engine.handle("configure skills")).text).toContain("human operator");
-    expect((await engine.handle("configure search")).text).toContain("human operator");
-    expect((await engine.handle("import memory")).text).toContain("human operator");
-    expect(runChannelSetupWizard).not.toHaveBeenCalled();
-    expect(runSkillsSetupWizard).not.toHaveBeenCalled();
-    expect(runSearchSetupWizard).not.toHaveBeenCalled();
-    expect(runMemoryImportWizard).not.toHaveBeenCalled();
-  });
+      expect(armed).toEqual([false, false]);
+      expect(duplicate).toBeNull();
+      expect(observedInputs[1]).toContain("[proposal-resolved]");
+      if (decision === "allow-once") {
+        expect(runConfigSet).toHaveBeenCalledOnce();
+        expect(runConfigSet).toHaveBeenCalledWith({
+          path: "gateway.port",
+          value: "19001",
+          cliOptions: {},
+        });
+        expect(applied?.text).toContain("[openclaw] done: config.set");
+        expect(observedInputs[1]).toContain("was approved");
+      } else {
+        expect(runConfigSet).not.toHaveBeenCalled();
+        expect(applied?.text).toBe("Denied. No change.");
+        expect(observedInputs[1]).toContain("was declined");
+      }
+      expect(observedInputs[1]).not.toContain("host-seeded");
+    },
+  );
 
   it("applies a delegated host proposal without another model turn", async () => {
     useTempStateDir();
@@ -184,7 +160,7 @@ describe("SystemAgentChatEngine approval", () => {
     expect(runAgentTurn).not.toHaveBeenCalled();
     expect(runConfigSet).toHaveBeenCalledOnce();
     expect(applied?.text).toContain("[openclaw] done: config.set");
-    expect(engine.hasPendingProposal()).toBe(false);
+    expect(engine.getPendingOperatorProposal()).toBeNull();
   });
 
   it("applies a seeded proposal on a bare yes with verified inference", async () => {
@@ -194,13 +170,19 @@ describe("SystemAgentChatEngine approval", () => {
 
     const plan = engine.propose({ kind: "config-set", path: "gateway.port", value: "19001" });
     expect(plan).toContain("gateway.port");
-    expect(engine.hasPendingProposal()).toBe(true);
+    expect(engine.getPendingOperatorProposal()?.operation).toEqual({
+      kind: "config-set",
+      path: "gateway.port",
+      value: "19001",
+    });
 
     const reply = await engine.handle("yes");
     expect(runConfigSet).toHaveBeenCalledOnce();
     expect(reply.action).toBe("none");
     expect(reply.text).toContain("[openclaw] done: config.set");
-    expect(engine.hasPendingProposal()).toBe(false);
+    expect(reply.agentDraft).toBeUndefined();
+    expect(reply.handoff).toBeUndefined();
+    expect(engine.getPendingOperatorProposal()).toBeNull();
   });
 
   it("hatches into the agent after a fresh setup applies", async () => {
@@ -403,19 +385,6 @@ describe("SystemAgentChatEngine approval", () => {
     expect(reply.text).not.toContain("Your agent is hatching");
   });
 
-  it("does not hand off when a non-setup persistent operation applies", async () => {
-    useTempStateDir();
-    const runConfigSet = vi.fn(async () => {});
-    const engine = new SystemAgentChatEngine({ deps: { runConfigSet } });
-    engine.propose({ kind: "config-set", path: "gateway.port", value: "19002" });
-
-    const reply = await engine.handle("yes");
-
-    expect(reply.action).toBe("none");
-    expect(reply.agentDraft).toBeUndefined();
-    expect(reply.handoff).toBeUndefined();
-  });
-
   it("routes model provider changes out of the active inference session", async () => {
     const engine = new SystemAgentChatEngine({
       surface: "gateway",
@@ -440,16 +409,6 @@ describe("SystemAgentChatEngine approval", () => {
     expect(reply.text).not.toContain("Exit OpenClaw");
   });
 
-  it("keeps the current inference route when model provider setup is declined", async () => {
-    const engine = new SystemAgentChatEngine();
-    engine.propose({ kind: "model-setup" });
-
-    const reply = await engine.handle("not now");
-
-    expect(reply.text).toContain("current inference route is unchanged");
-    expect(engine.hasPendingProposal()).toBe(false);
-  });
-
   it("drops the proposal when the user declines", async () => {
     const runConfigSet = vi.fn(async () => {});
     const engine = new SystemAgentChatEngine({ deps: { runConfigSet } });
@@ -458,7 +417,7 @@ describe("SystemAgentChatEngine approval", () => {
     const reply = await engine.handle("no thanks");
     expect(runConfigSet).not.toHaveBeenCalled();
     expect(reply.text).toContain("Skipped");
-    expect(engine.hasPendingProposal()).toBe(false);
+    expect(engine.getPendingOperatorProposal()).toBeNull();
   });
 
   it("voids an agent-loop proposal on decline and lets the AI acknowledge", async () => {
@@ -517,41 +476,57 @@ describe("SystemAgentChatEngine approval", () => {
   });
 
   it("clears a stale host proposal once the agent loop owns the conversation", async () => {
+    const operation = { kind: "config-set", path: "gateway.port", value: "19002" } as const;
+    const hash = hashSystemAgentOperation(operation);
+    const runAgentTurn = vi.fn(async (params: Parameters<SystemAgentTurnRunner>[0]) => {
+      params.session.proposalRef.current = hash;
+      params.session.proposalRef.operation = operation;
+      return { text: "loop reply" };
+    });
     const router = createRouterHarness({
-      runAgentTurn: async (params) => {
-        params.session.proposalRef.current = "agent-proposal";
-        return { text: "loop reply" };
-      },
-      classifyApproval: async () => "other",
+      runAgentTurn,
+      classifyApproval: async ({ message }) => classifySystemAgentApprovalText(message),
     });
     router.propose({ kind: "config-set", path: "gateway.port", value: "19001" });
 
     await router.resolveTurn("actually, tell me about workspaces first");
 
-    // A later approval must arm the loop's own proposal, not the stale one.
-    expect(router.hasPendingProposal()).toBe(false);
+    expect(router.getPendingOperatorProposal()).toEqual({ operation, hash });
+    await router.resolveTurn("yes");
+
+    expect(runAgentTurn.mock.calls.map(([params]) => params.approvalArmed)).toEqual([false, true]);
+    expect(runAgentTurn.mock.calls[1]?.[0].input).not.toContain("host-seeded");
   });
 
-  it("keeps a host setup proposal when the loop only answers a question", async () => {
-    let observedInput = "";
-    const router = createRouterHarness({
-      runAgentTurn: async (params) => {
-        observedInput = params.input;
-        return { text: "A workspace is where your agent keeps its project files." };
-      },
-      classifyApproval: async () => "other",
-    });
-    router.propose({
+  it("keeps a host setup proposal across approval reads and follow-up questions", async () => {
+    const operation = {
       kind: "setup",
       workspace: "/tmp/work",
       model: "openai/gpt-5.5",
+    } as const;
+    const proposal = { operation, hash: hashSystemAgentOperation(operation) };
+    const runAgentTurn = vi.fn(async (_params: Parameters<SystemAgentTurnRunner>[0]) => ({
+      text: "A workspace is where your agent keeps its project files.",
+    }));
+    const router = createRouterHarness({
+      runAgentTurn,
+      classifyApproval: async ({ message }) => classifySystemAgentApprovalText(message),
     });
+    router.propose(operation);
+
+    expect(router.getPendingOperatorProposal()).toEqual(proposal);
+    expect(router.getPendingOperatorProposal()).toEqual(proposal);
 
     await router.resolveTurn("what does workspace mean?");
 
-    expect(router.hasPendingProposal()).toBe(true);
-    expect(observedInput).toContain('"model":"openai/gpt-5.5"');
-    expect(observedInput).toContain("Keep the verified model");
+    expect(router.getPendingOperatorProposal()).toEqual(proposal);
+    expect(runAgentTurn.mock.calls[0]?.[0].input).toContain('"model":"openai/gpt-5.5"');
+    expect(runAgentTurn.mock.calls[0]?.[0].input).toContain("Keep the verified model");
+
+    await router.resolveTurn("yes");
+
+    expect(runAgentTurn).toHaveBeenCalledOnce();
+    expect(router.getPendingOperatorProposal()).toBeNull();
   });
 
   it("preserves the verified setup model when planner fallback changes only the workspace", async () => {
@@ -757,7 +732,11 @@ describe("SystemAgentChatEngine approval", () => {
     expect(planner).not.toHaveBeenCalled();
     expect(proposed.text).toContain("<redacted>");
     expect(proposed.text).not.toContain("very-secret");
-    expect(engine.hasPendingProposal()).toBe(true);
+    expect(engine.getPendingOperatorProposal()?.operation).toEqual({
+      kind: "config-set",
+      path,
+      value,
+    });
 
     const applied = await engine.handle("yes");
     expect(runConfigSet).toHaveBeenCalledOnce();
@@ -784,7 +763,11 @@ describe("SystemAgentChatEngine approval", () => {
     expect(proposed.text).toContain(path);
     expect(proposed.text).toContain(shown);
     expect(proposed.text).not.toContain("<redacted>");
-    expect(engine.hasPendingProposal()).toBe(true);
+    expect(engine.getPendingOperatorProposal()?.operation).toEqual({
+      kind: "config-set",
+      path,
+      value,
+    });
   });
 
   it("host-routes validated SecretRef writes without exposing the command to a model", async () => {
@@ -803,7 +786,12 @@ describe("SystemAgentChatEngine approval", () => {
     expect(planner).not.toHaveBeenCalled();
     expect(proposed.text).toContain("env SecretRef <redacted>");
     expect(proposed.text).not.toContain("GATEWAY_TOKEN");
-    expect(engine.hasPendingProposal()).toBe(true);
+    expect(engine.getPendingOperatorProposal()?.operation).toEqual({
+      kind: "config-set-ref",
+      path: "gateway.auth.token",
+      source: "env",
+      id: "GATEWAY_TOKEN",
+    });
   });
 
   it("keeps valid SecretRef ids out of pending context and later history", async () => {
@@ -849,7 +837,12 @@ describe("SystemAgentChatEngine approval", () => {
     expect(planner).not.toHaveBeenCalled();
     expect(proposed.text).toContain(path);
     expect(proposed.text).not.toContain("TELEGRAM_TOKEN");
-    expect(engine.hasPendingProposal()).toBe(true);
+    expect(engine.getPendingOperatorProposal()?.operation).toEqual({
+      kind: "config-set-ref",
+      path,
+      source: "env",
+      id: "TELEGRAM_TOKEN",
+    });
   });
 
   it.each([
@@ -931,7 +924,7 @@ describe("SystemAgentChatEngine approval", () => {
     expect(proposed.text).toContain("Invalid config path");
     expect(proposed.text).not.toContain("very-secret");
     expect(proposed.text).not.toContain("abcDEF123");
-    expect(engine.hasPendingProposal()).toBe(false);
+    expect(engine.getPendingOperatorProposal()).toBeNull();
   });
 
   it.each([
@@ -1112,6 +1105,9 @@ describe("SystemAgentChatEngine approval", () => {
     expect(reply.text).toContain("Refused:");
     expect(reply.text).toContain("was not applied from this chat");
     expect(reply.text).not.toContain("Say yes to apply");
-    expect(engine.hasPendingProposal()).toBe(true);
+    expect(engine.getPendingOperatorProposal()?.operation).toEqual({
+      kind: "set-default-model",
+      model: "openai/gpt-5.5",
+    });
   });
 });

--- a/src/system-agent/chat-turn-router.operations.test.ts
+++ b/src/system-agent/chat-turn-router.operations.test.ts
@@ -21,6 +21,7 @@ import {
 } from "./chat-engine.test-support.js";
 import { ChatTurnRouter } from "./chat-turn-router.js";
 import { ChatWizardHost } from "./chat-wizard-host.js";
+import type { SystemAgentOperation } from "./operation-types.js";
 import { installSystemAgentClaudeCliBackendTestFixture } from "./system-agent.test-helpers.js";
 
 const loggingMocks = vi.hoisted(() => ({ chatWarn: vi.fn() }));
@@ -82,6 +83,55 @@ function createRouterHarness(
 }
 
 describe("SystemAgentChatEngine operations", () => {
+  describe.each(["typed", "tool", "planner"] as const)("delegated %s navigation", (source) => {
+    it.each([
+      ["connect telegram", { kind: "channel-setup", channel: "telegram" }],
+      ["configure skills", { kind: "skills-setup" }],
+      ["configure search", { kind: "search-setup" }],
+      ["configure gateway", { kind: "gateway-config-setup" }],
+      ["import memory", { kind: "memory-import" }],
+      ["model setup", { kind: "model-setup" }],
+      ["open channel wizard", { kind: "open-setup", target: "channels" }],
+      ["talk to agent", { kind: "open-tui" }],
+    ] satisfies Array<[string, SystemAgentOperation]>)(
+      "keeps %s with the operator",
+      async (command, directive) => {
+        const startWizard = vi.fn(async () => {});
+        const importMemory = vi.fn(async () => ({
+          status: "workspace-missing" as const,
+          providers: [] as [],
+          workspace: "/tmp/openclaw-no-workspace",
+        }));
+        const router = createRouterHarness(
+          {
+            operatorApprovalOnly: true,
+            runAgentTurn: async () =>
+              source === "tool" ? { text: "Opening setup.", directive } : null,
+            planWithAssistant: async () => ({ command }),
+          },
+          {
+            wizardDependencies: {
+              runChannelSetupWizard: startWizard,
+              runSkillsSetupWizard: startWizard,
+              runSearchSetupWizard: startWizard,
+              runGatewaySetupWizard: startWizard,
+              runMemoryImportWizard: importMemory,
+            },
+          },
+        );
+
+        const reply = await router.resolveTurn(source === "typed" ? command : "help me set up");
+
+        expect(reply.action).toBe("none");
+        expect(reply.handoff).toBeUndefined();
+        expect(reply.step).toBeUndefined();
+        expect(reply.text).toContain("cannot run from a delegated agent request");
+        expect(startWizard).not.toHaveBeenCalled();
+        expect(importMemory).not.toHaveBeenCalled();
+      },
+    );
+  });
+
   it("handles the exact agent handoff without consulting a usable model", async () => {
     const runAgentTurn = vi.fn(async () => ({ text: "model reply without a directive" }));
     const engine = new SystemAgentChatEngine({
@@ -414,7 +464,10 @@ describe("SystemAgentChatEngine operations", () => {
     expect(reply.text).toContain("Let's point your agent at gpt-5.5.");
     expect(reply.text).toContain("(claude-cli → `set default model openai/gpt-5.5`)");
     expect(reply.text).toContain("Apply this operation");
-    expect(router.hasPendingProposal()).toBe(true);
+    expect(router.getPendingOperatorProposal()?.operation).toEqual({
+      kind: "set-default-model",
+      model: "openai/gpt-5.5",
+    });
   });
 
   it("records an executor-reported interactive exit without sniffing reply text", async () => {
@@ -527,7 +580,11 @@ describe("SystemAgentChatEngine operations", () => {
     expect(reply.text).toContain("That port was not a number");
     expect(reply.text).toContain("config set gateway.port 18789");
     // The corrective write is proposed, not auto-applied.
-    expect(engine.hasPendingProposal()).toBe(true);
+    expect(engine.getPendingOperatorProposal()?.operation).toEqual({
+      kind: "config-set",
+      path: "gateway.port",
+      value: "18789",
+    });
     expect(planner.mock.calls[0]?.[0]?.input).toContain("[config-verify]");
   });
 

--- a/src/system-agent/chat-turn-router.ts
+++ b/src/system-agent/chat-turn-router.ts
@@ -24,17 +24,20 @@ import {
   SystemAgentInferenceUnavailableError,
   isSystemAgentInferenceUnavailableError,
 } from "./inference-error.js";
+import { isSystemAgentNavigationOperation } from "./operation-types.js";
 import { isInvalidConfigSetOperation } from "./operations-internal.js";
 import {
   describeSystemAgentPersistentOperation,
   executeSystemAgentOperation,
   isPersistentSystemAgentOperation,
   parseSystemAgentOperation,
+  SYSTEM_AGENT_OPERATOR_NAVIGATION_HANDOFF,
   type SystemAgentCommandDeps,
   type SystemAgentOperation,
   type SystemAgentOperationResult,
 } from "./operations.js";
 import {
+  hashSystemAgentOperation,
   resolveOperatorApprovalDecision,
   resolvePendingOperatorProposal,
   type SystemAgentApprovalIntent,
@@ -158,22 +161,17 @@ export class ChatTurnRouter {
     return describeSystemAgentPersistentOperation(this.pending);
   }
 
-  hasPendingProposal(): boolean {
-    return this.pending !== null;
-  }
-
   getPendingOperatorProposal(): { operation: SystemAgentOperation; hash: string } | null {
-    const proposalOperation = this.agentSession.proposalRef.operation;
-    if (proposalOperation) {
-      const recordedOperation = this.recordCreateAgentRequester(proposalOperation);
-      if (recordedOperation !== proposalOperation) {
-        // Request provenance is part of the exact approval-bound operation.
-        // Replace the model-tool hash before exposing the proposal to the operator.
-        this.agentSession.proposalRef.current = undefined;
-        this.agentSession.proposalRef.operation = recordedOperation;
-      }
+    const proposal = resolvePendingOperatorProposal(this.pending, this.agentSession.proposalRef);
+    if (!proposal) {
+      return null;
     }
-    return resolvePendingOperatorProposal(this.pending, this.agentSession.proposalRef);
+    const operation = this.recordCreateAgentRequester(proposal.operation);
+    // Request provenance participates in approval identity, but reading the
+    // operator projection must not transfer ownership of a host-seeded plan.
+    return operation === proposal.operation
+      ? proposal
+      : { operation, hash: hashSystemAgentOperation(operation) };
   }
 
   async resolveOperatorApproval(
@@ -189,15 +187,16 @@ export class ChatTurnRouter {
         this.proposalResolution = "approved";
         return await this.applyApprovedPersistentOperation(operation);
       },
-      denied: () => ({ text: "Denied. No change.", action: "none" as const }),
+      denied: () => {
+        this.proposalResolution = "declined";
+        return { text: "Denied. No change.", action: "none" as const };
+      },
     });
   }
 
   clearForInferenceLoss(): void {
-    this.pending = null;
+    this.clearPendingProposals();
     this.proposalResolution = undefined;
-    this.agentSession.proposalRef.current = undefined;
-    this.agentSession.proposalRef.operation = undefined;
     this.awaitingSetupChannel = false;
     this.lastSensitiveChannel = undefined;
   }
@@ -257,23 +256,7 @@ export class ChatTurnRouter {
     ) {
       return await this.runOperation(typed, undefined);
     }
-    const typedRefusal = this.refuseDelegatedNavigationDirective(typed.kind);
-    if (typedRefusal) {
-      return { text: typedRefusal, action: "none" };
-    }
-    if (typed.kind === "open-tui") {
-      this.clearPendingProposals();
-      return await this.runOperation(typed, undefined);
-    }
-    if (
-      typed.kind === "open-setup" ||
-      typed.kind === "channel-setup" ||
-      typed.kind === "skills-setup" ||
-      typed.kind === "search-setup" ||
-      typed.kind === "gateway-config-setup" ||
-      typed.kind === "memory-import" ||
-      typed.kind === "model-setup"
-    ) {
+    if (isSystemAgentNavigationOperation(typed)) {
       return await this.runOperation(typed, undefined);
     }
 
@@ -286,13 +269,10 @@ export class ChatTurnRouter {
         return await this.applyPendingProposal(this.pending);
       }
       if (intent === "decline") {
-        const skippedModelSetup = this.pending.kind === "model-setup";
         this.clearPendingProposals();
         this.proposalResolution = "declined";
         return {
-          text: skippedModelSetup
-            ? "Skipped. The current inference route is unchanged."
-            : "Skipped. No barnacles on config today.",
+          text: "Skipped. No barnacles on config today.",
           action: "none",
         };
       }
@@ -327,15 +307,6 @@ export class ChatTurnRouter {
   private async applyPendingProposal(pending: SystemAgentOperation): Promise<SystemAgentChatReply> {
     this.clearPendingProposals();
     this.proposalResolution = "approved";
-    if (pending.kind === "channel-setup") {
-      return await this.startWizard(this.wizard.startChannel(pending.channel));
-    }
-    if (pending.kind === "model-setup") {
-      return this.startModelSetup();
-    }
-    if (!isPersistentSystemAgentOperation(pending)) {
-      return await this.runOperation(pending, undefined);
-    }
     return await this.applyApprovedPersistentOperation(pending);
   }
 
@@ -475,61 +446,20 @@ export class ChatTurnRouter {
   }): Promise<SystemAgentChatReply> {
     await this.callbacks.requireVerifiedInference();
     const directive = loopReply.directive;
-    const refusal = this.refuseDelegatedNavigationDirective(directive?.kind);
-    if (refusal) {
-      return { text: [loopReply.text, refusal].filter(Boolean).join("\n\n"), action: "none" };
+    if (!directive) {
+      return { text: loopReply.text, action: "none" };
     }
-    if (directive?.kind === "approved-operation") {
-      const applied = await this.applyApprovedPersistentOperation(directive.operation);
-      return { ...applied, text: [loopReply.text, applied.text].filter(Boolean).join("\n\n") };
-    }
-    if (directive?.kind === "channel-setup") {
-      return await this.prependWizard(loopReply.text, this.wizard.startChannel(directive.channel));
-    }
-    if (directive?.kind === "skills-setup") {
-      return await this.prependWizard(loopReply.text, this.wizard.startSkills());
-    }
-    if (directive?.kind === "search-setup") {
-      return await this.prependWizard(loopReply.text, this.wizard.startSearch());
-    }
-    if (directive?.kind === "gateway-config-setup") {
-      return await this.prependWizard(loopReply.text, this.wizard.startGateway());
-    }
-    if (directive?.kind === "memory-import") {
-      return await this.prependWizard(loopReply.text, this.wizard.startMemoryImport());
-    }
-    if (directive?.kind === "model-setup") {
-      const setup = this.startModelSetup();
-      return { ...setup, text: [loopReply.text, setup.text].filter(Boolean).join("\n\n") };
-    }
-    if (directive?.kind === "open-tui") {
-      this.clearPendingProposals();
-      return { text: loopReply.text, action: "open-tui", handoff: directive };
-    }
-    if (directive?.kind === "open-setup") {
-      const handoff = await this.runOperation(directive, undefined);
-      return { ...handoff, text: [loopReply.text, handoff.text].filter(Boolean).join("\n\n") };
-    }
-    return { text: loopReply.text, action: "none" };
-  }
-
-  private refuseDelegatedNavigationDirective(kind: string | undefined): string | undefined {
-    if (!this.options.operatorApprovalOnly) {
-      return undefined;
-    }
-    if (
-      kind === "channel-setup" ||
-      kind === "skills-setup" ||
-      kind === "search-setup" ||
-      kind === "gateway-config-setup" ||
-      kind === "memory-import" ||
-      kind === "model-setup" ||
-      kind === "open-setup" ||
-      kind === "open-tui"
-    ) {
-      return "Channel, model, and setup flows need a human operator in the OpenClaw app; they cannot run from a delegated agent request.";
-    }
-    return undefined;
+    const reply =
+      directive.kind === "approved-operation"
+        ? await this.applyApprovedPersistentOperation(directive.operation)
+        : await this.runOperation(directive, undefined);
+    return {
+      ...reply,
+      text:
+        directive.kind === "open-tui" && reply.action === "open-tui"
+          ? loopReply.text
+          : [loopReply.text, reply.text].filter(Boolean).join("\n\n"),
+    };
   }
 
   private async runOperation(
@@ -538,6 +468,14 @@ export class ChatTurnRouter {
   ): Promise<SystemAgentChatReply> {
     const recordedOperation = this.recordCreateAgentRequester(operation);
     await this.callbacks.requireVerifiedInference();
+    // All inputs (typed commands, tool directives, and planner fallback) enter
+    // here before any wizard or handoff starts.
+    if (this.options.operatorApprovalOnly && isSystemAgentNavigationOperation(recordedOperation)) {
+      return {
+        text: SYSTEM_AGENT_OPERATOR_NAVIGATION_HANDOFF,
+        action: "none",
+      };
+    }
     if (recordedOperation.kind === "open-tui") {
       this.clearPendingProposals();
       return {
@@ -669,14 +607,6 @@ export class ChatTurnRouter {
       this.lastSensitiveChannel = resolved.sensitiveChannel;
     }
     return { text: await this.finishWizardText(resolved), action: "none" };
-  }
-
-  private async prependWizard(
-    prefix: string,
-    result: Promise<ChatWizardResult>,
-  ): Promise<SystemAgentChatReply> {
-    const reply = await this.startWizard(result);
-    return { ...reply, text: [prefix, reply.text].filter(Boolean).join("\n\n") };
   }
 
   private async finishWizardText(result: ChatWizardResult): Promise<string> {

--- a/src/system-agent/chat-wizard-host.test.ts
+++ b/src/system-agent/chat-wizard-host.test.ts
@@ -344,7 +344,7 @@ describe("SystemAgentChatEngine wizard", () => {
     const laterApproval = await engine.handle("yes");
 
     expect(cancelled.text).toContain("cancelled");
-    expect(engine.hasPendingProposal()).toBe(false);
+    expect(engine.getPendingOperatorProposal()).toBeNull();
     expect(runConfigSet).not.toHaveBeenCalled();
     expect(runAgentTurn.mock.calls.at(-1)?.[0]?.approvalArmed).toBe(false);
     expect(laterApproval.text).toContain("No pending change");

--- a/src/system-agent/operation-types.ts
+++ b/src/system-agent/operation-types.ts
@@ -23,19 +23,9 @@ export type SystemAgentOperation =
       provider?: string;
     }
   | { kind: "setup"; workspace?: string; model?: string; agentName?: string }
-  | { kind: "model-setup"; workspace?: string }
+  | SystemAgentNavigationOperation
   | { kind: "channel-list" }
   | { kind: "channel-info"; channel: string }
-  | { kind: "channel-setup"; channel: string }
-  | { kind: "skills-setup" }
-  | { kind: "search-setup" }
-  | { kind: "gateway-config-setup" }
-  | { kind: "memory-import" }
-  | {
-      kind: "open-setup";
-      target: "guided" | "classic" | "channels" | "search" | "gateway";
-      channel?: string;
-    }
   | { kind: "gateway-status" }
   | { kind: "gateway-start" }
   | { kind: "gateway-stop" }
@@ -54,5 +44,37 @@ export type SystemAgentOperation =
       model?: string;
       requesterAgentId?: string;
     }
-  | { kind: "open-tui"; agentId?: string; workspace?: string; agentDraft?: "hatch" }
   | { kind: "set-default-model"; model: string; agentId?: string };
+
+/** Interactive actions owned by the host chat, never by delegated model turns. */
+export type SystemAgentNavigationOperation =
+  | { kind: "model-setup"; workspace?: string }
+  | { kind: "channel-setup"; channel: string }
+  | { kind: "skills-setup" }
+  | { kind: "search-setup" }
+  | { kind: "gateway-config-setup" }
+  | { kind: "memory-import" }
+  | {
+      kind: "open-setup";
+      target: "guided" | "classic" | "channels" | "search" | "gateway";
+      channel?: string;
+    }
+  | { kind: "open-tui"; agentId?: string; workspace?: string; agentDraft?: "hatch" };
+
+export function isSystemAgentNavigationOperation(
+  operation: SystemAgentOperation,
+): operation is SystemAgentNavigationOperation {
+  switch (operation.kind) {
+    case "channel-setup":
+    case "skills-setup":
+    case "search-setup":
+    case "gateway-config-setup":
+    case "memory-import":
+    case "model-setup":
+    case "open-setup":
+    case "open-tui":
+      return true;
+    default:
+      return false;
+  }
+}

--- a/src/system-agent/operations-parse.ts
+++ b/src/system-agent/operations-parse.ts
@@ -565,6 +565,9 @@ export function describeSystemAgentPersistentOperation(operation: SystemAgentOpe
 export const SYSTEM_AGENT_OPERATOR_APPROVAL_HANDOFF =
   "This change needs operator approval and cannot be applied from this chat. Approve it in the OpenClaw operator UI (`openclaw dashboard` on the Gateway host), or run the change there with `openclaw setup`.";
 
+export const SYSTEM_AGENT_OPERATOR_NAVIGATION_HANDOFF =
+  "Channel, model, and setup flows need a human operator in the OpenClaw app; they cannot run from a delegated agent request. Open `openclaw dashboard` or run `openclaw setup` on the Gateway host.";
+
 /** Format the standard approval plan text for a persistent operation. */
 export function formatSystemAgentPersistentPlan(
   operation: SystemAgentOperation,

--- a/src/system-agent/operator-approval.ts
+++ b/src/system-agent/operator-approval.ts
@@ -1,8 +1,14 @@
 // Human-only arming for delegated OpenClaw changes.
-import { hashSystemAgentOperation } from "../agents/tools/system-agent-tool.js";
-import { isPersistentSystemAgentOperation, type SystemAgentOperation } from "./operations.js";
+import { createHash } from "node:crypto";
+import { stableStringify } from "@openclaw/normalization-core";
+import { isPersistentSystemAgentOperation, type SystemAgentOperation } from "./operations-parse.js";
 
-type ProposalRef = { current?: string; operation?: SystemAgentOperation };
+export type SystemAgentProposalRef = { current?: string; operation?: SystemAgentOperation };
+
+/** Canonical operation fingerprint used to bind approval to one exact mutation. */
+export function hashSystemAgentOperation(operation: SystemAgentOperation): string {
+  return createHash("sha256").update(stableStringify(operation)).digest("hex");
+}
 
 export type SystemAgentApprovalIntent = "approve" | "decline" | "other";
 
@@ -30,7 +36,7 @@ export function classifySystemAgentApprovalText(message: string): SystemAgentApp
 
 export function resolvePendingOperatorProposal(
   pending: SystemAgentOperation | null,
-  proposalRef: ProposalRef,
+  proposalRef: SystemAgentProposalRef,
 ): { operation: SystemAgentOperation; hash: string } | null {
   const operation = pending ?? proposalRef.operation;
   if (!operation || !isPersistentSystemAgentOperation(operation)) {
@@ -40,8 +46,6 @@ export function resolvePendingOperatorProposal(
   if (proposalRef.current && proposalRef.current !== hash) {
     return null;
   }
-  proposalRef.current = hash;
-  proposalRef.operation = operation;
   return { operation, hash };
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where delegated OpenClaw setup requests could start an interactive wizard through the planner fallback even though the same request was refused through direct commands and tool directives. The tool also promised handoffs that the host could not perform. After an operator denied or let a proposal expire, the model was not told that the proposal had been resolved.

This is the maintainer-requested cleanup follow-up to #117432 (delegated approval guidance, originally contributed by @SunnyShu0925).

## Why This Change Was Made

Typed commands, tool directives, and planner fallback now share the same host navigation dispatcher and operation contract. The tool returns operator guidance before promising an unavailable delegated handoff. Approval hashing and shared proposal state belong to the approval owner rather than the tool implementation, and reading a pending proposal no longer changes its ownership. Operator denials and timeouts record the same resolution marker used by other completed decisions.

Removed duplicate directive copies and dispatch branches, the test-only pending-status API, obsolete nonpersistent approval branches, and redundant tests. Host-seeded proposals still apply directly after approval; tool proposals still pass through an armed model turn. Exact-operation matching, requester attribution, inference revalidation, one-use approval, and direct operator setup remain intact. No configuration, environment variable, protocol, permission, or SQLite/persistence contract changes.

## User Impact

Delegated chat consistently directs users to the operator surface for interactive setup instead of starting an inaccessible wizard or promising that one is opening. A rejected or expired proposal is no longer presented to the next model turn as pending. Direct operator setup and approved writes continue to work as before.

Production: +107/-192 (**net -85**). Tests and test support: +222/-144 (net +78). Docs: +2. No dependency or generated-file changes. AI-assisted with Codex.

## Evidence

Before the fixes, the regression table passed all 16 direct-command/tool-directive refusal cases but failed all eight planner-fallback cases. The operator lifecycle regression failed for both denial and timeout, and all eight tool-producer cases incorrectly promised delegated handoffs. These same regressions now pass.

324 focused tests passed across nine files:

```sh
node scripts/run-vitest.mjs src/system-agent/chat-turn-router.approval.test.ts src/system-agent/chat-turn-router.operations.test.ts src/system-agent/chat-wizard-host.test.ts src/agents/tools/system-agent-tool.test.ts src/mcp/openclaw-tools-serve.test.ts src/system-agent/agent-turn.test.ts src/gateway/server-methods/system-agent.test.ts src/system-agent/operations.test.ts src/agents/cli-runner/bundle-mcp.resume.test.ts --maxWorkers=2
```

The coverage includes all eight navigation kinds through typed, tool, and planner entrypoints; direct hosted setup; exact proposal replacement; repeated proposal reads followed by questions and approval; requester-bound creation; inference changes; cancellation; Gateway approval registration/application; and CLI resume identity.

A real stdio MCP subprocess probe passed three write modes (delegated, direct unarmed, direct host-approved), all eight delegated navigation actions, and direct channel navigation. It used an isolated temporary HOME/state directory and called the real MCP server with the SDK client. Delegated navigation returned operator guidance with no mirrored directive; direct channel navigation still returned `channel-setup`. No operator config or real messaging account was used.

The full changed-file gate (`scripts/check-changed.mjs`, explicitly scoped to all 14 changed paths) and `pnpm build` passed. `pnpm docs:list` and `git diff --check` passed. The MCP probe also passed against the built server.

The initial CI run failed in an unrelated Gateway test inherited from main: it imported a private helper. The existing repair #131627 merged, and this branch was rebased onto it without changing the system-agent patch. All three Gateway rollback/manual-stop cases pass locally after that rebase. Exact-head [CI passed](https://github.com/openclaw/openclaw/actions/runs/33154443622) on `7682ee0a9c78e07f109620de3ef54b67a2c70aef`.

Fresh Codex Autoreview: no accepted/actionable findings. The latest stable release tag `v2026.7.1-2` predates `src/system-agent`; this is a current-main repair, not a stable-release regression claim.

Upstream Codex source personally checked at `6be2a6ca952ac9f70676ce4dd07fda27175aa9dd`: `codex-rs/rmcp-client/src/utils.rs:16–58` preserves explicit MCP environment overrides, `stdio_server_launcher.rs:265–291` launches with that environment, and `codex-rs/protocol/src/shell_environment.rs:14–26` defines the exact non-inheritable names. The existing OpenClaw transport values and result markers are unchanged.

Proof limits: no live messaging-account or full Codex orchestration run. The isolated subprocess has no channel credentials, and the operator's running Gateway was not used. Completion delivery back to the originating chat remains a separate follow-up: Gateway approval callbacks still discard the detailed completion reply. This PR deliberately does not change transcript persistence or delivery semantics. Human setup handoff product work remains tracked in #112077.

<details>
<summary>Reproducible MCP subprocess probe and observed output</summary>

Save this as `.local/approval-refactor-stdio-proof.mjs` in an installed checkout and run `node --import tsx .local/approval-refactor-stdio-proof.mjs`. It does not perform persistent writes.

```js
import assert from 'node:assert/strict';
import { mkdtemp, rm } from 'node:fs/promises';
import os from 'node:os';
import path from 'node:path';
import { Client } from '@modelcontextprotocol/sdk/client/index.js';
import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
import { buildSystemAgentToolsMcpServerConfig } from '../src/mcp/openclaw-tools-serve-config.ts';
import { hashSystemAgentOperation } from '../src/system-agent/operator-approval.ts';
import { resolveSystemAgentDirectiveTransition } from '../src/agents/tools/system-agent-tool.ts';
const state = await mkdtemp(path.join(os.tmpdir(), 'openclaw-approval-refactor-'));
const operation = { kind: 'config-set', path: 'agents.defaults.subagents.thinking', value: 'high' };
const hash = hashSystemAgentOperation(operation);
try {
  for (const mode of ['delegated', 'direct', 'direct-approved']) {
    const config = buildSystemAgentToolsMcpServerConfig({
      surface: 'cli',
      operatorApprovalOnly: mode === 'delegated',
      approvalArmed: mode === 'direct-approved',
      proposalRef: { current: hash },
    });
    const server = config.mcpServers.openclaw;
    const transport = new StdioClientTransport({
      command: server.command, args: server.args,
      env: { PATH: process.env.PATH, HOME: state, OPENCLAW_STATE_DIR: state, ...server.env },
      stderr: 'pipe',
    });
    const client = new Client({ name: 'approval-handoff-proof', version: '1.0.0' });
    const timer = setTimeout(() => void client.close(), 90000);
    try {
      await client.connect(transport);
      const result = await client.callTool({ name: 'openclaw', arguments: {
        action: 'config_set', path: operation.path, value: operation.value, approved: true,
      }});
      const text = result.content.filter(x => x.type === 'text').map(x => x.text).join('\n');
      if (mode === 'delegated') {
        assert.match(text, /needs-approval:/);
        assert.match(text, /cannot be applied from this chat/);
        assert.match(text, /openclaw dashboard/);
        assert.doesNotMatch(text, /ask the user to reply yes/);
      } else if (mode === 'direct') {
        assert.match(text, /ask the user to reply yes/);
      } else {
        assert.match(text, /directive:approved-operation:/);
      }
      console.log(JSON.stringify({ mode, passed: true, text }));
      if (mode !== 'direct-approved') {
        const actions = mode === 'delegated' ? [
          { action: 'connect_channel', channel: 'telegram' },
          { action: 'configure_skills' }, { action: 'configure_search' },
          { action: 'configure_gateway' }, { action: 'import_memory' },
          { action: 'configure_model_provider' }, { action: 'open_agent' },
          { action: 'open_setup', target: 'channels' },
        ] : [{ action: 'connect_channel', channel: 'telegram' }];
        for (const args of actions) {
          const response = await client.callTool({ name: 'openclaw', arguments: args });
          const resultText = response.content.filter(x => x.type === 'text').map(x => x.text).join('\n');
          const directive = resolveSystemAgentDirectiveTransition({ args, resultText });
          if (mode === 'delegated') {
            assert.match(resultText, /cannot run from a delegated agent request/);
            assert.match(resultText, /openclaw dashboard/);
            assert.equal(directive, null);
          } else {
            assert.deepEqual(directive, { kind: 'channel-setup', channel: 'telegram' });
          }
          console.log(JSON.stringify({ mode, action: args.action, passed: true, directive }));
        }
      }
    } finally {
      clearTimeout(timer);
      await client.close();
    }
  }
} finally { await rm(state, { recursive: true, force: true }); }
```

Observed output:

```jsonl
{"mode":"delegated","passed":true,"text":"needs-approval:86088ad9dc6698a3080f94ed68583cb553251592253ba56dab306c2524ad1806\nThis action changes state. The proposal is registered for operator approval. Do not request conversational approval. This change needs operator approval and cannot be applied from this chat. Approve it in the OpenClaw operator UI (`openclaw dashboard` on the Gateway host), or run the change there with `openclaw setup`."}
{"mode":"delegated","action":"connect_channel","passed":true,"directive":null}
{"mode":"delegated","action":"configure_skills","passed":true,"directive":null}
{"mode":"delegated","action":"configure_search","passed":true,"directive":null}
{"mode":"delegated","action":"configure_gateway","passed":true,"directive":null}
{"mode":"delegated","action":"import_memory","passed":true,"directive":null}
{"mode":"delegated","action":"configure_model_provider","passed":true,"directive":null}
{"mode":"delegated","action":"open_agent","passed":true,"directive":null}
{"mode":"delegated","action":"open_setup","passed":true,"directive":null}
{"mode":"direct","passed":true,"text":"needs-approval:86088ad9dc6698a3080f94ed68583cb553251592253ba56dab306c2524ad1806\nThis action changes state. The proposal is registered; describe this exact change and ask the user to reply yes (their approval unlocks THIS action only — then retry the exact registered operation with approved=true)."}
{"mode":"direct","action":"connect_channel","passed":true,"directive":{"kind":"channel-setup","channel":"telegram"}}
{"mode":"direct-approved","passed":true,"text":"directive:approved-operation: the host accepted this exact approved action and will apply it after this turn. Do not call it again."}
```
</details>
