### PR TITLE
fix(web-fetch): honor zero and shortened cache TTL on reads across fetch and search

### DIFF
--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -1127,6 +1127,15 @@ catalog, API-key auth, and dynamic model resolution.
         `hint`, `envVars`, `placeholder`, `signupUrl`, `credentialPath`,
         `getCredentialValue`, `setCredentialValue`, and `createTool` are all
         required.
+
+        Search providers using `openclaw/plugin-sdk/provider-web-search` should
+        resolve `resolveSearchCacheTtlMs(searchConfig)` once per execution and
+        pass that value to both `readCachedSearchPayload(cacheKey, ttlMs)` and
+        `writeCachedSearchPayload(cacheKey, payload, ttlMs)`. A zero TTL bypasses
+        reads and writes; a positive TTL bounds entry age without extending its
+        original expiry. Reads return a payload marked `cached: true`, or
+        `undefined` on a miss. The reader's `ttlMs` argument is optional:
+        existing one-argument calls continue to use the stored expiry alone.
       </Tab>
     </Tabs>
 

--- a/docs/tools/firecrawl.md
+++ b/docs/tools/firecrawl.md
@@ -77,6 +77,12 @@ Notes:
 - `FIRECRAWL_BASE_URL` is the shared env fallback for Firecrawl search and scrape base URLs.
 - Firecrawl search requests default to a 30-second timeout; `firecrawl_search`'s `timeoutSeconds` parameter overrides it per call.
 
+Both Firecrawl `web_search` providers and `firecrawl_search` use
+`tools.web.search.cacheTtlMinutes` for OpenClaw's local result cache (default: 15
+minutes). Set it to `0` to bypass cache reads and writes. A shorter TTL limits
+reuse of existing entries; a longer TTL does not extend their original expiry.
+This setting does not change Firecrawl's upstream scrape caching.
+
 ## Configure Firecrawl web_fetch fallback
 
 ```json5

--- a/docs/tools/tavily.md
+++ b/docs/tools/tavily.md
@@ -131,6 +131,12 @@ The generic `web_search` tool with Tavily as provider supports `query` and `coun
 
 ## Advanced configuration
 
+Tavily `web_search` and `tavily_search` use `tools.web.search.cacheTtlMinutes`
+for OpenClaw's local result cache (default: 15 minutes). Set it to `0` to bypass
+cache reads and writes. A shorter TTL limits reuse of existing entries; a
+longer TTL does not extend their original expiry. This setting does not control
+the separate `tavily_extract` cache.
+
 <AccordionGroup>
   <Accordion title="API key resolution order">
     The Tavily client looks up its API key in this order:

--- a/docs/tools/web-fetch.md
+++ b/docs/tools/web-fetch.md
@@ -83,6 +83,11 @@ truncated. The caller's requested URL is preserved.
   </Step>
 </Steps>
 
+Set `tools.web.fetch.cacheTtlMinutes: 0` to bypass OpenClaw's fetch cache for both
+reads and writes. A positive value limits reuse by the current request's TTL;
+cached entries still expire at their original deadline. Provider-side caching,
+such as Firecrawl's `maxAgeMs`, is configured separately.
+
 ## Progress updates
 
 `web_fetch` emits a public progress line only when the fetch is still pending

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -561,6 +561,11 @@ every provider. xAI credentials are always required.
 it falls back to `plugins.entries.xai.config.webSearch.baseUrl`, then the
 public xAI endpoint (`https://api.x.ai/v1`).
 
+`plugins.entries.xai.config.xSearch.cacheTtlMinutes` controls OpenClaw's local
+`x_search` result cache. Set it to `0` to bypass reads and writes. A shorter TTL
+limits reuse of existing entries; a longer TTL does not extend their original
+expiry.
+
 ### x_search parameters
 
 | Parameter                    | Description                                            |

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -384,6 +384,11 @@ trusted proxy owns those synthetic ranges.
 }
 ```
 
+`tools.web.search.cacheTtlMinutes` controls OpenClaw's local search-result
+caches. Set it to `0` to bypass reads and writes, even for previously cached
+queries. A shorter positive TTL limits reuse by entry age; a longer TTL does
+not extend an entry's original expiry. Provider-side caching is separate.
+
 Provider-specific config (API keys, base URLs, modes) lives under
 `plugins.entries.<plugin>.config.webSearch.*`. Gemini can also reuse
 `models.providers.google.apiKey` and `models.providers.google.baseUrl` as lower-priority

--- a/extensions/brave/src/brave-web-search-provider.runtime.ts
+++ b/extensions/brave/src/brave-web-search-provider.runtime.ts
@@ -442,7 +442,8 @@ export async function executeBraveSearch(
         ],
   );
   const diagnostics: BraveHttpDiagnostics = { enabled: options?.diagnosticsEnabled === true };
-  const cached = readCachedSearchPayload(cacheKey);
+  const cacheTtlMs = resolveSearchCacheTtlMs(searchConfig);
+  const cached = readCachedSearchPayload(cacheKey, cacheTtlMs);
   if (cached) {
     logBraveHttp(diagnostics, "cache hit", { mode: braveMode, query, cacheKey });
     return cached;
@@ -451,7 +452,6 @@ export async function executeBraveSearch(
 
   const start = Date.now();
   const timeoutSeconds = resolveSearchTimeoutSeconds(searchConfig);
-  const cacheTtlMs = resolveSearchCacheTtlMs(searchConfig);
   const request = {
     baseUrl: braveBaseUrl,
     endpointMode: braveEndpointMode,

--- a/extensions/brave/src/brave-web-search-provider.test.ts
+++ b/extensions/brave/src/brave-web-search-provider.test.ts
@@ -491,6 +491,59 @@ describe("brave web search provider", () => {
     expect(fetchRequestUrl(mockFetch, 1).pathname).toBe("/proxy-two/res/v1/web/search");
   });
 
+  it.each([
+    { mode: "web", cacheTtlMinutes: 0 },
+    { mode: "web", cacheTtlMinutes: 1 },
+    { mode: "llm-context", cacheTtlMinutes: 0 },
+    { mode: "llm-context", cacheTtlMinutes: 1 },
+  ])("honors current $mode cache TTL $cacheTtlMinutes", async ({ mode, cacheTtlMinutes }) => {
+    const now = Date.now();
+    const clock = vi.spyOn(Date, "now").mockReturnValue(now);
+    let requestCount = 0;
+    const mockFetch = vi.fn(async () => {
+      const result = { url: `https://example.com/result-${++requestCount}` };
+      return jsonResponse(
+        mode === "web" ? { web: { results: [result] } } : { grounding: { generic: [result] } },
+      );
+    });
+    global.fetch = mockFetch as typeof global.fetch;
+    const cachedTool = createBraveTool({
+      webSearch: { apiKey: "brave-test-key", mode },
+      searchConfig: { cacheTtlMinutes: 15 },
+    });
+    const currentTool = createBraveTool({
+      webSearch: { apiKey: "brave-test-key", mode },
+      searchConfig: { cacheTtlMinutes },
+    });
+    const args = { query: `brave cache TTL ${mode} ${cacheTtlMinutes}` };
+
+    try {
+      const original = await cachedTool.execute(args);
+      expect(original).toMatchObject({ results: [{ url: "https://example.com/result-1" }] });
+      expect(await cachedTool.execute(args)).toEqual({ ...original, cached: true });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      clock.mockReturnValue(now + 60_000);
+      const fresh = await currentTool.execute(args);
+      expect(fresh).toMatchObject({ results: [{ url: "https://example.com/result-2" }] });
+      expect(fresh).not.toHaveProperty("cached");
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+
+      if (cacheTtlMinutes === 0) {
+        expect(await currentTool.execute(args)).toMatchObject({
+          results: [{ url: "https://example.com/result-3" }],
+        });
+        expect(await cachedTool.execute(args)).toEqual({ ...original, cached: true });
+        expect(mockFetch).toHaveBeenCalledTimes(3);
+      } else {
+        expect(await currentTool.execute(args)).toEqual({ ...fresh, cached: true });
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+      }
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
   it("rejects invalid Brave mode values in the plugin config schema", () => {
     if (!braveManifest.configSchema) {
       throw new Error("Expected Brave manifest config schema");

--- a/extensions/duckduckgo/src/ddg-client.ts
+++ b/extensions/duckduckgo/src/ddg-client.ts
@@ -137,7 +137,10 @@ export async function runDuckDuckGoSearch(params: {
       ? params.safeSearch
       : resolveDdgSafeSearch(params.config);
   const timeoutSeconds = resolveTimeoutSeconds(params.timeoutSeconds, DEFAULT_TIMEOUT_SECONDS);
-  const cacheTtlMs = resolveCacheTtlMs(params.cacheTtlMinutes, DEFAULT_CACHE_TTL_MINUTES);
+  const cacheTtlMs = resolveCacheTtlMs(
+    params.cacheTtlMinutes ?? params.config?.tools?.web?.search?.cacheTtlMinutes,
+    DEFAULT_CACHE_TTL_MINUTES,
+  );
   const cacheKey = normalizeCacheKey(
     JSON.stringify({
       provider: "duckduckgo",
@@ -147,7 +150,7 @@ export async function runDuckDuckGoSearch(params: {
       safeSearch,
     }),
   );
-  const cached = readCache(DDG_SEARCH_CACHE, cacheKey);
+  const cached = readCache(DDG_SEARCH_CACHE, cacheKey, cacheTtlMs);
   if (cached) {
     return { ...cached.value, cached: true };
   }

--- a/extensions/duckduckgo/src/ddg-search-provider.cache.test.ts
+++ b/extensions/duckduckgo/src/ddg-search-provider.cache.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDuckDuckGoWebSearchProvider } from "./ddg-search-provider.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("DuckDuckGo provider cache TTL", () => {
+  it.each([0, 1])(
+    "applies the current %s-minute TTL to cached results",
+    async (cacheTtlMinutes) => {
+      const clock = vi.spyOn(Date, "now").mockReturnValue(Date.now());
+      let requests = 0;
+      const fetch = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+        requests += 1;
+        return new Response(
+          `<a class="result__a" href="https://example.com/${requests}">Result ${requests}</a>`,
+          { headers: { "content-type": "text/html" } },
+        );
+      });
+      const search = async (ttl: number) => {
+        const searchConfig = { cacheTtlMinutes: ttl };
+        const tool = createDuckDuckGoWebSearchProvider().createTool({
+          config: { tools: { web: { search: searchConfig } } },
+          searchConfig,
+        });
+        if (!tool) {
+          throw new Error("Expected DuckDuckGo search tool");
+        }
+        return await tool.execute({ query: `DuckDuckGo current TTL ${cacheTtlMinutes}` });
+      };
+
+      const original = await search(15);
+      expect(await search(15)).toEqual({ ...original, cached: true });
+      expect(fetch).toHaveBeenCalledTimes(1);
+
+      if (cacheTtlMinutes > 0) {
+        clock.mockReturnValue(Date.now() + 60_000);
+      }
+      const fresh = await search(cacheTtlMinutes);
+      expect(fresh.cached).toBeUndefined();
+      expect(fresh.results).toEqual([expect.objectContaining({ url: "https://example.com/2" })]);
+      expect(fetch).toHaveBeenCalledTimes(2);
+
+      if (cacheTtlMinutes === 0) {
+        const next = await search(0);
+        expect(next.cached).toBeUndefined();
+        expect(next.results).toEqual([expect.objectContaining({ url: "https://example.com/3" })]);
+        expect(await search(15)).toEqual({ ...original, cached: true });
+        expect(fetch).toHaveBeenCalledTimes(3);
+      } else {
+        expect(await search(1)).toEqual({ ...fresh, cached: true });
+        expect(fetch).toHaveBeenCalledTimes(2);
+      }
+    },
+  );
+});

--- a/extensions/exa/src/exa-web-search-provider.runtime.ts
+++ b/extensions/exa/src/exa-web-search-provider.runtime.ts
@@ -494,7 +494,8 @@ export async function executeExaWebSearchProviderTool(
     dateBefore,
     contents,
   });
-  const cached = readCachedSearchPayload(cacheKey);
+  const cacheTtlMs = resolveSearchCacheTtlMs(searchConfig);
+  const cached = readCachedSearchPayload(cacheKey, cacheTtlMs);
   if (cached) {
     return cached;
   }
@@ -554,7 +555,7 @@ export async function executeExaWebSearchProviderTool(
     }),
   };
 
