### PR TITLE
test(cron): cover stale-delivery one-shot retention (#131491)

### DIFF
--- a/src/cron/completion-status.test.ts
+++ b/src/cron/completion-status.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveAdmittedCronCompletionStatus,
+  resolveCronCompletionStatus,
+} from "./completion-status.js";
+
+describe("resolveAdmittedCronCompletionStatus", () => {
+  it("fails a stale-suppressed default announce delivery so the one-shot is retained (#131491)", () => {
+    // The stale-run guard records a plain not-delivered outcome with no
+    // suppression reason; requested delivery is required unless explicitly
+    // best-effort, so discarding the run's only deliverable can never resolve
+    // to a successful completion that would retire the one-shot.
+    expect(
+      resolveAdmittedCronCompletionStatus(
+        { delivery: { mode: "announce" } },
+        "ok",
+        "not-delivered",
+      ),
+    ).toBe("failed");
+  });
+
+  it("keeps intentional silence successful without claiming delivery", () => {
+    expect(
+      resolveAdmittedCronCompletionStatus(
+        { delivery: { mode: "announce" } },
+        "ok",
+        "not-delivered",
+        "silent",
+      ),
+    ).toBe("succeeded");
+  });
+
+  it("keeps delivered and error outcomes unchanged", () => {
+    expect(
+      resolveAdmittedCronCompletionStatus({ delivery: { mode: "announce" } }, "ok", "delivered"),
+    ).toBe("succeeded");
+    expect(
+      resolveAdmittedCronCompletionStatus(
+        { delivery: { mode: "announce" } },
+        "error",
+        "not-delivered",
+      ),
+    ).toBe("failed");
+    expect(
+      resolveAdmittedCronCompletionStatus({ delivery: { mode: "announce" } }, "ok", "unknown"),
+    ).toBe("unknown");
+    expect(
+      resolveAdmittedCronCompletionStatus({ delivery: { mode: "none" } }, "ok", "not-requested"),
+    ).toBe("succeeded");
+  });
+});
+
+describe("resolveCronCompletionStatus", () => {
+  it("resolves legacy stored facts without a required-delivery contract", () => {
+    expect(resolveCronCompletionStatus({ status: "ok", deliveryStatus: "not-requested" })).toBe(
+      "succeeded",
+    );
+    expect(resolveCronCompletionStatus({ status: "ok", delivered: true })).toBe("succeeded");
+    expect(resolveCronCompletionStatus({ status: "ok", deliveryStatus: "not-delivered" })).toBe(
+      "unknown",
+    );
+  });
+});

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -2148,6 +2148,37 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     });
     expect(state.deliveryError).toEqual(deliveryError);
     expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+    // The stale guard is a delivery failure, not intentional silence: without a
+    // suppression reason the whole-run completion resolves to "failed", which
+    // retains the one-shot and its transcript instead of a false success (#131491).
+    expect(state.deliveryState.status).toBe("not-delivered");
+    expect(state.deliveryState.delivered).toBe(false);
+    expect(state.deliveryState.error).toEqual(deliveryError);
+    expect(state.deliveryState.deliverySuppressionReason).toBeUndefined();
+  });
+
+  it("retains the deleteAfterRun transcript when a stale delivery suppresses a non-empty reply", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-18T17:00:00.000Z"));
+
+    const params = makeBaseParams({ synthesizedText: "Yesterday's morning briefing." });
+    params.agentSessionKey = "agent:main:cron:test-job";
+    params.job.deleteAfterRun = true;
+    params.beforeSessionDelete = vi.fn();
+    (params.job as { state?: { nextRunAtMs?: number } }).state = {
+      nextRunAtMs: Date.now() - (3 * 60 * 60_000 + 1),
+    };
+
+    const state = await dispatchCronDelivery(params);
+
+    // Completed non-empty output was suppressed as stale; the run transcript
+    // is the only remaining copy of the deliverable, so it must survive the
+    // deleteAfterRun cleanup that a successful one-shot would retire (#131491).
+    expect(state.deliveryState.status).toBe("not-delivered");
+    expect(state.deliveryError).toContain("skipping stale delivery");
+    expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+    expect(params.beforeSessionDelete).not.toHaveBeenCalled();
+    expect(callGateway).not.toHaveBeenCalled();
   });
 
   it("still delivers when the run started on time but finished more than three hours later", async () => {

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -2126,11 +2126,14 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(enqueueSystemEvent).not.toHaveBeenCalled();
   });
 
