### PR TITLE
fix(release): canonicalize composite job ordering

### DIFF
--- a/scripts/full-release-validation-policy.d.mts
+++ b/scripts/full-release-validation-policy.d.mts
@@ -53,6 +53,7 @@ export function validateReleaseExecutionPlanArtifact(
 ): ReleaseExecutionPlan;
 export function releaseExecutionPlanSha256(plan: ReleaseRecord): string;
 export function releaseCompositeJobsSha256(value: ReleaseRecord): string;
+export function compareReleaseJobsByName(left: { name: string }, right: { name: string }): number;
 export function composeReleaseAttemptJobs(
   attempts: Array<{ jobs: ReleaseRecord[]; runAttempt: number }>,
   expected: { effectiveRunAttempt: number; plannedRunAttempt: number },

--- a/scripts/full-release-validation-policy.mjs
+++ b/scripts/full-release-validation-policy.mjs
@@ -246,6 +246,12 @@ function normalizedAttemptJob(job, runAttempt) {
   };
 }
 
+export function compareReleaseJobsByName(left, right) {
+  // Composite evidence is hashed and revalidated across runners, so its order
+  // must not depend on the host's locale collation.
+  return left.name === right.name ? 0 : left.name < right.name ? -1 : 1;
+}
+
 export function validateReleaseChildRunProvenance(run, expected = {}) {
   const plannedRunAttempt = positiveInteger(expected.plannedRunAttempt);
   const effectiveRunAttempt = positiveInteger(run?.run_attempt);
@@ -336,7 +342,7 @@ export function composeReleaseAttemptJobs(attempts, expected = {}) {
 
   const composite = {
     effectiveRunAttempt,
-    jobs: [...accepted.values()].toSorted((left, right) => left.name.localeCompare(right.name)),
+    jobs: [...accepted.values()].toSorted(compareReleaseJobsByName),
     plannedRunAttempt,
   };
   return { ...composite, sha256: releaseCompositeJobsSha256(composite) };
@@ -1302,6 +1308,9 @@ export function validateReleaseStateArtifact(payload, expected, expectedMode) {
               url: boundedString(job?.url, MAX_URL_LENGTH),
             }));
             const jobNames = timingJobs.map((job) => job.name);
+            const canonicalJobNames = timingJobs
+              .toSorted(compareReleaseJobsByName)
+              .map((job) => job.name);
             if (
               child.compositeJobsSha256 &&
               (timingJobs.length === 0 ||
@@ -1313,7 +1322,7 @@ export function validateReleaseStateArtifact(payload, expected, expectedMode) {
                     job.acceptedRunAttempt > runAttempt,
                 ) ||
                 new Set(jobNames).size !== jobNames.length ||
-                JSON.stringify(jobNames) !== JSON.stringify(jobNames.toSorted()))
+                JSON.stringify(jobNames) !== JSON.stringify(canonicalJobNames))
             ) {
               throw new Error(`release state child composite jobs are invalid: ${key}`);
             }

--- a/scripts/release-ci-summary.mjs
+++ b/scripts/release-ci-summary.mjs
@@ -12,6 +12,7 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 import {
   classifyReleaseGhTransportError,
+  compareReleaseJobsByName,
   composeReleaseChildAttemptEvidence,
   formatReleaseStateOutcome,
   isReleaseGhArtifactMissingError,
@@ -579,7 +580,9 @@ function normalizeManifestChildEvidence(value) {
         });
         if (
           new Set(jobs.map((job) => job.name)).size !== jobs.length ||
-          jobs.some((job, index) => index > 0 && jobs[index - 1].name.localeCompare(job.name) >= 0)
+          jobs.some(
+            (job, index) => index > 0 && compareReleaseJobsByName(jobs[index - 1], job) >= 0,
+          )
         ) {
           throw new Error(`release validation child job identity is duplicated: ${key}`);
         }

--- a/test/scripts/full-release-validation-state.test.ts
+++ b/test/scripts/full-release-validation-state.test.ts
@@ -1039,6 +1039,34 @@ describe("release state artifacts", () => {
     };
   }
 
