### PR TITLE
test(ui): measure scroll interruption at native pointer arrival

### DIFF
--- a/ui/src/e2e/chat-transcript-disclosure-anchor.e2e.test.ts
+++ b/ui/src/e2e/chat-transcript-disclosure-anchor.e2e.test.ts
@@ -226,28 +226,103 @@ suite.define(() => {
                   (button as HTMLElement).click();
                 });
               }, controlUiE2eWaitTimeoutMs);
+          } else if (interruption === "native-pointer") {
+            const track = await thread.boundingBox();
+            expect(track).not.toBeNull();
+            const pointer = await thread.evaluateHandle((scroller, waitTimeout) => {
+              const pendingAboveReader = () => {
+                const viewportTop = scroller.getBoundingClientRect().top;
+                const bubble = Array.from(
+                  scroller.querySelectorAll<HTMLElement>(
+                    '.chat-bubble[data-entry-id^="sizing-message-"]',
+                  ),
+                ).findLast(
+                  (candidate) =>
+                    Number(candidate.dataset.entryId!.slice("sizing-message-".length)) % 2 === 1 &&
+                    candidate.closest(".chat-virtual-row")!.getBoundingClientRect().bottom <=
+                      viewportTop,
+                );
+                return bubble
+                  ? {
+                      messageId: bubble.dataset.entryId!,
+                      bottom: bubble.closest(".chat-virtual-row")!.getBoundingClientRect().bottom,
+                      viewportTop,
+                    }
+                  : null;
+              };
+              let eligible = false;
+              let arrival: {
+                top: number;
+                max: number;
+                trusted: boolean;
+                scroller: boolean;
+                pending: ReturnType<typeof pendingAboveReader>;
+              } | null = null;
+              let resolveReady!: () => void;
+              let rejectReady!: (error: Error) => void;
+              const ready = new Promise<void>((resolve, reject) => {
+                resolveReady = resolve;
+                rejectReady = reject;
+              });
+              const onScroll = (event: Event) => {
+                if (!event.isTrusted || scroller.scrollTop <= 0 || !pendingAboveReader()) {
+                  return;
+                }
+                eligible = true;
+                clearTimeout(timer);
+                scroller.removeEventListener("scroll", onScroll);
+                resolveReady();
+              };
+              const onPointer = (event: PointerEvent) => {
+                if (!eligible) {
+                  return;
+                }
+                // Sample the real input before the scroller's takeover handler cancels motion.
+                arrival = {
+                  top: scroller.scrollTop,
+                  max: scroller.scrollHeight - scroller.clientHeight,
+                  trusted: event.isTrusted,
+                  scroller: event.target === scroller,
+                  pending: pendingAboveReader(),
+                };
+                document.removeEventListener("pointerdown", onPointer, true);
+              };
+              const dispose = () => {
+                clearTimeout(timer);
+                scroller.removeEventListener("scroll", onScroll);
+                document.removeEventListener("pointerdown", onPointer, true);
+                rejectReady(new Error("Native pointer observation ended before scrolling"));
+              };
+              const timer = setTimeout(dispose, waitTimeout);
+              scroller.addEventListener("scroll", onScroll);
+              document.addEventListener("pointerdown", onPointer, true);
+              return { ready, read: () => arrival, dispose };
+            }, controlUiE2eWaitTimeoutMs);
+            try {
+              // Arm before START; its post-click bookkeeping must not delay native input.
+              const interrupt = pointer
+                .evaluate((observation) => observation.ready)
+                .then(() => page.mouse.click(track!.x + track!.width - 3, track!.y + 20));
+              await Promise.all([interrupt, page.locator(".chat-scroll-to-bottom").click()]);
+              const arrival = await pointer.evaluate((observation) => observation.read());
+              expect(arrival).not.toBeNull();
+              expect(arrival).toMatchObject({ trusted: true, scroller: true });
+              expect(arrival!.top).toBeGreaterThan(0);
+              expect(arrival!.pending).not.toBeNull();
+              expect(arrival!.pending!.bottom).toBeLessThanOrEqual(arrival!.pending!.viewportTop);
+              during = arrival!;
+            } finally {
+              await pointer.evaluate((observation) => observation.dispose());
+              await pointer.dispose();
+            }
           } else {
             await page.locator(".chat-scroll-to-bottom").click();
-            await page.waitForFunction((pointerInterruption) => {
+            await page.waitForFunction(() => {
               const scroller = document.querySelector<HTMLElement>(
                 ".chat-pane-cache__pane--active .chat-thread",
               );
-              return (
-                scroller &&
-                scroller.scrollTop > 0 &&
-                (!pointerInterruption ||
-                  Array.from(
-                    scroller.querySelectorAll<HTMLElement>(
-                      '.chat-bubble[data-entry-id^="sizing-message-"]',
-                    ),
-                  ).some(
-                    (bubble) =>
-                      Number(bubble.dataset.entryId!.slice("sizing-message-".length)) % 2 === 1 &&
-                      bubble.closest(".chat-virtual-row")!.getBoundingClientRect().bottom <=
-                        scroller.getBoundingClientRect().top,
-                  ))
-              );
-            }, interruption === "native-pointer");
+              return scroller && scroller.scrollTop > 0;
+            });
             during = await thread.evaluate((element) => ({
               top: element.scrollTop,
               max: element.scrollHeight - element.clientHeight,
@@ -260,13 +335,6 @@ suite.define(() => {
             await thread.hover();
             await page.mouse.wheel(0, -100_000);
           } else {
-            if (interruption === "native-pointer") {
-              const track = await thread.boundingBox();
-              expect(track).not.toBeNull();
-              // A real pointer press in the scroll gutter can take over without
-              // a wheel event or a changed offset.
-              await page.mouse.click(track!.x + track!.width - 3, track!.y + 20);
-            }
             await page.locator(".chat-scroll-to-bottom").waitFor({ state: "visible" });
             // Chromium can commit its last canceled animation offset after the
             // pointer action returns. Capture the reader before releasing text.


### PR DESCRIPTION
Related: #131539, #131479

## What Problem This Solves

Resolves a problem where the transcript recovery browser test could fail before its native pointer interruption was delivered. The affected CI case reached the end of smooth scrolling while the test was still waiting on and sampling browser state, then failed its in-flight assertion before exercising cancellation.

## Why This Change Was Made

This maintainer-requested repair arms browser observation before the normal scroll-to-latest click and sends the real gutter click as soon as eligible scrolling is observed, without waiting for the start click's post-action bookkeeping. Geometry is recorded at the trusted pointer-down event before the production takeover handler runs, so the assertion describes actual input arrival rather than an earlier sample.

The native pointer, native animation and default browser behavior remain real. Late arrival still fails explicitly; this does not promise deterministic delivery under arbitrary host starvation. Production scrolling code, timeouts and retry behavior are unchanged.

## User Impact

No user-facing behavior change. The browser test more accurately protects interruption and late transcript recovery while preserving both wheel variants, the explicit synthetic-pointer case, visible reader anchoring, measured row growth, one-pixel adjacency and virtual unmount/remount coverage.

## Evidence

- Original failure: [CI run33166877582, UI shard1/14](https://github.com/openclaw/openclaw/actions/runs/33166877582/job/98834528501) recorded `6894 < 6894` failing before native input. The same test bytes were present on the tested main base and the reviewed current-main snapshot.
- The unchanged local source-Vite baseline passed once; this is not presented as a local failing reproduction.
- Selected repaired case: one real Chromium test passed in12.62s. Captured actual arrival was297/6894 pixels, trusted and targeted at the scroller, with a mounted pending assistant above the reader. Recovery grew the row79→534 pixels, preserved the visible anchor and left zero adjacency gap; remount checks passed.
- Full existing eight-case file: eight passed, no skips, in55.09s. Native input was again captured in flight at344/6894 pixels; all recovery, disclosure and remount assertions passed.
- Final automated review found no actionable P0–P2 defects. [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33171834057) completed successfully on `00beee4bf0d660f77008a9ddef2de2245f3cb5dd`, including the unchanged normal bundled CI configuration. Native landing gates remain required.

Local browser proof uses source Vite and deterministic mock Gateway WebSocket data. It does not prove production bundling, static serving, authentication or live provider behavior. The normal bundled CI configuration is unchanged.

Named follow-up: **Control UI ResizeObserver delivery loop during intrinsic-image and work/tool disclosure resize.** The source-Vite run logged nine delivery-loop errors in two unchanged sibling cases running in fresh browser contexts. Their assertions passed; this test-only repair neither suppresses nor fixes those errors, and does not classify them as harmless.

Production LOC:0. Test LOC:+92/-24. AI-assisted maintainer repair.
