### PR TITLE
refactor(transcripts): reuse artifact contracts

### DIFF
--- a/src/cli/program/register.transcripts.test.ts
+++ b/src/cli/program/register.transcripts.test.ts
@@ -99,22 +99,36 @@ describe("transcripts CLI", () => {
     expect(output).toContain(path.join(sessionDir, "summary.md"));
   });
 
-  it("prints summary markdown and keeps its export current", async () => {
+  it.each([
+    ["", "\n"],
+    ["# Design review", "# Design review\n"],
+    ["# Design review\n", "# Design review\n"],
+    ["# Design review\n\n", "# Design review\n\n"],
+  ])("prints and materializes exact bytes for summary %j", async (markdown, expected) => {
     const sessionDir = await writeSession(stateDir, "design-review");
+    const database = openOpenClawStateDatabase({
+      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+    });
+    const db = getNodeSqliteKysely<
+      Pick<OpenClawStateKyselyDatabase, "meeting_transcript_summaries">
+    >(database.db);
+    executeSqliteQuerySync(
+      database.db,
+      db
+        .updateTable("meeting_transcript_summaries")
+        .set({ markdown })
+        .where("session_id", "=", "design-review"),
+    );
     await fs.rm(sessionDir, { recursive: true, force: true });
 
     const output = await runTranscriptsCli(["show", "design-review"]);
 
-    expect(output).toContain("# Design review");
-    expect(output).toContain("Ship CLI");
-    expect(output.endsWith("\n")).toBe(true);
+    expect(output).toBe(expected);
     const jsonOutput = JSON.parse(await runTranscriptsCli(["show", "design-review", "--json"])) as {
       summary: string;
     };
-    expect(jsonOutput.summary.endsWith("\n")).toBe(true);
-    await expect(fs.readFile(path.join(sessionDir, "summary.md"), "utf8")).resolves.toContain(
-      "Ship CLI",
-    );
+    expect(jsonOutput.summary).toBe(expected);
+    await expect(fs.readFile(path.join(sessionDir, "summary.md"), "utf8")).resolves.toBe(expected);
   });
 
   it("keeps JSON inspection available before a summary exists", async () => {

--- a/src/cli/program/register.transcripts.ts
+++ b/src/cli/program/register.transcripts.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type { Command } from "commander";
 import { sanitizeTerminalText } from "../../../packages/terminal-core/src/safe-text.js";
 import { resolveStateDir } from "../../config/paths.js";
+import { normalizeExportText } from "../../transcripts/store-artifacts.js";
 import {
   TranscriptsStore,
   type TranscriptArtifactKind,
@@ -86,11 +87,7 @@ async function showCommand(sessionSelector: string, options: TranscriptsCliOptio
   }
   const storedSummary = await store.readSummary(entry.session);
   const materializedMarkdown =
-    storedSummary.markdown === undefined
-      ? undefined
-      : storedSummary.markdown.endsWith("\n")
-        ? storedSummary.markdown
-        : `${storedSummary.markdown}\n`;
+    storedSummary.markdown === undefined ? undefined : normalizeExportText(storedSummary.markdown);
   // `show` is an explicit export boundary: keep the shipped summary path current.
   await store.materializeSessionArtifacts(entry.session, "summary");
   if (options.json) {

--- a/src/infra/state-migrations.meeting-transcripts-detection.ts
+++ b/src/infra/state-migrations.meeting-transcripts-detection.ts
@@ -3,7 +3,10 @@ import fs from "node:fs";
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
-import { TRANSCRIPT_PATH_SEGMENT_MAX_BYTES } from "../transcripts/store-artifacts.js";
+import {
+  TRANSCRIPT_EXPORT_FILE_NAMES,
+  TRANSCRIPT_PATH_SEGMENT_MAX_BYTES,
+} from "../transcripts/store-artifacts.js";
 import { openNodeSqliteDatabase } from "./node-sqlite.js";
 import {
   hasMatchingRecordedTranscriptArtifact,
@@ -26,18 +29,11 @@ type MeetingTranscriptMigrationDetectionState = {
   hasOversizedSessionSlugs: boolean;
 };
 
-const TRANSCRIPT_ARTIFACT_NAMES = new Set([
-  "metadata.json",
-  "summary.json",
-  "summary.md",
-  "transcript.jsonl",
-]);
-
 function hasLegacyArtifactsSync(directory: string): boolean {
   const entries = fs.readdirSync(directory, { withFileTypes: true });
   let found = false;
   for (const entry of entries) {
-    if (!TRANSCRIPT_ARTIFACT_NAMES.has(entry.name.toLowerCase())) {
+    if (!TRANSCRIPT_EXPORT_FILE_NAMES.has(entry.name.toLowerCase())) {
       continue;
     }
     const stat = fs.lstatSync(path.join(directory, entry.name));

--- a/src/infra/state-migrations.meeting-transcripts-files.ts
+++ b/src/infra/state-migrations.meeting-transcripts-files.ts
@@ -10,18 +10,12 @@ import type {
   TranscriptSessionDescriptor,
   TranscriptUtterance,
 } from "../transcripts/provider-types.js";
+import { TRANSCRIPT_EXPORT_FILE_NAMES } from "../transcripts/store-artifacts.js";
 import type { TranscriptsSummary } from "../transcripts/summary.js";
 import { renderTranscriptsMarkdown } from "../transcripts/summary.js";
 import { sha256File, sha256Hex } from "./crypto-digest.js";
 import { assertNoSymlinkParents } from "./fs-safe-advanced.js";
 import { openNodeSqliteDatabase } from "./node-sqlite.js";
-
-const TRANSCRIPT_EXPORT_FILE_NAMES = new Set([
-  "metadata.json",
-  "summary.json",
-  "summary.md",
-  "transcript.jsonl",
-]);
 
 export const LEGACY_UTTERANCE_INSERT_CHUNK_SIZE = 64;
 const LEGACY_UTTERANCE_STAGE_BATCH_SIZE = 256;

--- a/src/infra/state-migrations.meeting-transcripts.ts
+++ b/src/infra/state-migrations.meeting-transcripts.ts
@@ -516,7 +516,6 @@ export async function migrateLegacyMeetingTranscripts(params: {
         }),
       );
     }
-    const plans: LegacyMeetingTranscriptSnapshot[] = [];
     for (const snapshot of snapshots) {
       const database = openOpenClawStateDatabase(databaseOptions);
       const existing = executeSqliteQueryTakeFirstSync(
@@ -532,7 +531,6 @@ export async function migrateLegacyMeetingTranscripts(params: {
           `legacy transcript conflicts with canonical SQLite state: ${snapshot.relativeDir}`,
         );
       }
-      plans.push(snapshot);
     }
     if (divergentExportDirs.length > 0) {
       const recoveryRoot = `${detected.sourceDir}.exports-recovered-${new Date(now)
@@ -554,7 +552,7 @@ export async function migrateLegacyMeetingTranscripts(params: {
         await store.materializeSessionArtifacts(session, "all");
       }
     }
-    if (plans.length === 0 && partialRelativeDirs.length > 0) {
+    if (snapshots.length === 0 && partialRelativeDirs.length > 0) {
       const recoveryRoot = `${detected.sourceDir}.partials-recovered-${new Date(now)
         .toISOString()
         .replace(/[:.]/g, "-")}`;
@@ -570,7 +568,7 @@ export async function migrateLegacyMeetingTranscripts(params: {
     const expectedArchiveRelativeDirs = await listLegacyMeetingTranscriptSessionDirs(
       detected.sourceDir,
     );
-    if (plans.length === 0) {
+    if (snapshots.length === 0) {
       return { changes: recoveryChanges, warnings: [] };
     }
 
@@ -581,7 +579,7 @@ export async function migrateLegacyMeetingTranscripts(params: {
       env: { ...env, OPENCLAW_STATE_DIR: params.stateDir },
     });
     insertMeetingTranscriptSnapshots({
-      snapshots: plans,
+      snapshots,
       runId,
       now,
       archiveRoot,
@@ -594,12 +592,12 @@ export async function migrateLegacyMeetingTranscripts(params: {
       const database = openOpenClawStateDatabase(databaseOptions);
       await verifyImportedMeetingTranscriptSnapshots({
         store,
-        snapshots: plans,
+        snapshots,
         stageDatabase: stage,
         database: database.db,
       });
-      if (!(await rehashLegacyMeetingTranscriptSnapshots(plans))) {
-        rollbackImportedSnapshots({ snapshots: plans, runId, env, stateDir: params.stateDir });
+      if (!(await rehashLegacyMeetingTranscriptSnapshots(snapshots))) {
+        rollbackImportedSnapshots({ snapshots, runId, env, stateDir: params.stateDir });
         return {
           changes: recoveryChanges,
           warnings: [
@@ -608,7 +606,7 @@ export async function migrateLegacyMeetingTranscripts(params: {
         };
       }
     } catch (error) {
-      rollbackImportedSnapshots({ snapshots: plans, runId, env, stateDir: params.stateDir });
+      rollbackImportedSnapshots({ snapshots, runId, env, stateDir: params.stateDir });
       throw error;
     }
     params.testHooks?.afterImport?.();
@@ -616,7 +614,7 @@ export async function migrateLegacyMeetingTranscripts(params: {
     try {
       archiveRootAfterMove = await archiveLegacyMeetingTranscriptSnapshots({
         sourceRoot: detected.sourceDir,
-        snapshots: plans,
+        snapshots,
         expectedRelativeDirs: expectedArchiveRelativeDirs,
         canonicalRelativeDirs,
         archiveRoot,
@@ -626,14 +624,14 @@ export async function migrateLegacyMeetingTranscripts(params: {
         return {
           changes: [
             ...recoveryChanges,
-            `Imported ${plans.length} meeting transcript session${plans.length === 1 ? "" : "s"} into shared SQLite state`,
+            `Imported ${snapshots.length} meeting transcript session${snapshots.length === 1 ? "" : "s"} into shared SQLite state`,
           ],
           warnings: [
             `Meeting transcript archive needs Doctor resume after moving the source tree: ${String(error)}`,
           ],
         };
       }
-      rollbackImportedSnapshots({ snapshots: plans, runId, env, stateDir: params.stateDir });
+      rollbackImportedSnapshots({ snapshots, runId, env, stateDir: params.stateDir });
       return {
         changes: recoveryChanges,
         warnings: [
@@ -649,11 +647,14 @@ export async function migrateLegacyMeetingTranscripts(params: {
       env,
       stateDir: params.stateDir,
     });
-    const utteranceCount = plans.reduce((total, snapshot) => total + snapshot.utteranceCount, 0);
+    const utteranceCount = snapshots.reduce(
+      (total, snapshot) => total + snapshot.utteranceCount,
+      0,
+    );
     return {
       changes: [
         ...recoveryChanges,
-        `Migrated ${plans.length} meeting transcript session${plans.length === 1 ? "" : "s"} and ${utteranceCount} utterance${utteranceCount === 1 ? "" : "s"} to shared SQLite state`,
+        `Migrated ${snapshots.length} meeting transcript session${snapshots.length === 1 ? "" : "s"} and ${utteranceCount} utterance${utteranceCount === 1 ? "" : "s"} to shared SQLite state`,
         `Archived legacy meeting transcript files → ${archiveRootAfterMove}`,
       ],
       warnings: [],

--- a/src/transcripts/store-artifacts.ts
+++ b/src/transcripts/store-artifacts.ts
@@ -17,12 +17,6 @@ export const TRANSCRIPT_EXPORT_FILE_NAMES = new Set([
 
 export function safeTranscriptPathSegment(value: string): string {
   let segment = value.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
-  if (segment === ".") {
-    return "%2E";
-  }
-  if (segment === "..") {
-    return "%2E%2E";
-  }
   if (!segment) {
     return "session";
   }


### PR DESCRIPTION
Related: #131508 — the landed repair that preserves transcript captures when encoded export names exceed filesystem limits.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed. This branch is in the main repository and remains writable by maintainers.

</details>

## What Problem This Solves

This is the explicitly maintainer-requested cleanup following the bounded transcript export-name repair in #131508. Meeting-transcript inspection and Doctor repair duplicated artifact membership and newline rules, and migration retained an unnecessary second array of the same snapshots. Keeping those contracts in one place reduces maintenance drift without changing operator behavior.

## Why This Change Was Made

Reuse the existing artifact-name set in Doctor and the existing export-text normalizer in the CLI; use the already validated snapshots directly instead of copying them into a redundant plans array; remove dot/dot-dot early returns because the existing portable encoder produces the same bytes. The CLI test extends its existing summary case to assert exact terminal, JSON, and exported bytes for empty text and trailing-newline variants.

The staging and conflict-validation passes remain separate and ordered. Ordered source-hash arrays, legacy dot selectors, ownership/collision checks, transactions, receipts, raw IDs, durable notes, and normal/hashed filenames are unchanged. There are no schema, stored-value, configuration, dependency, or public API changes. AI-assisted; the implementation and preservation boundaries were reviewed by the maintainer workflow.

Production LOC: **+23/-41 (net -18)** across five files. Tests: **+22/-8 (net +14)** in one existing file. No generated or lockfile changes.

## User Impact

No user-visible behavior change. Existing transcript content, export paths, newline bytes, and Doctor phases remain intact. Missing summaries remain distinct from empty summaries. Terminal sanitization and export-before-output ordering are preserved.

## Evidence

Validated on head `aa3a4b1fdc1a6f91472e447ddc8fc1f4245dbdb0`, rebased without conflicts onto `1dba34be9be1249c0e35badcb5ec887ce5d71c72`. The six-file patch is byte-identical to the reviewed patch before rebase.

```sh
node scripts/check-changed.mjs --timed -- src/cli/program/register.transcripts.test.ts src/cli/program/register.transcripts.ts src/infra/state-migrations.meeting-transcripts-detection.ts src/infra/state-migrations.meeting-transcripts-files.ts src/infra/state-migrations.meeting-transcripts.ts src/transcripts/store-artifacts.ts
node scripts/run-vitest.mjs src/transcripts/store.test.ts --reporter=verbose
node scripts/run-vitest.mjs src/infra/state-migrations.meeting-transcripts.test.ts src/infra/state-migrations.meeting-transcripts-projections.test.ts --reporter=verbose
node scripts/run-vitest.mjs src/cli/program/register.transcripts.test.ts --reporter=verbose
node scripts/run-vitest.mjs src/agents/tools/transcripts-tool.session-id.test.ts -t 'round-trips.*dot' --reporter=verbose
git diff HEAD^ HEAD --check
```

All commands passed. The actual changed gate reached and passed all 28 steps, including core production/test typechecks, formatting, lint, database-first, import-cycle, and subsequent guards; no skip flags. Focused tests: store **20 passed**; Doctor/projections **33 passed, 2 existing filesystem-platform skips**; CLI **13 passed**; dot/dot-dot **2 passed, 29 intentionally filtered cases**. Total **68 passed**, with no failed tests or retries. Store/Doctor coverage includes collision ownership, import preflight, rollback, archive interruption/resume, and content preservation; CLI coverage asserts exact bytes and existing missing-summary/sanitization behavior.

The initial changed gate on base `a53f04c076875b9964f10aef62bdfa90944c2633` stopped at unrelated TS2459 in `src/gateway/server-reload-channel-restart.test.ts:8` (private helper import). Neither Gateway file was changed by this refactor. Main already contained the public-boundary test fix in #131627, commit `871b18dff5039484e86c76d282699a8defcb1654`; after rebase, the full gate above passed.

Fresh isolated Codex autoreview of this cleanup reported no accepted/actionable findings at its default P0 threshold (lower priorities excluded by that receipt). No source changes followed that review. Hosted exact-head CI is green: [run 33157474523](https://github.com/openclaw/openclaw/actions/runs/33157474523), with 165 successful and 18 skipped jobs, including the successful required [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33157474523/job/98807667646). No new full local build, provider/live-channel run, or UI/media proof: this is bounded behavior-preserving reuse with no new lazy/published/module boundary or operator-facing change. The original repair's prior live proof is not claimed as fresh proof for this cleanup.

Latest completed [ClawSweeper review](https://github.com/openclaw/openclaw/pull/131679#issuecomment-5450752634) covers this exact head and reports no introduced correctness or security findings. Its two before-merge items are addressed: (1) the omitted 09:02 UTC comment was inspected in full and was only the [review-started placeholder](https://github.com/openclaw/openclaw/pull/131679#issuecomment-5450563033), with no findings or Rank-up moves; (2) exact-head CI is now successful as linked above. No mechanical repair or re-review is needed. The generic stored-data warning was checked against the complete diff: this refactor changes no schema, serialized values, receipts, or persistence semantics. ClawSweeper separately reports a passing `pnpm openclaw transcripts --help` smoke on this head; that checks command loading, while the focused tests above prove summary bytes and migration behavior. The maintainer verification checkpoint was approved for exact head `aa3a4b1fdc1a6f91472e447ddc8fc1f4245dbdb0`. Native prepare and merge completed; landed as [13915384a3a6141a61f9bcb4a0ff18ea46d11e80](https://github.com/openclaw/openclaw/commit/13915384a3a6141a61f9bcb4a0ff18ea46d11e80). The landed six-file patch is byte-identical to the approved patch.
