### PR TITLE
feat(docker): install openssh-client in the runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -235,10 +235,8 @@ WORKDIR /app
 # so it must be installed explicitly here. Without it `/etc/ssl/certs/`
 # stays empty and every HTTPS outbound dies at TLS handshake with
 # `error setting certificate file`.
-# `openssh-client` provides the `ssh` binary that the SSH sandbox backend
-# spawns directly (`src/agents/sandbox/ssh.ts`). Without it, every SSH-backed
-# sandbox fails at session start with `spawn ssh ENOENT`, and `git` cannot use
-# SSH remotes even though `git` itself is installed.
+# The runtime image must include the SSH client because the sandbox backend
+# spawns `ssh` directly, and bookworm-slim does not provide it.
 # Apply current Debian point-release security fixes even when the pinned base
 # digest predates them, without waiting for a base-digest refresh.
 RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \

--- a/Dockerfile
+++ b/Dockerfile
@@ -235,6 +235,10 @@ WORKDIR /app
 # so it must be installed explicitly here. Without it `/etc/ssl/certs/`
 # stays empty and every HTTPS outbound dies at TLS handshake with
 # `error setting certificate file`.
+# `openssh-client` provides the `ssh` binary that the SSH sandbox backend
+# spawns directly (`src/agents/sandbox/ssh.ts`). Without it, every SSH-backed
+# sandbox fails at session start with `spawn ssh ENOENT`, and `git` cannot use
+# SSH remotes even though `git` itself is installed.
 # Apply current Debian point-release security fixes even when the pinned base
 # digest predates them, without waiting for a base-digest refresh.
 RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
@@ -242,7 +246,7 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      ca-certificates curl git hostname lsof openssl procps python3 tini && \
+      ca-certificates curl git hostname lsof openssh-client openssl procps python3 tini && \
     update-ca-certificates
 
 # Keep npm as an operator-facing capability while replacing the base image's

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -103,7 +103,7 @@ describe("Dockerfile", () => {
       "FROM ${OPENCLAW_NODE_BOOKWORM_SLIM_IMAGE} AS base-runtime",
     );
     const caInstallIndex = collapsed.indexOf(
-      "ca-certificates curl git hostname lsof openssl procps python3",
+      "ca-certificates curl git hostname lsof openssh-client openssl procps python3",
     );
 
     expect(runtimeIndex).toBeGreaterThan(-1);
@@ -119,14 +119,14 @@ describe("Dockerfile", () => {
       "FROM ${OPENCLAW_NODE_BOOKWORM_SLIM_IMAGE} AS base-runtime",
     );
     const pythonInstallIndex = dockerfile.indexOf(
-      "ca-certificates curl git hostname lsof openssl procps python3",
+      "ca-certificates curl git hostname lsof openssh-client openssl procps python3",
     );
 
     expect(runtimeIndex).toBeGreaterThan(-1);
     expect(pythonInstallIndex).toBeGreaterThan(runtimeIndex);
     expect(pythonInstallIndex).toBeLessThan(dockerfile.indexOf("RUN chown node:node /app"));
     expect(dockerfile).toContain(
-      "ca-certificates curl git hostname lsof openssl procps python3 tini",
+      "ca-certificates curl git hostname lsof openssh-client openssl procps python3 tini",
     );
     expect(dockerfile).toContain('ENTRYPOINT ["tini", "-s", "--"]');
   });


### PR DESCRIPTION
The runtime stage installs `git` but not `openssh-client`, so the published image has no `ssh` binary.

`src/agents/sandbox/ssh.ts` spawns `ssh` directly, defaulting to the bare `ssh` command name, so an SSH-backed sandbox session on the published image fails at start with `spawn ssh ENOENT`. The same gap means `git` cannot use SSH remotes despite `git` being installed.

`OPENCLAW_IMAGE_APT_PACKAGES` adds the package at build time and is the supported workaround today, and the prerequisite is documented in `docs/gateway/openshell.md`. Installing it by default removes the need to maintain a derived image to use a backend that already ships in the product.

