### PR TITLE
fix(test): accept systemd Node flags in doctor switch validation

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -42,6 +42,7 @@ const repositoryScriptEntries = [
   "scripts/e2e/lib/config-reload/mutate-metadata.mjs!",
   "scripts/e2e/lib/docker-artifact-proof/write-identities.ts!",
   "scripts/e2e/lib/docker-stats/assert-resource-ceiling.mjs!",
+  "scripts/e2e/lib/doctor-install-switch/assert-exec-start.mjs!",
   "scripts/e2e/lib/doctor-install-switch/write-wrapper.mjs!",
   "scripts/e2e/lib/fixture.mjs!",
   "scripts/e2e/lib/fixtures/config.mjs!",

--- a/scripts/e2e/lib/doctor-install-switch/assert-exec-start.mjs
+++ b/scripts/e2e/lib/doctor-install-switch/assert-exec-start.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import { parseSystemdExecStart } from "./shims/systemd-exec-start.mjs";
+
+function fail(message) {
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+}
+
+function readProgramArguments(unitPath) {
+  const execLines = fs
+    .readFileSync(unitPath, "utf8")
+    .split(/\r?\n/u)
+    .filter((line) => line.startsWith("ExecStart="));
+  if (execLines.length !== 1) {
+    fail(`Expected one ExecStart in ${unitPath}, found ${execLines.length}.`);
+  }
+  try {
+    return parseSystemdExecStart(execLines[0].slice("ExecStart=".length));
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error));
+    return [];
+  }
+}
+
+function resolveGatewayEntrypoint(programArguments) {
+  const commandIndex = programArguments.findIndex(
+    (arg, index, args) =>
+      index > 0 &&
+      !args[index - 1]?.startsWith("-") &&
+      (arg === "gateway" || (arg === "node" && args[index + 1] === "run")),
+  );
+  if (commandIndex <= 0) {
+    fail(`Could not resolve the gateway entrypoint from ${JSON.stringify(programArguments)}.`);
+  }
+  return programArguments[commandIndex - 1];
+}
+
+function assertEqual(label, actual, expected, argv) {
+  if (actual !== expected) {
+    fail(
+      `Expected ${label} ${expected}, got ${actual ?? "<missing>"}.\nExecStart argv: ${JSON.stringify(argv)}`,
+    );
+  }
+}
+
+const [mode, unitPath, expected, positionRaw] = process.argv.slice(2);
+if (!mode || !unitPath || expected === undefined) {
+  fail(
+    "usage: assert-exec-start.mjs entrypoint <unit-path> <expected> | argument <unit-path> <expected> <one-based-position>",
+  );
+}
+
+const programArguments = readProgramArguments(unitPath);
+if (mode === "entrypoint") {
+  assertEqual("entrypoint", resolveGatewayEntrypoint(programArguments), expected, programArguments);
+} else if (mode === "argument") {
+  const position = Number.parseInt(positionRaw ?? "", 10);
+  if (!Number.isSafeInteger(position) || position < 1) {
+    fail(`Invalid one-based argument position: ${positionRaw ?? "<missing>"}.`);
+  }
+  assertEqual(
+    `ExecStart argument ${position}`,
+    programArguments[position - 1],
+    expected,
+    programArguments,
+  );
+} else {
+  fail(`Unknown mode: ${mode}.`);
+}

--- a/scripts/e2e/lib/doctor-install-switch/scenario.sh
+++ b/scripts/e2e/lib/doctor-install-switch/scenario.sh
@@ -15,6 +15,7 @@ mkdir -p /tmp/openclaw-bin
 cp scripts/e2e/lib/doctor-install-switch/shims/systemctl /tmp/openclaw-bin/systemctl
 cp scripts/e2e/lib/doctor-install-switch/shims/loginctl /tmp/openclaw-bin/loginctl
 cp scripts/e2e/lib/doctor-install-switch/shims/busctl /tmp/openclaw-bin/busctl
