### PR TITLE
fix(matrix): live message previews can leak content past outbound-filtering hooks

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler-draft-controller.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-draft-controller.test.ts
@@ -1,0 +1,81 @@
+// Matrix tests cover the draft controller's hook-safety gate for provider previews.
+import { describe, expect, it, vi } from "vitest";
+
+const getGlobalHookRunner = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/plugin-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/plugin-runtime")>()),
+  getGlobalHookRunner,
+}));
+
+vi.mock("../draft-stream.js", () => ({
+  createMatrixDraftStream: vi.fn(() => ({
+    update: vi.fn(),
+    stop: vi.fn(async () => undefined),
+    discardPending: vi.fn(async () => {}),
+    eventId: vi.fn(() => undefined),
+    mustDeliverFinalNormally: vi.fn(() => false),
+    matchesPreparedText: vi.fn(() => false),
+    finalizeLive: vi.fn(async () => false),
+    reset: vi.fn(),
+  })),
+}));
+
+import { createMatrixDraftController } from "./handler-draft-controller.js";
+
+function baseParams() {
+  return {
+    streaming: "partial" as const,
+    previewToolProgressEnabled: false,
+    replyToMode: "off" as const,
+    messageId: "$event:example.org",
+    cfg: {} as never,
+    accountId: "acct1",
+    roomId: "!room:example.org",
+    client: {} as never,
+    logVerboseMessage: () => {},
+  };
+}
+
+describe("createMatrixDraftController hook safety", () => {
+  it("starts a draft stream when no hooks are registered", async () => {
+    getGlobalHookRunner.mockReturnValue(null);
+
+    const controller = await createMatrixDraftController(baseParams());
+
+    expect(controller.draftStream).toBeDefined();
+  });
+
+  it("preserves the draft stream for observer-only hooks", async () => {
+    getGlobalHookRunner.mockReturnValue({
+      hasHooks: (name: string) => name === "message_sent",
+    });
+
+    const controller = await createMatrixDraftController(baseParams());
+
+    expect(controller.draftStream).toBeDefined();
+  });
+
+  it.each(["reply_payload_sending", "message_sending"])(
+    "suppresses the draft stream when %s is registered",
+    async (hookName) => {
+      getGlobalHookRunner.mockReturnValue({
+        hasHooks: (name: string) => name === hookName,
+      });
+
+      const controller = await createMatrixDraftController(baseParams());
+
+      expect(controller.draftStream).toBeUndefined();
+    },
+  );
+
+  it("suppresses the draft stream when both modifying hooks are registered", async () => {
+    getGlobalHookRunner.mockReturnValue({
+      hasHooks: (name: string) => name === "reply_payload_sending" || name === "message_sending",
+    });
+
+    const controller = await createMatrixDraftController(baseParams());
+
+    expect(controller.draftStream).toBeUndefined();
+  });
+});

--- a/extensions/matrix/src/matrix/monitor/handler-draft-controller.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-draft-controller.ts
@@ -5,6 +5,7 @@ import {
   formatChannelProgressDraftLine,
   formatChannelProgressDraftText,
 } from "openclaw/plugin-sdk/channel-outbound";
+import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import type { GetReplyOptions } from "openclaw/plugin-sdk/reply-runtime";
 import type { CoreConfig, MatrixConfig, MatrixStreamingMode, ReplyToMode } from "../../types.js";
 import type { MatrixClient } from "../sdk.js";
@@ -41,7 +42,14 @@ export async function createMatrixDraftController(params: {
   type DraftDisposition = "active" | "retained" | "consumed";
   let draftDisposition: DraftDisposition = "active";
 
-  const draftStreamingEnabled = streaming !== "off";
+  // Provider drafts render before outbound modifiers run. Keep them off whenever a hook can
+  // rewrite or cancel the payload so the raw draft cannot escape the durable delivery gate.
+  const hookRunner = getGlobalHookRunner();
+  const allowProviderPreview = !(
+    (hookRunner?.hasHooks("reply_payload_sending") ?? false) ||
+    (hookRunner?.hasHooks("message_sending") ?? false)
+  );
+  const draftStreamingEnabled = allowProviderPreview && streaming !== "off";
   const quietDraftStreaming = streaming === "quiet" || streaming === "progress";
   const progressDraftStreaming = streaming === "progress";
   const draftReplyToId = replyToMode !== "off" && !threadTarget ? messageId : undefined;


### PR DESCRIPTION
**AI-assisted change** (Claude, via Claude Code). I understand what the code does and verified the failure and the fix with local tests; see Evidence below. No pre-existing issue for this — happy to open one if preferred.

## What Problem This Solves

Fixes an issue where a plugin that registers a `reply_payload_sending` or `message_sending` hook to rewrite or block outbound replies on a Matrix account cannot actually stop the original, unfiltered content from reaching the room: Matrix's live "draft" preview already streamed the raw model output into the room before those hooks ever run.

## Why This Change Was Made

`createMatrixDraftController` enabled the live draft stream purely from the account's `streaming` config, with no awareness of registered outbound-modifying hooks. Discord, Telegram, Mattermost, and Feishu already guard the equivalent code path (see e.g. the mattermost fix at 817aec8445d689a5322c799f215c30b7194e9b97, "fix(mattermost): prevent hook-controlled preview leaks", and the matching telegram/discord commits) by disabling the provider preview whenever `reply_payload_sending` or `message_sending` is registered. This change applies the same guard to Matrix, in the one place (`draftStreamingEnabled`) that everything else in the controller (`shouldStreamPreviewToolProgress`, `shouldSuppressDefaultToolProgressMessages`, etc.) already derives from.

## User Impact

Operators running a content-filtering, redaction, or approval-gating plugin on a Matrix account now get the same guarantee they already have on every other streaming-capable channel: the plugin's hook is the source of truth for what actually reaches the room, not a preview that already leaked before the hook ran.

## Evidence

- Added `extensions/matrix/src/matrix/monitor/handler-draft-controller.test.ts` (no direct unit test previously existed for this function) covering: no hooks → draft stream starts; observer-only `message_sent` hook → draft stream still starts; `reply_payload_sending` and/or `message_sending` registered → draft stream is suppressed.
- `node scripts/run-vitest.mjs extensions/matrix/src/matrix/monitor/handler-draft-controller.test.ts` → 5 passed.
- Confirmed the pre-fix code lets the draft stream start even with `reply_payload_sending` registered (reproduced the leak against `main` before writing the fix), and confirmed unrelated existing test files touching this controller's broader integration surface are unaffected by this change (the guard is additive and defaults to unchanged behavior with no hooks registered).
