### PR TITLE
fix(update): avoid declaration build timeouts when switching to dev

### DIFF
--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -104,6 +104,11 @@ installs. Extended-stable is rejected on a git checkout without mutating or
 converting it. If the gateway is already installed, `openclaw update` refreshes
 the service metadata and restarts it unless you pass `--no-restart`.
 
+Dev updates build the complete runtime, including plugins and the Control UI,
+without generating TypeScript declarations. Preflight still validates the
+candidate, and the final checkout is rebuilt after checkout or rebase. Ordinary
+`pnpm build` and package builds continue to generate declarations.
+
 For package installs with a managed Gateway service, `openclaw update` targets
 the package root used by that service. If the shell `openclaw` command comes
 from a different install, the updater prints both roots and the managed

--- a/scripts/build-all.mts
+++ b/scripts/build-all.mts
@@ -551,12 +551,18 @@ export function resolveBuildAllEnvironment(
   now: () => Date = () => new Date(),
   readGitCommit: () => string | null = readCurrentGitCommit,
 ) {
-  return resolveBuildIdentityEnvironment({
+  const buildEnv = resolveBuildIdentityEnvironment({
     commitLabel: "build commit",
     env,
     now,
     readGitCommit,
   });
+  // Older installed updaters already send this marker to candidate builds.
+  // Updates need runtime artifacts; explicit declaration/package builds still win.
+  if (buildEnv.OPENCLAW_UPDATE_IN_PROGRESS === "1") {
+    buildEnv[RUN_NODE_SKIP_DTS_BUILD_ENV] ??= "1";
+  }
+  return buildEnv;
 }
 
 export function resolveBuildAllTsdownPlan(
@@ -1009,7 +1015,7 @@ export function runBuildAllSteps(
     steps?: BuildAllStep[];
   } = {},
 ) {
-  let buildEnv = params.env ?? resolveBuildAllEnvironment();
+  let buildEnv = resolveBuildAllEnvironment(params.env);
   const steps = params.steps ?? resolveBuildAllSteps(profile, buildEnv);
   const cacheEnabled = params.cacheEnabled ?? buildEnv.OPENCLAW_BUILD_CACHE !== "0";
   const logger = params.logger ?? console;

--- a/src/infra/update-runner-git-commands.ts
+++ b/src/infra/update-runner-git-commands.ts
@@ -27,17 +27,13 @@ function resolveBuildNodeOptions(baseOptions: string | undefined): string {
 }
 
 export function resolveBuildEnv(
-  env?: NodeJS.ProcessEnv,
+  env: NodeJS.ProcessEnv = process.env,
   buildCacheRoot?: string,
-): NodeJS.ProcessEnv | undefined {
-  const currentNodeOptions = env?.NODE_OPTIONS ?? process.env.NODE_OPTIONS;
-  const nextNodeOptions = resolveBuildNodeOptions(currentNodeOptions);
-  if (nextNodeOptions === currentNodeOptions && !buildCacheRoot) {
-    return env;
-  }
+): NodeJS.ProcessEnv {
   return {
     ...env,
-    NODE_OPTIONS: nextNodeOptions,
+    OPENCLAW_UPDATE_IN_PROGRESS: "1",
+    NODE_OPTIONS: resolveBuildNodeOptions(env.NODE_OPTIONS ?? process.env.NODE_OPTIONS),
     ...(buildCacheRoot ? { BUILD_ALL_CACHE_ROOT: buildCacheRoot } : {}),
   };
 }

--- a/src/infra/update-runner-git-preflight.ts
+++ b/src/infra/update-runner-git-preflight.ts
@@ -361,7 +361,7 @@ async function testPreflightCandidates(params: {
       };
       const buildArgs = managerScriptArgs(manager.manager, "build");
       const buildEnv = resolveBuildEnv(
-        manager.env,
+        manager.env ?? params.defaultCommandEnv,
         path.join(params.gitRoot, ".artifacts", "build-all-cache"),
       );
       const configCommand = ["config", "validate", "--json"];

--- a/src/infra/update-runner-git-recovery.ts
+++ b/src/infra/update-runner-git-recovery.ts
@@ -102,7 +102,7 @@ export async function rebuildRolledBackGitRuntime(params: {
       "git rollback build",
       managerScriptArgs(manager.manager, "build"),
       resolveBuildEnv(
-        manager.env,
+        manager.env ?? params.defaultCommandEnv,
         params.channel === "dev"
           ? path.join(params.gitRoot, ".artifacts", "build-all-cache")
           : undefined,

--- a/src/infra/update-runner-git.ts
+++ b/src/infra/update-runner-git.ts
@@ -442,7 +442,7 @@ export async function updateGitCheckout(params: {
         managerScriptArgs(manager.manager, "build"),
         gitRoot,
         resolveBuildEnv(
-          manager.env,
+          manager.env ?? defaultCommandEnv,
           channel === "dev" ? path.join(gitRoot, ".artifacts", "build-all-cache") : undefined,
         ),
       ),

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -2040,30 +2040,65 @@ describe("runGatewayUpdate", () => {
     expect(cleanupStep?.stderrTail ?? "").toContain("fallback cleanup removed preflight tree");
   });
 
-  it("shares the build cache while adding heap headroom to dev builds", async () => {
-    await setupGitPackageManagerFixture();
-    const buildNodeOptions: string[] = [];
-    const buildCacheRoots: string[] = [];
-    const { calls, runCommand } = await createDevGitRunner({
-      onCommand: (key, options) => {
-        if (key === "pnpm build") {
-          buildNodeOptions.push(options?.env?.NODE_OPTIONS ?? "");
-          buildCacheRoots.push(options?.env?.BUILD_ALL_CACHE_ROOT ?? "");
-        }
-        return undefined;
-      },
-    });
+  it.each([
+    {
+      nodeOptions: undefined,
+      skipDts: undefined,
+      expectedNodeOptions: "--max-old-space-size=8192",
+    },
+    {
+      nodeOptions: "--max-old-space-size=8192",
+      skipDts: "0",
+      expectedNodeOptions: "--max-old-space-size=8192",
+    },
+    {
+      nodeOptions: "--max-old-space-size=16384",
+      skipDts: "1",
+      expectedNodeOptions: "--max-old-space-size=16384",
+    },
+  ])(
+    "marks direct dev builds while preserving heap/cache/override ($skipDts)",
+    async ({ nodeOptions, skipDts, expectedNodeOptions }) => {
+      await setupGitPackageManagerFixture();
+      const buildEnvs: NodeJS.ProcessEnv[] = [];
+      const { calls, runCommand } = await createDevGitRunner({
+        onCommand: (key, options) => {
+          if (key === "pnpm build") {
+            buildEnvs.push(options?.env ?? {});
+          }
+          return undefined;
+        },
+      });
 
-    const result = await runWithCommand(runCommand, { channel: "dev" });
-
-    expect(result.status).toBe("ok");
-    expect(buildNodeOptions).toEqual(["--max-old-space-size=8192", "--max-old-space-size=8192"]);
-    expect(buildCacheRoots).toEqual([
-      path.join(tempDir, ".artifacts", "build-all-cache"),
-      path.join(tempDir, ".artifacts", "build-all-cache"),
-    ]);
-    expect(calls.filter((call) => call === "pnpm build")).toHaveLength(2);
-  });
+      await withEnvAsync(
+        {
+          NODE_OPTIONS: nodeOptions,
+          COREPACK_ENABLE_DOWNLOAD_PROMPT: undefined,
+          OPENCLAW_UPDATE_IN_PROGRESS: undefined,
+          OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: skipDts,
+        },
+        async () => {
+          const result = await runWithCommand(runCommand, { channel: "dev" });
+          expect(result.status).toBe("ok");
+          expect(buildEnvs).toHaveLength(2);
+          for (const env of buildEnvs) {
+            expect(env).toMatchObject({
+              OPENCLAW_UPDATE_IN_PROGRESS: "1",
+              COREPACK_ENABLE_DOWNLOAD_PROMPT: "0",
+              NODE_OPTIONS: expectedNodeOptions,
+              BUILD_ALL_CACHE_ROOT: path.join(tempDir, ".artifacts", "build-all-cache"),
+              PATH: process.env.PATH,
+            });
+            expect(env.OPENCLAW_RUN_NODE_SKIP_DTS_BUILD).toBe(skipDts);
+          }
+          expect(process.env.OPENCLAW_UPDATE_IN_PROGRESS).toBeUndefined();
+          expect(process.env.NODE_OPTIONS).toBe(nodeOptions);
+          expect(process.env.OPENCLAW_RUN_NODE_SKIP_DTS_BUILD).toBe(skipDts);
+        },
+      );
+      expect(calls.filter((call) => call === "pnpm build")).toHaveLength(2);
+    },
+  );
 
   it("pins dev updates to an explicit target ref when requested", async () => {
     await setupGitPackageManagerFixture();
@@ -2973,6 +3008,7 @@ describe("runGatewayUpdate", () => {
       let currentHead = beforeSha;
       let buildCount = 0;
       const calls: string[] = [];
+      const buildEnvs: NodeJS.ProcessEnv[] = [];
       const doctorNodePath = await resolveStableNodePath(process.execPath);
       const doctorCommand = `${doctorNodePath} ${path.join(tempDir, "openclaw.mjs")} doctor --non-interactive --fix`;
       const writeRuntime = async (head: string) => {
@@ -3004,7 +3040,7 @@ describe("runGatewayUpdate", () => {
           ),
         ]);
       };
-      const runCommand = async (argv: string[]) => {
+      const runCommand = async (argv: string[], options?: TestCommandOptions) => {
         const key = argv.join(" ");
         calls.push(key);
         if (key === `git -C ${tempDir} rev-parse --show-toplevel`) {
@@ -3041,6 +3077,7 @@ describe("runGatewayUpdate", () => {
         }
         if (key === "pnpm build") {
           buildCount += 1;
+          buildEnvs.push(options?.env ?? {});
           await writeRuntime(currentHead);
           return toCommandResult();
         }
@@ -3050,7 +3087,17 @@ describe("runGatewayUpdate", () => {
         return toCommandResult();
       };
 
-      const result = await runWithCommand(runCommand, { channel: "stable" });
+      const result = await withEnvAsync(
+        {
+          OPENCLAW_UPDATE_IN_PROGRESS: undefined,
+          NODE_OPTIONS: "--max-old-space-size=8192",
+        },
+        async () => {
+          const updateResult = await runWithCommand(runCommand, { channel: "stable" });
+          expect(process.env.OPENCLAW_UPDATE_IN_PROGRESS).toBeUndefined();
+          return updateResult;
+        },
+      );
 
       expect(result).toMatchObject({
         status: "error",
@@ -3060,6 +3107,10 @@ describe("runGatewayUpdate", () => {
           : { serviceRestartSafe: false, reason: "runtime-verification-failed" },
       });
       expect(buildCount).toBe(2);
+      expect(buildEnvs).toEqual([
+        expect.objectContaining({ OPENCLAW_UPDATE_IN_PROGRESS: "1" }),
+        expect.objectContaining({ OPENCLAW_UPDATE_IN_PROGRESS: "1" }),
+      ]);
       expect(currentHead).toBe(beforeSha);
       expect(
         JSON.parse(await fs.readFile(path.join(tempDir, "dist", "build-info.json"), "utf8")),

--- a/test/scripts/build-all.test.ts
+++ b/test/scripts/build-all.test.ts
@@ -740,28 +740,62 @@ describe("resolveBuildAllSteps", () => {
     expect(labels).not.toContain("check-plugin-sdk-exports");
   });
 
-  it("selects the runtime-only graph from the runner environment", () => {
-    const selectedLabels: string[] = [];
-    const result = runBuildAllSteps("full", {
-      cacheEnabled: false,
-      env: { OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "1" },
-      logger: { error: vi.fn(), warn: vi.fn() },
-      memoryLimit: { cgroupMemoryLimitBytes: 5 * 1024 * 1024 * 1024 },
-      now: () => 0,
-      resolveCacheState(step) {
-        selectedLabels.push(step.label);
-        return { cacheable: false, fresh: false, reason: "no-cache" };
+  describe.each(["full", "package"])("%s runner build environment", (profile) => {
+    it.each([
+      { name: "ordinary build", env: {}, runtimeOnly: false, skipDts: undefined },
+      {
+        name: "runtime override",
+        env: { OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "1" },
+        runtimeOnly: true,
+        skipDts: "1",
       },
-      runStep: () => ({ status: 0 }),
-    });
+      {
+        name: "legacy updater marker",
+        env: { OPENCLAW_UPDATE_IN_PROGRESS: "1" },
+        runtimeOnly: true,
+        skipDts: "1",
+      },
+      {
+        name: "explicit declarations during update",
+        env: { OPENCLAW_UPDATE_IN_PROGRESS: "1", OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "0" },
+        runtimeOnly: false,
+        skipDts: "0",
+      },
+    ])("honors $name in selected steps and compiler children", ({ env, runtimeOnly, skipDts }) => {
+      const originalEnv = { ...env };
+      const invocations: ReturnType<typeof resolveBuildAllStep>[] = [];
+      const result = runBuildAllSteps(profile, {
+        cacheEnabled: false,
+        env,
+        logger: { error: vi.fn(), warn: vi.fn() },
+        memoryLimit: { cgroupMemoryLimitBytes: 5 * 1024 * 1024 * 1024 },
+        now: () => 0,
+        resolveCacheState: () => ({ cacheable: false, fresh: false, reason: "no-cache" }),
+        runStep(invocation) {
+          invocations.push(invocation);
+          return { status: 0 };
+        },
+      });
 
-    expect(result.exitCode).toBe(0);
-    expect(selectedLabels).toEqual(
-      resolveBuildAllSteps("full", { OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "1" }).map(
-        (step) => step.label,
-      ),
-    );
-    expect(selectedLabels).not.toContain("write-plugin-sdk-entry-dts");
+      expect(result.exitCode).toBe(0);
+      const labels = result.timings.map((timing) => timing.label);
+      expect(labels).toEqual(
+        resolveBuildAllSteps(profile, {
+          OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: runtimeOnly ? "1" : "0",
+        }).map((step) => step.label),
+      );
+      expect(labels.includes("write-plugin-sdk-entry-dts")).toBe(!runtimeOnly);
+      expect(labels.includes("check-plugin-sdk-exports")).toBe(!runtimeOnly);
+      expect(labels.includes("clean:dist")).toBe(profile === "package");
+      const compilers = invocations.filter((call) =>
+        call.args.includes("scripts/tsdown-build.mts"),
+      );
+      expect(compilers).toHaveLength(runtimeOnly ? 1 : 3);
+      for (const compiler of compilers) {
+        expect(compiler.options.env.OPENCLAW_RUN_NODE_SKIP_DTS_BUILD).toBe(skipDts);
+      }
+      expect(env).toEqual(originalEnv);
+    });
   });
 
   it("uses a source performance profile with QA assets and immutable build provenance", () => {


### PR DESCRIPTION
Closes #131737

## What Problem This Solves

Fixes an issue where users switching from a stable package to the dev channel could exhaust the Windows upgrade deadline while the candidate source build generated TypeScript declarations. The observed `2026.7.1-2` → `7715da924886d031740161da6a754acf1f9bb12a` run failed in `upgrade.update-dev` after 1,090,130 ms, with the first preflight build still emitting plugin declarations. No compiler, npm, or memory failure was observed.

## Why This Change Was Made

The installed stable updater already marks the whole CLI operation with `OPENCLAW_UPDATE_IN_PROGRESS=1`, so the candidate build now uses that existing marker to default to the existing complete runtime graph before selecting steps or creating compiler children. An explicit declaration override still wins. Current updater build callers also mark preflight, final, and recovery subprocesses, preserving the prepared package-manager environment without mutating the parent process.

Both candidate validation and the final source build remain: ordinary dev updates may rebase local commits between them. Runtime JS, plugin assets, external local plugin output, bootstrap checks, stamps, Control UI, metadata, config validation, doctor, installation, and shim behavior are retained. The incomplete-cache rejection from #125954 is unchanged. No timeouts, retries, config options, dependencies, or environment names are added.

## User Impact

Dev updates build what is needed to run OpenClaw instead of generating package declarations on every candidate and final build. Ordinary `pnpm build`, explicit full declaration builds, and canonical package/release builds retain declarations and their package guards. The updating guide describes the distinction without exposing new configuration.

## Evidence

AI-assisted; implementation and proof inspected by the maintainer agent.

- Before owner edits: two legacy-marker build-runner cases failed because they still selected declarations; three direct-update environment cases and two recovery cases failed because the update marker was missing. All existing cases passed.
- A further prepared-environment regression failed before preserving the default package-manager environment at the three build callers, then passed with the repair.
- `node scripts/run-vitest.mjs test/scripts/build-all.test.ts src/infra/update-runner.test.ts`: 150 passed, including actual build-runner invocation capture, compiler child environment, ordinary/full/package selection, explicit DTS override, preflight/final/recovery, and cache/SDK completeness.
- `node scripts/run-vitest.mjs test/scripts/tsdown-build.test.ts src/infra/run-node.test.ts test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts`: 287 passed, 3 platform skips. This includes the canonical package builder's explicit declaration override and local runtime build behavior.
- Fresh restricted Codex autoreview: no accepted/actionable findings at the skill's default P0 threshold. The final pass includes prepared-environment preservation; no unrestricted reviewer was used.

- `node scripts/check-changed.mjs -- scripts/build-all.mts src/infra/update-runner-git-commands.ts src/infra/update-runner-git-preflight.ts src/infra/update-runner-git-recovery.ts src/infra/update-runner-git.ts src/infra/update-runner.test.ts test/scripts/build-all.test.ts docs/install/updating.md`: passed all selected guards, formatting, typechecks, lint, and import-cycle checks. An initial test-variable shadowing failure was fixed before this successful run.
- Rebased once onto `640d73e3d45`; `git range-diff` proves the reviewed patch is unchanged. Focused tests passed again on candidate `cacca62466ebcffcbaa6d2e0eacd94d613d008c9`.
- `env -u OPENCLAW_RUN_NODE_SKIP_DTS_BUILD OPENCLAW_UPDATE_IN_PROGRESS=1 pnpm build`: passed on candidate, 60.06 seconds on the local Mac, including runtime validators and Control UI. This is not a Windows timing result.
- `env -u OPENCLAW_UPDATE_IN_PROGRESS -u OPENCLAW_RUN_NODE_SKIP_DTS_BUILD pnpm build`: passed afterward, 273.62 seconds, including all declaration groups, canonical SDK declarations, and SDK export validation. The incomplete unified cache was rebuilt, not accepted as complete. No ineffective dynamic-import warnings.
- Exact-head CI passed on attempt 1: [run 33166402900](https://github.com/openclaw/openclaw/actions/runs/33166402900), head `cacca62466ebcffcbaa6d2e0eacd94d613d008c9`. No CI retry or source fix was needed.
- Built commit metadata equals the candidate SHA; runtime entry, Control UI index, SDK declarations, and CLI startup metadata are present. Worktree clean after both builds.

Production: +7/−11 (net −4). Build tooling: +8/−2 (net +6). Tests: +130/−45 (net +85). Docs: +5. The net +2 executable lines connect existing update intent to the existing build graph; the obsolete identity-return branch is removed. No new build flow or production test seam is introduced.

Source/history: stable `src/cli/update-cli/update-command.ts:3652` and `src/infra/update-runner.ts:1335,1577` establish the first-hop marker and two builds. Current direct doctor, automatic preflight, and unsupervised Gateway RPC entry points converge on the same updater build owner. Cache reuse in #117246 and incomplete-cache repair in #125954 were reviewed and preserved. No single introduction date is claimed for the older full-build command combined with current declaration cost.

### Completed exact-head platform and package proof

Landing approved at `cacca62466ebcffcbaa6d2e0eacd94d613d008c9`; source is unchanged after the reviewed patch. The original stable `2026.7.1-2` updater was used, with no harness flag forcing runtime mode and no timeout increase.

| Original upgrade flow | Before | After on approved head |
| --- | --- | --- |
| Windows | Failed during declarations after 1,090,130 ms | Passed: update 1,040,203 ms (17m20s), total 1,766s; original 1,200s phase cap and 120s cleanup reserve unchanged |
| macOS | Update passed in 1,304,684 ms (21m44s) | Passed: update 622,326 ms (10m22s), total 850s |

Windows preflight dependencies/build took 82.613s/231.251s; final dependencies/build took 47.350s/191.574s; explicit UI build took 15.443s. macOS preflight/final builds took 76.019s/79.236s. All builds exited 0; both build summaries on both platforms retained the complete runtime stages and omitted declaration stages. Exact target revision, dev-channel/git-install verification, re-onboarding, Gateway RPC, and a real OpenAI agent turn passed. Windows used its native managed Gateway restart; macOS also passed dashboard loading.

Limits: one Windows Parallels done-poll transport timeout (124) recovered through the existing bounded poll logic, without a whole-lane rerun or budget increase. The macOS old-stable latest-ref precheck failed because the snapshot lacks a GUI-user launchd service domain; the harness's existing documented sudo/manual Gateway path passed after the update. No new workaround was introduced. Raw logs and VM/snapshot identities remain private and were not uploaded.

Actual commands (private VM/snapshot selector values omitted; explicit redaction, not changed execution settings):

```sh
OPENCLAW_PARALLELS_DEV_TARGET_REF=cacca62466ebcffcbaa6d2e0eacd94d613d008c9 \
  gtimeout 90m bash scripts/e2e/parallels-windows-smoke.sh \
  --mode upgrade --provider openai --model openai/gpt-5.6-luna \
  --latest-version 2026.7.1-2 --target-package-spec openclaw@2026.7.1-2 --json
OPENCLAW_PARALLELS_DEV_TARGET_REF=cacca62466ebcffcbaa6d2e0eacd94d613d008c9 \
  gtimeout 75m bash scripts/e2e/parallels-macos-smoke.sh \
  --mode upgrade --provider openai --model openai/gpt-5.6-luna \
  --latest-version 2026.7.1-2 --json
OPENCLAW_UPDATE_IN_PROGRESS=1 node scripts/package-openclaw-for-docker.mjs \
  --allow-unreleased-changelog --source-dir . \
  --output-dir .artifacts/parallels/dev-runtime-candidate-cacca62466e \
  --output-name openclaw-dev-runtime-cacca62466e.tgz --pnpm-pack
```

The package command exited 0 under the update marker, without a caller-supplied DTS override. The canonical packer forced its existing declaration flag to `0`; full declaration generation and the SDK export gate ran. The tarball records the exact candidate SHA and contains 147 `dist/plugin-sdk/*.d.ts` files. SHA-256: `762747f7b9ad9386c23c8ea82f446f6165becb53366eed8e22481eb757c3c4da`. This is real canonical package-build/inventory proof, not the GitHub Package Acceptance workflow, release, or publication.

ClawSweeper's latest full review at https://github.com/openclaw/openclaw/pull/131746#issuecomment-5452000250 has no actionable code/security findings. Its Windows proof requirement, maintainer decision, and rank-up request for after-fix evidence are satisfied by the exact-head results above. Its separate terminal proof timed out; that failed attempt is not claimed as a pass. Completed local runtime/full builds, canonical packaging, and both original VM flows supply the missing observed behavior. No proof waiver, re-review request, or source change is needed for this unchanged head.
