### PR TITLE
fix(exec): require an explicit node in multi-node environments

### DIFF
--- a/src/agents/bash-tools.exec-host-node-phases.test.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.test.ts
@@ -3,7 +3,10 @@ import {
   formatNodeInvokeFailureFollowup,
   invokeNodeSystemRun,
 } from "./bash-tools.exec-host-node-failure.js";
-import { invokeNodeSystemRunDirect } from "./bash-tools.exec-host-node-phases.js";
+import {
+  invokeNodeSystemRunDirect,
+  resolveNodeExecutionTarget,
+} from "./bash-tools.exec-host-node-phases.js";
 
 const callGatewayToolMock = vi.hoisted(() => vi.fn());
 
@@ -44,6 +47,152 @@ async function invokeFailure(error: unknown) {
   }
   return result.failure;
 }
+
+type NodeTargetRequest = Parameters<typeof resolveNodeExecutionTarget>[0];
+
+function createNodeTargetRequest(overrides: Partial<NodeTargetRequest> = {}): NodeTargetRequest {
+  return {
+    command: "tool --version",
+    workdir: undefined,
+    env: {},
+    security: "full",
+    ask: "off",
+    defaultTimeoutSec: 30,
+    approvalRunningNoticeMs: 0,
+    warnings: [],
+    ...overrides,
+  };
+}
+
+describe("node exec target resolution", () => {
+  beforeEach(() => {
+    callGatewayToolMock.mockReset();
+  });
+
+  it("rejects an omitted target when multiple connected nodes support system.run", async () => {
+    callGatewayToolMock.mockResolvedValue({
+      nodes: [
+        {
+          nodeId: "mac-a",
+          displayName: "Laptop",
+          platform: "macos",
+          connected: true,
+          connectedAtMs: 1_000,
+          caps: ["canvas"],
+          commands: ["system.run"],
+        },
+        {
+          nodeId: "mac-b",
+          displayName: "Desktop",
+          platform: "macos",
+          connected: true,
+          connectedAtMs: 2_000,
+          caps: ["canvas"],
+          commands: ["system.run"],
+        },
+      ],
+    });
+
+    const target = resolveNodeExecutionTarget(createNodeTargetRequest());
+    await expect(target).rejects.toThrow(/multiple.*system\.run/is);
+    await expect(target).rejects.toThrow(/tools\.exec\.node.*Laptop \(mac-a\).*Desktop \(mac-b\)/s);
+    expect(callGatewayToolMock.mock.calls.map(([method]) => method)).toEqual(["node.list"]);
+  });
+
+  it("selects the only connected system.run node instead of a Canvas default", async () => {
+    callGatewayToolMock.mockResolvedValue({
+      nodes: [
+        {
+          nodeId: "mac-canvas",
+          displayName: "Canvas Mac",
+          platform: "macos",
+          connected: true,
+          connectedAtMs: 2_000,
+          caps: ["canvas"],
+          commands: ["canvas.present"],
+        },
+        {
+          nodeId: "linux-shell",
+          displayName: "Build Server",
+          platform: "linux",
+          connected: true,
+          connectedAtMs: 1_000,
+          commands: ["system.run"],
+        },
+      ],
+    });
+
+    await expect(resolveNodeExecutionTarget(createNodeTargetRequest())).resolves.toMatchObject({
+      nodeId: "linux-shell",
+      platform: "linux",
+    });
+  });
+
+  it("preserves an explicit target when multiple nodes support system.run", async () => {
+    callGatewayToolMock.mockResolvedValue({
+      nodes: [
+        { nodeId: "node-a", displayName: "Laptop", connected: true, commands: ["system.run"] },
+        { nodeId: "node-b", displayName: "Desktop", connected: true, commands: ["system.run"] },
+      ],
+    });
+
+    await expect(
+      resolveNodeExecutionTarget(createNodeTargetRequest({ requestedNode: "Desktop" })),
+    ).resolves.toMatchObject({ nodeId: "node-b" });
+  });
+
+  it("resolves an explicit name among eligible nodes", async () => {
+    callGatewayToolMock.mockResolvedValue({
+      nodes: [
+        { nodeId: "canvas", displayName: "Shared", connected: true, commands: [] },
+        { nodeId: "shell", displayName: "Shared", connected: true, commands: ["system.run"] },
+      ],
+    });
+
+    await expect(
+      resolveNodeExecutionTarget(createNodeTargetRequest({ requestedNode: "Shared" })),
+    ).resolves.toMatchObject({ nodeId: "shell" });
+  });
+
+  it("preserves a configured binding when multiple nodes support system.run", async () => {
+    callGatewayToolMock.mockResolvedValue({
+      nodes: [
+        { nodeId: "node-a", displayName: "Laptop", connected: true, commands: ["system.run"] },
+        { nodeId: "node-b", displayName: "Desktop", connected: true, commands: ["system.run"] },
+      ],
+    });
+
+    await expect(
+      resolveNodeExecutionTarget(createNodeTargetRequest({ boundNode: "Laptop" })),
+    ).resolves.toMatchObject({ nodeId: "node-a" });
+  });
+
+  it("rejects an ambiguous configured binding before eligibility filtering", async () => {
+    callGatewayToolMock.mockResolvedValue({
+      nodes: [
+        { nodeId: "canvas", displayName: "Shared", connected: true, commands: [] },
+        { nodeId: "shell", displayName: "Shared", connected: true, commands: ["system.run"] },
+      ],
+    });
+
+    await expect(
+      resolveNodeExecutionTarget(createNodeTargetRequest({ boundNode: "Shared" })),
+    ).rejects.toThrow(/ambiguous node: Shared.*canvas.*shell/);
+  });
+
+  it("reports when no connected node supports system.run", async () => {
+    callGatewayToolMock.mockResolvedValue({
+      nodes: [
+        { nodeId: "offline", connected: false, commands: ["system.run"] },
+        { nodeId: "canvas", connected: true, caps: ["canvas"], commands: [] },
+      ],
+    });
+
+    await expect(resolveNodeExecutionTarget(createNodeTargetRequest())).rejects.toThrow(
+      "requires a connected node that supports system.run (none available)",
+    );
+  });
+});
 
 describe("invokeNodeSystemRun failure classification", () => {
   it("classifies only proven pre-dispatch NOT_CONNECTED as retry-safe", async () => {
@@ -152,7 +301,7 @@ describe("direct node run", () => {
 
   it("forwards the original cancellation signal to the gateway", async () => {
     const controller = new AbortController();
-    await invokeNodeSystemRunDirect(createDirectNodeRun(controller.signal));
+    const result = await invokeNodeSystemRunDirect(createDirectNodeRun(controller.signal));
 
     expect(callGatewayToolMock).toHaveBeenCalledWith(
       "node.invoke",
@@ -160,6 +309,8 @@ describe("direct node run", () => {
       expect.objectContaining({ command: "system.run" }),
       { signal: controller.signal },
     );
+    expect(result.content).toEqual([{ type: "text", text: "Node: node-1\n\nok" }]);
+    expect(result.details).toMatchObject({ nodeId: "node-1", aggregated: "ok" });
   });
 
   it("combines stdout, stderr, and the node error", async () => {
@@ -179,8 +330,9 @@ describe("direct node run", () => {
     const result = await invokeNodeSystemRunDirect(createDirectNodeRun());
     const visibleText = result.content[0]?.type === "text" ? result.content[0].text : "";
 
-    expect(visibleText).toBe(`${stdout}\n${stderr}\n${errorText}\n(Command exited with code 1)`);
-    expect(result.details).toMatchObject({ aggregated: visibleText });
+    const output = `${stdout}\n${stderr}\n${errorText}\n(Command exited with code 1)`;
+    expect(visibleText).toBe(`Node: node-1\n\n${output}`);
+    expect(result.details).toMatchObject({ aggregated: output, nodeId: "node-1" });
   });
 
   it("renders a nonzero exit code in the model-visible text", async () => {

--- a/src/agents/bash-tools.exec-host-node-phases.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.ts
@@ -37,6 +37,7 @@ import {
   extractShellCommandFromArgv,
   resolveSystemRunCommandRequest,
 } from "../infra/system-run-command.js";
+import { type EligibleNodeMessages, resolveEligibleNodeFromList } from "../shared/node-resolve.js";
 import { addSafeTimeoutDelayGraceMs } from "../utils/timer-delay.js";
 import {
   formatNodeInvokeFailureToolResult,
@@ -47,7 +48,7 @@ import { appendExecTimeoutRetryGuidance, renderExecUpdateText } from "./bash-too
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import type { AgentToolResult } from "./runtime/index.js";
 import { callGatewayTool } from "./tools/gateway.js";
-import { listNodes, resolveNodeIdFromList } from "./tools/nodes-utils.js";
+import { listNodes, type NodeListNode, resolveNodeIdFromList } from "./tools/nodes-utils.js";
 
 type NodeExecutionTarget = {
   nodeId: string;
@@ -83,6 +84,27 @@ type NodeApprovalAnalysis = {
   requiresSecurityAuditSuppressionApproval: boolean;
   autoReviewArgv?: string[];
   allowAlwaysPersistence: AllowAlwaysPersistenceDecision;
+};
+
+function isEligibleExecNode(node: NodeListNode): boolean {
+  return node.connected === true && node.commands?.includes("system.run") === true;
+}
+
+const EXEC_NODE_MESSAGES: EligibleNodeMessages<NodeListNode> = {
+  ineligibleExact: (query, eligibleIds) =>
+    `exec host=node requires a connected node that supports system.run (${query} is not eligible; eligible node ids: ${eligibleIds}).`,
+  nameResolveFailed: (reason, eligibleIds) => `${reason} (eligible exec node ids: ${eligibleIds})`,
+  noneEligible: () =>
+    "exec host=node requires a connected node that supports system.run (none available). Start or reconnect a companion app or node host.",
+  multipleEligible: (eligible) => {
+    const listed = eligible.toSorted((a, b) => a.nodeId.localeCompare(b.nodeId)).slice(0, 10);
+    const remaining = eligible.length - listed.length;
+    return `exec host=node found multiple connected nodes that support system.run; select one with node, tools.exec.node, or /exec node=...: ${listed
+      .map((node) =>
+        node.displayName?.trim() ? `${node.displayName.trim()} (${node.nodeId})` : node.nodeId,
+      )
+      .join(", ")}${remaining > 0 ? `, ... (+${remaining} more)` : ""}`;
+  },
 };
 
 function resolveNodeRunTimeoutSec(
@@ -239,6 +261,7 @@ export function shouldSkipNodeApprovalPrepare(params: {
 /** Formats a raw `node.invoke system.run` response as an exec tool result. */
 export function formatNodeRunToolResult(params: {
   raw: unknown;
+  nodeId: string;
   startedAt: number;
   cwd: string | undefined;
   warnings?: string[];
@@ -263,12 +286,13 @@ export function formatNodeRunToolResult(params: {
       ? `(Command exited with code ${exitCode})`
       : "";
   const output = [stdout, stderr, errorText, outcomeNote].filter(Boolean).join("\n");
+  const visibleOutput = `Node: ${params.nodeId}\n\n${output || "(no output)"}`;
   return {
     content: [
       {
         type: "text",
         text: renderExecUpdateText({
-          tailText: output,
+          tailText: visibleOutput,
           warnings: params.warnings ?? [],
         }),
       },
@@ -278,6 +302,7 @@ export function formatNodeRunToolResult(params: {
       exitCode,
       durationMs: Date.now() - params.startedAt,
       aggregated: output,
+      nodeId: params.nodeId,
       ...(timedOut ? { timedOut: true } : {}),
       cwd: params.cwd,
     } satisfies ExecToolDetails,
@@ -296,19 +321,18 @@ export async function resolveNodeExecutionTarget(
   }
   // Canonicalize boundNode and requestedNode (which may be display names, IPs,
   // or partial ID prefixes) to full device IDs before comparing.
-  let resolvedBoundNodeId: string | undefined;
-  if (params.boundNode) {
-    try {
-      resolvedBoundNodeId = resolveNodeIdFromList(nodes, params.boundNode);
-    } catch {
-      // boundNode comes from config; if it cannot be resolved, fall through
-      // to the existing nodeQuery resolution which produces a clearer error.
-    }
-  }
+  const resolvedBoundNodeId = params.boundNode
+    ? resolveNodeIdFromList(nodes, params.boundNode)
+    : undefined;
   let resolvedRequestedNodeId: string | undefined;
   if (params.requestedNode) {
     try {
-      resolvedRequestedNodeId = resolveNodeIdFromList(nodes, params.requestedNode);
+      resolvedRequestedNodeId = resolveEligibleNodeFromList(
+        nodes,
+        params.requestedNode,
+        isEligibleExecNode,
+        EXEC_NODE_MESSAGES,
+      ).nodeId;
     } catch (err) {
       throw new Error(
         `requested node not found: ${params.requestedNode} (${err instanceof Error ? err.message : String(err)})`,
@@ -322,35 +346,15 @@ export async function resolveNodeExecutionTarget(
       `exec node not allowed (bound to ${canonicalBound}, requested resolved to ${resolvedRequestedNodeId})`,
     );
   }
-  // Prefer resolved IDs; fall back to raw boundNode so stale/unresolvable
-  // values still reach resolveNodeIdFromList (which produces a clear
-  // "unknown node" error) instead of silently picking a default node.
-  const nodeQuery = resolvedBoundNodeId || resolvedRequestedNodeId || params.boundNode;
-  let nodeId: string;
-  try {
-    nodeId = resolveNodeIdFromList(nodes, nodeQuery, !nodeQuery);
-  } catch (err) {
-    if (!nodeQuery && String(err).includes("node required")) {
-      throw new Error(
-        "exec host=node requires a node id when multiple nodes are available (set tools.exec.node or exec.node).",
-        { cause: err },
-      );
-    }
-    throw err;
-  }
-  const nodeInfo = nodes.find((entry) => entry.nodeId === nodeId);
-  if (nodeInfo?.connected === false) {
-    throw new Error(
-      `exec host=node requires a connected node (${nodeId} is currently disconnected). Start or reconnect the companion app or node host, or select a connected node.`,
-    );
-  }
+  const nodeQuery = resolvedBoundNodeId || resolvedRequestedNodeId;
+  const nodeInfo = resolveEligibleNodeFromList(
+    nodes,
+    nodeQuery,
+    isEligibleExecNode,
+    EXEC_NODE_MESSAGES,
+  );
+  const nodeId = nodeInfo.nodeId;
   const declaredCommands = Array.isArray(nodeInfo?.commands) ? nodeInfo.commands : [];
-  const supportsSystemRun = declaredCommands.includes("system.run");
-  if (!supportsSystemRun) {
-    throw new Error(
-      "exec host=node requires a node that supports system.run (companion app or node host).",
-    );
-  }
 
   const runTimeoutSec = resolveNodeRunTimeoutSec(params.timeoutSec, params.defaultTimeoutSec);
   const invokeDeadlineMs = resolveNodeInvokeDeadlineMs(runTimeoutSec, params.defaultTimeoutSec);
@@ -456,6 +460,7 @@ export async function invokeNodeSystemRunDirect(params: {
   }
   return formatNodeRunToolResult({
     raw: result.raw,
+    nodeId: params.target.nodeId,
     startedAt,
     cwd: params.request.workdir,
     warnings: [...params.request.warnings, ...(params.request.foregroundWarnings ?? [])],

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -729,6 +729,7 @@ describe("executeNodeHostCommand", () => {
       {
         nodeId: "node-1",
         commands: ["system.run", "system.run.prepare"],
+        connected: true,
         platform: process.platform,
       },
     ]);
@@ -3235,6 +3236,7 @@ describe("executeNodeHostCommand", () => {
       {
         nodeId: "node-1",
         commands: ["system.run", "system.which", "system.notify"],
+        connected: true,
         platform: "darwin",
       },
     ]);
@@ -3923,7 +3925,7 @@ describe("executeNodeHostCommand", () => {
         }),
       ),
     ).rejects.toThrow(
-      "exec host=node requires a connected node (node-1 is currently disconnected)",
+      "exec host=node requires a connected node that supports system.run (node-1 is not eligible",
     );
     expect(callGatewayToolMock).not.toHaveBeenCalled();
   });
@@ -3952,7 +3954,7 @@ describe("executeNodeHostCommand", () => {
       }),
     );
 
-    expect(result.content).toEqual([{ type: "text", text: "(no output)" }]);
+    expect(result.content).toEqual([{ type: "text", text: "Node: node-1\n\n(no output)" }]);
     const details = result.details;
     expect(details?.status).toBe("completed");
     if (details?.status !== "completed") {
@@ -3960,6 +3962,7 @@ describe("executeNodeHostCommand", () => {
     }
     expect(details.exitCode).toBe(0);
     expect(details.aggregated).toBe("");
+    expect(details.nodeId).toBe("node-1");
     expect(details.cwd).toBe("/tmp/work");
   });
 
@@ -4074,6 +4077,7 @@ describe("executeNodeHostCommand", () => {
         nodeId: "f2396b588d391d30a79d300e196a17cf197f34969b5e2485d2734c953567f44e",
         displayName: "home-wsl-debian",
         commands: ["system.run"],
+        connected: true,
         platform: process.platform,
       },
     ]);
@@ -4095,6 +4099,7 @@ describe("executeNodeHostCommand", () => {
         nodeId: "f2396b588d391d30a79d300e196a17cf197f34969b5e2485d2734c953567f44e",
         displayName: "home-wsl-debian",
         commands: ["system.run"],
+        connected: true,
         platform: process.platform,
       },
     ]);
@@ -4116,12 +4121,14 @@ describe("executeNodeHostCommand", () => {
         nodeId: "f2396b588d391d30a79d300e196a17cf197f34969b5e2485d2734c953567f44e",
         displayName: "home-wsl-debian",
         commands: ["system.run"],
+        connected: true,
         platform: process.platform,
       },
       {
         nodeId: "aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaa7777bbb88889999",
         displayName: "other-node",
         commands: ["system.run"],
+        connected: true,
         platform: process.platform,
       },
     ]);
@@ -4144,6 +4151,7 @@ describe("executeNodeHostCommand", () => {
         nodeId: "f2396b588d391d30a79d300e196a17cf197f34969b5e2485d2734c953567f44e",
         displayName: "home-wsl-debian",
         commands: ["system.run"],
+        connected: true,
         platform: process.platform,
       },
     ]);
@@ -4156,9 +4164,7 @@ describe("executeNodeHostCommand", () => {
           requestedNode: "nonexistent-node",
         }),
       ),
-    ).rejects.toThrow(
-      "requested node not found: nonexistent-node (unknown node: nonexistent-node)",
-    );
+    ).rejects.toThrow("requested node not found: nonexistent-node (unknown node: nonexistent-node");
   });
 
   it("allows exec when boundNode is a display name matching the same device as requestedNode", async () => {
@@ -4167,6 +4173,7 @@ describe("executeNodeHostCommand", () => {
         nodeId: "f2396b588d391d30a79d300e196a17cf197f34969b5e2485d2734c953567f44e",
         displayName: "home-wsl-debian",
         commands: ["system.run"],
+        connected: true,
         platform: process.platform,
       },
     ]);

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -685,6 +685,7 @@ export async function executeNodeHostCommand(
   }
   return formatNodeRunToolResult({
     raw: invocation.raw,
+    nodeId: target.nodeId,
     startedAt,
     cwd: params.workdir,
     warnings: [...params.warnings, ...(params.foregroundWarnings ?? [])],

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -172,6 +172,7 @@ export type ExecToolDetails = {
       timedOut?: boolean;
       noOutputTimedOut?: boolean;
       cwd?: string;
+      nodeId?: string;
     }
   | {
       status: "approval-pending";

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -35,6 +35,7 @@ vi.mock("./tools/nodes-utils.js", () => ({
     {
       nodeId: "node-1",
       commands: ["system.run", "system.run.prepare"],
+      connected: true,
       platform: "darwin",
     },
   ]),


### PR DESCRIPTION
Closes #131766

## What Problem This Solves

Fixes an issue where `exec host=node` could silently choose one of several connected shell-capable machines when no node was specified. The choice inherited Canvas-specific local-Mac and recency rules, so a mutating command could run on an unintended node without the result identifying that node.

## Why This Change Was Made

Node exec now resolves against connected nodes advertising `system.run`, selects implicitly only when exactly one is eligible, and otherwise returns bounded, actionable disambiguation guidance before `node.invoke`. Explicit per-call targets and configured bindings retain full-inventory identity checks, and completed node results include the effective canonical `nodeId` in structured details and model-visible text.

## User Impact

Single-node setups continue to work without configuration. Multi-node setups must select a target with `node`, `tools.exec.node`, or `/exec node=...`; successful output now states which node executed the command.

## Evidence

- Before: the regression test with two connected `system.run` nodes resolved to `mac-b` and failed with `promise resolved ... instead of rejecting`; changing connection recency changed that implicit target.
- After: the same boundary rejects before dispatch and lists eligible names/IDs; a Canvas-only Mac beside one headless `system.run` node selects the headless node.
- Coverage: `src/agents/bash-tools.exec-host-node-phases.test.ts:72-197` verifies multiple/one/none eligible nodes, explicit request, configured binding, identity ambiguity, and zero `node.invoke` calls on ambiguity. `src/agents/bash-tools.exec-host-node-phases.test.ts:303-335` and `src/agents/bash-tools.exec-host-node.test.ts:3933-3967` verify effective-node observability.
- Owner: `src/agents/bash-tools.exec-host-node-phases.ts:89-108,312-371` now uses the shared eligibility-aware resolver instead of the Canvas default. Success propagation is at `src/agents/bash-tools.exec-host-node-phases.ts:259-309,457-468` and `src/agents/bash-tools.exec-host-node.ts:686-692`.
- Provenance: `efdb33c9758` introduced node exec with explicit multi-node disambiguation in its design; `47bb568cb2a` added automatic multi-node selection for Canvas/A2UI; `a1346a519a13` generalized that picker and exposed exec to the Canvas fallback.
- Independent verification: a second adversarial review attempted to refute the analysis and confirmed the bug. A final code review found no actionable issues.
- Checks: `node scripts/run-vitest.mjs src/agents/bash-tools.exec-host-node-phases.test.ts src/agents/bash-tools.exec-host-node.test.ts src/agents/bash-tools.exec.approval-id.test.ts src/agents/tools/nodes-utils.test.ts src/shared/node-resolve.test.ts` (163 passed); `node scripts/check-changed.mjs` (passed), both rerun after rebasing onto current `origin/main`.
