### PR TITLE
fix(usage): retain reset history and unify accounting

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2990,7 +2990,6 @@ src/gateway/server-methods/terminal.ts	7
 src/gateway/server-methods/tools-catalog.ts	2
 src/gateway/server-methods/ui-command.ts	1
 src/gateway/server-methods/update.ts	2
-src/gateway/server-methods/usage.ts	3
 src/gateway/server-methods/web.ts	3
 src/gateway/server-methods/wizard.ts	1
 src/gateway/server-methods/workspace-fs.ts	2
@@ -3239,7 +3238,7 @@ src/infra/session-cost-usage-cache-runtime.ts	1
 src/infra/session-cost-usage-cache.sqlite.ts	1
 src/infra/session-cost-usage-collection.ts	4
 src/infra/session-cost-usage-pricing.ts	6
-src/infra/session-cost-usage-reporting.ts	9
+src/infra/session-cost-usage-reporting.ts	8
 src/infra/session-delivery-queue-runtime.ts	1
 src/infra/session-delivery-queue-storage.ts	6
 src/infra/shell-env.ts	1

--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -653,7 +653,6 @@ src/gateway/server-methods/sessions-files.ts
 src/gateway/server-methods/skills.ts
 src/gateway/server-methods/talk.test.ts
 src/gateway/server-methods/talk.ts
-src/gateway/server-methods/usage.ts
 src/gateway/server-node-events.test.ts
 src/gateway/server-node-events.ts
 src/gateway/server-plugins.test.ts
@@ -884,7 +883,6 @@ ui/src/pages/sessions/view.test.ts
 ui/src/pages/sessions/view.ts
 ui/src/pages/skill-workshop/view.ts
 ui/src/pages/skills/view.ts
-ui/src/pages/usage/metrics.ts
 ui/src/pages/usage/view-details.ts
 ui/src/pages/usage/view-overview.ts
 ui/src/pages/usage/view.ts

--- a/docs/reference/api-usage-costs.md
+++ b/docs/reference/api-usage-costs.md
@@ -28,6 +28,7 @@ Map of OpenClaw features that can call paid provider APIs, where each reads its 
 
 - Shows transcript-derived token and estimated-cost totals for the selected date range, with breakdowns by provider, model, agent, channel, and token type.
 - Named sessions use their stored agent owner. Identical session IDs under different agents remain separate, including when historical lineage is grouped.
+- Grouped history remains visible after a session reset, even before the new session has its first message. Filtering and JSON exports retain the breakdown of entries with missing model prices.
 - Compares shorter calendar windows ending on the selected range end date. Missing dates count as zero-usage calendar days; they are not skipped to create a denser window.
 - Labels the daily chart scale directly. A `√` badge means square-root compression is keeping low-usage days visible.
 - These totals describe the available local session history, not a provider invoice or lifetime billing ledger. The UI warns when pricing is missing for some entries.

--- a/scripts/check-session-accessor-boundary.mts
+++ b/scripts/check-session-accessor-boundary.mts
@@ -268,7 +268,7 @@ export const readOnlyGatewaySessionAccessorFiles = new Set([
   "src/gateway/server-methods/sessions-subscriptions.ts",
   "src/gateway/server-methods/task-suggestions.ts",
   "src/gateway/server-methods/tools-effective.ts",
-  "src/gateway/server-methods/usage.ts",
+  "src/gateway/server-methods/usage-session-selection.ts",
   "src/gateway/server-session-events.ts",
 ]);
 

