### PR TITLE
fix(control-ui): bind archived deletion to agent scope

### DIFF
--- a/ui/src/pages/sessions/sessions-page.archived.test.ts
+++ b/ui/src/pages/sessions/sessions-page.archived.test.ts
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { SessionsListResult } from "../../api/types.ts";
-import type { ApplicationGatewaySnapshot } from "../../app/context.ts";
+import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
 import { showConfirmDialog } from "../../components/confirm-dialog.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
 import {
@@ -27,6 +27,18 @@ afterEach(() => {
 });
 
 describe("sessions page archived deletion", () => {
+  const captureScopeChange = (context: ApplicationContext) => {
+    let notify: Parameters<ApplicationContext["agentSelection"]["subscribe"]>[0] = () => undefined;
+    context.agentSelection.subscribe = (listener) => {
+      notify = listener;
+      return () => undefined;
+    };
+    return (scopeId: string | null) => {
+      context.agentSelection.state.scopeId = scopeId;
+      notify(context.agentSelection.state);
+    };
+  };
+
   it("removes a confirmed selection while the delete RPC is pending and restores it on rejection", async () => {
     const target = {
       key: "agent:main:cloud",
@@ -365,6 +377,60 @@ describe("sessions page archived deletion", () => {
     expect(showConfirmDialog).not.toHaveBeenCalled();
     expect(sessions.deleteMany).not.toHaveBeenCalled();
     expect(page.error).toContain("archived session enumeration was incomplete");
+  });
+
+  it("abandons archived enumeration when the agent scope changes", async () => {
+    const pendingList = createDeferred<SessionsListResult>();
+    const sessions = createSessions({
+      list: vi.fn(() => pendingList.promise) as unknown as SessionCapability["list"],
+    });
+    const { gateway } = createGateway({} as GatewayBrowserClient);
+    const context = createContext(gateway, sessions);
+    const changeScope = captureScopeChange(context);
+    const page = await createRenderedPage(
+      context,
+      { count: 1, sessions: [{ key: "agent:main:old", archived: true }] } as SessionsListResult,
+      "archived",
+    );
+
+    const deletion = page.deleteAllArchived();
+    await vi.waitFor(() => expect(sessions.list).toHaveBeenCalledOnce());
+    changeScope("writer");
+    pendingList.resolve({
+      count: 1,
+      sessions: [{ key: "agent:main:old", archived: true }],
+    } as SessionsListResult);
+    await deletion;
+
+    expect(showConfirmDialog).not.toHaveBeenCalled();
+    expect(sessions.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("abandons an archived deletion confirmation when the agent scope changes", async () => {
+    const pendingConfirmation = createDeferred<boolean>();
+    const sessions = createSessions({
+      list: vi.fn(async () => ({
+        count: 1,
+        sessions: [{ key: "agent:main:old", archived: true }],
+      })) as unknown as SessionCapability["list"],
+    });
+    const { gateway } = createGateway({} as GatewayBrowserClient);
+    const context = createContext(gateway, sessions);
+    const changeScope = captureScopeChange(context);
+    const page = await createRenderedPage(
+      context,
+      { count: 1, sessions: [{ key: "agent:main:old", archived: true }] } as SessionsListResult,
+      "archived",
+    );
+    vi.mocked(showConfirmDialog).mockReturnValue(pendingConfirmation.promise);
+
+    const deletion = page.deleteAllArchived();
+    await vi.waitFor(() => expect(showConfirmDialog).toHaveBeenCalledOnce());
+    changeScope("writer");
+    pendingConfirmation.resolve(true);
+    await deletion;
+
+    expect(sessions.deleteMany).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -158,6 +158,7 @@ class SessionsPage extends OpenClawLightDomElement {
   private searchTimer?: ReturnType<typeof setTimeout>;
   private appliedListResult: SessionsListResult | null | undefined;
   private readonly observeAgentScope = watchAgentScope(() => {
+    this.invalidatePageWork();
     this.resetTranscriptSearchState(this.transcriptSearchQuery);
     if (!this.deepLinkSessionKey) {
       this.page = 0;


### PR DESCRIPTION
Closes #131747

## What Problem This Solves

Fixes an issue where users switching the Sessions agent scope while **Delete all archived** was enumerating or awaiting confirmation could still confirm deletion of archived sessions and transcripts from the previously visible agent.

## Why This Change Was Made

A semantic agent-scope change now retires page-owned work through the existing page epoch lifecycle. This invalidates both late archived enumeration and an already-open destructive confirmation without changing Gateway protocol or deletion guards.

## User Impact

Archived deletion no longer survives an agent switch. Users must start the action again against the agent scope they can currently see, preventing hidden transcripts from being deleted by stale UI intent.

## Evidence

- Before on `640d73e3d452b3fb53f78cfa679c23101434c927`: the two regression tests failed because stale enumeration called `showConfirmDialog` and a scope switch during confirmation called `deleteMany`.
- After on `3eb0f70e0ff`: `ui/src/pages/sessions/sessions-page.archived.test.ts` passes 11/11, including scope changes before enumeration resolves and after confirmation opens (`ui/src/pages/sessions/sessions-page.archived.test.ts:324-376`).
- Owner fix: the agent-scope observer now invalidates page work (`ui/src/pages/sessions/sessions-page.ts:152-161`), consumed by the existing archived enumeration and post-confirm liveness checks (`ui/src/pages/sessions/sessions-page.ts:794-848`). Production delta: +1 line.
- Independent adversarial verification attempted to refute the analysis and confirmed the bug and owner-level fix.
- Checks: `node scripts/run-vitest.mjs ui/src/pages/sessions/sessions-page.archived.test.ts`; focused lifecycle and roster tests (6/6 selected); `node scripts/check-changed.mjs`.
- Screenshot proof is not stable for this RPC/confirmation ordering race; the deterministic real-page test controls the two async boundaries and asserts no destructive call after scope retirement.
