### PR TITLE
refactor: reuse SQLite WAL test directory cleanup

### DIFF
--- a/src/infra/sqlite-wal.test.ts
+++ b/src/infra/sqlite-wal.test.ts
@@ -1,7 +1,6 @@
 // Covers SQLite WAL maintenance configuration.
 import childProcess from "node:child_process";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { expectDefined } from "@openclaw/normalization-core";
@@ -50,26 +49,22 @@ describe("sqlite WAL maintenance", () => {
   });
 
   it("uses rollback journaling for databases on NFS-backed volumes", () => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-nfs-"));
-    try {
-      const db = createMockDb();
-      vi.spyOn(process, "platform", "get").mockReturnValue("linux");
-      const statfs = vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0x6969));
+    const tempDir = tempDirs.make("openclaw-sqlite-nfs-");
+    const db = createMockDb();
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    const statfs = vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0x6969));
 
-      const maintenance = configureSqliteWalMaintenance(db, {
-        checkpointIntervalMs: 0,
-        databasePath: path.join(tempDir, "missing", "openclaw.sqlite"),
-      });
+    const maintenance = configureSqliteWalMaintenance(db, {
+      checkpointIntervalMs: 0,
+      databasePath: path.join(tempDir, "missing", "openclaw.sqlite"),
+    });
 
-      expect(statfs).toHaveBeenCalledWith(fs.realpathSync(tempDir));
-      expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
-      expect(db["exec"]).not.toHaveBeenCalled();
-      expect(maintenance.checkpoint()).toBe(true);
-      expect(maintenance.close()).toBe(true);
-      expect(db["exec"]).not.toHaveBeenCalled();
-    } finally {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    }
+    expect(statfs).toHaveBeenCalledWith(fs.realpathSync(tempDir));
+    expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
+    expect(db["exec"]).not.toHaveBeenCalled();
+    expect(maintenance.checkpoint()).toBe(true);
+    expect(maintenance.close()).toBe(true);
+    expect(db["exec"]).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -78,21 +73,17 @@ describe("sqlite WAL maintenance", () => {
     ["SMB2", 0xfe534d42],
     ["9p (V9FS)", 0x01021997],
   ])("uses rollback journaling for databases on Linux %s volumes", (_label, fsType) => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-network-"));
-    try {
-      const db = createMockDb();
-      vi.spyOn(process, "platform", "get").mockReturnValue("linux");
-      vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(fsType));
+    const tempDir = tempDirs.make("openclaw-sqlite-network-");
+    const db = createMockDb();
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(fsType));
 
-      configureSqliteWalMaintenance(db, {
-        checkpointIntervalMs: 0,
-        databasePath: path.join(tempDir, "openclaw.sqlite"),
-      });
+    configureSqliteWalMaintenance(db, {
+      checkpointIntervalMs: 0,
+      databasePath: path.join(tempDir, "openclaw.sqlite"),
+    });
 
-      expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
-    } finally {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    }
+    expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
   });
 
   it.each([
@@ -165,24 +156,20 @@ describe("sqlite WAL maintenance", () => {
   });
 
   it("refuses network-backed databases when SQLite keeps WAL active", () => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-nfs-"));
-    try {
-      const db = createMockDb();
-      vi.mocked(db["prepare"]).mockReturnValue({
-        get: vi.fn(() => ({ journal_mode: "wal" })),
-      } as unknown as ReturnType<DatabaseSync["prepare"]>);
-      vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0x6969));
+    const tempDir = tempDirs.make("openclaw-sqlite-nfs-");
+    const db = createMockDb();
+    vi.mocked(db["prepare"]).mockReturnValue({
+      get: vi.fn(() => ({ journal_mode: "wal" })),
+    } as unknown as ReturnType<DatabaseSync["prepare"]>);
+    vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0x6969));
 
