### PR TITLE
fix(ui): reject unknown chat agents

### DIFF
--- a/ui/src/app/app-root.ts
+++ b/ui/src/app/app-root.ts
@@ -38,6 +38,7 @@ type FocusDashboardRouteState =
   | { kind: "not-found" }
   | { kind: "error"; message: string }
   | { kind: "ambiguous"; data: Extract<ChatRouteData, { kind: "ambiguous" }> }
+  | { kind: "agent-not-found"; data: Extract<ChatRouteData, { kind: "agent-not-found" }> }
   | { kind: "session"; data: Extract<ChatRouteData, { kind: "session" }> };
 
 function routeLocationHref(location: RouteLocation): string {
@@ -331,6 +332,10 @@ export class OpenClawApp extends OpenClawLightDomElement {
         };
         return;
       }
+      if (result.kind === "agent-not-found") {
+        this.focusDashboardRoute = { kind: "agent-not-found", data: result };
+        return;
+      }
       this.focusDashboardRoute = { kind: "session", data: result };
       if (result.canonicalLocation && result.canonicalLocationSource) {
         this.replaceFocusDashboardLocation(
@@ -379,6 +384,15 @@ export class OpenClawApp extends OpenClawLightDomElement {
         <section class="board-document__state board-document__state--error stack" role="alert">
           <span>${t("dashboardDocument.loadFailed", { error: route.message })}</span>
           ${this.renderFocusEscape(t("dashboardDocument.close"))}
+        </section>
+      </main>`;
+    }
+    if (route.kind === "agent-not-found") {
+      return html`<main class="board-document">
+        <section class="board-document__state stack" role="status">
+          <strong>${t("chat.sessionRoute.agentNotFoundTitle")}</strong>
+          <span>${t("chat.sessionRoute.agentNotFound", { agentId: route.data.agentId })}</span>
+          ${this.renderFocusEscape(t("common.back"))}
         </section>
       </main>`;
     }

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5291,6 +5291,10 @@ export const en: TranslationMap = {
       chooseTitle: "Choose a session",
       multipleMatches: "More than one session matches {shortId}.",
       additionalMatches: "Search results remain. Use a longer id prefix.",
+      agentNotFoundTitle: "Agent not found",
+      agentNotFound: 'Agent "{agentId}" is not configured and has no saved conversation.',
+      agentRemoved: 'Agent "{agentId}" was removed. This conversation is read-only.',
+      openDefault: "Open default chat",
     },
     commandResults: {
       startingNewThread: "Starting new session...",

--- a/ui/src/pages/chat/chat-page.test.ts
+++ b/ui/src/pages/chat/chat-page.test.ts
@@ -151,7 +151,9 @@ function setNavigationContext(page: ChatPage) {
   const context = {
     basePath: "",
     sessions: { state: { result: null }, subscribe: () => () => undefined, patch },
-    agents: { state: { agentsList: { defaultId: "main", mainKey: "main" } } },
+    agents: {
+      state: { agentsList: { defaultId: "main", agents: [{ id: "main" }, { id: "research" }] } },
+    },
     gateway: { snapshot: { hello: null }, subscribe: () => () => undefined },
     navigate,
     replace,

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -38,7 +38,11 @@ import type { BoardFace, BoardVisibleChatDock } from "../../lib/board/settings.t
 import type { BoardTab } from "../../lib/board/types.ts";
 import { formatUiError } from "../../lib/format-error.ts";
 import { parseCatalogSessionKey } from "../../lib/sessions/catalog-key.ts";
-import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
+import {
+  areUiSessionKeysEquivalent,
+  normalizeAgentId,
+  parseAgentSessionKey,
+} from "../../lib/sessions/session-key.ts";
 import type { SwarmRosterHydrator } from "../../lib/sessions/swarm-roster.ts";
 import { SessionUnreadPatchGuard } from "../../lib/sessions/unread.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
@@ -466,6 +470,14 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
   // the sentinel never scrolls out of view when nothing new renders.
   protected readonly olderCursorsSeen = new Set<string>();
 
+  protected get removedAgent(): boolean {
+    const agentId = parseAgentSessionKey(this.state?.sessionKey)?.agentId;
+    const agents = this.context?.agents.state.agentsList?.agents;
+    return Boolean(
+      agentId && agents && !agents.some((agent) => normalizeAgentId(agent.id) === agentId),
+    );
+  }
+
   constructor() {
     super();
     observeNativeGateway(this);
@@ -479,6 +491,10 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
             }
             notify();
           }),
+      )
+      .watch(
+        () => this.context?.agents,
+        (agents, notify) => agents.subscribe(notify),
       )
       .watch(
         () => this.context?.runtimeConfig,

--- a/ui/src/pages/chat/chat-pane-board.ts
+++ b/ui/src/pages/chat/chat-pane-board.ts
@@ -362,12 +362,13 @@ export abstract class ChatPaneBoard extends ChatPaneHistory {
         dockSize: this.boardChatDockSize,
         chat,
         divider: this.renderBoardDivider("bottom"),
-        canMutate: board.provider.canMutate,
-        canGrant: board.provider.canGrant,
+        canMutate: !this.removedAgent && board.provider.canMutate,
+        canGrant: !this.removedAgent && board.provider.canGrant,
         callbacks: {
           appViewGeneration: board.provider.appViewGeneration,
-          applyOps: (ops) => board.provider.applyOps(ops),
-          grant: (name, decision) => board.provider.grant(name, decision),
+          applyOps: (ops) => (this.removedAgent ? Promise.resolve() : board.provider.applyOps(ops)),
+          grant: (name, decision) =>
+            this.removedAgent ? Promise.resolve() : board.provider.grant(name, decision),
           selectTab: (tabId) => {
             this.boardCommandDock = null;
             this.persistBoardSessionView({ face: "dashboard", activeTabId: tabId });

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -23,6 +23,7 @@ import { collectKnownSessionGroups } from "../../lib/sessions/grouping.ts";
 import {
   canArchiveSessionRow,
   canDeleteSessionRows,
+  parseAgentSessionKey,
   resolveUiConfiguredMainKey,
   resolveUiSessionNavigationParentKey,
 } from "../../lib/sessions/session-key.ts";
@@ -178,12 +179,13 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
       sharingReadAccess.allowed || sharingVisibilityAccess.allowed
         ? undefined
         : sharingReadAccess.reason;
-    const renameAccess = row
-      ? readSessionMethodAccess(this.context.gateway.snapshot, {
-          method: "sessions.patch",
-          params: { key: row.key, label: null },
-        })
-      : null;
+    const renameAccess =
+      row && !this.removedAgent
+        ? readSessionMethodAccess(this.context.gateway.snapshot, {
+            method: "sessions.patch",
+            params: { key: row.key, label: null },
+          })
+        : null;
     const renameDisabledReason =
       this.state?.connected !== true || !renameAccess
         ? t("sessionsView.actionRequiresConnection")
@@ -194,8 +196,12 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
       agentsList: this.context.agents.state.agentsList,
       hello: this.context.gateway.snapshot.hello,
     });
-    const archiveAllowed = Boolean(row && canArchiveSessionRow(row, configuredMainKey));
-    const deleteAllowed = Boolean(row && canDeleteSessionRows([row], configuredMainKey));
+    const archiveAllowed = Boolean(
+      row && !this.removedAgent && canArchiveSessionRow(row, configuredMainKey),
+    );
+    const deleteAllowed = Boolean(
+      row && !this.removedAgent && canDeleteSessionRows([row], configuredMainKey),
+    );
     const sessionActionDisabledReasons = row
       ? sessionMenuReasons({
           snapshot: this.context.gateway.snapshot,
@@ -399,7 +405,8 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
       ownerViewing,
       personActivity,
       catalog,
-      editing: this.headerEditing && this.headerRenameSession?.key === row?.key,
+      editing:
+        !this.removedAgent && this.headerEditing && this.headerRenameSession?.key === row?.key,
       renameValue: this.headerRenameValue,
       workspaceRoot: workspace.root,
       workspaceLabel: workspace.label,
@@ -407,7 +414,11 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
       parentSession: resolveChatPaneParentSession(row, this.state?.sessionsResult?.sessions ?? []),
       branch,
       branches: this.state ? displayedChatSessionBranches(this.state) : [],
-      branchSwitchDisabledReason,
+      branchSwitchDisabledReason: this.removedAgent
+        ? t("chat.sessionRoute.agentRemoved", {
+            agentId: parseAgentSessionKey(this.state?.sessionKey)?.agentId ?? "",
+          })
+        : branchSwitchDisabledReason,
       platform: this.headerPlatform,
       canReveal,
       copiedAction: this.headerCopiedAction,
@@ -433,67 +444,70 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
               variant="session"
             ></openclaw-viewer-facepile>`
           : nothing,
-      faceControl: renderBoardViewSwitch({
-        hasBoard: board.hasBoard,
-        face: board.face,
-        dock: board.dock,
-        canChangeDock: canChangeBoardDock,
-        fullscreenControl: board.hasBoard ? this.boardFullscreen.renderButton() : undefined,
-        onSelectMode: (mode) => {
-          if (mode === "chat") {
-            void this.boardFullscreen.exit();
-          }
-          if (!canChangeBoardDock) {
-            const face = mode === "chat" ? "chat" : "dashboard";
-            this.syncChatSidebarForDock(face === "dashboard" ? board.dock : "hidden");
-            this.persistBoardSessionView({ face });
-            return;
-          }
-          if (mode === "chat") {
-            this.syncChatSidebarForDock("hidden");
-            this.persistBoardSessionView({ face: "chat" });
-            return;
-          }
-          this.persistBoardSessionView({ face: "dashboard" });
-          if (mode === "split") {
-            if (board.dock === "hidden") {
-              this.handleBoardDockChange(board.reopenDock);
-            } else {
-              this.syncChatSidebarForDock(board.dock);
-            }
-          } else if (board.dock !== "hidden") {
-            this.handleBoardDockChange("hidden");
-          }
-        },
-        onDockSideChange: (dock) => this.handleBoardDockChange(dock),
-      }),
-      sharingControl: sharingMethodsSupported
-        ? renderChatSessionSharing({
-            session: row,
-            state: row
-              ? this.sessionSharingStates.get(this.sessionSharingCacheKey(row.key))
-              : undefined,
-            allowedVisibilities: sharingSnapshot.hello?.policy?.allowedSessionVisibilities,
-            membersAvailable: sharingReadAccess.allowed,
-            openDisabledReason: sharingOpenDisabledReason,
-            visibilityDisabledReason: sharingVisibilityAccess.allowed
-              ? undefined
-              : sharingVisibilityAccess.reason,
-            memberAddDisabledReason: sharingMemberAddAccess.allowed
-              ? undefined
-              : sharingMemberAddAccess.reason,
-            memberRemoveDisabledReason: sharingMemberRemoveAccess.allowed
-              ? undefined
-              : sharingMemberRemoveAccess.reason,
-            onOpen: () => row && void this.loadSessionSharing(row),
-            onVisibilityChange: (visibility) =>
-              row && void this.setSessionVisibility(row, visibility),
-            onMemberChange: (identityId, member) =>
-              row && void this.setSessionMember(row, identityId, member),
-          })
-        : nothing,
+      faceControl: this.removedAgent
+        ? nothing
+        : renderBoardViewSwitch({
+            hasBoard: board.hasBoard,
+            face: board.face,
+            dock: board.dock,
+            canChangeDock: canChangeBoardDock,
+            fullscreenControl: board.hasBoard ? this.boardFullscreen.renderButton() : undefined,
+            onSelectMode: (mode) => {
+              if (mode === "chat") {
+                void this.boardFullscreen.exit();
+              }
+              if (!canChangeBoardDock) {
+                const face = mode === "chat" ? "chat" : "dashboard";
+                this.syncChatSidebarForDock(face === "dashboard" ? board.dock : "hidden");
+                this.persistBoardSessionView({ face });
+                return;
+              }
+              if (mode === "chat") {
+                this.syncChatSidebarForDock("hidden");
+                this.persistBoardSessionView({ face: "chat" });
+                return;
+              }
+              this.persistBoardSessionView({ face: "dashboard" });
+              if (mode === "split") {
+                if (board.dock === "hidden") {
+                  this.handleBoardDockChange(board.reopenDock);
+                } else {
+                  this.syncChatSidebarForDock(board.dock);
+                }
+              } else if (board.dock !== "hidden") {
+                this.handleBoardDockChange("hidden");
+              }
+            },
+            onDockSideChange: (dock) => this.handleBoardDockChange(dock),
+          }),
+      sharingControl:
+        sharingMethodsSupported && !this.removedAgent
+          ? renderChatSessionSharing({
+              session: row,
+              state: row
+                ? this.sessionSharingStates.get(this.sessionSharingCacheKey(row.key))
+                : undefined,
+              allowedVisibilities: sharingSnapshot.hello?.policy?.allowedSessionVisibilities,
+              membersAvailable: sharingReadAccess.allowed,
+              openDisabledReason: sharingOpenDisabledReason,
+              visibilityDisabledReason: sharingVisibilityAccess.allowed
+                ? undefined
+                : sharingVisibilityAccess.reason,
+              memberAddDisabledReason: sharingMemberAddAccess.allowed
+                ? undefined
+                : sharingMemberAddAccess.reason,
+              memberRemoveDisabledReason: sharingMemberRemoveAccess.allowed
+                ? undefined
+                : sharingMemberRemoveAccess.reason,
+              onOpen: () => row && void this.loadSessionSharing(row),
+              onVisibilityChange: (visibility) =>
+                row && void this.setSessionVisibility(row, visibility),
+              onMemberChange: (identityId, member) =>
+                row && void this.setSessionMember(row, identityId, member),
+            })
+          : nothing,
       sessionMenuAction:
-        row && this.state
+        row && this.state && !this.removedAgent
           ? html`<openclaw-chat-header-session-menu
               .session=${{
                 label:
@@ -542,7 +556,7 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
       nativeGateways: this.nativeGateways,
       gatewaysSnapshot: this.gatewaysSnapshot,
       onboarding: this.onboarding,
-      onBeginRename: () => row && this.beginHeaderRename(row),
+      onBeginRename: () => row && !this.removedAgent && this.beginHeaderRename(row),
       onRenameInput: (value) => {
         this.headerRenameValue = value;
       },
@@ -561,9 +575,12 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
       onOpenParentSession: (sessionKey) => {
         this.onPaneSessionChange?.(this.paneId, sessionKey);
       },
-      onPlacementMove: () => row && void this.moveHeaderPlacement(row),
-      onPlacementReclaim: () => row && void this.reclaimHeaderPlacement(row),
+      onPlacementMove: () => row && !this.removedAgent && void this.moveHeaderPlacement(row),
+      onPlacementReclaim: () => row && !this.removedAgent && void this.reclaimHeaderPlacement(row),
       onBranchSelect: (leafEntryId) => {
+        if (this.removedAgent) {
+          return;
+        }
         const access = readChatSessionActionAccess(
           this.context.gateway.snapshot,
           Boolean(this.state?.chatRunId),

--- a/ui/src/pages/chat/chat-pane-layout-render.ts
+++ b/ui/src/pages/chat/chat-pane-layout-render.ts
@@ -122,13 +122,21 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
       lastReadAt: selectedSession?.lastReadAt,
       pullRequests: this.sessionPullRequests,
       companion: companionThread,
-      onCompanionSubmit: (question) => void this.submitSessionCompanionQuestion(question),
+      onCompanionSubmit: (question) => {
+        if (!this.removedAgent) {
+          void this.submitSessionCompanionQuestion(question);
+        }
+      },
       onCompanionDraftChange: (draft) =>
         this.sessionCompanionThreads.setDraft(state.sessionKey, draft, currentAgentId),
       onCompanionVisibilityChange: this.setSessionObserverVisibility,
       connected: state.connected,
       pendingQuestion: companionThread.pendingQuestion,
-      onClearCompanion: () => void this.clearSessionCompanion(),
+      onClearCompanion: () => {
+        if (!this.removedAgent) {
+          void this.clearSessionCompanion();
+        }
+      },
       discussion,
       discussionAvailable,
       discussionOpenUrl: discussion?.openUrl ?? null,

--- a/ui/src/pages/chat/chat-pane-removed-agent.test.ts
+++ b/ui/src/pages/chat/chat-pane-removed-agent.test.ts
@@ -1,0 +1,64 @@
+/* @vitest-environment jsdom */
+
+import { html, nothing } from "lit";
+import { describe, expect, it } from "vitest";
+import type { ApplicationContext } from "../../app/context.ts";
+import { ChatPane } from "./chat-pane-render.ts";
+import {
+  createInitializationContext,
+  createSessionCapabilityFixture,
+} from "./chat-pane.test-support.ts";
+import { createPageState } from "./chat-state-page.ts";
+import type { ChatProps } from "./chat-view.ts";
+
+describe("chat pane removed agent", () => {
+  it("keeps the saved conversation read-only", () => {
+    class RemovedAgentChatPane extends ChatPane {
+      chatProps: ChatProps | undefined;
+
+      initialize(context: ApplicationContext) {
+        this.context = context;
+        this.state = createPageState(
+          context,
+          { afterCommit: () => () => {}, invalidate: () => {} },
+          this,
+        );
+        return this.state;
+      }
+
+      protected override renderChatPaneLayout(params: { chatProps: ChatProps }) {
+        this.chatProps = params.chatProps;
+        return html``;
+      }
+    }
+    customElements.define("openclaw-chat-removed-agent", RemovedAgentChatPane);
+    const pane = document.createElement("openclaw-chat-removed-agent") as RemovedAgentChatPane;
+    const context = {
+      ...createInitializationContext(),
+      agents: {
+        state: { agentsList: { defaultId: "main", agents: [{ id: "main" }] } },
+        subscribe: () => () => undefined,
+      },
+      sessions: createSessionCapabilityFixture({
+        state: { modelOverrides: {} },
+        think: () => undefined,
+      }),
+    } as unknown as ApplicationContext;
+    const state = pane.initialize(context);
+    state.sessionKey = "agent:ghost:main";
+    state.agentsList = { defaultId: "main", agents: [{ id: "main" }] } as never;
+    pane.render();
+
+    expect(pane.chatProps).toMatchObject({
+      canSend: false,
+      disabledReason: 'Agent "ghost" was removed. This conversation is read-only.',
+      composerControls: nothing,
+      capabilityMenu: undefined,
+      onClearHistory: undefined,
+      onForkMessage: undefined,
+      onGoalAction: undefined,
+      onGoalSubmit: undefined,
+      onRewindMessage: undefined,
+    });
+  });
+});

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -102,6 +102,7 @@ export class ChatPane extends ChatPaneLayoutRender {
       Boolean(placement) && placement?.state !== "local" && !hasAbortableSessionRun(state);
     const canPublishPullRequest =
       Boolean(publishClient) &&
+      !this.removedAgent &&
       Boolean(selectedSession?.key && !selectedSessionArchived) &&
       !hasAbortableSessionRun(state) &&
       publicationHasDirectPlacement &&
@@ -206,7 +207,12 @@ export class ChatPane extends ChatPaneLayoutRender {
     // Placement progress already explains its gate in the transcript. Other
     // gates need a reason here or a sessionDisabledBanner.
     const modelUnavailableMessage = chatModelUnavailableMessage(modelUnavailableReason);
+    const removedAgentMessage =
+      this.removedAgent && currentAgentId
+        ? t("chat.sessionRoute.agentRemoved", { agentId: currentAgentId })
+        : null;
     const disabledReason =
+      removedAgentMessage ??
       modelUnavailableMessage ??
       (sessionParticipationBlocked && !suggestionViewer
         ? t("chat.sessionSharing.readOnlyNotice")
@@ -282,19 +288,20 @@ export class ChatPane extends ChatPaneLayoutRender {
       state.requestUpdate?.();
     };
     const replyMessageAccess = this.currentReplyMessageAccess(state.sessionKey);
-    const composerControls = catalogKey
-      ? undefined
-      : renderChatPaneComposerControls({
-          state,
-          selectedSession,
-          agentDefaultModel,
-          modelAccess: mutationAccess.model,
-          effortAccess: mutationAccess.effort,
-          permissionAccess: mutationAccess.permission,
-          canSelectFull: hasOperatorAdminAccess(gatewaySnapshot.hello?.auth ?? null),
-          toastAnchor: this,
-          onModelSetup: () => this.context.navigate("model-setup"),
-        });
+    const composerControls =
+      catalogKey || removedAgentMessage
+        ? undefined
+        : renderChatPaneComposerControls({
+            state,
+            selectedSession,
+            agentDefaultModel,
+            modelAccess: mutationAccess.model,
+            effortAccess: mutationAccess.effort,
+            permissionAccess: mutationAccess.permission,
+            canSelectFull: hasOperatorAdminAccess(gatewaySnapshot.hello?.auth ?? null),
+            toastAnchor: this,
+            onModelSetup: () => this.context.navigate("model-setup"),
+          });
     const props: ChatProps = {
       transcript: this.transcript,
       paneId: this.presentationId,
@@ -386,8 +393,9 @@ export class ChatPane extends ChatPaneLayoutRender {
         ? (typing, preview) => this.sendTypingState(typing, preview)
         : undefined,
       canSend: catalogKey
-        ? this.catalogSession?.canContinue === true
-        : !modelSetupRequired &&
+        ? !removedAgentMessage && this.catalogSession?.canContinue === true
+        : !removedAgentMessage &&
+          !modelSetupRequired &&
           !modelUnavailableMessage &&
           !selectedSessionArchived &&
           !restartRecoveryTombstoned &&
@@ -395,12 +403,13 @@ export class ChatPane extends ChatPaneLayoutRender {
           !placementStartupPending,
       disabledReason: catalogDisabledReason ?? disabledReason,
       disabledReasonTone:
-        sessionParticipationBlocked && !suggestionViewer && !catalogDisabledReason
+        removedAgentMessage ||
+        (sessionParticipationBlocked && !suggestionViewer && !catalogDisabledReason)
           ? "info"
           : "danger",
       disabledBanner: this.sessionDisabledBanner({
         catalogDisabledReason,
-        modelSetupRequired,
+        modelSetupRequired: modelSetupRequired && !removedAgentMessage,
         restartRecoveryTombstoned,
         selectedSessionArchived,
         selectedSessionId: selectedSession?.sessionId?.trim() || undefined,
@@ -434,9 +443,10 @@ export class ChatPane extends ChatPaneLayoutRender {
           : undefined,
       sessions: state.sessionsResult,
       toolOverrides: selectedSession?.toolOverrides,
-      capabilityMenu: catalogKey
-        ? undefined
-        : this.composerCapabilities.props(this.context, state, selectedSession, currentAgentId),
+      capabilityMenu:
+        catalogKey || removedAgentMessage
+          ? undefined
+          : this.composerCapabilities.props(this.context, state, selectedSession, currentAgentId),
       swarmSessions: this.swarmHydrator?.rows ?? [],
       sessionHost: {
         assistantAgentId: state.assistantAgentId,
@@ -605,7 +615,9 @@ export class ChatPane extends ChatPaneLayoutRender {
         onEditSubmit: sessionParticipationBlocked ? undefined : state.submitQueuedChatMessageEdit,
         onCancel: state.cancelQueuedChatMessageEdit,
       },
-      onGoalAction: (goalId, action) => void mutateChatGoal(state, { goalId, action }),
+      onGoalAction: removedAgentMessage
+        ? undefined
+        : (goalId, action) => void mutateChatGoal(state, { goalId, action }),
       goalDraftMode: state.chatGoalDraftMode ?? null,
       currentSessionId: state.currentSessionId,
       onGoalDraftModeChange: (mode) => {
@@ -613,7 +625,7 @@ export class ChatPane extends ChatPaneLayoutRender {
         state.handleChatDraftChange(state.chatMessage);
       },
       onGoalSubmit:
-        suggestionViewer || catalogKey
+        suggestionViewer || catalogKey || removedAgentMessage
           ? undefined
           : (draft, submissionAction) => submitChatGoalDraft(state, draft, submissionAction),
       onCompanionQuestion: (question) => void this.submitSessionCompanionQuestion(question),
@@ -623,11 +635,14 @@ export class ChatPane extends ChatPaneLayoutRender {
         state.chatReplyTarget = null;
         state.requestUpdate?.();
       },
-      onSetReply: selectedSessionArchived ? undefined : setReply,
+      onSetReply: selectedSessionArchived || removedAgentMessage ? undefined : setReply,
       replyMessageAccess: catalogKey || selectedSessionArchived ? undefined : replyMessageAccess,
-      onRewindMessage: selectedSessionArchived ? undefined : sessionActionCallbacks.onRewindMessage,
-      onForkMessage: sessionActionCallbacks.onForkMessage,
-      onClearHistory: sessionActionCallbacks.onClearHistory,
+      onRewindMessage:
+        selectedSessionArchived || removedAgentMessage
+          ? undefined
+          : sessionActionCallbacks.onRewindMessage,
+      onForkMessage: removedAgentMessage ? undefined : sessionActionCallbacks.onForkMessage,
+      onClearHistory: removedAgentMessage ? undefined : sessionActionCallbacks.onClearHistory,
       agentsList: state.agentsList,
       currentAgentId,
       ...chatProps,

--- a/ui/src/pages/chat/chat-pane-session-menu.ts
+++ b/ui/src/pages/chat/chat-pane-session-menu.ts
@@ -60,6 +60,9 @@ export abstract class ChatPaneSessionMenu extends ChatPaneContext {
   }
 
   protected async handleHeaderSessionAction(action: HeaderMenuAction, row: GatewaySessionRow) {
+    if (this.removedAgent) {
+      return;
+    }
     if (action.kind === "open-in") {
       openEditor(action.editor, action.path);
       return;
@@ -334,7 +337,8 @@ export abstract class ChatPaneSessionMenu extends ChatPaneContext {
       this.context.gateway === scope.gateway &&
       this.context.sessions === scope.sessions &&
       scope.gateway.snapshot.phase === "connected" &&
-      scope.gateway.snapshot.client === scope.client
+      scope.gateway.snapshot.client === scope.client &&
+      !this.removedAgent
     );
   }
 
@@ -385,7 +389,7 @@ export abstract class ChatPaneSessionMenu extends ChatPaneContext {
     this.headerEditing = false;
     this.headerRenameSession = null;
     const state = this.state;
-    if (!session || !state || unchangedGeneratedTitle || unchangedLabel) {
+    if (!session || !state || this.removedAgent || unchangedGeneratedTitle || unchangedLabel) {
       return;
     }
     const access = readSessionMethodAccess(this.context.gateway.snapshot, {

--- a/ui/src/pages/chat/chat-pane-task-suggestions.ts
+++ b/ui/src/pages/chat/chat-pane-task-suggestions.ts
@@ -219,9 +219,12 @@ export abstract class ChatPaneTaskSuggestions extends ChatPaneSharing {
       sessionSuggestionBusyIds: this.sessionSuggestionBusyIds,
       sessionSuggestionsArchived: archived,
       canResolveSessionSuggestions:
+        !this.removedAgent &&
         canWrite &&
         isGatewayMethodAdvertised(gatewaySnapshot, "session.suggestions.resolve") === true,
-      onResolveSessionSuggestion: this.resolveCurrentSessionSuggestion.bind(this),
+      onResolveSessionSuggestion: this.removedAgent
+        ? undefined
+        : this.resolveCurrentSessionSuggestion.bind(this),
       canAcceptTaskSuggestions:
         canAdmin && isGatewayMethodAdvertised(gatewaySnapshot, "taskSuggestions.accept") === true,
       canAcceptTaskSuggestionModes:

--- a/ui/src/pages/chat/route-loader-session-query.ts
+++ b/ui/src/pages/chat/route-loader-session-query.ts
@@ -1,0 +1,196 @@
+import { controlUiSessionSlug } from "@openclaw/session-url-contract";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
+import { waitForGatewayClient } from "../../app/gateway-readiness.ts";
+import {
+  areUiSessionKeysEquivalent,
+  isUiGlobalScopeConfigured,
+  isUiGlobalSessionKey,
+  normalizeAgentId,
+  parseAgentSessionKey,
+  resolveUiGlobalAliasAgentId,
+} from "../../lib/sessions/session-key.ts";
+import type { SessionRouteContext as ApplicationContext } from "./route-loader-context.ts";
+import { sessionKeyUuid } from "./route-loader-short-cache.ts";
+
+const SESSION_REF_SEARCH_LIMIT = 20;
+const SESSION_REF_SEARCH_MAX_PAGES = 5;
+
+type SessionReferenceSearch = { agentId: string } & (
+  | { kind: "exact"; value: string }
+  | { kind: "slug"; value: string }
+);
+
+type PendingSessionReference = {
+  controller: AbortController;
+  promise: Promise<SessionQueryResolution | null>;
+  subscribers: Set<AbortSignal>;
+};
+
+export type SessionQueryResolution =
+  | { kind: "not-found" }
+  | { kind: "unique"; session: GatewaySessionRow }
+  | { kind: "ambiguous"; sessions: GatewaySessionRow[]; truncated: boolean };
+
+const resolutionCache = new WeakMap<GatewayBrowserClient, Map<string, PendingSessionReference>>();
+
+function exactGlobalAliasAgentId(
+  context: ApplicationContext,
+  search: SessionReferenceSearch,
+): string | null {
+  if (search.kind !== "exact") {
+    return null;
+  }
+  const host = {
+    agentsList: context.agents.state.agentsList,
+    hello: context.gateway.snapshot.hello,
+  };
+  const aliasAgentId = resolveUiGlobalAliasAgentId(host, search.value);
+  const aliasRest = parseAgentSessionKey(search.value)?.rest.toLowerCase();
+  return aliasRest === "global" || isUiGlobalScopeConfigured(host) ? aliasAgentId : null;
+}
+
+function sessionReferenceSearchText(
+  context: ApplicationContext,
+  search: SessionReferenceSearch,
+): string {
+  if (search.kind === "exact") {
+    // Gateway search filters literal stored keys before client-side alias matching.
+    // A scoped main alias therefore has to request the canonical global key.
+    if (exactGlobalAliasAgentId(context, search) === normalizeAgentId(search.agentId)) {
+      return "global";
+    }
+    return search.value;
+  }
+  // Slugs are built from contiguous alphanumeric runs, so the longest token is
+  // the safest selective search term without excluding a valid display name.
+  return search.value
+    .split("-")
+    .reduce((longest, token) => (token.length > longest.length ? token : longest), "");
+}
+
+function sessionReferenceMatches(
+  context: ApplicationContext,
+  result: SessionsListResult,
+  search: SessionReferenceSearch,
+): GatewaySessionRow[] {
+  if (search.kind === "exact") {
+    const aliasAgentId = exactGlobalAliasAgentId(context, search);
+    return result.sessions.filter(
+      (row) =>
+        areUiSessionKeysEquivalent(row.key, search.value) ||
+        (isUiGlobalSessionKey(row.key) && aliasAgentId === normalizeAgentId(search.agentId)),
+    );
+  }
+  return result.sessions.filter(
+    (row) =>
+      sessionKeyUuid(row.key) !== null && controlUiSessionSlug(row.displayName) === search.value,
+  );
+}
+
+function incompleteResolution(
+  kind: SessionReferenceSearch["kind"],
+  sessions: GatewaySessionRow[],
+): SessionQueryResolution {
+  if (kind === "slug" && sessions.length === 0) {
+    // Preserve incomplete exact routes, but a bounded zero-match slug is a 404.
+    return { kind: "not-found" };
+  }
+  return { kind: "ambiguous", sessions, truncated: true };
+}
+
+async function querySessionReferencePages(
+  context: ApplicationContext,
+  search: SessionReferenceSearch,
+  signal: AbortSignal,
+): Promise<SessionQueryResolution | null> {
+  const matches = new Map<string, GatewaySessionRow>();
+  let offset = 0;
+  for (let page = 0; ; page += 1) {
+    signal.throwIfAborted();
+    const result = await context.sessions.list({
+      agentId: search.agentId,
+      archivedFilter: "all",
+      includeDerivedTitles: true,
+      limit: SESSION_REF_SEARCH_LIMIT,
+      search: sessionReferenceSearchText(context, search),
+      ...(offset > 0 ? { offset } : {}),
+    });
+    signal.throwIfAborted();
+    if (!result) {
+      return null;
+    }
+    for (const session of sessionReferenceMatches(context, result, search)) {
+      matches.set(session.key, session);
+    }
+    const sessions = [...matches.values()];
+    if (search.kind === "exact" && sessions[0]) {
+      return { kind: "unique", session: sessions[0] };
+    }
+    if (sessions.length > 1) {
+      return { kind: "ambiguous", sessions, truncated: result.hasMore === true };
+    }
+    if (result.hasMore !== true) {
+      const session = sessions[0];
+      return session ? { kind: "unique", session } : { kind: "not-found" };
+    }
+    if (page === SESSION_REF_SEARCH_MAX_PAGES - 1) {
+      return incompleteResolution(search.kind, sessions);
+    }
+    const nextOffset = result.nextOffset ?? offset + result.sessions.length;
+    if (nextOffset <= offset) {
+      return incompleteResolution(search.kind, sessions);
+    }
+    offset = nextOffset;
+  }
+}
+
+export async function querySessionReference(
+  context: ApplicationContext,
+  search: SessionReferenceSearch,
+  signal: AbortSignal,
+): Promise<SessionQueryResolution | null> {
+  const client = await waitForGatewayClient(context.gateway, signal);
+  signal.throwIfAborted();
+  const cache = resolutionCache.get(client) ?? new Map<string, PendingSessionReference>();
+  resolutionCache.set(client, cache);
+  const cacheKey = `${normalizeAgentId(search.agentId)}:${search.kind}:${search.value}`;
+  let pending = cache.get(cacheKey);
+  if (!pending || pending.controller.signal.aborted) {
+    const controller = new AbortController();
+    pending = {
+      controller,
+      promise: Promise.resolve().then(() =>
+        querySessionReferencePages(context, search, controller.signal),
+      ),
+      subscribers: new Set(),
+    };
+    cache.set(cacheKey, pending);
+  }
+  pending.subscribers.add(signal);
+  const shared = pending;
+  let rejectAbort: (reason: unknown) => void = () => undefined;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    rejectAbort = reject;
+  });
+  const onAbort = () => {
+    shared.subscribers.delete(signal);
+    if (shared.subscribers.size === 0) {
+      shared.controller.abort(signal.reason);
+    }
+    rejectAbort(signal.reason);
+  };
+  signal.addEventListener("abort", onAbort, { once: true });
+  if (signal.aborted) {
+    onAbort();
+  }
+  try {
+    return await Promise.race([shared.promise, aborted]);
+  } finally {
+    signal.removeEventListener("abort", onAbort);
+    shared.subscribers.delete(signal);
+    if (shared.subscribers.size === 0 && cache.get(cacheKey) === shared) {
+      cache.delete(cacheKey);
+    }
+  }
+}

--- a/ui/src/pages/chat/route-loader.ts
+++ b/ui/src/pages/chat/route-loader.ts
@@ -1,8 +1,7 @@
-import { controlUiSessionSlug, SHORT_SESSION_ID_RE } from "@openclaw/session-url-contract";
+import { SHORT_SESSION_ID_RE } from "@openclaw/session-url-contract";
 import type { RouteLocation } from "@openclaw/uirouter";
 import { notFound } from "@openclaw/uirouter";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
+import type { GatewaySessionRow } from "../../api/types.ts";
 import { INTERNAL_SESSION_PATH_PARAM } from "../../app-route-paths.ts";
 import { pathForSession } from "../../app-session-path-builder.ts";
 import { sessionRefFromPath, type SessionPathTarget } from "../../app-session-route-paths.ts";
@@ -19,26 +18,22 @@ import {
 } from "../../lib/sessions/route-navigation.ts";
 import {
   buildAgentMainSessionKey,
-  areUiSessionKeysEquivalent,
-  isUiGlobalScopeConfigured,
   isUiGlobalSessionKey,
   normalizeAgentId,
   parseAgentSessionKey,
   resolveAgentIdFromSessionKey,
   resolveUiConfiguredMainKey,
-  resolveUiGlobalAliasAgentId,
+  resolveUiDefaultAgentId,
 } from "../../lib/sessions/session-key.ts";
 import { draftRouteDataFromLocation, draftSearchFromLocation } from "./route-draft.ts";
 import type { SessionRouteContext as ApplicationContext } from "./route-loader-context.ts";
+import { querySessionReference } from "./route-loader-session-query.ts";
 import { findCachedShortSession, sessionKeyUuid } from "./route-loader-short-cache.ts";
 import {
   resolveShortSessionReference,
   type SessionReferenceResolution,
   type SessionRoutePresentation,
 } from "./route-loader-short-resolve.ts";
-
-const SESSION_REF_SEARCH_LIMIT = 20;
-const SESSION_REF_SEARCH_MAX_PAGES = 5;
 
 type SessionCandidate = {
   agentId: string;
@@ -66,6 +61,12 @@ export type ChatRouteData =
       candidates: SessionCandidate[];
       truncated: boolean;
       face: BoardFace;
+    }
+  | {
+      kind: "agent-not-found";
+      agentId: string;
+      fallbackHref: string;
+      face: BoardFace;
     };
 
 export type SessionChatRouteData = Omit<
@@ -75,19 +76,6 @@ export type SessionChatRouteData = Omit<
   face?: BoardFace;
   kind?: "session";
 };
-
-type SessionReferenceSearch = { agentId: string } & (
-  | { kind: "exact"; value: string }
-  | { kind: "slug"; value: string }
-);
-
-type PendingSessionReference = {
-  controller: AbortController;
-  promise: Promise<SessionReferenceResolution | null>;
-  subscribers: Set<AbortSignal>;
-};
-
-const resolutionCache = new WeakMap<GatewayBrowserClient, Map<string, PendingSessionReference>>();
 
 function uniqueShortIdPrefix(
   value: string,
@@ -117,170 +105,6 @@ function uniqueShortIdPrefix(
 // fields, so every needle here has to be a run that literally appears in one of them.
 // sessionReferenceMatches still applies the exact rule per row, so a loose needle only
 // widens the candidate set; too narrow a needle loses the session entirely.
-function exactGlobalAliasAgentId(
-  context: ApplicationContext,
-  search: SessionReferenceSearch,
-): string | null {
-  if (search.kind !== "exact") {
-    return null;
-  }
-  const host = {
-    agentsList: context.agents.state.agentsList,
-    hello: context.gateway.snapshot.hello,
-  };
-  const aliasAgentId = resolveUiGlobalAliasAgentId(host, search.value);
-  const aliasRest = parseAgentSessionKey(search.value)?.rest.toLowerCase();
-  return aliasRest === "global" || isUiGlobalScopeConfigured(host) ? aliasAgentId : null;
-}
-
-function sessionReferenceSearchText(
-  context: ApplicationContext,
-  search: SessionReferenceSearch,
-): string {
-  if (search.kind === "exact") {
-    // Gateway search filters literal stored keys before client-side alias matching.
-    // A scoped main alias therefore has to request the canonical global key.
-    if (exactGlobalAliasAgentId(context, search) === normalizeAgentId(search.agentId)) {
-      return "global";
-    }
-    return search.value;
-  }
-  // controlUiSessionSlug builds every token from a contiguous alphanumeric run of the
-  // lowercased display name, so the longest token is the safest selective search term.
-  return search.value
-    .split("-")
-    .reduce((longest, token) => (token.length > longest.length ? token : longest), "");
-}
-
-function sessionReferenceMatches(
-  context: ApplicationContext,
-  result: SessionsListResult,
-  search: SessionReferenceSearch,
-): GatewaySessionRow[] {
-  if (search.kind === "exact") {
-    const aliasAgentId = exactGlobalAliasAgentId(context, search);
-    return result.sessions.filter(
-      (row) =>
-        areUiSessionKeysEquivalent(row.key, search.value) ||
-        (isUiGlobalSessionKey(row.key) && aliasAgentId === normalizeAgentId(search.agentId)),
-    );
-  }
-  return result.sessions.filter(
-    (row) =>
-      sessionKeyUuid(row.key) !== null && controlUiSessionSlug(row.displayName) === search.value,
-  );
-}
-
-async function querySessionReference(
-  context: ApplicationContext,
-  search: SessionReferenceSearch,
-  signal: AbortSignal,
-): Promise<SessionReferenceResolution | null> {
-  const client = await waitForGatewayClient(context.gateway, signal);
-  signal.throwIfAborted();
-  const cache = resolutionCache.get(client) ?? new Map<string, PendingSessionReference>();
-  resolutionCache.set(client, cache);
-  const cacheKey = `${normalizeAgentId(search.agentId)}:${search.kind}:${search.value}`;
-  let pending = cache.get(cacheKey);
-  if (!pending || pending.controller.signal.aborted) {
-    const controller = new AbortController();
-    pending = {
-      controller,
-      promise: Promise.resolve().then(() =>
-        querySessionReferencePages(context, search, controller.signal),
-      ),
-      subscribers: new Set(),
-    };
-    cache.set(cacheKey, pending);
-  }
-  pending.subscribers.add(signal);
-  const shared = pending;
-  let rejectAbort: (reason: unknown) => void = () => undefined;
-  const aborted = new Promise<never>((_resolve, reject) => {
-    rejectAbort = reject;
-  });
-  const onAbort = () => {
-    shared.subscribers.delete(signal);
-    // The producer is shared: one cancelled navigation must not cancel another
-    // active route's lookup, but the final subscriber must stop later pages.
-    if (shared.subscribers.size === 0) {
-      shared.controller.abort(signal.reason);
-    }
-    rejectAbort(signal.reason);
-  };
-  signal.addEventListener("abort", onAbort, { once: true });
-  if (signal.aborted) {
-    onAbort();
-  }
-  try {
-    return await Promise.race([shared.promise, aborted]);
-  } finally {
-    signal.removeEventListener("abort", onAbort);
-    shared.subscribers.delete(signal);
-    if (shared.subscribers.size === 0 && cache.get(cacheKey) === shared) {
-      cache.delete(cacheKey);
-    }
-  }
-}
-
-function incompleteSessionReferenceResolution(
-  kind: SessionReferenceSearch["kind"],
-  sessions: GatewaySessionRow[],
-): SessionReferenceResolution {
-  if (kind === "slug" && sessions.length === 0) {
-    // Slugs are best-effort: an incomplete exact-key search must retain the
-    // authoritative literal route, while a bounded zero-match slug is a 404.
-    return { kind: "not-found" };
-  }
-  return { kind: "ambiguous", sessions, truncated: true };
-}
-
-async function querySessionReferencePages(
-  context: ApplicationContext,
-  search: SessionReferenceSearch,
-  signal: AbortSignal,
-): Promise<SessionReferenceResolution | null> {
-  const matches = new Map<string, GatewaySessionRow>();
-  let offset = 0;
-  for (let page = 0; ; page += 1) {
-    signal.throwIfAborted();
-    const result = await context.sessions.list({
-      agentId: search.agentId,
-      archivedFilter: "all",
-      includeDerivedTitles: true,
-      limit: SESSION_REF_SEARCH_LIMIT,
-      search: sessionReferenceSearchText(context, search),
-      ...(offset > 0 ? { offset } : {}),
-    });
-    signal.throwIfAborted();
-    if (!result) {
-      return null;
-    }
-    for (const session of sessionReferenceMatches(context, result, search)) {
-      matches.set(session.key, session);
-    }
-    const sessions = [...matches.values()];
-    if (search.kind === "exact" && sessions[0]) {
-      return { kind: "unique", session: sessions[0] };
-    }
-    if (sessions.length > 1) {
-      return { kind: "ambiguous", sessions, truncated: result.hasMore === true };
-    }
-    if (result.hasMore !== true) {
-      const session = sessions[0];
-      return session ? { kind: "unique", session } : { kind: "not-found" };
-    }
-    if (page === SESSION_REF_SEARCH_MAX_PAGES - 1) {
-      return incompleteSessionReferenceResolution(search.kind, sessions);
-    }
-    const nextOffset = result.nextOffset ?? offset + result.sessions.length;
-    if (nextOffset <= offset) {
-      return incompleteSessionReferenceResolution(search.kind, sessions);
-    }
-    offset = nextOffset;
-  }
-}
-
 function isPreferenceDerivedFace(location: RouteLocation): boolean {
   return new URLSearchParams(location.search).get(SESSION_FACE_PREFERENCE_PARAM) === "1";
 }
@@ -391,6 +215,52 @@ function mainSessionKey(
     agentId: target.agentId,
     mainKey: configuredMainKey(context),
   });
+}
+
+function fallbackMainHref(context: ApplicationContext, face: BoardFace): string {
+  const agentId = resolveUiDefaultAgentId({
+    agentsList: context.agents.state.agentsList,
+    hello: context.gateway.snapshot.hello,
+  });
+  return (
+    pathForSession(
+      face,
+      agentId,
+      buildAgentMainSessionKey({ agentId, mainKey: configuredMainKey(context) }),
+      context.basePath,
+      { mainKey: configuredMainKey(context) },
+    ) ?? context.basePath
+  );
+}
+
+async function routeAgents(context: ApplicationContext, signal: AbortSignal) {
+  if (!context.agents.state.agentsList) {
+    await waitForGatewayClient(context.gateway, signal);
+  }
+  const agentsList = context.agents.state.agentsList ?? (await context.agents.ensureList());
+  signal.throwIfAborted();
+  if (!agentsList) {
+    throw new Error(context.agents.state.agentsError ?? "Agent list unavailable");
+  }
+  return agentsList;
+}
+
+function removedAgentOwnsSession(agentId: string, row: SessionRoutePresentation): boolean {
+  const rowAgentId = parseAgentSessionKey(row.key)?.agentId;
+  return Boolean(rowAgentId && normalizeAgentId(rowAgentId) === normalizeAgentId(agentId));
+}
+
+function unknownAgentRoute(
+  context: ApplicationContext,
+  face: BoardFace,
+  agentId: string,
+): Extract<ChatRouteData, { kind: "agent-not-found" }> {
+  return {
+    kind: "agent-not-found",
+    agentId,
+    fallbackHref: fallbackMainHref(context, face),
+    face,
+  };
 }
 
 function candidatesForResolution(
@@ -505,6 +375,7 @@ export async function loadChatRoute(
   face: BoardFace,
   signal: AbortSignal,
 ): Promise<ChatRouteData | ReturnType<typeof notFound>> {
+  const agentsList = await routeAgents(context, signal);
   const resolvedTarget = targetFromLocation(context, location);
   if (!resolvedTarget || resolvedTarget.target.namespace !== face) {
     return notFound({ routeId: face });
@@ -512,9 +383,16 @@ export async function loadChatRoute(
   const { target } = resolvedTarget;
   const routeLocation = resolvedTarget.location;
   const preferenceDerived = isPreferenceDerivedFace(routeLocation);
+  const targetAgentId = normalizeAgentId(target.agentId);
+  const configuredAgent = agentsList.agents.some(
+    (agent) => normalizeAgentId(agent.id) === targetAgentId,
+  );
   const catalogKey = catalogSessionKeyFromSearch(routeLocation.search);
   if (target.kind === "main" && catalogKey) {
     const sessionKey = buildCatalogSessionKey(catalogKey);
+    if (!configuredAgent) {
+      return unknownAgentRoute(context, face, target.agentId);
+    }
     let canonicalLocation = preferenceDerived
       ? locationWithoutNavigationHints(routeLocation)
       : null;
@@ -553,6 +431,22 @@ export async function loadChatRoute(
   if (target.kind === "main") {
     await waitForGatewayClient(context.gateway, signal);
     const sessionKey = mainSessionKey(context, target);
+    if (!configuredAgent) {
+      const resolution = await querySessionReference(
+        context,
+        { kind: "exact", value: sessionKey, agentId: target.agentId },
+        signal,
+      );
+      if (!resolution || resolution.kind === "ambiguous") {
+        throw new Error("Session lookup unavailable while resolving agent URL");
+      }
+      if (
+        resolution.kind !== "unique" ||
+        !removedAgentOwnsSession(target.agentId, resolution.session)
+      ) {
+        return unknownAgentRoute(context, face, target.agentId);
+      }
+    }
     if (preferenceDerived) {
       const resolution = await querySessionReference(
         context,
@@ -586,7 +480,8 @@ export async function loadChatRoute(
   }
   if (target.kind === "literal") {
     let defaultsKnown = hasConfiguredMainKey(context);
-    const needsGatewayResolution = preferenceDerived || Boolean(target.slugCandidate);
+    const needsGatewayResolution =
+      !configuredAgent || preferenceDerived || Boolean(target.slugCandidate);
     if (!defaultsKnown && needsGatewayResolution) {
       await waitForGatewayClient(context.gateway, signal);
       defaultsKnown = hasConfiguredMainKey(context);
@@ -610,6 +505,9 @@ export async function loadChatRoute(
             signal,
           );
       if (exactResolution?.kind === "unique") {
+        if (!configuredAgent && !removedAgentOwnsSession(target.agentId, exactResolution.session)) {
+          return unknownAgentRoute(context, face, target.agentId);
+        }
         const resolved = resolvedSessionRouteData({
           context,
           location: routeLocation,
@@ -644,6 +542,12 @@ export async function loadChatRoute(
           };
         }
         if (slugResolution?.kind === "unique") {
+          if (
+            !configuredAgent &&
+            !removedAgentOwnsSession(target.agentId, slugResolution.session)
+          ) {
+            return unknownAgentRoute(context, face, target.agentId);
+          }
           // No shortId: a resolved slug canonicalizes to the same short reference every
           // other surface links to, so `/chat/main/deploy-monitor` settles on
           // `/chat/main/deploy-monitor-6db92d48` rather than a full uuid. A later
@@ -657,6 +561,12 @@ export async function loadChatRoute(
           });
           return resolved ?? notFound({ routeId: face });
         }
+      }
+      if (!configuredAgent && exactResolution?.kind === "not-found") {
+        return unknownAgentRoute(context, face, target.agentId);
+      }
+      if (!configuredAgent && exactResolution?.kind !== "not-found") {
+        throw new Error("Session lookup unavailable while resolving agent URL");
       }
     }
     const canonicalLocation = defaultsKnown
@@ -689,6 +599,9 @@ export async function loadChatRoute(
   }
   const cached = findCachedShortSession(context, routeLocation, target);
   if (cached && !cached.row) {
+    if (!configuredAgent) {
+      return unknownAgentRoute(context, face, target.agentId);
+    }
     const canonicalLocation = locationWithoutNavigationHints(routeLocation);
     const canonicalLocationChanged = canonicalLocation.search !== routeLocation.search;
     return {
@@ -723,7 +636,9 @@ export async function loadChatRoute(
       });
       return literal ?? notFound({ routeId: face });
     }
-    return notFound({ routeId: face });
+    return configuredAgent
+      ? notFound({ routeId: face })
+      : unknownAgentRoute(context, face, target.agentId);
   }
   if (resolution.kind === "ambiguous") {
     return {
@@ -739,6 +654,11 @@ export async function loadChatRoute(
       truncated: resolution.truncated,
       face,
     };
+  }
+  if (!configuredAgent) {
+    if (!removedAgentOwnsSession(target.agentId, resolution.session)) {
+      return unknownAgentRoute(context, face, target.agentId);
+    }
   }
   const resolved = resolvedSessionRouteData({
     context,

--- a/ui/src/pages/chat/route-resolution.test.ts
+++ b/ui/src/pages/chat/route-resolution.test.ts
@@ -60,7 +60,15 @@ function contextFor(
       snapshot: { phase: "connected", client, hello: null },
       subscribe: vi.fn(() => () => undefined),
     },
-    agents: { state: { agentsList: { mainKey: "main" } } },
+    agents: {
+      state: {
+        agentsList: {
+          defaultId: "roboclaw",
+          mainKey: "main",
+          agents: [{ id: "roboclaw" }, { id: "main" }],
+        },
+      },
+    },
     agentSelection: { state: { selectedId: "roboclaw" } },
     sessions: { state: { result: result(cachedSessions) }, list },
   } as unknown as ApplicationContext;
@@ -114,7 +122,7 @@ describe("gateway-backed session route resolution", () => {
       defaultId: "main",
       mainKey: "main",
       scope: "global",
-      agents: [],
+      agents: [{ id: "research" }],
     };
     context.gateway.snapshot.hello = {
       snapshot: {
@@ -362,7 +370,10 @@ describe("gateway-backed session route resolution", () => {
           return () => undefined;
         },
       },
-      agents: { state: { agentsList: null } },
+      agents: {
+        state: { agentsList: null },
+        ensureList: async () => ({ defaultId: "roboclaw", agents: [{ id: "roboclaw" }] }),
+      },
       sessions: { state: { result: result([]) }, list },
     } as unknown as ApplicationContext;
     const pending = loadChatRoute(

--- a/ui/src/pages/chat/route.test.ts
+++ b/ui/src/pages/chat/route.test.ts
@@ -66,14 +66,19 @@ function contextFor(listResult: SessionsListResult | null, mainKey = "main") {
   });
   const client = { request };
   const list = vi.fn(async (_options?: { offset?: number; search?: string }) => listResult);
+  const agentsList = {
+    defaultId: "main",
+    mainKey,
+    agents: ["main", "work", "research", "ops"].map((id) => ({ id })),
+  };
   const context = {
     basePath: "",
     gateway: {
       snapshot: { phase: "connected", client, hello: null },
       subscribe: vi.fn(() => () => undefined),
     },
-    agents: { state: { agentsList: { mainKey } } },
-    sessions: { list },
+    agents: { state: { agentsList }, ensureList: vi.fn(async () => agentsList) },
+    sessions: { state: { result: listResult }, list },
   } as unknown as ApplicationContext;
   return { context, list, request };
 }
@@ -263,6 +268,93 @@ describe("loadChatRoute", () => {
     expect(list).not.toHaveBeenCalled();
   });
 
+  it.each(["chat", "dashboard"] as const)(
+    "rejects an unknown agent main route in the %s namespace",
+    async (face) => {
+      const { context, list } = contextFor(result([]));
+
+      await expect(
+        loadChatRoute(
+          context,
+          { pathname: `/${face}/ghost`, search: "", hash: "" },
+          face,
+          new AbortController().signal,
+        ),
+      ).resolves.toEqual({
+        kind: "agent-not-found",
+        agentId: "ghost",
+        fallbackHref: `/${face}/main`,
+        face,
+      });
+      expect(list).toHaveBeenCalledWith(
+        expect.objectContaining({ agentId: "ghost", search: "agent:ghost:main" }),
+      );
+    },
+  );
+
+  it("opens a removed agent's saved main conversation as read-only", async () => {
+    const saved = row({ key: "agent:ghost:main", agentId: "ghost" });
+    const { context } = contextFor(result([saved]));
+
+    await expect(
+      loadChatRoute(
+        context,
+        { pathname: "/chat/ghost", search: "", hash: "" },
+        "chat",
+        new AbortController().signal,
+      ),
+    ).resolves.toMatchObject({
+      kind: "session",
+      sessionKey: "agent:ghost:main",
+      face: "chat",
+    });
+  });
+
+  it.each([null, result([], { hasMore: true, nextOffset: 20 })])(
+    "does not trust an unavailable or truncated lookup for a removed agent",
+    async (lookup) => {
+      const { context } = contextFor(lookup);
+      await expect(
+        loadChatRoute(
+          context,
+          { pathname: "/chat/ghost/telegram/12345", search: "", hash: "" },
+          "chat",
+          new AbortController().signal,
+        ),
+      ).rejects.toThrow("Session lookup unavailable while resolving agent URL");
+    },
+  );
+
+  it.each([
+    ["/chat/ghost/telegram/12345", "agent:ghost:telegram:12345"],
+    [
+      "/chat/ghost/deploy-monitor-12345678",
+      "agent:ghost:dashboard:12345678-90ab-cdef-1234-567890abcdef",
+    ],
+  ])("rejects unknown agents across explicit session routes", async (pathname, key) => {
+    const { context } = contextFor(result([]));
+
+    await expect(
+      loadChatRoute(
+        context,
+        { pathname, search: "", hash: "" },
+        "chat",
+        new AbortController().signal,
+      ),
+    ).resolves.toMatchObject({ kind: "agent-not-found", agentId: "ghost" });
+
+    const saved = row({ key, agentId: "ghost" });
+    const { context: savedContext } = contextFor(result([saved]));
+    await expect(
+      loadChatRoute(
+        savedContext,
+        { pathname, search: "", hash: "" },
+        "chat",
+        new AbortController().signal,
+      ),
+    ).resolves.toMatchObject({ kind: "session", sessionKey: key });
+  });
+
   it("waits for configured session defaults before resolving an agent main route", async () => {
     type GatewayListener = Parameters<ApplicationContext["gateway"]["subscribe"]>[0];
     let listener: GatewayListener | null = null;
@@ -282,7 +374,15 @@ describe("loadChatRoute", () => {
           return () => undefined;
         },
       },
-      agents: { state: { agentsList: null } },
+      agents: {
+        state: { agentsList: null },
+        ensureList: async () => ({
+          defaultId: "main",
+          mainKey: "workspace",
+          agents: [{ id: "main" }, { id: "research" }],
+        }),
+      },
+      sessions: { state: { result: null }, list: async () => result([]) },
     } as unknown as ApplicationContext;
     const pending = loadChatRoute(
       context,
@@ -383,7 +483,15 @@ describe("loadChatRoute", () => {
           return () => undefined;
         },
       },
-      agents: { state: { agentsList: null } },
+      agents: {
+        state: { agentsList: null },
+        ensureList: async () => ({
+          defaultId: "main",
+          mainKey: "workspace",
+          agents: [{ id: "main" }, { id: "research" }],
+        }),
+      },
+      sessions: { state: { result: null }, list: async () => result([]) },
     } as unknown as ApplicationContext;
     const pending = loadChatRoute(
       context,
@@ -451,23 +559,23 @@ describe("loadChatRoute", () => {
             return () => undefined;
           },
         },
-        agents: { state: { agentsList: null } },
+        agents: {
+          state: { agentsList: null },
+          ensureList: async () => ({
+            defaultId: "main",
+            mainKey,
+            agents: [{ id: "main" }, { id: "research" }],
+          }),
+        },
+        sessions: { state: { result: null }, list: async () => result([]) },
       } as unknown as ApplicationContext;
-      const loaded = await loadChatRoute(
+      const pending = loadChatRoute(
         context,
         { pathname, search: "", hash: "" },
         "chat",
         new AbortController().signal,
       );
-      expect(loaded).toMatchObject({
-        kind: "session",
-        sessionKey: targetSessionKey,
-        face: "chat",
-      });
-      if (!("kind" in loaded) || loaded.kind !== "session" || !loaded.canonicalLocationReady) {
-        throw new Error("expected deferred main-session canonicalization");
-      }
-
+      await Promise.resolve();
       snapshot = {
         phase: "connected",
         client: {},
@@ -478,8 +586,17 @@ describe("loadChatRoute", () => {
         throw new Error("expected gateway readiness subscription");
       }
       connectedListener(snapshot);
+      const loaded = await pending;
+      expect(loaded).toMatchObject({
+        kind: "session",
+        sessionKey: targetSessionKey,
+        face: "chat",
+      });
+      if (!("kind" in loaded) || loaded.kind !== "session") {
+        throw new Error("expected main-session canonicalization");
+      }
 
-      await expect(loaded.canonicalLocationReady).resolves.toEqual(expectedCanonicalLocation);
+      expect(loaded.canonicalLocation ?? null).toEqual(expectedCanonicalLocation);
     }
   });
 

--- a/ui/src/pages/chat/route.ts
+++ b/ui/src/pages/chat/route.ts
@@ -34,6 +34,16 @@ function renderAmbiguous(data: Extract<ChatRouteData, { kind: "ambiguous" }>) {
   `;
 }
 
+function renderAgentNotFound(data: Extract<ChatRouteData, { kind: "agent-not-found" }>) {
+  return html`
+    <section class="card" role="status">
+      <h2>${t("chat.sessionRoute.agentNotFoundTitle")}</h2>
+      <p>${t("chat.sessionRoute.agentNotFound", { agentId: data.agentId })}</p>
+      <a class="btn primary" href=${data.fallbackHref}>${t("chat.sessionRoute.openDefault")}</a>
+    </section>
+  `;
+}
+
 function sessionLoaderDeps(
   face: BoardFace,
   context: ApplicationContext,
@@ -55,7 +65,7 @@ function sessionLoaderDeps(
 
 function sessionRenderOwnerKey(match: SessionOwnerMatch): string | undefined {
   const data = match.data as ChatRouteData | undefined;
-  return data?.kind === "ambiguous" ? undefined : CHAT_PAGE_OWNER_KEY;
+  return !data || data.kind === "session" ? CHAT_PAGE_OWNER_KEY : undefined;
 }
 
 function sessionPage(face: BoardFace) {
@@ -84,9 +94,11 @@ function sessionPage(face: BoardFace) {
           if (!routeData) {
             return nothing;
           }
-          return routeData.kind === "ambiguous"
-            ? renderAmbiguous(routeData)
-            : html`<openclaw-chat-page .data=${routeData}></openclaw-chat-page>`;
+          return routeData.kind === "session"
+            ? html`<openclaw-chat-page .data=${routeData}></openclaw-chat-page>`
+            : routeData.kind === "ambiguous"
+              ? renderAmbiguous(routeData)
+              : renderAgentNotFound(routeData);
         },
       })),
   });


