### PR TITLE
fix(release): handle frozen plugin consent records

### DIFF
--- a/scripts/e2e/lib/upgrade-survivor/assertions.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/assertions.mjs
@@ -1075,8 +1075,26 @@ function assertCompanionPluginConsent(record, pluginId) {
   );
 }
 
-function assertCompanionPluginInstalls([expectedVersion]) {
+function assertLegacyCompanionPluginConsent(record, pluginId) {
+  for (const property of [
+    "acceptedSurface",
+    "acceptedSurfaceHash",
+    "acceptedSurfaceAt",
+    "acceptedSurfaceIntegrity",
+  ]) {
+    assert(
+      !Object.hasOwn(record, property),
+      `${pluginId} plugin legacy install retained consent property: ${property}`,
+    );
+  }
+}
+
+function assertCompanionPluginInstalls([expectedVersion, consentMode]) {
   assert(expectedVersion, "assert-companion-installs requires <expected-version>");
+  assert(
+    consentMode === "required" || consentMode === "unsupported",
+    "assert-companion-installs requires consent mode required or unsupported",
+  );
   const records = readInstalledPluginIndex().installRecords ?? {};
   for (const [pluginId, packageName, source] of [
     ["discord", "@openclaw/discord", "npm"],
@@ -1095,7 +1113,11 @@ function assertCompanionPluginInstalls([expectedVersion]) {
       packageJson.version === expectedVersion,
       `${pluginId} installed package version changed: ${String(packageJson.version)}`,
     );
-    assertCompanionPluginConsent(record, pluginId);
+    if (consentMode === "required") {
+      assertCompanionPluginConsent(record, pluginId);
+    } else {
+      assertLegacyCompanionPluginConsent(record, pluginId);
+    }
   }
 }
 

--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -473,17 +473,18 @@ NODE
 
 install_companion_plugins() {
   local authored_config="$OPENCLAW_UPGRADE_SURVIVOR_ARTIFACT_ROOT/companion-install-authored.json"
+  local capability_consent_mode=""
   local install_status=0
   local restore_status=0
   node "$OPENCLAW_UPGRADE_SURVIVOR_CONFIG_PARKING_HELPER" \
     park-companion-install "$OPENCLAW_CONFIG_PATH" "$authored_config"
 
   set +e
-  openclaw_e2e_fixture_plugin_command openclaw -- \
+  openclaw_e2e_fixture_plugin_command --consent-mode-output capability_consent_mode openclaw -- \
     plugins install "npm:@openclaw/discord@$package_version" --pin
   install_status=$?
   if [ "$install_status" -eq 0 ]; then
-    openclaw_e2e_fixture_plugin_command openclaw -- \
+    openclaw_e2e_fixture_plugin_command --consent-mode-output capability_consent_mode openclaw -- \
       plugins install "clawhub:@openclaw/whatsapp@$package_version"
     install_status=$?
   fi
@@ -493,7 +494,7 @@ install_companion_plugins() {
     install_status=$?
   fi
   if [ "$install_status" -eq 0 ]; then
-    openclaw_e2e_fixture_plugin_command openclaw -- \
+    openclaw_e2e_fixture_plugin_command --consent-mode-output capability_consent_mode openclaw -- \
       plugins install "npm:@openclaw/codex@$package_version" --pin
     install_status=$?
   fi
@@ -509,7 +510,7 @@ install_companion_plugins() {
     return "$restore_status"
   fi
   node scripts/e2e/lib/upgrade-survivor/assertions.mjs \
-    assert-companion-installs "$package_version"
+    assert-companion-installs "$package_version" "$capability_consent_mode"
 }
 
 openclaw_e2e_eval_test_state_from_b64 "${OPENCLAW_TEST_STATE_FUNCTION_B64:?missing OPENCLAW_TEST_STATE_FUNCTION_B64}"

--- a/scripts/lib/openclaw-e2e-instance.sh
+++ b/scripts/lib/openclaw-e2e-instance.sh
@@ -527,13 +527,18 @@ openclaw_e2e_run_command() {
   openclaw_e2e_maybe_timeout "$timeout_value" "$@"
 }
 openclaw_e2e_fixture_plugin_command() {
+  local consent_mode_output=""
+  if [[ "${1:-}" == "--consent-mode-output" ]]; then
+    consent_mode_output="$2"
+    shift 2
+  fi
   local runner=()
   while [[ "${1:-}" != "--" && "$#" -gt 0 ]]; do
     runner+=("$1")
     shift
   done
   shift
-  local help consent
+  local help consent detected_consent_mode="unsupported"
   # Use the caller's bounded runner for both calls; never cache across package replacement.
   help="$("${runner[@]}" "$1" "$2" --help)" || {
     local probe_status=$?
@@ -542,7 +547,11 @@ openclaw_e2e_fixture_plugin_command() {
   }
   consent="$(printf '%s' "$help" | node scripts/e2e/lib/package-compat.mjs fixture-consent)" || return $?
   if [[ -n "$consent" ]]; then
+    detected_consent_mode="required"
     set -- "$@" "$consent"
+  fi
+  if [[ -n "$consent_mode_output" ]]; then
+    printf -v "$consent_mode_output" '%s' "$detected_consent_mode"
   fi
   "${runner[@]}" "$@"
 }

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -2583,21 +2583,23 @@ docker_e2e_docker_run_cmd run demo
       publishedRunner.indexOf("phase doctor run_doctor"),
     );
     const discordInstallIndex = runner.indexOf(
-      'openclaw_e2e_fixture_plugin_command openclaw -- \\\n    plugins install "npm:@openclaw/discord@$package_version" --pin',
+      'openclaw_e2e_fixture_plugin_command --consent-mode-output capability_consent_mode openclaw -- \\\n    plugins install "npm:@openclaw/discord@$package_version" --pin',
     );
     const whatsappInstallIndex = runner.indexOf(
-      'openclaw_e2e_fixture_plugin_command openclaw -- \\\n      plugins install "clawhub:@openclaw/whatsapp@$package_version"',
+      'openclaw_e2e_fixture_plugin_command --consent-mode-output capability_consent_mode openclaw -- \\\n      plugins install "clawhub:@openclaw/whatsapp@$package_version"',
     );
     const clawhubRequestIndex = runner.indexOf(
       'assert-prepublish-requests "$OPENCLAW_CLAWHUB_URL" "@openclaw/whatsapp" "$package_version"',
     );
     const codexInstallIndex = runner.indexOf(
-      'openclaw_e2e_fixture_plugin_command openclaw -- \\\n      plugins install "npm:@openclaw/codex@$package_version" --pin',
+      'openclaw_e2e_fixture_plugin_command --consent-mode-output capability_consent_mode openclaw -- \\\n      plugins install "npm:@openclaw/codex@$package_version" --pin',
     );
     const restoreCompanionIndex = runner.indexOf(
       'restore "$OPENCLAW_CONFIG_PATH" "$authored_config"',
     );
-    const assertCompanionIndex = runner.indexOf('assert-companion-installs "$package_version"');
+    const assertCompanionIndex = runner.indexOf(
+      'assert-companion-installs "$package_version" "$capability_consent_mode"',
+    );
     expect(discordInstallIndex).toBeGreaterThan(-1);
     expect(discordInstallIndex).toBeLessThan(whatsappInstallIndex);
     expect(whatsappInstallIndex).toBeLessThan(clawhubRequestIndex);
@@ -2606,7 +2608,9 @@ docker_e2e_docker_run_cmd run demo
     expect(restoreCompanionIndex).toBeLessThan(assertCompanionIndex);
     expect(assertCompanionIndex).toBeLessThan(runnerPrepareIndex);
     expect(
-      runner.match(/openclaw_e2e_fixture_plugin_command openclaw -- \\\n\s+plugins install/gu),
+      runner.match(
+        /openclaw_e2e_fixture_plugin_command --consent-mode-output capability_consent_mode openclaw -- \\\n\s+plugins install/gu,
+      ),
     ).toHaveLength(3);
     expect(runner).not.toContain("--accept-capabilities");
     expect(runner).toContain('park-companion-install "$OPENCLAW_CONFIG_PATH" "$authored_config"');

--- a/test/scripts/package-compat.test.ts
+++ b/test/scripts/package-compat.test.ts
@@ -205,6 +205,32 @@ ${fixtureCommand} plugins update fixture`,
     ]);
   });
 
+  it.each([
+    [true, "required"],
+    [false, "unsupported"],
+  ])("reports capability consent mode from the help probe (supported=%s)", (supported, mode) => {
+    const root = tempDirs.make("openclaw-consent-mode-");
+    const entry = writeCandidate(root, { commands: supported ? undefined : [] });
+    const result = runShell(
+      root,
+      entry,
+      `
+source scripts/lib/openclaw-e2e-instance.sh
+consent_mode=
+openclaw_e2e_fixture_plugin_command --consent-mode-output consent_mode \
+  openclaw_e2e_maybe_timeout 5s node "$OPENCLAW_ENTRY" -- \
+  plugins install fixture
+printf 'consent-mode=%s\\n' "$consent_mode"
+`,
+    );
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain(`consent-mode=${mode}`);
+    expect(result.calls).toEqual([
+      ["plugins", "install", "--help"],
+      ["plugins", "install", "fixture", ...(supported ? [consent] : [])],
+    ]);
+  });
+
   it.each([true, false])(
     "consents to ClawHub install but not unchanged update (supported=%s)",
     (supported) => {

--- a/test/scripts/upgrade-survivor-assertions.test.ts
+++ b/test/scripts/upgrade-survivor-assertions.test.ts
@@ -308,6 +308,12 @@ const ACCEPTED_SURFACE = {
   skills: [],
   dangerousConfigFlags: [],
 };
+const CONSENT_PROPERTIES = [
+  "acceptedSurface",
+  "acceptedSurfaceHash",
+  "acceptedSurfaceAt",
+  "acceptedSurfaceIntegrity",
+] as const;
 
 function acceptedSurfaceHash(): string {
   return createHash("sha256").update(JSON.stringify(ACCEPTED_SURFACE)).digest("hex");
@@ -318,6 +324,7 @@ function assertCompanionPluginRecords(
     records: Record<string, Record<string, unknown>>,
     installPaths: Record<"codex" | "discord" | "whatsapp", string>,
   ) => void,
+  consentMode: string | null = "required",
 ): void {
   const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-survivor-companions-"));
   try {
@@ -397,7 +404,11 @@ function assertCompanionPluginRecords(
     mkdirSync(join(stateDir, "plugins"), { recursive: true });
     writeJson(join(stateDir, "plugins", "installs.json"), { installRecords: records });
 
-    execFileSync(process.execPath, [ASSERTIONS_PATH, "assert-companion-installs", version], {
+    const assertionArgs = [ASSERTIONS_PATH, "assert-companion-installs", version];
+    if (consentMode !== null) {
+      assertionArgs.push(consentMode);
+    }
+    execFileSync(process.execPath, assertionArgs, {
       env: {
         ...process.env,
         OPENCLAW_STATE_DIR: stateDir,
@@ -710,6 +721,42 @@ describe("upgrade survivor assertions", () => {
         Reflect.deleteProperty(discord, "acceptedSurfaceIntegrity");
       }),
     ).toThrow(/discord plugin consent integrity/);
+  });
+
+  it("accepts legacy companion records only when capability consent is unsupported", () => {
+    const removeConsent = (records: Record<string, Record<string, unknown>>) => {
+      for (const record of Object.values(records)) {
+        for (const property of CONSENT_PROPERTIES) {
+          Reflect.deleteProperty(record, property);
+        }
+      }
+    };
+    expect(() => assertCompanionPluginRecords(removeConsent, "unsupported")).not.toThrow();
+  });
+
+  it.each(CONSENT_PROPERTIES)(
+    "rejects legacy companion records retaining %s",
+    (retainedProperty) => {
+      expect(() =>
+        assertCompanionPluginRecords((records) => {
+          for (const record of Object.values(records)) {
+            for (const property of CONSENT_PROPERTIES) {
+              if (property !== retainedProperty) {
+                Reflect.deleteProperty(record, property);
+              }
+            }
+          }
+        }, "unsupported"),
+      ).toThrow(
+        new RegExp(`discord plugin legacy install retained consent property: ${retainedProperty}`),
+      );
+    },
+  );
+
+  it.each([null, "optional"])("rejects invalid companion consent mode %j", (mode) => {
+    expect(() => assertCompanionPluginRecords(undefined, mode)).toThrow(
+      /assert-companion-installs requires consent mode required or unsupported/,
+    );
   });
 
   it.each([


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation run https://github.com/openclaw/openclaw/actions/runs/33150824191 installed companion plugins from frozen target `6e9fefd1aa42fc4af0d7c0b4056fabf3e10d48e8`, then failed because the current harness unconditionally required capability-consent fields that the frozen CLI could not create.

## Why This Change Was Made

The existing bounded `plugins install --help` probe already establishes whether `--accept-capabilities` is supported. This change carries that same probe result as a closed `required|unsupported` mode into the upgrade-survivor assertion:

- `required` preserves the full artifact-bound surface, hash, integrity, and timestamp checks.
- `unsupported` requires all four consent properties to be absent while preserving source, managed path, package name, and version checks.
- Missing or unknown modes fail closed.

No version gates, provider exceptions, workflow changes, product runtime changes, configuration, or persistence are added.

## User Impact

Frozen package candidates that predate capability-consent records can complete upgrade-survivor validation without weakening checks for current candidates.

## Evidence

Pre-fix regression:

- Legacy records failed with `discord plugin accepted surface missing`.
- Missing and unknown consent modes were accepted.
- The Docker runner did not forward the probe-derived mode.

Passing validation:

```text
node scripts/run-vitest.mjs test/scripts/package-compat.test.ts test/scripts/upgrade-survivor-assertions.test.ts test/scripts/docker-build-helper.test.ts
209 tooling-docker tests passed
60 tooling tests passed

pnpm lint:scripts
bash -n scripts/lib/openclaw-e2e-instance.sh scripts/e2e/upgrade-survivor-docker.sh
oxfmt --check on changed JavaScript and TypeScript files
git diff --check
```

`check:changed` passed all guards before the root-test typecheck, which is unavailable in this sparse worktree because unrelated tracked UI, Android, and QA files are excluded and the shared install lacks the unrelated `pako` declaration.

Production runtime LOC: `0`. Harness: `+39/-7`. Tests: `+83/-6`.
