### PR TITLE
fix(test): exercise channel restart through rollback owner

### DIFF
--- a/src/gateway/server-reload-channel-restart.test.ts
+++ b/src/gateway/server-reload-channel-restart.test.ts
@@ -1,11 +1,11 @@
-import { afterEach, expect, it } from "vitest";
+import { afterEach, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import { resetGatewayWorkAdmission } from "../process/gateway-work-admission.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import { createChannelManager, type ChannelManager } from "./server-channels.js";
-import { startGatewayChannelFromActiveRegistry } from "./server-reload-channel-restart.js";
+import { rollbackStoppedGatewayChannels } from "./server-reload-channel-restart.js";
 
 let manager: ChannelManager | undefined;
 afterEach(async () => {
@@ -16,7 +16,7 @@ afterEach(async () => {
 });
 
 it.each(["idle", "stopped", "racing"] as const)(
-  "automatic reload preserves %s manual stops while explicit starts resume",
+  "reload rollback preserves %s manual stops while explicit starts resume",
   async (state) => {
     const starts: string[] = [];
     const configuring = createDeferred();
@@ -59,14 +59,19 @@ it.each(["idle", "stopped", "racing"] as const)(
     if (state !== "racing") {
       await manager.stopChannel("discord", "manual");
     }
-    const reload = startGatewayChannelFromActiveRegistry(manager, "discord");
+    const reload = rollbackStoppedGatewayChannels(
+      { startChannel: manager.startChannel, logChannels: { info: vi.fn(), error: vi.fn() } },
+      new Set(["discord"]),
+      new Map(),
+      "configuration rollback",
+    );
     if (state === "racing") {
       await configuring.promise;
       await manager.stopChannel("discord", "manual");
       blockConfiguration = false;
       releaseConfiguration.resolve();
     }
-    await reload;
+    expect(await reload).toEqual([]);
     expect(manager.isManuallyStopped("discord", "manual")).toBe(true);
     expect(manager.getRuntimeSnapshot().channelAccounts.discord?.manual?.running).toBe(false);
     expect(starts).toEqual(state === "stopped" ? ["manual", "running"] : ["running"]);


### PR DESCRIPTION
Related: #131614 and #131626.

## What Problem This Solves

Resolves a problem where main's Gateway restart tests fail before exercising channel behavior because they import a helper that is now private. This also breaks the core test typecheck and unrelated PR CI. The failure is present in the merge checkout used by #131614, not in that PR's delivery changes.

## Why This Change Was Made

The test now enters through the existing exported rollback owner and uses the real channel manager. It keeps the assertions for idle, stopped, and concurrently stopped accounts, verifies that explicit operator starts still resume them, and additionally asserts that rollback records no failures. The private helper stays private; no runtime API is added just for a test.

## User Impact

No production behavior changes. CI can again exercise the intended manual-stop invariant. Production LOC: 0. Tests: +10/-5, net +5.

## Evidence

- Reproduced all three failures on main-derived `7a6a7945cecb4eb1a0eae8d0274cb8ee9462cf1e` with `node scripts/run-vitest.mjs src/gateway/server-reload-channel-restart.test.ts`.
- The same three cases pass after the test repair, with unchanged race ordering and behavior assertions.
- The exact failing typecheck, `node scripts/run-tsgo-core-test-shards.mjs --stripe 3/5 --concurrency 2`, passes.
- Scoped lint, formatting, whitespace checks, and Codex autoreview passed. Autoreview's reporting threshold was P0; direct owner/caller review also found no actionable issue.
- [Hosted CI33153198426](https://github.com/openclaw/openclaw/actions/runs/33153198426) passed at exact head `930eac1235236ed5ff28f19da44ce615b2ad0eba`, with no pending checks. No live product proof is claimed or required for a test-only change; the delivery and memory PRs retain their separate real Gateway/CLI proof.

Provenance: #131545 (`0da947dbf0f`) made the helper private, then #118157 (`0bb870a40a6`) added a test importing it. The integration of those changes made the failure visible. CI run [33151329542](https://github.com/openclaw/openclaw/actions/runs/33151329542) checked merge commit `e237fd8dd60930ce9ef14f667057b42562966012`; both the test shard and typecheck identify the same import. No stable release behavior is affected.

AI-assisted test repair with Codex.
