### PR TITLE
fix(agents): keep dangling symlinks visible in ls listings

### DIFF
--- a/src/agents/sessions/tools/ls.test.ts
+++ b/src/agents/sessions/tools/ls.test.ts
@@ -42,7 +42,7 @@ describe("ls tool", () => {
     const cwd = tempDirs.make("openclaw-ls-links-");
     const tool = createLsTool(cwd);
     const symlinkType = process.platform === "win32" ? "junction" : "dir";
-    const list = (limit?: number) => tool.execute("ls-links", { ...(limit ? { limit } : {}) });
+    const list = (limit?: number) => tool.execute("ls-links", limit ? { limit } : {});
 
     expect((await list()).content).toEqual([{ type: "text", text: "(empty directory)" }]);
     await fs.symlink(path.join(cwd, "missing-target"), path.join(cwd, "a-broken"), symlinkType);

--- a/src/agents/sessions/tools/ls.test.ts
+++ b/src/agents/sessions/tools/ls.test.ts
@@ -1,7 +1,12 @@
 // ls tool tests cover deterministic directory listings and safe limit
 // normalization for agent-visible file enumeration.
-import { describe, expect, it, vi } from "vitest";
-import { createLsToolDefinition, type LsOperations } from "./ls.js";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
+import { createLsTool, createLsToolDefinition, type LsOperations } from "./ls.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function operations(entries: string[]): LsOperations {
   return {
@@ -33,6 +38,33 @@ function trackAbortListener(signal: AbortSignal) {
 }
 
 describe("ls tool", () => {
+  it("retains dangling links without losing directory suffixes or entry limits", async () => {
+    const cwd = tempDirs.make("openclaw-ls-links-");
+    const tool = createLsTool(cwd);
+    const symlinkType = process.platform === "win32" ? "junction" : "dir";
+    const list = (limit?: number) => tool.execute("ls-links", { ...(limit ? { limit } : {}) });
+
+    expect((await list()).content).toEqual([{ type: "text", text: "(empty directory)" }]);
+    await fs.symlink(path.join(cwd, "missing-target"), path.join(cwd, "a-broken"), symlinkType);
+
+    const dangling = await list();
+    expect(dangling.content).toEqual([{ type: "text", text: "a-broken" }]);
+    expect(dangling.details).toBeUndefined();
+
+    await fs.mkdir(path.join(cwd, "target-dir"));
+    await fs.symlink(path.join(cwd, "target-dir"), path.join(cwd, "link-to-dir"), symlinkType);
+    await fs.writeFile(path.join(cwd, "z-file.txt"), "fixture\n");
+    expect((await list()).content).toEqual([
+      { type: "text", text: "a-broken\nlink-to-dir/\ntarget-dir/\nz-file.txt" },
+    ]);
+
+    const limited = await list(1);
+    expect(limited.content).toEqual([
+      { type: "text", text: "a-broken\n\n[1 entries limit reached. Use limit=2 for more]" },
+    ]);
+    expect(limited.details).toEqual({ entryLimitReached: 1 });
+  });
+
   it("clamps non-positive limits instead of reporting a non-empty directory as empty", async () => {
     // Clamp to one entry so bad numeric input cannot hide directory contents.
     const tool = createLsToolDefinition("/workspace", {

--- a/src/agents/sessions/tools/ls.ts
+++ b/src/agents/sessions/tools/ls.ts
@@ -160,8 +160,7 @@ export function createLsToolDefinition(
                 suffix = "/";
               }
             } catch {
-              // Skip entries we cannot stat.
-              continue;
+              // Directory metadata is optional; keep names even when a symlink target is missing.
             }
             results.push(entry + suffix);
           }


### PR DESCRIPTION
Related: #131776. Closure will follow verified main-branch landing.

## What Problem This Solves

Fixes an issue where developers explicitly selecting the session `ls` tool, including through the read-only tool factory, received an empty-directory result when the directory contained only a dangling symlink. Mixed listings could also omit the link and report the wrong entry-limit outcome.

## Why This Change Was Made

Directory enumeration already supplies the entry name. A later `stat` failure was discarding that known name, even though the metadata is only needed to append `/` for directories. Keep the name when metadata is unavailable; continue following healthy directory symlinks so their existing suffix stays intact.

The repair removes the discard path at the listing owner: production +1/-2 (net −1); regression tests +34/-2. It adds no API, configuration, dependency, fallback, or authorization change. Root-directory errors, cancellation, alphabetical order and output bounds retain their existing owners.

## User Impact

Explicitly selected session/read-only `ls` listings now show dangling links and count them toward the requested entry limit. This does not add `ls` to the default coding tool set or change CLI/worker tool availability.

Release-note context: retain directory-entry names when optional metadata lookup fails, while preserving healthy directory-link suffixes and bounded listing notices.

## Evidence

- Real filesystem, actual `createLsTool.execute`, default operations, isolated temporary state: baseline `b6aff3ef0e16a47f10b82bf6223598326d632705` produced exactly two failures (dangling-only and mixed/limit-one), while five controls passed. The same seven assertions all pass with this fix, including empty directories, ordinary files, healthy directory links, pre-aborted calls and unreadable-root errors.
- The new checked-in regression was run against the unchanged production owner: it failed with `(empty directory)` instead of `a-broken`; all seven existing `ls` tests passed. Restoring the fix makes it pass.
- `node scripts/run-vitest.mjs src/agents/sessions/tools/ls.test.ts src/agents/sessions/tools/index.test.ts src/agents/sessions/tools/find.test.ts src/agents/sessions/tools/limits.test.ts src/agents/sessions/tools/truncate.test.ts src/agents/sessions/tools/render-utils.test.ts --reporter=verbose`: six files, 48 passed, one existing Windows-only test skipped, 8.01 seconds. Executed on macOS / Node 26.7.0; no Windows runtime claim.
- The same discard behavior exists in stable-tag source `v2026.7.1-2`. Node's `stat` contract follows symbolic links; switching to `lstat` would lose the healthy-directory-link behavior covered by the test.

Independent source and real-filesystem differential review accepted the bounded repair. The final structured Codex review of the complete two-file candidate, including the mechanical lint correction, reported no actionable P0–P2 findings. Formatting and changed-check classification passed on the original repair; a fresh two-file formatting check also passed before the final commit. [ClawSweeper's latest review](https://github.com/openclaw/openclaw/pull/131783#issuecomment-5453378765) covers final head `8ad9dcf735add06c0c9b8feff43eff1b8e68616b`, reports no source findings, and asks for completed CI and maintainer handling. The exact-head CI condition is now satisfied.

Initial CI identified a redundant object spread in the new test helper. The mechanical correction preserves the same parameters and assertions; the proper core type-aware lint check now passes with zero warnings/errors, and all eight `ls` tests pass again. The same initial CI run also reported three failures in the unchanged shared Gateway test-instance helper. The canonical helper repair has now [landed separately in PR #131890](https://github.com/openclaw/openclaw/pull/131890) at `1593e2908727d64b93d049dbbc3a0323839d186a`, with its exact-head CI green, including all 26 helper cases and type checking. No helper changes are bundled here, and those failures were not treated as flaky or bypassed.

Final [CI run 33197871678](https://github.com/openclaw/openclaw/actions/runs/33197871678) completed successfully for head `8ad9dcf735add06c0c9b8feff43eff1b8e68616b`; the required `openclaw/ci-gate` is green. It executed merge `ca144b059d10b385923d1d365ac2942ee9390e95` (base `e11c566824b100dc7a3a7989b8a0913c2c68a3bb` plus this head). Exact Git blobs confirm both reviewed `ls` files and the separately landed helper repair are present in that executed tree.

On Linux / Node 24.19.0, [the agent-support shard](https://github.com/openclaw/openclaw/actions/runs/33197871678/job/98939932094) passed all eight `ls` cases, including the real dangling-link/directory-suffix/entry-limit regression, plus the factory, find and rendering siblings. Its support cohort passed 108 files / 1,953 tests, with three existing skips. [The shared-helper shard](https://github.com/openclaw/openclaw/actions/runs/33197871678/job/98939932475) passed all 26 helper cases, including the earlier failing deadline and cleanup paths; its complete cohort passed 68 files / 1,072 tests. Both shard processes exited successfully. These are results from this PR's final run, not a rerun of the old failing head or a substitution of the helper PR's CI.
