### PR TITLE
refactor(agents): derive core tool labels from catalog ids

### DIFF
--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -46,7 +46,6 @@ type CoreToolSection = {
 
 type CoreToolDefinition = {
   id: string;
-  label: string;
   description: string;
   sectionId: string;
   profiles: ToolProfileId[];
@@ -70,49 +69,42 @@ const CORE_TOOL_SECTION_ORDER: Array<{ id: string; label: string }> = [
 const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   {
     id: "read",
-    label: "read",
     description: "Read file contents",
     sectionId: "fs",
     profiles: ["coding"],
   },
   {
     id: "write",
-    label: "write",
     description: "Create or overwrite files",
     sectionId: "fs",
     profiles: ["coding"],
   },
   {
     id: "edit",
-    label: "edit",
     description: "Make precise edits",
     sectionId: "fs",
     profiles: ["coding"],
   },
   {
     id: "apply_patch",
-    label: "apply_patch",
     description: "Patch files",
     sectionId: "fs",
     profiles: ["coding"],
   },
   {
     id: "exec",
-    label: "exec",
     description: EXEC_TOOL_DISPLAY_SUMMARY,
     sectionId: "runtime",
     profiles: ["coding"],
   },
   {
     id: "process",
-    label: "process",
     description: PROCESS_TOOL_DISPLAY_SUMMARY,
     sectionId: "runtime",
     profiles: ["coding"],
   },
   {
     id: "code_execution",
-    label: "code_execution",
     description: "Run sandboxed remote analysis",
     sectionId: "runtime",
     profiles: ["coding"],
@@ -120,7 +112,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "secrets",
-    label: "secrets",
     description: "Request and manage write-only credentials",
     sectionId: "runtime",
     profiles: ["coding", "messaging"],
@@ -128,7 +119,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "web_search",
-    label: "web_search",
     description: "Search the web",
     sectionId: "web",
     profiles: ["coding"],
@@ -136,7 +126,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "web_fetch",
-    label: "web_fetch",
     description: "Fetch web content",
     sectionId: "web",
     profiles: ["coding"],
@@ -144,7 +133,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "x_search",
-    label: "x_search",
     description: "Search X posts",
     sectionId: "web",
     profiles: ["coding"],
@@ -152,7 +140,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "memory_search",
-    label: "memory_search",
     description: "Semantic search",
     sectionId: "memory",
     profiles: ["coding"],
@@ -160,7 +147,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "memory_get",
-    label: "memory_get",
     description: "Read memory files",
     sectionId: "memory",
     profiles: ["coding"],
@@ -168,7 +154,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "sessions",
-    label: "sessions",
     description: "Session settings: label, pin, archive, groups",
     sectionId: "sessions",
     profiles: ["coding", "messaging"],
@@ -176,7 +161,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "sessions_list",
-    label: "sessions_list",
     description: SESSIONS_LIST_TOOL_DISPLAY_SUMMARY,
     sectionId: "sessions",
     profiles: ["coding", "messaging"],
@@ -184,7 +168,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "sessions_history",
-    label: "sessions_history",
     description: SESSIONS_HISTORY_TOOL_DISPLAY_SUMMARY,
     sectionId: "sessions",
     profiles: ["coding", "messaging"],
@@ -192,7 +175,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "sessions_search",
-    label: "sessions_search",
     description: SESSIONS_SEARCH_TOOL_DISPLAY_SUMMARY,
     sectionId: "sessions",
     profiles: ["coding", "messaging"],
@@ -200,7 +182,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "conversations_list",
-    label: "conversations_list",
     description: "List exact external conversation addresses",
     sectionId: "sessions",
     profiles: ["coding", "messaging"],
@@ -208,7 +189,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "conversations_send",
-    label: "conversations_send",
     description: "Send to an exact external conversation",
     sectionId: "sessions",
     profiles: ["coding", "messaging"],
@@ -216,7 +196,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "conversations_turn",
-    label: "conversations_turn",
     description: "Send and wait for a correlated external reply",
     sectionId: "sessions",
     profiles: ["coding", "messaging"],
@@ -224,7 +203,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "sessions_send",
-    label: "sessions_send",
     description: SESSIONS_SEND_TOOL_DISPLAY_SUMMARY,
     sectionId: "sessions",
     profiles: ["coding", "messaging"],
@@ -232,7 +210,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "sessions_spawn",
-    label: "sessions_spawn",
     description: SESSIONS_SPAWN_TOOL_DISPLAY_SUMMARY,
     sectionId: "sessions",
     profiles: ["coding", "messaging"],
@@ -240,7 +217,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "github_identity_status",
-    label: "github_identity_status",
     description: "Inspect the effective GitHub identity and credential health",
     sectionId: "sessions",
     profiles: ["coding"],
@@ -248,7 +224,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "github_publish",
-    label: "github_publish",
     description: "Publish the reconciled session worktree as a draft GitHub pull request",
     sectionId: "sessions",
     profiles: ["coding"],
@@ -256,7 +231,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "agents_wait",
-    label: "agents_wait",
     description: AGENTS_WAIT_TOOL_DISPLAY_SUMMARY,
     sectionId: "sessions",
     profiles: ["coding"],
@@ -264,7 +238,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "sessions_yield",
-    label: "sessions_yield",
     description: "End turn to receive sub-agent results",
     sectionId: "sessions",
     profiles: ["coding", "messaging"],
@@ -272,7 +245,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "subagents",
-    label: "subagents",
     description: "Background work: subagents, media gen, automation runs. list/cancel.",
     sectionId: "sessions",
     profiles: ["coding", "messaging"],
@@ -280,7 +252,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "session_status",
-    label: "session_status",
     description: SESSION_STATUS_TOOL_DISPLAY_SUMMARY,
     sectionId: "sessions",
     profiles: ["minimal", "coding", "messaging"],
@@ -288,7 +259,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "suggest_task",
-    label: "suggest_task",
     description: SUGGEST_TASK_TOOL_DISPLAY_SUMMARY,
     sectionId: "sessions",
     profiles: ["coding"],
@@ -296,7 +266,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "dismiss_task",
-    label: "dismiss_task",
     description: DISMISS_TASK_TOOL_DISPLAY_SUMMARY,
     sectionId: "sessions",
     profiles: ["coding"],
@@ -304,7 +273,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "browser",
-    label: "browser",
     description: "Control web browser",
     sectionId: "ui",
     profiles: [],
@@ -312,7 +280,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "screen",
-    label: "screen",
     description: "Drive operator web UI",
     sectionId: "ui",
     profiles: ["coding"],
@@ -320,7 +287,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "dashboard",
-    label: "dashboard",
     description: "Read and arrange the session dashboard",
     sectionId: "ui",
     profiles: ["coding"],
@@ -328,7 +294,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "terminal",
-    label: "terminal",
     description: "Use shared operator terminals with policy-governed input",
     sectionId: "ui",
     profiles: ["coding"],
@@ -336,7 +301,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "portal",
-    label: "portal",
     description: "Expose local web apps through the gateway",
     sectionId: "ui",
     profiles: ["coding"],
@@ -344,14 +308,12 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "canvas",
-    label: "canvas",
     description: "Control node Canvas surfaces when the Canvas plugin is enabled",
     sectionId: "ui",
     profiles: [],
   },
   {
     id: "show_widget",
-    label: "show_widget",
     description: "Show an interactive widget on chat or an auto-fitting dashboard",
     sectionId: "ui",
     profiles: [],
@@ -359,7 +321,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "message",
-    label: "message",
     description: "Send messages",
     sectionId: "messaging",
     profiles: ["messaging"],
@@ -367,7 +328,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "heartbeat_respond",
-    label: "heartbeat_respond",
     description: "Accept heartbeat outcomes for post-turn handling",
     sectionId: "automation",
     profiles: [],
@@ -375,7 +335,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: AUTOMATIONS_TOOL_NAME,
-    label: AUTOMATIONS_TOOL_NAME,
     description: CRON_TOOL_DISPLAY_SUMMARY,
     sectionId: "automation",
     profiles: ["coding"],
@@ -383,7 +342,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "gateway",
-    label: "gateway",
     description: "Read Gateway config and schema",
     sectionId: "automation",
     profiles: [],
@@ -391,7 +349,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "nodes",
-    label: "nodes",
     description: "Nodes + devices",
     sectionId: "nodes",
     profiles: [],
@@ -399,7 +356,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "computer",
-    label: "computer",
     description: "Control a paired computer node desktop",
     sectionId: "nodes",
     profiles: [],
@@ -407,7 +363,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "mobile_ui",
-    label: "mobile_ui",
     description: "Observe and control a paired Android app",
     sectionId: "nodes",
     profiles: [],
@@ -415,7 +370,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "agents_list",
-    label: "agents_list",
     description: "List agents",
     sectionId: "agents",
     profiles: [],
@@ -423,7 +377,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "get_goal",
-    label: "get_goal",
     description: "Get current thread goal",
     sectionId: "agents",
     profiles: ["coding"],
@@ -431,7 +384,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "create_goal",
-    label: "create_goal",
     description: "Create a thread goal",
     sectionId: "agents",
     profiles: ["coding"],
@@ -439,7 +391,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "update_goal",
-    label: "update_goal",
     description: "Complete or block a thread goal",
     sectionId: "agents",
     profiles: ["coding"],
@@ -447,7 +398,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "progress_card",
-    label: "progress_card",
     description: "Maintain the session progress card",
     sectionId: "agents",
     profiles: ["coding"],
@@ -455,7 +405,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "ask_user",
-    label: "ask_user",
     description: ASK_USER_TOOL_DISPLAY_SUMMARY,
     sectionId: "agents",
     profiles: ["coding", "messaging"],
@@ -463,7 +412,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "skill_workshop",
-    label: "skill_workshop",
     description: SKILL_WORKSHOP_TOOL_DISPLAY_SUMMARY,
     sectionId: "agents",
     profiles: ["coding"],
@@ -471,7 +419,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "view_image",
-    label: "view_image",
     description: "Image understanding",
     sectionId: "media",
     profiles: ["coding"],
@@ -479,7 +426,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "image_generate",
-    label: "image_generate",
     description: "Image generation",
     sectionId: "media",
     profiles: ["coding"],
@@ -487,7 +433,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "music_generate",
-    label: "music_generate",
     description: "Music generation",
     sectionId: "media",
     profiles: ["coding"],
@@ -495,7 +440,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "video_generate",
-    label: "video_generate",
     description: "Video generation",
     sectionId: "media",
     profiles: ["coding"],
@@ -503,7 +447,6 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   },
   {
     id: "tts",
-    label: "tts",
     description: "Text-to-speech conversion",
     sectionId: "media",
     profiles: [],
@@ -602,7 +545,7 @@ export function listCoreToolSections(params?: {
         (tool.id !== "github_publish" || params?.githubPublicationAvailable === true),
     ).map((tool) => ({
       id: tool.id,
-      label: tool.label,
+      label: tool.id,
       description: tool.description,
     })),
   })).filter((section) => section.tools.length > 0);


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested cleanup: the core tool catalog stores every tool name twice, even though all 56 labels are identical to their IDs. Adding or renaming a tool unnecessarily requires keeping both copies aligned.

## Why This Change Was Made

Remove the private definition's `label` field and its duplicate values. The existing `listCoreToolSections` projection emits `label: tool.id`, preserving the public catalog shape. Group names, descriptions, ordering, visibility, profiles, and plugin-defined display names are unchanged.

This removes 57 production lines (+1/-58) without a replacement abstraction. Keeping optional label overrides would retain unused state; changing public responses would impose needless client work.

## User Impact

No visible or behavioral change. The Gateway and Control UI receive the same catalog values; plugin custom labels remain supported. No public API, configuration, permission, persistence, or provider contract changes.

## Evidence

- Reviewed source commit: `84b86c3fe1de4f0735acf25752f5252336db371d`.
- Before/after execution of the real catalog module: all 56 tool labels equal their IDs. Serialized output matches across seven Swarm/GitHub-capability variants, all groups and profiles, per-tool profile lookups, and unknown-tool lookups. SHA-256: `92d4c55d5a998ed291cad476483af5da674c37ff94723dab2b570314c8a13138`.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/tool-catalog.test.ts src/gateway/server-methods/tools-catalog.test.ts src/gateway/server.tools-catalog.test.ts` — 15 tests passed across three files, including the real Gateway RPC boundary and plugin custom display metadata.
- No tests added or removed. Existing owner and Gateway tests plus exhaustive output parity cover this data-only refactor.
- Scoped formatting, typed core lint, and `git diff --check` passed on refreshed base `871b18dff5039484e86c76d282699a8defcb1654`. The earlier complete selected `check-changed` gate also passed; the catalog owner, handler, and test files are unchanged upstream.
- Codex autoreview and an independent read-only review of the exact committed change passed with no actionable findings. Hosted CI will be verified before landing.

AI-assisted; requested as part of the maintainer's autonomous code cleanup.
