### PR TITLE
fix(plugins): resolve CLI plugin metadata once per invocation

### DIFF
--- a/src/plugins/cli-registry-loader.register-once.test.ts
+++ b/src/plugins/cli-registry-loader.register-once.test.ts
@@ -1,0 +1,95 @@
+// Pins one plugin register execution per CLI invocation across independent bootstrap stages.
+import fs from "node:fs";
+import path from "node:path";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { loadPluginCliDescriptors, resolvePluginCliRootOwnerIds } from "./cli-registry-loader.js";
+import { getPluginCliCommandDescriptors } from "./cli-root-descriptors.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  makePluginLoaderTempDir,
+  resetPluginLoaderTestStateForTest,
+  useNoBundledPlugins,
+  writePlugin,
+} from "./loader.test-fixtures.js";
+
+afterEach(() => {
+  resetPluginLoaderTestStateForTest();
+});
+
+afterAll(() => {
+  cleanupPluginLoaderFixturesForTest();
+});
+
+function countRegisterRuns(markerPath: string): number {
+  return fs.existsSync(markerPath)
+    ? fs.readFileSync(markerPath, "utf8").split("\n").filter(Boolean).length
+    : 0;
+}
+
+function setupCountingCliPlugin(): { config: OpenClawConfig; markerPath: string } {
+  useNoBundledPlugins();
+  const pluginDir = makePluginLoaderTempDir();
+  const markerPath = path.join(makePluginLoaderTempDir(), "register-runs.log");
+  writePlugin({
+    id: "counting-cli",
+    dir: pluginDir,
+    filename: "index.cjs",
+    body: `const fs = require("node:fs");
+module.exports = {
+  id: "counting-cli",
+  register(api) {
+    fs.appendFileSync(${JSON.stringify(markerPath)}, "register\\n");
+    api.registerCli(() => {}, {
+      commands: ["counting-cli"],
+      descriptors: [
+        { name: "counting-cli", description: "Counting CLI", hasSubcommands: false },
+      ],
+    });
+  },
+};`,
+  });
+  return {
+    config: {
+      plugins: {
+        load: { paths: [path.join(pluginDir, "index.cjs")] },
+        allow: ["counting-cli"],
+      },
+    } as OpenClawConfig,
+    markerPath,
+  };
+}
+
+describe("plugin CLI metadata registration count", () => {
+  it("runs a legacy external plugin register once across CLI bootstrap stages", async () => {
+    const { config, markerPath } = setupCountingCliPlugin();
+
+    // Stage order mirrors one `openclaw counting-cli --help` invocation: the unowned-primary
+    // guard resolves plugin CLI root ownership, then command registration resolves descriptors
+    // for the same primary. Both stages resolve CLI metadata for the same load scope.
+    const ownerIds = await resolvePluginCliRootOwnerIds({
+      cfg: config,
+      env: process.env,
+      primaryCommand: "counting-cli",
+    });
+    const descriptors = await loadPluginCliDescriptors({
+      cfg: config,
+      env: process.env,
+      primaryCommand: "counting-cli",
+    });
+
+    expect(ownerIds).toEqual(["counting-cli"]);
+    expect(descriptors.map((entry) => entry.name)).toContain("counting-cli");
+    expect(countRegisterRuns(markerPath)).toBe(1);
+  });
+
+  it("keeps distinct load scopes on separate register passes", async () => {
+    const { config, markerPath } = setupCountingCliPlugin();
+    // Root help executes only the legacy external plugins it could not read from manifests, so
+    // its narrower scope must not be served the full-scope registry (or vice versa).
+    await loadPluginCliDescriptors({ cfg: config, env: process.env });
+    await getPluginCliCommandDescriptors(config, process.env);
+
+    expect(countRegisterRuns(markerPath)).toBe(2);
+  });
+});

--- a/src/plugins/loader-cache.ts
+++ b/src/plugins/loader-cache.ts
@@ -18,6 +18,11 @@ export function getReusableCachedPluginRegistry(cacheKey: string): PluginRegistr
   return pluginLoaderCacheState.get(cacheKey);
 }
 
