### PR TITLE
fix(release): resume protected child publication

### DIFF
--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -58,6 +58,11 @@ on:
         required: false
         default: ""
         type: string
+      release_publish_full_ref:
+        description: Full ref of the approving OpenClaw Release Publish workflow run
+        required: false
+        default: ""
+        type: string
       plugin_npm_run_id:
         description: Successful Plugin NPM Release run id for the exact extended-stable branch and release SHA
         required: false
@@ -1543,6 +1548,8 @@ jobs:
           OPENCLAW_NPM_PUBLISH_TAG: ${{ inputs.npm_dist_tag }}
           PUBLISH_TARBALL_PATH: ${{ steps.preflight_provenance.outputs.tarball_path }}
           RELEASE_PUBLISH_PARENT_STATE_POLICY: ${{ inputs.release_publish_run_id != '' && (github.actor == 'github-actions[bot]' && 'active' || 'manual-recovery') || '' }}
+          RELEASE_PUBLISH_REF: ${{ inputs.release_publish_branch }}
+          RELEASE_PUBLISH_FULL_REF: ${{ inputs.release_publish_full_ref }}
           RELEASE_PUBLISH_RUN_ATTEMPT: ${{ inputs.release_publish_run_attempt }}
           RELEASE_PUBLISH_RUN_ID: ${{ inputs.release_publish_run_id }}
           WORKFLOW_FULL_REF: ${{ github.ref }}
@@ -1558,6 +1565,8 @@ jobs:
               --workflow-sha "$WORKFLOW_SHA" \
               --release-publish-run-id "$RELEASE_PUBLISH_RUN_ID" \
               --release-publish-run-attempt "$RELEASE_PUBLISH_RUN_ATTEMPT" \
+              --release-publish-ref "$RELEASE_PUBLISH_REF" \
+              --release-publish-full-ref "$RELEASE_PUBLISH_FULL_REF" \
               --release-publish-parent-state-policy "$RELEASE_PUBLISH_PARENT_STATE_POLICY" \
               --allow-prevalidated-ref
           }

--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -1005,6 +1005,7 @@ jobs:
           TARGET_SHA: ${{ needs.resolve_release_target.outputs.sha }}
           GH_TOKEN: ${{ github.token }}
           PARENT_WORKFLOW_BRANCH: ${{ github.ref_name }}
+          PARENT_WORKFLOW_FULL_REF: ${{ github.ref }}
           RELEASE_TAG: ${{ inputs.tag }}
           PLUGIN_PUBLISH_SCOPE: ${{ inputs.plugin_publish_scope }}
           PLUGINS: ${{ inputs.plugins }}
@@ -1082,6 +1083,7 @@ jobs:
             --release-tag "${RELEASE_TAG}"
             --release-sha "${TARGET_SHA}"
             --release-publish-branch "${PARENT_WORKFLOW_BRANCH}"
+            --release-publish-full-ref "${PARENT_WORKFLOW_FULL_REF}"
             --release-publish-run-attempt "${GITHUB_RUN_ATTEMPT}"
             --release-publish-run-id "${GITHUB_RUN_ID}"
             --plugin-publish-scope "${PLUGIN_PUBLISH_SCOPE}"
@@ -1234,6 +1236,7 @@ jobs:
           CHILD_WORKFLOW_REF: ${{ steps.clawhub_plan.outputs.child_workflow_ref }}
           PARENT_WORKFLOW_SHA: ${{ github.sha }}
           PARENT_WORKFLOW_BRANCH: ${{ github.ref_name }}
+          PARENT_WORKFLOW_FULL_REF: ${{ github.ref }}
           RELEASE_TAG: ${{ inputs.tag }}
           PREFLIGHT_RUN_ID: ${{ inputs.preflight_run_id }}
           FULL_RELEASE_VALIDATION_RUN_ID: ${{ inputs.full_release_validation_run_id }}
@@ -2552,7 +2555,7 @@ jobs:
             if [[ "${WAIT_FOR_CLAWHUB}" == "true" ]]; then
               echo "- Workflow completion waits for ClawHub"
             else
-              echo "- Workflow completion does not wait for ClawHub; monitor the dispatched ClawHub run separately"
+              echo "- Workflow does not wait for ClawHub; monitor its run separately"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -2574,7 +2577,7 @@ jobs:
             bootstrap_workflow_sha="$(verify_bootstrap_workflow_sha)"
           fi
 
-          npm_args=(-f publish_scope="${PLUGIN_PUBLISH_SCOPE}" -f ref="${TARGET_SHA}" -f release_publish_run_id="${GITHUB_RUN_ID}" -f release_publish_run_attempt="${GITHUB_RUN_ATTEMPT}" -f release_publish_branch="${PARENT_WORKFLOW_BRANCH}")
+          npm_args=(-f publish_scope="${PLUGIN_PUBLISH_SCOPE}" -f ref="${TARGET_SHA}" -f release_publish_run_id="${GITHUB_RUN_ID}" -f release_publish_run_attempt="${GITHUB_RUN_ATTEMPT}" -f release_publish_branch="${PARENT_WORKFLOW_BRANCH}" -f release_publish_full_ref="${PARENT_WORKFLOW_FULL_REF}")
           if [[ -n "${PLUGINS}" ]]; then
             npm_args+=(-f plugins="${PLUGINS}")
           fi
@@ -2586,7 +2589,7 @@ jobs:
             append_clawhub_dispatch_args normal
             plugin_clawhub_run_id="$(dispatch_workflow_at_ref \
               "$(jq -r '.normal.ref' "${clawhub_plan_path}")" \
-              "${TARGET_SHA}" \
+              "${PARENT_WORKFLOW_SHA}" \
               "$(jq -r '.normal.workflow' "${clawhub_plan_path}")" \
               "${clawhub_dispatch_args[@]}")"
           else
@@ -2662,6 +2665,7 @@ jobs:
                 -f release_publish_run_id="${GITHUB_RUN_ID}" \
                 -f release_publish_run_attempt="${GITHUB_RUN_ATTEMPT}" \
                 -f release_publish_branch="${PARENT_WORKFLOW_BRANCH}" \
+                -f release_publish_full_ref="${PARENT_WORKFLOW_FULL_REF}" \
                 -f plugin_sdk_api_acknowledgement="${PLUGIN_SDK_API_ACKNOWLEDGEMENT}" \
                 -f npm_dist_tag="${RELEASE_NPM_DIST_TAG}" \
                 "${evidence_args[@]}")"
@@ -2679,7 +2683,7 @@ jobs:
             if [[ -n "${plugin_clawhub_run_id}" ]]; then
               clawhub_result="$RUNNER_TEMP/clawhub-result.txt"
               wait_run_pid=""
-              wait_for_run_background plugin-clawhub-release.yml "${plugin_clawhub_run_id}" "${TARGET_SHA}" "${clawhub_result}"
+              wait_for_run_background plugin-clawhub-release.yml "${plugin_clawhub_run_id}" "${PARENT_WORKFLOW_SHA}" "${clawhub_result}"
               clawhub_pid="${wait_run_pid}"
             fi
             if [[ -n "${plugin_clawhub_bootstrap_run_id}" ]]; then