-      expect(() =>
-        configureSqliteWalMaintenance(db, {
-          checkpointIntervalMs: 0,
-          databaseLabel: "test-db",
-          databasePath: path.join(tempDir, "openclaw.sqlite"),
-        }),
-      ).toThrow(/test-db .*journal_mode=wal/);
-    } finally {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    }
+    expect(() =>
+      configureSqliteWalMaintenance(db, {
+        checkpointIntervalMs: 0,
+        databaseLabel: "test-db",
+        databasePath: path.join(tempDir, "openclaw.sqlite"),
+      }),
+    ).toThrow(/test-db .*journal_mode=wal/);
   });
 
   it("accepts SQLite's memory journal for an in-memory database", () => {
@@ -275,178 +262,150 @@ describe("sqlite WAL maintenance", () => {
     ["9p", "VirtFS cross-VM"],
     ["9p2000.L", "VirtFS 2000.L"],
   ])("uses rollback journaling for %s mounts (%s)", (fsType, _label) => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-virtiofs-"));
-    try {
-      const db = createMockDb();
-      vi.spyOn(process, "platform", "get").mockReturnValue("linux");
-      vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
-      vi.spyOn(fs, "readFileSync").mockReturnValue(
-        `42 12 0:41 / ${tempDir} rw,relatime - ${fsType} host0 rw\n`,
-      );
+    const tempDir = tempDirs.make("openclaw-sqlite-virtiofs-");
+    const db = createMockDb();
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
+    vi.spyOn(fs, "readFileSync").mockReturnValue(
+      `42 12 0:41 / ${tempDir} rw,relatime - ${fsType} host0 rw\n`,
+    );
 
-      configureSqliteWalMaintenance(db, {
-        checkpointIntervalMs: 0,
-        databasePath: path.join(tempDir, "openclaw.sqlite"),
-      });
+    configureSqliteWalMaintenance(db, {
+      checkpointIntervalMs: 0,
+      databasePath: path.join(tempDir, "openclaw.sqlite"),
+    });
 
-      expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
-      expect(db["exec"]).not.toHaveBeenCalled();
-    } finally {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    }
+    expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
+    expect(db["exec"]).not.toHaveBeenCalled();
   });
 
   it("uses rollback journaling for virtiofs reported by macOS mount command", () => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-virtiofs-mac-"));
-    try {
-      const db = createMockDb();
-      vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
-      vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
-      vi.spyOn(fs, "readFileSync").mockImplementation(() => {
-        throw new Error("no proc mountinfo");
-      });
-      vi.spyOn(childProcess, "execFileSync").mockReturnValue(
-        Buffer.from(`hostdir on ${tempDir} (virtiofs, nodev, nosuid)\n`),
-      );
+    const tempDir = tempDirs.make("openclaw-sqlite-virtiofs-mac-");
+    const db = createMockDb();
+    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
+    vi.spyOn(fs, "readFileSync").mockImplementation(() => {
+      throw new Error("no proc mountinfo");
+    });
+    vi.spyOn(childProcess, "execFileSync").mockReturnValue(
+      Buffer.from(`hostdir on ${tempDir} (virtiofs, nodev, nosuid)\n`),
+    );
 
-      configureSqliteWalMaintenance(db, {
-        checkpointIntervalMs: 0,
-        databasePath: path.join(tempDir, "openclaw.sqlite"),
-      });
+    configureSqliteWalMaintenance(db, {
+      checkpointIntervalMs: 0,
+      databasePath: path.join(tempDir, "openclaw.sqlite"),
+    });
 
-      expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
-      expect(db["exec"]).not.toHaveBeenCalled();
-    } finally {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    }
+    expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
+    expect(db["exec"]).not.toHaveBeenCalled();
   });
 
   it("uses mountinfo filesystem names when statfs magic is not enough", () => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-nfs-"));
-    try {
-      const db = createMockDb();
-      vi.spyOn(process, "platform", "get").mockReturnValue("linux");
-      vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
-      vi.spyOn(fs, "readFileSync").mockReturnValue(
-        `42 12 0:41 / ${tempDir} rw,relatime - nfs4 server:/share rw\n`,
-      );
+    const tempDir = tempDirs.make("openclaw-sqlite-nfs-");
+    const db = createMockDb();
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
+    vi.spyOn(fs, "readFileSync").mockReturnValue(
+      `42 12 0:41 / ${tempDir} rw,relatime - nfs4 server:/share rw\n`,
+    );
 
-      configureSqliteWalMaintenance(db, {
-        checkpointIntervalMs: 0,
-        databasePath: path.join(tempDir, "openclaw.sqlite"),
-      });
+    configureSqliteWalMaintenance(db, {
+      checkpointIntervalMs: 0,
+      databasePath: path.join(tempDir, "openclaw.sqlite"),
+    });
 
-      expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
-    } finally {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    }
+    expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
   });
 
   it("refuses fuse.sshfs mountinfo entries", () => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-sshfs-"));
-    try {
-      const db = createMockDb();
-      vi.spyOn(process, "platform", "get").mockReturnValue("linux");
-      vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
-      vi.spyOn(fs, "readFileSync").mockReturnValue(
-        `42 12 0:41 / ${tempDir} rw,relatime - fuse.sshfs user@host:/share rw\n`,
-      );
+    const tempDir = tempDirs.make("openclaw-sqlite-sshfs-");
+    const db = createMockDb();
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
+    vi.spyOn(fs, "readFileSync").mockReturnValue(
+      `42 12 0:41 / ${tempDir} rw,relatime - fuse.sshfs user@host:/share rw\n`,
+    );
 
-      expect(() =>
-        configureSqliteWalMaintenance(db, {
-          checkpointIntervalMs: 0,
-          databaseLabel: "test-db",
-          databasePath: path.join(tempDir, "openclaw.sqlite"),
-        }),
-      ).toThrow(/test-db .*SSHFS.*refusing to open/);
+    expect(() =>
+      configureSqliteWalMaintenance(db, {
+        checkpointIntervalMs: 0,
+        databaseLabel: "test-db",
+        databasePath: path.join(tempDir, "openclaw.sqlite"),
+      }),
+    ).toThrow(/test-db .*SSHFS.*refusing to open/);
 
-      expect(db["prepare"]).not.toHaveBeenCalled();
-      expect(db["exec"]).not.toHaveBeenCalled();
-    } finally {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    }
+    expect(db["prepare"]).not.toHaveBeenCalled();
+    expect(db["exec"]).not.toHaveBeenCalled();
   });
 
   it("refuses symlinked paths into fuse.sshfs mounts", () => {
     if (process.platform === "win32") {
       return;
     }
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-sshfs-link-"));
+    const tempDir = tempDirs.make("openclaw-sqlite-sshfs-link-");
     const mountDir = path.join(tempDir, "mount");
     const linkedDir = path.join(tempDir, "linked");
-    try {
-      fs.mkdirSync(mountDir);
-      fs.symlinkSync(mountDir, linkedDir);
-      const canonicalMountDir = fs.realpathSync(mountDir);
-      vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
-      vi.spyOn(fs, "readFileSync").mockReturnValue(
-        `42 12 0:41 / ${canonicalMountDir} rw,relatime - fuse.sshfs user@host:/share rw\n`,
-      );
+    fs.mkdirSync(mountDir);
+    fs.symlinkSync(mountDir, linkedDir);
+    const canonicalMountDir = fs.realpathSync(mountDir);
+    vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
+    vi.spyOn(fs, "readFileSync").mockReturnValue(
+      `42 12 0:41 / ${canonicalMountDir} rw,relatime - fuse.sshfs user@host:/share rw\n`,
+    );
 
-      expect(() =>
-        configureSqliteWalMaintenance(createMockDb(), {
-          checkpointIntervalMs: 0,
-          databasePath: path.join(linkedDir, "openclaw.sqlite"),
-        }),
-      ).toThrow(/SSHFS.*refusing to open/);
-    } finally {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    }
+    expect(() =>
+      configureSqliteWalMaintenance(createMockDb(), {
+        checkpointIntervalMs: 0,
+        databasePath: path.join(linkedDir, "openclaw.sqlite"),
+      }),
+    ).toThrow(/SSHFS.*refusing to open/);
   });
 
   it("matches raw mount paths when the existing path canonicalizes elsewhere", () => {
     if (process.platform === "win32") {
       return;
     }
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-sshfs-prefix-"));
+    const tempDir = tempDirs.make("openclaw-sqlite-sshfs-prefix-");
     const canonicalMountDir = path.join(tempDir, "canonical-mount");
     const rawMountDir = path.join(tempDir, "raw-mount");
-    try {
-      fs.mkdirSync(canonicalMountDir);
-      fs.symlinkSync(canonicalMountDir, rawMountDir);
-      vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
-      vi.spyOn(fs, "readFileSync").mockReturnValue(
-        `42 12 0:41 / ${rawMountDir} rw,relatime - fuse.sshfs user@host:/share rw\n`,
-      );
+    fs.mkdirSync(canonicalMountDir);
+    fs.symlinkSync(canonicalMountDir, rawMountDir);
+    vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
+    vi.spyOn(fs, "readFileSync").mockReturnValue(
+      `42 12 0:41 / ${rawMountDir} rw,relatime - fuse.sshfs user@host:/share rw\n`,
+    );
 
-      expect(() =>
-        configureSqliteWalMaintenance(createMockDb(), {
-          checkpointIntervalMs: 0,
-          databasePath: path.join(rawMountDir, "openclaw.sqlite"),
-        }),
-      ).toThrow(/SSHFS.*refusing to open/);
-    } finally {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    }
+    expect(() =>
+      configureSqliteWalMaintenance(createMockDb(), {
+        checkpointIntervalMs: 0,
+        databasePath: path.join(rawMountDir, "openclaw.sqlite"),
+      }),
+    ).toThrow(/SSHFS.*refusing to open/);
   });
 
   it("uses mount command filesystem names on platforms without proc mountinfo", () => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-nfs-"));
-    try {
-      const db = createMockDb();
-      vi.spyOn(process, "platform", "get").mockReturnValue("linux");
-      vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
-      vi.spyOn(fs, "readFileSync").mockImplementation(() => {
-        throw new Error("no proc mountinfo");
-      });
-      const mount = vi
-        .spyOn(childProcess, "execFileSync")
-        .mockReturnValue(Buffer.from(`server:/share on ${tempDir} (nfs, nodev, nosuid)\n`));
+    const tempDir = tempDirs.make("openclaw-sqlite-nfs-");
+    const db = createMockDb();
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
+    vi.spyOn(fs, "readFileSync").mockImplementation(() => {
+      throw new Error("no proc mountinfo");
+    });
+    const mount = vi
+      .spyOn(childProcess, "execFileSync")
+      .mockReturnValue(Buffer.from(`server:/share on ${tempDir} (nfs, nodev, nosuid)\n`));
 
-      configureSqliteWalMaintenance(db, {
-        checkpointIntervalMs: 0,
-        databasePath: path.join(tempDir, "openclaw.sqlite"),
-      });
+    configureSqliteWalMaintenance(db, {
+      checkpointIntervalMs: 0,
+      databasePath: path.join(tempDir, "openclaw.sqlite"),
+    });
 
-      expect(mount).toHaveBeenCalledWith("mount", [], {
-        killSignal: "SIGKILL",
-        timeout: 1_000,
-      });
-      expect(mount).toHaveBeenCalledTimes(1);
-      expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
-    } finally {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    }
+    expect(mount).toHaveBeenCalledWith("mount", [], {
+      killSignal: "SIGKILL",
+      timeout: 1_000,
+    });
+    expect(mount).toHaveBeenCalledTimes(1);
+    expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
   });
 
   it("uses rollback journaling when mount classification times out", () => {
@@ -492,27 +451,23 @@ describe("sqlite WAL maintenance", () => {
   });
 
   it("uses macOS SMB mount filesystem names", () => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-smb-"));
-    try {
-      const db = createMockDb();
-      vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
-      vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
-      vi.spyOn(fs, "readFileSync").mockImplementation(() => {
-        throw new Error("no proc mountinfo");
-      });
-      vi.spyOn(childProcess, "execFileSync").mockReturnValue(
-        Buffer.from(`//server/share on ${tempDir} (smbfs, nodev, nosuid)\n`),
-      );
+    const tempDir = tempDirs.make("openclaw-sqlite-smb-");
+    const db = createMockDb();
+    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
+    vi.spyOn(fs, "readFileSync").mockImplementation(() => {
+      throw new Error("no proc mountinfo");
+    });
+    vi.spyOn(childProcess, "execFileSync").mockReturnValue(
+      Buffer.from(`//server/share on ${tempDir} (smbfs, nodev, nosuid)\n`),
+    );
 
-      configureSqliteWalMaintenance(db, {
-        checkpointIntervalMs: 0,
-        databasePath: path.join(tempDir, "openclaw.sqlite"),
-      });
+    configureSqliteWalMaintenance(db, {
+      checkpointIntervalMs: 0,
+      databasePath: path.join(tempDir, "openclaw.sqlite"),
+    });
 
-      expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
-    } finally {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    }
+    expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
   });
 
   it.each([
@@ -522,77 +477,65 @@ describe("sqlite WAL maintenance", () => {
     ["osxfuse", "user@host:/share"],
     ["osxfuse", "sshfs@osxfuse0"],
   ])("refuses SSHFS reported as %s by mount", (fsType, source) => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-sshfs-macfuse-"));
-    try {
-      const db = createMockDb();
-      vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
-      vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
-      vi.spyOn(fs, "readFileSync").mockImplementation(() => {
-        throw new Error("no proc mountinfo");
-      });
-      vi.spyOn(childProcess, "execFileSync").mockReturnValue(
-        Buffer.from(`${source} on ${tempDir} (${fsType}, nodev, nosuid)\n`),
-      );
+    const tempDir = tempDirs.make("openclaw-sqlite-sshfs-macfuse-");
+    const db = createMockDb();
+    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
+    vi.spyOn(fs, "readFileSync").mockImplementation(() => {
+      throw new Error("no proc mountinfo");
+    });
+    vi.spyOn(childProcess, "execFileSync").mockReturnValue(
+      Buffer.from(`${source} on ${tempDir} (${fsType}, nodev, nosuid)\n`),
+    );
 
-      expect(() =>
-        configureSqliteWalMaintenance(db, {
-          checkpointIntervalMs: 0,
-          databasePath: path.join(tempDir, "openclaw.sqlite"),
-        }),
-      ).toThrow(/refusing to open/);
+    expect(() =>
+      configureSqliteWalMaintenance(db, {
+        checkpointIntervalMs: 0,
+        databasePath: path.join(tempDir, "openclaw.sqlite"),
+      }),
+    ).toThrow(/refusing to open/);
 
-      expect(db["exec"]).not.toHaveBeenCalled();
-    } finally {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    }
+    expect(db["exec"]).not.toHaveBeenCalled();
   });
 
   it("keeps WAL enabled for non-remote macFUSE mounts", () => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-macfuse-"));
-    try {
-      const db = createMockDb();
-      vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
-      vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
-      vi.spyOn(fs, "readFileSync").mockImplementation(() => {
-        throw new Error("no proc mountinfo");
-      });
-      vi.spyOn(childProcess, "execFileSync").mockReturnValue(
-        Buffer.from(`remote-volume on ${tempDir} (macfuse, nodev, nosuid)\n`),
-      );
+    const tempDir = tempDirs.make("openclaw-sqlite-macfuse-");
+    const db = createMockDb();
+    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
+    vi.spyOn(fs, "readFileSync").mockImplementation(() => {
+      throw new Error("no proc mountinfo");
+    });
+    vi.spyOn(childProcess, "execFileSync").mockReturnValue(
+      Buffer.from(`remote-volume on ${tempDir} (macfuse, nodev, nosuid)\n`),
+    );
 
-      configureSqliteWalMaintenance(db, {
-        checkpointIntervalMs: 0,
-        databasePath: path.join(tempDir, "openclaw.sqlite"),
-      });
+    configureSqliteWalMaintenance(db, {
+      checkpointIntervalMs: 0,
+      databasePath: path.join(tempDir, "openclaw.sqlite"),
+    });
 
-      expect(db["exec"]).toHaveBeenNthCalledWith(1, "PRAGMA journal_mode = WAL;");
-    } finally {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    }
+    expect(db["exec"]).toHaveBeenNthCalledWith(1, "PRAGMA journal_mode = WAL;");
   });
 
   it("parses Linux mount command filesystem names when proc mountinfo is unavailable", () => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-nfs-"));
-    try {
-      const db = createMockDb();
-      vi.spyOn(process, "platform", "get").mockReturnValue("linux");
-      vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
-      vi.spyOn(fs, "readFileSync").mockImplementation(() => {
-        throw new Error("no proc mountinfo");
-      });
-      vi.spyOn(childProcess, "execFileSync").mockReturnValue(
-        Buffer.from(`server:/share on ${tempDir} type nfs4 (rw,relatime)\n`),
-      );
+    const tempDir = tempDirs.make("openclaw-sqlite-nfs-");
+    const db = createMockDb();
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0));
+    vi.spyOn(fs, "readFileSync").mockImplementation(() => {
+      throw new Error("no proc mountinfo");
+    });
+    vi.spyOn(childProcess, "execFileSync").mockReturnValue(
+      Buffer.from(`server:/share on ${tempDir} type nfs4 (rw,relatime)\n`),
+    );
 
-      configureSqliteWalMaintenance(db, {
-        checkpointIntervalMs: 0,
-        databasePath: path.join(tempDir, "openclaw.sqlite"),
-      });
+    configureSqliteWalMaintenance(db, {
+      checkpointIntervalMs: 0,
+      databasePath: path.join(tempDir, "openclaw.sqlite"),
+    });
 
-      expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
-    } finally {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    }
+    expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
   });
 
   it("runs lightweight periodic PASSIVE checkpoints and TRUNCATE on close", () => {
@@ -815,7 +758,6 @@ describe("sqlite WAL maintenance", () => {
       }
       maintenance?.close();
       writer.close();
-      fs.rmSync(tempDir, { recursive: true, force: true });
     }
   });
 