-  writeCachedSearchPayload(cacheKey, payload, resolveSearchCacheTtlMs(searchConfig));
+  writeCachedSearchPayload(cacheKey, payload, cacheTtlMs);
   return payload;
 }
 

--- a/extensions/exa/src/exa-web-search-provider.test.ts
+++ b/extensions/exa/src/exa-web-search-provider.test.ts
@@ -246,6 +246,58 @@ describe("exa web search provider", () => {
     expect(new Set(disabledKeys).size).toBe(disabledKeys.length);
   });
 
+  it.each([0, 1])("honors the current cache TTL %s", async (cacheTtlMinutes) => {
+    const now = Date.now();
+    const clock = vi.spyOn(Date, "now").mockReturnValue(now);
+    let requestCount = 0;
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(
+        async () =>
+          new Response(
+            JSON.stringify({ results: [{ url: `https://example.com/result-${++requestCount}` }] }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+      );
+    const provider = createExaWebSearchProvider();
+    const config = {
+      plugins: { entries: { exa: { config: { webSearch: { apiKey: "exa-test-key" } } } } },
+    };
+    const cachedTool = provider.createTool({ config, searchConfig: { cacheTtlMinutes: 15 } });
+    const currentTool = provider.createTool({ config, searchConfig: { cacheTtlMinutes } });
+    const args = { query: `exa cache TTL ${cacheTtlMinutes}` };
+
+    try {
+      if (!cachedTool || !currentTool) {
+        throw new Error("Expected tool definitions");
+      }
+      const original = await cachedTool.execute(args);
+      expect(original).toMatchObject({ results: [{ url: "https://example.com/result-1" }] });
+      expect(await cachedTool.execute(args)).toEqual({ ...original, cached: true });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      clock.mockReturnValue(now + 60_000);
+      const fresh = await currentTool.execute(args);
+      expect(fresh).toMatchObject({ results: [{ url: "https://example.com/result-2" }] });
+      expect(fresh).not.toHaveProperty("cached");
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+
+      if (cacheTtlMinutes === 0) {
+        expect(await currentTool.execute(args)).toMatchObject({
+          results: [{ url: "https://example.com/result-3" }],
+        });
+        expect(await cachedTool.execute(args)).toEqual({ ...original, cached: true });
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+      } else {
+        expect(await currentTool.execute(args)).toEqual({ ...fresh, cached: true });
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+      }
+    } finally {
+      clock.mockRestore();
+      fetchMock.mockRestore();
+    }
+  });
+
   it("normalizes Exa result descriptions from highlights before text", () => {
     expect(
       testing.resolveExaDescription({

--- a/extensions/firecrawl/src/firecrawl-cache.test.ts
+++ b/extensions/firecrawl/src/firecrawl-cache.test.ts
@@ -1,0 +1,117 @@
+import { createServer, type Server } from "node:http";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createFirecrawlFreeWebSearchProvider } from "./firecrawl-free-search-provider.js";
+import { createFirecrawlWebSearchProvider } from "./firecrawl-search-provider.js";
+import { createFirecrawlSearchTool } from "./firecrawl-search-tool.js";
+
+describe.each(["keyed", "free", "standalone"] as const)("Firecrawl %s search cache", (kind) => {
+  let server: Server;
+  let baseUrl: string;
+  let networkCalls: number;
+  let body: string;
+
+  beforeEach(async () => {
+    networkCalls = 0;
+    body = "original";
+    server = createServer((_request, response) => {
+      networkCalls += 1;
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          success: true,
+          data: [{ url: `https://example.com/${body}`, title: body }],
+        }),
+      );
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected a loopback TCP address");
+    }
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+      server.closeAllConnections();
+    });
+  });
+
+  async function search(query: string, cacheTtlMinutes: number) {
+    const config: OpenClawConfig = {
+      tools: { web: { search: { cacheTtlMinutes } } },
+      plugins: {
+        entries: {
+          firecrawl: { config: { webSearch: { baseUrl, apiKey: "firecrawl-cache-test-key" } } },
+        },
+      },
+    };
+    if (kind === "standalone") {
+      const tool = createFirecrawlSearchTool(createTestPluginApi({ config }));
+      return (await tool.execute("cache-test", { query })).details;
+    }
+    const provider =
+      kind === "free" ? createFirecrawlFreeWebSearchProvider() : createFirecrawlWebSearchProvider();
+    const tool = provider.createTool({ config, searchConfig: config.tools?.web?.search });
+    if (!tool) {
+      throw new Error("expected Firecrawl search tool");
+    }
+    return await tool.execute({ query });
+  }
+
+  it.each([0, 15])("bypasses reads and writes after starting with TTL %i", async (initialTtl) => {
+    const query = `${kind} cache disable from ${initialTtl}`;
+    expect(await search(query, initialTtl)).toMatchObject({
+      results: [{ url: "https://example.com/original" }],
+    });
+    if (initialTtl > 0) {
+      expect(await search(query, initialTtl)).toMatchObject({ cached: true });
+    }
+    expect(networkCalls).toBe(1);
+
+    for (const freshBody of ["fresh", "newest"]) {
+      body = freshBody;
+      const result = await search(query, 0);
+      expect(result).toMatchObject({ results: [{ url: `https://example.com/${freshBody}` }] });
+      expect(result).not.toHaveProperty("cached");
+    }
+    expect(networkCalls).toBe(3);
+
+    // Disabled requests must neither replace an existing entry nor populate an empty cache.
+    body = "reenabled";
+    expect(await search(query, 15)).toMatchObject({
+      results: [{ url: `https://example.com/${initialTtl > 0 ? "original" : "reenabled"}` }],
+    });
+    expect(networkCalls).toBe(initialTtl > 0 ? 3 : 4);
+  });
+
+  it("honors a shorter reader TTL and does not extend the replacement entry's expiry", async () => {
+    let now = Date.now();
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    const query = `${kind} shorter cache TTL`;
+    await search(query, 15);
+    now += 59_999;
+    expect(await search(query, 1)).toMatchObject({ cached: true });
+    expect(networkCalls).toBe(1);
+
+    now += 1;
+    body = "fresh";
+    const shortened = await search(query, 1);
+    expect(shortened).toMatchObject({ results: [{ url: "https://example.com/fresh" }] });
+    expect(shortened).not.toHaveProperty("cached");
+    expect(networkCalls).toBe(2);
+
+    now += 60_001;
+    body = "expired";
+    const expired = await search(query, 15);
+    expect(expired).toMatchObject({ results: [{ url: "https://example.com/expired" }] });
+    expect(expired).not.toHaveProperty("cached");
+    expect(networkCalls).toBe(3);
+  });
+});

--- a/extensions/firecrawl/src/firecrawl-client.ts
+++ b/extensions/firecrawl/src/firecrawl-client.ts
@@ -469,7 +469,11 @@ export async function runFirecrawlSearch(
       scrapeResults,
     }),
   );
