### PR TITLE
fix(ui): cover split and commentary-interleaved rows in steer prefix subtraction

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -4134,7 +4134,7 @@ ui/src/pages/chat/route.ts	2
 ui/src/pages/chat/run-lifecycle.ts	1
 ui/src/pages/chat/scroll.ts	1
 ui/src/pages/chat/session-cache.ts	2
-ui/src/pages/chat/stream-reconciliation.ts	12
+ui/src/pages/chat/stream-reconciliation.ts	11
 ui/src/pages/chat/tool-stream.ts	5
 ui/src/pages/chat/workspace-conflict.ts	2
 ui/src/pages/config/config-page.ts	1

--- a/ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts
@@ -474,6 +474,139 @@ suite.define(() => {
     },
   );
 
+  it("replaces a retained cumulative steer prefix with split history around keyed commentary", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const runId = "run-steer-split";
+    const steerRunId = "steer-split";
+    const startedAt = Date.now() - 5_000;
+    const initialText = "Explain the long running operation.";
+    const beforeText = "A B";
+    const commentaryText = "Checking the intermediate result.";
+    const steerText = "Now focus on the remaining work.";
+    const afterText = "The remaining work continues after steering.";
+    const userMessage = {
+      role: "user",
+      content: initialText,
+      timestamp: startedAt - 1_000,
+      __openclaw: { id: "split-user", idempotencyKey: `${runId}:user`, seq: 1 },
+    };
+    const steerMessage = {
+      role: "user",
+      content: steerText,
+      timestamp: startedAt + 3_000,
+      __openclaw: {
+        id: "split-steer",
+        idempotencyKey: `${steerRunId}:user`,
+        seq: 5,
+        steerTargetRunId: runId,
+      },
+    };
+    const sessionInfo = { activeRunIds: [runId], hasActiveRun: true, key: "main" };
+    const gateway = await installMockGateway(page, {
+      historyMessages: [userMessage],
+      inFlightRun: { runId, startedAt, text: "" },
+      sessionInfo,
+    });
+    const emitDelta = (text: string) =>
+      gateway.emitGatewayEvent("chat", {
+        message: { role: "assistant", content: [{ type: "text", text }] },
+        runId,
+        sessionKey: "main",
+        state: "delta",
+      });
+    const capture = async (name: string) => {
+      const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      if (artifactDir) {
+        await mkdir(artifactDir, { recursive: true });
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(artifactDir, `steer-split-commentary-${name}.png`),
+        });
+      }
+    };
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const transcript = page.locator(".chat-thread-inner");
+      const bubbleTexts = () =>
+        transcript
+          .locator(".chat-bubble .chat-text")
+          .evaluateAll((bubbles) => bubbles.map((bubble) => bubble.textContent?.trim()));
+      await transcript.getByText(initialText, { exact: true }).waitFor();
+      await emitDelta(beforeText);
+      await transcript.getByText(beforeText, { exact: true }).waitFor();
+      // The live steer closes one combined segment before split history replaces it.
+      await gateway.emitGatewayEvent("session.message", {
+        ...sessionInfo,
+        clientRunId: steerRunId,
+        message: steerMessage,
+        messageId: "split-steer",
+        messageSeq: 5,
+        sessionKey: "main",
+      });
+      await expect.poll(bubbleTexts).toEqual([initialText, beforeText, steerText]);
+      await capture("retained-prefix");
+
+      await gateway.setMethodResponse("chat.history", {
+        messages: [
+          userMessage,
+          {
+            role: "assistant",
+            content: "A",
+            timestamp: startedAt,
+            __openclaw: { id: "split-a", idempotencyKey: runId, seq: 2 },
+          },
+          {
+            role: "assistant",
+            content: commentaryText,
+            timestamp: startedAt + 1_000,
+            __openclaw: { id: "split-commentary", idempotencyKey: runId, seq: 3 },
+            openclawStreamFallback: {
+              itemId: "split-commentary-item",
+              source: "segment",
+              replacementText: commentaryText,
+              runId,
+            },
+          },
+          {
+            role: "assistant",
+            content: "B",
+            timestamp: startedAt + 2_000,
+            __openclaw: { id: "split-b", idempotencyKey: runId, seq: 4 },
+          },
+          steerMessage,
+        ],
+        inFlightRun: { runId, startedAt, text: beforeText },
+        sessionInfo,
+      });
+      const startupsBefore = (await gateway.getRequests("chat.startup")).length;
+      await gateway.deferNext("chat.startup");
+      await gateway.setOnline(false);
+      await waitForControlUiGatewayReconnecting(page);
+      await gateway.setOnline(true);
+      await gateway.waitForRequest("chat.startup", { after: startupsBefore });
+      await gateway.resolveDeferred("chat.startup");
+      await transcript.getByText(commentaryText, { exact: true }).waitFor();
+      await page.getByRole("button", { name: "Stop generating" }).waitFor();
+      await emitDelta(`${beforeText} ${afterText}`);
+
+      try {
+        await expect
+          .poll(bubbleTexts)
+          .toEqual([initialText, "A", commentaryText, "B", steerText, afterText]);
+      } finally {
+        await capture("recovered-continuation");
+      }
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
   it("keeps modified Enter queued in modifier-enter shortcut mode", async () => {
     const context = await suite.newBrowserContext({
       locale: "en-US",

--- a/ui/src/pages/chat/chat-history.inflight.test.ts
+++ b/ui/src/pages/chat/chat-history.inflight.test.ts
@@ -412,10 +412,15 @@ describe("chat history in-flight assistant recovery", () => {
     expect(state.chatMessages).toEqual(history.messages);
   });
 
-  it.each(["fresh adoption", "retained boundary"])(
-    "keeps the cumulative prefix after persisted history replacement: %s",
-    async (mode) => {
+  it.each(
+    ["fresh adoption", "retained boundary"].flatMap((mode) =>
+      ["single row", "split rows", "split rows with commentary"].map((rows) => ({ mode, rows })),
+    ),
+  )(
+    "keeps the cumulative prefix after persisted history replacement: $mode, $rows",
+    async ({ mode, rows }) => {
       const history = activeHistory("active-run");
+      const prefix = rows === "single row" ? "Before steer." : "Before tool.Before steer.";
       const original = {
         role: "user",
         content: "Original prompt",
@@ -425,25 +430,52 @@ describe("chat history in-flight assistant recovery", () => {
       const steer = {
         role: "user",
         content: "Steer prompt",
-        timestamp: 3,
+        timestamp: 5,
         __openclaw: {
           id: "steer",
           idempotencyKey: "steer-run:user",
-          seq: 3,
+          seq: 5,
           steerTargetRunId: "active-run",
         },
       };
       history.messages = [
         original,
+        ...(rows === "single row"
+          ? []
+          : [
+              {
+                role: "assistant",
+                content: "Before tool.",
+                timestamp: 2,
+                __openclaw: { idempotencyKey: "active-run", seq: 2 },
+              },
+            ]),
+        ...(rows === "split rows with commentary"
+          ? [
+              {
+                role: "assistant",
+                content: "Checking the result.",
+                timestamp: 3,
+                __openclaw: { idempotencyKey: "active-run", seq: 3 },
+                openclawStreamFallback: {
+                  itemId: "commentary-item",
+                  source: "segment",
+                  replacementText: "Checking the result.",
+                  runId: "active-run",
+                },
+              },
+            ]
+          : []),
         {
           role: "assistant",
           content: "Before steer.",
-          timestamp: 2,
-          __openclaw: { idempotencyKey: "active-run", seq: 2 },
+          timestamp: 4,
+          __openclaw: { idempotencyKey: "active-run", seq: 4 },
         },
         steer,
       ];
-      history.inFlightRun!.text = "Before steer. After steer.";
+      history.inFlightRun!.text = `${prefix} After steer.`;
+      const persistedText = history.messages.map((message) => extractText(message));
       const state = createState(history);
       if (mode === "retained boundary") {
         state.chatRunId = "active-run";
@@ -455,37 +487,31 @@ describe("chat history in-flight assistant recovery", () => {
           message: { role: "assistant", content: history.inFlightRun!.text },
         });
         state.chatStreamSegments = [
-          { text: "Before steer.", ts: 2, runId: "active-run", boundaryRunId: "steer-run" },
+          { text: prefix, ts: 2, runId: "active-run", boundaryRunId: "steer-run" },
         ];
       }
       await loadChatHistory(state);
+      expect(renderedText(state)).toEqual([...persistedText, "After steer."]);
       handleChatGatewayEvent(state, {
         sessionKey: "main",
         runId: "active-run",
         state: "delta",
         deltaText: " Continued.",
-        message: { role: "assistant", content: "Before steer. After steer. Continued." },
+        message: { role: "assistant", content: `${prefix} After steer. Continued.` },
       });
-      expect(renderedText(state)).toEqual([
-        "Original prompt",
-        "Before steer.",
-        "Steer prompt",
-        "After steer. Continued.",
-      ]);
-      expect(state.chatStream).toBe("Before steer. After steer. Continued.");
+      expect(renderedText(state)).toEqual([...persistedText, "After steer. Continued."]);
+      expect(state.chatStream).toBe(`${prefix} After steer. Continued.`);
       handleChatGatewayEvent(state, {
         sessionKey: "main",
         runId: "active-run",
         state: "final",
         message: {
           role: "assistant",
-          content: "Before steer. After steer. Continued. Final suffix.",
+          content: `${prefix} After steer. Continued. Final suffix.`,
         },
       });
       expect(renderedText(state)).toEqual([
-        "Original prompt",
-        "Before steer.",
-        "Steer prompt",
+        ...persistedText,
         "After steer. Continued. Final suffix.",
       ]);
     },
@@ -621,24 +647,7 @@ describe("chat history in-flight assistant recovery", () => {
     expect(visibleCurrentAssistantStreamTail(state, isHiddenAssistantStreamText)).toBe(
       "Trimmed live tail.",
     );
-    const renderedBeforeTerminal = buildChatItems({
-      paneId: "reconnected-steer-boundary",
-      sessionKey: state.sessionKey,
-      runId: state.chatRunId,
-      messages: state.chatMessages,
-      toolMessages: state.chatToolMessages,
-      streamSegments: state.chatStreamSegments,
-      stream: state.chatStream,
-      streamStartedAt: state.chatStreamStartedAt,
-      showToolCalls: true,
-    }).flatMap((item) =>
-      item.kind === "group"
-        ? item.messages.map(({ message }) => extractText(message))
-        : item.kind === "stream"
-          ? [item.text.trim()]
-          : [],
-    );
-    expect(renderedBeforeTerminal).toEqual([
+    expect(renderedText(state)).toEqual([
       "Start working.",
       "Saved opening.",
       "Also check the result.",

--- a/ui/src/pages/chat/stream-causal-boundary.ts
+++ b/ui/src/pages/chat/stream-causal-boundary.ts
@@ -8,6 +8,7 @@ import {
 } from "../../lib/chat/chat-types.ts";
 import { extractText } from "../../lib/chat/message-extract.ts";
 import { userTurnSendIdentity } from "./chat-thread-items.ts";
+import { isKeyedAssistantStreamFallbackMessage } from "./chat-thread-run-identity.ts";
 
 export type StreamCausalBoundaryState = {
   chatMessages?: unknown[];
@@ -233,7 +234,10 @@ export function resolveCumulativeAssistantTail(
   for (let index = 0; index < endIndex; index += 1) {
     const message = messages[index];
     const identity = readSessionMessageIdentity(message);
-    const persistedText = identity?.runId === runId ? extractText(message) : null;
+    const persistedText =
+      identity?.runId === runId && !isKeyedAssistantStreamFallbackMessage(message)
+        ? extractText(message)
+        : null;
     if (
       identity?.role === "assistant" &&
       persistedText &&
@@ -245,13 +249,24 @@ export function resolveCumulativeAssistantTail(
   }
   const turnStart =
     ownedPrefixIndex >= 0 ? ownedPrefixIndex : lastUserMessageIndex(messages, endIndex) + 1;
+  const persistedTexts = messages.slice(turnStart, endIndex).map((message) => {
+    const identity = readSessionMessageIdentity(message);
+    // Keyed commentary mirrors travel through item events, outside the cumulative buffer.
+    return identity?.role === "assistant" &&
+      (!identity.runId || identity.runId === runId) &&
+      !isKeyedAssistantStreamFallbackMessage(message)
+      ? extractText(message)
+      : null;
+  });
+  return resolveAssistantTextTail(persistedTexts, cumulativeText);
+}
+
+export function resolveAssistantTextTail(
+  persistedTexts: readonly (string | null)[],
+  cumulativeText: string,
+): string | null {
   let persistedPrefixLength = 0;
-  for (let index = turnStart; index < endIndex; index += 1) {
-    const identity = readSessionMessageIdentity(messages[index]);
-    if (identity?.role !== "assistant" || (identity.runId && identity.runId !== runId)) {
-      continue;
-    }
-    const persistedText = extractText(messages[index]);
+  for (const persistedText of persistedTexts) {
     if (!persistedText) {
       continue;
     }

--- a/ui/src/pages/chat/stream-reconciliation.test.ts
+++ b/ui/src/pages/chat/stream-reconciliation.test.ts
@@ -1,7 +1,11 @@
 // @vitest-environment node
 // Control UI tests cover stream reconciliation behavior.
 import { describe, expect, it } from "vitest";
-import { reconcileTerminalStreamBoundary, rolloverChatStream } from "./stream-causal-boundary.ts";
+import {
+  reconcileTerminalStreamBoundary,
+  resolveCumulativeAssistantTail,
+  rolloverChatStream,
+} from "./stream-causal-boundary.ts";
 import {
   appendTerminalAssistantMessage,
   historyReplacedVisibleStream,
@@ -75,6 +79,49 @@ function createConcurrentToolStreamState() {
 }
 
 describe("stream reconciliation", () => {
+  it.each([
+    { name: "commentary mirror", fallback: { itemId: "commentary" }, text: "Progress", tail: "C" },
+    {
+      name: "matching commentary mirror",
+      fallback: { itemId: "commentary" },
+      text: "BC",
+      tail: "C",
+    },
+    { name: "ordinary assistant", fallback: undefined, text: "Other answer", tail: "BC" },
+    { name: "unkeyed fallback", fallback: {}, text: "Other answer", tail: "BC" },
+    { name: "blank item id", fallback: { itemId: " " }, text: "Other answer", tail: "BC" },
+  ])("subtracts the cumulative prefix across an interleaved $name", ({ fallback, text, tail }) => {
+    const messages = [
+      { role: "assistant", content: "A", __openclaw: { idempotencyKey: "active-run" } },
+      {
+        role: "assistant",
+        content: text,
+        __openclaw: { idempotencyKey: "active-run" },
+        ...(fallback ? { openclawStreamFallback: { source: "segment", ...fallback } } : {}),
+      },
+      { role: "assistant", content: "B", __openclaw: { idempotencyKey: "active-run" } },
+    ];
+
+    expect(resolveCumulativeAssistantTail(messages, "ABC", "active-run")).toBe(tail);
+  });
+
+  it("does not anchor cumulative coverage on matching commentary before an older reply", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: "ABC",
+        __openclaw: { idempotencyKey: "active-run" },
+        openclawStreamFallback: { source: "segment", itemId: "commentary" },
+      },
+      { role: "assistant", content: "ABC" },
+      { role: "user", content: "Current request" },
+      { role: "assistant", content: "A", __openclaw: { idempotencyKey: "active-run" } },
+      { role: "assistant", content: "B", __openclaw: { idempotencyKey: "active-run" } },
+    ];
+
+    expect(resolveCumulativeAssistantTail(messages, "ABC", "active-run")).toBe("C");
+  });
+
   it("materializes keyed preambles by timestamp instead of tool index", () => {
     const state = makeIdleStreamState({
       chatStreamSegments: [

--- a/ui/src/pages/chat/stream-reconciliation.ts
+++ b/ui/src/pages/chat/stream-reconciliation.ts
@@ -13,7 +13,9 @@ import {
   trimAccumulatedStreamPrefix,
 } from "../../lib/chat/chat-types.ts";
 import { extractText } from "../../lib/chat/message-extract.ts";
+import { isKeyedAssistantStreamFallbackMessage } from "./chat-thread-run-identity.ts";
 import {
+  resolveAssistantTextTail,
   streamCausalInsertIndex,
   streamCausalInterval,
   streamCausalTimestamp,
@@ -255,33 +257,6 @@ function visibleAssistantStreamText(
   return stream;
 }
 
-function hasAssistantStreamReplacement(
-  messages: unknown[],
-  stream: string,
-  isHiddenAssistantMessage: AssistantMessageVisibility,
-  startIndex: number,
-  endIndex = messages.length,
-): boolean {
-  const expected = stream.trim();
-  if (!expected) {
-    return false;
-  }
-  return messages.slice(startIndex, endIndex).some((message) => {
-    if (!message || typeof message !== "object") {
-      return false;
-    }
-    const role = normalizeLowercaseStringOrEmpty((message as { role?: unknown }).role);
-    if (role && role !== "assistant") {
-      return false;
-    }
-    if (role === "assistant" && isHiddenAssistantMessage(message)) {
-      return false;
-    }
-    const text = extractText(message)?.trim();
-    return Boolean(text && (text === expected || text.startsWith(expected)));
-  });
-}
-
 export function assistantMessageReplacesCurrentStream(
   state: StreamReconciliationState,
   message: unknown,
@@ -291,9 +266,7 @@ export function assistantMessageReplacesCurrentStream(
     isHiddenStreamText: () => false,
   }).findLast((part) => part.source === "current");
   return Boolean(
-    currentPart &&
-    (hasAssistantStreamReplacement([message], currentPart.replacementText, () => false, 0) ||
-      hasAssistantStreamReplacement([message], currentPart.text, () => false, 0)),
+    currentPart && hasAssistantStreamPartReplacement([message], currentPart, () => false, 0),
   );
 }
 
@@ -426,21 +399,20 @@ export function hasAssistantStreamPartReplacement(
   if (part.itemId) {
     return hasKeyedAssistantStreamReplacement(messages, part.itemId, startIndex, endIndex);
   }
-  return (
-    hasAssistantStreamReplacement(
-      messages,
-      part.replacementText,
-      isHiddenAssistantMessage,
-      startIndex,
-      endIndex,
-    ) ||
-    hasAssistantStreamReplacement(
-      messages,
-      part.text,
-      isHiddenAssistantMessage,
-      startIndex,
-      endIndex,
-    )
+  const persistedTexts = messages.slice(startIndex, endIndex).map((message) => {
+    const identity = readSessionMessageIdentity(message);
+    if (
+      (identity?.role && identity.role !== "assistant") ||
+      (identity?.runId && part.runId && identity.runId !== part.runId) ||
+      isHiddenAssistantMessage(message) ||
+      isKeyedAssistantStreamFallbackMessage(message)
+    ) {
+      return null;
+    }
+    return extractText(message)?.trim() ?? null;
+  });
+  return [part.replacementText, part.text].some(
+    (text) => Boolean(text.trim()) && !resolveAssistantTextTail(persistedTexts, text.trim()),
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #131550/#131606 closing two consumer gaps in the persisted-prefix coverage that decides whether streamed text is already replaced by durable rows. Both were found during the steering-prefix investigation, with reproductions: a retained combined segment covered by *several* split run-owned rows re-rendered as duplicated text (the replacement check accepted only a single covering row), and an interleaved keyed commentary mirror truncated the cumulative-tail subtraction (rows A → commentary → B with cumulative ABC yielded tail "BC" instead of "C").

## Why This Change Was Made

The replacement check and the cumulative subtraction answered the same question — "do these durable rows cover this text?" — with two different algorithms of different strength. One canonical sequential coverage algorithm (`resolveAssistantTextTail`) now serves both; the weaker single-row matcher is deleted. Keyed commentary mirrors travel through item events and are never part of the assistant run buffer, so both paths now skip them; genuinely unmatched assistant rows still stop coverage (that guard protects against foreign-run truncation).

## User Impact

After history refreshes and reloads around steering, transcripts no longer show duplicated pre-steer text when history splits rows, and prefix subtraction stays correct when commentary interleaves with answer text.

## Evidence

- 6 regression cases fail on pre-fix production (HEAD-copy proof) and pass with the fix, across `chat-history.inflight.test.ts`, `stream-reconciliation.test.ts`.
- 596 tests green across the seven affected suites; `node scripts/check-changed.mjs` exit 0; Codex autoreview clean (no P0, 0.98).
- Production +39/−52 (net **−13**); tests +96/−40; assertion baseline shrinks by the deleted function's entry (shrink-only ratchet maintenance).

## CI note

The MCP app conformance flake was fixed on main by #131690, and this branch dropped its superseded copy during rebase.
