### PR TITLE
test(ui): read lifted tooltip titles in exposed e2e assertions

### DIFF
--- a/ui/src/e2e/chat-composer-capability-menu.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-capability-menu.e2e.test.ts
@@ -2,7 +2,7 @@
 import type { Page } from "playwright";
 import { expect, it } from "vitest";
 import { installMockGateway, type MockGatewayControls } from "../test-helpers/control-ui-e2e.ts";
-import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import { createControlUiE2eSuite, tooltipTitleText } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI composer capability menu",
@@ -180,22 +180,6 @@ async function openMenu(page: Page) {
 
 function webSearchItem(menu: import("playwright").Locator) {
   return menu.locator('wa-dropdown-item[value="toggle-web-search"]');
-}
-
-// The shared tooltip moves active title hints onto the row or its nested link.
-// Read the reason from the element that owns that accessible description.
-function disabledReason(item: import("playwright").Locator) {
-  return item.evaluate((element) => {
-    const title = element.getAttribute("title");
-    if (title) {
-      return title;
-    }
-    const describedBy =
-      element.getAttribute("aria-describedby") ??
-      element.querySelector("[aria-describedby]")?.getAttribute("aria-describedby");
-    const description = describedBy ? element.ownerDocument.getElementById(describedBy) : null;
-    return description?.textContent?.trim() ?? "";
-  });
 }
 
 suite.define(() => {
@@ -567,7 +551,7 @@ suite.define(() => {
       await gateway.resolveDeferred("tools.effective", effectiveToolsResponse());
       const listIssues = menu.locator('wa-dropdown-item[value="mcp-tool:0"]');
       await expect.poll(() => listIssues.isDisabled()).toBe(true);
-      await expect.poll(() => disabledReason(listIssues)).toBe("Loading…");
+      await expect.poll(() => tooltipTitleText(listIssues)).toBe("Loading…");
       await listIssues.evaluate((item) => {
         item
           .closest("wa-dropdown")
@@ -608,12 +592,12 @@ suite.define(() => {
       const menu = composer.locator("wa-dropdown.agent-chat__capability-menu");
       const clear = menu.locator('wa-dropdown-item[value="clear-overrides"]');
       await expect.poll(() => clear.isDisabled()).toBe(true);
-      await expect.poll(() => disabledReason(clear)).toContain("operator.admin access");
+      await expect.poll(() => tooltipTitleText(clear)).toContain("operator.admin access");
       await expect.poll(() => webSearchItem(menu).isDisabled()).toBe(true);
       await menu.getByRole("menuitem", { name: /^Skills/ }).click();
       const docs = menu.getByRole("menuitem", { name: /^Docs/ });
       await expect.poll(() => docs.isDisabled()).toBe(true);
-      await expect.poll(() => disabledReason(docs)).toContain("operator.admin access");
+      await expect.poll(() => tooltipTitleText(docs)).toContain("operator.admin access");
       await menu.getByRole("menuitem", { name: "Back" }).click();
       await menu.getByRole("menuitem", { name: /^Connectors/ }).click();
       await expect
@@ -622,10 +606,10 @@ suite.define(() => {
       const browse = menu.getByRole("menuitem", { name: "Browse connectors" });
       await expect.poll(() => browse.isDisabled()).toBe(true);
       await browse.hover();
-      await expect.poll(() => disabledReason(browse)).toContain("Admin access");
+      await expect.poll(() => tooltipTitleText(browse)).toContain("Admin access");
       const addServer = menu.getByRole("menuitem", { name: /Add MCP server/ });
       await expect.poll(() => addServer.isDisabled()).toBe(true);
-      await expect.poll(() => disabledReason(addServer)).toContain("Admin access");
+      await expect.poll(() => tooltipTitleText(addServer)).toContain("Admin access");
     });
   });
 
@@ -651,7 +635,7 @@ suite.define(() => {
       const menu = composer.locator("wa-dropdown.agent-chat__capability-menu");
       const webSearch = webSearchItem(menu);
       await expect.poll(() => webSearch.isDisabled()).toBe(true);
-      await expect.poll(() => disabledReason(webSearch)).toBe("Loading…");
+      await expect.poll(() => tooltipTitleText(webSearch)).toBe("Loading…");
       await webSearch.evaluate((item) => {
         item
           .closest("wa-dropdown")
@@ -667,7 +651,7 @@ suite.define(() => {
         }),
       );
       await expect.poll(() => webSearchItem(menu).isDisabled()).toBe(true);
-      await expect.poll(() => disabledReason(webSearchItem(menu))).toBe("Loading…");
+      await expect.poll(() => tooltipTitleText(webSearchItem(menu))).toBe("Loading…");
       expect(await gateway.getRequests("sessions.patch")).toHaveLength(0);
 
       await gateway.resolveDeferred("config.get", configResponse({}, false));

--- a/ui/src/e2e/codex-sessions.e2e.test.ts
+++ b/ui/src/e2e/codex-sessions.e2e.test.ts
@@ -4,7 +4,7 @@ import type { Page } from "playwright";
 import { expect, it } from "vitest";
 import type { SessionsCatalogHostEvent } from "../../../packages/gateway-protocol/src/index.ts";
 import { controlUiSessionPath, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
-import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import { createControlUiE2eSuite, tooltipTitleText } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Codex native session catalog",
@@ -771,12 +771,10 @@ suite.define(() => {
         '[data-session-section="catalog:codex"] .sidebar-session-group-toggle',
       );
       await warning.waitFor({ state: "visible" });
-      await expect.poll(() => warning.getAttribute("title")).toContain("[NODE_LIST_FAILED]");
+      await expect.poll(() => tooltipTitleText(warning)).toContain("[NODE_LIST_FAILED]");
+      await expect.poll(() => tooltipTitleText(warning)).toContain("pairing database is locked");
       await expect
-        .poll(() => warning.getAttribute("title"))
-        .toContain("pairing database is locked");
-      await expect
-        .poll(() => warning.getAttribute("title"))
+        .poll(() => tooltipTitleText(warning))
         .toContain("Settings > Automation > Plugins");
       expect(await page.locator('[data-session-catalog-host="node:registry"]').count()).toBe(0);
 

--- a/ui/src/e2e/control-ui-e2e-suite.test-support.ts
+++ b/ui/src/e2e/control-ui-e2e-suite.test-support.ts
@@ -1,4 +1,4 @@
-import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
+import { chromium, type Browser, type BrowserContext, type Locator, type Page } from "playwright";
 import { afterAll, afterEach, beforeAll, describe, expect } from "vitest";
 import {
   canRunPlaywrightChromium,
@@ -33,6 +33,33 @@ type ControlUiE2eSuite = {
     run: (fixture: ControlUiE2ePage) => Promise<T>,
   ) => Promise<T>;
 };
+
+/* The shared title tooltip (components/tooltip-title.ts) lifts a hovered or
+   focused element's `title` into its overlay and blanks the attribute until
+   pointer-leave/focusout, so elements that can sit under the pointer or hold
+   focus race a raw getAttribute("title") read. Read the lifted overlay
+   description when the attribute is blank. */
+export function tooltipTitleText(item: Locator) {
+  return item.evaluate((element) => {
+    const title = element.getAttribute("title");
+    if (title) {
+      return title;
+    }
+    // The overlay describes the first interactive descendant when the titled
+    // row itself is not describable (tooltip.ts resolveDescribedElement), so
+    // link rows carry the description on their nested anchor.
+    const described = element.hasAttribute("aria-describedby")
+      ? element
+      : (element.querySelector("[aria-describedby]") ?? element);
+    const root = described.getRootNode();
+    const scope = root instanceof ShadowRoot ? root : described.ownerDocument;
+    return (described.getAttribute("aria-describedby") ?? "")
+      .split(/\s+/u)
+      .map((id) => scope.getElementById(id)?.textContent?.trim() ?? "")
+      .filter(Boolean)
+      .join(" ");
+  });
+}
 
 export async function holdModuleResponse(page: Page, module: RegExp) {
   let release!: () => void;

--- a/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { expect, it } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { CLOUD_PROFILE_RETRY_DELAYS_MS } from "../pages/new-session/cloud-profile-discovery.ts";
+import { tooltipTitleText } from "./control-ui-e2e-suite.test-support.ts";
 import {
   ONE_PIXEL_PNG_B64,
   SESSION_LIST_DEFAULTS,
@@ -398,9 +399,9 @@ suite.define(() => {
       await trigger.click();
       const retainedCloudProfile = place.getByRole("button", { name: "Cloud · aws" });
       await expect.poll(() => retainedCloudProfile.isDisabled()).toBe(false);
-      expect(await retainedCloudProfile.getAttribute("title")).toBe(
-        "Cloud worker provider: crabbox",
-      );
+      await expect
+        .poll(() => tooltipTitleText(retainedCloudProfile))
+        .toBe("Cloud worker provider: crabbox");
       await expect.poll(() => place.getByRole("button", { name: /Fast/ }).isVisible()).toBe(true);
       if (captureUiProofEnabled) {
         await page.screenshot({

--- a/ui/src/e2e/new-session-page.environment-metadata.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.environment-metadata.e2e.test.ts
@@ -1,4 +1,5 @@
 import { expect, it } from "vitest";
+import { tooltipTitleText } from "./control-ui-e2e-suite.test-support.ts";
 import {
   WORKSPACE,
   captureDeviceRuntimeUiProof,
@@ -121,7 +122,7 @@ suite.define(() => {
       await whereTrigger.click();
       await expect.poll(() => device.isEnabled()).toBe(true);
       await expect.poll(() => restrictedDevice.isDisabled()).toBe(true);
-      expect(await restrictedDevice.getAttribute("title")).toMatch(/enable|approv/i);
+      await expect.poll(() => tooltipTitleText(restrictedDevice)).toMatch(/enable|approv/i);
       await captureDeviceRuntimeUiProof(
         page,
         "02-codex-zero-slot-enabled-denied-command-disabled.png",
@@ -136,9 +137,9 @@ suite.define(() => {
       await expect
         .poll(() => device.locator(".new-session-page__menu-fact").allTextContents())
         .toEqual(["This runtime does not support paired devices"]);
-      expect(await device.getAttribute("title")).toBe(
-        "This runtime does not support paired devices",
-      );
+      await expect
+        .poll(() => tooltipTitleText(device))
+        .toBe("This runtime does not support paired devices");
       await captureDeviceRuntimeUiProof(page, "03-cloud-only-device-disabled.png");
       await page.keyboard.press("Escape");
 

--- a/ui/src/e2e/new-session-page.operator-scopes.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.operator-scopes.e2e.test.ts
@@ -1,4 +1,5 @@
 import { expect, it } from "vitest";
+import { tooltipTitleText } from "./control-ui-e2e-suite.test-support.ts";
 import {
   SESSION_LIST_DEFAULTS,
   createNewSessionPageE2eSuite,
@@ -151,9 +152,9 @@ suite.define(() => {
       await permission.click();
       const fullAccess = page.locator('[data-chat-permission-option="full"]');
       await expect.poll(() => fullAccess.getAttribute("disabled")).not.toBeNull();
-      expect(await fullAccess.getAttribute("title")).toBe(
-        "Full access requires operator.admin access.",
-      );
+      await expect
+        .poll(() => tooltipTitleText(fullAccess))
+        .toBe("Full access requires operator.admin access.");
       await page.keyboard.press("Escape");
       await page.locator(".new-session-page__message").press("Enter");
 

--- a/ui/src/e2e/new-session-page.places-live.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.places-live.e2e.test.ts
@@ -1,4 +1,5 @@
 import { expect, it } from "vitest";
+import { tooltipTitleText } from "./control-ui-e2e-suite.test-support.ts";
 import {
   WORKSPACE,
   createNewSessionPageE2eSuite,
@@ -153,9 +154,11 @@ suite.define(() => {
 
       await profile.waitFor();
       await expect.poll(() => profile.isDisabled()).toBe(true);
-      expect(await profile.getAttribute("title")).toBe(
-        "The codex runtime cannot use this cloud worker. Choose a compatible cloud worker or run locally.",
-      );
+      await expect
+        .poll(() => tooltipTitleText(profile))
+        .toBe(
+          "The codex runtime cannot use this cloud worker. Choose a compatible cloud worker or run locally.",
+        );
       await page.keyboard.press("Escape");
 
       await model.click();

--- a/ui/src/e2e/new-session-page.projects-places.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.projects-places.e2e.test.ts
@@ -1,4 +1,5 @@
 import { expect, it } from "vitest";
+import { tooltipTitleText } from "./control-ui-e2e-suite.test-support.ts";
 import {
   SESSION_LIST_DEFAULTS,
   WORKSPACE,
@@ -200,7 +201,7 @@ suite.define(() => {
         const local = place.locator('[data-value="gateway"]');
         if (late === "recovery scope") {
           await trigger.click();
-          await expect.poll(() => local.getAttribute("title")).toBe("Gateway · QA-Gateway");
+          await expect.poll(() => tooltipTitleText(local)).toBe("Gateway · QA-Gateway");
           const catalogRequests = (await gateway.getRequests("environments.list")).length;
           await page.evaluate(() => window.dispatchEvent(new Event("test-release-recovery-scope")));
           await gateway.waitForRequest("environments.list", { after: catalogRequests });
@@ -216,7 +217,7 @@ suite.define(() => {
         if (late === "system info") {
           await expect.poll(() => pathInput.getAttribute("placeholder")).toBe("Gateway · local");
           await gateway.resolveDeferred("system.info", systemInfo);
-          await expect.poll(() => local.getAttribute("title")).toBe("Gateway · QA-Gateway");
+          await expect.poll(() => tooltipTitleText(local)).toBe("Gateway · QA-Gateway");
         }
         await expect.poll(() => pathInput.getAttribute("placeholder")).toBe("Gateway · QA-Gateway");
         await captureProjectUiProof(page, `gateway-name-${late.replaceAll(" ", "-")}.png`);
@@ -225,7 +226,7 @@ suite.define(() => {
         await replaceGatewayClient(page);
         await pollLocatorText(trigger.locator(".new-session-page__trigger-label")).toBe("Local");
         await trigger.click();
-        await expect.poll(() => local.getAttribute("title")).toBe("Gateway · QA-Gateway");
+        await expect.poll(() => tooltipTitleText(local)).toBe("Gateway · QA-Gateway");
       } finally {
         try {
           await captureProjectUiProof(page, `gateway-name-${late.replaceAll(" ", "-")}-final.png`);
@@ -351,7 +352,7 @@ suite.define(() => {
       await where.getByText("Cloud", { exact: true }).waitFor();
       const cloud = where.getByRole("button", { name: "Cloud · aws" });
       expect(await cloud.isDisabled()).toBe(true);
-      expect(await cloud.getAttribute("title")).toBe("Cloud needs a Git checkout");
+      await expect.poll(() => tooltipTitleText(cloud)).toBe("Cloud needs a Git checkout");
       await page.keyboard.press("Escape");
 
       await page.locator(".new-session-page__message").fill("clone and inspect this project");

--- a/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
@@ -3,6 +3,7 @@ import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
 import { expect, it } from "vitest";
+import { tooltipTitleText } from "./control-ui-e2e-suite.test-support.ts";
 import {
   ONE_PIXEL_PNG_B64,
   SESSION_LIST_DEFAULTS,
@@ -797,12 +798,12 @@ suite.define(() => {
       const failedStatus = failedGroup.locator(".chat-send-status");
       await failedGroup.waitFor({ state: "visible", timeout: 30_000 });
       expect(await failedStatus.textContent()).toContain("Not sent");
-      expect(await failedStatus.getAttribute("title")).toBe(runError);
+      await expect.poll(() => tooltipTitleText(failedStatus)).toBe(runError);
 
       await page.reload();
       await failedGroup.waitFor({ state: "visible", timeout: 30_000 });
       expect(await failedStatus.textContent()).toContain("Not sent");
-      expect(await failedStatus.getAttribute("title")).toBe(runError);
+      await expect.poll(() => tooltipTitleText(failedStatus)).toBe(runError);
 
       await page.getByRole("button", { name: "Retry queued message" }).click();
       const retry = await gateway.waitForRequest("chat.send");
@@ -859,7 +860,7 @@ suite.define(() => {
       const failedStatus = failedGroup.locator(".chat-send-status");
       await failedGroup.waitFor({ state: "visible", timeout: 30_000 });
       expect(await failedStatus.textContent()).toContain("Not sent");
-      expect(await failedStatus.getAttribute("title")).toBe(runError);
+      await expect.poll(() => tooltipTitleText(failedStatus)).toBe(runError);
       await page.getByRole("button", { name: "Retry queued message" }).click();
       const retry = await gateway.waitForRequest("chat.send");
       expect(retry.params).toMatchObject({

--- a/ui/src/e2e/new-session-page.workspace-validation.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.workspace-validation.e2e.test.ts
@@ -4,6 +4,7 @@ import {
   waitForControlUiGatewayReady,
   waitForControlUiGatewayReconnecting,
 } from "../test-helpers/control-ui-e2e-readiness.ts";
+import { tooltipTitleText } from "./control-ui-e2e-suite.test-support.ts";
 import {
   SOURCE_REPO,
   TARGET_REPO,
@@ -231,9 +232,9 @@ suite.define(() => {
       await trigger.click();
       const worktree = place.getByRole("button", { name: "Worktree" });
       expect(await worktree.isEnabled()).toBe(true);
-      expect(await worktree.getAttribute("title")).toBe(
-        "Couldn't verify Git for this folder. Choose it again to retry.",
-      );
+      await expect
+        .poll(() => tooltipTitleText(worktree))
+        .toBe("Couldn't verify Git for this folder. Choose it again to retry.");
       await worktree.click();
       await expect.poll(() => trigger.count()).toBe(0);
       await expect.poll(() => start.isEnabled()).toBe(true);
@@ -289,9 +290,9 @@ suite.define(() => {
       await whereTrigger.click();
       const cloud = where.getByRole("button", { name: "Cloud · aws" });
       expect(await cloud.isDisabled()).toBe(true);
-      expect(await cloud.getAttribute("title")).toBe(
-        "Couldn't verify Git for this folder. Choose it again to retry.",
-      );
+      await expect
+        .poll(() => tooltipTitleText(cloud))
+        .toBe("Couldn't verify Git for this folder. Choose it again to retry.");
       await page.keyboard.press("Escape");
       await projectTrigger.click();
       await project.getByText("Advanced", { exact: true }).click();

--- a/ui/src/e2e/session-ownership.e2e.test.ts
+++ b/ui/src/e2e/session-ownership.e2e.test.ts
@@ -3,7 +3,7 @@ import type { Locator, Page } from "playwright";
 import { expect as expectBrowser } from "playwright/test";
 import { afterEach, expect, it } from "vitest";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
-import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import { createControlUiE2eSuite, tooltipTitleText } from "./control-ui-e2e-suite.test-support.ts";
 import { openNewSessionPlusMenu, replaceGatewayClient } from "./new-session-page.test-support.ts";
 import {
   avatarLabelCenterDelta,
@@ -997,12 +997,12 @@ suite.define(() => {
     // Agent and system identities render the non-human icon from identity.type,
     // not from an ID-string heuristic; owner-chip presentation is human-only.
     await expectBrowser(dropdown.locator(".chat-pane__sharing-member-icon > svg")).toHaveCount(2);
-    expect(
-      await longNameItem.locator(".chat-pane__sharing-member-label").getAttribute("title"),
-    ).toBe(longMemberLabel);
-    expect(await longIdItem.locator(".chat-pane__sharing-member-label").getAttribute("title")).toBe(
-      longMemberId,
-    );
+    await expect
+      .poll(() => tooltipTitleText(longNameItem.locator(".chat-pane__sharing-member-label")))
+      .toBe(longMemberLabel);
+    await expect
+      .poll(() => tooltipTitleText(longIdItem.locator(".chat-pane__sharing-member-label")))
+      .toBe(longMemberId);
     await expectBrowser(selectedIndicator).toHaveCount(1);
     expect(await selectedIndicator.getAttribute("aria-label")).not.toBeNull();
   });

--- a/ui/src/e2e/session-placement.move.e2e.test.ts
+++ b/ui/src/e2e/session-placement.move.e2e.test.ts
@@ -8,6 +8,7 @@ import {
   installMockGateway,
   requireString,
 } from "./chat-flow.test-support.ts";
+import { tooltipTitleText } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
@@ -215,7 +216,7 @@ suite.define(() => {
       const reclaimItem = page.locator(".chat-pane__placement-reclaim");
       expect(await moveItem.isDisabled()).toBe(false);
       expect(await reclaimItem.isDisabled()).toBe(true);
-      expect(await reclaimItem.getAttribute("title")).toContain("Reconnect the device");
+      await expect.poll(() => tooltipTitleText(reclaimItem)).toContain("Reconnect the device");
       await captureRunnerOffline(page);
       await gateway.deferNext("sessions.move");
       await continueAction.click();


### PR DESCRIPTION
## What Problem This Solves

`components/tooltip-title.ts` (#131335) lifts a hovered/focused element's `title` into the shared tooltip overlay and blanks the attribute until pointer-leave/focusout. E2E assertions polling `getAttribute("title")` on elements that can sit under the pointer at poll time (dropdown/popover items after a trigger click, sidebar rows that relayout under a stationary pointer, status chips re-hover-checked after `page.reload()`) race the lift and flake under CI load. #131471 fixed the hot case with a file-local helper; the same hazard existed across the suite.

## Why This Change Was Made

Sweep of all ~45 title-attribute assertions in `ui/src/e2e`. 27 call sites across 11 files are exposed and now read through a shared `tooltipTitleText` helper in `control-ui-e2e-suite.test-support.ts` (title attribute, or the lifted `aria-describedby` overlay description when blank; multi-id and shadow-root safe). The file-local `disabledReason` copy from #131471 is folded into the shared helper, including its nested-link description handling.

Deliberately kept raw: assertions with zero pointer/focus activity before the read (Playwright fires no hover events until the first mouse action), `toBeNull()` absence checks (the lift blanks to `""`, never null), and chat-message-actions' deliberate lift contract test.

## User Impact

None at runtime; test-only. CI stops flaking on tooltip-lift races in Control UI e2e suites.

## Evidence

- All 11 touched e2e files green locally before rebase (94 tests, single run, no retries); independent 3-file rerun green (30 tests).
- Post-rebase full-file rerun of chat-composer-capability-menu was 10/10 green after folding main's #131471 nested-link description handling into the shared helper. The existing explicit `browse.hover()` regression exercise is preserved; all ten cases also passed on the latest rebased head without retries.
- Focused command: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-composer-capability-menu.e2e.test.ts` — `Tests 10 passed (10)`.
- `node scripts/check-changed.mjs -- ui/src/e2e/chat-composer-capability-menu.e2e.test.ts ui/src/e2e/control-ui-e2e-suite.test-support.ts` passed; oxfmt clean.
- Structured second-model review of the sweep clean, no findings; the latest rebase preserves the sweep patch unchanged (`git range-diff`).
- `disabledReason` fully removed; all seven composer capability-menu sites use the shared helper with unchanged matchers and expected strings.
- Named follow-up, outside this PR: the main-push-only `checks-ui-e2e-real-gateway` / `mcp-app-conformance.e2e.test.ts` failure in "preserves composed operations and propagates caller cancellation through real transports" concerns a separate MCP App request-lifetime invariant, not exercised by PR lanes or addressed here. Its separate repair #131690 has now merged; this PR does not claim verification of that repair's main-push CI result.
- Production LOC delta 0 (test lane only). AI-assisted.
