### PR TITLE
chore(process): make descendant termination proof deterministic

### DIFF
--- a/src/process/exec.test.ts
+++ b/src/process/exec.test.ts
@@ -1,12 +1,18 @@
 // Exec tests cover command execution, output capture, and cancellation behavior.
 import type { ChildProcess } from "node:child_process";
-import { EventEmitter } from "node:events";
+import { EventEmitter, once } from "node:events";
+import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
+import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import { setVerbose } from "../global-state.js";
+import { isPidAlive } from "../shared/pid-alive.js";
+import { readPidFile, waitForPidToExit } from "../test-utils/process-tree.js";
+import { withTempDir } from "../test-utils/temp-dir.js";
 import { attachChildProcessBridge } from "./child-process-bridge.js";
+import * as execSpawn from "./exec-spawn.js";
 import {
   resolveCommandEnv,
   resolveProcessExitCode,
@@ -532,48 +538,88 @@ describe("runCommandBuffered", () => {
   it.runIf(process.platform !== "win32")(
     "force-kills inherited-pipe descendants after the direct child exits",
     { timeout: 5_000 },
-    async () => {
-      const descendantSource =
-        "process.on('SIGTERM', () => {}); setInterval(() => process.stdout.write('.'), 20)";
-      const parentSource = [
-        "const { spawn } = require('node:child_process')",
-        `const child = spawn(${JSON.stringify(process.execPath)}, ['-e', ${JSON.stringify(descendantSource)}], { stdio: ['ignore', 'inherit', 'inherit'] })`,
-        "child.unref()",
-        "process.stdout.write(`PID:${child.pid}\\n`)",
-      ].join(";");
-      const result = await runCommandBuffered([process.execPath, "-e", parentSource], {
-        // The timeout starts before Node initializes; loaded CI still needs time to spawn and report the descendant.
-        timeoutMs: 500,
-      });
-      const pidMatch = result.stdout.toString().match(/PID:(\d+)/u);
-      if (!pidMatch) {
-        throw new Error(`missing descendant pid in ${result.stdout.toString()}`);
-      }
-      const descendantPid = Number(pidMatch[1]);
-
-      try {
-        expect(result).toMatchObject({ code: null, termination: "timeout" });
-        let descendantExited = false;
-        for (let attempt = 0; attempt < 40; attempt += 1) {
-          try {
-            process.kill(descendantPid, 0);
-          } catch {
-            descendantExited = true;
-            break;
-          }
-          await new Promise<void>((resolve) => {
-            setTimeout(resolve, 25);
-          });
-        }
-        expect(descendantExited).toBe(true);
-      } finally {
+    async () =>
+      withTempDir("openclaw-exec-descendant-", async (dir) => {
+        const pidPath = path.join(dir, "descendant.pid");
+        const termPath = path.join(dir, "sigterm");
+        // Acknowledge only after the handler and keepalive exist. Stay quiet so
+        // inherited-pipe release cannot kill the descendant through EPIPE.
+        const descendantSource = [
+          "const { writeFileSync } = require('node:fs')",
+          `process.on('SIGTERM', () => writeFileSync(${JSON.stringify(termPath)}, 'handled'))`,
+          "setInterval(() => {}, 1_000)",
+          "process.send('ready')",
+        ].join(";");
+        const parentSource = [
+          "const { spawn } = require('node:child_process')",
+          "const { writeFileSync } = require('node:fs')",
+          `const child = spawn(process.execPath, ['-e', ${JSON.stringify(descendantSource)}], { stdio: ['ignore', 'inherit', 'inherit', 'ipc'] })`,
+          `child.once('message', () => { writeFileSync(${JSON.stringify(pidPath)}, String(child.pid)); process.exit(0) })`,
+        ].join(";");
+        const realSetTimeout = setTimeout;
+        const spawnSpy = vi.spyOn(execSpawn, "spawnCommandWithInvocation");
+        let parent: ChildProcess | undefined;
+        let command: ReturnType<typeof runCommandBuffered> | undefined;
+        // Freeze deadlines, not subprocess I/O: Node startup must not consume the
+        // timeout or the 100ms inherited-pipe idle grace. Polling must stay real.
+        vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
         try {
-          process.kill(descendantPid, "SIGKILL");
-        } catch {
-          // Already gone.
+          let settled = false;
+          command = runCommandBuffered([process.execPath, "-e", parentSource], {
+            timeoutMs: 50,
+          }).then((result) => {
+            settled = true;
+            return result;
+          });
+          const spawnResult = spawnSpy.mock.results[0];
+          if (spawnResult?.type !== "return") {
+            throw new Error("command did not spawn");
+          }
+          parent = spawnResult.value.child.nodeChildProcess;
+          if (!parent) {
+            throw new Error("command did not expose a child process");
+          }
+          expect(await once(parent, "exit", { signal: AbortSignal.timeout(2_000) })).toEqual([
+            0,
+            null,
+          ]);
+          const descendantPid = await readPidFile(pidPath);
+          expect(isPidAlive(descendantPid)).toBe(true);
+          expect(settled).toBe(false);
+
+          await vi.advanceTimersByTimeAsync(50);
+          for (let attempt = 0; attempt < 40 && !existsSync(termPath); attempt += 1) {
+            await new Promise<void>((resolve) => {
+              realSetTimeout(resolve, 25);
+            });
+          }
+          expect(existsSync(termPath)).toBe(true);
+          expect(isPidAlive(descendantPid)).toBe(true);
+          expect(settled).toBe(false);
+
+          await vi.advanceTimersByTimeAsync(execSpawn.COMMAND_PROCESS_TREE_KILL_GRACE_MS);
+          expect(await command).toMatchObject({ code: null, termination: "timeout" });
+          vi.useRealTimers();
+          expect(await waitForPidToExit(descendantPid)).toBe(true);
+        } finally {
+          try {
+            if (parent?.pid) {
+              try {
+                process.kill(-parent.pid, "SIGKILL");
+              } catch {
+                // Already gone.
+              }
+            }
+            if (vi.isFakeTimers()) {
+              await vi.runAllTimersAsync();
+            }
+          } finally {
+            vi.useRealTimers();
+            spawnSpy.mockRestore();
+          }
+          await command;
         }
-      }
-    },
+      }),
   );
 
   it.runIf(process.platform !== "win32")(


### PR DESCRIPTION
Related: #106495 (buffered execution through Execa), #107011 (earlier descendant-test timing adjustment).

## What Problem This Solves

Resolves a problem where the buffered process-tree regression test could report a normal exit instead of the expected timeout under process-startup load. This is a maintainer-requested repair of the existing test, not a runtime timeout-policy change.

## Why This Change Was Made

The fixture let its direct child exit before the descendant had installed its SIGTERM handler. The normal 100 ms inherited-pipe idle release could then settle Execa and clear the command deadline. Raising the deadline from 50 ms to 500 ms in #107011 did not synchronize that setup.

The fixture now acknowledges readiness over real IPC after installing its handler and a quiet keepalive, observes the direct child's actual exit through the existing pass-through spawn helper, and advances only host deadlines. It separately proves SIGTERM receipt and survival, then descendant disappearance after the existing kill grace. Quiet output prevents EPIPE from masquerading as force-kill proof. Cleanup restores timers and the spy, kills the owned process group, settles the command, and removes temporary artifacts. No production API or implementation changes.

## User Impact

No user-visible behavior, configuration, timeout, or runtime changes. Developers get deterministic coverage of cancellation and force-kill after direct-child exit.

Production LOC: +0/-0. Tests: +86/-40 (net +46), entirely in `src/process/exec.test.ts`.

## Evidence

- Before/after: a diagnostic 250 ms descendant initialization delay reproduced the original failure in full-file execution order (normal `code: 0`, `termination: exit`). The repaired full file passed with that same delay: 40 passed, 1 platform skip. The diagnostic delay is not included in the patch.
- Negative controls: disabling post-exit cancellation failed the SIGTERM acknowledgment assertion; suppressing SIGKILL failed descendant disappearance. Both temporary production mutations were removed.
- The repaired full file passed three further runs in the original execution order, and passed after final type/lint cleanup.
- Existing sibling proof covered inherited-pipe draining, no-output deadlines, process-group escalation, and simulated Windows semantics: 101 passed, 1 platform skip across five files. Windows intentionally does not reclassify a completed direct child as timed out; no real Windows execution is claimed.
- Fresh Codex autoreview: clean at the configured P0 threshold, with no accepted/actionable findings. AI-assisted; maintainer reviewed the lifecycle behavior and cleanup.

Local validation after a normal dependency install:

- `node scripts/check-changed.mjs -- src/process/exec.test.ts` passed, including the full dead-export scans, core-test typechecks, and changed-file lint.
- `node scripts/run-tsgo-core-test-shards.mjs` passed. The prior local Pako declaration error was an incomplete installation; `pnpm install` restored UI Pako 3.0.1 and its bundled declarations without manifest or lockfile edits.
- `node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.other.json --builders 1`, targeted oxlint, formatting, and `git diff --check` passed.

After rebasing, `node scripts/run-vitest.mjs src/process/exec.test.ts src/process/child-process.test.ts src/process/exec.no-output-timer.test.ts src/process/kill-tree.test.ts src/process/exec.windows.test.ts` passed again: 101 passed, 1 skipped. Targeted core-test types, formatting, and `git diff --check` also passed. The rebased patch is byte-identical to the reviewed patch.

Exact-head [CI run 33186830918](https://github.com/openclaw/openclaw/actions/runs/33186830918) passed for `e2a7e65b1db8101986e1cac78162f7ebc265a0e1`. The [Linux changed-test job](https://github.com/openclaw/openclaw/actions/runs/33186830918/job/98902091464) ran the full `exec.test.ts` file: 40 passed, 1 skipped, including the repaired descendant case. Native review artifacts validate with zero findings. ClawSweeper review follow-through: [latest review](https://github.com/openclaw/openclaw/pull/131876#issuecomment-5454712790) reported no code findings. Both remaining items are satisfied: exact-head CI 33186830918 and its Linux process integration job passed; direct local inspection of pinned Execa 10.0.1 `lib/resolve/wait-subprocess.js:85` and `lib/resolve/wait-stream.js:87` confirmed exit-plus-stream settlement and readable-stream destruction semantics. The reviewer could not inspect its own dependency checkout, but that gap is covered by this direct source inspection and the passing integration run. No production change or additional repair is needed. Native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 131876` passed hosted gates and preserved the exact reviewed head.
