### PR TITLE
fix(release): preserve frozen companion consent checks

### DIFF
--- a/scripts/e2e/lib/upgrade-survivor/assertions.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/assertions.mjs
@@ -1044,12 +1044,7 @@ function acceptedSurfaceHash(surface) {
   return createHash("sha256").update(JSON.stringify(canonical)).digest("hex");
 }
 
-function assertCompanionPluginConsent(record, pluginId) {
-  const integrity = pluginInstallIntegrity(record);
-  assert(
-    typeof integrity === "string" && integrity.length > 0,
-    `${pluginId} plugin integrity missing`,
-  );
+function assertCompanionPluginConsent(record, pluginId, integrity) {
   assert(
     record.acceptedSurface && typeof record.acceptedSurface === "object",
     `${pluginId} plugin accepted surface missing`,
@@ -1075,8 +1070,12 @@ function assertCompanionPluginConsent(record, pluginId) {
   );
 }
 
-function assertCompanionPluginInstalls([expectedVersion]) {
+function assertCompanionPluginInstalls([expectedVersion, capabilityConsentSupported]) {
   assert(expectedVersion, "assert-companion-installs requires <expected-version>");
+  assert(
+    capabilityConsentSupported === "0" || capabilityConsentSupported === "1",
+    "assert-companion-installs requires candidate capability-consent support",
+  );
   const records = readInstalledPluginIndex().installRecords ?? {};
   for (const [pluginId, packageName, source] of [
     ["discord", "@openclaw/discord", "npm"],
@@ -1095,7 +1094,14 @@ function assertCompanionPluginInstalls([expectedVersion]) {
       packageJson.version === expectedVersion,
       `${pluginId} installed package version changed: ${String(packageJson.version)}`,
     );
-    assertCompanionPluginConsent(record, pluginId);
+    const integrity = pluginInstallIntegrity(record);
+    assert(
+      typeof integrity === "string" && integrity.length > 0,
+      `${pluginId} plugin integrity missing`,
+    );
+    if (capabilityConsentSupported === "1") {
+      assertCompanionPluginConsent(record, pluginId, integrity);
+    }
   }
 }
 

--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -509,7 +509,8 @@ install_companion_plugins() {
     return "$restore_status"
   fi
   node scripts/e2e/lib/upgrade-survivor/assertions.mjs \
-    assert-companion-installs "$package_version"
+    assert-companion-installs "$package_version" \
+    "${OPENCLAW_E2E_LAST_FIXTURE_PLUGIN_CAPABILITY_CONSENT_SUPPORTED:?missing candidate capability-consent support}"
 }
 
 openclaw_e2e_eval_test_state_from_b64 "${OPENCLAW_TEST_STATE_FUNCTION_B64:?missing OPENCLAW_TEST_STATE_FUNCTION_B64}"

--- a/scripts/lib/openclaw-e2e-instance.sh
+++ b/scripts/lib/openclaw-e2e-instance.sh
@@ -534,6 +534,9 @@ openclaw_e2e_fixture_plugin_command() {
   done
   shift
   local help consent
+  # Preserve the successful candidate help result for evidence checks after mutation.
+  # Clear it first so a failed replacement probe cannot expose stale capabilities.
+  OPENCLAW_E2E_LAST_FIXTURE_PLUGIN_CAPABILITY_CONSENT_SUPPORTED=
   # Use the caller's bounded runner for both calls; never cache across package replacement.
   help="$("${runner[@]}" "$1" "$2" --help)" || {
     local probe_status=$?
@@ -542,7 +545,10 @@ openclaw_e2e_fixture_plugin_command() {
   }
   consent="$(printf '%s' "$help" | node scripts/e2e/lib/package-compat.mjs fixture-consent)" || return $?
   if [[ -n "$consent" ]]; then
+    OPENCLAW_E2E_LAST_FIXTURE_PLUGIN_CAPABILITY_CONSENT_SUPPORTED=1
     set -- "$@" "$consent"
+  else
+    OPENCLAW_E2E_LAST_FIXTURE_PLUGIN_CAPABILITY_CONSENT_SUPPORTED=0
   fi
   "${runner[@]}" "$@"
 }

--- a/test/scripts/package-compat.test.ts
+++ b/test/scripts/package-compat.test.ts
@@ -206,6 +206,21 @@ ${fixtureCommand} plugins update fixture`,
   });
 
   it.each([true, false])(
+    "records candidate capability consent support (supported=%s)",
+    (supported) => {
+      const root = tempDirs.make("openclaw-consent-support-");
+      const result = runShell(
+        root,
+        writeCandidate(root, { commands: supported ? undefined : [] }),
+        `${fixtureCommand} plugins install fixture
+printf 'support=%s\\n' "$OPENCLAW_E2E_LAST_FIXTURE_PLUGIN_CAPABILITY_CONSENT_SUPPORTED"`,
+      );
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain(`support=${supported ? "1" : "0"}`);
+    },
+  );
+
+  it.each([true, false])(
     "consents to ClawHub install but not unchanged update (supported=%s)",
     (supported) => {
       const root = tempDirs.make("openclaw-consent-clawhub-");

--- a/test/scripts/upgrade-survivor-assertions.test.ts
+++ b/test/scripts/upgrade-survivor-assertions.test.ts
@@ -318,6 +318,7 @@ function assertCompanionPluginRecords(
     records: Record<string, Record<string, unknown>>,
     installPaths: Record<"codex" | "discord" | "whatsapp", string>,
   ) => void,
+  capabilityConsentSupported = true,
 ): void {
   const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-survivor-companions-"));
   try {
@@ -366,7 +367,7 @@ function assertCompanionPluginRecords(
         resolvedVersion: version,
         integrity: npmIntegrity,
         installPath: discordInstallPath,
-        ...consent(npmIntegrity),
+        ...(capabilityConsentSupported ? consent(npmIntegrity) : {}),
       },
       whatsapp: {
         source: "clawhub",
@@ -377,7 +378,7 @@ function assertCompanionPluginRecords(
         artifactKind: "npm-pack",
         clawpackSha256,
         installPath: whatsappInstallPath,
-        ...consent(clawpackSha256),
+        ...(capabilityConsentSupported ? consent(clawpackSha256) : {}),
       },
       codex: {
         source: "npm",
@@ -386,7 +387,7 @@ function assertCompanionPluginRecords(
         resolvedVersion: version,
         integrity: npmIntegrity,
         installPath: codexInstallPath,
-        ...consent(npmIntegrity),
+        ...(capabilityConsentSupported ? consent(npmIntegrity) : {}),
       },
     };
     mutate?.(records, {
@@ -397,13 +398,22 @@ function assertCompanionPluginRecords(
     mkdirSync(join(stateDir, "plugins"), { recursive: true });
     writeJson(join(stateDir, "plugins", "installs.json"), { installRecords: records });
 
-    execFileSync(process.execPath, [ASSERTIONS_PATH, "assert-companion-installs", version], {
-      env: {
-        ...process.env,
-        OPENCLAW_STATE_DIR: stateDir,
+    execFileSync(
+      process.execPath,
+      [
+        ASSERTIONS_PATH,
+        "assert-companion-installs",
+        version,
+        capabilityConsentSupported ? "1" : "0",
+      ],
+      {
+        env: {
+          ...process.env,
+          OPENCLAW_STATE_DIR: stateDir,
+        },
+        stdio: "pipe",
       },
-      stdio: "pipe",
-    });
+    );
   } finally {
     rmSync(root, { force: true, recursive: true });
   }
@@ -710,6 +720,22 @@ describe("upgrade survivor assertions", () => {
         Reflect.deleteProperty(discord, "acceptedSurfaceIntegrity");
       }),
     ).toThrow(/discord plugin consent integrity/);
+  });
+
+  it("accepts frozen companion installs when the candidate lacks capability consent", () => {
+    expect(() => assertCompanionPluginRecords(undefined, false)).not.toThrow();
+  });
+
+  it("requires artifact integrity when the candidate lacks capability consent", () => {
+    expect(() =>
+      assertCompanionPluginRecords((records) => {
+        const discord = records.discord;
+        if (!discord) {
+          throw new Error("discord fixture missing");
+        }
+        Reflect.deleteProperty(discord, "integrity");
+      }, false),
+    ).toThrow(/discord plugin integrity missing/);
   });
 
   it.each([


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-validation failure where upgrade-survivor rejected a frozen candidate after all companion plugins installed successfully because that candidate predates plugin capability consent and therefore cannot persist `acceptedSurface*` fields.

The failing package lane is https://github.com/openclaw/openclaw/actions/runs/33150824191, from parent https://github.com/openclaw/openclaw/actions/runs/33149920029. The separate prerelease-registry failure is owned by https://github.com/openclaw/openclaw/pull/131639.

## Why This Change Was Made

The shared fixture command now carries forward its successful `plugins install --help` capability result. Upgrade-survivor always requires exact plugin package/version/source/integrity evidence, and requires artifact-bound capability-consent fields only when the candidate CLI advertises `--accept-capabilities`.

The check fails closed if the help probe fails, the support result is missing or malformed, or a consent-capable candidate omits its accepted surface. Candidate package and release branch code are unchanged.

Direct inspection of sibling Codex `rust-v0.150.1` covered `codex-rs/app-server/src/request_processors/initialize_processor.rs:44` and `codex-rs/app-server/src/message_processor.rs:835`; this repair stays entirely in OpenClaw's plugin-install release harness and does not change the Codex protocol/runtime contract.

## User Impact

No shipped runtime behavior changes. Release validation can test frozen pre-consent candidates without weakening consent evidence for current candidates.

## Evidence

- Pre-fix regression: `test/scripts/upgrade-survivor-assertions.test.ts` failed with `discord plugin accepted surface missing`.
- Post-fix focused proof: 264 tests passed across upgrade-survivor assertions, package compatibility, and Docker helper contracts.
- `bash -n` passed for both changed shell scripts.
- Targeted formatting and Oxlint passed.
- Autoreview: clean, no actionable findings.
- `check:changed` passed conflict, attribution, doctor registry, architecture, dependency, formatting, patch, and temp-file gates; the sparse worktree's repository-wide test-root typecheck stopped on unrelated files excluded by its sparse checkout.
- Tooling delta: +22/-9; tests: +50/-9. Product runtime delta: 0.
