### PR TITLE
docs: document node installed-app sharing flags

### DIFF
--- a/docs/cli/node.md
+++ b/docs/cli/node.md
@@ -97,6 +97,8 @@ Options:
 - `--tls-fingerprint <sha256>`: Expected TLS certificate fingerprint (sha256)
 - `--node-id <id>`: Override the client instance ID stored in shared SQLite state (does not reset pairing)
 - `--display-name <name>`: Override the node display name
+- `--share-installed-apps`: On macOS, advertise installed applications through `device.apps`
+- `--no-share-installed-apps`: Disable installed application sharing
 
 ## Gateway auth for node host
 
@@ -152,6 +154,8 @@ Options:
 - `--tls-fingerprint <sha256>`: Expected TLS certificate fingerprint (sha256)
 - `--node-id <id>`: Override the client instance ID stored in shared SQLite state (does not reset pairing)
 - `--display-name <name>`: Override the node display name
+- `--share-installed-apps`: On macOS, advertise installed applications through `device.apps`
+- `--no-share-installed-apps`: Disable installed application sharing
 - `--runtime <node|bun>`: Service runtime (default: `node`). Bun 1.4+ with WAL-reset-safe `node:sqlite` is an explicit opt-in; Node remains recommended.
 - `--force`: Reinstall/overwrite if already installed
 


### PR DESCRIPTION
## What Problem This Solves

The headless node CLI reference omitted the existing macOS installed-app sharing controls. Document `--share-installed-apps` and `--no-share-installed-apps` for both `node run` and `node install`, so operators can discover the opt-in and disable an existing opt-in.

## Why This Change Was Made

Current CLI registration, service argument forwarding, canonical node state, and runtime advertisement agree with the text. Sharing remains off by default and `device.apps` is advertised only on macOS when enabled. This is a documentation-only correction.

## User Impact

macOS node operators can find both the sharing opt-in and the switch that disables a saved opt-in.

## Evidence

Maintainer checks passed on the unchanged contributor head: docs-list, target-file MDX compilation, formatting with the trusted repository configuration, whitespace validation, and fresh Codex autoreview with no accepted P0 findings. Existing runtime and configuration tests were source-inspected; no runtime code changed. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33157794197) and [Workflow Sanity](https://github.com/openclaw/openclaw/actions/runs/33157707890) passed on rerun attempt 2. The refreshed ClawSweeper review found no actionable defect.

Thanks @qingminglong.