-  it("skips stale cron deliveries while still suppressing fallback main summary", async () => {
+  it("retains a stale one-shot transcript without delivery or a fallback summary", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-18T17:00:00.000Z"));
 
     const params = makeBaseParams({ synthesizedText: "Yesterday's morning briefing." });
+    params.agentSessionKey = "agent:main:cron:test-job";
+    params.job.deleteAfterRun = true;
+    params.beforeSessionDelete = vi.fn();
     (params.job as { state?: { nextRunAtMs?: number } }).state = {
       nextRunAtMs: Date.now() - (3 * 60 * 60_000 + 1),
     };
@@ -2148,35 +2151,10 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     });
     expect(state.deliveryError).toEqual(deliveryError);
     expect(deliverOutboundPayloads).not.toHaveBeenCalled();
-    // The stale guard is a delivery failure, not intentional silence: without a
-    // suppression reason the whole-run completion resolves to "failed", which
-    // retains the one-shot and its transcript instead of a false success (#131491).
     expect(state.deliveryState.status).toBe("not-delivered");
     expect(state.deliveryState.delivered).toBe(false);
     expect(state.deliveryState.error).toEqual(deliveryError);
     expect(state.deliveryState.deliverySuppressionReason).toBeUndefined();
-  });
-
-  it("retains the deleteAfterRun transcript when a stale delivery suppresses a non-empty reply", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-18T17:00:00.000Z"));
-
-    const params = makeBaseParams({ synthesizedText: "Yesterday's morning briefing." });
-    params.agentSessionKey = "agent:main:cron:test-job";
-    params.job.deleteAfterRun = true;
-    params.beforeSessionDelete = vi.fn();
-    (params.job as { state?: { nextRunAtMs?: number } }).state = {
-      nextRunAtMs: Date.now() - (3 * 60 * 60_000 + 1),
-    };
-
-    const state = await dispatchCronDelivery(params);
-
-    // Completed non-empty output was suppressed as stale; the run transcript
-    // is the only remaining copy of the deliverable, so it must survive the
-    // deleteAfterRun cleanup that a successful one-shot would retire (#131491).
-    expect(state.deliveryState.status).toBe("not-delivered");
-    expect(state.deliveryError).toContain("skipping stale delivery");
-    expect(deliverOutboundPayloads).not.toHaveBeenCalled();
     expect(params.beforeSessionDelete).not.toHaveBeenCalled();
     expect(callGateway).not.toHaveBeenCalled();
   });

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -218,6 +218,66 @@ describe("cron service timer regressions", () => {
     expect(overloadedResult.runIsolatedAgentJob).toHaveBeenCalledTimes(2);
   });
 
