### PR TITLE
fix(test): prevent false state DB recovery failures on slow CI

### DIFF
--- a/src/infra/sqlite-wal.test.ts
+++ b/src/infra/sqlite-wal.test.ts
@@ -751,8 +751,8 @@ describe("sqlite WAL maintenance", () => {
     expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA wal_checkpoint(FULL);");
     expect(db["exec"]).toHaveBeenNthCalledWith(4, "PRAGMA incremental_vacuum(512);");
 
-    expect(maintenance.close()).toBe(true);
-    expect(db["prepare"]).toHaveBeenLastCalledWith("PRAGMA wal_checkpoint(FULL);");
+    expect(maintenance.close({ checkpointMode: "PASSIVE" })).toBe(true);
+    expect(db["prepare"]).toHaveBeenLastCalledWith("PRAGMA wal_checkpoint(PASSIVE);");
   });
 
   it("reports a busy checkpoint result as incomplete", () => {

--- a/src/state/openclaw-state-db.corruption-recovery.test.ts
+++ b/src/state/openclaw-state-db.corruption-recovery.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
@@ -175,23 +175,23 @@ describe("shared state write transaction corruption recovery", () => {
     const walBytesBeforeEviction = fs.statSync(walPath).size;
     const { DatabaseSync } = requireNodeSqlite();
     const peer = new DatabaseSync(cached.path);
+    const close = vi.spyOn(cached.walMaintenance, "close");
 
     try {
       peer.exec("BEGIN;");
       peer.prepare("SELECT count(*) FROM diagnostic_events").get();
-      const evictionStartedAt = performance.now();
       expect(
         openClawStateDatabaseCache.evictOpenClawStateDatabaseAfterCorruption(
           cached,
           sqliteError("database disk image is malformed", 11),
         ),
       ).toBe(true);
-      const evictionElapsedMs = performance.now() - evictionStartedAt;
 
       expect(
         openClawStateDatabaseCache.getOpenClawStateDatabaseIfOpenAtPath(cached.path),
       ).toBeUndefined();
-      expect(evictionElapsedMs).toBeLessThan(250);
+      expect(close).toHaveBeenCalledTimes(1);
+      expect(close).toHaveBeenCalledWith({ checkpointMode: "PASSIVE" });
       expect(fs.statSync(walPath).size).toBe(walBytesBeforeEviction);
       expect(peer.prepare("PRAGMA quick_check").get()).toEqual({ quick_check: "ok" });
       expect(


### PR DESCRIPTION
Related: #128141

## What Problem This Solves

Resolves a problem where Full Release Validation could fail because a state DB corruption-recovery test measured host scheduling and filesystem latency against a 250 ms wall-clock threshold.

## Why This Change Was Made

The test now asserts the actual ownership contract: corruption eviction closes WAL maintenance exactly once with a PASSIVE checkpoint while preserving the peer transaction, WAL bytes, integrity check, committed row, and cache eviction behavior.

## User Impact

Release validation no longer treats a slow CI host as a state database regression.

## Evidence

- Reproduced in FRV run 33158564102 at 341.4 ms against the old 250 ms assertion.
- `node scripts/run-vitest.mjs src/state/openclaw-state-db.corruption-recovery.test.ts src/infra/sqlite-wal.test.ts`
- 59 passed, 3 platform-specific tests skipped.
- `git diff --check`
- Autoreview: clean, no actionable findings.
- Production LOC: 0. Test LOC: +6/-6.

AI-assisted: yes.
