### PR TITLE
refactor(plugins): simplify contribution owner lookup

### DIFF
--- a/src/commands/models/list.manifest-catalog.snapshot.test.ts
+++ b/src/commands/models/list.manifest-catalog.snapshot.test.ts
@@ -62,7 +62,10 @@ function prepareFixture() {
             ? {
                 aliases: {
                   // A competing declaration must not displace same-name convention rows.
-                  "fixture-direct": { provider: providerId },
+                  "fixture-direct": {
+                    provider: providerId,
+                    baseUrl: "https://competing.example.invalid/v1",
+                  },
                   "fixture-alias": {
                     provider: providerId,
                     api: "openai-responses",

--- a/src/plugins/plugin-registry-contributions.ts
+++ b/src/plugins/plugin-registry-contributions.ts
@@ -227,49 +227,6 @@ function listContributionManifestPlugins(
   }).plugins;
 }
 
-function resolveContributionOwnerMap(
-  table: PluginLookUpTable,
-  contribution: PluginRegistryContributionKey,
-): ReadonlyMap<string, readonly string[]> | undefined {
-  switch (contribution) {
-    case "channels":
-      return table.owners.channels;
-    case "channelConfigs":
-      return table.owners.channelConfigs;
-    case "providers":
-      return table.owners.providers;
-    case "modelCatalogProviders":
-      return table.owners.modelCatalogProviders;
-    case "cliBackends":
-      return table.owners.cliBackends;
-    case "setupProviders":
-      return table.owners.setupProviders;
-    case "commandAliases":
-      return table.owners.commandAliases;
-    case "contracts":
-      return table.owners.contracts;
-  }
-  return undefined;
-}
-
-function filterContributionOwnerIds(params: {
-  owners: readonly string[];
-  index: PluginRegistrySnapshot;
-  includeDisabled?: boolean;
-  config?: OpenClawConfig;
-}): readonly string[] {
-  const enabledPluginIds = new Set(
-    resolveContributionPluginIds({
-      index: params.index,
-      includeDisabled: params.includeDisabled,
-      config: params.config,
-    }),
-  );
-  return normalizeSortedUniqueStringEntries(
-    params.owners.filter((owner) => enabledPluginIds.has(owner)),
-  );
-}
-
 export function loadPluginManifestRegistryForPluginRegistry(
   params: LoadPluginRegistryManifestParams = {},
 ): PluginManifestRegistry {
@@ -314,17 +271,20 @@ export function resolvePluginContributionOwners(
 ): readonly string[] {
   const index = params.lookUpTable?.index ?? loadPluginRegistrySnapshot(params);
   if (params.lookUpTable && typeof params.matches === "string") {
-    const ownerMap = resolveContributionOwnerMap(params.lookUpTable, params.contribution);
-    const owners = ownerMap?.get(params.matches);
-    if (owners) {
-      return filterContributionOwnerIds({
-        owners,
+    const owners = params.lookUpTable.owners[params.contribution].get(params.matches);
+    if (!owners) {
+      return [];
+    }
+    const enabledPluginIds = new Set(
+      resolveContributionPluginIds({
         index,
         includeDisabled: params.includeDisabled,
         config: params.config,
-      });
-    }
-    return [];
+      }),
+    );
+    return normalizeSortedUniqueStringEntries(
+      owners.filter((owner) => enabledPluginIds.has(owner)),
+    );
   }
   const matcher =
     typeof params.matches === "string"

--- a/src/plugins/plugin-registry.test.ts
+++ b/src/plugins/plugin-registry.test.ts
@@ -358,48 +358,24 @@ describe("plugin registry facade", () => {
 
     expect(listPluginContributionIds({ lookUpTable, contribution: "providers" })).toEqual(["demo"]);
     expect(resolveProviderOwners({ lookUpTable, providerId: "DEMO" })).toEqual(["demo"]);
-    expect(
-      resolvePluginContributionOwners({
-        lookUpTable,
-        contribution: "channels",
-        matches: "demo-chat",
-      }),
-    ).toEqual(["demo"]);
-    expect(
-      resolvePluginContributionOwners({
-        lookUpTable,
-        contribution: "cliBackends",
-        matches: "demo-cli",
-      }),
-    ).toEqual(["demo"]);
-    expect(
-      resolvePluginContributionOwners({
-        lookUpTable,
-        contribution: "setupProviders",
-        matches: "demo-setup",
-      }),
-    ).toEqual(["demo"]);
-    expect(
-      resolvePluginContributionOwners({
-        lookUpTable,
-        contribution: "commandAliases",
-        matches: "demo-command",
-      }),
-    ).toEqual(["demo"]);
-    expect(
-      resolvePluginContributionOwners({
-        lookUpTable,
-        contribution: "cliBackends",
-        matches: "demo-setup-cli",
-      }),
-    ).toEqual(["demo"]);
-    expect(
-      resolvePluginContributionOwners({
-        lookUpTable,
-        contribution: "contracts",
-        matches: "tools",
-      }),
-    ).toEqual(["demo"]);
+    for (const [contribution, matches] of [
+      ["providers", "demo"],
+      ["channels", "demo-chat"],
+      ["channelConfigs", "demo-chat"],
+      ["cliBackends", "demo-cli"],
+      ["cliBackends", "demo-setup-cli"],
+      ["setupProviders", "demo-setup"],
+      ["modelCatalogProviders", "demo-alias"],
+      ["commandAliases", "demo-command"],
+      ["contracts", "tools"],
+    ] as const) {
+      const query = { lookUpTable, contribution, matches };
+      expect(resolvePluginContributionOwners(query), contribution).toEqual(["demo"]);
+      expect(
+        resolvePluginContributionOwners({ ...query, matches: "missing" }),
+        contribution,
+      ).toEqual([]);
+    }
 
     const policies: Array<[OpenClawConfig["plugins"], boolean]> = [
       [undefined, true],


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested cleanup: plugin contribution ownership used an eight-way switch that only selected the identically named owner map, followed by a helper used once to forward the same filtering inputs. These layers made the lookup harder to follow without adding behavior.

Related: #131518 preserves prepared model-catalog ownership; this cleanup retains that path and its new policy coverage.

## Why This Change Was Made

Read the required owner map directly using the existing closed contribution key, and keep the short filtering step at its only caller. Enablement remains owned by the existing canonical resolver, and sorting/deduplication remains unchanged. Missing owners still return before evaluating enablement. The cold-manifest and predicate paths, exports, configuration, and snapshot lifecycle are unchanged.

Production: +11/-51, net **-40 lines**. Tests: +22/-43, net **-21 lines**. The existing lookup test now covers all eight contribution kinds and missing matches through one table; the upstream seven-policy string/predicate loop is preserved. A bounded test-only follow-up gives the existing model-list fixture's competing alias a distinct URL, so the existing expectations distinguish same-name ownership from first-declared-owner selection.

## User Impact

No user-visible behavior or public API change. This is an internal simplification, including the prepared lookup used by model-list catalog coverage and provider/alias row loading. AI-assisted.

## Evidence

Reviewed source head: `3c97f4c4d9697066417a78f46f07ad1e0679e6ca`.

- 62 tests passed across the three plugin registry suites and both model-list manifest catalog suites. The snapshot fixture tests verify no manifest I/O, unchanged ownership after manifest modification/removal, and current policy filtering.
- After strengthening the competing alias fixture, all 15 existing snapshot tests passed again. Mutation proof: the old fixture accepted first-declared-owner selection (2 cases passed); the stronger fixture rejected it with the wrong URL (2 cases failed). The temporary mutation was removed, and the model-list production file was verified byte-identical to the reviewed source. No tests were added.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/plugins/plugin-registry.test.ts src/plugins/plugin-registry-contributions.current-snapshot.test.ts src/plugins/plugin-lookup-table.test.ts src/commands/models/list.manifest-catalog.test.ts src/commands/models/list.manifest-catalog.snapshot.test.ts`
- `node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.plugins-platform.json --builders 1`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/plugins/plugin-registry-contributions.ts src/plugins/plugin-registry.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/commands/models/list.manifest-catalog.snapshot.test.ts`
- Formatting and `git diff --check` passed; fresh Codex autoreview reported no findings.

Fresh Codex autoreview and a separate independent read-only review of the complete final three-file branch reported no findings. Hosted PR checks will be verified on the exact published head before landing.
