### PR TITLE
fix(sandbox): recreate OpenShell runtimes after backend switches

### DIFF
--- a/docs/gateway/openshell.md
+++ b/docs/gateway/openshell.md
@@ -372,10 +372,10 @@ remote workspace for that scope, and the next use seeds a fresh one from
 local. For `mirror` mode, recreate mainly resets the remote execution
 environment since local stays canonical.
 
-Sandbox CLI commands activate the configured backend's owning plugin before
-looking up runtime status or deleting a sandbox. Unrelated plugins are not
-loaded for these operations, and browser-only commands remain independent of
-the OpenShell backend.
+Sandbox list and recreate commands activate the configured backend's owning
+plugin plus the owner of each recorded runtime before inspecting or deleting
+it. Unrelated plugins are not loaded for these operations, and browser-only
+commands remain independent of the OpenShell backend.
 
 OpenClaw keeps a registered sandbox's shipped legacy runtime name after an
 upgrade so its remote workspace remains addressable. Recreating that scope

--- a/src/cli/command-bootstrap.test.ts
+++ b/src/cli/command-bootstrap.test.ts
@@ -139,7 +139,7 @@ describe("ensureCliCommandBootstrap", () => {
     });
   });
 
-  it("limits sandbox runtime commands to configured backend owner plugins", async () => {
+  it("loads configured and persisted backend owners for sandbox management", async () => {
     await ensureCliCommandBootstrap({
       runtime: {} as never,
       commandPath: ["sandbox", "list"],
@@ -147,7 +147,7 @@ describe("ensureCliCommandBootstrap", () => {
     });
 
     expect(ensureCliPluginRegistryLoadedMock).toHaveBeenCalledWith({
-      scope: "sandbox-backends",
+      scope: "sandbox-management",
       routeLogsToStderr: undefined,
     });
   });

--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -15,7 +15,8 @@ export type CliPluginRegistryScope =
   | "channels"
   | "configured-channels"
   | "memory"
-  | "sandbox-backends";
+  | "sandbox-backends"
+  | "sandbox-management";
 export type CliPluginRegistryPolicy = {
   scope: CliPluginRegistryScope;
 };
@@ -142,6 +143,14 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
         ),
       pluginRegistry: { scope: "sandbox-backends" },
     },
+  },
+  {
+    commandPath: ["sandbox", "list"],
+    policy: { pluginRegistry: { scope: "sandbox-management" } },
+  },
+  {
+    commandPath: ["sandbox", "recreate"],
+    policy: { pluginRegistry: { scope: "sandbox-management" } },
   },
   { commandPath: ["agents"], policy: { loadPlugins: "always", networkProxy: "bypass" } },
   {

--- a/src/cli/command-path-policy.test.ts
+++ b/src/cli/command-path-policy.test.ts
@@ -310,11 +310,7 @@ describe("command-path-policy", () => {
     expectLoadPluginsResolver(sandboxPolicy);
     expect(sandboxPolicy.pluginRegistry).toEqual({ scope: "sandbox-backends" });
 
-    for (const commandPath of [
-      ["sandbox", "list"],
-      ["sandbox", "recreate"],
-      ["sandbox", "explain"],
-    ]) {
+    for (const commandPath of [["sandbox", "explain"]]) {
       expect(resolveCliCommandPathPolicy(commandPath).pluginRegistry).toEqual({
         scope: "sandbox-backends",
       });
@@ -325,6 +321,15 @@ describe("command-path-policy", () => {
           jsonOutputMode: false,
         }),
       ).toBe(true);
+    }
+
+    for (const commandPath of [
+      ["sandbox", "list"],
+      ["sandbox", "recreate"],
+    ]) {
+      expect(resolveCliCommandPathPolicy(commandPath).pluginRegistry).toEqual({
+        scope: "sandbox-management",
+      });
     }
   });
 

--- a/src/cli/plugin-registry-loader.test.ts
+++ b/src/cli/plugin-registry-loader.test.ts
@@ -6,10 +6,17 @@ import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { measureCliCommandStartup } from "./command-startup-timing.js";
 
 const ensurePluginRegistryLoadedMock = vi.hoisted(() => vi.fn());
+const readRegistryMock = vi.hoisted(() =>
+  vi.fn(async (): Promise<{ entries: Array<{ backendId?: string }> }> => ({ entries: [] })),
+);
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 vi.mock("./plugin-registry.js", () => ({
   ensurePluginRegistryLoaded: ensurePluginRegistryLoadedMock,
+}));
+
+vi.mock("../agents/sandbox/registry.js", () => ({
+  readRegistry: readRegistryMock,
 }));
 
 describe("plugin-registry-loader", () => {
@@ -24,6 +31,7 @@ describe("plugin-registry-loader", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    readRegistryMock.mockResolvedValue({ entries: [] });
     originalForceStderr = loggingState.forceConsoleToStderr;
     loggingState.forceConsoleToStderr = false;
   });
@@ -89,6 +97,19 @@ describe("plugin-registry-loader", () => {
 
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
       scope: "configured-channels",
+    });
+  });
+
+  it("includes persisted runtime owners when loading sandbox managers", async () => {
+    readRegistryMock.mockResolvedValue({
+      entries: [{ backendId: "openshell" }, { backendId: "docker" }, { backendId: "openshell" }],
+    });
+
+    await ensureCliPluginRegistryLoaded({ scope: "sandbox-management" });
+
+    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
+      scope: "sandbox-backends",
+      persistedSandboxBackendIds: ["docker", "openshell"],
     });
   });
 

