### PR TITLE
fix(update): report foreign-root restart skips

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -44,7 +44,7 @@ launcher scripts).
 | `--channel <stable\|extended-stable\|beta\|dev>` | Set the update channel and persist it after core update success. Extended-stable is package-only.                                                                                                                                                                                                                                             |
 | `--tag <dist-tag\|version\|spec>`                | Override the package target for this update only. It cannot be combined with an effective `extended-stable` channel, whose verified exact target is mandatory. Package installs reject the `main` shorthand; use `--channel dev` for the supported checkout and build flow. Other explicit package specs keep their package-manager behavior. |
 | `--dry-run`                                      | Preview planned actions (channel/tag/target/restart flow) without writing config, installing, syncing plugins, or restarting.                                                                                                                                                                                                                 |
-| `--json`                                         | Print machine-readable `UpdateRunResult` JSON. Includes `postUpdate.plugins.warnings` when a managed plugin needs repair, beta-channel plugin fallback details, and `postUpdate.plugins.integrityDrifts` when npm plugin artifact drift is detected during post-update sync.                                                                  |
+| `--json`                                         | Print machine-readable `UpdateRunResult` JSON. Includes `restart` for a foreign-root managed Gateway skip, `postUpdate.plugins.warnings` when a managed plugin needs repair, beta-channel plugin fallback details, and `postUpdate.plugins.integrityDrifts` when npm plugin artifact drift is detected during post-update sync.               |
 | `--timeout <seconds>`                            | Per-step timeout. Default `1800`.                                                                                                                                                                                                                                                                                                             |
 | `--yes`                                          | Skip confirmation prompts (for example downgrade confirmation).                                                                                                                                                                                                                                                                               |
 
@@ -220,6 +220,13 @@ If restart cannot run, the command prints `Gateway: restart skipped (...)` or
 With `--no-restart`, package replacement or git rebuild still runs, but the
 managed service is not stopped or restarted, so the running Gateway keeps old
 code until you restart it manually.
+
+If a Git update finds a managed Gateway service owned by another OpenClaw root,
+it leaves that service untouched and reports
+`restart: { status: "skipped", reason: "foreign-service-root" }`. The updated
+checkout succeeds, but the installed Gateway continues running its previous
+code if it was running. Update the installation that owns it or deliberately
+reinstall the service from the updated root.
 
 ### Control-plane response shape
 

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -44,7 +44,7 @@ launcher scripts).
 | `--channel <stable\|extended-stable\|beta\|dev>` | Set the update channel and persist it after core update success. Extended-stable is package-only.                                                                                                                                                                                                                                             |
 | `--tag <dist-tag\|version\|spec>`                | Override the package target for this update only. It cannot be combined with an effective `extended-stable` channel, whose verified exact target is mandatory. Package installs reject the `main` shorthand; use `--channel dev` for the supported checkout and build flow. Other explicit package specs keep their package-manager behavior. |
 | `--dry-run`                                      | Preview planned actions (channel/tag/target/restart flow) without writing config, installing, syncing plugins, or restarting.                                                                                                                                                                                                                 |
-| `--json`                                         | Print machine-readable `UpdateRunResult` JSON. Includes `postUpdate.plugins.warnings` when a managed plugin needs repair, beta-channel plugin fallback details, and `postUpdate.plugins.integrityDrifts` when npm plugin artifact drift is detected during post-update sync.                                                                  |
+| `--json`                                         | Print machine-readable `UpdateRunResult` JSON. Includes `restart` for a foreign-root managed Gateway skip, `postUpdate.plugins.warnings` when a managed plugin needs repair, beta-channel plugin fallback details, and `postUpdate.plugins.integrityDrifts` when npm plugin artifact drift is detected during post-update sync.               |
 | `--timeout <seconds>`                            | Per-step timeout. Default `1800`.                                                                                                                                                                                                                                                                                                             |
 | `--yes`                                          | Skip confirmation prompts (for example downgrade confirmation).                                                                                                                                                                                                                                                                               |
 
