### PR TITLE
fix(webchat): show named cards for failed attachments

### DIFF
--- a/extensions/imessage/src/test-plugin.test.ts
+++ b/extensions/imessage/src/test-plugin.test.ts
@@ -462,34 +462,39 @@ describe("imessagePlugin contracts", () => {
       filename: "../outside.png",
       contents: IMESSAGE_WORKSPACE_PNG,
       readerCalls: 0,
+      expectedCode: "path-not-allowed",
     },
     {
       name: "private log document",
       filename: "debug.log",
       contents: Buffer.from("private operator logs"),
       readerCalls: 1,
+      expectedCode: "unsupported-media-type",
     },
     {
       name: "untrusted HTML before the host reader",
       filename: "report.html",
       contents: Buffer.from("<!doctype html><h1>untrusted</h1>"),
       readerCalls: 0,
+      expectedCode: "path-not-allowed",
     },
     {
       name: "plain text disguised as a PDF",
       filename: "report.pdf",
       contents: Buffer.from("private text without a PDF signature"),
       readerCalls: 1,
+      expectedCode: "unsupported-media-type",
     },
     {
       name: "binary data disguised as plain text",
       filename: "report.txt",
       contents: Buffer.from([0x50, 0x4b, 0x03, 0x04]),
       readerCalls: 1,
+      expectedCode: "unsupported-media-type",
     },
   ])(
     "rejects $name before native iMessage delivery",
-    async ({ filename, contents, readerCalls }) => {
+    async ({ filename, contents, readerCalls, expectedCode }) => {
       await withStateDirEnv("openclaw-imessage-media-policy-", async ({ stateDir }) => {
         const stateRoot = fs.realpathSync(stateDir);
         const workspaceDir = path.join(stateRoot, "workspace");
@@ -515,7 +520,7 @@ describe("imessagePlugin contracts", () => {
           } as Parameters<typeof sendMedia>[0] & {
             deps: { imessage: typeof nativeSend };
           }),
-        ).rejects.toMatchObject({ code: "path-not-allowed" });
+        ).rejects.toMatchObject({ code: expectedCode });
 
         expect(readFile).toHaveBeenCalledTimes(readerCalls);
         expect(conflictingReader).not.toHaveBeenCalled();

--- a/extensions/imessage/src/test-plugin.test.ts
+++ b/extensions/imessage/src/test-plugin.test.ts
@@ -469,7 +469,7 @@ describe("imessagePlugin contracts", () => {
       filename: "debug.log",
       contents: Buffer.from("private operator logs"),
       readerCalls: 1,
-      expectedCode: "unsupported-media-type",
+      expectedCode: "path-not-allowed",
     },
     {
       name: "untrusted HTML before the host reader",
@@ -483,14 +483,14 @@ describe("imessagePlugin contracts", () => {
       filename: "report.pdf",
       contents: Buffer.from("private text without a PDF signature"),
       readerCalls: 1,
-      expectedCode: "unsupported-media-type",
+      expectedCode: "path-not-allowed",
     },
     {
       name: "binary data disguised as plain text",
       filename: "report.txt",
       contents: Buffer.from([0x50, 0x4b, 0x03, 0x04]),
       readerCalls: 1,
-      expectedCode: "unsupported-media-type",
+      expectedCode: "path-not-allowed",
     },
   ])(
     "rejects $name before native iMessage delivery",

--- a/extensions/signal/src/media-access.test.ts
+++ b/extensions/signal/src/media-access.test.ts
@@ -298,10 +298,25 @@ describe("Signal host-owned outbound media access", () => {
   });
 
   it.each([
-    { name: "sensitive log", filename: "secret.log", contents: "sensitive host data" },
-    { name: "forged PDF", filename: "forged.pdf", contents: "not a real PDF" },
-    { name: "untrusted HTML", filename: "untrusted.html", contents: "<html>private</html>" },
-  ])("rejects a $name before contacting Signal", async ({ filename, contents }) => {
+    {
+      name: "sensitive log",
+      filename: "secret.log",
+      contents: "sensitive host data",
+      expectedCode: "unsupported-media-type",
+    },
+    {
+      name: "forged PDF",
+      filename: "forged.pdf",
+      contents: "not a real PDF",
+      expectedCode: "unsupported-media-type",
+    },
+    {
+      name: "untrusted HTML",
+      filename: "untrusted.html",
+      contents: "<html>private</html>",
+      expectedCode: "path-not-allowed",
+    },
+  ])("rejects a $name before contacting Signal", async ({ filename, contents, expectedCode }) => {
     await fs.writeFile(path.join(state.workspaceDir, filename), contents);
 
     await expect(
@@ -315,7 +330,7 @@ describe("Signal host-owned outbound media access", () => {
           },
         }),
       ),
-    ).rejects.toMatchObject({ code: "path-not-allowed" });
+    ).rejects.toMatchObject({ code: expectedCode });
 
     expect(requests).toHaveLength(0);
   });

--- a/extensions/signal/src/media-access.test.ts
+++ b/extensions/signal/src/media-access.test.ts
@@ -302,13 +302,13 @@ describe("Signal host-owned outbound media access", () => {
       name: "sensitive log",
       filename: "secret.log",
       contents: "sensitive host data",
-      expectedCode: "unsupported-media-type",
+      expectedCode: "path-not-allowed",
     },
     {
       name: "forged PDF",
       filename: "forged.pdf",
       contents: "not a real PDF",
-      expectedCode: "unsupported-media-type",
+      expectedCode: "path-not-allowed",
     },
     {
       name: "untrusted HTML",

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -29,6 +29,16 @@ export type ReplyMediaAttachment = {
   trustedLocalMedia?: boolean;
 };
 
+export type ReplyMediaFailureCode = "file-not-found" | "unsupported-format" | "delivery-failed";
+
+/** Producer-owned outcome for one attachment that could not be delivered. */
+export type ReplyMediaFailure = {
+  code: ReplyMediaFailureCode;
+  kind: "image" | "audio" | "video" | "document";
+  label: string;
+  mimeType?: string;
+};
+
 /** Channel-agnostic assistant reply payload. */
 export type ReplyPayload = {
   text?: string;
@@ -153,18 +163,44 @@ export type ReplyDeliveryContext = {
   replyToMode: ReplyToMode;
 };
 
-const REPLY_MEDIA_FAILURE_WARNING =
-  "⚠️ Media failed. Try sending a smaller supported file or a different format.";
+const REPLY_MEDIA_FAILURE_MESSAGES: Record<ReplyMediaFailureCode, string> = {
+  "file-not-found": "File not found. Check the path and try again.",
+  "unsupported-format": "Rejected by the local attachment allowlist. Send a supported file type.",
+  "delivery-failed": "Delivery failed. Try sending this file again.",
+};
 
-/** Appends the standard media failure warning without duplicating it. */
-export function appendReplyMediaFailureWarning(text: string | undefined): string {
-  if (!text?.trim()) {
-    return REPLY_MEDIA_FAILURE_WARNING;
-  }
-  if (text.includes(REPLY_MEDIA_FAILURE_WARNING)) {
+function formatReplyMediaFailures(failures: readonly ReplyMediaFailure[]): string {
+  return failures
+    .map((failure) => `⚠️ ${failure.label}: ${REPLY_MEDIA_FAILURE_MESSAGES[failure.code]}`)
+    .join("\n");
+}
+
+/** Appends one named, actionable fallback receipt per failed attachment. */
+export function appendReplyMediaFailures(
+  text: string | undefined,
+  failures: readonly ReplyMediaFailure[],
+): string | undefined {
+  if (failures.length === 0) {
     return text;
   }
-  return `${text}\n${REPLY_MEDIA_FAILURE_WARNING}`;
+  const receipt = formatReplyMediaFailures(failures);
+  return text?.trim() ? `${text}\n${receipt}` : receipt;
+}
+
+/** Removes producer-authored fallback receipts when structured display cards supersede them. */
+export function stripReplyMediaFailureFallback(
+  text: string | undefined,
+  failures: readonly ReplyMediaFailure[],
+): string | undefined {
+  if (!text || failures.length === 0) {
+    return text;
+  }
+  const receipt = formatReplyMediaFailures(failures);
+  if (text === receipt) {
+    return undefined;
+  }
+  const suffix = `\n${receipt}`;
+  return text.endsWith(suffix) ? text.slice(0, -suffix.length) : text;
 }
 
 function hasReplyPayloadMedia(payload: Pick<ReplyPayload, "mediaUrl" | "mediaUrls">): boolean {
@@ -248,8 +284,8 @@ export type ReplyPayloadMetadata = {
   ttsExplicit?: true;
   /** Original runtime MEDIA references used to identify the persisted assistant row. */
   assistantTranscriptMediaUrls?: string[];
-  /** Media normalization rejected at least one source before delivery. */
-  assistantMediaNormalizationFailed?: true;
+  /** Ordered per-source failures retained until transcript/display projection. */
+  assistantMediaFailures?: ReplyMediaFailure[];
   /** The runtime owns the transcript decision for this assistant payload. */
   assistantTranscriptOwned?: boolean;
   /** Exact channel/account transform owner that already accepted this payload. */

--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -458,9 +458,27 @@ describe("buildReplyPayloads media filter integration", () => {
   });
 
   it("drops only invalid media when reply media normalization fails", async () => {
-    const normalizeMediaPaths = async (payload: { mediaUrl?: string }) => {
+    const normalizeMediaPaths = async (payload: ReplyPayload) => {
       if (payload.mediaUrl === "./bad.png") {
-        throw new Error("Path escapes sandbox root");
+        return setReplyPayloadMetadata(
+          {
+            ...payload,
+            text: "keep text\n⚠️ bad.png: Delivery failed. Try sending this file again.",
+            mediaUrl: undefined,
+            mediaUrls: undefined,
+            audioAsVoice: false,
+          },
+          {
+            assistantMediaFailures: [
+              {
+                code: "delivery-failed",
+                kind: "image",
+                label: "bad.png",
+                mimeType: "image/png",
+              },
+            ],
+          },
+        );
       }
       return payload;
     };
@@ -475,7 +493,7 @@ describe("buildReplyPayloads media filter integration", () => {
 
     expect(replyPayloads).toHaveLength(2);
     expectFields(replyPayloads[0], {
-      text: "keep text\n⚠️ Media failed. Try sending a smaller supported file or a different format.",
+      text: "keep text\n⚠️ bad.png: Delivery failed. Try sending this file again.",
       mediaUrl: undefined,
       mediaUrls: undefined,
       audioAsVoice: false,
@@ -1187,9 +1205,12 @@ describe("buildReplyPayloads media filter integration", () => {
   });
 
   it("suppresses warning text when silent media payloads fail normalization", async () => {
-    const normalizeMediaPaths = async () => {
-      throw new Error("file not found");
-    };
+    const normalizeMediaPaths = async (payload: ReplyPayload) => ({
+      ...payload,
+      text: "⚠️ missing.png: File not found. Check the path and try again.",
+      mediaUrl: undefined,
+      mediaUrls: undefined,
+    });
 
     const { replyPayloads } = await buildTestReplyPayloads({
       payloads: [{ text: "NO_REPLY\nMEDIA: ./missing.png" }],
@@ -1199,10 +1220,14 @@ describe("buildReplyPayloads media filter integration", () => {
     expect(replyPayloads).toHaveLength(0);
   });
 
-  it("surfaces a warning when non-silent media payloads fail normalization", async () => {
-    const normalizeMediaPaths = async () => {
-      throw new Error("file not found");
-    };
+  it("surfaces a named receipt when non-silent media payloads fail normalization", async () => {
+    const normalizeMediaPaths = async (payload: ReplyPayload) => ({
+      ...payload,
+      text: "⚠️ missing.png: File not found. Check the path and try again.",
+      mediaUrl: undefined,
+      mediaUrls: undefined,
+      audioAsVoice: false,
+    });
 
     const { replyPayloads } = await buildTestReplyPayloads({
       payloads: [{ text: "MEDIA: ./missing.png" }],
@@ -1211,7 +1236,7 @@ describe("buildReplyPayloads media filter integration", () => {
 
     expect(replyPayloads).toHaveLength(1);
     expectFields(replyPayloads[0], {
-      text: "⚠️ Media failed. Try sending a smaller supported file or a different format.",
+      text: "⚠️ missing.png: File not found. Check the path and try again.",
       mediaUrl: undefined,
       mediaUrls: undefined,
       audioAsVoice: false,

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -13,7 +13,6 @@ import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { stripLegacyBracketToolCallBlocks } from "../../shared/text/assistant-visible-text.js";
 import { stripHeartbeatToken } from "../heartbeat.js";
 import {
-  appendReplyMediaFailureWarning,
   copyReplyPayloadMetadata,
   getReplyPayloadMetadata,
   setReplyPayloadMetadata,
@@ -43,28 +42,13 @@ export function loadReplyPayloadsDedupeRuntime() {
 async function normalizeReplyPayloadMedia(params: {
   payload: ReplyPayload;
   normalizeMediaPaths?: (payload: ReplyPayload) => Promise<ReplyPayload>;
-  suppressMediaFailureWarning?: boolean;
 }): Promise<ReplyPayload> {
   if (!params.normalizeMediaPaths || !resolveSendableOutboundReplyParts(params.payload).hasMedia) {
     return params.payload;
   }
 
-  try {
-    const normalized = await params.normalizeMediaPaths(params.payload);
-    return copyReplyPayloadMetadata(params.payload, normalized);
-  } catch (err) {
-    logVerbose(`reply payload media normalization failed: ${String(err)}`);
-    // Preserve the text reply and drop unusable media so channels can still send the answer.
-    return copyReplyPayloadMetadata(params.payload, {
-      ...params.payload,
-      text: params.suppressMediaFailureWarning
-        ? params.payload.text
-        : appendReplyMediaFailureWarning(params.payload.text),
-      mediaUrl: undefined,
-      mediaUrls: undefined,
-      audioAsVoice: false,
-    });
-  }
+  const normalized = await params.normalizeMediaPaths(params.payload);
+  return copyReplyPayloadMetadata(params.payload, normalized);
 }
 
 async function normalizeSentMediaUrlsForDedupe(params: {
@@ -270,7 +254,6 @@ export async function buildReplyPayloads(params: {
       const mediaNormalizedPayload = await normalizeReplyPayloadMedia({
         payload: parsed.payload,
         normalizeMediaPaths: params.normalizeMediaPaths,
-        suppressMediaFailureWarning: parsed.isSilent,
       });
       if (parsed.isSilent) {
         mediaNormalizedPayload.text = undefined;

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LocalMediaAccessError } from "../../media/local-media-access.js";
 import { captureEnv, setTestEnvValue } from "../../test-utils/env.js";
 import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "../reply-payload.js";
 
@@ -241,9 +242,7 @@ describe("createReplyMediaPathNormalizer", () => {
       path.join("/tmp/sandboxes/session-1", "out", "photo.png"),
       5 * 1024 * 1024,
     );
-    expect(result.text).toBe(
-      "⚠️ Media failed. Try sending a smaller supported file or a different format.",
-    );
+    expect(result.text).toBe("⚠️ photo.png: Delivery failed. Try sending this file again.");
   });
 
   it.each([
@@ -466,8 +465,10 @@ describe("createReplyMediaPathNormalizer", () => {
     expectNoMedia(result);
   });
 
-  it("keeps reply text and appends a warning when all reply media is dropped", async () => {
-    resolveOutboundAttachmentFromUrl.mockRejectedValueOnce(new Error("file not found"));
+  it("keeps reply text and appends a named receipt when all reply media is dropped", async () => {
+    resolveOutboundAttachmentFromUrl.mockRejectedValueOnce(
+      new LocalMediaAccessError("not-found", "missing test fixture"),
+    );
     const normalize = createTestReplyMediaNormalizer();
 
     const result = await normalize({
@@ -476,13 +477,15 @@ describe("createReplyMediaPathNormalizer", () => {
     });
 
     expect(result.text).toBe(
-      "WA_MEDIA_DM_07\n⚠️ Media failed. Try sending a smaller supported file or a different format.",
+      "WA_MEDIA_DM_07\n⚠️ missing.png: File not found. Check the path and try again.",
     );
     expectNoMedia(result);
   });
 
-  it("keeps surviving media and appends a warning when some reply media is dropped", async () => {
-    resolveOutboundAttachmentFromUrl.mockRejectedValueOnce(new Error("file not found"));
+  it("keeps surviving media and appends a named receipt for each dropped item", async () => {
+    resolveOutboundAttachmentFromUrl.mockRejectedValueOnce(
+      new LocalMediaAccessError("not-found", "missing test fixture"),
+    );
     const normalize = createTestReplyMediaNormalizer();
 
     const result = await normalize({
@@ -491,24 +494,31 @@ describe("createReplyMediaPathNormalizer", () => {
     });
 
     expect(result.text).toBe(
-      "Here is the surviving attachment\n⚠️ Media failed. Try sending a smaller supported file or a different format.",
+      "Here is the surviving attachment\n⚠️ missing.png: File not found. Check the path and try again.",
     );
     expectMedia(result, "https://example.com/ok.png", ["https://example.com/ok.png"]);
   });
 
   it("returns a warning-only text reply when media-only output is dropped upstream", async () => {
-    resolveOutboundAttachmentFromUrl.mockRejectedValueOnce(new Error("file not found"));
+    resolveOutboundAttachmentFromUrl.mockRejectedValueOnce(
+      new LocalMediaAccessError("not-found", "missing test fixture"),
+    );
     const normalize = createTestReplyMediaNormalizer();
 
     const result = await normalize({
       mediaUrls: ["./out/missing.png"],
     });
 
-    expect(result.text).toBe(
-      "⚠️ Media failed. Try sending a smaller supported file or a different format.",
-    );
+    expect(result.text).toBe("⚠️ missing.png: File not found. Check the path and try again.");
     expectNoMedia(result);
-    expect(getReplyPayloadMetadata(result)?.assistantMediaNormalizationFailed).toBe(true);
+    expect(getReplyPayloadMetadata(result)?.assistantMediaFailures).toEqual([
+      {
+        code: "file-not-found",
+        kind: "image",
+        label: "missing.png",
+        mimeType: "image/png",
+      },
+    ]);
   });
 
   it("threads requester context into shared outbound media access", async () => {

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { LocalMediaAccessError } from "../../media/local-media-access.js";
+import { HostReadMediaTypeError, LocalMediaAccessError } from "../../media/local-media-access.js";
 import { captureEnv, setTestEnvValue } from "../../test-utils/env.js";
 import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "../reply-payload.js";
 
@@ -518,6 +518,22 @@ describe("createReplyMediaPathNormalizer", () => {
         label: "missing.png",
         mimeType: "image/png",
       },
+    ]);
+  });
+
+  it("keeps host-read media type rejection internal to the reply outcome", async () => {
+    resolveOutboundAttachmentFromUrl.mockRejectedValueOnce(
+      new HostReadMediaTypeError("unsupported test fixture"),
+    );
+    const normalize = createTestReplyMediaNormalizer();
+
+    const result = await normalize({ mediaUrls: ["./out/settings.toml"] });
+
+    expect(result.text).toBe(
+      "⚠️ settings.toml: Rejected by the local attachment allowlist. Send a supported file type.",
+    );
+    expect(getReplyPayloadMetadata(result)?.assistantMediaFailures).toMatchObject([
+      { code: "unsupported-format", label: "settings.toml" },
     ]);
   });
 

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -1,7 +1,10 @@
 // Resolves media paths from reply payloads into runtime attachment metadata.
 import path from "node:path";
+import { mediaKindFromMime } from "@openclaw/media-core/constants";
+import { basenameFromAnyPath } from "@openclaw/media-core/file-name";
 import { isPassThroughRemoteMediaSource } from "@openclaw/media-core/media-source-url";
 import { mimeTypeFromFilePath } from "@openclaw/media-core/mime";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { resolvePathFromInput, toRelativeWorkspacePath } from "../../agents/path-policy.js";
@@ -13,13 +16,18 @@ import {
 import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
+import { sanitizeUntrustedFileName } from "../../infra/fs-safe-advanced.js";
+import { FsSafeError } from "../../infra/fs-safe.js";
 import { resolveOutboundMediaMaxBytes } from "../../media/configured-max-bytes.js";
+import { LocalMediaAccessError } from "../../media/local-media-access.js";
 import { resolveOutboundAttachmentFromUrl } from "../../media/outbound-attachment.js";
 import { resolveAgentScopedOutboundMediaAccess } from "../../media/read-capability.js";
 import {
-  appendReplyMediaFailureWarning,
+  appendReplyMediaFailures,
   copyReplyPayloadMetadata,
+  getReplyPayloadMetadata,
   setReplyPayloadMetadata,
+  type ReplyMediaFailure,
 } from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
 
@@ -27,6 +35,58 @@ const FILE_URL_RE = /^file:/i;
 const WINDOWS_DRIVE_RE = /^[a-zA-Z]:[\\/]/;
 const SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
 const HAS_FILE_EXT_RE = /\.\w{1,10}$/;
+const MAX_FAILURE_LABEL_LENGTH = 180;
+
+function resolveReplyMediaFailureLabel(media: string, index: number): string {
+  const trimmed = media.trim();
+  let source = trimmed;
+  if (SCHEME_RE.test(trimmed)) {
+    try {
+      source = new URL(trimmed).pathname;
+    } catch {
+      // Fall through to path-style basename handling for malformed sources.
+    }
+  }
+  const basename = basenameFromAnyPath(source).trim();
+  const fallback = `Attachment ${index + 1}`;
+  return truncateUtf16Safe(
+    sanitizeUntrustedFileName(basename, fallback) || fallback,
+    MAX_FAILURE_LABEL_LENGTH,
+  );
+}
+
+function resolveReplyMediaFailureKind(media: string): ReplyMediaFailure["kind"] {
+  const kind = mediaKindFromMime(mimeTypeFromFilePath(media));
+  return kind === "image" || kind === "audio" || kind === "video" ? kind : "document";
+}
+
+function resolveReplyMediaFailureCode(error: unknown): ReplyMediaFailure["code"] {
+  let current: unknown = error;
+  // Media loaders wrap filesystem/policy errors; bound cause traversal so malformed cycles fail safe.
+  for (let depth = 0; current instanceof Error && depth < 4; depth += 1) {
+    if (
+      (current instanceof LocalMediaAccessError && current.code === "not-found") ||
+      (current instanceof FsSafeError && current.code === "not-found")
+    ) {
+      return "file-not-found";
+    }
+    if (current instanceof LocalMediaAccessError && current.code === "unsupported-media-type") {
+      return "unsupported-format";
+    }
+    current = current.cause;
+  }
+  return "delivery-failed";
+}
+
+function createReplyMediaFailure(media: string, index: number, error: unknown): ReplyMediaFailure {
+  const mimeType = mimeTypeFromFilePath(media);
+  return {
+    code: resolveReplyMediaFailureCode(error),
+    kind: resolveReplyMediaFailureKind(media),
+    label: resolveReplyMediaFailureLabel(media, index),
+    ...(mimeType ? { mimeType } : {}),
+  };
+}
 
 function isLikelyLocalMediaSource(media: string): boolean {
   return (
@@ -265,13 +325,13 @@ export function createReplyMediaPathNormalizer(params: {
     const normalizedAttachments: NonNullable<ReplyPayload["attachments"]> = [];
     const seen = new Set<string>();
     let hasTrustedLocalMedia = payload.trustedLocalMedia === true;
-    let firstMediaDropError: unknown;
+    const mediaFailures: ReplyMediaFailure[] = [];
     for (const [mediaIndex, media] of mediaList.entries()) {
       let normalized: Awaited<ReturnType<typeof normalizeMediaSource>>;
       try {
         normalized = await normalizeMediaSource(media);
       } catch (err) {
-        firstMediaDropError ??= err;
+        mediaFailures.push(createReplyMediaFailure(media, mediaIndex, err));
         logVerbose(`dropping blocked reply media ${media}: ${String(err)}`);
         continue;
       }
@@ -292,10 +352,9 @@ export function createReplyMediaPathNormalizer(params: {
       });
     }
 
-    const text =
-      firstMediaDropError === undefined
-        ? payload.text
-        : appendReplyMediaFailureWarning(payload.text);
+    const text = appendReplyMediaFailures(payload.text, mediaFailures);
+    const previousMediaFailures = getReplyPayloadMetadata(payload)?.assistantMediaFailures ?? [];
+    const assistantMediaFailures = [...previousMediaFailures, ...mediaFailures];
 
     if (normalizedMedia.length === 0) {
       const normalized = copyReplyPayloadMetadata(payload, {
@@ -304,9 +363,9 @@ export function createReplyMediaPathNormalizer(params: {
         mediaUrl: undefined,
         mediaUrls: undefined,
       });
-      return firstMediaDropError === undefined
+      return mediaFailures.length === 0
         ? normalized
-        : setReplyPayloadMetadata(normalized, { assistantMediaNormalizationFailed: true });
+        : setReplyPayloadMetadata(normalized, { assistantMediaFailures });
     }
 
     const normalized = copyReplyPayloadMetadata(payload, {
@@ -319,9 +378,9 @@ export function createReplyMediaPathNormalizer(params: {
         : {}),
       ...(hasTrustedLocalMedia ? { trustedLocalMedia: true } : {}),
     });
-    return firstMediaDropError === undefined
+    return mediaFailures.length === 0
       ? normalized
-      : setReplyPayloadMetadata(normalized, { assistantMediaNormalizationFailed: true });
+      : setReplyPayloadMetadata(normalized, { assistantMediaFailures });
   };
 }
 

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -19,7 +19,7 @@ import { logVerbose } from "../../globals.js";
 import { sanitizeUntrustedFileName } from "../../infra/fs-safe-advanced.js";
 import { FsSafeError } from "../../infra/fs-safe.js";
 import { resolveOutboundMediaMaxBytes } from "../../media/configured-max-bytes.js";
-import { LocalMediaAccessError } from "../../media/local-media-access.js";
+import { HostReadMediaTypeError, LocalMediaAccessError } from "../../media/local-media-access.js";
 import { resolveOutboundAttachmentFromUrl } from "../../media/outbound-attachment.js";
 import { resolveAgentScopedOutboundMediaAccess } from "../../media/read-capability.js";
 import {
@@ -70,7 +70,10 @@ function resolveReplyMediaFailureCode(error: unknown): ReplyMediaFailure["code"]
     ) {
       return "file-not-found";
     }
-    if (current instanceof LocalMediaAccessError && current.code === "unsupported-media-type") {
+    if (
+      current instanceof HostReadMediaTypeError ||
+      (current instanceof LocalMediaAccessError && current.code === "unsupported-media-type")
+    ) {
       return "unsupported-format";
     }
     current = current.cause;

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -1613,7 +1613,7 @@ describe("createManagedOutgoingImageBlocks", () => {
     });
   });
 
-  it("does not publish a record when playback inspection fails", async () => {
+  it("returns a visible failure without publishing a record when playback inspection fails", async () => {
     const sourcePath = path.join(stateDir, "workspace", "voice.mp3");
     await fs.mkdir(path.dirname(sourcePath), { recursive: true });
     await fs.writeFile(sourcePath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
@@ -1630,7 +1630,17 @@ describe("createManagedOutgoingImageBlocks", () => {
       continueOnPrepareError: true,
     });
 
-    expect(blocks).toEqual([]);
+    expect(blocks).toEqual([
+      {
+        type: "attachment_error",
+        attachment: {
+          code: "delivery-failed",
+          kind: "audio",
+          label: "voice.mp3",
+          mimeType: "audio/mpeg",
+        },
+      },
+    ]);
     expect(listManagedImageRecordEntries({ stateDir })).toEqual([]);
     await expectPathMissing(path.join(stateDir, "media", "outgoing", "originals"));
   });
@@ -1959,7 +1969,7 @@ describe("createManagedOutgoingImageBlocks", () => {
     expect(requireBlock(blocks, 1).type).toBe("text");
   });
 
-  it("skips broken attachments when continueOnPrepareError is enabled", async () => {
+  it("returns a named failure block when continueOnPrepareError is enabled", async () => {
     const onPrepareError = vi.fn();
     const blocks = await createManagedOutgoingImageBlocks({
       sessionKey: "agent:main:main",
@@ -1970,8 +1980,16 @@ describe("createManagedOutgoingImageBlocks", () => {
       onPrepareError,
     });
 
-    expect(blocks).toHaveLength(1);
+    expect(blocks).toHaveLength(2);
     expect(requireBlock(blocks).type).toBe("image");
+    expect(requireBlock(blocks, 1)).toMatchObject({
+      type: "attachment_error",
+      attachment: {
+        code: "delivery-failed",
+        kind: "image",
+        label: "missing.png",
+      },
+    });
     expect(onPrepareError).toHaveBeenCalledTimes(1);
     const firstPrepareError = onPrepareError.mock.calls[0]?.[0];
     expect(firstPrepareError).toBeInstanceOf(Error);
@@ -1980,7 +1998,7 @@ describe("createManagedOutgoingImageBlocks", () => {
     );
   });
 
-  it("skips malformed media data URLs when continueOnPrepareError is enabled", async () => {
+  it("returns an error block for malformed media data URLs and keeps later media", async () => {
     const onPrepareError = vi.fn();
     const blocks = await createManagedOutgoingImageBlocks({
       sessionKey: "agent:main:main",
@@ -1990,8 +2008,12 @@ describe("createManagedOutgoingImageBlocks", () => {
       onPrepareError,
     });
 
-    expect(blocks).toHaveLength(1);
-    expect(requireBlock(blocks).type).toBe("image");
+    expect(blocks).toHaveLength(2);
+    expect(requireBlock(blocks)).toMatchObject({
+      type: "attachment_error",
+      attachment: { code: "delivery-failed", kind: "audio" },
+    });
+    expect(requireBlock(blocks, 1).type).toBe("image");
     expect(onPrepareError).toHaveBeenCalledOnce();
   });
 
@@ -2010,7 +2032,16 @@ describe("createManagedOutgoingImageBlocks", () => {
       onPrepareError,
     });
 
-    expect(blocks).toEqual([]);
+    expect(blocks).toEqual([
+      {
+        type: "attachment_error",
+        attachment: {
+          code: "delivery-failed",
+          kind: "document",
+          label: "mystery.blob",
+        },
+      },
+    ]);
     expect(onPrepareError).toHaveBeenCalledOnce();
     expect(onPrepareError.mock.calls[0]?.[0]).toMatchObject({
       message: expect.stringMatching(/could not be prepared/u),
@@ -2021,7 +2052,6 @@ describe("createManagedOutgoingImageBlocks", () => {
     {
       fileName: "config.xml",
       mimeType: "application/xml",
-      expectedMimeType: "text/xml",
       body: "<config/>",
     },
     { fileName: "vector.svg", mimeType: "image/svg+xml", body: "<svg/>" },
@@ -2054,7 +2084,17 @@ describe("createManagedOutgoingImageBlocks", () => {
       onPrepareError,
     });
 
-    expect(blocks).toEqual([]);
+    expect(blocks).toEqual([
+      {
+        type: "attachment_error",
+        attachment: {
+          code: "delivery-failed",
+          kind: "document",
+          label: fixture.fileName,
+          mimeType: fixture.mimeType,
+        },
+      },
+    ]);
     expect(onPrepareError).toHaveBeenCalledOnce();
     expect(listManagedImageRecordEntries({ stateDir })).toEqual([]);
     const originalsDir = path.join(stateDir, "media", MANAGED_OUTGOING_ORIGINALS_SUBDIR);

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -14,7 +14,11 @@ import {
 } from "@openclaw/normalization-core/number-coercion";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import pLimit from "p-limit";
-import type { ReplyMediaAttachment, ReplyPayload } from "../auto-reply/reply-payload.js";
+import type {
+  ReplyMediaAttachment,
+  ReplyMediaFailureCode,
+  ReplyPayload,
+} from "../auto-reply/reply-payload.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
 import { loadExactSessionEntryReadOnlyResult } from "../config/sessions/session-accessor.sqlite-entry-availability.js";
@@ -334,6 +338,23 @@ function getSanitizedManagedImageAttachmentError(
   return createManagedImageAttachmentError(
     `Managed ${kind} attachment ${JSON.stringify(label)} could not be prepared`,
   );
+}
+
+export function buildManagedMediaFailureBlock(params: {
+  code: ReplyMediaFailureCode;
+  kind: ManagedMediaKind | "media";
+  label: string;
+  mimeType?: string;
+}): Record<string, unknown> {
+  return {
+    type: "attachment_error",
+    attachment: {
+      code: params.code,
+      kind: params.kind === "media" ? "document" : params.kind,
+      label: params.label,
+      ...(params.mimeType ? { mimeType: params.mimeType } : {}),
+    },
+  };
 }
 
 function validateManagedImageBuffer(
@@ -1733,6 +1754,14 @@ export async function createManagedOutgoingMediaBlocks(params: {
       }
       const sanitizedError = getSanitizedManagedImageAttachmentError(error, label, hintedKind);
       if (params.continueOnPrepareError) {
+        blocks.push(
+          buildManagedMediaFailureBlock({
+            code: "delivery-failed",
+            kind: hintedKind,
+            label,
+            mimeType: item.mimeType ?? mimeTypeFromFilePath(localMediaPath ?? mediaUrl),
+          }),
+        );
         params.onPrepareError?.(sanitizedError);
         continue;
       }

--- a/src/gateway/server-methods/chat-assistant-content.ts
+++ b/src/gateway/server-methods/chat-assistant-content.ts
@@ -1,8 +1,9 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import {
-  appendReplyMediaFailureWarning,
+  getReplyPayloadMetadata,
   readPairingQrReplyChannelData,
+  stripReplyMediaFailureFallback,
   type ReplyPayload,
 } from "../../auto-reply/reply-payload.js";
 import { createOutboundPayloadPlan } from "../../infra/outbound/payloads.js";
@@ -11,6 +12,7 @@ import { renderQrTerminal } from "../../media/qr-terminal.js";
 import { stripInlineDirectiveTagsForDelivery } from "../../utils/directive-tags.js";
 import { stripEnvelopeFromMessage } from "../chat-sanitize.js";
 import {
+  buildManagedMediaFailureBlock,
   createManagedOutgoingMediaBlocks,
   prepareOutgoingMediaFromReplyPayload,
 } from "../managed-image-attachments.js";
@@ -137,6 +139,14 @@ export async function buildAssistantDisplayContentFromReplyPayloads(params: {
   ).length;
   const plan = createOutboundPayloadPlan(params.payloads);
   if (plan.length === 0) {
+    const failureBlocks = params.payloads.flatMap((payload) =>
+      (getReplyPayloadMetadata(payload)?.assistantMediaFailures ?? []).map(
+        buildManagedMediaFailureBlock,
+      ),
+    );
+    if (failureBlocks.length > 0) {
+      return failureBlocks;
+    }
     return rawTextPayloadCount > 0 ? [{ type: "text", text: "" }] : undefined;
   }
 
@@ -147,10 +157,14 @@ export async function buildAssistantDisplayContentFromReplyPayloads(params: {
   let strippedTextPayloadCount = 0;
   for (const entry of plan) {
     const payload = entry.payload;
-    let managedMediaPrepareFailed = false;
-    const text = sanitizeAssistantDisplayText(payload.text, {
-      preserveBoundaries: preserveTextBoundaries,
-    });
+    const metadataSource = params.payloads[entry.sourceIndex] ?? payload;
+    const mediaFailures = getReplyPayloadMetadata(metadataSource)?.assistantMediaFailures ?? [];
+    const text = sanitizeAssistantDisplayText(
+      stripReplyMediaFailureFallback(payload.text, mediaFailures),
+      {
+        preserveBoundaries: preserveTextBoundaries,
+      },
+    );
     if (text) {
       const previousBlock = content.at(-1);
       if (previousBlock?.type === "text" && typeof previousBlock.text === "string") {
@@ -177,14 +191,10 @@ export async function buildAssistantDisplayContentFromReplyPayloads(params: {
     const mediaBlocks = await createManagedOutgoingMediaBlocks({
       sessionKey: params.sessionKey,
       ...(params.agentId ? { agentId: params.agentId } : {}),
-      items: prepareOutgoingMediaFromReplyPayload(
-        payload,
-        params.payloads[entry.sourceIndex] ?? payload,
-      ),
+      items: prepareOutgoingMediaFromReplyPayload(payload, metadataSource),
       localRoots: params.managedMediaLocalRoots,
       continueOnPrepareError: true,
       onPrepareError: (error) => {
-        managedMediaPrepareFailed = true;
         params.onManagedMediaPrepareError?.(error.message);
       },
     });
@@ -196,9 +206,7 @@ export async function buildAssistantDisplayContentFromReplyPayloads(params: {
       }
     }
     content.push(...mediaBlocks);
-    if (managedMediaPrepareFailed) {
-      content.push({ type: "text", text: appendReplyMediaFailureWarning(undefined) });
-    }
+    content.push(...mediaFailures.map(buildManagedMediaFailureBlock));
   }
 
   if (content.length > 0) {
@@ -226,25 +234,17 @@ export function replaceAssistantContentTextBlocks(
   }
   const merged: AssistantDisplayContentBlock[] = [];
   let transcriptTextIndex = 0;
-  const mediaFailureWarning = appendReplyMediaFailureWarning(undefined);
   for (const block of content) {
     if (
       block?.type === "text" &&
       typeof block.text === "string" &&
-      block.text !== mediaFailureWarning &&
       transcriptTextIndex < transcriptTextBlocks.length
     ) {
       const replacement = expectDefined(
         transcriptTextBlocks[transcriptTextIndex++],
         "transcript text blocks entry at transcript text index++",
       );
-      merged.push(
-        block.text.includes(mediaFailureWarning) &&
-          typeof replacement.text === "string" &&
-          !replacement.text.includes(mediaFailureWarning)
-          ? { ...replacement, text: appendReplyMediaFailureWarning(replacement.text) }
-          : replacement,
-      );
+      merged.push(replacement);
       continue;
     }
     merged.push(block);

--- a/src/gateway/server-methods/chat-reply-media.test.ts
+++ b/src/gateway/server-methods/chat-reply-media.test.ts
@@ -183,7 +183,7 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
     expect(payload?.mediaUrl).toBeUndefined();
     expect(payload?.mediaUrls).toBeUndefined();
     expect(requireString(payload?.text, "suppressed media text")).toBe(
-      "⚠️ Media failed. Try sending a smaller supported file or a different format.",
+      "⚠️ chart.png: Delivery failed. Try sending this file again.",
     );
   });
 
@@ -227,7 +227,7 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
       });
 
       expect(payload).toMatchObject({
-        text: "Artifacts ready\n⚠️ Media failed. Try sending a smaller supported file or a different format.",
+        text: "Artifacts ready\n⚠️ vector.svg: Rejected by the local attachment allowlist. Send a supported file type.",
         attachments: [
           expect.objectContaining({ name: "artifact.json", mimeType: "application/json" }),
           {},
@@ -242,10 +242,7 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
         managedMediaLocalRoots: getAgentScopedMediaLocalRoots(cfg, "main"),
       });
       expect(content).toEqual([
-        {
-          type: "text",
-          text: "Artifacts ready\n⚠️ Media failed. Try sending a smaller supported file or a different format.",
-        },
+        { type: "text", text: "Artifacts ready" },
         expect.objectContaining({
           type: "attachment",
           attachment: expect.objectContaining({
@@ -255,10 +252,19 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
         }),
         expect.objectContaining({ type: "image", alt: "remote.png", mimeType: "image/png" }),
         expect.objectContaining({ type: "image", alt: "local.png", mimeType: "image/png" }),
+        {
+          type: "attachment_error",
+          attachment: {
+            code: "unsupported-format",
+            kind: "image",
+            label: "vector.svg",
+            mimeType: "image/svg+xml",
+          },
+        },
       ]);
       const serialized = JSON.stringify(content);
-      expect(serialized).not.toContain("vector.svg");
-      expect(serialized.match(/Media failed/gu)).toHaveLength(1);
+      expect(serialized).toContain("vector.svg");
+      expect(serialized).not.toContain("Media failed");
       expect(serialized).not.toContain("sig=secret");
     } finally {
       await new Promise<void>((resolve, reject) => {
@@ -267,7 +273,7 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
     }
   });
 
-  it("preserves rejection warnings and metadata beside trusted local audio", async () => {
+  it("preserves named rejection outcomes and metadata beside trusted local audio", async () => {
     const { workspaceDir, cfg } = createMediaTestContext({ allowRead: true });
     const documentPath = path.join(workspaceDir, "report.json");
     const unsupportedPath = path.join(workspaceDir, "script.js");
@@ -294,7 +300,7 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
     });
 
     expect(payload).toMatchObject({
-      text: "Artifacts ready\n⚠️ Media failed. Try sending a smaller supported file or a different format.",
+      text: "Artifacts ready\n⚠️ script.js: Rejected by the local attachment allowlist. Send a supported file type.",
       mediaUrls: [expect.stringMatching(/\.json$/u), audioPath],
       attachments: [
         expect.objectContaining({ name: "report.json", mimeType: "application/json" }),
@@ -341,8 +347,12 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
 
     expect(content).toEqual([
       {
-        type: "text",
-        text: "⚠️ Media failed. Try sending a smaller supported file or a different format.",
+        type: "attachment_error",
+        attachment: {
+          code: "delivery-failed",
+          kind: "audio",
+          label: "Generated audio 1",
+        },
       },
     ]);
     expect(errors).toEqual(["Invalid image data URL"]);
@@ -350,7 +360,7 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
     expect(Buffer.byteLength(JSON.stringify(content))).toBeLessThan(256);
   });
 
-  it("keeps an explicit warning when one media item cannot become an attachment", async () => {
+  it("keeps a named failure when one media item cannot become an attachment", async () => {
     const { workspaceDir } = createMediaTestContext({ allowRead: true });
     const sourcePath = path.join(workspaceDir, "mystery.blob");
     await fs.mkdir(workspaceDir, { recursive: true });
@@ -372,44 +382,42 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
     expect(content).toEqual([
       { type: "text", text: "Artifact result" },
       {
-        type: "text",
-        text: "⚠️ Media failed. Try sending a smaller supported file or a different format.",
+        type: "attachment_error",
+        attachment: {
+          code: "delivery-failed",
+          kind: "document",
+          label: "mystery.blob",
+        },
       },
     ]);
   });
 
-  it("preserves a media failure warning beside synthetic media-only text", () => {
-    const warning = "⚠️ Media failed. Try sending a smaller supported file or a different format.";
-
+  it("preserves a structured media failure beside replaced transcript text", () => {
     expect(
       replaceAssistantContentTextBlocks(
         [
-          { type: "image", url: "/managed/image" },
-          { type: "text", text: warning },
+          { type: "text", text: "Artifact result" },
+          {
+            type: "attachment_error",
+            attachment: {
+              code: "delivery-failed",
+              kind: "document",
+              label: "report.7z",
+            },
+          },
         ],
-        { content: [{ type: "text", text: "Image reply" }] },
+        { content: [{ type: "text", text: "Canonical transcript text" }] },
       ),
     ).toEqual([
-      { type: "text", text: "Image reply" },
-      { type: "image", url: "/managed/image" },
-      { type: "text", text: warning },
-    ]);
-  });
-
-  it("preserves a media failure warning appended to replaced transcript text", () => {
-    const warning = "⚠️ Media failed. Try sending a smaller supported file or a different format.";
-
-    expect(
-      replaceAssistantContentTextBlocks(
-        [
-          { type: "text", text: `Artifact result\n${warning}` },
-          { type: "attachment", attachment: { label: "report.pdf" } },
-        ],
-        { content: [{ type: "text", text: "Artifact result" }] },
-      ),
-    ).toEqual([
-      { type: "text", text: `Artifact result\n${warning}` },
-      { type: "attachment", attachment: { label: "report.pdf" } },
+      { type: "text", text: "Canonical transcript text" },
+      {
+        type: "attachment_error",
+        attachment: {
+          code: "delivery-failed",
+          kind: "document",
+          label: "report.7z",
+        },
+      },
     ]);
   });
 
@@ -556,8 +564,13 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
     expect(content).toEqual([
       expect.objectContaining({ type: "audio", mimeType: "audio/mpeg" }),
       {
-        type: "text",
-        text: "⚠️ Media failed. Try sending a smaller supported file or a different format.",
+        type: "attachment_error",
+        attachment: {
+          code: "delivery-failed",
+          kind: "audio",
+          label: "untrusted.mp3",
+          mimeType: "audio/mpeg",
+        },
       },
     ]);
   });
@@ -602,7 +615,7 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
     expect(payload?.mediaUrl).toBeUndefined();
     expect(payload?.mediaUrls).toBeUndefined();
     expect(requireString(payload?.text, "suppressed media text")).toBe(
-      "⚠️ Media failed. Try sending a smaller supported file or a different format.",
+      "⚠️ voice.mp3: Delivery failed. Try sending this file again.",
     );
     await expectOutboundMediaMissing(stateDir);
   });
@@ -642,9 +655,7 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
       payload: (imagePath) => ({ mediaUrls: mediaUrls(imagePath, dataUrl) }),
     });
 
-    expect(payload?.text).toBe(
-      "⚠️ Media failed. Try sending a smaller supported file or a different format.",
-    );
+    expect(payload?.text).toBe("⚠️ chart.png: Delivery failed. Try sending this file again.");
     expect(payload?.text).not.toContain(sourcePath);
     expect(Buffer.byteLength(payload?.text ?? "")).toBeLessThan(256);
     expect(payload?.mediaUrl).toBe(dataUrl);
@@ -678,7 +689,7 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
         path.join(path.dirname(imagePath), "private customer report.png"),
       ],
     },
-  ])("keeps exactly one failure receipt for $label", async ({ mediaUrls }) => {
+  ])("keeps one named failure receipt per missing file for $label", async ({ mediaUrls }) => {
     const dataUrl = dataImageUrl();
     const { stateDir, sourcePath, payload } = await normalizeCodexHomeImage({
       allowRead: true,
@@ -689,12 +700,18 @@ describe("normalizeWebchatReplyMediaPathsForDisplay", () => {
     });
     const normalizedLocalPath = requireString(payload?.mediaUrls?.[0], "normalized local media");
 
-    expect(payload?.text).toBe(
-      "Here is the surviving attachment\n⚠️ Media failed. Try sending a smaller supported file or a different format.",
+    expect(payload?.text).toContain(
+      "Here is the surviving attachment\n⚠️ missing.png: File not found. Check the path and try again.",
     );
     expect(payload?.text).not.toContain(sourcePath);
-    expect(payload?.text).not.toContain("private customer report.png");
-    expect(Buffer.byteLength(payload?.text ?? "")).toBeLessThan(256);
+    if (
+      mediaUrls(path.join(path.dirname(sourcePath), "missing.png"), sourcePath, dataUrl).length > 3
+    ) {
+      expect(payload?.text).toContain(
+        "⚠️ private customer report.png: File not found. Check the path and try again.",
+      );
+    }
+    expect(Buffer.byteLength(payload?.text ?? "")).toBeLessThan(512);
     expect(payload?.mediaUrl).toBe(normalizedLocalPath);
     expect(payload?.mediaUrls).toEqual([normalizedLocalPath, dataUrl]);
     expect(normalizedLocalPath).not.toBe(sourcePath);

--- a/src/gateway/server-methods/chat-reply-media.ts
+++ b/src/gateway/server-methods/chat-reply-media.ts
@@ -2,7 +2,13 @@
 import { isPassThroughRemoteMediaSource } from "@openclaw/media-core/media-source-url";
 import { isAudioFileName } from "@openclaw/media-core/mime";
 import { resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
-import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
+import {
+  copyReplyPayloadMetadata,
+  getReplyPayloadMetadata,
+  setReplyPayloadMetadata,
+  type ReplyMediaFailure,
+  type ReplyPayload,
+} from "../../auto-reply/reply-payload.js";
 import { createReplyMediaPathNormalizer } from "../../auto-reply/reply/reply-media-paths.runtime.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveSendableOutboundReplyParts } from "../../plugin-sdk/reply-payload.js";
@@ -66,6 +72,8 @@ export async function normalizeWebchatReplyMediaPathsForDisplay(params: {
     }
     const mergedMediaUrls: string[] = [];
     const mergedAttachments: NonNullable<ReplyPayload["attachments"]> = [];
+    const previousMediaFailures = getReplyPayloadMetadata(payload)?.assistantMediaFailures ?? [];
+    const mediaFailures: ReplyMediaFailure[] = [...previousMediaFailures];
     let text = payload.text;
     for (const [index, mediaUrl] of mediaUrls.entries()) {
       const attachment = payload.attachments?.[index];
@@ -82,6 +90,11 @@ export async function normalizeWebchatReplyMediaPathsForDisplay(params: {
         attachments: attachment ? [attachment] : undefined,
       });
       const normalizedMediaUrls = resolveSendableOutboundReplyParts(normalizedPayload).mediaUrls;
+      mediaFailures.push(
+        ...(getReplyPayloadMetadata(normalizedPayload)?.assistantMediaFailures ?? []).slice(
+          previousMediaFailures.length,
+        ),
+      );
       text = normalizedPayload.text;
       if (normalizedMediaUrls.length === 0) {
         continue;
@@ -91,13 +104,18 @@ export async function normalizeWebchatReplyMediaPathsForDisplay(params: {
         ...(normalizedPayload.attachments ?? normalizedMediaUrls.map(() => ({}))),
       );
     }
-    normalized.push({
+    const merged = copyReplyPayloadMetadata(payload, {
       ...payload,
       text,
       mediaUrl: mergedMediaUrls[0],
       mediaUrls: mergedMediaUrls,
       attachments: mergedAttachments,
     });
+    normalized.push(
+      mediaFailures.length > 0
+        ? setReplyPayloadMetadata(merged, { assistantMediaFailures: mediaFailures })
+        : merged,
+    );
   }
   return normalized;
 }

--- a/src/gateway/server-methods/chat-send-reply-dispatch.ts
+++ b/src/gateway/server-methods/chat-send-reply-dispatch.ts
@@ -1,6 +1,10 @@
 import { isAudioFileName } from "@openclaw/media-core/mime";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
-import { getReplyPayloadMetadata, type ReplyPayload } from "../../auto-reply/reply-payload.js";
+import {
+  getReplyPayloadMetadata,
+  stripReplyMediaFailureFallback,
+  type ReplyPayload,
+} from "../../auto-reply/reply-payload.js";
 import type { ReplyDispatcherOptions } from "../../auto-reply/reply/reply-dispatcher.js";
 import { readSessionTranscriptWatermark } from "../../config/sessions/session-accessor.js";
 import {
@@ -139,7 +143,7 @@ export function createChatSendReplyDispatch(params: {
   let appendedWebchatAgentMedia = false;
   const needsAgentMediaTranscriptFinalization = (payload: ReplyPayload): boolean =>
     isMediaBearingPayload(payload) ||
-    getReplyPayloadMetadata(payload)?.assistantMediaNormalizationFailed === true;
+    Boolean(getReplyPayloadMetadata(payload)?.assistantMediaFailures?.length);
   const agentMediaTranscriptKey = (payload: ReplyPayload): string => {
     const metadata = getReplyPayloadMetadata(payload);
     const ownedIdempotencyKey =
@@ -205,8 +209,9 @@ export function createChatSendReplyDispatch(params: {
       assistantContent,
       mediaMessage,
     );
-    const mediaNormalizationFailed =
-      getReplyPayloadMetadata(transcriptPayload)?.assistantMediaNormalizationFailed === true;
+    const transcriptPayloadMetadata = getReplyPayloadMetadata(transcriptPayload);
+    const mediaFailures = transcriptPayloadMetadata?.assistantMediaFailures ?? [];
+    const mediaNormalizationFailed = mediaFailures.length > 0;
     const persistedContentForAppend =
       hasAssistantDisplayMediaContent(persistedAssistantContent) || mediaNormalizationFailed
         ? persistedAssistantContent
@@ -305,6 +310,25 @@ export function createChatSendReplyDispatch(params: {
         }
         return;
       }
+    }
+    const hasOnlyFailureDisplay =
+      persistedContentForAppend.some((block) => block.type === "attachment_error") &&
+      persistedContentForAppend.every(
+        (block) => block.type === "text" || block.type === "attachment_error",
+      );
+    const runtimeOwnedText = stripReplyMediaFailureFallback(
+      transcriptPayload.text,
+      mediaFailures,
+    )?.trim();
+    if (
+      assistantMessageIndex === undefined &&
+      mediaNormalizationFailed &&
+      hasOnlyFailureDisplay &&
+      runtimeOwnedText
+    ) {
+      // Agent message_end owns the text row. Without its identity, appending a failure card
+      // would duplicate that row; the live broadcast still carries the visible failure.
+      return;
     }
     const appended = await appendAssistantTranscriptMessage({
       sessionKey,

--- a/src/gateway/server-methods/chat-transcript-persistence.ts
+++ b/src/gateway/server-methods/chat-transcript-persistence.ts
@@ -1,9 +1,6 @@
 // Transcript persistence and source-reply rewrites shared by chat send and abort.
 import { asOptionalRecord as transcriptEventRecord } from "@openclaw/normalization-core/record-coerce";
-import {
-  appendReplyMediaFailureWarning,
-  getReplyPayloadMetadata,
-} from "../../auto-reply/reply-payload.js";
+import { getReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
 import {
   findTranscriptEvent,
   loadTranscriptEventRowsAfterSeqSync,
@@ -147,14 +144,7 @@ function mergeManagedMediaIntoAssistantContent(params: {
     ? (params.message.content as AssistantDisplayContentBlock[])
     : [];
   const managedBlocks = params.replacement.filter((block) => block?.type !== "text");
-  const mediaFailureWarning = appendReplyMediaFailureWarning(undefined);
-  const preserveMediaFailureWarning = params.replacement.some(
-    (block) =>
-      block?.type === "text" &&
-      typeof block.text === "string" &&
-      block.text.includes(mediaFailureWarning),
-  );
-  if (managedBlocks.length === 0 && !preserveMediaFailureWarning) {
+  if (managedBlocks.length === 0) {
     return null;
   }
   let replaced = false;
@@ -172,18 +162,13 @@ function mergeManagedMediaIntoAssistantContent(params: {
       const { textSignature: _textSignature, ...rest } = block;
       merged.push({
         ...rest,
-        text: preserveMediaFailureWarning
-          ? appendReplyMediaFailureWarning(visibleText)
-          : visibleText,
+        text: visibleText,
       });
     }
     if (split.mediaUrls?.length && !replaced) {
       merged.push(...managedBlocks);
       replaced = true;
     }
-  }
-  if (replaced && preserveMediaFailureWarning && merged.length === 0) {
-    merged.push({ type: "text", text: mediaFailureWarning });
   }
   return replaced ? merged : null;
 }

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -1342,6 +1342,7 @@ async function expectUnpersistedAgentRunFinal(params: {
   idempotencyKey: string;
   payload: (typeof mockState.dispatchedReplies)[number]["payload"];
   staleAudio?: boolean;
+  expectedMediaFailure?: { code: string; kind: string; label: string; mimeType?: string };
 }) {
   const transcriptDir = await createTranscriptFixture(params.transcriptPrefix);
   const staleAudioPath = path.join(transcriptDir, "stale.mp3");
@@ -1365,15 +1366,29 @@ async function expectUnpersistedAgentRunFinal(params: {
   const { send } = createChatRequestFixture();
   await send({ idempotencyKey: params.idempotencyKey, expectBroadcast: false, waitFor: "dedupe" });
 
+  const assistantUpdates = findAssistantTranscriptUpdates();
+  const assistantEntries = readTranscriptJsonLines(mockState.transcriptPath).filter(
+    (entry) =>
+      (entry as { message?: { role?: string } }).message?.role === "assistant" ||
+      (entry as { role?: string }).role === "assistant",
+  );
+  if (params.expectedMediaFailure) {
+    expect(assistantUpdates).toHaveLength(1);
+    expect(assistantUpdates[0]?.message).toMatchObject({
+      role: "assistant",
+      content: [
+        { type: "text", text: params.payload.text },
+        { type: "attachment_error", attachment: params.expectedMediaFailure },
+      ],
+    });
+    expect(assistantEntries).toHaveLength(1);
+    expect(JSON.stringify(assistantUpdates)).not.toContain(staleAudioPath);
+    return;
+  }
+
   // Agent-run delivery is a live projection; message_end alone owns persisted assistant turns.
-  expect(findAssistantTranscriptUpdates()).toStrictEqual([]);
-  expect(
-    readTranscriptJsonLines(mockState.transcriptPath).filter(
-      (entry) =>
-        (entry as { message?: { role?: string } }).message?.role === "assistant" ||
-        (entry as { role?: string }).role === "assistant",
-    ),
-  ).toStrictEqual([]);
+  expect(assistantUpdates).toStrictEqual([]);
+  expect(assistantEntries).toStrictEqual([]);
 }
 
 async function expectImageOnlyFinal(params: {
@@ -1392,7 +1407,7 @@ async function expectImageOnlyFinal(params: {
   }
   const image = content.find((block) => block.type === "image");
   expect(getMessage(payload)?.role).toBe("assistant");
-  expect(content[0]).toEqual({ type: "text", text: "Image reply" });
+  expect(content).toHaveLength(1);
   expect(image).toMatchObject({
     type: "image",
     artifactId: expect.stringMatching(/^artifact_managed_image_/u),
@@ -3513,7 +3528,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     );
   });
 
-  it("does not mirror agent-run stale media final text from live delivery", async () => {
+  it("persists a named failure when agent-run media disappears before delivery", async () => {
     await expectUnpersistedAgentRunFinal({
       transcriptPrefix: "openclaw-chat-send-agent-stale-tts-",
       idempotencyKey: "idem-stale-agent-media",
@@ -3521,6 +3536,12 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         text: "Text-only test: one clean reply, no TTS, no media, no tool narration.",
       },
       staleAudio: true,
+      expectedMediaFailure: {
+        code: "delivery-failed",
+        kind: "audio",
+        label: "stale.mp3",
+        mimeType: "audio/mpeg",
+      },
     });
   });
 

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -1386,9 +1386,22 @@ async function expectImageOnlyFinal(params: {
   const { send } = createChatRequestFixture();
   const payload = await send({ idempotencyKey: params.idempotencyKey });
   const content = getMessageContent(payload);
+  const mediaUrl = params.finalPayload.mediaUrl;
+  if (typeof mediaUrl !== "string") {
+    throw new Error("Expected an image-only final media URL");
+  }
+  const image = content.find((block) => block.type === "image");
   expect(getMessage(payload)?.role).toBe("assistant");
   expect(content[0]).toEqual({ type: "text", text: "Image reply" });
-  expect(content[1]).toEqual({ type: "input_image", image_url: "data:image/png;base64,cG5n" });
+  expect(image).toMatchObject({
+    type: "image",
+    artifactId: expect.stringMatching(/^artifact_managed_image_/u),
+    mimeType: "image/png",
+    url: expect.stringMatching(/\/api\/chat\/media\/outgoing\//u),
+    openUrl: expect.stringMatching(/\/api\/chat\/media\/outgoing\//u),
+  });
+  expect(content.some((block) => block.type === "attachment_error")).toBe(false);
+  expect(JSON.stringify(content)).not.toContain(mediaUrl);
 }
 
 beforeAll(() => {
@@ -2762,9 +2775,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     });
 
     const serialized = JSON.stringify(payload?.message);
-    expect(serialized).toContain(
-      "⚠️ Media failed. Try sending a smaller supported file or a different format.",
-    );
+    expect(serialized).toContain('"type":"attachment_error"');
+    expect(serialized).toContain('"code":"delivery-failed"');
+    expect(serialized).toContain('"label":"Generated audio 1"');
     expect(serialized).not.toContain(source);
     expect(Buffer.byteLength(serialized)).toBeLessThan(1_024);
     const assistantEntries = await readActiveAssistantTranscriptMessages();
@@ -2779,13 +2792,22 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       idempotencyKey: mirrorKey,
       text: `Artifacts ready\nMEDIA:${mediaUrl}`,
     });
-    setAgentRunReplies([
-      createMainSourceReply({
-        idempotencyKey: mirrorKey,
-        text: "Artifacts ready\n⚠️ Media failed. Try sending a smaller supported file or a different format.",
-        mediaUrls: [mediaUrl],
-      }),
-    ]);
+    const sourceReply = createMainSourceReply({
+      idempotencyKey: mirrorKey,
+      text: "Artifacts ready\n⚠️ report.7z: Delivery failed. Try sending this file again.",
+      mediaUrls: [mediaUrl],
+    });
+    setReplyPayloadMetadata(sourceReply.payload, {
+      assistantMediaFailures: [
+        {
+          code: "delivery-failed",
+          kind: "document",
+          label: "report.7z",
+          mimeType: "application/x-7z-compressed",
+        },
+      ],
+    });
+    setAgentRunReplies([sourceReply]);
     const { send } = createChatRequestFixture();
 
     await send({
@@ -2794,9 +2816,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     });
 
     const assistantEntries = await readActiveAssistantTranscriptMessages();
-    expect(JSON.stringify(assistantEntries[0])).toContain(
-      "⚠️ Media failed. Try sending a smaller supported file or a different format.",
-    );
+    expect(JSON.stringify(assistantEntries[0])).toContain('"type":"attachment_error"');
+    expect(JSON.stringify(assistantEntries[0])).toContain('"label":"report.7z"');
+    expect(JSON.stringify(assistantEntries[0])).not.toContain("Media failed");
     expect(JSON.stringify(assistantEntries[0])).not.toContain("MEDIA:");
   });
 
@@ -4758,7 +4780,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     await createTranscriptFixture("openclaw-chat-send-agent-image-");
     mockState.finalPayload = {
       text: "Scan this QR code with the OpenClaw iOS app:",
-      mediaUrl: "data:image/png;base64,cG5n",
+      mediaUrl: `data:image/png;base64,${TINY_PNG_BASE64}`,
     };
     const { send } = createChatRequestFixture();
 
@@ -4767,13 +4789,22 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     });
 
     const content = getMessageContent(payload);
+    const image = content.find((block) => block.type === "image");
     expect(getMessage(payload)?.role).toBe("assistant");
     expect(content[0]).toEqual({
       type: "text",
       text: "Scan this QR code with the OpenClaw iOS app:",
     });
-    expect(content[1]).toEqual({ type: "input_image", image_url: "data:image/png;base64,cG5n" });
-    expect(JSON.stringify(payload?.message)).not.toContain("MEDIA:data:image/png;base64,cG5n");
+    expect(image).toMatchObject({
+      type: "image",
+      artifactId: expect.stringMatching(/^artifact_managed_image_/u),
+      mimeType: "image/png",
+      url: expect.stringMatching(/\/api\/chat\/media\/outgoing\//u),
+      openUrl: expect.stringMatching(/\/api\/chat\/media\/outgoing\//u),
+    });
+    expect(JSON.stringify(payload?.message)).not.toContain(
+      `MEDIA:data:image/png;base64,${TINY_PNG_BASE64}`,
+    );
   });
 
   it("suppresses reasoning payloads from webchat transcript replies", async () => {
@@ -5952,7 +5983,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     await expectImageOnlyFinal({
       transcriptPrefix: "openclaw-chat-send-media-only-final-",
       idempotencyKey: "idem-media-only-final",
-      finalPayload: { mediaUrl: "data:image/png;base64,cG5n" },
+      finalPayload: { mediaUrl: `data:image/png;base64,${TINY_PNG_BASE64}` },
     });
   });
 
@@ -5960,7 +5991,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     await expectImageOnlyFinal({
       transcriptPrefix: "openclaw-chat-send-media-only-silent-final-",
       idempotencyKey: "idem-media-only-silent-final",
-      finalPayload: { text: "NO_REPLY", mediaUrl: "data:image/png;base64,cG5n" },
+      finalPayload: { text: "NO_REPLY", mediaUrl: `data:image/png;base64,${TINY_PNG_BASE64}` },
     });
   });
 
@@ -5968,7 +5999,10 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     await expectImageOnlyFinal({
       transcriptPrefix: "openclaw-chat-send-media-reply-tags-",
       idempotencyKey: "idem-media-reply-tags",
-      finalPayload: { replyToCurrent: true, mediaUrl: "data:image/png;base64,cG5n" },
+      finalPayload: {
+        replyToCurrent: true,
+        mediaUrl: `data:image/png;base64,${TINY_PNG_BASE64}`,
+      },
     });
     const transcriptUpdate = mockState.emittedTranscriptUpdates.find(
       (update) =>
@@ -5985,8 +6019,13 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       type: "text",
       text: "Image reply",
     });
+    expect(transcriptMessage?.content?.[1]).toMatchObject({
+      type: "image",
+      artifactId: expect.stringMatching(/^artifact_managed_image_/u),
+      mimeType: "image/png",
+    });
     expect(JSON.stringify(transcriptUpdate)).not.toContain("[[reply_to_current]]");
-    expect(JSON.stringify(transcriptUpdate)).not.toContain("data:image/png;base64,cG5n");
+    expect(JSON.stringify(transcriptUpdate)).not.toContain(TINY_PNG_BASE64);
   });
 
   it("does not persist sensitive image media into transcript updates", async () => {

--- a/src/media/local-media-access.ts
+++ b/src/media/local-media-access.ts
@@ -16,6 +16,7 @@ export type LocalMediaAccessErrorCode =
   | "invalid-file-url"
   | "network-path-not-allowed"
   | "unsafe-bypass"
+  | "unsupported-media-type"
   | "not-found"
   | "invalid-path"
   | "not-file";

--- a/src/media/local-media-access.ts
+++ b/src/media/local-media-access.ts
@@ -32,6 +32,16 @@ export class LocalMediaAccessError extends Error {
   }
 }
 
+/**
+ * Lets core classify rejected content without changing loadWebMedia's public error code.
+ * Removing this boundary would make detailed reply outcomes break plugin error handling.
+ */
+export class HostReadMediaTypeError extends LocalMediaAccessError {
+  constructor(message: string) {
+    super("path-not-allowed", message);
+  }
+}
+
 /** Returns the default root allowlist for local media reads. */
 export function getDefaultLocalRootsCore(): readonly string[] {
   return getDefaultMediaLocalRoots();

--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -771,7 +771,7 @@ describe("loadWebMedia", () => {
         hostReadCapability: true,
       }),
     ).rejects.toMatchObject({
-      code: "unsupported-media-type",
+      code: "path-not-allowed",
     });
   });
 
@@ -785,7 +785,7 @@ describe("loadWebMedia", () => {
         readFile: async (filePath) => await fs.readFile(filePath),
         hostReadCapability: true,
       }),
-      "unsupported-media-type",
+      "path-not-allowed",
     );
   });
 
@@ -863,7 +863,7 @@ describe("loadWebMedia", () => {
             readFile: async (filePath) => await fs.readFile(filePath),
             hostReadCapability: true,
           }),
-          "unsupported-media-type",
+          "path-not-allowed",
         );
       });
     } finally {
@@ -1166,7 +1166,7 @@ describe("loadWebMedia", () => {
         readFile: async (filePath) => await fs.readFile(filePath),
         hostReadCapability: true,
       }),
-      "unsupported-media-type",
+      "path-not-allowed",
     );
   });
 
@@ -1235,7 +1235,7 @@ describe("loadWebMedia", () => {
         readFile: async (filePath) => await fs.readFile(filePath),
         hostReadCapability: true,
       }),
-      "unsupported-media-type",
+      "path-not-allowed",
     );
   });
 
@@ -1261,7 +1261,7 @@ describe("loadWebMedia", () => {
         readFile: async (filePath) => await fs.readFile(filePath),
         hostReadCapability: true,
       }),
-      "unsupported-media-type",
+      "path-not-allowed",
     );
   });
 
@@ -1284,7 +1284,7 @@ describe("loadWebMedia", () => {
           readFile: async (filePath) => await fs.readFile(filePath),
           hostReadCapability: true,
         }),
-        "unsupported-media-type",
+        "path-not-allowed",
       );
     },
   );
@@ -1353,7 +1353,7 @@ describe("loadWebMedia", () => {
         readFile: async (filePath) => await fs.readFile(filePath),
         hostReadCapability: true,
       }),
-      "unsupported-media-type",
+      "path-not-allowed",
     );
   });
 
@@ -1377,7 +1377,7 @@ describe("loadWebMedia", () => {
         readFile: async (filePath) => await fs.readFile(filePath),
         hostReadCapability: true,
       }),
-      "unsupported-media-type",
+      "path-not-allowed",
     );
   });
 
@@ -1402,7 +1402,7 @@ describe("loadWebMedia", () => {
         readFile: async (filePath) => await fs.readFile(filePath),
         hostReadCapability: true,
       }),
-      "unsupported-media-type",
+      "path-not-allowed",
     );
   });
 
@@ -1424,7 +1424,7 @@ describe("loadWebMedia", () => {
         readFile: async (filePath) => await fs.readFile(filePath),
         hostReadCapability: true,
       }),
-      "unsupported-media-type",
+      "path-not-allowed",
     );
   });
 

--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -771,7 +771,7 @@ describe("loadWebMedia", () => {
         hostReadCapability: true,
       }),
     ).rejects.toMatchObject({
-      code: "path-not-allowed",
+      code: "unsupported-media-type",
     });
   });
 
@@ -785,7 +785,7 @@ describe("loadWebMedia", () => {
         readFile: async (filePath) => await fs.readFile(filePath),
         hostReadCapability: true,
       }),
-      "path-not-allowed",
+      "unsupported-media-type",
     );
   });
 
@@ -863,7 +863,7 @@ describe("loadWebMedia", () => {
             readFile: async (filePath) => await fs.readFile(filePath),
             hostReadCapability: true,
           }),
-          "path-not-allowed",
+          "unsupported-media-type",
         );
       });
     } finally {
@@ -1166,7 +1166,7 @@ describe("loadWebMedia", () => {
         readFile: async (filePath) => await fs.readFile(filePath),
         hostReadCapability: true,
       }),
-      "path-not-allowed",
+      "unsupported-media-type",
     );
   });
 
@@ -1235,7 +1235,7 @@ describe("loadWebMedia", () => {
         readFile: async (filePath) => await fs.readFile(filePath),
         hostReadCapability: true,
       }),
-      "path-not-allowed",
+      "unsupported-media-type",
     );
   });
 
@@ -1261,7 +1261,7 @@ describe("loadWebMedia", () => {
         readFile: async (filePath) => await fs.readFile(filePath),
         hostReadCapability: true,
       }),
-      "path-not-allowed",
+      "unsupported-media-type",
     );
   });
 
@@ -1284,7 +1284,7 @@ describe("loadWebMedia", () => {
           readFile: async (filePath) => await fs.readFile(filePath),
           hostReadCapability: true,
         }),
-        "path-not-allowed",
+        "unsupported-media-type",
       );
     },
   );
@@ -1353,7 +1353,7 @@ describe("loadWebMedia", () => {
         readFile: async (filePath) => await fs.readFile(filePath),
         hostReadCapability: true,
       }),
-      "path-not-allowed",
+      "unsupported-media-type",
     );
   });
 
@@ -1377,7 +1377,7 @@ describe("loadWebMedia", () => {
         readFile: async (filePath) => await fs.readFile(filePath),
         hostReadCapability: true,
       }),
-      "path-not-allowed",
+      "unsupported-media-type",
     );
   });
 
@@ -1402,7 +1402,7 @@ describe("loadWebMedia", () => {
         readFile: async (filePath) => await fs.readFile(filePath),
         hostReadCapability: true,
       }),
-      "path-not-allowed",
+      "unsupported-media-type",
     );
   });
 
@@ -1424,7 +1424,7 @@ describe("loadWebMedia", () => {
         readFile: async (filePath) => await fs.readFile(filePath),
         hostReadCapability: true,
       }),
-      "path-not-allowed",
+      "unsupported-media-type",
     );
   });
 

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -41,6 +41,7 @@ import type { OutboundMediaReadFile } from "./load-options.js";
 import {
   assertLocalMediaAllowed,
   getDefaultLocalRootsCore,
+  HostReadMediaTypeError,
   LocalMediaAccessError,
   readLocalMediaFile,
   type LocalMediaAccessErrorCode,
@@ -554,7 +555,7 @@ function assertHostReadMediaAllowed(params: {
     ) {
       return;
     }
-    throw new LocalMediaAccessError("unsupported-media-type", HOST_READ_DECLARED_TEXT_ERROR);
+    throw new HostReadMediaTypeError(HOST_READ_DECLARED_TEXT_ERROR);
   }
   const sniffedKind = kindFromMime(params.sniffedContentType);
   if (sniffedKind === "image" || sniffedKind === "audio" || sniffedKind === "video") {
@@ -593,13 +594,11 @@ function assertHostReadMediaAllowed(params: {
     normalizedMime &&
     HOST_READ_ALLOWED_DOCUMENT_MIMES.has(normalizedMime)
   ) {
-    throw new LocalMediaAccessError(
-      "unsupported-media-type",
+    throw new HostReadMediaTypeError(
       `Host-local media sends require buffer-verified media/document types (got fallback ${normalizedMime}).`,
     );
   }
-  throw new LocalMediaAccessError(
-    "unsupported-media-type",
+  throw new HostReadMediaTypeError(
     `Host-local media sends only allow buffer-verified images, audio, video, PDF, Office documents, archives, and validated plain-text documents (got ${sniffedMime ?? normalizedMime ?? "unknown"}).`,
   );
 }

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -554,7 +554,7 @@ function assertHostReadMediaAllowed(params: {
     ) {
       return;
     }
-    throw new LocalMediaAccessError("path-not-allowed", HOST_READ_DECLARED_TEXT_ERROR);
+    throw new LocalMediaAccessError("unsupported-media-type", HOST_READ_DECLARED_TEXT_ERROR);
   }
   const sniffedKind = kindFromMime(params.sniffedContentType);
   if (sniffedKind === "image" || sniffedKind === "audio" || sniffedKind === "video") {
@@ -594,12 +594,12 @@ function assertHostReadMediaAllowed(params: {
     HOST_READ_ALLOWED_DOCUMENT_MIMES.has(normalizedMime)
   ) {
     throw new LocalMediaAccessError(
-      "path-not-allowed",
+      "unsupported-media-type",
       `Host-local media sends require buffer-verified media/document types (got fallback ${normalizedMime}).`,
     );
   }
   throw new LocalMediaAccessError(
-    "path-not-allowed",
+    "unsupported-media-type",
     `Host-local media sends only allow buffer-verified images, audio, video, PDF, Office documents, archives, and validated plain-text documents (got ${sniffedMime ?? normalizedMime ?? "unknown"}).`,
   );
 }

--- a/test/e2e/qa-lab/runtime/webchat-media-artifacts.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/webchat-media-artifacts.e2e.test.ts
@@ -49,10 +49,17 @@ const FIXTURES = [
   ["photo.jpg", "image/jpeg", "image", "artifact"],
   ["mystery.blob", "application/octet-stream", "attachment", "visible-error"],
 ] as const;
-const MEDIA_FAILURE_WARNING =
-  "Media failed. Try sending a smaller supported file or a different format.";
 const ARTIFACT_FIXTURES = FIXTURES.filter((fixture) => fixture[3] === "artifact");
 const REJECTED_FIXTURES = FIXTURES.filter((fixture) => fixture[3] === "visible-error");
+const MIXED_BATCH = [
+  ["deploy.yaml", "artifact"],
+  ["settings.toml", "unsupported-format"],
+  ["schema.sql", "unsupported-format"],
+  ["events.ndjson", "unsupported-format"],
+  ["font.ttf", "unsupported-format"],
+  ["font.woff2", "unsupported-format"],
+  ["bundle.7z", "delivery-failed"],
+] as const;
 
 let harness: Awaited<ReturnType<typeof startQaLiveLaneGateway>> | undefined;
 let bus: Awaited<ReturnType<typeof startQaBusServer>> | undefined;
@@ -81,6 +88,9 @@ async function writeFixtures(workspaceDir: string): Promise<void> {
     "report.pdf": "%PDF-1.4\n% OpenClaw artifact proof\n",
     "worker.py": "def ready():\n    return True\n",
     "script.js": "export const ready = true;\n",
+    "settings.toml": 'name = "media-artifacts"\n',
+    "schema.sql": "select 1;\n",
+    "events.ndjson": '{"ready":true}\n',
   };
   await Promise.all(
     Object.entries(textFiles).map(([name, body]) =>
@@ -103,6 +113,12 @@ async function writeFixtures(workspaceDir: string): Promise<void> {
   );
   await fs.writeFile(path.join(workspaceDir, "photo.jpg"), createTinyJpegBuffer());
   await fs.writeFile(path.join(workspaceDir, "mystery.blob"), Buffer.from([0, 1, 2, 3]));
+  await fs.writeFile(path.join(workspaceDir, "font.ttf"), Buffer.from([0x00, 0x01, 0x00, 0x00]));
+  await fs.writeFile(path.join(workspaceDir, "font.woff2"), Buffer.from("wOF2", "ascii"));
+  await fs.writeFile(
+    path.join(workspaceDir, "bundle.7z"),
+    Buffer.from([0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c, 0x00, 0x04]),
+  );
   await fs.writeFile(path.join(workspaceDir, "clip.mp4"), createMp4Buffer());
 }
 
@@ -166,6 +182,21 @@ function isExpectedMediaBlock(block: unknown, expected: (typeof FIXTURES)[number
   return candidate.type === type && candidate.mimeType === mimeType && label === name;
 }
 
+function isExpectedFailureBlock(block: unknown, label: string, code: string): boolean {
+  if (!block || typeof block !== "object") {
+    return false;
+  }
+  const candidate = block as Record<string, unknown>;
+  const attachment = candidate.attachment;
+  return (
+    candidate.type === "attachment_error" &&
+    Boolean(attachment) &&
+    typeof attachment === "object" &&
+    (attachment as Record<string, unknown>).label === label &&
+    (attachment as Record<string, unknown>).code === code
+  );
+}
+
 async function connectWebchat(url: string, token: string): Promise<GatewayClient> {
   return await new Promise<GatewayClient>((resolve, reject) => {
     const connecting = new GatewayClient({
@@ -214,7 +245,7 @@ async function sendMediaReply(
 
 describe("WebChat managed media artifact matrix", () => {
   it(
-    "renders every supported MEDIA reference or a visible failure",
+    "renders every MEDIA reference as one named success or failure outcome",
     { timeout: 180_000 },
     async () => {
       const state = createQaBusState();
@@ -256,9 +287,15 @@ describe("WebChat managed media artifact matrix", () => {
         const sessionKey = `agent:qa:rejected-${fixture[0].replace(/[^a-z0-9]+/giu, "-")}`;
         const rejectedContent = await sendMediaReply(client, sessionKey, [fixture[0]], false);
         const serialized = JSON.stringify(rejectedContent);
-        expect(serialized, fixture[0]).toContain(MEDIA_FAILURE_WARNING);
+        expect(
+          rejectedContent.some((block) =>
+            isExpectedFailureBlock(block, fixture[0], "unsupported-format"),
+          ),
+          fixture[0],
+        ).toBe(true);
         expect(rejectedContent.some((block) => isExpectedMediaBlock(block, fixture))).toBe(false);
         expect(serialized).not.toContain("MEDIA:./");
+        expect(serialized).not.toContain("Media failed");
         const artifactList = await client.request<{ artifacts?: unknown[] }>("artifacts.list", {
           sessionKey,
         });
@@ -271,15 +308,67 @@ describe("WebChat managed media artifact matrix", () => {
           present: true,
         });
       }
+      const missingContent = await sendMediaReply(
+        client,
+        "agent:qa:missing-attachment",
+        ["missing-proof.yaml"],
+        false,
+      );
+      expect(missingContent).toEqual([
+        expect.objectContaining({
+          type: "attachment_error",
+          attachment: expect.objectContaining({
+            code: "file-not-found",
+            label: "missing-proof.yaml",
+          }),
+        }),
+      ]);
+
+      const mixedContent = await sendMediaReply(
+        client,
+        "agent:qa:mixed-attachment-outcomes",
+        MIXED_BATCH.map(([name]) => name),
+      );
+      const mixedOutcomes = MIXED_BATCH.map(([name, outcome]) => ({
+        name,
+        outcome,
+        present:
+          outcome === "artifact"
+            ? mixedContent.some(
+                (block) =>
+                  Boolean(block) &&
+                  typeof block === "object" &&
+                  (block as Record<string, unknown>).type === "attachment" &&
+                  ((block as Record<string, unknown>).attachment as Record<string, unknown>)
+                    ?.label === name,
+              )
+            : mixedContent.some((block) => isExpectedFailureBlock(block, name, outcome)),
+      }));
+      expect(mixedOutcomes.every((entry) => entry.present)).toBe(true);
+      expect(JSON.stringify(mixedContent)).not.toContain("Media failed");
+      expect(JSON.stringify(mixedContent)).not.toContain("MEDIA:./");
       const observed = [...accepted, ...rejected];
       const verdict = {
         expected: FIXTURES.length,
         observed: observed.filter((entry) => entry.present).length,
         missing: observed.filter((entry) => !entry.present).map((entry) => entry.name),
+        missingPath: isExpectedFailureBlock(
+          missingContent[0],
+          "missing-proof.yaml",
+          "file-not-found",
+        ),
+        mixedBatch: mixedOutcomes,
         rawMediaVisible: JSON.stringify(content).includes("MEDIA:./"),
       };
 
-      expect(verdict).toEqual({ expected: 20, observed: 20, missing: [], rawMediaVisible: false });
+      expect(verdict).toEqual({
+        expected: 20,
+        observed: 20,
+        missing: [],
+        missingPath: true,
+        mixedBatch: MIXED_BATCH.map(([name, outcome]) => ({ name, outcome, present: true })),
+        rawMediaVisible: false,
+      });
       console.log(`WEBCHAT_MEDIA_ARTIFACTS_PROOF=${JSON.stringify(verdict)}`);
     },
   );

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -6257,6 +6257,11 @@ export const en: TranslationMap = {
       outsideAllowedFolders: "Outside allowed folders",
       unavailable: "Unavailable",
       checking: "Checking...",
+      failureDeliveryFailed: "Delivery failed. Try sending this file again.",
+      failureFileNotFound: "File not found. Check the path and try again.",
+      failureUnsupportedFormat:
+        "Rejected by the local attachment allowlist. Send a supported file type.",
+      notSent: "Not sent",
       video: "Video",
     },
     voice: {

--- a/ui/src/lib/chat/chat-types.ts
+++ b/ui/src/lib/chat/chat-types.ts
@@ -259,6 +259,15 @@ export type MessageContentItem =
       };
     }
   | {
+      type: "attachment_error";
+      attachment: {
+        code: "file-not-found" | "unsupported-format" | "delivery-failed";
+        kind: Exclude<MediaKind, "sticker" | "unknown">;
+        label: string;
+        mimeType?: string;
+      };
+    }
+  | {
       type: "canvas";
       preview: Extract<NonNullable<ToolCard["preview"]>, { kind: "canvas" }>;
       rawText?: string | null;

--- a/ui/src/lib/chat/message-normalizer-attachments.ts
+++ b/ui/src/lib/chat/message-normalizer-attachments.ts
@@ -1,0 +1,69 @@
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import type { MessageContentItem } from "./chat-types.ts";
+
+function isAttachmentKind(kind: unknown): kind is "image" | "audio" | "video" | "document" {
+  return kind === "image" || kind === "audio" || kind === "video" || kind === "document";
+}
+
+export function normalizeAttachmentContentBlock(value: unknown): MessageContentItem[] | undefined {
+  const item = asOptionalRecord(value);
+  if (!item || (item.type !== "attachment" && item.type !== "attachment_error")) {
+    return undefined;
+  }
+  const attachment = asOptionalRecord(item.attachment);
+  if (!attachment || !isAttachmentKind(attachment.kind) || typeof attachment.label !== "string") {
+    return [];
+  }
+  const mimeType = typeof attachment.mimeType === "string" ? attachment.mimeType : undefined;
+  if (item.type === "attachment_error") {
+    if (
+      attachment.code !== "file-not-found" &&
+      attachment.code !== "unsupported-format" &&
+      attachment.code !== "delivery-failed"
+    ) {
+      return [];
+    }
+    return [
+      {
+        type: "attachment_error",
+        attachment: {
+          code: attachment.code,
+          kind: attachment.kind,
+          label: attachment.label,
+          ...(mimeType !== undefined ? { mimeType } : {}),
+        },
+      },
+    ];
+  }
+  if (typeof attachment.url !== "string") {
+    return [];
+  }
+  return [
+    {
+      type: "attachment",
+      attachment: {
+        url: attachment.url,
+        kind: attachment.kind,
+        label: attachment.label,
+        ...(mimeType !== undefined ? { mimeType } : {}),
+        ...(attachment.isVoiceNote === true ? { isVoiceNote: true } : {}),
+        ...(typeof attachment.artifactId === "string" ? { artifactId: attachment.artifactId } : {}),
+        ...(attachment.playback === "native" || attachment.playback === "transcode"
+          ? { playback: attachment.playback }
+          : {}),
+        ...(typeof attachment.sizeBytes === "number" && attachment.sizeBytes >= 0
+          ? { sizeBytes: attachment.sizeBytes }
+          : {}),
+        ...(typeof attachment.durationMs === "number" && attachment.durationMs >= 0
+          ? { durationMs: attachment.durationMs }
+          : {}),
+        ...(typeof attachment.width === "number" && attachment.width > 0
+          ? { width: attachment.width }
+          : {}),
+        ...(typeof attachment.height === "number" && attachment.height > 0
+          ? { height: attachment.height }
+          : {}),
+      },
+    },
+  ];
+}

--- a/ui/src/lib/chat/message-normalizer.test.ts
+++ b/ui/src/lib/chat/message-normalizer.test.ts
@@ -827,6 +827,71 @@ describe("message-normalizer", () => {
       ]);
     });
 
+    it("preserves named attachment failures beside successful attachments", () => {
+      const result = normalizeMessage({
+        role: "assistant",
+        content: [
+          {
+            type: "attachment",
+            attachment: {
+              url: "https://files.example/deploy.yaml",
+              kind: "document",
+              label: "deploy.yaml",
+              mimeType: "application/yaml",
+            },
+          },
+          {
+            type: "attachment_error",
+            attachment: {
+              code: "unsupported-format",
+              kind: "document",
+              label: "settings.toml",
+              mimeType: "application/toml",
+            },
+          },
+          {
+            type: "attachment_error",
+            attachment: {
+              code: "delivery-failed",
+              kind: "document",
+              label: "bundle.7z",
+              mimeType: "application/x-7z-compressed",
+            },
+          },
+        ],
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "attachment",
+          attachment: {
+            url: "https://files.example/deploy.yaml",
+            kind: "document",
+            label: "deploy.yaml",
+            mimeType: "application/yaml",
+          },
+        },
+        {
+          type: "attachment_error",
+          attachment: {
+            code: "unsupported-format",
+            kind: "document",
+            label: "settings.toml",
+            mimeType: "application/toml",
+          },
+        },
+        {
+          type: "attachment_error",
+          attachment: {
+            code: "delivery-failed",
+            kind: "document",
+            label: "bundle.7z",
+            mimeType: "application/x-7z-compressed",
+          },
+        },
+      ]);
+    });
+
     it("detects tool result by toolCallId", () => {
       const result = normalizeMessage({
         role: "assistant",

--- a/ui/src/lib/chat/message-normalizer.ts
+++ b/ui/src/lib/chat/message-normalizer.ts
@@ -17,6 +17,7 @@ import {
 import { splitMediaFromOutput } from "../../../../src/media/parse.js";
 import { getMediaFileExtension } from "../media-file-extension.ts";
 import type { NormalizedMessage, MessageContentItem } from "./chat-types.ts";
+import { normalizeAttachmentContentBlock } from "./message-normalizer-attachments.ts";
 import { formatSenderLabel, normalizeSenderIdentity } from "./sender-label.ts";
 
 // Older gateways baked sender labels as "name (<profile uuid>)" into transcript
@@ -53,6 +54,8 @@ const rawCanvasPreviewSchema = z
   .catch(undefined);
 const rawAttachmentSchema = z
   .looseObject({
+    code: optionalMessageStringSchema,
+    kind: optionalMessageStringSchema,
     url: optionalMessageStringSchema,
     label: optionalMessageStringSchema,
     mimeType: optionalMessageStringSchema,
@@ -595,46 +598,9 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
       } else if (item.type === "audio") {
         return [];
       }
-      if (item.type === "attachment" && item.attachment) {
-        const attachment = item.attachment;
-        if (
-          attachment.url === undefined ||
-          (attachment.kind !== "image" &&
-            attachment.kind !== "audio" &&
-            attachment.kind !== "video" &&
-            attachment.kind !== "document") ||
-          attachment.label === undefined
-        ) {
-          return [];
-        }
-        return [
-          {
-            type: "attachment" as const,
-            attachment: {
-              url: attachment.url,
-              kind: attachment.kind,
-              label: attachment.label,
-              ...(attachment.mimeType !== undefined ? { mimeType: attachment.mimeType } : {}),
-              ...(attachment.isVoiceNote === true ? { isVoiceNote: true } : {}),
-              ...(attachment.artifactId !== undefined ? { artifactId: attachment.artifactId } : {}),
-              ...(attachment.playback === "native" || attachment.playback === "transcode"
-                ? { playback: attachment.playback }
-                : {}),
-              ...(attachment.sizeBytes !== undefined && attachment.sizeBytes >= 0
-                ? { sizeBytes: attachment.sizeBytes }
-                : {}),
-              ...(attachment.durationMs !== undefined && attachment.durationMs >= 0
-                ? { durationMs: attachment.durationMs }
-                : {}),
-              ...(attachment.width !== undefined && attachment.width > 0
-                ? { width: attachment.width }
-                : {}),
-              ...(attachment.height !== undefined && attachment.height > 0
-                ? { height: attachment.height }
-                : {}),
-            },
-          },
-        ];
+      const attachmentContent = normalizeAttachmentContentBlock(item);
+      if (attachmentContent) {
+        return attachmentContent;
       }
       if (item.type === "canvas" && item.preview) {
         const preview = coerceCanvasPreview(item.preview);

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -54,6 +54,7 @@ const SHARED_APP_CONTEXT_TEXT = "Context hover regression fixture.";
 const SHARED_APP_SLASH_TEXT = "Short landscape slash command keyboard regression fixture.";
 const SHARED_APP_IMAGE_URL = "https://cdn.example/render%2Epng?download=1";
 const SHARED_APP_VIDEO_URL = "https://cdn.example/clip%252Emp4?download=1";
+const SHARED_APP_ATTACHMENT_OUTCOME_TEXT = "Mixed attachment outcome fixture.";
 
 function installResponsiveChatGateway(page: Page, scenario: ControlUiMockGatewayScenario = {}) {
   return installMockGateway(page, {
@@ -102,6 +103,41 @@ async function createSharedAppPage(): Promise<Page> {
           content: [{ text: SHARED_APP_SLASH_TEXT, type: "text" }],
           role: "assistant",
           timestamp: Date.UTC(2026, 6, 9, 10, 2),
+        },
+        {
+          content: [
+            { text: SHARED_APP_ATTACHMENT_OUTCOME_TEXT, type: "text" },
+            {
+              type: "attachment",
+              attachment: {
+                url: "https://files.example/deploy.yaml",
+                kind: "document",
+                label: "deploy.yaml",
+                mimeType: "application/yaml",
+              },
+            },
+            ...["settings.toml", "schema.sql", "events.ndjson", "font.ttf", "font.woff2"].map(
+              (label) => ({
+                type: "attachment_error",
+                attachment: {
+                  code: "unsupported-format",
+                  kind: "document",
+                  label,
+                },
+              }),
+            ),
+            {
+              type: "attachment_error",
+              attachment: {
+                code: "delivery-failed",
+                kind: "document",
+                label: "bundle.7z",
+                mimeType: "application/x-7z-compressed",
+              },
+            },
+          ],
+          role: "assistant",
+          timestamp: Date.UTC(2026, 6, 9, 10, 3),
         },
       ],
     });
@@ -2542,6 +2578,115 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         (await videoCard.locator(".chat-assistant-attachment-card__title").textContent())?.trim(),
       ).toBe("clip%2Emp4");
       expect(await videoCard.locator("video").count()).toBe(0);
+    },
+  );
+
+  it(
+    "renders one named card for every success and failure in a mixed attachment batch",
+    FULL_APP_TEST_OPTIONS,
+    async () => {
+      const page = await getSharedAppPage();
+      const bubble = page
+        .locator(".chat-bubble")
+        .filter({ hasText: SHARED_APP_ATTACHMENT_OUTCOME_TEXT });
+      const cards = bubble.locator(".chat-assistant-attachment-card");
+      await expect.poll(() => cards.count()).toBe(7);
+      expect(
+        await cards.locator(".chat-assistant-attachment-card__title").allTextContents(),
+      ).toEqual([
+        "deploy.yaml",
+        "settings.toml",
+        "schema.sql",
+        "events.ndjson",
+        "font.ttf",
+        "font.woff2",
+        "bundle.7z",
+      ]);
+      expect(await bubble.locator(".chat-assistant-attachment-card--compact").count()).toBe(1);
+      expect(await bubble.locator(".chat-assistant-attachment-card--definitive").count()).toBe(6);
+      expect(
+        await bubble
+          .getByText(
+            "Not sent · Rejected by the local attachment allowlist. Send a supported file type.",
+          )
+          .count(),
+      ).toBe(5);
+      expect(
+        await bubble.getByText("Not sent · Delivery failed. Try sending this file again.").count(),
+      ).toBe(1);
+      expect(await bubble.getByText("Media failed").count()).toBe(0);
+
+      try {
+        const desktopStatusSpacing = await cards
+          .filter({ hasText: "settings.toml" })
+          .evaluate((card) => {
+            const badge = card.querySelector<HTMLElement>(
+              ".chat-assistant-attachment-card__status-badge",
+            )!;
+            const reason = card.querySelector<HTMLElement>(
+              ".chat-assistant-attachment-card__status-reason",
+            )!;
+            const separator = card.querySelector<HTMLElement>(
+              ".chat-assistant-attachment-card__status-separator",
+            )!;
+            const badgeRect = badge.getBoundingClientRect();
+            const reasonRect = reason.getBoundingClientRect();
+            const separatorRect = separator.getBoundingClientRect();
+            return {
+              leftGap: separatorRect.left - badgeRect.right,
+              rightGap: reasonRect.left - separatorRect.right,
+            };
+          });
+        expect(desktopStatusSpacing.leftGap).toBeGreaterThan(4);
+        expect(desktopStatusSpacing.rightGap).toBeGreaterThan(4);
+        expect(Math.abs(desktopStatusSpacing.leftGap - desktopStatusSpacing.rightGap)).toBeLessThan(
+          0.25,
+        );
+
+        for (const width of [320, 560]) {
+          await page.setViewportSize({ width, height: 852 });
+          const failedCard = cards.filter({ hasText: "settings.toml" });
+          const mobileStatusLayout = await failedCard.evaluate((card) => {
+            const badge = card.querySelector<HTMLElement>(
+              ".chat-assistant-attachment-card__status-badge",
+            )!;
+            const reason = card.querySelector<HTMLElement>(
+              ".chat-assistant-attachment-card__status-reason",
+            )!;
+            const separator = card.querySelector<HTMLElement>(
+              ".chat-assistant-attachment-card__status-separator",
+            )!;
+            const cardRect = card.getBoundingClientRect();
+            const reasonRect = reason.getBoundingClientRect();
+            return {
+              badgeBottom: badge.getBoundingClientRect().bottom,
+              cardBottom: cardRect.bottom,
+              cardClientWidth: card.clientWidth,
+              cardScrollWidth: card.scrollWidth,
+              reasonBottom: reasonRect.bottom,
+              reasonRight: reasonRect.right,
+              reasonTop: reasonRect.top,
+              separatorDisplay: getComputedStyle(separator).display,
+              reasonWhiteSpace: getComputedStyle(reason).whiteSpace,
+            };
+          });
+          expect(mobileStatusLayout.separatorDisplay).toBe("none");
+          expect(mobileStatusLayout.reasonWhiteSpace).toBe("normal");
+          expect(mobileStatusLayout.reasonTop).toBeGreaterThanOrEqual(
+            mobileStatusLayout.badgeBottom,
+          );
+          expect(mobileStatusLayout.reasonBottom).toBeLessThanOrEqual(
+            mobileStatusLayout.cardBottom,
+          );
+          expect(mobileStatusLayout.reasonRight).toBeLessThanOrEqual(width);
+          expect(mobileStatusLayout.cardScrollWidth).toBeLessThanOrEqual(
+            mobileStatusLayout.cardClientWidth,
+          );
+          await expectNoHorizontalOverflow(page);
+        }
+      } finally {
+        await page.setViewportSize({ width: 1366, height: 900 });
+      }
     },
   );
 

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -1658,6 +1658,60 @@ describe("chat transcript rendering", () => {
     );
   });
 
+  it("announces named attachment failures in attachment-only and mixed assistant rows", () => {
+    const transcript = createTestTranscript();
+    const container = document.createElement("div");
+    const existing = {
+      testVirtualRow: true,
+      testVirtualKey: "assistant-existing",
+      testVirtualRole: "assistant",
+      role: "assistant",
+      content: "Existing answer",
+    };
+    const renderMessages = (messages: unknown[]) =>
+      renderChatInto(container, { transcript, messages });
+
+    renderMessages([existing]);
+    const attachmentOnly = {
+      testVirtualRow: true,
+      testVirtualKey: "assistant-missing-attachment",
+      testVirtualRole: "assistant",
+      role: "assistant",
+      content: [
+        {
+          type: "attachment_error",
+          attachment: { code: "file-not-found", kind: "document", label: "missing.pdf" },
+        },
+      ],
+    };
+    renderMessages([existing, attachmentOnly]);
+    expect(container.querySelector(".chat-transcript-announcement")?.textContent).toBe(
+      "missing.pdf: Not sent. File not found. Check the path and try again.",
+    );
+
+    const mixed = {
+      testVirtualRow: true,
+      testVirtualKey: "assistant-mixed-attachments",
+      testVirtualRole: "assistant",
+      role: "assistant",
+      content: [
+        { type: "text", text: "Partial result" },
+        {
+          type: "attachment_error",
+          attachment: {
+            code: "unsupported-format",
+            kind: "document",
+            label: "settings.toml",
+          },
+        },
+      ],
+    };
+    renderMessages([existing, attachmentOnly, mixed]);
+    expect(container.querySelector(".chat-transcript-announcement")?.textContent).toBe(
+      "Partial result settings.toml: Not sent. Rejected by the local attachment allowlist. Send a supported file type.",
+    );
+  });
+
   it("announces a run preamble and its later terminal answer separately", () => {
     const transcript = createTestTranscript();
     const container = document.createElement("div");

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -1658,7 +1658,7 @@ describe("chat transcript rendering", () => {
     );
   });
 
-  it("announces named attachment failures in attachment-only and mixed assistant rows", () => {
+  it("announces named attachment failures in ordinary and completed-run assistant rows", () => {
     const transcript = createTestTranscript();
     const container = document.createElement("div");
     const existing = {
@@ -1709,6 +1709,56 @@ describe("chat transcript rendering", () => {
     renderMessages([existing, attachmentOnly, mixed]);
     expect(container.querySelector(".chat-transcript-announcement")?.textContent).toBe(
       "Partial result settings.toml: Not sent. Rejected by the local attachment allowlist. Send a supported file type.",
+    );
+
+    const runBoundary = {
+      kind: "group" as const,
+      key: "group:user:attachment-run",
+      role: "user" as const,
+      messages: [
+        {
+          key: "user:attachment-run",
+          message: {
+            role: "user",
+            content: "Send the attachment",
+            __openclaw: {
+              id: "user:attachment-run",
+              idempotencyKey: "attachment-run:user",
+            },
+          },
+        },
+      ],
+      timestamp: 1,
+      isStreaming: false,
+    };
+    const completedFailure = {
+      kind: "group" as const,
+      key: "group:assistant:attachment-run",
+      role: "assistant" as const,
+      messages: [
+        {
+          key: "assistant:attachment-run",
+          message: {
+            role: "assistant",
+            content: attachmentOnly.content,
+            runId: "attachment-run",
+          },
+        },
+      ],
+      timestamp: 2,
+      isStreaming: false,
+      runId: "attachment-run",
+    };
+    vi.mocked(chatThread.buildCachedChatItems).mockReturnValue([
+      runBoundary,
+      completedFailure,
+    ] as ReturnType<typeof chatThread.buildCachedChatItems>);
+    renderChatInto(container, {
+      transcript,
+      messages: [runBoundary, completedFailure],
+    });
+    expect(container.querySelector(".chat-transcript-announcement")?.textContent).toBe(
+      "missing.pdf: Not sent. File not found. Check the path and try again.",
     );
   });
 

--- a/ui/src/pages/chat/components/chat-message-attachment-status.ts
+++ b/ui/src/pages/chat/components/chat-message-attachment-status.ts
@@ -4,6 +4,16 @@ import { t } from "../../../i18n/index.ts";
 import { renderAttachmentCardIcon } from "./chat-attachment-card.ts";
 import type { AttachmentItem } from "./chat-message-media.ts";
 
+type AttachmentFailureCode = "file-not-found" | "unsupported-format" | "delivery-failed";
+
+export function attachmentFailureReason(code: AttachmentFailureCode): string {
+  return code === "file-not-found"
+    ? t("chat.attachments.failureFileNotFound")
+    : code === "unsupported-format"
+      ? t("chat.attachments.failureUnsupportedFormat")
+      : t("chat.attachments.failureDeliveryFailed");
+}
+
 export function renderAssistantAttachmentStatusCard(params: {
   kind: AttachmentItem["attachment"]["kind"];
   label: string;
@@ -41,8 +51,21 @@ export function renderAssistantAttachmentStatusCard(params: {
             >
             <span
               class="chat-assistant-attachment-card__meta chat-assistant-attachment-card__status-meta"
-              >${params.badge}${params.reason ? ` · ${params.reason}` : ""}</span
             >
+              <span class="chat-assistant-attachment-card__status-badge">${params.badge}</span>
+              ${params.reason
+                ? html`
+                    <span
+                      class="chat-assistant-attachment-card__status-separator"
+                      aria-hidden="true"
+                      >·</span
+                    >
+                    <span class="chat-assistant-attachment-card__status-reason"
+                      >${params.reason}</span
+                    >
+                  `
+                : nothing}
+            </span>
           </span>
         </div>
         ${params.onRetry

--- a/ui/src/pages/chat/components/chat-message-attachments.test.ts
+++ b/ui/src/pages/chat/components/chat-message-attachments.test.ts
@@ -795,6 +795,52 @@ describe("attachment sidebar source ownership", () => {
     container.remove();
   });
 
+  it("renders named attachment failures with separable status and reason text", () => {
+    const container = document.body.appendChild(document.createElement("div"));
+    render(
+      renderAssistantAttachments(
+        [
+          {
+            type: "attachment_error",
+            attachment: {
+              code: "unsupported-format",
+              kind: "document",
+              label: "settings.toml",
+            },
+          },
+        ],
+        {},
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".chat-assistant-attachment-card__title")?.textContent).toBe(
+      "settings.toml",
+    );
+    expect(container.querySelectorAll(".chat-assistant-attachment-card")).toHaveLength(1);
+    expect(container.querySelector(".chat-assistant-attachment-card--definitive")).not.toBeNull();
+    expect(
+      container.querySelector(".chat-assistant-attachment-card__status-badge")?.textContent,
+    ).toBe("Not sent");
+    expect(
+      container.querySelector(".chat-assistant-attachment-card__status-separator")?.textContent,
+    ).toBe("·");
+    expect(
+      container
+        .querySelector(".chat-assistant-attachment-card__status-separator")
+        ?.getAttribute("aria-hidden"),
+    ).toBe("true");
+    expect(
+      container.querySelector(".chat-assistant-attachment-card__status-reason")?.textContent,
+    ).toBe("Rejected by the local attachment allowlist. Send a supported file type.");
+    expect(
+      container.querySelector(
+        ".chat-assistant-attachment-card__download, .chat-assistant-attachment-card__expand, .chat-assistant-attachment-card__retry",
+      ),
+    ).toBeNull();
+    container.remove();
+  });
+
   it("keeps normalized base64 audio compact with download and Files actions", () => {
     const container = document.body.appendChild(document.createElement("div"));
     const onOpenSidebar = vi.fn();

--- a/ui/src/pages/chat/components/chat-message-attachments.ts
+++ b/ui/src/pages/chat/components/chat-message-attachments.ts
@@ -16,7 +16,10 @@ import {
   selectLaterExpiringManagedAttachment,
   type ManagedAttachmentAvailability,
 } from "./chat-message-attachment-availability.ts";
-import { renderAssistantAttachmentStatusCard } from "./chat-message-attachment-status.ts";
+import {
+  attachmentFailureReason,
+  renderAssistantAttachmentStatusCard,
+} from "./chat-message-attachment-status.ts";
 import { openResolvedImage } from "./chat-message-image-open.ts";
 import {
   buildAssistantAttachmentUrl,
@@ -30,6 +33,7 @@ import {
   observeChatMediaResource,
   scheduleChatMediaResourceRefresh,
   type AttachmentItem,
+  type AssistantAttachmentItem,
   type ArtifactDownloadResolver,
   type ChatMediaResource,
   type ImageRenderOptions,
@@ -353,7 +357,7 @@ function retryManagedAttachmentAvailability(
 }
 
 export function renderAssistantAttachments(
-  attachments: AttachmentItem[],
+  attachments: AssistantAttachmentItem[],
   options: ImageRenderOptions,
   onOpenSidebar?: (content: SidebarContent) => void,
   onAssistantAttachmentLoaded?: () => void,
@@ -371,7 +375,18 @@ export function renderAssistantAttachments(
     onOpenImage,
     resolveArtifactDownload,
   } = options;
-  const renderAttachment = ({ attachment }: AttachmentItem) => {
+  const renderAttachment = (item: AssistantAttachmentItem) => {
+    if (item.type === "attachment_error") {
+      const { attachment } = item;
+      return renderAssistantAttachmentStatusCard({
+        kind: attachment.kind,
+        label: attachment.label,
+        mimeType: attachment.mimeType,
+        badge: t("chat.attachments.notSent"),
+        reason: attachmentFailureReason(attachment.code),
+      });
+    }
+    const { attachment } = item;
     const localSource = isLocalAssistantAttachmentSource(attachment.url);
     const assistantAvailability = resolveAssistantAttachmentAvailability(
       attachment.url,

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -50,7 +50,7 @@ import {
   extractStructuredSvgAttachments,
   extractTranscriptAttachments,
   schedulePairingQrExpiryRefresh,
-  type AttachmentItem,
+  type AssistantAttachmentItem,
   type ArtifactDownloadResolver,
   type PairingQrExpiryNotice,
 } from "./chat-message-media.ts";
@@ -283,14 +283,19 @@ export function renderGroupedMessage(
   const displayMarkdown = resolveMessageDisplayMarkdown(message, normalizedMessage);
   const actionText = opts.actionMarkdown ?? displayMarkdown;
   const assistantAttachments = normalizedMessage.content.filter(
-    (item): item is AttachmentItem => item.type === "attachment",
+    (item): item is AssistantAttachmentItem =>
+      item.type === "attachment" || item.type === "attachment_error",
   );
   const attachmentUrls = new Set<string>();
   const visibleAttachments = [
     ...assistantAttachments,
     ...extractStructuredSvgAttachments(message),
     ...extractTranscriptAttachments(message),
-  ].filter(({ attachment }) => {
+  ].filter((item) => {
+    if (item.type === "attachment_error") {
+      return true;
+    }
+    const { attachment } = item;
     if (attachmentUrls.has(attachment.url)) {
       return false;
     }

--- a/ui/src/pages/chat/components/chat-message-media.ts
+++ b/ui/src/pages/chat/components/chat-message-media.ts
@@ -47,6 +47,8 @@ export type RenderableImageBlock = ImageBlock & {
 };
 
 export type AttachmentItem = Extract<MessageContentItem, { type: "attachment" }>;
+type AttachmentFailureItem = Extract<MessageContentItem, { type: "attachment_error" }>;
+export type AssistantAttachmentItem = AttachmentItem | AttachmentFailureItem;
 
 type ChatMediaResourceKind =
   | "assistant-attachment"

--- a/ui/src/pages/chat/components/chat-transcript-announcement.ts
+++ b/ui/src/pages/chat/components/chat-transcript-announcement.ts
@@ -1,7 +1,11 @@
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { t } from "../../../i18n/index.ts";
 import type { MessageGroup } from "../../../lib/chat/chat-types.ts";
 import { extractTextCached } from "../../../lib/chat/message-extract.ts";
+import { normalizeAttachmentContentBlock } from "../../../lib/chat/message-normalizer-attachments.ts";
 import type { coalesceAgentRunFrames } from "../chat-agent-run-grouping.ts";
+import { attachmentFailureReason } from "./chat-message-attachment-status.ts";
 
 export type TranscriptAnnouncement = {
   key: string;
@@ -11,6 +15,24 @@ export type TranscriptAnnouncement = {
 type ChatRenderItem = ReturnType<typeof coalesceAgentRunFrames>[number];
 const ANNOUNCEMENT_MAX_CHARS = 500;
 
+function assistantMessageAnnouncementText(message: unknown): string | null {
+  const text = extractTextCached(message)?.trim();
+  const rawContent = asOptionalRecord(message)?.content;
+  const content: unknown[] = Array.isArray(rawContent) ? rawContent : [];
+  const failures = content.flatMap((item) =>
+    (normalizeAttachmentContentBlock(item) ?? []).filter(
+      (block) => block.type === "attachment_error",
+    ),
+  );
+  const failureText = failures
+    .map(
+      ({ attachment }) =>
+        `${attachment.label}: ${t("chat.attachments.notSent")}. ${attachmentFailureReason(attachment.code)}`,
+    )
+    .join(" ");
+  return [text, failureText].filter(Boolean).join(" ") || null;
+}
+
 function assistantGroupAnnouncementSource(
   group: MessageGroup,
 ): { key: string; text: string } | null {
@@ -19,7 +41,7 @@ function assistantGroupAnnouncementSource(
   }
   for (let index = group.messages.length - 1; index >= 0; index -= 1) {
     const source = group.messages[index];
-    const text = extractTextCached(source?.message)?.trim();
+    const text = assistantMessageAnnouncementText(source?.message);
     if (text) {
       return { key: source?.key ?? group.key, text };
     }

--- a/ui/src/pages/chat/components/chat-transcript-announcement.ts
+++ b/ui/src/pages/chat/components/chat-transcript-announcement.ts
@@ -15,8 +15,7 @@ export type TranscriptAnnouncement = {
 type ChatRenderItem = ReturnType<typeof coalesceAgentRunFrames>[number];
 const ANNOUNCEMENT_MAX_CHARS = 500;
 
-function assistantMessageAnnouncementText(message: unknown): string | null {
-  const text = extractTextCached(message)?.trim();
+function assistantMessageAttachmentFailureText(message: unknown): string | null {
   const rawContent = asOptionalRecord(message)?.content;
   const content: unknown[] = Array.isArray(rawContent) ? rawContent : [];
   const failures = content.flatMap((item) =>
@@ -30,18 +29,25 @@ function assistantMessageAnnouncementText(message: unknown): string | null {
         `${attachment.label}: ${t("chat.attachments.notSent")}. ${attachmentFailureReason(attachment.code)}`,
     )
     .join(" ");
+  return failureText || null;
+}
+
+function assistantMessageAnnouncementText(message: unknown): string | null {
+  const text = extractTextCached(message)?.trim();
+  const failureText = assistantMessageAttachmentFailureText(message);
   return [text, failureText].filter(Boolean).join(" ") || null;
 }
 
 function assistantGroupAnnouncementSource(
   group: MessageGroup,
+  messageText: (message: unknown) => string | null = assistantMessageAnnouncementText,
 ): { key: string; text: string } | null {
   if (group.role.toLowerCase() !== "assistant") {
     return null;
   }
   for (let index = group.messages.length - 1; index >= 0; index -= 1) {
     const source = group.messages[index];
-    const text = assistantMessageAnnouncementText(source?.message);
+    const text = messageText(source?.message);
     if (text) {
       return { key: source?.key ?? group.key, text };
     }
@@ -64,9 +70,24 @@ export function latestTranscriptAnnouncement(
     if (item.kind === "agent-run-frame") {
       if (item.outcome.kind === "completed") {
         const owner = item.outcome.actionOwner;
-        const text = owner ? extractTextCached(owner.message)?.trim() : null;
+        const text = owner ? assistantMessageAnnouncementText(owner.message) : null;
         if (owner && text) {
           return announcement(owner.key, text);
+        }
+        for (const part of item.parts.toReversed()) {
+          if (part.kind === "stream-run") {
+            continue;
+          }
+          const groups = part.kind === "group" ? [part] : part.groups.toReversed();
+          for (const group of groups) {
+            const source = assistantGroupAnnouncementSource(
+              group,
+              assistantMessageAttachmentFailureText,
+            );
+            if (source) {
+              return announcement(source.key, source.text);
+            }
+          }
         }
         continue;
       }

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1442,6 +1442,45 @@ openclaw-chat-video-player {
   white-space: nowrap;
 }
 
+.chat-assistant-attachment-card__status-meta {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.5em;
+  min-width: 0;
+}
+
+.chat-assistant-attachment-card__status-badge,
+.chat-assistant-attachment-card__status-separator {
+  flex: none;
+}
+
+.chat-assistant-attachment-card__status-reason {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 560px) {
+  .chat-assistant-attachment-card--blocked .chat-assistant-attachment-card__status-meta {
+    display: grid;
+    gap: 2px;
+    overflow: visible;
+    text-overflow: clip;
+    white-space: normal;
+  }
+
+  .chat-assistant-attachment-card--blocked .chat-assistant-attachment-card__status-separator {
+    display: none;
+  }
+
+  .chat-assistant-attachment-card--blocked .chat-assistant-attachment-card__status-reason {
+    overflow: visible;
+    text-overflow: clip;
+    white-space: normal;
+  }
+}
+
 .chat-assistant-attachment-card__actions {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
Closes #131820

Follow-up to #130402.

## What Problem This Solves

WebChat could turn a missing attachment or a partially rejected batch into anonymous media warnings. Failed files disappeared from the assistant message, so operators could not tell which attachment failed or why.

## What Changes

- Records a typed, producer-owned outcome for every failed attachment and carries it through reply normalization, managed delivery, transcript persistence, and WebChat rendering.
- Keeps missing files, local allowlist rejections, and delivery failures distinct while successful files continue through the existing attachment flow.
- Renders each failure as a named status card and includes the same structured reason in polite transcript announcements, including completed attachment-only runs.
- Keeps non-WebChat delivery readable with one named text receipt per failed file.
- Prevents duplicate runtime-owned text rows when an unkeyed media attempt leaves only failure outcomes.

No configuration, protocol version, persistence schema, or dependency surface changes.

Production delta: +464/-141 (net +323). Test delta: +766/-129 (net +637). The production growth establishes one canonical typed outcome across the producer, gateway, transcript, and UI boundaries; it does not add a parallel fallback path. The detailed internal classification preserves the established Plugin SDK error code.

## User Impact

Every attempted attachment now has a visible, named result. Accepted files render normally. Failed files show the actual cause and a short next step, mixed batches cannot hide rejected siblings, narrow screens retain the full reason, and screen-reader users receive the same completed-run failure outcome.

## Evidence

### Before

A missing path is reported as an unrelated size or format problem:

![Before: missing path receives a generic warning](https://github.com/user-attachments/assets/4cff2810-95b8-48a1-a5be-b3bc73f50a98)

Distinct failures in a mixed batch collapse into anonymous warnings:

![Before: mixed attachment failures lose filenames and causes](https://github.com/user-attachments/assets/a6758bf3-559e-4ef0-9ae9-36db7002ca36)

### After

Desktop: one named missing-file card, one successful YAML card, five named allowlist-rejection cards, and one named delivery-failure card. Status punctuation uses symmetric spacing.

![After on desktop: every attachment has a named success or failure card](https://github.com/user-attachments/assets/4e18b6c6-893f-4d98-a664-c4556c916a20)

Mobile at 393x852: `Not sent` occupies the status line and the full reason wraps below without ellipsis.

![After on mobile: attachment failure reason wraps below Not sent](https://github.com/user-attachments/assets/8c7cee3d-ac04-4976-8674-4ebccf208139)

### Validation

- [Exact-head GitHub CI](https://github.com/openclaw/openclaw/actions/runs/33202454338) passed for `5221fd9537b4d6eb10ac6b593913cef378936414`.
- Producer coverage for missing paths, mixed surviving media, per-file failure metadata, and local allowlist classification.
- Gateway coverage for mixed successful and failed managed attachments, structured transcript replacement, failure-only replies, and runtime-owned transcript deduplication.
- Signal and iMessage coverage preserving the established public media error-code contract.
- Control UI coverage for named success and error cards, desktop and mobile layout, ordinary announcements, and attachment-only completed-run announcements.
- Mock-gateway coverage for a missing path and a mixed YAML/TOML/SQL/NDJSON/TTF/WOFF2/7Z batch, with one visible outcome per requested file.