@@ -913,23 +855,19 @@ describe("sqlite WAL maintenance", () => {
   });
 
   it("sets busy timeout before rollback journaling on NFS-backed volumes", () => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-nfs-"));
-    try {
-      const db = createMockDb();
-      vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0x6969));
+    const tempDir = tempDirs.make("openclaw-sqlite-nfs-");
+    const db = createMockDb();
+    vi.spyOn(fs, "statfsSync").mockReturnValue(statfsFixture(0x6969));
 
-      configureSqliteConnectionPragmas(db, {
-        busyTimeoutMs: 5000,
-        checkpointIntervalMs: 0,
-        databasePath: path.join(tempDir, "openclaw.sqlite"),
-        synchronous: "NORMAL",
-      });
+    configureSqliteConnectionPragmas(db, {
+      busyTimeoutMs: 5000,
+      checkpointIntervalMs: 0,
+      databasePath: path.join(tempDir, "openclaw.sqlite"),
+      synchronous: "NORMAL",
+    });
 
-      expect(db["exec"]).toHaveBeenNthCalledWith(1, "PRAGMA busy_timeout = 5000;");
-      expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
-      expect(db["exec"]).toHaveBeenNthCalledWith(2, "PRAGMA synchronous = NORMAL;");
-    } finally {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    }
+    expect(db["exec"]).toHaveBeenNthCalledWith(1, "PRAGMA busy_timeout = 5000;");
+    expect(db["prepare"]).toHaveBeenCalledWith("PRAGMA journal_mode = DELETE;");
+    expect(db["exec"]).toHaveBeenNthCalledWith(2, "PRAGMA synchronous = NORMAL;");
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested cleanup of SQLite WAL tests. Repeated directory-only cleanup blocks duplicate the existing temporary-directory tracker and make actual database shutdown ordering harder to see.

