### PR TITLE
perf(release): expose Windows upgrade timing evidence

### DIFF
--- a/scripts/lib/cross-os-release-checks/config.ts
+++ b/scripts/lib/cross-os-release-checks/config.ts
@@ -17,7 +17,21 @@ export type ProviderConfig = {
   timeoutSeconds?: number;
 };
 export type ParsedArgs = Record<string, string>;
-export type LaneResult = { status: string; error?: string } & Record<string, unknown>;
+export type PackagedUpgradeTiming = {
+  name: "total" | "package-install" | "package-install-omit-optional" | "staged-swap" | "doctor";
+  durationMs: number;
+};
+export type PackagedUpgradeFallbackEvidence = {
+  reason: "timeout" | "swap-cleanup";
+  action: "direct-candidate-install";
+};
+export type LaneResult = {
+  status: string;
+  error?: string;
+  phaseTimings?: LaneState["phaseTimings"];
+  updateTimings?: PackagedUpgradeTiming[];
+  updateFallback?: PackagedUpgradeFallbackEvidence;
+} & Record<string, unknown>;
 export type CandidateBuild = {
   candidateTgz: string;
   candidateVersion: string;
@@ -80,6 +94,11 @@ export type LaneCommandParams = {
 };
 export type AgentOutputOptions = { logText?: string; logPath?: string };
 export type SummaryPayload = {
+  platform?: string;
+  runnerOs?: string;
+  runnerLabel?: string;
+  nodeVersion?: string;
+  npmVersion?: string;
   provider: string;
   suite: string;
   mode: string;
@@ -100,6 +119,8 @@ export type SummaryPayload = {
     agentOutput?: string;
     error?: string;
     phaseTimings?: LaneState["phaseTimings"];
+    updateTimings?: PackagedUpgradeTiming[];
+    updateFallback?: PackagedUpgradeFallbackEvidence;
   };
 };
 
@@ -571,6 +592,58 @@ export function verifyPackagedUpgradeUpdateResult(
     `Packaged upgrade failed (${result.exitCode}): ${trimForSummary(
       `${result.stdout}\n${result.stderr}`,
     )}`,
+  );
+}
+
+const PACKAGED_UPGRADE_TIMING_FIELDS = [
+  ["global update", "package-install"],
+  ["global update (omit optional)", "package-install-omit-optional"],
+  ["global install swap", "staged-swap"],
+  ["openclaw doctor", "doctor"],
+] as const;
+const PACKAGED_UPGRADE_TIMING_MAX_MS = 60 * 60 * 1000;
+
+export function parsePackagedUpgradeUpdateTimings(stdout: string): PackagedUpgradeTiming[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout.trim());
+  } catch {
+    return [];
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return [];
+  }
+
+  const result = parsed as { durationMs?: unknown; steps?: unknown };
+  const timings: PackagedUpgradeTiming[] = [];
+  if (isBoundedTimingMs(result.durationMs)) {
+    timings.push({ name: "total", durationMs: result.durationMs });
+  }
+  if (!Array.isArray(result.steps)) {
+    return timings;
+  }
+
+  for (const [stepName, timingName] of PACKAGED_UPGRADE_TIMING_FIELDS) {
+    const step = result.steps.find(
+      (candidate) =>
+        candidate !== null &&
+        typeof candidate === "object" &&
+        !Array.isArray(candidate) &&
+        (candidate as { name?: unknown }).name === stepName,
+    ) as { durationMs?: unknown } | undefined;
+    if (step && isBoundedTimingMs(step.durationMs)) {
+      timings.push({ name: timingName, durationMs: step.durationMs });
+    }
+  }
+  return timings;
+}
+
+function isBoundedTimingMs(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value >= 0 &&
+    value <= PACKAGED_UPGRADE_TIMING_MAX_MS
   );
 }
 

