### PR TITLE
chore(imessage): observe integration timeout phases

### DIFF
--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -121,10 +121,33 @@ describe("sendMessageIMessage receipts", () => {
     return sourcePath;
   }
 
-  it("scrubs private markers before delivering fenced YAML over real iMessage RPC", async () => {
+  it("scrubs private markers before delivering fenced YAML over real iMessage RPC", async (ctx) => {
+    const { signal } = ctx;
+    const started = performance.now();
+    let phase = "fixture";
     const cliPath = openClawState.path("fake-imsg");
     const requestLogPath = openClawState.path("fake-imsg-requests.jsonl");
     const actionLogPath = openClawState.path("fake-imsg-actions.jsonl");
+    const countRecords = (file: string) => {
+      try {
+        const records = fs.readFileSync(file, "utf8").trim();
+        return records ? records.split("\n").length : 0;
+      } catch {
+        return null;
+      }
+    };
+    const recordPhase = () => {
+      console.info(
+        "imessage-send-phase",
+        JSON.stringify({
+          phase,
+          elapsedMs: Math.round(performance.now() - started),
+          requests: countRecords(requestLogPath),
+          actions: countRecords(actionLogPath),
+        }),
+      );
+    };
+    signal.addEventListener("abort", recordPhase, { once: true });
     fs.writeFileSync(
       cliPath,
       [
@@ -165,7 +188,9 @@ describe("sendMessageIMessage receipts", () => {
     vi.stubEnv("VITEST", "");
 
     try {
+      phase = "import-deliver";
       const { deliverIMessageReply } = await import("./monitor/deliver.js");
+      phase = "monitor-yaml";
       const cfg = {
         channels: { imessage: { accounts: { default: { cliPath } } } },
       };
@@ -369,16 +394,20 @@ describe("sendMessageIMessage receipts", () => {
         },
       ];
       for (const testCase of disguisedCases) {
+        phase = "monitor-disguised:" + testCase.name;
         await deliver(testCase.text.join("\n"));
       }
 
+      phase = "rpc-styled";
       await sendMessageIMessage(
         "chat_id:10",
         ["# assistant:", "**😀 styled**", "#+#+#", "assistant to=tool"].join("\n"),
         { config: cfg },
       );
 
+      phase = "import-channel";
       const { imessagePlugin } = await import("./channel.js");
+      phase = "channel-contracts";
       const channelChunker = imessagePlugin.outbound?.chunker;
       const channelSanitizer = imessagePlugin.outbound?.sanitizeText;
       if (!channelChunker || !channelSanitizer) {
@@ -484,6 +513,7 @@ describe("sendMessageIMessage receipts", () => {
         () => deliver(runtimeCompanion),
         () => deliverThroughChannel(runtimeCompanion),
       ]) {
+        phase = "runtime-companion-routes";
         const previousRequestCount = countNativeRequests();
         await sendPrivateRuntime();
         const runtimeRequests = fs
@@ -507,6 +537,7 @@ describe("sendMessageIMessage receipts", () => {
         channelContractRequestCount += runtimeRequests.length;
       }
 
+      phase = "channel-hidden-rejections";
       for (const hidden of [
         "```xml\n<thinking>HIDDEN_CHANNEL_FENCED_THINKING</thinking>\n```",
         "`<thinking>HIDDEN_CHANNEL_INLINE_THINKING</thinking>`",
@@ -526,6 +557,7 @@ describe("sendMessageIMessage receipts", () => {
         );
         expect(countNativeRequests()).toBe(requestCount);
       }
+      phase = "channel-malformed-rejections";
       const malformedHiddenFunctionResponse = [
         '<<script>function_calls><<script>invoke name="exec">HIDDEN_CHANNEL_SYNTH_FUNCTION_CALL</<script>invoke></<script>function_calls><<script>function_response>',
         "HIDDEN_CHANNEL_SYNTH_FUNCTION_RESPONSE",
@@ -622,6 +654,7 @@ describe("sendMessageIMessage receipts", () => {
 
       const rawSeparator = "#+#+#";
       const entitySeparator = "&#35;&#43;&#35;&#43;&#35;";
+      phase = "embedded-role-roundtrips";
       let embeddedRequestCount = 0;
       for (const separator of [rawSeparator, entitySeparator]) {
         for (const role of roles) {
@@ -639,6 +672,7 @@ describe("sendMessageIMessage receipts", () => {
         }
       }
 
+      phase = "dunder-reference";
       const dunderReferenceRequestIndex = countNativeRequests();
       await sendMessageIMessage(
         "chat_id:10",
@@ -657,6 +691,7 @@ describe("sendMessageIMessage receipts", () => {
         ).flat(),
         "```",
       ].join("\n");
+      phase = "oversized-yaml-roundtrips";
       const fixedRequestCount = fs.readFileSync(requestLogPath, "utf8").trim().split("\n").length;
       await deliver(oversizedYaml, 110);
       const monitorRequestCount =
@@ -672,6 +707,7 @@ describe("sendMessageIMessage receipts", () => {
         await sendMessageIMessage("chat_id:10", chunk, { config: cfg });
       }
 
+      phase = "rpc-assertions";
       const readRequests = () =>
         fs
           .readFileSync(requestLogPath, "utf8")
@@ -755,7 +791,9 @@ describe("sendMessageIMessage receipts", () => {
         formatting: [{ start: 153, length: 4, styles: ["bold"] }],
       });
 
+      phase = "import-actions";
       const { imessageActionsRuntime } = await import("./actions.runtime.js");
+      phase = "action-roundtrips";
       const actionOptions = { cliPath, chatGuid: "iMessage;+;chat0000" };
       const fencedYaml = ["```yaml", ...roles.map((role) => `${role}:`), "```"].join("\n");
       await imessageActionsRuntime.sendRichMessage({
@@ -882,6 +920,7 @@ describe("sendMessageIMessage receipts", () => {
         options: actionOptions,
       });
 
+      phase = "action-assertions";
       const readActions = (): string[][] =>
         fs
           .readFileSync(actionLogPath, "utf8")
@@ -981,6 +1020,7 @@ describe("sendMessageIMessage receipts", () => {
         }
       }
 
+      phase = "malformed-runtime-rejection-matrix";
       const forgedTokenEntity = "&#xE000;".repeat("user".length);
       const roleTokenSwap = [
         "```xml",
@@ -1092,6 +1132,7 @@ describe("sendMessageIMessage receipts", () => {
         }
       }
       for (const hidden of privateRuntimeBlocks) {
+        phase = "hidden-runtime-rejection-matrix";
         const previousActionCount = readActions().length;
         const previousRequestCount = readRequests().length;
         await expect(sendMessageIMessage("chat_id:10", hidden, { config: cfg })).rejects.toThrow(
@@ -1137,6 +1178,7 @@ describe("sendMessageIMessage receipts", () => {
         expect(readActions()).toHaveLength(previousActionCount);
         expect(readRequests()).toHaveLength(previousRequestCount);
       }
+      phase = "role-protection-rejections";
       await expect(sendMessageIMessage("chat_id:10", "# user:", { config: cfg })).rejects.toThrow(
         "iMessage send requires text or media",
       );
@@ -1289,6 +1331,7 @@ describe("sendMessageIMessage receipts", () => {
       }
 
       for (const tag of ["thinking", "relevant_memories"] as const) {
+        phase = "hidden-action-rejection-matrix";
         for (const hidden of [
           `<${tag}>HIDDEN_RAW_CODE_PAYLOAD</${tag}>`,
           `<${tag}>HIDDEN_UNTERMINATED_RAW_CODE_PAYLOAD`,
@@ -1348,7 +1391,10 @@ describe("sendMessageIMessage receipts", () => {
       }
       expect(readActions()).toHaveLength(actions.length);
       expect(readRequests()).toHaveLength(requests.length);
+      phase = "complete";
     } finally {
+      signal.removeEventListener("abort", recordPhase);
+      recordPhase();
       vi.unstubAllEnvs();
     }
   }, 30_000);


### PR DESCRIPTION
DIAGNOSTIC ONLY — DO NOT MERGE. This PR was temporarily marked ready solely to run the existing CI investigation. It must remain unmerged and return to draft after recording that evidence. It is not a proposed product repair or a merge-ready change. Auto-merge and merge-queue enrollment must remain disabled.

Related: #131479

## What Problem This Solves

The existing iMessage integration test timed out in the full Linux plugin shard, while the same case completed locally. The failed run did not record which phase was active, so the evidence does not yet distinguish a blocked operation from cumulative work or a shared-worker interaction.

## Why This Change Was Made

Add temporary fixed-phase diagnostics to the existing case. On its existing Vitest abort signal and on completion, record elapsed time and counts from the fixture-owned RPC/action logs. Do not log message contents, environment values, or configuration. A signal observation identifies the active phase, not the cause of the timeout; it does not cancel the underlying asynchronous test body.

The original 30-second deadline, assertions, fixture, real subprocess transport, and case order are unchanged. No production code, workflow, dependency, worker policy, or test selection changes. The normal planner selects the whole iMessage config for an iMessage test edit: the same 53-file set as the failed shard, not an isolated passing rerun. The job's numeric suffix may differ because it is relative to the other selected jobs. Preserving selection and the default sequencing policy does not establish identical worker assignment or interleaving.

## User Impact

None. This is a CI investigation, not an accepted fix. These diagnostics must be removed or independently justified before any eventual repair is considered for landing. No timeout increase, retry workaround, or flaky-test classification is proposed.

The full diagnostic shard passed, but the original timeout remains unexplained. Keep this investigation open and unmerged until #131479 runs its actual required gate again after the separately owned UI repair is incorporated. If iMessage passes there too, close this PR as a completed investigation, not as a root-cause fix. If the timeout recurs, continue from that new failure evidence.

## Evidence

- Original failure: [CI run 33166877582, job 98834532381](https://github.com/openclaw/openclaw/actions/runs/33166877582/job/98834532381), executing merge `0c164239c331b6f060721c602479f86783c04fe2` (CLI head `15bbc3eec2649069d81f8d6977a8fd49a5c227e1` into `56d89073dda41ccf19189474b8f2c110243afc4b`). The case timed out at 30 seconds; its reported duration including hooks was 42.636 seconds. The full config finished with 1 failed / 1,187 passed across 53 files. The job detected two CPUs and selected two workers. The timed-out phase is unknown.
- One isolated macOS Node 24 diagnostic observation passed with the original deadline and all assertions: final phase `complete`, 8,656ms in the instrumented body, 81 RPC requests and seven actions. Vitest reported 9.948 seconds including hooks. This does not reproduce or explain the original Linux full-shard failure.
- The observed test and six inspected runtime owners are byte-identical between that trusted snapshot and the failed CI source. All 53 reported test filenames exactly match the tracked iMessage test inventory. The local temporary diagnostic was then restored byte-for-byte and all owned subprocesses and temporary state were cleaned up.
- Independent whole-owner source review and a fresh complete Codex P2 review found no actionable findings in this diagnostic-only change. The trusted formatter check passed.
- [Diagnostic Linux full-shard CI](https://github.com/openclaw/openclaw/actions/runs/33171554554/job/98849836581) passed all 1,188 tests across 53 files, using two workers. It executed merge `b9d25c35b6eeca4042bb6925387e9494cc902df5` (investigation head `dccab524ec400220bb031395ce17f7fe5b9a7287` into `1454c60c18b4fcdb03c7414c279089a7608ef874`). The case recorded final phase `complete`, 5,334ms, 81 RPC requests and seven actions; Vitest reported 6.054 seconds including hooks. Its 53-file set and first-reported-result order match the failed run, but that does not establish identical worker assignment or interleaving. No abort phase was observed. The original timeout's cause remains unknown; this passing diagnostic run is not a repair and does not clear #131479's failed required gate.

Production LOC: +0/-0. Tests: +47/-1. Only the existing test receives temporary diagnostic statements.
