### PR TITLE
improve(ui): larger avatar in person activity hovercard

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -990,6 +990,14 @@ openclaw-session-progress-hovercard-provider {
   min-width: 0;
 }
 
+.person-activity-card__header .viewer-avatar--footer {
+  width: 32px;
+  height: 32px;
+  font-size: calc(12px * var(--control-ui-text-scale));
+  /* The base ring color assumes the sidebar surface; blend with the popover. */
+  border-color: var(--session-hovercard-surface);
+}
+
 .person-activity-card h2,
 .person-activity-card h3,
 .person-activity-card p {


### PR DESCRIPTION
## What Problem This Solves

The person activity hovercard (opened from the sidebar's Online roster) renders its header avatar at the 20px `footer` size — too small to recognize the person the card is about, especially next to the 14px name heading.

## Why This Change Was Made

The hovercard header now sizes the avatar at 32px with a proportionally larger initials font, following the existing pattern of context-scoped `viewer-avatar--footer` overrides (`.sidebar-identity-card`, `.sidebar-identity-menu__avatar`). The avatar's separation ring is re-colored to the hovercard surface token, since the base ring color assumes the sidebar background and would show as a mismatched halo at the larger size. The sidebar Online list itself intentionally keeps its compact 18px avatars.

## User Impact

The person hovercard leads with a clearly recognizable avatar; identifying who a presence card belongs to at a glance is easier. No behavior change.

## Evidence

CSS-only change (+8 production LOC, no tests needed). `node scripts/check-changed.mjs` green (format, stylelint, i18n, UI typecheck). Before/after captured on the mocked Control UI dev server (`scripts/control-ui-mock-dev.ts`) via Playwright, dark mode, element screenshot of the hovercard:

| Before (20px) | After (32px) |
| --- | --- |
| ![before-hovercard](https://github.com/user-attachments/assets/9d19015e-a83a-4582-ab6b-1628b4fb79d1) | ![after-hovercard](https://github.com/user-attachments/assets/c1424a35-1bba-4352-b74e-853a6773e706) |
