### PR TITLE
fix(ci): accept quarantined corrupt plugin recovery

### DIFF
--- a/scripts/e2e/lib/plugin-update/corrupt-update-scenario.sh
+++ b/scripts/e2e/lib/plugin-update/corrupt-update-scenario.sh
@@ -106,7 +106,7 @@ if [ "$update_status" -ne 0 ]; then
     exit "$post_core_status"
   fi
   node scripts/e2e/lib/plugin-update/probe.mjs assert-corrupt-plugin-result /tmp/openclaw-update-corrupt-plugin-post-core.json demo-corrupt-plugin
-  node scripts/e2e/lib/plugin-update/probe.mjs assert-disabled-policy-preserved "$OPENCLAW_CONFIG_PATH" demo-corrupt-plugin
+  node scripts/e2e/lib/plugin-update/probe.mjs assert-corrupt-policy-preserved "$OPENCLAW_CONFIG_PATH" demo-corrupt-plugin
   exit 0
 fi
 
@@ -117,4 +117,4 @@ if ! node scripts/e2e/lib/plugin-update/probe.mjs assert-corrupt-update /tmp/ope
   openclaw_e2e_print_log /tmp/openclaw-update-corrupt-plugin.err >&2
   exit 1
 fi
-node scripts/e2e/lib/plugin-update/probe.mjs assert-disabled-policy-preserved "$OPENCLAW_CONFIG_PATH" demo-corrupt-plugin
+node scripts/e2e/lib/plugin-update/probe.mjs assert-corrupt-policy-preserved "$OPENCLAW_CONFIG_PATH" demo-corrupt-plugin

