### PR TITLE
fix(release): pin publish children to approved tooling

### DIFF
--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -1003,25 +1003,79 @@ jobs:
         id: clawhub_plan
         env:
           TARGET_SHA: ${{ needs.resolve_release_target.outputs.sha }}
-          BOOTSTRAP_WORKFLOW_REF: ${{ startsWith(github.ref, 'refs/tags/release-publish/') && github.ref_name || 'main' }}
           GH_TOKEN: ${{ github.token }}
           PARENT_WORKFLOW_BRANCH: ${{ github.ref_name }}
           RELEASE_TAG: ${{ inputs.tag }}
           PLUGIN_PUBLISH_SCOPE: ${{ inputs.plugin_publish_scope }}
           PLUGINS: ${{ inputs.plugins }}
+          WORKFLOW_FULL_REF: ${{ github.ref }}
         run: |
           set -euo pipefail
-          plan_path="${RUNNER_TEMP}/openclaw-release-clawhub-plan.json"
-          if [[ "${BOOTSTRAP_WORKFLOW_REF}" == "main" ]]; then
+
+          resolve_child_workflow_ref() {
+            local workflow_full_ref="$1"
+            local workflow_sha="$2"
+            local workflow_prefix="${workflow_sha:0:12}"
+            local child_workflow_ref matching_ref_prefix matching_refs
+
+            if [[ "${workflow_full_ref}" =~ ^refs/tags/(release-publish/[a-f0-9]{12}-[1-9][0-9]*)$ ]]; then
+              # Request validation already proves this is the exact live
+              # lightweight tag; dispatch revalidates it immediately before use.
+              printf '%s\n' "${BASH_REMATCH[1]}"
+              return 0
+            fi
+
+            if [[ "${workflow_full_ref}" =~ ^refs/heads/(tideclaw/alpha/[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4}Z)$ ]]; then
+              printf '%s\n' "${BASH_REMATCH[1]}"
+              return 0
+            fi
+
+            if [[ "${workflow_full_ref}" != "refs/heads/main" ]]; then
+              echo "Publish children require trusted main, a protected release-publish tag, or a validated Tideclaw alpha branch." >&2
+              return 1
+            fi
+
+            matching_ref_prefix="$(
+              jq -rn --arg value "tags/release-publish/${workflow_prefix}-" '$value | @uri'
+            )"
+            matching_refs="$(
+              gh api "repos/${GITHUB_REPOSITORY}/git/matching-refs/${matching_ref_prefix}"
+            )"
+            if ! child_workflow_ref="$(
+              jq -er \
+                --arg prefix "${workflow_prefix}" \
+                --arg sha "${workflow_sha}" \
+                '[.[] |
+                  select(.ref | test("^refs/tags/release-publish/" + $prefix + "-[1-9][0-9]*$")) |
+                  select(.object.type == "commit" and .object.sha == $sha) |
+                  .ref | sub("^refs/tags/"; "")
+                ] | sort | last | select(type == "string" and length > 0)' \
+                <<<"${matching_refs}"
+            )"; then
+              echo "Trusted main publication requires a direct protected release-publish tag for ${workflow_sha}." >&2
+              return 1
+            fi
+            printf '%s\n' "${child_workflow_ref}"
+          }
+
+          # Regular publication binds every child to the exact parent revision.
+          # Tideclaw retains its validated branch child and main bootstrap split.
+          CHILD_WORKFLOW_REF="$(
+            resolve_child_workflow_ref "${WORKFLOW_FULL_REF}" "${GITHUB_SHA}"
+          )"
+          if [[ "${WORKFLOW_FULL_REF}" == refs/heads/tideclaw/alpha/* ]]; then
+            BOOTSTRAP_WORKFLOW_REF="main"
             bootstrap_workflow_sha="$(
               gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" \
                 --jq '.object.sha | select(test("^[a-f0-9]{40}$"))'
             )"
           else
-            # Protected release-publish tags bind every child to this exact
-            # parent revision, so unrelated main movement cannot change tooling.
+            BOOTSTRAP_WORKFLOW_REF="${CHILD_WORKFLOW_REF}"
             bootstrap_workflow_sha="${GITHUB_SHA}"
           fi
+          echo "child_workflow_ref=${CHILD_WORKFLOW_REF}" >> "${GITHUB_OUTPUT}"
+
+          plan_path="${RUNNER_TEMP}/openclaw-release-clawhub-plan.json"
           plan_args=(
             --bootstrap-workflow-ref "${BOOTSTRAP_WORKFLOW_REF}"
             --bootstrap-workflow-sha "${bootstrap_workflow_sha}"
@@ -1177,7 +1231,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TARGET_SHA: ${{ needs.resolve_release_target.outputs.sha }}
-          CHILD_WORKFLOW_REF: ${{ github.ref_name }}
+          CHILD_WORKFLOW_REF: ${{ steps.clawhub_plan.outputs.child_workflow_ref }}
           PARENT_WORKFLOW_SHA: ${{ github.sha }}
           PARENT_WORKFLOW_BRANCH: ${{ github.ref_name }}
           RELEASE_TAG: ${{ inputs.tag }}

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1060,6 +1060,48 @@ function runReleasePublishInputValidation(overrides: Record<string, string>) {
   });
 }
 
+function runReleasePublishChildWorkflowRef(overrides: Record<string, string> = {}) {
+  const job = workflowJob(RELEASE_PUBLISH_WORKFLOW, "publish");
+  const script = workflowStep(job, "Resolve ClawHub release plan").run;
+  if (!script) {
+    throw new Error("Expected ClawHub release plan script");
+  }
+  const workdir = tempDirs.make("release-publish-child-ref-");
+  const ghPath = resolve(workdir, "gh");
+  writeFileSync(
+    ghPath,
+    `#!/usr/bin/env bash
+set -euo pipefail
+case "$2" in
+  */git/matching-refs/*)
+    printf '%s\n' "$MOCK_MATCHING_REFS"
+    ;;
+  *)
+    exit 64
+    ;;
+esac
+`,
+    { mode: 0o755 },
+  );
+  const resolveChildRef = shellFunctionSource(script, "resolve_child_workflow_ref");
+  return spawnSync(
+    "bash",
+    ["-c", `${resolveChildRef}\nresolve_child_workflow_ref "$WORKFLOW_FULL_REF" "$WORKFLOW_SHA"`],
+    {
+      cwd: workdir,
+      encoding: "utf8",
+      env: {
+        GITHUB_REPOSITORY: "openclaw/openclaw",
+        MOCK_MATCHING_REFS: "[]",
+        PATH: `${workdir}:${process.env.PATH}`,
+        WORKFLOW_FULL_REF: "refs/heads/main",
+        WORKFLOW_SHA: "a".repeat(40),
+        ...overrides,
+      },
+    },
+  );
+}
+
 function runOpenClawNpmTrustedRefGuard(overrides: Record<string, string>) {
   const job = workflowJob(OPENCLAW_NPM_RELEASE_WORKFLOW, "validate_publish_request");
   const script = workflowStep(job, "Require trusted workflow ref for publish").run;
@@ -1696,6 +1738,91 @@ describe("package acceptance workflow", () => {
     );
   });
 
+  it("binds trusted-main publish children to an exact lightweight protected tag", () => {
+    const workflowSha = "a".repeat(40);
+    const workflowRef = `release-publish/${workflowSha.slice(0, 12)}-123`;
+    const validRef = {
+      object: { sha: workflowSha, type: "commit" },
+      ref: `refs/tags/${workflowRef}`,
+    };
+
+    const main = runReleasePublishChildWorkflowRef({
+      MOCK_MATCHING_REFS: JSON.stringify([validRef]),
+      WORKFLOW_SHA: workflowSha,
+    });
+    expect(main.status, main.stderr).toBe(0);
+    expect(main.stdout.trim()).toBe(workflowRef);
+
+    const protectedTag = runReleasePublishChildWorkflowRef({
+      WORKFLOW_FULL_REF: `refs/tags/${workflowRef}`,
+      WORKFLOW_SHA: workflowSha,
+    });
+    expect(protectedTag.status, protectedTag.stderr).toBe(0);
+    expect(protectedTag.stdout.trim()).toBe(workflowRef);
+
+    const alphaRef = "tideclaw/alpha/2026-08-28-1400Z";
+    const alpha = runReleasePublishChildWorkflowRef({
+      WORKFLOW_FULL_REF: `refs/heads/${alphaRef}`,
+      WORKFLOW_SHA: workflowSha,
+    });
+    expect(alpha.status, alpha.stderr).toBe(0);
+    expect(alpha.stdout.trim()).toBe(alphaRef);
+
+    const plan = workflowStep(
+      workflowJob(RELEASE_PUBLISH_WORKFLOW, "publish"),
+      "Resolve ClawHub release plan",
+    ).run;
+    expectTextToIncludeAll(plan, [
+      'if [[ "${WORKFLOW_FULL_REF}" == refs/heads/tideclaw/alpha/* ]]',
+      'BOOTSTRAP_WORKFLOW_REF="main"',
+      'gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main"',
+      'BOOTSTRAP_WORKFLOW_REF="${CHILD_WORKFLOW_REF}"',
+    ]);
+  });
+
+  it.each([
+    {
+      name: "missing tag",
+      refs: [],
+    },
+    {
+      name: "malformed tag",
+      refs: [
+        {
+          object: { sha: "a".repeat(40), type: "commit" },
+          ref: `refs/tags/release-publish/${"a".repeat(12)}-latest`,
+        },
+      ],
+    },
+    {
+      name: "annotated tag",
+      refs: [
+        {
+          object: { sha: "a".repeat(40), type: "tag" },
+          ref: `refs/tags/release-publish/${"a".repeat(12)}-123`,
+        },
+      ],
+    },
+    {
+      name: "moved tag",
+      refs: [
+        {
+          object: { sha: "b".repeat(40), type: "commit" },
+          ref: `refs/tags/release-publish/${"a".repeat(12)}-123`,
+        },
+      ],
+    },
+  ])("rejects $name as a trusted-main child workflow ref", ({ refs }) => {
+    const result = runReleasePublishChildWorkflowRef({
+      MOCK_MATCHING_REFS: JSON.stringify(refs),
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "Trusted main publication requires a direct protected release-publish tag",
+    );
+  });
+
   it("allows protected SHA-pinned tooling tags through the core npm publish guard", () => {
     const workflowSha = "a".repeat(40);
     const protectedRef = `refs/tags/release-publish/${workflowSha.slice(0, 12)}-123`;
@@ -2082,7 +2209,9 @@ describe("package acceptance workflow", () => {
     }
 
     expect(publishOrchestration.env?.PARENT_WORKFLOW_SHA).toBe("${{ github.sha }}");
-    expect(publishOrchestration.env?.CHILD_WORKFLOW_REF).toBe("${{ github.ref_name }}");
+    expect(publishOrchestration.env?.CHILD_WORKFLOW_REF).toBe(
+      "${{ steps.clawhub_plan.outputs.child_workflow_ref }}",
+    );
     expect(readFileSync(RELEASE_PUBLISH_WORKFLOW, "utf8")).toContain(
       "otherwise approve and monitor the detached runs separately",
     );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an approved OpenClaw release publish could fail before dispatching any child workflows when `main` advanced between release approval and child dispatch.

The failure reproduced in OpenClaw Release Publish run 33176344051, job 98866147731:
`Trusted main moved from approved ClawHub bootstrap workflow SHA ...; rerun release approval.`

## Why This Change Was Made

Trusted-main publication now resolves an existing direct lightweight `release-publish/<sha12>-<epoch>` tag for the parent workflow SHA and uses that immutable ref for every publish child. Missing, malformed, annotated, or moved tags fail closed. Parent approval identity remains the trusted `main` run and release candidate bytes are unchanged.

Tideclaw alpha keeps its validated split: publish children run from the exact alpha branch while ClawHub bootstrap resolves trusted `main`. This preserves the existing alpha contract instead of requiring a regular-release protected tag.

## User Impact

Release operators can approve and publish an immutable candidate without unrelated `main` movement invalidating child workflow identity after approval.

## Evidence

- Pre-fix focused regression: 6 failures, including missing resolver and moving `${{ github.ref_name }}` child ref.
- Post-fix focused regression: 6/6 passed, including the Tideclaw alpha child/main-bootstrap split.
- Full owning suite: `test/scripts/package-acceptance-workflow.test.ts` 205/205 passed.
- `actionlint .github/workflows/openclaw-release-publish.yml`
- `pnpm format:check --no-error-on-unmatched-pattern -- .github/workflows/openclaw-release-publish.yml test/scripts/package-acceptance-workflow.test.ts`
- Live GitHub matching-ref proof returned `release-publish/17a1225314cd-1787924262` as a direct commit ref at the exact parent SHA.
- ClawSweeper P1 accepted and repaired: Tideclaw alpha remains supported without weakening regular-release immutable child identity.
- `check:changed` passed every completed guard; root test typecheck could not complete in the sparse GWT because unrelated Android, QA, and UI config sources are intentionally omitted. Exact-head CI owns that full-checkout proof.

- [x] AI-assisted
