### PR TITLE
refactor: reuse strict numeric parsers in abort benchmark

### DIFF
--- a/scripts/embedded-run-abort-leak.ts
+++ b/scripts/embedded-run-abort-leak.ts
@@ -21,6 +21,7 @@ import * as path from "node:path";
 import * as v8 from "node:v8";
 import { expectDefined } from "../packages/normalization-core/src/expect.js";
 import { toErrorObject as toLintErrorObject } from "./lib/error-format.mts";
+import { parseNonNegativeInt, parsePositiveInt } from "./lib/numeric-options.mjs";
 
 type Mode = "production" | "closure-extracted" | "closure-inline" | "synthetic-leak";
 type Abortable = <T>(signal: AbortSignal, promise: Promise<T>) => Promise<T>;
@@ -77,11 +78,11 @@ function parseArgs(argv: string[]): Options {
     }
     switch (arg) {
       case "--iters":
-        opts.iters = parsePositiveInt(next, arg);
+        opts.iters = parsePositiveInt(readValue(next, arg), arg);
         i += 1;
         break;
       case "--batches":
-        opts.batches = parsePositiveInt(next, arg);
+        opts.batches = parsePositiveInt(readValue(next, arg), arg);
         i += 1;
         break;
       case "--snap-dir":
@@ -106,15 +107,15 @@ function parseArgs(argv: string[]): Options {
         break;
       }
       case "--max-rss-growth-mb":
-        opts.maxRssGrowthMb = parseNonNegativeInt(next, arg);
+        opts.maxRssGrowthMb = parseNonNegativeInt(readValue(next, arg), arg);
         i += 1;
         break;
       case "--max-tracked-retention":
-        opts.maxTrackedRetention = parseNonNegativeInt(next, arg);
+        opts.maxTrackedRetention = parseNonNegativeInt(readValue(next, arg), arg);
         i += 1;
         break;
       case "--scope-bytes":
-        opts.scopeBytes = parsePositiveInt(next, arg);
+        opts.scopeBytes = parsePositiveInt(readValue(next, arg), arg);
         i += 1;
         break;
       case "--quiet":
@@ -129,48 +130,7 @@ function parseArgs(argv: string[]): Options {
         fail(`Unknown arg: ${arg}`);
     }
   }
-  if (!Number.isFinite(opts.iters) || opts.iters <= 0) {
-    fail("--iters must be > 0");
-  }
-  if (!Number.isFinite(opts.batches) || opts.batches <= 0) {
-    fail("--batches must be > 0");
-  }
   return opts;
-}
-
-function parsePositiveInt(raw: string | undefined, flag: string): number {
-  const value = parseStrictInt(raw, flag, "positive");
-  if (value <= 0) {
-    fail(`${flag} must be a positive integer`);
-  }
-  return value;
-}
-
-function parseNonNegativeInt(raw: string | undefined, flag: string): number {
-  const value = parseStrictInt(raw, flag, "non-negative");
-  if (value < 0) {
-    fail(`${flag} must be a non-negative integer`);
-  }
-  return value;
-}
-
-function parseStrictInt(
-  raw: string | undefined,
-  flag: string,
-  label: "positive" | "non-negative",
-): number {
-  const text = (raw ?? "").trim();
-  if (!text || text.startsWith("-")) {
-    fail(`${flag} requires a value`);
-  }
-  if (!/^\d+$/u.test(text)) {
-    fail(`${flag} must be a ${label} integer`);
-  }
-  const value = Number(text);
-  if (!Number.isSafeInteger(value)) {
-    fail(`${flag} must be a ${label} integer`);
-  }
-  return value;
 }
 
 function printUsage(): void {
@@ -321,7 +281,12 @@ function fmtBytes(bytes: number): string {
 }
 
 async function main(): Promise<void> {
-  const opts = parseArgs(process.argv.slice(2));
+  let opts: Options;
+  try {
+    opts = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error));
+  }
   if (opts.mode === "production") {
     await loadProductionAbortable();
   }

--- a/test/scripts/embedded-run-abort-leak.test.ts
+++ b/test/scripts/embedded-run-abort-leak.test.ts
@@ -1,7 +1,7 @@
 // Embedded Run Abort Leak tests cover embedded run abort leak script behavior.
 import { spawnSync } from "node:child_process";
 import { readdirSync } from "node:fs";
