### PR TITLE
test(clawhub): serve audit metadata in install fixtures

### DIFF
--- a/scripts/e2e/lib/clawhub-fixture-server.cjs
+++ b/scripts/e2e/lib/clawhub-fixture-server.cjs
@@ -783,7 +783,11 @@ async function main() {
       url.pathname ===
       `/api/v1/packages/${encodeURIComponent(packageName)}/versions/${fixture.version}/security`
     ) {
-      json(response, securityDetail);
+      json(response, {
+        ...securityDetail,
+        overview: "No security concerns found in the fixture release.",
+        securityAuditUrl: `http://${request.headers.host}${url.pathname}`,
+      });
       return;
     }
     if (

--- a/test/scripts/clawhub-fixture-server.test.ts
+++ b/test/scripts/clawhub-fixture-server.test.ts
@@ -111,6 +111,28 @@ function runNoRequestsAssertion(baseUrl?: string, cwd = process.cwd()) {
 }
 
 describe("ClawHub fixture server", () => {
+  it.each([
+    ["plugins", "0.1.0"],
+    ["kitchen-sink-plugin", KITCHEN_SINK_VERSION],
+    ["catalog-search", "0.1.0"],
+  ])("serves an accepted install audit for the %s profile", async (profile, version) => {
+    const { baseUrl } = await startFixtureServer(profile);
+    const auditMessages: string[] = [];
+    const trust = await checkClawHubPackageTrust({
+      subject: { kind: "plugin", packageName: PACKAGE_NAME },
+      version,
+      baseUrl,
+      mode: "update",
+      logger: { info: (message) => auditMessages.push(message) },
+    });
+
+    expect(trust.ok).toBe(true);
+    expect(auditMessages).toHaveLength(1);
+    expect(auditMessages[0]).toContain("Outcome: Safe");
+    expect(auditMessages[0]).toContain("No security concerns found in the fixture release.");
+    expect(auditMessages[0]).toContain(`${baseUrl}${PACKAGE_PATH}/versions/${version}/security`);
+  });
+
   it("serves package metadata and npm-pack artifacts for kitchen-sink fixtures", async () => {
     const { baseUrl } = await startFixtureServer("kitchen-sink-plugin");
 


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation fails the Docker plugin install lane because its local ClawHub fixture returns a security report without the audit overview and details URL required by the installer. The production trust checker correctly rejects that incomplete response before installing anything.

## Why This Change Was Made

The common fixture security route now returns the audit overview and its own request URL, matching the existing prepublish-artifact fixture. The production security parser and trust decision are unchanged. Coverage exercises all three common fixture profiles through the real HTTP server and install trust checker, verifying an accepted clean result and rendered audit details.

The requirement became visible after #131233, authored and merged by @Patrick-Erichsen on August 27, commit 7b7858d9552fcfb1e4d1cff80ad214f4ae79313c. That change updated the prepublish fixture but left the common fixture response incomplete.

## User Impact

Internal release QA can exercise plugin installation again. No product runtime, security policy, permissions, configuration, dependency or storage changes.

## Evidence

- Current frozen candidate 871b18dff5039484e86c76d282699a8defcb1654 failed [Docker plugins job 98797615678](https://github.com/openclaw/openclaw/actions/runs/33155289056/job/98797615678) with `Malformed ClawHub security response: expected overview to be a non-empty string`.
- Before the fixture repair, all three new profile cases failed through the real trust checker; the four existing cases passed.
- After the repair, all seven fixture tests pass, including the existing exact prepublish artifact/request-ledger contract.
- Formatting and diff checks pass. Independent Codex autoreview found no accepted/actionable findings at the configured threshold; it did not run tests.

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts test/scripts/clawhub-fixture-server.test.ts
node scripts/check-changed.mjs -- scripts/e2e/lib/clawhub-fixture-server.cjs test/scripts/clawhub-fixture-server.test.ts
```

The full changed gate passed on Blacksmith (lease `tbx_01m13rc8pbm9fbg3pnpzrqa72v`, [run33156207573](https://github.com/openclaw/openclaw/actions/runs/33156207573)); the lease is stopped. [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33156337855) is green, including the aggregate gate. The frozen release QA parent is still draining independent lanes. A focused Docker retry will follow the trusted tooling landing; this is not a claim of full green release validation.

Production runtime LOC:0. Test fixture:+5/-1; regression tests:+22/-0. No changelog change for internal QA repair. AI-assisted maintainer work.
