### PR TITLE
feat(ui): persist Sessions view preferences

### DIFF
--- a/ui/src/pages/sessions/page-state.ts
+++ b/ui/src/pages/sessions/page-state.ts
@@ -1,16 +1,137 @@
-import { normalizeSessionsGroupBy, type SessionsGroupBy } from "../../lib/sessions/grouping.ts";
+import { parseStrictPositiveInteger } from "@openclaw/normalization-core/number-coercion";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import {
+  normalizeSessionsGroupBy,
+  SESSION_GROUP_MODES,
+  type SessionsGroupBy,
+} from "../../lib/sessions/grouping.ts";
+import type { SessionArchivedFilter } from "../../lib/sessions/index.ts";
 import { getSafeLocalStorage } from "../../local-storage.ts";
 
-const GROUP_BY_STORAGE_KEY = "openclaw:sessions:group-by";
+const LEGACY_GROUP_BY_STORAGE_KEY = "openclaw:sessions:group-by";
+const SESSIONS_PAGE_PREFERENCES_STORAGE_KEY = "openclaw:sessions:preferences:v1";
+const SORT_COLUMNS = ["key", "kind", "updated", "tokens"] as const;
+const SORT_DIRECTIONS = ["asc", "desc"] as const;
+const STATUS_FILTERS = ["active", "archived", "all"] as const;
+const PAGE_SIZES = [10, 25, 50, 100] as const;
+export type SessionsSortColumn = (typeof SORT_COLUMNS)[number];
+export type SessionsSortDirection = (typeof SORT_DIRECTIONS)[number];
 
-export function loadStoredGroupBy(): SessionsGroupBy {
-  return normalizeSessionsGroupBy(getSafeLocalStorage()?.getItem(GROUP_BY_STORAGE_KEY));
+export type SessionsPagePreferences = {
+  activeMinutes: string;
+  limit: string;
+  includeGlobal: boolean;
+  includeUnknown: boolean;
+  statusFilter: SessionArchivedFilter;
+  searchQuery: string;
+  sortColumn: SessionsSortColumn;
+  sortDir: SessionsSortDirection;
+  groupBy: SessionsGroupBy;
+  pageSize: number;
+};
+
+const DEFAULT_SESSIONS_PAGE_PREFERENCES: SessionsPagePreferences = {
+  activeMinutes: "",
+  limit: "50",
+  includeGlobal: true,
+  includeUnknown: false,
+  statusFilter: "active",
+  searchQuery: "",
+  sortColumn: "updated",
+  sortDir: "desc",
+  groupBy: "none",
+  pageSize: 25,
+};
+
+function isPreferenceValue<T extends string | number>(
+  value: unknown,
+  values: readonly T[],
+): value is T {
+  return values.some((candidate) => candidate === value);
 }
 
-export function saveStoredGroupBy(mode: SessionsGroupBy): void {
+function positiveIntegerString(value: unknown, fallback: string, allowEmpty = false): string {
+  if (allowEmpty && value === "") {
+    return "";
+  }
+  return typeof value === "string" && parseStrictPositiveInteger(value) !== undefined
+    ? value
+    : fallback;
+}
+
+function readStorageValue(storage: Storage, key: string): string | null {
   try {
-    getSafeLocalStorage()?.setItem(GROUP_BY_STORAGE_KEY, mode);
+    return storage.getItem(key);
   } catch {
-    // Storage may be unavailable or full; the in-memory selection still applies.
+    return null;
+  }
+}
+
+function storedGroupBy(storage: Storage): SessionsGroupBy {
+  const raw = readStorageValue(storage, LEGACY_GROUP_BY_STORAGE_KEY);
+  return normalizeSessionsGroupBy(raw);
+}
+
+export function loadSessionsPagePreferences(): SessionsPagePreferences {
+  const storage = getSafeLocalStorage();
+  if (!storage) {
+    return { ...DEFAULT_SESSIONS_PAGE_PREFERENCES };
+  }
+  const legacyGroupBy = storedGroupBy(storage);
+  const raw = readStorageValue(storage, SESSIONS_PAGE_PREFERENCES_STORAGE_KEY);
+  if (!raw) {
+    return { ...DEFAULT_SESSIONS_PAGE_PREFERENCES, groupBy: legacyGroupBy };
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed) || parsed.version !== 1) {
+      return { ...DEFAULT_SESSIONS_PAGE_PREFERENCES, groupBy: legacyGroupBy };
+    }
+    return {
+      activeMinutes: positiveIntegerString(parsed.activeMinutes, "", true),
+      limit: positiveIntegerString(parsed.limit, DEFAULT_SESSIONS_PAGE_PREFERENCES.limit),
+      includeGlobal:
+        typeof parsed.includeGlobal === "boolean"
+          ? parsed.includeGlobal
+          : DEFAULT_SESSIONS_PAGE_PREFERENCES.includeGlobal,
+      includeUnknown:
+        typeof parsed.includeUnknown === "boolean"
+          ? parsed.includeUnknown
+          : DEFAULT_SESSIONS_PAGE_PREFERENCES.includeUnknown,
+      statusFilter: isPreferenceValue(parsed.statusFilter, STATUS_FILTERS)
+        ? parsed.statusFilter
+        : DEFAULT_SESSIONS_PAGE_PREFERENCES.statusFilter,
+      searchQuery:
+        typeof parsed.searchQuery === "string"
+          ? parsed.searchQuery
+          : DEFAULT_SESSIONS_PAGE_PREFERENCES.searchQuery,
+      sortColumn: isPreferenceValue(parsed.sortColumn, SORT_COLUMNS)
+        ? parsed.sortColumn
+        : DEFAULT_SESSIONS_PAGE_PREFERENCES.sortColumn,
+      sortDir: isPreferenceValue(parsed.sortDir, SORT_DIRECTIONS)
+        ? parsed.sortDir
+        : DEFAULT_SESSIONS_PAGE_PREFERENCES.sortDir,
+      groupBy: isPreferenceValue(parsed.groupBy, SESSION_GROUP_MODES)
+        ? parsed.groupBy
+        : legacyGroupBy,
+      pageSize: isPreferenceValue(parsed.pageSize, PAGE_SIZES)
+        ? parsed.pageSize
+        : DEFAULT_SESSIONS_PAGE_PREFERENCES.pageSize,
+    };
+  } catch {
+    return { ...DEFAULT_SESSIONS_PAGE_PREFERENCES, groupBy: legacyGroupBy };
+  }
+}
+
+export function saveSessionsPagePreferences(preferences: SessionsPagePreferences): void {
+  try {
+    const storage = getSafeLocalStorage();
+    storage?.setItem(
+      SESSIONS_PAGE_PREFERENCES_STORAGE_KEY,
+      JSON.stringify({ version: 1, ...preferences }),
+    );
+    storage?.removeItem(LEGACY_GROUP_BY_STORAGE_KEY);
+  } catch {
+    // Storage may be unavailable or full; current in-memory preferences still apply.
   }
 }

--- a/ui/src/pages/sessions/page-state.ts
+++ b/ui/src/pages/sessions/page-state.ts
@@ -123,14 +123,18 @@ export function loadSessionsPagePreferences(): SessionsPagePreferences {
   }
 }
 
