### PR TITLE
test(cron): advance receipt retries without wall-clock waits

### DIFF
--- a/src/cron/service/owner-hardening.test.ts
+++ b/src/cron/service/owner-hardening.test.ts
@@ -458,20 +458,30 @@ describe("cron durable run ownership", () => {
         SELECT RAISE(ABORT, 'receipt finalization unavailable');
       END;
     `);
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     try {
       expect(() =>
         finishCronRunReceipt({ handle: receipt, status: "superseded", finishedAtMs: now }),
       ).toThrow("receipt finalization unavailable");
       releaseLocalCronRunReceiptOwnership(receipt);
       expect(isCronRunReceiptOwnerStale(receipt)).toBe(false);
+      expect(receipts(storePath, job.id)[0]?.status).toBe("running");
       database.exec("DROP TRIGGER reject_receipt_only_finish");
-      await vi.waitFor(() => expect(receipts(storePath, job.id)[0]?.status).toBe("superseded"), {
-        timeout: 3_000,
-        interval: 50,
-      });
+      await vi.advanceTimersByTimeAsync(999);
+      expect(isCronRunReceiptOwnerStale(receipt)).toBe(false);
+      expect(receipts(storePath, job.id)[0]?.status).toBe("running");
+      await vi.advanceTimersByTimeAsync(1);
+      expect(receipts(storePath, job.id)[0]?.status).toBe("superseded");
       expect(isCronRunReceiptOwnerStale(receipt)).toBe(true);
     } finally {
-      database.exec("DROP TRIGGER IF EXISTS reject_receipt_only_finish");
+      try {
+        database.exec("DROP TRIGGER IF EXISTS reject_receipt_only_finish");
+        // Drain even after a failed assertion so the retry clears its pending
+        // receipt and local ownership before the store fixture is removed.
+        await vi.runOnlyPendingTimersAsync();
+      } finally {
+        vi.useRealTimers();
+      }
     }
   });
 

--- a/src/cron/store/run-receipt-store.test.ts
+++ b/src/cron/store/run-receipt-store.test.ts
@@ -292,11 +292,12 @@ describe("cron run receipt store", () => {
     expect(
       openOpenClawStateDatabase()
         .db.prepare(
-          `SELECT owner_id
-           FROM execution_owner_lifecycle_bindings
-           WHERE owner_kind = 'cron'`,
+          `SELECT binding.owner_id
+           FROM execution_owner_lifecycle_bindings AS binding
+           JOIN cron_run_receipts AS receipt ON receipt.receipt_id = binding.owner_id
+           WHERE binding.owner_kind = 'cron' AND receipt.store_key = ?`,
         )
-        .all(),
+        .all(cronStoreKey(storePath)),
     ).toEqual([{ owner_id: replacement.receiptId }]);
 
     finishCronRunReceipt({ handle: replacement, status: "ok", finishedAtMs: 250 });


### PR DESCRIPTION
## What Problem This Solves

The cron ownership suite spends a real second waiting for a receipt-only finalization retry. That wait proves the queued retry, but does not check that ownership and the durable running status survive until the retry deadline. Related: #131473 (the original recovery change separated manual finalization recovery from this receipt-only case).

## Why This Change Was Made

Use Vitest's existing fake `setTimeout`/`clearTimeout` only inside this in-process case, after the real fixture, receipt claim, and SQLite trigger exist. Keep the actual failed transaction, production `finishCronRunReceipt`, release request, and queued retry. Assert ownership retained and durable `running` both before advancing and after 999ms, then advance the last 1ms and assert durable `superseded` plus released ownership.

The `finally` block drops the rejecting trigger and drains pending callbacks before restoring real timers. This lets the production callback clear its pending entry even after an early assertion fails. No direct second finalization call, exported delay constant, test seam, or production change. The file stays in the serial, non-isolated `cron` project; subprocess fixtures and their real clocks are unchanged.

Required shuffle proof exposed a pre-existing sibling assertion that compared all cron bindings in the shared database with this fixture's single expected row. The retention test legitimately leaves bindings for other store partitions. Scope that existing query to the fixture's partition by joining receipts; keep both abandoned and replacement receipts in scope. This is a bounded test repair, not a persistence change or another clock conversion.

## User Impact

No runtime behavior changes. Developers get faster and stronger receipt retry coverage. Production LOC: **+0/-0**. Tests: **+20/-9** (net +11) across two files. No schema, persistence, config, dependency, baseline, snapshot, changelog, release, or live Gateway changes. AI-assisted with Codex.

## Evidence

Benchmark base: `0a068cf3f1ef4c45988c7f6a947caacc134478b7`, verified clean and equal to freshly fetched `origin/main` before edits. One task-owned Blacksmith Testbox: `tbx_01m13qg8r2tgxcyx44wswznr3b`, [prepared environment run](https://github.com/openclaw/openclaw/actions/runs/33155196068). The wrapper's terminal exit/result is the remote command verdict; the Actions keepalive can be cancelled when the box is stopped.

Full-file baseline: **14/14 passed**, **90.58s wall / 86.25s Vitest / 75.63s bodies / 9.69s imports**; warmup excluded. The eight subprocess cases dominate full-file wall time. The balanced benchmark therefore runs the target plus all five in-process ownership siblings in their existing file/order: admission failure, manual rollback/recovery, receipt-only retry, successful local release, dead markerless owner mutation, and dead markerless force-run. All samples passed **6/6**, with the other eight cases filtered only for measurement.

Both datasets use eight A/B pairs in AB, BA, BA, AB, AB, BA, BA, AB order, one worker, import diagnostics and `/usr/bin/time -v`. Cold runs use a fresh module cache each invocation. The stability confirmation uses separate before/after caches with an excluded warmup for each; no cache is shared across variants. Diagnostics/fault runs are excluded from timings.

| Median metric | Cold before | Cold after | Warm before | Warm after |
| --- | ---: | ---: | ---: | ---: |
| Scoped wall (s) | 15.306 | 14.738 | 8.109 | 7.305 |
| Vitest (s) | 10.715 | 10.065 | 4.065 | 3.235 |
| Test bodies (s) | 1.220 | 0.205 | 1.165 | 0.158 |
| Target body (s) | 1.008 | 0.005 | 1.006 | 0.004 |
| Imports (s) | 8.550 | 8.840 | 2.560 | 2.715 |
| CPU user (s) | 15.585 | 15.895 | 7.265 | 7.440 |
| CPU system (s) | 1.750 | 1.865 | 0.920 | 0.870 |
| Peak RSS (KiB) | 981048.000 | 981008.000 | 732418.000 | 732944.000 |

These timing datasets are pinned to the starting SHA above. Subsequent main commits changed shared plugin import caches; they are not claimed as final-head timing measurements. Target owner, retry callback, fixture, SQLite API and cron routing remained unchanged in the inspected incoming range.

Cold median wall gain: **0.569s / 3.72%**, with import noise and two negative pairs. Warm median wall gain: **0.804s / 9.92%**; all eight pairs improved, with individual gains **0.657, 1.104, 1.902, 1.461, 0.650, 1.052, 0.908, 1.202 seconds**. Both pass the requested >=0.5s or >=3% scope threshold; the warmed set confirms stability. CPU and RSS are comparable: the change removes waiting, not SQLite work. These are scoped gains, not whole-suite percentage claims.

Reproduction command (fresh cache per cold invocation, separate warmed cache per variant for confirmation):

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_IMPORT_DURATIONS=1 OPENCLAW_VITEST_PRINT_IMPORT_BREAKDOWN=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=<variant-cache> /usr/bin/time -v pnpm test src/cron/service/owner-hardening.test.ts   --maxWorkers=1 --reporter=verbose   -t 'does not execute when the durable receipt|retains a failed manual finalization|retries receipt-only finalization|releases process-local receipt ownership|permits an owner change after a markerless|force-runs through a dead markerless'
```

SQLite and fault diagnostics used temporary instrumentation, excluded from all timings and restored exactly:

- Same six-case before/after scope: **3 OS processes / 5 process-thread entrypoints, 6 SQLite opens (4 memory, 2 disk), 5 explicit closes, 2 on-disk database paths, 159 transaction-control calls (79 BEGIN / 76 COMMIT / 4 ROLLBACK), zero child runners**, identical in both variants. These are observed calls, not an assertion that every connection closes explicitly; process exit releases the remaining handle. Each target run recorded **2 finish attempts, 1 queued retry, 1 callback, 1 successful commit**.
- Instrumented full candidate file: **14/14 passed**, **14 OS processes / 16 process-thread entrypoints**, including **11 child runner processes**, no surviving runner PIDs. The 14 logical cron partitions share the state database; they are not 14 databases. Diagnostics observed 87 SQLite opens (52 in-memory schema probes and 35 disk opens), 75 explicit closes, 2 on-disk database paths, and 533 transaction-control calls. Intentional SIGKILL cases retain their real process-exit lifecycle.
- Successful callback logged `pending:false, owned:false`; final cleanup logged `status:superseded, owned:false, timers:0`.
- Reversible early-release fault: inserted ownership deletion into the pending-retry release guard. The optimized case failed at its first ownership assertion (`expected true to be false`). Its `finally` still ran the queued commit and logged terminal status, released ownership, and zero timers. The other five in-process siblings passed.
- Reversible suppressed-callback fault: removed only the callback's `finishCronRunReceipt` invocation. The optimized case failed after the final 1ms (`expected 'running' to be 'superseded'`); the other five siblings passed. This intentionally broken process was disposable because the fault itself strands the private pending map; no cleanup guarantee is claimed for permanently broken production code.
- Production bytes restored to SHA-256 `ad80f68657828cde787d4cc33071243a6c944a74990ff9e1431d2c8644c76b1e`; test bytes restored to `0ceb062ceac0b0dc2480183b3c2e3b2bef3933960e4e1bdb5c3fbb16c27f8630`. Uninstrumented six-case proof passed after restoration.


The initial normal-order group passed 96/96 tests across eight files. Seed 17 exposed the pre-existing binding-table assertion from #126082 (`2e9c8f8d3f21bc91e44ac102e68191cf09cc339a`); it failed before the changed retry case executed. The receipt-store file alone reproduced 11 pass / 1 fail, then passed 12/12 with the same seed after partition-scoping the query. Final normal-order proof and shuffled seeds 17 and 73 each passed **96/96 across eight files** (wall 73.33s, 72.82s and 74.67s respectively). The **complete changed gate passed (exit 0)**, including all selected guards, core-test typechecking and typed lint (0 warnings/errors). [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33158037796) passed: 41 successful jobs, 19 intentional skips, no pending checks in the final rollup. Test-audit passed; diff-scoped deslop required no changes; fresh isolated Codex autoreview reported no accepted/actionable findings. This is test clock control over existing SQLite behavior, so no live Gateway is started or changed.

Validation harness note: the first complete changed gate hit an outer 600-second harness limit during the serial core-test typecheck. The underlying gate continued to typed lint; its result was not counted as a pass. The tracked full rerun passed in 139.47 seconds with no check skips.

Publication head: `8e295406a8e9b87cf91cdf0ec23ee2db31e53030`, rebased cleanly onto freshly fetched main `f7e5add45288ab095e7bfb9aaa8d719a8ce73b49`. The reviewed two-file diff and restored production hash are unchanged. Testbox was stopped and verified `completed`; all proof artifacts retained locally. The rebased head also passed **96/96** across the same eight files with seed 17 (95.96s launcher wall, 89.99s Vitest on macOS). [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33158037796) completed successfully before native landing.

Landed through native `scripts/pr` as [e479ae0bfba](https://github.com/openclaw/openclaw/commit/e479ae0bfbafe1b565863e7de2a2027c7ebad404). [Final proof](https://github.com/openclaw/openclaw/pull/131686#issuecomment-5450691931) and [native completion](https://github.com/openclaw/openclaw/pull/131686#issuecomment-5450715461). Native worktree removed; the existing checkout is clean main at the landed commit, equal to freshly pulled origin/main. ClawSweeper had only a review-started placeholder with no published findings or Rank-up moves at the final pre-merge read; no completed ClawSweeper review is claimed.
