### PR TITLE
chore(codex): use synthetic identifiers in warning fixtures

### DIFF
--- a/extensions/codex/src/app-server/event-projector.reasoning.test.ts
+++ b/extensions/codex/src/app-server/event-projector.reasoning.test.ts
@@ -426,7 +426,7 @@ describe("CodexAppServerEventProjector reasoning and guardian projection", () =>
   });
 
   it.each([
-    { tier: "priority", model: "ultima-alpha" },
+    { tier: "priority", model: "test-unsupported-tier-model" },
     { tier: "flex", model: "test-no-tier-model" },
   ])("logs unsupported $tier tiers without projecting a UI notice", async ({ tier, model }) => {
     const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => {});
@@ -446,7 +446,7 @@ describe("CodexAppServerEventProjector reasoning and guardian projection", () =>
   it.each([
     "Project hooks were disabled.",
     "Configured service tier `priority` requires account access.",
-    "Configured service tier `priority` is not advertised as supported for model `ultima-alpha` and will be omitted from requests. Additional action required.",
+    "Configured service tier `priority` is not advertised as supported for model `test-unsupported-tier-model` and will be omitted from requests. Additional action required.",
   ])("surfaces startup and thread warnings: %s", async (message) => {
     const onAgentEvent = vi.fn();
     const projector = await createProjector({ ...(await createParams()), onAgentEvent });


### PR DESCRIPTION
Related: #131189

## What Problem This Solves

The service-tier warning tests used an environment-specific model identifier in two fixtures. Test data should use an obviously synthetic identifier instead.

## Why This Change Was Made

Replace only those two string literals with `test-unsupported-tier-model`. The warning template, assertions, coverage and production implementation are unchanged.

## User Impact

Repository test fixtures no longer retain the environment-specific identifier. This is test-data maintenance only: no runtime behavior, configuration, credentials, deployment or release changes.

## Evidence

Superseded before merge by [#131633](https://github.com/openclaw/openclaw/pull/131633), merged as [5c1a4661e787230a169302a2e9c5593984178332](https://github.com/openclaw/openclaw/commit/5c1a4661e787230a169302a2e9c5593984178332) while this PR was being prepared. Direct byte comparison confirms that canonical change replaced exactly the same two literals with the existing synthetic `test-no-tier-model`, preserving every other fixture byte. Current main retains that file. Canonical exact-head [CI run 33153954192](https://github.com/openclaw/openclaw/actions/runs/33153954192) succeeded for `5eb93d0b6f18f7efbe8c500cddbab83546ab01e9`. This duplicate reached successful native preparation but was not merged; no history rewrite or second fixture rename was performed.

The identical sanitized test file passed all 19 tests with:

```sh
node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.reasoning.test.ts --maxWorkers=1
```

Fresh isolated Codex autoreview exited 0 with no actionable findings. The complete current-source identifier scan passed; historical diffs were not scanned or rewritten. `git diff --check` passed. Production LOC: +0/-0; tests: +2/-2.

Direct upstream inspection at Codex `rust-v0.150.1` (`90854393966b21e9ebfd21b122334eb09a20c93d`), `codex-rs/core/src/session/mod.rs:950-963` and `codex-rs/core/tests/suite/model_switching.rs:788-824`, confirms that the fixture preserves the warning template and uses an arbitrary model slug. The sanitized file SHA-256 is `adc75441b4e06f19fd0f5806b684460909fbd91cc3da75b6973c29810d13bb23`, identical to the tested bytes. The recorded local run took 726.65 seconds wall time under host load; test execution was 2.74 seconds. No fresh full local build or live-provider run was performed for this test-data-only change.

Source head: `a6a014fc333bc58c86734327702d0eb3e406f377`. Exact-head CI [run 33154212167](https://github.com/openclaw/openclaw/actions/runs/33154212167) completed successfully on that head (attempt 1). The native CI watcher returned `GREEN`, and required `openclaw/ci-gate` is `SUCCESS`. The fresh worktree had no dependencies, so the commit hook could not locate `oxfmt`; its exact formatter command was run with the existing repository binary, preserving the reviewed SHA-256, before committing through the documented separate-format-proof path. Existing historical Git content is outside this current-content cleanup; no history rewrite or protection change is requested.

AI-assisted, maintainer-requested maintenance.
