### PR TITLE
fix(ci): prepare shared release artifacts for every consumer

### DIFF
--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -2234,7 +2234,24 @@ jobs:
           set -euo pipefail
           mkdir -p .artifacts/docker-tests
 
-          if [[ "$PREPARE_ONLY" == "true" || "$INCLUDE_RELEASE_PATH_SUITES" == "true" ]]; then
+          if [[ "$PREPARE_ONLY" == "true" ]]; then
+            # Shared artifacts serve both release-path and plugin prerelease consumers.
+            # Plan their union here without expanding either child's execution scope.
+            preparation_lanes="$(node --input-type=module <<'NODE'
+          import { allReleasePathLanes } from "./.release-harness/scripts/lib/docker-e2e-scenarios.mts";
+          import { createPluginPrereleaseTestPlan } from "./.release-harness/scripts/lib/plugin-prerelease-test-plan.mts";
+          const releaseLanes = allReleasePathLanes({
+            includeOpenWebUI: process.env.INCLUDE_OPENWEBUI === "true",
+            releaseProfile: process.env.RELEASE_TEST_PROFILE,
+          });
+          console.log([...new Set([
+            ...releaseLanes.map(({ name }) => name),
+            ...createPluginPrereleaseTestPlan().dockerLanes,
+          ])].join(" "));
+          NODE
+            )"
+            export OPENCLAW_DOCKER_ALL_LANES="$preparation_lanes"
+          elif [[ "$INCLUDE_RELEASE_PATH_SUITES" == "true" ]]; then
             export OPENCLAW_DOCKER_ALL_PROFILE=release-path
             export OPENCLAW_DOCKER_ALL_PLAN_RELEASE_ALL=1
           elif [[ -n "$LANES" ]]; then

--- a/test/scripts/release-candidate-plan.test.ts
+++ b/test/scripts/release-candidate-plan.test.ts
@@ -1,0 +1,94 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync, symlinkSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import { resolveDockerE2ePlan } from "../../scripts/lib/docker-e2e-plan.mts";
+import { createPluginPrereleaseTestPlan } from "../../scripts/lib/plugin-prerelease-test-plan.mts";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const workflow = parse(
+  readFileSync(".github/workflows/openclaw-live-and-e2e-checks-reusable.yml", "utf8"),
+) as { jobs: Record<string, { steps: { name?: string; run?: string }[] }> };
+const step = workflow.jobs.prepare_docker_e2e_image.steps.find(
+  (entry) => entry.name === "Plan Docker E2E images",
+);
+if (!step?.run) {
+  throw new Error("Missing shared candidate planning step");
+}
+const planningScript = step.run;
+
+type Plan = ReturnType<typeof resolveDockerE2ePlan>["plan"];
+
+function runPlanningStep(
+  releaseProfile: "beta" | "stable" | "full",
+  mode: "prepare" | "release" | "targeted",
+) {
+  const root = tempDirs.make("openclaw-candidate-plan-");
+  const output = join(root, "github-output");
+  symlinkSync(resolve("."), join(root, ".release-harness"), "dir");
+  execFileSync("bash", ["--noprofile", "--norc", "-c", planningScript], {
+    cwd: root,
+    encoding: "utf8",
+    timeout: 30_000,
+    env: {
+      ...process.env,
+      GITHUB_OUTPUT: output,
+      TSX_TSCONFIG_PATH: resolve("tsconfig.json"),
+      INCLUDE_OPENWEBUI: "false",
+      INCLUDE_RELEASE_PATH_SUITES: String(mode === "release"),
+      LANES: mode === "targeted" ? "npm-onboard-channel-agent" : "",
+      PREPARE_ONLY: String(mode === "prepare"),
+      RELEASE_TEST_PROFILE: releaseProfile,
+      OPENCLAW_DOCKER_ALL_TIMINGS: "0",
+      OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC: "",
+      OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPECS: "",
+      OPENCLAW_UPGRADE_SURVIVOR_SCENARIOS: mode === "targeted" ? "" : "reported-issues",
+    },
+  });
+  return {
+    plan: JSON.parse(readFileSync(join(root, ".artifacts/docker-tests/plan.json"), "utf8")) as Plan,
+    output: readFileSync(output, "utf8"),
+  };
+}
+
+describe("shared release candidate preparation", () => {
+  it.each(["beta", "stable", "full"] as const)(
+    "prepares every plugin child's package under the %s profile",
+    (releaseProfile) => {
+      const { plan, output } = runPlanningStep(releaseProfile, "prepare");
+      const release = runPlanningStep(releaseProfile, "release").plan;
+      const child = resolveDockerE2ePlan({
+        includeOpenWebUI: false,
+        liveMode: "all",
+        liveRetries: 1,
+        orderLanes: (lanes) => lanes,
+        planReleaseAll: false,
+        profile: "all",
+        releaseChunk: "",
+        releaseProfile,
+        selectedLaneNames: createPluginPrereleaseTestPlan().dockerLanes,
+      }).plan;
+      const missing = [
+        ...child.requiredPrepublishPluginPackages,
+        ...release.requiredPrepublishPluginPackages,
+      ].filter((name) => !plan.requiredPrepublishPluginPackages.includes(name));
+      expect(missing).toEqual([]);
+      expect(output).toContain(
+        `required_prepublish_plugin_packages=${JSON.stringify(plan.requiredPrepublishPluginPackages)}`,
+      );
+      expect(plan.needs.bareImage).toBe(true);
+      expect(plan.needs.functionalImage).toBe(true);
+      expect(release.lanes.map((lane) => lane.name)).not.toContain(
+        "npm-onboard-slack-candidate-channel-agent",
+      );
+    },
+  );
+
+  it("keeps targeted execution limited to the selected lane and its packages", () => {
+    const { plan } = runPlanningStep("full", "targeted");
+    expect(plan.lanes.map((lane) => lane.name)).toEqual(["npm-onboard-channel-agent"]);
+    expect(plan.requiredPrepublishPluginPackages).toEqual(["@openclaw/codex"]);
+  });
+});

