### PR TITLE
fix(sessions): stop retries from inheriting stale elapsed time

### DIFF
--- a/docs/concepts/agent-loop.md
+++ b/docs/concepts/agent-loop.md
@@ -124,6 +124,8 @@ or raw errors out of the transcript/runtime path.
 
 Assistant deltas buffer into chat `delta` messages. A chat `final` is emitted on **lifecycle end/error**.
 
+Run-duration metadata belongs to the current run, including when preparation fails before the model starts. In Control UI completed-work rollups, independent sends have separate elapsed-time boundaries: a failed turn and the idle time before the next send are not part of that next turn's work. Steering remains associated with its target run rather than being treated as an independent retry.
+
 ## Timeouts
 
 | Timeout                                          | Default                                | Notes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
@@ -186,9 +186,10 @@ describe("handleAgentEnd", () => {
     );
   });
 
-  it("keeps explicit session and agent identity on lifecycle start events", () => {
+  it("keeps identity and the same observed start time on the bus and callback", () => {
     emitAgentEventMock.mockClear();
-    const ctx = createContext(undefined);
+    const onAgentEvent = vi.fn();
+    const ctx = createContext(undefined, { onAgentEvent });
     ctx.params.sessionId = "session-1";
     ctx.params.agentId = "main";
 
@@ -201,6 +202,12 @@ describe("handleAgentEnd", () => {
       agentId: "main",
       stream: "lifecycle",
       data: expect.objectContaining({ phase: "start" }),
+    });
+    const event = emitAgentEventMock.mock.calls[0]?.[0];
+    expect(event.data.startedAt).toEqual(expect.any(Number));
+    expect(onAgentEvent).toHaveBeenCalledExactlyOnceWith({
+      stream: "lifecycle",
+      data: event.data,
     });
   });
 

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
@@ -37,6 +37,7 @@ export {
 
 export function handleAgentStart(ctx: EmbeddedAgentSubscribeContext) {
   ctx.log.debug(`embedded run agent start: runId=${ctx.params.runId}`);
+  const data = { phase: "start", startedAt: Date.now() };
   emitAgentEvent({
     runId: ctx.params.runId,
     ...(ctx.params.sessionKey ? { sessionKey: ctx.params.sessionKey } : {}),
@@ -46,10 +47,7 @@ export function handleAgentStart(ctx: EmbeddedAgentSubscribeContext) {
       ? { lifecycleGeneration: ctx.params.lifecycleGeneration }
       : {}),
     stream: "lifecycle",
-    data: {
-      phase: "start",
-      startedAt: Date.now(),
-    },
+    data,
   });
   runBestEffortCallback({
     label: "lifecycle agent event",
@@ -57,7 +55,7 @@ export function handleAgentStart(ctx: EmbeddedAgentSubscribeContext) {
     callback: () =>
       ctx.params.onAgentEvent?.({
         stream: "lifecycle",
-        data: { phase: "start" },
+        data,
       }),
   });
 }

--- a/src/auto-reply/reply/agent-lifecycle-terminal.ts
+++ b/src/auto-reply/reply/agent-lifecycle-terminal.ts
@@ -49,7 +49,9 @@ export function createAgentLifecycleTerminalBackstop(params: {
   };
 }): AgentLifecycleTerminalBackstop {
   let terminalEmitted = false;
-  let startedAt = params.startedAt;
+  // Preparation can fail before a lifecycle start. Capture its real boundary
+  // without signaling readiness; an observed model start replaces it below.
+  let startedAt = params.startedAt ?? Date.now();
   let deferredError: string | undefined;
   const deferredTerminalMetadata: Record<string, unknown> = {};
 
@@ -91,7 +93,7 @@ export function createAgentLifecycleTerminalBackstop(params: {
       ...deferredTerminalMetadata,
       phase: restartAbort ? "end" : phase,
       endedAt: Date.now(),
-      ...(startedAt !== undefined ? { startedAt } : {}),
+      startedAt,
     };
     if (restartAbort) {
       data.aborted = true;

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
@@ -464,6 +464,7 @@ describe("runCliAgentWithLifecycle", () => {
       await runCliAgentWithLifecycle({
         runId: "run-before-restart",
         lifecycleGeneration,
+        startedAt: 1_000,
         provider: "claude-cli",
         runParams: {
           sessionId: "session-1",
@@ -488,6 +489,7 @@ describe("runCliAgentWithLifecycle", () => {
       lifecycleEvents.every((event) => event.lifecycleGeneration === lifecycleGeneration),
     ).toBe(true);
     expect(lifecycleEvents.every((event) => event.agentId === "support")).toBe(true);
+    expect(lifecycleEvents.every((event) => event.data?.startedAt === 1_000)).toBe(true);
   });
 
   it("preserves restart ownership when the CLI resolves after cancellation", async () => {

--- a/src/auto-reply/reply/agent-runner-error-handler.ts
+++ b/src/auto-reply/reply/agent-runner-error-handler.ts
@@ -20,15 +20,14 @@ import {
   renderRateLimitReplyCopy,
 } from "../../agents/failover/user-copy.js";
 import { LiveSessionModelSwitchError } from "../../agents/live-model-switch-error.js";
-import { resolveAgentRunErrorLifecycleFields } from "../../agents/run-termination.js";
 import { logVerbose } from "../../globals.js";
-import { emitAgentEvent } from "../../infra/agent-events.js";
 import { sleepWithAbort } from "../../infra/backoff.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
 import { defaultRuntime } from "../../runtime.js";
 import { markReplyPayloadForSourceSuppressionDelivery } from "../reply-payload.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
+import { createAgentLifecycleTerminalBackstop } from "./agent-lifecycle-terminal.js";
 import { buildContextOverflowRecoveryText } from "./agent-runner-context-recovery.js";
 import type { AgentTurnInternalResult, AgentTurnParams } from "./agent-runner-execution.types.js";
 import {
@@ -46,6 +45,7 @@ import {
   buildRestartLifecycleReplyText,
   isReplyOperationRestartAbort,
   isReplyOperationUserAbort,
+  resolveReplyOperationTerminationFields,
   resolveRestartLifecycleError,
 } from "./reply-operation-abort.js";
 
@@ -118,13 +118,26 @@ export async function handleAgentExecutionError(params: {
   const turn = params.turn;
   const err = params.error;
   const takePendingLifecycleTerminal = () => {
-    const terminal = params.state.pendingLifecycleTerminal?.backstop;
+    const terminal =
+      params.state.pendingLifecycleTerminal?.backstop ??
+      createAgentLifecycleTerminalBackstop({
+        runId: params.runId,
+        sessionKey: turn.sessionKey,
+        startedAt: params.overloadRetryState.turnStartedAtMs,
+        getLifecycleGeneration: () => params.state.lifecycleGeneration,
+        resolveTerminationFields: (error) =>
+          resolveReplyOperationTerminationFields(
+            error,
+            turn.replyOperation?.abortSignal ?? turn.opts?.abortSignal,
+            turn.replyOperation,
+          ),
+      });
     params.state.pendingLifecycleTerminal = undefined;
     return terminal;
   };
   const resolveReplyOperationAbortAction = (abortError: unknown): ErrorAction | undefined => {
     if (isReplyOperationRestartAbort(turn.replyOperation)) {
-      takePendingLifecycleTerminal()?.emit("end", abortError);
+      takePendingLifecycleTerminal().emit("end", abortError);
       return {
         kind: "final",
         payload:
@@ -134,7 +147,7 @@ export async function handleAgentExecutionError(params: {
       };
     }
     if (isReplyOperationUserAbort(turn.replyOperation)) {
-      takePendingLifecycleTerminal()?.emit("error", abortError);
+      takePendingLifecycleTerminal().emit("error", abortError);
       return { kind: "final", payload: { text: SILENT_REPLY_TOKEN } };
     }
     return undefined;
@@ -160,7 +173,7 @@ export async function handleAgentExecutionError(params: {
       `Live model switch failed after ${MAX_LIVE_SWITCH_RETRIES} retries ` +
         `(${sanitizeForLog(err.provider)}/${sanitizeForLog(err.model)}). The requested model may be unavailable.`,
     );
-    takePendingLifecycleTerminal()?.emit("error", err);
+    takePendingLifecycleTerminal().emit("error", err);
     const switchErrorText = params.shouldSurfaceToControlUi
       ? renderControlUiAgentFailureCopy(
           "model switch could not be completed. The requested model may be temporarily unavailable.",
@@ -229,7 +242,7 @@ export async function handleAgentExecutionError(params: {
     restartLifecycleError instanceof GatewayDrainingError ||
     restartLifecycleError instanceof CommandLaneClearedError
   ) {
-    takePendingLifecycleTerminal()?.emit("error", restartLifecycleError);
+    takePendingLifecycleTerminal().emit("error", restartLifecycleError);
     turn.replyOperation?.fail(
       restartLifecycleError instanceof GatewayDrainingError
         ? "gateway_draining"
@@ -242,7 +255,7 @@ export async function handleAgentExecutionError(params: {
     };
   }
   if (isCompactionFailure) {
-    takePendingLifecycleTerminal()?.emit("error", err);
+    takePendingLifecycleTerminal().emit("error", err);
     defaultRuntime.error(
       `Auto-compaction failed (${message}). Preserving existing session mapping for ${turn.sessionKey ?? turn.followupRun.run.sessionId}.`,
     );
@@ -414,7 +427,7 @@ export async function handleAgentExecutionError(params: {
     return { kind: "retry" };
   }
   if (providerRequestError) {
-    takePendingLifecycleTerminal()?.emit("error", err);
+    takePendingLifecycleTerminal().emit("error", err);
     turn.replyOperation?.fail("run_failed", err);
     await params.modelPatch.fail(err);
     return {
@@ -496,31 +509,7 @@ export async function handleAgentExecutionError(params: {
     isGenericRunnerFailure: externalRunFailureReply?.isGenericRunnerFailure ?? false,
     cfg: turn.followupRun.run.config,
   });
-  const abortedSignal =
-    turn.replyOperation?.abortSignal.aborted === true
-      ? turn.replyOperation.abortSignal
-      : turn.opts?.abortSignal?.aborted === true
-        ? turn.opts.abortSignal
-        : undefined;
-  const abortLifecycleFields = resolveAgentRunErrorLifecycleFields(err, abortedSignal);
-  const failedLifecycleTerminal = takePendingLifecycleTerminal();
-  if (failedLifecycleTerminal) {
-    failedLifecycleTerminal.emit("error", err, { fallbackExhaustedFailure: true });
-  } else {
-    emitAgentEvent({
-      runId: params.runId,
-      lifecycleGeneration: params.state.lifecycleGeneration,
-      ...(turn.sessionKey ? { sessionKey: turn.sessionKey } : {}),
-      stream: "lifecycle",
-      data: {
-        phase: "error",
-        error: message,
-        endedAt: Date.now(),
-        ...abortLifecycleFields,
-        fallbackExhaustedFailure: true,
-      },
-    });
-  }
+  takePendingLifecycleTerminal().emit("error", err, { fallbackExhaustedFailure: true });
   turn.replyOperation?.fail("run_failed", err);
   await params.modelPatch.fail(err);
   return {

--- a/src/auto-reply/reply/agent-runner-execution-timing.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-timing.test.ts
@@ -1,0 +1,107 @@
+import { expect, it, vi } from "vitest";
+import type { InternalSessionEntry } from "../../config/sessions.js";
+import { deriveGatewaySessionLifecycleSnapshot } from "../../gateway/session-lifecycle-state.js";
+import { emitAgentEvent, onAgentEvent, type AgentEventPayload } from "../../infra/agent-events.js";
+import {
+  createMinimalRunAgentTurnParams,
+  setupAgentRunnerExecutionTestState,
+  type EmbeddedAgentParams,
+} from "./agent-runner-execution.test-support.js";
+
+vi.mock("../../gateway/session-utils.js", () => ({ loadSessionEntry: vi.fn() }));
+
+const state = setupAgentRunnerExecutionTestState();
+
+it.each(["embedded preparation", "fallback preparation"])(
+  "times %s failure between successful turns without borrowing the previous start",
+  async (failureBoundary) => {
+    const { executeAgentTurn } = await import("./agent-runner-execution.js");
+    let now = 1_000_000;
+    const clock = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const session: InternalSessionEntry = { sessionId: "session", updatedAt: now };
+    const lifecycle: AgentEventPayload[] = [];
+    const unsubscribe = onAgentEvent((event) => {
+      if (event.stream !== "lifecycle" || event.sessionKey !== "main") {
+        return;
+      }
+      lifecycle.push(event);
+      Object.assign(session, deriveGatewaySessionLifecycleSnapshot({ session, event }));
+    });
+    const onAgentRunStart = vi.fn();
+    const turn = createMinimalRunAgentTurnParams({ opts: { onAgentRunStart } });
+    const run = (runId: string) =>
+      executeAgentTurn({
+        ...turn,
+        opts: { ...turn.opts, runId },
+        activeSessionStore: { main: session },
+        getActiveSessionEntry: () => session,
+      });
+    const succeed = async (params: EmbeddedAgentParams) => {
+      const data = { phase: "start", startedAt: now };
+      emitAgentEvent({ runId: params.runId, sessionKey: "main", stream: "lifecycle", data });
+      await params.onAgentEvent?.({ stream: "lifecycle", data });
+      expect(session).toMatchObject({ status: "running", startedAt: now });
+      expect(session.lastRunError).toBeUndefined();
+      expect(session.runtimeMs).toBeUndefined();
+      expect(session.endedAt).toBeUndefined();
+      now += 11_192;
+      return { payloads: [{ text: "done" }], meta: {} };
+    };
+    try {
+      state.runEmbeddedAgentMock.mockImplementationOnce(succeed);
+      await run("timing-previous");
+      expect(session).toMatchObject({ status: "done", startedAt: 1_000_000, runtimeMs: 11_192 });
+
+      now = 3_475_979;
+      const rejectPreparation = async () => {
+        now += 4_700;
+        throw new Error("preparation failed before model start");
+      };
+      if (failureBoundary === "embedded preparation") {
+        state.runEmbeddedAgentMock.mockImplementationOnce(rejectPreparation);
+      } else {
+        state.runEmbeddedAgentEntryMock.mockImplementationOnce(rejectPreparation);
+      }
+      const failed = await run("timing-failed");
+      expect(failed.outcome.kind).toBe("rejected");
+      expect(onAgentRunStart).toHaveBeenCalledTimes(1);
+      expect(turn.typingSignals.signalRunStart).not.toHaveBeenCalled();
+      expect(turn.typingSignals.signalExecutionActivity).not.toHaveBeenCalled();
+      const failureEvents = lifecycle.filter((event) => event.runId === "timing-failed");
+      expect(failureEvents).toHaveLength(1);
+      expect.soft(failureEvents[0]?.data).toMatchObject({
+        phase: "error",
+        startedAt: 3_475_979,
+        endedAt: 3_480_679,
+      });
+      expect.soft(session).toMatchObject({
+        status: "failed",
+        startedAt: 3_475_979,
+        runtimeMs: 4_700,
+        lastRunError: "preparation failed before model start",
+      });
+
+      now = 3_600_000;
+      state.runEmbeddedAgentMock.mockImplementationOnce(succeed);
+      await run("timing-recovered");
+      expect(session).toMatchObject({
+        status: "done",
+        startedAt: 3_600_000,
+        endedAt: 3_611_192,
+        runtimeMs: 11_192,
+      });
+      expect(session.lastRunError).toBeUndefined();
+      expect(onAgentRunStart).toHaveBeenCalledTimes(2);
+      expect(lifecycle.map((event) => [event.runId, event.data.phase])).toEqual([
+        ["timing-previous", "start"],
+        ["timing-previous", "end"],
+        ["timing-failed", "error"],
+        ["timing-recovered", "start"],
+        ["timing-recovered", "end"],
+      ]);
+    } finally {
+      unsubscribe();
+      clock.mockRestore();
+    }
+  },
+);

--- a/src/auto-reply/reply/agent-runner-execution.test-support.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test-support.ts
@@ -287,6 +287,7 @@ vi.mock("./agent-runner-utils.js", () => ({
           },
           senderContext: {},
           runBaseParams: {
+            runId: params.runId,
             provider: params.provider,
             model: params.model,
             thinkLevel: params.run.thinkLevel,

--- a/src/gateway/session-lifecycle-state.persistence.test.ts
+++ b/src/gateway/session-lifecycle-state.persistence.test.ts
@@ -1,0 +1,105 @@
+import path from "node:path";
+import { expect, it, vi } from "vitest";
+import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { createAgentLifecycleTerminalBackstop } from "../auto-reply/reply/agent-lifecycle-terminal.js";
+import { loadSessionEntry, replaceSessionEntry } from "../config/sessions/session-accessor.js";
+import {
+  emitAgentEvent,
+  getAgentEventLifecycleGeneration,
+  onAgentEvent,
+} from "../infra/agent-events.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { persistGatewaySessionLifecycleEvent } from "./session-lifecycle-state.js";
+
+const routing = vi.hoisted(() => ({ loadSessionEntry: vi.fn() }));
+vi.mock("./session-utils.js", () => ({ loadSessionEntry: routing.loadSessionEntry }));
+
+it("persists current-run timing after pre-start failure and clears it on the next run", async () => {
+  const tempDirs = createTempDirTracker();
+  const target = {
+    storePath: path.join(tempDirs.make("openclaw-lifecycle-timing-"), "sessions.json"),
+    sessionKey: "agent:main:timing",
+  };
+  let now = 1_000_000;
+  const clock = vi.spyOn(Date, "now").mockImplementation(() => now);
+  routing.loadSessionEntry.mockImplementation(() => ({
+    ...target,
+    canonicalKey: target.sessionKey,
+    entry: loadSessionEntry(target),
+  }));
+  let persistence = Promise.resolve();
+  const unsubscribe = onAgentEvent((event) => {
+    if (event.sessionKey === target.sessionKey && event.stream === "lifecycle") {
+      persistence = persistence.then(() =>
+        persistGatewaySessionLifecycleEvent({ sessionKey: target.sessionKey, event }),
+      );
+    }
+  });
+  const createBackstop = (runId: string) =>
+    createAgentLifecycleTerminalBackstop({
+      runId,
+      sessionKey: target.sessionKey,
+      getLifecycleGeneration: getAgentEventLifecycleGeneration,
+      resolveTerminationFields: () => ({}),
+    });
+  const start = (runId: string) => {
+    const backstop = createBackstop(runId);
+    const data = { phase: "start", startedAt: now };
+    emitAgentEvent({ runId, sessionKey: target.sessionKey, stream: "lifecycle", data });
+    backstop.note({ stream: "lifecycle", data });
+    return backstop;
+  };
+  try {
+    await replaceSessionEntry(target, { sessionId: "timing-session", updatedAt: now });
+    const previous = start("timing-persisted-previous");
+    now += 11_192;
+    previous.emit("end", { meta: {} });
+    await persistence;
+    expect(loadSessionEntry(target)).toMatchObject({
+      status: "done",
+      startedAt: 1_000_000,
+      runtimeMs: 11_192,
+    });
+
+    now = 3_475_979;
+    const failed = createBackstop("timing-persisted-failed");
+    now += 4_700;
+    failed.emit("error", new Error("preparation failed"));
+    await persistence;
+    expect.soft(loadSessionEntry(target)).toMatchObject({
+      status: "failed",
+      startedAt: 3_475_979,
+      endedAt: 3_480_679,
+      runtimeMs: 4_700,
+      lastRunError: "preparation failed",
+      lastRunId: "timing-persisted-failed",
+    });
+
+    now = 3_600_000;
+    const recovered = start("timing-persisted-recovered");
+    await persistence;
+    const running = loadSessionEntry(target);
+    expect(running).toMatchObject({ status: "running", startedAt: 3_600_000 });
+    expect(running?.runtimeMs).toBeUndefined();
+    expect(running?.endedAt).toBeUndefined();
+    expect(running?.lastRunError).toBeUndefined();
+    now += 11_192;
+    recovered.emit("end", { meta: {} });
+    await persistence;
+    closeOpenClawAgentDatabasesForTest();
+    expect(loadSessionEntry(target)).toMatchObject({
+      status: "done",
+      startedAt: 3_600_000,
+      endedAt: 3_611_192,
+      runtimeMs: 11_192,
+      lastRunId: "timing-persisted-recovered",
+    });
+  } finally {
+    unsubscribe();
+    await persistence;
+    clock.mockRestore();
+    routing.loadSessionEntry.mockReset();
+    closeOpenClawAgentDatabasesForTest();
+    tempDirs.cleanup();
+  }
+});

--- a/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
@@ -3,7 +3,11 @@ import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
 import { afterEach, expect, it } from "vitest";
-import { installMockGateway, pauseVirtualClock } from "../test-helpers/control-ui-e2e.ts";
+import {
+  controlUiSessionUrl,
+  installMockGateway,
+  pauseVirtualClock,
+} from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
@@ -20,6 +24,117 @@ suite.define(() => {
       .close()
       .catch(() => {});
     page = undefined;
+  });
+
+  it("excludes a reply-less failed turn's idle time from the next successful turn", async () => {
+    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const currentPage = await context.newPage();
+    page = currentPage;
+    const sessionKey = "agent:main:dashboard:failed-turn-elapsed";
+    const gateway = await installMockGateway(currentPage, { sessionKey });
+    await currentPage.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
+    const composer = currentPage.locator(".agent-chat__input textarea");
+    await composer.fill("First attempt");
+    // Freeze wall time without pausing the animation frames that publish sends.
+    const firstStartedAt = Date.now();
+    await currentPage.clock.setFixedTime(firstStartedAt);
+    const messages: Record<string, unknown>[] = [];
+    const persistUser = async (text: string, timestamp: number, after: number) => {
+      const send = await gateway.waitForRequest("chat.send", { after });
+      expect(send.params).toMatchObject({ sessionKey, idempotencyKey: expect.any(String) });
+      const { idempotencyKey: runId } = send.params as { idempotencyKey: string };
+      const message = {
+        role: "user",
+        content: text,
+        timestamp,
+        __openclaw: {
+          id: `user-${after}`,
+          idempotencyKey: `${runId}:user`,
+          senderId: "operator",
+        },
+      };
+      messages.push(message);
+      await gateway.setHistoryMessages(messages);
+      await gateway.emitGatewayEvent("session.message", {
+        sessionKey,
+        clientRunId: runId,
+        message,
+        messageId: message["__openclaw"].id,
+        messageSeq: messages.length,
+        activeRunIds: [runId],
+        hasActiveRun: true,
+      });
+      await currentPage.getByRole("button", { name: "Stop generating" }).waitFor();
+      return runId;
+    };
+    await currentPage.getByRole("button", { name: "Send message" }).click();
+    const failedRunId = await persistUser("First attempt", firstStartedAt, 0);
+    await gateway.emitGatewayEvent("chat", {
+      sessionKey,
+      runId: failedRunId,
+      state: "error",
+      errorMessage: "Failed before model output",
+    });
+    await currentPage
+      .getByRole("alert")
+      .filter({ hasText: "Failed before model output" })
+      .waitFor();
+    expect(await currentPage.locator(".chat-group.assistant").count()).toBe(0);
+    expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
+
+    await currentPage.clock.setFixedTime(firstStartedAt + 981_000);
+    await composer.fill("Try again independently");
+    await currentPage.getByRole("button", { name: "Send message" }).click();
+    const runId = await persistUser("Try again independently", firstStartedAt + 981_000, 1);
+    expect(runId).not.toBe(failedRunId);
+    await currentPage.clock.setFixedTime(firstStartedAt + 982_000);
+    const tool = {
+      role: "toolResult",
+      toolName: "bash",
+      toolCallId: "successful-tool",
+      content: "ok",
+      timestamp: firstStartedAt + 982_000,
+      __openclaw: { id: "successful-tool-result", runId },
+    };
+    messages.push(tool);
+    await gateway.setHistoryMessages(messages);
+    await gateway.emitGatewayEvent("session.message", {
+      sessionKey,
+      runId,
+      message: tool,
+      messageId: tool["__openclaw"].id,
+      messageSeq: messages.length,
+      activeRunIds: [runId],
+      hasActiveRun: true,
+    });
+    await currentPage.clock.setFixedTime(firstStartedAt + 994_000);
+    const reply = {
+      role: "assistant",
+      content: "Success after the earlier failure.",
+      timestamp: firstStartedAt + 994_000,
+      __openclaw: { id: "successful-reply", runId },
+    };
+    messages.push(reply);
+    // The same canonical history must survive a full page reload, not just
+    // the live terminal projection or its retained local timestamps.
+    await gateway.setMethodResponse("chat.history", {
+      messages,
+      sessionId: "control-ui-e2e-session",
+      sessionInfo: { key: sessionKey, hasActiveRun: false, activeRunIds: [], status: "done" },
+    });
+    await gateway.emitGatewayEvent("chat", { sessionKey, runId, state: "final", message: reply });
+    await currentPage.getByText(reply.content, { exact: true }).waitFor();
+    const elapsedLabel = currentPage.locator(".chat-work-group .chat-activity-group__label");
+    await elapsedLabel.waitFor();
+    expect.soft(await elapsedLabel.textContent()).toBe("Worked for 13s");
+    expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
+
+    await currentPage.reload();
+    await gateway.waitForRequest("chat.startup");
+    await currentPage.getByText(reply.content, { exact: true }).waitFor();
+    await elapsedLabel.waitFor();
+    expect(await elapsedLabel.textContent()).toBe("Worked for 13s");
+    expect(await currentPage.locator(".chat-group.user").count()).toBe(2);
   });
 
   it("keeps a continuing run inside its latest assistant reply", async () => {

--- a/ui/src/pages/chat/chat-thread-grouping.ts
+++ b/ui/src/pages/chat/chat-thread-grouping.ts
@@ -9,6 +9,7 @@ import { extractTextCached } from "../../lib/chat/message-extract.ts";
 import { normalizeMessage, normalizeRoleForGrouping } from "../../lib/chat/message-normalizer.ts";
 import { senderIdentityKey } from "../../lib/chat/sender-label.ts";
 import { isContextCompactionActivity } from "./chat-progress.ts";
+import { userTurnSendIdentity } from "./chat-thread-items.ts";
 import {
   isKeyedAssistantStreamFallbackMessage,
   streamPartBoundaryId,
@@ -20,7 +21,7 @@ import {
   chatItemStartsUserTurn,
   safeNormalizeMessage,
 } from "./chat-turn-boundary.ts";
-import { indexTurnContinuations } from "./stream-causal-boundary.ts";
+import { indexTurnContinuations, persistedSteerTargetRunId } from "./stream-causal-boundary.ts";
 
 function stampReplyAttribution(
   items: Array<ChatItem | MessageGroup>,
@@ -57,6 +58,7 @@ function stampReplyAttribution(
 export function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup> {
   const result: Array<ChatItem | MessageGroup> = [];
   let currentGroup: MessageGroup | null = null;
+  let currentUserTurnIdentity: string | null = null;
 
   for (const item of items) {
     if (item.kind !== "message") {
@@ -76,6 +78,16 @@ export function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup>
     const timestamp = normalized.timestamp || Date.now();
     const runId =
       role === "assistant" || role === "tool" ? transcriptRunId(item.message) : undefined;
+    // Independent sends own separate elapsed boundaries; consecutive steers
+    // before any output keep their target run's original start. Do not stamp
+    // user runIds onto groups: reply-less activity pooling uses that field.
+    const steerTarget = role === "user" ? persistedSteerTargetRunId(item.message) : null;
+    const userTurnIdentity =
+      role === "user"
+        ? steerTarget
+          ? `send:${steerTarget}`
+          : userTurnSendIdentity(item.message)
+        : null;
     const shouldSplitBySender = role === "user" || role === "assistant";
     const startsProjectedTurn =
       asRecord(asRecord(item.message)?.["__openclaw"])?.turnBoundary === true;
@@ -95,6 +107,7 @@ export function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup>
       startsProjectedTurn ||
       currentGroup.role !== role ||
       currentGroup.runId !== runId ||
+      currentUserTurnIdentity !== userTurnIdentity ||
       splitsAssistantCommentary ||
       splitsRuntimeActivity ||
       (shouldSplitBySender &&
@@ -104,6 +117,7 @@ export function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup>
       if (currentGroup) {
         result.push(currentGroup);
       }
+      currentUserTurnIdentity = userTurnIdentity;
       currentGroup = {
         kind: "group",
         key: `group:${role}:${item.key}`,

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -760,6 +760,67 @@ describe("collapseCompletedTurnWork", () => {
     expect(requireGroup(items[2]).role).toBe("assistant");
   });
 
+  it.each([
+    {
+      name: "independent sends",
+      identities: ["first", "second"],
+      steerTargetRunId: undefined,
+      durationMs: 13_000,
+      sizes: [1, 1],
+    },
+    {
+      name: "consecutive same-run steers",
+      identities: ["first", "steer-1", "steer-2"],
+      steerTargetRunId: "first",
+      durationMs: 994_000,
+      sizes: [3],
+    },
+    {
+      name: "same-submit projections",
+      identities: ["first", "first"],
+      steerTargetRunId: undefined,
+      durationMs: 994_000,
+      sizes: [2],
+    },
+    {
+      name: "unkeyed historical prompts",
+      identities: [null, null],
+      steerTargetRunId: undefined,
+      durationMs: 994_000,
+      sizes: [2],
+    },
+  ])(
+    "preserves elapsed ownership for $name before any assistant output",
+    ({ identities, steerTargetRunId, durationMs, sizes }) => {
+      const prompts = identities.map((identity, index) =>
+        userMessage(`Prompt ${index + 1}`, index === 0 ? 1_000 : 982_000 + index - 1, {
+          __openclaw: {
+            senderId: "operator",
+            ...(identity ? { idempotencyKey: `${identity}:user` } : {}),
+            ...(index > 0 && steerTargetRunId ? { steerTargetRunId } : {}),
+          },
+        }),
+      );
+      const items = collapsedItems({
+        messages: [
+          ...prompts,
+          toolResult("call-success", 983_000),
+          assistantMessage("Done.", 995_000),
+        ],
+      });
+      const work = items.find((item) => item.kind === "work-group");
+
+      expect(work?.durationMs).toBe(durationMs);
+      const users = items.filter(
+        (item): item is MessageGroup => item.kind === "group" && item.role === "user",
+      );
+      expect(users.map((group) => group.messages.length)).toEqual(sizes);
+      expect(users.flatMap((group) => group.messages.map(({ message }) => message))).toEqual(
+        prompts,
+      );
+    },
+  );
+
   it("keeps durable context compaction inside completed work instead of treating it as the reply", () => {
     const items = collapsedItems({
       messages: [
@@ -874,42 +935,45 @@ describe("collapseCompletedTurnWork", () => {
     expect(items.some((item) => item.kind === "work-group")).toBe(false);
   });
 
-  it("collapses completed pre-steer work before the steering message", () => {
-    const messages = [
-      userMessage("do it", 1_000, {
-        __openclaw: { idempotencyKey: "active-run:user", senderId: "operator" },
-      }),
-      assistantMessage("Checking…", 2_000),
-      toolResult("call-1", 3_000),
-      userMessage("queued follow-up", 3_500, {
-        __openclaw: { idempotencyKey: "queued-run:user", senderId: "peer" },
-      }),
-      userMessage("continue", 4_000, {
-        __openclaw: {
-          idempotencyKey: "steer-run:user",
-          senderId: "operator",
-          steerTargetRunId: "active-run",
-        },
-      }),
-      assistantMessage("All done.", 5_000),
-    ];
+  it.each(["peer", "operator"])(
+    "collapses pre-steer work across a queued message from %s",
+    (senderId) => {
+      const messages = [
+        userMessage("do it", 1_000, {
+          __openclaw: { idempotencyKey: "active-run:user", senderId: "operator" },
+        }),
+        assistantMessage("Checking…", 2_000),
+        toolResult("call-1", 3_000),
+        userMessage("queued follow-up", 3_500, {
+          __openclaw: { idempotencyKey: "queued-run:user", senderId },
+        }),
+        userMessage("continue", 4_000, {
+          __openclaw: {
+            idempotencyKey: "steer-run:user",
+            senderId: "operator",
+            steerTargetRunId: "active-run",
+          },
+        }),
+        assistantMessage("All done.", 5_000),
+      ];
 
-    expect(
-      collapsedItems({ messages, runWorking: true }, true).some(
-        (item) => item.kind === "work-group",
-      ),
-    ).toBe(false);
+      expect(
+        collapsedItems({ messages, runWorking: true }, true).some(
+          (item) => item.kind === "work-group",
+        ),
+      ).toBe(false);
 
-    const completed = collapsedItems({ messages });
-    expect(completed.map((item) => item.kind)).toEqual([
-      "group",
-      "work-group",
-      "group",
-      "group",
-      "group",
-    ]);
-    expect(requireWorkGroup(completed[1]).durationMs).toBe(4_000);
-  });
+      const completed = collapsedItems({ messages });
+      expect(completed.map((item) => item.kind)).toEqual([
+        "group",
+        "work-group",
+        "group",
+        "group",
+        "group",
+      ]);
+      expect(requireWorkGroup(completed[1]).durationMs).toBe(4_000);
+    },
+  );
 
   it("keeps reply-less turns expanded after the run finishes", () => {
     const messages = [userMessage("do it", 1_000), toolResult("call-1", 2_000)];
@@ -1194,10 +1258,21 @@ describe("coalesceActivityRuns", () => {
     const runs = groups.map((group, index) =>
       Object.assign({}, group, { runId: `run-${index + 1}` }),
     );
-    const projected = coalesceActivityRuns(runs);
-    const run = requireActivityRun(projected[0]);
+    const prompt = groupAt(
+      messageGroups({
+        messages: [
+          userMessage("Start", 500, {
+            __openclaw: { idempotencyKey: "run-1:user" },
+          }),
+        ],
+      }),
+      0,
+    );
+    const projected = coalesceActivityRuns([prompt, ...runs]);
+    const run = requireActivityRun(projected[1]);
 
-    expect(projected).toHaveLength(1);
+    expect(projected).toHaveLength(2);
+    expect(projected[0]).toBe(prompt);
     expect(run.groups).toEqual(runs);
   });
 
@@ -3034,17 +3109,16 @@ describe("buildCachedChatItems", () => {
       ],
     });
 
-    expect(groups).toHaveLength(1);
-    expect(groupAt(groups, 0).role).toBe("user");
-    expect(groupAt(groups, 0).messages).toHaveLength(2);
+    expect(groups.map((group) => group.role)).toEqual(["user", "user"]);
+    expect(groups.map((group) => group.messages.length)).toEqual([1, 1]);
     expect(messageRecord(groupAt(groups, 0), 0)["__openclaw"]).toMatchObject({
       id: "canonical-web-user",
     });
-    expect(messageRecord(groupAt(groups, 0), 1)["__openclaw"]).toMatchObject({
+    expect(messageRecord(groupAt(groups, 1), 0)["__openclaw"]).toMatchObject({
       id: "canonical-tui-user",
     });
     expect(messageAt(groupAt(groups, 0), 0).duplicateCount).toBeUndefined();
-    expect(messageAt(groupAt(groups, 0), 1).duplicateCount).toBeUndefined();
+    expect(messageAt(groupAt(groups, 1), 0).duplicateCount).toBeUndefined();
   });
 
   it("keeps imported prompts from distinct CLI sessions separate when provider IDs collide", () => {


### PR DESCRIPTION
Closes #131825 — preparation failures and retries inheriting stale elapsed time.

<details>
<summary>Additional instructions</summary>

Maintainer-owned branch in this repository; maintainers can update it. AI-assisted implementation and review.

</details>

## What Problem This Solves

Fixes an issue where a turn that failed before model startup could inherit the preceding run's start time. A later independent send could also include that failed turn and idle interval in Control UI's completed-work duration. The displayed latency could therefore be minutes longer than the work actually performed.

This is the elapsed-time follow-up from [native node-session hosting, PR #131717](https://github.com/openclaw/openclaw/pull/131717). The separately merged [duplicate-answer repair, PR #131681](https://github.com/openclaw/openclaw/pull/131681), remains untouched.

## Why This Change Was Made

The terminal owner now records the real preparation boundary, then replaces it with an observed model start when one exists. The embedded callback and event bus share that timestamp. Preparation errors use the same terminal owner instead of a second untimed emission path; no fake readiness event or duration clamp is introduced.

Control UI groups independent sends by the existing send identity while retaining same-run steering, same-submit projections, historical messages, and reply-less activity pooling. It does not stamp user run IDs onto groups or change duration arithmetic.

## User Impact

Failed preparation and later retries report their own elapsed time. Historical completed-work labels are corrected when the conversation is reloaded. Genuine steering continues to belong to its target run. Execution policy, cancellation, fallback ownership, and model behavior are unchanged.

Production LOC: **+45/-42, net +3**. Tests/support: **+457/-46, net +411**. Docs: **+2**. The small production increase adds the missing send boundary while removing duplicate terminal emission. No new configuration, dependency, SQLite schema, or protocol-version change.

## Evidence

Verified commit: `6b997084e86d292311e03130372fa09aaf7d4e17`.

### Real signed-node and Control UI proof

An isolated Gateway and Developer-ID-signed native Mac node reproduced the problem, then exercised the committed repair. A deliberately denied Full session still failed visibly and created no file on either host. Node policy was read back and restored after every probe.

- Before: a pre-model failure observed after about **2.87 seconds** was persisted as **663,195 ms**, borrowing the prior run's start.
- After: a fresh current-build session's pre-model failure recorded its own **4,756 ms** interval. The next successful turn executed on the node and reconciled the independently verified 19-byte file to the Gateway, with zero approval events.
- The **same unchanged historical recovery turn** displayed **Worked for 22s** before the UI repair and **Worked for 9s** after reload. These are timing-correctness results, not an execution-speed benchmark.

Before:

![Historical recovery includes failed-turn and idle time](https://github.com/user-attachments/assets/a8f585a5-c877-458a-8ad4-79533aefa6cc)

After, using the same history:

![Historical recovery uses its own send boundary](https://github.com/user-attachments/assets/3de85ecf-9172-4783-98fc-0e2ce1b193f5)

Real current-build recovery on the native node, through terminal completion:

https://github.com/user-attachments/assets/42a77667-4aa9-4647-8855-f37de07a97e9

Both screenshots and four initial/intermediate/final video frames were inspected. They contain only the disposable test workflow; no credentials, private device output, or internal model identifiers are shown. The video is unaccelerated.

### Regression and sibling proof

Five unit regressions and one Chromium regression failed before the production edits for the intended reasons. The ordered SQLite test reported **2,480,679 ms instead of 4,700 ms**; the browser reported **16m34s instead of 13s**, including after history reload. After repair, **506 unit tests across eleven files** and **21 Chromium E2E cases across three files** passed. Coverage includes deferred lifecycle ownership, cancellation, auth/preparation failures, CLI dispatch, same-run steering, same-submit grouping, persistence/reopen, and the merged duplicate-answer behavior.

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution-timing.test.ts src/auto-reply/reply/agent-runner-execution-lifecycle.test.ts src/auto-reply/reply/agent-runner-execution-auth-failures.test.ts src/auto-reply/reply/agent-runner-cli-dispatch.test.ts src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts src/gateway/session-lifecycle-state.persistence.test.ts src/gateway/session-lifecycle-state.test.ts src/agents/embedded-agent-runner/run/deferred-lifecycle-owner.test.ts ui/src/pages/chat/chat-thread.test.ts ui/src/pages/chat/chat-state.test.ts ui/src/pages/chat/stream-reconciliation.test.ts
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-run-lifecycle.e2e.test.ts ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts ui/src/e2e/chat-flow.stream-reconciliation.e2e.test.ts
```

All twelve-path changed gates passed: core/core-test/UI types, formatting, lint, storage/ownership guards, and import cycles. Full build and fresh **P0-only** Codex autoreview passed; the review is not represented as an all-priority audit.

```bash
pnpm build
```

```bash
git diff --check
```

### Proof limits and retained failures

The retained disposable Gateway profile required the existing stopped-writer Doctor migration before current main would start; only that test profile was migrated, with backups and service repair disabled. An initial after-test reused a placement from the previous Gateway build and correctly hit the build-identity fence. The comparable after-test used a newly provisioned session instead; no fallback or guard was weakened. A browser-helper wait/cleanup issue was corrected and failed artifacts were retained. A non-failing jsdom canvas warning remains disclosed. No production rollout, package publication, or universal latency improvement is claimed.

Documentation: https://docs.openclaw.ai/concepts/agent-loop
