### PR TITLE
fix(release): keep cross-os upgrade preparation runnable

### DIFF
--- a/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
+++ b/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
@@ -562,7 +562,7 @@ jobs:
         run: mkdir -p "$(pnpm store path --silent)"
 
       - name: Install workflow validation dependencies
-        if: inputs.candidate_artifact_name != ''
+        if: inputs.candidate_artifact_name != '' || inputs.mode != 'fresh'
         working-directory: workflow
         env:
           CI: "true"

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -110,6 +110,34 @@ describe("cross-OS release checks workflow", () => {
     expect(baselineMetadata.run).toContain("const entry = resolveNpmJsonEntries(payload).at(-1);");
   });
 
+  it("installs trusted workflow dependencies for artifact resolution and upgrade metadata", () => {
+    const prepare = job(readWorkflow(WORKFLOW_PATH), "prepare");
+    const install = step(prepare, "Install workflow validation dependencies");
+
+    expect(install).toMatchObject({
+      if: "inputs.candidate_artifact_name != '' || inputs.mode != 'fresh'",
+      "working-directory": "workflow",
+      run: "pnpm install --frozen-lockfile --prefer-offline --ignore-scripts",
+    });
+    expect(step(prepare, "Build candidate artifact once").if).toBe(
+      "inputs.candidate_artifact_name == ''",
+    );
+    expect(step(prepare, "Capture baseline metadata").if).toBe("${{ inputs.mode != 'fresh' }}");
+
+    const installIndex =
+      prepare.steps?.findIndex(
+        (candidate) => candidate.name === "Install workflow validation dependencies",
+      ) ?? -1;
+    for (const dependentStep of [
+      "Resolve provided candidate package",
+      "Capture baseline metadata",
+    ]) {
+      expect(installIndex, dependentStep).toBeLessThan(
+        prepare.steps?.findIndex((candidate) => candidate.name === dependentStep) ?? -1,
+      );
+    }
+  });
+
   it("keeps release artifact tarball filenames local before upload paths use them", () => {
     const workflow = readFileSync(WORKFLOW_PATH, "utf8");
 
@@ -377,10 +405,6 @@ describe("cross-OS release checks workflow", () => {
     );
 
     const resolve = step(prepare, "Resolve provided candidate package");
-    expect(step(prepare, "Install workflow validation dependencies")).toMatchObject({
-      if: "inputs.candidate_artifact_name != ''",
-      run: "pnpm install --frozen-lockfile --prefer-offline --ignore-scripts",
-    });
     expect(resolve.run).toContain("resolve-openclaw-package-candidate.mts");
     expect(resolve.run).toContain("--source artifact");
     expect(resolve.run).toContain('--package-sha256 "$INPUT_CANDIDATE_SHA256"');


### PR DESCRIPTION
Related: #131726

## What Problem This Solves

Fixes an issue where cross-OS upgrade validation could build the release candidate successfully, then fail before Windows started because baseline metadata ran without the trusted workflow dependencies installed.

Run 33168669690 reproduced the failure after a 7m32s candidate build: `Capture baseline metadata` could not resolve `tsx` from the trusted workflow checkout.

## Why This Change Was Made

Install trusted workflow validation dependencies when either an immutable candidate must be resolved or upgrade-mode baseline metadata will run. Fresh source builds still skip the install.

## User Impact

Release operators can run cross-OS upgrade validation from a source-built candidate without losing the completed package build to a deterministic setup failure.

## Evidence

- Before: run 33168669690 failed with `ERR_MODULE_NOT_FOUND: Cannot find package 'tsx'` in `Capture baseline metadata`.
- `node scripts/run-vitest.mjs test/scripts/openclaw-cross-os-release-workflow.test.ts` (15 tests)
- `actionlint .github/workflows/openclaw-cross-os-release-checks-reusable.yml`
- targeted oxlint and format checks passed
- no release, FRV, publish, or tag workflow was dispatched

## Review Metrics

- production/workflow: +1 / -1
- tests: +28 / -4
