### PR TITLE
fix(ci): unblock macOS Swift test discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3838,9 +3838,10 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: apps/macos/.build
-          key: ${{ runner.os }}-swift-build-v3-${{ steps.swift-toolchain.outputs.key }}-${{ hashFiles('apps/macos/Package.swift', 'apps/macos/Package.resolved', 'apps/macos/Sources/**', 'apps/macos/Tests/**', 'apps/shared/OpenClawKit/Package.swift', 'apps/shared/OpenClawKit/Sources/**', 'apps/swabble/Package.swift', 'apps/swabble/Sources/**') }}
+          # Exact hits are immutable; exclude pre-native products from both restore paths.
+          key: ${{ runner.os }}-swift-build-v4-native-tests-${{ steps.swift-toolchain.outputs.key }}-${{ hashFiles('apps/macos/Package.swift', 'apps/macos/Package.resolved', 'apps/macos/Sources/**', 'apps/macos/Tests/**', 'apps/shared/OpenClawKit/Package.swift', 'apps/shared/OpenClawKit/Sources/**', 'apps/swabble/Package.swift', 'apps/swabble/Sources/**') }}
           restore-keys: |
-            ${{ runner.os }}-swift-build-v3-${{ steps.swift-toolchain.outputs.key }}-
+            ${{ runner.os }}-swift-build-v4-native-tests-${{ steps.swift-toolchain.outputs.key }}-
 
       - name: Validate Swift build cache
         id: validate-swift-build-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3947,9 +3947,13 @@ jobs:
         id: swift-test
         run: |
           set -euo pipefail
-          swift build --package-path apps/macos --build-tests --enable-code-coverage
+          # SwiftPM's swiftbuild backend can omit the test-bundle rpath for Sparkle.
+          # Remove once runner toolchains pass with swiftlang/swift-package-manager#10394.
+          # Keep the release build above on the default backend.
+          swift_test_args=(--package-path apps/macos --build-system native --enable-code-coverage)
+          swift build "${swift_test_args[@]}" --build-tests
           echo "debug-tests-built=true" >> "$GITHUB_OUTPUT"
-          swift_test_args=(--package-path apps/macos --enable-code-coverage --skip-build)
+          swift_test_args+=(--skip-build)
           if [[ "$SWIFT_TEST_EXECUTION" == "parallel" ]]; then
             swift_test_args+=(--parallel)
           else

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -6626,8 +6626,9 @@ exit 1
 
     const absentFramework = runBuildFixture("absent", "fail");
     expect(absentFramework.status).toBe(1);
-    expect(absentFramework.calls.filter((call) => call.startsWith("build "))).toHaveLength(1);
-    expect(absentFramework.calls.filter((call) => call.startsWith("package "))).toHaveLength(0);
+    expect(absentFramework.calls).toEqual([
+      "build --package-path apps/macos --product OpenClaw --configuration release",
+    ]);
 
     const recovered = runBuildFixture("incomplete", "recover");
     expect(recovered.status).toBe(0);
@@ -6646,7 +6647,7 @@ exit 1
     expect(secondFailure.calls.filter((call) => call.startsWith("package "))).toHaveLength(1);
   });
 
