### PR TITLE
fix(whatsapp): retain unmatched attachments across captioned replacement

### DIFF
--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -410,6 +410,7 @@ When the linked self number is also present in `allowFrom`, self-chat safeguards
     - `gifPlayback: true` on video sends enables animated GIF playback
     - `forceDocument`/`asDocument` routes outbound images, GIFs, and videos through the Baileys document payload to avoid WhatsApp's media compression, preserving the resolved filename and MIME type
     - captions apply to the first media item in a multi-media reply, except PTT voice notes: the audio sends first with no caption, then the caption sends as a separate text message (WhatsApp clients do not render voice-note captions consistently)
+    - when a later captioned reply repeats pending attachments, only attachments accepted by WhatsApp replace their pending copies; unmatched attachments remain queued for delivery
     - media source can be HTTP(S), `file://`, or a local path
 
   </Accordion>

--- a/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
@@ -626,7 +626,8 @@ describe("deliverWebReply", () => {
   });
 
   it("falls back to text-only when the first media send fails", async () => {
-    const { msg, params } = createImageDelivery("caption", { textLimit: 20 });
+    const onMediaAccepted = vi.fn();
+    const { msg, params } = createImageDelivery("caption", { textLimit: 20, onMediaAccepted });
     vi.mocked(msg.platform.sendMedia).mockRejectedValueOnce(new Error("boom"));
 
     await deliverWebReply(params);
@@ -640,6 +641,7 @@ describe("deliverWebReply", () => {
       "replyLogger.warn",
     );
     expect(warnContext.mediaUrl).toBe("http://example.com/img.jpg");
+    expect(onMediaAccepted).not.toHaveBeenCalled();
   });
 
   it("delivers the opening text chunk when the first media fails on a multi-chunk reply", async () => {
@@ -778,10 +780,11 @@ describe("deliverWebReply", () => {
 
   it("preserves accepted voice receipts without false media fallback after caption rejection", async () => {
     hoisted.recordChannelActivity.mockClear();
-    const { msg, params } = createDelivery({
-      text: "caption",
-      mediaUrl: "http://example.com/accepted-voice.ogg",
-    });
+    const onMediaAccepted = vi.fn();
+    const { msg, params } = createDelivery(
+      { text: "caption", mediaUrl: "http://example.com/accepted-voice.ogg" },
+      { onMediaAccepted },
+    );
     mockLoadedMedia("aud", "audio/ogg", "audio");
     vi.mocked(msg.platform.sendMedia).mockImplementationOnce(async () =>
       normalizeWhatsAppSendResult(
@@ -808,6 +811,9 @@ describe("deliverWebReply", () => {
     expect(msg.platform.sendMedia).toHaveBeenCalledOnce();
     expect(msg.platform.reply).toHaveBeenCalledOnce();
     expect(msg.platform.reply).toHaveBeenCalledWith("caption", undefined);
+    expect(onMediaAccepted).toHaveBeenCalledExactlyOnceWith(
+      "http://example.com/accepted-voice.ogg",
+    );
     expect(hoisted.recordChannelActivity).toHaveBeenCalledOnce();
     expect(hoisted.recordChannelActivity).toHaveBeenCalledWith({
       channel: "whatsapp",
@@ -833,10 +839,11 @@ describe("deliverWebReply", () => {
       },
       defaultAccountId: "work",
     });
-    const { msg, params } = createDelivery({
-      text: "caption",
-      mediaUrl: "http://example.com/nested-voice.ogg",
-    });
+    const onMediaAccepted = vi.fn();
+    const { msg, params } = createDelivery(
+      { text: "caption", mediaUrl: "http://example.com/nested-voice.ogg" },
+      { onMediaAccepted },
+    );
     mockLoadedMedia("aud", "audio/ogg", "audio");
     vi.mocked(msg.platform.sendMedia).mockImplementationOnce(async () =>
       sendApi.sendMessage("+1555", "", Buffer.from("aud"), "audio/ogg"),
@@ -854,6 +861,7 @@ describe("deliverWebReply", () => {
     expect(msg.platform.sendMedia).toHaveBeenCalledOnce();
     expect(msg.platform.reply).not.toHaveBeenCalled();
     expect(replyLogger.warn).not.toHaveBeenCalled();
+    expect(onMediaAccepted).toHaveBeenCalledExactlyOnceWith("http://example.com/nested-voice.ogg");
     expect(hoisted.recordChannelActivity).toHaveBeenCalledExactlyOnceWith({
       channel: "whatsapp",
       accountId: "work",

--- a/extensions/whatsapp/src/auto-reply/deliver-reply.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.ts
@@ -136,6 +136,7 @@ type WhatsAppReplyDeliveryParams = {
   connectionId?: string;
   skipLog?: boolean;
   tableMode?: MarkdownTableMode;
+  onMediaAccepted?: (mediaUrl: string) => void;
 };
 
 export async function deliverWebReply(
@@ -153,6 +154,11 @@ async function deliverWebReplyInActivityScope(
   const isGroupConversation = transport.conversationKind === "group";
   const replyStarted = Date.now();
   const sendResults: WhatsAppSendResult[] = [];
+  const acceptedMediaUrls = new Set<string>();
+  const recordMediaAccepted = (mediaUrl: string) => {
+    acceptedMediaUrls.add(mediaUrl);
+    params.onMediaAccepted?.(mediaUrl);
+  };
   const finishDelivery = (): WhatsAppReplyDeliveryResult => {
     const receipt = createWhatsAppReplyDeliveryReceipt(sendResults);
     return {
@@ -161,14 +167,21 @@ async function deliverWebReplyInActivityScope(
       providerAccepted: sendResults.some((result) => result.providerAccepted),
     };
   };
-  const preserveAcceptedDeliveryError = (error: unknown, kind?: WhatsAppSendKind) => {
+  const preserveAcceptedDeliveryError = (
+    error: unknown,
+    kind?: WhatsAppSendKind,
+    mediaUrl?: string,
+  ) => {
     const sendKind = kind ?? sendResults[0]?.kind ?? "text";
     if (isChannelPartialDeliveryError(error)) {
-      rememberWhatsAppPartialSend({
+      const accepted = rememberWhatsAppPartialSend({
         error,
         kind: sendKind,
         results: sendResults,
       });
+      if (accepted && mediaUrl) {
+        recordMediaAccepted(mediaUrl);
+      }
     }
     return mergeWhatsAppAcceptedSendError({
       error,
@@ -176,7 +189,7 @@ async function deliverWebReplyInActivityScope(
       results: sendResults,
     });
   };
-  const rememberSendResult = (result: WhatsAppSendResult | undefined) => {
+  const rememberSendResult = (result: WhatsAppSendResult | undefined, mediaUrl?: string) => {
     if (!result) {
       return;
     }
@@ -191,6 +204,11 @@ async function deliverWebReplyInActivityScope(
         throw preserveAcceptedDeliveryError(error, result.kind);
       }
       throw error;
+    } finally {
+      // The owner appends the validated result before activity bookkeeping can throw.
+      if (mediaUrl && sendResults.includes(result)) {
+        recordMediaAccepted(mediaUrl);
+      }
     }
   };
   if (isReasoningReplyPayload(replyResult)) {
@@ -233,7 +251,12 @@ async function deliverWebReplyInActivityScope(
     });
   };
 
-  const sendWithRetry = async <T>(fn: () => Promise<T>, label: string, kind: WhatsAppSendKind) => {
+  const sendWithRetry = async <T>(
+    fn: () => Promise<T>,
+    label: string,
+    kind: WhatsAppSendKind,
+    mediaUrl?: string,
+  ) => {
     try {
       return await sendWhatsAppOutboundWithRetry({
         send: fn,
@@ -248,7 +271,7 @@ async function deliverWebReplyInActivityScope(
         isChannelPartialDeliveryError(error) ||
         sendResults.some((result) => result.providerAccepted)
       ) {
-        throw preserveAcceptedDeliveryError(error, kind);
+        throw preserveAcceptedDeliveryError(error, kind, mediaUrl);
       }
       throw error;
     }
@@ -292,14 +315,10 @@ async function deliverWebReplyInActivityScope(
 
   // Media (with optional caption on first item)
   const leadingCaption = remainingText.shift() || "";
-  let acceptedIdsBeforeCurrentMedia = new Set<string>();
   await sendMediaWithLeadingCaption({
     mediaUrls: mediaList,
     caption: leadingCaption,
     send: async ({ mediaUrl, caption }) => {
-      acceptedIdsBeforeCurrentMedia = new Set(
-        sendResults.flatMap(listWhatsAppSendResultMessageIds),
-      );
       const media = await prepareWhatsAppOutboundMedia(
         await loadWebMedia(mediaUrl, {
           maxBytes: maxMediaBytes,
@@ -313,79 +332,27 @@ async function deliverWebReplyInActivityScope(
         );
         logVerbose(`Web auto-reply media source: ${mediaUrl} (kind ${media.kind})`);
       }
-      if (media.kind === "image") {
-        const quote = getQuote();
+      const quote = getQuote();
+      const mediaContent =
+        media.kind === "image"
+          ? { image: media.buffer, caption }
+          : media.kind === "audio"
+            ? { audio: media.buffer, ptt: true }
+            : media.kind === "video"
+              ? { video: media.buffer, caption }
+              : { document: media.buffer, fileName: media.fileName, caption };
+      rememberSendResult(
+        await sendWithRetry(
+          () => transport.sendMedia({ ...mediaContent, mimetype: media.mimetype }, quote),
+          `media:${media.kind}`,
+          "media",
+          mediaUrl,
+        ),
+        mediaUrl,
+      );
+      if (media.kind === "audio" && caption) {
         rememberSendResult(
-          await sendWithRetry(
-            () =>
-              transport.sendMedia(
-                {
-                  image: media.buffer,
-                  caption,
-                  mimetype: media.mimetype,
-                },
-                quote,
-              ),
-            "media:image",
-            "media",
-          ),
-        );
-      } else if (media.kind === "audio") {
-        const quote = getQuote();
-        rememberSendResult(
-          await sendWithRetry(
-            () =>
-              transport.sendMedia(
-                {
-                  audio: media.buffer,
-                  ptt: true,
-                  mimetype: media.mimetype,
-                },
-                quote,
-              ),
-            "media:audio",
-            "media",
-          ),
-        );
-        if (caption) {
-          rememberSendResult(
-            await sendWithRetry(() => transport.reply(caption, quote), "media:audio-text", "text"),
-          );
-        }
-      } else if (media.kind === "video") {
-        const quote = getQuote();
-        rememberSendResult(
-          await sendWithRetry(
-            () =>
-              transport.sendMedia(
-                {
-                  video: media.buffer,
-                  caption,
-                  mimetype: media.mimetype,
-                },
-                quote,
-              ),
-            "media:video",
-            "media",
-          ),
-        );
-      } else {
-        const quote = getQuote();
-        rememberSendResult(
-          await sendWithRetry(
-            () =>
-              transport.sendMedia(
-                {
-                  document: media.buffer,
-                  fileName: media.fileName,
-                  caption,
-                  mimetype: media.mimetype,
-                },
-                quote,
-              ),
-            "media:document",
-            "media",
-          ),
+          await sendWithRetry(() => transport.reply(caption, quote), "media:audio-text", "text"),
         );
       }
       whatsappOutboundLog.info(
@@ -407,12 +374,7 @@ async function deliverWebReplyInActivityScope(
       );
     },
     onError: async ({ error, mediaUrl, caption, isFirst }) => {
-      const currentMediaWasAccepted = sendResults.some((result) =>
-        listWhatsAppSendResultMessageIds(result).some(
-          (messageId) => !acceptedIdsBeforeCurrentMedia.has(messageId),
-        ),
-      );
-      if (currentMediaWasAccepted) {
+      if (acceptedMediaUrls.has(mediaUrl)) {
         // Earlier accepted uploads do not make a genuinely rejected trailing upload successful.
         throw preserveAcceptedDeliveryError(error);
       }

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.message-sent.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.message-sent.test.ts
@@ -144,6 +144,7 @@ function createPlan(
 async function dispatchObservedPlatformReply(params: {
   payload: { text: string; mediaUrls?: string[] };
   platform: Pick<AdmittedWebInboundMessage["platform"], "reply" | "sendMedia">;
+  deferredMediaUrls?: string[];
 }) {
   const pluginHook = vi.fn();
   const internalHook = vi.fn();
@@ -157,11 +158,31 @@ async function dispatchObservedPlatformReply(params: {
   initializeGlobalHookRunner(registry);
   registerInternalHook("message:sent", internalHook);
   const { context, plan, replyLogger } = createPlan(deliverWebReply, params.platform);
+  const onDelivered = vi.fn(plan.delivery.onDelivered);
   let deliveryResult: unknown;
+  let settledResult: unknown;
   const dispatchReplyWithBufferedBlockDispatcher = vi.fn(async (dispatch) => {
     dispatch.replyOptions?.onAgentRunStart?.("run-wa-partial");
-    deliveryResult = await dispatch.dispatcherOptions.deliver(params.payload, { kind: "final" });
-    return { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } };
+    if (params.deferredMediaUrls) {
+      const deferred = await dispatch.dispatcherOptions.deliver(
+        { text: "tool images", mediaUrls: params.deferredMediaUrls },
+        { kind: "tool" },
+      );
+      expect(deferred).toMatchObject({
+        visibleReplySent: false,
+        finalization: expect.any(Promise),
+      });
+      expect(onDelivered).not.toHaveBeenCalled();
+    }
+    try {
+      deliveryResult = await dispatch.dispatcherOptions.deliver(params.payload, { kind: "final" });
+    } finally {
+      settledResult = await dispatch.dispatcherOptions.onSettled?.();
+    }
+    return {
+      queuedFinal: true,
+      counts: { tool: params.deferredMediaUrls ? 1 : 0, block: 0, final: 1 },
+    };
   });
   const failure = await dispatchChannelInboundReply({
     cfg: { channels: { whatsapp: {} } } as never,
@@ -174,11 +195,19 @@ async function dispatchObservedPlatformReply(params: {
     recordInboundSession: async () => undefined,
     dispatchReplyWithBufferedBlockDispatcher,
     dispatcherOptions: plan.dispatcherOptions,
-    delivery: plan.delivery,
+    delivery: { ...plan.delivery, onDelivered },
     replyOptions: plan.replyOptions,
     replyResolver: plan.replyResolver,
   }).catch((caught: unknown) => caught);
-  return { deliveryResult, failure, internalHook, pluginHook, replyLogger };
+  return {
+    deliveryResult,
+    failure,
+    internalHook,
+    pluginHook,
+    replyLogger,
+    onDelivered,
+    settledResult,
+  };
 }
 
 afterEach(() => {
@@ -187,6 +216,96 @@ afterEach(() => {
 });
 
 describe("WhatsApp canonical message_sent delivery", () => {
+  it.each([
+    {
+      replacement: ["/tmp/a.jpg"],
+      sent: ["/tmp/a.jpg", "/tmp/b.jpg"],
+      deferredIds: ["sent-2"],
+      replacementId: "sent-1",
+    },
+    {
+      replacement: ["/tmp/a.jpg", "/tmp/b.jpg"],
+      sent: ["/tmp/a.jpg", "/tmp/b.jpg"],
+      deferredIds: [],
+      replacementId: "sent-1",
+    },
+    {
+      replacement: ["/tmp/c.jpg"],
+      sent: ["/tmp/a.jpg", "/tmp/b.jpg", "/tmp/c.jpg"],
+      deferredIds: ["sent-1", "sent-2"],
+      replacementId: "sent-3",
+    },
+    {
+      deferredMedia: ["/tmp/a.jpg", "/tmp/b.jpg", "/tmp/c.jpg"],
+      replacement: ["/tmp/b.jpg"],
+      sent: ["/tmp/b.jpg", "/tmp/a.jpg", "/tmp/c.jpg"],
+      deferredIds: ["sent-2", "sent-3"],
+      replacementId: "sent-1",
+    },
+  ])(
+    "finalizes every deferred attachment through core after replacement $replacement",
+    async ({
+      replacement,
+      sent: expectedSent,
+      deferredIds,
+      replacementId,
+      deferredMedia = ["/tmp/a.jpg", "/tmp/b.jpg"],
+    }) => {
+      const sent: string[] = [];
+      vi.mocked(loadWebMedia).mockImplementation(async (url) => ({
+        buffer: Buffer.from(url),
+        contentType: "image/jpeg",
+        kind: "image",
+      }));
+      const sendMedia = vi.fn<AdmittedWebInboundMessage["platform"]["sendMedia"]>(
+        async (content) => {
+          if (!("image" in content) || !Buffer.isBuffer(content.image)) {
+            throw new Error("expected image transport payload");
+          }
+          sent.push(content.image.toString());
+          return normalizeWhatsAppSendResult(
+            { key: { id: `sent-${sent.length}` } } as WAMessage,
+            "media",
+          );
+        },
+      );
+      const reply = vi.fn<AdmittedWebInboundMessage["platform"]["reply"]>();
+      const { failure, pluginHook, internalHook, onDelivered, settledResult } =
+        await dispatchObservedPlatformReply({
+          payload: { text: "Here are the images", mediaUrls: replacement },
+          deferredMediaUrls: deferredMedia,
+          platform: { reply, sendMedia },
+        });
+
+      expect(failure).toMatchObject({ dispatched: true });
+      expect(sent).toEqual(expectedSent);
+      expect(reply).not.toHaveBeenCalled();
+      expect(settledResult).toEqual({ visibleReplySent: true });
+      expect(onDelivered).toHaveBeenCalledTimes(2);
+      const [, info, finalized] = onDelivered.mock.calls[1]!;
+      expect(info.kind).toBe("tool");
+      expect(finalized?.finalization).toBeUndefined();
+      if (deferredIds.length) {
+        expect(finalized).toMatchObject({
+          visibleReplySent: true,
+          content: "",
+          messageIds: deferredIds,
+          receipt: { platformMessageIds: deferredIds },
+        });
+      } else {
+        expect(finalized).toEqual({ visibleReplySent: false, finalization: undefined });
+      }
+      const observedIds = [replacementId, ...deferredIds.slice(0, 1)];
+      await vi.waitFor(() => {
+        expect(pluginHook).toHaveBeenCalledTimes(observedIds.length);
+        expect(internalHook).toHaveBeenCalledTimes(observedIds.length);
+      });
+      expect(pluginHook.mock.calls.map(([event]) => [event.messageId, event.success])).toEqual(
+        observedIds.map((id) => [id, true]),
+      );
+    },
+  );
+
   it("emits one receipt-backed event with session and run correlation for multipart media", async () => {
     const pluginHook = vi.fn();
     const internalHook = vi.fn();

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
@@ -1130,57 +1130,6 @@ describe("whatsapp inbound dispatch", () => {
     });
   });
 
-  it.each([
-    { replacement: ["/tmp/a.jpg"], expected: [["/tmp/a.jpg"], ["/tmp/b.jpg"]] },
-    { replacement: ["/tmp/a.jpg", "/tmp/b.jpg"], expected: [["/tmp/a.jpg", "/tmp/b.jpg"]] },
-    { replacement: ["/tmp/c.jpg"], expected: [["/tmp/a.jpg", "/tmp/b.jpg"], ["/tmp/c.jpg"]] },
-    {
-      deferredMedia: ["/tmp/a.jpg", "/tmp/b.jpg", "/tmp/c.jpg"],
-      replacement: ["/tmp/b.jpg"],
-      expected: [["/tmp/b.jpg"], ["/tmp/a.jpg", "/tmp/c.jpg"]],
-    },
-  ])(
-    "accounts for every deferred attachment after replacement $replacement",
-    async ({ replacement, expected, deferredMedia = ["/tmp/a.jpg", "/tmp/b.jpg"] }) => {
-      const sent: string[] = [];
-      vi.mocked(loadWebMedia).mockImplementation(async (url) => ({
-        buffer: Buffer.from(url),
-        contentType: "image/jpeg",
-        kind: "image",
-      }));
-      const sendMedia = vi.fn(async (content: Parameters<TestMsg["platform"]["sendMedia"]>[0]) => {
-        if (!("image" in content) || !Buffer.isBuffer(content.image)) {
-          throw new Error("expected image transport payload");
-        }
-        sent.push(content.image.toString());
-        return createAcceptedWhatsAppSendResult("media", `accepted-${sent.length}`);
-      });
-      const deliverReply = vi.fn(deliverWebReply);
-      await dispatchBufferedReply({ deliverReply, msg: makeMsg({ platform: { sendMedia } }) });
-      const deliver = requireCapturedDeliver(capturedDispatchParams as CapturedDispatchParams);
-      const deferred = requireRecord(
-        await deliver({ text: "tool images", mediaUrls: deferredMedia }, { kind: "tool" }),
-        "deferred batch",
-      );
-      const finalized = vi.fn();
-      void (deferred.finalization as Promise<unknown>).then(finalized);
-      expect(deliverReply).not.toHaveBeenCalled();
-      await deliver({ text: "Here are the images", mediaUrls: replacement }, { kind: "final" });
-      if (replacement.length === 1 && replacement[0] === "/tmp/a.jpg") {
-        expect(finalized).not.toHaveBeenCalled();
-      }
-      await getCapturedOnSettled()?.();
-
-      expect(deliverReply.mock.calls.map(([params]) => params.replyResult.mediaUrls)).toEqual(
-        expected,
-      );
-      expect(sent).toEqual(expected.flat());
-      await expect(deferred.finalization).resolves.toMatchObject({
-        visibleReplySent: expected.length > 1,
-      });
-    },
-  );
-
   it("drops deferred media when its captioned replacement fails after becoming visible", async () => {
     const error = Object.assign(new Error("post-send bookkeeping failed"), {
       sentBeforeError: true,

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
@@ -1,7 +1,11 @@
+import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 // Whatsapp tests cover inbound dispatch plugin behavior.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { createAcceptedWhatsAppSendResult } from "../../inbound/send-result.test-helper.js";
 import { createTestWebInboundMessage } from "../../inbound/test-message.test-helper.js";
+import { loadWebMedia } from "../../media.js";
+import { deliverWebReply } from "../deliver-reply.js";
 
 let capturedDispatchParams: unknown;
 
@@ -124,6 +128,8 @@ vi.mock("./runtime-api.js", async () => {
     shouldLogVerbose: () => false,
   };
 });
+
+vi.mock("../../media.js", () => ({ loadWebMedia: vi.fn() }));
 
 import {
   buildWhatsAppInboundTransportContext,
@@ -680,7 +686,13 @@ function requireCapturedDeliver(params: CapturedDispatchParams) {
   return deliver;
 }
 
-async function dispatchDeferredMediaReplacement(overrides: BufferedReplyOverrides): Promise<{
+async function dispatchDeferredMediaReplacement(
+  overrides: BufferedReplyOverrides,
+  media: { deferred: string[]; replacement: string[] } = {
+    deferred: DEFERRED_TOOL_MEDIA.mediaUrls,
+    replacement: CAPTIONED_MEDIA_REPLACEMENT.mediaUrls,
+  },
+): Promise<{
   finalization: Promise<unknown>;
   replacement: PromiseSettledResult<unknown>;
 }> {
@@ -691,12 +703,15 @@ async function dispatchDeferredMediaReplacement(overrides: BufferedReplyOverride
       capturedDispatchParams = params;
       const deliver = requireCapturedDeliver(params);
       const deferred = requireRecord(
-        await deliver(DEFERRED_TOOL_MEDIA, { kind: "tool" }),
+        await deliver({ ...DEFERRED_TOOL_MEDIA, mediaUrls: media.deferred }, { kind: "tool" }),
         "deferred media result",
       );
       finalization = deferred.finalization as Promise<unknown>;
       [replacement] = await Promise.allSettled([
-        deliver(CAPTIONED_MEDIA_REPLACEMENT, { kind: "block" }),
+        deliver(
+          { ...CAPTIONED_MEDIA_REPLACEMENT, mediaUrls: media.replacement },
+          { kind: "block" },
+        ),
       ]);
       await params.dispatcherOptions?.onSettled?.();
       return { queuedFinal: false, counts: { tool: 1, block: 1, final: 0 } };
@@ -1054,15 +1069,15 @@ describe("whatsapp inbound dispatch", () => {
   });
 
   it("replaces duplicate media-only interim payloads with the final captioned WhatsApp media", async () => {
-    const deliverReply = vi.fn(async () => acceptedDeliveryResult());
+    const deliverReply = vi.fn<BufferedReplyParams["deliverReply"]>(
+      async ({ replyResult, onMediaAccepted }) => {
+        replyResult.mediaUrls?.forEach((url) => onMediaAccepted?.(url));
+        return acceptedDeliveryResult();
+      },
+    );
 
-    await dispatchBufferedReply({
-      deliverReply,
-    });
-
+    await dispatchBufferedReply({ deliverReply });
     const deliver = getCapturedDeliver();
-    expect(deliver).toBeTypeOf("function");
-
     await deliver?.({ text: "tool payload" }, { kind: "tool" });
     expect(deliverReply).not.toHaveBeenCalled();
 
@@ -1093,12 +1108,12 @@ describe("whatsapp inbound dispatch", () => {
     expect(deliverReply).toHaveBeenCalledTimes(3);
   });
 
-  it("retains approved deferred media when its captioned replacement is cancelled", async () => {
+  it("retains the full approved batch when its partial replacement is cancelled", async () => {
     const deliverReply = vi.fn(async () => acceptedDeliveryResult());
-    const { finalization, replacement } = await dispatchDeferredMediaReplacement({
-      deliverReply,
-      cancelAfterPrepare: (payload) => payload.text === "captioned replacement",
-    });
+    const { finalization, replacement } = await dispatchDeferredMediaReplacement(
+      { deliverReply, cancelAfterPrepare: (payload) => payload.text === "captioned replacement" },
+      { deferred: ["/tmp/a.jpg", "/tmp/b.jpg"], replacement: ["/tmp/a.jpg"] },
+    );
 
     expect(replacement).toMatchObject({
       status: "fulfilled",
@@ -1110,17 +1125,71 @@ describe("whatsapp inbound dispatch", () => {
     await expect(finalization).resolves.toMatchObject({ visibleReplySent: true });
     expect(deliverReply).toHaveBeenCalledTimes(1);
     expectReplyResultFields(deliverReply, {
-      mediaUrls: ["/tmp/generated.jpg"],
+      mediaUrls: ["/tmp/a.jpg", "/tmp/b.jpg"],
       text: undefined,
     });
   });
+
+  it.each([
+    { replacement: ["/tmp/a.jpg"], expected: [["/tmp/a.jpg"], ["/tmp/b.jpg"]] },
+    { replacement: ["/tmp/a.jpg", "/tmp/b.jpg"], expected: [["/tmp/a.jpg", "/tmp/b.jpg"]] },
+    { replacement: ["/tmp/c.jpg"], expected: [["/tmp/a.jpg", "/tmp/b.jpg"], ["/tmp/c.jpg"]] },
+    {
+      deferredMedia: ["/tmp/a.jpg", "/tmp/b.jpg", "/tmp/c.jpg"],
+      replacement: ["/tmp/b.jpg"],
+      expected: [["/tmp/b.jpg"], ["/tmp/a.jpg", "/tmp/c.jpg"]],
+    },
+  ])(
+    "accounts for every deferred attachment after replacement $replacement",
+    async ({ replacement, expected, deferredMedia = ["/tmp/a.jpg", "/tmp/b.jpg"] }) => {
+      const sent: string[] = [];
+      vi.mocked(loadWebMedia).mockImplementation(async (url) => ({
+        buffer: Buffer.from(url),
+        contentType: "image/jpeg",
+        kind: "image",
+      }));
+      const sendMedia = vi.fn(async (content: Parameters<TestMsg["platform"]["sendMedia"]>[0]) => {
+        if (!("image" in content) || !Buffer.isBuffer(content.image)) {
+          throw new Error("expected image transport payload");
+        }
+        sent.push(content.image.toString());
+        return createAcceptedWhatsAppSendResult("media", `accepted-${sent.length}`);
+      });
+      const deliverReply = vi.fn(deliverWebReply);
+      await dispatchBufferedReply({ deliverReply, msg: makeMsg({ platform: { sendMedia } }) });
+      const deliver = requireCapturedDeliver(capturedDispatchParams as CapturedDispatchParams);
+      const deferred = requireRecord(
+        await deliver({ text: "tool images", mediaUrls: deferredMedia }, { kind: "tool" }),
+        "deferred batch",
+      );
+      const finalized = vi.fn();
+      void (deferred.finalization as Promise<unknown>).then(finalized);
+      expect(deliverReply).not.toHaveBeenCalled();
+      await deliver({ text: "Here are the images", mediaUrls: replacement }, { kind: "final" });
+      if (replacement.length === 1 && replacement[0] === "/tmp/a.jpg") {
+        expect(finalized).not.toHaveBeenCalled();
+      }
+      await getCapturedOnSettled()?.();
+
+      expect(deliverReply.mock.calls.map(([params]) => params.replyResult.mediaUrls)).toEqual(
+        expected,
+      );
+      expect(sent).toEqual(expected.flat());
+      await expect(deferred.finalization).resolves.toMatchObject({
+        visibleReplySent: expected.length > 1,
+      });
+    },
+  );
 
   it("drops deferred media when its captioned replacement fails after becoming visible", async () => {
     const error = Object.assign(new Error("post-send bookkeeping failed"), {
       sentBeforeError: true,
       visibleReplySent: true,
     });
-    const deliverReply = vi.fn().mockRejectedValueOnce(error);
+    const deliverReply = vi.fn<BufferedReplyParams["deliverReply"]>(async ({ onMediaAccepted }) => {
+      onMediaAccepted?.("/tmp/generated.jpg");
+      throw error;
+    });
     const { finalization, replacement } = await dispatchDeferredMediaReplacement({ deliverReply });
     const replacementFailure = replacement.status === "rejected" ? replacement.reason : undefined;
 
@@ -1136,6 +1205,103 @@ describe("whatsapp inbound dispatch", () => {
       visibleReplySent: true,
     });
     expect((replacementFailure as Error).cause).toBe(error);
+  });
+
+  it.each([
+    {
+      name: "first upload rejected",
+      failIndex: 0,
+      acceptedBeforeError: false,
+      expectedRemainder: ["/tmp/a.jpg"],
+    },
+    {
+      name: "trailing upload rejected",
+      failIndex: 1,
+      acceptedBeforeError: false,
+      expectedRemainder: ["/tmp/b.jpg"],
+    },
+    {
+      name: "first upload accepted before transport error",
+      failIndex: 0,
+      acceptedBeforeError: true,
+      expectedRemainder: ["/tmp/b.jpg"],
+    },
+  ])(
+    "retains only unsent attachments when $name",
+    async ({ failIndex, acceptedBeforeError, expectedRemainder }) => {
+      const sent: string[] = [];
+      let attempt = 0;
+      vi.mocked(loadWebMedia).mockImplementation(async (url) => ({
+        buffer: Buffer.from(url),
+        contentType: "image/jpeg",
+        kind: "image",
+      }));
+      const sendMedia: TestMsg["platform"]["sendMedia"] = async (content) => {
+        if (!("image" in content) || !Buffer.isBuffer(content.image)) {
+          throw new Error("expected image transport payload");
+        }
+        const url = content.image.toString();
+        if (attempt++ === failIndex) {
+          const error = new Error("upload failed");
+          if (acceptedBeforeError) {
+            sent.push(url);
+            throw createChannelPartialDeliveryError(error, {
+              visibleReplySent: true,
+              messageIds: ["accepted-before-error"],
+            });
+          }
+          throw error;
+        }
+        sent.push(url);
+        return createAcceptedWhatsAppSendResult("media", `accepted-${attempt}`);
+      };
+      const reply = vi.fn<TestMsg["platform"]["reply"]>(async () =>
+        createAcceptedWhatsAppSendResult("text", "warning"),
+      );
+      const deliverReply = vi.fn(deliverWebReply);
+      const { finalization, replacement } = await dispatchDeferredMediaReplacement(
+        { deliverReply, msg: makeMsg({ platform: { sendMedia, reply } }) },
+        { deferred: ["/tmp/a.jpg", "/tmp/b.jpg"], replacement: ["/tmp/a.jpg", "/tmp/b.jpg"] },
+      );
+
+      expect(deliverReply.mock.calls.map(([params]) => params.replyResult.mediaUrls)).toEqual([
+        ["/tmp/a.jpg", "/tmp/b.jpg"],
+        expectedRemainder,
+      ]);
+      expect(sent.toSorted()).toEqual(["/tmp/a.jpg", "/tmp/b.jpg"]);
+      await expect(finalization).resolves.toMatchObject({ visibleReplySent: true });
+      if (acceptedBeforeError) {
+        expect(replacement).toMatchObject({
+          status: "rejected",
+          reason: {
+            code: "CHANNEL_PARTIAL_DELIVERY",
+            deliveryResult: { visibleReplySent: true },
+          },
+        });
+        expect(reply).not.toHaveBeenCalled();
+      } else {
+        expect(replacement).toMatchObject({
+          status: "fulfilled",
+          value: { visibleReplySent: true },
+        });
+        expect(reply).toHaveBeenCalledOnce();
+        expect(reply.mock.calls[0]?.[0]).toContain("⚠️ Media");
+      }
+    },
+  );
+
+  it("does not defer or send a tool batch vetoed by the sending hook", async () => {
+    const deliverReply = vi.fn(async () => acceptedDeliveryResult());
+    await dispatchBufferedReply({ deliverReply, cancelAfterPrepare: () => true });
+    const deliver = requireCapturedDeliver(capturedDispatchParams as CapturedDispatchParams);
+    await expect(
+      deliver({ mediaUrls: ["/tmp/a.jpg", "/tmp/b.jpg"] }, { kind: "tool" }),
+    ).resolves.toMatchObject({
+      visibleReplySent: false,
+      suppression: { reason: "cancelled_by_message_sending_hook" },
+    });
+    await getCapturedOnSettled()?.();
+    expect(deliverReply).not.toHaveBeenCalled();
   });
 
   it("returns receipt-backed delivery facts for native text fallback", async () => {

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
@@ -15,10 +15,7 @@ import {
 } from "openclaw/plugin-sdk/channel-outbound";
 import { buildInboundHistoryFromEntries } from "openclaw/plugin-sdk/reply-history";
 import type { FinalizedMsgContext } from "openclaw/plugin-sdk/reply-runtime";
-import {
-  normalizeOptionalString,
-  normalizeStringEntries,
-} from "openclaw/plugin-sdk/string-coerce-runtime";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   requireWhatsAppInboundAdmission,
   resolveWhatsAppAdmissionChannelIngress,
@@ -237,15 +234,6 @@ function resolveWhatsAppDeliverablePayload(
   return payload;
 }
 
-function getWhatsAppPayloadMediaUrls(payload: ReplyPayload): Set<string> {
-  return new Set(
-    normalizeStringEntries([
-      ...(Array.isArray(payload.mediaUrls) ? payload.mediaUrls : []),
-      ...(typeof payload.mediaUrl === "string" ? [payload.mediaUrl] : []),
-    ]),
-  );
-}
-
 function hasWhatsAppMediaUrlOverlap(left: Set<string>, right: Set<string>): boolean {
   for (const url of left) {
     if (right.has(url)) {
@@ -327,19 +315,24 @@ function createWhatsAppMediaOnlyReplyCoalescer(params: {
     },
     flushNonDuplicateMedia: (mediaUrls: Set<string>) =>
       flushWhere((pending) => !hasWhatsAppMediaUrlOverlap(pending.mediaUrls, mediaUrls)),
-    dropDuplicateMedia(mediaUrls: Set<string>): WhatsAppMediaOnlyFlushResult {
+    supersedeMedia(mediaUrl: string): WhatsAppMediaOnlyFlushResult {
       const flushResult: WhatsAppMediaOnlyFlushResult = {
         delivered: 0,
         droppedDuplicateMedia: 0,
       };
       const retained: PendingWhatsAppMediaOnlyPayload[] = [];
       for (const pending of pendingMediaOnlyPayloads.splice(0)) {
-        if (hasWhatsAppMediaUrlOverlap(pending.mediaUrls, mediaUrls)) {
-          pending.resolveFinalization(whatsAppReplyDeliveryVisibility(false));
+        if (pending.mediaUrls.delete(mediaUrl)) {
           flushResult.droppedDuplicateMedia += 1;
-        } else {
-          retained.push(pending);
+          // The original finalization still owns every unmatched attachment, in order.
+          const mediaUrls = [...pending.mediaUrls];
+          pending.payload = { ...pending.payload, mediaUrl: mediaUrls[0], mediaUrls };
         }
+        if (pending.mediaUrls.size === 0) {
+          pending.resolveFinalization(whatsAppReplyDeliveryVisibility(false));
+          continue;
+        }
+        retained.push(pending);
       }
       pendingMediaOnlyPayloads.push(...retained);
       return flushResult;
@@ -354,7 +347,7 @@ function logWhatsAppMediaOnlyFlushResult(result: WhatsAppMediaOnlyFlushResult) {
   }
   if (result.droppedDuplicateMedia > 0) {
     logVerbose(
-      `Dropped ${result.droppedDuplicateMedia} deferred media-only WhatsApp reply payload(s) superseded by captioned media`,
+      `Superseded ${result.droppedDuplicateMedia} deferred WhatsApp attachment(s) with accepted replacement media`,
     );
   }
   if (result.delivered > 0) {
@@ -634,6 +627,7 @@ export function createWhatsAppReplyPlan(params: {
     connectionId?: string;
     skipLog?: boolean;
     tableMode?: ReturnType<typeof resolveMarkdownTableMode>;
+    onMediaAccepted?: (mediaUrl: string) => void;
   }) => Promise<WhatsAppReplyDeliveryResult>;
   groupHistories: Map<string, GroupHistoryEntry[]>;
   groupHistoryKey: string;
@@ -684,7 +678,7 @@ export function createWhatsAppReplyPlan(params: {
   const deliverNormalizedPayload = async (
     normalizedDeliveryPayload: DeliverableWhatsAppOutboundPayload<ReplyPayload>,
     info: ReplyDeliveryInfo,
-    options?: { recordDelivery?: boolean },
+    options?: { recordDelivery?: boolean; onMediaAccepted?: (mediaUrl: string) => void },
   ): Promise<WhatsAppReplyDeliveryVisibility> => {
     const reply = resolveSendableOutboundReplyParts(normalizedDeliveryPayload);
     if (!reply.hasMedia && !reply.text.trim()) {
@@ -704,6 +698,7 @@ export function createWhatsAppReplyPlan(params: {
         connectionId: params.connectionId,
         skipLog: false,
         tableMode,
+        onMediaAccepted: options?.onMediaAccepted,
       });
     } catch (error: unknown) {
       if (isWhatsAppVisibleDeliveryError(error) && !isChannelPartialDeliveryError(error)) {
@@ -778,7 +773,7 @@ export function createWhatsAppReplyPlan(params: {
       if (!reply.hasMedia && !reply.text.trim()) {
         return normalizedDeliveryPayload;
       }
-      const mediaUrls = getWhatsAppPayloadMediaUrls(normalizedDeliveryPayload);
+      const mediaUrls = new Set(normalizedDeliveryPayload.mediaUrls);
       const flushResult = reply.hasMedia
         ? shouldDeferWhatsAppMediaOnlyPayload({ info, mediaUrls, reply })
           ? { delivered: 0, droppedDuplicateMedia: 0 }
@@ -818,7 +813,7 @@ export function createWhatsAppReplyPlan(params: {
           recordDelivery: false,
         });
       }
-      const mediaUrls = getWhatsAppPayloadMediaUrls(normalizedDeliveryPayload);
+      const mediaUrls = new Set(normalizedDeliveryPayload.mediaUrls);
       if (shouldDeferWhatsAppMediaOnlyPayload({ info, mediaUrls, reply })) {
         const finalization = mediaOnlyCoalescer.defer({
           info,
@@ -827,20 +822,14 @@ export function createWhatsAppReplyPlan(params: {
         });
         return { visibleReplySent: false, finalization };
       }
-      try {
-        const result = await deliverNormalizedPayload(normalizedDeliveryPayload, info);
-        if (result.visibleReplySent) {
-          logWhatsAppMediaOnlyFlushResult(mediaOnlyCoalescer.dropDuplicateMedia(mediaUrls));
-        }
-        return result;
-      } catch (error: unknown) {
-        // A visible replacement owns this media even when later bookkeeping fails.
-        // Drop its deferred predecessor so settlement cannot send the same media twice.
-        if (isWhatsAppVisibleDeliveryError(error)) {
-          logWhatsAppMediaOnlyFlushResult(mediaOnlyCoalescer.dropDuplicateMedia(mediaUrls));
-        }
-        throw error;
-      }
+      return await deliverNormalizedPayload(normalizedDeliveryPayload, info, {
+        // Visibility may come from a caption or failure warning. Only a media acceptance
+        // transfers attachment ownership, including before later bookkeeping fails.
+        onMediaAccepted: (mediaUrl) => {
+          didSendReply = true;
+          logWhatsAppMediaOnlyFlushResult(mediaOnlyCoalescer.supersedeMedia(mediaUrl));
+        },
+      });
     },
     onDelivered: (payload, _info, result) => {
       const reply = resolveSendableOutboundReplyParts(payload);


### PR DESCRIPTION
> [!IMPORTANT]
> **review-required: per-attachment delivery/finalization semantics.** Prepared under the auto-QA campaign from a channel-delivery audit (finding C1). Changes WhatsApp attachment finalization ownership, so this stays a draft for maintainer review.

## What Problem This Solves

A WhatsApp reply that sends multiple images and is then followed by a captioned replacement sharing one image **silently dropped the unmatched image**. A multi-image tool response `mediaUrls:[A,B]` enters the deferred-media path; a later `text:"Here is A", mediaUrls:[A]` replacement — because the dedup tested whether *any* URL overlapped — resolved the **entire** pending `[A,B]` batch as non-visible and removed it. The recipient got A, never B, with no error and a misleading "superseded" message; settlement could not flush the removed remainder.

## Why This Change Was Made

The invariant: replacing attachment A must not discard an unsent attachment B just because they share a logical payload — every admitted attachment gets delivery or an accurate recorded non-outcome. The fix subtracts only the attachments actually covered by the replacement and retains the unmatched units with their finalization ownership, recording real per-attachment acceptance instead of inferring "some content became visible." This also let the owner shed accumulated cruft: the whole-batch overlap-discard (introduced by `a2efabf4c93`, retained through `66a75bb9e52`), a redundant post-canonical URL normalization, four duplicated media-send branches, and an ID-compare acceptance inference all removed — **net −49 production lines**.

## User Impact

`[A,B]` followed by a captioned `[A]` now delivers B exactly once and does not re-deliver A; a full `[A,B]→[A,B]` replacement still supersedes cleanly; a non-overlapping `[A,B]→[C]` is unchanged; a vetoed or errored replacement still suppresses / surfaces its error.

## Evidence

- Production **net −49** (+74/−123); tests net +242; docs +1. No schema, persistence-format, public-contract, or dependency change. WhatsApp-owned — no shared code changed (Telegram/Discord/`message-plan` already account per-attachment; verified unaffected).
- Failing-first: `[A,B]→[A]` produced `[[A]]` pre-fix, `[[A],[B]]` after (real `createWhatsAppReplyPlan` + injected accepting transport, original prepare→tool→final→settled order).
- Deep review kept the production fix unchanged, verified the opposite-failure direction (no double-send of a covered attachment, no resurrection of a suppressed one, hook-veto and visible-then-error handling preserved), confirmed the four removed media-send branches dropped no real path, and moved the four overlap cases into the canonical `message_sent` suite. Post-rebase whatsapp inbound-dispatch suite green; changed-file gate + two Codex autoreviews clean.
- **Proof caveat for the landing owner:** this is core-dispatch integration proof, not a running mock-gateway or live WhatsApp delivery. The repository's channel-visible live/mock-gateway proof requirement should be satisfied (or a concrete exception recorded) before merge.
