### PR TITLE
fix(test): stop gateway clients on connection failure

### DIFF
--- a/test/helpers/gateway-e2e-harness.real.test.ts
+++ b/test/helpers/gateway-e2e-harness.real.test.ts
@@ -1,0 +1,71 @@
+// Gateway E2E harness real-transport tests cover failed client cleanup.
+import net from "node:net";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { connectGatewayStatusClient } from "./gateway-e2e-harness.js";
+
+describe("connectGatewayStatusClient real transport", () => {
+  let server: net.Server | undefined;
+  let socket: net.Socket | undefined;
+
+  afterEach(async () => {
+    socket?.destroy();
+    if (!server) {
+      return;
+    }
+    await new Promise<void>((resolve, reject) => {
+      server?.close((error) => (error ? reject(error) : resolve()));
+    });
+    server = undefined;
+  });
+
+  it("closes a real transport after the status handshake times out", async () => {
+    let resolveAccepted = () => {};
+    const accepted = new Promise<void>((resolve) => {
+      resolveAccepted = resolve;
+    });
+    let resolveUpgrade = () => {};
+    const upgradeRequested = new Promise<void>((resolve) => {
+      resolveUpgrade = resolve;
+    });
+    const closed = new Promise<void>((resolve) => {
+      server = net.createServer((clientSocket) => {
+        socket = clientSocket;
+        resolveAccepted();
+        clientSocket.on("data", (data) => {
+          if (data.toString("utf8").includes("Upgrade: websocket")) {
+            resolveUpgrade();
+          }
+        });
+        clientSocket.once("close", resolve);
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      server?.once("error", reject);
+      server?.listen(0, "127.0.0.1", resolve);
+    });
+    const port = (server?.address() as AddressInfo).port;
+    const attempt = connectGatewayStatusClient(
+      {
+        homeDir: "",
+        name: "real-timeout",
+        port,
+        gatewayToken: "token",
+      } as Parameters<typeof connectGatewayStatusClient>[0],
+      100,
+    );
+
+    await accepted;
+    await upgradeRequested;
+    await expect(attempt).rejects.toThrow("timeout waiting for status client hello");
+    await expect(
+      Promise.race([
+        closed.then(() => true),
+        new Promise<false>((resolve) => setTimeout(() => resolve(false), 1_000)),
+      ]),
+    ).resolves.toBe(true);
+    console.log(
+      "[gateway-e2e real proof] handshake_failed=true upgrade_requested=true transport_closed=true cleanup_observed=true",
+    );
+  });
+});

--- a/test/helpers/gateway-e2e-harness.real.test.ts
+++ b/test/helpers/gateway-e2e-harness.real.test.ts
@@ -32,8 +32,10 @@ describe("connectGatewayStatusClient real transport", () => {
       server = net.createServer((clientSocket) => {
         socket = clientSocket;
         resolveAccepted();
+        let request = "";
         clientSocket.on("data", (data) => {
-          if (data.toString("utf8").includes("Upgrade: websocket")) {
+          request += data.toString("utf8");
+          if (request.includes("Upgrade: websocket")) {
             resolveUpgrade();
           }
         });

--- a/test/helpers/gateway-e2e-harness.test.ts
+++ b/test/helpers/gateway-e2e-harness.test.ts
@@ -1,11 +1,32 @@
 // Gateway E2E harness tests cover helper server and probe behavior.
 import { createServer, type RequestListener, type Server } from "node:http";
-import { afterEach, describe, expect, it } from "vitest";
-import { postJson } from "./gateway-e2e-harness.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { connectGatewayStatusClient, postJson } from "./gateway-e2e-harness.js";
+
+const gatewayClientState = vi.hoisted(() => ({
+  clients: [] as Array<{ stopped: boolean }>,
+}));
+
+vi.mock("../../src/gateway/client.js", () => ({
+  GatewayClient: class {
+    stopped = false;
+
+    constructor() {
+      gatewayClientState.clients.push(this);
+    }
+
+    start() {}
+
+    stop() {
+      this.stopped = true;
+    }
+  },
+}));
 
 let server: Server | undefined;
 
 afterEach(async () => {
+  gatewayClientState.clients.length = 0;
   if (!server) {
     return;
   }
@@ -70,5 +91,22 @@ describe("postJson", () => {
     await expect(
       postJson(`${baseUrl}/large`, {}, undefined, { maxResponseBytes: 32 }),
     ).rejects.toThrow("response exceeded 32 bytes");
+  });
+});
+
+describe("connectGatewayStatusClient", () => {
+  it("stops a client when the status hello times out", async () => {
+    const inst = {
+      homeDir: "",
+      name: "timeout",
+      port: 1,
+      gatewayToken: "token",
+    } as Parameters<typeof connectGatewayStatusClient>[0];
+
+    await expect(connectGatewayStatusClient(inst, 1)).rejects.toThrow(
+      "timeout waiting for status client hello for timeout",
+    );
+    expect(gatewayClientState.clients).toHaveLength(1);
+    expect(gatewayClientState.clients[0]?.stopped).toBe(true);
   });
 });

--- a/test/helpers/gateway-e2e-harness.ts
+++ b/test/helpers/gateway-e2e-harness.ts
@@ -159,6 +159,8 @@ export async function connectGatewayStatusClient(
         clearTimeout(timer);
       }
       if (err) {
+        // A failed handshake never returns the client to the caller, so the helper owns teardown.
+        client.stop();
         reject(err);
         return;
       }


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the shared Gateway E2E status helper could leave a client running after the status connection failed or timed out before `hello-ok`, allowing failed connection attempts to leak sockets and reconnect timers into later tests.

## Why This Change Was Made

The helper now stops the `GatewayClient` before rejecting connection failures. The caller still owns clients returned after a successful handshake, while failed handshakes are cleaned up at the point where the helper still owns them.

## User Impact

There is no direct product-user impact. Gateway E2E tests now reliably release failed status-client attempts instead of carrying their resources into subsequent test cases.

This PR was AI-assisted.

## Evidence

- Final behavior proof (exact head `effcc62ae22cc152e411cc925d0600a8683e25ea`): contributor CI [checks-node-compact-large-17](https://github.com/openclaw/openclaw/actions/runs/33262520259/job/99127062432) ran `test/helpers/gateway-e2e-harness.real.test.ts` with the real `GatewayClient` and a controlled TCP peer that accepted the WebSocket upgrade request but withheld the handshake. The test passed and recorded:
  ```text
  [gateway-e2e real proof] handshake_failed=true upgrade_requested=true transport_closed=true cleanup_observed=true
  ```
- The real-transport test now accumulates TCP request data across `data` callbacks before matching `Upgrade: websocket`, so ordinary packet fragmentation cannot leave the proof waiting on a header that is split across chunks.
- Supporting checks: CI run [33262520259](https://github.com/openclaw/openclaw/actions/runs/33262520259) completed with 131 successful jobs, 30 conditional skips, and no failures; [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33262520259/job/99127824202) passed.
- Proof boundary: this is a deterministic local transport failure, proving the helper releases its failed-handshake client and transport; it does not claim behavior against an external Gateway deployment or network.