## Why This Change Was Made

Reuse the already imported tracker for 15 temporary directories and remove their redundant directory-only `finally` blocks. Keep all five real database cleanup blocks, reader rollback/close ordering, actual inner symlinks, mount-timeout cases and all assertions. No new helper or production seam.

Only `src/infra/sqlite-wal.test.ts` changes: **62 fewer test lines; production unchanged**. Explicit Myers counts: +215/-277; configured histogram: +214/-276, same source and net reduction.

## User Impact

No runtime, SQLite schema, migration, filesystem policy, configuration, dependency or public API change. Existing failure and platform coverage remains.

## Evidence

Unchanged baseline and candidate both passed 52 cases with the same three existing Linux-only skips on macOS, using Node 24.19.0 and pnpm 11.22.0:

```sh
node scripts/run-vitest.mjs src/infra/sqlite-wal.test.ts test/helpers/temp-dir.test.ts
node scripts/check-changed.mjs --dry-run -- src/infra/sqlite-wal.test.ts
node scripts/check-changed.mjs -- src/infra/sqlite-wal.test.ts
git diff --check
```

The complete 19-stage candidate changed gate passed. All 91 assertion calls, 17 close calls, two rollbacks and their ordering remain. The canonical helper's actual temporary-directory tests passed alongside WAL. Managed precommit Codex review and two separate complete published-head P0 review contexts completed without findings; source and relevant dependency inputs were unchanged.

