### PR TITLE
fix(systemd): stop leaking live gateway tokens through readable .service.bak files

### DIFF
--- a/docs/install/uninstall.md
+++ b/docs/install/uninstall.md
@@ -123,7 +123,7 @@ Default unit name is `openclaw-gateway.service` (or `openclaw-gateway-<profile>.
 
 ```bash
 systemctl --user disable --now openclaw-gateway.service
-rm -f ~/.config/systemd/user/openclaw-gateway.service
+rm -f ~/.config/systemd/user/openclaw-gateway.service{,.bak}
 systemctl --user daemon-reload
 ```
 

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { StaleOpenClawUpdateLaunchdJob } from "../../daemon/launchd.js";
+import type { ServiceConfigAudit } from "../../daemon/service-audit.js";
 import { createMockGatewayService } from "../../daemon/service.test-helpers.js";
 import type { PortListener, PortUsageStatus } from "../../infra/ports-types.js";
 import type { GatewayRestartHandoff } from "../../infra/restart-handoff.js";
@@ -119,7 +120,9 @@ const inspectWindowsGatewayFirewall = vi.fn<(opts?: unknown) => Promise<unknown>
   message: "Windows LAN firewall diagnostics do not apply.",
   details: [],
 }));
-const auditGatewayServiceConfig = vi.fn(async (_opts?: unknown) => undefined);
+const auditGatewayServiceConfig = vi.fn<(_opts?: unknown) => Promise<ServiceConfigAudit>>(
+  async () => ({ ok: true, issues: [] }),
+);
 const serviceIsLoaded = vi.fn<
   (opts?: { env?: NodeJS.ProcessEnv; timeoutMs?: number }) => Promise<boolean>
 >(async (_opts?: { env?: NodeJS.ProcessEnv; timeoutMs?: number }) => true);
@@ -898,6 +901,28 @@ describe("gatherDaemonStatus", () => {
     expect(status.service.loaded).toBe(true);
     expect(status.service.runtime?.status).toBe("running");
     expect((status.service.runtime as { detail?: string }).detail).toBe("19001");
+  });
+
+  it("retains service audit findings when the active command is absent", async () => {
+    serviceReadCommand.mockResolvedValueOnce(null);
+    auditGatewayServiceConfig.mockResolvedValueOnce({
+      ok: false,
+      issues: [
+        {
+          code: "systemd-unit-backup-unsafe",
+          message: "Systemd service backup exposes gateway credentials.",
+        },
+      ],
+    });
+
+    const status = await gatherStatus({ probe: false });
+
+    expect(auditGatewayServiceConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ command: null }),
+    );
+    expect(status.service.configAudit?.issues).toEqual([
+      expect.objectContaining({ code: "systemd-unit-backup-unsafe" }),
+    ]);
   });
 
   it("renders Gateway-specific recovery in text and JSON after service reads time out", async () => {

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -599,15 +599,14 @@ export async function gatherDaemonStatus(
     !isGatewayExternallySupervised(process.env);
   const targetServiceCommand = useNativeServiceTargetContext ? command : null;
   const restartHandoff = opts.deep ? readGatewayRestartHandoffSync(serviceEnv) : null;
-  const configAudit: ServiceConfigAudit = command
-    ? await loadServiceAuditModule().then(({ auditGatewayServiceConfig }) =>
-        auditGatewayServiceConfig({
-          env: process.env,
-          command,
-          timeoutMs,
-        }),
-      )
-    : { ok: true, issues: [] satisfies ServiceConfigAudit["issues"] };
+  const configAudit: ServiceConfigAudit = await loadServiceAuditModule().then(
+    ({ auditGatewayServiceConfig }) =>
+      auditGatewayServiceConfig({
+        env: process.env,
+        command,
+        timeoutMs,
+      }),
+  );
   const {
     mergedDaemonEnv,
     cliCfg,

--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -108,7 +108,9 @@ vi.mock("../daemon/service-audit.js", () => ({
     gatewayRuntimeProbeFailed: "gateway-runtime-probe-failed",
     gatewayTokenDrift: "gateway-token-drift",
     gatewayTokenEmbedded: "gateway-token-embedded",
+    gatewayPasswordEmbedded: "gateway-password-embedded",
     gatewayTokenMismatch: testServiceAuditCodes.gatewayTokenMismatch,
+    systemdUnitBackupUnsafe: "systemd-unit-backup-unsafe",
   },
 }));
 
@@ -523,6 +525,33 @@ describe("maybeRepairGatewayServiceConfig", () => {
       "service management skipped: non-default state dir or config path",
       "Gateway",
     );
+  });
+
+  it("reports an orphaned unsafe systemd backup without an active service command", async () => {
+    mocks.readCommand.mockResolvedValue(null);
+    mocks.auditGatewayServiceConfig.mockResolvedValue({
+      ok: false,
+      issues: [
+        {
+          code: "systemd-unit-backup-unsafe",
+          message: "Systemd service backup exposes gateway credentials.",
+          detail: "/home/test/.config/systemd/user/openclaw-gateway.service.bak",
+          level: "recommended",
+        },
+      ],
+    });
+
+    await runRepair({ gateway: {} });
+
+    expect(mocks.auditGatewayServiceConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ command: null, platform: process.platform }),
+    );
+    expectNoteContaining(
+      "Systemd service backup exposes gateway credentials",
+      "Gateway service config",
+    );
+    expect(mocks.stage).not.toHaveBeenCalled();
+    expect(mocks.install).not.toHaveBeenCalled();
   });
 
   it("treats gateway.auth.token as source of truth for service token repairs", async () => {

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -223,6 +223,10 @@ function isOperatorOwnedEnvironmentIssue(
       return hasGatewayServiceEnvironmentOverride(command, ["OPENCLAW_GATEWAY_TOKEN"], {
         environmentValueSources,
       });
+    case SERVICE_AUDIT_CODES.gatewayPasswordEmbedded:
+      return hasGatewayServiceEnvironmentOverride(command, ["OPENCLAW_GATEWAY_PASSWORD"], {
+        environmentValueSources,
+      });
     case SERVICE_AUDIT_CODES.gatewayManagedEnvEmbedded:
       return hasGatewayServiceEnvironmentOverride(command, issue.environmentKeys ?? [], {
         environmentValueSources,
@@ -525,6 +529,21 @@ export async function maybeRepairGatewayServiceConfig(
     command = null;
   }
   if (!command) {
+    const audit = await auditGatewayServiceConfig({
+      env: process.env,
+      command: null,
+      platform: process.platform,
+    });
+    if (audit.issues.length > 0) {
+      note(
+        audit.issues
+          .map((issue) =>
+            issue.detail ? `- ${issue.message} (${issue.detail})` : `- ${issue.message}`,
+          )
+          .join("\n"),
+        "Gateway service config",
+      );
+    }
     return cfg;
   }
   const managedDefinition = resolveManagedGatewayServiceCommand(command) ?? command;

--- a/src/daemon/inspect.test.ts
+++ b/src/daemon/inspect.test.ts
@@ -283,6 +283,49 @@ describe("findExtraGatewayServices (linux / scanSystemdDir) — real filesystem"
     },
   );
 
+  it.skipIf(!isLinux)("reports an orphaned legacy systemd backup", async () => {
+    const tmpHome = tempDirs.make("openclaw-test-", os.tmpdir());
+    const systemdDir = path.join(tmpHome, ".config", "systemd", "user");
+    const backupPath = path.join(systemdDir, "clawdbot-gateway.service.bak");
+    await fs.mkdir(systemdDir, { recursive: true });
+    await fs.writeFile(backupPath, CLAWDBOT_GATEWAY_CONTENTS);
+
+    const result = await findExtraGatewayServices({ HOME: tmpHome });
+
+    expect(result).toEqual([
+      {
+        platform: "linux",
+        label: "clawdbot-gateway.service",
+        detail: `unit backup: ${backupPath}`,
+        scope: "user",
+        marker: "clawdbot",
+        legacy: true,
+      },
+    ]);
+  });
+
+  it.skipIf(!isLinux)("reports a legacy systemd unit and its backup once", async () => {
+    const tmpHome = tempDirs.make("openclaw-test-", os.tmpdir());
+    const systemdDir = path.join(tmpHome, ".config", "systemd", "user");
+    const unitPath = path.join(systemdDir, "clawdbot-gateway.service");
+    await fs.mkdir(systemdDir, { recursive: true });
+    await fs.writeFile(unitPath, CLAWDBOT_GATEWAY_CONTENTS);
+    await fs.writeFile(`${unitPath}.bak`, CLAWDBOT_GATEWAY_CONTENTS);
+
+    const result = await findExtraGatewayServices({ HOME: tmpHome });
+
+    expect(result).toEqual([
+      {
+        platform: "linux",
+        label: "clawdbot-gateway.service",
+        detail: `unit: ${unitPath}`,
+        scope: "user",
+        marker: "clawdbot",
+        legacy: true,
+      },
+    ]);
+  });
+
   it.skipIf(!isLinux)(
     "does not report companion units that only depend on the gateway",
     async () => {

--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -5,6 +5,7 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import {
   GATEWAY_SERVICE_KIND,
   GATEWAY_SERVICE_MARKER,
+  LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES,
   resolveGatewayLaunchAgentLabel,
   resolveGatewaySystemdServiceName,
   resolveGatewayWindowsTaskName,
@@ -529,11 +530,31 @@ export async function findExtraGatewayServices(
     try {
       const home = resolveDaemonHomeDir(env);
       const userDir = path.join(home, ".config", "systemd", "user");
-      for (const svc of await scanSystemdDir({
+      const userServices = await scanSystemdDir({
         dir: userDir,
         scope: "user",
-      })) {
+      });
+      for (const svc of userServices) {
         push(svc);
+      }
+      for (const name of LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES) {
+        const label = `${name}.service`;
+        // The unit and its managed backup are one cleanup target. Report the
+        // backup separately only when it is the remaining orphaned artifact.
+        if (userServices.some((service) => service.label === label)) {
+          continue;
+        }
+        const backupPath = path.join(userDir, `${name}.service.bak`);
+        if ((await readUtf8File(backupPath)) !== null) {
+          push({
+            platform: "linux",
+            label,
+            detail: `unit backup: ${backupPath}`,
+            scope: "user",
+            marker: "clawdbot",
+            legacy: true,
+          });
+        }
       }
       if (opts.deep) {
         for (const dir of [

--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -728,6 +728,89 @@ describe("auditGatewayServiceConfig", () => {
     ).toBe(false);
   });
 
+  it.each([
+    {
+      name: "embedded credentials",
+      content:
+        'Environment = "OPENCLAW_GATEWAY_TOKEN=audit-token" SAFE=kept \\\n  "OPENCLAW_GATEWAY_PASSWORD=audit-password"\n',
+      mode: 0o600,
+      expectedDetail: "OPENCLAW_GATEWAY_PASSWORD, OPENCLAW_GATEWAY_TOKEN",
+    },
+    {
+      name: "permissive mode",
+      content: "Environment=OPERATOR_SETTING=kept\n",
+      mode: 0o644,
+      expectedDetail: "mode: 644",
+    },
+  ])("flags systemd unit backups with $name without revealing values", async (fixture) => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-service-audit-backup-"));
+    try {
+      await writeSystemdUnitForAudit(home, [
+        "After=network-online.target",
+        "Wants=network-online.target",
+        "RestartSec=5",
+        "KillMode=control-group",
+      ]);
+      const backupPath = path.join(
+        home,
+        ".config",
+        "systemd",
+        "user",
+        "openclaw-gateway.service.bak",
+      );
+      await fs.writeFile(backupPath, fixture.content, { mode: fixture.mode });
+      await fs.chmod(backupPath, fixture.mode);
+
+      const audit = await auditGatewayServiceConfig({
+        env: { HOME: home },
+        platform: "linux",
+        command: {
+          programArguments: ["/usr/bin/node", "gateway"],
+          environment: { PATH: "/usr/bin:/bin" },
+        },
+      });
+      const issue = audit.issues.find(
+        (entry) => entry.code === SERVICE_AUDIT_CODES.systemdUnitBackupUnsafe,
+      );
+      expect(issue).toMatchObject({
+        level: "recommended",
+        detail: expect.stringContaining(fixture.expectedDetail),
+      });
+      expect(JSON.stringify(issue)).not.toContain("audit-token");
+      expect(JSON.stringify(issue)).not.toContain("audit-password");
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("audits an orphaned systemd backup without an active command", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-service-audit-orphan-"));
+    try {
+      const backupPath = path.join(
+        home,
+        ".config",
+        "systemd",
+        "user",
+        "openclaw-gateway.service.bak",
+      );
+      await fs.mkdir(path.dirname(backupPath), { recursive: true });
+      await fs.writeFile(backupPath, "Environment=OPENCLAW_GATEWAY_TOKEN=orphan-token\n", {
+        mode: 0o600,
+      });
+
+      const audit = await auditGatewayServiceConfig({
+        env: { HOME: home },
+        platform: "linux",
+        command: null,
+      });
+
+      expect(hasIssue(audit, SERVICE_AUDIT_CODES.systemdUnitBackupUnsafe)).toBe(true);
+      expect(JSON.stringify(audit.issues)).not.toContain("orphan-token");
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
+
   it("accepts systemd RestartSec values with seconds suffixes", async () => {
     const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-service-audit-restartsec-"));
     await writeSystemdUnitForAudit(home, [
@@ -753,6 +836,14 @@ describe("auditGatewayServiceConfig", () => {
       serviceToken: "new-token",
     });
     expectTokenAudit(audit, { embedded: true, mismatch: false });
+  });
+
+  it("flags an embedded service password without revealing it", async () => {
+    const audit = await createGatewayAudit({
+      extraEnvironment: { OPENCLAW_GATEWAY_PASSWORD: "active-password" },
+    });
+    expect(hasIssue(audit, SERVICE_AUDIT_CODES.gatewayPasswordEmbedded)).toBe(true);
+    expect(JSON.stringify(audit.issues)).not.toContain("active-password");
   });
 
   it("does not flag token issues when service token is not embedded", async () => {

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -31,6 +31,7 @@ import { isNonMinimalServicePathEntry, normalizeServicePathEntry } from "./servi
 import type { GatewayServiceEnvironmentValueSource } from "./service-types.js";
 import { execSystemctlUser } from "./systemd-exec.js";
 import { resolveSystemdServiceName, resolveSystemdUnitPath } from "./systemd-service-files.js";
+import { parseSystemdEnvAssignments, splitSystemdLogicalLines } from "./systemd-unit.js";
 
 export type GatewayServiceCommand = {
   programArguments: string[];
@@ -58,6 +59,7 @@ export const SERVICE_AUDIT_CODES = {
   gatewayPathMissingDirs: "gateway-path-missing-dirs",
   gatewayPathNonMinimal: "gateway-path-nonminimal",
   gatewayTokenEmbedded: "gateway-token-embedded",
+  gatewayPasswordEmbedded: "gateway-password-embedded",
   gatewayManagedEnvEmbedded: "gateway-managed-env-embedded",
   gatewayPortMismatch: "gateway-port-mismatch",
   gatewayProxyEnvEmbedded: "gateway-proxy-env-embedded",
@@ -73,6 +75,7 @@ export const SERVICE_AUDIT_CODES = {
   systemdRestartSec: "systemd-restart-sec",
   systemdWantsNetworkOnline: "systemd-wants-network-online",
   systemdKillModeProcessOrNone: "systemd-kill-mode-process-or-none",
+  systemdUnitBackupUnsafe: "systemd-unit-backup-unsafe",
 } as const;
 
 /** Returns whether audit issues require migrating a daemon to a stable Node runtime. */
@@ -188,6 +191,7 @@ async function auditSystemdUnit(
   timeoutMs?: number,
 ) {
   const unitPath = resolveSystemdUnitPath(env);
+  await auditSystemdUnitBackup(unitPath, issues);
   let content;
   try {
     content = await fs.readFile(unitPath, "utf8");
@@ -251,6 +255,63 @@ async function auditSystemdUnit(
       level: "recommended",
     });
   }
+}
+
+async function auditSystemdUnitBackup(unitPath: string, issues: ServiceConfigIssue[]) {
+  const backupPath = `${unitPath}.bak`;
+  let stat;
+  try {
+    stat = await fs.lstat(backupPath);
+  } catch {
+    return;
+  }
+  const mode = stat.mode & 0o777;
+  const embeddedKeys = new Set<string>();
+  let unreadable = false;
+  if (stat.isFile()) {
+    const content = await fs.readFile(backupPath, "utf8").catch(() => {
+      unreadable = true;
+      return "";
+    });
+    for (const rawLine of splitSystemdLogicalLines(content)) {
+      const line = rawLine.trim();
+      const separator = line.indexOf("=");
+      if (separator < 0 || line.slice(0, separator).trim() !== "Environment") {
+        continue;
+      }
+      for (const { key, value } of parseSystemdEnvAssignments(line.slice(separator + 1).trim())) {
+        const normalizedKey = key.toUpperCase();
+        if (
+          value &&
+          (normalizedKey === "OPENCLAW_GATEWAY_TOKEN" ||
+            normalizedKey === "OPENCLAW_GATEWAY_PASSWORD")
+        ) {
+          embeddedKeys.add(normalizedKey);
+        }
+      }
+    }
+  }
+  if (stat.isFile() && !unreadable && embeddedKeys.size === 0 && (mode & 0o077) === 0) {
+    return;
+  }
+  const detail = [
+    backupPath,
+    !stat.isFile() ? "not a regular file" : undefined,
+    unreadable ? "unreadable" : undefined,
+    embeddedKeys.size > 0 ? `embedded keys: ${[...embeddedKeys].toSorted().join(", ")}` : undefined,
+    (mode & 0o077) !== 0 ? `mode: ${mode.toString(8).padStart(3, "0")}` : undefined,
+  ]
+    .filter(Boolean)
+    .join("; ");
+  issues.push({
+    code: SERVICE_AUDIT_CODES.systemdUnitBackupUnsafe,
+    message:
+      embeddedKeys.size > 0
+        ? "Systemd service backup exposes gateway credentials; reinstall the service and rotate the embedded credentials."
+        : "Systemd service backup is unsafe; reinstall the service to replace it.",
+    detail,
+    level: "recommended",
+  });
 }
 
 async function auditLaunchdPlist(
@@ -396,6 +457,21 @@ function auditGatewayToken(
   });
 }
 
+function auditGatewayPassword(command: GatewayServiceCommand, issues: ServiceConfigIssue[]) {
+  if (
+    !command?.environment?.OPENCLAW_GATEWAY_PASSWORD?.trim() ||
+    isEnvironmentFileOnlySource(command.environmentValueSources?.OPENCLAW_GATEWAY_PASSWORD)
+  ) {
+    return;
+  }
+  issues.push({
+    code: SERVICE_AUDIT_CODES.gatewayPasswordEmbedded,
+    message: "Gateway service embeds OPENCLAW_GATEWAY_PASSWORD and should be reinstalled.",
+    detail: "Rotate the password after reinstalling because the service definition exposed it.",
+    level: "recommended",
+  });
+}
+
 function auditManagedServiceEnvironment(
   command: GatewayServiceCommand,
   issues: ServiceConfigIssue[],
@@ -482,6 +558,9 @@ function auditGatewayServicePath(
   platform: NodeJS.Platform,
   expectedServicePath?: string,
 ) {
+  if (!command) {
+    return;
+  }
   if (platform === "win32") {
     return;
   }
@@ -647,6 +726,7 @@ export async function auditGatewayServiceConfig(params: {
   auditManagedServiceEnvironment(params.command, issues, params.expectedManagedServiceEnvKeys);
   auditProxyServiceEnvironment(params.command, issues);
   auditGatewayToken(params.command, issues, params.expectedGatewayToken);
+  auditGatewayPassword(params.command, issues);
   auditGatewayServicePath(params.command, issues, params.env, platform, params.expectedServicePath);
   await auditGatewayRuntime(params.env, params.command, issues, platform);
 

--- a/src/daemon/systemd-definition-mutation.ts
+++ b/src/daemon/systemd-definition-mutation.ts
@@ -259,7 +259,17 @@ export async function withSystemdDefinitionMutation<T>(
       const directory = await fs.realpath(path.dirname(file));
       const temporary = path.join(directory, `${path.basename(file)}.${randomUUID()}.tmp`);
       try {
-        await fs.writeFile(temporary, contents, { flag: "wx", mode });
+        // Keep owner-write during preparation so the descriptor can be reopened
+        // even when the final snapshot mode is read-only.
+        await fs.writeFile(temporary, contents, { flag: "wx", mode: mode | 0o200 });
+        const temporaryHandle = await fs.open(temporary, constants.O_WRONLY | constants.O_NOFOLLOW);
+        try {
+          // Creation mode is filtered by umask. Apply the admitted mode through
+          // the already-open inode so rollback restores the exact snapshot mode.
+          await temporaryHandle.chmod(mode);
+        } finally {
+          await temporaryHandle.close();
+        }
         const written = await fs.lstat(temporary);
         await refresh(true);
         // Locks coordinate OpenClaw writers, not external editors: POSIX rename

--- a/src/daemon/systemd-install.ts
+++ b/src/daemon/systemd-install.ts
@@ -54,7 +54,18 @@ import {
   buildSystemdUnit,
   parseSystemdEnvAssignments,
   renderSystemdEnvAssignment,
+  splitSystemdLogicalLines,
 } from "./systemd-unit.js";
+
+const SYSTEMD_GATEWAY_CREDENTIAL_KEYS = new Set([
+  "OPENCLAW_GATEWAY_TOKEN",
+  "OPENCLAW_GATEWAY_PASSWORD",
+]);
+
+function restrictSystemdArtifactMode(mode: number | undefined): number {
+  const ownerOnly = (mode ?? 0o600) & 0o700;
+  return ownerOnly || 0o600;
+}
 
 function collectSystemdInlineManagedKeys(params: {
   environment?: GatewayServiceEnv;
@@ -110,13 +121,14 @@ function collectSystemdFileBackedEnvironment(params: {
 
 function removeSystemdInlineEnvironmentKeys(content: string, keys: ReadonlySet<string>): string {
   const sanitizedLines: string[] = [];
-  for (const rawLine of content.split("\n")) {
+  for (const rawLine of splitSystemdLogicalLines(content)) {
     const line = rawLine.trim();
-    if (!line.startsWith("Environment=")) {
+    const separator = line.indexOf("=");
+    if (separator < 0 || line.slice(0, separator).trim() !== "Environment") {
       sanitizedLines.push(rawLine);
       continue;
     }
-    const assignments = parseSystemdEnvAssignments(line.slice("Environment=".length).trim());
+    const assignments = parseSystemdEnvAssignments(line.slice(separator + 1).trim());
     const keptAssignments = assignments.filter(({ key }) => {
       const normalizedKey = normalizeServiceEnvKey(key);
       return !normalizedKey || !keys.has(normalizedKey);
@@ -142,12 +154,12 @@ function sanitizeSystemdUnitBackupContent(params: {
   content: string;
   fileManagedKeys: ReadonlySet<string>;
 }): string {
-  if (params.fileManagedKeys.size === 0) {
-    return params.content;
-  }
-  // Backups should not retain file-managed secrets that OpenClaw moved into the
-  // generated EnvironmentFile during this rewrite.
-  return removeSystemdInlineEnvironmentKeys(params.content, params.fileManagedKeys);
+  // Gateway credentials are never useful in a recovery artifact. File-managed
+  // values are also omitted after OpenClaw moves them to the generated env file.
+  return removeSystemdInlineEnvironmentKeys(
+    params.content,
+    new Set([...params.fileManagedKeys, ...SYSTEMD_GATEWAY_CREDENTIAL_KEYS]),
+  );
 }
 
 function removeLegacyGatewayVersionMetadata(content: string): string {
@@ -264,6 +276,8 @@ async function writeSystemdUnit({
       ? undefined
       : (mutation.snapshots.get(environmentFilePath) ?? null);
     const existingUnit = mutation.snapshots.get(unitPath) ?? null;
+    const backupPath = `${unitPath}.bak`;
+    const existingBackup = mutation.snapshots.get(backupPath) ?? null;
     const { entries: stateDirDotEnvEntries, skippedShellReferenceKeys } =
       readStateDirDotEnvFromStateDir(stateDir);
     const stateDirDotEnvVars = new Map(
@@ -279,14 +293,15 @@ async function writeSystemdUnit({
     const fileManagedKeys = collectSystemdFileManagedKeys(environmentValueSources);
     const existingEnvironment = await readSystemdGatewayEnvironmentFiles(stateDir, environment);
 
-    if (existingUnit) {
+    const backupSource = existingUnit ?? existingBackup;
+    if (backupSource) {
       await mutation.publish(
-        `${unitPath}.bak`,
+        backupPath,
         sanitizeSystemdUnitBackupContent({
-          content: existingUnit.contents.toString("utf8"),
+          content: backupSource.contents.toString("utf8"),
           fileManagedKeys,
         }),
-        existingUnit.mode || 0o600,
+        restrictSystemdArtifactMode(backupSource.mode),
       );
     }
     try {
@@ -351,7 +366,7 @@ async function writeSystemdUnit({
         environmentFiles: hasGeneratedValues ? [environmentFilePath] : [],
       });
       await assertNoSystemGatewayOwnership(env);
-      await mutation.publish(unitPath, unit, existingUnit?.mode ?? 0o644);
+      await mutation.publish(unitPath, unit, restrictSystemdArtifactMode(existingUnit?.mode));
       try {
         await assertNoSystemGatewayOwnership(env);
       } catch (ownershipError) {
@@ -359,8 +374,26 @@ async function writeSystemdUnit({
         throw ownershipError;
       }
     } catch (error) {
+      let rollbackError: unknown;
+      try {
+        await mutation.restore(backupPath, existingBackup);
+      } catch (cause) {
+        rollbackError = cause;
+      }
       if (environmentFileSnapshot !== undefined) {
-        await mutation.restore(environmentFilePath, environmentFileSnapshot);
+        try {
+          await mutation.restore(environmentFilePath, environmentFileSnapshot);
+        } catch (cause) {
+          rollbackError ??= cause;
+        }
+      }
+      if (rollbackError) {
+        const failureDetail = error instanceof Error ? error.message : String(error);
+        const rollbackDetail =
+          rollbackError instanceof Error ? rollbackError.message : "unknown rollback error";
+        throw new Error(`${failureDetail}\nSystemd rollback failed: ${rollbackDetail}`, {
+          cause: error,
+        });
       }
       throw error;
     }
@@ -525,6 +558,11 @@ export async function uninstallSystemdService({
     }
     // Unit file was already absent; still clean generated node env state below.
   }
+  await fs.unlink(`${unitPath}.bak`).catch((error: unknown) => {
+    if (!hasErrnoCode(error, "ENOENT")) {
+      throw error;
+    }
+  });
   await removeNodeSystemdManagedEnvironmentKeys(env);
   if (removed) {
     stdout.write(`${formatLine("Removed systemd service", unitPath)}\n`);

--- a/src/daemon/systemd-lifecycle.ts
+++ b/src/daemon/systemd-lifecycle.ts
@@ -1,5 +1,6 @@
 /** systemd start, stop, restart, and obsolete-unit removal. */
 import fs from "node:fs/promises";
+import { hasErrnoCode } from "../infra/errno.js";
 import { LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES } from "./constants.js";
 import { formatLine } from "./output.js";
 import { createGatewayLifecycleMutationReporter } from "./service-mutation.js";
@@ -129,6 +130,16 @@ type LegacySystemdUnit = {
   exists: boolean;
 };
 
+async function removeSystemdUnitBackup(unitPath: string): Promise<void> {
+  try {
+    await fs.unlink(`${unitPath}.bak`);
+  } catch (error) {
+    if (!hasErrnoCode(error, "ENOENT")) {
+      throw error;
+    }
+  }
+}
+
 async function findLegacySystemdUnits(env: GatewayServiceEnv): Promise<LegacySystemdUnit[]> {
   const results: LegacySystemdUnit[] = [];
   const systemctlAvailable = await isSystemctlAvailable(env);
@@ -141,12 +152,19 @@ async function findLegacySystemdUnits(env: GatewayServiceEnv): Promise<LegacySys
     } catch {
       // ignore
     }
+    let backupExists = false;
+    try {
+      await fs.access(`${unitPath}.bak`);
+      backupExists = true;
+    } catch {
+      // ignore
+    }
     let enabled = false;
     if (systemctlAvailable) {
       const res = await execSystemctlUser(env, ["is-enabled", `${name}.service`]);
       enabled = res.code === 0;
     }
-    if (exists || enabled) {
+    if (exists || backupExists || enabled) {
       results.push({ name, unitPath, enabled, exists });
     }
   }
@@ -181,6 +199,7 @@ export async function uninstallLegacySystemdUnits({
       }
       stdout.write(`Legacy systemd unit not found at ${unit.unitPath}\n`);
     }
+    await removeSystemdUnitBackup(unit.unitPath);
   }
   if (systemctlAvailable && removedAny) {
     await reloadSystemdUserManager(env);
@@ -233,6 +252,7 @@ export async function uninstallUserSystemdGatewayUnit({
     }
     stdout.write(`User-scope systemd unit not found at ${unitPath}\n`);
   }
+  await removeSystemdUnitBackup(unitPath);
   // The manager keeps a deleted unit's definition loaded until it reloads, so
   // without this the unit stays startable while the detector reports it gone.
   if (removed && disabled) {

--- a/src/daemon/systemd-service-files.ts
+++ b/src/daemon/systemd-service-files.ts
@@ -18,7 +18,11 @@ import type {
   GatewayServiceReadOptions,
 } from "./service-types.js";
 import { execBusctlUser } from "./systemd-exec.js";
-import { parseSystemdEnvAssignments, parseSystemdExecStart } from "./systemd-unit.js";
+import {
+  parseSystemdEnvAssignments,
+  parseSystemdExecStart,
+  splitSystemdLogicalLines,
+} from "./systemd-unit.js";
 
 const SYSTEMD_GATEWAY_DOTENV_FILENAME = "gateway.systemd.env";
 const SYSTEMD_NODE_DOTENV_FILENAME = "node.systemd.env";
@@ -369,32 +373,36 @@ export async function readSystemdServiceExecStart(
     let inlineEnvironment: Record<string, string> = {};
     const environmentFileSpecs: string[] = [];
     const unsetEnvironment: string[] = [];
-    for (const rawLine of (content ?? "").split("\n")) {
+    for (const rawLine of splitSystemdLogicalLines(content ?? "")) {
       const line = rawLine.trim();
       if (!line || line.startsWith("#")) {
         continue;
       }
-      if (line.startsWith("ExecStart=")) {
-        execStart = line.slice("ExecStart=".length).trim();
-      } else if (line.startsWith("WorkingDirectory=")) {
-        const parsed = parseSystemdExecStart(line.slice("WorkingDirectory=".length))[0] ?? "";
+      const separator = line.indexOf("=");
+      if (separator < 0) {
+        continue;
+      }
+      const directive = line.slice(0, separator).trim();
+      const value = line.slice(separator + 1).trim();
+      if (directive === "ExecStart") {
+        execStart = value;
+      } else if (directive === "WorkingDirectory") {
+        const parsed = parseSystemdExecStart(value)[0] ?? "";
         workingDirectory = expandSystemdSpecifier(parsed.replace(/^-/, ""), env);
-      } else if (line.startsWith("Environment=")) {
-        const raw = line.slice("Environment=".length).trim();
-        if (!raw) {
+      } else if (directive === "Environment") {
+        if (!value) {
           inlineEnvironment = {};
         }
-        for (const parsed of parseSystemdEnvAssignments(raw)) {
+        for (const parsed of parseSystemdEnvAssignments(value)) {
           inlineEnvironment[parsed.key] = expandSystemdSpecifier(parsed.value, env);
         }
-      } else if (line.startsWith("EnvironmentFile=") || line.startsWith("UnsetEnvironment=")) {
-        const file = line.startsWith("EnvironmentFile=");
+      } else if (directive === "EnvironmentFile" || directive === "UnsetEnvironment") {
+        const file = directive === "EnvironmentFile";
         const entries = file ? environmentFileSpecs : unsetEnvironment;
-        const raw = line.slice(line.indexOf("=") + 1).trim();
-        if (!raw) {
+        if (!value) {
           entries.length = 0;
         } else {
-          entries.push(...(file ? [raw] : splitSystemdEnvironmentWords(raw)));
+          entries.push(...(file ? [value] : splitSystemdEnvironmentWords(value)));
         }
       }
     }

--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -142,6 +142,12 @@ export function parseSystemdEnvAssignments(raw: string): Array<{ key: string; va
   });
 }
 
+export function splitSystemdLogicalLines(content: string): string[] {
+  // A trailing backslash joins the next physical line. Comments inside that
+  // continuation are skipped by systemd and must not hide later assignments.
+  return content.replace(/\\\r?\n(?:\s*[#;][^\r\n]*\r?\n)*\s*/g, " ").split(/\r?\n/);
+}
+
 export function renderSystemdEnvAssignment(key: string, value: string): string {
   return systemdEscapeArg(`${key}=${value}`);
 }

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -1666,6 +1666,25 @@ describe("readSystemdServiceExecStart", () => {
     });
   });
 
+  it("parses continued environment assignments using systemd syntax", async () => {
+    mockReadGatewayServiceFile([
+      "[Service]",
+      "ExecStart = /usr/bin/openclaw gateway run",
+      "Environment = OPENCLAW_GATEWAY_TOKEN=one \\", // pragma: allowlist secret
+      "  # ignored continuation comment",
+      "  OPENCLAW_GATEWAY_PASSWORD=two", // pragma: allowlist secret
+    ]);
+    mockSystemdManagerProperties(new Error("manager unavailable"));
+
+    await expect(readSystemdServiceExecStart({ HOME: TEST_SERVICE_HOME })).resolves.toMatchObject({
+      programArguments: ["/usr/bin/openclaw", "gateway", "run"],
+      environment: {
+        OPENCLAW_GATEWAY_TOKEN: "one",
+        OPENCLAW_GATEWAY_PASSWORD: "two",
+      },
+    });
+  });
+
   it.each([false, true])(
     "accepts manager LoadState=not-found before inspecting empty service properties (local=%s)",
     async (local) => {
@@ -2995,6 +3014,72 @@ describe("stageSystemdService", () => {
     });
   });
 
+  it("protects tokenless gateway units and backups from legacy credentials", async () => {
+    await withStageFixture(async ({ env, unitPath }) => {
+      await fs.mkdir(path.dirname(unitPath), { recursive: true });
+      await fs.writeFile(
+        unitPath,
+        [
+          "[Service]",
+          "ExecStart=/opt/operator/openclaw gateway run --operator-flag",
+          "Environment=OPENCLAW_GATEWAY_TOKEN=legacy-token CUSTOM_SETTING=kept \\",
+          "  # legacy installer note",
+          "  OPENCLAW_GATEWAY_PASSWORD=legacy-password",
+          "RestartSec=17",
+        ].join("\n"),
+        { encoding: "utf8", mode: 0o644 },
+      );
+      await fs.chmod(unitPath, 0o644);
+      mockSystemctlStatusOk();
+
+      await stageSystemdService(gatewayPortSystemdServiceFixture(env, "18789"));
+
+      const [unit, backup, unitStat, backupStat] = await Promise.all([
+        fs.readFile(unitPath, "utf8"),
+        fs.readFile(`${unitPath}.bak`, "utf8"),
+        fs.stat(unitPath),
+        fs.stat(`${unitPath}.bak`),
+      ]);
+      expect(unit).not.toContain("OPENCLAW_GATEWAY_TOKEN");
+      expect(unit).not.toContain("OPENCLAW_GATEWAY_PASSWORD");
+      expect(backup).not.toContain("OPENCLAW_GATEWAY_TOKEN");
+      expect(backup).not.toContain("OPENCLAW_GATEWAY_PASSWORD");
+      expect(backup).toContain("CUSTOM_SETTING=kept");
+      expect(backup).toContain("RestartSec=17");
+      expect(unitStat.mode & 0o777).toBe(0o600);
+      expect(backupStat.mode & 0o777).toBe(0o600);
+    });
+  });
+
+  it("restores an orphan backup when later staging fails", async () => {
+    await withStageFixture(async ({ env, unitPath }) => {
+      const backupPath = `${unitPath}.bak`;
+      const previous =
+        "[Service]\nEnvironment=OPENCLAW_GATEWAY_TOKEN=legacy-token CUSTOM_SETTING=kept\n";
+      await fs.mkdir(path.dirname(backupPath), { recursive: true });
+      await fs.writeFile(backupPath, previous, { encoding: "utf8", mode: 0o640 });
+      await fs.chmod(backupPath, 0o640);
+      mockSystemctlStatusOk();
+
+      await expect(
+        stageSystemdService(
+          gatewaySystemdServiceFixture(env, {
+            environment: {
+              OPENCLAW_GATEWAY_PORT: "18789",
+              OPENCLAW_GATEWAY_TOKEN: "invalid\nmultiline",
+            },
+            environmentValueSources: { OPENCLAW_GATEWAY_TOKEN: "file" },
+          }),
+        ),
+      ).rejects.toThrow("systemd EnvironmentFile values must be single-line");
+
+      const restored = await fs.stat(backupPath);
+      expect(restored.mode & 0o777).toBe(0o640);
+      await expect(fs.readFile(backupPath, "utf8")).resolves.toBe(previous);
+      await expect(fs.access(unitPath)).rejects.toMatchObject({ code: "ENOENT" });
+    });
+  });
+
   it("keeps explicit inline overrides while leaving dotenv values to gateway startup", async () => {
     await withStageFixture(async ({ env, stateDir, unitPath, envFilePath }) => {
       await fs.writeFile(
@@ -3556,6 +3641,7 @@ describe("systemd service install and uninstall", () => {
     await withNodeSystemdFixture(async ({ env, unitPath, nodeEnvFilePath }) => {
       await fs.mkdir(path.dirname(unitPath), { recursive: true });
       await fs.writeFile(unitPath, "[Unit]\nDescription=OpenClaw Node\n", "utf8");
+      await fs.writeFile(`${unitPath}.bak`, "[Unit]\nDescription=Previous OpenClaw Node\n");
       await fs.writeFile(
         nodeEnvFilePath,
         [
@@ -3584,6 +3670,7 @@ describe("systemd service install and uninstall", () => {
         accessError = error as NodeJS.ErrnoException;
       }
       expect(accessError?.code).toBe("ENOENT");
+      await expect(fs.access(`${unitPath}.bak`)).rejects.toMatchObject({ code: "ENOENT" });
       await expect(fs.readFile(nodeEnvFilePath, "utf8")).resolves.toBe(
         [
           "OPENROUTER_API_KEY=operator-key",
@@ -3622,6 +3709,7 @@ describe("systemd service install and uninstall", () => {
     await withNodeSystemdFixture(async ({ env, unitPath, nodeEnvFilePath }) => {
       await fs.mkdir(path.dirname(unitPath), { recursive: true });
       await fs.writeFile(unitPath, "[Unit]\nDescription=OpenClaw Node\n", "utf8");
+      await fs.writeFile(`${unitPath}.bak`, "[Unit]\nDescription=Previous OpenClaw Node\n");
       await fs.writeFile(
         nodeEnvFilePath,
         "OPENCLAW_GATEWAY_TOKEN=stale-node-token\nOPENROUTER_API_KEY=operator-key\n",
@@ -3642,6 +3730,9 @@ describe("systemd service install and uninstall", () => {
       );
 
       await expect(fs.readFile(unitPath, "utf8")).resolves.toContain("OpenClaw Node");
+      await expect(fs.readFile(`${unitPath}.bak`, "utf8")).resolves.toContain(
+        "Previous OpenClaw Node",
+      );
       await expect(fs.readFile(nodeEnvFilePath, "utf8")).resolves.toBe(
         "OPENCLAW_GATEWAY_TOKEN=stale-node-token\nOPENROUTER_API_KEY=operator-key\n",
       );
@@ -3735,6 +3826,7 @@ describe("uninstallLegacySystemdUnits", () => {
       try {
         await fs.mkdir(path.dirname(unitPath), { recursive: true });
         await fs.writeFile(unitPath, "[Unit]\nDescription=Clawdbot Gateway\n", "utf8");
+        await fs.writeFile(`${unitPath}.bak`, "[Unit]\nDescription=Previous Clawdbot Gateway\n");
         execFileMock.mockImplementation((_command, args, _options, callback) => {
           if (args[1] === "status") {
             callback(
@@ -3757,11 +3849,35 @@ describe("uninstallLegacySystemdUnits", () => {
           "systemctl disable failed: Permission denied",
         );
         await expect(fs.access(unitPath)).resolves.toBeUndefined();
+        await expect(fs.access(`${unitPath}.bak`)).resolves.toBeUndefined();
       } finally {
         await fs.rm(tempHomeRoot, { recursive: true, force: true });
       }
     },
   );
+
+  it("discovers and removes an orphaned legacy backup", async () => {
+    const tempHomeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-legacy-backup-"));
+    const env = { HOME: path.join(tempHomeRoot, "home") };
+    const backupPath = path.join(
+      env.HOME,
+      ".config",
+      "systemd",
+      "user",
+      "clawdbot-gateway.service.bak",
+    );
+    try {
+      await fs.mkdir(path.dirname(backupPath), { recursive: true });
+      await fs.writeFile(backupPath, "Environment=OPENCLAW_GATEWAY_TOKEN=legacy-token\n");
+      execFileMock.mockImplementation(execFileSuccess());
+
+      await uninstallLegacySystemdUnits({ env, stdout: createWritableStreamMock().stdout });
+
+      await expect(fs.access(backupPath)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await fs.rm(tempHomeRoot, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("uninstallUserSystemdGatewayUnit", () => {
@@ -3788,6 +3904,7 @@ describe("uninstallUserSystemdGatewayUnit", () => {
   it("disables and removes the user-scope unit when systemctl is available", async () => {
     await withUserUnitFixture(async ({ env, unitPath }) => {
       await fs.writeFile(unitPath, "[Unit]\nDescription=OpenClaw Gateway\n", "utf8");
+      await fs.writeFile(`${unitPath}.bak`, "[Unit]\nDescription=Previous gateway\n", "utf8");
       execFileMock
         .mockImplementationOnce(systemctlUserSuccess("status"))
         .mockImplementationOnce(systemctlUserSuccess("disable", "--now", GATEWAY_SERVICE))
@@ -3801,12 +3918,14 @@ describe("uninstallUserSystemdGatewayUnit", () => {
       expect(result.disabled).toBe(true);
       expect(result.unitName).toBe(GATEWAY_SERVICE);
       await expect(fs.access(unitPath)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.access(`${unitPath}.bak`)).rejects.toMatchObject({ code: "ENOENT" });
       expect(requireFirstWrite(write)).toContain("Removed user-scope systemd service");
     });
   });
 
   it("reports removed:false without throwing when the unit file is already absent", async () => {
-    await withUserUnitFixture(async ({ env }) => {
+    await withUserUnitFixture(async ({ env, unitPath }) => {
+      await fs.writeFile(`${unitPath}.bak`, "Environment=OPENCLAW_GATEWAY_TOKEN=orphaned-token\n");
       execFileMock
         .mockImplementationOnce(systemctlUserSuccess("status"))
         .mockImplementationOnce(systemctlUserSuccess("disable", "--now", GATEWAY_SERVICE));
@@ -3815,6 +3934,7 @@ describe("uninstallUserSystemdGatewayUnit", () => {
       const result = await uninstallUserSystemdGatewayUnit({ env, stdout });
 
       expect(result.removed).toBe(false);
+      await expect(fs.access(`${unitPath}.bak`)).rejects.toMatchObject({ code: "ENOENT" });
       expect(requireFirstWrite(write)).toContain("User-scope systemd unit not found");
     });
   });


### PR DESCRIPTION
Closes #131781. Supersedes #131784.

## What Problem This Solves

Legacy Linux installs can embed a still-valid Gateway token or password in a user systemd unit. Reinstalling writes a tokenless current unit but previously copied the old definition into `<unit>.service.bak` with its permissive mode. On a traversable home path, another local UID could read that backup. Uninstall also left the backup behind.

## Why This Change Was Made

The repair now lives in current `main`'s atomic systemd-definition mutation owner:

- Parse systemd logical lines according to upstream continuation and comment rules.
- Remove Gateway token/password assignments from existing-unit and orphan-backup recovery artifacts.
- Strip group/world permissions from managed units and backups while preserving stricter owner-only modes.
- Restore the exact prior backup and environment-file snapshots if later staging fails, including mode under a restrictive umask.
- Remove the exact managed backup from canonical, doctor, profile/custom-unit, and legacy uninstall paths while leaving operator drop-ins untouched.
- Report unsafe or uninspectable backups through status/Doctor without returning credential values, including orphaned backups with no active service command.

## User Impact

Reinstalling a legacy Gateway no longer copies live credentials into a readable backup. Existing unsafe backups are visible in status/Doctor with rotation guidance. Uninstall removes managed backups as well as the active unit.

## Evidence

### Reproduction on current main

AWS Crabbox run [`run_04f08ba12a11`](https://crabbox.openclaw.ai/portal/runs/run_04f08ba12a11), base `fabe69f3fdf0927a1556884aa0cbc38790a982d0`:

- The new active unit contained neither Gateway credential.
- The generated backup still contained both credential assignments and retained mode `0644`.
- The regression failed at `src/daemon/systemd.test.ts` for the intended reason.
- The orphan-backup failure control passed on current main because current main did not mutate the orphan; the stale PR implementation introduced that rollback gap. This rewrite sanitizes it inside the atomic owner and restores it on failure.

### Repaired tests and static proof

- Final focused run [`run_d3f77b06c64f`](https://crabbox.openclaw.ai/portal/runs/run_d3f77b06c64f): 578 tests passed, 1 platform skip across systemd publication/lifecycle, parser, audit, Doctor, status, and extra-service discovery.
- Core production and core-test typechecks: [`run_1b92ec4e0f5a`](https://crabbox.openclaw.ai/portal/runs/run_1b92ec4e0f5a).
- Targeted lint and Docs MDX: [`run_16c9242c224c`](https://crabbox.openclaw.ai/portal/runs/run_16c9242c224c).
- Full build after a local workspace install: [`run_722bee1424fd`](https://crabbox.openclaw.ai/portal/runs/run_722bee1424fd).
- `git diff --check` and conflict-marker guard passed locally.

### Real systemd behavior

Built-CLI run [`run_4e139c62e93d`](https://crabbox.openclaw.ai/portal/runs/run_4e139c62e93d) used a disposable profile and a real `systemd --user` manager:

- A second local UID could read the legacy `0644` unit before repair.
- Reinstall produced active unit and backup modes `0600`.
- Neither artifact contained the token/password keys; unrelated operator environment remained in the backup.
- The second UID could no longer read either artifact.
- Deep status reported no unsafe-backup issue after repair.
- Gateway uninstall removed the active unit and exact backup while preserving the operator drop-in.

### Review and size

- Final autoreview: `.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main --stream-engine-output` — scoped clean, no accepted/actionable findings, correctness confidence `0.99`.
- Production: `+235/-41` (net `+194`). The growth establishes the security audit and atomic publication/rollback boundary; it replaces the stale parallel writer in the previous PR rather than retaining it.
- Tests: `+288/-2` (net `+286`). Docs: net `0`.
- No config, environment-variable, protocol, or SQLite surface is added.

## Attribution

Worked on by:
- @vyctorbrzezowski
