### PR TITLE
fix(test): run plugin batches from unbuilt checkouts

### DIFF
--- a/scripts/lib/extension-test-plan.mts
+++ b/scripts/lib/extension-test-plan.mts
@@ -406,7 +406,7 @@ export function resolveExtensionTestPlan(params: { cwd?: string; targetArg?: str
 
 type ResolvedExtensionTestPlan = ReturnType<typeof resolveExtensionTestPlan>;
 
-function mergeTestPlans(plans: ResolvedExtensionTestPlan[]): ExtensionBatchPlan {
+export function mergeExtensionTestPlans(plans: ResolvedExtensionTestPlan[]): ExtensionBatchPlan {
   const groupsByConfig = new Map<string, ExtensionTestPlanGroup>();
 
   const testPlans = plans.filter((plan) => plan.hasTests);
@@ -462,7 +462,9 @@ export function resolveExtensionBatchPlan(params: { cwd?: string; extensionIds?:
     resolveExtensionTestPlan({ cwd, targetArg: extensionId }),
   );
 
-  return mergeTestPlans(hasExplicitExtensionIds ? plans : plans.filter((plan) => plan.hasTests));
+  return mergeExtensionTestPlans(
+    hasExplicitExtensionIds ? plans : plans.filter((plan) => plan.hasTests),
+  );
 }
 
 type PendingExtensionTestShard = {
@@ -523,7 +525,7 @@ export function createExtensionTestShards(
       Object.assign(
         {},
         { index, checkName: `checks-node-extensions-shard-${index + 1}` },
-        mergeTestPlans(shard.plans),
+        mergeExtensionTestPlans(shard.plans),
       ),
     )
     .filter((shard) => shard.hasTests);

--- a/scripts/lib/vitest-build-prerequisites.mts
+++ b/scripts/lib/vitest-build-prerequisites.mts
@@ -1,6 +1,8 @@
 import { spawn } from "node:child_process";
-import { matchesGlob } from "node:path";
+import path from "node:path";
+import { matchesVitestCliSelection } from "../../test/vitest/vitest.pattern-file.ts";
 import { fullSuiteVitestShards } from "../../test/vitest/vitest.test-shards.mjs";
+import { runManagedCommand } from "./managed-child-process.mts";
 
 export type VitestPretestBuildMode = "private-qa" | "runtime";
 type SetupCommandRunner = (args: string[], env: NodeJS.ProcessEnv) => Promise<number>;
@@ -8,6 +10,7 @@ type SetupCommandRunner = (args: string[], env: NodeJS.ProcessEnv) => Promise<nu
 type TestSelection = {
   configs?: readonly string[];
   includePatterns?: readonly string[] | null;
+  cli?: { args: string[]; dir: string; env: NodeJS.ProcessEnv };
 };
 
 // These process tests consume built runtime artifacts. Prepare their strongest
@@ -19,39 +22,78 @@ const runtimeConsumers = [
     file: "extensions/qa-lab/src/suite-process-lifecycle.test.ts",
     configs: ["test/vitest/vitest.extension-qa.config.ts"],
     mode: "private-qa",
+    dir: "extensions",
   },
   {
     file: "test/e2e/qa-lab/runtime/gateway-support-export-runtime.test.ts",
     configs: ["test/vitest/vitest.tooling.config.ts"],
     mode: "runtime",
+    dir: "",
   },
   {
     file: "src/gateway/gateway-concurrent-streams.test.ts",
     configs: ["test/vitest/vitest.gateway-core.config.ts", "test/vitest/vitest.gateway.config.ts"],
     mode: "runtime",
+    dir: "src/gateway",
   },
 ] as const;
+
+function includesRuntimeConfig(configs: readonly string[] | undefined, config: string) {
+  return configs?.some(
+    (selected) =>
+      selected === config ||
+      selected === "vitest.config.ts" ||
+      selected === "test/vitest/vitest.config.ts" ||
+      fullSuiteVitestShards.some(
+        (shard) => shard.config === selected && shard.projects.includes(config),
+      ),
+  );
+}
+
+export function resolveVitestRuntimeCliSelections(
+  config: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+): TestSelection[] {
+  return runtimeConsumers
+    .filter((consumer) =>
+      consumer.configs.some((candidate) => includesRuntimeConfig([config], candidate)),
+    )
+    .map((consumer) => ({ configs: consumer.configs, cli: { args, dir: consumer.dir, env } }));
+}
 
 export function resolveVitestPretestBuildMode(
   selections: readonly TestSelection[],
 ): VitestPretestBuildMode | undefined {
   return runtimeConsumers.find(({ file, configs: consumerConfigs }) =>
-    selections.some(({ configs, includePatterns }) =>
-      includePatterns
-        ? includePatterns.some((pattern) => matchesGlob(file, pattern))
-        : configs?.some(
-            (selected) =>
-              consumerConfigs.some((config) => selected === config) ||
-              selected === "vitest.config.ts" ||
-              selected === "test/vitest/vitest.config.ts" ||
-              fullSuiteVitestShards.some(
-                (shard) =>
-                  shard.config === selected &&
-                  consumerConfigs.some((config) => shard.projects.includes(config)),
-              ),
-          ),
-    ),
+    selections.some(({ configs, includePatterns, cli }) => {
+      const included = includePatterns
+        ? includePatterns.some((pattern) => path.matchesGlob(file, pattern))
+        : consumerConfigs.some((config) => includesRuntimeConfig(configs, config));
+      // Only project the canonical consumers; config loading and test discovery
+      // stay with Vitest. Include-file overrides still intersect emitted filters.
+      return cli
+        ? matchesVitestCliSelection(file, included ? [file] : [], cli.args, cli.dir, cli.env)
+        : included;
+    }),
   )?.mode;
+}
+
+export async function prepareVitestRuntime(
+  selections: readonly TestSelection[],
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<number> {
+  const mode = resolveVitestPretestBuildMode(selections);
+  if (!mode) {
+    return 0;
+  }
+  console.error(`[test] preparing ${mode} runtime before Vitest workers`);
+  return runManagedCommand({
+    bin: process.execPath,
+    args: ["scripts/run-node.mjs", "--version"],
+    cwd: path.resolve(import.meta.dirname, "../.."),
+    env: { ...env, ...(mode === "private-qa" ? { OPENCLAW_BUILD_PRIVATE_QA: "1" } : {}) },
+  });
 }
 
 export function isE2eBuildSkipped(env: NodeJS.ProcessEnv) {

--- a/scripts/run-vitest.mts
+++ b/scripts/run-vitest.mts
@@ -20,6 +20,10 @@ import { createGatewayServerTestTargetChunks } from "./lib/gateway-server-test-p
 import { signalExitCode } from "./lib/managed-child-process.mts";
 import { resolveRepoRoot } from "./lib/repo-root.mjs";
 import { spawnTestProjectsRunner } from "./lib/test-projects-delegation.mts";
+import {
+  resolveVitestRuntimeCliSelections,
+  prepareVitestRuntime,
+} from "./lib/vitest-build-prerequisites.mts";
 import { resolveVitestProcessEnv } from "./lib/vitest-process-env.mts";
 import {
   createVitestUnhandledErrorDetector,
@@ -1410,6 +1414,29 @@ async function main(
 
   const vitestArgs = resolveImplicitVitestArgs(argv);
   const invocations = resolveBoundedVitestInvocations(vitestArgs, { env });
+  const config = resolveVitestConfigArg(vitestArgs);
+  const relativeConfig = config ? toRepoRelativeArg(path.resolve(config), repoRoot) : "";
+  // Canonical configs have known project scopes. Custom roots/projects keep
+  // their own setup; never infer their runtime selection from a config name.
+  if (
+    config &&
+    !hasAlternateVitestRootArg(vitestArgs) &&
+    !hasExplicitVitestProjectArg(vitestArgs) &&
+    !hasNonRunVitestSubcommand(vitestArgs) &&
+    !hasExplicitDisabledRunFlag(vitestArgs) &&
+    !vitestArgs.some((arg) => ["--help", "-h", "--version", "-v"].includes(arg))
+  ) {
+    const code = await prepareVitestRuntime(
+      invocations.flatMap((cliArgs) =>
+        resolveVitestRuntimeCliSelections(relativeConfig, cliArgs, env),
+      ),
+      env,
+    );
+    if (code !== 0) {
+      process.exitCode = code;
+      return;
+    }
+  }
   let vitestCliEntry;
   try {
     vitestCliEntry = resolveVitestCliEntry();

--- a/scripts/test-extension-batch.mts
+++ b/scripts/test-extension-batch.mts
@@ -3,6 +3,7 @@
 // Runs grouped Vitest plans for one or more bundled plugins.
 import path from "node:path";
 import pMap from "p-map";
+import { collectVitestExcludePatterns } from "../test/vitest/vitest.pattern-file.ts";
 import {
   createExtensionTestProcessTargetChunks,
   listExtensionTestFilesForRoots,
@@ -19,6 +20,7 @@ import {
 import { parsePositiveInt } from "./lib/numeric-options.mjs";
 import { isDirectScriptRun, runVitestBatch } from "./lib/vitest-batch-runner.mts";
 import type { VitestBatchRunParams } from "./lib/vitest-batch-runner.mts";
+import { prepareVitestRuntime } from "./lib/vitest-build-prerequisites.mts";
 
 const FS_MODULE_CACHE_PATH_ENV_KEY = "OPENCLAW_VITEST_FS_MODULE_CACHE_PATH";
 const PARALLEL_ENV_KEY = "OPENCLAW_EXTENSION_BATCH_PARALLEL";
@@ -141,25 +143,9 @@ function addExactExcludePath(excludePaths: Set<string>, value: string) {
  */
 export function parseExactVitestExcludePaths(vitestArgs: string[]) {
   const excludePaths = new Set<string>();
-  for (let index = 0; index < vitestArgs.length; index += 1) {
-    const arg = vitestArgs[index];
-    if (arg === undefined) {
-      break;
-    }
-    if (arg === "--exclude") {
-      const value = vitestArgs[index + 1];
-      if (value && isExactExcludePath(value)) {
-        addExactExcludePath(excludePaths, value);
-      }
-      index += 1;
-      continue;
-    }
-    const prefix = "--exclude=";
-    if (arg.startsWith(prefix)) {
-      const value = arg.slice(prefix.length);
-      if (value && isExactExcludePath(value)) {
-        addExactExcludePath(excludePaths, value);
-      }
+  for (const value of collectVitestExcludePatterns(vitestArgs)) {
+    if (isExactExcludePath(value)) {
+      addExactExcludePath(excludePaths, value);
     }
   }
   return excludePaths;
@@ -178,46 +164,49 @@ function resolveGroupTargets(group: ExtensionTestPlanGroup, exactExcludePaths: S
   return testFiles.filter((file) => !exactExcludePaths.has(file));
 }
 
-async function runPlanGroup(
+function preparePlanGroup(
   group: ExtensionTestPlanGroup,
-  params: {
-    env: NodeJS.ProcessEnv;
-    groupIndex: number;
-    runGroup: (params: VitestBatchRunParams) => Promise<number>;
-    exactExcludePaths: Set<string>;
-    allowEmptyAfterExclude: boolean;
-    useDedicatedCache: boolean;
-    vitestArgs: string[];
-  },
+  groupIndex: number,
+  env: NodeJS.ProcessEnv,
+  vitestArgs: string[],
+  exactExcludePaths: Set<string>,
+  useDedicatedCache: boolean,
 ) {
-  const targets = resolveGroupTargets(group, params.exactExcludePaths);
-  if (targets.length === 0) {
-    console.error(`[test-extension-batch] ${group.config}: no test files remain after excludes`);
-    return params.allowEmptyAfterExclude ? 0 : 1;
-  }
-
+  const targets = resolveGroupTargets(group, exactExcludePaths);
   const targetChunks =
-    params.exactExcludePaths.size > 0
-      ? shouldSplitExtensionTestProcesses(group.config, params.vitestArgs)
-        ? splitExtensionTestProcessTargets(group.config, targets)
-        : [targets]
-      : createExtensionTestProcessTargetChunks(group.config, group.roots, params.vitestArgs);
-  let finalExitCode = 0;
-  for (const [index, chunk] of targetChunks.entries()) {
-    console.log(
-      `[test-extension-batch] ${group.config}: ${group.extensionIds.join(", ")} (${chunk.length} targets${targetChunks.length > 1 ? `, chunk ${index + 1}/${targetChunks.length}` : ""})`,
-    );
-    const exitCode = await params.runGroup({
-      args: relativizeExtensionVitestArgs(params.vitestArgs),
+    targets.length === 0
+      ? []
+      : exactExcludePaths.size > 0
+        ? shouldSplitExtensionTestProcesses(group.config, vitestArgs)
+          ? splitExtensionTestProcessTargets(group.config, targets)
+          : [targets]
+        : createExtensionTestProcessTargetChunks(group.config, group.roots, vitestArgs);
+  return {
+    group,
+    invocations: targetChunks.map((chunk) => ({
+      args: relativizeExtensionVitestArgs(vitestArgs),
       config: group.config,
-      env: createGroupEnv({
-        baseEnv: params.env,
-        group,
-        groupIndex: params.groupIndex,
-        useDedicatedCache: params.useDedicatedCache,
-      }),
+      env: createGroupEnv({ baseEnv: env, group, groupIndex, useDedicatedCache }),
       targets: chunk.map((target) => relativizeExtensionVitestPath(target)),
-    });
+    })),
+  };
+}
+
+async function runPlanGroup(
+  { group, invocations }: ReturnType<typeof preparePlanGroup>,
+  runGroup: (params: VitestBatchRunParams) => Promise<number>,
+  allowEmptyAfterExclude: boolean,
+) {
+  if (invocations.length === 0) {
+    console.error(`[test-extension-batch] ${group.config}: no test files remain after excludes`);
+    return allowEmptyAfterExclude ? 0 : 1;
+  }
+  let finalExitCode = 0;
+  for (const [index, invocation] of invocations.entries()) {
+    console.log(
+      `[test-extension-batch] ${group.config}: ${group.extensionIds.join(", ")} (${invocation.targets.length} targets${invocations.length > 1 ? `, chunk ${index + 1}/${invocations.length}` : ""})`,
+    );
+    const exitCode = await runGroup(invocation);
     if (exitCode !== 0 && finalExitCode === 0) {
       finalExitCode = exitCode;
     }
@@ -232,6 +221,7 @@ export async function runExtensionBatchPlan(
   batchPlan: ExtensionBatchPlan,
   params: {
     allowEmptyAfterExclude?: boolean;
+    expandExactExcludes?: boolean;
     env?: NodeJS.ProcessEnv;
     runGroup?: (params: VitestBatchRunParams) => Promise<number>;
     vitestArgs?: string[];
@@ -239,7 +229,11 @@ export async function runExtensionBatchPlan(
 ) {
   const env = params.env ?? process.env;
   const vitestArgs = params.vitestArgs ?? [];
-  const exactExcludePaths = parseExactVitestExcludePaths(vitestArgs);
+  // Single-plugin CLI historically leaves exact exclusions to Vitest.
+  const exactExcludePaths =
+    params.expandExactExcludes === false
+      ? new Set<string>()
+      : parseExactVitestExcludePaths(vitestArgs);
   const runGroup = params.runGroup ?? runVitestBatch;
   const parallelism = resolveExtensionBatchParallelism(batchPlan.planGroups.length, env);
   const orderedGroups = orderPlanGroups(batchPlan.planGroups, parallelism);
@@ -250,22 +244,31 @@ export async function runExtensionBatchPlan(
     console.log(`[test-extension-batch] Running up to ${parallelism} config groups in parallel`);
   }
 
+  const preparedGroups = orderedGroups.map((group, index) =>
+    preparePlanGroup(group, index, env, vitestArgs, exactExcludePaths, useDedicatedCache),
+  );
+  // No reader may start while a shared generation is being replaced. Select
+  // from the exact emitted chunks, including existing exact-exclude expansion.
+  const preparationCode = await prepareVitestRuntime(
+    preparedGroups.flatMap(({ invocations }) =>
+      invocations.map(({ config, args, targets }) => ({
+        configs: [config],
+        cli: { args: [...args, ...targets], dir: "extensions", env },
+      })),
+    ),
+    env,
+  );
+  if (preparationCode !== 0) {
+    return preparationCode;
+  }
   let exitCode = 0;
   await pMap(
-    orderedGroups,
-    async (group, groupIndex) => {
+    preparedGroups,
+    async (group) => {
       if (exitCode !== 0) {
         return;
       }
-      const groupExitCode = await runPlanGroup(group, {
-        env,
-        groupIndex,
-        runGroup,
-        exactExcludePaths,
-        allowEmptyAfterExclude,
-        useDedicatedCache,
-        vitestArgs,
-      });
+      const groupExitCode = await runPlanGroup(group, runGroup, allowEmptyAfterExclude);
       if (groupExitCode !== 0 && exitCode === 0) {
         exitCode = groupExitCode;
       }

--- a/scripts/test-extension.mts
+++ b/scripts/test-extension.mts
@@ -2,15 +2,9 @@
 
 // Runs the Vitest plan for one bundled plugin by id or path.
 import { formatErrorMessage } from "./lib/error-format.mts";
-import {
-  createExtensionTestProcessTargetChunks,
-  resolveExtensionTestPlan,
-} from "./lib/extension-test-plan.mts";
-import {
-  relativizeExtensionVitestArgs,
-  relativizeExtensionVitestPath,
-} from "./lib/extension-vitest-paths.mts";
-import { isDirectScriptRun, runVitestBatch } from "./lib/vitest-batch-runner.mts";
+import { mergeExtensionTestPlans, resolveExtensionTestPlan } from "./lib/extension-test-plan.mts";
+import { isDirectScriptRun } from "./lib/vitest-batch-runner.mts";
+import { runExtensionBatchPlan } from "./test-extension-batch.mts";
 
 const ALLOW_NO_TESTS_FLAG = "--allow-no-tests";
 
@@ -60,26 +54,10 @@ async function run(): Promise<void> {
   }
 
   console.log(`[test-extension] Running ${plan.testFileCount} test files for ${plan.extensionId}`);
-  const targetChunks = createExtensionTestProcessTargetChunks(
-    plan.config,
-    plan.roots,
-    passthroughArgs,
-  );
-  let finalExitCode = 0;
-  for (const [index, targets] of targetChunks.entries()) {
-    if (targetChunks.length > 1) {
-      console.log(`[test-extension] Process chunk ${index + 1}/${targetChunks.length}`);
-    }
-    const exitCode = await runVitestBatch({
-      args: relativizeExtensionVitestArgs(passthroughArgs),
-      config: plan.config,
-      env: process.env,
-      targets: targets.map((target) => relativizeExtensionVitestPath(target)),
-    });
-    if (exitCode !== 0 && finalExitCode === 0) {
-      finalExitCode = exitCode;
-    }
-  }
+  const finalExitCode = await runExtensionBatchPlan(mergeExtensionTestPlans([plan]), {
+    expandExactExcludes: false,
+    vitestArgs: passthroughArgs,
+  });
   if (finalExitCode !== 0) {
     process.exit(finalExitCode);
   }

--- a/scripts/test-projects.mts
+++ b/scripts/test-projects.mts
@@ -8,7 +8,7 @@ import { formatMs } from "./lib/check-timing-summary.mts";
 import { runManagedCommand } from "./lib/managed-child-process.mts";
 import {
   isE2eBuildSkipped,
-  resolveVitestPretestBuildMode,
+  prepareVitestRuntime,
   runE2eGlobalSetup,
 } from "./lib/vitest-build-prerequisites.mts";
 import {
@@ -310,9 +310,6 @@ async function main() {
     return;
   }
 
-  const pretestBuildMode = resolveVitestPretestBuildMode(
-    runSpecs.map((spec) => ({ configs: [spec.config], includePatterns: spec.includePatterns })),
-  );
   const runBuildCommand = (commandArgs: string[], env: NodeJS.ProcessEnv) =>
     runManagedCommand({ bin: process.execPath, args: commandArgs, cwd: process.cwd(), env });
   const e2eSpecs = runSpecs.filter((spec) => spec.config === "test/vitest/vitest.e2e.config.ts");
@@ -326,12 +323,11 @@ async function main() {
         spec.env = { ...spec.env, OPENCLAW_E2E_USE_PREBUILT_DIST: "1" };
       }
     }
-  } else if (pretestBuildMode) {
-    console.error(`[test] preparing ${pretestBuildMode} runtime before Vitest workers`);
-    const code = await runBuildCommand(["scripts/run-node.mjs", "--version"], {
-      ...baseEnv,
-      ...(pretestBuildMode === "private-qa" ? { OPENCLAW_BUILD_PRIVATE_QA: "1" } : {}),
-    });
+  } else {
+    const code = await prepareVitestRuntime(
+      runSpecs.map((spec) => ({ configs: [spec.config], includePatterns: spec.includePatterns })),
+      baseEnv,
+    );
     if (code !== 0) {
       printTestSummary("failed", 0, performance.now() - suiteStartedAt);
       process.exitCode = code;

--- a/test/scripts/test-projects-build-admission.test.ts
+++ b/test/scripts/test-projects-build-admission.test.ts
@@ -1,5 +1,11 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createPatternFileHelper } from "../helpers/pattern-file.js";
+import { waitForChildClose, waitForDead, waitForPidFile } from "../helpers/process-wait.js";
 import { createDeferred } from "../helpers/promise.js";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const commands = vi.hoisted(() => ({ prepare: vi.fn(), prepareE2e: vi.fn(), reader: vi.fn() }));
 vi.mock("../../scripts/lib/managed-child-process.mts", () => ({
@@ -21,6 +27,10 @@ vi.mock("../../scripts/lib/vitest-shard-timings.mts", async (importOriginal) => 
 
 const modelTarget = "src/agents/embedded-agent-runner/model-resolution-consistency.test.ts";
 const targets = [modelTarget, "extensions/qa-lab/src/suite-process-lifecycle.test.ts"];
+const lifecycle = targets[1]!;
+const ordinaryQa = "extensions/qa-lab/src/gateway-child.test.ts";
+const patternFiles = createPatternFileHelper("plugin-build-selection-");
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const e2eTarget = "test/openclaw-launcher-version.e2e.test.ts";
 const e2eConfig = "test/vitest/vitest.e2e.config.ts";
 let originalArgv: string[];
@@ -42,6 +52,7 @@ beforeEach(() => {
   vi.stubEnv("OPENCLAW_BUILD_PRIVATE_QA", "");
   vi.stubEnv("OPENCLAW_E2E_SKIP_BUILD", "");
   vi.stubEnv("OPENCLAW_E2E_USE_PREBUILT_DIST", "");
+  vi.stubEnv("OPENCLAW_VITEST_INCLUDE_FILE", "");
   terminal = createDeferred<unknown>();
   vi.spyOn(console, "warn").mockImplementation(() => {});
   vi.spyOn(console, "error").mockImplementation((value: unknown) => {
@@ -52,10 +63,176 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  patternFiles.cleanup();
   process.argv = originalArgv;
   process.exitCode = originalExitCode;
   vi.unstubAllEnvs();
   vi.restoreAllMocks();
+});
+
+describe("CLI runtime admission", () => {
+  const posixIt = process.platform === "win32" ? it.skip : it;
+  posixIt.each([
+    ["ordinary target", [ordinaryQa]],
+    [
+      "Gateway scoped exclusion",
+      [
+        "--config",
+        "test/vitest/vitest.gateway-core.config.ts",
+        "--exclude",
+        "gateway-concurrent-streams.test.ts",
+      ],
+    ],
+    ["scoped exclusion", ["--exclude", lifecycle.replace("extensions/", "")]],
+    ["absolute exclusion", ["--exclude", path.resolve(lifecycle)]],
+    ["alternate root", ["--root", "."]],
+    ["alternate directory", ["--dir=extensions"]],
+    ["project override", ["--project", "extension-qa"]],
+    ["custom config", ["--config", "custom.config.ts"]],
+    ["list command", ["list"]],
+    ["help", ["--help"]],
+  ])("leaves direct $0 selection without runtime preparation", async (_name, args) => {
+    const root = tempDirs.make("plugin-build-direct-");
+    const preload = path.join(root, "preload.mjs");
+    fs.writeFileSync(
+      preload,
+      `import cp from 'node:child_process';
+import { syncBuiltinESMExports } from 'node:module';
+const spawn = cp.spawn;
+cp.spawn = (bin, args, options) => spawn(process.execPath, ['-e',
+  args.includes('scripts/run-node.mjs') ? 'process.exit(91)' : ''], options);
+syncBuiltinESMExports();\n`,
+    );
+    const configArgs = args.includes("--config")
+      ? []
+      : ["--config", "test/vitest/vitest.extension-qa.config.ts"];
+    const child = spawn(
+      process.execPath,
+      ["--import", preload, "scripts/run-vitest.mts", ...configArgs, ...args],
+      { stdio: "ignore" },
+    );
+    try {
+      await expect(waitForChildClose(child)).resolves.toEqual({ code: 0, signal: null });
+    } finally {
+      if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+    }
+  });
+  posixIt.each([
+    ["single", "scripts/test-extension.mts", []],
+    ["batch", "scripts/test-extension-batch.mts", ["qa-lab,firecrawl"]],
+    [
+      "direct",
+      "scripts/run-vitest.mts",
+      ["run", "--config", "test/vitest/vitest.extension-qa.config.ts"],
+    ],
+    [
+      "direct watch",
+      "scripts/run-vitest.mts",
+      ["watch", "--config=test/vitest/vitest.extension-qa.config.ts"],
+    ],
+    ["root config", "scripts/run-vitest.mts", ["run", "--config", "vitest.config.ts"]],
+    [
+      "Gateway core",
+      "scripts/run-vitest.mts",
+      ["run", "--config", "test/vitest/vitest.gateway-core.config.ts"],
+      "runtime",
+    ],
+    [
+      "Gateway umbrella",
+      "scripts/run-vitest.mts",
+      ["run", "--config", "test/vitest/vitest.gateway.config.ts"],
+      "runtime",
+    ],
+    [
+      "agentic aggregate",
+      "scripts/run-vitest.mts",
+      ["run", "--config", "test/vitest/vitest.full-agentic.config.ts"],
+      "runtime",
+    ],
+    [
+      "aggregate config",
+      "scripts/run-vitest.mts",
+      ["run", "--config", "test/vitest/vitest.full-extensions.config.ts"],
+    ],
+  ] as const)(
+    "blocks %s CLI readers until successful build and preserves SIGTERM",
+    async (_name, script, args, mode: "private-qa" | "runtime" = "private-qa") => {
+      for (const outcome of [0, 7, "SIGTERM"] as const) {
+        const root = tempDirs.make("plugin-build-cli-");
+        const pidFile = path.join(root, "build.pid");
+        const readersFile = path.join(root, "readers");
+        const builder = path.join(root, "build.mjs");
+        const preload = path.join(root, "preload.mjs");
+        fs.writeFileSync(
+          builder,
+          `import fs from 'node:fs';
+process.on('SIGTERM', () => process.exit(0));
+process.stdin.once('data', () => process.exit(${typeof outcome === "number" ? outcome : 0}));
+fs.writeFileSync(${JSON.stringify(pidFile)}, String(process.pid));
+process.stdin.resume();\n`,
+        );
+        // Keep the real managed process owner and CLI scheduler. Replace only
+        // heavyweight build/test executables at Node's child-process boundary.
+        fs.writeFileSync(
+          preload,
+          `import cp from 'node:child_process';
+import fs from 'node:fs';
+import { syncBuiltinESMExports } from 'node:module';
+const spawn = cp.spawn;
+cp.spawn = (bin, args, options) => {
+  if (args.includes('scripts/run-node.mjs')) return spawn(process.execPath, [${JSON.stringify(builder)}], options);
+  if (args.some((arg) => arg === 'vitest' || arg.endsWith('/vitest.mjs'))) {
+    fs.appendFileSync(${JSON.stringify(readersFile)}, 'reader\\n');
+    return spawn(process.execPath, ['-e', ''], options);
+  }
+  return spawn(bin, args, options);
+};
+syncBuiltinESMExports();\n`,
+        );
+        const child = spawn(
+          process.execPath,
+          ["--import", preload, path.resolve(script), ...args],
+          {
+            cwd: _name === "single" ? path.resolve("extensions/qa-lab") : process.cwd(),
+            env: { ...process.env, OPENCLAW_EXTENSION_BATCH_PARALLEL: "2" },
+            stdio: ["pipe", "pipe", "pipe"],
+          },
+        );
+        let output = "";
+        child.stdout.on("data", (data) => {
+          output += data;
+        });
+        child.stderr.on("data", (data) => {
+          output += data;
+        });
+        const closed = waitForChildClose(child);
+        let buildPid: number | undefined;
+        try {
+          buildPid = await waitForPidFile(pidFile, 5_000);
+          expect(fs.existsSync(readersFile)).toBe(false);
+          if (outcome === "SIGTERM") child.kill("SIGTERM");
+          else child.stdin.end("finish\n");
+          expect(await closed, output).toEqual({
+            code: outcome === "SIGTERM" ? 143 : outcome,
+            signal: null,
+          });
+          expect(fs.existsSync(readersFile), output).toBe(outcome === 0);
+          expect(output.match(new RegExp(`preparing ${mode} runtime`, "gu"))).toHaveLength(1);
+          await waitForDead(buildPid, 5_000);
+        } finally {
+          if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+          if (buildPid) {
+            try {
+              process.kill(buildPid, "SIGKILL");
+            } catch {
+              /* Already exited. */
+            }
+          }
+          await closed;
+        }
+      }
+    },
+  );
 });
 
 async function start(args: string[]) {
@@ -117,6 +294,23 @@ describe("test-projects build admission", () => {
     expect(commands.reader).toHaveBeenCalledOnce();
   });
 
+  it.each(["", "OPENCLAW_E2E_SKIP_BUILD", "OPENCLAW_E2E_USE_PREBUILT_DIST"])(
+    "prepares an ordinary runtime reader independently of E2E flag %s",
+    async (key) => {
+      if (key) vi.stubEnv(key, "1");
+      commands.prepare.mockResolvedValue(0);
+      await start(["test/e2e/qa-lab/runtime/gateway-support-export-runtime.test.ts"]);
+      await terminal.promise;
+      expect(commands.prepare).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          env: expect.objectContaining({ OPENCLAW_BUILD_PRIVATE_QA: "" }),
+        }),
+      );
+      expect(commands.prepareE2e).not.toHaveBeenCalled();
+      expect(commands.reader).toHaveBeenCalledOnce();
+    },
+  );
+
   it("coalesces mixed E2E and private QA preparation before marking only E2E prebuilt", async () => {
     vi.stubEnv("OPENCLAW_TEST_PROJECTS_PARALLEL", "2");
     const preparation = createDeferred();
@@ -161,6 +355,152 @@ describe("test-projects build admission", () => {
       for (const [options] of commands.reader.mock.calls) {
         expect(options.env[key]).toBe("1");
       }
+    },
+  );
+});
+
+describe("plugin batch build admission", () => {
+  it.each(["1", "2"])(
+    "holds all groups and chunks behind one build (parallel=%s)",
+    async (parallel) => {
+      const { resolveExtensionBatchPlan, createExtensionTestProcessTargetChunks } =
+        await import("../../scripts/lib/extension-test-plan.mts");
+      const { runExtensionBatchPlan } = await import("../../scripts/test-extension-batch.mts");
+      const batch = resolveExtensionBatchPlan({ extensionIds: ["qa-lab", "matrix", "firecrawl"] });
+      const preparation = createDeferred<number>();
+      commands.prepare.mockReturnValue(preparation.promise);
+      const reader = vi.fn().mockResolvedValue(0);
+      const running = runExtensionBatchPlan(batch, {
+        env: { OPENCLAW_EXTENSION_BATCH_PARALLEL: parallel },
+        runGroup: reader,
+      });
+      try {
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        expect(reader).not.toHaveBeenCalled();
+        expect(commands.prepare).toHaveBeenCalledExactlyOnceWith(
+          expect.objectContaining({
+            args: ["scripts/run-node.mjs", "--version"],
+            env: expect.objectContaining({ OPENCLAW_BUILD_PRIVATE_QA: "1" }),
+          }),
+        );
+      } finally {
+        preparation.resolve(0);
+        await running;
+      }
+      expect(await running).toBe(0);
+      expect(reader).toHaveBeenCalledTimes(
+        batch.planGroups.reduce(
+          (sum, group) =>
+            sum + createExtensionTestProcessTargetChunks(group.config, group.roots).length,
+          0,
+        ),
+      );
+      expect(commands.prepare).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each([7, 143, "throw"])("admits no readers after preparation outcome %s", async (outcome) => {
+    const { resolveExtensionBatchPlan } = await import("../../scripts/lib/extension-test-plan.mts");
+    const { runExtensionBatchPlan } = await import("../../scripts/test-extension-batch.mts");
+    commands.prepare.mockImplementation(async () => {
+      if (outcome === "throw") throw new Error("build spawn failed");
+      return outcome;
+    });
+    const reader = vi.fn().mockResolvedValue(0);
+    const running = runExtensionBatchPlan(
+      resolveExtensionBatchPlan({ extensionIds: ["qa-lab", "matrix"] }),
+      {
+        runGroup: reader,
+        env: { OPENCLAW_EXTENSION_BATCH_PARALLEL: "2" },
+      },
+    );
+    if (outcome === "throw") await expect(running).rejects.toThrow("build spawn failed");
+    else await expect(running).resolves.toBe(outcome);
+    expect(reader).not.toHaveBeenCalled();
+    expect(commands.prepare).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    { name: "full QA", ids: ["qa-lab"], build: true },
+    { name: "shared config, channel only", ids: ["qa-channel"], build: false },
+    { name: "unrelated plugin", ids: ["firecrawl"], build: false },
+    { name: "ordinary QA file", args: [ordinaryQa], build: false },
+    { name: "lifecycle file", args: [lifecycle], build: true },
+    { name: "absolute lifecycle", args: [path.resolve(lifecycle)], build: true },
+    { name: "exact exclusion", args: ["--exclude", lifecycle], build: false },
+    { name: "equals exclusion", args: [`--exclude=${lifecycle}`], build: false },
+    {
+      name: "scoped exclusion",
+      args: ["--exclude", lifecycle.replace("extensions/", "")],
+      build: false,
+    },
+    { name: "absolute exclusion", args: ["--exclude", path.resolve(lifecycle)], build: false },
+    {
+      name: "glob exclusion",
+      args: ["--exclude", "extensions/qa-lab/**/suite-process-*.test.ts"],
+      build: false,
+    },
+    { name: "all QA excluded", args: ["--exclude=extensions/qa-lab/**"], build: false },
+    { name: "empty include", include: [], build: false },
+    { name: "unrelated include", include: [ordinaryQa], build: false },
+    { name: "lifecycle include", include: [lifecycle], build: true },
+    { name: "absolute lifecycle include", include: [path.resolve(lifecycle)], build: true },
+    {
+      name: "scoped lifecycle include",
+      include: [lifecycle.replace("extensions/", "")],
+      build: true,
+    },
+    {
+      name: "runtime include outside config directory",
+      include: ["test/e2e/qa-lab/runtime/gateway-support-export-runtime.test.ts"],
+      args: ["test/e2e/qa-lab/runtime/gateway-support-export-runtime.test.ts"],
+      build: false,
+    },
+    {
+      name: "include outside emitted roots",
+      ids: ["qa-channel"],
+      include: [lifecycle],
+      build: false,
+    },
+    {
+      name: "cross-root CLI with include",
+      ids: ["qa-channel"],
+      args: [lifecycle],
+      include: [lifecycle],
+      build: true,
+    },
+    {
+      name: "include outside explicit target",
+      args: [ordinaryQa],
+      include: [lifecycle],
+      build: true,
+    },
+    {
+      name: "existing exact-exclude expansion",
+      args: [ordinaryQa, "--exclude", "extensions/codex/src/app-server/run-attempt.test.ts"],
+      build: true,
+    },
+    { name: "no groups", ids: [], build: false },
+  ])(
+    "prepares the actual invocation selection: $name",
+    async ({ ids = ["qa-lab"], args = [], include, build }) => {
+      const { resolveExtensionBatchPlan } =
+        await import("../../scripts/lib/extension-test-plan.mts");
+      const { runExtensionBatchPlan } = await import("../../scripts/test-extension-batch.mts");
+      const env = include
+        ? { OPENCLAW_VITEST_INCLUDE_FILE: patternFiles.writePatternFile("include.json", include) }
+        : {};
+      commands.prepare.mockResolvedValue(0);
+      const reader = vi.fn().mockResolvedValue(0);
+      await expect(
+        runExtensionBatchPlan(resolveExtensionBatchPlan({ extensionIds: ids }), {
+          runGroup: reader,
+          env,
+          vitestArgs: args,
+        }),
+      ).resolves.toBe(0);
+      expect(commands.prepare).toHaveBeenCalledTimes(build ? 1 : 0);
+      expect(reader).toHaveBeenCalledTimes(ids.length ? 1 : 0);
     },
   );
 });

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -64,7 +64,7 @@ describe("test runtime prerequisites", () => {
     ["Gateway umbrella config", ["test/vitest/vitest.gateway.config.ts"], "runtime"],
     ["agentic config", ["test/vitest/vitest.full-agentic.config.ts"], "runtime"],
     ["ordinary Gateway unit test", ["src/gateway/net.test.ts"], undefined],
-    ["ordinary QA unit test", ["extensions/qa-lab/src/gateway-child-command.test.ts"], undefined],
+    ["ordinary QA unit test", ["extensions/qa-lab/src/gateway-child.test.ts"], undefined],
     [
       "model reader",
       ["src/agents/embedded-agent-runner/model-resolution-consistency.test.ts"],
@@ -482,7 +482,7 @@ describe("scripts/test-projects changed-target routing", () => {
   it("keeps extension batch runner edits on extension script tests", () => {
     expectChangedTargets(
       ["scripts/test-extension-batch.mts"],
-      ["test/scripts/test-extension.test.ts"],
+      ["test/scripts/test-extension.test.ts", "test/scripts/test-projects-build-admission.test.ts"],
     );
   });
 

--- a/test/vitest/vitest.pattern-file.ts
+++ b/test/vitest/vitest.pattern-file.ts
@@ -2,6 +2,8 @@
 import fs from "node:fs";
 import path from "node:path";
 
+const repoRoot = path.resolve(import.meta.dirname, "../..");
+
 const VITEST_OPTION_VALUE_FLAGS = new Set([
   "-c",
   "-r",
@@ -265,13 +267,10 @@ export function loadPatternListFromEnv(
   return loadPatternListFile(filePath, envKey);
 }
 
-function loadPatternListFromArgvForScope(
-  argv: string[] = process.argv,
-  options: { scopedDir?: string } = {},
-): string[] | null {
+function collectVitestFileFilters(args: string[]): string[] {
   const values: string[] = [];
   let skipNext = false;
-  for (const value of argv.slice(2)) {
+  for (const value of args) {
     if (skipNext) {
       skipNext = false;
       continue;
@@ -288,9 +287,26 @@ function loadPatternListFromArgvForScope(
     }
     values.push(value);
   }
+  return values;
+}
 
+export function collectVitestExcludePatterns(args: string[]): string[] {
+  return args
+    .flatMap((arg, index) => {
+      if (arg === "--exclude") {
+        return args[index + 1] ? [args[index + 1]!] : [];
+      }
+      return arg.startsWith("--exclude=") ? [arg.slice("--exclude=".length)] : [];
+    })
+    .filter(Boolean);
+}
+
+function loadPatternListFromArgvForScope(
+  argv: string[] = process.argv,
+  options: { scopedDir?: string } = {},
+): string[] | null {
   const scopedDir = normalizeScopedDir(options.scopedDir);
-  const patterns = values
+  const patterns = collectVitestFileFilters(argv.slice(2))
     .map((value) => applyScopedDir(value, scopedDir))
     .filter(looksLikeCliIncludePattern)
     .map(normalizeCliPattern);
@@ -309,4 +325,61 @@ export function narrowIncludePatternsForCli(
   }
 
   return narrowIncludePatterns(includePatterns, cliPatterns);
+}
+
+export function relativizeScopedPatterns(values: string[], dir = ""): string[] {
+  const normalizedDir = dir.replaceAll("\\", "/").replace(/\/+$/u, "");
+  return values.map((value) => {
+    const normalized = value.replaceAll("\\", "/");
+    if (!normalizedDir) return normalized;
+    if (normalized === normalizedDir) return ".";
+    const prefix = `${normalizedDir}/`;
+    return normalized.startsWith(prefix) ? normalized.slice(prefix.length) : normalized;
+  });
+}
+
+/** Project one candidate through the same scoped include and CLI file filters as Vitest. */
+export function matchesVitestCliSelection(
+  file: string,
+  include: string[],
+  args: string[],
+  scopedDir: string,
+  env: NodeJS.ProcessEnv,
+): boolean {
+  const patterns =
+    loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", env) ??
+    narrowIncludePatternsForCli(include, ["node", "vitest", ...args], { scopedDir }) ??
+    include;
+  const relativeFile = path.posix.relative(scopedDir, file);
+  const absoluteFile = path.resolve(repoRoot, file);
+  if (
+    !relativizeScopedPatterns(patterns, scopedDir).some((pattern) =>
+      path.matchesGlob(path.isAbsolute(pattern) ? absoluteFile : relativeFile, pattern),
+    ) ||
+    collectVitestExcludePatterns(args).some((pattern) =>
+      path.matchesGlob(path.isAbsolute(pattern) ? absoluteFile : relativeFile, pattern),
+    )
+  ) {
+    return false;
+  }
+  const filters = collectVitestFileFilters(args).map((filter) =>
+    process.platform === "win32" ? filter.replaceAll("\\", "/") : filter,
+  );
+  const dir = path.resolve(repoRoot, scopedDir);
+  // Vitest filterFiles uses OR/substring matching, not glob matching, after discovery.
+  return (
+    filters.length === 0 ||
+    filters.some((filter) => {
+      if (path.isAbsolute(filter) && absoluteFile.startsWith(filter)) {
+        return true;
+      }
+      const relativeFilter = filter.endsWith("/")
+        ? path.join(path.relative(dir, filter), "/")
+        : path.relative(dir, filter);
+      return (
+        relativeFile.toLocaleLowerCase().includes(filter.toLocaleLowerCase()) ||
+        relativeFile.toLocaleLowerCase().includes(relativeFilter.toLocaleLowerCase())
+      );
+    })
+  );
 }

--- a/test/vitest/vitest.scoped-config.ts
+++ b/test/vitest/vitest.scoped-config.ts
@@ -5,6 +5,7 @@ import {
   intersectIncludePatterns,
   loadPatternListFromEnv,
   narrowIncludePatternsForCli,
+  relativizeScopedPatterns,
 } from "./vitest.pattern-file.ts";
 import {
   nonIsolatedRunnerPath,
@@ -16,28 +17,6 @@ import { getUnitFastTestFilesForIncludePatterns } from "./vitest.unit-fast-paths
 
 function normalizePathPattern(value: string): string {
   return value.replaceAll("\\", "/");
-}
-
-function relativizeScopedPattern(value: string, dir: string): string {
-  const normalizedValue = normalizePathPattern(value);
-  const normalizedDir = normalizePathPattern(dir).replace(/\/+$/u, "");
-  if (!normalizedDir) {
-    return normalizedValue;
-  }
-  if (normalizedValue === normalizedDir) {
-    return ".";
-  }
-  const prefix = `${normalizedDir}/`;
-  return normalizedValue.startsWith(prefix)
-    ? normalizedValue.slice(prefix.length)
-    : normalizedValue;
-}
-
-function relativizeScopedPatterns(values: string[], dir?: string): string[] {
-  if (!dir) {
-    return values.map(normalizePathPattern);
-  }
-  return values.map((value) => relativizeScopedPattern(value, dir));
 }
 
 function globRoot(pattern: string): string | null {


### PR DESCRIPTION
Related: #131297 (the earlier shared-build ownership repair)

<details>
<summary>Additional instructions</summary>

Maintainer-editable branch in this repository. This is a maintainer-requested full-release-verification repair.

</details>

## What Problem This Solves

Resolves a problem where plugin tests in a clean, dependency-installed checkout fail before the QA Gateway can start because the required built runtime is absent. This blocked the [Plugin Prerelease shard in full release verification](https://github.com/openclaw/openclaw/actions/runs/33155287393/job/98796713827).

## Why This Change Was Made

The earlier build-ownership repair correctly removed builds from test children, but the plugin-batch entry point bypassed pre-worker preparation. The existing prerequisite owner now prepares the selected runtime once before any batch reader; single-plugin and known direct-config invocations share that flow, while E2E skip/prebuilt contracts, selection, chunking, and parallelism remain intact.

The refactor removes the duplicate single-plugin scheduling loop and shares exclusion/scoped-pattern handling instead of introducing a second runtime inventory or builder. Product runtime: **+0/-0**. Executable tooling, including selection helpers: **+250/-150 (net +100)**. Tests: **+342/-2 (net +340)**. The remaining tooling growth implements the missing admission boundary and accurate selected-file handling; no dependency, configuration, environment, schema, baseline, inventory, timeout, or retry setting changes.

## User Impact

Developers and release CI can use the existing plugin test commands from unbuilt source checkouts without a missing-runtime failure or a child build replacing artifacts while other workers are reading them. This changes maintainer tooling only, not OpenClaw's product behavior.

## Evidence

- Before the production edit, both new serial/parallel admission regressions failed: six readers started while runtime preparation was still held pending (`2 failed / 9 passed`). After the repair, the final required focused command passed **525 tests across four files**, including **55 admission cases**. Separate wrapper/config/CI-descriptor coverage passed; overlapping test counts are not added together.
- Fifteen actual Vitest discovery cases agreed with prerequisite selection, covering include files, exclusions, scoped/absolute paths, unrelated plugin selections, and canonical direct configurations. This is discovery evidence, not a substitute for test execution.
- Final **cold Linux original-order proof** passed on Node 24.19.0: **19 plugins, seven groups, 434 planned targets, 422 discovered test files, 5,162 passing tests**. The disposable checkout started without `dist/index.js`; one private-QA preparation finished before the original QA/catch-all reader order. The lifecycle scenario passed in **22.147 seconds**, including terminal summary, process exit, and closed Gateway listeners. Complete remote command: **255.573 seconds, exit 0**. [Testbox provisioning run](https://github.com/openclaw/openclaw/actions/runs/33169057632), lease `tbx_01m143mnzg2mpstxjs1vyx3s07`; the lease is stopped. Command results, not the provisioning workflow's cleanup status, are the proof.
- The final classified Linux changed-file gate passed: script/root-test typechecks and scripts lint, with zero warnings/errors. Local formatting, erasability and focused lint passed. Local full types remain blocked by the unchanged missing `pako` declaration in `ui/vite.config.ts`; no declaration shim or dependency mutation was used to conceal it.
- Proof source: base `8d0424cd7903772c009bdd71eb6d03755349b891` plus complete overlay SHA-256 `c33cbf90cb9ad7bb5bbd6a05160eb147ae665c9f3cb1a7fcda17cb815ba1862d`. Every changed-file hash was verified before and after the final cold run. Fresh isolated Codex autoreview of that exact uncommitted overlay reported no actionable P0 findings (confidence 0.95); its empty workspace, credential scan and managed reviewer sandbox remained enabled. The reviewer did not run tests. The original cold proof is not a PR-head run.
- Published source: head `f6c5c7172e35fa8e4c9a06ff8becf63f942b18d6` on base `b6aff3ef0e16a47f10b82bf6223598326d632705`, complete diff SHA-256 `031f4249d64a535870d3d83aa2db308f0899f29690d3cbaa2cad7b1527c17431`. The explicit rebase preserves main's newly added concurrent Gateway streams consumer and its multi-config inventory. Seven file hashes match the original proof; the three integration files retain upstream coverage and add direct Gateway core/umbrella/aggregate admission plus scoped-exclusion checks. Rebased focused proof passed **825 tests across eight files** (59 admission + 766 siblings); the final admission rerun passed all 59 after a test-only type annotation. Fresh isolated Codex autoreview of this integrated diff found no actionable P0 defects (confidence 0.97); reviewer tests were not run. Owner lint and formatting passed. Local script/root-test typechecks remain blocked only by the unchanged missing `pako` declaration. [Exact-head CI run 33174196069, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33174196069/attempts/2) is green (165 successful jobs, 18 skipped). One narrow recovery of the package-boundary job passed all 123 plugin compiles and the canary with unchanged source and gate settings: preparation 209,099ms, compile 66,537ms, canary 802ms. Both attempts executed synthetic merge c0c5bdad9d75ce4c3b5933d6d3b5a18207183b58 over base cb696a1bb3b66a8d51392a8ab743e270e4f249cf; the introduced patch/hash is identical to the branch diff. The original 421,132ms preparation timeout remains unexplained: recovery used a different fallback cache, and the original cache is unavailable. No timeout increase or speculative source fix was made.
- The latest ClawSweeper directory-selector finding was checked and rejected: the actual matcher calls permissive CLI narrowing, not the throwing include-file intersection helper. The exact canonical Gateway-config plus src/gateway CLI was exercised through its real admission/process code with controlled child executables: success admits after the barrier; exit 7/SIGTERM admit no readers and propagate 7/143. No intersection error. The requested directory behavior and current-head CI are proven; no accepted actionable findings remain.
- Additional unchanged-owner coverage passed 66 tests. Branch-head cold Linux declaration proof passed all 123 compiles and canary, but is not CI-merge parity because its declaration writer predates the merged upstream repair. Exact-merge Linux proof is the successful CI job above. A local exact-merge emission test also exposed the existing missing macOS yuku-codegen native binding; dependencies were not changed. The original local pako gap remains.

Focused command:

```bash
node scripts/run-vitest.mjs test/scripts/test-projects-build-admission.test.ts test/scripts/test-extension.test.ts test/scripts/test-projects.test.ts test/scripts/vitest-e2e-global-setup.test.ts
```

Cold original-order command (after verifying the isolated checkout has no built runtime):

```bash
env -u OPENCLAW_VITEST_INCLUDE_FILE -u OPENCLAW_E2E_SKIP_BUILD -u OPENCLAW_E2E_USE_PREBUILT_DIST -u OPENCLAW_FORCE_BUILD -u OPENCLAW_BUILD_PRIVATE_QA CI=true NODE_OPTIONS=--max-old-space-size=8192 OPENCLAW_EXTENSION_BATCH_PARALLEL=2 OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test:extensions:batch arcee,clawrouter,clickclack,deepseek,diagnostics-prometheus,document-extract,gradium,llama-cpp,mistral,nextcloud-talk,openrouter,qa-channel,qa-lab,searxng,stepfun,venice,voice-call,volcengine,zalouser -- --retry=1 --exclude extensions/codex/src/app-server/run-attempt.test.ts
```

Scope limits: existing exact-exclude positional broadening is preserved, not silently changed. Arbitrary custom configs/root/dir/project overrides retain their own setup contract; this patch does not claim universal discovery support. One batch barrier does not serialize independently launched top-level commands in the same checkout. No authenticated provider or user-visible UI change is involved. This focused repair does not make the original full release-validation parent green by itself.

AI-assisted: yes.
