### PR TITLE
fix(http): deliver body rejection responses before closing uploads

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -15,7 +15,7 @@ extensions/active-memory/index.ts	6
 extensions/active-memory/query.ts	2
 extensions/active-memory/session.ts	4
 extensions/active-memory/transcript-result.ts	2
-extensions/admin-http-rpc/src/handler.ts	2
+extensions/admin-http-rpc/src/handler.ts	1
 extensions/amazon-bedrock-mantle/discovery.ts	3
 extensions/amazon-bedrock-mantle/mantle-anthropic.runtime.ts	4
 extensions/amazon-bedrock-mantle/register.sync.runtime.ts	2

--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -744,7 +744,7 @@ extensions/mattermost/src/mattermost/monitor-slash.ts	1
 extensions/mattermost/src/mattermost/monitor-websocket.ts	2
 extensions/mattermost/src/mattermost/monitor.ts	1
 extensions/mattermost/src/mattermost/slash-commands.ts	1
-extensions/mattermost/src/mattermost/slash-state.ts	6
+extensions/mattermost/src/mattermost/slash-state.ts	5
 extensions/mattermost/src/session-route.ts	1
 extensions/mattermost/src/setup-core.ts	2
 extensions/memory-core/index.ts	4

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -258,6 +258,38 @@ advertised node command.
 
 Gateway methods default to `profileAccess: "required"`, so authenticated-profile verification fails closed before plugin dispatch. Set `profileAccess: "independent"` only for an audited method that neither reads nor mutates durable user or session state. Operator scope remains a separate authorization requirement.
 
+#### Webhook body rejection
+
+Use `readWebhookBodyOrReject` or `readJsonWebhookBodyOrReject` from
+`openclaw/plugin-sdk/webhook-request-guards` for bounded body reads. Return when
+the result is `{ ok: false }`; the helper owns the error response and connection
+cleanup. Body byte limits and read timeouts remain separate from transport cleanup.
+
+For a custom error representation after a response-first body read, await
+`sendHttpRequestRejection(req, res, statusCode, body, contentType?)` instead of
+calling `res.end()` and destroying the request. It preserves security headers,
+frames the complete error, then on Node closes the write side while keeping application
+body readers paused. Node's request backpressure bounds residual input buffering;
+cleanup allows at most one second, not another body-read timeout. A disconnected peer, malformed HTTP, or an
+exhausted cleanup budget can prevent delivery. Committed responses are closed
+without appending a replacement error or completing a partial successful body.
+
+On Node, transport-owned rejections emit response `close` without `finish`.
+Use `close` for terminal cleanup or selected-error diagnostics; it does not prove
+delivery. Keep successful-response activity on `finish`, with the caller's
+success-status check, so an aborted request cannot report healthy activity.
+
+Bun uses its native HTTP response completion because its raw socket operations
+do not flush the HTTP response. Bun can still report client connection resets
+during large outstanding uploads, even after delivering the complete error.
+
+Gateway HTTP requests run in order on each connection, including their response
+lifetimes. A closing connection cannot admit later requests or upgrades. Queued
+requests apply input backpressure until earlier responses finish; finite pipelines
+drain in order. Use separate connections for concurrent requests. Keep the release hook returned by
+`beginWebhookRequestPipelineOrReject` in `finally`; it retains any selected
+rejection cleanup before releasing the in-flight slot.
+
 #### Post-ack webhook work
 
 Webhook routes that acknowledge a request before processing finishes must move

--- a/extensions/a2a/src/http.test.ts
+++ b/extensions/a2a/src/http.test.ts
@@ -1,9 +1,8 @@
 import { EventEmitter } from "node:events";
-import type { IncomingMessage, ServerResponse } from "node:http";
-import { Readable } from "node:stream";
+import type { ServerResponse } from "node:http";
 import { VERSION } from "openclaw/plugin-sdk/cli-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { createMockServerResponse } from "openclaw/plugin-sdk/test-env";
+import { createMockIncomingRequest, createMockServerResponse } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createA2aHttpHandler } from "./http.js";
 import { A2aTaskStore } from "./task-store.js";
