### PR TITLE
fix(release): avoid rate limits during exact-SHA validation

### DIFF
--- a/docs/reference/full-release-validation.md
+++ b/docs/reference/full-release-validation.md
@@ -69,10 +69,15 @@ The helper creates a temporary `release-ci/*` ref pinned to the Tooling SHA,
 passes the Validation SHA as both the candidate ref and `expected_sha`, and
 deletes the temporary ref after successful validation and strict evidence
 verification. The helper reads Release Decision artifacts while the parent is
-active so blockers can surface while Diagnostic Drain collects failures. A
-not-yet-created artifact remains an unavailable polling result; terminal
-handling and temporary-ref cleanup wait for the parent to complete with a
-conclusion. Failed validations retain both refs for reruns and diagnosis. The
+active so blockers can surface while Diagnostic Drain collects failures. It
+waits 15 minutes between run-discovery attempts and between parent polling
+iterations. One parent iteration may perform status, decision-artifact, and
+progress-job reads together; the delay limits repeated polling cycles rather
+than spacing every GitHub call. Run discovery makes one immediate check and one
+delayed retry before failing. A not-yet-created artifact remains an unavailable
+polling result; terminal handling and temporary-ref cleanup wait for the parent
+to complete with a conclusion. Failed validations retain both refs for reruns
+and diagnosis. The
 Validation SHA equals the Code SHA for product validation or the Release SHA
 for changelog-only validation; it is not a third release identity. The workflow
 rejects malformed or mismatched expected SHAs before child dispatch. Every

--- a/scripts/full-release-validation-at-sha.mts
+++ b/scripts/full-release-validation-at-sha.mts
@@ -28,8 +28,8 @@ const RELEASE_EVIDENCE_VERIFIER_PATHS = [
 ];
 const GH_READ_TIMEOUT_MS = 60_000;
 export const FULL_RELEASE_WAIT_TIMEOUT_MINUTES = 720;
