### PR TITLE
fix(codex): keep native overrides effective at launch and turn start

### DIFF
--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -512,7 +512,19 @@ and [Run Codex on a cloud worker](/plugins/codex-harness#run-codex-on-a-cloud-wo
 In the default per-agent home, stdio launches use Codex's ephemeral credential
 store, including custom commands selected by `appServer.command` or
 `OPENCLAW_CODEX_APP_SERVER_BIN`. Command wrappers must forward Codex's `-c`
-configuration arguments. OpenClaw supplies auth in this order:
+configuration arguments. For stdio launches with an explicit `app-server`
+subcommand, OpenClaw groups `-c` / `--config` overrides before that subcommand,
+preserving their order and leaving wrapper prefixes and other arguments in place.
+This prevents Codex from dropping earlier overrides when flags appear on both
+sides of `app-server`. OpenClaw's ephemeral credential-store override remains
+last when OpenClaw owns auth; native user-home auth is unchanged.
+Workspace-write turns also preserve explicit `sandbox_workspace_write` temporary
+root exclusions from these arguments, including attached `-ckey=value` flags
+and TOML comments after boolean values. The last explicit value wins.
+Explicit turn sandbox policies and network-proxy permission profiles keep their
+existing precedence.
+
+OpenClaw supplies auth in this order:
 
 1. An explicit or ordered OpenClaw auth profile for the agent.
 2. For an API-key route only, a prepared key or local stdio fallback from

--- a/extensions/codex/src/app-server/app-server-policy.test.ts
+++ b/extensions/codex/src/app-server/app-server-policy.test.ts
@@ -347,20 +347,65 @@ describe("Codex app-server policy", () => {
     ).toBe("user");
   });
 
-  it("checks the selected native profile before trusting model-backed review", async () => {
-    const codexHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-review-profile-"));
-    try {
-      await fs.writeFile(
-        path.join(codexHome, "work.config.toml"),
-        'openai_base_url = "http://localhost:8080/v1"\n',
-      );
+  it.each([["--profile", "work"], ["--profile=work"], ["-pwork"]])(
+    "checks the selected native profile before trusting model-backed review: %j",
+    async (...profileArgs) => {
+      const codexHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-review-profile-"));
+      try {
+        await fs.writeFile(
+          path.join(codexHome, "work.config.toml"),
+          'openai_base_url = "http://localhost:8080/v1"\n',
+        );
+        const appServer = resolveCodexAppServerRuntimeOptions({
+          env: {},
+          requirementsToml: null,
+          execMode: "auto",
+          modelProvider: "openai",
+          model: "gpt-5.5",
+          pluginConfig: { appServer: { homeScope: "user" } },
+        });
+
+        expect(
+          resolveCodexAppServerForModelProvider({
+            appServer: {
+              ...appServer,
+              start: {
+                ...appServer.start,
+                args: [...profileArgs, "app-server"],
+                env: { CODEX_HOME: codexHome },
+              },
+            },
+            provider: "openai",
+            model: "gpt-5.5",
+            env: {},
+          }).approvalsReviewer,
+        ).toBe("user");
+      } finally {
+        await fs.rm(codexHome, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.each([
+    ["-c", 'openai_base_url="http://localhost:8080/v1"'],
+    ["--config", 'openai_base_url="http://localhost:8080/v1"'],
+    ['--config=openai_base_url="http://localhost:8080/v1"'],
+    ['-copenai_base_url="http://localhost:8080/v1"'],
+    ['-c=chatgpt_base_url="http://localhost:8080/v1"'],
+    ['-cmodel_providers.openai.base_url="http://localhost:8080/v1"'],
+    [
+      '-copenai_base_url="http://localhost:8080/v1"',
+      '-copenai_base_url="https://api.openai.com/v1"',
+    ],
+  ])(
+    "checks native command-line endpoint overrides before trusting model-backed review: %j",
+    (...args) => {
       const appServer = resolveCodexAppServerRuntimeOptions({
         env: {},
         requirementsToml: null,
         execMode: "auto",
         modelProvider: "openai",
         model: "gpt-5.5",
-        pluginConfig: { appServer: { homeScope: "user" } },
       });
 
       expect(
@@ -369,8 +414,7 @@ describe("Codex app-server policy", () => {
             ...appServer,
             start: {
               ...appServer.start,
-              args: ["--profile", "work", "app-server"],
-              env: { CODEX_HOME: codexHome },
+              args: ["app-server", ...args],
             },
           },
           provider: "openai",
@@ -378,33 +422,6 @@ describe("Codex app-server policy", () => {
           env: {},
         }).approvalsReviewer,
       ).toBe("user");
-    } finally {
-      await fs.rm(codexHome, { recursive: true, force: true });
-    }
-  });
-
-  it("checks native command-line endpoint overrides before trusting model-backed review", () => {
-    const appServer = resolveCodexAppServerRuntimeOptions({
-      env: {},
-      requirementsToml: null,
-      execMode: "auto",
-      modelProvider: "openai",
-      model: "gpt-5.5",
-    });
-
-    expect(
-      resolveCodexAppServerForModelProvider({
-        appServer: {
-          ...appServer,
-          start: {
-            ...appServer.start,
-            args: ["app-server", "-c", 'openai_base_url="http://localhost:8080/v1"'],
-          },
-        },
-        provider: "openai",
-        model: "gpt-5.5",
-        env: {},
-      }).approvalsReviewer,
-    ).toBe("user");
-  });
+    },
+  );
 });

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -224,7 +224,7 @@ function createStartOptions(
   };
 }
 
-const EPHEMERAL_AUTH_ARGS = ["app-server", "-c", 'cli_auth_credentials_store="ephemeral"'];
+const EPHEMERAL_AUTH_ARGS = ["-c", 'cli_auth_credentials_store="ephemeral"', "app-server"];
 
 async function expectPathMissing(filePath: string): Promise<void> {
   try {
@@ -777,9 +777,9 @@ describe("bridgeCodexAppServerStartOptions", () => {
       expect(bridged.args).toEqual([
         "-c",
         'cli_auth_credentials_store="keyring"',
-        "app-server",
         "-c",
         'cli_auth_credentials_store="ephemeral"',
+        "app-server",
       ]);
     });
   });
@@ -795,9 +795,9 @@ describe("bridgeCodexAppServerStartOptions", () => {
       expect(bridged.args).toEqual([
         "--profile",
         "app-server",
-        "app-server",
         "-c",
         'cli_auth_credentials_store="ephemeral"',
+        "app-server",
       ]);
     });
   });

--- a/extensions/codex/src/app-server/auth-start-options.ts
+++ b/extensions/codex/src/app-server/auth-start-options.ts
@@ -1,12 +1,23 @@
+import { homedir as readHomeDir } from "node:os";
 import path from "node:path";
-import { resolveCodexAppServerUserHomeDir } from "./config-reviewer.js";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { CodexAppServerStartOptions } from "./config.js";
+import { normalizeCodexAppServerArgs } from "./launch-args.js";
 
 const CODEX_APP_SERVER_HOME_DIRNAME = "codex-home";
 const CODEX_EPHEMERAL_AUTH_STORE_OVERRIDE = 'cli_auth_credentials_store="ephemeral"';
 
 export function resolveCodexAppServerHomeDir(agentDir: string): string {
   return path.join(path.resolve(agentDir), CODEX_APP_SERVER_HOME_DIRNAME);
+}
+
+/** Resolves the native user Codex home used by Desktop and the CLI. */
+export function resolveCodexAppServerUserHomeDir(
+  env: NodeJS.ProcessEnv = process.env,
+  homedir: () => string = readHomeDir,
+): string {
+  const configured = normalizeOptionalString(env.CODEX_HOME);
+  return path.resolve(configured ?? path.join(homedir(), ".codex"));
 }
 
 /** Resolves the local CODEX_HOME used when starting one app-server connection. */
