### PR TITLE
fix(test): keep typed onboarding fixtures and diagnostics usable

### DIFF
--- a/scripts/e2e/lib/codex-media-path/scenario.sh
+++ b/scripts/e2e/lib/codex-media-path/scenario.sh
@@ -32,7 +32,7 @@ dump_debug_logs() {
   echo "Codex media-path Docker E2E failed with exit code $status" >&2
   openclaw_e2e_dump_logs "$PLUGIN_INSTALL_LOG" "$PLUGIN_INSPECT_LOG" "$GATEWAY_LOG" "$CLIENT_LOG" "$OPENCLAW_CODEX_MEDIA_PATH_APP_SERVER_LOG"
 }
-trap 'status=$?; dump_debug_logs "$status"; exit "$status"' ERR
+openclaw_e2e_enable_failure_diagnostics
 
 entry="$(openclaw_e2e_resolve_entrypoint)"
 mkdir -p "$OPENCLAW_STATE_DIR" "$OPENCLAW_TEST_WORKSPACE_DIR"

--- a/scripts/e2e/lib/openai-chat-tools/scenario.sh
+++ b/scripts/e2e/lib/openai-chat-tools/scenario.sh
@@ -51,7 +51,7 @@ dump_debug_logs() {
     node -e "const fs=require('fs'); const cfg=JSON.parse(fs.readFileSync(process.argv[1],'utf8')); console.error(JSON.stringify({model:cfg.agents?.defaults?.model, tools:cfg.tools, provider:cfg.models?.providers?.openai && {api:cfg.models.providers.openai.api, baseUrl:cfg.models.providers.openai.baseUrl, agentRuntime:cfg.models.providers.openai.agentRuntime}}, null, 2));" "$OPENCLAW_CONFIG_PATH" || true
   fi
 }
-trap 'status=$?; dump_debug_logs "$status"; exit "$status"' ERR
+openclaw_e2e_enable_failure_diagnostics
 
 entry="$(openclaw_e2e_resolve_entrypoint)"
 mkdir -p "$OPENCLAW_STATE_DIR" "$OPENCLAW_TEST_WORKSPACE_DIR"

--- a/scripts/e2e/lib/openai-web-search-minimal/scenario.sh
+++ b/scripts/e2e/lib/openai-web-search-minimal/scenario.sh
@@ -57,7 +57,7 @@ dump_debug_logs() {
   done
   echo "OpenAI web_search minimal failed command: $failed_command" >&2
 }
-trap 'status=$?; dump_debug_logs "$status" "$BASH_COMMAND"; exit "$status"' ERR
+openclaw_e2e_enable_failure_diagnostics
 
 entry="$(openclaw_e2e_resolve_entrypoint)"
 mkdir -p "$OPENCLAW_STATE_DIR" "$TLS_DIR"

--- a/scripts/e2e/lib/release-media-memory/scenario.sh
+++ b/scripts/e2e/lib/release-media-memory/scenario.sh
@@ -80,7 +80,7 @@ dump_debug_logs() {
     "$GATEWAY_1_LOG" \
     "$GATEWAY_2_LOG"
 }
