### PR TITLE
docs(plugins): clarify installed entrypoint source fallback

### DIFF
--- a/docs/plugins/sdk-entrypoints.md
+++ b/docs/plugins/sdk-entrypoints.md
@@ -36,17 +36,24 @@ built entries:
 
 - `extensions` and `setupEntry` are source entries, used for workspace and git
   checkout development.
-- `runtimeExtensions` and `runtimeSetupEntry` are preferred for installed
-  packages: they let npm packages skip runtime TypeScript compilation.
+- `runtimeExtensions` and `runtimeSetupEntry` select the built entries instead
+  of the corresponding source entries.
 - `runtimeExtensions`, when present, must match `extensions` in array length
   (entries pair positionally). `runtimeSetupEntry` requires `setupEntry`.
 - If a `runtimeExtensions`/`runtimeSetupEntry` artifact is declared but
-  missing, install/discovery fails with a packaging error; OpenClaw does not
-  silently fall back to source. Source fallback (below) only applies when no
-  runtime entry is declared at all.
-- If an installed package declares only a TypeScript source entry, OpenClaw
-  looks for a matching built `dist/*.js` (or `.mjs`/`.cjs`) peer and uses it;
-  otherwise it falls back to the TypeScript source.
+  missing, installation fails and discovery reports a packaging error for that
+  entry; OpenClaw does not silently fall back to source.
+- Without an explicit runtime entry, package discovery through
+  `plugins.load.paths` or global roots looks for matching JavaScript peers under
+  `dist/` first, then beside the TypeScript source entry, trying `.js`, `.mjs`,
+  and `.cjs` in that order at each location.
+- Package installation and managed installed-package discovery require compiled
+  output for TypeScript extension and setup entries. Missing compiled output is
+  a packaging error, not a reason to fall back to TypeScript.
+- Trusted local/source development paths can use TypeScript when no runtime
+  entry is declared. These include workspace plugins, explicit local load paths,
+  untracked local plugin directories, and linked source checkouts. Workspace
+  discovery keeps the source entry rather than inferring built peers.
 - All entry paths must stay inside the plugin package directory. Runtime
   entries and inferred built-JS peers do not make an escaping `extensions` or
   `setupEntry` source path valid.


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where plugin authors reading the SDK entry-point reference were told that an installed package could fall back to TypeScript when its compiled JavaScript peer was missing. That promise contradicts the installed-package validation and managed discovery contracts and can lead authors to publish incomplete packages.

## Why This Change Was Made

Correct the package-entry wording rather than weakening the existing runtime contract. The reference now distinguishes installed-package compiled-output requirements from trusted local/source development, explains the `dist/`-then-colocated JavaScript lookup order for configured/global package discovery, and keeps explicitly declared missing runtime artifacts as errors with no source fallback. Workspace source preference and linked/untracked local source paths remain supported.

This is docs-only. No runtime, tests, configuration, persistence, or compatibility behavior changes. Production LOC: +0/-0. Tests: +0/-0. Documentation: +15/-8.

## User Impact

Plugin authors can tell which artifacts an installed package must ship and when a local development checkout may use TypeScript source. The requirements apply to both plugin and setup entries. A missing setup runtime entry produces its own discovery diagnostic; the wording no longer implies that discovery necessarily drops an otherwise valid main plugin entry.

Reference: https://docs.openclaw.ai/plugins/sdk-entrypoints#package-entries

## Evidence

- Read the full root/scoped guides, complete `src/plugins/package-entry-resolution.ts`, built-peer candidate helper, full discovery/install callers, linked-source management caller, and relevant existing discovery/install/metadata tests before editing.
- Verified the audited files match current `main` at `150eb9a924c0ca74dde48e10b44dc2d5ca251081`; the resolver and original wording also match the reported snapshot `629a47e3cc20a9f8b6d19c105f840b8a693ec4aa`.
- Source enforcement: `src/plugins/package-entry-resolution.ts:143-334` (install validation), `:402-408` and `:509-570` (runtime selection and compiled-output requirements); `src/plugins/discovery.ts:460-518` and `:967-1070` (managed versus local discovery); `src/plugins/package-entrypoints.ts:10-30` (peer lookup order); `src/plugins/management-service.ts:1552-1587` (linked-source opt-in).
- History confirms that compiled-output enforcement and local-source exceptions are intentional existing behavior; this corrects stale prose, not a runtime regression.
- `pnpm docs:list` — passed.
- `node scripts/check-docs-mdx.mjs docs/plugins/sdk-entrypoints.md` — passed.
- `git diff --check` — passed.
- `node scripts/run-vitest.mjs src/plugins/discovery.test.ts src/plugins/install.test.ts --testNamePattern 'TypeScript|compiled runtime|runtime|dist entries|sourcePath as managed|package installs|linked source probes|escaping source entries' --reporter=verbose` — 52 selected tests passed; 177 tests outside the filter were skipped. The initial narrower run had one failure caused by this checkout lacking pnpm workspace dependency metadata; `pnpm install` resolved that prerequisite, and the rerun passed without changing runtime or test code.
- Fresh independent autoreview of the exact documentation diff and frozen source bundle was clean: no accepted/actionable findings; runtime behavior is unchanged.
- No live Gateway or UI proof is needed for this prose-only correction. No changelog edit; release context is captured in this PR.

AI-assisted documentation correction.
