### PR TITLE
test(ui): await MCP cancellation network evidence

### DIFF
--- a/ui/src/e2e/mcp-app-conformance.e2e.test.ts
+++ b/ui/src/e2e/mcp-app-conformance.e2e.test.ts
@@ -782,11 +782,14 @@ describeConformance("MCP App Control UI and standalone host conformance", () => 
             expect(events.filter((event) => event.event === "tool-complete")).toMatchObject(
               spec.cooperative ? [] : [{ requestId: call.id, aborted: true }],
             );
-            expect(
-              diagnostics
-                .slice(networkStart)
-                .filter((event) => event.event === "requestfailed" && event.method === "POST"),
-            ).toHaveLength(1);
+            // Fixture stdio and Playwright network events arrive independently.
+            await expect
+              .poll(() =>
+                diagnostics
+                  .slice(networkStart)
+                  .filter((event) => event.event === "requestfailed" && event.method === "POST"),
+              )
+              .toHaveLength(1);
           } finally {
             if (releasePath) {
               await fs.writeFile(releasePath, "released");


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-verification failure where the real MCP App browser conformance test reports no cancelled HTTP request even though cancellation has reached the MCP server. [Full Release Validation](https://github.com/openclaw/openclaw/actions/runs/33154285571) exposed the failure in [the real-Gateway UI job](https://github.com/openclaw/openclaw/actions/runs/33154316855/job/98793575681).

## Why This Change Was Made

The fixture's stdio records and Playwright's browser network events arrive on independent channels. Completing the upstream fixture is not a delivery barrier for the browser's `requestfailed` callback. Await the existing per-scenario failed-POST observation with the suite's existing polling defaults, retaining the exact count of one.

There is no production, fixture, timeout, retry, dependency, configuration, or storage change. Cancellation notification correlation, late-reply suppression, subsequent connection reuse, composed operation budgets, and browser-history assertions remain intact. The synchronous assertion originated in [PR #119388 — own standalone MCP App request lifetimes](https://github.com/openclaw/openclaw/pull/119388), authored by @tzy-17 and merged by @steipete on August 28.

## User Impact

No product behavior changes. Release CI now waits for the browser evidence it is asserting instead of treating unrelated fixture progress as synchronous network-event delivery.

## Evidence

- The original uninstrumented CI failure was captured before editing. The unchanged Linux baseline passed 2/2; this PR does not claim the natural intermittent ordering reproduced on demand.
- A temporary delayed-observer control held a genuine Playwright failure callback and published it with `setImmediate`: the old assertion failed with zero versus one, while the fix passed both tests and all five cancellation scenarios. Fetch, HTTP, SDK, and producer results were not mocked.
- A negative control dropped the real browser cancellation message. The fixed test still failed for the missing failed POST, so polling does not hide broken cancellation. All diagnostic controls were removed from the final diff.
- Final uninstrumented Linux Node 24.19.0 / Chromium 144 conformance: 2/2 passed, with exactly one failed POST and cancellation notification per scenario, no late app replies, complete history navigation, and empty cleanup failures.
- Focused Gateway/HTTP siblings: 91 passed. Focused MCP runtime cancellation: 3 passed (102 unrelated cases filtered out).
- Fresh isolated Codex autoreview: no accepted/actionable findings at its configured P0 threshold; the reviewer did not run tests.
- Blacksmith Testbox proof: [run 33156274663](https://github.com/openclaw/openclaw/actions/runs/33156274663), lease `tbx_01m13re1xw8ewv18rzpmjef5pw`. Wrapper terminal results, not the lease-cleanup workflow conclusion, establish test outcomes.

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/mcp-app-conformance.e2e.test.ts
node scripts/run-vitest.mjs src/gateway/mcp-app-standalone.test.ts src/gateway/mcp-app-standalone-cancellation.test.ts src/gateway/http-common.test.ts
node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-runtime.test.ts -t 'cancels.*catalog waiter|cancels materialized MCP calls'
node scripts/check-changed.mjs -- ui/src/e2e/mcp-app-conformance.e2e.test.ts
git diff --check
```

The full changed gate passed, including core-test typechecking, lint, format, and guards; exact-head hosted CI remains required before landing. The proof lease was stopped and cleanup verified. Optional recording was unavailable because the Testbox lacked Playwright's ffmpeg bundle; no screenshots/video or full-dashboard proof is claimed. The real Gateway, browser, stdio server, and official MCP App are exercised. Ordinary history is not BFCache proof.

Production LOC: +0/-0. Tests: +8/-5 (net +3). AI-assisted maintainer-requested CI repair; no changelog change.