--- a/.github/workflows/plugin-clawhub-release.yml
+++ b/.github/workflows/plugin-clawhub-release.yml
@@ -16,7 +16,12 @@ on:
         required: false
         type: string
       ref:
-        description: Dry-run target ref to validate; real OIDC publishes must dispatch the workflow with --ref set to the target release tag/ref
+        description: Exact target SHA for protected-tooling release publication, or a dry-run target ref
+        required: false
+        default: ""
+        type: string
+      release_tag:
+        description: Exact release tag that must peel to ref for protected-tooling publication
         required: false
         default: ""
         type: string
@@ -24,9 +29,24 @@ on:
         description: Approved OpenClaw Release Publish workflow run id
         required: false
         type: string
+      release_publish_run_attempt:
+        description: Exact approving OpenClaw Release Publish workflow run attempt
+        required: false
+        default: ""
+        type: string
       release_publish_branch:
         description: Branch name of the approving OpenClaw Release Publish workflow run
         required: false
+        type: string
+      release_publish_full_ref:
+        description: Full ref of the approving OpenClaw Release Publish workflow run
+        required: false
+        default: ""
+        type: string
+      release_publish_workflow_sha:
+        description: Exact SHA of the approving OpenClaw Release Publish workflow run
+        required: false
+        default: ""
         type: string
       dry_run:
         description: Validate the full ClawHub artifact handoff without publishing.
@@ -73,12 +93,21 @@ jobs:
       - name: Resolve checked-out ref
         id: ref
         env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
           TARGET_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || '' }}
         run: |
           set -euo pipefail
           timeout --signal=TERM --kill-after=10s 120s git fetch --no-tags origin \
             +refs/heads/main:refs/remotes/origin/main \
             '+refs/heads/release/*:refs/remotes/origin/release/*'
+          if [[ -n "${RELEASE_TAG}" ]]; then
+            [[ "${RELEASE_TAG}" =~ ^v[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*((-(alpha|beta)\.[1-9][0-9]*)|(-[1-9][0-9]*))?$ ]] || {
+              echo "Invalid ClawHub release tag: ${RELEASE_TAG}" >&2
+              exit 1
+            }
+            timeout --signal=TERM --kill-after=10s 120s git fetch --no-tags origin \
+              "+refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+          fi
           if [[ -n "${TARGET_REF}" ]]; then
             if git rev-parse --verify --quiet "${TARGET_REF}^{commit}" >/dev/null; then
               target_sha="$(git rev-parse "${TARGET_REF}^{commit}")"
@@ -96,7 +125,11 @@ jobs:
         env:
           TARGET_SHA: ${{ steps.ref.outputs.sha }}
           WORKFLOW_SHA: ${{ github.sha }}
+          WORKFLOW_REF: ${{ github.ref }}
           DRY_RUN: ${{ inputs.dry_run && 'true' || 'false' }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_PUBLISH_RUN_ID: ${{ inputs.release_publish_run_id }}
+          RELEASE_PUBLISH_RUN_ATTEMPT: ${{ inputs.release_publish_run_attempt }}
         run: |
           set -euo pipefail
           if [[ "${TARGET_SHA}" != "${WORKFLOW_SHA}" ]]; then
@@ -104,9 +137,15 @@ jobs:
               echo "Dry-run publish target differs from workflow ref; allowing validation-only dispatch."
               exit 0
             fi
-            echo "Plugin ClawHub OIDC publishes must run from the same ref that is being published." >&2
-            echo "The ref input is only supported for dry_run=true." >&2
-            echo "For real publishes, dispatch this workflow with --ref pointing at the target release tag/ref and omit the ref input." >&2
+            if [[ "${WORKFLOW_REF}" =~ ^refs/tags/release-publish/[a-f0-9]{12}-[1-9][0-9]*$ ]] &&
+              [[ -n "${RELEASE_PUBLISH_RUN_ID// }" ]] &&
+              [[ "${RELEASE_PUBLISH_RUN_ATTEMPT}" =~ ^[1-9][0-9]*$ ]] &&
+              [[ -n "${RELEASE_TAG}" ]] &&
+              [[ "$(git rev-parse "${RELEASE_TAG}^{commit}")" == "${TARGET_SHA}" ]]; then
+              echo "Protected release tooling is publishing the exact immutable release tag target."
+              exit 0
+            fi
+            echo "Plugin ClawHub OIDC publish target is not bound to protected tooling and the exact release tag." >&2
             exit 1
           fi
 
@@ -286,7 +325,10 @@ jobs:
           ALLOW_COMPLETED_SUCCESSFUL_PARENT: "true"
           GH_TOKEN: ${{ github.token }}
           RELEASE_PUBLISH_RUN_ID: ${{ inputs.release_publish_run_id }}
+          EXPECTED_RUN_ATTEMPT: ${{ inputs.release_publish_run_attempt }}
           EXPECTED_WORKFLOW_BRANCH: ${{ inputs.release_publish_branch || github.ref_name }}
+          EXPECTED_WORKFLOW_FULL_REF: ${{ inputs.release_publish_full_ref }}
+          EXPECTED_WORKFLOW_SHA: ${{ inputs.release_publish_workflow_sha }}
         run: |
           set -euo pipefail
           if [[ -z "${RELEASE_PUBLISH_RUN_ID// }" ]]; then
@@ -303,7 +345,7 @@ jobs:
             echo "Direct Plugin ClawHub Release recovery with release_publish_run_id; relying on this workflow's clawhub-plugin-release environment approval."
           fi
           RUN_JSON="$(
-            gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RELEASE_PUBLISH_RUN_ID}" |
+            gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RELEASE_PUBLISH_RUN_ID}/attempts/${EXPECTED_RUN_ATTEMPT}" |
               jq '{
                 repository: .repository.full_name,
                 workflowName: .name,
@@ -374,7 +416,7 @@ jobs:
           CLAWHUB_REGISTRY: ${{ env.CLAWHUB_REGISTRY }}
           SOURCE_REPO: ${{ github.repository }}
           SOURCE_COMMIT: ${{ needs.preview_plugins_clawhub.outputs.ref_revision }}
-          SOURCE_REF: ${{ github.ref }}
+          SOURCE_REF: ${{ inputs.release_tag != '' && format('refs/tags/{0}', inputs.release_tag) || github.ref }}
           PACKAGE_TAG: ${{ matrix.plugin.publishTag }}
           PACKAGE_DIR: ${{ matrix.plugin.packageDir }}
           OPENCLAW_CLAWHUB_PACK_OUTPUT_DIR: ${{ runner.temp }}/clawhub-package-artifact