### PR DESCRIPTION
Closes #131821

## What Problem This Solves

Fixes an issue where explicit chat or dashboard URLs for an unconfigured agent opened an apparently writable session while navigation showed the default agent. The mismatch surfaced only after send failed at the Gateway.

## Why This Change Was Made

The route loader now waits for the authoritative agent roster and rejects unknown owners across main, catalog, literal, and short session URLs. Persisted conversations for removed agents remain readable only when an exact qualified session row proves ownership; all mutation surfaces stay disabled and react to roster changes.

## User Impact

Mistyped or stale unknown-agent links now show an Agent not found state with a link to the default chat, preserving the requested URL. Operators can still inspect saved conversations from removed agents, clearly marked read-only.

## Evidence

- Before: roster `[main]` plus `/chat/ghost` resolved to writable `agent:ghost:main`, while shared selection displayed `main`; send later failed as an unconfigured owner (`ui/src/pages/chat/route-loader.ts:502-585`, `ui/src/app/agent-selection.ts:49-60`, `src/gateway/server-methods/chat-send-session.ts:131-146`).
- After: regression coverage rejects unknown agents in chat/dashboard and across main/literal/short/catalog routes, while exact persisted removed-agent sessions remain readable and mutation-free (`ui/src/pages/chat/route.test.ts:272`, `ui/src/pages/chat/route.test.ts:295`, `ui/src/pages/chat/chat-pane-removed-agent.test.ts:15`).
- Focused tests: 8 files, 144 tests passed.
- `node scripts/check-changed.mjs`: passed.
- The diagnosis and final fix were independently challenged by an adversarial review; it confirmed the bug and completed with no findings after the identified bypasses were fixed.
- Provenance: `cca5b147857` introduced path-based main-session routing; `8eafae4af749` added roster fallback; `8c0cdc653559` rejected unconfigured session owners at send time.

UI screenshot proof was not recaptured in this worktree because a real isolated Gateway/browser setup was not available; the route and rendered composer boundaries are covered directly by the focused tests above.