--- a/test/scripts/release-candidate-plan.test.ts
+++ b/test/scripts/release-candidate-plan.test.ts
@@ -11,7 +11,7 @@ const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const workflow = parse(
   readFileSync(".github/workflows/openclaw-live-and-e2e-checks-reusable.yml", "utf8"),
 ) as { jobs: Record<string, { steps: { name?: string; run?: string }[] }> };
-const step = workflow.jobs.prepare_docker_e2e_image.steps.find(
+const step = workflow.jobs.prepare_docker_e2e_image?.steps.find(
   (entry) => entry.name === "Plan Docker E2E images",
 );
 if (!step?.run) {


### PR DESCRIPTION
Closes #131651
Related: #131298

## What Problem This Solves

Resolves a problem where Full Release Validation prepares a shared plugin registry that the Plugin Prerelease child immediately rejects because a required candidate package is absent. The release-path plan omitted the candidate Slack onboarding lane, while that child required its exact package from the same immutable registry.

## Why This Change Was Made

Shared candidate preparation now selects the union of the release-path and plugin prerelease catalogs from the trusted harness. The existing Docker planner derives package and image requirements, deduplicates lanes, and expands upgrade scenarios. The repair belongs at artifact preparation: it does not hardcode Slack, rebuild artifacts in consumers, or weaken immutable-registry validation. Normal release-path and targeted execution remain unchanged.

The mismatch became visible with #131298, authored by @RomneyDa and merged by @steipete, when candidate channel onboarding gained explicit package requirements. That behavior remains intact.

## User Impact

Release operators can prepare one candidate artifact that covers both consuming suites. There is no product runtime, configuration, plugin permission, persisted-state, or published-package behavior change.

## Evidence

At source `871b18dff5039484e86c76d282699a8defcb1654`, the new regression executes the actual YAML planning step and fails for beta, stable, and full with missing `@openclaw/slack`. The unchanged targeted lane passes. After the repair, all 64 tests pass:

```text
node scripts/run-vitest.mjs test/scripts/release-candidate-plan.test.ts test/scripts/docker-e2e-plan.test.ts
node --import ./scripts/tsx.mjs scripts/check-workflows.mts
git diff --check
```

The regression also verifies the shared registry covers both consumers, emitted GitHub outputs match the planned packages, both image kinds remain required, and ordinary release/targeted execution is not broadened. Workflow validation passed, including Zizmor. Fresh independent Codex Autoreview returned no accepted/actionable findings; the reviewer did not run tests, so the executed tests above are separate evidence.

Historical hosted failure: https://github.com/openclaw/openclaw/actions/runs/33150903609/job/98783148424. That run used an older target; it is corroboration, not proof of this PR head. Fresh full QA reproduced the same failure on frozen `871b18dff5039484e86c76d282699a8defcb1654`: [plugin preparation job98797294685](https://github.com/openclaw/openclaw/actions/runs/33155287393/job/98797294685) rejects the shared registry with `prepublish plugin registry is missing Docker-plan package @openclaw/slack`. The actual registry artifact binds to that source SHA and contains codex, discord, feishu, matrix and whatsapp; Slack is absent. The full parent continues Diagnostic Drain without cancelling independent children.

Product runtime LOC: +0/-0. Workflow/tooling LOC: +18/-1 (net +17), needed to derive shared requirements from the two existing owners. Regression tests: +94/-0. No dependency, schema, protocol, or configuration changes. The first changed-files gate found TS18048 in the new YAML job lookup. That was corrected explicitly (a missing job still throws), independently reviewed, and the four new tests passed again. The corrected complete changed gate passed on Blacksmith Testbox `tbx_01m13qkjkv0bsp1dc936rtjz44`, [Actions33155315503](https://github.com/openclaw/openclaw/actions/runs/33155315503), with terminal wrapper `exitCode:0`; the one-shot lease stopped after success. Exact-head [PR CI33155376341](https://github.com/openclaw/openclaw/actions/runs/33155376341) passed on attempt2 at the exact head430c5e80e3a4b4f27b883b408cdf4edad100b8a7. Attempt1 had three npm tarball download timeouts before test execution; one failed-only retry cleared them without code or timeout changes. All scheduled head checks are terminal with no failures. Latest ClawSweeper comment is a review-start placeholder with no findings/rank-up list yet; independent review is already complete. After landing the trusted workflow correction, the frozen candidate will receive a narrow plugin-prerelease retry; no broad green release claim is made.

AI-assisted maintainer release QA repair.
