### PR TITLE
docs: add unattended Team server update skill

### DIFF
--- a/.agents/skills/update-team-server/SKILL.md
+++ b/.agents/skills/update-team-server/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: update-team-server
+description: "Update the operator-configured Team server unattended through its canonical deployment owner; verify serving code, supported migrations, session continuity, and recovery without duplicating the hourly scheduler."
+---
+
+# Update Team server
+
+Keep Team current automatically. Routine deployments, controlled interruptions, and supported upstream-owned migrations are already authorized for this workflow; do not request another routine approval. This is a repository operator skill, not a bundled runtime skill or a deployer implementation.
+
+## Resolve the owner
+
+Read the operator-provided private deployment runbook before acting. Resolve and verify the host, access, canonical deployment command, service, hourly timer, lock, journal, release pointers, backup destination, and recovery contract from that configuration. Never guess access or copy private connection details, credentials, state, or receipts into public output.
+
+Verify installed owner capabilities against their current source; this skill does not install a migration phase. Missing access or a safe capability is a concrete blocker: repair through the existing owner within authority, or report what remains unavailable. Never invent success or bypass a denial. Keep source/PR repairs in separate worktrees; do not delay an otherwise safe prepared update for them.
+
+## Deploy through one owner
+
+1. Keep the existing hourly timer enabled and active as the sole cadence. Never pause it for proof or create another scheduler/deployer. Inspect the active invocation, lock, and journal; observe an active owner instead of duplicating it. Resolve retained journals through canonical recovery before requesting a new deployment. Do not clear failed status to manufacture idleness.
+2. When idle, request the configured updater service using its documented command. The canonical owner alone controls deployment, Gateway lifecycle, rollback, and recovery. Do not substitute direct restarts, partial build overlays, or an in-place source build.
+3. Keep the incumbent serving while the owner freezes official upstream `main`, builds the complete release off-path, validates it, and seals it. Check runtime-user disk/quota headroom, not just host free space.
+4. Use the owner's genuine, unexpired maintenance authority bound to the incumbent generation. Allow controlled interruption after its configured drain budget; active agents and PTYs are not indefinite vetoes. Pending terminal persistence still blocks interruption. Never relabel DRAINING as READY. Bound shutdown, migration, startup, and verification separately; the drain budget is not total downtime.
+
+## Cross schemas safely
+
+Before stopping writers, identify the exact incumbent/candidate reader contracts, supported Doctor migration, and durable phase/recovery owner. Package versions and numeric schema ceilings alone are insufficient. Require the owner to prove these gates before mutation:
+
+- A complete database inventory, including configured external agent roots and registered stores; verified WAL-aware backups covering that inventory and protected state. Check backup omissions and sanitization: a portable export is not necessarily a full recovery image. Doctor does not create the backup.
+- The original pre-cutover session-preservation witness, retained through recovery; a filtered session-list page, empty baseline, or fresh-current witness cannot prove historical continuity.
+- Stopped writers and maintenance authority fencing new claims. Only the candidate's supported upstream Doctor flow performs migration; assess its full repair scope, not a presumed single-table operation.
+- Per-database integrity, physical schema, `PRAGMA user_version`, `schema_meta`, ownership, registry, and candidate runtime-readiness checks before and after migration. One successful database or healthy HTTP cannot prove all-agent readiness.
+
+Transactions may commit per database, leaving mixed schemas or stale registry metadata after interruption. Once any database advances beyond the old reader's contract, never automatically restart that old reader, even when candidate verification fails. Preserve the journal and backups; continue through the canonical forward-recovery owner until every store is ready. Before mutation, a safe refusal leaves the incumbent serving. No custom schema SQL, version-marker edits, downgrade, or wholesale backup restoration.
+
+Read [database contracts](https://docs.openclaw.ai/reference/database-schemas) and [backup semantics](https://docs.openclaw.ai/cli/backup); their general recovery examples do not expand this workflow's authority.
+
+## Verify and recover
+
+Require the exact invocation's successful deployment receipt, matching new serving/build SHA, stable process generation, RPC, health/startup/readiness, configured channels, unchanged protected policy/identities, and original-witness verification. Reuse the owner's real model-marker receipt; do not send duplicate marker turns. Require journal resolution and an active hourly timer. Supervisor success, a skip, healthy old code, or same-release recovery is not a new deployment.
+
+Bracket live checks with generation and owner-phase checks; never run ordinary RPCs across an active fence or pause the timer for a quiet proof window. Preserve failed outcomes and unresolved journals; do not delete evidence or retry blindly. Use only the owner's compatibility-checked recovery and cleanup, preserving referenced releases, backups, ordinary sessions, unrelated state, and dirty workspaces.
+
+Let [Gateway restart recovery](https://docs.openclaw.ai/gateway/restart-recovery) resume eligible work; do not duplicate it manually. PTYs end, unsaved work may be lost, and recovery budgets/quarantine remain: neither universal recovery nor exactly-once execution is promised.
+
+Report the invocation outcome, observed serving SHA, migration/readiness and continuity proof, recovery phase, and any exact blocker privately. No credential rotation, release publication, security-policy weakening, or unrelated mutations are authorized.

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -298,6 +298,7 @@
   - changed-files:
       - any-glob-to-any-file:
           - "docs/**"
+          - ".agents/skills/update-team-server/**"
 
 "r: skill":
   - changed-files:

--- a/src/infra/restart-handoff.test.ts
+++ b/src/infra/restart-handoff.test.ts
@@ -3,6 +3,7 @@ import { spawn } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { createInterface } from "node:readline";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
@@ -25,6 +26,7 @@ import {
 import type { GatewayRestartHandoff } from "./restart-handoff.js";
 
 const tempDirs: string[] = [];
+const handoffConsumerCleanups: Array<() => Promise<void>> = [];
 type GatewayRestartHandoffDatabase = Pick<OpenClawStateKyselyDatabase, "gateway_restart_handoff">;
 
 function createHandoffEnv(): NodeJS.ProcessEnv {
@@ -123,86 +125,48 @@ function spawnHandoffConsumer(params: {
   env: NodeJS.ProcessEnv;
   expectedPid: number;
   now: number;
-  startFile: string;
-}): Promise<unknown> {
+  signal: AbortSignal;
+}) {
+  params.signal.throwIfAborted();
   const moduleUrl = new URL("./restart-handoff.ts", import.meta.url).href;
   const script = `
-    import fs from "node:fs";
-    while (!fs.existsSync(process.env.OPENCLAW_HANDOFF_TEST_START_FILE)) {
-      await new Promise((resolve) => setTimeout(resolve, 5));
-    }
-    const mod = await import(process.env.OPENCLAW_HANDOFF_TEST_MODULE_URL);
+    const mod = await import(${JSON.stringify(moduleUrl)});
+    const start = new Promise((resolve) => process.stdin.once("data", resolve));
+    process.stdout.write("ready\\n");
+    await start;
     const result = mod.consumeGatewayRestartHandoffSync({
-      expectedPid: Number(process.env.OPENCLAW_HANDOFF_TEST_EXPECTED_PID),
-      now: Number(process.env.OPENCLAW_HANDOFF_TEST_NOW),
+      expectedPid: ${params.expectedPid},
+      now: ${params.now},
       env: process.env,
     });
-    process.stdout.write(JSON.stringify(result));
+    process.stdout.write(JSON.stringify(result) + "\\n");
   `;
-  return new Promise((resolve, reject) => {
-    let settled = false;
-    const child = spawn(
-      process.execPath,
-      ["--import", "tsx", "--input-type=module", "--eval", script],
-      {
-        cwd: process.cwd(),
-        env: {
-          ...params.env,
-          OPENCLAW_HANDOFF_TEST_EXPECTED_PID: String(params.expectedPid),
-          OPENCLAW_HANDOFF_TEST_MODULE_URL: moduleUrl,
-          OPENCLAW_HANDOFF_TEST_NOW: String(params.now),
-          OPENCLAW_HANDOFF_TEST_START_FILE: params.startFile,
-        },
-        stdio: ["ignore", "pipe", "pipe"],
-      },
-    );
-    const timeout = setTimeout(() => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      child.kill();
-      reject(new Error("handoff consumer timed out"));
-    }, 10_000);
-    let stdout = "";
-    let stderr = "";
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-    child.stdout.on("data", (chunk: string) => {
-      stdout += chunk;
-    });
-    child.stderr.on("data", (chunk: string) => {
-      stderr += chunk;
-    });
-    child.once("error", (err) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      clearTimeout(timeout);
-      reject(err);
-    });
-    child.once("exit", (code) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      clearTimeout(timeout);
-      if (code !== 0) {
-        reject(new Error(`handoff consumer exited ${code}: ${stderr}`));
-        return;
-      }
-      try {
-        resolve(JSON.parse(stdout));
-      } catch (err) {
-        reject(new Error(`invalid handoff consumer output: ${stdout}`, { cause: err }));
-      }
-    });
+  const child = spawn(
+    process.execPath,
+    ["--import", "tsx", "--input-type=module", "--eval", script],
+    { cwd: process.cwd(), env: params.env, stdio: ["pipe", "pipe", "pipe"] },
+  );
+  const stderr: string[] = [];
+  child.stderr.on("data", (chunk) => stderr.push(String(chunk)));
+  child.once("error", (error) => stderr.push(error.message));
+  const closed = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
+    child.once("close", (code, signal) => resolve({ code, signal }));
   });
+  const lines = createInterface({ input: child.stdout, signal: params.signal });
+  const output = lines[Symbol.asyncIterator]();
+  handoffConsumerCleanups.push(async () => {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill("SIGKILL");
+    }
+    await closed;
+    lines.close();
+  });
+  return { child, closed, output, stderr };
 }
 
 describe("gateway restart handoff", () => {
-  afterEach(() => {
+  afterEach(async () => {
+    await Promise.all(handoffConsumerCleanups.splice(0).map((cleanup) => cleanup()));
     closeOpenClawStateDatabaseForTest();
     for (const dir of tempDirs.splice(0)) {
       fs.rmSync(dir, { force: true, recursive: true });
@@ -584,9 +548,9 @@ describe("gateway restart handoff", () => {
     expect(readHandoffRow(env)).toBeUndefined();
   });
 
-  it("accepts a handoff exactly once across concurrent consumers", async () => {
+  it("accepts a handoff exactly once across concurrent consumers", async ({ signal }) => {
     const env = createHandoffEnv();
-    expectWrittenHandoff({
+    const handoff = expectWrittenHandoff({
       env,
       pid: 12_345,
       restartKind: "full-process",
@@ -594,29 +558,53 @@ describe("gateway restart handoff", () => {
       createdAt: 1_000,
     });
     closeOpenClawStateDatabaseForTest();
-    const startFile = path.join(env.OPENCLAW_STATE_DIR ?? "", "start-consumers");
+    const consumers = [0, 1].map(() =>
+      spawnHandoffConsumer({ env, expectedPid: 12_345, now: 1_500, signal }),
+    );
 
-    const first = spawnHandoffConsumer({
-      env,
-      expectedPid: 12_345,
-      now: 1_500,
-      startFile,
-    });
-    const second = spawnHandoffConsumer({
-      env,
-      expectedPid: 12_345,
-      now: 1_500,
-      startFile,
-    });
-    fs.writeFileSync(startFile, "start", "utf8");
-
-    const results = await Promise.all([first, second]);
-    expect(
-      results
-        .map((result) => (result as { status?: string }).status)
-        .toSorted((a, b) => String(a).localeCompare(String(b))),
-    ).toStrictEqual(["accepted", "none"]);
-    expect(readHandoffRow(env)).toBeUndefined();
+    // Source bootstrap belongs to the test budget, not the consume deadline.
+    // Release both readers only once their real owner module is loaded.
+    await Promise.all(
+      consumers.map(async ({ output, stderr }) => {
+        const ready = await output.next();
+        if (ready.done) {
+          throw new Error(`handoff consumer closed before readiness: ${stderr.join("")}`);
+        }
+        expect(ready.value).toBe("ready");
+      }),
+    );
+    const timeout = setTimeout(() => {
+      for (const { child } of consumers) {
+        child.kill("SIGKILL");
+      }
+    }, 10_000);
+    try {
+      for (const { child } of consumers) {
+        child.stdin.end("consume\n");
+      }
+      const results = await Promise.all(
+        consumers.map(async ({ closed, output, stderr }) => {
+          const { code, signal: exitSignal } = await closed;
+          if (code !== 0) {
+            throw new Error(`handoff consumer exited ${exitSignal ?? code}: ${stderr.join("")}`);
+          }
+          const result = await output.next();
+          if (result.done) {
+            throw new Error("handoff consumer closed without a result");
+          }
+          return JSON.parse(result.value) as unknown;
+        }),
+      );
+      expect(results).toEqual(
+        expect.arrayContaining([
+          { status: "accepted", handoff },
+          { status: "none", reason: "missing" },
+        ]),
+      );
+      expect(readHandoffRow(env)).toBeUndefined();
+    } finally {
+      clearTimeout(timeout);
+    }
   });
 
   it("samples the default time after beginning the write transaction", () => {


### PR DESCRIPTION
## What Problem This Solves

The Team update workflow needs durable repository-scoped instructions for unattended operation, rather than repeatedly treating ordinary deployments, bounded interruptions, and supported upstream migrations as new operator decisions.

This is an explicitly maintainer-requested operator skill. It is not a community runtime skill, a new deployment implementation, or a claim that a live deployment has completed.

## Why This Change Was Made

Add `update-team-server` under the existing `.agents/skills` convention. It requires the operator-provided private runbook and the installed canonical deployment owner, preserves the existing hourly scheduler, and defines preparation, cutover, verification, and recovery responsibilities without exposing host/access details.

The skill keeps the one-way migration boundary explicit: verified WAL-aware backups, stopped/fenced writers, the original session witness, and complete physical-schema/metadata/registry readiness are prerequisites. An incompatible predecessor must not restart after a newer schema commits. Missing owner capability remains a repairable blocker, not fabricated success or permission to bypass a guard.

The exact skill path maps to the existing `docs` label; no new label or packaged skill surface is introduced. The bounded, invocation-only instruction body keeps its safety gates together rather than splitting mandatory cutover/recovery instructions across partial reads.

CI also exposed a longstanding restart-handoff concurrency-fixture defect: its ten-second consumption timer included child startup and TypeScript imports, and its file barrier was released before either consumer loaded the real owner. The bounded test-only repair waits for both consumers' readiness before releasing them, retains the ten-second consumption deadline and existing overall test timeout, and joins both children before removing test state. Production handoff transactions and guards are unchanged.

## User Impact

Operators with the configured Team deployment authority can run normal supported updates unattended through one owner. Ordinary OpenClaw installs are unchanged: no runtime code, configuration, scheduler, credentials, database, or release artifact changes. The skill does not install or assert availability of a new migration phase.

## Evidence

- `pnpm docs:list` completed; checked the current [database contracts](https://docs.openclaw.ai/reference/database-schemas), [backup semantics](https://docs.openclaw.ai/cli/backup), and [restart recovery](https://docs.openclaw.ai/gateway/restart-recovery) guidance.
- `python3 skills/skill-creator/scripts/quick_validate.py .agents/skills/update-team-server` passed.
- `node scripts/check-docs-mdx.mjs .agents/skills/update-team-server/SKILL.md` passed for the new file.
- `git diff --check` passed; YAML parsing and exact-path documentation-label routing passed.
- Confirmed the existing `.claude/skills` alias resolves the new canonical skill, and the package allowlist does not include `.agents`.
- Fresh restricted Codex autoreview completed with no actionable findings; its outgoing review pack passed the required secret scan.
- The original exact-head [CI run](https://github.com/openclaw/openclaw/actions/runs/33187152198) failed `checks-node-compact-small-14` at the fixture's spawn-to-exit timer. The test fixture dates to #109162 (external supervisor restart handoffs); no new production handoff regression is claimed.
- `node scripts/run-vitest.mjs src/infra/restart-handoff.test.ts src/cli/gateway-cli/register-restart-handoff.test.ts src/state/openclaw-state-db-restart-handoff-migration.test.ts` passed all 31 tests across three shards.
- Controlled fault proof on the same concurrency case: an 11-second pre-import startup delay failed before the repair and passed afterward; an 11-second post-readiness consumption delay still failed under the unchanged ten-second deadline. Both fault injections were removed, and no task-owned consumer processes remained after failure cleanup.
- `node scripts/check-changed.mjs -- src/infra/restart-handoff.test.ts` passed, including full core-test typechecking, targeted lint/format, dead-export scans, and repository guards.
- Fresh restricted Codex review of the fixture repair found no actionable P0–P2 findings.
- Production LOC: +0/-0. Tests: +82/-94 (net -12). Other changes are 44 operator-instruction lines and one labeler metadata entry.

AI-assisted. No live operational action was performed: no server access, lifecycle action, live data copy or migration, or scheduler change. Synthetic test fixtures are isolated; live deployment acceptance remains a separate operational responsibility.

ClawSweeper follow-up: read the complete August 28 16:00 UTC review and its rank-up section. Its only rank-up move asks for that review inspection; no introduced correctness finding or skill change was requested. The public skill remains private-runbook-dependent operator guidance, distinct from the generic updater. The subsequent test-fixture repair receives fresh review and exact-head CI.
