### PR TITLE
fix(ui): keep moved toasts clear of mobile header

### DIFF
--- a/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
+++ b/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
@@ -911,9 +911,20 @@ suite.define(() => {
     await expect.poll(() => navigation.getAttribute("class")).not.toContain("nav-drawer");
   });
 
-  it.each(["dark", "light"] as const)(
-    "keeps the toast above the mobile drawer in %s mode",
-    async (colorScheme) => {
+  it.each([
+    {
+      colorScheme: "dark",
+      finalLayout: "compact",
+      finalViewport: { height: 844, width: 390 },
+    },
+    {
+      colorScheme: "light",
+      finalLayout: "desktop",
+      finalViewport: { height: 900, width: 1280 },
+    },
+  ] as const)(
+    "keeps the toast above the mobile drawer in $colorScheme mode",
+    async ({ colorScheme, finalLayout, finalViewport }) => {
       const page = await openPage({
         colorScheme,
         height: 844,
@@ -944,13 +955,14 @@ suite.define(() => {
         animations: "disabled",
         path: path.join(TOAST_PROOF_DIR, `mobile-drawer-toast-${colorScheme}.png`),
       });
-      if (colorScheme === "dark") {
+      if (finalLayout === "compact") {
         await page.keyboard.press("Escape");
         await expect.poll(() => dialog.isVisible()).toBe(false);
       } else {
-        await page.setViewportSize({ width: 1280, height: 900 });
+        await page.setViewportSize(finalViewport);
         await expect.poll(() => drawer.count()).toBe(0);
       }
+      expect(page.viewportSize()).toEqual(finalViewport);
       const retainedToast = page.locator(".shell > openclaw-toast-host .app-toast");
       await expect.poll(() => retainedToast.textContent()).toContain("Codex hidden");
       const [toastBounds, composerBounds] = await Promise.all([
@@ -960,7 +972,15 @@ suite.define(() => {
       if (!toastBounds || !composerBounds) {
         throw new Error("expected the handed-off toast and chat composer to have layout boxes");
       }
-      expect(Math.round(toastBounds.y)).toBe(20);
+      if (finalLayout === "compact") {
+        const headerBounds = await page.locator(".chat-pane__header:visible").first().boundingBox();
+        if (!headerBounds) {
+          throw new Error("expected the visible compact chat header to have a layout box");
+        }
+        expect(toastBounds.y).toBeGreaterThanOrEqual(headerBounds.y + headerBounds.height);
+      } else {
+        expect(Math.round(toastBounds.y)).toBe(20);
+      }
       expect(toastBounds.y + toastBounds.height).toBeLessThan(composerBounds.y);
       await retainedToast.getByRole("button", { name: "Dismiss" }).click();
       await expect.poll(() => retainedToast.isVisible()).toBe(false);

--- a/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
+++ b/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
@@ -923,7 +923,7 @@ suite.define(() => {
       finalViewport: { height: 900, width: 1280 },
     },
   ] as const)(
-    "keeps the toast above the mobile drawer in $colorScheme mode",
+    "keeps drawer toast actionable and handed-off toast clear of chat chrome in $finalLayout $colorScheme mode",
     async ({ colorScheme, finalLayout, finalViewport }) => {
       const page = await openPage({
         colorScheme,
@@ -948,6 +948,17 @@ suite.define(() => {
       const toast = host.locator(".app-toast");
       await toast.waitFor();
       await expect.poll(() => toast.textContent()).toContain("Codex hidden");
+      const drawerToastGeometry = await host.evaluate((node) => {
+        const toastElement = node.querySelector<HTMLElement>(".app-toast");
+        return {
+          computedTop: toastElement
+            ? Math.round(Number.parseFloat(getComputedStyle(toastElement).top))
+            : null,
+          placement: node.dataset.toastPlacement,
+        };
+      });
+      expect(drawerToastGeometry.placement).toBe("overlay");
+      expect(drawerToastGeometry.computedTop).toBe(20);
       const dismiss = toast.getByRole("button", { name: "Dismiss" });
       await dismiss.click({ trial: true });
 
@@ -963,25 +974,42 @@ suite.define(() => {
         await expect.poll(() => drawer.count()).toBe(0);
       }
       expect(page.viewportSize()).toEqual(finalViewport);
-      const retainedToast = page.locator(".shell > openclaw-toast-host .app-toast");
+      const retainedHost = page.locator(".shell > openclaw-toast-host");
+      await expect.poll(() => retainedHost.getAttribute("data-toast-placement")).toBe("shell");
+      const retainedToast = retainedHost.locator(".app-toast");
       await expect.poll(() => retainedToast.textContent()).toContain("Codex hidden");
-      const [toastBounds, composerBounds] = await Promise.all([
-        retainedToast.boundingBox(),
-        page.locator(".agent-chat__composer-shell").boundingBox(),
-      ]);
-      if (!toastBounds || !composerBounds) {
-        throw new Error("expected the handed-off toast and chat composer to have layout boxes");
-      }
       if (finalLayout === "compact") {
-        const headerBounds = await page.locator(".chat-pane__header:visible").first().boundingBox();
-        if (!headerBounds) {
-          throw new Error("expected the visible compact chat header to have a layout box");
-        }
-        expect(toastBounds.y).toBeGreaterThanOrEqual(headerBounds.y + headerBounds.height);
+        await expect
+          .poll(async () => {
+            const [toastBounds, headerBounds] = await Promise.all([
+              retainedToast.boundingBox(),
+              page.locator(".chat-pane__header:visible").first().boundingBox(),
+            ]);
+            return Boolean(
+              toastBounds && headerBounds && toastBounds.y >= headerBounds.y + headerBounds.height,
+            );
+          })
+          .toBe(true);
       } else {
-        expect(Math.round(toastBounds.y)).toBe(20);
+        await expect
+          .poll(async () => Math.round((await retainedToast.boundingBox())?.y ?? -1))
+          .toBe(20);
       }
-      expect(toastBounds.y + toastBounds.height).toBeLessThan(composerBounds.y);
+      await expect
+        .poll(async () => {
+          const [toastBounds, composerBounds] = await Promise.all([
+            retainedToast.boundingBox(),
+            page.locator(".agent-chat__composer-shell").boundingBox(),
+          ]);
+          return Boolean(
+            toastBounds && composerBounds && toastBounds.y + toastBounds.height < composerBounds.y,
+          );
+        })
+        .toBe(true);
+      await page.screenshot({
+        animations: "disabled",
+        path: path.join(TOAST_PROOF_DIR, `handed-off-toast-${finalLayout}-${colorScheme}.png`),
+      });
       await retainedToast.getByRole("button", { name: "Dismiss" }).click();
       await expect.poll(() => retainedToast.isVisible()).toBe(false);
     },

--- a/ui/src/lib/toast.ts
+++ b/ui/src/lib/toast.ts
@@ -47,8 +47,13 @@ class OpenClawToastHost extends OpenClawLightDomContentsElement {
   private exitTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
   private exitReason: ToastDismissReason | null = null;
 
+  private syncPlacement() {
+    this.dataset.toastPlacement = this.parentElement?.matches(".shell") ? "shell" : "overlay";
+  }
+
   override connectedCallback() {
     super.connectedCallback();
+    this.syncPlacement();
     const pending = queuedToast;
     queuedToast = null;
     if (pending) {
@@ -66,8 +71,10 @@ class OpenClawToastHost extends OpenClawLightDomContentsElement {
     super.disconnectedCallback();
   }
 
-  /** Keep the active outcome intact while moveBefore() crosses top-layer owners. */
-  connectedMoveCallback() {}
+  /** Keep the outcome intact and refresh ancestor-owned placement across moveBefore() handoffs. */
+  connectedMoveCallback() {
+    this.syncPlacement();
+  }
 
   show(options: ToastOptions) {
     this.finishDismiss(this.exitReason ?? "replaced");

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -1846,7 +1846,9 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
                 </div>
               </section>
             </main>
-            <openclaw-toast-host><div class="app-toast">Connection notice</div></openclaw-toast-host>
+            <openclaw-toast-host data-toast-placement="shell">
+              <div class="app-toast">Connection notice</div>
+            </openclaw-toast-host>
           </div>
         </body></html>`);
         // The card entrance animation moves every measured descendant together.

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -762,13 +762,17 @@ openclaw-session-owner-chip {
 /* A corner toast degenerates at phone widths, where it would span nearly the
  * whole viewport anyway. Use the full-width top idiom instead. */
 @media (max-width: 768px), (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
-  /* The unanchored chat toast shares the viewport with shell and pane chrome.
-     Anchored permission toasts already carry a measured pane-header offset. */
-  .shell--chat > openclaw-toast-host .app-toast:not(.app-toast--anchored) {
-    top: calc(
+  .shell--chat {
+    --app-toast-shell-top: calc(
       var(--safe-area-top) + var(--shell-topbar-height) + var(--chat-mobile-pane-header-height) +
         20px
     );
+  }
+
+  /* The unanchored chat toast shares the viewport with shell and pane chrome.
+     Anchored permission toasts already carry a measured pane-header offset. */
+  openclaw-toast-host[data-toast-placement="shell"] .app-toast:not(.app-toast--anchored) {
+    top: var(--app-toast-shell-top, calc(20px + var(--safe-area-top)));
   }
 
   .app-toast {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a toast moved from the mobile navigation drawer back into the chat shell could remain at the drawer's 20px viewport position and overlap the visible chat header.

## Why This Change Was Made

The movable toast host now records whether its direct owner is the shell or an overlay during connection and `moveBefore()` handoffs. Responsive CSS consumes that host-owned placement state instead of relying on an ancestor selector whose computed `top` stayed stale in Linux Chromium.

The drawer-to-shell E2E preserves the actionability proof, verifies overlay and shell placement independently, polls post-handoff geometry, and covers compact and desktop layouts. The static responsive fixture continues to cover the CSS consumer.

## User Impact

Mobile chat toasts remain visible and actionable after the navigation drawer closes, clear the chat header, and stay above the composer. Desktop toast positioning remains unchanged.

Release-note context: fixes mobile Control UI toasts overlapping chat header controls after drawer handoff.

## Evidence

- Pre-fix Linux reproduction: compact toast top `20px`, visible header bottom `56px`; the toast overlapped the header.
- Post-fix Linux Testbox `tbx_01m14k2hmae23w468hms0x5sey`: compact toast top `72px`, bottom `137.375px`, header bottom `56px`, composer top `725px`; desktop remained at top `20px`, bottom `85.375px`, composer top `774px`.
- Focused Linux E2E: 2 passed, 22 skipped. Run: https://github.com/openclaw/openclaw/actions/runs/33189936362
- Clean-hydration changed gate against GitHub `main` at `6ee9b5ed7ca4`: passed `coreTests, ui`, including core/UI typechecks, Oxlint, Stylelint, dead exports, formatting, i18n, and ratchets. Testbox `tbx_01m14knh7jzxdcrjkx8mczsd16`; run: https://github.com/openclaw/openclaw/actions/runs/33190765304
- Local focused lifecycle E2E after the final main rebase: 2 passed, 22 skipped.
- Toast, modal, and responsive sibling suites: 130 passed.
- Four screenshots generated and visually inspected: dark/light drawer states plus compact/dark and desktop/light post-handoff states.
- Deslop: clean.
- Autoreview: clean, no actionable findings.

AI-assisted: yes.
