### PR TITLE
fix(message): honor explicit top-level sends

### DIFF
--- a/packages/gateway-protocol/src/schema/agent.ts
+++ b/packages/gateway-protocol/src/schema/agent.ts
@@ -148,6 +148,8 @@ export const SendParamsSchema = closedObject({
   replyToId: Type.Optional(Type.String()),
   /** Thread id (channel-specific meaning, e.g. Telegram forum topic id). */
   threadId: Type.Optional(Type.String()),
+  /** Explicitly suppress inherited thread placement and send to the channel root. */
+  topLevel: Type.Optional(Type.Boolean()),
   /** Force document-style media sends where supported. */
   forceDocument: Type.Optional(Type.Boolean()),
   /** Send silently (no notification) where supported. */

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -2734,6 +2734,33 @@ describe("gateway send mirroring", () => {
     expect(deliveryCall()?.threadId).toBe("1710000000.9999");
   });
 
+  it("suppresses inherited thread and session routing for an explicit top-level send", async () => {
+    registerMessageThreadAddressingPlugin("slack");
+    mockDeliverySuccess("m-top-level");
+    mocks.resolveOutboundSessionRoute.mockResolvedValueOnce({
+      sessionKey: "agent:main:slack:channel:c2",
+      baseSessionKey: "agent:main:slack:channel:c2",
+      peer: { kind: "channel", id: "c2" },
+      chatType: "channel",
+      from: "slack:channel:C2",
+      to: "channel:C2",
+    });
+
+    await runSend({
+      to: "channel:C2",
+      message: "new root",
+      channel: "slack",
+      sessionKey: "agent:main:slack:channel:c1:thread:1710000000.9999",
+      topLevel: true,
+      idempotencyKey: "idem-top-level",
+    });
+
+    expect(outboundRouteCall()?.currentSessionKey).toBeUndefined();
+    expect(deliveryCall()?.threadId).toBeNull();
+    expect(deliveryCall()?.session?.key).toBe("agent:main:slack:channel:c2");
+    expect(deliveryCall()?.mirror?.sessionKey).toBe("agent:main:slack:channel:c2");
+  });
+
   it("forwards gateway send delivery options to outbound delivery", async () => {
     mockDeliverySuccess("m-options");
 

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -1216,6 +1216,7 @@ export const sendHandlers: GatewayRequestHandlers = {
       agentId?: string;
       replyToId?: string;
       threadId?: string;
+      topLevel?: boolean;
       forceDocument?: boolean;
       silent?: boolean;
       parseMode?: "HTML";
@@ -1242,6 +1243,7 @@ export const sendHandlers: GatewayRequestHandlers = {
     const requestedAccountId = normalizeOptionalString(request.accountId);
     const replyToId = normalizeOptionalString(request.replyToId);
     const threadId = normalizeOptionalString(request.threadId);
+    const topLevel = request.topLevel === true;
     const agentRuntimeAuthority = createAgentRuntimeAuthorityGuard(client, context, respond);
     const hasAgentRuntimeAuthority = client?.internal?.agentRuntimeIdentity !== undefined;
     const commitAgentRuntimeAuthority = agentRuntimeAuthority.commitGuard;
@@ -1370,36 +1372,37 @@ export const sendHandlers: GatewayRequestHandlers = {
             agentId: effectiveAgentId,
             accountId,
             target: deliveryTarget,
-            currentSessionKey: providedSessionKey,
+            currentSessionKey: topLevel ? undefined : providedSessionKey,
             resolvedTarget: idLikeTarget,
             replyToId,
             threadId,
           });
+          const routeSourceSessionKey = topLevel ? undefined : providedSessionKey;
           const providedSessionBaseKey =
-            parseThreadSessionSuffix(providedSessionKey).baseSessionKey ?? providedSessionKey;
+            parseThreadSessionSuffix(routeSourceSessionKey).baseSessionKey ?? routeSourceSessionKey;
           const shouldUseDerivedThreadSessionKey =
             resolveChannelThreadAddressing(channel) === "message" &&
-            Boolean(providedSessionKey) &&
+            Boolean(routeSourceSessionKey) &&
             Boolean(normalizeOptionalString(derivedRoute?.threadId)) &&
             normalizeOptionalLowercaseString(derivedRoute?.baseSessionKey) ===
               normalizeOptionalLowercaseString(providedSessionBaseKey) &&
-            normalizeOptionalLowercaseString(derivedRoute?.sessionKey) !== providedSessionKey;
+            normalizeOptionalLowercaseString(derivedRoute?.sessionKey) !== routeSourceSessionKey;
           // Message-scoped threads can refine an existing base session only after target lookup.
           const outboundRoute = derivedRoute
-            ? providedSessionKey
+            ? routeSourceSessionKey
               ? shouldUseDerivedThreadSessionKey
                 ? {
                     ...derivedRoute,
-                    baseSessionKey: derivedRoute.baseSessionKey ?? providedSessionKey,
+                    baseSessionKey: derivedRoute.baseSessionKey ?? routeSourceSessionKey,
                   }
                 : {
                     ...derivedRoute,
-                    sessionKey: providedSessionKey,
-                    baseSessionKey: providedSessionKey,
+                    sessionKey: routeSourceSessionKey,
+                    baseSessionKey: routeSourceSessionKey,
                   }
               : derivedRoute
             : null;
-          const outboundSessionKey = outboundRoute?.sessionKey ?? providedSessionKey;
+          const outboundSessionKey = outboundRoute?.sessionKey ?? routeSourceSessionKey;
           if (outboundSessionKey) {
             const agentAccessError = authorizeGatewaySessionCreation({
               cfg,
@@ -1464,7 +1467,7 @@ export const sendHandlers: GatewayRequestHandlers = {
             session: outboundSession,
             gifPlayback: request.gifPlayback,
             forceDocument: request.forceDocument,
-            threadId: outboundRoute?.threadId ?? threadId ?? null,
+            threadId: topLevel ? null : (outboundRoute?.threadId ?? threadId ?? null),
             deps: outboundDeps,
             gatewayClientScopes: client?.connect?.scopes ?? [],
             silent: request.silent,

--- a/src/infra/outbound/message-action-send.ts
+++ b/src/infra/outbound/message-action-send.ts
@@ -694,6 +694,7 @@ export async function executeMessageSend(ctx: ResolvedActionContext): Promise<Me
     bestEffort: sendPayload.bestEffort,
     reply,
     threadId: resolvedThreadId ?? undefined,
+    topLevel: params.topLevel === true ? true : undefined,
   });
 
   // Gateway-relayed core sends return no identified platform result locally;

--- a/src/infra/outbound/message.channels.test.ts
+++ b/src/infra/outbound/message.channels.test.ts
@@ -484,6 +484,7 @@ describe("gateway url override hardening", () => {
       name: "forwards gateway delivery options in send params",
       params: {
         threadId: "topic456",
+        topLevel: true,
         forceDocument: true,
         silent: true,
         parseMode: "HTML" as const,
@@ -491,6 +492,7 @@ describe("gateway url override hardening", () => {
       expected: {
         params: {
           threadId: "topic456",
+          topLevel: true,
           forceDocument: true,
           silent: true,
           parseMode: "HTML",

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -94,6 +94,8 @@ type MessageSendParams = {
   reply?: OutboundReplyFacts;
   replyToId?: string;
   threadId?: string | number;
+  /** Explicitly suppress inherited thread placement for gateway-routed sends. */
+  topLevel?: boolean;
   dryRun?: boolean;
   bestEffort?: boolean;
   queuePolicy?: OutboundDeliveryQueuePolicy;
@@ -521,6 +523,7 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
       channel,
       replyToId: reply?.replyToId,
       threadId: params.threadId != null ? String(params.threadId) : undefined,
+      topLevel: params.topLevel === true ? true : undefined,
       forceDocument: params.forceDocument,
       silent: params.silent,
       parseMode: params.parseMode,

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -143,6 +143,7 @@ async function sendCoreMessage(params: {
   bestEffort?: boolean;
   reply?: OutboundReplyFacts;
   threadId?: string | number;
+  topLevel?: boolean;
   queuePolicy: NonNullable<SendMessageParams["queuePolicy"]>;
   payloads?: SendMessageParams["payloads"];
 }): Promise<{ result: MessageSendResult; deliveredText?: string }> {
@@ -171,6 +172,7 @@ async function sendCoreMessage(params: {
     conversationReadOrigin: params.ctx.conversationReadOrigin,
     reply: params.reply,
     threadId: params.threadId,
+    topLevel: params.topLevel,
     gifPlayback: params.gifPlayback,
     forceDocument: params.forceDocument,
     dryRun: params.ctx.dryRun,
@@ -345,6 +347,7 @@ export async function executeSendAction(params: {
   bestEffort?: boolean;
   reply?: OutboundReplyFacts;
   threadId?: string | number;
+  topLevel?: boolean;
 }): Promise<{
   handledBy: "plugin" | "core";
   payload: unknown;


### PR DESCRIPTION
## Summary
- carry the generic message tool’s explicit `topLevel` intent through core send and the gateway protocol
- suppress inherited thread/session routing when `topLevel: true`
- derive and mirror the destination channel root session instead

## Tests
- `src/infra/outbound/message.channels.test.ts`: 19 passed
- `src/infra/outbound/message-action-send.core.test.ts` plus outbound test: 36 passed
- `src/gateway/server-methods/send.test.ts`: 124 passed
- `oxfmt --check` and `git diff --check`