+/** Registry reuse is off for explicit opt-outs and for raw env-substituted config loads. */
+export function isPluginRegistryCacheEnabled(options: PluginLoadOptions): boolean {
+  return options.cache !== false && options.resolveRawConfigEnvVars !== true;
+}
+
 export function clearPluginRegistryLoadCache(): void {
   clearPluginRuntimeArtifactResolutionMemo();
   pluginLoaderCacheState.clearCachedRegistries();

--- a/src/plugins/loader-cli-registry.ts
+++ b/src/plugins/loader-cli-registry.ts
@@ -11,6 +11,11 @@ import {
 } from "./config-state.js";
 import { isPluginEnabledByDefaultForPlatform } from "./default-enablement.js";
 import { shouldRejectHardlinkedPluginFiles } from "./hardlink-policy.js";
+import {
+  getReusableCachedPluginRegistry,
+  isPluginRegistryCacheEnabled,
+  setCachedPluginRegistry,
+} from "./loader-cache.js";
 import { resolvePluginLoadDiscovery } from "./loader-discovery.js";
 import { resolvePluginLoadCacheContext } from "./loader-load-context.js";
 import {
@@ -48,6 +53,19 @@ export async function loadOpenClawPluginCliRegistry(
   options: PluginLoadOptions = {},
 ): Promise<PluginRegistry> {
   const context = resolvePluginLoadCacheContext({ ...options, activate: false });
+  // One CLI invocation resolves descriptors from several bootstrap stages; without reuse each
+  // stage re-executes every legacy external plugin's register and re-emits its diagnostics.
+  // The namespace is required: a runtime load with activate:false shares this cacheKey but
+  // produces a completely different registry. Diagnostics ride the cached registry, so only
+  // the duplicate log emission is dropped.
+  const cacheKey = `cli-metadata::${context.cacheKey}`;
+  const cacheEnabled = isPluginRegistryCacheEnabled(options);
+  if (cacheEnabled) {
+    const cached = getReusableCachedPluginRegistry(cacheKey);
+    if (cached) {
+      return cached;
+    }
+  }
   const logger = options.logger ?? createPluginLoaderLogger();
   const onlyPluginIdSet = createPluginIdScopeSet(context.onlyPluginIds);
   const loadPluginModule = createPluginModuleLoader({
@@ -345,6 +363,9 @@ export async function loadOpenClawPluginCliRegistry(
         diagnosticMessagePrefix: "plugin failed during register: ",
       });
     }
+  }
+  if (cacheEnabled) {
+    setCachedPluginRegistry(cacheKey, registry);
   }
   return registry;
 }

--- a/src/plugins/loader-runtime-load.ts
+++ b/src/plugins/loader-runtime-load.ts
@@ -8,6 +8,7 @@ import { resolveEffectivePluginActivationState } from "./config-state.js";
 import { isPluginEnabledByDefaultForPlatform } from "./default-enablement.js";
 import {
   getReusableCachedPluginRegistry,
+  isPluginRegistryCacheEnabled,
   pluginLoaderCacheState,
   setCachedPluginRegistry,
 } from "./loader-cache.js";
@@ -99,7 +100,7 @@ function loadOpenClawPluginsInternal(
   const logger = options.logger ?? createPluginLoaderLogger();
   const validateOnly = options.mode === "validate";
   const onlyPluginIdSet = createPluginIdScopeSet(context.onlyPluginIds);
-  const cacheEnabled = options.cache !== false && options.resolveRawConfigEnvVars !== true;
+  const cacheEnabled = isPluginRegistryCacheEnabled(options);
   if (cacheEnabled) {
     const cached = getReusableCachedPluginRegistry(context.cacheKey);
     if (cached) {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where every OpenClaw CLI invocation ran a legacy external plugin's `register()` up to three times, so a plugin that fails to register printed its error three times in a row and paid its module-load cost three times. Operators saw it as duplicated `[plugins] <id> failed during register from ...` noise on ordinary commands: an unknown command, `openclaw <plugin-cmd> --help`, `openclaw plugins list`.

Follow-up to #130597 (`bbd66c475e4`) and #130743 (`ab255086f7e`), where this was named as a deferred follow-up in both.

## Why This Change Was Made

`loadOpenClawPluginCliRegistry` is the only path that executes a plugin's `register(api)` in CLI-metadata mode, and unlike its sibling runtime loader in `src/plugins/loader-runtime-load.ts` it had no registry reuse at all — every call rebuilt a registry from scratch. A single invocation resolves plugin CLI metadata from several independent bootstrap stages: `resolvePluginMachineOutput` → `loadPluginCliDescriptors`, `isPluginCliRoot` → `resolvePluginCliRootOwnerIds`, `resolveCliCommandSurfaceOwner` → `resolvePluginCliRootOwnerIds`, and command registration. They are not mutually exclusive, because `src/cli/run-main.ts`'s unowned-primary guard runs *after* the help fast paths rather than instead of them.

The producer now serves and populates the existing lifecycle-owned registry cache under a `cli-metadata::` key namespace, keyed by the `cacheKey` that `resolvePluginLoadCacheContext` already computes (allowlist, plugin entries, `onlyPluginIds`, SDK resolution, workspace). The namespace is not cosmetic: a runtime load with `activate: false` shares that same `cacheKey` but produces a completely different registry, so the two keyspaces must not touch. Reusing the existing cache means it inherits the existing clear hooks (`clearPluginRegistryLoadCache`, the test fixture reset) rather than introducing another cache to keep alive.

Scopes that are intentionally distinct still get their own pass: `resolveCliCommandSurfaceOwner`'s deliberately allowlist-agnostic lookup, and root help's narrower legacy-external `onlyPluginIds` scope. Nothing became eager — the execution fallback that `extensions/canvas` relies on for its nested node CLI is untouched.

The duplicated "is registry caching allowed" predicate also moves into `isPluginRegistryCacheEnabled`, so both loaders share one policy instead of two copies.

## User Impact

Operators stop seeing plugin register diagnostics repeated on ordinary CLI commands, and CLI startup stops re-importing and re-executing legacy external plugin entrypoints two extra times per invocation. No configuration, API, or behavior change otherwise.

## Evidence

**Regression test** — `src/plugins/cli-registry-loader.register-once.test.ts` drives two real production entry points with a fixture plugin whose `register` appends to a marker file. It fails pre-fix for the intended reason (verified by reverting only the production file):

```
× runs a legacy external plugin register once across CLI bootstrap stages
  → expected 2 to be 1
✓ keeps distinct load scopes on separate register passes
```

The second case asserts `2` for two genuinely distinct scopes and passes both before and after, so the fix cannot be satisfied by over-collapsing.

**Real CLI proof** — built `dist`, pointed a fixture legacy external plugin at an isolated `OPENCLAW_CONFIG_PATH` / `OPENCLAW_STATE_DIR`, made its `register` throw, and counted `failed during register` lines on stderr (the reported symptom). Default config:

| command | before | after |
| --- | --- | --- |
| `openclaw totally-unknown-cmd` | 3 | 1 |
| `openclaw dupe-probe --help` | 3 | 1 |
| `openclaw plugins list` | 3 | 1 |

The rows record observed duplicate-diagnostic counts per invocation, not which named stage fired. `plugins` is a built-in command root, so the unowned-primary probes named above do *not* run for `plugins list`; that command reaches three CLI-metadata loads by other stages, and the row was re-verified independently after review.

With `plugins.allow` set it goes 3 → 2, the residual being the intentional allowlist-agnostic diagnostic lookup.

**Validation**

- `node scripts/run-vitest.mjs src/plugins` — 13 test files fail, all 13 reproducing identically on clean `origin/main` (baselined in the same checkout; the new plugin-cache subsystem owns them). The contracts lane on this branch fails only `package-manifest.contract.test.ts`, matching baseline.
- `node scripts/run-vitest.mjs src/cli` — 292 files / 6386 tests pass. `acp-cli-exit.process.test.ts` fails 2 with `ETIMEDOUT` spawning the tsx CLI entrypoint against a 30s budget; baselined as pre-existing with these changes removed.
- `node scripts/check-changed.mjs` — green.
- `pnpm build` — exit 0, zero `[INEFFECTIVE_DYNAMIC_IMPORT]`.
- Codex autoreview (`gpt-5.6-sol`, high) — clean, no accepted/actionable findings.

Production delta is +26/−1 across three files, 7 of those lines comment.
