### PR TITLE
fix: /think levels never reach NVIDIA-hosted models

### DIFF
--- a/extensions/nvidia/openclaw.plugin.json
+++ b/extensions/nvidia/openclaw.plugin.json
@@ -40,7 +40,9 @@
               "cacheWrite": 0
             },
             "compat": {
-              "requiresStringContent": true
+              "requiresStringContent": true,
+              "supportsReasoningEffort": true,
+              "supportedReasoningEfforts": ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
             }
           },
           {
@@ -57,7 +59,9 @@
               "cacheWrite": 0
             },
             "compat": {
-              "requiresStringContent": true
+              "requiresStringContent": true,
+              "supportsReasoningEffort": true,
+              "supportedReasoningEfforts": ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
             }
           },
           {
@@ -74,7 +78,9 @@
               "cacheWrite": 0
             },
             "compat": {
-              "requiresStringContent": true
+              "requiresStringContent": true,
+              "supportsReasoningEffort": true,
+              "supportedReasoningEfforts": ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
             }
           },
           {
@@ -126,7 +132,9 @@
               "cacheWrite": 0
             },
             "compat": {
-              "requiresStringContent": true
+              "requiresStringContent": true,
+              "supportsReasoningEffort": true,
+              "supportedReasoningEfforts": ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
             }
           },
           {

--- a/extensions/nvidia/provider-catalog.test.ts
+++ b/extensions/nvidia/provider-catalog.test.ts
@@ -361,6 +361,27 @@ describe("nvidia provider catalog", () => {
     });
   });
 
+  it("declares the reasoning efforts the NVIDIA endpoint accepts", () => {
+    // The endpoint enumerates this set itself when rejecting an unknown value. Without it
+    // OpenClaw clamps to a generic low/medium/high set and silently downgrades minimal,
+    // xhigh and max.
+    const provider = buildSelectableNvidiaProvider();
+    for (const id of [
+      "nvidia/nemotron-3-ultra-550b-a55b",
+      "nvidia/nemotron-3-super-120b-a12b",
+      "nvidia/nemotron-3.5-lightning-30b-a3b",
+      "minimaxai/minimax-m3",
+    ]) {
+      const model = provider.models.find((entry) => entry.id === id);
+      expect(model?.compat).toMatchObject({
+        // Both are required: the vocabulary alone is inert, because the request builder
+        // gates emission on the capability flag and the endpoint class defaults it to false.
+        supportsReasoningEffort: true,
+        supportedReasoningEfforts: ["none", "minimal", "low", "medium", "high", "xhigh", "max"],
+      });
+    }
+  });
+
   it("keeps deprecated exact-reference rows out of the selectable catalog", () => {
     const provider = buildSelectableNvidiaProvider();
 


### PR DESCRIPTION
Related: #131028

## What Problem This Solves

Fixes an issue where users setting any thinking level on NVIDIA-hosted models get no effect at all. `/think off`, `/think high` and `/think max` all produce the same request, and the model reasons at the endpoint's own default every time.

This is the same defect #131028 reports for Groq, on a different provider.

## Why This Change Was Made

OpenClaw gates OpenAI-compatible reasoning-effort emission on `compat.supportsReasoningEffort`. That flag is derived from the endpoint class: it is false whenever the class is anything other than `default` or a known OpenAI host. NVIDIA declares `nvidia-native`, so the flag is false and `reasoning_effort` is never added to the payload.

Declaring the accepted efforts alone does not fix it. The vocabulary reaches the model but emission stays gated, so both fields are required together.

The endpoint enumerates its own accepted set when rejecting an unknown value:

```
POST integrate.api.nvidia.com/v1/chat/completions   reasoning_effort=off
  400  unknown variant `off`, expected one of
       `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`
```

## User Impact

Thinking levels take effect on NVIDIA-hosted Nemotron and MiniMax models. `/think off` disables reasoning instead of leaving it on at the provider default, and the enabled levels reach the endpoint as requested.

## Evidence

Measured from inside `openai-completions-transport.ts`, immediately after compat resolution, against the live endpoint.

Before, at every level:

```
--thinking off   supportsReasoningEffort=false   reasoning_effort=undefined
--thinking high  supportsReasoningEffort=false   reasoning_effort=undefined
--thinking max   supportsReasoningEffort=false   reasoning_effort=undefined
```

After:

```
--thinking off   supportsReasoningEffort=true    reasoning_effort="none"
--thinking high  supportsReasoningEffort=true    reasoning_effort="high"
```

What those values do at the endpoint, sent directly:

```
reasoning_effort omitted   completion_tokens=173  reasoning present   <- the before state
reasoning_effort="none"    completion_tokens=4    reasoning absent
reasoning_effort="high"    completion_tokens=115  reasoning present
```

So the before state was not merely ignoring the setting; a `/think off` request still generated and billed reasoning. On a bare "Hello" that was 550 characters of reasoning content.

`pnpm test extensions/nvidia` passes 37 tests. The added contract test fails against the unchanged manifest.

## Notes

Scoped to rows whose accepted set was confirmed directly against the endpoint: the three NVIDIA-served Nemotron rows and MiniMax M3. Kimi K2.6 is excluded because the key used for verification is not entitled for it, so there is no evidence either way. The remaining rows in that catalog are third-party models on the same host whose accepted sets were not verified here.

The enum is an observed fact taken from the endpoint's own rejection, not a documented contract. If NVIDIA changes what it accepts, this metadata goes stale and the failure mode is a rejected request rather than a silent downgrade.

Worth flagging for maintainers: this pattern is not NVIDIA-specific. Any provider declaring an endpoint class other than `default` gets `supportsReasoningEffort: false` by default, and its catalog rows must opt back in explicitly. #131028 is the same root cause on Groq, and #71556 was the same shape on z.ai. A general fix may be preferable to per-provider metadata.

One pre-existing failure on current `main` is unrelated to this change: `pnpm check:test-types` reports `src/gateway/server-reload-channel-restart.test.ts(8,10): error TS2459`, reproducible on a clean checkout with no local changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