-trap 'status=$?; dump_debug_logs "$status"; exit "$status"' ERR
+openclaw_e2e_enable_failure_diagnostics
 
 start_gateway() {
   local log_path="$1"

--- a/scripts/e2e/lib/release-plugin-marketplace/scenario.sh
+++ b/scripts/e2e/lib/release-plugin-marketplace/scenario.sh
@@ -31,7 +31,7 @@ dump_debug_logs() {
     /tmp/openclaw-release-plugin-marketplace-uninstall.log \
     /tmp/openclaw-release-plugin-marketplace-cli-after-uninstall.log
 }
-trap 'status=$?; dump_debug_logs "$status"; exit "$status"' ERR
+openclaw_e2e_enable_failure_diagnostics
 
 openclaw_e2e_install_package /tmp/openclaw-release-plugin-marketplace-install.log
 command -v openclaw >/dev/null

--- a/scripts/e2e/lib/release-typed-onboarding/scenario.sh
+++ b/scripts/e2e/lib/release-typed-onboarding/scenario.sh
@@ -5,6 +5,7 @@ export TERM=xterm-256color
 export NO_COLOR=1
 
 source scripts/lib/openclaw-e2e-instance.sh
+source scripts/e2e/lib/prepublish-plugin-registry.sh
 
 openclaw_e2e_eval_test_state_from_b64 "${OPENCLAW_TEST_STATE_SCRIPT_B64:?missing OPENCLAW_TEST_STATE_SCRIPT_B64}"
 openclaw_e2e_install_trash_shim
@@ -24,11 +25,13 @@ LOG_DIR="$scenario_tmp/logs"
 mkdir -p "$LOG_DIR"
 INSTALL_LOG="$LOG_DIR/install.log"
 ONBOARD_LOG="$LOG_DIR/onboard.log"
+CODEX_INSTALL_LOG="$LOG_DIR/codex-install.log"
 OPENAI_LOG="$LOG_DIR/openai.log"
 AGENT_LOG="$LOG_DIR/agent.log"
 MOCK_REQUEST_LOG="$scenario_tmp/openai-requests.jsonl"
 export SUCCESS_MARKER MOCK_REQUEST_LOG
 
+plugin_registry_pid=""
 mock_pid=""
 wizard_pid=""
 input_fifo_dir=""
@@ -36,6 +39,7 @@ cleanup() {
   { exec 3>&-; } 2>/dev/null || true
   openclaw_e2e_stop_process "${wizard_pid:-}"
   openclaw_e2e_stop_process "${mock_pid:-}"
+  openclaw_e2e_stop_process "${plugin_registry_pid:-}"
   if [ -n "${input_fifo_dir:-}" ]; then
     rm -rf "$input_fifo_dir"
   fi
@@ -49,11 +53,12 @@ dump_debug_logs() {
   openclaw_e2e_dump_logs \
     "$INSTALL_LOG" \
     "$ONBOARD_LOG" \
+    "$CODEX_INSTALL_LOG" \
     "$OPENAI_LOG" \
     "$MOCK_REQUEST_LOG" \
     "$AGENT_LOG"
 }
-trap 'status=$?; dump_debug_logs "$status"; exit "$status"' ERR
+openclaw_e2e_enable_failure_diagnostics
 
 send() {
   local payload="$1"
@@ -87,6 +92,7 @@ wait_for_log() {
 
 openclaw_e2e_install_package "$INSTALL_LOG"
 echo "Installed the OpenClaw package."
+openclaw_prepublish_plugin_registry_start_mounted "$scenario_tmp/registry" plugin_registry_pid '["@openclaw/codex"]'
 command -v openclaw >/dev/null
 package_root="$(openclaw_e2e_package_root)"
 entry="$(openclaw_e2e_package_entrypoint "$package_root")"
@@ -120,6 +126,19 @@ input_fifo_dir=""
 echo "Interactive typed onboarding completed."
 
 node scripts/e2e/lib/release-scenarios/assertions.mjs assert-session-memory-hook-enabled
+
+# Explicit older packages keep automatic setup; successful help establishes consent support.
+plugin_install_help="$(openclaw plugins install --help)"
+fixture_consent="$(printf '%s' "$plugin_install_help" | node scripts/e2e/lib/package-compat.mjs fixture-consent)"
+if [ -n "$fixture_consent" ]; then
+  codex_install_args=(codex)
+  if [ -n "${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR:-}" ]; then
+    candidate_version="${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION:?missing candidate version}"
+    codex_install_args=("npm:@openclaw/codex@$candidate_version" --pin)
+  fi
+  openclaw_e2e_fixture_plugin_command openclaw -- plugins install "${codex_install_args[@]}" \
+    >"$CODEX_INSTALL_LOG" 2>&1
+fi
 
 openclaw onboard \
   --non-interactive \

--- a/scripts/e2e/lib/release-upgrade-user-journey/scenario.sh
+++ b/scripts/e2e/lib/release-upgrade-user-journey/scenario.sh
@@ -88,7 +88,7 @@ dump_debug_logs() {
     "$GATEWAY_LOG" \
     "$CLICKCLACK_STATE"
 }
-trap 'status=$?; dump_debug_logs "$status"; exit "$status"' ERR
+openclaw_e2e_enable_failure_diagnostics
 
 start_gateway() {
   local log_path="$1"

--- a/scripts/e2e/lib/release-user-journey/scenario.sh
+++ b/scripts/e2e/lib/release-user-journey/scenario.sh
@@ -88,7 +88,7 @@ dump_debug_logs() {
     "$DOCTOR_LOG" \
     "$CLICKCLACK_STATE"
 }
-trap 'status=$?; dump_debug_logs "$status"; exit "$status"' ERR
+openclaw_e2e_enable_failure_diagnostics
 
 start_gateway() {
   local log_path="$1"

--- a/scripts/e2e/release-typed-onboarding-docker.sh
+++ b/scripts/e2e/release-typed-onboarding-docker.sh
@@ -5,12 +5,18 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
 source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
+source "$ROOT_DIR/scripts/e2e/lib/prepublish-plugin-registry.sh"
 
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-release-typed-onboarding-e2e" OPENCLAW_RELEASE_TYPED_ONBOARDING_E2E_IMAGE)"
 SKIP_BUILD="${OPENCLAW_RELEASE_TYPED_ONBOARDING_E2E_SKIP_BUILD:-0}"
+OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DOCKER_ARGS=()
+AUTO_PREPUBLISH_PLUGIN_REGISTRY_ROOT=""
 run_log=""
 cleanup() {
   docker_e2e_cleanup_package_tgz "${PACKAGE_TGZ:-}"
+  if [ -n "$AUTO_PREPUBLISH_PLUGIN_REGISTRY_ROOT" ]; then
+    rm -rf "$AUTO_PREPUBLISH_PLUGIN_REGISTRY_ROOT"
+  fi
   if [ -n "${run_log:-}" ]; then
     rm -f "$run_log"
   fi
@@ -18,6 +24,22 @@ cleanup() {
 trap cleanup EXIT
 
 PACKAGE_TGZ="$(docker_e2e_prepare_package_tgz release-typed-onboarding "${OPENCLAW_CURRENT_PACKAGE_TGZ:-}")"
+if [ -n "${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR:-}" ]; then
+  openclaw_prepublish_plugin_registry_configure_docker_args \
+    "$OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR"
+elif [ -z "${OPENCLAW_CURRENT_PACKAGE_TGZ:-}" ]; then
+  # Source builds need matching companions; explicit package overrides keep their catalog source.
+  AUTO_PREPUBLISH_PLUGIN_REGISTRY_ROOT="$(
+    mktemp -d "${TMPDIR:-/tmp}/openclaw-typed-onboarding-plugin-registry.XXXXXX"
+  )"
+  OPENCLAW_DOCKER_ALL_LANES=release-typed-onboarding \
+    OPENCLAW_DOCKER_ALL_LOG_DIR="$AUTO_PREPUBLISH_PLUGIN_REGISTRY_ROOT" \
+    OPENCLAW_DOCKER_ALL_TIMINGS=0 \
+    node "$ROOT_DIR/scripts/test-docker-all.mjs" --prepare-plugin-registry >/dev/null
+  openclaw_prepublish_plugin_registry_configure_docker_args \
+    "$AUTO_PREPUBLISH_PLUGIN_REGISTRY_ROOT/prepublish-plugin-registry"
+fi
+
 docker_e2e_package_mount_args "$PACKAGE_TGZ"
 
 docker_e2e_build_or_reuse "$IMAGE_NAME" release-typed-onboarding "$ROOT_DIR/scripts/e2e/Dockerfile" "$ROOT_DIR" "bare" "$SKIP_BUILD"
@@ -27,6 +49,7 @@ run_log="$(docker_e2e_run_log release-typed-onboarding)"
 echo "Running release typed onboarding Docker E2E..."
 if ! docker_e2e_run_with_harness \
   -e COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
+  ${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DOCKER_ARGS[@]+"${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DOCKER_ARGS[@]}"} \
   -e "OPENCLAW_TEST_STATE_SCRIPT_B64=$OPENCLAW_TEST_STATE_SCRIPT_B64" \
   "${DOCKER_E2E_PACKAGE_ARGS[@]}" \
   -i "$IMAGE_NAME" bash scripts/e2e/lib/release-typed-onboarding/scenario.sh >"$run_log" 2>&1; then

--- a/scripts/lib/docker-e2e-scenarios.mts
+++ b/scripts/lib/docker-e2e-scenarios.mts
@@ -188,10 +188,8 @@ function releaseTypedOnboardingLane() {
     "release-typed-onboarding",
     "OPENCLAW_SKIP_DOCKER_BUILD=1 pnpm test:docker:release-typed-onboarding",
     {
-      resources: ["npm", "service"],
-      stateScenario: "empty",
+      ...npmOnboardLaneOptions,
       timeoutMs: 20 * 60 * 1000,
-      weight: 3,
     },
   );
 }

--- a/scripts/lib/openclaw-e2e-instance.sh
+++ b/scripts/lib/openclaw-e2e-instance.sh
@@ -101,8 +101,9 @@ openclaw_e2e_maybe_timeout() {
           set -- "$resolved_command" "${@:2}"
         fi
       fi
-      node - "$timeout_value" "$@" <<'NODE'
-const [, , timeoutValue, command, ...args] = process.argv;
+      # Keep stdin attached to the child instead of consuming it as watchdog source.
+      node --input-type=module -e '
+const [, timeoutValue, command, ...args] = process.argv;
 const parseTimeoutMs = (value) => {
   const match = /^([0-9]+(?:\.[0-9]+)?)(ms|s|m|h)?$/u.exec(String(value ?? "").trim());
   if (!match) {
@@ -202,7 +203,7 @@ child.on("error", (error) => {
   console.error(error.message);
   process.exit(127);
 });
-NODE
+      ' -- "$timeout_value" "$@"
       return
     fi
     echo "timeout command not found and Node is unavailable; cannot bound OpenClaw E2E command after $timeout_value" >&2
@@ -237,6 +238,13 @@ openclaw_e2e_print_log() {
     echo "[failure log omitted: canonical redaction failed]"
   fi
 }
+openclaw_e2e_enable_failure_diagnostics() {
+  # Keep diagnostics outside command log redirections, including inherited traps.
+  # Scenarios reserve fd 4 and provide dump_debug_logs before enabling this handler.
+  exec 4>&2
+  set -E
+  trap 'status=$?; dump_debug_logs "$status" "$BASH_COMMAND" >&4 2>&4; exit "$status"' ERR
+}
 openclaw_e2e_install_package() {
   local log_file="$1"
   local label="${2:-mounted OpenClaw package}"
@@ -248,19 +256,10 @@ openclaw_e2e_install_package() {
     args+=("--prefix" "$prefix")
   fi
   echo "Installing $label..."
-  local had_errexit=0
-  case "$-" in
-    *e*) had_errexit=1 ;;
-  esac
-  set +e
-  openclaw_e2e_maybe_timeout "$timeout_value" npm install "${args[@]}" "$package_tgz" --no-fund --no-audit >"$log_file" 2>&1
-  local install_status=$?
-  if [ "$had_errexit" -eq 1 ]; then
-    set -e
+  if openclaw_e2e_maybe_timeout "$timeout_value" npm install "${args[@]}" "$package_tgz" --no-fund --no-audit >"$log_file" 2>&1; then
+    return 0
   else
-    set +e
-  fi
-  if [ "$install_status" -ne 0 ]; then
+    local install_status=$?
     if [ "$install_status" -eq 124 ] || [ "$install_status" -eq 137 ]; then
       echo "npm install timed out after $timeout_value for $label" >&2
     fi

--- a/test/scripts/docker-e2e-plan.test.ts
+++ b/test/scripts/docker-e2e-plan.test.ts
@@ -139,6 +139,7 @@ function bundledPluginSweepLane(index: number): ReturnType<typeof summarizeLane>
 
 describe("scripts/lib/docker-e2e-plan", () => {
   it.each([
+    ["release-typed-onboarding", ["@openclaw/codex"]],
     ["npm-onboard-channel-agent", ["@openclaw/codex"]],
     ["npm-onboard-discord-channel-agent", ["@openclaw/codex"]],
     ["npm-onboard-slack-channel-agent", ["@openclaw/codex"]],

--- a/test/scripts/openclaw-e2e-instance.test.ts
+++ b/test/scripts/openclaw-e2e-instance.test.ts
@@ -532,6 +532,51 @@ describe("scripts/lib/openclaw-e2e-instance.sh", () => {
     });
   });
 
+  it("preserves child stdin, arguments, and exit status through the Node watchdog", () => {
+    withTempDir("openclaw-e2e-instance-node-watchdog-stdin-", (tempDir) => {
+      writeNodeShim(tempDir);
+      const payload = "harmless watchdog stdin\nsecond line\n";
+      const args = ["two words", "--literal", "quote'arg"];
+      const child =
+        'const fs = require("node:fs"); process.stdout.write(JSON.stringify({ stdin: fs.readFileSync(0, "utf8"), args: process.argv.slice(1) })); process.exit(37);';
+      const result = spawnSync(
+        "/bin/bash",
+        [
+          "-c",
+          [
+            "set -euo pipefail",
+            `source ${shellQuote(helperPath)}`,
+            `openclaw_e2e_maybe_timeout 5s node -e ${shellQuote(child)} -- ${args.map(shellQuote).join(" ")}`,
+          ].join("\n"),
+        ],
+        {
+          encoding: "utf8",
+          env: shellTestEnv({ PATH: tempDir }),
+          input: payload,
+          timeout: 10_000,
+        },
+      );
+
+      expect(result.status).toBe(37);
+      expect(result.stderr).toContain("using Node watchdog");
+      expect(JSON.parse(result.stdout)).toEqual({ stdin: payload, args });
+    });
+  });
+
+  it("treats Node-watchdog timeout values as data, not Node options", () => {
+    withTempDir("openclaw-e2e-instance-node-watchdog-option-", (tempDir) => {
+      writeNodeShim(tempDir);
+      const result = runBashWithHelper(
+        ["openclaw_e2e_maybe_timeout --version node --version"],
+        { PATH: tempDir },
+        5_000,
+      );
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("unsupported timeout value: --version");
+      expect(result.stdout).toBe("");
+    });
+  });
+
   for (const [shellSignal, expectedStatus] of [
     ["TERM", "143"],
     ["HUP", "129"],


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where release QA's typed-onboarding scenario could not use its matching Codex companion after installing a fresh package. Redirected shell commands also hid failure diagnostics, and the shared Node timeout fallback consumed stdin before it could reach the child command.

This is a maintainer-requested repair from [full release QA](https://github.com/openclaw/openclaw/actions/runs/33154285571), not a production onboarding or consent-policy change.

## Why This Change Was Made

Use the existing Docker lane prerequisites and prepublish plugin registry so a source invocation builds the package and its matching companion together. Keep explicit package overrides on their selected catalog source, and install the fixture through the existing capability-consent helper. Preserve the capability-help receipt already landed in #131649.

The shared shell owner now keeps failure diagnostics on the scenarios' reserved stderr descriptor and preserves the original failure status. Package installation uses a normal conditional instead of changing global errexit. The Node watchdog receives its program through argv, leaving stdin for the child. Eight sibling scenarios use the same diagnostic owner; timeout values, signal handling, redaction, and cleanup remain intact.

## User Impact

No production runtime change. Release maintainers can run the typed-onboarding lane directly from source, and failures remain visible in captured logs. This changes 13 harness/test files: tooling +65/-26, tests +46/-0, production runtime +0/-0. The tooling growth supplies matching-package preparation and one shared diagnostic owner. QA provider inventory, worker authority, telemetry, and ClawHub changes are excluded.

## Evidence

The tested composition is immutable main `468054f93c431bfe192327f439efe325be52f2b4` plus exactly these 13 reviewed changes. Full pre/post source checks matched all 34,625 entries and modes (source-map SHA256 `603c2dda3beb421077a0245483f8f494ed96ed796de8dac8c18f7b13ac798c90`). The synced transport commit was `9d2758a152575d39b697bcda432823f8580732c4`; it is not the candidate base. Candidate [427c12d6eac318b78554bbf9794c1deacad804d8](https://github.com/openclaw/openclaw/commit/427c12d6eac318b78554bbf9794c1deacad804d8) has the exact same full tree as that tested transport (`9b8cda2dfaa6a5c2b32d7dde859cbd594964b0a2`). The normal commit hook preserved every tested source byte.

One Blacksmith Testbox command passed:

```sh
pnpm test test/scripts/openclaw-e2e-instance.test.ts test/scripts/docker-e2e-plan.test.ts test/scripts/prepublish-plugin-registry-shell.test.ts
pnpm check:changed --base origin/main --timed
env -u OPENCLAW_CURRENT_PACKAGE_TGZ -u OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR -u OPENCLAW_SKIP_DOCKER_BUILD -u OPENCLAW_RELEASE_TYPED_ONBOARDING_E2E_SKIP_BUILD pnpm test:docker:release-typed-onboarding
```

This produced 100 passing focused tests, all 15 changed checks, a fresh public package build and tarball-integrity check, matching companion registry preparation, and a passing Docker scenario with real TTY keypresses and mock-provider completion. Remote `origin/main` was explicitly bound to the immutable base before execution. The command and final source check both exited 0; command time was 12m4.6s.

[Backing workflow 33175068139](https://github.com/openclaw/openclaw/actions/runs/33175068139) was cancelled by explicit lease stop **after** the command passed; it is not green PR CI. The sole lease is completed, its temporary checkout/registration/admin directory and known process group are gone. Raw retained log: 114,327 bytes, SHA256 `965c8dc3c57488580534a6b1f5b5b91131fc423a90fb0ecd1900387233b65eaf`. [Exact-head PR CI 33185395828](https://github.com/openclaw/openclaw/actions/runs/33185395828) completed successfully for `427c12d6eac318b78554bbf9794c1deacad804d8`: 99 successful jobs, 18 intentional skips, and the required `openclaw/ci-gate` passed (job `98901178448`).

Earlier matched failing/passing probes cover Bash 3/Bash 5, handled failures, exit 37, timeout 124, redacted diagnostics, cleanup, and native/Node/disabled watchdog stdin and arguments. The added watchdog regression asserts exact stdin, argv, and child exit status; a second test rejects a timeout value that resembles a Node option. Independent managed P0-P2 review found no actionable issues before commit.

I personally inspected upstream Codex revision `94311d447587411789533c47601fd8bc9d81eb48`, `codex-rs/cli/src/main.rs:1547-1549` and `codex-rs/cli/src/login.rs:277-318`: API-key login reads nonterminal stdin and rejects empty input. This supports stdin preservation; it does not establish the cause of the separate original 1,800-second package-harness timeout. Local blame reaches a shallow-history boundary for the watchdog, so this PR does not attribute its introduction to that boundary commit.

The Docker proof uses a mock completion endpoint, not live-provider inference. It does not close the other recorded full-release failures or authorize a release. AI-assisted; manually inspected and reviewed.

## Maintainer Review Follow-through

I read the complete [ClawSweeper review](https://github.com/openclaw/openclaw/pull/131856#issuecomment-5454532299), including its Rank-up moves. It found no introduced functional or security defect. Its two remaining conditions are now addressed: exact-head CI passed, and the latest published review and rank-up list were checked. No code or assertion changes were requested, and no findings were waived.

The acting maintainer decision is to land this shared harness repair through the normal native review/prepare/merge gates under the requested release-QA work. Native landing completed as [b5acb499231967a8b2dba178b10650493b8ee09a](https://github.com/openclaw/openclaw/commit/b5acb499231967a8b2dba178b10650493b8ee09a): all 34,741 entries and modes in landed tree `25372c4683b8b8a5c32b1e3e246ea89e50613b5a` exactly match actual parent `d402305e1586f186d1300f12c90f3abf3d9e2ebf` with the 13 reviewed candidate entries applied; ancestry and task-owned native cleanup were verified. The cancelled proof backing workflow, mock-provider scope, and other unresolved full-release failures remain as qualified above.
