### PR TITLE
fix: SDK preparation timeouts leave compilers running

### DIFF
--- a/scripts/lib/managed-child-process.mts
+++ b/scripts/lib/managed-child-process.mts
@@ -2,6 +2,7 @@
 import { spawn, spawnSync } from "node:child_process";
 import type { ChildProcess, StdioOptions } from "node:child_process";
 import { constants as osConstants } from "node:os";
+import { Writable } from "node:stream";
 import { buildCmdExeCommandLine, resolveWindowsCmdExePath } from "../windows-cmd-helpers.mjs";
 import { resolveWindowsTaskkillPath } from "./windows-taskkill.mjs";
 
@@ -57,15 +58,19 @@ type RunManagedCommandOptions = ManagedCommandOptions & {
   requireProcessTreeExit?: boolean;
   runTaskkill?: TaskkillRunner;
   onReady?: (child: ChildProcess) => void;
+  signal?: AbortSignal;
+  abortKillGraceMs?: number;
+  onSignal?: (signal: NodeJS.Signals) => void;
 };
 
-type ManagedChild = {
-  child: ChildProcess;
-  forceKillTimer: ReturnType<typeof setTimeout> | null;
-  receivedSignal?: NodeJS.Signals;
-};
+type ManagedCommandOutcome =
+  | { type: "completed"; status: number }
+  | { type: "failed"; error: unknown }
+  | { type: "timeout" }
+  | { type: "aborted" }
+  | { type: "signal"; signal: NodeJS.Signals };
 
-const managedChildren = new Set<ManagedChild>();
+const managedChildren = new Set<(signal: NodeJS.Signals) => void>();
 const signalHandlers = new Map<NodeJS.Signals, () => void>();
 
 /** Return the conventional shell exit code for a signal. */
