### PR TITLE
fix(agents): invalidate advertised MCP catalogs on config changes

### DIFF
--- a/src/agents/agent-bundle-mcp-harness.test.ts
+++ b/src/agents/agent-bundle-mcp-harness.test.ts
@@ -44,15 +44,21 @@ const mocks = vi.hoisted(() => {
     getOrCreateRequesterScopedMcpRuntime: vi.fn(
       async (params: { sessionId: string; requesterSenderId?: string | null }) => {
         if (resolveImpl) {
-          return resolveImpl(params);
+          const runtime = await resolveImpl(params);
+          return runtime
+            ? { runtime, advertisedCatalogConfigFingerprint: runtime.configFingerprint }
+            : undefined;
         }
         return undefined;
       },
     ),
     getOrCreateSessionMcpRuntime: vi.fn(),
     rememberAdvertisedScopedMcpCatalog: vi.fn(
-      (sessionId: string, catalog: typeof advertised extends Map<string, infer V> ? V : never) => {
-        advertised.set(sessionId, catalog);
+      (
+        handle: { runtime: Runtime },
+        catalog: typeof advertised extends Map<string, infer V> ? V : never,
+      ) => {
+        advertised.set(handle.runtime.sessionId, catalog);
       },
     ),
     getAdvertisedScopedMcpCatalog: vi.fn((sessionId: string) => advertised.get(sessionId) ?? null),

--- a/src/agents/agent-bundle-mcp-harness.ts
+++ b/src/agents/agent-bundle-mcp-harness.ts
@@ -289,7 +289,11 @@ export async function materializeRequesterScopedMcpToolsForHarnessRunCore(
       });
       liveCatalog = scopedRuntime.peekCatalog() ?? (await scopedRuntime.getCatalog());
       if (liveCatalog.tools.length > 0) {
-        rememberAdvertisedScopedMcpCatalog(params.sessionId, liveCatalog);
+        rememberAdvertisedScopedMcpCatalog(
+          params.sessionId,
+          liveCatalog,
+          scopedRuntime.advertisedCatalogConfigFingerprint,
+        );
       }
     }
 

--- a/src/agents/agent-bundle-mcp-harness.ts
+++ b/src/agents/agent-bundle-mcp-harness.ts
@@ -265,7 +265,7 @@ export async function materializeStaticMcpToolsForScheduledHarnessRunCore(
 export async function materializeRequesterScopedMcpToolsForHarnessRunCore(
   params: MaterializeRequesterScopedMcpToolsForHarnessRunParams,
 ): Promise<RequesterScopedHarnessMcpTools | undefined> {
-  const scopedRuntime = await getOrCreateRequesterScopedMcpRuntime({
+  const scopedRuntimeHandle = await getOrCreateRequesterScopedMcpRuntime({
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
     workspaceDir: params.workspaceDir,
@@ -277,6 +277,7 @@ export async function materializeRequesterScopedMcpToolsForHarnessRunCore(
     agentAccountId: params.agentAccountId,
     messageChannel: params.messageChannel,
   });
+  const scopedRuntime = scopedRuntimeHandle?.runtime;
 
   let liveRuntime: Awaited<ReturnType<typeof materializeBundleMcpToolsForRun>> | undefined;
   let liveCatalog: McpToolCatalog | undefined;
@@ -288,12 +289,8 @@ export async function materializeRequesterScopedMcpToolsForHarnessRunCore(
         reservedToolNames: params.reservedToolNames,
       });
       liveCatalog = scopedRuntime.peekCatalog() ?? (await scopedRuntime.getCatalog());
-      if (liveCatalog.tools.length > 0) {
-        rememberAdvertisedScopedMcpCatalog(
-          params.sessionId,
-          liveCatalog,
-          scopedRuntime.advertisedCatalogConfigFingerprint,
-        );
+      if (liveCatalog.tools.length > 0 && scopedRuntimeHandle) {
+        rememberAdvertisedScopedMcpCatalog(scopedRuntimeHandle, liveCatalog);
       }
     }
 

--- a/src/agents/agent-bundle-mcp-manager-api.ts
+++ b/src/agents/agent-bundle-mcp-manager-api.ts
@@ -8,6 +8,7 @@ import { createSessionMcpRuntimeManager } from "./agent-bundle-mcp-manager.js";
 import { SESSION_MCP_RUNTIME_MANAGER_KEY } from "./agent-bundle-mcp-runtime-shared.js";
 import type {
   McpToolCatalog,
+  RequesterScopedMcpRuntime,
   SessionMcpRuntime,
   SessionMcpRuntimeManager,
 } from "./agent-bundle-mcp-types.js";
@@ -53,15 +54,20 @@ export async function getOrCreateRequesterScopedMcpRuntime(params: {
   agentAccountId?: string | null;
   messageChannel?: string | null;
   toolOverrides?: Pick<SessionToolOverrides, "mcpServers" | "mcpToolsDeny">;
-}): Promise<SessionMcpRuntime | undefined> {
+}): Promise<RequesterScopedMcpRuntime | undefined> {
   return await getSessionMcpRuntimeManager().getOrCreateRequesterScoped(params);
 }
 
 export function rememberAdvertisedScopedMcpCatalog(
   sessionId: string,
   catalog: McpToolCatalog,
+  configFingerprint: string,
 ): void {
-  getSessionMcpRuntimeManager().rememberAdvertisedScopedCatalog(sessionId, catalog);
+  getSessionMcpRuntimeManager().rememberAdvertisedScopedCatalog(
+    sessionId,
+    catalog,
+    configFingerprint,
+  );
 }
 
 export function getAdvertisedScopedMcpCatalog(sessionId: string): McpToolCatalog | null {

--- a/src/agents/agent-bundle-mcp-manager-api.ts
+++ b/src/agents/agent-bundle-mcp-manager-api.ts
@@ -8,7 +8,7 @@ import { createSessionMcpRuntimeManager } from "./agent-bundle-mcp-manager.js";
 import { SESSION_MCP_RUNTIME_MANAGER_KEY } from "./agent-bundle-mcp-runtime-shared.js";
 import type {
   McpToolCatalog,
-  RequesterScopedMcpRuntime,
+  RequesterScopedMcpRuntimeHandle,
   SessionMcpRuntime,
   SessionMcpRuntimeManager,
 } from "./agent-bundle-mcp-types.js";
@@ -54,20 +54,15 @@ export async function getOrCreateRequesterScopedMcpRuntime(params: {
   agentAccountId?: string | null;
   messageChannel?: string | null;
   toolOverrides?: Pick<SessionToolOverrides, "mcpServers" | "mcpToolsDeny">;
-}): Promise<RequesterScopedMcpRuntime | undefined> {
+}): Promise<RequesterScopedMcpRuntimeHandle | undefined> {
   return await getSessionMcpRuntimeManager().getOrCreateRequesterScoped(params);
 }
 
 export function rememberAdvertisedScopedMcpCatalog(
-  sessionId: string,
+  handle: RequesterScopedMcpRuntimeHandle,
   catalog: McpToolCatalog,
-  configFingerprint: string,
 ): void {
-  getSessionMcpRuntimeManager().rememberAdvertisedScopedCatalog(
-    sessionId,
-    catalog,
-    configFingerprint,
-  );
+  getSessionMcpRuntimeManager().rememberAdvertisedScopedCatalog(handle, catalog);
 }
 
 export function getAdvertisedScopedMcpCatalog(sessionId: string): McpToolCatalog | null {

--- a/src/agents/agent-bundle-mcp-manager-lifecycle.ts
+++ b/src/agents/agent-bundle-mcp-manager-lifecycle.ts
@@ -10,6 +10,7 @@ import type {
   McpCatalogTool,
   McpServerCatalog,
   McpToolCatalog,
+  RequesterScopedMcpRuntimeHandle,
   SessionMcpRuntime,
 } from "./agent-bundle-mcp-types.js";
 
@@ -21,6 +22,7 @@ type ManagerCreateInFlight = {
 };
 
 type AdvertisedScopedCatalogEntry = {
+  configFingerprint: string;
   servers: Map<string, McpServerCatalog>;
   toolsByServer: Map<string, McpCatalogTool[]>;
   signaturesByServer: Map<string, string>;
@@ -34,7 +36,6 @@ type SessionMcpRuntimeManagerStore = {
   requiredRetirementSessionIds: Set<string>;
   connectionMetaByRuntimeKey: Map<string, { connectionHash: string; resolvedAt: number }>;
   advertisedScopedCatalogBySessionId: Map<string, AdvertisedScopedCatalogEntry>;
-  advertisedScopedCatalogConfigFingerprints: Map<string, string>;
   requesterWorkChains: Map<string, Promise<unknown>>;
   createInFlight: Map<string, ManagerCreateInFlight>;
   createRuntime: CreateSessionMcpRuntime;
@@ -84,7 +85,6 @@ export function createSessionMcpRuntimeManagerStore(
      * Codex threads rotate (dynamicToolsFingerprint churn).
      */
     advertisedScopedCatalogBySessionId: new Map(),
-    advertisedScopedCatalogConfigFingerprints: new Map(),
     /**
      * Per-runtimeKey serialization for requester resolve+install and dispose.
      * Sections never overlap for one key, so a slow resolve cannot clobber a newer install.
@@ -120,12 +120,15 @@ export type SessionMcpRuntimeManagerLifecycle = {
     opts?: { preserveRequiredRetirement?: boolean },
   ) => Promise<void>;
   rememberAdvertisedScopedCatalog: (
-    sessionId: string,
+    handle: RequesterScopedMcpRuntimeHandle,
     catalog: McpToolCatalog,
-    configFingerprint: string,
   ) => void;
   getAdvertisedScopedCatalog: (sessionId: string) => McpToolCatalog | null;
-  reconcileAdvertisedScopedCatalogConfig: (sessionId: string, fingerprint: string) => void;
+  reconcileAdvertisedScopedCatalogConfig: (
+    sessionId: string,
+    fingerprint: string,
+    preparePublication: boolean,
+  ) => void;
 };
 
 function scopedCatalogToolsSignature(tools: readonly McpCatalogTool[]): string {
@@ -310,7 +313,6 @@ export function createSessionMcpRuntimeManagerLifecycle(
       store.requiredRetirementSessionIds.delete(sessionId);
     }
     store.advertisedScopedCatalogBySessionId.delete(sessionId);
-    store.advertisedScopedCatalogConfigFingerprints.delete(sessionId);
     const runtimeKeys = new Set(runtimeKeysForSessionId(sessionId));
     for (const runtimeKey of store.createInFlight.keys()) {
       if (parseRuntimeCacheSessionId(runtimeKey) === sessionId) {
@@ -334,23 +336,15 @@ export function createSessionMcpRuntimeManagerLifecycle(
   };
 
   const rememberAdvertisedScopedCatalog = (
-    sessionId: string,
+    handle: RequesterScopedMcpRuntimeHandle,
     catalog: McpToolCatalog,
-    configFingerprint: string,
   ): void => {
+    const { runtime, advertisedCatalogConfigFingerprint } = handle;
     // An older requester may finish after reconciliation; reject its catalog
     // instead of allowing stale tools to repopulate the session cache.
-    if (store.advertisedScopedCatalogConfigFingerprints.get(sessionId) !== configFingerprint) {
+    const entry = store.advertisedScopedCatalogBySessionId.get(runtime.sessionId);
+    if (entry?.configFingerprint !== advertisedCatalogConfigFingerprint) {
       return;
-    }
-    let entry = store.advertisedScopedCatalogBySessionId.get(sessionId);
-    if (!entry) {
-      entry = {
-        servers: new Map(),
-        toolsByServer: new Map(),
-        signaturesByServer: new Map(),
-      };
-      store.advertisedScopedCatalogBySessionId.set(sessionId, entry);
     }
     const toolsByServerName = new Map<string, McpCatalogTool[]>();
     for (const tool of catalog.tools) {
@@ -399,12 +393,21 @@ export function createSessionMcpRuntimeManagerLifecycle(
     };
   };
 
-  const reconcileAdvertisedScopedCatalogConfig = (sessionId: string, fingerprint: string): void => {
-    const previous = store.advertisedScopedCatalogConfigFingerprints.get(sessionId);
-    if (previous !== undefined && previous !== fingerprint) {
-      store.advertisedScopedCatalogBySessionId.delete(sessionId);
+  const reconcileAdvertisedScopedCatalogConfig = (
+    sessionId: string,
+    fingerprint: string,
+    preparePublication: boolean,
+  ): void => {
+    const current = store.advertisedScopedCatalogBySessionId.get(sessionId);
+    if (current?.configFingerprint === fingerprint || (!current && !preparePublication)) {
+      return;
     }
-    store.advertisedScopedCatalogConfigFingerprints.set(sessionId, fingerprint);
+    store.advertisedScopedCatalogBySessionId.set(sessionId, {
+      configFingerprint: fingerprint,
+      servers: new Map(),
+      toolsByServer: new Map(),
+      signaturesByServer: new Map(),
+    });
   };
 
   return {

--- a/src/agents/agent-bundle-mcp-manager-lifecycle.ts
+++ b/src/agents/agent-bundle-mcp-manager-lifecycle.ts
@@ -34,6 +34,7 @@ type SessionMcpRuntimeManagerStore = {
   requiredRetirementSessionIds: Set<string>;
   connectionMetaByRuntimeKey: Map<string, { connectionHash: string; resolvedAt: number }>;
   advertisedScopedCatalogBySessionId: Map<string, AdvertisedScopedCatalogEntry>;
+  advertisedScopedCatalogConfigFingerprints: Map<string, string>;
   requesterWorkChains: Map<string, Promise<unknown>>;
   createInFlight: Map<string, ManagerCreateInFlight>;
   createRuntime: CreateSessionMcpRuntime;
@@ -83,6 +84,7 @@ export function createSessionMcpRuntimeManagerStore(
      * Codex threads rotate (dynamicToolsFingerprint churn).
      */
     advertisedScopedCatalogBySessionId: new Map(),
+    advertisedScopedCatalogConfigFingerprints: new Map(),
     /**
      * Per-runtimeKey serialization for requester resolve+install and dispose.
      * Sections never overlap for one key, so a slow resolve cannot clobber a newer install.
@@ -119,6 +121,7 @@ export type SessionMcpRuntimeManagerLifecycle = {
   ) => Promise<void>;
   rememberAdvertisedScopedCatalog: (sessionId: string, catalog: McpToolCatalog) => void;
   getAdvertisedScopedCatalog: (sessionId: string) => McpToolCatalog | null;
+  reconcileAdvertisedScopedCatalogConfig: (sessionId: string, fingerprint: string) => void;
 };
 
 function scopedCatalogToolsSignature(tools: readonly McpCatalogTool[]): string {
@@ -303,6 +306,7 @@ export function createSessionMcpRuntimeManagerLifecycle(
       store.requiredRetirementSessionIds.delete(sessionId);
     }
     store.advertisedScopedCatalogBySessionId.delete(sessionId);
+    store.advertisedScopedCatalogConfigFingerprints.delete(sessionId);
     const runtimeKeys = new Set(runtimeKeysForSessionId(sessionId));
     for (const runtimeKey of store.createInFlight.keys()) {
       if (parseRuntimeCacheSessionId(runtimeKey) === sessionId) {
@@ -382,6 +386,14 @@ export function createSessionMcpRuntimeManagerLifecycle(
     };
   };
 
+  const reconcileAdvertisedScopedCatalogConfig = (sessionId: string, fingerprint: string): void => {
+    const previous = store.advertisedScopedCatalogConfigFingerprints.get(sessionId);
+    if (previous !== undefined && previous !== fingerprint) {
+      store.advertisedScopedCatalogBySessionId.delete(sessionId);
+    }
+    store.advertisedScopedCatalogConfigFingerprints.set(sessionId, fingerprint);
+  };
+
   return {
     store,
     forgetSessionKeysForSessionId,
@@ -396,5 +408,6 @@ export function createSessionMcpRuntimeManagerLifecycle(
     disposeManagedSession,
     rememberAdvertisedScopedCatalog,
     getAdvertisedScopedCatalog,
+    reconcileAdvertisedScopedCatalogConfig,
   };
 }

--- a/src/agents/agent-bundle-mcp-manager-lifecycle.ts
+++ b/src/agents/agent-bundle-mcp-manager-lifecycle.ts
@@ -119,7 +119,11 @@ export type SessionMcpRuntimeManagerLifecycle = {
     sessionId: string,
     opts?: { preserveRequiredRetirement?: boolean },
   ) => Promise<void>;
-  rememberAdvertisedScopedCatalog: (sessionId: string, catalog: McpToolCatalog) => void;
+  rememberAdvertisedScopedCatalog: (
+    sessionId: string,
+    catalog: McpToolCatalog,
+    configFingerprint: string,
+  ) => void;
   getAdvertisedScopedCatalog: (sessionId: string) => McpToolCatalog | null;
   reconcileAdvertisedScopedCatalogConfig: (sessionId: string, fingerprint: string) => void;
 };
@@ -329,7 +333,16 @@ export function createSessionMcpRuntimeManagerLifecycle(
     forgetSessionKeysForSessionId(sessionId);
   };
 
-  const rememberAdvertisedScopedCatalog = (sessionId: string, catalog: McpToolCatalog): void => {
+  const rememberAdvertisedScopedCatalog = (
+    sessionId: string,
+    catalog: McpToolCatalog,
+    configFingerprint: string,
+  ): void => {
+    // An older requester may finish after reconciliation; reject its catalog
+    // instead of allowing stale tools to repopulate the session cache.
+    if (store.advertisedScopedCatalogConfigFingerprints.get(sessionId) !== configFingerprint) {
+      return;
+    }
     let entry = store.advertisedScopedCatalogBySessionId.get(sessionId);
     if (!entry) {
       entry = {

--- a/src/agents/agent-bundle-mcp-manager.ts
+++ b/src/agents/agent-bundle-mcp-manager.ts
@@ -103,13 +103,14 @@ export function createSessionMcpRuntimeManager(
         store.sessionIdBySessionKey.set(params.sessionKey, params.sessionId);
       }
 
-      const fullConfig = loadSessionMcpConfig({
+      const configParams = {
         workspaceDir: params.workspaceDir,
         cfg: params.cfg,
         logDiagnostics: false,
         manifestRegistry: params.manifestRegistry,
         toolOverrides: params.toolOverrides,
-      });
+      };
+      const fullConfig = loadSessionMcpConfig(configParams);
       // Safe names from the FULL declared set so partial resolution never changes tool names.
       const safeServerNamesByServer = assignSafeServerNames(
         Object.keys(fullConfig.loaded.mcpServers),
@@ -121,18 +122,16 @@ export function createSessionMcpRuntimeManager(
         resolverRequesterServerNames,
       } = partitionMcpServersByConnectionScope(fullConfig.loaded.mcpServers);
       const hasRequesterScoped = requesterScopedServerNames.length > 0;
+      const requesterSenderId = normalizeOptionalString(params.requesterSenderId);
       lifecycle.reconcileAdvertisedScopedCatalogConfig(
         params.sessionId,
         loadSessionMcpConfig({
-          workspaceDir: params.workspaceDir,
-          cfg: params.cfg,
+          ...configParams,
           loaded: fullConfig.loaded,
-          logDiagnostics: false,
-          manifestRegistry: params.manifestRegistry,
           redactConnectionServerNames: new Set(requesterScopedServerNames),
           safeServerNamesByServer,
-          toolOverrides: params.toolOverrides,
         }).fingerprint,
+        hasRequesterScoped && requesterSenderId !== undefined,
       );
 
       if (!hasRequesterScoped) {
@@ -183,7 +182,6 @@ export function createSessionMcpRuntimeManager(
         });
       }
 
-      const requesterSenderId = normalizeOptionalString(params.requesterSenderId);
       if (requesterSenderId) {
         const { runtimeKey, runtime: scopedRuntime } = await materializeRequesterScopedRuntime({
           ...params,
@@ -230,13 +228,14 @@ export function createSessionMcpRuntimeManager(
       // Anonymous turns own no requester runtime; reconcile first so a cached
       // catalog cannot survive a senderless harness turn.
       const requesterSenderId = normalizeOptionalString(params.requesterSenderId);
-      const fullConfig = loadSessionMcpConfig({
+      const configParams = {
         workspaceDir: params.workspaceDir,
         cfg: params.cfg,
         logDiagnostics: false,
         manifestRegistry: params.manifestRegistry,
         toolOverrides: params.toolOverrides,
-      });
+      };
+      const fullConfig = loadSessionMcpConfig(configParams);
       const {
         requesterScopedServerNames,
         oauthRequesterServerNames,
@@ -246,18 +245,15 @@ export function createSessionMcpRuntimeManager(
         Object.keys(fullConfig.loaded.mcpServers),
       );
       const advertisedCatalogConfigFingerprint = loadSessionMcpConfig({
-        workspaceDir: params.workspaceDir,
-        cfg: params.cfg,
+        ...configParams,
         loaded: fullConfig.loaded,
-        logDiagnostics: false,
-        manifestRegistry: params.manifestRegistry,
         redactConnectionServerNames: new Set(requesterScopedServerNames),
         safeServerNamesByServer,
-        toolOverrides: params.toolOverrides,
       }).fingerprint;
       lifecycle.reconcileAdvertisedScopedCatalogConfig(
         params.sessionId,
         advertisedCatalogConfigFingerprint,
+        requesterSenderId !== undefined && requesterScopedServerNames.length > 0,
       );
       if (!requesterSenderId) {
         return undefined;
@@ -280,14 +276,11 @@ export function createSessionMcpRuntimeManager(
         safeServerNamesByServer,
         requesterSenderId,
       });
-      const requesterRuntime = runtime
-        ? Object.assign(runtime, { advertisedCatalogConfigFingerprint })
-        : undefined;
-      if (!requesterRuntime) {
+      if (!runtime) {
         return undefined;
       }
       await lifecycle.enforceRequesterRuntimeCap(params.sessionId, runtimeKey);
-      return requesterRuntime;
+      return { runtime, advertisedCatalogConfigFingerprint };
     },
     rememberAdvertisedScopedCatalog: lifecycle.rememberAdvertisedScopedCatalog,
     getAdvertisedScopedCatalog: lifecycle.getAdvertisedScopedCatalog,
@@ -379,7 +372,6 @@ export function createSessionMcpRuntimeManager(
       store.requiredRetirementSessionIds.clear();
       store.connectionMetaByRuntimeKey.clear();
       store.advertisedScopedCatalogBySessionId.clear();
-      store.advertisedScopedCatalogConfigFingerprints.clear();
       const lateRuntimes = await Promise.all(
         inFlightRuntimes.map(async ({ promise }) => await promise.catch(() => undefined)),
       );

--- a/src/agents/agent-bundle-mcp-manager.ts
+++ b/src/agents/agent-bundle-mcp-manager.ts
@@ -121,6 +121,18 @@ export function createSessionMcpRuntimeManager(
         resolverRequesterServerNames,
       } = partitionMcpServersByConnectionScope(fullConfig.loaded.mcpServers);
       const hasRequesterScoped = requesterScopedServerNames.length > 0;
+      lifecycle.reconcileAdvertisedScopedCatalogConfig(
+        params.sessionId,
+        loadSessionMcpConfig({
+          workspaceDir: params.workspaceDir,
+          cfg: params.cfg,
+          logDiagnostics: false,
+          manifestRegistry: params.manifestRegistry,
+          redactConnectionServerNames: new Set(requesterScopedServerNames),
+          safeServerNamesByServer,
+          toolOverrides: params.toolOverrides,
+        }).fingerprint,
+      );
 
       if (!hasRequesterScoped) {
         return await install.getOrCreateRuntimeEntry({
@@ -243,6 +255,18 @@ export function createSessionMcpRuntimeManager(
       const safeServerNamesByServer = assignSafeServerNames(
         Object.keys(fullConfig.loaded.mcpServers),
       );
+      lifecycle.reconcileAdvertisedScopedCatalogConfig(
+        params.sessionId,
+        loadSessionMcpConfig({
+          workspaceDir: params.workspaceDir,
+          cfg: params.cfg,
+          logDiagnostics: false,
+          manifestRegistry: params.manifestRegistry,
+          redactConnectionServerNames: new Set(requesterScopedServerNames),
+          safeServerNamesByServer,
+          toolOverrides: params.toolOverrides,
+        }).fingerprint,
+      );
       const scopedNameSet = new Set(requesterScopedServerNames);
       const { runtimeKey, runtime } = await materializeRequesterScopedRuntime({
         ...params,
@@ -348,6 +372,7 @@ export function createSessionMcpRuntimeManager(
       store.requiredRetirementSessionIds.clear();
       store.connectionMetaByRuntimeKey.clear();
       store.advertisedScopedCatalogBySessionId.clear();
+      store.advertisedScopedCatalogConfigFingerprints.clear();
       const lateRuntimes = await Promise.all(
         inFlightRuntimes.map(async ({ promise }) => await promise.catch(() => undefined)),
       );

--- a/src/agents/agent-bundle-mcp-manager.ts
+++ b/src/agents/agent-bundle-mcp-manager.ts
@@ -126,6 +126,7 @@ export function createSessionMcpRuntimeManager(
         loadSessionMcpConfig({
           workspaceDir: params.workspaceDir,
           cfg: params.cfg,
+          loaded: fullConfig.loaded,
           logDiagnostics: false,
           manifestRegistry: params.manifestRegistry,
           redactConnectionServerNames: new Set(requesterScopedServerNames),
@@ -226,17 +227,9 @@ export function createSessionMcpRuntimeManager(
       });
     },
     async getOrCreateRequesterScoped(params) {
-      // Anonymous turns own no requester runtime; avoid leaking session keys or
-      // sweeping unrelated runtimes before confirming the requester exists.
+      // Anonymous turns own no requester runtime; reconcile first so a cached
+      // catalog cannot survive a senderless harness turn.
       const requesterSenderId = normalizeOptionalString(params.requesterSenderId);
-      if (!requesterSenderId) {
-        return undefined;
-      }
-      await lifecycle.sweepIdleRuntimes();
-      lifecycle.ensureIdleSweepTimer();
-      if (params.sessionKey) {
-        store.sessionIdBySessionKey.set(params.sessionKey, params.sessionId);
-      }
       const fullConfig = loadSessionMcpConfig({
         workspaceDir: params.workspaceDir,
         cfg: params.cfg,
@@ -249,24 +242,34 @@ export function createSessionMcpRuntimeManager(
         oauthRequesterServerNames,
         resolverRequesterServerNames,
       } = partitionMcpServersByConnectionScope(fullConfig.loaded.mcpServers);
-      if (requesterScopedServerNames.length === 0) {
-        return undefined;
-      }
       const safeServerNamesByServer = assignSafeServerNames(
         Object.keys(fullConfig.loaded.mcpServers),
       );
+      const advertisedCatalogConfigFingerprint = loadSessionMcpConfig({
+        workspaceDir: params.workspaceDir,
+        cfg: params.cfg,
+        loaded: fullConfig.loaded,
+        logDiagnostics: false,
+        manifestRegistry: params.manifestRegistry,
+        redactConnectionServerNames: new Set(requesterScopedServerNames),
+        safeServerNamesByServer,
+        toolOverrides: params.toolOverrides,
+      }).fingerprint;
       lifecycle.reconcileAdvertisedScopedCatalogConfig(
         params.sessionId,
-        loadSessionMcpConfig({
-          workspaceDir: params.workspaceDir,
-          cfg: params.cfg,
-          logDiagnostics: false,
-          manifestRegistry: params.manifestRegistry,
-          redactConnectionServerNames: new Set(requesterScopedServerNames),
-          safeServerNamesByServer,
-          toolOverrides: params.toolOverrides,
-        }).fingerprint,
+        advertisedCatalogConfigFingerprint,
       );
+      if (!requesterSenderId) {
+        return undefined;
+      }
+      await lifecycle.sweepIdleRuntimes();
+      lifecycle.ensureIdleSweepTimer();
+      if (params.sessionKey) {
+        store.sessionIdBySessionKey.set(params.sessionKey, params.sessionId);
+      }
+      if (requesterScopedServerNames.length === 0) {
+        return undefined;
+      }
       const scopedNameSet = new Set(requesterScopedServerNames);
       const { runtimeKey, runtime } = await materializeRequesterScopedRuntime({
         ...params,
@@ -277,10 +280,14 @@ export function createSessionMcpRuntimeManager(
         safeServerNamesByServer,
         requesterSenderId,
       });
-      if (runtime) {
-        await lifecycle.enforceRequesterRuntimeCap(params.sessionId, runtimeKey);
+      const requesterRuntime = runtime
+        ? Object.assign(runtime, { advertisedCatalogConfigFingerprint })
+        : undefined;
+      if (!requesterRuntime) {
+        return undefined;
       }
-      return runtime;
+      await lifecycle.enforceRequesterRuntimeCap(params.sessionId, runtimeKey);
+      return requesterRuntime;
     },
     rememberAdvertisedScopedCatalog: lifecycle.rememberAdvertisedScopedCatalog,
     getAdvertisedScopedCatalog: lifecycle.getAdvertisedScopedCatalog,

--- a/src/agents/agent-bundle-mcp-runtime-config.ts
+++ b/src/agents/agent-bundle-mcp-runtime-config.ts
@@ -79,6 +79,7 @@ function filterMcpServers<T>(
 export function loadSessionMcpConfig(params: {
   workspaceDir: string;
   cfg?: OpenClawConfig;
+  loaded?: LoadedMcpConfig;
   logDiagnostics?: boolean;
   manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
   includeServerNames?: ReadonlySet<string>;
@@ -92,12 +93,14 @@ export function loadSessionMcpConfig(params: {
   loaded: LoadedMcpConfig;
   fingerprint: string;
 } {
-  const loaded = loadEmbeddedAgentMcpConfig({
-    workspaceDir: params.workspaceDir,
-    cfg: params.cfg,
-    manifestRegistry: params.manifestRegistry,
-    toolOverrides: params.toolOverrides,
-  });
+  const loaded =
+    params.loaded ??
+    loadEmbeddedAgentMcpConfig({
+      workspaceDir: params.workspaceDir,
+      cfg: params.cfg,
+      manifestRegistry: params.manifestRegistry,
+      toolOverrides: params.toolOverrides,
+    });
   if (params.logDiagnostics !== false) {
     for (const diagnostic of loaded.diagnostics) {
       logWarn(`bundle-mcp: ${diagnostic.pluginId}: ${diagnostic.message}`);

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -3413,7 +3413,7 @@ describe("requester-scoped MCP connection resolution", () => {
       };
       const getRuntime = () =>
         entrypoint === "requester-only"
-          ? manager.getOrCreateRequesterScoped(params)
+          ? manager.getOrCreateRequesterScoped(params).then((handle) => handle?.runtime)
           : manager.getOrCreate(params);
       try {
         await getRuntime();
@@ -4708,7 +4708,7 @@ describe("requester-scoped MCP connection resolution", () => {
     const scoped = await manager.getOrCreateRequesterScoped(
       makeRequesterParams(sessionId, cfg as never, "sender-a", { sessionKey }),
     );
-    expect(scoped?.requesterScope?.requesterSenderId).toBe("sender-a");
+    expect(scoped?.runtime.requesterScope?.requesterSenderId).toBe("sender-a");
     await vi.waitFor(() =>
       expect(testing.getBookkeepingSizes(manager).requesterWorkChains).toBe(0),
     );
@@ -4792,10 +4792,10 @@ describe("requester-scoped MCP connection resolution", () => {
     const fullRuntimeKey = manager.listRuntimeKeys().find((key) => key.startsWith("{"));
     const requesterOnly = await manager.getOrCreateRequesterScoped(params);
     const requesterOnlyRuntimeKey = manager.listRuntimeKeys().find((key) => key.startsWith("{"));
-    expect(requesterOnly).toBe(full);
+    expect(requesterOnly?.runtime).toBe(full);
     expect(resolveCount).toBe(1);
     expect(requesterOnlyRuntimeKey).toBe(fullRuntimeKey);
-    expect(requesterOnly?.configFingerprint).toBe(full.configFingerprint);
+    expect(requesterOnly?.runtime.configFingerprint).toBe(full.configFingerprint);
     expect(manager.listRuntimeKeys()).toHaveLength(2);
 
     await manager.disposeAll();
@@ -4827,12 +4827,8 @@ describe("requester-scoped MCP connection resolution", () => {
       makeRequesterParams("session-adv", cfg as never, "authed"),
     );
     expect(authed).toBeDefined();
-    const catalog = await authed!.getCatalog();
-    manager.rememberAdvertisedScopedCatalog(
-      "session-adv",
-      catalog,
-      authed!.advertisedCatalogConfigFingerprint,
-    );
+    const catalog = await authed!.runtime.getCatalog();
+    manager.rememberAdvertisedScopedCatalog(authed!, catalog);
 
     const advertised = manager.getAdvertisedScopedCatalog("session-adv");
     expect(advertised?.tools.map((tool) => tool.toolName)).toEqual(["inbox"]);
@@ -4884,11 +4880,7 @@ describe("requester-scoped MCP connection resolution", () => {
     const runtime = await manager.getOrCreateRequesterScoped(
       makeRequesterParams("session-adv-config", cfgA as never, "authed"),
     );
-    manager.rememberAdvertisedScopedCatalog(
-      "session-adv-config",
-      await runtime!.getCatalog(),
-      runtime!.advertisedCatalogConfigFingerprint,
-    );
+    manager.rememberAdvertisedScopedCatalog(runtime!, await runtime!.runtime.getCatalog());
     expect(manager.getAdvertisedScopedCatalog("session-adv-config")?.tools).toHaveLength(1);
 
     await manager.getOrCreateRequesterScoped(
@@ -4926,11 +4918,7 @@ describe("requester-scoped MCP connection resolution", () => {
     const runtime = await manager.getOrCreateRequesterScoped(
       makeRequesterParams("session-adv-removal", scopedConfig as never, "authed"),
     );
-    manager.rememberAdvertisedScopedCatalog(
-      "session-adv-removal",
-      await runtime!.getCatalog(),
-      runtime!.advertisedCatalogConfigFingerprint,
-    );
+    manager.rememberAdvertisedScopedCatalog(runtime!, await runtime!.runtime.getCatalog());
     expect(manager.getAdvertisedScopedCatalog("session-adv-removal")?.tools).toHaveLength(1);
 
     await expect(
@@ -4962,11 +4950,7 @@ describe("requester-scoped MCP connection resolution", () => {
     const runtime = await manager.getOrCreateRequesterScoped(
       makeRequesterParams("session-adv-senderless", scopedConfig as never, "authed"),
     );
-    manager.rememberAdvertisedScopedCatalog(
-      "session-adv-senderless",
-      await runtime!.getCatalog(),
-      runtime!.advertisedCatalogConfigFingerprint,
-    );
+    manager.rememberAdvertisedScopedCatalog(runtime!, await runtime!.runtime.getCatalog());
 
     await expect(
       manager.getOrCreateRequesterScoped(
@@ -4988,11 +4972,13 @@ describe("requester-scoped MCP connection resolution", () => {
     const oldStarted = new Promise<void>((resolve) => {
       markOldStarted = resolve;
     });
+    let resolveCount = 0;
     resolverTesting.setMcpServerConnectionResolversForTest([
       {
         serverName: "user-mail",
-        resolve: async (ctx) => {
-          if (ctx.requesterSenderId === "old") {
+        resolve: async () => {
+          resolveCount += 1;
+          if (resolveCount === 1) {
             markOldStarted();
             await oldResolve;
           }
@@ -5003,30 +4989,35 @@ describe("requester-scoped MCP connection resolution", () => {
     const createRuntime: RuntimeFactory = (params) =>
       makeManagedRuntime(params, [{ toolName: "inbox", description: "read inbox" }], "user-mail");
     const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
-    const scopedConfig = {
-      mcp: { servers: { "user-mail": { transport: "streamable-http" } } },
+    const oldConfig = {
+      mcp: {
+        servers: {
+          "user-mail": { transport: "streamable-http" },
+          shared: { command: "first" },
+        },
+      },
     };
-    const staticConfig = {
-      mcp: { servers: { shared: { command: "true" } } },
+    const newConfig = {
+      mcp: {
+        servers: {
+          "user-mail": { transport: "streamable-http" },
+          shared: { command: "second" },
+        },
+      },
     };
 
     const oldRequest = manager.getOrCreateRequesterScoped(
-      makeRequesterParams("session-adv-race", scopedConfig as never, "old"),
+      makeRequesterParams("session-adv-race", oldConfig as never, "same-requester"),
     );
     await oldStarted;
-    await expect(
-      manager.getOrCreateRequesterScoped(
-        makeRequesterParams("session-adv-race", staticConfig as never, "new"),
-      ),
-    ).resolves.toBeUndefined();
-
+    const newRequest = manager.getOrCreateRequesterScoped(
+      makeRequesterParams("session-adv-race", newConfig as never, "same-requester"),
+    );
     releaseOldResolve();
     const oldRuntime = await oldRequest;
-    manager.rememberAdvertisedScopedCatalog(
-      "session-adv-race",
-      await oldRuntime!.getCatalog(),
-      oldRuntime!.advertisedCatalogConfigFingerprint,
-    );
+    const newRuntime = await newRequest;
+    expect(newRuntime!.runtime).toBe(oldRuntime!.runtime);
+    manager.rememberAdvertisedScopedCatalog(oldRuntime!, await oldRuntime!.runtime.getCatalog());
     expect(manager.getAdvertisedScopedCatalog("session-adv-race")).toBeNull();
   });
 

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -4849,6 +4849,44 @@ describe("requester-scoped MCP connection resolution", () => {
     await manager.disposeSession("session-adv");
     expect(manager.getAdvertisedScopedCatalog("session-adv")).toBeNull();
   });
+
+  it("clears advertised scoped catalog when its MCP config changes", async () => {
+    const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
+    resolverTesting.setMcpServerConnectionResolversForTest([
+      {
+        serverName: "user-mail",
+        resolve: async () => ({ url: "https://mcp.example.test/authed" }),
+      },
+    ]);
+    const createRuntime: RuntimeFactory = (params) =>
+      makeManagedRuntime(params, [{ toolName: "inbox", description: "read inbox" }], "user-mail");
+    const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
+    const cfgA = {
+      mcp: {
+        servers: {
+          "user-mail": { transport: "streamable-http", toolFilter: { include: ["read*"] } },
+        },
+      },
+    };
+    const cfgB = {
+      mcp: {
+        servers: {
+          "user-mail": { transport: "streamable-http", toolFilter: { include: ["send*"] } },
+        },
+      },
+    };
+
+    const runtime = await manager.getOrCreateRequesterScoped(
+      makeRequesterParams("session-adv-config", cfgA as never, "authed"),
+    );
+    manager.rememberAdvertisedScopedCatalog("session-adv-config", await runtime!.getCatalog());
+    expect(manager.getAdvertisedScopedCatalog("session-adv-config")?.tools).toHaveLength(1);
+
+    await manager.getOrCreateRequesterScoped(
+      makeRequesterParams("session-adv-config", cfgB as never, "authed"),
+    );
+    expect(manager.getAdvertisedScopedCatalog("session-adv-config")).toBeNull();
+  });
 });
 
 describe("disposeSession timeout", () => {

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -14,6 +14,7 @@ import {
   useAutoCleanupTempDirTracker,
 } from "../../test/helpers/temp-dir.js";
 import { createCombinedSessionMcpRuntime } from "./agent-bundle-mcp-combined.js";
+import { materializeRequesterScopedMcpToolsForHarnessRunCore } from "./agent-bundle-mcp-harness.js";
 import { runWithSessionMcpRequestSignal } from "./agent-bundle-mcp-request-context.js";
 import {
   completeDeferredSessionMcpRuntimeRetirement,
@@ -4827,7 +4828,11 @@ describe("requester-scoped MCP connection resolution", () => {
     );
     expect(authed).toBeDefined();
     const catalog = await authed!.getCatalog();
-    manager.rememberAdvertisedScopedCatalog("session-adv", catalog);
+    manager.rememberAdvertisedScopedCatalog(
+      "session-adv",
+      catalog,
+      authed!.advertisedCatalogConfigFingerprint,
+    );
 
     const advertised = manager.getAdvertisedScopedCatalog("session-adv");
     expect(advertised?.tools.map((tool) => tool.toolName)).toEqual(["inbox"]);
@@ -4879,7 +4884,11 @@ describe("requester-scoped MCP connection resolution", () => {
     const runtime = await manager.getOrCreateRequesterScoped(
       makeRequesterParams("session-adv-config", cfgA as never, "authed"),
     );
-    manager.rememberAdvertisedScopedCatalog("session-adv-config", await runtime!.getCatalog());
+    manager.rememberAdvertisedScopedCatalog(
+      "session-adv-config",
+      await runtime!.getCatalog(),
+      runtime!.advertisedCatalogConfigFingerprint,
+    );
     expect(manager.getAdvertisedScopedCatalog("session-adv-config")?.tools).toHaveLength(1);
 
     await manager.getOrCreateRequesterScoped(
@@ -4887,6 +4896,237 @@ describe("requester-scoped MCP connection resolution", () => {
     );
     expect(manager.getAdvertisedScopedCatalog("session-adv-config")).toBeNull();
   });
+
+  it("clears advertised scoped catalog when the last scoped server is removed", async () => {
+    const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
+    resolverTesting.setMcpServerConnectionResolversForTest([
+      {
+        serverName: "user-mail",
+        resolve: async () => ({ url: "https://mcp.example.test/authed" }),
+      },
+    ]);
+    const createRuntime: RuntimeFactory = (params) =>
+      makeManagedRuntime(params, [{ toolName: "inbox", description: "read inbox" }], "user-mail");
+    const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
+    const scopedConfig = {
+      mcp: {
+        servers: {
+          "user-mail": { transport: "streamable-http" },
+        },
+      },
+    };
+    const staticConfig = {
+      mcp: {
+        servers: {
+          shared: { command: "true" },
+        },
+      },
+    };
+
+    const runtime = await manager.getOrCreateRequesterScoped(
+      makeRequesterParams("session-adv-removal", scopedConfig as never, "authed"),
+    );
+    manager.rememberAdvertisedScopedCatalog(
+      "session-adv-removal",
+      await runtime!.getCatalog(),
+      runtime!.advertisedCatalogConfigFingerprint,
+    );
+    expect(manager.getAdvertisedScopedCatalog("session-adv-removal")?.tools).toHaveLength(1);
+
+    await expect(
+      manager.getOrCreateRequesterScoped(
+        makeRequesterParams("session-adv-removal", staticConfig as never, "guest"),
+      ),
+    ).resolves.toBeUndefined();
+    expect(manager.getAdvertisedScopedCatalog("session-adv-removal")).toBeNull();
+  });
+
+  it("reconciles cached scoped catalog before a senderless turn", async () => {
+    const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
+    resolverTesting.setMcpServerConnectionResolversForTest([
+      {
+        serverName: "user-mail",
+        resolve: async () => ({ url: "https://mcp.example.test/authed" }),
+      },
+    ]);
+    const createRuntime: RuntimeFactory = (params) =>
+      makeManagedRuntime(params, [{ toolName: "inbox", description: "read inbox" }], "user-mail");
+    const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
+    const scopedConfig = {
+      mcp: { servers: { "user-mail": { transport: "streamable-http" } } },
+    };
+    const staticConfig = {
+      mcp: { servers: { shared: { command: "true" } } },
+    };
+
+    const runtime = await manager.getOrCreateRequesterScoped(
+      makeRequesterParams("session-adv-senderless", scopedConfig as never, "authed"),
+    );
+    manager.rememberAdvertisedScopedCatalog(
+      "session-adv-senderless",
+      await runtime!.getCatalog(),
+      runtime!.advertisedCatalogConfigFingerprint,
+    );
+
+    await expect(
+      manager.getOrCreateRequesterScoped(
+        makeRequesterParams("session-adv-senderless", staticConfig as never, "", {
+          requesterSenderId: undefined,
+        }),
+      ),
+    ).resolves.toBeUndefined();
+    expect(manager.getAdvertisedScopedCatalog("session-adv-senderless")).toBeNull();
+  });
+
+  it("rejects a late catalog publication from an older configuration", async () => {
+    const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
+    let releaseOldResolve!: () => void;
+    const oldResolve = new Promise<void>((resolve) => {
+      releaseOldResolve = resolve;
+    });
+    let markOldStarted!: () => void;
+    const oldStarted = new Promise<void>((resolve) => {
+      markOldStarted = resolve;
+    });
+    resolverTesting.setMcpServerConnectionResolversForTest([
+      {
+        serverName: "user-mail",
+        resolve: async (ctx) => {
+          if (ctx.requesterSenderId === "old") {
+            markOldStarted();
+            await oldResolve;
+          }
+          return { url: "https://mcp.example.test/authed" };
+        },
+      },
+    ]);
+    const createRuntime: RuntimeFactory = (params) =>
+      makeManagedRuntime(params, [{ toolName: "inbox", description: "read inbox" }], "user-mail");
+    const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
+    const scopedConfig = {
+      mcp: { servers: { "user-mail": { transport: "streamable-http" } } },
+    };
+    const staticConfig = {
+      mcp: { servers: { shared: { command: "true" } } },
+    };
+
+    const oldRequest = manager.getOrCreateRequesterScoped(
+      makeRequesterParams("session-adv-race", scopedConfig as never, "old"),
+    );
+    await oldStarted;
+    await expect(
+      manager.getOrCreateRequesterScoped(
+        makeRequesterParams("session-adv-race", staticConfig as never, "new"),
+      ),
+    ).resolves.toBeUndefined();
+
+    releaseOldResolve();
+    const oldRuntime = await oldRequest;
+    manager.rememberAdvertisedScopedCatalog(
+      "session-adv-race",
+      await oldRuntime!.getCatalog(),
+      oldRuntime!.advertisedCatalogConfigFingerprint,
+    );
+    expect(manager.getAdvertisedScopedCatalog("session-adv-race")).toBeNull();
+  });
+
+  it(
+    "clears removed scoped catalog through the harness after a real MCP transport run",
+    { timeout: 15_000 },
+    async () => {
+      const server = http.createServer((request, response) => {
+        if (request.method === "DELETE") {
+          response.writeHead(204).end();
+          return;
+        }
+        if (request.method !== "POST") {
+          response.writeHead(405).end();
+          return;
+        }
+        let body = "";
+        request.setEncoding("utf8");
+        request.on("data", (chunk) => {
+          body += chunk;
+        });
+        request.on("end", () => {
+          const message = JSON.parse(body) as { id?: string | number; method?: string };
+          if (message.method === "notifications/initialized") {
+            response.writeHead(202).end();
+            return;
+          }
+          response.setHeader("content-type", "application/json");
+          response.setHeader("mcp-session-id", "session-proof");
+          response.writeHead(200).end(
+            JSON.stringify(
+              message.method === "initialize"
+                ? {
+                    jsonrpc: "2.0",
+                    id: message.id,
+                    result: {
+                      protocolVersion: "2025-03-26",
+                      capabilities: { tools: {} },
+                      serverInfo: { name: "catalog-proof-server", version: "1.0.0" },
+                    },
+                  }
+                : {
+                    jsonrpc: "2.0",
+                    id: message.id,
+                    result: {
+                      tools: [
+                        {
+                          name: "inbox",
+                          description: "read inbox",
+                          inputSchema: { type: "object", properties: {} },
+                        },
+                      ],
+                    },
+                  },
+            ),
+          );
+        });
+      });
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      const address = server.address() as { port: number };
+      const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
+      resolverTesting.setMcpServerConnectionResolversForTest([
+        {
+          serverName: "user-mail",
+          resolve: async () => ({ url: `http://127.0.0.1:${address.port}/mcp` }),
+        },
+      ]);
+      const scopedConfig = {
+        mcp: { servers: { "user-mail": { transport: "streamable-http" } } },
+      };
+      const staticConfig = {
+        mcp: { servers: { shared: { command: "true" } } },
+      };
+
+      try {
+        const first = await materializeRequesterScopedMcpToolsForHarnessRunCore({
+          sessionId: "session-harness-removal",
+          workspaceDir: "/workspace",
+          cfg: scopedConfig as never,
+          requesterSenderId: "authed",
+        });
+        expect(first?.advertisedTools.map((tool) => tool.name)).toEqual(["user-mail__inbox"]);
+        await first?.dispose();
+
+        const afterRemoval = await materializeRequesterScopedMcpToolsForHarnessRunCore({
+          sessionId: "session-harness-removal",
+          workspaceDir: "/workspace",
+          cfg: staticConfig as never,
+          requesterSenderId: "guest",
+        });
+        expect(afterRemoval).toBeUndefined();
+      } finally {
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
+    },
+  );
 });
 
 describe("disposeSession timeout", () => {

--- a/src/agents/agent-bundle-mcp-types.ts
+++ b/src/agents/agent-bundle-mcp-types.ts
@@ -142,6 +142,11 @@ export type SessionMcpRuntime = {
   dispose: () => Promise<void>;
 };
 
+/** Requester runtime carrying the config version that authorizes catalog publication. */
+export type RequesterScopedMcpRuntime = SessionMcpRuntime & {
+  advertisedCatalogConfigFingerprint: string;
+};
+
 /** Manager for session-scoped MCP runtimes and their idle lifecycle. */
 export type SessionMcpRuntimeManager = {
   getOrCreate: (params: {
@@ -172,12 +177,16 @@ export type SessionMcpRuntimeManager = {
     agentAccountId?: string | null;
     messageChannel?: string | null;
     toolOverrides?: Pick<SessionToolOverrides, "mcpServers" | "mcpToolsDeny">;
-  }) => Promise<SessionMcpRuntime | undefined>;
+  }) => Promise<RequesterScopedMcpRuntime | undefined>;
   /**
    * Session-stable advertised catalog for scoped servers. Used by shared-thread
    * harnesses so dynamic tool specs do not rotate per sender.
    */
-  rememberAdvertisedScopedCatalog: (sessionId: string, catalog: McpToolCatalog) => void;
+  rememberAdvertisedScopedCatalog: (
+    sessionId: string,
+    catalog: McpToolCatalog,
+    configFingerprint: string,
+  ) => void;
   getAdvertisedScopedCatalog: (sessionId: string) => McpToolCatalog | null;
   bindSessionKey: (sessionKey: string, sessionId: string) => void;
   resolveSessionId: (sessionKey: string) => string | undefined;

--- a/src/agents/agent-bundle-mcp-types.ts
+++ b/src/agents/agent-bundle-mcp-types.ts
@@ -142,8 +142,9 @@ export type SessionMcpRuntime = {
   dispose: () => Promise<void>;
 };
 
-/** Requester runtime carrying the config version that authorizes catalog publication. */
-export type RequesterScopedMcpRuntime = SessionMcpRuntime & {
+/** One requester call's runtime and immutable catalog publication version. */
+export type RequesterScopedMcpRuntimeHandle = {
+  runtime: SessionMcpRuntime;
   advertisedCatalogConfigFingerprint: string;
 };
 
@@ -177,15 +178,14 @@ export type SessionMcpRuntimeManager = {
     agentAccountId?: string | null;
     messageChannel?: string | null;
     toolOverrides?: Pick<SessionToolOverrides, "mcpServers" | "mcpToolsDeny">;
-  }) => Promise<RequesterScopedMcpRuntime | undefined>;
+  }) => Promise<RequesterScopedMcpRuntimeHandle | undefined>;
   /**
    * Session-stable advertised catalog for scoped servers. Used by shared-thread
    * harnesses so dynamic tool specs do not rotate per sender.
    */
   rememberAdvertisedScopedCatalog: (
-    sessionId: string,
+    handle: RequesterScopedMcpRuntimeHandle,
     catalog: McpToolCatalog,
-    configFingerprint: string,
   ) => void;
   getAdvertisedScopedCatalog: (sessionId: string) => McpToolCatalog | null;
   bindSessionKey: (sessionKey: string, sessionId: string) => void;


### PR DESCRIPTION
## What Problem This Solves

A session could keep advertising requester-scoped Model Context Protocol (MCP) tools from an older configuration. This happened after the last scoped server was removed, during senderless turns, or when an older catalog request finished late.

## Root Cause

The session MCP manager returned before it reconciled the advertised catalog in two paths. Catalog publication also had no immutable per-call configuration version, so a late request could repopulate stale tools.

## Fix

The session MCP manager now reconciles its catalog before both early returns. It stores the configuration fingerprint with the lifecycle-owned catalog and publishes through one immutable requester handle. A late caller can no longer publish under a newer configuration.

## User Impact

Agents stop seeing stale requester-scoped MCP tools after configuration changes. The stable tool surface still remains shared across senders while the configuration stays unchanged.

## Evidence

- Current main at adf5c6738216 failed the real loopback streamable HTTP MCP transport scenario: the removed scoped tool stayed advertised.
- Repaired exact head a2fbe3ee9a02 passed the same real transport scenario: the harness returned no scoped tool after removal.
- The focused manager and harness suites passed 129 tests on the repaired head.
- Oxfmt, Oxlint, max-lines, assertion safety, conflict markers, and git diff checks passed.

The proof covers the production harness and a real local MCP transport. It does not claim external MCP account behavior.