### PR TITLE
fix(test): restore MCP channel smoke on SQLite startup

### DIFF
--- a/scripts/e2e/mcp-channels-seed.ts
+++ b/scripts/e2e/mcp-channels-seed.ts
@@ -2,20 +2,100 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { applyDockerOpenAiProviderConfig, type OpenClawConfig } from "./docker-openai-seed.ts";
+import { pathToFileURL } from "node:url";
+import {
+  replaceSessionEntry,
+  replaceTranscriptEvents,
+} from "../../src/config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../../src/config/types.openclaw.js";
 
-async function main() {
-  const stateDir = process.env.OPENCLAW_STATE_DIR?.trim() || path.join(os.homedir(), ".openclaw");
+const SESSION_ID = "sess-main";
+const SESSION_KEY = "agent:main:main";
+
+export async function seedMcpChannelsState(params: {
+  env: NodeJS.ProcessEnv;
+  now?: number;
+  seededConfig: OpenClawConfig;
+}) {
+  const stateDir = params.env.OPENCLAW_STATE_DIR?.trim() || path.join(os.homedir(), ".openclaw");
   const configPath =
-    process.env.OPENCLAW_CONFIG_PATH?.trim() || path.join(stateDir, "openclaw.json");
+    params.env.OPENCLAW_CONFIG_PATH?.trim() || path.join(stateDir, "openclaw.json");
   const sessionsDir = path.join(stateDir, "agents", "main", "sessions");
-  const sessionFile = path.join(sessionsDir, "sess-main.jsonl");
-  const storePath = path.join(sessionsDir, "sessions.json");
-  const now = Date.now();
+  const sessionFile = path.join(sessionsDir, `${SESSION_ID}.jsonl`);
+  const now = params.now ?? Date.now();
+  const transcriptEvents = [
+    { type: "session", version: 1, id: SESSION_ID },
+    {
+      id: "msg-1",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "hello from seeded transcript" }],
+        timestamp: now,
+      },
+    },
+    {
+      id: "msg-attachment",
+      message: {
+        role: "user",
+        content: "seeded image attachment",
+        __openclaw: {
+          media: [
+            {
+              url: "media://inbound/seeded-image.png",
+              contentType: "image/png",
+              kind: "image",
+              fileName: "seeded-image.png",
+              sizeBytes: 3,
+            },
+          ],
+        },
+        timestamp: now + 1,
+      },
+    },
+  ];
 
   await fs.mkdir(sessionsDir, { recursive: true });
   await fs.mkdir(path.dirname(configPath), { recursive: true });
+  await fs.writeFile(configPath, JSON.stringify(params.seededConfig, null, 2), "utf-8");
 
