### PR TITLE
fix(cron): distinguish intentionally suppressed deliveries

### DIFF
--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -220,6 +220,8 @@ Isolated automation turns suppress stale acknowledgement-only replies. If the fi
 
 If an isolated automation run returns only the silent token (`NO_REPLY` or `no_reply`), the scheduler suppresses both direct outbound delivery and the fallback queued summary path, so nothing is posted back to chat.
 
+Human-readable `automations list` and `automations show` label successful intentional suppression as `ok (suppressed)`, not a delivery warning. `automations show` includes `last delivery suppression` with the recorded reason (`empty`, `silent`, `heartbeat`, or `channel_transform`). JSON keeps `deliveryStatus: "not-delivered"` and the separate `deliverySuppressionReason`; genuine delivery failures without an intentional reason still show `ok (not delivered)` when execution succeeded.
+
 ### Structured denials
 
 Isolated automation runs use structured execution-denial metadata from the embedded run (fatal exec-tool errors coded `SYSTEM_RUN_DENIED` or `INVALID_REQUEST`) as the authoritative denial signal. They also honor node-host `UNAVAILABLE` wrappers around a nested structured error carrying one of those codes.

--- a/src/cli/cron-cli/cron-suppression.gateway.test.ts
+++ b/src/cli/cron-cli/cron-suppression.gateway.test.ts
@@ -1,0 +1,332 @@
+// Boundary proof: real silent dispatch, service persistence, Gateway handlers, and CLI rendering.
+// The agent-output input and RPC transport are test boundaries; no provider or channel send is claimed.
+import { randomUUID } from "node:crypto";
+import { expectDefined } from "@openclaw/normalization-core";
+import { Command } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isRich, theme } from "../../../packages/terminal-core/src/theme.js";
+import { dispatchCronDelivery } from "../../cron/isolated-agent/delivery-dispatch.js";
+import { CronService, type CronEvent } from "../../cron/service.js";
+import { createNoopLogger } from "../../cron/service.test-harness.js";
+import type { CronServiceDeps } from "../../cron/service/state.js";
+import { loadCronStore } from "../../cron/store.js";
+import { cronStoreKey } from "../../cron/store/key.js";
+import { readCronTaskRunHistoryPage } from "../../cron/task-run-history.js";
+import type { CronJob } from "../../cron/types.js";
+import { cronHandlers } from "../../gateway/server-methods/cron.js";
+import type { RespondFn } from "../../gateway/server-methods/types.js";
+import { getActiveGatewayRootWorkCount } from "../../process/gateway-work-admission.js";
+import { resetTaskRegistryForTests } from "../../tasks/task-runtime.test-helpers.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+
+const mocks = vi.hoisted(() => ({
+  runtime: {
+    log: vi.fn(),
+    error: vi.fn(),
+    writeStdout: vi.fn(),
+    writeJson: vi.fn(),
+    exit: vi.fn(),
+  },
+  callGatewayFromCli: vi.fn(),
+}));
+
+vi.mock("../gateway-rpc.js", async () => {
+  const actual = await vi.importActual<typeof import("../gateway-rpc.js")>("../gateway-rpc.js");
+  return { ...actual, callGatewayFromCli: mocks.callGatewayFromCli };
+});
+vi.mock("../../runtime.js", async () => {
+  const actual = await vi.importActual<typeof import("../../runtime.js")>("../../runtime.js");
+  return { ...actual, defaultRuntime: mocks.runtime };
+});
+
+const { registerCronCli } = await import("../cron-cli.js");
+
+async function runCli(args: string[]) {
+  for (const mock of Object.values(mocks.runtime)) {
+    mock.mockClear();
+  }
+  const program = new Command();
+  program.exitOverride();
+  registerCronCli(program);
+  await program.parseAsync(["cron", ...args], { from: "user" });
+  expect(mocks.runtime.error).not.toHaveBeenCalled();
+  return {
+    text: mocks.runtime.log.mock.calls.map(([line]) => String(line)).join("\n"),
+    json: mocks.runtime.writeJson.mock.calls.at(-1)?.[0],
+    exitCode: mocks.runtime.exit.mock.calls.at(-1)?.[0],
+  };
+}
+
+function installGatewayTransport(cron: CronService, storePath: string) {
+  const invoke = async (method: string, params: Record<string, unknown> = {}) => {
+    const handler = expectDefined(cronHandlers[method], `missing Gateway method ${method}`);
+    let response: { ok: boolean; payload?: unknown; error?: { message?: string } } | undefined;
+    const respond: RespondFn = (ok, payload, error) => {
+      response = { ok, payload, error };
+    };
+    await handler({
+      req: {} as never,
+      client: null,
+      params,
+      respond,
+      context: { cron, cronStorePath: storePath, getRuntimeConfig: () => ({}) } as never,
+    } as never);
+    const result = expectDefined(response, `${method} returned no response`);
+    expect(result.ok, result.error?.message).toBe(true);
+    // JSON wire encoding drops undefined fields; structuredClone would preserve them.
+    // oxlint-disable-next-line unicorn/prefer-structured-clone
+    return JSON.parse(JSON.stringify(result.payload)) as unknown;
+  };
+  mocks.callGatewayFromCli.mockImplementation(
+    async (method: string, _options: unknown, params?: Record<string, unknown>) =>
+      invoke(method, params),
+  );
+  return invoke;
+}
+
+afterEach(() => {
+  mocks.callGatewayFromCli.mockReset();
+  vi.restoreAllMocks();
+});
+
+describe("cron CLI delivery suppression readback", () => {
+  it("distinguishes intentional silence from failures across repeated runs of one stored job", async () => {
+    await withOpenClawTestState(
+      { layout: "home", prefix: "openclaw-cron-cli-suppression-" },
+      async (state) => {
+        await state.writeConfig({});
+        resetTaskRegistryForTests({ persist: false });
+        const storePath = state.statePath("cron", "jobs.json");
+        const events: CronEvent[] = [];
+        let phase:
+          | "silent"
+          | "delivery-error"
+          | "required-delivery-error"
+          | "execution-error"
+          | "not-requested" = "silent";
+        const runIsolatedAgentJob: CronServiceDeps["runIsolatedAgentJob"] = async ({
+          job,
+          abortSignal,
+        }) => {
+          if (phase === "execution-error") {
+            throw new Error("fixture agent execution failed");
+          }
+          const text = phase === "silent" ? "NO_REPLY" : "Actionable update";
+          const sessionId = randomUUID();
+          const sessionKey = `agent:main:cron:${job.id}:run:${sessionId}`;
+          const now = Date.now();
+          const dispatch = await dispatchCronDelivery({
+            cfg: {},
+            cfgWithAgentDefaults: {},
+            deps: {},
+            job,
+            agentId: "main",
+            agentSessionKey: sessionKey,
+            runSessionKey: sessionKey,
+            sessionId,
+            lifecycleRevision: randomUUID(),
+            sessionUpdatedAt: now,
+            runStartedAt: now,
+            runEndedAt: now,
+            timeoutMs: 5_000,
+            resolvedDelivery:
+              phase === "delivery-error" || phase === "required-delivery-error"
+                ? {
+                    ok: false,
+                    mode: "explicit",
+                    error: new Error("fixture delivery route unavailable"),
+                  }
+                : { ok: true, mode: "explicit", channel: "telegram", to: "123" },
+            deliveryRequested: phase !== "not-requested",
+            undeliveredRunStatus: "ok",
+            spawnOnlyHandoff: false,
+            sourceDeliveryOutcome: {
+              visibleDeliveries: [],
+              verifiedMessageToolDelivery: false,
+              satisfiesSourceDelivery: false,
+              unverifiedMessageToolDelivery: false,
+            },
+            deliveryBestEffort: job.delivery?.bestEffort === true,
+            deliveryPayloadHasStructuredContent: false,
+            deliveryPayloads: [{ text }],
+            synthesizedText: text,
+            summary: text,
+            outputText: text,
+            abortSignal,
+            isAborted: () => abortSignal?.aborted === true,
+            abortReason: () => "fixture aborted",
+            withRunSession: (result) => ({ ...result, sessionId, sessionKey }),
+          });
+          return {
+            status: "ok",
+            ...dispatch.result,
+            delivered: dispatch.delivered,
+            deliveryAttempted: dispatch.deliveryAttempted,
+            deliveryError: dispatch.deliveryError,
+            deliverySuppressionReason: dispatch.deliverySuppressionReason,
+            deliveryState: dispatch.deliveryState,
+          };
+        };
+        const cron = new CronService({
+          storePath,
+          defaultAgentId: "main",
+          cronEnabled: true,
+          log: createNoopLogger(),
+          enqueueSystemEvent: vi.fn(),
+          requestHeartbeat: vi.fn(),
+          runIsolatedAgentJob,
+          onEvent: (event) => {
+            if (event.action === "finished") {
+              events.push(event);
+            }
+          },
+        });
+        const invoke = installGatewayTransport(cron, storePath);
+        try {
+          await cron.start();
+          const job = await cron.add({
+            name: "idle-check",
+            enabled: true,
+            schedule: { kind: "every", everyMs: 3_600_000 },
+            sessionTarget: "isolated",
+            wakeMode: "next-heartbeat",
+            payload: { kind: "agentTurn", message: "Check for work; reply NO_REPLY when idle." },
+            delivery: { mode: "announce", channel: "telegram", to: "123" },
+          });
+          for (const nextPhase of [
+            "silent",
+            "delivery-error",
+            "required-delivery-error",
+            "execution-error",
+            "silent",
+            "not-requested",
+          ] as const) {
+            phase = nextPhase;
+            await cron.update(job.id, {
+              delivery:
+                phase === "not-requested"
+                  ? { mode: "none" }
+                  : {
+                      mode: "announce",
+                      channel: "telegram",
+                      to: "123",
+                      bestEffort: phase === "delivery-error",
+                    },
+            });
+            const run = await runCli([
+              "run",
+              job.id,
+              "--wait",
+              "--wait-timeout",
+              "10s",
+              "--poll-interval",
+              "10ms",
+            ]);
+            const failed = phase === "execution-error" || phase === "required-delivery-error";
+            const expectedStatus = failed ? "error" : "ok";
+            const completionStatus = failed ? "failed" : "succeeded";
+            const deliveryStatus =
+              phase === "execution-error"
+                ? "unknown"
+                : phase === "not-requested"
+                  ? "not-requested"
+                  : "not-delivered";
+            const delivered = phase === "execution-error" ? undefined : false;
+            expect(run.exitCode).toBe(failed ? 1 : 0);
+            await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+
+            const reason = phase === "silent" ? "silent" : undefined;
+            const persisted = expectDefined(
+              (await loadCronStore(storePath)).jobs.find((entry) => entry.id === job.id),
+              "expected persisted cron job",
+            );
+            expect(persisted.state.deliverySuppressionReason).toBe(reason);
+            expect(persisted.state).toMatchObject({
+              lastRunStatus: expectedStatus,
+              lastDeliveryStatus: deliveryStatus,
+            });
+            expect(persisted.state.lastDelivered).toBe(delivered);
+            const history = readCronTaskRunHistoryPage({
+              storeKey: cronStoreKey(storePath),
+              jobId: job.id,
+            });
+            expect(history.entries[0]?.deliverySuppressionReason).toBe(reason);
+            const outcome = { status: expectedStatus, completionStatus, deliveryStatus };
+            expect(history.entries[0]).toMatchObject(outcome);
+            expect(history.entries[0]?.delivered).toBe(delivered);
+            expect(run.json).toMatchObject({
+              completed: true,
+              status: expectedStatus,
+              completionStatus,
+              run: outcome,
+            });
+            if (phase === "silent" || phase === "not-requested") {
+              expect(persisted.state.lastError).toBeUndefined();
+              expect(persisted.state.lastDeliveryError).toBeUndefined();
+              expect(history.entries[0]?.deliveryError).toBeUndefined();
+            } else {
+              expect(persisted.state.lastDeliveryError).toContain(
+                phase === "execution-error"
+                  ? "fixture agent execution failed"
+                  : "fixture delivery route unavailable",
+              );
+            }
+            expect(events.at(-1)?.deliverySuppressionReason).toBe(reason);
+            expect(
+              (run.json as { run: { deliverySuppressionReason?: string } }).run
+                .deliverySuppressionReason,
+            ).toBe(reason);
+            const get = (await runCli(["get", job.id])).json as CronJob & {
+              deliverySuppressionReason?: string;
+            };
+            expect(get.deliverySuppressionReason).toBe(reason);
+            expect(get.state.deliverySuppressionReason).toBe(reason);
+            const compact = (await invoke("cron.list", { compact: true })) as {
+              jobs: Array<{ deliverySuppressionReason?: string }>;
+            };
+            expect(compact.jobs[0]?.deliverySuppressionReason).toBe(reason);
+            const listJson = (await runCli(["list", "--json"])).json as { jobs: CronJob[] };
+            expect(listJson.jobs[0]?.state.deliverySuppressionReason).toBe(reason);
+            const list = await runCli(["list"]);
+            const show = await runCli(["show", job.id]);
+            if (isRich()) {
+              const color = failed
+                ? theme.error
+                : phase === "delivery-error"
+                  ? theme.warn
+                  : theme.success;
+              const probe = color("probe");
+              const expectedAnsi = probe.slice(0, probe.indexOf("probe"));
+              expect(expectedAnsi).not.toBe("");
+              expect.soft(list.text).toContain(`${expectedAnsi}${expectedStatus}`);
+            }
+            if (phase === "silent") {
+              expect.soft(list.text).toMatch(/silent|suppressed/i);
+              expect.soft(show.text).toMatch(/silent|suppressed/i);
+              expect.soft(list.text).not.toContain("ok (not delivered)");
+              expect.soft(show.text).not.toContain("ok (not delivered)");
+            } else if (phase === "delivery-error") {
+              expect(list.text).toContain("ok (not delivered)");
+              expect(show.text).toContain(
+                "last delivery error: fixture delivery route unavailable",
+              );
+            } else if (failed) {
+              expect(show.text).toContain("status: error");
+              expect(show.text).not.toContain("ok (not delivered)");
+            } else {
+              expect(show.text).toContain("status: ok");
+              expect(show.text).not.toContain("ok (not delivered)");
+            }
+          }
+          expect(events).toHaveLength(6);
+          expect(
+            readCronTaskRunHistoryPage({ storeKey: cronStoreKey(storePath), jobId: job.id }).total,
+          ).toBe(6);
+        } finally {
+          cron.stop();
+          resetTaskRegistryForTests({ persist: false });
+        }
+      },
+    );
+  }, 30_000);
+});