@@ -195,6 +195,13 @@ If restart cannot run, the command prints `Gateway: restart skipped (...)` or
 With `--no-restart`, package replacement or git rebuild still runs, but the
 managed service is not stopped or restarted, so the running Gateway keeps old
 code until you restart it manually.
+
+If a Git update finds a managed Gateway service owned by another OpenClaw root,
+it leaves that service untouched and reports
+`restart: { status: "skipped", reason: "foreign-service-root" }`. The updated
+checkout succeeds, but the installed Gateway continues running its previous
+code if it was running. Update the installation that owns it or deliberately
+reinstall the service from the updated root.
 
 ### Control-plane response shape
 

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -5799,13 +5799,30 @@ describe("update-cli", () => {
     mockRunningManagedGateway(["node", otherEntrypoint, "gateway", "run"]);
     const preparations = mockGitUpdateAfterMutation();
 
-    await updateCommand({ yes: true });
+    const sentinel = await runControlPlaneUpdate({
+      meta: {},
+      options: { yes: true, json: true },
+    });
 
     expectNoSideEffects(serviceStop, prepareRestartScript, serviceRestart, runDaemonRestart);
     expect(runGatewayUpdate).toHaveBeenCalledTimes(1);
     expect(preparations).toEqual([
       { allowGatewayServiceRepair: false, allowGatewayActivation: false },
     ]);
+    expect(lastWriteJsonCall()).toEqual(
+      expect.objectContaining({
+        status: "ok",
+        restart: { status: "skipped", reason: "foreign-service-root" },
+      }),
+    );
+    expect(sentinel?.payload).toEqual(
+      expect.objectContaining({
+        status: "ok",
+        stats: expect.objectContaining({
+          restart: { status: "skipped", reason: "foreign-service-root" },
+        }),
+      }),
+    );
   });
 
   it("leaves a stopped git service down when plugin post-update fails", async () => {

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -5365,13 +5365,30 @@ describe("update-cli", () => {
     mockRunningManagedGateway(["node", otherEntrypoint, "gateway", "run"]);
     const preparations = mockGitUpdateAfterMutation();
 
-    await updateCommand({ yes: true });
+    const sentinel = await runControlPlaneUpdate({
+      meta: {},
+      options: { yes: true, json: true },
+    });
 
     expectNoSideEffects(serviceStop, prepareRestartScript, serviceRestart, runDaemonRestart);
     expect(runGatewayUpdate).toHaveBeenCalledTimes(1);
     expect(preparations).toEqual([
       { allowGatewayServiceRepair: false, allowGatewayActivation: false },
     ]);
+    expect(lastWriteJsonCall()).toEqual(
+      expect.objectContaining({
+        status: "ok",
+        restart: { status: "skipped", reason: "foreign-service-root" },
+      }),
+    );
+    expect(sentinel?.payload).toEqual(
+      expect.objectContaining({
+        status: "ok",
+        stats: expect.objectContaining({
+          restart: { status: "skipped", reason: "foreign-service-root" },
+        }),
+      }),
+    );
   });
 
   it("leaves a stopped git service down when plugin post-update fails", async () => {

--- a/src/cli/update-cli/progress.test.ts
+++ b/src/cli/update-cli/progress.test.ts
@@ -112,3 +112,23 @@ describe("update failure hints", () => {
     expect(output).not.toContain("npm config set prefix ~/.local");
   });
 });
+
+describe("update restart result", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("explains a foreign-service-root restart skip", () => {
+    const output = renderResult({
+      status: "ok",
+      mode: "git",
+      restart: { status: "skipped", reason: "foreign-service-root" },
+      steps: [],
+      durationMs: 1,
+    });
+
+    expect(output).toContain("installed service belongs to another OpenClaw root");
+    expect(output).toContain("If it is running, it still uses the previous code");
+    expect(output).toContain("gateway install --force");
+  });
+});

--- a/src/cli/update-cli/progress.ts
+++ b/src/cli/update-cli/progress.ts
@@ -10,6 +10,8 @@ import type {
   UpdateStepProgress,
 } from "../../infra/update-runner.js";
 import { defaultRuntime } from "../../runtime.js";
+import { replaceCliName, resolveCliName } from "../cli-name.js";
+import { formatCliCommand } from "../command-format.js";
 import type { UpdateCommandOptions } from "./shared.js";
 
 const STEP_LABELS: Record<string, string> = {
@@ -216,6 +218,14 @@ export function printResult(result: UpdateRunResult, opts: PrintResultOptions): 
   }
   if (result.reason) {
     defaultRuntime.log(`  Reason: ${theme.muted(result.reason)}`);
+  }
+  if (result.restart?.reason === "foreign-service-root") {
+    defaultRuntime.log(
+      `  Gateway restart: ${theme.warn("skipped; the installed service belongs to another OpenClaw root and was left untouched.")}`,
+    );
+    defaultRuntime.log(
+      `  Next: ${theme.muted(`If it is running, it still uses the previous code. Update the installation that owns the service, or run \`${replaceCliName(formatCliCommand("openclaw gateway install --force"), resolveCliName())}\` from this root to replace it deliberately.`)}`,
+    );
   }
 
   if (result.before?.version || result.before?.sha) {

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -370,6 +370,7 @@ export async function finishUpdate(params: {
   let gatewayServiceInstallEnv: NodeJS.ProcessEnv | null | undefined;
   let serviceUpdateVerdict = params.preManagedServiceStop?.serviceUpdateVerdict;
   let skipLegacyServiceRestart = serviceUpdateVerdict?.kind === "absent";
+  let foreignServiceRoot = serviceUpdateVerdict?.kind === "foreign";
   const serviceStateReadEnv = resolvePostUpdateServiceStateReadEnv({
     updateMode: resultWithPostUpdate.mode,
     processEnv: process.env,
@@ -403,6 +404,7 @@ export async function finishUpdate(params: {
         preManagedServiceStop: params.preManagedServiceStop,
       });
       gatewayServiceEnv = serviceState.env;
+      foreignServiceRoot = serviceUpdateVerdict.kind === "foreign";
       skipLegacyServiceRestart =
         serviceUpdateVerdict.kind === "foreign" || serviceUpdateVerdict.kind === "absent";
       if (serviceUpdateVerdict.kind === "unavailable") {
@@ -475,35 +477,46 @@ export async function finishUpdate(params: {
     skipPrompt: Boolean(params.opts.yes),
   });
 
-  await writeControlPlaneUpdateRestartSentinelBestEffort({
-    meta: params.controlPlaneUpdateSentinelMeta,
-    result: buildControlPlaneUpdateRestartHealthPendingResult(resultWithPostUpdate),
-    jsonMode: Boolean(params.opts.json),
-  });
+  const finalResult: UpdateRunResult = foreignServiceRoot
+    ? {
+        ...resultWithPostUpdate,
+        restart: { status: "skipped", reason: "foreign-service-root" },
+      }
+    : resultWithPostUpdate;
+
+  if (!foreignServiceRoot) {
+    await writeControlPlaneUpdateRestartSentinelBestEffort({
+      meta: params.controlPlaneUpdateSentinelMeta,
+      result: buildControlPlaneUpdateRestartHealthPendingResult(resultWithPostUpdate),
+      jsonMode: Boolean(params.opts.json),
+    });
+  }
 
   if (!(await restoreWindowsTaskAutoStartOrExit(params.preManagedServiceStop))) {
     return;
   }
-  const restartOk = await withOwnedManagedUpdateEnv(params.ownedManagedUpdateEnv, async () =>
-    maybeRestartService({
-      shouldRestart: params.shouldRestart && serviceMutationAllowed,
-      result: resultWithPostUpdate,
-      channel: params.channel,
-      opts: params.opts,
-      refreshServiceEnv: refreshGatewayServiceEnv,
-      serviceUpdateVerdict,
-      serviceEnv: gatewayServiceEnv,
-      serviceInstallEnv: gatewayServiceInstallEnv,
-      gatewayPort,
-      restartScriptPath,
-      invocationCwd: params.invocationCwd,
-      nodeRunner: params.packageUpdateNodeRunner,
-      skipLegacyServiceRestart,
-      requireRunningServiceAfterRestart: params.preManagedServiceStop?.stopped === true,
-      serviceMutationSkipMessage,
-      timeoutMs: params.updateStepTimeoutMs,
-    }),
-  );
+  const restartOk =
+    foreignServiceRoot ||
+    (await withOwnedManagedUpdateEnv(params.ownedManagedUpdateEnv, async () =>
+      maybeRestartService({
+        shouldRestart: params.shouldRestart && serviceMutationAllowed,
+        result: finalResult,
+        channel: params.channel,
+        opts: params.opts,
+        refreshServiceEnv: refreshGatewayServiceEnv,
+        serviceUpdateVerdict,
+        serviceEnv: gatewayServiceEnv,
+        serviceInstallEnv: gatewayServiceInstallEnv,
+        gatewayPort,
+        restartScriptPath,
+        invocationCwd: params.invocationCwd,
+        nodeRunner: params.packageUpdateNodeRunner,
+        skipLegacyServiceRestart,
+        requireRunningServiceAfterRestart: params.preManagedServiceStop?.stopped === true,
+        serviceMutationSkipMessage,
+        timeoutMs: params.updateStepTimeoutMs,
+      }),
+    ));
   if (!restartOk) {
     await markControlPlaneUpdateRestartSentinelFailureBestEffort({
       meta: params.controlPlaneUpdateSentinelMeta,
@@ -526,7 +539,7 @@ export async function finishUpdate(params: {
         jsonMode: Boolean(params.opts.json),
       });
       const failedResult: UpdateRunResult = {
-        ...resultWithPostUpdate,
+        ...finalResult,
         status: "error",
         reason: "wrapper-retirement-failed",
       };
@@ -538,11 +551,11 @@ export async function finishUpdate(params: {
 
   await writeControlPlaneUpdateRestartSentinelBestEffort({
     meta: params.controlPlaneUpdateSentinelMeta,
-    result: resultWithPostUpdate,
+    result: finalResult,
     jsonMode: Boolean(params.opts.json),
   });
 
-  printResult(resultWithPostUpdate, { ...params.opts, hideSteps: params.showProgress });
+  printResult(finalResult, { ...params.opts, hideSteps: params.showProgress });
   if (!params.opts.json) {
     defaultRuntime.log(theme.muted(pickUpdateQuip()));
   }

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -365,7 +365,7 @@ export async function finishUpdate(params: {
   let refreshGatewayServiceEnv = false;
   let gatewayServiceEnv: NodeJS.ProcessEnv | undefined;
   let gatewayServiceInstallEnv: NodeJS.ProcessEnv | null | undefined;
-  let skipLegacyServiceRestart = false;
+  let foreignServiceRoot = false;
   const serviceStateReadEnv = resolvePostUpdateServiceStateReadEnv({
     updateMode: resultWithPostUpdate.mode,
     processEnv: process.env,
@@ -404,7 +404,7 @@ export async function finishUpdate(params: {
         params.preManagedServiceStop?.serviceMatchesMutationRoot === false &&
         serviceMatchesUpdateRoot !== true;
       const serviceLoaded = serviceState.loadState.status === "loaded";
-      skipLegacyServiceRestart =
+      foreignServiceRoot =
         knownForeignService ||
         (resultWithPostUpdate.mode === "git" &&
           serviceState.installed &&
@@ -472,35 +472,45 @@ export async function finishUpdate(params: {
     skipPrompt: Boolean(params.opts.yes),
   });
 
-  await writeControlPlaneUpdateRestartSentinelBestEffort({
-    meta: params.controlPlaneUpdateSentinelMeta,
-    result: buildControlPlaneUpdateRestartHealthPendingResult(resultWithPostUpdate),
-    jsonMode: Boolean(params.opts.json),
-  });
+  const finalResult: UpdateRunResult = foreignServiceRoot
+    ? {
+        ...resultWithPostUpdate,
+        restart: { status: "skipped", reason: "foreign-service-root" },
+      }
+    : resultWithPostUpdate;
+
+  if (!foreignServiceRoot) {
+    await writeControlPlaneUpdateRestartSentinelBestEffort({
+      meta: params.controlPlaneUpdateSentinelMeta,
+      result: buildControlPlaneUpdateRestartHealthPendingResult(resultWithPostUpdate),
+      jsonMode: Boolean(params.opts.json),
+    });
+  }
 
   if (!(await restoreWindowsTaskAutoStartOrExit(params.preManagedServiceStop))) {
     return;
   }
-  const restartOk = await withOwnedManagedUpdateEnv(params.ownedManagedUpdateEnv, async () =>
-    maybeRestartService({
-      shouldRestart: params.shouldRestart && serviceMutationAllowed,
-      result: resultWithPostUpdate,
-      channel: params.channel,
-      opts: params.opts,
-      refreshServiceEnv: refreshGatewayServiceEnv,
-      serviceEnv: gatewayServiceEnv,
-      serviceInstallEnv: gatewayServiceInstallEnv,
-      gatewayPort,
-      restartScriptPath,
-      invocationCwd: params.invocationCwd,
-      nodeRunner: params.packageUpdateNodeRunner,
-      skipLegacyServiceRestart,
-      requireRunningServiceAfterRestart:
-        resultWithPostUpdate.mode === "git" && params.preManagedServiceStop?.stopped === true,
-      serviceMutationSkipMessage,
-      timeoutMs: params.updateStepTimeoutMs,
-    }),
-  );
+  const restartOk =
+    foreignServiceRoot ||
+    (await withOwnedManagedUpdateEnv(params.ownedManagedUpdateEnv, async () =>
+      maybeRestartService({
+        shouldRestart: params.shouldRestart && serviceMutationAllowed,
+        result: finalResult,
+        channel: params.channel,
+        opts: params.opts,
+        refreshServiceEnv: refreshGatewayServiceEnv,
+        serviceEnv: gatewayServiceEnv,
+        serviceInstallEnv: gatewayServiceInstallEnv,
+        gatewayPort,
+        restartScriptPath,
+        invocationCwd: params.invocationCwd,
+        nodeRunner: params.packageUpdateNodeRunner,
+        requireRunningServiceAfterRestart:
+          resultWithPostUpdate.mode === "git" && params.preManagedServiceStop?.stopped === true,
+        serviceMutationSkipMessage,
+        timeoutMs: params.updateStepTimeoutMs,
+      }),
+    ));
   if (!restartOk) {
     await markControlPlaneUpdateRestartSentinelFailureBestEffort({
       meta: params.controlPlaneUpdateSentinelMeta,
@@ -523,7 +533,7 @@ export async function finishUpdate(params: {
         jsonMode: Boolean(params.opts.json),
       });
       const failedResult: UpdateRunResult = {
-        ...resultWithPostUpdate,
+        ...finalResult,
         status: "error",
         reason: "wrapper-retirement-failed",
       };
@@ -535,11 +545,11 @@ export async function finishUpdate(params: {
 
   await writeControlPlaneUpdateRestartSentinelBestEffort({
     meta: params.controlPlaneUpdateSentinelMeta,
-    result: resultWithPostUpdate,
+    result: finalResult,
     jsonMode: Boolean(params.opts.json),
   });
 
-  printResult(resultWithPostUpdate, { ...params.opts, hideSteps: params.showProgress });
+  printResult(finalResult, { ...params.opts, hideSteps: params.showProgress });
   if (!params.opts.json) {
     defaultRuntime.log(theme.muted(pickUpdateQuip()));
   }

--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -1091,7 +1091,6 @@ export async function maybeRestartService(params: {
   restartScriptPath?: string | null;
   invocationCwd?: string;
   nodeRunner?: string;
-  skipLegacyServiceRestart?: boolean;
   requireRunningServiceAfterRestart?: boolean;
   serviceMutationSkipMessage?: string;
   timeoutMs: number;

--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -1091,6 +1091,7 @@ export async function maybeRestartService(params: {
   restartScriptPath?: string | null;
   invocationCwd?: string;
   nodeRunner?: string;
+  skipLegacyServiceRestart?: boolean;
   requireRunningServiceAfterRestart?: boolean;
   serviceMutationSkipMessage?: string;
   timeoutMs: number;

--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -1062,7 +1062,6 @@ export async function maybeRestartService(params: {
   restartScriptPath?: string | null;
   invocationCwd?: string;
   nodeRunner?: string;
-  skipLegacyServiceRestart?: boolean;
   requireRunningServiceAfterRestart?: boolean;
   serviceMutationSkipMessage?: string;
   timeoutMs: number;
@@ -1310,8 +1309,7 @@ export async function maybeRestartService(params: {
         }
       } else if (
         !refreshedGatewayAlreadyHealthy &&
-        shouldUseLegacyProcessRestartAfterUpdate({ updateMode: params.result.mode }) &&
-        !params.skipLegacyServiceRestart
+        shouldUseLegacyProcessRestartAfterUpdate({ updateMode: params.result.mode })
       ) {
         await createUpdateConfigSnapshot();
         restarted = await runDaemonRestart();

--- a/src/commands/status-update-restart.test.ts
+++ b/src/commands/status-update-restart.test.ts
@@ -57,6 +57,24 @@ describe("status update restart formatting", () => {
     ).toBe("ok(verified · gateway 2026.5.15)");
   });
 
+  it("does not call a foreign-service-root skip verified", () => {
+    const payload = {
+      ...basePayload,
+      status: "ok" as const,
+      stats: {
+        ...basePayload.stats,
+        restart: { status: "skipped" as const, reason: "foreign-service-root" as const },
+      },
+    };
+
+    expect(formatUpdateRestartStatusValue(payload)).toBe(
+      "restart skipped · service belongs to another OpenClaw root",
+    );
+    expect(formatUpdateRestartActionLines(payload)).toContain(
+      "The installed Gateway service belongs to another OpenClaw root and was left untouched.",
+    );
+  });
+
   it("adds action lines for failed and pending update restarts only", () => {
     expect(
       formatUpdateRestartActionLines({

--- a/src/commands/status-update-restart.ts
+++ b/src/commands/status-update-restart.ts
@@ -61,6 +61,10 @@ export function formatUpdateRestartStatusValue(
     return muted(`skipped · ${reason ?? "restart skipped"}${age}`);
   }
 
+  if (payload.stats?.restart?.reason === "foreign-service-root") {
+    return warn(`restart skipped · service belongs to another OpenClaw root${age}`);
+  }
+
   const version = readAfterVersion(payload);
   return ok(`verified${version ? ` · gateway ${version}` : ""}${age}`);
 }
@@ -79,6 +83,12 @@ export function formatUpdateRestartActionLines(
     ];
   }
   const reason = readReason(payload);
+  if (payload.stats?.restart?.reason === "foreign-service-root") {
+    return [
+      "The installed Gateway service belongs to another OpenClaw root and was left untouched.",
+      "Update that installation, or reinstall the service deliberately from the updated root.",
+    ];
+  }
   if (
     payload.status === "skipped" &&
     (reason === CONTROL_PLANE_UPDATE_HANDOFF_STARTED_REASON ||

--- a/src/infra/restart-sentinel-store.ts
+++ b/src/infra/restart-sentinel-store.ts
@@ -31,6 +31,10 @@ type RestartSentinelStats = {
   after?: Record<string, unknown> | null;
   steps?: RestartSentinelStep[];
   reason?: string | null;
+  restart?: {
+    status: "skipped";
+    reason: "foreign-service-root";
+  };
   durationMs?: number | null;
 };
 
@@ -179,6 +183,7 @@ function parseRestartSentinelStats(value: unknown): RestartSentinelStats | null 
   const root = parseOptionalNullableString(value, "root");
   const handoffId = parseOptionalNullableString(value, "handoffId");
   const reason = parseOptionalNullableString(value, "reason");
+  const restart = value.restart;
   const before = value.before;
   const after = value.after;
   const steps = value.steps;
@@ -191,6 +196,10 @@ function parseRestartSentinelStats(value: unknown): RestartSentinelStats | null 
     handoffId === false ||
     handoffId === null ||
     reason === false ||
+    (restart !== undefined &&
+      (!isPlainRecord(restart) ||
+        restart.status !== "skipped" ||
+        restart.reason !== "foreign-service-root")) ||
     (value.requiresRestart !== undefined && typeof value.requiresRestart !== "boolean") ||
     (before !== undefined && before !== null && !isPlainRecord(before)) ||
     (after !== undefined && after !== null && !isPlainRecord(after)) ||
@@ -224,6 +233,12 @@ function parseRestartSentinelStats(value: unknown): RestartSentinelStats | null 
   }
   if (reason !== undefined) {
     result.reason = reason;
+  }
+  if (restart !== undefined) {
+    result.restart = {
+      status: "skipped",
+      reason: "foreign-service-root",
+    };
   }
   if (durationMs !== undefined) {
     result.durationMs = durationMs as number | null;

--- a/src/infra/restart-sentinel.test.ts
+++ b/src/infra/restart-sentinel.test.ts
@@ -795,6 +795,69 @@ describe("restart success continuation", () => {
 });
 
 describe("control-plane update restart sentinel", () => {
+  it("preserves a foreign-service-root restart skip without scheduling continuation", () => {
+    const payload = buildUpdateRestartSentinelPayload({
+      result: {
+        status: "ok",
+        mode: "git",
+        before: { sha: "aaaaaaaa" },
+        after: { sha: "aaaaaaaa" },
+        restart: { status: "skipped", reason: "foreign-service-root" },
+        steps: [],
+        durationMs: 42,
+      },
+      meta: {
+        sessionKey: "agent:main:webchat:dm:user-123",
+        continuationMessage: "Check the running version and finish the update report.",
+      },
+      nowMs: 1,
+    });
+
+    expect(payload.status).toBe("ok");
+    expect(payload.stats?.reason).toBeNull();
+    expect(payload.stats?.restart).toEqual({
+      status: "skipped",
+      reason: "foreign-service-root",
+    });
+    expect(payload.continuation).toBeUndefined();
+  });
+
+  it("does not verify a persisted foreign-service-root restart skip", async () => {
+    await withRestartSentinelStateDir(async () => {
+      const payload = buildUpdateRestartSentinelPayload({
+        result: {
+          status: "ok",
+          mode: "git",
+          root: "/tmp/updated-openclaw",
+          before: { sha: "aaaaaaaa" },
+          after: { sha: "bbbbbbbb" },
+          restart: { status: "skipped", reason: "foreign-service-root" },
+          steps: [],
+          durationMs: 42,
+        },
+        meta: {},
+        nowMs: 1,
+      });
+      await writeRestartSentinel(payload);
+
+      await expect(
+        finalizeUpdateRestartSentinelRunningVersion(
+          "2026.8.28",
+          process.env,
+          "aaaaaaaa",
+          "/tmp/foreign-openclaw",
+        ),
+      ).resolves.toBeNull();
+      await expect(readRestartSentinel()).resolves.toMatchObject({
+        payload: {
+          kind: "update",
+          status: "ok",
+          stats: { restart: { status: "skipped", reason: "foreign-service-root" } },
+        },
+      });
+    });
+  });
+
   it("reports a successful same-revision Git run as already current", () => {
     const payload = buildUpdateRestartSentinelPayload({
       result: {

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -104,6 +104,9 @@ export async function finalizeUpdateRestartSentinelRunningVersion(
   if (!snapshot || snapshot.payload.kind !== "update") {
     return null;
   }
+  if (snapshot.payload.stats?.restart?.status === "skipped") {
+    return null;
+  }
   const snapshotRoot = snapshot.payload.stats?.root;
   const expectedRoot =
     typeof snapshotRoot === "string" ? resolveUpdateInstallRoot(snapshotRoot) : null;

--- a/src/infra/update-restart-sentinel-payload.ts
+++ b/src/infra/update-restart-sentinel-payload.ts
@@ -28,6 +28,7 @@ export function normalizeControlPlaneUpdateResult(result: UpdateRunResult): Upda
   const afterSha = result.after?.sha?.trim();
   return result.status === "ok" &&
     result.mode === "git" &&
+    result.restart?.status !== "skipped" &&
     result.postUpdate?.plugins?.changed !== true &&
     beforeSha &&
     afterSha &&
@@ -45,7 +46,7 @@ export function buildUpdateRestartSentinelPayload(params: {
   const result = normalizeControlPlaneUpdateResult(params.result);
   const { meta } = params;
   const continuation =
-    result.status === "ok"
+    result.status === "ok" && result.restart?.status !== "skipped"
       ? buildRestartSuccessContinuation({
           sessionKey: meta.sessionKey,
           continuationMessage: meta.continuationMessage,
@@ -79,6 +80,7 @@ export function buildUpdateRestartSentinelPayload(params: {
         },
       })),
       reason: result.reason ?? null,
+      ...(result.restart ? { restart: result.restart } : {}),
       durationMs: result.durationMs,
     },
   };

--- a/src/infra/update-runner-types.ts
+++ b/src/infra/update-runner-types.ts
@@ -35,6 +35,10 @@ export type UpdateRunResult = {
   };
   steps: UpdateStepResult[];
   durationMs: number;
+  restart?: {
+    status: "skipped";
+    reason: "foreign-service-root";
+  };
   recovery?:
     | { serviceRestartSafe: true }
     | {


### PR DESCRIPTION
**TL;DR:** `openclaw update` run from a checkout that does not own the installed Gateway now reports that honestly: JSON gains `restart: { status: "skipped", reason: "foreign-service-root" }`, and the human output stops claiming `no installed service found` for a service that exists.

> Scope note: adds the public `UpdateRunResult.restart` JSON field and persisted control-plane sentinel restart metadata.

Closes #131794
## What Problem This Solves

Fixes an issue where updating Git checkout A while the installed managed Gateway belongs to checkout B reported a successful update without representing the known restart skip in JSON or persisted status. Human output also ended with the inaccurate `no installed service found` message even though the service was known to exist.

## Why This Change Was Made

Successful update finalization now records the ownership decision once as `restart: { status: "skipped", reason: "foreign-service-root" }`. The same fact drives human output, `--json`, and the restart sentinel; the foreign service remains untouched, no restart continuation or health verification is scheduled, and the generic absent-service branch is reserved for actual absence.

## User Impact

Operators and automation can distinguish “checkout updated” from “installed Gateway restarted.” The guidance directs operators to update the installation that owns the service or deliberately reinstall it from the desired root.

## Evidence

Before: the foreign-checkout regression produced `status: "ok"`, no restart field, and `Gateway: restart skipped (no installed service found).` The sentinel likewise had no restart disposition.

After: `src/cli/update-cli.test.ts:5360` asserts no stop/restart/service mutation while JSON and the persisted sentinel both contain `foreign-service-root`; `src/cli/update-cli/progress.test.ts:121` verifies actionable human guidance; `src/infra/restart-sentinel.test.ts:798` verifies persistence, continuation suppression, and no later false root verification; `src/commands/status-update-restart.test.ts:60` verifies status does not call the outcome verified.

The root cause and repair were independently checked by a second adversarial review that attempted to refute the analysis and confirmed the reporting bug. A final code review also caught and closed sentinel finalization and unchanged-SHA edge cases before push.

Checks run on the rebased head:

- `node scripts/run-vitest.mjs src/cli/update-cli.test.ts` (239 passed)
- `node scripts/run-vitest.mjs src/cli/update-cli/update-command-post-update.test.ts src/cli/update-cli/progress.test.ts` (20 passed)
- `node scripts/run-vitest.mjs src/infra/restart-sentinel.test.ts src/commands/status-update-restart.test.ts` (48 passed)
- `node scripts/run-vitest.mjs src/cli/update-cli.test.ts -t "does not stop or restart a managed gateway owned by another git checkout"` (1 passed after rebase)
- `node scripts/run-vitest.mjs src/infra/restart-sentinel.test.ts -t "foreign-service-root"` (2 passed after rebase)
- `node scripts/check-changed.mjs` (passed after rebase)

Production delta: +68/-34 lines; test delta: +119/-1; docs delta: +8/-1. The production growth is the additive public result contract, strict persisted-sentinel parsing, human/status presentation, and owner-level finalization needed to keep all outputs on one recorded fact.

