### PR TITLE
fix(telegram): keep the DM topic auto-rename off the reply path

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.fallback-topic-media.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.fallback-topic-media.test.ts
@@ -150,6 +150,36 @@ describeTelegramDispatch("dispatchTelegramMessage fallback-topic-media", () => {
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
+  it("labels a DM topic whose first turn produced no visible response", async () => {
+    const sessionKey = "agent:test:telegram:direct:123";
+    loadSessionStore.mockReturnValue({ [sessionKey]: { sessionId: "s1", updatedAt: 1 } });
+    // An aborted or superseded run leaves the turn with nothing delivered.
+    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
+      queuedFinal: false,
+      counts: { block: 0, final: 0, tool: 0 },
+    });
+    generateTopicLabel.mockResolvedValue("Dentist appointment");
+    const bot = createBot();
+
+    await dispatchWithContext({
+      bot,
+      context: createContext({
+        ctxPayload: {
+          ...createDirectSessionPayload(),
+          RawBody: "book me a dentist appointment",
+        } as TelegramMessageContext["ctxPayload"],
+      }),
+      streamMode: "off",
+      telegramCfg: { autoTopicLabel: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(bot.api["editForumTopic"]).toHaveBeenCalledWith(123, 777, {
+        name: "Dentist appointment",
+      });
+    });
+  });
+
   it("does not emit a silent-reply fallback for no-response DM turns", async () => {
     dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
       queuedFinal: false,

--- a/extensions/telegram/src/bot-message-dispatch.fallback-topic-media.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.fallback-topic-media.test.ts
@@ -180,6 +180,43 @@ describeTelegramDispatch("dispatchTelegramMessage fallback-topic-media", () => {
     });
   });
 
+  it("labels a DM topic whose first turn is superseded mid-flight", async () => {
+    const sessionKey = "agent:test:telegram:direct:123";
+    loadSessionStore.mockReturnValue({ [sessionKey]: { sessionId: "s1", updatedAt: 1 } });
+    const abortController = new AbortController();
+    // The durable owner fences this attempt while the reply pipeline is running.
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async () => {
+      abortController.abort(new Error("handler-timeout"));
+      return { queuedFinal: false, counts: { block: 0, final: 0, tool: 0 } };
+    });
+    generateTopicLabel.mockResolvedValue("Renew the domain");
+    const bot = createBot();
+
+    await dispatchWithContext({
+      bot,
+      context: createContext({
+        ctxPayload: {
+          ...createDirectSessionPayload(),
+          RawBody: "remind me to renew the domain",
+        } as TelegramMessageContext["ctxPayload"],
+      }),
+      streamMode: "off",
+      telegramCfg: { autoTopicLabel: true },
+      turnAdoptionLifecycle: {
+        abortSignal: abortController.signal,
+        onAdopted: vi.fn(),
+        onDeferred: vi.fn(),
+        onAbandoned: vi.fn(),
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(bot.api["editForumTopic"]).toHaveBeenCalledWith(123, 777, {
+        name: "Renew the domain",
+      });
+    });
+  });
+
   it("does not emit a silent-reply fallback for no-response DM turns", async () => {
     dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
       queuedFinal: false,

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -496,10 +496,10 @@ export const dispatchTelegramMessage = async (
   if (retryableDispatchFailure && shouldReturnRetryableDispatchFailure) {
     return { kind: "failed-retryable", error: retryableDispatchFailure };
   }
-  if (!hasVisibleResponse) {
-    return { kind: "completed" };
-  }
-
+  // The topic name is generated from the inbound message, not from the answer, so it
+  // must not depend on the reply landing. A first turn that is aborted or whose delivery
+  // is skipped still returns below, and because the rename is gated on
+  // `isFirstTurnInSession` that topic would keep Telegram's default name forever.
   scheduleDmTopicLabel({
     bot,
     cfg,
@@ -507,6 +507,10 @@ export const dispatchTelegramMessage = async (
     isFirstTurnInSession,
     telegramCfg,
   });
+  if (!hasVisibleResponse) {
+    return { kind: "completed" };
+  }
+
   if (status.controller) {
     status.finalizeInBackground(
       {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -414,6 +414,18 @@ export const dispatchTelegramMessage = async (
     dispatchWasSuperseded = isDispatchSuperseded();
   }
 
+  // The topic name is generated from the inbound message, not from the answer, so it
+  // must not wait for the reply. Every exit below is an accepted completion — an
+  // undispatched turn, a superseded one, an aborted run, a delivery that is skipped —
+  // and the rename is gated on `isFirstTurnInSession`, so a topic that misses its
+  // first turn here keeps Telegram's default name forever.
+  scheduleDmTopicLabel({
+    bot,
+    cfg,
+    context: dispatchContext,
+    isFirstTurnInSession,
+    telegramCfg,
+  });
   if (turnDispatched === false) {
     return { kind: "completed" };
   }
@@ -496,17 +508,6 @@ export const dispatchTelegramMessage = async (
   if (retryableDispatchFailure && shouldReturnRetryableDispatchFailure) {
     return { kind: "failed-retryable", error: retryableDispatchFailure };
   }
-  // The topic name is generated from the inbound message, not from the answer, so it
-  // must not depend on the reply landing. A first turn that is aborted or whose delivery
-  // is skipped still returns below, and because the rename is gated on
-  // `isFirstTurnInSession` that topic would keep Telegram's default name forever.
-  scheduleDmTopicLabel({
-    bot,
-    cfg,
-    context: dispatchContext,
-    isFirstTurnInSession,
-    telegramCfg,
-  });
   if (!hasVisibleResponse) {
     return { kind: "completed" };
   }

--- a/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
@@ -63,6 +63,14 @@ vi.mock("openclaw/plugin-sdk/web-media", () => ({
   loadWebMedia,
 }));
 
+// Dispatch schedules the DM topic auto-rename for the first turn in any DM topic,
+// including turns that deliver nothing. These bot-level tests never assert on the
+// generated name, and the real generator would reach for a model, so stub it out.
+vi.mock("./bot-message-dispatch.runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./bot-message-dispatch.runtime.js")>()),
+  generateTopicLabel: vi.fn(async () => ""),
+}));
+
 const {
   getSessionEntryMock,
   getRuntimeConfig,


### PR DESCRIPTION
## What Problem This Solves

A DM topic whose **first turn never produced a visible response** keeps Telegram's default name (`New Chat` / `New Thread`) permanently.

`scheduleDmTopicLabel` was called at the very end of `dispatchTelegramMessage`, below several accepted completion exits. A first turn that is aborted, superseded, undispatched, or whose delivery is skipped returns before the rename is ever scheduled — and because the rename is gated on `isFirstTurnInSession`, no later turn in that topic ever tries again. One interrupted first message costs the topic its name forever.

## Why This Change Was Made

Observed on a live Telegram DM, topic `189879`. Gateway log:

```
14:28:11 [telegram] Inbound message telegram:<chat> (direct, audio/ogg, 0 chars)
14:28:12 [agent/cli-backend] cli exec: trigger=user session=none
14:28:24 [telegram] Inbound message telegram:<chat> (direct, 4 chars)
14:28:24 [agent/cli-backend] claude live session close: reason=abort
```

The user sent a follow-up 12 seconds into the first turn, which aborted the run. Nothing visible was delivered, the labeler was never reached, and that topic is still called `New Chat`. Topics in the same chat whose first turn answered normally are named correctly.

The generated name is derived from the inbound message, never from the answer, so it never needed the reply to land. The call now sits directly after the `finally` that resolves `dispatchWasSuperseded`, above every accepted completion exit. `isFirstTurnInSession` still gates it, so a topic is renamed at most once and a name the user chose is never overwritten.

The pre-pipeline `isDispatchSuperseded()` return at `bot-message-dispatch.ts:390` is deliberately left alone: that attempt never entered the pipeline and the canonical spool row retries it, so the retry gets the first-turn label.

Scheduling the rename on turns that deliver nothing means the bot-level integration tests now reach the real `generateTopicLabel`, which waits on a model. They never assert on the generated name, so the shared harness they both import stubs it — without that, two Vitest shards stall until the 300s no-output watchdog kills them.

## User Impact

A DM topic opened with a message that gets interrupted — the common case being a follow-up sent while the agent is still working — now gets its generated title instead of silently keeping Telegram's placeholder for the life of the conversation.

## Evidence

### Current maintainer qualification

Original fix and reproduction by **Eugene Z. / @uggy-ug**; contributor ancestry is retained. The maintainer follow-up strengthens the existing regression coverage and repairs the fixture for the current runner.

Candidate: `36c7505c4ec35ff601a0f88b969fe1e5a062fc89`, based on `38c4aa42e4ce9cf2be96ba7b99b979bcba25958a`.

- All **31 selected rows passed** in two serial, isolated single-file runs using the maintained Telegram runner and a separate frozen dependency installation.
- The no-response and superseded-first-turn controls both fail on the pre-fix production file because topic-label generation is never called.
- The real SDK echo row observes **DROP / outbound-echo / dispatched:false**, not agent admission, and restores the shared echo Map in `finally`.
- Fresh independent P0–P2 source review found no actionable issues.
- Changed-file checks: passed in the separate physical checkout, including formatting, production/test typechecks, lint, declaration-boundary preparation, and all maintained changed-file guards.

- Full `pnpm build` passed on the published head in the independent checkout.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34923231677) completed successfully; the maintained exact-head watcher reports GREEN.

**Still required before landing:** authentic Telegram Test Server proof tying an interrupted/no-response first turn to the resulting topic rename. This host currently lacks the authenticated Convex QA capability; no live Telegram run is claimed.

### Historical contributor evidence (not exact-head live proof)

Focused suites on head `dfeb24f3`:

- `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-dispatch.fallback-topic-media.test.ts` → **16 passed**, including two new regression tests:
  - `labels a DM topic whose first turn produced no visible response`
  - `labels a DM topic whose first turn is superseded mid-flight` (aborts the lifecycle signal from inside the dispatcher)
- Both new tests **fail without the production change** — `editForumTopic` is never called — verified by stashing `bot-message-dispatch.ts` and re-running.
- `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-dispatch.pipeline-init.test.ts` → 3 passed.
- `node scripts/run-vitest.mjs extensions/telegram/src/bot.create-telegram-bot.test.ts` → **146 passed in 13.0s**. Before the harness stub this file hit a 120s timeout inside a 355s run (`reloads topic agent overrides between messages without recreating the bot`), which is what killed CI shard `changed-extensions-config-9`.
- `node scripts/run-vitest.mjs extensions/telegram/src/bot.test.ts` → **143 passed in 10.4s**; this was the stalled shard `changed-extensions-config-10`.
- `oxfmt --check` and `oxlint` clean on all three changed files.

Live behavior on a patched runtime: after applying the equivalent change to an installed gateway, two DM topics opened with voice notes renamed themselves within the same turn (`Тест голосового сообщения`, `Тестирование названия топика`), where the same flow previously left both on `New Chat`.

## Relationship to #131695

Independent defect in the same feature, different line. [#131695](https://github.com/openclaw/openclaw/pull/131695) fixes *which text* the labeler reads (captionless media hands it an empty `RawBody`); this one fixes *whether the labeler runs at all*. They touch different hunks and merge in either order — both are needed for a DM topic opened with a voice note to reliably get a name.
