### PR TITLE
fix: give web and terminal users correct agent handoff guidance

### DIFF
--- a/src/system-agent/chat-turn-router.approval.test.ts
+++ b/src/system-agent/chat-turn-router.approval.test.ts
@@ -185,48 +185,6 @@ describe("SystemAgentChatEngine approval", () => {
     expect(engine.getPendingOperatorProposal()).toBeNull();
   });
 
-  it("hatches into the agent after a fresh setup applies", async () => {
-    useTempStateDir();
-    const verifyInferenceConfig = vi.fn(async () => ({
-      ok: true as const,
-      modelRef: "openai/gpt-5.5",
-      latencyMs: 100,
-    }));
-    const applySetup = vi.fn(async () => ({
-      configPath: "/tmp/openclaw.json",
-      configHashBefore: "before",
-      configHashAfter: "after",
-      bootstrapPending: true,
-      workspaceReady: true,
-      gateway: { status: "ready" as const, action: "reused" as const },
-      lines: ["Workspace: /tmp/hatch-work"],
-    }));
-    const engine = new SystemAgentChatEngine({
-      runAgentTurn: async () => null,
-      planWithAssistant: async () => null,
-      classifyApproval: async ({ message }) => (message === "yes" ? "approve" : "other"),
-      deps: {
-        applySetup,
-        verifyInferenceConfig,
-        loadOverview: fakeOverviewLoader({ defaultModel: "openai/gpt-5.5" }),
-      },
-    });
-    engine.propose({ kind: "setup", workspace: "/tmp/hatch-work" });
-
-    const reply = await engine.handle("yes");
-
-    expect(applySetup).toHaveBeenCalledOnce();
-    expect(reply.action).toBe("open-tui");
-    expect(reply.agentDraft).toBe("hatch");
-    expect(reply.handoff).toMatchObject({
-      kind: "open-tui",
-      workspace: "/tmp/hatch-work",
-      agentDraft: "hatch",
-    });
-    expect(reply.text).toContain("Your agent is hatching");
-    expect(reply.text).toContain("Settings → Ask OpenClaw");
-  });
-
   it.each([
     {
       origin: "custodian",

--- a/src/system-agent/chat-turn-router.handoff.test.ts
+++ b/src/system-agent/chat-turn-router.handoff.test.ts
@@ -1,0 +1,71 @@
+import "./chat-engine.mocks.test-support.js";
+import { describe, expect, it, vi } from "vitest";
+import {
+  fakeOverviewLoader,
+  useTempStateDir,
+  SystemAgentChatEngine,
+} from "./chat-engine.test-support.js";
+
+describe.each([
+  ["cli", "Use /openclaw to come back."],
+  ["gateway", "You can return through Settings → Ask OpenClaw."],
+] as const)("SystemAgentChatEngine %s handoff", (surface, returnHint) => {
+  it("handles the exact agent handoff without consulting a model", async () => {
+    const runAgentTurn = vi.fn(async () => ({ text: "model reply without a directive" }));
+    const engine = new SystemAgentChatEngine({
+      surface,
+      runAgentTurn,
+      deps: { loadOverview: fakeOverviewLoader() },
+    });
+
+    const reply = await engine.handle("talk to agent");
+
+    expect(runAgentTurn).not.toHaveBeenCalled();
+    expect(reply.action).toBe("open-tui");
+    expect(reply.handoff).toEqual({ kind: "open-tui" });
+    expect(reply.text).toBe(`Opening a chat with your agent. ${returnHint}`);
+  });
+
+  it("hatches into the agent after a fresh setup applies", async () => {
+    useTempStateDir();
+    const verifyInferenceConfig = vi.fn(async () => ({
+      ok: true as const,
+      modelRef: "openai/gpt-5.5",
+      latencyMs: 100,
+    }));
+    const applySetup = vi.fn(async () => ({
+      configPath: "/tmp/openclaw.json",
+      configHashBefore: "before",
+      configHashAfter: "after",
+      bootstrapPending: true,
+      workspaceReady: true,
+      gateway: { status: "ready" as const, action: "reused" as const },
+      lines: ["Workspace: /tmp/hatch-work"],
+    }));
+    const engine = new SystemAgentChatEngine({
+      surface,
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      classifyApproval: async ({ message }) => (message === "yes" ? "approve" : "other"),
+      deps: {
+        applySetup,
+        verifyInferenceConfig,
+        loadOverview: fakeOverviewLoader({ defaultModel: "openai/gpt-5.5" }),
+      },
+    });
+    engine.propose({ kind: "setup", workspace: "/tmp/hatch-work" });
+
+    const reply = await engine.handle("yes");
+
+    expect(applySetup).toHaveBeenCalledOnce();
+    expect(reply.action).toBe("open-tui");
+    expect(reply.agentDraft).toBe("hatch");
+    expect(reply.handoff).toMatchObject({
+      kind: "open-tui",
+      workspace: "/tmp/hatch-work",
+      agentDraft: "hatch",
+    });
+    expect(reply.text).toContain("Your agent is hatching");
+    expect(reply.text).toContain(returnHint);
+  });
+});

--- a/src/system-agent/chat-turn-router.operations.test.ts
+++ b/src/system-agent/chat-turn-router.operations.test.ts
@@ -132,20 +132,6 @@ describe("SystemAgentChatEngine operations", () => {
     );
   });
 
-  it("handles the exact agent handoff without consulting a usable model", async () => {
-    const runAgentTurn = vi.fn(async () => ({ text: "model reply without a directive" }));
-    const engine = new SystemAgentChatEngine({
-      runAgentTurn,
-      deps: { loadOverview: fakeOverviewLoader() },
-    });
-
-    const reply = await engine.handle("talk to agent");
-
-    expect(runAgentTurn).not.toHaveBeenCalled();
-    expect(reply.action).toBe("open-tui");
-    expect(reply.handoff).toEqual({ kind: "open-tui" });
-  });
-
   it("retires an agent proposal before a reusable Gateway handoff", async () => {
     const armed: boolean[] = [];
     let turn = 0;

--- a/src/system-agent/chat-turn-router.ts
+++ b/src/system-agent/chat-turn-router.ts
@@ -332,7 +332,7 @@ export class ChatTurnRouter {
       return {
         text: [
           baseText,
-          "Your agent is hatching — handing you over now. You can always find me in Settings → Ask OpenClaw.",
+          `Your agent is hatching — handing you over now. ${this.agentHandoffReturnHint()}`,
         ].join("\n\n"),
         action: "open-tui",
         agentDraft: "hatch",
@@ -479,7 +479,7 @@ export class ChatTurnRouter {
     if (recordedOperation.kind === "open-tui") {
       this.clearPendingProposals();
       return {
-        text: "Opening your normal agent TUI. Use /openclaw there to come back.",
+        text: `Opening a chat with your agent. ${this.agentHandoffReturnHint()}`,
         action: "open-tui",
         handoff: recordedOperation,
       };
@@ -633,6 +633,13 @@ export class ChatTurnRouter {
       ...this.options.deps,
       ...(this.options.surface ? { setupSurface: this.options.surface } : {}),
     };
+  }
+
+  private agentHandoffReturnHint(): string {
+    // Only the TUI uses /openclaw for navigation; web chat runs rescue in place.
+    return this.options.surface === "gateway"
+      ? "You can return through Settings → Ask OpenClaw."
+      : "Use /openclaw to come back.";
   }
 
   private clearPendingProposals(): void {


### PR DESCRIPTION
Closes #131623

<details>
<summary>Additional instructions</summary>

This branch is in the main repository and remains editable by maintainers.

</details>

## What Problem This Solves

Fixes an issue where users choosing **Talk to my agent** in the Control UI would be told that a terminal UI was opening and instructed to use `/openclaw` to return. Web chat opens correctly, but that command runs the repair helper in place instead of reopening Ask OpenClaw. The related post-setup hatch message had the inverse error: it told terminal users to navigate through Settings.

## Why This Change Was Made

The shared chat turn router owns these replies and already knows whether its caller is the CLI or Gateway. Both handoff paths now use one client-specific return hint, with neutral wording for the chat destination. Fixing the producer also keeps the recorded conversation correct; the Gateway adapter and UI do not rewrite response text.

No action names, handoff targets, approval behavior, protocol, configuration, or persistent stores change. Production delta is +9/-2 (net +7), including the shared private selector and its contract comment. A single neutral return hint cannot describe both existing client navigation contracts; dropping the hint would lose useful guidance. This small selector removes the two contradictory inline hints without creating downstream policy.

## User Impact

Web users are directed to **Settings → Ask OpenClaw**. Terminal users retain the working `/openclaw` return command. This applies to both direct handoff and successful setup/agent hatch.

Release-note context is retained here rather than editing the release-owned changelog, as approved by the maintainer.

## Evidence

Landing refresh: rebased onto current main to resolve the overlapping router-test change, preserving main's delegated-navigation cases. The production patch is unchanged; independent Codex review of the resolved patch reported no blocking findings. The original source head's CI passed on a failed-shard retry; the unrelated Canvas doctor timeout is tracked in #131674. The next run hit the managed-image browser test's ambient `expect.poll()` context race. Existing fix #132066 is now included from main; no duplicate repair or weaker assertions were added. Range-diff confirms the handoff patch is identical. Exact-head CI33207130843 attempt 1 passed for `4d52ddaa9019aaf20887babf2d5768cfe2559241`, including the aggregate CI gate. The latest exact-head ClawSweeper review reports no findings and sufficient real-browser proof; the maintainer explicitly approved landing.

Codex-assisted live QA reproduced the original message in real Chrome against a freshly built, task-isolated Gateway on macOS 26.6.2. Following `/openclaw` in web chat produced the repair-helper hint, not navigation; following Settings → Ask OpenClaw opened the correct page. A normal agent chat returned the requested `QA-ready` response.

The extended existing regression cases failed before the repair. Afterward, all 143 tests passed:

```text
node scripts/run-vitest.mjs src/system-agent/chat-turn-router.operations.test.ts src/system-agent/chat-turn-router.approval.test.ts src/system-agent/chat-turn-router.handoff.test.ts src/system-agent/operations.tui.test.ts
```

Final proof: all 143 tests across four files passed; `pnpm build` and the changed-file repository gate exited 0. Independent Codex autoreview reported no findings at its default blocking threshold. The first changed-check run caught the approval test file exceeding the line limit; both retained handoff cases now share a focused CLI/Gateway table in `chat-turn-router.handoff.test.ts`, and the rerun passed. Test delta is +71/-56 (net +15), largely moving existing cases.

On the patched Gateway, selecting **Talk to my agent** opened `/chat/main` and displayed the correct Settings return hint. Old history remains unchanged. Settings → Ask OpenClaw was verified again; one Settings navigation changed the URL but retained the chat view until reload, recorded separately below rather than attributed to this copy-only patch.

Before:

![Before: web handoff gives terminal-only instructions](https://github.com/user-attachments/assets/2836cdf6-a30e-441b-a690-8d3c5e6a8016)

After (new reply below the preserved historical reply):

![After: web handoff gives the Settings return path](https://github.com/user-attachments/assets/c6666fe1-c35a-43ba-a101-8e7a9873b0ce)

Source evidence: `src/system-agent/chat-turn-router.ts` owns the reply; `src/gateway/server-methods/system-agent-chat-turn.ts` maps the action while preserving text; `ui/src/pages/custodian/custodian-session-store.ts` records it before navigation. `src/tui/tui-command-handlers.ts` implements the terminal return command. The existing web and TUI docs already describe their respective return paths.

Provenance: the terminal wording was carried unchanged into the router by commit `6e851103dc81` on 2026-08-11, authored/committed by Peter Steinberger. No original-introduction or PR-merger attribution is claimed from that file split.

Separate QA follow-ups, not claimed fixed here: first cold guided activation took 112.5 seconds and recorded event-loop stalls; that needs profiling. One post-rebuild Settings navigation retained the previous view until reload; investigate route loading/recovery separately. The previously observed post-activation deletion guard failure did not recur in this run: deletion succeeded before setup, after hot activation, and again roughly 113 seconds after reload, without restarting the Gateway.
