### PR TITLE
test(ui): observe MCP cancellation at the HTTP boundary

### DIFF
--- a/ui/src/e2e/mcp-app-conformance.e2e.test.ts
+++ b/ui/src/e2e/mcp-app-conformance.e2e.test.ts
@@ -36,6 +36,7 @@ import {
   createMcpAppTeardownRecorder,
   type McpAppFixtureEvent as FixtureEvent,
   openMcpAppProofContext,
+  observeMcpAppHttpResponses,
   observeMcpAppNetwork,
   findAppFrame,
   mountControlUiHost,
@@ -548,6 +549,7 @@ describeConformance("MCP App Control UI and standalone host conformance", () => 
       ),
     );
     const diagnostics: Array<Record<string, unknown>> = [];
+    const http = observeMcpAppHttpResponses(gatewayPort);
     const cancellationResults: Array<Record<string, unknown>> = [];
     const timingResults: Array<{
       scenario: string;
@@ -716,6 +718,7 @@ describeConformance("MCP App Control UI and standalone host conformance", () => 
           await fixture.configure({ ...spec, releasePath });
           const startedAtMs = Date.now();
           const networkStart = diagnostics.length;
+          const httpStart = http.responses.length;
           const observation: Record<string, unknown> = { scenario: spec.scenario, startedAtMs };
           cancellationResults.push(observation);
           try {
@@ -728,6 +731,9 @@ describeConformance("MCP App Control UI and standalone host conformance", () => 
                   ).length,
               )
               .toBe(1);
+            const startedResponses = http.responses.slice(httpStart);
+            expect(startedResponses).toHaveLength(1);
+            const response = startedResponses[0]!;
             if (spec.action === "abort") {
               await app.locator("#cancel-call").click();
             }
@@ -782,14 +788,14 @@ describeConformance("MCP App Control UI and standalone host conformance", () => 
             expect(events.filter((event) => event.event === "tool-complete")).toMatchObject(
               spec.cooperative ? [] : [{ requestId: call.id, aborted: true }],
             );
-            // Fixture stdio and Playwright network events arrive independently.
-            await expect
-              .poll(() =>
-                diagnostics
-                  .slice(networkStart)
-                  .filter((event) => event.event === "requestfailed" && event.method === "POST"),
-              )
-              .toHaveLength(1);
+            // Chromium may omit requestfailed when navigation destroys the old document.
+            // Observe the exact Gateway response, not an unrelated teardown/control POST.
+            await expect.poll(() => response.destroyed).toBe(true);
+            observation.transport = {
+              closed: response.destroyed,
+              writableFinished: response.writableFinished,
+            };
+            expect(response.writableFinished).toBe(false);
           } finally {
             if (releasePath) {
               await fs.writeFile(releasePath, "released");
@@ -837,8 +843,12 @@ describeConformance("MCP App Control UI and standalone host conformance", () => 
             scenario: spec.scenario + "-control",
             callDelayMs: 0,
           });
+          const controlHttpStart = http.responses.length;
           await app.locator("#call-app").click();
           await waitForTextContaining(app.locator("#app-tool"), "companion-called");
+          const controlResponses = http.responses.slice(controlHttpStart);
+          expect(controlResponses).toHaveLength(1);
+          expect(controlResponses[0]?.writableFinished).toBe(true);
           const controlEvents = (await fixture.readEvents()).filter(
             (event) => event.scenario === spec.scenario + "-control",
           );
@@ -998,6 +1008,7 @@ describeConformance("MCP App Control UI and standalone host conformance", () => 
         "companion-called",
       );
     } finally {
+      http.stop();
       await fs.writeFile(
         path.join(proofDir, "browser-diagnostics.json"),
         JSON.stringify(diagnostics, null, 2),

--- a/ui/src/test-helpers/mcp-app-conformance-fixture.ts
+++ b/ui/src/test-helpers/mcp-app-conformance-fixture.ts
@@ -1,11 +1,34 @@
 // Real official App and stdio MCP fixtures shared by conformance scenarios.
+import { channel } from "node:diagnostics_channel";
 import fs from "node:fs/promises";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import { createRequire } from "node:module";
 import path from "node:path";
 import type { Browser, BrowserContext, ConsoleMessage, Frame, Locator, Page } from "playwright";
 import { expect } from "vitest";
 
 const require = createRequire(import.meta.url);
+
+export function observeMcpAppHttpResponses(gatewayPort: number) {
+  const responses: ServerResponse[] = [];
+  const requests = channel("http.server.request.start");
+  const onRequest = (message: unknown) => {
+    // SAFETY: Node publishes these exact objects before the real HTTP request handler runs.
+    const { request, response } = message as {
+      request: IncomingMessage;
+      response: ServerResponse;
+    };
+    if (
+      request.socket.localPort === gatewayPort &&
+      request.method === "POST" &&
+      request.url === "/__openclaw__/mcp-app/view"
+    ) {
+      responses.push(response);
+    }
+  };
+  requests.subscribe(onRequest);
+  return { responses, stop: () => requests.unsubscribe(onRequest) };
+}
 
 export function observeMcpAppNetwork(
   page: Page,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where full release QA reports failed MCP App cancellation when leaving the standalone page, even though the real Gateway has disconnected and the MCP request has been cancelled. Reproduced from the frozen release-QA candidate in [the real-Gateway CI job](https://github.com/openclaw/openclaw/actions/runs/33154316855/job/98793575681), then locally with unchanged source.

This is a maintainer-requested full release QA repair, assisted by Codex.

## Why This Change Was Made

Chromium can omit `requestfailed` during document navigation. A separate real-browser HTTP probe confirmed that neither Playwright page/context events nor CDP `Network.loadingFailed` necessarily report that disconnect, so awaiting the missing event would not fix the evidence.

Observe the actual Gateway HTTP response through Node's documented diagnostics channel instead. The observer is restricted to the test Gateway's local port, POST method and standalone view path. Each scenario captures its exact response before performing cancellation, then requires it to close without finishing; the later successful control request must finish normally. The listener is removed in the existing cleanup block. No request headers, bodies or tickets are added to artifacts.

The exact upstream cancellation ID, cooperative/noncooperative behavior, no-late-response checks, successful control call, and fresh-document/history checks remain intact. No product behavior or timeout changes; production LOC delta is zero, with 42 added/8 removed test and test-support lines after the mechanical refresh. The Node diagnostics contract was checked against installed Node 24 source and the supported [Node 22.22.3 source/docs](https://github.com/nodejs/node/blob/v22.22.3/doc/api/diagnostics_channel.md#event-httpserverrequeststart).

## User Impact

No user-visible behavior changes. Release QA now checks the actual HTTP disconnect without depending on an event Chromium may omit during navigation.

## Evidence

- Unchanged candidate `871b18dff5039484e86c76d282699a8defcb1654`: the full real Chromium/Gateway test failed naturally at the old pagehide POST failure-event assertion. Upstream cancellation still matched the exact call.
- Fixed full scenario passed twice: 2/2 tests in 105.54s, then 2/2 in 77.05s after restoring the fault injection. Node 24.19.0, Chromium 151.0.7922.34, actual Gateway HTTP/WebSocket, official MCP App and stdio MCP SDK. This mounts the real Control UI component; it is not a full-dashboard smoke test.
- All five modes (caller timeout, abort, cooperative cancellation, frame teardown, pagehide) recorded a closed response with `writableFinished=false`, matched upstream cancellation, no late reply, and a successful subsequent control call. Ordinary history back/forward passed; cleanup reported no failures.
- Negative control: temporarily removing the real fetch abort signal made the test fail specifically because the HTTP response finished normally (`writableFinished=true`, HTTP 403). The independent SDK timeout still emitted cancellation, demonstrating why correlated cancellation alone cannot substitute for transport proof. Mutation restored; no dependency edits retained or made.
- Required changed-file gate passed on Blacksmith Testbox `tbx_01m13rj72df125cwh4a4kssar6`: exitCode0 in13m05.99s, including all core-test and UI typechecks, Knip, i18n, lint, formatting and ratchets. [Backing run](https://github.com/openclaw/openclaw/actions/runs/33156422300); the one-shot lease stopped after success, so the backing lease workflow may show cancellation during cleanup.
- Codex autoreview: clean, no accepted/actionable findings. Targeted formatting and diff checks passed.

Reproduction command:

```sh
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/mcp-app-conformance.e2e.test.ts --reporter=verbose
```

Named follow-up: **sanitized MCP conformance failure-artifact upload**. This test writes `.artifacts/control-ui-e2e/mcp-app-request-lifetime`, while the existing optional CI proof upload collects only the sibling `real-gateway` directory. Keep that CI artifact-routing improvement separate from this cancellation-evidence repair.

### Refreshed-head verification

Mechanically rebased to resolve the conflict with #131690's partial polling repair. Reviewed/pushed head: `dafd9df3b6e5f07751a7a8813524282f558d6acc`. Both resulting files are byte-for-byte identical to the original reviewed head `dbbae686193487b967218df005c03fffbfb86c18`; the old polling assertion is removed, not retained alongside HTTP observation. Production +0/-0; E2E +19/-8; test support +23/-0.

Fresh isolated Codex autoreview on the resolved diff passed with no accepted/actionable findings (default P0 scope). Diff whitespace and patch-equality checks passed. No source edits followed review.

Fresh Linux proof on Blacksmith Testbox `tbx_01m13y6y69pmv7j9anb85rh31b` ([backing run 33163043879](https://github.com/openclaw/openclaw/actions/runs/33163043879)):

- Node 24.19.0, Chromium 151.0.7922.34: complete conformance file **2/2 passed in 92.77s**.
- Caller timeout, caller abort, cooperative cancellation, frame teardown, and pagehide each recorded `closed=true, writableFinished=false`. Each subsequent control completed normally; request-ID correlation, late-reply suppression and connection reuse assertions passed.
- Ordinary back/forward history completed; cleanup recorded `failures: []`. BFCache restoration remains unproven and is not claimed. This is the real source-mounted component/Gateway/stdio/official App flow, not a full-dashboard smoke test.
- Sibling Gateway HTTP cancellation suite **7/7 passed in 7.88s**.
- Changed-file gate **passed**; the complete Testbox proof command exited 0 in **16m1.383s**. The owned lease is stopped and confirmed completed.
- Exact-head [CI 33163017681](https://github.com/openclaw/openclaw/actions/runs/33163017681) **completed successfully**. Workflow Sanity [33163017659](https://github.com/openclaw/openclaw/actions/runs/33163017659) passed. Native review artifacts validated as `READY FOR /prepare-pr`, and `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 131680` passed with `selection.mode=exact-head`, without moving the reviewed SHA.

Commands:

```sh
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/mcp-app-conformance.e2e.test.ts --reporter=verbose
node scripts/run-vitest.mjs src/gateway/mcp-app-standalone-cancellation.test.ts --reporter=verbose
node scripts/check-changed.mjs -- ui/src/e2e/mcp-app-conformance.e2e.test.ts ui/src/test-helpers/mcp-app-conformance-fixture.ts
git diff origin/main...HEAD --check
git diff --exit-code dbbae686193487b967218df005c03fffbfb86c18 HEAD -- ui/src/e2e/mcp-app-conformance.e2e.test.ts ui/src/test-helpers/mcp-app-conformance-fixture.ts
```

The old failed UI shard ([33157532185/job/98803949528](https://github.com/openclaw/openclaw/actions/runs/33157532185/job/98803949528)) actually timed out waiting for `Recovered paragraph 1` in the transcript pointer case. The refreshed base contains #131539's repair (`90b7950ccdcffbd9a87cec29d44951a9c9a5efce`), and the refreshed shard passed. No unrelated repair was added here.

ClawSweeper's 09:09 UTC review had no actionable code findings; its `expect_output` deadline expired at Vitest `RUN` before the scenario executed. The fresh real-browser results above address its after-fix proof request and Rank-up move. Its automatic re-review may finish independently; no review placeholder substitutes for the actual CI gate.

The refreshed [10:29 UTC ClawSweeper review](https://github.com/openclaw/openclaw/pull/131680#issuecomment-5450734269) also found no actionable code/security defect. Its only Rank-up move was green exact-head required CI; that is now satisfied. Native prepare passed; land-ready on the unchanged reviewed head. Live matching rules require GitHub Actions `openclaw/ci-gate` and no independent approval rule; no bypass is used.