@@ -34,14 +45,6 @@ export function withEphemeralCodexAuthStore(params: {
   if (!params.preparedAuth && params.authProfileId === null) {
     return startOptions;
   }
-  if (
-    startOptions.args.at(-2) === "-c" &&
-    startOptions.args.at(-1) === CODEX_EPHEMERAL_AUTH_STORE_OVERRIDE
-  ) {
-    return startOptions;
-  }
-  return {
-    ...startOptions,
-    args: [...startOptions.args, "-c", CODEX_EPHEMERAL_AUTH_STORE_OVERRIDE],
-  };
+  const args = normalizeCodexAppServerArgs(startOptions.args, CODEX_EPHEMERAL_AUTH_STORE_OVERRIDE);
+  return args === startOptions.args ? startOptions : { ...startOptions, args };
 }

--- a/extensions/codex/src/app-server/auth-start-options.ts
+++ b/extensions/codex/src/app-server/auth-start-options.ts
@@ -1,7 +1,7 @@
 import { homedir as readHomeDir } from "node:os";
 import path from "node:path";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import type { CodexAppServerStartOptions } from "./config.js";
+import type { CodexAppServerStartOptions } from "./config-contracts.js";
 import { normalizeCodexAppServerArgs } from "./launch-args.js";
 
 const CODEX_APP_SERVER_HOME_DIRNAME = "codex-home";

--- a/extensions/codex/src/app-server/bounded-turn.test.ts
+++ b/extensions/codex/src/app-server/bounded-turn.test.ts
@@ -511,6 +511,51 @@ describe("runBoundedCodexAppServerTurn settled finalization isolation", () => {
     },
   );
 
+  it("carries attached provider overrides into private turns without importing tool policy", async () => {
+    const fake = createClientFactory();
+    await runBoundedCodexAppServerTurn({
+      model: { mode: "required", id: "gpt-5.4" },
+      timeoutMs: 5_000,
+      options: {
+        clientFactory: fake.factory,
+        pluginConfig: {
+          appServer: {
+            args: [
+              '-copenai_base_url="http://127.0.0.1:9/first"',
+              "app-server",
+              '--config=openai_base_url="http://127.0.0.1:9/last"',
+              '-c=model_catalog_json="/tmp/synthetic-models.json"',
+              "-csandbox_workspace_write.exclude_slash_tmp=false",
+              "--config",
+              "features.hooks=true",
+              "--",
+              '-copenai_base_url="http://127.0.0.1:9/ignored"',
+            ],
+          },
+        },
+      },
+      taskLabel: "isolated completion",
+      developerInstructions: "Answer only.",
+      input: [{ type: "text", text: "Name this conversation.", text_elements: [] }],
+      requiredModalities: ["text"],
+      isolation: "private-stdio",
+    });
+    expect(vi.mocked(fake.factory).mock.calls[0]?.[0]?.startOptions?.args).toEqual([
+      "app-server",
+      "-c",
+      'openai_base_url="http://127.0.0.1:9/first"',
+      "-c",
+      'openai_base_url="http://127.0.0.1:9/last"',
+      "-c",
+      'model_catalog_json="/tmp/synthetic-models.json"',
+      "--listen",
+      "stdio://",
+    ]);
+    expect(
+      fake.request.mock.calls.find(([method]) => method === "thread/start")?.[1],
+    ).toMatchObject({ sandbox: "read-only", approvalPolicy: "on-request" });
+  });
+
   it("preserves the configured native model provider when no override is supplied", async () => {
     const fake = createClientFactory();
 

--- a/extensions/codex/src/app-server/bounded-turn.ts
+++ b/extensions/codex/src/app-server/bounded-turn.ts
@@ -21,6 +21,7 @@ import type { CodexAppServerClient } from "./client.js";
 import { resolveCodexAppServerRuntimeOptions } from "./config.js";
 import { createCodexElicitationResponse } from "./elicitation-response.js";
 import { normalizeCodexResponseTokenUsage } from "./event-projector-usage.js";
+import { readCodexAppServerConfigOptions } from "./launch-args.js";
 import { readModelListResult } from "./models.js";
 import { readCodexNotificationTurnId } from "./notification-correlation.js";
 import { mergeCodexThreadConfigs } from "./plugin-thread-config.js";
@@ -403,17 +404,13 @@ function buildPrivateCodexAppServerStartOptions(
 ): ReturnType<typeof resolveCodexAppServerRuntimeOptions>["start"] {
   // Provider identity and model catalogs must survive isolation; hooks, MCP,
   // sandbox policy, and other process overrides must not cross that boundary.
-  const providerArgs = start.args.flatMap((arg, index) => {
-    const override =
-      arg === "-c" || arg === "--config"
-        ? start.args[index + 1]
-        : arg.startsWith("--config=")
-          ? arg.slice("--config=".length)
-          : undefined;
-    return override && /^\s*(?:openai_base_url|model_catalog_json)\s*=/u.test(override)
-      ? ["-c", override]
-      : [];
-  });
+  const providerArgs = readCodexAppServerConfigOptions(start.args).flatMap(({ name, value }) =>
+    (name === "-c" || name === "--config") &&
+    value &&
+    /^\s*(?:openai_base_url|model_catalog_json)\s*=/u.test(value)
+      ? ["-c", value]
+      : [],
+  );
   const privateEnv = Object.fromEntries(
     Object.entries(start.env ?? {}).filter(
       ([name]) => name.trim().toUpperCase() !== CODEX_APP_SERVER_ARGS_ENV_KEY,

--- a/extensions/codex/src/app-server/config-reviewer.ts
+++ b/extensions/codex/src/app-server/config-reviewer.ts
@@ -1,8 +1,11 @@
 import { readFileSync } from "node:fs";
-import { homedir as readHomeDir } from "node:os";
 import path from "node:path";
 import { resolveProviderIdForAuth } from "openclaw/plugin-sdk/agent-runtime";
 import { parse as parseToml } from "smol-toml";
+import {
+  resolveCodexAppServerHomeDir,
+  resolveCodexAppServerUserHomeDir,
+} from "./auth-start-options.js";
 import type {
   CodexAppServerHomeScope,
   CodexModelBackedReviewerContext,
@@ -16,9 +19,9 @@ import {
   stripTomlLineComments,
 } from "./config-requirements.js";
 import { readNonEmptyString, readRecord } from "./config-utils.js";
+import { readCodexAppServerConfigOptions } from "./launch-args.js";
 import type { CodexConfigReadParams, CodexConfigReadResponse } from "./protocol-control-plane.js";
 
-const CODEX_APP_SERVER_HOME_DIRNAME = "codex-home";
 const CODEX_CONFIG_TOML_FILENAME = "config.toml";
 
 /** Cloud/system config can redirect reviews after local home/profile checks have passed. */
@@ -234,26 +237,19 @@ function readCodexBaseUrlOverridesForModelBackedReview(
 function readNativeCodexReviewerConfigOverrides(
   params: Pick<CodexModelBackedReviewerContext, "agentDir" | "codexArgs" | "env" | "homeScope">,
 ): string[] | false {
+  if (params.codexArgs?.some((arg) => !arg)) {
+    return false;
+  }
   const overrides: string[] = [];
   let profile: string | undefined;
-  const args = params.codexArgs ?? [];
-  for (let index = 0; index < args.length; index += 1) {
-    const arg = args[index];
-    if (!arg) {
+  for (const { name, value } of readCodexAppServerConfigOptions(params.codexArgs ?? [])) {
+    if (!value) {
       return false;
     }
-    if (arg === "--profile" || arg === "-p") {
-      profile = args[++index];
-    } else if (arg.startsWith("--profile=")) {
-      profile = arg.slice("--profile=".length);
-    } else if (arg === "-c" || arg === "--config") {
-      const override = args[++index];
-      if (!override) {
-        return false;
-      }
-      overrides.push(`${override}\n`);
-    } else if (arg.startsWith("--config=")) {
-      overrides.push(`${arg.slice("--config=".length)}\n`);
+    if (name === "--profile" || name === "-p") {
+      profile = value;
+    } else {
+      overrides.push(`${value}\n`);
     }
   }
   if (profile) {
@@ -351,19 +347,9 @@ function resolveCodexAppServerConfigPath(
     return path.join(resolveCodexAppServerUserHomeDir(params.env), CODEX_CONFIG_TOML_FILENAME);
   }
   const agentDir = readNonEmptyString(params.agentDir);
-  const codexHome = agentDir
-    ? path.join(path.resolve(agentDir), CODEX_APP_SERVER_HOME_DIRNAME)
+  return agentDir
+    ? path.join(resolveCodexAppServerHomeDir(agentDir), CODEX_CONFIG_TOML_FILENAME)
     : undefined;
-  return codexHome ? path.join(codexHome, CODEX_CONFIG_TOML_FILENAME) : undefined;
-}
-
-/** Resolves the native user Codex home used by Desktop and the CLI. */
-export function resolveCodexAppServerUserHomeDir(
-  env: NodeJS.ProcessEnv = process.env,
-  homedir: () => string = readHomeDir,
-): string {
-  const configured = readNonEmptyString(env.CODEX_HOME);
-  return path.resolve(configured ?? path.join(homedir(), ".codex"));
 }
 
 function readErrorCode(error: unknown): string | undefined {

--- a/extensions/codex/src/app-server/config-runtime.ts
+++ b/extensions/codex/src/app-server/config-runtime.ts
@@ -1,4 +1,5 @@
 import { normalizeTrimmedStringList } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { parse as parseToml } from "smol-toml";
 import type {
   CodexAppServerApprovalPolicySource,
   CodexAppServerCommandSource,
@@ -63,6 +64,7 @@ import {
   readNumberEnv,
   resolveArgs,
 } from "./config-utils.js";
+import { readCodexAppServerConfigOptions } from "./launch-args.js";
 import type { CodexSandboxPolicy } from "./protocol.js";
 
 /**
@@ -556,15 +558,8 @@ export function codexSandboxPolicyForTurn(
   }
   let excludeTmpdirEnvVar = false;
   let excludeSlashTmp = false;
-  for (let index = 0; index < nativeArgs.length; index += 1) {
-    const arg = nativeArgs[index];
-    const override =
-      arg === "-c" || arg === "--config"
-        ? nativeArgs[++index]
-        : arg?.startsWith("--config=")
-          ? arg.slice("--config=".length)
-          : undefined;
-    if (!override) {
+  for (const { name, value: override } of readCodexAppServerConfigOptions(nativeArgs)) {
+    if ((name !== "-c" && name !== "--config") || !override) {
       continue;
     }
     const separator = override.indexOf("=");
@@ -572,14 +567,21 @@ export function codexSandboxPolicyForTurn(
       continue;
     }
     const key = override.slice(0, separator).trim();
-    const value = override.slice(separator + 1).trim();
-    if (value !== "true" && value !== "false") {
+    let value: unknown;
+    try {
+      // Match Codex's TOML value wrapper, including comments after booleans.
+      value = parseToml(`_x_ = ${override.slice(separator + 1).trim()}`)["_x_"];
+    } catch {
+      // Native parse failures become strings, never boolean exclusions.
+      continue;
+    }
+    if (typeof value !== "boolean") {
       continue;
     }
     if (key === "sandbox_workspace_write.exclude_tmpdir_env_var") {
-      excludeTmpdirEnvVar = value === "true";
+      excludeTmpdirEnvVar = value;
     } else if (key === "sandbox_workspace_write.exclude_slash_tmp") {
-      excludeSlashTmp = value === "true";
+      excludeSlashTmp = value;
     }
   }
   // Native turn/start overrides replace the thread's sandbox. Carry explicit

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -1,4 +1,5 @@
 // Codex helper facade keeps the existing config import surface stable.
+export { resolveCodexAppServerUserHomeDir } from "./auth-start-options.js";
 export {
   CODEX_PLUGIN_MARKETPLACE_NAME_PATTERN,
   CODEX_PLUGINS_MARKETPLACE_NAME,
@@ -29,7 +30,6 @@ export {
 } from "./config-parsing.js";
 export {
   canUseCodexModelBackedApprovalsReviewerForModel,
-  resolveCodexAppServerUserHomeDir,
   resolveCodexModelBackedReviewerPolicyContext,
 } from "./config-reviewer.js";
 export { readCodexRequirementsToml } from "./config-requirements.js";

--- a/extensions/codex/src/app-server/launch-args.ts
+++ b/extensions/codex/src/app-server/launch-args.ts
@@ -1,0 +1,109 @@
+// Single-value root/app-server options from the pinned Codex CLI, shared_options,
+// tui/cli, transport/auth, and code_mode_host. Values are never subcommands.
+const CODEX_VALUE_OPTIONS = new Set([
+  "-m",
+  "--model",
+  "--local-provider",
+  "-p",
+  "--profile",
+  "-s",
+  "--sandbox",
+  "-a",
+  "--ask-for-approval",
+  "-C",
+  "--cd",
+  "--add-dir",
+  "--remote",
+  "--remote-auth-token-env",
+  "-c",
+  "--config",
+  "--enable",
+  "--disable",
+  "--listen",
+  "--code-mode-host",
+  "--ws-auth",
+  "--ws-token-file",
+  "--ws-token-sha256",
+  "--ws-shared-secret-file",
+  "--ws-issuer",
+  "--ws-audience",
+  "--ws-max-clock-skew-seconds",
+]);
+
+type CodexArg = { index: number; end: number; name: string; value?: string };
+
+/** One tokenization owner for launch, turn policy, reviewer trust, and private turns. */
+function readCodexArgs(args: readonly string[]): CodexArg[] {
+  const tokens: CodexArg[] = [];
+  let nativeSubcommand = false;
+  let end = 0;
+  for (const [index, arg] of args.entries()) {
+    if (index < end) {
+      continue;
+    }
+    end = index + 1;
+    const attached = /^(--[^=]+)=([\s\S]*)$/u.exec(arg) ?? /^(-[cmpisaC])=?([\s\S]+)$/u.exec(arg);
+    const name = attached?.[1] ?? arg;
+    let value = attached?.[2];
+    if (name === "-i" || name === "--image") {
+      // Native image arguments consume multiple paths, even one named app-server.
+      while (args[end]?.startsWith("-") === false) {
+        end += 1;
+      }
+    } else if (!attached && CODEX_VALUE_OPTIONS.has(name)) {
+      value = args[end];
+      if (value !== undefined) {
+        end += 1;
+      }
+    }
+    tokens.push({ index, end, name, value });
+    if (name === "app-server") {
+      nativeSubcommand = true;
+    }
+    // A prefix -- may belong to a shell wrapper. After app-server it is native.
+    if (name === "--" && nativeSubcommand) {
+      break;
+    }
+  }
+  return tokens;
+}
+
+export function readCodexAppServerConfigOptions(args: readonly string[]) {
+  return readCodexArgs(args).filter(
+    ({ name }) => name === "-c" || name === "--config" || name === "-p" || name === "--profile",
+  );
+}
+
+/** Keeps Codex overrides in one CLI scope without rewriting raw TOML or wrapper prefixes. */
+export function normalizeCodexAppServerArgs(
+  rawArgs: string[],
+  enforcedOverride?: string,
+): string[] {
+  const tokens = readCodexArgs(rawArgs);
+  const subcommandIndex = tokens.findLast(({ name }) => name === "app-server")?.index ?? -1;
+  const prefix = subcommandIndex < 0 ? [...rawArgs] : rawArgs.slice(0, subcommandIndex);
+  const suffix: string[] = [];
+  if (subcommandIndex >= 0) {
+    // clap replaces root global Append values when a suffix config flag exists.
+    // Move only native suffix overrides, retaining their original order and bytes.
+    for (const token of tokens) {
+      if (token.index <= subcommandIndex) {
+        continue;
+      }
+      if (token.name === "--") {
+        suffix.push(...rawArgs.slice(token.index));
+        break;
+      }
+      const target = token.name === "-c" || token.name === "--config" ? prefix : suffix;
+      target.push(...rawArgs.slice(token.index, token.end));
+    }
+  }
+  if (enforcedOverride && !(prefix.at(-2) === "-c" && prefix.at(-1) === enforcedOverride)) {
+    prefix.push("-c", enforcedOverride);
+  }
+  const normalized = subcommandIndex < 0 ? prefix : [...prefix, "app-server", ...suffix];
+  return normalized.length === rawArgs.length &&
+    normalized.every((arg, index) => arg === rawArgs[index])
+    ? rawArgs
+    : normalized;
+}

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -2015,32 +2015,114 @@ describe("Codex app-server native code mode config", () => {
 });
 
 describe("Codex app-server turn input image sanitizing", () => {
-  it("carries native workspace temporary-root overrides into turn policy", () => {
-    const request = buildTurnStartParams(createAttemptParams({ provider: "openai" }), {
-      threadId: "thread-1",
-      cwd: "/tmp/qa/workspace",
-      appServer: {
-        ...createAppServerOptions(),
-        start: {
-          args: [
-            "app-server",
-            "-c",
-            "sandbox_workspace_write.exclude_tmpdir_env_var=true",
-            "-c",
-            "sandbox_workspace_write.exclude_slash_tmp=true",
-          ],
-        },
-      } as never,
-    });
-
-    expect(request.sandboxPolicy).toEqual({
-      type: "workspaceWrite",
-      writableRoots: ["/tmp/qa/workspace"],
-      networkAccess: false,
-      excludeTmpdirEnvVar: true,
-      excludeSlashTmp: true,
-    });
-  });
+  it.each([
+    {
+      name: "separate",
+      args: [
+        "-c",
+        "sandbox_workspace_write.exclude_tmpdir_env_var=true",
+        "--config",
+        "sandbox_workspace_write.exclude_slash_tmp=true",
+      ],
+      tmpdir: true,
+      slashTmp: true,
+    },
+    {
+      name: "attached short",
+      args: [
+        "-csandbox_workspace_write.exclude_tmpdir_env_var=true",
+        "-c=sandbox_workspace_write.exclude_slash_tmp=true",
+      ],
+      tmpdir: true,
+      slashTmp: true,
+    },
+    {
+      name: "mixed last true",
+      args: [
+        "--config=sandbox_workspace_write.exclude_tmpdir_env_var=false",
+        "-csandbox_workspace_write.exclude_tmpdir_env_var=true",
+        "--config=sandbox_workspace_write.exclude_slash_tmp=true",
+      ],
+      tmpdir: true,
+      slashTmp: true,
+    },
+    {
+      name: "mixed last false",
+      args: [
+        "-csandbox_workspace_write.exclude_tmpdir_env_var=true",
+        "--config",
+        "sandbox_workspace_write.exclude_tmpdir_env_var=false",
+        "--config=sandbox_workspace_write.exclude_slash_tmp=true",
+        "-c=sandbox_workspace_write.exclude_slash_tmp=false",
+      ],
+      tmpdir: false,
+      slashTmp: false,
+    },
+    {
+      name: "commented true across separate and attached forms",
+      args: [
+        "-c",
+        "sandbox_workspace_write.exclude_tmpdir_env_var = false # earlier",
+        "--config=sandbox_workspace_write.exclude_tmpdir_env_var = true # exclusion retained",
+        "--config",
+        "sandbox_workspace_write.exclude_slash_tmp = false # earlier",
+        "-c=sandbox_workspace_write.exclude_slash_tmp = true # exclusion retained",
+      ],
+      tmpdir: true,
+      slashTmp: true,
+    },
+    {
+      name: "commented false wins last",
+      args: [
+        "-csandbox_workspace_write.exclude_tmpdir_env_var=true",
+        "--config",
+        "sandbox_workspace_write.exclude_tmpdir_env_var=false # explicit last value",
+        "--config=sandbox_workspace_write.exclude_slash_tmp=true",
+        "-csandbox_workspace_write.exclude_slash_tmp=false # explicit last value",
+      ],
+      tmpdir: false,
+      slashTmp: false,
+    },
+    {
+      name: "quoted booleans remain strings",
+      args: [
+        '-csandbox_workspace_write.exclude_tmpdir_env_var="true" # not a boolean',
+        "--config=sandbox_workspace_write.exclude_slash_tmp='true' # not a boolean",
+      ],
+      tmpdir: false,
+      slashTmp: false,
+    },
+    {
+      name: "option value and terminator",
+      args: [
+        "--ws-issuer",
+        "-csandbox_workspace_write.exclude_tmpdir_env_var=true",
+        "--",
+        "--config=sandbox_workspace_write.exclude_slash_tmp=true",
+      ],
+      tmpdir: false,
+      slashTmp: false,
+    },
+  ])(
+    "carries native workspace temporary-root overrides into turn policy: $name",
+    ({ args, tmpdir, slashTmp }) => {
+      const request = buildTurnStartParams(createAttemptParams({ provider: "openai" }), {
+        threadId: "thread-1",
+        cwd: "/tmp/qa/workspace",
+        appServer: {
+          ...createAppServerOptions(),
+          start: { args: ["app-server", ...args] },
+        } as never,
+      });
+      expect(request.sandboxPolicy).toEqual({
+        type: "workspaceWrite",
+        writableRoots: ["/tmp/qa/workspace"],
+        networkAccess: false,
+        excludeTmpdirEnvVar: tmpdir,
+        excludeSlashTmp: slashTmp,
+      });
+    },
+  );
 
   it("preserves implicit temporary writable roots for ordinary Codex turns", () => {
     const request = buildTurnStartParams(createAttemptParams({ provider: "openai" }), {
@@ -2062,7 +2144,16 @@ describe("Codex app-server turn input image sanitizing", () => {
     const request = buildTurnStartParams(createAttemptParams({ provider: "openai" }), {
       threadId: "thread-1",
       cwd: "/repo",
-      appServer: createAppServerOptions() as never,
+      appServer: {
+        ...createAppServerOptions(),
+        start: {
+          args: [
+            "-csandbox_workspace_write.exclude_tmpdir_env_var=true",
+            "-csandbox_workspace_write.exclude_slash_tmp=true",
+            "app-server",
+          ],
+        },
+      } as never,
       sandboxPolicy: {
         type: "workspaceWrite",
         writableRoots: ["/repo"],
@@ -2085,7 +2176,16 @@ describe("Codex app-server turn input image sanitizing", () => {
     const request = buildTurnStartParams(createAttemptParams({ provider: "openai" }), {
       threadId: "thread-1",
       cwd: "/repo",
-      appServer: createNetworkProxyAppServerOptions() as never,
+      appServer: {
+        ...createNetworkProxyAppServerOptions(),
+        start: {
+          args: [
+            "-csandbox_workspace_write.exclude_tmpdir_env_var=true",
+            "-csandbox_workspace_write.exclude_slash_tmp=true",
+            "app-server",
+          ],
+        },
+      } as never,
     });
 
     expect(request).not.toHaveProperty("permissions");
@@ -2096,7 +2196,16 @@ describe("Codex app-server turn input image sanitizing", () => {
     const request = buildTurnStartParams(createAttemptParams({ provider: "openai" }), {
       threadId: "thread-1",
       cwd: "/repo",
-      appServer: createNetworkProxyAppServerOptions() as never,
+      appServer: {
+        ...createNetworkProxyAppServerOptions(),
+        start: {
+          args: [
+            "-csandbox_workspace_write.exclude_tmpdir_env_var=true",
+            "-csandbox_workspace_write.exclude_slash_tmp=true",
+            "app-server",
+          ],
+        },
+      } as never,
       sandboxPolicy: {
         type: "externalSandbox",
         networkAccess: "enabled",

--- a/extensions/codex/src/app-server/transport-stdio.config.test.ts
+++ b/extensions/codex/src/app-server/transport-stdio.config.test.ts
@@ -1,0 +1,256 @@
+import fs from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { createInterface } from "node:readline";
+import { withTempDir } from "openclaw/plugin-sdk/test-env";
+import { describe, expect, it, vi } from "vitest";
+import { withEphemeralCodexAuthStore } from "./auth-start-options.js";
+import type { CodexAppServerStartOptions } from "./config.js";
+import { resolveManagedCodexNativeCommand } from "./managed-binary.js";
+import type { CodexConfigReadResponse, CodexInitializeResponse } from "./protocol.js";
+import { createStdioTransport } from "./transport-stdio.js";
+import { closeCodexAppServerTransportAndWait } from "./transport.js";
+import { CODEX_APP_SERVER_VERSION } from "./version.js";
+
+vi.unmock("node:child_process");
+
+const require = createRequire(import.meta.url);
+const launcher = path.join(
+  path.dirname(require.resolve("@openai/codex/package.json")),
+  "bin/codex.js",
+);
+const baseUrl = "http://127.0.0.1:9/config-override-probe";
+
+async function readNativeConfig(startOptions: CodexAppServerStartOptions, env: NodeJS.ProcessEnv) {
+  const child = createStdioTransport(startOptions, env);
+  const closed = new Promise<void>((resolve) => {
+    child.once("close", () => resolve());
+  });
+  const lines = createInterface({ input: child.stdout });
+  let stderr = "";
+  child.stderr.on("data", (chunk: Buffer) => {
+    stderr = (stderr + chunk.toString()).slice(-4_000);
+  });
+  child.stdin.on("error", () => {});
+  try {
+    return await new Promise<CodexConfigReadResponse>((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error(`Native config read timed out: ${stderr}`)),
+        60_000,
+      );
+      const send = (message: object) => child.stdin.write(`${JSON.stringify(message)}\n`);
+      child.once("error", reject);
+      child.once("close", () => {
+        clearTimeout(timeout);
+        reject(new Error(`Native config process closed before config/read: ${stderr}`));
+      });
+      lines.on("line", (line) => {
+        try {
+          const message = JSON.parse(line) as {
+            id?: number;
+            error?: unknown;
+            result?: CodexInitializeResponse | CodexConfigReadResponse;
+          };
+          if (message.error) {
+            throw new Error(JSON.stringify(message.error));
+          }
+          if (message.id === 1) {
+            const initialized = message.result as CodexInitializeResponse;
+            expect(initialized.userAgent).toContain(`/${CODEX_APP_SERVER_VERSION} `);
+            send({ method: "initialized", params: {} });
+            send({
+              id: 2,
+              method: "config/read",
+              params: { includeLayers: false, cwd: startOptions.cwd },
+            });
+          } else if (message.id === 2) {
+            clearTimeout(timeout);
+            resolve(message.result as CodexConfigReadResponse);
+          }
+        } catch (error) {
+          clearTimeout(timeout);
+          reject(new Error("Native config response failed", { cause: error }));
+        }
+      });
+      send({
+        id: 1,
+        method: "initialize",
+        params: {
+          clientInfo: { name: "openclaw_config_test", version: "1.0.0" },
+          capabilities: { experimentalApi: true },
+        },
+      });
+    });
+  } finally {
+    lines.close();
+    expect(await closeCodexAppServerTransportAndWait(child)).toBe(true);
+    await closed;
+  }
+}
+
+describe("Codex stdio effective configuration", () => {
+  it.for([
+    {
+      name: "root overrides with injected auth",
+      placement: "root",
+      authProfileId: undefined,
+      wrapped: false,
+      terminator: false,
+    },
+    {
+      name: "mixed override spellings and last-value precedence",
+      placement: "mixed",
+      authProfileId: undefined,
+      wrapped: false,
+      terminator: false,
+    },
+    {
+      name: "wrapper prefix and option terminator",
+      placement: "mixed",
+      authProfileId: undefined,
+      wrapped: "script",
+      terminator: true,
+    },
+    {
+      name: "shell-owned -c and -- prefix",
+      placement: "mixed",
+      authProfileId: undefined,
+      wrapped: "shell",
+      terminator: true,
+    },
+    {
+      name: "wrapper-supplied subcommand with marker-shaped root values",
+      placement: "root",
+      authProfileId: undefined,
+      wrapped: "implicit",
+      terminator: false,
+    },
+    {
+      name: "native-owned auth without injection",
+      placement: "mixed",
+      authProfileId: null,
+      wrapped: false,
+      terminator: false,
+    },
+  ] as const)(
+    "preserves $name",
+    { timeout: 75_000 },
+    async ({ placement, authProfileId, wrapped, terminator }, context) => {
+      if ((wrapped === "shell" || wrapped === "implicit") && process.platform === "win32") {
+        context.skip();
+      }
+      await withTempDir("openclaw-codex-config-", async (dir) => {
+        const home = await fs.realpath(dir);
+        const codexHome = path.join(home, ".codex");
+        const cwd = path.join(home, "workspace");
+        const tmp = path.join(home, "tmp");
+        await Promise.all([codexHome, cwd, tmp].map((entry) => fs.mkdir(entry)));
+        // No auth, inference, model discovery, or operator-home access is needed.
+        await fs.writeFile(
+          path.join(codexHome, "config.toml"),
+          'cli_auth_credentials_store="file"\n[features]\nrespect_system_proxy=false\n[analytics]\nenabled=false\n[feedback]\nenabled=false\n',
+        );
+        const proxy = "http://127.0.0.1:9";
+        const env: NodeJS.ProcessEnv = {
+          PATH: [path.dirname(process.execPath), "/usr/bin", "/bin"].join(path.delimiter),
+          ...(process.platform === "win32" ? { SystemRoot: process.env.SystemRoot } : {}),
+          HOME: home,
+          USERPROFILE: home,
+          CODEX_HOME: codexHome,
+          TMPDIR: tmp,
+          TMP: tmp,
+          TEMP: tmp,
+          XDG_CONFIG_HOME: path.join(home, ".config"),
+          XDG_DATA_HOME: path.join(home, ".local/share"),
+          XDG_STATE_HOME: path.join(home, ".local/state"),
+          XDG_CACHE_HOME: path.join(home, ".cache"),
+          HTTP_PROXY: proxy,
+          HTTPS_PROXY: proxy,
+          ALL_PROXY: proxy,
+          http_proxy: proxy,
+          https_proxy: proxy,
+          all_proxy: proxy,
+          NO_PROXY: "127.0.0.1,localhost,::1",
+          no_proxy: "127.0.0.1,localhost,::1",
+        };
+        const args =
+          placement === "root"
+            ? [
+                "-c",
+                `openai_base_url=${JSON.stringify(baseUrl)}`,
+                "--config",
+                "model_reasoning_effort=high",
+                ...(wrapped === "implicit" ? [] : ["app-server", "--listen", "stdio://"]),
+              ]
+            : [
+                `-copenai_base_url=${JSON.stringify(baseUrl)}`,
+                "--config=model_reasoning_effort=low",
+                "--config=model_context_window=8192",
+                "-cmodel_auto_compact_token_limit=6000",
+                "--config=model_auto_compact_token_limit_scope=total",
+                "--disable",
+                "fast_mode",
+                "app-server",
+                "-c=model_reasoning_effort=high",
+                "--config",
+                'cli_auth_credentials_store="file"',
+                "--listen",
+                "stdio://",
+              ];
+        const nativeCommand = resolveManagedCodexNativeCommand(launcher);
+        if (!nativeCommand) {
+          throw new Error(
+            "Install the pinned @openai/codex platform package before native config tests.",
+          );
+        }
+        const invocation =
+          wrapped === "implicit"
+            ? {
+                command: "/bin/sh",
+                prefix: [
+                  "-c",
+                  'exec "$@" app-server --listen stdio://',
+                  "--",
+                  nativeCommand,
+                  "--model",
+                  "app-server",
+                  "--image",
+                  "photo.png",
+                  "app-server",
+                ],
+              }
+            : wrapped === "shell"
+              ? { command: "/bin/sh", prefix: ["-c", 'exec "$@"', "--", nativeCommand] }
+              : wrapped === "script"
+                ? { command: process.execPath, prefix: [launcher] }
+                : { command: nativeCommand, prefix: [] };
+        const options: CodexAppServerStartOptions = {
+          transport: "stdio",
+          command: invocation.command,
+          commandSource: "config",
+          args: [...invocation.prefix, ...args, ...(terminator ? ["--"] : [])],
+          cwd,
+          headers: {},
+        };
+        const start = withEphemeralCodexAuthStore({ startOptions: options, authProfileId });
+        const { config } = await readNativeConfig(start, env);
+        expect(config).toMatchObject({
+          openai_base_url: baseUrl,
+          model_reasoning_effort: "high",
+          cli_auth_credentials_store: authProfileId === null ? "file" : "ephemeral",
+          ...(placement === "mixed"
+            ? {
+                model_context_window: 8192,
+                model_auto_compact_token_limit: 6000,
+                model_auto_compact_token_limit_scope: "total",
+                features: { fast_mode: false },
+              }
+            : {}),
+        });
+        await expect(fs.access(path.join(codexHome, "auth.json"))).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+      });
+    },
+  );
+});

--- a/extensions/codex/src/app-server/transport-stdio.sandbox.test.ts
+++ b/extensions/codex/src/app-server/transport-stdio.sandbox.test.ts
@@ -1,0 +1,338 @@
+import fs from "node:fs/promises";
+import http from "node:http";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { createInterface } from "node:readline";
+import { describe, expect, it, vi } from "vitest";
+import { resolveCodexAppServerRuntimeOptions } from "./config.js";
+import { resolveManagedCodexNativeCommand } from "./managed-binary.js";
+import { createStdioTransport } from "./transport-stdio.js";
+import { closeCodexAppServerTransportAndWait } from "./transport.js";
+import { buildTurnStartParams } from "./turn-params.js";
+import { createCodexUserInputTestParams } from "./user-input-bridge.test-support.js";
+import { CODEX_APP_SERVER_VERSION } from "./version.js";
+
+vi.unmock("node:child_process");
+
+// This fixture replaces only model responses. Native turn processing, approvals,
+// process execution, and the platform sandbox are not mocked.
+describe.skipIf(process.platform !== "darwin")("native Codex turn sandbox", () => {
+  it.for([
+    {
+      name: "raw true",
+      args: [
+        "-csandbox_workspace_write.exclude_tmpdir_env_var=true",
+        "-c=sandbox_workspace_write.exclude_slash_tmp=true",
+        "app-server",
+      ],
+      excluded: true,
+    },
+    {
+      name: "commented true",
+      args: [
+        "-csandbox_workspace_write.exclude_tmpdir_env_var=true # exclusion retained",
+        "app-server",
+        "--config=sandbox_workspace_write.exclude_slash_tmp=true # exclusion retained",
+      ],
+      excluded: true,
+    },
+    {
+      name: "commented false wins last",
+      args: [
+        "-csandbox_workspace_write.exclude_tmpdir_env_var=true",
+        "--config=sandbox_workspace_write.exclude_slash_tmp=true",
+        "app-server",
+        "-c",
+        "sandbox_workspace_write.exclude_tmpdir_env_var=false # explicit last value",
+        "-c=sandbox_workspace_write.exclude_slash_tmp=false # explicit last value",
+      ],
+      excluded: false,
+    },
+  ])(
+    "keeps temporary-root exclusions at the native execution boundary: $name",
+    { timeout: 75_000 },
+    async ({ args, excluded }, context) => {
+      const root = await fs.realpath(
+        await fs.mkdtemp(path.join(os.tmpdir(), "codex-turn-sandbox-")),
+      );
+      context.onTestFinished(() => fs.rm(root, { recursive: true, force: true }));
+      const slashTmp = await fs.realpath(await fs.mkdtemp("/tmp/codex-turn-denied-"));
+      context.onTestFinished(() => fs.rm(slashTmp, { recursive: true, force: true }));
+      const cwd = path.join(root, "workspace");
+      const home = path.join(root, "home");
+      const codexHome = path.join(home, ".codex");
+      const tmp = path.join(root, "tmp");
+      await Promise.all([cwd, codexHome, tmp].map((dir) => fs.mkdir(dir, { recursive: true })));
+      const targets = [
+        path.join(cwd, "workspace.txt"),
+        path.join(slashTmp, "slash-tmp.txt"),
+        path.join(tmp, "tmpdir.txt"),
+      ] as const;
+      // All targets are writable by this account before native containment.
+      for (const target of targets) {
+        await fs.writeFile(target, "control");
+        await fs.unlink(target);
+      }
+      let requestCount = 0;
+      const server = http.createServer((req, res) => {
+        req.resume();
+        req.on("end", () => {
+          if (req.url !== "/v1/responses" || req.method !== "POST") {
+            res.writeHead(404).end();
+            return;
+          }
+          requestCount += 1;
+          const script = targets
+            .map(
+              (target, index) =>
+                `if printf proof > '${target}'; then printf 'write-${index}:ok\\n'; else printf 'write-${index}:denied\\n'; fi`,
+            )
+            .join("; ");
+          const item =
+            requestCount === 1
+              ? {
+                  type: "function_call",
+                  call_id: "write-probe",
+                  name: "exec_command",
+                  arguments: JSON.stringify({
+                    cmd: script,
+                    shell: "/bin/sh",
+                    login: false,
+                    max_output_tokens: 1000,
+                  }),
+                }
+              : {
+                  type: "message",
+                  role: "assistant",
+                  id: "done",
+                  content: [{ type: "output_text", text: "Probe complete." }],
+                };
+          const events = [
+            { type: "response.created", response: { id: `response-${requestCount}` } },
+            { type: "response.output_item.done", item },
+            {
+              type: "response.completed",
+              response: {
+                id: `response-${requestCount}`,
+                usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
+              },
+            },
+          ];
+          res.writeHead(200, { "Content-Type": "text/event-stream" });
+          res.end(
+            events
+              .map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
+              .join(""),
+          );
+        });
+      });
+      context.onTestFinished(async () => {
+        server.closeAllConnections();
+        if (server.listening) {
+          await new Promise<void>((resolve, reject) => {
+            server.close((error) => (error ? reject(error) : resolve()));
+          });
+        }
+      });
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Loopback fixture has no TCP address");
+      }
+      const config = [
+        'model="gpt-5.6-luna"',
+        'model_provider="loopback-fixture"',
+        'sandbox_mode="workspace-write"',
+        'approval_policy="on-request"',
+        'approvals_reviewer="user"',
+        'cli_auth_credentials_store="ephemeral"',
+        'web_search="disabled"',
+        "allow_login_shell=false",
+        "[features]",
+        "respect_system_proxy=false",
+        "shell_snapshot=false",
+        "code_mode=false",
+        "code_mode_only=false",
+        "[analytics]",
+        "enabled=false",
+        "[feedback]",
+        "enabled=false",
+        "[model_providers.loopback-fixture]",
+        'name="Loopback test fixture"',
+        `base_url="http://127.0.0.1:${address.port}/v1"`,
+        'wire_api="responses"',
+        "requires_openai_auth=false",
+        "supports_websockets=false",
+      ].join("\n");
+      await fs.writeFile(path.join(codexHome, "config.toml"), config);
+      const require = createRequire(import.meta.url);
+      const launcher = path.join(
+        path.dirname(require.resolve("@openai/codex/package.json")),
+        "bin/codex.js",
+      );
+      const command = resolveManagedCodexNativeCommand(launcher);
+      if (!command) {
+        throw new Error("Pinned native Codex package is required");
+      }
+      const proxy = "http://127.0.0.1:9";
+      const env = {
+        PATH: "/usr/bin:/bin",
+        HOME: home,
+        USERPROFILE: home,
+        CODEX_HOME: codexHome,
+        TMPDIR: tmp,
+        TMP: tmp,
+        TEMP: tmp,
+        SHELL: "/bin/sh",
+        XDG_CONFIG_HOME: path.join(home, ".config"),
+        XDG_DATA_HOME: path.join(home, ".local/share"),
+        XDG_STATE_HOME: path.join(home, ".local/state"),
+        XDG_CACHE_HOME: path.join(home, ".cache"),
+        HTTP_PROXY: proxy,
+        HTTPS_PROXY: proxy,
+        ALL_PROXY: proxy,
+        http_proxy: proxy,
+        https_proxy: proxy,
+        all_proxy: proxy,
+        NO_PROXY: "127.0.0.1,localhost,::1",
+        no_proxy: "127.0.0.1,localhost,::1",
+      };
+      const child = createStdioTransport(
+        { transport: "stdio", command, commandSource: "config", args, cwd, headers: {} },
+        env,
+      );
+      const lines = createInterface({ input: child.stdout });
+      context.onTestFinished(async () => {
+        lines.close();
+        expect(await closeCodexAppServerTransportAndWait(child)).toBe(true);
+      });
+      const pending = new Map<
+        number,
+        { resolve: (value: unknown) => void; reject: (error: Error) => void }
+      >();
+      let nextId = 0;
+      let approvals = 0;
+      let commandOutput = "";
+      let finishTurn: (value: unknown) => void = () => {};
+      const completed = new Promise<unknown>((resolve) => {
+        finishTurn = resolve;
+      });
+      const send = (message: object) => child.stdin.write(`${JSON.stringify(message)}\n`);
+      const request = (method: string, params: object) =>
+        new Promise<unknown>((resolve, reject) => {
+          const id = ++nextId;
+          pending.set(id, { resolve, reject });
+          send({ id, method, params });
+        });
+      child.stdin.on("error", () => {});
+      child.stderr.resume();
+      child.once("close", () => {
+        for (const waiter of pending.values()) {
+          waiter.reject(new Error("Native child closed"));
+        }
+      });
+      lines.on("line", (line) => {
+        const message = JSON.parse(line) as {
+          id?: number;
+          method?: string;
+          result?: unknown;
+          error?: unknown;
+          params?: { item?: { type: string; aggregatedOutput?: string }; turn?: unknown };
+        };
+        if (message.method && message.id !== undefined) {
+          approvals += 1;
+          send({
+            id: message.id,
+            result:
+              message.method === "item/permissions/requestApproval"
+                ? { permissions: {}, scope: "turn" }
+                : { decision: "decline" },
+          });
+        } else if (message.id !== undefined) {
+          const waiter = pending.get(message.id);
+          pending.delete(message.id);
+          if (message.error) {
+            waiter?.reject(new Error(JSON.stringify(message.error)));
+          } else {
+            waiter?.resolve(message.result);
+          }
+        } else if (
+          message.method === "item/completed" &&
+          message.params?.item?.type === "commandExecution"
+        ) {
+          commandOutput += message.params.item.aggregatedOutput ?? "";
+        } else if (message.method === "turn/completed") {
+          finishTurn(message.params?.turn);
+        }
+      });
+      const initialized = await request("initialize", {
+        clientInfo: { name: "openclaw_sandbox_test", version: "1.0.0" },
+        capabilities: { experimentalApi: true },
+      });
+      expect(initialized).toMatchObject({
+        userAgent: expect.stringContaining(`/${CODEX_APP_SERVER_VERSION} `),
+      });
+      send({ method: "initialized", params: {} });
+      const thread = (await request("thread/start", {
+        cwd,
+        model: "gpt-5.6-luna",
+        modelProvider: "loopback-fixture",
+        approvalPolicy: "on-request",
+        approvalsReviewer: "user",
+        sandbox: "workspace-write",
+        ephemeral: true,
+      })) as { thread: { id: string }; sandbox: unknown };
+      expect(thread.sandbox).toMatchObject({
+        type: "workspaceWrite",
+        excludeTmpdirEnvVar: excluded,
+        excludeSlashTmp: excluded,
+      });
+      const appServer = resolveCodexAppServerRuntimeOptions({
+        env: {},
+        codexConfigToml: null,
+        requirementsToml: null,
+        pluginConfig: {
+          appServer: {
+            command,
+            args,
+            sandbox: "workspace-write",
+            approvalPolicy: "on-request",
+            approvalsReviewer: "user",
+          },
+        },
+      });
+      const params = createCodexUserInputTestParams();
+      params.prompt = "Run the deterministic sandbox write probe.";
+      const turn = buildTurnStartParams(params, {
+        threadId: thread.thread.id,
+        cwd,
+        appServer,
+        preserveNativeTurnSettings: true,
+      });
+      await request("turn/start", turn);
+      expect(await completed).toMatchObject({ status: "completed" });
+      expect(approvals).toBe(0);
+      expect(requestCount).toBe(2);
+      expect(commandOutput).toContain("write-0:ok");
+      expect(await fs.readFile(targets[0], "utf8")).toBe("proof");
+      for (const [index, target] of targets.entries()) {
+        if (index === 0) {
+          continue;
+        }
+        expect(commandOutput).toContain(`write-${index}:${excluded ? "denied" : "ok"}`);
+        if (excluded) {
+          expect(commandOutput).toMatch(/Operation not permitted|Permission denied/);
+          await expect(fs.access(target)).rejects.toMatchObject({ code: "ENOENT" });
+        } else {
+          expect(await fs.readFile(target, "utf8")).toBe("proof");
+        }
+      }
+      await expect(fs.access(path.join(codexHome, "auth.json"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    },
+  );
+});

--- a/extensions/codex/src/app-server/transport-stdio.test.ts
+++ b/extensions/codex/src/app-server/transport-stdio.test.ts
@@ -1,7 +1,6 @@
 // Codex tests cover transport stdio plugin behavior.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CodexAppServerStartOptions } from "./config.js";
-import { resolveCodexAppServerRuntimeOptions } from "./config.js";
 import { createStdioTransport, resolveCodexAppServerSpawnEnv } from "./transport-stdio.js";
 
 const spawnMock = vi.hoisted(() => vi.fn(() => ({ pid: 1234 })));
@@ -35,27 +34,53 @@ describe("createStdioTransport", () => {
     );
   });
 
-  it("passes native context and auto-compaction arguments to Codex unchanged", () => {
+  it("preserves wrapper prefixes, root option values, and raw override ordering", () => {
+    const overrides = ["-c", 'developer_instructions="app-server = literal"'];
     const args = [
+      "/wrapper.js",
+      ...overrides,
+      "--profile",
+      "app-server",
       "app-server",
       "--listen",
       "stdio://",
-      "-c",
-      "model_context_window=1000000",
-      "-c",
-      "model_auto_compact_token_limit=700000",
-      "-c",
-      "model_auto_compact_token_limit_scope=total",
+      "--config=model_reasoning_effort=high",
     ];
-    const runtime = resolveCodexAppServerRuntimeOptions({
-      pluginConfig: { appServer: { command: "codex", args } },
-      env: {},
-      requirementsToml: null,
+    createStdioTransport({ ...startOptions("node"), args });
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      "node",
+      [
+        "/wrapper.js",
+        ...overrides,
+        "--profile",
+        "app-server",
+        "--config=model_reasoning_effort=high",
+        "app-server",
+        "--listen",
+        "stdio://",
+      ],
+      expect.any(Object),
+    );
+    expect(args[1]).toBe("-c");
+  });
+
+  it("does not reinterpret a wrapper's positional arguments after --", () => {
+    const args = ["/wrapper.js", "--", "-c", "opaque", "app-server"];
+    createStdioTransport({ ...startOptions("node"), args });
+    expect(spawnMock).toHaveBeenCalledWith("node", args, expect.any(Object));
+  });
+
+  it.each(["--ws-issuer", "--ws-audience"])("preserves a subcommand-shaped %s value", (flag) => {
+    createStdioTransport({
+      ...startOptions("codex"),
+      args: ["app-server", flag, "app-server", "-c", "model_reasoning_effort=high"],
     });
-
-    createStdioTransport(runtime.start);
-
-    expect(spawnMock).toHaveBeenCalledWith("codex", args, expect.any(Object));
+    expect(spawnMock).toHaveBeenCalledWith(
+      "codex",
+      ["-c", "model_reasoning_effort=high", "app-server", flag, "app-server"],
+      expect.any(Object),
+    );
   });
 });
 

--- a/extensions/codex/src/app-server/transport-stdio.ts
+++ b/extensions/codex/src/app-server/transport-stdio.ts
@@ -8,6 +8,7 @@ import {
   resolveWindowsSpawnProgram,
 } from "openclaw/plugin-sdk/windows-spawn";
 import type { CodexAppServerStartOptions } from "./config.js";
+import { normalizeCodexAppServerArgs } from "./launch-args.js";
 
 const UNSAFE_ENVIRONMENT_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 const RUNTIME_INJECTION_ENVIRONMENT_KEYS = new Set([
@@ -45,7 +46,8 @@ function resolveCodexAppServerSpawnInvocation(
     execPath: runtime.execPath,
     packageName: "@openai/codex",
   });
-  const resolved = materializeWindowsSpawnProgram(program, options.args);
+  const args = normalizeCodexAppServerArgs(options.args);
+  const resolved = materializeWindowsSpawnProgram(program, args);
   return {
     command: resolved.command,
     args: resolved.argv,


### PR DESCRIPTION
Closes #131741
Related: #131677

## What Problem This Solves

Fixes an issue where operators supplying native Codex CLI overrides could lose their configured endpoint or reasoning settings at startup, or get different temporary-root settings when a turn starts. Separate, long, and attached short config flags did not all survive the same preparation path.

## Why This Change Was Made

Use one argument reader across stdio launch, turn policy, reviewer endpoint checks, and bounded-turn filtering. Native config overrides are grouped into one CLI parsing scope without rewriting their raw TOML, ordering, wrapper prefixes, or other arguments; the turn owner uses the existing TOML parser for boolean values, including comments and last-value precedence.

This preserves the native CLI contract rather than patching the dependency or dropping the enforced ephemeral auth setting. Pure home resolution also moves out of the broad reviewer import path, and its type import uses the existing leaf contract to avoid a barrel cycle. Three drifting argument-reader loops are removed.

## User Impact

Configured Codex overrides remain effective across launch and turn preparation. OpenClaw-owned auth stays ephemeral; native-owned auth is unchanged. Explicit turn sandbox policies and network-proxy permission profiles keep their existing precedence. Reviewer endpoint trust and the bounded-turn allowlist are not broadened.

No new configuration or environment option, dependency, database/schema, or protocol change. This is code only: no Codex/ClawRouter runtime configuration, credentials, deployment, or private-route enablement.

## Evidence

**Local proof and exact-head PR CI are complete.** Independent Codex P0 review found no actionable blocking issue in the complete patch and directly supplied pinned native source contracts.

Before repair, five of six genuine native config/read scenarios failed. An actual native thread reported both temporary-root exclusions enabled, but the OpenClaw-generated turn allowed writes to both task-owned temporary targets. Additional commented-boolean tests failed at both the turn builder and native execution boundary: commented true lost exclusions, while commented false could retain an earlier true.

After repair, 510 tests in eight focused suites pass, including six real native configuration scenarios and three real macOS sandbox scenarios. Workspace writes are the positive control; raw/commented true denies both outside-workspace temporary writes, and commented false last-wins deliberately permits those task-owned writes. Native startup, turn processing, approvals, execution, and kernel enforcement are genuine. Only model Responses are supplied by a deterministic in-process loopback fixture. All three native scenarios observed zero approval requests and zero grants.

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/codex/src/app-server/auth-bridge.test.ts extensions/codex/src/app-server/config.test.ts extensions/codex/src/app-server/app-server-policy.test.ts extensions/codex/src/app-server/bounded-turn.test.ts extensions/codex/src/app-server/thread-lifecycle.test.ts extensions/codex/src/app-server/transport-stdio.test.ts extensions/codex/src/app-server/transport-stdio.config.test.ts extensions/codex/src/app-server/transport-stdio.sandbox.test.ts
```

The complete changed-scope classifier/check plan passed, including production/test types, formatting, both lint batches, boundary and safety ratchets, and zero runtime import cycles. The full build passed in 373.12 seconds, including all nine unified compilations, runtime-postbuild, SDK declarations/exports, Control UI budgets, and final startup metadata.

```bash
pnpm build
```

An earlier local build failed because the worktree's shared dependency link resolved another checkout's stale AI artifact. A normal task-local pnpm installation fixed the resolution; no package/lockfile, loader override, unrelated source, or other checkout was changed. Two test-authoring/lint issues were corrected before the final full reruns. No timeout, assertion, sandbox, guard, or baseline was weakened.

Native dependency source was inspected directly at Codex `rust-v0.150.1`, commit `90854393966b21e9ebfd21b122334eb09a20c93d`: CLI config/arity owners, config-manager/read, turn settings overrides, filesystem permission conversion, and Seatbelt dispatch. The tested native package is `0.150.1-darwin-arm64`; native initialize also verifies the version.

Every native case uses fresh canonicalized HOME, CODEX_HOME, workspace and temporary roots, a credential-free child environment, workspace-write/on-request/user-reviewer controls, and joined process/socket/temp cleanup. No real account, external provider, private model, or operator service is used. Kernel enforcement proof is macOS arm64 only; Linux/Windows kernel enforcement, authenticated provider behavior, and a stable-release backport range are not claimed. Workspace-write remains workspace-write; this is not a demonstrated sandbox-mode downgrade. There is no visual UI change.

Production LOC: +167/-68 (net +99). Tests: +876/-86 (net +790). Docs: +13/-1. Production growth implements the pinned CLI argument grammar and shared preservation boundary; the TOML continuation adds eight net lines using an existing dependency, without a new exported helper or test-only production seam.

Complete current-source/documentation and publication-text naming checks are clean; credential scans precede review and publication. No raw transcripts, private routing identifiers, credentials, or live configuration are included.

AI-assisted, maintainer-requested implementation and review.

CI follow-up: the first run found a type-only dependency cycle at the moved home-resolution boundary. Importing the same type directly from its existing contract removes the cycle; runtime JavaScript is byte-identical. The failure reproduced locally before the one-line change; Madge and production extension types pass afterward. One unrelated CI job also hit a dependency-download network reset before running its check. Fresh final-source Codex P0 review completed clean after the correction. Exact-head CI [33166926490](https://github.com/openclaw/openclaw/actions/runs/33166926490) passed on `4eb92e9f1f2dd50101499433d31b6e05e11ed73a`, including the native configuration and turn-owner tests. The macOS kernel cases are deliberately skipped by Linux CI and retain their separate local macOS proof. Native landing gates remain required.
