### PR TITLE
fix(telegram): stop silently dropping exec approval prompts when only a generic approval client is connected

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch-reply.ts
+++ b/extensions/telegram/src/bot-message-dispatch-reply.ts
@@ -54,7 +54,6 @@ import {
   resolveTelegramErrorPolicy,
   shouldSuppressTelegramError,
 } from "./error-policy.js";
-import { shouldSuppressLocalTelegramExecApprovalPrompt } from "./exec-approvals.js";
 import { createTelegramReasoningStepState } from "./reasoning-lane-coordinator.js";
 import { resolveTelegramTargetChatType } from "./targets.js";
 
@@ -237,16 +236,6 @@ export async function deliverReply(
   }
   const controls = resolvePayloadTelegramControls(turn, deduped);
   const effectivePayload = controls.payload;
-  if (
-    shouldSuppressLocalTelegramExecApprovalPrompt({
-      cfg: turn.cfg,
-      accountId: turn.context.route.accountId,
-      payload: effectivePayload,
-    })
-  ) {
-    turn.queuedFinal = true;
-    return await settleTerminalNoVisibleDelivery(turn, info);
-  }
   const telegramButtons = controls.buttons;
   const lanePayload =
     info.kind === "block" &&

--- a/extensions/telegram/src/bot-native-command-dispatch.delivery.test.ts
+++ b/extensions/telegram/src/bot-native-command-dispatch.delivery.test.ts
@@ -91,7 +91,7 @@ describe("Telegram native command dispatch delivery", () => {
     expect(deliveredPayload?.["channelData"]).toBeUndefined();
   });
 