--- a/scripts/lib/cross-os-release-checks/lanes.ts
+++ b/scripts/lib/cross-os-release-checks/lanes.ts
@@ -7,7 +7,9 @@ import type {
   CommandResult,
   GatewayHandle,
   LaneBaseParams,
+  LaneResult,
   LaneState,
+  PackagedUpgradeFallbackEvidence,
   ProviderConfig,
 } from "./config.ts";
 import {
@@ -16,6 +18,7 @@ import {
   isRecoverableWindowsPackagedUpgradeSwapCleanupFailure,
   isRecoverableWindowsPackagedUpgradeTimeoutError,
   normalizeRequestedRef,
+  parsePackagedUpgradeUpdateTimings,
   resolveDevUpdateVerificationRef,
   resolveExpectedDevUpdateRef,
   shouldRunMainChannelDevUpdate,
@@ -204,6 +207,11 @@ export async function runUpgradeLane(
   const lane = createLaneState("upgrade");
   const cleanup: Cleanup[] = [];
   const gatewayHolder: { current: GatewayHandle | null } = { current: null };
+  const result: LaneResult = {
+    status: "pending",
+    phaseTimings: lane.phaseTimings,
+    updateTimings: [],
+  };
   try {
     const env = buildLaneEnv(lane, params.providerConfig, params.providerSecretValue);
     await runTimedLanePhase(lane, "install-baseline", async () => {
@@ -272,9 +280,17 @@ export async function runUpgradeLane(
     if (!updateResult) {
       throw new Error("Packaged update completed without a command result.");
     }
-    const usedWindowsPackagedUpgradeFallback =
-      usedWindowsPackagedUpgradeTimeoutFallback ||
-      isRecoverableWindowsPackagedUpgradeSwapCleanupFailure(updateResult, process.platform);
+    result.updateTimings = parsePackagedUpgradeUpdateTimings(updateResult.stdout);
+    const updateFallback: PackagedUpgradeFallbackEvidence | undefined =
+      usedWindowsPackagedUpgradeTimeoutFallback
+        ? { reason: "timeout", action: "direct-candidate-install" }
+        : isRecoverableWindowsPackagedUpgradeSwapCleanupFailure(updateResult, process.platform)
+          ? { reason: "swap-cleanup", action: "direct-candidate-install" }
+          : undefined;
+    if (updateFallback) {
+      result.updateFallback = updateFallback;
+    }
+    const usedWindowsPackagedUpgradeFallback = Boolean(updateFallback);
     if (usedWindowsPackagedUpgradeFallback) {
       await runTimedLanePhase(lane, "update-fallback-install", async () => {
         await installPackageSpec({
@@ -384,6 +400,7 @@ export async function runUpgradeLane(
     );
 
     return {
+      ...result,
       status: "pass",
       baselineVersion: baseline.version,
       installedVersion: installed.version,
@@ -391,7 +408,12 @@ export async function runUpgradeLane(
       dashboardStatus: "pass",
       gatewayPort: lane.gatewayPort,
       agentOutput: trimForSummary(agent.stdout),
-      phaseTimings: lane.phaseTimings,
+    };
+  } catch (error) {
+    return {
+      ...result,
+      status: "fail",
+      error: formatError(error),
     };
   } finally {
     await runCleanup(cleanup);

--- a/scripts/lib/cross-os-release-checks/reporting.ts
+++ b/scripts/lib/cross-os-release-checks/reporting.ts
@@ -18,6 +18,10 @@ export function writeSummary(baseDir: string, summaryPayload: SummaryPayload) {
     `- Source SHA: \`${summaryPayload.sourceSha || "unknown"}\``,
     `- Candidate version: \`${summaryPayload.candidateVersion || "unknown"}\``,
     `- Baseline spec: \`${summaryPayload.baselineSpec}\``,
+    summaryPayload.runnerLabel ? `- Runner: \`${summaryPayload.runnerLabel}\`` : "",
+    summaryPayload.runnerOs ? `- Runner OS: \`${summaryPayload.runnerOs}\`` : "",
+    summaryPayload.nodeVersion ? `- Node: \`${summaryPayload.nodeVersion}\`` : "",
+    summaryPayload.npmVersion ? `- npm: \`${summaryPayload.npmVersion}\`` : "",
     result.status ? `- Result: \`${result.status}\`` : "",
     result.installTarget ? `- Install target: \`${result.installTarget}\`` : "",
     result.installVersion ? `- Install version: \`${result.installVersion}\`` : "",
@@ -29,6 +33,9 @@ export function writeSummary(baseDir: string, summaryPayload: SummaryPayload) {
     result.dashboardStatus ? `- Dashboard: \`${result.dashboardStatus}\`` : "",
     result.discordStatus ? `- Discord: \`${result.discordStatus}\`` : "",
     result.agentOutput ? `- Agent output: \`${trimForSummary(result.agentOutput)}\`` : "",
+    result.updateFallback
+      ? `- Updater fallback: \`${result.updateFallback.reason}/${result.updateFallback.action}\``
+      : "",
     result.error ? `- Error: \`${trimForSummary(result.error)}\`` : "",
   ].filter(Boolean);
   if (Array.isArray(result.phaseTimings) && result.phaseTimings.length > 0) {
@@ -36,6 +43,12 @@ export function writeSummary(baseDir: string, summaryPayload: SummaryPayload) {
     for (const phase of result.phaseTimings) {
       const suffix = phase.status === "pass" ? "" : ` (${phase.status})`;
       lines.push(`- \`${phase.name}\`: ${Math.round(phase.durationMs / 1000)}s${suffix}`);
+    }
+  }
+  if (Array.isArray(result.updateTimings) && result.updateTimings.length > 0) {
+    lines.push("", "### Updater timings");
+    for (const timing of result.updateTimings) {
+      lines.push(`- \`${timing.name}\`: ${Math.round(timing.durationMs / 1000)}s`);
     }
   }
   writeFileSync(summaryMarkdownPath, `${lines.join("\n")}\n`, "utf8");

--- a/scripts/openclaw-cross-os-release-checks.ts
+++ b/scripts/openclaw-cross-os-release-checks.ts
@@ -14,14 +14,18 @@ import {
   resolveProviderConfig,
   resolveRunnerMatrix,
 } from "./lib/cross-os-release-checks/config.ts";
-import { prepareCandidate, readProvidedCandidate } from "./lib/cross-os-release-checks/install.ts";
+import {
+  npmCommand,
+  prepareCandidate,
+  readProvidedCandidate,
+} from "./lib/cross-os-release-checks/install.ts";
 import {
   runDevUpdateSuite,
   runFreshLane,
   runInstallerFreshSuite,
   runUpgradeLane,
 } from "./lib/cross-os-release-checks/lanes.ts";
-import { startStaticFileServer } from "./lib/cross-os-release-checks/process.ts";
+import { runCommand, startStaticFileServer } from "./lib/cross-os-release-checks/process.ts";
 import {
   requireArg,
   writeCandidateManifest,
@@ -149,6 +153,8 @@ async function main(argv: string[]) {
     platform: process.platform,
     runnerOs: process.env.OPENCLAW_RELEASE_CHECK_OS ?? "",
     runnerLabel: process.env.OPENCLAW_RELEASE_CHECK_RUNNER ?? "",
+    nodeVersion: process.version,
+    npmVersion: await readNpmVersion(logsDir),
     provider,
     mode,
     suite,
@@ -255,5 +261,18 @@ async function main(argv: string[]) {
 
   if (summary.result.status !== "pass") {
     process.exit(1);
+  }
+}
+
+async function readNpmVersion(logsDir: string) {
+  try {
+    const result = await runCommand(npmCommand(), ["--version"], {
+      logPath: join(logsDir, "npm-version.log"),
+      timeoutMs: 30_000,
+      check: false,
+    });
+    return result.exitCode === 0 ? result.stdout.trim() || "unknown" : "unknown";
+  } catch {
+    return "unknown";
   }
 }

--- a/test/scripts/openclaw-cross-os-release-checks-upgrade-lane.test.ts
+++ b/test/scripts/openclaw-cross-os-release-checks-upgrade-lane.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createScriptTestHarness } from "./test-helpers.js";
+
+const mocks = vi.hoisted(() => ({
+  ensureLocalNpmShim: vi.fn(),
+  installPackageSpec: vi.fn(),
+  installTarballPackage: vi.fn(),
+  readInstalledMetadata: vi.fn(),
+  readInstalledVersion: vi.fn(),
+  runAgentTurn: vi.fn(),
+  runBundledPluginPostinstall: vi.fn(),
+  runDashboardSmoke: vi.fn(),
+  runModelsSet: vi.fn(),
+  runOnboard: vi.fn(),
+  runOpenClaw: vi.fn(),
+  startGateway: vi.fn(),
+  stopGateway: vi.fn(),
+  waitForGateway: vi.fn(),
+}));
+
+vi.mock("../../scripts/lib/cross-os-release-checks/install.ts", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("../../scripts/lib/cross-os-release-checks/install.ts")
+  >()),
+  ensureLocalNpmShim: mocks.ensureLocalNpmShim,
+  installPackageSpec: mocks.installPackageSpec,
+  installTarballPackage: mocks.installTarballPackage,
+  readInstalledMetadata: mocks.readInstalledMetadata,
+  readInstalledVersion: mocks.readInstalledVersion,
+  runBundledPluginPostinstall: mocks.runBundledPluginPostinstall,
+}));
+
+vi.mock("../../scripts/lib/cross-os-release-checks/runtime.ts", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("../../scripts/lib/cross-os-release-checks/runtime.ts")
+  >()),
+  runAgentTurn: mocks.runAgentTurn,
+  runDashboardSmoke: mocks.runDashboardSmoke,
+  runModelsSet: mocks.runModelsSet,
+  runOnboard: mocks.runOnboard,
+  runOpenClaw: mocks.runOpenClaw,
+  startGateway: mocks.startGateway,
+  waitForGateway: mocks.waitForGateway,
+}));
+
+vi.mock("../../scripts/lib/cross-os-release-checks/process.ts", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("../../scripts/lib/cross-os-release-checks/process.ts")
+  >()),
+  stopGateway: mocks.stopGateway,
+}));
+
+import { runUpgradeLane } from "../../scripts/lib/cross-os-release-checks/lanes.ts";
+
+const { createTempDir } = createScriptTestHarness();
+
+const candidate = {
+  candidateTgz: "/tmp/openclaw-candidate.tgz",
+  candidateVersion: "2026.8.28-beta.1",
+  candidateFileName: "openclaw-candidate.tgz",
+  sourceDir: "/tmp/source",
+  sourceSha: "abc123",
+};
+
+let logsDir: string;
+
+function upgradeParams() {
+  return {
+    baselineSpec: "openclaw@2026.7.1",
+    baselineTgz: "",
+    build: candidate,
+    candidateUrl: "http://127.0.0.1:49951/openclaw-candidate.tgz",
+    companions: [],
+    logsDir,
+    providerConfig: {
+      extensionId: "openai",
+      secretEnv: "OPENAI_API_KEY",
+      authChoice: "openai-api-key",
+      model: "openai/gpt-5.6-luna",
+      requiredCompanionPackages: [],
+    },
+    providerSecretValue: "secret",
+  };
+}
+
+function arrangeSuccessfulLane() {
+  mocks.installPackageSpec.mockResolvedValue(undefined);
+  mocks.installTarballPackage.mockResolvedValue(undefined);
+  mocks.readInstalledVersion
+    .mockReturnValueOnce("2026.7.1")
+    .mockReturnValue(candidate.candidateVersion);
+  mocks.readInstalledMetadata.mockReturnValue({
+    version: candidate.candidateVersion,
+    commit: candidate.sourceSha,
+  });
+  mocks.runBundledPluginPostinstall.mockResolvedValue(undefined);
+  mocks.runOnboard.mockResolvedValue(undefined);
+  mocks.runModelsSet.mockResolvedValue(undefined);
+  mocks.startGateway.mockResolvedValue({
+    child: {},
+    closeLog: vi.fn(),
+    launchLogOffset: 0,
+    logPath: "/tmp/upgrade-gateway.log",
+    waitForClose: vi.fn(),
+  });
+  mocks.waitForGateway.mockResolvedValue(undefined);
+  mocks.runDashboardSmoke.mockResolvedValue(undefined);
+  mocks.runAgentTurn.mockResolvedValue({ exitCode: 0, stdout: "OK", stderr: "" });
+}
+
+describe("cross-OS packaged upgrade lane evidence", () => {
+  beforeEach(() => {
+    logsDir = createTempDir("openclaw-upgrade-lane-test-");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    for (const mock of Object.values(mocks)) {
+      mock.mockReset();
+    }
+  });
+
+  it("records bounded evidence when the supported Windows timeout fallback succeeds", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    arrangeSuccessfulLane();
+    mocks.runOpenClaw.mockRejectedValueOnce(
+      new Error(
+        "Command timed out: C:\\prefix\\node_modules\\openclaw\\openclaw.mjs update --tag http://127.0.0.1:49951/openclaw-candidate.tgz --yes --json --no-restart --timeout 600",
+      ),
+    );
+
+    const result = await runUpgradeLane(upgradeParams());
+
+    expect(result).toMatchObject({
+      status: "pass",
+      updateFallback: {
+        reason: "timeout",
+        action: "direct-candidate-install",
+      },
+      updateTimings: [],
+    });
+    expect(result.phaseTimings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "update", status: "pass" }),
+        expect.objectContaining({ name: "update-fallback-install", status: "pass" }),
+      ]),
+    );
+  });
+
+  it("retains sanitized updater timings when a later upgrade phase fails", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    arrangeSuccessfulLane();
+    mocks.runOpenClaw.mockResolvedValue({
+      exitCode: 0,
+      stdout: JSON.stringify({
+        durationMs: 622_000,
+        root: String.raw`C:\private\openclaw`,
+        steps: [
+          {
+            name: "global update",
+            command: "npm install --global secret-package",
+            durationMs: 461_000,
+          },
+        ],
+      }),
+      stderr: "",
+    });
+    mocks.runBundledPluginPostinstall
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("post-update plugin failure"));
+
+    const result = await runUpgradeLane(upgradeParams());
+
+    expect(result).toMatchObject({
+      status: "fail",
+      updateTimings: [
+        { name: "total", durationMs: 622_000 },
+        { name: "package-install", durationMs: 461_000 },
+      ],
+    });
+    expect(result.error).toContain("post-update plugin failure");
+    expect(result).not.toHaveProperty("updateFallback");
+    expect(result.phaseTimings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "update", status: "pass" }),
+        expect.objectContaining({ name: "run-bundled-plugin-postinstall", status: "fail" }),
+      ]),
+    );
+    expect(JSON.stringify(result)).not.toContain("private");
+    expect(JSON.stringify(result)).not.toContain("npm install");
+  });
+});

