### PR TITLE
fix(transcripts): keep date-shaped IDs readable and stop handles unambiguous

### DIFF
--- a/docs/cli/transcripts.md
+++ b/docs/cli/transcripts.md
@@ -57,11 +57,21 @@ openclaw transcripts path <session> --json
 | `path <session> --transcript` | Materialize and print `transcript.jsonl`.            |
 | `--json`                      | Print machine-readable output (any subcommand).      |
 
-`<session>` accepts either a bare session id or a date-qualified selector
-(`YYYY-MM-DD/<session>`). Use the qualified form when the same session id
-occurs on more than one day, for example `openclaw transcripts show
-2026-05-22/standup`. Default session ids include a timestamp and random
-suffix; give a session a fixed id only when that id is unique within the day.
+Use the selector printed by `list` to address an exact capture. An existing
+canonical selector takes priority over a raw session ID with the same text.
+Otherwise, `show` and `path` accept `YYYY-MM-DD/<raw-session-id>`, keeping the
+entire suffix literal, including punctuation and slashes. For example:
+
+```bash
+openclaw transcripts show '2026-05-22/notes: room/one'
+```
+
+If neither qualified form finds a capture, the complete input is matched as a
+literal raw session ID or export slug, case-sensitively. A date-like prefix in
+a raw ID does not prevent this lookup. Multiple matches require a dated
+selector; no raw ID is sanitized to choose a capture. Default session IDs
+include a timestamp and random suffix; give a session a fixed ID only when
+that ID is unique within the day.
 
 If the filesystem-safe export name exceeds 255 bytes, OpenClaw shortens it
 to a prefix plus a deterministic SHA-256 hash of the complete original session
