### PR TITLE
refactor(discord): simplify realtime lifecycle bookkeeping

### DIFF
--- a/extensions/discord/src/voice/realtime-consults.ts
+++ b/extensions/discord/src/voice/realtime-consults.ts
@@ -41,8 +41,8 @@ export type AgentProxyConsultState = {
   speaker: DiscordRealtimeSpeakerContext;
   providerEpoch: number;
   handledByForcedPlayback?: boolean;
-  providerDelivery?: Promise<boolean>;
-  settleProviderDelivery?: (accepted: boolean) => void;
+  providerDelivery?: Promise<void>;
+  settleProviderDelivery?: () => void;
   promise?: Promise<string>;
   result?: RecentAgentProxyConsultResult;
 };
@@ -525,11 +525,11 @@ export class DiscordRealtimeConsults {
       !state.result &&
       session.bridge.supportsToolResultSuppression === false,
     );
-    let resolveProviderDelivery: ((accepted: boolean) => void) | undefined;
+    let resolveProviderDelivery: (() => void) | undefined;
     if (providerOwnsDelivery) {
       // Forced playback waits for native acceptance so a failed delivery can restore
       // the local success/fallback path instead of losing the answer entirely.
-      state.providerDelivery = new Promise<boolean>((resolve) => {
+      state.providerDelivery = new Promise<void>((resolve) => {
         resolveProviderDelivery = resolve;
         state.settleProviderDelivery = resolve;
       });
@@ -592,11 +592,11 @@ export class DiscordRealtimeConsults {
       if (providerOwnsDelivery) {
         state.handledByForcedPlayback = false;
         state.settleProviderDelivery = undefined;
-        resolveProviderDelivery?.(true);
+        resolveProviderDelivery?.();
       }
     } catch (error) {
       state.settleProviderDelivery = undefined;
-      resolveProviderDelivery?.(false);
+      resolveProviderDelivery?.();
       throw error;
     }
     return true;
@@ -609,7 +609,7 @@ export class DiscordRealtimeConsults {
         continue;
       }
       state.handledByForcedPlayback = false;
-      state.settleProviderDelivery?.(false);
+      state.settleProviderDelivery?.();
       state.settleProviderDelivery = undefined;
       state.providerDelivery = undefined;
     }

--- a/extensions/discord/src/voice/realtime-playback.ts
+++ b/extensions/discord/src/voice/realtime-playback.ts
@@ -85,7 +85,7 @@ export class DiscordRealtimePlayback<TState> {
       onTerminalError: (error: Error) => void;
       providerId: () => string | undefined;
       realtimeConfig: () => DiscordRealtimeVoiceConfig;
-      stopTerminally: (reason: string) => void;
+      stopTerminally: () => void;
       stopped: () => boolean;
       wakeNameRequired: () => boolean;
     },
@@ -382,7 +382,7 @@ export class DiscordRealtimePlayback<TState> {
   }
 
   private stopAfterOverflow(reason: string, error: Error): void {
-    this.params.stopTerminally(reason);
+    this.params.stopTerminally();
     this.queuedExactSpeechMessages = [];
     this.exactSpeechState = { status: "idle" };
     this.clearOutputAudio(reason);

--- a/extensions/discord/src/voice/realtime-session.runtime.ts
+++ b/extensions/discord/src/voice/realtime-session.runtime.ts
@@ -54,12 +54,6 @@ const DISCORD_REALTIME_VERBOSE_OMITTED_EVENTS = new Set([
 
 type DiscordRealtimeVoiceConfig = NonNullable<DiscordAccountConfig["voice"]>["realtime"];
 
-type DiscordRealtimeLifecycle =
-  | { status: "inactive"; generation: number }
-  | { status: "starting"; generation: number; instance: DiscordRealtimeVoiceSession }
-  | { status: "active"; generation: number; instance: DiscordRealtimeVoiceSession }
-  | { status: "stopped"; generation: number; reason: string };
-
 function formatRealtimeInterruptionLog(event: RealtimeVoiceBridgeEvent): string | undefined {
   const detail = event.detail ? ` ${event.detail}` : "";
   if (event.direction === "client") {
@@ -117,8 +111,10 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
   private readonly playback: DiscordRealtimePlayback<AgentProxyConsultState>;
   private readonly turns: DiscordRealtimeTurns;
   private readonly consults: DiscordRealtimeConsults;
-  private lifecycle: DiscordRealtimeLifecycle = { status: "inactive", generation: 0 };
-  private nextLifecycleGeneration = 0;
+  private lifecycle: {
+    status: "inactive" | "starting" | "active" | "stopped";
+    generation: number;
+  } = { status: "inactive", generation: 0 };
   private consultToolPolicy: RealtimeVoiceAgentConsultToolPolicy = "safe-read-only";
   private consultToolsAllow: string[] | undefined;
   private consultPolicy: "auto" | "always" = "auto";
@@ -180,8 +176,8 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
       onTerminalError: this.params.onTerminalError,
       providerId: () => this.realtimeProviderId,
       realtimeConfig: () => this.realtimeConfig,
-      stopTerminally: (reason) => {
-        this.stopLifecycle(reason);
+      stopTerminally: () => {
+        this.lifecycle.status = "stopped";
         this.consults.close();
       },
       stopped: () => this.isStopped(),
@@ -223,11 +219,10 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
   }
 
   async connect(): Promise<void> {
-    const lifecycleGeneration = ++this.nextLifecycleGeneration;
+    const lifecycleGeneration = this.lifecycle.generation + 1;
     this.lifecycle = {
       status: "starting",
       generation: lifecycleGeneration,
-      instance: this,
     };
     const configuredProviderId = this.realtimeConfig?.provider?.trim();
     if (configuredProviderId) {
@@ -398,7 +393,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
       onClose: (reason) => {
         // Reconnects stay provider-owned. A close is terminal unless local teardown started it.
         if (!this.isStopped()) {
-          this.stopLifecycle(`provider closed: ${reason}`);
+          this.lifecycle.status = "stopped";
           this.params.onTerminalError(
             new Error(`Realtime provider closed unexpectedly: ${reason}`),
           );
@@ -431,7 +426,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
   }
 
   close(): void {
-    this.stopLifecycle("session close");
+    this.lifecycle.status = "stopped";
     this.providerContinuityEpoch += 1;
     this.flushSuppressedRealtimeErrors();
     this.consults.close();
@@ -477,13 +472,8 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     ) {
       return false;
     }
-    this.lifecycle = { status: "active", generation, instance: this };
+    this.lifecycle.status = "active";
     return true;
-  }
-
-  private stopLifecycle(reason: string): void {
-    const generation = this.lifecycle.generation;
-    this.lifecycle = { status: "stopped", generation, reason };
   }
 
   private humanParticipantCount(): number {
@@ -528,11 +518,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     }
     this.providerGenerationObserved = false;
     if (this.lifecycle.status === "active") {
-      this.lifecycle = {
-        status: "starting",
-        generation: this.lifecycle.generation,
-        instance: this,
-      };
+      this.lifecycle.status = "starting";
     }
     this.providerContinuityEpoch += 1;
     this.consults.resetProviderContinuity();

--- a/extensions/discord/src/voice/realtime-turns.test.ts
+++ b/extensions/discord/src/voice/realtime-turns.test.ts
@@ -1,3 +1,4 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { RealtimeVoiceAgentControlResult } from "openclaw/plugin-sdk/realtime-voice";
 import type { MockCallSource } from "./manager.e2e.test-support.js";
 import { defineDiscordVoiceTests } from "./voice-test-harness.test-support.js";
@@ -588,13 +589,9 @@ defineDiscordVoiceTests(
     it.each(["continuity reset", "terminal close"] as const)(
       "drops stale native consult delivery after provider %s",
       async (transition) => {
-        let resolveOld: ((result: { payloads: Array<{ text: string }> }) => void) | undefined;
+        const oldAnswer = createDeferred<{ payloads: Array<{ text: string }> }>();
         agentCommandMock
-          .mockReturnValueOnce(
-            new Promise((resolve) => {
-              resolveOld = resolve;
-            }),
-          )
+          .mockReturnValueOnce(oldAnswer.promise)
           .mockResolvedValueOnce({ payloads: [{ text: "fresh answer" }] });
         const fixture = await createJoinedAgentProxyFixture();
         const { manager } = fixture;
@@ -618,7 +615,7 @@ defineDiscordVoiceTests(
             bridgeParams.onEvent?.({ direction: "client", type: "session.continuity.reset" });
             bridgeParams.onEvent?.({ direction: "client", type: "session.reconnect.scheduled" });
           }
-          resolveOld?.({ payloads: [{ text: "stale answer" }] });
+          oldAnswer.resolve({ payloads: [{ text: "stale answer" }] });
           await oldSubmission;
           expect(
             realtimeSessionMock.submitToolResult.mock.calls.some(

--- a/extensions/discord/src/voice/voice-session.terminal.test.ts
+++ b/extensions/discord/src/voice/voice-session.terminal.test.ts
@@ -1,3 +1,4 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { defineDiscordVoiceTests } from "./voice-test-harness.test-support.js";
 
 defineDiscordVoiceTests(
@@ -38,10 +39,7 @@ defineDiscordVoiceTests(
           allowFrom: ["discord:u-owner"],
           voice: { mode },
         });
-        let finishDecoding!: () => void;
-        const decoding = new Promise<void>((resolve) => {
-          finishDecoding = resolve;
-        });
+        const decoding = createDeferred<void>();
         let receive: Promise<void> | undefined;
         try {
           await manager.join({ guildId: "g1", channelId: "1001" });
@@ -56,7 +54,7 @@ defineDiscordVoiceTests(
             },
           };
           await manager.join({ guildId: "g1", channelId: "1001" }, { transcripts });
-          decodeOpusStreamChunksMock.mockReturnValueOnce(decoding);
+          decodeOpusStreamChunksMock.mockReturnValueOnce(decoding.promise);
           receive = handleSpeakingStart(manager, entry, "u-owner");
           await vi.waitFor(() => expect(decodeOpusStreamChunksMock).toHaveBeenCalledOnce());
           const captureStream = expectDefined(
@@ -130,7 +128,7 @@ defineDiscordVoiceTests(
           beginSpeakerTurn(replacement);
           expect(realtimeSessionMock.sendAudio).toHaveBeenCalledTimes(inputCalls + 1);
         } finally {
-          finishDecoding();
+          decoding.resolve();
           await receive;
           await manager.destroy();
         }


### PR DESCRIPTION
Follow-up to [the Discord realtime lifecycle repair](https://github.com/openclaw/openclaw/pull/131548).

<details>
<summary>Additional instructions</summary>

Maintainers can push to this same-repository branch.

</details>

## What Problem This Solves

Maintaining Discord realtime voice required reasoning about redundant lifecycle data, a completion value that no caller consumed, and hand-written test synchronization. This cleanup makes the existing ownership rules easier to follow without changing voice behavior.

## Why This Change Was Made

The session-private lifecycle now carries only phase and generation. Its unread self-reference and stop reason are removed, and the next generation derives from the existing generation instead of a duplicate counter. Captured-generation checks, provider continuity epochs, stop-before-callback ordering, and factory-returned bridge disposal remain intact. The outer voice-entry lifecycle is deliberately unchanged.

The internal provider-delivery promise is completion-only (`Promise<void>`). Both invocation-local and teardown-held resolver references remain, with the same settlement ordering, ownership flags, and error propagation. Playback retains the reasons it actually logs; only the unused stop-callback argument is removed. Two existing tests reuse the public SDK deferred helper at the same release and cleanup points.

## User Impact

No intended user-visible change. Terminal teardown, temporary reconnection, speech delivery, capture ownership, configuration, and public Plugin SDK contracts stay the same. This is a bounded maintainer-requested internal refactor, not another behavior fix. No schema, dependency, protocol, default, or permission changes. AI-assisted.

## Evidence

Four independent cleanup reviews covered reuse, simplification, efficiency, and ownership. The broader suggestion to remove generation fencing was rejected; the wider legacy test-entry alias migration is a separate follow-up because it overlaps active capture work. A separate fresh Codex autoreview found no P0 regressions in this patch.

Formatting, whitespace checks, twelve early changed-gate stages, and five doctor contract tests passed locally. **Local owner validation did not complete:** the Discord test attempt was interrupted after about fifteen minutes during startup, before collection, and produced no owner test result. The changed gate was interrupted during deprecated-API scanning. Targeted lint then stopped before lint execution when SDK declaration preparation reached its unchanged 300000 ms deadline. None of those incomplete stages is claimed as a pass, and no timeout, heap, worker, cache, or guard bypass was introduced.

Exact-head [CI run 33154945273](https://github.com/openclaw/openclaw/actions/runs/33154945273) passed for `07075563d72d84fcb67cdb8a0a1b4ae29ffa84d1`: all 41 selected jobs succeeded, including production/test types, typed lint, artifact build, and `openclaw/ci-gate` (18 other jobs were skipped, not counted as passes). The [Discord execution log](https://github.com/openclaw/openclaw/actions/runs/33154945273/job/98795536408) records 235 files and 3,021 tests passing. All six required voice files executed: terminal lifecycle 5, startup 7, turns 44, consults 18, playback 18, and real Opus playback integration 1 (93 tests total). See the [exact commands and proof](https://github.com/openclaw/openclaw/pull/131652#issuecomment-5450273047). No source changes or CI reruns were needed. These hosted results do not change the local validation gaps above. No live Discord interaction is claimed; acceptance is behavior preservation under the existing owner-boundary regressions.

```bash
node scripts/run-vitest.mjs extensions/discord/src/voice/voice-session.terminal.test.ts extensions/discord/src/voice/voice-session.startup.test.ts extensions/discord/src/voice/realtime-turns.test.ts extensions/discord/src/voice/realtime-consults.test.ts extensions/discord/src/voice/realtime-playback.test.ts extensions/discord/src/voice/realtime-playback.integration.test.ts
```

```bash
node scripts/check-changed.mjs -- extensions/discord/src/voice/realtime-session.runtime.ts extensions/discord/src/voice/realtime-consults.ts extensions/discord/src/voice/realtime-playback.ts extensions/discord/src/voice/voice-session.terminal.test.ts extensions/discord/src/voice/realtime-turns.test.ts
```

Production LOC: **+20/-34 (net -14)**. Tests: **+8/-13 (net -5)**. No assertions, scenarios, or production test seams were removed or added.