@@ -423,7 +465,7 @@ jobs:
       tags: ${{ matrix.plugin.publishTag }}
       source_repo: ${{ github.repository }}
       source_commit: ${{ needs.preview_plugins_clawhub.outputs.ref_revision }}
-      source_ref: ${{ github.ref }}
+      source_ref: ${{ inputs.release_tag != '' && format('refs/tags/{0}', inputs.release_tag) || github.ref }}
       source_path: ${{ matrix.plugin.packageDir }}
       inspector_artifact_name: ${{ matrix.plugin.artifactName }}-inspector
       publish_json_artifact_name: ${{ matrix.plugin.artifactName }}-publish-json

--- a/.github/workflows/plugin-npm-release.yml
+++ b/.github/workflows/plugin-npm-release.yml
@@ -65,6 +65,11 @@ on:
         required: false
         default: ""
         type: string
+      release_publish_full_ref:
+        description: Full ref of the approving OpenClaw Release Publish workflow run
+        required: false
+        default: ""
+        type: string
       preflight_only:
         description: Prepare and verify immutable plugin npm artifacts without publishing
         required: true
@@ -1156,6 +1161,8 @@ jobs:
           PACKAGE_VERSION: ${{ matrix.plugin.version }}
           PUBLISH_TAG: ${{ matrix.plugin.publishTag }}
           RELEASE_PUBLISH_PARENT_STATE_POLICY: ${{ inputs.release_publish_run_id != '' && (github.actor == 'github-actions[bot]' && 'active' || 'manual-recovery') || '' }}
+          RELEASE_PUBLISH_REF: ${{ inputs.release_publish_branch }}
+          RELEASE_PUBLISH_FULL_REF: ${{ inputs.release_publish_full_ref }}
           RELEASE_PUBLISH_RUN_ATTEMPT: ${{ inputs.release_publish_run_attempt }}
           RELEASE_PUBLISH_RUN_ID: ${{ inputs.release_publish_run_id }}
           TARGET_SHA: ${{ needs.preview_plugins_npm.outputs.ref_revision }}
@@ -1223,6 +1230,8 @@ jobs:
               --workflow-sha "$WORKFLOW_SHA" \
               --release-publish-run-id "$RELEASE_PUBLISH_RUN_ID" \
               --release-publish-run-attempt "$RELEASE_PUBLISH_RUN_ATTEMPT" \
+              --release-publish-ref "$RELEASE_PUBLISH_REF" \
+              --release-publish-full-ref "$RELEASE_PUBLISH_FULL_REF" \
               --release-publish-parent-state-policy "$RELEASE_PUBLISH_PARENT_STATE_POLICY"
           fi
           artifact_id="$(jq -er '.id' "$artifact_metadata")"
@@ -1359,6 +1368,8 @@ jobs:
           OPENCLAW_PLUGIN_NPM_PUBLISH_TAG: ${{ inputs.npm_dist_tag == 'extended-stable' && inputs.npm_dist_tag || '' }}
           OPENCLAW_RELEASE_PUBLISH_RUN_ID: ${{ inputs.release_publish_run_id }}
           OPENCLAW_RELEASE_PUBLISH_RUN_ATTEMPT: ${{ inputs.release_publish_run_attempt }}
+          OPENCLAW_RELEASE_PUBLISH_REF: ${{ inputs.release_publish_branch }}
+          OPENCLAW_RELEASE_PUBLISH_FULL_REF: ${{ inputs.release_publish_full_ref }}
           OPENCLAW_RELEASE_PUBLISH_PARENT_STATE_POLICY: ${{ inputs.release_publish_run_id != '' && (github.actor == 'github-actions[bot]' && 'active' || 'manual-recovery') || '' }}
           OPENCLAW_RELEASE_TOOLING_ALLOW_PREVALIDATED_REF: "true"
           OPENCLAW_RELEASE_TOOLING_FULL_REF: ${{ github.ref }}
@@ -1432,6 +1443,8 @@ jobs:
           PACKAGE_VERSION: ${{ steps.publication_evidence.outputs.package_version }}
           PUBLISH_TAG: ${{ steps.publication_evidence.outputs.publish_tag }}
           RELEASE_PUBLISH_PARENT_STATE_POLICY: ${{ inputs.release_publish_run_id != '' && (github.actor == 'github-actions[bot]' && 'active' || 'manual-recovery') || '' }}
+          RELEASE_PUBLISH_REF: ${{ inputs.release_publish_branch }}
+          RELEASE_PUBLISH_FULL_REF: ${{ inputs.release_publish_full_ref }}
           RELEASE_PUBLISH_RUN_ID: ${{ inputs.release_publish_run_id }}
           RELEASE_PUBLISH_RUN_ATTEMPT: ${{ inputs.release_publish_run_attempt }}
           TARBALL_PATH: ${{ steps.publication_evidence.outputs.tarball_path }}
@@ -1470,6 +1483,8 @@ jobs:
             --workflow-sha "$WORKFLOW_SHA" \
             --release-publish-run-id "$RELEASE_PUBLISH_RUN_ID" \
             --release-publish-run-attempt "$RELEASE_PUBLISH_RUN_ATTEMPT" \
+            --release-publish-ref "$RELEASE_PUBLISH_REF" \
+            --release-publish-full-ref "$RELEASE_PUBLISH_FULL_REF" \
             --release-publish-parent-state-policy "$RELEASE_PUBLISH_PARENT_STATE_POLICY"
           HOME="$publish_home" \
             NPM_CONFIG_GLOBALCONFIG=/dev/null \