--- a/src/cli/plugin-registry-loader.ts
+++ b/src/cli/plugin-registry-loader.ts
@@ -6,9 +6,20 @@ import type { CliPluginRegistryScope } from "./command-catalog.js";
 import { measureCliCommandStartup } from "./command-startup-timing.js";
 
 const pluginRegistryModuleLoader = createLazyImportLoader(() => import("./plugin-registry.js"));
+const sandboxRegistryModuleLoader = createLazyImportLoader(
+  () => import("../agents/sandbox/registry.js"),
+);
 
 function loadPluginRegistryModule() {
   return pluginRegistryModuleLoader.load();
+}
+
+async function readPersistedSandboxBackendIds(): Promise<string[]> {
+  // Management must activate each recorded owner before lifecycle code can
+  // inspect or remove its runtime. Configured-only activation strands old rows.
+  const { readRegistry } = await sandboxRegistryModuleLoader.load();
+  const registry = await readRegistry();
+  return [...new Set(registry.entries.map((entry) => entry.backendId ?? "docker"))].toSorted();
 }
 
 /** Load the CLI plugin registry and optionally route activation logs to stderr. */
@@ -18,6 +29,10 @@ export async function ensureCliPluginRegistryLoaded(params: {
   config?: OpenClawConfig;
   activationSourceConfig?: OpenClawConfig;
 }) {
+  const persistedSandboxBackendIds =
+    params.scope === "sandbox-management"
+      ? await measureCliCommandStartup("sandbox-registry-read", readPersistedSandboxBackendIds)
+      : undefined;
   const { ensurePluginRegistryLoaded } = await measureCliCommandStartup(
     "plugin-registry-module-import",
     loadPluginRegistryModule,
@@ -29,11 +44,12 @@ export async function ensureCliPluginRegistryLoaded(params: {
     }
     try {
       ensurePluginRegistryLoaded({
-        scope: params.scope,
+        scope: params.scope === "sandbox-management" ? "sandbox-backends" : params.scope,
         ...(params.config ? { config: params.config } : {}),
         ...(params.activationSourceConfig
           ? { activationSourceConfig: params.activationSourceConfig }
           : {}),
+        ...(persistedSandboxBackendIds ? { persistedSandboxBackendIds } : {}),
       });
     } finally {
       loggingState.forceConsoleToStderr = previousForceStderr;

--- a/src/plugins/runtime/runtime-registry-loader.test.ts
+++ b/src/plugins/runtime/runtime-registry-loader.test.ts
@@ -231,6 +231,36 @@ describe("ensurePluginRegistryLoaded", () => {
     expect(mocks.resolveEffectivePluginIds).not.toHaveBeenCalled();
   });
 
+  it("loads installed persisted sandbox owners after configuration switches to Docker", () => {
+    const config = {
+      agents: { defaults: { sandbox: { backend: "docker" } } },
+      plugins: {
+        entries: {
+          openshell: { enabled: true },
+          "broken-plugin": { enabled: true },
+        },
+      },
+    };
+    mocks.resolvePluginMetadataSnapshot.mockReturnValue({
+      index: {
+        installRecords: {},
+        plugins: ["openshell", "broken-plugin"].map((pluginId) => ({
+          pluginId,
+          startup: { sidecar: false, memory: false, agentHarnesses: [] },
+        })),
+      },
+      manifestRegistry: { plugins: [], diagnostics: [] },
+    } as never);
+
+    ensurePluginRegistryLoaded({
+      scope: "sandbox-backends",
+      config,
+      persistedSandboxBackendIds: ["openshell", "docker", "missing-owner"],
+    });
+
+    expect(requireLoadOptions().onlyPluginIds).toEqual(["openshell"]);
+  });
+
   it.each([undefined, "docker", "podman", "ssh"])(
     "does not activate plugins for the built-in sandbox backend %s",
     (backend) => {

--- a/src/plugins/runtime/runtime-registry-loader.ts
+++ b/src/plugins/runtime/runtime-registry-loader.ts
@@ -52,6 +52,7 @@ function resolveMemoryPluginIds(
 
 function resolveSandboxBackendPluginIds(
   context: ReturnType<typeof resolvePluginRuntimeLoadContext>,
+  persistedBackendIds: readonly string[] = [],
 ): string[] {
   if (!context.metadataSnapshot) {
     return [];
@@ -61,6 +62,7 @@ function resolveSandboxBackendPluginIds(
     agents?.defaults?.sandbox?.backend,
     ...Object.values(agents?.entries ?? {}).map((agent) => agent.sandbox?.backend),
     ...(agents?.list ?? []).map((agent) => agent.sandbox?.backend),
+    ...persistedBackendIds,
   ];
   const lookup = createInstalledPluginIndexScopeLookup(context.metadataSnapshot.index);
   const pluginIds = new Set<string>();
@@ -82,6 +84,7 @@ function resolveSandboxBackendPluginIds(
 function resolveScopePluginIds(params: {
   scope: PluginRegistryScope;
   context: ReturnType<typeof resolvePluginRuntimeLoadContext>;
+  persistedSandboxBackendIds?: readonly string[];
 }): string[] {
   if (params.scope === "configured-channels") {
     return resolveConfiguredChannelPluginIds({
@@ -104,7 +107,7 @@ function resolveScopePluginIds(params: {
     return resolveMemoryPluginIds(params.context);
   }
   if (params.scope === "sandbox-backends") {
-    return resolveSandboxBackendPluginIds(params.context);
+    return resolveSandboxBackendPluginIds(params.context, params.persistedSandboxBackendIds);
   }
   return resolveEffectivePluginIds({
     config: params.context.rawConfig,
@@ -119,10 +122,15 @@ export function ensurePluginRegistryLoaded(options?: {
   activationSourceConfig?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   workspaceDir?: string;
+  persistedSandboxBackendIds?: readonly string[];
 }): void {
   const scope = options?.scope ?? "all";
   const context = resolvePluginRuntimeLoadContext(options);
-  const pluginIds = resolveScopePluginIds({ scope, context });
+  const pluginIds = resolveScopePluginIds({
+    scope,
+    context,
+    persistedSandboxBackendIds: options?.persistedSandboxBackendIds,
+  });
   const activateConfigured = scope === "configured-channels" && pluginIds.length > 0;
   const config = activateConfigured
     ? (withActivatedPluginIds({ config: context.config, pluginIds }) ?? context.config)


### PR DESCRIPTION
Closes #131287

## What Problem This Solves

Fixes an issue where users could not list or recreate an OpenShell sandbox after changing their current sandbox backend to Docker, Podman, or SSH. The persisted runtime still identified OpenShell as its lifecycle owner, but CLI startup activated only the currently configured backend plugin, so cleanup failed with `Sandbox backend "openshell" is unavailable` and deliberately retained the registry row.

## Why This Change Was Made

Sandbox `list` and `recreate` now use a management-only plugin scope. The CLI reads the canonical runtime registry, carries its distinct backend IDs into the existing sandbox-owner resolver, and activates only installed matching owner plugins alongside the configured owners.

The storage read stays at the CLI management boundary; the generic plugin runtime loader remains storage-agnostic. Built-in Docker, Podman, and SSH IDs, missing owners, and unrelated enabled plugins remain excluded. Browser-only list/recreate commands still skip plugin activation.

## User Impact

Operators can switch the configured sandbox backend and still use `openclaw sandbox list` or `openclaw sandbox recreate` to inspect and remove historical plugin-owned runtimes. If the recorded owner plugin is missing or disabled, the existing fail-safe behavior is unchanged: cleanup reports the unavailable backend and keeps the registry entry for a later retry.

No config, environment, protocol, persistent-store, or SQLite schema change is involved.

## Evidence

Exact tested head: `74fdec8e512e52258f828413698c3f527a6f350a`  
Base: `fae55749085189ed6380891a5945a0e96acc62ee` (`origin/main` at push)

Live behavior proof used OpenShell `0.0.106`, an isolated loopback OpenShell gateway, an actual Podman-backed OpenShell object/container, isolated OpenClaw state, and this branch's OpenShell plugin source. The current OpenClaw config selected `backend: "docker"`; the canonical registry row retained `backendId: "openshell"`, matching the reported backend-switch state.

The temporary plaintext gateway could not provide OpenShell's sandbox-token policy bootstrap, so the disposable object was stopped rather than Ready. That does not alter the owner-selection or `DeleteSandbox` lifecycle path being proved here.

Before cleanup, the exact-head CLI found the historical owner despite current Docker configuration:

```json
{
  "containers": [
    {
      "containerName": "oc-issue-131287",
      "backendId": "openshell",
      "runtimeLabel": "oc-issue-131287",
      "sessionKey": "agent:issue-131287:main",
      "image": "openshell/sandbox-from:1787926763",
      "running": false,
      "imageMatch": true
    }
  ],
  "browsers": []
}
```

Actual public cleanup flow:

```text
$ openclaw sandbox recreate --all --force

Sandbox runtimes to be recreated:

📦 Sandbox Runtimes:
  - oc-issue-131287 [openshell] (stopped)

Total: 1 runtime(s)

Removing sandbox runtimes...

✓ Removed oc-issue-131287

Done: 1 removed, 0 failed
```

The OpenShell gateway recorded `DeleteSandbox` and deletion of the backing Podman container. Both postconditions were empty:

```text
$ openshell --gateway-endpoint <isolated-loopback> sandbox list --output json
[]

$ readRegistry()
{"entries":[]}
```

The isolated gateway then shut down cleanly. Pre-existing OpenShell sandboxes were not touched.

Regression and repository proof:

- New tests failed on pre-fix `main`: persisted `openshell` was absent from owner activation, and list/recreate used the configured-only scope.
- 83 focused CLI, plugin-runtime, sandbox-management, and command tests pass at exact head.
- `node scripts/check-changed.mjs` passes at exact head, including core/test typechecks, lint, import-cycle, plugin-boundary, database-first, and schema-version guards.
- `pnpm build` passes; exact-head live CLI startup rebuilt and validated the distribution before the proof.
- Local Codex autoreview: no actionable findings; patch correct with 0.99 confidence.

## Scope and compatibility

- Architectural owner: CLI plugin activation for sandbox lifecycle management.
- Canonical fix: union configured backend IDs with persisted runtime owner IDs before the existing exact installed-plugin lookup.
- Removed paths: none; unavailable-owner registry preservation remains the single cleanup safety path.
- Sibling coverage: configured plugin owners, historical plugin owners, Docker/Podman/SSH built-ins, missing owners, unrelated plugins, and browser-only commands.
- Production delta: +33 net lines. The added boundary is needed to pass persisted ownership from CLI storage into the existing storage-independent resolver without broad-loading all plugins or coupling plugin runtime loading to SQLite.