-export const FULL_RELEASE_WAIT_POLL_INTERVAL_MS = 45_000;
-const FULL_RELEASE_PROGRESS_INTERVAL_MS = 5 * 60_000;
+export const FULL_RELEASE_GITHUB_POLL_INTERVAL_MS = 15 * 60_000;
+const FULL_RELEASE_RUN_DISCOVERY_ATTEMPTS = 2;
 const RELEASE_DECISION_FILE = "full-release-decision.json";
 const MAX_RELEASE_DECISION_BYTES = 128 * 1024;
 const GH_READ_OPTIONS = {
@@ -684,7 +684,7 @@ function waitForWorkflowRun(parentRunId: string, workflowSha: string) {
   let consecutiveErrors = 0;
   const startedAt = Date.now();
   const deadline = startedAt + FULL_RELEASE_WAIT_TIMEOUT_MINUTES * 60_000;
-  let nextProgressAt = startedAt + FULL_RELEASE_PROGRESS_INTERVAL_MS;
+  let nextProgressAt = startedAt + FULL_RELEASE_GITHUB_POLL_INTERVAL_MS;
   while (Date.now() < deadline) {
     let suite: Record<string, unknown> | undefined;
     try {
@@ -742,7 +742,7 @@ function waitForWorkflowRun(parentRunId: string, workflowSha: string) {
           `Parent run progress query failed: ${error instanceof Error ? error.message : String(error)}`,
         );
       }
-      nextProgressAt += FULL_RELEASE_PROGRESS_INTERVAL_MS;
+      nextProgressAt += FULL_RELEASE_GITHUB_POLL_INTERVAL_MS;
     }
     const remainingMs = deadline - Date.now();
     if (remainingMs <= 0) {
@@ -752,7 +752,7 @@ function waitForWorkflowRun(parentRunId: string, workflowSha: string) {
       new Int32Array(new SharedArrayBuffer(4)),
       0,
       0,
-      Math.min(FULL_RELEASE_WAIT_POLL_INTERVAL_MS, remainingMs),
+      Math.min(FULL_RELEASE_GITHUB_POLL_INTERVAL_MS, remainingMs),
     );
   }
   throw new Error(
@@ -981,12 +981,19 @@ function main() {
     }
     parentRunId = collectRunId(dispatchOutput);
     if (!parentRunId && !args.dryRun) {
-      for (let attempt = 0; attempt < 60; attempt += 1) {
+      for (let attempt = 0; attempt < FULL_RELEASE_RUN_DISCOVERY_ATTEMPTS; attempt += 1) {
         parentRunId = findLatestRunId(branch, workflowSha);
         if (parentRunId) {
           break;
         }
-        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5000);
+        if (attempt + 1 < FULL_RELEASE_RUN_DISCOVERY_ATTEMPTS) {
+          Atomics.wait(
+            new Int32Array(new SharedArrayBuffer(4)),
+            0,
+            0,
+            FULL_RELEASE_GITHUB_POLL_INTERVAL_MS,
+          );
+        }
       }
     }
     if (!parentRunId) {

--- a/test/scripts/full-release-validation-at-sha.test.ts
+++ b/test/scripts/full-release-validation-at-sha.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 import { parse as parseYaml } from "yaml";
 import {
   assertTrustedWorkflowHarness,
-  FULL_RELEASE_WAIT_POLL_INTERVAL_MS,
+  FULL_RELEASE_GITHUB_POLL_INTERVAL_MS,
   FULL_RELEASE_WAIT_TIMEOUT_MINUTES,
   parseArgs,
   releaseProfileForTarget,
@@ -55,7 +55,9 @@ function runGit(cwd: string, args: string[]): string {
 
 function createDispatchFixture(
   options: {
+    dispatchReturnsRunUrl?: boolean;
     parentRunStates?: Array<{ conclusion: string | null; status: string }>;
+    runDiscoveryMisses?: number;
     workflowSource?: string;
   } = {},
 ) {
@@ -66,16 +68,27 @@ function createDispatchFixture(
   const gitCallsPath = join(root, "git-calls.jsonl");
   const ghCallsPath = join(root, "gh-calls.jsonl");
   const parentRunIndexPath = join(root, "parent-run-index.txt");
+  const runDiscoveryIndexPath = join(root, "run-discovery-index.txt");
   const preloadPath = join(root, "immediate-poll.mjs");
+  const waitCallsPath = join(root, "wait-calls.txt");
   const releaseRef = "release/2026.8.1";
   mkdirSync(checkout);
   mkdirSync(binDir);
   writeFileSync(gitCallsPath, "");
   writeFileSync(ghCallsPath, "");
   writeFileSync(parentRunIndexPath, "0");
+  writeFileSync(runDiscoveryIndexPath, "0");
+  writeFileSync(waitCallsPath, "");
   writeFileSync(
     preloadPath,
-    'const wait = Atomics.wait; Atomics.wait = (array, index, value, timeout) => timeout === undefined ? wait(array, index, value) : "timed-out";\n',
+    `import { appendFileSync } from "node:fs";
+const wait = Atomics.wait;
+Atomics.wait = (array, index, value, timeout) => {
+  if (timeout === undefined) return wait(array, index, value);
+  appendFileSync(process.env.MOCK_WAIT_CALLS, String(timeout) + "\\n");
+  return "timed-out";
+};
+`,
   );
 
   execFileSync("git", ["init", "--bare", origin], { stdio: "ignore" });
@@ -163,6 +176,7 @@ const args = process.argv.slice(2);
 fs.appendFileSync(process.env.MOCK_GH_CALLS, JSON.stringify(args) + "\\n");
 const parentRunStates = ${JSON.stringify(options.parentRunStates ?? [{ conclusion: "success", status: "completed" }])};
 const parentRunIndexPath = ${JSON.stringify(parentRunIndexPath)};
+const runDiscoveryIndexPath = ${JSON.stringify(runDiscoveryIndexPath)};
 if (args[0] === "workflow" && args[1] === "run") {
   const declaredInputs = new Set(JSON.parse(process.env.MOCK_WORKFLOW_INPUTS));
   for (let index = 0; index < args.length; index += 1) {
@@ -175,7 +189,15 @@ if (args[0] === "workflow" && args[1] === "run") {
     }
     index += 1;
   }
-  console.log("https://github.com/openclaw/openclaw/actions/runs/123");
+  if (${JSON.stringify(options.dispatchReturnsRunUrl ?? true)}) {
+    console.log("https://github.com/openclaw/openclaw/actions/runs/123");
+  }
+} else if (args[0] === "run" && args[1] === "list") {
+  const index = Number(fs.readFileSync(runDiscoveryIndexPath, "utf8"));
+  fs.writeFileSync(runDiscoveryIndexPath, String(index + 1));
+  console.log(JSON.stringify(index < ${JSON.stringify(options.runDiscoveryMisses ?? 0)}
+    ? []
+    : [{ databaseId: 123, headSha: process.env.MOCK_WORKFLOW_SHA, createdAt: "2026-08-28T00:00:00Z" }]));
 } else if (args[0] === "api" && args.at(-1).endsWith("/actions/runs/123")) {
   const index = Number(fs.readFileSync(parentRunIndexPath, "utf8"));
   const state = parentRunStates[Math.min(index, parentRunStates.length - 1)];
@@ -207,18 +229,15 @@ if (args[0] === "workflow" && args[1] === "run") {
         encoding: "utf8",
         env: {
           ...process.env,
-          ...(options.parentRunStates
-            ? {
-                NODE_OPTIONS: [process.env.NODE_OPTIONS, "--import", preloadPath]
-                  .filter(Boolean)
-                  .join(" "),
-              }
-            : {}),
+          NODE_OPTIONS: [process.env.NODE_OPTIONS, "--import", preloadPath]
+            .filter(Boolean)
+            .join(" "),
           MOCK_GH_CALLS: ghCallsPath,
           MOCK_GIT_CALLS: gitCallsPath,
           MOCK_REAL_PATH: process.env.PATH,
           MOCK_TRUSTED_WORKFLOW_FULL_REF: trustedWorkflowFullRef,
           MOCK_TRUSTED_WORKFLOW_REF: trustedWorkflowRef,
+          MOCK_WAIT_CALLS: waitCallsPath,
           MOCK_WORKFLOW_INPUTS: JSON.stringify(declaredWorkflowInputs),
           MOCK_WORKFLOW_SHA: workflowSha,
           PATH: `${binDir}:${process.env.PATH}`,
@@ -232,6 +251,8 @@ if (args[0] === "workflow" && args[1] === "run") {
       .split("\n")
       .filter(Boolean)
       .map((line) => JSON.parse(line) as string[]);
+  const readWaits = (): number[] =>
+    readFileSync(waitCallsPath, "utf8").trim().split("\n").filter(Boolean).map(Number);
 
   return {
     checkout,
@@ -241,6 +262,7 @@ if (args[0] === "workflow" && args[1] === "run") {
     origin,
     oldWorkflowSha,
     readCalls,
+    readWaits,
     releaseRef,
     run,
     targetSha,
@@ -583,19 +605,58 @@ describe("full-release-validation-at-sha", () => {
   it("bounds polling for the exact workflow run", () => {
     const source = readFileSync("scripts/full-release-validation-at-sha.mts", "utf8");
     expect(FULL_RELEASE_WAIT_TIMEOUT_MINUTES).toBe(720);
-    expect(FULL_RELEASE_WAIT_POLL_INTERVAL_MS).toBe(45_000);
-    expect(source).toContain("const FULL_RELEASE_PROGRESS_INTERVAL_MS = 5 * 60_000;");
+    expect(FULL_RELEASE_GITHUB_POLL_INTERVAL_MS).toBe(900_000);
     expect(source).toContain("workflowRun.head_sha !== workflowSha");
     expect(source).toContain("return suite;");
     expect(source).toContain("startedAt + FULL_RELEASE_WAIT_TIMEOUT_MINUTES * 60_000");
     expect(source).toContain("const remainingMs = deadline - Date.now();");
-    expect(source).toContain("Math.min(FULL_RELEASE_WAIT_POLL_INTERVAL_MS, remainingMs)");
+    expect(source).toContain("Math.min(FULL_RELEASE_GITHUB_POLL_INTERVAL_MS, remainingMs)");
     expect(source).toContain("Parent run progress after ${elapsedMinutes}m");
     expect(source).toContain("formatReleaseStateOutcome(releaseDecision)");
     expect(source).toContain(
       "Timed out after ${FULL_RELEASE_WAIT_TIMEOUT_MINUTES} minutes waiting for Full Release Validation",
     );
     expect(source).not.toContain("attempt < 480");
+  });
+
+  it("waits 15 minutes between run-discovery attempts and parent polling iterations", () => {
+    const fixture = createDispatchFixture({
+      dispatchReturnsRunUrl: false,
+      parentRunStates: [
+        { conclusion: null, status: "in_progress" },
+        { conclusion: "success", status: "completed" },
+      ],
+      runDiscoveryMisses: 1,
+    });
+    try {
+      const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
+      expect(result.status, result.stderr).toBe(0);
+      expect(fixture.readWaits()).toEqual([900_000, 900_000]);
+      const calls = fixture.readCalls(fixture.ghCallsPath);
+      expect(calls.filter((args) => args[0] === "run" && args[1] === "list")).toHaveLength(2);
+      expect(
+        calls.filter((args) => args[0] === "api" && args[1]?.endsWith("/actions/runs/123")),
+      ).toHaveLength(2);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("bounds run discovery to one delayed retry", () => {
+    const fixture = createDispatchFixture({
+      dispatchReturnsRunUrl: false,
+      runDiscoveryMisses: 2,
+    });
+    try {
+      const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("Could not determine Full Release Validation run id.");
+      expect(fixture.readWaits()).toEqual([900_000]);
+      const calls = fixture.readCalls(fixture.ghCallsPath);
+      expect(calls.filter((args) => args[0] === "run" && args[1] === "list")).toHaveLength(2);
+    } finally {
+      fixture.cleanup();
+    }
   });
 
   it("binds release decisions to the exact parent attempt and tooling SHA", () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where exact-SHA Full Release Validation could consume GitHub API quota unnecessarily while waiting for workflow discovery and completion. The helper retried run discovery every 5 seconds and parent status every 45 seconds, creating avoidable rate-limit pressure during long release-validation campaigns.

## Why This Change Was Made

The helper now uses one 15-minute polling cadence across run discovery, parent status, and progress queries, with one bounded discovery retry. This keeps the exact-SHA validation contract intact while preventing tight repeated GitHub reads.

## User Impact

Release operators can run exact-SHA validation with substantially lower GitHub API pressure. The tradeoff is intentionally slower status visibility while a validation run is active.

## Evidence

- Pre-fix regression proof recorded wait durations `[5000, 45000]`.
- Post-fix focused suite: 33/33 tests passed.
- Entrypoint behavior records `900000` ms waits for discovery and parent-status polling.
- Formatting, focused lint, and script-erasability checks passed.
- `check:changed --dry-run` selected the expected scripts, root-test, docs, and tooling lanes.
- Full `check:changed` was limited by unrelated stale shared `pako@1.0.11` state and sparse-checkout omissions; this is not presented as a passing full gate.
- Independent Claude autoreview reported no findings.

LOC split:

- Tooling: `+14/-7`
- Tests: `+74/-13`
- Docs/changelog: `+5/-1`
