### PR TITLE
fix(system-agent): system-agent turns fail with stale Codex session generation when two conversations run

### DIFF
--- a/src/system-agent/agent-turn.test.ts
+++ b/src/system-agent/agent-turn.test.ts
@@ -7,6 +7,8 @@ import { testing as cliBackendsTesting } from "../agents/cli-backends.test-suppo
 import { fingerprintResolvedProviderAuth } from "../agents/execution-auth-binding.js";
 import { createSystemAgentTool } from "../agents/tools/system-agent-tool.js";
 import type { OpenClawConfig } from "../config/types.js";
+import { toAgentStoreSessionKey } from "../routing/session-key.js";
+import { SYSTEM_AGENT_ID } from "./agent-id.js";
 import {
   cleanupSystemAgentSession,
   createSystemAgentSession,
@@ -265,6 +267,25 @@ describe("runSystemAgentTurn", () => {
     expect(firstPath).toBe(`in-memory:${first.sessionId}`);
     expect(secondPath).toBe(`in-memory:${second.sessionId}`);
     expect(firstPath).not.toBe(secondPath);
+    const firstSessionKey = requireValue(
+      mocks.runEmbeddedAgent.mock.calls[0]?.[0]?.sessionKey,
+      "missing first embedded session key",
+    );
+    const secondSessionKey = requireValue(
+      mocks.runEmbeddedAgent.mock.calls[1]?.[0]?.sessionKey,
+      "missing second embedded session key",
+    );
+    expect(firstSessionKey).toBe(
+      toAgentStoreSessionKey({ agentId: SYSTEM_AGENT_ID, requestKey: first.sessionId }),
+    );
+    expect(secondSessionKey).toBe(
+      toAgentStoreSessionKey({ agentId: SYSTEM_AGENT_ID, requestKey: second.sessionId }),
+    );
+    // Independent conversations must not share one runner key, or the first
+    // Codex session-generation fence invalidates every later conversation.
+    expect(firstSessionKey).not.toBe(secondSessionKey);
+    expect(firstSessionKey).not.toBe("agent:openclaw:main");
+    expect(secondSessionKey).not.toBe("agent:openclaw:main");
     expect(first.sessionManager).not.toBe(second.sessionManager);
     await cleanupSystemAgentSession(first);
     expect(first.sessionManager).toBeUndefined();
@@ -321,7 +342,10 @@ describe("runSystemAgentTurn", () => {
       agentDir,
       authProfileId: "claude-cli:ops",
       agentId: "openclaw",
-      sessionKey: "agent:openclaw:main",
+      sessionKey: toAgentStoreSessionKey({
+        agentId: SYSTEM_AGENT_ID,
+        requestKey: session.sessionId,
+      }),
       sessionId: session.sessionId,
       workspaceDir: path.join(stateDir, "openclaw", "workspace"),
       sessionFile: `in-memory:${session.sessionId}`,
@@ -812,7 +836,10 @@ describe("runSystemAgentTurn", () => {
       authProfileIdSource: "user",
       agentHarnessRuntimeOverride: "codex",
       agentId: "openclaw",
-      sessionKey: "agent:openclaw:main",
+      sessionKey: toAgentStoreSessionKey({
+        agentId: SYSTEM_AGENT_ID,
+        requestKey: session.sessionId,
+      }),
       sessionId: session.sessionId,
       workspaceDir: path.join(stateDir, "openclaw", "workspace"),
       sessionFile: `in-memory:${session.sessionId}`,

--- a/src/system-agent/agent-turn.ts
+++ b/src/system-agent/agent-turn.ts
@@ -9,7 +9,7 @@ import { normalizeCliModel } from "../agents/cli-runner/helpers.js";
 import { SessionManager } from "../agents/sessions/index.js";
 import { resolveStateDir } from "../config/paths.js";
 import type { CliSessionBinding } from "../config/sessions.js";
-import { buildAgentMainSessionKey } from "../routing/session-key.js";
+import { toAgentStoreSessionKey } from "../routing/session-key.js";
 import { SYSTEM_AGENT_ID } from "./agent-id.js";
 import { SYSTEM_AGENT_SYSTEM_PROMPT } from "./assistant-prompts.js";
 import { SystemAgentInferenceUnavailableError } from "./inference-error.js";
@@ -314,7 +314,13 @@ async function runSystemAgentTurnWithDeps(
   );
   const shared = {
     sessionId: params.session.sessionId,
-    sessionKey: buildAgentMainSessionKey({ agentId: SYSTEM_AGENT_ID }),
+    // Derive the runner key from this conversation's in-memory session id so
+    // independent system-agent conversations do not share one Codex session
+    // generation fence (see issue #131807).
+    sessionKey: toAgentStoreSessionKey({
+      agentId: SYSTEM_AGENT_ID,
+      requestKey: params.session.sessionId,
+    }),
     agentId: SYSTEM_AGENT_ID,
     trigger: "manual" as const,
     sessionFile: `in-memory:${params.session.sessionId}`,


### PR DESCRIPTION
Closes #131807

## What Problem This Solves

Fixes an issue where OpenClaw system-agent conversations would fail every turn before inference with `Codex session generation is no longer current` as soon as one conversation completed a turn through the Codex embedded harness. The system-agent surface then reported that working inference was unavailable and suggested running onboarding, even though the configured route, endpoint, and authentication were healthy.

## Why This Change Was Made

Every system-agent conversation created a distinct in-memory session id and transcript, but all of them supplied the same durable runner key `agent:openclaw:main`. Codex binds its physical session generation to that key on the first turn, so any other conversation reusing the key is deterministically rejected at the session-binding boundary.

The fix derives the runner key from each conversation's own in-memory session id via `toAgentStoreSessionKey({ agentId: SYSTEM_AGENT_ID, requestKey: session.sessionId })`. Keys remain stable within one conversation (resume still works) while independent conversations no longer share one generation fence. The synthetic `openclaw` agent identity is preserved, and the helper falls back to the `main` key when no request key is present. The TUI session catalog (`tui-backend.ts`) intentionally keeps its own single-session key — it is a display surface with a fixed `openclaw` session id and does not feed the Codex runner boundary.

## User Impact

Operators can run multiple independent system-agent conversations through the Codex embedded harness without the second conversation invalidating the first. System-agent turns no longer surface a false "inference unavailable / run onboarding" error when the route is healthy.

## Evidence

- Regression coverage added to `src/system-agent/agent-turn.test.ts` ("uses a distinct transcript for each chat session"): two independent conversations now receive keys derived from their own session ids, the keys differ from each other and from `agent:openclaw:main`, and turns within one conversation stay on its key.
- Focused suite passes: `src/system-agent/agent-turn.test.ts` — 22/22 tests.
- Typecheck (`tsgo:core`) and oxlint are clean for the touched files (`src/system-agent/agent-turn.ts`, `src/system-agent/agent-turn.test.ts`); the remaining `tsgo` failures on `main` are pre-existing in `src/tui/*` and `packages/*` and unaffected by this change.

### Real behavior proof: two independent system-agent conversations

Runtime trace through the real production turn pipeline (`createSystemAgentSession` → `runSystemAgentTurn` dependency-injection boundary, Node 24.15.0, source checkout), with the runner boundary enforcing the documented Codex session-generation fence (a key already bound to one physical session rejects any other session). Session IDs are redacted. Branch rebased on current `origin/main` at `23b2c21f37a`.

```text
== two independent system-agent conversations ==
conversation A: sessionId=openclaw-04ab…
conversation B: sessionId=openclaw-a97a…
A turn 1: OK (reply="SYSTEM_HELPER_OK")
B turn 1: OK (reply="SYSTEM_HELPER_OK")
B turn 2 (resume): OK (reply="SYSTEM_HELPER_OK")
A turn 2 (resume): OK (reply="SYSTEM_HELPER_OK")

== runner session keys bound at the Codex boundary ==
agent:openclaw:openclaw-04ab… -> openclaw-04ab…
agent:openclaw:openclaw-a97a… -> openclaw-a97a…
distinct keys: 2 (expected 2)
shared legacy key present: false (expected false)

== legacy shared-key failure mode (pre-fix behavior, simulated) ==
legacy key agent:openclaw:main bound by conversation A
conversation B on same legacy key: rejected -> Codex session generation is no longer current: openclaw-04ab…
(matches the pre-fix failure reported in issue #131807)

PROOF RESULT: PASS — conversations isolated, resume stable, failure mode reproduced
```

Before the fix, the same fence trace showed conversation B failing with `Codex session generation is no longer current` and the runner reporting `OpenClaw could not reach working inference. Run openclaw onboard…`, while only one key (`agent:openclaw:main`) was bound. After the fix, both conversations keep distinct keys, resume turns stay on their own key, and every turn succeeds.

### CI note

One CI shard failed on the first push: `checks-node-compact-small-43` timed out in `test/scripts/dev-tooling-safety.test.ts` (Discord smoke arg parsing). That suite is unrelated to this change and passes locally (60/60 on the same commit). The branch has been rebased onto current `origin/main` to pick up a fresh CI run.

### Live gateway run (built artifact at this PR head)

Ran the REAL built gateway from this branch (`OpenClaw 2026.8.1 (23b2c21)`, `pnpm build` completed) with an isolated state dir, `gateway.mode: local`, route `openai/gpt-5.6-luna`, and the Codex extension loaded (16 plugins including `codex`). Two independent operator connections were driven through the raw Gateway WebSocket protocol (`connect.challenge` handshake + `openclaw.chat` RPC), matching the issue's reproduction shape (two independent system-agent conversations):

```text
[proof] proof-device-a: connected (challenge nonce 235c3004-2…)
[proof] proof-device-b: connected (challenge nonce 161ad3a9-2…)
[proof] two independent operator connections established
[proof] A turn 1: ok=false UNAVAILABLE system_agent_inference_unavailable: HTTP 403 (provider boundary)
[proof] B turn 1: ok=false UNAVAILABLE system_agent_inference_unavailable: HTTP 403 (provider boundary)
gateway log: setup_inference_probe_failed provider=openai model=gpt-5.6-luna runner=embedded
```

Both conversations independently progressed through the complete pre-inference pipeline to the real provider HTTP boundary. Note the failure location: the reported bug rejects turns at OpenClaw's session-binding boundary BEFORE any provider request (`Codex session generation is no longer current`); here both conversations reach live provider HTTP instead, which is the stage after session-key binding.

### Environment limitation for full live Codex inference

A successful after-fix reply through a real Codex app-server client could not be captured from this contributor environment:

- Direct OpenAI endpoint: `HTTP 403: Country, region, or territory not supported` (region-blocked).
- The locally available corporate relay used by the Codex CLI (`maas-apigateway.dt.zte.com.cn`) does not implement the `responses` API required by Codex app-server 0.146: `413` at `…/v1/chat/completions/responses` with `wire_api = "responses"`, `404` at `…/v1/responses`, and the CLI rejects `wire_api = "chat"` for this flow.

The dependency-injected fence trace above exercises the exact production key-derivation and runner-binding code paths with the documented fence semantics, and the live run above shows both conversations passing the binding stage independently. A maintainer or reviewer with Codex/OpenAI access can confirm end-to-end with any two system-agent conversations on this branch.
