### PR TITLE
refactor(agents): compress auth availability projections

### DIFF
--- a/src/agents/model-auth-availability.ts
+++ b/src/agents/model-auth-availability.ts
@@ -781,18 +781,14 @@ export function createModelAuthAvailabilityResolver(
         evidence: "profile",
       };
     }
+    // Direct policy adds retry times only for unavailable inline keys; unknown reasons stay hidden.
+    const { unavailableReason, ...evaluation } = directEvaluation;
     return {
-      availability: fromProviderModelAuthReadiness(source.readiness),
+      ...evaluation,
       ...(source.readiness === "unavailable"
-        ? {
-            unavailableReason: directEvaluation.unavailableReason ?? "auth-failed",
-            ...(directEvaluation.unavailableUntil !== undefined
-              ? { unavailableUntil: directEvaluation.unavailableUntil }
-              : {}),
-          }
+        ? { unavailableReason: unavailableReason ?? "auth-failed" }
         : {}),
       selectedAuthMode: source.mode,
-      ...(source.evidence === "none" ? {} : { evidence: source.evidence }),
     };
   };
   const directPolicy = (provider: string, target: AuthTarget) => {
@@ -840,7 +836,7 @@ export function createModelAuthAvailabilityResolver(
     provider: string,
     ref: ModelAuthAvailabilityRef,
     target: AuthTarget,
-  ) => {
+  ): AuthSourceEvaluation | undefined => {
     if (ref.lockedProfileId?.trim()) {
       return undefined;
     }
@@ -868,7 +864,16 @@ export function createModelAuthAvailabilityResolver(
     });
     const decision = selectProviderModelAuthSources({ provider, plan });
     return decision.kind === "rejected"
-      ? { ...decision, ...rejectedSourceEvaluation(decision.reason, plan, target) }
+      ? {
+          ...rejectedSourceEvaluation(decision.reason, plan, target),
+          evidence: "profile",
+          ...(decision.source
+            ? {
+                selectedAuthMode: decision.source.mode,
+                selectedProfileId: decision.source.profileId,
+              }
+            : {}),
+        }
       : undefined;
   };
   const resolveProviderEvaluation = (
@@ -954,24 +959,7 @@ export function createModelAuthAvailabilityResolver(
     }
     if (routeResolution.kind === "indeterminate") {
       const rejection = automaticSourceRejection(provider, ref, prepareAuthTarget(provider, ref));
-      if (rejection) {
-        return {
-          availability: false,
-          unavailableReason: rejection.unavailableReason,
-          ...(rejection.unavailableUntil !== undefined
-            ? { unavailableUntil: rejection.unavailableUntil }
-            : {}),
-          routeResolution,
-          ...(rejection.source
-            ? {
-                evidence: "profile" as const,
-                selectedAuthMode: rejection.source.mode,
-                selectedProfileId: rejection.source.profileId,
-              }
-            : { evidence: "profile" as const }),
-        };
-      }
-      return { availability: undefined, routeResolution };
+      return { ...(rejection ?? { availability: undefined }), routeResolution };
     }
     const modelLock = ref.lockedProfileId?.trim();
     const configuredAuthMode = resolveConfiguredOpenAIAuthMode(params.cfg);


### PR DESCRIPTION
## What Problem This Solves

Follow-up compression of the availability-reason feature landed in #131697. That change added +275/−124 production lines; two of its projection sites carried provable redundancy: the non-profile `sourceEvaluation` branch re-derived availability/mode/evidence facts that the direct policy evaluation already owned (via a lossless readiness round-trip), and the indeterminate-route caller re-projected `automaticSourceRejection`'s result field by field after the helper had leaked the full selector decision.

## Why This Change Was Made

Behavior-frozen refactor: reuse the recorded direct-policy facts instead of re-deriving them, and let `automaticSourceRejection` return the projected `AuthSourceEvaluation` itself so its only caller just attaches route resolution. No selector inputs change; the deliberately load-bearing seams (the profile recompute compensating for `requiredProfileSource`'s cooldown-bypass contract, and the empty-plan reason override that also covers the deferred branch) are byte-identical to the base.

Two further candidate folds were evaluated and skipped with recorded reasons: a typed unusable-window result (breaks the primitive's numeric contract and ripples into status/display adapters) and the gateway projection spreads (each conditional encodes a distinct property-presence rule for legacy clients).

## User Impact

None — pure production-LOC reduction. Wire payloads, field values, and property presence are unchanged.

## Evidence

- **Net −12 production lines** (+16/−28, single file `src/agents/model-auth-availability.ts`); zero test-file changes (`git diff --stat -- '*test*'` empty).
- Frozen contract held: the full required suite — 261 tests across 10 files (evaluator + reasons, route selection, five models.list suites, models.test.ts, models-auth-status) — passes **unmodified**.
- Equivalence proofs: producer/selector trace of the readiness round-trip (`provider-model-auth-source-plan.ts:109/:115/:122`), plus two ephemeral differential checks comparing old vs new projection functions over 1,680 direct/none combinations and 1,536 indeterminate-route cases with own-property presence compared via `deepStrictEqual`.
- `node scripts/check-changed.mjs` exit 0 (formatting, lint, all type shards, dead exports, import cycles, guards); Codex autoreview clean at the default threshold.
