### PR TITLE
fix(systemd): remove service backups during uninstall

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2809,8 +2809,7 @@ src/daemon/schtasks-process.ts	2
 src/daemon/schtasks-runtime.ts	4
 src/daemon/service.ts	1
 src/daemon/systemd-exec.ts	2
-src/daemon/systemd-install.ts	5
-src/daemon/systemd-lifecycle.ts	2
+src/daemon/systemd-install.ts	3
 src/daemon/systemd-runtime.ts	1
 src/entry.compile-cache.ts	3
 src/entry.respawn.ts	1

--- a/docs/install/uninstall.md
+++ b/docs/install/uninstall.md
@@ -120,7 +120,7 @@ Default unit name is `openclaw-gateway.service` (or `openclaw-gateway-<profile>.
 
 ```bash
 systemctl --user disable --now openclaw-gateway.service
-rm -f ~/.config/systemd/user/openclaw-gateway.service
+rm -f ~/.config/systemd/user/openclaw-gateway.service ~/.config/systemd/user/openclaw-gateway.service.bak
 systemctl --user daemon-reload
 ```
 

--- a/src/daemon/systemd-install.ts
+++ b/src/daemon/systemd-install.ts
@@ -7,6 +7,7 @@ import {
   isUnresolvedShellReference,
   readStateDirDotEnvFromStateDir,
 } from "../config/state-dir-dotenv.js";
+import { hasErrnoCode } from "../infra/errors.js";
 import { resolveGatewayServiceDescription } from "./constants.js";
 import { formatLine, writeFormattedLines } from "./output.js";
 import {
@@ -121,7 +122,7 @@ function sanitizeSystemdUnitBackupContent(params: {
   // Backups should not retain file-managed secrets that OpenClaw moved into the
   // generated EnvironmentFile during this rewrite.
   const sanitizedLines: string[] = [];
-  for (const rawLine of params.content.split("\n")) {
+  for (const rawLine of params.content.replace(/\\\r?\n\s*/gu, " ").split("\n")) {
     const line = rawLine.trim();
     if (!line.startsWith("Environment=")) {
       sanitizedLines.push(rawLine);
@@ -153,6 +154,11 @@ function sanitizeSystemdUnitBackupContent(params: {
   return sanitizedLines.join("\n");
 }
 
+const SYSTEMD_MANAGED_CREDENTIAL_KEYS = normalizeServiceEnvKeys([
+  "OPENCLAW_GATEWAY_TOKEN",
+  "OPENCLAW_GATEWAY_PASSWORD",
+]);
+
 async function writeSystemdUnit({
   env,
   programArguments,
@@ -169,7 +175,7 @@ async function writeSystemdUnit({
     resolveManagedGatewayServiceCommand(await readSystemdServiceExecStart(env))?.environment,
   );
   await fs.mkdir(path.dirname(unitPath), { recursive: true });
-  await assertSystemdManagedPathIsNotSymlink(unitPath);
+  await assertSystemdManagedPathIsRegularOrMissing(unitPath);
   const fileManagedKeys = collectSystemdFileManagedKeys({
     environmentValueSources,
   });
@@ -179,17 +185,22 @@ async function writeSystemdUnit({
   try {
     const backupPath = `${unitPath}.bak`;
     const existingUnit = await fs.readFile(unitPath, "utf8");
-    const existingStat = await fs.stat(unitPath);
-    const backupMode = existingStat.mode & 0o777 || 0o600;
+    await assertSystemdManagedPathIsRegularOrMissing(backupPath);
     const backupUnit = sanitizeSystemdUnitBackupContent({
       content: existingUnit,
-      fileManagedKeys,
+      fileManagedKeys: normalizeServiceEnvKeys([
+        ...fileManagedKeys,
+        ...priorManagedKeys,
+        ...readManagedServiceEnvKeysFromEnvironment(environment),
+        ...SYSTEMD_MANAGED_CREDENTIAL_KEYS,
+      ]),
     });
-    await fs.writeFile(backupPath, backupUnit, { encoding: "utf8", mode: backupMode });
-    await fs.chmod(backupPath, backupMode);
+    await publishSystemdPrivateFile(backupPath, backupUnit);
     backedUp = true;
-  } catch {
-    // File does not exist yet — nothing to back up.
+  } catch (error) {
+    if (!hasErrnoCode(error, "ENOENT")) {
+      throw error;
+    }
   }
 
   const serviceDescription = resolveGatewayServiceDescription({ env, description });
@@ -281,18 +292,58 @@ async function writeSystemdUnit({
 
 type SystemdFileSnapshot = { contents: Buffer; mode: number } | null;
 
-async function assertSystemdManagedPathIsNotSymlink(filePath: string): Promise<void> {
+async function assertSystemdManagedPathIsRegularOrMissing(filePath: string): Promise<boolean> {
   try {
     const stat = await fs.lstat(filePath);
     if (stat.isSymbolicLink()) {
       throw new Error(`Refusing to rewrite symlinked managed systemd file: ${filePath}`);
     }
+    if (
+      stat.isDirectory() ||
+      stat.isBlockDevice() ||
+      stat.isCharacterDevice() ||
+      stat.isFIFO() ||
+      stat.isSocket()
+    ) {
+      throw new Error(`Refusing to rewrite non-regular managed systemd file: ${filePath}`);
+    }
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return;
+    if (hasErrnoCode(error, "ENOENT")) {
+      return false;
     }
     throw error;
   }
+  return true;
+}
+
+async function publishSystemdPrivateFile(filePath: string, contents: string): Promise<void> {
+  const temporaryPath = `${filePath}.openclaw-${randomUUID()}.tmp`;
+  try {
+    await fs.writeFile(temporaryPath, contents, { encoding: "utf8", flag: "wx", mode: 0o600 });
+    await fs.chmod(temporaryPath, 0o600);
+    await fs.rename(temporaryPath, filePath);
+  } finally {
+    await fs.unlink(temporaryPath).catch(() => undefined);
+  }
+}
+
+export async function removeSystemdUnitArtifacts(unitPath: string): Promise<boolean> {
+  // The generated unit and its recovery copy share one lifecycle. Validate both
+  // before unlinking either so an unexpected artifact cannot cause partial cleanup.
+  const backupPath = `${unitPath}.bak`;
+  const unitExists = await assertSystemdManagedPathIsRegularOrMissing(unitPath);
+  if (await assertSystemdManagedPathIsRegularOrMissing(backupPath)) {
+    await fs.unlink(backupPath);
+  }
+  if (unitExists) {
+    await fs.unlink(unitPath);
+  }
+  return unitExists;
+}
+
+export async function assertSystemdUnitArtifactsRemovable(unitPath: string): Promise<void> {
+  await assertSystemdManagedPathIsRegularOrMissing(unitPath);
+  await assertSystemdManagedPathIsRegularOrMissing(`${unitPath}.bak`);
 }
 
 async function readSystemdFileSnapshot(filePath: string): Promise<SystemdFileSnapshot> {
@@ -481,11 +532,10 @@ async function removeNodeSystemdManagedEnvironmentKeys(env: GatewayServiceEnv): 
   } catch {
     return;
   }
-  const managedKeys = new Set(["OPENCLAW_GATEWAY_TOKEN", "OPENCLAW_GATEWAY_PASSWORD"]);
   const remaining = Object.fromEntries(
     Object.entries(existingFile.environment).filter(([key, value]) => {
       const normalized = normalizeServiceEnvKey(key);
-      if (normalized && managedKeys.has(normalized)) {
+      if (normalized && SYSTEMD_MANAGED_CREDENTIAL_KEYS.has(normalized)) {
         return false;
       }
       return existingFile.literalShellReferenceKeys.has(key) || !isUnresolvedShellReference(value);
@@ -616,19 +666,10 @@ export async function uninstallSystemdService({
   await assertSystemdAvailable(env);
   const serviceName = resolveSystemdServiceName(env);
   const unitName = `${serviceName}.service`;
-  await disableSystemdUserUnitForRemoval(env, unitName);
-
   const unitPath = resolveSystemdUnitPath(env);
-  let removed = false;
-  try {
-    await fs.unlink(unitPath);
-    removed = true;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-      throw error;
-    }
-    // Unit file was already absent; still clean generated node env state below.
-  }
+  await assertSystemdUnitArtifactsRemovable(unitPath);
+  await disableSystemdUserUnitForRemoval(env, unitName);
+  const removed = await removeSystemdUnitArtifacts(unitPath);
   await removeNodeSystemdManagedEnvironmentKeys(env);
   if (removed) {
     stdout.write(`${formatLine("Removed systemd service", unitPath)}\n`);

--- a/src/daemon/systemd-lifecycle.ts
+++ b/src/daemon/systemd-lifecycle.ts
@@ -18,6 +18,10 @@ import {
   reloadSystemdUserManager,
 } from "./systemd-exec.js";
 import {
+  assertSystemdUnitArtifactsRemovable,
+  removeSystemdUnitArtifacts,
+} from "./systemd-install.js";
+import {
   assertNoSystemGatewayOwnership,
   findInstalledSystemdGatewayScope,
 } from "./systemd-scope.js";
@@ -141,6 +145,12 @@ async function findLegacySystemdUnits(env: GatewayServiceEnv): Promise<LegacySys
     } catch {
       // ignore
     }
+    try {
+      await fs.lstat(`${unitPath}.bak`);
+      exists = true;
+    } catch {
+      // ignore
+    }
     let enabled = false;
     if (systemctlAvailable) {
       const res = await execSystemctlUser(env, ["is-enabled", `${name}.service`]);
@@ -165,20 +175,18 @@ export async function uninstallLegacySystemdUnits({
   const systemctlAvailable = await isSystemctlAvailable(env);
   let removedAny = false;
   for (const unit of units) {
+    await assertSystemdUnitArtifactsRemovable(unit.unitPath);
     if (systemctlAvailable) {
       await disableSystemdUserUnitForRemoval(env, `${unit.name}.service`);
     } else {
       stdout.write(`systemctl unavailable; removed legacy unit file only: ${unit.name}.service\n`);
     }
 
-    try {
-      await fs.unlink(unit.unitPath);
-      removedAny = true;
+    const removed = await removeSystemdUnitArtifacts(unit.unitPath);
+    removedAny ||= removed;
+    if (removed) {
       stdout.write(`${formatLine("Removed legacy systemd service", unit.unitPath)}\n`);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-        throw error;
-      }
+    } else {
       stdout.write(`Legacy systemd unit not found at ${unit.unitPath}\n`);
     }
   }
@@ -213,6 +221,7 @@ export async function uninstallUserSystemdGatewayUnit({
 }: GatewayServiceManageArgs): Promise<UninstallUserSystemdGatewayUnitResult> {
   const unitName = `${resolveSystemdServiceName(env)}.service`;
   const unitPath = resolveSystemdUnitPath(env);
+  await assertSystemdUnitArtifactsRemovable(unitPath);
   let disabled = false;
   if (await isSystemctlAvailable(env)) {
     await disableSystemdUserUnitForRemoval(env, unitName);
@@ -222,15 +231,10 @@ export async function uninstallUserSystemdGatewayUnit({
       `systemctl unavailable; removing unit file only: ${unitName}. A loaded unit keeps running until systemd reloads.\n`,
     );
   }
-  let removed = false;
-  try {
-    await fs.unlink(unitPath);
-    removed = true;
+  const removed = await removeSystemdUnitArtifacts(unitPath);
+  if (removed) {
     stdout.write(`${formatLine("Removed user-scope systemd service", unitPath)}\n`);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-      throw error;
-    }
+  } else {
     stdout.write(`User-scope systemd unit not found at ${unitPath}\n`);
   }
   // The manager keeps a deleted unit's definition loaded until it reloads, so

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -2191,6 +2191,25 @@ describe("stageSystemdService", () => {
     });
   });
 
+  it("refuses to replace a symlinked unit backup", async () => {
+    await withStageFixture(async ({ env, unitPath }) => {
+      const backupTarget = path.join(path.dirname(unitPath), "operator-backup.service");
+      const operatorBackup = "[Unit]\nDescription=Operator backup\n";
+      await fs.mkdir(path.dirname(unitPath), { recursive: true });
+      await fs.writeFile(unitPath, "[Unit]\nDescription=Existing gateway\n", "utf8");
+      await fs.writeFile(backupTarget, operatorBackup, "utf8");
+      await fs.symlink(backupTarget, `${unitPath}.bak`);
+      mockSystemctlStatusOk();
+
+      await expect(stageSystemdService(gatewaySystemdServiceFixture(env))).rejects.toThrow(
+        `Refusing to rewrite symlinked managed systemd file: ${unitPath}.bak`,
+      );
+
+      await expect(fs.readlink(`${unitPath}.bak`)).resolves.toBe(backupTarget);
+      await expect(fs.readFile(backupTarget, "utf8")).resolves.toBe(operatorBackup);
+    });
+  });
+
   it("refuses to rewrite a symlinked managed environment file", async () => {
     await withStageFixture(async ({ env, envFilePath }) => {
       const targetPath = path.join(path.dirname(envFilePath), "operator-gateway.env");
@@ -2670,6 +2689,48 @@ describe("stageSystemdService", () => {
       expect(backupUnit).toContain("Environment=FROM_SINGLE=kept");
       expect(backupUnit).toContain("Environment=OPENCLAW_GATEWAY_PORT=18789");
       expect(backupStat.mode & 0o777).toBe(0o600);
+    });
+  });
+
+  it("keeps legacy gateway credentials out of private backups without a new credential plan", async () => {
+    await withStageFixture(async ({ env, unitPath }) => {
+      await fs.mkdir(path.dirname(unitPath), { recursive: true });
+      await fs.writeFile(
+        unitPath,
+        [
+          "[Service]",
+          "ExecStart=/usr/bin/proxychains4 /usr/bin/openclaw gateway run",
+          "Environment=OPENCLAW_GATEWAY_TOKEN=legacy-token \\",
+          "  OPENROUTER_API_KEY=operator-key",
+          "Environment=OPENCLAW_GATEWAY_PASSWORD=legacy-password",
+        ].join("\n"),
+        { encoding: "utf8", mode: 0o644 },
+      );
+      await fs.chmod(unitPath, 0o644);
+      mockSystemctlStatusOk();
+
+      await stageSystemdService(gatewaySystemdServiceFixture(env));
+
+      const backupPath = `${unitPath}.bak`;
+      const [backupUnit, backupStat] = await Promise.all([
+        fs.readFile(backupPath, "utf8"),
+        fs.stat(backupPath),
+      ]);
+      expect(backupUnit).toContain("ExecStart=/usr/bin/proxychains4 /usr/bin/openclaw gateway run");
+      expect(backupUnit).toContain("OPENROUTER_API_KEY=operator-key");
+      expect(backupUnit).not.toContain("legacy-token");
+      expect(backupUnit).not.toContain("legacy-password");
+      expect(backupStat.mode & 0o777).toBe(0o600);
+
+      execFileMock
+        .mockImplementationOnce(systemctlUserSuccess("status"))
+        .mockImplementationOnce(
+          systemctlUserSuccess("disable", "--now", "openclaw-gateway-stage-test.service"),
+        );
+      await uninstallSystemdService({ env, stdout: createWritableStreamMock().stdout });
+
+      await expect(fs.access(unitPath)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.access(backupPath)).rejects.toMatchObject({ code: "ENOENT" });
     });
   });
 
@@ -3167,6 +3228,7 @@ describe("systemd service install and uninstall", () => {
     await withNodeSystemdFixture(async ({ env, unitPath, nodeEnvFilePath }) => {
       await fs.mkdir(path.dirname(unitPath), { recursive: true });
       await fs.writeFile(unitPath, "[Unit]\nDescription=OpenClaw Node\n", "utf8");
+      await fs.writeFile(`${unitPath}.bak`, "[Unit]\nDescription=OpenClaw Node backup\n", "utf8");
       await fs.writeFile(nodeEnvFilePath, "OPENCLAW_GATEWAY_TOKEN=preserved-token\n", "utf8");
       execFileMock
         .mockImplementationOnce(systemctlUserSuccess("status"))
@@ -3185,6 +3247,9 @@ describe("systemd service install and uninstall", () => {
         `systemctl disable failed: ${detail}`,
       );
       await expect(fs.readFile(unitPath, "utf8")).resolves.toContain("OpenClaw Node");
+      await expect(fs.readFile(`${unitPath}.bak`, "utf8")).resolves.toContain(
+        "OpenClaw Node backup",
+      );
       await expect(fs.readFile(nodeEnvFilePath, "utf8")).resolves.toContain("preserved-token");
     });
   });
@@ -3258,6 +3323,64 @@ describe("systemd service install and uninstall", () => {
       expect(requireFirstWrite(write)).toContain("Removed systemd service");
       expect(execFileMock).toHaveBeenCalledTimes(2);
     });
+  });
+
+  it("removes an orphaned backup without following a symlinked backup", async () => {
+    await withNodeSystemdFixture(async ({ env, unitPath }) => {
+      const backupPath = `${unitPath}.bak`;
+      await fs.mkdir(path.dirname(unitPath), { recursive: true });
+      await fs.writeFile(backupPath, "[Unit]\nDescription=Old gateway\n", "utf8");
+      execFileMock
+        .mockImplementationOnce(systemctlUserSuccess("status"))
+        .mockImplementationOnce(systemctlUserSuccess("disable", "--now", NODE_SERVICE));
+
+      await uninstallSystemdService({ env, stdout: createWritableStreamMock().stdout });
+      await expect(fs.access(backupPath)).rejects.toMatchObject({ code: "ENOENT" });
+
+      const targetPath = path.join(path.dirname(unitPath), "operator-backup.service");
+      const targetContent = "[Unit]\nDescription=Operator backup\n";
+      await fs.writeFile(targetPath, targetContent, "utf8");
+      await fs.symlink(targetPath, backupPath);
+      execFileMock
+        .mockImplementationOnce(systemctlUserSuccess("status"))
+        .mockImplementationOnce(systemctlUserSuccess("disable", "--now", NODE_SERVICE));
+
+      await expect(
+        uninstallSystemdService({ env, stdout: createWritableStreamMock().stdout }),
+      ).rejects.toThrow(`Refusing to rewrite symlinked managed systemd file: ${backupPath}`);
+      await expect(fs.readlink(backupPath)).resolves.toBe(targetPath);
+      await expect(fs.readFile(targetPath, "utf8")).resolves.toBe(targetContent);
+      expect(execFileMock).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  it("removes only the resolved profile unit and its backup", async () => {
+    const tempHomeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-profile-systemd-"));
+    const env = { HOME: path.join(tempHomeRoot, "home"), OPENCLAW_PROFILE: "work" };
+    const unitPath = resolveSystemdUserUnitPath(env);
+    const defaultUnitPath = resolveSystemdUserUnitPath({ HOME: env.HOME });
+    try {
+      await fs.mkdir(path.dirname(unitPath), { recursive: true });
+      await Promise.all(
+        [unitPath, `${unitPath}.bak`, defaultUnitPath, `${defaultUnitPath}.bak`].map((filePath) =>
+          fs.writeFile(filePath, "[Unit]\nDescription=Gateway\n", "utf8"),
+        ),
+      );
+      execFileMock
+        .mockImplementationOnce(systemctlUserSuccess("status"))
+        .mockImplementationOnce(
+          systemctlUserSuccess("disable", "--now", "openclaw-gateway-work.service"),
+        );
+
+      await uninstallSystemdService({ env, stdout: createWritableStreamMock().stdout });
+
+      await expect(fs.access(unitPath)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.access(`${unitPath}.bak`)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.access(defaultUnitPath)).resolves.toBeUndefined();
+      await expect(fs.access(`${defaultUnitPath}.bak`)).resolves.toBeUndefined();
+    } finally {
+      await fs.rm(tempHomeRoot, { recursive: true, force: true });
+    }
   });
 
   it("removes a password-only node environment file during uninstall", async () => {
@@ -3398,6 +3521,11 @@ describe("uninstallLegacySystemdUnits", () => {
       try {
         await fs.mkdir(path.dirname(unitPath), { recursive: true });
         await fs.writeFile(unitPath, "[Unit]\nDescription=Clawdbot Gateway\n", "utf8");
+        await fs.writeFile(
+          `${unitPath}.bak`,
+          "[Unit]\nDescription=Clawdbot Gateway backup\n",
+          "utf8",
+        );
         execFileMock.mockImplementation((_command, args, _options, callback) => {
           if (args[1] === "status") {
             callback(
@@ -3420,11 +3548,44 @@ describe("uninstallLegacySystemdUnits", () => {
           "systemctl disable failed: Permission denied",
         );
         await expect(fs.access(unitPath)).resolves.toBeUndefined();
+        await expect(fs.access(`${unitPath}.bak`)).resolves.toBeUndefined();
       } finally {
         await fs.rm(tempHomeRoot, { recursive: true, force: true });
       }
     },
   );
+
+  it("discovers and removes an orphaned legacy backup", async () => {
+    const tempHomeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-legacy-backup-"));
+    const env = { HOME: path.join(tempHomeRoot, "home") };
+    const backupPath = path.join(
+      env.HOME,
+      ".config",
+      "systemd",
+      "user",
+      "clawdbot-gateway.service.bak",
+    );
+    try {
+      await fs.mkdir(path.dirname(backupPath), { recursive: true });
+      await fs.writeFile(backupPath, "[Unit]\nDescription=Clawdbot Gateway\n", "utf8");
+      execFileMock.mockImplementation((_command, args, _options, callback) => {
+        if (args[1] === "status") {
+          callback(null, "", "");
+        } else if (args[1] === "is-enabled") {
+          callback(createExecFileError("disabled"), "disabled\n", "");
+        } else {
+          assertUserSystemctlArgs(args, "disable", "--now", "clawdbot-gateway.service");
+          callback(null, "", "");
+        }
+      });
+
+      await uninstallLegacySystemdUnits({ env, stdout: createWritableStreamMock().stdout });
+
+      await expect(fs.access(backupPath)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await fs.rm(tempHomeRoot, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("uninstallUserSystemdGatewayUnit", () => {
@@ -3451,6 +3612,7 @@ describe("uninstallUserSystemdGatewayUnit", () => {
   it("disables and removes the user-scope unit when systemctl is available", async () => {
     await withUserUnitFixture(async ({ env, unitPath }) => {
       await fs.writeFile(unitPath, "[Unit]\nDescription=OpenClaw Gateway\n", "utf8");
+      await fs.writeFile(`${unitPath}.bak`, "[Unit]\nDescription=Previous gateway\n", "utf8");
       execFileMock
         .mockImplementationOnce(systemctlUserSuccess("status"))
         .mockImplementationOnce(systemctlUserSuccess("disable", "--now", GATEWAY_SERVICE))
@@ -3464,6 +3626,7 @@ describe("uninstallUserSystemdGatewayUnit", () => {
       expect(result.disabled).toBe(true);
       expect(result.unitName).toBe(GATEWAY_SERVICE);
       await expect(fs.access(unitPath)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.access(`${unitPath}.bak`)).rejects.toMatchObject({ code: "ENOENT" });
       expect(requireFirstWrite(write)).toContain("Removed user-scope systemd service");
     });
   });


### PR DESCRIPTION
Closes #131775

## What Problem This Solves

Fixes an issue where users upgrading a legacy systemd service could leave a plaintext gateway token or password in a world-readable `.bak` file, even after uninstalling OpenClaw.

## Why This Change Was Made

Systemd now treats the resolved unit and its backup as one lifecycle: backups preserve operator customizations while stripping OpenClaw-managed credentials, are atomically written as `0600`, and are removed by canonical, profile/custom-unit, doctor, and legacy cleanup paths. Unexpected symlink or non-regular artifacts are rejected before disabling the service; drop-ins remain operator-owned and untouched.

## User Impact

Reinstalling no longer exposes legacy managed credentials through service backups, and uninstall removes the exact resolved backup along with the unit. Operator customizations and unrelated environment entries remain available in the private backup until uninstall.

## Evidence

- Before: `keeps legacy gateway credentials out of private backups without a new credential plan` failed because the backup contained `legacy-token`; the reproduced backup inherited mode `0644` and survived uninstall.
- After: `node scripts/run-vitest.mjs src/daemon/systemd.test.ts` passed 192/192. The regression proves continued legacy token/password assignments are scrubbed, operator `ExecStart` and unrelated environment survive, mode is `0600`, and stage followed by uninstall removes both files (`src/daemon/systemd.test.ts:2695-2738`).
- Exact lifecycle coverage: backup publication and cleanup are in `src/daemon/systemd-install.ts:115-203,319-348,662-680`; profile/orphan/symlink cases are covered at `src/daemon/systemd.test.ts:3328-3391`; doctor and legacy cleanup share the same artifact owner at `src/daemon/systemd-lifecycle.ts:136-193,218-247`, including an orphaned legacy-backup test at `src/daemon/systemd.test.ts:3558-3588`.
- The analysis was independently verified by a second adversarial review that attempted to refute it and confirmed the bug.
- Checks: `node scripts/run-vitest.mjs src/daemon/systemd.test.ts`; `node scripts/check-changed.mjs --timed`.
- Production LOC: `src/daemon/systemd-install.ts` +41 net, `src/daemon/systemd-lifecycle.ts` +4 net. This growth establishes atomic private backup publication plus one shared no-follow lifecycle for canonical, doctor, and legacy removals; test LOC +163.