--- a/test/scripts/openclaw-cross-os-release-checks.test.ts
+++ b/test/scripts/openclaw-cross-os-release-checks.test.ts
@@ -66,6 +66,7 @@ import {
   normalizeWindowsCommandShimPath,
   normalizeWindowsInstalledCliPath,
   maybeBuildOptionalAgentTurnSkipResult,
+  parsePackagedUpgradeUpdateTimings,
   parsePositiveIntegerEnv,
   parseCrossOsSuiteFilter,
   parseArgs,
@@ -110,6 +111,7 @@ import {
   verifyWindowsPackagedUpgradeFallbackInstall,
   waitForGatewayWithStartupMigrationRestart,
   writePackageDistInventoryForCandidate,
+  writeSummary,
 } from "../../scripts/lib/cross-os-release-checks/index.ts";
 import { LOCAL_BUILD_METADATA_DIST_PATHS } from "../../scripts/lib/local-build-metadata-paths.mts";
 
@@ -793,6 +795,90 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
     expect(freshLaneSource).toContain('runTimedLanePhase(lane, "install-candidate"');
     expect(freshLaneSource).toContain('runTimedLanePhase(lane, "agent-turn"');
     expect(freshLaneSource).toContain("phaseTimings: lane.phaseTimings");
+  });
+
+  it("retains only bounded allowlisted packaged-upgrade timings", () => {
+    expect(
+      parsePackagedUpgradeUpdateTimings(
+        JSON.stringify({
+          durationMs: 622_000,
+          root: String.raw`C:\private\openclaw`,
+          steps: [
+            {
+              name: "global update",
+              command: "npm install --global secret-package",
+              cwd: String.raw`C:\private\prefix`,
+              durationMs: 461_000,
+            },
+            { name: "global install swap", durationMs: 39_000 },
+            { name: "openclaw doctor", durationMs: 66_000 },
+            { name: "unknown internal step", durationMs: 123_000 },
+          ],
+        }),
+      ),
+    ).toEqual([
+      { name: "total", durationMs: 622_000 },
+      { name: "package-install", durationMs: 461_000 },
+      { name: "staged-swap", durationMs: 39_000 },
+      { name: "doctor", durationMs: 66_000 },
+    ]);
+  });
+
+  it("drops malformed, unsafe, and out-of-bounds packaged-upgrade timings", () => {
+    expect(parsePackagedUpgradeUpdateTimings("not json")).toEqual([]);
+    expect(parsePackagedUpgradeUpdateTimings("[]")).toEqual([]);
+    expect(
+      parsePackagedUpgradeUpdateTimings(
+        JSON.stringify({
+          durationMs: 3_600_001,
+          steps: [
+            { name: "global update", durationMs: -1 },
+            { name: "global install swap", durationMs: 1.5 },
+            { name: "openclaw doctor", durationMs: "66000" },
+          ],
+        }),
+      ),
+    ).toEqual([]);
+  });
+
+  it("renders runner, runtime, and sanitized updater timing evidence", () => {
+    withTempDir("openclaw-cross-os-summary-", (dir) => {
+      writeSummary(dir, {
+        platform: "win32",
+        runnerOs: "Windows",
+        runnerLabel: "blacksmith-32vcpu-windows-2025",
+        nodeVersion: "v24.15.0",
+        npmVersion: "11.8.0",
+        provider: "openai",
+        suite: "packaged-upgrade",
+        mode: "upgrade",
+        sourceSha: "abc123",
+        candidateVersion: "2026.8.28-beta.1",
+        baselineSpec: "openclaw@2026.8.27",
+        result: {
+          status: "pass",
+          updateFallback: {
+            reason: "timeout",
+            action: "direct-candidate-install",
+          },
+          updateTimings: [
+            { name: "total", durationMs: 622_000 },
+            { name: "package-install", durationMs: 461_000 },
+          ],
+        },
+      });
+
+      const json = readFileSync(join(dir, "summary.json"), "utf8");
+      const markdown = readFileSync(join(dir, "summary.md"), "utf8");
+      expect(json).toContain('"runnerLabel": "blacksmith-32vcpu-windows-2025"');
+      expect(markdown).toContain("- Runner: `blacksmith-32vcpu-windows-2025`");
+      expect(markdown).toContain("- Node: `v24.15.0`");
+      expect(markdown).toContain("- npm: `11.8.0`");
+      expect(markdown).toContain("- Updater fallback: `timeout/direct-candidate-install`");
+      expect(markdown).toContain("- `package-install`: 461s");
+      expect(markdown).not.toContain("private");
+      expect(markdown).not.toContain("npm install");
+    });
   });
 
   it("accepts OK agent output from the captured log when stdout is empty", () => {


### PR DESCRIPTION
## Summary

- expose allowlisted updater subphase timings in cross-OS release-check summaries
- preserve sanitized timing evidence when a later upgrade phase fails
- record bounded Windows timeout-fallback evidence
- include runner, Node, and npm versions for comparable hosted-runner evidence

## Problem

Windows packaged upgrade is currently the Full Release Validation critical path, but its summary collapses the updater into one opaque phase. Recent evidence, including run `33159805726`, cannot distinguish package installation, staged swap, or doctor cost, and it lacks enough runner/runtime context for a fair hosted-runner comparison.

The first version also lost the new evidence on the supported Windows timeout fallback and when a later upgrade phase failed.

## Approach

Parse only the updater's known timing fields, require non-negative safe integers bounded to one hour, and discard unknown JSON fields. Carry the accumulated evidence in the lane result so later failures still produce useful summaries. Record timeout fallback as a bounded reason/action pair. No raw paths, commands, logs, package caches, or machine details are retained.

Release behavior is unchanged: failed lanes still produce a summary and exit nonzero.

## Validation

- 133 focused tests passed
- timeout-fallback and post-update failure regressions passed
- `pnpm check:script-erasability`
- `node scripts/report-test-temp-creations.mjs --base origin/main --head HEAD`
- targeted Oxfmt and Oxlint
- `pnpm check:temp-path-guardrails`
- `git diff --check`
- Sol autoreview clean at 0.98

`pnpm tsgo:scripts` is blocked in this sparse worktree by omitted tracked Control UI config modules and the existing shared `pako` declaration layout. Exact-head hosted CI runs the full-checkout type gate.

## Review Finding

ClawSweeper's P2 finding is addressed: sanitized updater timings now survive later lane failures, and supported Windows timeout fallback emits explicit bounded evidence. Both paths have focused regression coverage.

## LOC

- tooling: +134/-7
- tests: +278/-0
- production runtime: +0/-0