-export function saveSessionsPagePreferences(preferences: SessionsPagePreferences): void {
+export function saveSessionsPagePreferences(changes: Partial<SessionsPagePreferences>): void {
   try {
     const storage = getSafeLocalStorage();
-    storage?.setItem(
+    if (!storage) {
+      return;
+    }
+    const preferences = { ...loadSessionsPagePreferences(), ...changes };
+    storage.setItem(
       SESSIONS_PAGE_PREFERENCES_STORAGE_KEY,
       JSON.stringify({ version: 1, ...preferences }),
     );
-    storage?.removeItem(LEGACY_GROUP_BY_STORAGE_KEY);
+    storage.removeItem(LEGACY_GROUP_BY_STORAGE_KEY);
   } catch {
     // Storage may be unavailable or full; current in-memory preferences still apply.
   }

--- a/ui/src/pages/sessions/route-preferences.runtime.ts
+++ b/ui/src/pages/sessions/route-preferences.runtime.ts
@@ -1,0 +1,1 @@
+export { loadSessionsPagePreferences } from "./page-state.ts";

--- a/ui/src/pages/sessions/route.test.ts
+++ b/ui/src/pages/sessions/route.test.ts
@@ -1,15 +1,17 @@
-// @vitest-environment node
+// @vitest-environment jsdom
 
 import type { RouteLoaderOptions } from "@openclaw/uirouter";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ApplicationContext } from "../../app/context.ts";
 import type { SessionListOptions } from "../../lib/sessions/index.ts";
+import { createStorageMock } from "../../test-helpers/storage.ts";
+import { loadSessionsPagePreferences, saveSessionsPagePreferences } from "./page-state.ts";
 import { page, sessionsPageListQuery, type SessionsRouteData } from "./route.ts";
 
 async function loadSessionsRoute(options: {
   search: string;
   scopeId: string | null;
-  expectedQuery: SessionListOptions;
+  expectedData: SessionsRouteData;
 }) {
   const list = vi.fn();
   const listSnapshot = vi.fn();
@@ -34,80 +36,82 @@ async function loadSessionsRoute(options: {
   expect(refreshList).not.toHaveBeenCalled();
   expect(listSnapshot).not.toHaveBeenCalled();
   expect(list).not.toHaveBeenCalled();
-  expect(data).toEqual({
-    expandedSessionKey: options.expectedQuery.search ?? null,
-    statusFilter: options.expectedQuery.archivedFilter,
-  });
-  expect(
-    sessionsPageListQuery(context, {
-      statusFilter: data.statusFilter,
-      deepLinkSessionKey: data.expandedSessionKey,
-      includeGlobal: true,
-      includeUnknown: false,
-      limit: 50,
-    }),
-  ).toEqual(options.expectedQuery);
+  expect(data).toEqual(options.expectedData);
 }
 
 describe("sessions route", () => {
-  it.each([
-    {
-      name: "default selected-agent roster",
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", createStorageMock());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uses the persisted status for the initial roster", async () => {
+    saveSessionsPagePreferences({
+      ...loadSessionsPagePreferences(),
+      statusFilter: "archived",
+    });
+
+    await loadSessionsRoute({
       search: "",
       scopeId: "writer",
-      expectedQuery: {
-        limit: 50,
-        includeGlobal: true,
-        includeUnknown: false,
-        includeDerivedTitles: false,
-        includeLastMessage: false,
-        archivedFilter: "active" as const,
-        agentId: "writer",
-      },
-    },
-    {
-      name: "archived all-agent roster",
-      search: "?status=archived",
-      scopeId: null,
-      expectedQuery: {
-        limit: 50,
-        includeGlobal: true,
-        includeUnknown: false,
-        includeDerivedTitles: false,
-        includeLastMessage: false,
-        archivedFilter: "archived" as const,
-      },
-    },
-    {
-      name: "all-status selected-agent roster",
+      expectedData: { expandedSessionKey: null, statusFilter: "archived" },
+    });
+  });
+
+  it("keeps explicit status URLs ahead of persisted status", async () => {
+    saveSessionsPagePreferences({
+      ...loadSessionsPagePreferences(),
+      statusFilter: "archived",
+    });
+
+    await loadSessionsRoute({
       search: "?status=all",
-      scopeId: "main",
-      expectedQuery: {
-        limit: 50,
-        includeGlobal: true,
-        includeUnknown: false,
-        includeDerivedTitles: false,
-        includeLastMessage: false,
-        archivedFilter: "all" as const,
-        agentId: "main",
-      },
-    },
-    {
-      name: "deep link owned by a different agent",
+      scopeId: null,
+      expectedData: { expandedSessionKey: null, statusFilter: "all" },
+    });
+  });
+
+  it("keeps direct-session links active and isolated from persisted status", async () => {
+    saveSessionsPagePreferences({
+      ...loadSessionsPagePreferences(),
+      statusFilter: "archived",
+    });
+
+    await loadSessionsRoute({
       search: "?session=agent%3Aresearch%3Alinked",
       scopeId: "main",
-      expectedQuery: {
-        limit: 50,
-        search: "agent:research:linked",
-        includeGlobal: true,
-        includeUnknown: true,
-        includeDerivedTitles: false,
-        includeLastMessage: false,
-        archivedFilter: "active" as const,
-        agentId: "research",
+      expectedData: {
+        expandedSessionKey: "agent:research:linked",
+        statusFilter: "active",
       },
-    },
-  ])("prepares the $name without issuing outside the page owner", async (testCase) => {
-    await loadSessionsRoute(testCase);
+    });
+  });
+
+  it("keeps direct-session list queries independent from roster filters", () => {
+    const context = {
+      agentSelection: { state: { scopeId: "main" } },
+    } as unknown as ApplicationContext;
+    const query = sessionsPageListQuery(context, {
+      activeMinutes: 15,
+      limit: 10,
+      includeGlobal: false,
+      includeUnknown: false,
+      statusFilter: "archived",
+      deepLinkSessionKey: "agent:research:linked",
+    });
+
+    expect(query).toEqual({
+      limit: 50,
+      search: "agent:research:linked",
+      includeGlobal: true,
+      includeUnknown: true,
+      includeDerivedTitles: false,
+      includeLastMessage: false,
+      archivedFilter: "archived",
+      agentId: "research",
+    } satisfies SessionListOptions);
   });
 });

--- a/ui/src/pages/sessions/route.ts
+++ b/ui/src/pages/sessions/route.ts
@@ -25,14 +25,24 @@ type SessionsPageListFilters = {
   search?: string;
 };
 
-function routeOptions(location: RouteLocation) {
+function routeOptions(
+  location: RouteLocation,
+  storedStatusFilter: SessionArchivedFilter = "active",
+) {
   const search = new URLSearchParams(location.search);
   const expandedSessionKey = search.get("session")?.trim() || null;
   // The retired internal `showArchived` param is deliberately not read; Sessions
   // URLs are not a shipped contract and stale links fall back to the Active view.
   const requestedStatus = search.get("status");
-  const statusFilter: SessionArchivedFilter =
-    requestedStatus === "archived" ? "archived" : requestedStatus === "all" ? "all" : "active";
+  const statusFilter: SessionArchivedFilter = search.has("status")
+    ? requestedStatus === "archived"
+      ? "archived"
+      : requestedStatus === "all"
+        ? "all"
+        : "active"
+    : expandedSessionKey
+      ? "active"
+      : storedStatusFilter;
   return { expandedSessionKey, statusFilter };
 }
 
@@ -65,10 +75,12 @@ async function loadSessionsRoute(
   context: ApplicationContext,
   location: RouteLocation,
 ): Promise<SessionsRouteData> {
+  const preferenceState = await import("./route-preferences.runtime.ts");
+  const preferences = preferenceState.loadSessionsPagePreferences();
   await context.runtimeConfig.ensureLoaded().catch(() => undefined);
   // The mounted page owns list issuance, including scope/status navigation
   // during a search. Prefetching here bypasses its single in-flight request.
-  return routeOptions(location);
+  return routeOptions(location, preferences.statusFilter);
 }
 
 export const page = definePage({

--- a/ui/src/pages/sessions/sessions-page.roster.test.ts
+++ b/ui/src/pages/sessions/sessions-page.roster.test.ts
@@ -37,6 +37,7 @@ async function createPage(context: ApplicationContext): Promise<TestSessionsPage
 
 afterEach(() => {
   document.body.replaceChildren();
+  localStorage.clear();
   vi.restoreAllMocks();
 });
 

--- a/ui/src/pages/sessions/sessions-page.test.ts
+++ b/ui/src/pages/sessions/sessions-page.test.ts
@@ -21,6 +21,8 @@ import type {
   SessionDeleteOutcome,
   SessionDeleteTarget,
 } from "../../lib/sessions/session-capability.ts";
+import { loadSessionsPagePreferences } from "./page-state.ts";
+import type { SessionsPagePreferences } from "./page-state.ts";
 import {
   createContext,
   createGateway,
@@ -89,11 +91,99 @@ async function createDeletionPage(rows: GatewaySessionRow[], agentId = "main") {
 
 afterEach(() => {
   document.body.replaceChildren();
+  localStorage.clear();
   vi.mocked(showConfirmDialog).mockReset();
   vi.restoreAllMocks();
 });
 
 describe("sessions page lifecycle", () => {
+  it("merges ordered preference updates from two page owners", async () => {
+    const first = await createRenderedPage(
+      createContext(createGateway({} as GatewayBrowserClient).gateway, createSessions()),
+    );
+    const second = await createRenderedPage(
+      createContext(createGateway({} as GatewayBrowserClient).gateway, createSessions()),
+    );
+    const persist = (page: TestSessionsPage, changes: Partial<SessionsPagePreferences>) =>
+      (
+        page as unknown as {
+          persistPreferences: (value: Partial<SessionsPagePreferences>) => void;
+        }
+      ).persistPreferences(changes);
+
+    persist(first, { activeMinutes: "5" });
+    persist(second, { groupBy: "person" });
+
+    expect(loadSessionsPagePreferences()).toMatchObject({ activeMinutes: "5", groupBy: "person" });
+  });
+
+  it("does not replay a failed old field on a later write", async () => {
+    const first = await createRenderedPage(
+      createContext(createGateway({} as GatewayBrowserClient).gateway, createSessions()),
+    );
+    const second = await createRenderedPage(
+      createContext(createGateway({} as GatewayBrowserClient).gateway, createSessions()),
+    );
+    const persist = (page: TestSessionsPage, changes: Partial<SessionsPagePreferences>) =>
+      (
+        page as unknown as {
+          persistPreferences: (value: Partial<SessionsPagePreferences>) => void;
+        }
+      ).persistPreferences(changes);
+
+    const setItem = vi.spyOn(Storage.prototype, "setItem").mockImplementationOnce(() => {
+      throw new Error("storage unavailable");
+    });
+    persist(first, { groupBy: "agent" });
+    setItem.mockRestore();
+    persist(second, { groupBy: "person" });
+    persist(first, { activeMinutes: "5" });
+
+    expect(loadSessionsPagePreferences()).toMatchObject({ activeMinutes: "5", groupBy: "person" });
+  });
+
+  it("keeps a failed preference write through a route update", async () => {
+    const page = await createRenderedPage(
+      createContext(createGateway({} as GatewayBrowserClient).gateway, createSessions()),
+    );
+    const persist = (
+      page as unknown as { persistPreferences: (value: Record<string, unknown>) => void }
+    ).persistPreferences;
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("storage unavailable");
+    });
+    page.searchQuery = "keep me";
+    persist.call(page, { searchQuery: "keep me" });
+
+    page.routeData = { expandedSessionKey: null, statusFilter: "archived" };
+    await page.updateComplete;
+
+    expect(page.searchQuery).toBe("keep me");
+  });
+
+  it("restores preferences after leaving a direct-session route", async () => {
+    const page = await createRenderedPage(
+      createContext(createGateway({} as GatewayBrowserClient).gateway, createSessions()),
+    );
+    page.searchQuery = "before deep link";
+    (
+      page as unknown as {
+        persistPreferences: (value: Partial<SessionsPagePreferences>) => void;
+      }
+    ).persistPreferences({ searchQuery: "before deep link" });
+    page.routeData = {
+      expandedSessionKey: "agent:main:direct",
+      statusFilter: "active",
+    };
+    await page.updateComplete;
+    expect(page.searchQuery).toBe("");
+
+    page.routeData = { expandedSessionKey: null, statusFilter: "active" };
+    await page.updateComplete;
+
+    expect(page.searchQuery).toBe("before deep link");
+  });
+
   it("switches between Active and Archived with the route parameter", async () => {
     const { gateway } = createGateway({} as GatewayBrowserClient);
     const context = createContext(gateway, createSessions());

--- a/ui/src/pages/sessions/sessions-page.test.ts
+++ b/ui/src/pages/sessions/sessions-page.test.ts
@@ -1,5 +1,6 @@
 /* @vitest-environment jsdom */
 
+import type { RouteLoaderOptions } from "@openclaw/uirouter";
 import { nothing } from "lit";
 import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import type { PreservedSessionWorktree } from "../../../../packages/gateway-protocol/src/index.js";
@@ -23,6 +24,7 @@ import type {
 } from "../../lib/sessions/session-capability.ts";
 import { loadSessionsPagePreferences } from "./page-state.ts";
 import type { SessionsPagePreferences } from "./page-state.ts";
+import { page as sessionsRoutePage, type SessionsRouteData } from "./route.ts";
 import {
   createContext,
   createGateway,
@@ -122,20 +124,27 @@ describe("sessions page lifecycle", () => {
   it("does not replay a failed old field on a later write", async () => {
     const first = await createPreferencesPage();
     const second = await createPreferencesPage();
-    const setItem = vi.spyOn(Storage.prototype, "setItem").mockImplementationOnce(() => {
+    const storage = localStorage;
+    const storedBeforeFailure = storage.getItem("openclaw:sessions:preferences:v1");
+    const setItem = vi.spyOn(storage, "setItem").mockImplementationOnce(() => {
       throw new Error("storage unavailable");
     });
     first.persistPreferences({ groupBy: "agent" });
-    setItem.mockRestore();
+    expect(setItem).toHaveBeenCalledTimes(1);
+    expect(storage.getItem("openclaw:sessions:preferences:v1")).toBe(storedBeforeFailure);
     second.persistPreferences({ groupBy: "person" });
     first.persistPreferences({ activeMinutes: "5" });
 
+    expect(setItem).toHaveBeenCalledTimes(3);
     expect(loadSessionsPagePreferences()).toMatchObject({ activeMinutes: "5", groupBy: "person" });
   });
 
   it("keeps a failed preference write through a route update", async () => {
     const page = await createPreferencesPage();
-    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+    const storage = localStorage;
+    page.persistPreferences({ searchQuery: "stored value" });
+    const storedBeforeFailure = storage.getItem("openclaw:sessions:preferences:v1");
+    const setItem = vi.spyOn(storage, "setItem").mockImplementation(() => {
       throw new Error("storage unavailable");
     });
     page.searchQuery = "keep me";
@@ -144,6 +153,8 @@ describe("sessions page lifecycle", () => {
     page.routeData = { expandedSessionKey: null, statusFilter: "archived" };
     await page.updateComplete;
 
+    expect(setItem).toHaveBeenCalled();
+    expect(storage.getItem("openclaw:sessions:preferences:v1")).toBe(storedBeforeFailure);
     expect(page.searchQuery).toBe("keep me");
   });
 
@@ -199,6 +210,62 @@ describe("sessions page lifecycle", () => {
       )?.checked,
     ).toBe(true);
   });
+
+  it.each(["archived", "all"] as const)(
+    "keeps an Active navigation explicit when saving a %s preference fails",
+    async (storedStatusFilter) => {
+      const storage = localStorage;
+      storage.setItem(
+        "openclaw:sessions:preferences:v1",
+        JSON.stringify({ version: 1, statusFilter: storedStatusFilter }),
+      );
+      const { gateway } = createGateway({} as GatewayBrowserClient);
+      const context = createContext(gateway, createSessions());
+      Object.assign(context.runtimeConfig, { ensureLoaded: vi.fn(async () => undefined) });
+      const page = await createRenderedPage(context, sessionsResult([], 0), storedStatusFilter);
+      const setItem = vi.spyOn(storage, "setItem").mockImplementation(() => {
+        throw new Error("storage unavailable");
+      });
+      const active = [
+        ...page.querySelectorAll<HTMLElement & { checked: boolean }>("wa-radio"),
+      ].find((radio) => radio.textContent?.trim() === "Active");
+      const group = active?.closest<HTMLElement & { value: string }>("wa-radio-group");
+      expect(group).toBeDefined();
+      group!.value = "active";
+      group!.dispatchEvent(new Event("change", { bubbles: true }));
+      await page.updateComplete;
+
+      expect(setItem).toHaveBeenCalled();
+      expect(setItem).toHaveBeenCalledTimes(1);
+      expect(loadSessionsPagePreferences().statusFilter).toBe(storedStatusFilter);
+      expect(context.navigate).toHaveBeenCalledWith("sessions", { search: "?status=active" });
+
+      const navigation = vi.mocked(context.navigate).mock.calls.at(-1);
+      const routeData = await sessionsRoutePage.loader?.(context, {
+        signal: new AbortController().signal,
+        shouldRun: () => true,
+        revalidating: false,
+        location: {
+          pathname: "/sessions",
+          search: navigation?.[1]?.search ?? "",
+          hash: "",
+        },
+        deps: "",
+        cause: "navigation",
+      } satisfies RouteLoaderOptions);
+      if (
+        !routeData ||
+        typeof routeData !== "object" ||
+        !("expandedSessionKey" in routeData) ||
+        !("statusFilter" in routeData)
+      ) {
+        throw new Error("sessions route loader did not return route data");
+      }
+      page.routeData = routeData as SessionsRouteData;
+      await page.updateComplete;
+      expect(page.statusFilter).toBe("active");
+    },
+  );
 
   it("offers undo after archiving from the Sessions page", async () => {
     const key = "agent:main:pinned";

--- a/ui/src/pages/sessions/sessions-page.test.ts
+++ b/ui/src/pages/sessions/sessions-page.test.ts
@@ -48,6 +48,19 @@ async function createPage(context: ApplicationContext): Promise<TestSessionsPage
   return page;
 }
 
+type TestPreferencesPage = TestSessionsPage &
+  Pick<SessionsPagePreferences, "searchQuery"> & {
+    persistPreferences: (changes: Partial<SessionsPagePreferences>) => void;
+  };
+
+async function createPreferencesPage(): Promise<TestPreferencesPage> {
+  const gateway = createGateway({} as GatewayBrowserClient);
+  return (await createRenderedPage(
+    createContext(gateway.gateway, createSessions()),
+    sessionsResult([], 0),
+  )) as TestPreferencesPage;
+}
+
 async function createDeletionPage(rows: GatewaySessionRow[], agentId = "main") {
   let serverRows = rows;
   const deleteRequest = vi.fn(
@@ -98,62 +111,35 @@ afterEach(() => {
 
 describe("sessions page lifecycle", () => {
   it("merges ordered preference updates from two page owners", async () => {
-    const first = await createRenderedPage(
-      createContext(createGateway({} as GatewayBrowserClient).gateway, createSessions()),
-    );
-    const second = await createRenderedPage(
-      createContext(createGateway({} as GatewayBrowserClient).gateway, createSessions()),
-    );
-    const persist = (page: TestSessionsPage, changes: Partial<SessionsPagePreferences>) =>
-      (
-        page as unknown as {
-          persistPreferences: (value: Partial<SessionsPagePreferences>) => void;
-        }
-      ).persistPreferences(changes);
-
-    persist(first, { activeMinutes: "5" });
-    persist(second, { groupBy: "person" });
+    const first = await createPreferencesPage();
+    const second = await createPreferencesPage();
+    first.persistPreferences({ activeMinutes: "5" });
+    second.persistPreferences({ groupBy: "person" });
 
     expect(loadSessionsPagePreferences()).toMatchObject({ activeMinutes: "5", groupBy: "person" });
   });
 
   it("does not replay a failed old field on a later write", async () => {
-    const first = await createRenderedPage(
-      createContext(createGateway({} as GatewayBrowserClient).gateway, createSessions()),
-    );
-    const second = await createRenderedPage(
-      createContext(createGateway({} as GatewayBrowserClient).gateway, createSessions()),
-    );
-    const persist = (page: TestSessionsPage, changes: Partial<SessionsPagePreferences>) =>
-      (
-        page as unknown as {
-          persistPreferences: (value: Partial<SessionsPagePreferences>) => void;
-        }
-      ).persistPreferences(changes);
-
+    const first = await createPreferencesPage();
+    const second = await createPreferencesPage();
     const setItem = vi.spyOn(Storage.prototype, "setItem").mockImplementationOnce(() => {
       throw new Error("storage unavailable");
     });
-    persist(first, { groupBy: "agent" });
+    first.persistPreferences({ groupBy: "agent" });
     setItem.mockRestore();
-    persist(second, { groupBy: "person" });
-    persist(first, { activeMinutes: "5" });
+    second.persistPreferences({ groupBy: "person" });
+    first.persistPreferences({ activeMinutes: "5" });
 
     expect(loadSessionsPagePreferences()).toMatchObject({ activeMinutes: "5", groupBy: "person" });
   });
 
   it("keeps a failed preference write through a route update", async () => {
-    const page = await createRenderedPage(
-      createContext(createGateway({} as GatewayBrowserClient).gateway, createSessions()),
-    );
-    const persist = (
-      page as unknown as { persistPreferences: (value: Record<string, unknown>) => void }
-    ).persistPreferences;
+    const page = await createPreferencesPage();
     vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
       throw new Error("storage unavailable");
     });
     page.searchQuery = "keep me";
-    persist.call(page, { searchQuery: "keep me" });
+    page.persistPreferences({ searchQuery: "keep me" });
 
     page.routeData = { expandedSessionKey: null, statusFilter: "archived" };
     await page.updateComplete;
@@ -162,15 +148,9 @@ describe("sessions page lifecycle", () => {
   });
 
   it("restores preferences after leaving a direct-session route", async () => {
-    const page = await createRenderedPage(
-      createContext(createGateway({} as GatewayBrowserClient).gateway, createSessions()),
-    );
+    const page = await createPreferencesPage();
     page.searchQuery = "before deep link";
-    (
-      page as unknown as {
-        persistPreferences: (value: Partial<SessionsPagePreferences>) => void;
-      }
-    ).persistPreferences({ searchQuery: "before deep link" });
+    page.persistPreferences({ searchQuery: "before deep link" });
     page.routeData = {
       expandedSessionKey: "agent:main:direct",
       statusFilter: "active",

--- a/ui/src/pages/sessions/sessions-page.transcript-search.test.ts
+++ b/ui/src/pages/sessions/sessions-page.transcript-search.test.ts
@@ -19,6 +19,7 @@ import {
 
 afterEach(() => {
   document.body.replaceChildren();
+  localStorage.clear();
   vi.restoreAllMocks();
 });
 

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -84,7 +84,7 @@ import {
   type SessionsSortDirection,
 } from "./page-state.ts";
 import { sessionsPageListQuery, type SessionsRouteData } from "./route.ts";
-import { renderSessions, type SessionsProps, type TranscriptSearchState } from "./view.ts";
+import { renderSessions, type SessionsProps } from "./view.ts";
 
 const SESSIONS_DOCS_URL = "https://docs.openclaw.ai/concepts/session";
 const SESSION_SEARCH_DEBOUNCE_MS = 200;
@@ -118,7 +118,7 @@ class SessionsPage extends OpenClawLightDomElement {
   @property({ attribute: false }) routeData?: SessionsRouteData;
 
   private readonly initialPreferences = loadSessionsPagePreferences();
-  private persistedPreferences = this.initialPreferences;
+  private preferenceSnapshot = this.initialPreferences;
   @state() private result: SessionsListResult | null = null;
   @state() private loading = false;
   @state() private error: string | null = null;
@@ -130,7 +130,6 @@ class SessionsPage extends OpenClawLightDomElement {
   @state() private searchQuery = this.initialPreferences.searchQuery;
   @state() private transcriptSearchQuery = "";
   @state() private submittedTranscriptSearchQuery = "";
-  @state() private transcriptSearch: TranscriptSearchState = { status: "idle" };
   @state() private sortColumn: SessionsSortColumn = this.initialPreferences.sortColumn;
   @state() private sortDir: SessionsSortDirection = this.initialPreferences.sortDir;
   @state() private groupBy: SessionsGroupBy = this.initialPreferences.groupBy;
@@ -402,6 +401,7 @@ class SessionsPage extends OpenClawLightDomElement {
     if (!data || !context) {
       return;
     }
+    const leavingDeepLink = this.appliedRouteData?.expandedSessionKey && !data.expandedSessionKey;
     if (data !== this.appliedRouteData) {
       this.appliedRouteData = data;
       this.routeDataEnabled = true;
@@ -419,7 +419,9 @@ class SessionsPage extends OpenClawLightDomElement {
       this.page = 0;
       this.selectedKeys = new Set();
     } else {
-      this.applyStoredPreferences();
+      if (leavingDeepLink) {
+        this.restorePreferenceSnapshot();
+      }
       // An explicit route status owns this visit without overwriting the saved default.
       this.statusFilter = data.statusFilter;
     }
@@ -972,23 +974,23 @@ class SessionsPage extends OpenClawLightDomElement {
     this.persistPreferences({ groupBy: mode });
   }
 
-  private applyStoredPreferences() {
-    const preferences = loadSessionsPagePreferences();
-    this.persistedPreferences = preferences;
-    this.activeMinutes = preferences.activeMinutes;
-    this.limit = preferences.limit;
-    this.includeGlobal = preferences.includeGlobal;
-    this.includeUnknown = preferences.includeUnknown;
-    this.searchQuery = preferences.searchQuery;
-    this.sortColumn = preferences.sortColumn;
-    this.sortDir = preferences.sortDir;
-    this.groupBy = preferences.groupBy;
-    this.pageSize = preferences.pageSize;
+  private persistPreferences(changes: Partial<SessionsPagePreferences>) {
+    this.preferenceSnapshot = { ...this.preferenceSnapshot, ...changes };
+    saveSessionsPagePreferences(changes);
   }
 
-  private persistPreferences(changes: Partial<SessionsPagePreferences>) {
-    this.persistedPreferences = { ...this.persistedPreferences, ...changes };
-    saveSessionsPagePreferences(this.persistedPreferences);
+  private restorePreferenceSnapshot() {
+    // Deep-link filters are temporary; restore the in-memory choices without
+    // writing a stale whole-record snapshot over another page's changes.
+    this.activeMinutes = this.preferenceSnapshot.activeMinutes;
+    this.limit = this.preferenceSnapshot.limit;
+    this.includeGlobal = this.preferenceSnapshot.includeGlobal;
+    this.includeUnknown = this.preferenceSnapshot.includeUnknown;
+    this.searchQuery = this.preferenceSnapshot.searchQuery;
+    this.sortColumn = this.preferenceSnapshot.sortColumn;
+    this.sortDir = this.preferenceSnapshot.sortDir;
+    this.groupBy = this.preferenceSnapshot.groupBy;
+    this.pageSize = this.preferenceSnapshot.pageSize;
   }
 
   private async rememberCustomGroup(

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -717,10 +717,9 @@ class SessionsPage extends OpenClawLightDomElement {
     // until its current list subscription publishes.
     this.loading = true;
     this.error = null;
-    context.navigate(
-      "sessions",
-      statusFilter === "active" ? undefined : { search: `?status=${statusFilter}` },
-    );
+    // Every status is explicit so a failed preference write cannot let the
+    // route loader restore a stale persisted default for this navigation.
+    context.navigate("sessions", { search: `?status=${statusFilter}` });
   }
 
   private async deleteSelected() {

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -76,9 +76,15 @@ import {
 } from "../../plugins/control-ui-actions.ts";
 import { sessionAgentIdentityById, sessionAgentIds } from "./agent-scope.ts";
 import { rememberSessionCustomGroup, sessionCategoryNames } from "./custom-groups.ts";
-import { loadStoredGroupBy, saveStoredGroupBy } from "./page-state.ts";
+import {
+  loadSessionsPagePreferences,
+  saveSessionsPagePreferences,
+  type SessionsPagePreferences,
+  type SessionsSortColumn,
+  type SessionsSortDirection,
+} from "./page-state.ts";
 import { sessionsPageListQuery, type SessionsRouteData } from "./route.ts";
-import { renderSessions, type SessionsProps } from "./view.ts";
+import { renderSessions, type SessionsProps, type TranscriptSearchState } from "./view.ts";
 
 const SESSIONS_DOCS_URL = "https://docs.openclaw.ai/concepts/session";
 const SESSION_SEARCH_DEBOUNCE_MS = 200;
@@ -111,22 +117,25 @@ class SessionsPage extends OpenClawLightDomElement {
 
   @property({ attribute: false }) routeData?: SessionsRouteData;
 
+  private readonly initialPreferences = loadSessionsPagePreferences();
+  private persistedPreferences = this.initialPreferences;
   @state() private result: SessionsListResult | null = null;
   @state() private loading = false;
   @state() private error: string | null = null;
-  @state() private activeMinutes = "";
-  @state() private limit = String(SESSIONS_PAGE_DEFAULT_LIMIT);
-  @state() private includeGlobal = true;
-  @state() private includeUnknown = false;
-  @state() private statusFilter: SessionArchivedFilter = "active";
-  @state() private searchQuery = "";
+  @state() private activeMinutes = this.initialPreferences.activeMinutes;
+  @state() private limit = this.initialPreferences.limit;
+  @state() private includeGlobal = this.initialPreferences.includeGlobal;
+  @state() private includeUnknown = this.initialPreferences.includeUnknown;
+  @state() private statusFilter: SessionArchivedFilter = this.initialPreferences.statusFilter;
+  @state() private searchQuery = this.initialPreferences.searchQuery;
   @state() private transcriptSearchQuery = "";
   @state() private submittedTranscriptSearchQuery = "";
-  @state() private sortColumn: "key" | "kind" | "updated" | "tokens" = "updated";
-  @state() private sortDir: "asc" | "desc" = "desc";
-  @state() private groupBy: SessionsGroupBy = loadStoredGroupBy();
+  @state() private transcriptSearch: TranscriptSearchState = { status: "idle" };
+  @state() private sortColumn: SessionsSortColumn = this.initialPreferences.sortColumn;
+  @state() private sortDir: SessionsSortDirection = this.initialPreferences.sortDir;
+  @state() private groupBy: SessionsGroupBy = this.initialPreferences.groupBy;
   @state() private page = 0;
-  @state() private pageSize = 25;
+  @state() private pageSize = this.initialPreferences.pageSize;
   @state() private selectedKeys = new Set<string>();
   @state() private sessionMenu:
     | (Pick<GatewaySessionRow, "key" | "sessionId"> & { x: number; y: number })
@@ -410,10 +419,9 @@ class SessionsPage extends OpenClawLightDomElement {
       this.page = 0;
       this.selectedKeys = new Set();
     } else {
-      this.activeMinutes = "";
-      this.limit = String(SESSIONS_PAGE_DEFAULT_LIMIT);
-      this.includeGlobal = true;
-      this.includeUnknown = false;
+      this.applyStoredPreferences();
+      // An explicit route status owns this visit without overwriting the saved default.
+      this.statusFilter = data.statusFilter;
     }
     this.expandedSessionKey = data.expandedSessionKey;
     // Only route-driven expansion narrows the list query; interactive drawer
@@ -667,6 +675,19 @@ class SessionsPage extends OpenClawLightDomElement {
     includeGlobal: boolean;
     includeUnknown: boolean;
   }) {
+    const changedPreferences: Partial<SessionsPagePreferences> = {};
+    if (next.activeMinutes !== this.activeMinutes) {
+      changedPreferences.activeMinutes = next.activeMinutes;
+    }
+    if (next.limit !== this.limit) {
+      changedPreferences.limit = next.limit;
+    }
+    if (next.includeGlobal !== this.includeGlobal) {
+      changedPreferences.includeGlobal = next.includeGlobal;
+    }
+    if (next.includeUnknown !== this.includeUnknown) {
+      changedPreferences.includeUnknown = next.includeUnknown;
+    }
     this.activeMinutes = next.activeMinutes;
     this.limit = next.limit;
     this.includeGlobal = next.includeGlobal;
@@ -675,6 +696,7 @@ class SessionsPage extends OpenClawLightDomElement {
     this.selectedKeys = new Set();
     // Explicit filter edits leave deep-link mode; load the full roster.
     this.deepLinkSessionKey = null;
+    this.persistPreferences(changedPreferences);
     void this.refreshSessionList();
   }
 
@@ -688,6 +710,7 @@ class SessionsPage extends OpenClawLightDomElement {
     this.page = 0;
     this.selectedKeys = new Set();
     this.deepLinkSessionKey = null;
+    this.persistPreferences({ statusFilter });
     // Route navigation changes the managed query; mask the old view's rows
     // until its current list subscription publishes.
     this.loading = true;
@@ -946,7 +969,26 @@ class SessionsPage extends OpenClawLightDomElement {
   private setGroupBy(mode: SessionsGroupBy) {
     this.groupBy = mode;
     this.page = 0;
-    saveStoredGroupBy(mode);
+    this.persistPreferences({ groupBy: mode });
+  }
+
+  private applyStoredPreferences() {
+    const preferences = loadSessionsPagePreferences();
+    this.persistedPreferences = preferences;
+    this.activeMinutes = preferences.activeMinutes;
+    this.limit = preferences.limit;
+    this.includeGlobal = preferences.includeGlobal;
+    this.includeUnknown = preferences.includeUnknown;
+    this.searchQuery = preferences.searchQuery;
+    this.sortColumn = preferences.sortColumn;
+    this.sortDir = preferences.sortDir;
+    this.groupBy = preferences.groupBy;
+    this.pageSize = preferences.pageSize;
+  }
+
+  private persistPreferences(changes: Partial<SessionsPagePreferences>) {
+    this.persistedPreferences = { ...this.persistedPreferences, ...changes };
+    saveSessionsPagePreferences(this.persistedPreferences);
   }
 
   private async rememberCustomGroup(
@@ -1673,6 +1715,13 @@ class SessionsPage extends OpenClawLightDomElement {
             this.page = 0;
             this.selectedKeys = new Set();
             this.deepLinkSessionKey = null;
+            this.persistPreferences({
+              activeMinutes: "",
+              limit: String(SESSIONS_PAGE_DEFAULT_LIMIT),
+              includeGlobal: true,
+              includeUnknown: false,
+              searchQuery: "",
+            });
             void this.refreshSessionList();
           },
           onSearchChange: (query) => {
@@ -1689,6 +1738,7 @@ class SessionsPage extends OpenClawLightDomElement {
               }, SESSION_SEARCH_DEBOUNCE_MS);
             }
             this.bindSessionList();
+            this.persistPreferences({ searchQuery: query });
           },
           onTranscriptSearchChange: (query) => this.updateTranscriptSearchQuery(query),
           onTranscriptSearch: () => void this.runTranscriptSearch(),
@@ -1697,6 +1747,7 @@ class SessionsPage extends OpenClawLightDomElement {
             this.sortColumn = column;
             this.sortDir = direction;
             this.page = 0;
+            this.persistPreferences({ sortColumn: column, sortDir: direction });
           },
           onGroupByChange: (mode) => this.setGroupBy(mode),
           onAssignCategory: (key, category) => this.assignCategory(key, category),
@@ -1714,6 +1765,7 @@ class SessionsPage extends OpenClawLightDomElement {
           onPageSizeChange: (pageSize) => {
             this.pageSize = pageSize;
             this.page = 0;
+            this.persistPreferences({ pageSize });
           },
           onRefresh: () => void this.refreshSessionList(),
           onStatusFilterChange: (statusFilter) => this.updateStatusFilter(statusFilter),

--- a/ui/src/pages/sessions/sessions-page.typing.test.ts
+++ b/ui/src/pages/sessions/sessions-page.typing.test.ts
@@ -89,6 +89,7 @@ async function mountTypingPage(initialResult = result("agent:main:initial")) {
 
 afterEach(() => {
   document.body.replaceChildren();
+  localStorage.clear();
   vi.useRealTimers();
   vi.restoreAllMocks();
 });


### PR DESCRIPTION
Closes #131588

## What Problem This Solves

The Control UI Sessions page loses stable view preferences after a reload or return visit. Operators must rebuild filters, search, sorting, grouping, and page size. Restoring controls only after the first list request also makes that request inconsistent with the saved view.

## Why This Change Was Made

The [automated issue-review acceptance direction](https://github.com/openclaw/openclaw/issues/131588#issuecomment-5449215690) calls for validated browser-local preferences applied before the first mounted list request. `page-state.ts` owns validation and partial writes; the lazy `route-preferences.runtime.ts` boundary restores route preferences; `sessionsPageListQuery` remains the canonical query builder. Explicit status URLs and direct-session links take precedence for that visit without overwriting unrelated defaults.

Existing-solutions preflight: the existing guarded Control UI local-storage seam is sufficient. No plugin, dependency, external service, server store, or OpenClaw configuration is added.

## User Impact

Reloads and revisits restore active-window and limit inputs, global/unknown toggles, default status, search, sorting, grouping, and page size. Fields are validated individually. The previous group-only preference is read and upgraded when preferences are saved. Explicit Active navigation remains active even if persisting it fails and the stored default is Archived or All.

Partial writes preserve unrelated ordered writes from another mounted page. Temporary deep-link filters restore the page's in-memory choices on exit instead of writing a stale whole-record snapshot. Page index, selection, drawers, errors, transcript search, and server data remain temporary.

## Evidence

### Maintenance validation — 2026-09-09

I rebased this PR onto upstream main `338a53fbde2cd2668e987156a22b4383b4207bdc`. The current contributor head is `6347207304240e2508dec3e2f41961e277c26db4`.

Updated the base to include upstream presence-audience synchronization fixes, including waiting for the typing event from the current interaction. The Sessions preference production patch is unchanged by this rebase.

Validation on Linux with Node 24.16.0 and the repository-pinned pnpm 12.3.4 / Vitest 5:
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts --configLoader runner ui/src/pages/sessions/route.test.ts ui/src/pages/sessions/sessions-page.test.ts ui/src/pages/sessions/sessions-page.roster.test.ts ui/src/pages/sessions/sessions-page.typing.test.ts ui/src/pages/sessions/sessions-page.transcript-search.test.ts --reporter=dot`: 88 passed.
- `node scripts/run-vitest.mjs run src/gateway/server.auth.presence-audience.test.ts --reporter=dot`: 1 passed.
- Fresh structured autoreview covered actionable priorities P0–P3; no remaining accepted findings.
- `git diff --check` passed. Contributor author/committer identities and maintainer edit permission were verified before the exact-lease push.

These are focused regression checks, not a new live behavior proof. The earlier runtime/media/transcript receipts below belong to their stated historical heads and were not rerun on this rebased head. Upstream CI for the new head is reported by the checks attached to this PR; I am not claiming it green before completion.

### Earlier validation receipts (historical heads)

**Historical browser-proof head:** `497bfc0c04ffdf6c295db489f6ec7a8a7cd8232a`; parent `e313f159bdc1687a1cbca6f06d1aeaf53773334b`; frozen main baseline `c4052ca628ac0e1026b82c10d7d80a5ebd8aaff9`.

**Historical-run limitations:** its original captures have been replaced below by provenance-preserving crops. Crabbox publication is blocked by unconfigured coordinator authentication. Browser proof below uses the repository's mocked Gateway, not a production Gateway or model. At that historical head, CI was red on an unchanged server test; the current-head result is recorded below. No hidden appendix or pending proof is asserted to close these gaps.

### Acceptance And Focused Checks

- Acceptance-red: both Archived/All-to-Active cases failed with the parent production implementation, which navigated with an undefined search. The repair includes an explicit status query for every choice. Tests intercept writes on the actual storage instance, assert unchanged stored data, and exercise the route loader.
- Green: 69/69 tests in the four files below on Node 24.15.0. Coverage includes ordered partial writes, failed storage, temporary-link exit, route restoration, and sibling roster/typing storage isolation. Scoped formatting, type-aware Oxlint, and `git diff --check` passed.
- Fresh `autoreview --mode local --base HEAD --max-priority P3` on the pre-commit repair returned scoped-clean with no accepted/actionable findings. This is repair-scope review, not whole-history certification or a full local TypeScript build.

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts --configLoader runner \
  ui/src/pages/sessions/sessions-page.test.ts \
  ui/src/pages/sessions/sessions-page.roster.test.ts \
  ui/src/pages/sessions/sessions-page.typing.test.ts \
  ui/src/pages/sessions/route.test.ts --reporter=dot
```

### Browser Behavior Readback

Four scenarios passed in 116.88 seconds: Linux, Node 24.15.0, Chromium, 1280x900, freshly bundled rendered Control UI and repository mock Gateway WebSocket. The proof uses visible controls, not private page methods. Initial storage is seeded once per context, never on reload.

1. Saved v1 filters are present in the first outgoing list request; a visible search edit persists through revisit.
2. Legacy grouping upgrades to the canonical record, removes the old key on save, and survives reload.
3. Archived-to-Active with one intercepted failing browser storage write preserves the explicit Active route and visible selection while stored data stays Archived.
4. All-to-Active proves the same failure behavior from an All default.

```json
{
  "committedHead": "497bfc0c04ffdf6c295db489f6ec7a8a7cd8232a",
  "environment": "Chromium; rendered Control UI; mocked Gateway WebSocket",
  "v1FirstRequest": {
    "includeGlobal": false, "includeUnknown": true,
    "configuredAgentsOnly": true, "limit": 25,
    "activeMinutes": 5, "agentId": "main", "search": "persisted"
  },
  "failureCases": [
    {"storedStatus":"archived","interceptedWrites":1,"visibleStatus":"active","route":"/sessions?status=active","storageUnchanged":true},
    {"storedStatus":"all","interceptedWrites":1,"visibleStatus":"active","route":"/sessions?status=active","storageUnchanged":true}
  ],
  "publicMediaUrl": "https://github.com/user-attachments/assets/8f675cca-5728-45f2-b7d2-f3fff91468da"
}
```

The browser ran on the parent plus the final patch before commit. Tested files match committed blobs: `sessions-page.ts` = `c7d1403cca4a22a1228fb0f6e3e25854a0928c19`; `sessions-page.test.ts` = `6fec2d047f480a8e26d5fbf02d36194e0798d232`. Before/after Archived-to-Active screenshots were visually inspected. Earlier harness argument/locator failures are excluded from product evidence. Media are not committed; the inspected captures are published in the Public Media section above.


### Public Media

The following are cropped copies of the historical Chromium captures at `497bfc0c04ffdf6c295db489f6ec7a8a7cd8232a`, not a newly executed browser run. The proof used rendered Control UI with the repository's mocked Gateway and synthetic sessions. Only the unrelated sidebar, including its invitation card, was removed: crop rectangle `(258, 0, 1280, 900)`, with no redraw, retouching, or resizing. Sessions controls and results remain unchanged. All seven cropped images were visually inspected before publication.

[Original URLs, original/output SHA-256 hashes, and crop coordinates](https://github.com/Leon-SK668/openclaw/blob/6669c35c86eb24274c586bae0a45fb1a5b18e3ef/evidence/pr131716/manifest.json) are retained with the [scope and provenance](https://github.com/Leon-SK668/openclaw/blob/6669c35c86eb24274c586bae0a45fb1a5b18e3ef/evidence/pr131716/README.md). The earlier uncropped screenshots and videos are superseded here for capture-policy delivery; their historical runtime assertions are not relabeled as a current-head run.

**Initial saved preferences**

![Initial saved preferences](https://github.com/Leon-SK668/openclaw/blob/6669c35c86eb24274c586bae0a45fb1a5b18e3ef/evidence/pr131716/initial-v1.png?raw=true)

**Visible search edit retained after revisit**

![Visible search edit retained after revisit](https://github.com/Leon-SK668/openclaw/blob/6669c35c86eb24274c586bae0a45fb1a5b18e3ef/evidence/pr131716/revisit-search.png?raw=true)

**Legacy grouping scenario**

![Legacy grouping scenario](https://github.com/Leon-SK668/openclaw/blob/6669c35c86eb24274c586bae0a45fb1a5b18e3ef/evidence/pr131716/legacy-group.png?raw=true)

**Archived before failed storage write**

![Archived before failed storage write](https://github.com/Leon-SK668/openclaw/blob/6669c35c86eb24274c586bae0a45fb1a5b18e3ef/evidence/pr131716/archived-before.png?raw=true)

**Active after failed storage write**

![Active after failed storage write](https://github.com/Leon-SK668/openclaw/blob/6669c35c86eb24274c586bae0a45fb1a5b18e3ef/evidence/pr131716/archived-to-active.png?raw=true)

**All before failed storage write**

![All before failed storage write](https://github.com/Leon-SK668/openclaw/blob/6669c35c86eb24274c586bae0a45fb1a5b18e3ef/evidence/pr131716/all-before.png?raw=true)

**Active after failed storage write from All**

![Active after failed storage write from All](https://github.com/Leon-SK668/openclaw/blob/6669c35c86eb24274c586bae0a45fb1a5b18e3ef/evidence/pr131716/all-to-active.png?raw=true)

### Exact-Head CI

[Run 33950849322](https://github.com/openclaw/openclaw/actions/runs/33950849322) completed: production types, all three test-type jobs, all three UI checks, all 13 bundled UI E2E shards, and real-Gateway E2E passed. The generic Gateway lane is not a production-session preference proof.

[Node shard 101265322236](https://github.com/openclaw/openclaw/actions/runs/33950849322/job/101265322236) failed 1/324 tests at `src/gateway/server.auth.presence-audience.test.ts:349`, comparing an event timestamp with later live presence state. The complete test exercises server WebSocket/profile/session helpers, not the changed browser modules. Its blob `d0c5195e1b9070925da2653b50d1ae0d9306204c` is identical at the frozen baseline and this head. All nine PR files are under `ui/src/pages/sessions/`. This identifies an unchanged failing surface, not its full root cause. The aggregate is not green; a failed-jobs rerun was denied with HTTP 403 requiring repository admin rights.

### Compatibility, Size, And Repair History

- Browser-profile-local preferences only: no Gateway protocol, server database, plugin API, model, channel, environment variable, or OpenClaw configuration changes. No cross-device sync or transactional simultaneous-tab guarantee. Storage unavailability is best effort and does not block the page; search text is preference data, not a credential store.
- Full PR against the frozen baseline: 9 files; production +222/-31, tests +213/-69, total +435/-100. Latest repair: 2 files, production +3/-4 and tests +70/-3. No generated files, lockfiles, or media. Growth implements one validated preference record, route integration, control persistence, and temporary-link protection, not a parallel store or retry cache.
- Earlier repair head `56b2d5efce4468696bf4a5bf61ba58a8361a6550` had passing browser/runtime checks but CI found 11 test-fixture type diagnostics. Those were repaired before this head; current exact-head type jobs pass. Earlier roster/typing contamination was attributable to this PR and repaired with storage isolation, not dismissed as unrelated.
- Earlier acceptance evidence for missing restoration, whole-record overwrites, and unsafe numeric strings belongs to its historical heads. It is not relabeled as current-head proof; the current checks above supersede historical pending-CI statements.

AI-assisted contribution: diagnosis, implementation, focused tests, browser verification, and independent review used agent assistance. The final diff and evidence were reviewed before pushing.

<!-- leon-evidence-maintenance-20260919-aa0yfe -->
### Current-head evidence maintenance — September 19, 2026

The product head remains `6347207304240e2508dec3e2f41961e277c26db4`. Its [main CI run 34324698580](https://github.com/openclaw/openclaw/actions/runs/34324698580) completed successfully. The older CI failures described above belong to their stated historical heads, not this current result.

The [latest durable review](https://github.com/openclaw/openclaw/pull/131716#issuecomment-5451345226) reports Overall / Proof / Patch **Platinum / Platinum / Platinum**, no remaining patch finding, and separate merge prerequisites. This update addresses invitation-card capture delivery only. It does **not** record maintainer acceptance of the ten browser-local preferences or of deleting the legacy grouping key on save. Rollback to v2026.9.3 still loses the migrated grouping preference under the proposed contract. Those ownership decisions remain open.
