### PR TITLE
test(gateway): synchronize admitted auth-refresh regression

### DIFF
--- a/src/gateway/server.agent.gateway-server-agent-auth-refresh.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-auth-refresh.test.ts
@@ -4,6 +4,11 @@ import { createDeferred } from "../../test/helpers/promise.js";
 import { resolveAgentDir } from "../agents/agent-scope.js";
 import { setRuntimeAuthProfileStoreSnapshot } from "../agents/auth-profiles/runtime-snapshots.js";
 import {
+  getPreparedModelRuntimeBorrowedSnapshot,
+  getPreparedModelRuntimePluginGeneration,
+} from "../agents/prepared-model-runtime-generation-scope.js";
+import {
+  getPreparedModelRuntimeSnapshot,
   loadPublishedGatewayReplyDispatchRuntime,
   registerPreparedModelRuntimePublicationListener,
 } from "../agents/prepared-model-runtime.js";
@@ -133,19 +138,66 @@ describe("gateway agent auth refresh dispatch", () => {
     const admittedRunId = "idem-agent-auth-admitted";
     const subsequentRunId = "idem-agent-auth-next";
     const before = await prepareAuthDispatchAgents(affectedAgentId);
+    expect(before.runtime).toBeDefined();
+    const snapshotInput = {
+      agentId: affectedAgentId,
+      agentDir: before.agentDir,
+      config: before.runtime!.config,
+      workspaceDir: before.runtime!.workspaceDir,
+      allowGatewaySubagentBinding: true,
+    };
+    const dispatchedSnapshots = new Map<
+      string,
+      ReturnType<typeof getPreparedModelRuntimeBorrowedSnapshot>
+    >();
+    const originalCommand = agentCommandMock.getMockImplementation();
+    expect(originalCommand).toBeDefined();
+    const dispatchEntered = createDeferred();
+    const releaseDispatch = createDeferred();
+    const handlerHelpers = await import("./agent-turn/agent-handler-helpers.js");
+    // Receiving the ACK is not a barrier against the server's dispatch timer.
+    const yieldSpy = vi
+      .spyOn(handlerHelpers, "yieldAfterAgentAcceptedAck")
+      .mockImplementationOnce(() => {
+        dispatchEntered.resolve();
+        return releaseDispatch.promise;
+      });
     const published = createDeferred();
     const unregister = registerPreparedModelRuntimePublicationListener((event) => {
       if (event.phase === "published") {
         published.resolve();
       }
     });
+    let admitted: ReturnType<typeof sendAgentRpc> | undefined;
+    let subsequent: ReturnType<typeof sendAgentRpc> | undefined;
     try {
-      const admitted = sendAgentRpc(gatewaySuite.ws, {
+      agentCommandMock.mockImplementation((options, ...args) => {
+        if (
+          !options ||
+          typeof options !== "object" ||
+          !("runId" in options) ||
+          typeof options.runId !== "string"
+        ) {
+          throw new Error("Expected an agent command with a run ID");
+        }
+        const generation = getPreparedModelRuntimePluginGeneration();
+        dispatchedSnapshots.set(
+          options.runId,
+          generation ? getPreparedModelRuntimeBorrowedSnapshot(generation) : undefined,
+        );
+        return originalCommand!(options, ...args);
+      });
+      admitted = sendAgentRpc(gatewaySuite.ws, {
         agentId: affectedAgentId,
         runId: admittedRunId,
       });
       await admitted.accepted;
+      await expect(
+        Promise.race([dispatchEntered.promise, admitted.final]),
+      ).resolves.toBeUndefined();
       expect(agentCommandCallsFor(admittedRunId)).toHaveLength(0);
+      const admittedSnapshot = getPreparedModelRuntimeSnapshot(snapshotInput);
+      expect(admittedSnapshot).toBeDefined();
 
       setRuntimeAuthProfileStoreSnapshot(
         {
@@ -160,11 +212,17 @@ describe("gateway agent auth refresh dispatch", () => {
         },
         before.agentDir,
       );
-      await published.promise;
+      await expect(Promise.race([published.promise, admitted.final])).resolves.toBeUndefined();
       const after = await loadPublishedGatewayReplyDispatchRuntime({
         agentId: affectedAgentId,
       });
       expect(after).not.toBe(before.runtime);
+      const refreshedSnapshot = getPreparedModelRuntimeSnapshot(snapshotInput);
+      expect(refreshedSnapshot).toBeDefined();
+      // Auth refresh can reuse config and plugin identities; the leased snapshot must differ.
+      expect(refreshedSnapshot === admittedSnapshot).toBe(false);
+      expect(agentCommandCallsFor(admittedRunId)).toHaveLength(0);
+      releaseDispatch.resolve();
 
       await expect(admitted.final).resolves.toMatchObject({
         ok: true,
@@ -174,8 +232,9 @@ describe("gateway agent auth refresh dispatch", () => {
         config: before.runtime?.config,
         pluginGeneration: before.runtime?.pluginGeneration,
       });
+      expect(dispatchedSnapshots.get(admittedRunId) === admittedSnapshot).toBe(true);
 
-      const subsequent = sendAgentRpc(gatewaySuite.ws, {
+      subsequent = sendAgentRpc(gatewaySuite.ws, {
         agentId: affectedAgentId,
         runId: subsequentRunId,
       });
@@ -188,8 +247,20 @@ describe("gateway agent auth refresh dispatch", () => {
         config: after?.config,
         pluginGeneration: after?.pluginGeneration,
       });
+      expect(dispatchedSnapshots.get(subsequentRunId) === refreshedSnapshot).toBe(true);
     } finally {
+      releaseDispatch.resolve();
       unregister();
+      try {
+        // Drain this test's real RPC listeners before shared-server fixtures reset.
+        await Promise.allSettled([
+          ...(admitted ? [admitted.accepted, admitted.final] : []),
+          ...(subsequent ? [subsequent.accepted, subsequent.final] : []),
+        ]);
+      } finally {
+        yieldSpy.mockRestore();
+        agentCommandMock.mockImplementation(originalCommand!);
+      }
     }
   });
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Gateway CI can fail the admitted-runtime auth-refresh regression before it even changes credentials. The test assumes receiving the `accepted` WebSocket response means server dispatch has not started; the server's independent 10 ms yield does not guarantee that ordering.

This is a maintainer-requested test repair needed to complete validation of #120658, not a change to that plugin or to authentication policy. Related: #131120, which introduced the admission-pinning regression test.

The timing assumption came with #131120 (authored and merged by @vincentkoc on 2026-08-27). This repair preserves that PR's production fix, which pins the runtime before acceptance.

## Why This Change Was Made

Hold the existing pre-dispatch yield for this one test while receiving the real acknowledgment and publishing the real refreshed runtime. Then release the admitted request and check its original snapshot, followed by a second real request using the refreshed snapshot. No production hook, clock override, extra retry, or longer timeout is added.

The snapshot assertions also close a weakness in the original test: auth refresh can reuse the config and plugin-generation objects. The test now observes the actual snapshot borrowed by each dispatched run through the existing generation-scope reader, without inspecting credentials. Failure cleanup releases dispatch and drains both responses for each created RPC before shared fixtures reset.

## User Impact

No product behavior, configuration, protocol, storage, dependency, or security-policy changes. Developers get deterministic coordination and a more discriminating regression test for admitted runtime snapshots.

## Evidence

- Observed baseline failure: [CI run 33173035054, job 98854896675](https://github.com/openclaw/openclaw/actions/runs/33173035054/job/98854896675), tested merge `f0502cbb900223ff0d539c2e522badb4f83b045f`. The test failed at line 148 with one command call instead of zero, before auth mutation; 322 tests passed and one failed. Both neighboring auth-refresh cases passed.
- Source review follows the public RPC, admission snapshot lease, existing yield, WebSocket delivery, auth publication, command dispatch, and shared-server cleanup. `ws` 8.21.3's write callback is not a client-processing acknowledgment.
- Final one-file formatting with pinned oxfmt 0.60.0 and `git diff --check` passed. Production LOC: 0; test LOC: +74/-3.
- Independent source review and a fresh full-context Codex structured review found no actionable P0–P2 issues.
- [Exact-head CI 33178899683](https://github.com/openclaw/openclaw/actions/runs/33178899683) passed all selected checks, including the aggregate gate, test types, and lint. The [focused Gateway job](https://github.com/openclaw/openclaw/actions/runs/33178899683/job/98874903679) ran the complete three-case auth-refresh file on tested merge `51de36e4399bc113dbf3dbe43ed6a931ea081d14`: all three passed, including the admitted old-snapshot and subsequent refreshed-snapshot assertions. An independent reviewer verified the raw results and exact source identity. This satisfies the latest ClawSweeper proof/rank-up request.
- The successful ordinary changed-target job runs this complete file, not the original 26-file shard. No identical cross-file schedule, historical pre-#131120 mutation run, or live provider validation is claimed. The original CI failure does not establish an authentication or runtime-authority product defect.

AI-assisted with Codex. Required exact-head CI remains a landing gate.