+  function compositeArtifact(status = "completed"): Record<string, any> {
+    const composite = composeReleaseAttemptJobs(
+      [
+        {
+          jobs: ["qa smoke ci", "QA Smoke CI"].map((name) => ({
+            conclusion: "success",
+            name,
+            status: "completed",
+          })),
+          runAttempt: 1,
+        },
+      ],
+      { effectiveRunAttempt: 1, plannedRunAttempt: 1 },
+    );
+    return artifact("decision", 2, executionPlan({ rerunGroup: "ci" }), {
+      compositeJobsSha256: composite.sha256,
+      conclusion: status === "completed" ? "success" : "",
+      dispatchActor: "github-actions[bot]",
+      jobs: composite.jobs,
+      observedRunAttempts: [1],
+      plannedRunAttempt: 1,
+      repository: "openclaw/openclaw",
+      runAttempt: 1,
+      status,
+      triggeringActor: "github-actions[bot]",
+    });
+  }
+
   function selectPair(
     sealedPlan: Record<string, any>,
     decision: Record<string, any>,
@@ -1061,6 +1089,43 @@ describe("release state artifacts", () => {
         { ...stateExpected(), parentRunAttempt: 2 },
       ),
     ).toMatchObject({ decision: { state: "passed" }, drain: { state: "passed" } });
+  });
+
+  it("round-trips mixed-case composite jobs through state validation", () => {
+    const payload = compositeArtifact();
+    expect(payload.children.normalCi.timing.jobs.map((job: { name: string }) => job.name)).toEqual([
+      "QA Smoke CI",
+      "qa smoke ci",
+    ]);
+    expect(() => validateReleaseStateArtifact(payload, stateExpected(), "decision")).not.toThrow();
+  });
+
+  it("rejects noncanonical composite job ordering", () => {
+    const payload = compositeArtifact();
+    payload.children.normalCi.timing.jobs.reverse();
+    expect(() => validateReleaseStateArtifact(payload, stateExpected(), "decision")).toThrow(
+      "release state child composite jobs are invalid: normalCi",
+    );
+  });
+
+  it("accepts a queued run snapshot after its jobs have progressed", () => {
+    expect(
+      validateReleaseStateArtifact(compositeArtifact("queued"), stateExpected(), "decision"),
+    ).toMatchObject({
+      activeRunIds: ["101"],
+      children: {
+        normalCi: {
+          status: "queued",
+          timing: {
+            jobs: [
+              { name: "QA Smoke CI", status: "completed" },
+              { name: "qa smoke ci", status: "completed" },
+            ],
+          },
+        },
+      },
+      state: "qualifying",
+    });
   });
 
   it("requires Decision and Drain to carry identical accepted attempt evidence", () => {

--- a/test/scripts/release-ci-summary.test.ts
+++ b/test/scripts/release-ci-summary.test.ts
@@ -9,6 +9,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildFullReleaseCandidateRequest } from "../../scripts/full-release-candidate-contract.mjs";
 import {
   buildReleaseExecutionPlanArtifact,
+  composeReleaseAttemptJobs,
   releaseCompositeJobsSha256,
 } from "../../scripts/full-release-validation-policy.mjs";
 import {
@@ -2203,6 +2204,60 @@ describe("release CI summary child correlation", () => {
     expect(() => manifestChildEntries(missing, children, selected)).toThrow(
       "selected child is missing from manifest: CI",
     );
+  });
+
+  it("validates mixed-case composite job ordering using the producer contract", () => {
+    const composite = composeReleaseAttemptJobs(
+      [
+        {
+          jobs: [
+            { conclusion: "success", name: "qa smoke ci", status: "completed" },
+            { conclusion: "success", name: "QA Smoke CI", status: "completed" },
+          ],
+          runAttempt: 1,
+        },
+      ],
+      { effectiveRunAttempt: 1, plannedRunAttempt: 1 },
+    );
+    const releaseChecksEvidence = {
+      compositeJobsSha256: composite.sha256,
+      dispatchActor: "github-actions[bot]",
+      effectiveRunAttempt: composite.effectiveRunAttempt,
+      jobs: composite.jobs,
+      observedRunAttempts: [1],
+      plannedRunAttempt: composite.plannedRunAttempt,
+      repository: "openclaw/openclaw",
+      runId: "404",
+      triggeringActor: "github-actions[bot]",
+    };
+    const raw = Object.assign(rawManifest({}), {
+      childEvidence: {
+        releaseChecks: releaseChecksEvidence,
+      },
+    });
+
+    expect(() =>
+      validateParentManifest(raw, {
+        runAttempt: 2,
+        runId: "29090000000",
+      }),
+    ).not.toThrow();
+
+    const reversedJobs = composite.jobs.toReversed();
+    const reversedCompositeJobsSha256 = releaseCompositeJobsSha256({
+      effectiveRunAttempt: composite.effectiveRunAttempt,
+      jobs: reversedJobs,
+      plannedRunAttempt: composite.plannedRunAttempt,
+    });
+    releaseChecksEvidence.compositeJobsSha256 = reversedCompositeJobsSha256;
+    releaseChecksEvidence.jobs = reversedJobs;
+
+    expect(() =>
+      validateParentManifest(raw, {
+        runAttempt: 2,
+        runId: "29090000000",
+      }),
+    ).toThrow("release validation child job identity is duplicated: releaseChecks");
   });
 
   it("requires the npm Telegram child for all-validation with an effective package spec", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Full Release Validation could reject valid composite child-job evidence when job names differed by case. The producer and state validator used deterministic code-unit ordering, while the manifest validator still used locale collation.

## Why This Change Was Made

The policy owner now exports one locale-independent job-name comparator, and both the producer and manifest/state validators reuse it. The validation contract still rejects noncanonical order and continues to accept the valid temporal skew where a run is reported as queued after its jobs have progressed.

## User Impact

Release operators no longer get a false orchestration failure from mixed-case GitHub job names. No product runtime behavior changes.

## Evidence

- Pre-fix: `node scripts/run-vitest.mjs test/scripts/release-ci-summary.test.ts -t "mixed-case composite"` failed because the manifest validator rejected producer-generated `["QA Smoke CI", "qa smoke ci"]` ordering.
- Post-fix: the same targeted regression passed.
- `node scripts/run-vitest.mjs test/scripts/release-ci-summary.test.ts test/scripts/full-release-validation-state.test.ts` passed (`229` tests).
- Targeted Oxfmt and Oxlint passed.
- Script erasability passed (`532` TypeScript implementation files).
- `node --check` passed for both changed `.mjs` files.
- `git diff --check` passed.
- `check:changed --dry-run` completed. The actual gate passed every guard through formatting and erasability, then the broad scripts typecheck hit checkout/install state outside this diff: sparse checkout omitted tracked `ui/config/*` modules and the shared install contains `pako@1.0.11` while this checkout declares `3.0.1`.
- Production/tooling LOC: `+16/-3` (`+13` net). Test LOC: `+120/-0`.
- Fresh Codex Sol autoreview: clean, no actionable findings (`0.99`).

AI-assisted: yes.
