### PR TITLE
fix(ui): show a not-found state for missing session links

### DIFF
--- a/ui/src/app/app-root.ts
+++ b/ui/src/app/app-root.ts
@@ -310,7 +310,7 @@ export class OpenClawApp extends OpenClawLightDomElement {
       if (controller.signal.aborted || this.focusDashboardAbort !== controller) {
         return;
       }
-      if (isRouteNotFound(result)) {
+      if (isRouteNotFound(result) || result.kind === "missing-session") {
         this.focusDashboardRoute = { kind: "not-found" };
         return;
       }

--- a/ui/src/app/router-outlet-chat.test.ts
+++ b/ui/src/app/router-outlet-chat.test.ts
@@ -248,7 +248,27 @@ describe("openclaw-router-outlet chat ownership", () => {
     router.stop();
   });
 
-  it("retains an unresolved route until an ambiguous result replaces it", async () => {
+  it.each([
+    {
+      label: "an ambiguous result",
+      result: {
+        kind: "ambiguous",
+        shortId: "12345678",
+        candidates: [],
+        truncated: false,
+        face: "chat",
+      } satisfies ChatRouteData,
+    },
+    {
+      label: "a missing-session result",
+      result: {
+        kind: "missing-session",
+        face: "chat",
+        currentSessionHref: "/chat/main",
+        sessionsHref: "/sessions",
+      } satisfies ChatRouteData,
+    },
+  ])("retains an unresolved route until $label replaces it", async ({ result }) => {
     const sessionKey = "agent:main:dashboard:12345678-0aaa-4000-8000-000000000001";
     const nextData = deferred<ChatRouteData>();
     let loadCount = 0;
@@ -275,13 +295,7 @@ describe("openclaw-router-outlet chat ownership", () => {
     expect(outlet.querySelector("mcp-app-view")).toBe(firstView);
     expect(teardown).not.toHaveBeenCalled();
 
-    nextData.resolve({
-      kind: "ambiguous",
-      shortId: "12345678",
-      candidates: [],
-      truncated: false,
-      face: "chat",
-    });
+    nextData.resolve(result);
     await navigation;
     await settleOutlet(outlet);
     expect(outlet.querySelector('[data-testid="route-value"]')?.textContent).toBe("chooser");

--- a/ui/src/components/lazy-view-error.ts
+++ b/ui/src/components/lazy-view-error.ts
@@ -1,4 +1,4 @@
-import { html, nothing } from "lit";
+import { html, nothing, type TemplateResult } from "lit";
 import { t } from "../i18n/index.ts";
 import { formatUiError } from "../lib/format-error.ts";
 import { icon } from "./icons.ts";
@@ -58,28 +58,55 @@ export function renderLazyViewError({
   subtitle?: string;
 }) {
   const detail = formatUiError(error);
-  const errorClasses = `lazy-view-error${render ? " lazy-view-error--inline" : ""}${stale ? " lazy-view-error--stale" : ""}`;
   return html`
     ${render?.() ?? nothing}
-    <div class=${errorClasses} role="alert">
-      <div class="lazy-view-error__icon" aria-hidden="true">
-        ${icon(stale ? "refresh" : "alertTriangle")}
-      </div>
-      <div class="lazy-view-error__title">
-        ${stale ? t("lazyView.staleTitle") : t("lazyView.errorTitle")}
-      </div>
-      <div class="lazy-view-error__subtitle">
-        ${subtitle ?? (stale ? t("lazyView.staleSubtitle") : t("lazyView.genericSubtitle"))}
-      </div>
-      <div class="lazy-view-error__actions">
+    ${renderPanelErrorState({
+      title: stale ? t("lazyView.staleTitle") : t("lazyView.errorTitle"),
+      subtitle: subtitle ?? (stale ? t("lazyView.staleSubtitle") : t("lazyView.genericSubtitle")),
+      actions: html`
         <button class="btn lazy-view-error__action" @click=${onRetry}>
           ${actionLabel ?? (stale ? t("common.reload") : t("lazyView.retry"))}
         </button>
         ${onClose
           ? html`<button class="btn" type="button" @click=${onClose}>${t("common.close")}</button>`
           : nothing}
+      `,
+      detail,
+      inline: Boolean(render),
+      stale,
+    })}
+  `;
+}
+
+export function renderPanelErrorState({
+  actions,
+  className,
+  detail,
+  inline = false,
+  role = "alert",
+  stale = false,
+  subtitle,
+  title,
+}: {
+  actions?: TemplateResult;
+  className?: string;
+  detail?: string;
+  inline?: boolean;
+  role?: "alert" | "status";
+  stale?: boolean;
+  subtitle: string;
+  title: string;
+}) {
+  const errorClasses = `lazy-view-error${inline ? " lazy-view-error--inline" : ""}${stale ? " lazy-view-error--stale" : ""}${className ? ` ${className}` : ""}`;
+  return html`
+    <div class=${errorClasses} role=${role}>
+      <div class="lazy-view-error__icon" aria-hidden="true">
+        ${icon(stale ? "refresh" : "alertTriangle")}
       </div>
-      <code class="lazy-view-error__detail">${detail}</code>
+      <div class="lazy-view-error__title">${title}</div>
+      <div class="lazy-view-error__subtitle">${subtitle}</div>
+      ${actions ? html`<div class="lazy-view-error__actions">${actions}</div>` : nothing}
+      ${detail ? html`<code class="lazy-view-error__detail">${detail}</code>` : nothing}
     </div>
   `;
 }

--- a/ui/src/e2e/dashboard-final-reply-recovery.e2e.test.ts
+++ b/ui/src/e2e/dashboard-final-reply-recovery.e2e.test.ts
@@ -41,6 +41,7 @@ suite.define(() => {
           tabs: [{ tabId: "main", title: "Nightly Disk Cleanup", position: 0, chatDock: "right" }],
           widgets: [],
         },
+        "sessions.resolve": { ok: true, key: sessionKey, boardFace: "dashboard" },
         "sessions.list": {
           count: 1,
           defaults: { contextTokens: null, model: "gpt-5.6-sol", modelProvider: "openai" },

--- a/ui/src/e2e/session-link-not-found.e2e.test.ts
+++ b/ui/src/e2e/session-link-not-found.e2e.test.ts
@@ -15,6 +15,7 @@ const suite = createControlUiE2eSuite({
 suite.define(() => {
   it("keeps an explicitly requested missing session as a visible dead end", async () => {
     const mainKey = "agent:main:main";
+    const savedActiveKey = "agent:main:saved-active-session";
     const attemptedPath = "/chat/main/deadbeef";
     await suite.withPage(
       { locale: "en-US", serviceWorkers: "block", viewport: { height: 900, width: 1280 } },
@@ -24,7 +25,8 @@ suite.define(() => {
             "sessions.list": sessionsListResponse([sessionRow(mainKey, "Main", 1)]),
             "sessions.resolve": { ok: false },
           },
-          sessionKey: mainKey,
+          mainSessionKey: mainKey,
+          sessionKey: savedActiveKey,
         });
 
         await page.goto(`${suite.server.baseUrl}${attemptedPath.slice(1)}`);

--- a/ui/src/e2e/session-link-not-found.e2e.test.ts
+++ b/ui/src/e2e/session-link-not-found.e2e.test.ts
@@ -1,0 +1,71 @@
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  captureUiProof,
+  sessionRow,
+  sessionsListResponse,
+} from "./session-management.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "missing session link",
+  startServerBeforeBrowser: true,
+});
+
+suite.define(() => {
+  it("keeps an explicitly requested missing session as a visible dead end", async () => {
+    const mainKey = "agent:main:main";
+    const attemptedPath = "/chat/main/deadbeef";
+    await suite.withPage(
+      { locale: "en-US", serviceWorkers: "block", viewport: { height: 900, width: 1280 } },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "sessions.list": sessionsListResponse([sessionRow(mainKey, "Main", 1)]),
+            "sessions.resolve": { ok: false },
+          },
+          sessionKey: mainKey,
+        });
+
+        await page.goto(`${suite.server.baseUrl}${attemptedPath.slice(1)}`);
+        const state = page.locator(".session-route-not-found");
+        await state.getByText("Session not found", { exact: true }).waitFor();
+        expect(new URL(page.url()).pathname).toBe(attemptedPath);
+        await state
+          .getByText("The session may have been removed, or the link may be incorrect.", {
+            exact: true,
+          })
+          .waitFor();
+        const currentSession = state.getByRole("button", { name: "Go to main session" });
+        const sessions = state.getByRole("button", { name: "View sessions" });
+        expect(
+          await currentSession.evaluate((element) => getComputedStyle(element).textDecorationLine),
+        ).toBe("none");
+        expect(
+          await sessions.evaluate((element) => getComputedStyle(element).textDecorationLine),
+        ).toBe("none");
+        expect(
+          await state
+            .locator(".lazy-view-error__subtitle")
+            .evaluate((element) => getComputedStyle(element).textWrap),
+        ).toBe("balance");
+        expect(await page.locator("openclaw-chat-page").count()).toBe(0);
+        expect(await page.locator(".agent-chat__input textarea").count()).toBe(0);
+        expect(await page.locator("openclaw-toast-host .app-toast").count()).toBe(0);
+        expect(await gateway.getRequests("sessions.resolve")).toHaveLength(1);
+        await captureUiProof(page, "session-link-not-found-after.png");
+
+        await currentSession.click();
+        await expect.poll(() => new URL(page.url()).pathname).toBe("/chat/main");
+        await page.locator(".agent-chat__input textarea").waitFor({ state: "visible" });
+
+        await page.goto(`${suite.server.baseUrl}${attemptedPath.slice(1)}`);
+        await page.getByRole("button", { name: "View sessions" }).click();
+        await expect.poll(() => new URL(page.url()).pathname).toBe("/sessions");
+        const sessionsHeader = page.locator("openclaw-sessions-page .sessions-hub-header");
+        await sessionsHeader.waitFor({ state: "visible" });
+        expect(await sessionsHeader.textContent()).toContain("Active sessions and defaults.");
+      },
+    );
+  });
+});

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5301,6 +5301,10 @@ export const en: TranslationMap = {
       chooseTitle: "Choose a session",
       multipleMatches: "More than one session matches {shortId}.",
       additionalMatches: "Search results remain. Use a longer id prefix.",
+      notFoundTitle: "Session not found",
+      notFoundExplanation: "The session may have been removed, or the link may be incorrect.",
+      goToMain: "Go to main session",
+      viewSessions: "View sessions",
     },
     commandResults: {
       startingNewThread: "Starting new session...",

--- a/ui/src/lib/sessions/route-navigation.ts
+++ b/ui/src/lib/sessions/route-navigation.ts
@@ -25,8 +25,13 @@ export function composerDraftSearch(draft: string): string {
 const SESSION_KEY_UUID_SUFFIX_RE =
   /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
 
+type SessionNavigationContext<TRouteId extends string> = Pick<
+  ApplicationContext<TRouteId>,
+  "agents" | "agentSelection" | "basePath" | "gateway" | "sessions"
+>;
+
 type ContextSessionNavigationTargetParams<TRouteId extends string> = {
-  context: ApplicationContext<TRouteId>;
+  context: SessionNavigationContext<TRouteId>;
   face: BoardFace;
   sessionKey: string;
   agentId?: string;

--- a/ui/src/pages/chat/route-loader-session-reference.ts
+++ b/ui/src/pages/chat/route-loader-session-reference.ts
@@ -7,10 +7,12 @@ import type { BoardFace } from "../../lib/board/settings.ts";
 import { sessionNavigationTarget } from "../../lib/sessions/route-navigation.ts";
 import {
   areUiSessionKeysEquivalent,
+  buildAgentMainSessionKey,
   isUiGlobalScopeConfigured,
   isUiGlobalSessionKey,
   normalizeAgentId,
   parseAgentSessionKey,
+  resolveUiConfiguredMainKey,
   resolveUiGlobalAliasAgentId,
 } from "../../lib/sessions/session-key.ts";
 import type { SessionRouteContext as ApplicationContext } from "./route-loader-context.ts";
@@ -43,14 +45,22 @@ const resolutionCache = new WeakMap<GatewayBrowserClient, Map<string, PendingSes
 export function missingSessionRouteData(
   context: ApplicationContext,
   face: BoardFace,
+  agentId: string,
 ): MissingSessionRouteData {
-  const currentSessionKey = context.gateway.snapshot.sessionKey.trim();
+  const mainKey = resolveUiConfiguredMainKey({
+    agentsList: context.agents.state.agentsList,
+    hello: context.gateway.snapshot.hello,
+  });
+  const mainSessionKey = buildAgentMainSessionKey({ agentId, mainKey });
   return {
     kind: "missing-session",
     face,
-    currentSessionHref: currentSessionKey
-      ? sessionNavigationTarget({ context, face, sessionKey: currentSessionKey }).href
-      : pathForRoute(face, context.basePath),
+    currentSessionHref: sessionNavigationTarget({
+      context,
+      face,
+      sessionKey: mainSessionKey,
+      agentId,
+    }).href,
     sessionsHref: pathForRoute("sessions", context.basePath),
   };
 }

--- a/ui/src/pages/chat/route-loader-session-reference.ts
+++ b/ui/src/pages/chat/route-loader-session-reference.ts
@@ -200,14 +200,8 @@ export async function querySessionReference(
 }
 
 function incompleteSessionReferenceResolution(
-  kind: SessionReferenceSearch["kind"],
   sessions: GatewaySessionRow[],
 ): SessionReferenceResolution {
-  if (kind === "slug" && sessions.length === 0) {
-    // Slugs are best-effort: an incomplete exact-key search must retain the
-    // authoritative literal route, while a bounded zero-match slug is a 404.
-    return { kind: "not-found" };
-  }
   return { kind: "ambiguous", sessions, truncated: true };
 }
 
@@ -247,11 +241,11 @@ async function querySessionReferencePages(
       return session ? { kind: "unique", session } : { kind: "not-found" };
     }
     if (page === SESSION_REF_SEARCH_MAX_PAGES - 1) {
-      return incompleteSessionReferenceResolution(search.kind, sessions);
+      return incompleteSessionReferenceResolution(sessions);
     }
     const nextOffset = result.nextOffset ?? offset + result.sessions.length;
     if (nextOffset <= offset) {
-      return incompleteSessionReferenceResolution(search.kind, sessions);
+      return incompleteSessionReferenceResolution(sessions);
     }
     offset = nextOffset;
   }

--- a/ui/src/pages/chat/route-loader-session-reference.ts
+++ b/ui/src/pages/chat/route-loader-session-reference.ts
@@ -1,0 +1,248 @@
+import { controlUiSessionSlug, SHORT_SESSION_ID_RE } from "@openclaw/session-url-contract";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
+import { pathForRoute } from "../../app-route-paths.ts";
+import { waitForGatewayClient } from "../../app/gateway-readiness.ts";
+import type { BoardFace } from "../../lib/board/settings.ts";
+import { sessionNavigationTarget } from "../../lib/sessions/route-navigation.ts";
+import {
+  areUiSessionKeysEquivalent,
+  isUiGlobalScopeConfigured,
+  isUiGlobalSessionKey,
+  normalizeAgentId,
+  parseAgentSessionKey,
+  resolveUiGlobalAliasAgentId,
+} from "../../lib/sessions/session-key.ts";
+import type { SessionRouteContext as ApplicationContext } from "./route-loader-context.ts";
+import { sessionKeyUuid } from "./route-loader-short-cache.ts";
+import type { SessionReferenceResolution } from "./route-loader-short-resolve.ts";
+
+const SESSION_REF_SEARCH_LIMIT = 20;
+const SESSION_REF_SEARCH_MAX_PAGES = 5;
+
+export type MissingSessionRouteData = {
+  kind: "missing-session";
+  face: BoardFace;
+  currentSessionHref: string;
+  sessionsHref: string;
+};
+
+export type SessionReferenceSearch = { agentId: string } & (
+  | { kind: "exact"; value: string }
+  | { kind: "slug"; value: string }
+);
+
+type PendingSessionReference = {
+  controller: AbortController;
+  promise: Promise<SessionReferenceResolution | null>;
+  subscribers: Set<AbortSignal>;
+};
+
+const resolutionCache = new WeakMap<GatewayBrowserClient, Map<string, PendingSessionReference>>();
+
+export function missingSessionRouteData(
+  context: ApplicationContext,
+  face: BoardFace,
+): MissingSessionRouteData {
+  const currentSessionKey = context.gateway.snapshot.sessionKey.trim();
+  return {
+    kind: "missing-session",
+    face,
+    currentSessionHref: currentSessionKey
+      ? sessionNavigationTarget({ context, face, sessionKey: currentSessionKey }).href
+      : pathForRoute(face, context.basePath),
+    sessionsHref: pathForRoute("sessions", context.basePath),
+  };
+}
+
+export function uniqueShortIdPrefix(
+  value: string,
+  candidates: readonly string[],
+  truncated: boolean,
+): string | null {
+  const uuid = value.toLowerCase().replaceAll("-", "");
+  if (!SHORT_SESSION_ID_RE.test(uuid)) {
+    return null;
+  }
+  if (truncated) {
+    return uuid;
+  }
+  const normalizedCandidates = candidates.map((candidate) =>
+    candidate.toLowerCase().replaceAll("-", ""),
+  );
+  for (let length = 8; length <= uuid.length; length += 1) {
+    const prefix = uuid.slice(0, length);
+    if (normalizedCandidates.filter((candidate) => candidate.startsWith(prefix)).length === 1) {
+      return prefix;
+    }
+  }
+  return uuid;
+}
+
+// The gateway matches `search` as a plain substring of the stored key, id, and title
+// fields, so every needle here has to be a run that literally appears in one of them.
+// sessionReferenceMatches still applies the exact rule per row, so a loose needle only
+// widens the candidate set; too narrow a needle loses the session entirely.
+function exactGlobalAliasAgentId(
+  context: ApplicationContext,
+  search: SessionReferenceSearch,
+): string | null {
+  if (search.kind !== "exact") {
+    return null;
+  }
+  const host = {
+    agentsList: context.agents.state.agentsList,
+    hello: context.gateway.snapshot.hello,
+  };
+  const aliasAgentId = resolveUiGlobalAliasAgentId(host, search.value);
+  const aliasRest = parseAgentSessionKey(search.value)?.rest.toLowerCase();
+  return aliasRest === "global" || isUiGlobalScopeConfigured(host) ? aliasAgentId : null;
+}
+
+function sessionReferenceSearchText(
+  context: ApplicationContext,
+  search: SessionReferenceSearch,
+): string {
+  if (search.kind === "exact") {
+    // Gateway search filters literal stored keys before client-side alias matching.
+    // A scoped main alias therefore has to request the canonical global key.
+    if (exactGlobalAliasAgentId(context, search) === normalizeAgentId(search.agentId)) {
+      return "global";
+    }
+    return search.value;
+  }
+  // controlUiSessionSlug builds every token from a contiguous alphanumeric run of the
+  // lowercased display name, so the longest token is the safest selective search term.
+  return search.value
+    .split("-")
+    .reduce((longest, token) => (token.length > longest.length ? token : longest), "");
+}
+
+function sessionReferenceMatches(
+  context: ApplicationContext,
+  result: SessionsListResult,
+  search: SessionReferenceSearch,
+): GatewaySessionRow[] {
+  if (search.kind === "exact") {
+    const aliasAgentId = exactGlobalAliasAgentId(context, search);
+    return result.sessions.filter(
+      (row) =>
+        areUiSessionKeysEquivalent(row.key, search.value) ||
+        (isUiGlobalSessionKey(row.key) && aliasAgentId === normalizeAgentId(search.agentId)),
+    );
+  }
+  return result.sessions.filter(
+    (row) =>
+      sessionKeyUuid(row.key) !== null && controlUiSessionSlug(row.displayName) === search.value,
+  );
+}
+
+export async function querySessionReference(
+  context: ApplicationContext,
+  search: SessionReferenceSearch,
+  signal: AbortSignal,
+): Promise<SessionReferenceResolution | null> {
+  const client = await waitForGatewayClient(context.gateway, signal);
+  signal.throwIfAborted();
+  const cache = resolutionCache.get(client) ?? new Map<string, PendingSessionReference>();
+  resolutionCache.set(client, cache);
+  const cacheKey = `${normalizeAgentId(search.agentId)}:${search.kind}:${search.value}`;
+  let pending = cache.get(cacheKey);
+  if (!pending || pending.controller.signal.aborted) {
+    const controller = new AbortController();
+    pending = {
+      controller,
+      promise: Promise.resolve().then(() =>
+        querySessionReferencePages(context, search, controller.signal),
+      ),
+      subscribers: new Set(),
+    };
+    cache.set(cacheKey, pending);
+  }
+  pending.subscribers.add(signal);
+  const shared = pending;
+  let rejectAbort: (reason: unknown) => void = () => undefined;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    rejectAbort = reject;
+  });
+  const onAbort = () => {
+    shared.subscribers.delete(signal);
+    // The producer is shared: one cancelled navigation must not cancel another
+    // active route's lookup, but the final subscriber must stop later pages.
+    if (shared.subscribers.size === 0) {
+      shared.controller.abort(signal.reason);
+    }
+    rejectAbort(signal.reason);
+  };
+  signal.addEventListener("abort", onAbort, { once: true });
+  if (signal.aborted) {
+    onAbort();
+  }
+  try {
+    return await Promise.race([shared.promise, aborted]);
+  } finally {
+    signal.removeEventListener("abort", onAbort);
+    shared.subscribers.delete(signal);
+    if (shared.subscribers.size === 0 && cache.get(cacheKey) === shared) {
+      cache.delete(cacheKey);
+    }
+  }
+}
+
+function incompleteSessionReferenceResolution(
+  kind: SessionReferenceSearch["kind"],
+  sessions: GatewaySessionRow[],
+): SessionReferenceResolution {
+  if (kind === "slug" && sessions.length === 0) {
+    // Slugs are best-effort: an incomplete exact-key search must retain the
+    // authoritative literal route, while a bounded zero-match slug is a 404.
+    return { kind: "not-found" };
+  }
+  return { kind: "ambiguous", sessions, truncated: true };
+}
+
+async function querySessionReferencePages(
+  context: ApplicationContext,
+  search: SessionReferenceSearch,
+  signal: AbortSignal,
+): Promise<SessionReferenceResolution | null> {
+  const matches = new Map<string, GatewaySessionRow>();
+  let offset = 0;
+  for (let page = 0; ; page += 1) {
+    signal.throwIfAborted();
+    const result = await context.sessions.list({
+      agentId: search.agentId,
+      archivedFilter: "all",
+      includeDerivedTitles: true,
+      limit: SESSION_REF_SEARCH_LIMIT,
+      search: sessionReferenceSearchText(context, search),
+      ...(offset > 0 ? { offset } : {}),
+    });
+    signal.throwIfAborted();
+    if (!result) {
+      return null;
+    }
+    for (const session of sessionReferenceMatches(context, result, search)) {
+      matches.set(session.key, session);
+    }
+    const sessions = [...matches.values()];
+    if (search.kind === "exact" && sessions[0]) {
+      return { kind: "unique", session: sessions[0] };
+    }
+    if (sessions.length > 1) {
+      return { kind: "ambiguous", sessions, truncated: result.hasMore === true };
+    }
+    if (result.hasMore !== true) {
+      const session = sessions[0];
+      return session ? { kind: "unique", session } : { kind: "not-found" };
+    }
+    if (page === SESSION_REF_SEARCH_MAX_PAGES - 1) {
+      return incompleteSessionReferenceResolution(search.kind, sessions);
+    }
+    const nextOffset = result.nextOffset ?? offset + result.sessions.length;
+    if (nextOffset <= offset) {
+      return incompleteSessionReferenceResolution(search.kind, sessions);
+    }
+    offset = nextOffset;
+  }
+}

--- a/ui/src/pages/chat/route-loader.ts
+++ b/ui/src/pages/chat/route-loader.ts
@@ -1,8 +1,6 @@
-import { controlUiSessionSlug, SHORT_SESSION_ID_RE } from "@openclaw/session-url-contract";
 import type { RouteLocation } from "@openclaw/uirouter";
 import { notFound } from "@openclaw/uirouter";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
+import type { GatewaySessionRow } from "../../api/types.ts";
 import { INTERNAL_SESSION_PATH_PARAM } from "../../app-route-paths.ts";
 import { pathForSession } from "../../app-session-path-builder.ts";
 import { sessionRefFromPath, type SessionPathTarget } from "../../app-session-route-paths.ts";
@@ -19,26 +17,25 @@ import {
 } from "../../lib/sessions/route-navigation.ts";
 import {
   buildAgentMainSessionKey,
-  areUiSessionKeysEquivalent,
-  isUiGlobalScopeConfigured,
   isUiGlobalSessionKey,
-  normalizeAgentId,
   parseAgentSessionKey,
   resolveAgentIdFromSessionKey,
   resolveUiConfiguredMainKey,
-  resolveUiGlobalAliasAgentId,
 } from "../../lib/sessions/session-key.ts";
 import { draftRouteDataFromLocation, draftSearchFromLocation } from "./route-draft.ts";
 import type { SessionRouteContext as ApplicationContext } from "./route-loader-context.ts";
+import {
+  missingSessionRouteData,
+  querySessionReference,
+  type MissingSessionRouteData,
+  uniqueShortIdPrefix,
+} from "./route-loader-session-reference.ts";
 import { findCachedShortSession, sessionKeyUuid } from "./route-loader-short-cache.ts";
 import {
   resolveShortSessionReference,
   type SessionReferenceResolution,
   type SessionRoutePresentation,
 } from "./route-loader-short-resolve.ts";
-
-const SESSION_REF_SEARCH_LIMIT = 20;
-const SESSION_REF_SEARCH_MAX_PAGES = 5;
 
 type SessionCandidate = {
   agentId: string;
@@ -66,7 +63,8 @@ export type ChatRouteData =
       candidates: SessionCandidate[];
       truncated: boolean;
       face: BoardFace;
-    };
+    }
+  | MissingSessionRouteData;
 
 export type SessionChatRouteData = Omit<
   Extract<ChatRouteData, { kind: "session" }>,
@@ -75,211 +73,6 @@ export type SessionChatRouteData = Omit<
   face?: BoardFace;
   kind?: "session";
 };
-
-type SessionReferenceSearch = { agentId: string } & (
-  | { kind: "exact"; value: string }
-  | { kind: "slug"; value: string }
-);
-
-type PendingSessionReference = {
-  controller: AbortController;
-  promise: Promise<SessionReferenceResolution | null>;
-  subscribers: Set<AbortSignal>;
-};
-
-const resolutionCache = new WeakMap<GatewayBrowserClient, Map<string, PendingSessionReference>>();
-
-function uniqueShortIdPrefix(
-  value: string,
-  candidates: readonly string[],
-  truncated: boolean,
-): string | null {
-  const uuid = value.toLowerCase().replaceAll("-", "");
-  if (!SHORT_SESSION_ID_RE.test(uuid)) {
-    return null;
-  }
-  if (truncated) {
-    return uuid;
-  }
-  const normalizedCandidates = candidates.map((candidate) =>
-    candidate.toLowerCase().replaceAll("-", ""),
-  );
-  for (let length = 8; length <= uuid.length; length += 1) {
-    const prefix = uuid.slice(0, length);
-    if (normalizedCandidates.filter((candidate) => candidate.startsWith(prefix)).length === 1) {
-      return prefix;
-    }
-  }
-  return uuid;
-}
-
-// The gateway matches `search` as a plain substring of the stored key, id, and title
-// fields, so every needle here has to be a run that literally appears in one of them.
-// sessionReferenceMatches still applies the exact rule per row, so a loose needle only
-// widens the candidate set; too narrow a needle loses the session entirely.
-function exactGlobalAliasAgentId(
-  context: ApplicationContext,
-  search: SessionReferenceSearch,
-): string | null {
-  if (search.kind !== "exact") {
-    return null;
-  }
-  const host = {
-    agentsList: context.agents.state.agentsList,
-    hello: context.gateway.snapshot.hello,
-  };
-  const aliasAgentId = resolveUiGlobalAliasAgentId(host, search.value);
-  const aliasRest = parseAgentSessionKey(search.value)?.rest.toLowerCase();
-  return aliasRest === "global" || isUiGlobalScopeConfigured(host) ? aliasAgentId : null;
-}
-
-function sessionReferenceSearchText(
-  context: ApplicationContext,
-  search: SessionReferenceSearch,
-): string {
-  if (search.kind === "exact") {
-    // Gateway search filters literal stored keys before client-side alias matching.
-    // A scoped main alias therefore has to request the canonical global key.
-    if (exactGlobalAliasAgentId(context, search) === normalizeAgentId(search.agentId)) {
-      return "global";
-    }
-    return search.value;
-  }
-  // controlUiSessionSlug builds every token from a contiguous alphanumeric run of the
-  // lowercased display name, so the longest token is the safest selective search term.
-  return search.value
-    .split("-")
-    .reduce((longest, token) => (token.length > longest.length ? token : longest), "");
-}
-
-function sessionReferenceMatches(
-  context: ApplicationContext,
-  result: SessionsListResult,
-  search: SessionReferenceSearch,
-): GatewaySessionRow[] {
-  if (search.kind === "exact") {
-    const aliasAgentId = exactGlobalAliasAgentId(context, search);
-    return result.sessions.filter(
-      (row) =>
-        areUiSessionKeysEquivalent(row.key, search.value) ||
-        (isUiGlobalSessionKey(row.key) && aliasAgentId === normalizeAgentId(search.agentId)),
-    );
-  }
-  return result.sessions.filter(
-    (row) =>
-      sessionKeyUuid(row.key) !== null && controlUiSessionSlug(row.displayName) === search.value,
-  );
-}
-
-async function querySessionReference(
-  context: ApplicationContext,
-  search: SessionReferenceSearch,
-  signal: AbortSignal,
-): Promise<SessionReferenceResolution | null> {
-  const client = await waitForGatewayClient(context.gateway, signal);
-  signal.throwIfAborted();
-  const cache = resolutionCache.get(client) ?? new Map<string, PendingSessionReference>();
-  resolutionCache.set(client, cache);
-  const cacheKey = `${normalizeAgentId(search.agentId)}:${search.kind}:${search.value}`;
-  let pending = cache.get(cacheKey);
-  if (!pending || pending.controller.signal.aborted) {
-    const controller = new AbortController();
-    pending = {
-      controller,
-      promise: Promise.resolve().then(() =>
-        querySessionReferencePages(context, search, controller.signal),
-      ),
-      subscribers: new Set(),
-    };
-    cache.set(cacheKey, pending);
-  }
-  pending.subscribers.add(signal);
-  const shared = pending;
-  let rejectAbort: (reason: unknown) => void = () => undefined;
-  const aborted = new Promise<never>((_resolve, reject) => {
-    rejectAbort = reject;
-  });
-  const onAbort = () => {
-    shared.subscribers.delete(signal);
-    // The producer is shared: one cancelled navigation must not cancel another
-    // active route's lookup, but the final subscriber must stop later pages.
-    if (shared.subscribers.size === 0) {
-      shared.controller.abort(signal.reason);
-    }
-    rejectAbort(signal.reason);
-  };
-  signal.addEventListener("abort", onAbort, { once: true });
-  if (signal.aborted) {
-    onAbort();
-  }
-  try {
-    return await Promise.race([shared.promise, aborted]);
-  } finally {
-    signal.removeEventListener("abort", onAbort);
-    shared.subscribers.delete(signal);
-    if (shared.subscribers.size === 0 && cache.get(cacheKey) === shared) {
-      cache.delete(cacheKey);
-    }
-  }
-}
-
-function incompleteSessionReferenceResolution(
-  kind: SessionReferenceSearch["kind"],
-  sessions: GatewaySessionRow[],
-): SessionReferenceResolution {
-  if (kind === "slug" && sessions.length === 0) {
-    // Slugs are best-effort: an incomplete exact-key search must retain the
-    // authoritative literal route, while a bounded zero-match slug is a 404.
-    return { kind: "not-found" };
-  }
-  return { kind: "ambiguous", sessions, truncated: true };
-}
-
-async function querySessionReferencePages(
-  context: ApplicationContext,
-  search: SessionReferenceSearch,
-  signal: AbortSignal,
-): Promise<SessionReferenceResolution | null> {
-  const matches = new Map<string, GatewaySessionRow>();
-  let offset = 0;
-  for (let page = 0; ; page += 1) {
-    signal.throwIfAborted();
-    const result = await context.sessions.list({
-      agentId: search.agentId,
-      archivedFilter: "all",
-      includeDerivedTitles: true,
-      limit: SESSION_REF_SEARCH_LIMIT,
-      search: sessionReferenceSearchText(context, search),
-      ...(offset > 0 ? { offset } : {}),
-    });
-    signal.throwIfAborted();
-    if (!result) {
-      return null;
-    }
-    for (const session of sessionReferenceMatches(context, result, search)) {
-      matches.set(session.key, session);
-    }
-    const sessions = [...matches.values()];
-    if (search.kind === "exact" && sessions[0]) {
-      return { kind: "unique", session: sessions[0] };
-    }
-    if (sessions.length > 1) {
-      return { kind: "ambiguous", sessions, truncated: result.hasMore === true };
-    }
-    if (result.hasMore !== true) {
-      const session = sessions[0];
-      return session ? { kind: "unique", session } : { kind: "not-found" };
-    }
-    if (page === SESSION_REF_SEARCH_MAX_PAGES - 1) {
-      return incompleteSessionReferenceResolution(search.kind, sessions);
-    }
-    const nextOffset = result.nextOffset ?? offset + result.sessions.length;
-    if (nextOffset <= offset) {
-      return incompleteSessionReferenceResolution(search.kind, sessions);
-    }
-    offset = nextOffset;
-  }
-}
 
 function isPreferenceDerivedFace(location: RouteLocation): boolean {
   return new URLSearchParams(location.search).get(SESSION_FACE_PREFERENCE_PARAM) === "1";
@@ -626,7 +419,7 @@ export async function loadChatRoute(
           signal,
         );
         if (slugResolution?.kind === "not-found") {
-          return notFound({ routeId: face });
+          return missingSessionRouteData(context, face);
         }
         if (slugResolution?.kind === "ambiguous") {
           return {
@@ -723,7 +516,9 @@ export async function loadChatRoute(
       });
       return literal ?? notFound({ routeId: face });
     }
-    return notFound({ routeId: face });
+    return literalResolution?.kind === "not-found"
+      ? missingSessionRouteData(context, face)
+      : notFound({ routeId: face });
   }
   if (resolution.kind === "ambiguous") {
     return {

--- a/ui/src/pages/chat/route-loader.ts
+++ b/ui/src/pages/chat/route-loader.ts
@@ -419,7 +419,7 @@ export async function loadChatRoute(
           signal,
         );
         if (slugResolution?.kind === "not-found") {
-          return missingSessionRouteData(context, face);
+          return missingSessionRouteData(context, face, target.agentId);
         }
         if (slugResolution?.kind === "ambiguous") {
           return {
@@ -517,7 +517,7 @@ export async function loadChatRoute(
       return literal ?? notFound({ routeId: face });
     }
     return literalResolution?.kind === "not-found"
-      ? missingSessionRouteData(context, face)
+      ? missingSessionRouteData(context, face, target.agentId)
       : notFound({ routeId: face });
   }
   if (resolution.kind === "ambiguous") {

--- a/ui/src/pages/chat/route-resolution.test.ts
+++ b/ui/src/pages/chat/route-resolution.test.ts
@@ -763,8 +763,9 @@ describe("gateway-backed session route resolution", () => {
     expect(loaded).toMatchObject({ kind: "ambiguous", shortId: "12345678", truncated: true });
   });
 
-  it("returns a persistent missing-session state when the gateway has no short-id match", async () => {
+  it("routes a missing-session exit to the route agent's main session", async () => {
     const { context, list } = contextFor(() => result([]));
+    context.gateway.snapshot.sessionKey = "agent:main:saved-active-session";
     const request = installShortResolver(context, [], { ok: false });
 
     const loaded = await loadChatRoute(

--- a/ui/src/pages/chat/route-resolution.test.ts
+++ b/ui/src/pages/chat/route-resolution.test.ts
@@ -929,6 +929,29 @@ describe("gateway-backed session route resolution", () => {
     expect(list).toHaveBeenCalledTimes(2);
   });
 
+  it("keeps a capped slug lookup nonterminal while later matches remain possible", async () => {
+    const exactKey = "agent:roboclaw:unknown-thread";
+    const laterMatch = row({ displayName: "Unknown thread" });
+    const { context, list } = contextFor(({ search, offset = 0 }) => {
+      if (search === exactKey) {
+        return result([]);
+      }
+      return offset === 100
+        ? result([laterMatch], { offset })
+        : result([], { hasMore: true, nextOffset: offset + 20, offset });
+    });
+    const loaded = await loadChatRoute(
+      context,
+      { pathname: "/chat/roboclaw/unknown-thread", search: "", hash: "" },
+      "chat",
+      new AbortController().signal,
+    );
+
+    expect(loaded).toMatchObject({ kind: "ambiguous", candidates: [], truncated: true });
+    expect(list).toHaveBeenCalledTimes(6);
+    expect(list).not.toHaveBeenCalledWith(expect.objectContaining({ offset: 100 }));
+  });
+
   it("resolves a cached literal without a gateway round-trip", async () => {
     const literal = row({ key: "agent:roboclaw:standup", displayName: "Standup" });
     const { context, list } = contextFor(() => result([literal]), [literal]);

--- a/ui/src/pages/chat/route-resolution.test.ts
+++ b/ui/src/pages/chat/route-resolution.test.ts
@@ -57,7 +57,12 @@ function contextFor(
   const context = {
     basePath: "",
     gateway: {
-      snapshot: { phase: "connected", client, hello: null },
+      snapshot: {
+        phase: "connected",
+        client,
+        hello: null,
+        sessionKey: "agent:roboclaw:main",
+      },
       subscribe: vi.fn(() => () => undefined),
     },
     agents: { state: { agentsList: { mainKey: "main" } } },
@@ -758,7 +763,7 @@ describe("gateway-backed session route resolution", () => {
     expect(loaded).toMatchObject({ kind: "ambiguous", shortId: "12345678", truncated: true });
   });
 
-  it("returns not found when the gateway has no short-id match", async () => {
+  it("returns a persistent missing-session state when the gateway has no short-id match", async () => {
     const { context, list } = contextFor(() => result([]));
     const request = installShortResolver(context, [], { ok: false });
 
@@ -769,7 +774,12 @@ describe("gateway-backed session route resolution", () => {
       new AbortController().signal,
     );
 
-    expect(loaded).not.toHaveProperty("kind", "session");
+    expect(loaded).toEqual({
+      kind: "missing-session",
+      face: "chat",
+      currentSessionHref: "/chat/roboclaw",
+      sessionsHref: "/sessions",
+    });
     expect(list).toHaveBeenCalledWith(
       expect.objectContaining({ agentId: "roboclaw", search: "agent:roboclaw:deadbeef" }),
     );
@@ -900,7 +910,7 @@ describe("gateway-backed session route resolution", () => {
     });
   });
 
-  it("returns not found when neither a literal key nor slug resolves", async () => {
+  it("returns a persistent missing-session state when neither a literal key nor slug resolves", async () => {
     const { context, list } = contextFor(() => result([]));
     const loaded = await loadChatRoute(
       context,
@@ -909,7 +919,12 @@ describe("gateway-backed session route resolution", () => {
       new AbortController().signal,
     );
 
-    expect(loaded).not.toHaveProperty("kind", "session");
+    expect(loaded).toEqual({
+      kind: "missing-session",
+      face: "chat",
+      currentSessionHref: "/chat/roboclaw",
+      sessionsHref: "/sessions",
+    });
     expect(list).toHaveBeenCalledTimes(2);
   });
 

--- a/ui/src/pages/chat/route.test.ts
+++ b/ui/src/pages/chat/route.test.ts
@@ -88,7 +88,7 @@ describe("loadChatRoute", () => {
       new AbortController().signal,
     );
 
-    expect(loaded).not.toHaveProperty("kind", "session");
+    expect(loaded).toEqual({ type: "notFound", data: { routeId: "chat" } });
     expect(list).not.toHaveBeenCalled();
   });
 

--- a/ui/src/pages/chat/route.ts
+++ b/ui/src/pages/chat/route.ts
@@ -3,12 +3,18 @@ import { definePage } from "@openclaw/uirouter";
 import { html, nothing } from "lit";
 import { INTERNAL_SESSION_PATH_PARAM, pathForRoute, routePageSpec } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
+import { renderPanelErrorState } from "../../components/lazy-view-error.ts";
 import { t } from "../../i18n/index.ts";
 import type { BoardFace } from "../../lib/board/settings.ts";
 import type { ChatRouteData } from "./route-loader.ts";
 
 type SessionOwnerMatch = Pick<RouteMatch, "data">;
 const CHAT_PAGE_OWNER_KEY = "chat-page";
+
+function navigateTo(href: string) {
+  window.history.pushState({}, "", href);
+  window.dispatchEvent(new PopStateEvent("popstate"));
+}
 
 function renderAmbiguous(data: Extract<ChatRouteData, { kind: "ambiguous" }>) {
   return html`
@@ -34,6 +40,23 @@ function renderAmbiguous(data: Extract<ChatRouteData, { kind: "ambiguous" }>) {
   `;
 }
 
+function renderMissingSession(data: Extract<ChatRouteData, { kind: "missing-session" }>) {
+  return renderPanelErrorState({
+    className: "session-route-not-found",
+    role: "status",
+    title: t("chat.sessionRoute.notFoundTitle"),
+    subtitle: t("chat.sessionRoute.notFoundExplanation"),
+    actions: html`
+      <button class="btn primary" type="button" @click=${() => navigateTo(data.currentSessionHref)}>
+        ${t("chat.sessionRoute.goToMain")}
+      </button>
+      <button class="btn" type="button" @click=${() => navigateTo(data.sessionsHref)}>
+        ${t("chat.sessionRoute.viewSessions")}
+      </button>
+    `,
+  });
+}
+
 function sessionLoaderDeps(
   face: BoardFace,
   context: ApplicationContext,
@@ -55,7 +78,7 @@ function sessionLoaderDeps(
 
 function sessionRenderOwnerKey(match: SessionOwnerMatch): string | undefined {
   const data = match.data as ChatRouteData | undefined;
-  return data?.kind === "ambiguous" ? undefined : CHAT_PAGE_OWNER_KEY;
+  return data?.kind === "session" ? CHAT_PAGE_OWNER_KEY : undefined;
 }
 
 function sessionPage(face: BoardFace) {
@@ -84,9 +107,13 @@ function sessionPage(face: BoardFace) {
           if (!routeData) {
             return nothing;
           }
-          return routeData.kind === "ambiguous"
-            ? renderAmbiguous(routeData)
-            : html`<openclaw-chat-page .data=${routeData}></openclaw-chat-page>`;
+          if (routeData.kind === "ambiguous") {
+            return renderAmbiguous(routeData);
+          }
+          if (routeData.kind === "missing-session") {
+            return renderMissingSession(routeData);
+          }
+          return html`<openclaw-chat-page .data=${routeData}></openclaw-chat-page>`;
         },
       })),
   });

--- a/ui/src/pages/chat/route.ts
+++ b/ui/src/pages/chat/route.ts
@@ -76,8 +76,11 @@ function sessionLoaderDeps(
   }`;
 }
 
-function sessionRenderOwnerKey(match: SessionOwnerMatch): string | undefined {
-  const data = match.data as ChatRouteData | undefined;
+function sessionRenderOwnerKey(
+  match: SessionOwnerMatch,
+  settled: SessionOwnerMatch | undefined,
+): string | undefined {
+  const data = (match.data ?? settled?.data) as ChatRouteData | undefined;
   return data?.kind === "session" ? CHAT_PAGE_OWNER_KEY : undefined;
 }
 

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -4127,6 +4127,14 @@ wa-dropdown.sidebar-identity-menu::part(menu) {
   min-height: 0;
 }
 
+.session-route-not-found {
+  width: min(440px, 100%);
+}
+
+.session-route-not-found .lazy-view-error__subtitle {
+  text-wrap: balance;
+}
+
 .content--custodian {
   display: flex;
   flex-direction: column;

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -359,6 +359,7 @@ export type ControlUiMockGatewayScenario = {
   operatorScopes?: string[];
   sessionKey?: string;
   sessionScope?: "agent" | "global";
+  mainSessionKey?: string;
   /** Initial gateway-owned custom group catalog (sessions.groups.*), in order. */
   sessionGroups?: string[];
   /** Optional New Session defaults keyed by custom group name. */
@@ -875,6 +876,7 @@ function normalizeScenario(
 ): NormalizedControlUiMockGatewayScenario {
   const defaultAgentId = scenario.defaultAgentId?.trim() || "main";
   const sessionKey = scenario.sessionKey?.trim() || "main";
+  const mainSessionKey = scenario.mainSessionKey?.trim() || sessionKey;
   const basePathValue = scenario.basePath?.trim() ?? "";
   const basePathWithSlash = basePathValue
     ? basePathValue.startsWith("/")
@@ -920,6 +922,7 @@ function normalizeScenario(
     omitFeatureMethods: scenario.omitFeatureMethods ?? false,
     historyMessages: scenario.historyMessages ?? [],
     maxPayload: scenario.maxPayload ?? DEFAULT_MOCK_MAX_PAYLOAD_BYTES,
+    mainSessionKey,
     methodResponses: scenario.methodResponses ?? {},
     webSocketPassthroughPrefixes: scenario.webSocketPassthroughPrefixes ?? [],
     inFlightRun: scenario.inFlightRun ?? null,
@@ -1764,7 +1767,7 @@ function installControlUiMockGateway(
             sessionDefaults: {
               defaultAgentId: scenario.defaultAgentId,
               mainKey: "main",
-              mainSessionKey: scenario.sessionKey,
+              mainSessionKey: scenario.mainSessionKey,
               modelConfigured: Boolean(scenario.agentModel),
               scope: scenario.sessionScope,
             },


### PR DESCRIPTION
Closes #131816

## What Problem This Solves

An explicit WebChat link for a session that no longer exists silently opened another active session with its composer enabled. The user received no error and could act in the wrong context.

## Why This Change Was Made

Authoritative missing session references now produce a named `missing-session` route state. The route keeps the attempted URL, renders the approved panel-error presentation, and does not mount chat or its composer.

The primary recovery action is built from the agent in the requested route and that agent's configured main session key. It does not use the user's saved active session. Bare `/chat`, unavailable or uncertain lookups, startup behavior, and live session deletion retain their existing behavior.

## User Impact

A stale or broken session link now explains what happened and offers two explicit exits: **Go to main session** for the route's agent, or **View sessions**. No configuration, persistence, or other navigation behavior changes.

## Evidence

### Before

Opening `/chat/main/deadbeef` silently ended at `/chat/main` with an active composer and no error state.

![Before: the missing session link silently opens the active session and composer](https://github.com/user-attachments/assets/fb454333-b761-4d98-aecf-8f2f213511fd)

### After: light theme

The attempted URL remains in place. The approved state is visible, and no chat page, composer, or toast is mounted.

![After in light theme: persistent Session not found state with Go to main session and View sessions actions](https://github.com/user-attachments/assets/d4b0d76c-0bc2-46d4-a62c-633fcf8a73d7)

### After: dark theme

![After in dark theme: the same persistent Session not found state and actions](https://github.com/user-attachments/assets/30b1b099-a502-4945-ba30-65177c59a096)

Focused regression proof covers a saved active session that differs from the configured main session, route-level destination construction, the missing-state boundary, and retained chat ownership while resolution is pending:

- `ui/src/e2e/session-link-not-found.e2e.test.ts`
- `ui/src/pages/chat/route-resolution.test.ts`
- `ui/src/app/router-outlet-chat.test.ts`

Validated locally:

- `node scripts/check-changed.mjs`
- `node scripts/run-vitest.mjs ui/src/app/router-outlet-chat.test.ts ui/src/pages/chat/route-resolution.test.ts ui/src/e2e/session-link-not-found.e2e.test.ts`
- `node scripts/run-vitest.mjs ui/src/e2e/dashboard-session-retention.e2e.test.ts ui/src/e2e/board-mcp-app.e2e.test.ts`

The first command passed all selected UI and core-test checks. The focused runs passed 38 route/not-found tests and 5 dashboard retention tests.
