### PR TITLE
fix(ai): honor supportsPromptCacheKey false on azure responses requests

### DIFF
--- a/packages/ai/src/providers/azure-openai-responses.test.ts
+++ b/packages/ai/src/providers/azure-openai-responses.test.ts
@@ -164,6 +164,51 @@ describe("azure-openai-responses", () => {
     }
   });
 
+  it("omits prompt_cache_key when the model declares supportsPromptCacheKey false", async () => {
+    let sentParams: { prompt_cache_key?: unknown } | undefined;
+    const hostFetch: typeof fetch = async (input, init) => {
+      sentParams = (await new Request(input, init).json()) as typeof sentParams;
+      return Response.json({ error: { message: "captured" } }, { status: 400 });
+    };
+
+    configureAiTransportHost({ buildModelFetch: () => hostFetch });
+    try {
+      await streamSimpleAzureOpenAIResponses(
+        { ...azureResponsesModel, compat: { supportsPromptCacheKey: false } },
+        context,
+        { apiKey: "test-api-key", sessionId: "cache-key-session" },
+      ).result();
+
+      expect(sentParams).not.toHaveProperty("prompt_cache_key");
+    } finally {
+      configureAiTransportHost({});
+    }
+  });
+
+  it("keeps prompt_cache_key by default and on explicit compat support", async () => {
+    const collect = async (compat?: { supportsPromptCacheKey?: boolean }) => {
+      let sentParams: { prompt_cache_key?: unknown } | undefined;
+      const hostFetch: typeof fetch = async (input, init) => {
+        sentParams = (await new Request(input, init).json()) as typeof sentParams;
+        return Response.json({ error: { message: "captured" } }, { status: 400 });
+      };
+      configureAiTransportHost({ buildModelFetch: () => hostFetch });
+      try {
+        await streamSimpleAzureOpenAIResponses(
+          compat ? { ...azureResponsesModel, compat } : azureResponsesModel,
+          context,
+          { apiKey: "test-api-key", sessionId: "cache-key-session" },
+        ).result();
+      } finally {
+        configureAiTransportHost({});
+      }
+      return sentParams?.prompt_cache_key;
+    };
+
+    await expect(collect()).resolves.toBe("cache-key-session");
+    await expect(collect({ supportsPromptCacheKey: true })).resolves.toBe("cache-key-session");
+  });
+
   it("fences compaction replay by the resolved Azure endpoint", async () => {
     const routeA = "https://route-a.openai.azure.com/openai/v1";
     const routeB = "https://route-b.openai.azure.com/openai/v1";

--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -6,6 +6,7 @@ import { getAiTransportHost } from "../host.js";
 import type { BaseOpenAIStreamOptions } from "../provider-options.js";
 import type { OpenAIResponsesReplayMode } from "../transports/openai-responses-compaction-replay.js";
 import type { OpenAIResponsesRequestParams } from "../transports/openai-responses-contracts.js";
+import { readCompatPayloadBoolean } from "../transports/openai-responses-payload-policy.js";
 import type { Context, Model, SimpleStreamOptions, StreamFunction } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { resolveAzureDeploymentNameFromMap } from "./azure-deployment-map.js";
@@ -227,14 +228,19 @@ function buildParams(
     replayMode,
   });
 
+  // An explicit false compat declaration is a documented endpoint contract, not a default:
+  // unsupported Azure deployments reject prompt_cache_key with a 400 for otherwise valid requests.
+  const omitPromptCacheKey =
+    options?.cacheRetention === "none" ||
+    readCompatPayloadBoolean(model.compat, "supportsPromptCacheKey") === false;
+
   const params: ResponseCreateParamsStreaming & OpenAIResponsesRequestParams = {
     model: deploymentName,
     input: messages,
     stream: true,
-    prompt_cache_key:
-      options?.cacheRetention === "none"
-        ? undefined
-        : clampOpenAIPromptCacheKey(options?.promptCacheKey ?? options?.sessionId),
+    prompt_cache_key: omitPromptCacheKey
+      ? undefined
+      : clampOpenAIPromptCacheKey(options?.promptCacheKey ?? options?.sessionId),
     store: false,
   };
 

--- a/packages/ai/src/transports/openai-responses-payload-policy.ts
+++ b/packages/ai/src/transports/openai-responses-payload-policy.ts
@@ -217,7 +217,7 @@ function isOpenAIResponsesApi(api: string | undefined): boolean {
   return api !== undefined && OPENAI_RESPONSES_APIS.has(api);
 }
 
-function readCompatPayloadBoolean(
+export function readCompatPayloadBoolean(
   compat: unknown,
   key: "supportsInstructions" | "supportsPromptCacheKey" | "supportsStore",
 ): boolean | undefined {


### PR DESCRIPTION
## What Problem This Solves

Fixes #102907.

The Azure Responses producer (`buildParams`, shared by both `streamAzureOpenAIResponses` and `streamSimpleAzureOpenAIResponses`) emits `prompt_cache_key` unconditionally — only `cacheRetention: "none"` suppresses it. Azure deployments whose API version does not support the field reject the whole request with a 400, so a standard completion fails until the operator disables caching outright.

`compat.supportsPromptCacheKey` already exists as a documented per-model opt-out, and the shared Responses payload policy already honors it (`readCompatPayloadBoolean(model.compat, "supportsPromptCacheKey")` -> `shouldStripResponsesPromptCache`, `packages/ai/src/transports/openai-responses-payload-policy.ts:270`). The Azure request path is the only Responses producer that ignores the declaration — the chat-completions producer reads the same compat flag (`packages/ai/src/providers/openai-completions.ts:386-389`).

## Why This Change Was Made

The repair reuses the existing capability declaration rather than adding a configuration option or an Azure-wide heuristic: when a model declares `supportsPromptCacheKey: false`, the producer now omits `prompt_cache_key`, exactly as the shared policy and the completions path already do for the same declaration. The helper is the policy module's existing `readCompatPayloadBoolean`, now exported instead of duplicated into the provider.

Default behavior is unchanged: models with no compat declaration, or with `supportsPromptCacheKey: true`, keep emitting `prompt_cache_key` as before. This deliberately does not touch the policy-level `enablePromptCacheStripping` path (which no caller enables today) — changing stripping defaults for proxy-like endpoints is Azure-wide behavior work that needs its own endpoint/API-version contract evidence, per the review guidance on the issue.

**Production LOC delta:** +9/-3 in the producer (a named `omitPromptCacheKey` boolean folding one more clause into the existing suppression condition) plus exporting an existing private helper (+1/-1). The absorbed alternative would be teaching the payload policy to strip after the fact, but that requires enabling a currently-dead stripping switch for all Responses providers — a wider behavior change than the contract repair the issue asks for.

## User Impact

- Operators pointing OpenClaw at an Azure deployment whose endpoint rejects `prompt_cache_key` can set `compat.supportsPromptCacheKey: false` on the model and the request succeeds, with no change to caching behavior on endpoints that support the field.
- No model with an explicit `true` or no declaration sees any request change.

## Evidence

**Source-level repro, matching the issue's report:** the Azure request builder emitted `prompt_cache_key` for a model declaring `supportsPromptCacheKey: false`.

**Regression tests** (`packages/ai/src/providers/azure-openai-responses.test.ts`), driven through the real request path with a transport-host fetch capture:

- *"omits prompt_cache_key when the model declares supportsPromptCacheKey false"* — asserts the sent request body has no `prompt_cache_key` even with a `sessionId` that would otherwise clamp into the field. **Failed on pre-fix code** (the field was still sent) and passes after.
- *"keeps prompt_cache_key by default and on explicit compat support"* — both the no-declaration and `supportsPromptCacheKey: true` cases still send the clamped session key, pinning default behavior.

**Sibling coverage:** `openai-responses-payload-policy.test.ts` (the module whose private helper is now exported) passes unchanged; the two Azure stream functions share one `buildParams`, so both producers are covered by the same payload-level assertions.

**Checks:** `oxfmt` formatted; `oxlint` clean on touched files; scoped suites green locally.
