### PR TITLE
fix(ui): preserve composer attachments across offline reloads

### DIFF
--- a/ui/src/e2e/chat-attachment-read-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-attachment-read-lifecycle.e2e.test.ts
@@ -125,6 +125,59 @@ async function waitForCommittedAttachmentDraft(
 }
 
 suite.define(() => {
+  it("restores an attachment staged offline after reload and reconnect", async () => {
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page);
+        const sessionKey = "global";
+        const text = "offline attachment draft";
+        const contents = "offline attachment contents";
+        await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
+        const composer = page.locator(".agent-chat__composer-combobox textarea");
+        await composer.waitFor();
+
+        await gateway.setOnline(false);
+        await page.locator('.agent-chat__composer-underlaps[data-tone="warn"]').waitFor();
+        await composer.fill(text);
+        await page.locator(".agent-chat__file-input").setInputFiles({
+          name: "offline.txt",
+          mimeType: "text/plain",
+          buffer: Buffer.from(contents),
+        });
+        await expect.poll(() => page.locator(".chat-attachment-thumb").count()).toBe(1);
+        await waitForCommittedAttachmentDraft(page, sessionKey, text);
+
+        await page.reload();
+        await gateway.setOnline(true);
+        await expect.poll(() => composer.inputValue()).toBe(text);
+        await expect.poll(() => page.locator(".chat-attachment-thumb").count()).toBe(1);
+        const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+        if (artifactDir) {
+          await mkdir(artifactDir, { recursive: true });
+          await page.screenshot({ path: path.join(artifactDir, "offline-draft-restored.png") });
+        }
+        await composer.press("Enter");
+
+        const request = await gateway.waitForRequest("chat.send");
+        expect(request.params).toMatchObject({
+          attachments: [
+            {
+              content: Buffer.from(contents).toString("base64"),
+              fileName: "offline.txt",
+              mimeType: "text/plain",
+            },
+          ],
+          message: text,
+        });
+      },
+    );
+  });
+
   it("restores isolated session drafts across fresh pages and retires sent or removed attachments", async () => {
     const firstSession = "agent:main:restart-session-a";
     const secondSession = "agent:main:restart-session-b";

--- a/ui/src/e2e/composer-draft-store.e2e.test.ts
+++ b/ui/src/e2e/composer-draft-store.e2e.test.ts
@@ -64,6 +64,80 @@ async function rawDraftRecords(page: Page, scopes: readonly TestDraftScope[], ex
 }
 
 suite.define(() => {
+  it("does not reuse a cached composer owner while reconnect authentication is unresolved", async () => {
+    await suite.withPage({ locale: "en-US", serviceWorkers: "block" }, async ({ page }) => {
+      await installMockGateway(page);
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const storeHandle = await page.evaluateHandle<
+        typeof import("../lib/chat/composer-draft-store.runtime.ts")
+      >('import("/src/lib/chat/composer-draft-store.runtime.ts")');
+      const composerHandle = await page.evaluateHandle<
+        typeof import("../pages/chat/composer-persistence.ts")
+      >('import("/src/pages/chat/composer-persistence.ts")');
+      const result = await page.evaluate(
+        async ({ draftStore, composer }) => {
+          const client = { recoveryScope: "credential-a", recoveryScopeReady: true };
+          const state = {
+            settings: { gatewayUrl: "owner-fence-gateway" },
+            sessionKey: "agent:main:owner-fence",
+            chatMessage: "",
+            chatAttachments: [],
+            chatQueue: [],
+            client,
+            connected: true,
+            selectedChatSessionIncognito: false,
+          };
+          const scope = {
+            gatewayOwner: state.settings.gatewayUrl,
+            recoveryScope: client.recoveryScope,
+            scopeKey: composer.storedChatOutboxScopeKey(
+              composer.resolveStoredChatOutboxScope(state, state.sessionKey),
+            ),
+          };
+          const persistence = new composer.ChatComposerPersistence(() => state);
+          persistence.start();
+          state.connected = false;
+          client.recoveryScopeReady = false;
+          state.chatMessage = "authenticated offline draft";
+          persistence.persistChangedState();
+          let offlineStored = false;
+          for (let attempt = 0; attempt < 100; attempt += 1) {
+            const stored = await draftStore.readDurableComposerDraft(scope);
+            if (stored.status === "found" && stored.draft.text === state.chatMessage) {
+              offlineStored = true;
+              break;
+            }
+            await new Promise((resolve) => {
+              setTimeout(resolve, 10);
+            });
+          }
+          if (!offlineStored) {
+            throw new Error("offline composer draft did not settle");
+          }
+
+          state.connected = true;
+          state.chatMessage = "unresolved reconnect draft";
+          persistence.persistChangedState();
+          // Let a wrongly admitted fire-and-forget write open its transaction,
+          // then commit a later transaction in the same object store as a barrier.
+          await Promise.resolve();
+          await draftStore.writeDurableComposerDraft(
+            { ...scope, recoveryScope: "credential-b", scopeKey: "reconnect-barrier" },
+            { revision: 1, text: "barrier", attachments: [] },
+            { expectedRevision: 0, writeId: "reconnect-barrier" },
+          );
+          return draftStore.readDurableComposerDraft(scope);
+        },
+        { draftStore: storeHandle, composer: composerHandle },
+      );
+
+      expect(result).toMatchObject({
+        status: "found",
+        draft: { text: "authenticated offline draft" },
+      });
+    });
+  });
+
   it("reads the requested draft before global expiry maintenance settles", async () => {
     await suite.withPage(
       { locale: "en-US", serviceWorkers: "block" },

--- a/ui/src/pages/chat/composer-persistence.ts
+++ b/ui/src/pages/chat/composer-persistence.ts
@@ -703,7 +703,13 @@ export class ChatComposerPersistence {
   private committedDraftRevision = 0;
   private latestDraftRevision = 0;
   private durableRestoreProtected = false;
-  private durableOwnerKey = "";
+  // A transient disconnect invalidates scope readiness, not the owner authenticated
+  // by this client. Client or Gateway replacement still fences the cached owner.
+  private durableOwner: {
+    client: ChatComposerPersistenceState["client"];
+    gatewayOwner: string;
+    recoveryScope: string;
+  } | null = null;
   private durableRetiredScopeKey = "";
   private forceDurableOwnerRestore = false;
   private readonly durablePersistence = new DurableChatComposerPersistence(
@@ -1009,7 +1015,16 @@ export class ChatComposerPersistence {
     if (state.selectedChatSessionIncognito) {
       return null;
     }
-    return this.resolveConnectedDurableScope(state, scope);
+    return (
+      this.resolveConnectedDurableScope(state, scope) ??
+      (this.durableOwner &&
+      !state.connected &&
+      this.durableOwner.client === state.client &&
+      this.durableOwner.gatewayOwner ===
+        storageTargetForGateway(state.settings?.gatewayUrl).gatewayOwner
+        ? { ...this.durableOwner, scopeKey: storedChatOutboxScopeKey(scope) }
+        : null)
+    );
   }
 
   private resolveConnectedDurableScope(
@@ -1038,7 +1053,7 @@ export class ChatComposerPersistence {
         const scopeKey = durableComposerScopeIdentity(connectedScope);
         if (this.durableRetiredScopeKey !== scopeKey) {
           this.durableRetiredScopeKey = scopeKey;
-          this.durableOwnerKey = "";
+          this.durableOwner = null;
           this.forceDurableOwnerRestore = false;
           this.durableRestoreProtected = false;
           this.durablePersistence.retire(connectedScope, this.latestDraftRevision);
@@ -1051,8 +1066,11 @@ export class ChatComposerPersistence {
     if (!scope) {
       return;
     }
-    const ownerKey = JSON.stringify([scope.gatewayOwner, scope.recoveryScope]);
-    if (this.durableOwnerKey && this.durableOwnerKey !== ownerKey) {
+    if (
+      this.durableOwner &&
+      (this.durableOwner.gatewayOwner !== scope.gatewayOwner ||
+        this.durableOwner.recoveryScope !== scope.recoveryScope)
+    ) {
       releaseChatAttachmentPayloads(state.chatAttachments);
       state.chatMessage = "";
       state.chatAttachments = [];
@@ -1071,7 +1089,11 @@ export class ChatComposerPersistence {
       this.durablePersistence.resetRestoreScope();
       state.requestUpdate?.();
     }
-    this.durableOwnerKey = ownerKey;
+    this.durableOwner = {
+      client: state.client,
+      gatewayOwner: scope.gatewayOwner,
+      recoveryScope: scope.recoveryScope,
+    };
     if (this.durableRestoreProtected) {
       this.durableRestoreProtected = false;
       const snapshot = this.snapshot(


### PR DESCRIPTION
Closes #131752

## What Problem This Solves

Attachments staged after the Control UI disconnects could disappear after a hard reload, even though the attachment chip had been visible and the draft text survived.

## Why This Change Was Made

The composer now keeps the last authenticated draft owner only while the same browser client is disconnected. Reconnects must resolve authentication before connected writes resume, and client, Gateway, owner, and Incognito boundaries remain isolated.

This fixes the loss at the durable-persistence owner instead of adding an attachment-specific recovery path.

## User Impact

Attachments staged during a temporary Gateway outage now survive reload and are sent after reconnect with their original filename, media type, and bytes. Drafts cannot cross browser-client, Gateway, recovery-owner, or Incognito boundaries.

## Evidence

- The regression reproduces on the previous implementation: disconnect, stage a file, reload, and reconnect leaves the text but loses the attachment.
- Browser coverage exercises the complete offline → reload → reconnect → send flow and verifies the exact attachment payload sent afterward.
- Owner-isolation coverage confirms that offline writes remain bound to the authenticated owner and that an unresolved reconnect cannot reuse the cached scope.
- [Hosted validation](https://github.com/openclaw/openclaw/actions/runs/33207385450) is green at exact head `1578198da300f9347d4f15457f842e7fc8665c6c`, including Control UI coverage.
- The stored draft schema is unchanged; only admission of the existing scoped snapshot during a same-client disconnect changes.
- Visual capture is not attached because it could show the restored chip but not prove that the original payload bytes survived. The browser regression verifies the consequential filename, media type, and bytes at the send boundary.
