### PR TITLE
perf(test): narrow Gmail dependency fixtures

### DIFF
--- a/src/hooks/gmail-setup-utils.test.ts
+++ b/src/hooks/gmail-setup-utils.test.ts
@@ -3,8 +3,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withTestDir } from "../test-helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
-import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { withMockedPlatform } from "../test-utils/vitest-spies.js";
 const itUnix = process.platform === "win32" ? it.skip : it;
 const runCommandWithTimeoutMock = vi.fn();
@@ -29,8 +29,8 @@ describe("ensureDependency binary availability", () => {
     "checks the installed executable when installer creates it: %s",
     async (createsBinary) => {
       const { ensureDependency } = await loadGmailSetupUtils();
-      await withOpenClawTestState({ label: "dependency-probe" }, async (state) => {
-        const binDir = state.path("bin");
+      await withTestDir({ prefix: "openclaw-dependency-probe-" }, async (root) => {
+        const binDir = path.join(root, "bin");
         await fs.mkdir(binDir);
         const writeExecutable = async (name: string) => {
           const executable = path.join(binDir, name);
@@ -38,7 +38,7 @@ describe("ensureDependency binary availability", () => {
           await fs.chmod(executable, 0o755);
         };
         await writeExecutable("brew");
-        await withEnvAsync({ PATH: binDir, XDG_CONFIG_HOME: state.path("config") }, () =>
+        await withEnvAsync({ PATH: binDir, XDG_CONFIG_HOME: path.join(root, "config") }, () =>
           withMockedPlatform("darwin", async () => {
             runCommandWithTimeoutMock.mockImplementation(async (argv: string[]) => {
               expect(argv).toEqual(["brew", "install", "fixture-probe-formula"]);


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested test-performance work: the Gmail setup utility suite pays for an OpenClaw home/state/auth/session fixture in two cases that only need temporary executables. This adds avoidable imports and cleanup to every full-file run.

Related: #131617 introduced the unchanged-PATH installation regressions retained here. This does not duplicate #131502's separate Gmail error-diagnostics work.

## Why This Change Was Made

Use the existing `withTestDir` helper for those two binary-availability cases. Keep real executable files and mode `0755`, PATH/XDG restoration, the scoped Darwin mock, installer mocks, both installer outcomes, and the repeated successful lookup. All nine per-case module resets remain: Python resolution and executable caches still require fresh owner modules. The remaining seven cases are unchanged.

The canonical fixture boundary is filesystem-only here. `ensureDependency` uses `hasBinary` and the mocked installer, not OpenClaw config, auth, or SQLite state. Shared test setup still owns its isolated home and runtime cleanup. No custom helper, production seam, schema, persistence, dependency, baseline, snapshot, or runtime behavior changes. Production LOC **+0/-0**; tests **+4/-4**. Incidental full-state fixture setup/teardown is removed; no asserted behavior is removed.

## User Impact

No product behavior change. Developers get a faster full Gmail utility test run with the same nine cases and fault sensitivity.

## Evidence

### Full-file benchmark

One task-owned Blacksmith Testbox, `tbx_01m13vkwrx9wndx2xkttjm8pnc`, Linux Node **24.19.0**, pnpm **11.22.0**. [Testbox workflow](https://github.com/openclaw/openclaw/actions/runs/33160041038). Baseline source: `65e0f00dad8f51b9fd52b4212e78ebab4f670cde`. Baseline was run before editing. Warmups, hydration, sync, and resource diagnostics are excluded from the eight balanced pairs in each series. Odd pairs run baseline then candidate; even pairs reverse that order. Each invocation runs the entire file with one worker and import diagnostics:

```bash
/usr/bin/time -v env \
  OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 \
  OPENCLAW_VITEST_MAX_WORKERS=1 \
  OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=<variant-cache> \
  OPENCLAW_VITEST_IMPORT_DURATIONS=1 \
  OPENCLAW_VITEST_PRINT_IMPORT_BREAKDOWN=1 \
  pnpm test src/hooks/gmail-setup-utils.test.ts --maxWorkers=1 --reporter=verbose
```

The cold series uses a fresh cache for every sample. The additional warm series uses separately warmed baseline/candidate caches. GNU time wall values are authoritative. All 32 measured invocations passed **9/9** tests.

| Median metric | Cold baseline | Cold candidate | Warm baseline | Warm candidate |
| --- | ---: | ---: | ---: | ---: |
| Wall | 10.445s | 8.100s | 8.245s | 7.185s |
| Vitest | 6.470s | 3.975s | 3.775s | 2.765s |
| Collection import | 4.765s | 0.0195s | 2.380s | 0.009s |
| Test bodies | 0.7995s | 3.115s | 1.003s | 2.270s |
| User CPU | 11.835s | 9.130s | 9.290s | 8.080s |
| System CPU | 1.170s | 0.815s | 0.885s | 0.745s |
| Max RSS | 1118.30 MiB | 1020.67 MiB | 893.29 MiB | 773.51 MiB |

Cold savings: **2.345s / 22.45%**, all eight pairs faster. Warm savings: **1.060s / 12.86%**, seven of eight pairs faster. Warm wall pairs (baseline/candidate seconds): `9.93/7.19, 8.68/7.18, 8.31/7.51, 8.18/7.44, 8.61/7.08, 7.72/8.00, 7.52/6.09, 7.91/6.52`. The one warm loss is retained; no slow samples were discarded. Both series clear the required stable 0.5s absolute or 3% scoped-wall threshold.

Removing the static full-state import shifts required Gmail imports into the first test body; body time alone therefore increases while total time and RSS decrease. This is not a claim that all collection import time vanished from execution.

Separate temporary instrumentation observed **5 fixture roots before/after**, **18 → 14 fixture directories**, **9 → 9 per-case module resets**, and **zero remaining fixture directories**. PATH, XDG_CONFIG_HOME, and platform restored after every case. The cold process-tree diagnostic observed 6–8 processes per invocation including `/usr/bin/time` and command wrappers, peak 6–7; one Vitest worker was fixed in both versions. Installer/Python/Tailscale subprocess calls remain mocked, not real external executions.

### Reversible fault proof

Each fault was run against the full baseline and candidate files, then restored before the next experiment. All eight fault runs failed at the same intended test boundary:

| Temporary fault | Expected failure in both versions |
| --- | --- |
| Stop scanning PATH | Both binary-install cases cannot find Homebrew |
| Reintroduce cached negative binary probes | Installer creates binary, but unchanged-PATH lookup remains stale |
| Remove post-install availability check | Installer-success-without-binary case incorrectly resolves |
| Remove Python cache reuse | Python cache case loses its interpreter/call-count contract after PATH changes |

Exact production bytes restored and SHA-256 checked: `gmail-setup-utils.ts` = `ee2fb0c518e0b9c12245371ddd866b2af12280532468f33b69897a83f3725b61`; `config-eval.ts` = `09af08c8b7237dbfd6b105d405028d1546143004a75bdef9eae3a7a5b85e53d9`. Uninstrumented full-file proof passed after restoration. No fault or diagnostic instrumentation is in the patch.

### Coverage and gates

- **63 tests passed** on macOS in normal order and shuffled with seed `731`; the same **63 passed** on Linux shuffled with seed `947`. Files: Gmail utilities, Gmail operations, Gmail configuration, shared config-eval, temp-dir helper, and env helper.
- Complete local changed gate passed: `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 pnpm check:changed` (canonical flag selects local execution). Includes formatting, guards, all three dead-export scans, full core test typechecks, and changed-file lint. Initial automatic remote-delegation attempts were stopped before acquiring another lease; they are not counted as validation.
- `git diff --check`, numstat, test-audit, and deslop passed. Fresh isolated **Codex autoreview passed at P0 scope**, no accepted/actionable findings.
- One mechanical pre-push rebase onto current main; candidate bytes unchanged (SHA-256 `4405196c84732e2cc34cf7077dcd20186e5c7fe70e7574f3ed6cee49263583b0`). Upstream changes did not touch the measured owner/helper/harness surface. Focused post-rebase proof passed **9/9** on head `e169af64aeebfecad0d87fb2aa0bc0c923f0c24f`.
- The Testbox is stopped and verified `completed`. No live Gateway, authenticated Gmail, cloud resource, or native Windows run is claimed. Windows skip behavior, mocked-platform behavior, existing cleanup semantics, and real executable permissions are unchanged.

The fallback plugin-index import candidate remains unmeasured because Gmail qualified. Only this PR is in scope. AI-assisted with Codex.
