### PR TITLE
fix(browser): avoid navigation timeouts during tab access renewal

### DIFF
--- a/extensions/browser/chrome-extension/bootstrap.chromium.test.ts
+++ b/extensions/browser/chrome-extension/bootstrap.chromium.test.ts
@@ -22,10 +22,16 @@ import { getFreePort } from "../src/browser/test-port.js";
 import { getBrowserControlState, stopBrowserControlService } from "../src/control-service.js";
 import { createBootstrapDiagnostic } from "./bootstrap-diagnostics.test-support.js";
 import chromeExtensionManifest from "./manifest.json" with { type: "json" };
+import { holdNavigationAccessCheck } from "./navigation-race.test-support.js";
 import { relayTestKey } from "./relay-key.test-support.js";
 
 declare const chrome: {
   runtime: { sendMessage: (message: unknown) => Promise<Record<string, unknown>> };
+  tabs: {
+    query(query: Record<string, unknown>): Promise<Array<{ id: number; url?: string }>>;
+    group(options: { tabIds: number[] }): Promise<number>;
+  };
+  tabGroups: { update(groupId: number, options: { title: string }): Promise<unknown> };
 };
 
 const runE2E =
@@ -147,7 +153,7 @@ function decodeSingleNativeResponse(frame: Buffer): Record<string, unknown> {
 }
 
 describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