-  const cached = readCache(SEARCH_CACHE, cacheKey);
+  const cacheTtlMs = resolveCacheTtlMs(
+    params.cfg?.tools?.web?.search?.cacheTtlMinutes,
+    DEFAULT_CACHE_TTL_MINUTES,
+  );
+  const cached = readCache(SEARCH_CACHE, cacheKey, cacheTtlMs);
   if (cached) {
     return { ...cached.value, cached: true };
   }
@@ -545,12 +549,7 @@ export async function runFirecrawlSearch(
     tookMs: Date.now() - start,
     scrapeResults,
   });
-  writeCache(
-    SEARCH_CACHE,
-    cacheKey,
-    result,
-    resolveCacheTtlMs(undefined, DEFAULT_CACHE_TTL_MINUTES),
-  );
+  writeCache(SEARCH_CACHE, cacheKey, result, cacheTtlMs);
   return result;
 }
 

--- a/extensions/google/src/gemini-web-search-provider.runtime.ts
+++ b/extensions/google/src/gemini-web-search-provider.runtime.ts
@@ -445,7 +445,8 @@ export async function executeGeminiSearch(
     timeRange.dateBefore,
     headersCacheKey,
   ]);
-  const cached = readCachedSearchPayload(cacheKey);
+  const cacheTtlMs = resolveSearchCacheTtlMs(searchConfig);
+  const cached = readCachedSearchPayload(cacheKey, cacheTtlMs);
   if (cached) {
     return cached;
   }
@@ -476,6 +477,6 @@ export async function executeGeminiSearch(
     content: wrapWebContent(result.content),
     citations: result.citations,
   };
-  writeCachedSearchPayload(cacheKey, payload, resolveSearchCacheTtlMs(searchConfig));
+  writeCachedSearchPayload(cacheKey, payload, cacheTtlMs);
   return payload;
 }

--- a/extensions/google/web-search-provider.test.ts
+++ b/extensions/google/web-search-provider.test.ts
@@ -210,6 +210,55 @@ describe("google web search provider", () => {
     expect(postCalls).toHaveLength(1);
   });
 