@@ -81,6 +91,41 @@ summary path.
 ```
 
 The selector is the safest value to pass back to `show` or `path`.
+
+## Tool selectors
+
+The `transcripts` tool returns both the unchanged raw `sessionId` and a canonical
+`selector` from start, import, stop, and summarize. Authorized `status` results
+include selectors for active captures and entries awaiting finalization. Its
+model-facing text shows up to three complete selectors, prioritizing captures
+awaiting finalization and reporting any omitted count. Structured status details
+retain the full authorized list. Prefer `selector` for subsequent stop or
+summarize calls:
+
+```json validate=false
+{ "action": "summarize", "selector": "2026-05-22/notes-room-one" }
+```
+
+Stop and summarize require exactly one of `selector` or `sessionId`. Other
+actions reject `selector`; start and import continue to accept raw IDs through
+`sessionId`. Explicit `selector` input accepts canonical selectors and the
+historical date/raw-ID form above, but never falls back to the whole input as a
+raw ID.
+
+Legacy `sessionId` input considers qualified and raw/slug meanings together. If
+they identify different captures, the tool reports ambiguity without listing
+candidate details. This stays ambiguous after a capture ends. Use a selector
+returned by start, import, or authorized status, or inspect `openclaw transcripts
+list` locally and pass the desired value in the `selector` field. Both sides of
+a raw-ID/selector collision remain addressable by their own canonical selector.
+
+Without a conflicting qualified meaning or a different raw-ID/slug candidate,
+legacy `sessionId` selects the current exact raw-ID capture for both stop and
+summarize, even when historical captures reuse that ID. With no current capture,
+repeated historical IDs require a dated selector. An explicit selector for an
+older capture does not stop its newer same-ID sibling.
+
+## JSON output
 
 `list --json` returns objects with `sessionId`, `selector`, `date`, `title`,
 `startedAt`, `stoppedAt`, `source`, `path`, `summaryPath`, `hasSummary`.

--- a/scripts/lib/session-accessor-debt-baseline.json
+++ b/scripts/lib/session-accessor-debt-baseline.json
@@ -3,7 +3,6 @@
   "memoryHostSessionCorpus": {},
   "sessionAccessorRead": {
     "src/agents/subagents/announce/subagent-announce.test-support.ts": 2,
-    "src/agents/tools/transcripts-tool.ts": 2,
     "src/auto-reply/reply/commands-session-store.ts": 2,
     "src/config/sessions/session-accessor.entry.ts": 1
   },

--- a/src/agents/tools/transcripts-tool-runtime.ts
+++ b/src/agents/tools/transcripts-tool-runtime.ts
@@ -12,6 +12,7 @@ import type {
   TranscriptsStartResult,
 } from "../../transcripts/provider-types.js";
 import { sanitizeTranscriptSourceLocator } from "../../transcripts/source-locator.js";
+import { transcriptSessionSelector } from "../../transcripts/store-artifacts.js";
 import type { TranscriptsStore } from "../../transcripts/store.js";
 import { summarizeTranscripts } from "../../transcripts/summary.js";
 import { truncateUtf16Safe } from "../../utils.js";
@@ -60,7 +61,7 @@ export function isTranscriptSessionStarting(sessionId: string): boolean {
   return startingSessionIds.has(sessionId);
 }
 
-export async function persistTranscriptSummary(params: {
+export async function readTranscriptSummary(params: {
   config: ReturnType<typeof resolveTranscriptsConfig>;
   store: TranscriptsStore;
   session: TranscriptSessionDescriptor;
@@ -68,7 +69,13 @@ export async function persistTranscriptSummary(params: {
   const utterances = await params.store.readUtterancesForSession(params.session, {
     maxUtterances: params.config.maxUtterances,
   });
-  const summary = summarizeTranscripts({ session: params.session, utterances });
+  return summarizeTranscripts({ session: params.session, utterances });
+}
+
+export async function persistTranscriptSummary(
+  params: Parameters<typeof readTranscriptSummary>[0],
+) {
+  const summary = await readTranscriptSummary(params);
   const intendedSummaryPath = await params.store.writeSummary(summary, params.session);
   return { summary, intendedSummaryPath };
 }
@@ -299,9 +306,14 @@ export function resolveTranscriptSourceOwnership(params: {
   return { source: providerSource };
 }
 
-export function toolText(text: string, details?: Record<string, unknown>) {
+export function toolText(text: string, details?: Record<string, unknown> & { selector?: string }) {
   return {
-    content: [{ type: "text" as const, text }],
+    content: [
+      {
+        type: "text" as const,
+        text: details?.selector ? `${text}\nSelector: ${details.selector}` : text,
+      },
+    ],
     details: details ?? {},
   };
 }
@@ -457,6 +469,7 @@ export async function startTranscripts(params: {
       await finalizeTranscriptCapture({ ...params, entry });
       return toolText(`Transcripts ended during startup: ${session.sessionId}`, {
         sessionId: session.sessionId,
+        selector: transcriptSessionSelector(session),
         active: false,
         stoppedAt: entry.session.stoppedAt,
       });
@@ -468,6 +481,7 @@ export async function startTranscripts(params: {
       {
         sessionId: session.sessionId,
         startedAt: session.startedAt,
+        selector: transcriptSessionSelector(session),
         providerId: provider.id,
         ...(effectiveAccount ? { accountId: effectiveAccount } : {}),
       },

--- a/src/agents/tools/transcripts-tool-selection.ts
+++ b/src/agents/tools/transcripts-tool-selection.ts
@@ -1,0 +1,130 @@
+import type { TranscriptSessionDescriptor } from "../../transcripts/provider-types.js";
+import { transcriptSessionSelector, type TranscriptsStore } from "../../transcripts/store.js";
+import {
+  activeSessions,
+  authorizeTranscriptSource,
+  readTranscriptStringParam,
+  resolveSourceProvider,
+  toolText,
+  type TranscriptsRuntimeContext,
+} from "./transcripts-tool-runtime.js";
+
+type TranscriptSessionIdentity = Pick<TranscriptSessionDescriptor, "sessionId" | "startedAt">;
+
+function sameSessionIdentity(
+  left: TranscriptSessionIdentity,
+  right: TranscriptSessionIdentity,
+): boolean {
+  return left.sessionId === right.sessionId && left.startedAt === right.startedAt;
+}
+
+function ownsTranscriptSession(
+  ctx: TranscriptsRuntimeContext,
+  session: TranscriptSessionDescriptor,
+): boolean {
+  const ownerAgentId = session.metadata?.agentId;
+  if (typeof ownerAgentId === "string") {
+    return ownerAgentId === ctx.agentId;
+  }
+  // Shipped ownerless rows stay with main; provider access still decides whether
+  // the current caller may act on an account-bound canonical source.
+  return ctx.agentId ? ctx.agentId === "main" : ctx.caller?.kind === "operator";
+}
+
+export async function canAccessTranscriptSession(
+  ctx: TranscriptsRuntimeContext,
+  session: TranscriptSessionDescriptor,
+  action: "status" | "stop" | "summarize",
+): Promise<boolean> {
+  if (!ownsTranscriptSession(ctx, session)) {
+    return false;
+  }
+  const provider = resolveSourceProvider(session.source.providerId, ctx);
+  if (!provider) {
+    return ctx.caller?.kind === "operator";
+  }
+  try {
+    await authorizeTranscriptSource({ action, ctx, provider, source: session.source });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function resolveTranscriptToolSession(params: {
+  ctx: TranscriptsRuntimeContext;
+  store: TranscriptsStore;
+  rawParams: Record<string, unknown>;
+  action: "stop" | "summarize";
+}) {
+  const explicit = params.rawParams.selector !== undefined;
+  if (explicit === (params.rawParams.sessionId !== undefined)) {
+    throw new Error("Provide exactly one of selector or sessionId for stop or summarize.");
+  }
+  const value = readTranscriptStringParam(params.rawParams, explicit ? "selector" : "sessionId", {
+    required: true,
+    trim: true,
+  });
+  params.ctx.assertCallerActive?.();
+  const exactActive = explicit ? undefined : activeSessions.get(value);
+  const { qualified, unqualified } = params.store.matchSessionEntries(value);
+  let entry: { session: TranscriptSessionDescriptor; selector: string } | undefined;
+  // Current raw handles can span historical dates, but never another raw ID
+  // or a conflicting qualified meaning. Authorization cannot break a tie.
+  const preferActive =
+    !qualified.length &&
+    exactActive &&
+    unqualified.every((candidate) => candidate.session.sessionId === value);
+  if (preferActive) {
+    entry = {
+      session: exactActive.session,
+      selector: transcriptSessionSelector(exactActive.session),
+    };
+  } else {
+    const candidates = explicit ? qualified : [...qualified, ...unqualified];
+    const distinct = candidates.filter(
+      (candidate, index) =>
+        candidates.findIndex((other) => sameSessionIdentity(candidate.session, other.session)) ===
+        index,
+    );
+    if (distinct.length > 1) {
+      throw new Error(
+        "Ambiguous transcripts session; pass selector from start, import, status, or the local transcripts list.",
+      );
+    }
+    entry = distinct[0];
+  }
+  const activeCandidate = preferActive
+    ? exactActive
+    : entry && activeSessions.get(entry.session.sessionId);
+  const selectedActive =
+    entry && activeCandidate && sameSessionIdentity(entry.session, activeCandidate.session)
+      ? activeCandidate
+      : undefined;
+  // A durable same-tuple rewrite cannot rebind an admitted capture's authority.
+  // Historical selection still authorizes the canonical stored source.
+  const session = selectedActive?.session ?? entry?.session;
+  if (
+    !entry ||
+    !session ||
+    !(await canAccessTranscriptSession(params.ctx, session, params.action))
+  ) {
+    throw new Error(`transcripts session not found: ${value}`);
+  }
+  return { session, selector: entry.selector, activeCandidate, selectedActive };
+}
+
+type TranscriptToolSelection = Awaited<ReturnType<typeof resolveTranscriptToolSession>>;
+
+export function isTranscriptSelectionCurrent(selection: TranscriptToolSelection): boolean {
+  return activeSessions.get(selection.session.sessionId) === selection.activeCandidate;
+}
+
+export function transcriptSelectionNoLongerActive(selection: TranscriptToolSelection) {
+  const sessionId = selection.session.sessionId;
+  return toolText(`Transcripts session no longer active: ${sessionId}`, {
+    sessionId,
+    selector: selection.selector,
+    skipped: true,
+  });
+}

--- a/src/agents/tools/transcripts-tool.account-ownership.test.ts
+++ b/src/agents/tools/transcripts-tool.account-ownership.test.ts
@@ -456,7 +456,7 @@ describe("transcripts tool account ownership", () => {
     );
     expect(result.details).toMatchObject({ accountId: meetingAccountId });
     const text = result.content.find((entry) => entry.type === "text")?.text;
-    expect(text?.split("\n")).toHaveLength(2);
+    expect(text?.split("\n")).toHaveLength(3);
     expect(text).not.toContain("x".repeat(65));
     expect(text).toContain('Account: "meeting\\n');
   });

--- a/src/agents/tools/transcripts-tool.lifecycle.test.ts
+++ b/src/agents/tools/transcripts-tool.lifecycle.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import type {
@@ -77,6 +78,47 @@ function harness() {
 }
 
 describe("transcript capture ownership", () => {
+  it.each(["stop", "summarize"] as const)(
+    "rejects %s when its caller closes during provider policy",
+    async (action) => {
+      const h = harness();
+      await h.start();
+      let callerActive = true;
+      const tool = h.createTool(() => {
+        if (!callerActive) {
+          throw new Error("caller ended");
+        }
+      });
+      const entered = createDeferred();
+      const release = createDeferred();
+      h.provider.accessControl = {
+        channelId: "capture-channel",
+        resolveAccountId: ({ source }) => ({ ok: true, value: source.accountId }),
+        authorize: async () => {
+          entered.resolve();
+          await release.promise;
+          return { ok: true, value: undefined };
+        },
+      };
+      const session = await h.session();
+      const pending = tool.execute("closed-caller", {
+        action,
+        selector: `${session.startedAt.slice(0, 10)}/notes`,
+      });
+      const rejected = expect(pending).rejects.toThrow();
+      try {
+        await Promise.race([entered.promise, pending]);
+        callerActive = false;
+      } finally {
+        release.resolve();
+      }
+      await rejected;
+      expect(h.provider.stop).not.toHaveBeenCalled();
+      expect((await h.session()).stoppedAt).toBeUndefined();
+      expect(await h.store.readSummary(session)).toEqual({});
+    },
+  );
+
   it.each(["terminal", "rejected", "thrown"] as const)(
     "fences a %s startup and its retained callbacks after same-millisecond id reuse",
     async (outcome) => {
@@ -109,7 +151,12 @@ describe("transcript capture ownership", () => {
       };
       if (outcome === "terminal") {
         await expect(h.start()).resolves.toMatchObject({
-          details: { sessionId: "notes", active: false, stoppedAt: expect.any(String) },
+          details: {
+            sessionId: "notes",
+            selector: `${new Date().toISOString().slice(0, 10)}/notes`,
+            active: false,
+            stoppedAt: expect.any(String),
+          },
         });
         expect(await h.store.readSummary(await h.session())).toMatchObject({
           summary: { utteranceCount: 1 },
@@ -207,7 +254,13 @@ describe("transcript capture ownership", () => {
       await expect(h.execute({ action: "status" })).resolves.toMatchObject({
         details: {
           active: [],
-          pendingFinalization: [{ sessionId: "notes", stoppedAt: expect.any(String) }],
+          pendingFinalization: [
+            {
+              sessionId: "notes",
+              selector: `${request.session.startedAt.slice(0, 10)}/notes`,
+              stoppedAt: expect.any(String),
+            },
+          ],
         },
       });
       expect(h.logger.warn).toHaveBeenCalledWith(
@@ -225,9 +278,15 @@ describe("transcript capture ownership", () => {
     },
   );
 
-  it.each(["stop", "status"] as const)(
-    "revalidates capture identity after awaited %s authorization without reusing startup authority",
-    async (action) => {
+  it.each([
+    { action: "stop", key: "sessionId" },
+    { action: "stop", key: "selector" },
+    { action: "summarize", key: "sessionId" },
+    { action: "summarize", key: "selector" },
+    { action: "status", key: "sessionId" },
+  ] as const)(
+    "revalidates capture identity after awaited $action authorization via $key without reusing startup authority",
+    async ({ action, key }) => {
       vi.useFakeTimers({ toFake: ["Date"] });
       const h = harness();
       let callerActive = true;
@@ -262,18 +321,118 @@ describe("transcript capture ownership", () => {
         providerId: "capture",
         sessionId: "notes",
       });
-      const delayed = h.execute({ action, sessionId: "notes" });
-      await entered;
+      const delayed = h.execute({
+        action,
+        ...(action !== "status"
+          ? {
+              [key]:
+                key === "selector" ? `${new Date().toISOString().slice(0, 10)}/notes` : "notes",
+            }
+          : {}),
+      });
+      await Promise.race([entered, delayed]);
       callerActive = false;
       await h.requests[0]!.onStatus?.({ active: false });
       await h.start();
+      const replacement = await h.session();
+      const savedSummary = await h.store.readSummary(replacement);
+      const read = vi.spyOn(TranscriptsStore.prototype, "readUtterancesForSession");
+      const write = vi.spyOn(TranscriptsStore.prototype, "writeSummary");
+      const materialize = vi.spyOn(TranscriptsStore.prototype, "materializeSessionArtifacts");
       releaseAuthorization();
-      await expect(delayed).resolves.toMatchObject({
-        details: action === "stop" ? { skipped: true } : { active: [] },
+      await expect.soft(delayed).resolves.toMatchObject({
+        details: action === "status" ? { active: [] } : { skipped: true },
+      });
+      expect.soft(read).not.toHaveBeenCalled();
+      expect.soft(write).not.toHaveBeenCalled();
+      expect.soft(materialize).not.toHaveBeenCalled();
+      expect.soft(await h.store.readSummary(replacement)).toEqual(savedSummary);
+      await expect.soft(fs.stat(h.store.sessionDir(replacement))).rejects.toMatchObject({
+        code: "ENOENT",
       });
       expect(h.provider.stop).not.toHaveBeenCalled();
       expect((await h.session()).stoppedAt).toBeUndefined();
       await h.execute({ action: "stop", sessionId: "notes" });
     },
   );
+
+  it("does not persist or export a summary after its capture retires during the read", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    const h = harness();
+    await h.start();
+    const session = await h.session();
+    await h.requests[0]!.onUtterance({ text: "before retirement" });
+    const entered = createDeferred();
+    const release = createDeferred();
+    const originalRead = h.store.readUtterancesForSession.bind(h.store);
+    vi.spyOn(TranscriptsStore.prototype, "readUtterancesForSession").mockImplementationOnce(
+      async (...args) => {
+        const utterances = await originalRead(...args);
+        entered.resolve();
+        await release.promise;
+        return utterances;
+      },
+    );
+    const delayed = h.execute({
+      action: "summarize",
+      selector: `${session.startedAt.slice(0, 10)}/notes`,
+    });
+    try {
+      await Promise.race([entered.promise, delayed]);
+      await h.requests[0]!.onStatus?.({ active: false });
+      await h.start();
+      await h.requests[1]!.onUtterance({ text: "replacement note" });
+    } finally {
+      release.resolve();
+    }
+    const write = vi.spyOn(TranscriptsStore.prototype, "writeSummary");
+    const materialize = vi.spyOn(TranscriptsStore.prototype, "materializeSessionArtifacts");
+    await expect.soft(delayed).resolves.toMatchObject({ details: { skipped: true } });
+    expect.soft(write).not.toHaveBeenCalled();
+    expect.soft(materialize).not.toHaveBeenCalled();
+    await expect
+      .soft(fs.stat(h.store.sessionDir(session)))
+      .rejects.toMatchObject({ code: "ENOENT" });
+    expect((await h.session()).stoppedAt).toBeUndefined();
+    await h.execute({ action: "stop", sessionId: "notes" });
+  });
+
+  it.each([
+    { phase: "active", fault: "missing" },
+    { phase: "active", fault: "unreadable" },
+    { phase: "terminal", fault: "missing" },
+    { phase: "terminal", fault: "unreadable" },
+  ] as const)("keeps $phase status visible with a $fault stored row", async ({ phase, fault }) => {
+    const h = harness();
+    await h.start();
+    const session = await h.session();
+    if (phase === "terminal") {
+      const write = vi
+        .spyOn(TranscriptsStore.prototype, "writeSession")
+        .mockRejectedValueOnce(new Error("store unavailable"));
+      await expect(h.requests[0]!.onStatus?.({ active: false })).rejects.toThrow(
+        "store unavailable",
+      );
+      write.mockRestore();
+    }
+    const read = vi.spyOn(TranscriptsStore.prototype, "readSessionEntry");
+    if (fault === "missing") {
+      read.mockResolvedValue(undefined);
+    } else {
+      read.mockRejectedValue(new Error("row unreadable"));
+    }
+    await expect.soft(h.execute({ action: "status" })).resolves.toMatchObject({
+      details: {
+        [phase === "terminal" ? "pendingFinalization" : "active"]: [
+          {
+            sessionId: "notes",
+            selector: `${session.startedAt.slice(0, 10)}/notes`,
+          },
+        ],
+      },
+    });
+    expect.soft(read).not.toHaveBeenCalled();
+    read.mockRestore();
+    await h.execute({ action: "stop", sessionId: "notes" });
+  });
 });

--- a/src/agents/tools/transcripts-tool.selection.test.ts
+++ b/src/agents/tools/transcripts-tool.selection.test.ts
@@ -1,0 +1,447 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import type {
+  TranscriptSourceProvider,
+  TranscriptStartRequest,
+} from "../../transcripts/provider-types.js";
+import { TranscriptsStore, transcriptSessionSelector } from "../../transcripts/store.js";
+import { activeSessions } from "./transcripts-tool-runtime.js";
+import { createTranscriptsAutoStartService, createTranscriptsTool } from "./transcripts-tool.js";
+
+const { getProvider } = vi.hoisted(() => ({ getProvider: vi.fn() }));
+vi.mock("../../transcripts/provider-registry.js", () => ({
+  getTranscriptSourceProvider: getProvider,
+  listTranscriptSourceProviders: () => [],
+}));
+const tempDirs = createTempDirTracker();
+afterEach(() => {
+  activeSessions.clear();
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+  closeOpenClawStateDatabaseForTest();
+  tempDirs.cleanup();
+});
+
+function harness() {
+  vi.useFakeTimers({ toFake: ["Date"] });
+  const stateDir = tempDirs.make("transcript-selection-");
+  const requests: TranscriptStartRequest[] = [];
+  const authorize = vi.fn<NonNullable<TranscriptSourceProvider["accessControl"]>["authorize"]>(
+    async ({ source }) =>
+      source.accountId === "private-account"
+        ? { ok: false, error: "private provider reason" }
+        : { ok: true, value: undefined },
+  );
+  const stop = vi.fn<NonNullable<TranscriptSourceProvider["stop"]>>(async ({ sessionId }) => ({
+    ok: true,
+    sessionId,
+  }));
+  const provider: TranscriptSourceProvider = {
+    id: "capture",
+    name: "Capture",
+    sourceKinds: ["live-audio"],
+    accessControl: {
+      channelId: "capture",
+      resolveAccountId: ({ source }) => ({ ok: true, value: source.accountId }),
+      authorize,
+    },
+    start: async (request) => {
+      requests.push(request);
+      await request.onUtterance({ text: `Notes for ${request.session.sessionId}`, final: true });
+      return { ok: true, session: request.session };
+    },
+    stop,
+  };
+  getProvider.mockReturnValue(provider);
+  const ctx = {
+    stateDir,
+    agentId: "research",
+    caller: { kind: "operator" as const, source: "local" as const },
+    logger: { warn: vi.fn() },
+  };
+  const tool = createTranscriptsTool(ctx);
+  const execute = (params: Record<string, unknown>) => tool.execute("selection", params);
+  const store = new TranscriptsStore(path.join(stateDir, "transcripts"), {
+    env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+  });
+  const start = async (id: string, date: string) => {
+    vi.setSystemTime(new Date(`${date}T10:00:00.000Z`));
+    return await execute({ action: "start", providerId: provider.id, sessionId: id });
+  };
+  const configuredCapture = (accountId: string) =>
+    createTranscriptsAutoStartService({
+      ...ctx,
+      config: {
+        transcripts: { autoStart: [{ providerId: "capture", sessionId: "notes", accountId }] },
+      },
+    });
+  return { ctx, execute, start, configuredCapture, store, requests, stop, authorize };
+}
+
+const collision = [
+  { sessionId: "2026-07-03/raw-id", date: "2026-07-04", selector: "2026-07-04/2026-07-03-raw-id" },
+  { sessionId: "raw-id", date: "2026-07-03", selector: "2026-07-03/raw-id" },
+];
+
+describe("transcript tool selection", () => {
+  it.each([false, true])(
+    "rejects legacy collisions before and after retirement; reversed=%s",
+    async (reverse) => {
+      const h = harness();
+      for (const target of reverse ? collision.toReversed() : collision) {
+        await h.start(target.sessionId, target.date);
+      }
+      const rejectLegacy = async () => {
+        h.authorize.mockClear();
+        for (const action of ["stop", "summarize"]) {
+          await expect(h.execute({ action, sessionId: collision[0]!.sessionId })).rejects.toThrow(
+            /ambiguous.*selector/i,
+          );
+        }
+        expect(h.authorize).not.toHaveBeenCalled();
+      };
+      await rejectLegacy();
+      expect(h.stop).not.toHaveBeenCalled();
+      for (const request of h.requests) {
+        expect(await h.store.readSummary(request.session)).toEqual({});
+        expect(
+          (await h.store.readSession(transcriptSessionSelector(request.session)))?.stoppedAt,
+        ).toBeUndefined();
+        await expect(fs.stat(h.store.sessionDir(request.session))).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+      }
+      const status = await h.execute({ action: "status" });
+      expect(status).toMatchObject({
+        details: {
+          active: expect.arrayContaining(
+            collision.map(({ sessionId, selector }) =>
+              expect.objectContaining({ sessionId, selector }),
+            ),
+          ),
+        },
+      });
+      const statusText = status.content.find((part) => part.type === "text")?.text ?? "";
+      const shownSelectors = [...statusText.matchAll(/^active: (.+)$/gm)].map((match) => match[1]);
+      expect(shownSelectors).toEqual(collision.map(({ selector }) => selector).toSorted());
+      for (const target of collision) {
+        const selector = shownSelectors.find((value) => value === target.selector);
+        for (const action of ["summarize", "stop", "stop"]) {
+          const result = await h.execute({ action, selector });
+          expect(result).toMatchObject({
+            details: {
+              sessionId: target.sessionId,
+              selector: target.selector,
+              summary: {
+                sessionId: target.sessionId,
+                transcript: [`Notes for ${target.sessionId}`],
+              },
+            },
+          });
+          expect(result.content).toContainEqual({
+            type: "text",
+            text: expect.stringContaining(`Selector: ${target.selector}`),
+          });
+        }
+        expect(h.stop.mock.calls.map(([request]) => request.sessionId)).toEqual(
+          collision.slice(0, collision.indexOf(target) + 1).map(({ sessionId }) => sessionId),
+        );
+        await rejectLegacy();
+      }
+    },
+  );
+
+  it.each(["raw-id", "2026-07-03/raw-id"])(
+    "prefers the current exact raw %s only without another identity",
+    async (sessionId) => {
+      const h = harness();
+      for (const date of ["2026-07-01", "2026-07-02"]) {
+        vi.setSystemTime(new Date(`${date}T10:00:00.000Z`));
+        await h.execute({ action: "import", sessionId, transcript: `Historical ${date}` });
+      }
+      await h.start(sessionId, "2026-07-04");
+      for (const action of ["summarize", "stop"]) {
+        await expect(h.execute({ action, sessionId })).resolves.toMatchObject({
+          details: {
+            sessionId,
+            summary: { transcript: [`Notes for ${sessionId}`] },
+          },
+        });
+      }
+      expect(h.stop).toHaveBeenCalledOnce();
+      for (const action of ["summarize", "stop"]) {
+        await expect(h.execute({ action, sessionId })).rejects.toThrow(/ambiguous.*selector/i);
+        await expect(
+          h.execute({ action, selector: `2026-07-01/${sessionId}` }),
+        ).resolves.toMatchObject({
+          details: { sessionId, summary: { transcript: ["Speaker: Historical 2026-07-01"] } },
+        });
+      }
+      expect(h.stop).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("bounds model-visible status selectors without truncating recovery handles", async () => {
+    const h = harness();
+    const selectors: string[] = [];
+    for (const index of [3, 2, 1, 0]) {
+      const result = await h.start(`notes-${index}-${"x".repeat(900)}`, "2026-07-04");
+      const text = result.content.find((part) => part.type === "text")?.text ?? "";
+      const selector = text.match(/\nSelector: (.+)$/)?.[1];
+      if (!selector) {
+        throw new Error("Start must expose a complete selector to the model");
+      }
+      selectors.push(selector);
+    }
+    const failure = vi
+      .spyOn(TranscriptsStore.prototype, "writeSession")
+      .mockRejectedValueOnce(new Error("store unavailable"));
+    await expect(h.requests[0]!.onStatus?.({ active: false })).rejects.toThrow("store unavailable");
+    failure.mockRestore();
+
+    const result = await h.execute({ action: "status" });
+    const text = result.content.find((part) => part.type === "text")?.text ?? "";
+    const shown = [...text.matchAll(/^(?:pending|active): (.+)$/gm)].map((match) => match[1]);
+    expect(shown).toEqual([selectors[0], ...selectors.slice(1).toSorted().slice(0, 2)]);
+    expect(text).toContain(`pending: ${selectors[0]}`);
+    expect(text).toContain("1 more; ask a local operator to run openclaw transcripts list.");
+    expect(text).toContain("\nSelectors:\n");
+    expect(text.slice(text.indexOf("Selectors:")).length).toBeLessThanOrEqual(1024);
+    expect(text).not.toContain("x".repeat(900));
+    for (const selector of shown) {
+      await expect(h.execute({ action: "summarize", selector })).resolves.toMatchObject({
+        details: { selector },
+      });
+    }
+  });
+
+  it("does not hide a different slug identity behind repeated exact raw IDs", async () => {
+    const h = harness();
+    await h.start("foo-bar", "2026-07-04");
+    for (const [sessionId, date] of [
+      ["foo-bar", "2026-07-03"],
+      ["foo@bar", "2026-07-01"],
+    ] as const) {
+      await h.store.writeSession({
+        sessionId,
+        startedAt: `${date}T10:00:00.000Z`,
+        source: { providerId: "capture" },
+        metadata: { agentId: "research" },
+      });
+    }
+    for (const action of ["summarize", "stop"]) {
+      await expect(h.execute({ action, sessionId: "foo-bar" })).rejects.toThrow(
+        /ambiguous.*selector/i,
+      );
+    }
+    expect(h.stop).not.toHaveBeenCalled();
+  });
+
+  it.each(["agent", "account"])(
+    "never uses access denial to resolve a collision or disclose %s metadata",
+    async (denial) => {
+      const h = harness();
+      await h.start(collision[0]!.sessionId, collision[0]!.date);
+      const privateSession = {
+        sessionId: "raw-id",
+        startedAt: "2026-07-03T10:00:00.000Z",
+        title: "private title",
+        source: {
+          providerId: "capture",
+          accountId: denial === "account" ? "private-account" : "public-account",
+        },
+        metadata: { agentId: denial === "agent" ? "private-owner" : "research" },
+      };
+      await h.store.writeSession(privateSession);
+      for (const action of ["stop", "summarize"]) {
+        h.authorize.mockClear();
+        await expect(h.execute({ action, sessionId: collision[0]!.sessionId })).rejects.toThrow(
+          /^Ambiguous transcripts session; pass selector from start, import, status, or the local transcripts list\.$/,
+        );
+        expect(h.authorize).not.toHaveBeenCalled();
+        await expect(h.execute({ action, selector: collision[1]!.selector })).rejects.toThrow(
+          "transcripts session not found",
+        );
+        expect(h.authorize).toHaveBeenCalledTimes(denial === "account" ? 1 : 0);
+      }
+      expect(h.stop).not.toHaveBeenCalled();
+      expect(await h.store.readSummary(privateSession)).toEqual({});
+      await expect(h.execute({ action: "status" })).resolves.toMatchObject({
+        details: {
+          active: [{ sessionId: collision[0]!.sessionId, selector: collision[0]!.selector }],
+        },
+      });
+    },
+  );
+
+  it.each(["start", "import", "status", "stop", "summarize"])(
+    "validates selector admission before %s side effects",
+    async (action) => {
+      const h = harness();
+      const rawParams = {
+        action,
+        sessionId: "notes",
+        selector: "2026-07-03/notes",
+        providerId: "capture",
+        transcript: "do not import",
+      };
+      await expect(h.execute(rawParams)).rejects.toThrow(
+        action === "stop" || action === "summarize"
+          ? /exactly one.*selector.*sessionId/i
+          : /selector.*only.*stop.*summarize/i,
+      );
+      if (action === "stop" || action === "summarize") {
+        await expect(h.execute({ action })).rejects.toThrow(/exactly one.*selector.*sessionId/i);
+      }
+      expect(h.requests).toEqual([]);
+      expect(h.authorize).not.toHaveBeenCalled();
+      expect(h.stop).not.toHaveBeenCalled();
+      expect(await h.store.listSessionEntries()).toEqual([]);
+    },
+  );
+
+  it("explicit selectors never fall back to a whole raw ID", async () => {
+    const h = harness();
+    await h.start(collision[0]!.sessionId, collision[0]!.date);
+    for (const action of ["stop", "summarize"]) {
+      await expect(h.execute({ action, selector: collision[0]!.sessionId })).rejects.toThrow(
+        "transcripts session not found",
+      );
+    }
+    expect(h.stop).not.toHaveBeenCalled();
+  });
+
+  it("returns the canonical selector when starting and importing opaque IDs", async () => {
+    const h = harness();
+    await expect(h.start(collision[0]!.sessionId, collision[0]!.date)).resolves.toMatchObject({
+      details: { sessionId: collision[0]!.sessionId, selector: collision[0]!.selector },
+    });
+    await expect(
+      h.execute({ action: "import", sessionId: "notes: room/one", transcript: "retained" }),
+    ).resolves.toMatchObject({
+      details: { sessionId: "notes: room/one", selector: "2026-07-04/notes-room-one" },
+    });
+  });
+
+  it("keeps configured cleanup bound to its lifecycle token despite a selector collision", async () => {
+    const h = harness();
+    await h.start(collision[1]!.sessionId, collision[1]!.date);
+    vi.setSystemTime(new Date("2026-07-04T10:00:00.000Z"));
+    const service = createTranscriptsAutoStartService({
+      ...h.ctx,
+      config: {
+        transcripts: {
+          autoStart: [
+            {
+              providerId: "capture",
+              sessionId: collision[0]!.sessionId,
+              accountId: "public-account",
+            },
+          ],
+        },
+      },
+    });
+    try {
+      service.start();
+      await vi.waitFor(() => expect(activeSessions.has(collision[0]!.sessionId)).toBe(true));
+      await service.stop();
+      expect(h.stop.mock.calls.map(([request]) => request.sessionId)).toEqual([
+        collision[0]!.sessionId,
+      ]);
+      await service.stop();
+      expect(h.stop).toHaveBeenCalledOnce();
+      expect(h.ctx.logger.warn).not.toHaveBeenCalled();
+      expect(activeSessions.has(collision[1]!.sessionId)).toBe(true);
+    } finally {
+      await service.stop();
+    }
+  });
+
+  it.each(["missing", "unreadable"] as const)(
+    "cleans up a configured provider without reading its $0 stored row",
+    async (fault) => {
+      const h = harness();
+      const service = h.configuredCapture("public-account");
+      try {
+        service.start();
+        await vi.waitFor(() => expect(activeSessions.has("notes")).toBe(true));
+        const session = (await h.store.readSession("notes"))!;
+        const read = vi.spyOn(TranscriptsStore.prototype, "readSessionEntry");
+        if (fault === "missing") {
+          read.mockResolvedValue(undefined);
+        } else {
+          read.mockRejectedValue(new Error("row unreadable"));
+        }
+        await service.stop();
+        expect
+          .soft(h.stop)
+          .toHaveBeenCalledExactlyOnceWith(
+            expect.objectContaining({ sessionId: "notes", source: session.source }),
+          );
+        expect.soft(read).not.toHaveBeenCalled();
+        expect.soft(h.ctx.logger.warn).not.toHaveBeenCalled();
+        read.mockRestore();
+        expect.soft((await h.store.readSession("notes"))?.stoppedAt).toEqual(expect.any(String));
+        expect
+          .soft(await h.store.readSummary(session))
+          .toMatchObject({ summary: { transcript: ["Notes for notes"] } });
+      } finally {
+        await service.stop();
+      }
+    },
+  );
+
+  it.each(["stop", "summarize", "service-stop"] as const)(
+    "%s retains the admitted private source after a same-tuple public row rewrite",
+    async (action) => {
+      const h = harness();
+      const service = h.configuredCapture("private-account");
+      try {
+        service.start();
+        await vi.waitFor(() => expect(activeSessions.has("notes")).toBe(true));
+        const session = (await h.store.readSession("notes"))!;
+        const selector = transcriptSessionSelector(session);
+        await h.store.writeSession({
+          ...session,
+          source: { ...session.source, accountId: "public-account" },
+        });
+        expect((await h.store.readSession(selector))?.source.accountId).toBe("public-account");
+        h.authorize.mockClear();
+        if (action !== "service-stop") {
+          const read = vi.spyOn(TranscriptsStore.prototype, "readUtterancesForSession");
+          const write = vi.spyOn(TranscriptsStore.prototype, "writeSummary");
+          const materialize = vi.spyOn(TranscriptsStore.prototype, "materializeSessionArtifacts");
+          await expect
+            .soft(h.execute({ action, selector }))
+            .rejects.toThrow("transcripts session not found");
+          expect
+            .soft(h.authorize)
+            .toHaveBeenCalledExactlyOnceWith(
+              expect.objectContaining({ action, source: session.source }),
+            );
+          expect.soft(h.stop).not.toHaveBeenCalled();
+          expect.soft(read).not.toHaveBeenCalled();
+          expect.soft(write).not.toHaveBeenCalled();
+          expect.soft(materialize).not.toHaveBeenCalled();
+          expect.soft(await h.store.readSummary(session)).toEqual({});
+          expect.soft((await h.store.readSession(selector))?.stoppedAt).toBeUndefined();
+          await expect
+            .soft(fs.stat(h.store.sessionDir(session)))
+            .rejects.toMatchObject({ code: "ENOENT" });
+        }
+        await service.stop();
+        expect(h.stop).toHaveBeenCalledExactlyOnceWith(
+          expect.objectContaining({ sessionId: "notes", source: session.source }),
+        );
+        expect(await h.store.readSummary(session)).toMatchObject({
+          summary: { transcript: ["Notes for notes"] },
+        });
+      } finally {
+        await service.stop();
+      }
+    },
+  );
+});

--- a/src/agents/tools/transcripts-tool.session-id.test.ts
+++ b/src/agents/tools/transcripts-tool.session-id.test.ts
@@ -112,6 +112,7 @@ describe("transcripts bounded export names", () => {
     { label: "overlong encoded device name", sessionId: "CON." + "x".repeat(100) },
   ];
   const ordinaryIds = [
+    { label: "date-prefixed raw ID", sessionId: "2026-07-03/raw-id", slug: "2026-07-03-raw-id" },
     { label: "generated", sessionId: undefined, slug: undefined },
     { label: "punctuation", sessionId: "notes: room/one", slug: "notes-room-one" },
     { label: "255 safe bytes", sessionId: "x".repeat(255), slug: "x".repeat(255) },
@@ -122,6 +123,14 @@ describe("transcripts bounded export names", () => {
     { label: "device", sessionId: "CON", slug: "%43%4F%4E" },
   ];
   const cases = [
+    {
+      label: "date-prefixed import",
+      sessionId: "2026-07-03/raw-id",
+      slug: "2026-07-03-raw-id",
+      action: "import" as const,
+      exportParentExists: false,
+      shortened: false,
+    },
     ...oversizedIds.flatMap(({ label, sessionId }) =>
       [false, true].flatMap((exportParentExists) =>
         (["start", "import"] as const).map((action) => ({

--- a/src/agents/tools/transcripts-tool.ts
+++ b/src/agents/tools/transcripts-tool.ts
@@ -22,7 +22,7 @@ import type {
   TranscriptToolCaller,
 } from "../../transcripts/provider-types.js";
 import { sanitizeTranscriptSourceLocator } from "../../transcripts/source-locator.js";
-import { TranscriptsStore, type TranscriptsSessionEntry } from "../../transcripts/store.js";
+import { TranscriptsStore, transcriptSessionSelector } from "../../transcripts/store.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import type { AnyAgentTool } from "./common.js";
 import {
@@ -33,6 +33,7 @@ import {
   isTranscriptSessionStarting,
   persistTranscriptSummary,
   readTranscriptStringParam,
+  readTranscriptSummary,
   resolveTranscriptSourceOwnership,
   resolveSourceProvider,
   sourceFromParams,
@@ -42,55 +43,20 @@ import {
   type TranscriptsLogger,
   type TranscriptsRuntimeContext,
 } from "./transcripts-tool-runtime.js";
+import {
+  canAccessTranscriptSession,
+  isTranscriptSelectionCurrent,
+  resolveTranscriptToolSession,
+  transcriptSelectionNoLongerActive,
+} from "./transcripts-tool-selection.js";
 const AUTO_START_RETRY_ATTEMPTS = 12;
 const AUTO_START_RETRY_MS = 5_000;
 const AUTO_START_STOP_TIMEOUT_MS = 5_000;
 const AUTO_START_PROVIDER_READY_TIMEOUT_MS = 30_000;
+const STATUS_SELECTOR_LIMIT = 3;
 
 function formatAutoStopDiagnostic(value: unknown): string {
   return JSON.stringify(truncateUtf16Safe(sanitizeTerminalText(formatErrorMessage(value)), 300));
-}
-
-type TranscriptSessionIdentity = Pick<TranscriptSessionDescriptor, "sessionId" | "startedAt">;
-
-function sameSessionIdentity(
-  left: TranscriptSessionIdentity,
-  right: TranscriptSessionIdentity,
-): boolean {
-  return left.sessionId === right.sessionId && left.startedAt === right.startedAt;
-}
-
-function ownsTranscriptSession(
-  ctx: TranscriptsRuntimeContext,
-  session: TranscriptSessionDescriptor,
-): boolean {
-  const ownerAgentId = session.metadata?.agentId;
-  if (typeof ownerAgentId === "string") {
-    return ownerAgentId === ctx.agentId;
-  }
-  // Shipped ownerless rows stay with main; provider access still decides whether
-  // the current caller may act on an account-bound canonical source.
-  return ctx.agentId ? ctx.agentId === "main" : ctx.caller?.kind === "operator";
-}
-
-async function canAccessTranscriptSession(
-  ctx: TranscriptsRuntimeContext,
-  session: TranscriptSessionDescriptor,
-  action: "status" | "stop" | "summarize",
-): Promise<boolean> {
-  if (!ownsTranscriptSession(ctx, session)) {
-    return false;
-  }
-  const provider = resolveSourceProvider(session.source.providerId, ctx);
-  if (!provider) {
-    return ctx.caller?.kind === "operator";
-  }
-  try {
-    await authorizeTranscriptSource({ action, ctx, provider, source: session.source });
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 const TranscriptsSchema = Type.Object(
@@ -98,7 +64,20 @@ const TranscriptsSchema = Type.Object(
     action: Type.String({
       description: "start, stop, status, import, or summarize.",
     }),
-    sessionId: Type.Optional(Type.String({ minLength: 1 })),
+    sessionId: Type.Optional(
+      Type.String({
+        minLength: 1,
+        description:
+          "Raw ID for start/import. Legacy stop/summarize handle; prefer selector for an exact capture. Cannot be combined with selector.",
+      }),
+    ),
+    selector: Type.Optional(
+      Type.String({
+        minLength: 1,
+        description:
+          "Exact dated capture selector returned by start/import/status. Only for stop/summarize; supply this or sessionId, never both. No raw-ID fallback.",
+      }),
+    ),
     title: Type.Optional(Type.String({ minLength: 1 })),
     providerId: Type.Optional(Type.String({ minLength: 1 })),
     accountId: Type.Optional(Type.String({ minLength: 1 })),
@@ -141,18 +120,6 @@ async function waitForPendingAutoStartsToSettle(
 
 // Tool stop/import/summarize actions explicitly materialize artifacts, but a
 // divergent export must not turn a successful canonical summary write into failure.
-async function summarizeAndPersist(params: {
-  config: ReturnType<typeof resolveTranscriptsConfig>;
-  store: TranscriptsStore;
-  session: TranscriptSessionDescriptor;
-}) {
-  return await exportTranscriptSummary(
-    params.store,
-    params.session,
-    await persistTranscriptSummary(params),
-  );
-}
-
 async function exportTranscriptSummary(
   store: TranscriptsStore,
   session: TranscriptSessionDescriptor,
@@ -172,66 +139,47 @@ async function stopTranscripts(params: {
   rawParams: Record<string, unknown>;
   lifecycleToken?: symbol;
 }) {
-  const sessionSelector = readTranscriptStringParam(params.rawParams, "sessionId", {
-    required: true,
-    trim: true,
-  });
-  const directActive = activeSessions.get(sessionSelector);
-  if (
-    params.lifecycleToken &&
-    (!directActive || directActive.lifecycleToken !== params.lifecycleToken)
-  ) {
-    return toolText(`Transcripts session no longer active: ${sessionSelector}`, {
-      sessionId: sessionSelector,
-      skipped: true,
-    });
-  }
-  const resolvedEntry: TranscriptsSessionEntry | undefined = directActive
-    ? undefined
-    : await params.store.readSessionEntry(sessionSelector);
-  const resolvedSession = directActive?.session ?? resolvedEntry?.session;
-  const activeCandidate =
-    resolvedSession !== undefined ? activeSessions.get(resolvedSession.sessionId) : undefined;
-  const activeMatchesResolved =
-    activeCandidate !== undefined &&
-    resolvedSession !== undefined &&
-    sameSessionIdentity(activeCandidate.session, resolvedSession);
-  const selectedActive = directActive ?? (activeMatchesResolved ? activeCandidate : undefined);
-  const session = selectedActive?.session ?? resolvedSession;
-  if (
-    !session ||
-    (!params.lifecycleToken && !(await canAccessTranscriptSession(params.ctx, session, "stop")))
-  ) {
-    throw new Error(`transcripts session not found: ${sessionSelector}`);
-  }
-  const sessionId = session.sessionId;
-  if (!params.lifecycleToken) {
+  let selection: Awaited<ReturnType<typeof resolveTranscriptToolSession>>;
+  if (params.lifecycleToken) {
+    const sessionId = readTranscriptStringParam(params.rawParams, "sessionId", { required: true });
+    const active = activeSessions.get(sessionId);
+    // Service cleanup is exact lifecycle ownership, not an operator string lookup.
+    if (!active || active.lifecycleToken !== params.lifecycleToken) {
+      return toolText(`Transcripts session no longer active: ${sessionId}`, {
+        sessionId,
+        skipped: true,
+      });
+    }
+    selection = {
+      session: active.session,
+      selector: transcriptSessionSelector(active.session),
+      activeCandidate: active,
+      selectedActive: active,
+    };
+  } else {
+    selection = await resolveTranscriptToolSession({ ...params, action: "stop" });
     params.ctx.assertCallerActive?.();
   }
-  const noLongerActive = () =>
-    toolText(`Transcripts session no longer active: ${sessionId}`, {
-      sessionId,
-      skipped: true,
-    });
+  // Authorization may await native policy while the provider retires this owner.
+  if (!isTranscriptSelectionCurrent(selection)) {
+    return transcriptSelectionNoLongerActive(selection);
+  }
+  const { session, selector, selectedActive } = selection;
+  const sessionId = session.sessionId;
   if (isTranscriptSessionStarting(sessionId)) {
     return toolText(
       `Transcripts session start still in progress: ${sessionId}; retry stop after startup settles.`,
       {
         sessionId,
+        selector,
         skipped: true,
       },
     );
   }
-  // Authorization may await native policy while the provider retires this owner.
-  if (selectedActive && activeSessions.get(sessionId) !== selectedActive) {
-    return noLongerActive();
-  }
-  if (!selectedActive && activeSessions.get(sessionId) !== activeCandidate) {
-    return noLongerActive();
-  }
   if (selectedActive?.stopping) {
     return toolText(`Transcripts session stop already in progress: ${sessionId}`, {
       sessionId,
+      selector,
       skipped: true,
     });
   }
@@ -265,7 +213,7 @@ async function stopTranscripts(params: {
         }
       }
       if (activeSessions.get(sessionId) !== selectedActive) {
-        return noLongerActive();
+        return transcriptSelectionNoLongerActive(selection);
       }
       if (providerStopError && !selectedActive.session.stoppedAt) {
         selectedActive.session = {
@@ -301,6 +249,7 @@ async function stopTranscripts(params: {
       `Transcripts stopped: ${sessionId}${summaryPath ? `\nSummary: ${summaryPath}` : `\nSummary export failed: ${summaryExportError}`}`,
       {
         sessionId,
+        selector,
         ...(providerStopError ? { providerStopError } : {}),
         ...(summaryExportError ? { summaryExportError } : {}),
         ...(intendedSummaryPath ? { intendedSummaryPath } : {}),
@@ -368,16 +317,18 @@ async function importTranscripts(params: {
   for (const utterance of utterances) {
     await params.store.appendUtteranceForSession(session, utterance);
   }
+  const persisted = await persistTranscriptSummary({
+    config: resolveTranscriptsConfig(params.ctx.config?.transcripts),
+    store: params.store,
+    session,
+  });
   const { summaryPath, intendedSummaryPath, summary, summaryExportError } =
-    await summarizeAndPersist({
-      config: resolveTranscriptsConfig(params.ctx.config?.transcripts),
-      store: params.store,
-      session,
-    });
+    await exportTranscriptSummary(params.store, session, persisted);
   return toolText(
     `Transcript imported: ${session.sessionId}${summaryPath ? `\nSummary: ${summaryPath}` : `\nSummary export failed: ${summaryExportError}`}`,
     {
       sessionId: session.sessionId,
+      selector: transcriptSessionSelector(session),
       utteranceCount: utterances.length,
       ...(summaryExportError ? { summaryExportError } : {}),
       ...(intendedSummaryPath ? { intendedSummaryPath } : {}),
@@ -393,24 +344,34 @@ async function summarizeExisting(params: {
   store: TranscriptsStore;
   rawParams: Record<string, unknown>;
 }) {
-  const sessionId = readTranscriptStringParam(params.rawParams, "sessionId", {
-    required: true,
-    trim: true,
-  });
-  const entry = await params.store.readSessionEntry(sessionId);
-  if (!entry || !(await canAccessTranscriptSession(params.ctx, entry.session, "summarize"))) {
-    throw new Error(`transcripts session not found: ${sessionId}`);
+  const selection = await resolveTranscriptToolSession({ ...params, action: "summarize" });
+  params.ctx.assertCallerActive?.();
+  if (!isTranscriptSelectionCurrent(selection)) {
+    return transcriptSelectionNoLongerActive(selection);
   }
-  const { summaryPath, intendedSummaryPath, summary, summaryExportError } =
-    await summarizeAndPersist({
-      config: params.config,
-      store: params.store,
-      session: entry.session,
-    });
+  const { session, selector } = selection;
+  const sessionId = session.sessionId;
+  const summary = await readTranscriptSummary({ ...params, session });
+  // Reading yields; a retired capture cannot write into its same-tuple replacement.
+  params.ctx.assertCallerActive?.();
+  if (!isTranscriptSelectionCurrent(selection)) {
+    return transcriptSelectionNoLongerActive(selection);
+  }
+  const intendedPath = await params.store.writeSummary(summary, session);
+  params.ctx.assertCallerActive?.();
+  if (!isTranscriptSelectionCurrent(selection)) {
+    return transcriptSelectionNoLongerActive(selection);
+  }
+  const { summaryPath, intendedSummaryPath, summaryExportError } = await exportTranscriptSummary(
+    params.store,
+    session,
+    { summary, intendedSummaryPath: intendedPath },
+  );
   return toolText(
     `Transcripts summarized: ${sessionId}${summaryPath ? `\nSummary: ${summaryPath}` : `\nSummary export failed: ${summaryExportError}`}`,
     {
       sessionId,
+      selector,
       ...(summaryExportError ? { summaryExportError } : {}),
       ...(intendedSummaryPath ? { intendedSummaryPath } : {}),
       summary,
@@ -438,18 +399,35 @@ async function statusTranscripts(ctx: TranscriptsRuntimeContext) {
   const pendingFinalization = visibleEntries
     .filter((entry) => entry.phase === "terminal")
     .map((entry) => ({
+      selector: transcriptSessionSelector(entry.session),
       sessionId: entry.session.sessionId,
       stoppedAt: entry.session.stoppedAt,
     }));
   const active = visibleEntries
     .filter((entry) => entry.phase !== "terminal")
     .map((entry) => ({
+      selector: transcriptSessionSelector(entry.session),
       sessionId: entry.session.sessionId,
       providerId: entry.providerId,
       title: entry.session.title,
       source: entry.session.source,
       cleanupPending: entry.cleanupPending === true,
     }));
+  // Three complete canonical selectors keep this model-facing section under 1 KiB.
+  // Recovery handles take priority; structured details retain the full authorized list.
+  const selectorGroups = [
+    { state: "pending", entries: pendingFinalization },
+    { state: "active", entries: active },
+  ];
+  const selectorLines = selectorGroups
+    .flatMap(({ state, entries }) =>
+      entries
+        .toSorted((left, right) => left.selector.localeCompare(right.selector))
+        .slice(0, STATUS_SELECTOR_LIMIT)
+        .map(({ selector }) => `${state}: ${selector}`),
+    )
+    .slice(0, STATUS_SELECTOR_LIMIT);
+  const omitted = visibleEntries.length - selectorLines.length;
   return toolText(
     [
       `Transcripts providers: ${uniqueProviders.length ? uniqueProviders.join(", ") : "none"}`,
@@ -458,6 +436,10 @@ async function statusTranscripts(ctx: TranscriptsRuntimeContext) {
         ? [
             `Ended captures awaiting persistence: ${pendingFinalization.length}; use transcripts stop to retry.`,
           ]
+        : []),
+      ...(selectorLines.length ? ["Selectors:", ...selectorLines] : []),
+      ...(omitted
+        ? [`${omitted} more; ask a local operator to run openclaw transcripts list.`]
         : []),
     ].join("\n"),
     { providers: uniqueProviders, active, pendingFinalization },
@@ -498,6 +480,9 @@ export function createTranscriptsTool(options?: {
       }
       const params = asOptionalRecord(rawParams) ?? {};
       const action = readTranscriptStringParam(params, "action", { required: true, trim: true });
+      if (params.selector !== undefined && action !== "stop" && action !== "summarize") {
+        throw new Error("selector is only supported for stop or summarize.");
+      }
       const store = createStore(ctx);
       switch (action) {
         case "start":

--- a/src/cli/program/register.transcripts.test.ts
+++ b/src/cli/program/register.transcripts.test.ts
@@ -242,16 +242,45 @@ describe("transcripts CLI", () => {
     expect(showOutput).toContain("# Design review");
   });
 
-  it("requires date-qualified selectors for repeated ids", async () => {
-    const olderSessionDir = await writeSession(stateDir, "standup", "2026-05-21");
-    await writeSession(stateDir, "standup", "2026-05-22");
+  it.each(["standup", "2026-07-03/raw-id", "notes: room/one"])(
+    "requires dated selectors for repeated %s",
+    async (id) => {
+      const olderSessionDir = await writeSession(stateDir, id, "2026-05-21");
+      await writeSession(stateDir, id, "2026-05-22");
 
-    await expect(runTranscriptsCli(["path", "standup"])).rejects.toThrow(
-      "multiple transcripts sessions match standup",
-    );
-    const output = await runTranscriptsCli(["path", "2026-05-21/standup"]);
+      await expect(runTranscriptsCli(["path", id])).rejects.toThrow(
+        "multiple transcripts sessions match",
+      );
+      const output = await runTranscriptsCli(["path", `2026-05-21/${id}`]);
 
-    expect(output.trim()).toBe(path.join(olderSessionDir, "summary.md"));
+      expect(output.trim()).toBe(path.join(olderSessionDir, "summary.md"));
+    },
+  );
+
+  it("round-trips list selectors and gives qualified targets priority over raw IDs", async () => {
+    await writeSession(stateDir, "2026-07-03/raw-id", "2026-07-04");
+    const fallback = JSON.parse(await runTranscriptsCli(["show", "2026-07-03/raw-id", "--json"]));
+    expect(fallback.session.sessionId).toBe("2026-07-03/raw-id");
+    await writeSession(stateDir, "raw-id", "2026-07-03");
+    const selected = JSON.parse(await runTranscriptsCli(["show", "2026-07-03/raw-id", "--json"]));
+    expect(selected.session.sessionId).toBe("raw-id");
+    const entries = JSON.parse(await runTranscriptsCli(["list", "--json"])) as Array<{
+      sessionId: string;
+      selector: string;
+    }>;
+    for (const entry of entries) {
+      const shown = JSON.parse(await runTranscriptsCli(["show", entry.selector, "--json"]));
+      expect(shown.session.sessionId).toBe(entry.sessionId);
+      const exported = JSON.parse(
+        await runTranscriptsCli(["path", entry.selector, "--transcript", "--json"]),
+      );
+      expect(exported).toMatchObject({
+        sessionId: entry.sessionId,
+        selector: entry.selector,
+        exists: true,
+      });
+      expect(await fs.readFile(exported.path, "utf8")).toContain("Ship CLI");
+    }
   });
 
   it("materializes metadata, transcript, and directory exports from SQLite", async () => {

--- a/src/transcripts/store.test.ts
+++ b/src/transcripts/store.test.ts
@@ -95,17 +95,54 @@ describe("TranscriptsStore", () => {
     ]);
   });
 
-  it("requires date-qualified selectors for repeated ids", async () => {
-    const { store } = createStore();
-    await store.writeSession(session("standup", "2026-07-01T10:00:00.000Z"));
-    await store.writeSession(session("standup", "2026-07-02T10:00:00.000Z"));
+  it.each(["standup", "2026-07-03/raw-id"])(
+    "requires dated selectors for repeated %s",
+    async (id) => {
+      const { store } = createStore();
+      await store.writeSession(session(id, "2026-07-01T10:00:00.000Z"));
+      await store.writeSession(session(id, "2026-07-02T10:00:00.000Z"));
 
-    await expect(store.readSession("standup")).rejects.toThrow(
-      "multiple transcripts sessions match standup",
-    );
-    await expect(store.readSession("2026-07-01/standup")).resolves.toMatchObject({
-      startedAt: "2026-07-01T10:00:00.000Z",
-    });
+      await expect(store.readSession(id)).rejects.toThrow("multiple transcripts sessions match");
+      await expect(store.readSession(`2026-07-01/${id}`)).resolves.toMatchObject({
+        startedAt: "2026-07-01T10:00:00.000Z",
+      });
+    },
+  );
+
+  it.each([false, true])(
+    "prioritizes qualified targets regardless of insertion order %s",
+    async (reverse) => {
+      const { store } = createStore();
+      const raw = session("2026-07-03/raw-id", "2026-07-04T10:00:00.000Z");
+      const qualified = session("raw-id", "2026-07-03T10:00:00.000Z");
+      for (const target of reverse ? [qualified, raw] : [raw, qualified]) {
+        await store.writeSession(target);
+      }
+      closeOpenClawStateDatabaseForTest();
+      await expect(store.readSession(raw.sessionId)).resolves.toEqual(qualified);
+      await expect(store.readSession("2026-07-04/2026-07-03-raw-id")).resolves.toEqual(raw);
+      await expect(store.readSession(`2026-07-04/${raw.sessionId}`)).resolves.toEqual(raw);
+    },
+  );
+
+  it("reads literal date-prefixed raw IDs and shipped date/raw suffixes", async () => {
+    const { store } = createStore();
+    const raw = session("2026-07-03/raw-id");
+    const punctuated = session("notes: room/one");
+    for (const target of [raw, punctuated]) {
+      await store.writeSession(target);
+      await expect(store.readSession(target.sessionId)).resolves.toEqual(target);
+      await expect(store.readSession(`2026-07-01/${target.sessionId}`)).resolves.toEqual(target);
+      await expect(store.readSession(`2026-07-02/${target.sessionId}`)).resolves.toBeUndefined();
+    }
+    await expect(store.readSession("2026-07-01/notes: Room/one")).resolves.toBeUndefined();
+  });
+
+  it("does not reinterpret legacy export ownership as a raw ID lookup", async () => {
+    const { store } = createStore();
+    await store.writeSession(session(".", "2026-07-01T10:00:00.000Z"));
+    await store.writeSession(session(".", "2026-07-02T10:00:00.000Z"));
+    await expect(store.writeSession(session(".."))).resolves.toBeUndefined();
   });
 
   it("matches bare selector slugs literally and case-sensitively", async () => {

--- a/src/transcripts/store.ts
+++ b/src/transcripts/store.ts
@@ -328,7 +328,8 @@ export class TranscriptsStore {
       const legacySelector = legacyTranscriptSessionSelector(session);
       if (legacySelector !== undefined) {
         const legacySessionDir = path.join(this.exportRootDir, legacySelector);
-        const legacyOwner = await this.readSession(legacySelector);
+        const legacyRow = this.readCanonicalSelectorRow(legacySelector);
+        const legacyOwner = legacyRow ? sessionFromRow(legacyRow) : undefined;
         const legacyPathIsCanonical =
           legacyOwner !== undefined &&
           path.resolve(this.sessionDir(legacyOwner)) === path.resolve(legacySessionDir);
@@ -383,38 +384,65 @@ export class TranscriptsStore {
   async readSessionEntry(
     sessionSelector: string,
   ): Promise<StoreTypes.TranscriptsSessionEntry | undefined> {
-    const database = this.database();
-    const db = meetingTranscriptDb(database.db);
-    const qualified = /^\d{4}-\d{2}-\d{2}\//u.test(sessionSelector);
-    const matchingRows = (column: "selector" | "session_id" | "session_slug") => {
-      let query = db
-        .selectFrom("meeting_transcript_sessions")
-        .selectAll()
-        .where(column, "=", sessionSelector);
-      if (column !== "selector") {
-        query = query.orderBy("started_at", "desc").limit(2);
-      }
-      return executeSqliteQuerySync(database.db, query).rows;
-    };
-    const exactRows = matchingRows(qualified ? "selector" : "session_id");
-    const slugRows = qualified ? [] : matchingRows("session_slug");
-    const rows = [
-      ...new Map(
-        [...exactRows, ...slugRows].map((row) => [`${row.session_id}\0${row.started_at}`, row]),
-      ).values(),
-    ];
-    if (rows.length > 1) {
+    const { qualified, unqualified } = this.matchSessionEntries(sessionSelector);
+    const entries = qualified.length ? qualified : unqualified;
+    if (entries.length > 1) {
       throw new Error(
-        `multiple transcripts sessions match ${sessionSelector}; use one of: ${rows
-          .map((row) => row.selector)
+        `multiple transcripts sessions match ${sessionSelector}; use one of: ${entries
+          .map((entry) => entry.selector)
           .join(", ")}`,
       );
     }