--- a/src/cli/cron-cli/shared.test.ts
+++ b/src/cli/cron-cli/shared.test.ts
@@ -375,6 +375,9 @@ describe("printCronList", () => {
       state: {
         streamStatus: "disabled",
         streamError: "stream sources require cron.triggers.enabled=true",
+        lastRunStatus: "ok",
+        lastDeliveryStatus: "not-delivered",
+        deliverySuppressionReason: "silent",
       },
     });
 
@@ -383,6 +386,7 @@ describe("printCronList", () => {
     const row = list.logs.find((line) => line.includes(job.id)) ?? "";
     expect(row).toContain("disabled");
     expect(row).not.toContain("idle");
+    expect(row).not.toContain("ok (suppressed)");
 
     const show = createRuntimeLogCapture();
     printCronShow(job, show.runtime);
@@ -473,43 +477,81 @@ describe("printCronList", () => {
     },
   );
 
-  it.each([
-    {
-      label: "disabled",
-      enabled: false,
-      running: false,
-      runStatus: "ok" as const,
-      expectedStatus: "disabled",
+  it.each(["empty", "silent", "heartbeat", "channel_transform"] as const)(
+    "shows recorded %s suppression without changing JSON delivery status",
+    (deliverySuppressionReason) => {
+      const job = createBaseJob({
+        state: {
+          lastRunStatus: "ok",
+          lastDeliveryStatus: "not-delivered",
+          lastDelivered: false,
+          deliverySuppressionReason,
+        },
+      });
+      const list = createRuntimeLogCapture();
+      printCronList([job], list.runtime);
+      expectLogsToInclude(list.logs, "ok (suppressed)");
+      expect(list.logs.join("\n")).not.toContain("ok (not delivered)");
+
+      const show = createRuntimeLogCapture();
+      printCronShow(job, show.runtime);
+      expectLogsToInclude(show.logs, "status: ok (suppressed)");
+      expectLogsToInclude(show.logs, "last delivery: not-delivered");
+      expectLogsToInclude(show.logs, `last delivery suppression: ${deliverySuppressionReason}`);
+      expect(enrichCronJsonWithStatus(job)).toMatchObject({
+        status: "ok",
+        state: {
+          lastDeliveryStatus: "not-delivered",
+          lastDelivered: false,
+          deliverySuppressionReason,
+        },
+      });
     },
-    {
-      label: "running",
-      enabled: true,
-      running: true,
-      runStatus: "ok" as const,
-      expectedStatus: "running",
-    },
-    {
-      label: "paused but force-running",
-      enabled: false,
-      running: true,
-      runStatus: "ok" as const,
-      expectedStatus: "running",
-    },
-    {
-      label: "failed",
-      enabled: true,
-      running: false,
-      runStatus: "error" as const,
-      expectedStatus: "error",
-    },
-  ])(
-    "does not let prior non-delivery override a $label automation",
-    ({ enabled, running, runStatus, expectedStatus }) => {
+  );
+
+  it.each(
+    [
+      {
+        label: "disabled",
+        enabled: false,
+        running: false,
+        runStatus: "ok" as const,
+        expectedStatus: "disabled",
+      },
+      {
+        label: "running",
+        enabled: true,
+        running: true,
+        runStatus: "ok" as const,
+        expectedStatus: "running",
+      },
+      {
+        label: "paused but force-running",
+        enabled: false,
+        running: true,
+        runStatus: "ok" as const,
+        expectedStatus: "running",
+      },
+      {
+        label: "failed",
+        enabled: true,
+        running: false,
+        runStatus: "error" as const,
+        expectedStatus: "error",
+      },
+    ].flatMap((entry) => [
+      { ...entry, deliverySuppressionReason: undefined },
+      { ...entry, deliverySuppressionReason: "silent" as const },
+    ]),
+  )(
+    "does not let prior non-delivery ($deliverySuppressionReason) override a $label automation",
+    ({ enabled, running, runStatus, expectedStatus, deliverySuppressionReason }) => {
       const job = createBaseJob({
         enabled,
         state: {
           lastRunStatus: runStatus,
           lastDeliveryStatus: "not-delivered",
+          deliverySuppressionReason,
           ...(running ? { runningAtMs: Date.now() } : {}),
         },
       });
@@ -523,6 +565,7 @@ describe("printCronList", () => {
 
       expectLogsToInclude(show.logs, `status: ${expectedStatus}`);
       expect(show.logs.join("\n")).not.toContain("ok (not delivered)");
+      expect(show.logs.join("\n")).not.toContain("status: ok (suppressed)");
       expect(enrichCronJsonWithStatus(job)).toMatchObject({ status: expectedStatus });
       expect(enrichCronJsonWithStatus({ jobs: [job] })).toMatchObject({
         jobs: [{ status: expectedStatus }],

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -196,21 +196,35 @@ function decorateStatusWithFailures(status: string, consecutiveErrors: number | 
   return failures > 99 ? `${status} (99+x)` : `${status} (${failures}x)`;
 }
 
-function formatCronStatusForDisplay(job: CronJob): string {
+function formatCronStatusForDisplay(job: CronJob) {
   const state = job.state ?? {};
   const status = computeStatus(job);
-  if (job.enabled && job.schedule?.kind === "stream" && state.streamStatus === "disabled") {
-    return "disabled";
+  const streamDisabled =
+    job.enabled && job.schedule?.kind === "stream" && state.streamStatus === "disabled";
+  const undelivered = status === "ok" && state.lastDeliveryStatus === "not-delivered";
+  const suppressed =
+    undelivered && !streamDisabled && state.deliverySuppressionReason !== undefined;
+  // The recorded non-outcome, not completion success, distinguishes silence from failed best-effort delivery.
+  const color =
+    status === "error"
+      ? theme.error
+      : status === "running" || (undelivered && !suppressed)
+        ? theme.warn
+        : status === "ok"
+          ? theme.success
+          : theme.muted;
+  let label = decorateStatusWithFailures(status, state.consecutiveErrors);
+  if (streamDisabled) {
+    label = "disabled";
+  } else if (status === "disabled" && state.autoDisabled) {
+    label =
+      state.autoDisabled.reason === "schedule-errors"
+        ? "disabled (schedule)"
+        : `disabled (${state.autoDisabled.consecutiveErrors}x)`;
+  } else if (undelivered) {
+    label = suppressed ? "ok (suppressed)" : "ok (not delivered)";
   }
-  if (status === "disabled" && state.autoDisabled) {
-    return state.autoDisabled.reason === "schedule-errors"
-      ? "disabled (schedule)"
-      : `disabled (${state.autoDisabled.consecutiveErrors}x)`;
-  }
-  if (status === "ok" && state.lastDeliveryStatus === "not-delivered") {
-    return "ok (not delivered)";
-  }
-  return decorateStatusWithFailures(status, state.consecutiveErrors);
+  return { label, color };
 }
 
 export function handleCronCliError(err: unknown) {
@@ -504,8 +518,8 @@ export function printCronList(
       CRON_NEXT_PAD,
     );
     const lastLabel = formatCell(formatRelative(state.lastRunAtMs, now), CRON_LAST_PAD);
-    const statusRaw = computeStatus(job);
-    const statusLabel = formatCell(formatCronStatusForDisplay(job), CRON_STATUS_PAD);
+    const status = formatCronStatusForDisplay(job);
+    const statusLabel = formatCell(status.label, CRON_STATUS_PAD);
     const targetLabel = formatCell(job.sessionTarget, CRON_TARGET_PAD);
     const deliveryPreview = opts?.deliveryPreviews?.get(job.id);
     const deliveryText = deliveryPreview
@@ -518,22 +532,6 @@ export function printCronList(
       job.payload?.kind === "agentTurn" ? job.payload.model : undefined,
       CRON_MODEL_PAD,
     );
-
-    const coloredStatus = (() => {
-      if (statusRaw === "ok" && state.lastDeliveryStatus !== "not-delivered") {
-        return colorize(rich, theme.success, statusLabel);
-      }
-      if (statusRaw === "error") {
-        return colorize(rich, theme.error, statusLabel);
-      }
-      if (statusRaw === "running" || statusRaw === "ok") {
-        return colorize(rich, theme.warn, statusLabel);
-      }
-      if (statusRaw === "skipped") {
-        return colorize(rich, theme.muted, statusLabel);
-      }
-      return colorize(rich, theme.muted, statusLabel);
-    })();
 
     const coloredTarget =
       job.sessionTarget === "main"
@@ -550,7 +548,7 @@ export function printCronList(
       colorize(rich, theme.info, scheduleLabel),
       colorize(rich, theme.muted, nextLabel),
       colorize(rich, theme.muted, lastLabel),
-      coloredStatus,
+      colorize(rich, status.color, statusLabel),
       coloredTarget,
       deliveryPreview
         ? colorize(rich, theme.info, deliveryLabel)
@@ -598,11 +596,12 @@ export function printCronShow(
   runtime.log(`delivery: ${showValue(preview.label)} (${showValue(preview.detail)})`);
   runtime.log(`next: ${formatRelative(job.state.nextRunAtMs, Date.now())}`);
   runtime.log(`last: ${formatRelative(job.state.lastRunAtMs, Date.now())}`);
-  runtime.log(`status: ${showValue(formatCronStatusForDisplay(job))}`);
+  runtime.log(`status: ${showValue(formatCronStatusForDisplay(job).label)}`);
   // lastError is the run/schedule failure message; the diagnostic line below is
   // the run-diagnostics summary and can be empty when only lastError is set.
   runtime.log(`last error: ${showValue(job.state.lastError)}`);
   runtime.log(`last delivery: ${showValue(job.state.lastDeliveryStatus)}`);
+  runtime.log(`last delivery suppression: ${showValue(job.state.deliverySuppressionReason)}`);
   runtime.log(`last delivery error: ${showValue(job.state.lastDeliveryError)}`);
   runtime.log(`diagnostic: ${showValue(job.state.lastDiagnosticSummary)}`);
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users inspecting a healthy, intentionally silent automation run see `ok (not delivered)` and a delivery warning in the human-readable list and detail views. The structured results already distinguish intentional silence from delivery failure.

Related: #111851. Thanks to @akalsey for the production report. The structured reason propagation landed separately in #130811; this PR repairs the remaining human-readable CLI presentation.

AI-assisted implementation and review with Codex.

## Why This Change Was Made

One private presentation decision now owns the status label and color for both list and show. It uses the recorded suppression reason, rather than parsing summary text or treating all successful completions as delivered. The list's duplicate status/color classification is removed.

Actual non-delivery still warns, including successful best-effort runs whose delivery failed. Running, paused, disabled-stream, and execution-error precedence remain unchanged. Production LOC: +32/-33 (net -1); tests and documentation are separate.

## User Impact

Successful intentional suppression appears as `ok (suppressed)`. The detail view also shows the recorded `last delivery suppression` reason. JSON retains the existing transport status and separate `deliverySuppressionReason`; this changes no public status enum, completion policy, configuration, or persistence format.

## Evidence

The pre-fix boundary diagnostic failed on the two silent runs: both human views omitted the reason and retained the old label, and the list used warning color. The real dispatcher, service persistence/history, public Gateway handlers, and registered Commander actions carried the correct structured facts throughout. The four non-silent controls passed.

The same six ordered runs of one job passed after the fix: silence, best-effort delivery-target failure, required delivery-target failure, execution failure, silence again, and no requested delivery. The repeated sequence verifies stale suppression reasons and errors are cleared.

- Original diagnostic, explicit rich output: 1 passing test, 9.20 seconds.
- Normal non-TTY regression plus formatter siblings: 98 passing tests in 2 files, 7.11 seconds. This includes all four suppression reasons and status precedence controls.
- Node 24.20.0, one worker, tested against main `c85129f85507b5f2e6c3bd0ce4ede29e1420195a` with this patch.
- Publication base `ccbbaf2e2e57f53b3a2b086b3490d21fe40a7c9d`: the changed owners and producer/service/history/public-handler/CLI proof paths are unchanged from that tested base. This is source-parity verification, not an additional test run.
- Final native regression on that publication base: rich output 1 pass (17.13 seconds), normal output plus formatter siblings 98 passes (7.44 seconds). Four test-only lint findings were corrected while retaining JSON wire serialization and actual color assertions; production was unchanged.
- Native four-file formatting and targeted type-aware lint on all three TypeScript files pass.
- Independent source and observed RED/GREEN review: no actionable findings.
- Fresh isolated Codex review through P2: no actionable findings; the review covered the full owner, producer/service, public handlers, caller, tests, and documentation. It did not rerun validation.

Proof boundaries: the diagnostic supplies agent output and bridges RPC calls directly into the real handlers. It is not a live model, channel send, or Gateway-socket test; the changed owner is CLI presentation. The identical rich diagnostic was retained separately while the committed test was made compatible with normal non-TTY CI.

Refreshed final Codex review after the test-only corrections found no actionable P0–P2 issues. [Exact-head CI run 33173617297](https://github.com/openclaw/openclaw/actions/runs/33173617297) completed successfully for `388f0c2c1eea56b826651ca10fc3cf027c4d49a6`, including broad type/guard checks and `openclaw/ci-gate`. The [CLI job](https://github.com/openclaw/openclaw/actions/runs/33173617297/job/98856666697) actually ran the new six-phase regression (407ms) and the 97 formatter cases; the whole shard finished with 5801 passed and 42 skipped tests.

CI used merge `c7169240053283c8f70e44c2d906980c040f0ce7` into main `b6aff3ef0e16a47f10b82bf6223598326d632705`. Because newer main introduced a shared-state transaction wrapper, the unchanged six-phase test was also replayed with this production patch on `babb2fc7c1363587a4e08266d59772e35a78d1c9`: one test passed (394ms, 10.52s total). This separately covers the newer real shared-store/task-history composition; it is not a claim that the older CI merge tested newer main. No schema or persistence implementation was changed by this PR.

The focused current-main command was:

```sh
env -u NO_COLOR FORCE_COLOR=1 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_TEST_WORKERS=1 node scripts/run-vitest.mjs --config test/vitest/vitest.cli.config.ts src/cli/cron-cli/cron-suppression.gateway.test.ts --maxWorkers 1 --reporter verbose
```

It ran under a bounded 115-second timeout at low priority on Node 24.20.0. The captured terminal result was `Test Files 1 passed (1)` and `Tests 1 passed (1)`; SHA256 of the complete log is `a22fa0246c8c495056b3a8197260752ac80348230ae7b1f6c7aca2e8933256b2`. Both candidate hashes remained unchanged, the temporary overlay was removed, and the checkout and owned process groups were clean afterward. The earlier unconditional rich diagnostic remains the explicit color proof; this newer receipt establishes current composition.

ClawSweeper feedback addressed: its [verification output](https://github.com/openclaw/openclaw/pull/131774#issuecomment-5453050402) shows the regression passing and the command exiting successfully. Its outer `expect_output` assertion missed the long test title because the terminal wrapped `repeated` across two lines. The linked CI log and focused terminal result above provide independently observed successful execution without changing the test name, assertions, or timeouts. The previously pending CI item is now green. The optional Rank-up request for a real-setup recording was not performed and is not claimed. The changed-owner proof runs the real dispatcher, service, SQLite, public handlers and Commander with declared agent-input and RPC-transport test boundaries; it does not prove a live provider, channel send, or Gateway socket. No broader status-enum decision is needed for this PR: the reporter explicitly accepted a separate recorded reason. Native prepare/merge and issue closure remain separate gates.

Named follow-up: Control UI run-history presentation also omits the suppression reason in current source. That separate UI lead has not been reproduced in a browser and is not claimed fixed here. The TUI has no corresponding delivery-status presentation consumer.
