### PR TITLE
refactor(lobster): track cycles through approval arrays

### DIFF
--- a/extensions/lobster/src/lobster-taskflow.test.ts
+++ b/extensions/lobster/src/lobster-taskflow.test.ts
@@ -93,6 +93,9 @@ describe("runManagedLobsterFlow", () => {
     const objectArrayCycle: Record<string, unknown> = {};
     objectArrayCycle.items = [objectArrayCycle];
     const shared = { id: "shared" };
+    const protoEntry: Record<string, unknown> = JSON.parse(
+      '{"__proto__":{"polluted":true},"kept":"value"}',
+    );
     const runner = createRunner({
       ok: true,
       status: "needs_approval",
@@ -114,6 +117,7 @@ describe("runManagedLobsterFlow", () => {
               function: () => true,
               symbol: Symbol("skip"),
             },
+            protoEntry,
             arrayValues: [undefined, () => true, Symbol("skip"), Number.NaN],
           },
         ],
@@ -140,6 +144,7 @@ describe("runManagedLobsterFlow", () => {
             infinity: "Infinity",
             count: "2",
             omitted: { kept: true },
+            protoEntry: { kept: "value" },
             arrayValues: [null, null, null, "NaN"],
           },
         ],

--- a/extensions/lobster/src/lobster-taskflow.test.ts
+++ b/extensions/lobster/src/lobster-taskflow.test.ts
@@ -85,9 +85,14 @@ describe("runManagedLobsterFlow", () => {
     });
   });
 
-  it("moves the flow to waiting when Lobster requests approval", async () => {
+  it("serializes cyclic and supported approval items before waiting", async () => {
     const taskFlow = createFakeTaskFlow();
     const createdAt = new Date("2026-04-05T21:00:00.000Z");
+    const selfArray: unknown[] = [];
+    selfArray.push(selfArray);
+    const objectArrayCycle: Record<string, unknown> = {};
+    objectArrayCycle.items = [objectArrayCycle];
+    const shared = { id: "shared" };
     const runner = createRunner({
       ok: true,
       status: "needs_approval",
@@ -95,7 +100,23 @@ describe("runManagedLobsterFlow", () => {
       requiresApproval: {
         type: "approval_request",
         prompt: "Approve this?",
-        items: [{ id: "item-1", createdAt, count: 2n, skip: undefined }],
+        items: [
+          {
+            selfArray,
+            objectArrayCycle,
+            repeated: [shared, shared],
+            createdAt,
+            infinity: Number.POSITIVE_INFINITY,
+            count: 2n,
+            omitted: {
+              kept: true,
+              undefinedValue: undefined,
+              function: () => true,
+              symbol: Symbol("skip"),
+            },
+            arrayValues: [undefined, () => true, Symbol("skip"), Number.NaN],
+          },
+        ],
         resumeToken: "resume-1",
       },
     });
@@ -110,7 +131,18 @@ describe("runManagedLobsterFlow", () => {
       waitJson: {
         kind: "lobster_approval",
         prompt: "Approve this?",
-        items: [{ id: "item-1", createdAt: createdAt.toISOString(), count: "2" }],
+        items: [
+          {
+            selfArray: ["[Circular]"],
+            objectArrayCycle: { items: ["[Circular]"] },
+            repeated: [{ id: "shared" }, { id: "shared" }],
+            createdAt: createdAt.toISOString(),
+            infinity: "Infinity",
+            count: "2",
+            omitted: { kept: true },
+            arrayValues: [null, null, null, "NaN"],
+          },
+        ],
         resumeToken: "resume-1",
       },
     });

--- a/extensions/lobster/src/lobster-taskflow.ts
+++ b/extensions/lobster/src/lobster-taskflow.ts
@@ -73,41 +73,37 @@ function toJsonLike(value: unknown, seen = new WeakSet<object>()): JsonLike {
   if (value === null) {
     return null;
   }
-  switch (typeof value) {
-    case "boolean":
-    case "string":
-      return value;
-    case "number":
-      return Number.isFinite(value) ? value : String(value);
-    case "bigint":
-      return value.toString();
-    case "undefined":
-    case "function":
-    case "symbol":
-      return null;
-    case "object": {
-      if (value instanceof Date) {
-        return value.toISOString();
-      }
-      if (Array.isArray(value)) {
-        return value.map((item) => toJsonLike(item, seen));
-      }
-      if (seen.has(value)) {
-        return "[Circular]";
-      }
-      seen.add(value);
-      const jsonObject: Record<string, JsonLike> = {};
-      for (const [key, entry] of Object.entries(value)) {
-        if (entry === undefined || typeof entry === "function" || typeof entry === "symbol") {
-          continue;
-        }
-        jsonObject[key] = toJsonLike(entry, seen);
-      }
-      seen.delete(value);
-      return jsonObject;
-    }
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : String(value);
   }
-  return null;
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  if (typeof value === "boolean" || typeof value === "string") {
+    return value;
+  }
+  if (typeof value !== "object") {
+    return null;
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (seen.has(value)) {
+    return "[Circular]";
+  }
+  seen.add(value);
+  const jsonValue: JsonLike = Array.isArray(value)
+    ? value.map((item) => toJsonLike(item, seen))
+    : Object.fromEntries(
+        Object.entries(value)
+          .filter(
+            ([, entry]) =>
+              entry !== undefined && typeof entry !== "function" && typeof entry !== "symbol",
+          )
+          .map(([key, entry]) => [key, toJsonLike(entry, seen)] as const),
+      );
+  seen.delete(value);
+  return jsonValue;
 }
 
 function buildApprovalWaitState(envelope: Extract<LobsterEnvelope, { ok: true }>): JsonLike {

--- a/extensions/lobster/src/lobster-taskflow.ts
+++ b/extensions/lobster/src/lobster-taskflow.ts
@@ -92,18 +92,20 @@ function toJsonLike(value: unknown, seen = new WeakSet<object>()): JsonLike {
     return "[Circular]";
   }
   seen.add(value);
-  const jsonValue: JsonLike = Array.isArray(value)
-    ? value.map((item) => toJsonLike(item, seen))
-    : Object.fromEntries(
-        Object.entries(value)
-          .filter(
-            ([, entry]) =>
-              entry !== undefined && typeof entry !== "function" && typeof entry !== "symbol",
-          )
-          .map(([key, entry]) => [key, toJsonLike(entry, seen)] as const),
-      );
+  if (Array.isArray(value)) {
+    const jsonArray = value.map((item) => toJsonLike(item, seen));
+    seen.delete(value);
+    return jsonArray;
+  }
+  const jsonObject: Record<string, JsonLike> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (entry === undefined || typeof entry === "function" || typeof entry === "symbol") {
+      continue;
+    }
+    jsonObject[key] = toJsonLike(entry, seen);
+  }
   seen.delete(value);
-  return jsonValue;
+  return jsonObject;
 }
 
 function buildApprovalWaitState(envelope: Extract<LobsterEnvelope, { ok: true }>): JsonLike {


### PR DESCRIPTION
## What Problem This Solves

Closes an internal consistency gap in the managed TaskFlow converter: object
cycles were guarded, but array cycles from an injected/private runner could
overflow the converter stack instead of using the same circular-value
representation.

The default embedded Lobster runner serializes envelopes with `JSON.stringify`
before this boundary and therefore rejects cyclic envelopes earlier. This is
not a demonstrated standard-runtime or operator-facing failure.

## Why This Change Was Made

The approval serializer now applies one recursion-stack `WeakSet` to every
non-Date object, including arrays. Each array or object is removed after its
subtree is serialized, so real cycles become `"[Circular]"` while repeated
non-cyclic references are serialized normally.

The existing scalar and container behavior is preserved:

- non-finite numbers and bigint values become strings
- unsupported object properties are omitted
- unsupported array entries become `null`
- Dates remain ISO strings

No run/resume lifecycle, parsing, runner normalization, SDK, documentation, or
output-bound behavior changes.

## User Impact

No current default-runtime behavior changes. The private/injected runner
boundary now handles array and object cycles consistently, which keeps the
converter robust for tests and future custom runner integrations.

## Evidence

Base: `b6aff3ef0e16a47f10b82bf6223598326d632705`
Head: `fcea5688bd9e1b1de71626243b6567aeb588eb01`

Pre-fix owner-boundary reproduction:

- focused regression failed `1/1`
- an injected runner returning a cyclic approval envelope caused
  `RangeError: Maximum call stack size exceeded`
- `failFlow` received `flow-1` revision `1`; `setWaiting` was not called
- the default embedded runner remains cycle-rejecting at its earlier
  `JSON.stringify` boundary

Review regression:

- the prior head changed own enumerable `__proto__` handling by using
  `Object.fromEntries`
- a `JSON.parse` object proved that head persisted the key instead of preserving
  the prior assignment-path omission
- the final implementation retains the original object assignment loop and
  moves only arrays behind the shared recursion-stack tracking

Post-fix:

- consolidated cycle/object-semantics regression: `1/1` passed
- Lobster taskflow + tool tests: `47/47` passed
- `pnpm test:extension lobster`: `74/74` passed
- extension production and test typechecks passed
- exact-file Oxlint and formatting passed
- changed-file routing selected only `extensions` and `extensionTests`
- all changed-gate surfaces passed
- `git diff --check` passed
- Sol/high autoreview: clean, correctness `0.99`

Protected Crabbox AWS:

- workflow: `33176853084`
- trusted main/workflow SHA:
  `1186e6a6f3d45494e1d2c22b626480471713797f`
- exact PR base/head:
  `cb696a1bb3b66a8d51392a8ab743e270e4f249cf` /
  `fcea5688bd9e1b1de71626243b6567aeb588eb01`
- provider/target: AWS/Linux, sanitized public-network mode
- run/lease: `run_b410a5b8e3a3` / `cbx_f1ef6580c27c`
  (`blue-krill`)
- bootstrap SHA-256:
  `5cd52c255f6df752e74a6f913354107516de3fc002a5bcf19586e04ac13d5985`
- plan SHA-256:
  `8a98f3781f7e035f619acf40d064f254cf1f9da720cc6a052136f27b94712759`
  (2 targets: the complete TaskFlow and tool test files)
- build, check, and PR-derived tests passed; command exit `0`
- broker result `succeeded`; `leaseStopped=true`
- exact-head `openclaw/crabbox-gate` check `98873205189` completed
  successfully from GitHub Actions app `15368`
- the local native waiter initially missed the just-published check due to
  check-API visibility timing; no second AWS proof was dispatched

Reviews and hosted checks:

- Franklin final audit: satisfied after the enumerable `__proto__` repair
- exact-head ClawSweeper: no findings or security issues
- exact-head owner decision resolves the bounded-refactor P2 next step
- hosted CI: 60 success, 55 skipped, 0 failed or pending

Test-audit:

- protects the observable managed-flow waiting mutation
- demonstrably failed on the pre-fix implementation for the intended reason
- consolidates the existing approval-wait test instead of duplicating setup
- adds no test-only production seam

LOC:

- production: `+31/-33` (net `-2`)
- tests: `+40/-3` (net `+37`)

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted task transcript</summary>

```text
[user]
Implement one bounded Lobster campaign from current main. Limit the change to
lobster-taskflow.ts and its test, first prove the self-referential approval
array failure, preserve serialization and lifecycle invariants, run the owning
tests and reviews, and open a draft PR without merging it.

[assistant]
Created a fresh GWT from current origin/main and inspected the serializer,
managed-flow owner, tests, history, scoped policy, and sibling Codex review
runtime before editing.

[assistant]
Captured the pre-fix injected-runner boundary failure: a self-referential
approval array caused RangeError, failed flow-1 at revision 1, and never called
setWaiting. Confirmed the default embedded runner rejects cycles earlier during
JSON serialization.

[assistant]
Moved array traversal behind the shared recursion-stack check while retaining
Date and scalar handling. Added one consolidated approval-wait test covering
cycles, back-references, repeated objects, scalar conversions, omissions, null
array entries, and the exact waiting mutation.

[assistant]
After review found an enumerable `__proto__` behavior drift, reproduced it
against the prior head, restored the original object assignment loop, and kept
only array cycle tracking as the production change.

[assistant]
Focused tests, extension tests, typechecks, lint, formatting, changed-file
checks, test-audit, deslop, and Sol/high autoreview completed cleanly.

[assistant]
Ran the protected-main publisher-owned Crabbox gate once on the corrected exact
head. AWS/Linux build, check, and the two-target PR-derived plan passed; the
broker run succeeded and stopped its lease, and GitHub Actions published the
exact-head `openclaw/crabbox-gate` check.
```

</details>
<!-- agent-transcript:end -->
