### PR TITLE
refactor(test): couple watchdog release and completion

### DIFF
--- a/test/helpers/process-watchdog.ts
+++ b/test/helpers/process-watchdog.ts
@@ -15,7 +15,11 @@ export function startProcessWatchdogFixture<T>(start: () => Promise<T>) {
       }, ms),
     );
   try {
-    return { runPromise: start(), releaseTimeout: ready.resolve };
+    const completion = start();
+    return function releaseAndWait() {
+      ready.resolve();
+      return completion;
+    };
   } finally {
     timeoutSpy.mockRestore();
   }

--- a/test/non-isolated-runner.test.ts
+++ b/test/non-isolated-runner.test.ts
@@ -203,6 +203,8 @@ function fixtureFiles(): Record<string, string> {
     ].join("\n"),
     // Native require keeps only the constructors stable across module resets.
     // Plain factory closures avoid vi.fn's separate process-lifetime mock set.
+    // Each census collects and traverses the heap, so check presence and release
+    // across files without also scanning before allocation.
     "mock-payloads.cjs": [
       'class ManualPayload { value = "manual"; }',
       "class AutoPayload extends Date {}",
@@ -222,7 +224,6 @@ function fixtureFiles(): Record<string, string> {
       "  return { flavor: () => payload.value };",
       "});",
       'it("creates a file-owned manual mock payload", async () => {',
-      "  expect(queryObjects(ManualPayload)).toBe(0);",
       '  const { flavor } = await import("./07-manual-dep.js");',
       '  expect(flavor()).toBe("manual");',
       "  expect(queryObjects(ManualPayload)).toBe(1);",
@@ -275,7 +276,6 @@ function fixtureFiles(): Record<string, string> {
       payloadImports,
       'vi.mock("./08-auto-dep.js");',
       'it("creates a file-owned automock payload", async () => {',
-      "  expect(queryObjects(AutoPayload)).toBe(0);",
       '  const { payload } = await import("./08-auto-dep.js");',
       "  expect(payload.getTime()).toBe(1234);",
       "  expect(queryObjects(AutoPayload)).toBe(1);",

--- a/test/scripts/managed-child-process.test.ts
+++ b/test/scripts/managed-child-process.test.ts
@@ -466,16 +466,17 @@ ${publishReadyPidScript(2)}
       "utf8",
     );
 
-    const run = startProcessWatchdogFixture(() =>
-      runManagedCommand({
-        bin: process.execPath,
-        args: [childPath, childPidPath, descendantPidPath],
-        shell: false,
-        stdio: "ignore",
-        timeoutMs: 500,
-      }),
+    const releaseAndWait = startProcessWatchdogFixture(() =>
+      expect(
+        runManagedCommand({
+          bin: process.execPath,
+          args: [childPath, childPidPath, descendantPidPath],
+          shell: false,
+          stdio: "ignore",
+          timeoutMs: 500,
+        }),
+      ).rejects.toMatchObject({ code: "ETIMEDOUT" }),
     );
-    const timeoutAssertion = expect(run.runPromise).rejects.toMatchObject({ code: "ETIMEDOUT" });
     const killSpy = vi.spyOn(process, "kill");
     let childPid = 0;
     let descendantPid = 0;
@@ -484,17 +485,15 @@ ${publishReadyPidScript(2)}
       descendantPid = await waitForPidFile(descendantPidPath, 2_000);
       expect(isProcessAlive(childPid)).toBe(true);
       expect(isProcessAlive(descendantPid)).toBe(true);
-      run.releaseTimeout();
-      await timeoutAssertion;
+      await releaseAndWait();
       if (process.platform !== "win32") {
         expect(killSpy).toHaveBeenCalledWith(-childPid, "SIGKILL");
       }
       expect(isProcessAlive(childPid)).toBe(false);
       expect(isProcessAlive(descendantPid)).toBe(false);
     } finally {
-      run.releaseTimeout();
       try {
-        await timeoutAssertion;
+        await releaseAndWait();
       } finally {
         killSpy.mockRestore();
         try {

--- a/test/scripts/resolve-openclaw-package-candidate.test.ts
+++ b/test/scripts/resolve-openclaw-package-candidate.test.ts
@@ -494,26 +494,25 @@ describe("resolve-openclaw-package-candidate", () => {
       `spawn(process.execPath, ['-e', ${JSON.stringify(childScript)}], { stdio: 'ignore' });`,
       "setInterval(() => {}, 1000);",
     ].join("\n");
-    const run = startProcessWatchdogFixture(() =>
-      runCommandForTest(process.execPath, ["-e", parentScript], {
-        killAfterMs: 25,
-        timeoutMs: 500,
-      }),
+    const releaseAndWait = startProcessWatchdogFixture(() =>
+      expect(
+        runCommandForTest(process.execPath, ["-e", parentScript], {
+          killAfterMs: 25,
+          timeoutMs: 500,
+        }),
+      ).rejects.toThrow(/timed out after 500ms/u),
     );
-    const timeoutAssertion = expect(run.runPromise).rejects.toThrow(/timed out after 500ms/u);
     const killSpy = vi.spyOn(process, "kill");
     let childPid: number | undefined;
     try {
       childPid = await waitForPidFile(childPidPath, 2_000);
       expect(isProcessAlive(childPid)).toBe(true);
-      run.releaseTimeout();
-      await timeoutAssertion;
+      await releaseAndWait();
       expect(killSpy).toHaveBeenCalledWith(expect.any(Number), "SIGKILL");
       await waitForDead(childPid, 2_000);
     } finally {
-      run.releaseTimeout();
       try {
-        await timeoutAssertion;
+        await releaseAndWait();
       } finally {
         killSpy.mockRestore();
         if (childPid !== undefined && isProcessAlive(childPid)) {
@@ -540,24 +539,23 @@ describe("resolve-openclaw-package-candidate", () => {
       "setInterval(() => {}, 1000);",
       `fs.writeFileSync(${JSON.stringify(childPidPath)}, String(process.pid));`,
     ].join("\n");
-    const run = startProcessWatchdogFixture(() =>
-      runCommandForTest(process.execPath, ["-e", childScript], {
-        killAfterMs: Number.MAX_SAFE_INTEGER,
-        timeoutMs: 500,
-      }),
+    const releaseAndWait = startProcessWatchdogFixture(() =>
+      expect(
+        runCommandForTest(process.execPath, ["-e", childScript], {
+          killAfterMs: Number.MAX_SAFE_INTEGER,
+          timeoutMs: 500,
+        }),
+      ).rejects.toThrow(/timed out after 500ms/u),
     );
-    const timeoutAssertion = expect(run.runPromise).rejects.toThrow(/timed out after 500ms/u);
     let childPid: number | undefined;
     try {
       childPid = await waitForPidFile(childPidPath, 2_000);
-      run.releaseTimeout();
-      await timeoutAssertion;
+      await releaseAndWait();
       expect(readFileSync(cleanupPath, "utf8")).toBe("clean");
       await waitForDead(childPid, 2_000);
     } finally {
-      run.releaseTimeout();
       try {
-        await timeoutAssertion;
+        await releaseAndWait();
       } finally {
         if (childPid !== undefined && isProcessAlive(childPid)) {
           process.kill(childPid, "SIGKILL");
@@ -592,24 +590,23 @@ describe("resolve-openclaw-package-candidate", () => {
       `spawn(process.execPath, ['-e', ${JSON.stringify(childScript)}], { stdio: 'ignore' });`,
       "setInterval(() => {}, 1000);",
     ].join("\n");
-    const run = startProcessWatchdogFixture(() =>
-      runCommandForTest(process.execPath, ["-e", parentScript], {
-        killAfterMs: 250,
-        timeoutMs: 250,
-      }),
+    const releaseAndWait = startProcessWatchdogFixture(() =>
+      expect(
+        runCommandForTest(process.execPath, ["-e", parentScript], {
+          killAfterMs: 250,
+          timeoutMs: 250,
+        }),
+      ).rejects.toThrow(/timed out after 250ms/u),
     );
-    const timeoutAssertion = expect(run.runPromise).rejects.toThrow(/timed out after 250ms/u);
     let childPid: number | undefined;
     try {
       childPid = await waitForPidFile(childPidPath, 2_000);
-      run.releaseTimeout();
-      await timeoutAssertion;
+      await releaseAndWait();
       expect(readFileSync(cleanupPath, "utf8")).toBe("clean");
       await waitForDead(childPid, 2_000);
     } finally {
-      run.releaseTimeout();
       try {
-        await timeoutAssertion;
+        await releaseAndWait();
       } finally {
         if (childPid !== undefined && isProcessAlive(childPid)) {
           process.kill(childPid, "SIGKILL");

--- a/test/scripts/test-group-report.test.ts
+++ b/test/scripts/test-group-report.test.ts
@@ -1114,7 +1114,7 @@ describe("scripts/test-group-report child process guard", () => {
       `spawn(process.execPath, ["--eval", ${JSON.stringify(childScript)}], { stdio: "ignore" });`,
       "setInterval(() => {}, 1000);",
     ].join("\n");
-    const run = startProcessWatchdogFixture(() =>
+    const releaseAndWait = startProcessWatchdogFixture(() =>
       spawnText(process.execPath, ["--eval", parentScript], {
         cwd: process.cwd(),
         env: process.env,
@@ -1126,8 +1126,7 @@ describe("scripts/test-group-report child process guard", () => {
     try {
       childPid = await waitForPidFile(childPidPath, 2_000);
       const startedAt = Date.now();
-      run.releaseTimeout();
-      const result = await run.runPromise;
+      const result = await releaseAndWait();
 
       expect(result).toMatchObject({
         status: 1,
@@ -1138,9 +1137,8 @@ describe("scripts/test-group-report child process guard", () => {
       expect(Date.now() - startedAt).toBeLessThan(900);
       await waitForDead(childPid, 2_000);
     } finally {
-      run.releaseTimeout();
       try {
-        await run.runPromise;
+        await releaseAndWait();
       } finally {
         if (childPid !== undefined && isProcessAlive(childPid)) {
           process.kill(childPid, "SIGKILL");

--- a/test/scripts/tsdown-build.test.ts
+++ b/test/scripts/tsdown-build.test.ts
@@ -2348,23 +2348,21 @@ describe("runTsdownBuildInvocation", () => {
         "setInterval(() => {}, 1000);",
       ].join("");
       const output = createWriteSink();
-      const run = startTimeoutFixture(parentScript, output);
+      const releaseAndWait = startTimeoutFixture(parentScript, output);
       let childPid: number | undefined;
 
       try {
         // The descendant publishes its PID only after installing its SIGTERM handler.
         childPid = await waitForPidFile(childPidPath, 2_000);
         expect(isProcessAlive(childPid)).toBe(true);
-        run.releaseTimeout();
-        const result = await run.runPromise;
+        const result = await releaseAndWait();
 
         expect(result).toMatchObject({ timedOut: true, status: 0, signal: null, error: null });
         expect(fs.readFileSync(termPath, "utf8")).toBe("SIGTERM");
         expect(output.chunks.join("")).toContain("forcing SIGKILL");
         await waitForDead(childPid, 2_000);
       } finally {
-        run.releaseTimeout();
-        await run.runPromise;
+        await releaseAndWait();
         if (childPid !== undefined && isProcessAlive(childPid)) {
           process.kill(childPid, "SIGKILL");
           await waitForDead(childPid, 2_000);
@@ -2397,15 +2395,14 @@ describe("runTsdownBuildInvocation", () => {
         "setInterval(() => {}, 1000);",
       ].join("");
       const output = createWriteSink();
-      const run = startTimeoutFixture(parentScript, output);
+      const releaseAndWait = startTimeoutFixture(parentScript, output);
       let childPid: number | undefined;
 
       try {
         // The descendant publishes its PID only after installing its SIGTERM handler.
         childPid = await waitForPidFile(childPidPath, 2_000);
         const startedAt = Date.now();
-        run.releaseTimeout();
-        const result = await run.runPromise;
+        const result = await releaseAndWait();
 
         expect(result).toMatchObject({ timedOut: true, status: 0, signal: null, error: null });
         expect(fs.readFileSync(cleanupPath, "utf8")).toBe("clean");
@@ -2413,8 +2410,7 @@ describe("runTsdownBuildInvocation", () => {
         expect(Date.now() - startedAt).toBeLessThan(900);
         await waitForDead(childPid, 2_000);
       } finally {
-        run.releaseTimeout();
-        await run.runPromise;
+        await releaseAndWait();
         if (childPid !== undefined && isProcessAlive(childPid)) {
           process.kill(childPid, "SIGKILL");
           await waitForDead(childPid, 2_000);


### PR DESCRIPTION
Related: #131481 (descendant-watchdog readiness and terminal-liveness test repair).

## What Problem This Solves

Maintainer-requested cleanup of the descendant-watchdog fixtures. Seven tests had to coordinate separate release and completion controls at fourteen normal/finally call sites, with four additional timeout-assertion variables. Those controls always describe one operation and did not need to remain independently exposed.

The first CI run also exposed unnecessary full-heap census work in the shared-runner regression fixture. Its producer tests scanned for zero instances before creating anything, then scanned again to prove creation. Those extra scans can exhaust the existing five-second test budget without adding cross-file cleanup evidence.

## Why This Change Was Made

The existing watchdog helper now starts the operation once and returns a single `releaseAndWait` function. Each call releases readiness and joins the same stored completion. Expected-rejection fixtures attach their existing matcher immediately inside the start callback, rather than keeping a separate assertion promise. The old two-field API is removed and all callers migrate.

Readiness observations, elapsed-time boundaries and emergency PID cleanup remain explicit; nested `finally` blocks still ensure later cleanup runs if an earlier step fails. Native timer interception and synchronous restoration are unchanged. No generic cleanup framework or compatibility alias is added.

The shared-runner fixture drops only the two pre-allocation heap censuses. It keeps the exact positive-one observations after creation and next-file zero observations before reimport, plus all 20 behavior tests and the intentional collection failure. CJS constructor identity, the Date-based automock sentinel, remocking/redirect checks, and the five-second nested test budget remain unchanged. The actual runner is not modified.

## User Impact

No application or configuration behavior changes. Maintainers get one watchdog-completion operation and four necessary heap censuses instead of six. All watchdog, grace, readiness, death and polling values remain unchanged, as do real signals and cleanup/escalation assertions.

Production: +0/-0. Test support: +5/-1; tests: +50/-60; combined +55/-61, net −6 lines across six files. AI-assisted; independent quality review selected the bounded cleanup, and fresh isolated review covered the combined patch.

## Evidence

Final exact-head CI: [run 33158240403, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33158240403) passed on `bf5f96ee0f1c0532059a9df714bd4aa44dded1cd`, including the required `openclaw/ci-gate`. The initial failed run below was not rerun.

### Watchdog completion

The same seven affected real-process fixtures passed once before and once after the refactor on Darwin arm64, Node 24.20.0/libuv 1.52.1: **7 passed / 0 failed in each run**, with `--retry=0`. The other 272 cases were filtered, not newly skipped. No unhandled or unawaited assertion warnings occurred.

```bash
node scripts/run-vitest.mjs test/scripts/managed-child-process.test.ts test/scripts/resolve-openclaw-package-candidate.test.ts test/scripts/test-group-report.test.ts test/scripts/tsdown-build.test.ts -t 'times out and kills managed command descendants|kills timed-out package runner process groups|clamps oversized package runner kill grace before scheduling|rejects timed-out package runner commands when descendants exit cleanly|finishes promptly when timed process-group descendants exit cleanly|kills timed-out tsdown process groups when the wrapper exits first|preserves timeout grace when descendant processes exit cleanly' --retry=0 --reporter=verbose --reporter=json --outputFile=.artifacts/watchdog-simplify/after.json
```

The baseline used the same command with `baseline.json`. The rebase preserved this five-file patch byte-for-byte and retained its source hashes and stable patch ID.

### CI follow-up and retained regression sensitivity

[Initial CI run 33153338177](https://github.com/openclaw/openclaw/actions/runs/33153338177) failed three jobs. Two came from a stale gateway-test import in CI's synthetic merge, already repaired by [the rollback-test boundary fix](https://github.com/openclaw/openclaw/pull/131627). Rebasing onto `871b18dff5039484e86c76d282699a8defcb1654` incorporates that fix without re-exporting a private production helper. The third was a nested automock-producer timeout.

A single instrumented local baseline reproduced a census overrun: manual heap scans took 3706.634 and 2907.222 ms, while the awaited import took 0.333 ms—over six seconds of scans inside the unchanged five-second budget. The automock pre-allocation scan alone took 5093.479 ms. Reporter suppression lost some passing-test console records, so baseline telemetry is partial; that run was preserved, not retried.

After removing the two redundant scans, the complete ordered fixture passed all **20 behavior tests**, with only its intentional collection failure. File-backed measurements observed exactly four real censuses, returning manual `1 → 0` and automock `1 → 0`. The ordinary uninstrumented test also passed:

```bash
node scripts/run-vitest.mjs test/non-isolated-runner.test.ts --retry=0 --reporter=verbose
```

A disposable negative control restored only the historical pre-#131338 mock-metadata cleanup. Both retained release assertions failed on actual native counts of one rather than zero; the other 18 behavior tests passed, with no timeout/setup failures. This confirms that removing the pre-allocation checks does not hide the memory-retention regression. No instrumentation or negative-control code ships.

The integrated gateway boundary passed **462 tests** and its test type program:

```bash
node scripts/run-vitest.mjs src/gateway/server-reload-channel-restart.test.ts src/gateway/server-reload-handlers.test.ts src/gateway/config-reload.test.ts --retry=0 --reporter=verbose
```

```bash
node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.gateway-root.json --builders 1
```

### Static checks and review

```bash
node scripts/check-changed.mjs -- test/helpers/process-watchdog.ts test/scripts/managed-child-process.test.ts test/scripts/resolve-openclaw-package-candidate.test.ts test/scripts/test-group-report.test.ts test/scripts/tsdown-build.test.ts
```

```bash
node scripts/check-changed.mjs -- test/non-isolated-runner.test.ts
```

Both selected gates passed formatting, root-test types, script/tooling lint and guards with recorded exit 0. `git diff --check` passed. Fresh isolated Codex autoreview of the combined six-file patch reported no accepted/actionable P0 findings. Owned test processes and temporary repository proof copies were cleaned up; operator services were untouched.

Node/V8 and installed Vitest contracts were inspected directly. `queryObjects` performs heap traversal and garbage collection, not a cheap counter lookup. Rejection handlers attach when matchers are invoked; repeated awaits join the same completion; watchdog interception is restored synchronously before yielding.

**Limits:** local census proof used macOS Node 24.20.0, while the failing CI used Linux Node 24.19.0. Host load and recorder implementation differed between baseline and after. This proves a local overrun and a six-to-four work reduction, not a controlled latency speedup or precise attribution of the original CI occurrence. The predecessor's older whole-suite timing observations remain unclaimed. No deadlines, retry/skip policy, dependencies, runtime configuration or release artifacts were changed.