### PR TITLE
fix(ui): show Codex node approvals in the controlling chat

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -18062,6 +18062,7 @@ public struct PendingApprovalSnapshot: Codable, Sendable {
     public let expiresatms: Int
     public let presentation: ApprovalPresentation
     public let status: String
+    public let sourcesessionkey: String?
 
     public init(
         id: String,
@@ -18069,7 +18070,8 @@ public struct PendingApprovalSnapshot: Codable, Sendable {
         createdatms: Int,
         expiresatms: Int,
         presentation: ApprovalPresentation,
-        status: String)
+        status: String,
+        sourcesessionkey: String? = nil)
     {
         self.id = id
         self.urlpath = urlpath
@@ -18077,6 +18079,7 @@ public struct PendingApprovalSnapshot: Codable, Sendable {
         self.expiresatms = expiresatms
         self.presentation = presentation
         self.status = status
+        self.sourcesessionkey = sourcesessionkey
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -18086,6 +18089,7 @@ public struct PendingApprovalSnapshot: Codable, Sendable {
         case expiresatms = "expiresAtMs"
         case presentation
         case status
+        case sourcesessionkey = "sourceSessionKey"
     }
 }
 

--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -4122,7 +4122,6 @@ ui/src/pages/chat/realtime-talk-google-live.ts	2
 ui/src/pages/chat/realtime-talk-shared.ts	7
 ui/src/pages/chat/realtime-talk-webrtc.ts	3
 ui/src/pages/chat/realtime-talk.ts	7
-ui/src/pages/chat/route.ts	2
 ui/src/pages/chat/run-lifecycle.ts	1
 ui/src/pages/chat/scroll.ts	1
 ui/src/pages/chat/session-cache.ts	2

--- a/packages/gateway-protocol/src/approvals-validators.test.ts
+++ b/packages/gateway-protocol/src/approvals-validators.test.ts
@@ -245,7 +245,7 @@ describe("unified approval protocol validators", () => {
           sourceSessionKey: "agent:worker:subagent:123",
         },
       }),
-    ).toBe(false);
+    ).toBe(true);
     expect(
       validateApprovalGetResult({
         approval: {

--- a/packages/gateway-protocol/src/schema/approvals.ts
+++ b/packages/gateway-protocol/src/schema/approvals.ts
@@ -221,6 +221,8 @@ const ApprovalResolutionFields = {
 export const PendingApprovalSnapshotSchema = closedObject({
   ...ApprovalRecordCommonFields,
   status: Type.Literal("pending"),
+  /** Canonical raising session when projected into a session-scoped reviewer surface. */
+  sourceSessionKey: Type.Optional(NonEmptyString),
 });
 
 /** Approval whose first recorded reviewer decision allows the operation. */

--- a/packages/gateway-protocol/src/session-approval-validators.test.ts
+++ b/packages/gateway-protocol/src/session-approval-validators.test.ts
@@ -23,7 +23,11 @@ const approval = {
   expiresAtMs: 1_780_001_800_000,
 } as const;
 
-const pending = { ...approval, status: "pending" } as const;
+const pending = {
+  ...approval,
+  status: "pending",
+  sourceSessionKey: "agent:worker:subagent:child",
+} as const;
 const terminal = {
   ...approval,
   status: "denied",

--- a/src/gateway/node-invoke-plugin-policy.test.ts
+++ b/src/gateway/node-invoke-plugin-policy.test.ts
@@ -179,6 +179,7 @@ describe("applyPluginNodeInvokePolicy", () => {
         internal: {
           syntheticClient: true,
           pluginRuntimeOwnerId: DEMO_PLUGIN_ID,
+          nodeInvokeApprovalSessionKey: "agent:main:paired",
           nodeInvokeStream: stream,
         },
       },
@@ -190,6 +191,7 @@ describe("applyPluginNodeInvokePolicy", () => {
     });
 
     const approval = await expectSinglePendingApproval(manager);
+    expect(approval.request.sessionKey).toBe("agent:main:paired");
     expect(invoke).not.toHaveBeenCalled();
     expect(manager.resolve(approval.id, "allow-once")).toBe(true);
 
@@ -213,6 +215,35 @@ describe("applyPluginNodeInvokePolicy", () => {
 
     runtimeCurrent = false;
     expect(invoke.mock.calls[0]?.[0]?.isDispatchAuthorized?.()).toBe(false);
+  });
+
+  it("does not trust a plugin-owned invocation session without host attestation", async () => {
+    const manager = new ExecApprovalManager<PluginApprovalRequestPayload>();
+    setDangerousDemoCommandRegistry([createApprovalRequestPolicy()]);
+    const reviewer = createOperatorClient("conn-owner-approval");
+    const { context } = createContext({
+      pluginApprovalManager: manager,
+      getApprovalClientConnIds: createApprovalClientLookup([reviewer]),
+    });
+    const resultPromise = applyPluginNodeInvokePolicy({
+      context,
+      client: {
+        ...createOperatorClient(),
+        internal: {
+          syntheticClient: true,
+          pluginRuntimeOwnerId: DEMO_PLUGIN_ID,
+        },
+      },
+      nodeSession: createNodeSession(),
+      command: DEMO_COMMAND,
+      params: DEMO_PARAMS,
+      sessionKey: "agent:main:plugin-asserted",
+    });
+
+    const approval = await expectSinglePendingApproval(manager);
+    expect(approval.request.sessionKey).toBeNull();
+    expect(manager.resolve(approval.id, "deny")).toBe(true);
+    await expect(resultPromise).resolves.toMatchObject({ ok: true });
   });
 
   it("classifies exact arguments before the policy handler and transport", async () => {
@@ -725,6 +756,7 @@ describe("applyPluginNodeInvokePolicy", () => {
       nodeSession: createNodeSession(),
       command: DEMO_COMMAND,
       params: DEMO_PARAMS,
+      sessionKey: "agent:main:spoofed",
       turnSource: {
         channel: "tui",
         to: "terminal",
@@ -843,6 +875,7 @@ describe("applyPluginNodeInvokePolicy", () => {
       nodeSession: createNodeSession(),
       command: DEMO_COMMAND,
       params: DEMO_PARAMS,
+      sessionKey: "agent:main:spoofed",
       turnSource: {
         channel: "telegram",
         to: "chat:other",

--- a/src/gateway/node-invoke-plugin-policy.ts
+++ b/src/gateway/node-invoke-plugin-policy.ts
@@ -128,6 +128,10 @@ function createApprovalRuntime(params: {
       const timeoutMs = resolvePluginApprovalTimeoutMs(input.timeoutMs);
       const turnSource = resolveNodeInvokeTurnSourceFields(params.turnSource);
       const callerIdentity = params.client?.internal?.agentRuntimeIdentity;
+      const invocationSessionKey =
+        params.client?.internal?.pluginRuntimeOwnerId === params.pluginId
+          ? params.client.internal.nodeInvokeApprovalSessionKey
+          : undefined;
       if (
         callerIdentity &&
         params.context.validateAgentRuntimeApprovalAuthority?.(callerIdentity) !== true
@@ -162,7 +166,11 @@ function createApprovalRuntime(params: {
         toolName: sanitizeOptionalMeta(input.toolName),
         toolCallId: normalizeOptionalString(input.toolCallId) ?? null,
         agentId: callerIdentity?.agentId ?? sanitizeOptionalMeta(input.agentId),
-        sessionKey: callerIdentity?.sessionKey ?? normalizeOptionalString(input.sessionKey) ?? null,
+        sessionKey:
+          callerIdentity?.sessionKey ??
+          invocationSessionKey ??
+          normalizeOptionalString(input.sessionKey) ??
+          null,
         runId: callerIdentity?.operationalRunInstance.runId ?? null,
         turnSourceChannel: turnSource.turnSourceChannel,
         turnSourceTo: turnSource.turnSourceTo,

--- a/src/gateway/operator-approval-session-events.test.ts
+++ b/src/gateway/operator-approval-session-events.test.ts
@@ -440,6 +440,7 @@ describe("operator approval session events", () => {
         {
           id: "source-and-parent",
           status: "pending",
+          sourceSessionKey: SOURCE_SESSION_KEY,
           presentation: createPendingRecord({ id: "source-and-parent" }).presentation,
           urlPath: "/operator/approve/source-and-parent",
           createdAtMs: 1_000,
@@ -448,6 +449,7 @@ describe("operator approval session events", () => {
         {
           id: parentOnly.id,
           status: "pending",
+          sourceSessionKey: PARENT_SESSION_KEY,
           presentation: parentOnly.presentation,
           urlPath: "/operator/approve/parent-only",
           createdAtMs: 1_001,

--- a/src/gateway/operator-approval-session-events.ts
+++ b/src/gateway/operator-approval-session-events.ts
@@ -26,6 +26,15 @@ type OperatorApprovalSessionEventRuntime = {
   replay: (sessionKey: string, client: GatewayClient | null) => SessionApprovalReplay;
 };
 
+function resolveApprovalSourceStreamKeyForRecord(record: OperatorApprovalRecord): string | null {
+  return (
+    record.audienceSessionKeys[0] ??
+    (record.source.sessionKey
+      ? resolveApprovalSourceStreamKey(record.source.sessionKey, record.source.agentId)
+      : null)
+  );
+}
+
 /** Project durable approval truth to exact, explicitly opted-in session audiences. */
 export function createOperatorApprovalSessionEventRuntime(params: {
   clients: Iterable<ApprovalSessionClient>;
@@ -77,14 +86,7 @@ export function createOperatorApprovalSessionEventRuntime(params: {
     // first entry; publish that exact form so parents can correlate the event
     // with a stream key they subscribed to. Raw source aliases (bare "global",
     // "main", unscoped child keys) never reach subscribers.
-    const sourceStreamKey =
-      event.record.audienceSessionKeys[0] ??
-      (event.record.source.sessionKey
-        ? resolveApprovalSourceStreamKey(
-            event.record.source.sessionKey,
-            event.record.source.agentId,
-          )
-        : null);
+    const sourceStreamKey = resolveApprovalSourceStreamKeyForRecord(event.record);
     for (const sessionKey of event.record.audienceSessionKeys) {
       const recipients = authorizedRecipients(sessionKey, event.record);
       if (recipients.size === 0) {
@@ -141,7 +143,11 @@ export function createOperatorApprovalSessionEventRuntime(params: {
         }
         const approval = projectOperatorApprovalSnapshot(record, controlUiBasePath);
         if (approval?.status === "pending") {
-          approvals.push(approval);
+          const sourceSessionKey = resolveApprovalSourceStreamKeyForRecord(record);
+          approvals.push({
+            ...approval,
+            ...(sourceSessionKey ? { sourceSessionKey } : {}),
+          });
         }
       }
       return { sessionKey, updatedAtMs: snapshotAtMs, approvals, truncated };

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -145,6 +145,8 @@ export type GatewayClient = {
     cronRunContinuation?: boolean;
     agentRuntimeIdentity?: AgentRuntimeIdentity;
     pluginRuntimeOwnerId?: string;
+    /** Host-attested session provenance for a trusted official plugin node invocation. */
+    nodeInvokeApprovalSessionKey?: string;
     /** Plugin-owned in-process invoke hooks; never accepted from Gateway wire params. */
     nodeInvokeStream?: GatewayNodeInvokeStream;
     agentRunTracking?: GatewayAgentRunTaskOwner;

--- a/src/gateway/server-plugin-in-process-dispatch.ts
+++ b/src/gateway/server-plugin-in-process-dispatch.ts
@@ -1,6 +1,7 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import type { AgentWaitParams } from "../../packages/gateway-protocol/src/index.js";
 import type { SubagentCompletionToolHandoffRegistration } from "../agents/subagents/announce/subagent-announce-handoff.js";
+import { getActivePluginRegistry } from "../plugins/runtime.js";
 import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
 import type { PluginSubagentRequesterContext } from "../plugins/runtime/subagent-requester-context.js";
 import type { RuntimePluginToolGrant } from "../plugins/runtime/tool-grant.js";
@@ -70,6 +71,7 @@ type DispatchGatewayMethodInProcessOptions = {
   internalDeliveryMediaUrls?: string[];
   internalDeliverySuppressText?: boolean;
   nodeInvokeStream?: GatewayNodeInvokeStream;
+  nodeInvokeApprovalSessionKey?: string;
   onAccepted?: (payload: unknown) => void;
   onSignalAbort?: () => Promise<void> | void;
   operatorRoleActor?: GatewayOperatorRoleActor;
@@ -148,6 +150,18 @@ function resolveInProcessGatewayDispatch(
     typeof options?.pluginRuntimeOwnerId === "string" && options.pluginRuntimeOwnerId.trim()
       ? options.pluginRuntimeOwnerId.trim()
       : undefined;
+  const pluginRecord = pluginRuntimeOwnerId
+    ? getActivePluginRegistry()?.plugins.find((entry) => entry.id === pluginRuntimeOwnerId)
+    : undefined;
+  const nodeInvokeApprovalSessionKey =
+    method === "node.invoke" &&
+    scope?.pluginId?.trim() === pluginRuntimeOwnerId &&
+    (scope?.pluginOrigin === "bundled" ||
+      scope?.pluginTrustedOfficialInstall === true ||
+      pluginRecord?.origin === "bundled" ||
+      pluginRecord?.trustedOfficialInstall === true)
+      ? options?.nodeInvokeApprovalSessionKey
+      : undefined;
   if (
     options?.nodeInvokeStream &&
     (method !== "node.invoke" || !pluginRuntimeOwnerId || options.forceSyntheticClient !== true)
@@ -181,6 +195,7 @@ function resolveInProcessGatewayDispatch(
     internalDeliveryMediaUrls: options?.internalDeliveryMediaUrls,
     internalDeliverySuppressText: options?.internalDeliverySuppressText,
     ...(pluginRuntimeOwnerId ? { pluginRuntimeOwnerId } : {}),
+    ...(nodeInvokeApprovalSessionKey ? { nodeInvokeApprovalSessionKey } : {}),
     ...(options?.pluginSubagentRequester
       ? { pluginSubagentRequester: options.pluginSubagentRequester }
       : {}),

--- a/src/gateway/server-plugin-runtime-client.ts
+++ b/src/gateway/server-plugin-runtime-client.ts
@@ -31,6 +31,7 @@ export function createSyntheticPluginRuntimeClient(params?: {
   internalDeliveryMediaUrls?: string[];
   internalDeliverySuppressText?: boolean;
   pluginRuntimeOwnerId?: string;
+  nodeInvokeApprovalSessionKey?: string;
   pluginSubagentRequester?: PluginSubagentRequesterContext;
   runtimePluginToolGrant?: RuntimePluginToolGrant;
   pluginSubagentToolsAllow?: string[];
@@ -74,6 +75,9 @@ export function createSyntheticPluginRuntimeClient(params?: {
         : {}),
       ...(params?.scopes?.includes(APPROVALS_SCOPE) ? { approvalRuntime: true } : {}),
       ...(pluginRuntimeOwnerId ? { pluginRuntimeOwnerId } : {}),
+      ...(params?.nodeInvokeApprovalSessionKey
+        ? { nodeInvokeApprovalSessionKey: params.nodeInvokeApprovalSessionKey }
+        : {}),
       ...(params?.pluginSubagentRequester
         ? { pluginSubagentRequester: params.pluginSubagentRequester }
         : {}),

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -1340,6 +1340,7 @@ describe("loadGatewayPlugins", () => {
           nodeId: "node-1",
           command: "browser.proxy",
           params: { method: "GET", path: "/profiles" },
+          sessionKey: "agent:main:trusted",
           scopes: ["operator.admin"],
         }),
     );
@@ -1351,6 +1352,9 @@ describe("loadGatewayPlugins", () => {
     });
     expect(getLastDispatchedClientScopes()).toEqual(["operator.admin"]);
     expect(getLastDispatchedClientInternal().pluginRuntimeOwnerId).toBe("google-meet");
+    expect(getLastDispatchedClientInternal().nodeInvokeApprovalSessionKey).toBe(
+      "agent:main:trusted",
+    );
   });
 
   test("honors trusted plugin node scopes inside a narrower Gateway request", async () => {
@@ -1517,6 +1521,7 @@ describe("loadGatewayPlugins", () => {
           nodeId: "node-1",
           command: "browser.proxy",
           params: { method: "GET", path: "/profiles" },
+          sessionKey: "agent:main:untrusted",
           scopes: ["operator.admin"],
         }),
     );
@@ -1529,6 +1534,7 @@ describe("loadGatewayPlugins", () => {
     expect(getLastDispatchedClientScopes()).toEqual(["operator.write"]);
     expect(getLastDispatchedClientScopes()).not.toContain("operator.admin");
     expect(getLastDispatchedClientInternal().pluginRuntimeOwnerId).toBe("third-party");
+    expect(getLastDispatchedClientInternal()).not.toHaveProperty("nodeInvokeApprovalSessionKey");
   });
 
   test("rejects an owned non-duplex node command before invoking its handler", async () => {

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -458,6 +458,7 @@ export function createGatewayNodesRuntime(
       },
       {
         ...(pluginId ? { pluginRuntimeOwnerId: pluginId } : {}),
+        nodeInvokeApprovalSessionKey: params.sessionKey,
         ...(syntheticScopes ? { syntheticScopes } : {}),
         ...(stream || syntheticScopes ? { forceSyntheticClient: true } : {}),
         ...(stream ? { nodeInvokeStream: stream } : {}),

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -208,9 +208,7 @@ function resolveRuntimeNodeInvokeSyntheticScopes(params: {
   requestedScopes?: OperatorScope[];
 }): OperatorScope[] | undefined {
   // Requested scopes may replace caller scopes, so only bundled or trusted official plugins qualify.
-  return params.requestedScopes && canTrustedOfficialPluginRequestScopes(params)
-    ? params.requestedScopes
-    : undefined;
+  return canTrustedOfficialPluginRequestScopes(params) ? params.requestedScopes : undefined;
 }
 
 export async function dispatchTrustedPluginGatewayMethod<T>(

--- a/ui/src/app/exec-approval.ts
+++ b/ui/src/app/exec-approval.ts
@@ -32,6 +32,8 @@ export type ExecApprovalRequest = {
   pluginSeverity?: string | null;
   pluginId?: string | null;
   proposalHash?: string | null;
+  /** Canonical raising session when this request is projected into an ancestor session. */
+  sourceSessionKey?: string | null;
   createdAtMs: number;
   expiresAtMs: number;
 };

--- a/ui/src/app/overlays-types.ts
+++ b/ui/src/app/overlays-types.ts
@@ -29,7 +29,11 @@ export type ApplicationOverlays = {
   refreshUpdateStatus: () => Promise<void>;
   runUpdate: () => Promise<void>;
   holdUpdate: () => Promise<boolean>;
-  decideApproval: (decision: ExecApprovalDecision, approvalId?: string) => Promise<void>;
+  decideApproval: (
+    decision: ExecApprovalDecision,
+    approvalId?: string,
+    projectedApproval?: ExecApprovalRequest,
+  ) => Promise<void>;
   openDevicePairSetup: () => Promise<boolean>;
   refreshDevicePairSetup: () => Promise<void>;
   setDevicePairSetupAccess: (access: DevicePairSetupAccess) => Promise<void>;

--- a/ui/src/app/overlays.test.ts
+++ b/ui/src/app/overlays.test.ts
@@ -563,6 +563,37 @@ describe("application approval overlays", () => {
     overlays.dispose();
   });
 
+  it("keeps a projected approval's resolve failure visible", async () => {
+    let resolveAttempts = 0;
+    const request = vi.fn<RequestFn>((method) => {
+      if (method.endsWith(".list")) {
+        return Promise.resolve([]);
+      }
+      resolveAttempts += 1;
+      return resolveAttempts === 1
+        ? Promise.reject(new Error("gateway unavailable"))
+        : Promise.resolve({ ok: true });
+    });
+    const harness = createGatewayHarness(client(request));
+    const overlays = createApplicationOverlays(harness.gateway);
+    const projectedApproval = {
+      ...approval("approval-projected", 1_000),
+      kind: "exec" as const,
+    };
+
+    await overlays.decideApproval("allow-once", projectedApproval.id, projectedApproval);
+
+    expect(overlays.snapshot.approvalErrors.get(projectedApproval.id)).toBe(
+      "Approval failed: gateway unavailable",
+    );
+    expect(overlays.snapshot.approvalBusy).toBe(false);
+
+    await overlays.decideApproval("allow-once", projectedApproval.id, projectedApproval);
+
+    expect(overlays.snapshot.approvalErrors.has(projectedApproval.id)).toBe(false);
+    overlays.dispose();
+  });
+
   it("surfaces a connection error when a rendered approval races a disconnect", async () => {
     const request = vi.fn<RequestFn>((method) =>
       Promise.resolve(method.endsWith(".list") ? [] : { ok: true }),

--- a/ui/src/app/overlays.ts
+++ b/ui/src/app/overlays.ts
@@ -581,9 +581,10 @@ export function createApplicationOverlays(
         updateHoldInFlight = false;
       }
     },
-    async decideApproval(decision, approvalId) {
+    async decideApproval(decision, approvalId, projectedApproval) {
       const active = approvalId
-        ? promptState.execApprovalQueue.find((entry) => entry.id === approvalId)
+        ? (promptState.execApprovalQueue.find((entry) => entry.id === approvalId) ??
+          (projectedApproval?.id === approvalId ? projectedApproval : undefined))
         : promptState.execApprovalQueue[0];
       const client = gateway.snapshot.client;
       if (!active || promptState.execApprovalBusy || disposed) {

--- a/ui/src/app/overlays.ts
+++ b/ui/src/app/overlays.ts
@@ -590,6 +590,7 @@ export function createApplicationOverlays(
       if (!active || promptState.execApprovalBusy || disposed) {
         return;
       }
+      const isProjectedApproval = active === projectedApproval;
       if (!client || gateway.snapshot.phase !== "connected") {
         promptState.execApprovalErrors.set(active.id, t("sessionsView.actionRequiresConnection"));
         publish();
@@ -639,7 +640,8 @@ export function createApplicationOverlays(
         }
         if (
           isCurrentOperation() &&
-          promptState.execApprovalQueue.some((entry) => entry.id === active.id)
+          (isProjectedApproval ||
+            promptState.execApprovalQueue.some((entry) => entry.id === active.id))
         ) {
           promptState.execApprovalErrors.set(active.id, `Approval failed: ${formatUiError(error)}`);
         }

--- a/ui/src/components/exec-approval-card.test.ts
+++ b/ui/src/components/exec-approval-card.test.ts
@@ -100,6 +100,12 @@ describe("exec approval card", () => {
     expect(card?.textContent).not.toContain("agent:main:session-1");
   });
 
+  it("labels an approval projected from a child session", () => {
+    const card = renderCard(approval({ sourceSessionKey: "agent:main:cloud-child" }), "inline");
+
+    expect(card?.textContent).toContain("Approval requested by session cloud-child");
+  });
+
   it("keeps host and cwd visible while collapsing lower-value exec metadata", () => {
     const card = renderCard(
       approval({

--- a/ui/src/components/exec-approval-card.ts
+++ b/ui/src/components/exec-approval-card.ts
@@ -381,6 +381,13 @@ export function renderExecApprovalCard(props: ExecApprovalCardProps) {
           </div>`
         : nothing}
     </div>
+    ${props.variant === "inline" && active.sourceSessionKey
+      ? html`<div class="exec-approval-warning" role="note">
+          ${t("execApproval.requestedBySession", {
+            session: resolveSessionDisplayName(active.sourceSessionKey),
+          })}
+        </div>`
+      : nothing}
     ${active.kind === "exec"
       ? renderExecBody(active.request, props.variant)
       : renderPluginBody(active, props.variant)}

--- a/ui/src/e2e/chat-side-panel.test-support.ts
+++ b/ui/src/e2e/chat-side-panel.test-support.ts
@@ -56,14 +56,7 @@ export async function activateChatHeaderPanelAction(page: Page, label: string): 
     }
   }
   await action.waitFor({ state: "visible" });
-  const afterHide = menu.locator("wa-dropdown").evaluate(
-    (dropdown) =>
-      new Promise<void>((resolve) => {
-        dropdown.addEventListener("wa-after-hide", () => resolve(), { once: true });
-      }),
-  );
   await action.click();
-  await afterHide;
   await page.waitForFunction(() => {
     const dropdown = document.querySelector("openclaw-chat-header-session-menu wa-dropdown");
     return !dropdown || Reflect.get(dropdown, "open") !== true;

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -2058,6 +2058,7 @@ export const en: TranslationMap = {
     expired: "expired",
     execApprovalNeeded: "Exec approval needed",
     pluginApprovalNeeded: "Plugin approval needed",
+    requestedBySession: "Approval requested by session {session}",
     pending: "{count} pending",
     otherPending: "Other pending requests",
     reviewRequest: "Review approval from {agent}: {command}",

--- a/ui/src/pages/chat/chat-history-subscription-disposal.test.ts
+++ b/ui/src/pages/chat/chat-history-subscription-disposal.test.ts
@@ -49,12 +49,22 @@ describe("disposed chat message subscriptions", () => {
     const state = createSubscriptionState(unsubscribeMessages);
     state.chatSessionMessageSubscriptionRequestedKey = subscription.key;
     state.chatSessionMessageSubscription = subscription;
+    state.chatSessionApprovalQueue = [
+      {
+        id: "approval-1",
+        kind: "plugin",
+        request: { command: "Approve", sessionKey: subscription.key },
+        createdAtMs: 1,
+        expiresAtMs: 2,
+      },
+    ];
 
     disposeSelectedSessionMessageSubscription(state);
 
     expect(unsubscribeMessages).toHaveBeenCalledExactlyOnceWith(subscription);
     expect(state.chatSessionMessageSubscriptionRequestedKey).toBeNull();
     expect(state.chatSessionMessageSubscription).toBeNull();
+    expect(state.chatSessionApprovalQueue).toEqual([]);
   });
 
   it("releases a subscription that resolves after its pane is disposed", async () => {

--- a/ui/src/pages/chat/chat-history-subscription-errors.test.ts
+++ b/ui/src/pages/chat/chat-history-subscription-errors.test.ts
@@ -179,3 +179,122 @@ describe("visible chat message subscription failures", () => {
     expect(state.requestUpdate).not.toHaveBeenCalled();
   });
 });
+
+describe("selected agent subscription changes", () => {
+  it("clears stale approvals while switching the selected global agent", async () => {
+    const previous = { key: "global", agentId: "main", includeApprovals: true as const };
+    let resolveSubscribe!: (subscription: {
+      key: string;
+      agentId: string;
+      includeApprovals: true;
+      approvalReplay: { sessionKey: string; updatedAtMs: number; approvals: []; truncated: false };
+    }) => void;
+    const subscribeMessages = vi.fn(
+      () =>
+        new Promise<{
+          key: string;
+          agentId: string;
+          includeApprovals: true;
+          approvalReplay: {
+            sessionKey: string;
+            updatedAtMs: number;
+            approvals: [];
+            truncated: false;
+          };
+        }>((resolve) => {
+          resolveSubscribe = resolve;
+        }),
+    );
+    const state = {
+      ...makeChatHost({ requestHandlers: {}, sessionKey: "global" }),
+      assistantAgentId: "research",
+      chatSessionMessageSubscriptionRequestedKey: "global",
+      chatSessionMessageSubscription: previous,
+      chatSessionApprovalQueue: [
+        {
+          id: "stale-main-approval",
+          kind: "exec" as const,
+          request: { command: "echo stale", agentId: "main", sessionKey: "global" },
+          createdAtMs: 1,
+          expiresAtMs: 10_000,
+        },
+      ],
+      connectionEpoch: 1,
+      sessions: {
+        subscribeMessages,
+        unsubscribeMessages: vi.fn(async () => undefined),
+      },
+      requestUpdate: vi.fn(),
+    };
+
+    const sync = syncSelectedSessionMessageSubscription(state as never);
+    await Promise.resolve();
+    const queueWhileReplacementIsPending = [...state.chatSessionApprovalQueue];
+    resolveSubscribe({
+      key: "global",
+      agentId: "research",
+      includeApprovals: true,
+      approvalReplay: {
+        sessionKey: "agent:research:global",
+        updatedAtMs: 2,
+        approvals: [],
+        truncated: false,
+      },
+    });
+    await sync;
+
+    expect(queueWhileReplacementIsPending).toEqual([]);
+    expect(subscribeMessages).toHaveBeenCalledWith("global", {
+      agentId: "research",
+      includeApprovals: true,
+    });
+  });
+
+  it("keeps the latest selection when pending release retries settle out of order", async () => {
+    const previous = { key: "agent:main:previous", agentId: null };
+    let resolveSecondRetry: () => void = () => undefined;
+    let resolveLatestRetry: () => void = () => undefined;
+    const secondRetry = new Promise<void>((resolve) => {
+      resolveSecondRetry = resolve;
+    });
+    const latestRetry = new Promise<void>((resolve) => {
+      resolveLatestRetry = resolve;
+    });
+    const unsubscribeMessages = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("previous release failed"))
+      .mockRejectedValueOnce(new Error("replacement release failed"))
+      .mockReturnValueOnce(secondRetry)
+      .mockReturnValueOnce(latestRetry)
+      .mockResolvedValue(undefined);
+    const subscribeMessages = vi.fn(async (key: string) => ({ key, agentId: null }));
+    const state = {
+      ...makeChatHost({ requestHandlers: {}, sessionKey: "agent:main:first" }),
+      chatSessionMessageSubscriptionRequestedKey: previous.key,
+      chatSessionMessageSubscription: previous,
+      connectionEpoch: 1,
+      sessions: { subscribeMessages, unsubscribeMessages },
+      requestUpdate: vi.fn(),
+    };
+    await syncSelectedSessionMessageSubscription(state as never);
+
+    state.sessionKey = "agent:main:second";
+    const secondSync = syncSelectedSessionMessageSubscription(state as never);
+    await Promise.resolve();
+    state.sessionKey = "agent:main:latest";
+    const latestSync = syncSelectedSessionMessageSubscription(state as never);
+    await Promise.resolve();
+
+    resolveLatestRetry();
+    await latestSync;
+    resolveSecondRetry();
+    await secondSync;
+
+    expect(state.chatSessionMessageSubscriptionRequestedKey).toBe("agent:main:latest");
+    expect(state.chatSessionMessageSubscription).toEqual({
+      key: "agent:main:latest",
+      agentId: null,
+    });
+    expect(subscribeMessages).not.toHaveBeenCalledWith("agent:main:second", expect.anything());
+  });
+});

--- a/ui/src/pages/chat/chat-history.test.ts
+++ b/ui/src/pages/chat/chat-history.test.ts
@@ -98,7 +98,10 @@ describe("syncSelectedSessionMessageSubscription", () => {
     await Promise.resolve();
 
     expect(unsubscribeMessages).toHaveBeenCalledOnce();
-    expect(subscribeMessages).toHaveBeenCalledWith("agent:main:next", { agentId: undefined });
+    expect(subscribeMessages).toHaveBeenCalledWith("agent:main:next", {
+      agentId: undefined,
+      includeApprovals: true,
+    });
     expect(state.chatSessionMessageSubscription).toEqual({
       key: "agent:main:previous",
       agentId: null,

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -880,9 +880,6 @@ export async function syncSelectedSessionMessageSubscription(
   if (!nextKey) {
     return;
   }
-  await retryPendingSessionMessageSubscriptionReleases(state);
-  const paneRequests = getChatHistoryPaneRequests(state);
-  const generation = ++paneRequests.subscriptionGeneration;
   const previousRequestedKey = normalizeSubscriptionKey(
     state.chatSessionMessageSubscriptionRequestedKey,
   );
@@ -894,6 +891,13 @@ export async function syncSelectedSessionMessageSubscription(
     nextSubscriptionAgentId !== null &&
     previousSelectedKey === nextKey &&
     (previousSubscription?.agentId ?? null) !== nextSubscriptionAgentId;
+  if (selectedAgentChanged) {
+    state.chatSessionApprovalQueue = [];
+    state.requestUpdate?.();
+  }
+  const paneRequests = getChatHistoryPaneRequests(state);
+  const generation = ++paneRequests.subscriptionGeneration;
+  await retryPendingSessionMessageSubscriptionReleases(state);
   const selectedKeyChanged = previousSelectedKey !== null && previousSelectedKey !== nextKey;
   const shouldUnsubscribePrevious =
     previousSubscription !== null &&

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -8,6 +8,7 @@ import type {
   SessionBranch,
   SessionsListResult,
 } from "../../api/types.ts";
+import { hasOperatorApprovalsAccess } from "../../app/operator-access.ts";
 import type { ChatMetadataResult } from "../../lib/chat/chat-metadata-store.ts";
 import { accumulatedStreamText, advanceAccumulatedStreamText } from "../../lib/chat/chat-types.ts";
 import {
@@ -66,6 +67,7 @@ import {
   setChatRunError,
 } from "./run-lifecycle.ts";
 import { scheduleChatScroll } from "./scroll.ts";
+import { projectSessionApprovalReplay } from "./session-approval-projection.ts";
 import { applySessionMessagePayload } from "./session-message-apply.ts";
 import {
   cacheChatSessionSnapshot,
@@ -836,6 +838,7 @@ export function disposeSelectedSessionMessageSubscription(state: ChatState): voi
   }
   state.chatSessionMessageSubscriptionRequestedKey = null;
   state.chatSessionMessageSubscription = null;
+  state.chatSessionApprovalQueue = [];
   const sessions = state.sessions;
   if (!sessions?.unsubscribeMessages) {
     return;
@@ -949,6 +952,9 @@ export async function syncSelectedSessionMessageSubscription(
       shouldSubscribe && isCurrent()
         ? state.sessions.subscribeMessages(nextKey, {
             agentId: nextSubscriptionAgentId ?? undefined,
+            ...(hasOperatorApprovalsAccess(state.hello?.auth ?? null)
+              ? { includeApprovals: true }
+              : {}),
           })
         : Promise.resolve(null);
     // Gateway subscriptions are independent canonical-key entries. Overlap the old
@@ -1012,6 +1018,15 @@ export async function syncSelectedSessionMessageSubscription(
     }
     state.chatSessionMessageSubscriptionRequestedKey = nextKey;
     state.chatSessionMessageSubscription = subscribed;
+    if (subscribed.includeApprovals) {
+      state.chatSessionApprovalQueue = projectSessionApprovalReplay(
+        subscribed.approvalReplay,
+        subscribed.key,
+        subscribed.agentId ?? undefined,
+      );
+    } else {
+      state.chatSessionApprovalQueue = [];
+    }
     clearRecoveredError();
   } catch (err) {
     if (isCurrent()) {

--- a/ui/src/pages/chat/chat-pane-identity.test.ts
+++ b/ui/src/pages/chat/chat-pane-identity.test.ts
@@ -1,12 +1,140 @@
 /* @vitest-environment jsdom */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
-import { createTestChatPane } from "./chat-pane.test-support.ts";
+import {
+  createSessionCapabilityFixture,
+  createSessionContext,
+  createTestChatPane,
+  type TestChatPane,
+} from "./chat-pane.test-support.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 
 describe("chat pane assistant identity snapshots", () => {
+  it("rebinds approval delivery when the selected global agent changes", async () => {
+    const replacement = createDeferred<{
+      key: string;
+      agentId: string;
+      includeApprovals: true;
+      approvalReplay: { sessionKey: string; updatedAtMs: number; approvals: []; truncated: false };
+    }>();
+    const subscribeMessages = vi.fn(
+      async (key: string, options?: { agentId?: string | null; includeApprovals?: boolean }) => {
+        const agentId = options?.agentId ?? null;
+        if (agentId === "research") {
+          return replacement.promise;
+        }
+        return {
+          key,
+          agentId,
+          includeApprovals: true as const,
+          approvalReplay: {
+            sessionKey: "agent:main:global",
+            updatedAtMs: 1,
+            approvals: [],
+            truncated: false as const,
+          },
+        };
+      },
+    );
+    const unsubscribeMessages = vi.fn(async () => undefined);
+    const sessions = createSessionCapabilityFixture({
+      state: {
+        result: null,
+        agentId: null,
+        modelOverrides: {},
+        loading: false,
+        error: null,
+        deletedSessions: [],
+        groups: [],
+        groupSettings: [],
+        sectionOrder: [],
+      },
+      subscribe: () => () => undefined,
+      subscribeMessages,
+      unsubscribeMessages,
+    });
+    const client = { request: vi.fn(async () => ({})) } as unknown as GatewayBrowserClient;
+    const context = createSessionContext(client, sessions);
+    Object.assign(context.agents, { ensureList: vi.fn(async () => null) });
+    Object.assign(context.config.current, {
+      allowExternalEmbedUrls: false,
+      embedSandboxMode: "strict",
+      localMediaPreviewRoots: [],
+      serverVersion: null,
+    });
+    Object.assign(context.config, { subscribe: () => () => undefined });
+    Object.assign(context, {
+      placementStartup: {
+        get: () => null,
+        hasPendingTurn: () => false,
+        retry: () => undefined,
+        subscribe: () => () => undefined,
+      },
+      runtimeConfig: {
+        state: { configNeedsApply: false, configSnapshot: null },
+        subscribe: () => () => undefined,
+      },
+    });
+    const { pane } = createTestChatPane({ client, sessions });
+    pane.context = context;
+    pane.connectedClient = null;
+    pane.sessionKey = "global";
+    (pane as TestChatPane & { render: () => null }).render = () => null;
+
+    try {
+      pane.connectedCallback();
+      await vi.waitFor(() =>
+        expect(subscribeMessages).toHaveBeenCalledWith("global", {
+          agentId: "main",
+          includeApprovals: true,
+        }),
+      );
+      pane.state.chatSessionApprovalQueue = [
+        {
+          id: "stale-main-approval",
+          kind: "exec",
+          request: { command: "echo stale", agentId: "main", sessionKey: "global" },
+          createdAtMs: 1,
+          expiresAtMs: 10_000,
+        },
+      ];
+
+      context.agentSelection.set("research");
+
+      expect(pane.state.chatSessionApprovalQueue).toEqual([]);
+      await vi.waitFor(() =>
+        expect(subscribeMessages).toHaveBeenCalledWith("global", {
+          agentId: "research",
+          includeApprovals: true,
+        }),
+      );
+      expect(unsubscribeMessages).toHaveBeenCalledWith(
+        expect.objectContaining({ key: "global", agentId: "main" }),
+      );
+      replacement.resolve({
+        key: "global",
+        agentId: "research",
+        includeApprovals: true,
+        approvalReplay: {
+          sessionKey: "agent:research:global",
+          updatedAtMs: 2,
+          approvals: [],
+          truncated: false,
+        },
+      });
+      await vi.waitFor(() =>
+        expect(pane.state.chatSessionMessageSubscription).toEqual(
+          expect.objectContaining({ key: "global", agentId: "research" }),
+        ),
+      );
+    } finally {
+      pane.disconnectedCallback();
+    }
+  });
+
   it("keeps a session-specific assistant identity across ordinary gateway snapshots", () => {
     const client = {} as GatewayBrowserClient;
     const { pane } = createTestChatPane({ client, sessions: {} as SessionCapability });

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -30,6 +30,7 @@ import { parseCatalogSessionKey } from "../../lib/sessions/catalog-key.ts";
 import { resolveSessionKey } from "../../lib/sessions/index.ts";
 import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
 import { invalidateChatAvatarCache, refreshChatAvatar } from "./chat-avatar.ts";
+import { syncSelectedSessionMessageSubscription } from "./chat-history.ts";
 import {
   type ChatAttachmentGatewayOwner,
   discardStateStagedAttachments,
@@ -543,9 +544,12 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
     chatState.addCleanup(() => this.removeEventListener(WIDGET_PROMPT_EVENT, handleWidgetPrompt));
     chatState.addCleanup(this.context.gateway.subscribe((next) => this.applyGatewaySnapshot(next)));
     chatState.addCleanup(
-      this.context.agentSelection.subscribe((next) =>
-        applySelectedChatAgent(this.state, next.selectedId),
-      ),
+      this.context.agentSelection.subscribe((next) => {
+        applySelectedChatAgent(this.state, next.selectedId);
+        if (this.state) {
+          void syncSelectedSessionMessageSubscription(this.state);
+        }
+      }),
     );
     const sessionPullRequests = sessionPullRequestsForGateway(this.context.gateway);
     chatState.addCleanup(

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -143,10 +143,9 @@ export class ChatPane extends ChatPaneLayoutRender {
     const currentAgentId = resolveChatAgentId(state);
     const { catalogKey, chatProps } = resolveChatMessageAccess(state);
     const overlays = this.context?.overlays;
-    const inlineApproval = findInlineApproval(
-      overlays?.snapshot?.approvalQueue ?? [],
-      state.sessionKey,
-    );
+    const inlineApproval =
+      findInlineApproval(state.chatSessionApprovalQueue ?? [], state.sessionKey) ??
+      findInlineApproval(overlays?.snapshot?.approvalQueue ?? [], state.sessionKey);
     // Tool rows consult the global title store while rendering. Requests capture
     // session + agent at schedule time, so another pane cannot re-route them.
     configureToolTitleFetcher({
@@ -422,7 +421,8 @@ export class ChatPane extends ChatPaneLayoutRender {
       approvalErrors: overlays?.snapshot?.approvalErrors,
       onApprovalDecision:
         overlays && !sessionParticipationBlocked
-          ? (approvalId, decision) => overlays.decideApproval(decision, approvalId)
+          ? (approvalId, decision) =>
+              overlays.decideApproval(decision, approvalId, inlineApproval ?? undefined)
           : undefined,
       workspaceConflict: visibleWorkspaceConflict,
       onDismissWorkspaceConflict:

--- a/ui/src/pages/chat/chat-state-contract.ts
+++ b/ui/src/pages/chat/chat-state-contract.ts
@@ -1,5 +1,6 @@
 import type { GatewayBrowserClient, GatewayHelloOk } from "../../api/gateway.ts";
 import type { AgentsListResult, GatewaySessionRow, SessionBranch } from "../../api/types.ts";
+import type { ExecApprovalRequest } from "../../app/exec-approval.ts";
 import type { ApplicationInitialUserMessageHandoff } from "../../app/initial-user-message-handoff.ts";
 import type { AuthenticatedUser } from "../../app/user-profile.ts";
 import type { ChatAttachment, ChatQueueItem } from "../../lib/chat/chat-types.ts";
@@ -67,6 +68,7 @@ export type ChatState = StreamCausalBoundaryState & {
   sessions?: Partial<SessionCapability>;
   chatSessionMessageSubscriptionRequestedKey?: string | null;
   chatSessionMessageSubscription?: SessionMessageSubscription | null;
+  chatSessionApprovalQueue?: ExecApprovalRequest[];
   chatBranches?: SessionBranch[];
   chatBranchesSessionKey?: string | null;
   chatBranchesConnectionEpoch?: number | null;

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -67,6 +67,7 @@ import {
   reconcileChatRunFromSessionRow,
   reconcileChatRunAfterSessionStatePublication,
 } from "./run-lifecycle.ts";
+import { reconcileSessionApprovalEvent } from "./session-approval-projection.ts";
 import { applySessionMessagePayload } from "./session-message-apply.ts";
 import { isSidebarSlotVisible } from "./sidebar-layout.ts";
 import { rememberAuthoritativeTerminal } from "./terminal-message-identity.ts";
@@ -533,6 +534,23 @@ export function handlePageGatewayEvent(
   event: GatewayEventFrame,
   isPresented: ChatPanePresentation = () => true,
 ) {
+  if (event.event === "session.approval") {
+    const payload = asNullableRecord(event.payload);
+    if (!payload || typeof payload.sessionKey !== "string") {
+      return;
+    }
+    const queue = reconcileSessionApprovalEvent(
+      state.chatSessionApprovalQueue ?? [],
+      payload,
+      state.sessionKey,
+      resolveChatAgentId(state),
+    );
+    if (queue) {
+      state.chatSessionApprovalQueue = queue;
+      requestChatPageUpdate(state);
+    }
+    return;
+  }
   if (event.event === "chat") {
     const payload = event.payload as ChatEventPayload | undefined;
     const sessionMatches = Boolean(

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -95,6 +95,110 @@ describe("canonical session message recovery", () => {
     });
   }
 
+  it("reconciles live approval events for the selected session", () => {
+    const { state } = createSessionEventState();
+    const approval = {
+      id: "plugin:approval-live",
+      status: "pending" as const,
+      presentation: {
+        kind: "plugin" as const,
+        title: "Run Codex execution on node",
+        description: "Allows node account access",
+        severity: "critical" as const,
+        pluginId: "codex",
+        agentId: "main",
+        allowedDecisions: ["allow-once", "deny"] as const,
+      },
+      urlPath: "/approve/plugin%3Aapproval-live",
+      createdAtMs: 1_000,
+      expiresAtMs: 10_000,
+    };
+
+    handlePageGatewayEvent(state, {
+      type: "event",
+      event: "session.approval",
+      payload: {
+        sessionKey: "agent:main:main",
+        sourceSessionKey: "agent:main:cloud-child",
+        phase: "pending",
+        updatedAtMs: 1_000,
+        approval,
+      },
+      seq: 1,
+    });
+
+    expect(state.chatSessionApprovalQueue).toEqual([
+      expect.objectContaining({
+        id: approval.id,
+        sourceSessionKey: "agent:main:cloud-child",
+      }),
+    ]);
+
+    handlePageGatewayEvent(state, {
+      type: "event",
+      event: "session.approval",
+      payload: {
+        sessionKey: "agent:main:main",
+        sourceSessionKey: "agent:main:cloud-child",
+        phase: "terminal",
+        updatedAtMs: 2_000,
+        approval: {
+          ...approval,
+          status: "denied",
+          decision: "deny",
+          reason: "user",
+          resolvedAtMs: 2_000,
+        },
+      },
+      seq: 2,
+    });
+
+    expect(state.chatSessionApprovalQueue).toEqual([]);
+
+    state.sessionKey = "global";
+    state.assistantAgentId = "research";
+    handlePageGatewayEvent(state, {
+      type: "event",
+      event: "session.approval",
+      payload: {
+        sessionKey: "agent:research:global",
+        phase: "pending",
+        updatedAtMs: 3_000,
+        approval,
+      },
+      seq: 3,
+    });
+    expect(state.chatSessionApprovalQueue).toEqual([
+      expect.objectContaining({
+        id: approval.id,
+        request: expect.objectContaining({ sessionKey: "global" }),
+      }),
+    ]);
+
+    for (const [sessionKey, expectedCount] of [
+      ["agent:main:global", 1],
+      ["agent:research:global", 0],
+    ] as const) {
+      handlePageGatewayEvent(state, {
+        type: "event",
+        event: "session.approval",
+        payload: {
+          sessionKey,
+          phase: "terminal",
+          updatedAtMs: 4_000,
+          approval: {
+            ...approval,
+            status: "denied",
+            decision: "deny",
+            reason: "user",
+            resolvedAtMs: 4_000,
+          },
+        },
+      });
+      expect(state.chatSessionApprovalQueue).toHaveLength(expectedCount);
+    }
+  });
+
   it("rejects envelope-only sequence for an incomplete imported user identity", () => {
     const { state } = createSessionEventState({ connected: false });
 

--- a/ui/src/pages/chat/route-view.ts
+++ b/ui/src/pages/chat/route-view.ts
@@ -1,0 +1,77 @@
+import type { RouteMatch } from "@openclaw/uirouter";
+import { html, nothing } from "lit";
+import { renderPanelErrorState } from "../../components/lazy-view-error.ts";
+import { t } from "../../i18n/index.ts";
+import type { ChatRouteData } from "./route-loader.ts";
+
+const CHAT_PAGE_OWNER_KEY = "chat-page";
+
+function navigateTo(href: string) {
+  window.history.pushState({}, "", href);
+  window.dispatchEvent(new PopStateEvent("popstate"));
+}
+
+function renderAmbiguous(data: Extract<ChatRouteData, { kind: "ambiguous" }>) {
+  return html`
+    <section class="card">
+      <h2>${t("chat.sessionRoute.chooseTitle")}</h2>
+      <p>
+        ${data.candidates.length > 1
+          ? t("chat.sessionRoute.multipleMatches", { shortId: data.shortId })
+          : t("chat.sessionRoute.additionalMatches")}
+      </p>
+      ${data.candidates.map(
+        (candidate) => html`
+          <p>
+            <a href=${candidate.href}>${candidate.displayName}</a><br />
+            <small>${candidate.agentId} · ${candidate.idPrefix}</small>
+          </p>
+        `,
+      )}
+      ${data.truncated && data.candidates.length > 1
+        ? html`<p><small>${t("chat.sessionRoute.additionalMatches")}</small></p>`
+        : null}
+    </section>
+  `;
+}
+
+function renderMissingSession(data: Extract<ChatRouteData, { kind: "missing-session" }>) {
+  return renderPanelErrorState({
+    className: "session-route-not-found",
+    role: "status",
+    title: t("chat.sessionRoute.notFoundTitle"),
+    subtitle: t("chat.sessionRoute.notFoundExplanation"),
+    actions: html`
+      <button class="btn primary" type="button" @click=${() => navigateTo(data.currentSessionHref)}>
+        ${t("chat.sessionRoute.goToMain")}
+      </button>
+      <button class="btn" type="button" @click=${() => navigateTo(data.sessionsHref)}>
+        ${t("chat.sessionRoute.viewSessions")}
+      </button>
+    `,
+  });
+}
+
+export function renderChatRoute(data: unknown) {
+  // SAFETY: This renderer receives only this route's colocated ChatRouteData loader result.
+  const routeData = data as ChatRouteData | undefined;
+  if (!routeData) {
+    return nothing;
+  }
+  if (routeData.kind === "ambiguous") {
+    return renderAmbiguous(routeData);
+  }
+  if (routeData.kind === "missing-session") {
+    return renderMissingSession(routeData);
+  }
+  return html`<openclaw-chat-page .data=${routeData}></openclaw-chat-page>`;
+}
+
+export function sessionRenderOwnerKey(
+  match: Pick<RouteMatch, "data">,
+  settled: Pick<RouteMatch, "data"> | undefined,
+): string | undefined {
+  // SAFETY: Both matches carry only this route's colocated ChatRouteData loader result.
+  const data = (match.data ?? settled?.data) as ChatRouteData | undefined;
+  return data?.kind === "session" ? CHAT_PAGE_OWNER_KEY : undefined;
+}

--- a/ui/src/pages/chat/route.ts
+++ b/ui/src/pages/chat/route.ts
@@ -1,61 +1,8 @@
-import type { RouteLocation, RouteMatch } from "@openclaw/uirouter";
+import type { RouteLocation } from "@openclaw/uirouter";
 import { definePage } from "@openclaw/uirouter";
-import { html, nothing } from "lit";
 import { INTERNAL_SESSION_PATH_PARAM, pathForRoute, routePageSpec } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
-import { renderPanelErrorState } from "../../components/lazy-view-error.ts";
-import { t } from "../../i18n/index.ts";
 import type { BoardFace } from "../../lib/board/settings.ts";
-import type { ChatRouteData } from "./route-loader.ts";
-
-type SessionOwnerMatch = Pick<RouteMatch, "data">;
-const CHAT_PAGE_OWNER_KEY = "chat-page";
-
-function navigateTo(href: string) {
-  window.history.pushState({}, "", href);
-  window.dispatchEvent(new PopStateEvent("popstate"));
-}
-
-function renderAmbiguous(data: Extract<ChatRouteData, { kind: "ambiguous" }>) {
-  return html`
-    <section class="card">
-      <h2>${t("chat.sessionRoute.chooseTitle")}</h2>
-      <p>
-        ${data.candidates.length > 1
-          ? t("chat.sessionRoute.multipleMatches", { shortId: data.shortId })
-          : t("chat.sessionRoute.additionalMatches")}
-      </p>
-      ${data.candidates.map(
-        (candidate) => html`
-          <p>
-            <a href=${candidate.href}>${candidate.displayName}</a><br />
-            <small>${candidate.agentId} · ${candidate.idPrefix}</small>
-          </p>
-        `,
-      )}
-      ${data.truncated && data.candidates.length > 1
-        ? html`<p><small>${t("chat.sessionRoute.additionalMatches")}</small></p>`
-        : null}
-    </section>
-  `;
-}
-
-function renderMissingSession(data: Extract<ChatRouteData, { kind: "missing-session" }>) {
-  return renderPanelErrorState({
-    className: "session-route-not-found",
-    role: "status",
-    title: t("chat.sessionRoute.notFoundTitle"),
-    subtitle: t("chat.sessionRoute.notFoundExplanation"),
-    actions: html`
-      <button class="btn primary" type="button" @click=${() => navigateTo(data.currentSessionHref)}>
-        ${t("chat.sessionRoute.goToMain")}
-      </button>
-      <button class="btn" type="button" @click=${() => navigateTo(data.sessionsHref)}>
-        ${t("chat.sessionRoute.viewSessions")}
-      </button>
-    `,
-  });
-}
 
 function sessionLoaderDeps(
   face: BoardFace,
@@ -76,14 +23,6 @@ function sessionLoaderDeps(
   }`;
 }
 
-function sessionRenderOwnerKey(
-  match: SessionOwnerMatch,
-  settled: SessionOwnerMatch | undefined,
-): string | undefined {
-  const data = (match.data ?? settled?.data) as ChatRouteData | undefined;
-  return data?.kind === "session" ? CHAT_PAGE_OWNER_KEY : undefined;
-}
-
 function sessionPage(face: BoardFace) {
   return definePage({
     ...routePageSpec(face),
@@ -98,26 +37,15 @@ function sessionPage(face: BoardFace) {
     component: () =>
       Promise.all([
         import("./chat-page.ts"),
+        import("./route-view.ts"),
         import("../../styles/chat/composer-progress.css"),
         import("../../styles/chat/composer-queue.css"),
-      ]).then(() => ({
+      ]).then(([, { renderChatRoute, sessionRenderOwnerKey }]) => ({
         header: true,
         // ChatPage's bounded inner cache owns per-session teardown, so session
         // routes share the outer owner while their data and URL keep changing.
         renderOwnerKey: sessionRenderOwnerKey,
-        render: (data: unknown) => {
-          const routeData = data as ChatRouteData | undefined;
-          if (!routeData) {
-            return nothing;
-          }
-          if (routeData.kind === "ambiguous") {
-            return renderAmbiguous(routeData);
-          }
-          if (routeData.kind === "missing-session") {
-            return renderMissingSession(routeData);
-          }
-          return html`<openclaw-chat-page .data=${routeData}></openclaw-chat-page>`;
-        },
+        render: renderChatRoute,
       })),
   });
 }

--- a/ui/src/pages/chat/session-approval-projection.test.ts
+++ b/ui/src/pages/chat/session-approval-projection.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import {
+  projectSessionApprovalReplay,
+  reconcileSessionApprovalEvent,
+} from "./session-approval-projection.ts";
+
+const pendingPluginApproval = {
+  id: "plugin:approval-1",
+  status: "pending" as const,
+  presentation: {
+    kind: "plugin" as const,
+    title: "Run Codex execution on node",
+    description: "Allows node account access",
+    severity: "critical" as const,
+    pluginId: "codex",
+    toolName: null,
+    agentId: "main",
+    allowedDecisions: ["allow-once", "deny"] as const,
+  },
+  urlPath: "/approve/plugin%3Aapproval-1",
+  createdAtMs: 1_000,
+  expiresAtMs: 10_000,
+};
+
+describe("session approval projection", () => {
+  it("projects replay into the subscribed host session", () => {
+    const queue = projectSessionApprovalReplay(
+      {
+        sessionKey: "agent:main:host",
+        updatedAtMs: 2_000,
+        approvals: [{ ...pendingPluginApproval, sourceSessionKey: "agent:main:cloud-child" }],
+        truncated: false,
+      },
+      "agent:main:host",
+    );
+
+    expect(queue).toEqual([
+      expect.objectContaining({
+        id: "plugin:approval-1",
+        kind: "plugin",
+        pluginTitle: "Run Codex execution on node",
+        sourceSessionKey: "agent:main:cloud-child",
+        request: expect.objectContaining({ sessionKey: "agent:main:host" }),
+      }),
+    ]);
+  });
+
+  it("ignores malformed replay and live events", () => {
+    expect(projectSessionApprovalReplay({ approvals: [{}] }, "agent:main:host")).toEqual([]);
+    expect(reconcileSessionApprovalEvent([], { sessionKey: "agent:main:host" })).toBeNull();
+  });
+
+  it("ignores replay for a different session", () => {
+    expect(
+      projectSessionApprovalReplay(
+        {
+          sessionKey: "agent:main:other",
+          updatedAtMs: 2_000,
+          approvals: [pendingPluginApproval],
+          truncated: false,
+        },
+        "agent:main:host",
+      ),
+    ).toEqual([]);
+  });
+
+  it("tracks the source session for a live ancestor projection and removes terminal state", () => {
+    const pending = reconcileSessionApprovalEvent([], {
+      sessionKey: "agent:main:host",
+      sourceSessionKey: "agent:main:cloud-child",
+      phase: "pending",
+      updatedAtMs: 2_000,
+      approval: pendingPluginApproval,
+    });
+
+    expect(pending).toEqual([
+      expect.objectContaining({
+        id: "plugin:approval-1",
+        sourceSessionKey: "agent:main:cloud-child",
+        request: expect.objectContaining({ sessionKey: "agent:main:host" }),
+      }),
+    ]);
+    expect(
+      reconcileSessionApprovalEvent(pending ?? [], {
+        sessionKey: "agent:main:host",
+        sourceSessionKey: "agent:main:cloud-child",
+        phase: "terminal",
+        updatedAtMs: 3_000,
+        approval: {
+          ...pendingPluginApproval,
+          status: "denied",
+          decision: "deny",
+          reason: "user",
+          resolvedAtMs: 3_000,
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  it("projects only the selected agent's qualified global approval stream", () => {
+    const replay = {
+      sessionKey: "agent:research:global",
+      updatedAtMs: 2_000,
+      approvals: [pendingPluginApproval],
+      truncated: false,
+    };
+    expect(projectSessionApprovalReplay(replay, "global", "research")).toEqual([
+      expect.objectContaining({
+        id: "plugin:approval-1",
+        request: expect.objectContaining({ sessionKey: "global" }),
+      }),
+    ]);
+    expect(projectSessionApprovalReplay(replay, "global", "main")).toEqual([]);
+
+    const event = {
+      sessionKey: "agent:research:global",
+      phase: "pending" as const,
+      updatedAtMs: 2_000,
+      approval: pendingPluginApproval,
+    };
+    expect(reconcileSessionApprovalEvent([], event, "global", "research")).toEqual([
+      expect.objectContaining({
+        id: "plugin:approval-1",
+        request: expect.objectContaining({ sessionKey: "global" }),
+      }),
+    ]);
+    expect(reconcileSessionApprovalEvent([], event, "global", "main")).toBeNull();
+  });
+});

--- a/ui/src/pages/chat/session-approval-projection.ts
+++ b/ui/src/pages/chat/session-approval-projection.ts
@@ -1,0 +1,115 @@
+import { Value } from "typebox/value";
+import type { PendingApprovalSnapshot } from "../../../../packages/gateway-protocol/src/index.js";
+import {
+  SessionApprovalEventSchema,
+  SessionApprovalReplaySchema,
+} from "../../../../packages/gateway-protocol/src/index.js";
+import type { ExecApprovalRequest } from "../../app/exec-approval.ts";
+import {
+  isUiGlobalSessionKey,
+  normalizeAgentId,
+  parseAgentSessionKey,
+} from "../../lib/sessions/session-key.ts";
+
+function approvalStreamMatchesSession(
+  streamSessionKey: string,
+  sessionKey: string,
+  selectedAgentId?: string,
+): boolean {
+  if (streamSessionKey === sessionKey) {
+    return true;
+  }
+  const stream = parseAgentSessionKey(streamSessionKey);
+  return Boolean(
+    selectedAgentId &&
+    isUiGlobalSessionKey(sessionKey) &&
+    stream?.rest === "global" &&
+    normalizeAgentId(stream.agentId) === normalizeAgentId(selectedAgentId),
+  );
+}
+
+function projectPendingApproval(
+  approval: PendingApprovalSnapshot,
+  sessionKey: string,
+  sourceSessionKey?: string,
+): ExecApprovalRequest {
+  const presentation = approval.presentation;
+  const common = {
+    id: approval.id,
+    request: {
+      command: presentation.kind === "exec" ? presentation.commandText : presentation.title,
+      agentId: presentation.agentId ?? null,
+      sessionKey,
+      allowedDecisions: presentation.allowedDecisions,
+    },
+    ...(sourceSessionKey && sourceSessionKey !== sessionKey ? { sourceSessionKey } : {}),
+    createdAtMs: approval.createdAtMs,
+    expiresAtMs: approval.expiresAtMs,
+  } satisfies Partial<ExecApprovalRequest>;
+  if (presentation.kind === "exec") {
+    return {
+      ...common,
+      kind: "exec",
+      request: {
+        ...common.request,
+        host: presentation.host ?? null,
+      },
+    };
+  }
+  if (presentation.kind === "plugin") {
+    return {
+      ...common,
+      kind: "plugin",
+      pluginTitle: presentation.title,
+      pluginDescription: presentation.description,
+      pluginSeverity: presentation.severity,
+      pluginId: presentation.pluginId ?? null,
+    };
+  }
+  return {
+    ...common,
+    kind: "system-agent",
+    pluginTitle: presentation.title,
+    pluginDescription: presentation.description,
+    proposalHash: presentation.proposalHash,
+  };
+}
+
+export function projectSessionApprovalReplay(
+  value: unknown,
+  sessionKey: string,
+  selectedAgentId?: string,
+): ExecApprovalRequest[] {
+  if (!Value.Check(SessionApprovalReplaySchema, value)) {
+    return [];
+  }
+  const replay = Value.Decode(SessionApprovalReplaySchema, value);
+  if (!approvalStreamMatchesSession(replay.sessionKey, sessionKey, selectedAgentId)) {
+    return [];
+  }
+  return replay.approvals
+    .filter((approval) => approval.status === "pending")
+    .map((approval) => projectPendingApproval(approval, sessionKey, approval.sourceSessionKey));
+}
+
+export function reconcileSessionApprovalEvent(
+  queue: readonly ExecApprovalRequest[],
+  value: unknown,
+  sessionKey?: string,
+  selectedAgentId?: string,
+): ExecApprovalRequest[] | null {
+  if (!Value.Check(SessionApprovalEventSchema, value)) {
+    return null;
+  }
+  const event = Value.Decode(SessionApprovalEventSchema, value);
+  const presentationSessionKey = sessionKey ?? event.sessionKey;
+  if (!approvalStreamMatchesSession(event.sessionKey, presentationSessionKey, selectedAgentId)) {
+    return null;
+  }
+  if (event.phase === "terminal") {
+    return queue.filter((entry) => entry.id !== event.approval.id);
+  }
+  const next = queue.filter((entry) => entry.id !== event.approval.id);
+  next.push(projectPendingApproval(event.approval, presentationSessionKey, event.sourceSessionKey));
+  return next.toSorted((left, right) => left.createdAtMs - right.createdAtMs);
+}


### PR DESCRIPTION
Follow-up to #130967.

AI-assisted: implemented and reviewed with Codex.

## What Problem This Solves

Fixes an issue where operators controlling a Codex cloud or paired-node session could see its approval only in the global inbox, not inline in the controlling host or ancestor chat. The approval lacked trusted session provenance at the node-invocation boundary, and selected chats did not subscribe to authorized session-scoped approval projection.

## Why This Change Was Made

The Gateway now carries host-attested session provenance only through trusted official plugin node invocations, while retaining signed agent-runtime identity as the higher-precedence authority and rejecting plugin-asserted provenance. Existing approval audience expansion remains the canonical routing owner. The Control UI opts authorized selected chats into session approval replay/live events, maintains a pane-local queue, identifies child-originated approvals, and leaves the global inbox unchanged.

This adds one optional Gateway protocol field (`sourceSessionKey`) for pending session approval snapshots. It does not change the plugin SDK, configuration, SQLite schema, or persistent state. `chatSessionApprovalQueue` is transient pane memory and is cleared with its subscription.

Raw production delta against current `main` is +303/-97. Discounting the render-only route module move gives judged production +227/-21 (net +206); tests/test-support are +300/-10, generated Swift +5/-1, and the assertion-safety baseline shrinks by one entry. The growth implements the previously missing trusted provenance path and pane-local replay/live projection; no obsolete production path or parallel durable owner remains.

## User Impact

Operators can review and resolve a Codex node-execution approval in the chat that controls the work, including when the request originated in a child/cloud session. Ancestor projections are labeled with the requesting session so the operator can distinguish their source.

## Evidence

- Live managed Gateway/Control UI verification: a real Codex node-execution approval appeared inline in the controlling chat with **Allow once** and **Deny** actions. The global inbox continued to show the same authoritative approval rather than a duplicate record.
- Addressed review feedback for global sessions: replay and live events on `agent:<selected-agent>:global` now project to the visible `global` chat, while another agent's qualified global stream is rejected. The regression failed against the previous projection and now passes.
- Direct current Codex source inspection: command approvals carry `thread_id`, `turn_id`, and `item_id` in `codex-rs/app-server-protocol/src/protocol/v2/item.rs:1447-1521`; the app server constructs and sends that request in `codex-rs/app-server/src/bespoke_event_handling.rs:1967-2008`. OpenClaw therefore owns the trusted managed-node-to-OpenClaw-session mapping.
- Focused Gateway/protocol tests: 4 files, 128 tests passed.
- Focused Control UI tests: 5 files, 144 tests passed.
- Exact-head CI exposed a pre-existing Playwright helper race: an in-page Promise waiting for `wa-after-hide` could be garbage-collected before the event. The redundant event wait was removed while retaining the authoritative `dropdown.open !== true` state wait; the failed mobile E2E passed 5 consecutive runs and all 5 helper-consumer suites passed (21 E2Es).
- The next exact-head run exposed a current-`main` Control UI startup-budget regression: its merge parent was already 375 B over the growth limit. Render-only chat route code introduced on `main` bypassed the route component's existing lazy import. Moving that code behind the same lazy boundary restores the startup bundle to 346,975 B against the 347,037 B enforcement limit without changing the baseline.
- Focused route, route-resolution, router-outlet, and approval UI suites: 8 files, 196 tests passed; the missing-session browser E2E passed.
- Unified protocol validator: 8 tests passed.
- `pnpm protocol:check`: TypeScript schema plus Swift and Kotlin generation are consistent.
- `pnpm build`: passed on the final rebased head, including all nine unified bundle invocations, CLI bootstrap imports, 63 plugin distributions, plugin SDK export checks, runtime postbuild, and Control UI startup at 344,803 B versus the 345,947 B enforcement limit.
- `pnpm check:changed`: formatting, dependency/boundary/dead-code/i18n, core and test typechecks, UI typecheck, and core/UI lint passed. The app lane initially lacked the fresh worktree's pinned SwiftLint on `PATH`; after installing the repository-pinned tools, full Swift lint passed with 0 violations across 713 files.
- Fresh whole-branch autoreview on the final rebased head (Codex, `gpt-5.6-sol`, high): no accepted/actionable findings, confidence 0.97. Earlier focused repair reviews were also clean.
- Final exact-head GitHub CI: run 33223395351 for `49e57f1e69c1f688b6c8e8d1afeb4967287d4b5b` (running).

### Live Control UI proof

Inline approval in the controlling chat:

![Codex node approval shown inline in the controlling chat](https://github.com/user-attachments/assets/aca92212-7732-4183-98c2-4b09ed6af620)

The same authoritative approval shown inline and in the global inbox:

![Codex node approval shown in the controlling chat and global approval inbox](https://github.com/user-attachments/assets/400ba766-091c-4004-b983-c40a17ad3fbb)

## Worked on by

- Josh Lehman (@jalehman)

- Final current-main reconciliation: main introduced the canonical `ui-pages` TypeScript test partition while this PR waited, so the temporary chat shard was removed. The exact PR graph passes the 720-root boundary unchanged; 25 focused exact-head tests and the full changed-surface gate pass.