@@ -248,23 +253,46 @@ export async function runManagedCommand({
   requireProcessTreeExit = false,
   runTaskkill = spawnSync,
   onReady,
+  signal,
+  abortKillGraceMs,
+  onSignal,
 }: RunManagedCommandOptions) {
   if (platform === "win32" && requireProcessTreeExit) {
     throw createManagedCommandUnsupportedTreeVerificationError();
   }
+  signal?.throwIfAborted();
+  const managedStdio: StdioOptions =
+    stdio === "inherit"
+      ? ["inherit", "inherit", "inherit"]
+      : Array.isArray(stdio)
+        ? [...stdio]
+        : stdio;
+  // Non-TTY inherited output must remain observable when a nested detached
+  // wrapper outlives its leader. Preserve terminal descriptors and stream bytes.
+  const forwardedOutputs = [process.stdout, process.stderr].map((target, index) => {
+    if (
+      platform !== "win32" &&
+      !target.isTTY &&
+      Array.isArray(managedStdio) &&
+      managedStdio[index + 1] === "inherit"
+    ) {
+      managedStdio[index + 1] = "pipe";
+      return target;
+    }
+    return undefined;
+  });
   const spawnSpec = createManagedCommandSpawnSpec({
     bin,
     args,
     cwd,
     env,
-    stdio,
+    stdio: managedStdio,
     shell,
     windowsVerbatimArguments,
     platform,
     comSpec,
   });
-  // A child can become ready before spawn returns. Catch OS signals first so
-  // their callbacks wait for registration instead of orphaning a detached child.
+  // Register before spawn: a child can become ready before spawn returns.
   installSignalHandlers();
   let child: ChildProcess;
   try {
@@ -273,104 +301,177 @@ export async function runManagedCommand({
     removeSignalHandlersIfIdle();
     throw error;
   }
-  const managedChild: ManagedChild = {
-    child,
-    forceKillTimer: null,
-    receivedSignal: undefined,
-  };
-  managedChildren.add(managedChild);
-  let timeoutTimer: ReturnType<typeof setTimeout> | null = null;
-  let signalTimeout!: () => void;
-  let timedOut = false;
-  let timeoutTermination: ManagedChildTermination | undefined;
-  const timeoutTriggered = new Promise<void>((resolve) => {
-    signalTimeout = resolve;
+  let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+  let cancellation: Promise<ManagedCommandOutcome> | undefined;
+  let resolveCancellation!: (outcome: ManagedCommandOutcome) => void;
+  const canceled = new Promise<ManagedCommandOutcome>((resolve) => {
+    resolveCancellation = resolve;
   });
-
-  try {
-    const childCompletion = new Promise<number>((resolve, reject) => {
-      child.once("error", reject);
-      child.once("close", (status, signal) => {
-        if (timeoutTimer) {
-          clearTimeout(timeoutTimer);
-          timeoutTimer = null;
-        }
-        if (managedChild.forceKillTimer) {
-          clearTimeout(managedChild.forceKillTimer);
-        }
-        if (managedChild.receivedSignal) {
-          terminateManagedChild(child, "SIGKILL");
-          resolve(signalExitCode(managedChild.receivedSignal));
-          return;
-        }
-        if (timedOut) {
-          reject(createManagedCommandTimeoutError(timeoutMs));
-          return;
-        }
-        resolve(signal ? signalExitCode(signal) : (status ?? 1));
-      });
-      if (timeoutMs !== undefined) {
-        timeoutTimer = setTimeout(() => {
-          timedOut = true;
-          // Shell commands may spawn grandchildren, so timeout cleanup owns the whole tree.
-          timeoutTermination = terminateManagedChild(child, "SIGKILL", {
-            platform,
-            runTaskkill,
-          });
-          signalTimeout();
-        }, timeoutMs);
-      }
-    });
-    const childOutcome = childCompletion.then(
-      (status) => ({ status, type: "completed" as const }),
-      (error: unknown) => ({ error, type: "failed" as const }),
+  const stop = (
+    outcome: ManagedCommandOutcome,
+    stopSignal: NodeJS.Signals,
+    forceKillDelayMs?: number,
+  ) => {
+    if (cancellation) {
+      return cancellation;
+    }
+    clearTimeout(timeoutTimer);
+    cancellation = terminateManagedChildAndWait(child, stopSignal, {
+      platform,
+      runTaskkill,
+      forceKillDelayMs,
+    }).then(
+      () => outcome,
+      (error: unknown) => ({ type: "failed" as const, error }),
     );
+    void cancellation.then(resolveCancellation);
+    return cancellation;
+  };
+  const forwardSignal = (received: NodeJS.Signals) => {
+    onSignal?.(received);
+    void stop({ type: "signal", signal: received }, received);
+  };
+  const abort = () => {
+    void stop({ type: "aborted" }, "SIGTERM", abortKillGraceMs);
+  };
+  managedChildren.add(forwardSignal);
+  try {
+    const completion = new Promise<ManagedCommandOutcome>((resolve) => {
+      child.once("error", (error) => {
+        clearTimeout(timeoutTimer);
+        resolve({ type: "failed", error });
+      });
+      child.once("close", (status, received) => {
+        clearTimeout(timeoutTimer);
+        resolve({
+          type: "completed",
+          status: received ? signalExitCode(received) : (status ?? 1),
+        });
+      });
+    });
+    if (timeoutMs !== undefined) {
+      timeoutTimer = setTimeout(() => {
+        void stop({ type: "timeout" }, "SIGTERM");
+      }, timeoutMs);
+    }
+    signal?.addEventListener("abort", abort, { once: true });
+    if (signal?.aborted) {
+      abort();
+    }
     try {
+      for (const [index, target] of forwardedOutputs.entries()) {
+        if (target) {
+          const output = index === 0 ? child.stdout : child.stderr;
+          // Each child owns its pipe listeners; shared stdout/stderr only receive
+          // writes. The callback carries target completion and backpressure.
+          output!.pipe(
+            new Writable({
+              write(chunk, encoding, callback) {
+                target.write(chunk, encoding, callback);
+              },
+            }),
+          );
+        }
+      }
       onReady?.(child);
     } catch (error) {
-      const setupTermination = terminateManagedChild(child, "SIGKILL", {
-        platform,
-        runTaskkill,
-      });
-      try {
-        await ensureManagedProcessTreeExit(child, platform, {
-          windowsTermination: setupTermination,
-        });
-      } catch (cleanupError) {
-        throw createManagedCommandSetupCleanupError(error, cleanupError);
+      const cleanup = await stop({ type: "failed", error }, "SIGTERM");
+      if (cleanup.type === "failed" && cleanup.error !== error) {
+        throw createManagedCommandSetupCleanupError(error, cleanup.error);
       }
       throw error;
     }
-    const timeoutOutcome = timeoutTriggered.then(() => ({ type: "timeout" as const }));
-    const outcome =
-      timeoutMs === undefined
-        ? await childOutcome
-        : await Promise.race([childOutcome, timeoutOutcome]);
-    if (outcome.type === "timeout") {
-      await ensureManagedProcessTreeExit(child, platform, {
-        windowsTermination: timeoutTermination,
-      });
-      throw createManagedCommandTimeoutError(timeoutMs);
+    let outcome = await Promise.race([completion, canceled]);
+    // A leader's close can race cleanup of its group or inherited output pipes.
+    if (cancellation) {
+      outcome = await cancellation;
     }
     if (outcome.type === "failed") {
-      if (timedOut) {
-        await ensureManagedProcessTreeExit(child, platform, {
-          windowsTermination: timeoutTermination,
-        });
-      }
       throw outcome.error;
     }
+    if (outcome.type === "timeout") {
+      throw createManagedCommandTimeoutError(timeoutMs);
+    }
+    if (outcome.type === "aborted") {
+      throw Object.assign(new Error("Managed command aborted"), { code: "ABORT_ERR" });
+    }
+    if (outcome.type === "signal") {
+      return signalExitCode(outcome.signal);
+    }
     if (requireProcessTreeExit) {
-      await ensureManagedProcessTreeExit(child, platform, { terminateIfLive: true });
+      await ensureManagedProcessTreeExit(child, platform);
     }
     return outcome.status;
   } finally {
-    if (timeoutTimer) {
-      clearTimeout(timeoutTimer);
-    }
-    managedChildren.delete(managedChild);
+    clearTimeout(timeoutTimer);
+    signal?.removeEventListener("abort", abort);
+    managedChildren.delete(forwardSignal);
     removeSignalHandlersIfIdle();
   }
+}
+
+async function terminateManagedChildAndWait(
+  child: ChildProcess,
+  signal: NodeJS.Signals,
+  {
+    platform,
+    runTaskkill,
+    forceKillDelayMs = FORCE_KILL_DELAY_MS,
+  }: {
+    platform: NodeJS.Platform;
+    runTaskkill: TaskkillRunner;
+    forceKillDelayMs?: number;
+  },
+) {
+  // Nested wrappers own detached groups. Let them forward the signal before
+  // killing their leader, then join inherited pipes as well as our own group.
+  const termination = terminateManagedChild(child, signal, { platform, runTaskkill });
+  if (platform === "win32" && termination?.processTreeState !== "terminated") {
+    throw createManagedCommandCleanupError(
+      "Windows taskkill could not verify managed process tree exit",
+      child,
+      platform,
+      "indeterminate",
+    );
+  }
+  const forceAt = Date.now() + forceKillDelayMs;
+  const deadline = forceAt + PROCESS_GROUP_DRAIN_TIMEOUT_MS;
+  let forced = platform === "win32";
+  let groupState: "dead" | "indeterminate" | "live" = "indeterminate";
+  while (true) {
+    groupState =
+      platform === "win32"
+        ? "dead"
+        : inspectManagedProcessGroup(child, { errorPolicy: "indeterminate", platform });
+    const exited = child.exitCode !== null || child.signalCode !== null;
+    const pipesClosed = [child.stdout, child.stderr].every((pipe) => !pipe || pipe.closed);
+    if (groupState === "dead" && exited && pipesClosed) {
+      return;
+    }
+    const now = Date.now();
+    if (!forced && now >= forceAt) {
+      forced = true;
+      if (groupState !== "dead") {
+        terminateManagedChild(child, "SIGKILL", { platform, runTaskkill });
+      }
+    }
+    if (now >= deadline) {
+      break;
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, Math.min(PROCESS_GROUP_POLL_MS, deadline - now));
+    });
+  }
+  // Stop owning pipe handles only after recording failure; never disguise an
+  // escaped descendant holding stdio as a successfully cleaned timeout.
+  child.stdout?.destroy();
+  child.stderr?.destroy();
+  throw createManagedCommandCleanupError(
+    "Managed command cleanup could not verify child, process group, and output closure",
+    child,
+    platform,
+    groupState === "live" ? "live" : "indeterminate",
+  );
 }
 
 function createManagedCommandTimeoutError(timeoutMs: number | undefined) {
@@ -396,25 +497,7 @@ function createManagedCommandSetupCleanupError(error: unknown, cleanupError: unk
   );
 }
 
-async function ensureManagedProcessTreeExit(
-  child: ChildProcess,
-  platform: NodeJS.Platform,
-  {
-    terminateIfLive = false,
-    windowsTermination,
-  }: { terminateIfLive?: boolean; windowsTermination?: ManagedChildTermination } = {},
-) {
-  if (platform === "win32") {
-    if (windowsTermination?.processTreeState === "indeterminate") {
-      throw createManagedCommandCleanupError(
-        "Windows taskkill could not verify managed process tree exit",
-        child,
-        platform,
-        "indeterminate",
-      );
-    }
-    return;
-  }
+async function ensureManagedProcessTreeExit(child: ChildProcess, platform: NodeJS.Platform) {
   const initialStatus = inspectManagedProcessGroup(child, {
     errorPolicy: "indeterminate",
     platform,
@@ -424,9 +507,7 @@ async function ensureManagedProcessTreeExit(
   }
   let status: ReturnType<typeof inspectManagedProcessGroup> = initialStatus;
   // A missing group at signal time supersedes the earlier racy liveness probe.
-  const termination = terminateIfLive
-    ? terminateManagedChild(child, "SIGKILL", { platform })
-    : undefined;
+  const termination = terminateManagedChild(child, "SIGKILL", { platform });
   const deadline = Date.now() + PROCESS_GROUP_DRAIN_TIMEOUT_MS;
   while (Date.now() < deadline) {
     await new Promise((resolve) => {
@@ -434,7 +515,7 @@ async function ensureManagedProcessTreeExit(
     });
     status = inspectManagedProcessGroup(child, { errorPolicy: "indeterminate", platform });
     if (status === "dead") {
-      if (terminateIfLive && termination?.processTreeState !== "terminated") {
+      if (termination?.processTreeState !== "terminated") {
         throw createManagedCommandCleanupError(
           "Managed command exited while its process group remained active",
           child,
@@ -499,12 +580,8 @@ function removeSignalHandlersIfIdle() {
 }
 
 function forwardSignalToManagedChildren(signal: NodeJS.Signals) {
-  for (const managedChild of managedChildren) {
-    managedChild.receivedSignal ??= signal;
-    terminateManagedChild(managedChild.child, signal);
-    managedChild.forceKillTimer ??= setTimeout(() => {
-      terminateManagedChild(managedChild.child, "SIGKILL");
-    }, FORCE_KILL_DELAY_MS);
+  for (const forward of managedChildren) {
+    forward(signal);
   }
 }
 

--- a/scripts/prepare-extension-package-boundary-artifacts.mts
+++ b/scripts/prepare-extension-package-boundary-artifacts.mts
@@ -1,12 +1,6 @@
 // Prepares declaration and entry-shim artifacts that prove plugin package
 // boundary imports resolve through public package surfaces.
-import {
-  spawn,
-  spawnSync,
-  type SpawnOptionsWithStdioTuple,
-  type StdioNull,
-  type StdioPipe,
-} from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import { createRequire } from "node:module";
@@ -24,7 +18,8 @@ import {
 } from "./lib/local-check-runtime.mts";
 import {
   createManagedCommandInvocation,
-  terminateManagedChild,
+  runManagedCommand,
+  signalExitCode,
 } from "./lib/managed-child-process.mts";
 import { parsePositiveInt } from "./lib/numeric-options.mjs";
 import {
@@ -52,13 +47,6 @@ const ROOT_SHIMS_MAX_OLD_SPACE_SIZE =
 const ROOT_SHIMS_NODE_OPTIONS =
   `${process.env.NODE_OPTIONS ?? ""} --max-old-space-size=${ROOT_SHIMS_MAX_OLD_SPACE_SIZE}`.trim();
 const DEFAULT_NODE_STEP_ABORT_KILL_GRACE_MS = 1_000;
-type NodeStepSignal = "SIGHUP" | "SIGINT" | "SIGKILL" | "SIGTERM";
-const NODE_STEP_PARENT_SIGNALS = ["SIGHUP", "SIGINT", "SIGTERM"] satisfies NodeStepSignal[];
-const NODE_STEP_PARENT_SIGNAL_EXIT_CODES = new Map([
-  ["SIGHUP", 129],
-  ["SIGINT", 130],
-  ["SIGTERM", 143],
-]);
 type NodeStep = Pick<NodeStepParams, "abortKillGraceMs" | "env"> & {
   args: string[];
   label: string;
@@ -73,34 +61,13 @@ type ArtifactFreshParams = {
   hashStampPath?: string;
 };
 type ArtifactStamp = Pick<ArtifactFreshParams, "includeFile" | "inputPaths"> & { path: string };
-type NodeStepOutput = {
-  on(event: "data", listener: (chunk: string) => void): unknown;
-  setEncoding(encoding: "utf8"): void;
-};
-type NodeStepChild = {
-  kill(signal: NodeStepSignal): void;
-  on(event: "close", listener: (code: number | null) => void): unknown;
-  on(event: "error", listener: (error: Error) => void): unknown;
-  pid?: number;
-  stderr: NodeStepOutput;
-  stdout: NodeStepOutput;
-};
-type SpawnNodeStep = (
-  command: string,
-  args: string[],
-  options: SpawnOptionsWithStdioTuple<StdioNull, StdioPipe, StdioPipe>,
-) => NodeStepChild;
 type NodeStepParams = {
   abortController?: AbortController;
   abortKillGraceMs?: number;
   env?: NodeJS.ProcessEnv;
-  spawnImpl?: SpawnNodeStep;
 };
-const ACTIVE_NODE_STEP_KILLERS = new Map<(signal: NodeStepSignal) => void, number>();
-let nodeStepParentSignalForwardersInstalled = false;
-let exitingAfterParentSignal = false;
-let parentSignalExitCode = 1;
-let parentSignalExitTimer: ReturnType<typeof setTimeout> | undefined;
+const activeNodeSteps = new Set<Promise<number>>();
+let nodeStepParentSignal: NodeJS.Signals | undefined;
 
 /** Resolve tsx's loader through the selected checkout toolchain. */
 export function resolveTsxImportSpecifier({
@@ -730,206 +697,70 @@ export function createPrefixedOutputWriter(label: string, target: { write(chunk:
   };
 }
 
-function abortSiblingSteps(abortController: AbortController | undefined) {
-  if (abortController && !abortController.signal.aborted) {
-    abortController.abort();
-  }
-}
-
-function signalActiveNodeSteps(signal: NodeStepSignal) {
-  for (const killNodeStep of ACTIVE_NODE_STEP_KILLERS.keys()) {
-    killNodeStep(signal);
-  }
-}
-
-function activeNodeStepKillGraceMs() {
-  return ACTIVE_NODE_STEP_KILLERS.size > 0
-    ? Math.max(...ACTIVE_NODE_STEP_KILLERS.values())
-    : DEFAULT_NODE_STEP_ABORT_KILL_GRACE_MS;
-}
-
-function installNodeStepParentSignalForwarders() {
-  if (nodeStepParentSignalForwardersInstalled) {
-    return;
-  }
-  nodeStepParentSignalForwardersInstalled = true;
-  for (const signal of NODE_STEP_PARENT_SIGNALS) {
-    process.on(signal, () => {
-      const exitCode = NODE_STEP_PARENT_SIGNAL_EXIT_CODES.get(signal) ?? 1;
-      if (exitingAfterParentSignal) {
-        signalActiveNodeSteps("SIGKILL");
-        process.exit(exitCode);
-      }
-      exitingAfterParentSignal = true;
-      parentSignalExitCode = exitCode;
-      signalActiveNodeSteps(signal);
-      parentSignalExitTimer ??= setTimeout(
-        () => process.exit(parentSignalExitCode),
-        activeNodeStepKillGraceMs(),
-      );
-    });
-  }
-  process.on("exit", () => {
-    signalActiveNodeSteps("SIGKILL");
-  });
-}
-
-/**
- * Runs one artifact step with timeout, abort propagation, and prefixed output.
- */
-export function runNodeStep(
+/** Runs a declaration step through the shared managed lifecycle with prefixed output. */
+export async function runNodeStep(
   label: string,
   args: string[],
   timeoutMs: number,
   params: NodeStepParams = {},
 ) {
   const resolvedTimeoutMs = resolveTimerTimeoutMs(timeoutMs, MAX_TIMER_TIMEOUT_MS);
-  const abortKillGraceMs = Math.max(
-    0,
-    Math.floor(params.abortKillGraceMs ?? DEFAULT_NODE_STEP_ABORT_KILL_GRACE_MS),
-  );
-  const abortController = params.abortController;
-  const spawnImpl: SpawnNodeStep = params.spawnImpl ?? spawn;
-  installNodeStepParentSignalForwarders();
-  return new Promise<void>((resolvePromise, rejectPromise) => {
-    const child = spawnImpl(process.execPath, args, {
-      cwd: repoRoot,
-      detached: process.platform !== "win32",
-      env: params.env ? { ...process.env, ...params.env } : process.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let settled = false;
-    let canceled = false;
-    let killTimer: ReturnType<typeof setTimeout> | undefined;
-    let killDeadlineAt = 0;
-    const stdoutWriter = createPrefixedOutputWriter(label, process.stdout);
-    const stderrWriter = createPrefixedOutputWriter(label, process.stderr);
-    const useProcessGroup = process.platform !== "win32";
-    const killNodeStep = (signal: NodeStepSignal) =>
-      terminateManagedChild(child, signal, { useProcessGroup });
-    const processGroupAlive = () => {
-      if (!useProcessGroup || !child.pid) {
-        return false;
-      }
-      try {
-        process.kill(-child.pid, 0);
-        return true;
-      } catch (error) {
-        return Boolean(
-          error && typeof error === "object" && "code" in error && error.code === "EPERM",
-        );
-      }
-    };
-    const waitForProcessGroupExit = async (waitMs: number) => {
-      const deadlineAt = Date.now() + waitMs;
-      while (Date.now() < deadlineAt) {
-        if (!processGroupAlive()) {
-          return true;
-        }
-        await new Promise((resolvePoll) => {
-          setTimeout(resolvePoll, 25);
-        });
-      }
-      return !processGroupAlive();
-    };
-    const waitForCanceledStepTeardown = async () => {
-      const remainingGraceMs = Math.max(0, killDeadlineAt - Date.now());
-      if (remainingGraceMs > 0) {
-        await waitForProcessGroupExit(remainingGraceMs);
-      }
-      if (processGroupAlive()) {
-        killNodeStep("SIGKILL");
-        await waitForProcessGroupExit(100);
-      }
-    };
-    ACTIVE_NODE_STEP_KILLERS.set(killNodeStep, abortKillGraceMs);
-    const abortStep = () => {
-      if (settled || canceled) {
-        return;
-      }
-      canceled = true;
-      killNodeStep("SIGTERM");
-      killDeadlineAt = Date.now() + abortKillGraceMs;
-      killTimer = setTimeout(() => {
-        killTimer = undefined;
-        killNodeStep("SIGKILL");
-      }, abortKillGraceMs);
-      killTimer.unref?.();
-    };
-    function cleanup() {
-      clearTimeout(timer);
-      clearTimeout(killTimer);
-      ACTIVE_NODE_STEP_KILLERS.delete(killNodeStep);
-      abortController?.signal.removeEventListener("abort", abortStep);
-    }
-    const timer = setTimeout(() => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      killNodeStep("SIGKILL");
-      cleanup();
-      stdoutWriter.flush();
-      stderrWriter.flush();
-      abortSiblingSteps(abortController);
-      rejectPromise(new Error(`${label} timed out after ${resolvedTimeoutMs}ms`));
-    }, resolvedTimeoutMs);
-    abortController?.signal.addEventListener("abort", abortStep, { once: true });
-
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-    child.stdout.on("data", (chunk: string) => {
-      stdoutWriter.write(chunk);
-    });
-    child.stderr.on("data", (chunk: string) => {
-      stderrWriter.write(chunk);
-    });
-    child.on("error", (error: Error) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      stdoutWriter.flush();
-      stderrWriter.flush();
-      if (exitingAfterParentSignal) {
-        killNodeStep("SIGKILL");
-        cleanup();
-        return;
-      }
-      cleanup();
-      abortSiblingSteps(abortController);
-      rejectPromise(new Error(`${label} failed to start: ${error.message}`));
-    });
-    child.on("close", (code: number | null) => {
-      if (settled) {
-        return;
-      }
-      void (async () => {
-        settled = true;
-        stdoutWriter.flush();
-        stderrWriter.flush();
-        if (exitingAfterParentSignal) {
-          killNodeStep("SIGKILL");
-          cleanup();
-          return;
-        }
-        if (canceled) {
-          await waitForCanceledStepTeardown();
-          cleanup();
-          rejectPromise(new Error(`${label} canceled after sibling failure`));
-          return;
-        }
-        cleanup();
-        if (code === 0) {
-          resolvePromise();
-          return;
-        }
-        abortSiblingSteps(abortController);
-        rejectPromise(new Error(`${label} failed with exit code ${code ?? 1}`));
-      })();
-    });
+  const stdoutWriter = createPrefixedOutputWriter(label, process.stdout);
+  const stderrWriter = createPrefixedOutputWriter(label, process.stderr);
+  const command = runManagedCommand({
+    bin: process.execPath,
+    args,
+    cwd: repoRoot,
+    env: params.env ? { ...process.env, ...params.env } : process.env,
+    shell: false,
+    stdio: ["ignore", "pipe", "pipe"],
+    timeoutMs: resolvedTimeoutMs,
+    signal: params.abortController?.signal,
+    abortKillGraceMs: Math.max(
+      0,
+      Math.floor(params.abortKillGraceMs ?? DEFAULT_NODE_STEP_ABORT_KILL_GRACE_MS),
+    ),
+    onSignal(signal) {
+      nodeStepParentSignal ??= signal;
+    },
+    onReady(child) {
+      // This invocation explicitly requests both output pipes above.
+      child.stdout!.setEncoding("utf8");
+      child.stderr!.setEncoding("utf8");
+      child.stdout!.on("data", (chunk: string) => stdoutWriter.write(chunk));
+      child.stderr!.on("data", (chunk: string) => stderrWriter.write(chunk));
+    },
   });
+  activeNodeSteps.add(command);
+  try {
+    const code = await command;
+    if (code !== 0) {
+      throw new Error(`${label} failed with exit code ${code}`);
+    }
+  } catch (error) {
+    const code = error && typeof error === "object" && "code" in error ? error.code : undefined;
+    const failure =
+      code === "ETIMEDOUT"
+        ? new Error(`${label} timed out after ${resolvedTimeoutMs}ms`, { cause: error })
+        : code === "ABORT_ERR"
+          ? new Error(`${label} canceled after sibling failure`, { cause: error })
+          : error;
+    if (nodeStepParentSignal && code === "EPROCESSGROUP_CLEANUP_FAILED") {
+      console.error(failure);
+    }
+    if (params.abortController && !params.abortController.signal.aborted) {
+      params.abortController.abort(failure);
+    }
+    throw failure;
+  } finally {
+    stdoutWriter.flush();
+    stderrWriter.flush();
+    activeNodeSteps.delete(command);
+    // The last sibling exits only after all managed cancellation has joined.
+    if (nodeStepParentSignal && activeNodeSteps.size === 0) {
+      process.exit(signalExitCode(nodeStepParentSignal));
+    }
+  }
 }
 
 /**
@@ -946,9 +777,26 @@ export async function runNodeStepsInParallel(steps: NodeStep[]) {
       }),
     ),
   );
-  const firstFailure = results.find((result) => result.status === "rejected");
-  if (firstFailure) {
-    throw firstFailure.reason;
+  const failures: unknown[] = results.flatMap((result) =>
+    result.status === "rejected" ? [result.reason] : [],
+  );
+  if (failures.length > 0) {
+    const primary = abortController.signal.reason ?? failures[0];
+    const cleanupFailures = failures.filter(
+      (error: unknown) =>
+        error &&
+        typeof error === "object" &&
+        "code" in error &&
+        error.code === "EPROCESSGROUP_CLEANUP_FAILED" &&
+        error !== primary,
+    );
+    if (cleanupFailures.length > 0) {
+      throw new AggregateError(
+        [primary, ...cleanupFailures],
+        `${primary instanceof Error ? primary.message : String(primary)}; sibling cleanup could not be verified`,
+      );
+    }
+    throw primary;
   }
 }
 

--- a/scripts/run-tsgo.mts
+++ b/scripts/run-tsgo.mts
@@ -75,9 +75,8 @@ async function main(): Promise<void> {
     return;
   }
   try {
-    // Managed run owns the whole tsgo process tree: on timeout it SIGKILLs the
-    // process group, because a wedged checker ignores SIGTERM and would otherwise
-    // block the caller forever on a compiler that will never report.
+    // Managed cleanup forwards SIGTERM before bounded SIGKILL escalation, then
+    // joins the compiler group and output before reporting a timeout.
     process.exitCode = await runManagedCommand({
       bin: tsgoPath,
       args: finalArgs,

--- a/test/scripts/bundled-plugin-assets.test.ts
+++ b/test/scripts/bundled-plugin-assets.test.ts
@@ -2,7 +2,6 @@
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
-import { setTimeout as delay } from "node:timers/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildDiscordActivitySdk } from "../../scripts/build-discord-activity-sdk.mts";
 import {
@@ -176,23 +175,30 @@ describe("bundled plugin assets", () => {
       fs.writeFileSync(packagePath, JSON.stringify(packageJson, null, 2));
       fs.mkdirSync(path.join(pluginDir, "scripts"));
       const pidFile = path.join(pluginDir, "stall.pid");
+      const readyFile = path.join(pluginDir, "stall.ready");
+      fs.writeFileSync(
+        path.join(pluginDir, "scripts", "stall.mjs"),
+        [
+          'import { writeFileSync } from "node:fs";',
+          'process.on("SIGTERM", () => {});',
+          `writeFileSync(${JSON.stringify(readyFile)}, String(process.pid));`,
+          "setInterval(() => {}, 100);",
+          "",
+        ].join("\n"),
+      );
       fs.writeFileSync(
         path.join(pluginDir, "scripts", "launch-stall.mjs"),
         [
           'import { spawn } from "node:child_process";',
           'import { writeFileSync } from "node:fs";',
-          "const child = spawn(process.execPath, [",
-          '  "-e",',
-          '  "process.on(\\"SIGTERM\\", () => {}); setTimeout(() => process.exit(0), 5_000); setInterval(() => {}, 100);",',
-          '], { stdio: "ignore" });',
-          `writeFileSync(${JSON.stringify(pidFile)}, String(child.pid));`,
           'process.on("SIGTERM", () => {});',
+          'const child = spawn(process.execPath, ["scripts/stall.mjs"], { stdio: "ignore" });',
+          `writeFileSync(${JSON.stringify(pidFile)}, String(child.pid));`,
           "setInterval(() => {}, 100);",
           "",
         ].join("\n"),
       );
 
-      const startedAt = Date.now();
       let thrown: unknown;
       let childPid = 0;
       try {
@@ -201,9 +207,10 @@ describe("bundled plugin assets", () => {
         thrown = error;
       }
       try {
-        expect(Date.now() - startedAt).toBeLessThan(2_000);
         childPid = Number(fs.readFileSync(pidFile, "utf8"));
-        await waitForProcessExit(childPid);
+        // Timeout rejection must join cleanup, not leave the caller to poll for it.
+        expect(isProcessAlive(childPid)).toBe(false);
+        expect(fs.readFileSync(readyFile, "utf8")).toBe(String(childPid));
         expect(thrown).toMatchObject({
           code: "ETIMEDOUT",
           message: "Bundled plugin asset build hook timed out after 500ms: canvas",
@@ -288,16 +295,6 @@ describe("bundled plugin assets", () => {
     });
   });
 });
-
-async function waitForProcessExit(pid: number, timeoutMs = 1_500) {
-  const startedAt = Date.now();
-  while (isProcessAlive(pid)) {
-    if (Date.now() - startedAt > timeoutMs) {
-      throw new Error(`process ${pid} remained alive after timeout cleanup`);
-    }
-    await delay(5);
-  }
-}
 
 function isProcessAlive(pid: number) {
   try {

--- a/test/scripts/managed-child-process.test.ts
+++ b/test/scripts/managed-child-process.test.ts
@@ -112,31 +112,31 @@ ${publish(2)}
       const abortController = new AbortController();
       const stdout = vi.spyOn(process.stdout, "write");
       let output = "";
-      const run = startProcessWatchdogFixture(async () =>
-        runner === "preparation"
-          ? runNodeStep("nested", [wrapper], 100, { abortController })
-          : runManagedCommand({
-              bin: process.execPath,
-              args: [wrapper],
-              stdio: runner === "managed-inherit" ? "inherit" : ["ignore", "pipe", "pipe"],
-              timeoutMs: 100,
-              onReady: (child) =>
-                child.stdout?.on("data", (chunk) => {
-                  output += String(chunk);
-                }),
-            }),
-      );
-      const outcome = run.runPromise.then(
-        () => undefined,
-        (error: unknown) => error,
-      );
+      const releaseAndWait = startProcessWatchdogFixture(() => {
+        const command =
+          runner === "preparation"
+            ? runNodeStep("nested", [wrapper], 100, { abortController })
+            : runManagedCommand({
+                bin: process.execPath,
+                args: [wrapper],
+                stdio: runner === "managed-inherit" ? "inherit" : ["ignore", "pipe", "pipe"],
+                timeoutMs: 100,
+                onReady: (child) =>
+                  child.stdout?.on("data", (chunk) => {
+                    output += String(chunk);
+                  }),
+              });
+        return command.then(
+          () => undefined,
+          (error: unknown) => error,
+        );
+      });
       const pids: number[] = [];
       try {
         for (const pidPath of pidPaths) pids.push(await waitForPidFile(pidPath, 10_000));
         expect(pids.every(isProcessAlive)).toBe(true);
         if (abort) abortController.abort();
-        run.releaseTimeout();
-        expect(await outcome).toMatchObject({
+        expect(await releaseAndWait()).toMatchObject({
           message: expect.stringContaining(
             abort ? "canceled after sibling failure" : "timed out after 100ms",
           ),
@@ -153,8 +153,7 @@ ${publish(2)}
           expect(stdout.mock.calls.some(([chunk]) => String(chunk) === "shutdown-tail")).toBe(true);
         } else expect(output).toBe("shutdown-tail");
       } finally {
-        run.releaseTimeout();
-        await outcome;
+        await releaseAndWait();
         stdout.mockRestore();
         for (const pidPath of [...pidPaths].reverse()) {
           if (!fs.existsSync(pidPath)) continue;
@@ -792,36 +791,40 @@ require('node:child_process').spawn(process.execPath, ['-e', ${JSON.stringify(le
       ];
       let child: ReturnType<typeof spawn> | undefined;
       let escapedPid = 0;
-      const run = startProcessWatchdogFixture(async () =>
-        mode === "timeout"
-          ? runManagedCommand({
-              bin: process.execPath,
-              args,
-              stdio: ["ignore", "pipe", "pipe"],
-              timeoutMs: 100,
-              onReady: (owned) => {
-                child = owned;
-              },
-            })
-          : runNodeStepsInParallel([
-              { label: "blocked", args, timeoutMs: 100 },
-              {
-                label: "primary",
-                args: [
-                  "-e",
-                  `setInterval(() => { if (require('node:fs').existsSync(${JSON.stringify(failPath)})) process.exit(2); }, 5);`,
-                ],
-                timeoutMs: 30_000,
-              },
-            ]),
-      );
-      const outcome = run.runPromise.catch((error: unknown) => error);
+      let outcome!: Promise<unknown>;
+      const releaseAndWait = startProcessWatchdogFixture(() => {
+        const command =
+          mode === "timeout"
+            ? runManagedCommand({
+                bin: process.execPath,
+                args,
+                stdio: ["ignore", "pipe", "pipe"],
+                timeoutMs: 100,
+                onReady: (owned) => {
+                  child = owned;
+                },
+              })
+            : runNodeStepsInParallel([
+                { label: "blocked", args, timeoutMs: 100 },
+                {
+                  label: "primary",
+                  args: [
+                    "-e",
+                    `setInterval(() => { if (require('node:fs').existsSync(${JSON.stringify(failPath)})) process.exit(2); }, 5);`,
+                  ],
+                  timeoutMs: 30_000,
+                },
+              ]);
+        // Observe sibling cancellation without releasing the blocked watchdog.
+        outcome = command.catch((error: unknown) => error);
+        return outcome;
+      });
       try {
         escapedPid = await waitForPidFile(pidPath, 10_000);
         const parentPid = await waitForPidFile(parentPidPath, 10_000);
         const canceledAt = Date.now();
         if (mode === "sibling failure") fs.writeFileSync(failPath, "fail");
-        else run.releaseTimeout();
+        else await releaseAndWait();
         const failure = await outcome;
         const cleanupFailure = {
           code: "EPROCESSGROUP_CLEANUP_FAILED",
@@ -842,9 +845,8 @@ require('node:child_process').spawn(process.execPath, ['-e', ${JSON.stringify(le
         expect(isProcessAlive(parentPid)).toBe(false);
         expect(isProcessAlive(escapedPid)).toBe(true);
       } finally {
-        run.releaseTimeout();
         fs.writeFileSync(failPath, "fail");
-        await outcome;
+        await releaseAndWait();
         if (!escapedPid && fs.existsSync(pidPath))
           escapedPid = Number(fs.readFileSync(pidPath, "utf8"));
         if (escapedPid && isProcessAlive(escapedPid)) {

--- a/test/scripts/managed-child-process.test.ts
+++ b/test/scripts/managed-child-process.test.ts
@@ -13,6 +13,10 @@ import {
   terminateManagedChild,
   waitForManagedProcessGroupExit,
 } from "../../scripts/lib/managed-child-process.mts";
+import {
+  runNodeStep,
+  runNodeStepsInParallel,
+} from "../../scripts/prepare-extension-package-boundary-artifacts.mts";
 import { waitForDead, waitForPidFile } from "../helpers/process-wait.js";
 import { startProcessWatchdogFixture } from "../helpers/process-watchdog.js";
 import { createScriptTestHarness } from "./test-helpers.js";
@@ -59,6 +63,115 @@ fs.renameSync(pidPath + ".tmp", pidPath);
 }
 
 describe("managed-child-process", () => {
+  posixIt.each([
+    { runner: "managed", resistant: false, abort: false },
+    { runner: "managed", resistant: true, abort: false },
+    { runner: "managed-inherit", resistant: true, abort: false },
+    { runner: "preparation", resistant: false, abort: false },
+    { runner: "preparation", resistant: true, abort: false },
+    { runner: "preparation", resistant: false, abort: true },
+    { runner: "preparation", resistant: true, abort: true },
+  ])(
+    "joins nested $runner cleanup (resistant=$resistant, abort=$abort)",
+    async ({ runner, resistant, abort }) => {
+      const dir = fs.realpathSync(createTempDir("openclaw-nested-timeout-"));
+      const moduleUrl = (file: string) => pathToFileURL(path.resolve(file)).href;
+      const pidPaths = ["wrapper", "implementation", "leaf"].map((role) =>
+        path.join(dir, `${role}.pid`),
+      );
+      const publish = (index: number) =>
+        `fs.writeFileSync(${JSON.stringify(pidPaths[index])} + '.tmp', String(process.pid)); fs.renameSync(${JSON.stringify(pidPaths[index])} + '.tmp', ${JSON.stringify(pidPaths[index])});`;
+      const wrapper = path.join(dir, "wrapper.mjs");
+      fs.writeFileSync(
+        wrapper,
+        `
+import fs from 'node:fs';
+import { runTsxCliShim } from ${JSON.stringify(moduleUrl("scripts/lib/tsx-cli-shim.mjs"))};
+${publish(0)}
+await runTsxCliShim(import.meta.url, { implementation: './implementation.mts', forceKillDelayMs: 10000 });
+`,
+      );
+      fs.writeFileSync(
+        path.join(dir, "implementation.mts"),
+        `
+import fs from 'node:fs';
+import { runManagedCommand } from ${JSON.stringify(moduleUrl("scripts/lib/managed-child-process.mts"))};
+${publish(1)}
+process.exitCode = await runManagedCommand({ bin: process.execPath, args: [${JSON.stringify(path.join(dir, "leaf.mjs"))}], shell: false });
+`,
+      );
+      fs.writeFileSync(
+        path.join(dir, "leaf.mjs"),
+        `
+import fs from 'node:fs';
+process.on('SIGTERM', () => { process.stdout.write('shutdown-tail'); ${resistant ? "" : "process.exit(0);"} });
+setInterval(() => {}, 1000);
+${publish(2)}
+`,
+      );
+      const abortController = new AbortController();
+      const stdout = vi.spyOn(process.stdout, "write");
+      let output = "";
+      const run = startProcessWatchdogFixture(async () =>
+        runner === "preparation"
+          ? runNodeStep("nested", [wrapper], 100, { abortController })
+          : runManagedCommand({
+              bin: process.execPath,
+              args: [wrapper],
+              stdio: runner === "managed-inherit" ? "inherit" : ["ignore", "pipe", "pipe"],
+              timeoutMs: 100,
+              onReady: (child) =>
+                child.stdout?.on("data", (chunk) => {
+                  output += String(chunk);
+                }),
+            }),
+      );
+      const outcome = run.runPromise.then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      const pids: number[] = [];
+      try {
+        for (const pidPath of pidPaths) pids.push(await waitForPidFile(pidPath, 10_000));
+        expect(pids.every(isProcessAlive)).toBe(true);
+        if (abort) abortController.abort();
+        run.releaseTimeout();
+        expect(await outcome).toMatchObject({
+          message: expect.stringContaining(
+            abort ? "canceled after sibling failure" : "timed out after 100ms",
+          ),
+        });
+        expect(
+          pids.filter(isProcessAlive),
+          "timeout must join every nested child before rejection",
+        ).toEqual([]);
+        if (runner === "preparation") {
+          expect(
+            stdout.mock.calls.some(([chunk]) => String(chunk) === "[nested] shutdown-tail"),
+          ).toBe(true);
+        } else if (runner === "managed-inherit") {
+          expect(stdout.mock.calls.some(([chunk]) => String(chunk) === "shutdown-tail")).toBe(true);
+        } else expect(output).toBe("shutdown-tail");
+      } finally {
+        run.releaseTimeout();
+        await outcome;
+        stdout.mockRestore();
+        for (const pidPath of [...pidPaths].reverse()) {
+          if (!fs.existsSync(pidPath)) continue;
+          const pid = Number(fs.readFileSync(pidPath, "utf8"));
+          if (!Number.isSafeInteger(pid) || pid <= 1) continue;
+          try {
+            process.kill(pid, "SIGKILL");
+          } catch (error) {
+            if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+          }
+          await waitForDead(pid, 2_000);
+        }
+      }
+    },
+    20_000,
+  );
+
   it("maps forwarded signals to shell-compatible exit codes", () => {
     expect(signalExitCode("SIGHUP")).toBe(129);
     expect(signalExitCode("SIGINT")).toBe(130);
@@ -390,43 +503,82 @@ describe("managed-child-process", () => {
     expect(child.kill).toHaveBeenCalledWith("SIGTERM");
   });
 
-  it("shares signal listeners across parallel commands even when another spawn throws", async () => {
-    const signals = ["SIGHUP", "SIGINT", "SIGTERM"] as const;
-    const baseline = new Map(signals.map((signal) => [signal, process.listenerCount(signal)]));
-    const children: Array<Parameters<typeof terminateManagedChild>[0]> = [];
-    let readyCount = 0;
-    const commands = Array.from({ length: 12 }, () =>
-      runManagedCommand({
-        args: ["-e", "setTimeout(() => {}, 10_000)"],
-        bin: process.execPath,
-        shell: false,
-        stdio: "ignore",
-        onReady: (child) => {
-          children.push(child);
-          readyCount += 1;
-        },
-      }),
-    );
+  it.each(["ignore", "inherit"] as const)(
+    "shares listeners across parallel %s commands even when another spawn throws",
+    async (stdio) => {
+      const signals = ["SIGHUP", "SIGINT", "SIGTERM"] as const;
+      const baseline = new Map(signals.map((signal) => [signal, process.listenerCount(signal)]));
+      const warnings: string[] = [];
+      const onWarning = (warning: Error) => {
+        if (warning.name === "MaxListenersExceededWarning") warnings.push(warning.message);
+      };
+      process.on("warning", onWarning);
+      const stdout = vi.spyOn(process.stdout, "write");
+      const stderr = vi.spyOn(process.stderr, "write");
+      const children: Array<Parameters<typeof terminateManagedChild>[0]> = [];
+      let readyCount = 0;
+      const commands = Array.from({ length: 12 }, (_, index) =>
+        runManagedCommand({
+          args: [
+            "-e",
+            `process.stdout.write('managed-parallel-out-${index}-π\\n'); process.stderr.write('managed-parallel-err-${index}-π\\n'); setTimeout(() => {}, 10_000);`,
+          ],
+          bin: process.execPath,
+          shell: false,
+          stdio,
+          onReady: (child) => {
+            children.push(child);
+            readyCount += 1;
+          },
+        }),
+      );
 
-    try {
-      await waitFor(() => readyCount === commands.length);
-      await expect(runManagedCommand({ bin: "invalid\0command" })).rejects.toMatchObject({
-        code: "ERR_INVALID_ARG_VALUE",
-      });
+      try {
+        await waitFor(() => readyCount === commands.length);
+        await expect(runManagedCommand({ bin: "invalid\0command" })).rejects.toMatchObject({
+          code: "ERR_INVALID_ARG_VALUE",
+        });
+        for (const signal of signals) {
+          expect(process.listenerCount(signal)).toBe((baseline.get(signal) ?? 0) + 1);
+        }
+        if (stdio === "inherit" && process.platform !== "win32") {
+          for (const [output, kind] of [
+            [stdout, "out"],
+            [stderr, "err"],
+          ] as const) {
+            const lines = () =>
+              output.mock.calls
+                .map(([chunk]) => String(chunk))
+                .join("")
+                .split("\n")
+                .filter((line) => line.startsWith(`managed-parallel-${kind}-`))
+                .sort();
+            await waitFor(() => lines().length === commands.length);
+            expect(lines()).toEqual(
+              Array.from(
+                { length: 12 },
+                (_, index) => `managed-parallel-${kind}-${index}-π`,
+              ).sort(),
+            );
+          }
+        }
+      } finally {
+        for (const child of children) {
+          terminateManagedChild(child, "SIGTERM");
+        }
+        await Promise.all(commands);
+        process.off("warning", onWarning);
+        stdout.mockRestore();
+        stderr.mockRestore();
+      }
+
+      expect(warnings).toEqual([]);
+      expect(children.every((child) => !child.pid || !isProcessAlive(child.pid))).toBe(true);
       for (const signal of signals) {
-        expect(process.listenerCount(signal)).toBe((baseline.get(signal) ?? 0) + 1);
+        expect(process.listenerCount(signal)).toBe(baseline.get(signal) ?? 0);
       }
-    } finally {
-      for (const child of children) {
-        terminateManagedChild(child, "SIGTERM");
-      }
-      await Promise.all(commands);
-    }
-
-    for (const signal of signals) {
-      expect(process.listenerCount(signal)).toBe(baseline.get(signal) ?? 0);
-    }
-  });
+    },
+  );
 
   it.each([
     { bin: "invalid\0command", code: "ERR_INVALID_ARG_VALUE" },
@@ -616,6 +768,94 @@ ${publishReadyPidScript(2)}
     expect(Date.now() - startedAt).toBeLessThan(2_000);
     expect(isProcessAlive(childPid)).toBe(false);
   });
+
+  posixIt.each(["timeout", "sibling failure"])(
+    "fails closed within the cleanup budget when an escaped child holds output after $0",
+    async (mode) => {
+      const dir = createTempDir("openclaw-managed-held-output-");
+      const pidPath = path.join(dir, "escaped.pid");
+      const parentPidPath = path.join(dir, "parent.pid");
+      const failPath = path.join(dir, "fail");
+      const leaf = `
+const fs = require('node:fs');
+process.on('SIGTERM', () => {});
+setInterval(() => {}, 1000);
+fs.writeFileSync(${JSON.stringify(pidPath)} + '.tmp', String(process.pid));
+fs.renameSync(${JSON.stringify(pidPath)} + '.tmp', ${JSON.stringify(pidPath)});
+`;
+      const args = [
+        "-e",
+        `
+require('node:fs').writeFileSync(${JSON.stringify(parentPidPath)}, String(process.pid));
+require('node:child_process').spawn(process.execPath, ['-e', ${JSON.stringify(leaf)}], { detached: true, stdio: 'inherit' });
+`,
+      ];
+      let child: ReturnType<typeof spawn> | undefined;
+      let escapedPid = 0;
+      const run = startProcessWatchdogFixture(async () =>
+        mode === "timeout"
+          ? runManagedCommand({
+              bin: process.execPath,
+              args,
+              stdio: ["ignore", "pipe", "pipe"],
+              timeoutMs: 100,
+              onReady: (owned) => {
+                child = owned;
+              },
+            })
+          : runNodeStepsInParallel([
+              { label: "blocked", args, timeoutMs: 100 },
+              {
+                label: "primary",
+                args: [
+                  "-e",
+                  `setInterval(() => { if (require('node:fs').existsSync(${JSON.stringify(failPath)})) process.exit(2); }, 5);`,
+                ],
+                timeoutMs: 30_000,
+              },
+            ]),
+      );
+      const outcome = run.runPromise.catch((error: unknown) => error);
+      try {
+        escapedPid = await waitForPidFile(pidPath, 10_000);
+        const parentPid = await waitForPidFile(parentPidPath, 10_000);
+        const canceledAt = Date.now();
+        if (mode === "sibling failure") fs.writeFileSync(failPath, "fail");
+        else run.releaseTimeout();
+        const failure = await outcome;
+        const cleanupFailure = {
+          code: "EPROCESSGROUP_CLEANUP_FAILED",
+          processTreeState: "indeterminate",
+        };
+        if (mode === "timeout") {
+          expect(failure).toMatchObject(cleanupFailure);
+          expect(child?.stdout?.destroyed).toBe(true);
+          expect(child?.stderr?.destroyed).toBe(true);
+        } else {
+          expect(failure).toBeInstanceOf(AggregateError);
+          expect(failure).toMatchObject({
+            message: "primary failed with exit code 2; sibling cleanup could not be verified",
+            errors: [{ message: "primary failed with exit code 2" }, cleanupFailure],
+          });
+        }
+        expect(Date.now() - canceledAt).toBeLessThan(12_000);
+        expect(isProcessAlive(parentPid)).toBe(false);
+        expect(isProcessAlive(escapedPid)).toBe(true);
+      } finally {
+        run.releaseTimeout();
+        fs.writeFileSync(failPath, "fail");
+        await outcome;
+        if (!escapedPid && fs.existsSync(pidPath))
+          escapedPid = Number(fs.readFileSync(pidPath, "utf8"));
+        if (escapedPid && isProcessAlive(escapedPid)) {
+          process.kill(escapedPid, "SIGKILL");
+          await waitForDead(escapedPid, 2_000);
+        }
+        if (child?.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+      }
+    },
+    25_000,
+  );
 
   posixIt("waits through transient indeterminate process-group state", async () => {
     const originalKill = process.kill.bind(process);

--- a/test/scripts/prepare-extension-package-boundary-artifacts.test.ts
+++ b/test/scripts/prepare-extension-package-boundary-artifacts.test.ts
@@ -1,6 +1,5 @@
 // Prepare Extension Package Boundary Artifacts tests cover prepare extension package boundary artifacts script behavior.
 import { spawn } from "node:child_process";
-import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -29,14 +28,6 @@ import { makeTempDir } from "../helpers/temp-dir.js";
 
 const tempRoots = new Set<string>();
 
-function createMockPipe() {
-  const pipe = new EventEmitter() as EventEmitter & {
-    setEncoding: (encoding: string) => void;
-  };
-  pipe.setEncoding = () => {};
-  return pipe;
-}
-
 afterEach(() => {
   for (const rootDir of tempRoots) {
     fs.rmSync(rootDir, { force: true, recursive: true });
@@ -45,8 +36,8 @@ afterEach(() => {
 });
 
 async function waitForFile(filePath: string, timeoutMs: number): Promise<string> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
+  const deadline = performance.now() + timeoutMs;
+  while (performance.now() < deadline) {
     try {
       // writeFileSync is not atomic for concurrent readers: the path can exist
       // before the payload is flushed. Wait for non-empty content, or pid
@@ -184,13 +175,13 @@ describe("prepare-extension-package-boundary-artifacts", () => {
     await expect(
       runNodeStepsInParallel([
         {
-          label: "fail-fast",
-          args: ["--eval", "process.exit(2)"],
+          label: "slow-step",
+          args: ["--eval", "setTimeout(() => {}, 60_000)"],
           timeoutMs: slowStepTimeoutMs,
         },
         {
-          label: "slow-step",
-          args: ["--eval", "setTimeout(() => {}, 60_000)"],
+          label: "fail-fast",
+          args: ["--eval", "process.exit(2)"],
           timeoutMs: slowStepTimeoutMs,
         },
       ]),
@@ -263,6 +254,7 @@ describe("prepare-extension-package-boundary-artifacts", () => {
       const rootDir = makeTempDir(tempRoots, "openclaw-boundary-abort-drain-");
       const readyPath = path.join(rootDir, "descendant.ready");
       const drainedPath = path.join(rootDir, "descendant.drained");
+      const failPath = path.join(rootDir, "fail");
       const descendantScript = [
         "const fs = require('node:fs');",
         "process.on('SIGTERM', () => {",
@@ -271,7 +263,7 @@ describe("prepare-extension-package-boundary-artifacts", () => {
         "    process.exit(0);",
         "  }, 50);",
         "});",
-        `fs.writeFileSync(${JSON.stringify(readyPath)}, 'ready');`,
+        `fs.writeFileSync(${JSON.stringify(readyPath)}, String(process.pid));`,
         "setInterval(() => {}, 1000);",
       ].join("\n");
       const parentScript = [
@@ -280,19 +272,16 @@ describe("prepare-extension-package-boundary-artifacts", () => {
         "process.on('SIGTERM', () => process.exit(0));",
         "setInterval(() => {}, 1000);",
       ].join("\n");
-
-      // Fail the sibling only once the descendant installed its SIGTERM trap
-      // (signalled via readyPath) so the group abort cannot race its boot.
-      const failWhenDescendantReady = [
+      const failWhenRequested = [
         "const fs = require('node:fs');",
         "setInterval(() => {",
-        `  try { if (fs.readFileSync(${JSON.stringify(readyPath)}, 'utf8').trim()) { process.exit(2); } } catch {}`,
+        `  if (fs.existsSync(${JSON.stringify(failPath)})) process.exit(2);`,
         "}, 25);",
       ].join("\n");
       const command = runNodeStepsInParallel([
         {
           label: "delayed-fail",
-          args: ["--eval", failWhenDescendantReady],
+          args: ["--eval", failWhenRequested],
           timeoutMs: 30_000,
         },
         {
@@ -302,39 +291,28 @@ describe("prepare-extension-package-boundary-artifacts", () => {
           timeoutMs: 60_000,
         },
       ]);
-
-      await waitForFile(readyPath, 10_000);
+      const outcome = command.catch((error: unknown) => error);
+      const clock = vi.spyOn(Date, "now");
+      let descendantPid = 0;
+      try {
+        descendantPid = Number(await waitForFile(readyPath, 10_000));
+        // Hold the supervisor's grace clock, not the real child's cleanup timer.
+        // Separate force-kill tests cover expiry; this case proves graceful drain.
+        clock.mockReturnValue(Date.now());
+        fs.writeFileSync(failPath, "fail");
+        expect(await waitForFile(drainedPath, 10_000)).toBe("drained");
+      } finally {
+        clock.mockRestore();
+        fs.writeFileSync(failPath, "fail");
+        await outcome;
+        if (descendantPid && isProcessAlive(descendantPid)) {
+          process.kill(descendantPid, "SIGKILL");
+          await waitForDead(descendantPid, 2_000);
+        }
+      }
       await expect(command).rejects.toThrow("delayed-fail failed with exit code 2");
-      expect(await waitForFile(drainedPath, 10_000)).toBe("drained");
     },
   );
-
-  it("hard-kills timed out prep steps", async () => {
-    const signals: Array<NodeJS.Signals | number | undefined> = [];
-    const child = new EventEmitter() as EventEmitter & {
-      kill: (signal?: NodeJS.Signals | number) => boolean;
-      stderr: ReturnType<typeof createMockPipe>;
-      stdout: ReturnType<typeof createMockPipe>;
-    };
-    child.stdout = createMockPipe();
-    child.stderr = createMockPipe();
-    child.kill = (signal) => {
-      signals.push(signal);
-      return true;
-    };
-
-    await expect(
-      runNodeStep("hung-prep", ["--eval", "setTimeout(() => {}, 60_000)"], 5, {
-        spawnImpl(command: string, args: string[]) {
-          expect(command).toBe(process.execPath);
-          expect(args).toEqual(["--eval", "setTimeout(() => {}, 60_000)"]);
-          return child;
-        },
-      }),
-    ).rejects.toThrow("hung-prep timed out after 5ms");
-
-    expect(signals).toEqual(["SIGKILL"]);
-  });
 
   it("clamps oversized prep step timers before scheduling", async () => {
     await expect(

--- a/test/scripts/run-oxlint.test.ts
+++ b/test/scripts/run-oxlint.test.ts
@@ -389,24 +389,22 @@ describe("run-oxlint", () => {
       const runner = join(tempDir, "timeout-runner.mjs");
       const childPidPath = join(tempDir, "child.pid");
       let childPid = 0;
-      let releaseTimeout = () => {};
-      let command: Promise<number> | undefined;
       const childScript = [
         "const fs = require('node:fs');",
         "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);",
         "fs.writeFileSync(process.env.CHILD_PID_PATH + '.tmp', String(process.pid));",
         "fs.renameSync(process.env.CHILD_PID_PATH + '.tmp', process.env.CHILD_PID_PATH);",
       ].join("\n");
-      try {
-        writeModule(runner, [
-          "import { spawn } from 'node:child_process';",
-          `spawn(process.execPath, ['-e', ${JSON.stringify(childScript)}], { stdio: 'ignore' });`,
-          "process.on('SIGTERM', () => process.exit(0));",
-          "setInterval(() => {}, 1000);",
-        ]);
+      writeModule(runner, [
+        "import { spawn } from 'node:child_process';",
+        `spawn(process.execPath, ['-e', ${JSON.stringify(childScript)}], { stdio: 'ignore' });`,
+        "process.on('SIGTERM', () => process.exit(0));",
+        "setInterval(() => {}, 1000);",
+      ]);
 
-        // The watchdog must test teardown, not win a race against child startup.
-        const run = startProcessWatchdogFixture(() =>
+      // The watchdog must test teardown, not win a race against child startup.
+      const releaseAndWait = startProcessWatchdogFixture(() =>
+        expect(
           runShard({
             env: {
               ...process.env,
@@ -419,24 +417,23 @@ describe("run-oxlint", () => {
             runner,
             shard: { name: "timeout-group-test", args: [] },
           }),
-        );
-        command = run.runPromise;
-        releaseTimeout = run.releaseTimeout;
-
+        ).resolves.toBe(124),
+      );
+      try {
         childPid = await waitForPidFile(childPidPath, 15_000);
         expect(isProcessAlive(childPid)).toBe(true);
-        releaseTimeout();
-
-        await expect(command).resolves.toBe(124);
+        await releaseAndWait();
         await waitFor(() => !isProcessAlive(childPid), 15_000);
       } finally {
-        releaseTimeout();
-        await command;
-        if (!childPid && existsSync(childPidPath))
-          childPid = Number(readFileSync(childPidPath, "utf8"));
-        if (childPid && isProcessAlive(childPid)) {
-          process.kill(childPid, "SIGKILL");
-          await waitForDead(childPid, 2_000);
+        try {
+          await releaseAndWait();
+        } finally {
+          if (!childPid && existsSync(childPidPath))
+            childPid = Number(readFileSync(childPidPath, "utf8"));
+          if (childPid && isProcessAlive(childPid)) {
+            process.kill(childPid, "SIGKILL");
+            await waitForDead(childPid, 2_000);
+          }
         }
       }
     },

--- a/test/scripts/run-oxlint.test.ts
+++ b/test/scripts/run-oxlint.test.ts
@@ -24,6 +24,8 @@ import {
   filterSparseMissingOxlintTargets,
   shouldPrepareExtensionPackageBoundaryArtifacts,
 } from "../../scripts/run-oxlint.mts";
+import { waitForDead, waitForPidFile } from "../helpers/process-wait.js";
+import { startProcessWatchdogFixture } from "../helpers/process-watchdog.js";
 import { createScriptTestHarness } from "./test-helpers.js";
 
 const { createTempDir } = createScriptTestHarness();
@@ -387,39 +389,54 @@ describe("run-oxlint", () => {
       const runner = join(tempDir, "timeout-runner.mjs");
       const childPidPath = join(tempDir, "child.pid");
       let childPid = 0;
-      const childScript = "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);";
+      let releaseTimeout = () => {};
+      let command: Promise<number> | undefined;
+      const childScript = [
+        "const fs = require('node:fs');",
+        "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);",
+        "fs.writeFileSync(process.env.CHILD_PID_PATH + '.tmp', String(process.pid));",
+        "fs.renameSync(process.env.CHILD_PID_PATH + '.tmp', process.env.CHILD_PID_PATH);",
+      ].join("\n");
       try {
         writeModule(runner, [
           "import { spawn } from 'node:child_process';",
-          "import { writeFileSync } from 'node:fs';",
-          `const child = spawn(process.execPath, ['-e', ${JSON.stringify(childScript)}], { stdio: 'ignore' });`,
-          "writeFileSync(process.env.CHILD_PID_PATH, String(child.pid));",
+          `spawn(process.execPath, ['-e', ${JSON.stringify(childScript)}], { stdio: 'ignore' });`,
           "process.on('SIGTERM', () => process.exit(0));",
           "setInterval(() => {}, 1000);",
         ]);
 
-        const command = runShard({
-          env: {
-            ...process.env,
-            CHILD_PID_PATH: childPidPath,
-            OPENCLAW_OXLINT_SHARD_HEARTBEAT_MS: "0",
-            OPENCLAW_OXLINT_SHARD_KILL_GRACE_MS: "25",
-            OPENCLAW_OXLINT_SHARD_TIMEOUT_MS: "250",
-          },
-          extraArgs: [],
-          runner,
-          shard: { name: "timeout-group-test", args: [] },
-        });
+        // The watchdog must test teardown, not win a race against child startup.
+        const run = startProcessWatchdogFixture(() =>
+          runShard({
+            env: {
+              ...process.env,
+              CHILD_PID_PATH: childPidPath,
+              OPENCLAW_OXLINT_SHARD_HEARTBEAT_MS: "0",
+              OPENCLAW_OXLINT_SHARD_KILL_GRACE_MS: "25",
+              OPENCLAW_OXLINT_SHARD_TIMEOUT_MS: "250",
+            },
+            extraArgs: [],
+            runner,
+            shard: { name: "timeout-group-test", args: [] },
+          }),
+        );
+        command = run.runPromise;
+        releaseTimeout = run.releaseTimeout;
 
-        await waitFor(() => existsSync(childPidPath), 15_000);
-        childPid = Number(readFileSync(childPidPath, "utf8"));
+        childPid = await waitForPidFile(childPidPath, 15_000);
         expect(isProcessAlive(childPid)).toBe(true);
+        releaseTimeout();
 
         await expect(command).resolves.toBe(124);
         await waitFor(() => !isProcessAlive(childPid), 15_000);
       } finally {
+        releaseTimeout();
+        await command;
+        if (!childPid && existsSync(childPidPath))
+          childPid = Number(readFileSync(childPidPath, "utf8"));
         if (childPid && isProcessAlive(childPid)) {
           process.kill(childPid, "SIGKILL");
+          await waitForDead(childPid, 2_000);
         }
       }
     },


### PR DESCRIPTION
Closes #131861.

## What Problem This Solves

Fixes an issue where developers running SDK declaration preparation would receive a timeout while compiler processes continued running. Real nested-wrapper reproductions left a managed implementation reparented to PID 1 and a live child after the outer supervisor rejected.

## Why This Change Was Made

The shared managed-command lifecycle now forwards SIGTERM before the existing bounded force-kill/drain phases and joins child exit, process-group exit, and owned output closure. Preparation uses that owner instead of its duplicate cleanup implementation and mock-only spawn seam; non-TTY inherited output is forwarded through per-child writable bridges that preserve backpressure without accumulating listeners on shared output streams.

Primary parallel failures remain visible, including when a sibling's cleanup cannot be verified. The existing **300,000 ms SDK work deadline is unchanged**, as are the force/drain budgets. Build output, package boundaries, public SDK APIs, and dependency semantics do not change. This repairs teardown; it does not diagnose why the original declaration compile reached its deadline.

## User Impact

Timed-out or canceled SDK preparation waits for its owned work to stop, or reports an explicit cleanup failure when closure cannot be verified. Developers retain trailing/prefixed output and the original failure instead of receiving an apparently completed timeout while nested work remains alive. Resistant managed commands receive the shared five-second graceful shutdown phase before forced termination, allowing nested wrappers to forward signals.

Production/tooling: **+277/−353 (net −76)**. Tests: **+365/−134 (net +231)**; the asset-test repair reduces the previous test delta by three lines. Removed paths are the preparation-specific process lifecycle, test-only spawn injection, and obsolete asset-test exit polling. No configuration, dependency, work-deadline, or release changes. AI-assisted implementation and review; human attribution is Peter Steinberger (@steipete).

## Evidence

**Before:** four real nested `runNodeStep`/`runManagedCommand` → `runTsxCliShim` → managed implementation → child cases failed on pre-fix source with live descendants. An inherited-output regression also failed before the owned-pipe repair. Nested watchdog fixtures gate release on child-owned readiness.

**After:** the complete candidate passed **184 tests across six files**, including seven nested cooperative/resistant/abort/inherited-output cases, bounded held-output failures, primary-versus-secondary diagnostics, parent signals, direct cleanup, Windows unit contracts, and the asset-hook suite:

```bash
node scripts/run-vitest.mjs test/scripts/bundled-plugin-assets.test.ts test/scripts/managed-child-process.test.ts test/scripts/prepare-extension-package-boundary-artifacts.test.ts test/scripts/direct-run-entrypoints.test.ts test/scripts/run-oxlint.test.ts test/scripts/run-tsgo.test.ts
```

Standalone real Node wrapper probes reported no surviving fixture PIDs. A twelve-command parallel output probe completed all commands with no survivors or listener warnings. Watchdog fixtures use current main's canonical `releaseAndWait()` helper. Existing oxlint startup readiness and graceful-drain scheduling races were repaired without weakening timeout/exit/marker assertions; separate real force-expiry cases remain.

Scoped script lint, targeted formatting, and `git diff --check` passed:

```bash
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts/lib/managed-child-process.mts scripts/prepare-extension-package-boundary-artifacts.mts scripts/run-tsgo.mts
```

The integrated production/test candidate and subsequent asset-test repair received fresh isolated review with no actionable P0 findings. Node's installed child-process exit/close/signal implementation and the compiler launcher were inspected directly.

**First hosted CI failure and repair:** [run 33185905757](https://github.com/openclaw/openclaw/actions/runs/33185905757) on `8ffb8a42a0b20822b277aada094c7d7f4814ebba` failed [checks-node-compact-small-33](https://github.com/openclaw/openclaw/actions/runs/33185905757/job/98898925071). The asset-hook test expected under 2,000 ms but observed 5,553 ms; the focused local reproduction observed 5,555 ms. Both match the real 500 ms fixture deadline followed by shared graceful cleanup. The introducing [asset-hook repair](https://github.com/openclaw/openclaw/commit/b5c08787776a10d68a474c309bb4559066460d37) specifies a 600,000 ms work deadline and complete managed-tree termination; the two-second cleanup threshold was test-only policy.

The test now requires its descendant to be **already dead when timeout rejection returns**, without the former 1,500 ms polling allowance. Its five-second self-exit was removed because it could conceal a leak at the shared force deadline. Both launcher and descendant still resist SIGTERM, child-owned readiness is checked, the real `timeoutMs: 500` is unchanged, and exact `ETIMEDOUT`, plugin-safe message, and command-redaction assertions remain. PID capture precedes assertions so failures still reach emergency cleanup. No production change, raised threshold, timer interception, or new deadline was used for this CI repair. The shared owner tests retain bounded hard-kill and output-drain coverage.

**ClawSweeper review:** the [fresh exact-head review](https://github.com/openclaw/openclaw/pull/131862#issuecomment-5454612904) at 16:20 UTC reports no actionable findings and accepts the asset-test repair as resolving the prior timing finding. Its earlier caller-selectable immediate-kill recommendation was not adopted after maintainer review of the actual caller contract and history; the new review recommends retaining the shared lifecycle and stronger no-survivor invariant. The sole remaining rank-up move was exact-head hosted CI completion, now satisfied. No manual re-review request was made.

**Types and remaining proof:** this head's hosted [check-test-types job](https://github.com/openclaw/openclaw/actions/runs/33188766028/job/98908884232) passed after frozen-lockfile setup. Its completed log confirms both `tsconfig.scripts.json` and `test/tsconfig/tsconfig.test.root.json` executed successfully, closing the installed-environment type proof on the new head. Local typechecks remain unclaimed: the partial checkout lacks UI-local `pako@3.0.1`, causing unchanged `ui/vite.config.ts:9` to resolve root `pako@1.0.11` without declarations. No install, fake declaration, or node_modules edit hid that gap. An earlier extra root-test lint invocation entered full declaration preparation and was canceled; it is not claimed as passing. No full local declaration build or real Windows/TTY execution is claimed.

**Current CI checkpoint — green:** [run 33188766028](https://github.com/openclaw/openclaw/actions/runs/33188766028) completed successfully on `fe9c365ff6eceb14895c50602125d7c2b7aaf0d2`, including required [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33188766028/job/98911867840), the formerly failing [asset/tooling shard](https://github.com/openclaw/openclaw/actions/runs/33188766028/job/98908886541), and hosted types. The bounded exact-head watcher returned `GREEN` with exit 0. Native review guard and artifacts validate on this exact head, with the review recommendation `READY FOR /prepare-pr`. Final maintainer authorization remains separate; no prepare or merge has run.