+cp scripts/e2e/lib/doctor-install-switch/shims/systemd-exec-start.mjs /tmp/openclaw-bin/systemd-exec-start.mjs
 chmod +x /tmp/openclaw-bin/systemctl /tmp/openclaw-bin/loginctl /tmp/openclaw-bin/busctl
 
 package_tgz="${OPENCLAW_CURRENT_PACKAGE_TGZ:?missing OPENCLAW_CURRENT_PACKAGE_TGZ}"
@@ -90,18 +91,8 @@ is_legacy_package_acceptance_compat() {
 assert_entrypoint() {
   local unit_path="$1"
   local expected="$2"
-  local exec_line=""
-  exec_line=$(grep -m1 "^ExecStart=" "$unit_path" || true)
-  if [ -z "$exec_line" ]; then
-    echo "Missing ExecStart in $unit_path"
-    exit 1
-  fi
-  exec_line="${exec_line#ExecStart=}"
-  entrypoint=$(echo "$exec_line" | awk "{print \$2}")
-  entrypoint="${entrypoint%\"}"
-  entrypoint="${entrypoint#\"}"
-  if [ "$entrypoint" != "$expected" ]; then
-    echo "Expected entrypoint $expected, got $entrypoint"
+  if ! node scripts/e2e/lib/doctor-install-switch/assert-exec-start.mjs \
+    entrypoint "$unit_path" "$expected"; then
     if [ -n "${doctor_log:-}" ] && [ -f "$doctor_log" ]; then
       grep -E "Gateway service entrypoint|operator-owned systemd drop-in|managed externally" "$doctor_log" || true
     fi
@@ -113,19 +104,8 @@ assert_exec_arg() {
   local unit_path="$1"
   local index="$2"
   local expected="$3"
-  local exec_line=""
-  local actual=""
-  exec_line=$(grep -m1 "^ExecStart=" "$unit_path" || true)
-  if [ -z "$exec_line" ]; then
-    echo "Missing ExecStart in $unit_path"
-    exit 1
-  fi
-  exec_line="${exec_line#ExecStart=}"
-  actual=$(echo "$exec_line" | awk -v field="$index" "{print \$field}")
-  actual="${actual%\"}"
-  actual="${actual#\"}"
-  if [ "$actual" != "$expected" ]; then
-    echo "Expected ExecStart arg $index to be $expected, got $actual"
+  if ! node scripts/e2e/lib/doctor-install-switch/assert-exec-start.mjs \
+    argument "$unit_path" "$expected" "$index"; then
     cat "$unit_path"
     exit 1
   fi

--- a/scripts/e2e/lib/doctor-install-switch/shims/busctl
+++ b/scripts/e2e/lib/doctor-install-switch/shims/busctl
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import fs from "node:fs";
 import path from "node:path";
+import { parseSystemdExecStart } from "./systemd-exec-start.mjs";
 
 const manager = "org.freedesktop.systemd1";
 const rootObjectPath = "/org/freedesktop/systemd1";
@@ -9,6 +10,14 @@ const args = process.argv.slice(2);
 function fail() {
   process.stderr.write("doctor-switch busctl shim: unexpected invocation or unavailable unit\n");
   process.exit(1);
+}
+
+function parseWords(value) {
+  try {
+    return parseSystemdExecStart(value);
+  } catch {
+    return fail();
+  }
 }
 
 function readUnitContent(unitPath, missingUnitName) {
@@ -22,43 +31,6 @@ function readUnitContent(unitPath, missingUnitName) {
     }
     return fail();
   }
-}
-
-function splitWords(value) {
-  const words = [];
-  let word = "";
-  let quote = "";
-  let escaped = false;
-  for (const character of value) {
-    if (escaped) {
-      word += character;
-      escaped = false;
-    } else if (character === "\\" && quote !== "'") {
-      escaped = true;
-    } else if (quote) {
-      if (character === quote) {
-        quote = "";
-      } else {
-        word += character;
-      }
-    } else if (character === '"' || character === "'") {
-      quote = character;
-    } else if (/\s/u.test(character)) {
-      if (word) {
-        words.push(word);
-        word = "";
-      }
-    } else {
-      word += character;
-    }
-  }
-  if (quote || escaped) {
-    fail();
-  }
-  if (word) {
-    words.push(word);
-  }
-  return words;
 }
 
 function encodeUnitName(name) {
@@ -155,14 +127,14 @@ for (const rawLine of content.split(/\r?\n/u)) {
   const directive = line.slice(0, separator);
   const value = line.slice(separator + 1).trim();
   if (directive === "ExecStart") {
-    programArguments = splitWords(value).map(expandHome);
+    programArguments = parseWords(value).map(expandHome);
   } else if (directive === "WorkingDirectory") {
-    workingDirectory = expandHome(splitWords(value)[0] || "").replace(/^-/, "");
+    workingDirectory = expandHome(parseWords(value)[0] || "").replace(/^-/, "");
   } else if (directive === "Environment") {
     if (!value) {
       environment.clear();
     }
-    for (const assignment of splitWords(value)) {
+    for (const assignment of parseWords(value)) {
       const assignmentSeparator = assignment.indexOf("=");
       if (assignmentSeparator <= 0) {
         fail();
@@ -176,7 +148,7 @@ for (const rawLine of content.split(/\r?\n/u)) {
     if (!value) {
       environmentFiles.length = 0;
     }
-    for (const filename of splitWords(value)) {
+    for (const filename of parseWords(value)) {
       const optional = filename.startsWith("-");
       environmentFiles.push([expandHome(optional ? filename.slice(1) : filename), optional]);
     }
@@ -184,7 +156,7 @@ for (const rawLine of content.split(/\r?\n/u)) {
     if (!value) {
       unsetEnvironment.length = 0;
     } else {
-      unsetEnvironment.push(...splitWords(value));
+      unsetEnvironment.push(...parseWords(value));
     }
   }
 }

--- a/scripts/e2e/lib/doctor-install-switch/shims/systemd-exec-start.mjs
+++ b/scripts/e2e/lib/doctor-install-switch/shims/systemd-exec-start.mjs
@@ -1,0 +1,36 @@
+export function parseSystemdExecStart(value) {
+  const words = [];
+  let word = "";
+  let quote = "";
+  let escaped = false;
+  for (const character of value) {
+    if (escaped) {
+      word += character;
+      escaped = false;
+    } else if (character === "\\" && quote !== "'") {
+      escaped = true;
+    } else if (quote) {
+      if (character === quote) {
+        quote = "";
+      } else {
+        word += character;
+      }
+    } else if (character === '"' || character === "'") {
+      quote = character;
+    } else if (/\s/u.test(character)) {
+      if (word) {
+        words.push(word);
+        word = "";
+      }
+    } else {
+      word += character;
+    }
+  }
+  if (quote || escaped) {
+    throw new Error("Invalid systemd ExecStart quoting.");
+  }
+  if (word) {
+    words.push(word);
+  }
+  return words;
+}

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -84,6 +84,8 @@ const PLUGIN_LIFECYCLE_MATRIX_DOCKER_E2E_PATH = "scripts/e2e/plugin-lifecycle-ma
 const DOCTOR_SWITCH_DOCKER_E2E_PATH = "scripts/e2e/doctor-install-switch-docker.sh";
 const DOCTOR_SWITCH_SCENARIO_PATH = "scripts/e2e/lib/doctor-install-switch/scenario.sh";
 const DOCTOR_SWITCH_BUSCTL_SHIM_PATH = "scripts/e2e/lib/doctor-install-switch/shims/busctl";
+const DOCTOR_SWITCH_SYSTEMD_EXEC_START_PATH =
+  "scripts/e2e/lib/doctor-install-switch/shims/systemd-exec-start.mjs";
 const DOCTOR_SWITCH_LOGINCTL_SHIM_PATH = "scripts/e2e/lib/doctor-install-switch/shims/loginctl";
 const DOCTOR_SWITCH_SYSTEMCTL_SHIM_PATH = "scripts/e2e/lib/doctor-install-switch/shims/systemctl";
 const PACKAGE_COMPAT_PATH = "scripts/e2e/lib/package-compat.mjs";
@@ -5234,6 +5236,7 @@ done
       "cp scripts/e2e/lib/doctor-install-switch/shims/systemctl",
       "cp scripts/e2e/lib/doctor-install-switch/shims/loginctl",
       "cp scripts/e2e/lib/doctor-install-switch/shims/busctl",
+      "cp scripts/e2e/lib/doctor-install-switch/shims/systemd-exec-start.mjs",
       "OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_SERVICE_REPAIR=1",
       "scripts/e2e/lib/package-compat.mjs",
     ]);
@@ -5376,7 +5379,10 @@ done
     ]);
 
     const binDir = join(home, "bin");
-    writeExecutables(binDir, { busctl: readFileSync(DOCTOR_SWITCH_BUSCTL_SHIM_PATH, "utf8") });
+    writeExecutables(binDir, {
+      busctl: readFileSync(DOCTOR_SWITCH_BUSCTL_SHIM_PATH, "utf8"),
+      "systemd-exec-start.mjs": readFileSync(DOCTOR_SWITCH_SYSTEMD_EXEC_START_PATH, "utf8"),
+    });
     const { readSystemdServiceExecStart } =
       await import("../../src/daemon/systemd-service-files.js");
     expect(
@@ -5409,7 +5415,10 @@ done
     const binDir = join(home, "bin");
     const serviceName = "openclaw-gateway-fixture.service";
     const unitPath = join(home, ".config/systemd/user", serviceName);
-    writeExecutables(binDir, { busctl: readFileSync(DOCTOR_SWITCH_BUSCTL_SHIM_PATH, "utf8") });
+    writeExecutables(binDir, {
+      busctl: readFileSync(DOCTOR_SWITCH_BUSCTL_SHIM_PATH, "utf8"),
+      "systemd-exec-start.mjs": readFileSync(DOCTOR_SWITCH_SYSTEMD_EXEC_START_PATH, "utf8"),
+    });
     const env = {
       HOME: home,
       PATH: `${binDir}:${process.env.PATH}`,

--- a/test/scripts/doctor-install-switch-wrapper.test.ts
+++ b/test/scripts/doctor-install-switch-wrapper.test.ts
@@ -1,4 +1,4 @@
-// Doctor Install Switch Wrapper tests cover the generated wrapper script contract.
+// Doctor Install Switch tests cover its generated wrapper and service assertion contracts.
 import { spawnSync } from "node:child_process";
 import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../helpers/temp-dir.js";
 
 const SCRIPT_PATH = "scripts/e2e/lib/doctor-install-switch/write-wrapper.mjs";
+const EXEC_START_ASSERTION_PATH = "scripts/e2e/lib/doctor-install-switch/assert-exec-start.mjs";
 const tempDirs: string[] = [];
 
 afterEach(() => {
@@ -14,6 +15,13 @@ afterEach(() => {
 
 function runWriter(args: string[]) {
   return spawnSync(process.execPath, [SCRIPT_PATH, ...args], {
+    encoding: "utf8",
+    env: { ...process.env },
+  });
+}
+
+function runExecStartAssertion(args: string[]) {
+  return spawnSync(process.execPath, [EXEC_START_ASSERTION_PATH, ...args], {
     encoding: "utf8",
     env: { ...process.env },
   });
@@ -61,5 +69,59 @@ fs.writeFileSync(${JSON.stringify(forwardedArgsPath)}, JSON.stringify(process.ar
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("usage: write-wrapper.mjs <wrapper-path> <npm-bin> [log-path]");
+  });
+});
+
+describe("doctor install switch ExecStart assertions", () => {
+  it("resolves a quoted entrypoint after inserted Node heap flags", () => {
+    const root = makeTempDir(tempDirs, "openclaw-doctor-exec-start-");
+    const unitPath = path.join(root, "openclaw-gateway.service");
+    const entrypoint = "/opt/openclaw git/dist/index.js";
+    writeFileSync(
+      unitPath,
+      [
+        "[Service]",
+        `ExecStart="/usr/local/bin/node runtime" --max-old-space-size=4096 "${entrypoint}" gateway --port 18789`,
+      ].join("\n"),
+    );
+
+    const result = runExecStartAssertion(["entrypoint", unitPath, entrypoint]);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+  });
+
+  it("reads wrapper arguments from parsed ExecStart argv", () => {
+    const root = makeTempDir(tempDirs, "openclaw-doctor-exec-start-");
+    const unitPath = path.join(root, "openclaw-gateway.service");
+    const wrapper = "/home/test user/.local/bin/openclaw-wrapper";
+    writeFileSync(unitPath, `[Service]\nExecStart="${wrapper}" gateway\n`);
+
+    const wrapperResult = runExecStartAssertion(["argument", unitPath, wrapper, "1"]);
+    const gatewayResult = runExecStartAssertion(["argument", unitPath, "gateway", "2"]);
+
+    expect(wrapperResult.status).toBe(0);
+    expect(wrapperResult.stderr).toBe("");
+    expect(gatewayResult.status).toBe(0);
+    expect(gatewayResult.stderr).toBe("");
+  });
+
+  it("reports the parsed argv when entrypoint detection fails", () => {
+    const root = makeTempDir(tempDirs, "openclaw-doctor-exec-start-");
+    const unitPath = path.join(root, "openclaw-gateway.service");
+    writeFileSync(
+      unitPath,
+      "[Service]\nExecStart=/usr/bin/node --max-old-space-size=4096 /app/dist/index.js gateway\n",
+    );
+
+    const result = runExecStartAssertion(["entrypoint", unitPath, "/app/dist/other-index.js"]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "Expected entrypoint /app/dist/other-index.js, got /app/dist/index.js.",
+    );
+    expect(result.stderr).toContain(
+      'ExecStart argv: ["/usr/bin/node","--max-old-space-size=4096","/app/dist/index.js","gateway"]',
+    );
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Package Acceptance and Plugin Prerelease doctor-switch validation could falsely reject a valid systemd service when Node heap flags shifted the gateway entrypoint or executable paths contained spaces.

The new path-invoked assertion was also invisible to Knip, which caused the PR's full-tree dependency check to fail even though the assertion is invoked by the shell scenario.

## Why This Change Was Made

The doctor-switch harness now parses `ExecStart` into semantic argv through one shared harness parser used by both the systemd manager shim and scenario assertions. Gateway entrypoint detection follows the parsed command boundary instead of fixed shell fields.

Knip now registers `scripts/e2e/lib/doctor-install-switch/assert-exec-start.mjs` as the executable root. Its statically imported parser remains discoverable without a separate entry, broader glob, or ignore.

This is test/harness/tooling-only; production behavior is unchanged.

## User Impact

Release qualification can validate quoted service paths and Node heap flags without reporting a false doctor-switch failure, and the required dependency scan recognizes the shell-invoked assertion.

## Evidence

- Original behavior reproduction: `ExecStart=/usr/bin/node --max-old-space-size=4096 "/opt/openclaw git/dist/index.js" gateway` resolved field 2 as `--max-old-space-size=4096` instead of the entrypoint.
- Knip pre-fix reproduction: production unused-file scan passed; full-tree scan reported exactly `assert-exec-start.mjs` and its statically imported `shims/systemd-exec-start.mjs`.
- `pnpm deadcode:unused-files` (production and full-tree: 0 entries)
- `pnpm deadcode:exports` (production, full-tree, and scripts: 0 entries)
- `node scripts/run-vitest.mjs test/scripts/doctor-install-switch-wrapper.test.ts test/scripts/docker-build-helper.test.ts` (215 passed)
- `node scripts/check-changed.mjs -- config/knip.config.ts`
- `git diff --check`
- Deslop: clean; no changes needed
- Autoreview: clean; patch correct at 0.99 confidence

Production LOC: 0. The follow-up is one config line; the complete PR remains harness, test, and tooling-only.