--- a/src/gateway/server-methods/usage-date-range.ts
+++ b/src/gateway/server-methods/usage-date-range.ts
@@ -1,0 +1,365 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import {
+  createTimeZoneDayKeyFormatter,
+  resolveTimezone,
+  resolveTimeZoneDayStartMs,
+} from "../../infra/format-time/format-datetime.js";
+import type { UsageDailyBucket } from "../../infra/session-cost-usage.js";
+
+export type DateRange = { startMs: number; endMs: number; includeUntimestamped?: boolean };
+// Keep validation and parsed timestamps in one result so handlers cannot forward
+// an invalid or backwards window to the usage loaders.
+type DateRangeResolution = { ok: true; value: DateRange } | { ok: false; error: string };
+// 100 years: callers requesting unbounded history should use `range: "all"`.
+// Larger explicit day counts would overflow ECMAScript Date arithmetic and
+// surface as a misleading "calendar day does not exist" error from the resolver.
+const MAX_USAGE_DAYS = 366 * 100;
+export type DateInterpretation =
+  | { mode: "utc" | "gateway" }
+  | { mode: "utc-offset"; utcOffsetMinutes: number }
+  | { mode: "time-zone"; timeZone: string; formatDayKey: (date: Date) => string };
+type DateInterpretationResolution =
+  | { ok: true; value: DateInterpretation }
+  | { ok: false; error: string };
+type DateParts = { year: number; monthIndex: number; day: number };
+
+const MAX_CONSECUTIVE_SKIPPED_TIME_ZONE_DAYS = 1;
+
+const parseDateParts = (raw: unknown): DateParts | undefined => {
+  if (typeof raw !== "string" || !raw.trim()) {
+    return undefined;
+  }
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(raw.trim());
+  if (!match) {
+    return undefined;
+  }
+  const [, yearStr, monthStr, dayStr] = match;
+  const year = Number(yearStr);
+  const monthIndex = Number(monthStr) - 1;
+  const day = Number(dayStr);
+  if (!Number.isFinite(year) || !Number.isFinite(monthIndex) || !Number.isFinite(day)) {
+    return undefined;
+  }
+  // The regex only checks shape; Date.* silently rolls impossible calendar dates over
+  // (e.g. 2026-02-30 -> 2026-03-02), so a typo'd day would return usage for the wrong day.
+  // Reject parts that don't round-trip through a UTC probe (also catches the JS 2-digit-year remap).
+  const probe = new Date(Date.UTC(year, monthIndex, day));
+  if (
+    probe.getUTCFullYear() !== year ||
+    probe.getUTCMonth() !== monthIndex ||
+    probe.getUTCDate() !== day
+  ) {
+    return undefined;
+  }
+  return { year, monthIndex, day };
+};
+
+const shiftDateParts = (parts: DateParts, days: number): DateParts => {
+  const shifted = new Date(Date.UTC(parts.year, parts.monthIndex, parts.day + days));
+  return {
+    year: shifted.getUTCFullYear(),
+    monthIndex: shifted.getUTCMonth(),
+    day: shifted.getUTCDate(),
+  };
+};
+
+const datePartsToStartMs = (
+  parts: DateParts,
+  interpretation: DateInterpretation,
+): number | undefined => {
+  const { year, monthIndex, day } = parts;
+  if (interpretation.mode === "gateway") {
+    return new Date(year, monthIndex, day).getTime();
+  }
+  if (interpretation.mode === "time-zone") {
+    return resolveTimeZoneDayStartMs(
+      formatDateParts(year, monthIndex, day),
+      interpretation.timeZone,
+    );
+  }
+  if (interpretation.mode === "utc-offset") {
+    return Date.UTC(year, monthIndex, day) - interpretation.utcOffsetMinutes * 60 * 1000;
+  }
+  return Date.UTC(year, monthIndex, day);
+};
+
+const datePartsToEndMs = (
+  parts: DateParts,
+  interpretation: DateInterpretation,
+): number | undefined => {
+  const lookaheadDays =
+    interpretation.mode === "time-zone" ? 1 + MAX_CONSECUTIVE_SKIPPED_TIME_ZONE_DAYS : 1;
+  // A 24-hour date-line transition can remove one civil date entirely. Range
+  // resolution separately verifies the requested day; this only finds its end.
+  for (let daysAhead = 1; daysAhead <= lookaheadDays; daysAhead += 1) {
+    const nextDayStartMs = datePartsToStartMs(shiftDateParts(parts, daysAhead), interpretation);
+    if (nextDayStartMs !== undefined) {
+      return nextDayStartMs - 1;
+    }
+  }
+  return undefined;
+};
+
+// usage.cost / sessions.usage accept optional startDate/endDate. parseDateParts returns
+// undefined for both absent and invalid input, so an explicitly supplied but unparseable
+// date (bad format or impossible calendar date like 2026-02-30) would otherwise silently
+// fall through to the default range and return a successful response for an unrelated range.
+// Return the offending field so range resolution can reject it instead of querying the wrong window.
+const findInvalidExplicitDate = (params: {
+  startDate?: unknown;
+  endDate?: unknown;
+}): "startDate" | "endDate" | undefined => {
+  for (const field of ["startDate", "endDate"] as const) {
+    const raw = params[field];
+    if (raw === undefined || raw === null || (typeof raw === "string" && raw.trim() === "")) {
+      continue;
+    }
+    if (parseDateParts(raw) === undefined) {
+      return field;
+    }
+  }
+  return undefined;
+};
+
+/**
+ * Parse a UTC offset string in the format UTC+H, UTC-H, UTC+HH, UTC-HH, UTC+H:MM, UTC-HH:MM.
+ * Returns the UTC offset in minutes (east-positive), or undefined if invalid.
+ */
+const parseUtcOffsetToMinutes = (raw: unknown): number | undefined => {
+  if (typeof raw !== "string" || !raw.trim()) {
+    return undefined;
+  }
+  const match = /^UTC([+-])(\d{1,2})(?::([0-5]\d))?$/.exec(raw.trim());
+  if (!match) {
+    return undefined;
+  }
+  const sign = match[1] === "+" ? 1 : -1;
+  const hours = Number(match[2]);
+  const minutes = Number(match[3] ?? "0");
+  if (!Number.isInteger(hours) || !Number.isInteger(minutes)) {
+    return undefined;
+  }
+  if (hours > 14 || (hours === 14 && minutes !== 0)) {
+    return undefined;
+  }
+  const totalMinutes = sign * (hours * 60 + minutes);
+  if (totalMinutes < -12 * 60 || totalMinutes > 14 * 60) {
+    return undefined;
+  }
+  return totalMinutes;
+};
+
+export const resolveDateInterpretation = (params: {
+  mode?: unknown;
+  utcOffset?: unknown;
+  timeZone?: unknown;
+}): DateInterpretationResolution => {
+  if (params.mode === "gateway") {
+    return { ok: true, value: { mode: "gateway" } };
+  }
+  if (params.mode === "specific") {
+    const utcOffsetMinutes = parseUtcOffsetToMinutes(params.utcOffset);
+    if (params.timeZone !== undefined && params.timeZone !== null) {
+      const requestedTimeZone = normalizeOptionalString(params.timeZone);
+      const timeZone = requestedTimeZone ? resolveTimezone(requestedTimeZone) : undefined;
+      if (!timeZone) {
+        // Browser tzdata can lead Gateway ICU. Preserve legacy fixed-offset
+        // reporting when the concurrently supplied offset is still usable.
+        if (utcOffsetMinutes !== undefined) {
+          return { ok: true, value: { mode: "utc-offset", utcOffsetMinutes } };
+        }
+        return { ok: false, error: "invalid timeZone: expected a valid IANA time zone" };
+      }
+      return {
+        ok: true,
+        value: {
+          mode: "time-zone",
+          timeZone,
+          formatDayKey: createTimeZoneDayKeyFormatter(timeZone),
+        },
+      };
+    }
+    if (utcOffsetMinutes !== undefined) {
+      return { ok: true, value: { mode: "utc-offset", utcOffsetMinutes } };
+    }
+  }
+  // Backward compatibility: when mode is missing (or invalid), keep current UTC interpretation.
+  return { ok: true, value: { mode: "utc" } };
+};
+
+export const resolveDayBucket = (
+  interpretation: DateInterpretation,
+): UsageDailyBucket | undefined => {
+  if (interpretation.mode === "gateway") {
+    return undefined;
+  }
+  if (interpretation.mode === "time-zone") {
+    return { mode: "time-zone", timeZone: interpretation.timeZone };
+  }
+  return {
+    mode: "utc-offset",
+    utcOffsetMinutes: interpretation.mode === "utc-offset" ? interpretation.utcOffsetMinutes : 0,
+  };
+};
+
+const getDateParts = (date: Date, interpretation: DateInterpretation): DateParts => {
+  if (interpretation.mode === "gateway") {
+    return { year: date.getFullYear(), monthIndex: date.getMonth(), day: date.getDate() };
+  }
+  if (interpretation.mode === "time-zone") {
+    const parts = parseDateParts(interpretation.formatDayKey(date));
+    if (!parts) {
+      throw new Error("timezone formatter returned an invalid calendar day");
+    }
+    return parts;
+  }
+  if (interpretation.mode === "utc-offset") {
+    const shifted = new Date(date.getTime() + interpretation.utcOffsetMinutes * 60 * 1000);
+    return {
+      year: shifted.getUTCFullYear(),
+      monthIndex: shifted.getUTCMonth(),
+      day: shifted.getUTCDate(),
+    };
+  }
+  return {
+    year: date.getUTCFullYear(),
+    monthIndex: date.getUTCMonth(),
+    day: date.getUTCDate(),
+  };
+};
+
+export const formatDateLabel = (ms: number, interpretation: DateInterpretation): string => {
+  const parts = getDateParts(new Date(ms), interpretation);
+  return formatDateParts(parts.year, parts.monthIndex, parts.day);
+};
+
+const formatDateParts = (year: number, monthIndex: number, day: number): string =>
+  `${year}-${String(monthIndex + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+
+const parseDays = (raw: unknown): number | undefined => {
+  const fromFinite = (n: number): number | undefined => {
+    if (!Number.isFinite(n)) {
+      return undefined;
+    }
+    return Math.min(Math.floor(n), MAX_USAGE_DAYS);
+  };
+  if (typeof raw === "number") {
+    return fromFinite(raw);
+  }
+  if (typeof raw === "string" && raw.trim() !== "") {
+    return fromFinite(Number(raw));
+  }
+  return undefined;
+};
+
+const resolveRangeDays = (raw: unknown): number | "all" | undefined => {
+  if (raw === "all") {
+    return "all";
+  }
+  if (raw === "7d") {
+    return 7;
+  }
+  if (raw === "30d") {
+    return 30;
+  }
+  if (raw === "90d") {
+    return 90;
+  }
+  if (raw === "1y") {
+    return 365;
+  }
+  return undefined;
+};
+
+const resolveTrailingDays = (
+  endDateParts: DateParts,
+  days: number,
+  interpretation: DateInterpretation,
+): DateRangeResolution => {
+  const startMs = datePartsToStartMs(shiftDateParts(endDateParts, -(days - 1)), interpretation);
+  const endMs = datePartsToEndMs(endDateParts, interpretation);
+  if (startMs === undefined || endMs === undefined) {
+    return { ok: false, error: "calendar day does not exist in requested time zone" };
+  }
+  return { ok: true, value: { startMs, endMs } };
+};
+
+/**
+ * Get date range from params (startDate/endDate or days).
+ * Falls back to last 30 days if not provided.
+ */
+export const resolveDateRange = (
+  params: {
+    startDate?: unknown;
+    endDate?: unknown;
+    days?: unknown;
+    range?: unknown;
+    mode?: unknown;
+    utcOffset?: unknown;
+    timeZone?: unknown;
+  },
+  resolvedInterpretation?: DateInterpretation,
+): DateRangeResolution => {
+  const invalidDate = findInvalidExplicitDate(params);
+  if (invalidDate) {
+    return {
+      ok: false,
+      error: `invalid ${invalidDate}: expected a valid YYYY-MM-DD calendar date`,
+    };
+  }
+
+  const now = new Date();
+  const interpretationResolution = resolvedInterpretation
+    ? { ok: true as const, value: resolvedInterpretation }
+    : resolveDateInterpretation(params);
+  if (!interpretationResolution.ok) {
+    return interpretationResolution;
+  }
+  const interpretation = interpretationResolution.value;
+  const todayDateParts = getDateParts(now, interpretation);
+  const todayEndMs = datePartsToEndMs(todayDateParts, interpretation);
+  if (todayEndMs === undefined) {
+    return { ok: false, error: "calendar day does not exist in requested time zone" };
+  }
+
+  const startDateParts = parseDateParts(params.startDate);
+  const endDateParts = parseDateParts(params.endDate);
+  // Explicit date windows are atomic. A single boundary must not silently
+  // fall through to the unrelated default 30-day range.
+  if ((startDateParts === undefined) !== (endDateParts === undefined)) {
+    return { ok: false, error: "startDate and endDate must be provided together" };
+  }
+
+  if (startDateParts && endDateParts) {
+    const startMs = datePartsToStartMs(startDateParts, interpretation);
+    const endStartMs = datePartsToStartMs(endDateParts, interpretation);
+    const endMs = datePartsToEndMs(endDateParts, interpretation);
+    if (startMs === undefined || endStartMs === undefined || endMs === undefined) {
+      return { ok: false, error: "calendar day does not exist in requested time zone" };
+    }
+    if (startMs > endStartMs) {
+      return { ok: false, error: "startDate must not be after endDate" };
+    }
+    return { ok: true, value: { startMs, endMs } };
+  }
+
+  const rangeDays = resolveRangeDays(params.range);
+  if (rangeDays === "all") {
+    return {
+      ok: true,
+      value: { startMs: 0, endMs: todayEndMs, includeUntimestamped: true },
+    };
+  }
+  if (rangeDays !== undefined) {
+    return resolveTrailingDays(todayDateParts, rangeDays, interpretation);
+  }
+
+  const days = parseDays(params.days);
+  if (days !== undefined) {
+    const clampedDays = Math.max(1, days);
+    return resolveTrailingDays(todayDateParts, clampedDays, interpretation);
+  }
+
+  // Default to last 30 days
+  return resolveTrailingDays(todayDateParts, 30, interpretation);
+};

--- a/src/gateway/server-methods/usage-result-cache.ts
+++ b/src/gateway/server-methods/usage-result-cache.ts
@@ -1,0 +1,253 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  addCostUsageTotals,
+  createEmptyCostUsageTotals,
+} from "../../infra/session-cost-usage-totals.js";
+import {
+  loadCostUsageSummaryFromCache,
+  type CostUsageSummary,
+  type CostUsageTotals,
+  type UsageCacheStatus,
+  type UsageDailyBucket,
+} from "../../infra/session-cost-usage.js";
+import { normalizeAgentId } from "../../routing/session-key.js";
+import type { SessionsUsageResult } from "../../shared/usage-types.js";
+import { listGatewayAgentsBasic } from "../agent-list.js";
+import { mergeUsageCacheStatus, runUsageAgentTasks } from "./usage-session-loading.js";
+import type { UsageGroupingMode } from "./usage-session-selection.js";
+
+const USAGE_CACHE_TTL_MS = 30_000;
+const USAGE_CACHE_MAX = 256;
+
+type UsageCacheEntry<T extends object> = {
+  configRef: object;
+  value?: T;
+  updatedAt?: number;
+  inFlight?: Promise<T>;
+};
+
+export const costUsageCache = new Map<string, UsageCacheEntry<CostUsageSummary>>();
+export const sessionsUsageCache = new Map<string, UsageCacheEntry<SessionsUsageResult>>();
+
+function setUsageCache<T extends object>(
+  cache: Map<string, UsageCacheEntry<T>>,
+  cacheKey: string,
+  entry: UsageCacheEntry<T>,
+): void {
+  if (!cache.has(cacheKey) && cache.size >= USAGE_CACHE_MAX) {
+    let evictionKey = cache.keys().next().value;
+    // Preserve active loads whenever a settled entry can be evicted instead.
+    for (const [key, candidate] of cache) {
+      if (!candidate.inFlight) {
+        evictionKey = key;
+        break;
+      }
+    }
+    if (evictionKey !== undefined) {
+      cache.delete(evictionKey);
+    }
+  }
+  cache.set(cacheKey, entry);
+}
+
+async function loadUsageResultCached<T extends object>(params: {
+  cache: Map<string, UsageCacheEntry<T>>;
+  cacheKey: string;
+  configRef: object;
+  load: () => Promise<T>;
+  isComplete?: (value: T) => boolean;
+}): Promise<T> {
+  const { cache, cacheKey, configRef } = params;
+  const candidate = cache.get(cacheKey);
+  const cached = candidate?.configRef === configRef ? candidate : undefined;
+  if (cached?.value && cached.updatedAt && Date.now() - cached.updatedAt < USAGE_CACHE_TTL_MS) {
+    return cached.value;
+  }
+  if (cached?.inFlight) {
+    return cached.value && cached.updatedAt ? cached.value : await cached.inFlight;
+  }
+
+  const entry: UsageCacheEntry<T> = cached ?? { configRef };
+  const inFlight = params
+    .load()
+    .then((value) => {
+      if (cache.get(cacheKey) !== entry) {
+        return value;
+      }
+      if (params.isComplete?.(value) ?? true) {
+        entry.value = value;
+        entry.updatedAt = Date.now();
+      } else if (!entry.value) {
+        // Partial snapshots serve cold callers without masking the next refresh.
+        entry.value = value;
+        delete entry.updatedAt;
+      }
+      return value;
+    })
+    .catch((error: unknown) => {
+      if (entry.value) {
+        return entry.value;
+      }
+      throw error;
+    })
+    .finally(() => {
+      const current = cache.get(cacheKey);
+      if (current === entry && current.inFlight === inFlight) {
+        current.inFlight = undefined;
+      }
+    });
+
+  entry.inFlight = inFlight;
+  setUsageCache(cache, cacheKey, entry);
+  return entry.value && entry.updatedAt ? entry.value : await inFlight;
+}
+
+function usageDayBucketCacheKey(dayBucket: UsageDailyBucket | undefined): string {
+  return dayBucket
+    ? dayBucket.mode === "time-zone"
+      ? `time-zone:${dayBucket.timeZone}`
+      : `utc-offset:${dayBucket.utcOffsetMinutes}`
+    : "gateway";
+}
+
+type SessionsUsageCacheKeyParams = {
+  configRef: object;
+  visibilityIdentity?: string;
+  agentId?: string;
+  agentScope?: "all";
+  startMs: number;
+  endMs: number;
+  includeUntimestamped?: boolean;
+  dayBucket?: UsageDailyBucket;
+  limit: number;
+  groupingMode: UsageGroupingMode;
+  specificKey: string | null;
+  includeContextWeight: boolean;
+};
+
+// Every normalized query axis that can change response bytes belongs in this
+// key; the 30s TTL mirrors usage.cost and keeps dashboard refreshes coherent.
+function sessionsUsageCacheKey(params: SessionsUsageCacheKeyParams): string {
+  return JSON.stringify([
+    params.agentScope === "all" ? "all" : `agent:${params.agentId}`,
+    params.startMs,
+    params.endMs,
+    params.includeUntimestamped === true,
+    usageDayBucketCacheKey(params.dayBucket),
+    params.limit,
+    params.groupingMode,
+    params.specificKey,
+    params.includeContextWeight,
+    ...(params.visibilityIdentity ? [params.visibilityIdentity] : []),
+  ]);
+}
+
+export async function loadSessionsUsageResultCached(
+  params: SessionsUsageCacheKeyParams & {
+    load: () => Promise<SessionsUsageResult>;
+  },
+): Promise<SessionsUsageResult> {
+  return await loadUsageResultCached({
+    cache: sessionsUsageCache,
+    cacheKey: sessionsUsageCacheKey(params),
+    configRef: params.configRef,
+    load: params.load,
+    // Incomplete lower-cache snapshots must not acquire the outer freshness TTL.
+    isComplete: (result) => !result.cacheStatus || result.cacheStatus.status === "fresh",
+  });
+}
+
+export async function loadCostUsageSummaryCached(params: {
+  startMs: number;
+  endMs: number;
+  dayBucket?: UsageDailyBucket;
+  config: OpenClawConfig;
+  agentId?: string;
+  agentScope?: "all";
+}): Promise<CostUsageSummary> {
+  const allAgents = params.agentScope === "all";
+  const agentId = allAgents
+    ? undefined
+    : normalizeAgentId(params.agentId ?? resolveSessionAgentId({ config: params.config }));
+  const dayBucketKey = usageDayBucketCacheKey(params.dayBucket);
+  const cacheKey = `${allAgents ? "all" : `agent:${agentId}`}:${params.startMs}-${params.endMs}:${dayBucketKey}`;
+  return await loadUsageResultCached({
+    cache: costUsageCache,
+    cacheKey,
+    configRef: params.config,
+    load: () =>
+      allAgents
+        ? loadAllAgentCostUsageSummary({
+            startMs: params.startMs,
+            endMs: params.endMs,
+            dayBucket: params.dayBucket,
+            config: params.config,
+          })
+        : loadCostUsageSummaryFromCache({
+            startMs: params.startMs,
+            endMs: params.endMs,
+            dayBucket: params.dayBucket,
+            config: params.config,
+            agentId: expectDefined(agentId, "non-aggregate usage agent id"),
+            requestRefresh: true,
+            refreshMode: "background",
+          }),
+  });
+}
+
+async function loadAllAgentCostUsageSummary(params: {
+  startMs: number;
+  endMs: number;
+  dayBucket?: UsageDailyBucket;
+  config: OpenClawConfig;
+}): Promise<CostUsageSummary> {
+  // Same agent universe as discoverAllSessionsForUsage: enumerating configured
+  // ids only would list system-agent sessions whose cost never reaches totals.
+  const agentIds = listGatewayAgentsBasic(params.config).agents.map((agent) =>
+    normalizeAgentId(agent.id),
+  );
+  const summaries = await runUsageAgentTasks(
+    agentIds.map(
+      (agentId) => () =>
+        loadCostUsageSummaryFromCache({
+          startMs: params.startMs,
+          endMs: params.endMs,
+          dayBucket: params.dayBucket,
+          config: params.config,
+          agentId,
+          requestRefresh: true,
+          refreshMode: "background",
+        }),
+    ),
+  );
+  const dailyByDate = new Map<string, CostUsageTotals & { date: string }>();
+  const totals = createEmptyCostUsageTotals();
+  let cacheStatus: UsageCacheStatus | undefined;
+  let updatedAt = 0;
+  let days = 0;
+  for (const summary of summaries) {
+    updatedAt = Math.max(updatedAt, summary.updatedAt);
+    days = Math.max(days, summary.days);
+    addCostUsageTotals(totals, summary.totals);
+    if (summary.cacheStatus) {
+      cacheStatus = mergeUsageCacheStatus(cacheStatus, summary.cacheStatus);
+    }
+    for (const day of summary.daily) {
+      const entry = dailyByDate.get(day.date) ?? {
+        date: day.date,
+        ...createEmptyCostUsageTotals(),
+      };
+      addCostUsageTotals(entry, day);
+      dailyByDate.set(day.date, entry);
+    }
+  }
+  return {
+    updatedAt,
+    days,
+    daily: Array.from(dailyByDate.values()).toSorted((a, b) => a.date.localeCompare(b.date)),
+    totals,
+    ...(cacheStatus ? { cacheStatus } : {}),
+  };
+}

--- a/src/gateway/server-methods/usage-session-loading.ts
+++ b/src/gateway/server-methods/usage-session-loading.ts
@@ -14,9 +14,15 @@ import {
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { runTasksWithConcurrency } from "../../utils/run-with-concurrency.js";
 import { listGatewayAgentsBasic } from "../agent-list.js";
-import type { UsageSessionSelection } from "./usage-session-selection.js";
 
 type DiscoveredSessionWithAgent = DiscoveredSession & { agentId: string };
+
+export type UsageSessionSummaryTarget = {
+  agentId: string;
+  sessionId: string;
+  sessionFile: string;
+  instances: Array<Pick<DiscoveredSession, "sessionId" | "sessionFile">>;
+};
 
 const USAGE_AGENT_LOAD_CONCURRENCY = 12;
 
@@ -82,7 +88,7 @@ export function mergeUsageCacheStatus(
 }
 
 export async function loadUsageSessionSummaries(params: {
-  entries: UsageSessionSelection[];
+  entries: UsageSessionSummaryTarget[];
   config: OpenClawConfig;
   startMs: number;
   endMs: number;

--- a/src/gateway/server-methods/usage-session-loading.ts
+++ b/src/gateway/server-methods/usage-session-loading.ts
@@ -1,0 +1,158 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { mergeSessionCostSummaryInto } from "../../infra/session-cost-usage-rollup.js";
+import { createEmptyCostUsageTotals } from "../../infra/session-cost-usage-totals.js";
+import {
+  discoverAllSessions,
+  loadSessionCostSummariesFromCache,
+  type DiscoveredSession,
+  type SessionCostSummary,
+  type UsageDailyBucket,
+  type UsageCacheStatus,
+} from "../../infra/session-cost-usage.js";
+import { normalizeAgentId } from "../../routing/session-key.js";
+import { runTasksWithConcurrency } from "../../utils/run-with-concurrency.js";
+import { listGatewayAgentsBasic } from "../agent-list.js";
+import type { UsageSessionSelection } from "./usage-session-selection.js";
+
+type DiscoveredSessionWithAgent = DiscoveredSession & { agentId: string };
+
+const USAGE_AGENT_LOAD_CONCURRENCY = 12;
+
+export async function runUsageAgentTasks<T>(tasks: Array<() => Promise<T>>): Promise<T[]> {
+  const result = await runTasksWithConcurrency({
+    tasks,
+    limit: USAGE_AGENT_LOAD_CONCURRENCY,
+    errorMode: "stop",
+  });
+  // These fan-outs historically rejected as one unit. Never return partial
+  // per-agent usage; successful results retain their input order.
+  if (result.hasError) {
+    throw result.firstError;
+  }
+  return result.results;
+}
+
+export async function discoverAllSessionsForUsage(params: {
+  config: OpenClawConfig;
+  agentId?: string;
+  startMs: number;
+  endMs: number;
+}): Promise<DiscoveredSessionWithAgent[]> {
+  const requestedAgentId = normalizeOptionalString(params.agentId);
+  const agents = requestedAgentId
+    ? [{ id: normalizeAgentId(requestedAgentId) }]
+    : listGatewayAgentsBasic(params.config).agents;
+  const discovered = await runUsageAgentTasks(
+    agents.map((agent) => async () => {
+      const agentId = normalizeAgentId(agent.id);
+      const sessions = await discoverAllSessions({
+        agentId,
+        startMs: params.startMs,
+        endMs: params.endMs,
+        includeFirstUserMessage: false,
+      });
+      return sessions.map((session) => Object.assign({}, session, { agentId }));
+    }),
+  );
+  return discovered.flat().toSorted((a, b) => b.mtime - a.mtime);
+}
+
+export function mergeUsageCacheStatus(
+  target: UsageCacheStatus | undefined,
+  source: UsageCacheStatus,
+): UsageCacheStatus {
+  if (!target) {
+    return { ...source };
+  }
+  const statusRank = { fresh: 0, partial: 1, stale: 2, refreshing: 3 } as const;
+  return {
+    status: statusRank[source.status] > statusRank[target.status] ? source.status : target.status,
+    cachedFiles: target.cachedFiles + source.cachedFiles,
+    pendingFiles: target.pendingFiles + source.pendingFiles,
+    staleFiles: target.staleFiles + source.staleFiles,
+    refreshedAt:
+      target.refreshedAt === undefined
+        ? source.refreshedAt
+        : source.refreshedAt === undefined
+          ? target.refreshedAt
+          : Math.max(target.refreshedAt, source.refreshedAt),
+  };
+}
+
+export async function loadUsageSessionSummaries(params: {
+  entries: UsageSessionSelection[];
+  config: OpenClawConfig;
+  startMs: number;
+  endMs: number;
+  includeUntimestamped?: boolean;
+  dayBucket?: UsageDailyBucket;
+}) {
+  const {
+    entries: mergedEntries,
+    config,
+    startMs,
+    endMs,
+    includeUntimestamped,
+    dayBucket,
+  } = params;
+  let cacheStatus: UsageCacheStatus | undefined;
+  const usageByEntryIndex: Array<SessionCostSummary | null> = Array.from(
+    { length: mergedEntries.length },
+    () => null,
+  );
+
+  // Batch all included instances by agent so cache reads do not scale with the row limit.
+  const sessionsByAgent = new Map<
+    string,
+    Array<{ entryIndex: number; sessionId: string; sessionFile: string }>
+  >();
+  for (const [entryIndex, merged] of mergedEntries.entries()) {
+    for (const { sessionId, sessionFile } of merged.instances) {
+      const agentSessions = sessionsByAgent.get(merged.agentId) ?? [];
+      agentSessions.push({
+        entryIndex,
+        sessionId,
+        sessionFile,
+      });
+      sessionsByAgent.set(merged.agentId, agentSessions);
+    }
+  }
+
+  const agentLoads = await runUsageAgentTasks(
+    Array.from(sessionsByAgent.entries()).map(([agentId, agentSessions]) => async () => ({
+      agentSessions,
+      loaded: await loadSessionCostSummariesFromCache({
+        sessions: agentSessions,
+        config,
+        agentId,
+        startMs,
+        endMs,
+        includeUntimestamped,
+        dayBucket,
+      }),
+    })),
+  );
+  for (const { agentSessions, loaded } of agentLoads) {
+    cacheStatus = mergeUsageCacheStatus(cacheStatus, loaded.cacheStatus);
+    for (const [index, summary] of loaded.summaries.entries()) {
+      if (!summary) {
+        continue;
+      }
+      const session = expectDefined(agentSessions[index], "agent sessions entry at index");
+      const merged = expectDefined(
+        mergedEntries[session.entryIndex],
+        "merged entries entry at session.entry index",
+      );
+      const usage: SessionCostSummary =
+        usageByEntryIndex[session.entryIndex] ?? createEmptyCostUsageTotals();
+      usage.sessionId = merged.sessionId;
+      usage.sessionFile = merged.sessionFile;
+      mergeSessionCostSummaryInto(usage, summary);
+      usageByEntryIndex[session.entryIndex] = usage;
+    }
+  }
+
+  return { summaries: usageByEntryIndex, cacheStatus };
+}

--- a/src/gateway/server-methods/usage-session-selection.ts
+++ b/src/gateway/server-methods/usage-session-selection.ts
@@ -17,7 +17,10 @@ import {
   loadCombinedSessionStoreForGatewayCore,
   loadGatewaySessionEntryReadOnly,
 } from "../session-utils.js";
-import { discoverAllSessionsForUsage } from "./usage-session-loading.js";
+import {
+  discoverAllSessionsForUsage,
+  type UsageSessionSummaryTarget,
+} from "./usage-session-loading.js";
 
 export class UsageSessionInvalidRequestError extends Error {}
 
@@ -66,12 +69,8 @@ export function resolveSessionUsageTarget(
 
 export type UsageGroupingMode = "instance" | "family";
 
-export type UsageSessionSelection = {
+export type UsageSessionSelection = UsageSessionSummaryTarget & {
   key: string;
-  agentId: string;
-  sessionId: string;
-  sessionFile: string;
-  instances: Array<{ sessionId: string; sessionFile: string }>;
   label?: string;
   updatedAt: number;
   storeEntry?: SessionEntry;

--- a/src/gateway/server-methods/usage-session-selection.ts
+++ b/src/gateway/server-methods/usage-session-selection.ts
@@ -1,0 +1,385 @@
+import fs from "node:fs";
+import { expectDefined } from "@openclaw/normalization-core";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { parseSqliteSessionFileMarker } from "../../config/sessions/legacy-sqlite-marker.js";
+import {
+  resolveSessionFilePathCore,
+  resolveSessionFilePathOptions,
+} from "../../config/sessions/paths.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveExistingUsageSessionFile } from "../../infra/session-cost-usage.js";
+import { parseAgentSessionKey } from "../../routing/session-key.js";
+import { resolvePreferredSessionKeyForSessionIdMatches } from "../../sessions/session-id-resolution.js";
+import { resolveStoredSessionKeyForAgentStore } from "../session-store-key.js";
+import {
+  loadCombinedSessionStoreForGatewayCore,
+  loadGatewaySessionEntryReadOnly,
+} from "../session-utils.js";
+import { discoverAllSessionsForUsage } from "./usage-session-loading.js";
+
+export class UsageSessionInvalidRequestError extends Error {}
+
+type ResolvedSessionUsageTarget = {
+  entry: SessionEntry | undefined;
+  agentId: string;
+  sessionId: string;
+  sessionFile: string;
+};
+
+export function resolveSessionUsageTarget(
+  key: string,
+  config: OpenClawConfig,
+  agentIdHint?: string,
+): ResolvedSessionUsageTarget | undefined {
+  const { canonicalKey, entry, storePath } = loadGatewaySessionEntryReadOnly(
+    key,
+    agentIdHint ? { agentId: agentIdHint } : undefined,
+  );
+  const parsed = parseAgentSessionKey(key);
+  const agentId =
+    parsed?.agentId ?? agentIdHint ?? resolveSessionAgentId({ config, sessionKey: key });
+  const sessionId = entry?.sessionId ?? parsed?.rest ?? key;
+  const sessionFile = entry
+    ? resolveExistingUsageSessionFile({
+        agentId,
+        sessionId,
+        sessionTarget: {
+          agentId,
+          sessionId,
+          sessionKey: canonicalKey,
+          storePath,
+        },
+      })
+    : resolveExistingUsageSessionFile({
+        agentId,
+        sessionId,
+        sessionFile: resolveSessionFilePathCore(
+          sessionId,
+          undefined,
+          resolveSessionFilePathOptions({ storePath, agentId }),
+        ),
+      });
+  return sessionFile ? { entry, agentId, sessionId, sessionFile } : undefined;
+}
+
+export type UsageGroupingMode = "instance" | "family";
+
+export type UsageSessionSelection = {
+  key: string;
+  agentId: string;
+  sessionId: string;
+  sessionFile: string;
+  instances: Array<{ sessionId: string; sessionFile: string }>;
+  label?: string;
+  updatedAt: number;
+  storeEntry?: SessionEntry;
+  scope?: "instance" | "family";
+  sessionFamilyKey?: string;
+  currentSessionId?: string;
+  includedSessionIds?: string[];
+};
+
+function usageSessionIdentity(agentId: string, sessionId: string): string {
+  return `${agentId}\0${sessionId}`;
+}
+
+type StoredUsageSession = { key: string; entry: SessionEntry };
+
+function buildStoreBySessionIdentity(
+  store: Record<string, SessionEntry>,
+  agentIdBySessionKey: ReadonlyMap<string, string>,
+) {
+  const matchesByIdentity = new Map<string, Array<[string, SessionEntry]>>();
+  for (const [key, entry] of Object.entries(store)) {
+    if (!entry?.sessionId) {
+      continue;
+    }
+    const agentId = expectDefined(agentIdBySessionKey.get(key), "stored session owner");
+    const identity = usageSessionIdentity(agentId, entry.sessionId);
+    const matches = matchesByIdentity.get(identity) ?? [];
+    matches.push([key, entry]);
+    matchesByIdentity.set(identity, matches);
+  }
+
+  const storeByIdentity = new Map<string, StoredUsageSession>();
+  for (const [identity, matches] of matchesByIdentity) {
+    // Aliases within one agent share a transcript; another agent's identical id does not.
+    const sessionId = expectDefined(matches[0], "stored session match")[1].sessionId;
+    const preferredKey = resolvePreferredSessionKeyForSessionIdMatches(matches, sessionId);
+    if (!preferredKey) {
+      continue;
+    }
+    const preferredEntry = store[preferredKey];
+    if (preferredEntry) {
+      storeByIdentity.set(identity, { key: preferredKey, entry: preferredEntry });
+    }
+  }
+  const familyMatches = new Map<
+    string,
+    { sessionId: string; matches: Array<[string, SessionEntry]> }
+  >();
+  for (const { key, entry } of storeByIdentity.values()) {
+    const agentId = expectDefined(agentIdBySessionKey.get(key), "stored session owner");
+    for (const sessionId of entry.usageFamilySessionIds ?? []) {
+      const identity = usageSessionIdentity(agentId, sessionId);
+      if (!storeByIdentity.has(identity)) {
+        const candidates = familyMatches.get(identity) ?? { sessionId, matches: [] };
+        candidates.matches.push([key, entry]);
+        familyMatches.set(identity, candidates);
+      }
+    }
+  }
+  // Direct current owners beat recorded history (for example cron continuation
+  // aliases). Ambiguous history stays an instance rather than being counted twice.
+  const familyOwners = new Map(storeByIdentity);
+  for (const [identity, { sessionId, matches }] of familyMatches) {
+    const key = resolvePreferredSessionKeyForSessionIdMatches(matches, sessionId);
+    if (key) {
+      familyOwners.set(identity, { key, entry: expectDefined(store[key], "family owner") });
+    }
+  }
+  return { storeByIdentity, familyOwners };
+}
+
+function withUsageGrouping(
+  base: Omit<UsageSessionSelection, "instances">,
+  groupingMode: UsageGroupingMode,
+  familyOwners: ReadonlyMap<string, StoredUsageSession>,
+  discoveredByIdentity: ReadonlyMap<string, { sessionId: string; sessionFile: string }>,
+): UsageSessionSelection {
+  const currentInstance = { sessionId: base.sessionId, sessionFile: base.sessionFile };
+  if (groupingMode !== "family") {
+    return { ...base, instances: [currentInstance] };
+  }
+  // Historical ids belong to this agent; identical ids owned by other agents stay separate.
+  const includedSessionIds = [
+    ...new Set(
+      [base.sessionId, ...(base.storeEntry?.usageFamilySessionIds ?? [])]
+        .map(normalizeOptionalString)
+        .filter((id): id is string => Boolean(id)),
+    ),
+  ].filter(
+    (id) =>
+      id === base.sessionId ||
+      familyOwners.get(usageSessionIdentity(base.agentId, id))?.entry.sessionId === base.sessionId,
+  );
+  return {
+    ...base,
+    // Discovery owns SQLite/archive precedence; loading must not guess storage
+    // from the current instance, because one family can span both sources.
+    instances: includedSessionIds.flatMap((id) => {
+      const instance =
+        id === base.sessionId
+          ? currentInstance
+          : discoveredByIdentity.get(usageSessionIdentity(base.agentId, id));
+      return instance ? [instance] : [];
+    }),
+    scope: "family",
+    sessionFamilyKey: base.storeEntry?.usageFamilyKey ?? base.key,
+    currentSessionId: base.sessionId,
+    includedSessionIds,
+  };
+}
+
+export async function selectUsageSessions(params: {
+  config: OpenClawConfig;
+  agentId?: string;
+  specificKey: string | null;
+  groupingMode: UsageGroupingMode;
+  startMs: number;
+  endMs: number;
+  visibilityFilter?: (key: string, entry: SessionEntry) => boolean;
+}): Promise<UsageSessionSelection[]> {
+  const {
+    config,
+    agentId: effectiveAgentId,
+    specificKey,
+    groupingMode,
+    startMs,
+    endMs,
+    visibilityFilter,
+  } = params;
+  // Load session store for named sessions only on a result-cache miss.
+  const sessionStoreOpts = effectiveAgentId ? { agentId: effectiveAgentId } : {};
+  const { store, agentIdBySessionKey } = loadCombinedSessionStoreForGatewayCore(
+    config,
+    sessionStoreOpts,
+  );
+  const scopedStore = Object.fromEntries(
+    Object.entries(store).filter(
+      ([key, entry]) =>
+        (!effectiveAgentId || agentIdBySessionKey.get(key) === effectiveAgentId) &&
+        (!visibilityFilter || visibilityFilter(key, entry)),
+    ),
+  );
+  const { storeByIdentity: storeBySessionIdentity, familyOwners } = buildStoreBySessionIdentity(
+    scopedStore,
+    agentIdBySessionKey,
+  );
+  // Only an individual instance can skip discovery. Families need the actual
+  // historical sources, including retained JSONL artifacts beside SQLite windows.
+  const discoveredSessions =
+    !specificKey || groupingMode === "family"
+      ? await discoverAllSessionsForUsage({
+          config,
+          ...(effectiveAgentId ? { agentId: effectiveAgentId } : {}),
+          startMs,
+          endMs,
+        })
+      : [];
+  const discoveredByIdentity = new Map(
+    discoveredSessions.map((session) => [
+      usageSessionIdentity(session.agentId, session.sessionId),
+      session,
+    ]),
+  );
+  const now = Date.now();
+
+  const mergedEntries: UsageSessionSelection[] = [];
+
+  if (specificKey) {
+    const scopedSpecificKey = resolveStoredSessionKeyForAgentStore({
+      cfg: config,
+      agentId: expectDefined(effectiveAgentId, "specific session owner"),
+      sessionKey: specificKey,
+    });
+    const scopedParsed = parseAgentSessionKey(scopedSpecificKey);
+    const agentIdFromKey =
+      scopedParsed?.agentId ?? expectDefined(effectiveAgentId, "specific session owner");
+    const keyRest = scopedParsed?.rest ?? specificKey;
+
+    // Prefer the store entry when available, even if the caller provides a discovered key
+    // (`agent:<id>:<sessionId>`) for a session that now has a canonical store key.
+    const storeMatch = scopedStore[scopedSpecificKey]
+      ? { key: scopedSpecificKey, entry: scopedStore[scopedSpecificKey] }
+      : scopedStore[specificKey]
+        ? { key: specificKey, entry: scopedStore[specificKey] }
+        : null;
+    const storeByIdMatch =
+      storeBySessionIdentity.get(usageSessionIdentity(agentIdFromKey, keyRest)) ??
+      (keyRest !== specificKey
+        ? storeBySessionIdentity.get(usageSessionIdentity(agentIdFromKey, specificKey))
+        : undefined) ??
+      null;
+    const resolvedStoreKey = storeMatch?.key ?? storeByIdMatch?.key ?? scopedSpecificKey;
+    const storeEntry = storeMatch?.entry ?? storeByIdMatch?.entry;
+    if (visibilityFilter && !storeEntry) {
+      throw new UsageSessionInvalidRequestError(`Invalid session reference: ${specificKey}`);
+    }
+    const sessionId = storeEntry?.sessionId ?? keyRest;
+
+    // Stored sessions are canonical SQLite targets. JSONL discovery remains only for
+    // sessions without a store row, so retired locators cannot redirect live state.
+    let resolved: ResolvedSessionUsageTarget | undefined;
+    try {
+      resolved = resolveSessionUsageTarget(resolvedStoreKey, config, agentIdFromKey);
+      if (!resolved || resolved.agentId !== agentIdFromKey || resolved.sessionId !== sessionId) {
+        throw new Error("session target mismatch");
+      }
+    } catch {
+      throw new UsageSessionInvalidRequestError(`Invalid session reference: ${specificKey}`);
+    }
+    const { sessionFile } = resolved;
+
+    let updatedAt: number | undefined;
+    if (parseSqliteSessionFileMarker(sessionFile)) {
+      updatedAt = storeEntry?.updatedAt ?? now;
+    } else {
+      try {
+        const stats = fs.statSync(sessionFile);
+        if (stats.isFile()) {
+          updatedAt = storeEntry?.updatedAt ?? stats.mtimeMs;
+        }
+      } catch {
+        // File doesn't exist - no results for this key
+      }
+    }
+    if (updatedAt !== undefined) {
+      mergedEntries.push(
+        withUsageGrouping(
+          {
+            key: resolvedStoreKey,
+            agentId: agentIdFromKey,
+            sessionId,
+            sessionFile,
+            label: storeEntry?.label,
+            updatedAt,
+            storeEntry,
+          },
+          groupingMode,
+          familyOwners,
+          discoveredByIdentity,
+        ),
+      );
+    }
+  } else {
+    const selectedFamilies = new Set<string>();
+    for (const discovered of discoveredSessions) {
+      const identity = usageSessionIdentity(discovered.agentId, discovered.sessionId);
+      const owner = (groupingMode === "family" ? familyOwners : storeBySessionIdentity).get(
+        identity,
+      );
+      if (!owner) {
+        if (!visibilityFilter) {
+          mergedEntries.push({
+            key: `agent:${discovered.agentId}:${discovered.sessionId}`,
+            agentId: discovered.agentId,
+            sessionId: discovered.sessionId,
+            sessionFile: discovered.sessionFile,
+            instances: [discovered],
+            updatedAt: discovered.mtime,
+            scope: "instance",
+          });
+        }
+        continue;
+      }
+      const { key, entry } = owner;
+      const familyIdentity = usageSessionIdentity(discovered.agentId, key);
+      if (selectedFamilies.has(familyIdentity)) {
+        continue;
+      }
+      // Rotation can leave the current window empty. A discovered historical
+      // member still selects its recorded owner, once per canonical family row.
+      let sessionFile = discoveredByIdentity.get(
+        usageSessionIdentity(discovered.agentId, entry.sessionId),
+      )?.sessionFile;
+      if (!sessionFile) {
+        const target = resolveSessionUsageTarget(key, config, discovered.agentId);
+        if (
+          !target ||
+          target.agentId !== discovered.agentId ||
+          target.sessionId !== entry.sessionId
+        ) {
+          throw new UsageSessionInvalidRequestError(`Invalid session reference: ${key}`);
+        }
+        sessionFile = target.sessionFile;
+      }
+      mergedEntries.push(
+        withUsageGrouping(
+          {
+            key,
+            agentId: discovered.agentId,
+            sessionId: entry.sessionId,
+            sessionFile,
+            label: entry.label,
+            updatedAt: entry.updatedAt ?? discovered.mtime,
+            storeEntry: entry,
+          },
+          groupingMode,
+          familyOwners,
+          discoveredByIdentity,
+        ),
+      );
+      if (groupingMode === "family") {
+        selectedFamilies.add(familyIdentity);
+      }
+    }
+  }
+
+  // Sort by most recent first
+  mergedEntries.sort((a, b) => b.updatedAt - a.updatedAt);
+
+  return mergedEntries;
+}

--- a/src/gateway/server-methods/usage.cost-usage-cache.test.ts
+++ b/src/gateway/server-methods/usage.cost-usage-cache.test.ts
@@ -1,23 +1,3 @@
-// Regression: costUsageCache (usage.ts:65) has no production delete/prune/evict
-// path. The TTL at L310 is read-only — on a miss after expiry, set() overwrites
-// the same key but never removes stale keys. resolveDateRange derives cacheKey
-// from the current calendar day so cacheKey rolls at every UTC 00:00, and additional
-// axes (days, startDate, endDate, utcOffset) multiply cardinality.
-//
-// The same file has three sibling caches that implement MAX + FIFO eviction
-// (resolvedSessionKeyByRunId, TRANSCRIPT_SESSION_KEY_CACHE,
-// sessionTitleFieldsCache); costUsageCache alone lacked the pattern.
-//
-// Production trigger: MenuSessionsInjector polls usage.cost every ~45s with
-// no params, exercising parseDateRange's default branch on every UTC day
-// rollover. The Control UI adds more key variance via explicit startDate /
-// endDate / utcTimeZone combinations.
-//
-// CAL-003 compliance: no mock of internal branches. Growth is driven through
-// the testApi.loadCostUsageSummaryCached seam (same entry point usage.test.ts
-// already exercises) with distinct (startMs, endMs) pairs. Only the external
-// loadCostUsageSummaryFromCache dependency is stubbed.
-
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 

--- a/src/gateway/server-methods/usage.sessions-usage-owner-attribution.integration.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage-owner-attribution.integration.test.ts
@@ -1,12 +1,17 @@
+import fs from "node:fs/promises";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { expect, it, vi } from "vitest";
+import { SessionManager } from "../../agents/sessions/session-manager.js";
 import { getRuntimeConfig } from "../../config/config.js";
 import { loadCombinedSessionStoreForGatewayCore } from "../../config/sessions/combined-store-gateway.js";
 import {
+  listSessionTranscriptInstances,
   persistSessionTranscriptTurn,
   upsertSessionEntryCore,
 } from "../../config/sessions/session-accessor.js";
+import { discoverAllSessions, loadSessionCostSummary } from "../../infra/session-cost-usage.js";
+import type { AssistantMessage } from "../../llm/types.js";
 import type { SessionsUsageResult } from "../../shared/usage-types.js";
 import { createOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { usageHandlers } from "./usage.js";
@@ -75,6 +80,205 @@ it.each([undefined, "agent:opus:slack:dm", "global"])(
           { key: opusKey ?? `agent:opus:${sessionId}`, agentId: "opus" },
         ]),
       );
+    } finally {
+      await state.cleanup();
+    }
+  },
+);
+
+it.each([
+  { name: "SQLite history", artifact: false, directOwner: false, currentArtifact: false },
+  {
+    name: "a direct owner for a historical instance",
+    artifact: false,
+    directOwner: true,
+    currentArtifact: false,
+  },
+  {
+    name: "mixed JSONL and SQLite history",
+    artifact: true,
+    directOwner: false,
+    currentArtifact: false,
+  },
+  {
+    name: "current JSONL discovered after SQLite history",
+    artifact: false,
+    directOwner: false,
+    currentArtifact: true,
+  },
+])(
+  "keeps family usage with $name before the current SQLite transcript exists",
+  async ({ artifact, directOwner, currentArtifact }) => {
+    const state = await createOpenClawTestState({ label: "usage-empty-current-family" });
+    try {
+      await state.writeConfig({
+        agents: { ownership: "explicit", entries: { main: {}, opus: {} } },
+        plugins: { enabled: false },
+      });
+      const config = getRuntimeConfig();
+      const mainKey = "agent:main:chat";
+      const opusKey = "agent:opus:chat";
+      const directKey = "agent:main:chat:run:retained";
+      const archiveManager = SessionManager.inMemory(state.workspaceDir);
+      const firstId = artifact ? archiveManager.getSessionId() : "family-first";
+      const secondId = "family-second";
+      const currentId = currentArtifact ? archiveManager.getSessionId() : "family-current";
+      const timestamp = Date.now();
+      const scopeFor = (agentId: string, sessionKey: string) => ({
+        agentId,
+        sessionKey,
+        storePath: path.join(state.sessionsDir(agentId), "sessions.json"),
+      });
+      const mainScope = scopeFor("main", mainKey);
+      const opusScope = scopeFor("opus", opusKey);
+      const usageMessage = (tokens: number): AssistantMessage => ({
+        role: "assistant",
+        content: [{ type: "text", text: "Recorded usage" }],
+        api: "openai-responses",
+        provider: "fixture",
+        model: "usage-model",
+        stopReason: "stop",
+        timestamp,
+        usage: {
+          input: tokens,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: tokens,
+          cost: { input: 0.01, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.01 },
+        },
+      });
+      const writeArtifact = async (tokens: number) => {
+        archiveManager.appendMessage(usageMessage(tokens));
+        return await state.writeText(
+          path.join(
+            "agents",
+            "main",
+            "sessions",
+            `${archiveManager.getSessionId()}.jsonl.reset.2026-08-01T00-00-00.000Z`,
+          ),
+          [archiveManager.getHeader(), ...archiveManager.getEntries()]
+            .map((entry) => JSON.stringify(entry))
+            .join("\n"),
+        );
+      };
+      for (const [scope, sessionId, tokens] of [
+        [mainScope, firstId, 10],
+        [mainScope, secondId, 20],
+        [opusScope, firstId, 100],
+      ] as const) {
+        await upsertSessionEntryCore(scope, {
+          sessionId,
+          label: `${scope.agentId} chat`,
+          updatedAt: timestamp,
+        });
+        if (artifact && scope.agentId === "main" && sessionId === firstId) {
+          await writeArtifact(tokens);
+          continue;
+        }
+        await persistSessionTranscriptTurn(
+          { ...scope, sessionId },
+          {
+            cwd: state.workspaceDir,
+            updateMode: "none",
+            messages: [{ message: usageMessage(tokens), now: timestamp }],
+          },
+        );
+      }
+      const current = await upsertSessionEntryCore(mainScope, {
+        sessionId: currentId,
+        updatedAt: timestamp + 1,
+      });
+      if (currentArtifact) {
+        const artifactPath = await writeArtifact(40);
+        const older = new Date(timestamp - 60_000);
+        await fs.utimes(artifactPath, older, older);
+      }
+      if (directOwner) {
+        // Exact-run continuation nodes retain an instance while their logical root rotates.
+        await upsertSessionEntryCore(scopeFor("main", directKey), {
+          sessionId: firstId,
+          label: "retained run",
+          updatedAt: timestamp,
+        });
+      }
+      expect(current?.usageFamilySessionIds).toEqual([firstId, secondId, currentId]);
+      expect(
+        listSessionTranscriptInstances(mainScope)
+          .map(({ sessionId }) => sessionId)
+          .toSorted(),
+      ).toEqual((artifact ? [secondId] : [firstId, secondId]).toSorted());
+
+      // Warm the real rollups so the handler assertion tests selection, not refresh timing.
+      for (const agentId of ["main", "opus"]) {
+        const discovered = await discoverAllSessions({
+          agentId,
+          includeFirstUserMessage: false,
+        });
+        if (currentArtifact && agentId === "main") {
+          expect(discovered[0]?.sessionId).not.toBe(currentId);
+        }
+        for (const { sessionId, sessionFile } of discovered) {
+          await loadSessionCostSummary({ agentId, sessionId, sessionFile, config });
+        }
+      }
+      await loadSessionCostSummary({
+        agentId: mainScope.agentId,
+        sessionId: currentId,
+        sessionTarget: { ...mainScope, sessionId: currentId },
+        config,
+      });
+
+      for (const specificKey of [undefined, mainKey]) {
+        const respond = vi.fn();
+        await expectDefined(
+          usageHandlers["sessions.usage"],
+          "usage handler",
+        )({
+          params: {
+            ...(specificKey ? { key: specificKey } : { agentScope: "all" }),
+            range: "all",
+            groupBy: "family",
+            limit: 50,
+          },
+          context: { getRuntimeConfig: () => config },
+          respond,
+        } as unknown as Parameters<(typeof usageHandlers)["sessions.usage"]>[0]);
+        expect(respond).toHaveBeenCalledOnce();
+        const [ok, payload] = expectDefined(respond.mock.calls[0], "usage response");
+        expect(ok).toBe(true);
+        const result = payload as SessionsUsageResult;
+        // Explicit keys use the canonical stored target; only list discovery reads current JSONL.
+        const mainTokens = currentArtifact && !specificKey ? 70 : directOwner ? 20 : 30;
+        expect(result.sessions).toHaveLength(specificKey ? 1 : directOwner ? 3 : 2);
+        expect(result.sessions.find(({ key }) => key === mainKey)).toMatchObject({
+          key: mainKey,
+          agentId: "main",
+          label: "main chat",
+          sessionId: currentId,
+          scope: "family",
+          includedSessionIds: directOwner ? [currentId, secondId] : [currentId, firstId, secondId],
+          usage: expect.objectContaining({ totalTokens: mainTokens }),
+        });
+        if (!specificKey) {
+          expect(result.sessions.find(({ key }) => key === opusKey)).toMatchObject({
+            key: opusKey,
+            agentId: "opus",
+            sessionId: firstId,
+            usage: expect.objectContaining({ totalTokens: 100 }),
+          });
+          if (directOwner) {
+            expect(result.sessions.find(({ key }) => key === directKey)).toMatchObject({
+              agentId: "main",
+              sessionId: firstId,
+              usage: expect.objectContaining({ totalTokens: 10 }),
+            });
+          }
+        }
+        expect(result.totals.totalTokens).toBe(
+          specificKey ? mainTokens : currentArtifact ? 170 : 130,
+        );
+      }
     } finally {
       await state.cleanup();
     }

--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -725,8 +725,11 @@ describe("sessions.usage", () => {
 
     await withUsageState(async (writeSessionFile) => {
       writeSessionFile("current.jsonl");
-      writeSessionFile("old.jsonl.reset.2026-02-01T00-00-00.000Z");
+      const oldSessionFile = writeSessionFile("old.jsonl.reset.2026-02-01T00-00-00.000Z");
       mockStoredSession(storeKey, "current");
+      vi.mocked(discoverAllSessions).mockResolvedValueOnce([
+        { sessionId: "old", sessionFile: oldSessionFile, mtime: 1_000 },
+      ]);
 
       vi.mocked(loadCombinedSessionStoreForGatewayCore).mockReturnValue({
         agentIdBySessionKey: new Map([[storeKey, "opus"]]),

--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -724,7 +724,6 @@ describe("sessions.usage", () => {
     const storeKey = "agent:opus:main";
 
     await withUsageState(async (writeSessionFile) => {
-      writeSessionFile("current.jsonl");
       const oldSessionFile = writeSessionFile("old.jsonl.reset.2026-02-01T00-00-00.000Z");
       mockStoredSession(storeKey, "current");
       vi.mocked(discoverAllSessions).mockResolvedValueOnce([
@@ -738,7 +737,6 @@ describe("sessions.usage", () => {
         store: {
           [storeKey]: {
             sessionId: "current",
-            sessionFile: "current.jsonl",
             updatedAt: 1_000,
             usageFamilyKey: storeKey,
             usageFamilySessionIds: ["old", "current"],

--- a/src/gateway/server-methods/usage.test.ts
+++ b/src/gateway/server-methods/usage.test.ts
@@ -509,6 +509,22 @@ describe("gateway usage helpers", () => {
     });
   });
 
+  it("refreshes aggregate cost usage when the configured agent set changes", async () => {
+    const request = { startDate: "2026-02-01", endDate: "2026-02-02", agentScope: "all" };
+    const respond = vi.fn();
+    for (const entries of [{ main: {} }, { main: {}, research: {} }]) {
+      await expectDefined(
+        usageHandlers["usage.cost"],
+        "cost handler",
+      )({
+        respond,
+        params: request,
+        context: { getRuntimeConfig: () => ({ agents: { entries } }) },
+      } as unknown as Parameters<(typeof usageHandlers)["usage.cost"]>[0]);
+    }
+    expect(respond.mock.calls.map((call) => call[1].totals.totalTokens)).toEqual([1, 2]);
+  });
+
   it("keeps cost usage cache entries scoped by the complete day bucket", async () => {
     const config = {} as OpenClawConfig;
 

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -1,7 +1,4 @@
-// Usage gateway methods aggregate provider and session cost/token metrics from
-// caches, logs, session stores, and discovered transcript files.
-import fs from "node:fs";
-import { expectDefined } from "@openclaw/normalization-core";
+// Gateway usage methods validate requests and assemble owner-scoped usage reports.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   GATEWAY_CLIENT_CAPS,
@@ -12,50 +9,10 @@ import {
   errorShape,
   validateSessionsUsageParams,
 } from "../../../packages/gateway-protocol/src/index.js";
-import { resolveSessionAgentId } from "../../agents/agent-scope.js";
-import { parseSqliteSessionFileMarker } from "../../config/sessions/legacy-sqlite-marker.js";
-import {
-  resolveSessionFilePathCore,
-  resolveSessionFilePathOptions,
-} from "../../config/sessions/paths.js";
-import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import {
-  createTimeZoneDayKeyFormatter,
-  resolveTimezone,
-  resolveTimeZoneDayStartMs,
-} from "../../infra/format-time/format-datetime.js";
-import { mergeSessionCostSummaryInto } from "../../infra/session-cost-usage-rollup.js";
-import {
-  addCostUsageTotals,
-  createEmptyCostUsageTotals,
-} from "../../infra/session-cost-usage-totals.js";
-import {
-  type CostUsageSummary,
-  type CostUsageTotals,
-  type SessionCostSummary,
-  type SessionDailyModelUsage,
-  type SessionMessageCounts,
-  type SessionModelUsage,
-  loadCostUsageSummaryFromCache,
-  loadSessionLogs,
-  loadSessionCostSummariesFromCache,
-  loadSessionUsageTimeSeries,
-  discoverAllSessions,
-  resolveExistingUsageSessionFile,
-  type DiscoveredSession,
-  type UsageDailyBucket,
-  type UsageCacheStatus,
-} from "../../infra/session-cost-usage.js";
-import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
-import { resolvePreferredSessionKeyForSessionIdMatches } from "../../sessions/session-id-resolution.js";
-import {
-  buildUsageAggregateTail,
-  mergeUsageDailyLatency,
-  mergeUsageLatency,
-  usageDailyModelIdentity,
-  usageModelIdentity,
-} from "../../shared/usage-aggregates.js";
+import { loadSessionLogs, loadSessionUsageTimeSeries } from "../../infra/session-cost-usage.js";
+import { normalizeAgentId } from "../../routing/session-key.js";
+import { createUsageAggregateAccumulator } from "../../shared/usage-aggregates.js";
 import type {
   SessionUsageEntry,
   SessionsUsageAggregates,
@@ -65,253 +22,46 @@ import {
   sessionDeliveryChannel,
   sessionDeliveryOrigin,
 } from "../../utils/delivery-context.shared.js";
-import { runTasksWithConcurrency } from "../../utils/run-with-concurrency.js";
-import { listGatewayAgentsBasic } from "../agent-list.js";
 import { operatorSessionCap } from "../operator-role-policy.js";
 import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
 import { createSessionListEntryFilter, isGatewayAdmin } from "../session-sharing.js";
-import { resolveStoredSessionKeyForAgentStore } from "../session-store-key.js";
-import {
-  loadCombinedSessionStoreForGatewayCore,
-  loadGatewaySessionEntryReadOnly,
-} from "../session-utils.js";
 import { gatewayClientSessionCreator } from "./gateway-client-identity.js";
 import { loadUsageStatusStaleWhileRevalidate } from "./models-auth-status-usage-cache.js";
 import type { GatewayRequestHandlers, RespondFn } from "./types.js";
+import {
+  formatDateLabel,
+  resolveDateInterpretation,
+  resolveDateRange,
+  resolveDayBucket,
+  type DateInterpretation,
+  type DateRange,
+} from "./usage-date-range.js";
+import {
+  costUsageCache,
+  sessionsUsageCache,
+  loadCostUsageSummaryCached,
+  loadSessionsUsageResultCached,
+} from "./usage-result-cache.js";
+import { loadUsageSessionSummaries } from "./usage-session-loading.js";
+import {
+  resolveSessionUsageTarget,
+  selectUsageSessions,
+  UsageSessionInvalidRequestError,
+  type UsageGroupingMode,
+} from "./usage-session-selection.js";
 import { assertValidParams } from "./validation.js";
-
-const USAGE_CACHE_TTL_MS = 30_000;
-const USAGE_CACHE_MAX = 256;
-const USAGE_AGENT_LOAD_CONCURRENCY = 12;
-
-async function runUsageAgentTasks<T>(tasks: Array<() => Promise<T>>): Promise<T[]> {
-  const result = await runTasksWithConcurrency({
-    tasks,
-    limit: USAGE_AGENT_LOAD_CONCURRENCY,
-    errorMode: "stop",
-  });
-  // These fan-outs historically rejected as one unit. Never return partial
-  // per-agent usage; successful results retain their input order.
-  if (result.hasError) {
-    throw result.firstError;
-  }
-  return result.results;
-}
-
-type DateRange = { startMs: number; endMs: number; includeUntimestamped?: boolean };
-// Keep validation and parsed timestamps in one result so handlers cannot forward
-// an invalid or backwards window to the usage loaders.
-type DateRangeResolution = { ok: true; value: DateRange } | { ok: false; error: string };
-// 100 years: callers requesting unbounded history should use `range: "all"`.
-// Larger explicit day counts would overflow ECMAScript Date arithmetic and
-// surface as a misleading "calendar day does not exist" error from the resolver.
-const MAX_USAGE_DAYS = 366 * 100;
-type DateInterpretation =
-  | { mode: "utc" | "gateway" }
-  | { mode: "utc-offset"; utcOffsetMinutes: number }
-  | { mode: "time-zone"; timeZone: string; formatDayKey: (date: Date) => string };
-type DateInterpretationResolution =
-  | { ok: true; value: DateInterpretation }
-  | { ok: false; error: string };
-type DateParts = { year: number; monthIndex: number; day: number };
-
-const MAX_CONSECUTIVE_SKIPPED_TIME_ZONE_DAYS = 1;
-
-type UsageCacheEntry<T extends object> = {
-  configRef?: object;
-  value?: T;
-  updatedAt?: number;
-  inFlight?: Promise<T>;
-};
-
-const costUsageCache = new Map<string, UsageCacheEntry<CostUsageSummary>>();
-const sessionsUsageCache = new Map<string, UsageCacheEntry<SessionsUsageResult>>();
-
-class SessionsUsageInvalidRequestError extends Error {}
-
-type ResolvedSessionUsageTarget = {
-  entry: SessionEntry | undefined;
-  agentId: string;
-  sessionId: string;
-  sessionFile: string;
-};
-
-function resolveSessionUsageTarget(
-  key: string,
-  config: OpenClawConfig,
-  agentIdHint?: string,
-): ResolvedSessionUsageTarget | undefined {
-  const { canonicalKey, entry, storePath } = loadGatewaySessionEntryReadOnly(
-    key,
-    agentIdHint ? { agentId: agentIdHint } : undefined,
-  );
-  const parsed = parseAgentSessionKey(key);
-  const agentId =
-    parsed?.agentId ?? agentIdHint ?? resolveSessionAgentId({ config, sessionKey: key });
-  const sessionId = entry?.sessionId ?? parsed?.rest ?? key;
-  const sessionFile = entry
-    ? resolveExistingUsageSessionFile({
-        agentId,
-        sessionId,
-        sessionTarget: {
-          agentId,
-          sessionId,
-          sessionKey: canonicalKey,
-          storePath,
-        },
-      })
-    : resolveExistingUsageSessionFile({
-        agentId,
-        sessionId,
-        sessionFile: resolveSessionFilePathCore(
-          sessionId,
-          undefined,
-          resolveSessionFilePathOptions({ storePath, agentId }),
-        ),
-      });
-  return sessionFile ? { entry, agentId, sessionId, sessionFile } : undefined;
-}
-
-function setUsageCache<T extends object>(
-  cache: Map<string, UsageCacheEntry<T>>,
-  cacheKey: string,
-  entry: UsageCacheEntry<T>,
-): void {
-  if (!cache.has(cacheKey) && cache.size >= USAGE_CACHE_MAX) {
-    let evictionKey = cache.keys().next().value;
-    // Preserve active loads whenever a settled entry can be evicted instead.
-    for (const [key, candidate] of cache) {
-      if (!candidate.inFlight) {
-        evictionKey = key;
-        break;
-      }
-    }
-    if (evictionKey !== undefined) {
-      cache.delete(evictionKey);
-    }
-  }
-  cache.set(cacheKey, entry);
-}
-
-async function loadUsageResultCached<T extends object>(params: {
-  cache: Map<string, UsageCacheEntry<T>>;
-  cacheKey: string;
-  configRef?: object;
-  load: () => Promise<T>;
-  isComplete?: (value: T) => boolean;
-}): Promise<T> {
-  const { cache, cacheKey, configRef } = params;
-  const candidate = cache.get(cacheKey);
-  const cached =
-    configRef === undefined || candidate?.configRef === configRef ? candidate : undefined;
-  if (cached?.value && cached.updatedAt && Date.now() - cached.updatedAt < USAGE_CACHE_TTL_MS) {
-    return cached.value;
-  }
-  if (cached?.inFlight) {
-    return cached.value && cached.updatedAt ? cached.value : await cached.inFlight;
-  }
-
-  const entry: UsageCacheEntry<T> = cached ?? { ...(configRef && { configRef }) };
-  const inFlight = params
-    .load()
-    .then((value) => {
-      if (cache.get(cacheKey) !== entry) {
-        return value;
-      }
-      if (params.isComplete?.(value) ?? true) {
-        entry.value = value;
-        entry.updatedAt = Date.now();
-      } else if (!entry.value) {
-        // Partial snapshots serve cold callers without masking the next refresh.
-        entry.value = value;
-        delete entry.updatedAt;
-      }
-      return value;
-    })
-    .catch((error: unknown) => {
-      if (entry.value) {
-        return entry.value;
-      }
-      throw error;
-    })
-    .finally(() => {
-      const current = cache.get(cacheKey);
-      if (current === entry && current.inFlight === inFlight) {
-        current.inFlight = undefined;
-      }
-    });
-
-  entry.inFlight = inFlight;
-  setUsageCache(cache, cacheKey, entry);
-  return entry.value && entry.updatedAt ? entry.value : await inFlight;
-}
-
-function usageDayBucketCacheKey(dayBucket: UsageDailyBucket | undefined): string {
-  return dayBucket
-    ? dayBucket.mode === "time-zone"
-      ? `time-zone:${dayBucket.timeZone}`
-      : `utc-offset:${dayBucket.utcOffsetMinutes}`
-    : "gateway";
-}
-
-type SessionsUsageCacheKeyParams = {
-  configRef: object;
-  visibilityIdentity?: string;
-  agentId?: string;
-  agentScope?: "all";
-  startMs: number;
-  endMs: number;
-  includeUntimestamped?: boolean;
-  dayBucket?: UsageDailyBucket;
-  limit: number;
-  groupingMode: UsageGroupingMode;
-  specificKey: string | null;
-  includeContextWeight: boolean;
-};
-
-// Every normalized query axis that can change response bytes belongs in this
-// key; the 30s TTL mirrors usage.cost and keeps dashboard refreshes coherent.
-function sessionsUsageCacheKey(params: SessionsUsageCacheKeyParams): string {
-  return JSON.stringify([
-    params.agentScope === "all" ? "all" : `agent:${params.agentId}`,
-    params.startMs,
-    params.endMs,
-    params.includeUntimestamped === true,
-    usageDayBucketCacheKey(params.dayBucket),
-    params.limit,
-    params.groupingMode,
-    params.specificKey,
-    params.includeContextWeight,
-    ...(params.visibilityIdentity ? [params.visibilityIdentity] : []),
-  ]);
-}
-
-async function loadSessionsUsageResultCached(
-  params: SessionsUsageCacheKeyParams & {
-    load: () => Promise<SessionsUsageResult>;
-  },
-): Promise<SessionsUsageResult> {
-  return await loadUsageResultCached({
-    cache: sessionsUsageCache,
-    cacheKey: sessionsUsageCacheKey(params),
-    configRef: params.configRef,
-    load: params.load,
-    // Incomplete lower-cache snapshots must not acquire the outer freshness TTL.
-    isComplete: (result) => !result.cacheStatus || result.cacheStatus.status === "fresh",
-  });
-}
 
 function resolveSessionUsageFileOrRespond(
   key: string,
   respond: RespondFn,
   config: OpenClawConfig,
-): (ResolvedSessionUsageTarget & { config: OpenClawConfig }) | null {
+): (NonNullable<ReturnType<typeof resolveSessionUsageTarget>> & { config: OpenClawConfig }) | null {
   const sessionOwner = resolveRequestedSessionAgentId(config, key);
   if (!sessionOwner.ok) {
     respond(false, undefined, sessionOwner.error);
     return null;
   }
-  let resolved: ResolvedSessionUsageTarget | undefined;
+  let resolved: NonNullable<ReturnType<typeof resolveSessionUsageTarget>> | undefined;
   try {
     resolved = resolveSessionUsageTarget(key, config, sessionOwner.agentId);
   } catch {
@@ -327,343 +77,6 @@ function resolveSessionUsageFileOrRespond(
   }
   return { config, ...resolved };
 }
-
-const parseDateParts = (raw: unknown): DateParts | undefined => {
-  if (typeof raw !== "string" || !raw.trim()) {
-    return undefined;
-  }
-  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(raw.trim());
-  if (!match) {
-    return undefined;
-  }
-  const [, yearStr, monthStr, dayStr] = match;
-  const year = Number(yearStr);
-  const monthIndex = Number(monthStr) - 1;
-  const day = Number(dayStr);
-  if (!Number.isFinite(year) || !Number.isFinite(monthIndex) || !Number.isFinite(day)) {
-    return undefined;
-  }
-  // The regex only checks shape; Date.* silently rolls impossible calendar dates over
-  // (e.g. 2026-02-30 -> 2026-03-02), so a typo'd day would return usage for the wrong day.
-  // Reject parts that don't round-trip through a UTC probe (also catches the JS 2-digit-year remap).
-  const probe = new Date(Date.UTC(year, monthIndex, day));
-  if (
-    probe.getUTCFullYear() !== year ||
-    probe.getUTCMonth() !== monthIndex ||
-    probe.getUTCDate() !== day
-  ) {
-    return undefined;
-  }
-  return { year, monthIndex, day };
-};
-
-const shiftDateParts = (parts: DateParts, days: number): DateParts => {
-  const shifted = new Date(Date.UTC(parts.year, parts.monthIndex, parts.day + days));
-  return {
-    year: shifted.getUTCFullYear(),
-    monthIndex: shifted.getUTCMonth(),
-    day: shifted.getUTCDate(),
-  };
-};
-
-const datePartsToStartMs = (
-  parts: DateParts,
-  interpretation: DateInterpretation,
-): number | undefined => {
-  const { year, monthIndex, day } = parts;
-  if (interpretation.mode === "gateway") {
-    return new Date(year, monthIndex, day).getTime();
-  }
-  if (interpretation.mode === "time-zone") {
-    return resolveTimeZoneDayStartMs(
-      formatDateParts(year, monthIndex, day),
-      interpretation.timeZone,
-    );
-  }
-  if (interpretation.mode === "utc-offset") {
-    return Date.UTC(year, monthIndex, day) - interpretation.utcOffsetMinutes * 60 * 1000;
-  }
-  return Date.UTC(year, monthIndex, day);
-};
-
-const datePartsToEndMs = (
-  parts: DateParts,
-  interpretation: DateInterpretation,
-): number | undefined => {
-  const lookaheadDays =
-    interpretation.mode === "time-zone" ? 1 + MAX_CONSECUTIVE_SKIPPED_TIME_ZONE_DAYS : 1;
-  // A 24-hour date-line transition can remove one civil date entirely. Range
-  // resolution separately verifies the requested day; this only finds its end.
-  for (let daysAhead = 1; daysAhead <= lookaheadDays; daysAhead += 1) {
-    const nextDayStartMs = datePartsToStartMs(shiftDateParts(parts, daysAhead), interpretation);
-    if (nextDayStartMs !== undefined) {
-      return nextDayStartMs - 1;
-    }
-  }
-  return undefined;
-};
-
-// usage.cost / sessions.usage accept optional startDate/endDate. parseDateParts returns
-// undefined for both absent and invalid input, so an explicitly supplied but unparseable
-// date (bad format or impossible calendar date like 2026-02-30) would otherwise silently
-// fall through to the default range and return a successful response for an unrelated range.
-// Return the offending field so range resolution can reject it instead of querying the wrong window.
-const findInvalidExplicitDate = (params: {
-  startDate?: unknown;
-  endDate?: unknown;
-}): "startDate" | "endDate" | undefined => {
-  for (const field of ["startDate", "endDate"] as const) {
-    const raw = params[field];
-    if (raw === undefined || raw === null || (typeof raw === "string" && raw.trim() === "")) {
-      continue;
-    }
-    if (parseDateParts(raw) === undefined) {
-      return field;
-    }
-  }
-  return undefined;
-};
-
-/**
- * Parse a UTC offset string in the format UTC+H, UTC-H, UTC+HH, UTC-HH, UTC+H:MM, UTC-HH:MM.
- * Returns the UTC offset in minutes (east-positive), or undefined if invalid.
- */
-const parseUtcOffsetToMinutes = (raw: unknown): number | undefined => {
-  if (typeof raw !== "string" || !raw.trim()) {
-    return undefined;
-  }
-  const match = /^UTC([+-])(\d{1,2})(?::([0-5]\d))?$/.exec(raw.trim());
-  if (!match) {
-    return undefined;
-  }
-  const sign = match[1] === "+" ? 1 : -1;
-  const hours = Number(match[2]);
-  const minutes = Number(match[3] ?? "0");
-  if (!Number.isInteger(hours) || !Number.isInteger(minutes)) {
-    return undefined;
-  }
-  if (hours > 14 || (hours === 14 && minutes !== 0)) {
-    return undefined;
-  }
-  const totalMinutes = sign * (hours * 60 + minutes);
-  if (totalMinutes < -12 * 60 || totalMinutes > 14 * 60) {
-    return undefined;
-  }
-  return totalMinutes;
-};
-
-const resolveDateInterpretation = (params: {
-  mode?: unknown;
-  utcOffset?: unknown;
-  timeZone?: unknown;
-}): DateInterpretationResolution => {
-  if (params.mode === "gateway") {
-    return { ok: true, value: { mode: "gateway" } };
-  }
-  if (params.mode === "specific") {
-    const utcOffsetMinutes = parseUtcOffsetToMinutes(params.utcOffset);
-    if (params.timeZone !== undefined && params.timeZone !== null) {
-      const requestedTimeZone = normalizeOptionalString(params.timeZone);
-      const timeZone = requestedTimeZone ? resolveTimezone(requestedTimeZone) : undefined;
-      if (!timeZone) {
-        // Browser tzdata can lead Gateway ICU. Preserve legacy fixed-offset
-        // reporting when the concurrently supplied offset is still usable.
-        if (utcOffsetMinutes !== undefined) {
-          return { ok: true, value: { mode: "utc-offset", utcOffsetMinutes } };
-        }
-        return { ok: false, error: "invalid timeZone: expected a valid IANA time zone" };
-      }
-      return {
-        ok: true,
-        value: {
-          mode: "time-zone",
-          timeZone,
-          formatDayKey: createTimeZoneDayKeyFormatter(timeZone),
-        },
-      };
-    }
-    if (utcOffsetMinutes !== undefined) {
-      return { ok: true, value: { mode: "utc-offset", utcOffsetMinutes } };
-    }
-  }
-  // Backward compatibility: when mode is missing (or invalid), keep current UTC interpretation.
-  return { ok: true, value: { mode: "utc" } };
-};
-
-const resolveDayBucket = (interpretation: DateInterpretation): UsageDailyBucket | undefined => {
-  if (interpretation.mode === "gateway") {
-    return undefined;
-  }
-  if (interpretation.mode === "time-zone") {
-    return { mode: "time-zone", timeZone: interpretation.timeZone };
-  }
-  return {
-    mode: "utc-offset",
-    utcOffsetMinutes: interpretation.mode === "utc-offset" ? interpretation.utcOffsetMinutes : 0,
-  };
-};
-
-const getDateParts = (date: Date, interpretation: DateInterpretation): DateParts => {
-  if (interpretation.mode === "gateway") {
-    return { year: date.getFullYear(), monthIndex: date.getMonth(), day: date.getDate() };
-  }
-  if (interpretation.mode === "time-zone") {
-    const parts = parseDateParts(interpretation.formatDayKey(date));
-    if (!parts) {
-      throw new Error("timezone formatter returned an invalid calendar day");
-    }
-    return parts;
-  }
-  if (interpretation.mode === "utc-offset") {
-    const shifted = new Date(date.getTime() + interpretation.utcOffsetMinutes * 60 * 1000);
-    return {
-      year: shifted.getUTCFullYear(),
-      monthIndex: shifted.getUTCMonth(),
-      day: shifted.getUTCDate(),
-    };
-  }
-  return {
-    year: date.getUTCFullYear(),
-    monthIndex: date.getUTCMonth(),
-    day: date.getUTCDate(),
-  };
-};
-
-const formatDateLabel = (ms: number, interpretation: DateInterpretation): string => {
-  const parts = getDateParts(new Date(ms), interpretation);
-  return formatDateParts(parts.year, parts.monthIndex, parts.day);
-};
-
-const formatDateParts = (year: number, monthIndex: number, day: number): string =>
-  `${year}-${String(monthIndex + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
-
-const parseDays = (raw: unknown): number | undefined => {
-  const fromFinite = (n: number): number | undefined => {
-    if (!Number.isFinite(n)) {
-      return undefined;
-    }
-    return Math.min(Math.floor(n), MAX_USAGE_DAYS);
-  };
-  if (typeof raw === "number") {
-    return fromFinite(raw);
-  }
-  if (typeof raw === "string" && raw.trim() !== "") {
-    return fromFinite(Number(raw));
-  }
-  return undefined;
-};
-
-const resolveRangeDays = (raw: unknown): number | "all" | undefined => {
-  if (raw === "all") {
-    return "all";
-  }
-  if (raw === "7d") {
-    return 7;
-  }
-  if (raw === "30d") {
-    return 30;
-  }
-  if (raw === "90d") {
-    return 90;
-  }
-  if (raw === "1y") {
-    return 365;
-  }
-  return undefined;
-};
-
-const resolveTrailingDays = (
-  endDateParts: DateParts,
-  days: number,
-  interpretation: DateInterpretation,
-): DateRangeResolution => {
-  const startMs = datePartsToStartMs(shiftDateParts(endDateParts, -(days - 1)), interpretation);
-  const endMs = datePartsToEndMs(endDateParts, interpretation);
-  if (startMs === undefined || endMs === undefined) {
-    return { ok: false, error: "calendar day does not exist in requested time zone" };
-  }
-  return { ok: true, value: { startMs, endMs } };
-};
-
-/**
- * Get date range from params (startDate/endDate or days).
- * Falls back to last 30 days if not provided.
- */
-const resolveDateRange = (
-  params: {
-    startDate?: unknown;
-    endDate?: unknown;
-    days?: unknown;
-    range?: unknown;
-    mode?: unknown;
-    utcOffset?: unknown;
-    timeZone?: unknown;
-  },
-  resolvedInterpretation?: DateInterpretation,
-): DateRangeResolution => {
-  const invalidDate = findInvalidExplicitDate(params);
-  if (invalidDate) {
-    return {
-      ok: false,
-      error: `invalid ${invalidDate}: expected a valid YYYY-MM-DD calendar date`,
-    };
-  }
-
-  const now = new Date();
-  const interpretationResolution = resolvedInterpretation
-    ? { ok: true as const, value: resolvedInterpretation }
-    : resolveDateInterpretation(params);
-  if (!interpretationResolution.ok) {
-    return interpretationResolution;
-  }
-  const interpretation = interpretationResolution.value;
-  const todayDateParts = getDateParts(now, interpretation);
-  const todayEndMs = datePartsToEndMs(todayDateParts, interpretation);
-  if (todayEndMs === undefined) {
-    return { ok: false, error: "calendar day does not exist in requested time zone" };
-  }
-
-  const startDateParts = parseDateParts(params.startDate);
-  const endDateParts = parseDateParts(params.endDate);
-  // Explicit date windows are atomic. A single boundary must not silently
-  // fall through to the unrelated default 30-day range.
-  if ((startDateParts === undefined) !== (endDateParts === undefined)) {
-    return { ok: false, error: "startDate and endDate must be provided together" };
-  }
-
-  if (startDateParts && endDateParts) {
-    const startMs = datePartsToStartMs(startDateParts, interpretation);
-    const endStartMs = datePartsToStartMs(endDateParts, interpretation);
-    const endMs = datePartsToEndMs(endDateParts, interpretation);
-    if (startMs === undefined || endStartMs === undefined || endMs === undefined) {
-      return { ok: false, error: "calendar day does not exist in requested time zone" };
-    }
-    if (startMs > endStartMs) {
-      return { ok: false, error: "startDate must not be after endDate" };
-    }
-    return { ok: true, value: { startMs, endMs } };
-  }
-
-  const rangeDays = resolveRangeDays(params.range);
-  if (rangeDays === "all") {
-    return {
-      ok: true,
-      value: { startMs: 0, endMs: todayEndMs, includeUntimestamped: true },
-    };
-  }
-  if (rangeDays !== undefined) {
-    return resolveTrailingDays(todayDateParts, rangeDays, interpretation);
-  }
-
-  const days = parseDays(params.days);
-  if (days !== undefined) {
-    const clampedDays = Math.max(1, days);
-    return resolveTrailingDays(todayDateParts, clampedDays, interpretation);
-  }
-
-  // Default to last 30 days
-  return resolveTrailingDays(todayDateParts, 30, interpretation);
-};
 
 function resolveUsageDateRangeOrRespond(
   params: Parameters<typeof resolveDateRange>[0],
@@ -681,239 +94,6 @@ function resolveUsageDateRangeOrRespond(
     return null;
   }
   return { interpretation: interpretation.value, range: range.value };
-}
-
-type DiscoveredSessionWithAgent = DiscoveredSession & { agentId: string };
-type UsageGroupingMode = "instance" | "family";
-
-type MergedEntry = {
-  key: string;
-  agentId: string;
-  sessionId: string;
-  sessionFile: string;
-  label?: string;
-  updatedAt: number;
-  storeEntry?: SessionEntry;
-  firstUserMessage?: string;
-  scope?: "instance" | "family";
-  sessionFamilyKey?: string;
-  currentSessionId?: string;
-  includedSessionIds?: string[];
-};
-
-function usageSessionIdentity(agentId: string, sessionId: string): string {
-  return `${agentId}\0${sessionId}`;
-}
-
-function buildStoreBySessionIdentity(
-  store: Record<string, SessionEntry>,
-  agentIdBySessionKey: ReadonlyMap<string, string>,
-): Map<string, { key: string; entry: SessionEntry }> {
-  const matchesByIdentity = new Map<string, Array<[string, SessionEntry]>>();
-  for (const [key, entry] of Object.entries(store)) {
-    if (!entry?.sessionId) {
-      continue;
-    }
-    const agentId = expectDefined(agentIdBySessionKey.get(key), "stored session owner");
-    const identity = usageSessionIdentity(agentId, entry.sessionId);
-    const matches = matchesByIdentity.get(identity) ?? [];
-    matches.push([key, entry]);
-    matchesByIdentity.set(identity, matches);
-  }
-
-  const storeByIdentity = new Map<string, { key: string; entry: SessionEntry }>();
-  for (const [identity, matches] of matchesByIdentity) {
-    // Aliases within one agent share a transcript; another agent's identical id does not.
-    const sessionId = expectDefined(matches[0], "stored session match")[1].sessionId;
-    const preferredKey = resolvePreferredSessionKeyForSessionIdMatches(matches, sessionId);
-    if (!preferredKey) {
-      continue;
-    }
-    const preferredEntry = store[preferredKey];
-    if (preferredEntry) {
-      storeByIdentity.set(identity, { key: preferredKey, entry: preferredEntry });
-    }
-  }
-  return storeByIdentity;
-}
-
-async function discoverAllSessionsForUsage(params: {
-  config: OpenClawConfig;
-  agentId?: string;
-  startMs: number;
-  endMs: number;
-}): Promise<DiscoveredSessionWithAgent[]> {
-  const requestedAgentId = normalizeOptionalString(params.agentId);
-  const agents = requestedAgentId
-    ? [{ id: normalizeAgentId(requestedAgentId) }]
-    : listGatewayAgentsBasic(params.config).agents;
-  const discovered = await runUsageAgentTasks(
-    agents.map((agent) => async () => {
-      const agentId = normalizeAgentId(agent.id);
-      const sessions = await discoverAllSessions({
-        agentId,
-        startMs: params.startMs,
-        endMs: params.endMs,
-        includeFirstUserMessage: false,
-      });
-      return sessions.map((session) => Object.assign({}, session, { agentId }));
-    }),
-  );
-  return discovered.flat().toSorted((a, b) => b.mtime - a.mtime);
-}
-
-function addUniqueSessionIds(target: string[], ids: Array<string | undefined>): string[] {
-  const seen = new Set(target);
-  for (const id of ids) {
-    const normalized = normalizeOptionalString(id);
-    if (normalized && !seen.has(normalized)) {
-      seen.add(normalized);
-      target.push(normalized);
-    }
-  }
-  return target;
-}
-
-function resolveUsageFamilySessionIds(entry: SessionEntry | undefined, currentSessionId: string) {
-  return addUniqueSessionIds([], [currentSessionId, ...(entry?.usageFamilySessionIds ?? [])]);
-}
-
-function maybeMergeFamilyEntry(params: {
-  mergedEntries: MergedEntry[];
-  base: MergedEntry;
-  groupingMode: UsageGroupingMode;
-}) {
-  if (params.groupingMode !== "family") {
-    params.mergedEntries.push(params.base);
-    return;
-  }
-
-  const includedSessionIds = resolveUsageFamilySessionIds(
-    params.base.storeEntry,
-    params.base.sessionId,
-  );
-  // Family rows keep historical transcript ids so usage survives session resets.
-  params.mergedEntries.push({
-    ...params.base,
-    scope: "family",
-    sessionFamilyKey: params.base.storeEntry?.usageFamilyKey ?? params.base.key,
-    currentSessionId: params.base.sessionId,
-    includedSessionIds,
-  });
-}
-
-async function loadCostUsageSummaryCached(params: {
-  startMs: number;
-  endMs: number;
-  dayBucket?: UsageDailyBucket;
-  config: OpenClawConfig;
-  agentId?: string;
-  agentScope?: "all";
-}): Promise<CostUsageSummary> {
-  const allAgents = params.agentScope === "all";
-  const agentId = allAgents
-    ? undefined
-    : normalizeAgentId(params.agentId ?? resolveSessionAgentId({ config: params.config }));
-  const dayBucketKey = usageDayBucketCacheKey(params.dayBucket);
-  const cacheKey = `${allAgents ? "all" : `agent:${agentId}`}:${params.startMs}-${params.endMs}:${dayBucketKey}`;
-  return await loadUsageResultCached({
-    cache: costUsageCache,
-    cacheKey,
-    load: () =>
-      allAgents
-        ? loadAllAgentCostUsageSummary({
-            startMs: params.startMs,
-            endMs: params.endMs,
-            dayBucket: params.dayBucket,
-            config: params.config,
-          })
-        : loadCostUsageSummaryFromCache({
-            startMs: params.startMs,
-            endMs: params.endMs,
-            dayBucket: params.dayBucket,
-            config: params.config,
-            agentId: expectDefined(agentId, "non-aggregate usage agent id"),
-            requestRefresh: true,
-            refreshMode: "background",
-          }),
-  });
-}
-
-async function loadAllAgentCostUsageSummary(params: {
-  startMs: number;
-  endMs: number;
-  dayBucket?: UsageDailyBucket;
-  config: OpenClawConfig;
-}): Promise<CostUsageSummary> {
-  // Same agent universe as discoverAllSessionsForUsage: enumerating configured
-  // ids only would list system-agent sessions whose cost never reaches totals.
-  const agentIds = listGatewayAgentsBasic(params.config).agents.map((agent) =>
-    normalizeAgentId(agent.id),
-  );
-  const summaries = await runUsageAgentTasks(
-    agentIds.map(
-      (agentId) => () =>
-        loadCostUsageSummaryFromCache({
-          startMs: params.startMs,
-          endMs: params.endMs,
-          dayBucket: params.dayBucket,
-          config: params.config,
-          agentId,
-          requestRefresh: true,
-          refreshMode: "background",
-        }),
-    ),
-  );
-  const dailyByDate = new Map<string, CostUsageTotals & { date: string }>();
-  const totals = createEmptyCostUsageTotals();
-  let cacheStatus: UsageCacheStatus | undefined;
-  let updatedAt = 0;
-  let days = 0;
-  for (const summary of summaries) {
-    updatedAt = Math.max(updatedAt, summary.updatedAt);
-    days = Math.max(days, summary.days);
-    addCostUsageTotals(totals, summary.totals);
-    if (summary.cacheStatus) {
-      cacheStatus = mergeUsageCacheStatus(cacheStatus, summary.cacheStatus);
-    }
-    for (const day of summary.daily) {
-      const entry = dailyByDate.get(day.date) ?? {
-        date: day.date,
-        ...createEmptyCostUsageTotals(),
-      };
-      addCostUsageTotals(entry, day);
-      dailyByDate.set(day.date, entry);
-    }
-  }
-  return {
-    updatedAt,
-    days,
-    daily: Array.from(dailyByDate.values()).toSorted((a, b) => a.date.localeCompare(b.date)),
-    totals,
-    ...(cacheStatus ? { cacheStatus } : {}),
-  };
-}
-
-function mergeUsageCacheStatus(
-  target: UsageCacheStatus | undefined,
-  source: UsageCacheStatus,
-): UsageCacheStatus {
-  if (!target) {
-    return { ...source };
-  }
-  const statusRank = { fresh: 0, partial: 1, stale: 2, refreshing: 3 } as const;
-  return {
-    status: statusRank[source.status] > statusRank[target.status] ? source.status : target.status,
-    cachedFiles: target.cachedFiles + source.cachedFiles,
-    pendingFiles: target.pendingFiles + source.pendingFiles,
-    staleFiles: target.staleFiles + source.staleFiles,
-    refreshedAt:
-      target.refreshedAt === undefined
-        ? source.refreshedAt
-        : source.refreshedAt === undefined
-          ? target.refreshedAt
-          : Math.max(target.refreshedAt, source.refreshedAt),
-  };
 }
 
 // Exposed for unit tests (kept as a single export to avoid widening the public API surface).
@@ -1060,426 +240,37 @@ export const usageHandlers: GatewayRequestHandlers = {
         includeContextWeight,
         ...(visibilityIdentity ? { visibilityIdentity } : {}),
         load: async () => {
-          // Load session store for named sessions only on a result-cache miss.
-          const sessionStoreOpts = effectiveAgentId ? { agentId: effectiveAgentId } : {};
-          const { store, agentIdBySessionKey } = loadCombinedSessionStoreForGatewayCore(
-            config,
-            sessionStoreOpts,
-          );
-          const scopedStore = Object.fromEntries(
-            Object.entries(store).filter(
-              ([key, entry]) =>
-                (!effectiveAgentId || agentIdBySessionKey.get(key) === effectiveAgentId) &&
-                (!visibilityFilter || visibilityFilter(key, entry)),
-            ),
-          );
-          const storeBySessionIdentity = buildStoreBySessionIdentity(
-            scopedStore,
-            agentIdBySessionKey,
-          );
           const now = Date.now();
-
-          const mergedEntries: MergedEntry[] = [];
-
-          // Optimization: If a specific key is requested, skip full directory scan
-          if (specificKey) {
-            const scopedSpecificKey = resolveStoredSessionKeyForAgentStore({
-              cfg: config,
-              agentId:
-                effectiveAgentId ??
-                expectDefined(specificSessionOwner?.agentId, "specific session owner"),
-              sessionKey: specificKey,
-            });
-            const scopedParsed = parseAgentSessionKey(scopedSpecificKey);
-            const agentIdFromKey =
-              scopedParsed?.agentId ??
-              effectiveAgentId ??
-              expectDefined(specificSessionOwner?.agentId, "specific session owner");
-            const keyRest = scopedParsed?.rest ?? specificKey;
-
-            // Prefer the store entry when available, even if the caller provides a discovered key
-            // (`agent:<id>:<sessionId>`) for a session that now has a canonical store key.
-            const storeMatch = scopedStore[scopedSpecificKey]
-              ? { key: scopedSpecificKey, entry: scopedStore[scopedSpecificKey] }
-              : scopedStore[specificKey]
-                ? { key: specificKey, entry: scopedStore[specificKey] }
-                : null;
-            const storeByIdMatch =
-              storeBySessionIdentity.get(usageSessionIdentity(agentIdFromKey, keyRest)) ??
-              (keyRest !== specificKey
-                ? storeBySessionIdentity.get(usageSessionIdentity(agentIdFromKey, specificKey))
-                : undefined) ??
-              null;
-            const resolvedStoreKey = storeMatch?.key ?? storeByIdMatch?.key ?? scopedSpecificKey;
-            const storeEntry = storeMatch?.entry ?? storeByIdMatch?.entry;
-            if (visibilityFilter && !storeEntry) {
-              throw new SessionsUsageInvalidRequestError(
-                `Invalid session reference: ${specificKey}`,
-              );
-            }
-            const sessionId = storeEntry?.sessionId ?? keyRest;
-
-            // Stored sessions are canonical SQLite targets. JSONL discovery remains only for
-            // sessions without a store row, so retired locators cannot redirect live state.
-            let resolved: ResolvedSessionUsageTarget | undefined;
-            try {
-              resolved = resolveSessionUsageTarget(resolvedStoreKey, config, agentIdFromKey);
-              if (
-                !resolved ||
-                resolved.agentId !== agentIdFromKey ||
-                resolved.sessionId !== sessionId
-              ) {
-                throw new Error("session target mismatch");
-              }
-            } catch {
-              throw new SessionsUsageInvalidRequestError(
-                `Invalid session reference: ${specificKey}`,
-              );
-            }
-            const { sessionFile } = resolved;
-
-            let updatedAt: number | undefined;
-            if (parseSqliteSessionFileMarker(sessionFile)) {
-              updatedAt = storeEntry?.updatedAt ?? now;
-            } else {
-              try {
-                const stats = fs.statSync(sessionFile);
-                if (stats.isFile()) {
-                  updatedAt = storeEntry?.updatedAt ?? stats.mtimeMs;
-                }
-              } catch {
-                // File doesn't exist - no results for this key
-              }
-            }
-            if (updatedAt !== undefined) {
-              maybeMergeFamilyEntry({
-                mergedEntries,
-                groupingMode,
-                base: {
-                  key: resolvedStoreKey,
-                  agentId: agentIdFromKey,
-                  sessionId,
-                  sessionFile,
-                  label: storeEntry?.label,
-                  updatedAt,
-                  storeEntry,
-                },
-              });
-            }
-          } else {
-            // Full discovery for list view
-            const discoveredSessions = await discoverAllSessionsForUsage({
-              config,
-              ...(effectiveAgentId ? { agentId: effectiveAgentId } : {}),
-              startMs,
-              endMs,
-            });
-
-            const storeFamilySessionIds = new Set<string>();
-            if (groupingMode === "family") {
-              for (const [key, entry] of Object.entries(scopedStore)) {
-                const agentId = expectDefined(agentIdBySessionKey.get(key), "stored session owner");
-                for (const sessionId of entry?.usageFamilySessionIds ?? []) {
-                  storeFamilySessionIds.add(usageSessionIdentity(agentId, sessionId));
-                }
-              }
-            }
-
-            for (const discovered of discoveredSessions) {
-              const identity = usageSessionIdentity(discovered.agentId, discovered.sessionId);
-              const storeMatch = storeBySessionIdentity.get(identity);
-              if (visibilityFilter && !storeMatch) {
-                continue;
-              }
-              if (storeMatch) {
-                // Named session from store
-                maybeMergeFamilyEntry({
-                  mergedEntries,
-                  groupingMode,
-                  base: {
-                    key: storeMatch.key,
-                    agentId: discovered.agentId,
-                    sessionId: discovered.sessionId,
-                    sessionFile: discovered.sessionFile,
-                    label: storeMatch.entry.label,
-                    updatedAt: storeMatch.entry.updatedAt ?? discovered.mtime,
-                    storeEntry: storeMatch.entry,
-                  },
-                });
-              } else {
-                if (groupingMode === "family" && storeFamilySessionIds.has(identity)) {
-                  // The current store row will load this historical transcript through included ids.
-                  continue;
-                }
-                // Unnamed session - use session ID as key, no label
-                mergedEntries.push({
-                  // Keep agentId in the key so the dashboard can attribute sessions and later fetch logs.
-                  key: `agent:${discovered.agentId}:${discovered.sessionId}`,
-                  agentId: discovered.agentId,
-                  sessionId: discovered.sessionId,
-                  sessionFile: discovered.sessionFile,
-                  label: undefined, // No label for unnamed sessions
-                  updatedAt: discovered.mtime,
-                  scope: "instance",
-                });
-              }
-            }
-          }
-
-          // Sort by most recent first
-          mergedEntries.sort((a, b) => b.updatedAt - a.updatedAt);
+          const mergedEntries = await selectUsageSessions({
+            config,
+            agentId: effectiveAgentId,
+            specificKey,
+            groupingMode,
+            startMs,
+            endMs,
+            visibilityFilter,
+          });
 
           // Load usage for each session
           const sessions: SessionUsageEntry[] = [];
-          const aggregateTotals = createEmptyCostUsageTotals();
-          const aggregateMessages: SessionMessageCounts = {
-            total: 0,
-            user: 0,
-            assistant: 0,
-            toolCalls: 0,
-            toolResults: 0,
-            errors: 0,
-          };
-          const toolAggregateMap = new Map<string, number>();
-          const byModelMap = new Map<string, SessionModelUsage>();
-          const byProviderMap = new Map<string, SessionModelUsage>();
-          const byAgentMap = new Map<string, CostUsageSummary["totals"]>();
-          const byChannelMap = new Map<string, CostUsageSummary["totals"]>();
-          const dailyAggregateMap = new Map<
-            string,
-            {
-              date: string;
-              tokens: number;
-              cost: number;
-              messages: number;
-              toolCalls: number;
-              errors: number;
-            }
-          >();
-          const latencyTotals = {
-            count: 0,
-            sum: 0,
-            min: Number.POSITIVE_INFINITY,
-            max: 0,
-            p95Max: 0,
-          };
-          const dailyLatencyMap = new Map<
-            string,
-            { date: string; count: number; sum: number; min: number; max: number; p95Max: number }
-          >();
-          const modelDailyMap = new Map<string, SessionDailyModelUsage>();
-          let cacheStatus: UsageCacheStatus | undefined;
-
-          const usageByEntryIndex: Array<SessionCostSummary | null> = Array.from(
-            { length: mergedEntries.length },
-            () => null,
-          );
-
-          // Group every included session (visible + hidden) by agent so the usage-cost
-          // cache is read and parsed at most once per agent. Loading each session
-          // individually re-reads and re-parses the whole cache file, so RSS spikes
-          // in proportion to `limit` on every dashboard connect (issue #100041).
-          const sessionsByAgent = new Map<
-            string,
-            Array<{ entryIndex: number; sessionId: string; sessionFile: string }>
-          >();
-          for (const [entryIndex, merged] of mergedEntries.entries()) {
-            for (const includedSessionId of merged.includedSessionIds ?? [merged.sessionId]) {
-              const includedSessionFile =
-                includedSessionId === merged.sessionId
-                  ? merged.sessionFile
-                  : resolveExistingUsageSessionFile({
-                      sessionId: includedSessionId,
-                      agentId: merged.agentId,
-                    });
-              if (!includedSessionFile) {
-                continue;
-              }
-              const agentSessions = sessionsByAgent.get(merged.agentId) ?? [];
-              agentSessions.push({
-                entryIndex,
-                sessionId: includedSessionId,
-                sessionFile: includedSessionFile,
-              });
-              sessionsByAgent.set(merged.agentId, agentSessions);
-            }
-          }
-
-          const agentLoads = await runUsageAgentTasks(
-            Array.from(sessionsByAgent.entries()).map(([agentId, agentSessions]) => async () => ({
-              agentSessions,
-              loaded: await loadSessionCostSummariesFromCache({
-                sessions: agentSessions,
-                config,
-                agentId,
-                startMs,
-                endMs,
-                includeUntimestamped,
-                dayBucket,
-              }),
-            })),
-          );
-          for (const { agentSessions, loaded } of agentLoads) {
-            cacheStatus = mergeUsageCacheStatus(cacheStatus, loaded.cacheStatus);
-            for (const [index, summary] of loaded.summaries.entries()) {
-              if (!summary) {
-                continue;
-              }
-              const session = expectDefined(agentSessions[index], "agent sessions entry at index");
-              const merged = expectDefined(
-                mergedEntries[session.entryIndex],
-                "merged entries entry at session.entry index",
-              );
-              const usage: SessionCostSummary =
-                usageByEntryIndex[session.entryIndex] ?? createEmptyCostUsageTotals();
-              usage.sessionId = merged.sessionId;
-              usage.sessionFile = merged.sessionFile;
-              mergeSessionCostSummaryInto(usage, summary);
-              usageByEntryIndex[session.entryIndex] = usage;
-            }
-          }
-
-          // Track session-level aggregates across every matched session, so profile
-          // stats stay correct when the row list is truncated by `limit`.
-          let longestSessionDurationMs = 0;
-          let activeSessionCount = 0;
+          const accumulator = createUsageAggregateAccumulator();
+          const { summaries: usageByEntryIndex, cacheStatus } = await loadUsageSessionSummaries({
+            entries: mergedEntries,
+            config,
+            startMs,
+            endMs,
+            includeUntimestamped,
+            dayBucket,
+          });
 
           for (const [entryIndex, merged] of mergedEntries.entries()) {
             const agentId = merged.agentId;
-            // A cold or stale cache intentionally yields null until its background refresh completes.
             const usage = usageByEntryIndex[entryIndex] ?? null;
-
-            if (usage) {
-              addCostUsageTotals(aggregateTotals, usage);
-              longestSessionDurationMs = Math.max(longestSessionDurationMs, usage.durationMs ?? 0);
-              // Discovery admits transcripts modified after endMs (they can still hold
-              // in-range activity), so count only sessions whose filtered usage does.
-              if (usage.firstActivity !== undefined || (usage.messageCounts?.total ?? 0) > 0) {
-                activeSessionCount += 1;
-              }
-            }
-
             const channel = sessionDeliveryChannel(merged.storeEntry);
-            const chatType =
-              merged.storeEntry?.chatType ?? sessionDeliveryOrigin(merged.storeEntry)?.chatType;
-
-            if (usage) {
-              if (usage.messageCounts) {
-                aggregateMessages.total += usage.messageCounts.total;
-                aggregateMessages.user += usage.messageCounts.user;
-                aggregateMessages.assistant += usage.messageCounts.assistant;
-                aggregateMessages.toolCalls += usage.messageCounts.toolCalls;
-                aggregateMessages.toolResults += usage.messageCounts.toolResults;
-                aggregateMessages.errors += usage.messageCounts.errors;
-              }
-
-              if (usage.toolUsage) {
-                for (const tool of usage.toolUsage.tools) {
-                  toolAggregateMap.set(
-                    tool.name,
-                    (toolAggregateMap.get(tool.name) ?? 0) + tool.count,
-                  );
-                }
-              }
-
-              if (usage.modelUsage) {
-                for (const entry of usage.modelUsage) {
-                  const modelKey = usageModelIdentity(entry.provider, entry.model);
-                  const modelExisting =
-                    byModelMap.get(modelKey) ??
-                    ({
-                      provider: entry.provider,
-                      model: entry.model,
-                      count: 0,
-                      totals: createEmptyCostUsageTotals(),
-                    } as SessionModelUsage);
-                  modelExisting.count += entry.count;
-                  addCostUsageTotals(modelExisting.totals, entry.totals);
-                  byModelMap.set(modelKey, modelExisting);
-
-                  const providerKey = entry.provider ?? "unknown";
-                  const providerExisting =
-                    byProviderMap.get(providerKey) ??
-                    ({
-                      provider: entry.provider,
-                      model: undefined,
-                      count: 0,
-                      totals: createEmptyCostUsageTotals(),
-                    } as SessionModelUsage);
-                  providerExisting.count += entry.count;
-                  addCostUsageTotals(providerExisting.totals, entry.totals);
-                  byProviderMap.set(providerKey, providerExisting);
-                }
-              }
-
-              mergeUsageLatency(latencyTotals, usage.latency);
-              mergeUsageDailyLatency(dailyLatencyMap, usage.dailyLatency);
-
-              if (usage.dailyModelUsage) {
-                for (const entry of usage.dailyModelUsage) {
-                  const key = usageDailyModelIdentity(entry.date, entry.provider, entry.model);
-                  const existing =
-                    modelDailyMap.get(key) ??
-                    ({
-                      date: entry.date,
-                      provider: entry.provider,
-                      model: entry.model,
-                      tokens: 0,
-                      cost: 0,
-                      count: 0,
-                    } as SessionDailyModelUsage);
-                  existing.tokens += entry.tokens;
-                  existing.cost += entry.cost;
-                  existing.count += entry.count;
-                  modelDailyMap.set(key, existing);
-                }
-              }
-
-              if (agentId) {
-                const agentTotals = byAgentMap.get(agentId) ?? createEmptyCostUsageTotals();
-                addCostUsageTotals(agentTotals, usage);
-                byAgentMap.set(agentId, agentTotals);
-              }
-
-              if (channel) {
-                const channelTotals = byChannelMap.get(channel) ?? createEmptyCostUsageTotals();
-                addCostUsageTotals(channelTotals, usage);
-                byChannelMap.set(channel, channelTotals);
-              }
-
-              if (usage.dailyBreakdown) {
-                for (const day of usage.dailyBreakdown) {
-                  const daily = dailyAggregateMap.get(day.date) ?? {
-                    date: day.date,
-                    tokens: 0,
-                    cost: 0,
-                    messages: 0,
-                    toolCalls: 0,
-                    errors: 0,
-                  };
-                  daily.tokens += day.tokens;
-                  daily.cost += day.cost;
-                  dailyAggregateMap.set(day.date, daily);
-                }
-              }
-
-              if (usage.dailyMessageCounts) {
-                for (const day of usage.dailyMessageCounts) {
-                  const daily = dailyAggregateMap.get(day.date) ?? {
-                    date: day.date,
-                    tokens: 0,
-                    cost: 0,
-                    messages: 0,
-                    toolCalls: 0,
-                    errors: 0,
-                  };
-                  daily.messages += day.total;
-                  daily.toolCalls += day.toolCalls;
-                  daily.errors += day.errors;
-                  dailyAggregateMap.set(day.date, daily);
-                }
-              }
-            }
+            const origin = sessionDeliveryOrigin(merged.storeEntry);
+            const chatType = merged.storeEntry?.chatType ?? origin?.chatType;
+            // Aggregate every matched row before limiting the visible list.
+            accumulator.add({ usage, agentId, channel });
 
             if (entryIndex < limit) {
               sessions.push({
@@ -1495,7 +286,7 @@ export const usageHandlers: GatewayRequestHandlers = {
                 agentId,
                 channel,
                 chatType,
-                origin: sessionDeliveryOrigin(merged.storeEntry),
+                origin,
                 modelOverride: merged.storeEntry?.modelOverride,
                 providerOverride: merged.storeEntry?.providerOverride,
                 modelProvider: merged.storeEntry?.modelProvider,
@@ -1508,61 +299,19 @@ export const usageHandlers: GatewayRequestHandlers = {
             }
           }
 
-          const tail = buildUsageAggregateTail({
-            byChannelMap,
-            latencyTotals,
-            dailyLatencyMap,
-            modelDailyMap,
-            dailyMap: dailyAggregateMap,
-          });
-
-          const aggregates: SessionsUsageAggregates = {
-            sessionCount: activeSessionCount,
-            ...(longestSessionDurationMs > 0 ? { longestSessionDurationMs } : {}),
-            messages: aggregateMessages,
-            tools: {
-              totalCalls: Array.from(toolAggregateMap.values()).reduce(
-                (sum, count) => sum + count,
-                0,
-              ),
-              uniqueTools: toolAggregateMap.size,
-              tools: Array.from(toolAggregateMap.entries())
-                .map(([name, count]) => ({ name, count }))
-                .toSorted((a, b) => b.count - a.count),
-            },
-            byModel: Array.from(byModelMap.values()).toSorted((a, b) => {
-              const costDiff = (b.totals?.totalCost ?? 0) - (a.totals?.totalCost ?? 0);
-              if (costDiff !== 0) {
-                return costDiff;
-              }
-              return (b.totals?.totalTokens ?? 0) - (a.totals?.totalTokens ?? 0);
-            }),
-            byProvider: Array.from(byProviderMap.values()).toSorted((a, b) => {
-              const costDiff = (b.totals?.totalCost ?? 0) - (a.totals?.totalCost ?? 0);
-              if (costDiff !== 0) {
-                return costDiff;
-              }
-              return (b.totals?.totalTokens ?? 0) - (a.totals?.totalTokens ?? 0);
-            }),
-            byAgent: Array.from(byAgentMap.entries())
-              .map(([id, totals]) => ({ agentId: id, totals }))
-              .toSorted((a, b) => (b.totals?.totalCost ?? 0) - (a.totals?.totalCost ?? 0)),
-            ...tail,
-          };
-
           return {
             updatedAt: now,
             startDate: formatDateLabel(startMs, dateInterpretation),
             endDate: formatDateLabel(endMs, dateInterpretation),
             sessions,
-            totals: aggregateTotals,
-            aggregates,
+            totals: accumulator.totals,
+            aggregates: accumulator.finish(),
             cacheStatus,
           };
         },
       });
     } catch (err) {
-      if (err instanceof SessionsUsageInvalidRequestError) {
+      if (err instanceof UsageSessionInvalidRequestError) {
         respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, err.message));
         return;
       }
@@ -1637,4 +386,3 @@ export const usageHandlers: GatewayRequestHandlers = {
     respond(true, { logs: logs ?? [] }, undefined);
   },
 };
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/infra/session-cost-usage-pricing.ts
+++ b/src/infra/session-cost-usage-pricing.ts
@@ -14,7 +14,7 @@ import type {
 const normalizeUsageCostTotalOrigin = (value: unknown): CostBreakdown["totalOrigin"] =>
   value === "provider-billed" ? value : undefined;
 
-export const extractCostBreakdown = (usageRaw?: UsageLike | null): CostBreakdown | undefined => {
+const extractCostBreakdown = (usageRaw?: UsageLike | null): CostBreakdown | undefined => {
   if (!usageRaw || typeof usageRaw !== "object") {
     return undefined;
   }
@@ -39,7 +39,7 @@ export const extractCostBreakdown = (usageRaw?: UsageLike | null): CostBreakdown
   };
 };
 
-export const parseTimestamp = (entry: Record<string, unknown>): Date | undefined => {
+const parseTimestamp = (entry: Record<string, unknown>): Date | undefined => {
   const message = entry.message as Record<string, unknown> | undefined;
   const messageTimestamp = asFiniteNumber(message?.timestamp);
   if (messageTimestamp !== undefined) {
@@ -189,7 +189,7 @@ const shouldPreserveRecordedZeroCost = (costBreakdown: CostBreakdown | undefined
       costBreakdown.cacheWrite,
     ].some((value) => value !== undefined && value !== 0));
 
-export const shouldRecomputeRecordedZeroCost = (params: {
+const shouldRecomputeRecordedZeroCost = (params: {
   cost: ReturnType<typeof resolveModelCostConfig>;
   costBreakdown: CostBreakdown | undefined;
   costTotal: number | undefined;

--- a/src/infra/session-cost-usage-reporting.test.ts
+++ b/src/infra/session-cost-usage-reporting.test.ts
@@ -1,0 +1,158 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { ModelDefinitionConfig } from "../config/types.models.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import {
+  loadSessionCostSummary,
+  loadSessionLogs,
+  loadSessionUsageTimeSeries,
+} from "./session-cost-usage.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const flatPricing = { input: 1, output: 2, cacheRead: 0.5, cacheWrite: 0 };
+const tieredPricing: ModelDefinitionConfig["cost"] = {
+  ...flatPricing,
+  tieredPricing: [
+    { ...flatPricing, range: [0, 1_000] },
+    { input: 2, output: 4, cacheRead: 1, cacheWrite: 0, range: [1_000, 100_000] },
+  ],
+};
+
+type PricingCase = {
+  name: string;
+  pricing?: ModelDefinitionConfig["cost"];
+  recordedCost?: { total: number; totalOrigin?: "provider-billed" };
+  topLevelUsage?: boolean;
+  expectedCost: number | undefined;
+};
+
+describe("session usage reporting pricing", () => {
+  it.each<PricingCase>([
+    {
+      name: "top-level usage and pricing metadata",
+      pricing: flatPricing,
+      topLevelUsage: true,
+      expectedCost: 0.0021,
+    },
+    {
+      name: "unknown recorded zero cost",
+      recordedCost: { total: 0 },
+      expectedCost: undefined,
+    },
+    {
+      name: "configured all-zero pricing",
+      pricing: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      recordedCost: { total: 0 },
+      expectedCost: undefined,
+    },
+    {
+      name: "tiered pricing replacing a recorded flat estimate",
+      pricing: tieredPricing,
+      recordedCost: { total: 0.001 },
+      expectedCost: 0.0042,
+    },
+    {
+      name: "provider-billed zero preserved with tiered pricing",
+      pricing: tieredPricing,
+      recordedCost: { total: 0, totalOrigin: "provider-billed" },
+      expectedCost: 0,
+    },
+    {
+      name: "recorded positive cost preserved with flat pricing",
+      pricing: flatPricing,
+      recordedCost: { total: 0.125 },
+      expectedCost: 0.125,
+    },
+  ])("keeps logs, summaries, and charts consistent for $name", async (testCase) => {
+    const root = tempDirs.make("openclaw-usage-reporting-");
+    const sessionFile = path.join(root, "transcript.jsonl");
+    const timestamp = Date.UTC(2026, 7, 1, 12);
+    const usage = {
+      input: 1_000,
+      output: 500,
+      cacheRead: 200,
+      totalTokens: 1_700,
+      ...(testCase.recordedCost ? { cost: testCase.recordedCost } : {}),
+    };
+    const entries = [
+      { message: { role: "user", content: "Question", timestamp: timestamp - 1 } },
+      {
+        provider: "reporting",
+        model: "fixture-model",
+        ...(testCase.topLevelUsage ? { usage } : {}),
+        message: {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Answer" },
+            { type: "tool_use", name: "lookup" },
+          ],
+          timestamp,
+          ...(testCase.topLevelUsage ? {} : { usage }),
+        },
+      },
+      {
+        message: {
+          role: "toolResult",
+          toolName: "lookup",
+          content: "Done",
+          timestamp: timestamp + 1,
+        },
+      },
+    ];
+    await fs.writeFile(sessionFile, entries.map((entry) => JSON.stringify(entry)).join("\n"));
+    const config: OpenClawConfig = testCase.pricing
+      ? {
+          models: {
+            providers: {
+              reporting: {
+                baseUrl: "https://reporting.invalid",
+                models: [
+                  {
+                    id: "fixture-model",
+                    name: "Reporting fixture",
+                    reasoning: false,
+                    input: ["text"],
+                    cost: testCase.pricing,
+                    contextWindow: 100_000,
+                    maxTokens: 8_000,
+                  },
+                ],
+              },
+            },
+          },
+        }
+      : {};
+
+    await withEnvAsync({ OPENCLAW_STATE_DIR: root }, async () => {
+      const params = { agentId: "main", sessionFile, config };
+      const logs = await loadSessionLogs(params);
+      expect(logs).toEqual([
+        expect.objectContaining({ role: "user", content: "Question" }),
+        {
+          timestamp,
+          role: "assistant",
+          content: "Answer\n[Tool: lookup]",
+          tokens: 1_700,
+          cost: testCase.expectedCost,
+        },
+        expect.objectContaining({
+          role: "toolResult",
+          content: "[Tool: lookup]\n[Tool Result]\nDone",
+        }),
+      ]);
+
+      const summary = await loadSessionCostSummary(params);
+      expect(summary?.totalTokens).toBe(1_700);
+      expect(summary?.totalCost).toBeCloseTo(testCase.expectedCost ?? 0, 8);
+      expect(summary?.missingCostEntries).toBe(testCase.expectedCost === undefined ? 1 : 0);
+
+      const series = await loadSessionUsageTimeSeries(params);
+      expect(series?.points).toHaveLength(1);
+      expect(series?.points[0]?.totalTokens).toBe(1_700);
+      expect(series?.points[0]?.cost).toBeCloseTo(testCase.expectedCost ?? 0, 8);
+    });
+  });
+});

--- a/src/infra/session-cost-usage-reporting.ts
+++ b/src/infra/session-cost-usage-reporting.ts
@@ -2,7 +2,6 @@ import fs from "node:fs";
 import path from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import { normalizeUsage } from "../agents/usage.js";
 import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
 import {
   isPrimarySessionTranscriptFileName,
@@ -12,7 +11,6 @@ import { parseSqliteSessionFileMarker } from "../config/sessions/legacy-sqlite-m
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { stripEnvelope, stripMessageIdHints } from "../shared/chat-envelope.js";
-import { estimateUsageCost } from "../utils/usage-format.js";
 import {
   isUsageCostRollupFresh,
   readUsageCostRollups,
@@ -31,10 +29,7 @@ import {
 import {
   computeUsageTokenTotals,
   createUsageCostResolver,
-  extractCostBreakdown,
-  parseTimestamp,
   parseUsageCostTranscriptEntry,
-  shouldRecomputeRecordedZeroCost,
 } from "./session-cost-usage-pricing.js";
 import { createUsageDayKeyFormatter } from "./session-cost-usage-projection.js";
 import { buildSessionCostSummaryFromRollup } from "./session-cost-usage-rollup.js";
@@ -431,55 +426,17 @@ export async function loadSessionLogs(params: {
         content = truncateUtf16Safe(content, maxLen) + "…";
       }
 
-      // Get timestamp
-      // Keep detail logs on the usage-summary timestamp path, including nested
-      // fallback; direct Date parsing can leak NaN as null through Gateway JSON.
-      const timestamp = parseTimestamp(parsed)?.getTime() ?? 0;
-
-      // Get usage for assistant messages
-      let tokens: number | undefined;
-      let cost: number | undefined;
-      if (role === "assistant") {
-        const usageRaw = message.usage as Record<string, unknown> | undefined;
-        const usage = normalizeUsage(usageRaw);
-        if (usage) {
-          tokens =
-            usage.total ??
-            (usage.input ?? 0) +
-              (usage.output ?? 0) +
-              (usage.cacheRead ?? 0) +
-              (usage.cacheWrite ?? 0);
-          const breakdown = extractCostBreakdown(usageRaw);
-          const costConfig = resolveCost({
-            provider:
-              (typeof message.provider === "string" ? message.provider : undefined) ??
-              (typeof parsed.provider === "string" ? parsed.provider : undefined),
-            model:
-              (typeof message.model === "string" ? message.model : undefined) ??
-              (typeof parsed.model === "string" ? parsed.model : undefined),
-          });
-          if (
-            breakdown?.total !== undefined &&
-            !shouldRecomputeRecordedZeroCost({
-              usage,
-              cost: costConfig,
-              costBreakdown: breakdown,
-              costTotal: breakdown.total,
-            })
-          ) {
-            cost = breakdown.total;
-          } else {
-            cost = estimateUsageCost({ usage, cost: costConfig });
-          }
-        }
-      }
+      // Logs share pricing and timestamp interpretation with summaries and charts.
+      // Recomputing here can turn unknown prices into zero or ignore tiered rates.
+      const entry = parseUsageCostTranscriptEntry(parsed, resolveCost);
+      const usage = role === "assistant" ? entry?.usage : undefined;
 
       logs.push({
-        timestamp,
+        timestamp: entry?.timestamp?.getTime() ?? 0,
         role,
         content,
-        tokens,
-        cost,
+        tokens: usage ? computeUsageTokenTotals(usage).totalTokens : undefined,
+        cost: usage ? entry?.costTotal : undefined,
       });
       // Timestamps can arrive out of order, so keep a bounded sorted window instead
       // of relying on transcript append order or retaining the whole file.

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -16,12 +16,6 @@ export type {
   CostUsageTotals,
   DiscoveredSession,
   SessionCostSummary,
-  SessionDailyLatency,
-  SessionDailyModelUsage,
-  SessionLatencyStats,
-  SessionMessageCounts,
-  SessionModelUsage,
-  SessionToolUsage,
   UsageCacheStatus,
   UsageDailyBucket,
 } from "./session-cost-usage.types.js";

--- a/src/shared/usage-aggregates.test.ts
+++ b/src/shared/usage-aggregates.test.ts
@@ -1,12 +1,27 @@
-// Usage aggregate tests cover token, cost, and latency accumulation.
 import { describe, expect, it } from "vitest";
+import type { SessionCostSummary } from "../infra/session-cost-usage.types.js";
 import {
-  buildUsageAggregateTail,
-  mergeUsageDailyLatency,
-  mergeUsageLatency,
+  createUsageAggregateAccumulator,
   usageDailyModelIdentity,
   usageModelIdentity,
 } from "./usage-aggregates.js";
+
+function usage(overrides: Partial<SessionCostSummary> = {}): SessionCostSummary {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    totalCost: 0,
+    inputCost: 0,
+    outputCost: 0,
+    cacheReadCost: 0,
+    cacheWriteCost: 0,
+    missingCostEntries: 0,
+    ...overrides,
+  };
+}
 
 describe("shared/usage-aggregates", () => {
   it("builds collision-free model identities with legacy unknown grouping", () => {
@@ -22,153 +37,227 @@ describe("shared/usage-aggregates", () => {
     expect(usageModelIdentity()).toBe(usageModelIdentity("unknown", "unknown"));
   });
 
-  it("merges latency totals and ignores empty inputs", () => {
-    const totals = {
-      count: 1,
-      sum: 100,
-      min: 100,
-      max: 100,
-      p95Max: 100,
-    };
+  it("accounts for every supplied row without conflating matching session IDs or mutating usage", () => {
+    const accumulator = createUsageAggregateAccumulator();
+    const first = usage({
+      sessionId: "same-id",
+      firstActivity: 0,
+      durationMs: 500,
+      input: 10,
+      cacheRead: 3,
+      totalTokens: 13,
+      totalCost: 2,
+      inputCost: 1,
+      cacheReadCost: 1,
+      missingCostEntries: 1,
+      missingCostByModel: { "fixture/unpriced": 1 },
+      messageCounts: { total: 3, user: 1, assistant: 2, toolCalls: 3, toolResults: 2, errors: 1 },
+      toolUsage: {
+        totalCalls: 3,
+        uniqueTools: 2,
+        tools: [
+          { name: "read", count: 2 },
+          { name: "write", count: 1 },
+        ],
+      },
+    });
+    const second = usage({
+      sessionId: "same-id",
+      durationMs: 900,
+      output: 5,
+      cacheWrite: 2,
+      totalTokens: 7,
+      totalCost: 4,
+      outputCost: 3,
+      cacheWriteCost: 1,
+      missingCostEntries: 2,
+      missingCostByModel: { "fixture/unpriced": 2 },
+      messageCounts: { total: 2, user: 1, assistant: 1, toolCalls: 2, toolResults: 1, errors: 0 },
+      toolUsage: { totalCalls: 2, uniqueTools: 1, tools: [{ name: "read", count: 2 }] },
+    });
+    const original = structuredClone([first, second]);
+    accumulator.add({ usage: first, agentId: "first", channel: "discord" });
+    accumulator.add({ usage: second, agentId: "second", channel: "telegram" });
+    accumulator.add({ usage: usage({ totalTokens: 30 }) });
+    accumulator.add({ usage: null, agentId: "cold" });
 
-    mergeUsageLatency(totals, undefined);
-    mergeUsageLatency(totals, {
-      count: 0,
-      avgMs: 999,
-      minMs: 1,
-      maxMs: 999,
-      p95Ms: 999,
+    const aggregates = accumulator.finish();
+    expect(accumulator.totals).toEqual({
+      input: 10,
+      output: 5,
+      cacheRead: 3,
+      cacheWrite: 2,
+      totalTokens: 50,
+      totalCost: 6,
+      inputCost: 1,
+      outputCost: 3,
+      cacheReadCost: 1,
+      cacheWriteCost: 1,
+      missingCostEntries: 3,
+      missingCostByModel: { "fixture/unpriced": 3 },
     });
-    mergeUsageLatency(totals, {
-      count: 2,
-      avgMs: 50,
-      minMs: 20,
-      maxMs: 90,
-      p95Ms: 80,
+    expect(aggregates.sessionCount).toBe(2);
+    expect(aggregates.longestSessionDurationMs).toBe(900);
+    expect(aggregates.messages).toEqual({
+      total: 5,
+      user: 2,
+      assistant: 3,
+      toolCalls: 5,
+      toolResults: 3,
+      errors: 1,
     });
-
-    expect(totals).toEqual({
-      count: 3,
-      sum: 200,
-      min: 20,
-      max: 100,
-      p95Max: 100,
+    expect(aggregates.tools).toEqual({
+      totalCalls: 5,
+      uniqueTools: 2,
+      tools: [
+        { name: "read", count: 4 },
+        { name: "write", count: 1 },
+      ],
     });
+    expect(aggregates.byAgent.map(({ agentId, totals }) => [agentId, totals.totalTokens])).toEqual([
+      ["second", 7],
+      ["first", 13],
+    ]);
+    expect(aggregates.byChannel.map(({ channel }) => channel)).toEqual(["telegram", "discord"]);
+    expect([first, second]).toEqual(original);
   });
 
-  it("merges daily latency by date and computes aggregate tail sorting", () => {
-    const dailyLatencyMap = new Map<
-      string,
-      {
-        date: string;
-        count: number;
-        sum: number;
-        min: number;
-        max: number;
-        p95Max: number;
-      }
-    >();
-
-    mergeUsageDailyLatency(dailyLatencyMap, [
-      { date: "2026-03-12", count: 2, avgMs: 50, minMs: 20, maxMs: 90, p95Ms: 80 },
-      { date: "2026-03-12", count: 1, avgMs: 120, minMs: 120, maxMs: 120, p95Ms: 120 },
-      { date: "2026-03-11", count: 1, avgMs: 30, minMs: 30, maxMs: 30, p95Ms: 30 },
+  it("merges models and providers by identity and ranks equal costs by token usage", () => {
+    const accumulator = createUsageAggregateAccumulator();
+    for (const [provider, model, tokens] of [
+      ["fixture", "bedrock::arn", 10],
+      ["fixture::bedrock", "arn", 20],
+      ["fixture", "bedrock::arn", 15],
+    ] as const) {
+      accumulator.add({
+        usage: usage({
+          modelUsage: [{ provider, model, count: 1, totals: usage({ totalTokens: tokens }) }],
+          dailyModelUsage: [{ date: "2026-03-12", provider, model, tokens, cost: 0, count: 1 }],
+        }),
+      });
+    }
+    const aggregates = accumulator.finish();
+    expect(aggregates.byModel).toMatchObject([
+      { provider: "fixture", model: "bedrock::arn", count: 2, totals: { totalTokens: 25 } },
+      { provider: "fixture::bedrock", model: "arn", count: 1, totals: { totalTokens: 20 } },
     ]);
-    mergeUsageDailyLatency(dailyLatencyMap, null);
-
-    const tail = buildUsageAggregateTail({
-      byChannelMap: new Map([
-        ["discord", { totalCost: 4 }],
-        ["telegram", { totalCost: 8 }],
-      ]),
-      latencyTotals: {
-        count: 3,
-        sum: 200,
-        min: 20,
-        max: 120,
-        p95Max: 120,
+    expect(aggregates.byProvider).toMatchObject([
+      { provider: "fixture", model: undefined, count: 2, totals: { totalTokens: 25 } },
+      { provider: "fixture::bedrock", model: undefined, count: 1, totals: { totalTokens: 20 } },
+    ]);
+    expect(aggregates.modelDaily).toEqual([
+      {
+        date: "2026-03-12",
+        provider: "fixture",
+        model: "bedrock::arn",
+        tokens: 25,
+        cost: 0,
+        count: 2,
       },
-      dailyLatencyMap,
-      modelDailyMap: new Map([
-        ["b", { date: "2026-03-12", cost: 1 }],
-        ["a", { date: "2026-03-12", cost: 2 }],
-        ["c", { date: "2026-03-11", cost: 9 }],
-      ]),
-      dailyMap: new Map([
-        ["b", { date: "2026-03-12" }],
-        ["a", { date: "2026-03-11" }],
-      ]),
-    });
+      {
+        date: "2026-03-12",
+        provider: "fixture::bedrock",
+        model: "arn",
+        tokens: 20,
+        cost: 0,
+        count: 1,
+      },
+    ]);
+  });
 
-    expect(tail.byChannel.map((entry) => entry.channel)).toEqual(["telegram", "discord"]);
-    expect(tail.latency).toEqual({
+  it("merges overlapping daily buckets and uses weighted latency summaries", () => {
+    const accumulator = createUsageAggregateAccumulator();
+    const earlier = "2026-03-11";
+    const later = "2026-03-12";
+    const quick = { count: 2, avgMs: 50, minMs: 20, maxMs: 90, p95Ms: 80 };
+    const slow = { count: 1, avgMs: 120, minMs: 120, maxMs: 120, p95Ms: 120 };
+    accumulator.add({
+      usage: usage({
+        latency: quick,
+        dailyLatency: [{ date: later, ...quick }],
+        dailyBreakdown: [
+          { date: later, tokens: 3, cost: 4 },
+          { date: earlier, tokens: 5, cost: 6 },
+        ],
+        dailyModelUsage: [
+          { date: later, provider: "fixture", model: "one", tokens: 3, cost: 4, count: 2 },
+        ],
+      }),
+    });
+    accumulator.add({
+      usage: usage({
+        latency: slow,
+        dailyLatency: [
+          { date: later, ...slow },
+          { date: earlier, ...slow },
+        ],
+        dailyBreakdown: [{ date: later, tokens: 7, cost: 8 }],
+        dailyMessageCounts: [
+          { date: later, total: 9, user: 5, assistant: 4, toolCalls: 2, toolResults: 2, errors: 1 },
+        ],
+        dailyModelUsage: [
+          { date: later, provider: "fixture", model: "two", tokens: 7, cost: 8, count: 1 },
+          { date: earlier, provider: "fixture", model: "one", tokens: 5, cost: 6, count: 1 },
+        ],
+      }),
+    });
+    const aggregates = accumulator.finish();
+    expect(aggregates.latency).toEqual({
       count: 3,
-      avgMs: 200 / 3,
+      avgMs: 220 / 3,
       minMs: 20,
       maxMs: 120,
       p95Ms: 120,
     });
-    expect(tail.dailyLatency).toEqual([
-      { date: "2026-03-11", count: 1, avgMs: 30, minMs: 30, maxMs: 30, p95Ms: 30 },
-      { date: "2026-03-12", count: 3, avgMs: 220 / 3, minMs: 20, maxMs: 120, p95Ms: 120 },
+    expect(aggregates.dailyLatency).toEqual([
+      { date: earlier, ...slow },
+      { date: later, count: 3, avgMs: 220 / 3, minMs: 20, maxMs: 120, p95Ms: 120 },
     ]);
-    expect(tail.modelDaily).toEqual([
-      { date: "2026-03-11", cost: 9 },
-      { date: "2026-03-12", cost: 2 },
-      { date: "2026-03-12", cost: 1 },
+    expect(aggregates.daily).toEqual([
+      { date: earlier, tokens: 5, cost: 6, messages: 0, toolCalls: 0, errors: 0 },
+      { date: later, tokens: 10, cost: 12, messages: 9, toolCalls: 2, errors: 1 },
     ]);
-    expect(tail.daily).toEqual([{ date: "2026-03-11" }, { date: "2026-03-12" }]);
+    expect(aggregates.modelDaily?.map(({ date, model }) => [date, model])).toEqual([
+      [earlier, "one"],
+      [later, "two"],
+      [later, "one"],
+    ]);
   });
 
-  it("omits latency when no requests were counted", () => {
-    const tail = buildUsageAggregateTail({
-      byChannelMap: new Map(),
-      latencyTotals: {
-        count: 0,
-        sum: 0,
-        min: Number.POSITIVE_INFINITY,
-        max: 0,
-        p95Max: 0,
-      },
-      dailyLatencyMap: new Map(),
-      modelDailyMap: new Map(),
-      dailyMap: new Map(),
+  it("keeps empty reports and zero-count latency free of nonfinite values", () => {
+    const accumulator = createUsageAggregateAccumulator();
+    accumulator.add({ usage: null });
+    expect(accumulator.finish()).toEqual({
+      sessionCount: 0,
+      messages: { total: 0, user: 0, assistant: 0, toolCalls: 0, toolResults: 0, errors: 0 },
+      tools: { totalCalls: 0, uniqueTools: 0, tools: [] },
+      byModel: [],
+      byProvider: [],
+      byAgent: [],
+      byChannel: [],
+      latency: undefined,
+      dailyLatency: [],
+      modelDaily: [],
+      daily: [],
     });
-
-    expect(tail.latency).toBeUndefined();
-    expect(tail.dailyLatency).toStrictEqual([]);
-  });
-
-  it("normalizes zero-count daily latency entries to zero averages and mins", () => {
-    const dailyLatencyMap = new Map([
-      [
-        "2026-03-12",
-        {
-          date: "2026-03-12",
-          count: 0,
-          sum: 0,
-          min: Number.POSITIVE_INFINITY,
-          max: 0,
-          p95Max: 0,
-        },
-      ],
-    ]);
-
-    const tail = buildUsageAggregateTail({
-      byChannelMap: new Map(),
-      latencyTotals: {
-        count: 0,
-        sum: 0,
-        min: Number.POSITIVE_INFINITY,
-        max: 0,
-        p95Max: 0,
-      },
-      dailyLatencyMap,
-      modelDailyMap: new Map(),
-      dailyMap: new Map(),
+    accumulator.add({
+      usage: usage({
+        latency: { count: 0, avgMs: 999, minMs: 1, maxMs: 999, p95Ms: 999 },
+        dailyLatency: [
+          {
+            date: "2026-03-12",
+            count: 0,
+            avgMs: 0,
+            minMs: Number.POSITIVE_INFINITY,
+            maxMs: 0,
+            p95Ms: 0,
+          },
+        ],
+      }),
     });
-
-    expect(tail.dailyLatency).toEqual([
+    const aggregates = accumulator.finish();
+    expect(aggregates.latency).toBeUndefined();
+    expect(aggregates.dailyLatency).toEqual([
       { date: "2026-03-12", count: 0, avgMs: 0, minMs: 0, maxMs: 0, p95Ms: 0 },
     ]);
   });

--- a/src/shared/usage-aggregates.ts
+++ b/src/shared/usage-aggregates.ts
@@ -1,34 +1,22 @@
-// Usage aggregate helpers accumulate token, cost, and latency usage totals.
-type LatencyTotalsLike = {
+import {
+  addCostUsageTotals,
+  createEmptyCostUsageTotals,
+} from "../infra/session-cost-usage-totals.js";
+import type {
+  CostUsageTotals,
+  SessionDailyModelUsage,
+  SessionLatencyStats,
+  SessionModelUsage,
+} from "../infra/session-cost-usage.types.js";
+import type { SessionUsageEntry, SessionsUsageAggregates } from "./usage-types.js";
+
+type LatencyAccumulator = {
   count: number;
   sum: number;
   min: number;
   max: number;
   p95Max: number;
 };
-
-type DailyLatencyLike = {
-  date: string;
-  count: number;
-  sum: number;
-  min: number;
-  max: number;
-  p95Max: number;
-};
-
-type DailyLike = {
-  date: string;
-};
-
-type LatencyLike = {
-  count: number;
-  avgMs: number;
-  minMs: number;
-  maxMs: number;
-  p95Ms: number;
-};
-
-type DailyLatencyInput = LatencyLike & { date: string };
 
 /** Builds a collision-free identity while preserving legacy missing-as-unknown grouping. */
 export function usageModelIdentity(provider?: string, model?: string): string {
@@ -40,85 +28,192 @@ export function usageDailyModelIdentity(date: string, provider?: string, model?:
   return JSON.stringify([date, provider ?? "unknown", model ?? "unknown"]);
 }
 
-/** Merges latency summaries by keeping weighted averages as sum/count accumulator state. */
-export function mergeUsageLatency(
-  totals: LatencyTotalsLike,
-  latency: LatencyLike | undefined,
+function createLatencyAccumulator(): LatencyAccumulator {
+  return { count: 0, sum: 0, min: Number.POSITIVE_INFINITY, max: 0, p95Max: 0 };
+}
+
+// Session summaries carry no raw samples: weight averages by count and retain the largest p95.
+function mergeLatency(target: LatencyAccumulator, source: SessionLatencyStats): void {
+  target.count += source.count;
+  target.sum += source.avgMs * source.count;
+  target.min = Math.min(target.min, source.minMs);
+  target.max = Math.max(target.max, source.maxMs);
+  target.p95Max = Math.max(target.p95Max, source.p95Ms);
+}
+
+function summarizeLatency(value: LatencyAccumulator): SessionLatencyStats {
+  return {
+    count: value.count,
+    avgMs: value.count ? value.sum / value.count : 0,
+    // Empty daily buckets must not expose the sentinel used for min comparisons.
+    minMs: value.min === Number.POSITIVE_INFINITY ? 0 : value.min,
+    maxMs: value.max,
+    p95Ms: value.p95Max,
+  };
+}
+
+function mergeModelUsage(
+  map: Map<string, SessionModelUsage>,
+  key: string,
+  entry: SessionModelUsage,
 ): void {
-  if (!latency || latency.count <= 0) {
+  const existing = map.get(key) ?? {
+    provider: entry.provider,
+    model: entry.model,
+    count: 0,
+    totals: createEmptyCostUsageTotals(),
+  };
+  existing.count += entry.count;
+  addCostUsageTotals(existing.totals, entry.totals);
+  map.set(key, existing);
+}
+
+function mergeGroupedTotals(
+  map: Map<string, CostUsageTotals>,
+  key: string | undefined,
+  usage: CostUsageTotals,
+): void {
+  if (!key) {
     return;
   }
-  totals.count += latency.count;
-  totals.sum += latency.avgMs * latency.count;
-  totals.min = Math.min(totals.min, latency.minMs);
-  totals.max = Math.max(totals.max, latency.maxMs);
-  totals.p95Max = Math.max(totals.p95Max, latency.p95Ms);
+  const totals = map.get(key) ?? createEmptyCostUsageTotals();
+  addCostUsageTotals(totals, usage);
+  map.set(key, totals);
 }
 
-/** Groups daily latency summaries by date while preserving weighted averages for output. */
-export function mergeUsageDailyLatency(
-  dailyLatencyMap: Map<string, DailyLatencyLike>,
-  dailyLatency?: DailyLatencyInput[] | null,
-): void {
-  for (const day of dailyLatency ?? []) {
-    const existing = dailyLatencyMap.get(day.date) ?? {
-      date: day.date,
-      count: 0,
-      sum: 0,
-      min: Number.POSITIVE_INFINITY,
-      max: 0,
-      p95Max: 0,
-    };
-    existing.count += day.count;
-    existing.sum += day.avgMs * day.count;
-    existing.min = Math.min(existing.min, day.minMs);
-    existing.max = Math.max(existing.max, day.maxMs);
-    existing.p95Max = Math.max(existing.p95Max, day.p95Ms);
-    dailyLatencyMap.set(day.date, existing);
+function compareModelUsage(left: SessionModelUsage, right: SessionModelUsage): number {
+  return (
+    right.totals.totalCost - left.totals.totalCost ||
+    right.totals.totalTokens - left.totals.totalTokens
+  );
+}
+
+/** Shared accounting for gateway-wide results and filtered Control UI session rows. */
+export function createUsageAggregateAccumulator() {
+  const totals = createEmptyCostUsageTotals();
+  const messages = { total: 0, user: 0, assistant: 0, toolCalls: 0, toolResults: 0, errors: 0 };
+  const tools = new Map<string, number>();
+  const models = new Map<string, SessionModelUsage>();
+  const providers = new Map<string, SessionModelUsage>();
+  const agents = new Map<string, CostUsageTotals>();
+  const channels = new Map<string, CostUsageTotals>();
+  const days = new Map<string, SessionsUsageAggregates["daily"][number]>();
+  const dailyLatency = new Map<string, LatencyAccumulator>();
+  const dailyModels = new Map<string, SessionDailyModelUsage>();
+  const latency = createLatencyAccumulator();
+  let sessionCount = 0;
+  let longestSessionDurationMs = 0;
+
+  function getDay(date: string) {
+    let day = days.get(date);
+    if (!day) {
+      day = { date, tokens: 0, cost: 0, messages: 0, toolCalls: 0, errors: 0 };
+      days.set(date, day);
+    }
+    return day;
   }
-}
 
-/** Builds deterministic usage aggregate arrays for API responses and UI rendering. */
-export function buildUsageAggregateTail<
-  TTotals extends { totalCost: number },
-  TDaily extends DailyLike,
-  TModelDaily extends { date: string; cost: number },
->(params: {
-  byChannelMap: Map<string, TTotals>;
-  latencyTotals: LatencyTotalsLike;
-  dailyLatencyMap: Map<string, DailyLatencyLike>;
-  modelDailyMap: Map<string, TModelDaily>;
-  dailyMap: Map<string, TDaily>;
-}) {
-  return {
-    byChannel: Array.from(params.byChannelMap.entries())
-      .map(([channel, totals]) => ({ channel, totals }))
-      .toSorted((a, b) => b.totals.totalCost - a.totals.totalCost),
-    latency:
-      params.latencyTotals.count > 0
-        ? {
-            count: params.latencyTotals.count,
-            avgMs: params.latencyTotals.sum / params.latencyTotals.count,
-            // Empty aggregates keep Infinity internally so later real samples win min comparisons.
-            minMs:
-              params.latencyTotals.min === Number.POSITIVE_INFINITY ? 0 : params.latencyTotals.min,
-            maxMs: params.latencyTotals.max,
-            p95Ms: params.latencyTotals.p95Max,
-          }
-        : undefined,
-    dailyLatency: Array.from(params.dailyLatencyMap.values())
-      .map((entry) => ({
-        date: entry.date,
-        count: entry.count,
-        avgMs: entry.count ? entry.sum / entry.count : 0,
-        minMs: entry.min === Number.POSITIVE_INFINITY ? 0 : entry.min,
-        maxMs: entry.max,
-        p95Ms: entry.p95Max,
-      }))
-      .toSorted((a, b) => a.date.localeCompare(b.date)),
-    modelDaily: Array.from(params.modelDailyMap.values()).toSorted(
-      (a, b) => a.date.localeCompare(b.date) || b.cost - a.cost,
-    ),
-    daily: Array.from(params.dailyMap.values()).toSorted((a, b) => a.date.localeCompare(b.date)),
-  };
+  function add({
+    usage,
+    agentId,
+    channel,
+  }: Pick<SessionUsageEntry, "usage" | "agentId" | "channel">) {
+    if (!usage) {
+      return;
+    }
+    addCostUsageTotals(totals, usage);
+    longestSessionDurationMs = Math.max(longestSessionDurationMs, usage.durationMs ?? 0);
+    // Discovery can include recently modified transcripts with no activity in the requested range.
+    if (usage.firstActivity !== undefined || (usage.messageCounts?.total ?? 0) > 0) {
+      sessionCount += 1;
+    }
+    if (usage.messageCounts) {
+      messages.total += usage.messageCounts.total;
+      messages.user += usage.messageCounts.user;
+      messages.assistant += usage.messageCounts.assistant;
+      messages.toolCalls += usage.messageCounts.toolCalls;
+      messages.toolResults += usage.messageCounts.toolResults;
+      messages.errors += usage.messageCounts.errors;
+    }
+    for (const tool of usage.toolUsage?.tools ?? []) {
+      tools.set(tool.name, (tools.get(tool.name) ?? 0) + tool.count);
+    }
+    for (const entry of usage.modelUsage ?? []) {
+      mergeModelUsage(models, usageModelIdentity(entry.provider, entry.model), entry);
+      mergeModelUsage(providers, entry.provider ?? "unknown", { ...entry, model: undefined });
+    }
+    mergeGroupedTotals(agents, agentId, usage);
+    mergeGroupedTotals(channels, channel, usage);
+    if (usage.latency && usage.latency.count > 0) {
+      mergeLatency(latency, usage.latency);
+    }
+    for (const day of usage.dailyLatency ?? []) {
+      const existing = dailyLatency.get(day.date) ?? createLatencyAccumulator();
+      mergeLatency(existing, day);
+      dailyLatency.set(day.date, existing);
+    }
+    for (const day of usage.dailyBreakdown ?? []) {
+      const existing = getDay(day.date);
+      existing.tokens += day.tokens;
+      existing.cost += day.cost;
+    }
+    for (const day of usage.dailyMessageCounts ?? []) {
+      const existing = getDay(day.date);
+      existing.messages += day.total;
+      existing.toolCalls += day.toolCalls;
+      existing.errors += day.errors;
+    }
+    for (const day of usage.dailyModelUsage ?? []) {
+      const key = usageDailyModelIdentity(day.date, day.provider, day.model);
+      const existing = dailyModels.get(key) ?? {
+        date: day.date,
+        provider: day.provider,
+        model: day.model,
+        tokens: 0,
+        cost: 0,
+        count: 0,
+      };
+      existing.tokens += day.tokens;
+      existing.cost += day.cost;
+      existing.count += day.count;
+      dailyModels.set(key, existing);
+    }
+  }
+
+  function finish(): SessionsUsageAggregates {
+    const toolEntries = Array.from(tools, ([name, count]) => ({ name, count })).toSorted(
+      (a, b) => b.count - a.count,
+    );
+    return {
+      sessionCount,
+      ...(longestSessionDurationMs > 0 ? { longestSessionDurationMs } : {}),
+      messages,
+      tools: {
+        totalCalls: toolEntries.reduce((sum, { count }) => sum + count, 0),
+        uniqueTools: tools.size,
+        tools: toolEntries,
+      },
+      byModel: Array.from(models.values()).toSorted(compareModelUsage),
+      byProvider: Array.from(providers.values()).toSorted(compareModelUsage),
+      byAgent: Array.from(agents, ([agentId, groupTotals]) => ({
+        agentId,
+        totals: groupTotals,
+      })).toSorted((a, b) => b.totals.totalCost - a.totals.totalCost),
+      byChannel: Array.from(channels, ([channel, groupTotals]) => ({
+        channel,
+        totals: groupTotals,
+      })).toSorted((a, b) => b.totals.totalCost - a.totals.totalCost),
+      latency: latency.count > 0 ? summarizeLatency(latency) : undefined,
+      dailyLatency: Array.from(dailyLatency, ([date, value]) => ({
+        date,
+        ...summarizeLatency(value),
+      })).toSorted((a, b) => a.date.localeCompare(b.date)),
+      modelDaily: Array.from(dailyModels.values()).toSorted(
+        (a, b) => a.date.localeCompare(b.date) || b.cost - a.cost,
+      ),
+      daily: Array.from(days.values()).toSorted((a, b) => a.date.localeCompare(b.date)),
+    };
+  }
+
+  return { totals, add, finish };
 }

--- a/src/shared/usage-types.ts
+++ b/src/shared/usage-types.ts
@@ -9,7 +9,7 @@ import type {
   SessionMessageCounts,
   SessionModelUsage,
   SessionToolUsage,
-} from "../infra/session-cost-usage.js";
+} from "../infra/session-cost-usage.types.js";
 
 /** One session or session-family row returned by the gateway usage endpoint. */
 export type SessionUsageEntry = {

--- a/ui/src/e2e/usage-sessions-owner-attribution.e2e.test.ts
+++ b/ui/src/e2e/usage-sessions-owner-attribution.e2e.test.ts
@@ -4,7 +4,6 @@ import type { Page } from "playwright";
 import { expect, it } from "vitest";
 import { createOpenClawTestState } from "../../../src/test-utils/openclaw-test-state.ts";
 import { getFreePort } from "../../../src/test-utils/ports.ts";
-import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
@@ -38,123 +37,155 @@ async function capture(page: Page, name: string) {
 }
 
 suite.define(() => {
-  it("attributes the Telegram DM session card to its store owner when another agent has the same sessionId", async () => {
-    const port = await getFreePort();
-    const state = await createOpenClawTestState({
-      label: "usage-sessions-owner-attribution",
-      env: {
-        OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
-        OPENCLAW_SKIP_CANVAS_HOST: "1",
-        OPENCLAW_SKIP_CHANNELS: "1",
-        OPENCLAW_SKIP_CRON: "1",
-        OPENCLAW_SKIP_GMAIL_WATCHER: "1",
-        OPENCLAW_SKIP_PROVIDERS: "1",
-        OPENCLAW_TEST_MINIMAL_GATEWAY: "1",
-        VITEST: "1",
-      },
-    });
-
-    const { startGatewayServer } = await import("../../../src/gateway/server.js");
-    const { persistSessionTranscriptTurn, upsertSessionEntryCore } =
-      await import("../../../src/config/sessions/session-accessor.js");
-
-    let gateway: Awaited<ReturnType<typeof startGatewayServer>> | null = null;
-
-    try {
-      await state.writeConfig({
-        agents: {
-          defaults: { workspace: state.workspaceDir },
-          list: [
-            { id: "main", default: true, workspace: state.workspaceDir },
-            { id: "opus", workspace: state.workspaceDir },
-          ],
-        },
-        gateway: {
-          mode: "local",
-          port,
-          bind: "loopback",
-          auth: { mode: "none" },
-          controlUi: { enabled: false },
-        },
-        plugins: { enabled: false },
-        session: {
-          store: path.join(state.stateDir, "agents", "{agentId}", "sessions", "sessions.json"),
+  it.each([false, true])(
+    "keeps same-id owners separate with an empty current session: %s",
+    async (resetCurrentSession) => {
+      const port = await getFreePort();
+      const state = await createOpenClawTestState({
+        label: "usage-sessions-owner-attribution",
+        env: {
+          OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+          OPENCLAW_SKIP_CANVAS_HOST: "1",
+          OPENCLAW_SKIP_CHANNELS: "1",
+          OPENCLAW_SKIP_CRON: "1",
+          OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+          OPENCLAW_SKIP_PROVIDERS: "1",
+          OPENCLAW_TEST_MINIMAL_GATEWAY: "1",
+          VITEST: "1",
         },
       });
 
-      for (const agentId of ["main", "opus"]) {
-        const scope = {
-          agentId,
-          sessionId: PROOF_SESSION_ID,
-          sessionKey: agentId === "main" ? PROOF_STORE_KEY : `agent:opus:${PROOF_SESSION_ID}`,
-          storePath: path.join(state.sessionsDir(agentId), "sessions.json"),
-        };
-        const now = Date.now();
-        if (agentId === "main") {
-          await upsertSessionEntryCore(scope, {
+      const { startGatewayServer } = await import("../../../src/gateway/server.js");
+      const { persistSessionTranscriptTurn, upsertSessionEntryCore } =
+        await import("../../../src/config/sessions/session-accessor.js");
+
+      let gateway: Awaited<ReturnType<typeof startGatewayServer>> | null = null;
+
+      try {
+        await state.writeConfig({
+          agents: {
+            ownership: "explicit",
+            defaults: { workspace: state.workspaceDir },
+            entries: {
+              main: { workspace: state.workspaceDir },
+              opus: { workspace: state.workspaceDir },
+            },
+          },
+          gateway: {
+            mode: "local",
+            port,
+            bind: "loopback",
+            auth: { mode: "none" },
+            controlUi: { enabled: false },
+          },
+          plugins: { enabled: false },
+          session: {
+            store: path.join(state.stateDir, "agents", "{agentId}", "sessions", "sessions.json"),
+          },
+        });
+
+        for (const agentId of ["main", "opus"]) {
+          const scope = {
+            agentId,
             sessionId: PROOF_SESSION_ID,
-            label: PROOF_LABEL,
-            updatedAt: now,
+            sessionKey: agentId === "main" ? PROOF_STORE_KEY : `agent:opus:${PROOF_SESSION_ID}`,
+            storePath: path.join(state.sessionsDir(agentId), "sessions.json"),
+          };
+          const now = Date.now();
+          if (agentId === "main") {
+            await upsertSessionEntryCore(scope, {
+              sessionId: PROOF_SESSION_ID,
+              label: PROOF_LABEL,
+              updatedAt: now,
+            });
+          }
+          // Both transcripts must fall inside the dashboard's current date window.
+          await persistSessionTranscriptTurn(scope, {
+            cwd: state.workspaceDir,
+            updateMode: "none",
+            messages: [
+              { message: { role: "user", content: `${agentId} turn`, timestamp: now }, now },
+            ],
           });
         }
-        // Both transcripts must fall inside the dashboard's current date window.
-        await persistSessionTranscriptTurn(scope, {
-          cwd: state.workspaceDir,
-          updateMode: "none",
-          messages: [
-            { message: { role: "user", content: `${agentId} turn`, timestamp: now }, now },
-          ],
+
+        if (resetCurrentSession) {
+          await upsertSessionEntryCore(
+            {
+              agentId: "main",
+              sessionKey: PROOF_STORE_KEY,
+              storePath: path.join(state.sessionsDir("main"), "sessions.json"),
+            },
+            {
+              sessionId: "empty-current-session",
+              label: PROOF_LABEL,
+              updatedAt: Date.now(),
+            },
+          );
+        }
+
+        gateway = await startGatewayServer(port, {
+          auth: { mode: "none" },
+          bind: "loopback",
+          controlUiEnabled: false,
+          sidecarStartup: "defer",
         });
+
+        await suite.withPage(
+          {
+            locale: "en-US",
+            serviceWorkers: "block",
+            viewport,
+          },
+          async ({ page }) => {
+            const pageErrors: string[] = [];
+            page.on("pageerror", (error) => pageErrors.push(String(error)));
+
+            const url = new URL("usage", suite.server.baseUrl);
+            url.searchParams.set("gatewayUrl", `ws://127.0.0.1:${port}`);
+            await page.goto(url.toString());
+            const confirmation = page.locator("openclaw-gateway-url-confirmation");
+            await confirmation.waitFor();
+            await confirmation.getByRole("button", { name: "Confirm", exact: true }).click();
+
+            const otherRow = page.locator(
+              `.session-bar-row[title="agent:opus:${PROOF_SESSION_ID}"]`,
+            );
+            // A rendered usage row proves the handshake and requested report both arrived.
+            await otherRow.waitFor();
+            await expect.poll(() => otherRow.count()).toBe(1);
+            await otherRow.scrollIntoViewIfNeeded();
+            await capture(
+              page,
+              resetCurrentSession ? "02-empty-current-family.png" : "01-same-id-owners.png",
+            );
+
+            // The named family stays visible before its new current instance has a transcript.
+            const row = page.locator(`.session-bar-row[title="${PROOF_STORE_KEY}"]`);
+            await row.waitFor();
+            await expect.poll(() => row.count()).toBe(1);
+            const meta = row.locator(".session-bar-meta");
+            await expect.poll(async () => (await meta.textContent()) ?? "").toContain("agent:main");
+            await expect
+              .poll(async () => (await meta.textContent()) ?? "")
+              .not.toContain("agent:opus");
+            await expect
+              .poll(() => otherRow.locator(".session-bar-meta").textContent())
+              .toContain("agent:opus");
+            await expect.poll(() => page.locator(".session-bar-row").count()).toBe(2);
+
+            await row.scrollIntoViewIfNeeded();
+            await capture(
+              page,
+              resetCurrentSession ? "02-empty-current-family.png" : "01-same-id-owners.png",
+            );
+            expect(pageErrors).toEqual([]);
+          },
+        );
+      } finally {
+        await gateway?.close({ reason: "usage sessions owner attribution e2e cleanup" });
+        await state.cleanup();
       }
-
-      gateway = await startGatewayServer(port, {
-        auth: { mode: "none" },
-        bind: "loopback",
-        controlUiEnabled: false,
-        sidecarStartup: "defer",
-      });
-
-      await suite.withPage(
-        {
-          locale: "en-US",
-          serviceWorkers: "block",
-          viewport,
-        },
-        async ({ page }) => {
-          const pageErrors: string[] = [];
-          page.on("pageerror", (error) => pageErrors.push(String(error)));
-
-          const url = new URL("usage", suite.server.baseUrl);
-          url.searchParams.set("gatewayUrl", `ws://127.0.0.1:${port}`);
-          await page.goto(url.toString());
-          const confirmation = page.locator("openclaw-gateway-url-confirmation");
-          await confirmation.waitFor();
-          await confirmation.getByRole("button", { name: "Confirm", exact: true }).click();
-          await waitForControlUiGatewayReady(page);
-
-          // The Telegram DM row must exist, exactly once, attributed to main.
-          const row = page.locator(`.session-bar-row[title="${PROOF_STORE_KEY}"]`);
-          await row.waitFor();
-          await expect.poll(() => row.count()).toBe(1);
-          const meta = row.locator(".session-bar-meta");
-          await expect.poll(async () => (await meta.textContent()) ?? "").toContain("agent:main");
-          await expect
-            .poll(async () => (await meta.textContent()) ?? "")
-            .not.toContain("agent:opus");
-          const otherRow = page.locator(`.session-bar-row[title="agent:opus:${PROOF_SESSION_ID}"]`);
-          await expect.poll(() => otherRow.count()).toBe(1);
-          await expect
-            .poll(() => otherRow.locator(".session-bar-meta").textContent())
-            .toContain("agent:opus");
-          await expect.poll(() => page.locator(".session-bar-row").count()).toBe(2);
-
-          await capture(page, "01-telegram-dm-owner-attribution-main.png");
-          expect(pageErrors).toEqual([]);
-        },
-      );
-    } finally {
-      await gateway?.close({ reason: "usage sessions owner attribution e2e cleanup" });
-      await state.cleanup();
-    }
-  });
+    },
+  );
 });

--- a/ui/src/pages/usage/metrics.test.ts
+++ b/ui/src/pages/usage/metrics.test.ts
@@ -125,6 +125,50 @@ describe("usage aggregate model identity", () => {
       { provider: "fixture:bedrock", model: "arn" },
     ]);
   });
+
+  it("preserves missing-cost attribution and token ranking when filtering sessions", () => {
+    const session = (agentId: string, model: string, tokens: number): UsageSessionEntry => {
+      const totals = {
+        input: tokens,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: tokens,
+        totalCost: 0,
+        inputCost: 0,
+        outputCost: 0,
+        cacheReadCost: 0,
+        cacheWriteCost: 0,
+        missingCostEntries: 1,
+        missingCostByModel: { [`fixture/${model}`]: 1 },
+      };
+      return {
+        key: `agent:${agentId}:session`,
+        agentId,
+        channel: "webchat",
+        usage: { ...totals, modelUsage: [{ provider: "fixture", model, count: 1, totals }] },
+      };
+    };
+
+    const aggregates = buildAggregatesFromSessions([
+      session("first", "small", 10),
+      session("second", "large", 100),
+    ]);
+
+    expect(aggregates.byProvider[0]?.totals.missingCostByModel).toEqual({
+      "fixture/small": 1,
+      "fixture/large": 1,
+    });
+    expect(aggregates.byAgent.map(({ totals }) => totals.missingCostByModel)).toEqual([
+      { "fixture/small": 1 },
+      { "fixture/large": 1 },
+    ]);
+    expect(aggregates.byChannel[0]?.totals.missingCostByModel).toEqual({
+      "fixture/small": 1,
+      "fixture/large": 1,
+    });
+    expect(aggregates.byModel.map(({ model }) => model)).toEqual(["large", "small"]);
+  });
 });
 
 describe("buildPeakErrorHours", () => {

--- a/ui/src/pages/usage/metrics.ts
+++ b/ui/src/pages/usage/metrics.ts
@@ -2,12 +2,10 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 // Control UI view renders usage metrics screen content.
 import { html } from "lit";
 import {
-  buildUsageAggregateTail,
-  mergeUsageDailyLatency,
-  mergeUsageLatency,
-  usageDailyModelIdentity,
-  usageModelIdentity,
-} from "../../../../src/shared/usage-aggregates.js";
+  addCostUsageTotals,
+  createEmptyCostUsageTotals,
+} from "../../../../src/infra/session-cost-usage-totals.js";
+import { createUsageAggregateAccumulator } from "../../../../src/shared/usage-aggregates.js";
 import { renderSettingsSection } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
 import { formatCompactTokenCount } from "../../lib/format.ts";
@@ -529,34 +527,6 @@ function formatFullDate(dateStr: string): string {
   return date.toLocaleDateString(undefined, { month: "long", day: "numeric", year: "numeric" });
 }
 
-const emptyUsageTotals = (): UsageTotals => ({
-  input: 0,
-  output: 0,
-  cacheRead: 0,
-  cacheWrite: 0,
-  totalTokens: 0,
-  totalCost: 0,
-  inputCost: 0,
-  outputCost: 0,
-  cacheReadCost: 0,
-  cacheWriteCost: 0,
-  missingCostEntries: 0,
-});
-
-const mergeUsageTotals = (target: UsageTotals, source: Partial<UsageTotals>) => {
-  target.input += source.input ?? 0;
-  target.output += source.output ?? 0;
-  target.cacheRead += source.cacheRead ?? 0;
-  target.cacheWrite += source.cacheWrite ?? 0;
-  target.totalTokens += source.totalTokens ?? 0;
-  target.totalCost += source.totalCost ?? 0;
-  target.inputCost += source.inputCost ?? 0;
-  target.outputCost += source.outputCost ?? 0;
-  target.cacheReadCost += source.cacheReadCost ?? 0;
-  target.cacheWriteCost += source.cacheWriteCost ?? 0;
-  target.missingCostEntries += source.missingCostEntries ?? 0;
-};
-
 function buildUsageCostWindowSummary(
   daily: Array<UsageTotals & { date: string }>,
   startDate: string,
@@ -568,11 +538,11 @@ function buildUsageCostWindowSummary(
     return null;
   }
 
-  const totals = emptyUsageTotals();
+  const totals = createEmptyCostUsageTotals();
   for (const entry of daily) {
     const day = parseIsoDayIndex(entry.date);
     if (day !== null && day >= startDay && day <= endDay) {
-      mergeUsageTotals(totals, entry);
+      addCostUsageTotals(totals, entry);
     }
   }
 
@@ -625,171 +595,11 @@ const buildAggregatesFromSessions = (
     );
   }
 
-  const messages = { total: 0, user: 0, assistant: 0, toolCalls: 0, toolResults: 0, errors: 0 };
-  const toolMap = new Map<string, number>();
-  const modelMap = new Map<
-    string,
-    { provider?: string; model?: string; count: number; totals: UsageTotals }
-  >();
-  const providerMap = new Map<
-    string,
-    { provider?: string; model?: string; count: number; totals: UsageTotals }
-  >();
-  const agentMap = new Map<string, UsageTotals>();
-  const channelMap = new Map<string, UsageTotals>();
-  const dailyMap = new Map<
-    string,
-    {
-      date: string;
-      tokens: number;
-      cost: number;
-      messages: number;
-      toolCalls: number;
-      errors: number;
-    }
-  >();
-  const dailyLatencyMap = new Map<
-    string,
-    { date: string; count: number; sum: number; min: number; max: number; p95Max: number }
-  >();
-  const modelDailyMap = new Map<
-    string,
-    { date: string; provider?: string; model?: string; tokens: number; cost: number; count: number }
-  >();
-  const latencyTotals = { count: 0, sum: 0, min: Number.POSITIVE_INFINITY, max: 0, p95Max: 0 };
-
+  const accumulator = createUsageAggregateAccumulator();
   for (const session of sessions) {
-    const usage = session.usage;
-    if (!usage) {
-      continue;
-    }
-    if (usage.messageCounts) {
-      messages.total += usage.messageCounts.total;
-      messages.user += usage.messageCounts.user;
-      messages.assistant += usage.messageCounts.assistant;
-      messages.toolCalls += usage.messageCounts.toolCalls;
-      messages.toolResults += usage.messageCounts.toolResults;
-      messages.errors += usage.messageCounts.errors;
-    }
-
-    if (usage.toolUsage) {
-      for (const tool of usage.toolUsage.tools) {
-        toolMap.set(tool.name, (toolMap.get(tool.name) ?? 0) + tool.count);
-      }
-    }
-
-    if (usage.modelUsage) {
-      for (const entry of usage.modelUsage) {
-        const modelKey = usageModelIdentity(entry.provider, entry.model);
-        const modelExisting = modelMap.get(modelKey) ?? {
-          provider: entry.provider,
-          model: entry.model,
-          count: 0,
-          totals: emptyUsageTotals(),
-        };
-        modelExisting.count += entry.count;
-        mergeUsageTotals(modelExisting.totals, entry.totals);
-        modelMap.set(modelKey, modelExisting);
-
-        const providerKey = entry.provider ?? "unknown";
-        const providerExisting = providerMap.get(providerKey) ?? {
-          provider: entry.provider,
-          model: undefined,
-          count: 0,
-          totals: emptyUsageTotals(),
-        };
-        providerExisting.count += entry.count;
-        mergeUsageTotals(providerExisting.totals, entry.totals);
-        providerMap.set(providerKey, providerExisting);
-      }
-    }
-
-    mergeUsageLatency(latencyTotals, usage.latency);
-
-    if (session.agentId) {
-      const totals = agentMap.get(session.agentId) ?? emptyUsageTotals();
-      mergeUsageTotals(totals, usage);
-      agentMap.set(session.agentId, totals);
-    }
-    if (session.channel) {
-      const totals = channelMap.get(session.channel) ?? emptyUsageTotals();
-      mergeUsageTotals(totals, usage);
-      channelMap.set(session.channel, totals);
-    }
-
-    for (const day of usage.dailyBreakdown ?? []) {
-      const daily = dailyMap.get(day.date) ?? {
-        date: day.date,
-        tokens: 0,
-        cost: 0,
-        messages: 0,
-        toolCalls: 0,
-        errors: 0,
-      };
-      daily.tokens += day.tokens;
-      daily.cost += day.cost;
-      dailyMap.set(day.date, daily);
-    }
-    for (const day of usage.dailyMessageCounts ?? []) {
-      const daily = dailyMap.get(day.date) ?? {
-        date: day.date,
-        tokens: 0,
-        cost: 0,
-        messages: 0,
-        toolCalls: 0,
-        errors: 0,
-      };
-      daily.messages += day.total;
-      daily.toolCalls += day.toolCalls;
-      daily.errors += day.errors;
-      dailyMap.set(day.date, daily);
-    }
-    mergeUsageDailyLatency(dailyLatencyMap, usage.dailyLatency);
-    for (const day of usage.dailyModelUsage ?? []) {
-      const key = usageDailyModelIdentity(day.date, day.provider, day.model);
-      const existing = modelDailyMap.get(key) ?? {
-        date: day.date,
-        provider: day.provider,
-        model: day.model,
-        tokens: 0,
-        cost: 0,
-        count: 0,
-      };
-      existing.tokens += day.tokens;
-      existing.cost += day.cost;
-      existing.count += day.count;
-      modelDailyMap.set(key, existing);
-    }
+    accumulator.add(session);
   }
-
-  const tail = buildUsageAggregateTail({
-    byChannelMap: channelMap,
-    latencyTotals,
-    dailyLatencyMap,
-    modelDailyMap,
-    dailyMap,
-  });
-
-  return {
-    messages,
-    tools: {
-      totalCalls: Array.from(toolMap.values()).reduce((sum, count) => sum + count, 0),
-      uniqueTools: toolMap.size,
-      tools: Array.from(toolMap.entries())
-        .map(([name, count]) => ({ name, count }))
-        .toSorted((a, b) => b.count - a.count),
-    },
-    byModel: Array.from(modelMap.values()).toSorted(
-      (a, b) => b.totals.totalCost - a.totals.totalCost,
-    ),
-    byProvider: Array.from(providerMap.values()).toSorted(
-      (a, b) => b.totals.totalCost - a.totals.totalCost,
-    ),
-    byAgent: Array.from(agentMap.entries())
-      .map(([agentId, totals]) => ({ agentId, totals }))
-      .toSorted((a, b) => b.totals.totalCost - a.totals.totalCost),
-    ...tail,
-  };
+  return accumulator.finish();
 };
 
 type UsageInsightStats = {
@@ -873,4 +683,3 @@ export {
   renderUsageMosaic,
   sessionTouchesSelectedHours,
 };
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/ui/src/pages/usage/view.test.ts
+++ b/ui/src/pages/usage/view.test.ts
@@ -3,12 +3,18 @@
 import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
 import { buildAggregatesFromSessions } from "./metrics.ts";
+import * as usageQuery from "./query.ts";
 import type { UsageProps, UsageSessionEntry, UsageTotals } from "./types.ts";
 import { renderUsage } from "./view.ts";
 
 const noop = vi.fn();
 
-function usageSession(key: string, agentId: string, provider: string): UsageSessionEntry {
+function usageSession(
+  key: string,
+  agentId: string,
+  provider: string,
+  totalsOverrides: Partial<UsageTotals> = {},
+): UsageSessionEntry {
   const totals: UsageTotals = {
     input: 100,
     output: 20,
@@ -21,6 +27,7 @@ function usageSession(key: string, agentId: string, provider: string): UsageSess
     cacheReadCost: 0,
     cacheWriteCost: 0,
     missingCostEntries: 0,
+    ...totalsOverrides,
   };
   return {
     key,
@@ -294,6 +301,47 @@ describe("renderUsage", () => {
     expect(providers?.textContent).toContain("No provider data");
     expect(providers?.textContent).not.toContain("openai");
   });
+
+  it.each(["session", "day"] as const)(
+    "preserves missing-cost attribution in %s-filtered JSON exports",
+    (filter) => {
+      const base = createUsageProps();
+      const missing = { missingCostEntries: 2, missingCostByModel: { "fixture/unpriced": 2 } };
+      const session = usageSession("agent:main:priced", "main", "fixture", missing);
+      const totals = session.usage;
+      if (!totals) {
+        throw new Error("usage session fixture must include totals");
+      }
+      const download = vi.spyOn(usageQuery, "downloadTextFile").mockImplementation(() => {});
+      try {
+        const container = document.createElement("div");
+        render(
+          renderUsage(
+            createUsageProps({
+              data: {
+                ...base.data,
+                sessions: [session],
+                costDaily: [{ ...totals, date: "2026-05-14" }],
+              },
+              filters: {
+                ...base.filters,
+                selectedSessions: filter === "session" ? [session.key] : [],
+                selectedDays: filter === "day" ? ["2026-05-14"] : [],
+              },
+            }),
+          ),
+          container,
+        );
+        container
+          .querySelector(".usage-export-menu")
+          ?.dispatchEvent(new CustomEvent("wa-select", { detail: { item: { value: "json" } } }));
+        expect(download).toHaveBeenCalledOnce();
+        expect(JSON.parse(download.mock.calls[0]?.[1] ?? "{}")).toMatchObject({ totals: missing });
+      } finally {
+        download.mockRestore();
+      }
+    },
+  );
 
   it("keeps selected session labels on UTF-16 boundaries", () => {
     const container = document.createElement("div");

--- a/ui/src/pages/usage/view.ts
+++ b/ui/src/pages/usage/view.ts
@@ -1,5 +1,9 @@
 // Control UI view renders usage screen content.
 import { html, nothing } from "lit";
+import {
+  addCostUsageTotals,
+  createEmptyCostUsageTotals,
+} from "../../../../src/infra/session-cost-usage-totals.js";
 import { renderProviderUsageDetails } from "../../components/provider-usage.ts";
 import { renderSettingsPage, renderSettingsSection } from "../../components/settings-ui.ts";
 import "../../components/tooltip.ts";
@@ -41,52 +45,6 @@ import {
   renderSessionsCard,
   renderUsageInsights,
 } from "./view-overview.ts";
-
-function createEmptyUsageTotals(): UsageTotals {
-  return {
-    input: 0,
-    output: 0,
-    cacheRead: 0,
-    cacheWrite: 0,
-    totalTokens: 0,
-    totalCost: 0,
-    inputCost: 0,
-    outputCost: 0,
-    cacheReadCost: 0,
-    cacheWriteCost: 0,
-    missingCostEntries: 0,
-  };
-}
-
-function addUsageTotals(
-  acc: UsageTotals,
-  usage: {
-    input: number;
-    output: number;
-    cacheRead: number;
-    cacheWrite: number;
-    totalTokens: number;
-    totalCost: number;
-    inputCost?: number;
-    outputCost?: number;
-    cacheReadCost?: number;
-    cacheWriteCost?: number;
-    missingCostEntries?: number;
-  },
-): UsageTotals {
-  acc.input += usage.input;
-  acc.output += usage.output;
-  acc.cacheRead += usage.cacheRead;
-  acc.cacheWrite += usage.cacheWrite;
-  acc.totalTokens += usage.totalTokens;
-  acc.totalCost += usage.totalCost;
-  acc.inputCost += usage.inputCost ?? 0;
-  acc.outputCost += usage.outputCost ?? 0;
-  acc.cacheReadCost += usage.cacheReadCost ?? 0;
-  acc.cacheWriteCost += usage.cacheWriteCost ?? 0;
-  acc.missingCostEntries += usage.missingCostEntries ?? 0;
-  return acc;
-}
 
 function renderUsageLoadingStatus(label: unknown, title?: string) {
   return html`
@@ -293,16 +251,24 @@ export function renderUsage(props: UsageProps) {
 
   // Compute totals from sessions
   const computeSessionTotals = (sessions: UsageSessionEntry[]): UsageTotals => {
-    return sessions.reduce(
-      (acc, s) => (s.usage ? addUsageTotals(acc, s.usage) : acc),
-      createEmptyUsageTotals(),
-    );
+    const totals = createEmptyCostUsageTotals();
+    for (const session of sessions) {
+      if (session.usage) {
+        addCostUsageTotals(totals, session.usage);
+      }
+    }
+    return totals;
   };
 
   // Compute totals from daily data for selected days (more accurate than session totals)
   const computeDailyTotals = (days: ReadonlySet<string>): UsageTotals => {
-    const matchingDays = data.costDaily.filter((d) => days.has(d.date));
-    return matchingDays.reduce((acc, day) => addUsageTotals(acc, day), createEmptyUsageTotals());
+    const totals = createEmptyCostUsageTotals();
+    for (const day of data.costDaily) {
+      if (days.has(day.date)) {
+        addCostUsageTotals(totals, day);
+      }
+    }
+    return totals;
   };
 
   // Compute display totals and count based on filters
@@ -917,5 +883,4 @@ export function renderUsage(props: UsageProps) {
   );
 }
 
-// Exposed for Playwright/Vitest browser unit tests.
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
Follow-up to #128803 (preserving agent ownership for matching session IDs).

## What Problem This Solves

Fixes an issue where the Usage page loses a session's historical usage immediately after reset, before the new instance has a transcript. The same accounting flow also had drift between aggregate totals, filtered UI exports, and conversation details: fleet configuration changes could reuse old totals, filtered results dropped missing-price attribution, and detail logs could disagree with the canonical pricing rules.

## Why This Change Was Made

Session selection now owns the agent-scoped current/history join and passes selected instances to batched loading. Historical discovery selects its recorded canonical family even when its current transcript is empty. Each instance is assigned once: a direct current owner takes precedence over historical references, and unresolved historical aliases remain independent instances. Discovery supplies the actual SQLite or retained JSONL source to loading; storage is not guessed from the current instance. Independent agents with identical session IDs remain independent. No lineage is inferred beyond the stored family IDs.

The Gateway and Control UI now share one pure accumulator and canonical total arithmetic. Conversation logs reuse the same token, timestamp, and price parser as summaries and charts. Calendar resolution, bounded result caching, session selection, and batched loading have separate owners; the old duplicate paths and two oversized-file exemptions are removed. Both result caches require configuration identity.

No configuration options, protocol shape, database schema, persistence semantics, dependencies, or provider runtime behavior change. Existing file-backed transcript artifacts remain readable. Equal-cost model/provider rows now use the Gateway's token-count tie-breaker consistently in filtered UI results.

## User Impact

Historical lineage remains visible after reset. Fleet changes invalidate aggregate cost results. Filtering and JSON exports retain which models have missing prices. Detail logs agree with summary pricing, including tiered rates, unknown pricing, and explicitly provider-billed zero cost.

Real-state regressions retain 30 historical tokens plus 100 from another agent reusing an ID. A retained direct run owns its 10 tokens separately, leaving 20 in the reset family and 130 overall; mixed JSONL/SQLite history also retains all 130.

## Evidence

Before-fix reproductions on the pinned Vitest 4.1.11 fail at the actual boundaries: stale fleet totals; three missing-price UI aggregate/export assertions; four log-pricing cases; and a real SQLite reset family omitted from the Gateway response. Candidate tests cover the same cases, sibling archive behavior, cache refresh/eviction, aliases, date/time-zone boundaries, weighted latency, and pre-limit aggregates.

Validation: 99 Gateway usage tests, 73 accounting/pricing tests, and 58 Control UI tests passed (230 total). The full build and Control UI asset/performance gates passed before the final family-source adjustments; those adjustments passed the Gateway selection tests and type checks. Exact-head CI validates the final build before merge. Independent Codex review is clean (no actionable P0–P2 findings); repository changed checks, final Gateway type checks, and formatting passed. Initial CI run33155908560 caught two type-import cycles and a test file two lines over its cap. The follow-up removes the import cycles at their type owners and deletes obsolete fixture setup, with no exemptions. Both failed checks pass locally, all50 affected tests pass, and the repair also has clean independent review. Run33156849140 then identified six unused type re-exports left in the former barrel; those are removed. Production/full-tree/script unused-export scans and core typecheck now pass, with another clean independent review of that type-only deletion.

Real Gateway + Chromium proof ran on Blacksmith Testbox `tbx_01m13nb58x9hbrfedxjwnytnvb` ([workflow lease](https://github.com/openclaw/openclaw/actions/runs/33152724369)). The original baseline `bccb649077f086a4935c8f2473b7a72656f1d5a1` fails the reset case because the named row is absent. The usage behavior candidate passes both owner/reset cases (2/2); the reset case completed in 1.85 seconds. The lease was stopped after proof. Local browser attempts stalled during startup under shared host load; the clean Testbox run used the normal timeouts, without relaxing assertions. This exercises a real Gateway and browser with synthetic stored transcripts, not a live model or Telegram account.

| Before: reset hides the named family | After: both owners remain visible |
| --- | --- |
| ![Baseline missing the named session](https://github.com/user-attachments/assets/613b2230-69da-45f3-9b07-829c107f0f9b) | ![Candidate retaining the named session](https://github.com/user-attachments/assets/8a8d530e-68fe-483e-b28f-49e014f433c9) |

Usage behavior candidate browser recording: the reset case passed on Testbox `tbx_01m13qm07s8bqv13qmyk4vydxv` ([workflow lease](https://github.com/openclaw/openclaw/actions/runs/33155330886)). Recording adds only Playwright `recordVideo` to the existing test context; assertions and product source are unchanged. The first recording attempt lacked Playwright FFmpeg; installing that recorder dependency on the disposable box fixed the setup failure. The video was inspected before upload, and the lease was stopped.

https://github.com/user-attachments/assets/744138b2-d887-462d-86c5-f0d06759bf57

Production: 266 fewer lines after accounting for the extracted modules; tests: +571 lines; tooling/docs: -2 lines. The 1,640-line handler is now 388 lines. No oversized-file baseline is increased; two exemptions are removed.

<details>
<summary>Focused proof commands</summary>

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/server-methods/usage.sessions-usage-owner-attribution.integration.test.ts src/gateway/server-methods/usage.sessions-usage.test.ts src/gateway/server-methods/usage.sessions-usage-owner-attribution.test.ts src/gateway/server-methods/usage.sessions-usage-cache.test.ts src/gateway/server-methods/usage.cost-usage-cache.test.ts src/gateway/server-methods/usage.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/usage-sessions-owner-attribution.e2e.test.ts
pnpm build
```

The browser command ran through the repository Crabbox wrapper on the Testbox above. Regression tests were demonstrated failing before each owner-boundary repair, not only added after the fix.
</details>

The separate conflicting-scope request validation issue #125268 already has PR #125269; this follow-up does not duplicate that RPC contract change.

CI run [33157421585](https://github.com/openclaw/openclaw/actions/runs/33157421585) passed every lane except the unchanged Chat disclosure scrolling test, which timed out on both attempts. Current main had already fixed that same test race in #131622 by binding deferred recovery to a still-mounted row. This branch was rebased onto `4ec40f190d4580dad0c5d4dc5d111400ef12a60c` to reuse that landed fix; `git range-diff` confirms all three usage commits are patch-identical. Final head `878b2f0a036ed1579f5c0989977e818523ea5706` receives fresh CI. The screenshots/video above precede the mechanical type cleanup and rebase; final-head CI supplies the refreshed build and browser gates.

Refreshed real-flow proof on head `878b2f0a036ed1579f5c0989977e818523ea5706`: [the hosted Gateway/Chromium job](https://github.com/openclaw/openclaw/actions/runs/33159536134/job/98810523033) passed both owner/reset cases, 2/2, in 25.96 seconds total; the empty-current reset case itself took 2.04 seconds. This addresses the latest ClawSweeper Rank-up request for after-fix proof. Its attempt expired while waiting 30 seconds for terminal output and showed only Vitest startup, without a failing product assertion. The completed hosted run and inspected Testbox recording provide the missing terminal and browser evidence. The inherited Chat disclosure shard also passes on this head.

The latest ClawSweeper re-review on this exact head failed before either case ran: `/usr/bin/chromium-browser` aborted during `browserType.launch` (SIGABRT; both cases skipped). That is browser setup failure, not a failed usage assertion. The final-head hosted Gateway/Chromium job linked above completed both cases successfully, and the inspected recording remains attached. This supplies the requested real-flow evidence without weakening the product tests or treating the failed sandbox run as a pass.
