### PR TITLE
fix(control-ui): re-scope credentials when editing Gateway URLs

### DIFF
--- a/config/control-ui-startup-budget-baseline.json
+++ b/config/control-ui-startup-budget-baseline.json
@@ -1,5 +1,5 @@
 {
-  "startupJsGzipBytes": 347255,
-  "reason": "compact mobile session sharing with preserved draft state and a bounded member drilldown; recorded at the CI build-artifacts lane (347255 B)",
+  "startupJsGzipBytes": 348449,
+  "reason": "Gateway credential re-scoping across login, startup, connection, and final client construction; rebased over the 347255 B main baseline using the exact-head CI-observed 1194 B delta",
   "updatedAt": "2026-08-28"
 }

--- a/test/vitest/vitest.ui-isolated-paths.mjs
+++ b/test/vitest/vitest.ui-isolated-paths.mjs
@@ -3,6 +3,7 @@
 // matching the current registry, so they need a fresh graph in the isolated lane.
 export const uiIsolatedTestFiles = [
   "ui/src/app/app-host.server-prefs.test.ts",
+  "ui/src/app/bootstrap.gateway-credentials.test.ts",
   "ui/src/app/bootstrap.test.ts",
   "ui/src/app/router-outlet.test.ts",
   "ui/src/components/markdown-tables.test.ts",

--- a/ui/src/app/app-host.gateway-lineage.test.ts
+++ b/ui/src/app/app-host.gateway-lineage.test.ts
@@ -90,6 +90,42 @@ describe("Control UI Gateway target lineage", () => {
     expect(surface).not.toContain("<openclaw-app-shell");
   });
 
+  it("re-scopes credentials when the login draft changes Gateway", () => {
+    const { gateway, clients } = createGatewayHarness();
+    gateway.connect({ token: "old-token", password: "old-password" });
+    clients[0]?.opts.onClose?.({ code: 1006, reason: "login required", willRetry: true });
+    const app = document.createElement("openclaw-app") as unknown as {
+      runtime: Pick<ApplicationRuntime, "context" | "documentMode">;
+      render: () => { strings: readonly string[] };
+      synchronizeGateway: (gateway: ApplicationGateway) => void;
+    };
+    app.runtime = {
+      documentMode: null,
+      context: {
+        gateway,
+        basePath: "",
+        agentSelection: { state: { selectedId: null } },
+        config: { current: { terminalEnabled: false } },
+        theme: { resolvedMode: "dark" },
+      } as unknown as ApplicationContext,
+    };
+    app.synchronizeGateway(gateway);
+    const container = document.createElement("div");
+    render(app.render(), container);
+    const loginGate = container.querySelector("openclaw-login-gate") as unknown as {
+      props: {
+        onGatewayUrlChange: (value: string) => void;
+        onConnect: () => void;
+      };
+    };
+
+    loginGate.props.onGatewayUrlChange("wss://other-gateway.example.test");
+    loginGate.props.onConnect();
+
+    expect(clients[1]?.opts.token).toBeUndefined();
+    expect(clients[1]?.opts.password).toBeUndefined();
+  });
+
   it("keeps retryable Gateway startup on the initial progress surface", () => {
     const { gateway, clients } = createGatewayHarness();
     gateway.start();

--- a/ui/src/app/app-root.ts
+++ b/ui/src/app/app-root.ts
@@ -32,6 +32,7 @@ import {
 } from "./lazy-custom-element.ts";
 import { resolveOnboardingMode } from "./onboarding-mode.ts";
 import { isDesktopPanelAvailable } from "./panel-availability.ts";
+import { resolveGatewayCredentialsForUrlEdit } from "./settings.ts";
 
 type FocusDashboardRouteState =
   | { kind: "loading" }
@@ -216,6 +217,16 @@ export class OpenClawApp extends OpenClawLightDomElement {
   private resetLoginSensitivePresentation() {
     this.loginShowGatewayToken = false;
     this.loginShowGatewayPassword = false;
+  }
+
+  private updateLoginGatewayUrl(value: string) {
+    const credentials = resolveGatewayCredentialsForUrlEdit(this.loginGatewayUrl, value, {
+      token: this.loginToken,
+      password: this.loginPassword,
+    });
+    this.loginGatewayUrl = value;
+    this.loginToken = credentials.token;
+    this.loginPassword = credentials.password;
   }
 
   private closeDocument(basePath: string): void {
@@ -556,7 +567,7 @@ export class OpenClawApp extends OpenClawLightDomElement {
               showGatewayToken: this.loginShowGatewayToken,
               showGatewayPassword: this.loginShowGatewayPassword,
               onGatewayUrlChange: (value: string) => {
-                this.loginGatewayUrl = value;
+                this.updateLoginGatewayUrl(value);
               },
               onTokenChange: (value: string) => {
                 this.loginToken = value;

--- a/ui/src/app/bootstrap.gateway-credentials.test.ts
+++ b/ui/src/app/bootstrap.gateway-credentials.test.ts
@@ -1,0 +1,67 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createStorageMock } from "../test-helpers/storage.ts";
+import { bootstrapApplication, type ApplicationRuntime } from "./bootstrap.ts";
+import { persistSessionToken } from "./settings.ts";
+
+const NATIVE_AUTH_KEY = "__OPENCLAW_NATIVE_CONTROL_AUTH__";
+const originalUrl = window.location.href;
+let runtime: ApplicationRuntime | undefined;
+
+function setNativeAuth(auth: { gatewayUrl: string; token?: string; password?: string }) {
+  window[NATIVE_AUTH_KEY] = auth;
+}
+
+beforeEach(() => {
+  vi.stubGlobal("localStorage", createStorageMock());
+  vi.stubGlobal("sessionStorage", createStorageMock());
+});
+
+afterEach(() => {
+  runtime?.stop();
+  runtime = undefined;
+  window.history.replaceState({}, "", originalUrl);
+  vi.unstubAllGlobals();
+});
+
+describe("pending Gateway credentials", () => {
+  it("re-scopes credentials before confirming a changed Gateway URL", () => {
+    const currentGatewayUrl = "wss://gateway.example/openclaw";
+    const nextGatewayUrl = "wss://other-gateway.example/openclaw";
+    persistSessionToken(nextGatewayUrl, "next-token");
+    setNativeAuth({
+      gatewayUrl: currentGatewayUrl,
+      token: "old-token",
+      password: "old-password",
+    });
+    window.history.replaceState({}, "", `/#gatewayUrl=${encodeURIComponent(nextGatewayUrl)}`);
+    runtime = bootstrapApplication({ sessionPathBuilderReady: new Promise<void>(() => {}) });
+
+    runtime.confirmPendingGatewayConnection();
+
+    expect(runtime.context.gateway.connection.gatewayUrl).toBe(nextGatewayUrl);
+    expect(runtime.context.gateway.connection.token).toBe("next-token");
+    expect(runtime.context.gateway.connection.password).toBe("");
+    persistSessionToken(nextGatewayUrl, "");
+  });
+
+  it("holds a bootstrap token until its changed Gateway URL is confirmed", () => {
+    const currentGatewayUrl = "wss://gateway.example/openclaw";
+    const nextGatewayUrl = "wss://other-gateway.example/openclaw";
+    setNativeAuth({ gatewayUrl: currentGatewayUrl });
+    window.history.replaceState(
+      {},
+      "",
+      `/#gatewayUrl=${encodeURIComponent(nextGatewayUrl)}&bootstrapToken=next-bootstrap`,
+    );
+    runtime = bootstrapApplication({ sessionPathBuilderReady: new Promise<void>(() => {}) });
+
+    expect(runtime.context.gateway.connection.bootstrapToken).toBe("");
+
+    runtime.confirmPendingGatewayConnection();
+
+    expect(runtime.context.gateway.connection.gatewayUrl).toBe(nextGatewayUrl);
+    expect(runtime.context.gateway.connection.bootstrapToken).toBe("next-bootstrap");
+  });
+});

--- a/ui/src/app/bootstrap.ts
+++ b/ui/src/app/bootstrap.ts
@@ -61,6 +61,7 @@ import {
   loadSettings,
   patchSettings,
   persistSessionToken,
+  resolveGatewayCredentialsForUrlEdit,
   resolvePageGatewaySettings,
   saveSettings,
   type UiSettings,
@@ -273,7 +274,7 @@ export type ApplicationRuntime = {
   readonly focusLocation: ControlUiFocusLocation | null;
   readonly pendingGatewayConnection: {
     readonly gatewayUrl: string;
-    readonly token: string;
+    readonly token: string | null;
   } | null;
   readonly confirmPendingGatewayConnection: () => void;
   readonly cancelPendingGatewayConnection: () => void;
@@ -361,15 +362,16 @@ export function bootstrapApplication(
           setSessionPathBuilder(contract.buildControlUiSessionPath);
         }));
 
+  const hasPendingGateway = startup.pendingGatewayUrl !== null;
   const gateway = createApplicationGateway(
     settings,
     startup.password ?? "",
-    startup.pendingBootstrapToken ?? "",
+    hasPendingGateway ? "" : (startup.pendingBootstrapToken ?? ""),
     undefined,
     {
       persistDefaultConnectionSettings: documentMode === null,
       resourceBasePath,
-      ...(startup.pendingBootstrapProfile
+      ...(!hasPendingGateway && startup.pendingBootstrapProfile
         ? { bootstrapProfile: startup.pendingBootstrapProfile }
         : {}),
     },
@@ -478,7 +480,7 @@ export function bootstrapApplication(
     startup.pendingGatewayUrl !== null
       ? {
           gatewayUrl: startup.pendingGatewayUrl,
-          token: startup.pendingGatewayToken ?? "",
+          token: startup.pendingGatewayToken,
           bootstrapToken: startup.pendingBootstrapToken ?? "",
           ...(startup.pendingBootstrapProfile
             ? { bootstrapProfile: startup.pendingBootstrapProfile }
@@ -541,9 +543,15 @@ export function bootstrapApplication(
       return;
     }
     pendingGatewayConnection = null;
+    const credentials = resolveGatewayCredentialsForUrlEdit(
+      gateway.connection.gatewayUrl,
+      pending.gatewayUrl,
+      gateway.connection,
+    );
     gateway.connect({
       gatewayUrl: pending.gatewayUrl,
-      token: pending.token,
+      token: pending.bootstrapToken ? "" : (pending.token ?? credentials.token),
+      password: credentials.password,
       bootstrapToken: pending.bootstrapToken,
       bootstrapProfile: pending.bootstrapProfile,
     });

--- a/ui/src/app/gateway-store.test.ts
+++ b/ui/src/app/gateway-store.test.ts
@@ -376,6 +376,18 @@ describe("createApplicationGateway connection phase", () => {
     expect(loadSettings().selectedAgentId).toBeUndefined();
   });
 
+  it("clears inherited credentials when selecting another Gateway", () => {
+    const settings = { ...loadSettings(), token: "old-token" };
+    const { gateway, current } = createStore({ settings });
+    gateway.connect({ password: "old-password", bootstrapToken: "old-bootstrap" });
+
+    gateway.connect({ gatewayUrl: "wss://other-gateway.example.test" });
+
+    expect(current().opts.token).toBeUndefined();
+    expect(current().opts.password).toBeUndefined();
+    expect(current().opts.bootstrapToken).toBeUndefined();
+  });
+
   it("advances the connection revision only when credentials change", () => {
     const { gateway, current } = createStore();
     gateway.start();

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -1,4 +1,5 @@
 import {
+  gatewayCredentialScope,
   isRetryableGatewayStartupUnavailableError,
   readControlUiBuildMismatchId,
   resolveSafeTimeoutDelayMs,
@@ -36,6 +37,7 @@ import {
   loadSettings,
   patchSettings,
   persistSessionToken,
+  resolveGatewayCredentialsForUrlEdit,
 } from "./settings.ts";
 import { scheduleStaleChunkReload } from "./stale-chunk-reload.ts";
 import { readPresenceEntries, resolveSelfPresenceUser } from "./user-profile.ts";
@@ -324,9 +326,26 @@ export function createApplicationGateway(
   const connect = (overrides: ApplicationGatewayConnectOptions = {}) => {
     stopped = false;
     const { sessionKey: requestedSessionKey, ...connectionOverrides } = overrides;
+    const nextGatewayUrl = connectionOverrides.gatewayUrl ?? connection.gatewayUrl;
+    const logicalGatewayChanged =
+      gatewayCredentialScope(nextGatewayUrl) !== gatewayCredentialScope(connection.gatewayUrl);
+    const scopedCredentials = resolveGatewayCredentialsForUrlEdit(
+      connection.gatewayUrl,
+      nextGatewayUrl,
+      connection,
+    );
     const nextConnection = {
       ...connection,
       ...connectionOverrides,
+      ...(logicalGatewayChanged && connectionOverrides.token === undefined
+        ? { token: scopedCredentials.token }
+        : {}),
+      ...(logicalGatewayChanged && connectionOverrides.password === undefined
+        ? { password: scopedCredentials.password }
+        : {}),
+      ...(logicalGatewayChanged && connectionOverrides.bootstrapToken === undefined
+        ? { bootstrapToken: "", bootstrapProfile: undefined }
+        : {}),
       ...(connectionOverrides.bootstrapToken !== undefined &&
       connectionOverrides.bootstrapProfile === undefined
         ? { bootstrapProfile: undefined }

--- a/ui/src/app/settings.node.test.ts
+++ b/ui/src/app/settings.node.test.ts
@@ -57,6 +57,23 @@ describe("resolveApplicationStartupSettings", () => {
     expect(startup.pendingBootstrapProfile).toBeNull();
     expect(startup.location).toEqual({ pathname: "/dash", search: "", hash: "" });
   });
+
+  it("re-scopes the selected token when native auth changes only the Gateway and password", () => {
+    window["__OPENCLAW_NATIVE_CONTROL_AUTH__"] = {
+      gatewayUrl: "wss://gateway-b.example",
+      password: "next-password",
+    };
+    const initial = makeUiSettings("wss://gateway-a.example", { token: "old-token" });
+
+    const startup = resolveApplicationStartupSettings(initial, {
+      pathname: "/",
+      search: "",
+      hash: "",
+    });
+
+    expect(startup.settings.token).toBe("");
+    expect(startup.password).toBe("next-password");
+  });
 });
 
 describe("loadSettings default gateway URL derivation", () => {

--- a/ui/src/app/settings.ts
+++ b/ui/src/app/settings.ts
@@ -1,4 +1,4 @@
-import { gatewayOriginScope } from "@openclaw/gateway-client/browser";
+import { gatewayCredentialScope, gatewayOriginScope } from "@openclaw/gateway-client/browser";
 import { safeParseJson } from "@openclaw/normalization-core";
 import { normalizeAgentId } from "@openclaw/normalization-core/agent-id";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
@@ -297,7 +297,10 @@ export function resolvePageGatewaySettings(settings: UiSettings): UiSettings {
   return {
     ...settings,
     gatewayUrl: effectiveUrl,
-    token: resolveGatewayTokenForUrlEdit(settings.gatewayUrl, effectiveUrl, settings.token),
+    token: resolveGatewayCredentialsForUrlEdit(settings.gatewayUrl, effectiveUrl, {
+      token: settings.token,
+      password: "",
+    }).token,
     sessionKey: session.sessionKey,
     lastActiveSessionKey: session.lastActiveSessionKey,
   };
@@ -405,17 +408,21 @@ function loadSessionToken(gatewayUrl: string): string {
   }
 }
 
-export function resolveGatewayTokenForUrlEdit(
+export function resolveGatewayCredentialsForUrlEdit(
   currentGatewayUrl: string,
   nextGatewayUrl: string,
-  currentToken: string,
-): string {
-  if (gatewayOriginScope(currentGatewayUrl) === gatewayOriginScope(nextGatewayUrl)) {
-    return currentToken;
-  }
-  // Gateway tokens stay session-scoped across endpoint edits.
-  // Durable settings may contain scrubbed legacy tokens, but must not restore them here.
-  return loadSessionToken(nextGatewayUrl);
+  credentials: { token: string; password: string },
+): { token: string; password: string } {
+  const sameTokenScope =
+    gatewayOriginScope(currentGatewayUrl) === gatewayOriginScope(nextGatewayUrl);
+  const sameCredentialScope =
+    gatewayCredentialScope(currentGatewayUrl) === gatewayCredentialScope(nextGatewayUrl);
+  return {
+    // Gateway tokens stay session-scoped across endpoint edits. Durable settings
+    // may contain scrubbed legacy tokens, but must not restore them here.
+    token: sameTokenScope ? credentials.token : loadSessionToken(nextGatewayUrl),
+    password: sameCredentialScope ? credentials.password : "",
+  };
 }
 
 export function persistSessionToken(gatewayUrl: string, token: string) {

--- a/ui/src/app/startup-settings.ts
+++ b/ui/src/app/startup-settings.ts
@@ -7,7 +7,7 @@ import {
   type ControlUiBootstrapProfileHint,
 } from "../../../src/gateway/control-ui-bootstrap-contract.js";
 import { inferBasePathFromPathname, sessionRouteNamespaceFromPath } from "../app-route-paths.ts";
-import type { UiSettings } from "./settings.ts";
+import { resolveGatewayCredentialsForUrlEdit, type UiSettings } from "./settings.ts";
 
 type ApplicationStartupLocation = {
   pathname: string;
@@ -96,9 +96,15 @@ export function resolveApplicationStartupSettings(
     const gatewayUrl = normalizeOptionalString(nativeAuth.gatewayUrl);
     const token = normalizeOptionalString(nativeAuth.token);
     const nativePassword = normalizeOptionalString(nativeAuth.password);
+    const credentials = gatewayUrl
+      ? resolveGatewayCredentialsForUrlEdit(settings.gatewayUrl, gatewayUrl, {
+          token: settings.token,
+          password: "",
+        })
+      : null;
     updateSettings({
       ...(gatewayUrl ? { gatewayUrl } : {}),
-      ...(token ? { token } : {}),
+      ...(token ? { token } : credentials ? { token: credentials.token } : {}),
     });
     if (nativePassword) {
       password = nativePassword;

--- a/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
+++ b/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
@@ -72,6 +72,7 @@ type ProxyConnectionEvidence = {
   browserOrigin: string | null;
   gatewayResult?: GatewayResultEvidence;
   identityInjected: boolean;
+  requestTarget: string;
   requestMethods: string[];
   requiredHeaderInjected: boolean;
   route: ProxyRoute;
@@ -81,6 +82,7 @@ type ProxyConnectionEvidence = {
 type RealTransportProxy = {
   close: () => Promise<void>;
   evidence: ProxyConnectionEvidence[];
+  ipv4TrustedUrl: string;
   port: number;
   trustedUrl: string;
   untrustedUrl: string;
@@ -173,6 +175,7 @@ function sanitizeProxyEvidence(evidence: ProxyConnectionEvidence) {
     browserOriginPresent: Boolean(evidence.browserOrigin),
     gatewayResult: evidence.gatewayResult,
     identityInjected: evidence.identityInjected,
+    requestTarget: evidence.requestTarget,
     requestMethods: evidence.requestMethods,
     requiredHeaderInjected: evidence.requiredHeaderInjected,
     route: evidence.route,
@@ -293,6 +296,7 @@ async function startRealTransportProxy(gatewayUrl: string): Promise<RealTranspor
       const connectionEvidence: ProxyConnectionEvidence = {
         browserOrigin: stringValue(request.headers.origin),
         identityInjected: route === "trusted",
+        requestTarget: request.url ?? "",
         requestMethods: [],
         requiredHeaderInjected: route === "trusted",
         route,
@@ -324,6 +328,7 @@ async function startRealTransportProxy(gatewayUrl: string): Promise<RealTranspor
       });
     },
     evidence,
+    ipv4TrustedUrl: `ws://127.0.0.1:${address.port}/trusted`,
     port: address.port,
     trustedUrl: `${baseUrl}/trusted`,
     untrustedUrl: `${baseUrl}/untrusted`,
@@ -893,6 +898,93 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
       )}\n`,
       "utf8",
     );
+  });
+
+  it("does not forward prior Gateway credentials across URL scopes", async () => {
+    const connected = await createBrowserPage(gateway.httpUrl, proxy.trustedUrl);
+    await connected.page
+      .locator("openclaw-app-shell")
+      .waitFor({ timeout: controlUiSettleTimeoutMs });
+
+    const seededEvidenceStart = proxy.evidence.length;
+    await connected.page.evaluate((gatewayUrl) => {
+      const app = document.querySelector<HTMLElement & { runtime?: ApplicationRuntime }>(
+        "openclaw-app",
+      );
+      if (!app?.runtime) {
+        throw new Error("Control UI runtime is unavailable");
+      }
+      app.runtime.context.gateway.connect({
+        gatewayUrl,
+        token: "prior-gateway-token",
+        password: "prior-gateway-password",
+        bootstrapToken: "prior-gateway-bootstrap",
+      });
+    }, proxy.trustedUrl);
+    await waitForConnectionEvidence(
+      (entry) =>
+        entry.requestTarget === "/trusted" &&
+        entry.browserConnect?.authFields.includes("bootstrapToken") === true,
+      seededEvidenceStart,
+    );
+
+    const queryScopedUrl = `${proxy.trustedUrl}?credential-scope=next`;
+    const queryEvidenceStart = proxy.evidence.length;
+    await connected.page.evaluate((gatewayUrl) => {
+      const app = document.querySelector<HTMLElement & { runtime?: ApplicationRuntime }>(
+        "openclaw-app",
+      );
+      if (!app?.runtime) {
+        throw new Error("Control UI runtime is unavailable");
+      }
+      app.runtime.context.gateway.connect({ gatewayUrl });
+    }, queryScopedUrl);
+    const queryEvidence = await waitForConnectionEvidence(
+      (entry) =>
+        entry.requestTarget === "/trusted?credential-scope=next" &&
+        entry.browserConnect !== undefined,
+      queryEvidenceStart,
+    );
+    expect(queryEvidence.browserConnect?.authFields).toEqual(["token"]);
+
+    const originEvidenceStart = proxy.evidence.length;
+    await connected.page.evaluate((gatewayUrl) => {
+      const app = document.querySelector<HTMLElement & { runtime?: ApplicationRuntime }>(
+        "openclaw-app",
+      );
+      if (!app?.runtime) {
+        throw new Error("Control UI runtime is unavailable");
+      }
+      app.runtime.context.gateway.connect({ gatewayUrl });
+    }, proxy.ipv4TrustedUrl);
+    const originEvidence = await waitForConnectionEvidence(
+      (entry) => entry.requestTarget === "/trusted" && entry.gatewayResult?.ok === true,
+      originEvidenceStart,
+    );
+    expect(originEvidence.browserConnect?.authFields).toEqual([]);
+
+    const proof = {
+      differentOrigin: {
+        emittedAuthFields: originEvidence.browserConnect?.authFields ?? [],
+        priorApplicationCredentialsAbsent: true,
+        requestTarget: originEvidence.requestTarget,
+      },
+      queryOnly: {
+        emittedAuthFields: queryEvidence.browserConnect?.authFields ?? [],
+        passwordBootstrapAndDeviceTokenAbsent: true,
+        requestTarget: queryEvidence.requestTarget,
+        tokenOriginScopePreserved: true,
+      },
+      source: "built-control-ui-browser-to-real-gateway-proxy",
+    };
+    await writeFile(
+      path.join(artifactDir, "gateway-credential-rescope-proof.json"),
+      `${JSON.stringify(proof, null, 2)}\n`,
+      "utf8",
+    );
+    console.info(`[gateway-credential-rescope-proof] ${JSON.stringify(proof)}`);
+    expect(connected.errors).toEqual([]);
+    await closeConnectedContext(connected.context);
   });
 
   it("confirms gatewayUrl, accepts the allowed origin, and rejects an unlisted origin", async () => {

--- a/ui/src/lib/connection-hints.node.test.ts
+++ b/ui/src/lib/connection-hints.node.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
-import { resolveGatewayTokenForUrlEdit } from "../app/settings.ts";
+import { resolveGatewayCredentialsForUrlEdit } from "../app/settings.ts";
 import { createStorageMock } from "../test-helpers/storage.ts";
 import {
   resolveAuthHintKind,
@@ -13,18 +13,18 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-describe("resolveGatewayTokenForUrlEdit", () => {
-  it("preserves the current token for same normalized gateway endpoint edits", () => {
+describe("resolveGatewayCredentialsForUrlEdit", () => {
+  it("preserves credentials for same normalized gateway endpoint edits", () => {
     expect(
-      resolveGatewayTokenForUrlEdit(
+      resolveGatewayCredentialsForUrlEdit(
         "wss://gateway.example/openclaw",
         " wss://gateway.example/openclaw/ ",
-        "abc123",
+        { token: "abc123", password: "secret" },
       ),
-    ).toBe("abc123");
+    ).toEqual({ token: "abc123", password: "secret" });
   });
 
-  it("loads a scoped token when the normalized gateway endpoint changes", () => {
+  it("loads a scoped token and clears the password when the gateway endpoint changes", () => {
     vi.stubGlobal("sessionStorage", createStorageMock());
     sessionStorage.setItem(
       "openclaw.control.token.v1:wss://other-gateway.example/openclaw",
@@ -32,24 +32,34 @@ describe("resolveGatewayTokenForUrlEdit", () => {
     );
 
     expect(
-      resolveGatewayTokenForUrlEdit(
+      resolveGatewayCredentialsForUrlEdit(
         "wss://gateway.example/openclaw",
         "wss://other-gateway.example/openclaw/",
-        "abc123",
+        { token: "abc123", password: "secret" },
       ),
-    ).toBe("other-token");
+    ).toEqual({ token: "other-token", password: "" });
   });
 
-  it("clears the token when the changed gateway endpoint has no scoped token", () => {
+  it("clears credentials when the changed gateway endpoint has no scoped token", () => {
     vi.stubGlobal("sessionStorage", createStorageMock());
 
     expect(
-      resolveGatewayTokenForUrlEdit(
+      resolveGatewayCredentialsForUrlEdit(
         "wss://gateway.example/openclaw",
         "wss://other-gateway.example/openclaw",
-        "abc123",
+        { token: "abc123", password: "secret" },
       ),
-    ).toBe("");
+    ).toEqual({ token: "", password: "" });
+  });
+
+  it("preserves the token but clears the password when only the query scope changes", () => {
+    expect(
+      resolveGatewayCredentialsForUrlEdit(
+        "wss://gateway.example/openclaw?tenant=first",
+        "wss://gateway.example/openclaw?tenant=second",
+        { token: "abc123", password: "secret" },
+      ),
+    ).toEqual({ token: "abc123", password: "" });
   });
 
   it("does not restore legacy durable tokens when the gateway endpoint changes", () => {
@@ -64,12 +74,12 @@ describe("resolveGatewayTokenForUrlEdit", () => {
     );
 
     expect(
-      resolveGatewayTokenForUrlEdit(
+      resolveGatewayCredentialsForUrlEdit(
         "wss://gateway.example/openclaw",
         "wss://other-gateway.example/openclaw",
-        "abc123",
+        { token: "abc123", password: "secret" },
       ),
-    ).toBe("");
+    ).toEqual({ token: "", password: "" });
   });
 });
 

--- a/ui/src/pages/connection/connection-page.test.ts
+++ b/ui/src/pages/connection/connection-page.test.ts
@@ -1,5 +1,6 @@
 /* @vitest-environment jsdom */
 
+import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SystemInfoResult } from "../../../../packages/gateway-protocol/src/index.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
@@ -8,6 +9,7 @@ import type {
   ApplicationGateway,
   ApplicationGatewaySnapshot,
 } from "../../app/context.ts";
+import { loadSettings } from "../../app/settings.ts";
 import { ConnectionPage, supportsSystemInfo } from "./connection-page.ts";
 
 function deferred<T>() {
@@ -35,6 +37,40 @@ describe("supportsSystemInfo", () => {
     expect(supportsSystemInfo(hello)).toBe(true);
     expect(supportsSystemInfo(unsupportedHello)).toBe(false);
     expect(supportsSystemInfo(null)).toBe(false);
+  });
+});
+
+describe("ConnectionPage credentials", () => {
+  it("re-scopes credentials when the Gateway URL changes", () => {
+    const page = new ConnectionPage();
+    const state = page as unknown as {
+      settings: ReturnType<typeof loadSettings>;
+      password: string;
+      context: ApplicationContext;
+      render: () => ReturnType<ConnectionPage["render"]>;
+    };
+    state.settings = {
+      ...loadSettings(),
+      gatewayUrl: "wss://gateway.example/openclaw",
+      token: "old-token",
+    };
+    state.password = "old-password";
+    state.context = {
+      gateway: { snapshot: { phase: "stopped", hello: null, lastError: null } },
+      channels: { state: { channelsLastSuccess: null } },
+    } as unknown as ApplicationContext;
+    const container = document.createElement("div");
+    render(state.render(), container);
+    const input = container.querySelector<HTMLInputElement>('input[aria-label="WebSocket URL"]');
+    if (!input) {
+      throw new Error("expected Gateway URL input");
+    }
+
+    input.value = "wss://other-gateway.example/openclaw";
+    input.dispatchEvent(new Event("input"));
+
+    expect(state.settings.token).toBe("");
+    expect(state.password).toBe("");
   });
 });
 

--- a/ui/src/pages/connection/connection-page.ts
+++ b/ui/src/pages/connection/connection-page.ts
@@ -12,7 +12,12 @@ import {
   type ApplicationContext,
   type ApplicationGatewaySnapshot,
 } from "../../app/context.ts";
-import { loadGatewaySessionSelection, loadSettings, type UiSettings } from "../../app/settings.ts";
+import {
+  loadGatewaySessionSelection,
+  loadSettings,
+  resolveGatewayCredentialsForUrlEdit,
+  type UiSettings,
+} from "../../app/settings.ts";
 import { renderLearnMoreLink } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { isMissingOperatorReadScopeError } from "../../lib/gateway-errors.ts";
@@ -238,6 +243,20 @@ export class ConnectionPage extends OpenClawLightDomElement {
     });
   }
 
+  private updateConnection(patch: Partial<Pick<UiSettings, "gatewayUrl" | "token">>) {
+    if (patch.gatewayUrl !== undefined) {
+      const credentials = resolveGatewayCredentialsForUrlEdit(
+        this.settings.gatewayUrl,
+        patch.gatewayUrl,
+        { token: this.settings.token, password: this.password },
+      );
+      this.password = credentials.password;
+      this.settings = { ...this.settings, ...patch, token: credentials.token };
+      return;
+    }
+    this.settings = { ...this.settings, ...patch };
+  }
+
   override render() {
     const gateway = this.context.gateway.snapshot;
     const body = renderConnection({
@@ -251,9 +270,7 @@ export class ConnectionPage extends OpenClawLightDomElement {
       systemInfoUnavailable: this.systemInfoUnavailable,
       showGatewayToken: this.gatewayTokenVisible,
       showGatewayPassword: this.gatewayPasswordVisible,
-      onConnectionChange: (patch) => {
-        this.settings = { ...this.settings, ...patch };
-      },
+      onConnectionChange: (patch) => this.updateConnection(patch),
       onPasswordChange: (next) => (this.password = next),
       onSessionKeyChange: (sessionKey) => {
         this.sessionKeyDirty = true;

--- a/ui/src/pages/connection/view.ts
+++ b/ui/src/pages/connection/view.ts
@@ -2,7 +2,7 @@
 import { html } from "lit";
 import type { SystemInfoResult } from "../../../../packages/gateway-protocol/src/index.js";
 import type { GatewayHelloOk } from "../../api/gateway.ts";
-import { resolveGatewayTokenForUrlEdit, type UiSettings } from "../../app/settings.ts";
+import type { UiSettings } from "../../app/settings.ts";
 import {
   renderSettingsPage,
   renderSettingsRow,
@@ -74,12 +74,8 @@ export function renderConnection(props: ConnectionProps) {
           aria-label=${t("connection.access.wsUrl")}
           .value=${props.settings.gatewayUrl}
           @input=${(e: Event) => {
-            const settings = props.settings;
             const v = (e.target as HTMLInputElement).value;
-            props.onConnectionChange({
-              gatewayUrl: v,
-              token: resolveGatewayTokenForUrlEdit(settings.gatewayUrl, v, settings.token),
-            });
+            props.onConnectionChange({ gatewayUrl: v });
           }}
           placeholder="ws://100.x.y.z:18789"
         />


### PR DESCRIPTION
Closes #131773

## What Problem This Solves

Changing the Gateway URL could reuse the previous Gateway's token, password, or bootstrap credential when connecting to the new target. The same unsafe inheritance existed in the login gate, Connection page, confirmed startup handoffs, and the final connection owner.

## Why This Change Was Made

Gateway URL edits now follow one credential-scope rule at every entry point and again at the connection owner. Normalized same-scope edits preserve credentials, a different origin loads only that destination's tab-local token, and a changed browser credential scope clears password and bootstrap credentials. Pending bootstrap credentials remain isolated until the operator confirms the destination.

## User Impact

Operators can edit or confirm a Gateway URL without sending credentials from the previous target. Credentials supplied explicitly for the destination still take precedence, while harmless URL normalization keeps the current authentication state.

## Evidence

- The regression is covered at the rendered login form, Connection page, native startup handoff, pending URL confirmation, bootstrap quarantine, scope resolver, and final client-construction boundary.
- The final connection owner independently re-scopes omitted credentials before creating a client, so callers cannot accidentally inherit credentials from another target (`ui/src/app/gateway-store.ts:329`).
- Query-only target changes preserve the origin-scoped token but clear password and bootstrap credentials, matching their narrower browser credential scope (`ui/src/app/settings.ts:411`).
- An [exact-head real-Gateway wire trace](https://github.com/openclaw/openclaw/actions/runs/33213681499/job/98992773407) passed through the built browser UI: a query-only change emitted only the preserved origin-scoped token, with password, bootstrap, and device tokens absent; a different-origin change emitted no prior application auth fields (`ui/src/e2e/control-ui-auth-transports.e2e.test.ts:903`).
- No visual layout or copy changes are included; the observable change is limited to which credentials are sent during connection.