--- a/scripts/e2e/lib/plugin-update/probe.mjs
+++ b/scripts/e2e/lib/plugin-update/probe.mjs
@@ -266,14 +266,17 @@ function assertCorruptPluginDetails(plugins, pluginId) {
   const evidence = collectPluginEvidence(plugins, pluginId);
   const outcome = evidence.outcome;
   const disabledAfterFailure = isCorruptPluginDisabledAfterUpdate(evidence, pluginId);
-  if (!outcome || (outcome.status !== "error" && !disabledAfterFailure)) {
+  const quarantinedAfterFailure = outcome?.status === "error";
+  if (!disabledAfterFailure && !quarantinedAfterFailure) {
     throw new Error(
-      `expected error or disabled-after-failure outcome for ${pluginId}, got ${JSON.stringify({
-        outcomes: plugins.npm?.outcomes ?? [],
-        warnings: plugins.warnings ?? [],
-        sync: plugins.sync,
-        integrityDrifts: plugins.integrityDrifts ?? [],
-      })}`,
+      `expected quarantined or disabled-after-failure outcome for ${pluginId}, got ${JSON.stringify(
+        {
+          outcomes: plugins.npm?.outcomes ?? [],
+          warnings: plugins.warnings ?? [],
+          sync: plugins.sync,
+          integrityDrifts: plugins.integrityDrifts ?? [],
+        },
+      )}`,
     );
   }
   const warning = evidence.warning;
@@ -334,14 +337,11 @@ function assertLegacyPostUpdatePluginFailure(updateJsonPath) {
   }
 }
 
-function assertDisabledPluginPolicyPreserved(configPath, pluginId) {
+function assertCorruptPluginPolicyPreserved(configPath, pluginId) {
   const config = readJson(configPath);
   const allow = config.plugins?.allow;
   if (JSON.stringify(allow) !== JSON.stringify([pluginId])) {
     throw new Error(`expected plugins.allow to preserve ${pluginId}, got ${JSON.stringify(allow)}`);
-  }
-  if (config.plugins?.entries?.[pluginId]?.enabled !== false) {
-    throw new Error(`expected ${pluginId} to be disabled after update failure`);
   }
 }
 
@@ -356,7 +356,7 @@ const commands = {
   "assert-corrupt-update": () => assertCorruptUpdate(arg, arg2),
   "assert-corrupt-plugin-result": () => assertCorruptPluginResult(arg, arg2),
   "assert-legacy-post-update-plugin-failure": () => assertLegacyPostUpdatePluginFailure(arg),
-  "assert-disabled-policy-preserved": () => assertDisabledPluginPolicyPreserved(arg, arg2),
+  "assert-corrupt-policy-preserved": () => assertCorruptPluginPolicyPreserved(arg, arg2),
 };
 const run = commands[command];
 await (

--- a/test/scripts/plugin-update-unchanged-docker.test.ts
+++ b/test/scripts/plugin-update-unchanged-docker.test.ts
@@ -306,20 +306,25 @@ describe("plugin update unchanged Docker E2E", () => {
     );
     expect(script.match(/openclaw_e2e_print_log \/tmp\/openclaw-update-corrupt-/g)).toHaveLength(8);
     expect(script).not.toContain("cat /tmp/openclaw-update-corrupt-");
-    expect(script.match(/assert-disabled-policy-preserved/g)).toHaveLength(2);
+    expect(script.match(/assert-corrupt-policy-preserved/g)).toHaveLength(2);
   });
 
-  it("requires corrupt update failures to preserve the explicit allow policy", () => {
+  it.each([
+    ["explicit disable", { enabled: false }],
+    ["typed quarantine", { enabled: true }],
+  ])("preserves the explicit allow policy after %s recovery", (_recovery, entry) => {
     expect(() =>
-      runProbe("assert-disabled-policy-preserved", {
+      runProbe("assert-corrupt-policy-preserved", {
         plugins: {
           allow: [CORRUPT_PLUGIN_ID],
-          entries: { [CORRUPT_PLUGIN_ID]: { enabled: false } },
+          entries: { [CORRUPT_PLUGIN_ID]: entry },
         },
       }),
     ).not.toThrow();
+  });
 
-    const revokedPolicy = runProbeStatus("assert-disabled-policy-preserved", {
+  it("rejects corrupt update recovery that revokes the explicit allow policy", () => {
+    const revokedPolicy = runProbeStatus("assert-corrupt-policy-preserved", {
       plugins: {
         entries: { [CORRUPT_PLUGIN_ID]: { enabled: false } },
       },
@@ -328,7 +333,7 @@ describe("plugin update unchanged Docker E2E", () => {
     expect(revokedPolicy.stderr).toContain("expected plugins.allow to preserve");
   });
 
-  it("requires disabled-after-failure corrupt plugin updates to stay warnings", () => {
+  it("accepts disabled or quarantined corrupt plugin warnings and rejects neither", () => {
     const disabledAfterFailure = {
       status: "ok",
       npm: {
@@ -365,5 +370,38 @@ describe("plugin update unchanged Docker E2E", () => {
         ],
       }),
     ).not.toThrow();
+
+    const quarantinedAfterFailure = {
+      status: "warning",
+      npm: {
+        outcomes: [
+          {
+            pluginId: CORRUPT_PLUGIN_ID,
+            status: "error",
+            message: `Plugin "${CORRUPT_PLUGIN_ID}" failed post-core payload smoke check: package.json is missing`,
+          },
+        ],
+      },
+      warnings: [
+        {
+          pluginId: CORRUPT_PLUGIN_ID,
+          reason: "package.json is missing",
+          guidance: [
+            "Run openclaw update repair to retry post-update plugin repair.",
+            `Run openclaw plugins inspect ${CORRUPT_PLUGIN_ID} --runtime --json for details.`,
+          ],
+        },
+      ],
+    };
+    expect(() => runProbe("assert-corrupt-plugin-result", quarantinedAfterFailure)).not.toThrow();
+
+    const neitherRecovery = runProbeStatus("assert-corrupt-plugin-result", {
+      ...quarantinedAfterFailure,
+      npm: { outcomes: [] },
+    });
+    expect(neitherRecovery.status).not.toBe(0);
+    expect(neitherRecovery.stderr).toContain(
+      "expected quarantined or disabled-after-failure outcome",
+    );
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Full Release Validation rejected a valid corrupt-plugin recovery when the updated gateway quarantined the plugin instead of writing `enabled: false` to config.

## Why This Change Was Made

The corrupt-plugin result probe now names and tests both accepted recovery contracts: an explicit disable or a typed quarantine error. The following config probe only verifies that the operator's explicit `plugins.allow` policy survived the update, so it no longer contradicts the typed-quarantine branch.

Production behavior is unchanged.

## User Impact

Release validation can distinguish valid quarantine recovery from a missing recovery instead of failing a healthy package update path.

## Evidence

- Pre-fix reproduction: a config with the plugin still enabled and preserved in `plugins.allow` failed with `expected demo-corrupt-plugin to be disabled after update failure`.
- `node scripts/run-vitest.mjs run test/scripts/plugin-update-unchanged-docker.test.ts` (`12/12` passed).
- `pnpm lint:scripts`.
- `bash -n scripts/e2e/lib/plugin-update/corrupt-update-scenario.sh`.
- `node --check scripts/e2e/lib/plugin-update/probe.mjs`.
- Targeted format check and `git diff --check`.
- Changed-file gates passed through formatting and test-temp checks. The aggregate test-root typecheck remains blocked by sparse-checkout omissions and the existing shared `pako` declaration failure, unrelated to this diff.
- Claude autoreview: clean, no accepted/actionable findings.

Related validation failure: https://github.com/openclaw/openclaw/actions/runs/33180403690
