### PR TITLE
fix(ui): make inactive split panes obvious and directly closable

### DIFF
--- a/ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts
@@ -365,43 +365,63 @@ suite.define(() => {
 
       const cells = page.locator(".chat-split-view__cell");
       const actionRows = headers.locator(".chat-pane__actions");
-      await expect.poll(() => actionRows.first().isVisible()).toBe(false);
+      const browserPanelToggles = headers.locator(".chat-browser-panel-toggle");
+      const closeButtons = headers.locator(".chat-pane__close-pane");
+      await expect.poll(() => actionRows.first().isVisible()).toBe(true);
       await expect.poll(() => actionRows.last().isVisible()).toBe(true);
+      await expect.poll(() => closeButtons.first().isVisible()).toBe(true);
+      await expect.poll(() => browserPanelToggles.first().isVisible()).toBe(false);
       expect(
-        await headers
-          .first()
-          .locator(".chat-pane__close-pane")
-          .evaluate((button) => {
-            (button as HTMLElement).focus();
-            return document.activeElement === button;
-          }),
-      ).toBe(false);
+        await closeButtons.first().evaluate((button) => {
+          (button as HTMLElement).focus();
+          return document.activeElement === button;
+        }),
+      ).toBe(true);
+      await expect.poll(() => cells.last().getAttribute("class")).toContain("--active");
 
       await panes.first().click({ position: { x: 20, y: 80 } });
       await expect.poll(() => cells.first().getAttribute("class")).toContain("--active");
       await expect.poll(() => actionRows.first().isVisible()).toBe(true);
-      await expect.poll(() => actionRows.last().isVisible()).toBe(false);
+      await expect.poll(() => actionRows.last().isVisible()).toBe(true);
+      await expect.poll(() => browserPanelToggles.last().isVisible()).toBe(false);
       const paneEmphasis = await cells.evaluateAll((nodes) =>
         nodes.map((cell) => {
           const style = getComputedStyle(cell);
+          const overlay = getComputedStyle(cell, "::after");
           return {
             active: cell.classList.contains("chat-split-view__cell--active"),
             boxShadow: style.boxShadow,
             filter: style.filter,
             opacity: style.opacity,
+            overlayBackground: overlay.backgroundColor,
+            overlayContent: overlay.content,
+            overlayPointerEvents: overlay.pointerEvents,
           };
         }),
       );
-      expect(paneEmphasis).toEqual([
-        { active: true, boxShadow: "none", filter: "none", opacity: "1" },
-        { active: false, boxShadow: "none", filter: "saturate(0.45)", opacity: "1" },
-      ]);
+      expect(paneEmphasis[0]).toMatchObject({
+        active: true,
+        boxShadow: "none",
+        filter: "none",
+        opacity: "1",
+        overlayContent: "none",
+      });
+      expect(paneEmphasis[1]).toMatchObject({
+        active: false,
+        boxShadow: "none",
+        filter: "none",
+        opacity: "1",
+        overlayContent: '""',
+        overlayPointerEvents: "none",
+      });
+      expect(paneEmphasis[1]?.overlayBackground).not.toBe("rgba(0, 0, 0, 0)");
 
       const lastPane = page.locator(".chat-split-view__pane").last();
       await lastPane.click({ position: { x: 20, y: 80 } });
       await expect.poll(() => cells.last().getAttribute("class")).toContain("--active");
-      await expect.poll(() => actionRows.first().isVisible()).toBe(false);
+      await expect.poll(() => actionRows.first().isVisible()).toBe(true);
       await expect.poll(() => actionRows.last().isVisible()).toBe(true);
+      await expect.poll(() => browserPanelToggles.first().isVisible()).toBe(false);
       const targetHeader = headers.first();
       const headerGeometry = await headers.evaluateAll((nodes) =>
         nodes.map((header) => {
@@ -476,6 +496,14 @@ suite.define(() => {
       await expect
         .poll(() => new URL(page.url()).pathname)
         .toBe(controlUiSessionPath("agent:main:session-b"));
+
+      const inactiveClose = page
+        .locator(".chat-split-view__cell:not(.chat-split-view__cell--active)")
+        .first()
+        .getByRole("button", { name: "Close pane" });
+      await expect.poll(() => inactiveClose.isVisible()).toBe(true);
+      await inactiveClose.click();
+      await expect.poll(() => panes.count()).toBe(2);
     } finally {
       await suite.closeBrowserContext(context);
     }

--- a/ui/src/pages/chat/components/chat-pane-header.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.ts
@@ -389,6 +389,12 @@ function renderGatewayPicker(props: ChatPaneHeaderProps) {
   `;
 }
 
+// Pane cells activate on bubbled pointer and focus events. Keep close events on
+// their button so an inactive pane is removed before activation can rerender it.
+function stopClosePaneActivation(event: Event): void {
+  event.stopPropagation();
+}
+
 export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
   const copyPathLabel =
     props.copiedAction === "copy-path"
@@ -615,6 +621,8 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
                       class="btn btn--ghost btn--icon chat-icon-btn chat-pane__close-pane"
                       type="button"
                       aria-label=${t("chat.splitView.closePane")}
+                      @pointerdown=${stopClosePaneActivation}
+                      @focusin=${stopClosePaneActivation}
                       @click=${() => props.onClosePane?.(props.paneId)}
                     >
                       ${icons.x}

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -67,6 +67,11 @@
   --resize-handle-active-line-size: 2px;
   --resize-handle-rest-color: color-mix(in srgb, var(--border) 74%, transparent);
   --resize-handle-active-color: color-mix(in srgb, var(--text) 42%, transparent);
+  --split-inactive-content-opacity: 0.75;
+  --split-inactive-saturation: 0.8;
+  --split-inactive-overlay-alpha: 0.45;
+  --split-inactive-brightness: 1;
+  --split-inactive-transition-duration: 0ms;
 
   /*
    * Accent - Punchy signature red
@@ -508,6 +513,12 @@
 /* Light theme tokens apply to every light-mode family. */
 /* Defaults must lose to named palettes even when their link precedes the app CSS. */
 :root:where([data-theme-mode="light"]) {
+  --split-inactive-content-opacity: 0.75;
+  --split-inactive-saturation: 0.65;
+  --split-inactive-overlay-alpha: 0.1;
+  --split-inactive-brightness: 1;
+  --split-inactive-transition-duration: 0ms;
+
   /*
    * Warm paper light mode - terracotta accent on ivory
    *

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -37,17 +37,34 @@ openclaw-chat-pane {
 .chat-split-view__cell {
   --chat-surface: var(--bg-content, var(--bg));
 
+  position: relative;
   display: flex;
   flex-direction: column;
   min-width: 0;
   min-height: 200px;
   overflow: hidden;
+  isolation: isolate;
 }
 
 .chat-split-view:has(> .chat-split-view__column > .chat-split-view__cell--active)
   > .chat-split-view__column
-  > .chat-split-view__cell:not(.chat-split-view__cell--active) {
-  filter: saturate(0.45);
+  > .chat-split-view__cell:not(.chat-split-view__cell--active)::after {
+  /* A flat foreground tint separates neutral transcripts in either theme
+     without filtering the subtree or reducing the close control's contrast. */
+  content: "";
+  position: absolute;
+  z-index: 1;
+  inset: 0;
+  background: color-mix(in srgb, var(--text) 12%, transparent);
+  pointer-events: none;
+}
+
+.chat-split-view:has(> .chat-split-view__column > .chat-split-view__cell--active)
+  > .chat-split-view__column
+  > .chat-split-view__cell:not(.chat-split-view__cell--active)
+  .chat-pane__header {
+  position: relative;
+  z-index: 2;
 }
 
 .chat-split-view:has(> .chat-split-view__column > .chat-split-view__cell--active)
@@ -64,7 +81,8 @@ openclaw-chat-pane {
     .chat-pane__draft-indicator,
     .chat-pane__branches-menu,
     .chat-pane__gateway-menu,
-    .chat-pane__actions
+    .chat-pane__actions .chat-icon-btn:not(.chat-pane__close-pane),
+    .chat-pane__actions > openclaw-chat-header-session-menu
   ) {
   display: none;
 }

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -25,11 +25,23 @@ openclaw-chat-pane {
   overflow: auto;
 }
 
+/* The 6px divider stays fully draggable but overlays the pane boundary instead
+   of consuming a transparent gutter that exposes the split-view background. */
+.chat-split-view > resizable-divider {
+  z-index: 3;
+  margin-inline: -3px;
+}
+
 .chat-split-view__column {
   display: flex;
   flex-direction: column;
   min-width: min(320px, 100%);
   min-height: 0;
+}
+
+.chat-split-view__column > resizable-divider[orientation="horizontal"] {
+  z-index: 3;
+  margin-block: -3px;
 }
 
 /* One cell = pane header + pane; the header lives in-flow with its pane, so
@@ -49,14 +61,26 @@ openclaw-chat-pane {
 .chat-split-view:has(> .chat-split-view__column > .chat-split-view__cell--active)
   > .chat-split-view__column
   > .chat-split-view__cell:not(.chat-split-view__cell--active)::after {
-  /* A flat foreground tint separates neutral transcripts in either theme
-     without filtering the subtree or reducing the close control's contrast. */
+  /* The theme-tuned tint and transcript filter separate neutral panes without
+     reducing the close control's contrast. */
   content: "";
   position: absolute;
   z-index: 1;
   inset: 0;
-  background: color-mix(in srgb, var(--text) 12%, transparent);
+  background: rgb(0 0 0 / var(--split-inactive-overlay-alpha));
   pointer-events: none;
+  transition: background-color var(--split-inactive-transition-duration) ease-out;
+}
+
+.chat-split-view:has(> .chat-split-view__column > .chat-split-view__cell--active)
+  > .chat-split-view__column
+  > .chat-split-view__cell:not(.chat-split-view__cell--active)
+  .chat-main__conversation {
+  opacity: var(--split-inactive-content-opacity);
+  filter: saturate(var(--split-inactive-saturation)) brightness(var(--split-inactive-brightness));
+  transition:
+    opacity var(--split-inactive-transition-duration) ease-out,
+    filter var(--split-inactive-transition-duration) ease-out;
 }
 
 .chat-split-view:has(> .chat-split-view__column > .chat-split-view__cell--active)


### PR DESCRIPTION
Closes #131815

Follow-up to #126714.

## What Problem This Solves

Inactive split panes were too easy to confuse with the active pane, their close action was hidden, and the transparent resize handle exposed a visible gap between panes.

## Why This Change Was Made

The split shell now owns a theme-calibrated inactive treatment instead of applying a blunt filter to the whole pane. Content is gently desaturated and dimmed under a neutral overlay while the pane header remains legible and the close action stays available.

The resize divider keeps its full 6px hit target but overlays the pane boundary rather than consuming layout space, removing the visible seam without reducing usability.

## User Impact

Users can identify the active pane at a glance, close an inactive pane directly, and resize either split direction without seeing a gap beside the handle.

## Evidence

Captured from the Control UI browser flow with a mocked Gateway, two split panes, a 1440x900 viewport, and identical fixture content and framing for every before/after pair.

### Resize handle close-up

The 6px resize target remains in place. Before, it consumes a transparent gutter; after, it overlays the pane boundary so both surfaces meet cleanly.

| Mode | Before | After |
| --- | --- | --- |
| Claw light | ![Claw light resize handle before, showing a gap between panes](https://github.com/user-attachments/assets/2e92ae09-242b-43f4-b64f-2afbbedbfd9e) | ![Claw light resize handle after, with panes meeting cleanly](https://github.com/user-attachments/assets/c71facf7-ae76-4c47-bc6c-6a82f3c2c78c) |
| Claw dark | ![Claw dark resize handle before, showing a gap between panes](https://github.com/user-attachments/assets/5ba5082f-2e5f-4301-bf0e-5cddf3bd7076) | ![Claw dark resize handle after, with panes meeting cleanly](https://github.com/user-attachments/assets/57b782aa-092c-4767-8ac2-1b40268088af) |

### Default theme

The inactive right pane is now visibly subordinate while remaining readable, and its close action stays available.

| Mode | Before | After |
| --- | --- | --- |
| Claw light | ![Claw light split view before](https://github.com/user-attachments/assets/57f38b37-58ef-492c-9ae8-0d60eb66ba68) | ![Claw light split view after, with the inactive right pane demoted](https://github.com/user-attachments/assets/3b25f5a3-e82b-4a42-ac01-f437d302e16c) |
| Claw dark | ![Claw dark split view before](https://github.com/user-attachments/assets/0548ddb2-0dca-41a0-9f45-5561abf8dc55) | ![Claw dark split view after, with the inactive right pane demoted](https://github.com/user-attachments/assets/8db5a32d-8f39-470d-abfb-b9e5d8830ae0) |

<details open>
<summary>All other theme families: 12 before/after combinations</summary>

#### Knot

| Mode | Before | After |
| --- | --- | --- |
| Light | ![Knot light split view before](https://github.com/user-attachments/assets/11869dfd-707b-40d9-85c6-718541023bcd) | ![Knot light split view after](https://github.com/user-attachments/assets/9305d815-eb94-4b00-9c50-2b0cd4d24706) |
| Dark | ![Knot dark split view before](https://github.com/user-attachments/assets/da308e09-1f58-4bff-be72-d55c14f85b31) | ![Knot dark split view after](https://github.com/user-attachments/assets/4fccdb1c-9ca6-423f-b30c-b3e9fc297731) |

#### Dash

| Mode | Before | After |
| --- | --- | --- |
| Light | ![Dash light split view before](https://github.com/user-attachments/assets/7e5c502b-b018-4457-bbb9-911faf7cfcdb) | ![Dash light split view after](https://github.com/user-attachments/assets/65c712c2-062a-4735-ab5c-a603cf9fab6c) |
| Dark | ![Dash dark split view before](https://github.com/user-attachments/assets/1d106005-a3af-4f65-b2ba-f7d1873207ac) | ![Dash dark split view after](https://github.com/user-attachments/assets/e1717482-67b1-4b85-895f-050b9672d477) |

#### Absolutely

| Mode | Before | After |
| --- | --- | --- |
| Light | ![Absolutely light split view before](https://github.com/user-attachments/assets/e72a8a20-b440-4be3-b675-834d82b8612f) | ![Absolutely light split view after](https://github.com/user-attachments/assets/6a5af24f-1a6c-4cc9-ab33-a9a09e174b58) |
| Dark | ![Absolutely dark split view before](https://github.com/user-attachments/assets/945d3f96-5f68-4dd9-9ef9-4d594e9819a5) | ![Absolutely dark split view after](https://github.com/user-attachments/assets/c8246ac6-1908-4cc9-84df-6c16bd6c0240) |

#### Tide

| Mode | Before | After |
| --- | --- | --- |
| Light | ![Tide light split view before](https://github.com/user-attachments/assets/93061d24-979e-4b76-921e-3cc56516f93a) | ![Tide light split view after](https://github.com/user-attachments/assets/3d459f3a-ff18-4458-8c23-fd546cdf7e49) |
| Dark | ![Tide dark split view before](https://github.com/user-attachments/assets/d5865ad4-a28a-41ac-90b1-1784bcab078e) | ![Tide dark split view after](https://github.com/user-attachments/assets/838945d7-c3b3-44eb-82e3-3863c983a879) |

#### Beacon

| Mode | Before | After |
| --- | --- | --- |
| Light | ![Beacon light split view before](https://github.com/user-attachments/assets/4eeca03c-53dd-4e55-a800-acaa89205b2e) | ![Beacon light split view after](https://github.com/user-attachments/assets/02e3460c-c471-4d0b-9b14-8a4d35d4d430) |
| Dark | ![Beacon dark split view before](https://github.com/user-attachments/assets/d4bf9b05-4aa3-4e64-976b-40b5b2bc19da) | ![Beacon dark split view after](https://github.com/user-attachments/assets/9e1b6e48-bb2f-4355-92c4-a55bd5fdced6) |

#### Phosphor

| Mode | Before | After |
| --- | --- | --- |
| Light | ![Phosphor light split view before](https://github.com/user-attachments/assets/28e65b5c-fba4-4c09-8550-bc522287b20d) | ![Phosphor light split view after](https://github.com/user-attachments/assets/b8e599b0-25ec-4b1c-a8c5-ab145c2eeb01) |
| Dark | ![Phosphor dark split view before](https://github.com/user-attachments/assets/87056de1-2479-4c43-a360-a317ebe8f2b2) | ![Phosphor dark split view after](https://github.com/user-attachments/assets/ccfb1395-81ea-44cf-82a1-0ed51f48e129) |

</details>