+  it("#131491: retains a deleteAfterRun one-shot whose stale guard suppressed its delivery", async () => {
+    const store = timerRegressionFixtures.makeStorePath();
+    // The run fires long after its scheduled slot, executes fully, and the
+    // stale-delivery guard discards its only deliverable. The dispatch-level
+    // transcript retention is covered by the double-announce dispatch tests;
+    // this regression pins the service-side retention policy.
+    const scheduledAt = Date.parse("2026-02-06T10:00:00.000Z");
+    const firedAt = scheduledAt + 18 * 60 * 60_000;
+
+    const cronJob = createIsolatedRegressionJob({
+      id: "oneshot-stale-delivery",
+      name: "late report",
+      scheduledAt,
+      schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+      payload: { kind: "agentTurn", message: "summarize and report" },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    cronJob.deleteAfterRun = true;
+    await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
+
+    // Faithful replay of what the isolated runner returns after the stale
+    // guard records its delivery outcome: execution ok, delivery failed.
+    const runIsolatedAgentJob = vi.fn().mockResolvedValue({
+      status: "ok",
+      summary: "report finished",
+      outputText: "report finished",
+      delivered: false,
+      deliveryAttempted: true,
+      deliveryState: {
+        delivered: false,
+        status: "not-delivered",
+        error: "skipping stale delivery scheduled at 2026-02-06T10:00:00.000Z, started 1080m late",
+        failureNotification: { status: "not-requested" },
+      },
+    });
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => firedAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob,
+    });
+
+    await onTimer(state);
+
+    // The completed one-shot stays inspectable instead of being deleted as a success.
+    const job = state.store?.jobs.find((entry) => entry.id === "oneshot-stale-delivery");
+    expect(job).toBeDefined();
+    expect(job?.enabled).toBe(false);
+    expect(job?.state.nextRunAtMs).toBeUndefined();
+    expect(job?.state.lastStatus).toBe("ok");
+    expect(job?.state.lastDelivered).toBe(false);
+    expect(job?.state.lastDeliveryStatus).toBe("not-delivered");
+    expect(job?.state.lastDeliveryError).toContain("skipping stale delivery");
+    // The turn already ran to completion; the failed completion must not replay it.
+    expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+  });
+
   it("#24355: one-shot job disabled after max transient retries", async () => {
     const store = timerRegressionFixtures.makeStorePath();
     const scheduledAt = Date.parse("2026-02-06T10:00:00.000Z");

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -220,10 +220,6 @@ describe("cron service timer regressions", () => {
 
   it("#131491: retains a deleteAfterRun one-shot whose stale guard suppressed its delivery", async () => {
     const store = timerRegressionFixtures.makeStorePath();
-    // The run fires long after its scheduled slot, executes fully, and the
-    // stale-delivery guard discards its only deliverable. The dispatch-level
-    // transcript retention is covered by the double-announce dispatch tests;
-    // this regression pins the service-side retention policy.
     const scheduledAt = Date.parse("2026-02-06T10:00:00.000Z");
     const firedAt = scheduledAt + 18 * 60 * 60_000;
 
@@ -238,8 +234,7 @@ describe("cron service timer regressions", () => {
     cronJob.deleteAfterRun = true;
     await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
 
-    // Faithful replay of what the isolated runner returns after the stale
-    // guard records its delivery outcome: execution ok, delivery failed.
+    // Execution succeeded, but the delivery owner rejected its stale output.
     const runIsolatedAgentJob = vi.fn().mockResolvedValue({
       status: "ok",
       summary: "report finished",
@@ -265,17 +260,23 @@ describe("cron service timer regressions", () => {
 
     await onTimer(state);
 
-    // The completed one-shot stays inspectable instead of being deleted as a success.
-    const job = state.store?.jobs.find((entry) => entry.id === "oneshot-stale-delivery");
-    expect(job).toBeDefined();
-    expect(job?.enabled).toBe(false);
-    expect(job?.state.nextRunAtMs).toBeUndefined();
-    expect(job?.state.lastStatus).toBe("ok");
-    expect(job?.state.lastDelivered).toBe(false);
-    expect(job?.state.lastDeliveryStatus).toBe("not-delivered");
-    expect(job?.state.lastDeliveryError).toContain("skipping stale delivery");
-    // The turn already ran to completion; the failed completion must not replay it.
+    const persisted = await loadCronStore(store.storePath);
+    expect(persisted.jobs).toHaveLength(1);
+    const job = requireJob({ store: persisted }, cronJob.id);
+    expect(job.enabled).toBe(false);
+    expect(job.state.nextRunAtMs).toBeUndefined();
+    expect(job.state.lastStatus).toBe("ok");
+    expect(job.state.lastDelivered).toBe(false);
+    expect(job.state.lastDeliveryStatus).toBe("not-delivered");
+    expect(job.state.lastDeliveryError).toContain("skipping stale delivery");
+
+    // A fresh scheduler must retain the evidence without replaying completed work.
+    stop(state);
+    const restarted = createCronServiceState(state.deps);
+    await onTimer(restarted);
     expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+    expect((await loadCronStore(store.storePath)).jobs).toEqual(persisted.jobs);
+    stop(restarted);
   });
 
   it("#24355: one-shot job disabled after max transient retries", async () => {


### PR DESCRIPTION
## What Problem This Solves

Protect the already-landed repair for #131491: a late one-shot can finish its agent turn but fail required delivery because its output is stale. The completed job and transcript must remain inspectable, and restarting the scheduler must not replay the completed work.

This tests-only PR covers the completion decision, dispatcher cleanup, and timer persistence boundaries. The maintainer pass consolidated duplicate dispatch coverage and strengthened the timer case to reload the saved job, run a fresh scheduler, and verify both durable failure details and no replay. Runtime behavior and the separate best-effort policy are unchanged. Thanks @LiuwqGit.

## Evidence

Independently run on Linux in a fresh isolated Crabbox using synthetic data and no provider credentials:

- Original published head `801e17312a7e20709882e49d5d2753b179f514fd`: all 239 tests passed across the three changed files.
- Revised candidate: all 238 tests passed; one duplicate was removed. Formatting and type-aware lint passed with zero warnings/errors.
- Deliberately changing the job-deletion predicate back to execution-only success made the strengthened timer case fail because the saved job disappeared. Deliberately allowing failed delivery to clean up the transcript made the dispatcher regression fail on the deletion callback. Both mutations were confined to the proof run and restored afterward.
- The proof exercised real cron-store persistence/readback and a fresh scheduler with a synthetic runner outcome. It did not make a new live channel or external model call; production is unchanged.

Reviewed surface: production +0; tests +134/-1 (net +133). The existing completion, delivery, session-cleanup, finalization, and timer owners were read alongside successful-deletion sibling coverage. No config, schema, public API, or dependency changes.

Fresh independent Codex Autoreview found no actionable P0-P2 issue. The latest ClawSweeper review has no actionable finding or Rank-up move beyond ordinary maintainer review; a refresh will be requested after publication because that review is older than 12 hours. Exact published-head CI remains a landing gate.
