### PR TITLE
fix(webchat): strip reply directives during media transcript rewrites

### DIFF
--- a/src/agents/sessions/session-manager.persistence-compat.test.ts
+++ b/src/agents/sessions/session-manager.persistence-compat.test.ts
@@ -78,7 +78,6 @@ describe("SessionManager persistence compatibility", () => {
     expect(tagged).toMatchObject({
       openclawDelivery: {
         audioAsVoice: true,
-        replyToCurrent: true,
         replyToId: "message-7",
         tts: {
           tagged: true,

--- a/src/config/sessions/transcript-assistant-delivery.ts
+++ b/src/config/sessions/transcript-assistant-delivery.ts
@@ -70,10 +70,10 @@ export function applyAssistantDeliveryDirectives<T extends AssistantDirectiveMes
   if (facts) {
     const currentFacts = isRecord(message.openclawDelivery) ? message.openclawDelivery : undefined;
     const mergedFacts = { ...currentFacts, ...facts };
-    if (facts.replyToCurrent) {
-      delete mergedFacts.replyToId;
-    } else if (facts.replyToId) {
+    if (facts.replyToId) {
       delete mergedFacts.replyToCurrent;
+    } else if (facts.replyToCurrent) {
+      delete mergedFacts.replyToId;
     }
     Object.assign(message, { openclawDelivery: mergedFacts });
   }

--- a/src/config/sessions/transcript-assistant-delivery.ts
+++ b/src/config/sessions/transcript-assistant-delivery.ts
@@ -69,7 +69,13 @@ export function applyAssistantDeliveryDirectives<T extends AssistantDirectiveMes
   }
   if (facts) {
     const currentFacts = isRecord(message.openclawDelivery) ? message.openclawDelivery : undefined;
-    Object.assign(message, { openclawDelivery: { ...currentFacts, ...facts } });
+    const mergedFacts = { ...currentFacts, ...facts };
+    if (facts.replyToCurrent) {
+      delete mergedFacts.replyToId;
+    } else if (facts.replyToId) {
+      delete mergedFacts.replyToCurrent;
+    }
+    Object.assign(message, { openclawDelivery: mergedFacts });
   }
   return message;
 }

--- a/src/config/sessions/transcript-assistant-delivery.ts
+++ b/src/config/sessions/transcript-assistant-delivery.ts
@@ -68,7 +68,8 @@ export function applyAssistantDeliveryDirectives<T extends AssistantDirectiveMes
     });
   }
   if (facts) {
-    Object.assign(message, { openclawDelivery: facts });
+    const currentFacts = isRecord(message.openclawDelivery) ? message.openclawDelivery : undefined;
+    Object.assign(message, { openclawDelivery: { ...currentFacts, ...facts } });
   }
   return message;
 }

--- a/src/gateway/server-methods/chat-transcript-persistence.ts
+++ b/src/gateway/server-methods/chat-transcript-persistence.ts
@@ -414,11 +414,11 @@ export async function rewriteSourceReplyTranscriptMirrors(params: {
         return event;
       }
       return Object.assign({}, event as Record<string, unknown>, {
-        message: {
+        message: applyAssistantDeliveryDirectives({
           ...replacement.message,
           idempotencyKey: replacement.request.idempotencyKey,
-          content: replacement.request.state.persistedContent,
-        },
+          content: replacement.request.state.persistedContent.map((block) => ({ ...block })),
+        }),
       });
     });
     await transcript.replaceEvents(rewrittenEvents);
@@ -447,10 +447,10 @@ export async function rewriteAssistantTranscriptMessageByIdempotencyKey(params: 
     const rewrittenEvents = events.map((event) =>
       transcriptEventId(event) === target.messageId
         ? Object.assign({}, event as Record<string, unknown>, {
-            message: {
+            message: applyAssistantDeliveryDirectives({
               ...target.message,
-              content: params.content,
-            },
+              content: params.content.map((block) => ({ ...block })),
+            }),
           })
         : event,
     );

--- a/src/gateway/server-methods/chat-transcript-persistence.ts
+++ b/src/gateway/server-methods/chat-transcript-persistence.ts
@@ -417,7 +417,9 @@ export async function rewriteSourceReplyTranscriptMirrors(params: {
         message: applyAssistantDeliveryDirectives({
           ...replacement.message,
           idempotencyKey: replacement.request.idempotencyKey,
-          content: replacement.request.state.persistedContent.map((block) => ({ ...block })),
+          content: replacement.request.state.persistedContent.map((block) =>
+            Object.assign({}, block),
+          ),
         }),
       });
     });
