### PR TITLE
chore(codex): use synthetic model names in warning tests

### DIFF
--- a/extensions/codex/src/app-server/event-projector.reasoning.test.ts
+++ b/extensions/codex/src/app-server/event-projector.reasoning.test.ts
@@ -426,7 +426,7 @@ describe("CodexAppServerEventProjector reasoning and guardian projection", () =>
   });
 
   it.each([
-    { tier: "priority", model: "ultima-alpha" },
+    { tier: "priority", model: "test-no-tier-model" },
     { tier: "flex", model: "test-no-tier-model" },
   ])("logs unsupported $tier tiers without projecting a UI notice", async ({ tier, model }) => {
     const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => {});
@@ -446,7 +446,7 @@ describe("CodexAppServerEventProjector reasoning and guardian projection", () =>
   it.each([
     "Project hooks were disabled.",
     "Configured service tier `priority` requires account access.",
-    "Configured service tier `priority` is not advertised as supported for model `ultima-alpha` and will be omitted from requests. Additional action required.",
+    "Configured service tier `priority` is not advertised as supported for model `test-no-tier-model` and will be omitted from requests. Additional action required.",
   ])("surfaces startup and thread warnings: %s", async (message) => {
     const onAgentEvent = vi.fn();
     const projector = await createProjector({ ...(await createParams()), onAgentEvent });


### PR DESCRIPTION
## What Problem This Solves

Warning-projection tests should use synthetic model names rather than environment-specific model identifiers.

## Why This Change Was Made

Reuse the existing `test-no-tier-model` fixture in the priority-tier case and the near-match warning case. Keep the complete warning template and the extra-suffix negative control unchanged.

## User Impact

No runtime behavior change. Only two test string literals change; production code and assertions are unchanged.

## Evidence

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.reasoning.test.ts`: all 19 tests passed.
- Fresh structured Codex autoreview: no findings.
- `git diff --check`: passed; the commit hook formatted the changed file.
- Production LOC: +0/-0. Tests: +2/-2, net zero.
- Personally inspected upstream Codex warning construction in `codex-rs/core/src/session/mod.rs` at commit `94311d447587411789533c47601fd8bc9d81eb48`: the model slug is interpolated data, not a required fixed identifier.
