### PR TITLE
fix(agents): restore collector output and prepared harness execution

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -13,13 +13,6 @@ import {
 import { readMemoryArtifactProvenance } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import { createAgentHarnessHostCapabilitiesForTest } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  addSubagentRunForTests,
-  getSubagentRunByRunId,
-  resetSubagentRegistryForTests,
-  testing as registryTesting,
-} from "../../../../src/agents/subagents/registry/subagent-registry.test-helpers.js";
-import { consumeSwarmStructuredOutput } from "../../../../src/agents/tools/structured-output-tool.js";
 import { dynamicToolBuildState } from "./dynamic-tool-build-state.js";
 import {
   buildDynamicTools,
@@ -869,133 +862,75 @@ describe("Codex app-server dynamic tool build", () => {
     expect(receivedOptions).toMatchObject({ taskSuggestionDeliveryMode: "gateway" });
   });
 
-  it.each([
-    { label: "structured child", collector: true, toolsAllow: undefined },
-    { label: "structured child with read-only allowlist", collector: true, toolsAllow: ["read"] },
-    { label: "structured child with empty allowlist", collector: true, toolsAllow: [] },
-    { label: "ordinary child", collector: false, toolsAllow: undefined },
-    { label: "ordinary child with read-only allowlist", collector: false, toolsAllow: ["read"] },
-  ])("preserves swarm collector tool contract for $label", async ({ collector, toolsAllow }) => {
-    const workspaceDir = path.join(tempDir, "workspace");
-    const params = createParams(path.join(tempDir, "collector-session.jsonl"), workspaceDir);
-    params.disableTools = false;
-    params.disableMessageTool = true;
-    params.sessionKey = "agent:main:subagent:collector-contract";
-    params.runId = "codex-collector-contract";
-    params.runtimePlan = createCodexRuntimePlanFixture();
-    params.config = {
-      agents: { entries: { main: { default: true } } },
-      tools: { swarm: true },
-    };
-    params.toolsAllow = toolsAllow;
-    params.swarmCollector = collector;
-    // The selection boundary prepares this marker for collector attempts.
-    params.pluginHarnessToolPolicyRestricted = collector;
-    params.swarmOutputSchema = {
-      type: "object",
-      properties: { answer: { type: "string" } },
-      required: ["answer"],
-      additionalProperties: false,
-    };
-    // The production host must build core tools from Codex's options; injecting
-    // collector fields inside a replacement factory hides a dropped handoff.
-    const { hostCapabilities: _hostCapabilities, ...attempt } = params;
-    const host = await createAgentHarnessHostCapabilitiesForTest({ attempt, pluginId: "codex" });
-    params.hostCapabilities = host.capabilities;
-
-    try {
-      resetSubagentRegistryForTests({ persist: false });
-      registryTesting.setDepsForTest({ persistSubagentRunsToDiskOrThrow: vi.fn() });
-      addSubagentRunForTests({
-        runId: params.runId,
-        childSessionKey: params.sessionKey,
-        collect: collector,
-        outputSchema: params.swarmOutputSchema,
-      });
+  it.each([{ toolsAllow: undefined }, { toolsAllow: ["read"] }, { toolsAllow: [] }])(
+    "preserves the collector handoff and dynamic tool through allowlist %j",
+    async ({ toolsAllow }) => {
+      const workspaceDir = path.join(tempDir, "workspace");
+      const params = createParams(path.join(tempDir, "collector-session.jsonl"), workspaceDir);
+      params.disableTools = false;
+      params.runtimePlan = createCodexRuntimePlanFixture();
+      params.toolsAllow = toolsAllow;
+      params.swarmCollector = true;
+      params.pluginHarnessToolPolicyRestricted = true;
+      params.swarmOutputSchema = {
+        type: "object",
+        properties: { answer: { type: "string" } },
+        required: ["answer"],
+      };
+      // An independent host result: the factory must not repair dropped attempt fields.
+      const output = {
+        ...createRuntimeDynamicTool("structured_output"),
+        catalogMode: "direct-only" as const,
+      };
+      const factory = vi.fn(() => [createRuntimeDynamicTool("read"), output]);
+      setOpenClawCodingToolsFactoryForTests(factory);
       const tools = await buildDynamicToolsForTest(params, workspaceDir, {
-        sandbox: null as never,
+        sandbox: null,
         nativeToolSurfaceEnabled: shouldEnableCodexAppServerNativeToolSurface(params),
       });
-      const names = tools.map((tool) => tool.name);
-      if (toolsAllow) {
-        expect
-          .soft(names.toSorted())
-          .toEqual([...toolsAllow, ...(collector ? ["structured_output"] : [])].toSorted());
-      }
-      if (!collector) {
-        expect(names).not.toContain("structured_output");
-        if (!toolsAllow) {
-          expect(names).toEqual(expect.arrayContaining(["web_fetch", "sessions_yield"]));
-        }
-        return;
-      }
-      for (const forbidden of ["ask_user", "sessions_send", "sessions_yield", "message"]) {
-        expect.soft(names).not.toContain(forbidden);
-      }
+
+      expect(factory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          swarmCollector: true,
+          swarmOutputSchema: params.swarmOutputSchema,
+          ...(toolsAllow ? { runtimeToolAllowlist: [...toolsAllow, "structured_output"] } : {}),
+        }),
+      );
       expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
-      if (!toolsAllow) {
-        expect(names).toEqual(
-          expect.arrayContaining(["read", "write", "edit", "apply_patch", "exec", "process"]),
-        );
-        await fs.mkdir(workspaceDir, { recursive: true });
-        const write = expectDefined(
-          tools.find((tool) => tool.name === "write"),
-          "collector workspace write tool",
-        );
-        await write.execute("collector-write", {
-          path: "result.txt",
-          content: "collector file proof",
-        });
-        const read = expectDefined(
-          tools.find((tool) => tool.name === "read"),
-          "collector workspace read tool",
-        );
-        const readResult = await read.execute("collector-read", { path: "result.txt" });
-        expect(readResult.content).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({
-              type: "text",
-              text: expect.stringContaining("collector file proof"),
-            }),
-          ]),
-        );
-      }
+      expect(tools.map((tool) => tool.name).toSorted()).toEqual(
+        [...(toolsAllow ?? ["read"]), "structured_output"].toSorted(),
+      );
       const bridge = createCodexDynamicToolBridge({
         tools,
         signal: new AbortController().signal,
       });
-      const outputSpec = flattenCodexDynamicToolFunctions(bridge.specs).find(
-        (tool) => tool.name === "structured_output",
+      const outputSpec = expectDefined(
+        flattenCodexDynamicToolFunctions(bridge.specs).find(
+          (tool) => tool.name === "structured_output",
+        ),
+        "collector dynamic tool spec",
       );
-      expect(outputSpec, "collector must advertise structured_output").toBeDefined();
-      expect(outputSpec).not.toHaveProperty("deferLoading", true);
+      expect(outputSpec.deferLoading).not.toBe(true);
+      const args = { result: { answer: "ok" } };
       const response = await bridge.handleToolCall({
         threadId: "collector-thread",
         turnId: "collector-turn",
         tool: "structured_output",
         callId: "collector-result",
-        arguments: { result: { answer: "ok" } },
+        arguments: args,
       });
-      expect(response.success).toBe(true);
-      const text = expectDefined(
-        response.contentItems.find((item) => item.type === "inputText"),
-        "structured_output response text",
+      expect(response).toMatchObject({
+        success: true,
+        contentItems: [{ type: "inputText", text: "structured_output done" }],
+      });
+      expect(output.execute).toHaveBeenCalledWith(
+        "collector-result",
+        args,
+        expect.any(AbortSignal),
+        undefined,
       );
-      if (!("text" in text) || typeof text.text !== "string") {
-        throw new Error("Expected structured_output text response");
-      }
-      expect(JSON.parse(text.text)).toEqual({ status: "recorded" });
-      expect(getSubagentRunByRunId(params.runId)?.structuredOutput).toEqual({
-        structured: { answer: "ok" },
-        invalidAttempts: 0,
-      });
-    } finally {
-      host.close();
-      consumeSwarmStructuredOutput(params.runId);
-      resetSubagentRegistryForTests({ persist: false });
-      registryTesting.setDepsForTest();
-    }
-  });
+    },
+  );
 
   it("preserves the host-provided OpenClaw tool through the Codex allowlist", async () => {
     const workspaceDir = path.join(tempDir, "workspace");

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -13,6 +13,13 @@ import {
 import { readMemoryArtifactProvenance } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import { createAgentHarnessHostCapabilitiesForTest } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  addSubagentRunForTests,
+  getSubagentRunByRunId,
+  resetSubagentRegistryForTests,
+  testing as registryTesting,
+} from "../../../../src/agents/subagents/registry/subagent-registry.test-helpers.js";
+import { consumeSwarmStructuredOutput } from "../../../../src/agents/tools/structured-output-tool.js";
 import { dynamicToolBuildState } from "./dynamic-tool-build-state.js";
 import {
   buildDynamicTools,
@@ -633,10 +640,22 @@ describe("Codex app-server dynamic tool build", () => {
     {
       mode: "guarded" as const,
       execMode: "ask" as const,
+      command: "echo allowed",
+      expected: { status: "completed" },
+    },
+    {
+      mode: "guarded" as const,
+      execMode: "ask" as const,
+      command: "echo approval required",
       expected: { status: "failed", failureKind: "approval_required" },
     },
-    { mode: "full" as const, execMode: "full" as const, expected: { status: "completed" } },
-  ])("enforces the final $mode policy for an allowlisted Gateway command", async (testCase) => {
+    {
+      mode: "full" as const,
+      execMode: "full" as const,
+      command: "echo approval required",
+      expected: { status: "completed" },
+    },
+  ])("enforces $mode collector policy for $command", async (testCase) => {
     const workspaceDir = path.join(tempDir, `${testCase.mode}-allowlisted-workspace`);
     await fs.mkdir(workspaceDir, { recursive: true });
     const params = createParams(
@@ -644,22 +663,22 @@ describe("Codex app-server dynamic tool build", () => {
       workspaceDir,
     );
     params.disableTools = false;
+    params.swarmCollector = true;
+    params.pluginHarnessToolPolicyRestricted = true;
     params.permissionMode = testCase.mode;
     params.sessionRoot = workspaceDir;
     params.execOverrides = { host: "gateway", mode: testCase.execMode };
+    // Guarded mode asks only on an allowlist miss; two arguments exceed this profile.
     params.config = {
       tools: { exec: { safeBins: ["echo"], safeBinProfiles: { echo: { maxPositional: 1 } } } },
     };
     params.runtimePlan = createCodexRuntimePlanFixture();
     setOpenClawCodingToolsFactoryForTests((options) =>
-      createOpenClawCodingTools({
-        ...options,
-        swarmCollector: true,
-        wrapBeforeToolCallHook: false,
-      }).filter((tool) => ["exec", "process"].includes(tool.name)),
+      createOpenClawCodingTools(options).filter((tool) => ["exec", "process"].includes(tool.name)),
     );
 
     const tools = await buildDynamicToolsForTest(params, workspaceDir, {
+      nativeToolSurfaceEnabled: shouldEnableCodexAppServerNativeToolSurface(params),
       sessionPermissionPolicy: {
         mode: testCase.mode,
         root: workspaceDir,
@@ -667,11 +686,11 @@ describe("Codex app-server dynamic tool build", () => {
       },
     });
     const gatewayExec = expectDefined(
-      tools.find((tool) => tool.name === "gateway_exec"),
-      `${testCase.mode} Gateway shell alias`,
+      tools.find((tool) => tool.name === "exec"),
+      `${testCase.mode} OpenClaw shell replacement`,
     );
     const result = await gatewayExec.execute(`${testCase.mode}-allowlisted`, {
-      command: `echo ${testCase.mode}`,
+      command: testCase.command,
       ask: "off",
       security: "full",
     });
@@ -848,6 +867,134 @@ describe("Codex app-server dynamic tool build", () => {
     await buildDynamicToolsForTest(params, workspaceDir);
 
     expect(receivedOptions).toMatchObject({ taskSuggestionDeliveryMode: "gateway" });
+  });
+
+  it.each([
+    { label: "structured child", collector: true, toolsAllow: undefined },
+    { label: "structured child with read-only allowlist", collector: true, toolsAllow: ["read"] },
+    { label: "structured child with empty allowlist", collector: true, toolsAllow: [] },
+    { label: "ordinary child", collector: false, toolsAllow: undefined },
+    { label: "ordinary child with read-only allowlist", collector: false, toolsAllow: ["read"] },
+  ])("preserves swarm collector tool contract for $label", async ({ collector, toolsAllow }) => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "collector-session.jsonl"), workspaceDir);
+    params.disableTools = false;
+    params.disableMessageTool = true;
+    params.sessionKey = "agent:main:subagent:collector-contract";
+    params.runId = "codex-collector-contract";
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    params.config = {
+      agents: { entries: { main: { default: true } } },
+      tools: { swarm: true },
+    };
+    params.toolsAllow = toolsAllow;
+    params.swarmCollector = collector;
+    // The selection boundary prepares this marker for collector attempts.
+    params.pluginHarnessToolPolicyRestricted = collector;
+    params.swarmOutputSchema = {
+      type: "object",
+      properties: { answer: { type: "string" } },
+      required: ["answer"],
+      additionalProperties: false,
+    };
+    // The production host must build core tools from Codex's options; injecting
+    // collector fields inside a replacement factory hides a dropped handoff.
+    const { hostCapabilities: _hostCapabilities, ...attempt } = params;
+    const host = await createAgentHarnessHostCapabilitiesForTest({ attempt, pluginId: "codex" });
+    params.hostCapabilities = host.capabilities;
+
+    try {
+      resetSubagentRegistryForTests({ persist: false });
+      registryTesting.setDepsForTest({ persistSubagentRunsToDiskOrThrow: vi.fn() });
+      addSubagentRunForTests({
+        runId: params.runId,
+        childSessionKey: params.sessionKey,
+        collect: collector,
+        outputSchema: params.swarmOutputSchema,
+      });
+      const tools = await buildDynamicToolsForTest(params, workspaceDir, {
+        sandbox: null as never,
+        nativeToolSurfaceEnabled: shouldEnableCodexAppServerNativeToolSurface(params),
+      });
+      const names = tools.map((tool) => tool.name);
+      if (toolsAllow) {
+        expect
+          .soft(names.toSorted())
+          .toEqual([...toolsAllow, ...(collector ? ["structured_output"] : [])].toSorted());
+      }
+      if (!collector) {
+        expect(names).not.toContain("structured_output");
+        if (!toolsAllow) {
+          expect(names).toEqual(expect.arrayContaining(["web_fetch", "sessions_yield"]));
+        }
+        return;
+      }
+      for (const forbidden of ["ask_user", "sessions_send", "sessions_yield", "message"]) {
+        expect.soft(names).not.toContain(forbidden);
+      }
+      expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+      if (!toolsAllow) {
+        expect(names).toEqual(
+          expect.arrayContaining(["read", "write", "edit", "apply_patch", "exec", "process"]),
+        );
+        await fs.mkdir(workspaceDir, { recursive: true });
+        const write = expectDefined(
+          tools.find((tool) => tool.name === "write"),
+          "collector workspace write tool",
+        );
+        await write.execute("collector-write", {
+          path: "result.txt",
+          content: "collector file proof",
+        });
+        const read = expectDefined(
+          tools.find((tool) => tool.name === "read"),
+          "collector workspace read tool",
+        );
+        const readResult = await read.execute("collector-read", { path: "result.txt" });
+        expect(readResult.content).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              type: "text",
+              text: expect.stringContaining("collector file proof"),
+            }),
+          ]),
+        );
+      }
+      const bridge = createCodexDynamicToolBridge({
+        tools,
+        signal: new AbortController().signal,
+      });
+      const outputSpec = flattenCodexDynamicToolFunctions(bridge.specs).find(
+        (tool) => tool.name === "structured_output",
+      );
+      expect(outputSpec, "collector must advertise structured_output").toBeDefined();
+      expect(outputSpec).not.toHaveProperty("deferLoading", true);
+      const response = await bridge.handleToolCall({
+        threadId: "collector-thread",
+        turnId: "collector-turn",
+        tool: "structured_output",
+        callId: "collector-result",
+        arguments: { result: { answer: "ok" } },
+      });
+      expect(response.success).toBe(true);
+      const text = expectDefined(
+        response.contentItems.find((item) => item.type === "inputText"),
+        "structured_output response text",
+      );
+      if (!("text" in text) || typeof text.text !== "string") {
+        throw new Error("Expected structured_output text response");
+      }
+      expect(JSON.parse(text.text)).toEqual({ status: "recorded" });
+      expect(getSubagentRunByRunId(params.runId)?.structuredOutput).toEqual({
+        structured: { answer: "ok" },
+        invalidAttempts: 0,
+      });
+    } finally {
+      host.close();
+      consumeSwarmStructuredOutput(params.runId);
+      resetSubagentRegistryForTests({ persist: false });
+      registryTesting.setDepsForTest();
+    }
   });
 
   it("preserves the host-provided OpenClaw tool through the Codex allowlist", async () => {

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -254,6 +254,10 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
   const messagePolicyParams = input.ignoreDisableMessageTool
     ? { ...params, disableMessageTool: false }
     : params;
+  const toolRunContext = buildEmbeddedAttemptToolRunContext({
+    ...params,
+    forceMessageTool: shouldForceMessageTool(messagePolicyParams),
+  });
   if (params.disableTools) {
     input.onWebSearchPolicyResolved?.(false);
     return [];
@@ -291,7 +295,7 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
     );
     const options: OpenClawCodingToolsOptions = {
       agentId: input.sessionAgentId,
-      ...buildEmbeddedAttemptToolRunContext(params),
+      ...toolRunContext,
       exec: {
         ...params.execOverrides,
         ...(input.sessionPermissionPolicy ? { mode: input.sessionPermissionPolicy.execMode } : {}),
@@ -508,8 +512,10 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
         transientWebSearchRestriction &&
         webSearchPolicy.persistentAllowed),
   );
-  const toolsAllow = includeForcedCodexDynamicToolAllow(params.toolsAllow, messagePolicyParams);
-  const filteredTools = filterCodexDynamicToolsForAllowlist(visionFilteredTools, toolsAllow);
+  const filteredTools = filterCodexDynamicToolsForAllowlist(
+    visionFilteredTools,
+    toolRunContext.runtimeToolAllowlist,
+  );
   toolBuildStages.mark("allowlist-filter");
   const normalizedTools = normalizeAgentRuntimeTools({
     runtimePlan: input.ignoreRuntimePlan ? undefined : params.runtimePlan,
@@ -626,27 +632,6 @@ function addGatewayShellDynamicToolsIfAvailable(
   }
   return [...filteredTools, ...toolsToAppend];
 }
-/** Preserves delivery-critical tools when a narrow allowlist would otherwise hide them. */
-function includeForcedCodexDynamicToolAllow(
-  toolsAllow: string[] | undefined,
-  params: EmbeddedRunAttemptParams,
-): string[] | undefined {
-  if (toolsAllow === undefined || hasWildcardCodexToolsAllow(toolsAllow)) {
-    return toolsAllow;
-  }
-  const forcedToolNames = shouldForceMessageTool(params) ? ["message"] : [];
-  if (forcedToolNames.length === 0) {
-    return toolsAllow;
-  }
-  if (toolsAllow.length === 0) {
-    return forcedToolNames;
-  }
-  const normalized = new Set(toolsAllow.map((name) => normalizeCodexDynamicToolName(name)));
-  const missingToolNames = forcedToolNames.filter(
-    (toolName) => !normalized.has(normalizeCodexDynamicToolName(toolName)),
-  );
-  return missingToolNames.length === 0 ? toolsAllow : [...toolsAllow, ...missingToolNames];
-}
 /** Decides whether Codex native code mode can own shell/file tools for this turn. */
 export function shouldEnableCodexAppServerNativeToolSurface(
   params: EmbeddedRunAttemptParams,
@@ -675,7 +660,7 @@ export function shouldEnableCodexAppServerNativeToolSurface(
   ) {
     return false;
   }
-  const toolsAllow = includeForcedCodexDynamicToolAllow(params.toolsAllow, params);
+  const toolsAllow = params.toolsAllow;
   if (toolsAllow === undefined) {
     return canCodexAppServerNativeToolSurfaceHonorSandbox(sandbox, options);
   }

--- a/extensions/copilot/index.test.ts
+++ b/extensions/copilot/index.test.ts
@@ -1,7 +1,13 @@
 // Copilot tests cover index plugin behavior.
 import fs from "node:fs";
-import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
-import { describe, expect, it, vi } from "vitest";
+import { createTestPluginApi, type TestPluginApiInput } from "openclaw/plugin-sdk/plugin-test-api";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./src/runtime.js", () => ({
+  createCopilotClientPool: vi.fn(() => {
+    throw new Error("registration and stored-session reset must not start the SDK pool");
+  }),
+}));
 
 vi.mock("./harness.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./harness.js")>();
@@ -11,8 +17,9 @@ vi.mock("./harness.js", async (importOriginal) => {
   };
 });
 
-import { createCopilotAgentHarness } from "./harness.js";
+import { createCopilotAgentHarness, type CopilotSessionBinding } from "./harness.js";
 import plugin from "./index.js";
+import { createCopilotClientPool } from "./src/runtime.js";
 
 function loadManifest(): Record<string, unknown> {
   return JSON.parse(
@@ -20,12 +27,19 @@ function loadManifest(): Record<string, unknown> {
   ) as Record<string, unknown>;
 }
 
-function registerWithPluginConfig(pluginConfig: Record<string, unknown> | undefined) {
-  const registerAgentHarness = vi.fn();
+function registerWithPluginConfig(
+  pluginConfig: Record<string, unknown> | undefined,
+  registrationMode: TestPluginApiInput["registrationMode"] = "full",
+) {
+  const registerAgentHarness =
+    vi.fn<(harness: ReturnType<typeof createCopilotAgentHarness>) => void>();
+  const entries = new Map<string, CopilotSessionBinding>();
   const sessionStore = {
-    register: vi.fn(),
-    lookup: vi.fn(),
-    delete: vi.fn(),
+    register: vi.fn((key: string, value: CopilotSessionBinding) => {
+      entries.set(key, value);
+    }),
+    lookup: vi.fn((key: string) => entries.get(key)),
+    delete: vi.fn((key: string) => entries.delete(key)),
   };
   const openSyncKeyedStore = vi.fn(() => sessionStore);
   plugin.register(
@@ -35,23 +49,20 @@ function registerWithPluginConfig(pluginConfig: Record<string, unknown> | undefi
       source: "test",
       config: {},
       pluginConfig,
+      registrationMode,
       runtime: { state: { openSyncKeyedStore } } as never,
       registerAgentHarness,
     }),
   );
-  const harness = registerAgentHarness.mock.calls.at(0)?.at(0) as {
-    id: string;
-    label: string;
-    supports(ctx: {
-      provider: string;
-      modelId?: string;
-      requestedRuntime?: string;
-    }): { supported: true; priority?: number } | { supported: false; reason?: string };
-  };
-  return { registerAgentHarness, harness, openSyncKeyedStore, sessionStore };
+  const harness = registerAgentHarness.mock.calls[0]?.[0];
+  return { registerAgentHarness, harness, openSyncKeyedStore, sessionStore, entries };
 }
 
 describe("copilot plugin", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("is opt-in by default and only declares an agent harness activation", () => {
     const manifest = loadManifest();
     const activation = manifest.activation as Record<string, unknown>;
@@ -64,66 +75,91 @@ describe("copilot plugin", () => {
     expect(manifest.version).not.toBe("");
   });
 
-  it("registers exactly one copilot agent harness and nothing else", () => {
-    const registerAgentHarness = vi.fn();
-    const registerProvider = vi.fn();
-    const registerModelCatalogProvider = vi.fn();
-    const registerMediaUnderstandingProvider = vi.fn();
-    const registerMigrationProvider = vi.fn();
-    const registerCommand = vi.fn();
-    const registerNodeHostCommand = vi.fn();
-    const registerNodeInvokePolicy = vi.fn();
-    const on = vi.fn();
-    const onConversationBindingResolved = vi.fn();
+  it.each(["full", "discovery", "tool-discovery"] as const)(
+    "registers exactly one inert copilot agent harness in %s mode",
+    (registrationMode) => {
+      const registerAgentHarness = vi.fn();
+      const registerProvider = vi.fn();
+      const registerModelCatalogProvider = vi.fn();
+      const registerMediaUnderstandingProvider = vi.fn();
+      const registerMigrationProvider = vi.fn();
+      const registerCommand = vi.fn();
+      const registerNodeHostCommand = vi.fn();
+      const registerNodeInvokePolicy = vi.fn();
+      const on = vi.fn();
+      const onConversationBindingResolved = vi.fn();
+      const openSyncKeyedStore = vi.fn(() => {
+        throw new Error("registration must not open state");
+      });
 
-    plugin.register(
-      createTestPluginApi({
-        id: "copilot",
-        name: "GitHub Copilot agent runtime",
-        source: "test",
-        config: {},
-        pluginConfig: {},
-        runtime: { state: { openSyncKeyedStore: vi.fn(() => ({})) } } as never,
-        registerAgentHarness,
-        registerProvider,
-        registerModelCatalogProvider,
-        registerMediaUnderstandingProvider,
-        registerMigrationProvider,
-        registerCommand,
-        registerNodeHostCommand,
-        registerNodeInvokePolicy,
-        on,
-        onConversationBindingResolved,
-      }),
-    );
+      plugin.register(
+        createTestPluginApi({
+          id: "copilot",
+          name: "GitHub Copilot agent runtime",
+          source: "test",
+          config: {},
+          pluginConfig: {},
+          registrationMode,
+          runtime: { state: { openSyncKeyedStore } } as never,
+          registerAgentHarness,
+          registerProvider,
+          registerModelCatalogProvider,
+          registerMediaUnderstandingProvider,
+          registerMigrationProvider,
+          registerCommand,
+          registerNodeHostCommand,
+          registerNodeInvokePolicy,
+          on,
+          onConversationBindingResolved,
+        }),
+      );
 
-    expect(registerAgentHarness).toHaveBeenCalledTimes(1);
-    expect(registerAgentHarness).toHaveBeenCalledWith(
-      expect.objectContaining({ id: "copilot", label: "GitHub Copilot agent runtime" }),
-    );
-    expect(registerProvider).not.toHaveBeenCalled();
-    expect(registerModelCatalogProvider).not.toHaveBeenCalled();
-    expect(registerMediaUnderstandingProvider).not.toHaveBeenCalled();
-    expect(registerMigrationProvider).not.toHaveBeenCalled();
-    expect(registerCommand).not.toHaveBeenCalled();
-    expect(registerNodeHostCommand).not.toHaveBeenCalled();
-    expect(registerNodeInvokePolicy).not.toHaveBeenCalled();
-    expect(on).not.toHaveBeenCalled();
-    expect(onConversationBindingResolved).not.toHaveBeenCalled();
-  });
+      expect(registerAgentHarness).toHaveBeenCalledTimes(1);
+      expect(registerAgentHarness).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "copilot", label: "GitHub Copilot agent runtime" }),
+      );
+      expect(registerProvider).not.toHaveBeenCalled();
+      expect(registerModelCatalogProvider).not.toHaveBeenCalled();
+      expect(registerMediaUnderstandingProvider).not.toHaveBeenCalled();
+      expect(registerMigrationProvider).not.toHaveBeenCalled();
+      expect(registerCommand).not.toHaveBeenCalled();
+      expect(registerNodeHostCommand).not.toHaveBeenCalled();
+      expect(registerNodeInvokePolicy).not.toHaveBeenCalled();
+      expect(on).not.toHaveBeenCalled();
+      expect(onConversationBindingResolved).not.toHaveBeenCalled();
+      expect(openSyncKeyedStore).not.toHaveBeenCalled();
+      expect(createCopilotClientPool).not.toHaveBeenCalled();
+    },
+  );
 
-  it("registers a harness hard-bound to the canonical github-copilot provider", () => {
+  it.each(["cli-metadata", "setup-only", "setup-runtime"] as const)(
+    "skips harness and state registration in %s mode",
+    (registrationMode) => {
+      const { registerAgentHarness, openSyncKeyedStore } = registerWithPluginConfig(
+        {},
+        registrationMode,
+      );
+
+      expect(registerAgentHarness).not.toHaveBeenCalled();
+      expect(openSyncKeyedStore).not.toHaveBeenCalled();
+      expect(createCopilotAgentHarness).not.toHaveBeenCalled();
+      expect(createCopilotClientPool).not.toHaveBeenCalled();
+    },
+  );
+
+  it("supports github-copilot and rejects providers without BYOK ownership facts", () => {
     const { harness } = registerWithPluginConfig({});
+    expect(harness).toBeDefined();
 
     expect(
-      harness.supports({
+      harness!.supports({
         provider: "github-copilot",
         modelId: "gpt-4.1",
         requestedRuntime: "copilot",
       }),
     ).toEqual({ supported: true, priority: 100 });
     expect(
-      harness.supports({
+      harness!.supports({
         provider: "anthropic",
         modelId: "claude-sonnet-4.5",
         requestedRuntime: "copilot",
@@ -148,16 +184,37 @@ describe("copilot plugin", () => {
     expect(createHarness.mock.calls[1]?.[0]).not.toHaveProperty("poolOptions");
   });
 
-  it("opens the durable Copilot SDK session binding store", () => {
-    const createHarness = vi.mocked(createCopilotAgentHarness);
-    createHarness.mockClear();
-    const { openSyncKeyedStore, sessionStore } = registerWithPluginConfig({});
+  it("lazily opens and reuses the durable store when a discovered harness resets a stored session", async () => {
+    const { harness, openSyncKeyedStore, sessionStore, entries } = registerWithPluginConfig(
+      {},
+      "discovery",
+    );
+    expect(harness).toBeDefined();
+    expect(openSyncKeyedStore).not.toHaveBeenCalled();
+    entries.set("stored-session", {
+      schemaVersion: 2,
+      sdkSessionId: "sdk-session",
+      compatKey: "compat",
+      compactKey: "compact",
+      authMode: "useLoggedInUser",
+      updatedAt: 1,
+    });
+
+    await harness!.reset!({ sessionId: "stored-session" });
 
     expect(openSyncKeyedStore).toHaveBeenCalledWith({
       namespace: "sdk-sessions",
       maxEntries: 5000,
       defaultTtlMs: 90 * 24 * 60 * 60 * 1000,
     });
-    expect(createHarness).toHaveBeenCalledWith(expect.objectContaining({ sessionStore }));
+    expect(sessionStore.lookup).toHaveBeenCalledWith("stored-session");
+    expect(sessionStore.delete).toHaveBeenCalledWith("stored-session");
+    expect(entries.has("stored-session")).toBe(false);
+
+    await harness!.reset!({ sessionId: "stored-session" });
+    await harness!.dispose?.();
+    expect(openSyncKeyedStore).toHaveBeenCalledTimes(1);
+    expect(sessionStore.delete).toHaveBeenCalledTimes(1);
+    expect(createCopilotClientPool).not.toHaveBeenCalled();
   });
 });

--- a/extensions/copilot/index.ts
+++ b/extensions/copilot/index.ts
@@ -1,5 +1,6 @@
 // Copilot plugin entrypoint registers its OpenClaw integration.
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { createCopilotAgentHarness, type CopilotSessionBinding } from "./harness.js";
 
@@ -26,24 +27,32 @@ export default definePluginEntry({
   name: "GitHub Copilot agent runtime",
   description: "Registers the GitHub Copilot agent runtime.",
   register(api) {
-    // Copilot is a full-runtime plugin (registers an agent harness).
-    // Metadata-only registration paths (discovery, cli-metadata, setup-only)
-    // cannot supply a durable session store — skip registration here and let
-    // the full gateway activation path pick it up later.
-    if (api.registrationMode !== "full") {
+    if (
+      api.registrationMode !== "full" &&
+      api.registrationMode !== "discovery" &&
+      api.registrationMode !== "tool-discovery"
+    ) {
       return;
     }
     const poolOptions = readPoolOptions(api.pluginConfig);
-    const sessionStore = api.runtime.state.openSyncKeyedStore<CopilotSessionBinding>({
-      namespace: "sdk-sessions",
-      maxEntries: 5000,
-      defaultTtlMs: 90 * 24 * 60 * 60 * 1000,
-    });
+    // Prepared registries discover the harness without activating runtime state.
+    // Resolve the trusted store only when a harness operation needs a binding.
+    let sessionStore: PluginStateSyncKeyedStore<CopilotSessionBinding> | undefined;
+    const getSessionStore = () =>
+      (sessionStore ??= api.runtime.state.openSyncKeyedStore<CopilotSessionBinding>({
+        namespace: "sdk-sessions",
+        maxEntries: 5000,
+        defaultTtlMs: 90 * 24 * 60 * 60 * 1000,
+      }));
 
     api.registerAgentHarness(
       createCopilotAgentHarness({
         ...(poolOptions ? { poolOptions } : {}),
-        sessionStore,
+        sessionStore: {
+          register: (key, value, options) => getSessionStore().register(key, value, options),
+          lookup: (key) => getSessionStore().lookup(key),
+          delete: (key) => getSessionStore().delete(key),
+        },
       }),
     );
   },

--- a/extensions/copilot/prepared-registry.integration.test.ts
+++ b/extensions/copilot/prepared-registry.integration.test.ts
@@ -1,0 +1,140 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterAll, afterEach, expect, it } from "vitest";
+import { ensureSelectedAgentHarnessPlugin } from "../../src/agents/harness/runtime-plugin.js";
+import { prepareWorkspacePluginRegistries } from "../../src/agents/prepared-model-runtime.inbound-registry.js";
+import type { OpenClawConfig } from "../../src/config/types.openclaw.js";
+import { loadAndActivateRootPluginRegistry } from "../../src/plugins/loader.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  makePluginLoaderTempDir,
+  resetPluginLoaderTestStateForTest,
+  writePlugin,
+} from "../../src/plugins/loader.test-fixtures.js";
+import { loadPluginMetadataSnapshot } from "../../src/plugins/plugin-metadata-snapshot.js";
+import { getActivePluginRegistry } from "../../src/plugins/runtime.js";
+import copilotPlugin from "./index.js";
+
+const REGISTER_COPILOT = Symbol.for("openclaw.test.registerCopilot");
+type RegistrationGlobal = typeof globalThis & {
+  [REGISTER_COPILOT]?: typeof copilotPlugin.register;
+};
+
+afterEach(() => {
+  delete (globalThis as RegistrationGlobal)[REGISTER_COPILOT];
+  resetPluginLoaderTestStateForTest();
+});
+afterAll(cleanupPluginLoaderFixturesForTest);
+
+it("prepares an agent-local Copilot BYOK harness without replacing the active root registry", async () => {
+  const workspaceDir = fs.realpathSync(makePluginLoaderTempDir());
+  const bundledRoot = fs.realpathSync(makePluginLoaderTempDir());
+  // Let Vitest import the public entrypoint once; the real loader still owns its
+  // manifest, mode, API, and registry without a second SDK source-transform graph.
+  const plugin = writePlugin({
+    id: "copilot",
+    filename: "index.cjs",
+    dir: path.join(bundledRoot, "copilot"),
+    body: `module.exports = {
+      id: "copilot",
+      register(api) { globalThis[Symbol.for("openclaw.test.registerCopilot")](api); },
+    };`,
+  });
+  fs.copyFileSync(
+    new URL("./openclaw.plugin.json", import.meta.url),
+    path.join(plugin.dir, "openclaw.plugin.json"),
+  );
+  (globalThis as RegistrationGlobal)[REGISTER_COPILOT] = copilotPlugin.register;
+  const env = {
+    ...process.env,
+    OPENCLAW_STATE_DIR: fs.realpathSync(makePluginLoaderTempDir()),
+    OPENCLAW_BUNDLED_PLUGINS_DIR: bundledRoot,
+    OPENCLAW_DISABLE_BUNDLED_PLUGINS: "0",
+  };
+  const config: OpenClawConfig = {
+    agents: {
+      ownership: "explicit",
+      entries: {
+        worker: {
+          model: "custom-proxy/test-model",
+          models: { "custom-proxy/test-model": { agentRuntime: { id: "copilot" } } },
+        },
+      },
+    },
+    models: {
+      providers: {
+        "custom-proxy": {
+          api: "openai-responses",
+          baseUrl: "https://api.example.com/v1",
+          models: [
+            {
+              id: "test-model",
+              name: "Test model",
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              maxTokens: 8192,
+            },
+          ],
+        },
+      },
+    },
+    plugins: { allow: ["copilot"], slots: { memory: "none" } },
+  };
+  const root = loadAndActivateRootPluginRegistry({
+    config,
+    env,
+    workspaceDir,
+    onlyPluginIds: [],
+    cache: false,
+  });
+  const metadata = loadPluginMetadataSnapshot({
+    config,
+    env,
+    workspaceDir,
+    pluginIds: ["copilot"],
+    allowCurrent: false,
+    preferPersisted: false,
+  });
+  const selection = { agentId: "worker", provider: "custom-proxy", modelId: "test-model" };
+  const { runtimePluginRegistry } = prepareWorkspacePluginRegistries(
+    {
+      config,
+      env,
+      agentDir: workspaceDir,
+      workspaceDir,
+      loadRuntimePlugins: true,
+      runtimePluginSelections: [selection],
+    },
+    metadata,
+  );
+
+  expect(runtimePluginRegistry).not.toBe(root);
+  expect(getActivePluginRegistry()).toBe(root);
+  expect(root.agentHarnesses).toEqual([]);
+  expect(
+    runtimePluginRegistry?.plugins,
+    JSON.stringify(runtimePluginRegistry?.diagnostics),
+  ).toEqual([expect.objectContaining({ id: "copilot", status: "loaded" })]);
+  await expect(
+    ensureSelectedAgentHarnessPlugin({
+      ...selection,
+      config,
+      workspaceDir,
+      pluginRegistry: runtimePluginRegistry,
+    }),
+  ).resolves.toBeUndefined();
+  const harness = runtimePluginRegistry?.agentHarnesses.find(
+    (entry) => entry.harness.id === "copilot",
+  )?.harness;
+  expect(
+    harness?.supports({
+      ...selection,
+      requestedRuntime: "copilot",
+      providerOwnerStatus: "unowned",
+      providerOwnerPluginIds: [],
+      modelProvider: config.models!.providers!["custom-proxy"],
+    }),
+  ).toEqual({ supported: true, priority: 100 });
+  await harness?.dispose?.();
+});

--- a/extensions/copilot/src/attempt-config.ts
+++ b/extensions/copilot/src/attempt-config.ts
@@ -53,7 +53,6 @@ export function createResult(
     promptError: Error | undefined;
     resumeFailureRecovered?: boolean;
     sdkSessionId?: string;
-    sessionIdUsed?: string;
     timedOut?: boolean;
     timedOutDuringCompaction?: boolean;
     toolMetas?: AgentHarnessAttemptResult["toolMetas"];
@@ -134,7 +133,9 @@ export function createResult(
     messagingToolSentTexts: [],
     replayMetadata,
     sessionFileUsed: readNonEmptyString(params.sessionFile),
-    sessionIdUsed: state.sessionIdUsed ?? readNonEmptyString(params.sessionId) ?? "copilot-session",
+    // Core adopts this identity before its next transcript write; SDK session
+    // identity belongs only in sdkSessionId and must not replace the host id.
+    sessionIdUsed: params.sessionId,
     toolMetas,
     yieldDetected: state.yieldDetected === true,
     ...(state.yieldAcknowledgment ? { yieldAcknowledgment: state.yieldAcknowledgment } : {}),

--- a/extensions/copilot/src/attempt-execution.ts
+++ b/extensions/copilot/src/attempt-execution.ts
@@ -98,7 +98,6 @@ export async function runCopilotExecution(context: {
   let timedOut = false;
   let promptError: Error | undefined;
   let sdkSessionId: string | undefined;
-  let sessionIdUsed = input.sessionId;
   // Resumed sessions may predate the atomic journal or survive a crash. Only a
   // session created under this journal can be deleted after incomplete cleanup.
   let nativeSessionCreatedFresh = false;
@@ -169,7 +168,6 @@ export async function runCopilotExecution(context: {
             now,
             promptError: undefined,
             sdkSessionId: undefined,
-            sessionIdUsed: input.sessionId,
           }),
         );
       }
@@ -183,7 +181,6 @@ export async function runCopilotExecution(context: {
             error,
           ),
           sdkSessionId: undefined,
-          sessionIdUsed: input.sessionId,
         }),
       );
     }
@@ -202,7 +199,6 @@ export async function runCopilotExecution(context: {
           "[copilot-attempt] cwd override is not supported for sandboxed Copilot runs; omit cwd or use the agent workspace as cwd",
         ),
         sdkSessionId: undefined,
-        sessionIdUsed: input.sessionId,
       }),
     );
   }
@@ -239,7 +235,6 @@ export async function runCopilotExecution(context: {
         now,
         promptError: createPromptError("model_not_supported", toCopilotError(error).message, error),
         sdkSessionId: undefined,
-        sessionIdUsed: input.sessionId,
       }),
     );
   }
@@ -316,7 +311,6 @@ export async function runCopilotExecution(context: {
             error,
           ),
           sdkSessionId: undefined,
-          sessionIdUsed: input.sessionId,
         });
         return finishAttempt(result);
       }
@@ -400,7 +394,6 @@ export async function runCopilotExecution(context: {
         "[copilot-attempt] canonical transcript persistence requires the Copilot SDK session id",
       );
     }
-    sessionIdUsed = sdkSessionId ?? input.sessionId;
     if (sdkSessionId && deps.onSessionEstablished && !settledToolFinalization) {
       try {
         deps.onSessionEstablished({
@@ -662,7 +655,6 @@ export async function runCopilotExecution(context: {
     resumeFailureRecovered,
     sdkSessionId,
     sentTurnStarted,
-    sessionIdUsed,
     settledFinalizationAssistantCompleted,
     settledToolFinalization,
     timedOut,

--- a/extensions/copilot/src/attempt-finalize.ts
+++ b/extensions/copilot/src/attempt-finalize.ts
@@ -39,7 +39,6 @@ export async function completeCopilotAttempt(params: {
   resumeFailureRecovered: boolean;
   sdkSessionId: string | undefined;
   sentTurnStarted: boolean;
-  sessionIdUsed: string | undefined;
   settledFinalizationAssistantCompleted: boolean;
   settledToolFinalization: boolean;
   timedOut: boolean;
@@ -68,7 +67,6 @@ export async function completeCopilotAttempt(params: {
     resumeFailureRecovered,
     sdkSessionId,
     sentTurnStarted,
-    sessionIdUsed,
     settledFinalizationAssistantCompleted,
     settledToolFinalization,
     timedOut,
@@ -129,7 +127,6 @@ export async function completeCopilotAttempt(params: {
     promptError,
     resumeFailureRecovered,
     sdkSessionId,
-    sessionIdUsed,
     timedOut,
     timedOutDuringCompaction,
     toolMetas: snap ? [...snap.toolMetas] : [],

--- a/extensions/copilot/src/attempt-session.integration.test.ts
+++ b/extensions/copilot/src/attempt-session.integration.test.ts
@@ -1,0 +1,129 @@
+import type { CopilotClient } from "@github/copilot-sdk";
+import type { AgentHarnessAttemptParamsV2 } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { readSessionTranscriptEvents } from "openclaw/plugin-sdk/session-transcript-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanupAttemptTranscriptJournalFixtures,
+  createFakeSession,
+  createFixture,
+  event,
+  transcriptMessages,
+} from "./attempt-transcript-journal.test-helpers.js";
+import type { AttemptResultWithSdkSessionId } from "./attempt-types.js";
+import { runCopilotAttempt } from "./attempt.js";
+import { createCopilotTestHostCapabilities } from "./host-capability.test-support.js";
+import type { CopilotClientPool } from "./runtime.js";
+
+afterEach(cleanupAttemptTranscriptJournalFixtures);
+
+describe("Copilot canonical session identity", () => {
+  it("keeps the host session through provider failure, retry, resume, and finalization", async () => {
+    const { attempt, target, tempDir, bridge } = await createFixture();
+    bridge.detach();
+    const failure = new Error("Authentication failed with provider (HTTP 401)");
+    let turns = 0;
+    let sessions = 0;
+    const newSession = (sessionId: string) => {
+      const session = { ...createFakeSession(), sessionId };
+      session.sendAndWait = vi.fn(async () => {
+        turns += 1;
+        session.emit(event("user.message", `user-${turns}`, { content: attempt.prompt }));
+        if (turns === 1) {
+          throw failure;
+        }
+        const assistant = event("assistant.message", `assistant-${turns}`, {
+          content: `answer-${turns}`,
+          messageId: `assistant-${turns}`,
+        });
+        session.emit(assistant);
+        session.emit(event("session.idle", `idle-${turns}`, {}));
+        return assistant as Awaited<ReturnType<typeof session.sendAndWait>>;
+      });
+      return session;
+    };
+    const client = {
+      createSession: vi.fn(async () => newSession(`sdk-session-${++sessions}`)),
+      resumeSession: vi.fn(async (id: string) => newSession(id)),
+      deleteSession: vi.fn(async () => undefined),
+    };
+    const pool = {
+      acquire: vi.fn(async (key) => ({ client: client as unknown as CopilotClient, key })),
+      release: vi.fn(async () => undefined),
+      dispose: vi.fn(async () => []),
+      size: () => 0,
+    } satisfies CopilotClientPool;
+    const params = {
+      ...attempt,
+      agentDir: tempDir,
+      model: {
+        api: "openai-responses",
+        id: "gpt-5.6-luna",
+        name: "Luna",
+        provider: "github-copilot",
+        baseUrl: "https://api.githubcopilot.com",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128_000,
+        maxTokens: 4096,
+      } satisfies AgentHarnessAttemptParamsV2["model"],
+      auth: { useLoggedInUser: true },
+      hostCapabilities: createCopilotTestHostCapabilities(),
+      promptMode: "none" as const,
+      disableTools: true,
+    };
+    const deps = {
+      pool,
+      createToolBridge: async () => ({
+        sourceTools: [],
+        promptToolPolicy: { apply: () => ({ tools: [], callableToolNames: [] }) },
+      }),
+    };
+    const failed = (await runCopilotAttempt(params, deps)) as AttemptResultWithSdkSessionId;
+    expect(failed.terminal).toEqual({ kind: "failed", source: "prompt", error: failure });
+    expect(failed.sdkSessionId).toBe("sdk-session-1");
+
+    // The host adopts sessionIdUsed before retrying; storage must still accept
+    // that exact identity, while the SDK independently resumes its native id.
+    const retryParams = {
+      ...params,
+      sessionId: failed.sessionIdUsed,
+      sessionTarget: { ...target, sessionId: failed.sessionIdUsed },
+    };
+    const retried = (await runCopilotAttempt(retryParams, deps)) as AttemptResultWithSdkSessionId;
+    expect(retried.terminal).toEqual({ kind: "ok" });
+    expect(retried.sessionIdUsed).toBe(target.sessionId);
+    expect(retried.replayMetadata.replaySafe).toBe(true);
+
+    const resumeParams = {
+      ...retryParams,
+      sessionId: retried.sessionIdUsed,
+      initialReplayState: {
+        replayInvalid: !retried.replayMetadata.replaySafe,
+        hadPotentialSideEffects: retried.replayMetadata.hadPotentialSideEffects,
+        journalValidated: retried.journalValidated,
+        sdkSessionId: retried.sdkSessionId,
+      },
+    };
+    const resumed = (await runCopilotAttempt(resumeParams, deps)) as AttemptResultWithSdkSessionId;
+    expect(resumed.terminal).toEqual({ kind: "ok" });
+    expect(resumed.sessionIdUsed).toBe(target.sessionId);
+    expect(resumed.replayMetadata.replaySafe).toBe(true);
+
+    const final = (await runCopilotAttempt(
+      { ...resumeParams, sessionId: resumed.sessionIdUsed },
+      { ...deps, operation: "settled-tool-finalization" },
+    )) as AttemptResultWithSdkSessionId;
+    expect(final.terminal).toEqual({ kind: "ok" });
+    expect(final.sessionIdUsed).toBe(target.sessionId);
+    expect(final.sdkSessionId).toBe("sdk-session-2");
+    expect(client.createSession).toHaveBeenCalledTimes(2);
+    expect(client.resumeSession.mock.calls.map(([id]) => id)).toEqual([
+      "sdk-session-2",
+      "sdk-session-2",
+    ]);
+    expect(
+      transcriptMessages(await readSessionTranscriptEvents(target)).map((row) => row.message.role),
+    ).toEqual(["user", "assistant", "assistant", "assistant"]);
+  });
+});

--- a/extensions/copilot/src/attempt.ts
+++ b/extensions/copilot/src/attempt.ts
@@ -48,7 +48,6 @@ export async function runCopilotAttempt(
         now,
         promptError: undefined,
         sdkSessionId: undefined,
-        sessionIdUsed: input.sessionId,
       }),
     );
   }
@@ -65,7 +64,6 @@ export async function runCopilotAttempt(
         now,
         promptError: createPromptError("model_not_supported", toCopilotError(error).message, error),
         sdkSessionId: undefined,
-        sessionIdUsed: input.sessionId,
       }),
     );
   }
@@ -82,7 +80,6 @@ export async function runCopilotAttempt(
           "[copilot-attempt] settled tool finalization requires the existing Copilot SDK session",
         ),
         sdkSessionId: undefined,
-        sessionIdUsed: input.sessionId,
       }),
     );
   }

--- a/extensions/copilot/src/provider-bridge.test.ts
+++ b/extensions/copilot/src/provider-bridge.test.ts
@@ -230,15 +230,19 @@ describe("resolveCopilotProvider", () => {
     });
   });
 
-  it("does not synthesize SDK apiKey auth when request auth already prepared headers", () => {
+  it.each([
+    { mode: "header", headers: { "x-api-key": "header-secret" } },
+    { mode: "bearer", headers: { Authorization: "Bearer header-secret" } },
+    { mode: "none", headers: undefined },
+  ])("does not synthesize SDK auth for prepared $mode request auth", ({ mode, headers }) => {
     const result = resolveCopilotProvider({
       model: {
         provider: "custom-header-proxy",
         api: "openai-responses",
         id: "proxy-model",
         baseUrl: "https://proxy.example/v1",
-        headers: { "x-api-key": "header-secret" },
-        requestAuthMode: "header",
+        headers,
+        requestAuthMode: mode,
       },
       resolvedApiKey: "header-secret",
     });
@@ -249,7 +253,7 @@ describe("resolveCopilotProvider", () => {
       baseUrl: "https://proxy.example/v1",
       modelId: "proxy-model",
       wireModel: "proxy-model",
-      headers: { "x-api-key": "header-secret" },
+      ...(headers ? { headers } : {}),
     });
   });
 

--- a/extensions/copilot/src/tool-bridge.test.ts
+++ b/extensions/copilot/src/tool-bridge.test.ts
@@ -24,6 +24,13 @@ import {
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { withTempDir } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  addSubagentRunForTests,
+  getSubagentRunByRunId,
+  resetSubagentRegistryForTests,
+  testing as registryTesting,
+} from "../../../src/agents/subagents/registry/subagent-registry.test-helpers.js";
+import { consumeSwarmStructuredOutput } from "../../../src/agents/tools/structured-output-tool.js";
 import { createCopilotTestHostCapabilities } from "./host-capability.test-support.js";
 import { createCopilotToolBridge as createCopilotToolBridgeImpl } from "./tool-bridge.js";
 
@@ -1358,6 +1365,101 @@ describe("createCopilotToolBridge", () => {
   // so a Copilot run cannot expose the SDK any tool that the same
   // OpenClaw attempt would suppress. These tests pin the contract.
   describe("tool-surface gating (PR #86155 [P1] round-6)", () => {
+    it.each([
+      { collector: true, toolsAllow: undefined, codeMode: false },
+      { collector: true, toolsAllow: ["read"], codeMode: false },
+      { collector: true, toolsAllow: [], codeMode: false },
+      { collector: true, toolsAllow: undefined, codeMode: true },
+      { collector: false, toolsAllow: undefined, codeMode: false },
+      { collector: false, toolsAllow: ["read"], codeMode: false },
+    ])("preserves swarm collector contract %j", async ({ collector, toolsAllow, codeMode }) => {
+      await withTempDir("openclaw-copilot-collector-", async (workspaceDir) => {
+        const runId = "copilot-collector-contract";
+        const sessionKey = "agent:main:subagent:collector-contract";
+        const schema = {
+          type: "object",
+          properties: { answer: { type: "string" } },
+          required: ["answer"],
+          additionalProperties: false,
+        };
+        resetSubagentRegistryForTests({ persist: false });
+        registryTesting.setDepsForTest({ persistSubagentRunsToDiskOrThrow: vi.fn() });
+        addSubagentRunForTests({
+          runId,
+          childSessionKey: sessionKey,
+          collect: collector,
+          outputSchema: schema,
+        });
+        let bridge: Awaited<ReturnType<typeof createCopilotToolBridge>> | undefined;
+        try {
+          bridge = await createCopilotToolBridge({
+            agentId: "main",
+            modelId: "gpt-5.6-luna",
+            sessionKey,
+            workspaceDir,
+            attemptParams: {
+              config: {
+                agents: { entries: { main: { default: true } } },
+                tools: { swarm: true, codeMode },
+              },
+              disableMessageTool: true,
+              runId,
+              sessionKey,
+              workspaceDir,
+              toolsAllow,
+              swarmCollector: collector,
+              swarmOutputSchema: schema,
+            },
+            createOpenClawCodingTools: createRealOpenClawCodingTools,
+          });
+          const initial = bridge.promptToolPolicy.apply();
+          const names = initial.tools.map((tool) => tool.name);
+          if (toolsAllow) {
+            expect
+              .soft(names.toSorted())
+              .toEqual([...toolsAllow, ...(collector ? ["structured_output"] : [])].toSorted());
+          }
+          if (!collector) {
+            expect(names).not.toContain("structured_output");
+            if (!toolsAllow) {
+              expect(names).toContain("sessions_yield");
+            }
+            return;
+          }
+          for (const forbidden of ["ask_user", "sessions_send", "sessions_yield", "message"]) {
+            expect.soft(initial.callableToolNames).not.toContain(forbidden);
+          }
+          expect.soft(names).toContain("structured_output");
+          // Prompt hooks can narrow the already-compacted surface again.
+          const narrowed = bridge.promptToolPolicy.apply({ toolsAllow: ["read"] });
+          expect.soft(narrowed.callableToolNames).toContain("structured_output");
+          const output = expectDefined(
+            narrowed.tools.find((tool) => tool.name === "structured_output"),
+            "collector structured output tool",
+          );
+          expect.soft(output.defer).toBe("never");
+          const response = await runSdkTool(
+            output,
+            { result: { answer: "ok" } },
+            makeInvocation({
+              toolName: "structured_output",
+              toolCallId: "collector-result",
+            }),
+          );
+          expect(response).toMatchObject({ resultType: "success" });
+          expect(getSubagentRunByRunId(runId)?.structuredOutput).toEqual({
+            structured: { answer: "ok" },
+            invalidAttempts: 0,
+          });
+        } finally {
+          bridge?.cleanup?.();
+          consumeSwarmStructuredOutput(runId);
+          resetSubagentRegistryForTests({ persist: false });
+          registryTesting.setDepsForTest();
+        }
+      });
+    });
+
     it("submits the exact conversation-policy-filtered catalog to the SDK", async () => {
       await withTempDir("openclaw-copilot-policy-", async (workspaceDir) => {
         const result = await createCopilotToolBridge({

--- a/extensions/copilot/src/tool-bridge.test.ts
+++ b/extensions/copilot/src/tool-bridge.test.ts
@@ -24,13 +24,6 @@ import {
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { withTempDir } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  addSubagentRunForTests,
-  getSubagentRunByRunId,
-  resetSubagentRegistryForTests,
-  testing as registryTesting,
-} from "../../../src/agents/subagents/registry/subagent-registry.test-helpers.js";
-import { consumeSwarmStructuredOutput } from "../../../src/agents/tools/structured-output-tool.js";
 import { createCopilotTestHostCapabilities } from "./host-capability.test-support.js";
 import { createCopilotToolBridge as createCopilotToolBridgeImpl } from "./tool-bridge.js";
 
@@ -1366,98 +1359,61 @@ describe("createCopilotToolBridge", () => {
   // OpenClaw attempt would suppress. These tests pin the contract.
   describe("tool-surface gating (PR #86155 [P1] round-6)", () => {
     it.each([
-      { collector: true, toolsAllow: undefined, codeMode: false },
-      { collector: true, toolsAllow: ["read"], codeMode: false },
-      { collector: true, toolsAllow: [], codeMode: false },
-      { collector: true, toolsAllow: undefined, codeMode: true },
-      { collector: false, toolsAllow: undefined, codeMode: false },
-      { collector: false, toolsAllow: ["read"], codeMode: false },
-    ])("preserves swarm collector contract %j", async ({ collector, toolsAllow, codeMode }) => {
-      await withTempDir("openclaw-copilot-collector-", async (workspaceDir) => {
-        const runId = "copilot-collector-contract";
-        const sessionKey = "agent:main:subagent:collector-contract";
-        const schema = {
-          type: "object",
-          properties: { answer: { type: "string" } },
-          required: ["answer"],
-          additionalProperties: false,
-        };
-        resetSubagentRegistryForTests({ persist: false });
-        registryTesting.setDepsForTest({ persistSubagentRunsToDiskOrThrow: vi.fn() });
-        addSubagentRunForTests({
-          runId,
-          childSessionKey: sessionKey,
-          collect: collector,
-          outputSchema: schema,
-        });
-        let bridge: Awaited<ReturnType<typeof createCopilotToolBridge>> | undefined;
-        try {
-          bridge = await createCopilotToolBridge({
-            agentId: "main",
-            modelId: "gpt-5.6-luna",
-            sessionKey,
-            workspaceDir,
-            attemptParams: {
-              config: {
-                agents: { entries: { main: { default: true } } },
-                tools: { swarm: true, codeMode },
-              },
-              disableMessageTool: true,
-              runId,
-              sessionKey,
-              workspaceDir,
-              toolsAllow,
-              swarmCollector: collector,
-              swarmOutputSchema: schema,
-            },
-            createOpenClawCodingTools: createRealOpenClawCodingTools,
-          });
-          const initial = bridge.promptToolPolicy.apply();
-          const names = initial.tools.map((tool) => tool.name);
-          if (toolsAllow) {
-            expect
-              .soft(names.toSorted())
-              .toEqual([...toolsAllow, ...(collector ? ["structured_output"] : [])].toSorted());
-          }
-          if (!collector) {
-            expect(names).not.toContain("structured_output");
-            if (!toolsAllow) {
-              expect(names).toContain("sessions_yield");
-            }
-            return;
-          }
-          for (const forbidden of ["ask_user", "sessions_send", "sessions_yield", "message"]) {
-            expect.soft(initial.callableToolNames).not.toContain(forbidden);
-          }
-          expect.soft(names).toContain("structured_output");
-          // Prompt hooks can narrow the already-compacted surface again.
-          const narrowed = bridge.promptToolPolicy.apply({ toolsAllow: ["read"] });
-          expect.soft(narrowed.callableToolNames).toContain("structured_output");
-          const output = expectDefined(
-            narrowed.tools.find((tool) => tool.name === "structured_output"),
-            "collector structured output tool",
-          );
-          expect.soft(output.defer).toBe("never");
-          const response = await runSdkTool(
-            output,
-            { result: { answer: "ok" } },
-            makeInvocation({
-              toolName: "structured_output",
-              toolCallId: "collector-result",
-            }),
-          );
-          expect(response).toMatchObject({ resultType: "success" });
-          expect(getSubagentRunByRunId(runId)?.structuredOutput).toEqual({
-            structured: { answer: "ok" },
-            invalidAttempts: 0,
-          });
-        } finally {
-          bridge?.cleanup?.();
-          consumeSwarmStructuredOutput(runId);
-          resetSubagentRegistryForTests({ persist: false });
-          registryTesting.setDepsForTest();
-        }
+      { toolsAllow: undefined, codeMode: false },
+      { toolsAllow: ["read"], codeMode: false },
+      { toolsAllow: [], codeMode: false },
+      { toolsAllow: undefined, codeMode: true },
+    ])("preserves the collector handoff and SDK result %j", async ({ toolsAllow, codeMode }) => {
+      const schema = {
+        type: "object",
+        properties: { answer: { type: "string" } },
+        required: ["answer"],
+      };
+      const output = makeTool({ name: "structured_output", catalogMode: "direct-only" });
+      // The host contract is checked below, not recreated inside this factory.
+      const createTools = vi.fn(async () => [makeTool({ name: "read" }), output]);
+      const bridge = await createCopilotToolBridge({
+        attemptParams: {
+          config: { tools: { codeMode } },
+          runId: "copilot-collector-contract",
+          toolsAllow,
+          swarmCollector: true,
+          swarmOutputSchema: schema,
+        },
+        createOpenClawCodingTools: createTools,
       });
+      try {
+        expect(createTools).toHaveBeenCalledWith(
+          expect.objectContaining({
+            swarmCollector: true,
+            swarmOutputSchema: schema,
+            ...(toolsAllow ? { runtimeToolAllowlist: [...toolsAllow, "structured_output"] } : {}),
+          }),
+        );
+        const initial = bridge.promptToolPolicy.apply();
+        expect(initial.callableToolNames).toContain("structured_output");
+        if (toolsAllow) {
+          expect(initial.tools.map((tool) => tool.name).toSorted()).toEqual(
+            [...toolsAllow, "structured_output"].toSorted(),
+          );
+        }
+        // Prompt hooks narrow the already-compacted surface a second time.
+        const narrowed = bridge.promptToolPolicy.apply({ toolsAllow: ["read"] });
+        expect(narrowed.callableToolNames).toContain("structured_output");
+        const sdkOutput = expectDefined(
+          narrowed.tools.find((tool) => tool.name === "structured_output"),
+          "collector structured output tool",
+        );
+        expect(sdkOutput.defer).toBe("never");
+        const args = { result: { answer: "ok" } };
+        await expect(runSdkTool(sdkOutput, args)).resolves.toEqual({
+          resultType: "success",
+          textResultForLlm: "done",
+        });
+        expect(output.execute).toHaveBeenCalledWith("call-1", args, undefined, undefined);
+      } finally {
+        bridge.cleanup?.();
+      }
     });
 
     it("submits the exact conversation-policy-filtered catalog to the SDK", async () => {

--- a/extensions/copilot/src/tool-bridge.ts
+++ b/extensions/copilot/src/tool-bridge.ts
@@ -182,7 +182,10 @@ export async function createCopilotToolBridge(
     disableTools: attemptParams.disableTools,
     forceMessageTool: shouldForceCopilotMessageTool(attemptParams),
     isRawModelRun: isRawCopilotModelRun(attemptParams),
-    toolsAllow: attemptParams.toolsAllow,
+    toolsAllow: buildEmbeddedAttemptToolRunContext({
+      ...attemptParams,
+      forceMessageTool: shouldForceCopilotMessageTool(attemptParams),
+    }).runtimeToolAllowlist,
   });
   if (!toolPlan.constructTools) {
     return { codeModeEngaged: false, promptToolPolicy: EMPTY_PROMPT_TOOL_POLICY, sourceTools: [] };
@@ -304,7 +307,14 @@ export async function createCopilotToolBridge(
     codeModeEngaged: toolSurfaceRuntime.codeModeControlsEnabled,
     promptToolPolicy: {
       apply: (params: { toolsAllow?: string[]; forceToolNames?: readonly string[] } = {}) => {
-        const result = compactedTools.promptToolPolicy.apply(params);
+        const result = compactedTools.promptToolPolicy.apply({
+          ...params,
+          toolsAllow: buildEmbeddedAttemptToolRunContext({
+            ...attemptParams,
+            toolsAllow: params.toolsAllow,
+            forceMessageTool: shouldForceCopilotMessageTool(attemptParams),
+          }).runtimeToolAllowlist,
+        });
         const directToolNames = new Set(result.tools.map((tool) => tool.name));
         return {
           tools: sdkTools.filter((tool) => directToolNames.has(tool.name)),
@@ -317,26 +327,9 @@ export async function createCopilotToolBridge(
 }
 
 /**
- * Builds the full `createOpenClawCodingTools` options bag mirroring the
- * PI in-tree call at `src/agents/pi-embedded-runner/run/attempt.ts:1029-1117`.
- *
- * Why PI parity matters: bridged OpenClaw tools register with the SDK
- * as `overridesBuiltInTool: true, skipPermission: true` (see
- * `convertOpenClawToolToSdkTool` below). That means the wrapped-tool
- * enforcement layer
- * (`src/agents/pi-tools.before-tool-call.ts → wrapToolWithBeforeToolCallHook`)
- * is the single gate for permission, owner-only allowlists, loop
- * detection, trusted-plugin policies, and two-phase plugin approvals.
- * That layer reads its context from the fields forwarded here; missing
- * fields silently degrade policy decisions. See docs/plugins/copilot.md.
- *
- * The shared embedded-runner tool plan is forwarded so the bridge does
- * not construct broad tool families only to filter them later. That
- * preserves PI allowlist semantics such as `write` not materializing
- * `apply_patch`.
- * Sandbox is forwarded via the explicit `sandbox` field on
- * {@link CopilotToolBridgeInput}; callers resolve it via
- * `resolveSandboxContext` before constructing the bridge.
+ * Bridged tools skip SDK permission prompts, so host wrappers need the complete
+ * attempt context and prepared sandbox/construction policy to enforce access.
+ * Missing fields here silently weaken or misapply the native harness contract.
  */
 function buildOpenClawCodingToolsOptions(
   input: CopilotToolBridgeInput,
@@ -392,13 +385,7 @@ function buildOpenClawCodingToolsOptions(
 
   return {
     agentId: input.agentId,
-    ...buildEmbeddedAttemptToolRunContext({
-      trigger: a.trigger,
-      jobId: a.jobId,
-      memoryFlushWritePath: a.memoryFlushWritePath,
-      toolsAllow: a.toolsAllow,
-      conversationToolPolicy: a.conversationToolPolicy,
-    }),
+    ...buildEmbeddedAttemptToolRunContext(a),
     exec: {
       ...a.execOverrides,
       elevated: a.bashElevated,
@@ -681,6 +668,7 @@ function convertOpenClawToolToSdkTool(
 
   return {
     description: sourceTool.description,
+    defer: sourceTool.catalogMode === "direct-only" ? "never" : undefined,
     handler,
     name: sourceTool.name,
     // OpenClaw owns its bridged tools by design (the harness docs:

--- a/extensions/imap/src/imap-test-support.ts
+++ b/extensions/imap/src/imap-test-support.ts
@@ -1,4 +1,5 @@
 import type { AuthenticateResult } from "mailauth";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { vi } from "vitest";
@@ -6,6 +7,7 @@ import { createImapState } from "./state.js";
 
 export function createImapTestRuntime() {
   const namespaces = new Map<string, Map<string, unknown>>();
+  const initialCursorRegistered = createDeferred<void>();
   const dispatchHookAgentTurn = vi.fn<
     OpenClawPluginApi["runtime"]["hooks"]["dispatchHookAgentTurn"]
   >(async () => ({ ok: true, runId: "mail-run" }));
@@ -20,7 +22,12 @@ export function createImapTestRuntime() {
         }
         const entries = values;
         return {
-          register: async (key: string, value: T) => void entries.set(key, value),
+          register: async (key: string, value: T) => {
+            entries.set(key, value);
+            if (options.namespace === "cursor") {
+              initialCursorRegistered.resolve();
+            }
+          },
           registerIfAbsent: async (key: string, value: T) => {
             if (entries.has(key)) {
               return false;
@@ -42,7 +49,12 @@ export function createImapTestRuntime() {
       },
     },
   });
-  return { runtime, state: createImapState(runtime), dispatchHookAgentTurn };
+  return {
+    runtime,
+    state: createImapState(runtime),
+    dispatchHookAgentTurn,
+    initialCursorRegistered: initialCursorRegistered.promise,
+  };
 }
 
 type AuthenticationStatus = Exclude<AuthenticateResult["dmarc"], false>["status"]["result"];

--- a/extensions/imap/src/watcher.test.ts
+++ b/extensions/imap/src/watcher.test.ts
@@ -1,5 +1,6 @@
 import { once } from "node:events";
 import { createServer, type Server, type Socket } from "node:net";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { OpenClawPluginServiceContext } from "openclaw/plugin-sdk/plugin-entry";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveImapConfig, type ImapAccountConfig } from "./config.js";
@@ -18,8 +19,13 @@ class ScriptedImapServer {
   fetchGate: Promise<void> | undefined;
   private readonly server: Server;
 
-  constructor(private readonly supportsIdle = true) {
-    this.server = createServer((socket) => this.accept(socket));
+  constructor(
+    private readonly supportsIdle = true,
+    private readonly beforeGreeting?: () => Promise<void>,
+  ) {
+    this.server = createServer((socket) => {
+      void this.accept(socket);
+    });
   }
 
   async listen(): Promise<number> {
@@ -57,12 +63,13 @@ class ScriptedImapServer {
     });
   }
 
-  private accept(socket: Socket): void {
+  private async accept(socket: Socket): Promise<void> {
     this.connectionCount++;
     this.sockets.add(socket);
     socket.on("error", () => {});
     socket.once("close", () => this.sockets.delete(socket));
     const capabilities = `IMAP4rev1${this.supportsIdle ? " IDLE" : ""}`;
+    await this.beforeGreeting?.();
     socket.write(`* OK [CAPABILITY ${capabilities}] scripted IMAP ready\r\n`);
     let buffered = "";
     let idleTag: string | undefined;
@@ -144,9 +151,10 @@ async function startWatcher(
     supportsIdle?: boolean;
     rejectAuthentication?: boolean;
     account?: Partial<ImapAccountConfig>;
+    beforeGreeting?: () => Promise<void>;
   } = {},
 ) {
-  const server = new ScriptedImapServer(options.supportsIdle);
+  const server = new ScriptedImapServer(options.supportsIdle, options.beforeGreeting);
   server.rejectAuthentication = options.rejectAuthentication ?? false;
   activeServers.push(server);
   server.append("From: trusted@example.com\r\nSubject: Existing\r\n\r\nExisting email");
@@ -168,7 +176,8 @@ async function startWatcher(
     throw new Error("fixture account was not configured");
   }
   Object.assign(account, options.account);
-  const { runtime, state, dispatchHookAgentTurn } = createImapTestRuntime();
+  const { runtime, state, dispatchHookAgentTurn, initialCursorRegistered } =
+    createImapTestRuntime();
   const context: OpenClawPluginServiceContext = {
     config: {},
     stateDir: "/unused-imap-test-state",
@@ -186,6 +195,11 @@ async function startWatcher(
   });
   activeWatchers.push(watcher);
   watcher.start();
+  // start() is fire-and-forget; observe the committed baseline before driving mail.
+  // Authentication-failure tests intentionally never reach cursor registration.
+  if (!options.rejectAuthentication) {
+    await initialCursorRegistered;
+  }
   return { server, watcher, state, context, authenticator, dispatchHookAgentTurn };
 }
 
@@ -213,9 +227,7 @@ describe("IMAP watcher protocol boundary", () => {
           addressTokens: [{ token: "secret-token", senders: ["trusted@example.com"] }],
         },
       });
-      await vi.waitFor(async () =>
-        expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 1 }),
-      );
+      expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 1 });
       authenticator.mockResolvedValue(createImapAuthResult(dmarc));
       server.append(
         `From: trusted@example.com\r\n${headers}Subject: Admission\r\n\r\nEmail content`,
@@ -243,9 +255,7 @@ describe("IMAP watcher protocol boundary", () => {
           addressTokens: [{ token: "secret-token", senders: ["@evil.example"] }],
         },
       });
-      await vi.waitFor(async () =>
-        expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 1 }),
-      );
+      expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 1 });
       server.append(`${from}\r\nTo: reader+secret-token@example.com\r\n\r\nRejected mail`);
       await vi.waitFor(async () =>
         expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 2 }),
@@ -266,9 +276,7 @@ describe("IMAP watcher protocol boundary", () => {
       const { server, state, authenticator, dispatchHookAgentTurn } = await startWatcher({
         account: { watch: { mode: "auto", pollSeconds: 0.02 } },
       });
-      await vi.waitFor(async () =>
-        expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 1 }),
-      );
+      expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 1 });
       if (failure === "rejected admission") {
         dispatchHookAgentTurn.mockResolvedValueOnce({ ok: false, reason: "Gateway unavailable" });
       } else if (failure === "throwing admission") {
@@ -298,9 +306,7 @@ describe("IMAP watcher protocol boundary", () => {
     const { server, state, dispatchHookAgentTurn } = await startWatcher({
       account: { watch: { mode: "auto", pollSeconds: 0.02 } },
     });
-    await vi.waitFor(async () =>
-      expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 1 }),
-    );
+    expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 1 });
     dispatchHookAgentTurn.mockRejectedValue(new Error("Gateway unavailable"));
     server.append("From: trusted@example.com\r\nSubject: Exhausted\r\n\r\nNo admission");
     await vi.waitFor(async () =>
@@ -323,9 +329,7 @@ describe("IMAP watcher protocol boundary", () => {
     const { server, state, dispatchHookAgentTurn } = await startWatcher({
       account: { watch: { mode: "auto", pollSeconds: 0.02 } },
     });
-    await vi.waitFor(async () =>
-      expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 1 }),
-    );
+    expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 1 });
     dispatchHookAgentTurn.mockImplementationOnce(async () => {
       // Keep admission unresolved across subsequent mailbox notifications and polls.
       server.append("From: trusted@example.com\r\nSubject: Later\r\n\r\nWait for earlier mail");
@@ -355,9 +359,7 @@ describe("IMAP watcher protocol boundary", () => {
     const { server, watcher, state, context, dispatchHookAgentTurn } = await startWatcher({
       account: { watch: { mode: "auto", pollSeconds: 0.1 } },
     });
-    await vi.waitFor(async () =>
-      expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 1 }),
-    );
+    expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 1 });
     dispatchHookAgentTurn.mockRejectedValue(new Error("Gateway unavailable"));
     server.append("From: trusted@example.com\r\nSubject: Stop\r\n\r\nDo not retry after stop");
     await vi.waitFor(() => expect(context.logger.warn).toHaveBeenCalled());
@@ -371,12 +373,28 @@ describe("IMAP watcher protocol boundary", () => {
   });
 
   it("sweeps a pushed message through the real IMAP connection into one isolated hook dispatch", async () => {
-    const { server, state, dispatchHookAgentTurn } = await startWatcher();
-    await vi.waitFor(async () => {
-      expect(await state.cursors.lookup("inbox")).toMatchObject({
-        uidValidity: "17",
-        lastSeenUid: 1,
-      });
+    const connected = createDeferred<void>();
+    const greeting = createDeferred<void>();
+    let initialized = false;
+    const starting = startWatcher({
+      beforeGreeting: async () => {
+        connected.resolve();
+        await greeting.promise;
+      },
+    }).then((fixture) => {
+      initialized = true;
+      return fixture;
+    });
+    try {
+      await connected.promise;
+      expect(initialized).toBe(false);
+    } finally {
+      greeting.resolve();
+    }
+    const { server, state, dispatchHookAgentTurn } = await starting;
+    expect(await state.cursors.lookup("inbox")).toMatchObject({
+      uidValidity: "17",
+      lastSeenUid: 1,
     });
     server.append(
       "From: trusted@example.com\r\nTo: reader@example.com\r\nSubject: New mail\r\nMessage-ID: <new@example.com>\r\n\r\nHello safely",
@@ -412,9 +430,7 @@ describe("IMAP watcher protocol boundary", () => {
 
   it("delivers mail that arrived during an IDLE connection interruption", async () => {
     const { server, state, dispatchHookAgentTurn } = await startWatcher();
-    await vi.waitFor(async () =>
-      expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 1 }),
-    );
+    expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 1 });
     server.disconnect();
     server.messages.push({
       uid: 2,
@@ -431,9 +447,7 @@ describe("IMAP watcher protocol boundary", () => {
 
   it("coalesces a wakeup that arrives during an active sweep", async () => {
     const { server, state, dispatchHookAgentTurn } = await startWatcher();
-    await vi.waitFor(async () =>
-      expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 1 }),
-    );
+    expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 1 });
     let releaseFetch = () => {};
     server.fetchGate = new Promise<void>((resolve) => {
       releaseFetch = resolve;
@@ -455,9 +469,7 @@ describe("IMAP watcher protocol boundary", () => {
 
   it("re-baselines a rotated UIDVALIDITY without replaying existing mail", async () => {
     const { server, state, dispatchHookAgentTurn } = await startWatcher();
-    await vi.waitFor(async () =>
-      expect(await state.cursors.lookup("inbox")).toMatchObject({ uidValidity: "17" }),
-    );
+    expect(await state.cursors.lookup("inbox")).toMatchObject({ uidValidity: "17" });
     server.uidValidity = "18";
     server.disconnect();
     server.messages.push({
@@ -480,7 +492,7 @@ describe("IMAP watcher protocol boundary", () => {
       supportsIdle: false,
       account: { watch: { mode: "auto", pollSeconds: 0.02 } },
     });
-    await vi.waitFor(async () => expect(await state.cursors.lookup("inbox")).toBeDefined());
+    expect(await state.cursors.lookup("inbox")).toBeDefined();
     server.messages.push({
       uid: 2,
       raw: "From: trusted@example.com\r\nSubject: Poll\r\n\r\nPolled",

--- a/scripts/check-changed.mts
+++ b/scripts/check-changed.mts
@@ -676,6 +676,12 @@ export function createChangedCheckPlan(
   const runAll = lanes.all;
   const shouldRunAndroidVersionSync = hasAndroidVersionSyncPath(result.paths);
 
+  // Typechecking alone accepts extension imports; the graph guard also covers
+  // shared test/tooling dependencies that core tests can pull into their graph.
+  if (runAll || lanes.core || lanes.coreTests || lanes.ui || lanes.tooling) {
+    add("core tsgo graph boundary", ["lint:tmp:tsgo-core-boundary"]);
+  }
+
   if (runAll || lanes.scripts || result.paths.includes("scripts/check-script-erasability.mjs")) {
     add("script TypeScript erasability", ["check:script-erasability"]);
   }
@@ -779,6 +785,7 @@ export function createChangedCheckPlan(
     lanes.liveDockerTooling &&
     result.paths.some((changedPath) => getChangedPathFacts(changedPath).surface === "source")
   ) {
+    add("core tsgo graph boundary", ["lint:tmp:tsgo-core-boundary"]);
     addTypecheck("typecheck core tests", ["tsgo:core:test"]);
     addLint("lint core", ["lint:core"]);
   }

--- a/scripts/check-changed.mts
+++ b/scripts/check-changed.mts
@@ -102,6 +102,8 @@ const DEPRECATION_HYGIENE_PATH_RE =
   /^(?:package\.json$|src\/|extensions\/|packages\/|scripts\/(?:check-deprecated-api-usage\.mts$|plugin-boundary-report\.ts$|lib\/plugin-sdk))/u;
 const WRAPPER_SHADOWING_PATH_RE =
   /^(?:package\.json$|src\/|scripts\/(?:check-(?:export-name-collisions|wrapper-shadowing)\.mts$|lib\/ts-guard-utils\.mts$))/u;
+const EXTENSION_TEST_CORE_IMPORT_PATH_RE =
+  /^(?:extensions\/|test\/helpers\/|scripts\/(?:check-no-extension-test-core-imports|check-file-utils)\.ts$|scripts\/check-changed\.m[jt]s$)/u;
 const CONTROL_UI_I18N_VERIFY_PATH_RE =
   /^(?:package\.json$|ui\/(?:src\/|config\/control-ui-locales\.ts$)|scripts\/(?:control-ui-i18n(?:-(?:report|verify))?\.ts|lib\/(?:control-ui-i18n-[^/]+\.ts|control-ui-i18n-config\.json))$|test\/scripts\/control-ui-i18n[^/]*\.test\.ts$)/u;
 const SHRINK_RATCHET_OWNER_PATH = "scripts/lib/shrink-ratchet.mts";
@@ -567,6 +569,12 @@ export function createChangedCheckPlan(
   add("doctor deprecation registry", ["check:doctor-deprecation-registry"]);
   add("guarded extension wildcard re-exports", ["lint:extensions:no-guarded-wildcard-reexports"]);
   add("plugin-sdk wildcard re-exports", ["lint:extensions:no-plugin-sdk-wildcard-reexports"]);
+  if (
+    result.lanes.all ||
+    result.paths.some((changedPath) => EXTENSION_TEST_CORE_IMPORT_PATH_RE.test(changedPath))
+  ) {
+    add("extension test core imports", ["lint:plugins:no-extension-test-core-imports"]);
+  }
   add("duplicate scan target coverage", ["dup:check:coverage"]);
   add("coercion helper declaration guard", ["check:coercion-helpers"]);
   add("dependency pin guard", ["deps:pins:check"]);

--- a/scripts/e2e/mcp-channels-seed.ts
+++ b/scripts/e2e/mcp-channels-seed.ts
@@ -2,18 +2,21 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import {
+  normalizeSessionDeliveryState,
+  upsertSessionEntry,
+} from "openclaw/plugin-sdk/session-store-runtime";
+import { appendSessionTranscriptMessagesByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
+import { resolveOpenClawAgentSqlitePath } from "openclaw/plugin-sdk/sqlite-runtime";
 import { applyDockerOpenAiProviderConfig, type OpenClawConfig } from "./docker-openai-seed.ts";
 
 async function main() {
   const stateDir = process.env.OPENCLAW_STATE_DIR?.trim() || path.join(os.homedir(), ".openclaw");
   const configPath =
     process.env.OPENCLAW_CONFIG_PATH?.trim() || path.join(stateDir, "openclaw.json");
-  const sessionsDir = path.join(stateDir, "agents", "main", "sessions");
-  const sessionFile = path.join(sessionsDir, "sess-main.jsonl");
-  const storePath = path.join(sessionsDir, "sessions.json");
+  const storePath = resolveOpenClawAgentSqlitePath({ agentId: "main" });
   const now = Date.now();
 
-  await fs.mkdir(sessionsDir, { recursive: true });
   await fs.mkdir(path.dirname(configPath), { recursive: true });
 
   const seededConfig = applyDockerOpenAiProviderConfig(
@@ -39,45 +42,45 @@ async function main() {
 
   await fs.writeFile(configPath, JSON.stringify(seededConfig, null, 2), "utf-8");
 
-  await fs.writeFile(
+  await upsertSessionEntry({
+    agentId: "main",
+    sessionKey: "agent:main:main",
     storePath,
-    JSON.stringify(
-      {
-        "agent:main:main": {
-          sessionId: "sess-main",
-          sessionFile,
-          updatedAt: now,
-          deliveryContext: {
-            channel: "imessage",
-            to: "+15551234567",
-            accountId: "imessage-default",
-            threadId: "thread-42",
-          },
-          displayName: "Docker MCP Channel Smoke",
-          derivedTitle: "Docker MCP Channel Smoke",
-          lastMessagePreview: "seeded transcript",
+    entry: {
+      sessionId: "sess-main",
+      updatedAt: now,
+      delivery: normalizeSessionDeliveryState({
+        context: {
+          channel: "imessage",
+          to: "+15551234567",
+          accountId: "imessage-default",
+          threadId: "thread-42",
         },
-      },
-      null,
-      2,
-    ),
-    "utf-8",
-  );
+      }),
+      displayName: "Docker MCP Channel Smoke",
+    },
+  });
 
-  await fs.writeFile(
-    sessionFile,
-    [
-      JSON.stringify({ type: "session", version: 1, id: "sess-main" }),
-      JSON.stringify({
-        id: "msg-1",
+  // The installed candidate owns the transcript header and ordered parent links.
+  await appendSessionTranscriptMessagesByIdentity({
+    agentId: "main",
+    sessionKey: "agent:main:main",
+    sessionId: "sess-main",
+    storePath,
+    config: seededConfig,
+    messages: [
+      {
+        eventId: "msg-1",
+        now,
         message: {
           role: "assistant",
           content: [{ type: "text", text: "hello from seeded transcript" }],
           timestamp: now,
         },
-      }),
-      JSON.stringify({
-        id: "msg-attachment",
+      },
+      {
+        eventId: "msg-attachment",
+        now: now + 1,
         message: {
           role: "user",
           content: "seeded image attachment",
@@ -94,20 +97,11 @@ async function main() {
           },
           timestamp: now + 1,
         },
-      }),
-    ].join("\n") + "\n",
-    "utf-8",
-  );
+      },
+    ],
+  });
 
-  process.stdout.write(
-    JSON.stringify({
-      ok: true,
-      stateDir,
-      configPath,
-      storePath,
-      sessionFile,
-    }) + "\n",
-  );
+  process.stdout.write(`${JSON.stringify({ ok: true, stateDir, configPath, storePath })}\n`);
 }
 
 await main();

--- a/scripts/lib/ci-changed-node-test-plan.mts
+++ b/scripts/lib/ci-changed-node-test-plan.mts
@@ -486,11 +486,14 @@ export function createChangedNodeTestShards(
     return null;
   }
 
-  const targets = resolvePreciseChangedTargets(
-    regularLivePaths,
-    cwd,
-    [...policyTargetsByPath.values()].flat(),
-  );
+  const targets = resolvePreciseChangedTargets(regularLivePaths, cwd, [
+    ...[...policyTargetsByPath.values()].flat(),
+    // Plugin changes normally select only extension suites. This host-owned
+    // proof also exercises the real Copilot entrypoint and manifest discovery.
+    ...(livePaths.some((changedPath) => changedPath.startsWith("extensions/copilot/"))
+      ? ["src/agents/prepared-model-runtime.copilot.integration.test.ts"]
+      : []),
+  ]);
   if (targets === null) {
     return null;
   }

--- a/src/agents/agent-tools.collector.integration.test.ts
+++ b/src/agents/agent-tools.collector.integration.test.ts
@@ -1,0 +1,122 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { createOpenClawCodingTools } from "./agent-tools.js";
+import { applyEmbeddedAttemptToolsAllow } from "./embedded-agent-runner/run/attempt-tool-construction-plan.js";
+import { buildEmbeddedAttemptToolRunContext } from "./embedded-agent-runner/run/attempt-tool-run-context.js";
+import {
+  addSubagentRunForTests,
+  getSubagentRunByRunId,
+  resetSubagentRegistryForTests,
+  testing as registryTesting,
+} from "./subagents/registry/subagent-registry.test-helpers.js";
+import { consumeSwarmStructuredOutput } from "./tools/structured-output-tool.js";
+
+const runId = "collector-tool-contract";
+const sessionKey = "agent:main:subagent:collector-contract";
+const schema = {
+  type: "object",
+  properties: { answer: { type: "string" } },
+  required: ["answer"],
+  additionalProperties: false,
+};
+let workspaceDir: string;
+
+beforeEach(async () => {
+  workspaceDir = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "collector-tools-")));
+  resetSubagentRegistryForTests({ persist: false });
+  registryTesting.setDepsForTest({ persistSubagentRunsToDiskOrThrow: vi.fn() });
+});
+
+afterEach(async () => {
+  consumeSwarmStructuredOutput(runId);
+  resetSubagentRegistryForTests({ persist: false });
+  registryTesting.setDepsForTest();
+  await fs.rm(workspaceDir, { recursive: true, force: true });
+});
+
+it.each([
+  { collector: true, toolsAllow: undefined },
+  { collector: true, toolsAllow: ["read"] },
+  { collector: true, toolsAllow: [] },
+  { collector: false, toolsAllow: undefined },
+  { collector: false, toolsAllow: ["read"] },
+])("constructs the real attempt collector surface %j", async ({ collector, toolsAllow }) => {
+  addSubagentRunForTests({
+    runId,
+    childSessionKey: sessionKey,
+    collect: collector,
+    outputSchema: schema,
+  });
+  const context = buildEmbeddedAttemptToolRunContext({
+    toolsAllow,
+    swarmCollector: collector,
+    swarmOutputSchema: schema,
+  });
+  const constructedTools = createOpenClawCodingTools({
+    ...context,
+    config: {
+      agents: { entries: { main: { default: true } } },
+      tools: { swarm: true },
+    },
+    agentId: "main",
+    modelProvider: "openai",
+    modelId: "gpt-5.6-luna",
+    disableMessageTool: true,
+    runId,
+    sessionKey,
+    workspaceDir,
+    cwd: workspaceDir,
+  });
+  const tools = applyEmbeddedAttemptToolsAllow(constructedTools, context.runtimeToolAllowlist);
+  const names = tools.map((tool) => tool.name);
+  if (toolsAllow) {
+    expect(names.toSorted()).toEqual(
+      [...toolsAllow, ...(collector ? ["structured_output"] : [])].toSorted(),
+    );
+  }
+  if (!collector) {
+    expect(names).not.toContain("structured_output");
+    if (!toolsAllow) {
+      expect(names).toEqual(expect.arrayContaining(["web_fetch", "sessions_yield"]));
+    }
+    return;
+  }
+  for (const forbidden of ["ask_user", "sessions_send", "sessions_yield", "message"]) {
+    expect(names).not.toContain(forbidden);
+  }
+  if (!toolsAllow) {
+    expect(names).toEqual(
+      expect.arrayContaining(["read", "write", "edit", "apply_patch", "exec", "process"]),
+    );
+    const write = expectDefined(
+      tools.find((tool) => tool.name === "write"),
+      "workspace write",
+    );
+    await write.execute("collector-write", { path: "result.txt", content: "collector file proof" });
+    const read = expectDefined(
+      tools.find((tool) => tool.name === "read"),
+      "workspace read",
+    );
+    const result = await read.execute("collector-read", { path: "result.txt" });
+    expect(result.content).toContainEqual(
+      expect.objectContaining({
+        type: "text",
+        text: expect.stringContaining("collector file proof"),
+      }),
+    );
+  }
+  const output = expectDefined(
+    tools.find((tool) => tool.name === "structured_output"),
+    "collector output transport",
+  );
+  expect(output.catalogMode).toBe("direct-only");
+  const result = await output.execute("collector-result", { result: { answer: "ok" } });
+  expect(result.details).toEqual({ status: "recorded" });
+  expect(getSubagentRunByRunId(runId)?.structuredOutput).toEqual({
+    structured: { answer: "ok" },
+    invalidAttempts: 0,
+  });
+});

--- a/src/agents/embedded-agent-runner/run.harness-auth-failover.test.ts
+++ b/src/agents/embedded-agent-runner/run.harness-auth-failover.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   loadRunOverflowCompactionHarness,
@@ -9,7 +9,14 @@ import {
   mockedResolveAuthProfileOrder,
   mockedRunEmbeddedAttempt,
   overflowBaseRunParams,
+  resetSharedRunIntegrationHarnessMocks,
 } from "./run.overflow-compaction.harness.js";
+
+let runHarness: Awaited<ReturnType<typeof loadRunOverflowCompactionHarness>>;
+beforeAll(async () => {
+  runHarness = await loadRunOverflowCompactionHarness();
+});
+beforeEach(resetSharedRunIntegrationHarnessMocks);
 
 const failedProfile = "openai:failed";
 const backupProfile = "openai:backup";
@@ -22,9 +29,8 @@ function permanentAuthFailure(): Error {
   });
 }
 
-async function prepareAuthFailoverRun() {
-  const { registerPreparedAgentHarness, runEmbeddedAgent } =
-    await loadRunOverflowCompactionHarness();
+function prepareAuthFailoverRun() {
+  const { registerPreparedAgentHarness, runEmbeddedAgent } = runHarness;
   registerPreparedAgentHarness({
     id: "codex",
     label: "Codex",
@@ -61,7 +67,7 @@ async function prepareAuthFailoverRun() {
 
 describe("native harness auth failover", () => {
   it("retries a permanent harness auth failure with the next automatic profile", async () => {
-    const runEmbeddedAgent = await prepareAuthFailoverRun();
+    const runEmbeddedAgent = prepareAuthFailoverRun();
     mockedBuildEmbeddedRunPayloads.mockReturnValue([{ text: "OK" }]);
     mockedRunEmbeddedAttempt
       .mockRejectedValueOnce(permanentAuthFailure())
@@ -87,7 +93,7 @@ describe("native harness auth failover", () => {
   });
 
   it("keeps an explicit user profile strict", async () => {
-    const runEmbeddedAgent = await prepareAuthFailoverRun();
+    const runEmbeddedAgent = prepareAuthFailoverRun();
     const failure = permanentAuthFailure();
     mockedRunEmbeddedAttempt.mockRejectedValueOnce(failure);
 
@@ -108,7 +114,7 @@ describe("native harness auth failover", () => {
   });
 
   it("surfaces the original auth failure when automatic profiles are exhausted", async () => {
-    const runEmbeddedAgent = await prepareAuthFailoverRun();
+    const runEmbeddedAgent = prepareAuthFailoverRun();
     mockedResolveAuthProfileOrder.mockReturnValue([failedProfile]);
     const failure = permanentAuthFailure();
     mockedRunEmbeddedAttempt.mockRejectedValueOnce(failure);
@@ -130,7 +136,7 @@ describe("native harness auth failover", () => {
   });
 
   it("does not rotate profiles for an unclassified harness failure", async () => {
-    const runEmbeddedAgent = await prepareAuthFailoverRun();
+    const runEmbeddedAgent = prepareAuthFailoverRun();
     const failure = new Error("native harness process exited");
     mockedRunEmbeddedAttempt.mockRejectedValueOnce(failure);
 

--- a/src/agents/embedded-agent-runner/run.prepared-harness-credentials.test.ts
+++ b/src/agents/embedded-agent-runner/run.prepared-harness-credentials.test.ts
@@ -1,0 +1,109 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
+import {
+  loadRunOverflowCompactionHarness,
+  mockedBuildEmbeddedRunPayloads,
+  mockedGetApiKeyForModel,
+  mockedRunEmbeddedAttempt,
+  overflowBaseRunParams,
+} from "./run.overflow-compaction.harness.js";
+
+describe("prepared plugin harness credentials", () => {
+  let runEmbeddedAgent: Awaited<
+    ReturnType<typeof loadRunOverflowCompactionHarness>
+  >["runEmbeddedAgent"];
+  let registerPreparedAgentHarness: Awaited<
+    ReturnType<typeof loadRunOverflowCompactionHarness>
+  >["registerPreparedAgentHarness"];
+  beforeAll(async () => {
+    const loaded = await loadRunOverflowCompactionHarness();
+    runEmbeddedAgent = loaded.runEmbeddedAgent;
+    registerPreparedAgentHarness = loaded.registerPreparedAgentHarness;
+    const modelAuth = await import("../model-auth.js");
+    const actual = await vi.importActual<typeof modelAuth>("../model-auth.js");
+    vi.mocked(modelAuth.applyAuthHeaderOverride).mockImplementation(actual.applyAuthHeaderOverride);
+    vi.mocked(modelAuth.resolveProviderEntryApiKeyProfileReference).mockImplementation(
+      actual.resolveProviderEntryApiKeyProfileReference,
+    );
+    vi.mocked(modelAuth.shouldPreferExplicitConfigApiKeyAuth).mockImplementation(
+      actual.shouldPreferExplicitConfigApiKeyAuth,
+    );
+  });
+  beforeEach(() => {
+    registerPreparedAgentHarness({
+      id: "test-byok",
+      label: "Test BYOK",
+      supports: ({ provider }) =>
+        provider === "custom-proof" ? { supported: true, priority: 100 } : { supported: false },
+      runAttempt: (params) => mockedRunEmbeddedAttempt(params),
+    });
+    mockedRunEmbeddedAttempt.mockClear();
+    mockedGetApiKeyForModel.mockClear();
+    mockedGetApiKeyForModel.mockResolvedValue({
+      apiKey: "synthetic-configured-key",
+      mode: "api-key",
+      source: "models.providers.custom-proof",
+    });
+    mockedRunEmbeddedAttempt.mockResolvedValue(makeAttemptResult({ assistantTexts: ["OK"] }));
+    mockedBuildEmbeddedRunPayloads.mockReturnValue([{ text: "OK" }]);
+  });
+
+  it.each([true, false])(
+    "forwards a configured direct key with authHeader=%s",
+    async (authHeader) => {
+      await runEmbeddedAgent({
+        ...overflowBaseRunParams,
+        provider: "custom-proof",
+        model: "gpt-5.6-luna",
+        config: {
+          models: {
+            providers: {
+              "custom-proof": {
+                api: "openai-responses",
+                baseUrl: "https://api.openai.com/v1",
+                apiKey: "synthetic-configured-key",
+                authHeader,
+                models: [
+                  {
+                    id: "gpt-5.6-luna",
+                    name: "Luna",
+                    reasoning: true,
+                    input: ["text"],
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 128_000,
+                    maxTokens: 4096,
+                  },
+                ],
+              },
+            },
+          },
+        },
+      });
+
+      expect(mockedRunEmbeddedAttempt).toHaveBeenCalledOnce();
+      expect(mockedRunEmbeddedAttempt.mock.calls[0]?.[0].agentHarnessId).toBe("test-byok");
+      expect(mockedRunEmbeddedAttempt.mock.calls[0]?.[0].resolvedApiKey).toBe(
+        "synthetic-configured-key",
+      );
+      expect(mockedGetApiKeyForModel).toHaveBeenCalledWith(
+        expect.objectContaining({ allowAuthProfileFallback: false }),
+      );
+      expect(mockedRunEmbeddedAttempt.mock.calls[0]?.[0].model.headers).toEqual(
+        authHeader ? { Authorization: "Bearer synthetic-configured-key" } : undefined,
+      );
+    },
+  );
+
+  it("does not discover a credential for an implicit harness auth attempt", async () => {
+    await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "custom-proof",
+      model: "gpt-5.6-luna",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledOnce();
+    expect(mockedRunEmbeddedAttempt.mock.calls[0]?.[0].agentHarnessId).toBe("test-byok");
+    expect(mockedRunEmbeddedAttempt.mock.calls[0]?.[0].resolvedApiKey).toBeUndefined();
+    expect(mockedGetApiKeyForModel).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-tool-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-prepare.ts
@@ -45,7 +45,6 @@ import { resolveAttemptToolPolicyMessageProvider } from "./attempt-run-decisions
 import { resolveAttemptSpawnWorkspaceDir } from "./attempt-thread-helpers.js";
 import {
   applyEmbeddedAttemptToolsAllow,
-  mergeForcedEmbeddedAttemptToolsAllow,
   resolveEmbeddedAttemptToolConstructionPlan,
 } from "./attempt-tool-construction-plan.js";
 import { buildEmbeddedAttemptToolRunContext } from "./attempt-tool-run-context.js";
@@ -80,14 +79,15 @@ export function prepareEmbeddedAttemptToolBase(params: {
     attempt.forceCodeModeReconciliationTools === true
       ? false
       : messageToolOwnsVisibleReply(attempt);
+  const toolRunContext = buildEmbeddedAttemptToolRunContext({
+    ...attempt,
+    forceMessageTool: forceDirectMessageTool,
+    trace: params.runTrace,
+  });
   const toolsAllowWithForcedRuntimeTools =
     attempt.forceCodeModeReconciliationTools === true
       ? ["read"]
-      : mergeForcedEmbeddedAttemptToolsAllow(attempt.toolsAllow, {
-          forceMessageTool: forceDirectMessageTool,
-          forceToolNames:
-            attempt.swarmCollector && attempt.swarmOutputSchema ? ["structured_output"] : undefined,
-        });
+      : toolRunContext.runtimeToolAllowlist;
   const toolsEnabled = supportsModelTools(attempt.model);
   const isRawModelRun = attempt.modelRun === true || attempt.promptMode === "none";
   const toolConstructionPlan = resolveEmbeddedAttemptToolConstructionPlan({
@@ -246,7 +246,7 @@ export function prepareEmbeddedAttemptToolBase(params: {
     : (() => {
         const allTools = createOpenClawCodingTools({
           agentId: params.sessionAgentId,
-          ...buildEmbeddedAttemptToolRunContext({ ...attempt, trace: params.runTrace }),
+          ...toolRunContext,
           messageChannel: attempt.messageChannel,
           clientCaps: attempt.clientCaps,
           toolBindings: attempt.toolBindings,
@@ -349,8 +349,6 @@ export function prepareEmbeddedAttemptToolBase(params: {
           taskSuggestionDeliveryMode: attempt.taskSuggestionDeliveryMode,
           inboundEventKind: attempt.currentInboundEventKind,
           disableMessageTool: attempt.disableMessageTool,
-          swarmCollector: attempt.swarmCollector,
-          swarmOutputSchema: attempt.swarmOutputSchema,
           forceMessageTool: attempt.forceMessageTool,
           enableHeartbeatTool: attempt.enableHeartbeatTool,
           forceHeartbeatTool: attempt.forceHeartbeatTool,

--- a/src/agents/embedded-agent-runner/run/attempt-tool-run-context.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-run-context.ts
@@ -1,11 +1,9 @@
 import type { GroupToolPolicyConfig } from "../../../config/types.tools.js";
-/**
- * Builds tool run context passed to embedded-agent tool handlers.
- */
 import {
   freezeDiagnosticTraceContext,
   type DiagnosticTraceContext,
 } from "../../../infra/diagnostic-trace-context.js";
+import { mergeForcedEmbeddedAttemptToolsAllow } from "./attempt-tool-construction-plan.js";
 import type { EmbeddedRunTrigger } from "./params.js";
 
 /**
@@ -16,21 +14,25 @@ export function buildEmbeddedAttemptToolRunContext(params: {
   jobId?: string;
   memoryFlushWritePath?: string;
   toolsAllow?: string[];
+  forceMessageTool?: boolean;
+  swarmCollector?: boolean;
+  swarmOutputSchema?: Record<string, unknown>;
   conversationToolPolicy?: GroupToolPolicyConfig;
   trace?: DiagnosticTraceContext;
-}): {
-  trigger?: EmbeddedRunTrigger;
-  jobId?: string;
-  memoryFlushWritePath?: string;
-  runtimeToolAllowlist?: string[];
-  conversationToolPolicy?: GroupToolPolicyConfig;
-  trace?: DiagnosticTraceContext;
-} {
+}) {
+  // Collector output is mandatory result transport, even on a narrowed tool surface.
+  const runtimeToolAllowlist = mergeForcedEmbeddedAttemptToolsAllow(params.toolsAllow, {
+    forceMessageTool: params.forceMessageTool,
+    forceToolNames:
+      params.swarmCollector && params.swarmOutputSchema ? ["structured_output"] : undefined,
+  });
   return {
     trigger: params.trigger,
     jobId: params.jobId,
     memoryFlushWritePath: params.memoryFlushWritePath,
-    ...(params.toolsAllow ? { runtimeToolAllowlist: params.toolsAllow } : {}),
+    swarmCollector: params.swarmCollector,
+    swarmOutputSchema: params.swarmOutputSchema,
+    ...(runtimeToolAllowlist ? { runtimeToolAllowlist } : {}),
     ...(params.conversationToolPolicy
       ? { conversationToolPolicy: params.conversationToolPolicy }
       : {}),

--- a/src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts
@@ -95,6 +95,7 @@ function shouldSkipNonVisibleTurnRetry(params: {
   return Boolean(
     params.aborted ||
     params.timedOut ||
+    params.attempt.terminal.kind === "failed" ||
     params.attempt.clientToolCalls ||
     params.attempt.yieldDetected ||
     params.attempt.didSendDeterministicApprovalPrompt ||

--- a/src/agents/embedded-agent-runner/run/runtime-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-preparation.ts
@@ -258,7 +258,7 @@ export async function prepareEmbeddedRunRuntime(input: {
     pluginHarnessOwnsTransport &&
     (preparedApiKeyRoute ||
       (!pluginHarnessOwnsAuthBootstrap &&
-        profileCandidates.some((profileId) => Boolean(profileId))));
+        preparedAuthAttempts.some((attempt) => attempt.kind !== "implicit")));
   const findPreparedAuthAttempt = (profileId: string | undefined, attemptIndex?: number) => {
     const attempt =
       attemptIndex === undefined

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.test.ts
@@ -118,6 +118,33 @@ async function resolveTerminalText(overrides: TerminalInputOverrides): Promise<s
 }
 
 describe("terminal resolution", () => {
+  it.each(["empty", "reasoning"])(
+    "preserves a failed harness turn instead of retrying its %s output",
+    async (output) => {
+      const error = new Error("Authentication failed with provider (HTTP 401)");
+      const assistant =
+        output === "reasoning"
+          ? buildEmbeddedRunnerAssistant({ content: [{ type: "thinking", thinking: "checking" }] })
+          : undefined;
+      const attempt = makeEmbeddedRunnerAttempt({
+        terminal: { kind: "failed", source: "prompt", error },
+        assistantTexts: [],
+        currentAttemptAssistant: assistant,
+        lastAssistant: assistant,
+        replayMetadata: { hadPotentialSideEffects: false, replaySafe: false },
+      });
+      const input = makeTerminalInput({ attempt });
+
+      const resolved = await resolveEmbeddedRunTerminal(input);
+
+      expect(resolved).toMatchObject({
+        action: "complete",
+        result: { meta: { error: { message: error.message, fallbackSafe: false } } },
+      });
+      expect(input.activateInternalPrompt).not.toHaveBeenCalled();
+    },
+  );
+
   it.each(["openai:selected", undefined])(
     "reports the successful profile %s privately for command maintenance",
     async (authProfileId) => {

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -2,6 +2,7 @@ import { randomBytes } from "node:crypto";
 import { isCompactionReplayCheckpoint } from "@openclaw/ai/transports";
 import { SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
 import { freezeDiagnosticTraceContext } from "../../../infra/diagnostic-trace-context.js";
+import { formatErrorMessage } from "../../../infra/errors.js";
 import type { AssistantMessage } from "../../../llm/types.js";
 import type { ProviderRouteOverridePresence } from "../../../plugin-sdk/provider-model-types.js";
 import { projectAgentRunAttemptTerminal } from "../../agent-run-terminal-outcome.js";
@@ -524,7 +525,10 @@ async function surfaceIncompleteTurn(
         livenessState,
         error: {
           kind: "incomplete_turn",
-          message: "Agent couldn't generate a response.",
+          message:
+            input.attempt.terminal.kind === "failed"
+              ? formatErrorMessage(input.attempt.terminal.error)
+              : "Agent couldn't generate a response.",
           fallbackSafe: input.incompleteTurnFallbackSafe,
           terminalPresentation: input.terminalToolPresentation !== undefined,
         },

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -1444,7 +1444,7 @@ describe("runAgentHarnessAttempt", () => {
     expect(received[0]?.safeDeniedTools).toEqual(["image_generate"]);
   });
 
-  it("marks only explicit restrictive policy layers for plugin harness isolation", async () => {
+  it("isolates collector runs and explicit restrictive policy layers for plugin harnesses", async () => {
     const received: boolean[] = [];
     const runAttempt = vi.fn<AgentHarness["runAttempt"]>(async (attempt) => {
       received.push(attempt.pluginHarnessToolPolicyRestricted === true);
@@ -1467,11 +1467,14 @@ describe("runAgentHarnessAttempt", () => {
       conversationToolPolicy?: EmbeddedRunAttemptParams["conversationToolPolicy"];
       agentId?: string;
       sessionKey?: string;
+      swarmCollector?: boolean;
     }> = [
       {},
       { config: { tools: { profile: "coding" } } as OpenClawConfig },
       { conversationToolPolicy: {} },
       { conversationToolPolicy: { allow: ["*"] } },
+      { swarmCollector: false },
+      { swarmCollector: true },
       { conversationToolPolicy: { deny: ["exec"] } },
       { config: { tools: { deny: ["exec"] } } as OpenClawConfig },
       {
@@ -1493,10 +1496,11 @@ describe("runAgentHarnessAttempt", () => {
         conversationToolPolicy: testCase.conversationToolPolicy,
         agentId: testCase.agentId,
         sessionKey: testCase.sessionKey,
+        swarmCollector: testCase.swarmCollector,
       });
     }
 
-    expect(received).toEqual([false, false, false, false, true, true, true, true]);
+    expect(received).toEqual([false, false, false, false, false, true, true, true, true, true]);
   });
 
   it("rejects restrictive policy before an unsupported plugin harness runs", async () => {

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -152,6 +152,7 @@ type PluginHarnessToolPolicyContext = Pick<
   | "runtimePluginToolGrant"
   | "toolsAllow"
   | "disableTools"
+  | "swarmCollector"
 >;
 
 type PluginHarnessToolPolicy = { allow?: string[]; deny?: string[] };
@@ -870,9 +871,13 @@ function resolvePluginHarnessToolPolicies(
       requestedToolPolicy,
     ],
     safeDeniedToolNames: collectHarnessSafeDeniedToolNames(explicitPolicies, safeDenyToolNameSet),
-    toolPolicyRestricted: explicitPolicies.some((explicitPolicy) =>
-      toolPolicyRestrictsHarnessNativeTools(explicitPolicy, safeDenyToolNameSet),
-    ),
+    // Native tools bypass the collector's noninteractive OpenClaw wrappers.
+    // Keep policy-allowed host replacements, without ambient input or approval surfaces.
+    toolPolicyRestricted:
+      params.swarmCollector === true ||
+      explicitPolicies.some((explicitPolicy) =>
+        toolPolicyRestrictsHarnessNativeTools(explicitPolicy, safeDenyToolNameSet),
+      ),
   };
 }
 

--- a/src/agents/prepared-model-catalog-worker.integration.test.ts
+++ b/src/agents/prepared-model-catalog-worker.integration.test.ts
@@ -36,6 +36,11 @@ import {
 } from "./prepared-model-runtime-auth.js";
 import { startSerializedSnapshotBuild } from "./prepared-model-runtime.build.js";
 import type { PreparedModelRuntimeAgentFacts } from "./prepared-model-runtime.catalog-contract.js";
+import {
+  getPreparedModelRuntimeSnapshot,
+  refreshPreparedModelRuntimeSnapshots,
+} from "./prepared-model-runtime.js";
+import { resetPreparedModelRuntimeSnapshotsForTest } from "./prepared-model-runtime.test-support.js";
 import { AuthStorage } from "./sessions/auth-storage.js";
 
 const PROVIDER_ID = "worker-catalog-fixture";
@@ -55,6 +60,7 @@ const EXTERNAL_AUTH_PROFILE_ID = `${PROVIDER_ID}:external`;
 const EXTERNAL_AUTH_PATH_ENV = "OPENCLAW_WORKER_EXTERNAL_AUTH_PATH";
 const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
   afterEach(() => {
+    resetPreparedModelRuntimeSnapshotsForTest();
     clearRuntimeAuthProfileStoreSnapshots();
     closeOpenClawAgentDatabasesForTest();
     cleanup();
@@ -160,12 +166,21 @@ module.exports = {
           } };
         },
       },
-      augmentModelCatalog(context) {
+      async augmentModelCatalog(context) {
         const marker = process.env.OPENCLAW_WORKER_CATALOG_MARKER;
         const invocation = fs.existsSync(marker)
           ? fs.readFileSync(marker, "utf8").split("start\\n").length
           : 1;
         fs.appendFileSync(process.env.OPENCLAW_WORKER_CATALOG_MARKER, "start\\n");
+        const barrier = marker + ".hold";
+        if (fs.existsSync(barrier)) {
+          await new Promise((resolve) => {
+            const watcher = fs.watch(require("node:path").dirname(barrier), () => {
+              if (!fs.existsSync(barrier)) { watcher.close(); resolve(); }
+            });
+            if (!fs.existsSync(barrier)) { watcher.close(); resolve(); }
+          });
+        }
         const until = Date.now() + ${params.spinMs};
         while (Date.now() < until) {}
         const hasSqlite = context.entries.some((entry) =>
@@ -199,12 +214,11 @@ module.exports = {
   return pluginFile;
 }
 
-async function createStaticSnapshot(
+function createCatalogFixture(
   spinMs: number,
   envOverride: NodeJS.ProcessEnv = {},
   options?: {
     hydrateExternalCliProviderIds?: readonly string[];
-    metadataWorkspace?: "gateway" | "none" | "activation";
   },
 ) {
   const root = tempDirs.make("openclaw-model-catalog-worker-");
@@ -290,6 +304,19 @@ async function createStaticSnapshot(
       }),
     },
   });
+  return { agentDir, config, env, marker, externalAuthPath, hydratedAuthStore, root, workspaceDir };
+}
+
+async function createStaticSnapshot(
+  spinMs: number,
+  envOverride: NodeJS.ProcessEnv = {},
+  options?: {
+    hydrateExternalCliProviderIds?: readonly string[];
+    metadataWorkspace?: "gateway" | "none" | "activation";
+  },
+) {
+  const fixture = createCatalogFixture(spinMs, envOverride, options);
+  const { agentDir, workspaceDir, config, env, root } = fixture;
   let current = true;
   const build = await startSerializedSnapshotBuild(
     { agentId: "main", agentDir, inheritedAuthDir: agentDir, workspaceDir, config, env },
@@ -313,17 +340,10 @@ async function createStaticSnapshot(
       : undefined,
   ).pending;
   return {
-    agentDir,
-    config,
-    env,
-    marker,
-    externalAuthPath,
-    hydratedAuthStore,
+    ...fixture,
     pluginMetadataSnapshot: build.pluginGeneration.pluginMetadataSnapshot,
     snapshot: build.snapshot,
-    root,
     supersede: () => (current = false),
-    workspaceDir,
   };
 }
 
@@ -332,6 +352,111 @@ async function waitForMarker(marker: string): Promise<void> {
 }
 
 describe("prepared model catalog worker boundary", () => {
+  it("keeps an unaffected configured worker live across a scoped sibling reload", async () => {
+    const fixture = createCatalogFixture(0);
+    // Configured publication reads the process environment; keep both the parent and worker
+    // inside the same synthetic plugin/state fixture, without a supplied liveness predicate.
+    for (const name of [
+      "OPENCLAW_DISABLE_BUNDLED_PLUGINS",
+      "OPENCLAW_STATE_DIR",
+      "OPENCLAW_WORKER_CATALOG_MARKER",
+      EXTERNAL_AUTH_PATH_ENV,
+      REF_ONLY_API_ENV,
+      REF_ONLY_TOKEN_ENV,
+    ] as const) {
+      vi.stubEnv(name, fixture.env[name]);
+    }
+    const siblingDir = path.join(fixture.root, "sibling-agent");
+    const initialConfig = {
+      ...fixture.config,
+      agents: {
+        ...fixture.config.agents,
+        entries: {
+          main: { default: true, agentDir: fixture.agentDir, workspace: fixture.workspaceDir },
+          sibling: {
+            agentDir: siblingDir,
+            workspace: fixture.workspaceDir,
+            tools: { exec: { security: "full", ask: "off" } },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+    const buildCounts: number[] = [];
+    const options = {
+      gatewayLifecycle: true,
+      catalogMode: "static" as const,
+      onBuildStats: (stats: { agentCount: number }) => buildCounts.push(stats.agentCount),
+    };
+    const mainInput = { agentId: "main", agentDir: fixture.agentDir, config: initialConfig };
+    const siblingInput = { agentId: "sibling", agentDir: siblingDir, config: initialConfig };
+    await refreshPreparedModelRuntimeSnapshots(initialConfig, options);
+    const main = getPreparedModelRuntimeSnapshot(mainInput)!;
+    const sibling = getPreparedModelRuntimeSnapshot(siblingInput)!;
+    const catalog = await main.loadFullModelCatalog!();
+    expect(catalog.entries).toContainEqual(
+      expect.objectContaining({ provider: PROVIDER_ID, id: "plugin-generation-v1" }),
+    );
+    const authScope = { providerIds: [PROVIDER_ID] };
+    await expect(loadPreparedModelRuntimeAuth(sibling, authScope)).resolves.toMatchObject({
+      authStore: { profiles: { [EXTERNAL_AUTH_PROFILE_ID]: { access: "v1:A" } } },
+    });
+
+    fs.writeFileSync(`${fixture.marker}.hold`, "", "utf8");
+    const inFlight = main.loadFullModelCatalog!({ refresh: true });
+    void inFlight.catch(() => undefined);
+    try {
+      await expect.poll(() => fs.readFileSync(fixture.marker, "utf8")).toBe("start\ndone\nstart\n");
+      const nextConfig = {
+        ...initialConfig,
+        agents: {
+          ...initialConfig.agents,
+          entries: {
+            ...initialConfig.agents.entries,
+            sibling: {
+              ...initialConfig.agents.entries.sibling,
+              tools: { exec: { security: "full", ask: "always" } },
+            },
+          },
+        },
+      } satisfies OpenClawConfig;
+      await refreshPreparedModelRuntimeSnapshots(nextConfig, {
+        ...options,
+        agentIds: new Set(["sibling"]),
+      });
+      const retained = getPreparedModelRuntimeSnapshot({ ...mainInput, config: nextConfig })!;
+      expect(buildCounts).toEqual([2, 1]);
+      expect(retained.modelCatalog).toBe(main.modelCatalog);
+      expect(retained.metadataSnapshot).toBe(main.metadataSnapshot);
+      expect(retained.readFullModelCatalog!()).toBe(catalog);
+      await expect(loadPreparedModelRuntimeAuth(sibling, authScope)).rejects.toThrow("superseded");
+      await expect(sibling.loadFullModelCatalog!()).rejects.toThrow("superseded");
+
+      fs.rmSync(`${fixture.marker}.hold`);
+      const refreshed = await inFlight;
+      expect(refreshed).not.toBe(catalog);
+      expect(retained.readFullModelCatalog!()).toBe(refreshed);
+      expect(refreshed.entries).toContainEqual(
+        expect.objectContaining({ id: "proof-refresh-2-sqlite-true-shared-true-unrelated-true" }),
+      );
+      fs.writeFileSync(fixture.externalAuthPath, "B", "utf8");
+      await expect(loadPreparedModelRuntimeAuth(retained, authScope)).resolves.toMatchObject({
+        authStore: { profiles: { [EXTERNAL_AUTH_PROFILE_ID]: { access: "v1:B" } } },
+      });
+      await expect(retained.loadFullModelCatalog!({ refresh: true })).resolves.toMatchObject({
+        entries: expect.arrayContaining([
+          expect.objectContaining({ id: "proof-refresh-3-sqlite-true-shared-true-unrelated-true" }),
+        ]),
+      });
+      const replaced = getPreparedModelRuntimeSnapshot({ ...siblingInput, config: nextConfig })!;
+      await expect(loadPreparedModelRuntimeAuth(replaced, authScope)).resolves.toMatchObject({
+        authStore: { profiles: { [EXTERNAL_AUTH_PROFILE_ID]: { access: "v1:B" } } },
+      });
+    } finally {
+      fs.rmSync(`${fixture.marker}.hold`, { force: true });
+      await Promise.allSettled([inFlight]);
+    }
+  });
+
   it.each([
     ["gateway", "catalog"],
     ["gateway", "auth-refresh"],

--- a/src/agents/prepared-model-runtime.copilot.integration.test.ts
+++ b/src/agents/prepared-model-runtime.copilot.integration.test.ts
@@ -13,7 +13,6 @@ import {
 } from "../plugins/loader.test-fixtures.js";
 import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { getActivePluginRegistry } from "../plugins/runtime.js";
-import { resolveBundledPluginPublicModulePath } from "../test-utils/bundled-plugin-public-surface.js";
 import { ensureSelectedAgentHarnessPlugin } from "./harness/runtime-plugin.js";
 import { prepareWorkspacePluginRegistries } from "./prepared-model-runtime.inbound-registry.js";
 
@@ -30,10 +29,9 @@ it("prepares an agent-local Copilot BYOK harness without replacing the active ro
       throw new Error("prepared harness discovery must not activate state stores");
     });
   const workspaceDir = fs.realpathSync(makePluginLoaderTempDir());
-  const entrypoint = resolveBundledPluginPublicModulePath({
-    pluginId: "copilot",
-    artifactBasename: "index.ts",
-  });
+  // This composition uses the checkout's source fixture, not installed plugin resolution.
+  const bundledRoot = path.resolve(import.meta.dirname, "../../extensions");
+  const entrypoint = path.join(bundledRoot, "copilot", "index.ts");
   const copilotModule = await loadBundledPluginPublicSurface({
     pluginId: "copilot",
     artifactBasename: "index.ts",
@@ -45,7 +43,6 @@ it("prepares an agent-local Copilot BYOK harness without replacing the active ro
     return copilotModule;
   });
   vi.spyOn(pluginModuleRuntime, "createPluginModuleLoader").mockReturnValue(loadModule);
-  const bundledRoot = path.dirname(path.dirname(entrypoint));
   const env = {
     ...process.env,
     OPENCLAW_STATE_DIR: fs.realpathSync(makePluginLoaderTempDir()),

--- a/src/agents/prepared-model-runtime.copilot.integration.test.ts
+++ b/src/agents/prepared-model-runtime.copilot.integration.test.ts
@@ -1,19 +1,20 @@
 import fs from "node:fs";
 import path from "node:path";
-import { afterAll, afterEach, expect, it } from "vitest";
-import { ensureSelectedAgentHarnessPlugin } from "../../src/agents/harness/runtime-plugin.js";
-import { prepareWorkspacePluginRegistries } from "../../src/agents/prepared-model-runtime.inbound-registry.js";
-import type { OpenClawConfig } from "../../src/config/types.openclaw.js";
-import { loadAndActivateRootPluginRegistry } from "../../src/plugins/loader.js";
+import { afterAll, afterEach, expect, it, vi } from "vitest";
+import copilotPlugin from "../../extensions/copilot/index.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import * as pluginState from "../plugin-state/plugin-state-store.js";
+import { loadAndActivateRootPluginRegistry } from "../plugins/loader.js";
 import {
   cleanupPluginLoaderFixturesForTest,
   makePluginLoaderTempDir,
   resetPluginLoaderTestStateForTest,
   writePlugin,
-} from "../../src/plugins/loader.test-fixtures.js";
-import { loadPluginMetadataSnapshot } from "../../src/plugins/plugin-metadata-snapshot.js";
-import { getActivePluginRegistry } from "../../src/plugins/runtime.js";
-import copilotPlugin from "./index.js";
+} from "../plugins/loader.test-fixtures.js";
+import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import { getActivePluginRegistry } from "../plugins/runtime.js";
+import { ensureSelectedAgentHarnessPlugin } from "./harness/runtime-plugin.js";
+import { prepareWorkspacePluginRegistries } from "./prepared-model-runtime.inbound-registry.js";
 
 const REGISTER_COPILOT = Symbol.for("openclaw.test.registerCopilot");
 type RegistrationGlobal = typeof globalThis & {
@@ -21,12 +22,18 @@ type RegistrationGlobal = typeof globalThis & {
 };
 
 afterEach(() => {
+  vi.restoreAllMocks();
   delete (globalThis as RegistrationGlobal)[REGISTER_COPILOT];
   resetPluginLoaderTestStateForTest();
 });
 afterAll(cleanupPluginLoaderFixturesForTest);
 
 it("prepares an agent-local Copilot BYOK harness without replacing the active root registry", async () => {
+  const openStore = vi
+    .spyOn(pluginState, "createPluginStateSyncKeyedStore")
+    .mockImplementation(() => {
+      throw new Error("prepared harness discovery must not activate state stores");
+    });
   const workspaceDir = fs.realpathSync(makePluginLoaderTempDir());
   const bundledRoot = fs.realpathSync(makePluginLoaderTempDir());
   // Let Vitest import the public entrypoint once; the real loader still owns its
@@ -41,7 +48,7 @@ it("prepares an agent-local Copilot BYOK harness without replacing the active ro
     };`,
   });
   fs.copyFileSync(
-    new URL("./openclaw.plugin.json", import.meta.url),
+    new URL("../../extensions/copilot/openclaw.plugin.json", import.meta.url),
     path.join(plugin.dir, "openclaw.plugin.json"),
   );
   (globalThis as RegistrationGlobal)[REGISTER_COPILOT] = copilotPlugin.register;
@@ -137,4 +144,5 @@ it("prepares an agent-local Copilot BYOK harness without replacing the active ro
     }),
   ).toEqual({ supported: true, priority: 100 });
   await harness?.dispose?.();
+  expect(openStore).not.toHaveBeenCalled();
 });

--- a/src/agents/prepared-model-runtime.copilot.integration.test.ts
+++ b/src/agents/prepared-model-runtime.copilot.integration.test.ts
@@ -1,29 +1,24 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterAll, afterEach, expect, it, vi } from "vitest";
-import copilotPlugin from "../../extensions/copilot/index.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { loadBundledPluginPublicSurface } from "../plugin-sdk/test-helpers/public-surface-loader.js";
 import * as pluginState from "../plugin-state/plugin-state-store.js";
+import * as pluginModuleRuntime from "../plugins/loader-module-runtime.js";
 import { loadAndActivateRootPluginRegistry } from "../plugins/loader.js";
 import {
   cleanupPluginLoaderFixturesForTest,
   makePluginLoaderTempDir,
   resetPluginLoaderTestStateForTest,
-  writePlugin,
 } from "../plugins/loader.test-fixtures.js";
 import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { getActivePluginRegistry } from "../plugins/runtime.js";
+import { resolveBundledPluginPublicModulePath } from "../test-utils/bundled-plugin-public-surface.js";
 import { ensureSelectedAgentHarnessPlugin } from "./harness/runtime-plugin.js";
 import { prepareWorkspacePluginRegistries } from "./prepared-model-runtime.inbound-registry.js";
 
-const REGISTER_COPILOT = Symbol.for("openclaw.test.registerCopilot");
-type RegistrationGlobal = typeof globalThis & {
-  [REGISTER_COPILOT]?: typeof copilotPlugin.register;
-};
-
 afterEach(() => {
   vi.restoreAllMocks();
-  delete (globalThis as RegistrationGlobal)[REGISTER_COPILOT];
   resetPluginLoaderTestStateForTest();
 });
 afterAll(cleanupPluginLoaderFixturesForTest);
@@ -35,23 +30,22 @@ it("prepares an agent-local Copilot BYOK harness without replacing the active ro
       throw new Error("prepared harness discovery must not activate state stores");
     });
   const workspaceDir = fs.realpathSync(makePluginLoaderTempDir());
-  const bundledRoot = fs.realpathSync(makePluginLoaderTempDir());
-  // Let Vitest import the public entrypoint once; the real loader still owns its
-  // manifest, mode, API, and registry without a second SDK source-transform graph.
-  const plugin = writePlugin({
-    id: "copilot",
-    filename: "index.cjs",
-    dir: path.join(bundledRoot, "copilot"),
-    body: `module.exports = {
-      id: "copilot",
-      register(api) { globalThis[Symbol.for("openclaw.test.registerCopilot")](api); },
-    };`,
+  const entrypoint = resolveBundledPluginPublicModulePath({
+    pluginId: "copilot",
+    artifactBasename: "index.ts",
   });
-  fs.copyFileSync(
-    new URL("../../extensions/copilot/openclaw.plugin.json", import.meta.url),
-    path.join(plugin.dir, "openclaw.plugin.json"),
-  );
-  (globalThis as RegistrationGlobal)[REGISTER_COPILOT] = copilotPlugin.register;
+  const copilotModule = await loadBundledPluginPublicSurface({
+    pluginId: "copilot",
+    artifactBasename: "index.ts",
+  });
+  // Reuse Vitest's source graph at the module-loading seam. The real loader
+  // still discovers and validates the entrypoint and owns registration.
+  const loadModule = vi.fn((source: string) => {
+    expect(source).toBe(entrypoint);
+    return copilotModule;
+  });
+  vi.spyOn(pluginModuleRuntime, "createPluginModuleLoader").mockReturnValue(loadModule);
+  const bundledRoot = path.dirname(path.dirname(entrypoint));
   const env = {
     ...process.env,
     OPENCLAW_STATE_DIR: fs.realpathSync(makePluginLoaderTempDir()),
@@ -117,12 +111,13 @@ it("prepares an agent-local Copilot BYOK harness without replacing the active ro
   );
 
   expect(runtimePluginRegistry).not.toBe(root);
+  expect(loadModule).toHaveBeenCalledWith(entrypoint);
   expect(getActivePluginRegistry()).toBe(root);
   expect(root.agentHarnesses).toEqual([]);
   expect(
     runtimePluginRegistry?.plugins,
     JSON.stringify(runtimePluginRegistry?.diagnostics),
-  ).toEqual([expect.objectContaining({ id: "copilot", status: "loaded" })]);
+  ).toEqual([expect.objectContaining({ id: "copilot", status: "loaded", source: entrypoint })]);
   await expect(
     ensureSelectedAgentHarnessPlugin({
       ...selection,

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -456,19 +456,21 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
     const generation = owner.generation;
     const key = ownerKey(input);
     let registered = params.owners.get(key) === owner;
+    // Scoped reloads retain unaffected generations beyond their creating publication epoch.
+    // Persistent catalog/auth callbacks must retire only with this exact registered generation.
+    const isGenerationCurrent = () =>
+      owner.generation === generation && params.owners.get(key) === owner;
     return {
       catalogMode: owner.catalogMode,
       input,
+      isGenerationCurrent,
       isEligible: () =>
         (params.isPublicationCurrent?.() ?? true) &&
         owner.generation === generation &&
         (registered
           ? params.owners.get(key) === owner
           : params.registerEntriesAfterBuildStart === true),
-      isCurrent: () =>
-        (params.isPublicationCurrent?.() ?? true) &&
-        owner.generation === generation &&
-        params.owners.get(key) === owner,
+      isCurrent: () => (params.isPublicationCurrent?.() ?? true) && isGenerationCurrent(),
       key,
       generation,
       markRegistered: () => {
@@ -512,8 +514,11 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
               params.buildTimeoutMs,
               catalogMode,
               params.onBuildStats,
-              new Map(currentGroup.map((candidate) => [candidate.input, candidate.isCurrent])),
-              params.isBuildCurrent,
+              new Map(
+                currentGroup.map((candidate) => [candidate.input, candidate.isGenerationCurrent]),
+              ),
+              params.isBuildCurrent ??
+                new Map(currentGroup.map((candidate) => [candidate.input, candidate.isCurrent])),
               new Set(
                 currentGroup
                   .filter((candidate) => candidate.owner.provenance === "configured")

--- a/src/agents/prepared-model-runtime.scoped-refresh.test.ts
+++ b/src/agents/prepared-model-runtime.scoped-refresh.test.ts
@@ -17,55 +17,84 @@ const mocks = getPreparedModelRuntimeMocks();
 describe("prepared model runtime scoped refresh", () => {
   beforeEach(() => resetPreparedModelRuntimeHarness());
 
-  it("retains unaffected configured owners across an agent-scoped refresh", async () => {
-    mocks.configuredAgentIds = ["pro", "free"];
-    const initialConfig = {
-      agents: {
-        entries: {
-          pro: { model: "openai/gpt-5.6" },
-          free: { model: "openai/gpt-5.5" },
+  it.each([false, true])(
+    "retains catalog callbacks across scoped exec reloads (warmed: %s)",
+    async (warmed) => {
+      mocks.configuredAgentIds = ["pro", "free"];
+      const initialConfig = {
+        agents: {
+          defaults: { model: "openai/gpt-5.6-luna" },
+          entries: {
+            pro: { tools: { exec: { security: "full", ask: "off" } } },
+            free: {},
+          },
         },
-      },
-    } satisfies OpenClawConfig;
-    const nextConfig = {
-      agents: {
-        entries: {
-          pro: { model: "openai/gpt-5.4" },
-          free: { model: "openai/gpt-5.5" },
-        },
-      },
-    } satisfies OpenClawConfig;
-    const buildCounts: number[] = [];
-    const freeInput = {
-      config: initialConfig,
-      agentId: "free",
-      agentDir: "/tmp/configured-free",
-      inheritedAuthDir: "/tmp/unused-agent",
-      workspaceDir: "/tmp/workspace-free",
-    };
+      } satisfies OpenClawConfig;
+      const buildCounts: number[] = [];
+      const options = {
+        gatewayLifecycle: true,
+        catalogMode: "static" as const,
+        onBuildStats: (stats: { agentCount: number }) => buildCounts.push(stats.agentCount),
+      };
+      const freeInput = {
+        config: initialConfig,
+        agentId: "free",
+        agentDir: "/tmp/configured-free",
+        inheritedAuthDir: "/tmp/unused-agent",
+        workspaceDir: "/tmp/workspace-free",
+      };
+      const proInput = {
+        ...freeInput,
+        agentId: "pro",
+        agentDir: "/tmp/configured-pro",
+        workspaceDir: "/tmp/workspace-pro",
+      };
+      // The harness stubs discovery, not the snapshot's catalog guards. Real worker retirement
+      // and auth liveness are covered by prepared-model-catalog-worker.integration.test.ts.
+      mocks.runPreparedModelCatalogWorker.mockImplementation(async () => ({
+        entries: [],
+        routeVariants: [],
+      }));
+      await refreshPreparedModelRuntimeSnapshots(initialConfig, options);
+      const retainedReader = getPreparedModelRuntimeSnapshot(freeInput)!;
+      const retainedAuthStore = getPreparedModelRuntimeAuthStore(retainedReader);
+      let catalog = warmed ? await retainedReader.loadFullModelCatalog!() : undefined;
 
-    await refreshPreparedModelRuntimeSnapshots(initialConfig, {
-      gatewayLifecycle: true,
-      onBuildStats: (stats) => buildCounts.push(stats.agentCount),
-    });
-    const retainedReader = getPreparedModelRuntimeSnapshot(freeInput)!;
-    const retainedAuthStore = getPreparedModelRuntimeAuthStore(retainedReader);
+      for (const ask of ["always", "off"] as const) {
+        const previousPro = getPreparedModelRuntimeSnapshot(proInput)!;
+        const nextConfig = {
+          agents: {
+            ...initialConfig.agents,
+            entries: {
+              ...initialConfig.agents.entries,
+              pro: { tools: { exec: { security: "full", ask } } },
+            },
+          },
+        } satisfies OpenClawConfig;
+        await refreshPreparedModelRuntimeSnapshots(nextConfig, {
+          ...options,
+          agentIds: new Set(["pro"]),
+        });
 
-    await refreshPreparedModelRuntimeSnapshots(nextConfig, {
-      gatewayLifecycle: true,
-      agentIds: new Set(["pro"]),
-      onBuildStats: (stats) => buildCounts.push(stats.agentCount),
-    });
-
-    const retained = getPreparedModelRuntimeSnapshot({ ...freeInput, config: nextConfig });
-    expect(buildCounts).toEqual([2, 1]);
-    expect(retained).toMatchObject({ agentId: "free", config: nextConfig });
-    expect(retained).not.toBe(retainedReader);
-    expect(retainedReader.config).toBe(initialConfig);
-    expect(retained?.metadataSnapshot).toBe(retainedReader.metadataSnapshot);
-    expect(retained?.modelCatalog).toBe(retainedReader.modelCatalog);
-    expect(getPreparedModelRuntimeAuthStore(retained!)).toBe(retainedAuthStore);
-  });
+        const retained = getPreparedModelRuntimeSnapshot({ ...freeInput, config: nextConfig })!;
+        expect(retained).toMatchObject({ agentId: "free", config: nextConfig });
+        expect(retained).not.toBe(retainedReader);
+        expect(retainedReader.config).toBe(initialConfig);
+        expect(retained.metadataSnapshot).toBe(retainedReader.metadataSnapshot);
+        expect(retained.modelCatalog).toBe(retainedReader.modelCatalog);
+        expect(getPreparedModelRuntimeAuthStore(retained)).toBe(retainedAuthStore);
+        expect(retained.readFullModelCatalog!()).toBe(catalog);
+        expect(retainedReader.readFullModelCatalog!()).toBe(catalog);
+        const refreshed = await retained.loadFullModelCatalog!({ refresh: true });
+        expect(refreshed).not.toBe(catalog);
+        expect(retainedReader.readFullModelCatalog!()).toBe(refreshed);
+        catalog = refreshed;
+        expect(() => previousPro.readFullModelCatalog!()).toThrow("superseded");
+        await expect(previousPro.loadFullModelCatalog!()).rejects.toThrow("superseded");
+      }
+      expect(buildCounts).toEqual([2, 1, 1]);
+    },
+  );
 
   it("falls back to full refresh when an out-of-scope owner dependency changes", async () => {
     mocks.configuredAgentIds = ["pro", "free"];

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -2737,8 +2737,10 @@ describe("gateway server chat", () => {
           8_000,
         );
         blockedReply.resolve();
-        const settledEvent = await settledSessionChange.catch(() => {
-          throw new Error("Gateway did not publish settled run ownership after chat.send cleanup");
+        const settledEvent = await settledSessionChange.catch((cause: unknown) => {
+          throw new Error("Gateway did not publish settled run ownership after chat.send cleanup", {
+            cause,
+          });
         });
         await waitForAgentRunOk(runId);
         expectRecordFields(settledEvent.payload, {

--- a/src/gateway/test-helpers.server-rpc.test.ts
+++ b/src/gateway/test-helpers.server-rpc.test.ts
@@ -1,0 +1,83 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+import type { WebSocket } from "ws";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { loadSessionEntry, updateSessionEntry } from "../config/sessions/session-accessor.js";
+import { SQLITE_SESSION_WRITER_QUEUES } from "../config/sessions/store-writer-state.js";
+import {
+  disposeOpenClawAgentDatabaseByPath,
+  listOpenClawAgentDatabasesForTest,
+} from "../state/openclaw-agent-db.js";
+import {
+  installGatewayTestHooks,
+  onceMessage,
+  rpcReq,
+  testState,
+  writeSessionStore,
+} from "./test-helpers.js";
+import { installConnectedControlUiServerSuite } from "./test-with-server.js";
+
+installGatewayTestHooks({ scope: "suite" });
+let ws: WebSocket;
+installConnectedControlUiServerSuite((started) => {
+  ws = started.ws;
+});
+
+describe("Gateway RPC fixture session writes", () => {
+  test.each(["raw WebSocket", "rpcReq"])("%s preserves queued session writes", async (request) => {
+    const dir = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-rpc-writes-")),
+    );
+    const storePath = path.join(dir, "openclaw-agent.sqlite");
+    testState.sessionStorePath = storePath;
+    const scope = { agentId: "main", sessionKey: "agent:main:main", storePath };
+    const planning = createDeferred();
+    const release = createDeferred();
+    const writes: Promise<unknown>[] = [];
+    let drains: Promise<void>[] = [];
+    try {
+      await writeSessionStore({ entries: { main: { sessionId: "rpc-writes", updatedAt: 1 } } });
+      expect((await rpcReq(ws, "sessions.subscribe", {})).ok).toBe(true);
+      const first = updateSessionEntry(scope, async () => {
+        planning.resolve();
+        await release.promise;
+        return { label: "first" };
+      });
+      writes.push(first);
+      await planning.promise;
+      const second = updateSessionEntry(scope, () => ({ label: "second" }));
+      writes.push(second);
+      // Observe rejection immediately; retain drains even if the faulty helper drops their map.
+      const outcomes = Promise.allSettled(writes);
+      drains = [...SQLITE_SESSION_WRITER_QUEUES.values()].flatMap((queue) =>
+        queue.drainPromise ? [queue.drainPromise] : [],
+      );
+      if (request === "rpcReq") {
+        expect((await rpcReq(ws, "sessions.subscribe", {})).ok).toBe(true);
+      } else {
+        const id = "queued-writes-control";
+        const response = onceMessage(ws, (event) => event.type === "res" && event.id === id);
+        ws.send(JSON.stringify({ type: "req", id, method: "sessions.subscribe", params: {} }));
+        expect((await response).ok).toBe(true);
+      }
+      release.resolve();
+      expect(await outcomes).toEqual([
+        { status: "fulfilled", value: expect.objectContaining({ label: "first" }) },
+        { status: "fulfilled", value: expect.objectContaining({ label: "second" }) },
+      ]);
+      expect(loadSessionEntry(scope)?.label).toBe("second");
+    } finally {
+      release.resolve();
+      await Promise.allSettled([...writes, ...drains]);
+      // This custom store lives outside the Gateway HOME and owns its own disposal.
+      disposeOpenClawAgentDatabaseByPath(storePath);
+      testState.sessionStorePath = undefined;
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+    expect(
+      listOpenClawAgentDatabasesForTest().some((database) => database.path === storePath),
+    ).toBe(false);
+  });
+});

--- a/src/gateway/test-helpers.server.ts
+++ b/src/gateway/test-helpers.server.ts
@@ -1250,11 +1250,9 @@ export async function rpcReq<T extends Record<string, unknown>>(
   if (hasUnsyncedGatewayTestSessionConfig()) {
     await persistTestSessionConfig();
   }
-  // Gateway suites often mutate testState-backed config/session inputs between
-  // RPCs while reusing one server instance; flush caches so the next request
-  // observes the updated test fixture state.
+  // Refresh mutable config fixtures, but leave in-flight session writers owned
+  // by the running Gateway; their producers publish SQLite cache updates.
   resetConfigRuntimeState();
-  clearSessionStoreCacheForTest();
   if (method === "agent" || method === "chat.send") {
     await prepareGatewayReplyRuntimeForTest();
   }

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -1855,6 +1855,22 @@ describe("scripts/changed-lanes", () => {
     );
   });
 
+  it.each([
+    "extensions/copilot/src/tool-bridge.test.ts",
+    "extensions/codex/src/app-server/dynamic-tool-build.test.ts",
+    "extensions/copilot/src/test-support/fixture.ts",
+    "test/helpers/plugins/fixture.ts",
+    "scripts/check-no-extension-test-core-imports.ts",
+    "scripts/check-file-utils.ts",
+    "scripts/check-changed.mts",
+  ])("checks extension test import boundaries for %s", (changedPath) => {
+    const plan = createChangedCheckPlan(detectChangedLanes([changedPath]));
+    expect(plan.commands).toContainEqual({
+      name: "extension test core imports",
+      args: ["lint:plugins:no-extension-test-core-imports"],
+    });
+  });
+
   it("runs deprecation hygiene checks for outcome-changing paths and all lanes", () => {
     expect(
       shouldRunDeprecationHygieneChecks([

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -411,6 +411,7 @@ describe("scripts/changed-lanes", () => {
       `pnpm format:check --no-error-on-unmatched-pattern -- ${lanes.paths.join(" ")}`,
       "pnpm deps:patches:check",
       "node scripts/report-test-temp-creations.mjs --base origin/main --head HEAD",
+      "pnpm lint:tmp:tsgo-core-boundary",
       "pnpm tsgo:test:root",
       "pnpm lint:scripts",
     ]);
@@ -1469,6 +1470,7 @@ describe("scripts/changed-lanes", () => {
       // orphan an export here too.
       "dead export scan (skip with OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE=1)",
       "test temp creation report (warning-only)",
+      "core tsgo graph boundary",
       "typecheck core tests",
       "lint core",
       "lint scripts",
@@ -1869,6 +1871,27 @@ describe("scripts/changed-lanes", () => {
       name: "extension test core imports",
       args: ["lint:plugins:no-extension-test-core-imports"],
     });
+  });
+
+  it.each([
+    ["src/agents/prepared-model-runtime.copilot.integration.test.ts", true],
+    ["src/plugins/loader.ts", true],
+    ["src/gateway/gateway-acp-bind.live.test.ts", true],
+    ["packages/normalization-core/src/result.ts", true],
+    ["ui/src/app.ts", true],
+    ["test/helpers/temp-dir.ts", true],
+    ["test/tsconfig/tsconfig.core.test.agents-root.json", true],
+    ["scripts/check-tsgo-core-boundary.mts", true],
+    ["scripts/lib/tsgo-core-test-shards.mts", true],
+    ["scripts/check-changed.mts", true],
+    ["tsconfig.json", true],
+    ["docs/ci.md", false],
+    ["extensions/copilot/index.ts", false],
+  ])("routes the core tsgo graph boundary for %s: %s", (changedPath, expected) => {
+    const commands = createChangedCheckPlan(detectChangedLanes([changedPath])).commands;
+    expect(commands.some((command) => command.args[0] === "lint:tmp:tsgo-core-boundary")).toBe(
+      expected,
+    );
   });
 
   it("runs deprecation hygiene checks for outcome-changing paths and all lanes", () => {

--- a/test/scripts/ci-changed-node-test-plan.test.ts
+++ b/test/scripts/ci-changed-node-test-plan.test.ts
@@ -95,6 +95,20 @@ it.each([
 
 describe("CI changed Node test plan", () => {
   it.each([
+    "extensions/copilot/index.ts",
+    "extensions/copilot/harness.ts",
+    "extensions/copilot/openclaw.plugin.json",
+  ])("keeps host discovery proof when only %s changes", (changedPath) => {
+    const shards = createChangedNodeTestShards([changedPath]);
+    expect(shards?.flatMap((shard) => shard.targets ?? [])).toContain(
+      "src/agents/prepared-model-runtime.copilot.integration.test.ts",
+    );
+    expect(shards?.flatMap((shard) => shard.configs)).toContain(
+      resolveExtensionTestConfig("extensions/copilot"),
+    );
+  });
+
+  it.each([
     {
       source: "ui/src/styles/chat/layout.css",
       targets: [

--- a/test/scripts/ci-changed-node-test-plan.test.ts
+++ b/test/scripts/ci-changed-node-test-plan.test.ts
@@ -18,6 +18,7 @@ import {
   resolveExtensionTestConfig,
 } from "../../scripts/lib/extension-test-plan.mts";
 import {
+  buildVitestRunPlans,
   hasImportGraphImpactOnTargets,
   resolveChangedTestTargetPlan,
 } from "../../scripts/test-projects.test-support.mts";
@@ -99,13 +100,35 @@ describe("CI changed Node test plan", () => {
     "extensions/copilot/harness.ts",
     "extensions/copilot/openclaw.plugin.json",
   ])("keeps host discovery proof when only %s changes", (changedPath) => {
+    const hostTest = "src/agents/prepared-model-runtime.copilot.integration.test.ts";
     const shards = createChangedNodeTestShards([changedPath]);
-    expect(shards?.flatMap((shard) => shard.targets ?? [])).toContain(
-      "src/agents/prepared-model-runtime.copilot.integration.test.ts",
-    );
-    expect(shards?.flatMap((shard) => shard.configs)).toContain(
-      resolveExtensionTestConfig("extensions/copilot"),
-    );
+    expect(shards).not.toBeNull();
+    expect(shards).toHaveLength(2);
+    expect(shards?.flatMap((shard) => shard.targets ?? [])).toEqual([hostTest]);
+    expect(shards?.flatMap((shard) => shard.configs)).toEqual([
+      "test/vitest/vitest.extensions.config.ts",
+    ]);
+    expect(buildVitestRunPlans([hostTest])).toEqual([
+      {
+        config: "test/vitest/vitest.agents-core.config.ts",
+        forwardedArgs: [],
+        includePatterns: [hostTest],
+        watchMode: false,
+      },
+    ]);
+    expect(
+      buildVitestRunPlans([
+        "extensions/copilot/index.test.ts",
+        "extensions/copilot/harness.test.ts",
+      ]),
+    ).toEqual([
+      {
+        config: "test/vitest/vitest.extensions.config.ts",
+        forwardedArgs: [],
+        includePatterns: ["extensions/copilot/index.test.ts", "extensions/copilot/harness.test.ts"],
+        watchMode: false,
+      },
+    ]);
   });
 
   it.each([

--- a/test/scripts/mcp-channels-seed.built-cli.e2e.test.ts
+++ b/test/scripts/mcp-channels-seed.built-cli.e2e.test.ts
@@ -1,0 +1,109 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+import { runSessionStartupMigration } from "../../src/config/sessions/startup-migration.js";
+import type { OpenClawConfig } from "../../src/config/types.openclaw.js";
+import {
+  getSessionEntry,
+  projectSessionDeliveryFields,
+} from "../../src/plugin-sdk/session-store-runtime.js";
+import {
+  readSessionTranscriptEvents,
+  readVisibleSessionTranscriptMessageEntries,
+} from "../../src/plugin-sdk/session-transcript-runtime.js";
+import { withOpenClawTestState } from "../../src/test-utils/openclaw-test-state.js";
+
+const execFileAsync = promisify(execFile);
+
+describe("MCP channels Docker seed", () => {
+  it("seeds startup-ready SQLite history with the MCP conversation and attachment identity", async () => {
+    await withOpenClawTestState(
+      { label: "mcp-channels-seed", scenario: "empty" },
+      async (state) => {
+        // Disable checkout aliases so the seed uses built public SDK entrypoints,
+        // just as the installed candidate does in the functional Docker image.
+        const tsconfigPath = state.path("tsconfig.json");
+        await fs.writeFile(tsconfigPath, "{}");
+        await execFileAsync(
+          process.execPath,
+          ["--import", "tsx", "scripts/e2e/mcp-channels-seed.ts"],
+          {
+            cwd: process.cwd(),
+            env: {
+              PATH: process.env.PATH,
+              ...state.envVars,
+              TSX_TSCONFIG_PATH: tsconfigPath,
+              TSX_DISABLE_CACHE: "1",
+            },
+            timeout: 30_000,
+          },
+        );
+
+        const cfg = JSON.parse(await fs.readFile(state.configPath, "utf8")) as OpenClawConfig;
+        await runSessionStartupMigration({ cfg, env: state.env, log: { info() {}, warn() {} } });
+        const storePath = path.join(state.agentDir(), "openclaw-agent.sqlite");
+        await expect(fs.stat(storePath)).resolves.toMatchObject({ size: expect.any(Number) });
+        const scope = {
+          agentId: "main",
+          sessionKey: "agent:main:main",
+          sessionId: "sess-main",
+          storePath,
+          env: state.env,
+        };
+        const entry = getSessionEntry(scope);
+        expect(entry).toMatchObject({
+          sessionId: "sess-main",
+          displayName: "Docker MCP Channel Smoke",
+        });
+        expect(projectSessionDeliveryFields(entry?.delivery)).toMatchObject({
+          deliveryContext: {
+            channel: "imessage",
+            to: "+15551234567",
+            accountId: "imessage-default",
+            threadId: "thread-42",
+          },
+        });
+        expect(entry).not.toHaveProperty("sessionFile");
+        await expect(readSessionTranscriptEvents(scope)).resolves.toMatchObject([
+          { type: "session", id: "sess-main" },
+          { type: "message", id: "msg-1", parentId: null },
+          { type: "message", id: "msg-attachment", parentId: "msg-1" },
+        ]);
+        await expect(readVisibleSessionTranscriptMessageEntries(scope)).resolves.toMatchObject([
+          {
+            entryId: "msg-1",
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "hello from seeded transcript" }],
+            },
+          },
+          {
+            entryId: "msg-attachment",
+            message: {
+              role: "user",
+              content: "seeded image attachment",
+              __openclaw: {
+                media: [
+                  {
+                    url: "media://inbound/seeded-image.png",
+                    contentType: "image/png",
+                    kind: "image",
+                    fileName: "seeded-image.png",
+                    sizeBytes: 3,
+                  },
+                ],
+              },
+            },
+          },
+        ]);
+        for (const name of ["sessions.json", "sess-main.jsonl"]) {
+          await expect(fs.stat(path.join(state.sessionsDir(), name))).rejects.toMatchObject({
+            code: "ENOENT",
+          });
+        }
+      },
+    );
+  });
+});

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -1831,6 +1831,7 @@ describe("scripts/test-projects changed-target routing", () => {
         config: "test/vitest/vitest.e2e.config.ts",
         forwardedArgs: [
           "test/scripts/doctor-config-preflight-plugin-index.built-cli.e2e.test.ts",
+          "test/scripts/mcp-channels-seed.built-cli.e2e.test.ts",
           "test/scripts/sqlite-sessions-transcripts-flip-proof.built-cli.e2e.test.ts",
           "test/scripts/sqlite-sessions-transcripts-flip-proof.e2e.test.ts",
         ],
@@ -2019,6 +2020,7 @@ describe("scripts/test-projects changed-target routing", () => {
         config: "test/vitest/vitest.e2e.config.ts",
         forwardedArgs: [
           "test/scripts/doctor-config-preflight-plugin-index.built-cli.e2e.test.ts",
+          "test/scripts/mcp-channels-seed.built-cli.e2e.test.ts",
           "test/scripts/sqlite-sessions-transcripts-flip-proof.built-cli.e2e.test.ts",
           "test/scripts/sqlite-sessions-transcripts-flip-proof.e2e.test.ts",
         ],


### PR DESCRIPTION
Closes #131552 — required output tool missing from structured collectors.
Closes #131580 — Copilot absent from prepared agent registries.
Closes #131591 — worker-policy reload poisons retained catalog callbacks.
Closes #131699 — direct credentials skipped during harness preparation.
Closes #131700 — Copilot SDK IDs replace canonical transcript identities.
Closes #131701 — failed harness attempts enter empty-answer recovery.

<details>
<summary>Additional instructions</summary>

Maintainer-editable branch in the upstream repository. AI-assisted maintainer repair.

</details>

## What Problem This Solves

Fixes an issue where operators running structured Swarm collectors would receive missing-output errors or no usable result when work crossed a prepared agent-runtime boundary. The same live investigation found ordinary Copilot turns failing authentication, losing session continuity on retry, and hiding the original failure. Changing a worker's execution policy could also leave the Gateway's retained model catalog spinning indefinitely.

## Why This Change Was Made

Keep collector/schema/credential facts in the canonical preparation flow, register Copilot's inert harness during discovery, and keep OpenClaw's session identity distinct from the SDK's native session. Retained catalog callbacks validate their exact owner generation rather than an expired publication transaction, and failed attempts preserve their error instead of entering empty-answer recovery. No proxy credential fallback, relaxed transcript check, retry workaround, or new storage/configuration surface is added.

The CI follow-ups repair test ownership rather than weaken checks: real host integration uses the supported plugin-loading seam, plugin tests protect the SDK handoff, and changed checks now include both existing import-boundary guards. The Docker MCP seed uses the installed package's canonical SQLite APIs instead of retired session files. A separately reproduced Gateway test-helper bug no longer cancels queued SQLite writes before ordinary RPCs.

## User Impact

Structured collectors retain their required output tool in native, Codex, and Copilot tool construction, including narrowed tool policies. They remain noninteractive while retaining policy-allowed filesystem and shell work. Configured Copilot BYOK turns receive the selected credential, preserve canonical session continuity, and retain useful failure details. A worker-only policy reload no longer invalidates unrelated catalog/auth callbacks.

Thanks to @tmill313 for the original Codex collector report in #120077. This focused repair does not incorporate or close that branch's broader factory/schema/replay proposal. Exact-parent cancellation (#131553), remaining collector settlement defects, and progress presentation remain separate campaign work; this PR does not claim the entire experimental Swarm surface is clean.

## Evidence

**Application runtime:** +97/−113, net −16 across 14 files. **CI tooling:** +23/−5, net +18 across two files. **Tests:** +1370/−194. **Test support:** +58/−54, net +4. The net +2 production/tooling total comes from selecting existing boundary checks and keeping host integration selected for plugin-only changes, not new runtime paths or SDK exports. Lazy existing-store access and generation-versus-publication lifetime are the necessary runtime ownership distinctions; duplicate forwarding and SDK-ID override paths are removed. No schema/version, protocol, dependency, configuration option, baseline, or changelog changes.

The collector factory/policy, discovery registration, retained catalog, direct-credential, session-identity, and failed-terminal regressions failed before their respective owner repairs. Follow-up boundary, seed, queued-write, and fixture-disposal regressions also have red-before/green-after proof. Four native auth-failover controls initially timed out while rebuilding the whole runner per test; the suite now loads once and uses the existing shared-fixture reset, retaining all assertions.

The runtime repair had a separate clean independent review. Fresh independent review of the integrated CI repairs found no actionable P0–P2 findings. This is not a substitute for green exact-head CI.

### Local verification

The full rebased build passed in 4m20.6s, without an ineffective dynamic-import warning. Its runtime source remained unchanged through the test-only follow-ups; all 39 final candidate file hashes were checked before and after the grouped commits. The build stamp predates those test commits, so it is not represented as a separate later rebuild.

```bash
pnpm build
```

The integrated nine-file run passed **332 tests across seven shards** in 196.79s:

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 OPENCLAW_E2E_WORKERS=2 OPENCLAW_E2E_USE_PREBUILT_DIST=1 node scripts/run-vitest.mjs src/agents/prepared-model-runtime.copilot.integration.test.ts extensions/copilot/index.test.ts src/plugins/contracts/boundary-invariants.test.ts test/scripts/changed-lanes.test.ts test/scripts/ci-changed-node-test-plan.test.ts test/scripts/mcp-channels-seed.built-cli.e2e.test.ts src/gateway/server.chat.gateway-server-chat.test.ts src/gateway/test-helpers.server-rpc.test.ts src/test-utils/session-state-cleanup.test.ts --reporter=dot
```

After the final custom-store disposal correction, the focused RPC regression again passed both cases. Against the historical helper, the raw-WebSocket control passed and the helper case failed specifically with `SQLite session store queue cleared for test`.

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/gateway/test-helpers.server-rpc.test.ts --reporter=verbose
```

The final changed gate passed, including both import-boundary checks, core/core-test/scripts/root-test typechecking, lint/format, database-first guards and unchanged state-schema v13:

```bash
OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/check-changed.mjs --timed --base HEAD -- scripts/check-changed.mts scripts/e2e/mcp-channels-seed.ts src/agents/prepared-model-runtime.copilot.integration.test.ts src/gateway/server.chat.gateway-server-chat.test.ts src/gateway/test-helpers.server.ts src/gateway/test-helpers.server-rpc.test.ts test/scripts/changed-lanes.test.ts test/scripts/mcp-channels-seed.built-cli.e2e.test.ts
```

Earlier focused runs also passed: 107 direct-auth/session/error controls, 673 loader/collector/catalog controls, and 129 distinct Gateway owner/sibling/teardown cases on CI's exact synthetic merge. These counts overlap and are not one aggregate total. The seed regression executes real built SDK writes and SQLite reads; the full installed-package/MCP-client lane subsequently passed on `17d808607170c8f1709101ea2ef0ce8d75e2ca45`, along with cron cleanup and MCP Code Mode siblings.

### Real-provider and Control UI verification

The rebuilt candidate passed without a diagnostic observer:

- One Swarm program ran native OpenClaw, Codex, and Copilot collectors. All three actually called `structured_output`, recorded 42/43/44, and returned `CROSS_HARNESS_SWARM_OK 129`, with no active child work left.
- Copilot passed all seven scenarios: real file write/read in both authentication-header modes, same-canonical-session continuation, collectors in both modes, an invalid configured key retaining the original HTTP 401 without empty-answer retry, and same-session recovery after credential restoration. Cleanup was observed through the existing lifecycle-error grace.
- Both worker-policy reload directions passed in one Gateway process, retaining all 251 warmed models. Actual execution succeeded in `full`; `ask` returned `approval_required`; each collector recorded the observed result.

The proof client retains the final `agent` response rather than treating `agent.wait`'s lifecycle summary as the full result. A later negative-auth probe admitted its turn 569 ms before a CLI-written key change was applied; accepted turns intentionally keep their admitted generation. The corrected proof uses the existing `config.patch` hot-application receipt and verifies the applied revision before admission. No production timing or generation rule was changed for either probe.

Before — required output tool missing:

https://github.com/user-attachments/assets/5ec0d55b-f5ff-453d-81dc-e2429ae1d11a

After — native/Codex/Copilot collectors in one rebuilt real run:

https://github.com/user-attachments/assets/feadbcec-3066-4ca0-9dbd-318a42dc0fdc

Hot-reloaded `full` policy — actual execution allowed:

https://github.com/user-attachments/assets/e46888bc-5149-40f5-b2ce-66697efd8da4

Hot-reloaded `ask` policy — actual approval-required denial:

https://github.com/user-attachments/assets/445aad16-1290-4675-82b5-eefcebef555c

These are actual Gateway runs observed in real Chrome through the authenticated extension relay. All 36 new source frames and nine encoded samples were inspected before upload. Capture windows are shorter than total execution; underlying tool calls and results were separately asserted. The isolated Gateway and its runtime descendants were stopped; the operator's instance and unrelated browser tabs were untouched.

Dependency contracts were inspected directly at the exercised Codex **0.150.1** release (`rust-v0.150.1`, commit `90854393966b21e9ebfd21b122334eb09a20c93d`): [native and dynamic tool registration](https://github.com/openai/codex/blob/90854393966b21e9ebfd21b122334eb09a20c93d/codex-rs/core/src/tools/spec_plan.rs#L970-L1248), [dynamic-tool protocol](https://github.com/openai/codex/blob/90854393966b21e9ebfd21b122334eb09a20c93d/codex-rs/protocol/src/dynamic_tools.rs), and [host dispatch/response handling](https://github.com/openai/codex/blob/90854393966b21e9ebfd21b122334eb09a20c93d/codex-rs/core/src/tools/handlers/dynamic.rs). Copilot SDK 1.0.11's tool-defer contract and create/resume wire projection were also inspected.

### CI history and remaining verification boundary

[The previous exact-head run](https://github.com/openclaw/openclaw/actions/runs/33169562969) caught reciprocal test-import/typegraph violations and a Docker seed still producing legacy session files. Those have owner-boundary repairs and failing/passing local regressions. The two later Docker lanes were skipped after the first failure, not counted as passes. The earlier unrelated ingress max-lines failure was already repaired upstream by #131731.

One Gateway settlement assertion timed out in that CI run. Repeated full-file runs on its exact synthetic merge preserved all 64 test names and their order and passed locally. The investigation independently proved and fixed destructive per-RPC writer-queue teardown, but that is **not claimed as the established cause of the original timeout**. The settlement assertion and timeout remain intact, and its underlying rejection cause is now retained. The subsequent Linux/x64 run passed this Gateway shard and all three Docker seed lanes. The independent queued-write defect remains a valid repair, but that green run does not retroactively establish the cause of the original timeout. No failed check is waived.

### Final test-boundary correction

[CI run 33175262882](https://github.com/openclaw/openclaw/actions/runs/33175262882) passed the previous plugin/core import, core typegraph, Gateway settlement and Docker failures. The [installed-package Docker job](https://github.com/openclaw/openclaw/actions/runs/33175262882/job/98862409378) explicitly passed `mcp-channels`, `cron-mcp-cleanup`, and `mcp-code-mode-gateway`. Its remaining failures were the host test's unnecessary broad public-surface path-resolver dependency and two exact tooling test expectations missing the new MCP seed test.

The final correction removes that resolver dependency and declares the source fixture directly; real index evaluation, metadata/discovery, harness registration, lazy state and root-registry isolation remain intact. The host test stays in its existing agent suite. A root-test relocation was rejected because it widened every Copilot-only change to full-core CI. Strengthened entrypoint/harness/manifest cases now require the exact host target plus plugin configuration and reject that widening. Both shell-helper expectations retain independent exact comparisons. This last commit is tests only: +34/−12, with no runtime or CI implementation changes.

The two CI failures and the rejected full-suite-widening candidate have failing-before proof. The final candidate passed **673 tests across 20 files**, including the entire 122-test built-artifact/core-support boundary suite, all six existing import/typegraph guards, the complete changed check, and fresh independent P0–P2 review with no actionable findings. Counts overlap earlier runs and are not one aggregate total.

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/agents/prepared-model-runtime.copilot.integration.test.ts test/scripts/ci-changed-node-test-plan.test.ts test/scripts/test-projects.test.ts
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run --config test/vitest/vitest.full-core-support-boundary.config.ts
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/agents/prepared-model-runtime.inbound-registry.test.ts src/agents/prepared-model-runtime.owner-selection.test.ts src/agents/runtime-plugins.test.ts src/agents/harness/runtime-plugin.test.ts extensions/copilot/index.test.ts extensions/copilot/harness.test.ts
```

```bash
node scripts/check-changed.mjs -- src/agents/prepared-model-runtime.copilot.integration.test.ts test/scripts/ci-changed-node-test-plan.test.ts test/scripts/test-projects.test.ts
```

The direct Codex contract inspection was repeated against the same immutable 0.150.1 source cited above; the review service's missing sibling checkout is not a gap in the maintainer inspection. The Docker seed change uses existing SQLite APIs for disposable test fixtures: it changes no runtime schema, migration, persisted-user-data contract or storage version. These address the latest ClawSweeper rank-up requests, subject to final integrated CI.

[CI run 33179396883](https://github.com/openclaw/openclaw/actions/runs/33179396883) tested merge `6bb51c4eb2d5738f3a2f69d49a88d50c245c6df7` against main `fae55749085189ed6380891a5945a0e96acc62ee`. It passed all prior failing boundaries, Gateway and Docker lanes, but stopped on one unrelated IMAP fixture-startup assertion. The new main-side harness host scope and Codex/embedded/plugin-hook changes were inspected for composition; no conflicting runtime change was found. Main also upgrades QuickJS-WASI from 3.4.0 to 3.5.0, so the combined CI tree—not the older local dependency install—is the integration proof.

### IMAP CI fixture follow-up

The failure was at the **initial cursor assertion**, before any new mail or hook dispatch. The test fixture returned immediately from fire-and-forget watcher startup, then imposed Vitest's default one-second polling deadline on TCP/auth/mailbox initialization. A controlled real-protocol reproduction delayed EXAMINE: the old assertion failed at 1,002 ms, while the same healthy connection had committed its expected cursor at 1,505 ms, with real timers and no health failure or dispatch. With the repaired fixture, the same delayed initialization was observed at 1,254 ms and the original full-file flow passed. The exact scheduler delay in the historical CI run remains unobserved; no delivered-message loss is claimed.

The fixture now waits for the existing SDK cursor store's committed-registration fact. Its rejected-auth case deliberately does not wait for an impossible cursor. The existing push test uses a held greeting to prove startup cannot return prematurely, releases it in `finally`, and retains the actual protocol, dispatch, dedupe and reconnect checks. All 56 original assertions remain; one readiness assertion was added. No timeout increase, retained diagnostic sleep, new runtime API, broader mock, production behavior, or storage change. This defect traces to the original IMAP fixture in #130230 (`87b56458a1dd`).

The full original-order watcher file has red/green delayed-response proof and a deterministic greeting-gate regression that fails with the old helper. All **45 IMAP tests across four files** passed on both Node 24.20.0 and Node 26.7.0 locally. The complete changed gate, extension typechecks, plugin boundaries and independent P0–P2 review passed. A native-promise simplification was discarded because the project targets ES2023 types; the final patch retains the existing typed SDK helper and is byte-identical to the reviewed/tested candidate, with a fresh passing extension-test typecheck.

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/imap
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/check-changed.mjs -- extensions/imap/src/watcher.test.ts extensions/imap/src/imap-test-support.ts
```

The IMAP follow-up is **tests +51/−39, test support +14/−2, runtime +0/−0**. The support module has test callers only. Local macOS proof is not Linux CI parity; the final composed CI run is still mandatory.

**Current head:** `91df52fb3e953bc7f59975b2f067958b9aa182bc`. [Exact-head CI run 33183947656](https://github.com/openclaw/openclaw/actions/runs/33183947656) completed **SUCCESS**, including required gate job 98896909770. It tested merge `63c2bc90f132807fb4dcc38ab3df62fc2ba29814` into reviewed main `9a7de4daa8102a77c1b4280a2bf4a4d55ec2177c`. Native review validation and `OPENCLAW_TESTBOX=1` preparation passed without changing the head. On this branch, all 14 application-runtime files remain byte-identical to the real-provider-tested repair. The prepared head remains unchanged and is ready for native merge.
