### PR TITLE
chore(test): guard Vitest progress and stall reporting

### DIFF
--- a/test/scripts/run-vitest-progress.test.ts
+++ b/test/scripts/run-vitest-progress.test.ts
@@ -1,0 +1,174 @@
+import fs from "node:fs";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { afterEach, expect, it, vi } from "vitest";
+import {
+  resolveVitestCliEntry,
+  resolveVitestNodeArgs,
+  resolveVitestSpawnParams,
+  spawnWatchedVitestProcess,
+} from "../../scripts/run-vitest.mts";
+import { forceKillVitestProcessGroup } from "../../scripts/vitest-process-group.mts";
+import { isProcessAlive } from "../helpers/process-wait.js";
+import { withTestTimeout } from "../helpers/promise.js";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const repoRoot = path.resolve(import.meta.dirname, "../..");
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const posixIt = process.platform === "win32" ? it.skip : it;
+const ioTimeoutMs = 15_000;
+const silenceMs = 1_000;
+
+async function waitForRealIo(ready: () => boolean, description: string) {
+  const deadline = Date.now() + ioTimeoutMs;
+  while (!ready()) {
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting for ${description}`);
+    }
+    await delay(5);
+  }
+}
+
+posixIt.each([false, true])(
+  "keeps real case progress alive across watchdog windows, then stall=%s",
+  async (stall) => {
+    const root = tempDirs.make("oc-vt-progress-");
+    fs.symlinkSync(
+      path.join(repoRoot, "node_modules"),
+      path.join(root, "node_modules"),
+      "junction",
+    );
+    const configPath = path.join(root, "vitest.config.mjs");
+    // Vitest can batch a case result until later task activity. A file boundary
+    // explicitly flushes updates, so waiting for its case line cannot deadlock
+    // against the next case's release barrier.
+    for (let index = 0; index < 5; index++) {
+      fs.writeFileSync(
+        path.join(root, `progress-${index}.test.ts`),
+        `import fs from "node:fs";
+import { expect, it } from "vitest";
+import { waitForFile } from ${JSON.stringify(path.join(repoRoot, "test/helpers/process-wait.ts"))};
+const index = ${index};
+it("real progress " + index, async () => {
+  const ready = ${JSON.stringify(root)} + "/ready-" + index;
+  fs.writeFileSync(ready + ".tmp", String(process.pid));
+  fs.renameSync(ready + ".tmp", ready);
+  await waitForFile(${JSON.stringify(root)} + "/release-" + index, 15000);
+  expect(index).toBeLessThan(5);
+});
+`,
+      );
+    }
+    fs.writeFileSync(
+      configPath,
+      `import tooling from ${JSON.stringify(path.join(repoRoot, "test/vitest/vitest.tooling.config.ts"))};
+import { BaseSequencer } from "vitest/node";
+class OrderedFixtures extends BaseSequencer {
+  async sort(files) { return [...files].sort((a, b) => a.moduleId.localeCompare(b.moduleId)); }
+}
+export default {
+  ...tooling,
+  root: ${JSON.stringify(root)},
+  cacheDir: ${JSON.stringify(path.join(root, ".vite"))},
+  test: {
+    ...tooling.test, dir: ${JSON.stringify(root)}, include: ["progress-*.test.ts"], maxWorkers: 1,
+    // Pure Vitest fixtures need no OpenClaw environment setup or shared-state runner.
+    setupFiles: [], runner: undefined,
+    sequence: { ...tooling.test.sequence, sequencer: OrderedFixtures },
+  },
+};
+`,
+    );
+    const env = { ...process.env };
+    for (const key of Object.keys(env)) {
+      if (key.startsWith("VITEST") || key.startsWith("OPENCLAW_")) {
+        delete env[key];
+      }
+    }
+    Object.assign(env, {
+      AI_AGENT: "vitest-progress-test",
+      GITHUB_ACTIONS: "false",
+      NO_COLOR: "1",
+      FORCE_COLOR: "0",
+      OPENCLAW_VITEST_FS_MODULE_CACHE_PATH: path.join(root, "module-cache"),
+      OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS: String(silenceMs),
+      OPENCLAW_VITEST_NO_OUTPUT_HEARTBEAT_MS: "400",
+    });
+
+    // The watchdog captures timer functions during synchronous registration.
+    // Uninstall immediately: transport, readiness, diagnostics and group joins
+    // must use real timers, while the watchdog retains its own Sinon clock.
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const { clock } = setTimeout as typeof setTimeout & { clock: { tick(ms: number): void } };
+    const onNoOutputTimeout = vi.fn();
+    let watched: ReturnType<typeof spawnWatchedVitestProcess>;
+    try {
+      watched = spawnWatchedVitestProcess({
+        pnpmArgs: [
+          "exec",
+          "node",
+          ...resolveVitestNodeArgs(env),
+          resolveVitestCliEntry(),
+          "run",
+          "--config",
+          configPath,
+        ],
+        spawnParams: { cwd: repoRoot, ...resolveVitestSpawnParams(env) },
+        env,
+        onNoOutputTimeout,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+    let output = "";
+    watched.child.stdout!.on("data", (chunk: string) => {
+      output += chunk;
+    });
+    watched.child.stderr!.on("data", (chunk: string) => {
+      output += chunk;
+    });
+    const casePassed = (index: number) =>
+      output
+        .split("\n")
+        .some((line) => line.includes("✓") && line.includes(` > real progress ${index} `));
+    let workerPid: number | undefined;
+    try {
+      for (let index = 0; index < 4; index++) {
+        const readyPath = path.join(root, `ready-${index}`);
+        await waitForRealIo(() => fs.existsSync(readyPath), `case ${index} readiness\n${output}`);
+        workerPid = Number(fs.readFileSync(readyPath, "utf8"));
+        clock.tick(600);
+        expect(onNoOutputTimeout, output).not.toHaveBeenCalled();
+        fs.writeFileSync(path.join(root, `release-${index}`), "");
+        // File barriers never enter the watched pipes. Only Vitest's completed
+        // case output can reset the watchdog before the next 600ms advance.
+        await waitForRealIo(
+          () => casePassed(index),
+          `Vitest completion for case ${index}\n${output}`,
+        );
+      }
+      await waitForRealIo(() => fs.existsSync(path.join(root, "ready-4")), "final case readiness");
+      expect(isProcessAlive(watched.child.pid!)).toBe(true);
+      expect(onNoOutputTimeout).not.toHaveBeenCalled();
+      if (stall) {
+        clock.tick(silenceMs - 1);
+        expect(onNoOutputTimeout).not.toHaveBeenCalled();
+        clock.tick(1);
+        expect(onNoOutputTimeout).toHaveBeenCalledOnce();
+      } else {
+        fs.writeFileSync(path.join(root, "release-4"), "");
+      }
+      const result = await watched.completion;
+      // Vitest's logger handles SIGTERM and exits with 128 + 15, rather than
+      // leaving Node to report a signal-only exit (as a bare silent child does).
+      expect(result, output).toEqual({ code: stall ? 143 : 0, signal: null });
+      expect(casePassed(4)).toBe(!stall);
+      expect(isProcessAlive(watched.child.pid!)).toBe(false);
+      expect(isProcessAlive(workerPid!)).toBe(false);
+    } finally {
+      watched.teardown();
+      forceKillVitestProcessGroup(watched.child);
+      await withTestTimeout(watched.completion, ioTimeoutMs, "owned Vitest group did not stop");
+    }
+  },
+);

--- a/test/vitest-reporters-config.test.ts
+++ b/test/vitest-reporters-config.test.ts
@@ -4,6 +4,7 @@ import { DEFAULT_VITEST_TEST_TIMEOUT_MS } from "./vitest/vitest.timeouts.ts";
 
 const reporterConfigs = [
   "vitest.config.ts",
+  "test/vitest/vitest.tooling.config.ts",
   "test/vitest/vitest.cli-process.config.ts",
   "test/vitest/vitest.ui.config.ts",
   "test/vitest/vitest.ui-e2e.config.ts",


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/131448 (shared verbose reporter repair)

## What Problem This Solves

Adds maintainer-requested executable regression coverage for healthy macOS validation being mistaken for a stalled child. The reported `check-changed` invocation selected `pnpm test:macos:ci`; the tooling shard executed new elevation-host fixture subprocesses but produced no successful-case output for 900,000 ms, so the no-output watchdog terminated and retried it. The identical selected suite passed when run with `--reporter=verbose`.

The production repair is already on `main` in the linked PR. Existing coverage resolved reporter configuration and tested watchdogs against synthetic stream activity or silent Node children, but did not connect real Vitest completions to watchdog survival.

## Why This Change Was Made

The regression runs real Vitest through `spawnWatchedVitestProcess`, the shared child boundary used by `test-projects` and the direct wrapper. It inherits the actual tooling reporter policy rather than forcing a reporter on the command line. Real successful cases keep the child alive across multiple watchdog windows; a later silent case must time out, exit 143, and leave no live child or worker.

Only the watchdog's captured clock is controlled. File-based synchronization never enters the watched output streams, and native timers are restored immediately after registration. Each fixture module contains one case because Vitest guarantees a task-result flush at module completion; the initial within-file report/release handshake exposed a separate dependency batching edge case and was replaced rather than hidden with retries or longer deadlines. The existing reporter-resolution table now includes the tooling config, retaining GitHub Actions and explicit reporter-override coverage.

No production behavior, reporter policy, watchdog/test timeout, retry policy, assertion, dependency, or live app/Gateway is changed. No heartbeat is used as liveness proof. Production LOC: +0/-0. Tests: +175/-0.

## User Impact

No new product-runtime behavior. This protects the existing reporting repair against regression and verifies that preserving real progress does not let genuinely silent children escape termination. This tests-only follow-up was explicitly requested by a maintainer.

## Evidence

Local proof on macOS with Node 24.20.0:

- `node scripts/run-vitest.mjs test/scripts/run-vitest-progress.test.ts test/vitest-reporters-config.test.ts test/scripts/vitest-process-diagnostics.test.ts` — 8 tests passed; three sequential worker reruns and an independent final rerun passed. The final run took 26.43 seconds through the wrapper. Active completions survived 2.4 watchdog windows; the later silent child timed out at the controlled 1,000 ms boundary and exited 143.
- Historical-reporter mutation: a temporary copy set only its generated fixture's reporter list to empty under agent detection, reproducing the pre-repair dependency default. Both progress scenarios failed for missing real case-completion output. The production config was never altered; the temporary copy was removed.
- `node scripts/run-vitest.mjs test/scripts/run-vitest.test.ts` — all 103 wrapper regressions passed.
- `pnpm test:macos:ci` — unchanged command, no reporter override: 508 tests in 14 files across 7 shards passed in 1,963.51 seconds. The log contained all 508 case-completion lines, zero no-output terminations, and zero retries. This is the current checkout's macOS selection, not a claim that the original signing branch's additional tests are present here.
- `node scripts/check-changed.mjs -- test/scripts/run-vitest-progress.test.ts test/vitest-reporters-config.test.ts` — passed all selected guards, formatting, test-root typechecking, and script lint.
- Focused test lint, formatting, and `git diff --check` passed. Fresh isolated Codex autoreview completed before commit with no actionable findings at its default P0 threshold.

Publication update: the native PR wrapper required a mechanical rebase onto its current trusted main baseline. Both reviewed test-file SHA256 hashes remained identical. At head `ec2869ad759a3cddb18e6c3f007090045a003d81`, the same focused command passed 8/8 again in 46.24 seconds and the changed-file gate passed again. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33186795821) attached successfully. The longer macOS and wrapper-suite results above remain pre-rebase evidence; they were not rerun after this mechanical refresh.

The executable regression is POSIX-only; Windows keeps its existing process handling coverage. No UI or product-runtime surface changed, so screenshots are not applicable. The separately reproduced Vitest batching issue is tracked as a follow-up, not patched in this PR.

AI-assisted. The ownership boundary, dependency contracts, regression design, and observed proof were inspected during this maintainer-requested work. No agent transcripts or private host data are included.
