### PR TITLE
fix(mcp): retrieve attachments from older messages

### DIFF
--- a/src/mcp/channel-bridge.startup.test.ts
+++ b/src/mcp/channel-bridge.startup.test.ts
@@ -94,13 +94,10 @@ describe("OpenClawChannelBridge startup", () => {
     await bridge.start();
 
     expect(mockState.clientOptions?.tlsFingerprint).toBe("sha256:local");
-    expect(
-      (bridge as unknown as { supportsExactMessageLookup: boolean }).supportsExactMessageLookup,
-    ).toBe(true);
     await bridge.close();
   });
 
-  it("waits through retryable Gateway startup until hello succeeds", async () => {
+  it("waits through retryable startup and updates lookup support after reconnect", async () => {
     mockState.autoHello = false;
     const bridge = new OpenClawChannelBridge({} as never, {
       claudeChannelMode: "off",
@@ -119,27 +116,6 @@ describe("OpenClawChannelBridge startup", () => {
     }
     onHelloOk({ features: { methods: ["chat.message.get"], events: [] } });
 
-    await expect(started).resolves.toBeUndefined();
-    await bridge.close();
-  });
-
-  it("updates exact message lookup support after reconnecting", async () => {
-    mockState.autoHello = false;
-    const bridge = new OpenClawChannelBridge({} as never, {
-      claudeChannelMode: "off",
-      verbose: false,
-    });
-
-    const started = bridge.start();
-    await vi.waitFor(() => {
-      expect(mockState.clientOptions).not.toBeNull();
-    });
-    const onHelloOk = mockState.clientOptions?.onHelloOk;
-    if (typeof onHelloOk !== "function") {
-      throw new Error("Expected Gateway hello callback");
-    }
-
-    onHelloOk({ features: { methods: ["chat.message.get"], events: [] } });
     await expect(started).resolves.toBeUndefined();
     expect(
       (bridge as unknown as { supportsExactMessageLookup: boolean }).supportsExactMessageLookup,

--- a/src/mcp/channel-bridge.startup.test.ts
+++ b/src/mcp/channel-bridge.startup.test.ts
@@ -42,7 +42,7 @@ vi.mock("../gateway/client.js", () => ({
       }
       const onHelloOk = this.options.onHelloOk;
       if (typeof onHelloOk === "function") {
-        onHelloOk();
+        onHelloOk({ features: { methods: ["chat.message.get"], events: [] } });
       }
     }
 
@@ -94,6 +94,9 @@ describe("OpenClawChannelBridge startup", () => {
     await bridge.start();
 
     expect(mockState.clientOptions?.tlsFingerprint).toBe("sha256:local");
+    expect(
+      (bridge as unknown as { supportsExactMessageLookup: boolean }).supportsExactMessageLookup,
+    ).toBe(true);
     await bridge.close();
   });
 
@@ -114,9 +117,38 @@ describe("OpenClawChannelBridge startup", () => {
     if (typeof onHelloOk !== "function") {
       throw new Error("Expected Gateway hello callback");
     }
-    onHelloOk();
+    onHelloOk({ features: { methods: ["chat.message.get"], events: [] } });
 
     await expect(started).resolves.toBeUndefined();
+    await bridge.close();
+  });
+
+  it("updates exact message lookup support after reconnecting", async () => {
+    mockState.autoHello = false;
+    const bridge = new OpenClawChannelBridge({} as never, {
+      claudeChannelMode: "off",
+      verbose: false,
+    });
+
+    const started = bridge.start();
+    await vi.waitFor(() => {
+      expect(mockState.clientOptions).not.toBeNull();
+    });
+    const onHelloOk = mockState.clientOptions?.onHelloOk;
+    if (typeof onHelloOk !== "function") {
+      throw new Error("Expected Gateway hello callback");
+    }
+
+    onHelloOk({ features: { methods: ["chat.message.get"], events: [] } });
+    await expect(started).resolves.toBeUndefined();
+    expect(
+      (bridge as unknown as { supportsExactMessageLookup: boolean }).supportsExactMessageLookup,
+    ).toBe(true);
+
+    onHelloOk({ features: { methods: [], events: [] } });
+    expect(
+      (bridge as unknown as { supportsExactMessageLookup: boolean }).supportsExactMessageLookup,
+    ).toBe(false);
     await bridge.close();
   });
 });

--- a/src/mcp/channel-bridge.ts
+++ b/src/mcp/channel-bridge.ts
@@ -2,6 +2,7 @@
 import { randomUUID } from "node:crypto";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { resolveIntegerOption } from "@openclaw/normalization-core/number-coercion";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
@@ -27,7 +28,13 @@ import type {
   SessionMessagePayload,
   WaitFilter,
 } from "./channel-shared.js";
-import { matchEventFilter, normalizeApprovalId, toConversation, toText } from "./channel-shared.js";
+import {
+  matchEventFilter,
+  normalizeApprovalId,
+  resolveMessageId,
+  toConversation,
+  toText,
+} from "./channel-shared.js";
 
 /**
  * Runtime bridge between MCP tools and the OpenClaw Gateway channel APIs.
@@ -78,6 +85,7 @@ export class OpenClawChannelBridge {
   private ready = false;
   private started = false;
   private retryingInitialConnect = false;
+  private supportsExactMessageLookup = false;
   private readonly readyPromise: Promise<void>;
   private resolveReady!: () => void;
   private rejectReady!: (error: Error) => void;
@@ -156,7 +164,8 @@ export class OpenClawChannelBridge {
       onEvent: (event) => {
         void this.dispatchGatewayEvent(event);
       },
-      onHelloOk: () => {
+      onHelloOk: (hello) => {
+        this.supportsExactMessageLookup = hello.features.methods.includes("chat.message.get");
         this.retryingInitialConnect = false;
         void this.handleHelloOk();
       },
@@ -267,6 +276,19 @@ export class OpenClawChannelBridge {
       limit: requestLimit,
     });
     return response.messages ?? [];
+  }
+
+  async readMessage(sessionKey: string, messageId: string, limit = 100) {
+    const messages = await this.readMessages(sessionKey, limit);
+    const message = messages.find((entry) => resolveMessageId(entry) === messageId);
+    if (message || !this.supportsExactMessageLookup) {
+      return message ?? null;
+    }
+    const result = await this.requestGateway("chat.message.get", {
+      sessionKey,
+      messageId,
+    });
+    return result.ok === true && isRecord(result.message) ? result.message : null;
   }
 
   /** Send a reply using the same channel route stored on the conversation. */

--- a/src/mcp/channel-bridge.ts
+++ b/src/mcp/channel-bridge.ts
@@ -2,7 +2,6 @@
 import { randomUUID } from "node:crypto";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { resolveIntegerOption } from "@openclaw/normalization-core/number-coercion";
-import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
@@ -278,17 +277,19 @@ export class OpenClawChannelBridge {
     return response.messages ?? [];
   }
 
-  async readMessage(sessionKey: string, messageId: string, limit = 100) {
-    const messages = await this.readMessages(sessionKey, limit);
-    const message = messages.find((entry) => resolveMessageId(entry) === messageId);
-    if (message || !this.supportsExactMessageLookup) {
-      return message ?? null;
+  async readMessage(sessionKey: string, messageId: string, legacyLimit = 100) {
+    await this.waitUntilReady();
+    if (!this.supportsExactMessageLookup) {
+      // v2026.5.28 shares protocol v4 but predates chat.message.get. Remove this
+      // bounded fallback when the remote compatibility floor excludes that release.
+      const messages = await this.readMessages(sessionKey, legacyLimit);
+      return messages.find((entry) => resolveMessageId(entry) === messageId) ?? null;
     }
     const result = await this.requestGateway("chat.message.get", {
       sessionKey,
       messageId,
     });
-    return result.ok === true && isRecord(result.message) ? result.message : null;
+    return result.ok === true ? (result.message ?? null) : null;
   }
 
   /** Send a reply using the same channel route stored on the conversation. */

--- a/src/mcp/channel-server.test.ts
+++ b/src/mcp/channel-server.test.ts
@@ -46,28 +46,21 @@ async function connectMcpWithoutGateway(params?: { claudeChannelMode?: "auto" | 
 function attachReadyGateway(
   bridge: OpenClawChannelBridge,
   gatewayRequest: ReturnType<typeof vi.fn>,
+  supportsExactMessageLookup = true,
 ) {
-  (
-    bridge as unknown as {
-      gateway: { request: typeof gatewayRequest; stopAndWait: () => Promise<void> };
-      readySettled: boolean;
-      resolveReady: () => void;
-    }
-  ).gateway = {
+  const bridgeInternals = bridge as unknown as {
+    gateway: { request: typeof gatewayRequest; stopAndWait: () => Promise<void> };
+    readySettled: boolean;
+    resolveReady: () => void;
+    supportsExactMessageLookup: boolean;
+  };
+  bridgeInternals.supportsExactMessageLookup = supportsExactMessageLookup;
+  bridgeInternals.gateway = {
     request: gatewayRequest,
     stopAndWait: async () => {},
   };
-  (
-    bridge as unknown as {
-      readySettled: boolean;
-      resolveReady: () => void;
-    }
-  ).readySettled = true;
-  (
-    bridge as unknown as {
-      resolveReady: () => void;
-    }
-  ).resolveReady();
+  bridgeInternals.readySettled = true;
+  bridgeInternals.resolveReady();
 }
 
 async function flushMcpNotifications() {
@@ -203,43 +196,49 @@ describe("openclaw channel mcp server", () => {
         ).toBe(true);
       });
 
-      test("projects canonical persisted media from a text-only transcript message", async () => {
+      test("fetches canonical persisted media by message id after recent history misses", async () => {
         const mcp = await connectMcpWithoutGateway({ claudeChannelMode: "off" });
         try {
-          attachReadyGateway(
-            mcp.bridge,
-            vi.fn(async (method: string) => {
-              if (method !== "sessions.get") {
-                throw new Error(`unexpected gateway method ${method}`);
-              }
+          const gatewayRequest = vi.fn(async (method: string, params: Record<string, unknown>) => {
+            if (method === "sessions.get") {
+              expect(params).toEqual({ key: "agent:main:main", limit: 1 });
+              return { messages: [] };
+            }
+            if (method === "chat.message.get") {
+              expect(params).toEqual({
+                sessionKey: "agent:main:main",
+                messageId: "msg-canonical-media",
+              });
               return {
-                messages: [
-                  {
-                    id: "msg-canonical-media",
-                    role: "user",
-                    content: "text-only transcript content",
-                    __openclaw: {
-                      media: [
-                        {
-                          url: "media://inbound/photo.png",
-                          contentType: "image/png",
-                          kind: "image",
-                          fileName: "photo.png",
-                          sizeBytes: 123,
-                        },
-                      ],
-                    },
+                ok: true,
+                message: {
+                  id: "msg-canonical-media",
+                  role: "user",
+                  content: "text-only transcript content",
+                  __openclaw: {
+                    media: [
+                      {
+                        url: "media://inbound/photo.png",
+                        contentType: "image/png",
+                        kind: "image",
+                        fileName: "photo.png",
+                        sizeBytes: 123,
+                      },
+                    ],
                   },
-                ],
+                },
               };
-            }),
-          );
+            }
+            throw new Error(`unexpected gateway method ${method}`);
+          });
+          attachReadyGateway(mcp.bridge, gatewayRequest);
 
           const result = (await mcp.client.callTool({
             name: "attachments_fetch",
             arguments: {
               session_key: "agent:main:main",
               message_id: "msg-canonical-media",
+              limit: 1,
             },
           })) as {
             structuredContent?: { attachments?: unknown[] };
@@ -258,9 +257,107 @@ describe("openclaw channel mcp server", () => {
               },
             },
           ]);
+          expect(gatewayRequest).toHaveBeenCalledTimes(2);
         } finally {
           await mcp.close();
         }
+      });
+
+      test("preserves recent-history lookup when the message is already present", async () => {
+        const mcp = await connectMcpWithoutGateway({ claudeChannelMode: "off" });
+        try {
+          const gatewayRequest = vi.fn(async (method: string, params: Record<string, unknown>) => {
+            if (method === "sessions.get") {
+              expect(params).toEqual({ key: "agent:main:main", limit: 1 });
+              return {
+                messages: [
+                  {
+                    id: "msg-recent",
+                    role: "user",
+                    content: [{ type: "image", source: { type: "url", url: "media://photo" } }],
+                  },
+                ],
+              };
+            }
+            throw new Error(`unexpected gateway method ${method}`);
+          });
+          attachReadyGateway(mcp.bridge, gatewayRequest);
+
+          const result = (await mcp.client.callTool({
+            name: "attachments_fetch",
+            arguments: {
+              session_key: "agent:main:main",
+              message_id: "msg-recent",
+              limit: 1,
+            },
+          })) as {
+            structuredContent?: { attachments?: unknown[] };
+          };
+
+          expect(result.structuredContent?.attachments).toHaveLength(1);
+          expect(gatewayRequest).toHaveBeenCalledTimes(1);
+        } finally {
+          await mcp.close();
+        }
+      });
+
+      test("falls back to recent history when an older Gateway lacks exact message lookup", async () => {
+        const mcp = await connectMcpWithoutGateway({ claudeChannelMode: "off" });
+        try {
+          const gatewayRequest = vi.fn(async (method: string, params: Record<string, unknown>) => {
+            if (method === "sessions.get") {
+              expect(params).toEqual({ key: "agent:main:main", limit: 1 });
+              return {
+                messages: [
+                  {
+                    id: "msg-legacy",
+                    role: "user",
+                    content: [{ type: "image", source: { type: "url", url: "media://photo" } }],
+                  },
+                ],
+              };
+            }
+            throw new Error(`unexpected gateway method ${method}`);
+          });
+          attachReadyGateway(mcp.bridge, gatewayRequest, false);
+
+          const result = (await mcp.client.callTool({
+            name: "attachments_fetch",
+            arguments: {
+              session_key: "agent:main:main",
+              message_id: "msg-legacy",
+              limit: 1,
+            },
+          })) as {
+            structuredContent?: { attachments?: unknown[] };
+          };
+
+          expect(result.structuredContent?.attachments).toHaveLength(1);
+          expect(gatewayRequest).toHaveBeenCalledTimes(1);
+        } finally {
+          await mcp.close();
+        }
+      });
+
+      test("preserves exact lookup errors", async () => {
+        const gatewayError = new Error("exact lookup failed");
+        const gatewayRequest = vi.fn(async (method: string) => {
+          if (method === "sessions.get") {
+            return { messages: [] };
+          }
+          if (method === "chat.message.get") {
+            throw gatewayError;
+          }
+          throw new Error(`unexpected gateway method ${method}`);
+        });
+        const bridge = new OpenClawChannelBridge({} as never, {
+          claudeChannelMode: "off",
+          verbose: false,
+        });
+        attachReadyGateway(bridge, gatewayRequest);
+
+        await expect(bridge.readMessage("agent:main:main", "msg-1")).rejects.toBe(gatewayError);
+        expect(gatewayRequest).toHaveBeenCalledTimes(2);
       });
 
       test("clamps direct bridge session limits to the public MCP windows", async () => {

--- a/src/mcp/channel-server.test.ts
+++ b/src/mcp/channel-server.test.ts
@@ -196,14 +196,10 @@ describe("openclaw channel mcp server", () => {
         ).toBe(true);
       });
 
-      test("fetches canonical persisted media by message id after recent history misses", async () => {
+      test("fetches canonical persisted media by message id without scanning recent history", async () => {
         const mcp = await connectMcpWithoutGateway({ claudeChannelMode: "off" });
         try {
           const gatewayRequest = vi.fn(async (method: string, params: Record<string, unknown>) => {
-            if (method === "sessions.get") {
-              expect(params).toEqual({ key: "agent:main:main", limit: 1 });
-              return { messages: [] };
-            }
             if (method === "chat.message.get") {
               expect(params).toEqual({
                 sessionKey: "agent:main:main",
@@ -257,44 +253,6 @@ describe("openclaw channel mcp server", () => {
               },
             },
           ]);
-          expect(gatewayRequest).toHaveBeenCalledTimes(2);
-        } finally {
-          await mcp.close();
-        }
-      });
-
-      test("preserves recent-history lookup when the message is already present", async () => {
-        const mcp = await connectMcpWithoutGateway({ claudeChannelMode: "off" });
-        try {
-          const gatewayRequest = vi.fn(async (method: string, params: Record<string, unknown>) => {
-            if (method === "sessions.get") {
-              expect(params).toEqual({ key: "agent:main:main", limit: 1 });
-              return {
-                messages: [
-                  {
-                    id: "msg-recent",
-                    role: "user",
-                    content: [{ type: "image", source: { type: "url", url: "media://photo" } }],
-                  },
-                ],
-              };
-            }
-            throw new Error(`unexpected gateway method ${method}`);
-          });
-          attachReadyGateway(mcp.bridge, gatewayRequest);
-
-          const result = (await mcp.client.callTool({
-            name: "attachments_fetch",
-            arguments: {
-              session_key: "agent:main:main",
-              message_id: "msg-recent",
-              limit: 1,
-            },
-          })) as {
-            structuredContent?: { attachments?: unknown[] };
-          };
-
-          expect(result.structuredContent?.attachments).toHaveLength(1);
           expect(gatewayRequest).toHaveBeenCalledTimes(1);
         } finally {
           await mcp.close();
@@ -337,27 +295,6 @@ describe("openclaw channel mcp server", () => {
         } finally {
           await mcp.close();
         }
-      });
-
-      test("preserves exact lookup errors", async () => {
-        const gatewayError = new Error("exact lookup failed");
-        const gatewayRequest = vi.fn(async (method: string) => {
-          if (method === "sessions.get") {
-            return { messages: [] };
-          }
-          if (method === "chat.message.get") {
-            throw gatewayError;
-          }
-          throw new Error(`unexpected gateway method ${method}`);
-        });
-        const bridge = new OpenClawChannelBridge({} as never, {
-          claudeChannelMode: "off",
-          verbose: false,
-        });
-        attachReadyGateway(bridge, gatewayRequest);
-
-        await expect(bridge.readMessage("agent:main:main", "msg-1")).rejects.toBe(gatewayError);
-        expect(gatewayRequest).toHaveBeenCalledTimes(2);
       });
 
       test("clamps direct bridge session limits to the public MCP windows", async () => {

--- a/src/mcp/channel-tools.ts
+++ b/src/mcp/channel-tools.ts
@@ -4,7 +4,6 @@ import { z } from "zod";
 import type { OpenClawChannelBridge } from "./channel-bridge.js";
 import {
   extractAttachmentsFromMessage,
-  resolveMessageId,
   summarizeResult,
   summarizeStructuredResult,
   toText,
@@ -94,8 +93,7 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
       limit: z.number().int().min(1).max(200).optional(),
     },
     async ({ session_key, message_id, limit }) => {
-      const messages = await bridge.readMessages(session_key, limit ?? 100);
-      const message = messages.find((entry) => resolveMessageId(entry) === message_id);
+      const message = await bridge.readMessage(session_key, message_id, limit ?? 100);
       if (!message) {
         return {
           content: [{ type: "text", text: `message not found: ${message_id}` }],


### PR DESCRIPTION
Closes #131694

## What Problem This Solves

`attachments_fetch` searches at most 200 recent messages. It reports `message not found` when a valid target is older than that window.

## Why This Change Was Made

The bounded scan made sense when `attachments_fetch` was added because OpenClaw did not have exact message lookup. The Gateway now owns exact lookup through `chat.message.get`.

The bridge uses exact lookup when the Gateway advertises `chat.message.get` in `hello-ok.features.methods`. The shipped v2026.5.28 Gateway still uses protocol v4 but does not advertise that method, so the bridge keeps the original bounded scan only for that compatibility case. The existing `limit` argument controls only the compatibility path.

This keeps the lookup at the Gateway owner, avoids a larger history request, and does not add a config surface.

## User Impact

Model Context Protocol (MCP) channel clients can retrieve attachments from messages outside recent history. Existing clients may keep sending `limit`, and current clients can still use a v2026.5.28 remote Gateway.

## Evidence

The same real loopback Gateway and stdio MCP flow persisted 202 messages and tested current `main` at `548c9f2ac4c37058c12a73bb5882f824623c0f42` against this head at `be6a34e516ffb15892354e5c21616b7da7a21759`. The affected current-main files are unchanged at this PR's base `6165efefeb502c0550e67d1ffda166f18ca6c123`.

Current `main` returned 200 bounded rows without the target, then returned `message not found`:

```json
{"transcriptMessageCount":202,"boundedHistoryCount":200,"targetVisibleInBoundedHistory":false,"attachmentFetchIsError":true,"attachmentCount":0,"exactLookupCalls":0,"boundedHistoryCalls":2}
```

This head returned the same target attachment through one exact lookup:

```json
{"transcriptMessageCount":202,"boundedHistoryCount":200,"targetVisibleInBoundedHistory":false,"attachmentFetchIsError":false,"attachmentCount":1,"gatewayAdvertisesExactLookup":true,"exactLookupCalls":1,"boundedHistoryCalls":1}
```

An intermediate rebased head first scanned bounded history before exact lookup. The same trace recorded two `sessions.get` calls. The final head restores the canonical exact-first path and records one `sessions.get` call only from the independent anti-cheat probe.

The same head connected to the published `openclaw@2026.5.28` Gateway. That Gateway did not advertise exact lookup, and the fallback returned the attachment without probing the unsupported method:

```json
{"gatewayAdvertisesExactLookup":false,"attachmentFetchIsError":false,"attachmentCount":1,"exactLookupCalls":0,"boundedHistoryCalls":2}
```

The owner-boundary regression failed on the pre-fix code because the attachment result was absent, then passed with the repair. Focused validation on the final head:

```text
node scripts/run-vitest.mjs src/mcp/channel-bridge.startup.test.ts src/mcp/channel-server.test.ts
Test Files  2 passed (2)
Tests       16 passed (16)

node scripts/run-oxlint.mjs --openclaw-focused-config src/mcp/channel-bridge.ts src/mcp/channel-bridge.startup.test.ts src/mcp/channel-server.test.ts src/mcp/channel-tools.ts
pnpm check:no-conflict-markers
pnpm check:max-lines-ratchet --base 640d73e3d452b3fb53f78cfa679c23101434c927
pnpm check:assertion-safety --base 640d73e3d452b3fb53f78cfa679c23101434c927
pnpm check:coercion-helpers
./node_modules/.bin/oxfmt --check src/mcp/channel-bridge.ts src/mcp/channel-bridge.startup.test.ts src/mcp/channel-server.test.ts src/mcp/channel-tools.ts
git diff --check
```

Judged line delta against the contributor base: production +21; tests +42. The production growth is the advertised-method state and one canonical exact-or-shipped-fallback lookup. The cleanup removes an unnecessary runtime record guard and implementation-only tests while preserving reconnect coverage.

AI-assisted: Yes. The maintainer reviewed the source, history, dependency contracts, reproduction, tests, and final behavior proof.
