### PR TITLE
fix(agents): retain actionable text in bounded tool results

### DIFF
--- a/src/agents/embedded-agent-runner/tool-result-context-guard.image.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.image.test.ts
@@ -199,10 +199,13 @@ describe("native image tool result context projection", () => {
     },
   );
 
-  it("keeps a fitting image without letting oversized text starve a later text block", async () => {
+  it.each([
+    ["short", "retain the image description"],
+    ["2,000-character", "d".repeat(2_000)],
+  ])("keeps a fitting image without starving a later %s text block", async (_name, description) => {
     const native = await executeNativeImageTool(2);
     const nativeBlocks = blocksOf(native);
-    const trailingText = { type: "text", text: "retain the image description" };
+    const trailingText = { type: "text", text: description };
     const source = castAgentMessage({
       ...native,
       content: [

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
@@ -7,14 +7,21 @@ import { describe, expect, it, vi } from "vitest";
 import type { ContextEngine, ContextEngineRuntimeSettings } from "../../context-engine/types.js";
 import { sanitizeToolUseResultPairing } from "../session-transcript-repair.js";
 import { castAgentMessage } from "../test-helpers/agent-message-fixtures.js";
+import { resolveLiveToolResultMaxChars } from "../tool-result-limits.js";
 import { formatContextLimitTruncationNotice } from "./context-truncation-notice.js";
 import { MidTurnPrecheckSignal } from "./run/midturn-precheck.js";
+import {
+  createMessageCharEstimateCache,
+  estimateMessageCharsCached,
+  getToolResultText as getAllToolResultText,
+} from "./tool-result-char-estimator.js";
 import {
   installContextEngineLoopHook,
   installToolResultContextGuard,
   markTranscriptPromptText,
 } from "./tool-result-context-guard.js";
 import { estimateToolResultTextChars } from "./tool-result-text-budget.js";
+import { truncateToolResultMessage, truncateToolResultText } from "./tool-result-truncation.js";
 
 const CONTEXT_LIMIT_TRUNCATION_NOTICE = "more characters truncated";
 
@@ -189,6 +196,67 @@ describe("formatContextLimitTruncationNotice", () => {
 });
 
 describe("installToolResultContextGuard", () => {
+  it.each([
+    ["ASCII diagnostic tail", "progress output\n".repeat(400), false],
+    ["separate diagnostic block", "progress output\n".repeat(400), true],
+    ["non-keyword retry hint", "progress output\n".repeat(400), true],
+    ["CJK diagnostic tail", "進捗\n".repeat(1_000), false],
+    ["UTF-16 diagnostic tail", "😀 progress\n".repeat(600), false],
+  ] as const)(
+    "preserves actionable tool text within the existing cap: %s",
+    async (name, preamble, separate) => {
+      const expected =
+        name === "non-keyword retry hint"
+          ? "Inspect src/fixture.ts before retrying."
+          : "Error: missing import; inspect src/fixture.ts before retrying.";
+      const blocks = separate ? [preamble, expected] : [preamble + expected];
+      const source = castAgentMessage({
+        ...makeToolResult("call_actionable", ""),
+        content: blocks.map((text) => ({ type: "text", text })),
+      });
+      const original = structuredClone(source);
+      const contextWindowTokens = 8_192;
+      const sourceChars = blocks.reduce(
+        (total, text) => total + estimateToolResultTextChars(text),
+        0,
+      );
+      expect(sourceChars).toBeLessThanOrEqual(
+        resolveLiveToolResultMaxChars({ contextWindowTokens }),
+      );
+
+      // ASCII multi-block controls use half the guard's weighted budget. The
+      // shared message allocator does not apply the guard's raw-weight floor.
+      const sharedMessage = separate ? truncateToolResultMessage(source, 4_096) : undefined;
+      const sharedText = sharedMessage
+        ? getAllToolResultText(sharedMessage)
+        : truncateToolResultText(blocks[0]!, contextWindowTokens, {
+            minKeepChars: 0,
+            minimumRawWeight: 2,
+          });
+      expect(sharedText).toContain(expected);
+      const sharedChars = sharedMessage
+        ? estimateMessageCharsCached(sharedMessage, createMessageCharEstimateCache())
+        : estimateToolResultTextChars(sharedText, { minimumRawWeight: 2 });
+      expect(sharedChars).toBeLessThanOrEqual(contextWindowTokens);
+
+      const transformed = (await applyGuardToContext(
+        makeGuardableAgent(),
+        [source],
+        contextWindowTokens,
+      )) as AgentMessage[];
+      const projected = expectDefined(transformed[0], "projected tool result");
+      const projectedText = getAllToolResultText(projected);
+
+      expect(source).toEqual(original);
+      expect(Buffer.from(projectedText, "utf8").toString("utf8")).toBe(projectedText);
+      expect(
+        estimateMessageCharsCached(projected, createMessageCharEstimateCache()),
+      ).toBeLessThanOrEqual(contextWindowTokens);
+      expect(projectedText).toContain(CONTEXT_LIMIT_TRUNCATION_NOTICE);
+      expect(projectedText).toContain(expected);
+    },
+  );
+
   it("passes through unchanged context when under the per-tool and total budget", async () => {
     const agent = makeGuardableAgent();
     const contextForNextCall = [makeUser("hello"), makeToolResult("call_ok", "small output")];

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
@@ -319,12 +319,13 @@ describe("installToolResultContextGuard", () => {
       const original = structuredClone(content);
       const requests: Message[][] = [];
       const execute = vi.fn(async () => ({ content, details: { privateReference: "fixture" } }));
+      const contextWindowTokens = 8_192;
       const model = makeProviderModelFixture({
         id: "test-model",
         api: "openai-responses",
         provider: "openai",
         baseUrl: "https://example.test",
-        contextWindow: 8_192,
+        contextWindow: contextWindowTokens,
       });
       const agent = new Agent({
         initialState: {
@@ -363,7 +364,7 @@ describe("installToolResultContextGuard", () => {
       });
       const dispose = installToolResultContextGuard({
         agent,
-        contextWindowTokens: model.contextWindow,
+        contextWindowTokens,
       });
       try {
         await agent.prompt("Read the diagnostic and report its next step.");
@@ -389,7 +390,7 @@ describe("installToolResultContextGuard", () => {
       expect(projected).not.toHaveProperty("details");
       expect(
         estimateMessageCharsCached(projected, createMessageCharEstimateCache()),
-      ).toBeLessThanOrEqual(model.contextWindow);
+      ).toBeLessThanOrEqual(contextWindowTokens);
       expect(getAllToolResultText(projected)).toContain(CONTEXT_LIMIT_TRUNCATION_NOTICE);
       expect(getAllToolResultText(projected)).toContain(hint);
       expect(agent.state.messages.at(-1)).toMatchObject({

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
@@ -2,11 +2,18 @@
 // prechecks, and context-engine loop hooks for oversized tool outputs.
 
 import { expectDefined } from "@openclaw/normalization-core";
-import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
+import { Agent, type AgentMessage } from "openclaw/plugin-sdk/agent-core";
+import { createAssistantMessageEventStream, type Message } from "openclaw/plugin-sdk/llm";
+import { Type } from "typebox";
 import { describe, expect, it, vi } from "vitest";
 import type { ContextEngine, ContextEngineRuntimeSettings } from "../../context-engine/types.js";
 import { sanitizeToolUseResultPairing } from "../session-transcript-repair.js";
-import { castAgentMessage } from "../test-helpers/agent-message-fixtures.js";
+import { convertToLlm } from "../sessions/messages.js";
+import {
+  castAgentMessage,
+  makeAgentAssistantMessage,
+} from "../test-helpers/agent-message-fixtures.js";
+import { makeProviderModelFixture } from "../test-helpers/provider-model-fixture.js";
 import { resolveLiveToolResultMaxChars } from "../tool-result-limits.js";
 import { formatContextLimitTruncationNotice } from "./context-truncation-notice.js";
 import { MidTurnPrecheckSignal } from "./run/midturn-precheck.js";
@@ -265,6 +272,135 @@ describe("installToolResultContextGuard", () => {
 
     expect(transformed).toBe(contextForNextCall);
   });
+
+  it.each([64, 8_192])(
+    "reserves or omits %i characters of non-text content without exceeding the cap",
+    async (metadataChars) => {
+      const metadata = { type: "custom", value: "m".repeat(metadataChars) };
+      const hint = { type: "text", text: "Inspect src/fixture.ts before retrying." };
+      const source = castAgentMessage({
+        ...makeToolResult("call_blocks", ""),
+        content: [{ type: "text", text: "x".repeat(6_000) }, metadata, hint],
+        details: { privateReference: "not model context" },
+      });
+      const original = structuredClone(source);
+      const transformed = (await applyGuardToContext(
+        makeGuardableAgent(),
+        [source],
+        8_192,
+      )) as AgentMessage[];
+      const projected = expectDefined(transformed[0], "bounded mixed result");
+      expect(
+        estimateMessageCharsCached(projected, createMessageCharEstimateCache()),
+      ).toBeLessThanOrEqual(8_192);
+      expect(source).toEqual(original);
+      expect(projected).not.toHaveProperty("details");
+      expect(getAllToolResultText(projected)).toContain(CONTEXT_LIMIT_TRUNCATION_NOTICE);
+      expect(getAllToolResultText(projected)).toContain(hint.text);
+      const content = (projected as { content: unknown[] }).content;
+      if (metadataChars === 64) {
+        expect(content).toContain(metadata);
+        expect(content).toContainEqual(hint);
+      } else {
+        expect(content).not.toContain(metadata);
+      }
+    },
+  );
+
+  it.each([false, true])(
+    "delivers actionable tool text through the real agent loop (separate block: %s)",
+    async (separate) => {
+      const hint = "Inspect src/fixture.ts before retrying.";
+      const preamble = "progress output\n".repeat(400);
+      const sourceTexts = separate
+        ? [preamble, hint]
+        : [preamble + "Error: missing import; " + hint];
+      const content = sourceTexts.map((text) => ({ type: "text" as const, text }));
+      const original = structuredClone(content);
+      const requests: Message[][] = [];
+      const execute = vi.fn(async () => ({ content, details: { privateReference: "fixture" } }));
+      const model = makeProviderModelFixture({
+        id: "test-model",
+        api: "openai-responses",
+        provider: "openai",
+        baseUrl: "https://example.test",
+        contextWindow: 8_192,
+      });
+      const agent = new Agent({
+        initialState: {
+          model,
+          tools: [
+            {
+              name: "diagnostic",
+              label: "Diagnostic",
+              description: "Read diagnostic output",
+              parameters: Type.Object({}),
+              execute,
+            },
+          ],
+        },
+        convertToLlm,
+        streamFn: (_model, context) => {
+          requests.push(structuredClone(context.messages));
+          const result = context.messages.find((message) => message.role === "toolResult");
+          const hasHint = result && getAllToolResultText(result).includes(hint);
+          const message = makeAgentAssistantMessage({
+            content:
+              requests.length === 1
+                ? [{ type: "toolCall", id: "call_diagnostic", name: "diagnostic", arguments: {} }]
+                : [{ type: "text", text: hasHint ? hint : "The diagnostic hint was unavailable." }],
+            stopReason: requests.length === 1 ? "toolUse" : "stop",
+          });
+          const stream = createAssistantMessageEventStream();
+          stream.push({
+            type: "done",
+            reason: message.stopReason === "toolUse" ? "toolUse" : "stop",
+            message,
+          });
+          stream.end();
+          return stream;
+        },
+      });
+      const dispose = installToolResultContextGuard({
+        agent,
+        contextWindowTokens: model.contextWindow,
+      });
+      try {
+        await agent.prompt("Read the diagnostic and report its next step.");
+      } finally {
+        agent.abort();
+        await agent.waitForIdle();
+        dispose();
+      }
+
+      expect(execute).toHaveBeenCalledOnce();
+      expect(requests).toHaveLength(2);
+      expect(content).toEqual(original);
+      const stored = expectDefined(
+        agent.state.messages.find((message) => message.role === "toolResult"),
+        "raw agent tool result",
+      );
+      expect(stored.content).toEqual(original);
+      expect(stored).toHaveProperty("details.privateReference", "fixture");
+      const projected = expectDefined(
+        requests[1]?.find((message) => message.role === "toolResult"),
+        "provider-bound tool result",
+      );
+      expect(projected).not.toHaveProperty("details");
+      expect(
+        estimateMessageCharsCached(projected, createMessageCharEstimateCache()),
+      ).toBeLessThanOrEqual(model.contextWindow);
+      expect(getAllToolResultText(projected)).toContain(CONTEXT_LIMIT_TRUNCATION_NOTICE);
+      expect(getAllToolResultText(projected)).toContain(hint);
+      expect(agent.state.messages.at(-1)).toMatchObject({
+        role: "assistant",
+        content: [{ type: "text", text: hint }],
+        stopReason: "stop",
+      });
+      expect(agent.state.isStreaming).toBe(false);
+      expect(agent.state.errorMessage).toBeUndefined();
+    },
+  );
 
   it("does not preemptively overflow large non-tool context that is still under the high-water mark", async () => {
     const agent = makeGuardableAgent();

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.ts
@@ -195,6 +195,7 @@ function truncateToolResultToChars(
         { minimumRawWeight: TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE },
       );
       return replaceToolResultContent(msg, [
+        // SAFETY: Array input is preserved or mapped to another array by truncateToolResultMessage.
         ...(bounded as { content: unknown[] }).content,
         ...notice,
       ]);

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.ts
@@ -163,7 +163,6 @@ function truncateToolResultToChars(
   if (estimatedChars <= maxChars) {
     return msg;
   }
-  let rawText = getToolResultText(msg);
   const content = (msg as { content?: unknown }).content;
   if (Array.isArray(content)) {
     const isImage = (block: unknown) =>
@@ -174,88 +173,77 @@ function truncateToolResultToChars(
       (block as { type?: unknown }).type === "text" &&
       typeof (block as { text?: unknown }).text === "string";
     const imageCount = content.filter(isImage).length;
-    if (imageCount > 0) {
-      const omissionNotice = (retainedImages: number) => {
-        const omittedImages = imageCount - retainedImages;
-        return (
-          `[${omittedImages} image${omittedImages === 1 ? "" : "s"} omitted from context` +
-          `${retainedImages === 0 ? "; no images fit the context limit" : ""}; rerun with fewer images]`
-        );
-      };
+    const omissionNotice = (retainedImages: number) => {
+      const omittedImages = imageCount - retainedImages;
+      return (
+        `[${omittedImages} image${omittedImages === 1 ? "" : "s"} omitted from context` +
+        `${retainedImages === 0 ? "; no images fit the context limit" : ""}; rerun with fewer images]`
+      );
+    };
+    const projectContent = (retainedContent: unknown[], noticeText?: string) => {
+      const notice = noticeText ? [{ type: "text", text: noticeText }] : [];
+      const reservedChars = estimateMessageCharsCached(
+        replaceToolResultContent(msg, [
+          ...retainedContent.filter((block) => !isText(block)),
+          ...notice,
+        ]),
+        cache,
+      );
+      const bounded = truncateToolResultMessage(
+        replaceToolResultContent(msg, retainedContent),
+        Math.max(0, maxChars - reservedChars),
+        { minimumRawWeight: TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE },
+      );
+      return replaceToolResultContent(msg, [
+        ...(bounded as { content: unknown[] }).content,
+        ...notice,
+      ]);
+    };
 
-      // Reserve images first; shared multi-block truncation preserves later text
-      // while the existing weighted estimator enforces the unchanged hard cap.
-      for (let retainedImages = imageCount; retainedImages >= 0; retainedImages -= 1) {
-        let seenImages = 0;
-        const retainedContent = content.filter(
-          (block) => !isImage(block) || ++seenImages <= retainedImages,
-        );
-        const notice =
-          retainedImages < imageCount
-            ? [{ type: "text", text: omissionNotice(retainedImages) }]
-            : [];
-        const reservedChars = estimateMessageCharsCached(
-          replaceToolResultContent(msg, [
-            ...retainedContent.filter((block) => !isText(block)),
-            ...notice,
-          ]),
-          cache,
-        );
-        const availableTextChars = maxChars - reservedChars;
-        if (availableTextChars < 0 || (availableTextChars === 0 && retainedContent.some(isText))) {
-          continue;
-        }
-        let textBudget = availableTextChars;
-        while (true) {
-          const bounded = truncateToolResultMessage(
-            replaceToolResultContent(msg, retainedContent),
-            textBudget,
-          );
-          const projectedContent = (bounded as { content: unknown[] }).content;
-          if (
-            retainedContent.some((block, index) => {
-              const projectedBlock = projectedContent[index];
-              return (
-                isText(block) && block.text && (!isText(projectedBlock) || !projectedBlock.text)
-              );
-            })
-          ) {
-            break;
-          }
-          const projected = replaceToolResultContent(msg, [...projectedContent, ...notice]);
-          const projectedChars = estimateMessageCharsCached(projected, cache);
-          if (projectedChars <= maxChars) {
-            return projected;
-          }
-          const adjustedTextBudget = Math.floor(
-            (textBudget * availableTextChars) / (projectedChars - reservedChars),
-          );
-          if (adjustedTextBudget <= 0 || adjustedTextBudget >= textBudget) {
-            break;
-          }
-          textBudget = adjustedTextBudget;
-        }
+    // Reserve non-text content first. The shared allocator keeps diagnostic tails
+    // and short text blocks within the same weighted cap, with or without images.
+    for (let retainedImages = imageCount; retainedImages >= 0; retainedImages -= 1) {
+      let seenImages = 0;
+      const retainedContent = content.filter(
+        (block) => !isImage(block) || ++seenImages <= retainedImages,
+      );
+      const projected = projectContent(
+        retainedContent,
+        retainedImages < imageCount ? omissionNotice(retainedImages) : undefined,
+      );
+      const projectedContent = (projected as { content: unknown[] }).content;
+      if (
+        retainedContent.some((block, index) => {
+          const projectedBlock = projectedContent[index];
+          return isText(block) && block.text && (!isText(projectedBlock) || !projectedBlock.text);
+        })
+      ) {
+        continue;
       }
-      rawText = omissionNotice(0) + (rawText ? `\n\n${rawText}` : "");
+      if (estimateMessageCharsCached(projected, cache) <= maxChars) {
+        return projected;
+      }
     }
-  }
-
-  if (!rawText) {
-    const omittedChars = Math.max(
-      1,
-      estimateBudgetToRawChars(Math.max(estimatedChars - maxChars, 1)),
+    // Dropping unfit non-text content must not flatten away surviving semantic
+    // blocks. Reserve a visible notice even when only omission markers can fit.
+    const omittedChars = estimateMessageCharsCached(
+      replaceToolResultContent(
+        msg,
+        content.filter((block) => !isText(block)),
+      ),
+      cache,
     );
-    return replaceToolResultContent(msg, formatContextLimitTruncationNotice(omittedChars));
+    return projectContent(
+      content.filter(isText),
+      imageCount > 0
+        ? omissionNotice(0)
+        : formatContextLimitTruncationNotice(Math.max(1, estimateBudgetToRawChars(omittedChars))),
+    );
   }
 
-  if (maxChars <= 0) {
-    return replaceToolResultContent(msg, formatContextLimitTruncationNotice(rawText.length));
-  }
-
-  const truncatedText = truncateToolResultText(rawText, maxChars, {
+  const truncatedText = truncateToolResultText(getToolResultText(msg), maxChars, {
     minKeepChars: 0,
     minimumRawWeight: TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE,
-    preserveImportantTail: false,
   });
   return replaceToolResultContent(msg, truncatedText);
 }

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -248,7 +248,6 @@ type ToolResultTruncationOptions = {
   suffix?: string | ((truncatedChars: number) => string);
   minKeepChars?: number;
   minimumRawWeight?: number;
-  preserveImportantTail?: boolean;
 };
 
 const DEFAULT_SUFFIX = (truncatedChars: number) =>
@@ -380,11 +379,7 @@ export function truncateToolResultText(
     maxChars - estimateToolResultTextChars(defaultSuffix, budgetOptions),
   );
 
-  if (
-    options.preserveImportantTail !== false &&
-    hasImportantTail(text) &&
-    budget > minKeepChars * 2
-  ) {
+  if (hasImportantTail(text) && budget > minKeepChars * 2) {
     const tailBudget = Math.min(Math.floor(budget * 0.3), 4_000);
     const headBudget =
       budget - tailBudget - estimateToolResultTextChars(MIDDLE_OMISSION_MARKER, budgetOptions);
@@ -480,35 +475,45 @@ export function truncateToolResultMessage(
   options: ToolResultTruncationOptions = {},
 ): AgentMessage {
   const suffixFactory = resolveSuffixFactory(options.suffix);
+  const budgetOptions = { minimumRawWeight: options.minimumRawWeight };
   const minKeepChars = resolveEffectiveMinKeepChars({
     maxChars,
     minKeepChars: options.minKeepChars ?? MIN_KEEP_CHARS,
     suffixFactory,
+    minimumRawWeight: options.minimumRawWeight,
   });
   const content = (msg as { content?: unknown }).content;
   if (!Array.isArray(content)) {
     return msg;
   }
 
-  const totalTextChars = getToolResultTextBudget(msg);
+  const blockTextChars = content.map((block) =>
+    isToolResultTextBlock(block) ? estimateToolResultTextChars(block.text, budgetOptions) : 0,
+  );
+  const totalTextChars = blockTextChars.reduce((sum, chars) => sum + chars, 0);
   if (totalTextChars <= maxChars) {
     return msg;
   }
 
-  const blockTextChars = content.map((block) =>
-    isToolResultTextBlock(block) ? estimateToolResultTextChars(block.text) : 0,
+  // A caller's raw-text safety floor changes cost, not which semantic blocks
+  // are short. Reserve their actual weighted cost before shrinking larger text.
+  const smallBlocks = content.map(
+    (block, index) =>
+      (blockTextChars[index] ?? 0) > 0 &&
+      isToolResultTextBlock(block) &&
+      estimateToolResultTextChars(block.text) <= minKeepChars,
   );
   const blockNoticeChars = content.map((block, index) =>
     (blockTextChars[index] ?? 0) > 0 && isToolResultTextBlock(block)
-      ? estimateToolResultTextChars(suffixFactory(Math.max(1, block.text.length)))
+      ? estimateToolResultTextChars(suffixFactory(Math.max(1, block.text.length)), budgetOptions)
       : 0,
   );
   const smallBlockChars = blockTextChars.reduce(
-    (sum, chars) => sum + (chars > 0 && chars <= minKeepChars ? chars : 0),
+    (sum, chars, index) => sum + (smallBlocks[index] ? chars : 0),
     0,
   );
-  const largeBlockNoticeChars = blockTextChars.reduce(
-    (sum, chars, index) => sum + (chars > minKeepChars ? (blockNoticeChars[index] ?? 0) : 0),
+  const largeBlockNoticeChars = blockNoticeChars.reduce(
+    (sum, chars, index) => sum + (smallBlocks[index] ? 0 : chars),
     0,
   );
   // Preserve short semantic blocks when larger ones can retain a complete truncation notice.
@@ -529,7 +534,7 @@ export function truncateToolResultMessage(
     }
     const textBlock = block;
     const textChars = blockTextChars[index] ?? 0;
-    const preserveBlock = preserveSmallBlocks && textChars > 0 && textChars <= minKeepChars;
+    const preserveBlock = preserveSmallBlocks && smallBlocks[index];
     const blockShare = reducibleChars > 0 ? textChars / reducibleChars : 0;
     const noticeBudget = (blockNoticeChars[index] ?? 0) * noticeScale;
     const blockBudget = preserveBlock
@@ -539,6 +544,7 @@ export function truncateToolResultMessage(
     const truncatedText = truncateToolResultText(textBlock.text, blockBudget, {
       suffix: suffixFactory,
       minKeepChars: blockMinKeepChars,
+      minimumRawWeight: options.minimumRawWeight,
     });
     const nextBlock = Object.assign({}, textBlock, { text: truncatedText });
     if (typeof textBlock.content === "string") {


### PR DESCRIPTION
## What Problem This Solves

Related #131824. Retains actionable diagnostic tails and short later text blocks when oversized tool results are projected into the next model request. The existing capacity is unchanged; raw captured output is not rewritten.

The original guard had two projection policies. Image-bearing results used the shared bounded block allocator, while text-only results were flattened and explicitly opted out of diagnostic-tail selection. The latter could remove the information the model needed next even when it fit the existing limit.

## Why This Change Was Made

Text arrays and image-bearing results now use the same canonical block allocator, including the fallback that omits non-text content too large to fit. Existing weighted cost is carried consistently through allocation, while the established semantic small-block threshold remains separate from that cost. The flattened parallel path, proportional retry loop and sole tail-preservation opt-out are removed.

This repairs longstanding divergent behavior. Stable v2026.7.1-2 already had shared diagnostic-tail preservation alongside a prefix-only guard. #117149 carried that behavior forward, not a proven introduction. The newer multi-block allocator came from #114755; it is not claimed to be that same allocator in the stable tag.

## User Impact

The next model request can retain a fitting error or retry instruction without increasing context limits. Existing privacy/detail stripping, raw-result immutability, image ordering and bounded prefixes, UTF-16 handling and ordinary pass-through behavior remain covered. There are no new settings, dependencies, SDK/protocol changes or persistence semantics.

## Evidence

Before repair, [CI run 33188808868 / job 98909068896](https://github.com/openclaw/openclaw/actions/runs/33188808868/job/98909068896) executed exact merge `3062103eee28688e94d7619e1de5ee861799e4aa` of diagnostic `f65427029c72e99e6d65a26faba5287d473b1b01` into `fa68ddb2ec9e54c257ece2556c51c9c794f01851`. It reported **nine intended missing-text failures and 1,264 passing tests**, across 68 files. All nine image controls, including the added 2,000-character description, passed. The complete 796,736-byte log has SHA256 `a773bdd58a829a037220512e25374050961f332407d072dd47d4f8e94528e668`; independent review verified all failures and 31 exact executed source/venue identities.

After repair, [CI run 33195783997 / job 98933464357](https://github.com/openclaw/openclaw/actions/runs/33195783997/job/98933464357) executed merge `7a43b1c8795ab01342e32bd84ac6f80c652a33da` of `c71556cc1b301c10b33ef9226ccbbd274c07f467` into `267b0799b63c178e5be80122bb33d711f79e57e9`. All **1,273 tests across 68 files passed**, including the same nine regressions and all nine image controls. The same job also passed 16 overflow-compaction tests in two files. Its complete 505,781-byte log has SHA256 `288daecd8d7d572bbc62e155ed27f1771282107ff6cca324829b7a0f37d94f6f`. Thirty of the 31 named executed source/venue files match the repair commit exactly; the remaining prerequisite-table change only registers an unrelated Gateway test.

The cases cover ASCII, CJK, UTF-16, separate diagnostic/non-keyword text blocks, bounded/oversized non-text content, and two real Agent-loop cases. The latter execute a fixture tool through the production Agent, guard and canonical conversion, capture the second model request and inspect raw in-memory state. They use an injected model transport, not a live provider, Gateway, native tool implementation or persistent transcript. Passing complete cases now reaches the final-reply/idle/error and post-hint metadata assertions that were not reached on RED.

The earlier test-type error was corrected by carrying the same explicit 8,192 constant into fixture, guard and assertion; the repair commit's type and lint jobs passed. Its required [assertion-safety ratchet](https://github.com/openclaw/openclaw/actions/runs/33195783997/job/98933460996) did fail: one new array assertion lacked its invariant explanation. The follow-up adds only a brief comment documenting that the shared allocator preserves or maps the supplied array. It changes no executable code, type, test or baseline. The check is not weakened or bypassed.

Final head `3efc8cacaac55b90552f446dcb683013d4bbf03a` now passes [CI run 33198773591 / behavior job 98942972048](https://github.com/openclaw/openclaw/actions/runs/33198773591/job/98942972048), executed at exact merge `e4ee71fa1b7c0cd7df66b53f2328a3544038c6e4` into `9219c92065ede2aa4cf65e38c3e87df135fdda52`. The same nine regressions and all nine image controls pass: 1,273 tests in 68 files, plus the 16 overflow tests in two files. The complete 505,689-byte log has SHA256 `8c18f15f46bb665ecc32713beeb5ee4afa1ce3fd42ce37c050393c9b848f1644`. The [assertion-safety ratchet](https://github.com/openclaw/openclaw/actions/runs/33198773591/job/98942969046) also passes. The exact-head rollup is 190 successes, 55 skips, one neutral result and two routine dispatch/labeler cancellations, with no pending or failing checks; required `openclaw/ci-gate` is successful. Independent review bound the complete logs to 31 named executed source/venue files: 30 match the reviewed head, and the remaining prerequisite registration is the same unrelated Gateway-test entry previously examined.

No local product import, build, test or install ran under the campaign resource limit. The existing secretless hosted lane is used without new jobs, environment overrides or production test seams. Fresh structured review of the complete four-file candidate found no actionable P0–P2 issues; independent review verified the exact source, complete review inputs and final before/after evidence. Normal repository-native prepare/merge gates still apply.

The latest [ClawSweeper review](https://github.com/openclaw/openclaw/pull/131827#issuecomment-5453963666) reviewed this exact head at 18:26 UTC. Its requested exact-head checks and rank-up are now complete. Its current-main/release comparison gap was independently covered: direct comparison of the 31 named owners and venue files from the PR base to main `c8ddecdbfaae065fc0bce844d996b2a962776324` found only the unrelated Gateway prerequisite entry; the stable-tag distinction is recorded above. Its generic persistent-cache-schema annotation does not describe this diff: there is no schema/version/table/migration/store-write change. The changed production paths allocate bounded in-memory model projections; context-engine ingestion/assembly hooks and persistence eligibility are untouched, and raw in-memory Agent state remains unchanged in the passing tests. No migration is introduced or needed. This PR retains ownership of the repair; no duplicate fix was dispatched.

Production LOC: `+85/-90` (net−5, including the invariant comment). Tests: `+212/-4` across two existing modules, no new line-count suppression. Release-note context: preserve fitting actionable text when final tool-result context projection truncates large output.

