### PR TITLE
fix(release): preserve publish evidence identity

### DIFF
--- a/.github/workflows/plugin-clawhub-new.yml
+++ b/.github/workflows/plugin-clawhub-new.yml
@@ -367,6 +367,7 @@ jobs:
             gh api \
               "repos/${GITHUB_REPOSITORY}/actions/runs/${RELEASE_PUBLISH_RUN_ID}/attempts/${EXPECTED_RUN_ATTEMPT}" |
               jq '{
+                repository: .repository.full_name,
                 workflowName: .name,
                 headBranch: .head_branch,
                 headSha: .head_sha,

--- a/.github/workflows/plugin-clawhub-release.yml
+++ b/.github/workflows/plugin-clawhub-release.yml
@@ -302,7 +302,21 @@ jobs:
             direct_recovery=true
             echo "Direct Plugin ClawHub Release recovery with release_publish_run_id; relying on this workflow's clawhub-plugin-release environment approval."
           fi
-          RUN_JSON="$(gh run view "$RELEASE_PUBLISH_RUN_ID" --repo "$GITHUB_REPOSITORY" --json workflowName,headBranch,event,status,conclusion,url)"
+          RUN_JSON="$(
+            gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RELEASE_PUBLISH_RUN_ID}" |
+              jq '{
+                repository: .repository.full_name,
+                workflowName: .name,
+                headBranch: .head_branch,
+                headSha: .head_sha,
+                event,
+                status,
+                conclusion,
+                path,
+                url: .html_url,
+                runAttempt: .run_attempt
+              }'
+          )"
           printf '%s' "$RUN_JSON" | DIRECT_RELEASE_RECOVERY="${direct_recovery}" node scripts/validate-release-publish-approval.mjs
 
   pack_plugins_clawhub_artifacts:

--- a/.github/workflows/plugin-npm-release.yml
+++ b/.github/workflows/plugin-npm-release.yml
@@ -700,7 +700,7 @@ jobs:
           artifacts_json="${RUNNER_TEMP}/${EXTENSION_ID}-artifacts.json"
           gh api --paginate \
             "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/artifacts?per_page=100" |
-            jq -s '{artifacts: [.[].artifacts[]]}' > "${artifacts_json}"
+            jq -s '{artifacts: [.[].artifacts[]] | unique_by(.id)}' > "${artifacts_json}"
           artifact_count="$(
             jq --arg name "${ARTIFACT_NAME}" \
               '[.artifacts[] | select(.name == $name and .expired == false)] | length' \

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -7349,7 +7349,12 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
       PLUGIN_CLAWHUB_RELEASE_WORKFLOW,
       "approve_plugins_clawhub_release",
     );
+    const clawHubAuthorization = workflowStep(
+      workflowJob(PLUGIN_CLAWHUB_RELEASE_WORKFLOW, "validate_release_publish_approval"),
+      "Validate release publish approval run",
+    );
     const clawHubPublish = workflowJob(PLUGIN_CLAWHUB_RELEASE_WORKFLOW, "publish_plugins_clawhub");
+    expect(clawHubAuthorization.run).toContain("repository: .repository.full_name");
     expect(clawHubApproval.environment).toBe("clawhub-plugin-release");
     expect(clawHubPublish.needs).toContain("approve_plugins_clawhub_release");
 
@@ -7381,6 +7386,7 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
     expectTextToIncludeAll(authorization.run, [
       '${GITHUB_ACTOR}" != "github-actions[bot]"',
       "actions/runs/${RELEASE_PUBLISH_RUN_ID}/attempts/${EXPECTED_RUN_ATTEMPT}",
+      "repository: .repository.full_name",
       '--source-ref "${EXPECTED_WORKFLOW_REF}"',
       '--source-digest "${EXPECTED_WORKFLOW_SHA}"',
       "validate-release-publish-approval.mjs",

--- a/test/scripts/plugin-clawhub-new-workflow.test.ts
+++ b/test/scripts/plugin-clawhub-new-workflow.test.ts
@@ -144,6 +144,7 @@ describe("Plugin ClawHub New workflow", () => {
     expect(validation.run).toContain(
       "actions/runs/${RELEASE_PUBLISH_RUN_ID}/attempts/${EXPECTED_RUN_ATTEMPT}",
     );
+    expect(validation.run).toContain("repository: .repository.full_name");
     expect(validation.run).toContain(
       'EXPECTED_WORKFLOW_REF="refs/tags/${EXPECTED_WORKFLOW_BRANCH}"',
     );

--- a/test/scripts/plugin-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/plugin-npm-extended-stable-workflow.test.ts
@@ -310,6 +310,8 @@ describe("plugin npm extended-stable workflow", () => {
     );
     const readback = step(verify, "Validate npm preflight artifact readback");
     expect(readback.run).toContain('git show "${SOURCE_SHA}:${PACKAGE_DIR}/package.json"');
+    expect(readback.run).toContain("unique_by(.id)");
+    expect(readback.run).not.toContain("unique_by(.name)");
     expect(readback.run).toContain("Expected exactly one live package artifact named");
     expect(readback.run).toContain('crypto.createHash("sha256")');
     expect(readback.run).toContain('crypto.createHash("sha512")');


### PR DESCRIPTION
## Summary

- preserve the authoritative parent repository in both ClawHub publish approval payloads
- deduplicate paginated plugin npm artifacts by immutable artifact ID before strict name counting
- keep distinct same-name artifacts fail-closed

## Release blocker

Publish parent https://github.com/openclaw/openclaw/actions/runs/33173284814 passed target, npm-preflight, and Full Release Validation checks, then failed before publishing:

- Plugin NPM child `33173609596`, job `98857791757`: one Qwen package artifact was returned twice across offset-paginated artifact pages, producing a false duplicate
- Plugin ClawHub Release child `33173612115`, job `98857226975`: parent evidence omitted `repository`
- Plugin ClawHub New child `33173614776`, job `98857342303`: parent evidence omitted `repository`

No package was published. `openclaw@2026.9.1-beta.1` remained absent from npm after the failed parent.

## Root cause and owner

The release workflows own immutable publish evidence normalization. One workflow queried a reduced `gh run view` projection that did not contain repository identity, another omitted that field from its API projection, and plugin npm artifact pagination concatenated pages without deduplicating immutable artifact IDs.

## Verification

- pre-fix focused proof: 3 expected failures, 221 passes
- post-fix focused proof: 224/224 passes
- `actionlint` on all three changed workflows
- `node scripts/check-changed.mjs -- <six changed files>`
- `git diff --check`
- autoreview: clean, no actionable findings

## Scope

Six release workflow/test files only. No candidate, package, runtime, changelog, or release-branch changes.