[Exact-head CI 33186060669](https://github.com/openclaw/openclaw/actions/runs/33186060669) completed successfully at `f77e0e7ae3ba53705a6e0ec9bb9ccd2c47339de7`. [Linux job 98899500881](https://github.com/openclaw/openclaw/actions/runs/33186060669/job/98899500881) passed all 49 WAL cases, including sidecar unlink/reopen and EACCES/EPERM. Actual checkout `35277137f4787c56ab5f880d79642f602ae42e6c`, Node 24.19.0 and all 10 source-owner blobs were verified. No Linux baseline/helper-suite replay or live database upgrade is claimed.

Current-main composition through `61fc3d2d` retains the original test beforeimage and unchanged WAL/helper owners. The tested lock's Tlon-only dependency change and Copilot-only test-planner addition do not alter this owner. Newer local graph guards are not relabeled as part of the historical 19-stage run. Native review, mandatory hosted preparation and normal merge completed successfully. Ordinary exact-head checks requested by the latest ClawSweeper review are complete.

## Retained Diagnostics

The normal signed commit and formatting hook succeeded without source changes; its outer observer rejected a histogram-versus-Myers gross-count mismatch, subsequently reconciled without retrying the commit. Earlier raw-index byte drift remains unattributed despite equal logical index/source inventories. A Linux log parser initially selected zero rows because of color encoding; an additive parser verified the original 49 results without rerunning tests. Native-init's outer observer rejected the expected tracking-branch config addition; removing that exact block reconstructs all prior config bytes. An initial mergeability read was unknown; a separate affirmative REST read resolved it without a repeated write. One published review lane's historical temporary paths were not captured; helper success and current recorded-process absence are retained separately, not claimed as an exhaustive historical resource census.

## Landed

Merged as [59d0e5f63cd3](https://github.com/openclaw/openclaw/commit/59d0e5f63cd3dbdf85425e1e9b9ce1c69d0fb8a9). The complete 34,728-entry landed tree equals the actual parent plus the reviewed one-file patch. The exact test blob, patch, 37 reviewed context files, ten source owners, native wrapper closure and main ancestry were verified. Net change: **62 fewer test lines; production unchanged**. The managed PR worktree, temporary refs, operation lock and source remote branch were removed; the original source checkout remains preserved.

The final pre-merge observer stopped on a newly added Gateway-only test prerequisite and CI build-memory documentation. Both exact additions were inspected at their owners and callers, then pinned in a new composition check; no WAL behavior, test assertion, dependency or deadline changed. The original observer failures remain recorded. Native preparation did not push or rebase the candidate, and no tests were rerun or relabeled as a newer-main run.