--- a/scripts/lib/openclaw-release-clawhub-plan.ts
+++ b/scripts/lib/openclaw-release-clawhub-plan.ts
@@ -28,6 +28,7 @@ type OpenClawReleaseClawHubPlanArgs = {
   releaseTag: string;
   releaseSha: string;
   releasePublishBranch: string;
+  releasePublishFullRef: string;
   releasePublishRunAttempt: string;
   releasePublishRunId: string;
   pluginPublishScope: PluginReleaseSelectionMode;
@@ -138,6 +139,8 @@ function createDispatchTarget(params: {
   packages: readonly string[];
   releasePublishRunId: string;
   releasePublishBranch: string;
+  releasePublishFullRef?: string;
+  releasePublishWorkflowSha?: string;
   includePublishScope: boolean;
   bootstrapWorkflowSha?: string;
   releaseTag?: string;
@@ -169,6 +172,12 @@ function createDispatchTarget(params: {
       ...(params.releaseTag ? { release_tag: params.releaseTag } : {}),
       ...(params.releasePublishRunAttempt
         ? { release_publish_run_attempt: params.releasePublishRunAttempt }
+        : {}),
+      ...(params.releasePublishFullRef
+        ? { release_publish_full_ref: params.releasePublishFullRef }
+        : {}),
+      ...(params.releasePublishWorkflowSha
+        ? { release_publish_workflow_sha: params.releasePublishWorkflowSha }
         : {}),
       plugins,
       release_publish_run_id: params.releasePublishRunId,
@@ -239,6 +248,7 @@ export function parseOpenClawReleaseClawHubPlanArgs(
   let bootstrapWorkflowRef: string | undefined;
   let bootstrapWorkflowSha: string | undefined;
   let releasePublishBranch: string | undefined;
+  let releasePublishFullRef: string | undefined;
   let releasePublishRunAttempt: string | undefined;
   let releasePublishRunId: string | undefined;
   let pluginPublishScope: PluginReleaseSelectionMode | undefined;
@@ -271,6 +281,9 @@ export function parseOpenClawReleaseClawHubPlanArgs(
         break;
       case "--release-publish-branch":
         releasePublishBranch = next();
+        break;
+      case "--release-publish-full-ref":
+        releasePublishFullRef = next();
         break;
       case "--release-publish-run-attempt":
         releasePublishRunAttempt = next();
@@ -307,6 +320,7 @@ export function parseOpenClawReleaseClawHubPlanArgs(
     releaseTag: requireArg(releaseTag, "--release-tag"),
     releaseSha: requireCommitSha(releaseSha, "--release-sha"),
     releasePublishBranch: requireArg(releasePublishBranch, "--release-publish-branch"),
+    releasePublishFullRef: requireArg(releasePublishFullRef, "--release-publish-full-ref"),
     releasePublishRunAttempt: requirePositiveInteger(
       releasePublishRunAttempt,
       "--release-publish-run-attempt",
@@ -330,6 +344,7 @@ export async function buildOpenClawReleaseClawHubPlan(
   const releaseTag = requireArg(args.releaseTag, "releaseTag");
   const releaseSha = requireCommitSha(args.releaseSha, "releaseSha");
   const releasePublishBranch = requireArg(args.releasePublishBranch, "releasePublishBranch");
+  const releasePublishFullRef = requireArg(args.releasePublishFullRef, "releasePublishFullRef");
   const releasePublishRunAttempt = requirePositiveInteger(
     args.releasePublishRunAttempt,
     "releasePublishRunAttempt",
@@ -353,15 +368,20 @@ export async function buildOpenClawReleaseClawHubPlan(
 
   return {
     bootstrapWorkflowSha,
-    clawHubWorkflowRef: releaseTag,
+    clawHubWorkflowRef: bootstrapWorkflowRef,
     releasePublishBranch,
     normal: createDispatchTarget({
       workflow: "plugin-clawhub-release.yml",
-      ref: releaseTag,
+      ref: bootstrapWorkflowRef,
       packages: normalPackages,
       releasePublishRunId,
       releasePublishBranch,
       includePublishScope: true,
+      releasePublishFullRef,
+      releasePublishWorkflowSha: bootstrapWorkflowSha,
+      releaseTag,
+      releasePublishRunAttempt,
+      targetRef: releaseSha,
     }),
     bootstrap: createDispatchTarget({
       workflow: "plugin-clawhub-new.yml",
@@ -384,7 +404,7 @@ export async function buildOpenClawReleaseClawHubPlan(
       missingTrustedPlugins: joinPackageNames(missingTrustedPlugins),
     },
     verifier: {
-      clawHubWorkflowRef: releaseTag,
+      clawHubWorkflowRef: bootstrapWorkflowRef,
     },
   };
 }

--- a/scripts/plugin-npm-publish.sh
+++ b/scripts/plugin-npm-publish.sh
@@ -184,6 +184,8 @@ verify_release_tooling_identity() {
     --workflow-sha "${OPENCLAW_RELEASE_TOOLING_SHA:-}"
     --release-publish-run-id "${OPENCLAW_RELEASE_PUBLISH_RUN_ID:-}"
     --release-publish-run-attempt "${OPENCLAW_RELEASE_PUBLISH_RUN_ATTEMPT:-}"
+    --release-publish-ref "${OPENCLAW_RELEASE_PUBLISH_REF:-}"
+    --release-publish-full-ref "${OPENCLAW_RELEASE_PUBLISH_FULL_REF:-}"
     --release-publish-parent-state-policy "${OPENCLAW_RELEASE_PUBLISH_PARENT_STATE_POLICY:-}"
   )
   if [[ "${OPENCLAW_RELEASE_TOOLING_ALLOW_PREVALIDATED_REF:-}" == "true" ]]; then

--- a/scripts/release-tooling-identity.d.mts
+++ b/scripts/release-tooling-identity.d.mts
@@ -30,7 +30,9 @@ export function validateReleaseToolingIdentity(
 export function verifyReleaseToolingIdentity(
   input: ReleaseToolingIdentityInput & {
     repository: string;
+    releasePublishFullRef?: string;
     releasePublishParentStatePolicy?: "active" | "active-or-success" | "manual-recovery";
+    releasePublishRef?: string;
     releasePublishRunAttempt?: string;
     releasePublishRunId?: string;
     runGh?: (args: string[]) => string;
@@ -39,7 +41,9 @@ export function verifyReleaseToolingIdentity(
 
 export function validateReleasePublishParentRun(input: {
   identity: Pick<ReleaseToolingIdentity, "fullRef" | "ref" | "sha">;
+  releasePublishFullRef: string;
   releasePublishParentStatePolicy: "active" | "active-or-success" | "manual-recovery";
+  releasePublishRef: string;
   releasePublishRunAttempt: string;
   releasePublishRunId: string;
   repository: string;

--- a/scripts/release-tooling-identity.mjs
+++ b/scripts/release-tooling-identity.mjs
@@ -208,7 +208,9 @@ export function validateReleaseToolingIdentity({
 
 export function validateReleasePublishParentRun({
   identity,
+  releasePublishFullRef,
   releasePublishParentStatePolicy,
+  releasePublishRef,
   releasePublishRunAttempt,
   releasePublishRunId,
   repository,
@@ -226,11 +228,22 @@ export function validateReleasePublishParentRun({
   if (!RELEASE_PUBLISH_PARENT_STATE_POLICIES.has(parentStatePolicy)) {
     fail(`release publish parent state policy ${parentStatePolicy} is not supported.`);
   }
+  const parentRef = requiredString(releasePublishRef, "release publish ref");
+  const parentFullRef = requiredString(releasePublishFullRef, "release publish full ref");
+  const parentProtectedMatch = RELEASE_PUBLISH_REF_PATTERN.exec(parentRef);
+  const parentDirectRoute =
+    parentFullRef === `refs/heads/${parentRef}` && DIRECT_WORKFLOW_REF_PATTERN.test(parentRef);
+  const parentProtectedRoute =
+    parentFullRef === `refs/tags/${parentRef}` &&
+    parentProtectedMatch?.[1] === identity.sha.slice(0, 12);
+  if (!parentDirectRoute && !parentProtectedRoute) {
+    fail("release publish parent ref is not a trusted direct or exact protected-tag route.");
+  }
   const normalizedRepository = requireRepository(repository);
   const [workflowPath, workflowFullRef] = String(run?.path ?? "").split("@", 2);
   const expected = {
     event: "workflow_dispatch",
-    headBranch: identity.ref,
+    headBranch: parentRef,
     headSha: identity.sha,
     repository: normalizedRepository,
     runAttempt: Number(runAttempt),
@@ -251,7 +264,7 @@ export function validateReleasePublishParentRun({
       fail(`release publish parent run ${key} does not match the trusted tooling identity.`);
     }
   }
-  if (workflowFullRef && workflowFullRef !== identity.fullRef) {
+  if (workflowFullRef && workflowFullRef !== parentFullRef) {
     fail("release publish parent run workflow full ref does not match trusted tooling.");
   }
   const active = run?.status === "in_progress" && !run?.conclusion;
@@ -288,7 +301,9 @@ function runReleaseToolingGh(args) {
 
 export function verifyReleaseToolingIdentity({
   allowPrevalidatedRef = false,
+  releasePublishFullRef,
   releasePublishParentStatePolicy,
+  releasePublishRef,
   releasePublishRunAttempt,
   releasePublishRunId,
   repository,
@@ -329,7 +344,9 @@ export function verifyReleaseToolingIdentity({
     });
     validateParentRunIfRequested({
       identity: validated,
+      releasePublishFullRef,
       releasePublishParentStatePolicy,
+      releasePublishRef,
       releasePublishRunAttempt,
       releasePublishRunId,
       repository: normalizedRepository,
@@ -362,7 +379,9 @@ export function verifyReleaseToolingIdentity({
     });
     validateParentRunIfRequested({
       identity: validated,
+      releasePublishFullRef,
       releasePublishParentStatePolicy,
+      releasePublishRef,
       releasePublishRunAttempt,
       releasePublishRunId,
       repository: normalizedRepository,
@@ -396,7 +415,9 @@ export function verifyReleaseToolingIdentity({
   });
   validateParentRunIfRequested({
     identity: validated,
+    releasePublishFullRef,
     releasePublishParentStatePolicy,
+    releasePublishRef,
     releasePublishRunAttempt,
     releasePublishRunId,
     repository: normalizedRepository,
@@ -407,17 +428,33 @@ export function verifyReleaseToolingIdentity({
 
 function validateParentRunIfRequested({
   identity,
+  releasePublishFullRef,
   releasePublishParentStatePolicy,
+  releasePublishRef,
   releasePublishRunAttempt,
   releasePublishRunId,
   repository,
   runGh,
 }) {
-  if (!releasePublishRunId && !releasePublishRunAttempt && !releasePublishParentStatePolicy) {
+  if (
+    !releasePublishRunId &&
+    !releasePublishRunAttempt &&
+    !releasePublishParentStatePolicy &&
+    !releasePublishRef &&
+    !releasePublishFullRef
+  ) {
     return;
   }
-  if (!releasePublishRunId || !releasePublishRunAttempt || !releasePublishParentStatePolicy) {
-    fail("release publish run id, attempt, and parent state policy must be provided together.");
+  if (
+    !releasePublishRunId ||
+    !releasePublishRunAttempt ||
+    !releasePublishParentStatePolicy ||
+    !releasePublishRef ||
+    !releasePublishFullRef
+  ) {
+    fail(
+      "release publish run id, attempt, ref, full ref, and parent state policy must be provided together.",
+    );
   }
   let run;
   try {
@@ -430,7 +467,9 @@ function validateParentRunIfRequested({
   }
   validateReleasePublishParentRun({
     identity,
+    releasePublishFullRef,
     releasePublishParentStatePolicy,
+    releasePublishRef,
     releasePublishRunAttempt,
     releasePublishRunId,
     repository,
@@ -444,6 +483,8 @@ function parseArgs(argv) {
     command: "",
     releasePublishRunAttempt: "",
     releasePublishRunId: "",
+    releasePublishRef: "",
+    releasePublishFullRef: "",
     releasePublishParentStatePolicy: "",
     repository: "",
     requestedIdentityJson: "",
@@ -467,6 +508,10 @@ function parseArgs(argv) {
       options.releasePublishRunId = value;
     } else if (arg === "--release-publish-run-attempt") {
       options.releasePublishRunAttempt = value;
+    } else if (arg === "--release-publish-ref") {
+      options.releasePublishRef = value;
+    } else if (arg === "--release-publish-full-ref") {
+      options.releasePublishFullRef = value;
     } else if (arg === "--release-publish-parent-state-policy") {
       options.releasePublishParentStatePolicy = value;
     } else if (arg === "--repository") {
@@ -496,7 +541,9 @@ function main(argv = process.argv.slice(2)) {
     const protectedMatch = RELEASE_PUBLISH_REF_PATTERN.exec(identity.ref);
     verifyReleaseToolingIdentity({
       allowPrevalidatedRef: identity.ref !== "main" && !protectedMatch,
+      releasePublishFullRef: options.releasePublishFullRef,
       releasePublishParentStatePolicy: options.releasePublishParentStatePolicy,
+      releasePublishRef: options.releasePublishRef,
       releasePublishRunAttempt: options.releasePublishRunAttempt,
       releasePublishRunId: options.releasePublishRunId,
       repository: options.repository,

--- a/test/plugin-clawhub-release.test.ts
+++ b/test/plugin-clawhub-release.test.ts
@@ -1283,7 +1283,7 @@ describe("collectPluginClawHubReleasePlan", () => {
 });
 
 describe("buildOpenClawReleaseClawHubPlan", () => {
-  it("emits a dispatch plan that keeps ClawHub children on the release tag", async () => {
+  it("emits a dispatch plan that keeps release bytes separate from protected tooling", async () => {
     const repoDir = createTempPluginRepo({
       extraExtensionIds: ["demo-two", "demo-three"],
     });
@@ -1337,6 +1337,7 @@ describe("buildOpenClawReleaseClawHubPlan", () => {
         releaseTag: "v2026.4.1-beta.1",
         releaseSha: "a".repeat(40),
         releasePublishBranch: "main",
+        releasePublishFullRef: "refs/heads/main",
         releasePublishRunAttempt: "2",
         releasePublishRunId: "12345",
         pluginPublishScope: "all-publishable",
@@ -1349,19 +1350,24 @@ describe("buildOpenClawReleaseClawHubPlan", () => {
       },
     );
 
-    expect(plan.clawHubWorkflowRef).toBe("v2026.4.1-beta.1");
+    expect(plan.clawHubWorkflowRef).toBe(`release-publish/${"d".repeat(12)}-12345`);
     expect(plan.bootstrapWorkflowSha).toBe("d".repeat(40));
     expect(plan.releasePublishBranch).toBe("main");
     expect(plan.normal).toEqual({
       workflow: "plugin-clawhub-release.yml",
-      ref: "v2026.4.1-beta.1",
+      ref: `release-publish/${"d".repeat(12)}-12345`,
       shouldDispatch: true,
       packages: ["@openclaw/demo-plugin"],
       inputs: {
         publish_scope: "selected",
+        ref: "a".repeat(40),
+        release_tag: "v2026.4.1-beta.1",
         plugins: "@openclaw/demo-plugin",
+        release_publish_full_ref: "refs/heads/main",
+        release_publish_run_attempt: "2",
         release_publish_run_id: "12345",
         release_publish_branch: "main",
+        release_publish_workflow_sha: "d".repeat(40),
       },
     });
     expect(plan.bootstrap).toEqual({
@@ -1389,7 +1395,7 @@ describe("buildOpenClawReleaseClawHubPlan", () => {
       missingTrustedPlugins: "@openclaw/demo-three",
     });
     expect(plan.verifier).toEqual({
-      clawHubWorkflowRef: "v2026.4.1-beta.1",
+      clawHubWorkflowRef: `release-publish/${"d".repeat(12)}-12345`,
     });
   });
 
@@ -1425,6 +1431,7 @@ describe("buildOpenClawReleaseClawHubPlan", () => {
         releaseTag: "v2026.4.1-beta.1",
         releaseSha: "b".repeat(40),
         releasePublishBranch: "release/2026.4.1",
+        releasePublishFullRef: "refs/heads/release/2026.4.1",
         releasePublishRunAttempt: "3",
         releasePublishRunId: "12345",
         pluginPublishScope: "selected",
@@ -1522,6 +1529,8 @@ describe("buildOpenClawReleaseClawHubPlan", () => {
       "c".repeat(40),
       "--release-publish-branch",
       "main",
+      "--release-publish-full-ref",
+      "refs/heads/main",
       "--release-publish-run-id",
       "12345",
     ];

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -5860,13 +5860,13 @@ server.listen(0, "127.0.0.1", () => {
   });
 
   it.each([
-    [".github/workflows/mantis-discord-smoke.yml"],
-    [".github/workflows/plugin-clawhub-release.yml"],
-  ])("bounds %s git fetches", (workflowPath) => {
+    [".github/workflows/mantis-discord-smoke.yml", 2],
+    [".github/workflows/plugin-clawhub-release.yml", 3],
+  ])("bounds %s git fetches", (workflowPath, expectedFetchCount) => {
     const source = readFileSync(workflowPath, "utf8");
     const gitFetchLines = source.split("\n").filter((line) => line.includes("git fetch"));
 
-    expect(gitFetchLines, workflowPath).toHaveLength(2);
+    expect(gitFetchLines, workflowPath).toHaveLength(expectedFetchCount);
     expect(
       gitFetchLines.every((line) =>
         line.trimStart().startsWith("timeout --signal=TERM --kill-after=10s 120s git fetch"),

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2037,6 +2037,10 @@ describe("package acceptance workflow", () => {
     expect(evidenceStep.env?.RELEASE_PUBLISH_RUN_ATTEMPT).toBe(
       "${{ inputs.release_publish_run_attempt }}",
     );
+    expect(evidenceStep.env?.RELEASE_PUBLISH_REF).toBe("${{ inputs.release_publish_branch }}");
+    expect(evidenceStep.env?.RELEASE_PUBLISH_FULL_REF).toBe(
+      "${{ inputs.release_publish_full_ref }}",
+    );
     expect(evidenceStep.env?.RELEASE_PUBLISH_PARENT_STATE_POLICY).toBe(
       "${{ inputs.release_publish_run_id != '' && (github.actor == 'github-actions[bot]' && 'active' || 'manual-recovery') || '' }}",
     );
@@ -2048,6 +2052,8 @@ describe("package acceptance workflow", () => {
     expect(evidenceStep.run).toContain(
       '--release-publish-run-attempt "$RELEASE_PUBLISH_RUN_ATTEMPT"',
     );
+    expect(evidenceStep.run).toContain('--release-publish-ref "$RELEASE_PUBLISH_REF"');
+    expect(evidenceStep.run).toContain('--release-publish-full-ref "$RELEASE_PUBLISH_FULL_REF"');
     expect(evidenceStep.run).toContain(
       '--release-publish-parent-state-policy "$RELEASE_PUBLISH_PARENT_STATE_POLICY"',
     );
@@ -2065,6 +2071,8 @@ describe("package acceptance workflow", () => {
         "${{ inputs.release_publish_run_id != '' && (github.actor == 'github-actions[bot]' && 'active' || 'manual-recovery') || '' }}",
       RELEASE_PUBLISH_RUN_ATTEMPT: "${{ inputs.release_publish_run_attempt }}",
       RELEASE_PUBLISH_RUN_ID: "${{ inputs.release_publish_run_id }}",
+      RELEASE_PUBLISH_REF: "${{ inputs.release_publish_branch }}",
+      RELEASE_PUBLISH_FULL_REF: "${{ inputs.release_publish_full_ref }}",
       WORKFLOW_FULL_REF: "${{ github.ref }}",
       WORKFLOW_REF: "${{ github.ref_name }}",
       WORKFLOW_SHA: "${{ github.workflow_sha }}",
@@ -2076,6 +2084,8 @@ describe("package acceptance workflow", () => {
     expect(corePublish.run).toContain(
       '--release-publish-run-attempt "$RELEASE_PUBLISH_RUN_ATTEMPT"',
     );
+    expect(corePublish.run).toContain('--release-publish-ref "$RELEASE_PUBLISH_REF"');
+    expect(corePublish.run).toContain('--release-publish-full-ref "$RELEASE_PUBLISH_FULL_REF"');
     expect(corePublish.run).toContain(
       '--release-publish-parent-state-policy "$RELEASE_PUBLISH_PARENT_STATE_POLICY"',
     );
@@ -2092,6 +2102,8 @@ describe("package acceptance workflow", () => {
       GH_TOKEN: "${{ github.token }}",
       OPENCLAW_RELEASE_PUBLISH_RUN_ATTEMPT: "${{ inputs.release_publish_run_attempt }}",
       OPENCLAW_RELEASE_PUBLISH_RUN_ID: "${{ inputs.release_publish_run_id }}",
+      OPENCLAW_RELEASE_PUBLISH_REF: "${{ inputs.release_publish_branch }}",
+      OPENCLAW_RELEASE_PUBLISH_FULL_REF: "${{ inputs.release_publish_full_ref }}",
       OPENCLAW_RELEASE_PUBLISH_PARENT_STATE_POLICY:
         "${{ inputs.release_publish_run_id != '' && (github.actor == 'github-actions[bot]' && 'active' || 'manual-recovery') || '' }}",
       OPENCLAW_RELEASE_TOOLING_ALLOW_PREVALIDATED_REF: "true",
@@ -2109,6 +2121,8 @@ describe("package acceptance workflow", () => {
         "${{ inputs.release_publish_run_id != '' && (github.actor == 'github-actions[bot]' && 'active' || 'manual-recovery') || '' }}",
       RELEASE_PUBLISH_RUN_ATTEMPT: "${{ inputs.release_publish_run_attempt }}",
       RELEASE_PUBLISH_RUN_ID: "${{ inputs.release_publish_run_id }}",
+      RELEASE_PUBLISH_REF: "${{ inputs.release_publish_branch }}",
+      RELEASE_PUBLISH_FULL_REF: "${{ inputs.release_publish_full_ref }}",
       WORKFLOW_FULL_REF: "${{ github.ref }}",
       WORKFLOW_REF: "${{ github.ref_name }}",
       WORKFLOW_SHA: "${{ github.workflow_sha }}",
@@ -2122,8 +2136,16 @@ describe("package acceptance workflow", () => {
     expect(bootstrapPublish.run).toContain(
       '--release-publish-parent-state-policy "$RELEASE_PUBLISH_PARENT_STATE_POLICY"',
     );
+    expect(bootstrapPublish.run).toContain('--release-publish-ref "$RELEASE_PUBLISH_REF"');
+    expect(bootstrapPublish.run).toContain(
+      '--release-publish-full-ref "$RELEASE_PUBLISH_FULL_REF"',
+    );
 
     const pluginWrapper = readFileSync("scripts/plugin-npm-publish.sh", "utf8");
+    expect(pluginWrapper).toContain('--release-publish-ref "${OPENCLAW_RELEASE_PUBLISH_REF:-}"');
+    expect(pluginWrapper).toContain(
+      '--release-publish-full-ref "${OPENCLAW_RELEASE_PUBLISH_FULL_REF:-}"',
+    );
     expect(pluginWrapper).toContain(
       '--release-publish-parent-state-policy "${OPENCLAW_RELEASE_PUBLISH_PARENT_STATE_POLICY:-}"',
     );
@@ -2210,6 +2232,7 @@ describe("package acceptance workflow", () => {
 
     expect(publishOrchestration.env?.PARENT_WORKFLOW_SHA).toBe("${{ github.sha }}");
     expect(publishOrchestration.env?.PARENT_WORKFLOW_BRANCH).toBe("${{ github.ref_name }}");
+    expect(publishOrchestration.env?.PARENT_WORKFLOW_FULL_REF).toBe("${{ github.ref }}");
     expect(publishOrchestration.env?.CHILD_WORKFLOW_REF).toBe(
       "${{ steps.clawhub_plan.outputs.child_workflow_ref }}",
     );
@@ -2227,6 +2250,7 @@ describe("package acceptance workflow", () => {
       'wait_for_run plugin-npm-release.yml "${plugin_npm_run_id}" "${PARENT_WORKFLOW_SHA}"',
       'wait_for_run_background openclaw-npm-release.yml "${openclaw_npm_run_id}" "${PARENT_WORKFLOW_SHA}"',
       '-f release_publish_branch="${PARENT_WORKFLOW_BRANCH}"',
+      '-f release_publish_full_ref="${PARENT_WORKFLOW_FULL_REF}"',
       "plugin-clawhub-release.yml: detached; approval and publish not awaited",
       "plugin-clawhub-new.yml: detached; approvals and bootstrap not awaited",
     ]);
@@ -7664,6 +7688,9 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
       expect(
         readWorkflow(workflowPath).on?.workflow_dispatch?.inputs?.release_publish_branch,
       ).toBeDefined();
+      expect(
+        readWorkflow(workflowPath).on?.workflow_dispatch?.inputs?.release_publish_full_ref,
+      ).toBeDefined();
     }
 
     for (const [workflowPath, publishJobName, environment] of [
@@ -7688,6 +7715,23 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
     );
     const clawHubPublish = workflowJob(PLUGIN_CLAWHUB_RELEASE_WORKFLOW, "publish_plugins_clawhub");
     expect(clawHubAuthorization.run).toContain("repository: .repository.full_name");
+    expect(clawHubAuthorization.run).toContain(
+      "actions/runs/${RELEASE_PUBLISH_RUN_ID}/attempts/${EXPECTED_RUN_ATTEMPT}",
+    );
+    expect(clawHubAuthorization.run).toContain("path,");
+    expect(clawHubAuthorization.run).toContain("runAttempt: .run_attempt");
+    expect(clawHubAuthorization.run).not.toContain("gh run view");
+    expect(clawHubAuthorization.env).toMatchObject({
+      EXPECTED_RUN_ATTEMPT: "${{ inputs.release_publish_run_attempt }}",
+      EXPECTED_WORKFLOW_FULL_REF: "${{ inputs.release_publish_full_ref }}",
+      EXPECTED_WORKFLOW_SHA: "${{ inputs.release_publish_workflow_sha }}",
+    });
+    const clawHubInputs = readWorkflow(PLUGIN_CLAWHUB_RELEASE_WORKFLOW).on?.workflow_dispatch
+      ?.inputs;
+    expect(clawHubInputs?.release_tag).toBeDefined();
+    expect(clawHubInputs?.release_publish_run_attempt).toBeDefined();
+    expect(clawHubInputs?.release_publish_full_ref).toBeDefined();
+    expect(clawHubInputs?.release_publish_workflow_sha).toBeDefined();
     expect(clawHubApproval.environment).toBe("clawhub-plugin-release");
     expect(clawHubPublish.needs).toContain("approve_plugins_clawhub_release");
 
@@ -7784,23 +7828,22 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
     expect(
       readWorkflow(PLUGIN_CLAWHUB_RELEASE_WORKFLOW).on?.workflow_dispatch?.inputs
         ?.release_publish_run_attempt,
-    ).toBeUndefined();
+    ).toBeDefined();
     expect(
       readWorkflow(PLUGIN_CLAWHUB_RELEASE_WORKFLOW).on?.workflow_dispatch?.inputs
         ?.release_publish_full_ref,
-    ).toBeUndefined();
+    ).toBeDefined();
     expect(
       readWorkflow(PLUGIN_CLAWHUB_RELEASE_WORKFLOW).on?.workflow_dispatch?.inputs
         ?.release_publish_workflow_sha,
-    ).toBeUndefined();
+    ).toBeDefined();
     expect(clawHubPreview.outputs?.trusted_tooling_identity_json).toBeUndefined();
     const publishOrchestration = workflowStep(releasePublishJob, "Dispatch publish workflows");
-    expect(publishOrchestration.env?.PARENT_WORKFLOW_FULL_REF).toBeUndefined();
+    expect(publishOrchestration.env?.PARENT_WORKFLOW_FULL_REF).toBe("${{ github.ref }}");
     expect(publishOrchestration.run).toContain(
-      'wait_for_run_background plugin-clawhub-release.yml "${plugin_clawhub_run_id}" "${TARGET_SHA}"',
+      'wait_for_run_background plugin-clawhub-release.yml "${plugin_clawhub_run_id}" "${PARENT_WORKFLOW_SHA}"',
     );
-    expect(publishOrchestration.run).not.toContain("release_publish_full_ref");
-    expect(publishOrchestration.run).not.toContain("release_publish_workflow_sha");
+    expect(publishOrchestration.run).toContain("release_publish_full_ref");
     expect(clawHubBootstrapValidation.environment).toBe("clawhub-plugin-bootstrap");
     expect(clawHubBootstrapPublish.environment).toBe("clawhub-plugin-bootstrap");
 

--- a/test/scripts/release-tooling-identity.test.ts
+++ b/test/scripts/release-tooling-identity.test.ts
@@ -276,9 +276,9 @@ describe("release tooling identity", () => {
         id: Number(PARENT_RUN_ID),
         run_attempt: Number(PARENT_RUN_ATTEMPT),
         repository: { full_name: "openclaw/openclaw" },
-        path: `.github/workflows/openclaw-release-publish.yml@${FULL_REF}`,
+        path: ".github/workflows/openclaw-release-publish.yml@refs/heads/main",
         event: "workflow_dispatch",
-        head_branch: REF,
+        head_branch: "main",
         head_sha: SHA,
         status: "in_progress",
         conclusion: null,
@@ -288,7 +288,9 @@ describe("release tooling identity", () => {
     expect(
       verifyReleaseToolingIdentity({
         ...protectedIdentity(),
+        releasePublishFullRef: "refs/heads/main",
         releasePublishParentStatePolicy: "active",
+        releasePublishRef: "main",
         releasePublishRunAttempt: PARENT_RUN_ATTEMPT,
         releasePublishRunId: PARENT_RUN_ID,
         runGh,
@@ -319,7 +321,9 @@ describe("release tooling identity", () => {
       const validate = () =>
         validateReleasePublishParentRun({
           identity: { ref: REF, fullRef: FULL_REF, sha: SHA },
+          releasePublishFullRef: "refs/heads/main",
           releasePublishParentStatePolicy,
+          releasePublishRef: "main",
           releasePublishRunAttempt: PARENT_RUN_ATTEMPT,
           releasePublishRunId: PARENT_RUN_ID,
           repository: "openclaw/openclaw",
@@ -327,9 +331,9 @@ describe("release tooling identity", () => {
             id: Number(PARENT_RUN_ID),
             run_attempt: Number(PARENT_RUN_ATTEMPT),
             repository: { full_name: "openclaw/openclaw" },
-            path: `.github/workflows/openclaw-release-publish.yml@${FULL_REF}`,
+            path: ".github/workflows/openclaw-release-publish.yml@refs/heads/main",
             event: "workflow_dispatch",
-            head_branch: REF,
+            head_branch: "main",
             head_sha: SHA,
             status,
             conclusion,
@@ -356,6 +360,35 @@ describe("release tooling identity", () => {
             object: { sha: SHA, type: "commit" },
           }),
       }),
-    ).toThrow("run id, attempt, and parent state policy must be provided together");
+    ).toThrow("run id, attempt, ref, full ref, and parent state policy must be provided together");
+  });
+
+  it.each([
+    ["wrong parent branch", "release/2026.8.1", "refs/heads/main"],
+    ["wrong parent full ref", "main", "refs/heads/release/2026.8.1"],
+    ["untrusted parent ref", "feature/release", "refs/heads/feature/release"],
+  ])("rejects %s independently of protected child identity", (_label, parentRef, parentFullRef) => {
+    expect(() =>
+      validateReleasePublishParentRun({
+        identity: { ref: REF, fullRef: FULL_REF, sha: SHA },
+        releasePublishFullRef: parentFullRef,
+        releasePublishParentStatePolicy: "active",
+        releasePublishRef: parentRef,
+        releasePublishRunAttempt: PARENT_RUN_ATTEMPT,
+        releasePublishRunId: PARENT_RUN_ID,
+        repository: "openclaw/openclaw",
+        run: {
+          id: Number(PARENT_RUN_ID),
+          run_attempt: Number(PARENT_RUN_ATTEMPT),
+          repository: { full_name: "openclaw/openclaw" },
+          path: ".github/workflows/openclaw-release-publish.yml@refs/heads/main",
+          event: "workflow_dispatch",
+          head_branch: "main",
+          head_sha: SHA,
+          status: "in_progress",
+          conclusion: null,
+        },
+      }),
+    ).toThrow();
   });
 });

--- a/test/scripts/release-wrapper-scripts.test.ts
+++ b/test/scripts/release-wrapper-scripts.test.ts
@@ -99,6 +99,8 @@ describe("release wrapper scripts", () => {
         releaseSha,
         "--release-publish-branch",
         "main",
+        "--release-publish-full-ref",
+        "refs/heads/main",
         "--release-publish-run-attempt",
         "1",
         "--release-publish-run-id",
@@ -112,7 +114,7 @@ describe("release wrapper scripts", () => {
     expect(JSON.parse(plan.stdout)).toMatchObject({
       bootstrapWorkflowSha: "b".repeat(40),
       bootstrap: { ref: bootstrapWorkflowRef, shouldDispatch: false },
-      normal: { ref: "v2026.7.1-beta.3", shouldDispatch: false },
+      normal: { ref: bootstrapWorkflowRef, shouldDispatch: false },
     });
     expect(plan.stderr).not.toContain("old target planner invoked");
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an approved OpenClaw release publish could not publish npm plugins or ClawHub packages when the parent workflow ran from trusted `main` and its children ran from the required protected tooling tag.

The blocked beta publish is https://github.com/openclaw/openclaw/actions/runs/33183680823. Plugin npm child https://github.com/openclaw/openclaw/actions/runs/33184033831 rejected all publish jobs before mutation, and ClawHub child https://github.com/openclaw/openclaw/actions/runs/33184037025 rejected its incomplete parent-run payload.

## Why This Change Was Made

Publication now binds the approving parent run's branch and full ref separately from the child workflow's protected tooling ref while preserving the existing repository, workflow path, SHA, run ID, attempt, event, and state checks.

ClawHub publication runs trusted workflow code from the protected tooling tag, checks out the immutable release SHA, and requires the exact release tag to peel to that SHA. Its approval lookup now uses the canonical complete parent-run payload.

## User Impact

Release operators can resume an already-approved release without moving its public release tag or weakening protected child-workflow identity checks.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/release-tooling-identity.test.ts test/scripts/release-wrapper-scripts.test.ts test/scripts/package-acceptance-workflow.test.ts`: 242 passed
- `pnpm exec vitest run --config test/vitest/vitest.tooling.config.ts test/plugin-clawhub-release.test.ts -t 'buildOpenClawReleaseClawHubPlan'`: 5 passed
- `actionlint -shellcheck= -pyflakes= .github/workflows/openclaw-release-publish.yml .github/workflows/plugin-npm-release.yml .github/workflows/openclaw-npm-release.yml .github/workflows/plugin-clawhub-release.yml`: passed
- `node_modules/.bin/oxfmt --write --threads=1 <changed files>` and `git diff --check`: passed

The broader `plugin-clawhub-release.test.ts` shell integration cases require GNU `timeout`/`gtimeout`, which is unavailable on this macOS host; the changed plan and workflow contracts are covered by the focused tests above and exact-head CI.
