### PR TITLE
fix(ci): let plugin prerelease build its own registry

### DIFF
--- a/.github/workflows/plugin-prerelease.yml
+++ b/.github/workflows/plugin-prerelease.yml
@@ -792,12 +792,6 @@ jobs:
       package_sha256: ${{ fromJSON(inputs.candidate_artifact_json || '{}').packageSha256 || '' }}
       package_version: ${{ fromJSON(inputs.candidate_artifact_json || '{}').packageVersion || '' }}
       enable_prepublish_plugin_registry: true
-      prepublish_plugin_registry_artifact_name: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactName || '' }}
-      prepublish_plugin_registry_artifact_id: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactId || '' }}
-      prepublish_plugin_registry_artifact_digest: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactDigest || '' }}
-      prepublish_plugin_registry_artifact_run_id: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunId || '' }}
-      prepublish_plugin_registry_artifact_run_attempt: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryArtifactRunAttempt || '' }}
-      prepublish_plugin_registry_manifest_sha256: ${{ fromJSON(inputs.candidate_artifact_json || '{}').prepublishPluginRegistryManifestSha256 || '' }}
       shared_image_artifact_name: ${{ fromJSON(inputs.candidate_artifact_json || '{}').imageArtifactName || '' }}
       shared_image_artifact_id: ${{ fromJSON(inputs.candidate_artifact_json || '{}').imageArtifactId || '' }}
       shared_image_artifact_digest: ${{ fromJSON(inputs.candidate_artifact_json || '{}').imageArtifactDigest || '' }}

--- a/test/scripts/plugin-prerelease-test-plan.test.ts
+++ b/test/scripts/plugin-prerelease-test-plan.test.ts
@@ -801,6 +801,16 @@ describe("scripts/lib/plugin-prerelease-test-plan.mts", () => {
         targeted_docker_lane_group_size: 2,
       },
     });
+    expect(dockerSuite.with.enable_prepublish_plugin_registry).toBe(true);
+    expect(
+      Object.keys(dockerSuite.with).filter((key) => key.startsWith("prepublish_plugin_registry_")),
+    ).toEqual([]);
+    expect(dockerSuite.with.package_artifact_id).toBe(
+      "${{ fromJSON(inputs.candidate_artifact_json || '{}').packageArtifactId || '' }}",
+    );
+    expect(dockerSuite.with.shared_image_artifact_id).toBe(
+      "${{ fromJSON(inputs.candidate_artifact_json || '{}').imageArtifactId || '' }}",
+    );
     expect(dockerSuite.secrets).toBeUndefined();
     expect(suite.needs).toEqual([
       "preflight",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Full Release Validation Plugin Prerelease could reuse a registry artifact built for the parent release plan, then fail when its own targeted Docker plan required a different plugin package such as Slack.

## Why This Change Was Made

The Plugin Prerelease child workflow now builds its prerelease plugin registry from its own selected Docker lanes. Candidate package and shared image artifacts remain reused; only the parent registry tuple is no longer forwarded.

## User Impact

Release operators can run Plugin Prerelease validation without a deterministic missing-package failure caused by cross-plan registry reuse.

## Evidence

- Regression assertion failed before the workflow change, reporting all six forwarded `prepublish_plugin_registry_*` keys.
- `node scripts/run-vitest.mjs test/scripts/plugin-prerelease-test-plan.test.ts test/scripts/docker-e2e-plan.test.ts test/scripts/prepublish-plugin-registry-artifact.test.ts` passed: 89 tests.
- `actionlint .github/workflows/plugin-prerelease.yml` passed.
- `pnpm lint:scripts` passed.
- Changed-file formatting and `git diff --check` passed.
- `pnpm check:workflows` was blocked before repository validation because the configured package index does not provide pinned `pre-commit==4.6.2`.
- `check-changed` passed guards through formatting and package checks, then the sparse worktree test-root typecheck stopped on unrelated files omitted by the sparse profile.

Production runtime LOC: 0. Workflow: -6. Tests: +10.

AI-assisted: yes.