+  await replaceSessionEntry(
+    { agentId: "main", env: params.env, sessionKey: SESSION_KEY },
+    {
+      sessionId: SESSION_ID,
+      updatedAt: now,
+      deliveryContext: {
+        channel: "imessage",
+        to: "+15551234567",
+        accountId: "imessage-default",
+        threadId: "thread-42",
+      },
+      displayName: "Docker MCP Channel Smoke",
+      derivedTitle: "Docker MCP Channel Smoke",
+      lastMessagePreview: "seeded transcript",
+    },
+  );
+  await replaceTranscriptEvents(
+    { agentId: "main", env: params.env, sessionId: SESSION_ID, sessionKey: SESSION_KEY },
+    transcriptEvents,
+  );
+
+  await fs.writeFile(
+    sessionFile,
+    transcriptEvents.map((event) => JSON.stringify(event)).join("\n") + "\n",
+    "utf-8",
+  );
+
+  return {
+    stateDir,
+    configPath,
+    sessionFile,
+    sessionId: SESSION_ID,
+    sessionKey: SESSION_KEY,
+  };
+}
+
+async function main() {
+  const { applyDockerOpenAiProviderConfig } = await import("./docker-openai-seed.ts");
   const seededConfig = applyDockerOpenAiProviderConfig(
     {
       gateway: {
@@ -36,78 +116,10 @@ async function main() {
     } satisfies OpenClawConfig,
     "sk-docker-smoke-test",
   );
-
-  await fs.writeFile(configPath, JSON.stringify(seededConfig, null, 2), "utf-8");
-
-  await fs.writeFile(
-    storePath,
-    JSON.stringify(
-      {
-        "agent:main:main": {
-          sessionId: "sess-main",
-          sessionFile,
-          updatedAt: now,
-          deliveryContext: {
-            channel: "imessage",
-            to: "+15551234567",
-            accountId: "imessage-default",
-            threadId: "thread-42",
-          },
-          displayName: "Docker MCP Channel Smoke",
-          derivedTitle: "Docker MCP Channel Smoke",
-          lastMessagePreview: "seeded transcript",
-        },
-      },
-      null,
-      2,
-    ),
-    "utf-8",
-  );
-
-  await fs.writeFile(
-    sessionFile,
-    [
-      JSON.stringify({ type: "session", version: 1, id: "sess-main" }),
-      JSON.stringify({
-        id: "msg-1",
-        message: {
-          role: "assistant",
-          content: [{ type: "text", text: "hello from seeded transcript" }],
-          timestamp: now,
-        },
-      }),
-      JSON.stringify({
-        id: "msg-attachment",
-        message: {
-          role: "user",
-          content: "seeded image attachment",
-          __openclaw: {
-            media: [
-              {
-                url: "media://inbound/seeded-image.png",
-                contentType: "image/png",
-                kind: "image",
-                fileName: "seeded-image.png",
-                sizeBytes: 3,
-              },
-            ],
-          },
-          timestamp: now + 1,
-        },
-      }),
-    ].join("\n") + "\n",
-    "utf-8",
-  );
-
-  process.stdout.write(
-    JSON.stringify({
-      ok: true,
-      stateDir,
-      configPath,
-      storePath,
-      sessionFile,
-    }) + "\n",
-  );
+  const result = await seedMcpChannelsState({ env: process.env, seededConfig });
+  process.stdout.write(JSON.stringify({ ok: true, ...result }) + "\n");
 }
 
-await main();
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/test/scripts/mcp-channels-seed.test.ts
+++ b/test/scripts/mcp-channels-seed.test.ts
@@ -1,0 +1,94 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { seedMcpChannelsState } from "../../scripts/e2e/mcp-channels-seed.ts";
+import {
+  loadSessionEntry,
+  loadTranscriptEvents,
+} from "../../src/config/sessions/session-accessor.js";
+import { runSessionStartupMigration } from "../../src/config/sessions/startup-migration.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  resolveOpenClawAgentSqlitePath,
+} from "../../src/state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../src/state/openclaw-state-db.js";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+});
+
+it("seeds canonical MCP channel state that passes session startup maintenance", async () => {
+  const root = fs.realpathSync.native(tempDirs.make("openclaw-mcp-channels-seed-"));
+  const stateDir = path.join(root, "state");
+  const env = {
+    ...process.env,
+    OPENCLAW_CONFIG_PATH: path.join(stateDir, "openclaw.json"),
+    OPENCLAW_STATE_DIR: stateDir,
+  };
+  const now = 1_788_000_000_000;
+  const seededConfig = {
+    agents: { defaults: { heartbeat: { every: "0m" } } },
+    plugins: { enabled: false },
+  };
+
+  const result = await seedMcpChannelsState({ env, now, seededConfig });
+
+  expect(fs.existsSync(path.join(stateDir, "agents", "main", "sessions", "sessions.json"))).toBe(
+    false,
+  );
+  expect(fs.existsSync(resolveOpenClawAgentSqlitePath({ agentId: "main", env }))).toBe(true);
+  expect(loadSessionEntry({ agentId: "main", env, sessionKey: result.sessionKey })).toMatchObject({
+    deliveryContext: {
+      accountId: "imessage-default",
+      channel: "imessage",
+      threadId: "thread-42",
+      to: "+15551234567",
+    },
+    displayName: "Docker MCP Channel Smoke",
+    sessionId: result.sessionId,
+    updatedAt: now,
+  });
+
+  const jsonlEvents = fs
+    .readFileSync(result.sessionFile, "utf8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line) as unknown);
+  expect(jsonlEvents).toHaveLength(3);
+  expect(jsonlEvents).toEqual(
+    await loadTranscriptEvents({
+      agentId: "main",
+      env,
+      sessionId: result.sessionId,
+      sessionKey: result.sessionKey,
+    }),
+  );
+  expect(jsonlEvents[2]).toMatchObject({
+    id: "msg-attachment",
+    message: {
+      __openclaw: {
+        media: [{ fileName: "seeded-image.png", kind: "image" }],
+      },
+    },
+  });
+
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  await expect(
+    runSessionStartupMigration({
+      cfg: seededConfig,
+      env,
+      log: { info: vi.fn(), warn: vi.fn() },
+    }),
+  ).resolves.toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        agentId: "main",
+      }),
+    ]),
+  );
+});


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the MCP channels Docker validation wrote a legacy `sessions.json` fixture, causing SQLite-only Gateway startup to reject the state before the channel scenario could run.

## Why This Change Was Made

The fixture now writes session metadata and transcript events through the canonical session accessors. The transcript JSONL artifact remains available for the package harness, while startup migration enforcement stays unchanged.

## User Impact

Release validation can exercise MCP channel listing, history, attachments, and delivery against canonical SQLite state. There is no runtime schema, config, or product behavior change.

## Evidence

- Pre-fix reproduction: the seed created `agents/main/sessions/sessions.json`; `runSessionStartupMigration` rejected it with `Legacy session store requires migration`.
- Post-fix real seed/startup probe: startup succeeded with session `sess-main`, three canonical transcript events, the retained JSONL artifact, and no `sessions.json`.
- Focused regression: `node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts test/scripts/mcp-channels-seed.test.ts` (1 passed).
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts/e2e/mcp-channels-seed.ts`.
- `pnpm format:check --no-error-on-unmatched-pattern -- scripts/e2e/mcp-channels-seed.ts test/scripts/mcp-channels-seed.test.ts`.
- `pnpm check:script-erasability`.
- `git diff --check`.
- Autoreview: clean, no accepted/actionable findings, overall 0.99.
- LOC: production 0; tooling `+92/-80`; tests `+94/-0`.

`pnpm tsgo:scripts` remains blocked in this sparse worktree by omitted Control UI config files and the existing missing `pako` declaration; none are touched by this change.