+  it.each([0, 1])("honors the current Gemini cache TTL of %s minutes", async (cacheTtlMinutes) => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_000_000);
+    let content = "Original grounded answer";
+    const mockFetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ candidates: [{ content: { parts: [{ text: content }] } }] })),
+    );
+    vi.stubGlobal("fetch", withFetchPreconnect(mockFetch));
+    const provider = createGeminiWebSearchProvider();
+    const createTool = (ttl: number) =>
+      provider.createTool({
+        config: {
+          plugins: {
+            entries: { google: { config: { webSearch: { apiKey: "AIza-plugin-test" } } } },
+          },
+        },
+        searchConfig: { provider: "gemini", cacheTtlMinutes: ttl },
+      });
+    const query = `Gemini current request cache TTL ${cacheTtlMinutes}`;
+    const cachedTool = createTool(15);
+    await cachedTool?.execute({ query });
+    await expect(cachedTool?.execute({ query })).resolves.toMatchObject({
+      cached: true,
+      content: expect.stringContaining("Original grounded answer"),
+    });
+    expect(mockFetch).toHaveBeenCalledOnce();
+
+    now.mockReturnValue(1_060_000);
+    content = "Fresh grounded answer";
+    const currentTool = createTool(cacheTtlMinutes);
+    const fresh = await currentTool?.execute({ query });
+    expect(fresh).not.toHaveProperty("cached");
+    expect(fresh).toMatchObject({ content: expect.stringContaining("Fresh grounded answer") });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    if (cacheTtlMinutes === 0) {
+      await expect(currentTool?.execute({ query })).resolves.not.toHaveProperty("cached");
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      await expect(cachedTool?.execute({ query })).resolves.toMatchObject({
+        cached: true,
+        content: expect.stringContaining("Original grounded answer"),
+      });
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    } else {
+      await expect(currentTool?.execute({ query })).resolves.toEqual({ ...fresh, cached: true });
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    }
+  });
+
   it("does not partition cached results by overwritten provider-owned headers", async () => {
     const mockFetch = installGeminiFetch();
 

--- a/extensions/minimax/src/minimax-web-search-provider.runtime.ts
+++ b/extensions/minimax/src/minimax-web-search-provider.runtime.ts
@@ -232,14 +232,14 @@ export async function executeMiniMaxWebSearchProviderTool(
   const endpoint = resolveMiniMaxEndpoint(searchConfig, config);
 
   const cacheKey = buildSearchCacheKey(["minimax", endpoint, query, resolvedCount]);
-  const cached = readCachedSearchPayload(cacheKey);
+  const cacheTtlMs = resolveSearchCacheTtlMs(searchConfig);
+  const cached = readCachedSearchPayload(cacheKey, cacheTtlMs);
   if (cached) {
     return cached;
   }
 
   const start = Date.now();
   const timeoutSeconds = resolveSearchTimeoutSeconds(searchConfig);
-  const cacheTtlMs = resolveSearchCacheTtlMs(searchConfig);
 
   const { results, relatedSearches } = await runMiniMaxSearch({
     query,

--- a/extensions/minimax/src/minimax-web-search-provider.test.ts
+++ b/extensions/minimax/src/minimax-web-search-provider.test.ts
@@ -42,6 +42,66 @@ describe("minimax web search provider", () => {
     restoreEnvValue("MINIMAX_API_KEY", originalApiKey);
   });
 
+  it.each([0, 1])(
+    "applies the current cache TTL of %i minutes to existing results",
+    async (ttl) => {
+      const now = vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+      const fetchMock = vi.spyOn(globalThis, "fetch");
+      for (const result of ["initial", "fresh", "uncached"]) {
+        fetchMock.mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              organic: [{ title: result, link: `https://example.test/${result}` }],
+              base_resp: { status_code: 0 },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+        );
+      }
+      const createTool = (cacheTtlMinutes: number) => {
+        const tool = createMiniMaxWebSearchProvider().createTool({
+          config: {
+            plugins: {
+              entries: { minimax: { config: { webSearch: { apiKey: "minimax-test-key" } } } },
+            },
+          },
+          searchConfig: { cacheTtlMinutes },
+        });
+        if (!tool) {
+          throw new Error("Expected tool definition");
+        }
+        return tool;
+      };
+
+      try {
+        const args = { query: `minimax current cache TTL ${ttl}` };
+        const originalTool = createTool(15);
+        const initial = await originalTool.execute(args);
+        expect(await originalTool.execute(args)).toEqual({ ...initial, cached: true });
+        expect(fetchMock).toHaveBeenCalledOnce();
+
+        now.mockReturnValue(1_700_000_060_000);
+        const currentTool = createTool(ttl);
+        const fresh = await currentTool.execute(args);
+        expect(fresh.cached).toBeUndefined();
+        expect(fresh.results).toEqual([
+          expect.objectContaining({ url: "https://example.test/fresh" }),
+        ]);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+
+        const repeated = await currentTool.execute(args);
+        expect(repeated.cached).toBe(ttl === 0 ? undefined : true);
+        expect(fetchMock).toHaveBeenCalledTimes(ttl === 0 ? 3 : 2);
+        if (ttl === 0) {
+          expect(await originalTool.execute(args)).toEqual({ ...initial, cached: true });
+        }
+      } finally {
+        fetchMock.mockRestore();
+        now.mockRestore();
+      }
+    },
+  );
+
   it("does not send an already canceled MiniMax search", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ organic: [], base_resp: { status_code: 0 } }), {

--- a/extensions/moonshot/src/kimi-web-search-provider.runtime.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.runtime.ts
@@ -371,7 +371,8 @@ export async function executeKimiWebSearchProviderTool(
   const model = resolveKimiModel(kimiConfig);
   const baseUrl = resolveKimiBaseUrl(kimiConfig, ctx.config);
   const cacheKey = buildSearchCacheKey(["kimi", query, baseUrl, model]);
-  const cached = readCachedSearchPayload(cacheKey);
+  const cacheTtlMs = resolveSearchCacheTtlMs(searchConfig);
+  const cached = readCachedSearchPayload(cacheKey, cacheTtlMs);
   if (cached) {
     return cached;
   }
@@ -412,7 +413,7 @@ export async function executeKimiWebSearchProviderTool(
     content: wrapWebContent(result.content),
     citations: result.citations,
   };
-  writeCachedSearchPayload(cacheKey, payload, resolveSearchCacheTtlMs(searchConfig));
+  writeCachedSearchPayload(cacheKey, payload, cacheTtlMs);
   return payload;
 }
 

--- a/extensions/moonshot/src/kimi-web-search-provider.test.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.test.ts
@@ -14,9 +14,12 @@ function jsonResponse(body: unknown): Response {
   });
 }
 
-async function executeKimiSearch(query: string): Promise<Record<string, unknown>> {
+async function executeKimiSearch(
+  query: string,
+  cacheTtlMinutes?: number,
+): Promise<Record<string, unknown>> {
   const provider = createKimiWebSearchProvider();
-  const tool = provider.createTool({ config: {}, searchConfig: {} });
+  const tool = provider.createTool({ config: {}, searchConfig: { cacheTtlMinutes } });
   if (!tool) {
     throw new Error("Expected tool definition");
   }
@@ -31,6 +34,7 @@ function expectStringFieldContains(result: Record<string, unknown>, field: strin
 
 describe("kimi web search provider", () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
@@ -329,6 +333,51 @@ describe("kimi web search provider", () => {
         "count must be an integer from 1 to 10.",
       );
       expect(fetchMock).toHaveBeenCalledOnce();
+    });
+  });
+
+  it.each([0, 1])("honors the current Kimi cache TTL of %s minutes", async (cacheTtlMinutes) => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_000_000);
+    let content = "Original grounded answer";
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        search_results: [{ url: "https://example.com/kimi" }],
+        choices: [{ finish_reason: "stop", message: { content } }],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await withEnvAsync({ KIMI_API_KEY: "kimi-test-key" }, async () => {
+      const query = `Kimi current request cache TTL ${cacheTtlMinutes}`;
+      await executeKimiSearch(query, 15);
+      await expect(executeKimiSearch(query, 15)).resolves.toMatchObject({
+        cached: true,
+        content: expect.stringContaining("Original grounded answer"),
+      });
+      expect(fetchMock).toHaveBeenCalledOnce();
+
+      now.mockReturnValue(1_060_000);
+      content = "Fresh grounded answer";
+      const fresh = await executeKimiSearch(query, cacheTtlMinutes);
+      expect(fresh).not.toHaveProperty("cached");
+      expectStringFieldContains(fresh, "content", "Fresh grounded answer");
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+
+      if (cacheTtlMinutes === 0) {
+        await expect(executeKimiSearch(query, 0)).resolves.not.toHaveProperty("cached");
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+        await expect(executeKimiSearch(query, 15)).resolves.toMatchObject({
+          cached: true,
+          content: expect.stringContaining("Original grounded answer"),
+        });
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+      } else {
+        await expect(executeKimiSearch(query, cacheTtlMinutes)).resolves.toEqual({
+          ...fresh,
+          cached: true,
+        });
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+      }
     });
   });
 

--- a/extensions/parallel/src/parallel-search-normalize.ts
+++ b/extensions/parallel/src/parallel-search-normalize.ts
@@ -111,7 +111,8 @@ export async function executeParallelSearchRequest(params: {
     return request.error;
   }
   const cacheKey = buildParallelCacheKey({ endpoint: params.endpoint, ...request });
-  const cached = readCachedSearchPayload(cacheKey);
+  const cacheTtlMs = resolveSearchCacheTtlMs(params.searchConfig);
+  const cached = readCachedSearchPayload(cacheKey, cacheTtlMs);
   if (cached) {
     return cached;
   }
@@ -128,7 +129,7 @@ export async function executeParallelSearchRequest(params: {
     start,
   });
   const cachePayload = request.sessionId ? payload : stripParallelGeneratedSessionId(payload);
-  writeCachedSearchPayload(cacheKey, cachePayload, resolveSearchCacheTtlMs(params.searchConfig));
+  writeCachedSearchPayload(cacheKey, cachePayload, cacheTtlMs);
   return payload;
 }
 

--- a/extensions/parallel/src/parallel-web-search-provider.test.ts
+++ b/extensions/parallel/src/parallel-web-search-provider.test.ts
@@ -60,9 +60,9 @@ function paidTool(searchConfig: Record<string, unknown> = { parallel: { apiKey: 
     "Parallel tool definition",
   );
 }
-function freeTool() {
+function freeTool(searchConfig: Record<string, unknown> = {}) {
   return expectDefined(
-    createParallelFreeWebSearchProvider().createTool({ config: {}, searchConfig: {} }),
+    createParallelFreeWebSearchProvider().createTool({ config: {}, searchConfig }),
     "Parallel free tool definition",
   );
 }
@@ -127,6 +127,58 @@ beforeEach(() => {
   endpointMockState.calls = [];
   endpointMockState.effects = [];
   endpointMockState.responses = [];
+});
+describe.each(["paid", "free"] as const)("Parallel %s cache policy", (transport) => {
+  it.each([0, 1])(
+    "honors the current %i-minute TTL after populating at 15 minutes",
+    async (ttl) => {
+      const now = Date.now();
+      const clock = vi.spyOn(Date, "now").mockReturnValue(now);
+      const createTool = (cacheTtlMinutes: number) =>
+        transport === "paid"
+          ? paidTool({ parallel: { apiKey: "par-secret" }, cacheTtlMinutes })
+          : freeTool({ cacheTtlMinutes });
+      const enqueue = transport === "paid" ? enqueueJson : pushMcpHandshake;
+      const callsPerSearch = transport === "paid" ? 1 : 3;
+      const args = { search_queries: [`parallel-${transport}-ttl-${ttl}`] };
+      try {
+        enqueue({ search_id: "original", results: [] });
+        const originalTool = createTool(15);
+        await originalTool.execute(args);
+        expect(await originalTool.execute(args)).toMatchObject({
+          searchId: "original",
+          cached: true,
+        });
+        expect(endpointMockState.calls).toHaveLength(callsPerSearch);
+
+        clock.mockReturnValue(now + 60_000);
+        enqueue({ search_id: "fresh", results: [] });
+        const currentTool = createTool(ttl);
+        const fresh = await currentTool.execute(args);
+        expect(fresh.searchId).toBe("fresh");
+        expect(fresh).not.toHaveProperty("cached");
+        expect(endpointMockState.calls).toHaveLength(2 * callsPerSearch);
+
+        if (ttl === 0) {
+          enqueue({ search_id: "fresh-again", results: [] });
+          expect(await currentTool.execute(args)).toMatchObject({ searchId: "fresh-again" });
+          expect(await originalTool.execute(args)).toMatchObject({
+            searchId: "original",
+            cached: true,
+          });
+          expect(endpointMockState.calls).toHaveLength(3 * callsPerSearch);
+        } else {
+          expect(await currentTool.execute(args)).toMatchObject({
+            searchId: "fresh",
+            cached: true,
+          });
+          expect(endpointMockState.calls).toHaveLength(2 * callsPerSearch);
+        }
+      } finally {
+        clock.mockRestore();
+      }
+    },
+  );
 });
 describe("parallel web search provider", () => {
   it("exposes the expected metadata and selection wiring", () => {

--- a/extensions/perplexity/src/perplexity-web-search-provider.runtime.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.runtime.ts
@@ -446,7 +446,8 @@ export async function executePerplexitySearch(
     maxTokens,
     maxTokensPerPage,
   ]);
-  const cached = readCachedSearchPayload(cacheKey);
+  const cacheTtlMs = resolveSearchCacheTtlMs(searchConfig);
+  const cached = readCachedSearchPayload(cacheKey, cacheTtlMs);
   if (cached) {
     return cached;
   }
@@ -518,7 +519,7 @@ export async function executePerplexitySearch(
   }
 
   signal?.throwIfAborted();
-  writeCachedSearchPayload(cacheKey, payload, resolveSearchCacheTtlMs(searchConfig));
+  writeCachedSearchPayload(cacheKey, payload, cacheTtlMs);
   return payload;
 }
 

--- a/extensions/perplexity/src/perplexity-web-search-provider.test.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.test.ts
@@ -33,14 +33,18 @@ function mockPerplexityResponseOnce(body: unknown): void {
   );
 }
 
-function createConfiguredPerplexityTool(structured: boolean, apiKey = directPerplexityApiKey) {
+function createConfiguredPerplexityTool(
+  structured: boolean,
+  apiKey = directPerplexityApiKey,
+  cacheTtlMinutes?: number,
+) {
   const webSearch = {
     apiKey,
     ...(structured ? {} : { baseUrl: "https://api.perplexity.ai" }),
   };
   const tool = createPerplexityWebSearchProvider().createTool({
     config: { plugins: { entries: { perplexity: { config: { webSearch } } } } },
-    searchConfig: {},
+    searchConfig: { cacheTtlMinutes },
   });
   if (!tool) {
     throw new Error("Expected tool definition");
@@ -251,6 +255,58 @@ describe("perplexity web search provider", () => {
     ).rejects.toThrow("Perplexity caller canceled");
     expect(withTrustedWebSearchEndpointMock).not.toHaveBeenCalled();
   });
+
+  it.each([
+    { name: "native Search API", structured: true, ttl: 0 },
+    { name: "native Search API", structured: true, ttl: 1 },
+    { name: "chat completions", structured: false, ttl: 0 },
+    { name: "chat completions", structured: false, ttl: 1 },
+  ])(
+    "applies the current cache TTL of $ttl minutes to $name results",
+    async ({ name, structured, ttl }) => {
+      const now = vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+      withTrustedWebSearchEndpointMock.mockReset();
+      for (const result of ["initial", "fresh", "uncached"]) {
+        mockPerplexityResponseOnce(
+          structured
+            ? { results: [{ title: result, url: `https://example.test/${result}` }] }
+            : {
+                choices: [{ message: { content: result } }],
+                citations: [`https://example.test/${result}`],
+              },
+        );
+      }
+
+      try {
+        const args = { query: `perplexity current cache TTL ${name} ${ttl}` };
+        const originalTool = createConfiguredPerplexityTool(structured, undefined, 15);
+        const initial = await originalTool.execute(args);
+        expect(await originalTool.execute(args)).toEqual({ ...initial, cached: true });
+        expect(withTrustedWebSearchEndpointMock).toHaveBeenCalledOnce();
+
+        now.mockReturnValue(1_700_000_060_000);
+        const currentTool = createConfiguredPerplexityTool(structured, undefined, ttl);
+        const fresh = await currentTool.execute(args);
+        expect(fresh.cached).toBeUndefined();
+        expect(fresh).toMatchObject(
+          structured
+            ? { results: [expect.objectContaining({ url: "https://example.test/fresh" })] }
+            : { citations: ["https://example.test/fresh"] },
+        );
+        expect(withTrustedWebSearchEndpointMock).toHaveBeenCalledTimes(2);
+
+        const repeated = await currentTool.execute(args);
+        expect(repeated.cached).toBe(ttl === 0 ? undefined : true);
+        expect(withTrustedWebSearchEndpointMock).toHaveBeenCalledTimes(ttl === 0 ? 3 : 2);
+        if (ttl === 0) {
+          expect(await originalTool.execute(args)).toEqual({ ...initial, cached: true });
+        }
+      } finally {
+        now.mockRestore();
+        withTrustedWebSearchEndpointMock.mockReset();
+      }
+    },
+  );
 
   it.each([
     { name: "missing choices", response: {} },

--- a/extensions/searxng/src/searxng-client.transport.test.ts
+++ b/extensions/searxng/src/searxng-client.transport.test.ts
@@ -1,6 +1,7 @@
 import { createServer, type Server } from "node:http";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { runSearxngSearch, testing } from "./searxng-client.js";
+import { createSearxngWebSearchProvider } from "./searxng-search-provider.js";
 
 const servers = new Set<Server>();
 
@@ -28,12 +29,69 @@ async function closeServer(server: Server): Promise<void> {
 }
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   testing.SEARXNG_SEARCH_CACHE.clear();
   await Promise.all([...servers].map(closeServer));
   servers.clear();
 });
 
 describe("searxng real transport", () => {
+  it.each([0, 1])(
+    "applies the current %s-minute provider TTL to cached results",
+    async (cacheTtlMinutes) => {
+      const clock = vi.spyOn(Date, "now").mockReturnValue(Date.now());
+      let requests = 0;
+      const baseUrl = await listen(
+        createServer((_request, response) => {
+          requests += 1;
+          response.writeHead(200, { "Content-Type": "application/json" });
+          response.end(
+            JSON.stringify({
+              results: [{ title: `Result ${requests}`, url: `https://example.com/${requests}` }],
+            }),
+          );
+        }),
+      );
+      const search = async (ttl: number) => {
+        const searchConfig = { cacheTtlMinutes: ttl };
+        const tool = createSearxngWebSearchProvider().createTool({
+          config: {
+            tools: { web: { search: searchConfig } },
+            plugins: { entries: { searxng: { config: { webSearch: { baseUrl } } } } },
+          },
+          searchConfig,
+        });
+        if (!tool) {
+          throw new Error("Expected SearXNG search tool");
+        }
+        return await tool.execute({ query: "current search TTL" });
+      };
+
+      const original = await search(15);
+      expect(await search(15)).toEqual({ ...original, cached: true });
+      expect(requests).toBe(1);
+
+      if (cacheTtlMinutes > 0) {
+        clock.mockReturnValue(Date.now() + 60_000);
+      }
+      const fresh = await search(cacheTtlMinutes);
+      expect(fresh.cached).toBeUndefined();
+      expect(fresh.results).toEqual([expect.objectContaining({ url: "https://example.com/2" })]);
+      expect(requests).toBe(2);
+
+      if (cacheTtlMinutes === 0) {
+        const next = await search(0);
+        expect(next.cached).toBeUndefined();
+        expect(next.results).toEqual([expect.objectContaining({ url: "https://example.com/3" })]);
+        expect(await search(15)).toEqual({ ...original, cached: true });
+        expect(requests).toBe(3);
+      } else {
+        expect(await search(1)).toEqual({ ...fresh, cached: true });
+        expect(requests).toBe(2);
+      }
+    },
+  );
+
   it("reads JSON results from a loopback endpoint", async () => {
     const server = createServer((_request, response) => {
       response.writeHead(200, { "Content-Type": "application/json" });

--- a/extensions/searxng/src/searxng-client.ts
+++ b/extensions/searxng/src/searxng-client.ts
@@ -249,7 +249,10 @@ export async function runSearxngSearch(params: {
   const language = params.language ?? resolveSearxngLanguage(params.config);
   const baseUrl = params.baseUrl ?? resolveSearxngBaseUrl(params.config);
   const timeoutSeconds = resolveTimeoutSeconds(params.timeoutSeconds, DEFAULT_TIMEOUT_SECONDS);
-  const cacheTtlMs = resolveCacheTtlMs(params.cacheTtlMinutes, DEFAULT_CACHE_TTL_MINUTES);
+  const cacheTtlMs = resolveCacheTtlMs(
+    params.cacheTtlMinutes ?? params.config?.tools?.web?.search?.cacheTtlMinutes,
+    DEFAULT_CACHE_TTL_MINUTES,
+  );
 
   if (!baseUrl) {
     throw new Error(
@@ -269,7 +272,7 @@ export async function runSearxngSearch(params: {
       baseUrl,
     }),
   );
-  const cached = readCache(SEARXNG_SEARCH_CACHE, cacheKey);
+  const cached = readCache(SEARXNG_SEARCH_CACHE, cacheKey, cacheTtlMs);
   if (cached) {
     return { ...cached.value, cached: true };
   }

--- a/extensions/tavily/src/tavily-client.ts
+++ b/extensions/tavily/src/tavily-client.ts
@@ -165,7 +165,11 @@ export async function runTavilySearch(
       excludeDomains: params.excludeDomains,
     }),
   );
-  const cached = readCache(SEARCH_CACHE, cacheKey);
+  const cacheTtlMs = resolveCacheTtlMs(
+    params.cfg?.tools?.web?.search?.cacheTtlMinutes,
+    DEFAULT_CACHE_TTL_MINUTES,
+  );
+  const cached = readCache(SEARCH_CACHE, cacheKey, cacheTtlMs);
   if (cached) {
     return { ...cached.value, cached: true };
   }
@@ -258,12 +262,7 @@ export async function runTavilySearch(
     result.truncated = true;
   }
 
-  writeCache(
-    SEARCH_CACHE,
-    cacheKey,
-    result,
-    resolveCacheTtlMs(undefined, DEFAULT_CACHE_TTL_MINUTES),
-  );
+  writeCache(SEARCH_CACHE, cacheKey, result, cacheTtlMs);
   return result;
 }
 

--- a/extensions/tavily/src/tavily-search.cache.test.ts
+++ b/extensions/tavily/src/tavily-search.cache.test.ts
@@ -1,0 +1,72 @@
+import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTavilyWebSearchProvider } from "./tavily-search-provider.js";
+import { createTavilySearchTool } from "./tavily-search-tool.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe.each(["web_search", "tavily_search"] as const)("%s cache TTL", (kind) => {
+  it.each([0, 1])(
+    "applies the current %s-minute TTL to cached results",
+    async (cacheTtlMinutes) => {
+      const clock = vi.spyOn(Date, "now").mockReturnValue(Date.now());
+      let requests = 0;
+      const fetch = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+        requests += 1;
+        return Response.json({
+          results: [
+            {
+              title: `Result ${requests}`,
+              url: `https://example.com/${requests}`,
+              content: `Body ${requests}`,
+            },
+          ],
+        });
+      });
+      const search = async (ttl: number) => {
+        const searchConfig = { cacheTtlMinutes: ttl };
+        const config = {
+          tools: { web: { search: searchConfig } },
+          plugins: {
+            entries: { tavily: { config: { webSearch: { apiKey: "tavily-test-key" } } } },
+          },
+        };
+        const query = `Tavily ${kind} current TTL ${cacheTtlMinutes}`;
+        if (kind === "tavily_search") {
+          const tool = createTavilySearchTool(createTestPluginApi({ config }));
+          return (await tool.execute("cache-ttl", { query })).details as Record<string, unknown>;
+        }
+        const tool = createTavilyWebSearchProvider().createTool({ config, searchConfig });
+        if (!tool) {
+          throw new Error("Expected Tavily search tool");
+        }
+        return await tool.execute({ query });
+      };
+
+      const original = await search(15);
+      expect(await search(15)).toEqual({ ...original, cached: true });
+      expect(fetch).toHaveBeenCalledTimes(1);
+
+      if (cacheTtlMinutes > 0) {
+        clock.mockReturnValue(Date.now() + 60_000);
+      }
+      const fresh = await search(cacheTtlMinutes);
+      expect(fresh.cached).toBeUndefined();
+      expect(fresh.results).toEqual([expect.objectContaining({ url: "https://example.com/2" })]);
+      expect(fetch).toHaveBeenCalledTimes(2);
+
+      if (cacheTtlMinutes === 0) {
+        const next = await search(0);
+        expect(next.cached).toBeUndefined();
+        expect(next.results).toEqual([expect.objectContaining({ url: "https://example.com/3" })]);
+        expect(await search(15)).toEqual({ ...original, cached: true });
+        expect(fetch).toHaveBeenCalledTimes(3);
+      } else {
+        expect(await search(1)).toEqual({ ...fresh, cached: true });
+        expect(fetch).toHaveBeenCalledTimes(2);
+      }
+    },
+  );
+});

--- a/extensions/xai/src/web-search-provider.runtime.ts
+++ b/extensions/xai/src/web-search-provider.runtime.ts
@@ -136,7 +136,7 @@ function runXaiWebSearch(params: {
   const cacheKey = normalizeCacheKey(
     `grok:${params.endpoint}:${params.model}:${String(params.inlineCitations)}:${params.query}`,
   );
-  const cached = readCache(XAI_WEB_SEARCH_CACHE, cacheKey);
+  const cached = readCache(XAI_WEB_SEARCH_CACHE, cacheKey, params.cacheTtlMs);
   if (cached) {
     return Promise.resolve({ ...cached.value, cached: true });
   }

--- a/extensions/xai/web-search.test.ts
+++ b/extensions/xai/web-search.test.ts
@@ -825,6 +825,61 @@ describe("xai web search config resolution", () => {
     expect(recovered.content).toContain("Recovered Grok answer");
   });
 
+  it.each([false, true])(
+    "bypasses Grok cache reads and writes at zero TTL (populated: %s)",
+    async (populated) => {
+      vi.spyOn(Date, "now").mockReturnValue(1_000_000);
+      const mockFetch = vi.fn(async () => xaiAnswerResponse("Fresh Grok answer"));
+      global.fetch = withFetchPreconnect(mockFetch);
+      const query = `Grok zero TTL cache policy ${populated}`;
+      const search = (cacheTtlMinutes: number) =>
+        requireXaiWebSearchTool({
+          config: xaiPluginConfig({ webSearch: { apiKey: "xai-cache-key" } }),
+          searchConfig: { cacheTtlMinutes },
+        }).execute({ query });
+      if (populated) {
+        mockFetch.mockResolvedValueOnce(xaiAnswerResponse("Original Grok answer"));
+        await search(15);
+      }
+
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        const uncached = await search(0);
+        expect(uncached.cached).toBeUndefined();
+        expect(uncached.content).toContain("Fresh Grok answer");
+      }
+      const enabled = await search(15);
+
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(enabled.cached).toBe(populated ? true : undefined);
+      expect(enabled.content).toContain(populated ? "Original Grok answer" : "Fresh Grok answer");
+    },
+  );
+
+  it("applies a shortened Grok cache TTL to an existing result", async () => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_000_000);
+    const mockFetch = vi
+      .fn(async () => xaiAnswerResponse("Fresh Grok answer"))
+      .mockResolvedValueOnce(xaiAnswerResponse("Original Grok answer"));
+    global.fetch = withFetchPreconnect(mockFetch);
+    const query = "Grok shortened TTL cache policy";
+    const search = (cacheTtlMinutes: number) =>
+      requireXaiWebSearchTool({
+        config: xaiPluginConfig({ webSearch: { apiKey: "xai-cache-key" } }),
+        searchConfig: { cacheTtlMinutes },
+      }).execute({ query });
+    await search(15);
+    now.mockReturnValue(1_060_000);
+
+    const refreshed = await search(1);
+    const cached = await search(1);
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(refreshed.cached).toBeUndefined();
+    expect(refreshed.content).toContain("Fresh Grok answer");
+    expect(cached.cached).toBe(true);
+    expect(cached.content).toBe(refreshed.content);
+  });
+
   it("does not contact the generic xAI provider when the caller is already cancelled", async () => {
     const mockFetch = installXaiWebSearchFetch();
     const controller = new AbortController();

--- a/extensions/xai/x-search.test.ts
+++ b/extensions/xai/x-search.test.ts
@@ -295,6 +295,60 @@ describe("xai x_search tool", () => {
     expect((recovered.details as { content?: string }).content).toContain("Recovered X answer");
   });
 
+  it.each([false, true])(
+    "bypasses X search cache reads and writes at zero TTL (populated: %s)",
+    async (populated) => {
+      vi.spyOn(Date, "now").mockReturnValue(1_000_000);
+      const mockFetch = installXSearchFetch({ output_text: "Fresh X answer" });
+      const query = `X search zero TTL cache policy ${populated}`;
+      const search = async (cacheTtlMinutes: number) => {
+        const result = await createConfiguredXSearchTool({
+          xSearch: { cacheTtlMinutes },
+        }).execute("x-search:cache-policy", { query });
+        return result.details as Record<string, unknown>;
+      };
+      if (populated) {
+        mockFetch.mockResolvedValueOnce(jsonResponse({ output_text: "Original X answer" }));
+        await search(15);
+      }
+
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        const uncached = await search(0);
+        expect(uncached.cached).toBeUndefined();
+        expect(uncached.content).toContain("Fresh X answer");
+      }
+      const enabled = await search(15);
+
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(enabled.cached).toBe(populated ? true : undefined);
+      expect(enabled.content).toContain(populated ? "Original X answer" : "Fresh X answer");
+    },
+  );
+
+  it("applies a shortened X search cache TTL to an existing result", async () => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_000_000);
+    const mockFetch = installXSearchFetch({ output_text: "Fresh X answer" });
+    mockFetch.mockResolvedValueOnce(jsonResponse({ output_text: "Original X answer" }));
+    const query = "X search shortened TTL cache policy";
+    const search = async (cacheTtlMinutes: number) => {
+      const result = await createConfiguredXSearchTool({
+        xSearch: { cacheTtlMinutes },
+      }).execute("x-search:shortened-ttl", { query });
+      return result.details as Record<string, unknown>;
+    };
+    await search(15);
+    now.mockReturnValue(1_060_000);
+
+    const refreshed = await search(1);
+    const cached = await search(1);
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(refreshed.cached).toBeUndefined();
+    expect(refreshed.content).toContain("Fresh X answer");
+    expect(cached.cached).toBe(true);
+    expect(cached.content).toBe(refreshed.content);
+  });
+
   it("uses the xAI Responses x_search tool with structured filters", async () => {
     const mockFetch = installXSearchFetch();
     const tool = createConfiguredXSearchTool({ xSearch: { maxTurns: 2 } });

--- a/extensions/xai/x-search.ts
+++ b/extensions/xai/x-search.ts
@@ -189,7 +189,8 @@ export function createXSearchTool(options?: {
         enableVideoUnderstanding: xSearchOptions.enableVideoUnderstanding,
       },
     });
-    const cached = readCache(X_SEARCH_CACHE, cacheKey);
+    const cacheTtlMs = resolveCacheTtlMs(xSearchConfig?.cacheTtlMinutes, 15);
+    const cached = readCache(X_SEARCH_CACHE, cacheKey, cacheTtlMs);
     if (cached) {
       return jsonResult({ ...cached.value, cached: true });
     }
@@ -216,12 +217,7 @@ export function createXSearchTool(options?: {
       truncated: result.truncated,
       options: xSearchOptions,
     });
-    writeCache(
-      X_SEARCH_CACHE,
-      cacheKey,
-      payload,
-      resolveCacheTtlMs(xSearchConfig?.cacheTtlMinutes, 15),
-    );
+    writeCache(X_SEARCH_CACHE, cacheKey, payload, cacheTtlMs);
     return jsonResult(payload);
   });
 }

--- a/src/agents/tools/web-fetch.cache.test.ts
+++ b/src/agents/tools/web-fetch.cache.test.ts
@@ -1,0 +1,93 @@
+import { createServer } from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createWebFetchTool } from "./web-fetch.js";
+
+const runtimeState = vi.hoisted(() => ({
+  config: undefined as OpenClawConfig | undefined,
+  resolveWebFetchDefinition: vi.fn(),
+}));
+
+vi.mock("../../secrets/runtime-state.js", () => ({
+  getActiveSecretsRuntimeConfigSnapshot: () => ({ config: runtimeState.config }),
+}));
+vi.mock("../../secrets/runtime-web-tools-state.js", () => ({
+  getActiveRuntimeWebToolsMetadataFromState: () => null,
+}));
+vi.mock("../../web-fetch/runtime.js", () => ({
+  resolveWebFetchDefinition: runtimeState.resolveWebFetchDefinition,
+}));
+
+afterEach(() => {
+  runtimeState.config = undefined;
+  runtimeState.resolveWebFetchDefinition.mockReset();
+});
+
+describe.each(["direct", "provider fallback"])("web_fetch %s cache", (source) => {
+  it.each([0, 15])("honors zero TTL after starting with TTL %i", async (initialTtl) => {
+    let body = "original body";
+    let networkCalls = 0;
+    const providerExecute = vi.fn(async () => ({ text: body }));
+    runtimeState.resolveWebFetchDefinition.mockReturnValue({
+      provider: { id: "test-fetch-provider" },
+      definition: { execute: providerExecute },
+    });
+    const server = createServer((_request, response) => {
+      networkCalls += 1;
+      response.writeHead(source === "direct" ? 200 : 503, { "content-type": "text/plain" });
+      response.end(body);
+    });
+    try {
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("expected a loopback TCP address");
+      }
+      const args = { url: `http://127.0.0.1:${address.port}/cache-ttl-${initialTtl}-${source}` };
+      const setTtl = (cacheTtlMinutes: number) => {
+        runtimeState.config = {
+          tools: {
+            web: { fetch: { cacheTtlMinutes, ssrfPolicy: { allowedHostnames: ["127.0.0.1"] } } },
+          },
+        };
+      };
+      setTtl(initialTtl);
+      const tool = createWebFetchTool({ lateBindRuntimeConfig: true });
+      if (!tool) {
+        throw new Error("expected web_fetch to be enabled");
+      }
+      const first = await tool.execute("populate", args);
+      expect(first.details).toMatchObject({ text: expect.stringContaining("original body") });
+      if (initialTtl > 0) {
+        expect((await tool.execute("cached", args)).details).toMatchObject({ cached: true });
+      }
+      expect(networkCalls).toBe(1);
+
+      setTtl(0);
+      for (const freshBody of ["fresh body", "newest body"]) {
+        body = freshBody;
+        const result = await tool.execute("uncached", args);
+        expect(result.details).toMatchObject({ text: expect.stringContaining(freshBody) });
+        expect(result.details).not.toHaveProperty("cached");
+      }
+      expect(networkCalls).toBe(3);
+      expect(providerExecute).toHaveBeenCalledTimes(source === "direct" ? 0 : 3);
+
+      // Disabled requests neither replace another caller's entry nor insert their own.
+      setTtl(15);
+      body = "after re-enable";
+      const enabled = await tool.execute("re-enabled", args);
+      expect(enabled.details).toMatchObject({
+        text: expect.stringContaining(initialTtl > 0 ? "original body" : "after re-enable"),
+      });
+      expect(networkCalls).toBe(initialTtl > 0 ? 3 : 4);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+        server.closeAllConnections();
+      });
+    }
+  });
+});

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -750,7 +750,7 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       ...cacheDiscriminators,
     ].join(":"),
   );