-    const row = rows[0];
-    if (!row) {
-      return undefined;
-    }
-    return this.entryFromRow(row, this.hasSummary(database, row));
+    return entries[0];
+  }
+
+  private readCanonicalSelectorRow(selector: string) {
+    const database = this.database();
+    return executeSqliteQueryTakeFirstSync(
+      database.db,
+      meetingTranscriptDb(database.db)
+        .selectFrom("meeting_transcript_sessions")
+        .selectAll()
+        .where("selector", "=", selector),
+    );
+  }
+
+  // Return bounded evidence, not a selection policy: operators prefer qualified
+  // matches, while legacy tool handles must also account for raw-ID collisions.
+  matchSessionEntries(value: string): {
+    qualified: StoreTypes.TranscriptsSessionEntry[];
+    unqualified: StoreTypes.TranscriptsSessionEntry[];
+  } {
+    const database = this.database();
+    const query = meetingTranscriptDb(database.db)
+      .selectFrom("meeting_transcript_sessions")
+      .selectAll()
+      .orderBy("started_at", "desc")
+      .limit(2);
+    const entries = (selection: typeof query) =>
+      executeSqliteQuerySync(database.db, selection).rows.map((row) =>
+        this.entryFromRow(row, this.hasSummary(database, row)),
+      );
+    const canonical = this.readCanonicalSelectorRow(value);
+    const date = value.match(/^(\d{4}-\d{2}-\d{2})\//u)?.[1];
+    const qualified = canonical
+      ? [this.entryFromRow(canonical, this.hasSummary(database, canonical))]
+      : date
+        ? entries(
+            query
+              .where("session_id", "=", value.slice(11))
+              .where("started_at", "like", `${date}T%`),
+          )
+        : [];
+    return {
+      qualified,
+      unqualified: [
+        ...entries(query.where("session_id", "=", value)),
+        // Exclude exact raw IDs so their historical rows cannot fill this bound
+        // and hide a different identity when the tool prefers a current capture.
+        ...entries(query.where("session_slug", "=", value).where("session_id", "!=", value)),
+      ],
+    };
   }
 
   async appendUtteranceForSession(
@@ -451,12 +479,8 @@ export class TranscriptsStore {
 
   async writeSummary(
     summary: TranscriptsSummary,
-    session?: TranscriptSessionDescriptor,
+    session: TranscriptSessionDescriptor,
   ): Promise<string> {
-    const resolved = session ?? (await this.readSession(summary.sessionId));
-    if (!resolved) {
-      throw new Error(`transcripts session not found: ${summary.sessionId}`);
-    }
     const summaryJson = JSON.stringify(summary);
     const markdown = renderTranscriptsMarkdown(summary);
     const summaryValues = {
@@ -472,8 +496,8 @@ export class TranscriptsStore {
         meetingTranscriptDb(database)
           .insertInto("meeting_transcript_summaries")
           .values({
-            session_id: resolved.sessionId,
-            session_started_at: resolved.startedAt,
+            session_id: session.sessionId,
+            session_started_at: session.startedAt,
             ...summaryValues,
           })
           .onConflict((conflict) =>
@@ -481,7 +505,7 @@ export class TranscriptsStore {
           ),
       );
     });
-    return path.join(this.sessionDir(resolved), "summary.md");
+    return path.join(this.sessionDir(session), "summary.md");
   }
 
   async readSummary(


### PR DESCRIPTION
Closes #131720

## What Problem This Solves

Fixes an issue where users could import or start a transcript with a date-shaped raw ID but could not look it up again. If that raw ID equaled another capture's dated selector, stop and summarize could select different captures; two identical stop requests could stop two different active captures as the first retired.

## Why This Change Was Made

Keep the documented CLI/operator contract: an actual canonical selector wins, then the historical date/full-raw-ID form, then complete literal raw-ID/slug lookup. Tool stop and summarize now share one resolver and accept an explicit `selector`; conflicting legacy `sessionId` meanings fail visibly rather than guessing or using authorization to break a tie.

Selection does not grant authority. Active captures retain their admitted source and exact lifecycle owner across awaited work. Configured shutdown remains token-owned and can attempt provider cleanup without a database lookup; status remains process-owned. Removed the competing active-stop lookup, separate summarize lookup, optional summary string lookup, and unnecessary row reads. No SQLite schema, material storage migration, config/env option, dependency, filename/hash, or ignore changes. The follow-up removes one obsolete two-call accessor-debt allowance; no baseline allowance is added or increased.

## User Impact

Complete raw IDs and notes remain intact, listed CLI selectors keep their meaning, and both sides of a collision are explicitly addressable. Start/import/stop/summarize return a usable selector; status supplies up to three complete model-visible recovery handles with an explicit omitted count. Existing unambiguous tool handles still work. Ambiguous legacy calls now require the returned selector, consistently before and after capture retirement.

Documentation: https://docs.openclaw.ai/cli/transcripts

## Evidence

- Original isolated SQLite/tool reproduction: date-prefixed raw lookup failed; both collision insertion orders were confirmed; two identical active stop calls targeted different raw IDs. Permanent regressions failed on pre-fix source before the repair.
- **235 tests passed across 17 files after rebase**, with two unchanged platform-specific migration skips (the original run passed 232; current main adds three CLI byte-preservation cases). Coverage includes store/CLI, raw-ID/selector collisions, both insertion orders, same-ID history, full notes/handles, foreign-agent/account denial, configured shutdown, missing-row status/cleanup, delayed authorization, same-millisecond replacement, and meeting-transcript siblings.
- Full scoped changed checks passed: production/test typechecks, formatting/lint, dead exports, schema/storage guards, and import cycles. `pnpm build` passed.
- Fresh isolated Codex autoreview: no accepted/actionable findings at the workflow's default blocking/P0 scope.
- Real isolated Gateway + real Anthropic model + actual built-in manual transcript provider: **16 initial cases and 11 post-restart cases passed**, plus the initial status turn and two real Control UI recovery turns. Actual persisted tool-call arguments/results were verified, not just assistant prose. Full raw IDs, canonical selectors, CLI precedence, distinct notes, repeated historical stops, and foreign-agent denial survived restart without reimporting.
- The real Control UI recording shows a legacy ambiguity error, then successful explicit selection of capture B and capture A. Screenshots and the 26-second video were inspected before attachment in the live-proof comment. No mocked Gateway, fake caller authority, or operator state was used. Native capture races and account-bound provider cleanup remain boundary-test proof, not live manual-provider proof.
- The first CI run found only a stale accessor-debt allowance after the refactor removed both calls. The one-line shrink is now committed, `pnpm lint:tmp:session-accessor-boundary` passes, and fresh full-candidate Codex autoreview is clean. Runtime source digests still match the live-tested build.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/33184409326 for `374ca89ac872346c85f6a3be2538e4bb582d7e0d` — **completed successfully**. The native wrapper trust guard required a mechanical rebase onto current main; `git range-diff` confirms both repair commits are patch-identical, and all reviewed runtime/docs bytes remain unchanged.
- Maintainer decision: accept the documented explicit-selector recovery for ambiguous legacy calls. ClawSweeper's vector/embedding metadata classification is a false positive; existing owner metadata is read, not migrated or extended.

Focused test command:

```bash
node scripts/run-vitest.mjs src/transcripts src/agents/tools/transcripts-tool.test.ts src/agents/tools/transcripts-tool.auto-start.test.ts src/agents/tools/transcripts-tool.import.test.ts src/agents/tools/transcripts-tool.account-ownership.test.ts src/agents/tools/transcripts-tool.lifecycle.test.ts src/agents/tools/transcripts-tool.selection.test.ts src/agents/tools/transcripts-tool.session-id.test.ts src/cli/program/register.transcripts.test.ts src/meeting-bot/session-transcript-store.test.ts src/meeting-bot/session-runtime.test.ts src/meeting-bot/transcripts-bridge.test.ts
```

Changed checks:

```bash
node scripts/check-changed.mjs -- docs/cli/transcripts.md src/agents/tools/transcripts-tool-runtime.ts src/agents/tools/transcripts-tool-selection.ts src/agents/tools/transcripts-tool.ts src/agents/tools/transcripts-tool.account-ownership.test.ts src/agents/tools/transcripts-tool.lifecycle.test.ts src/agents/tools/transcripts-tool.selection.test.ts src/agents/tools/transcripts-tool.session-id.test.ts src/cli/program/register.transcripts.test.ts src/transcripts/store.test.ts src/transcripts/store.ts
```

Production LOC: **+314/-161 (net +153)**; tests: **+710/-29**; docs: **+50/-5**. Production growth implements the explicit selector namespace, bounded candidate evidence and model-visible recovery handles, and retained-owner checks across asynchronous summary boundaries. Pure moves cancel in the net; the old competing paths were removed. A raw-first or selector-first global flip cannot preserve both meanings of the same string.

Provenance: clearly carried forward by [the SQLite transcript-store migration (#112910)](https://github.com/openclaw/openclaw/pull/112910), commit `a2be4efb63129d049822ae0d855f233407f2bfd6` (July 23, 2026; code author, PR author, and merger: @steipete). Earlier file-backed parsing already preferred qualified strings. The independent [bounded export-name repair (#131508)](https://github.com/openclaw/openclaw/pull/131508) and [export cleanup (#131679)](https://github.com/openclaw/openclaw/pull/131679) are preserved.