This departs from the opt-in pattern that `OPENCLAW_INSTALL_DOCKER_CLI` establishes for sandbox backend dependencies. The argument for the departure is cost: the Docker CLI adds ~50MB plus a third-party apt repository, where this measures 7.60MB (1452453516 -> 1460057262 bytes, 0.52%) from the base distribution already in use.

Client only. No SSH server, and no change to sandbox defaults or behavior.

Closes #131705

## What Problem This Solves

Resolves a problem where operators running the published Docker image cannot use an SSH-backed sandbox without rebuilding the image: every session fails at start with `spawn ssh ENOENT`. The runtime image installs `git` but not `openssh-client`, so the `ssh` binary the sandbox backend invokes is not on `PATH`. The same gap prevents Git remotes over SSH from working inside the container, even though `git` itself is installed.

The supported workaround today is `--build-arg OPENCLAW_IMAGE_APT_PACKAGES="openssh-client"`, which works but requires maintaining a private derived image and tag, rebuilt on every release bump, to use a backend that already ships in the product. The prerequisite is documented in `docs/gateway/openshell.md`, so this is a convenience and failure-mode argument rather than a missing-documentation one.

## Why This Change Was Made

`src/agents/sandbox/ssh.ts` resolves the SSH executable as `params.command?.trim() || "ssh"` (line 659) and `settings.command.trim() || "ssh"` (line 675), then calls `spawn(sshExecutable, sshArgs, ...)` (line 849). With no explicit `command` configured, the default is the bare name `ssh`, which must resolve on `PATH`.

This adds `openssh-client` to the existing runtime apt install list, keeping the list alphabetical, with a comment in the style of the existing `ca-certificates` note explaining why the package is non-obvious. One line plus a comment; no code, config, or docs surface changes.

Non-goals: no SSH server, no daemon, and no change to sandbox defaults, configuration, or behavior. Nothing is enabled that an operator has not already explicitly configured.

Cost, measured rather than estimated: `ghcr.io/openclaw/openclaw:2026.8.1-beta.3` is 1452453516 bytes; the same image with only `openssh-client` added is 1460057262 bytes. That is 7603746 bytes, 7.60MB, or 0.52%. `openssh-client` reports an installed size of 5801KB, and the remainder is `libedit2` and `libfido2-1`, the only two of its dependencies not already in the image. It is a client only, so no listening port and no daemon, but it is one more package tracking CVEs in every image including deployments that never use SSH.

I want to name the counter-argument rather than leave it for review. This Dockerfile already treats sandbox backend dependencies as opt-in: `OPENCLAW_INSTALL_DOCKER_CLI` is documented as "Required for `agents.defaults.sandbox` to function in Docker deployments" and defaults to off. The prerequisite is also already documented for this backend, in `docs/gateway/openshell.md` ("OpenSSH client available on the Gateway host"), so this is not an undocumented trap. Shipping the package by default departs from that pattern, and doing nothing is a defensible answer.

The difference I would point to is cost: the Docker CLI adds roughly 50MB plus a third-party apt repository with a pinned GPG key, where this is 7.6MB from the base distribution already in use. If maintainers prefer consistency over that, I am happy to rework this as `OPENCLAW_INSTALL_SSH_CLIENT=1` mirroring the Docker CLI arg, or to close it in favor of a
clearer startup error, since `spawn ssh ENOENT` is a Node spawn failure that does not name the missing package.

## User Impact

Operators can use SSH-backed sandboxes directly from the published image, with no derived image and no rebuild. Git remotes over SSH work from inside the container. Users who do not use SSH sandboxes see no behavior change, only the small image size increase.

## Evidence

Rebuilt as requested: a named image built from this PR head, not a derived image on top of a
published tag. The earlier transcript used a placeholder and has been replaced.

Image identity, built from commit 0e5f4089d:

```
$ podman build -t openclaw-pr131710:0e5f4089d .
$ podman image inspect openclaw-pr131710:0e5f4089d --format '{{.Digest}} {{.Created}}'
sha256:92ae7255c7488268a4cf21e524ef3733b847f2c53d7759dc4856b123de316cab  2026-08-28T10:49:50Z
```

The build log shows the changed apt list installing the package:

```
[6/6] STEP 5/39: RUN ... apt-get install -y --no-install-recommends \
      ca-certificates curl git hostname lsof openssh-client openssl procps python3 tini
Get:37 http://deb.debian.org/debian bookworm/main amd64 openssh-client amd64 1:9.2p1-2+deb12u10 [994 kB]
Setting up openssh-client (1:9.2p1-2+deb12u10) ...
```

`ssh` is present in the PR-head image:

```
$ podman run --rm --entrypoint ssh openclaw-pr131710:0e5f4089d -V
OpenSSH_9.2p1 Debian-2+deb12u10, OpenSSL 3.0.20 7 Apr 2026

$ podman run --rm --entrypoint sh openclaw-pr131710:0e5f4089d -c 'command -v ssh'
/usr/bin/ssh

$ podman run --rm --entrypoint sh openclaw-pr131710:0e5f4089d \
    -c "dpkg-query -W -f='${Package} ${Version} (${Installed-Size}KB)\n' openssh-client"
openssh-client 1:9.2p1-2+deb12u10 (5801KB)
```

The same check on the published image, for contrast:

```
$ podman run --rm --entrypoint sh ghcr.io/openclaw/openclaw:2026.8.1-beta.3 \
    -c 'command -v ssh || echo "ssh: NOT FOUND"'
ssh: NOT FOUND
```

Executable startup, which is the mechanism this PR fixes. `src/agents/sandbox/ssh.ts:849` calls
`spawn(sshExecutable, ...)` with the bare name `ssh`, so this runs that same spawn inside each
image:

```
--- published image ---
$ podman run --rm --entrypoint node ghcr.io/openclaw/openclaw:2026.8.1-beta.3 \
    -e 'require("child_process").spawn("ssh",["-V"],{stdio:"inherit"})
        .on("error",e=>console.log("spawn error:",e.code,"-",e.message))'
spawn error: ENOENT - spawn ssh ENOENT

--- PR-head image ---
$ podman run --rm --entrypoint node openclaw-pr131710:0e5f4089d \
    -e 'require("child_process").spawn("ssh",["-V"],{stdio:"inherit"})
        .on("error",e=>console.log("spawn error:",e.code,"-",e.message))
        .on("exit",c=>console.log("ssh exited",c))'
OpenSSH_9.2p1 Debian-2+deb12u10, OpenSSL 3.0.20 7 Apr 2026
ssh exited 0
```

And the client actually executes rather than merely resolving, reaching the network layer:

```
$ podman run --rm --entrypoint ssh openclaw-pr131710:0e5f4089d \
    -o BatchMode=yes -o ConnectTimeout=5 -p 2222 nobody@127.0.0.1 true
ssh: connect to host 127.0.0.1 port 2222: Connection refused
```

Scope note, to be precise about what this does and does not show: this demonstrates that the
`ssh` executable resolves and runs inside the PR-head image, which is the `spawn ssh ENOENT`
failure the PR addresses. It is not a full agent-driven sandbox session; that additionally needs
a reachable SSH target and a configured model provider, neither of which is in this environment.
Happy to extend the proof if a maintainer wants that lane specifically.

Size cost, measured by adding only this package to the published image so the two differ by one
apt layer:

```
ghcr.io/openclaw/openclaw:2026.8.1-beta.3              1452453516 bytes
same image + openssh-client                           1460057262 bytes
delta                                                    7603746 bytes  (7.60MB, 0.52%)
```

The locally built PR-head image is not used for that comparison: a default local build and a
published release build select different bundled extensions, so their absolute sizes are not
comparable.


Repository gates, run with Node 24.20.0, pnpm 11.22.0 on Ubuntu 26.04 - clean.

`src/dockerfile.test.ts` asserts the runtime package list as an exact string in three places,
so this PR updates those assertions to match. That is the only other change in the diff, and it
is a test update required by the change itself rather than an unrelated test edit. The file
passes 37/37 locally:

```
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.full-core-unit-src.config.ts \
    src/dockerfile.test.ts
 Test Files  1 passed (1)
      Tests  37 passed (37)
```

Correcting the record: an earlier revision of this description claimed no test asserted the
package list. That was wrong, and CI caught it on this PR.

AI-assisted