### PR TITLE
improve(ui): refine chat image presentation and controls

### DIFF
--- a/ui/src/components/image-lightbox.ts
+++ b/ui/src/components/image-lightbox.ts
@@ -52,7 +52,14 @@ class OpenClawImageLightbox extends OpenClawLitElement {
 
   static override styles = css`
     :host {
+      --image-lightbox-control-background: rgba(12, 16, 24, 0.64);
+      --image-lightbox-control-background-hover: rgba(12, 16, 24, 0.78);
       display: contents;
+    }
+
+    :host-context([data-theme-mode="dark"]) {
+      --image-lightbox-control-background: rgba(255, 255, 255, 0.16);
+      --image-lightbox-control-background-hover: rgba(255, 255, 255, 0.22);
     }
 
     openclaw-modal-dialog {
@@ -84,16 +91,23 @@ class OpenClawImageLightbox extends OpenClawLitElement {
       gap: 4px;
     }
 
+    .actions .action,
+    .zoom-control {
+      color: #fff;
+      background-color: var(--image-lightbox-control-background);
+      -webkit-backdrop-filter: blur(16px) saturate(140%);
+      backdrop-filter: blur(16px) saturate(140%);
+      box-shadow: 0 6px 24px rgba(0, 0, 0, 0.18);
+    }
+
     .actions .action {
       border-radius: 999px;
-      background-color: color-mix(in srgb, var(--text) 10%, transparent);
-      -webkit-backdrop-filter: blur(12px);
-      backdrop-filter: blur(12px);
       transition: background-color 180ms ease;
     }
 
-    .actions .action:hover {
-      background-color: color-mix(in srgb, var(--text) 16%, transparent);
+    .actions .action:hover,
+    .zoom-control:hover:not(:disabled) {
+      background-color: var(--image-lightbox-control-background-hover);
     }
 
     .title {
@@ -201,14 +215,11 @@ class OpenClawImageLightbox extends OpenClawLitElement {
       min-height: 40px;
       padding: 0 10px;
       border: 0;
-      background: color-mix(in srgb, var(--text) 10%, transparent);
-      -webkit-backdrop-filter: blur(12px);
-      backdrop-filter: blur(12px);
       font-size: 15px;
     }
 
     .zoom-control:disabled {
-      color: rgba(255, 255, 255, 0.35);
+      color: rgba(255, 255, 255, 0.8);
     }
 
     .zoom-level {

--- a/ui/src/components/image-lightbox.ts
+++ b/ui/src/components/image-lightbox.ts
@@ -92,8 +92,8 @@ class OpenClawImageLightbox extends OpenClawLitElement {
     }
 
     .actions .action,
-    .zoom-control {
-      color: #fff;
+    .action.zoom-control {
+      color: var(--media-foreground);
       background-color: var(--image-lightbox-control-background);
       -webkit-backdrop-filter: blur(16px) saturate(140%);
       backdrop-filter: blur(16px) saturate(140%);

--- a/ui/src/e2e/chat-image-lightbox.e2e.test.ts
+++ b/ui/src/e2e/chat-image-lightbox.e2e.test.ts
@@ -130,6 +130,49 @@ describeControlUiE2e("Control UI image lightbox", () => {
       const openOriginal = page.getByRole("link", { name: "Open in new tab" });
       await openOriginal.waitFor({ state: "visible" });
       await expect.poll(() => openOriginal.getAttribute("href")).toMatch(/^blob:/);
+      const readControlContrast = () =>
+        page.locator("openclaw-image-lightbox").evaluate((lightbox) => {
+          const root = lightbox.shadowRoot!;
+          return [".open-original", ".close", '[aria-label="Zoom in"]'].map((selector) => {
+            const style = getComputedStyle(root.querySelector(selector)!);
+            return {
+              backdropFilter: style.backdropFilter,
+              backgroundColor: style.backgroundColor,
+              borderWidth: style.borderWidth,
+              color: style.color,
+            };
+          });
+        });
+      for (const [theme, backgroundColor] of [
+        ["dark", "rgba(255, 255, 255, 0.16)"],
+        ["light", "rgba(12, 16, 24, 0.64)"],
+      ] as const) {
+        await page.evaluate(
+          (mode) => document.documentElement.setAttribute("data-theme-mode", mode),
+          theme,
+        );
+        await expect.poll(readControlContrast).toEqual([
+          expect.objectContaining({
+            backdropFilter: expect.stringContaining("blur(16px)"),
+            backgroundColor,
+            borderWidth: "0px",
+            color: "rgb(255, 255, 255)",
+          }),
+          expect.objectContaining({
+            backdropFilter: expect.stringContaining("blur(16px)"),
+            backgroundColor,
+            borderWidth: "0px",
+            color: "rgb(255, 255, 255)",
+          }),
+          expect.objectContaining({
+            backdropFilter: expect.stringContaining("blur(16px)"),
+            backgroundColor,
+            borderWidth: "0px",
+            color: "rgb(255, 255, 255)",
+          }),
+        ]);
+      }
+      await page.evaluate(() => document.documentElement.setAttribute("data-theme-mode", "dark"));
       const focusIsInsideLightbox = () =>
         page.locator("openclaw-image-lightbox").evaluate((lightbox) => {
           let active: Element | null = document.activeElement;

--- a/ui/src/e2e/managed-image-actions.e2e.test.ts
+++ b/ui/src/e2e/managed-image-actions.e2e.test.ts
@@ -97,9 +97,7 @@ suite.define(() => {
       await expect.poll(() => imageActions.getByRole("button").count()).toBe(2);
       await expect
         .poll(() =>
-          imageActions
-            .getByRole("button", { name: "Open image Ticketed generated image" })
-            .count(),
+          imageActions.getByRole("button", { name: "Open image Ticketed generated image" }).count(),
         )
         .toBe(0);
       const downloadButton = imageActions.getByRole("button", { name: "Download image" });

--- a/ui/src/e2e/managed-image-actions.e2e.test.ts
+++ b/ui/src/e2e/managed-image-actions.e2e.test.ts
@@ -94,6 +94,14 @@ suite.define(() => {
       const imageFrame = page.locator(".chat-image-frame--managed").filter({ has: image });
       await imageFrame.hover();
       const imageActions = imageFrame.locator(".chat-image-actions");
+      await expect.poll(() => imageActions.getByRole("button").count()).toBe(2);
+      await expect
+        .poll(() =>
+          imageActions
+            .getByRole("button", { name: "Open image Ticketed generated image" })
+            .count(),
+        )
+        .toBe(0);
       const downloadButton = imageActions.getByRole("button", { name: "Download image" });
       await expect
         .poll(() =>
@@ -118,9 +126,7 @@ suite.define(() => {
       await downloadButton.click();
       expect((await download).suggestedFilename()).toBe("Ticketed generated image.png");
 
-      await imageActions
-        .getByRole("button", { name: "Open image Ticketed generated image" })
-        .click();
+      await page.getByRole("button", { name: "Open image Ticketed generated image" }).click();
       await page
         .getByRole("dialog", { name: "Image preview: Ticketed generated image" })
         .waitFor({ state: "visible" });

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -2239,6 +2239,144 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     }
   });
 
+  it("keeps managed image actions anchored around tiny rendered images", async () => {
+    const page = await openBrowserPage(1280, 900);
+    try {
+      await page.setContent(
+        `<!doctype html><html><head><style>${readUiCss()}</style></head><body>
+          <div class="chat-message-images">
+            <span class="chat-image-frame chat-image-frame--managed">
+            <button class="chat-message-image-button" type="button">
+              <img
+                class="chat-message-image chat-message-image--small"
+                width="16"
+                height="16"
+                alt="Tiny generated image"
+                src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16'%3E%3Crect width='16' height='16' fill='%23dc4f92'/%3E%3C/svg%3E"
+              />
+            </button>
+            <span class="chat-image-actions">
+              <button class="chat-image-action" type="button">1</button>
+              <button class="chat-image-action" type="button">2</button>
+            </span>
+            </span>
+            <span class="chat-image-frame chat-image-frame--managed">
+            <button class="chat-message-image-button" type="button">
+              <img
+                class="chat-message-image"
+                width="420"
+                height="1800"
+                alt="Tall generated image"
+                src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='420' height='1800'%3E%3Crect width='420' height='1800' fill='%235c86ff'/%3E%3C/svg%3E"
+              />
+            </button>
+            <span class="chat-image-actions">
+              <button class="chat-image-action" type="button">1</button>
+              <button class="chat-image-action" type="button">2</button>
+            </span>
+            </span>
+          </div>
+        </body></html>`,
+      );
+      const frames = page.locator(".chat-image-frame--managed");
+      await expect.poll(() => frames.count()).toBe(2);
+      const frameRows = await frames.evaluateAll((elements) =>
+        elements.map((element) => {
+          const box = element.getBoundingClientRect();
+          return { bottom: box.bottom, top: box.top };
+        }),
+      );
+      expect(frameRows[1]!.top).toBeGreaterThan(frameRows[0]!.bottom);
+      for (const [index, expectedWidth] of [160, 84].entries()) {
+        const frame = frames.nth(index);
+        await frame.hover();
+        const geometry = await frame.evaluate((element) => {
+          const actions = element.querySelector<HTMLElement>(".chat-image-actions")!;
+          const frameRect = element.getBoundingClientRect();
+          const actionsRect = actions.getBoundingClientRect();
+          return {
+            actionsInsideFrame:
+              actionsRect.left >= frameRect.left &&
+              actionsRect.right <= frameRect.right &&
+              actionsRect.top >= frameRect.top &&
+              actionsRect.bottom <= frameRect.bottom,
+            actionsNearBottom: frameRect.bottom - actionsRect.bottom <= 9,
+            fadeOpacity: getComputedStyle(element, "::after").opacity,
+            fadeWidth: Number.parseFloat(getComputedStyle(element, "::after").width),
+            frameWidth: frameRect.width,
+            overflow: getComputedStyle(element).overflow,
+          };
+        });
+        expect(geometry.actionsInsideFrame).toBe(true);
+        expect(geometry.actionsNearBottom).toBe(true);
+        expect(geometry.fadeOpacity).toBe("1");
+        expect(geometry.fadeWidth).toBeCloseTo(geometry.frameWidth, 0);
+        expect(geometry.frameWidth).toBeCloseTo(expectedWidth, 0);
+        expect(geometry.overflow).toBe("hidden");
+      }
+    } finally {
+      await closeBrowserPage(page);
+    }
+  });
+
+  it("places a five-image sent gallery above its separate text bubble", async () => {
+    const page = await openBrowserPage(1280, 900);
+    try {
+      const tile = (index: number) => `
+        <span class="chat-image-frame" data-tile="${index}">
+          <button class="chat-message-image-button" type="button">
+            <img class="chat-message-image" width="640" height="640" alt="Image ${index}"
+              src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='640' height='640'%3E%3Crect width='640' height='640' fill='%23865cff'/%3E%3C/svg%3E" />
+          </button>
+        </span>`;
+      await page.setContent(
+        `<!doctype html><html><head><style>${readUiCss()}</style></head><body>
+          <div class="chat-group user">
+            <div class="chat-bubble chat-bubble--with-images">
+              <div
+                class="chat-message-images chat-message-images--gallery chat-message-images--five"
+              >
+                ${Array.from({ length: 5 }, (_, index) => tile(index + 1)).join("")}
+              </div>
+              <div class="chat-text">oi</div>
+            </div>
+          </div>
+        </body></html>`,
+      );
+      await page.locator(".chat-message-image").first().waitFor();
+      const geometry = await page.locator(".chat-bubble").evaluate((bubble) => {
+        const gallery = bubble.querySelector<HTMLElement>(".chat-message-images")!;
+        const text = bubble.querySelector<HTMLElement>(".chat-text")!;
+        const frames = [...gallery.querySelectorAll<HTMLElement>(".chat-image-frame")];
+        const boxes = frames.map((frame) => frame.getBoundingClientRect());
+        const galleryBox = gallery.getBoundingClientRect();
+        const textBox = text.getBoundingClientRect();
+        return {
+          background: getComputedStyle(bubble).backgroundColor,
+          firstRow: boxes.filter(
+            (box) => Math.round(box.top) === Math.round(boxes[0]!.top),
+          ).length,
+          fourthAlignedWithSecond: Math.abs(boxes[3]!.left - boxes[1]!.left) <= 1,
+          lastRowRightAligned: Math.abs(boxes[4]!.right - galleryBox.right) <= 1,
+          textBelow: textBox.top >= galleryBox.bottom + 7,
+          textRightAligned: Math.abs(textBox.right - galleryBox.right) <= 1,
+          tileSize: boxes[0]!.width,
+        };
+      });
+      expect(geometry).toMatchObject({
+        background: "rgba(0, 0, 0, 0)",
+        firstRow: 3,
+        fourthAlignedWithSecond: true,
+        lastRowRightAligned: true,
+        textBelow: true,
+        textRightAligned: true,
+      });
+      expect(geometry.tileSize).toBeCloseTo(128, 0);
+    } finally {
+      await closeBrowserPage(page);
+    }
+  });
+
   it("wraps long question and approval metadata inside narrow cards", async () => {
     const page = await openBrowserPage(320, 568);
     try {

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -2354,9 +2354,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         const textBox = text.getBoundingClientRect();
         return {
           background: getComputedStyle(bubble).backgroundColor,
-          firstRow: boxes.filter(
-            (box) => Math.round(box.top) === Math.round(boxes[0]!.top),
-          ).length,
+          firstRow: boxes.filter((box) => Math.round(box.top) === Math.round(boxes[0]!.top)).length,
           fourthAlignedWithSecond: Math.abs(boxes[3]!.left - boxes[1]!.left) <= 1,
           lastRowRightAligned: Math.abs(boxes[4]!.right - galleryBox.right) <= 1,
           textBelow: textBox.top >= galleryBox.bottom + 7,

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -2290,6 +2290,9 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       for (const [index, expectedWidth] of [160, 84].entries()) {
         const frame = frames.nth(index);
         await frame.hover();
+        await expect
+          .poll(() => frame.evaluate((element) => getComputedStyle(element, "::after").opacity))
+          .toBe("1");
         const geometry = await frame.evaluate((element) => {
           const actions = element.querySelector<HTMLElement>(".chat-image-actions")!;
           const frameRect = element.getBoundingClientRect();
@@ -2301,7 +2304,6 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
               actionsRect.top >= frameRect.top &&
               actionsRect.bottom <= frameRect.bottom,
             actionsNearBottom: frameRect.bottom - actionsRect.bottom <= 9,
-            fadeOpacity: getComputedStyle(element, "::after").opacity,
             fadeWidth: Number.parseFloat(getComputedStyle(element, "::after").width),
             frameWidth: frameRect.width,
             overflow: getComputedStyle(element).overflow,
@@ -2309,7 +2311,6 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         });
         expect(geometry.actionsInsideFrame).toBe(true);
         expect(geometry.actionsNearBottom).toBe(true);
-        expect(geometry.fadeOpacity).toBe("1");
         expect(geometry.fadeWidth).toBeCloseTo(geometry.frameWidth, 0);
         expect(geometry.frameWidth).toBeCloseTo(expectedWidth, 0);
         expect(geometry.overflow).toBe("hidden");
@@ -2372,6 +2373,53 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         textRightAligned: true,
       });
       expect(geometry.tileSize).toBeCloseTo(128, 0);
+    } finally {
+      await closeBrowserPage(page);
+    }
+  });
+
+  it("keeps every sent-image text shape on the user bubble surface", async () => {
+    const page = await openBrowserPage(1280, 900);
+    try {
+      await page.setContent(
+        `<!doctype html><html><head><style>${readUiCss()}</style></head><body>
+          <div class="chat-group user">
+            <div class="chat-bubble chat-bubble--with-images">
+              <div class="chat-text" data-shape="text">Short text</div>
+            </div>
+            <div class="chat-bubble chat-bubble--with-images">
+              <div class="chat-message-disclosure" data-shape="disclosure">
+                <div class="chat-message-disclosure__content">
+                  <div class="chat-text">Collapsed text</div>
+                </div>
+              </div>
+            </div>
+            <div class="chat-bubble chat-bubble--with-images">
+              <details class="chat-json-collapse" data-shape="json">
+                <summary class="chat-json-summary">JSON</summary>
+              </details>
+            </div>
+          </div>
+        </body></html>`,
+      );
+      for (const theme of ["dark", "light"] as const) {
+        await page.evaluate(
+          (mode) => document.documentElement.setAttribute("data-theme-mode", mode),
+          theme,
+        );
+        const surfaces = await page.locator("[data-shape]").evaluateAll((elements) =>
+          elements.map((element) => {
+            const style = getComputedStyle(element);
+            return {
+              backgroundColor: style.backgroundColor,
+              padding: style.padding,
+            };
+          }),
+        );
+        expect(surfaces[0]).toMatchObject({ padding: "10px 14px" });
+        expect(surfaces[1]).toEqual(surfaces[0]);
+        expect(surfaces[2]).toEqual(surfaces[0]);
+      }
     } finally {
       await closeBrowserPage(page);
     }

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -320,6 +320,7 @@ export function renderGroupedMessage(
 
   const bubbleClasses = [
     "chat-bubble",
+    hasImages ? "chat-bubble--with-images" : "",
     isToolShell ? "chat-bubble--tool-shell" : "",
     opts.isStreaming ? "streaming" : "",
     opts.entryAnimated ? "chat-bubble--user-turn-enter" : "",

--- a/ui/src/pages/chat/components/chat-message-images.ts
+++ b/ui/src/pages/chat/components/chat-message-images.ts
@@ -36,6 +36,7 @@ import {
 
 const MANAGED_OUTGOING_IMAGE_FETCH_TIMEOUT_MS = 30_000;
 const MANAGED_OUTGOING_IMAGE_RETRY_MS = 5_000;
+const MIN_CHAT_IMAGE_PREVIEW_WIDTH = 160;
 type ManagedImageVariant = "full" | "thumbnail";
 
 class ManagedImageResourceDirective extends AsyncDirective {
@@ -205,6 +206,12 @@ export function renderMessageImages(images: RenderableImageBlock[], opts?: Image
   const renderImageElement = (img: RenderableImageBlock, previewUrl: string) => {
     const title = img.alt?.trim() || t("chat.imageLightbox.untitled");
     const managed = isManagedOutgoingImageSource(img.displayUrl);
+    // Upscale genuinely tiny sources enough to read and operate without
+    // stretching every transcript image into a fixed-size tile.
+    const imageClass =
+      img.width !== undefined && img.width < MIN_CHAT_IMAGE_PREVIEW_WIDTH
+        ? "chat-message-image chat-message-image--small"
+        : "chat-message-image";
     return html`
       <span class="chat-image-frame ${managed ? "chat-image-frame--managed" : ""}">
         <button
@@ -219,14 +226,12 @@ export function renderMessageImages(images: RenderableImageBlock[], opts?: Image
           <img
             src=${previewUrl}
             alt=${title}
-            class="chat-message-image"
+            class=${imageClass}
             width=${img.width ?? nothing}
             height=${img.height ?? nothing}
           />
         </button>
-        ${managed
-          ? renderManagedImageActions(img, opts, () => openImage(img, previewUrl))
-          : nothing}
+        ${managed ? renderManagedImageActions(img, opts) : nothing}
       </span>
     `;
   };
@@ -238,7 +243,15 @@ export function renderMessageImages(images: RenderableImageBlock[], opts?: Image
     return renderManagedImageResource(img, opts, renderImageElement);
   };
 
-  return html` <div class="chat-message-images">${images.map((img) => renderImage(img))}</div> `;
+  const layoutClasses = [
+    "chat-message-images",
+    images.length === 1 ? "chat-message-images--single" : "chat-message-images--gallery",
+    images.length === 2 || images.length === 4 ? "chat-message-images--two-column" : "",
+    images.length === 5 ? "chat-message-images--five" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return html` <div class=${layoutClasses}>${images.map((img) => renderImage(img))}</div> `;
 }
 
 function isManagedOutgoingImageSource(source: string): boolean {
@@ -500,7 +513,6 @@ async function convertImageBlobToPng(blob: Blob): Promise<Blob> {
 function renderManagedImageActions(
   image: RenderableImageBlock,
   opts: ImageRenderOptions | undefined,
-  onOpen: () => void,
 ) {
   const title = image.alt?.trim() || t("chat.imageLightbox.untitled");
   const download = async () => {
@@ -528,15 +540,6 @@ function renderManagedImageActions(
   };
   return html`
     <span class="chat-image-actions">
-      <button
-        type="button"
-        class="chat-image-action"
-        title=${t("chat.imageLightbox.open", { title })}
-        aria-label=${t("chat.imageLightbox.open", { title })}
-        @click=${onOpen}
-      >
-        ${icons.externalLink}
-      </button>
       <button
         type="button"
         class="chat-image-action"

--- a/ui/src/pages/chat/components/chat-message-media-lifecycle.test.ts
+++ b/ui/src/pages/chat/components/chat-message-media-lifecycle.test.ts
@@ -82,6 +82,30 @@ function observeSubscriber(subscriber: () => void): () => void {
 }
 
 describe("chat media resource lifecycle", () => {
+  it("marks one-to-five image turns for the transcript and sent-message layouts", () => {
+    const container = document.createElement("div");
+    for (const count of [1, 2, 3, 4, 5]) {
+      const images: RenderableImageBlock[] = Array.from({ length: count }, (_, index) => ({
+        url: `data:image/png;base64,image-${count}-${index}`,
+        displayUrl: `data:image/png;base64,image-${count}-${index}`,
+        alt: `Image ${index + 1}`,
+        width: count === 1 ? 16 : 640,
+        height: count === 1 ? 16 : 640,
+      }));
+      render(renderMessageImages(images), container);
+      const gallery = container.querySelector(".chat-message-images");
+      expect(gallery?.classList.contains("chat-message-images--single")).toBe(count === 1);
+      expect(gallery?.classList.contains("chat-message-images--gallery")).toBe(count > 1);
+      expect(gallery?.classList.contains("chat-message-images--two-column")).toBe(
+        count === 2 || count === 4,
+      );
+      expect(gallery?.classList.contains("chat-message-images--five")).toBe(count === 5);
+      if (count === 1) {
+        expect(container.querySelector(".chat-message-image--small")).not.toBeNull();
+      }
+    }
+  });
+
   it("refreshes every split pane when a shared pairing QR expires", async () => {
     const message = {
       content: [

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -1005,15 +1005,10 @@ describe("grouped chat rendering", () => {
       .mockImplementationOnce(renderMarkdownHtml)
       .mockImplementationOnce(renderMarkdownHtml);
 
-    renderGroupedMessage(
-      container,
-      message,
-      "user",
-      {
-        isUserMessageExpanded: () => false,
-        onToggleUserMessageExpanded,
-      },
-    );
+    renderGroupedMessage(container, message, "user", {
+      isUserMessageExpanded: () => false,
+      onToggleUserMessageExpanded,
+    });
 
     const disclosure = expectElement(container, ".chat-message-disclosure", HTMLDivElement);
     expect(
@@ -1039,15 +1034,10 @@ describe("grouped chat rendering", () => {
     toggle.click();
     expect(onToggleUserMessageExpanded).toHaveBeenCalledWith("user-message:user-message");
 
-    renderGroupedMessage(
-      container,
-      message,
-      "user",
-      {
-        isUserMessageExpanded: () => true,
-        onToggleUserMessageExpanded,
-      },
-    );
+    renderGroupedMessage(container, message, "user", {
+      isUserMessageExpanded: () => true,
+      onToggleUserMessageExpanded,
+    });
 
     const expandedDisclosure = expectElement(container, ".chat-message-disclosure", HTMLDivElement);
     const collapseToggle = expectElement(

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -983,11 +983,23 @@ describe("grouped chat rendering", () => {
     });
   });
 
-  it("collapses long user messages and toggles their disclosure state", () => {
+  it("collapses long image-bearing user messages and toggles their disclosure state", () => {
     const container = document.createElement("div");
     const collapsedLines = ["Inspect AGENTS.md:188 first.", "a".repeat(1_201)];
     const expandedTail = "Full prompt tail after the disclosure boundary.";
     const markdownContent = [...collapsedLines, expandedTail].join("\n");
+    const message = createUserMessage(
+      [
+        { type: "text", text: markdownContent },
+        createMediaBlock({
+          url: "data:image/png;base64,cG5n",
+          alt: "Sent image",
+          width: 640,
+          height: 640,
+        }),
+      ],
+      { timestamp: 1001 },
+    );
     const onToggleUserMessageExpanded = vi.fn();
     markdownRenderMock
       .mockImplementationOnce(renderMarkdownHtml)
@@ -995,7 +1007,7 @@ describe("grouped chat rendering", () => {
 
     renderGroupedMessage(
       container,
-      createUserMessage(markdownContent, { timestamp: 1001 }),
+      message,
       "user",
       {
         isUserMessageExpanded: () => false,
@@ -1004,6 +1016,12 @@ describe("grouped chat rendering", () => {
     );
 
     const disclosure = expectElement(container, ".chat-message-disclosure", HTMLDivElement);
+    expect(
+      expectElement(container, ".chat-bubble", HTMLDivElement).classList.contains(
+        "chat-bubble--with-images",
+      ),
+    ).toBe(true);
+    expect(container.querySelector(".chat-message-image")).not.toBeNull();
     const toggle = expectElement(disclosure, ".chat-message-disclosure__toggle", HTMLButtonElement);
     const collapsedText = expectElement(disclosure, ".chat-text", HTMLDivElement);
     const collapsedFileLink = expectElement(
@@ -1023,7 +1041,7 @@ describe("grouped chat rendering", () => {
 
     renderGroupedMessage(
       container,
-      createUserMessage(markdownContent, { timestamp: 1001 }),
+      message,
       "user",
       {
         isUserMessageExpanded: () => true,

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -4997,8 +4997,11 @@ describe("grouped chat rendering", () => {
     expect(fetchMock).toHaveBeenCalledWith(thumbnailUrl, expect.anything());
 
     const imageActions = container.querySelectorAll<HTMLButtonElement>(".chat-image-action");
-    expect(imageActions).toHaveLength(3);
-    imageActions[1]?.click();
+    expect([...imageActions].map((action) => action.getAttribute("aria-label"))).toEqual([
+      "Download image",
+      "Copy image",
+    ]);
+    imageActions[0]?.click();
     await vi.waitFor(() => expect(click).toHaveBeenCalledOnce());
     expect(clickedDownloads[0]).toBe("Ticketed image.png");
 

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -1031,6 +1031,42 @@ img.chat-avatar.chat-avatar--logo {
   color: hsl(var(--chat-sender-hue) 60% 36%);
 }
 
+/* Keep sent media outside the text surface: the image gallery remains bare,
+   while the following text retains the normal right-aligned user bubble. */
+.chat-group.user:not(.chat-group--peer) .chat-bubble--with-images {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
+
+.chat-group.user:not(.chat-group--peer) .chat-bubble--with-images:hover {
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.chat-group.user:not(.chat-group--peer)
+  .chat-bubble--with-images
+  > .chat-text {
+  width: fit-content;
+  max-width: 100%;
+  padding: 10px 14px;
+  border-radius: var(--radius-md);
+  background: var(--accent-subtle);
+}
+
+:root[data-theme-mode="light"]
+  .chat-group.user:not(.chat-group--peer)
+  .chat-bubble--with-images
+  > .chat-text {
+  background: color-mix(in srgb, var(--accent) 15%, var(--bg));
+  color: var(--text-strong);
+}
+
 /* ── Message metadata (tokens, cost, model, context %) ── */
 .msg-meta {
   --openclaw-tooltip-max-width: min(36rem, calc(100vw - 32px));

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -1051,7 +1051,7 @@ img.chat-avatar.chat-avatar--logo {
 
 .chat-group.user:not(.chat-group--peer)
   .chat-bubble--with-images
-  > .chat-text {
+  > :is(.chat-text, .chat-message-disclosure, .chat-json-collapse) {
   width: fit-content;
   max-width: 100%;
   padding: 10px 14px;
@@ -1062,7 +1062,7 @@ img.chat-avatar.chat-avatar--logo {
 :root[data-theme-mode="light"]
   .chat-group.user:not(.chat-group--peer)
   .chat-bubble--with-images
-  > .chat-text {
+  > :is(.chat-text, .chat-message-disclosure, .chat-json-collapse) {
   background: color-mix(in srgb, var(--accent) 15%, var(--bg));
   color: var(--text-strong);
 }

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1143,8 +1143,11 @@ openclaw-chat-page {
 /* Message images (sent images displayed in chat) */
 .chat-message-images {
   display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  align-items: flex-start;
+  width: 100%;
+  gap: 12px;
   margin-bottom: 8px;
 }
 
@@ -1167,27 +1170,42 @@ openclaw-chat-page {
 }
 
 .chat-image-frame--managed {
-  width: min(100%, 400px);
+  width: fit-content;
+  max-width: min(100%, 400px);
 }
 
 .chat-image-frame--managed .chat-message-image-button {
   align-items: center;
   justify-content: flex-start;
-  width: 100%;
-  min-width: 110px;
-  min-height: 42px;
+  width: auto;
+  min-width: 0;
+  min-height: 0;
+}
+
+.chat-image-frame--managed::after {
+  position: absolute;
+  z-index: 1;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: min(100%, 72px);
+  background: linear-gradient(to bottom, transparent, rgb(4 8 18 / 56%));
+  content: "";
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 140ms ease-out;
 }
 
 .chat-image-actions {
   position: absolute;
-  z-index: 1;
-  top: 6px;
-  right: 6px;
+  z-index: 2;
+  right: 8px;
+  bottom: 8px;
   display: flex;
   gap: 4px;
   opacity: 0;
   pointer-events: none;
-  transform: translateY(-2px);
+  transform: translateY(2px);
   transition:
     opacity 120ms ease-out,
     transform 120ms ease-out;
@@ -1200,11 +1218,20 @@ openclaw-chat-page {
   transform: translateY(0);
 }
 
+.chat-image-frame--managed:hover::after,
+.chat-image-frame--managed:focus-within::after {
+  opacity: 1;
+}
+
 @media (hover: none) {
   .chat-image-actions {
     opacity: 1;
     pointer-events: auto;
     transform: translateY(0);
+  }
+
+  .chat-image-frame--managed::after {
+    opacity: 1;
   }
 }
 
@@ -1212,19 +1239,19 @@ openclaw-chat-page {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 30px;
-  height: 30px;
+  width: 28px;
+  height: 28px;
   padding: 0;
-  border: 1px solid rgb(255 255 255 / 22%);
-  border-radius: 8px;
-  color: var(--media-foreground);
-  background: rgb(12 16 24 / 78%);
-  backdrop-filter: blur(8px);
+  border: 0;
+  border-radius: 0;
+  color: #fff;
+  background: transparent;
   cursor: var(--cursor-action);
 }
 
 .chat-image-action:hover {
-  background: rgb(12 16 24 / 94%);
+  color: rgb(255 255 255 / 72%);
+  background: transparent;
 }
 
 .chat-image-action:focus-visible {
@@ -1246,10 +1273,15 @@ openclaw-chat-page {
   width: auto;
   max-width: min(100%, 400px);
   height: auto;
-  max-height: 240px;
+  max-height: 360px;
   border-radius: var(--radius-xl);
   object-fit: contain;
   transition: transform 150ms ease-out;
+}
+
+.chat-message-image--small {
+  width: 160px;
+  min-width: 160px;
 }
 
 @supports (corner-shape: superellipse(1.5)) {
@@ -1271,13 +1303,45 @@ openclaw-chat-page {
   transform: scale(1.02);
 }
 
-/* User message images align right */
-.chat-group.user .chat-message-images {
-  justify-content: flex-end;
+/* Local user images sit above the text bubble. Multi-image turns use compact
+   gallery tiles; assistant and peer transcript images remain one per row. */
+.chat-group.user:not(.chat-group--peer) .chat-message-images {
+  --chat-user-image-grid-size: min(128px, calc((100vw - 48px) / 3));
+  display: grid;
+  grid-template-columns: repeat(3, var(--chat-user-image-grid-size));
+  justify-content: end;
+  justify-items: end;
+  width: fit-content;
+  max-width: 100%;
+  gap: 4px;
+  margin: 0;
+}
+
+.chat-group.user:not(.chat-group--peer) .chat-message-images--two-column {
+  grid-template-columns: repeat(2, var(--chat-user-image-grid-size));
+}
+
+.chat-group.user:not(.chat-group--peer) .chat-message-images--five
+  > .chat-image-frame:nth-child(4) {
+  grid-column: 2;
+}
+
+.chat-group.user:not(.chat-group--peer) .chat-message-images--single {
+  grid-template-columns: minmax(0, auto);
+}
+
+.chat-group.user:not(.chat-group--peer)
+  .chat-message-images--gallery
+  :is(.chat-image-frame, .chat-message-image-button, .chat-message-image) {
+  width: var(--chat-user-image-grid-size);
+  min-width: 0;
+  height: var(--chat-user-image-grid-size);
+  max-height: none;
+  object-fit: cover;
 }
 
 .chat-group.user.chat-group--peer .chat-message-images {
-  justify-content: flex-start;
+  align-items: flex-start;
 }
 
 .chat-assistant-attachments {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1244,7 +1244,7 @@ openclaw-chat-page {
   padding: 0;
   border: 0;
   border-radius: 0;
-  color: #fff;
+  color: var(--media-foreground);
   background: transparent;
   cursor: var(--cursor-action);
 }

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1321,7 +1321,8 @@ openclaw-chat-page {
   grid-template-columns: repeat(2, var(--chat-user-image-grid-size));
 }
 
-.chat-group.user:not(.chat-group--peer) .chat-message-images--five
+.chat-group.user:not(.chat-group--peer)
+  .chat-message-images--five
   > .chat-image-frame:nth-child(4) {
   grid-column: 2;
 }


### PR DESCRIPTION
Closes #131809

## What Problem This Solves

Chat images currently use inconsistent layouts across assistant and user turns. Tiny previews can be difficult to operate, managed-image controls can escape narrow frames, and lightbox controls can lose contrast over image content.

## Why This Change Was Made

In this PR, the existing image renderer owns the message-count policy while CSS owns presentation:

- Assistant and general transcript images render one per row.
- User images render above a separate right-aligned text surface. One image keeps its natural preview shape; two through five images use compact galleries with the final row right-aligned.
- Known source widths below 160 px scale to a 160 px-wide preview while preserving aspect ratio and the transcript height cap.
- Managed-image actions use a clipped footer fade and expose only Download and Copy.
- Lightbox zoom, original-view, and close controls use borderless glass backgrounds and white foregrounds in both themes.
- Direct text, long-message disclosure, and JSON content retain the normal user text surface when the same message also contains images.

This keeps layout decisions at the renderer and presentation owners without adding configuration or a parallel rendering path.

## User Impact

Media-heavy conversations would be easier to scan, sent photos would read as one message without swallowing the text bubble, and image actions would stay discoverable on tiny, panoramic, tall, and large previews. Lightbox controls would remain visible in both themes without adding opaque chrome over the image.

## Evidence

- [Exact-head GitHub CI passed](https://github.com/openclaw/openclaw/actions/runs/33200119371) for [`111b0016d967`](https://github.com/openclaw/openclaw/commit/111b0016d9674e3d1553996da7f241fa538a8cd2).
- The fixture-backed Control UI rendered the complete media and attachment stress transcript with production message and lightbox components.
- Inspected dark- and light-theme captures cover user image counts one through five, tiny and tall hover bounds, and all lightbox controls.
- Regression coverage exercises the 160 px tiny-image minimum, one-image-per-row transcript flow, tall-image overlay clipping, five-image user gallery placement, renderer layout classes, the two-action managed-image contract, lightbox contrast in both themes, and image-bearing disclosure and JSON text surfaces.
- Production delta: +162/-46 (net +116). Test delta: +290/-24 (net +266).

Source boundaries: `ui/src/pages/chat/components/chat-message-images.ts:248`, `ui/src/styles/chat/layout.css:1143`, `ui/src/styles/chat/grouped.css:1036`, and `ui/src/components/image-lightbox.ts:95`.

Regression boundaries: `ui/src/pages/chat/chat-responsive.browser.test.ts:2242`, `ui/src/pages/chat/chat-responsive.browser.test.ts:2379`, `ui/src/pages/chat/components/chat-message.test.ts:986`, and `ui/src/e2e/chat-image-lightbox.e2e.test.ts:133`.

### User gallery — dark and light

![Five sent images above a separate text bubble in dark mode](https://github.com/user-attachments/assets/a7e89f0c-a397-4dd6-847d-b6e3867a824f)

![Five sent images above a separate text bubble in light mode](https://github.com/user-attachments/assets/01031cec-af9f-4ec2-9335-ee5d0e43c168)

### Hover bounds — tiny and tall

![Tiny image footer controls clipped to the preview in light mode](https://github.com/user-attachments/assets/b442f112-fc52-4863-bb13-e0fb2b482b82)

![Tall image footer controls clipped to the narrow preview in dark mode](https://github.com/user-attachments/assets/1d548637-49d4-403e-b586-6c632f5d5314)

### Lightbox controls — dark and light

![Glassy lightbox controls with a lighter dark-theme base](https://github.com/user-attachments/assets/2b812755-f649-4ea4-9623-a1b34ca06ee2)

![Glassy lightbox controls over light-theme content](https://github.com/user-attachments/assets/72d6c7bd-2818-4322-ab1e-17f21402d3ea)
