### PR TITLE
fix: avoid unnecessary filesystem probes during test selection

### DIFF
--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -1183,12 +1183,13 @@ function resolveExplicitTestPrefixTargets(targetArg: string, cwd: string) {
   }
   const directory = path.posix.dirname(relative);
   const prefix = `${relative}.`;
+  // Bound filesystem probes to matching tests, even with a cached repo-wide inventory.
   const targets = listExplicitTestTargetFilesForCwd(cwd).filter(
     (file) =>
-      fs.existsSync(path.join(cwd, file)) &&
       path.posix.dirname(file) === directory &&
       file.startsWith(prefix) &&
-      isTestFileTarget(file),
+      isTestFileTarget(file) &&
+      fs.existsSync(path.join(cwd, file)),
   );
   return targets.length > 0 ? targets.toSorted((left, right) => left.localeCompare(right)) : null;
 }

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -22,6 +22,7 @@ import {
   formatNoChangedTestTargetLines,
   listFullExtensionVitestProjectConfigs,
   orderFullSuiteSpecsForParallelRun,
+  parseTestProjectsArgs,
   resolveChangedTestTargetPlanForArgs,
   resolveChangedTestTargetPlan,
   resolveChangedTargetArgs,
@@ -200,6 +201,71 @@ describe("scripts/test-projects changed-target routing", () => {
       "packages/normalization-core/src/string-normalization.test.ts",
       "src/utils/provider-utils.test.ts",
     ]);
+  });
+
+  it("bounds extensionless prefix probes while excluding deleted cached matches", () => {
+    const target = "src/selector/topic";
+    const rejectedFiles = [
+      "src/other/topic.test.ts",
+      "src/selector/topic-other.test.ts",
+      "src/selector/topic.helper.ts",
+      "src/selector/topic.child/nested.test.ts",
+    ];
+    const files = Object.fromEntries(
+      [`${target}.test.ts`, `${target}.extra.spec.mts`, ...rejectedFiles].map((file) => [file, ""]),
+    );
+    withTinyGitRepo(files, (tempDir) => {
+      const cwd = fs.realpathSync(tempDir);
+      const candidatePaths = new Set(Object.keys(files).map((file) => path.join(cwd, file)));
+      const rejectedPaths = new Set(rejectedFiles.map((file) => path.join(cwd, file)));
+      const candidateProbes: string[] = [];
+      const originalExistsSync = fs.existsSync;
+      fs.existsSync = (file) => {
+        if (typeof file === "string" && candidatePaths.has(file)) {
+          candidateProbes.push(file);
+        }
+        return originalExistsSync(file);
+      };
+      try {
+        const parsed = [
+          parseTestProjectsArgs(["--changed", "origin/main"], cwd),
+          parseTestProjectsArgs(["--changed", "origin/main"], cwd),
+        ];
+        for (const result of parsed) {
+          expect(result).toStrictEqual({
+            forwardedArgs: ["--changed", "origin/main"],
+            targetArgs: [],
+            watchMode: false,
+          });
+        }
+        expect(candidateProbes).toHaveLength(0);
+
+        expectSingleVitestRunPlan(buildVitestRunPlans([target], cwd), {
+          config: "test/vitest/vitest.unit.config.ts",
+          forwardedArgs: [`${target}.extra.spec.mts`, `${target}.test.ts`],
+        });
+        expect(findUnmatchedExplicitTestTargets([target], cwd)).toEqual([]);
+
+        fs.unlinkSync(path.join(cwd, `${target}.extra.spec.mts`));
+        expectSingleVitestRunPlan(buildVitestRunPlans([target], cwd), {
+          config: "test/vitest/vitest.unit.config.ts",
+          forwardedArgs: [`${target}.test.ts`],
+        });
+        expect(findUnmatchedExplicitTestTargets([target], cwd)).toEqual([]);
+
+        fs.unlinkSync(path.join(cwd, `${target}.test.ts`));
+        expect(findUnmatchedExplicitTestTargets([target], cwd)).toEqual([
+          {
+            target,
+            reason: "path-does-not-exist",
+            includePattern: `${target}{,.*}.{test,spec}.{js,jsx,ts,tsx,mjs,cjs,mts,cts}`,
+          },
+        ]);
+        expect(candidateProbes.filter((file) => rejectedPaths.has(file))).toHaveLength(0);
+      } finally {
+        fs.existsSync = originalExistsSync;
+      }
+    });
   });
 
   it.each([


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where changed-test planning performs filesystem existence checks across the cached repository inventory for arguments that cannot match any test prefix. Repeated planning still pays that cost even after inventory discovery is cached.

## Why This Change Was Made

Move the existing directory, dot-prefix, and test-name predicates before the existing existence check in the prefix-selection owner. Matching candidates are still checked on every call, so deleting files after inventory caching continues to remove them from selection. Parsing, discovery, file eligibility, caching, fallback behavior, and sorting are unchanged.

This is a maintainer-requested, AI-assisted tooling repair. No new helper, production seam, dependency, flag, timeout, retry, or runtime configuration is introduced.

## User Impact

Developers get less filesystem work during changed/prefix test planning without changing the selected tests or missing-target diagnostics. There is no bot runtime or UI behavior change.

## Evidence

A transparent wrapper around real `fs.existsSync`, forwarding every call to the original implementation, measured two consecutive calls to `parseTestProjectsArgs(['--changed', 'origin/main'])`: **27,950 → 2** existence calls on each invocation; candidate probes **27,948 → 0**. The complete parser result remained identical, including empty `targetArgs`. Timings were measured on a contended host, so operation counts are the primary evidence.

The new real-Git-fixture regression failed before the implementation edit with 12 candidate probes where zero were expected, then passed after it. It also verifies sorted prefix expansion, rejection of unrelated directories/non-dot prefixes/non-test files/nested directories, actual deletion after cached inventory, and the final missing-prefix diagnostic.

Owner/sibling proof passed **556 tests across five files and two normal shards**:

```sh
node scripts/run-vitest.mjs test/scripts/test-projects.test.ts src/scripts/test-projects.test.ts test/scripts/run-vitest.test.ts test/scripts/ci-changed-node-test-plan.test.ts test/scripts/pr-crabbox-gate-plan.test.ts
```

Tooling implementation: **+3/-2, net +1 explanatory comment; executable LOC neutral**. Tests: **+66/-0**. The implementation is the existing canonical owner; a new cache or parser special case would add complexity without addressing the unnecessary candidate work more directly.

This proves needless filesystem work, **not** causation of historical 900-second watchdog failures or the separate approximately 130-second test timeout. Discovery and reporting repairs are outside this patch. No optional channel/UI proof applies to this CLI planner reorder; the real parser invocation and owner/sibling tests exercise the changed behavior.

The initial changed-file gate failed on unchanged UI code because this worktree lacked the declared UI `pako` package and resolved an old root copy. A normal `pnpm install --frozen-lockfile` restored declared dependencies without tracked dependency changes. The complete gate then passed:

```sh
node scripts/check-changed.mjs -- scripts/test-projects.test-support.mts test/scripts/test-projects.test.ts
```

The focused regression also passed again after dependency restoration:

```sh
node scripts/run-vitest.mjs test/scripts/test-projects.test.ts -- -t 'bounds extensionless prefix probes while excluding deleted cached matches'
```

Provenance: the existence-first ordering was introduced by the transport-test sharding change in #109181 (2026-07-16); code author, PR author, and merger were @steipete. The repair only changes the order of those existing predicates.

Fresh isolated Codex autoreview completed before commit with no accepted/actionable findings (default P0 scope). The reviewer confirmed preservation of candidate existence checks and the repeated-parser/expansion/deletion regression. `git diff --check` and the normal commit formatting hook passed.
