### PR TITLE
fix(qa): seed stale child sessions canonically

### DIFF
--- a/extensions/qa-lab/src/scenario-runtime-api.ts
+++ b/extensions/qa-lab/src/scenario-runtime-api.ts
@@ -60,6 +60,7 @@ export type QaScenarioRuntimeDeps = {
   readEffectiveTools: QaScenarioRuntimeFunction;
   readSkillStatus: QaScenarioRuntimeFunction;
   readRawQaSessionStore: QaScenarioRuntimeFunction;
+  seedQaSessionEntries: QaScenarioRuntimeFunction;
   seedQaSessionTranscript: QaScenarioRuntimeFunction;
   readGatewayLogs: QaScenarioRuntimeFunction;
   markGatewayLogCursor: QaScenarioRuntimeFunction;

--- a/extensions/qa-lab/src/suite-runtime-agent-session.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-session.test.ts
@@ -18,6 +18,7 @@ import {
   readRawQaSessionStore,
   readSessionTranscriptSummary,
   readSkillStatus,
+  seedQaSessionEntries,
   seedQaSessionTranscript,
 } from "./suite-runtime-agent-session.js";
 import { createTempDirHarness } from "./temp-dir.test-helper.js";
@@ -277,6 +278,72 @@ describe("qa suite runtime agent session helpers", () => {
     await expect(
       fs.stat(path.join(tempRoot, "state", "agents", "qa", "sessions", `${sessionId}.jsonl`)),
     ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("seeds multi-agent session entries through the canonical accessor", async () => {
+    const tempRoot = await makeTempDir("qa-session-entry-seed-");
+    const parentSessionKey = "agent:qa:main";
+
+    await seedQaSessionEntries(
+      {
+        gateway: { tempRoot },
+      } as never,
+      [
+        {
+          agentId: "qa",
+          sessionKey: parentSessionKey,
+          entry: {
+            sessionId: "session-main",
+            updatedAt: 300,
+          },
+        },
+        {
+          agentId: "qa",
+          sessionKey: "agent:qa:subagent:child",
+          entry: {
+            sessionId: "session-child",
+            updatedAt: 200,
+            spawnedBy: parentSessionKey,
+            status: "done",
+            endedAt: 250,
+          },
+        },
+        {
+          agentId: "claude",
+          sessionKey: "agent:claude:acp:child",
+          entry: {
+            sessionId: "session-acp-child",
+            updatedAt: 100,
+            parentSessionKey,
+          },
+        },
+      ],
+    );
+
+    await expect(
+      readRawQaSessionStore({ gateway: { tempRoot } } as never, { agentId: "qa" }),
+    ).resolves.toMatchObject({
+      [parentSessionKey]: {
+        sessionId: "session-main",
+        updatedAt: 300,
+      },
+      "agent:qa:subagent:child": {
+        sessionId: "session-child",
+        updatedAt: 200,
+        spawnedBy: parentSessionKey,
+        status: "done",
+        endedAt: 250,
+      },
+    });
+    await expect(
+      readRawQaSessionStore({ gateway: { tempRoot } } as never, { agentId: "claude" }),
+    ).resolves.toMatchObject({
+      "agent:claude:acp:child": {
+        sessionId: "session-acp-child",
+        updatedAt: 100,
+        parentSessionKey,
+      },
+    });
   });
 
   it("reports bounded persisted compaction summaries", async () => {

--- a/extensions/qa-lab/src/suite-runtime-agent-session.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-session.ts
@@ -7,6 +7,7 @@ import {
   listSessionEntries,
   loadTranscriptEventsSync,
   resolveStorePath,
+  type SessionEntry,
   upsertSessionEntry,
 } from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
@@ -40,6 +41,12 @@ type QaSessionTranscriptSeedParams = {
   sessionId: string;
   sessionKey: string;
   updatedAt: number;
+};
+
+type QaSessionEntrySeed = {
+  agentId: string;
+  entry: SessionEntry;
+  sessionKey: string;
 };
 
 const SESSION_STORE_FTS_SETTLE_RETRY_DELAYS_MS = [100, 250, 500, 1_000, 2_000] as const;
@@ -369,6 +376,27 @@ function qaSessionRuntimeEnv(tempRoot: string): NodeJS.ProcessEnv {
   };
 }
 
+async function seedQaSessionEntries(
+  env: Pick<QaSuiteRuntimeEnv, "gateway">,
+  entries: readonly QaSessionEntrySeed[],
+): Promise<void> {
+  const runtimeEnv = qaSessionRuntimeEnv(env.gateway.tempRoot);
+  for (const seed of entries) {
+    const agentId = seed.agentId.trim();
+    const sessionKey = seed.sessionKey.trim();
+    if (!agentId || !sessionKey) {
+      throw new Error("seedQaSessionEntries requires agentId and sessionKey");
+    }
+    await upsertSessionEntry({
+      agentId,
+      env: runtimeEnv,
+      sessionKey,
+      storePath: resolveStorePath(undefined, { agentId, env: runtimeEnv }),
+      entry: seed.entry,
+    });
+  }
+}
+
 async function seedQaSessionTranscript(
   env: Pick<QaSuiteRuntimeEnv, "gateway">,
   params: QaSessionTranscriptSeedParams,
@@ -527,5 +555,6 @@ export {
   readRawQaSessionStore,
   readSessionTranscriptSummary,
   readSkillStatus,
+  seedQaSessionEntries,
   seedQaSessionTranscript,
 };

--- a/extensions/qa-lab/src/suite-runtime-agent.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent.ts
@@ -5,6 +5,7 @@ export {
   readRawQaSessionStore,
   readSessionTranscriptSummary,
   readSkillStatus,
+  seedQaSessionEntries,
   seedQaSessionTranscript,
 } from "./suite-runtime-agent-session.js";
 export {

--- a/qa/scenarios/agents/subagent-stale-child-links.yaml
+++ b/qa/scenarios/agents/subagent-stale-child-links.yaml
@@ -59,11 +59,7 @@ flow:
                     const now = Date.now();
                     const old = now - 2 * 60 * 60 * 1000;
                     const recent = now - 5000;
-                    const qaSessionsDir = path.join(ctx.stateDir, "agents", "qa", "sessions");
-                    const claudeSessionsDir = path.join(ctx.stateDir, "agents", "claude", "sessions");
                     const subagentDir = path.join(ctx.stateDir, "subagents");
-                    await fs.mkdir(qaSessionsDir, { recursive: true });
-                    await fs.mkdir(claudeSessionsDir, { recursive: true });
                     await fs.mkdir(subagentDir, { recursive: true });
                     await fs.writeFile(path.join(subagentDir, "runs.json"), `${JSON.stringify({
                       version: 2,
@@ -94,48 +90,88 @@ flow:
                         },
                       },
                     }, null, 2)}\n`, "utf8");
-                    await fs.writeFile(path.join(qaSessionsDir, "sessions.json"), `${JSON.stringify({
-                      [mainKey]: {
-                        sessionId: "sess-main",
-                        updatedAt: now,
+                    await seedQaSessionEntries(env, [
+                      {
+                        agentId: "qa",
+                        sessionKey: mainKey,
+                        entry: {
+                          sessionId: "sess-main",
+                          updatedAt: now,
+                        },
                       },
-                      [staleRunKey]: {
-                        sessionId: "sess-stale-run",
-                        updatedAt: old,
-                        spawnedBy: mainKey,
-                        status: "done",
-                        endedAt: old,
+                      {
+                        agentId: "qa",
+                        sessionKey: staleRunKey,
+                        entry: {
+                          sessionId: "sess-stale-run",
+                          updatedAt: old,
+                          spawnedBy: mainKey,
+                          status: "done",
+                          endedAt: old,
+                        },
                       },
-                      [staleOrphanKey]: {
-                        sessionId: "sess-orphan",
-                        updatedAt: old,
-                        parentSessionKey: mainKey,
+                      {
+                        agentId: "qa",
+                        sessionKey: staleOrphanKey,
+                        entry: {
+                          sessionId: "sess-orphan",
+                          updatedAt: old,
+                          parentSessionKey: mainKey,
+                        },
                       },
-                      [freshDashboardKey]: {
-                        sessionId: "sess-fresh-dashboard",
-                        updatedAt: now,
-                        parentSessionKey: mainKey,
+                      {
+                        agentId: "qa",
+                        sessionKey: freshDashboardKey,
+                        entry: {
+                          sessionId: "sess-fresh-dashboard",
+                          updatedAt: now,
+                          parentSessionKey: mainKey,
+                        },
                       },
-                      [liveRunKey]: {
-                        sessionId: "sess-live-child",
-                        updatedAt: recent,
-                        spawnedBy: mainKey,
+                      {
+                        agentId: "qa",
+                        sessionKey: liveRunKey,
+                        entry: {
+                          sessionId: "sess-live-child",
+                          updatedAt: recent,
+                          spawnedBy: mainKey,
+                        },
                       },
-                    }, null, 2)}\n`, "utf8");
-                    await fs.writeFile(path.join(claudeSessionsDir, "sessions.json"), `${JSON.stringify({
-                      [staleAcpKey]: {
-                        sessionId: "sess-acp-stale",
-                        updatedAt: old,
-                        spawnedBy: mainKey,
-                        status: "done",
-                        endedAt: old,
+                      {
+                        agentId: "claude",
+                        sessionKey: staleAcpKey,
+                        entry: {
+                          sessionId: "sess-acp-stale",
+                          updatedAt: old,
+                          spawnedBy: mainKey,
+                          status: "done",
+                          endedAt: old,
+                        },
                       },
-                    }, null, 2)}\n`, "utf8");
+                    ]);
                   })()
         - call: waitForGatewayHealthy
           args:
             - ref: env
             - 60000
+        - call: readRawQaSessionStore
+          saveAs: qaSessionStore
+          args:
+            - ref: env
+            - agentId: qa
+        - call: readRawQaSessionStore
+          saveAs: claudeSessionStore
+          args:
+            - ref: env
+            - agentId: claude
+        - assert:
+            expr: "[mainKey, staleRunKey, staleOrphanKey, freshDashboardKey, liveRunKey].every((key) => qaSessionStore[key]?.sessionId)"
+            message:
+              expr: "`canonical QA session entries missing: ${JSON.stringify(Object.keys(qaSessionStore))}`"
+        - assert:
+            expr: "claudeSessionStore[staleAcpKey]?.sessionId === 'sess-acp-stale'"
+            message:
+              expr: "`canonical Claude session entry missing: ${JSON.stringify(Object.keys(claudeSessionStore))}`"
         - call: env.gateway.call
           saveAs: listed
           args:
@@ -171,4 +207,4 @@ flow:
             expr: "![staleRunKey, staleOrphanKey, staleAcpKey].some((key) => mainChildren.includes(key) || filteredKeys.includes(key))"
             message:
               expr: "`stale child leaked through sessions.list (main=${JSON.stringify(mainChildren)} filtered=${JSON.stringify(filteredKeys)})`"
-      detailsExpr: "({ mainChildren, filteredKeys })"
+      detailsExpr: "({ persistedQaKeys: Object.keys(qaSessionStore), persistedClaudeKeys: Object.keys(claudeSessionStore), mainChildren, filteredKeys })"


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the QA Lab stale-child scenario wrote legacy `sessions.json` fixtures, causing current gateway startup migration enforcement to abort before the scenario could test stale child filtering.

## Why This Change Was Made

The scenario now seeds its multi-agent session relationship fixtures through the existing QA/session accessor seam while the gateway is stopped. The startup migration remains strict, and the scenario still exercises the real restarted gateway with the same stale, fresh, live, orphaned, and ACP child relationships.

## User Impact

No production behavior changes. QA Lab can continue validating stale child-link filtering against the canonical persisted session store instead of a retired file fixture.

## Evidence

- Pre-fix startup probe: placing `agents/qa/sessions/sessions.json` under the scenario state root caused startup to fail with `Legacy session store requires migration ... Run "openclaw doctor --fix"`.
- Exact QA scenario: `subagent-stale-child-links` passed `1/1` against the real gateway child and mock OpenAI provider.
- Canonical persistence evidence:
  - QA store contained `agent:qa:main`, the stale ended child, stale orphan, fresh dashboard child, and live child.
  - Claude store contained `agent:claude:acp:qa-stale-acp`.
  - `sessions.list` exposed only the fresh dashboard child and live child after restart.
- Focused Vitest: `81/81` passed across the session helper and scenario catalog suites.
- Passed: extension production and test typechecks, extension lint, formatting, session-accessor boundary guard, database-first legacy-store guard, and `git diff --check`.
- Autoreview: clean, no accepted/actionable findings.
- LOC: production `0`; QA harness, scenario, and test support only (`+170/-36`).
- Changelog omitted because this is QA-only test infrastructure.