-import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const tempRoots = useAutoCleanupTempDirTracker(afterEach);
@@ -18,59 +18,58 @@ function runHarness(args: string[]) {
 }
 
 describe("scripts/embedded-run-abort-leak", () => {
-  let looseThresholdProbe: {
-    result: ReturnType<typeof runHarness>;
-    snapDir: string;
-  };
-
-  beforeAll(() => {
+  it.each([
+    [["--iters", "1e3"], "--iters must be a positive integer"],
+    [["--iters", "0"], "--iters must be a positive integer"],
+    [["--batches", "+1"], "--batches must be a positive integer"],
+    [["--scope-bytes", "9007199254740992"], "--scope-bytes must be a positive integer"],
+    [["--max-rss-growth-mb", "1.5"], "--max-rss-growth-mb must be a non-negative integer"],
+    [
+      ["--max-tracked-retention", "9007199254740992"],
+      "--max-tracked-retention must be a non-negative integer",
+    ],
+    [["--iters", "1", "--iters", "2"], "--iters was provided more than once"],
+    [["--iters", "1", "--iters"], "--iters was provided more than once"],
+    [["--iters", "1", "--iters", "-h"], "--iters was provided more than once"],
+    [["--iters", "  "], "--iters requires a value"],
+    [["--iters", " -1 "], "--iters requires a value"],
+    [["--iters", "-h"], "--iters requires a value"],
+    [["--mode", "-h"], "--mode requires a value"],
+  ])("rejects %j before writing heap snapshots", (args, message) => {
     const snapDir = tempRoots.make("openclaw-embedded-abort-leak-test-");
-    looseThresholdProbe = {
-      result: runHarness(["--snap-dir", snapDir, "--iters", "1e3", "--quiet"]),
-      snapDir,
-    };
-  });
-
-  it("rejects loose numeric thresholds before writing heap snapshots", () => {
-    expect(looseThresholdProbe.result.status).toBe(2);
-    expect(looseThresholdProbe.result.stdout).toBe("");
-    expect(looseThresholdProbe.result.stderr).toContain(
-      "error: --iters must be a positive integer",
-    );
-    expect(readdirSync(looseThresholdProbe.snapDir)).toEqual([]);
-  });
-
-  it("rejects duplicate thresholds before writing heap snapshots", () => {
-    const snapDir = tempRoots.make("openclaw-embedded-abort-leak-test-");
-    const result = runHarness(["--snap-dir", snapDir, "--iters", "1", "--iters", "2", "--quiet"]);
+    const result = runHarness(["--snap-dir", snapDir, ...args]);
 
     expect(result.status).toBe(2);
     expect(result.stdout).toBe("");
-    expect(result.stderr).toContain("error: --iters was provided more than once");
+    expect(result.stderr).toBe(`error: ${message}\n`);
     expect(readdirSync(snapDir)).toEqual([]);
   });
 
-  it("rejects missing snapshot directories before writing heap snapshots", () => {
-    const result = runHarness(["--snap-dir", "--quiet", "--iters", "1", "--batches", "1"]);
+  it.each(["--quiet", "-h"])("rejects %s as a snapshot directory", (value) => {
+    const result = runHarness(["--snap-dir", value]);
 
     expect(result.status).toBe(2);
     expect(result.stdout).toBe("");
-    expect(result.stderr).toContain("error: --snap-dir requires a value");
+    expect(result.stderr).toBe("error: --snap-dir requires a value\n");
   });
 
-  it("rejects short flag values before writing heap snapshots", () => {
-    const snapDirResult = runHarness(["--snap-dir", "-h", "--quiet", "--iters", "1"]);
-    const itersResult = runHarness(["--iters", "-h", "--quiet"]);
-    const modeResult = runHarness(["--mode", "-h", "--quiet"]);
+  it("accepts padded decimal controls and zero thresholds before help", () => {
+    const result = runHarness([
+      "--iters",
+      " 01 ",
+      "--batches",
+      "01",
+      "--scope-bytes",
+      "9007199254740991",
+      "--max-rss-growth-mb",
+      " 0 ",
+      "--max-tracked-retention",
+      "00",
+      "--help",
+    ]);
 
-    expect(snapDirResult.status).toBe(2);
-    expect(snapDirResult.stdout).toBe("");
-    expect(snapDirResult.stderr).toContain("error: --snap-dir requires a value");
-    expect(itersResult.status).toBe(2);
-    expect(itersResult.stdout).toBe("");
-    expect(itersResult.stderr).toContain("error: --iters requires a value");
-    expect(modeResult.status).toBe(2);
-    expect(modeResult.stdout).toBe("");
-    expect(modeResult.stderr).toContain("error: --mode requires a value");
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("Usage: node --import tsx --expose-gc");
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested cleanup: the embedded-run abort heap benchmark maintains its own copies of strict integer validation already provided by the shared script helpers.

## Why This Change Was Made

Reuse the existing positive and non-negative integer parsers and delete the three local parsers and unreachable final range checks. Keep the benchmark's value guard, duplicate-argument ordering, error text, and exit status unchanged. Consolidate its existing executable CLI tests into meaningful boundary cases without adding a test-only production interface.

## User Impact

No behavior change. All benchmark modes, defaults, numeric controls, help output, and heap measurement logic remain unchanged. Production/tooling LOC: +12/-47 (net -35); tests: +41/-42 (net -1).

## Evidence

- 36 focused tests passed on the refreshed branch: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/embedded-run-abort-leak.test.ts test/scripts/numeric-options.test.ts`.
- Scoped script lint, two-file formatting, and `git diff --check` passed. Fresh isolated Codex autoreview reported no accepted/actionable findings.
- Before refreshing the branch, six actual CLI invocations produced identical status/stdout/stderr before and after the change, including malformed integers, duplicate/missing precedence, short flags, and accepted padded decimal values. A one-iteration closure-extracted benchmark passed and produced two verified heap snapshots, which were then removed.
- Script and root-test typechecks and script erasability passed before the refresh. The affected owner, imported helpers, and test inputs are unchanged upstream; executable tests and scoped checks were rerun on the refreshed branch.

AI-assisted maintainer refactor. No configuration, storage, public SDK, dependency, or workflow changes.
