### PR TITLE
fix(doctor): preserve WhatsApp DM mentions during migration

### DIFF
--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.retired.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.retired.ts
@@ -335,6 +335,7 @@ function migrateFinalLayoutKills(raw: Record<string, unknown>, changes: string[]
     changes.push("Removed messages.removeAckAfterReply; acknowledgements are retained.");
   }
 
+  const legacyWhatsAppAckScopes: Array<{ path: string; scope?: string }> = [];
   visitChannelEntries(raw, "whatsapp", (entry, path) => {
     moveKey(entry, "messagePrefix", "responsePrefix", path, changes);
     const ack = getRecord(entry.ackReaction);
@@ -359,28 +360,47 @@ function migrateFinalLayoutKills(raw: Record<string, unknown>, changes: string[]
             ? identityEmoji
             : "👀";
     }
-    if (messages.ackReactionScope === undefined) {
-      const direct = ack.direct !== false;
-      const group = ack.group ?? "mentions";
-      const scope =
-        direct && group === "always"
-          ? "all"
-          : direct && group === "never"
-            ? "direct"
-            : !direct && group === "always"
-              ? "group-all"
-              : !direct && group === "mentions"
-                ? "group-mentions"
-                : !direct && group === "never"
-                  ? "off"
-                  : undefined;
-      if (scope) {
-        messages.ackReactionScope = scope;
-      }
+    const direct = ack.direct !== false;
+    const group = ack.group ?? "mentions";
+    const scope =
+      direct && group === "always"
+        ? "all"
+        : direct && group === "never"
+          ? "direct"
+          : !direct && group === "always"
+            ? "group-all"
+            : !direct && group === "mentions"
+              ? "group-mentions"
+              : !direct && group === "never"
+                ? "off"
+                : undefined;
+    if (messages.ackReactionScope === undefined && scope) {
+      messages.ackReactionScope = scope;
+    }
+    if (scope || (direct && group === "mentions")) {
+      legacyWhatsAppAckScopes.push({ path: `${path}.ackReaction`, scope });
     }
     delete entry.ackReaction;
     changes.push(`Moved translatable ${path}.ackReaction settings to messages ack settings.`);
   });
+  // Root and account settings collapse into one global scope. Compare after the
+  // traversal so every discarded intent is reported against the final value.
+  const finalScope = messages?.ackReactionScope ?? "group-mentions";
+  const comparableFinalScope = finalScope === "none" ? "off" : finalScope;
+  for (const source of legacyWhatsAppAckScopes) {
+    if (source.scope === comparableFinalScope) {
+      continue;
+    }
+    if (source.scope) {
+      changes.push(
+        `${source.path} requested ${JSON.stringify(source.scope)}, but final messages.ackReactionScope is ${JSON.stringify(finalScope)}; review the global scope if this source should win.`,
+      );
+    } else {
+      changes.push(
+        `${source.path} cannot represent direct messages plus mentioned groups in messages.ackReactionScope; final scope is ${JSON.stringify(finalScope)}; use "direct" to keep direct messages only, or "all" to keep direct messages and acknowledge every group message.`,
+      );
+    }
+  }
 
   visitChannelEntries(raw, "slack", (entry, path) => {
     const socketMode = getRecord(entry.socketMode);

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.retired.whatsapp-ack.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.retired.whatsapp-ack.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { LEGACY_CONFIG_MIGRATIONS_RUNTIME_RETIRED } from "./legacy-config-migrations.runtime.retired.js";
+
+function applyRetired(raw: Record<string, unknown>) {
+  const changes: string[] = [];
+  for (const migration of LEGACY_CONFIG_MIGRATIONS_RUNTIME_RETIRED) {
+    migration.apply(raw, changes);
+  }
+  return { raw, changes };
+}
+
+function whatsappAckConfig(params: {
+  root: Record<string, unknown>;
+  account?: Record<string, unknown>;
+  scope?: string;
+}): Record<string, unknown> {
+  return {
+    ...(params.scope ? { messages: { ackReactionScope: params.scope } } : {}),
+    channels: {
+      whatsapp: {
+        ackReaction: params.root,
+        ...(params.account ? { accounts: { work: { ackReaction: params.account } } } : {}),
+      },
+    },
+  };
+}
+
+describe("retired WhatsApp ack reaction migration", () => {
+  it.each([
+    ["explicit", { emoji: "eyes", direct: true, group: "mentions" }],
+    ["implicit", { emoji: "eyes" }],
+  ])("reports the %s unrepresentable legacy defaults", (_name, ackReaction) => {
+    const result = applyRetired(whatsappAckConfig({ root: ackReaction }));
+
+    expect(result.raw).not.toHaveProperty("channels.whatsapp.ackReaction");
+    expect(result.raw).not.toHaveProperty("messages.ackReactionScope");
+    const warning = result.changes.find((change) => change.includes("cannot represent"));
+    expect(warning).toContain("channels.whatsapp.ackReaction");
+    expect(warning).toContain('final scope is "group-mentions"');
+    expect(warning).toContain('use "direct"');
+    expect(warning).toContain('or "all"');
+  });
+
+  it("reports a representable account scope discarded by the root scope", () => {
+    const result = applyRetired(
+      whatsappAckConfig({
+        root: { direct: false, group: "always" },
+        account: { direct: true, group: "never" },
+      }),
+    );
+
+    expect(result.raw).toHaveProperty("messages.ackReactionScope", "group-all");
+    expect(result.changes.join("\n")).toContain(
+      'channels.whatsapp.accounts.work.ackReaction requested "direct", but final messages.ackReactionScope is "group-all"',
+    );
+  });
+
+  it("reports a representable legacy scope discarded by a canonical scope", () => {
+    const result = applyRetired(
+      whatsappAckConfig({
+        root: { direct: true, group: "never" },
+        scope: "group-mentions",
+      }),
+    );
+
+    expect(result.raw).toHaveProperty("messages.ackReactionScope", "group-mentions");
+    expect(result.changes.join("\n")).toContain(
+      'channels.whatsapp.ackReaction requested "direct", but final messages.ackReactionScope is "group-mentions"',
+    );
+  });
+
+  it.each([
+    ["matching scopes", "direct", { direct: true, group: "never" }],
+    ["equivalent disabled scopes", "none", { direct: false, group: "never" }],
+  ])("keeps %s quiet", (_name, scope, ackReaction) => {
+    const result = applyRetired(whatsappAckConfig({ root: ackReaction, scope }));
+
+    expect(result.raw).toHaveProperty("messages.ackReactionScope", scope);
+    expect(result.changes).toEqual([
+      "Moved translatable channels.whatsapp.ackReaction settings to messages ack settings.",
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #131787

## What Problem This Solves

Fixes an issue where upgrading users with the legacy WhatsApp default acknowledgement policy would silently lose DM acknowledgements when Doctor migrated their config. The legacy combination acknowledges DMs plus mentioned groups, but the shared scope has no exact equivalent and Doctor previously deleted the source while reporting only a clean move.

## Why This Change Was Made

The Doctor migration now records every root/account acknowledgement intent, preserves the existing canonical scope selection, and reports any intent that the final global scope cannot represent. The diagnostic names the `direct` versus `all` recovery choice; equivalent `off` and `none` scopes remain quiet.

## User Impact

Doctor now tells operators when WhatsApp acknowledgement behavior will narrow or conflict during migration and gives an actionable scope choice. Persisted scope selection and runtime behavior are otherwise unchanged.

## Evidence

- Before: the focused regression had 4 failures and 2 passes. Both explicit and implicit `direct + mentions` cases had no `cannot represent` diagnostic, and root/account plus canonical conflicts had no discarded-scope diagnostic.
- After: `node scripts/run-vitest.mjs src/commands/doctor/shared/legacy-config-migrations.runtime.retired.whatsapp-ack.test.ts src/commands/doctor/shared/legacy-config-migrations.runtime.retired.test.ts` passed 108/108.
- `node scripts/check-changed.mjs` passed on rebased head `dcedc40ab24`.
- Exact owner refs: `src/commands/doctor/shared/legacy-config-migrations.runtime.retired.ts:338-402`; regression coverage: `src/commands/doctor/shared/legacy-config-migrations.runtime.retired.whatsapp-ack.test.ts:1-83`.
- Provenance: granular behavior originated in `2daead27cf22d5f81a180b1d19a68c95ec4e403a`; the lossy migration originated in `edecdbd05efc98c4f580309ac89e8459462f00c9`.
- A second independent adversarial review attempted to refute the analysis and confirmed the bug. A separate final diff review confirmed the regression fails pre-fix for the intended missing-diagnostic reason.