-  it("preserves the first macOS Swift test failure", () => {
+  it("uses native macOS Swift tests and preserves the first failure", () => {
     const workflow = readCiWorkflow();
     const macosSwift = workflow.jobs["macos-swift"];
     const testStep = macosSwift.steps.find((step: WorkflowStep) => step.name === "Swift test");
@@ -6701,10 +6702,10 @@ test_count="$(grep -c '^test ' "$SWIFT_CALLS")"
       const calls = readFileSync(callsPath, "utf8").trim().split("\n");
       expect(result.status).toBe(buildExitCode || 1);
       expect(calls).toEqual([
-        "build --package-path apps/macos --build-tests --enable-code-coverage",
+        "build --package-path apps/macos --build-system native --enable-code-coverage --build-tests",
         ...(buildExitCode === 0
           ? [
-              `test --package-path apps/macos --enable-code-coverage --skip-build --${
+              `test --package-path apps/macos --build-system native --enable-code-coverage --skip-build --${
                 execution === "parallel" ? "parallel" : "no-parallel"
               }`,
             ]

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -6654,7 +6654,16 @@ exit 1
     const renderStep = macosSwift.steps.find(
       (step: WorkflowStep) => step.name === "Render isolated macOS health fixtures",
     );
+    const buildCache = macosSwift.steps.find(
+      (step: WorkflowStep) => step.id === "swift-build-cache",
+    );
+    const nativeCachePrefix =
+      "${{ runner.os }}-swift-build-v4-native-tests-${{ steps.swift-toolchain.outputs.key }}-";
 
+    expect(buildCache.with).toMatchObject({
+      key: expect.stringContaining(nativeCachePrefix),
+      "restore-keys": `${nativeCachePrefix}\n`,
+    });
     expect(macosSwift.env.SWIFT_TEST_EXECUTION).toBe(
       "${{ (github.event_name == 'workflow_dispatch' || github.run_attempt > 1) && 'serial' || 'parallel' }}",
     );


### PR DESCRIPTION
## What Problem This Solves

macOS Swift tests can build successfully and then fail before discovery because SwiftPM's default Swift Build backend omits the runtime search path needed by the nested test bundle to load Sparkle.

The reproduction uses Xcode 27.0 build 27A5237l, Apple Swift 6.4 (swiftlang-6.4.0.30.4), SwiftPM 6.4.0-dev and pinned Sparkle 2.9.6. Generated extraction tasks and identical artifact hashes prove Sparkle is staged correctly; the test bundle cannot reach it. This matches https://github.com/swiftlang/swift-package-manager/issues/10384.

## Why This Change Was Made

Select the supported native backend for the macOS test build and test execution, using one shared argument array. Preserve current main's separate coverage-enabled `--build-tests` phase, build-success output, `--skip-build` execution and isolated health-render gating. The preceding release build remains on the default backend. Neither phase retries test failures.

The build-cache key **and** fallback prefix move to `swift-build-v4-native-tests`. Exact cache hits are immutable and skip saving, so a pre-native exact hit otherwise keeps restoring old contents after a successful native build. The new namespace excludes those entries from both restore paths. The SwiftPM dependency cache, dependency pins and artifact handling are unchanged. This addresses the latest ClawSweeper cache-identity feedback without claiming old caches are corrupt.

This is an explicitly temporary maintainer-requested mitigation. Native is deprecated; remove the override after runner toolchains containing https://github.com/swiftlang/swift-package-manager/pull/10394 pass the default test path. No application code, Package.swift, library-search-path, framework-copy or packaged-app RPATH change is included.

## User Impact

No application or Gateway runtime change. Maintainers retain actual macOS test execution on affected toolchains instead of stopping at discovery. Release builds continue to exercise the default backend; the native test rollout gets a distinct immutable build-cache identity.

## Evidence

- **Before:** the frozen default-backend build completed in 406.29s, then `swiftpm-xctest-helper` failed loading `@rpath/Sparkle.framework/Versions/B/Sparkle`, exit 1.
- **Affected Swift 6.4 live proof:** coverage-enabled native `swift build --build-tests` completed in 551.59s. Subsequent coverage-enabled `swift test --skip-build` executed all three selected ownership tests in each of parallel and serial modes, exit 0 (21.80s / 5.84s); one test has four cases. Selectors retain the actual listed literal backticks. Fresh LLVM coverage contains the tested source paths, and the binary has `@loader_path/../../../`. Sparkle's binary hash still matches the pinned artifact. This is selected execution, not full-suite or default-backend success.
- Local runs used isolated source/build/HOME/state, locked dependencies, scrubbed environment and the unchanged outer no-network/no-real-home/Keychain/preferences sandbox. No installed app, Gateway, or original in-progress candidate was operated or modified. SwiftPM's nested manifest sandbox alone was disabled. The Swift sources/manifests and pins are unchanged across the final locale-only rebase; the adopted resource catalogs pass their own strict verification.
- The original default and native control scripts also used the same scratch directory, with the later correctly filtered native run executing three tests. The final cache rollout nevertheless does not rely on restoring those old entries: both primary and prefix identities exclude the pre-native namespace. `actions/cache`'s pinned restore implementation and documented exact-hit/prefix semantics were inspected directly.
- **Regression coverage:** parsed cache-identity assertions failed on the old namespace, then passed. The existing shell fixture exercises exact build/test argv, both execution modes, build-success/render gating, build failure before marker publication, first test failure without retry, and default release argv. Final full workflow guard suite: **151 passed, 2 skipped**.
- Final root test types and scoped actionlint **with ShellCheck**, pinned zizmor, composite-input and conflict-marker checks passed. The prior changed gate also passed its type/lint and three Knip scans. Fresh isolated Codex reviews of the split-flow integration and cache rollout found no accepted/actionable findings.
- **Historical full hosted proof at `e76dd8`:** default release build, 1,493 OpenClawKit tests, 1,859 app Swift Testing tests in 191 suites and 3 XCTest tests passed on Xcode 26.6 / Swift 6.3.3: https://github.com/openclaw/openclaw/actions/runs/33188970674/job/98909571610. This result is not promoted to the final head.
- **Final exact-target native job passed:** https://github.com/openclaw/openclaw/actions/runs/33203113976/job/98957292290 checked out `22a0fa21a9598abe46ea51ef2501a4aeb0a2fa1d` and ran the unchanged parsed `macos-swift` job/global environment via a one-off scope selector (workflow commit `d23a944bb9f49e8f467c3be0f60f678d4c1ece0c`, not part of this PR). On the configured Blacksmith 12-vCPU runner, Xcode 26.6 / Swift 6.3.3, it finished in **8m38s within the unchanged 20-minute limit**. The dependency cache restored, both new v4-native-tests build-cache keys missed, and the preserve-exact-hit step was skipped. Default release build, trait opt-out, **1,496 Kit tests**, **1,872 app Swift tests plus 3 XCTest cases**, and the health-render test passed. All four generated ready/running/stale-socket/disabled renders were opened and inspected. Cache writes stayed disabled; no provider hydration occurred.
- **Final required CI passed:** https://github.com/openclaw/openclaw/actions/runs/33202680239 on the exact PR head above. The prior cold GitHub-hosted attempt https://github.com/openclaw/openclaw/actions/runs/33197263249/job/98937711027 reached its existing 30-minute deadline after native compilation and while app tests were running; it is not counted as a full pass. No timeout or runner-policy change is included.

Validation also exposed separate issues, tracked without folding unrelated runtime changes into this PR:

- The test-only Code Mode public-wait repair passed 82 tests and was adopted by current main via https://github.com/openclaw/openclaw/commit/2f7d1419ff8b6f94ab2b8580d9126cfabb9d6a84. Git dropped that already-upstream commit during rebase; it is **not part of the final PR diff**.
- A full Doctor timeout passed an exact failed-tree/artifact/cache diagnostic and then the uninstrumented required retry: https://github.com/openclaw/openclaw/actions/runs/33188970656/job/98929046031. No Doctor, SQLite, timeout or cache-policy patch was made; the original stall's precise cause remains unknown.
- The stale mobile-toast assertion was fixed by https://github.com/openclaw/openclaw/pull/131840. Strict native locale parity was fixed by https://github.com/openclaw/openclaw/pull/131987; that canonical commit is now our base, and local source verification plus strict checks pass for all 21 catalogs / 4,301 entries without generating changes. The broad lint job emitted no lint finding: its runner shut down with exit 143.
- The optional all-workflow local sweep hit actionlint 1.7.12's confirmed stdin-before-spawn pipe deadlock on an unchanged oversized release-publisher script. It was stopped after a stack dump, not counted as passed; the changed workflow passes with ShellCheck enabled. A separate tooling follow-up is recorded.

Final scope: **two files**. Application runtime **+0/-0**; CI **+9/-4** (net +5, primarily context comments); tests **+15/-5**. No dependency, generated locale, persistence, release-publisher, app or Gateway changes. `CHANGELOG.md` is release-only and untouched. Documentation alignment already landed separately in https://github.com/openclaw/openclaw/pull/131502 and https://github.com/openclaw/openclaw/pull/131650.

AI-assisted implementation and review.