-  it("pre-registers before the first native call, auto-pairs, and revokes a paused tab", async () => {
+  async function testBootstrap(navigationMode: "all" | "selected") {
     const diagnostic = createBootstrapDiagnostic();
     cleanups.push(async () => {
       diagnostic.dispose();
@@ -318,7 +324,11 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
         if (process.platform === "linux") {
           // Linux CDP loads are transient and omit the protected record written by Load unpacked.
           // Seed that exact record only after Chromium confirms the path-derived extension ID.
-          await seedLinuxSecurePreferences({ userDataDir, extensionId, extensionPath: installed });
+          await seedLinuxSecurePreferences({
+            userDataDir,
+            extensionId,
+            extensionPath: installed,
+          });
         }
 
         const status = await installPromise;
@@ -528,6 +538,20 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
         await expect
           .poll(() => relay.bridge.accessibleTabs().some((tab) => tab.url === distractingUrl))
           .toBe(true);
+        if (navigationMode === "selected") {
+          await extensionPage.evaluate(
+            async (urls) => {
+              const tabs = await chrome.tabs.query({});
+              const tabIds = tabs
+                .filter((tab) => urls.includes(tab.url ?? ""))
+                .map((tab) => tab.id);
+              const groupId = await chrome.tabs.group({ tabIds });
+              await chrome.tabGroups.update(groupId, { title: "OpenClaw" });
+              await chrome.runtime.sendMessage({ type: "setAccessMode", accessMode: "selected" });
+            },
+            [controlled.url(), distractingUrl],
+          );
+        }
         const liveTabsResponse = await dispatcher.dispatch({
           method: "GET",
           path: "/tabs",
@@ -563,6 +587,16 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
           diagnostic.mark("injection.used", true);
           return Promise.reject(new Error("page.goto: Frame has been detached"));
         });
+        const worker = context
+          .serviceWorkers()
+          .find((entry) => entry.url().startsWith(`chrome-extension://${extensionId}/`));
+        if (!worker) {
+          throw new Error("Extension service worker missing");
+        }
+        const finishNavigationProbe = await holdNavigationAccessCheck(
+          worker,
+          `http://127.0.0.1:${gatewayPort}/browser-owner-proof`,
+        );
         try {
           const navigationResponse = await dispatcher.dispatch({
             method: "POST",
@@ -603,7 +637,15 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
           diagnostic.flush();
           detachedNavigation.mockRestore();
           browserState.resolved.ssrfPolicy = previousSsrfPolicy;
+          const probe = await finishNavigationProbe();
+          expect(probe.heldReads).toBeGreaterThan(0);
+          expect(probe.sawLoad).toBe(true);
         }
+
+        await extensionPage.evaluate(
+          async () =>
+            await chrome.runtime.sendMessage({ type: "setAccessMode", accessMode: "all" }),
+        );
 
         const registration = status.registrations.find(
           (entry) => relevantManifestPaths.includes(entry.manifestPath) && entry.state === "owned",
@@ -748,5 +790,11 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
         expect(context.pages()).toHaveLength(pageCountBeforeUnavailableSelection);
       },
     );
-  }, 120_000);
+  }
+
+  it.each(["all", "selected"] as const)(
+    "pre-registers, auto-pairs, navigates in %s mode, and revokes a paused tab",
+    testBootstrap,
+    120_000,
+  );
 });

--- a/extensions/browser/chrome-extension/bootstrap.chromium.test.ts
+++ b/extensions/browser/chrome-extension/bootstrap.chromium.test.ts
@@ -153,7 +153,7 @@ function decodeSingleNativeResponse(frame: Buffer): Record<string, unknown> {
 }
 
 describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
-  async function testBootstrap(navigationMode: "all" | "selected") {
+  it("pre-registers before the first native call, auto-pairs, and revokes a paused tab", async () => {
     const diagnostic = createBootstrapDiagnostic();
     cleanups.push(async () => {
       diagnostic.dispose();
@@ -221,7 +221,7 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
           nativeHostPath,
         };
         const gatewayServer = http.createServer((req, res) => {
-          if (req.url === "/browser-owner-proof") {
+          if (req.url?.split("?")[0] === "/browser-owner-proof") {
             diagnostic.mark("http.request", true);
             res.once("finish", () => diagnostic.mark("http.finish", res.statusCode));
             res.writeHead(200, { "content-type": "text/html" });
@@ -538,108 +538,106 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
         await expect
           .poll(() => relay.bridge.accessibleTabs().some((tab) => tab.url === distractingUrl))
           .toBe(true);
-        if (navigationMode === "selected") {
-          await extensionPage.evaluate(
-            async (urls) => {
-              const tabs = await chrome.tabs.query({});
-              const tabIds = tabs
-                .filter((tab) => urls.includes(tab.url ?? ""))
-                .map((tab) => tab.id);
-              const groupId = await chrome.tabs.group({ tabIds });
-              await chrome.tabGroups.update(groupId, { title: "OpenClaw" });
-              await chrome.runtime.sendMessage({ type: "setAccessMode", accessMode: "selected" });
-            },
-            [controlled.url(), distractingUrl],
-          );
-        }
-        const liveTabsResponse = await dispatcher.dispatch({
-          method: "GET",
-          path: "/tabs",
-          query: { profile: "e2e" },
-        });
-        const liveTabs = (
-          liveTabsResponse.body as { tabs?: Array<{ targetId?: string; url?: string }> }
-        ).tabs;
-        const selectedTab = liveTabs?.find((tab) => tab.url === controlled.url());
-        const unrelatedTab = liveTabs?.find((tab) => tab.url === distractingUrl);
-        if (!selectedTab?.targetId || !unrelatedTab?.targetId) {
-          throw new Error(`Extension navigation proof tabs missing: ${JSON.stringify(liveTabs)}`);
-        }
-        expect(selectedTab.targetId).not.toBe(unrelatedTab.targetId);
-        const previousSsrfPolicy = browserState.resolved.ssrfPolicy;
-        browserState.resolved.ssrfPolicy = { allowPrivateNetwork: true };
-        const extensionCdpUrl = routeContext.forProfile("e2e").profile.cdpUrl;
-        const proofUrl = `http://127.0.0.1:${gatewayPort}/browser-owner-proof`;
-        diagnostic.arm(selectedTab.targetId, unrelatedTab.targetId);
-        diagnostic.mark("relay.clients", relay.bridge.cdpClientCount);
-        for (const session of [...chromeMcpSessions.values()].slice(0, 8)) {
-          diagnostic.peer(session.client.getServerVersion());
-        }
-        const stopPageObservation = diagnostic.watchPage(controlled, proofUrl);
-        const selectedOwner = relay.bridge.captureOperationTarget(selectedTab.targetId);
-        const unrelatedOwner = relay.bridge.captureOperationTarget(unrelatedTab.targetId);
-        const actedPage = await getPageForTargetId({
-          cdpUrl: extensionCdpUrl,
-          targetId: selectedTab.targetId,
-          ssrfPolicy: browserState.resolved.ssrfPolicy,
-        });
-        const detachedNavigation = vi.spyOn(actedPage, "goto").mockImplementationOnce(() => {
-          diagnostic.mark("injection.used", true);
-          return Promise.reject(new Error("page.goto: Frame has been detached"));
-        });
-        const worker = context
-          .serviceWorkers()
-          .find((entry) => entry.url().startsWith(`chrome-extension://${extensionId}/`));
-        if (!worker) {
-          throw new Error("Extension service worker missing");
-        }
-        const finishNavigationProbe = await holdNavigationAccessCheck(
-          worker,
-          `http://127.0.0.1:${gatewayPort}/browser-owner-proof`,
-        );
-        try {
-          const navigationResponse = await dispatcher.dispatch({
-            method: "POST",
-            path: "/navigate",
+        for (const navigationMode of ["all", "selected"] as const) {
+          const proofUrl = `http://127.0.0.1:${gatewayPort}/browser-owner-proof?mode=${navigationMode}`;
+          if (navigationMode === "selected") {
+            await extensionPage.evaluate(
+              async (urls) => {
+                const tabs = await chrome.tabs.query({});
+                const tabIds = tabs
+                  .filter((tab) => urls.includes(tab.url ?? ""))
+                  .map((tab) => tab.id);
+                const groupId = await chrome.tabs.group({ tabIds });
+                await chrome.tabGroups.update(groupId, { title: "OpenClaw" });
+                await chrome.runtime.sendMessage({ type: "setAccessMode", accessMode: "selected" });
+              },
+              [controlled.url(), distractingUrl],
+            );
+          }
+          const liveTabsResponse = await dispatcher.dispatch({
+            method: "GET",
+            path: "/tabs",
             query: { profile: "e2e" },
-            body: {
-              targetId: selectedTab.targetId,
-              url: `http://127.0.0.1:${gatewayPort}/browser-owner-proof`,
-            },
           });
-          diagnostic.mark("navigate.status", navigationResponse.status);
-          expect(navigationResponse.status, JSON.stringify(navigationResponse.body)).toBe(200);
-          expect(navigationResponse.body).toMatchObject({
-            ok: true,
-            targetId: selectedTab.targetId,
-            url: `http://127.0.0.1:${gatewayPort}/browser-owner-proof`,
-          });
-          expect(detachedNavigation).toHaveBeenCalledTimes(1);
-          const recoveredPage = await getPageForTargetId({
+          const liveTabs = (
+            liveTabsResponse.body as { tabs?: Array<{ targetId?: string; url?: string }> }
+          ).tabs;
+          const selectedTab = liveTabs?.find((tab) => tab.url === controlled.url());
+          const unrelatedTab = liveTabs?.find((tab) => tab.url === distractingUrl);
+          if (!selectedTab?.targetId || !unrelatedTab?.targetId) {
+            throw new Error(`Extension navigation proof tabs missing: ${JSON.stringify(liveTabs)}`);
+          }
+          expect(selectedTab.targetId).not.toBe(unrelatedTab.targetId);
+          const previousSsrfPolicy = browserState.resolved.ssrfPolicy;
+          browserState.resolved.ssrfPolicy = { allowPrivateNetwork: true };
+          const extensionCdpUrl = routeContext.forProfile("e2e").profile.cdpUrl;
+          diagnostic.arm(selectedTab.targetId, unrelatedTab.targetId);
+          diagnostic.mark("relay.clients", relay.bridge.cdpClientCount);
+          for (const session of [...chromeMcpSessions.values()].slice(0, 8)) {
+            diagnostic.peer(session.client.getServerVersion());
+          }
+          const stopPageObservation = diagnostic.watchPage(controlled, proofUrl);
+          const selectedOwner = relay.bridge.captureOperationTarget(selectedTab.targetId);
+          const unrelatedOwner = relay.bridge.captureOperationTarget(unrelatedTab.targetId);
+          const actedPage = await getPageForTargetId({
             cdpUrl: extensionCdpUrl,
             targetId: selectedTab.targetId,
             ssrfPolicy: browserState.resolved.ssrfPolicy,
           });
-          diagnostic.mark("adapter.fresh", recoveredPage !== actedPage);
-          expect(recoveredPage).not.toBe(actedPage);
-          expect(distractingPage.url()).toBe(distractingUrl);
-          process.stderr.write(
-            "[browser-extension-e2e] injected-detach=1 production-reconnect=1 owner-target-preserved=1 unrelated-tab-unchanged=1 status=200\n",
-          );
-        } finally {
-          diagnostic.mark("injection.calls", detachedNavigation.mock.calls.length);
-          diagnostic.mark("owner.selected", selectedOwner?.() === selectedTab.targetId);
-          diagnostic.mark("owner.unrelated", unrelatedOwner?.() === unrelatedTab.targetId);
-          diagnostic.mark("direct.url", controlled.url() === proofUrl);
-          diagnostic.mark("unrelated.url", distractingPage.url() === distractingUrl);
-          diagnostic.mark("relay.clients", relay.bridge.cdpClientCount);
-          stopPageObservation();
-          diagnostic.flush();
-          detachedNavigation.mockRestore();
-          browserState.resolved.ssrfPolicy = previousSsrfPolicy;
-          const probe = await finishNavigationProbe();
-          expect(probe.heldReads).toBeGreaterThan(0);
-          expect(probe.sawLoad).toBe(true);
+          const detachedNavigation = vi.spyOn(actedPage, "goto").mockImplementationOnce(() => {
+            diagnostic.mark("injection.used", true);
+            return Promise.reject(new Error("page.goto: Frame has been detached"));
+          });
+          const worker = context
+            .serviceWorkers()
+            .find((entry) => entry.url().startsWith(`chrome-extension://${extensionId}/`));
+          if (!worker) {
+            throw new Error("Extension service worker missing");
+          }
+          const finishNavigationProbe = await holdNavigationAccessCheck(worker, proofUrl);
+          try {
+            const navigationResponse = await dispatcher.dispatch({
+              method: "POST",
+              path: "/navigate",
+              query: { profile: "e2e" },
+              body: {
+                targetId: selectedTab.targetId,
+                url: proofUrl,
+              },
+            });
+            diagnostic.mark("navigate.status", navigationResponse.status);
+            expect(navigationResponse.status, JSON.stringify(navigationResponse.body)).toBe(200);
+            expect(navigationResponse.body).toMatchObject({
+              ok: true,
+              targetId: selectedTab.targetId,
+              url: proofUrl,
+            });
+            expect(detachedNavigation).toHaveBeenCalledTimes(1);
+            const recoveredPage = await getPageForTargetId({
+              cdpUrl: extensionCdpUrl,
+              targetId: selectedTab.targetId,
+              ssrfPolicy: browserState.resolved.ssrfPolicy,
+            });
+            diagnostic.mark("adapter.fresh", recoveredPage !== actedPage);
+            expect(recoveredPage).not.toBe(actedPage);
+            expect(distractingPage.url()).toBe(distractingUrl);
+            process.stderr.write(
+              `[browser-extension-e2e] mode=${navigationMode} injected-detach=1 production-reconnect=1 owner-target-preserved=1 unrelated-tab-unchanged=1 status=200\n`,
+            );
+          } finally {
+            diagnostic.mark("injection.calls", detachedNavigation.mock.calls.length);
+            diagnostic.mark("owner.selected", selectedOwner?.() === selectedTab.targetId);
+            diagnostic.mark("owner.unrelated", unrelatedOwner?.() === unrelatedTab.targetId);
+            diagnostic.mark("direct.url", controlled.url() === proofUrl);
+            diagnostic.mark("unrelated.url", distractingPage.url() === distractingUrl);
+            diagnostic.mark("relay.clients", relay.bridge.cdpClientCount);
+            stopPageObservation();
+            detachedNavigation.mockRestore();
+            browserState.resolved.ssrfPolicy = previousSsrfPolicy;
+            const probe = await finishNavigationProbe();
+            expect(probe.heldReads).toBeGreaterThan(0);
+            expect(probe.sawLoad).toBe(true);
+          }
         }
 
         await extensionPage.evaluate(
@@ -790,11 +788,5 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
         expect(context.pages()).toHaveLength(pageCountBeforeUnavailableSelection);
       },
     );
-  }
-
-  it.each(["all", "selected"] as const)(
-    "pre-registers, auto-pairs, navigates in %s mode, and revokes a paused tab",
-    testBootstrap,
-    120_000,
-  );
+  }, 120_000);
 });

--- a/extensions/browser/chrome-extension/bootstrap.chromium.test.ts
+++ b/extensions/browser/chrome-extension/bootstrap.chromium.test.ts
@@ -538,13 +538,14 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
         await expect
           .poll(() => relay.bridge.accessibleTabs().some((tab) => tab.url === distractingUrl))
           .toBe(true);
+        const previousSsrfPolicy = browserState.resolved.ssrfPolicy;
         for (const navigationMode of ["all", "selected"] as const) {
           const proofUrl = `http://127.0.0.1:${gatewayPort}/browser-owner-proof?mode=${navigationMode}`;
           if (navigationMode === "selected") {
             await extensionPage.evaluate(
               async (urls) => {
-                const tabs = await chrome.tabs.query({});
-                const tabIds = tabs
+                const browserTabs = await chrome.tabs.query({});
+                const tabIds = browserTabs
                   .filter((tab) => urls.includes(tab.url ?? ""))
                   .map((tab) => tab.id);
                 const groupId = await chrome.tabs.group({ tabIds });
@@ -568,7 +569,6 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
             throw new Error(`Extension navigation proof tabs missing: ${JSON.stringify(liveTabs)}`);
           }
           expect(selectedTab.targetId).not.toBe(unrelatedTab.targetId);
-          const previousSsrfPolicy = browserState.resolved.ssrfPolicy;
           browserState.resolved.ssrfPolicy = { allowPrivateNetwork: true };
           const extensionCdpUrl = routeContext.forProfile("e2e").profile.cdpUrl;
           diagnostic.arm(selectedTab.targetId, unrelatedTab.targetId);

--- a/extensions/browser/chrome-extension/bootstrap.chromium.test.ts
+++ b/extensions/browser/chrome-extension/bootstrap.chromium.test.ts
@@ -27,11 +27,6 @@ import { relayTestKey } from "./relay-key.test-support.js";
 
 declare const chrome: {
   runtime: { sendMessage: (message: unknown) => Promise<Record<string, unknown>> };
-  tabs: {
-    query(query: Record<string, unknown>): Promise<Array<{ id: number; url?: string }>>;
-    group(options: { tabIds: number[] }): Promise<number>;
-  };
-  tabGroups: { update(groupId: number, options: { title: string }): Promise<unknown> };
 };
 
 const runE2E =
@@ -221,7 +216,7 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
           nativeHostPath,
         };
         const gatewayServer = http.createServer((req, res) => {
-          if (req.url?.split("?")[0] === "/browser-owner-proof") {
+          if (req.url === "/browser-owner-proof") {
             diagnostic.mark("http.request", true);
             res.once("finish", () => diagnostic.mark("http.finish", res.statusCode));
             res.writeHead(200, { "content-type": "text/html" });
@@ -324,11 +319,7 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
         if (process.platform === "linux") {
           // Linux CDP loads are transient and omit the protected record written by Load unpacked.
           // Seed that exact record only after Chromium confirms the path-derived extension ID.
-          await seedLinuxSecurePreferences({
-            userDataDir,
-            extensionId,
-            extensionPath: installed,
-          });
+          await seedLinuxSecurePreferences({ userDataDir, extensionId, extensionPath: installed });
         }
 
         const status = await installPromise;
@@ -538,112 +529,92 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
         await expect
           .poll(() => relay.bridge.accessibleTabs().some((tab) => tab.url === distractingUrl))
           .toBe(true);
+        const liveTabsResponse = await dispatcher.dispatch({
+          method: "GET",
+          path: "/tabs",
+          query: { profile: "e2e" },
+        });
+        const liveTabs = (
+          liveTabsResponse.body as { tabs?: Array<{ targetId?: string; url?: string }> }
+        ).tabs;
+        const selectedTab = liveTabs?.find((tab) => tab.url === controlled.url());
+        const unrelatedTab = liveTabs?.find((tab) => tab.url === distractingUrl);
+        if (!selectedTab?.targetId || !unrelatedTab?.targetId) {
+          throw new Error(`Extension navigation proof tabs missing: ${JSON.stringify(liveTabs)}`);
+        }
+        expect(selectedTab.targetId).not.toBe(unrelatedTab.targetId);
         const previousSsrfPolicy = browserState.resolved.ssrfPolicy;
-        for (const navigationMode of ["all", "selected"] as const) {
-          const proofUrl = `http://127.0.0.1:${gatewayPort}/browser-owner-proof?mode=${navigationMode}`;
-          if (navigationMode === "selected") {
-            await extensionPage.evaluate(
-              async (urls) => {
-                const browserTabs = await chrome.tabs.query({});
-                const tabIds = browserTabs
-                  .filter((tab) => urls.includes(tab.url ?? ""))
-                  .map((tab) => tab.id);
-                const groupId = await chrome.tabs.group({ tabIds });
-                await chrome.tabGroups.update(groupId, { title: "OpenClaw" });
-                await chrome.runtime.sendMessage({ type: "setAccessMode", accessMode: "selected" });
-              },
-              [controlled.url(), distractingUrl],
-            );
-          }
-          const liveTabsResponse = await dispatcher.dispatch({
-            method: "GET",
-            path: "/tabs",
+        browserState.resolved.ssrfPolicy = { allowPrivateNetwork: true };
+        const extensionCdpUrl = routeContext.forProfile("e2e").profile.cdpUrl;
+        const proofUrl = `http://127.0.0.1:${gatewayPort}/browser-owner-proof`;
+        diagnostic.arm(selectedTab.targetId, unrelatedTab.targetId);
+        diagnostic.mark("relay.clients", relay.bridge.cdpClientCount);
+        for (const session of [...chromeMcpSessions.values()].slice(0, 8)) {
+          diagnostic.peer(session.client.getServerVersion());
+        }
+        const stopPageObservation = diagnostic.watchPage(controlled, proofUrl);
+        const selectedOwner = relay.bridge.captureOperationTarget(selectedTab.targetId);
+        const unrelatedOwner = relay.bridge.captureOperationTarget(unrelatedTab.targetId);
+        const actedPage = await getPageForTargetId({
+          cdpUrl: extensionCdpUrl,
+          targetId: selectedTab.targetId,
+          ssrfPolicy: browserState.resolved.ssrfPolicy,
+        });
+        const detachedNavigation = vi.spyOn(actedPage, "goto").mockImplementationOnce(() => {
+          diagnostic.mark("injection.used", true);
+          return Promise.reject(new Error("page.goto: Frame has been detached"));
+        });
+        const worker = context
+          .serviceWorkers()
+          .find((entry) => entry.url().startsWith(`chrome-extension://${extensionId}/`));
+        if (!worker) {
+          throw new Error("Extension service worker missing");
+        }
+        const finishNavigationProbe = await holdNavigationAccessCheck(worker, proofUrl);
+        try {
+          const navigationResponse = await dispatcher.dispatch({
+            method: "POST",
+            path: "/navigate",
             query: { profile: "e2e" },
+            body: {
+              targetId: selectedTab.targetId,
+              url: `http://127.0.0.1:${gatewayPort}/browser-owner-proof`,
+            },
           });
-          const liveTabs = (
-            liveTabsResponse.body as { tabs?: Array<{ targetId?: string; url?: string }> }
-          ).tabs;
-          const selectedTab = liveTabs?.find((tab) => tab.url === controlled.url());
-          const unrelatedTab = liveTabs?.find((tab) => tab.url === distractingUrl);
-          if (!selectedTab?.targetId || !unrelatedTab?.targetId) {
-            throw new Error(`Extension navigation proof tabs missing: ${JSON.stringify(liveTabs)}`);
-          }
-          expect(selectedTab.targetId).not.toBe(unrelatedTab.targetId);
-          browserState.resolved.ssrfPolicy = { allowPrivateNetwork: true };
-          const extensionCdpUrl = routeContext.forProfile("e2e").profile.cdpUrl;
-          diagnostic.arm(selectedTab.targetId, unrelatedTab.targetId);
-          diagnostic.mark("relay.clients", relay.bridge.cdpClientCount);
-          for (const session of [...chromeMcpSessions.values()].slice(0, 8)) {
-            diagnostic.peer(session.client.getServerVersion());
-          }
-          const stopPageObservation = diagnostic.watchPage(controlled, proofUrl);
-          const selectedOwner = relay.bridge.captureOperationTarget(selectedTab.targetId);
-          const unrelatedOwner = relay.bridge.captureOperationTarget(unrelatedTab.targetId);
-          const actedPage = await getPageForTargetId({
+          diagnostic.mark("navigate.status", navigationResponse.status);
+          expect(navigationResponse.status, JSON.stringify(navigationResponse.body)).toBe(200);
+          expect(navigationResponse.body).toMatchObject({
+            ok: true,
+            targetId: selectedTab.targetId,
+            url: `http://127.0.0.1:${gatewayPort}/browser-owner-proof`,
+          });
+          expect(detachedNavigation).toHaveBeenCalledTimes(1);
+          const recoveredPage = await getPageForTargetId({
             cdpUrl: extensionCdpUrl,
             targetId: selectedTab.targetId,
             ssrfPolicy: browserState.resolved.ssrfPolicy,
           });
-          const detachedNavigation = vi.spyOn(actedPage, "goto").mockImplementationOnce(() => {
-            diagnostic.mark("injection.used", true);
-            return Promise.reject(new Error("page.goto: Frame has been detached"));
-          });
-          const worker = context
-            .serviceWorkers()
-            .find((entry) => entry.url().startsWith(`chrome-extension://${extensionId}/`));
-          if (!worker) {
-            throw new Error("Extension service worker missing");
-          }
-          const finishNavigationProbe = await holdNavigationAccessCheck(worker, proofUrl);
-          try {
-            const navigationResponse = await dispatcher.dispatch({
-              method: "POST",
-              path: "/navigate",
-              query: { profile: "e2e" },
-              body: {
-                targetId: selectedTab.targetId,
-                url: proofUrl,
-              },
-            });
-            diagnostic.mark("navigate.status", navigationResponse.status);
-            expect(navigationResponse.status, JSON.stringify(navigationResponse.body)).toBe(200);
-            expect(navigationResponse.body).toMatchObject({
-              ok: true,
-              targetId: selectedTab.targetId,
-              url: proofUrl,
-            });
-            expect(detachedNavigation).toHaveBeenCalledTimes(1);
-            const recoveredPage = await getPageForTargetId({
-              cdpUrl: extensionCdpUrl,
-              targetId: selectedTab.targetId,
-              ssrfPolicy: browserState.resolved.ssrfPolicy,
-            });
-            diagnostic.mark("adapter.fresh", recoveredPage !== actedPage);
-            expect(recoveredPage).not.toBe(actedPage);
-            expect(distractingPage.url()).toBe(distractingUrl);
-            process.stderr.write(
-              `[browser-extension-e2e] mode=${navigationMode} injected-detach=1 production-reconnect=1 owner-target-preserved=1 unrelated-tab-unchanged=1 status=200\n`,
-            );
-          } finally {
-            diagnostic.mark("injection.calls", detachedNavigation.mock.calls.length);
-            diagnostic.mark("owner.selected", selectedOwner?.() === selectedTab.targetId);
-            diagnostic.mark("owner.unrelated", unrelatedOwner?.() === unrelatedTab.targetId);
-            diagnostic.mark("direct.url", controlled.url() === proofUrl);
-            diagnostic.mark("unrelated.url", distractingPage.url() === distractingUrl);
-            diagnostic.mark("relay.clients", relay.bridge.cdpClientCount);
-            stopPageObservation();
-            detachedNavigation.mockRestore();
-            browserState.resolved.ssrfPolicy = previousSsrfPolicy;
-            const probe = await finishNavigationProbe();
-            expect(probe.heldReads).toBeGreaterThan(0);
-            expect(probe.sawLoad).toBe(true);
-          }
+          diagnostic.mark("adapter.fresh", recoveredPage !== actedPage);
+          expect(recoveredPage).not.toBe(actedPage);
+          expect(distractingPage.url()).toBe(distractingUrl);
+          process.stderr.write(
+            "[browser-extension-e2e] injected-detach=1 production-reconnect=1 owner-target-preserved=1 unrelated-tab-unchanged=1 status=200\n",
+          );
+        } finally {
+          diagnostic.mark("injection.calls", detachedNavigation.mock.calls.length);
+          diagnostic.mark("owner.selected", selectedOwner?.() === selectedTab.targetId);
+          diagnostic.mark("owner.unrelated", unrelatedOwner?.() === unrelatedTab.targetId);
+          diagnostic.mark("direct.url", controlled.url() === proofUrl);
+          diagnostic.mark("unrelated.url", distractingPage.url() === distractingUrl);
+          diagnostic.mark("relay.clients", relay.bridge.cdpClientCount);
+          stopPageObservation();
+          diagnostic.flush();
+          detachedNavigation.mockRestore();
+          browserState.resolved.ssrfPolicy = previousSsrfPolicy;
+          const probe = await finishNavigationProbe();
+          expect(probe.heldReads).toBeGreaterThan(0);
+          expect(probe.sawLoad).toBe(true);
         }
-
-        await extensionPage.evaluate(
-          async () =>
-            await chrome.runtime.sendMessage({ type: "setAccessMode", accessMode: "all" }),
-        );
 
         const registration = status.registrations.find(
           (entry) => relevantManifestPaths.includes(entry.manifestPath) && entry.state === "owned",

--- a/extensions/browser/chrome-extension/modules/tab-access-events.d.ts
+++ b/extensions/browser/chrome-extension/modules/tab-access-events.d.ts
@@ -1,4 +1,5 @@
 import type { TabAccessEpoch, TabAccessMode } from "./tab-access.js";
+import type { BrowserTabSnapshot } from "./tab-eligibility.js";
 
 type ChromeEvent<Listener> = {
   addListener(listener: Listener): void;
@@ -14,7 +15,13 @@ export type TabAccessEventsChromeApi = {
   tabs: {
     onRemoved: ChromeEvent<(tabId: number) => void>;
     onReplaced: ChromeEvent<(addedTabId: number, removedTabId: number) => void>;
-    onUpdated: ChromeEvent<(tabId: number, changeInfo: { groupId?: number; url?: string }) => void>;
+    onUpdated: ChromeEvent<
+      (
+        tabId: number,
+        changeInfo: { groupId?: number; url?: string },
+        tab: BrowserTabSnapshot,
+      ) => void
+    >;
   };
   tabGroups: {
     onUpdated: ChromeEvent<() => void>;
@@ -29,6 +36,11 @@ export type TabAccessEventPolicy = {
   capture(tabId: number): TabAccessEpoch;
   epochIsCurrent(tabId: number, epoch: TabAccessEpoch): boolean;
   invalidateTab(tabId: number): void;
+  renewTabAccess(
+    tabId: number,
+    attachedEpoch: TabAccessEpoch | undefined,
+    tab: BrowserTabSnapshot | undefined,
+  ): TabAccessEpoch | undefined;
   invalidateAll(): void;
   inspectTab(tabId: number, epoch: TabAccessEpoch): Promise<{ accessible: boolean }>;
   listAccessibleTabs(): Promise<Array<{ id: number }>>;

--- a/extensions/browser/chrome-extension/modules/tab-access-events.js
+++ b/extensions/browser/chrome-extension/modules/tab-access-events.js
@@ -91,15 +91,16 @@ export function registerTabAccessEvents({
     })().catch(() => undefined);
   });
 
-  chromeApi.tabs.onUpdated.addListener((tabId, changeInfo) => {
+  chromeApi.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     scheduleTabsSync();
     if (
       typeof changeInfo.url === "string" ||
       (policy.mode === ACCESS_MODE_SELECTED && typeof changeInfo.groupId === "number")
     ) {
-      // Security contract: every URL change retires synchronous CDP authority.
-      // Pre-proof events intentionally drop; replay could cross a restricted destination.
-      policy.invalidateTab(tabId);
+      const renewed = policy.renewTabAccess(tabId, attachedAccessEpochs.get(tabId), tab);
+      if (renewed && attachedTabs.has(tabId)) {
+        attachedAccessEpochs.set(tabId, renewed);
+      }
     }
     const eventEpoch = policy.capture(tabId);
     void (async () => {

--- a/extensions/browser/chrome-extension/modules/tab-access-events.navigation.test.ts
+++ b/extensions/browser/chrome-extension/modules/tab-access-events.navigation.test.ts
@@ -110,7 +110,9 @@ async function createNavigationHarness(
       chromeApi.tabs.get.mockImplementation(async () => await pending);
       return async () => {
         release(tab);
-        await new Promise<void>((resolve) => setImmediate(resolve));
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
       };
     },
   };

--- a/extensions/browser/chrome-extension/modules/tab-access-events.navigation.test.ts
+++ b/extensions/browser/chrome-extension/modules/tab-access-events.navigation.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it, vi } from "vitest";
+import { registerTabAccessEvents } from "./tab-access-events.js";
+import { createTabAccessPolicy, type TabAccessEpoch, type TabAccessMode } from "./tab-access.js";
+import type { BrowserTabSnapshot } from "./tab-eligibility.js";
+
+function chromeEvent<Args extends unknown[]>() {
+  let listener: (...args: Args) => void = () => {
+    throw new Error("Chrome event listener was not registered");
+  };
+  return {
+    addListener(next: (...args: Args) => void) {
+      listener = next;
+    },
+    emit(...args: Args) {
+      listener(...args);
+    },
+  };
+}
+
+const navigationEvents = [
+  { method: "Network.responseReceived", params: { requestId: "navigation-1" } },
+  { method: "Runtime.executionContextCreated", params: { context: { id: 12 } } },
+  { method: "Page.frameNavigated", params: { frame: { id: "frame-7", loaderId: "loader-1" } } },
+  { method: "Page.lifecycleEvent", params: { frameId: "frame-7", name: "load" } },
+];
+
+async function createNavigationHarness(
+  mode: TabAccessMode,
+  { fileAccessAllowed = true, proveAttachment = true } = {},
+) {
+  let tab: BrowserTabSnapshot = {
+    id: 7,
+    url: "https://source.example/",
+    groupId: mode === "selected" ? 11 : -1,
+    incognito: false,
+  };
+  const chromeApi = {
+    extension: { isAllowedFileSchemeAccess: async () => fileAccessAllowed },
+    storage: {
+      session: {
+        get: async () => ({}),
+        set: async () => {},
+        remove: async () => {},
+      },
+    },
+    tabs: {
+      get: vi.fn(async (_tabId: number) => tab),
+      query: async () => [tab],
+      onUpdated: chromeEvent<[number, { groupId?: number; url?: string }, BrowserTabSnapshot]>(),
+      onRemoved: chromeEvent<[number]>(),
+      onReplaced: chromeEvent<[number, number]>(),
+    },
+    tabGroups: { onUpdated: chromeEvent<[]>(), onRemoved: chromeEvent<[]>() },
+    debugger: {
+      onEvent: chromeEvent<[{ tabId?: number; sessionId?: string }, string, unknown]>(),
+      onDetach: chromeEvent<[{ tabId?: number }, string]>(),
+    },
+  };
+  const policy = createTabAccessPolicy({
+    chromeApi,
+    isSelectedTab: async (candidate) => candidate.groupId === 11,
+  });
+  await policy.initialize(mode, true);
+  const attachmentEpoch = policy.capture(7);
+  if (proveAttachment) {
+    await policy.requireTab(7, attachmentEpoch);
+  }
+  const attachedTabs = new Set([7]);
+  const attachedAccessEpochs = new Map<number, TabAccessEpoch>([[7, attachmentEpoch]]);
+  const send = vi.fn<(message: Record<string, unknown>) => void>();
+  const detachDebugger = vi.fn(async (tabId: number) => {
+    attachedTabs.delete(tabId);
+    attachedAccessEpochs.delete(tabId);
+  });
+  registerTabAccessEvents({
+    chromeApi,
+    accessReady: Promise.resolve(),
+    policy,
+    attachedTabs,
+    attachedAccessEpochs,
+    attachingTabs: new Map(),
+    send,
+    scheduleTabsSync() {},
+    detachDebugger,
+    pauseTab: async (tabId) => await policy.pause(tabId),
+    removeTabFromOpenClawGroup: async () => {},
+    runAccessMutation: async (task) => await task(),
+  });
+  return {
+    chromeApi,
+    policy,
+    attachmentEpoch,
+    attachedAccessEpochs,
+    send,
+    detachDebugger,
+    update(update: Partial<BrowserTabSnapshot>) {
+      tab = { ...tab, ...update };
+      chromeApi.tabs.onUpdated.emit(7, { url: tab.url }, tab);
+    },
+    emitNavigation() {
+      for (const { method, params } of navigationEvents) {
+        chromeApi.debugger.onEvent.emit({ tabId: 7 }, method, params);
+      }
+    },
+    deferLookup() {
+      let release = (_value: BrowserTabSnapshot) => {};
+      const pending = new Promise<BrowserTabSnapshot>((resolve) => {
+        release = resolve;
+      });
+      chromeApi.tabs.get.mockImplementation(async () => await pending);
+      return async () => {
+        release(tab);
+        await new Promise<void>((resolve) => setImmediate(resolve));
+      };
+    },
+  };
+}
+
+describe("Chrome navigation event access", () => {
+  it.each(
+    (["all", "selected"] as const).flatMap((mode) =>
+      [
+        "http://destination.example/",
+        "https://destination.example/",
+        "data:text/html,proof",
+        "blob:https://destination.example/document",
+        "file:///tmp/openclaw-navigation-proof.html",
+      ].map((url) => ({ mode, url })),
+    ),
+  )("preserves ordered navigation events in $mode mode for $url", async ({ mode, url }) => {
+    const harness = await createNavigationHarness(mode);
+    const releaseLookup = harness.deferLookup();
+    try {
+      harness.update({ url });
+      harness.emitNavigation();
+
+      expect(harness.send.mock.calls.map(([frame]) => frame)).toEqual(
+        navigationEvents.map((event) => ({ type: "cdpEvent", tabId: 7, ...event })),
+      );
+      await expect(harness.policy.requireTab(7, harness.attachmentEpoch)).rejects.toThrow(
+        "access was revoked",
+      );
+
+      harness.send.mockClear();
+      harness.update({ url: `${url}next` });
+      harness.emitNavigation();
+      expect(harness.send.mock.calls.map(([frame]) => frame.method)).toEqual(
+        navigationEvents.map((event) => event.method),
+      );
+    } finally {
+      await releaseLookup();
+    }
+    expect(harness.detachDebugger).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "restricted committed URL",
+    "restricted pending URL",
+    "incognito tab",
+    "different selected group",
+    "wrong tab identity",
+    "paused tab",
+    "mode transition",
+    "changed group authority",
+    "stale attachment",
+    "unproven attachment",
+    "forged epoch copy",
+    "detached tab",
+    "replaced tab",
+  ])("does not renew access for %s from a URL snapshot", async (scenario) => {
+    const harness = await createNavigationHarness(scenario === "paused tab" ? "all" : "selected", {
+      proveAttachment: scenario !== "unproven attachment",
+    });
+    const update: Partial<BrowserTabSnapshot> = { url: "https://destination.example/" };
+    if (scenario === "paused tab") {
+      await harness.policy.pause(7);
+    }
+    const releaseLookup = harness.deferLookup();
+    try {
+      switch (scenario) {
+        case "restricted committed URL":
+          update.url = "chrome://settings";
+          break;
+        case "restricted pending URL":
+          update.pendingUrl = "chrome://settings";
+          break;
+        case "incognito tab":
+          update.incognito = true;
+          break;
+        case "different selected group":
+          update.groupId = 12;
+          break;
+        case "wrong tab identity":
+          update.id = 8;
+          break;
+        case "mode transition":
+          harness.policy.beginTransition();
+          break;
+        case "changed group authority":
+          harness.chromeApi.tabGroups.onUpdated.emit();
+          break;
+        case "stale attachment":
+          harness.policy.invalidateTab(7);
+          break;
+        case "forged epoch copy":
+          harness.attachedAccessEpochs.set(7, { ...harness.attachmentEpoch });
+          break;
+        case "detached tab":
+          harness.chromeApi.debugger.onDetach.emit({ tabId: 7 }, "target_closed");
+          break;
+        case "replaced tab":
+          harness.chromeApi.tabs.onReplaced.emit(8, 7);
+          break;
+      }
+      harness.send.mockClear();
+      harness.update(update);
+      harness.emitNavigation();
+      expect(harness.send).not.toHaveBeenCalled();
+    } finally {
+      await releaseLookup();
+    }
+    // Events observed without authority must never replay after an async lookup.
+    expect(harness.send).not.toHaveBeenCalled();
+  });
+
+  it("does not retain file permission across a recreated extension policy", async () => {
+    for (const fileAccessAllowed of [true, false]) {
+      const harness = await createNavigationHarness("all", { fileAccessAllowed });
+      const releaseLookup = harness.deferLookup();
+      try {
+        harness.update({ url: "file:///tmp/openclaw-navigation-proof.html" });
+        harness.emitNavigation();
+        expect(harness.send).toHaveBeenCalledTimes(fileAccessAllowed ? navigationEvents.length : 0);
+      } finally {
+        await releaseLookup();
+      }
+      if (!fileAccessAllowed) {
+        await expect(harness.policy.requireTab(7)).rejects.toThrow("restricted or unavailable");
+      }
+    }
+  });
+});

--- a/extensions/browser/chrome-extension/modules/tab-access-events.test.ts
+++ b/extensions/browser/chrome-extension/modules/tab-access-events.test.ts
@@ -39,6 +39,10 @@ function createHarness(
     invalidateTab: vi.fn(() => {
       revision += 1;
     }),
+    renewTabAccess: vi.fn(() => {
+      revision += 1;
+      return undefined;
+    }),
     invalidateAll: vi.fn(() => {
       revision += 1;
     }),

--- a/extensions/browser/chrome-extension/modules/tab-access-events.test.ts
+++ b/extensions/browser/chrome-extension/modules/tab-access-events.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { registerTabAccessEvents } from "./tab-access-events.js";
+import type { BrowserTabSnapshot } from "./tab-eligibility.js";
 
 function deferred<T>() {
   let resolve = (_value: T) => {};
@@ -18,7 +19,11 @@ function createHarness(
     | undefined;
   let debuggerDetachListener: ((source: { tabId?: number }, reason: string) => void) | undefined;
   let tabsUpdatedListener:
-    | ((tabId: number, changeInfo: { groupId?: number; url?: string }) => void)
+    | ((
+        tabId: number,
+        changeInfo: { groupId?: number; url?: string },
+        tab: BrowserTabSnapshot,
+      ) => void)
     | undefined;
   let tabsReplacedListener: ((addedTabId: number, removedTabId: number) => void) | undefined;
   let groupUpdatedListener: (() => void) | undefined;
@@ -132,7 +137,8 @@ function createHarness(
     setAccessible: (next: boolean) => {
       accessible = next;
     },
-    tabsUpdatedListener,
+    tabsUpdatedListener: (tabId: number, changeInfo: { groupId?: number; url?: string }) =>
+      tabsUpdatedListener?.(tabId, changeInfo, { id: tabId, ...changeInfo }),
     tabsReplacedListener,
   };
 }

--- a/extensions/browser/chrome-extension/modules/tab-access.d.ts
+++ b/extensions/browser/chrome-extension/modules/tab-access.d.ts
@@ -50,6 +50,11 @@ export type TabAccessPolicy = {
   capture(tabId: number): TabAccessEpoch;
   epochIsCurrent(tabId: number, epoch: TabAccessEpoch): boolean;
   invalidateTab(tabId: number): void;
+  renewTabAccess(
+    tabId: number,
+    attachedEpoch: TabAccessEpoch | undefined,
+    tab: BrowserTabSnapshot | undefined,
+  ): TabAccessEpoch | undefined;
   invalidateAll(): void;
   inspectTab(tabId: number, epoch?: TabAccessEpoch): Promise<TabAccessState>;
   requireTab(tabId: number, epoch?: TabAccessEpoch): Promise<AccessibleBrowserTabSnapshot>;

--- a/extensions/browser/chrome-extension/modules/tab-access.js
+++ b/extensions/browser/chrome-extension/modules/tab-access.js
@@ -14,6 +14,8 @@ function isValidTabId(value) {
 export function createTabAccessPolicy({ chromeApi = chrome, isSelectedTab }) {
   const deniedTabIds = new Set();
   const tabRevisions = new Map();
+  const provenEpochs = new WeakMap();
+  let fileAccessGranted = false;
   let mode = ACCESS_MODE_SELECTED;
   let enabled = false;
   let transitioning = false;
@@ -40,13 +42,8 @@ export function createTabAccessPolicy({ chromeApi = chrome, isSelectedTab }) {
     }
   }
 
-  async function tabIsEligible(tab) {
-    return tabEligibility(tab, {
-      fileAccessAllowed:
-        tab?.url?.startsWith("file:") || tab?.pendingUrl?.startsWith("file:")
-          ? await fileAccessAllowed()
-          : true,
-    }).eligible;
+  function tabIsEligible(tab) {
+    return tabEligibility(tab, { fileAccessAllowed: fileAccessGranted }).eligible;
   }
 
   async function persistDeniedIds() {
@@ -93,10 +90,14 @@ export function createTabAccessPolicy({ chromeApi = chrome, isSelectedTab }) {
     mode = initialMode === ACCESS_MODE_ALL ? ACCESS_MODE_ALL : ACCESS_MODE_SELECTED;
     enabled = initialEnabled;
     initialized = (async () => {
-      const [stored, tabs] = await Promise.all([
+      const [stored, tabs, allowFiles] = await Promise.all([
         chromeApi.storage.session.get([DENIED_TAB_IDS_KEY]),
         chromeApi.tabs.query({}),
+        fileAccessAllowed(),
       ]);
+      // Chrome reloads the extension and closes its debugger sessions when this
+      // permission changes (Chromium extension_util.cc: SetAllowFileAccess).
+      fileAccessGranted = allowFiles;
       const existingIds = new Set();
       for (const tab of tabs) {
         if (isValidTabId(tab.id)) {
@@ -175,6 +176,25 @@ export function createTabAccessPolicy({ chromeApi = chrome, isSelectedTab }) {
     invalidateTab(tabId);
   }
 
+  function renewTabAccess(tabId, attachedEpoch, tab) {
+    const proof = attachedEpoch && provenEpochs.get(attachedEpoch);
+    const canRenew =
+      proof?.tabId === tabId &&
+      epochIsCurrent(tabId, attachedEpoch) &&
+      tab?.id === tabId &&
+      tabIsEligible(tab) &&
+      (mode === ACCESS_MODE_ALL || tab.groupId === proof.groupId);
+    // Every navigation retires in-flight commands. Only Chrome's full Tab
+    // observation can renew an already-proven attachment without losing events.
+    invalidateTab(tabId);
+    if (!canRenew) {
+      return undefined;
+    }
+    const epoch = capture(tabId);
+    provenEpochs.set(epoch, { tabId, groupId: tab.groupId });
+    return epoch;
+  }
+
   async function inspectTab(tabId, epoch = capture(tabId)) {
     if (!isValidTabId(tabId)) {
       return { accessible: false, eligible: false, denied: false, reason: "missing", tab: null };
@@ -194,15 +214,8 @@ export function createTabAccessPolicy({ chromeApi = chrome, isSelectedTab }) {
     if (!epochIsCurrent(tabId, epoch)) {
       return { accessible: false, eligible: false, denied: false, reason: "revoked", tab };
     }
-    let allowedFileAccess = true;
-    if (tab?.url?.startsWith("file:") || tab?.pendingUrl?.startsWith("file:")) {
-      allowedFileAccess = await fileAccessAllowed();
-      if (!epochIsCurrent(tabId, epoch)) {
-        return { accessible: false, eligible: false, denied: false, reason: "revoked", tab };
-      }
-    }
     const eligibility = tabEligibility(tab, {
-      fileAccessAllowed: allowedFileAccess,
+      fileAccessAllowed: fileAccessGranted,
     });
     if (!eligibility.eligible) {
       return { accessible: false, eligible: false, denied: false, reason: eligibility.reason, tab };
@@ -222,10 +235,7 @@ export function createTabAccessPolicy({ chromeApi = chrome, isSelectedTab }) {
       if (!epochIsCurrent(tabId, epoch)) {
         return { accessible: false, eligible: false, denied, reason: "revoked", tab: current };
       }
-      const currentEligible = await tabIsEligible(current);
-      if (!epochIsCurrent(tabId, epoch)) {
-        return { accessible: false, eligible: false, denied, reason: "revoked", tab: current };
-      }
+      const currentEligible = tabIsEligible(current);
       const currentSelected = await isSelectedTab(current);
       if (!epochIsCurrent(tabId, epoch)) {
         return { accessible: false, eligible: false, denied, reason: "revoked", tab: current };
@@ -242,6 +252,9 @@ export function createTabAccessPolicy({ chromeApi = chrome, isSelectedTab }) {
     }
     if (!epochIsCurrent(tabId, epoch)) {
       return { accessible: false, eligible: true, denied, reason: "revoked", tab };
+    }
+    if (!denied && selected) {
+      provenEpochs.set(epoch, { tabId, groupId: tab.groupId });
     }
     return {
       accessible: !denied && selected,
@@ -285,7 +298,7 @@ export function createTabAccessPolicy({ chromeApi = chrome, isSelectedTab }) {
         if (tabIsRevoking(tab.id)) {
           continue;
         }
-        if (!(await tabIsEligible(tab))) {
+        if (!tabIsEligible(tab)) {
           continue;
         }
         if (mode === ACCESS_MODE_ALL) {
@@ -315,7 +328,7 @@ export function createTabAccessPolicy({ chromeApi = chrome, isSelectedTab }) {
       invalidateTab(tabId);
       throw error;
     }
-    if (!(await tabIsEligible(tab))) {
+    if (!tabIsEligible(tab)) {
       deniedTabIds.delete(tabId);
       invalidateTab(tabId);
       throw new Error(`tab ${tabId} is restricted or unavailable to OpenClaw`);
@@ -387,6 +400,7 @@ export function createTabAccessPolicy({ chromeApi = chrome, isSelectedTab }) {
     capture,
     epochIsCurrent,
     invalidateTab,
+    renewTabAccess,
     invalidateAll: () => {
       revision += 1;
       discoveryRevision += 1;

--- a/extensions/browser/chrome-extension/navigation-race.test-support.ts
+++ b/extensions/browser/chrome-extension/navigation-race.test-support.ts
@@ -57,9 +57,12 @@ export async function holdNavigationAccessCheck(worker: Worker, url: string) {
     };
     self.navigationProbe = probe;
     chrome.tabs.get = async (id) => {
-      const tab = await originalGet.call(chrome.tabs, id);
-      if (id === tabId && !probe.sawLoad) {
+      const waitForLoad = id === tabId && !probe.sawLoad;
+      if (waitForLoad) {
         probe.heldReads += 1;
+      }
+      const tab = await originalGet.call(chrome.tabs, id);
+      if (waitForLoad) {
         await loaded;
       }
       return tab;

--- a/extensions/browser/chrome-extension/navigation-race.test-support.ts
+++ b/extensions/browser/chrome-extension/navigation-race.test-support.ts
@@ -27,7 +27,7 @@ declare const self: { navigationProbe?: NavigationProbe };
 /** Hold Chrome's real access lookup until its real load event, without delaying navigation. */
 export async function holdNavigationAccessCheck(worker: Worker, url: string) {
   await worker.evaluate((destination) => {
-    const originalGet = chrome.tabs.get;
+    const originalGet = chrome.tabs.get.bind(chrome.tabs);
     let tabId: number | undefined;
     let release = () => {};
     const loaded = new Promise<void>((resolve) => {
@@ -61,7 +61,7 @@ export async function holdNavigationAccessCheck(worker: Worker, url: string) {
       if (waitForLoad) {
         probe.heldReads += 1;
       }
-      const tab = await originalGet.call(chrome.tabs, id);
+      const tab = await originalGet(id);
       if (waitForLoad) {
         await loaded;
       }

--- a/extensions/browser/chrome-extension/navigation-race.test-support.ts
+++ b/extensions/browser/chrome-extension/navigation-race.test-support.ts
@@ -1,0 +1,81 @@
+import type { Worker } from "playwright-core";
+
+type ChromeEvent<T> = {
+  addListener(listener: T): void;
+  removeListener(listener: T): void;
+};
+
+type NavigationProbe = {
+  heldReads: number;
+  sawLoad: boolean;
+  restore(): void;
+};
+
+declare const chrome: {
+  tabs: {
+    get(tabId: number): Promise<unknown>;
+    onUpdated: ChromeEvent<(tabId: number, change: { url?: string }) => void>;
+  };
+  debugger: {
+    onEvent: ChromeEvent<
+      (source: { tabId?: number }, method: string, params?: { name?: string }) => void
+    >;
+  };
+};
+declare const self: { navigationProbe?: NavigationProbe };
+
+/** Hold Chrome's real access lookup until its real load event, without delaying navigation. */
+export async function holdNavigationAccessCheck(worker: Worker, url: string) {
+  await worker.evaluate((destination) => {
+    const originalGet = chrome.tabs.get;
+    let tabId: number | undefined;
+    let release = () => {};
+    const loaded = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const onUpdated = (id: number, change: { url?: string }) => {
+      if (change.url === destination) {
+        tabId = id;
+      }
+    };
+    const onEvent = (source: { tabId?: number }, method: string, params?: { name?: string }) => {
+      if (source.tabId === tabId && method === "Page.lifecycleEvent" && params?.name === "load") {
+        probe.sawLoad = true;
+        release();
+      }
+    };
+    const probe: NavigationProbe = {
+      heldReads: 0,
+      sawLoad: false,
+      restore() {
+        release();
+        chrome.tabs.get = originalGet;
+        chrome.tabs.onUpdated.removeListener(onUpdated);
+        chrome.debugger.onEvent.removeListener(onEvent);
+        delete self.navigationProbe;
+      },
+    };
+    self.navigationProbe = probe;
+    chrome.tabs.get = async (id) => {
+      const tab = await originalGet.call(chrome.tabs, id);
+      if (id === tabId && !probe.sawLoad) {
+        probe.heldReads += 1;
+        await loaded;
+      }
+      return tab;
+    };
+    chrome.tabs.onUpdated.addListener(onUpdated);
+    chrome.debugger.onEvent.addListener(onEvent);
+  }, url);
+
+  return async () =>
+    await worker.evaluate(() => {
+      const probe = self.navigationProbe;
+      if (!probe) {
+        throw new Error("Navigation access probe missing");
+      }
+      const result = { heldReads: probe.heldReads, sawLoad: probe.sawLoad };
+      probe.restore();
+      return result;
+    });
+}


### PR DESCRIPTION
Closes #131309.

## What Problem This Solves

Fixes Chrome-extension navigation intermittently returning a 20-second load timeout after the selected page has already loaded. This also flakes the Chrome bootstrap E2E on unrelated PRs, including #131275 and #131483.

## Why This Change Was Made

The proof HTTP server already waits for its listen callback. The 500 is the browser dispatcher wrapping Playwright's timeout, not a proof-server response. A URL update retired the attachment's event epoch before asynchronous tab inspection, silently dropping the Runtime, Network, and Page events needed to finish navigation.

The access-policy owner now records successful epoch proofs and uses Chrome's authoritative full Tab update to renew only an existing, current attachment synchronously. Every navigation still retires old command epochs. Selected-group changes, restricted current/pending URLs, incognito, pauses, detached/unproven attachments, and mode revocation cannot renew. There is no event replay, timeout increase, retry, or public configuration change.

File permission is read once per extension policy lifetime: Chromium reloads the extension and closes debugger sessions when that permission changes. This allows the same renewal contract for file documents without a file-specific event-loss gap.

## User Impact

Allowed navigation keeps its original selected tab and completes normally in both All tabs and Selected tabs modes. Tab access boundaries are unchanged. AI-assisted repair.

## Evidence

- Unmodified Linux Chromium bootstrap E2E reproduced the exact `page.goto: Timeout 20000ms exceeded` / expected 500 to be 200 failure.
- New real-policy/Chrome-event regressions failed before the fix (11 failed, 13 passed); the new and existing policy, event, and background authorization suites pass after it (102 tests).
- The Chromium E2E holds the real post-URL access lookup until the real load event, checks that the fault was exercised, and retains selected-target, unrelated-tab, native bootstrap, pause, and version-doctor proof.
- Independent Codex autoreview reported no actionable blocker.
- Dependency contracts checked: Playwright 1.62.1 navigation/Network interception implementation; Chromium 151.0.7922.34 `tabs_event_router.cc` (full Tab snapshot), `extension_util.cc::SetAllowFileAccess`, and debugger unload behavior.
- Runtime delta: +15 lines; declarations +17 lines. Tests/test support counted separately. The added owner-held epoch proof replaces the asynchronous forwarding gap without introducing a queue or alternate navigation path.

### Completed Linux Chromium proof

On Chromium 151.0.7922.34, the deterministic test with the two pre-fix runtime modules restored failed with the original 20-second `page.goto` timeout / expected 500 to be 200. Restoring the fix then passed five consecutive complete bootstrap runs: ten forced-race navigations, covering All tabs and Selected tabs each time. The fault holds the real post-URL lookup until Chrome's real load event; it does not synthesize lifecycle events or increase the timeout.

Pre-rebase CI passed at `ebacf3c033926fcce0d52881c0b4852ec38ead15`: [CI run](https://github.com/openclaw/openclaw/actions/runs/33184480997). Earlier test-type and lint failures were corrected; no production changes were needed for those corrections. The dedicated [Linux Chromium proof lease](https://github.com/openclaw/openclaw/actions/runs/33183771469) also passed an additional bootstrap at that head with temporary group-revocation instrumentation:

```text
mode=all injected-detach=1 production-reconnect=1 owner-target-preserved=1 unrelated-tab-unchanged=1 status=200
mode=selected injected-detach=1 production-reconnect=1 owner-target-preserved=1 unrelated-tab-unchanged=1 status=200
group-before-url=1 relayed-after-revoke=0 action-status=500 side-effects=0
Test Files 1 passed; Tests 1 passed
```

The revocation probe renamed the actual selected group, navigated through independent Chromium control, observed the worker's actual event order and outgoing CDP event messages, and attempted an extension action with a page sentinel. The action was denied and the sentinel was absent. Temporary instrumentation was restored after the run. External lease cleanup may leave its hosting Actions run cancelled; the delegated proof command exited 0.

### ClawSweeper reconciliation

The latest review and rank-up move asked for group-title revocation ordering/final-effect proof. In the tested Chromium version, title mutation synchronously notifies the group router ([producer](https://github.com/chromium/chromium/blob/151.0.7922.34/chrome/browser/ui/tabs/tab_strip_model.cc#L2167)), which dispatches `tabGroups.onUpdated`. All events for the running worker share one ordered dispatcher ([worker remote](https://github.com/chromium/chromium/blob/151.0.7922.34/extensions/browser/event_router.cc#L180), [Mojo ordering](https://github.com/chromium/chromium/blob/151.0.7922.34/mojo/public/cpp/bindings/associated_remote.h#L29)); [debugger events use that same router](https://github.com/chromium/chromium/blob/151.0.7922.34/chrome/browser/extensions/api/debugger/debugger_api.cc#L675). Worker dispatch reaches its JS listeners synchronously ([dispatch](https://github.com/chromium/chromium/blob/151.0.7922.34/extensions/renderer/service_worker_data.cc#L127), [worker V8 invocation](https://github.com/chromium/chromium/blob/151.0.7922.34/extensions/renderer/script_context.cc#L239)). Thus a URL event already dispatched before a rename may precede it, but later debugger events cannot overtake the revocation. The existing group handler invalidates all epochs synchronously before awaiting anything. Restart discards the old in-memory proofs.

This is source evidence for the exact tested Chromium version, complemented by the real final-effect probe, not an assertion about undocumented behavior in every future browser. It resolves the selected-group concern without adding a title cache or weakening revocation. No new config, protocol, permission, or persistent state surface was added.

### Known separate follow-up

An additional real Chromium run exposed the pre-existing command-completion error `Protocol error (Page.navigate): tab ... access was revoked`; the next unchanged run passed. This is not the lost-load-event timeout. Real owner-module reproduction on both baseline and current code, in both modes, proves that a successful navigation can retire its own response epoch. Tracked in #131857; this PR does not claim to fix that separate signature. Repair requires preserving strict pre-effect checks while designing safe post-effect result release, rather than weakening the intentional stale-command guard.

Final size: runtime +41/-26 (net +15), declarations +18/-1 (net +17), tests/test-support +351/-2. The 84-line fault injector is test support, not production. The small runtime growth is the exact-object proof/renewal owner; async file-permission branches were removed instead of adding parallel navigation or replay paths.

### Final bootstrap scope

After reconciling the navigation diagnostics newly landed on main, a further selected-mode bootstrap expansion reproduced #131857 again. That newly added full-bootstrap variant is deferred to the command-completion repair, rather than adding a known intermittent failure to CI. The committed bootstrap retains main's original All tabs flow and every assertion/diagnostic unchanged; its only delta is 11 lines to install, restore, and assert the deterministic event-loss probe. The 24 policy/event-boundary cases retain All/Selected mode coverage, and the earlier five successful two-mode live runs plus selected-group revocation proof remain evidence for the unchanged production repair. No timeout, retry, or assertion was weakened.

### Final-head verification

At `e67cafd14153834119bdf4a6a7b3c25aab13060e`, the original-scope bootstrap passed **five consecutive complete real Chromium runs** with the race forced each time (delegated command exit 0, 4m36s). The combined policy/event/background/diagnostic suites passed 105 tests after the main reconciliation. Fresh independent review of the final test simplification was clean. Production files are byte-identical to the candidate used for the earlier all/selected and group-revocation proofs.

The final CI attempt encountered an unrelated Matrix native-binary download `ECONNRESET` during Node setup in `check-session-transcript-reader-boundary`; the boundary check itself never ran in that failed job. No dependency or test behavior is changed to work around that infrastructure failure.

Final CI is green at the exact head: [run33187183739, attempt2](https://github.com/openclaw/openclaw/actions/runs/33187183739/attempts/2). Only the failed installation job and its dependent gate were rerun; the browser E2E shards, lint, types, and other checks had already passed. Native review/prepare artifacts are refreshed for the final head.
