### PR TITLE
test(release): seed plugin ownership for the installed schema

### DIFF
--- a/scripts/e2e/lib/plugin-index-sqlite.mjs
+++ b/scripts/e2e/lib/plugin-index-sqlite.mjs
@@ -219,7 +219,12 @@ export function writePluginInstallIndexForE2E(index, options = {}) {
   const db = new DatabaseSync(dbPath);
   try {
     const now = Date.now();
-    const storageMode = options.storageMode ?? "current";
+    const storageMode =
+      options.storageMode === "existing-schema"
+        ? Number(db.prepare("PRAGMA user_version").get()?.user_version ?? 0) >= 13
+          ? "current"
+          : "pre-v13"
+        : (options.storageMode ?? "current");
     if (storageMode === "current") {
       db.exec(`
         CREATE TABLE IF NOT EXISTS config_machine_state (

--- a/scripts/e2e/lib/plugin-update/probe.mjs
+++ b/scripts/e2e/lib/plugin-update/probe.mjs
@@ -116,7 +116,9 @@ function seedInstallState() {
     ],
     diagnostics: [],
   };
-  writePluginInstallIndexForE2E(index, { storageMode: "pre-v13" });
+  // Package installation may already initialize current state. Unversioned
+  // fixtures retain the pre-v13 bootstrap path for frozen older candidates.
+  writePluginInstallIndexForE2E(index, { storageMode: "existing-schema" });
 }
 
 async function waitRegistry() {

--- a/test/scripts/plugin-index-sqlite.test.ts
+++ b/test/scripts/plugin-index-sqlite.test.ts
@@ -333,32 +333,48 @@ describe("plugin index SQLite E2E helpers", () => {
   it.each([
     {
       mode: "current",
+      schemaVersion: 0,
       options: {},
       expectedTable: "config_machine_state",
       absentTable: "installed_plugin_index",
     },
     {
       mode: "pre-v13",
+      schemaVersion: 0,
       options: { storageMode: "pre-v13" },
       expectedTable: "installed_plugin_index",
       absentTable: "config_machine_state",
     },
-  ])("writes only the $mode storage contract", async ({ absentTable, expectedTable, options }) => {
-    const root = mkdtempSync(path.join(tmpdir(), "openclaw-plugin-index-"));
-    try {
-      const { writePluginInstallIndexForE2E } = await loadPluginIndex();
+    ...[0, 12, 13].map((schemaVersion) => ({
+      mode: `existing schema v${schemaVersion}`,
+      schemaVersion,
+      options: { storageMode: "existing-schema" },
+      expectedTable: schemaVersion >= 13 ? "config_machine_state" : "installed_plugin_index",
+      absentTable: schemaVersion >= 13 ? "installed_plugin_index" : "config_machine_state",
+    })),
+  ])(
+    "writes only the $mode storage contract",
+    async ({ absentTable, expectedTable, options, schemaVersion }) => {
+      const root = mkdtempSync(path.join(tmpdir(), "openclaw-plugin-index-"));
+      try {
+        const db = openSqlite(root);
+        db.exec(`PRAGMA user_version = ${schemaVersion}`);
+        db.close();
+        const { readPluginInstallRecords, writePluginInstallIndexForE2E } = await loadPluginIndex();
 
-      writePluginInstallIndexForE2E(
-        { installRecords: { demo: { source: "npm" } } },
-        { stateDir: root, ...options },
-      );
+        writePluginInstallIndexForE2E(
+          { installRecords: { demo: { source: "npm" } } },
+          { stateDir: root, ...options },
+        );
 
-      expect(readTableNames(root)).toContain(expectedTable);
-      expect(readTableNames(root)).not.toContain(absentTable);
-    } finally {
-      rmSync(root, { force: true, recursive: true });
-    }
-  });
+        expect(readTableNames(root)).toContain(expectedTable);
+        expect(readTableNames(root)).not.toContain(absentTable);
+        expect(readPluginInstallRecords({ stateDir: root })).toEqual({ demo: { source: "npm" } });
+      } finally {
+        rmSync(root, { force: true, recursive: true });
+      }
+    },
+  );
 
   it("rejects unknown writer storage modes", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "openclaw-plugin-index-"));

--- a/test/scripts/plugin-update-unchanged-docker.test.ts
+++ b/test/scripts/plugin-update-unchanged-docker.test.ts
@@ -14,7 +14,6 @@ import {
   openOpenClawStateDatabase,
 } from "../../src/state/openclaw-state-db.js";
 
-const PLUGIN_UPDATE_DOCKER_SCRIPT = "scripts/e2e/plugin-update-unchanged-docker.sh";
 const PLUGIN_UPDATE_SCENARIO_SCRIPT = "scripts/e2e/lib/plugin-update/unchanged-scenario.sh";
 const CORRUPT_UPDATE_SCENARIO_SCRIPT = "scripts/e2e/lib/plugin-update/corrupt-update-scenario.sh";
 const PLUGIN_UPDATE_PROBE_SCRIPT = "scripts/e2e/lib/plugin-update/probe.mjs";
@@ -24,7 +23,7 @@ const PLUGIN_INDEX_MODULE_URL = pathToFileURL(
   path.resolve("scripts/e2e/lib/plugin-index-sqlite.mjs"),
 ).href;
 
-function seedInstallState(root: string) {
+function seedInstallState(root: string, initialized: boolean) {
   const stateDir = path.join(root, ".openclaw");
   const configPath = path.join(stateDir, "openclaw.json");
   const env = {
@@ -36,6 +35,10 @@ function seedInstallState(root: string) {
     OPENCLAW_VERSION: "2026.8.1",
     VITEST: "true",
   };
+  if (initialized) {
+    const database = openOpenClawStateDatabase({ env });
+    closeOpenClawStateDatabaseByPath(database.path);
+  }
   execFileSync("node", [PLUGIN_UPDATE_PROBE_SCRIPT, "seed"], {
     encoding: "utf8",
     env,
@@ -105,65 +108,62 @@ async function waitForPortFile(portFile: string): Promise<number> {
 }
 
 describe("plugin update unchanged Docker E2E", () => {
-  it("seeds pre-v13 plugin install ledger state before checking config stability", async () => {
-    const runner = readFileSync(PLUGIN_UPDATE_DOCKER_SCRIPT, "utf8");
-    const scenario = readFileSync(PLUGIN_UPDATE_SCENARIO_SCRIPT, "utf8");
-    const probe = readFileSync(PLUGIN_UPDATE_PROBE_SCRIPT, "utf8");
+  it.each([false, true])(
+    "seeds plugin ownership with initialized state=%s",
+    async (initialized) => {
+      const root = mkdtempSync(path.join(tmpdir(), "openclaw-plugin-update-seed-"));
+      try {
+        const { configPath, env, stateDir } = seedInstallState(root, initialized);
+        const config = JSON.parse(readFileSync(configPath, "utf8")) as {
+          plugins?: Record<string, unknown>;
+        };
+        expect(config).toEqual({ plugins: {} });
+        expect(
+          JSON.parse(
+            execFileSync("node", [PLUGIN_UPDATE_PROBE_SCRIPT, "snapshot"], {
+              encoding: "utf8",
+              env,
+            }),
+          ),
+        ).toMatchObject({ source: "npm", resolvedVersion: "0.9.0" });
 
-    expect(runner).toContain("scripts/e2e/lib/plugin-update/unchanged-scenario.sh");
-    expect(scenario).toContain('node "$probe" seed');
-    expect(probe).toContain("writeJson(process.env.OPENCLAW_CONFIG_PATH, { plugins: {} });");
-    expect(probe).not.toContain(
-      "writeJson(process.env.OPENCLAW_CONFIG_PATH, { plugins: { installs",
-    );
-    expect(probe).toContain("installRecords: {");
-    expect(probe).toContain('"lossless-claw": {');
-    expect(probe).toContain('{ storageMode: "pre-v13" }');
+        const { readPluginInstallIndex } = await import(PLUGIN_INDEX_MODULE_URL);
+        const persisted = readPluginInstallIndex({ configPath, stateDir });
+        expect(persisted.installRecords).toMatchObject({
+          "lossless-claw": {
+            source: "npm",
+            installPath: "~/.openclaw/extensions/lossless-claw",
+          },
+        });
+        expect(persisted.plugins).toEqual([
+          expect.objectContaining({
+            pluginId: "lossless-claw",
+            installOwner: "lossless-claw",
+            rootDir: path.join(stateDir, "extensions", "lossless-claw"),
+          }),
+        ]);
 
-    const root = mkdtempSync(path.join(tmpdir(), "openclaw-plugin-update-seed-"));
-    try {
-      const { configPath, env, stateDir } = seedInstallState(root);
-      const config = JSON.parse(readFileSync(configPath, "utf8")) as {
-        plugins?: Record<string, unknown>;
-      };
-      expect(config).toEqual({ plugins: {} });
-
-      const { readPluginInstallIndex } = await import(PLUGIN_INDEX_MODULE_URL);
-      const persisted = readPluginInstallIndex({ configPath, stateDir });
-      expect(persisted.installRecords).toMatchObject({
-        "lossless-claw": {
-          source: "npm",
-          installPath: "~/.openclaw/extensions/lossless-claw",
-        },
-      });
-      expect(persisted.plugins).toEqual([
-        expect.objectContaining({
-          pluginId: "lossless-claw",
-          installOwner: "lossless-claw",
-          rootDir: path.join(stateDir, "extensions", "lossless-claw"),
-        }),
-      ]);
-
-      const database = openOpenClawStateDatabase({ env });
-      closeOpenClawStateDatabaseByPath(database.path);
-      const liveIndex = loadInstalledPluginIndex({
-        config,
-        env,
-        stateDir,
-      });
-      expect(resolveInstalledPluginPackageOwnership(liveIndex, "lossless-claw", env)).toMatchObject(
-        {
+        const database = openOpenClawStateDatabase({ env });
+        closeOpenClawStateDatabaseByPath(database.path);
+        const liveIndex = loadInstalledPluginIndex({
+          config,
+          env,
+          stateDir,
+        });
+        expect(
+          resolveInstalledPluginPackageOwnership(liveIndex, "lossless-claw", env),
+        ).toMatchObject({
           ok: true,
           value: {
             installOwner: "lossless-claw",
             pluginIds: ["lossless-claw"],
           },
-        },
-      );
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
-  });
+        });
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("bounds the update command and prints diagnostics on hangs", () => {
     const script = readFileSync(PLUGIN_UPDATE_SCENARIO_SCRIPT, "utf8");


### PR DESCRIPTION
## What Problem This Solves

The release plugin-update fixture can lose its seeded install record before the update command runs. A current package's postinstall migration initializes current SQLite state, but the fixture always writes the retired pre-v13 index table. The version-aware reader correctly ignores that table in current databases.

## Why This Change Was Made

The fixture now asks the shared E2E writer to use the database's existing schema: current storage for v13+, and the pre-v13 bootstrap format for older or unversioned fixture state. Explicit current/pre-v13 writer behavior and the version-aware reader remain unchanged. Exactly one table is written; there is no runtime fallback or dual write.

The earlier frozen-candidate compatibility repair in #131596, authored and merged by @vincentkoc, introduced the unconditional pre-v13 seed. That compatibility requirement remains covered: frozen candidate `6e9fefd1aa42fc4af0d7c0b4056fabf3e10d48e8` needs the older format. This change also covers already-initialized current candidates rather than inferring storage from the package version.

## User Impact

Internal release validation only. No production persistence, schema, migration, security, configuration, or dependency changes.

## Evidence

- Frozen candidate `871b18dff5039484e86c76d282699a8defcb1654` failed [plugin-update job 98798416581](https://github.com/openclaw/openclaw/actions/runs/33155289056/job/98798416581) with `missing plugin install record` at the pre-command snapshot.
- The added initialized-state reproduction failed before the fix, returning no install record; the uninitialized case passed.
- Afterward, both actual seed/snapshot subprocess flows pass, and the production plugin ownership resolver sees the seeded owner after bootstrap/reopen.
- All 28 tests pass across the two owning suites, including v0/v12/v13 writer/read round trips, absence of the other table, existing explicit storage modes, malformed-state checks, registry behavior, and update-output assertions.
- A clean Node 24.19.0 Docker run using the exact parent package artifact `9679284592` reproduces the original snapshot failure on the old harness and passes the full unchanged-update scenario with this patch. The same runner image and tarball are used (SHA256 `2a8a8fe494a6c996ab8043418a4e46a35501275c8f177c3f5641969cad5876c8`). Config hash, install-record snapshot, up-to-date output, and no-download assertions all pass. The optional final log printer safely omitted output because its canonical redactor was unavailable in the standalone bare runner.
- Syntax, formatting and diff checks pass. Independent Codex P0–P2 review found no accepted/actionable findings. The reviewer did not execute tests.

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts test/scripts/plugin-update-unchanged-docker.test.ts test/scripts/plugin-index-sqlite.test.ts
node scripts/check-changed.mjs -- scripts/e2e/lib/plugin-index-sqlite.mjs scripts/e2e/lib/plugin-update/probe.mjs test/scripts/plugin-update-unchanged-docker.test.ts test/scripts/plugin-index-sqlite.test.ts
```

The full changed check passed on [Blacksmith run 33157782656](https://github.com/openclaw/openclaw/actions/runs/33157782656), lease `tbx_01m13sqtpezcy0agpjv48095gc`, terminal exit 0 and stopped; exact-head PR CI must pass before landing. The original full-release diagnostic matrix is still draining. A targeted package lane rerun follows trusted tooling landing; no full-release success is claimed here.

Production runtime LOC: +0/-0. E2E tooling: +9/-2 (net +7), providing schema selection while preserving the frozen-candidate contract. Tests: +84/-68, including formatter movement; brittle source-text checks were removed in favor of executable seed/snapshot and ownership proof. AI-assisted maintainer work; no changelog change for this internal fixture repair.