-  it("suppresses local structured exec approval replies for native commands", async () => {
+  it("preserves local structured exec approval replies when no native route is active", async () => {
     replyMocks.dispatchReplyWithBufferedBlockDispatcher.mockImplementationOnce(
       async ({ dispatcherOptions }: DispatchReplyWithBufferedBlockDispatcherParams) => {
         await dispatcherOptions.deliver(
@@ -126,7 +126,13 @@ describe("Telegram native command dispatch delivery", () => {
     });
     await handler(createTelegramPrivateCommandContext());
 
-    expect(deliveryMocks.deliverReplies).not.toHaveBeenCalled();
+    expect(deliveryMocks.deliverReplies).toHaveBeenCalledTimes(1);
+    expect(
+      (firstMockArg(deliveryMocks.deliverReplies, "deliverReplies") as DeliverRepliesParams)
+        .replies[0],
+    ).toMatchObject({
+      text: expect.stringContaining("/approve 7f423fdc allow-once"),
+    });
   });
 
   it("does not emit the empty fallback when reply-payload hooks cancel a native reply", async () => {

--- a/extensions/telegram/src/bot-native-command-dispatch.ts
+++ b/extensions/telegram/src/bot-native-command-dispatch.ts
@@ -48,7 +48,6 @@ import {
   resolveTelegramConversationRoute,
   resolveTelegramTargetSession,
 } from "./conversation-route.js";
-import { shouldSuppressLocalTelegramExecApprovalPrompt } from "./exec-approvals.js";
 import {
   evaluateTelegramGroupBaseAccess,
   evaluateTelegramGroupPolicyAccess,
@@ -618,16 +617,6 @@ export async function dispatchTelegramBuiltinTurn(params: {
     },
     delivery: {
       deliverWithProviderMessageSending: async (payload, info) => {
-        if (
-          shouldSuppressLocalTelegramExecApprovalPrompt({
-            cfg: dispatch.runtimeCfg,
-            accountId: dispatch.route.accountId,
-            payload,
-          })
-        ) {
-          deliveryState.delivered = true;
-          return { visibleReplySent: false, suppression: { reason: "no_visible_result" } };
-        }
         const targetedPayload = payload.replyToId
           ? payload
           : { ...payload, replyToId: String(dispatch.msg.message_id) };

--- a/extensions/telegram/src/bot-native-command-plugins.test.ts
+++ b/extensions/telegram/src/bot-native-command-plugins.test.ts
@@ -449,7 +449,7 @@ describe("registerTelegramNativeCommands", () => {
     expect(replyAt(firstDeliverRepliesParams()).text).toBe("Command completed successfully");
   });
 
-  it("cleans up the progress placeholder when Telegram suppresses a local exec approval reply", async () => {
+  it("keeps the local exec approval reply when no native route is active", async () => {
     const { handler, sendMessage, deleteMessage } = registerPlugCommand({
       args: "now",
       command: {
@@ -481,9 +481,13 @@ describe("registerTelegramNativeCommands", () => {
     await handler(createPrivateCommandContext({ match: "now" }));
 
     expect(sendMessage).toHaveBeenCalledWith(100, "Working on it...", undefined);
-    expect(deleteMessage).toHaveBeenCalledWith(100, 999);
-    expect(editMessageTelegram).not.toHaveBeenCalled();
-    expect(deliverReplies).not.toHaveBeenCalled();
+    expect(editMessageTelegram).toHaveBeenCalledWith(
+      100,
+      999,
+      expect.stringContaining("/approve 7f423fdc allow-once"),
+      expect.any(Object),
+    );
+    expect(deleteMessage).not.toHaveBeenCalled();
   });
 
   it("sends plugin command error replies silently when silentErrorReplies is enabled", async () => {

--- a/extensions/telegram/src/bot-native-command-plugins.ts
+++ b/extensions/telegram/src/bot-native-command-plugins.ts
@@ -25,7 +25,6 @@ import {
 } from "./bot/helpers.js";
 import type { TelegramGetChat } from "./bot/types.js";
 import type { TelegramInlineButtons } from "./button-types.js";
-import { shouldSuppressLocalTelegramExecApprovalPrompt } from "./exec-approvals.js";
 import { buildInlineKeyboard } from "./inline-keyboard.js";
 import { recordSentMessage } from "./sent-message-cache.js";
 
@@ -234,13 +233,7 @@ export async function executeTelegramPluginCommand(
       messageThreadId: dispatch.threadSpec.id,
     }),
   );
-  const suppressReply =
-    shouldSuppressLocalTelegramExecApprovalPrompt({
-      cfg: dispatch.runtimeCfg,
-      accountId: dispatch.route.accountId,
-      payload: result,
-    }) || result.suppressReply === true;
-  if (suppressReply) {
+  if (result.suppressReply === true) {
     await cleanupTelegramProgressPlaceholder({
       bot: dispatch.bot,
       chatId: dispatch.chatId,

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -871,7 +871,7 @@ describe("dispatchTelegramMessage reply settlement", () => {
     await expect(bufferedSettlement).resolves.toEqual({ status: "rejected", error });
   });
 
-  it("keeps a suppressed exec-approval final in the fallback ledger", async () => {
+  it("delivers an exec-approval final when no native route is active", async () => {
     const telegramCfg = {
       execApprovals: { enabled: true, approvers: ["123"], target: "dm" as const },
     };
@@ -887,6 +887,7 @@ describe("dispatchTelegramMessage reply settlement", () => {
       }
       suppressedResult = await deliver(
         {
+          text: "Approval required. /approve req-1 allow-once",
           channelData: {
             execApproval: { approvalId: "req-1", approvalSlug: "req-1" },
           },
@@ -902,11 +903,8 @@ describe("dispatchTelegramMessage reply settlement", () => {
 
     await dispatchDirectTelegramTurn({ cfg, deliverReplies, telegramCfg });
 
-    expect(suppressedResult).toEqual({
-      visibleReplySent: false,
-      suppression: { reason: "no_visible_result" },
-    });
-    expect(deliverReplies).not.toHaveBeenCalled();
+    expect(suppressedResult).toEqual({ visibleReplySent: true });
+    expect(deliverReplies).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/extensions/telegram/src/channel.message-adapter.test.ts
+++ b/extensions/telegram/src/channel.message-adapter.test.ts
@@ -255,6 +255,39 @@ describe("telegram channel message adapter", () => {
     });
   });
 
+  it("keeps local exec approval prompts without an active native route", () => {
+    const suppress = telegramPlugin.outbound?.shouldSuppressLocalPayloadPrompt;
+    const cfg = {
+      channels: {
+        telegram: {
+          botToken: "tok",
+          execApprovals: { enabled: true, approvers: ["123"] },
+        },
+      },
+    } as never;
+    const payload = {
+      text: "Approval required. /approve req-1 allow-once",
+      channelData: {
+        execApproval: { approvalId: "req-1", approvalSlug: "req-1" },
+      },
+    };
+
+    expect(
+      suppress?.({
+        cfg,
+        payload,
+        hint: { kind: "approval-pending", approvalKind: "exec", nativeRouteActive: false },
+      }),
+    ).toBe(false);
+    expect(
+      suppress?.({
+        cfg,
+        payload,
+        hint: { kind: "approval-pending", approvalKind: "exec", nativeRouteActive: true },
+      }),
+    ).toBe(true);
+  });
+
   it("keeps implicit first replies on the first delivered payload media", async () => {
     const adapter = requireTelegramMessageAdapter();
     sendMessageTelegramMock

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -221,11 +221,12 @@ function resolveTelegramTokenHelper() {
 const telegramChannelOutbound = createTelegramOutboundAdapter({
   resolveSend: resolveTelegramSend,
   loadSendModule: loadTelegramSendModule,
-  shouldSuppressLocalPayloadPrompt: ({ cfg, accountId, payload }) =>
+  shouldSuppressLocalPayloadPrompt: ({ cfg, accountId, payload, hint }) =>
     shouldSuppressLocalTelegramExecApprovalPrompt({
       cfg,
       accountId,
       payload,
+      hint,
     }),
   beforeDeliverPayload: async ({ cfg, target, hint }) => {
     if (hint?.kind !== "approval-pending" || hint.approvalKind !== "exec") {

--- a/extensions/telegram/src/exec-approvals.test.ts
+++ b/extensions/telegram/src/exec-approvals.test.ts
@@ -25,6 +25,7 @@ import {
   resolveTelegramExecApprovalTarget,
   shouldHandleTelegramExecApprovalRequest,
   shouldInjectTelegramExecApprovalButtons,
+  shouldSuppressLocalTelegramExecApprovalPrompt,
 } from "./exec-approvals.js";
 
 const tempWorkspaces: TempWorkspaceSync[] = [];
@@ -445,6 +446,43 @@ describe("telegram exec approvals", () => {
     expect(shouldInjectTelegramExecApprovalButtons({ cfg: channelCfg, to: "123" })).toBe(false);
     expect(shouldInjectTelegramExecApprovalButtons({ cfg: bothCfg, to: "123" })).toBe(true);
     expect(shouldInjectTelegramExecApprovalButtons({ cfg: bothCfg, to: "-100123" })).toBe(true);
+  });
+
+  it("suppresses the local prompt only while the native approval route is active", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["123"] });
+    const payload = {
+      text: "Approval required. /approve req-1 allow-once",
+      channelData: {
+        execApproval: {
+          approvalId: "req-1",
+          approvalSlug: "req-1",
+          allowedDecisions: ["allow-once", "allow-always", "deny"] as const,
+        },
+      },
+    };
+
+    expect(
+      shouldSuppressLocalTelegramExecApprovalPrompt({
+        cfg,
+        payload,
+        hint: {
+          kind: "approval-pending",
+          approvalKind: "exec",
+          nativeRouteActive: false,
+        },
+      }),
+    ).toBe(false);
+    expect(
+      shouldSuppressLocalTelegramExecApprovalPrompt({
+        cfg,
+        payload,
+        hint: {
+          kind: "approval-pending",
+          approvalKind: "exec",
+          nativeRouteActive: true,
+        },
+      }),
+    ).toBe(true);
   });
 
   describe("isTelegramExecApprovalTargetRecipient", () => {

--- a/extensions/telegram/src/exec-approvals.ts
+++ b/extensions/telegram/src/exec-approvals.ts
@@ -6,12 +6,16 @@ import {
   isChannelExecApprovalTargetRecipient,
   matchesApprovalRequestFilters,
 } from "openclaw/plugin-sdk/approval-client-runtime";
-import { doesApprovalRequestSelectChannelAccount } from "openclaw/plugin-sdk/approval-native-runtime";
+import {
+  doesApprovalRequestSelectChannelAccount,
+  shouldSuppressLocalNativeExecApprovalPrompt,
+} from "openclaw/plugin-sdk/approval-native-runtime";
 import type {
   ExecApprovalRequest,
   PluginApprovalRequest,
   SystemAgentApprovalRequest,
 } from "openclaw/plugin-sdk/approval-runtime";
+import type { ChannelOutboundPayloadHint } from "openclaw/plugin-sdk/channel-contract";
 import type {
   OpenClawConfig,
   TelegramExecApprovalConfig,
@@ -129,7 +133,6 @@ const telegramExecApprovalProfile = createChannelExecApprovalProfile({
   matchesRequestAccount: matchesTelegramRequestAccount,
   // Telegram session keys often carry the only stable agent ID for approval routing.
   fallbackAgentIdFromSessionKey: true,
-  requireClientEnabledForLocalPromptSuppression: false,
 });
 
 export const isTelegramExecApprovalClientEnabled = telegramExecApprovalProfile.isClientEnabled;
@@ -163,8 +166,13 @@ export function shouldSuppressLocalTelegramExecApprovalPrompt(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
   payload: ReplyPayload;
+  hint?: ChannelOutboundPayloadHint;
 }): boolean {
-  return telegramExecApprovalProfile.shouldSuppressLocalPrompt(params);
+  return shouldSuppressLocalNativeExecApprovalPrompt({
+    ...params,
+    isNativeDeliveryEnabled: isTelegramExecApprovalClientEnabled,
+    resolveApprovalConfig: resolveTelegramExecApprovalConfig,
+  });
 }
 
 export function isTelegramExecApprovalHandlerConfigured(params: {

--- a/src/agents/bash-tools.exec-approval-request.test.ts
+++ b/src/agents/bash-tools.exec-approval-request.test.ts
@@ -123,6 +123,24 @@ describe("exec approval requests", () => {
     });
   });
 
+  it("preserves the gateway-selected approval delivery route", async () => {
+    vi.mocked(callGatewayTool).mockResolvedValue({
+      id: "approval-id",
+      deliveryRoute: "turn-source",
+    });
+
+    await expect(
+      registerExecApprovalRequestForHostOrThrow({
+        approvalId: "approval-id",
+        command: "echo hi",
+        workdir: "/tmp",
+        host: "gateway",
+        security: "allowlist",
+        ask: "on-miss",
+      }),
+    ).resolves.toMatchObject({ deliveryRoute: "turn-source" });
+  });
+
   it("distinguishes run abort cancellation from unchanged timeout fallback", async () => {
     vi.mocked(callGatewayTool)
       .mockResolvedValueOnce({ decision: null, terminalReason: "timeout" })

--- a/src/agents/bash-tools.exec-approval-request.test.ts
+++ b/src/agents/bash-tools.exec-approval-request.test.ts
@@ -123,10 +123,11 @@ describe("exec approval requests", () => {
     });
   });
 
-  it("preserves the gateway-selected approval delivery route", async () => {
+  it("preserves the gateway-selected approval routing facts", async () => {
     vi.mocked(callGatewayTool).mockResolvedValue({
       id: "approval-id",
       deliveryRoute: "turn-source",
+      originNativeRouteActive: false,
     });
 
     await expect(
@@ -138,7 +139,25 @@ describe("exec approval requests", () => {
         security: "allowlist",
         ask: "on-miss",
       }),
-    ).resolves.toMatchObject({ deliveryRoute: "turn-source" });
+    ).resolves.toMatchObject({ deliveryRoute: "turn-source", originNativeRouteActive: false });
+  });
+
+  it("ignores malformed origin-native route state", async () => {
+    vi.mocked(callGatewayTool).mockResolvedValue({
+      id: "approval-id",
+      originNativeRouteActive: "false",
+    });
+
+    await expect(
+      registerExecApprovalRequestForHostOrThrow({
+        approvalId: "approval-id",
+        command: "echo hi",
+        workdir: "/tmp",
+        host: "gateway",
+        security: "allowlist",
+        ask: "on-miss",
+      }),
+    ).resolves.not.toHaveProperty("originNativeRouteActive");
   });
 
   it("distinguishes run abort cancellation from unchanged timeout fallback", async () => {

--- a/src/agents/bash-tools.exec-approval-request.test.ts
+++ b/src/agents/bash-tools.exec-approval-request.test.ts
@@ -126,7 +126,7 @@ describe("exec approval requests", () => {
   it("preserves the gateway-selected approval routing facts", async () => {
     vi.mocked(callGatewayTool).mockResolvedValue({
       id: "approval-id",
-      deliveryRoute: "turn-source",
+      approvalClientConnected: true,
       originNativeRouteActive: false,
     });
 
@@ -139,15 +139,44 @@ describe("exec approval requests", () => {
         security: "allowlist",
         ask: "on-miss",
       }),
-    ).resolves.toMatchObject({ deliveryRoute: "turn-source", originNativeRouteActive: false });
+    ).resolves.toMatchObject({ approvalClientConnected: true, originNativeRouteActive: false });
+  });
+
+  it("accepts a shipped approval-client route from an older remote gateway", async () => {
+    vi.mocked(callGatewayTool).mockResolvedValue({
+      id: "approval-id",
+      deliveryRoute: "approval-client",
+    });
+
+    await expect(
+      registerExecApprovalRequestForHostOrThrow({
+        approvalId: "approval-id",
+        command: "echo hi",
+        workdir: "/tmp",
+        host: "gateway",
+        security: "allowlist",
+        ask: "on-miss",
+      }),
+    ).resolves.toMatchObject({ approvalClientConnected: true });
   });
 
   it("ignores malformed origin-native route state", async () => {
     vi.mocked(callGatewayTool).mockResolvedValue({
       id: "approval-id",
+      approvalClientConnected: "true",
       originNativeRouteActive: "false",
     });
 
+    await expect(
+      registerExecApprovalRequestForHostOrThrow({
+        approvalId: "approval-id",
+        command: "echo hi",
+        workdir: "/tmp",
+        host: "gateway",
+        security: "allowlist",
+        ask: "on-miss",
+      }),
+    ).resolves.not.toHaveProperty("approvalClientConnected");
     await expect(
       registerExecApprovalRequestForHostOrThrow({
         approvalId: "approval-id",

--- a/src/agents/bash-tools.exec-approval-request.ts
+++ b/src/agents/bash-tools.exec-approval-request.ts
@@ -112,6 +112,7 @@ function buildExecApprovalRequestToolParams(
 }
 
 type ParsedDecision = { present: boolean; value: string | null };
+type ExecApprovalDeliveryRoute = "approval-client" | "forwarder" | "turn-source" | "none";
 
 function parseDecision(value: unknown): ParsedDecision {
   if (!value || typeof value !== "object") {
@@ -130,6 +131,15 @@ function parseExpiresAtMs(value: unknown): number | undefined {
   return asDateTimestampMs(value);
 }
 
+function parseDeliveryRoute(value: unknown): ExecApprovalDeliveryRoute | undefined {
+  return value === "approval-client" ||
+    value === "forwarder" ||
+    value === "turn-source" ||
+    value === "none"
+    ? value
+    : undefined;
+}
+
 function resolveDefaultExecApprovalExpiresAtMs(): number {
   return resolveExpiresAtMsFromDurationMs(DEFAULT_APPROVAL_TIMEOUT_MS) ?? 0;
 }
@@ -139,6 +149,7 @@ export type ExecApprovalRegistration = {
   id: string;
   expiresAtMs: number;
   finalDecision?: string | null;
+  deliveryRoute?: ExecApprovalDeliveryRoute;
 };
 
 class ExecApprovalRunAbortedError extends Error {
@@ -169,10 +180,16 @@ async function registerExecApprovalRequest(
   const id = parseString(registrationResult?.id) ?? params.id;
   const expiresAtMs =
     parseExpiresAtMs(registrationResult?.expiresAtMs) ?? resolveDefaultExecApprovalExpiresAtMs();
+  const deliveryRoute = parseDeliveryRoute(registrationResult?.deliveryRoute);
   if (decision.present) {
-    return { id, expiresAtMs, finalDecision: decision.value };
+    return {
+      id,
+      expiresAtMs,
+      finalDecision: decision.value,
+      ...(deliveryRoute ? { deliveryRoute } : {}),
+    };
   }
-  return { id, expiresAtMs };
+  return { id, expiresAtMs, ...(deliveryRoute ? { deliveryRoute } : {}) };
 }
 
 /** Uses a pre-resolved decision or waits for the registered approval id. */

--- a/src/agents/bash-tools.exec-approval-request.ts
+++ b/src/agents/bash-tools.exec-approval-request.ts
@@ -139,6 +139,9 @@ function parseDeliveryRoute(value: unknown): ExecApprovalDeliveryRoute | undefin
     ? value
     : undefined;
 }
+function parseOptionalBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
 
 function resolveDefaultExecApprovalExpiresAtMs(): number {
   return resolveExpiresAtMsFromDurationMs(DEFAULT_APPROVAL_TIMEOUT_MS) ?? 0;
@@ -150,6 +153,7 @@ export type ExecApprovalRegistration = {
   expiresAtMs: number;
   finalDecision?: string | null;
   deliveryRoute?: ExecApprovalDeliveryRoute;
+  originNativeRouteActive?: boolean;
 };
 
 class ExecApprovalRunAbortedError extends Error {
@@ -181,15 +185,14 @@ async function registerExecApprovalRequest(
   const expiresAtMs =
     parseExpiresAtMs(registrationResult?.expiresAtMs) ?? resolveDefaultExecApprovalExpiresAtMs();
   const deliveryRoute = parseDeliveryRoute(registrationResult?.deliveryRoute);
-  if (decision.present) {
-    return {
-      id,
-      expiresAtMs,
-      finalDecision: decision.value,
-      ...(deliveryRoute ? { deliveryRoute } : {}),
-    };
-  }
-  return { id, expiresAtMs, ...(deliveryRoute ? { deliveryRoute } : {}) };
+  const originNativeRouteActive = parseOptionalBoolean(registrationResult?.originNativeRouteActive);
+  const registration = {
+    id,
+    expiresAtMs,
+    ...(deliveryRoute ? { deliveryRoute } : {}),
+    ...(originNativeRouteActive === undefined ? {} : { originNativeRouteActive }),
+  };
+  return decision.present ? { ...registration, finalDecision: decision.value } : registration;
 }
 
 /** Uses a pre-resolved decision or waits for the registered approval id. */

--- a/src/agents/bash-tools.exec-approval-request.ts
+++ b/src/agents/bash-tools.exec-approval-request.ts
@@ -112,8 +112,6 @@ function buildExecApprovalRequestToolParams(
 }
 
 type ParsedDecision = { present: boolean; value: string | null };
-type ExecApprovalDeliveryRoute = "approval-client" | "forwarder" | "turn-source" | "none";
-
 function parseDecision(value: unknown): ParsedDecision {
   if (!value || typeof value !== "object") {
     return { present: false, value: null };
@@ -131,14 +129,6 @@ function parseExpiresAtMs(value: unknown): number | undefined {
   return asDateTimestampMs(value);
 }
 
-function parseDeliveryRoute(value: unknown): ExecApprovalDeliveryRoute | undefined {
-  return value === "approval-client" ||
-    value === "forwarder" ||
-    value === "turn-source" ||
-    value === "none"
-    ? value
-    : undefined;
-}
 function parseOptionalBoolean(value: unknown): boolean | undefined {
   return typeof value === "boolean" ? value : undefined;
 }
@@ -152,7 +142,7 @@ export type ExecApprovalRegistration = {
   id: string;
   expiresAtMs: number;
   finalDecision?: string | null;
-  deliveryRoute?: ExecApprovalDeliveryRoute;
+  approvalClientConnected?: boolean;
   originNativeRouteActive?: boolean;
 };
 
@@ -184,12 +174,16 @@ async function registerExecApprovalRequest(
   const id = parseString(registrationResult?.id) ?? params.id;
   const expiresAtMs =
     parseExpiresAtMs(registrationResult?.expiresAtMs) ?? resolveDefaultExecApprovalExpiresAtMs();
-  const deliveryRoute = parseDeliveryRoute(registrationResult?.deliveryRoute);
+  // Remote Gateways can lag the local agent during an upgrade. Their shipped
+  // winner-only route is safe only when the independent availability fact is absent.
+  const approvalClientConnected =
+    parseOptionalBoolean(registrationResult?.approvalClientConnected) ??
+    (registrationResult?.deliveryRoute === "approval-client" ? true : undefined);
   const originNativeRouteActive = parseOptionalBoolean(registrationResult?.originNativeRouteActive);
   const registration = {
     id,
     expiresAtMs,
-    ...(deliveryRoute ? { deliveryRoute } : {}),
+    ...(approvalClientConnected === undefined ? {} : { approvalClientConnected }),
     ...(originNativeRouteActive === undefined ? {} : { originNativeRouteActive }),
   };
   return decision.present ? { ...registration, finalDecision: decision.value } : registration;

--- a/src/agents/bash-tools.exec-approval-wait.ts
+++ b/src/agents/bash-tools.exec-approval-wait.ts
@@ -1,7 +1,9 @@
 import { isNativeApprovalChannel, normalizeMessageChannel } from "../utils/message-channel.js";
+import type { ExecApprovalRegistration } from "./bash-tools.exec-approval-request.js";
 
 export function shouldAwaitExecApprovalInline(params: {
   turnSourceChannel?: string;
+  deliveryRoute?: ExecApprovalRegistration["deliveryRoute"];
   approvalFollowupMode?: "agent" | "direct";
   trigger?: string;
 }): boolean {
@@ -23,5 +25,8 @@ export function shouldAwaitExecApprovalInline(params: {
   // mirrors the webchat path that PR #85239 fixed; without it the agent run
   // terminates on the "approval-pending" tool result and the operator must
   // send a follow-up chat message to recover the turn (issue #93918).
-  return isNativeApprovalChannel(normalizeMessageChannel(params.turnSourceChannel));
+  return (
+    params.deliveryRoute === "approval-client" &&
+    isNativeApprovalChannel(normalizeMessageChannel(params.turnSourceChannel))
+  );
 }

--- a/src/agents/bash-tools.exec-approval-wait.ts
+++ b/src/agents/bash-tools.exec-approval-wait.ts
@@ -1,9 +1,7 @@
 import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../utils/message-channel.js";
-import type { ExecApprovalRegistration } from "./bash-tools.exec-approval-request.js";
-
 export function shouldAwaitExecApprovalInline(params: {
   turnSourceChannel?: string;
-  deliveryRoute?: ExecApprovalRegistration["deliveryRoute"];
+  approvalClientConnected?: boolean;
   originNativeRouteActive?: boolean;
   approvalFollowupMode?: "agent" | "direct";
   trigger?: string;
@@ -28,6 +26,6 @@ export function shouldAwaitExecApprovalInline(params: {
   // when the Gateway selected that exact originating channel/account runtime;
   // a generic connected Control UI is not evidence that the origin can surface it.
   return turnSourceChannel === INTERNAL_MESSAGE_CHANNEL
-    ? params.deliveryRoute === "approval-client"
+    ? params.approvalClientConnected === true
     : params.originNativeRouteActive === true;
 }

--- a/src/agents/bash-tools.exec-approval-wait.ts
+++ b/src/agents/bash-tools.exec-approval-wait.ts
@@ -1,9 +1,10 @@
-import { isNativeApprovalChannel, normalizeMessageChannel } from "../utils/message-channel.js";
+import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../utils/message-channel.js";
 import type { ExecApprovalRegistration } from "./bash-tools.exec-approval-request.js";
 
 export function shouldAwaitExecApprovalInline(params: {
   turnSourceChannel?: string;
   deliveryRoute?: ExecApprovalRegistration["deliveryRoute"];
+  originNativeRouteActive?: boolean;
   approvalFollowupMode?: "agent" | "direct";
   trigger?: string;
 }): boolean {
@@ -19,14 +20,14 @@ export function shouldAwaitExecApprovalInline(params: {
   if (params.trigger === "cron") {
     return true;
   }
-  // Native chat approval clients (Telegram /approve, Discord buttons,
-  // etc.) resolve the approval back into the same session, so the agent can
-  // wait inline and return the real exec output as the tool result. This
-  // mirrors the webchat path that PR #85239 fixed; without it the agent run
-  // terminates on the "approval-pending" tool result and the operator must
-  // send a follow-up chat message to recover the turn (issue #93918).
-  return (
-    params.deliveryRoute === "approval-client" &&
-    isNativeApprovalChannel(normalizeMessageChannel(params.turnSourceChannel))
-  );
+  const turnSourceChannel = normalizeMessageChannel(params.turnSourceChannel);
+  if (!turnSourceChannel) {
+    return false;
+  }
+  // Webchat itself is the approval client. External chat channels may wait only
+  // when the Gateway selected that exact originating channel/account runtime;
+  // a generic connected Control UI is not evidence that the origin can surface it.
+  return turnSourceChannel === INTERNAL_MESSAGE_CHANNEL
+    ? params.deliveryRoute === "approval-client"
+    : params.originNativeRouteActive === true;
 }

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -91,6 +91,7 @@ type MockRegisteredExecApprovalRequest = {
   approvalId: string;
   approvalSlug: string;
   deliveryRoute?: "approval-client" | "forwarder" | "turn-source" | "none";
+  originNativeRouteActive?: boolean;
   warningText: string;
   expiresAtMs: number;
   preResolvedDecision: string | null | undefined;
@@ -2847,6 +2848,31 @@ EOF`,
       { phase: "waiting-approval", approvalId: "req-1", toolCallId: "tool-inline" },
       { phase: "approval-resolved", approvalId: "req-1", toolCallId: "tool-inline" },
     ]);
+  });
+
+  it("returns the Telegram approval prompt when only a generic approval client is active", async () => {
+    createAndRegisterDefaultExecApprovalRequestMock.mockResolvedValueOnce({
+      approvalId: "req-1",
+      approvalSlug: "slug-1",
+      deliveryRoute: "approval-client",
+      originNativeRouteActive: false,
+      warningText: "",
+      expiresAtMs: Date.now() + 60_000,
+      preResolvedDecision: undefined,
+      initiatingSurface: "origin",
+      sentApproverDms: false,
+      unavailableReason: null,
+    });
+    buildExecApprovalFollowupTargetMock.mockImplementation((value) => value);
+
+    const result = await runGatewayAllowlist({
+      command: "find . -maxdepth 1",
+      turnSourceChannel: "telegram",
+    });
+
+    expect(result.pendingResult?.details.status).toBe("approval-pending");
+    expect(resolveApprovalDecisionOrUndefinedMock).not.toHaveBeenCalled();
+    expect(buildExecApprovalFollowupTargetMock).toHaveBeenCalledOnce();
   });
 
   it.each([

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -90,6 +90,7 @@ type MockAllowlistResult = {
 type MockRegisteredExecApprovalRequest = {
   approvalId: string;
   approvalSlug: string;
+  deliveryRoute?: "approval-client" | "forwarder" | "turn-source" | "none";
   warningText: string;
   expiresAtMs: number;
   preResolvedDecision: string | null | undefined;
@@ -592,6 +593,7 @@ describe("processGatewayAllowlist", () => {
     createAndRegisterDefaultExecApprovalRequestMock.mockResolvedValue({
       approvalId: "req-1",
       approvalSlug: "slug-1",
+      deliveryRoute: "approval-client",
       warningText: "",
       expiresAtMs: Date.now() + 60_000,
       preResolvedDecision: null,
@@ -2880,6 +2882,30 @@ EOF`,
       expect(sendExecApprovalFollowupResultMock).not.toHaveBeenCalled();
     },
   );
+
+  it("returns the local approval prompt when a native chat has only a turn-source route", async () => {
+    createAndRegisterDefaultExecApprovalRequestMock.mockResolvedValueOnce({
+      approvalId: "req-1",
+      approvalSlug: "slug-1",
+      deliveryRoute: "turn-source",
+      warningText: "",
+      expiresAtMs: Date.now() + 60_000,
+      preResolvedDecision: undefined,
+      initiatingSurface: "origin",
+      sentApproverDms: false,
+      unavailableReason: null,
+    });
+    buildExecApprovalFollowupTargetMock.mockImplementation((value) => value);
+
+    const result = await runGatewayAllowlist({
+      command: "find . -maxdepth 1",
+      turnSourceChannel: "telegram",
+    });
+
+    expect(result.pendingResult?.details.status).toBe("approval-pending");
+    expect(resolveApprovalDecisionOrUndefinedMock).toHaveBeenCalledOnce();
+    expect(buildExecApprovalFollowupTargetMock).toHaveBeenCalledOnce();
+  });
 
   it.each([
     ["telegram"],

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -90,7 +90,7 @@ type MockAllowlistResult = {
 type MockRegisteredExecApprovalRequest = {
   approvalId: string;
   approvalSlug: string;
-  deliveryRoute?: "approval-client" | "forwarder" | "turn-source" | "none";
+  approvalClientConnected?: boolean;
   originNativeRouteActive?: boolean;
   warningText: string;
   expiresAtMs: number;
@@ -608,7 +608,7 @@ describe("processGatewayAllowlist", () => {
     createAndRegisterDefaultExecApprovalRequestMock.mockResolvedValue({
       approvalId: "req-1",
       approvalSlug: "slug-1",
-      deliveryRoute: "approval-client",
+      approvalClientConnected: true,
       originNativeRouteActive: false,
       warningText: "",
       expiresAtMs: Date.now() + 60_000,
@@ -2869,7 +2869,7 @@ EOF`,
     createAndRegisterDefaultExecApprovalRequestMock.mockResolvedValueOnce({
       approvalId: "req-1",
       approvalSlug: "slug-1",
-      deliveryRoute: "approval-client",
+      approvalClientConnected: true,
       originNativeRouteActive: false,
       warningText: "",
       expiresAtMs: Date.now() + 60_000,
@@ -2929,7 +2929,7 @@ EOF`,
     createAndRegisterDefaultExecApprovalRequestMock.mockResolvedValueOnce({
       approvalId: "req-1",
       approvalSlug: "slug-1",
-      deliveryRoute: "turn-source",
+      approvalClientConnected: false,
       warningText: "",
       expiresAtMs: Date.now() + 60_000,
       preResolvedDecision: undefined,

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -130,6 +130,20 @@ const createAndRegisterDefaultExecApprovalRequestMock = vi.hoisted(() =>
       undefined,
   ),
 );
+function mockOriginNativeRouteActiveOnce(): void {
+  const register = createAndRegisterDefaultExecApprovalRequestMock.getMockImplementation();
+  if (!register) {
+    throw new Error("expected approval registration mock");
+  }
+  createAndRegisterDefaultExecApprovalRequestMock.mockImplementationOnce(async (params) => {
+    const registration = await register(params);
+    if (!registration) {
+      throw new Error("expected approval registration");
+    }
+    return { ...registration, originNativeRouteActive: true };
+  });
+}
+
 const buildExecApprovalPendingToolResultMock = vi.hoisted(() => vi.fn());
 const buildExecApprovalFollowupTargetMock = vi.hoisted(() =>
   vi.fn<BuildExecApprovalFollowupTargetMock>(() => null),
@@ -595,6 +609,7 @@ describe("processGatewayAllowlist", () => {
       approvalId: "req-1",
       approvalSlug: "slug-1",
       deliveryRoute: "approval-client",
+      originNativeRouteActive: false,
       warningText: "",
       expiresAtMs: Date.now() + 60_000,
       preResolvedDecision: null,
@@ -2871,7 +2886,7 @@ EOF`,
     });
 
     expect(result.pendingResult?.details.status).toBe("approval-pending");
-    expect(resolveApprovalDecisionOrUndefinedMock).not.toHaveBeenCalled();
+    expect(resolveApprovalDecisionOrUndefinedMock).toHaveBeenCalledOnce();
     expect(buildExecApprovalFollowupTargetMock).toHaveBeenCalledOnce();
   });
 
@@ -2888,6 +2903,7 @@ EOF`,
   ])(
     "waits inline for native chat approval (%s) so the exec tool returns real output (issue #93918)",
     async (turnSourceChannel) => {
+      mockOriginNativeRouteActiveOnce();
       resolveApprovalDecisionOrUndefinedMock.mockResolvedValue("allow-once");
       createExecApprovalDecisionStateMock.mockReturnValue({
         baseDecision: { timedOut: false },
@@ -2946,6 +2962,7 @@ EOF`,
   ])(
     "returns native chat approval denials (%s) as the foreground tool result (issue #93918)",
     async (turnSourceChannel) => {
+      mockOriginNativeRouteActiveOnce();
       resolveApprovalDecisionOrUndefinedMock.mockResolvedValue("deny");
       createExecApprovalDecisionStateMock.mockReturnValue({
         baseDecision: { timedOut: false },

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -1128,6 +1128,7 @@ export async function processGatewayAllowlist(
     const {
       approvalId,
       approvalSlug,
+      deliveryRoute,
       warningText,
       expiresAtMs,
       preResolvedDecision,
@@ -1330,7 +1331,7 @@ export async function processGatewayAllowlist(
       };
     };
 
-    if (unavailableReason === null && shouldAwaitExecApprovalInline(params)) {
+    if (unavailableReason === null && shouldAwaitExecApprovalInline({ ...params, deliveryRoute })) {
       if (params.runId) {
         emitAgentEvent({
           runId: params.runId,

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -1128,7 +1128,7 @@ export async function processGatewayAllowlist(
     const {
       approvalId,
       approvalSlug,
-      deliveryRoute,
+      approvalClientConnected,
       originNativeRouteActive,
       warningText,
       expiresAtMs,
@@ -1334,7 +1334,11 @@ export async function processGatewayAllowlist(
 
     if (
       unavailableReason === null &&
-      shouldAwaitExecApprovalInline({ ...params, deliveryRoute, originNativeRouteActive })
+      shouldAwaitExecApprovalInline({
+        ...params,
+        approvalClientConnected,
+        originNativeRouteActive,
+      })
     ) {
       if (params.runId) {
         emitAgentEvent({
@@ -1629,6 +1633,7 @@ export async function processGatewayAllowlist(
         sentApproverDms,
         unavailableReason,
         allowedDecisions: approvalAllowedDecisions,
+        nativeRouteActive: originNativeRouteActive,
         processContinuationAvailable: params.processContinuationAvailable,
       }),
     };

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -1129,6 +1129,7 @@ export async function processGatewayAllowlist(
       approvalId,
       approvalSlug,
       deliveryRoute,
+      originNativeRouteActive,
       warningText,
       expiresAtMs,
       preResolvedDecision,
@@ -1331,7 +1332,10 @@ export async function processGatewayAllowlist(
       };
     };
 
-    if (unavailableReason === null && shouldAwaitExecApprovalInline({ ...params, deliveryRoute })) {
+    if (
+      unavailableReason === null &&
+      shouldAwaitExecApprovalInline({ ...params, deliveryRoute, originNativeRouteActive })
+    ) {
       if (params.runId) {
         emitAgentEvent({
           runId: params.runId,

--- a/src/agents/bash-tools.exec-host-node.integration.test.ts
+++ b/src/agents/bash-tools.exec-host-node.integration.test.ts
@@ -63,7 +63,11 @@ beforeEach(async () => {
       return readExecApprovalsSnapshot();
     }
     if (method === "exec.approval.request") {
-      return { id: params.id, expiresAtMs: Date.now() + 60000 };
+      return {
+        id: params.id,
+        expiresAtMs: Date.now() + 60000,
+        approvalClientConnected: true,
+      };
     }
     if (method === "exec.approval.waitDecision") {
       decisionEntered.resolve();

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -774,6 +774,7 @@ describe("executeNodeHostCommand", () => {
       return {
         approvalId: "approval-1",
         approvalSlug: "slug-1",
+        deliveryRoute: "approval-client",
         warningText: "",
         expiresAtMs: Date.now() + 60_000,
         preResolvedDecision: null,

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -787,7 +787,7 @@ describe("executeNodeHostCommand", () => {
       return {
         approvalId: "approval-1",
         approvalSlug: "slug-1",
-        deliveryRoute: "approval-client",
+        approvalClientConnected: true,
         originNativeRouteActive: false,
         warningText: "",
         expiresAtMs: Date.now() + 60_000,

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -195,6 +195,19 @@ const createAndRegisterDefaultExecApprovalRequestMock = vi.hoisted(() =>
       undefined,
   ),
 );
+function mockNodeOriginNativeRouteActiveOnce(active: boolean): void {
+  const register = createAndRegisterDefaultExecApprovalRequestMock.getMockImplementation();
+  if (!register) {
+    throw new Error("expected approval registration mock");
+  }
+  createAndRegisterDefaultExecApprovalRequestMock.mockImplementationOnce(async (params) => {
+    const registration = await register(params);
+    if (!registration) {
+      throw new Error("expected approval registration");
+    }
+    return { ...registration, originNativeRouteActive: active };
+  });
+}
 const runAbortedApprovalError = vi.hoisted(() => new Error("approval owning run aborted"));
 const resolveApprovalDecisionOrUndefinedMock = vi.hoisted(() =>
   vi.fn(
@@ -775,6 +788,7 @@ describe("executeNodeHostCommand", () => {
         approvalId: "approval-1",
         approvalSlug: "slug-1",
         deliveryRoute: "approval-client",
+        originNativeRouteActive: false,
         warningText: "",
         expiresAtMs: Date.now() + 60_000,
         preResolvedDecision: null,
@@ -1243,7 +1257,25 @@ describe("executeNodeHostCommand", () => {
     }
   });
 
+  it("returns the Telegram approval prompt when only a generic approval client is active", async () => {
+    mockNodeOriginNativeRouteActiveOnce(false);
+    resolveApprovalDecisionOrUndefinedMock.mockResolvedValueOnce("deny");
+    resolveExecHostApprovalContextMock.mockReturnValue({
+      approvals: { allowlist: [], file: { version: 1, agents: {} } },
+      hostSecurity: "full",
+      hostAsk: "always",
+      askFallback: "deny",
+    });
+
+    const result = await executeNodeHostCommand(
+      createNodeHostRequest({ turnSourceChannel: "telegram" }),
+    );
+
+    expect(result.details?.status).toBe("approval-pending");
+  });
+
   it("forwards prepared systemRunPlan within the native turn after approval", async () => {
+    mockNodeOriginNativeRouteActiveOnce(true);
     resolveExecHostApprovalContextMock.mockReturnValue({
       approvals: { allowlist: [], file: { version: 1, agents: {} } },
       hostSecurity: "full",

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -415,6 +415,7 @@ export async function executeNodeHostCommand(
       const {
         approvalId,
         approvalSlug,
+        deliveryRoute,
         warningText,
         expiresAtMs,
         preResolvedDecision,
@@ -442,7 +443,10 @@ export async function executeNodeHostCommand(
         inlineFallbackPolicy = currentFallback;
         inlineApprovalDecision = null;
         inlineApprovalId = approvalId;
-      } else if (unavailableReason === null && shouldAwaitExecApprovalInline(params)) {
+      } else if (
+        unavailableReason === null &&
+        shouldAwaitExecApprovalInline({ ...params, deliveryRoute })
+      ) {
         // Keep the admitted turn alive while its approval is pending. Returning
         // approval-pending here closes the authority before the operator can act.
         const outcome = await execHostShared.resolveExecApprovalWaitOutcome({

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -416,6 +416,7 @@ export async function executeNodeHostCommand(
         approvalId,
         approvalSlug,
         deliveryRoute,
+        originNativeRouteActive,
         warningText,
         expiresAtMs,
         preResolvedDecision,
@@ -445,7 +446,7 @@ export async function executeNodeHostCommand(
         inlineApprovalId = approvalId;
       } else if (
         unavailableReason === null &&
-        shouldAwaitExecApprovalInline({ ...params, deliveryRoute })
+        shouldAwaitExecApprovalInline({ ...params, deliveryRoute, originNativeRouteActive })
       ) {
         // Keep the admitted turn alive while its approval is pending. Returning
         // approval-pending here closes the authority before the operator can act.

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -415,7 +415,7 @@ export async function executeNodeHostCommand(
       const {
         approvalId,
         approvalSlug,
-        deliveryRoute,
+        approvalClientConnected,
         originNativeRouteActive,
         warningText,
         expiresAtMs,
@@ -446,7 +446,11 @@ export async function executeNodeHostCommand(
         inlineApprovalId = approvalId;
       } else if (
         unavailableReason === null &&
-        shouldAwaitExecApprovalInline({ ...params, deliveryRoute, originNativeRouteActive })
+        shouldAwaitExecApprovalInline({
+          ...params,
+          approvalClientConnected,
+          originNativeRouteActive,
+        })
       ) {
         // Keep the admitted turn alive while its approval is pending. Returning
         // approval-pending here closes the authority before the operator can act.
@@ -661,6 +665,7 @@ export async function executeNodeHostCommand(
           unavailableReason,
           allowedDecisions,
           nodeId: target.nodeId,
+          nativeRouteActive: originNativeRouteActive,
           processContinuationAvailable: params.processContinuationAvailable,
         });
       }

--- a/src/agents/bash-tools.exec-host-shared.test.ts
+++ b/src/agents/bash-tools.exec-host-shared.test.ts
@@ -701,11 +701,16 @@ describe("buildExecApprovalPendingToolResult", () => {
           id: approvalId,
           expiresAtMs: 60_000,
           deliveryRoute: "turn-source",
+          originNativeRouteActive: false,
         }),
         askFallback: "deny",
         requiresExplicitApproval: false,
       }),
-    ).resolves.toMatchObject({ kind: "wait", deliveryRoute: "turn-source" });
+    ).resolves.toMatchObject({
+      kind: "wait",
+      deliveryRoute: "turn-source",
+      originNativeRouteActive: false,
+    });
   });
 
   it("applies strict approval ordering to an inline route", async () => {

--- a/src/agents/bash-tools.exec-host-shared.test.ts
+++ b/src/agents/bash-tools.exec-host-shared.test.ts
@@ -691,6 +691,23 @@ describe("buildExecApprovalPendingToolResult", () => {
     await expect(createRoute(finalDecision, channel)).resolves.toMatchObject({ kind: "wait" });
   });
 
+  it("preserves the gateway-selected delivery route", async () => {
+    await expect(
+      createExecApprovalRequestRoute({
+        warnings: [],
+        approvalRunningNoticeMs: 1_000,
+        createApprovalSlug: (approvalId) => approvalId,
+        register: async (approvalId) => ({
+          id: approvalId,
+          expiresAtMs: 60_000,
+          deliveryRoute: "turn-source",
+        }),
+        askFallback: "deny",
+        requiresExplicitApproval: false,
+      }),
+    ).resolves.toMatchObject({ kind: "wait", deliveryRoute: "turn-source" });
+  });
+
   it("applies strict approval ordering to an inline route", async () => {
     await expect(
       createExecApprovalRequestRoute({

--- a/src/agents/bash-tools.exec-host-shared.test.ts
+++ b/src/agents/bash-tools.exec-host-shared.test.ts
@@ -641,6 +641,7 @@ describe("buildExecApprovalPendingToolResult", () => {
       },
       sentApproverDms: false,
       unavailableReason: params.unavailableReason,
+      nativeRouteActive: false,
       ...(params.allowedDecisions ? { allowedDecisions: params.allowedDecisions } : {}),
     });
   }
@@ -691,7 +692,7 @@ describe("buildExecApprovalPendingToolResult", () => {
     await expect(createRoute(finalDecision, channel)).resolves.toMatchObject({ kind: "wait" });
   });
 
-  it("preserves the gateway-selected delivery route", async () => {
+  it("preserves the gateway-selected route facts", async () => {
     await expect(
       createExecApprovalRequestRoute({
         warnings: [],
@@ -700,7 +701,7 @@ describe("buildExecApprovalPendingToolResult", () => {
         register: async (approvalId) => ({
           id: approvalId,
           expiresAtMs: 60_000,
-          deliveryRoute: "turn-source",
+          approvalClientConnected: false,
           originNativeRouteActive: false,
         }),
         askFallback: "deny",
@@ -708,7 +709,7 @@ describe("buildExecApprovalPendingToolResult", () => {
       }),
     ).resolves.toMatchObject({
       kind: "wait",
-      deliveryRoute: "turn-source",
+      approvalClientConnected: false,
       originNativeRouteActive: false,
     });
   });
@@ -742,6 +743,7 @@ describe("buildExecApprovalPendingToolResult", () => {
     });
 
     expect(result.details.status).toBe("approval-pending");
+    expect(result.details).toMatchObject({ nativeRouteActive: false });
     const text = result.content.find((part) => part.type === "text")?.text ?? "";
     expect(text).toContain("/approve approval-slug allow-once");
     expect(text).not.toContain("native chat exec approvals are not configured on Discord");

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -90,6 +90,7 @@ type ExecApprovalUnavailableReason =
 type RegisteredExecApprovalRequestContext = {
   approvalId: string;
   approvalSlug: string;
+  deliveryRoute: ExecApprovalRegistration["deliveryRoute"];
   warningText: string;
   expiresAtMs: number;
   preResolvedDecision: string | null | undefined;
@@ -313,6 +314,7 @@ async function createAndRegisterDefaultExecApprovalRequest(
   return {
     approvalId,
     approvalSlug,
+    deliveryRoute: registration.deliveryRoute,
     warningText,
     expiresAtMs: registration.expiresAtMs ?? defaultExpiresAtMs,
     preResolvedDecision:

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -90,7 +90,7 @@ type ExecApprovalUnavailableReason =
 type RegisteredExecApprovalRequestContext = {
   approvalId: string;
   approvalSlug: string;
-  deliveryRoute: ExecApprovalRegistration["deliveryRoute"];
+  approvalClientConnected: ExecApprovalRegistration["approvalClientConnected"];
   originNativeRouteActive: ExecApprovalRegistration["originNativeRouteActive"];
   warningText: string;
   expiresAtMs: number;
@@ -315,7 +315,7 @@ async function createAndRegisterDefaultExecApprovalRequest(
   return {
     approvalId,
     approvalSlug,
-    deliveryRoute: registration.deliveryRoute,
+    approvalClientConnected: registration.approvalClientConnected,
     originNativeRouteActive: registration.originNativeRouteActive,
     warningText,
     expiresAtMs: registration.expiresAtMs ?? defaultExpiresAtMs,
@@ -605,6 +605,7 @@ export function buildExecApprovalPendingToolResult(params: {
   unavailableReason: ExecApprovalUnavailableReason | null;
   allowedDecisions?: readonly ExecApprovalDecision[];
   nodeId?: string;
+  nativeRouteActive?: boolean;
   processContinuationAvailable?: boolean;
 }): AgentToolResult<ExecToolDetails> {
   const allowedDecisions = params.allowedDecisions ?? resolveExecApprovalAllowedDecisions();
@@ -663,6 +664,9 @@ export function buildExecApprovalPendingToolResult(params: {
             cwd: params.cwd,
             nodeId: params.nodeId,
             warningText: params.warningText,
+            ...(params.nativeRouteActive === undefined
+              ? {}
+              : { nativeRouteActive: params.nativeRouteActive }),
           } satisfies ExecToolDetails),
   };
 }

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -91,6 +91,7 @@ type RegisteredExecApprovalRequestContext = {
   approvalId: string;
   approvalSlug: string;
   deliveryRoute: ExecApprovalRegistration["deliveryRoute"];
+  originNativeRouteActive: ExecApprovalRegistration["originNativeRouteActive"];
   warningText: string;
   expiresAtMs: number;
   preResolvedDecision: string | null | undefined;
@@ -315,6 +316,7 @@ async function createAndRegisterDefaultExecApprovalRequest(
     approvalId,
     approvalSlug,
     deliveryRoute: registration.deliveryRoute,
+    originNativeRouteActive: registration.originNativeRouteActive,
     warningText,
     expiresAtMs: registration.expiresAtMs ?? defaultExpiresAtMs,
     preResolvedDecision:

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -182,6 +182,7 @@ export type ExecToolDetails = {
       cwd?: string;
       nodeId?: string;
       warningText?: string;
+      nativeRouteActive?: boolean;
     }
   | {
       status: "approval-unavailable";

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -207,8 +207,8 @@ async function writeExecApprovalsConfig(config: Record<string, unknown>) {
   saveExecApprovals(config as ExecApprovalsFile);
 }
 
-function acceptedApprovalResponse(params: unknown) {
-  return { status: "accepted", id: (params as { id?: string })?.id };
+function acceptedApprovalResponse(params: unknown, deliveryRoute?: "approval-client") {
+  return { status: "accepted", id: (params as { id?: string })?.id, deliveryRoute };
 }
 
 function getResultText(result: { content: Array<{ type?: string; text?: string }> }) {
@@ -340,10 +340,11 @@ async function expectGatewayAskAlwaysPrompt(options: {
 function mockAcceptedApprovalFlow(options: {
   onAgent?: (params: Record<string, unknown>) => void;
   onNodeInvoke?: (params: unknown) => unknown;
+  deliveryRoute?: "approval-client";
 }) {
   vi.mocked(callGatewayTool).mockImplementation(async (method, _opts, params) => {
     if (method === "exec.approval.request") {
-      return acceptedApprovalResponse(params);
+      return acceptedApprovalResponse(params, options.deliveryRoute);
     }
     if (method === "exec.approval.waitDecision") {
       return { decision: "allow-once" };
@@ -844,7 +845,7 @@ describe("exec approvals", () => {
     vi.mocked(callGatewayTool).mockImplementation(async (method, _opts, params) => {
       calls.push(method);
       if (method === "exec.approval.request") {
-        return acceptedApprovalResponse(params);
+        return acceptedApprovalResponse(params, "approval-client");
       }
       if (method === "exec.approval.waitDecision") {
         return { decision: "allow-always" };
@@ -1145,7 +1146,7 @@ describe("exec approvals", () => {
 
     vi.mocked(callGatewayTool).mockImplementation(async (method, _opts, params) => {
       if (method === "exec.approval.request") {
-        return acceptedApprovalResponse(params);
+        return acceptedApprovalResponse(params, "approval-client");
       }
       if (method === "exec.approval.waitDecision") {
         return await decisionPromise;
@@ -1199,6 +1200,7 @@ describe("exec approvals", () => {
       onAgent: (params) => {
         agentCalls.push(params);
       },
+      deliveryRoute: "approval-client",
     });
 
     const tool = createExecTool({

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -205,11 +205,16 @@ async function writeExecApprovalsConfig(config: Record<string, unknown>) {
   saveExecApprovals(config as ExecApprovalsFile);
 }
 
-function acceptedApprovalResponse(params: unknown, deliveryRoute?: "approval-client") {
+function acceptedApprovalResponse(
+  params: unknown,
+  deliveryRoute?: "approval-client" | "forwarder",
+  approvalClientConnected = deliveryRoute === "approval-client",
+) {
   return {
     status: "accepted",
     id: (params as { id?: string })?.id,
     deliveryRoute,
+    approvalClientConnected,
     originNativeRouteActive: deliveryRoute === "approval-client",
   };
 }
@@ -343,11 +348,16 @@ async function expectGatewayAskAlwaysPrompt(options: {
 function mockAcceptedApprovalFlow(options: {
   onAgent?: (params: Record<string, unknown>) => void;
   onNodeInvoke?: (params: unknown) => unknown;
-  deliveryRoute?: "approval-client";
+  deliveryRoute?: "approval-client" | "forwarder";
+  approvalClientConnected?: boolean;
 }) {
   vi.mocked(callGatewayTool).mockImplementation(async (method, _opts, params) => {
     if (method === "exec.approval.request") {
-      return acceptedApprovalResponse(params, options.deliveryRoute);
+      return acceptedApprovalResponse(
+        params,
+        options.deliveryRoute,
+        options.approvalClientConnected,
+      );
     }
     if (method === "exec.approval.waitDecision") {
       return { decision: "allow-once" };
@@ -1223,6 +1233,30 @@ describe("exec approvals", () => {
     expect(result.details.status).toBe("completed");
     expect(getResultText(result)).toContain("webchat-ok");
     expect(agentCalls).toHaveLength(0);
+  });
+
+  it("keeps webchat inline when forwarding wins route precedence", async () => {
+    mockAcceptedApprovalFlow({
+      deliveryRoute: "forwarder",
+      approvalClientConnected: true,
+    });
+
+    const tool = createExecTool({
+      host: "gateway",
+      ask: "always",
+      approvalRunningNoticeMs: 0,
+      sessionKey: "agent:main:main",
+      elevated: { enabled: true, allowed: true, defaultLevel: "ask" },
+      messageProvider: "webchat",
+    });
+
+    const result = await tool.execute("call-gw-forwarded-webchat", {
+      command: "printf webchat-ok",
+      workdir: process.cwd(),
+    });
+
+    expect(result.details.status).toBe("completed");
+    expect(getResultText(result)).toContain("webchat-ok");
   });
 
   it("keeps approved internal commands asynchronous without a webchat turn source", async () => {

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -61,8 +61,6 @@ vi.mock("../utils/message-channel.js", () => {
   const isGatewayMessageChannel = (value: string) => Boolean(normalizeMessageChannel(value));
   return {
     INTERNAL_MESSAGE_CHANNEL,
-    isNativeApprovalChannel: (value?: string | null) =>
-      value === INTERNAL_MESSAGE_CHANNEL || value === "discord",
     isDeliverableMessageChannel: (value: string) => {
       const channel = normalizeMessageChannel(value);
       return Boolean(channel && channel !== INTERNAL_MESSAGE_CHANNEL && channel !== "tui");
@@ -208,7 +206,12 @@ async function writeExecApprovalsConfig(config: Record<string, unknown>) {
 }
 
 function acceptedApprovalResponse(params: unknown, deliveryRoute?: "approval-client") {
-  return { status: "accepted", id: (params as { id?: string })?.id, deliveryRoute };
+  return {
+    status: "accepted",
+    id: (params as { id?: string })?.id,
+    deliveryRoute,
+    originNativeRouteActive: deliveryRoute === "approval-client",
+  };
 }
 
 function getResultText(result: { content: Array<{ type?: string; text?: string }> }) {

--- a/src/agents/bash-tools.exec.security-floor.test.ts
+++ b/src/agents/bash-tools.exec.security-floor.test.ts
@@ -91,7 +91,7 @@ function mockPendingApprovalGateway(): string[] {
   vi.mocked(callGatewayTool).mockImplementation(async (method) => {
     calls.push(method);
     if (method === "exec.approval.request") {
-      return { status: "accepted", id: "approval-id" };
+      return { status: "accepted", id: "approval-id", approvalClientConnected: true };
     }
     if (method === "exec.approval.waitDecision") {
       return { decision: null };
@@ -532,7 +532,9 @@ describe("exec security floor", () => {
       if (approved) {
         vi.mocked(callGatewayTool).mockImplementation(async (method) => {
           calls.push(method);
-          return { decision: "allow-once" };
+          return method === "exec.approval.request"
+            ? { status: "accepted", id: "approval-id", approvalClientConnected: true }
+            : { decision: "allow-once" };
         });
       }
       const tool = createExecTool({
@@ -631,7 +633,11 @@ describe("exec security floor", () => {
         return completion.promise;
       })
       .mockRejectedValueOnce(new Error("synthetic completion unavailable"));
-    vi.mocked(callGatewayTool).mockResolvedValue({ decision: "deny" });
+    vi.mocked(callGatewayTool).mockImplementation(async (method) =>
+      method === "exec.approval.request"
+        ? { status: "accepted", id: "approval-id", approvalClientConnected: true }
+        : { decision: "deny" },
+    );
     const tool = createExecTool({
       host: "gateway",
       mode: "auto",
@@ -683,7 +689,11 @@ describe("exec security floor", () => {
       throw new Error("synthetic reviewer import failure");
     });
     vi.doMock("./exec-auto-reviewer.js", loadReviewer);
-    vi.mocked(callGatewayTool).mockResolvedValue({ decision: "deny" });
+    vi.mocked(callGatewayTool).mockImplementation(async (method) =>
+      method === "exec.approval.request"
+        ? { status: "accepted", id: "approval-id", approvalClientConnected: true }
+        : { decision: "deny" },
+    );
     try {
       const tool = createExecTool({
         host: "gateway",

--- a/src/agents/embedded-agent-subscribe.handlers.tools.results.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.results.ts
@@ -515,6 +515,7 @@ function readExecApprovalPendingDetails(result: unknown): {
   cwd?: string;
   nodeId?: string;
   warningText?: string;
+  nativeRouteActive?: boolean;
 } | null {
   if (!result || typeof result !== "object") {
     return null;
@@ -549,6 +550,8 @@ function readExecApprovalPendingDetails(result: unknown): {
     cwd: readStringValue(details.cwd),
     nodeId: readStringValue(details.nodeId),
     warningText: readStringValue(details.warningText),
+    nativeRouteActive:
+      typeof details.nativeRouteActive === "boolean" ? details.nativeRouteActive : undefined,
   };
 }
 
@@ -647,6 +650,7 @@ export async function emitToolResultOutput(params: {
           nodeId: approvalPending.nodeId,
           expiresAtMs: approvalPending.expiresAtMs,
           warningText: approvalPending.warningText,
+          nativeRouteActive: approvalPending.nativeRouteActive,
         }),
       );
       ctx.state.deterministicApprovalPromptSent = true;

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -2821,6 +2821,7 @@ describe("handleToolExecutionEnd exec approval prompts", () => {
           command: "npm view diver name version description",
           cwd: "/tmp/work",
           warningText: "Warning: heredoc execution requires explicit approval in allowlist mode.",
+          nativeRouteActive: false,
         },
       },
     });
@@ -2837,6 +2838,7 @@ describe("handleToolExecutionEnd exec approval prompts", () => {
         approvalSlug: "12345678",
         approvalKind: "exec",
         allowedDecisions: ["allow-once", "allow-always", "deny"],
+        nativeRouteActive: false,
       },
     );
     expectInteractiveApprovalButtons(result, [

--- a/src/auto-reply/reply/dispatch-from-config.abort-and-dedupe.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.abort-and-dedupe.test-utils.ts
@@ -130,7 +130,10 @@ function createNativeApprovalTestConfig(channel: NativeApprovalTestChannel): Ope
       } as OpenClawConfig);
 }
 
-function createNativeApprovalReplyResolver(channel: NativeApprovalTestChannel) {
+function createNativeApprovalReplyResolver(
+  channel: NativeApprovalTestChannel,
+  nativeRouteActive: boolean,
+) {
   return vi.fn(async (_ctx: MsgContext, options?: GetReplyOptions) => {
     await options?.onToolResult?.({
       text: "Approval required.",
@@ -138,6 +141,7 @@ function createNativeApprovalReplyResolver(channel: NativeApprovalTestChannel) {
         execApproval: {
           approvalId: "12345678-1234-1234-1234-123456789012",
           approvalSlug: "12345678",
+          nativeRouteActive,
           ...(channel === "signal"
             ? { approvalKind: "exec" as const, sessionKey: "agent:main:signal:+15551230000" }
             : {}),
@@ -1641,23 +1645,33 @@ describe("dispatchReplyFromConfig", () => {
       name: "keeps local discord exec approval tool prompts when the native runtime is inactive",
       channel: "discord" as const,
       nativeActive: false,
+      nativeRouteActive: false,
     },
     {
       name: "suppresses local discord exec approval tool prompts when the native runtime is active",
       channel: "discord" as const,
       nativeActive: true,
+      nativeRouteActive: true,
+    },
+    {
+      name: "keeps local discord exec approval tool prompts when the active runtime is ineligible",
+      channel: "discord" as const,
+      nativeActive: true,
+      nativeRouteActive: false,
     },
     {
       name: "keeps local signal exec approval tool prompts when the native runtime is inactive",
       channel: "signal" as const,
       nativeActive: false,
+      nativeRouteActive: false,
     },
     {
       name: "suppresses local signal exec approval tool prompts when the native runtime is active",
       channel: "signal" as const,
       nativeActive: true,
+      nativeRouteActive: true,
     },
-  ])("$name", async ({ channel, nativeActive }) => {
+  ])("$name", async ({ channel, nativeActive, nativeRouteActive }) => {
     setNoAbort();
     const reporter = nativeActive
       ? createApprovalNativeRouteReporter({
@@ -1682,10 +1696,10 @@ describe("dispatchReplyFromConfig", () => {
         }),
         cfg: createNativeApprovalTestConfig(channel),
         dispatcher,
-        replyResolver: createNativeApprovalReplyResolver(channel),
+        replyResolver: createNativeApprovalReplyResolver(channel, nativeRouteActive),
       });
 
-      if (nativeActive) {
+      if (nativeRouteActive) {
         expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
       } else {
         expect(firstToolResultPayload(dispatcher)?.text).toBe("Approval required.");

--- a/src/channels/plugins/exec-approval-local.ts
+++ b/src/channels/plugins/exec-approval-local.ts
@@ -5,8 +5,7 @@
  */
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { getGatewayNativeApprovalRuntime } from "../../infra/approval-gateway-runtime-context.js";
-import { hasActiveApprovalNativeRouteRuntime } from "../../infra/approval-native-route-coordinator.js";
+import { getExecApprovalReplyMetadata } from "../../infra/exec-approval-reply.js";
 import { getChannelPlugin, normalizeChannelId } from "./registry.js";
 
 export function shouldSuppressLocalExecApprovalPrompt(params: {
@@ -19,8 +18,7 @@ export function shouldSuppressLocalExecApprovalPrompt(params: {
   if (!channel) {
     return false;
   }
-  // Native-route state is process-local and transient. Pass it as a hint so the
-  // channel owns the UX decision without duplicating route lookup logic.
+  const nativeRouteActive = getExecApprovalReplyMetadata(params.payload)?.nativeRouteActive;
   return (
     getChannelPlugin(channel)?.outbound?.shouldSuppressLocalPayloadPrompt?.({
       cfg: params.cfg,
@@ -29,17 +27,7 @@ export function shouldSuppressLocalExecApprovalPrompt(params: {
       hint: {
         kind: "approval-pending",
         approvalKind: "exec",
-        nativeRouteActive:
-          getGatewayNativeApprovalRuntime()?.routeCoordinator.hasActiveRuntime({
-            channel,
-            accountId: params.accountId,
-            approvalKind: "exec",
-          }) ??
-          hasActiveApprovalNativeRouteRuntime({
-            channel,
-            accountId: params.accountId,
-            approvalKind: "exec",
-          }),
+        nativeRouteActive,
       },
     }) ?? false
   );

--- a/src/gateway/server-instance-runtime.ts
+++ b/src/gateway/server-instance-runtime.ts
@@ -234,6 +234,16 @@ export function createGatewayInstanceRuntime(
   return {
     createAgentTurnFacade,
     approvalEvents: {
+      hasSelectedOriginRoute: (kind, request) => {
+        // SAFETY: approval publication receives normalized approval request events only.
+        const approvalRequest = request as GatewayApprovalRequest;
+        return routeCoordinator.hasActiveRuntime({
+          approvalKind: kind,
+          channel: approvalRequest.request.turnSourceChannel,
+          accountId: approvalRequest.request.turnSourceAccountId,
+          request: approvalRequest,
+        });
+      },
       publishRequested: (kind, request) =>
         publish(
           kind,

--- a/src/gateway/server-instance-runtime.types.ts
+++ b/src/gateway/server-instance-runtime.types.ts
@@ -24,6 +24,7 @@ export type GatewayInstanceAgentDispatchOptions = {
 };
 
 export type GatewayApprovalEventPublisher = {
+  hasSelectedOriginRoute?: (kind: ChannelApprovalKind, request: unknown) => boolean;
   publishRequested: (kind: ChannelApprovalKind, request: unknown) => number;
   publishResolved: (kind: ChannelApprovalKind, resolved: unknown) => void;
 };

--- a/src/gateway/server-methods/approval-shared.test.ts
+++ b/src/gateway/server-methods/approval-shared.test.ts
@@ -315,11 +315,51 @@ describe("handlePendingApprovalRequest", () => {
         id: "approval-with-client",
         status: "accepted",
         deliveryRoute: "approval-client",
+        approvalClientConnected: true,
         originNativeRouteActive: false,
       }),
       undefined,
     );
 
+    expect(manager.resolve(record.id, "allow-once")).toBe(true);
+    await requestPromise;
+  });
+
+  it("reports a connected approval client independently from forwarding", async () => {
+    const manager = new ExecApprovalManager();
+    const record = manager.create({ command: "echo ok" }, 60_000, "forwarded-with-client");
+    const decisionPromise = manager.register(record, 60_000);
+    const respond = vi.fn();
+    const requestPromise = handlePendingApprovalRequest({
+      manager,
+      record,
+      decisionPromise,
+      respond,
+      context: {
+        broadcast: vi.fn(),
+        hasExecApprovalClients: () => true,
+      } as unknown as GatewayRequestContext,
+      requestEventName: "exec.approval.requested",
+      requestEvent: {
+        id: record.id,
+        request: record.request,
+        createdAtMs: record.createdAtMs,
+        expiresAtMs: record.expiresAtMs,
+      },
+      twoPhase: true,
+      deliverRequest: () => true,
+    });
+
+    await Promise.resolve();
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        status: "accepted",
+        deliveryRoute: "forwarder",
+        approvalClientConnected: true,
+      }),
+      undefined,
+    );
     expect(manager.resolve(record.id, "allow-once")).toBe(true);
     await requestPromise;
   });

--- a/src/gateway/server-methods/approval-shared.test.ts
+++ b/src/gateway/server-methods/approval-shared.test.ts
@@ -274,13 +274,13 @@ describe("handlePendingApprovalRequest", () => {
     ).toBe(false);
   });
 
-  it("reports an active approval client instead of the manual turn-source route", async () => {
+  it("reports an inactive origin-native route alongside a generic approval client", async () => {
     const manager = new ExecApprovalManager();
     const record = manager.create(
       {
         command: "echo ok",
-        turnSourceChannel: "feishu",
-        turnSourceAccountId: "work",
+        turnSourceChannel: "telegram",
+        turnSourceAccountId: "default",
       },
       60_000,
       "approval-with-client",
@@ -315,6 +315,7 @@ describe("handlePendingApprovalRequest", () => {
         id: "approval-with-client",
         status: "accepted",
         deliveryRoute: "approval-client",
+        originNativeRouteActive: false,
       }),
       undefined,
     );
@@ -329,6 +330,7 @@ describe("handlePendingApprovalRequest", () => {
     const decisionPromise = manager.register(record, 60_000);
     const respond = vi.fn();
     const publishRequested = vi.fn(() => 1);
+    const hasSelectedOriginRoute = vi.fn(() => true);
     const requestPromise = handlePendingApprovalRequest({
       manager,
       record,
@@ -339,6 +341,7 @@ describe("handlePendingApprovalRequest", () => {
         hasExecApprovalClients: () => false,
         approvalEvents: {
           publishRequested,
+          hasSelectedOriginRoute,
           publishResolved: vi.fn(),
         },
       } as unknown as GatewayRequestContext,
@@ -354,13 +357,21 @@ describe("handlePendingApprovalRequest", () => {
     });
 
     await Promise.resolve();
+    expect(hasSelectedOriginRoute).toHaveBeenCalledWith(
+      "exec",
+      expect.objectContaining({ id: record.id }),
+    );
     expect(publishRequested).toHaveBeenCalledWith(
       "exec",
       expect.objectContaining({ id: record.id }),
     );
     expect(respond).toHaveBeenCalledWith(
       true,
-      expect.objectContaining({ status: "accepted", deliveryRoute: "approval-client" }),
+      expect.objectContaining({
+        status: "accepted",
+        deliveryRoute: "approval-client",
+        originNativeRouteActive: true,
+      }),
       undefined,
     );
     expect(manager.resolve(record.id, "allow-once")).toBe(true);

--- a/src/gateway/server-methods/approval-shared.ts
+++ b/src/gateway/server-methods/approval-shared.ts
@@ -354,12 +354,12 @@ export async function handlePendingApprovalRequest<
             params.requestEvent,
           ) ?? false);
 
-    const hasApprovalClients = suppressDelivery
+    const approvalClientConnected = suppressDelivery
       ? false
       : approvalClientConnIds !== null
-        ? approvalClientConnIds.size > 0 || internalApprovalSubscriberCount > 0
-        : (params.context.hasExecApprovalClients?.(params.clientConnId) ?? false) ||
-          internalApprovalSubscriberCount > 0;
+        ? approvalClientConnIds.size > 0
+        : (params.context.hasExecApprovalClients?.(params.clientConnId) ?? false);
+    const hasApprovalClients = approvalClientConnected || internalApprovalSubscriberCount > 0;
     const deliveredResult =
       suppressDelivery || approvalClientsOnly ? false : params.deliverRequest();
     const delivered = isPromiseLike(deliveredResult) ? await deliveredResult : deliveredResult;
@@ -452,6 +452,7 @@ export async function handlePendingApprovalRequest<
           // Agent-side timeouts use this to distinguish delivered prompts from
           // requests kept pending only because manual /approve routing may work.
           deliveryRoute,
+          approvalClientConnected,
           originNativeRouteActive,
           createdAtMs: params.record.createdAtMs,
           expiresAtMs: params.record.expiresAtMs,

--- a/src/gateway/server-methods/approval-shared.ts
+++ b/src/gateway/server-methods/approval-shared.ts
@@ -346,6 +346,14 @@ export async function handlePendingApprovalRequest<
             params.requestEvent,
           ) ?? 0);
 
+    const originNativeRouteActive =
+      suppressDelivery || approvalClientsOnly
+        ? false
+        : (params.context.approvalEvents?.hasSelectedOriginRoute?.(
+            params.approvalKind ?? "exec",
+            params.requestEvent,
+          ) ?? false);
+
     const hasApprovalClients = suppressDelivery
       ? false
       : approvalClientConnIds !== null
@@ -444,6 +452,7 @@ export async function handlePendingApprovalRequest<
           // Agent-side timeouts use this to distinguish delivered prompts from
           // requests kept pending only because manual /approve routing may work.
           deliveryRoute,
+          originNativeRouteActive,
           createdAtMs: params.record.createdAtMs,
           expiresAtMs: params.record.expiresAtMs,
         },

--- a/src/infra/approval-native-route-coordinator.test.ts
+++ b/src/infra/approval-native-route-coordinator.test.ts
@@ -97,6 +97,67 @@ describe("createApprovalNativeRouteReporter", () => {
     coordinator.close();
   });
 
+  it("reports liveness only for the selected originating runtime", () => {
+    const coordinator = createApprovalNativeRouteCoordinator();
+    let telegramEligible = false;
+    const telegramReporter = coordinator.createReporter({
+      handledKinds: new Set(["exec"]),
+      channel: "telegram",
+      accountId: "default",
+      requestGateway: createGatewayRequestMock(),
+      shouldHandle: () => telegramEligible,
+      classifyRoute: () => "bound-or-explicit",
+    });
+    const discordReporter = coordinator.createReporter({
+      ...defaultRouteSelector,
+      handledKinds: new Set(["exec"]),
+      channel: "discord",
+      accountId: "default",
+      requestGateway: createGatewayRequestMock(),
+    });
+    telegramReporter.start();
+    discordReporter.start();
+    const createRequest = (id: string, accountId = "default") =>
+      ({
+        id,
+        request: {
+          command: "echo hi",
+          turnSourceChannel: "telegram",
+          turnSourceAccountId: accountId,
+        },
+        createdAtMs: 0,
+        expiresAtMs: Date.now() + 60_000,
+      }) as const;
+
+    expect(
+      coordinator.hasActiveRuntime({
+        approvalKind: "exec",
+        channel: "telegram",
+        accountId: "default",
+        request: createRequest("approval-inactive-origin"),
+      }),
+    ).toBe(false);
+
+    telegramEligible = true;
+    expect(
+      coordinator.hasActiveRuntime({
+        approvalKind: "exec",
+        channel: "telegram",
+        accountId: "default",
+        request: createRequest("approval-active-origin"),
+      }),
+    ).toBe(true);
+    expect(
+      coordinator.hasActiveRuntime({
+        approvalKind: "exec",
+        channel: "telegram",
+        accountId: "ops",
+        request: createRequest("approval-wrong-account", "ops"),
+      }),
+    ).toBe(false);
+    coordinator.close();
+  });
+
   it("keeps each channel's sole eligible runtime independent", () => {
     const coordinator = createApprovalNativeRouteCoordinator();
     const requestGateway = createGatewayRequestMock();

--- a/src/infra/approval-native-route-coordinator.ts
+++ b/src/infra/approval-native-route-coordinator.ts
@@ -417,15 +417,12 @@ function resolveApprovalRouteNotice(params: {
   };
 }
 
-/** Returns whether a native approval runtime is active for the requested channel/account scope. */
-export function hasActiveApprovalNativeRouteRuntime(params: {
+type ApprovalNativeRouteLookup = (params: {
   approvalKind: ChannelApprovalKind;
   channel?: string | null;
   accountId?: string | null;
   request?: ApprovalRequest;
-}): boolean {
-  return hasActiveApprovalNativeRouteRuntimeForState(defaultCoordinatorState, params);
-}
+}) => boolean;
 
 function hasActiveApprovalNativeRouteRuntimeForState(
   state: ApprovalNativeRouteCoordinatorState,
@@ -678,7 +675,7 @@ function createApprovalNativeRouteReporterForState(
 
 export type ApprovalNativeRouteCoordinator = {
   createReporter: typeof createApprovalNativeRouteReporter;
-  hasActiveRuntime: typeof hasActiveApprovalNativeRouteRuntime;
+  hasActiveRuntime: ApprovalNativeRouteLookup;
   close: () => void;
 };
 

--- a/src/infra/approval-native-route-coordinator.ts
+++ b/src/infra/approval-native-route-coordinator.ts
@@ -422,6 +422,7 @@ export function hasActiveApprovalNativeRouteRuntime(params: {
   approvalKind: ChannelApprovalKind;
   channel?: string | null;
   accountId?: string | null;
+  request?: ApprovalRequest;
 }): boolean {
   return hasActiveApprovalNativeRouteRuntimeForState(defaultCoordinatorState, params);
 }
@@ -432,12 +433,22 @@ function hasActiveApprovalNativeRouteRuntimeForState(
     approvalKind: ChannelApprovalKind;
     channel?: string | null;
     accountId?: string | null;
+    request?: ApprovalRequest;
   },
 ): boolean {
   const channel = normalizeChannel(params.channel);
   const accountId = normalizeOptionalString(params.accountId);
+  const selection = params.request
+    ? resolveApprovalRouteSelection(state, {
+        approvalKind: params.approvalKind,
+        request: params.request,
+      })
+    : undefined;
   const matchingRuntimes = Array.from(state.activeRuntimes.values()).filter((runtime) => {
     if (!runtime.handledKinds.has(params.approvalKind)) {
+      return false;
+    }
+    if (selection && selection.verdicts.get(runtime.runtimeId)?.kind !== "selected") {
       return false;
     }
     if (channel && normalizeChannel(runtime.channel) !== channel) {

--- a/src/infra/exec-approval-reply.test.ts
+++ b/src/infra/exec-approval-reply.test.ts
@@ -426,6 +426,7 @@ describe("exec approval reply helpers", () => {
       approvalSlug: "slug-meta",
       agentId: "ops-agent",
       sessionKey: "agent:ops-agent:matrix:channel:!room:example.org",
+      nativeRouteActive: true,
       command: "echo ok",
       host: "gateway",
     });
@@ -438,6 +439,7 @@ describe("exec approval reply helpers", () => {
         agentId: "ops-agent",
         allowedDecisions: ["allow-once", "allow-always", "deny"],
         sessionKey: "agent:ops-agent:matrix:channel:!room:example.org",
+        nativeRouteActive: true,
       },
     });
   });

--- a/src/infra/exec-approval-reply.ts
+++ b/src/infra/exec-approval-reply.ts
@@ -40,6 +40,7 @@ export type ExecApprovalReplyMetadata = {
   agentId?: string;
   allowedDecisions?: readonly ExecApprovalReplyDecision[];
   sessionKey?: string;
+  nativeRouteActive?: boolean;
 };
 
 export type ExecApprovalActionDescriptor = {
@@ -71,6 +72,7 @@ export type ExecApprovalPendingReplyParams = {
   nodeId?: string;
   scope?: ApprovalScope | null;
   sessionKey?: string | null;
+  nativeRouteActive?: boolean;
   expiresAtMs?: number;
   nowMs?: number;
 };
@@ -384,6 +386,8 @@ export function getExecApprovalReplyMetadata(
     : undefined;
   const agentId = normalizeOptionalString(record.agentId);
   const sessionKey = normalizeOptionalString(record.sessionKey);
+  const nativeRouteActive =
+    typeof record.nativeRouteActive === "boolean" ? record.nativeRouteActive : undefined;
   return {
     approvalId,
     approvalSlug,
@@ -391,6 +395,7 @@ export function getExecApprovalReplyMetadata(
     agentId,
     allowedDecisions,
     sessionKey,
+    ...(nativeRouteActive === undefined ? {} : { nativeRouteActive }),
   };
 }
 
@@ -458,6 +463,9 @@ export function buildExecApprovalPendingReplyPayload(
         agentId: normalizeOptionalString(params.agentId),
         allowedDecisions,
         sessionKey: normalizeOptionalString(params.sessionKey),
+        ...(params.nativeRouteActive === undefined
+          ? {}
+          : { nativeRouteActive: params.nativeRouteActive }),
       },
     },
   };

--- a/src/plugins/plugin-command-runtime.test.ts
+++ b/src/plugins/plugin-command-runtime.test.ts
@@ -4,12 +4,16 @@ const getCurrentPluginConversationBinding = vi.hoisted(() => vi.fn(async () => n
 const cleanupReplacedPluginHostRegistry = vi.hoisted(() =>
   vi.fn(async () => ({ cleanupCount: 0, failures: [] })),
 );
+const shouldSuppressLocalExecApprovalPrompt = vi.hoisted(() => vi.fn(() => false));
 
 vi.mock("./host-hook-cleanup.js", () => ({ cleanupReplacedPluginHostRegistry }));
 vi.mock("./conversation-binding.js", () => ({
   getCurrentPluginConversationBinding,
   requestPluginConversationBinding: vi.fn(),
   detachPluginConversationBinding: vi.fn(),
+}));
+vi.mock("../channels/plugins/exec-approval-local.js", () => ({
+  shouldSuppressLocalExecApprovalPrompt,
 }));
 
 import { getPluginCommandExecutionCount } from "./command-execution-lock.js";
@@ -78,6 +82,7 @@ function requirePluginDispatch(
 afterEach(() => {
   cleanupReplacedPluginHostRegistry.mockClear();
   getCurrentPluginConversationBinding.mockClear();
+  shouldSuppressLocalExecApprovalPrompt.mockReset().mockReturnValue(false);
   resetPluginRuntimeStateForTest();
 });
 
@@ -282,6 +287,30 @@ describe("plugin command runtime", () => {
       text: expect.stringContaining("registry changed"),
     });
     expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("marks native exec approval replies suppressed when the channel route is active", async () => {
+    const registry = createEmptyPluginRegistry();
+    registerCommand(registry, {
+      pluginId: "approval",
+      name: "approval",
+      handler: async () => ({ text: "Approval required" }),
+    });
+    setActivePluginRegistry(registry);
+    shouldSuppressLocalExecApprovalPrompt.mockReturnValue(true);
+    const runtime = createPluginCommandRuntime();
+    const dispatch = requirePluginDispatch(runtime.listNativeCandidates("telegram")[0]!);
+
+    await expect(dispatch.execute(executionContext)).resolves.toMatchObject({
+      text: "Approval required",
+      suppressReply: true,
+    });
+    expect(shouldSuppressLocalExecApprovalPrompt).toHaveBeenCalledWith({
+      channel: "telegram",
+      cfg: {},
+      accountId: undefined,
+      payload: { text: "Approval required" },
+    });
   });
 
   it("keeps overlapping executions locked until both handlers settle", async () => {

--- a/src/plugins/plugin-command-runtime.ts
+++ b/src/plugins/plugin-command-runtime.ts
@@ -1,6 +1,7 @@
 /** Registry-bound plugin command selection and execution for native/channel surfaces. */
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { shouldSuppressLocalExecApprovalPrompt } from "../channels/plugins/exec-approval-local.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { redactToolPayloadTextWithConfig } from "../logging/redact.js";
 import type { RegisteredPluginCommand } from "./command-registry-state.js";
@@ -183,11 +184,19 @@ async function executeSelectedPluginCommand(
   if (isPluginRegistryRetired(selected.registry)) {
     return { ...RETIRED_SELECTION_REPLY };
   }
-  return await executeRegisteredPluginCommand(selected.registry, {
+  const result = await executeRegisteredPluginCommand(selected.registry, {
     ...context,
     args: selection.args,
     command: selection.command,
   });
+  return shouldSuppressLocalExecApprovalPrompt({
+    channel,
+    cfg: context.config,
+    accountId: context.accountId,
+    payload: result,
+  })
+    ? { ...result, suppressReply: true }
+    : result;
 }
 
 /** Validates and executes a dispatch carried through the core reply pipeline. */

--- a/src/utils/message-channel.test.ts
+++ b/src/utils/message-channel.test.ts
@@ -112,23 +112,16 @@ describe("message-channel", () => {
     expect(isInternalNonDeliveryChannel("exec-event")).toBe(false);
   });
 
-  it("reads native approval behavior from bundled channel manifests", async () => {
+  it("reads native approval prompt behavior from bundled channel manifests", async () => {
     const previousBundledPluginsDir = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
     const previousTrust = process.env.OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR;
     process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = path.resolve("extensions");
     process.env.OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR = "1";
     vi.resetModules();
     try {
-      const channelModule = await import("./message-channel.js");
       const promptModule = await import("../channels/plugins/native-approval-prompt.js");
-      for (const channel of ["webchat", "discord", "imessage", "qqbot", "telegram", "whatsapp"]) {
-        expect(channelModule.isNativeApprovalChannel(channel), channel).toBe(true);
-      }
       expect(promptModule.isKnownNativeApprovalPromptChannel("whatsapp")).toBe(true);
       expect(promptModule.isKnownNativeApprovalPromptChannel("qqbot")).toBe(true);
-      for (const channel of ["feishu", "msteams", "line", "heartbeat", "", "TELEGRAM"]) {
-        expect(channelModule.isNativeApprovalChannel(channel), channel).toBe(false);
-      }
     } finally {
       if (previousBundledPluginsDir === undefined) {
         delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;

--- a/src/utils/message-channel.ts
+++ b/src/utils/message-channel.ts
@@ -89,19 +89,6 @@ export function isInternalMessageChannel(
   return normalizeMessageChannel(raw) === INTERNAL_MESSAGE_CHANNEL;
 }
 
-/** Return whether a channel can resolve exec approvals in the originating chat. */
-export function isNativeApprovalChannel(value?: string | null): boolean {
-  if (!value) {
-    return false;
-  }
-  if (value === INTERNAL_MESSAGE_CHANNEL) {
-    return true;
-  }
-  return listBundledChannelCatalogEntries().some(
-    (entry) => entry.id === value && entry.channel.approvalFlags?.includes("native"),
-  );
-}
-
 /** Return whether a Gateway client is the public webchat surface. */
 export function isWebchatClient(client?: GatewayClientInfoLike | null): boolean {
   const mode = normalizeGatewayClientMode(client?.mode);


### PR DESCRIPTION
Closes #131845

## What Problem This Solves

Fixes an issue where Telegram users could receive no exec-approval prompt when the matching Telegram native approval runtime was inactive but a generic approval client was connected. The same route-selection state could also detach a webchat exec turn when forwarding won precedence, preventing the approved command result from returning to the model inline.

## Why This Change Was Made

The Gateway route coordinator now remains the owner of live native-route state and registration returns two independent facts: whether a generic approval client is connected, and whether the exact originating channel/account runtime was selected. Gateway-host and node-host execution carry those facts through the pending result; reply dispatch consumes the recorded origin fact instead of re-inferring global liveness. Older remote Gateways remain compatible through their shipped `deliveryRoute: "approval-client"` response when the new independent fact is absent.

Superseded static channel classification and downstream generic-liveness suppression were removed. No config, schema, SQLite, consent, or public protocol version changes are included.

## User Impact

Telegram receives exactly one local `/approve … allow-once` prompt when its native route is inactive, even if Control UI is connected. When the matching native route is active, Telegram receives the native approval card without a local duplicate. Webchat continues waiting inline when both forwarding and an approval client are available, so the approved exec output returns to the originating model turn. Gateway-host and node-host continuation behavior remains intact.

## Evidence

### Premise on current main

The defect was still present on fetched `main` at `a33604ea1ec`:

- `src/utils/message-channel.ts:92` owned a static native-capability classifier instead of live route state.
- `src/agents/bash-tools.exec-approval-wait.ts:26` waited for any statically capable channel.
- `src/gateway/server-methods/approval-shared.ts:370` collapsed forwarding and approval-client availability into one winner, and `src/gateway/server-methods/approval-shared.ts:446` returned only that winner.
- `src/agents/bash-tools.exec-approval-request.ts:172` discarded independent route facts.
- `extensions/telegram/src/channel.ts:224` called suppression without the exact lifecycle fact.

No commit on current `main` fixed this behavior. The static wait was introduced by `1bfa2787b503`.

### Before repair

- Webchat + successful forwarding + connected approval client: the full exec-tool boundary expected completed output but received `approval-pending`.
- Gateway producer boundary: forwarding + connected approval client omitted `approvalClientConnected`.
- Inactive origin route lifecycle: the channel emitted no local approval tool result because downstream code re-inferred generic native-runtime liveness.
- The prior exact-head CI failure was code-related, not infrastructure: `checks-node-compact-large-15` failed two files; the current pre-fix reproduction produced 9 failures across the node integration and security-floor suites.

### After repair

- Final local head: `01eb174ae8cb`; base: `a33604ea1ec`.
- `OPENCLAW_VITEST_MAX_WORKERS=2 pnpm check:changed`: passed on the final head. A first post-rebase attempt exposed the base's `@openclaw/fs-safe` 0.7.2 dependency bump; `pnpm install` refreshed the declared dependency and the required retry passed.
- Acceptance boundary run: 4 shards, 7 files, 182 tests passed (Gateway registration 42; coordinator/reply 53; agent registration/tool 52; Telegram route/adapter 35).
- Broader owner/sibling runs passed: agent owner matrix 289; Gateway/runtime 102; embedded/reply 266; Telegram/plugin 232; full reply lifecycle 74; former CI failures 44 with 1 platform skip.
- Isolated real Gateway E2E: 1 passed using its own temporary state directory and port.
- Full private build: passed.
- Fresh uncommitted review after the rolling-version repair: no accepted P0/P1 findings.
- Direct Codex contract check: `../codex/codex-rs/core/src/session/mod.rs:2375`, `../codex/codex-rs/core/src/state/turn.rs:87`, `../codex/codex-rs/core/src/session/handlers.rs:172`, and `../codex/codex-rs/protocol/src/approvals.rs:225`; genuine exact/webchat routes must retain turn authority, while detached routes must not.

### Telegram Test Server and fallback verdict

Live Telegram was blocked before TDLib authorization: the checked-out Test Server harness requires a CI-role broker secret, while the supplied broker pair is maintainer-role and was rejected with `AUTH_ROLE_MISMATCH`; the supported maintainer Convex CLI route could not load the QA broker. No secret was printed. This is not represented as live Telegram proof.

```json
{
  "label": "fallback-mock-gateway",
  "verdict": "pass",
  "liveTelegram": "blocked-before-tdlib",
  "cases": {
    "inactive-telegram-plus-generic-client": "one local prompt",
    "active-telegram-native-route": "one native card, no local duplicate",
    "gateway-and-node-continuation": "pass",
    "webchat-forwarder-plus-client": "inline result preserved",
    "native-delivery-no-target": "manual fallback notice preserved"
  },
  "isolatedGateway": "pass"
}
```

### Risk and coverage

- Risk: the independent route facts cross Gateway registration, both exec hosts, embedded result projection, and channel dispatch. Coverage exercises the producer, both consumers, projection/parser, and final Telegram suppression boundary.
- Risk: an older remote Gateway does not return the new boolean. Coverage proves fallback to its shipped `deliveryRoute: "approval-client"` contract only when the independent fact is absent.
- Risk: active native delivery can select a route and later reach no targets. Coordinator coverage proves the existing manual fallback notice remains visible.
- Risk: webchat forwarding and client availability coexist. Full-tool and Gateway-producer boundaries prove forwarding precedence no longer erases inline authority.
- Uncovered: real Telegram Test Server event timelines for the inactive and active cases; blocked before TDLib for the broker-role reason above. The explicitly labeled mock-Gateway boundary verdict is the fallback.

### ClawSweeper disposition

Latest in-place review: updated `2026-09-02T00:48:07Z`, reviewed head `0691e608160`, six Before merge items, no `Rank-up moves:` section.

- Preserve webchat inline waits: addressed with the independent `approvalClientConnected` fact and combined full-tool regression.
- Webchat merge risk: addressed at the Gateway producer and agent consumer boundaries, including older remote Gateway compatibility.
- Telegram visible proof: live attempt blocked before TDLib; fallback mock-Gateway verdict is labeled above and covers both visible outcomes.
- Positive production LOC: duplicate Telegram suppression, static classification, and downstream generic-liveness inference were removed; remaining growth carries owner-recorded facts across the required boundaries.
- Narrow P1 repair/live follow-up: repair is complete; real Telegram remains the explicit proof gap, not an implementation gap.
- Changed-surface validation: rerun and passed on final head.

### LOC

Production: +141/-89 (net +52). Tests/test support: +516/-40 (net +476). Pure moves are not counted.

- `extensions/telegram/src/bot-message-dispatch-reply.ts`: +0/-11 — removed duplicate suppression.
- `extensions/telegram/src/bot-native-command-dispatch.ts`: +0/-11 — removed duplicate suppression.
- `extensions/telegram/src/bot-native-command-plugins.ts`: +1/-8 — removed duplicate suppression and retained the canonical path.
- `extensions/telegram/src/channel.ts`: +2/-1 — forwards the exact route hint.
- `extensions/telegram/src/exec-approvals.ts`: +11/-3 — consumes the exact native-route fact at the Telegram owner.
- `src/agents/bash-tools.exec-approval-request.ts`: +19/-5 — parses independent facts and preserves older remote Gateway compatibility.
- `src/agents/bash-tools.exec-approval-wait.ts`: +13/-9 — replaces static channel inference with exact route/client facts.
- `src/agents/bash-tools.exec-host-gateway.ts`: +11/-1 — carries registration facts through the Gateway host result.
- `src/agents/bash-tools.exec-host-node.ts`: +11/-1 — carries registration facts through the node host result.
- `src/agents/bash-tools.exec-host-shared.ts`: +8/-0 — centralizes pending-result metadata construction.
- `src/agents/bash-tools.exec-types.ts`: +1/-0 — types the recorded native-route fact.
- `src/agents/embedded-agent-subscribe.handlers.tools.results.ts`: +4/-0 — projects the recorded fact into reply metadata.
- `src/channels/plugins/exec-approval-local.ts`: +3/-15 — deletes generic runtime-liveness re-inference.
- `src/gateway/server-instance-runtime.ts`: +10/-0 — injects the instance-local route coordinator.
- `src/gateway/server-instance-runtime.types.ts`: +1/-0 — types the injected coordinator.
- `src/gateway/server-methods/approval-shared.ts`: +14/-4 — records independent generic-client and exact-origin facts at the owner.
- `src/infra/approval-native-route-coordinator.ts`: +14/-6 — resolves the exact selected runtime within the owning Gateway instance.
- `src/infra/exec-approval-reply.ts`: +8/-0 — validates and preserves the exact reply fact.
- `src/plugins/plugin-command-runtime.ts`: +10/-1 — exposes instance-local native-route registration through the plugin command runtime.
- `src/utils/message-channel.ts`: +0/-13 — removes the obsolete static classifier.

The net production growth is the minimum cross-boundary data contract needed to record route truth at its lifecycle owner and consume it at both exec hosts and final channel delivery; the former parallel inference and suppression paths are removed.