@@ -449,7 +451,7 @@ export async function rewriteAssistantTranscriptMessageByIdempotencyKey(params: 
         ? Object.assign({}, event as Record<string, unknown>, {
             message: applyAssistantDeliveryDirectives({
               ...target.message,
-              content: params.content.map((block) => ({ ...block })),
+              content: params.content.map((block) => Object.assign({}, block)),
             }),
           })
         : event,

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -1228,14 +1228,16 @@ function createSourceReply(
 function createMainSourceReply(params: {
   idempotencyKey: string;
   mediaUrls?: string[];
+  replyToCurrent?: boolean;
   replyToId?: string;
   text?: string;
 }): TestReply {
-  const { idempotencyKey, mediaUrls, replyToId, text } = params;
+  const { idempotencyKey, mediaUrls, replyToCurrent, replyToId, text } = params;
   return createSourceReply(
     {
       ...(text ? { text } : {}),
       ...(mediaUrls ? { mediaUrls } : {}),
+      ...(replyToCurrent ? { replyToCurrent } : {}),
       ...(replyToId ? { replyToId } : {}),
     },
     {
@@ -3255,7 +3257,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     });
   });
 
-  it("replaces a runtime-owned media reply instead of appending a duplicate assistant", async () => {
+  it("replaces reply-to-current with an explicit id on a runtime-owned media rewrite", async () => {
     await withTranscriptFixtureState("openclaw-chat-send-owned-media-", async (fixtureDir) => {
       const mediaUrl = `data:image/png;base64,${TINY_PNG_BASE64}`;
       writeSavedPng(fixtureDir, "reply.png");
@@ -3267,7 +3269,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       });
       await appendSourceReplyMirrorEntry({
         idempotencyKey: "runtime-owned-assistant",
-        openclawDelivery: { audioAsVoice: true },
+        openclawDelivery: { audioAsVoice: true, replyToCurrent: true },
         text: `Dinner options\nMEDIA:${mediaUrl}`,
         provider: "openai",
         model: "codex",
@@ -3645,7 +3647,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(await readActiveAssistantTranscriptMessages()).toStrictEqual([]);
   });
 
-  it("does not duplicate media-bearing internal-ui source replies in the transcript", async () => {
+  it("replaces an explicit reply id with reply-to-current on a source reply rewrite", async () => {
     await withTranscriptFixtureState(
       "openclaw-chat-send-agent-source-reply-media-",
       async (fixtureDir) => {
@@ -3661,13 +3663,14 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         });
         await appendSourceReplyMirrorEntry({
           idempotencyKey: mirrorIdempotencyKey,
+          openclawDelivery: { audioAsVoice: true, replyToId: "stale-reply-id" },
           text: "Codex source reply with media",
         });
         const sourceReply = createMainSourceReply({
           idempotencyKey: mirrorIdempotencyKey,
           text: "Codex source reply with media",
           mediaUrls: [mediaUrl],
-          replyToId: "3114cf3c-e628-4c33-9214-894a1d8b6c60",
+          replyToCurrent: true,
         });
         setAgentRunReplies([sourceReply]);
         const { send } = createChatRequestFixture();
@@ -3697,7 +3700,8 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
           expect(JSON.stringify(assistantEntries[0])).toContain("/api/chat/media/outgoing/");
           expect(JSON.stringify(assistantEntries[0])).not.toContain(mediaUrl);
           expect(assistantEntries[0]?.openclawDelivery).toEqual({
-            replyToId: "3114cf3c-e628-4c33-9214-894a1d8b6c60",
+            audioAsVoice: true,
+            replyToCurrent: true,
           });
           expect(JSON.stringify(assistantEntries[0])).not.toContain("[[reply_to:");
           const entry = readSqliteMainSessionEntry();

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -703,6 +703,7 @@ function readSqliteMainSessionEntry(): Record<string, any> | undefined {
 async function appendSourceReplyMirrorEntry(params: {
   content?: Array<Record<string, unknown>>;
   idempotencyKey?: string;
+  openclawDelivery?: Record<string, unknown>;
   text: string;
   provider?: string;
   model?: string;
@@ -719,6 +720,7 @@ async function appendSourceReplyMirrorEntry(params: {
       provider: params.provider ?? "openclaw",
       model: params.model ?? "delivery-mirror",
       ...(params.idempotencyKey ? { idempotencyKey: params.idempotencyKey } : {}),
+      ...(params.openclawDelivery ? { openclawDelivery: params.openclawDelivery } : {}),
       usage: {
         input: 0,
         output: 0,
@@ -1226,11 +1228,16 @@ function createSourceReply(
 function createMainSourceReply(params: {
   idempotencyKey: string;
   mediaUrls?: string[];
+  replyToId?: string;
   text?: string;
 }): TestReply {
-  const { idempotencyKey, mediaUrls, text } = params;
+  const { idempotencyKey, mediaUrls, replyToId, text } = params;
   return createSourceReply(
-    { ...(text ? { text } : {}), ...(mediaUrls ? { mediaUrls } : {}) },
+    {
+      ...(text ? { text } : {}),
+      ...(mediaUrls ? { mediaUrls } : {}),
+      ...(replyToId ? { replyToId } : {}),
+    },
     {
       sessionKey: "main",
       ...(text ? { text } : {}),
@@ -3260,6 +3267,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       });
       await appendSourceReplyMirrorEntry({
         idempotencyKey: "runtime-owned-assistant",
+        openclawDelivery: { audioAsVoice: true },
         text: `Dinner options\nMEDIA:${mediaUrl}`,
         provider: "openai",
         model: "codex",
@@ -3272,6 +3280,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
               text: "Dinner options",
               mediaUrl,
               mediaUrls: [mediaUrl],
+              replyToId: "3114cf3c-e628-4c33-9214-894a1d8b6c60",
             },
             {
               assistantTranscriptOwned: true,
@@ -3299,6 +3308,11 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         : [];
       expect(content[0]).toEqual({ type: "text", text: "Dinner options" });
       expect(content.filter((block) => block.type === "image")).toHaveLength(1);
+      expect(rewritten?.openclawDelivery).toEqual({
+        audioAsVoice: true,
+        replyToId: "3114cf3c-e628-4c33-9214-894a1d8b6c60",
+      });
+      expect(JSON.stringify(rewritten)).not.toContain("[[reply_to:");
       expect(JSON.stringify(messages)).not.toContain(":assistant-media");
     });
   });
@@ -3653,6 +3667,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
           idempotencyKey: mirrorIdempotencyKey,
           text: "Codex source reply with media",
           mediaUrls: [mediaUrl],
+          replyToId: "3114cf3c-e628-4c33-9214-894a1d8b6c60",
         });
         setAgentRunReplies([sourceReply]);
         const { send } = createChatRequestFixture();
@@ -3681,6 +3696,10 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
           expect(assistantEntries[0]?.idempotencyKey).toBe(mirrorIdempotencyKey);
           expect(JSON.stringify(assistantEntries[0])).toContain("/api/chat/media/outgoing/");
           expect(JSON.stringify(assistantEntries[0])).not.toContain(mediaUrl);
+          expect(assistantEntries[0]?.openclawDelivery).toEqual({
+            replyToId: "3114cf3c-e628-4c33-9214-894a1d8b6c60",
+          });
+          expect(JSON.stringify(assistantEntries[0])).not.toContain("[[reply_to:");
           const entry = readSqliteMainSessionEntry();
           expect(entry?.updatedAt).toBeGreaterThanOrEqual(rewrittenAt);
           expect(entry?.updatedAt).toBeGreaterThan(updatedAt);

--- a/src/infra/state-migrations.transcript-directives.test.ts
+++ b/src/infra/state-migrations.transcript-directives.test.ts
@@ -290,7 +290,6 @@ describe("historical transcript directive migration", () => {
       content: [{ type: "text", text: "Final answer" }],
       openclawDelivery: {
         audioAsVoice: true,
-        replyToCurrent: true,
         replyToId: "message-7",
       },
     });


### PR DESCRIPTION
Closes #131844

## What Problem This Solves

Fixes an issue where WebChat conversations with delivered media could display and persist an internal reply directive as ordinary assistant text.

## Why This Change Was Made

Both direct media transcript replacement paths now pass cloned replacement content through the existing assistant-delivery normalizer. The normalizer removes inline reply controls, records the structured reply target, preserves unrelated delivery facts, and replaces stale mutually exclusive target state. If both reply controls occur, the explicit reply ID retains precedence.

This change is limited to Gateway transcript persistence. Media card rendering is unchanged.

## User Impact

Reply-targeted media deliveries retain their reply context without exposing internal directive syntax in WebChat or saved conversation history.

## Evidence

Before:

![Before: raw reply directive displayed in WebChat](https://github.com/user-attachments/assets/ea1ecde5-2a1f-440e-8c2f-14cfb41c80f8)

Exact-head CI completed successfully for `8330e4944c296294af3057d811aca3f10baaed93`.

Regression coverage verifies:

- replacement of a runtime-owned media reply by idempotency key;
- replacement of a source-reply transcript mirror;
- removal of raw reply directives from persisted text;
- preservation of independent delivery facts;
- stale reply-target replacement in both directions;
- explicit reply-ID precedence during normal persistence and historical migration.

## Repair Scope

- Architectural owner: assistant-delivery normalization at the Gateway transcript write boundary.
- Removed bypasses: two direct replacement paths now use the same normalizer as the existing turn-index rewrite.
- Production LOC: +16/-7 (net +9); tests: +27/-6 (net +21).
- Persistence compatibility: no field, schema, store, or serialized format was added or changed, so no migration is required.
