### PR TITLE
fix: keep live replies after their delayed prompt

### DIFF
--- a/packages/gateway-client/src/session-projection.test.ts
+++ b/packages/gateway-client/src/session-projection.test.ts
@@ -296,6 +296,55 @@ describe("session transcript projection", () => {
     expect(state.messages).toEqual([previous, prompt, persisted]);
   });
 
+  it("keeps every early same-run reply behind its delayed durable prompt", () => {
+    const first = createMessage("assistant", "first current reply");
+    const second = createMessage("assistant", "second current reply");
+    const later = createMessage("assistant", "later current reply");
+    const unrelated = createMessage("assistant", "unrelated live reply");
+    const previous = createMessage("assistant", "previous durable reply", {
+      id: "previous",
+      seq: 10,
+    });
+    const following = createMessage("user", "following durable prompt", {
+      id: "following",
+      seq: 20,
+    });
+    const prompt = createMessage("user", "delayed current prompt", {
+      id: "current-prompt",
+      seq: 11,
+      idempotencyKey: "current-run:user",
+    });
+    let state = projectLiveSessionMessage(createSessionProjection(primaryScope), unrelated, {
+      runId: "unrelated-run",
+    });
+    state = projectLiveSessionMessage(state, first, { runId: "current-run" });
+    state = projectLiveSessionMessage(state, second, { runId: "current-run" });
+    state = projectLiveSessionMessage(state, previous);
+    state = projectLiveSessionMessage(state, following);
+    state = projectLiveSessionMessage(state, later, { runId: "current-run" });
+    state = projectLiveSessionMessage(state, prompt);
+
+    expect(state.messages).toEqual([unrelated, previous, prompt, first, second, following, later]);
+    expect(reconcileSessionProjectionSnapshot(state, [], primaryScope).messages).toEqual(
+      state.messages,
+    );
+  });
+
+  it("does not move an earlier durable same-run reply behind a later prompt", () => {
+    const previous = createMessage("assistant", "earlier reply from the same run", {
+      id: "earlier-reply",
+      seq: 10,
+      runId: "shared-run",
+    });
+    const prompt = createMessage("user", "later prompt", {
+      id: "later-prompt",
+      seq: 11,
+      idempotencyKey: "shared-run:user",
+    });
+    const state = projectLiveSessionMessage(createSessionProjection(primaryScope), previous);
+    expect(projectLiveSessionMessage(state, prompt).messages).toEqual([previous, prompt]);
+  });
+
   it("does not promote a provisional final into same-run Codex commentary", () => {
     const commentary = createMessage("assistant", "commentary", {
       id: "commentary-1",

--- a/packages/gateway-client/src/session-projection.ts
+++ b/packages/gateway-client/src/session-projection.ts
@@ -328,34 +328,20 @@ function insertEntry(
   if (incoming.identity?.role === "user" && incoming.identity.runId) {
     const runId = incoming.identity.runId;
     const terminalMessage = runs?.[runId]?.message;
-    const terminalIndex = entries.findIndex(
-      (entry) =>
-        entry.identity?.role === "assistant" &&
-        (entry.identity.runId === runId || entry.message === terminalMessage),
-    );
-    const terminalEntry = entries[terminalIndex];
-    if (
-      terminalEntry &&
-      sequence !== undefined &&
-      sequence !== null &&
-      nextIndex >= 0 &&
-      terminalIndex < nextIndex
-    ) {
-      // A live final may overtake its durable prompt. Move the pair together so
-      // the causal repair cannot leapfrog older sequenced transcript rows.
-      const withoutTerminal = entries.filter((_, index) => index !== terminalIndex);
-      const sequenceIndex = withoutTerminal.findIndex((entry) => {
-        const candidate = entry.identity?.sequence;
-        return candidate !== undefined && candidate !== null && candidate > sequence;
-      });
-      const promptIndex = sequenceIndex < 0 ? withoutTerminal.length : sequenceIndex;
-      return [
-        ...withoutTerminal.slice(0, promptIndex),
-        incoming,
-        terminalEntry,
-        ...withoutTerminal.slice(promptIndex),
-      ];
+    const belongsToRun = (entry: SessionProjectionEntry) =>
+      entry.identity?.role === "assistant" &&
+      (entry.identity.runId === runId || entry.message === terminalMessage);
+    if (sequence !== undefined && sequence !== null) {
+      // A run can deliver several replies before its prompt. Move every early
+      // unsequenced reply together; durable sequence always wins over run ownership.
+      const before: SessionProjectionEntry[] = [];
+      const replies: SessionProjectionEntry[] = [];
+      for (const entry of entries.slice(0, nextIndex)) {
+        (entry.identity?.sequence === null && belongsToRun(entry) ? replies : before).push(entry);
+      }
+      return [...before, incoming, ...replies, ...entries.slice(nextIndex)];
     }
+    const terminalIndex = entries.findIndex(belongsToRun);
     if (terminalIndex >= 0 && (nextIndex < 0 || terminalIndex < nextIndex)) {
       nextIndex = terminalIndex;
     }

--- a/ui/src/e2e/chat-live-final-order.e2e.test.ts
+++ b/ui/src/e2e/chat-live-final-order.e2e.test.ts
@@ -10,6 +10,102 @@ import {
 const suite = createChatFlowE2eSuite();
 
 suite.define(() => {
+  it("keeps multiple live replies after their delayed prompt before history catches up", async () => {
+    const artifactDir = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
+    if (artifactDir) {
+      await mkdir(artifactDir, { recursive: true });
+    }
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+      ...(artifactDir
+        ? { recordVideo: { dir: artifactDir, size: { width: 1280, height: 900 } } }
+        : {}),
+    });
+    const page = await context.newPage();
+    const runId = "multi-reply-run";
+    const replies = ["First part of the current answer.", "Second part of the current answer."];
+    const previous = "Previous durable conversation.";
+    const prompt = "Please give me both parts.";
+    try {
+      const gateway = await installMockGateway(page, {
+        deferredMethods: ["chat.history"],
+        methodResponses: {
+          "chat.startup": {
+            deltaCursor: "before-multi-reply",
+            messages: [],
+            sessionId: "control-ui-e2e-session",
+            sessionInfo: {
+              activeRunIds: [],
+              hasActiveRun: false,
+              key: "main",
+              kind: "direct",
+              status: "done",
+              updatedAt: Date.now(),
+            },
+          },
+        },
+      });
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
+      for (const [index, text] of replies.entries()) {
+        await gateway.emitGatewayEvent("chat", {
+          runId,
+          seq: index + 1,
+          sessionKey: "main",
+          state: "final",
+          message: { role: "assistant", content: [{ type: "text", text }], timestamp: Date.now() },
+        });
+        await page.locator(".chat-thread-inner").getByText(text, { exact: true }).waitFor();
+      }
+      for (const [id, seq, role, text, idempotencyKey] of [
+        ["previous", 10, "user", previous, "previous-run:user"],
+        ["current-prompt", 11, "user", prompt, `${runId}:user`],
+      ] as const) {
+        await gateway.emitGatewayEvent("session.message", {
+          message: {
+            role,
+            content: [{ type: "text", text }],
+            __openclaw: { id, seq, idempotencyKey },
+            timestamp: Date.now(),
+          },
+          messageId: id,
+          messageSeq: seq,
+          sessionKey: "main",
+          session: {
+            activeRunIds: [],
+            hasActiveRun: false,
+            key: "main",
+            kind: "direct",
+            status: "done",
+            updatedAt: Date.now(),
+          },
+        });
+        await page.locator(".chat-thread-inner").getByText(text, { exact: true }).waitFor();
+      }
+      if (artifactDir) {
+        await page.screenshot({
+          path: path.join(artifactDir, "multi-reply-order.png"),
+          fullPage: true,
+        });
+      }
+      await expect
+        .poll(() =>
+          page.locator(".chat-thread-inner").evaluate(
+            (thread, texts) => {
+              const rows = Array.from(thread.querySelectorAll(".chat-bubble"));
+              return texts.map((text) => rows.findIndex((row) => row.textContent?.includes(text)));
+            },
+            [previous, prompt, ...replies],
+          ),
+        )
+        .toEqual([0, 1, 2, 3]);
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
   it("keeps durable turns ordered when a live final arrives before transcript events", async () => {
     const context = await suite.newBrowserContext({
       locale: "en-US",


### PR DESCRIPTION
Closes #131629. Related: #131593.

## What Problem This Solves

Fixes an issue where users watching a live chat could see the second part of an answer above both the conversation and its own prompt when several replies arrived before the durable prompt event. The same repair could also move an already-sequenced reply behind a later prompt.

## Why This Change Was Made

The shared transcript projection now moves all early, unsequenced replies belonging to the incoming prompt's run together, while preserving durable transcript order. Run ownership groups provisional replies; it never overrides authoritative sequence numbers. This replaces the first-reply-only relocation rather than adding a UI-specific sort or changing message identity, deduplication, snapshots, provider behavior, or protocol.

Provenance: the first-reply-only repair came from #131593, merged as dc4de544bbf8f061d9348fa247b03ad79f47fccf on August 28. That PR's author and merger were @fuller-stack-dev. This extends its causal-order invariant to multiple replies and preserves sequenced siblings.

## User Impact

Live answers remain below their prompt and in their original order while history catches up. Existing durable messages, unrelated live replies, and later replies retain their positions. The shared owner covers both Control UI and TUI consumers; there are no new settings or migrations.

## Evidence

- Before the fix, both new projection regressions failed (70 passed, 2 failed). Afterward, 341 owner/sibling tests passed across nine files, including snapshot reconciliation, run terminal/event projection, history merge, pagination, session switching, and terminal ownership.
- Native Chromium with the real Control UI and a synthetic Gateway reproduced visible row indices `[1, 2, 3, 0]` instead of `[0, 1, 2, 3]`. After the fix, both live-final ordering browser scenarios passed. This is browser/transport-harness proof, not an authenticated provider or live-channel run.
- The matrix covers two early same-run replies, an unrelated live reply, older/newer durable rows, a same-run reply already after the durable insertion point, empty snapshot replay, and an earlier sequenced same-run reply.
- Independent Codex autoreview completed with no actionable findings. A separate read-only owner/sibling review found no blocking findings.
- Production LOC: +13/-27 (net -14). Tests: +145/-0. The old single-terminal relocation and second sequence search are removed.
- After rebasing onto the Gateway test repair #131627 (871b18dff5039484e86c76d282699a8defcb1654), the complete changed gate exited 0 and the refreshed ten-file test command exited 0 with 343 passing tests.
- CI [33154195935](https://github.com/openclaw/openclaw/actions/runs/33154195935) failed the independently reproduced disclosure-anchor fixture timeout (95 other tests in that shard passed). Its canonical repair landed in #131622 as 1deff1bac414e9474182f0c386983f0d7d508433. This PR is now refreshed at 4dc2238b7d34341ba0146d00b048dd4d3e6ec1a6, with all three patch files byte-identical to the reviewed version. The refreshed local run passed 350 tests across eleven files, including all seven repaired disclosure-anchor scenarios and both ordering browser scenarios. Exact-head CI [33157977898](https://github.com/openclaw/openclaw/actions/runs/33157977898) completed SUCCESS and the complete refreshed changed gate exited0. Neither gate was waived.

Commands:

```sh
node scripts/run-vitest.mjs packages/gateway-client/src/session-projection.test.ts packages/gateway-client/src/session-projection-conformance.test.ts packages/gateway-client/src/session-projection-run-terminal.test.ts packages/gateway-client/src/session-projection-run-event.test.ts ui/src/pages/chat/history-merge.test.ts ui/src/pages/chat/chat-gateway.test.ts ui/src/pages/chat/chat-projection-run-id.test.ts ui/src/pages/chat/chat-pane-history.test.ts ui/src/pages/chat/chat-pane-terminal.test.ts ui/src/e2e/chat-live-final-order.e2e.test.ts ui/src/e2e/chat-transcript-disclosure-anchor.e2e.test.ts --reporter=verbose
node scripts/check-changed.mjs -- packages/gateway-client/src/session-projection.ts packages/gateway-client/src/session-projection.test.ts ui/src/e2e/chat-live-final-order.e2e.test.ts
```

Before (synthetic data):

![Before: the second reply appears above its prompt](https://github.com/user-attachments/assets/7dda159c-1c44-475b-b73a-be0589c5a64e)

After (same synthetic flow):

![After: both replies follow their prompt in order](https://github.com/user-attachments/assets/265a31af-90a6-4d7d-bcda-87156f73469f)
