### PR TITLE
fix: show recorded delivery suppression in automation history

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -386,6 +386,7 @@ select it to open the owning Approvals page.
   </Accordion>
   <Accordion title="Automations panel notes">
     - Selecting a row opens a full-page detail view with an Active/Paused switch and Run now in the header (run-if-due, clone, and remove in its menu); the Settings tab edits the automation inline (prompt, details, frequency, advanced overrides) and the Run history tab shows that automation's runs.
+    - Both Run history views show a recorded delivery-suppression reason alongside the delivery status when available. Intentional suppression remains separate from delivery errors; the history does not infer a reason from a successful run.
     - Starter automations under the table prefill the create form with an editable prompt and schedule.
     - For isolated tasks, delivery defaults to announce summary; switch to none for internal-only runs.
     - Channel/target fields appear when announce is selected.

--- a/ui/src/e2e/cron-run-suppression.e2e.test.ts
+++ b/ui/src/e2e/cron-run-suppression.e2e.test.ts
@@ -1,0 +1,138 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import type { CronJob, CronRunLogEntry } from "../api/types.ts";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI cron recorded delivery suppression",
+  startServerBeforeBrowser: true,
+});
+
+suite.define(() => {
+  it("shows recorded suppression independently of delivery failure in both history views", async () => {
+    const job: CronJob = {
+      id: "delivery-history-proof",
+      name: "Delivery history proof",
+      enabled: true,
+      createdAtMs: 1_000,
+      updatedAtMs: 2_000,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: { kind: "agentTurn", message: "Check for pending work." },
+      delivery: { mode: "announce", channel: "last", bestEffort: true },
+      state: {},
+    };
+    const entries: CronRunLogEntry[] = [
+      {
+        ts: 4_000,
+        jobId: job.id,
+        action: "finished",
+        status: "ok",
+        completionStatus: "succeeded",
+        delivered: false,
+        deliveryStatus: "not-delivered",
+        deliverySuppressionReason: "silent",
+        summary: "Polling completed.",
+      },
+      {
+        ts: 3_000,
+        jobId: job.id,
+        action: "finished",
+        status: "ok",
+        completionStatus: "succeeded",
+        delivered: false,
+        deliveryStatus: "not-delivered",
+        deliveryError: "Synthetic delivery target unavailable.",
+        summary: "Polling completed.",
+      },
+    ];
+    await suite.withPage(
+      { locale: "en-US", viewport: { width: 1_280, height: 900 } },
+      async ({ page }) => {
+        const pageErrors: string[] = [];
+        page.on("pageerror", (error) => pageErrors.push(error.message));
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "cron.list": {
+              jobs: [job],
+              snapshotRevision: "delivery-history-proof",
+              total: 1,
+              offset: 0,
+              limit: 50,
+              nextOffset: null,
+              hasMore: false,
+            },
+            "cron.runs": {
+              entries,
+              total: entries.length,
+              offset: 0,
+              limit: 50,
+              nextOffset: null,
+              hasMore: false,
+            },
+            "cron.status": { enabled: true, triggersEnabled: true, jobs: 1 },
+          },
+        });
+        const response = await page.goto(`${suite.server.baseUrl}cron`);
+        expect(response?.status()).toBe(200);
+        await page.locator('[data-test-id="cron-list-tab-activity"]').click();
+
+        for (const scope of ["all", "job"] as const) {
+          if (scope === "job") {
+            await page.locator('[data-test-id="cron-list-tab-tasks"]').click();
+            await page
+              .locator(`[data-test-id="cron-row-${job.id}"] .cron-table__name-text`)
+              .click();
+            await page.locator('[data-test-id="cron-detail-tab-history"]').click();
+          }
+          await expect
+            .poll(async () =>
+              (await gateway.getRequests("cron.runs")).some((request) => {
+                const params = request.params as { scope?: string; id?: string };
+                return params.scope === scope && (scope === "all" || params.id === job.id);
+              }),
+            )
+            .toBe(true);
+          const history = page.locator(scope === "all" ? ".cron-activity" : ".cron-history");
+          await history.waitFor({ state: "visible" });
+          const runs = history.locator(".cron-run-entry");
+          await expect.poll(() => runs.count()).toBe(2);
+          const suppressed = runs.nth(0);
+          const failedDelivery = runs.nth(1);
+          for (const run of [suppressed, failedDelivery]) {
+            expect(await run.locator(".cron-run-entry__title").textContent()).toContain("OK");
+            expect(await run.locator(".cron-run-entry__facts").textContent()).toContain(
+              "Not delivered",
+            );
+            expect(await run.locator(".cron-run-entry__body").textContent()).toContain(
+              "Polling completed.",
+            );
+          }
+          expect(await failedDelivery.textContent()).toContain(
+            "Synthetic delivery target unavailable.",
+          );
+          expect(await failedDelivery.textContent()).not.toContain("Delivery suppression:");
+          expect(await suppressed.textContent()).not.toContain(
+            "Synthetic delivery target unavailable.",
+          );
+          const artifactDir = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR;
+          if (artifactDir) {
+            await fs.mkdir(artifactDir, { recursive: true });
+            // Only the synthetic suppressed row is captured, never the error row.
+            await suppressed.screenshot({
+              path: path.join(artifactDir, `${scope}-suppressed.png`),
+            });
+          }
+          // Keep both consumers observable in the original failing run.
+          expect
+            .soft(await suppressed.textContent(), `${scope} recorded suppression`)
+            .toContain("Delivery suppression: silent");
+        }
+        expect(pageErrors).toEqual([]);
+      },
+    );
+  });
+});

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -6869,6 +6869,7 @@ export const en: TranslationMap = {
     },
     runEntry: {
       noSummary: "No summary.",
+      deliverySuppression: "Delivery suppression: {reason}",
       runAt: "Run at",
       openRunChat: "Open run chat",
       next: "Next {rel}",

--- a/ui/src/pages/cron/view-run-history.test.ts
+++ b/ui/src/pages/cron/view-run-history.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
-import { renderCronView as renderView } from "./view.test-support.ts";
+import type { CronRunLogEntry } from "../../api/types.ts";
+import { createCronViewJob, renderCronView as renderView } from "./view.test-support.ts";
 
 function getElement<T extends Element>(
   container: Element,
@@ -171,5 +172,130 @@ describe("cron view run history", () => {
 
     const filtered = renderView({ listTab: "activity", runsQuery: "fail" });
     expect(filtered.querySelector(".cron-runs__empty")?.textContent).toContain("No matching runs.");
+  });
+
+  it.each(["overview", "job"] as const)(
+    "shows recorded suppression without reclassifying delivery in %s history",
+    (scope) => {
+      const reasons = ["empty", "silent", "heartbeat", "channel_transform"];
+      const runs: CronRunLogEntry[] = reasons.map((reason, index) => ({
+        ts: index + 1,
+        jobId: "job-1",
+        action: "finished",
+        status: "ok",
+        completionStatus: "succeeded",
+        deliveryStatus: "not-delivered",
+        delivered: false,
+        deliverySuppressionReason: reason,
+        summary: `Recorded ${reason}`,
+      }));
+      runs.push(
+        {
+          ts: 5,
+          jobId: "job-1",
+          action: "finished",
+          status: "ok",
+          completionStatus: "succeeded",
+          deliveryStatus: "not-delivered",
+          deliveryError: "Synthetic delivery target unavailable.",
+          summary: "Best-effort failure",
+        },
+        {
+          ts: 6,
+          jobId: "job-1",
+          action: "finished",
+          status: "error",
+          error: "Synthetic execution failure.",
+          deliveryStatus: "not-delivered",
+          summary: "Execution failure",
+        },
+        {
+          ts: 7,
+          jobId: "job-1",
+          action: "finished",
+          status: "ok",
+          deliveryStatus: "delivered",
+          summary: "Successful delivery",
+        },
+        {
+          ts: 8,
+          jobId: "job-1",
+          action: "finished",
+          status: "ok",
+          deliveryStatus: "not-requested",
+          summary: "Internal run",
+        },
+        {
+          ts: 9,
+          jobId: "job-1",
+          action: "finished",
+          status: "ok",
+          deliveryStatus: "not-delivered",
+          summary: "No recorded reason",
+        },
+      );
+      const container = renderView({
+        listTab: "activity",
+        editingJob: scope === "job" ? createCronViewJob("job-1", { state: {} }) : null,
+        detailTab: "history",
+        runs,
+      });
+      const history = getElement(
+        container,
+        scope === "overview" ? ".cron-activity" : ".cron-history",
+        HTMLDivElement,
+      );
+      const entries = Array.from(history.querySelectorAll(".cron-run-entry"));
+      expect(entries).toHaveLength(runs.length);
+      for (const run of runs) {
+        const entry = entries.find((candidate) =>
+          candidate.querySelector(".cron-run-entry__body")?.textContent?.includes(run.summary!),
+        );
+        expect(entry).toBeDefined();
+        const facts = entry?.querySelector(".cron-run-entry__facts")?.textContent ?? "";
+        if (run.deliverySuppressionReason) {
+          expect(facts).toContain(`Delivery suppression: ${run.deliverySuppressionReason}`);
+          expect(facts).toContain("Not delivered");
+          expect(entry?.querySelector(".cron-run-entry__title")?.textContent).toContain("OK");
+        } else {
+          expect(facts).not.toContain("Delivery suppression:");
+        }
+        if (run.deliveryError) {
+          expect(entry?.textContent).toContain(run.deliveryError);
+          expect(facts).toContain("Not delivered");
+        }
+        if (run.error) {
+          expect(entry?.textContent).toContain(run.error);
+          expect(entry?.querySelector(".cron-run-entry__title")?.textContent).toContain("Error");
+        }
+        if (run.deliveryStatus === "delivered") {
+          expect(facts).toContain("Delivered");
+        }
+        if (run.deliveryStatus === "not-requested") {
+          expect(facts).toContain("Not requested");
+        }
+      }
+    },
+  );
+
+  it("redacts and escapes server-provided suppression text in run facts", () => {
+    const container = renderView({
+      listTab: "activity",
+      runs: [
+        {
+          ts: 1,
+          jobId: "job-1",
+          action: "finished",
+          status: "ok",
+          deliveryStatus: "not-delivered",
+          deliverySuppressionReason: "silent <img src=x onerror=alert(1)> Bearer abcdefghijkl",
+        },
+      ],
+    });
+    const facts = getElement(container, ".cron-run-entry__facts", HTMLDivElement);
+    expect(facts.textContent).toContain("Delivery suppression: silent <img");
+    expect(facts.textContent).toContain("Bearer [redacted]");
+    expect(facts.textContent).not.toContain("abcdefghijkl");
+    expect(facts.querySelector("img")).toBeNull();
   });
 });

