### PR TITLE
feat(macos): enable native node session hosting

### DIFF
--- a/apps/macos/Sources/OpenClaw/ExecCommandResolution.swift
+++ b/apps/macos/Sources/OpenClaw/ExecCommandResolution.swift
@@ -1,4 +1,5 @@
 import CryptoKit
+import Darwin
 import Foundation
 
 struct ExecAllowAlwaysPattern: Sendable, Hashable {
@@ -22,15 +23,21 @@ struct ExecCommandResolution {
         "SYSTEM_RUN_DENIED: approval cwd changed before execution"
 
     static func canonicalApprovalCwd(_ cwd: String?) -> String {
-        URL(fileURLWithPath: cwd ?? FileManager.default.currentDirectoryPath)
-            .standardizedFileURL
-            .resolvingSymlinksInPath()
-            .path
+        // Policy hashes also accept missing paths; execution requires the fallible snapshot below.
+        self.existingApprovalCwd(cwd) ?? URL(fileURLWithPath: cwd ?? FileManager.default.currentDirectoryPath)
+            .standardizedFileURL.path
+    }
+
+    private static func existingApprovalCwd(_ cwd: String?) -> String? {
+        let requestedPath = cwd ?? FileManager.default.currentDirectoryPath
+        // Foundation can fold /private/tmp back to the /tmp symlink. Identity needs POSIX realpath.
+        guard !requestedPath.utf8.contains(0), let resolved = realpath(requestedPath, nil) else { return nil }
+        defer { free(resolved) }
+        return String(cString: resolved)
     }
 
     static func captureApprovalCwdSnapshot(_ cwd: String?) -> ExecApprovalCwdSnapshot? {
-        let canonicalPath = self.canonicalApprovalCwd(cwd)
-        guard self.canonicalApprovalCwd(canonicalPath) == canonicalPath,
+        guard let canonicalPath = self.existingApprovalCwd(cwd),
               let attributes = try? FileManager.default.attributesOfItem(atPath: canonicalPath),
               attributes[.type] as? FileAttributeType == .typeDirectory,
               let device = attributes[.systemNumber] as? NSNumber,

--- a/apps/macos/Sources/OpenClaw/ExecHostExecutor.swift
+++ b/apps/macos/Sources/OpenClaw/ExecHostExecutor.swift
@@ -11,15 +11,15 @@ enum ExecHostExecutor {
         case let .failure(error):
             return self.errorResponse(error)
         }
-        let effectiveCwd = ExecCommandResolution.canonicalApprovalCwd(request.cwd)
-        guard let approvedCwdSnapshot = ExecCommandResolution.captureApprovalCwdSnapshot(effectiveCwd)
+        guard let approvedCwdSnapshot = ExecCommandResolution.captureApprovalCwdSnapshot(request.cwd)
         else {
             return self.errorResponse(
                 code: "UNAVAILABLE",
-                message: "SYSTEM_RUN_DENIED: approval requires an existing canonical cwd",
-                reason: "approval-required")
+                message: "Working directory does not exist, is inaccessible, or is not a directory.",
+                reason: "cwd-unavailable")
         }
 
+        let effectiveCwd = approvedCwdSnapshot.path
         let context = await self.buildContext(
             request: request,
             command: validatedRequest.command,

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeHostWorker.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeHostWorker.swift
@@ -6,6 +6,7 @@ import OSLog
 import Subprocess
 
 extension Notification.Name {
+    static let openclawNodeHostManifestChanged = Notification.Name("openclaw.node-host-worker.manifest-changed")
     static let openclawNodeHostWorkerFailed = Notification.Name("openclaw.node-host-worker.failed")
     static let openclawNodeHostWorkerRetryExhausted = Notification.Name(
         "openclaw.node-host-worker.retry-exhausted")
@@ -59,7 +60,8 @@ protocol MacNodeHostWorking: Sendable {
     func handleInput(invokeId: String, seq: Int, payloadJSON: String) async
     func cancel(invokeId: String) async
     func setRoute(_ route: GatewayNodeSessionRoute?, authorityGeneration: UInt64) async -> Bool
-    func publishInventory(ifCurrentRoute route: GatewayNodeSessionRoute) async
+    func gatewayConnected(ifCurrentRoute route: GatewayNodeSessionRoute) async
+
     func stop() async
 }
 
@@ -111,7 +113,6 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
     private var stderrHead = ""
     private static let maxStderrHeadLength = 700
     private var manifest: MacNodeHostManifest?
-    private var inventoryData: Data?
     private var route: GatewayNodeSessionRoute?
     private var routeAuthorityGeneration: UInt64 = 0
     private var startContinuation: CheckedContinuation<MacNodeHostManifest, Error>?
@@ -120,8 +121,7 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
     private var pendingInvokeControlOrder: [String] = []
     private var startTimer: DispatchSourceTimer?
     private var eventDeliveryTask: Task<Void, Never>?
-    private var inventoryPublicationTask: Task<Void, Never>?
-    private var inventoryPublicationGeneration: UInt64 = 0
+    private var gatewayGeneration: UInt64 = 0
 
     init(
         session: GatewayNodeSession,
@@ -184,9 +184,13 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
                         "nodeId": request.nodeId ?? "",
                         "command": request.command,
                         "paramsJSON": request.paramsJSON ?? NSNull(),
+                        "sessionKey": request.sessionKey ?? NSNull(),
+                        "timeoutMs": request.timeoutMs ?? NSNull(),
+                        "idempotencyKey": request.idempotencyKey ?? NSNull(),
                     ]
                     try self.enqueueWriteLocked([
                         "type": "invoke",
+                        "generation": self.gatewayGeneration,
                         "request": workerRequest,
                     ])
                     for control in self.takePendingInvokeControlsLocked(invokeId: request.id) {
@@ -269,6 +273,7 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
         case let .input(seq, payloadJSON):
             try self.enqueueWriteLocked([
                 "type": "invoke-input",
+                "generation": self.gatewayGeneration,
                 "invokeId": invokeId,
                 "seq": seq,
                 "payloadJSON": payloadJSON,
@@ -276,6 +281,7 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
         case .cancel:
             try self.enqueueWriteLocked([
                 "type": "invoke-cancel",
+                "generation": self.gatewayGeneration,
                 "invokeId": invokeId,
             ])
         }
@@ -298,9 +304,17 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
                 }
                 self.routeAuthorityGeneration = authorityGeneration
                 self.route = route
-                self.inventoryPublicationGeneration &+= 1
-                self.inventoryPublicationTask?.cancel()
-                self.inventoryPublicationTask = nil
+                self.gatewayGeneration &+= 1
+                try? self.enqueueWriteLocked([
+                    "type": "gateway-connection", "generation": self.gatewayGeneration, "connection": NSNull(),
+                ])
+                let pending = self.invokeContinuations
+                self.invokeContinuations.removeAll()
+                self.pendingInvokeControls.removeAll()
+                self.pendingInvokeControlOrder.removeAll()
+                for (id, waiter) in pending {
+                    waiter.resume(returning: Self.unavailableResponse(id, "UNAVAILABLE: Gateway route changed"))
+                }
                 self.eventDeliveryTask?.cancel()
                 self.eventDeliveryTask = nil
                 continuation.resume(returning: true)
@@ -315,19 +329,19 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
         candidateGeneration >= currentGeneration
     }
 
-    func publishInventory(ifCurrentRoute route: GatewayNodeSessionRoute) async {
-        let publication: Task<Void, Never>? = await withCheckedContinuation { continuation in
+    func gatewayConnected(ifCurrentRoute route: GatewayNodeSessionRoute) async {
+        guard let data = await self.session.workerConnectionData(ifCurrentRoute: route) else { return }
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
             self.queue.async {
-                guard let inventoryData = self.inventoryData else {
-                    continuation.resume(returning: nil)
-                    return
-                }
-                continuation.resume(returning: self.scheduleInventoryPublicationLocked(
-                    inventoryData,
-                    route: route))
+                defer { continuation.resume() }
+                guard self.route == route,
+                      let connection = try? JSONSerialization.jsonObject(with: data) else { return }
+                self.gatewayGeneration &+= 1
+                try? self.enqueueWriteLocked([
+                    "type": "gateway-connection", "generation": self.gatewayGeneration, "connection": connection,
+                ])
             }
         }
-        await publication?.value
     }
 
     func stop() async {
@@ -500,8 +514,12 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
     }
 
     private func handleMessageLocked(_ message: [String: Any]) {
-        switch message["type"] as? String {
-        case "ready":
+        let type = message["type"] as? String
+        if type == "invoke-result" || type == "node-event" || type == "gateway-request" {
+            guard (message["generation"] as? NSNumber)?.uint64Value == self.gatewayGeneration else { return }
+        }
+        switch type {
+        case "ready", "manifest":
             guard let version = message["version"] as? String,
                   let rawManifest = message["manifest"] as? [String: Any],
                   let caps = rawManifest["caps"] as? [String],
@@ -531,15 +549,10 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
                 computerUse: computerUse,
                 pathEnv: pathEnv)
             self.manifest = manifest
-            self.inventoryData = (message["inventory"] as? [String: Any]).flatMap(Self.jsonData)
-            self.finishStartLocked(.success(manifest))
-        case "inventory":
-            guard let inventory = message["inventory"] as? [String: Any],
-                  let inventoryData = Self.jsonData(inventory)
-            else { return }
-            self.inventoryData = inventoryData
-            if let route = self.route {
-                self.scheduleInventoryPublicationLocked(inventoryData, route: route)
+            if type == "ready" {
+                self.finishStartLocked(.success(manifest))
+            } else {
+                NotificationCenter.default.post(name: .openclawNodeHostManifestChanged, object: nil)
             }
         case "invoke-result":
             guard let result = message["result"] as? [String: Any],
@@ -579,6 +592,7 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
                 return
             }
             let timeoutMs = (message["timeoutMs"] as? NSNumber)?.intValue ?? 15000
+            let gatewayGeneration = self.gatewayGeneration
             Task {
                 await self.handleGatewayRequest(
                     id: id,
@@ -586,7 +600,8 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
                     paramsData: paramsData,
                     timeoutMs: timeoutMs,
                     route: route,
-                    processGeneration: processGeneration)
+                    processGeneration: processGeneration,
+                    gatewayGeneration: gatewayGeneration)
             }
         case "protocol-error":
             self.logger.error("node-host worker rejected a protocol frame")
@@ -601,7 +616,8 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
         paramsData: Data,
         timeoutMs: Int,
         route: GatewayNodeSessionRoute,
-        processGeneration: UUID) async
+        processGeneration: UUID,
+        gatewayGeneration: UInt64) async
     {
         do {
             guard let paramsJSON = String(bytes: paramsData, encoding: .utf8) else {
@@ -616,82 +632,45 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
             self.queue.async {
                 // A replacement worker restarts request ids. Never deliver an old
                 // route response into the replacement process.
-                guard self.processGeneration == processGeneration else { return }
+                guard self.processGeneration == processGeneration,
+                      self.gatewayGeneration == gatewayGeneration,
+                      self.route == route else { return }
                 guard let result = try? JSONSerialization.jsonObject(with: data) else { return }
                 try? self.enqueueWriteLocked([
                     "type": "gateway-response",
+                    "generation": gatewayGeneration,
                     "id": id,
                     "ok": true,
                     "result": result,
                 ])
             }
         } catch {
+            // Preserve only the public RPC code/message for shared publication classification.
+            let responseError = error as? GatewayResponseError
+            let code = responseError?.code ?? "UNAVAILABLE"
+            let publicMessage = responseError?.message
+            let message = code == "INVALID_REQUEST" &&
+                (publicMessage == "unknown method: \(method)" || publicMessage == "unauthorized role: node")
+                ? publicMessage! : "Gateway request unavailable"
             self.queue.async {
-                guard self.processGeneration == processGeneration else { return }
-                self.writeGatewayUnavailableLocked(id: id)
+                guard self.processGeneration == processGeneration,
+                      self.gatewayGeneration == gatewayGeneration,
+                      self.route == route else { return }
+                self.writeGatewayUnavailableLocked(id: id, code: code, message: message)
             }
         }
     }
 
-    private func writeGatewayUnavailableLocked(id: String) {
+    private func writeGatewayUnavailableLocked(
+        id: String, code: String = "UNAVAILABLE", message: String = "Gateway request unavailable")
+    {
         try? self.enqueueWriteLocked([
             "type": "gateway-response",
+            "generation": self.gatewayGeneration,
             "id": id,
             "ok": false,
-            "error": "Gateway request unavailable",
+            "error": ["code": code, "message": message],
         ])
-    }
-
-    @discardableResult
-    private func scheduleInventoryPublicationLocked(
-        _ inventoryData: Data,
-        route: GatewayNodeSessionRoute) -> Task<Void, Never>
-    {
-        self.inventoryPublicationGeneration &+= 1
-        let generation = self.inventoryPublicationGeneration
-        let previous = self.inventoryPublicationTask
-        let publication = Task { [weak self] in
-            await previous?.value
-            guard let self,
-                  !Task.isCancelled,
-                  await self.inventoryPublicationIsCurrent(generation, route: route)
-            else { return }
-            await self.sendInventory(inventoryData, route: route)
-        }
-        self.inventoryPublicationTask = publication
-        return publication
-    }
-
-    private func inventoryPublicationIsCurrent(
-        _ generation: UInt64,
-        route: GatewayNodeSessionRoute) async -> Bool
-    {
-        await withCheckedContinuation { continuation in
-            self.queue.async {
-                continuation.resume(returning:
-                    self.inventoryPublicationGeneration == generation && self.route == route)
-            }
-        }
-    }
-
-    private func sendInventory(_ inventoryData: Data, route: GatewayNodeSessionRoute) async {
-        guard let inventory = try? JSONSerialization.jsonObject(with: inventoryData) as? [String: Any] else { return }
-        if let skills = inventory["skills"], !(skills is NSNull),
-           let paramsJSON = Self.paramsJSON(["skills": skills])
-        {
-            _ = try? await self.session.request(
-                method: "node.skills.update",
-                paramsJSON: paramsJSON,
-                ifCurrentRoute: route)
-        }
-        if let tools = inventory["pluginTools"] as? [Any],
-           let paramsJSON = Self.paramsJSON(["tools": tools])
-        {
-            _ = try? await self.session.request(
-                method: "node.pluginTools.update",
-                paramsJSON: paramsJSON,
-                ifCurrentRoute: route)
-        }
     }
 
     private func enqueueWriteLocked(_ object: [String: Any]) throws {
@@ -721,9 +700,6 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
         self.startTimer = nil
         self.eventDeliveryTask?.cancel()
         self.eventDeliveryTask = nil
-        self.inventoryPublicationGeneration &+= 1
-        self.inventoryPublicationTask?.cancel()
-        self.inventoryPublicationTask = nil
         guard let continuation = self.startContinuation else { return }
         self.startContinuation = nil
         continuation.resume(with: result)
@@ -746,7 +722,6 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
         self.launchedWorker = nil
         self.stdoutBuffer.removeAll(keepingCapacity: false)
         self.manifest = nil
-        self.inventoryData = nil
         self.route = nil
         if !preserveStart {
             self.finishStartLocked(.failure(WorkerError.unavailable(reason: reason, diagnostic: diagnostic)))

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeHostWorker.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeHostWorker.swift
@@ -791,11 +791,6 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
             error: OpenClawNodeError(code: .unavailable, message: message))
     }
 
-    private static func paramsJSON(_ object: [String: Any]) -> String? {
-        guard let data = self.jsonData(object) else { return nil }
-        return String(bytes: data, encoding: .utf8)
-    }
-
     private static func jsonData(_ object: Any) -> Data? {
         guard JSONSerialization.isValidJSONObject(object) else { return nil }
         return try? JSONSerialization.data(withJSONObject: object)

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
@@ -204,6 +204,11 @@ final class MacNodeModeCoordinator: NSObject {
             object: nil)
         self.notificationCenter.addObserver(
             self,
+            selector: #selector(self.nodeHostManifestChanged),
+            name: .openclawNodeHostManifestChanged,
+            object: nil)
+        self.notificationCenter.addObserver(
+            self,
             selector: #selector(self.nodeHostWorkerFailed),
             name: .openclawNodeHostWorkerFailed,
             object: nil)
@@ -222,6 +227,12 @@ final class MacNodeModeCoordinator: NSObject {
             selector: #selector(self.nodeHostConfigurationChanged),
             name: .openclawCuaDriverAvailabilityChanged,
             object: nil)
+    }
+
+    @objc private nonisolated func nodeHostManifestChanged() {
+        Task { @MainActor [weak self] in
+            self?.enqueueRouteInvalidation(mode: .reconnectRefresh)
+        }
     }
 
     deinit {
@@ -662,7 +673,7 @@ final class MacNodeModeCoordinator: NSObject {
                     installedRoute,
                     authorityGeneration: attempt.routeAuthorityGeneration) ?? true
                 guard workerRouteInstalled else { return }
-                await self.nodeHostWorker?.publishInventory(ifCurrentRoute: installedRoute)
+                await self.nodeHostWorker?.gatewayConnected(ifCurrentRoute: installedRoute)
                 await self.cancelReconnectProbe()
                 await self.channelStatus.record(.connected(
                     workerUnavailableReason: attempt.workerUnavailable?.reason,

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
@@ -232,7 +232,9 @@ actor MacNodeRuntime {
                  MacNodeClaudeSessionCatalogContract.readCommand:
                 return try await self.handleClaudeSessionInvoke(req)
             default:
-                if let nodeHostWorker, await nodeHostWorker.supports(command) {
+                // Private supervisor controls are not public pairing capabilities.
+                // The shared dispatcher owns their validation and local hosting consent.
+                if let nodeHostWorker {
                     return await nodeHostWorker.invoke(req)
                 }
                 return Self.errorResponse(req, code: .invalidRequest, message: "INVALID_REQUEST: unknown command")

--- a/apps/macos/Tests/OpenClawIPCTests/ExecHostCwdTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecHostCwdTests.swift
@@ -1,0 +1,62 @@
+import Darwin
+import Foundation
+import Testing
+@testable import OpenClaw
+
+struct ExecHostCwdTests {
+    @Test(.execApprovalsStateIsolated, arguments: ["/tmp", "/private/tmp"])
+    func `native full execution uses the physical temporary directory`(cwd: String) async throws {
+        _ = try ExecApprovalsStore.updateDefaults { defaults in
+            defaults.security = .full
+            defaults.ask = .off
+        }.get()
+        let response = await ExecHostExecutor.handle(ExecHostRequest(
+            command: ["/bin/pwd", "-P"],
+            cwd: cwd,
+            timeoutMs: 2000))
+        #expect(response.ok)
+        #expect(response.payload?.success == true)
+        #expect(response.payload?.stdout == "/private/tmp\n")
+
+        let snapshot = try #require(ExecCommandResolution.captureApprovalCwdSnapshot(cwd))
+        #expect(snapshot.path == "/private/tmp")
+        #expect(ExecCommandResolution.revalidateApprovalCwdSnapshot(snapshot))
+        let patterns = ExecCommandResolution.resolveAllowAlwaysPatterns(
+            command: ["/bin/pwd", "-P"], cwd: cwd, env: nil)
+        let resolution = try #require(ExecCommandResolution.resolve(
+            command: ["/bin/pwd", "-P"], cwd: snapshot.path, env: nil))
+        let pattern = try #require(patterns.first)
+        #expect(ExecAllowlistMatcher.match(
+            entries: [ExecAllowlistEntry(pattern: pattern.pattern, argPattern: pattern.argPattern)],
+            resolution: resolution) != nil)
+    }
+
+    @Test(.execApprovalsStateIsolated) func `native missing cwd reports a directory error without requesting approval`() async {
+        let cwd = "/tmp/openclaw-missing-cwd-\(UUID().uuidString)"
+        let response = await ExecHostExecutor.handle(ExecHostRequest(
+            command: ["/bin/pwd"], cwd: cwd, timeoutMs: 2000))
+        #expect(!response.ok)
+        #expect(response.error?.reason == "cwd-unavailable")
+        #expect(response.error?.message == "Working directory does not exist, is inaccessible, or is not a directory.")
+        #expect(ExecCommandResolution.captureApprovalCwdSnapshot(cwd) == nil)
+    }
+
+    @Test func `cwd snapshot refuses files symlink loops and inaccessible paths`() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("openclaw-cwd-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let file = root.appendingPathComponent("file")
+        try Data().write(to: file)
+        #expect(ExecCommandResolution.captureApprovalCwdSnapshot(file.path) == nil)
+        let loop = root.appendingPathComponent("loop")
+        try FileManager.default.createSymbolicLink(atPath: loop.path, withDestinationPath: loop.path)
+        #expect(ExecCommandResolution.captureApprovalCwdSnapshot(loop.path) == nil)
+        #expect(ExecCommandResolution.captureApprovalCwdSnapshot("/tmp\0/ignored") == nil)
+        let inaccessible = root.appendingPathComponent("locked")
+        let child = inaccessible.appendingPathComponent("child")
+        try FileManager.default.createDirectory(at: child, withIntermediateDirectories: true)
+        try FileManager.default.setAttributes([.posixPermissions: 0], ofItemAtPath: inaccessible.path)
+        defer { try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: inaccessible.path) }
+        #expect(ExecCommandResolution.captureApprovalCwdSnapshot(child.path) == nil)
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/ExecHostSocketCancellationTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecHostSocketCancellationTests.swift
@@ -39,13 +39,15 @@ struct ExecHostSocketCancellationTests {
             let parentFile = root.appendingPathComponent("parent.pid")
             let childFile = root.appendingPathComponent("child.pid")
             let sentinel = root.appendingPathComponent("sentinel")
+            // Publish the PID atomically: file creation alone can race the printf payload.
             let command = [
                 "/bin/sh", "-c",
                 """
                 printf '%s' "$$" > '\(parentFile.path)'
                 /bin/sh -c '
                   trap "" TERM
-                  printf "%s" "$$" > "\(childFile.path)"
+                  printf "%s" "$$" > "\(childFile.path).tmp"
+                  /bin/mv "\(childFile.path).tmp" "\(childFile.path)"
                   /bin/sleep 2
                   /usr/bin/touch "\(sentinel.path)"
                 ' &

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
@@ -40,7 +40,7 @@ private actor StubMacNodeHostWorker: MacNodeHostWorking {
         true
     }
 
-    func publishInventory(ifCurrentRoute _: GatewayNodeSessionRoute) async {}
+    func gatewayConnected(ifCurrentRoute _: GatewayNodeSessionRoute) async {}
     func stop() async {}
     func invokedCommands() -> [String] {
         self.requests.map(\.command)
@@ -134,9 +134,10 @@ struct MacNodeHostWorkerTests {
         OpenClawSystemCommand.run.rawValue,
         "mcp.tools.call.v1",
         "codex.terminal.resume.v1",
+        "system.worker.start",
     ])
     func `Mac runtime forwards worker-owned commands to the shared worker`(command: String) async {
-        let worker = StubMacNodeHostWorker(commands: [command])
+        let worker = StubMacNodeHostWorker(commands: command == "system.worker.start" ? [] : [command])
         let runtime = MacNodeRuntime(nodeHostWorker: worker)
 
         let response = await runtime.handleInvoke(BridgeInvokeRequest(
@@ -400,11 +401,11 @@ struct MacNodeHostWorkerTests {
         while IFS= read -r line; do
           case "$line" in
             *'"type":"invoke"'*)
-              printf '%s\\n' '{"type":"gateway-request","id":"gateway-1","method":"node.invoke.progress","params":{"invokeId":"worker-run","nodeId":"","seq":0,"chunk":"hello"},"timeoutMs":1000}'
+              printf '%s\\n' '{"type":"gateway-request","generation":0,"id":"gateway-1","method":"node.invoke.progress","params":{"invokeId":"worker-run","nodeId":"","seq":0,"chunk":"hello"},"timeoutMs":1000}'
               IFS= read -r unavailable
               printf '%s' "$unavailable" | grep -q '"type":"gateway-response"' || exit 44
               printf '%s' "$unavailable" | grep -q '"ok":false' || exit 45
-              printf '%s\\n' '{"type":"invoke-result","result":{"id":"worker-run","ok":true,"payload":{"owner":"cli"}}}'
+              printf '%s\\n' '{"type":"invoke-result","generation":0,"result":{"id":"worker-run","ok":true,"payload":{"owner":"cli"}}}'
               ;;
           esac
         done
@@ -708,11 +709,11 @@ struct MacNodeHostWorkerTests {
         let script = """
         printf '%s\\n' '{"type":"ready","version":"test","manifest":{"caps":["system"],"commands":["system.run"],"pathEnv":"/usr/bin:/bin"},"inventory":{"skills":null,"pluginTools":[]}}'
         IFS= read -r first
-        printf '{"type":"invoke-result","result":{"id":"first","ok":true,"payload":{"blob":"'
+        printf '{"type":"invoke-result","generation":0,"result":{"id":"first","ok":true,"payload":{"blob":"'
         head -c 2097152 /dev/zero | tr '\\000' x
         printf '"}}}\\n'
         IFS= read -r second
-        printf '%s\\n' '{"type":"invoke-result","result":{"id":"second","ok":true,"payload":{"done":true}}}'
+        printf '%s\\n' '{"type":"invoke-result","generation":0,"result":{"id":"second","ok":true,"payload":{"done":true}}}'
         """
         _ = try await worker.start(launch: MacNodeHostWorkerLaunch(
             command: ["/bin/sh", "-c", script]))

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeModeCoordinatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeModeCoordinatorTests.swift
@@ -108,7 +108,7 @@ private actor CoordinatorNodeHostWorkerProbe: MacNodeHostWorking {
         self.routeClearReleaseGate.open()
     }
 
-    func publishInventory(ifCurrentRoute _: GatewayNodeSessionRoute) async {}
+    func gatewayConnected(ifCurrentRoute _: GatewayNodeSessionRoute) async {}
     func stop() async {
         self.stopCount += 1
         self.stopGate.open()
@@ -149,7 +149,7 @@ private actor CoordinatorFailingStartWorkerProbe: MacNodeHostWorking {
         true
     }
 
-    func publishInventory(ifCurrentRoute _: GatewayNodeSessionRoute) async {}
+    func gatewayConnected(ifCurrentRoute _: GatewayNodeSessionRoute) async {}
     func stop() async {}
 
     func startCallCount() -> Int {

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
@@ -37,7 +37,7 @@ struct MacNodeRuntimeTests {
             true
         }
 
-        func publishInventory(ifCurrentRoute _: GatewayNodeSessionRoute) {}
+        func gatewayConnected(ifCurrentRoute _: GatewayNodeSessionRoute) {}
         func stop() {}
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/BridgeFrames.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/BridgeFrames.swift
@@ -6,19 +6,28 @@ public struct BridgeInvokeRequest: Codable, Sendable {
     public let command: String
     public let paramsJSON: String?
     public let nodeId: String?
+    public let sessionKey: String?
+    public let timeoutMs: Int?
+    public let idempotencyKey: String?
 
     public init(
         type: String = "invoke",
         id: String,
         command: String,
         paramsJSON: String? = nil,
-        nodeId: String? = nil)
+        nodeId: String? = nil,
+        sessionKey: String? = nil,
+        timeoutMs: Int? = nil,
+        idempotencyKey: String? = nil)
     {
         self.type = type
         self.id = id
         self.command = command
         self.paramsJSON = paramsJSON
         self.nodeId = nodeId
+        self.sessionKey = sessionKey
+        self.timeoutMs = timeoutMs
+        self.idempotencyKey = idempotencyKey
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -222,7 +222,14 @@ public actor GatewayChannelActor {
     /// Operator-supplied proxy credentials (Cloudflare Access-style) ride on the upgrade
     /// request. Read from the provider at connect time so edits apply on the next reconnect
     /// without re-pairing. Values are credentials: never log them.
+    private var workerEdgeCredentials: [String: String]?
+
+    func currentWorkerEdgeCredentials() -> [String: String]? {
+        self.workerEdgeCredentials
+    }
+
     private func makeUpgradeRequest() -> URLRequest {
+        self.workerEdgeCredentials = nil
         var request = URLRequest(url: self.url)
         // Custom headers can contain service tokens or Authorization values. Do not even read
         // the provider for cleartext routes, where credentials would be exposed in transit.
@@ -230,6 +237,11 @@ public actor GatewayChannelActor {
         guard let headers = self.extraHeadersProvider?(), !headers.isEmpty else { return request }
         for (name, value) in GatewayCustomHeaders.sanitized(headers) {
             request.setValue(value, forHTTPHeaderField: name)
+        }
+        if let clientID = request.value(forHTTPHeaderField: "CF-Access-Client-Id"),
+           let clientSecret = request.value(forHTTPHeaderField: "CF-Access-Client-Secret")
+        {
+            self.workerEdgeCredentials = ["clientId": clientID, "clientSecret": clientSecret]
         }
         return request
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayConnectOptions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayConnectOptions.swift
@@ -65,6 +65,22 @@ public struct GatewayConnectOptions: Sendable {
     }
 }
 
+public struct GatewayNodeSessionCredentials: Sendable, Equatable {
+    public let token: String?
+    public let bootstrapToken: String?
+    public let password: String?
+
+    public init(
+        token: String? = nil,
+        bootstrapToken: String? = nil,
+        password: String? = nil)
+    {
+        self.token = token
+        self.bootstrapToken = bootstrapToken
+        self.password = password
+    }
+}
+
 public enum GatewayAuthSource: String, Sendable {
     case deviceToken = "device-token"
     case sharedToken = "shared-token"

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayErrors.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayErrors.swift
@@ -1,6 +1,12 @@
 import Foundation
 import OpenClawProtocol
 
+/// A route lease became stale before its request touched the channel. Unlike
+/// a socket cancellation, this proves the payload was never dispatched.
+public enum GatewayNodeSessionRequestError: Error, Sendable {
+    case routeChangedBeforeDispatch
+}
+
 public enum GatewayConnectAuthDetailCode: String, Sendable {
     case authRequired = "AUTH_REQUIRED"
     case authUnauthorized = "AUTH_UNAUTHORIZED"

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
@@ -10,6 +10,7 @@ private struct NodeInvokeRequestPayload: Codable {
     var paramsJSON: String?
     var timeoutMs: Int?
     var idempotencyKey: String?
+    var sessionKey: String?
 }
 
 private struct NodeInvokeCancelPayload: Codable {
@@ -35,12 +36,6 @@ public struct GatewayCanvasHostRoute: Sendable, Equatable {
     }
 }
 
-/// A route lease became stale before its request touched the channel. Unlike
-/// a socket cancellation, this proves the payload was never dispatched.
-public enum GatewayNodeSessionRequestError: Error, Sendable {
-    case routeChangedBeforeDispatch
-}
-
 /// Owns a server-event stream until its caller is finished or canceled.
 public struct GatewayServerEventSubscription: Sendable {
     public let events: AsyncStream<EventFrame>
@@ -57,22 +52,6 @@ public struct GatewayServerEventSubscription: Sendable {
     /// Finishes the stream and unregisters its Gateway subscriber.
     public func cancel() {
         self.continuation.finish()
-    }
-}
-
-public struct GatewayNodeSessionCredentials: Sendable, Equatable {
-    public let token: String?
-    public let bootstrapToken: String?
-    public let password: String?
-
-    public init(
-        token: String? = nil,
-        bootstrapToken: String? = nil,
-        password: String? = nil)
-    {
-        self.token = token
-        self.bootstrapToken = bootstrapToken
-        self.password = password
     }
 }
 
@@ -158,6 +137,7 @@ public actor GatewayNodeSession {
     private var hasEverConnected = false
     private var hasNotifiedConnected = false
     private var snapshotReceived = false
+    private var workerHello: (protocolVersion: Int, capabilities: [String])?
     private var serverMethods: Set<String>?
     private var serverCapabilities: Set<GatewayServerCapability>?
     private var mainSessionKey: String?
@@ -711,6 +691,24 @@ public actor GatewayNodeSession {
             socketGeneration: socketGeneration)
     }
 
+    /// Private app-worker context from the authenticated socket, never configured fallback routes.
+    public func workerConnectionData(ifCurrentRoute route: GatewayNodeSessionRoute) async -> Data? {
+        guard self.isCurrentRoute(route), let channel, let url = self.activeURL,
+              let hello = self.workerHello else { return nil }
+        let edge = await channel.currentWorkerEdgeCredentials()
+        guard self.isCurrentRoute(route), self.channel === channel else { return nil }
+        var connection: [String: Any] = [
+            "url": url.absoluteString,
+            "protocol": hello.protocolVersion,
+            "capabilities": hello.capabilities.sorted(),
+        ]
+        if let fingerprint = self.activeTLSRouteMetadataProvider?.effectiveTLSFingerprintSHA256 {
+            connection["tlsFingerprint"] = fingerprint
+        }
+        if let edge { connection["cloudflareAccess"] = edge }
+        return try? JSONSerialization.data(withJSONObject: connection)
+    }
+
     public func currentGatewayID(ifCurrentRoute route: GatewayNodeSessionRoute) -> String? {
         guard self.isCurrentRoute(route), self.channel != nil else { return nil }
         // iOS operator routes normalize this to the effective stable ID before connect.
@@ -895,6 +893,9 @@ extension GatewayNodeSession {
         case let .snapshot(ok):
             let admissionGeneration = self.admissionGeneration
             self.pluginSurfaceUrls = self.normalizePluginSurfaceUrls(ok.pluginsurfaceurls)
+            // Decoded arrays wrap their elements; a raw string cast silently disables worker features.
+            let capabilities = ok.features["capabilities"]?.arrayValue?.compactMap(\.stringValue) ?? []
+            self.workerHello = (ok._protocol, capabilities)
             self.serverMethods = ok.advertisedServerMethods()
             self.serverCapabilities = Set(
                 GatewayServerCapability.allCases.filter { ok.supportsServerCapability($0) })
@@ -926,6 +927,7 @@ extension GatewayNodeSession {
     private func resetConnectionState() {
         self.hasNotifiedConnected = false
         self.snapshotReceived = false
+        self.workerHello = nil
         self.serverMethods = nil
         self.serverCapabilities = nil
         self.mainSessionKey = nil
@@ -1206,7 +1208,10 @@ extension GatewayNodeSession {
             id: request.id,
             command: request.command,
             paramsJSON: request.paramsJSON,
-            nodeId: request.nodeId)
+            nodeId: request.nodeId,
+            sessionKey: request.sessionKey,
+            timeoutMs: request.timeoutMs,
+            idempotencyKey: request.idempotencyKey)
         let routeBoundInvoke: @Sendable (BridgeInvokeRequest) async -> BridgeInvokeResponse = { [weak self] req in
             guard let self else {
                 return Self.staleRouteInvokeResponse(requestId: req.id)

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/NodeError.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/NodeError.swift
@@ -6,6 +6,7 @@ public enum OpenClawNodeErrorCode: String, Codable, Sendable {
     case backgroundUnavailable = "NODE_BACKGROUND_UNAVAILABLE"
     case invalidRequest = "INVALID_REQUEST"
     case unavailable = "UNAVAILABLE"
+    case systemRunDenied = "SYSTEM_RUN_DENIED"
 }
 
 public struct OpenClawNodeError: Error, Codable, Sendable, Equatable {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/BridgeInvokeMetadataTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/BridgeInvokeMetadataTests.swift
@@ -1,0 +1,15 @@
+import Foundation
+import Testing
+@testable import OpenClawKit
+
+struct BridgeInvokeMetadataTests {
+    @Test func `outer invoke metadata survives the native bridge`() throws {
+        let raw = #"{"id":"invoke","command":"system.worker.start","nodeId":"node","paramsJSON":"{\"sessionKey\":\"untrusted\"}","sessionKey":"agent:main:owner","timeoutMs":42000,"idempotencyKey":"attempt","type":"invoke"}"#
+        let request = try JSONDecoder().decode(BridgeInvokeRequest.self, from: Data(raw.utf8))
+        let encoded = try JSONEncoder().encode(request)
+        let actual = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        #expect(actual["sessionKey"] as? String == "agent:main:owner")
+        #expect(actual["timeoutMs"] as? Int == 42000)
+        #expect(actual["idempotencyKey"] as? String == "attempt")
+    }
+}

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -189,6 +189,7 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
     private let lock = NSLock()
     private let helloAuth: [String: Any]?
     private let helloMethods: [String]
+    private let helloCapabilities: [String]
     private let helloSessionDefaults: [String: Any]?
     private let helloDelayNanoseconds: UInt64
     private let connectError: [String: Any]?
@@ -206,6 +207,7 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
     init(
         helloAuth: [String: Any]? = nil,
         helloMethods: [String] = [],
+        helloCapabilities: [String] = [],
         helloSessionDefaults: [String: Any]? = nil,
         helloDelayNanoseconds: UInt64 = 0,
         connectError: [String: Any]? = nil,
@@ -213,6 +215,7 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
     {
         self.helloAuth = helloAuth
         self.helloMethods = helloMethods
+        self.helloCapabilities = helloCapabilities
         self.helloSessionDefaults = helloSessionDefaults
         self.helloDelayNanoseconds = helloDelayNanoseconds
         self.connectError = connectError
@@ -317,6 +320,7 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
                     id: id,
                     auth: self.helloAuth,
                     methods: self.helloMethods,
+                    capabilities: self.helloCapabilities,
                     sessionDefaults: self.helloSessionDefaults))
             }
             try await Task.sleep(nanoseconds: 1_000_000)
@@ -328,6 +332,7 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
             id: "connect",
             auth: self.helloAuth,
             methods: self.helloMethods,
+            capabilities: self.helloCapabilities,
             sessionDefaults: self.helloSessionDefaults))
     }
 
@@ -410,6 +415,7 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
         id: String,
         auth: [String: Any]? = nil,
         methods: [String] = [],
+        capabilities: [String] = [],
         sessionDefaults: [String: Any]? = nil) -> Data
     {
         var payload: [String: Any] = [
@@ -422,6 +428,7 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
             "features": [
                 "methods": methods,
                 "events": [],
+                "capabilities": capabilities,
             ],
             "snapshot": [
                 "presence": [["ts": 1]],
@@ -503,6 +510,7 @@ private final class FakeGatewayWebSocketSession: WebSocketSessioning, GatewayTLS
     private let lock = NSLock()
     private let helloAuth: [String: Any]?
     private let helloMethods: [String]
+    private let helloCapabilities: [String]
     private let helloSessionDefaults: [String: Any]?
     private let helloDelayNanoseconds: UInt64
     private let connectError: [String: Any]?
@@ -515,6 +523,7 @@ private final class FakeGatewayWebSocketSession: WebSocketSessioning, GatewayTLS
     init(
         helloAuth: [String: Any]? = nil,
         helloMethods: [String] = [],
+        helloCapabilities: [String] = [],
         helloSessionDefaults: [String: Any]? = nil,
         helloDelayNanoseconds: UInt64 = 0,
         connectError: [String: Any]? = nil,
@@ -523,6 +532,7 @@ private final class FakeGatewayWebSocketSession: WebSocketSessioning, GatewayTLS
     {
         self.helloAuth = helloAuth
         self.helloMethods = helloMethods
+        self.helloCapabilities = helloCapabilities
         self.helloSessionDefaults = helloSessionDefaults
         self.helloDelayNanoseconds = helloDelayNanoseconds
         self.connectError = connectError
@@ -553,6 +563,7 @@ private final class FakeGatewayWebSocketSession: WebSocketSessioning, GatewayTLS
             let task = FakeGatewayWebSocketTask(
                 helloAuth: self.helloAuth,
                 helloMethods: self.helloMethods,
+                helloCapabilities: self.helloCapabilities,
                 helloSessionDefaults: self.helloSessionDefaults,
                 helloDelayNanoseconds: self.helloDelayNanoseconds,
                 connectError: self.connectError,
@@ -784,6 +795,76 @@ private func nodeInvokePush(id: String, command: String) -> GatewayPush {
 
 @Suite(.serialized)
 struct GatewayNodeSessionTests {
+    @Test func `authenticated invoke metadata reaches the native dispatcher unchanged`() async throws {
+        let gateway = GatewayNodeSession()
+        let capture = StringCapture()
+        try await gateway.connectForTest(
+            testURL("ws://gateway.example.invalid/current"),
+            options: nodeConnectOptions(caps: ["system"]),
+            session: FakeGatewayWebSocketSession(),
+            onInvoke: { request in
+                let encoded = try? JSONEncoder().encode(request)
+                await capture.set(encoded.flatMap { String(data: $0, encoding: .utf8) })
+                return BridgeInvokeResponse(id: request.id, ok: true)
+            })
+        await gateway._test_handlePush(.event(EventFrame(
+            type: "event", event: "node.invoke.request",
+            payload: AnyCodable([
+                "id": AnyCodable("invoke-metadata"), "nodeId": AnyCodable("node"),
+                "command": AnyCodable("system.worker.start"),
+                "paramsJSON": AnyCodable(#"{"sessionKey":"untrusted"}"#),
+                "sessionKey": AnyCodable("agent:main:owner"),
+                "timeoutMs": AnyCodable(42000), "idempotencyKey": AnyCodable("attempt"),
+            ]), seq: nil, stateversion: nil)), socketGeneration: 1)
+        try await waitUntil("invoke delivered") { await capture.get() != nil }
+        let value = try #require(await capture.get())
+        let request = try JSONDecoder().decode(BridgeInvokeRequest.self, from: Data(value.utf8))
+        #expect(request.sessionKey == "agent:main:owner")
+        #expect(request.timeoutMs == 42000)
+        #expect(request.idempotencyKey == "attempt")
+        await gateway.disconnect()
+    }
+
+    @Test(arguments: [
+        [],
+        [
+            "node-worker-portal-stream-v1",
+            "node-worker-environment-session-v1",
+            "node-worker-bundle-status-v1",
+            "node-worker-bundle-retention-v1",
+        ],
+    ])
+    func `worker connection uses the active authenticated route and expires on disconnect`(
+        capabilities: [String]) async throws
+    {
+        let fingerprint = String(repeating: "ab", count: 32)
+        let gateway = GatewayNodeSession()
+        try await gateway.connectForTest(
+            testURL("wss://gateway.example.invalid/current"),
+            options: nodeConnectOptions(caps: ["system"]),
+            session: FakeGatewayWebSocketSession(
+                helloCapabilities: capabilities,
+                effectiveTLSFingerprintSHA256: fingerprint),
+            extraHeadersProvider: { [
+                "CF-Access-Client-Id": "test-edge-id",
+                "CF-Access-Client-Secret": "test-edge-secret",
+                "Authorization": "test-unrelated-header",
+            ] })
+        let route = try #require(await gateway.currentRoute())
+        let data = try #require(await gateway.workerConnectionData(ifCurrentRoute: route))
+        let connection = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(connection["url"] as? String == "wss://gateway.example.invalid/current")
+        #expect(connection["protocol"] as? Int == 2)
+        #expect(connection["capabilities"] as? [String] == capabilities.sorted())
+        #expect(connection["tlsFingerprint"] as? String == fingerprint)
+        #expect(connection["cloudflareAccess"] as? [String: String] == [
+            "clientId": "test-edge-id", "clientSecret": "test-edge-secret",
+        ])
+        #expect(connection["Authorization"] == nil)
+        await gateway.disconnect()
+        #expect(await gateway.workerConnectionData(ifCurrentRoute: route) == nil)
+    }
+
     @Test func `operator canvas refresh uses the operator surface method`() async throws {
         let session = FakeGatewayWebSocketSession()
         let gateway = GatewayNodeSession()

--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -452,7 +452,8 @@ node does not advertise this command yet, so its rows remain view-only.
 
 ### Host OpenClaw sessions
 
-A headless node host can separately opt into full OpenClaw session hosting:
+The macOS menu bar app and the headless node host can opt into full OpenClaw
+session hosting with the same node-local setting:
 
 ```json5
 {
@@ -462,7 +463,13 @@ A headless node host can separately opt into full OpenClaw session hosting:
 }
 ```
 
-Restart the node host after enabling this setting. On the first session dispatch
+Restart the app or node host after enabling this setting. The macOS app owns
+one paired node identity and uses the shared node runtime for session hosting;
+do not start a second CLI node for the same Mac. Its native camera, screen, and
+desktop capabilities remain on that identity. If the shared runtime cannot
+start, native capabilities remain available, but session hosting is unavailable.
+
+On the first session dispatch
 for a Gateway build, the node downloads one sealed worker artifact from that
 paired Gateway, verifies its exact content hash, and publishes it atomically
 under the Gateway-namespaced node-host bundle root. The artifact already
@@ -945,7 +952,7 @@ Notes:
 - `system.run` returns stdout/stderr/exit code in the payload.
 - Shell execution now goes through the `exec` tool with `host=node`; `nodes` remains the direct-RPC surface for explicit node commands.
 - `nodes invoke` does not expose `system.run` or `system.run.prepare`; those stay on the exec path only.
-- The exec path prepares a canonical `systemRunPlan` before approval. Once an approval is granted, the gateway forwards that stored plan, not any later caller-edited command/cwd/session fields.
+- The exec path reads the node policy and prepares a canonical `systemRunPlan`. Full/off execution resolves working-directory aliases without adding approval-only script checks. When caller or node policy requires approval binding, stricter path and script checks remain in place. Once an approval is granted, the gateway forwards that stored plan, not any later caller-edited command/cwd/session fields.
 - `system.notify` respects notification permission state on the macOS app; supports `--priority <passive|active|timeSensitive>` and `--delivery <system|overlay|auto>`.
 - Unrecognized node `platform` / `deviceFamily` metadata uses a conservative default allowlist that excludes `system.run` and `system.which`. If you intentionally need those commands for an unknown platform, add them explicitly via `gateway.nodes.commands.allow`.
 - A `system.run` request supports `cwd`, an `env` map, `timeoutMs`, and `needsScreenRecording` — these are fields of the request payload carried on the exec path (see above), not `nodes invoke` CLI flags.

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -488,8 +488,15 @@ cloud worker is a separate, placement-owned execution path and does not require
 app-server and provider auth local, while the authorized node runs the managed,
 pinned Codex exec-server over its existing duplex connection. It requires
 explicit `gateway.nodes.commands.allow` authorization for
-`codex.exec-server.stdio.v1`, the approved pairing surface, and separate
-allow-once node invocation approval for each attempt. The node receives a
+`codex.exec-server.stdio.v1`, the approved pairing surface, and launch
+authorization for each attempt. A deliberately selected session **Full access**
+permission can replace the critical allow-once prompt only while the exact
+admitted turn and placement remain current and both node-local `tools.exec`
+and exec-approvals floors allow full/off execution. Ordinary and raw callers
+still require human approval. Local deny blocks either launch; local ask and
+allowlist policies cannot be bypassed with Full access. Changed local policy
+during setup refuses the launch. Gateway and node must both support this
+authorization path; missing node policy support fails closed. The node receives a
 fresh private home and sanitized environments, never Gateway provider, cloud,
 or GitHub credentials. A lost node connection terminates the attempt and
 process instead of resuming it. Each node-backed attempt uses its own Gateway

--- a/docs/plugins/codex-harness-runtime.md
+++ b/docs/plugins/codex-harness-runtime.md
@@ -231,8 +231,12 @@ Gateway rejects authentication, cookie, API-key, and other sensitive HTTP
 headers before they reach the node; authenticated HTTP must run on the
 Gateway. The existing duplex node channel carries the Codex JSON-RPC stream
 without starting an OpenClaw worker child or consuming a worker slot. Explicit
-Gateway command allowlisting and separate per-attempt allow-once approval
-remain required. Each attempt owns an isolated Gateway app-server client so its
+Gateway command allowlisting remains required. Launch needs per-attempt
+allow-once approval or exact admitted session Full access with node-local
+full/off policy. Full access never overrides local deny, ask, or allowlist
+restrictions, pairing, hosting consent, command authorization, or tool policy.
+The node rechecks local policy immediately before spawning the pinned binary;
+a stale launch is refused. Each attempt owns an isolated Gateway app-server client so its
 remote environment registration retires with that attempt. Disconnect ends the
 active attempt and its remote processes; reconnect allows only a fresh
 attempt. Normal Codex turns work, but `/btw` side questions fail closed because

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -191,8 +191,16 @@ capability and `codex.exec-server.stdio.v1` command. If enabling the plugin
 changes an existing node's command surface, reconnect the node, inspect
 `openclaw nodes pending`, and approve the updated pairing with
 `openclaw nodes approve <requestId>`. The persistent command allowlist does not
-replace the normal node invocation approval: deny starts no Codex process, and
-allow-once authorizes exactly one exec-server launch.
+replace launch authorization. Ordinarily, a critical allow-once decision
+authorizes exactly one exec-server launch; deny starts no process. Explicitly
+selected session **Full access** can substitute for that prompt only during
+the exact admitted turn and placement, and only when the node's own
+`tools.exec` policy and exec-approvals floors both allow full/off execution.
+Node-local deny always blocks. Local ask or allowlist restrictions require a
+human decision; Full access does not erase them. If a Full launch is refused
+by local policy, use an ordinary session permission mode to request approval,
+or deliberately change the node's local policy and reconnect it.
+Policy tightening during launch preparation refuses the stale launch.
 
 Codex launches its node exec-server directly rather than starting an OpenClaw
 worker, so a paired host remains eligible when all worker slots are occupied.
@@ -255,8 +263,9 @@ plugin and its pinned platform-native Codex binary. Crabbox validates the
 bundled or prepared installation and preserves its provenance in the disposable
 node's isolated state without installing a plugin during enrollment. The Gateway
 checks the cloud node's current pairing and
-effectively invocable command before starting a Codex process; approve the
-critical allow-once request for each exec-server attempt.
+effectively invocable command before starting a Codex process. The same
+per-attempt approval or explicitly selected Full access rules apply, including
+the cloud node's local exec policy and approvals floors.
 
 Codex runs its managed exec-server over the enrolled node's authenticated
 outbound connection without starting an OpenClaw worker child or consuming a

--- a/docs/plugins/sdk-agent-harness.md
+++ b/docs/plugins/sdk-agent-harness.md
@@ -468,6 +468,22 @@ runtime-compatible schema filtering, hidden catalog execution, directory
 hydration, and catalog cleanup. Harnesses still own their SDK-specific tool
 conversion and native execution callback.
 
+### Paired-device execution
+
+Declare `cloudPlacement.devicePlacement.requiredNodeCommands` for the exact node
+commands the harness needs to execute on a paired device. Core snapshots this
+set when it creates the selected harness's host capabilities. An admitted
+**Full access** session can authorize only those commands through the node
+policy's `invokeNodeWithSessionFull` callback; other commands owned by the same
+plugin do not inherit that permission. An absent declaration or an unlisted
+command returns `undefined`, so the policy must use its ordinary approval or
+denial path. Mutating the declaration during the attempt cannot widen authority.
+
+This declaration narrows authority; it does not grant it. Pairing, command
+allowlisting, hosting consent, node-local policy, and the exact live session,
+placement, and turn remain independently enforced. Plugins remain trusted code,
+not sandboxed by this callback.
+
 ### Native MCP inventory
 
 A harness that owns MCP connections outside OpenClaw's in-process MCP runtime

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -25,6 +25,10 @@ loosen them. If an approvals field is omitted, the `tools.exec` value is
 used. Host exec also uses local approvals state on that machine - a
 host-local `ask: "always"` in the execution host approvals document keeps
 prompting even if session or config defaults request `ask: "on-miss"`.
+An unconfigured node uses the same `full` / `off` baseline as the Gateway.
+Node execution still checks the target policy before dispatch: caller
+`allowlist` / `off` denies an unmatched command, and target `ask: "always"`
+requires approval even when the caller requests `full` / `off`.
 </Note>
 
 ## Where it applies
@@ -76,6 +80,12 @@ pending approval message. Matrix seeds reaction shortcuts (`✅` allow once,
 `♾️` allow always, `❌` deny) while still leaving `/approve ...` in the
 message as a fallback.
 </Tip>
+
+For native chat approval surfaces, a node exec waits for the decision within
+the originating tool call and returns the command output there. Closing or
+cancelling that turn invalidates its pending authority; a late approval cannot
+restart it. A typed `SYSTEM_RUN_DENIED` result means the node rejected execution,
+not that the command may have run.
 
 ## Settings and storage
 
@@ -252,7 +262,7 @@ explicitly when a no-UI approval prompt should fall back to allow.
 
 - `tools.exec.host=auto` chooses **where** exec runs: sandbox when available, otherwise gateway.
 - YOLO chooses **how** host exec is approved: `security=full` plus `ask=off`.
-- YOLO does **not** add a separate heuristic command-obfuscation approval gate or script-preflight rejection layer on top of the configured host exec policy.
+- YOLO does **not** add a separate heuristic command-obfuscation approval gate or script-preflight rejection layer on top of the configured host exec policy. Node preparation still reads the target policy and resolves the working directory once. If both sides allow full/off, ordinary path aliases and inline scripts do not require approval binding; restrictive policy and later policy changes remain enforced.
 - `auto` does not make node or gateway routing a free override from a sandboxed session. Per-call `host=node` and `host=gateway` requests are allowed from `auto` only when no sandbox runtime is active. For a stable non-auto default, set `tools.exec.host` or use `/exec host=...` explicitly.
 
 </Warning>

--- a/extensions/codex/src/node-exec-server.runtime.ts
+++ b/extensions/codex/src/node-exec-server.runtime.ts
@@ -152,6 +152,7 @@ function createNodeExecServerProcessOwner(
 
 /** Runs the one-connection paired-node exec-server after lightweight command admission. */
 export async function runCodexNodeExecServer(params: {
+  assertExecAuthorized: () => void;
   workspaceDir: string;
   io: OpenClawPluginNodeHostCommandIo;
   activeProcesses: Set<() => Promise<void>>;
@@ -206,6 +207,8 @@ export async function runCodexNodeExecServer(params: {
         if (io.signal.aborted) {
           throw nodeExecServerAbortError(io.signal);
         }
+        // Awaited setup is complete; policy and invocation closure win at spawn.
+        params.assertExecAuthorized();
         const child = createStdioTransport(
           {
             transport: "stdio",

--- a/extensions/codex/src/node-exec-server.test.ts
+++ b/extensions/codex/src/node-exec-server.test.ts
@@ -52,6 +52,7 @@ function createManagedWorkspaceInvocation(cwd: string) {
     sessionKey: placement.sessionKey,
     sendNodeEvent: async () => undefined,
     acquireManagedWorkspace,
+    prepareExecAuthorization: () => () => {},
   } satisfies NonNullable<Parameters<OpenClawPluginNodeHostCommand["handle"]>[2]>;
   return { placement, context, acquireManagedWorkspace, release };
 }
@@ -137,6 +138,112 @@ afterEach(() => {
 });
 
 describe("Codex node exec-server", () => {
+  it("uses admitted Full launch authority without asking for a human decision", async () => {
+    const { placement } = createManagedWorkspaceInvocation(process.cwd());
+    const request = vi.fn(async () => ({ decision: "deny" as const }));
+    const invokeNode = vi.fn();
+    const invokeNodeWithSessionFull = vi.fn(async () => ({ ok: true as const }));
+    await expect(
+      createCodexNodeExecServerInvokePolicy().handle({
+        nodeId: "paired-node",
+        command: CODEX_NODE_EXEC_SERVER_COMMAND,
+        params: placement,
+        config: {},
+        risk: { level: "high", family: "codex.exec-server" },
+        approvals: { request },
+        invokeNode,
+        invokeNodeWithSessionFull,
+      }),
+    ).resolves.toEqual({ ok: true });
+    expect(request).not.toHaveBeenCalled();
+    expect(invokeNode).not.toHaveBeenCalled();
+    expect(invokeNodeWithSessionFull).toHaveBeenCalledOnce();
+  });
+
+  it("checks node-local authorization before starting the pinned process", async () => {
+    const frames = createNodeFrames();
+    const workspace = createManagedWorkspaceInvocation(process.cwd());
+    const prepareExecAuthorization = vi.fn(() => {
+      throw new Error("node-local execution denied");
+    });
+    const invocation = createCodexNodeExecServerCommand().handle(
+      JSON.stringify({ placement: workspace.placement, authorization: "human-approved" }),
+      frames.io,
+      { ...workspace.context, prepareExecAuthorization },
+    );
+    void invocation.catch(() => {});
+    try {
+      await expect(Promise.race([frames.ready, invocation])).rejects.toThrow(
+        "node-local execution denied",
+      );
+      expect(prepareExecAuthorization).toHaveBeenCalledOnce();
+    } finally {
+      frames.controller.abort(new Error("policy fixture closed"));
+      await invocation.catch(() => {});
+    }
+  });
+
+  it("rejects forged launch authorization at the public policy boundary", async () => {
+    const { placement } = createManagedWorkspaceInvocation(process.cwd());
+    const request = vi.fn();
+    const invokeNode = vi.fn();
+    const invokeNodeWithSessionFull = vi.fn();
+    for (const params of [
+      { ...placement, authorization: "session-full" },
+      { placement, authorization: "human-approved" },
+      { placement, authorization: "session-full" },
+    ]) {
+      await expect(
+        createCodexNodeExecServerInvokePolicy().handle({
+          nodeId: "paired-node",
+          command: CODEX_NODE_EXEC_SERVER_COMMAND,
+          params,
+          config: {},
+          risk: { level: "high", family: "codex.exec-server" },
+          approvals: { request },
+          invokeNode,
+          invokeNodeWithSessionFull,
+        }),
+      ).resolves.toMatchObject({ ok: false, code: "CODEX_NODE_EXEC_WORKSPACE_INVALID" });
+    }
+    expect(request).not.toHaveBeenCalled();
+    expect(invokeNode).not.toHaveBeenCalled();
+    expect(invokeNodeWithSessionFull).not.toHaveBeenCalled();
+  });
+
+  it("revalidates local policy after awaited binary setup and fails closed without node support", async () => {
+    const transport = await import("./app-server/transport-stdio.js");
+    const spawn = vi.spyOn(transport, "createStdioTransport");
+    const workspace = createManagedWorkspaceInvocation(process.cwd());
+    const frames = createNodeFrames();
+    const encoded = JSON.stringify({
+      placement: workspace.placement,
+      authorization: "session-full",
+    });
+    const assertCurrent = vi.fn(() => {
+      throw new Error("node policy tightened");
+    });
+    try {
+      await expect(
+        createCodexNodeExecServerCommand().handle(encoded, frames.io, {
+          ...workspace.context,
+          prepareExecAuthorization: () => assertCurrent,
+        }),
+      ).rejects.toThrow("node policy tightened");
+      expect(assertCurrent).toHaveBeenCalledOnce();
+      expect(spawn).not.toHaveBeenCalled();
+      await expect(
+        createCodexNodeExecServerCommand().handle(encoded, frames.io, {
+          ...workspace.context,
+          prepareExecAuthorization: undefined,
+        }),
+      ).rejects.toThrow("update the node");
+      expect(spawn).not.toHaveBeenCalled();
+    } finally {
+      spawn.mockRestore();
+    }
+  });
+
   it.each([
     { host: "paired device", nodeId: "paired-node" },
     { host: "cloud worker", nodeId: "cloud-worker-node" },
@@ -195,7 +302,16 @@ describe("Codex node exec-server", () => {
       payload: { connected: true },
     });
     expect(invokeNode).toHaveBeenCalledOnce();
-    expect(invokeNode).toHaveBeenCalledWith({ params: approvedPlacement });
+    expect(invokeNode).toHaveBeenCalledWith({
+      workspace: {
+        workspaceDir: approvedPlacement.cwd,
+        environmentId: approvedPlacement.environmentId,
+        sessionId: approvedPlacement.sessionId,
+        ownerEpoch: approvedPlacement.ownerEpoch,
+        sessionKey: approvedPlacement.sessionKey,
+      },
+      params: { placement: approvedPlacement, authorization: "human-approved" },
+    });
     expect(request).toHaveBeenCalledWith(
       expect.objectContaining({
         title: "Run Codex execution on node",
@@ -213,7 +329,10 @@ describe("Codex node exec-server", () => {
     const command = createCodexNodeExecServerCommand();
     const frames = createNodeFrames();
     const workspace = createManagedWorkspaceInvocation(process.cwd());
-    const encodedPlacement = JSON.stringify(workspace.placement);
+    const encodedPlacement = JSON.stringify({
+      placement: workspace.placement,
+      authorization: "human-approved",
+    });
     await expect(command.handle(encodedPlacement)).rejects.toThrow("requires duplex frames");
     await expect(
       command.handle(
@@ -221,7 +340,7 @@ describe("Codex node exec-server", () => {
         frames.io,
         workspace.context,
       ),
-    ).rejects.toThrow("exact managed placement workspace");
+    ).rejects.toThrow("managed placement workspace");
     await expect(command.handle(encodedPlacement, frames.io)).rejects.toThrow(
       "active managed placement authority",
     );
@@ -240,7 +359,10 @@ describe("Codex node exec-server", () => {
     ]) {
       await expect(
         command.handle(
-          JSON.stringify({ ...workspace.placement, ...replacement }),
+          JSON.stringify({
+            placement: { ...workspace.placement, ...replacement },
+            authorization: "human-approved",
+          }),
           frames.io,
           workspace.context,
         ),
@@ -280,7 +402,7 @@ describe("Codex node exec-server", () => {
         const command = createCodexNodeExecServerCommand();
         const workspace = createManagedWorkspaceInvocation(cwd);
         const invocation = command.handle(
-          JSON.stringify(workspace.placement),
+          JSON.stringify({ placement: workspace.placement, authorization: "human-approved" }),
           frames.io,
           workspace.context,
         );

--- a/extensions/codex/src/node-exec-server.ts
+++ b/extensions/codex/src/node-exec-server.ts
@@ -65,7 +65,16 @@ export function createCodexNodeExecServerCommand(): OpenClawPluginNodeHostComman
       } catch {
         throw new Error("Codex node exec-server requires a valid workspace request.");
       }
-      const placement = parseCodexNodePlacementWorkspace(request);
+      if (
+        !isRecord(request) ||
+        Object.keys(request).length !== 2 ||
+        (request.authorization !== "human-approved" && request.authorization !== "session-full")
+      ) {
+        throw new Error(
+          "Codex node exec-server requires an authorized managed placement workspace launch.",
+        );
+      }
+      const placement = parseCodexNodePlacementWorkspace(request.placement);
       if (
         !context?.acquireManagedWorkspace ||
         context.sessionKey !== placement.sessionKey ||
@@ -83,11 +92,18 @@ export function createCodexNodeExecServerCommand(): OpenClawPluginNodeHostComman
       const frames = io.frames;
       let unsubscribe: (() => void) | undefined;
       try {
+        if (!context.prepareExecAuthorization) {
+          throw new Error(
+            "Codex node execution requires node-local exec policy support; update the node.",
+          );
+        }
+        const assertExecAuthorized = context.prepareExecAuthorization(request.authorization);
         const { runCodexNodeExecServer } = await import("./node-exec-server.runtime.js");
         return await runCodexNodeExecServer({
           workspaceDir: workspace.workspaceDir,
           io,
           activeProcesses,
+          assertExecAuthorized,
           // Listener registration announces readiness, so the child must own it first.
           onFrameReceiver: (receiver) => {
             unsubscribe = frames.onMessage(receiver);
@@ -104,14 +120,14 @@ export function createCodexNodeExecServerCommand(): OpenClawPluginNodeHostComman
   };
 }
 
-/** Keeps node exec-server launch behind explicit arming and one-time approval. */
+/** Keeps node launch behind command opt-in and a live Full owner or human decision. */
 export function createCodexNodeExecServerInvokePolicy(): OpenClawPluginNodeInvokePolicy {
   return {
     commands: [CODEX_NODE_EXEC_SERVER_COMMAND],
     dangerous: true,
     classifyRisk: () => ({ level: "high", family: CODEX_NODE_EXEC_SERVER_CAPABILITY }),
     handle: async (context) => {
-      if (!context.approvals || context.risk?.level !== "high") {
+      if (context.risk?.level !== "high") {
         return {
           ok: false,
           code: "CODEX_NODE_EXEC_APPROVAL_REQUIRED",
@@ -128,6 +144,27 @@ export function createCodexNodeExecServerInvokePolicy(): OpenClawPluginNodeInvok
           message: "Codex node execution requires an exact managed placement workspace.",
         };
       }
+      const workspace = {
+        workspaceDir: placement.cwd,
+        environmentId: placement.environmentId,
+        sessionId: placement.sessionId,
+        ownerEpoch: placement.ownerEpoch,
+        sessionKey: placement.sessionKey,
+      };
+      const fullLaunch = await context.invokeNodeWithSessionFull?.({
+        workspace,
+        createParams: () => ({ placement, authorization: "session-full" }),
+      });
+      if (fullLaunch) {
+        return fullLaunch;
+      }
+      if (!context.approvals) {
+        return {
+          ok: false,
+          code: "CODEX_NODE_EXEC_APPROVAL_REQUIRED",
+          message: "Codex node execution requires an available approval reviewer.",
+        };
+      }
       const nodeName = context.node?.displayName ?? context.nodeId;
       const approval = await context.approvals.request({
         title: "Run Codex execution on node",
@@ -142,7 +179,10 @@ export function createCodexNodeExecServerInvokePolicy(): OpenClawPluginNodeInvok
           message: "Codex node execution requires one-time approval.",
         };
       }
-      return await context.invokeNode({ params: placement });
+      return await context.invokeNode({
+        workspace,
+        params: { placement, authorization: "human-approved" },
+      });
     },
   };
 }

--- a/src/agents/bash-tools.exec-approval-wait.ts
+++ b/src/agents/bash-tools.exec-approval-wait.ts
@@ -1,0 +1,27 @@
+import { isNativeApprovalChannel, normalizeMessageChannel } from "../utils/message-channel.js";
+
+export function shouldAwaitExecApprovalInline(params: {
+  turnSourceChannel?: string;
+  approvalFollowupMode?: "agent" | "direct";
+  trigger?: string;
+}): boolean {
+  if (params.approvalFollowupMode !== undefined) {
+    return false;
+  }
+  // Scheduled runs cannot recover from an "approval-pending" handoff: the
+  // isolated session ends and authority-close cancels the parked approval
+  // seconds later. Wait inline so a connected approval client gets the full
+  // approval window; allow-always there mints the standing grant and this
+  // occurrence executes. Cron jobs are single-flight, so waiting cannot
+  // stack runs.
+  if (params.trigger === "cron") {
+    return true;
+  }
+  // Native chat approval clients (Telegram /approve, Discord buttons,
+  // etc.) resolve the approval back into the same session, so the agent can
+  // wait inline and return the real exec output as the tool result. This
+  // mirrors the webchat path that PR #85239 fixed; without it the agent run
+  // terminates on the "approval-pending" tool result and the operator must
+  // send a follow-up chat message to recover the turn (issue #93918).
+  return isNativeApprovalChannel(normalizeMessageChannel(params.turnSourceChannel));
+}

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -61,7 +61,6 @@ import {
   GatewayDrainingError,
   runWithGatewayIndependentRootWorkAdmission,
 } from "../process/gateway-work-admission.js";
-import { isNativeApprovalChannel, normalizeMessageChannel } from "../utils/message-channel.js";
 import { markBackgrounded, tail } from "./bash-process-registry.js";
 import { formatExecApprovalContinuationSourceOutput } from "./bash-tools.exec-approval-output.js";
 import {
@@ -69,6 +68,7 @@ import {
   buildExecApprovalTurnSourceContext,
   registerExecApprovalRequestForHostOrThrow,
 } from "./bash-tools.exec-approval-request.js";
+import { shouldAwaitExecApprovalInline } from "./bash-tools.exec-approval-wait.js";
 import {
   buildHeadlessExecApprovalDeniedMessage,
   buildExecApprovalFollowupTarget,
@@ -400,32 +400,6 @@ function buildGatewayExecApprovalFollowupSummary(params: {
       : `Exec finished (gateway id=${params.approvalId}, session=${params.sessionId}, ${exitLabel})`;
   }
   return appendExecTimeoutRetryGuidance(summary, params.outcome.exitReason);
-}
-
-function shouldAwaitGatewayApprovalInline(params: {
-  turnSourceChannel?: string;
-  approvalFollowupMode?: "agent" | "direct";
-  trigger?: string;
-}): boolean {
-  if (params.approvalFollowupMode !== undefined) {
-    return false;
-  }
-  // Scheduled runs cannot recover from an "approval-pending" handoff: the
-  // isolated session ends and authority-close cancels the parked approval
-  // seconds later. Wait inline so a connected approval client gets the full
-  // approval window; allow-always there mints the standing grant and this
-  // occurrence executes. Cron jobs are single-flight, so waiting cannot
-  // stack runs.
-  if (params.trigger === "cron") {
-    return true;
-  }
-  // Native chat approval clients (Telegram /approve, Discord buttons,
-  // etc.) resolve the approval back into the same session, so the agent can
-  // wait inline and return the real exec output as the tool result. This
-  // mirrors the webchat path that PR #85239 fixed; without it the agent run
-  // terminates on the "approval-pending" tool result and the operator must
-  // send a follow-up chat message to recover the turn (issue #93918).
-  return isNativeApprovalChannel(normalizeMessageChannel(params.turnSourceChannel));
 }
 
 function buildGatewayExecApprovalDeniedToolResult(params: {
@@ -1352,7 +1326,7 @@ export async function processGatewayAllowlist(
       };
     };
 
-    if (unavailableReason === null && shouldAwaitGatewayApprovalInline(params)) {
+    if (unavailableReason === null && shouldAwaitExecApprovalInline(params)) {
       if (params.runId) {
         emitAgentEvent({
           runId: params.runId,

--- a/src/agents/bash-tools.exec-host-node-failure.ts
+++ b/src/agents/bash-tools.exec-host-node-failure.ts
@@ -8,6 +8,14 @@ import { callGatewayTool } from "./tools/gateway.js";
 
 type NodeInvokeFailure =
   | {
+      reason: "policy-denied";
+      retrySafe: false;
+      code: "SYSTEM_RUN_DENIED";
+      message: string;
+      nodeCommandDispatched?: boolean;
+      requestSent?: boolean;
+    }
+  | {
       reason: "not-dispatched";
       retrySafe: true;
       code: "NOT_CONNECTED";
@@ -43,6 +51,9 @@ function classifyNodeInvokeFailure(error: unknown): NodeInvokeFailure {
   const requestSent =
     typeof errorRecord?.requestSent === "boolean" ? errorRecord.requestSent : undefined;
 
+  if (code === "SYSTEM_RUN_DENIED") {
+    return { reason: "policy-denied", retrySafe: false, code, message };
+  }
   if (code === "NOT_CONNECTED" && nodeCommandDispatched === false) {
     return {
       reason: "not-dispatched",
@@ -74,10 +85,15 @@ function formatNodeInvokeFailureText(params: {
           `Node command outcome is unknown for ${params.nodeId}.`,
           "The command may have executed. Do not rerun it automatically.",
         ]
-      : [
-          `Node command was not dispatched to ${params.nodeId}.`,
-          "It can be retried after the node reconnects.",
-        ];
+      : params.failure.reason === "policy-denied"
+        ? [
+            `Node command was denied before execution on ${params.nodeId}.`,
+            "Resolve the reported refusal before retrying.",
+          ]
+        : [
+            `Node command was not dispatched to ${params.nodeId}.`,
+            "It can be retried after the node reconnects.",
+          ];
   return [
     ...summary,
     "",
@@ -97,7 +113,9 @@ export function formatNodeInvokeFailureFollowup(params: {
   const prefix =
     params.failure.reason === "outcome-unknown"
       ? `Exec outcome unknown (node=${params.nodeId} id=${params.approvalId}, outcome-unknown)`
-      : `Exec not dispatched (node=${params.nodeId} id=${params.approvalId}, not-dispatched)`;
+      : params.failure.reason === "policy-denied"
+        ? `Exec denied (node=${params.nodeId} id=${params.approvalId}, policy-denied)`
+        : `Exec not dispatched (node=${params.nodeId} id=${params.approvalId}, not-dispatched)`;
   return `${prefix}\n${formatNodeInvokeFailureText(params)}`;
 }
 

--- a/src/agents/bash-tools.exec-host-node-phases.test.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.test.ts
@@ -3,7 +3,7 @@ import {
   formatNodeInvokeFailureFollowup,
   invokeNodeSystemRun,
 } from "./bash-tools.exec-host-node-failure.js";
-import { invokeNodeSystemRunDirect } from "./bash-tools.exec-host-node-phases.js";
+import { dispatchNodeSystemRun } from "./bash-tools.exec-host-node-phases.js";
 
 const callGatewayToolMock = vi.hoisted(() => vi.fn());
 
@@ -115,10 +115,15 @@ describe("invokeNodeSystemRun failure classification", () => {
   });
 });
 
-type DirectNodeRun = Parameters<typeof invokeNodeSystemRunDirect>[0];
+type DirectNodeRun = Parameters<typeof dispatchNodeSystemRun>[0];
 
 function createDirectNodeRun(signal?: AbortSignal): DirectNodeRun {
   return {
+    invoke: {
+      nodeId: "node-1",
+      command: "system.run",
+      params: { command: ["tool", "--version"], rawCommand: "tool --version" },
+    },
     request: {
       command: "tool --version",
       workdir: "/tmp/work",
@@ -150,9 +155,31 @@ describe("direct node run", () => {
     });
   });
 
+  it.each(["timeout", "malformed response"])("keeps %s outcomes ambiguous", async (kind) => {
+    if (kind === "timeout") {
+      callGatewayToolMock.mockRejectedValueOnce(
+        gatewayNodeInvokeError({
+          code: "TIMEOUT",
+          nodeCommandDispatched: true,
+        }),
+      );
+    } else {
+      callGatewayToolMock.mockResolvedValueOnce({ payload: { stdout: "partial" } });
+    }
+    const result = await dispatchNodeSystemRun(createDirectNodeRun());
+    expect(result.details).toMatchObject({ status: "failed", reason: "outcome-unknown" });
+    expect(result.content).toEqual([
+      expect.objectContaining({
+        text: expect.stringContaining(
+          "The command may have executed. Do not rerun it automatically.",
+        ),
+      }),
+    ]);
+  });
+
   it("forwards the original cancellation signal to the gateway", async () => {
     const controller = new AbortController();
-    await invokeNodeSystemRunDirect(createDirectNodeRun(controller.signal));
+    await dispatchNodeSystemRun(createDirectNodeRun(controller.signal));
 
     expect(callGatewayToolMock).toHaveBeenCalledWith(
       "node.invoke",
@@ -176,7 +203,7 @@ describe("direct node run", () => {
       },
     });
 
-    const result = await invokeNodeSystemRunDirect(createDirectNodeRun());
+    const result = await dispatchNodeSystemRun(createDirectNodeRun());
     const visibleText = result.content[0]?.type === "text" ? result.content[0].text : "";
 
     expect(visibleText).toBe(`${stdout}\n${stderr}\n${errorText}\n(Command exited with code 1)`);
@@ -188,7 +215,7 @@ describe("direct node run", () => {
       payload: { success: false, stdout: "done", stderr: "", error: null, exitCode: 3 },
     });
 
-    const result = await invokeNodeSystemRunDirect(createDirectNodeRun());
+    const result = await dispatchNodeSystemRun(createDirectNodeRun());
     const visibleText = result.content[0]?.type === "text" ? result.content[0].text : "";
 
     // Output alone must not read as success when the command failed.
@@ -202,7 +229,7 @@ describe("direct node run", () => {
       payload: { success: false, stdout: "", stderr: "", error: null, timedOut: true },
     });
 
-    const result = await invokeNodeSystemRunDirect(createDirectNodeRun());
+    const result = await dispatchNodeSystemRun(createDirectNodeRun());
     const visibleText = result.content[0]?.type === "text" ? result.content[0].text : "";
 
     expect(visibleText).toContain("Command timed out.");
@@ -214,7 +241,7 @@ describe("direct node run", () => {
     const reason = new Error("cancelled before direct node dispatch");
     controller.abort(reason);
 
-    await expect(invokeNodeSystemRunDirect(createDirectNodeRun(controller.signal))).rejects.toBe(
+    await expect(dispatchNodeSystemRun(createDirectNodeRun(controller.signal))).rejects.toBe(
       reason,
     );
     expect(callGatewayToolMock).not.toHaveBeenCalled();

--- a/src/agents/bash-tools.exec-host-node-phases.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.ts
@@ -225,19 +225,8 @@ function hasNodeAllowAlwaysCommandApproval(params: {
   return expectedPatterns.every((pattern) => matchingEntries.has(pattern));
 }
 
-/** Returns true when local policy allows direct node invoke without prepare/approval. */
-export function shouldSkipNodeApprovalPrepare(params: {
-  hostSecurity: ExecSecurity;
-  hostAsk: ExecAsk;
-  strictInlineEval?: boolean;
-}): boolean {
-  return (
-    params.hostSecurity === "full" && params.hostAsk === "off" && params.strictInlineEval !== true
-  );
-}
-
 /** Formats a raw `node.invoke system.run` response as an exec tool result. */
-export function formatNodeRunToolResult(params: {
+function formatNodeRunToolResult(params: {
   raw: unknown;
   startedAt: number;
   cwd: string | undefined;
@@ -423,25 +412,19 @@ export function buildNodeSystemRunInvoke(params: {
   };
 }
 
-/** Invokes `system.run` directly when approval policy is fully bypassed. */
-export async function invokeNodeSystemRunDirect(params: {
+/** Dispatches an authorized run and renders its transport or execution outcome. */
+export async function dispatchNodeSystemRun(params: {
   request: ExecuteNodeHostCommandParams;
   target: NodeExecutionTarget;
+  invoke: Record<string, unknown>;
+  scopes?: Parameters<typeof invokeNodeSystemRun>[0]["scopes"];
 }): Promise<AgentToolResult<ExecToolDetails>> {
   const startedAt = Date.now();
-  const invoke = buildNodeSystemRunInvoke({
-    target: params.target,
-    command: params.target.argv,
-    rawCommand: params.request.command,
-    cwd: params.request.workdir,
-    agentId: params.request.agentId,
-    sessionKey: params.request.sessionKey,
-    notifyOnExit: params.request.notifyOnExit,
-  });
   params.request.signal?.throwIfAborted();
   const result = await invokeNodeSystemRun({
     invokeWaitMs: params.target.invokeWaitMs,
-    invoke,
+    invoke: params.invoke,
+    scopes: params.scopes,
     signal: params.request.signal,
   });
   if (!result.ok) {
@@ -479,6 +462,8 @@ export async function prepareNodeSystemRun(params: {
       command: "system.run.prepare",
       params: {
         command: params.target.argv,
+        security: params.request.security,
+        ask: params.request.ask,
         rawCommand: params.request.command,
         ...(params.request.workdir != null ? { cwd: params.request.workdir } : {}),
         ...(params.target.env !== undefined ? { env: params.target.env } : {}),
@@ -612,6 +597,8 @@ export async function analyzeNodeApprovalRequirement(params: {
   if (
     (params.hostAsk === "always" ||
       params.hostSecurity === "allowlist" ||
+      params.prepared.execPolicy?.security === "allowlist" ||
+      params.prepared.execPolicy?.ask === "always" ||
       params.request.autoReview === true) &&
     analysisOk
   ) {

--- a/src/agents/bash-tools.exec-host-node.cancellation.test.ts
+++ b/src/agents/bash-tools.exec-host-node.cancellation.test.ts
@@ -1,164 +1,145 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs/promises";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance,
+} from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
-import type { ExecAsk, ExecSecurity } from "../infra/exec-approvals.js";
+import {
+  resolveExecApprovalsFromFile,
+  type ExecAllowlistEntry,
+  type ExecAsk,
+  type ExecSecurity,
+} from "../infra/exec-approvals.js";
 import type { ExecAutoReviewer } from "../infra/exec-auto-review.js";
-import type { ExecuteNodeHostCommandParams } from "./bash-tools.exec-host-node.types.js";
-
-type NodeApprovalPolicy = Awaited<
-  ReturnType<typeof import("./bash-tools.exec-host-shared.js").resolveExecHostApprovalContext>
->;
-
-const mocks = vi.hoisted(() => ({
-  analyzeNodeApprovalRequirement: vi.fn(),
-  callGatewayTool: vi.fn(
-    async (
-      _method: string,
-      _options: unknown,
-      _params?: { command?: string },
-      _extra?: { scopes?: string[]; signal?: AbortSignal },
-    ) => ({ payload: { success: true, stdout: "ok", exitCode: 0 } }),
-  ),
-  invokeNodeSystemRunDirect: vi.fn(),
-  registerNodeApproval: vi.fn(async () => undefined),
-  requiresExecApproval: vi.fn(),
-  resolveExecHostApprovalContext: vi.fn(),
-}));
-
-vi.mock("../infra/exec-approvals.js", () => ({
-  maxAsk: (left: ExecAsk, right: ExecAsk) => {
-    const priority: Record<ExecAsk, number> = { off: 0, "on-miss": 1, always: 2 };
-    return priority[left] >= priority[right] ? left : right;
-  },
-  minSecurity: (left: ExecSecurity, right: ExecSecurity) => {
-    const priority: Record<ExecSecurity, number> = { deny: 0, allowlist: 1, full: 2 };
-    return priority[left] <= priority[right] ? left : right;
-  },
-  requiresExecApproval: mocks.requiresExecApproval,
-  resolveExecApprovalAllowedDecisions: vi.fn(() => ["allow-once", "allow-always", "deny"]),
-  resolveExecApprovalUnavailableDecisions: vi.fn(() => []),
-}));
-
-vi.mock("../infra/exec-auto-review.js", () => ({
-  defaultExecAutoReviewer: vi.fn(),
-  resolveExecAutoReviewDecision: vi.fn(async (reviewer: ExecAutoReviewer, input) =>
-    reviewer(input),
-  ),
-}));
-
-vi.mock("./bash-tools.exec-approval-request.js", () => ({
-  buildExecApprovalRequesterContext: vi.fn(() => ({})),
-  buildExecApprovalTurnSourceContext: vi.fn(() => ({})),
-  isExecApprovalRunAbortedError: vi.fn(() => false),
-  registerExecApprovalRequestForHostOrThrow: mocks.registerNodeApproval,
-}));
-
-vi.mock("./bash-tools.exec-host-node-phases.js", () => ({
-  analyzeNodeApprovalRequirement: mocks.analyzeNodeApprovalRequirement,
-  buildNodeSystemRunInvoke: vi.fn(() => ({ command: "system.run" })),
-  formatNodeRunToolResult: vi.fn(() => ({
-    content: [],
-    details: { status: "completed" },
-  })),
-  invokeNodeSystemRunDirect: mocks.invokeNodeSystemRunDirect,
-  prepareNodeSystemRun: vi.fn(async () => ({
-    plan: {},
-    argv: ["tool", "--version"],
-    rawCommand: "tool --version",
-    transportRawCommand: "tool --version",
-    cwd: "/tmp/work",
-    agentId: "agent",
-    sessionKey: "agent:main:main",
-  })),
-  resolveNodeExecutionTarget: vi.fn(async () => ({
-    nodeId: "node-1",
-    argv: ["tool", "--version"],
-    invokeDeadlineMs: 30_000,
-    invokeWaitMs: 35_000,
-    supportsSystemRunPrepare: true,
-  })),
-  shouldSkipNodeApprovalPrepare: vi.fn(
-    (policy: { hostSecurity: ExecSecurity; hostAsk: ExecAsk }) =>
-      policy.hostSecurity === "full" && policy.hostAsk === "off",
-  ),
-}));
-
-vi.mock("./bash-tools.exec-host-shared.js", () => ({
-  resolveExecHostApprovalContext: mocks.resolveExecHostApprovalContext,
-}));
-
-vi.mock("./bash-process-registry.js", () => ({ tail: vi.fn((text: string) => text) }));
-
-vi.mock("./bash-tools.exec-runtime.js", () => ({
-  createApprovalSlug: vi.fn(() => "approval"),
-}));
-
-vi.mock("./embedded-agent-runner/run/abortable.js", () => ({
-  abortable: vi.fn(async (_signal: AbortSignal, pending: Promise<unknown>) => pending),
-}));
-
-vi.mock("./tools/gateway.js", () => ({ callGatewayTool: mocks.callGatewayTool }));
-
+import type { PreparedRunExecPolicy } from "../infra/system-run-approval-context.js";
+import { formatExecCommand } from "../infra/system-run-command.js";
+import { buildSystemRunPreparePayload } from "../test-utils/system-run-prepare-payload.js";
 import { executeNodeHostCommand } from "./bash-tools.exec-host-node.js";
+import type { ExecuteNodeHostCommandParams } from "./bash-tools.exec-host-node.types.js";
+import * as execHostShared from "./bash-tools.exec-host-shared.js";
+
+type NodeApprovalPolicy = Awaited<ReturnType<typeof execHostShared.resolveExecHostApprovalContext>>;
+type GatewayCallParams = {
+  command?: string;
+  params?: Parameters<typeof buildSystemRunPreparePayload>[0];
+  id?: string;
+};
+type GatewayCallExtra = Parameters<typeof import("./tools/gateway.js").callGatewayTool>[3];
+
+const callGatewayToolMock = vi.hoisted(() =>
+  vi.fn<
+    (
+      method: string,
+      options: unknown,
+      params?: GatewayCallParams,
+      extra?: GatewayCallExtra,
+    ) => Promise<unknown>
+  >(),
+);
+
+vi.mock("./tools/gateway.js", () => ({ callGatewayTool: callGatewayToolMock }));
+vi.mock("./tools/nodes-utils.js", () => ({
+  listNodes: async () => [
+    {
+      nodeId: "node-1",
+      connected: true,
+      platform: process.platform,
+      commands: ["system.run", "system.run.prepare"],
+    },
+  ],
+  resolveNodeIdFromList: () => "node-1",
+}));
 
 function createPolicy(security: ExecSecurity, ask: ExecAsk): NodeApprovalPolicy {
   return {
-    approvals: {
-      path: "",
-      socketPath: "",
-      token: "",
-      defaults: { security, ask, askFallback: "deny", autoAllowSkills: false },
-      agent: { security, ask, askFallback: "deny", autoAllowSkills: false },
-      agentSources: { security: null, ask: null, askFallback: null },
-      allowlist: [],
-      file: { version: 1, agents: {} },
-    },
+    approvals: resolveExecApprovalsFromFile({
+      file: {
+        version: 1,
+        defaults: { security, ask, askFallback: "deny", autoAllowSkills: false },
+        agents: {},
+      },
+      agentId: "main",
+    }),
     hostSecurity: security,
     hostAsk: ask,
     askFallback: "deny",
   };
 }
 
+let executable: string;
+let workdir: string;
+let nodePolicy: PreparedRunExecPolicy;
+let nodeAllowlist: ExecAllowlistEntry[];
+let resolvePolicy: MockInstance<typeof execHostShared.resolveExecHostApprovalContext>;
+
 function createRequest(overrides: Partial<ExecuteNodeHostCommandParams>) {
   return {
-    command: "tool --version",
-    workdir: "/tmp/work",
+    command: formatExecCommand([executable, "--version"]),
+    workdir,
     env: {},
     security: "full",
     ask: "off",
     defaultTimeoutSec: 30,
     approvalRunningNoticeMs: 0,
     warnings: [],
-    agentId: "agent",
+    agentId: "main",
     sessionKey: "agent:main:main",
     ...overrides,
   } satisfies ExecuteNodeHostCommandParams;
 }
 
 describe("node-host dispatch cancellation", () => {
+  beforeAll(async () => {
+    executable = await fs.realpath(process.execPath);
+    workdir = await fs.realpath(process.cwd());
+  });
+
   beforeEach(() => {
-    vi.clearAllMocks();
-    mocks.resolveExecHostApprovalContext.mockReset();
-    mocks.requiresExecApproval.mockImplementation(({ ask }: { ask: ExecAsk }) => ask !== "off");
-    mocks.analyzeNodeApprovalRequirement.mockResolvedValue({
-      analysisOk: true,
-      allowlistSatisfied: false,
-      durableApprovalSatisfied: false,
-      nodeApprovalPolicyKnown: true,
-      nodeSecurity: "allowlist",
-      nodeAsk: "on-miss",
-      inlineEvalHit: null,
-      requiresSecurityAuditSuppressionApproval: false,
-      autoReviewArgv: ["tool", "--version"],
-      allowAlwaysPersistence: { kind: "patterns", patterns: [] },
-    });
-    mocks.invokeNodeSystemRunDirect.mockResolvedValue({
-      content: [],
-      details: { status: "completed" },
+    nodePolicy = { security: "full", ask: "off" };
+    nodeAllowlist = [];
+    resolvePolicy = vi.spyOn(execHostShared, "resolveExecHostApprovalContext");
+    callGatewayToolMock.mockReset().mockImplementation(async (method, _options, params) => {
+      if (method === "exec.approvals.node.get") {
+        return {
+          file: {
+            version: 1,
+            defaults: nodePolicy,
+            agents: { main: { allowlist: nodeAllowlist } },
+          },
+        };
+      }
+      if (method === "exec.approval.request") {
+        return { status: "accepted", id: params?.id };
+      }
+      if (method === "exec.approval.resolve") {
+        return { ok: true };
+      }
+      if (method === "node.invoke" && params?.command === "system.run.prepare") {
+        if (!params.params) {
+          throw new Error("expected system.run.prepare parameters");
+        }
+        const prepared = buildSystemRunPreparePayload(params.params);
+        return { payload: { ...prepared.payload, execPolicy: nodePolicy } };
+      }
+      if (method === "node.invoke" && params?.command === "system.run") {
+        return { payload: { success: true, stdout: "ok", exitCode: 0 } };
+      }
+      throw new Error(`unexpected gateway call: ${method} ${params?.command ?? ""}`);
     });
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it.each([
-    { name: "direct full/off", security: "full", ask: "off", autoReview: false },
+    { name: "prepared full/off", security: "full", ask: "off", autoReview: false },
     {
       name: "auto-reviewed allowlist",
       security: "allowlist",
@@ -169,15 +150,14 @@ describe("node-host dispatch cancellation", () => {
     const controller = new AbortController();
     const reason = new Error("cancelled during final node dispatch policy");
     const policy = createPolicy(scenario.security, scenario.ask);
+    nodePolicy = { security: scenario.security, ask: scenario.ask };
     const checkpoint = createDeferred<NodeApprovalPolicy>();
-    mocks.resolveExecHostApprovalContext
-      .mockResolvedValueOnce(policy)
-      .mockReturnValueOnce(checkpoint.promise);
-    const reviewer: ExecAutoReviewer = async () => ({
+    resolvePolicy.mockResolvedValueOnce(policy).mockReturnValueOnce(checkpoint.promise);
+    const reviewer = vi.fn<ExecAutoReviewer>(async () => ({
       decision: "allow-once",
       risk: "low",
       rationale: "safe command",
-    });
+    }));
 
     const result = executeNodeHostCommand(
       createRequest({
@@ -188,31 +168,41 @@ describe("node-host dispatch cancellation", () => {
         signal: controller.signal,
       }),
     );
+    // Observe early fixture failures immediately and drain blocked work before restoring spies.
+    const drained = result.catch(() => undefined);
+    try {
+      await vi.waitFor(() => expect(resolvePolicy).toHaveBeenCalledTimes(2));
+      controller.abort(reason);
+      checkpoint.resolve(policy);
 
-    await vi.waitFor(() => expect(mocks.resolveExecHostApprovalContext).toHaveBeenCalledTimes(2));
-    controller.abort(reason);
-    checkpoint.resolve(policy);
-
-    await expect(result).rejects.toBe(reason);
-    expect(mocks.invokeNodeSystemRunDirect).not.toHaveBeenCalled();
-    expect(
-      mocks.callGatewayTool.mock.calls.some(
-        ([method, , params]) => method === "node.invoke" && params?.command === "system.run",
-      ),
-    ).toBe(false);
-    expect(mocks.registerNodeApproval).toHaveBeenCalledTimes(scenario.autoReview ? 1 : 0);
+      await expect(result).rejects.toBe(reason);
+      expect(
+        callGatewayToolMock.mock.calls.some(
+          ([method, , params]) => method === "node.invoke" && params?.command === "system.run",
+        ),
+      ).toBe(false);
+      expect(
+        callGatewayToolMock.mock.calls.filter(([method]) => method === "exec.approval.request"),
+      ).toHaveLength(scenario.autoReview ? 1 : 0);
+      expect(reviewer).toHaveBeenCalledTimes(scenario.autoReview ? 1 : 0);
+    } finally {
+      controller.abort(reason);
+      checkpoint.resolve(policy);
+      await drained;
+    }
   });
 
   it("forwards cancellation without removing auto-reviewed execution scopes", async () => {
     const controller = new AbortController();
-    mocks.resolveExecHostApprovalContext.mockResolvedValue(createPolicy("allowlist", "on-miss"));
+    resolvePolicy.mockResolvedValue(createPolicy("allowlist", "on-miss"));
+    nodePolicy = { security: "allowlist", ask: "on-miss" };
     const reviewer: ExecAutoReviewer = async () => ({
       decision: "allow-once",
       risk: "low",
       rationale: "safe command",
     });
 
-    await executeNodeHostCommand(
+    const result = await executeNodeHostCommand(
       createRequest({
         security: "allowlist",
         ask: "on-miss",
@@ -222,9 +212,11 @@ describe("node-host dispatch cancellation", () => {
       }),
     );
 
-    expect(mocks.callGatewayTool).toHaveBeenCalledWith(
+    expect(result.details).toMatchObject({ status: "completed", exitCode: 0, aggregated: "ok" });
+    expect(result.content).toEqual([{ type: "text", text: "ok" }]);
+    expect(callGatewayToolMock).toHaveBeenCalledWith(
       "node.invoke",
-      { timeoutMs: 35_000 },
+      { timeoutMs: 40_000 },
       expect.objectContaining({ command: "system.run" }),
       { scopes: ["operator.write", "operator.approvals"], signal: controller.signal },
     );
@@ -232,9 +224,11 @@ describe("node-host dispatch cancellation", () => {
 
   it("forwards cancellation for prepared commands that need no approval", async () => {
     const controller = new AbortController();
-    mocks.resolveExecHostApprovalContext.mockResolvedValue(createPolicy("allowlist", "off"));
+    resolvePolicy.mockResolvedValue(createPolicy("allowlist", "off"));
+    nodePolicy = { security: "allowlist", ask: "off" };
+    nodeAllowlist = [{ pattern: executable }];
 
-    await executeNodeHostCommand(
+    const result = await executeNodeHostCommand(
       createRequest({
         security: "allowlist",
         ask: "off",
@@ -242,12 +236,16 @@ describe("node-host dispatch cancellation", () => {
       }),
     );
 
-    expect(mocks.callGatewayTool).toHaveBeenCalledWith(
+    expect(result.details).toMatchObject({ status: "completed", exitCode: 0, aggregated: "ok" });
+    expect(result.content).toEqual([{ type: "text", text: "ok" }]);
+    expect(callGatewayToolMock).toHaveBeenCalledWith(
       "node.invoke",
-      { timeoutMs: 35_000 },
+      { timeoutMs: 40_000 },
       expect.objectContaining({ command: "system.run" }),
       { signal: controller.signal },
     );
-    expect(mocks.registerNodeApproval).not.toHaveBeenCalled();
+    expect(
+      callGatewayToolMock.mock.calls.filter(([method]) => method === "exec.approval.request"),
+    ).toHaveLength(0);
   });
 });

--- a/src/agents/bash-tools.exec-host-node.integration.test.ts
+++ b/src/agents/bash-tools.exec-host-node.integration.test.ts
@@ -1,0 +1,336 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { setRuntimeConfigSnapshot } from "../config/config.js";
+import { readExecApprovalsSnapshot, saveExecApprovals } from "../infra/exec-approvals.js";
+import { handleInvoke } from "../node-host/invoke.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import { executeNodeHostCommand } from "./bash-tools.exec-host-node.js";
+import type { ExecuteNodeHostCommandParams } from "./bash-tools.exec-host-node.types.js";
+
+const rpc = vi.hoisted(() => vi.fn());
+vi.mock("./tools/gateway.js", () => ({ callGatewayTool: rpc }));
+vi.mock("./tools/nodes-utils.js", () => ({
+  listNodes: async () => [
+    {
+      nodeId: "node-1",
+      connected: true,
+      platform: "darwin",
+      commands: ["system.run", "system.run.prepare"],
+    },
+  ],
+  resolveNodeIdFromList: () => "node-1",
+}));
+
+let state: OpenClawTestState;
+let invokeCount: number;
+let afterPrepare: () => Promise<void>;
+let request: ExecuteNodeHostCommandParams & { workdir: string };
+let resolveDecision: (result: { decision: string }) => void;
+beforeEach(async () => {
+  state = await createOpenClawTestState({ label: "node-exec-policy" });
+  await state.writeConfig({});
+  saveExecApprovals({ version: 1, defaults: { security: "full", ask: "off" } });
+  invokeCount = 0;
+  afterPrepare = async () => {};
+  request = {
+    command: "/usr/bin/printf node-policy-proof",
+    workdir: await fs.realpath(state.root),
+    env: {},
+    sessionKey: "agent:main:node-proof",
+    agentId: "main",
+    security: "full",
+    ask: "off",
+    defaultTimeoutSec: 5,
+    approvalRunningNoticeMs: 1000,
+    warnings: [],
+    turnSourceChannel: "webchat",
+  };
+  const decision = new Promise<{ decision: string }>((resolve) => {
+    resolveDecision = resolve;
+  });
+  rpc.mockReset().mockImplementation(async (method, _options, params) => {
+    if (method === "exec.approvals.node.get") {
+      return readExecApprovalsSnapshot();
+    }
+    if (method === "exec.approval.request") {
+      return { id: params.id, expiresAtMs: Date.now() + 60000 };
+    }
+    if (method === "exec.approval.waitDecision") {
+      return await decision;
+    }
+    if (method !== "node.invoke") {
+      throw new Error(`Unexpected RPC: ${method}`);
+    }
+    if (params.command === "system.run") {
+      invokeCount += 1;
+    }
+    let response:
+      | { ok: boolean; payloadJSON?: string; error?: { code?: string; message?: string } }
+      | undefined;
+    await handleInvoke(
+      {
+        id: "invoke-1",
+        nodeId: "node-1",
+        command: params.command,
+        paramsJSON: JSON.stringify(params.params),
+      },
+      {
+        async request<T>(name: string, value?: unknown): Promise<T> {
+          if (name === "node.invoke.result") {
+            response = value as typeof response;
+          }
+          return {} as T;
+        },
+      },
+      { current: async () => [] },
+    );
+    if (!response?.ok) {
+      throw Object.assign(new Error(response?.error?.message ?? "Node rejected invocation"), {
+        details: { nodeError: response?.error },
+      });
+    }
+    if (params.command === "system.run.prepare") {
+      await afterPrepare();
+    }
+    return { payload: JSON.parse(response.payloadJSON ?? "{}") };
+  });
+});
+afterEach(async () => {
+  await state.cleanup();
+});
+
+it("denies caller allowlist/off misses before dispatch to a permissive node", async () => {
+  await expect(executeNodeHostCommand({ ...request, security: "allowlist" })).rejects.toThrow(
+    "allowlist",
+  );
+  expect(invokeCount).toBe(0);
+});
+
+it.each(["allow-once", "allow-always"])(
+  "keeps node approval %s inside the originating tool lifetime",
+  async (decision) => {
+    let completed = false;
+    const result = executeNodeHostCommand({
+      ...request,
+      ask: "on-miss",
+      security: "allowlist",
+    }).finally(() => {
+      completed = true;
+    });
+    await vi.waitFor(() =>
+      expect(rpc.mock.calls.some(([method]) => method === "exec.approval.waitDecision")).toBe(true),
+    );
+    expect(completed).toBe(false);
+    resolveDecision({ decision });
+    expect((await result).details).toMatchObject({
+      status: "completed",
+      aggregated: "node-policy-proof",
+    });
+    expect(invokeCount).toBe(1);
+  },
+);
+
+it("prompts for target ask=always even when the caller is full/off", async () => {
+  setRuntimeConfigSnapshot({ tools: { exec: { security: "full", ask: "always" } } });
+  const result = executeNodeHostCommand(request);
+  await vi.waitFor(() =>
+    expect(rpc.mock.calls.some(([method]) => method === "exec.approval.waitDecision")).toBe(true),
+  );
+  expect(invokeCount).toBe(0);
+  resolveDecision({ decision: "allow-once" });
+  expect((await result).details.status).toBe("completed");
+});
+
+it("reports target policy denial as not executed", async () => {
+  setRuntimeConfigSnapshot({ tools: { exec: { security: "deny", ask: "off" } } });
+  const { dispatchNodeSystemRun, buildNodeSystemRunInvoke, resolveNodeExecutionTarget } =
+    await import("./bash-tools.exec-host-node-phases.js");
+  const target = await resolveNodeExecutionTarget(request);
+  const result = await dispatchNodeSystemRun({
+    request,
+    target,
+    invoke: buildNodeSystemRunInvoke({
+      target,
+      command: target.argv,
+      rawCommand: request.command,
+      cwd: request.workdir,
+      agentId: request.agentId,
+      sessionKey: request.sessionKey,
+    }),
+  });
+  expect(result.details).toMatchObject({ status: "failed", failureKind: "policy-denied" });
+  expect(result.content).toEqual([
+    expect.objectContaining({
+      text: expect.not.stringMatching(/may have executed|request approval/),
+    }),
+  ]);
+});
+
+it("does not dispatch a late approval after cancellation", async () => {
+  const controller = new AbortController();
+  const execution = executeNodeHostCommand({
+    ...request,
+    security: "allowlist",
+    ask: "on-miss",
+    signal: controller.signal,
+  });
+  const rejected = expect(execution).rejects.toThrow();
+  await vi.waitFor(() =>
+    expect(rpc.mock.calls.some(([method]) => method === "exec.approval.waitDecision")).toBe(true),
+  );
+  controller.abort(new Error("originating turn closed"));
+  resolveDecision({ decision: "allow-once" });
+  await rejected;
+  expect(invokeCount).toBe(0);
+});
+
+it("preserves a target deny introduced while approval was pending", async () => {
+  const execution = executeNodeHostCommand({
+    ...request,
+    security: "allowlist",
+    ask: "on-miss",
+  });
+  await vi.waitFor(() =>
+    expect(rpc.mock.calls.some(([method]) => method === "exec.approval.waitDecision")).toBe(true),
+  );
+  setRuntimeConfigSnapshot({ tools: { exec: { security: "deny", ask: "off" } } });
+  resolveDecision({ decision: "allow-once" });
+  expect((await execution).details).toMatchObject({
+    status: "failed",
+    failureKind: "policy-denied",
+  });
+});
+
+it("executes full/off through a symlink cwd using the prepared canonical directory", async () => {
+  const targetDir = path.join(request.workdir, "target");
+  const otherDir = path.join(request.workdir, "other");
+  const link = path.join(request.workdir, "link");
+  await fs.mkdir(targetDir);
+  await fs.mkdir(otherDir);
+  await fs.symlink(targetDir, link, "dir");
+  afterPrepare = async () => {
+    await fs.unlink(link);
+    await fs.symlink(otherDir, link, "dir");
+  };
+  const result = await executeNodeHostCommand({
+    ...request,
+    command: "/bin/pwd -P",
+    workdir: link,
+  });
+  expect(result.details).toMatchObject({ status: "completed", aggregated: `${targetDir}\n` });
+  expect(rpc.mock.calls.some(([method]) => method === "exec.approval.request")).toBe(false);
+});
+
+it.skipIf(process.platform !== "darwin")(
+  "executes full/off in the actual macOS /tmp alias",
+  async () => {
+    const result = await executeNodeHostCommand({
+      ...request,
+      command: "/bin/pwd -P",
+      workdir: "/tmp",
+    });
+    expect(result.details).toMatchObject({
+      status: "completed",
+      aggregated: `${await fs.realpath("/tmp")}\n`,
+    });
+  },
+);
+
+it("executes full/off inline Node without approval script preflight", async () => {
+  const result = await executeNodeHostCommand({
+    ...request,
+    command: `${JSON.stringify(process.execPath)} -e 'process.stdout.write("inline-proof")'`,
+  });
+  expect(result.details).toMatchObject({ status: "completed", aggregated: "inline-proof" });
+  expect(rpc.mock.calls.some(([method]) => method === "exec.approval.request")).toBe(false);
+});
+
+it("does not bind a full/off script to approval-time contents", async () => {
+  const script = path.join(request.workdir, "script.cjs");
+  await fs.writeFile(script, 'process.stdout.write("before")');
+  afterPrepare = async () => {
+    await fs.writeFile(script, 'process.stdout.write("after")');
+  };
+  const result = await executeNodeHostCommand({
+    ...request,
+    command: `${JSON.stringify(process.execPath)} ${JSON.stringify(script)}`,
+  });
+  expect(result.details).toMatchObject({ status: "completed", aggregated: "after" });
+});
+
+it.each([
+  { runtime: "Node", command: [process.execPath, "-e", 'process.stdout.write("inline")'] },
+  { runtime: "Python", command: ["python3", "-c", 'print("inline")'] },
+])("prepares direct inline $runtime only without approval binding", async ({ command }) => {
+  const params = { command, cwd: request.workdir, security: "full", ask: "off" };
+  const prepare = (ask = "off") =>
+    rpc("node.invoke", {}, { command: "system.run.prepare", params: { ...params, ask } });
+  const result = await prepare();
+  expect(result.payload.plan.argv).toEqual(command);
+  expect(result.payload.plan.mutableFileOperand).toBeUndefined();
+  await expect(prepare("always")).rejects.toThrow("cannot safely bind");
+  setRuntimeConfigSnapshot({ tools: { exec: { security: "full", ask: "always" } } });
+  await expect(prepare()).rejects.toThrow("cannot safely bind");
+  expect(invokeCount).toBe(0);
+});
+
+it.each(["caller", "node", "approvals"] as const)(
+  "keeps approval cwd binding for restrictive %s policy",
+  async (owner) => {
+    const link = path.join(request.workdir, "approval-link");
+    await fs.symlink(request.workdir, link, "dir");
+    if (owner === "node") {
+      setRuntimeConfigSnapshot({ tools: { exec: { security: "full", ask: "always" } } });
+    } else if (owner === "approvals") {
+      saveExecApprovals({ version: 1, defaults: { security: "full", ask: "always" } });
+    }
+    await expect(
+      executeNodeHostCommand({
+        ...request,
+        workdir: link,
+        ...(owner === "caller" ? { ask: "always" as const } : {}),
+      }),
+    ).rejects.toThrow("canonical cwd");
+    expect(invokeCount).toBe(0);
+  },
+);
+
+it.each(["deny", "ask"] as const)(
+  "refuses %s tightening after ordinary preparation",
+  async (policy) => {
+    afterPrepare = async () => {
+      setRuntimeConfigSnapshot({
+        tools: {
+          exec: {
+            security: policy === "deny" ? "deny" : "full",
+            ask: policy === "ask" ? "always" : "off",
+          },
+        },
+      });
+    };
+    const result = await executeNodeHostCommand(request);
+    expect(result.details).toMatchObject({ status: "failed", failureKind: "policy-denied" });
+  },
+);
+
+it("refuses a cwd replaced by a symlink after approval preparation", async () => {
+  const approved = path.join(request.workdir, "approved");
+  const moved = path.join(request.workdir, "moved");
+  await fs.mkdir(approved);
+  const execution = executeNodeHostCommand({ ...request, workdir: approved, ask: "always" });
+  await vi.waitFor(() =>
+    expect(rpc.mock.calls.some(([method]) => method === "exec.approval.waitDecision")).toBe(true),
+  );
+  await fs.rename(approved, moved);
+  await fs.symlink(moved, approved, "dir");
+  resolveDecision({ decision: "allow-once" });
+  const result = await execution;
+  expect(result.details).toMatchObject({ status: "failed", failureKind: "policy-denied" });
+  expect(result.content).toEqual([
+    expect.objectContaining({ text: expect.stringContaining("canonical cwd") }),
+  ]);
+});

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -522,20 +522,6 @@ type GatewayToolCall = {
   callOptions?: unknown;
 };
 
-function requireGatewayCall(index: number): GatewayToolCall {
-  const call = callGatewayToolMock.mock.calls[index];
-  if (!call) {
-    throw new Error(`expected gateway call at index ${index}`);
-  }
-  const [method, options, params, callOptions] = call as [
-    string,
-    { timeoutMs?: number },
-    MockNodeInvokeParams | undefined,
-    unknown,
-  ];
-  return { method, options, params, callOptions };
-}
-
 function requireGatewayCommand(command: string): GatewayToolCall {
   const call = callGatewayToolMock.mock.calls.find(
     ([method, , params]) =>
@@ -768,7 +754,7 @@ describe("executeNodeHostCommand", () => {
       },
     });
     requiresExecApprovalMock.mockReset();
-    requiresExecApprovalMock.mockReturnValue(true);
+    usePolicyApprovalRequirementMock();
     resolveAllowAlwaysPersistenceDecisionMock.mockReset();
     resolveAllowAlwaysPersistenceDecisionMock.mockReturnValue({
       kind: "patterns",
@@ -825,57 +811,6 @@ describe("executeNodeHostCommand", () => {
     detectInterpreterInlineEvalArgvMock.mockReset();
     detectInterpreterInlineEvalArgvMock.mockReturnValue(null);
     registerExecApprovalRequestForHostOrThrowMock.mockReset();
-  });
-
-  it("returns outcome-unknown for an ambiguous direct node timeout", async () => {
-    callGatewayToolMock.mockRejectedValueOnce(
-      createNodeInvokeFailure({
-        code: "TIMEOUT",
-        nodeCommandDispatched: true,
-        message: "node invoke timed out",
-      }),
-    );
-
-    const result = await executeNodeHostCommand(createNodeHostRequest());
-
-    expect(result.details).toMatchObject({
-      status: "failed",
-      failureKind: "outcome-unknown",
-      reason: "outcome-unknown",
-      nodeInvokeFailure: {
-        failureCode: "TIMEOUT",
-        message: "node invoke timed out",
-        nodeCommandDispatched: true,
-      },
-    });
-    expect(result.content).toEqual([
-      expect.objectContaining({
-        type: "text",
-        text: expect.stringContaining(
-          "The command may have executed. Do not rerun it automatically.",
-        ),
-      }),
-    ]);
-    expect(callGatewayToolMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("returns outcome-unknown for a malformed direct node response", async () => {
-    callGatewayToolMock.mockResolvedValueOnce({ payload: { stdout: "partial" } });
-
-    const result = await executeNodeHostCommand(createNodeHostRequest());
-
-    expect(result.details).toMatchObject({
-      status: "failed",
-      reason: "outcome-unknown",
-      nodeInvokeFailure: {
-        message: "malformed node invoke response",
-      },
-    });
-    expect(result.content).toEqual([
-      expect.objectContaining({
-        text: expect.stringContaining("The command may have executed."),
-      }),
-    ]);
   });
 
   it("returns outcome-unknown after an inline auto-approved node disconnect", async () => {
@@ -1312,7 +1247,7 @@ describe("executeNodeHostCommand", () => {
     }
   });
 
-  it("forwards prepared systemRunPlan on async node invoke after approval", async () => {
+  it("forwards prepared systemRunPlan within the native turn after approval", async () => {
     resolveExecHostApprovalContextMock.mockReturnValue({
       approvals: { allowlist: [], file: { version: 1, agents: {} } },
       hostSecurity: "full",
@@ -1330,7 +1265,7 @@ describe("executeNodeHostCommand", () => {
       }),
     );
 
-    expect(result.details?.status).toBe("approval-pending");
+    expect(result.details?.status).toBe("completed");
     expect(requireRegisteredApprovalRequest()).toMatchObject({
       systemRunPlan: preparedPlan,
       toolCallId: "tool-node",
@@ -1340,7 +1275,7 @@ describe("executeNodeHostCommand", () => {
       expect(callGatewayToolMock).toHaveBeenCalledTimes(3);
     });
 
-    const call = requireGatewayCall(2);
+    const call = requireGatewayCommand("system.run");
     expect(call.options.timeoutMs).toBe(40_000);
     expect(call.params?.timeoutMs).toBe(35_000);
     expect(call.callOptions).toEqual({ scopes: ["operator.write", "operator.approvals"] });
@@ -2648,59 +2583,63 @@ describe("executeNodeHostCommand", () => {
       nodeSecurity: "deny",
       nodeAsk: "off",
     },
-  ] as const)(
-    "requests human approval when node policy has $name floor",
-    async ({ nodeSecurity, nodeAsk }) => {
-      const autoReviewer = vi.fn<ExecAutoReviewer>(async () => ({
-        decision: "allow-once",
-        risk: "low",
-        rationale: "test reviewer would allow it",
-      }));
-      resolveExecHostApprovalContextMock.mockReturnValue({
-        approvals: { allowlist: [], file: { version: 1, agents: {} } },
-        hostSecurity: "allowlist",
-        hostAsk: "on-miss",
+  ] as const)("preserves node policy with a $name floor", async ({ nodeSecurity, nodeAsk }) => {
+    const autoReviewer = vi.fn<ExecAutoReviewer>(async () => ({
+      decision: "allow-once",
+      risk: "low",
+      rationale: "test reviewer would allow it",
+    }));
+    resolveExecHostApprovalContextMock.mockReturnValue({
+      approvals: { allowlist: [], file: { version: 1, agents: {} } },
+      hostSecurity: "allowlist",
+      hostAsk: "on-miss",
+      askFallback: "deny",
+    });
+    parsePreparedSystemRunPayloadMock.mockReturnValue({
+      plan: preparedPlan,
+      execPolicy: { security: nodeSecurity, ask: nodeAsk },
+    });
+    resolveExecApprovalsFromFileMock.mockReturnValue({
+      allowlist: [],
+      file: { version: 1, agents: {} },
+      agent: {
+        security: nodeSecurity,
+        ask: nodeAsk,
         askFallback: "deny",
-      });
-      parsePreparedSystemRunPayloadMock.mockReturnValue({
-        plan: preparedPlan,
+        autoAllowSkills: false,
+      },
+    });
+    callGatewayToolMock.mockImplementation(
+      createNodeGatewayHandler({
+        approvals: { version: 1, agents: {} },
+        allowApprovalResolve: true,
         execPolicy: { security: nodeSecurity, ask: nodeAsk },
-      });
-      resolveExecApprovalsFromFileMock.mockReturnValue({
-        allowlist: [],
-        file: { version: 1, agents: {} },
-        agent: {
-          security: nodeSecurity,
-          ask: nodeAsk,
-          askFallback: "deny",
-          autoAllowSkills: false,
-        },
-      });
-      callGatewayToolMock.mockImplementation(
-        createNodeGatewayHandler({
-          approvals: { version: 1, agents: {} },
-          allowApprovalResolve: true,
-          execPolicy: { security: nodeSecurity, ask: nodeAsk },
-        }),
-      );
+      }),
+    );
 
-      const result = await executeNodeHostCommand(
-        createNodeHostRequest({
-          security: "allowlist",
-          ask: "on-miss",
-          autoReview: true,
-          autoReviewer,
-        }),
-      );
+    const execution = executeNodeHostCommand(
+      createNodeHostRequest({
+        security: "allowlist",
+        ask: "on-miss",
+        autoReview: true,
+        autoReviewer,
+      }),
+    );
 
-      expect(result.details?.status).toBe("approval-pending");
+    if (nodeSecurity === "deny") {
+      await expect(execution).rejects.toThrow("security=deny");
       expect(autoReviewer).not.toHaveBeenCalled();
-      expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalledTimes(1);
-      expect(
-        callGatewayToolMock.mock.calls.some(([method]) => method === "exec.approval.resolve"),
-      ).toBe(false);
-    },
-  );
+      expect(createAndRegisterDefaultExecApprovalRequestMock).not.toHaveBeenCalled();
+      return;
+    }
+    const result = await execution;
+    expect(result.details?.status).toBe("approval-pending");
+    expect(autoReviewer).not.toHaveBeenCalled();
+    expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalledTimes(1);
+    expect(
+      callGatewayToolMock.mock.calls.some(([method]) => method === "exec.approval.resolve"),
+    ).toBe(false);
+  });
 
   it("requests human approval when node approval policy is unavailable", async () => {
     const autoReviewer = vi.fn<ExecAutoReviewer>(async () => ({
@@ -3838,33 +3777,35 @@ describe("executeNodeHostCommand", () => {
     expect(evalEnvs.every((env) => env != null && env.FOO === "bar" && env.PATH === "")).toBe(true);
   });
 
-  it("skips approval prepare in full/off mode", async () => {
+  it("prepares target policy even in full/off mode", async () => {
     await executeNodeHostCommand(
       createNodeHostRequest({
         notifyOnExit: false,
       }),
     );
 
-    expect(callGatewayToolMock).toHaveBeenCalledTimes(1);
-    const call = requireGatewayCall(0);
+    expect(callGatewayToolMock).toHaveBeenCalledTimes(2);
+    const call = requireGatewayCommand("system.run");
     expect(call.options.timeoutMs).toBe(40_000);
     expect(call.params?.timeoutMs).toBe(35_000);
     const runParams = requireRunParams(call);
-    expect(runParams.command).toEqual(["/bin/sh", "-lc", "bun ./script.ts"]);
+    expect(runParams.command).toEqual(preparedPlan.argv);
     expect(runParams.rawCommand).toBe("bun ./script.ts");
     expect(runParams.cwd).toBe("/tmp/work");
     expect(typeof runParams.runId).toBe("string");
     expect(runParams.suppressNotifyOnExit).toBe(true);
     expect(runParams.timeoutMs).toBe(30_000);
-    expect(Object.hasOwn(runParams, "systemRunPlan")).toBe(false);
+    expect(runParams.systemRunPlan).toEqual(preparedPlan);
   });
 
   it("bypasses host approval floors for an explicit full session", async () => {
     await executeNodeHostCommand(createNodeHostRequest({ bypassHostApprovalFloors: true }));
 
     expect(resolveExecHostApprovalContextMock).not.toHaveBeenCalled();
-    expect(callGatewayToolMock).toHaveBeenCalledTimes(1);
-    expect(Object.hasOwn(requireRunParams(requireGatewayCall(0)), "systemRunPlan")).toBe(false);
+    expect(callGatewayToolMock).toHaveBeenCalledTimes(2);
+    expect(requireRunParams(requireGatewayCommand("system.run")).systemRunPlan).toEqual(
+      preparedPlan,
+    );
   });
 
   it("does not dispatch a direct full/off command after gateway policy revocation", async () => {
@@ -3893,15 +3834,15 @@ describe("executeNodeHostCommand", () => {
     ).toBe(false);
   });
 
-  it("omits cwd from direct node system.run when workdir is undefined", async () => {
+  it("uses the prepared cwd when no workdir was requested", async () => {
     await executeNodeHostCommand(
       createNodeHostRequest({
         workdir: undefined,
       }),
     );
 
-    const runParams = requireRunParams(requireGatewayCall(0));
-    expect(Object.hasOwn(runParams, "cwd")).toBe(false);
+    const runParams = requireRunParams(requireGatewayCommand("system.run"));
+    expect(runParams.cwd).toBe(preparedPlan.cwd);
   });
 
   it("rejects disconnected node targets before invoking system.run", async () => {
@@ -3929,7 +3870,7 @@ describe("executeNodeHostCommand", () => {
   });
 
   it("returns a non-empty placeholder for silent node exec results", async () => {
-    callGatewayToolMock.mockImplementationOnce(
+    callGatewayToolMock.mockImplementation(
       async (method: string, _options: unknown, params: MockNodeInvokeParams | undefined) => {
         if (method === "node.invoke" && params?.command === "system.run") {
           return {
@@ -3942,7 +3883,11 @@ describe("executeNodeHostCommand", () => {
             },
           };
         }
-        throw new Error(`unexpected node invoke command: ${String(params?.command)}`);
+        return createNodeGatewayHandler({ approvals: { version: 1, agents: {} } })(
+          method,
+          _options,
+          params,
+        );
       },
     );
 
@@ -4073,7 +4018,7 @@ describe("executeNodeHostCommand", () => {
       {
         nodeId: "f2396b588d391d30a79d300e196a17cf197f34969b5e2485d2734c953567f44e",
         displayName: "home-wsl-debian",
-        commands: ["system.run"],
+        commands: ["system.run", "system.run.prepare"],
         platform: process.platform,
       },
     ]);
@@ -4094,7 +4039,7 @@ describe("executeNodeHostCommand", () => {
       {
         nodeId: "f2396b588d391d30a79d300e196a17cf197f34969b5e2485d2734c953567f44e",
         displayName: "home-wsl-debian",
-        commands: ["system.run"],
+        commands: ["system.run", "system.run.prepare"],
         platform: process.platform,
       },
     ]);
@@ -4115,13 +4060,13 @@ describe("executeNodeHostCommand", () => {
       {
         nodeId: "f2396b588d391d30a79d300e196a17cf197f34969b5e2485d2734c953567f44e",
         displayName: "home-wsl-debian",
-        commands: ["system.run"],
+        commands: ["system.run", "system.run.prepare"],
         platform: process.platform,
       },
       {
         nodeId: "aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaa7777bbb88889999",
         displayName: "other-node",
-        commands: ["system.run"],
+        commands: ["system.run", "system.run.prepare"],
         platform: process.platform,
       },
     ]);
@@ -4143,7 +4088,7 @@ describe("executeNodeHostCommand", () => {
       {
         nodeId: "f2396b588d391d30a79d300e196a17cf197f34969b5e2485d2734c953567f44e",
         displayName: "home-wsl-debian",
-        commands: ["system.run"],
+        commands: ["system.run", "system.run.prepare"],
         platform: process.platform,
       },
     ]);
@@ -4166,7 +4111,7 @@ describe("executeNodeHostCommand", () => {
       {
         nodeId: "f2396b588d391d30a79d300e196a17cf197f34969b5e2485d2734c953567f44e",
         displayName: "home-wsl-debian",
-        commands: ["system.run"],
+        commands: ["system.run", "system.run.prepare"],
         platform: process.platform,
       },
     ]);

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -25,19 +25,17 @@ import {
   isExecApprovalRunAbortedError,
   registerExecApprovalRequestForHostOrThrow,
 } from "./bash-tools.exec-approval-request.js";
+import { shouldAwaitExecApprovalInline } from "./bash-tools.exec-approval-wait.js";
 import {
   formatNodeInvokeFailureFollowup,
-  formatNodeInvokeFailureToolResult,
   invokeNodeSystemRun,
 } from "./bash-tools.exec-host-node-failure.js";
 import {
   analyzeNodeApprovalRequirement,
   buildNodeSystemRunInvoke,
-  formatNodeRunToolResult,
-  invokeNodeSystemRunDirect,
+  dispatchNodeSystemRun,
   prepareNodeSystemRun,
   resolveNodeExecutionTarget,
-  shouldSkipNodeApprovalPrepare,
 } from "./bash-tools.exec-host-node-phases.js";
 import type { ExecuteNodeHostCommandParams } from "./bash-tools.exec-host-node.types.js";
 import * as execHostShared from "./bash-tools.exec-host-shared.js";
@@ -67,6 +65,9 @@ async function assertCurrentNodeGatewayPolicyAllowsDispatch(params: {
   currentPolicyAllows?: (policy: { hostSecurity: ExecSecurity; hostAsk: ExecAsk }) => boolean;
   fallbackPolicy?: NodeGatewayPolicyCheckpoint;
 }): Promise<void> {
+  if (params.request.bypassHostApprovalFloors) {
+    return;
+  }
   const current = await execHostShared.resolveExecHostApprovalContext({
     agentId: params.request.agentId,
     security: params.request.security,
@@ -113,38 +114,19 @@ export async function executeNodeHostCommand(
 ): Promise<AgentToolResult<ExecToolDetails>> {
   const target = await resolveNodeExecutionTarget(params);
   params.signal?.throwIfAborted();
-  if (params.bypassHostApprovalFloors) {
-    return await invokeNodeSystemRunDirect({ request: params, target });
-  }
-  const { hostSecurity, hostAsk, askFallback } =
-    await execHostShared.resolveExecHostApprovalContext({
-      agentId: params.agentId,
-      security: params.security,
-      ask: params.ask,
-      host: "node",
-    });
-  if (
-    shouldSkipNodeApprovalPrepare({
-      hostSecurity,
-      hostAsk,
-      strictInlineEval: params.strictInlineEval,
-    })
-  ) {
-    await assertCurrentNodeGatewayPolicyAllowsDispatch({
-      request: params,
-      authority: "current-policy",
-      currentPolicyAllows: (current) =>
-        shouldSkipNodeApprovalPrepare({
-          hostSecurity: current.hostSecurity,
-          hostAsk: current.hostAsk,
-          strictInlineEval: params.strictInlineEval,
-        }),
-    });
-    params.signal?.throwIfAborted();
-    return await invokeNodeSystemRunDirect({ request: params, target });
-  }
+  const { hostSecurity, hostAsk, askFallback } = params.bypassHostApprovalFloors
+    ? { hostSecurity: params.security, hostAsk: params.ask, askFallback: "deny" as const }
+    : await execHostShared.resolveExecHostApprovalContext({
+        agentId: params.agentId,
+        security: params.security,
+        ask: params.ask,
+        host: "node",
+      });
 
-  const prepared = await prepareNodeSystemRun({ request: params, target });
+  const prepared = await prepareNodeSystemRun({
+    request: { ...params, security: hostSecurity, ask: hostAsk },
+    target,
+  });
   const approvalAnalysis = await analyzeNodeApprovalRequirement({
     request: params,
     target,
@@ -177,16 +159,29 @@ export async function executeNodeHostCommand(
   });
   const unavailableDecisionRequestParams =
     unavailableDecisions.length > 0 ? { unavailableDecisions } : {};
+  const effectiveSecurity =
+    nodeSecurity === undefined ? hostSecurity : minSecurity(hostSecurity, nodeSecurity);
+  const effectiveAsk = nodeAsk === undefined ? hostAsk : maxAsk(hostAsk, nodeAsk);
+  if (effectiveSecurity === "deny") {
+    throw new Error("exec denied: host=node security=deny");
+  }
   const requiresAsk =
     requiresExecApproval({
-      ask: hostAsk,
-      security: hostSecurity,
+      ask: effectiveAsk,
+      security: effectiveSecurity,
       analysisOk,
       allowlistSatisfied,
       durableApprovalSatisfied,
     }) ||
     inlineEvalHit !== null ||
     requiresSecurityAuditSuppressionApproval;
+  if (
+    !requiresAsk &&
+    effectiveSecurity === "allowlist" &&
+    !(durableApprovalSatisfied || (analysisOk && allowlistSatisfied))
+  ) {
+    throw new Error("exec denied: host=node allowlist miss (ask=off)");
+  }
   if (requiresAsk && params.nonInteractiveApproval) {
     const text = `Exec denied (approval_required): ${params.command}`;
     return {
@@ -447,6 +442,40 @@ export async function executeNodeHostCommand(
         inlineFallbackPolicy = currentFallback;
         inlineApprovalDecision = null;
         inlineApprovalId = approvalId;
+      } else if (unavailableReason === null && shouldAwaitExecApprovalInline(params)) {
+        // Keep the admitted turn alive while its approval is pending. Returning
+        // approval-pending here closes the authority before the operator can act.
+        const outcome = await execHostShared.resolveExecApprovalWaitOutcome({
+          approvalId,
+          preResolvedDecision,
+          signal: params.signal,
+          askFallback,
+          resolveTimedOut: async () => {
+            const fallback = await resolveCurrentTimeoutFallback();
+            return { ...fallback, context: fallback };
+          },
+          requiresExplicitApproval: (fallback) =>
+            fallback?.requiresExplicitApproval ?? inlineEvalHit !== null,
+          requiresAutoReviewHumanApproval: autoReviewRequiresHumanApproval,
+        });
+        params.signal?.throwIfAborted();
+        if (outcome.kind !== "resolved") {
+          throw new Error(`exec denied: ${outcome.kind}`);
+        }
+        if (outcome.state.deniedReason || !outcome.state.approvedByAsk) {
+          throw new Error(`exec denied: ${outcome.state.deniedReason ?? "approval-required"}`);
+        }
+        inlineApprovedByAsk = true;
+        inlineApprovalId = approvalId;
+        inlineApprovalDecision =
+          outcome.decision === "allow-always" && inlineEvalHit === null
+            ? "allow-always"
+            : outcome.decision === "allow-once" || outcome.decision === "allow-always"
+              ? "allow-once"
+              : null;
+        inlineApprovalSource = outcome.decision === null ? "ask-fallback" : undefined;
+        inlineDispatchAuthority = inlineApprovalSource ?? "human-approval";
+        inlineFallbackPolicy = outcome.state.timeoutContext;
       } else {
         const followupTarget = execHostShared.buildExecApprovalFollowupTarget({
           approvalId,
@@ -633,7 +662,6 @@ export async function executeNodeHostCommand(
     }
   }
 
-  const startedAt = Date.now();
   params.signal?.throwIfAborted();
   const invoke = buildNodeSystemRunInvoke({
     target,
@@ -642,6 +670,10 @@ export async function executeNodeHostCommand(
     cwd: prepared.cwd,
     agentId: prepared.agentId,
     sessionKey: prepared.sessionKey,
+    turnSourceChannel: params.turnSourceChannel,
+    turnSourceTo: params.turnSourceTo,
+    turnSourceAccountId: params.turnSourceAccountId,
+    turnSourceThreadId: params.turnSourceThreadId,
     approved: inlineApprovalSource ? undefined : inlineApprovedByAsk,
     approvalDecision: inlineApprovalSource ? null : inlineApprovalDecision,
     approvalSource: inlineApprovalSource,
@@ -661,32 +693,19 @@ export async function executeNodeHostCommand(
         allowlistSatisfied,
         durableApprovalSatisfied,
       }) &&
+      (current.hostSecurity !== "allowlist" ||
+        durableApprovalSatisfied ||
+        (analysisOk && allowlistSatisfied)) &&
       inlineEvalHit === null &&
       !requiresSecurityAuditSuppressionApproval,
   });
   params.signal?.throwIfAborted();
-  const invocation = await invokeNodeSystemRun({
-    invokeWaitMs: target.invokeWaitMs,
+  return dispatchNodeSystemRun({
+    request: params,
+    target,
     invoke,
-    signal: params.signal,
     ...((inlineApprovedByAsk || inlineApprovalSource) && inlineApprovalId
       ? { scopes: APPROVED_NODE_INVOKE_SCOPES }
       : {}),
-  });
-  if (!invocation.ok) {
-    return formatNodeInvokeFailureToolResult({
-      failure: invocation.failure,
-      nodeId: target.nodeId,
-      command: params.command,
-      startedAt,
-      cwd: params.workdir,
-      warnings: [...params.warnings, ...(params.foregroundWarnings ?? [])],
-    });
-  }
-  return formatNodeRunToolResult({
-    raw: invocation.raw,
-    startedAt,
-    cwd: params.workdir,
-    warnings: [...params.warnings, ...(params.foregroundWarnings ?? [])],
   });
 }

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -159,7 +159,7 @@ export type ExecToolDetails = {
       exitCode: number | null;
       exitSignal?: NodeJS.Signals | number | null;
       failureKind?: string;
-      reason?: "not-dispatched" | "outcome-unknown";
+      reason?: "not-dispatched" | "outcome-unknown" | "policy-denied";
       nodeInvokeFailure?: {
         failureCode?: string;
         message: string;

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -719,6 +719,9 @@ describe("exec approvals", () => {
     vi.mocked(callGatewayTool).mockImplementation(async (method, _opts, params) => {
       if (method === "node.invoke") {
         const invoke = params as { command?: string };
+        if (invoke.command === "system.run.prepare") {
+          return buildPreparedSystemRunPayload(params);
+        }
         if (invoke.command === "system.run") {
           return { payload: { success: true, stdout: "node-ok" } };
         }

--- a/src/agents/harness/host-capability.test.ts
+++ b/src/agents/harness/host-capability.test.ts
@@ -4,14 +4,23 @@ import path from "node:path";
 import { Type } from "typebox";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
+import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
 import type { GatewayRequestContext } from "../../gateway/server-methods/types.js";
 import {
   resetAgentRunRegistryForTest,
   rotateAgentRunRegistryLifecycleGeneration,
   validateAgentRunDelegatedAuthority,
 } from "../../infra/agent-run-registry.js";
+import { createPluginRecord } from "../../plugins/loader-records.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import {
+  getActivePluginRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "../../plugins/runtime.js";
 import {
   bindGatewayContextResolver,
+  getPluginRuntimeGatewayRequestScope,
   withPluginRuntimeGatewayRequestScope,
 } from "../../plugins/runtime/gateway-request-scope.js";
 import {
@@ -130,6 +139,151 @@ describe("agent harness host capability", () => {
     mockRewrap.mockClear();
     mockRunBefore.mockClear();
     mockCallGatewayTool.mockReset();
+  });
+
+  it("binds Full node invocation to the exact live admission, session and placement", async () => {
+    const previousRegistry = getActivePluginRegistry();
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "host-full-node-"));
+    const sessionTarget = {
+      agentId: "main",
+      sessionKey: "agent:main:session-1",
+      sessionId: "session-1",
+      storePath: path.join(root, "sessions.json"),
+    };
+    try {
+      for (const change of [
+        "none",
+        "ordinary",
+        "close",
+        "admission",
+        "restart",
+        "permission",
+        "session",
+        "placement",
+        "gateway",
+        "plugin",
+        "plugin-reload",
+      ] as const) {
+        await upsertSessionEntryCore(sessionTarget, {
+          sessionId: "session-1",
+          updatedAt: Date.now(),
+          permissionMode: "full",
+        });
+        const { attempt, admission } = await admittedAttempt(`run-${change}`, {
+          permissionMode: change === "ordinary" ? "workspace" : "full",
+          sessionTarget,
+        });
+        let placementActive = true;
+        const registry = createEmptyPluginRegistry();
+        registry.plugins.push(
+          createPluginRecord({
+            id: "fixture",
+            source: "fixture",
+            origin: "bundled",
+            enabled: true,
+            configSchema: true,
+          }),
+        );
+        setActivePluginRegistry(registry);
+        const context = {} as GatewayRequestContext;
+        const assertPlacementCurrent = vi.fn(() => {
+          if (!placementActive) {
+            throw new Error("placement no longer current");
+          }
+        });
+        let currentContext = context;
+        bindGatewayContextResolver(attempt.admittedRunContext, () => currentContext);
+        const host = createAgentHarnessHostCapabilities({ attempt, pluginId: "fixture" });
+        const dispatched = vi.fn(async () => "launched");
+        await withPluginRuntimeGatewayRequestScope(
+          { isWebchatConnect: () => false, assertNodeExecutionCurrent: assertPlacementCurrent },
+          () =>
+            host.runWithScope(async () => {
+              const invoke = getPluginRuntimeGatewayRequestScope()?.invokeWithSessionNodeAuthority;
+              expect(invoke).toBeTypeOf("function");
+              const ready = createDeferred();
+              const release = createDeferred();
+              const result = invoke!(
+                {
+                  source: "session-full",
+                  pluginId: change === "plugin" ? "other" : "fixture",
+                  nodeId: "node-1",
+                  workspace: {
+                    workspaceDir: "/node/workspace",
+                    sessionKey: sessionTarget.sessionKey,
+                    sessionId: "session-1",
+                    environmentId: "environment-1",
+                    ownerEpoch: 2,
+                  },
+                },
+                async (assertCurrent) => {
+                  ready.resolve();
+                  await release.promise;
+                  assertCurrent();
+                  return await dispatched();
+                },
+              );
+              void result.catch(() => {});
+              if (change === "ordinary") {
+                await expect(result).resolves.toBeUndefined();
+                expect(dispatched).not.toHaveBeenCalled();
+                return;
+              }
+              if (change === "plugin") {
+                await expect(result).rejects.toThrow("no longer current");
+                expect(dispatched).not.toHaveBeenCalled();
+                return;
+              }
+              await ready.promise;
+              switch (change) {
+                case "close":
+                  host.close();
+                  break;
+                case "admission":
+                  admission.close();
+                  break;
+                case "restart":
+                  rotateAgentRunRegistryLifecycleGeneration();
+                  break;
+                case "permission":
+                  await upsertSessionEntryCore(sessionTarget, { permissionMode: "workspace" });
+                  break;
+                case "session":
+                  await upsertSessionEntryCore(sessionTarget, { sessionId: "replacement" });
+                  break;
+                case "placement":
+                  placementActive = false;
+                  break;
+                case "gateway":
+                  currentContext = {} as GatewayRequestContext;
+                  break;
+                case "plugin-reload":
+                  setActivePluginRegistry(createEmptyPluginRegistry());
+                  break;
+                case "none":
+                  break;
+              }
+              release.resolve();
+              if (change === "none") {
+                await expect(result).resolves.toBe("launched");
+                expect(dispatched).toHaveBeenCalledOnce();
+              } else {
+                await expect(result).rejects.toThrow(/no longer (active|current)/);
+                expect(dispatched).not.toHaveBeenCalled();
+              }
+            }),
+        );
+        host.close();
+        admission.close();
+      }
+    } finally {
+      if (previousRegistry) {
+        setActivePluginRegistry(previousRegistry);
+      } else {
+        resetPluginRuntimeStateForTest();
+      }
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("overwrites plugin policy fields with the host snapshot and revokes lexically", async () => {

--- a/src/agents/harness/host-capability.test.ts
+++ b/src/agents/harness/host-capability.test.ts
@@ -193,7 +193,11 @@ describe("agent harness host capability", () => {
         });
         let currentContext = context;
         bindGatewayContextResolver(attempt.admittedRunContext, () => currentContext);
-        const host = createAgentHarnessHostCapabilities({ attempt, pluginId: "fixture" });
+        const host = createAgentHarnessHostCapabilities({
+          attempt,
+          pluginId: "fixture",
+          requiredNodeCommands: ["fixture.exec"],
+        });
         const dispatched = vi.fn(async () => "launched");
         await withPluginRuntimeGatewayRequestScope(
           { isWebchatConnect: () => false, assertNodeExecutionCurrent: assertPlacementCurrent },
@@ -206,6 +210,7 @@ describe("agent harness host capability", () => {
               const result = invoke!(
                 {
                   source: "session-full",
+                  command: "fixture.exec",
                   pluginId: change === "plugin" ? "other" : "fixture",
                   nodeId: "node-1",
                   workspace: {

--- a/src/agents/harness/host-capability.ts
+++ b/src/agents/harness/host-capability.ts
@@ -162,12 +162,16 @@ function createBoundCallerIdentity(params: AgentHarnessHostAttempt, receiptAutho
 export function createAgentHarnessHostCapabilities(params: {
   attempt: AgentHarnessHostAttempt;
   pluginId: string;
+  requiredNodeCommands?: readonly string[];
 }): {
   capabilities: AgentHarnessHostCapabilities;
   close: () => void;
   runWithScope: <T>(run: () => Promise<T>) => Promise<T>;
 } {
   const attempt = params.attempt;
+  // Capture the selected harness declaration before plugin code can mutate it.
+  // Full must not cover other commands merely because the same plugin owns them.
+  const requiredNodeCommands = new Set(params.requiredNodeCommands);
   const operationalRunInstance = attempt.admittedRunContext.operationalRunInstance;
   const delegatedAuthority = getAdmittedRunDelegatedAuthority(attempt.admittedRunContext);
   if (!delegatedAuthority) {
@@ -443,6 +447,7 @@ export function createAgentHarnessHostCapabilities(params: {
           invokeWithSessionNodeAuthority: createSessionNodeInvocation(
             attempt,
             params.pluginId,
+            requiredNodeCommands,
             assertActive,
             attempt.abortSignal
               ? AbortSignal.any([attempt.abortSignal, capabilityAbortController.signal])

--- a/src/agents/harness/host-capability.ts
+++ b/src/agents/harness/host-capability.ts
@@ -2,6 +2,10 @@ import path from "node:path";
 import { getActiveDiagnosticTraceContext } from "../../infra/diagnostic-trace-context.js";
 import { prepareSystemRunMutableFileApproval } from "../../infra/system-run-approval-binding.js";
 import { buildAgentHookContextChannelFields } from "../../plugins/hook-agent-context.js";
+import {
+  getPluginRuntimeGatewayRequestScope,
+  withPluginRuntimeGatewayRequestScope,
+} from "../../plugins/runtime/gateway-request-scope.js";
 import { getActiveSecretsRuntimeConfigSnapshot } from "../../secrets/runtime-state.js";
 import {
   getAdmittedRunDelegatedAuthority,
@@ -31,6 +35,7 @@ import {
 } from "../tools/gateway-caller-context.js";
 import { callGatewayTool } from "../tools/gateway.js";
 import type { AgentHarnessHostCapabilities } from "./host-capability-types.js";
+import { createSessionNodeInvocation } from "./node-execution-authority.js";
 
 type AgentHarnessHostAttempt = Partial<EmbeddedRunAttemptParams> &
   Pick<EmbeddedRunAttemptParams, "admittedRunContext" | "runId">;
@@ -157,7 +162,11 @@ function createBoundCallerIdentity(params: AgentHarnessHostAttempt, receiptAutho
 export function createAgentHarnessHostCapabilities(params: {
   attempt: AgentHarnessHostAttempt;
   pluginId: string;
-}): { capabilities: AgentHarnessHostCapabilities; close: () => void } {
+}): {
+  capabilities: AgentHarnessHostCapabilities;
+  close: () => void;
+  runWithScope: <T>(run: () => Promise<T>) => Promise<T>;
+} {
   const attempt = params.attempt;
   const operationalRunInstance = attempt.admittedRunContext.operationalRunInstance;
   const delegatedAuthority = getAdmittedRunDelegatedAuthority(attempt.admittedRunContext);
@@ -426,6 +435,22 @@ export function createAgentHarnessHostCapabilities(params: {
   });
   return {
     capabilities,
+    runWithScope: (run) =>
+      withPluginRuntimeGatewayRequestScope(
+        {
+          isWebchatConnect: () => false,
+          ...getPluginRuntimeGatewayRequestScope(),
+          invokeWithSessionNodeAuthority: createSessionNodeInvocation(
+            attempt,
+            params.pluginId,
+            assertActive,
+            attempt.abortSignal
+              ? AbortSignal.any([attempt.abortSignal, capabilityAbortController.signal])
+              : capabilityAbortController.signal,
+          ),
+        },
+        run,
+      ),
     close: () => {
       if (!active) {
         return;

--- a/src/agents/harness/node-execution-authority.ts
+++ b/src/agents/harness/node-execution-authority.ts
@@ -1,0 +1,84 @@
+import { loadSessionEntryReadOnly } from "../../config/sessions/session-accessor.js";
+import { capturePluginLifecycleAuthority } from "../../plugins/registry-lifecycle.js";
+import { getActivePluginRegistry } from "../../plugins/runtime.js";
+import {
+  getGatewayContextResolver,
+  getPluginRuntimeGatewayRequestScope,
+} from "../../plugins/runtime/gateway-request-scope.js";
+import type { EmbeddedRunAttemptParams } from "../embedded-agent-runner/run/types.js";
+
+type HostAttempt = Partial<EmbeddedRunAttemptParams> &
+  Pick<EmbeddedRunAttemptParams, "admittedRunContext" | "runId">;
+type SessionNodeInvocation = NonNullable<
+  NonNullable<
+    ReturnType<typeof getPluginRuntimeGatewayRequestScope>
+  >["invokeWithSessionNodeAuthority"]
+>;
+
+/** Full is admitted host authority, narrowed to one placement claim, never a request flag. */
+export function createSessionNodeInvocation(
+  attempt: HostAttempt,
+  pluginId: string,
+  assertActive: () => void,
+  signal: AbortSignal,
+): SessionNodeInvocation | undefined {
+  const admittedFull = attempt.permissionMode === "full";
+  const resolveContext = getGatewayContextResolver(attempt.admittedRunContext);
+  const context = resolveContext?.();
+  const target = attempt.sessionTarget;
+  const gatewayRegistry = getActivePluginRegistry();
+  const registry = getPluginRuntimeGatewayRequestScope()?.pluginRegistry ?? gatewayRegistry;
+  // Prepared runs can own a separate registry; both it and the Gateway policy owner must stay live.
+  const pluginOwners = [gatewayRegistry, registry].map((owner) => {
+    const record = owner?.plugins.find((candidate) => candidate.id === pluginId);
+    return owner && record
+      ? capturePluginLifecycleAuthority(owner, record, { scopedRuntime: owner !== gatewayRegistry })
+      : undefined;
+  });
+  const assertPlacementCurrent = getPluginRuntimeGatewayRequestScope()?.assertNodeExecutionCurrent;
+  if (
+    !context ||
+    !target?.storePath ||
+    !attempt.agentId ||
+    !attempt.sessionKey ||
+    !attempt.sessionId ||
+    !assertPlacementCurrent
+  ) {
+    return undefined;
+  }
+  const session = {
+    agentId: attempt.agentId,
+    sessionKey: attempt.sessionKey,
+    storePath: target.storePath,
+  };
+  return async (request, invoke) => {
+    if (request.source === "session-full" && !admittedFull) {
+      return undefined;
+    }
+    const assertCurrent = () => {
+      assertActive();
+      // This read can only revoke the admitted permission. It cannot create Full authority.
+      const entry = loadSessionEntryReadOnly(session);
+      if (
+        signal.aborted ||
+        getActivePluginRegistry() !== gatewayRegistry ||
+        pluginOwners.some((isCurrent) => !isCurrent?.()) ||
+        (request.source === "session-full" && attempt.permissionMode !== "full") ||
+        (resolveContext && resolveContext() !== context) ||
+        request.pluginId !== pluginId ||
+        !entry ||
+        entry.sessionId !== attempt.sessionId ||
+        (request.source === "session-full" && entry.permissionMode !== "full") ||
+        request.workspace.sessionKey !== attempt.sessionKey ||
+        request.workspace.sessionId !== attempt.sessionId
+      ) {
+        throw new Error("admitted node execution authority is no longer current");
+      }
+      assertPlacementCurrent({ ...request, runId: attempt.runId, agentId: session.agentId });
+    };
+    assertCurrent();
+    const result = await invoke(assertCurrent, signal);
+    assertCurrent();
+    return result;
+  };
+}

--- a/src/agents/harness/node-execution-authority.ts
+++ b/src/agents/harness/node-execution-authority.ts
@@ -19,6 +19,7 @@ type SessionNodeInvocation = NonNullable<
 export function createSessionNodeInvocation(
   attempt: HostAttempt,
   pluginId: string,
+  requiredNodeCommands: ReadonlySet<string>,
   assertActive: () => void,
   signal: AbortSignal,
 ): SessionNodeInvocation | undefined {
@@ -52,7 +53,10 @@ export function createSessionNodeInvocation(
     storePath: target.storePath,
   };
   return async (request, invoke) => {
-    if (request.source === "session-full" && !admittedFull) {
+    if (
+      request.source === "session-full" &&
+      (!admittedFull || !requiredNodeCommands.has(request.command))
+    ) {
       return undefined;
     }
     const assertCurrent = () => {
@@ -63,7 +67,8 @@ export function createSessionNodeInvocation(
         signal.aborted ||
         getActivePluginRegistry() !== gatewayRegistry ||
         pluginOwners.some((isCurrent) => !isCurrent?.()) ||
-        (request.source === "session-full" && attempt.permissionMode !== "full") ||
+        (request.source === "session-full" &&
+          (attempt.permissionMode !== "full" || !requiredNodeCommands.has(request.command))) ||
         (resolveContext && resolveContext() !== context) ||
         request.pluginId !== pluginId ||
         !entry ||

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -12,9 +12,17 @@ import { replaceSessionEntry } from "../../config/sessions/session-accessor.js";
 import type { TranscriptEntryAnchor } from "../../config/sessions/transcript-entry-anchor.js";
 import { OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST } from "../../context-engine/host-compat.js";
 import type { ContextEngine } from "../../context-engine/types.js";
+import type { GatewayRequestContext } from "../../gateway/server-methods/types.js";
 import { resetAgentRunRegistryForTest } from "../../infra/agent-run-registry.js";
 import { createOpenClawCodingTools } from "../../plugin-sdk/agent-harness.js";
+import { createPluginRecord } from "../../plugins/loader-records.js";
 import { getActivePluginRegistry } from "../../plugins/runtime.js";
+import {
+  bindGatewayContextResolver,
+  clearGatewayContextResolver,
+  getPluginRuntimeGatewayRequestScope,
+  withPluginRuntimeGatewayRequestScope,
+} from "../../plugins/runtime/gateway-request-scope.js";
 import { mintSecretSentinel } from "../../secrets/sentinel.js";
 import type { UserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.types.js";
 import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
@@ -573,6 +581,109 @@ describe("runAgentHarnessAttempt", () => {
 
     expect(observedApprovalOwner).toBe("actual-owner");
   });
+
+  it.each(["declared", "unlisted", "missing", "expanded"] as const)(
+    "limits selected harness Full authority to its captured node commands (%s)",
+    async (descriptor) => {
+      const root = trajectoryTempDirs.make("openclaw-harness-node-authority-");
+      const sessionTarget = {
+        agentId: "main",
+        sessionId: "session-1",
+        sessionKey: "agent:main:session-1",
+        storePath: path.join(root, "agents", "main", "sessions", "sessions.json"),
+      };
+      await replaceSessionEntry(sessionTarget, {
+        sessionId: sessionTarget.sessionId,
+        updatedAt: 10,
+        permissionMode: "full",
+      });
+      const workspace = {
+        workspaceDir: path.join(root, "workspace"),
+        sessionId: sessionTarget.sessionId,
+        sessionKey: sessionTarget.sessionKey,
+        environmentId: "environment-1",
+        ownerEpoch: 1,
+      };
+      const launchCommand = "fixture.exec.launch";
+      const unrelatedCommand = "fixture.maintenance.apply";
+      const requiredNodeCommands = [launchCommand];
+      const command =
+        descriptor === "unlisted" || descriptor === "expanded" ? unrelatedCommand : launchCommand;
+      const effect = vi.fn(async (assertCurrent: () => void) => {
+        assertCurrent();
+        return "launched";
+      });
+      registerAgentHarness(
+        {
+          id: "node-harness",
+          label: "Node harness",
+          cloudPlacement: {
+            mode: "remote-exec",
+            ...(descriptor !== "missing"
+              ? { devicePlacement: { requiredNodeCommands, consumesWorkerSlot: false } }
+              : {}),
+          },
+          supports: () => ({ supported: true, priority: 100 }),
+          runAttempt: async () => {
+            const invoke = getPluginRuntimeGatewayRequestScope()?.invokeWithSessionNodeAuthority;
+            if (!invoke) {
+              throw new Error("Expected the selected harness's admitted node invocation scope");
+            }
+            // Plugin initialization cannot widen the descriptor captured before its handoff.
+            if (descriptor === "expanded") {
+              requiredNodeCommands.push(unrelatedCommand);
+            }
+            const result = await invoke(
+              { source: "session-full", pluginId: "fixture", nodeId: "node-1", command, workspace },
+              effect,
+            );
+            expect(result).toBe(descriptor === "declared" ? "launched" : undefined);
+            return createAttemptResult("node-harness");
+          },
+        },
+        { ownerPluginId: "fixture" },
+      );
+      const registry = getActivePluginRegistry();
+      if (!registry) {
+        throw new Error("Expected the registered harness's plugin registry");
+      }
+      const record = createPluginRecord({
+        id: "fixture",
+        source: "fixture",
+        origin: "bundled",
+        enabled: true,
+        configSchema: true,
+      });
+      registry.plugins.push(record);
+      const context = {} as GatewayRequestContext;
+      bindGatewayContextResolver(selectionAdmittedRunContext, () => context);
+      try {
+        const params = createAttemptParams(providerRuntimeConfig("codex", "node-harness"));
+        params.agentId = sessionTarget.agentId;
+        params.sessionKey = sessionTarget.sessionKey;
+        params.sessionTarget = sessionTarget;
+        params.permissionMode = "full";
+        await withPluginRuntimeGatewayRequestScope(
+          {
+            isWebchatConnect: () => false,
+            assertNodeExecutionCurrent: (request) => {
+              expect(request).toMatchObject({
+                runId: params.runId,
+                agentId: sessionTarget.agentId,
+                nodeId: "node-1",
+                workspace,
+              });
+            },
+          },
+          () => runAgentHarnessAttempt(params),
+        );
+        expect(effect).toHaveBeenCalledTimes(descriptor === "declared" ? 1 : 0);
+      } finally {
+        clearGatewayContextResolver(selectionAdmittedRunContext);
+        registry.plugins.splice(registry.plugins.indexOf(record), 1);
+      }
+    },
+  );
 
   it("routes settled turns only through an explicit harness finalizer", async () => {
     const internalKey = "__openclawSourceReplyDeliveryRuntime";

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -473,7 +473,9 @@ async function runSelectedAgentHarnessAttempt(
           harness,
           effectiveAttemptParams.pluginHarnessToolPolicyRestricted === true,
         );
-        return runAgentHarnessLifecycleAttempt(harness, effectiveAttemptParams);
+        return pluginAttempt.runWithHostScope(() =>
+          runAgentHarnessLifecycleAttempt(harness, effectiveAttemptParams),
+        );
       }),
     );
   } finally {
@@ -592,6 +594,7 @@ function withoutInternalHarnessAuthority(
 ): {
   params: import("./types.js").AgentHarnessAttemptParamsV2;
   closeHostCapabilities: () => void;
+  runWithHostScope: <T>(run: () => Promise<T>) => Promise<T>;
 } {
   if (builtIn) {
     return {
@@ -602,6 +605,7 @@ function withoutInternalHarnessAuthority(
         operationalRunInstance: params.admittedRunContext.operationalRunInstance,
       } as import("./types.js").AgentHarnessAttemptParamsV2,
       closeHostCapabilities: () => {},
+      runWithHostScope: (run) => run(),
     };
   }
   const pluginParams = withoutPluginHarnessPrivateState(params);
@@ -616,6 +620,7 @@ function withoutInternalHarnessAuthority(
   return {
     params: { ...pluginParams, hostCapabilities: host.capabilities },
     closeHostCapabilities: host.close,
+    runWithHostScope: host.runWithScope,
   };
 }
 

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -611,6 +611,7 @@ function withoutInternalHarnessAuthority(
   const pluginParams = withoutPluginHarnessPrivateState(params);
   const host = createAgentHarnessHostCapabilities({
     attempt: params,
+    requiredNodeCommands: harness.cloudPlacement?.devicePlacement?.requiredNodeCommands,
     pluginId:
       ownerPluginId ??
       (() => {

--- a/src/auto-reply/reply/agent-runner-node-authority.test.ts
+++ b/src/auto-reply/reply/agent-runner-node-authority.test.ts
@@ -45,7 +45,17 @@ afterEach(async () => {
 
 describe("webchat admission to plugin node duplex authority", () => {
   const cases = [
-    ...(["full", "shared", "workspace", "raw"] as const).map((mode) => ({
+    ...(
+      [
+        "full",
+        "shared",
+        "workspace",
+        "raw",
+        "unrelated-command",
+        "missing-descriptor",
+        "expanded-descriptor",
+      ] as const
+    ).map((mode) => ({
       mode,
       phase: "startup" as const,
     })),
@@ -112,8 +122,16 @@ describe("webchat admission to plugin node duplex authority", () => {
         environmentId: ENVIRONMENT_ID,
         ownerEpoch: OWNER_EPOCH,
       };
+      const command =
+        mode === "unrelated-command" || mode === "expanded-descriptor" ? "demo.other" : "demo.read";
+      const requiredNodeCommands = mode === "missing-descriptor" ? undefined : ["demo.read"];
       const node = createNodeSession();
-      const { context, invoke } = createContext({ nodeSession: node });
+      node.declaredCommands = ["demo.read", "demo.other"];
+      node.commands = [...node.declaredCommands];
+      const { context, invoke } = createContext({
+        nodeSession: node,
+        getRuntimeConfig: () => ({ gateway: { nodes: { commands: { allow: node.commands } } } }),
+      });
       let currentContext: GatewayRequestContext | undefined = context;
       context.resolveGatewayContext = () => currentContext;
       const registry = createEmptyPluginRegistry();
@@ -126,18 +144,25 @@ describe("webchat admission to plugin node duplex authority", () => {
         configSchema: true,
       });
       registry.plugins.push(record);
-      registry.nodeHostCommands.push({
-        pluginId: record.id,
-        source: "fixture",
-        command: { command: "demo.read", dangerous: true, duplex: true, handle: async () => "{}" },
-      });
+      for (const declaredCommand of node.commands) {
+        registry.nodeHostCommands.push({
+          pluginId: record.id,
+          source: "fixture",
+          command: {
+            command: declaredCommand,
+            dangerous: true,
+            duplex: true,
+            handle: async () => "{}",
+          },
+        });
+      }
       const prompt = vi.fn();
       let revoke = async () => {};
       registry.nodeInvokePolicies.push({
         pluginId: record.id,
         source: "fixture",
         policy: {
-          commands: ["demo.read"],
+          commands: [...node.commands],
           async handle(policy) {
             await Promise.resolve();
             if (phase === "policy") {
@@ -172,7 +197,7 @@ describe("webchat admission to plugin node duplex authority", () => {
                 context: options.context,
                 client: options.client,
                 nodeSession: node,
-                command: "demo.read",
+                command,
                 params: options.params.params,
                 sessionKey: options.params.sessionKey as string,
                 nodeInvokeStream: options.client?.internal?.nodeInvokeStream,
@@ -260,13 +285,20 @@ describe("webchat admission to plugin node duplex authority", () => {
                   workspaceDir: params.workspaceDir,
                 },
                 pluginId: record.id,
+                requiredNodeCommands,
               });
+              if (mode === "expanded-descriptor") {
+                requiredNodeCommands?.push("demo.other");
+              }
               revoke = async () => {
                 switch (mode) {
                   case "full":
                   case "shared":
                   case "workspace":
                   case "raw":
+                  case "unrelated-command":
+                  case "missing-descriptor":
+                  case "expanded-descriptor":
                     break;
                   case "permission":
                     await upsertSessionEntryCore(sessionTarget, { permissionMode: "workspace" });
@@ -332,7 +364,7 @@ describe("webchat admission to plugin node duplex authority", () => {
                         try {
                           const input = {
                             nodeId: node.nodeId,
-                            command: "demo.read",
+                            command,
                             params: workspace,
                             sessionKey: SESSION_KEY,
                           };
@@ -394,10 +426,16 @@ describe("webchat admission to plugin node duplex authority", () => {
         expect(invoke.mock.calls[0]?.[0]).toMatchObject({
           params: { placement: workspace, authorization: "session-full" },
         });
-      } else if (mode === "workspace" || mode === "raw") {
+      } else if (
+        mode === "workspace" ||
+        mode === "raw" ||
+        mode === "unrelated-command" ||
+        mode === "missing-descriptor" ||
+        mode === "expanded-descriptor"
+      ) {
+        expect(invoke).not.toHaveBeenCalled();
         expect(launchErrors).toEqual(["one-time approval required"]);
         expect(prompt).toHaveBeenCalledOnce();
-        expect(invoke).not.toHaveBeenCalled();
       } else {
         expect(launchErrors).toHaveLength(1);
         expect(launchErrors[0]).toMatch(/no longer (active|current)/);

--- a/src/auto-reply/reply/agent-runner-node-authority.test.ts
+++ b/src/auto-reply/reply/agent-runner-node-authority.test.ts
@@ -1,0 +1,410 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RunEmbeddedAgentParams } from "../../agents/embedded-agent-runner/run/params.js";
+import type {
+  GatewayRequestContext,
+  GatewayRequestHandlerOptions,
+} from "../../gateway/server-methods/types.js";
+import type { WorkerTunnelHandle } from "../../gateway/worker-environments/tunnel.js";
+import {
+  createFollowupRun,
+  createMinimalRunAgentTurnParams,
+  getExecuteAgentTurnForTest,
+  setupAgentRunnerExecutionTestState,
+} from "./agent-runner-execution.test-support.js";
+
+// The fixture registers its plugin directly; disk discovery is outside this handoff.
+vi.mock("../../plugins/loader.js", () => ({
+  loadAndActivateRootPluginRegistry: vi.fn(() => {
+    throw new Error("unexpected plugin discovery");
+  }),
+  loadOpenClawPlugins: vi.fn(() => {
+    throw new Error("unexpected plugin discovery");
+  }),
+}));
+
+vi.mock("../../agents/agent-tools.js", () => ({
+  createOpenClawCodingTools: vi.fn(() => {
+    throw new Error("unexpected coding tool construction");
+  }),
+}));
+
+const state = setupAgentRunnerExecutionTestState();
+
+let execute: Awaited<ReturnType<typeof getExecuteAgentTurnForTest>>;
+let fixture: typeof import("../../gateway/worker-environments/worker-turn-launcher.test-support.js");
+beforeEach(async () => {
+  execute = await getExecuteAgentTurnForTest();
+  fixture = await import("../../gateway/worker-environments/worker-turn-launcher.test-support.js");
+  await fixture.setupWorkerTurnLauncherTest();
+});
+afterEach(async () => {
+  (await import("../../plugins/runtime.js")).resetPluginRuntimeStateForTest();
+  (await import("../../infra/agent-run-registry.js")).resetAgentRunRegistryForTest();
+  await fixture.cleanupWorkerTurnLauncherTest();
+});
+
+describe("webchat admission to plugin node duplex authority", () => {
+  const cases = [
+    ...(["full", "shared", "workspace", "raw"] as const).map((mode) => ({
+      mode,
+      phase: "startup" as const,
+    })),
+    ...(
+      [
+        "permission",
+        "session",
+        "admission",
+        "gateway",
+        "node",
+        "plugin",
+        "placement",
+        "runtime-plugin",
+        "runtime-retired",
+        "runtime-reactivated",
+        "gateway-reactivated",
+        "runtime-record-revoked",
+      ] as const
+    ).flatMap((mode) => (["startup", "policy"] as const).map((phase) => ({ mode, phase }))),
+  ];
+  it.each(cases)(
+    "carries only current admitted Full through the request envelope: $mode ($phase)",
+    async ({ mode, phase }) => {
+      const { createAgentHarnessHostCapabilities } =
+        await import("../../agents/harness/host-capability.js");
+      const { upsertSessionEntryCore } = await import("../../config/sessions/session-accessor.js");
+      const { createGatewayMethodRegistry } = await import("../../gateway/methods/registry.js");
+      const { applyPluginNodeInvokePolicy } =
+        await import("../../gateway/node-invoke-plugin-policy.js");
+      const { createContext, createNodeSession } =
+        await import("../../gateway/node-invoke-plugin-policy.test-helpers.js");
+      const { runWithGatewayRequestEnvelope } = await import("../../gateway/server-methods.js");
+      const { createGatewayNodesRuntime } = await import("../../gateway/server-plugins.js");
+      const { createPluginRecord } = await import("../../plugins/loader-records.js");
+      const {
+        markPluginRegistryActive,
+        markPluginRegistryRetired,
+        revokePluginRecordLifecycleEpoch,
+      } = await import("../../plugins/registry-lifecycle.js");
+      const { createEmptyPluginRegistry } = await import("../../plugins/registry-empty.js");
+      const { withPluginRuntimePluginScope, withPluginRuntimeRegistryScope } =
+        await import("../../plugins/runtime/gateway-request-scope.js");
+      const { setActivePluginRegistry } = await import("../../plugins/runtime.js");
+      const {
+        attachedEnvironment,
+        createWorkerSessionTurnPlacementProvider,
+        ENVIRONMENT_ID,
+        MANIFEST_REF,
+        OWNER_EPOCH,
+        placements,
+        root,
+        seedActivePlacement,
+        SESSION_ID,
+        SESSION_KEY,
+        sessionTarget,
+        unusedEnvironments,
+      } = fixture;
+      await upsertSessionEntryCore(sessionTarget, { permissionMode: "full" });
+      seedActivePlacement("remote-exec");
+      const workspace = {
+        workspaceDir: "/worker/workspace",
+        sessionKey: SESSION_KEY,
+        sessionId: SESSION_ID,
+        environmentId: ENVIRONMENT_ID,
+        ownerEpoch: OWNER_EPOCH,
+      };
+      const node = createNodeSession();
+      const { context, invoke } = createContext({ nodeSession: node });
+      let currentContext: GatewayRequestContext | undefined = context;
+      context.resolveGatewayContext = () => currentContext;
+      const registry = createEmptyPluginRegistry();
+      const nodes = createGatewayNodesRuntime(context.resolveGatewayContext);
+      const record = createPluginRecord({
+        id: "demo",
+        source: "fixture",
+        origin: "bundled",
+        enabled: true,
+        configSchema: true,
+      });
+      registry.plugins.push(record);
+      registry.nodeHostCommands.push({
+        pluginId: record.id,
+        source: "fixture",
+        command: { command: "demo.read", dangerous: true, duplex: true, handle: async () => "{}" },
+      });
+      const prompt = vi.fn();
+      let revoke = async () => {};
+      registry.nodeInvokePolicies.push({
+        pluginId: record.id,
+        source: "fixture",
+        policy: {
+          commands: ["demo.read"],
+          async handle(policy) {
+            await Promise.resolve();
+            if (phase === "policy") {
+              await revoke();
+            }
+            const result = await policy.invokeNodeWithSessionFull?.({
+              workspace,
+              createParams: () => ({ placement: workspace, authorization: "session-full" }),
+            });
+            if (result) {
+              return result;
+            }
+            prompt();
+            return { ok: false, code: "APPROVAL_REQUIRED", message: "one-time approval required" };
+          },
+        },
+      });
+      const preparedRegistry = createEmptyPluginRegistry();
+      const preparedRecord = { ...record };
+      preparedRegistry.plugins.push(preparedRecord);
+      preparedRegistry.nodeHostCommands.push(...registry.nodeHostCommands);
+      const scopedRegistry = mode === "shared" ? registry : preparedRegistry;
+      setActivePluginRegistry(registry);
+      const methodRegistry = createGatewayMethodRegistry(
+        [
+          {
+            name: "node.invoke",
+            owner: { kind: "core", area: "nodes" },
+            scope: "operator.write",
+            async handler(options: GatewayRequestHandlerOptions) {
+              const result = await applyPluginNodeInvokePolicy({
+                context: options.context,
+                client: options.client,
+                nodeSession: node,
+                command: "demo.read",
+                params: options.params.params,
+                sessionKey: options.params.sessionKey as string,
+                nodeInvokeStream: options.client?.internal?.nodeInvokeStream,
+              });
+              if (result?.ok) {
+                options.respond(true, result.payload);
+              } else {
+                options.respond(false, undefined, {
+                  code: "INVALID_REQUEST",
+                  message: result?.message ?? "missing policy",
+                });
+              }
+            },
+          },
+        ],
+        registry,
+      );
+      context.getGatewayMethodRegistry = () => methodRegistry;
+      invoke.mockImplementation(async (params) => {
+        expect(params?.isDispatchAuthorized?.()).toBe(true);
+        params?.onDispatchReady?.("fixture-invoke");
+        params?.onProgress?.(JSON.stringify({ v: 1, kind: "ready" }));
+        return { ok: true, payload: { launched: true } };
+      });
+      const tunnel: WorkerTunnelHandle = {
+        environmentId: ENVIRONMENT_ID,
+        ownerEpoch: OWNER_EPOCH,
+        launchTurn: vi.fn(),
+        runWorkspaceCommand: vi.fn(),
+        syncWorkspace: vi.fn(),
+        quiesceWorkspace: async () => ({ assertActive: async () => {}, resume: async () => {} }),
+        reconcileWorkspace: async (request) => {
+          request.journal.commit(MANIFEST_REF);
+          return {
+            manifestRef: MANIFEST_REF,
+            changed: false,
+            verifyStable: async () => {},
+            verifyLocalStable: async () => {},
+          };
+        },
+        stop: async () => {},
+      };
+      const environment = {
+        ...attachedEnvironment(),
+        providerId: "device",
+        nodeDeviceId: node.nodeId,
+        sshEndpoint: null,
+      };
+      const claimTurn = vi.spyOn(placements, "claimTurn");
+      const placement = createWorkerSessionTurnPlacementProvider({
+        placements,
+        environments: {
+          ...unusedEnvironments(),
+          get: () => environment,
+          startTunnel: async () => tunnel,
+        },
+      });
+      const launchErrors: string[] = [];
+      state.runEmbeddedAgentMock.mockImplementationOnce(
+        async (originalParams: RunEmbeddedAgentParams) => {
+          // The shared fixture omits runId from its parameter stub; retain the real admission's id.
+          const admission = originalParams.preparedRunAdmission!;
+          const params = { ...originalParams, runId: admission.operationalRunInstance.runId };
+          return placement.executeTurn(
+            {
+              sessionId: SESSION_ID,
+              sessionKey: SESSION_KEY,
+              agentId: "main",
+              runId: params.runId,
+            },
+            { ...params, sessionFile: SESSION_KEY, sessionTarget },
+            async () => {
+              const admittedRunContext = await admission.admit("plugin-harness");
+              const host = createAgentHarnessHostCapabilities({
+                attempt: {
+                  admittedRunContext,
+                  runId: params.runId,
+                  agentId: params.agentId,
+                  sessionId: params.sessionId,
+                  sessionKey: params.sessionKey,
+                  sessionTarget,
+                  permissionMode: params.permissionMode,
+                  abortSignal: params.abortSignal,
+                  config: params.config,
+                  workspaceDir: params.workspaceDir,
+                },
+                pluginId: record.id,
+              });
+              revoke = async () => {
+                switch (mode) {
+                  case "full":
+                  case "shared":
+                  case "workspace":
+                  case "raw":
+                    break;
+                  case "permission":
+                    await upsertSessionEntryCore(sessionTarget, { permissionMode: "workspace" });
+                    break;
+                  case "session":
+                    await upsertSessionEntryCore(sessionTarget, {
+                      sessionId: "replacement-session",
+                    });
+                    break;
+                  case "admission":
+                    admission.close();
+                    break;
+                  case "gateway":
+                    currentContext = { ...context };
+                    break;
+                  case "node":
+                    environment.nodeDeviceId = "replacement-node";
+                    break;
+                  case "plugin":
+                    registry.plugins.splice(0, 1, { ...record });
+                    break;
+                  case "runtime-plugin":
+                    preparedRegistry.plugins.splice(0, 1, { ...preparedRecord });
+                    break;
+                  case "runtime-retired":
+                    markPluginRegistryRetired(preparedRegistry);
+                    break;
+                  case "runtime-reactivated":
+                    markPluginRegistryRetired(preparedRegistry);
+                    markPluginRegistryActive(preparedRegistry);
+                    break;
+                  case "gateway-reactivated":
+                    markPluginRegistryActive(registry);
+                    break;
+                  case "runtime-record-revoked":
+                    revokePluginRecordLifecycleEpoch(preparedRegistry, preparedRecord);
+                    break;
+                  case "placement": {
+                    const claimed = claimTurn.mock.results[0];
+                    if (claimed?.type !== "return") {
+                      throw new Error("expected an admitted placement claim");
+                    }
+                    placements.cancelWorkspaceResultAndReleaseTurn(claimed.value, {
+                      reason: "node-disconnect",
+                    });
+                    break;
+                  }
+                }
+              };
+              try {
+                await withPluginRuntimeRegistryScope(scopedRegistry, () =>
+                  host.runWithScope(() =>
+                    withPluginRuntimePluginScope(
+                      { pluginId: record.id, pluginOrigin: "bundled" },
+                      async () => {
+                        // Runtime initialization completes asynchronously before opening the channel.
+                        await new Promise<void>((resolve) => {
+                          setImmediate(resolve);
+                        });
+                        if (phase === "startup") {
+                          await revoke();
+                        }
+                        try {
+                          const input = {
+                            nodeId: node.nodeId,
+                            command: "demo.read",
+                            params: workspace,
+                            sessionKey: SESSION_KEY,
+                          };
+                          if (mode === "raw") {
+                            await nodes.invoke(input);
+                          } else {
+                            const channel = await nodes.openDuplex(input);
+                            await channel.closed;
+                          }
+                        } catch (error) {
+                          launchErrors.push((error as Error).message);
+                        }
+                      },
+                    ),
+                  ),
+                );
+              } finally {
+                host.close();
+              }
+              return { payloads: [{ text: "finished" }], meta: { durationMs: 1 } };
+            },
+          );
+        },
+      );
+      const followupRun = createFollowupRun();
+      Object.assign(followupRun.run, {
+        sessionId: SESSION_ID,
+        sessionKey: SESSION_KEY,
+        agentDir: root,
+        workspaceDir: root,
+        permissionMode: mode === "workspace" ? "workspace" : "full",
+      });
+
+      const reply = await runWithGatewayRequestEnvelope(
+        "sessions.send",
+        null,
+        () =>
+          execute({
+            ...createMinimalRunAgentTurnParams({ followupRun }),
+            sessionKey: SESSION_KEY,
+          }),
+        {
+          context,
+          isWebchatConnect: () => true,
+          methodRegistry,
+          reject: (error) => {
+            throw new Error(error.message);
+          },
+        },
+      );
+      if (mode !== "placement" && mode !== "session") {
+        expect(reply).toMatchObject({ kind: "success" });
+      }
+      expect(state.runEmbeddedAgentMock).toHaveBeenCalledOnce();
+      if (mode === "full" || mode === "shared") {
+        expect(launchErrors).toEqual([]);
+        expect(prompt).not.toHaveBeenCalled();
+        expect(invoke).toHaveBeenCalledOnce();
+        expect(invoke.mock.calls[0]?.[0]).toMatchObject({
+          params: { placement: workspace, authorization: "session-full" },
+        });
+      } else if (mode === "workspace" || mode === "raw") {
+        expect(launchErrors).toEqual(["one-time approval required"]);
+        expect(prompt).toHaveBeenCalledOnce();
+        expect(invoke).not.toHaveBeenCalled();
+      } else {
+        expect(launchErrors).toHaveLength(1);
+        expect(launchErrors[0]).toMatch(/no longer (active|current)/);
+        expect(prompt).not.toHaveBeenCalled();
+        expect(invoke).not.toHaveBeenCalled();
+      }
+      currentContext = undefined;
+    },
+  );
+});

--- a/src/gateway/node-invoke-plugin-policy.session-full.test.ts
+++ b/src/gateway/node-invoke-plugin-policy.session-full.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
+import { withPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
+import { applyPluginNodeInvokePolicy } from "./node-invoke-plugin-policy.js";
+import {
+  createNodeSession,
+  createContext,
+  createDemoPolicy,
+  setDangerousDemoCommandRegistry,
+  DEMO_PLUGIN_ID,
+  DEMO_COMMAND,
+  DEMO_PARAMS,
+} from "./node-invoke-plugin-policy.test-helpers.js";
+import type { GatewayClient } from "./server-methods/types.js";
+afterEach(() => resetPluginRuntimeStateForTest());
+describe("admitted Full node dispatch", () => {
+  it.each(["stream", "raw", "permission", "plugin", "node", "command"] as const)(
+    "preserves the owned boundary during awaited policy (%s)",
+    async (change) => {
+      const node = createNodeSession();
+      const { context, invoke } = createContext({ nodeSession: node });
+      let active = true;
+      const assertCurrent = () => {
+        if (!active) {
+          throw new Error("Full authority revoked");
+        }
+      };
+      setDangerousDemoCommandRegistry([
+        createDemoPolicy(async (ctx) => {
+          if (!ctx.invokeNodeWithSessionFull) {
+            return { ok: false, code: "APPROVAL_REQUIRED", message: "human approval required" };
+          }
+          return (await ctx.invokeNodeWithSessionFull({
+            workspace: {
+              workspaceDir: "/node/workspace",
+              environmentId: "env",
+              sessionId: "session",
+              ownerEpoch: 1,
+              sessionKey: "agent:main:session",
+            },
+            createParams: () => ({ authorization: "session-full" }),
+          }))!;
+        }),
+      ]);
+      const result = withPluginRuntimeGatewayRequestScope(
+        {
+          context,
+          isWebchatConnect: () => false,
+          invokeWithSessionNodeAuthority: async (_request, dispatch) => {
+            assertCurrent();
+            return await dispatch(assertCurrent, new AbortController().signal);
+          },
+        },
+        () =>
+          applyPluginNodeInvokePolicy({
+            context,
+            nodeSession: node,
+            command: DEMO_COMMAND,
+            params: DEMO_PARAMS,
+            sessionKey: "agent:main:session",
+            client: {
+              internal: { pluginRuntimeOwnerId: DEMO_PLUGIN_ID },
+              connect: { scopes: [] },
+            } as unknown as GatewayClient,
+            ...(change !== "raw"
+              ? {
+                  nodeInvokeStream: {
+                    onProgress: () => {},
+                    onDispatchReady: () => {},
+                    isRuntimeCurrent: () => true,
+                  },
+                }
+              : {}),
+            isInvocationCurrent: async () => {
+              await Promise.resolve();
+              if (change === "permission") {
+                active = false;
+              }
+              if (change === "plugin") {
+                setActivePluginRegistry(createEmptyPluginRegistry());
+              }
+              if (change === "node") {
+                context.nodeRegistry.get = () => ({ ...node, connId: "replacement" });
+              }
+              if (change === "command") {
+                node.commands = [];
+              }
+              return true;
+            },
+          }),
+      );
+      if (change === "permission") {
+        await expect(result).rejects.toThrow("Full authority revoked");
+      } else {
+        await expect(result).resolves.toMatchObject({ ok: change === "stream" });
+      }
+      if (change === "stream") {
+        expect(invoke).toHaveBeenCalledOnce();
+      } else {
+        expect(invoke).not.toHaveBeenCalled();
+      }
+    },
+  );
+});

--- a/src/gateway/node-invoke-plugin-policy.test-helpers.ts
+++ b/src/gateway/node-invoke-plugin-policy.test-helpers.ts
@@ -1,6 +1,7 @@
 /** Shared harness for node invoke plugin-policy tests. */
 import { expect, vi } from "vitest";
 import type { PluginApprovalRequestPayload } from "../infra/plugin-approvals.js";
+import { createPluginRecord } from "../plugins/loader-records.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import type { PluginRegistry } from "../plugins/registry-types.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
@@ -165,6 +166,15 @@ export function createApprovalRequestPolicy(params?: {
 
 export function setDangerousDemoCommandRegistry(policies: NodeInvokePolicyRegistration[] = []) {
   const registry = createEmptyPluginRegistry();
+  registry.plugins.push(
+    createPluginRecord({
+      id: DEMO_PLUGIN_ID,
+      source: "test",
+      origin: "bundled",
+      enabled: true,
+      configSchema: true,
+    }),
+  );
   registry.nodeHostCommands.push({
     pluginId: DEMO_PLUGIN_ID,
     command: {

--- a/src/gateway/node-invoke-plugin-policy.ts
+++ b/src/gateway/node-invoke-plugin-policy.ts
@@ -14,6 +14,7 @@ import type { PluginApprovalRequestPayload } from "../infra/plugin-approvals.js"
 import { resolvePluginApprovalTimeoutMs } from "../infra/plugin-approvals.js";
 import type { PluginRegistry } from "../plugins/registry-types.js";
 import { getActivePluginGatewayNodePolicyRegistry } from "../plugins/runtime.js";
+import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
 import type {
   OpenClawPluginNodeInvokePolicyContext,
   OpenClawPluginNodeInvokePolicyResult,
@@ -361,8 +362,19 @@ export async function applyPluginNodeInvokePolicy(params: {
 
   let nodeCommandDispatched = false;
   let nodeGateDecisionRecorded = false;
-  const invokeNode: OpenClawPluginNodeInvokePolicyContext["invokeNode"] = async (
-    override = {},
+  const pluginRecord = registry?.plugins.find((record) => record.id === entry.pluginId);
+  const policy = entry.policy;
+  const isPluginCurrent = () =>
+    getActivePluginGatewayNodePolicyRegistry() === registry &&
+    entry.policy === policy &&
+    registry?.nodeInvokePolicies.includes(entry) === true &&
+    (!pluginRecord ||
+      (registry.plugins.includes(pluginRecord) &&
+        pluginRecord.enabled &&
+        pluginRecord.status === "loaded"));
+  const dispatchNode = async (
+    override: Parameters<OpenClawPluginNodeInvokePolicyContext["invokeNode"]>[0] = {},
+    sessionAuthority?: { assertCurrent: () => void; signal: AbortSignal },
   ): Promise<OpenClawPluginNodeInvokeTransportResult> => {
     const deny = (
       reasonCode: string,
@@ -378,6 +390,7 @@ export async function applyPluginNodeInvokePolicy(params: {
       });
       return result;
     };
+    sessionAuthority?.assertCurrent();
     if (
       callerIdentity &&
       params.context.validateAgentRuntimeApprovalAuthority?.(callerIdentity) !== true
@@ -452,6 +465,14 @@ export async function applyPluginNodeInvokePolicy(params: {
         : requestedTimeoutMs;
     // Pairing and policy checks above may await. Revalidate the exact runtime
     // capability at the final transport handoff so closure wins that race.
+    sessionAuthority?.assertCurrent();
+    if (!isPluginCurrent()) {
+      return deny("node_plugin_replaced", {
+        ok: false,
+        code: "PLUGIN_POLICY_CHANGED",
+        message: "node plugin policy changed before dispatch",
+      });
+    }
     if (
       callerIdentity &&
       params.context.validateAgentRuntimeApprovalAuthority?.(callerIdentity) !== true
@@ -487,19 +508,36 @@ export async function applyPluginNodeInvokePolicy(params: {
       command: params.command,
       params: override.params ?? params.params,
       timeoutMs,
-      ...(params.signal ? { signal: params.signal } : {}),
+      ...(sessionAuthority
+        ? {
+            signal: params.signal
+              ? AbortSignal.any([params.signal, sessionAuthority.signal])
+              : sessionAuthority.signal,
+          }
+        : params.signal
+          ? { signal: params.signal }
+          : {}),
       ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
       idempotencyKey: override.idempotencyKey ?? params.idempotencyKey,
       ...(params.nodeInvokeStream && {
         onProgress: params.nodeInvokeStream.onProgress,
         idleTimeoutMs: params.nodeInvokeStream.idleTimeoutMs,
       }),
-      isDispatchAuthorized: () =>
-        (params.nodeInvokeStream?.isRuntimeCurrent() ?? true) &&
-        (!callerIdentity ||
-          params.context.validateAgentRuntimeApprovalAuthority?.(callerIdentity) === true) &&
-        params.isApprovalAuthorityActive?.() !== false &&
-        resolveCommandAuthorization().ok,
+      isDispatchAuthorized: () => {
+        try {
+          sessionAuthority?.assertCurrent();
+        } catch {
+          return false;
+        }
+        return (
+          isPluginCurrent() &&
+          (params.nodeInvokeStream?.isRuntimeCurrent() ?? true) &&
+          (!callerIdentity ||
+            params.context.validateAgentRuntimeApprovalAuthority?.(callerIdentity) === true) &&
+          params.isApprovalAuthorityActive?.() !== false &&
+          resolveCommandAuthorization().ok
+        );
+      },
       onDispatchReady: (invokeId) => {
         // Only the registry knows that the transport send succeeded. Preserve
         // pre-send failures as retry-safe while making later failures ambiguous.
@@ -547,6 +585,45 @@ export async function applyPluginNodeInvokePolicy(params: {
       payloadJSON: res.payloadJSON ?? null,
     };
   };
+  const scope = getPluginRuntimeGatewayRequestScope();
+  const ownedInvocation =
+    params.nodeInvokeStream && params.client?.internal?.pluginRuntimeOwnerId === entry.pluginId
+      ? scope?.invokeWithSessionNodeAuthority
+      : undefined;
+  const invokeOwned = (
+    source: "human-approved" | "session-full",
+    override: NonNullable<Parameters<OpenClawPluginNodeInvokePolicyContext["invokeNode"]>[0]>,
+    createParams?: () => unknown,
+  ) =>
+    ownedInvocation && override.workspace
+      ? ownedInvocation(
+          {
+            pluginId: entry.pluginId,
+            nodeId: params.nodeSession.nodeId,
+            workspace: override.workspace,
+            source,
+          },
+          async (assertCurrent, signal) => {
+            if (params.sessionKey !== override.workspace?.sessionKey) {
+              throw new Error("Node launch requires its authenticated outer session");
+            }
+            return await dispatchNode(
+              createParams ? { ...override, params: createParams() } : override,
+              { assertCurrent, signal },
+            );
+          },
+        )
+      : undefined;
+  const invokeNode: OpenClawPluginNodeInvokePolicyContext["invokeNode"] = async (override = {}) => {
+    if (!ownedInvocation || !override.workspace) {
+      return await dispatchNode(override);
+    }
+    const result = await invokeOwned("human-approved", override);
+    if (!result) {
+      throw new Error("Node launch lost its admitted owner");
+    }
+    return result;
+  };
 
   let result: OpenClawPluginNodeInvokePolicyResult;
   try {
@@ -579,6 +656,12 @@ export async function applyPluginNodeInvokePolicy(params: {
         turnSource: trustedTurnSource,
       }),
       invokeNode,
+      ...(ownedInvocation
+        ? {
+            invokeNodeWithSessionFull: async ({ workspace, createParams }) =>
+              await invokeOwned("session-full", { workspace }, createParams),
+          }
+        : {}),
     });
   } catch (error) {
     // Plugin policy handlers may settle after their exact caller authority

--- a/src/gateway/node-invoke-plugin-policy.ts
+++ b/src/gateway/node-invoke-plugin-policy.ts
@@ -599,6 +599,7 @@ export async function applyPluginNodeInvokePolicy(params: {
       ? ownedInvocation(
           {
             pluginId: entry.pluginId,
+            command: params.command,
             nodeId: params.nodeSession.nodeId,
             workspace: override.workspace,
             source,

--- a/src/gateway/node-registry-private.ts
+++ b/src/gateway/node-registry-private.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { GATEWAY_CLIENT_IDS } from "../../packages/gateway-protocol/src/client-info.js";
 import {
   isPrivateNodeInvokeCommand,
   NODE_WORKER_ENVIRONMENT_STOP_COMMAND,
@@ -27,6 +26,7 @@ import {
 } from "./node-registry.system-run.js";
 import {
   createNodeRunnerStatePublisher,
+  isNodeWorkerHostClientId,
   resolveNodeRunnerInventoryIssue,
   resolveNodeWorkerSupervisorProof,
   sameBundleStatusObservation,
@@ -80,6 +80,8 @@ type NodeWorkerPrivateCommand = (typeof NODE_WORKER_PRIVATE_COMMANDS)[number];
 export type NodeWorkerSupervisorTransport = {
   listCurrentNodes(): Promise<readonly NodeWorkerSupervisorNodeProof[]>;
   hasCurrentRunner(nodeId: string): boolean;
+  /** Diagnostic connection presence, independent of session-host eligibility. */
+  isConnected?(nodeId: string): boolean;
   getIssue?(nodeId: string): NodeRunnerInventoryIssue | undefined;
   getBundleStatus?(nodeId: string): NodeWorkerBundleStatusObservation | undefined;
   acceptBundleStatus?(
@@ -190,7 +192,7 @@ function updateWorkerRunnerInventory(
     !node ||
     node.client.invalidated === true ||
     node.connId !== params.connId ||
-    node.clientId !== GATEWAY_CLIENT_IDS.NODE_HOST ||
+    !isNodeWorkerHostClientId(node.clientId) ||
     node.clientMode !== "node"
   ) {
     return null;
@@ -212,7 +214,7 @@ function updateWorkerRunnerInventory(
     connId: node.connId,
     pairingIdentity: node.pairingIdentity,
     ...(node.pairingGeneration ? { pairingGeneration: node.pairingGeneration } : {}),
-    clientId: GATEWAY_CLIENT_IDS.NODE_HOST,
+    clientId: node.clientId,
     clientMode: "node",
     protocolFeatures: [...params.declaration.protocolFeatures],
     ...(workerHost
@@ -341,6 +343,9 @@ async function invokeNodeRegistryCore(
   });
   // Serialization can consume the budget or close caller-owned authority.
   // Revalidate both before arming pending state and handing off to transport.
+  if (params.signal?.aborted) {
+    return { ok: false, error: { code: "ABORTED", message: "node invoke cancelled" } };
+  }
   if (params.isDispatchAuthorized?.() === false) {
     return {
       ok: false,
@@ -442,6 +447,10 @@ export function registerNodeRegistryPrivateRuntime(
       });
     },
     hasCurrentRunner: state.runnerState.hasCurrent,
+    isConnected: (nodeId) => {
+      const node = context.getNode(nodeId);
+      return Boolean(node && node.client.invalidated !== true);
+    },
     getIssue: (nodeId) => {
       const node = context.getNode(nodeId);
       return node ? resolveNodeRunnerInventoryIssue(node, state.runnerInventoryByConn) : undefined;

--- a/src/gateway/node-registry.test.ts
+++ b/src/gateway/node-registry.test.ts
@@ -36,6 +36,10 @@ import {
 import { NodeRegistry, serializeEventPayload } from "./node-registry.js";
 import { MAX_BUFFERED_BYTES } from "./server-constants.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
+import {
+  createDeviceWorkerRuntime,
+  deviceUnavailableText,
+} from "./worker-environments/device-provider.js";
 
 let testNodeHostCommands: NonNullable<
   ReturnType<typeof createEmptyPluginRegistry>["nodeHostCommands"]
@@ -409,12 +413,136 @@ describe("gateway/node-registry", () => {
     expect(Reflect.ownKeys(Object.getPrototypeOf(registry))).not.toContain("invokeCore");
   });
 
-  it("binds the private dialect to the exact connection generation", async () => {
-    let currentGeneration = "generation-a";
+  it.each([GATEWAY_CLIENT_IDS.NODE_HOST, GATEWAY_CLIENT_IDS.MACOS_APP])(
+    "binds the private dialect to the exact connection generation (%s)",
+    async (clientId) => {
+      let currentGeneration = "generation-a";
+      const { nodeRegistry, nodeWorkerSupervisorTransport } = createPrivateNodeRegistryRuntime({
+        resolveCurrentPairingState: async () => ({
+          identity: "identity-a",
+          generation: currentGeneration,
+        }),
+      });
+      registerNodeSession(
+        nodeRegistry,
+        makeClient("conn-1", "node-1", [], {
+          clientId,
+          commands: ["system.run"],
+        }),
+        { pairingIdentity: "identity-a", pairingGeneration: "generation-a" },
+      );
+
+      await expect(nodeWorkerSupervisorTransport.listCurrentNodes()).resolves.toEqual([]);
+      expect(
+        updateNodeRunnerInventory({
+          registry: nodeRegistry,
+          nodeId: "node-1",
+          connId: "conn-1",
+          declaration: {
+            protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE],
+            workerHost: { enabled: true, capacity: { total: 2, available: 2 } },
+          },
+        }),
+      ).toEqual({ changed: true });
+      await expect(nodeWorkerSupervisorTransport.listCurrentNodes()).resolves.toEqual([
+        expect.objectContaining({
+          nodeId: "node-1",
+          connId: "conn-1",
+          pairingIdentity: "identity-a",
+          pairingGeneration: "generation-a",
+          clientId,
+          protocolFeature: NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE,
+          workerHost: { enabled: true, capacity: { total: 2, available: 2 } },
+          commands: ["system.run"],
+        }),
+      ]);
+      expect(nodeRegistry.get("node-1")).not.toHaveProperty("protocolFeatures");
+      expect(
+        collectNodeCatalogRuntimeState(nodeRegistry, [
+          { nodeId: "node-1", connId: "conn-1", pairingGeneration: "generation-a" },
+        ]).sessionHostNodeIds.has("node-1"),
+      ).toBe(true);
+
+      currentGeneration = "generation-b";
+      expect(
+        nodeRegistry.updateSurface(
+          "node-1",
+          { commands: ["system.run"] },
+          {
+            expectedConnId: "conn-1",
+            expectedPairingIdentity: "identity-a",
+            expectedPairingGeneration: "generation-a",
+            nextPairingGeneration: "generation-b",
+          },
+        ),
+      ).not.toBeNull();
+      await expect(nodeWorkerSupervisorTransport.listCurrentNodes()).resolves.toEqual([]);
+      expect(
+        collectNodeCatalogRuntimeState(nodeRegistry, [
+          { nodeId: "node-1", connId: "conn-1", pairingGeneration: "generation-b" },
+        ]).sessionHostNodeIds.has("node-1"),
+      ).toBe(false);
+      expect(
+        updateNodeRunnerInventory({
+          registry: nodeRegistry,
+          nodeId: "node-1",
+          connId: "conn-1",
+          declaration: {
+            protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE],
+            workerHost: { enabled: true, capacity: { total: 2, available: 2 } },
+          },
+        }),
+      ).toEqual({ changed: true });
+      await expect(nodeWorkerSupervisorTransport.listCurrentNodes()).resolves.toEqual([
+        expect.objectContaining({ pairingGeneration: "generation-b" }),
+      ]);
+
+      registerNodeSession(
+        nodeRegistry,
+        makeClient("conn-2", "node-1", [], {
+          clientId,
+          commands: ["system.run"],
+        }),
+        { pairingIdentity: "identity-a", pairingGeneration: "generation-b" },
+      );
+      await expect(nodeWorkerSupervisorTransport.listCurrentNodes()).resolves.toEqual([]);
+      expect(
+        updateNodeRunnerInventory({
+          registry: nodeRegistry,
+          nodeId: "node-1",
+          connId: "conn-1",
+          declaration: {
+            protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE],
+            workerHost: { enabled: true, capacity: { total: 2, available: 2 } },
+          },
+        }),
+      ).toBeNull();
+      expect(
+        updateNodeRunnerInventory({
+          registry: nodeRegistry,
+          nodeId: "node-1",
+          connId: "conn-2",
+          declaration: {
+            protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE],
+            workerHost: { enabled: true, capacity: { total: 2, available: 2 } },
+          },
+        }),
+      ).toEqual({ changed: true });
+      await expect(nodeWorkerSupervisorTransport.listCurrentNodes()).resolves.toEqual([
+        expect.objectContaining({
+          connId: "conn-2",
+          pairingGeneration: "generation-b",
+          workerHost: { enabled: true, capacity: { total: 2, available: 2 } },
+        }),
+      ]);
+    },
+  );
+
+  it("reports connected nodes without session hosting as ineligible, not disconnected", async () => {
     const { nodeRegistry, nodeWorkerSupervisorTransport } = createPrivateNodeRegistryRuntime({
       resolveCurrentPairingState: async () => ({
         identity: "identity-a",
-        generation: currentGeneration,
+        generation: "generation-a",
       }),
     });
     registerNodeSession(
@@ -425,109 +553,25 @@ describe("gateway/node-registry", () => {
       }),
       { pairingIdentity: "identity-a", pairingGeneration: "generation-a" },
     );
-
-    await expect(nodeWorkerSupervisorTransport.listCurrentNodes()).resolves.toEqual([]);
-    expect(
-      updateNodeRunnerInventory({
-        registry: nodeRegistry,
-        nodeId: "node-1",
-        connId: "conn-1",
-        declaration: {
-          protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE],
-          workerHost: { enabled: true, capacity: { total: 2, available: 2 } },
-        },
+    const runtime = createDeviceWorkerRuntime({
+      getPairedDevice: async () => ({
+        deviceId: "node-1",
+        publicKey: "fixture",
+        role: "node",
+        roles: ["node"],
+        tokens: { node: { token: "fixture-token", role: "node", scopes: [], createdAtMs: 1 } },
+        createdAtMs: 1,
+        approvedAtMs: 1,
       }),
-    ).toEqual({ changed: true });
-    await expect(nodeWorkerSupervisorTransport.listCurrentNodes()).resolves.toEqual([
-      expect.objectContaining({
-        nodeId: "node-1",
-        connId: "conn-1",
-        pairingIdentity: "identity-a",
-        pairingGeneration: "generation-a",
-        protocolFeature: NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE,
-        workerHost: { enabled: true, capacity: { total: 2, available: 2 } },
-        commands: ["system.run"],
-      }),
-    ]);
-    expect(nodeRegistry.get("node-1")).not.toHaveProperty("protocolFeatures");
-    expect(
-      collectNodeCatalogRuntimeState(nodeRegistry, [
-        { nodeId: "node-1", connId: "conn-1", pairingGeneration: "generation-a" },
-      ]).sessionHostNodeIds.has("node-1"),
-    ).toBe(true);
-
-    currentGeneration = "generation-b";
-    expect(
-      nodeRegistry.updateSurface(
-        "node-1",
-        { commands: ["system.run"] },
-        {
-          expectedConnId: "conn-1",
-          expectedPairingIdentity: "identity-a",
-          expectedPairingGeneration: "generation-a",
-          nextPairingGeneration: "generation-b",
-        },
-      ),
-    ).not.toBeNull();
-    await expect(nodeWorkerSupervisorTransport.listCurrentNodes()).resolves.toEqual([]);
-    expect(
-      collectNodeCatalogRuntimeState(nodeRegistry, [
-        { nodeId: "node-1", connId: "conn-1", pairingGeneration: "generation-b" },
-      ]).sessionHostNodeIds.has("node-1"),
-    ).toBe(false);
-    expect(
-      updateNodeRunnerInventory({
-        registry: nodeRegistry,
-        nodeId: "node-1",
-        connId: "conn-1",
-        declaration: {
-          protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE],
-          workerHost: { enabled: true, capacity: { total: 2, available: 2 } },
-        },
-      }),
-    ).toEqual({ changed: true });
-    await expect(nodeWorkerSupervisorTransport.listCurrentNodes()).resolves.toEqual([
-      expect.objectContaining({ pairingGeneration: "generation-b" }),
-    ]);
-
-    registerNodeSession(
-      nodeRegistry,
-      makeClient("conn-2", "node-1", [], {
-        clientId: GATEWAY_CLIENT_IDS.NODE_HOST,
-        commands: ["system.run"],
-      }),
-      { pairingIdentity: "identity-a", pairingGeneration: "generation-b" },
-    );
-    await expect(nodeWorkerSupervisorTransport.listCurrentNodes()).resolves.toEqual([]);
-    expect(
-      updateNodeRunnerInventory({
-        registry: nodeRegistry,
-        nodeId: "node-1",
-        connId: "conn-1",
-        declaration: {
-          protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE],
-          workerHost: { enabled: true, capacity: { total: 2, available: 2 } },
-        },
-      }),
-    ).toBeNull();
-    expect(
-      updateNodeRunnerInventory({
-        registry: nodeRegistry,
-        nodeId: "node-1",
-        connId: "conn-2",
-        declaration: {
-          protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE],
-          workerHost: { enabled: true, capacity: { total: 2, available: 2 } },
-        },
-      }),
-    ).toEqual({ changed: true });
-    await expect(nodeWorkerSupervisorTransport.listCurrentNodes()).resolves.toEqual([
-      expect.objectContaining({
-        connId: "conn-2",
-        pairingGeneration: "generation-b",
-        workerHost: { enabled: true, capacity: { total: 2, available: 2 } },
-      }),
-    ]);
+    });
+    runtime.bindNodeTransport(nodeWorkerSupervisorTransport);
+    const availability = await runtime.resolveAvailability("node-1");
+    expect(nodeRegistry.get("node-1")).toBeDefined();
+    expect(availability).toMatchObject({
+      available: false,
+      unavailableReason: "hosting-unavailable",
+    });
+    expect(deviceUnavailableText("node-1", availability)).toContain("enable session hosting");
   });
 
   it("publishes current-runner edges once across disconnect, reconnect, and replacement", () => {
@@ -746,179 +790,191 @@ describe("gateway/node-registry", () => {
     });
   });
 
-  it("keeps capacity admission separate from negotiated environment turn reuse", async () => {
-    const frames: string[] = [];
-    const { nodeRegistry, nodeWorkerSupervisorTransport } = createPrivateNodeRegistryRuntime();
-    registerNodeSession(
-      nodeRegistry,
-      makeClient("conn-1", "node-1", frames, {
-        clientId: GATEWAY_CLIENT_IDS.NODE_HOST,
-        commands: ["system.run"],
-      }),
-      { pairingIdentity: "identity-a", pairingGeneration: "generation-a" },
-    );
-    expect(
-      updateNodeRunnerInventory({
-        registry: nodeRegistry,
-        nodeId: "node-1",
-        connId: "conn-1",
-        declaration: {
-          protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE],
-          workerHost: { enabled: true, capacity: { total: 2, available: 2 } },
-        },
-      }),
-    ).toEqual({ changed: true });
-    const [proof] = await nodeWorkerSupervisorTransport.listCurrentNodes();
-    if (!proof) {
-      throw new Error("expected current supervisor proof");
-    }
-    expect(
-      updateNodeRunnerInventory({
-        registry: nodeRegistry,
-        nodeId: "node-1",
-        connId: "conn-1",
-        declaration: {
-          protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE],
-          workerHost: { enabled: true, capacity: { total: 2, available: 0 } },
-        },
-      }),
-    ).toEqual({ changed: true });
-    expect(
-      collectNodeCatalogRuntimeState(nodeRegistry, [
-        { nodeId: "node-1", connId: "conn-1", pairingGeneration: "generation-a" },
-      ]).sessionHostNodeIds.has("node-1"),
-    ).toBe(true);
+  it.each([GATEWAY_CLIENT_IDS.NODE_HOST, GATEWAY_CLIENT_IDS.MACOS_APP])(
+    "keeps capacity admission separate from negotiated environment turn reuse (%s)",
+    async (clientId) => {
+      const frames: string[] = [];
+      const { nodeRegistry, nodeWorkerSupervisorTransport } = createPrivateNodeRegistryRuntime();
+      registerNodeSession(
+        nodeRegistry,
+        makeClient("conn-1", "node-1", frames, {
+          clientId,
+          commands: ["system.run"],
+        }),
+        { pairingIdentity: "identity-a", pairingGeneration: "generation-a" },
+      );
+      expect(
+        updateNodeRunnerInventory({
+          registry: nodeRegistry,
+          nodeId: "node-1",
+          connId: "conn-1",
+          declaration: {
+            protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE],
+            workerHost: { enabled: true, capacity: { total: 2, available: 2 } },
+          },
+        }),
+      ).toEqual({ changed: true });
+      const [proof] = await nodeWorkerSupervisorTransport.listCurrentNodes();
+      expect(proof?.clientId).toBe(clientId);
+      if (!proof) {
+        throw new Error("expected current supervisor proof");
+      }
+      expect(
+        updateNodeRunnerInventory({
+          registry: nodeRegistry,
+          nodeId: "node-1",
+          connId: "conn-1",
+          declaration: {
+            protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE],
+            workerHost: { enabled: true, capacity: { total: 2, available: 0 } },
+          },
+        }),
+      ).toEqual({ changed: true });
+      expect(
+        collectNodeCatalogRuntimeState(nodeRegistry, [
+          { nodeId: "node-1", connId: "conn-1", pairingGeneration: "generation-a" },
+        ]).sessionHostNodeIds.has("node-1"),
+      ).toBe(true);
 
-    // Catalog host consent uses the supplied generation; capacity still describes
-    // the current connection, including a full host with zero available slots.
-    const snapshot = collectNodeCatalogRuntimeState(nodeRegistry, [
-      { nodeId: "node-1", connId: "conn-1", pairingGeneration: "stale-generation" },
-    ]);
-    expect(snapshot.sessionHostNodeIds.has("node-1")).toBe(false);
-    expect(snapshot.workerSlotsByNodeId.get("node-1")).toEqual({ total: 2, available: 0 });
-    const projectedCapacity = snapshot.workerSlotsByNodeId.get("node-1");
-    if (!projectedCapacity) {
-      throw new Error("expected projected capacity");
-    }
-    // JavaScript consumers can mutate a readonly-typed snapshot without changing admission.
-    Object.assign(projectedCapacity, { available: 2 });
-    expect(nodeWorkerSupervisorTransport.isCurrent(proof, true)).toBe(false);
-    expect(frames).toEqual([]);
+      // Catalog host consent uses the supplied generation; capacity still describes
+      // the current connection, including a full host with zero available slots.
+      const snapshot = collectNodeCatalogRuntimeState(nodeRegistry, [
+        { nodeId: "node-1", connId: "conn-1", pairingGeneration: "stale-generation" },
+      ]);
+      expect(snapshot.sessionHostNodeIds.has("node-1")).toBe(false);
+      expect(snapshot.workerSlotsByNodeId.get("node-1")).toEqual({ total: 2, available: 0 });
+      const projectedCapacity = snapshot.workerSlotsByNodeId.get("node-1");
+      if (!projectedCapacity) {
+        throw new Error("expected projected capacity");
+      }
+      // JavaScript consumers can mutate a readonly-typed snapshot without changing admission.
+      Object.assign(projectedCapacity, { available: 2 });
+      expect(nodeWorkerSupervisorTransport.isCurrent(proof, true)).toBe(false);
+      expect(frames).toEqual([]);
 
-    const workspaceInvoke = nodeWorkerSupervisorTransport.invoke({
-      node: proof,
-      command: NODE_WORKER_WORKSPACE_EXEC_COMMAND,
-      isDispatchAuthorized: () => true,
-    });
-    await vi.waitFor(() => expect(frames).toHaveLength(1));
-    const request = JSON.parse(frames[0] ?? "{}") as { payload?: { id?: string } };
-    expect(
-      nodeRegistry.handleInvokeResult({
-        id: request.payload?.id ?? "",
-        nodeId: "node-1",
-        connId: "conn-1",
-        ok: true,
-        payloadJSON: "null",
-      }),
-    ).toBe(true);
-    await expect(workspaceInvoke).resolves.toMatchObject({ ok: true, payloadJSON: "null" });
-
-    await expect(
-      nodeWorkerSupervisorTransport.invoke({
+      const workspaceInvoke = nodeWorkerSupervisorTransport.invoke({
         node: proof,
-        command: NODE_WORKER_SUPERVISOR_LAUNCH_COMMAND,
-        isDispatchAuthorized: () => true,
-      }),
-    ).resolves.toMatchObject({
-      ok: false,
-      error: { code: "PRIVATE_DIALECT_UNAVAILABLE" },
-    });
-
-    updateNodeRunnerInventory({
-      registry: nodeRegistry,
-      nodeId: "node-1",
-      connId: "conn-1",
-      declaration: {
-        protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE],
-        workerHost: { enabled: true, capacity: { total: 2, available: 0 }, environmentSession: 1 },
-      },
-    });
-    expect(nodeWorkerSupervisorTransport.isCurrent(proof, true)).toBe(false);
-    for (const command of [
-      NODE_WORKER_SUPERVISOR_LAUNCH_COMMAND,
-      NODE_WORKER_ENVIRONMENT_STOP_COMMAND,
-    ] as const) {
-      const invocation = nodeWorkerSupervisorTransport.invoke({
-        node: proof,
-        command,
+        command: NODE_WORKER_WORKSPACE_EXEC_COMMAND,
         isDispatchAuthorized: () => true,
       });
-      await vi.waitFor(() => expect(frames.at(-1)).toContain(command));
-      const dispatched = JSON.parse(frames.at(-1) ?? "{}") as { payload: { id: string } };
-      nodeRegistry.handleInvokeResult({
-        id: dispatched.payload.id,
-        nodeId: "node-1",
-        connId: "conn-1",
-        ok: true,
-        payloadJSON: "null",
+      await vi.waitFor(() => expect(frames).toHaveLength(1));
+      const request = JSON.parse(frames[0] ?? "{}") as { payload?: { id?: string } };
+      expect(
+        nodeRegistry.handleInvokeResult({
+          id: request.payload?.id ?? "",
+          nodeId: "node-1",
+          connId: "conn-1",
+          ok: true,
+          payloadJSON: "null",
+        }),
+      ).toBe(true);
+      await expect(workspaceInvoke).resolves.toMatchObject({ ok: true, payloadJSON: "null" });
+
+      await expect(
+        nodeWorkerSupervisorTransport.invoke({
+          node: proof,
+          command: NODE_WORKER_SUPERVISOR_LAUNCH_COMMAND,
+          isDispatchAuthorized: () => true,
+        }),
+      ).resolves.toMatchObject({
+        ok: false,
+        error: { code: "PRIVATE_DIALECT_UNAVAILABLE" },
       });
-      await expect(invocation).resolves.toMatchObject({ ok: true });
-    }
-  });
 
-  it("fences retained proofs when runner consent is disabled", async () => {
-    const frames: string[] = [];
-    const { nodeRegistry, nodeWorkerSupervisorTransport } = createPrivateNodeRegistryRuntime();
-    registerNodeSession(
-      nodeRegistry,
-      makeClient("conn-1", "node-1", frames, {
-        clientId: GATEWAY_CLIENT_IDS.NODE_HOST,
-        commands: ["system.run"],
-      }),
-      { pairingIdentity: "identity-a", pairingGeneration: "generation-a" },
-    );
-    expect(
       updateNodeRunnerInventory({
         registry: nodeRegistry,
         nodeId: "node-1",
         connId: "conn-1",
         declaration: {
           protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE],
-          workerHost: { enabled: true, capacity: { total: 2, available: 2 } },
+          workerHost: {
+            enabled: true,
+            capacity: { total: 2, available: 0 },
+            environmentSession: 1,
+          },
         },
-      }),
-    ).toEqual({ changed: true });
-    const [proof] = await nodeWorkerSupervisorTransport.listCurrentNodes();
-    if (!proof) {
-      throw new Error("expected current supervisor proof");
-    }
-    expect(
-      updateNodeRunnerInventory({
-        registry: nodeRegistry,
-        nodeId: "node-1",
-        connId: "conn-1",
-        declaration: {
-          protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE],
-          workerHost: { enabled: false },
-        },
-      }),
-    ).toEqual({ changed: true });
+      });
+      expect(nodeWorkerSupervisorTransport.isCurrent(proof, true)).toBe(false);
+      for (const command of [
+        NODE_WORKER_SUPERVISOR_LAUNCH_COMMAND,
+        NODE_WORKER_ENVIRONMENT_STOP_COMMAND,
+      ] as const) {
+        const invocation = nodeWorkerSupervisorTransport.invoke({
+          node: proof,
+          command,
+          isDispatchAuthorized: () => true,
+        });
+        await vi.waitFor(() => expect(frames.at(-1)).toContain(command));
+        const dispatched = JSON.parse(frames.at(-1) ?? "{}") as { payload: { id: string } };
+        nodeRegistry.handleInvokeResult({
+          id: dispatched.payload.id,
+          nodeId: "node-1",
+          connId: "conn-1",
+          ok: true,
+          payloadJSON: "null",
+        });
+        await expect(invocation).resolves.toMatchObject({ ok: true });
+      }
+    },
+  );
 
-    await expect(
-      nodeWorkerSupervisorTransport.invoke({
-        node: proof,
-        command: NODE_WORKER_SUPERVISOR_STATUS_COMMAND,
-        isDispatchAuthorized: () => true,
-      }),
-    ).resolves.toEqual({
-      ok: false,
-      error: {
-        code: "PRIVATE_DIALECT_UNAVAILABLE",
-        message: "node worker supervisor dialect is unavailable",
-      },
-    });
-    expect(frames).toEqual([]);
-  });
+  it.each([GATEWAY_CLIENT_IDS.NODE_HOST, GATEWAY_CLIENT_IDS.MACOS_APP])(
+    "fences retained proofs when runner consent is disabled (%s)",
+    async (clientId) => {
+      const frames: string[] = [];
+      const { nodeRegistry, nodeWorkerSupervisorTransport } = createPrivateNodeRegistryRuntime();
+      registerNodeSession(
+        nodeRegistry,
+        makeClient("conn-1", "node-1", frames, {
+          clientId,
+          commands: ["system.run"],
+        }),
+        { pairingIdentity: "identity-a", pairingGeneration: "generation-a" },
+      );
+      expect(
+        updateNodeRunnerInventory({
+          registry: nodeRegistry,
+          nodeId: "node-1",
+          connId: "conn-1",
+          declaration: {
+            protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE],
+            workerHost: { enabled: true, capacity: { total: 2, available: 2 } },
+          },
+        }),
+      ).toEqual({ changed: true });
+      const [proof] = await nodeWorkerSupervisorTransport.listCurrentNodes();
+      expect(proof?.clientId).toBe(clientId);
+      if (!proof) {
+        throw new Error("expected current supervisor proof");
+      }
+      expect(
+        updateNodeRunnerInventory({
+          registry: nodeRegistry,
+          nodeId: "node-1",
+          connId: "conn-1",
+          declaration: {
+            protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE],
+            workerHost: { enabled: false },
+          },
+        }),
+      ).toEqual({ changed: true });
+
+      await expect(
+        nodeWorkerSupervisorTransport.invoke({
+          node: proof,
+          command: NODE_WORKER_SUPERVISOR_STATUS_COMMAND,
+          isDispatchAuthorized: () => true,
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        error: {
+          code: "PRIVATE_DIALECT_UNAVAILABLE",
+          message: "node worker supervisor dialect is unavailable",
+        },
+      });
+      expect(frames).toEqual([]);
+    },
+  );
 
   it("promotes bundle prewarm without changing runner authority", async () => {
     const { nodeRegistry, nodeWorkerSupervisorTransport } = createPrivateNodeRegistryRuntime();
@@ -2916,11 +2972,15 @@ describe("gateway/node-registry", () => {
     ).toBe(false);
   });
 
-  it.each(["mcp.tools.call.v1", "system.run"])(
-    "forwards cancellation of first-party non-streaming %s calls",
-    async (command) => {
+  it.each(
+    [GATEWAY_CLIENT_IDS.NODE_HOST, GATEWAY_CLIENT_IDS.MACOS_APP].flatMap((clientId) =>
+      ["mcp.tools.call.v1", "system.run"].map((command) => ({ clientId, command })),
+    ),
+  )(
+    "forwards cancellation of first-party non-streaming $clientId $command calls",
+    async ({ clientId, command }) => {
       const registry = createNodeRegistry();
-      const frames = registerNode(registry, { clientId: GATEWAY_CLIENT_IDS.NODE_HOST });
+      const frames = registerNode(registry, { clientId });
       const controller = new AbortController();
       const invoke = registry.invoke({
         nodeId: "node-1",
@@ -2943,13 +3003,17 @@ describe("gateway/node-registry", () => {
     },
   );
 
-  it.each(["mcp.tools.call.v1", "system.run"])(
-    "forwards timeouts of first-party non-streaming %s calls",
-    async (command) => {
+  it.each(
+    [GATEWAY_CLIENT_IDS.NODE_HOST, GATEWAY_CLIENT_IDS.MACOS_APP].flatMap((clientId) =>
+      ["mcp.tools.call.v1", "system.run"].map((command) => ({ clientId, command })),
+    ),
+  )(
+    "forwards timeouts of first-party non-streaming $clientId $command calls",
+    async ({ clientId, command }) => {
       vi.useFakeTimers();
       try {
         const registry = createNodeRegistry();
-        const frames = registerNode(registry, { clientId: GATEWAY_CLIENT_IDS.NODE_HOST });
+        const frames = registerNode(registry, { clientId });
         const invoke = registry.invoke({ nodeId: "node-1", command, timeoutMs: 100 });
         const request = JSON.parse(frames[0] ?? "{}") as { payload?: { id?: string } };
 
@@ -2971,7 +3035,7 @@ describe("gateway/node-registry", () => {
 
   it("preserves legacy non-streaming node cancellation behavior", async () => {
     const registry = createNodeRegistry();
-    const frames = registerNode(registry);
+    const frames = registerNode(registry, { clientId: GATEWAY_CLIENT_IDS.IOS_APP });
     const controller = new AbortController();
     const invoke = registry.invoke({
       nodeId: "node-1",

--- a/src/gateway/node-registry.ts
+++ b/src/gateway/node-registry.ts
@@ -5,7 +5,6 @@ import {
   isFutureDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
 } from "@openclaw/normalization-core/number-coercion";
-import { GATEWAY_CLIENT_IDS } from "../../packages/gateway-protocol/src/client-info.js";
 // NodeSession is plugin-SDK-reachable; importing these types from the
 // gateway-protocol index would retain the whole ProtocolSchemas registry in
 // the public plugin-sdk dts (check-plugin-sdk-exports guards this).
@@ -46,6 +45,7 @@ import {
   type PendingInvoke,
   type PendingSystemRunEvent,
 } from "./node-registry.invoke-stream.js";
+import { isNodeWorkerHostClientId } from "./node-runner-inventory-runtime.js";
 import { normalizeNodeSkillDescriptors } from "./node-skill-descriptors.js";
 import { MAX_BUFFERED_BYTES, WEBSOCKET_OPEN_READY_STATE } from "./server-constants.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
@@ -232,7 +232,8 @@ export class NodeRegistry {
       if (
         !node ||
         node.connId !== pending.connId ||
-        (!pending.onProgress && node.clientId !== GATEWAY_CLIENT_IDS.NODE_HOST)
+        (!pending.onProgress &&
+          (!isNodeWorkerHostClientId(node.clientId) || node.clientMode !== "node"))
       ) {
         return;
       }

--- a/src/gateway/node-runner-inventory-runtime.ts
+++ b/src/gateway/node-runner-inventory-runtime.ts
@@ -7,6 +7,17 @@ import {
 } from "../infra/node-runner-inventory.js";
 import type { NodeWorkerBundleStatus } from "../shared/node-list-types.js";
 
+type NodeWorkerHostClientId =
+  | typeof GATEWAY_CLIENT_IDS.NODE_HOST
+  | typeof GATEWAY_CLIENT_IDS.MACOS_APP;
+
+/** Both first-party hosts run the shared node runtime without changing client identity. */
+export function isNodeWorkerHostClientId(
+  clientId: string | undefined,
+): clientId is NodeWorkerHostClientId {
+  return clientId === GATEWAY_CLIENT_IDS.NODE_HOST || clientId === GATEWAY_CLIENT_IDS.MACOS_APP;
+}
+
 export type NodeWorkerBundleStatusObservation = {
   bundleHash: string;
   status: NodeWorkerBundleStatus;
@@ -40,7 +51,7 @@ export type NodeWorkerSupervisorNodeProof = {
   connId: string;
   pairingIdentity: string;
   pairingGeneration: string;
-  clientId: typeof GATEWAY_CLIENT_IDS.NODE_HOST;
+  clientId: NodeWorkerHostClientId;
   clientMode: "node";
   protocolFeature: typeof NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE;
   workerHost: Extract<NodeWorkerHostDeclaration, { enabled: true }>;
@@ -125,7 +136,7 @@ export function resolveNodeWorkerSupervisorProof(
     !declaration ||
     !node.pairingIdentity ||
     !node.pairingGeneration ||
-    node.clientId !== GATEWAY_CLIENT_IDS.NODE_HOST ||
+    !isNodeWorkerHostClientId(node.clientId) ||
     node.clientMode !== "node" ||
     declaration.nodeId !== node.nodeId ||
     declaration.pairingIdentity !== node.pairingIdentity ||
@@ -142,7 +153,7 @@ export function resolveNodeWorkerSupervisorProof(
     connId: node.connId,
     pairingIdentity: node.pairingIdentity,
     pairingGeneration: node.pairingGeneration,
-    clientId: GATEWAY_CLIENT_IDS.NODE_HOST,
+    clientId: node.clientId,
     clientMode: "node",
     protocolFeature: NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE,
     workerHost: {
@@ -164,7 +175,9 @@ export function resolveNodeRunnerInventoryIssue(
     declaration.pairingIdentity === node.pairingIdentity &&
     declaration.pairingGeneration !== undefined &&
     declaration.pairingGeneration === node.pairingGeneration &&
-    declaration.clientId === GATEWAY_CLIENT_IDS.NODE_HOST &&
+    isNodeWorkerHostClientId(node.clientId) &&
+    declaration.clientId === node.clientId &&
+    node.clientMode === "node" &&
     declaration.clientMode === "node" &&
     declaration.protocolFeatures.length === 1 &&
     declaration.protocolFeatures[0] !== NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -640,8 +640,17 @@ export async function runWithGatewayRequestEnvelope<T>(
       return await withPluginRuntimeGatewayRequestScope(
         {
           context: options.context,
+          // Detached turn admission needs the live instance resolver, not a captured request context.
+          resolveGatewayContext: options.context.resolveGatewayContext,
           client,
           isWebchatConnect: options.isWebchatConnect,
+          // Only an owner-bound in-process stream may retain admitted Full authority.
+          ...(client?.internal?.nodeInvokeStream
+            ? {
+                invokeWithSessionNodeAuthority:
+                  getPluginRuntimeGatewayRequestScope()?.invokeWithSessionNodeAuthority,
+              }
+            : {}),
           ...(pluginRegistry ? { pluginRegistry } : {}),
         },
         fn,

--- a/src/gateway/server-methods/nodes.runner-inventory.test.ts
+++ b/src/gateway/server-methods/nodes.runner-inventory.test.ts
@@ -1,5 +1,6 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GATEWAY_CLIENT_IDS } from "../../../packages/gateway-protocol/src/client-info.js";
 import { NODE_WORKER_SUPERVISOR_STATUS_COMMAND } from "../../infra/node-commands.js";
 import {
   NODE_RUNNER_UPDATE_REQUIRED_ISSUE,
@@ -85,49 +86,82 @@ beforeEach(() => {
 });
 
 describe("nodeHandlers node.runnerInventory.update", () => {
-  it("publishes explicit runner consent and launch capacity for the authenticated node", async () => {
-    const inventoryChanged = vi.fn();
-    const runtime = createNodeRegistryRuntime(() => new NodeRegistry());
-    setNodeRunnerStateChangedListener(runtime.nodeRegistry, inventoryChanged);
-    const client = createWorkerSupervisorNodeClient();
-    runtime.nodeRegistry.register(client, {
-      pairingIdentity: "identity-1",
-      pairingGeneration: "generation-1",
-    });
-    const opts = runnerInventoryOptions({
-      nodeRegistry: runtime.nodeRegistry,
-      client,
-      declaration: availableHost,
-    });
+  it.each([GATEWAY_CLIENT_IDS.NODE_HOST, GATEWAY_CLIENT_IDS.MACOS_APP])(
+    "publishes explicit runner consent and launch capacity for authenticated %s",
+    async (clientId) => {
+      const inventoryChanged = vi.fn();
+      const runtime = createNodeRegistryRuntime(() => new NodeRegistry());
+      setNodeRunnerStateChangedListener(runtime.nodeRegistry, inventoryChanged);
+      const client = createWorkerSupervisorNodeClient();
+      const sent: string[] = [];
+      client.socket.send = (frame) => {
+        if (typeof frame !== "string") {
+          throw new Error("expected a JSON text frame");
+        }
+        sent.push(frame);
+      };
+      client.connect.client.id = clientId;
+      runtime.nodeRegistry.register(client, {
+        pairingIdentity: "identity-1",
+        pairingGeneration: "generation-1",
+      });
+      const opts = runnerInventoryOptions({
+        nodeRegistry: runtime.nodeRegistry,
+        client,
+        declaration: availableHost,
+      });
 
-    await runnerInventoryHandler(opts);
+      await runnerInventoryHandler(opts);
 
-    expect(opts.respond).toHaveBeenCalledWith(true, { nodeId: "node-1" }, undefined);
-    expect(updatePairedNodeSessionHostMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        nodeId: "node-1",
-        sessionHost: true,
-        expectedPairingGeneration: { nodeId: "node-1", key: "generation-1" },
-      }),
-    );
-    expect(inventoryChanged).toHaveBeenCalledWith("node-1", {
-      inventoryChanged: true,
-      availabilityChanged: true,
-    });
-    await expect(runtime.nodeWorkerSupervisorTransport.listCurrentNodes()).resolves.toEqual([
-      expect.objectContaining({
+      expect(opts.respond).toHaveBeenCalledWith(true, { nodeId: "node-1" }, undefined);
+      expect(updatePairedNodeSessionHostMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          nodeId: "node-1",
+          sessionHost: true,
+          expectedPairingGeneration: { nodeId: "node-1", key: "generation-1" },
+        }),
+      );
+      expect(inventoryChanged).toHaveBeenCalledWith("node-1", {
+        inventoryChanged: true,
+        availabilityChanged: true,
+      });
+      await expect(runtime.nodeWorkerSupervisorTransport.listCurrentNodes()).resolves.toEqual([
+        expect.objectContaining({
+          clientId,
+          nodeId: "node-1",
+          connId: "conn-1",
+          pairingGeneration: "generation-1",
+          workerHost: { enabled: true, capacity: AVAILABLE_CAPACITY, bundlePrewarm: 1 },
+        }),
+      ]);
+      expect(
+        collectNodeCatalogRuntimeState(runtime.nodeRegistry, [
+          { nodeId: "node-1", connId: "conn-1" },
+        ]).workerSlotsByNodeId,
+      ).toEqual(new Map([["node-1", AVAILABLE_CAPACITY]]));
+      const proof = expectDefined(
+        (await runtime.nodeWorkerSupervisorTransport.listCurrentNodes())[0],
+        "current authenticated runner proof",
+      );
+      const invocation = runtime.nodeWorkerSupervisorTransport.invoke({
+        node: proof,
+        command: NODE_WORKER_SUPERVISOR_STATUS_COMMAND,
+        isDispatchAuthorized: () => true,
+      });
+      const frame = JSON.parse(expectDefined(sent[0], "private invoke frame"));
+      expect(frame.payload.command).toBe(NODE_WORKER_SUPERVISOR_STATUS_COMMAND);
+      expect(runtime.nodeRegistry.get("node-1")?.clientId).toBe(clientId);
+      runtime.nodeRegistry.handleInvokeResult({
+        id: frame.payload.id,
         nodeId: "node-1",
         connId: "conn-1",
-        pairingGeneration: "generation-1",
-        workerHost: { enabled: true, capacity: AVAILABLE_CAPACITY, bundlePrewarm: 1 },
-      }),
-    ]);
-    expect(
-      collectNodeCatalogRuntimeState(runtime.nodeRegistry, [{ nodeId: "node-1", connId: "conn-1" }])
-        .workerSlotsByNodeId,
-    ).toEqual(new Map([["node-1", AVAILABLE_CAPACITY]]));
-    runtime.nodeRegistry.unregister("conn-1");
-  });
+        ok: true,
+        payloadJSON: "{}",
+      });
+      await expect(invocation).resolves.toMatchObject({ ok: true });
+      runtime.nodeRegistry.unregister("conn-1");
+    },
+  );
 
   it("stores bundle status only for the exact current node proof", async () => {
     const runtime = createNodeRegistryRuntime(() => new NodeRegistry());

--- a/src/gateway/worker-environments/device-provider.ts
+++ b/src/gateway/worker-environments/device-provider.ts
@@ -29,7 +29,7 @@ export type DeviceWorkerAvailability = {
   available: boolean;
   node?: NodeWorkerSupervisorNodeProof;
   issue?: NodeRunnerInventoryIssue;
-  unavailableReason?: "unpaired" | "disconnected" | "at-capacity";
+  unavailableReason?: "unpaired" | "disconnected" | "hosting-unavailable" | "at-capacity";
 };
 type DeviceWorkerAvailabilityResolver = (deviceId: string) => Promise<DeviceWorkerAvailability>;
 type DeviceWorkerReconciliation = (deviceId: string) => Promise<readonly string[]>;
@@ -60,6 +60,8 @@ export function deviceUnavailableText(deviceId: string, availability: DeviceWork
       return `device worker is not a paired node host: ${deviceId}`;
     case "disconnected":
       return `device worker node is not connected: ${deviceId}; reconnect it before retrying`;
+    case "hosting-unavailable":
+      return `device node ${deviceId} is connected but cannot host sessions; enable session hosting (nodeHost.workerRuns.enabled), update the node if needed, then reconnect it`;
     case "at-capacity":
       return `device worker is at capacity (all worker slots in use): ${deviceId}; stop an existing worker environment or retry when a slot is free`;
     default:
@@ -124,7 +126,9 @@ export function createDeviceWorkerRuntime(options: DeviceWorkerRuntimeOptions) {
     const unavailableReason = !hasPairedNodeRole(paired)
       ? "unpaired"
       : !current
-        ? "disconnected"
+        ? nodeTransport?.isConnected?.(deviceId)
+          ? "hosting-unavailable"
+          : "disconnected"
         : undefined;
     const issue = nodeTransport?.getIssue?.(deviceId);
     return {

--- a/src/gateway/worker-environments/worker-turn-launcher.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.test.ts
@@ -10,6 +10,7 @@ import {
   loadSessionEntry,
   upsertSessionEntryCore,
 } from "../../config/sessions/session-accessor.js";
+import { getPluginRuntimeGatewayRequestScope } from "../../plugins/runtime/gateway-request-scope.js";
 import { createChatRunState } from "../server-chat-state.js";
 import { prepareSessionArchiveLifecycle } from "../server-methods/sessions-archive-lifecycle.js";
 import type { GatewayRequestContext } from "../server-methods/types.js";
@@ -511,8 +512,55 @@ describe("worker turn launcher local placement", () => {
         startTunnel: vi.fn(async () => tunnel),
       };
       const provider = createWorkerSessionTurnPlacementProvider({ environments, placements });
+      let retainedNodeAuthority: (() => void) | undefined;
       const runLocal = vi.fn(async () => {
         order.push("local");
+        if (nodeDeviceId) {
+          const assertCurrent = getPluginRuntimeGatewayRequestScope()?.assertNodeExecutionCurrent;
+          expect(assertCurrent).toBeTypeOf("function");
+          const request = {
+            runId: "run-remote-exec",
+            agentId: "main",
+            nodeId: nodeDeviceId,
+            workspace: {
+              workspaceDir: "/worker/workspace",
+              environmentId: ENVIRONMENT_ID,
+              sessionId: SESSION_ID,
+              sessionKey: SESSION_KEY,
+              ownerEpoch: OWNER_EPOCH,
+            },
+          };
+          retainedNodeAuthority = () => assertCurrent!(request);
+          retainedNodeAuthority();
+          for (const changed of [
+            { ...request, runId: "other" },
+            { ...request, nodeId: "other" },
+            ...[
+              { ownerEpoch: OWNER_EPOCH + 1 },
+              { environmentId: "other" },
+              { sessionId: "other" },
+              { workspaceDir: "/other" },
+            ].map((workspace) =>
+              Object.assign({}, request, {
+                workspace: Object.assign({}, request.workspace, workspace),
+              }),
+            ),
+          ]) {
+            expect(() => assertCurrent!(changed)).toThrow("no longer current");
+          }
+          const original = environments.get(ENVIRONMENT_ID)!;
+          if (original.state !== "attached") {
+            throw new Error("expected an attached environment");
+          }
+          for (const changed of [
+            { ...original, nodeDeviceId: "replacement" },
+            { ...original, leaseId: "replacement" },
+          ]) {
+            vi.mocked(environments.get).mockReturnValueOnce(changed);
+            await Promise.resolve();
+            expect(retainedNodeAuthority).toThrow("no longer current");
+          }
+        }
         return { payloads: [{ text: "local remote reply" }], meta: { durationMs: 1 } };
       });
 
@@ -533,6 +581,9 @@ describe("worker turn launcher local placement", () => {
       expect(placements.listPendingWorkspaceResults()).toEqual([]);
       const placement = placements.get(SESSION_ID);
       expect([placement?.state, placement?.turnClaim]).toEqual(["active", null]);
+      if (retainedNodeAuthority) {
+        expect(retainedNodeAuthority).toThrow("no longer current");
+      }
     },
   );
 

--- a/src/gateway/worker-environments/workspace-result-finalize.ts
+++ b/src/gateway/worker-environments/workspace-result-finalize.ts
@@ -4,6 +4,10 @@ import type { SessionPlacementTurnParams } from "../../agents/session-placement-
 import { SessionManager } from "../../agents/sessions/session-manager.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { redactSensitiveText } from "../../logging/redact.js";
+import {
+  getPluginRuntimeGatewayRequestScope,
+  withPluginRuntimeGatewayRequestScope,
+} from "../../plugins/runtime/gateway-request-scope.js";
 import type {
   WorkerSessionPlacementRecord,
   WorkerSessionPlacementStore,
@@ -315,10 +319,52 @@ export async function executeRemoteExecTurn(params: {
   params.onHandoff();
   let result: EmbeddedAgentRunResult | undefined;
   let executionError: unknown;
+  let executionActive = true;
   try {
-    result = await params.runLocal();
+    result = await withPluginRuntimeGatewayRequestScope(
+      {
+        isWebchatConnect: () => false,
+        ...getPluginRuntimeGatewayRequestScope(),
+        assertNodeExecutionCurrent: (request) => {
+          const placement = params.placements.get(params.placement.sessionId);
+          const currentEnvironment = params.environments.get(environment.environmentId);
+          if (
+            !executionActive ||
+            params.turn.abortSignal?.aborted ||
+            !params.placements.validateTurnClaim(params.turnClaim) ||
+            request.runId !== params.turnClaim.runId ||
+            request.agentId !== params.placement.agentId ||
+            request.workspace.sessionId !== params.placement.sessionId ||
+            request.workspace.sessionKey !== params.placement.sessionKey ||
+            request.workspace.environmentId !== params.placement.environmentId ||
+            request.workspace.ownerEpoch !== params.placement.activeOwnerEpoch ||
+            request.workspace.workspaceDir !== params.placement.remoteWorkspaceDir ||
+            placement?.state !== "active" ||
+            placement.executionMode !== "remote-exec" ||
+            placement.generation !== params.turnClaim.placementGeneration ||
+            placement.sessionKey !== params.placement.sessionKey ||
+            placement.agentId !== params.placement.agentId ||
+            placement.environmentId !== params.placement.environmentId ||
+            placement.activeOwnerEpoch !== params.placement.activeOwnerEpoch ||
+            placement.remoteWorkspaceDir !== params.placement.remoteWorkspaceDir ||
+            currentEnvironment?.state !== "attached" ||
+            currentEnvironment.ownerEpoch !== environment.ownerEpoch ||
+            currentEnvironment.leaseId !== environment.leaseId ||
+            currentEnvironment.nodeDeviceId !== environment.nodeDeviceId ||
+            currentEnvironment.nodeDeviceId !== request.nodeId ||
+            currentEnvironment.attachedSessionIds.length !== 1 ||
+            currentEnvironment.attachedSessionIds[0] !== params.placement.sessionId
+          ) {
+            throw new Error("node execution placement authority is no longer current");
+          }
+        },
+      },
+      params.runLocal,
+    );
   } catch (error) {
     executionError = error;
+  } finally {
+    executionActive = false;
   }
   const workspaceConflict = await reconcileWorkspaceAfterTurn({
     placement: params.placement,

--- a/src/node-host/connection.ts
+++ b/src/node-host/connection.ts
@@ -1,0 +1,396 @@
+/** Connection-scoped publication shared by the CLI and native app node transports. */
+import { isDeepStrictEqual } from "node:util";
+import { GATEWAY_SERVER_CAPS } from "../../packages/gateway-protocol/src/schema/frames.js";
+import { WORKER_BUNDLE_PREWARM_VERSION } from "../../packages/gateway-protocol/src/schema/worker-admission.js";
+import { GatewayClientRequestError } from "../gateway/client.js";
+import {
+  NODE_RUNNER_INVENTORY_UPDATE_METHOD,
+  NODE_WORKER_BUNDLE_RETENTION_VERSION,
+  NODE_WORKER_BUNDLE_STATUS_VERSION,
+  NODE_WORKER_ENVIRONMENT_SESSION_VERSION,
+  NODE_WORKER_PORTAL_STREAM_VERSION,
+  NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE,
+  type NodeWorkerCapacitySnapshot,
+} from "../infra/node-runner-inventory.js";
+import type { NodeHostClient } from "./client.js";
+import type { prepareNodeHostRuntime, NodeHostInventory } from "./runtime.js";
+
+type PreparedRuntime = Awaited<ReturnType<typeof prepareNodeHostRuntime>>;
+export type NodeHostGatewayConnection = NonNullable<
+  Parameters<ReturnType<PreparedRuntime["start"]>["updateGatewayConnection"]>[0]
+> & {
+  protocol: number;
+  capabilities: string[];
+};
+
+const NODE_PLUGIN_TOOLS_UPDATE_METHOD = "node.pluginTools.update";
+const NODE_SKILLS_UPDATE_METHOD = "node.skills.update";
+const NODE_OPTIONAL_PUBLICATION_RETRY_INITIAL_MS = 250;
+const NODE_OPTIONAL_PUBLICATION_RETRY_MAX_MS = 5_000;
+
+function isExactUnknownMethodError(error: unknown, method: string): boolean {
+  return (
+    error instanceof GatewayClientRequestError &&
+    error.gatewayCode === "INVALID_REQUEST" &&
+    error.message === `unknown method: ${method}`
+  );
+}
+
+function isExactLegacyNodeAuthorizationError(
+  error: unknown,
+  method: string,
+  gatewayProtocol: number,
+): boolean {
+  const legacyUnknownMethodShape =
+    gatewayProtocol === 3 ||
+    (gatewayProtocol === 4 && method === NODE_RUNNER_INVENTORY_UPDATE_METHOD);
+  return (
+    legacyUnknownMethodShape &&
+    error instanceof GatewayClientRequestError &&
+    error.gatewayCode === "INVALID_REQUEST" &&
+    error.message === "unauthorized role: node"
+  );
+}
+
+function classifyNodeMethodFailure(
+  error: unknown,
+  method: string,
+  gatewayProtocol: number,
+): "legacy-unsupported" | "rejected" | "transient" {
+  if (
+    isExactUnknownMethodError(error, method) ||
+    isExactLegacyNodeAuthorizationError(error, method, gatewayProtocol)
+  ) {
+    return "legacy-unsupported";
+  }
+  if (error instanceof GatewayClientRequestError && error.gatewayCode === "INVALID_REQUEST") {
+    return "rejected";
+  }
+  return "transient";
+}
+
+type NodeOptionalPublicationMethod =
+  | typeof NODE_RUNNER_INVENTORY_UPDATE_METHOD
+  | typeof NODE_PLUGIN_TOOLS_UPDATE_METHOD
+  | typeof NODE_SKILLS_UPDATE_METHOD;
+
+type NodeOptionalPublicationState = {
+  status: "unknown" | "supported" | "unsupported";
+  hasPending: boolean;
+  pendingParams?: unknown;
+  hasPublishedParams: boolean;
+  publishedParams?: unknown;
+  hasRejectedParams: boolean;
+  rejectedParams?: unknown;
+  retryDelayMs: number;
+  retryPending: boolean;
+  retryTimer?: NodeJS.Timeout;
+  hasInFlightParams: boolean;
+  inFlightParams?: unknown;
+  inFlight?: Promise<void>;
+};
+
+export function startNodeHostConnection({
+  prepared,
+  client,
+  onManifestChanged,
+  writeStderrLine,
+}: {
+  prepared: PreparedRuntime;
+  client: NodeHostClient;
+  onManifestChanged: NonNullable<Parameters<PreparedRuntime["start"]>[0]["onManifestChanged"]>;
+  writeStderrLine: (message: string) => void;
+}) {
+  let publicationClient = client;
+  let workerHostingEnabled = prepared.workerHostingEnabled;
+  let inventory: NodeHostInventory = prepared.initialInventory;
+  let workerCapacity: NodeWorkerCapacitySnapshot | undefined;
+  let gatewayHelloReceived = false;
+  let gatewayConnectionGeneration = 0;
+  let connectedGatewayProtocol = 0;
+  let gatewayCapabilities: ReadonlySet<string> = new Set();
+  const optionalPublicationStates = new Map<
+    NodeOptionalPublicationMethod,
+    NodeOptionalPublicationState
+  >();
+  const retireOptionalPublications = () => {
+    for (const state of optionalPublicationStates.values()) {
+      if (state.retryTimer) {
+        clearTimeout(state.retryTimer);
+      }
+    }
+    optionalPublicationStates.clear();
+  };
+  const retireGatewayConnection = () => {
+    gatewayConnectionGeneration += 1;
+    gatewayHelloReceived = false;
+    connectedGatewayProtocol = 0;
+    gatewayCapabilities = new Set();
+    retireOptionalPublications();
+  };
+
+  const queueOptionalPublication = (
+    method: NodeOptionalPublicationMethod,
+    params: unknown,
+    label: string,
+    isRetry = false,
+  ): void => {
+    if (!gatewayHelloReceived) {
+      return;
+    }
+    const connectionGeneration = gatewayConnectionGeneration;
+    const gatewayProtocol = connectedGatewayProtocol;
+    const connectionClient = publicationClient;
+    const connectionIsCurrent = () => connectionGeneration === gatewayConnectionGeneration;
+    let state = optionalPublicationStates.get(method);
+    if (!state) {
+      state = {
+        status: "unknown",
+        hasPending: false,
+        hasPublishedParams: false,
+        hasRejectedParams: false,
+        retryDelayMs: NODE_OPTIONAL_PUBLICATION_RETRY_INITIAL_MS,
+        retryPending: false,
+        hasInFlightParams: false,
+      };
+      optionalPublicationStates.set(method, state);
+    }
+    if (state.hasInFlightParams && isDeepStrictEqual(state.inFlightParams, params)) {
+      // The latest desired value remains authoritative even when it matches the
+      // active request. Replace a newer pending value so A -> B -> A cannot publish B.
+      if (state.hasPending) {
+        state.pendingParams = params;
+      }
+      return;
+    }
+    if (
+      state.status === "unsupported" ||
+      (state.hasRejectedParams && isDeepStrictEqual(state.rejectedParams, params)) ||
+      (state.hasPending && isDeepStrictEqual(state.pendingParams, params)) ||
+      (!state.inFlight &&
+        state.hasPublishedParams &&
+        isDeepStrictEqual(state.publishedParams, params))
+    ) {
+      return;
+    }
+    if (state.retryTimer) {
+      clearTimeout(state.retryTimer);
+      state.retryTimer = undefined;
+    }
+    if (!isRetry) {
+      state.retryDelayMs = NODE_OPTIONAL_PUBLICATION_RETRY_INITIAL_MS;
+    }
+    state.hasRejectedParams = false;
+    state.rejectedParams = undefined;
+    state.pendingParams = params;
+    state.hasPending = true;
+    if (state.inFlight) {
+      return;
+    }
+    const publish = async () => {
+      while (state.hasPending && state.status !== "unsupported") {
+        if (!connectionIsCurrent()) {
+          return;
+        }
+        const nextParams = state.pendingParams;
+        state.pendingParams = undefined;
+        state.hasPending = false;
+        if (state.hasPublishedParams && isDeepStrictEqual(state.publishedParams, nextParams)) {
+          continue;
+        }
+        if (state.hasRejectedParams && !isDeepStrictEqual(state.rejectedParams, nextParams)) {
+          // A different value reopens publication. Keeping the old rejection
+          // would drop a later return to that value while this request is in flight.
+          state.hasRejectedParams = false;
+          state.rejectedParams = undefined;
+        }
+        state.inFlightParams = nextParams;
+        state.hasInFlightParams = true;
+        try {
+          await connectionClient.request(method, nextParams);
+          // Request settlement races reconnect teardown. Stale completions must
+          // not mutate or report against the retired connection.
+          if (!connectionIsCurrent()) {
+            return;
+          }
+          state.status = "supported";
+          state.publishedParams = nextParams;
+          state.hasPublishedParams = true;
+          state.hasRejectedParams = false;
+          state.rejectedParams = undefined;
+          state.retryDelayMs = NODE_OPTIONAL_PUBLICATION_RETRY_INITIAL_MS;
+          state.retryPending = false;
+        } catch (error) {
+          if (!connectionIsCurrent()) {
+            return;
+          }
+          const failure = classifyNodeMethodFailure(error, method, gatewayProtocol);
+          if (failure === "legacy-unsupported") {
+            state.status = "unsupported";
+            state.pendingParams = undefined;
+            state.hasPending = false;
+            state.retryPending = false;
+          } else {
+            writeStderrLine(`node host ${label} publish failed: ${String(error)}`);
+            if (failure === "rejected") {
+              state.hasRejectedParams = true;
+              state.rejectedParams = nextParams;
+              state.retryPending = false;
+              if (state.hasPending && isDeepStrictEqual(state.pendingParams, nextParams)) {
+                state.pendingParams = undefined;
+                state.hasPending = false;
+              }
+            } else {
+              // A timeout or transport failure can occur after the Gateway applied
+              // the update. Forget the acknowledged baseline so the next desired
+              // value is never skipped against an uncertain remote state.
+              state.hasPublishedParams = false;
+              state.publishedParams = undefined;
+              if (!state.hasPending || isDeepStrictEqual(state.pendingParams, nextParams)) {
+                state.pendingParams = nextParams;
+                state.hasPending = true;
+                state.retryPending = true;
+                break;
+              }
+            }
+          }
+        } finally {
+          state.inFlightParams = undefined;
+          state.hasInFlightParams = false;
+        }
+      }
+    };
+    const inFlight = publish().finally(() => {
+      if (state.inFlight === inFlight) {
+        state.inFlight = undefined;
+        if (
+          state.hasPending &&
+          state.status !== "unsupported" &&
+          gatewayHelloReceived &&
+          connectionIsCurrent()
+        ) {
+          const pendingParams = state.pendingParams;
+          const retryPending = state.retryPending;
+          state.retryPending = false;
+          if (retryPending) {
+            const retryDelayMs = state.retryDelayMs;
+            state.retryDelayMs = Math.min(retryDelayMs * 2, NODE_OPTIONAL_PUBLICATION_RETRY_MAX_MS);
+            state.retryTimer = setTimeout(() => {
+              state.retryTimer = undefined;
+              if (
+                state.hasPending &&
+                isDeepStrictEqual(state.pendingParams, pendingParams) &&
+                gatewayHelloReceived &&
+                connectionIsCurrent()
+              ) {
+                state.pendingParams = undefined;
+                state.hasPending = false;
+                queueOptionalPublication(method, pendingParams, label, true);
+              }
+            }, retryDelayMs);
+            state.retryTimer.unref?.();
+          } else {
+            state.pendingParams = undefined;
+            state.hasPending = false;
+            queueOptionalPublication(method, pendingParams, label);
+          }
+        }
+      }
+    });
+    state.inFlight = inFlight;
+  };
+
+  const publishInventory = () => {
+    if (!gatewayHelloReceived) {
+      return;
+    }
+    if (inventory.skills) {
+      queueOptionalPublication(NODE_SKILLS_UPDATE_METHOD, { skills: inventory.skills }, "skill");
+    }
+    queueOptionalPublication(
+      NODE_PLUGIN_TOOLS_UPDATE_METHOD,
+      { tools: inventory.pluginTools },
+      "plugin tool",
+    );
+  };
+
+  const publishRunnerInventory = () => {
+    queueOptionalPublication(
+      NODE_RUNNER_INVENTORY_UPDATE_METHOD,
+      {
+        protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE],
+        workerHost:
+          workerHostingEnabled && workerCapacity
+            ? {
+                enabled: true,
+                capacity: workerCapacity,
+                bundlePrewarm: WORKER_BUNDLE_PREWARM_VERSION,
+                ...(gatewayCapabilities.has(GATEWAY_SERVER_CAPS.NODE_WORKER_BUNDLE_RETENTION)
+                  ? { bundleRetention: NODE_WORKER_BUNDLE_RETENTION_VERSION }
+                  : {}),
+                ...(gatewayCapabilities.has(GATEWAY_SERVER_CAPS.NODE_WORKER_BUNDLE_RETENTION) &&
+                gatewayCapabilities.has(GATEWAY_SERVER_CAPS.NODE_WORKER_BUNDLE_STATUS)
+                  ? { bundleStatus: NODE_WORKER_BUNDLE_STATUS_VERSION }
+                  : {}),
+                ...(gatewayCapabilities.has(GATEWAY_SERVER_CAPS.NODE_WORKER_PORTAL_STREAM)
+                  ? { portalStream: NODE_WORKER_PORTAL_STREAM_VERSION }
+                  : {}),
+                ...(gatewayCapabilities.has(GATEWAY_SERVER_CAPS.NODE_WORKER_ENVIRONMENT_SESSION)
+                  ? { environmentSession: NODE_WORKER_ENVIRONMENT_SESSION_VERSION }
+                  : {}),
+              }
+            : { enabled: false },
+      },
+      "runner inventory",
+    );
+  };
+
+  const disconnect = () => {
+    retireGatewayConnection();
+    runtime.updateGatewayConnection();
+    runtime.cancelAll();
+  };
+  const runtime = prepared.start({
+    client,
+    onInventoryChanged: (nextInventory) => {
+      inventory = nextInventory;
+      publishInventory();
+    },
+    onRunnerCapacityChanged: (capacity) => {
+      workerCapacity = capacity;
+      publishRunnerInventory();
+    },
+    onWorkerHostingDisabled: (reason) => {
+      workerHostingEnabled = false;
+      writeStderrLine(`node host worker hosting disabled: ${reason}`);
+      publishRunnerInventory();
+    },
+    onManifestChanged: (manifest) => {
+      retireGatewayConnection();
+      onManifestChanged(manifest);
+    },
+  });
+  return {
+    ...runtime,
+    connect(connection: NodeHostGatewayConnection, connectionClient: NodeHostClient = client) {
+      retireGatewayConnection();
+      publicationClient = connectionClient;
+      runtime.updateGatewayConnection({
+        url: connection.url,
+        ...(connection.tlsFingerprint ? { tlsFingerprint: connection.tlsFingerprint } : {}),
+        ...(connection.cloudflareAccess ? { cloudflareAccess: connection.cloudflareAccess } : {}),
+      });
+      gatewayHelloReceived = true;
+      connectedGatewayProtocol = connection.protocol;
+      gatewayCapabilities = new Set(connection.capabilities);
+      publishRunnerInventory();
+      publishInventory();
+    },
+    disconnect,
+    close() {
+      retireGatewayConnection();
+      runtime.updateGatewayConnection();
+      return runtime.close();
+    },
+  };
+}

--- a/src/node-host/exec-policy.ts
+++ b/src/node-host/exec-policy.ts
@@ -1,5 +1,31 @@
 /** Evaluates node-host exec policy from security, approval, and allowlist context. */
-import { requiresExecApproval, type ExecAsk, type ExecSecurity } from "../infra/exec-approvals.js";
+import { resolveAgentConfig } from "../agents/agent-scope-config.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  requiresExecApproval,
+  resolveExecModePolicy,
+  type ExecAsk,
+  type ExecSecurity,
+} from "../infra/exec-approvals.js";
+import { applyExecPolicyLayer } from "../infra/exec-policy.js";
+
+/** One config owner for system.run and plugin-hosted execution. */
+export function resolveNodeExecConfigPolicy(params: {
+  cfg: OpenClawConfig;
+  agentId: string | undefined;
+  defaultSecurity: ExecSecurity;
+  defaultAsk: ExecAsk;
+}) {
+  const agentExec = params.agentId
+    ? resolveAgentConfig(params.cfg, params.agentId)?.tools?.exec
+    : undefined;
+  const globalExec = params.cfg.tools?.exec;
+  const layered = applyExecPolicyLayer(
+    applyExecPolicyLayer({ security: params.defaultSecurity, ask: params.defaultAsk }, globalExec),
+    agentExec,
+  );
+  return { agentExec, globalExec, ...resolveExecModePolicy(layered) };
+}
 
 type ExecApprovalDecision = "allow-once" | "allow-always" | null;
 

--- a/src/node-host/invoke-agent-cli-claude.test.ts
+++ b/src/node-host/invoke-agent-cli-claude.test.ts
@@ -2,6 +2,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "../config/runtime-snapshot.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import type { NodeHostClient } from "./client.js";
 import { decodeClaudeCliNodeRunParams } from "./invoke-agent-cli-claude-params.js";
@@ -11,6 +15,7 @@ import { handleInvoke, type NodeInvokeRequestPayload } from "./invoke.js";
 const tempDirs: string[] = [];
 
 afterEach(async () => {
+  clearRuntimeConfigSnapshot();
   await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
 });
 
@@ -212,55 +217,67 @@ describe("Claude CLI node command", () => {
     });
   });
 
-  it("consults the system.run approval surface with a prompt-free command", async () => {
-    const executable = await executableScript("process.exit(0);");
-    const calls: Array<{ method: string; params: unknown }> = [];
-    const handleSystemRun = vi.fn(
-      async (options: {
-        params: { command: string[] };
-        sendNodeEvent: (client: NodeHostClient, event: string, payload: unknown) => Promise<void>;
-        sendExecFinishedEvent: (params: unknown) => Promise<void>;
-        sendInvokeResult: (result: unknown) => Promise<void>;
-      }) => {
-        expect(options.params.command).toEqual([executable, "-p", "--resume", "session-1"]);
-        await options.sendNodeEvent(client(calls), "exec.denied", {});
-        await options.sendExecFinishedEvent({});
-        await options.sendInvokeResult({
-          ok: false,
-          error: { code: "UNAVAILABLE", message: "SYSTEM_RUN_DENIED: approval required" },
-        });
-      },
-    );
-    await handleInvoke(
-      frame({
-        argv: ["-p", "--resume", "session-1"],
-        systemPrompt: "private prompt",
-        idleTimeoutMs: 1_000,
-        timeoutMs: 2_000,
-      }),
-      client(calls),
-      { current: async () => [] },
-      undefined,
-      { claudePath: executable, handleSystemRun: handleSystemRun as never },
-    );
-
-    expect(handleSystemRun).toHaveBeenCalledOnce();
-    expect(calls.some((call) => call.method === "node.event")).toBe(false);
-    expect(JSON.stringify(calls)).not.toContain("private prompt");
-    const response = calls.find((call) => call.method === "node.invoke.result")?.params as {
-      ok?: boolean;
-      payloadJSON?: string;
-    };
-    expect(response.ok).toBe(true);
-    expect(JSON.parse(response.payloadJSON ?? "{}")).toMatchObject({
-      approvalRequired: true,
+  it.each([
+    { name: "unconfigured", config: {}, security: "full", ask: "off" },
+    {
+      name: "explicit ask",
+      config: { tools: { exec: { mode: "ask" } } },
       security: "allowlist",
       ask: "on-miss",
-      systemRunPlan: {
-        argv: [executable, "-p", "--resume", "session-1"],
-      },
-    });
-  });
+    },
+  ] as const)(
+    "consults the system.run approval surface with a prompt-free command ($name)",
+    async ({ config, security, ask }) => {
+      setRuntimeConfigSnapshot(config);
+      const executable = await executableScript("process.exit(0);");
+      const calls: Array<{ method: string; params: unknown }> = [];
+      const handleSystemRun = vi.fn(
+        async (options: {
+          params: { command: string[] };
+          sendNodeEvent: (client: NodeHostClient, event: string, payload: unknown) => Promise<void>;
+          sendExecFinishedEvent: (params: unknown) => Promise<void>;
+          sendInvokeResult: (result: unknown) => Promise<void>;
+        }) => {
+          expect(options.params.command).toEqual([executable, "-p", "--resume", "session-1"]);
+          await options.sendNodeEvent(client(calls), "exec.denied", {});
+          await options.sendExecFinishedEvent({});
+          await options.sendInvokeResult({
+            ok: false,
+            error: { code: "UNAVAILABLE", message: "SYSTEM_RUN_DENIED: approval required" },
+          });
+        },
+      );
+      await handleInvoke(
+        frame({
+          argv: ["-p", "--resume", "session-1"],
+          systemPrompt: "private prompt",
+          idleTimeoutMs: 1_000,
+          timeoutMs: 2_000,
+        }),
+        client(calls),
+        { current: async () => [] },
+        undefined,
+        { claudePath: executable, handleSystemRun: handleSystemRun as never },
+      );
+
+      expect(handleSystemRun).toHaveBeenCalledOnce();
+      expect(calls.some((call) => call.method === "node.event")).toBe(false);
+      expect(JSON.stringify(calls)).not.toContain("private prompt");
+      const response = calls.find((call) => call.method === "node.invoke.result")?.params as {
+        ok?: boolean;
+        payloadJSON?: string;
+      };
+      expect(response.ok).toBe(true);
+      expect(JSON.parse(response.payloadJSON ?? "{}")).toMatchObject({
+        approvalRequired: true,
+        security,
+        ask,
+        systemRunPlan: {
+          argv: [executable, "-p", "--resume", "session-1"],
+        },
+      });
+    },
+  );
 
   it("converts forwarded OAuth into a child-only descriptor after approval", async () => {
     const executable = await executableScript(`

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -1,4 +1,5 @@
 /** Builds and revalidates system.run approval plans for cwd and executable paths. */
+import fs from "node:fs";
 import { normalizeNullableString } from "@openclaw/normalization-core/string-coerce";
 import type { SystemRunApprovalPlan } from "../infra/exec-approvals.js";
 import { resolveCommandResolutionFromArgv } from "../infra/exec-command-resolution.js";
@@ -92,13 +93,16 @@ export function hardenApprovedExecutionPaths(params: {
   return { ok: true, argv, argvChanged: true, cwd: hardenedCwd, approvedCwdSnapshot };
 }
 
-export function buildSystemRunApprovalPlan(params: {
-  command?: unknown;
-  rawCommand?: unknown;
-  cwd?: unknown;
-  agentId?: unknown;
-  sessionKey?: unknown;
-}): { ok: true; plan: SystemRunApprovalPlan } | { ok: false; message: string } {
+export function buildSystemRunApprovalPlan(
+  params: {
+    command?: unknown;
+    rawCommand?: unknown;
+    cwd?: unknown;
+    agentId?: unknown;
+    sessionKey?: unknown;
+  },
+  bindApproval = true,
+): { ok: true; plan: SystemRunApprovalPlan } | { ok: false; message: string } {
   const command = resolveSystemRunCommandRequest({
     command: params.command,
     rawCommand: params.rawCommand,
@@ -109,17 +113,29 @@ export function buildSystemRunApprovalPlan(params: {
   if (command.argv.length === 0) {
     return { ok: false, message: "command required" };
   }
-  if (command.shellPayload === null && isBlockedShellWrapperCommand(command.argv)) {
+  if (bindApproval && command.shellPayload === null && isBlockedShellWrapperCommand(command.argv)) {
     return {
       ok: false,
       message: "SYSTEM_RUN_DENIED: approval cannot safely bind this interpreter/runtime command",
     };
   }
+  let cwd = normalizeNullableString(params.cwd) ?? undefined;
+  if (!bindApproval) {
+    // Ordinary execution follows aliases once; approval binding keeps its stricter path checks.
+    try {
+      cwd = fs.realpathSync(cwd ?? process.cwd());
+    } catch {
+      return {
+        ok: false,
+        message: "SYSTEM_RUN_DENIED: working directory does not exist or is inaccessible",
+      };
+    }
+  }
   const hardening = hardenApprovedExecutionPaths({
-    approvedByAsk: true,
+    approvedByAsk: bindApproval,
     argv: command.argv,
     shellCommand: command.shellPayload,
-    cwd: normalizeNullableString(params.cwd) ?? undefined,
+    cwd,
   });
   if (!hardening.ok) {
     return hardening;
@@ -129,11 +145,13 @@ export function buildSystemRunApprovalPlan(params: {
     command.previewText?.trim() && command.previewText.trim() !== commandText
       ? command.previewText.trim()
       : null;
-  const mutableFileOperand = resolveMutableFileOperandSnapshotSync({
-    argv: hardening.argv,
-    cwd: hardening.cwd,
-    shellCommand: command.shellPayload,
-  });
+  const mutableFileOperand = bindApproval
+    ? resolveMutableFileOperandSnapshotSync({
+        argv: hardening.argv,
+        cwd: hardening.cwd,
+        shellCommand: command.shellPayload,
+      })
+    : { ok: true as const, snapshot: null };
   if (!mutableFileOperand.ok) {
     return mutableFileOperand;
   }

--- a/src/node-host/invoke-system-run.test.ts
+++ b/src/node-host/invoke-system-run.test.ts
@@ -277,7 +277,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     expect(requireInvokeResult(params.sendInvokeResult)).toMatchObject({
       ok: false,
       error: {
-        code: "UNAVAILABLE",
+        code: "SYSTEM_RUN_DENIED",
         message: "SYSTEM_RUN_DENIED: approval state could not be persisted",
       },
     });
@@ -547,6 +547,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
 
   async function runSystemInvoke(params: {
     preferMacAppExecHost: boolean;
+    execHostFallbackAllowed?: boolean;
     runViaResponse?: ExecHostResponse | null;
     command?: string[];
     env?: Record<string, string>;
@@ -647,7 +648,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       },
       signal: params.signal,
       execHostEnforced: false,
-      execHostFallbackAllowed: true,
+      execHostFallbackAllowed: params.execHostFallbackAllowed ?? true,
       resolveExecSecurity: params.resolveExecSecurity ?? (() => params.security ?? "full"),
       resolveExecAsk: params.resolveExecAsk ?? (() => params.ask ?? "off"),
       isCmdExeInvocation: params.isCmdExeInvocation ?? (() => false),
@@ -697,6 +698,31 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
   ) {
     return await runMacSystemInvoke({ ...params, security, ask });
   }
+
+  it("preserves a native cwd refusal without labelling it approval-required", async () => {
+    const result = await runMacSystemInvoke({
+      runViaResponse: {
+        ok: false,
+        error: {
+          code: "UNAVAILABLE",
+          reason: "cwd-unavailable",
+          message: "Working directory does not exist, is inaccessible, or is not a directory.",
+        },
+      },
+    });
+    expectExecDeniedEvent(result.sendNodeEvent, "cwd-unavailable");
+    expect(result.runCommand).not.toHaveBeenCalled();
+  });
+
+  it("keeps a lost companion response ambiguous", async () => {
+    const result = await runMacSystemInvoke({ execHostFallbackAllowed: false });
+    expect(result.runViaMacAppExecHost).toHaveBeenCalledOnce();
+    expect(result.runCommand).not.toHaveBeenCalled();
+    expect(requireInvokeResult(result.sendInvokeResult)).toMatchObject({
+      ok: false,
+      error: { code: "UNAVAILABLE" },
+    });
+  });
 
   it("forwards cancellation to locally spawned node commands", async () => {
     const controller = new AbortController();

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -1,7 +1,6 @@
 /** Policy and execution pipeline for approved node-host system.run requests. */
 import crypto from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { resolveAgentConfig } from "../agents/agent-scope-config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   describeInterpreterInlineEval,
@@ -21,7 +20,6 @@ import {
   resolveAllowAlwaysPersistenceDecision,
   resolveDurableExecApprovalRequirement,
   resolveExecApprovalsLocked,
-  resolveExecModePolicy,
   type ExecAllowlistEntry,
   type ExecApprovalUsageAuthorization,
   type ExecApprovalPolicySnapshot,
@@ -35,7 +33,6 @@ import {
 import type { ExecAuthorizationPlan } from "../infra/exec-authorization-plan.js";
 import { resolveExecAutoReviewDecision, type ExecAutoReviewer } from "../infra/exec-auto-review.js";
 import type { ExecHostRequest, ExecHostResponse, ExecHostRunResult } from "../infra/exec-host.js";
-import { applyExecPolicyLayer } from "../infra/exec-policy.js";
 import { resolveExecSafeBinRuntimePolicy } from "../infra/exec-safe-bin-runtime-policy.js";
 import {
   extractEnvAssignmentKeysFromDispatchWrappers,
@@ -62,7 +59,11 @@ import {
 } from "../infra/system-run-cwd-binding.js";
 import { logWarn } from "../logger.js";
 import type { NodeHostClient } from "./client.js";
-import { evaluateSystemRunPolicy, resolveExecApprovalDecision } from "./exec-policy.js";
+import {
+  evaluateSystemRunPolicy,
+  resolveExecApprovalDecision,
+  resolveNodeExecConfigPolicy,
+} from "./exec-policy.js";
 import {
   applyOutputTruncation,
   evaluateSystemRunAllowlist,
@@ -92,6 +93,7 @@ type SystemRunDeniedReason =
   | "allowlist-miss"
   | "execution-plan-miss"
   | "companion-unavailable"
+  | "cwd-unavailable"
   | "permission:screenRecording";
 
 type SystemRunExecutionContext = {
@@ -184,21 +186,12 @@ function normalizeDeniedReason(reason: string | null | undefined): SystemRunDeni
     case "allowlist-miss":
     case "execution-plan-miss":
     case "companion-unavailable":
+    case "cwd-unavailable":
     case "permission:screenRecording":
       return reason;
     default:
       return "approval-required";
   }
-}
-
-function resolveAgentExecConfig(
-  cfg: OpenClawConfig,
-  agentId: string | undefined,
-): ExecToolConfig | undefined {
-  if (!agentId) {
-    return undefined;
-  }
-  return resolveAgentConfig(cfg, agentId)?.tools?.exec;
 }
 
 /** Resolves the effective exec security/ask policy for one system.run request. */
@@ -209,23 +202,8 @@ export async function resolveEffectiveSystemRunExecPolicy(params: {
   defaultAsk: ExecAsk;
   requireSocket: boolean;
 }): Promise<EffectiveSystemRunExecPolicy> {
-  const agentExec = resolveAgentExecConfig(params.cfg, params.agentId);
-  const globalExec = params.cfg.tools?.exec;
-  const layeredPolicy = applyExecPolicyLayer(
-    applyExecPolicyLayer(
-      {
-        security: params.defaultSecurity,
-        ask: params.defaultAsk,
-      },
-      globalExec,
-    ),
-    agentExec,
-  );
-  const modePolicy = resolveExecModePolicy({
-    mode: layeredPolicy.mode,
-    security: layeredPolicy.security,
-    ask: layeredPolicy.ask,
-  });
+  const modePolicy = resolveNodeExecConfigPolicy(params);
+  const { agentExec, globalExec } = modePolicy;
   const approvals = await resolveExecApprovalsLocked(params.agentId, {
     security: modePolicy.security,
     ask: modePolicy.ask,
@@ -325,7 +303,11 @@ async function sendSystemRunDenied(
   );
   await opts.sendInvokeResult({
     ok: false,
-    error: { code: "UNAVAILABLE", message: params.message },
+    // A missing companion reply can follow execution; it is not a policy denial.
+    error: {
+      code: params.reason === "companion-unavailable" ? "UNAVAILABLE" : "SYSTEM_RUN_DENIED",
+      message: params.message,
+    },
   });
 }
 
@@ -912,13 +894,17 @@ async function executeSystemRunPhase(
   if (!(await revalidateSystemRunApprovedPathBindings(opts, phase))) {
     return;
   }
-  const expectedMutableFileOperand = phase.approvalPlan
-    ? resolveMutableFileOperandSnapshotSync({
-        argv: phase.argv,
-        cwd: phase.cwd,
-        shellCommand: phase.shellPayload,
-      })
-    : null;
+  const expectedMutableFileOperand =
+    phase.approvalPlan &&
+    (phase.policy.approvedByAsk ||
+      phase.approvalSource !== undefined ||
+      phase.security === "allowlist")
+      ? resolveMutableFileOperandSnapshotSync({
+          argv: phase.argv,
+          cwd: phase.cwd,
+          shellCommand: phase.shellPayload,
+        })
+      : null;
   if (expectedMutableFileOperand && !expectedMutableFileOperand.ok) {
     logWarn(`security: system.run approval script binding blocked (runId=${phase.runId})`);
     await sendSystemRunDenied(opts, phase.execution, {

--- a/src/node-host/invoke.test.ts
+++ b/src/node-host/invoke.test.ts
@@ -14,6 +14,7 @@ import type {
 } from "../plugins/types.node-host.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { withEnvAsync } from "../test-utils/env.js";
+import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import type { SkillBinsProvider } from "./invoke-types.js";
 import { handleInvoke } from "./invoke.js";
 
@@ -195,6 +196,7 @@ describe("node host invoke", () => {
     expect(handle).toHaveBeenCalledWith("{}", undefined, {
       sendNodeEvent,
       sessionKey: "agent:main:canvas",
+      prepareExecAuthorization: expect.any(Function),
     });
   });
 
@@ -957,6 +959,50 @@ describe("node host invoke", () => {
     expect(request).toHaveBeenCalledTimes(1);
   });
 
+  it.each(["system.run", "agent.cli.claude.run.v1"])(
+    "executes %s with omitted exec config and full/off host approvals",
+    async (command) => {
+      const state = await createOpenClawTestState({ label: "node-default-policy" });
+      try {
+        await state.writeConfig({});
+        saveExecApprovals({ version: 1, defaults: { security: "full", ask: "off" } });
+        const executable = path.join(fs.realpathSync(state.root), "native-agent.cjs");
+        fs.writeFileSync(executable, `#!${process.execPath}\nprocess.stdout.write('ok');\n`, {
+          mode: 0o700,
+        });
+        const request = vi.fn<GatewayClient["request"]>().mockResolvedValue(null);
+        await handleInvoke(
+          {
+            id: "default-policy",
+            nodeId: "node-1",
+            command,
+            paramsJSON: JSON.stringify(
+              command === "system.run"
+                ? { command: [process.execPath, "--version"] }
+                : { argv: ["-p"], timeoutMs: 5000, idleTimeoutMs: 1000 },
+            ),
+          },
+          {
+            request: async <T>(...args: Parameters<GatewayClient["request"]>) => {
+              await request(...args);
+              return {} as T;
+            },
+          },
+          { current: async () => [] },
+          undefined,
+          { claudePath: executable },
+        );
+        const result = request.mock.calls.find(
+          ([method]) => method === "node.invoke.result",
+        )?.[1] as InvokeResult;
+        expect(result).toMatchObject({ ok: true });
+        expect(JSON.parse(result.payloadJSON ?? "{}")).toMatchObject({ exitCode: 0 });
+      } finally {
+        await state.cleanup();
+      }
+    },
+  );
+
   it("includes effective exec policy in system.run.prepare responses", async () => {
     const request = vi.fn<GatewayClient["request"]>().mockResolvedValue(null);
     const skillBins: SkillBinsProvider = { current: async () => [] };
@@ -991,7 +1037,7 @@ describe("node host invoke", () => {
       execPolicy?: { security?: string; ask?: string };
       plan?: { policySnapshot?: unknown };
     };
-    expect(payload.execPolicy).toEqual({ security: "allowlist", ask: "on-miss" });
+    expect(payload.execPolicy).toEqual({ security: "full", ask: "off" });
     // The plan snapshot binds persisted approval state. Effective config-layer
     // policy is returned separately above and re-evaluated at execution.
     expect(payload.plan?.policySnapshot).toEqual({

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -2,14 +2,20 @@
 import fs from "node:fs";
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalString,
+} from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { DEFAULT_ASK, DEFAULT_SECURITY } from "../infra/exec-approvals-config.js";
 import {
   analyzeArgvCommand,
   createExecApprovalPolicySnapshot,
   ensureExecApprovalsSnapshot,
   mergeExecApprovalsSocketDefaults,
+  minSecurity,
+  maxAsk,
   normalizeExecApprovals,
   readExecApprovalsSnapshot,
   redactExecApprovals,
@@ -112,6 +118,8 @@ type SystemExecApprovalsSetParams = {
 };
 
 type SystemRunPrepareParams = {
+  security?: ExecSecurity;
+  ask?: ExecAsk;
   command?: unknown;
   rawCommand?: unknown;
   cwd?: unknown;
@@ -247,7 +255,7 @@ type ExecApprovalsSnapshot = {
 export type { NodeInvokeRequestPayload, SkillBinsProvider } from "./invoke-types.js";
 
 function resolveExecSecurity(value?: string): ExecSecurity {
-  return value === "deny" || value === "allowlist" || value === "full" ? value : "allowlist";
+  return value === "deny" || value === "allowlist" || value === "full" ? value : DEFAULT_SECURITY;
 }
 
 function isCmdExeInvocation(argv: string[]): boolean {
@@ -260,7 +268,7 @@ function isCmdExeInvocation(argv: string[]): boolean {
 }
 
 function resolveExecAsk(value?: string): ExecAsk {
-  return value === "off" || value === "on-miss" || value === "always" ? value : "on-miss";
+  return value === "off" || value === "on-miss" || value === "always" ? value : DEFAULT_ASK;
 }
 
 /** Builds a sanitized execution environment with controlled PATH and approved overrides. */
@@ -858,7 +866,25 @@ async function dispatchInvoke(
         decodeParams<SystemRunPrepareParams>(frame.paramsJSON),
         frame.nodeId,
       );
-      const prepared = buildSystemRunApprovalPlan(params);
+      const { getRuntimeConfig } = await import("../config/config.js");
+      const execPolicy = await resolveEffectiveSystemRunExecPolicy({
+        cfg: getRuntimeConfig(),
+        agentId: normalizeOptionalString(params.agentId),
+        defaultSecurity: resolveExecSecurity(undefined),
+        defaultAsk: resolveExecAsk(undefined),
+        requireSocket: preferMacAppExecHost,
+      });
+      // Omitted caller policy retains the approval-preparation contract. A caller can
+      // narrow local policy, but cannot turn a restrictive node into an ordinary launch.
+      const bindApproval =
+        params.security === undefined ||
+        params.ask === undefined ||
+        minSecurity(execPolicy.security, resolveExecSecurity(params.security)) !== "full" ||
+        maxAsk(execPolicy.ask, resolveExecAsk(params.ask)) !== "off" ||
+        params.strictInlineEval === true ||
+        execPolicy.agentExec?.strictInlineEval === true ||
+        execPolicy.globalExec?.strictInlineEval === true;
+      const prepared = buildSystemRunApprovalPlan(params, bindApproval);
       if (!prepared.ok) {
         await sendErrorResult(client, frame, "INVALID_REQUEST", prepared.message);
         return;
@@ -871,14 +897,6 @@ async function dispatchInvoke(
         await sendErrorResult(client, frame, "INVALID_REQUEST", prepareEnv.message);
         return;
       }
-      const { getRuntimeConfig } = await import("../config/config.js");
-      const execPolicy = await resolveEffectiveSystemRunExecPolicy({
-        cfg: getRuntimeConfig(),
-        agentId: prepared.plan.agentId ?? undefined,
-        defaultSecurity: resolveExecSecurity(undefined),
-        defaultAsk: resolveExecAsk(undefined),
-        requireSocket: preferMacAppExecHost,
-      });
       const plan = {
         ...prepared.plan,
         policySnapshot: createExecApprovalPolicySnapshot({
@@ -892,13 +910,15 @@ async function dispatchInvoke(
           security: execPolicy.security,
           ask: execPolicy.ask,
         },
-        allowAlwaysCoverage: await buildSystemRunAllowAlwaysCoverage({
-          argv: prepared.plan.argv,
-          rawCommand: typeof params.rawCommand === "string" ? params.rawCommand : null,
-          cwd: prepared.plan.cwd,
-          env: prepareEnv.env,
-          strictInlineEval: params.strictInlineEval === true,
-        }),
+        allowAlwaysCoverage: bindApproval
+          ? await buildSystemRunAllowAlwaysCoverage({
+              argv: prepared.plan.argv,
+              rawCommand: typeof params.rawCommand === "string" ? params.rawCommand : null,
+              cwd: prepared.plan.cwd,
+              env: prepareEnv.env,
+              strictInlineEval: params.strictInlineEval === true,
+            })
+          : { complete: false, patterns: [] },
       });
     } catch (err) {
       await sendInvalidRequestResult(client, frame, err);

--- a/src/node-host/plugin-exec-policy.test.ts
+++ b/src/node-host/plugin-exec-policy.test.ts
@@ -1,0 +1,136 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "../config/runtime-snapshot.js";
+import { saveExecApprovals, type ExecAsk, type ExecSecurity } from "../infra/exec-approvals.js";
+import { createPluginRecord } from "../plugins/loader-records.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { invokeRegisteredNodeHostCommand } from "./plugin-node-host.js";
+
+let root: string;
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "node-plugin-exec-policy-"));
+  vi.stubEnv("OPENCLAW_STATE_DIR", root);
+  setRuntimeConfigSnapshot({});
+  saveExecApprovals({ version: 1, defaults: { security: "full", ask: "off" } });
+});
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  clearRuntimeConfigSnapshot();
+  resetPluginRuntimeStateForTest();
+  vi.unstubAllEnvs();
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+function launch(source: "session-full" | "human-approved", whilePreparing: () => void = () => {}) {
+  const spawn = vi.fn();
+  const controller = new AbortController();
+  const registry = createEmptyPluginRegistry();
+  registry.plugins.push(
+    createPluginRecord({
+      id: "fixture",
+      source: "fixture",
+      origin: "bundled",
+      enabled: true,
+      configSchema: true,
+    }),
+  );
+  registry.nodeHostCommands.push({
+    pluginId: "fixture",
+    pluginName: "Fixture",
+    source: "fixture",
+    command: {
+      command: "fixture.exec",
+      dangerous: true,
+      handle: async (_params, _io, context) => {
+        const assertAuthorized = context!.prepareExecAuthorization!(source);
+        await Promise.resolve();
+        whilePreparing();
+        assertAuthorized();
+        spawn();
+        return "{}";
+      },
+    },
+  });
+  setActivePluginRegistry(registry);
+  const result = invokeRegisteredNodeHostCommand("fixture.exec", "{}", undefined, {
+    sendNodeEvent: async () => undefined,
+    sessionKey: "agent:main:session",
+    signal: controller.signal,
+  });
+  return { result, spawn, controller, registry };
+}
+
+function setPolicy(owner: "config" | "approvals", security: ExecSecurity, ask: ExecAsk) {
+  if (owner === "config") {
+    setRuntimeConfigSnapshot({ tools: { exec: { security, ask } } });
+  } else {
+    saveExecApprovals({ version: 1, defaults: { security, ask } });
+  }
+}
+
+describe("plugin node execution authorization", () => {
+  it.each(["config", "approvals"] as const)(
+    "keeps %s restrictions for Full and explicit human decisions",
+    async (owner) => {
+      for (const security of ["full", "allowlist", "deny"] as const) {
+        for (const ask of ["off", "on-miss", "always"] as const) {
+          for (const source of ["session-full", "human-approved"] as const) {
+            setPolicy(owner, security, ask);
+            const { result, spawn } = launch(source);
+            const allowed =
+              source === "human-approved"
+                ? security !== "deny"
+                : security === "full" && ask === "off";
+            if (allowed) {
+              await expect(result).resolves.toBe("{}");
+              expect(spawn).toHaveBeenCalledOnce();
+            } else {
+              await expect(result).rejects.toThrow();
+              expect(spawn).not.toHaveBeenCalled();
+            }
+          }
+        }
+      }
+    },
+  );
+
+  it.each(["config", "approvals"] as const)(
+    "refuses %s tightening during awaited setup",
+    async (owner) => {
+      for (const source of ["session-full", "human-approved"] as const) {
+        for (const [security, ask] of [
+          ["deny", "off"],
+          ["allowlist", "off"],
+          ["full", "always"],
+        ] as const) {
+          setPolicy(owner, "full", "off");
+          const { result, spawn } = launch(source, () => setPolicy(owner, security, ask));
+          await expect(result).rejects.toThrow();
+          expect(spawn).not.toHaveBeenCalled();
+        }
+      }
+    },
+  );
+
+  it.each(["cancel", "plugin-replaced"] as const)(
+    "refuses %s during awaited setup",
+    async (reason) => {
+      const invocation = launch("session-full", () => {
+        if (reason === "cancel") {
+          invocation.controller.abort();
+        } else {
+          setActivePluginRegistry(createEmptyPluginRegistry());
+        }
+      });
+      await expect(invocation.result).rejects.toThrow("authority is closed");
+      expect(invocation.spawn).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/src/node-host/plugin-exec-policy.ts
+++ b/src/node-host/plugin-exec-policy.ts
@@ -1,0 +1,64 @@
+import { getRuntimeConfig } from "../config/config.js";
+import { DEFAULT_ASK, DEFAULT_SECURITY } from "../infra/exec-approvals-config.js";
+import {
+  createExecApprovalPolicySnapshot,
+  loadExecApprovals,
+  recordAllowlistMatchesUse,
+} from "../infra/exec-approvals.js";
+import type { OpenClawPluginNodeHostCommandContext } from "../plugins/types.node-host.js";
+import { parseAgentSessionKey } from "../routing/session-key.js";
+import { resolveNodeExecConfigPolicy } from "./exec-policy.js";
+
+/** Local policy stays on the executor; Gateway approval never overrides a local deny. */
+export function preparePluginExecAuthorization(params: {
+  source: Parameters<
+    NonNullable<OpenClawPluginNodeHostCommandContext["prepareExecAuthorization"]>
+  >[0];
+  command: string;
+  sessionKey?: string;
+  assertActive: () => void;
+}): () => void {
+  params.assertActive();
+  const agentId = parseAgentSessionKey(params.sessionKey)?.agentId;
+  const resolvePolicy = () =>
+    resolveNodeExecConfigPolicy({
+      cfg: getRuntimeConfig(),
+      agentId,
+      defaultSecurity: DEFAULT_SECURITY,
+      defaultAsk: DEFAULT_ASK,
+    });
+  const policy = resolvePolicy();
+  const approvals = loadExecApprovals();
+  const policySnapshot = createExecApprovalPolicySnapshot({ file: approvals, agentId });
+  const assertCurrent = () => {
+    params.assertActive();
+    const current = resolvePolicy();
+    if (
+      current.security === "deny" ||
+      current.security !== policy.security ||
+      current.ask !== policy.ask ||
+      current.autoReview !== policy.autoReview ||
+      (params.source === "session-full" && (current.security !== "full" || current.ask !== "off"))
+    ) {
+      throw new Error("SYSTEM_RUN_DENIED: node-local exec policy does not authorize this launch");
+    }
+    // The synchronous commit primitive rereads the canonical approvals floor.
+    // Empty matches validate authority without writing usage or durable grants.
+    recordAllowlistMatchesUse({
+      approvals,
+      agentId,
+      command: params.command,
+      matches: [],
+      authorization: {
+        source: params.source === "human-approved" ? "explicit-approval" : "current-policy",
+        security: current.security,
+        ask: current.ask,
+        allowlistSatisfied: false,
+        policySnapshot,
+      },
+    });
+    params.assertActive();
+  };
+  assertCurrent();
+  return assertCurrent;
+}

--- a/src/node-host/plugin-node-host.abort.test.ts
+++ b/src/node-host/plugin-node-host.abort.test.ts
@@ -73,6 +73,7 @@ describe("non-duplex node-host plugin cancellation", () => {
       sendNodeEvent,
       sessionKey: "agent:main:local-model",
       signal: controller.signal,
+      prepareExecAuthorization: expect.any(Function),
     });
     expect(request).not.toHaveBeenCalled();
   });
@@ -105,7 +106,10 @@ describe("non-duplex node-host plugin cancellation", () => {
       { pluginCommandContext: { sendNodeEvent } },
     );
 
-    expect(handle).toHaveBeenCalledWith("{}", undefined, { sendNodeEvent });
+    expect(handle).toHaveBeenCalledWith("{}", undefined, {
+      sendNodeEvent,
+      prepareExecAuthorization: expect.any(Function),
+    });
     expect(request).toHaveBeenCalledWith(
       "node.invoke.result",
       expect.objectContaining({ ok: true, payloadJSON: '{"ok":true}' }),

--- a/src/node-host/plugin-node-host.test.ts
+++ b/src/node-host/plugin-node-host.test.ts
@@ -286,7 +286,10 @@ describe("plugin node-host registry", () => {
       invokeRegisteredNodeHostCommand("browser.proxy", '{"ok":true}', undefined, context),
     ).resolves.toBe('{"ok":true}');
     await expect(invokeRegisteredNodeHostCommand("missing.command", null)).resolves.toBeNull();
-    expect(handle).toHaveBeenCalledWith('{"ok":true}', undefined, context);
+    expect(handle).toHaveBeenCalledWith('{"ok":true}', undefined, {
+      ...context,
+      prepareExecAuthorization: expect.any(Function),
+    });
   });
 
   it("gates duplex commands from embedded-worker manifests and supplies their IO context", async () => {

--- a/src/node-host/plugin-node-host.ts
+++ b/src/node-host/plugin-node-host.ts
@@ -19,6 +19,7 @@ import type {
 } from "../plugins/types.js";
 import type { OpenClawPluginNodeHostCommandContext } from "../plugins/types.node-host.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
+import { preparePluginExecAuthorization } from "./plugin-exec-policy.js";
 
 /**
  * Plugin node-host command registry bridge.
@@ -195,19 +196,54 @@ export async function invokeRegisteredNodeHostCommand(
   if (!match) {
     return null;
   }
-  return await withPluginRuntimeRegistryScope(registry, async () => {
-    if (match.command.duplex === true) {
-      if (!io) {
-        throw new Error(`node command requires duplex transport: ${command}`);
-      }
-      return context
-        ? await match.command.handle(paramsJSON, io, context)
-        : await match.command.handle(paramsJSON, io);
+  let active = true;
+  const registeredCommand = match.command;
+  const pluginRecord = registry?.plugins.find((record) => record.id === match.pluginId);
+  const assertActive = () => {
+    if (
+      !active ||
+      match.command !== registeredCommand ||
+      io?.signal.aborted ||
+      context?.signal?.aborted ||
+      resolveNodeHostPluginRegistry() !== registry ||
+      !registry?.nodeHostCommands.includes(match) ||
+      !pluginRecord ||
+      !registry.plugins.includes(pluginRecord) ||
+      !pluginRecord.enabled ||
+      pluginRecord.status !== "loaded"
+    ) {
+      throw new Error("node plugin invocation authority is closed");
     }
-    return context
-      ? await match.command.handle(paramsJSON, undefined, context)
-      : await match.command.handle(paramsJSON);
-  });
+  };
+  const invokeContext = context
+    ? {
+        ...context,
+        prepareExecAuthorization: (source: "human-approved" | "session-full") =>
+          preparePluginExecAuthorization({
+            source,
+            command,
+            sessionKey: context.sessionKey,
+            assertActive,
+          }),
+      }
+    : undefined;
+  try {
+    return await withPluginRuntimeRegistryScope(registry, async () => {
+      if (match.command.duplex === true) {
+        if (!io) {
+          throw new Error(`node command requires duplex transport: ${command}`);
+        }
+        return invokeContext
+          ? await match.command.handle(paramsJSON, io, invokeContext)
+          : await match.command.handle(paramsJSON, io);
+      }
+      return invokeContext
+        ? await match.command.handle(paramsJSON, undefined, invokeContext)
+        : await match.command.handle(paramsJSON);
+    });
+  } finally {
+    active = false;
+  }
 }
 
 export function isRegisteredNodeHostCommandDuplex(command: string): boolean {

--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -1,5 +1,4 @@
 /** CLI runner for node-host stdin/stdout command dispatch. */
-import { isDeepStrictEqual } from "node:util";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { CloudflareAccessCredentials } from "../../packages/gateway-client/src/cloudflare-access.js";
 import {
@@ -7,8 +6,6 @@ import {
   GATEWAY_CLIENT_NAMES,
 } from "../../packages/gateway-protocol/src/client-info.js";
 import { ConnectErrorDetailCodes } from "../../packages/gateway-protocol/src/connect-error-details.js";
-import { GATEWAY_SERVER_CAPS } from "../../packages/gateway-protocol/src/schema/frames.js";
-import { WORKER_BUNDLE_PREWARM_VERSION } from "../../packages/gateway-protocol/src/schema/worker-admission.js";
 import { getRuntimeConfig, type OpenClawConfig } from "../config/config.js";
 import { copyConfigResolutionFactsExcept } from "../config/resolution-facts.js";
 import { startGatewayClientWhenEventLoopReady } from "../gateway/client-start-readiness.js";
@@ -16,17 +13,9 @@ import { GatewayClientRequestError, type GatewayReconnectPausedInfo } from "../g
 import { resolveGatewayCredentialsWithSecretInputs } from "../gateway/credentials-secret-inputs.js";
 import { loadOrCreateDeviceIdentity } from "../infra/device-identity.js";
 import { getMachineDisplayName } from "../infra/machine-name.js";
-import {
-  NODE_RUNNER_INVENTORY_UPDATE_METHOD,
-  NODE_WORKER_BUNDLE_RETENTION_VERSION,
-  NODE_WORKER_BUNDLE_STATUS_VERSION,
-  NODE_WORKER_ENVIRONMENT_SESSION_VERSION,
-  NODE_WORKER_PORTAL_STREAM_VERSION,
-  NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE,
-  type NodeWorkerCapacitySnapshot,
-} from "../infra/node-runner-inventory.js";
 import { VERSION } from "../version.js";
 import { configureNodeHost, type NodeHostGatewayConfig } from "./config.js";
+import { startNodeHostConnection } from "./connection.js";
 import { createNodeHostGatewayCandidateConnection } from "./gateway-candidate-connection.js";
 import {
   resolveNodeHostCloudflareAccess,
@@ -38,7 +27,7 @@ import {
   coerceNodeInvokeInputPayload,
   coerceNodeInvokePayload,
 } from "./invoke-payload.js";
-import { prepareNodeHostRuntime, type NodeHostInventory } from "./runtime.js";
+import { prepareNodeHostRuntime } from "./runtime.js";
 import { runStartupMigrations } from "./startup-state-migrations.js";
 
 type NodeHostRunOptions = {
@@ -107,73 +96,6 @@ function handleNodeHostReconnectPaused(
   const exit = deps.exit ?? ((code: number): never => process.exit(code));
   exit(1);
 }
-
-const NODE_PLUGIN_TOOLS_UPDATE_METHOD = "node.pluginTools.update";
-const NODE_SKILLS_UPDATE_METHOD = "node.skills.update";
-const NODE_OPTIONAL_PUBLICATION_RETRY_INITIAL_MS = 250;
-const NODE_OPTIONAL_PUBLICATION_RETRY_MAX_MS = 5_000;
-
-function isExactUnknownMethodError(error: unknown, method: string): boolean {
-  return (
-    error instanceof GatewayClientRequestError &&
-    error.gatewayCode === "INVALID_REQUEST" &&
-    error.message === `unknown method: ${method}`
-  );
-}
-
-function isExactLegacyNodeAuthorizationError(
-  error: unknown,
-  method: string,
-  gatewayProtocol: number,
-): boolean {
-  const legacyUnknownMethodShape =
-    gatewayProtocol === 3 ||
-    (gatewayProtocol === 4 && method === NODE_RUNNER_INVENTORY_UPDATE_METHOD);
-  return (
-    legacyUnknownMethodShape &&
-    error instanceof GatewayClientRequestError &&
-    error.gatewayCode === "INVALID_REQUEST" &&
-    error.message === "unauthorized role: node"
-  );
-}
-
-function classifyNodeMethodFailure(
-  error: unknown,
-  method: string,
-  gatewayProtocol: number,
-): "legacy-unsupported" | "rejected" | "transient" {
-  if (
-    isExactUnknownMethodError(error, method) ||
-    isExactLegacyNodeAuthorizationError(error, method, gatewayProtocol)
-  ) {
-    return "legacy-unsupported";
-  }
-  if (error instanceof GatewayClientRequestError && error.gatewayCode === "INVALID_REQUEST") {
-    return "rejected";
-  }
-  return "transient";
-}
-
-type NodeOptionalPublicationMethod =
-  | typeof NODE_RUNNER_INVENTORY_UPDATE_METHOD
-  | typeof NODE_PLUGIN_TOOLS_UPDATE_METHOD
-  | typeof NODE_SKILLS_UPDATE_METHOD;
-
-type NodeOptionalPublicationState = {
-  status: "unknown" | "supported" | "unsupported";
-  hasPending: boolean;
-  pendingParams?: unknown;
-  hasPublishedParams: boolean;
-  publishedParams?: unknown;
-  hasRejectedParams: boolean;
-  rejectedParams?: unknown;
-  retryDelayMs: number;
-  retryPending: boolean;
-  retryTimer?: NodeJS.Timeout;
-  hasInFlightParams: boolean;
-  inFlightParams?: unknown;
-  inFlight?: Promise<void>;
-};
 
 async function resolveNodeHostGatewayCredentials(params: {
   config: OpenClawConfig;
@@ -273,7 +195,6 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
     forceWorkerRuns: opts.forceWorkerRuns,
     installedAppsSharingEnabled: config.installedAppsSharing,
   });
-  let workerHostingEnabled = preparedRuntime.workerHostingEnabled;
   if (preparedRuntime.workerHostingDisabledReason) {
     writeStderrLine(
       `node host worker hosting disabled: ${preparedRuntime.workerHostingDisabledReason}`,
@@ -286,248 +207,7 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
         env: process.env,
       });
 
-  let inventory: NodeHostInventory = preparedRuntime.initialInventory;
-  let workerCapacity: NodeWorkerCapacitySnapshot | undefined;
-  let gatewayHelloReceived = false;
   let consecutivePermanentGatewayRejections = 0;
-  let gatewayConnectionGeneration = 0;
-  let connectedGatewayProtocol = 0;
-  let gatewayCapabilities: ReadonlySet<string> = new Set();
-  let optionalPublicationStates = new Map<
-    NodeOptionalPublicationMethod,
-    NodeOptionalPublicationState
-  >();
-  const retireOptionalPublications = () => {
-    for (const state of optionalPublicationStates.values()) {
-      if (state.retryTimer) {
-        clearTimeout(state.retryTimer);
-      }
-    }
-    optionalPublicationStates.clear();
-  };
-  const retireGatewayConnection = () => {
-    gatewayConnectionGeneration += 1;
-    gatewayHelloReceived = false;
-    connectedGatewayProtocol = 0;
-    gatewayCapabilities = new Set();
-    retireOptionalPublications();
-  };
-
-  const queueOptionalPublication = (
-    method: NodeOptionalPublicationMethod,
-    params: unknown,
-    label: string,
-    isRetry = false,
-  ): void => {
-    if (!gatewayHelloReceived) {
-      return;
-    }
-    const connectionGeneration = gatewayConnectionGeneration;
-    const gatewayProtocol = connectedGatewayProtocol;
-    const connectionIsCurrent = () => connectionGeneration === gatewayConnectionGeneration;
-    let state = optionalPublicationStates.get(method);
-    if (!state) {
-      state = {
-        status: "unknown",
-        hasPending: false,
-        hasPublishedParams: false,
-        hasRejectedParams: false,
-        retryDelayMs: NODE_OPTIONAL_PUBLICATION_RETRY_INITIAL_MS,
-        retryPending: false,
-        hasInFlightParams: false,
-      };
-      optionalPublicationStates.set(method, state);
-    }
-    if (state.hasInFlightParams && isDeepStrictEqual(state.inFlightParams, params)) {
-      // The latest desired value remains authoritative even when it matches the
-      // active request. Replace a newer pending value so A -> B -> A cannot publish B.
-      if (state.hasPending) {
-        state.pendingParams = params;
-      }
-      return;
-    }
-    if (
-      state.status === "unsupported" ||
-      (state.hasRejectedParams && isDeepStrictEqual(state.rejectedParams, params)) ||
-      (state.hasPending && isDeepStrictEqual(state.pendingParams, params)) ||
-      (!state.inFlight &&
-        state.hasPublishedParams &&
-        isDeepStrictEqual(state.publishedParams, params))
-    ) {
-      return;
-    }
-    if (state.retryTimer) {
-      clearTimeout(state.retryTimer);
-      state.retryTimer = undefined;
-    }
-    if (!isRetry) {
-      state.retryDelayMs = NODE_OPTIONAL_PUBLICATION_RETRY_INITIAL_MS;
-    }
-    state.hasRejectedParams = false;
-    state.rejectedParams = undefined;
-    state.pendingParams = params;
-    state.hasPending = true;
-    if (state.inFlight) {
-      return;
-    }
-    const publish = async () => {
-      while (state.hasPending && state.status !== "unsupported") {
-        if (!connectionIsCurrent()) {
-          return;
-        }
-        const nextParams = state.pendingParams;
-        state.pendingParams = undefined;
-        state.hasPending = false;
-        if (state.hasPublishedParams && isDeepStrictEqual(state.publishedParams, nextParams)) {
-          continue;
-        }
-        if (state.hasRejectedParams && !isDeepStrictEqual(state.rejectedParams, nextParams)) {
-          // A different value reopens publication. Keeping the old rejection
-          // would drop a later return to that value while this request is in flight.
-          state.hasRejectedParams = false;
-          state.rejectedParams = undefined;
-        }
-        state.inFlightParams = nextParams;
-        state.hasInFlightParams = true;
-        try {
-          await client.request(method, nextParams);
-          // Request settlement races reconnect teardown. Stale completions must
-          // not mutate or report against the retired connection.
-          if (!connectionIsCurrent()) {
-            return;
-          }
-          state.status = "supported";
-          state.publishedParams = nextParams;
-          state.hasPublishedParams = true;
-          state.hasRejectedParams = false;
-          state.rejectedParams = undefined;
-          state.retryDelayMs = NODE_OPTIONAL_PUBLICATION_RETRY_INITIAL_MS;
-          state.retryPending = false;
-        } catch (error) {
-          if (!connectionIsCurrent()) {
-            return;
-          }
-          const failure = classifyNodeMethodFailure(error, method, gatewayProtocol);
-          if (failure === "legacy-unsupported") {
-            state.status = "unsupported";
-            state.pendingParams = undefined;
-            state.hasPending = false;
-            state.retryPending = false;
-          } else {
-            writeStderrLine(`node host ${label} publish failed: ${String(error)}`);
-            if (failure === "rejected") {
-              state.hasRejectedParams = true;
-              state.rejectedParams = nextParams;
-              state.retryPending = false;
-              if (state.hasPending && isDeepStrictEqual(state.pendingParams, nextParams)) {
-                state.pendingParams = undefined;
-                state.hasPending = false;
-              }
-            } else {
-              // A timeout or transport failure can occur after the Gateway applied
-              // the update. Forget the acknowledged baseline so the next desired
-              // value is never skipped against an uncertain remote state.
-              state.hasPublishedParams = false;
-              state.publishedParams = undefined;
-              if (!state.hasPending || isDeepStrictEqual(state.pendingParams, nextParams)) {
-                state.pendingParams = nextParams;
-                state.hasPending = true;
-                state.retryPending = true;
-                break;
-              }
-            }
-          }
-        } finally {
-          state.inFlightParams = undefined;
-          state.hasInFlightParams = false;
-        }
-      }
-    };
-    const inFlight = publish().finally(() => {
-      if (state.inFlight === inFlight) {
-        state.inFlight = undefined;
-        if (
-          state.hasPending &&
-          state.status !== "unsupported" &&
-          gatewayHelloReceived &&
-          connectionIsCurrent()
-        ) {
-          const pendingParams = state.pendingParams;
-          const retryPending = state.retryPending;
-          state.retryPending = false;
-          if (retryPending) {
-            const retryDelayMs = state.retryDelayMs;
-            state.retryDelayMs = Math.min(retryDelayMs * 2, NODE_OPTIONAL_PUBLICATION_RETRY_MAX_MS);
-            state.retryTimer = setTimeout(() => {
-              state.retryTimer = undefined;
-              if (
-                state.hasPending &&
-                isDeepStrictEqual(state.pendingParams, pendingParams) &&
-                gatewayHelloReceived &&
-                connectionIsCurrent()
-              ) {
-                state.pendingParams = undefined;
-                state.hasPending = false;
-                queueOptionalPublication(method, pendingParams, label, true);
-              }
-            }, retryDelayMs);
-            state.retryTimer.unref?.();
-          } else {
-            state.pendingParams = undefined;
-            state.hasPending = false;
-            queueOptionalPublication(method, pendingParams, label);
-          }
-        }
-      }
-    });
-    state.inFlight = inFlight;
-  };
-
-  const publishInventory = () => {
-    if (!gatewayHelloReceived) {
-      return;
-    }
-    if (inventory.skills) {
-      queueOptionalPublication(NODE_SKILLS_UPDATE_METHOD, { skills: inventory.skills }, "skill");
-    }
-    queueOptionalPublication(
-      NODE_PLUGIN_TOOLS_UPDATE_METHOD,
-      { tools: inventory.pluginTools },
-      "plugin tool",
-    );
-  };
-
-  const publishRunnerInventory = () => {
-    queueOptionalPublication(
-      NODE_RUNNER_INVENTORY_UPDATE_METHOD,
-      {
-        protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE],
-        workerHost:
-          workerHostingEnabled && workerCapacity
-            ? {
-                enabled: true,
-                capacity: workerCapacity,
-                bundlePrewarm: WORKER_BUNDLE_PREWARM_VERSION,
-                ...(gatewayCapabilities.has(GATEWAY_SERVER_CAPS.NODE_WORKER_BUNDLE_RETENTION)
-                  ? { bundleRetention: NODE_WORKER_BUNDLE_RETENTION_VERSION }
-                  : {}),
-                ...(gatewayCapabilities.has(GATEWAY_SERVER_CAPS.NODE_WORKER_BUNDLE_RETENTION) &&
-                gatewayCapabilities.has(GATEWAY_SERVER_CAPS.NODE_WORKER_BUNDLE_STATUS)
-                  ? { bundleStatus: NODE_WORKER_BUNDLE_STATUS_VERSION }
-                  : {}),
-                ...(gatewayCapabilities.has(GATEWAY_SERVER_CAPS.NODE_WORKER_PORTAL_STREAM)
-                  ? { portalStream: NODE_WORKER_PORTAL_STREAM_VERSION }
-                  : {}),
-                ...(gatewayCapabilities.has(GATEWAY_SERVER_CAPS.NODE_WORKER_ENVIRONMENT_SESSION)
-                  ? { environmentSession: NODE_WORKER_ENVIRONMENT_SESSION_VERSION }
-                  : {}),
-              }
-            : { enabled: false },
-      },
-      "runner inventory",
-    );
-  };
-
   const persistWinningGateway = (winningGateway: NodeHostGatewayConfig) => {
     void configureNodeHost({
       nodeId,
@@ -591,23 +271,17 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
     onHelloOk: (hello, url, tlsFingerprint, cloudflareAccess) => {
       consecutivePermanentGatewayRejections = 0;
       writeStderrLine(`node host gateway connected: ${url}`);
-      activeRuntime.updateGatewayConnection({
-        url,
-        ...(tlsFingerprint ? { tlsFingerprint } : {}),
-        ...(cloudflareAccess ? { cloudflareAccess } : {}),
-      });
-      gatewayConnectionGeneration += 1;
-      gatewayHelloReceived = true;
-      connectedGatewayProtocol = hello.protocol;
-      gatewayCapabilities = new Set(hello.features?.capabilities);
-      retireOptionalPublications();
-      optionalPublicationStates = new Map();
       if (opts.stopAfterFirstConnect) {
         void finish(0);
         return;
       }
-      publishRunnerInventory();
-      publishInventory();
+      activeRuntime.connect({
+        url,
+        protocol: hello.protocol,
+        capabilities: hello.features?.capabilities ?? [],
+        ...(tlsFingerprint ? { tlsFingerprint } : {}),
+        ...(cloudflareAccess ? { cloudflareAccess } : {}),
+      });
     },
     onConnectError: (error) => {
       writeStderrLine(`node host gateway connect failed: ${error.message}`);
@@ -646,34 +320,16 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
       });
     },
     onClose: (code, reason) => {
-      retireGatewayConnection();
-      activeRuntime.updateGatewayConnection();
-      activeRuntime.cancelAll();
+      activeRuntime.disconnect();
       writeStderrLine(`node host gateway closed (${code}): ${reason}`);
     },
     onWinningCandidate: persistWinningGateway,
   });
-  const activeRuntime = preparedRuntime.start({
+  const activeRuntime = startNodeHostConnection({
+    prepared: preparedRuntime,
     client,
-    onInventoryChanged: (nextInventory) => {
-      inventory = nextInventory;
-      publishInventory();
-    },
-    onRunnerCapacityChanged: (capacity) => {
-      workerCapacity = capacity;
-      publishRunnerInventory();
-    },
-    onWorkerHostingDisabled: (reason) => {
-      workerHostingEnabled = false;
-      writeStderrLine(`node host worker hosting disabled: ${reason}`);
-      publishRunnerInventory();
-    },
-    onManifestChanged: (manifest) => {
-      // Manifest changes force a reconnect. Retire the current publication queue
-      // now so it cannot drain against the closing connection.
-      retireGatewayConnection();
-      client.updateNodeManifest(manifest);
-    },
+    writeStderrLine,
+    onManifestChanged: (manifest) => client.updateNodeManifest(manifest),
   });
 
   let stopping = false;
@@ -689,7 +345,6 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
     process.off("SIGTERM", onSigterm);
   };
   const stopClientAndMcp = async () => {
-    retireGatewayConnection();
     client.stop();
     try {
       await activeRuntime.close();

--- a/src/node-host/runtime.test.ts
+++ b/src/node-host/runtime.test.ts
@@ -130,6 +130,15 @@ function holdInvoke(onCommand?: (io: OpenClawPluginNodeHostCommandIo) => void) {
 }
 
 describe("node-host invocation cancellation", () => {
+  it("does not admit a queued invocation after its connection is retired", async () => {
+    const runtime = await startRuntime();
+    const pending = runtime.invoke({ ...frame, command: "system.run" });
+    runtime.cancelAll();
+    await pending;
+    expect(mocks.handleInvoke).not.toHaveBeenCalled();
+    await runtime.close();
+  });
+
   it("cancels ordinary node invocations", async () => {
     const held = holdInvoke();
     const runtime = await startRuntime();

--- a/src/node-host/runtime.ts
+++ b/src/node-host/runtime.ts
@@ -397,6 +397,7 @@ export async function prepareNodeHostRuntime(params?: {
     }) {
       const mcpAbort = new AbortController();
       let closing = false;
+      let connectionGeneration = 0;
       let closePromise: Promise<void> | undefined;
       let initializationRetry: ReturnType<typeof setTimeout> | undefined;
       const workerWorkspace =
@@ -510,7 +511,11 @@ export async function prepareNodeHostRuntime(params?: {
       }
       return {
         async invoke(frame) {
+          const generation = connectionGeneration;
           await pluginDisconnectCleanup;
+          if (closing || generation !== connectionGeneration) {
+            return;
+          }
           const duplexCommand = duplexEnabled && isRegisteredNodeHostCommandDuplex(frame.command);
           const progressEnabled = duplexCommand || frame.command === NODE_DESKTOP_STREAM_COMMAND;
           const controller = new AbortController();
@@ -639,6 +644,7 @@ export async function prepareNodeHostRuntime(params?: {
           activeInvokes.get(invokeId)?.controller.abort();
         },
         cancelAll() {
+          connectionGeneration += 1;
           for (const active of activeInvokes.values()) {
             active.controller.abort();
           }

--- a/src/node-host/worker-runtime.test.ts
+++ b/src/node-host/worker-runtime.test.ts
@@ -1,0 +1,138 @@
+import { EventEmitter } from "node:events";
+import { setImmediate } from "node:timers/promises";
+import { afterEach, expect, it, vi } from "vitest";
+
+const fixture = vi.hoisted(() => ({
+  prepare: vi.fn(),
+  start: vi.fn(),
+  input: undefined as EventEmitter | undefined,
+  runtime: {
+    invoke: vi.fn(),
+    handleInput: vi.fn(),
+    cancel: vi.fn(),
+    cancelAll: vi.fn(),
+    updateGatewayConnection: vi.fn(),
+    close: vi.fn(),
+  },
+}));
+vi.mock("node:readline", () => ({ createInterface: () => fixture.input }));
+vi.mock("./startup-state-migrations.js", () => ({ runStartupMigrations: async () => {} }));
+vi.mock("./config.js", () => ({ loadNodeHostConfig: async () => ({}) }));
+vi.mock("./runtime.js", () => ({ prepareNodeHostRuntime: fixture.prepare }));
+import { runNodeHostWorker } from "./worker.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+it("publishes hosting through the app route and retires it on disconnect", async () => {
+  const events = new EventEmitter();
+  const input = Object.assign(events, {
+    close: () => {
+      events.emit("close");
+    },
+  });
+  fixture.input = input;
+  const messages: Array<Record<string, unknown>> = [];
+  vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+    const message = JSON.parse(String(chunk));
+    messages.push(message);
+    if (message.type === "gateway-request") {
+      queueMicrotask(() =>
+        input.emit(
+          "line",
+          JSON.stringify({
+            type: "gateway-response",
+            generation: message.generation,
+            id: message.id,
+            ok: true,
+            result: {},
+          }),
+        ),
+      );
+    }
+    return true;
+  });
+  fixture.start.mockImplementation((callbacks) => {
+    callbacks.onRunnerCapacityChanged?.({ total: 2, available: 2 });
+    return fixture.runtime;
+  });
+  fixture.prepare.mockResolvedValue({
+    manifest: { commands: ["system.run"], caps: ["system"], pathEnv: "/bin" },
+    workerHostingEnabled: true,
+    initialInventory: { skills: [], pluginTools: [] },
+    start: fixture.start,
+  });
+  const running = runNodeHostWorker();
+  try {
+    await vi.waitFor(() => expect(messages.some((message) => message.type === "ready")).toBe(true));
+    expect(fixture.prepare).toHaveBeenCalledWith(
+      expect.objectContaining({ enableWorkerRuns: true }),
+    );
+    const connection = {
+      url: "wss://gateway.example.test/current",
+      protocol: 4,
+      capabilities: ["node.worker.bundleRetention.v1"],
+    };
+    input.emit("line", JSON.stringify({ type: "gateway-connection", generation: 1, connection }));
+    await vi.waitFor(() =>
+      expect(messages).toContainEqual(
+        expect.objectContaining({
+          type: "gateway-request",
+          method: "node.runnerInventory.update",
+          params: expect.objectContaining({
+            workerHost: expect.objectContaining({ enabled: true }),
+          }),
+        }),
+      ),
+    );
+    expect(fixture.runtime.updateGatewayConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ url: connection.url }),
+    );
+    input.emit(
+      "line",
+      JSON.stringify({ type: "gateway-connection", generation: 2, connection: null }),
+    );
+    expect(fixture.runtime.cancelAll).toHaveBeenCalled();
+    expect(fixture.runtime.updateGatewayConnection).toHaveBeenLastCalledWith();
+    input.emit("line", JSON.stringify({ type: "gateway-connection", generation: 3, connection }));
+    await setImmediate();
+    const callbacks = fixture.start.mock.calls[0]?.[0];
+    if (!callbacks) {
+      throw new Error("runtime was not started");
+    }
+    const count = messages.length;
+    // Capacity is owned by the supervisor; cleanup from an old invocation can
+    // notify it after reconnect without acquiring that invocation's authority.
+    callbacks.client.withConnection(1, () =>
+      callbacks.onRunnerCapacityChanged({ total: 2, available: 1 }),
+    );
+    await vi.waitFor(() =>
+      expect(messages.slice(count)).toContainEqual(
+        expect.objectContaining({
+          type: "gateway-request",
+          generation: 3,
+          method: "node.runnerInventory.update",
+          params: expect.objectContaining({
+            workerHost: expect.objectContaining({
+              capacity: { total: 2, available: 1 },
+            }),
+          }),
+        }),
+      ),
+    );
+    callbacks.onManifestChanged({ commands: ["system.run"], caps: ["system"], pathEnv: "/bin" });
+    input.emit(
+      "line",
+      JSON.stringify({
+        type: "invoke",
+        generation: 3,
+        request: { id: "stale", nodeId: "node", command: "system.worker.start" },
+      }),
+    );
+    expect(fixture.runtime.invoke).not.toHaveBeenCalled();
+  } finally {
+    input.close();
+    await running;
+  }
+});

--- a/src/node-host/worker-support.ts
+++ b/src/node-host/worker-support.ts
@@ -1,25 +1,51 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
+import { z } from "zod";
+import { GatewayClientRequestError } from "../gateway/client.js";
 import type { GatewayClientRequestOptions } from "../gateway/client.js";
 import { createPendingRequestRegistry } from "../shared/pending-request-registry.js";
 import type { NodeHostClient } from "./client.js";
+import type { NodeHostGatewayConnection } from "./connection.js";
 import type { NodeInvokeRequestPayload } from "./invoke.js";
 
-type NodeHostWorkerGatewayResponse =
+type NodeHostWorkerGatewayResponse = { generation: number } & (
   | { type: "gateway-response"; id: string; ok: true; result: unknown }
-  | { type: "gateway-response"; id: string; ok: false; error: string };
+  | { type: "gateway-response"; id: string; ok: false; error: { code: string; message: string } }
+);
 
 type NodeHostWorkerInput =
-  | { type: "invoke"; request: NodeInvokeRequestPayload }
-  | { type: "invoke-input"; invokeId: string; seq: number; payloadJSON: string }
-  | { type: "invoke-cancel"; invokeId: string }
+  | { type: "gateway-connection"; generation: number; connection: NodeHostGatewayConnection | null }
+  | { type: "invoke"; generation: number; request: NodeInvokeRequestPayload }
+  | { type: "invoke-input"; generation: number; invokeId: string; seq: number; payloadJSON: string }
+  | { type: "invoke-cancel"; generation: number; invokeId: string }
   | NodeHostWorkerGatewayResponse
   | { type: "stop" };
+
+const connectionSchema = z.object({
+  url: z.url(),
+  protocol: z.number().int().positive(),
+  capabilities: z.array(z.string()),
+  tlsFingerprint: z.string().optional(),
+  cloudflareAccess: z.object({ clientId: z.string(), clientSecret: z.string() }).optional(),
+});
 
 export function parseNodeHostWorkerInput(line: string): NodeHostWorkerInput | null {
   try {
     const parsed = asRecord(JSON.parse(line));
     const type = typeof parsed?.type === "string" ? parsed.type : "";
+    if (type === "stop") {
+      return { type };
+    }
+    const generation = parsed?.generation;
+    if (typeof generation !== "number" || !Number.isSafeInteger(generation) || generation < 0) {
+      return null;
+    }
+    if (type === "gateway-connection") {
+      const connection =
+        parsed?.connection === null ? null : connectionSchema.parse(parsed?.connection);
+      return { type, generation, connection };
+    }
     if (type === "invoke") {
       const request = asRecord(parsed?.request);
       if (
@@ -28,7 +54,7 @@ export function parseNodeHostWorkerInput(line: string): NodeHostWorkerInput | nu
         typeof request.nodeId === "string" &&
         typeof request.command === "string"
       ) {
-        return { type, request: request as NodeInvokeRequestPayload };
+        return { type, generation, request: request as NodeInvokeRequestPayload };
       }
       return null;
     }
@@ -38,12 +64,13 @@ export function parseNodeHostWorkerInput(line: string): NodeHostWorkerInput | nu
         return null;
       }
       return parsed?.ok === true
-        ? { type, id, ok: true, result: parsed.result }
+        ? { type, generation, id, ok: true, result: parsed.result }
         : {
             type,
+            generation,
             id,
             ok: false,
-            error: typeof parsed?.error === "string" ? parsed.error : "Gateway request failed",
+            error: z.object({ code: z.string(), message: z.string() }).parse(parsed?.error),
           };
     }
     if (type === "invoke-input") {
@@ -51,14 +78,14 @@ export function parseNodeHostWorkerInput(line: string): NodeHostWorkerInput | nu
       const seq = typeof parsed?.seq === "number" ? parsed.seq : -1;
       const payloadJSON = typeof parsed?.payloadJSON === "string" ? parsed.payloadJSON : null;
       return invokeId && Number.isInteger(seq) && seq >= 0 && payloadJSON !== null
-        ? { type, invokeId, seq, payloadJSON }
+        ? { type, generation, invokeId, seq, payloadJSON }
         : null;
     }
     if (type === "invoke-cancel") {
       const invokeId = typeof parsed?.invokeId === "string" ? parsed.invokeId : "";
-      return invokeId ? { type, invokeId } : null;
+      return invokeId ? { type, generation, invokeId } : null;
     }
-    return type === "stop" ? { type } : null;
+    return null;
   } catch {
     return null;
   }
@@ -66,6 +93,19 @@ export function parseNodeHostWorkerInput(line: string): NodeHostWorkerInput | nu
 
 export class NodeHostWorkerBridgeClient implements NodeHostClient {
   private nextRequestId = 1;
+  private generation = 0;
+  private connected = false;
+  private readonly invocationGeneration = new AsyncLocalStorage<number>();
+
+  setConnection(generation: number, connected: boolean): void {
+    this.pending.rejectAll(new Error("node-host Gateway route changed"));
+    this.generation = generation;
+    this.connected = connected;
+  }
+
+  withConnection<T>(generation: number, run: () => T): T {
+    return this.invocationGeneration.run(generation, run);
+  }
   private readonly pending = createPendingRequestRegistry<string, unknown, undefined>();
 
   constructor(private readonly writeMessage: (message: unknown) => void) {}
@@ -75,12 +115,16 @@ export class NodeHostWorkerBridgeClient implements NodeHostClient {
     params?: unknown,
     opts?: GatewayClientRequestOptions,
   ): Promise<T> {
+    const generation = this.invocationGeneration.getStore() ?? this.generation;
+    if (!this.connected || generation !== this.generation) {
+      throw new Error("node-host Gateway route is closed");
+    }
     if (method === "node.invoke.result") {
-      this.writeMessage({ type: "invoke-result", result: params ?? {} });
+      this.writeMessage({ type: "invoke-result", generation, result: params ?? {} });
       return {} as T;
     }
     if (method === "node.event") {
-      this.writeMessage({ type: "node-event", event: params ?? {} });
+      this.writeMessage({ type: "node-event", generation, event: params ?? {} });
       return {} as T;
     }
 
@@ -94,11 +138,21 @@ export class NodeHostWorkerBridgeClient implements NodeHostClient {
     if (!pending) {
       throw new Error(`Gateway request id collision: ${id}`);
     }
-    this.writeMessage({ type: "gateway-request", id, method, params: params ?? {}, timeoutMs });
+    this.writeMessage({
+      type: "gateway-request",
+      generation,
+      id,
+      method,
+      params: params ?? {},
+      timeoutMs,
+    });
     return (await pending.promise) as T;
   }
 
   handleResponse(message: NodeHostWorkerGatewayResponse): boolean {
+    if (message.generation !== this.generation) {
+      return false;
+    }
     const pending = this.pending.take(message.id);
     if (!pending) {
       return false;
@@ -106,12 +160,15 @@ export class NodeHostWorkerBridgeClient implements NodeHostClient {
     if (message.ok) {
       pending.resolve(message.result);
     } else {
-      pending.reject(new Error(message.error));
+      pending.reject(
+        new GatewayClientRequestError({ code: message.error.code, message: message.error.message }),
+      );
     }
     return true;
   }
 
   close(): void {
+    this.connected = false;
     this.pending.rejectAll(new Error("node-host worker stopped"));
   }
 }

--- a/src/node-host/worker.test.ts
+++ b/src/node-host/worker.test.ts
@@ -1,5 +1,6 @@
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { GatewayClientRequestError } from "../gateway/client.js";
 import {
   NodeHostWorkerBridgeClient,
   parseNodeHostWorkerInput,
@@ -10,22 +11,44 @@ describe("parseNodeHostWorkerInput", () => {
   it("accepts ordered input and cancel control frames", () => {
     expect(
       parseNodeHostWorkerInput(
-        JSON.stringify({ type: "invoke-input", invokeId: "invoke-1", seq: 2, payloadJSON: "x" }),
+        JSON.stringify({
+          type: "invoke-input",
+          generation: 1,
+          invokeId: "invoke-1",
+          seq: 2,
+          payloadJSON: "x",
+        }),
       ),
-    ).toEqual({ type: "invoke-input", invokeId: "invoke-1", seq: 2, payloadJSON: "x" });
+    ).toEqual({
+      type: "invoke-input",
+      generation: 1,
+      invokeId: "invoke-1",
+      seq: 2,
+      payloadJSON: "x",
+    });
     expect(
-      parseNodeHostWorkerInput(JSON.stringify({ type: "invoke-cancel", invokeId: "invoke-1" })),
-    ).toEqual({ type: "invoke-cancel", invokeId: "invoke-1" });
+      parseNodeHostWorkerInput(
+        JSON.stringify({ type: "invoke-cancel", generation: 1, invokeId: "invoke-1" }),
+      ),
+    ).toEqual({ type: "invoke-cancel", generation: 1, invokeId: "invoke-1" });
   });
 
   it("rejects malformed duplex control frames", () => {
     expect(
       parseNodeHostWorkerInput(
-        JSON.stringify({ type: "invoke-input", invokeId: "invoke-1", seq: -1, payloadJSON: "x" }),
+        JSON.stringify({
+          type: "invoke-input",
+          generation: 1,
+          invokeId: "invoke-1",
+          seq: -1,
+          payloadJSON: "x",
+        }),
       ),
     ).toBeNull();
     expect(
-      parseNodeHostWorkerInput(JSON.stringify({ type: "invoke-cancel", invokeId: "" })),
+      parseNodeHostWorkerInput(
+        JSON.stringify({ type: "invoke-cancel", generation: 1, invokeId: "" }),
+      ),
     ).toBeNull();
   });
 });
@@ -35,16 +58,68 @@ describe("NodeHostWorkerBridgeClient", () => {
     vi.useRealTimers();
   });
 
+  it("fences pending RPCs and retained invocation output after route replacement", async () => {
+    const write = vi.fn();
+    const client = new NodeHostWorkerBridgeClient(write);
+    client.setConnection(1, true);
+    const pending = client.request("skills.bins");
+    const rejected = expect(pending).rejects.toThrow("route changed");
+    let resume!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      resume = resolve;
+    });
+    const late = client.withConnection(1, async () => {
+      await gate;
+      return client.request("node.event", { event: "exec.finished" });
+    });
+    const lateRejected = expect(late).rejects.toThrow("route is closed");
+    client.setConnection(2, true);
+    resume();
+    await Promise.all([rejected, lateRejected]);
+    expect(
+      client.handleResponse({
+        type: "gateway-response",
+        generation: 1,
+        id: "gateway-1",
+        ok: true,
+        result: {},
+      }),
+    ).toBe(false);
+    expect(write).toHaveBeenCalledTimes(1);
+    client.close();
+  });
+
+  it("preserves structured gateway rejection for the shared publisher", async () => {
+    const client = new NodeHostWorkerBridgeClient(() => {});
+    client.setConnection(1, true);
+    const response = client.request("node.skills.update");
+    const rejection = expect(response).rejects.toMatchObject({
+      gatewayCode: "INVALID_REQUEST",
+      message: "unknown method: node.skills.update",
+    });
+    client.handleResponse({
+      type: "gateway-response",
+      generation: 1,
+      id: "gateway-1",
+      ok: false,
+      error: { code: "INVALID_REQUEST", message: "unknown method: node.skills.update" },
+    });
+    await rejection;
+    await expect(response).rejects.toBeInstanceOf(GatewayClientRequestError);
+    client.close();
+  });
+
   it("forwards invoke results and events without creating gateway request waits", async () => {
     const messages: unknown[] = [];
     const client = new NodeHostWorkerBridgeClient((message) => messages.push(message));
 
+    client.setConnection(1, true);
     await client.request("node.invoke.result", { id: "invoke-1", ok: true });
     await client.request("node.event", { event: "exec.started", payloadJSON: "{}" });
 
     expect(messages).toEqual([
-      { type: "invoke-result", result: { id: "invoke-1", ok: true } },
-      { type: "node-event", event: { event: "exec.started", payloadJSON: "{}" } },
+      { type: "invoke-result", generation: 1, result: { id: "invoke-1", ok: true } },
+      { type: "node-event", generation: 1, event: { event: "exec.started", payloadJSON: "{}" } },
     ]);
   });
 
@@ -54,6 +129,7 @@ describe("NodeHostWorkerBridgeClient", () => {
       messages.push(message as Record<string, unknown>);
     });
 
+    client.setConnection(1, true);
     let settled = false;
     const response = client
       .request("node.invoke.progress", {
@@ -70,6 +146,7 @@ describe("NodeHostWorkerBridgeClient", () => {
     expect(messages).toEqual([
       {
         type: "gateway-request",
+        generation: 1,
         id: "gateway-1",
         method: "node.invoke.progress",
         params: { invokeId: "invoke-1", nodeId: "node-1", seq: 0, chunk: "a" },
@@ -80,6 +157,7 @@ describe("NodeHostWorkerBridgeClient", () => {
     expect(
       client.handleResponse({
         type: "gateway-response",
+        generation: 1,
         id: "gateway-1",
         ok: true,
         result: { ok: true },
@@ -95,10 +173,12 @@ describe("NodeHostWorkerBridgeClient", () => {
       messages.push(message as Record<string, unknown>);
     });
 
+    client.setConnection(1, true);
     const response = client.request<{ bins: string[] }>("skills.bins", {}, { timeoutMs: 1_000 });
     expect(messages).toEqual([
       {
         type: "gateway-request",
+        generation: 1,
         id: "gateway-1",
         method: "skills.bins",
         params: {},
@@ -108,6 +188,7 @@ describe("NodeHostWorkerBridgeClient", () => {
     expect(
       client.handleResponse({
         type: "gateway-response",
+        generation: 1,
         id: "gateway-1",
         ok: true,
         result: { bins: ["rg"] },
@@ -118,6 +199,7 @@ describe("NodeHostWorkerBridgeClient", () => {
 
   it("fails pending gateway requests when the app worker stops", async () => {
     const client = new NodeHostWorkerBridgeClient(() => {});
+    client.setConnection(1, true);
     const response = client.request("skills.bins", {}, { timeoutMs: 1_000 });
 
     client.close();
@@ -129,6 +211,7 @@ describe("NodeHostWorkerBridgeClient", () => {
     const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
     const client = new NodeHostWorkerBridgeClient(() => {});
     try {
+      client.setConnection(1, true);
       const response = client.request("skills.bins", {}, { timeoutMs: 60_000 });
       const timer = timeoutSpy.mock.results[0]?.value as NodeJS.Timeout | undefined;
 
@@ -154,11 +237,13 @@ describe("NodeHostWorkerBridgeClient", () => {
       messages.push(message as Record<string, unknown>);
     });
 
+    client.setConnection(1, true);
     const response = client.request("skills.bins", {}, { timeoutMs: requested });
 
     expect(messages).toEqual([
       {
         type: "gateway-request",
+        generation: 1,
         id: "gateway-1",
         method: "skills.bins",
         params: {},
@@ -169,6 +254,7 @@ describe("NodeHostWorkerBridgeClient", () => {
     expect(
       client.handleResponse({
         type: "gateway-response",
+        generation: 1,
         id: "gateway-1",
         ok: true,
         result: { bins: [] },

--- a/src/node-host/worker.ts
+++ b/src/node-host/worker.ts
@@ -1,8 +1,10 @@
 /** Private JSONL worker exposing the CLI node-host runtime to the macOS app. */
 import { createInterface } from "node:readline";
 import { VERSION } from "../version.js";
+import type { NodeHostClient } from "./client.js";
 import { loadNodeHostConfig } from "./config.js";
-import { prepareNodeHostRuntime, type NodeHostInventory } from "./runtime.js";
+import { startNodeHostConnection } from "./connection.js";
+import { prepareNodeHostRuntime } from "./runtime.js";
 import { runStartupMigrations } from "./startup-state-migrations.js";
 import {
   NodeHostWorkerBridgeClient,
@@ -18,10 +20,6 @@ function writeStderrLine(message: string): void {
   process.stderr.write(`${message}\n`);
 }
 
-function emitInventory(inventory: NodeHostInventory): void {
-  writeMessage({ type: "inventory", inventory });
-}
-
 export async function runNodeHostWorker(): Promise<void> {
   // Operator-approved startup is a second authorized entry point for Doctor-owned
   // state migrators. Runtime invokes those owners here and never migrates inline.
@@ -29,6 +27,7 @@ export async function runNodeHostWorker(): Promise<void> {
   const nodeConfig = await loadNodeHostConfig();
   const prepared = await prepareNodeHostRuntime({
     enableDuplexPluginCommands: true,
+    enableWorkerRuns: true,
     installedAppsSharingEnabled: nodeConfig?.installedAppsSharing === true,
   });
   const client = new NodeHostWorkerBridgeClient(writeMessage);
@@ -52,19 +51,56 @@ export async function runNodeHostWorker(): Promise<void> {
     }
   };
 
-  const runtime = prepared.start({ client, onInventoryChanged: emitInventory });
+  let generation = 0;
+  let connected = false;
+  let readySent = false;
+  let currentManifest = prepared.manifest;
+  const runtime = startNodeHostConnection({
+    prepared,
+    client,
+    writeStderrLine,
+    onManifestChanged: (manifest) => {
+      currentManifest = manifest;
+      if (readySent) {
+        connected = false;
+        client.setConnection(generation, false);
+        runtime.disconnect();
+        writeMessage({ type: "manifest", version: VERSION, manifest });
+      }
+    },
+  });
   writeMessage({
     type: "ready",
     version: VERSION,
-    manifest: prepared.manifest,
-    inventory: prepared.initialInventory,
+    manifest: currentManifest,
   });
+
+  readySent = true;
 
   const input = createInterface({ input: process.stdin, crlfDelay: Infinity });
   input.on("line", (line) => {
     const message = parseNodeHostWorkerInput(line);
     if (!message) {
       writeMessage({ type: "protocol-error", error: "invalid worker request" });
+      return;
+    }
+    if (message.type === "gateway-connection") {
+      if (message.generation <= generation) {
+        return;
+      }
+      generation = message.generation;
+      connected = message.connection !== null;
+      client.setConnection(generation, connected);
+      runtime.disconnect();
+      if (message.connection) {
+        // Publication belongs to this connection, even when a supervisor update
+        // originates during cleanup of an invocation from the retired route.
+        const connectionGeneration = generation;
+        runtime.connect(message.connection, {
+          request: <T>(...args: Parameters<NodeHostClient["request"]>) =>
+            client.withConnection(connectionGeneration, () => client.request<T>(...args)),
+        });
+      }
       return;
     }
     if (message.type === "gateway-response") {
@@ -76,6 +112,9 @@ export async function runNodeHostWorker(): Promise<void> {
       void stop(0);
       return;
     }
+    if (!connected || message.generation !== generation) {
+      return;
+    }
     if (message.type === "invoke-input") {
       runtime.handleInput(message.invokeId, message.seq, message.payloadJSON);
       return;
@@ -84,10 +123,17 @@ export async function runNodeHostWorker(): Promise<void> {
       runtime.cancel(message.invokeId);
       return;
     }
-    void runtime.invoke(message.request);
+    void client.withConnection(generation, () => runtime.invoke(message.request));
   });
   input.on("close", () => void stop(0));
-  process.once("SIGINT", () => void stopNodeHostWorkerFromSignal(input, stop, 130));
-  process.once("SIGTERM", () => void stopNodeHostWorkerFromSignal(input, stop, 143));
-  await stopped;
+  const onInterrupt = () => void stopNodeHostWorkerFromSignal(input, stop, 130);
+  const onTerminate = () => void stopNodeHostWorkerFromSignal(input, stop, 143);
+  process.once("SIGINT", onInterrupt);
+  process.once("SIGTERM", onTerminate);
+  try {
+    await stopped;
+  } finally {
+    process.off("SIGINT", onInterrupt);
+    process.off("SIGTERM", onTerminate);
+  }
 }

--- a/src/plugins/plugin-registration.types.ts
+++ b/src/plugins/plugin-registration.types.ts
@@ -15,6 +15,7 @@ import type { DiagnosticTracePropagationBridge as DiagnosticTracePropagationBrid
 import type { SecurityAuditFinding } from "../security/audit.types.js";
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
 import type { PluginLogger } from "./logger-types.js";
+import type { OpenClawPluginNodeWorkspace } from "./types.node-host.js";
 
 type ChannelPlugin = import("../channels/plugins/types.plugin.js").ChannelPlugin;
 type DiagnosticTracePropagationBridge = DiagnosticTracePropagationBridgeContract<
@@ -261,8 +262,16 @@ export type OpenClawPluginNodeInvokePolicyContext = {
     family: string;
   };
   approvals?: OpenClawPluginNodeInvokePolicyApprovalRuntime;
+  /** Invoke only under the exact admitted Full owner; undefined requires a human decision. */
+  invokeNodeWithSessionFull?: (input: {
+    workspace: OpenClawPluginNodeWorkspace;
+    /** Called only after the host authorizes this exact admitted Full launch. */
+    createParams: () => unknown;
+  }) => Promise<OpenClawPluginNodeInvokeTransportResult | undefined>;
   invokeNode: (input?: {
     params?: unknown;
+    /** Bind an approved launch to its admitted managed workspace, when present. */
+    workspace?: OpenClawPluginNodeWorkspace;
     timeoutMs?: number;
     idempotencyKey?: string;
   }) => Promise<OpenClawPluginNodeInvokeTransportResult>;

--- a/src/plugins/plugin-registration.types.ts
+++ b/src/plugins/plugin-registration.types.ts
@@ -262,7 +262,7 @@ export type OpenClawPluginNodeInvokePolicyContext = {
     family: string;
   };
   approvals?: OpenClawPluginNodeInvokePolicyApprovalRuntime;
-  /** Invoke only under the exact admitted Full owner; undefined requires a human decision. */
+  /** Full covers only the selected harness's declared node commands; undefined requires a human decision. */
   invokeNodeWithSessionFull?: (input: {
     workspace: OpenClawPluginNodeWorkspace;
     /** Called only after the host authorizes this exact admitted Full launch. */

--- a/src/plugins/runtime/gateway-request-scope.ts
+++ b/src/plugins/runtime/gateway-request-scope.ts
@@ -22,6 +22,7 @@ type PluginRuntimeGatewayRequestScope = {
   invokeWithSessionNodeAuthority?: <T>(
     request: {
       pluginId: string;
+      command: string;
       source: "session-full" | "human-approved";
       nodeId: string;
       workspace: OpenClawPluginNodeWorkspace;

--- a/src/plugins/runtime/gateway-request-scope.ts
+++ b/src/plugins/runtime/gateway-request-scope.ts
@@ -8,8 +8,26 @@ import type {
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
 import type { PluginOrigin } from "../plugin-origin.types.js";
 import type { PluginRegistry } from "../registry-types.js";
+import type { OpenClawPluginNodeWorkspace } from "../types.node-host.js";
 
 type PluginRuntimeGatewayRequestScope = {
+  /** Exact placement owner captured before the local harness begins. */
+  assertNodeExecutionCurrent?: (request: {
+    runId: string;
+    agentId: string;
+    nodeId: string;
+    workspace: OpenClawPluginNodeWorkspace;
+  }) => void;
+  /** In-process admitted owner only; never projected into RPC parameters. */
+  invokeWithSessionNodeAuthority?: <T>(
+    request: {
+      pluginId: string;
+      source: "session-full" | "human-approved";
+      nodeId: string;
+      workspace: OpenClawPluginNodeWorkspace;
+    },
+    invoke: (assertCurrent: () => void, signal: AbortSignal) => Promise<T>,
+  ) => Promise<T | undefined>;
   context?: GatewayRequestContext;
   resolveGatewayContext?: GatewayContextResolver;
   client?: GatewayRequestOptions["client"];

--- a/src/plugins/types.node-host.ts
+++ b/src/plugins/types.node-host.ts
@@ -19,6 +19,14 @@ export type OpenClawPluginNodeHostCommandIo = {
   signal: AbortSignal;
 };
 
+export type OpenClawPluginNodeWorkspace = {
+  workspaceDir: string;
+  environmentId: string;
+  sessionId: string;
+  ownerEpoch: number;
+  sessionKey: string;
+};
+
 export type OpenClawPluginNodeHostCommandContext = {
   /** Emit one node-owned event through the active Gateway connection. */
   sendNodeEvent(event: string, payload: unknown): Promise<unknown>;
@@ -26,14 +34,13 @@ export type OpenClawPluginNodeHostCommandContext = {
   sessionKey?: string;
   /** Aborts when the Gateway cancels this specific node-host invocation. */
   signal?: AbortSignal;
+  /** Prepare local exec policy; call the returned guard synchronously immediately before spawn. */
+  prepareExecAuthorization?: (source: "human-approved" | "session-full") => () => void;
   /** Protect one exact node-owned placement workspace for this invocation's lifetime. */
-  acquireManagedWorkspace?: (request: {
+  acquireManagedWorkspace?: (request: OpenClawPluginNodeWorkspace) => {
     workspaceDir: string;
-    environmentId: string;
-    sessionId: string;
-    ownerEpoch: number;
-    sessionKey: string;
-  }) => { workspaceDir: string; release: () => void };
+    release: () => void;
+  };
 };
 
 type OpenClawPluginNodeHostCommandBase = {


### PR DESCRIPTION
Closes #131707 — native macOS app session hosting.

<details>
<summary>Additional instructions</summary>

Maintainer-owned branch in this repository; maintainers can update it. AI-assisted implementation and review.

</details>

## What Problem This Solves

A paired native macOS app could run desktop commands but could not host a managed session. Its embedded TypeScript worker lacked the complete authenticated connection lifecycle and inventory/capacity publication, and the Gateway excluded the actual native app client from worker-host eligibility.

The remote-work flow also exposed inconsistent execution defaults: the node receiver silently selected `allowlist/on-miss` instead of canonical `full/off`. Pending approvals could outlive their admitted turn, and deliberate session Full access still triggered a separate Codex exec-server launch approval.

This completes the existing native integration without a second CLI node or fake client identity. It builds on the separately merged [native IPC cancellation repair, PR #131650](https://github.com/openclaw/openclaw/pull/131650). A bounded test-only follow-up makes that repair's child-PID readiness marker atomic after the combined native suite reproduced an empty-file race.

## Why This Change Was Made

### One connection and publication owner

The app retains its node-role Gateway connection and device identity. Swift retains native/TCC-dependent commands; a private JSONL worker embeds the canonical TypeScript runtime. One shared connection owner now serves native and headless runners, handling inventory/capacity, negotiated features, publication ordering/retry, and retirement. Duplicate runner/Swift publication policy is removed.

The bridge preserves the active authenticated route, connection generation, and outer invocation metadata. Disconnect, replacement, pause, and shutdown retire pending work and fence late replies/events. Private supervisor commands remain absent from public pairing manifests. The Gateway admits the actual macOS client while retaining pairing, hosting consent, current worker dialect, capacity, and exact connection/placement checks.

### Full access is command-bound live authority

Explicitly admitted, host-validated Full access can authorize the exact live Codex exec-server launch. It is bound to the session/run/placement/turn and both prepared-runtime and Gateway plugin lifecycle owners, even when their registries differ. Raw invokes, stored Full without current admission, revoked claims, stale closures, and other plugins do not inherit it.

The final review identified one additional confinement omission: the selected harness's existing `cloudPlacement.devicePlacement.requiredNodeCommands` declaration was not carried into its host capability. [The repair](https://github.com/openclaw/openclaw/commit/f3ed06598853b59cdd40ba6f37b4e7ce070a68dc) snapshots that declaration, carries the Gateway-owned command privately, and checks membership before parameter construction and at final dispatch. Another command owned by the same plugin, a missing declaration, or later descriptor expansion cannot inherit Full. Core remains plugin-agnostic; no literal Codex exception or new metadata/configuration option was added.

Plugins remain trusted code and continue to own their ordinary approval policy; this is confinement of the host-issued capability, not a new sandbox around malicious plugins. The node separately revalidates its own policy immediately before spawn. Explicit deny, ask, allowlist, consent, pairing, and command enablement still win. Human-approved launches keep their existing approval path.

Canonical exec defaults replace the hidden receiver floor; caller and target restrictions still intersect. Allowlist/off misses deny rather than silently dispatch. Ordinary full/off avoids approval-only binding, while approval-backed execution keeps binding and final revalidation. Human approvals remain in the original admitted turn. Definite pre-execution denial remains distinct from transport-level outcome uncertainty. Native cwd identity uses POSIX `realpath` rather than Foundation's `/private/tmp` folding.

**Dependency contract:** personally inspected pinned Codex `rust-v0.150.1` [stdio transport](https://github.com/openai/codex/blob/rust-v0.150.1/codex-rs/exec-server/src/server/transport.rs#L131-L158) and [environment lifecycle](https://github.com/openai/codex/blob/rust-v0.150.1/codex-rs/core/src/environment_selection.rs#L271-L395). Stdio owns one connection and shuts down afterward; servers are not kept alive across turns as a latency workaround.

## User Impact

An operator can select an eligible paired native Mac in New Session, create a Gateway-managed worktree, use native remote shell/file tools, and receive reconciled changes on the Gateway. Native desktop capabilities remain available. Both Codex and embedded OpenClaw are covered. Codex inference, provider credentials, app-server, and transcript ownership remain on the Gateway; process/filesystem execution moves to the node.

**Intentional default transition:** an unconfigured node's hidden `allowlist/on-miss` receiver floor changes to canonical `full/off`. The operator approved that parity in the implementation plan. Explicit caller/node restrictions still tighten execution. Existing hosting consent, matching plugin installation, and command enablement remain required. There are no new configuration keys, dependencies, SQLite/schema changes, or protocol-version bumps.

Production LOC: **+1,495/-752 (net +743)** across 43 files. Tests/support: **+2,723/-684 (net +2,039)** across 30 files. Docs: **+65/-12 (net +53)** across six files. Growth implements the missing native bridge and live authorization owner; the final command-confinement repair adds only 13 net production lines. The unrelated workspace hash memo already landed in [PR #131254](https://github.com/openclaw/openclaw/pull/131254) and is not new scope here.

## Evidence

**Current head:** `fb6989eaa869466bcb85ab8edef0f469d160bf59`, rebased onto `cb696a1bb3b66a8d51392a8ab743e270e4f249cf` after GitHub rejected the previously prepared merge because `main` had introduced a test conflict. The sole manual resolution preserves main's worker-fixture message ordering and adds this PR's generation tags in that order. Range-diff shows no production patch change. All 27 native worker tests, eight real pinned-Codex transport tests, a full build (4m 30.9s), and fresh P0 autoreview passed after the rebase. Exact-head [CI 33175368325](https://github.com/openclaw/openclaw/actions/runs/33175368325) is **complete and green**; the pinned watcher exited 0 with no pending/failing checks. The latest 13:40 UTC ClawSweeper review found no introduced defect; its direct-source and maintainer-review items are completed as documented here. Earlier live proof remains tied to its recorded build, not relabeled as a new recording.

### Final real native Mac and Control UI flow

The isolated Gateway was rebuilt from exact head **`f3ed06598853b59cdd40ba6f37b4e7ce070a68dc`**. It used the verified Developer-ID-signed native app and canonical node/core/Codex packages from `6572580`; later node/app source changes only remove an uncalled private Swift serializer, rebuilt and covered by 27 worker tests. The final confinement repair runs on the rebuilt Gateway. This debug app omits the unrelated MLX TTS helper; no release or production deployment is claimed.

Four post-repair UI runs completed with **zero approval events**. The model used native session tools, not node_exec, gateway_exec, or SSH as an execution workaround. The exact 19-byte hostname file was independently verified on the physical node and reconciled Gateway workspace after every turn.

| Runtime / turn | Placement | Visible answer | Terminal completion |
| --- | ---: | ---: | ---: |
| Codex, new session | 5.924 s | 16.420 s | 17.896 s |
| Codex, follow-up | Reused | 5.872 s | 8.226 s |
| Embedded OpenClaw, new session | 2.864 s | 13.421 s | 15.027 s |
| Embedded OpenClaw, follow-up | Reused | 12.916 s | 14.432 s |

These are tiny-fixture measurements, not a universal speedup claim. Earlier cold/cached runs and reconciliation measurements are retained; latency is not declared fully solved.

A fresh Full Codex session under persisted node-local deny failed visibly. The deny was independently read back before and after, neither host received the requested file, and the original policy was restored and verified. Earlier permission proof also covered ordinary no-override node exec (0.14–0.32 s), Gateway-local parity, and UI Allow once resuming its original turn and consuming the grant.

The first fresh packaged Codex attempt stopped before session creation because core does not bundle the external Codex plugin. Gateway command opt-in was already present. The matching candidate was packed canonically and installed on the node with managed `npm-pack:` plus explicit capability consent, then the proof app was restarted. That proves managed dependency installation, not trusted-official provenance; node exec-server registration does not require official trust. No second CLI node or node-side provider login was introduced. The misleading allowlist-only picker hint is a separately recorded follow-up.

### Forbidden-path and regression proof

Before the final repair, three composed regressions reached `NodeRegistry.invoke` with session-Full authorization despite an undeclared command, missing descriptor, or descriptor expansion. Both commands were node-declared and Gateway-allowlisted, so rejection cannot be supplied accidentally by an unrelated gate. A separate table through real registered harness selection failed the same three negative cases on the frozen pre-fix source while its declared-command positive passed. All now pass.

The composed tests cover admission, real placement state, request scopes, both plugin registries, raw invokes, stored Full without admission, and revocation during awaited startup/policy work. Gateway tests check the final pre-transport assertion after awaited policy. Codex tests execute managed-binary setup and prove revoked local authority prevents the spawn call; another test uses the actual pinned binary to prove framing, credential isolation, and cleanup. Synthetic undeclared-command/revocation tests are boundary proof, not a claimed live malicious-plugin exploit.

Final repair commands, all passing:

```bash
node scripts/run-vitest.mjs src/agents/harness/host-capability.test.ts src/agents/harness/selection.test.ts src/auto-reply/reply/agent-runner-node-authority.test.ts src/gateway/node-invoke-plugin-policy.session-full.test.ts src/gateway/node-invoke-plugin-policy.test.ts src/node-host/plugin-exec-policy.test.ts extensions/codex/src/node-exec-server.test.ts
```

**257 tests**, seven files, five shards. The scoped `check-changed` plan also passed production/test types, lint, boundary, schema, and cycle checks. Fresh Codex autoreview was clean at its configured **P0-only** threshold; it is not presented as an all-priority or runtime audit.

```bash
pnpm build
```

Full build passed in **5m 18.5s**. Earlier integrated verification passed **641 focused TS tests** plus **194 approval siblings**; the four CI-repair files passed **77 tests**; complete changed gates included **513 contract/tooling tests**. Native proof passed **162 tests in the original ten-suite order**, two extra cancellation runs, and full OpenClawKit (**1,480 Swift Testing tests**, seven native-state tests, 57 XCTest cases with one existing live-audio skip).

```bash
swift test --package-path apps/macos --manifest-cache none --build-system native --disable-automatic-resolution --skip-update --jobs 2 --no-parallel --filter MacNodeHostWorkerTests
```

All **27 worker tests** passed after removing the unused serializer. SwiftFormat used `config/swiftformat`; dependency pins were unchanged.

### CI and review history

Initial [CI run 33162034999](https://github.com/openclaw/openclaw/actions/runs/33162034999) exposed six stale fixture/expectation failures. All reproduced locally and were repaired only in tests: real preparation/policy/dispatch replaced broad phase mocks, preparation returned a valid payload, native CLI defaults covered unconfigured and explicit-ask cases, and the exact plugin context included its authorization callback. Periphery then found the uncalled serializer in [run 33166149077](https://github.com/openclaw/openclaw/actions/runs/33166149077); it was deleted, not suppressed. Head `7475375` completed [CI 33167240190](https://github.com/openclaw/openclaw/actions/runs/33167240190) green before the late command-confinement finding was addressed.

Pre-rebase CI [33171086607](https://github.com/openclaw/openclaw/actions/runs/33171086607) completed green for `f3ed06598853b59cdd40ba6f37b4e7ce070a68dc`, and native prepare succeeded. GitHub then rejected the merge after a new mainline test conflict; the conflict-resolved current head and its new CI are recorded above. The [latest ClawSweeper finding and rank-up requests](https://github.com/openclaw/openclaw/pull/131717#issuecomment-5451289644) are addressed by the command-bound repair, before/after regressions, final live rerun, explicit default acceptance, and pinned dependency inspection. Its storage heuristic points to in-process generations and existing placement reads, not a schema/storage-design change.

Other retained verification failures were diagnosed rather than hidden: stale SwiftPM manifest evaluation resolved with `--manifest-cache none` and unchanged pins; stale tsgo diagnostics cleared after the supported owner-project rebuild; an accidental SwiftPM Xcode-build-system invocation compiled but could not load Sparkle for discovery, while the established native build system passed. An initial deny probe rejected execution but expected the wrong diagnostic; a fresh source-backed probe verified the canonical persisted-policy rejection. No weaker assertion, longer deadline, dependency override, or source workaround was used to silence these failures.

### Inspected visual proof

Before native hosting integration:

![Native Mac could not host a session](https://github.com/user-attachments/assets/bd350a6d-624c-48fb-8f02-3dbe69cfa7e0)

Post-confinement Codex session through Done:

https://github.com/user-attachments/assets/e78db421-c298-468a-855f-979de508c340

Post-confinement embedded OpenClaw session through Done:

https://github.com/user-attachments/assets/d16a3ea5-60fe-444a-b792-57228db7ab79

Full access still respects persisted node-local deny:

![Full session visibly refused by node-local policy](https://github.com/user-attachments/assets/87194102-f761-4d5e-a267-8a3e26c24981)

Videos remove only the first six seconds of private setup/picker UI; playback speed is unchanged, and timings use untrimmed events. Eight first/intermediate/final frames were inspected; 55 additional local OCR samples had no private-device matches. A temporary provisioning badge says `Runs on Cloud` before `Runs on device`; actual Studio placement and execution were independently verified, not inferred from the badge.

Documentation: [Nodes](https://docs.openclaw.ai/nodes), [Exec approvals](https://docs.openclaw.ai/tools/exec-approvals), [Codex harness](https://docs.openclaw.ai/plugins/codex-harness), [Harness SDK](https://docs.openclaw.ai/plugins/sdk-agent-harness#paired-device-execution).
