### PR TITLE
fix(agents): record forwarded auth profile in embedded trajectory session.started

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-trajectory.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-trajectory.test.ts
@@ -118,8 +118,12 @@ describe("prepareEmbeddedAttemptTrajectory", () => {
     await prepareEmbeddedAttemptTrajectory(createInput() as never);
 
     const started = recorder.recordEvent.mock.calls.find((call) => call[0] === "session.started");
-    expect(started?.[1]).toMatchObject({ toolCount: 7 });
-    expect((started?.[1] as { authProfileId?: unknown }).authProfileId).toBeUndefined();
+    if (!started) {
+      expect.unreachable("expected a session.started trajectory event");
+    }
+    const startedPayload = started[1] as { authProfileId?: unknown };
+    expect(startedPayload).toMatchObject({ toolCount: 7 });
+    expect(startedPayload.authProfileId).toBeUndefined();
   });
 
   it("keeps trajectory path resolution but skips recorder creation when disabled", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt-trajectory.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-trajectory.test.ts
@@ -94,6 +94,34 @@ describe("prepareEmbeddedAttemptTrajectory", () => {
     );
   });
 
+  it("records the forwarded stream auth profile on session.started", async () => {
+    const recorder = { recordEvent: vi.fn() };
+    hoisted.createTrajectoryRuntimeRecorder.mockReturnValue(recorder);
+
+    const input = createInput();
+    (input.attempt as { runtimePlan?: unknown }).runtimePlan = {
+      auth: { forwardedAuthProfileId: "profile-main" },
+    };
+    await prepareEmbeddedAttemptTrajectory(input as never);
+
+    expect(recorder.recordEvent).toHaveBeenNthCalledWith(
+      1,
+      "session.started",
+      expect.objectContaining({ authProfileId: "profile-main" }),
+    );
+  });
+
+  it("records no auth profile when the runtime auth plan forwarded none", async () => {
+    const recorder = { recordEvent: vi.fn() };
+    hoisted.createTrajectoryRuntimeRecorder.mockReturnValue(recorder);
+
+    await prepareEmbeddedAttemptTrajectory(createInput() as never);
+
+    const started = recorder.recordEvent.mock.calls.find((call) => call[0] === "session.started");
+    expect(started?.[1]).toMatchObject({ toolCount: 7 });
+    expect((started?.[1] as { authProfileId?: unknown }).authProfileId).toBeUndefined();
+  });
+
   it("keeps trajectory path resolution but skips recorder creation when disabled", async () => {
     await expect(prepareEmbeddedAttemptTrajectory(createInput(true) as never)).resolves.toBeNull();
 

--- a/src/agents/embedded-agent-runner/run/attempt-trajectory.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-trajectory.ts
@@ -3,6 +3,7 @@ import type { SessionSystemPromptReport } from "../../../config/sessions/types.j
 import { buildTrajectoryRunMetadata } from "../../../trajectory/metadata.js";
 import { createTrajectoryRuntimeRecorder } from "../../../trajectory/runtime.js";
 import type { AgentSession } from "../../sessions/index.js";
+import { resolveAttemptStreamAuthProfileId } from "./attempt-run-decisions.js";
 import { resolveAttemptTrajectorySessionFile } from "./attempt-transcript-helpers.js";
 import type { EmbeddedRunAttemptParams } from "./types.js";
 
@@ -55,6 +56,10 @@ export async function prepareEmbeddedAttemptTrajectory(input: {
   });
   recorder?.recordEvent("session.started", {
     trigger: attempt.trigger,
+    // Same credential identity the stream transport forwards; the codex app-server
+    // path records it too, and the reasoning-replay authProfileHash is only
+    // verifiable when the plaintext id is present in the trajectory bundle.
+    authProfileId: resolveAttemptStreamAuthProfileId(attempt),
     sessionFile: attempt.sessionFile,
     workspaceDir: input.effectiveWorkspace,
     agentId: input.sessionAgentId,

--- a/src/agents/payload-redaction.test.ts
+++ b/src/agents/payload-redaction.test.ts
@@ -286,4 +286,14 @@ describe("sanitizeDiagnosticPayload", () => {
     });
     expect(JSON.stringify(sanitized)).not.toMatch(/"[0-9]+":(?:[0-9]+|\{)/u);
   });
+
+  it("omits auth profile ids at every nesting level", () => {
+    expect(
+      sanitizeDiagnosticPayload({
+        authProfileId: "provider-1:main",
+        nested: { authProfileId: "provider-1:oauth", kept: true },
+        provider: "provider-1",
+      }),
+    ).toEqual({ nested: { kept: true }, provider: "provider-1" });
+  });
 });

--- a/src/agents/payload-redaction.ts
+++ b/src/agents/payload-redaction.ts
@@ -13,7 +13,9 @@ function mediaDigest(source: string | Uint8Array): string {
 }
 
 const CORE_DIAGNOSTIC_PROJECTION = {
-  omitField: (key) => key === "providerReplay",
+  // Auth profile ids come from a tiny enumerable set, so hashing them would be
+  // a dictionary-attack away from plaintext; they stay out of captures entirely.
+  omitField: (key) => key === "providerReplay" || key === "authProfileId",
   propertyScope: "enumerable",
   projectBinary: (binary) => ({
     redacted: REDACTED_MEDIA_DATA,


### PR DESCRIPTION
## What Problem This Solves

Fixes #130780.

The embedded agent runner resolves the auth profile forwarded to the model stream (`resolveAttemptStreamAuthProfileId` -> `runtimePlan.auth.forwardedAuthProfileId`) and uses it when building the stream fn, but never records it in the trajectory: `session.started` from this runner carries trigger/provider/model identity and no `authProfileId`. The codex app-server path does record the field (`extensions/codex/src/app-server/run-attempt-start.ts:225`), so the two runtimes disagree on the same trajectory surface.

Consequences for operators running audit/attestation tooling over exported trajectories:

- A trajectory cannot establish which credential identity executed the session, even though the runner *did* resolve and forward that identity to the transport.
- The reasoning-replay metadata includes `openclawReasoningReplay.authProfileHash` (`sha256(id.trim()).hex[:16]`), which is only verifiable when the plaintext id exists somewhere in the bundle. With the embedded path it never does, so the hash matches nothing the operator can enumerate.

## Why This Change Was Made

The `session.started` payload should carry the same credential identity the stream transport actually forwards. `resolveAttemptStreamAuthProfileId` already exists in the same module neighborhood and deliberately narrows to runtime-forwarded ids only (raw request auth ids can represent local caller state rather than provider-visible credentials), so reusing it keeps the "only forwarded ids are exposed" boundary intact. When nothing was forwarded the field is `undefined` and drops out of serialization, matching the codex path's absent-handling.

**Persistence projection (review follow-up):** trajectory capture is default-on, and the diagnostic projection that guards every persisted trajectory event and portable export did not treat `authProfileId` as an identity field. Profile ids come from a tiny operator-defined set, so hashing them before persistence would be a dictionary-attack away from plaintext. The projection now omits the field entirely (`src/agents/payload-redaction.ts`), on both the embedded runner and codex paths: `recordEvent` still records the forwarded-identity fact at the producer boundary, while the persisted capture and export stay free of the plaintext id. Run identity remains attributable to an operator who holds the local config by recomputing the reasoning-replay `authProfileHash`.

## User Impact

- Embedded-runner (non-codex) trajectory events record the forwarded auth-profile fact at the `session.started` producer boundary, so the two runtimes agree on the same trajectory surface.
- Persisted trajectory captures and portable exports do **not** contain the plaintext profile id on either path; the diagnostic projection omits it.
- No behavior change for runs with no forwarded auth profile (field stays absent), and no change to authorization or identity *decisions* — this is provenance recording with a redacted persistence projection.

## Evidence

Regression tests:

- `src/agents/embedded-agent-runner/run/attempt-trajectory.test.ts`
  - new case asserts `session.started` carries `authProfileId: "profile-main"` when `runtimePlan.auth.forwardedAuthProfileId` is set — **failed on pre-fix code** (expected `authProfileId` in the recorded payload):

    ```
    src/agents/embedded-agent-runner/run/attempt-trajectory.test.ts:107:34
    Test Files  1 failed (1)
         Tests  1 failed | 3 passed (4)
    ```

  - new case asserts the field stays `undefined` when the runtime auth plan forwarded none — passes pre- and post-fix.
  - post-fix: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt-trajectory.test.ts` -> `Tests 4 passed (4)`.
- `src/agents/payload-redaction.test.ts`
  - new case asserts `sanitizeDiagnosticPayload` drops `authProfileId` at every nesting level while keeping neighbouring fields.

Post-fix runs:

- `node scripts/run-vitest.mjs src/trajectory/ src/agents/transcript-redact.test.ts` -> all green (70 tests in the trajectory shard).
- `node scripts/run-vitest.mjs extensions/codex -t trajectory` -> 5 passed (codex app-server path unaffected by the projection change).
- `pnpm tsgo`, `pnpm format`, oxlint on the touched files -> clean.

Production LOC delta: +8 (3 functional lines: the payload field, the projection omission, and the projection invariant comment; plus test-support assertion lines counted under tests); tests +38.