-  const cached = readCache(FETCH_CACHE, cacheKey);
+  const cached = readCache(FETCH_CACHE, cacheKey, params.cacheTtlMs);
   if (cached) {
     return { ...cached.value, cached: true };
   }

--- a/src/agents/tools/web-search-provider-common.test.ts
+++ b/src/agents/tools/web-search-provider-common.test.ts
@@ -5,7 +5,10 @@ import { withServer } from "../../plugin-sdk/test-helpers/http-test-server.js";
 import { postTrustedWebToolsJson, throwWebSearchApiError } from "./web-search-provider-common.js";
 
 const realFetch = globalThis.fetch;
-afterEach(() => vi.unstubAllGlobals());
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
 
 function postSearch(overrides: Partial<Parameters<typeof postTrustedWebToolsJson>[0]> = {}) {
   return postTrustedWebToolsJson(
@@ -96,6 +99,21 @@ describe("web provider HTTP errors", () => {
 });
 
 describe("web_search shared cache", () => {
+  it("honors the reader TTL while preserving the shipped one-argument reader", async () => {
+    const { readCachedSearchPayload, writeCachedSearchPayload } =
+      await import("./web-search-provider-common.js");
+    const clock = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    const key = "query:reader-ttl";
+    writeCachedSearchPayload(key, { text: "original" }, 900_000);
+    expect(readCachedSearchPayload(key, 0)).toBeUndefined();
+    writeCachedSearchPayload(key, { text: "disabled" }, 0);
+    clock.mockReturnValue(61_000);
+    expect(readCachedSearchPayload(key, 60_000)).toBeUndefined();
+    expect(readCachedSearchPayload(key)).toEqual({ text: "original", cached: true });
+    clock.mockReturnValue(901_001);
+    expect(readCachedSearchPayload(key)).toBeUndefined();
+  });
+
   it("keeps cache entries module-local instead of exposing them on a global symbol", async () => {
     // Cache state should die with the module instance; a global symbol would
     // leak search payloads across tests, sessions, and plugin reloads.

--- a/src/agents/tools/web-search-provider-common.ts
+++ b/src/agents/tools/web-search-provider-common.ts
@@ -390,9 +390,12 @@ export function parseWebSearchTimeFilters<Provider extends WebSearchFreshnessPro
     : parsedDateRange;
 }
 
-/** Reads a search cache payload and marks it so provider responses can disclose cache hits. */
-export function readCachedSearchPayload(cacheKey: string): Record<string, unknown> | undefined {
-  const cached = readCache(SEARCH_CACHE, cacheKey);
+/** Reads a marked search payload; omitted TTL preserves the stored-expiry SDK contract. */
+export function readCachedSearchPayload(
+  cacheKey: string,
+  ttlMs?: number,
+): Record<string, unknown> | undefined {
+  const cached = readCache(SEARCH_CACHE, cacheKey, ttlMs);
   return cached ? { ...cached.value, cached: true } : undefined;
 }
 

--- a/src/agents/tools/web-shared.test.ts
+++ b/src/agents/tools/web-shared.test.ts
@@ -62,6 +62,26 @@ describe("web cache keys", () => {
   });
 });
 
+describe("web cache TTL", () => {
+  it.each([
+    { ttlMs: 0, ageMs: 0, hit: false },
+    { ttlMs: 60_000, ageMs: 59_999, hit: true },
+    { ttlMs: 60_000, ageMs: 60_000, hit: false },
+    { ttlMs: 900_000, ageMs: 60_000, hit: true },
+    { ttlMs: 1_800_000, ageMs: 900_001, hit: false },
+  ])("bounds reuse by current TTL $ttlMs at age $ageMs", ({ ttlMs, ageMs, hit }) => {
+    const clock = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    const cache = new Map<string, CacheEntry<string>>();
+    writeCache(cache, "key", "value", 900_000);
+    clock.mockReturnValue(1_000 + ageMs);
+
+    expect(readCache(cache, "key", ttlMs)).toEqual(hit ? { value: "value", cached: true } : null);
+    if (ageMs < 900_000) {
+      expect(readCache(cache, "key")).toEqual({ value: "value", cached: true });
+    }
+  });
+});
+
 describe("web shared timeout seconds", () => {
   it("caps timeoutSeconds at the shared timer-safe ceiling", () => {
     expect(resolveTimeoutSeconds(Number.MAX_SAFE_INTEGER, 30)).toBe(MAX_TIMER_TIMEOUT_SECONDS);

--- a/src/agents/tools/web-shared.test.ts
+++ b/src/agents/tools/web-shared.test.ts
@@ -68,6 +68,7 @@ describe("web cache TTL", () => {
     { ttlMs: 60_000, ageMs: 59_999, hit: true },
     { ttlMs: 60_000, ageMs: 60_000, hit: false },
     { ttlMs: 900_000, ageMs: 60_000, hit: true },
+    { ttlMs: 1_800_000, ageMs: 900_000, hit: false },
     { ttlMs: 1_800_000, ageMs: 900_001, hit: false },
   ])("bounds reuse by current TTL $ttlMs at age $ageMs", ({ ttlMs, ageMs, hit }) => {
     const clock = vi.spyOn(Date, "now").mockReturnValue(1_000);

--- a/src/agents/tools/web-shared.ts
+++ b/src/agents/tools/web-shared.ts
@@ -46,9 +46,10 @@ export function normalizeCacheKey(value: string): string {
 export function readCache<T>(
   cache: Map<string, CacheEntry<T>>,
   key: string,
+  ttlMs = Infinity,
 ): { value: T; cached: boolean } | null {
   const entry = cache.get(key);
-  if (!entry) {
+  if (!entry || ttlMs <= 0) {
     return null;
   }
   const now = asDateTimestampMs(Date.now());
@@ -56,7 +57,8 @@ export function readCache<T>(
     cache.delete(key);
     return null;
   }
-  return { value: entry.value, cached: true };
+  // A caller can shorten reuse without evicting an entry still valid for others.
+  return now - entry.insertedAt < ttlMs ? { value: entry.value, cached: true } : null;
 }
 
 export function writeCache<T>(

--- a/src/agents/tools/web-shared.ts
+++ b/src/agents/tools/web-shared.ts
@@ -53,7 +53,7 @@ export function readCache<T>(
     return null;
   }
   const now = asDateTimestampMs(Date.now());
-  if (now === undefined || now > entry.expiresAt) {
+  if (now === undefined || now >= entry.expiresAt) {
     cache.delete(key);
     return null;
   }


### PR DESCRIPTION
> [!IMPORTANT]
> **review-required: additive plugin-SDK surface.** Prepared under the auto-QA campaign; the third commit adds an optional argument to a shipped plugin-SDK helper (`readCachedSearchPayload`), so this stays a draft for maintainer review.

## What Problem This Solves

`cacheTtlMinutes: 0` did not actually disable web caching. Zero TTL suppressed cache *writes* but the readers ignored the current request's TTL, so a request that switched a session/agent to `cacheTtlMinutes: 0` (or a shorter TTL) after the cache was populated still returned the old cached body with zero network calls. This is a longstanding omission (since `f275cc180b7`, the original web-tools feature), not a shipped intentional "no-insert-but-still-read" contract — verified against `git log` history and stable `v2026.7.1`.

## Why This Change Was Made

The current request's effective TTL must govern **reuse** as well as admission. Fixes at the cache owner:

1. **web_fetch** (`web-shared.ts` reader + `web-fetch.ts`): `readCache` accepts the current TTL, bypasses reuse at zero, and age-checks via the entry's `insertedAt` (also correcting an off-by-one where an entry exactly at its deadline was admitted). Both direct and provider-fallback fetch results share the corrected reader. Writes were already correct.
2. **Direct search providers** (deep-review completion, net-zero production): DuckDuckGo, SearXNG, Firecrawl, Tavily, and xAI Grok/`x_search` resolved a configured search TTL for writes but read without it (DuckDuckGo/SearXNG's configured TTL was in fact wholly ineffective; Firecrawl/Tavily wrote a hardcoded default). Each now resolves one effective `cacheTtlMs` and uses it for both read and write.
3. **Shared search helper** (`web-search-provider-common.ts`): `readCachedSearchPayload(cacheKey, ttlMs?)` gains an optional TTL, forwarded to `readCache`. The seven bundled providers that share it — Brave (web + llm-context), Exa, Google/Gemini, MiniMax, Kimi, Parallel (paid/free), Perplexity (native + chat-completions) — now read with the same effective TTL they already pass to writes. Omitted TTL preserves the stored-expiry SDK contract, so existing single-argument callers are unaffected.

## User Impact

`cacheTtlMinutes: 0` now disables caching for both reads and writes across web fetch and all bundled search providers; a shortened TTL correctly expires older entries. Positive TTL and omitted TTL behave exactly as before.

## Evidence

- Production **net small-positive** (fetch +2, direct providers net 0, shared helper minimal); tests large positive; docs updated for repaired surfaces. No dependency, config option, storage/schema, or CHANGELOG change.
- Failing-first: fetch cache-after-disable (4 cases) + shared/common reuse; per-provider populate-then-disable and shortened-TTL (20 provider failures + 1 shared-reader failure) each reproduced then green.
- **Additive SDK proven three ways:** shipped `v2026.7.1` defines `readCachedSearchPayload(cacheKey)`; the change adds only the optional `ttlMs?`. `pnpm plugin-sdk:surface:check` exit 0; an isolated tsgo compat probe (one-arg, explicit-undefined, zero, positive, provider-context uses) passed; the emitted `dist/plugin-sdk/provider-web-search.d.ts` declares the optional arg with an unchanged return type.
- Per-provider TTL **symmetry verified** for all seven bundled providers (same effective TTL for read and write). Post-rebase focused fetch/shared/perplexity/brave suites green; check-changed exit 0; two Codex autoreviews clean (P0–P2 on the completion).
