### PR TITLE
fix(ci): restore ingress drain max-lines gate

### DIFF
--- a/src/channels/message/ingress-drain-state.ts
+++ b/src/channels/message/ingress-drain-state.ts
@@ -38,6 +38,37 @@ export type ActiveHandlerState<TPayload, TMetadata> = {
   settleOnce: (fn: () => Promise<void>) => Promise<void>;
 };
 
+export function createIngressSettleOwner<TPayload, TMetadata>(
+  state: ActiveHandlerState<TPayload, TMetadata>,
+  removeActive: (state: ActiveHandlerState<TPayload, TMetadata>) => void,
+): (fn: () => Promise<void>) => Promise<void> {
+  let settlePromise: Promise<void> | undefined;
+  let settled = false;
+  return async (fn) => {
+    if (settled) {
+      return;
+    }
+    if (settlePromise) {
+      await settlePromise;
+      return;
+    }
+    settlePromise = (async () => {
+      // Only mark settled after the tombstone/fail/release write commits.
+      // Write failure must keep heartbeat + in-memory ownership (wedged > duplicated).
+      await fn();
+      settled = true;
+      state.phase = "settled";
+      removeActive(state);
+    })();
+    try {
+      await settlePromise;
+    } catch (err) {
+      settlePromise = undefined;
+      throw err;
+    }
+  };
+}
+
 export function activeClaimKey<TPayload, TMetadata>(
   claim: ChannelIngressQueueClaim<TPayload, TMetadata>,
 ): string {

--- a/src/channels/message/ingress-drain.ts
+++ b/src/channels/message/ingress-drain.ts
@@ -23,6 +23,7 @@ import {
 import type { ChannelIngressDispatchLifecycle } from "./ingress-drain-lifecycle.js";
 import {
   activeClaimKey,
+  createIngressSettleOwner,
   IngressAdoptionLostError,
   isIngressAdoptionLostError,
   resolveLaneKey,
@@ -358,36 +359,6 @@ export function createChannelIngressDrain<
     await releaseClaim(claim, { lastError: disposition.message });
   };
 
-  const createSettleOwner = (
-    state: ActiveHandlerState<TPayload, TMetadata>,
-  ): ((fn: () => Promise<void>) => Promise<void>) => {
-    let settlePromise: Promise<void> | undefined;
-    let settled = false;
-    return async (fn) => {
-      if (settled) {
-        return;
-      }
-      if (settlePromise) {
-        await settlePromise;
-        return;
-      }
-      settlePromise = (async () => {
-        // Only mark settled after the tombstone/fail/release write commits.
-        // Write failure must keep heartbeat + in-memory ownership (wedged > duplicated).
-        await fn();
-        settled = true;
-        state.phase = "settled";
-        removeActive(state);
-      })();
-      try {
-        await settlePromise;
-      } catch (err) {
-        settlePromise = undefined;
-        throw err;
-      }
-    };
-  };
-
   const armStallWatchdog = (state: ActiveHandlerState<TPayload, TMetadata>) => {
     clearStallTimer(state);
     state.stallTimer = setTimeout(() => {
@@ -551,7 +522,7 @@ export function createChannelIngressDrain<
       task: Promise.resolve(),
       settleOnce: async () => {},
     } as ActiveHandlerState<TPayload, TMetadata>;
-    state.settleOnce = createSettleOwner(state);
+    state.settleOnce = createIngressSettleOwner(state, removeActive);
     const lifecycle = createLifecycle(state);
     armStallWatchdog(state);
     armClaimRefresh(state);


### PR DESCRIPTION
## What Problem This Solves

Fixes the current `main` core lint failure where `src/channels/message/ingress-drain.ts` exceeds the max-lines ratchet after independently landed ingress changes compose.

## Why This Change Was Made

Moves the existing single-settlement owner into the adjacent ingress state owner and passes the existing active-state removal callback explicitly. Settlement ordering, retry behavior, and lifecycle ownership are unchanged.

## User Impact

No runtime behavior change. This restores exact-head CI so unrelated fixes can be validated and landed.

## Evidence

- `node scripts/run-vitest.mjs` across the eight ingress drain/lifecycle suites: 42 passed
- `pnpm check:max-lines-ratchet --base origin/main`
- `pnpm tsgo:core`
- targeted Oxlint and Oxfmt
- `git diff --check`
- autoreview: clean

Production LOC: +33/-31 (net +2) | Tests: +0/-0