@@ -60,9 +59,7 @@ async function startHttpHarness(options?: {
     body?: string;
     token?: string | null;
   }) {
-    const request = Readable.from(
-      dispatch.body === undefined ? [] : [dispatch.body],
-    ) as IncomingMessage;
+    const request = createMockIncomingRequest(dispatch.body === undefined ? [] : [dispatch.body]);
     request.method = dispatch.method;
     request.url = dispatch.endpoint;
     request.headers = {
@@ -75,8 +72,8 @@ async function startHttpHarness(options?: {
           }),
       ...(dispatch.token ? { authorization: `Bearer ${dispatch.token}` } : {}),
     };
-    Object.defineProperty(request, "socket", {
-      value: { remoteAddress: "127.0.0.1" },
+    Object.defineProperty(request.socket, "remoteAddress", {
+      value: "127.0.0.1",
     });
 
     const response = createMockServerResponse();

--- a/extensions/admin-http-rpc/src/handler.test.ts
+++ b/extensions/admin-http-rpc/src/handler.test.ts
@@ -1,6 +1,6 @@
 // Admin Http Rpc tests cover handler plugin behavior.
 import { createServer, type Server } from "node:http";
-import { connect, type Socket } from "node:net";
+import { connect, Socket } from "node:net";
 import { Readable } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { handleAdminHttpRpcRequest } from "./handler.js";
@@ -37,6 +37,7 @@ function createRequest(body: unknown, method = "POST") {
   const req = Readable.from([typeof body === "string" ? body : JSON.stringify(body)]);
   Object.assign(req, {
     method,
+    socket: new Socket(),
     url: "/api/v1/admin/rpc",
     headers: {
       "content-type": "application/json",
@@ -53,6 +54,7 @@ function createHangingRequest() {
   });
   Object.assign(req, {
     method: "POST",
+    socket: new Socket(),
     url: "/api/v1/admin/rpc",
     headers: {
       "content-type": "application/json",
@@ -289,30 +291,6 @@ describe("admin-http-rpc plugin handler", () => {
     expect(result.captured.statusCode).toBe(405);
     expect(result.captured.headers.allow).toBe("POST");
     expect(dispatchGatewayMethod).not.toHaveBeenCalled();
-  });
-
-  it("times out incomplete request bodies before dispatch", async () => {
-    vi.useFakeTimers();
-    try {
-      const req = createHangingRequest();
-      const resultPromise = invokeRequest(req);
-      await vi.advanceTimersByTimeAsync(30_000);
-      const result = await resultPromise;
-
-      expect(result.handled).toBe(true);
-      expect(result.captured.statusCode).toBe(408);
-      expect(result.json).toEqual({
-        ok: false,
-        error: {
-          type: "invalid_request",
-          message: "Request body timeout",
-        },
-      });
-      expectBodyReadListenersCleaned(req);
-      expect(dispatchGatewayMethod).not.toHaveBeenCalled();
-    } finally {
-      vi.useRealTimers();
-    }
   });
 
   it("settles an early client close and removes request-body listeners", async () => {

--- a/extensions/admin-http-rpc/src/handler.ts
+++ b/extensions/admin-http-rpc/src/handler.ts
@@ -8,6 +8,7 @@ import { dispatchGatewayMethod } from "openclaw/plugin-sdk/gateway-method-runtim
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   readJsonBodyWithLimit,
+  sendHttpRequestRejection,
   WEBHOOK_BODY_READ_DEFAULTS,
 } from "openclaw/plugin-sdk/webhook-request-guards";
 import { isAdminHttpRpcAllowedMethod, listAdminHttpRpcAllowedMethods } from "./methods.js";
@@ -110,7 +111,7 @@ function statusForBodyErrorCode(code: RequestBodyLimitFailureCode): number {
 async function readAdminJsonBody(req: IncomingMessage): Promise<ReadJsonBodyResult> {
   const body = await readJsonBodyWithLimit(req, {
     // Admin responses are part of the client contract. The response-first profile
-    // defers destruction so closeRequestAfterResponse can flush the JSON error.
+    // defers destruction so the transport owner can flush the JSON error.
     ...WEBHOOK_BODY_READ_DEFAULTS.postAuthResponseFirst,
     emptyObjectOnEmpty: false,
   });
@@ -133,21 +134,6 @@ async function readAdminJsonBody(req: IncomingMessage): Promise<ReadJsonBodyResu
     message: body.error,
     closeAfterResponse: body.code !== "CONNECTION_CLOSED",
   };
-}
-
-function closeRequestAfterResponse(req: IncomingMessage, res: ServerResponse): void {
-  const once = (res as { once?: ServerResponse["once"] }).once;
-  if (typeof once !== "function") {
-    return;
-  }
-  res.setHeader("Connection", "close");
-  once.call(res, "finish", () => {
-    // Timeout/size failures must flush JSON first; destroying before finish drops
-    // the HTTP response on real partial-body sockets.
-    if (!req.destroyed) {
-      req.destroy();
-    }
-  });
 }
 
 function readRpcRequestBody(body: unknown):
@@ -246,12 +232,22 @@ export async function handleAdminHttpRpcRequest(
   const body = await readAdminJsonBody(req);
   if (!body.ok) {
     if (body.closeAfterResponse) {
-      closeRequestAfterResponse(req, res);
+      if (!res.headersSent) {
+        res.setHeader("Cache-Control", "no-store");
+      }
+      await sendHttpRequestRejection(
+        req,
+        res,
+        body.status,
+        JSON.stringify({ ok: false, error: { type: "invalid_request", message: body.message } }),
+        "application/json; charset=utf-8",
+      );
+    } else {
+      sendError(res, body.status, {
+        type: "invalid_request",
+        message: body.message,
+      });
     }
-    sendError(res, body.status, {
-      type: "invalid_request",
-      message: body.message,
-    });
     return true;
   }
 

--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -396,8 +396,12 @@ export async function monitorWebhook({
       return;
     }
 
-    res.on("finish", () => {
+    // Transport-owned rejections close without finish. Anomaly counts describe
+    // selected error outcomes, not successful delivery to the client.
+    res.once("close", () => {
       recordWebhookStatus(runtime, accountId, path, res.statusCode);
+    });
+    res.once("finish", () => {
       // Refresh lastEventAt / lastTransportActivityAt on every successful 2xx
       // response so the gateway health monitor sees inbound activity. Non-2xx
       // (e.g. 401 invalid signature, 400 invalid JSON, 429 rate-limited) is

--- a/extensions/feishu/src/monitor.webhook-activity.test.ts
+++ b/extensions/feishu/src/monitor.webhook-activity.test.ts
@@ -1,0 +1,90 @@
+import { createConnection } from "node:net";
+import * as Lark from "@larksuiteoapi/node-sdk";
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanupFeishuMonitorStateForTests } from "./monitor.cleanup.test-helpers.js";
+import { httpServers } from "./monitor.state.js";
+import { monitorWebhook } from "./monitor.transport.js";
+import {
+  createFeishuWebhookTestAccount,
+  getFreePort,
+  signFeishuPayload,
+  waitUntilServerReady,
+} from "./monitor.webhook.test-helpers.js";
+
+afterEach(() => {
+  cleanupFeishuMonitorStateForTests();
+});
+
+describe("Feishu webhook activity", () => {
+  it("does not publish healthy activity when the client aborts a held signed dispatch", async () => {
+    const accountId = "aborted-signed-dispatch";
+    const path = "/hook-e2e-aborted-signed-dispatch";
+    const port = await getFreePort();
+    let releaseDispatch: () => void = () => {};
+    const dispatchGate = new Promise<void>((resolve) => {
+      releaseDispatch = resolve;
+    });
+    let markDispatchStarted: () => void = () => {};
+    const dispatchStarted = new Promise<void>((resolve) => {
+      markDispatchStarted = resolve;
+    });
+    const handler = vi.fn(async () => {
+      markDispatchStarted();
+      await dispatchGate;
+      return { accepted: true };
+    });
+    const eventDispatcher = new Lark.EventDispatcher({ encryptKey: "encrypt_key" });
+    eventDispatcher.register({ "test.aborted_dispatch": handler });
+    const statusSink = vi.fn();
+    const abortController = new AbortController();
+    const monitorPromise = monitorWebhook({
+      account: createFeishuWebhookTestAccount(accountId, port, path),
+      accountId,
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      abortSignal: abortController.signal,
+      eventDispatcher,
+      statusSink,
+    });
+    const socket = createConnection({ host: "127.0.0.1", port });
+    try {
+      await waitUntilServerReady(`http://127.0.0.1:${port}${path}`);
+      statusSink.mockClear();
+      const server = expectDefined(httpServers.get(accountId), "webhook server");
+      const responseClosed = new Promise<void>((resolve) => {
+        server.once("request", (_req, res) => res.once("close", resolve));
+      });
+      const rawBody = JSON.stringify({
+        schema: "2.0",
+        header: { event_type: "test.aborted_dispatch" },
+        event: {},
+      });
+      const headers = Object.entries(signFeishuPayload({ encryptKey: "encrypt_key", rawBody }))
+        .map(([name, value]) => `${name}: ${value}`)
+        .join("\r\n");
+      socket.write(
+        `POST ${path} HTTP/1.1\r\nHost: localhost\r\n${headers}\r\nContent-Length: ${Buffer.byteLength(rawBody)}\r\n\r\n${rawBody}`,
+      );
+      await dispatchStarted;
+      const clientClosed = new Promise<void>((resolve) => {
+        socket.once("close", resolve);
+      });
+      socket.destroy();
+      await clientClosed;
+      await responseClosed;
+      expect(statusSink).not.toHaveBeenCalled();
+      releaseDispatch();
+      await expect(handler.mock.results[0]?.value).resolves.toEqual({ accepted: true });
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(statusSink).not.toHaveBeenCalled();
+    } finally {
+      socket.destroy();
+      releaseDispatch();
+      abortController.abort();
+      await monitorPromise;
+    }
+  });
+});

--- a/extensions/feishu/src/monitor.webhook-e2e.test.ts
+++ b/extensions/feishu/src/monitor.webhook-e2e.test.ts
@@ -400,6 +400,7 @@ describe("Feishu webhook signed-request e2e", () => {
 
   it("accepts signed non-challenge events and reaches the dispatcher", async () => {
     probeFeishuMock.mockResolvedValue({ ok: true, botOpenId: "bot_open_id" });
+    const statusSink = vi.fn();
 
     await withRunningWebhookMonitor(
       {
@@ -407,9 +408,11 @@ describe("Feishu webhook signed-request e2e", () => {
         path: "/hook-e2e-signed-dispatch",
         verificationToken: "verify_token",
         encryptKey: "encrypt_key",
+        statusSink,
       },
       monitorFeishuProvider,
       async (url) => {
+        statusSink.mockClear();
         const payload = {
           schema: "2.0",
           header: { event_type: "unknown.event" },
@@ -420,8 +423,82 @@ describe("Feishu webhook signed-request e2e", () => {
         expect(response.status).toBe(200);
         expect(response.headers.get("x-openclaw-delivery-accepted")).toBeNull();
         expect(await response.text()).toContain("no unknown.event event handle");
+        expect(statusSink.mock.calls).toEqual([
+          [{ lastEventAt: expect.any(Number), lastTransportActivityAt: expect.any(Number) }],
+        ]);
       },
     );
+  });
+
+  it("does not publish healthy activity when the client aborts a held signed dispatch", async () => {
+    const accountId = "aborted-signed-dispatch";
+    const path = "/hook-e2e-aborted-signed-dispatch";
+    const port = await getFreePort();
+    let releaseDispatch: () => void = () => {};
+    const dispatchGate = new Promise<void>((resolve) => {
+      releaseDispatch = resolve;
+    });
+    let markDispatchStarted: () => void = () => {};
+    const dispatchStarted = new Promise<void>((resolve) => {
+      markDispatchStarted = resolve;
+    });
+    const handler = vi.fn(async () => {
+      markDispatchStarted();
+      await dispatchGate;
+      return { accepted: true };
+    });
+    const eventDispatcher = new Lark.EventDispatcher({ encryptKey: "encrypt_key" });
+    eventDispatcher.register({ "test.aborted_dispatch": handler });
+    const statusSink = vi.fn();
+    const abortController = new AbortController();
+    const monitorPromise = monitorWebhook({
+      account: createFeishuWebhookTestAccount(accountId, port, path),
+      accountId,
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      abortSignal: abortController.signal,
+      eventDispatcher,
+      statusSink,
+    });
+    const socket = createConnection({ host: "127.0.0.1", port });
+    try {
+      await waitUntilServerReady(`http://127.0.0.1:${port}${path}`);
+      statusSink.mockClear();
+      const server = expectDefined(httpServers.get(accountId), "webhook server");
+      const responseClosed = new Promise<void>((resolve) => {
+        server.once("request", (_req, res) => res.once("close", resolve));
+      });
+      const rawBody = JSON.stringify({
+        schema: "2.0",
+        header: { event_type: "test.aborted_dispatch" },
+        event: {},
+      });
+      const headers = Object.entries(signFeishuPayload({ encryptKey: "encrypt_key", rawBody }))
+        .map(([name, value]) => `${name}: ${value}`)
+        .join("\r\n");
+      socket.write(
+        `POST ${path} HTTP/1.1\r\nHost: localhost\r\n${headers}\r\nContent-Length: ${Buffer.byteLength(rawBody)}\r\n\r\n${rawBody}`,
+      );
+      await dispatchStarted;
+      const clientClosed = new Promise<void>((resolve) => {
+        socket.once("close", resolve);
+      });
+      socket.destroy();
+      await clientClosed;
+      await responseClosed;
+      expect(statusSink).not.toHaveBeenCalled();
+      releaseDispatch();
+      await expect(handler.mock.results[0]?.value).resolves.toEqual({ accepted: true });
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(statusSink).not.toHaveBeenCalled();
+    } finally {
+      socket.destroy();
+      releaseDispatch();
+      abortController.abort();
+      await monitorPromise;
+    }
   });
 
   it("admits signed requests only on the configured POST webhook route", async () => {

--- a/extensions/feishu/src/monitor.webhook-e2e.test.ts
+++ b/extensions/feishu/src/monitor.webhook-e2e.test.ts
@@ -10,7 +10,9 @@ import { normalizeCompatibilityConfig } from "./doctor-contract.js";
 import { createFeishuRuntimeMockModule } from "./monitor.test-mocks.js";
 import {
   buildWebhookConfig,
+  createFeishuWebhookTestAccount,
   getFreePort,
+  signFeishuPayload,
   waitUntilServerReady,
   withRunningWebhookMonitor,
 } from "./monitor.webhook.test-helpers.js";
@@ -38,47 +40,9 @@ import { httpServers } from "./monitor.state.js";
 import { monitorWebhook } from "./monitor.transport.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
-function createFeishuWebhookTestAccount(
-  accountId: string,
-  port: number,
-  webhookPath: string,
-): ResolvedFeishuAccount {
-  return {
-    accountId,
-    encryptKey: "encrypt_key",
-    config: {
-      enabled: true,
-      connectionMode: "webhook",
-      webhookHost: "127.0.0.1",
-      webhookPort: port,
-      webhookPath,
-    },
-  } as ResolvedFeishuAccount;
-}
-
 beforeAll(async () => {
   await import("./monitor.account.js");
 });
-
-function signFeishuPayload(params: {
-  encryptKey: string;
-  rawBody: string;
-  timestamp?: string;
-  nonce?: string;
-}): Record<string, string> {
-  const timestamp = params.timestamp ?? "1711111111";
-  const nonce = params.nonce ?? "nonce-test";
-  const signature = crypto
-    .createHash("sha256")
-    .update(timestamp + nonce + params.encryptKey + params.rawBody)
-    .digest("hex");
-  return {
-    "content-type": "application/json",
-    "x-lark-request-timestamp": timestamp,
-    "x-lark-request-nonce": nonce,
-    "x-lark-signature": signature,
-  };
-}
 
 function encryptFeishuPayload(encryptKey: string, payload: Record<string, unknown>): string {
   const iv = crypto.randomBytes(16);
@@ -428,77 +392,6 @@ describe("Feishu webhook signed-request e2e", () => {
         ]);
       },
     );
-  });
-
-  it("does not publish healthy activity when the client aborts a held signed dispatch", async () => {
-    const accountId = "aborted-signed-dispatch";
-    const path = "/hook-e2e-aborted-signed-dispatch";
-    const port = await getFreePort();
-    let releaseDispatch: () => void = () => {};
-    const dispatchGate = new Promise<void>((resolve) => {
-      releaseDispatch = resolve;
-    });
-    let markDispatchStarted: () => void = () => {};
-    const dispatchStarted = new Promise<void>((resolve) => {
-      markDispatchStarted = resolve;
-    });
-    const handler = vi.fn(async () => {
-      markDispatchStarted();
-      await dispatchGate;
-      return { accepted: true };
-    });
-    const eventDispatcher = new Lark.EventDispatcher({ encryptKey: "encrypt_key" });
-    eventDispatcher.register({ "test.aborted_dispatch": handler });
-    const statusSink = vi.fn();
-    const abortController = new AbortController();
-    const monitorPromise = monitorWebhook({
-      account: createFeishuWebhookTestAccount(accountId, port, path),
-      accountId,
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      abortSignal: abortController.signal,
-      eventDispatcher,
-      statusSink,
-    });
-    const socket = createConnection({ host: "127.0.0.1", port });
-    try {
-      await waitUntilServerReady(`http://127.0.0.1:${port}${path}`);
-      statusSink.mockClear();
-      const server = expectDefined(httpServers.get(accountId), "webhook server");
-      const responseClosed = new Promise<void>((resolve) => {
-        server.once("request", (_req, res) => res.once("close", resolve));
-      });
-      const rawBody = JSON.stringify({
-        schema: "2.0",
-        header: { event_type: "test.aborted_dispatch" },
-        event: {},
-      });
-      const headers = Object.entries(signFeishuPayload({ encryptKey: "encrypt_key", rawBody }))
-        .map(([name, value]) => `${name}: ${value}`)
-        .join("\r\n");
-      socket.write(
-        `POST ${path} HTTP/1.1\r\nHost: localhost\r\n${headers}\r\nContent-Length: ${Buffer.byteLength(rawBody)}\r\n\r\n${rawBody}`,
-      );
-      await dispatchStarted;
-      const clientClosed = new Promise<void>((resolve) => {
-        socket.once("close", resolve);
-      });
-      socket.destroy();
-      await clientClosed;
-      await responseClosed;
-      expect(statusSink).not.toHaveBeenCalled();
-      releaseDispatch();
-      await expect(handler.mock.results[0]?.value).resolves.toEqual({ accepted: true });
-      await new Promise<void>((resolve) => {
-        setImmediate(resolve);
-      });
-      expect(handler).toHaveBeenCalledTimes(1);
-      expect(statusSink).not.toHaveBeenCalled();
-    } finally {
-      socket.destroy();
-      releaseDispatch();
-      abortController.abort();
-      await monitorPromise;
-    }
   });
 
   it("admits signed requests only on the configured POST webhook route", async () => {

--- a/extensions/feishu/src/monitor.webhook-security.test.ts
+++ b/extensions/feishu/src/monitor.webhook-security.test.ts
@@ -44,7 +44,7 @@ import { buildFeishuWebhookRateLimitKey } from "./monitor-rate-limit-key.js";
 import { resolveRequestClientIp } from "./monitor-transport-runtime-api.js";
 import { cleanupFeishuMonitorStateForTests } from "./monitor.cleanup.test-helpers.js";
 import { monitorFeishuProvider } from "./monitor.js";
-import { feishuWebhookRateLimiter } from "./monitor.state.js";
+import { feishuWebhookRateLimiter, httpServers } from "./monitor.state.js";
 import { monitorWebhook } from "./monitor.transport.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
@@ -167,6 +167,16 @@ function resolveTestClientIp(remoteAddress: string | undefined): string | undefi
   } as IncomingMessage);
 }
 
+function waitForWebhookResponseClose(accountId: string): Promise<void> {
+  const server = httpServers.get(accountId);
+  if (!server) {
+    throw new Error("expected webhook server");
+  }
+  return new Promise<void>((resolve) => {
+    server.once("request", (_req, res) => res.once("close", resolve));
+  });
+}
+
 afterEach(async () => {
   feishuWebhookRateLimiter.clear();
   cleanupFeishuMonitorStateForTests();
@@ -261,40 +271,70 @@ describe("Feishu webhook security hardening", () => {
 
   it("rejects oversized unsigned webhook bodies with 413 before signature verification", async () => {
     probeFeishuMock.mockResolvedValue({ ok: true, botOpenId: "bot_open_id" });
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+    const statusSink = vi.fn();
     await withRunningWebhookMonitor(
       {
         accountId: "payload-too-large",
         path: "/hook-payload-too-large",
         verificationToken: "verify_token",
         encryptKey: "encrypt_key",
+        runtime,
+        statusSink,
       },
       monitorFeishuProvider,
       async (url) => {
+        statusSink.mockClear();
+        const responseClosed = waitForWebhookResponseClose("payload-too-large");
         const response = await waitForOversizedBodyResponse(url);
 
         expect(response).toContain("413 Payload Too Large");
         expect(response).toContain("Payload too large");
         expect(response).toMatch(/connection: close/i);
+        await responseClosed;
+        expect(
+          runtime.log.mock.calls.filter(([message]) => message.includes("webhook anomaly")),
+        ).toEqual([
+          [
+            "feishu[payload-too-large]: webhook anomaly path=/hook-payload-too-large status=413 count=1",
+          ],
+        ]);
+        expect(statusSink).not.toHaveBeenCalled();
       },
     );
   });
 
   it("drops slow-body webhook requests within the tightened pre-auth timeout", async () => {
     probeFeishuMock.mockResolvedValue({ ok: true, botOpenId: "bot_open_id" });
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+    const statusSink = vi.fn();
     await withRunningWebhookMonitor(
       {
         accountId: "slow-body-timeout",
         path: "/hook-slow-body-timeout",
         verificationToken: "verify_token",
         encryptKey: "encrypt_key",
+        runtime,
+        statusSink,
       },
       monitorFeishuProvider,
       async (url) => {
+        statusSink.mockClear();
+        const responseClosed = waitForWebhookResponseClose("slow-body-timeout");
         const result = await waitForSlowBodyTimeoutResponse(url, 1_000);
         expect(result.body).toContain("408 Request Timeout");
         expect(result.body).toContain("Request body timeout");
         expect(result.body).toMatch(/connection: close/i);
         expect(result.elapsedMs).toBeLessThan(500);
+        await responseClosed;
+        expect(
+          runtime.log.mock.calls.filter(([message]) => message.includes("webhook anomaly")),
+        ).toEqual([
+          [
+            "feishu[slow-body-timeout]: webhook anomaly path=/hook-slow-body-timeout status=408 count=1",
+          ],
+        ]);
+        expect(statusSink).not.toHaveBeenCalled();
       },
     );
   });

--- a/extensions/feishu/src/monitor.webhook.test-helpers.ts
+++ b/extensions/feishu/src/monitor.webhook.test-helpers.ts
@@ -1,4 +1,5 @@
 // Feishu helper module supports monitor.webhook helpers behavior.
+import crypto from "node:crypto";
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import {
@@ -8,10 +9,49 @@ import {
 import { vi } from "vitest";
 import type { ClawdbotConfig, RuntimeEnv } from "../runtime-api.js";
 import type { FeishuStatusSink, monitorFeishuProvider } from "./monitor.js";
+import type { ResolvedFeishuAccount } from "./types.js";
 
 const WEBHOOK_READY_MAX_ATTEMPTS = 200;
 const WEBHOOK_READY_RETRY_DELAY_MS = 50;
 const WEBHOOK_MONITOR_START_MAX_ATTEMPTS = 4;
+
+export function createFeishuWebhookTestAccount(
+  accountId: string,
+  port: number,
+  webhookPath: string,
+): ResolvedFeishuAccount {
+  return {
+    accountId,
+    encryptKey: "encrypt_key",
+    config: {
+      enabled: true,
+      connectionMode: "webhook",
+      webhookHost: "127.0.0.1",
+      webhookPort: port,
+      webhookPath,
+    },
+  } as ResolvedFeishuAccount;
+}
+
+export function signFeishuPayload(params: {
+  encryptKey: string;
+  rawBody: string;
+  timestamp?: string;
+  nonce?: string;
+}): Record<string, string> {
+  const timestamp = params.timestamp ?? "1711111111";
+  const nonce = params.nonce ?? "nonce-test";
+  const signature = crypto
+    .createHash("sha256")
+    .update(timestamp + nonce + params.encryptKey + params.rawBody)
+    .digest("hex");
+  return {
+    "content-type": "application/json",
+    "x-lark-request-timestamp": timestamp,
+    "x-lark-request-nonce": nonce,
+    "x-lark-signature": signature,
+  };
+}
 
 export async function getFreePort(): Promise<number> {
   const server = createServer();

--- a/extensions/feishu/src/monitor.webhook.test-helpers.ts
+++ b/extensions/feishu/src/monitor.webhook.test-helpers.ts
@@ -6,8 +6,8 @@ import {
   ssrfPolicyFromDangerouslyAllowPrivateNetwork,
 } from "openclaw/plugin-sdk/ssrf-runtime";
 import { vi } from "vitest";
-import type { ClawdbotConfig } from "../runtime-api.js";
-import type { monitorFeishuProvider } from "./monitor.js";
+import type { ClawdbotConfig, RuntimeEnv } from "../runtime-api.js";
+import type { FeishuStatusSink, monitorFeishuProvider } from "./monitor.js";
 
 const WEBHOOK_READY_MAX_ATTEMPTS = 200;
 const WEBHOOK_READY_RETRY_DELAY_MS = 50;
@@ -89,6 +89,8 @@ export async function withRunningWebhookMonitor(
     path: string;
     verificationToken: string;
     encryptKey: string;
+    runtime?: RuntimeEnv;
+    statusSink?: FeishuStatusSink;
   },
   monitor: typeof monitorFeishuProvider,
   run: (url: string) => Promise<void>,
@@ -105,12 +107,13 @@ export async function withRunningWebhookMonitor(
     });
 
     const abortController = new AbortController();
-    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+    const runtime = params.runtime ?? { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
     const monitorPromise = monitor({
       config: cfg,
       runtime,
       abortSignal: abortController.signal,
       accountId: params.accountId,
+      statusSink: params.statusSink,
     });
 
     const url = `http://127.0.0.1:${port}${params.path}`;

--- a/extensions/line/src/monitor.lifecycle.test.ts
+++ b/extensions/line/src/monitor.lifecycle.test.ts
@@ -1,7 +1,7 @@
 // Line tests cover monitor.lifecycle plugin behavior.
 import crypto from "node:crypto";
-import { EventEmitter } from "node:events";
-import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { createServer, IncomingMessage, type ServerResponse } from "node:http";
+import { Socket } from "node:net";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { createMockIncomingRequest } from "openclaw/plugin-sdk/test-env";
@@ -716,7 +716,7 @@ describe("monitorLineProvider lifecycle", () => {
 
   it("rejects webhook requests above the shared in-flight limit before body handling", async () => {
     const limit = WEBHOOK_IN_FLIGHT_DEFAULTS.maxInFlightPerKey;
-    const heldRequests: Array<EventEmitter & { destroy: () => void }> = [];
+    const heldRequests: IncomingMessage[] = [];
 
     const monitor = await monitorLineProvider({
       channelAccessToken: "token",
@@ -727,13 +727,7 @@ describe("monitorLineProvider lifecycle", () => {
 
     const route = requireRegisteredRoute();
     const createHeldPostRequest = () => {
-      const req = Object.assign(new EventEmitter(), {
-        destroyed: false,
-        destroy(this: EventEmitter & { destroyed: boolean }) {
-          this.destroyed = true;
-          this.emit("close");
-        },
-      });
+      const req = new IncomingMessage(new Socket());
       heldRequests.push(req);
       return Object.assign(req, {
         method: "POST",

--- a/extensions/mattermost/src/mattermost/slash-http.send-config.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.send-config.test.ts
@@ -1,8 +1,8 @@
 // Mattermost tests cover slash http.send config plugin behavior.
 import { ServerResponse, type IncomingMessage } from "node:http";
-import { PassThrough } from "node:stream";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime";
+import { createMockIncomingRequest } from "openclaw/plugin-sdk/test-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ResolvedMattermostAccount } from "./accounts.js";
 
@@ -147,17 +147,13 @@ let createSlashCommandHttpHandler: typeof import("./slash-http.js").createSlashC
 const callbackUrlFixture = "https://gateway.example.com/slash";
 
 function createRequest(body = "token=valid-token"): IncomingMessage {
-  const req = new PassThrough();
-  const incoming = req as PassThrough & IncomingMessage;
-  incoming.method = "POST";
-  incoming.url = "/slash";
-  incoming.headers = {
+  const req = createMockIncomingRequest([body]);
+  req.method = "POST";
+  req.url = "/slash";
+  req.headers = {
     "content-type": "application/x-www-form-urlencoded",
   };
-  process.nextTick(() => {
-    req.end(body);
-  });
-  return incoming;
+  return req;
 }
 
 function createResponse(): {

--- a/extensions/mattermost/src/mattermost/slash-http.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.test.ts
@@ -1,6 +1,6 @@
 // Mattermost tests cover slash http plugin behavior.
-import type { IncomingMessage, ServerResponse } from "node:http";
-import { PassThrough } from "node:stream";
+import { IncomingMessage, type ServerResponse } from "node:http";
+import { Socket } from "node:net";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig, RuntimeEnv } from "../../runtime-api.js";
 import type { ResolvedMattermostAccount } from "./accounts.js";
@@ -35,21 +35,21 @@ function createRequest(params: {
   contentType?: string;
   autoEnd?: boolean;
 }): IncomingMessage {
-  const req = new PassThrough();
-  const incoming = req as PassThrough & IncomingMessage;
-  incoming.method = params.method ?? "POST";
-  incoming.headers = {
+  const req = new IncomingMessage(new Socket());
+  req.method = params.method ?? "POST";
+  req.headers = {
     "content-type": params.contentType ?? "application/x-www-form-urlencoded",
   };
   process.nextTick(() => {
     if (params.body) {
-      req.write(params.body);
+      req.push(Buffer.from(params.body));
     }
     if (params.autoEnd !== false) {
-      req.end();
+      req.complete = true;
+      req.push(null);
     }
   });
-  return incoming;
+  return req;
 }
 
 function createResponse(): {

--- a/extensions/mattermost/src/mattermost/slash-http.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.ts
@@ -576,7 +576,11 @@ async function authorizeSlashInvocation(params: {
 export function createSlashCommandHttpHandler(params: SlashHttpHandlerParams) {
   const { account, cfg, runtime, registeredCommands, triggerMap, log, bodyTimeoutMs } = params;
 
-  return async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
+  return async (
+    req: IncomingMessage,
+    res: ServerResponse,
+    bufferedBody?: string,
+  ): Promise<void> => {
     if (req.method !== "POST") {
       res.statusCode = 405;
       res.setHeader("Allow", "POST");
@@ -586,7 +590,7 @@ export function createSlashCommandHttpHandler(params: SlashHttpHandlerParams) {
 
     let body: string;
     try {
-      body = await readBody(req, MAX_BODY_BYTES, bodyTimeoutMs);
+      body = bufferedBody ?? (await readBody(req, MAX_BODY_BYTES, bodyTimeoutMs));
     } catch (error) {
       if (isRequestBodyLimitError(error, "REQUEST_BODY_TIMEOUT")) {
         res.statusCode = 408;

--- a/extensions/mattermost/src/mattermost/slash-state.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-state.test.ts
@@ -1,6 +1,6 @@
 // Mattermost tests cover slash state plugin behavior.
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { PassThrough } from "node:stream";
+import { createMockIncomingRequest, withServer } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ResolvedMattermostAccount } from "./accounts.js";
 import type { OpenClawConfig, RuntimeEnv } from "./runtime-api.js";
@@ -76,12 +76,9 @@ function replaceAccountHandler(accountId: string): void {
 }
 
 function createRequest(body: string): IncomingMessage {
-  const req = new PassThrough() as PassThrough & IncomingMessage;
+  const req = createMockIncomingRequest([body]);
   req.method = "POST";
   req.headers = { "content-type": "application/x-www-form-urlencoded" };
-  process.nextTick(() => {
-    req.end(body);
-  });
   return req;
 }
 
@@ -97,13 +94,10 @@ function createResponse(): { res: ServerResponse; getBody: () => string } {
   return { res, getBody: () => body };
 }
 
-async function routeSlashRequest(params: {
-  body: string;
-  register?: typeof registerSlashCommandRoute;
-}): Promise<{ statusCode: number; body: string; warn: ReturnType<typeof vi.fn> }> {
+function createSlashRoute(register = registerSlashCommandRoute) {
   let routeHandler: ((req: IncomingMessage, res: ServerResponse) => Promise<void>) | undefined;
   const warn = vi.fn();
-  (params.register ?? registerSlashCommandRoute)({
+  register({
     config: { channels: { mattermost: {} } },
     logger: { warn },
     registerHttpRoute(route: {
@@ -115,8 +109,16 @@ async function routeSlashRequest(params: {
   if (!routeHandler) {
     throw new Error("expected Mattermost slash route registration");
   }
+  return { handler: routeHandler, warn };
+}
+
+async function routeSlashRequest(params: {
+  body: string;
+  register?: typeof registerSlashCommandRoute;
+}): Promise<{ statusCode: number; body: string; warn: ReturnType<typeof vi.fn> }> {
+  const { handler, warn } = createSlashRoute(params.register);
   const response = createResponse();
-  await routeHandler(createRequest(params.body), response.res);
+  await handler(createRequest(params.body), response.res);
   return { statusCode: response.res.statusCode, body: response.getBody(), warn };
 }
 
@@ -163,6 +165,54 @@ describe("slash-state global singleton", () => {
 describe("slash-state request routing", () => {
   afterEach(() => {
     deactivateSlashCommands();
+  });
+
+  it.each([
+    {
+      name: "token match",
+      body: "token=token-1",
+      status: 400,
+      message: "Invalid slash command payload.",
+    },
+    {
+      name: "registered command match",
+      body: "token=rotated&team_id=team-1&channel_id=c1&user_id=u1&command=%2Foc_status&text=",
+      status: 401,
+      message: "Unauthorized: invalid command token.",
+    },
+  ])("keeps real multi-account $name requests in account validation", async (testCase) => {
+    activateSlashCommands({
+      account: createResolvedMattermostAccount("a1"),
+      commandTokens: ["token-1"],
+      registeredCommands: [createRegisteredCommand()],
+      api: slashApi,
+    });
+    activateSlashCommands({
+      account: createResolvedMattermostAccount("a2"),
+      commandTokens: ["token-2"],
+      registeredCommands: [createRegisteredCommand({ id: "cmd-2", teamId: "team-2" })],
+      api: slashApi,
+    });
+    const route = createSlashRoute();
+    await withServer(
+      (req, res) => {
+        void route.handler(req, res).catch((error: unknown) => {
+          res.destroy(error instanceof Error ? error : new Error(String(error)));
+        });
+      },
+      async (baseUrl) => {
+        const response = await fetch(`${baseUrl}/slash`, {
+          method: "POST",
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+          body: testCase.body,
+        });
+        expect(response.status).toBe(testCase.status);
+        expect(await response.json()).toEqual({
+          response_type: "ephemeral",
+          text: testCase.message,
+        });
+      },
+    );
   });
 
   it("routes a token owned by one account", async () => {

--- a/extensions/mattermost/src/mattermost/slash-state.ts
+++ b/extensions/mattermost/src/mattermost/slash-state.ts
@@ -11,7 +11,6 @@
  */
 
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { Readable } from "node:stream";
 import type { MattermostConfig } from "../types.js";
 import type { ResolvedMattermostAccount } from "./accounts.js";
 import {
@@ -32,13 +31,14 @@ import {
 
 const MULTI_ACCOUNT_BODY_MAX_BYTES = 64 * 1024;
 const MULTI_ACCOUNT_BODY_TIMEOUT_MS = 5_000;
+type SlashHandler = ReturnType<typeof createSlashCommandHttpHandler>;
 type SlashHandlerMatchSource = "token" | "command";
 type SlashHandlerMatch =
   | { kind: "none" }
   | {
       kind: "single";
       source: SlashHandlerMatchSource;
-      handler: (req: IncomingMessage, res: ServerResponse) => Promise<void>;
+      handler: SlashHandler;
       accountIds: string[];
     }
   | {
@@ -55,7 +55,7 @@ type SlashCommandAccountState = {
   /** Registered command IDs for cleanup on shutdown. */
   registeredCommands: MattermostRegisteredCommand[];
   /** Current HTTP handler for this account. */
-  handler: ((req: IncomingMessage, res: ServerResponse) => Promise<void>) | null;
+  handler: SlashHandler | null;
   /** The account that activated slash commands. */
   account: ResolvedMattermostAccount;
   /** Map from trigger to original command name (for skill commands that start with oc_). */
@@ -89,7 +89,7 @@ const accountStates = getSlashAccountStates();
 function resolveSlashHandlerForToken(token: string): SlashHandlerMatch {
   const matches: Array<{
     accountId: string;
-    handler: (req: IncomingMessage, res: ServerResponse) => Promise<void>;
+    handler: SlashHandler;
   }> = [];
 
   for (const [accountId, state] of accountStates) {
@@ -132,7 +132,7 @@ function resolveSlashHandlerForCommand(params: {
 
   const matches: Array<{
     accountId: string;
-    handler: (req: IncomingMessage, res: ServerResponse) => Promise<void>;
+    handler: SlashHandler;
   }> = [];
 
   for (const [accountId, state] of accountStates) {
@@ -325,8 +325,8 @@ export function registerSlashCommandRoute(api: OpenClawPluginApi) {
       return;
     }
 
-    // Multi-account: buffer the body, find the matching account by token or
-    // registered team/trigger, then replay the request to the correct handler.
+    // Multi-account: buffer the body, then find the matching account by token or
+    // registered team/trigger before account-specific validation.
     // Use the bounded helper so a slow/never-finishing client cannot tie up the
     // routing handler indefinitely (Slowloris).
     let bodyStr: string;
@@ -403,22 +403,9 @@ export function registerSlashCommandRoute(api: OpenClawPluginApi) {
       return;
     }
 
-    const matchedHandler = match.handler;
-
-    // Replay: create a synthetic readable that re-emits the buffered body
-    const syntheticReq = new Readable({
-      read() {
-        this.push(Buffer.from(bodyStr, "utf8"));
-        this.push(null);
-      },
-    }) as IncomingMessage;
-
-    // Copy necessary IncomingMessage properties
-    syntheticReq.method = req.method;
-    syntheticReq.url = req.url;
-    syntheticReq.headers = req.headers;
-
-    await matchedHandler(syntheticReq, res);
+    // Routing already enforced the body limit. Retain the original transport
+    // and pass those bytes forward instead of replaying a socket-less request.
+    await match.handler(req, res, bodyStr);
   };
 
   for (const callbackPath of callbackPaths) {

--- a/extensions/nextcloud-talk/src/monitor.replay.test.ts
+++ b/extensions/nextcloud-talk/src/monitor.replay.test.ts
@@ -35,8 +35,8 @@ async function invokeWebhookRequestListener(params: {
     method: "POST",
     url: params.path,
     headers: params.headers,
-    socket: { remoteAddress: params.remoteAddress },
-  }) as unknown as IncomingMessage;
+  });
+  Object.defineProperty(req.socket, "remoteAddress", { value: params.remoteAddress });
 
   return await new Promise<{ body: string; status: number }>((resolve) => {
     let status = 0;

--- a/extensions/openai/realtime-quicksilver.test-helpers.ts
+++ b/extensions/openai/realtime-quicksilver.test-helpers.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "node:events";
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { Readable } from "node:stream";
+import { createMockIncomingRequest } from "openclaw/plugin-sdk/test-env";
 import { vi } from "vitest";
 import { createOpenAIQuicksilverBrowserSessionBroker } from "./realtime-quicksilver-session.js";
 
@@ -49,7 +49,7 @@ export function createRequest(params: {
   contentType?: string;
   body?: string;
 }): IncomingMessage {
-  return Object.assign(Readable.from([params.body ?? "v=offer\r\n"]), {
+  return Object.assign(createMockIncomingRequest([params.body ?? "v=offer\r\n"]), {
     method: params.method ?? "POST",
     headers: {
       ...(params.token ? { authorization: `Bearer ${params.token}` } : {}),
@@ -61,11 +61,11 @@ export function createRequest(params: {
       ...(params.origin ? { origin: params.origin } : {}),
       ...(params.host ? { host: params.host } : {}),
     },
-  }) as unknown as IncomingMessage;
+  });
 }
 
 export function createPreflightRequest(origin: string, host?: string): IncomingMessage {
-  return Object.assign(Readable.from([]), {
+  return Object.assign(createMockIncomingRequest([]), {
     method: "OPTIONS",
     headers: {
       origin,
@@ -74,7 +74,7 @@ export function createPreflightRequest(origin: string, host?: string): IncomingM
       "access-control-request-headers": "authorization,content-type",
       "access-control-request-private-network": "true",
     },
-  }) as unknown as IncomingMessage;
+  });
 }
 
 export function createResponseHarness(): {

--- a/extensions/qa-lab/src/bus-server.test.ts
+++ b/extensions/qa-lab/src/bus-server.test.ts
@@ -1,6 +1,7 @@
 // Qa Lab tests cover bus server plugin behavior.
 import { Agent, createServer, request } from "node:http";
 import { setTimeout as sleep } from "node:timers/promises";
+import { createMockIncomingRequest } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { closeQaHttpServer, handleQaBusRequest, startQaBusServer } from "./bus-server.js";
 import { createQaBusState } from "./bus-state.js";
@@ -523,18 +524,18 @@ describe("qa-bus server", () => {
 });
 
 describe("handleQaBusRequest", () => {
-  it.each(["/v1/inbound/message", "/v1/outbound/message"] as const)(
-    "returns a controlled error when the %s body exceeds the media limit",
-    async (pathname) => {
-      const req = {
+  it.each([
+    { pathname: "/v1/inbound/message", limit: 16 * 1024 * 1024 },
+    { pathname: "/v1/outbound/message", limit: 16 * 1024 * 1024 },
+    { pathname: "/v1/reset", limit: 1024 * 1024 },
+  ])(
+    "returns a controlled error when the $pathname body exceeds its limit",
+    async ({ pathname, limit }) => {
+      const req = Object.assign(createMockIncomingRequest([]), {
         method: "POST",
         url: pathname,
-        headers: { "content-length": String(16 * 1024 * 1024 + 1) },
-        destroyed: false,
-        destroy() {
-          this.destroyed = true;
-        },
-      };
+        headers: { "content-length": String(limit + 1) },
+      });
       const res = {
         statusCode: 0,
         body: "",
@@ -547,7 +548,7 @@ describe("handleQaBusRequest", () => {
       };
 
       const handled = await handleQaBusRequest({
-        req: req as never,
+        req,
         res: res as never,
         state: createQaBusState(),
       });
@@ -558,36 +559,4 @@ describe("handleQaBusRequest", () => {
       expect(JSON.parse(res.body)).toEqual({ error: "Payload too large" });
     },
   );
-
-  it("returns a controlled error when a v1 POST body exceeds the limit", async () => {
-    const req = {
-      method: "POST",
-      url: "/v1/reset",
-      headers: { "content-length": String(1024 * 1024 + 1) },
-      destroyed: false,
-      destroy() {
-        this.destroyed = true;
-      },
-    };
-    const res = {
-      statusCode: 0,
-      body: "",
-      writeHead(statusCode: number) {
-        this.statusCode = statusCode;
-      },
-      end(payload: string) {
-        this.body = payload;
-      },
-    };
-
-    const handled = await handleQaBusRequest({
-      req: req as never,
-      res: res as never,
-      state: createQaBusState(),
-    });
-
-    expect(handled).toBe(true);
-    expect(res.statusCode).toBe(413);
-    expect(JSON.parse(res.body)).toEqual({ error: "Payload too large" });
-  });
 });

--- a/extensions/sms/src/twilio.test.ts
+++ b/extensions/sms/src/twilio.test.ts
@@ -1,7 +1,6 @@
 // Sms tests cover twilio plugin behavior.
 import { createHmac } from "node:crypto";
-import type { IncomingMessage } from "node:http";
-import { Readable } from "node:stream";
+import { createMockIncomingRequest } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveTwilioStatusCallbackUrl } from "./public-webhook-url.js";
 import {
@@ -70,7 +69,7 @@ function computeTestTwilioSignature(params: {
 }
 
 async function readTestTwilioForm(body: string): Promise<Record<string, string>> {
-  const req = Readable.from([body]) as IncomingMessage;
+  const req = createMockIncomingRequest([body]);
   req.headers = { "content-length": String(Buffer.byteLength(body)) };
   return await readTwilioWebhookForm(req);
 }

--- a/extensions/telegram/src/miniapp/routes.test.ts
+++ b/extensions/telegram/src/miniapp/routes.test.ts
@@ -1,11 +1,11 @@
 import crypto from "node:crypto";
 import { EventEmitter } from "node:events";
-import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
-import { connect, type Socket } from "node:net";
-import { Readable } from "node:stream";
+import { createServer, IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { connect, Socket } from "node:net";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import { createMockIncomingRequest } from "openclaw/plugin-sdk/test-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createTelegramMiniAppLaunchTickets,
@@ -99,12 +99,12 @@ async function callRoute(params: {
   contentType?: string;
   ip?: string;
 }) {
-  const req = Readable.from(params.body ? [params.body] : []) as IncomingMessage;
+  const req = createMockIncomingRequest(params.body ? [params.body] : []);
   req.method = params.method;
   req.url = params.url;
   req.headers = params.contentType ? { "content-type": params.contentType } : {};
-  Object.defineProperty(req, "socket", {
-    value: { remoteAddress: params.ip ?? "203.0.113.10" },
+  Object.defineProperty(req.socket, "remoteAddress", {
+    value: params.ip ?? "203.0.113.10",
   });
   return await callRouteRequest(params.route, req);
 }
@@ -116,15 +116,11 @@ async function callRouteRequest(route: OpenClawPluginHttpRouteParams, req: Incom
 }
 
 function createPendingAuthRequest(ip: string): IncomingMessage {
-  const req = new Readable({
-    read() {
-      // Keep the body open so the canonical reader owns timeout settlement.
-    },
-  }) as IncomingMessage;
+  const req = new IncomingMessage(new Socket());
   req.method = "POST";
   req.url = "/__openclaw_tg_miniapp/auth";
   req.headers = { "content-type": "application/json" };
-  Object.defineProperty(req, "socket", { value: { remoteAddress: ip } });
+  Object.defineProperty(req.socket, "remoteAddress", { value: ip });
   return req;
 }
 
@@ -160,12 +156,6 @@ async function readSocketResponse(socket: Socket): Promise<string> {
     socket.on("end", finish);
     socket.on("close", finish);
     socket.on("error", reject);
-  });
-}
-
-function createRouteServer(route: OpenClawPluginHttpRouteParams): Server {
-  return createServer((req, res) => {
-    void route.handler(req, res);
   });
 }
 
@@ -408,59 +398,61 @@ describe("registerTelegramMiniAppRoutes", () => {
     expect(issueDeviceBootstrapToken).not.toHaveBeenCalled();
   });
 
-  it("rejects an oversized auth body and closes the request", async () => {
-    const route = createRoute(config());
-    const req = Readable.from(["x".repeat(4097)]) as IncomingMessage;
-    req.method = "POST";
-    req.url = "/__openclaw_tg_miniapp/auth";
-    req.headers = { "content-type": "application/json" };
-    Object.defineProperty(req, "socket", { value: { remoteAddress: "203.0.113.50" } });
-
-    const res = await callRouteRequest(route, req);
-
-    expect(res.statusCode).toBe(413);
-    expect(res.body).toBe("Payload too large");
-    expect(req.destroyed).toBe(true);
-    expectBodyReadListenersCleaned(req);
-    expect(issueDeviceBootstrapToken).not.toHaveBeenCalled();
-  });
-
-  it("flushes a real HTTP 413 response before closing an oversized auth request", async () => {
-    const server = createRouteServer(createRoute(config()));
-    let socket: Socket | undefined;
-    try {
-      const port = await listen(server);
-      socket = connect({ host: "127.0.0.1", port });
-      await new Promise<void>((resolve) => {
-        socket?.once("connect", resolve);
+  it.each(["content-length", "chunked"])(
+    "flushes HTTP 413 before closing an oversized %s auth request",
+    async (framing) => {
+      const route = createRoute(config());
+      const handled: Promise<unknown>[] = [];
+      let request: IncomingMessage | undefined;
+      const server = createServer((req, res) => {
+        request = req;
+        handled.push(Promise.resolve(route.handler(req, res)));
       });
+      let socket: Socket | undefined;
+      try {
+        const port = await listen(server);
+        socket = connect({ host: "127.0.0.1", port });
+        await new Promise<void>((resolve) => {
+          socket?.once("connect", resolve);
+        });
 
-      socket.write(
-        [
-          "POST /__openclaw_tg_miniapp/auth HTTP/1.1",
-          "Host: 127.0.0.1",
-          "Content-Type: application/json",
-          `Content-Length: ${AUTH_BODY_MAX_BYTES + 1}`,
-          "Connection: keep-alive",
-          "",
-          "{",
-        ].join("\r\n"),
-      );
+        socket.write(
+          [
+            "POST /__openclaw_tg_miniapp/auth HTTP/1.1",
+            "Host: 127.0.0.1",
+            "Content-Type: application/json",
+            framing === "content-length"
+              ? `Content-Length: ${AUTH_BODY_MAX_BYTES + 1}`
+              : "Transfer-Encoding: chunked",
+            "Connection: keep-alive",
+            "",
+            framing === "content-length"
+              ? "{"
+              : `${(AUTH_BODY_MAX_BYTES + 1).toString(16)}\r\n${"x".repeat(AUTH_BODY_MAX_BYTES + 1)}\r\n0\r\n\r\n`,
+          ].join("\r\n"),
+        );
 
-      const response = await readSocketResponse(socket);
-      const [, body = ""] = response.split("\r\n\r\n", 2);
+        const response = await readSocketResponse(socket);
+        const [, body = ""] = response.split("\r\n\r\n", 2);
 
-      expect(response).toContain("HTTP/1.1 413");
-      expect(response).toContain("Connection: close");
-      expect(body).toBe("Payload too large");
-      expect(issueDeviceBootstrapToken).not.toHaveBeenCalled();
-    } finally {
-      socket?.destroy();
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-      });
-    }
-  });
+        expect(response).toContain("HTTP/1.1 413");
+        expect(response).toContain("Connection: close");
+        expect(body).toBe("Payload too large");
+        expect(issueDeviceBootstrapToken).not.toHaveBeenCalled();
+        await Promise.all(handled);
+        expect(request?.socket.destroyed).toBe(true);
+        if (!request) {
+          throw new Error("expected auth request");
+        }
+        expectBodyReadListenersCleaned(request);
+      } finally {
+        socket?.destroy();
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
+    },
+  );
 
   it("settles an early client close without leaking request-body listeners", async () => {
     const route = createRoute(config());
@@ -476,24 +468,6 @@ describe("registerTelegramMiniAppRoutes", () => {
     expect(issueDeviceBootstrapToken).not.toHaveBeenCalled();
   });
 
-  it("times out a slow auth body and closes the request", async () => {
-    const route = createRoute(config());
-    const req = createPendingAuthRequest("203.0.113.52");
-    try {
-      const res = await callRouteRequest(route, req);
-
-      expect(res.statusCode).toBe(408);
-      expect(res.body).toBe("Request body timeout");
-      expect(req.destroyed).toBe(false);
-      res.emit("close");
-      expect(req.destroyed).toBe(true);
-      expectBodyReadListenersCleaned(req);
-      expect(issueDeviceBootstrapToken).not.toHaveBeenCalled();
-    } finally {
-      req.destroy();
-    }
-  }, 10_000);
-
   it("flushes a real HTTP 408 response before closing a stalled auth request", async () => {
     vi.useFakeTimers();
     let markRequestStarted: (() => void) | undefined;
@@ -501,8 +475,11 @@ describe("registerTelegramMiniAppRoutes", () => {
       markRequestStarted = resolve;
     });
     const route = createRoute(config());
+    const handled: Promise<unknown>[] = [];
+    let request: IncomingMessage | undefined;
     const server = createServer((req, res) => {
-      void route.handler(req, res);
+      request = req;
+      handled.push(Promise.resolve(route.handler(req, res)));
       markRequestStarted?.();
     });
     let socket: Socket | undefined;
@@ -535,6 +512,12 @@ describe("registerTelegramMiniAppRoutes", () => {
       expect(response).toContain("Connection: close");
       expect(body).toBe("Request body timeout");
       expect(issueDeviceBootstrapToken).not.toHaveBeenCalled();
+      await Promise.all(handled);
+      expect(request?.socket.destroyed).toBe(true);
+      if (!request) {
+        throw new Error("expected auth request");
+      }
+      expectBodyReadListenersCleaned(request);
     } finally {
       vi.useRealTimers();
       socket?.destroy();

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -324,7 +324,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: descriptor-based allowFrom authentication classifier for channel security audits.
       // +1: downstream strength mappers need canonical ordering instead of duplicate rank tables.
       // +1: focused account media-limit resolver avoids the deprecated barrel on startup.
-      4350,
+      // +1: shared bounded HTTP rejection transport replaces plugin-local close policies.
+      4351,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -425,7 +426,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: descriptor-based allowFrom authentication classifier for channel security audits.
       // +1: downstream strength mappers need canonical ordering instead of duplicate rank tables.
       // +1: focused account media-limit resolver avoids the deprecated barrel on startup.
-      2586,
+      // +1: shared bounded HTTP rejection transport replaces plugin-local close policies.
+      2587,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/gateway/hooks-test-helpers.ts
+++ b/src/gateway/hooks-test-helpers.ts
@@ -1,6 +1,7 @@
 // Gateway hook test fixtures.
 // Builds resolved hook config and IncomingMessage-like requests for tests.
-import type { IncomingMessage } from "node:http";
+import { IncomingMessage } from "node:http";
+import { Socket } from "node:net";
 import type { HooksConfigResolved } from "./hooks.js";
 
 /** Creates the default resolved hook config used by gateway hook tests. */
@@ -41,10 +42,11 @@ export function createGatewayRequest(params: {
   if (params.authorization) {
     headers.authorization = params.authorization;
   }
-  return {
+  const socket = new Socket();
+  Object.defineProperty(socket, "remoteAddress", { value: params.remoteAddress ?? "127.0.0.1" });
+  return Object.assign(new IncomingMessage(socket), {
     method: params.method ?? "GET",
     url: params.path,
     headers,
-    socket: { remoteAddress: params.remoteAddress ?? "127.0.0.1" },
-  } as IncomingMessage;
+  });
 }

--- a/src/gateway/http-common.fuzz.test.ts
+++ b/src/gateway/http-common.fuzz.test.ts
@@ -1,7 +1,7 @@
 // Deterministic fuzz coverage for shared Gateway HTTP helpers and disconnect
 // handling without adding a property-test dependency.
 import { EventEmitter } from "node:events";
-import type { IncomingMessage } from "node:http";
+import { createServer, type IncomingMessage } from "node:http";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayAuthResult } from "./auth.js";
 import {
@@ -248,62 +248,81 @@ describe("fuzz: sendInvalidRequest", () => {
 });
 
 describe("fuzz: readJsonBodyOrError", () => {
-  const makeRequest = () => {
-    const req = { destroyed: false } as IncomingMessage;
-    req.destroy = vi.fn(() => {
-      req.destroyed = true;
-      return req;
-    });
-    return req;
-  };
-
   it("maps readJsonBody results to the documented status/body contract", async () => {
     const rng = makeRng(0xc0de);
-    for (let i = 0; i < ITERATIONS; i += 1) {
-      const { res, end } = makeMockHttpResponse();
-      const pick = randInt(rng, 0, 3);
-      let expectedStatus: number | undefined;
-      let expectedBody: string | undefined;
-      let expectedValue: unknown;
+    let maxBytes = 0;
+    let receivedRequest: IncomingMessage | undefined;
+    const tasks: Promise<void>[] = [];
+    const server = createServer((req, res) => {
+      receivedRequest = req;
+      tasks.push(
+        readJsonBodyOrError(req, res, maxBytes).then((value) => {
+          if (!res.headersSent) {
+            sendJson(res, 200, value);
+          }
+        }),
+      );
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("missing listener");
+    }
+    try {
+      for (let i = 0; i < ITERATIONS; i += 1) {
+        const pick = randInt(rng, 0, 3);
+        let expectedStatus: number | undefined;
+        let expectedBody: string | undefined;
+        let expectedValue: unknown;
 
-      if (pick === 0) {
-        const value = randBody(rng);
-        expectedValue = value;
-        readJsonBodyMock.mockResolvedValueOnce({ ok: true, value });
-      } else if (pick === 1) {
-        expectedStatus = 413;
-        expectedBody = JSON.stringify({
-          error: { message: "Payload too large", type: "invalid_request_error" },
-        });
-        readJsonBodyMock.mockResolvedValueOnce({ ok: false, error: "payload too large" });
-      } else if (pick === 2) {
-        expectedStatus = 408;
-        expectedBody = JSON.stringify({
-          error: { message: "Request body timeout", type: "invalid_request_error" },
-        });
-        readJsonBodyMock.mockResolvedValueOnce({ ok: false, error: "request body timeout" });
-      } else {
-        // Arbitrary error text must neither collide with the 413/408 sentinels
-        // nor accidentally reuse them; pick a prefix that can never match.
-        const text = `err-${randString(rng, 24)}`;
-        expectedStatus = 400;
-        expectedBody = JSON.stringify({
-          error: { message: text, type: "invalid_request_error" },
-        });
-        readJsonBodyMock.mockResolvedValueOnce({ ok: false, error: text });
-      }
+        if (pick === 0) {
+          const value = randBody(rng);
+          expectedValue = value;
+          readJsonBodyMock.mockResolvedValueOnce({ ok: true, value });
+        } else if (pick === 1) {
+          expectedStatus = 413;
+          expectedBody = JSON.stringify({
+            error: { message: "Payload too large", type: "invalid_request_error" },
+          });
+          readJsonBodyMock.mockResolvedValueOnce({ ok: false, error: "payload too large" });
+        } else if (pick === 2) {
+          expectedStatus = 408;
+          expectedBody = JSON.stringify({
+            error: { message: "Request body timeout", type: "invalid_request_error" },
+          });
+          readJsonBodyMock.mockResolvedValueOnce({ ok: false, error: "request body timeout" });
+        } else {
+          // Arbitrary error text must neither collide with the 413/408 sentinels
+          // nor accidentally reuse them; pick a prefix that can never match.
+          const text = `err-${randString(rng, 24)}`;
+          expectedStatus = 400;
+          expectedBody = JSON.stringify({
+            error: { message: text, type: "invalid_request_error" },
+          });
+          readJsonBodyMock.mockResolvedValueOnce({ ok: false, error: text });
+        }
 
-      const maxBytes = randInt(rng, 1, 1 << 20);
-      const req = makeRequest();
-      const result = await readJsonBodyOrError(req, res, maxBytes);
-      if (pick === 0) {
-        expect(result).toEqual(expectedValue);
-      } else {
-        expect(result).toBeUndefined();
-        expect(res.statusCode).toBe(expectedStatus);
-        expect(end).toHaveBeenCalledWith(expectedBody);
+        maxBytes = randInt(rng, 1, 1 << 20);
+        const response = await fetch(`http://127.0.0.1:${address.port}/`, {
+          headers: { Connection: "close" },
+        });
+        if (pick === 0) {
+          expect(response.status).toBe(200);
+          expect(await response.json()).toEqual(expectedValue);
+        } else {
+          expect(response.status).toBe(expectedStatus);
+          expect(await response.text()).toBe(expectedBody);
+        }
+        expect(readJsonBodyMock).toHaveBeenLastCalledWith(receivedRequest, maxBytes);
       }
-      expect(readJsonBodyMock).toHaveBeenLastCalledWith(req, maxBytes);
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+      await Promise.all(tasks);
     }
   });
 });

--- a/src/gateway/http-common.test.ts
+++ b/src/gateway/http-common.test.ts
@@ -1,7 +1,7 @@
 // HTTP common tests cover JSON/text response helpers, auth failures, security
 // headers, SSE headers, body parsing, and disconnect diagnostics.
 import { EventEmitter } from "node:events";
-import { ServerResponse, type IncomingMessage } from "node:http";
+import { createServer, ServerResponse, type IncomingMessage } from "node:http";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   onDiagnosticEvent,
@@ -253,52 +253,57 @@ describe("readJsonBodyOrError", () => {
     expect(readJsonBodyMock).toHaveBeenCalledWith(req, 1024);
   });
 
-  it("responds with 413 when the body is too large", async () => {
-    readJsonBodyMock.mockResolvedValueOnce({ ok: false, error: "payload too large" });
-    const events: DiagnosticEventPayload[] = [];
-    const stop = onDiagnosticEvent((event) => events.push(event));
-    const { res, end } = makeMockHttpResponse();
-    const req = makeRequest({ "content-length": "2048" });
-    const result = await readJsonBodyOrError(req, res, 1024);
-    stop();
-    expect(result).toBeUndefined();
-    expect(res.statusCode).toBe(413);
-    expect(end).toHaveBeenCalledWith(
-      JSON.stringify({
-        error: { message: "Payload too large", type: "invalid_request_error" },
-      }),
-    );
-    const event = events.find((entry) => entry.type === "payload.large");
-    expect(event?.surface).toBe("gateway.http.json");
-    expect(event?.action).toBe("rejected");
-    expect(event?.bytes).toBe(2048);
-    expect(event?.limitBytes).toBe(1024);
-    expect(event?.reason).toBe("json_body_limit");
-    expect(req.destroy).not.toHaveBeenCalled();
-    res.emit("finish");
-    expect(req.destroy).not.toHaveBeenCalled();
-    res.emit("close");
-    expect(req.destroy).toHaveBeenCalledOnce();
-  });
-
-  it("responds with 408 when the request body times out", async () => {
-    readJsonBodyMock.mockResolvedValueOnce({ ok: false, error: "request body timeout" });
-    const { res, end } = makeMockHttpResponse();
-    const req = makeRequest();
-    const result = await readJsonBodyOrError(req, res, 1024);
-    expect(result).toBeUndefined();
-    expect(res.statusCode).toBe(408);
-    expect(end).toHaveBeenCalledWith(
-      JSON.stringify({
-        error: { message: "Request body timeout", type: "invalid_request_error" },
-      }),
-    );
-    expect(req.destroy).not.toHaveBeenCalled();
-    res.emit("finish");
-    expect(req.destroy).not.toHaveBeenCalled();
-    res.emit("close");
-    expect(req.destroy).toHaveBeenCalledOnce();
-  });
+  it.each([
+    { error: "payload too large", status: 413, message: "Payload too large" },
+    { error: "request body timeout", status: 408, message: "Request body timeout" },
+  ])(
+    "delivers the complete $status response and preserves diagnostics",
+    async ({ error, status, message }) => {
+      readJsonBodyMock.mockResolvedValueOnce({ ok: false, error });
+      const events: DiagnosticEventPayload[] = [];
+      const stop = onDiagnosticEvent((event) => events.push(event));
+      const tasks: Promise<unknown>[] = [];
+      const server = createServer((req, res) => {
+        setDefaultSecurityHeaders(res);
+        tasks.push(readJsonBodyOrError(req, res, 1024));
+      });
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("missing listener");
+      }
+      try {
+        const response = await fetch(`http://127.0.0.1:${address.port}/`, {
+          method: "POST",
+          body: "x".repeat(2048),
+        });
+        expect(response.status).toBe(status);
+        expect(response.headers.get("connection")).toBe("close");
+        expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+        expect(await response.json()).toEqual({
+          error: { message, type: "invalid_request_error" },
+        });
+        if (status === 413) {
+          expect(events.find((entry) => entry.type === "payload.large")).toMatchObject({
+            surface: "gateway.http.json",
+            action: "rejected",
+            bytes: 2048,
+            limitBytes: 1024,
+            reason: "json_body_limit",
+          });
+        }
+      } finally {
+        stop();
+        server.closeAllConnections();
+        await new Promise<void>((resolve) => {
+          server.close(() => resolve());
+        });
+        await Promise.all(tasks);
+      }
+    },
+  );
 
   it("responds with 400 for other parse failures", async () => {
     readJsonBodyMock.mockResolvedValueOnce({ ok: false, error: "bad json" });

--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -3,7 +3,10 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { z } from "zod";
 import { buildMissingScopeErrorDetails } from "../../packages/gateway-protocol/src/index.js";
-import { closeRequestAfterResponse } from "../infra/http-body.js";
+import {
+  clearHttpResponseRepresentationHeaders,
+  sendHttpRequestRejection,
+} from "../infra/http-request-lifecycle.js";
 import {
   logRejectedLargePayload,
   parseContentLengthHeader,
@@ -38,20 +41,7 @@ export function finishFailedGatewayHttpResponse(res: ServerResponse): void {
     return;
   }
   if (!res.headersSent) {
-    // Replace representation metadata, not request-owned security or CORS headers.
-    for (const header of [
-      "Content-Encoding",
-      "Content-Disposition",
-      "Content-Range",
-      "Content-Language",
-      "Content-Location",
-      "ETag",
-      "Last-Modified",
-      "Transfer-Encoding",
-      "Trailer",
-    ]) {
-      res.removeHeader(header);
-    }
+    clearHttpResponseRepresentationHeaders(res);
     res.setHeader("Cache-Control", "no-store");
     res.statusMessage = "Internal Server Error";
     respondPlainText(res, 500, res.statusMessage);
@@ -176,17 +166,21 @@ export async function readJsonBodyOrError(
         reason: "json_body_limit",
         ...(contentLength !== undefined ? { bytes: contentLength } : {}),
       });
-      closeRequestAfterResponse(req, res);
-      sendJson(res, 413, {
-        error: { message: "Payload too large", type: "invalid_request_error" },
-      });
-      return undefined;
     }
-    if (body.error === "request body timeout") {
-      closeRequestAfterResponse(req, res);
-      sendJson(res, 408, {
-        error: { message: "Request body timeout", type: "invalid_request_error" },
-      });
+    if (body.error === "payload too large" || body.error === "request body timeout") {
+      const tooLarge = body.error === "payload too large";
+      await sendHttpRequestRejection(
+        req,
+        res,
+        tooLarge ? 413 : 408,
+        JSON.stringify({
+          error: {
+            message: tooLarge ? "Payload too large" : "Request body timeout",
+            type: "invalid_request_error",
+          },
+        }),
+        "application/json; charset=utf-8",
+      );
       return undefined;
     }
     sendInvalidRequest(res, body.error);

--- a/src/gateway/server-http-upgrades.ts
+++ b/src/gateway/server-http-upgrades.ts
@@ -5,6 +5,7 @@ import {
   createDiagnosticTraceContext,
   runWithDiagnosticTraceContext,
 } from "../infra/diagnostic-trace-context.js";
+import { runHttpConnectionRequest } from "../infra/http-request-lifecycle.js";
 import {
   getGatewaySuspendAdmissionPhase,
   isGatewayRestartDraining,
@@ -222,7 +223,7 @@ export function attachGatewayUpgradeHandler(opts: {
   const getResolvedAuth = opts.getResolvedAuth ?? (() => resolvedAuth);
   httpServer.on("upgrade", (req, socket, head) => {
     markGatewayIngressTransport(req, opts.ingressTransport ?? { kind: "ordinary" });
-    void runWithDiagnosticTraceContext(createDiagnosticTraceContext(), async () => {
+    const handleUpgrade = async () => {
       const configSnapshot = getRuntimeConfig();
       const trustedProxies = configSnapshot.gateway?.trustedProxies ?? [];
       const allowRealIpFallback = configSnapshot.gateway?.allowRealIpFallback === true;
@@ -445,7 +446,12 @@ export function attachGatewayUpgradeHandler(opts: {
       } catch {
         throw new Error("gateway websocket upgrade failed");
       }
-    }).catch((err: unknown) => {
+    };
+    void runHttpConnectionRequest(
+      req,
+      () => runWithDiagnosticTraceContext(createDiagnosticTraceContext(), handleUpgrade),
+      "upgrade",
+    ).catch((err: unknown) => {
       const remoteAddress = (socket as { remoteAddress?: string }).remoteAddress ?? "unknown";
       const errorMessage = err instanceof Error ? err.message : String(err);
       log?.warn(`ws upgrade error from ${remoteAddress}: ${errorMessage}`);

--- a/src/gateway/server-http.hooks-request-timeout.test.ts
+++ b/src/gateway/server-http.hooks-request-timeout.test.ts
@@ -1,8 +1,7 @@
 /**
  * Tests timeout behavior for gateway HTTP hook request handling.
  */
-import { EventEmitter } from "node:events";
-import type { ServerResponse } from "node:http";
+import { createServer } from "node:http";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import {
   createHookRequest,
@@ -42,33 +41,33 @@ describe("createHooksRequestHandler timeout status mapping", () => {
     const dispatchWakeHook = vi.fn();
     const dispatchAgentHook = vi.fn(() => ({ ok: true as const, runId: "run-1" }));
     const handler = createHooksHandler({ dispatchWakeHook, dispatchAgentHook });
-    const req = createHookRequest() as ReturnType<typeof createHookRequest> & {
-      destroyed: boolean;
-      destroy: ReturnType<typeof vi.fn>;
-    };
-    req.destroyed = false;
-    req.destroy = vi.fn(() => {
-      req.destroyed = true;
-      return req;
+    const tasks: Promise<boolean>[] = [];
+    const server = createServer((req, res) => {
+      tasks.push(handler(req, res));
     });
-    const res = new EventEmitter() as ServerResponse;
-    res.statusCode = 200;
-    const setHeader = vi.fn();
-    res.setHeader = setHeader;
-    const end = vi.fn();
-    res.end = end;
-
-    const handled = await handler(req, res);
-
-    expect(handled).toBe(true);
-    expect(res.statusCode).toBe(408);
-    expect(end).toHaveBeenCalledWith(JSON.stringify({ ok: false, error: "request body timeout" }));
-    expect(setHeader).toHaveBeenCalledWith("Connection", "close");
-    expect(req.destroy).not.toHaveBeenCalled();
-    res.emit("finish");
-    expect(req.destroy).not.toHaveBeenCalled();
-    res.emit("close");
-    expect(req.destroy).toHaveBeenCalledOnce();
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("missing listener");
+    }
+    try {
+      const response = await fetch(`http://127.0.0.1:${address.port}/hooks/wake`, {
+        method: "POST",
+        headers: { Authorization: "Bearer hook-secret" },
+        body: "{}",
+      });
+      expect(response.status).toBe(408);
+      expect(response.headers.get("connection")).toBe("close");
+      expect(await response.json()).toEqual({ ok: false, error: "request body timeout" });
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+      expect(await Promise.all(tasks)).toEqual([true]);
+    }
     expect(dispatchWakeHook).not.toHaveBeenCalled();
     expect(dispatchAgentHook).not.toHaveBeenCalled();
   });

--- a/src/gateway/server-http.rejection-transport.test.ts
+++ b/src/gateway/server-http.rejection-transport.test.ts
@@ -1,0 +1,298 @@
+import { once } from "node:events";
+import type { ServerResponse } from "node:http";
+import { connect } from "node:net";
+import type { Duplex } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import { createWebSocketStream, WebSocketServer, type WebSocket } from "ws";
+import { readWebhookBodyOrReject } from "../plugin-sdk/webhook-request-guards.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { attachGatewayUpgradeHandler, createGatewayHttpServer } from "./server-http.js";
+import { createPreauthConnectionBudget } from "./server/preauth-connection-budget.js";
+
+vi.mock("../config/io.js", () => ({ getRuntimeConfig: () => ({}) }));
+
+describe("Gateway closing connection admission", () => {
+  it.each([
+    { route: "Gateway", queued: false },
+    { route: "Gateway", queued: true },
+    { route: "plugin", queued: false },
+    { route: "plugin", queued: true },
+    { route: "plugin stream", queued: true },
+  ])(
+    "preserves $route WebSocket pause after upgrade (queued=$queued)",
+    async ({ route, queued }) => {
+      let earlier: ServerResponse | undefined;
+      let upgradeSeen = false;
+      let transport: Duplex | undefined;
+      let websocket: WebSocket | undefined;
+      let stream: Duplex | undefined;
+      const buffered = createDeferredCore();
+      const clients = new Set<never>();
+      const resolvedAuth = { mode: "none" as const, allowTailscale: false };
+      const server = createGatewayHttpServer({
+        clients,
+        controlUiEnabled: false,
+        controlUiBasePath: "",
+        openAiChatCompletionsEnabled: false,
+        openResponsesEnabled: false,
+        resolvedAuth,
+        getRuntimeConfig: () => ({}),
+        handleHooksRequest: async (_req, res) => {
+          earlier = res;
+          if (upgradeSeen) {
+            res.end("earlier");
+          }
+          return true;
+        },
+      });
+      const wss = new WebSocketServer({ noServer: true });
+      const accept = (ws: WebSocket) => {
+        websocket = ws;
+        if (route === "plugin stream") {
+          stream = createWebSocketStream(ws, { highWaterMark: 1 });
+          stream.once("readable", () => {
+            ws.send("ready");
+            buffered.resolve();
+          });
+        } else {
+          ws.pause();
+          ws.send("ready");
+        }
+      };
+      wss.on("connection", accept);
+      attachGatewayUpgradeHandler({
+        httpServer: server,
+        wss,
+        clients,
+        resolvedAuth,
+        preauthConnectionBudget: createPreauthConnectionBudget(),
+        handlePluginUpgrade: route.startsWith("plugin")
+          ? async (req, socket, head) => {
+              wss.handleUpgrade(req, socket, head, accept);
+              if (route === "plugin stream") {
+                await buffered.promise;
+              }
+              return true;
+            }
+          : undefined,
+        shouldEnforcePluginGatewayAuth: () => false,
+      });
+      server.once("upgrade", (_req, socket) => {
+        transport = socket;
+        upgradeSeen = true;
+        earlier?.end("earlier");
+      });
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("missing listener");
+      }
+      const socket = connect({ host: "127.0.0.1", port: address.port });
+      const ready = createDeferredCore();
+      let wire = "";
+      socket.on("data", (chunk) => {
+        wire += chunk.toString();
+        if (wire.endsWith("ready")) {
+          ready.resolve();
+        }
+      });
+      socket.on("error", ready.reject);
+      const deadline = setTimeout(() => ready.reject(new Error("client deadline")), 3000);
+      try {
+        socket.write(
+          (queued ? "GET /first HTTP/1.1\r\nHost: localhost\r\n\r\n" : "") +
+            "GET /socket HTTP/1.1\r\nHost: localhost\r\nConnection: Upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Key: dGVzdC1rZXktMDEyMzQ1Ng==\r\nSec-WebSocket-Version: 13\r\n\r\n",
+        );
+        if (route === "plugin stream") {
+          socket.write(Buffer.from([0x81, 0x81, 1, 2, 3, 4, 0x79]));
+        }
+        await ready.promise;
+        expect(wire.match(/HTTP\/1\.1 \d{3}/g)).toEqual(
+          queued ? ["HTTP/1.1 200", "HTTP/1.1 101"] : ["HTTP/1.1 101"],
+        );
+        expect(websocket!.isPaused).toBe(true);
+        expect(transport!.isPaused()).toBe(true);
+        if (stream) {
+          expect(stream.read().toString()).toBe("x");
+        }
+        const message = once(websocket!, "message");
+        socket.write(Buffer.from([0x81, 0x81, 1, 2, 3, 4, 0x79]));
+        websocket!.resume();
+        expect((await message)[0].toString()).toBe("x");
+      } finally {
+        clearTimeout(deadline);
+        socket.destroy();
+        stream?.destroy();
+        websocket?.terminate();
+        transport?.destroy();
+        server.closeAllConnections();
+        await new Promise<void>((resolve) => {
+          server.close(() => resolve());
+        });
+        wss.close();
+      }
+    },
+  );
+
+  it.each([
+    { version: "1.0", expectation: "100-continue", status: 200, interim: false },
+    { version: "1.0", expectation: "unsupported", status: 200, interim: false },
+    { version: "1.1", expectation: "100-Continue", status: 200, interim: true },
+    { version: "1.1", expectation: "other, 100-continue", status: 200, interim: true },
+    { version: "1.1", expectation: "unsupported", status: 417, interim: false },
+  ])(
+    "preserves Node Expect admission for HTTP/$version $expectation",
+    async ({ version, expectation, status, interim }) => {
+      const dispatched: string[] = [];
+      const server = createGatewayHttpServer({
+        clients: new Set(),
+        controlUiEnabled: false,
+        controlUiBasePath: "",
+        openAiChatCompletionsEnabled: false,
+        openResponsesEnabled: false,
+        resolvedAuth: { mode: "none", allowTailscale: false },
+        getRuntimeConfig: () => ({}),
+        handleHooksRequest: async (req, res) => {
+          dispatched.push(req.url!);
+          res.end("accepted");
+          return true;
+        },
+      });
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("missing listener");
+      }
+      const socket = connect({ host: "127.0.0.1", port: address.port });
+      const chunks: Buffer[] = [];
+      const errors: string[] = [];
+      socket.on("data", (chunk: Buffer) => chunks.push(chunk));
+      socket.on("error", (error) => errors.push(error.message));
+      const closed = new Promise<void>((resolve) => {
+        socket.once("close", resolve);
+      });
+      const deadline = setTimeout(() => {
+        errors.push("client deadline");
+        socket.destroy();
+      }, 3000);
+      try {
+        socket.write(
+          `GET /expect HTTP/${version}\r\nHost: localhost\r\nExpect: ${expectation}\r\nConnection: close\r\n\r\n`,
+        );
+        await closed;
+        const wire = Buffer.concat(chunks).toString();
+        expect(errors).toEqual([]);
+        expect(wire.match(/HTTP\/1\.1 \d{3}/g)).toEqual(
+          interim ? ["HTTP/1.1 100", `HTTP/1.1 ${status}`] : [`HTTP/1.1 ${status}`],
+        );
+        expect(dispatched).toEqual(status === 200 ? ["/expect"] : []);
+        expect(wire.endsWith(status === 200 ? "accepted" : "\r\n\r\n")).toBe(true);
+      } finally {
+        clearTimeout(deadline);
+        socket.destroy();
+        server.closeAllConnections();
+        await new Promise<void>((resolve) => {
+          server.close(() => resolve());
+        });
+      }
+    },
+  );
+
+  it.each(["ordinary", "upgrade", "continue", "expectation", "connect"])(
+    "does not route a pipelined %s request after a rejected upload",
+    async (next) => {
+      const dispatched: string[] = [];
+      const upgrades = vi.fn(async () => true);
+      const tasks: Promise<unknown>[] = [];
+      const clients = new Set<never>();
+      const resolvedAuth = { mode: "none" as const, allowTailscale: false };
+      const server = createGatewayHttpServer({
+        clients,
+        controlUiEnabled: false,
+        controlUiBasePath: "",
+        openAiChatCompletionsEnabled: false,
+        openResponsesEnabled: false,
+        resolvedAuth,
+        getRuntimeConfig: () => ({}),
+        handleHooksRequest: async (req, res) => {
+          dispatched.push(req.url!);
+          const task = readWebhookBodyOrReject({ req, res, maxBytes: 256 * 1024 });
+          tasks.push(task);
+          await task;
+          return true;
+        },
+      });
+      const wss = new WebSocketServer({ noServer: true });
+      attachGatewayUpgradeHandler({
+        httpServer: server,
+        wss,
+        clients,
+        resolvedAuth,
+        preauthConnectionBudget: createPreauthConnectionBudget(),
+        handlePluginUpgrade: upgrades,
+        shouldEnforcePluginGatewayAuth: () => false,
+      });
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("missing listener");
+      }
+      const socket = connect({ host: "127.0.0.1", port: address.port });
+      const received: Buffer[] = [];
+      const errors: string[] = [];
+      const closed = new Promise<void>((resolve) => {
+        socket.once("close", resolve);
+      });
+      socket.on("data", (chunk: Buffer) => received.push(chunk));
+      socket.on("error", (error) => errors.push(error.message));
+      const deadline = setTimeout(() => {
+        errors.push("client deadline");
+        socket.destroy();
+      }, 3000);
+      try {
+        const payload = "x".repeat(1024 * 1024 + 1);
+        const headers =
+          next === "upgrade"
+            ? "Connection: Upgrade\r\nUpgrade: websocket\r\n"
+            : next === "continue"
+              ? "Expect: 100-continue\r\nContent-Length: 1\r\n"
+              : next === "expectation"
+                ? "Expect: unsupported\r\n"
+                : "";
+        const requestLine =
+          next === "connect" ? "CONNECT localhost:80 HTTP/1.1" : "GET /second HTTP/1.1";
+        socket.write(
+          "POST /first HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\n\r\n" +
+            payload.length.toString(16) +
+            "\r\n" +
+            payload +
+            "\r\n0\r\n\r\n" +
+            requestLine +
+            "\r\nHost: localhost\r\n" +
+            headers +
+            "\r\n",
+        );
+        await closed;
+        const wire = Buffer.concat(received).toString();
+        expect(errors).toEqual([]);
+        expect(wire).toMatch(/^HTTP\/1\.1 413 /);
+        expect(wire).toContain("X-Content-Type-Options: nosniff");
+        expect(wire.split("\r\n\r\n")[1]).toBe("Payload too large");
+        expect(dispatched).toEqual(["/first"]);
+        expect(upgrades).not.toHaveBeenCalled();
+      } finally {
+        clearTimeout(deadline);
+        socket.destroy();
+        server.closeAllConnections();
+        await new Promise<void>((resolve) => {
+          server.close(() => resolve());
+        });
+        wss.close();
+        await Promise.all(tasks);
+      }
+    },
+  );
+});

--- a/src/gateway/server-http.rejection-transport.test.ts
+++ b/src/gateway/server-http.rejection-transport.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createWebSocketStream, WebSocketServer, type WebSocket } from "ws";
 import { readWebhookBodyOrReject } from "../plugin-sdk/webhook-request-guards.js";
 import { createDeferredCore } from "../shared/deferred.js";
+import { MAX_PREAUTH_PAYLOAD_BYTES } from "./server-constants.js";
 import { attachGatewayUpgradeHandler, createGatewayHttpServer } from "./server-http.js";
 import { createPreauthConnectionBudget } from "./server/preauth-connection-budget.js";
 
@@ -45,7 +46,7 @@ describe("Gateway closing connection admission", () => {
           return true;
         },
       });
-      const wss = new WebSocketServer({ noServer: true });
+      const wss = new WebSocketServer({ noServer: true, maxPayload: MAX_PREAUTH_PAYLOAD_BYTES });
       const accept = (ws: WebSocket) => {
         websocket = ws;
         if (route === "plugin stream") {
@@ -224,7 +225,7 @@ describe("Gateway closing connection admission", () => {
           return true;
         },
       });
-      const wss = new WebSocketServer({ noServer: true });
+      const wss = new WebSocketServer({ noServer: true, maxPayload: MAX_PREAUTH_PAYLOAD_BYTES });
       attachGatewayUpgradeHandler({
         httpServer: server,
         wss,

--- a/src/gateway/server-http.test-harness.ts
+++ b/src/gateway/server-http.test-harness.ts
@@ -1,6 +1,8 @@
 // Gateway HTTP test harness.
 // Builds fake requests/responses and dispatches them through Gateway HTTP servers.
-import type { IncomingMessage, ServerResponse } from "node:http";
+import { EventEmitter } from "node:events";
+import { IncomingMessage, type ServerResponse } from "node:http";
+import { Socket } from "node:net";
 import { expect, vi } from "vitest";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
@@ -78,6 +80,8 @@ export function createResponse(): {
     resolveEnd = resolve;
   });
   const end = vi.fn((chunk?: unknown) => {
+    res.writableFinished = true;
+    res.emit("finish");
     if (typeof chunk === "string") {
       body = chunk;
       resolveEnd();
@@ -91,16 +95,18 @@ export function createResponse(): {
     body = JSON.stringify(chunk);
     resolveEnd();
   });
-  const res = {
+  const res = Object.assign(new EventEmitter(), {
+    req: new IncomingMessage(new Socket()),
+    writableFinished: false,
     headersSent: false,
     statusCode: 200,
     setHeader,
     removeHeader: vi.fn(),
     end,
-  } as unknown as ServerResponse;
-  responseEndPromises.set(res, ended);
+  });
+  responseEndPromises.set(res as unknown as ServerResponse, ended);
   return {
-    res,
+    res: res as unknown as ServerResponse,
     setHeader,
     end,
     getBody: () => body,

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -16,6 +16,7 @@ import {
   createDiagnosticTraceContext,
   runWithDiagnosticTraceContext,
 } from "../infra/diagnostic-trace-context.js";
+import { runHttpConnectionRequest } from "../infra/http-request-lifecycle.js";
 import { parseDevicePairingJoinRequestPath } from "../pairing/join-code.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { resolveAssistantIdentity } from "./assistant-identity.js";
@@ -203,10 +204,19 @@ export function createGatewayHttpServer(opts: {
   const openAiCompatEnabled = openAiChatCompletionsEnabled || openResponsesEnabled;
   const controlUiRouteBasePath =
     controlUiBasePath && controlUiBasePath !== "/" ? controlUiBasePath.replace(/\/$/, "") : "";
-  const handleServerRequest = (req: IncomingMessage, res: ServerResponse) => {
+  const handleServerRequest = (
+    req: IncomingMessage,
+    res: ServerResponse,
+    expectation?: "continue" | "reject",
+  ) => {
     markGatewayIngressTransport(req, opts.ingressTransport ?? { kind: "ordinary" });
-    void runWithDiagnosticTraceContext(createDiagnosticTraceContext(), () =>
-      handleRequest(req, res),
+    void runHttpConnectionRequest(
+      req,
+      () =>
+        runWithDiagnosticTraceContext(createDiagnosticTraceContext(), () =>
+          handleRequest(req, res, expectation),
+        ),
+      res,
     ).catch((error: unknown) => {
       console.error("[gateway-http] failed to finalize request:", error);
       if (!res.destroyed) {
@@ -217,11 +227,37 @@ export function createGatewayHttpServer(opts: {
   const httpServer: HttpServer = opts.tlsOptions
     ? createHttpsServer(opts.tlsOptions, handleServerRequest)
     : createHttpServer(handleServerRequest);
+  // Node otherwise sends interim/expectation responses before application admission.
+  httpServer.on("checkContinue", (req, res) => handleServerRequest(req, res, "continue"));
+  httpServer.on("checkExpectation", (req, res) => handleServerRequest(req, res, "reject"));
+  httpServer.on("connect", (req, socket) => {
+    void runHttpConnectionRequest(
+      req,
+      async () => {
+        socket.destroy();
+      },
+      "upgrade",
+    );
+  });
 
-  async function handleRequest(req: IncomingMessage, res: ServerResponse) {
+  async function handleRequest(
+    req: IncomingMessage,
+    res: ServerResponse,
+    expectation?: "continue" | "reject",
+  ) {
     setDefaultSecurityHeaders(res, {
       strictTransportSecurity: strictTransportSecurityHeader,
     });
+    // Preserve Node's version/token classification while deferring its response
+    // until admission; reparsing Expect here would change HTTP/1.0 semantics.
+    if (expectation === "reject") {
+      res.writeHead(417);
+      res.end();
+      return;
+    }
+    if (expectation === "continue") {
+      res.writeContinue();
+    }
 
     // Don't interfere with real WebSocket upgrades; ws handles the 'upgrade' event.
     if (isWebSocketUpgradeRequest(req)) {

--- a/src/gateway/server/hooks-request-handler.ts
+++ b/src/gateway/server/hooks-request-handler.ts
@@ -1,7 +1,7 @@
 // Hook request handler validates hook tokens, applies mappings, dedupes requests, and dispatches wake or agent work.
 import { createHash } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { closeRequestAfterResponse } from "../../infra/http-body.js";
+import { sendHttpRequestRejection } from "../../infra/http-request-lifecycle.js";
 import { pruneMapToMaxSize } from "../../infra/map-size.js";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveHookExternalContentSource as resolveHookExternalContentSourceFromSession } from "../../security/external-content.js";
@@ -374,16 +374,18 @@ export function createHooksRequestHandler(
     // every other path keeps the shared default cap.
     const body = await readJsonBody(req, resolveHookPathBodyLimit(hooksConfig, subPath));
     if (!body.ok) {
-      const status =
-        body.error === "payload too large"
-          ? 413
-          : body.error === "request body timeout"
-            ? 408
-            : 400;
-      if (status === 413 || status === 408) {
-        closeRequestAfterResponse(req, res);
+      const error = { ok: false, error: body.error };
+      if (body.error === "payload too large" || body.error === "request body timeout") {
+        await sendHttpRequestRejection(
+          req,
+          res,
+          body.error === "payload too large" ? 413 : 408,
+          JSON.stringify(error),
+          "application/json; charset=utf-8",
+        );
+      } else {
+        sendJson(res, 400, error);
       }
-      sendJson(res, status, { ok: false, error: body.error });
       return true;
     }
 

--- a/src/gateway/server/http-work-admission.ts
+++ b/src/gateway/server/http-work-admission.ts
@@ -1,6 +1,7 @@
 // Gateway HTTP boundary helpers coordinate request and upgrade work with host suspension.
 import type { ServerResponse } from "node:http";
 import type { Duplex } from "node:stream";
+import { waitForHttpRequestRejection } from "../../infra/http-request-lifecycle.js";
 import { tryBeginGatewayRootWorkAdmission } from "../../process/gateway-work-admission.js";
 
 type GatewayBoundaryHandler = () => Promise<boolean> | boolean;
@@ -26,21 +27,30 @@ export async function runWithGatewayHttpWorkAdmission(
   res: ServerResponse,
   run: GatewayBoundaryHandler,
 ): Promise<boolean> {
-  return await runWithGatewayBoundaryWorkAdmission(() => {
-    res.statusCode = 503;
-    res.setHeader("Content-Type", "application/json; charset=utf-8");
-    res.setHeader("Cache-Control", "no-store");
-    res.setHeader("Retry-After", "1");
-    res.end(
-      JSON.stringify({
-        error: {
-          message: "Gateway is temporarily unavailable while suspending or restarting",
-          type: "service_unavailable",
-          code: "gateway_unavailable",
-        },
-      }),
-    );
-  }, run);
+  return await runWithGatewayBoundaryWorkAdmission(
+    () => {
+      res.statusCode = 503;
+      res.setHeader("Content-Type", "application/json; charset=utf-8");
+      res.setHeader("Cache-Control", "no-store");
+      res.setHeader("Retry-After", "1");
+      res.end(
+        JSON.stringify({
+          error: {
+            message: "Gateway is temporarily unavailable while suspending or restarting",
+            type: "service_unavailable",
+            code: "gateway_unavailable",
+          },
+        }),
+      );
+    },
+    async () => {
+      try {
+        return await run();
+      } finally {
+        await waitForHttpRequestRejection(res.req);
+      }
+    },
+  );
 }
 
 export function writeGatewayUpgradeServiceUnavailable(

--- a/src/gateway/test-http-response.ts
+++ b/src/gateway/test-http-response.ts
@@ -1,7 +1,8 @@
 // Gateway HTTP test helpers build minimal request/response doubles and collect
 // client response bodies.
 import { EventEmitter } from "node:events";
-import type { IncomingMessage, ServerResponse } from "node:http";
+import { IncomingMessage, type ServerResponse } from "node:http";
+import { Socket } from "node:net";
 import { PassThrough } from "node:stream";
 import { vi } from "vitest";
 
@@ -23,6 +24,7 @@ export function makeMockHttpResponse(): {
     streamEnd();
   });
   const res = Object.assign(stream, {
+    req: new IncomingMessage(new Socket()),
     headersSent: false,
     statusCode: 200,
     setHeader,

--- a/src/infra/http-body.test.ts
+++ b/src/infra/http-body.test.ts
@@ -1,11 +1,11 @@
 // Tests HTTP body reading and size-limit handling.
 import { EventEmitter } from "node:events";
-import type { IncomingMessage, ServerResponse } from "node:http";
+import type { IncomingMessage } from "node:http";
+import { Socket } from "node:net";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createMockServerResponse } from "../test-utils/mock-http-response.js";
 import {
-  closeRequestAfterResponse,
   installRequestBodyLimitGuard,
   RequestBodyLimitError,
   type RequestBodyLimitErrorCode,
@@ -76,32 +76,6 @@ async function expectReadPayloadTooLarge(params: {
   expect(req["__unhandledDestroyError"]).toBeUndefined();
 }
 
-async function expectGuardPayloadTooLarge(params: {
-  chunks?: string[];
-  headers?: Record<string, string>;
-  maxBytes: number;
-  responseFormat?: "json" | "text";
-  responseText?: { PAYLOAD_TOO_LARGE?: string };
-}) {
-  const req = createMockRequest({
-    chunks: params.chunks,
-    headers: params.headers,
-    emitEnd: false,
-  });
-  const res = createMockServerResponse();
-  const guard = installRequestBodyLimitGuard(req, res, {
-    maxBytes: params.maxBytes,
-    ...(params.responseFormat ? { responseFormat: params.responseFormat } : {}),
-    ...(params.responseText ? { responseText: params.responseText } : {}),
-  });
-  await waitForMicrotaskTurn();
-  expect(guard.isTripped()).toBe(true);
-  expect(guard.code()).toBe("PAYLOAD_TOO_LARGE");
-  expect(res.statusCode).toBe(413);
-  expect(req["__unhandledDestroyError"]).toBeUndefined();
-  return { req, res, guard };
-}
-
 async function readJsonBody(params: {
   chunks?: string[];
   maxBytes: number;
@@ -123,6 +97,7 @@ function createMockRequest(params: {
 }): MockIncomingMessage {
   const req = new EventEmitter() as MockIncomingMessage;
   req.destroyed = false;
+  req.socket = new Socket();
   req.headers = params.headers ?? {};
   req.destroy = ((error?: Error) => {
     req.destroyed = true;
@@ -221,39 +196,6 @@ describe("http body limits", () => {
     assertResult(result);
   });
 
-  it.each([
-    {
-      name: "guard rejects oversized declared content-length",
-      headers: { "content-length": "9999" },
-      maxBytes: 128,
-      expectedBody: '{"error":"Payload too large"}',
-    },
-    {
-      name: "guard rejects streamed oversized body",
-      chunks: ["small", "x".repeat(256)],
-      maxBytes: 128,
-      responseFormat: "text" as const,
-      expectedBody: "Payload too large",
-    },
-    {
-      name: "guard uses custom response text for payload-too-large",
-      chunks: ["small", "x".repeat(256)],
-      maxBytes: 128,
-      responseFormat: "text" as const,
-      responseText: { PAYLOAD_TOO_LARGE: "Too much" },
-      expectedBody: "Too much",
-    },
-  ])("$name", async ({ chunks, headers, maxBytes, responseFormat, responseText, expectedBody }) => {
-    const { res } = await expectGuardPayloadTooLarge({
-      chunks,
-      headers,
-      maxBytes,
-      ...(responseFormat ? { responseFormat } : {}),
-      ...(responseText ? { responseText } : {}),
-    });
-    expect(res.body).toBe(expectedBody);
-  });
-
   it("timeout surfaces typed error when timeoutMs is clamped", async () => {
     const req = createMockRequest({ emitEnd: false });
     const promise = readRequestBodyWithLimit(req, { maxBytes: 128, timeoutMs: 0 });
@@ -275,15 +217,6 @@ describe("http body limits", () => {
       maxBytes: 128,
       timeoutMs: MAX_TIMER_TIMEOUT_MS,
     });
-  });
-
-  it("guard clamps invalid maxBytes to one byte", async () => {
-    const { res } = await expectGuardPayloadTooLarge({
-      chunks: ["ab"],
-      maxBytes: Number.NaN,
-      responseFormat: "text",
-    });
-    expect(res.body).toBe("Payload too large");
   });
 
   it("surfaces connection-closed as a typed limit error", async () => {
@@ -395,51 +328,6 @@ describe("http body limits", () => {
 
     expect(req.destroyed).toBe(false);
     expect(pause).toHaveBeenCalledOnce();
-  });
-
-  it("closes a limited request only after its response transport closes", () => {
-    const req = createMockRequest({ emitEnd: false });
-    const res = new EventEmitter() as ServerResponse;
-    const setHeader = vi.fn();
-    res.setHeader = setHeader;
-
-    closeRequestAfterResponse(req, res);
-
-    expect(setHeader).toHaveBeenCalledWith("Connection", "close");
-    expect(req.destroyed).toBe(false);
-    res.emit("finish");
-    expect(req.destroyed).toBe(false);
-    res.emit("close");
-    expect(req.destroyed).toBe(true);
-  });
-
-  it("flushes an installed guard response before destroying the request", async () => {
-    const req = createMockRequest({ chunks: ["oversized"], emitEnd: false });
-    const res = new EventEmitter() as ServerResponse;
-    const setHeader = vi.fn();
-    const end = vi.fn();
-    res.setHeader = setHeader;
-    res.end = end;
-
-    installRequestBodyLimitGuard(req, res, { maxBytes: 1 });
-    await waitForMicrotaskTurn();
-
-    expect(res.statusCode).toBe(413);
-    expect(setHeader).toHaveBeenCalledWith("Connection", "close");
-    expect(end).toHaveBeenCalledWith(JSON.stringify({ error: "Payload too large" }));
-    expect(req.destroyed).toBe(false);
-    res.emit("finish");
-    expect(req.destroyed).toBe(false);
-    res.emit("close");
-    expect(req.destroyed).toBe(true);
-  });
-
-  it("allows lightweight responses without finish listeners", () => {
-    const req = createMockRequest({ emitEnd: false });
-    const res = createMockServerResponse();
-
-    expect(() => closeRequestAfterResponse(req, res)).not.toThrow();
-    expect(res.getHeader("connection")).toBe("close");
-    expect(req.destroyed).toBe(false);
+    req.socket.destroy();
   });
 });

--- a/src/infra/http-body.ts
+++ b/src/infra/http-body.ts
@@ -8,6 +8,11 @@ import {
 } from "@openclaw/normalization-core/number-coercion";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { formatErrorMessage } from "./errors.js";
+import {
+  isHttpConnectionClosing,
+  selectHttpRequestRejection,
+  sendHttpRequestRejection,
+} from "./http-request-lifecycle.js";
 import { readChunkWithIdleTimeout, withResponseBodyTimeout } from "./http-response-body-timeout.js";
 
 export { readChunkWithIdleTimeout } from "./http-response-body-timeout.js";
@@ -153,23 +158,7 @@ function stopRequestBodyAfterLimit(req: IncomingMessage, destroyOnLimit: boolean
     req.destroy();
     return;
   }
-  req.pause();
-}
-
-/** Close a limited request only after its response transport has closed. */
-export function closeRequestAfterResponse(req: IncomingMessage, res: ServerResponse): void {
-  if (!res.headersSent) {
-    res.setHeader("Connection", "close");
-  }
-  const once = Reflect.get(res, "once");
-  if (typeof once !== "function") {
-    return;
-  }
-  once.call(res, "close", () => {
-    if (!req.destroyed) {
-      req.destroy();
-    }
-  });
+  selectHttpRequestRejection(req);
 }
 
 type ReadResponsePrefixResult = {
@@ -377,6 +366,10 @@ export async function readRequestBodyWithLimit(
   const encoding = options.encoding ?? "utf-8";
   const destroyOnLimit = options.destroyOnLimit !== false;
 
+  if (isHttpConnectionClosing(req.socket)) {
+    throw new RequestBodyLimitError({ code: "CONNECTION_CLOSED" });
+  }
+
   const declaredLength = parseContentLengthHeader(req);
   if (declaredLength !== null && declaredLength > maxBytes) {
     const error = new RequestBodyLimitError({ code: "PAYLOAD_TOO_LARGE" });
@@ -432,6 +425,10 @@ export async function readRequestBodyWithLimit(
     };
 
     const onEnd = () => {
+      if (isHttpConnectionClosing(req.socket)) {
+        fail(new RequestBodyLimitError({ code: "CONNECTION_CLOSED" }));
+        return;
+      }
       finish(() =>
         resolve(
           chunks.length === 1
@@ -548,18 +545,16 @@ export function installRequestBodyLimitGuard(
   };
 
   const respond = (error: RequestBodyLimitError) => {
-    closeRequestAfterResponse(req, res);
     const text = customText[error.code] ?? requestBodyErrorToText(error.code);
-    if (!res.headersSent) {
-      res.statusCode = error.statusCode;
-      if (responseFormat === "text") {
-        res.setHeader("Content-Type", "text/plain; charset=utf-8");
-        res.end(text);
-      } else {
-        res.setHeader("Content-Type", "application/json; charset=utf-8");
-        res.end(JSON.stringify({ error: text }));
-      }
-    }
+    const body = responseFormat === "text" ? text : JSON.stringify({ error: text });
+    const contentType = responseFormat === "text" ? "text/plain" : "application/json";
+    void sendHttpRequestRejection(
+      req,
+      res,
+      error.statusCode,
+      body,
+      `${contentType}; charset=utf-8`,
+    );
   };
 
   const trip = (error: RequestBodyLimitError) => {
@@ -593,7 +588,11 @@ export function installRequestBodyLimitGuard(
   req.on("error", finish);
 
   const declaredLength = parseContentLengthHeader(req);
-  if (req.destroyed && !req.readableEnded) {
+  if (isHttpConnectionClosing(req.socket)) {
+    tripped = true;
+    reason = "CONNECTION_CLOSED";
+    finish();
+  } else if (req.destroyed && !req.readableEnded) {
     finish();
   } else if (declaredLength !== null && declaredLength > maxBytes) {
     trip(new RequestBodyLimitError({ code: "PAYLOAD_TOO_LARGE" }));

--- a/src/infra/http-request-lifecycle.test.ts
+++ b/src/infra/http-request-lifecycle.test.ts
@@ -1,0 +1,705 @@
+import { once } from "node:events";
+import { createServer, request, type IncomingMessage, type ServerResponse } from "node:http";
+import { connect, type Socket } from "node:net";
+import { describe, expect, it } from "vitest";
+import { runWithGatewayHttpWorkAdmission } from "../gateway/server/http-work-admission.js";
+import {
+  beginWebhookRequestPipelineOrReject,
+  createWebhookInFlightLimiter,
+  readJsonWebhookBodyOrReject,
+  readWebhookBodyOrReject,
+} from "../plugin-sdk/webhook-request-guards.js";
+import { getActiveGatewayRootWorkCount } from "../process/gateway-work-admission.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { installRequestBodyLimitGuard } from "./http-body.js";
+import {
+  runHttpConnectionRequest,
+  sendHttpRequestRejection,
+  waitForHttpRequestRejection,
+} from "./http-request-lifecycle.js";
+
+const maxBytes = 256 * 1024;
+const chunks = ['{"text":"', "x".repeat(1024 * 1024 + 1), '"}'];
+const oversizedChunkedBody =
+  chunks.map((chunk) => `${Buffer.byteLength(chunk).toString(16)}\r\n${chunk}\r\n`).join("") +
+  "0\r\n\r\n";
+
+function postHeaders(framing = "Transfer-Encoding: chunked") {
+  return `POST /rejected HTTP/1.1\r\nHost: localhost\r\n${framing}\r\nConnection: keep-alive\r\n\r\n`;
+}
+
+async function withServer(
+  handler: (req: IncomingMessage, res: ServerResponse) => Promise<void>,
+  run: (port: number) => Promise<void>,
+  waitForResponse: boolean | "standalone" = true,
+) {
+  const tasks: Promise<void>[] = [];
+  const errors: unknown[] = [];
+  const server = createServer((req, res) => {
+    const task =
+      waitForResponse === "standalone"
+        ? handler(req, res)
+        : runHttpConnectionRequest(req, () => handler(req, res), waitForResponse ? res : undefined);
+    tasks.push(
+      task.catch((error: unknown) => {
+        errors.push(error);
+        req.socket.destroy();
+      }),
+    );
+  });
+  server.on("upgrade", (req) => {
+    tasks.push(
+      runHttpConnectionRequest(req, async () => {
+        errors.push(new Error("unexpected upgrade dispatch"));
+        req.socket.destroy();
+      }),
+    );
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("missing TCP listener");
+  }
+  try {
+    await run(address.port);
+  } finally {
+    server.closeAllConnections();
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+    await Promise.all(tasks);
+  }
+  expect(errors).toEqual([]);
+}
+
+async function rawRequest(port: number, wire: string, afterResponse?: string) {
+  const socket = connect({ host: "127.0.0.1", port });
+  const received: Buffer[] = [];
+  const errors: string[] = [];
+  const deadline = setTimeout(() => {
+    errors.push("client deadline");
+    socket.destroy();
+  }, 3000);
+  socket.on("error", (error: NodeJS.ErrnoException) => errors.push(error.code ?? error.message));
+  socket.on("data", (chunk: Buffer) => received.push(chunk));
+  if (afterResponse) {
+    socket.once("data", () => socket.write(afterResponse));
+  }
+  const closed = new Promise<void>((resolve) => {
+    socket.once("close", resolve);
+  });
+  socket.once("connect", () => socket.write(wire));
+  await closed;
+  clearTimeout(deadline);
+  return { wire: Buffer.concat(received).toString(), errors };
+}
+
+async function nodeRequest(port: number) {
+  const received: Buffer[] = [];
+  const errors: string[] = [];
+  let statusCode: number | undefined;
+  let connection: string | undefined;
+  let complete = false;
+  const req = request({ host: "127.0.0.1", port, method: "POST", path: "/rejected" }, (res) => {
+    statusCode = res.statusCode;
+    connection = res.headers.connection;
+    res.on("data", (chunk: Buffer) => received.push(chunk));
+    res.on("end", () => {
+      complete = res.complete;
+    });
+    res.on("error", (error) => errors.push(error.message));
+  });
+  req.on("error", (error: NodeJS.ErrnoException) => errors.push(error.code ?? error.message));
+  const closed = new Promise<void>((resolve) => {
+    req.once("socket", (socket) => socket.once("close", resolve));
+  });
+  const deadline = setTimeout(() => {
+    errors.push("client deadline");
+    req.destroy();
+  }, 3000);
+  req.write(chunks[0]);
+  req.write(chunks[1]);
+  req.end(chunks[2]);
+  await closed;
+  clearTimeout(deadline);
+  return { statusCode, connection, complete, body: Buffer.concat(received).toString(), errors };
+}
+
+describe("bounded HTTP rejection transport", () => {
+  it.each(["raw SDK", "JSON SDK", "installed guard"])(
+    "delivers an exact 413 and closes during a large Node upload: %s",
+    async (surface) => {
+      await withServer(
+        async (req, res) => {
+          if (surface === "installed guard") {
+            installRequestBodyLimitGuard(req, res, { maxBytes });
+          } else {
+            const read =
+              surface === "raw SDK" ? readWebhookBodyOrReject : readJsonWebhookBodyOrReject;
+            expect(await read({ req, res, maxBytes })).toEqual({ ok: false });
+          }
+        },
+        async (port) => {
+          expect(await nodeRequest(port)).toEqual({
+            statusCode: 413,
+            connection: "close",
+            complete: true,
+            body:
+              surface === "installed guard" ? '{"error":"Payload too large"}' : "Payload too large",
+            errors: [],
+          });
+        },
+      );
+    },
+  );
+
+  it.each(["request", "upgrade"])(
+    "does not dispatch a pipelined %s after rejection",
+    async (next) => {
+      const dispatched: string[] = [];
+      await withServer(
+        async (req, res) => {
+          dispatched.push(req.url!);
+          await readWebhookBodyOrReject({ req, res, maxBytes });
+        },
+        async (port) => {
+          const nextHeaders =
+            next === "upgrade" ? "Connection: upgrade\r\nUpgrade: websocket\r\n" : "";
+          const result = await rawRequest(
+            port,
+            postHeaders() +
+              oversizedChunkedBody +
+              `GET /second HTTP/1.1\r\nHost: localhost\r\n${nextHeaders}\r\n`,
+          );
+          expect(result.errors).toEqual([]);
+          expect(result.wire).toMatch(/^HTTP\/1\.1 413 /);
+          expect(result.wire.split("\r\n\r\n")[1]).toBe("Payload too large");
+          expect(dispatched).toEqual(["/rejected"]);
+        },
+      );
+    },
+  );
+
+  it.each([
+    { limit: 1, text: "Payload too large" },
+    { limit: Number.NaN, text: "Too much" },
+  ])(
+    "keeps guard text customization and invalid limit clamping ($limit)",
+    async ({ limit, text }) => {
+      await withServer(
+        async (req, res) => {
+          const guard = installRequestBodyLimitGuard(req, res, {
+            maxBytes: limit,
+            responseFormat: "text",
+            responseText: { PAYLOAD_TOO_LARGE: text },
+          });
+          expect(guard.isTripped()).toBe(true);
+          expect(guard.code()).toBe("PAYLOAD_TOO_LARGE");
+          await waitForHttpRequestRejection(req);
+        },
+        async (port) => {
+          const result = await rawRequest(port, postHeaders("Content-Length: 2") + "ab");
+          expect(result.errors).toEqual([]);
+          expect(result.wire).toMatch(/^HTTP\/1\.1 413 /);
+          expect(result.wire).toContain("Content-Type: text/plain; charset=utf-8");
+          expect(result.wire.split("\r\n\r\n")[1]).toBe(text);
+        },
+      );
+    },
+  );
+
+  it("enforces the stricter SDK pre-auth body profile", async () => {
+    await withServer(
+      async (req, res) => {
+        expect(await readWebhookBodyOrReject({ req, res, profile: "pre-auth" })).toEqual({
+          ok: false,
+        });
+      },
+      async (port) => {
+        const result = await rawRequest(port, postHeaders(`Content-Length: ${70 * 1024}`));
+        expect(result.errors).toEqual([]);
+        expect(result.wire).toMatch(/^HTTP\/1\.1 413 /);
+        expect(result.wire.split("\r\n\r\n")[1]).toBe("Payload too large");
+      },
+    );
+  });
+
+  it.each(["declared size", "timeout"])(
+    "closes an unfinished upload after %s rejection",
+    async (reason) => {
+      await withServer(
+        async (req, res) => {
+          await readWebhookBodyOrReject({ req, res, maxBytes, timeoutMs: 20 });
+        },
+        async (port) => {
+          const length = reason === "declared size" ? maxBytes + 1 : 20;
+          const result = await rawRequest(port, postHeaders(`Content-Length: ${length}`) + "{");
+          expect(result.errors).toEqual([]);
+          expect(result.wire).toMatch(
+            reason === "declared size" ? /^HTTP\/1\.1 413 / : /^HTTP\/1\.1 408 /,
+          );
+          expect(result.wire.split("\r\n\r\n")[1]).toBe(
+            reason === "declared size" ? "Payload too large" : "Request body timeout",
+          );
+        },
+      );
+    },
+  );
+
+  it.each(["POST", "HEAD"])(
+    "keeps a queued %s rejection ordered behind an earlier response and fences new dispatch",
+    async (method) => {
+      let earlier: ServerResponse;
+      const selected = createDeferredCore();
+      const dispatched: string[] = [];
+      await withServer(
+        async (req, res) => {
+          dispatched.push(req.url!);
+          if (req.url === "/first") {
+            earlier = res;
+            return;
+          }
+          const sent = sendHttpRequestRejection(req, res, 413, "rejected");
+          selected.resolve();
+          await sent;
+        },
+        async (port) => {
+          const response = rawRequest(
+            port,
+            "GET /first HTTP/1.1\r\nHost: localhost\r\n\r\n" +
+              postHeaders("Content-Length: 1").replace("POST", method) +
+              "x" +
+              "GET /second HTTP/1.1\r\nHost: localhost\r\n\r\n",
+          );
+          await selected.promise;
+          earlier!.end("first");
+          const result = await response;
+          expect(result.errors).toEqual([]);
+          expect(result.wire).toMatch(/^HTTP\/1\.1 200 /);
+          expect(result.wire).toContain("firstHTTP/1.1 413");
+          expect(result.wire.endsWith(method === "HEAD" ? "\r\n\r\n" : "\r\n\r\nrejected")).toBe(
+            true,
+          );
+          expect(dispatched).toEqual(["/first", "/rejected"]);
+        },
+        false,
+      );
+    },
+  );
+
+  it.each([32, 2048])(
+    "drains a finite pipeline of %i ordinary requests in order",
+    async (count) => {
+      const dispatched: string[] = [];
+      await withServer(
+        async (req, res) => {
+          dispatched.push(req.url!);
+          res.end(req.url);
+        },
+        async (port) => {
+          const paths = Array.from({ length: count }, (_, i) => `/request-${i}`);
+          const result = await rawRequest(
+            port,
+            paths
+              .map(
+                (path, i) =>
+                  `GET ${path} HTTP/1.1\r\nHost: localhost\r\n${i === count - 1 ? "Connection: close\r\n" : ""}\r\n`,
+              )
+              .join(""),
+          );
+          expect(result.errors).toEqual([]);
+          expect(dispatched).toEqual(paths);
+          expect(result.wire.match(/HTTP\/1\.1 200 /g)).toHaveLength(count);
+          expect(result.wire.split(/HTTP\/1\.1 200 [^]*?\r\n\r\n/).slice(1)).toEqual(paths);
+        },
+      );
+    },
+  );
+
+  it("bounds a rejection stuck behind an earlier response", async () => {
+    const dispatched: string[] = [];
+    await withServer(
+      async (req, res) => {
+        dispatched.push(req.url!);
+        if (req.url !== "/first") {
+          await sendHttpRequestRejection(req, res, 413, "rejected");
+        }
+      },
+      async (port) => {
+        const result = await rawRequest(
+          port,
+          "GET /first HTTP/1.1\r\nHost: localhost\r\n\r\n" + postHeaders("Content-Length: 0"),
+        );
+        expect(result.errors).toEqual([]);
+        expect(result.wire).toBe("");
+        expect(dispatched).toEqual(["/first", "/rejected"]);
+      },
+      false,
+    );
+  });
+
+  it("retains the SDK limiter until a peer ignoring the half-close is retired", async () => {
+    const limiter = createWebhookInFlightLimiter({ maxInFlightPerKey: 1 });
+    const retired = createDeferredCore();
+    let socket: Socket | undefined;
+    await withServer(
+      async (req, res) => {
+        const pipeline = beginWebhookRequestPipelineOrReject({
+          req,
+          res,
+          inFlightLimiter: limiter,
+          inFlightKey: "test",
+        });
+        expect(pipeline.ok).toBe(true);
+        installRequestBodyLimitGuard(req, res, { maxBytes });
+        if (pipeline.ok) {
+          pipeline.release();
+        }
+        await waitForHttpRequestRejection(req);
+        retired.resolve();
+      },
+      async (port) => {
+        socket = connect({ host: "127.0.0.1", port, allowHalfOpen: true });
+        socket.on("data", () => {});
+        const closed = once(socket, "close");
+        socket.write(postHeaders(`Content-Length: ${maxBytes + 1}`));
+        await once(socket, "end");
+        expect(limiter.tryAcquire("test")).toBe(false);
+        await retired.promise;
+        expect(limiter.tryAcquire("test")).toBe(true);
+        limiter.release("test");
+        socket.end();
+        await closed;
+      },
+    ).finally(() => socket?.destroy());
+  });
+
+  it("does not reframe or complete an already committed partial response", async () => {
+    await withServer(
+      async (req, res) => {
+        res.write("partial");
+        await sendHttpRequestRejection(req, res, 413, "rejected");
+      },
+      async (port) => {
+        const result = await rawRequest(port, postHeaders("Content-Length: 0"));
+        expect(result.wire).not.toContain("413");
+        expect(result.wire).not.toContain("rejected");
+        expect(result.wire).not.toContain("0\r\n\r\n");
+      },
+    );
+  });
+
+  it("retains a Gateway admission while an installed guard completes bounded cleanup", async () => {
+    const retired = createDeferredCore();
+    await withServer(
+      async (req, res) => {
+        await runWithGatewayHttpWorkAdmission(res, async () => {
+          installRequestBodyLimitGuard(req, res, { maxBytes });
+          return true;
+        });
+        retired.resolve();
+      },
+      async (port) => {
+        const socket = connect({ host: "127.0.0.1", port, allowHalfOpen: true });
+        const closed = once(socket, "close");
+        socket.on("data", () => {});
+        try {
+          socket.write(postHeaders(`Content-Length: ${maxBytes + 1}`));
+          await once(socket, "end");
+          expect(getActiveGatewayRootWorkCount()).toBe(1);
+          await retired.promise;
+          expect(getActiveGatewayRootWorkCount()).toBe(0);
+        } finally {
+          socket.end();
+          await closed;
+        }
+      },
+    );
+  });
+
+  it.each(["async handler", "unfinished response"])(
+    "waits for an earlier %s before admitting a pipeline",
+    async (mode) => {
+      const started = createDeferredCore();
+      const release = createDeferredCore();
+      const dispatched: string[] = [];
+      let earlier: ServerResponse;
+      await withServer(
+        async (req, res) => {
+          dispatched.push(req.url!);
+          if (req.url === "/first") {
+            earlier = res;
+            started.resolve();
+            if (mode === "async handler") {
+              await release.promise;
+              res.end("first");
+            }
+            return;
+          }
+          await readWebhookBodyOrReject({ req, res, maxBytes });
+        },
+        async (port) => {
+          const response = rawRequest(
+            port,
+            "GET /first HTTP/1.1\r\nHost: localhost\r\n\r\n" +
+              postHeaders(`Content-Length: ${maxBytes + 1}`),
+          );
+          await started.promise;
+          await new Promise<void>((resolve) => {
+            setImmediate(resolve);
+          });
+          expect(dispatched).toEqual(["/first"]);
+          if (mode === "async handler") {
+            release.resolve();
+          } else {
+            earlier!.end("first");
+          }
+          const result = await response;
+          expect(result.errors).toEqual([]);
+          expect(result.wire).toContain("firstHTTP/1.1 413");
+          expect(dispatched).toEqual(["/first", "/rejected"]);
+        },
+      );
+    },
+  );
+
+  it("pauses queued input while an earlier response is unfinished, then drains it", async () => {
+    const paused = createDeferredCore();
+    let earlier: ServerResponse;
+    let transport: Socket;
+    let dispatched = 0;
+    await withServer(
+      async (req, res) => {
+        dispatched++;
+        if (dispatched === 1) {
+          earlier = res;
+          transport = req.socket;
+          transport.once("pause", () => setImmediate(paused.resolve));
+        } else {
+          res.end("next");
+        }
+      },
+      async (port) => {
+        const response = rawRequest(
+          port,
+          "GET /queued HTTP/1.1\r\nHost: localhost\r\n\r\n".repeat(32) +
+            "GET /last HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+        );
+        await paused.promise;
+        expect(transport!.destroyed).toBe(false);
+        expect(transport!.isPaused()).toBe(true);
+        expect(dispatched).toBe(1);
+        earlier!.end("first");
+        const result = await response;
+        expect(result.errors).toEqual([]);
+        expect(dispatched).toBe(33);
+        expect(result.wire.match(/HTTP\/1\.1 200 /g)).toHaveLength(33);
+      },
+    );
+  });
+
+  it.each(["request error", "response error", "sync write failure", "peer close"])(
+    "retires rejected transport on %s",
+    async (edge) => {
+      const selected = createDeferredCore();
+      let completed = false;
+      await withServer(
+        async (req, res) => {
+          const closed = sendHttpRequestRejection(
+            req,
+            res,
+            edge === "sync write failure" ? 0 : 413,
+            "rejected",
+          );
+          if (edge === "request error") {
+            req.emit("error", new Error("synthetic read failure"));
+          }
+          if (edge === "response error") {
+            res.emit("error", new Error("synthetic write failure"));
+          }
+          selected.resolve();
+          await closed;
+          completed = true;
+        },
+        async (port) => {
+          if (edge === "peer close") {
+            const socket = connect({ host: "127.0.0.1", port });
+            const closed = once(socket, "close");
+            socket.write(postHeaders(`Content-Length: ${maxBytes + 1}`));
+            await selected.promise;
+            socket.destroy();
+            await closed;
+          } else {
+            const result = await rawRequest(port, postHeaders("Content-Length: 0"));
+            expect(result.errors).not.toContain("client deadline");
+          }
+        },
+      );
+      expect(completed).toBe(true);
+    },
+  );
+
+  it("lets Node reject malformed chunking without hanging body ownership", async () => {
+    let completed = false;
+    await withServer(
+      async (req, res) => {
+        expect(await readWebhookBodyOrReject({ req, res, maxBytes })).toEqual({ ok: false });
+        completed = true;
+      },
+      async (port) => {
+        const result = await rawRequest(port, postHeaders() + "invalid-chunk-size\r\n");
+        expect(result.errors).not.toContain("client deadline");
+      },
+    );
+    expect(completed).toBe(true);
+  });
+
+  it("does not let a concurrent reader accept a body after an installed guard rejects it", async () => {
+    await withServer(
+      async (req, res) => {
+        installRequestBodyLimitGuard(req, res, { maxBytes: 1 });
+        expect(await readWebhookBodyOrReject({ req, res, maxBytes: 1024 })).toEqual({ ok: false });
+      },
+      async (port) => {
+        const result = await rawRequest(port, postHeaders() + "2\r\nab\r\n0\r\n\r\n");
+        expect(result.errors).toEqual([]);
+        expect(result.wire).toMatch(/^HTTP\/1\.1 413 /);
+        expect(result.wire.split("\r\n\r\n")[1]).toBe('{"error":"Payload too large"}');
+      },
+    );
+  });
+
+  it("keeps application body consumers paused while Node bounds residual upload buffering", async () => {
+    let delivered = 0;
+    let buffered = 0;
+    let bufferLimit = 0;
+    await withServer(
+      async (req, res) => {
+        req.on("data", (chunk: Buffer) => {
+          delivered += chunk.length;
+        });
+        await sendHttpRequestRejection(req, res, 413, "rejected");
+        buffered = req.readableLength;
+        bufferLimit = req.readableHighWaterMark + req.socket.readableHighWaterMark;
+      },
+      async (port) => {
+        const result = await rawRequest(
+          port,
+          postHeaders("Content-Length: 10000000") + "x".repeat(3 * 1024 * 1024),
+        );
+        expect(result.errors).not.toContain("client deadline");
+      },
+    );
+    expect(delivered).toBe(0);
+    expect(buffered).toBeLessThanOrEqual(bufferLimit);
+  });
+
+  it.each(["before rejection", "after the response"])(
+    "bounds subsequent pipelined input when the rejected request completes %s",
+    async (completion) => {
+      let read = 0;
+      let readLimit = 0;
+      await withServer(
+        async (req, res) => {
+          await sendHttpRequestRejection(req, res, 413, "rejected");
+          read = req.socket.bytesRead;
+          readLimit = 2 * req.socket.readableHighWaterMark;
+        },
+        async (port) => {
+          const pipeline = "GET /next HTTP/1.1\r\nHost: localhost\r\n\r\n".repeat(10000);
+          const result =
+            completion === "before rejection"
+              ? await rawRequest(port, "GET /first HTTP/1.1\r\nHost: localhost\r\n\r\n" + pipeline)
+              : await rawRequest(port, postHeaders("Content-Length: 1"), "x" + pipeline);
+          expect(result.errors).toEqual([]);
+          expect(result.wire).toMatch(/^HTTP\/1\.1 413 /);
+          expect(result.wire.split("\r\n\r\n")[1]).toBe("rejected");
+        },
+        "standalone",
+      );
+      expect(read).toBeLessThanOrEqual(readLimit);
+    },
+  );
+
+  it("delivers bodyless HEAD rejection headers before closing", async () => {
+    await withServer(
+      async (req, res) => {
+        await sendHttpRequestRejection(req, res, 413, "rejected");
+      },
+      async (port) => {
+        const result = await rawRequest(port, "HEAD / HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        expect(result.errors).toEqual([]);
+        expect(result.wire).toMatch(/^HTTP\/1\.1 413 /);
+        expect(result.wire).toContain("Content-Length: 8");
+        expect(result.wire.split("\r\n\r\n")[1]).toBe("");
+      },
+    );
+  });
+
+  it.each(["SDK reader", "installed guard"])(
+    "half-closes a standalone queued HEAD after both earlier responses: %s",
+    async (surface) => {
+      const earlier: ServerResponse[] = [];
+      const selected = createDeferredCore();
+      let retired = false;
+      let transport: Socket;
+      await withServer(
+        async (req, res) => {
+          if (req.method !== "HEAD") {
+            earlier.push(res);
+            return;
+          }
+          transport = req.socket;
+          const sent =
+            surface === "SDK reader"
+              ? readWebhookBodyOrReject({ req, res, maxBytes: 1 })
+              : (installRequestBodyLimitGuard(req, res, { maxBytes: 1 }),
+                waitForHttpRequestRejection(req));
+          selected.resolve();
+          await sent;
+          retired = true;
+        },
+        async (port) => {
+          const socket = connect({ host: "127.0.0.1", port, allowHalfOpen: true });
+          const received: Buffer[] = [];
+          socket.on("data", (chunk: Buffer) => received.push(chunk));
+          const ended = once(socket, "end");
+          const closed = new Promise<void>((resolve) => {
+            socket.once("close", resolve);
+          });
+          const deadline = setTimeout(() => socket.destroy(new Error("client deadline")), 3000);
+          try {
+            socket.write(
+              "GET /one HTTP/1.1\r\nHost: localhost\r\n\r\nGET /two HTTP/1.1\r\nHost: localhost\r\n\r\nHEAD /head HTTP/1.1\r\nHost: localhost\r\nContent-Length: 2\r\n\r\n",
+            );
+            await selected.promise;
+            earlier[1].end("two");
+            earlier[0].end("one");
+            await ended;
+            // FIN must precede the bounded disposal deadline, not be caused by it.
+            expect(retired).toBe(false);
+            expect(transport!.destroyed).toBe(false);
+            expect(transport!.writableEnded).toBe(true);
+            const wire = Buffer.concat(received).toString();
+            expect(wire.match(/HTTP\/1\.1 \d{3}/g)).toEqual([
+              "HTTP/1.1 200",
+              "HTTP/1.1 200",
+              "HTTP/1.1 413",
+            ]);
+            expect(wire).toContain("oneHTTP/1.1 200");
+            expect(wire).toContain("twoHTTP/1.1 413");
+            expect(wire.endsWith("\r\n\r\n")).toBe(true);
+            expect(wire).not.toContain("Payload too large");
+          } finally {
+            clearTimeout(deadline);
+            socket.destroy();
+            await closed;
+          }
+        },
+        "standalone",
+      );
+      expect(retired).toBe(true);
+    },
+  );
+});

--- a/src/infra/http-request-lifecycle.test.ts
+++ b/src/infra/http-request-lifecycle.test.ts
@@ -1,6 +1,7 @@
 import { once } from "node:events";
 import { createServer, request, type IncomingMessage, type ServerResponse } from "node:http";
 import { connect, type Socket } from "node:net";
+import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
 import { runWithGatewayHttpWorkAdmission } from "../gateway/server/http-work-admission.js";
 import {
@@ -674,8 +675,8 @@ describe("bounded HTTP rejection transport", () => {
               "GET /one HTTP/1.1\r\nHost: localhost\r\n\r\nGET /two HTTP/1.1\r\nHost: localhost\r\n\r\nHEAD /head HTTP/1.1\r\nHost: localhost\r\nContent-Length: 2\r\n\r\n",
             );
             await selected.promise;
-            earlier[1].end("two");
-            earlier[0].end("one");
+            expectDefined(earlier[1], "second queued response").end("two");
+            expectDefined(earlier[0], "first queued response").end("one");
             await ended;
             // FIN must precede the bounded disposal deadline, not be caused by it.
             expect(retired).toBe(false);

--- a/src/infra/http-request-lifecycle.ts
+++ b/src/infra/http-request-lifecycle.ts
@@ -263,7 +263,7 @@ export async function sendHttpRequestRejection(
         }
       };
       if (!res.socket) {
-        // HEAD ignores write callbacks. The public finish notification lets a
+        // HEAD write callbacks do not flush headers. The public notification lets a
         // standalone SDK response wait for earlier responses without private
         // socket-assignment events; Node completes that handoff on this stack.
         const finished = channel("http.server.response.finish");

--- a/src/infra/http-request-lifecycle.ts
+++ b/src/infra/http-request-lifecycle.ts
@@ -1,0 +1,295 @@
+// Owns HTTP rejection transport and per-connection request ordering.
+import { channel } from "node:diagnostics_channel";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { Duplex } from "node:stream";
+import { clearTimeout, setTimeout } from "node:timers";
+import { createDeferredCore } from "../shared/deferred.js";
+
+// This is a transport grace period, not another body-upload allowance. The
+// request stays paused; Node's readable high-water mark bounds residual input.
+const REJECTION_CLOSE_TIMEOUT_MS = 1_000;
+
+type Rejection = {
+  request: IncomingMessage;
+  phase: "selected" | "writing" | "written" | "closed";
+  closed: Promise<void>;
+  destroy: () => void;
+};
+
+type HttpConnection = {
+  requests: Set<() => void>;
+  detach: () => void;
+  rejection?: Rejection;
+};
+
+const connections = new WeakMap<Duplex, HttpConnection>();
+
+function connectionFor(socket: Duplex): HttpConnection {
+  const existing = connections.get(socket);
+  if (existing) {
+    return existing;
+  }
+  const requests = new Set<() => void>();
+  const connection: HttpConnection = {
+    requests,
+    detach: () => {
+      socket.off("resume", pauseQueuedInput);
+      socket.off("close", onClose);
+    },
+  };
+  connections.set(socket, connection);
+  const pauseQueuedInput = () => {
+    const phase = connection.rejection?.phase;
+    if (
+      requests.size > 1 ||
+      phase === "selected" ||
+      phase === "writing" ||
+      connection.rejection?.request.complete
+    ) {
+      socket.pause();
+    }
+  };
+  // Node resumes input after parsing each message. Reapply backpressure at
+  // that event so queued admission retains at most the current read batch.
+  socket.on("resume", pauseQueuedInput);
+  const onClose = () => {
+    connection.detach();
+    for (const resume of requests) {
+      resume();
+    }
+  };
+  socket.once("close", onClose);
+  return connection;
+}
+
+/** Closing is selected before any ordered response write can reach the socket. */
+export function isHttpConnectionClosing(socket: Duplex): boolean {
+  return socket.destroyed || socket.writableEnded || Boolean(connections.get(socket)?.rejection);
+}
+
+/**
+ * Serialize application admission, not Node's response writes. A later request
+ * must not cross async routing/auth while an earlier body can still be rejected.
+ * Already admitted work finishes; queued work is never dispatched after closure.
+ */
+export async function runHttpConnectionRequest(
+  req: IncomingMessage,
+  run: () => Promise<void>,
+  response?: ServerResponse | "upgrade",
+): Promise<void> {
+  const socket = req.socket;
+  if (isHttpConnectionClosing(socket)) {
+    socket.pause();
+    return;
+  }
+  const connection = connectionFor(socket);
+  const queued = connection.requests.size > 0;
+  const ready = createDeferredCore();
+  connection.requests.add(ready.resolve);
+  try {
+    if (queued) {
+      socket.pause();
+      await ready.promise;
+    }
+    if (!isHttpConnectionClosing(socket)) {
+      if (response === "upgrade") {
+        // The preceding HTTP response released queue-owned backpressure before
+        // admission. From this point the upgrade owner controls all socket flow.
+        connection.requests.delete(ready.resolve);
+        connection.detach();
+        connections.delete(socket);
+        return await run();
+      }
+      await run();
+      const res = response;
+      if (res && !res.writableFinished && !res.destroyed && !socket.destroyed) {
+        const responseDone = createDeferredCore();
+        res.once("finish", responseDone.resolve);
+        res.once("close", responseDone.resolve);
+        socket.once("close", responseDone.resolve);
+        await responseDone.promise;
+        res.off("finish", responseDone.resolve);
+        res.off("close", responseDone.resolve);
+        socket.off("close", responseDone.resolve);
+      }
+    }
+  } finally {
+    if (connections.get(socket) === connection) {
+      connection.requests.delete(ready.resolve);
+      if (connection.requests.size <= 1 && !isHttpConnectionClosing(socket)) {
+        socket.resume();
+      }
+      connection.requests.values().next().value?.();
+    }
+  }
+}
+
+/** Keep security/CORS headers, but discard metadata for an abandoned representation. */
+export function clearHttpResponseRepresentationHeaders(res: ServerResponse): void {
+  for (const header of [
+    "Content-Encoding",
+    "Content-Disposition",
+    "Content-Range",
+    "Content-Language",
+    "Content-Location",
+    "Content-Type",
+    "ETag",
+    "Last-Modified",
+    "Transfer-Encoding",
+    "Trailer",
+  ]) {
+    res.removeHeader(header);
+  }
+}
+
+/** Fence synchronously at the byte/time limit, before a reader rejects its promise. */
+export function selectHttpRequestRejection(req: IncomingMessage): Rejection {
+  const socket = req.socket;
+  const connection = connectionFor(socket);
+  if (connection.rejection) {
+    return connection.rejection;
+  }
+  const completion = createDeferredCore();
+  const rejection: Rejection = {
+    request: req,
+    phase: "selected",
+    closed: completion.promise,
+    destroy: () => socket.destroy(),
+  };
+  connection.rejection = rejection;
+  for (const resume of connection.requests) {
+    resume();
+  }
+  req.pause();
+  socket.pause();
+  // A completed request no longer provides body backpressure. Do not let its
+  // parser consume an arbitrary pipeline during the half-close grace period.
+  const pauseCompletedRequest = () => {
+    if (req.complete) {
+      socket.pause();
+    }
+  };
+  req.on("readable", pauseCompletedRequest);
+  const timer = setTimeout(rejection.destroy, REJECTION_CLOSE_TIMEOUT_MS);
+  timer.unref();
+  const onClose = () => {
+    rejection.phase = "closed";
+    clearTimeout(timer);
+    req.off("error", rejection.destroy);
+    req.off("readable", pauseCompletedRequest);
+    socket.off("error", rejection.destroy);
+    completion.resolve();
+  };
+  req.on("error", rejection.destroy);
+  socket.on("error", rejection.destroy);
+  socket.once("close", onClose);
+  if (socket.destroyed) {
+    socket.off("close", onClose);
+    onClose();
+  }
+  return rejection;
+}
+
+/** Preserve the caller's error representation and security headers until half-close. */
+export async function sendHttpRequestRejection(
+  req: IncomingMessage,
+  res: ServerResponse,
+  statusCode: number,
+  body: string,
+  contentType?: string,
+): Promise<void> {
+  const rejection = selectHttpRequestRejection(req);
+  if (rejection.request !== req || rejection.phase !== "selected") {
+    return await rejection.closed;
+  }
+  if (res.headersSent || res.destroyed || res.writableEnded) {
+    // Ending a committed chunked response would falsely complete a partial body.
+    rejection.destroy();
+    return await rejection.closed;
+  }
+  const socket = req.socket;
+  const onResponseClose = () => {
+    rejection.destroy();
+  };
+  res.on("error", rejection.destroy);
+  res.once("close", onResponseClose);
+  let stopWaitingForSocket: (() => void) | undefined;
+  try {
+    rejection.phase = "writing";
+    res.statusCode = statusCode;
+    clearHttpResponseRepresentationHeaders(res);
+    res.setHeader("Connection", "close");
+    res.setHeader("Content-Length", Buffer.byteLength(body));
+    if (contentType) {
+      res.setHeader("Content-Type", contentType);
+    }
+    // res.end() invokes Node's destroySoon on Connection: close. Write the
+    // entire framed response, then half-close only after its ordered callback.
+    const onWritten = (error?: Error | null) => {
+      if (error) {
+        rejection.destroy();
+      } else if (rejection.phase === "writing") {
+        rejection.phase = "written";
+        try {
+          socket.end();
+          // Do not resume application body consumers after rejection. Reading
+          // the socket alone lets Node buffer only up to request backpressure.
+          socket.resume();
+        } catch {
+          rejection.destroy();
+        }
+      }
+    };
+    if (process.versions.bun) {
+      // Bun's native HTTP response owns framing/closure; raw socket.end() does
+      // not flush that response and Bun emits no HTTP finish diagnostics event.
+      // Unlike Node's destroySoon path, use its ordered native end operation.
+      res.end(body, () => {
+        if (rejection.phase === "writing") {
+          rejection.phase = "written";
+        }
+      });
+    } else if (req.method === "HEAD") {
+      const writeHeaders = () => {
+        if (!res.socket || rejection.phase !== "writing") {
+          return;
+        }
+        stopWaitingForSocket?.();
+        try {
+          res.flushHeaders();
+          res.socket.write("", onWritten);
+        } catch {
+          rejection.destroy();
+        }
+      };
+      if (!res.socket) {
+        // HEAD ignores write callbacks. The public finish notification lets a
+        // standalone SDK response wait for earlier responses without private
+        // socket-assignment events; Node completes that handoff on this stack.
+        const finished = channel("http.server.response.finish");
+        const onFinish = (message: unknown) => {
+          // SAFETY: Node documents this channel's payload as including the response's socket.
+          if ((message as { socket: Duplex }).socket === socket) {
+            queueMicrotask(writeHeaders);
+          }
+        };
+        finished.subscribe(onFinish);
+        stopWaitingForSocket = () => finished.unsubscribe(onFinish);
+      }
+      writeHeaders();
+    } else {
+      res.write(body, onWritten);
+    }
+  } catch {
+    rejection.destroy();
+  }
+  await rejection.closed;
+  stopWaitingForSocket?.();
+  res.off("error", rejection.destroy);
+  res.off("close", onResponseClose);
+}
+
+/** Release handler/limiter ownership only after the selected transport closes. */
+export function waitForHttpRequestRejection(req: IncomingMessage): Promise<void> | undefined {
+  return connections.get(req.socket)?.rejection?.closed;
+}

--- a/src/plugin-sdk/test-helpers/mock-incoming-request.ts
+++ b/src/plugin-sdk/test-helpers/mock-incoming-request.ts
@@ -1,29 +1,22 @@
 /**
  * Mock IncomingMessage builder for webhook and HTTP request tests.
  */
-import { EventEmitter } from "node:events";
-import type { IncomingMessage } from "node:http";
+import { IncomingMessage } from "node:http";
+import { Socket } from "node:net";
 
 export function createMockIncomingRequest(chunks: string[]): IncomingMessage {
-  const req = new EventEmitter() as IncomingMessage & {
-    destroyed?: boolean;
-    destroy: (error?: Error) => IncomingMessage;
-  };
-  req.destroyed = false;
-  req.headers = {};
-  req.destroy = () => {
-    req.destroyed = true;
-    return req;
-  };
+  const req = new IncomingMessage(new Socket());
 
   void Promise.resolve().then(() => {
     for (const chunk of chunks) {
-      req.emit("data", Buffer.from(chunk, "utf-8"));
       if (req.destroyed) {
         return;
       }
+      req.push(Buffer.from(chunk, "utf-8"));
     }
-    req.emit("end");
+    // Like Node's parser, mark complete before EOF so normal cleanup keeps the socket open.
+    req.complete = true;
+    req.push(null);
   });
 
   return req;

--- a/src/plugin-sdk/webhook-request-guards.test.ts
+++ b/src/plugin-sdk/webhook-request-guards.test.ts
@@ -2,7 +2,8 @@
  * Tests webhook request guard body parsing and rejection behavior.
  */
 import { EventEmitter } from "node:events";
-import type { IncomingMessage } from "node:http";
+import { IncomingMessage, ServerResponse } from "node:http";
+import { Socket } from "node:net";
 import { describe, expect, it } from "vitest";
 import { createMockServerResponse } from "../test-utils/mock-http-response.js";
 import { createFixedWindowRateLimiter } from "./webhook-memory-guards.js";
@@ -31,6 +32,7 @@ function createMockRequest(params: {
   const req = new EventEmitter() as MockIncomingMessage;
   req.method = params.method ?? "POST";
   req.headers = params.headers ?? {};
+  req.socket = new Socket();
   req.destroyed = false;
   req.destroy = (() => {
     req.destroyed = true;
@@ -206,17 +208,6 @@ describe("readWebhookBodyOrReject", () => {
     const { result } = await readRawBody({ chunks: ["plain text"] });
     expect(result).toEqual({ ok: true, value: "plain text" });
   });
-
-  it("enforces strict pre-auth default body limits", async () => {
-    const { result, res } = await readRawBody(
-      {
-        headers: { "content-length": String(70 * 1024) },
-      },
-      "pre-auth",
-    );
-    expect(result).toEqual({ ok: false });
-    expect(res.statusCode).toBe(413);
-  });
 });
 
 describe("beginWebhookRequestPipelineOrReject", () => {
@@ -310,16 +301,19 @@ describe("runDetachedWebhookWork", () => {
     const order: string[] = [];
     const detached: Promise<void>[] = [];
 
-    await runWithGatewayHttpWorkAdmission(createMockServerResponse(), async () => {
-      detached.push(
-        runDetachedWebhookWork(async () => {
-          order.push("work");
-        }),
-      );
-      order.push("ack");
-      expect(order).toEqual(["ack"]);
-      return true;
-    });
+    await runWithGatewayHttpWorkAdmission(
+      new ServerResponse(new IncomingMessage(new Socket())),
+      async () => {
+        detached.push(
+          runDetachedWebhookWork(async () => {
+            order.push("work");
+          }),
+        );
+        order.push("ack");
+        expect(order).toEqual(["ack"]);
+        return true;
+      },
+    );
 
     await Promise.all(detached);
     expect(order).toEqual(["ack", "work"]);
@@ -331,17 +325,20 @@ describe("runDetachedWebhookWork", () => {
     const { enqueueCommandInLane } = await import("../process/command-queue.js");
 
     let detached: Promise<number> | null = null;
-    await runWithGatewayHttpWorkAdmission(createMockServerResponse(), async () => {
-      // Ack-first shape: dispatch continues after the handler (and its
-      // admission) completes; the queue enqueue happens well past release.
-      detached = runDetachedWebhookWork(async () => {
-        await new Promise<void>((resolve) => {
-          setTimeout(resolve, 25);
+    await runWithGatewayHttpWorkAdmission(
+      new ServerResponse(new IncomingMessage(new Socket())),
+      async () => {
+        // Ack-first shape: dispatch continues after the handler (and its
+        // admission) completes; the queue enqueue happens well past release.
+        detached = runDetachedWebhookWork(async () => {
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, 25);
+          });
+          return await enqueueCommandInLane("detached-webhook-work-test", async () => 42);
         });
-        return await enqueueCommandInLane("detached-webhook-work-test", async () => 42);
-      });
-      return true;
-    });
+        return true;
+      },
+    );
 
     await expect(detached).resolves.toBe(42);
   });
@@ -352,16 +349,19 @@ describe("runDetachedWebhookWork", () => {
     const { enqueueCommandInLane } = await import("../process/command-queue.js");
 
     let inherited: Promise<number> | null = null;
-    await runWithGatewayHttpWorkAdmission(createMockServerResponse(), async () => {
-      inherited = (async () => {
-        await new Promise<void>((resolve) => {
-          setTimeout(resolve, 25);
-        });
-        return await enqueueCommandInLane("inherited-webhook-work-test", async () => 42);
-      })();
-      inherited.catch(() => {});
-      return true;
-    });
+    await runWithGatewayHttpWorkAdmission(
+      new ServerResponse(new IncomingMessage(new Socket())),
+      async () => {
+        inherited = (async () => {
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, 25);
+          });
+          return await enqueueCommandInLane("inherited-webhook-work-test", async () => 42);
+        })();
+        inherited.catch(() => {});
+        return true;
+      },
+    );
 
     await expect(inherited).rejects.toThrow("Gateway is draining");
   });

--- a/src/plugin-sdk/webhook-request-guards.ts
+++ b/src/plugin-sdk/webhook-request-guards.ts
@@ -4,17 +4,22 @@ import { resolveIntegerOption } from "@openclaw/normalization-core/number-coerci
 import { normalizeOptionalLowercaseString } from "../../packages/normalization-core/src/string-coerce.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import {
-  closeRequestAfterResponse,
   isRequestBodyLimitError,
   readJsonBodyWithLimit,
   readRequestBodyWithLimit,
   requestBodyErrorToText,
 } from "../infra/http-body.js";
+import {
+  isHttpConnectionClosing,
+  sendHttpRequestRejection,
+  waitForHttpRequestRejection,
+} from "../infra/http-request-lifecycle.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { runWithGatewayIndependentRootWorkContinuation } from "../process/gateway-work-admission.js";
 import type { FixedWindowRateLimiter } from "./webhook-memory-guards.js";
 
 export { resolveAcceptedBrowserOrigin } from "../gateway/origin-check.js";
+export { sendHttpRequestRejection } from "../infra/http-request-lifecycle.js";
 
 /** Body-read profile for webhook payload limits before or after authentication. */
 export type WebhookBodyReadProfile = "pre-auth" | "post-auth";
@@ -84,24 +89,26 @@ function resolveWebhookBodyReadLimits(params: {
   return { maxBytes, timeoutMs };
 }
 
-function respondWebhookBodyReadError(params: {
+async function respondWebhookBodyReadError(params: {
   req: IncomingMessage;
   res: ServerResponse;
   code: string;
   invalidMessage?: string;
   invalidStatusCode?: number;
-}): { ok: false } {
+}): Promise<{ ok: false }> {
   const { req, res, code, invalidMessage, invalidStatusCode } = params;
-  if (code === "PAYLOAD_TOO_LARGE") {
-    closeRequestAfterResponse(req, res);
-    res.statusCode = 413;
-    res.end(requestBodyErrorToText("PAYLOAD_TOO_LARGE"));
+  if (code === "PAYLOAD_TOO_LARGE" || code === "REQUEST_BODY_TIMEOUT") {
+    await sendHttpRequestRejection(
+      req,
+      res,
+      code === "PAYLOAD_TOO_LARGE" ? 413 : 408,
+      requestBodyErrorToText(code),
+    );
     return { ok: false };
   }
-  if (code === "REQUEST_BODY_TIMEOUT") {
-    closeRequestAfterResponse(req, res);
-    res.statusCode = 408;
-    res.end(requestBodyErrorToText("REQUEST_BODY_TIMEOUT"));
+  const rejection = waitForHttpRequestRejection(req);
+  if (rejection) {
+    await rejection;
     return { ok: false };
   }
   if (code === "CONNECTION_CLOSED") {
@@ -194,6 +201,9 @@ export function applyBasicWebhookRequestGuards(params: {
   /** Require JSON content type for POST requests. */
   requireJsonContentType?: boolean;
 }): boolean {
+  if (isHttpConnectionClosing(params.req.socket)) {
+    return false;
+  }
   const allowMethods = params.allowMethods?.length ? params.allowMethods : null;
   if (allowMethods && !allowMethods.includes(params.req.method ?? "")) {
     params.res.statusCode = 405;
@@ -284,7 +294,12 @@ export function beginWebhookRequestPipelineOrReject(params: {
       // Pipeline cleanup may run from multiple exits; release must stay idempotent.
       released = true;
       if (inFlightLimiter && inFlightKey) {
-        inFlightLimiter.release(inFlightKey);
+        const closed = waitForHttpRequestRejection(params.req);
+        if (closed) {
+          void closed.then(() => inFlightLimiter.release(inFlightKey));
+        } else {
+          inFlightLimiter.release(inFlightKey);
+        }
       }
     },
   };

--- a/src/test-utils/mock-http-response.ts
+++ b/src/test-utils/mock-http-response.ts
@@ -1,11 +1,13 @@
 // Provides a lightweight ServerResponse mock for HTTP handler tests.
-import type { ServerResponse } from "node:http";
+import { IncomingMessage, type ServerResponse } from "node:http";
+import { Socket } from "node:net";
 import { lowercasePreservingWhitespace } from "@openclaw/normalization-core/string-coerce";
 
 /** Minimal ServerResponse double for route tests that inspect headers and body. */
 export function createMockServerResponse(): ServerResponse & { body?: string } {
   const headers: Record<string, string> = {};
   const res: {
+    req: IncomingMessage;
     headersSent: boolean;
     statusCode: number;
     body?: string;
@@ -13,6 +15,7 @@ export function createMockServerResponse(): ServerResponse & { body?: string } {
     getHeader: (key: string) => string | undefined;
     end: (body?: string) => unknown;
   } = {
+    req: new IncomingMessage(new Socket()),
     headersSent: false,
     statusCode: 200,
     setHeader: (key: string, value: string) => {


### PR DESCRIPTION
Related: #126808, #126818

AI-assisted with Codex; implementation, wire evidence, and dependency contracts independently checked.

## What Problem This Solves

Fixes an issue where clients uploading an oversized or stalled body to Node-hosted Gateway hooks and the shared webhook guards receive a connection reset instead of the intended complete 413/408 response. A response-first reader alone is insufficient: Node's response completion can hard-close the transport before the existing close listener runs.

This is the shared transport prerequisite, not a replacement for #126818's channel-reader migrations. It does not close #126808's broader channel/logging report.

## Why This Change Was Made

One connection-lifecycle owner now selects rejection synchronously at the body limit, fences later application admission, writes the complete response in HTTP order, and half-closes Node's write side before bounded disposal. Application body consumers remain paused. Gateway work admission and webhook in-flight slots retain ownership until cleanup completes. The duplicate Admin HTTP RPC teardown and the old close-after-response helper are removed.

Finite HTTP pipelines still drain in order, including response lifetimes. Expect handling preserves Node's event classification. An admitted upgrade transfers socket-flow ownership before invoking the WebSocket/plugin handler; HTTP cleanup cannot undo the upgraded owner's backpressure. Standalone queued HEAD responses use Node's public response-finish diagnostics notification to wait for socket assignment, with a bounded subscription lifetime.

Bun's native response implementation has a different framing/closure contract, demonstrated against the installed Bun 1.4.0 source and wire behavior. It uses native response completion; no raw-socket workaround or Node-only diagnostics dependency is applied there.

The existing response-first bounded reader is already public. A single focused `sendHttpRequestRejection` export lets callers that own a custom error envelope use the same lifecycle instead of copying teardown policy; the public export and callable budgets each increase by one with that rationale. The helper has a real bundled caller in Admin HTTP RPC. No public reader options or existing error envelopes are changed.

Feishu records selected-error anomalies once on response close, because Node transport-owned rejections do not emit response finish. Healthy activity remains tied to successful response finish. This preserves monitoring without treating an aborted response as healthy traffic.

Mattermost multi-account routing now passes its already-bounded body alongside the original request to the account handler. The old synthetic request had no connection and reread the same bytes. Removing that replay preserves the authoritative transport and keeps the existing account parsing, token validation, limits, and statuses unchanged.

Provenance: the shared close-after-response helper was introduced in #125893, commit 0684f50136e77bb832417d292fa20ad62380527d (2026-08-18), authored and merged by @steipete. The older Admin HTTP RPC finish/destroy copy is removed from the same lifecycle neighborhood.

## User Impact

Node-hosted hooks and shared webhook readers can deliver their existing rejection status and payload while retiring the rejected connection. Body limits and body-read timeouts are unchanged. No new configuration, persistence/schema, protocol, or dependency changes are required.

Connection cleanup is bounded to one second; disconnected peers, malformed HTTP, blocked earlier responses, or exhausted cleanup time can still prevent delivery. An already committed partial success is closed, not falsely completed or replaced. Bun still has a demonstrated baseline limitation: large outstanding uploads can report client connection resets even after receiving the complete error. This change does not claim to fix that Bun limitation.

Release-note context: preserve HTTP body-limit error responses on Node while bounding rejected-connection cleanup and fencing later pipelined work.

## Evidence

Before editing, the actual `/hooks/wake` 256 KiB limit was exercised with repeated 1 MiB-plus uploads on Node 24.20.0: 3/10 strict Node-client passes and 0/10 strict raw-socket passes. Failures were EPIPE/ECONNRESET, not just missing mock calls. The repaired candidate passed 10/10 Node-client and 10/10 raw-socket trials with exact 413/body, actual connection close, and no client errors.

The final combined owner/sibling and CI-regression suite passed 514 tests across 26 files and 12 shards in 235.81 seconds. It covers shared raw/JSON readers, installed guards, actual Gateway hook responses, HTTP admission, Admin HTTP RPC, finite 32/2048-request pipelines, unfinished-response backpressure, queued HEAD, Expect semantics, rejection fences for ordinary/upgrade/Expect/CONNECT requests, and WebSocket/stream pause ownership after fresh and queued upgrades, plus the affected plugin request fixtures and Mattermost account routing. Regression controls failed on the corresponding pre-fix owner paths.

Feishu real-TCP 413/408 cases failed with missing anomaly records before the consumer repair and passed afterward. All 66 webhook security/signed-request cases passed, including exactly one healthy activity update for a successful signed response and none after aborting a held dispatch. This is local synthetic-provider proof, not a live Feishu platform test; the changed behavior is local HTTP lifecycle observation and makes no external API changes.

Eight Bun baseline/candidate finite controls passed with exact status/order/body, actual EOF and close, no client deadline, and empty stderr. Large-upload Bun baseline and candidate controls both delivered 20/20 complete 413 responses but failed the strict zero-reset condition; that limitation is retained above rather than hidden by retries or weaker assertions.

Four real TLS 1.3 controls against `createGatewayHttpServer` passed: large chunked 413, ordered queued HEAD rejection, partial-body 408, and a peer retaining its writable half. All observed the expected response and actual cleanup without client errors, forced cleanup, or leftover listeners/sockets. The stalled peer retained admission until the production cleanup deadline. Certificates were synthetic committed test fixtures; no operator Gateway, credentials, or settings were used.

The complete canonical build passed. Two additional controls imported the built public SDK entrypoint and verified custom JSON 413 delivery and standalone queued HEAD ordering/half-close. The emitted Gateway, SDK, and Admin HTTP RPC graph shares one lifecycle implementation; runtime export identity and generated declaration were verified.

Production LOC: +492/-144 (net +348); tests: +1516/-534; test support: +82/-33; docs: +32; tooling ratchets/budget: +6/-4. The test/support counts include moving existing account/signing fixtures into their shared owner; those moves are not new behavior. The production growth establishes the missing connection-level owner for synchronous rejection selection, ordered response completion, bounded cleanup/input, and upgrade handoff. Request-local finish/destroy helpers cannot enforce these contracts; those duplicate paths are removed instead of retained as alternatives. The Mattermost follow-up removes nine production lines.

The full-patch isolated Codex autoreview completed successfully with no actionable P0 findings. The complete snapshot was verified byte-for-byte before committing. The refresh onto main was mechanical, with an identical range-diff; the existing main private-helper import repair is included rather than duplicated here. Refreshed checking exposed two fixture type errors and an oversized Feishu test file; checked fixture access and an unchanged test relocation repaired those, with a clean test-only review and all original assertions retained. The complete 28-path changed-file gate then passed all type, lint, format, SDK, and static checks.

Test-infrastructure follow-up: audit the pre-existing Feishu monitor-start helper retry boundary, which also catches callback exceptions. This repair adds no retries; the recorded red anomaly controls still failed through that existing wrapper before the consumer fix.

Unrelated CI follow-up: attempt 1 of run 33166710335 passed 205 checks but failed the Doctor config-state shard on process deadlines and a Canvas timeout followed by inconsistent temporary-state observations. The existing async-child repair in #130706 owns the concurrent `spawnSync` scheduling problem; this HTTP PR does not duplicate or claim to repair it. All ten Canvas cases passed unchanged in isolation, which does not establish the original ordered run or initial timeout cause. A deterministic regression for temporary-home cleanup after a timed-out callback is recorded as separate test-infrastructure work. Attempt 2 reran only the failed job and dependent gates, preserving the original order, source and timeouts, and completed successfully. [Evidence was shared with the existing repair](https://github.com/openclaw/openclaw/pull/130706#issuecomment-5452207555).

CI follow-up: the first hosted run exposed two WebSocket fixtures without an explicit payload limit and HTTP mocks without real request/socket behavior. Fixtures now use canonical incoming streams; the WebSocket fixtures use the Gateway's existing pre-auth payload cap. The Gateway seeded response mapping runs over loopback HTTP. Telegram's duplicate fake limit tests were consolidated into real length-framed/chunked 413 and stalled 408 delivery, socket-closure, listener-cleanup, and no-bootstrap proofs. No assertion, timeout, retry, or scan-policy bypass was added. Additional focused proof passed 298 tests across 14 files, including all affected plugin fixtures. Two real Mattermost multi-account regressions first failed with 413 instead of the existing 400/401 validation responses, then passed after deleting replay. The bounded CI correction received a clean isolated Codex review at the P0 threshold.

A2A and QA-bus fixture checks prove their existing classification/limits, not reset-free network delivery. Their legacy rejection teardown remains outside this shared-owner adoption; broader channel-reader migration is tracked separately in #126818.

Maintainer disposition under the authorized repair-and-land scope: accept the documented additive SDK contract as the canonical custom-envelope rejection seam. It is a single generic helper on an existing public subpath, with a real custom-envelope caller and no change to existing signatures, privilege boundaries, configuration, or persistent data. Its supported behavior and limits are documented. Connection-level ordering/cleanup is the capability requiring production growth; the additional Mattermost repair absorbs its fix while deleting replay. The review's persistent-data heuristics do not describe this patch: the new state is a process-local WeakMap and request/response lifecycle state, with no database or storage migration. Exact-head CI is still mandatory and will be verified before native landing; no bypass is used.

Latest-review evidence clarification: the repeated raw-upload before/after trials described here exercise the production Gateway hooks handler, not a signed LINE endpoint. The separate real-TCP anomaly controls are Feishu. LINE's affected fixture suites pass, but this PR does not claim new authenticated LINE platform proof or completion of #126818's reader migrations. The latest rank-up requests are covered by the explicit SDK disposition, final local gate/build and successful exact-head CI.

Verified source: `1e0eb61d97e5a51c91e31afaf965bad4684040e8`, based on `de12e0a06c1b1f3300823c001607ad3608edcc61`. The combined 514-test run passed; the subsequent lint-only executor/catch cleanup passed focused lint and the affected nine Gateway fuzz/eight Mattermost routing tests. The complete 42-path gate passed all type, lint, format, SDK and static checks after those lint corrections. The canonical build passed in 4m49s, then built-SDK 2/2 and TLS 4/4 controls passed again on this source with empty stderr, no client errors/deadlines/forced cleanup, and no leftover sockets/listeners. The unique emitted lifecycle owner is still shared across SDK/Gateway/Admin. [Exact-head CI attempt 2](https://github.com/openclaw/openclaw/actions/runs/33166710335/attempts/2) completed successfully.

<details>
<summary>Reproduce the checked-in boundary suite</summary>

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/infra/http-request-lifecycle.test.ts \
  src/infra/http-body.test.ts \
  src/gateway/http-common.test.ts \
  src/gateway/server-http.hooks-request-timeout.test.ts \
  src/gateway/server-http.rejection-transport.test.ts \
  src/gateway/server-http.upgrade-claim.test.ts \
  src/gateway/server/plugins-http.suspension-admission.test.ts \
  src/plugin-sdk/webhook-request-guards.test.ts \
  src/plugin-sdk/webhook-memory-guards.test.ts \
  extensions/admin-http-rpc/src/handler.test.ts \
  extensions/feishu/src/monitor.webhook-activity.test.ts \
  extensions/feishu/src/monitor.webhook-e2e.test.ts \
  extensions/feishu/src/monitor.webhook-security.test.ts \
  src/gateway/http-common.fuzz.test.ts \
  extensions/line/src/monitor.lifecycle.test.ts \
  extensions/line/src/webhook-node.test.ts \
  extensions/mattermost/src/mattermost/slash-http.send-config.test.ts \
  extensions/mattermost/src/mattermost/slash-http.test.ts \
  extensions/mattermost/src/mattermost/slash-state.test.ts \
  extensions/telegram/src/miniapp/routes.test.ts \
  extensions/nextcloud-talk/src/monitor.replay.test.ts \
  extensions/openai/realtime-quicksilver-ga-oauth.test.ts \
  extensions/openai/realtime-quicksilver-session.test.ts \
  extensions/sms/src/twilio.test.ts \
  extensions/qa-lab/src/bus-server.test.ts \
  extensions/a2a/src/http.test.ts
pnpm build
node scripts/check-changed.mjs -- $(git diff --name-only origin/main...HEAD)
```

</details>
