### PR TITLE
refactor: remove redundant updater test setup

### DIFF
--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { bundledDistPluginFile } from "openclaw/plugin-sdk/test-fixtures";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { writePackageDistInventory } from "../../scripts/lib/package-dist-inventory.ts";
 import { BUNDLED_RUNTIME_SIDECAR_PATHS } from "../plugins/runtime-sidecar-paths.js";
 import { runCommandWithTimeout } from "../process/exec.js";
@@ -102,13 +102,8 @@ describe("runGatewayUpdate", () => {
     await fs.writeFile(path.join(tempDir, "openclaw.mjs"), "export {};\n", "utf-8");
   });
 
-  afterEach(async () => {
-    // Shared fixtureRoot cleaned up in afterAll.
-  });
-
   async function createStableTagRunner(params: {
     stableTag: string;
-    uiIndexPath: string;
     onDoctor?: () => Promise<void>;
     onBuild?: () => Promise<void>;
     onUiBuild?: (count: number) => Promise<void>;
@@ -128,20 +123,8 @@ describe("runGatewayUpdate", () => {
       if (key === `git -C ${tempDir} rev-parse HEAD`) {
         return { stdout: "abc123", stderr: "", code: 0 };
       }
-      if (key === `git -C ${tempDir} status --porcelain -- :!dist/control-ui/`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} fetch --all --prune --tags`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
       if (key === `git -C ${tempDir} tag --list v* --sort=-v:refname`) {
         return { stdout: `${params.stableTag}\n`, stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} checkout --detach ${params.stableTag}`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === "pnpm install") {
-        return { stdout: "", stderr: "", code: 0 };
       }
       if (key === "pnpm build") {
         await params.onBuild?.();
@@ -399,7 +382,7 @@ describe("runGatewayUpdate", () => {
     timeoutMs?: number;
   };
 
-  async function createDevGitRunner(params?: {
+  function createDevGitRunner(params?: {
     targetSha?: string;
     targetRef?: string;
     packageManager?: string;
@@ -411,8 +394,6 @@ describe("runGatewayUpdate", () => {
   }) {
     const calls: string[] = [];
     const targetSha = params?.targetSha ?? "upstream123";
-    const doctorNodePath = await resolveStableNodePath(process.execPath);
-    const doctorCommand = `${doctorNodePath} ${path.join(tempDir, "openclaw.mjs")} doctor --non-interactive --fix`;
     const targetRef = params?.targetRef;
     const targetCandidate = targetRef
       ? targetRef === targetSha
@@ -438,12 +419,6 @@ describe("runGatewayUpdate", () => {
       }
       if (key === `git -C ${tempDir} rev-parse --abbrev-ref HEAD`) {
         return toCommandResult({ stdout: "main" });
-      }
-      if (key === `git -C ${tempDir} status --porcelain -- :!dist/control-ui/`) {
-        return toCommandResult();
-      }
-      if (key === `git -C ${tempDir} fetch --all --prune --no-tags`) {
-        return toCommandResult();
       }
       if (
         !targetRef &&
@@ -473,36 +448,6 @@ describe("runGatewayUpdate", () => {
           params?.packageManager ?? "pnpm@8.0.0",
         );
         return toCommandResult({ stdout: `HEAD is now at ${targetSha}` });
-      }
-      if (
-        key.startsWith("git -C ") &&
-        preflightPrefixPattern.test(key) &&
-        key.includes(` checkout --detach ${targetSha}`)
-      ) {
-        return toCommandResult();
-      }
-      if (
-        key === "pnpm install" ||
-        key === "pnpm install --ignore-scripts" ||
-        key === "pnpm build" ||
-        key === "pnpm lint" ||
-        key === "pnpm ui:build" ||
-        key === doctorCommand
-      ) {
-        return toCommandResult();
-      }
-      if (
-        key.startsWith(`git -C ${tempDir} worktree remove --force `) &&
-        preflightPrefixPattern.test(key)
-      ) {
-        return toCommandResult();
-      }
-      if (
-        key === `git -C ${tempDir} worktree prune` ||
-        key === `git -C ${tempDir} rebase ${targetSha}` ||
-        key === `git -C ${tempDir} checkout --detach ${targetSha}`
-      ) {
-        return toCommandResult();
       }
       return toCommandResult();
     };
@@ -867,7 +812,7 @@ describe("runGatewayUpdate", () => {
     await setupGitPackageManagerFixture();
     const beforeGitMutation = vi.fn<() => Promise<void>>();
     const invalidConfig = "target rejected the active config";
-    const { calls, runCommand, targetSha } = await createDevGitRunner({
+    const { calls, runCommand, targetSha } = createDevGitRunner({
       targetRef: "main",
       onCommand: (key, options) => {
         if (
@@ -978,9 +923,6 @@ describe("runGatewayUpdate", () => {
       if (response) {
         return toCommandResult(response);
       }
-      if (key === `git -C ${tempDir} fetch --all --prune --no-tags`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
       if (key === `git -C ${tempDir} rev-parse --abbrev-ref --symbolic-full-name main@{upstream}`) {
         return {
           stdout: "",
@@ -1017,32 +959,14 @@ describe("runGatewayUpdate", () => {
       if (key === "pnpm --version") {
         return { stdout: "10.0.0", stderr: "", code: 0 };
       }
-      if (key === "pnpm install" || key === "pnpm ui:build") {
-        return { stdout: "", stderr: "", code: 0 };
-      }
       if (key === "pnpm build") {
         if (preflightSha === upstreamSha) {
           return { stdout: "", stderr: "tip build failed", code: 1 };
         }
         return { stdout: "", stderr: "", code: 0 };
       }
-      if (
-        key.startsWith(`git -C ${tempDir} worktree remove --force `) &&
-        preflightPrefixPattern.test(key)
-      ) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} worktree prune`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
       if (key === `git -C ${tempDir} show-ref --verify refs/heads/main`) {
         return { stdout: "", stderr: "", code: 1 };
-      }
-      if (key === `git -C ${tempDir} checkout -B main ${selectedSha}`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} branch --set-upstream-to origin/main main`) {
-        return { stdout: "", stderr: "", code: 0 };
       }
       return { stdout: "", stderr: "", code: 0 };
     };
@@ -1088,9 +1012,6 @@ describe("runGatewayUpdate", () => {
       if (response) {
         return toCommandResult(response);
       }
-      if (key === `git -C ${tempDir} fetch --all --prune --no-tags`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
       if (key === `git -C ${tempDir} rev-parse --abbrev-ref --symbolic-full-name main@{upstream}`) {
         return {
           stdout: "",
@@ -1115,34 +1036,11 @@ describe("runGatewayUpdate", () => {
         await writePreflightPackageManagerFixtureFromWorktreeAdd(key);
         return { stdout: `HEAD is now at ${selectedSha}`, stderr: "", code: 0 };
       }
-      if (
-        key.startsWith("git -C ") &&
-        preflightPrefixPattern.test(key) &&
-        key.includes(" checkout --detach ") &&
-        key.endsWith(selectedSha)
-      ) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
       if (key === "pnpm --version") {
         return { stdout: "10.0.0", stderr: "", code: 0 };
       }
-      if (key === "pnpm install" || key === "pnpm build" || key === "pnpm ui:build") {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (
-        key.startsWith(`git -C ${tempDir} worktree remove --force `) &&
-        preflightPrefixPattern.test(key)
-      ) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} worktree prune`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
       if (key === `git -C ${tempDir} show-ref --verify refs/heads/main`) {
         return { stdout: "", stderr: "", code: 1 };
-      }
-      if (key === `git -C ${tempDir} checkout -B main ${selectedSha}`) {
-        return { stdout: "", stderr: "", code: 0 };
       }
       if (key === `git -C ${tempDir} branch --set-upstream-to origin/main main`) {
         return { stdout: "", stderr: "requested upstream does not exist", code: 1 };
@@ -1408,7 +1306,7 @@ describe("runGatewayUpdate", () => {
   it("uses pnpm highest resolution mode for dev preflight installs", async () => {
     await setupGitPackageManagerFixture();
     const installEnvs: NodeJS.ProcessEnv[] = [];
-    const { runCommand } = await createDevGitRunner({
+    const { runCommand } = createDevGitRunner({
       onCommand: (key, options) => {
         if (key === "pnpm install") {
           installEnvs.push(options?.env ?? {});
@@ -1434,7 +1332,7 @@ describe("runGatewayUpdate", () => {
     await setupGitCheckout({ packageManager: "npm@10.0.0" });
     await setupUiIndex();
     const preflightInstallCommands: string[] = [];
-    const { runCommand } = await createDevGitRunner({
+    const { runCommand } = createDevGitRunner({
       onCommand: (key, options) => {
         if (key === "npm --version") {
           return { stdout: "10.0.0" };
@@ -1520,18 +1418,6 @@ describe("runGatewayUpdate", () => {
       if (key === "npm --version") {
         return { stdout: "10.0.0", stderr: "", code: 0 };
       }
-      if (key === "npm install" || key === "npm run build" || key === "npm run ui:build") {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (
-        key.startsWith(`git -C ${tempDir} worktree remove --force `) &&
-        preflightPrefixPattern.test(key)
-      ) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} worktree prune`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
       return { stdout: "", stderr: "", code: 0 };
     };
 
@@ -1611,20 +1497,8 @@ describe("runGatewayUpdate", () => {
       if (key === "npm --version") {
         return { stdout: "10.0.0", stderr: "", code: 0 };
       }
-      if (key === "npm install") {
-        return { stdout: "", stderr: "", code: 0 };
-      }
       if (key === "npm run build") {
         return { stdout: "", stderr: "build failed", code: 1 };
-      }
-      if (
-        key.startsWith(`git -C ${tempDir} worktree remove --force `) &&
-        preflightPrefixPattern.test(key)
-      ) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} worktree prune`) {
-        return { stdout: "", stderr: "", code: 0 };
       }
       return { stdout: "", stderr: "", code: 0 };
     };
@@ -1872,7 +1746,7 @@ describe("runGatewayUpdate", () => {
   it("uses npm-bootstrapped pnpm for dev preflight when pnpm and corepack are missing", async () => {
     await setupGitPackageManagerFixture();
     const pnpmEnvPaths: string[] = [];
-    const { calls, runCommand } = await createDevGitRunner({
+    const { calls, runCommand } = createDevGitRunner({
       onCommand: (key, options) => {
         if (key === "pnpm --version") {
           const envPath = options?.env?.PATH ?? options?.env?.Path ?? "";
@@ -1919,7 +1793,7 @@ describe("runGatewayUpdate", () => {
   it("runs dev preflight lint in constrained mode when explicitly enabled", async () => {
     await setupGitPackageManagerFixture();
     const lintEnv: NodeJS.ProcessEnv[] = [];
-    const { calls, runCommand } = await createDevGitRunner({
+    const { calls, runCommand } = createDevGitRunner({
       onCommand: (key, options) => {
         if (key === "pnpm lint") {
           lintEnv.push(options?.env ?? {});
@@ -1944,7 +1818,7 @@ describe("runGatewayUpdate", () => {
     let preflightInstallAttempts = 0;
     let preflightIgnoreScriptsAttempts = 0;
     let finalInstallAttempts = 0;
-    const { calls, runCommand } = await createDevGitRunner({
+    const { calls, runCommand } = createDevGitRunner({
       onCommand: (key, options) => {
         if (key === "pnpm install") {
           if (options?.cwd && preflightPrefixPattern.test(options.cwd)) {
@@ -1986,7 +1860,7 @@ describe("runGatewayUpdate", () => {
   it("does not fail a good windows dev preflight only because worktree cleanup hit long paths", async () => {
     await setupGitPackageManagerFixture();
     const cleanupTimeouts: Array<number | undefined> = [];
-    const { runCommand } = await createDevGitRunner({
+    const { runCommand } = createDevGitRunner({
       onCommand: (key, options) => {
         if (
           key.startsWith(`git -C ${tempDir} worktree remove --force `) &&
@@ -2018,7 +1892,7 @@ describe("runGatewayUpdate", () => {
   it("falls back when dev preflight worktree cleanup times out", async () => {
     await setupGitPackageManagerFixture();
     const cleanupTimeouts: Array<number | undefined> = [];
-    const { runCommand } = await createDevGitRunner({
+    const { runCommand } = createDevGitRunner({
       onCommand: (key, options) => {
         if (
           key.startsWith(`git -C ${tempDir} worktree remove --force `) &&
@@ -2061,7 +1935,7 @@ describe("runGatewayUpdate", () => {
     async ({ nodeOptions, skipDts, expectedNodeOptions }) => {
       await setupGitPackageManagerFixture();
       const buildEnvs: NodeJS.ProcessEnv[] = [];
-      const { calls, runCommand } = await createDevGitRunner({
+      const { calls, runCommand } = createDevGitRunner({
         onCommand: (key, options) => {
           if (key === "pnpm build") {
             buildEnvs.push(options?.env ?? {});
@@ -2103,7 +1977,7 @@ describe("runGatewayUpdate", () => {
   it("pins dev updates to an explicit target ref when requested", async () => {
     await setupGitPackageManagerFixture();
     const targetSha = "f2fdb9d1253ce3f227ccaa6cb0e3b664a32be4ee";
-    const { calls, runCommand } = await createDevGitRunner({ targetSha, targetRef: targetSha });
+    const { calls, runCommand } = createDevGitRunner({ targetSha, targetRef: targetSha });
 
     const result = await runWithCommand(runCommand, {
       channel: "dev",
@@ -2226,7 +2100,7 @@ describe("runGatewayUpdate", () => {
   it("resolves symbolic dev target refs from the fetched remote branch", async () => {
     await setupGitPackageManagerFixture();
     const targetSha = "2222222222222222222222222222222222222222";
-    const { calls, runCommand } = await createDevGitRunner({ targetSha, targetRef: "main" });
+    const { calls, runCommand } = createDevGitRunner({ targetSha, targetRef: "main" });
 
     const result = await runWithCommand(runCommand, {
       channel: "dev",
@@ -2247,8 +2121,6 @@ describe("runGatewayUpdate", () => {
     const calls: string[] = [];
     const targetSha = "3333333333333333333333333333333333333333";
     const gitRoot = await fs.realpath(tempDir).catch(() => tempDir);
-    const doctorNodePath = await resolveStableNodePath(process.execPath);
-    const doctorCommand = `${doctorNodePath} ${path.join(gitRoot, "openclaw.mjs")} doctor --non-interactive --fix`;
 
     const runCommand = async (
       argv: string[],
@@ -2270,12 +2142,6 @@ describe("runGatewayUpdate", () => {
       if (key === `git -C ${gitRoot} rev-parse --abbrev-ref HEAD`) {
         return { stdout: "main", stderr: "", code: 0 };
       }
-      if (key === `git -C ${gitRoot} status --porcelain -- :!dist/control-ui/`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${gitRoot} fetch --all --prune --no-tags`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
       if (key === `git -C ${gitRoot} rev-parse refs/remotes/origin/main`) {
         return { stdout: `${targetSha}\n`, stderr: "", code: 0 };
       }
@@ -2286,31 +2152,6 @@ describe("runGatewayUpdate", () => {
       ) {
         await writePreflightPackageManagerFixtureFromWorktreeAdd(key);
         return { stdout: `HEAD is now at ${targetSha}`, stderr: "", code: 0 };
-      }
-      if (
-        key.startsWith("git -C ") &&
-        key.includes(` checkout --detach ${targetSha}`) &&
-        preflightPrefixPattern.test(key)
-      ) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === "pnpm install" || key === "pnpm build" || key === "pnpm lint") {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === "pnpm ui:build") {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === doctorCommand) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (
-        key.startsWith(`git -C ${gitRoot} worktree remove --force `) &&
-        preflightPrefixPattern.test(key)
-      ) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${gitRoot} checkout --detach ${targetSha}`) {
-        return { stdout: "", stderr: "", code: 0 };
       }
       return { stdout: "", stderr: "", code: 0 };
     };
@@ -2328,7 +2169,7 @@ describe("runGatewayUpdate", () => {
 
   it("does not fall back to npm scripts when a pnpm repo cannot bootstrap pnpm", async () => {
     await setupGitPackageManagerFixture();
-    const { calls, runCommand } = await createDevGitRunner({
+    const { calls, runCommand } = createDevGitRunner({
       onCommand: (key) => {
         if (key === "pnpm --version") {
           throw new Error("spawn pnpm ENOENT");
@@ -3052,12 +2893,6 @@ describe("runGatewayUpdate", () => {
         if (key === `git -C ${tempDir} rev-parse --abbrev-ref HEAD`) {
           return toCommandResult({ stdout: "main\n" });
         }
-        if (key === `git -C ${tempDir} status --porcelain -- :!dist/control-ui/`) {
-          return toCommandResult();
-        }
-        if (key === `git -C ${tempDir} fetch --all --prune --tags`) {
-          return toCommandResult();
-        }
         if (key === `git -C ${tempDir} tag --list v* --sort=-v:refname`) {
           return toCommandResult({ stdout: `${stableTag}\n` });
         }
@@ -3065,14 +2900,8 @@ describe("runGatewayUpdate", () => {
           currentHead = targetSha;
           return toCommandResult();
         }
-        if (key === `git -C ${tempDir} checkout --force main`) {
-          return toCommandResult();
-        }
         if (key === `git -C ${tempDir} reset --hard ${beforeSha}`) {
           currentHead = beforeSha;
-          return toCommandResult();
-        }
-        if (key === "pnpm install") {
           return toCommandResult();
         }
         if (key === "pnpm build") {
@@ -3129,7 +2958,7 @@ describe("runGatewayUpdate", () => {
   it("returns the build identity produced by a dev Git update build", async () => {
     await setupGitPackageManagerFixture();
     const buildId = "2026.8.1-target-build";
-    const { runCommand } = await createDevGitRunner({
+    const { runCommand } = createDevGitRunner({
       onCommand: async (key) => {
         if (key === "pnpm build") {
           await fs.mkdir(path.join(tempDir, "dist"), { recursive: true });
@@ -3153,12 +2982,11 @@ describe("runGatewayUpdate", () => {
     "does not return a build identity for a %s Git update",
     async (channel) => {
       await setupGitCheckout({ packageManager: "pnpm@8.0.0" });
-      const uiIndexPath = await setupUiIndex();
+      await setupUiIndex();
       const stableTag = "v1.0.1-1";
       const buildId = "2026.8.1-channel-build";
       const { runCommand } = await createStableTagRunner({
         stableTag,
-        uiIndexPath,
         onBuild: async () => {
           await fs.writeFile(
             path.join(tempDir, "dist", "build-info.json"),
@@ -3185,7 +3013,6 @@ describe("runGatewayUpdate", () => {
       const stableTag = "v1.0.1-1";
       const { runCommand, calls, doctorKey, getUiBuildCount } = await createStableTagRunner({
         stableTag,
-        uiIndexPath,
         onUiBuild: async () => {
           await fs.mkdir(path.dirname(startupAsset), { recursive: true });
           await fs.writeFile(uiIndexPath, '<script src="./assets/startup.js"></script>', "utf-8");
@@ -3223,7 +3050,6 @@ describe("runGatewayUpdate", () => {
       const stableTag = "v1.0.1-1";
       const { runCommand, calls, doctorKey, getUiBuildCount } = await createStableTagRunner({
         stableTag,
-        uiIndexPath,
         onUiBuild: async () => {
           await fs.mkdir(path.dirname(startupAsset), { recursive: true });
           await fs.writeFile(uiIndexPath, '<script src="./assets/startup.js"></script>', "utf-8");
@@ -3248,7 +3074,6 @@ describe("runGatewayUpdate", () => {
       const stableTag = "v1.0.1-1";
       const { runCommand } = await createStableTagRunner({
         stableTag,
-        uiIndexPath,
         onDoctor: removeControlUiAssets,
         onUiBuild: async () => {
           if (repairedBundle === "incomplete") {


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested cleanup of updater test scaffolding. Repeated command branches return the same empty-success response as their existing fallback, obscuring the callbacks, state changes and failures that distinguish each scenario.

## Why This Change Was Made

Remove 40 redundant success branches, four unused Doctor setup bindings, an empty teardown hook and unused fixture plumbing. Make the private command factory synchronous and remove its unnecessary awaits. Reuse the existing fallback; retain the strict unexpected-command dispatcher and every side-effecting or failure-injection branch.

Only `src/infra/update-runner.test.ts` changes: **+16/-191 test lines (175 fewer), production unchanged**. This is AI-assisted maintenance requested by a maintainer, not a product bug fix or a workaround for red CI.

## User Impact

No runtime, update behavior, configuration, dependency or public API changes. All 86 executed cases, 344 assertion expressions and command-order checks remain, including build-identity and declaration-build environment regressions.

## Evidence

Baseline and final candidate both passed the same 86 cases on Node 24.19.0 / pnpm 11.22.0:

```sh
node scripts/run-vitest.mjs src/infra/update-runner.test.ts --reporter=verbose
node scripts/check-changed.mjs --dry-run -- src/infra/update-runner.test.ts
node scripts/check-changed.mjs -- src/infra/update-runner.test.ts
git diff --check
```

The complete 19-stage changed gate passed. An intermediate run rejected 13 awaits after the factory became synchronous; those awaits were removed and the full gate passed. Independent source checks preserved assertions, cases, callbacks, counters, faults and recording order. Five cases use real temporary Git repositories; build and Doctor steps remain mocks, not live-upgrade proof.

[Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33175975855) completed successfully for `0f00aa01bba680ac4c3233a3fc17e9ac590abb7d`. Precommit and separate published-head managed Codex reviews each completed four bounded P0 context passes without findings. The published review's outer closing observer failed after its historical local Node binary disappeared. That failure remains recorded: a later independent audit verified all source/dependency/context bytes, native reviewer identity, four reports and recorded reviewer cleanup. It does not establish continuous presence of the old Node binary or relabel the failed outer run as successful.

Current-main composition preserves every entry except the reviewed test blob. Updater runtime owners and the baseline test are unchanged; relevant caller/test-runner changes and Vite 8.2.2's upstream contracts were inspected. This is static composition evidence, not a newly executed run with the newer dependency.

The latest [ClawSweeper review](https://github.com/openclaw/openclaw/pull/131789#issuecomment-5453270810) found no actionable issue. Its remaining move was normal exact-head CI and maintainer handling, now addressed by the green run and completed maintainer review. Native Testbox preparation and the normal pinned squash merge completed successfully. Landed as [5cb2eee257bc](https://github.com/openclaw/openclaw/commit/5cb2eee257bc9b7363bba70b3eea15a67618c0b7). The actual-parent whole-tree audit verified all 34,690 entries, the sole reviewed test blob, unchanged relevant contexts and the exact +16/-191 patch; the merge is an ancestor of refreshed main. Native worktree, temporary refs, operation lock and remote source branch are gone.

Named follow-up: initial updater Git-preflight command failures warrant reproduction before any production change. This cleanup neither fixes nor establishes that suspected issue.