--- a/ui/src/pages/cron/view-runs.ts
+++ b/ui/src/pages/cron/view-runs.ts
@@ -414,7 +414,16 @@ function renderRun(
   const bodySource =
     entry.summary || formatUiExternalText(entry.error) || t("cron.runEntry.noSummary");
   const showErrorInMeta = Boolean(entry.error) && Boolean(entry.summary);
-  const facts = [delivery, entry.model, entry.provider, usageSummary].filter(Boolean);
+  const suppressionReason = formatUiExternalText(entry.deliverySuppressionReason);
+  const facts = [
+    delivery,
+    suppressionReason
+      ? t("cron.runEntry.deliverySuppression", { reason: suppressionReason })
+      : null,
+    entry.model,
+    entry.provider,
+    usageSummary,
+  ].filter(Boolean);
   const highlighted = Boolean(highlightedRunId && cronRunEntryMatchesLink(highlightedRunId, entry));
   return html`
     <div class="cron-run-entry ${highlighted ? "cron-run-entry--highlighted" : ""}">


### PR DESCRIPTION
Related: #111851. Control UI follow-through to #131774; this PR does not close #111851.

<details>
<summary>Additional instructions</summary>

The head branch is in the base repository, `openclaw/openclaw`.

</details>

## What Problem This Solves

Fixes an issue where operators reviewing an intentionally suppressed automation run could not see its recorded delivery-suppression reason in either the overview run history or the individual automation's history. The UI already showed the neutral **Not delivered** label and actual delivery errors; it omitted the separate reason already returned by the Gateway.

## Why This Change Was Made

Both history views share one run-entry renderer. It now displays the recorded reason in the existing facts row, with one localized label and the existing external-text redaction and text escaping. It does not infer suppression from successful execution, introduce a delivery status or filter, or change delivery policy, the Gateway protocol, persistence, or CLI behavior. Genuine best-effort delivery failures can have successful execution too, so the recorded fact remains separate from both status and errors.

Production LOC: +11/-1 (net +10), exposing this existing diagnostic without a new helper or classification path. Tests: +265/-1; docs: +1. The renderer predates the reason producer added in #130811; this completes its UI presentation rather than repairing the delivery backend.

## User Impact

Run history now explains recorded suppression such as `silent`, `empty`, `heartbeat`, or `channel_transform` alongside the unchanged delivery status. Runs without a recorded reason do not acquire one, and real delivery errors remain visible.

## Evidence

- Real Chromium with the canonical deterministic mock-Gateway flow: the original test failed the missing-reason assertion in both distinct history views. The unchanged flow passes after the repair, including actual `cron.runs` scopes, visible consumer-specific rows, the genuine delivery-error control, and no page errors.
- Rendered regressions: three new failures on the original renderer, followed by all 12 history/accessibility tests passing. Coverage includes all four recorded reason codes, both consumers, successful execution with a genuine best-effort delivery failure, execution error, delivered/not-requested/absent-reason controls, and redaction/escaping of optional wire text.
- Keyless `ui:i18n:verify` passed without changing generated translations or baselines.
- These local results use historical trusted source `c07b7538` and its exact installed Vite 8.2.1 dependency closure; the original browser RED was on `b6aff3ef`. The affected owners are unchanged on the current base, and newer English/docs changes are preserved. This is source-Vite/mock-WebSocket proof, not a live Gateway/provider/channel/persistence test or a bundled-build result. The separate current-lock hosted proof is recorded below.
- The unchanged locale loader emitted its Vite dynamic-import-analysis warning in both rendered RED and GREEN runs; the warning was not suppressed.
- Two complementary Codex source reviews found no actionable P0–P2 findings. They cover the complete shared behavior path, tests and helpers, plus the complete English catalog and documentation.

### Current-head hosted verification

[Normal CI run 33181922483](https://github.com/openclaw/openclaw/actions/runs/33181922483) completed successfully for head `8c89e1c21237d39c4f244ad8010e2f892d9ef783`, testing merge `5f8d05350d30f06f5dbcbd65049dcceb7b931f07` with the current frozen Vite 8.2.2 lock.

- The [normal bundled UI browser shard](https://github.com/openclaw/openclaw/actions/runs/33181922483/job/98885233807) actually executed the new both-history regression: passed in 1,061 ms; the shard passed all 24 files / 96 tests. All 14 UI matrix jobs and the separate real-Gateway UI job passed. The new regression itself uses deterministic mock Gateway responses, not live delivery.
- The [UI test suite](https://github.com/openclaw/openclaw/actions/runs/33181922483/job/98885232956) passed 803 files / 11,890 tests, with one unrelated agent-memory browser case skipped. All eight history tests and four cron accessibility siblings passed, including both new consumer tables and the redaction/escaping case.
- [I18n source verification](https://github.com/openclaw/openclaw/actions/runs/33181922483/job/98885233089) passed: raw-copy baseline 83, 5,861 keys, 6,623 literal references and 67 template prefixes. The separate generated catalog fallback check reported drift and exited 1; the existing workflow explicitly treats source-only drift as advisory and assigns it to the post-merge locale bot. No generated catalog or baseline was changed here. This is not a claim that generated parity was clean.

The [latest ClawSweeper review](https://github.com/openclaw/openclaw/pull/131830#issuecomment-5454084561) found no actionable defects. Its pre-merge items are addressed by the completed exact-head CI, the explicit production net +10 capability justification above, and the normal maintainer landing workflow. The shared fact renderer is retained; no delivery-status policy or extra classification path was added.

The before/after images are cropped synthetic run rows, with no real Gateway error or private data. Both consumers render the same row; the RPC and visible-container assertions establish that each was exercised. One image pair represents both, rather than uploading duplicate captures.

Before — historical `b6aff3ef` source-Vite browser:

![Before: recorded reason omitted](https://github.com/user-attachments/assets/b8a4482d-48c3-4523-b5b9-271ba35e8305)

After — historical `c07b7538` source-Vite browser:

![After: recorded suppression shown separately](https://github.com/user-attachments/assets/2cd36f0b-47f7-47e4-8727-56d45f413778)
