### PR TITLE
fix(agents): allow empty write content

### DIFF
--- a/src/agents/agent-tools.params.ts
+++ b/src/agents/agent-tools.params.ts
@@ -104,7 +104,7 @@ export const REQUIRED_PARAM_GROUPS = {
   read: [{ keys: ["path"], label: "path" }],
   write: [
     { keys: ["path"], label: "path" },
-    { keys: ["content"], label: "content" },
+    { keys: ["content"], label: "content", allowEmpty: true },
   ],
   edit: [
     { keys: ["path"], label: "path" },

--- a/src/agents/agent-tools.read.host-write-integrity.test.ts
+++ b/src/agents/agent-tools.read.host-write-integrity.test.ts
@@ -230,6 +230,18 @@ describe("unrestricted host tool writes", () => {
     await expect(fs.readFile(filePath, "utf8")).resolves.toBe("short\n");
   });
 
+  it.each([
+    ["empty", ""],
+    ["whitespace-only", "   "],
+  ])("writes %s content", async (_label, content) => {
+    const filePath = await createFile("replace me\n");
+
+    const tool = createHostWorkspaceWriteTool(tempDir);
+    await tool.execute("call-1", { path: filePath, content });
+
+    await expect(fs.readFile(filePath, "utf8")).resolves.toBe(content);
+  });
+
   it("truncates to empty when an edit removes all content", async () => {
     const filePath = await createFile("wipe me\n");
 

--- a/src/agents/agent-tools.schema.test.ts
+++ b/src/agents/agent-tools.schema.test.ts
@@ -1737,6 +1737,38 @@ describe("assertRequiredParams", () => {
     );
   });
 
+  it("allows empty and whitespace-only write content", async () => {
+    const execute = vi.fn(async (_id, args) => args);
+    const tool = wrapToolParamValidation(
+      {
+        name: "write",
+        label: "write",
+        description: "test",
+        parameters: {},
+        execute,
+      },
+      REQUIRED_PARAM_GROUPS.write,
+    );
+
+    await tool.execute("tool-empty", { path: "empty.txt", content: "" });
+    await tool.execute("tool-whitespace", { path: "whitespace.txt", content: "   " });
+
+    expect(execute).toHaveBeenNthCalledWith(
+      1,
+      "tool-empty",
+      { path: "empty.txt", content: "" },
+      undefined,
+      undefined,
+    );
+    expect(execute).toHaveBeenNthCalledWith(
+      2,
+      "tool-whitespace",
+      { path: "whitespace.txt", content: "   " },
+      undefined,
+      undefined,
+    );
+  });
+
   it("excludes null and undefined values from received hint", () => {
     expect(() =>
       assertRequiredParams(

--- a/src/agents/agent-tools.schema.test.ts
+++ b/src/agents/agent-tools.schema.test.ts
@@ -1737,38 +1737,6 @@ describe("assertRequiredParams", () => {
     );
   });
 
-  it("allows empty and whitespace-only write content", async () => {
-    const execute = vi.fn(async (_id, args) => args);
-    const tool = wrapToolParamValidation(
-      {
-        name: "write",
-        label: "write",
-        description: "test",
-        parameters: {},
-        execute,
-      },
-      REQUIRED_PARAM_GROUPS.write,
-    );
-
-    await tool.execute("tool-empty", { path: "empty.txt", content: "" });
-    await tool.execute("tool-whitespace", { path: "whitespace.txt", content: "   " });
-
-    expect(execute).toHaveBeenNthCalledWith(
-      1,
-      "tool-empty",
-      { path: "empty.txt", content: "" },
-      undefined,
-      undefined,
-    );
-    expect(execute).toHaveBeenNthCalledWith(
-      2,
-      "tool-whitespace",
-      { path: "whitespace.txt", content: "   " },
-      undefined,
-      undefined,
-    );
-  });
-
   it("excludes null and undefined values from received hint", () => {
     expect(() =>
       assertRequiredParams(


### PR DESCRIPTION
## What Problem This Solves

The agent `write` tool rejected empty content as a missing parameter. An agent could not create a zero-byte file or clear an existing file through the normal write path.

## Why This Change Was Made

The write schema and host and sandbox filesystem operations already accept any string. The shared required-parameter wrapper was the conflicting owner: it treated every trimmed-empty string as absent.

The write content group now accepts a present empty string. Path validation stays strict, and missing or non-string content remains invalid. The regression test uses the real host workspace write factory and reads the persisted file back from disk.

## User Impact

Agents can create empty files, clear existing files, and write whitespace-only files. Calls that omit `content` still get actionable retry guidance.

## Evidence

- **Live red on current main `cb7eecdb5bfb39e2b854c07b1cfde08e4a99ff46`:** A fresh existing file contained 17 bytes. The real host workspace write tool rejected `{ content: "" }` with `Missing required parameter: content`, and the file stayed at 17 bytes.
- **Live green on head `ea0d461c4cdcf94abf86484a115760b109c9ed5a`:** The identical production tool call returned `Successfully wrote 0 bytes`, and disk readback confirmed a zero-byte file. Omitting `content` still returned `Missing required parameter: content`.
- **Regression red/green:** The new real-boundary cases failed for empty and whitespace-only content under the old validation policy, then passed after the repair.
- **Focused tests:** `node scripts/run-vitest.mjs src/agents/agent-tools.schema.test.ts src/agents/agent-tools.read.host-write-integrity.test.ts` — 2 files and 91 tests passed.
- **Focused checks:** Oxfmt, Oxlint, max-lines, assertion-safety, test-temp, coercion-helper, and `git diff --check` passed.
- **Change size:** production `+1/-1` (net 0); tests `+12/-0`.

### Redacted terminal trace

```text
revision: ea0d461c4cdcf94abf86484a115760b109c9ed5a
factory: createHostWorkspaceWriteTool
seedBytes: 17
call: { path: "existing.txt", content: "" }
result: Successfully wrote 0 bytes to existing.txt
persistedBytes: 0
persistedText: ""
omittedContent: Missing required parameter: content (received: path). Supply correct parameters before retrying.
```

This is an AI-assisted contribution. The implementation and validation results were reviewed against the runtime contract.
