### PR TITLE
refactor(line): reuse outbound send options

### DIFF
--- a/extensions/line/src/outbound.ts
+++ b/extensions/line/src/outbound.ts
@@ -62,6 +62,7 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
     const buildTemplate =
       lineRuntime?.buildTemplateMessageFromPayload ??
       outboundRuntime.buildTemplateMessageFromPayload;
+    const sendOptions = { verbose: false, cfg, accountId: accountId ?? undefined };
 
     let lastResult: LineSendResult | null = null;
     const recordResult = async (
@@ -102,13 +103,7 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
       }
       for (let i = 0; i < messages.length; i += 5) {
         const batch = messages.slice(i, i + 5) as unknown as Parameters<typeof sendBatch>[1];
-        await recordResult(
-          sendBatch(to, batch, {
-            verbose: false,
-            cfg,
-            accountId: accountId ?? undefined,
-          }),
-        );
+        await recordResult(sendBatch(to, batch, sendOptions));
       }
     };
 
@@ -117,13 +112,7 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
         await sendMessageBatch([{ type: "text", text, quickReply }]);
         return;
       }
-      await recordResult(
-        sendQuickReplies(to, text, quickReplies, {
-          verbose: false,
-          cfg,
-          accountId: accountId ?? undefined,
-        }),
-      );
+      await recordResult(sendQuickReplies(to, text, quickReplies, sendOptions));
     };
 
     const processed = payload.text
@@ -167,10 +156,8 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
         if (!useLineSpecificMedia) {
           await recordResult(
             (lineRuntime?.sendMessageLine ?? outboundRuntime.sendMessageLine)(to, "", {
-              verbose: false,
+              ...sendOptions,
               mediaUrl: trimmed,
-              cfg,
-              accountId: accountId ?? undefined,
             }),
           );
           continue;
@@ -178,14 +165,12 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
         const resolved = await resolveLineOutboundMedia(trimmed, mediaOptions);
         await recordResult(
           (lineRuntime?.sendMessageLine ?? outboundRuntime.sendMessageLine)(to, "", {
-            verbose: false,
+            ...sendOptions,
             mediaUrl: resolved.mediaUrl,
             mediaKind: resolved.mediaKind,
             previewImageUrl: resolved.previewImageUrl,
             durationMs: resolved.durationMs,
             trackingId: resolved.trackingId,
-            cfg,
-            accountId: accountId ?? undefined,
           }),
         );
       }
@@ -194,47 +179,23 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
     if (!shouldSendQuickRepliesInline) {
       if (lineData.flexMessage) {
         const flexContents = lineData.flexMessage.contents as Parameters<typeof sendFlex>[2];
-        await recordResult(
-          sendFlex(to, lineData.flexMessage.altText, flexContents, {
-            verbose: false,
-            cfg,
-            accountId: accountId ?? undefined,
-          }),
-        );
+        await recordResult(sendFlex(to, lineData.flexMessage.altText, flexContents, sendOptions));
       }
 
       if (lineData.templateMessage) {
         const template = buildTemplate(lineData.templateMessage);
         if (template) {
-          await recordResult(
-            sendTemplate(to, template, {
-              verbose: false,
-              cfg,
-              accountId: accountId ?? undefined,
-            }),
-          );
+          await recordResult(sendTemplate(to, template, sendOptions));
         }
       }
 
       if (location) {
-        await recordResult(
-          sendLocation(to, location, {
-            verbose: false,
-            cfg,
-            accountId: accountId ?? undefined,
-          }),
-        );
+        await recordResult(sendLocation(to, location, sendOptions));
       }
 
       if (!orderedMessages) {
         for (const flexMsg of processed.flexMessages) {
-          await recordResult(
-            sendFlex(to, flexMsg.altText, flexMsg.contents, {
-              verbose: false,
-              cfg,
-              accountId: accountId ?? undefined,
-            }),
-          );
+          await recordResult(sendFlex(to, flexMsg.altText, flexMsg.contents, sendOptions));
         }
       }
     }
@@ -251,24 +212,12 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
           if (isLast && quickReply) {
             await sendMessageBatch([{ ...message, quickReply }]);
           } else {
-            await recordResult(
-              sendFlex(to, message.altText, message.contents, {
-                verbose: false,
-                cfg,
-                accountId: accountId ?? undefined,
-              }),
-            );
+            await recordResult(sendFlex(to, message.altText, message.contents, sendOptions));
           }
         } else if (isLast && hasQuickReplies) {
           await sendTextWithQuickReply(message.text);
         } else {
-          await recordResult(
-            sendText(to, message.text, {
-              verbose: false,
-              cfg,
-              accountId: accountId ?? undefined,
-            }),
-          );
+          await recordResult(sendText(to, message.text, sendOptions));
         }
       }
     } else if (chunks.length > 0) {
@@ -277,13 +226,7 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
         if (isLast && hasQuickReplies) {
           await sendTextWithQuickReply(chunk);
         } else {
-          await recordResult(
-            sendText(to, chunk, {
-              verbose: false,
-              cfg,
-              accountId: accountId ?? undefined,
-            }),
-          );
+          await recordResult(sendText(to, chunk, sendOptions));
         }
       }
     } else if (shouldSendQuickRepliesInline) {


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested cleanup of the LINE plugin's outbound delivery path. The same account/configuration options were repeated across text, batch, Flex, template, location, and quick-reply sends, making routine maintenance unnecessarily repetitive.

## Why This Change Was Made

Keep one operation-local options object in the existing payload owner and reuse it for those sends. Media calls still construct their own objects by adding their existing media fields. The production callees only read these shared options; no new helper, public API, configuration, or fallback is introduced.

This is separate from the crash-reconciliation work in #124517, which overlaps these call sites and adds per-push state. Any such state must remain per-send when that work is reconciled; this cleanup only shares the options already invariant within the current payload operation.

## User Impact

No user-visible behavior change. Recipient/account selection, native message shapes, delivery order, quick-reply placement, media safety, receipt collection, and partial-delivery behavior are unchanged.

Production LOC: +12/-69 (net -57). Tests: +0/-0.

## Evidence

Validated commit `e52a134357e865e7edb5cc938fa1ef33435ba12a` on parent `871b18dff5039484e86c76d282699a8defcb1654`:

- All 89 tests pass across `channel.sendPayload.test.ts`, `send.test.ts`, `row-overflow-delivery.loopback.test.ts`, and `channel.rich-messages.test.ts` under `extensions/line/src/`, with one Vitest worker.
- The loopback exercises the production LINE outbound adapter and HTTP transport against a local fake provider. It is not authenticated live LINE delivery; installed `@line/bot-sdk@11.2.0` contracts were inspected separately.
- Canonical owning-package types pass: `node scripts/run-tsgo.mjs -p extensions/line/tsconfig.json`.
- Scoped configured lint, formatting, and `git diff --check` pass. The standard lint wrapper refreshed stale generated SDK declarations after the base update; no source or dependency workaround was needed.
- Fresh isolated Codex autoreview reported no actionable findings; independent exact-commit source review approved the change after checking option mutability, runtime bindings, callers, siblings, history, and SDK types.

Focused test command:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/line/src/channel.sendPayload.test.ts extensions/line/src/send.test.ts extensions/line/src/row-overflow-delivery.loopback.test.ts extensions/line/src/channel.rich-messages.test.ts
```

Scoped checks:

```sh
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/line/src/outbound.ts
node scripts/run-tsgo.mjs -p extensions/line/tsconfig.json
./node_modules/.bin/oxfmt --check extensions/line/src/outbound.ts
git diff --check
```
