### PR TITLE
fix(build): share heap budgets with CI artifact children

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -93,6 +93,14 @@ Use `pnpm ci:timings`, `pnpm ci:timings:recent`, or `node scripts/ci-run-timings
 
 Run the timing helper locally; there is no in-workflow timing-summary job (a permanently disabled one was removed once the local helper became the tool everyone actually used). For build timing, check the `build-artifacts` job's `Build dist` step: `pnpm build:ci-artifacts` prints `[build-all] phase timings:` and includes `ui:build`; the job also uploads the `startup-memory` artifact.
 
+Local `pnpm build:ci-artifacts` uses the same memory admission as full and package
+builds. The orchestrator passes the resolved heap budget to every child process,
+including the SDK declaration writer, so local builds do not depend on CI's
+`NODE_OPTIONS` setting. The existing policy accounts for host and cgroup limits
+and reserves native-memory headroom. If the default budget cannot fit the build,
+it stops before build steps or cache restoration; `OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB`
+remains the explicit operator override for attempting a different budget.
+
 ## PR context and evidence
 
 External contributor PRs run a PR context and evidence gate from

--- a/scripts/build-all.mts
+++ b/scripts/build-all.mts
@@ -568,13 +568,17 @@ export function resolveBuildAllTsdownPlan(
   profile: string,
   env: NodeJS.ProcessEnv,
   params: Omit<MemoryLimitParams, "env"> = {},
-) {
-  if (profile !== "full" && profile !== "package") {
+): {
+  env: NodeJS.ProcessEnv;
+  heapShortfall: ReturnType<typeof resolveTsdownBuildPlan>["heapShortfall"];
+} {
+  if (profile !== "full" && profile !== "package" && profile !== "ciArtifacts") {
     return { env, heapShortfall: null };
   }
   const plan = resolveTsdownBuildPlan({ ...params, env });
   return {
-    env: { ...env, [TSDOWN_MAX_OLD_SPACE_MB_ENV]: String(plan.maxOldSpaceMb) },
+    // Direct Node steps need NODE_OPTIONS; tsdown descendants also need the frozen budget.
+    env: { ...plan.env, [TSDOWN_MAX_OLD_SPACE_MB_ENV]: String(plan.maxOldSpaceMb) },
     heapShortfall: plan.heapShortfall,
   };
 }
@@ -1014,7 +1018,11 @@ export function runBuildAllSteps(
     steps?: BuildAllStep[];
   } = {},
 ) {
-  let buildEnv = resolveBuildAllEnvironment(params.env);
+  const { env: buildEnv, heapShortfall } = resolveBuildAllTsdownPlan(
+    profile,
+    resolveBuildAllEnvironment(params.env),
+    params.memoryLimit,
+  );
   const steps = params.steps ?? resolveBuildAllSteps(profile, buildEnv);
   const cacheEnabled = params.cacheEnabled ?? buildEnv.OPENCLAW_BUILD_CACHE !== "0";
   const logger = params.logger ?? console;
@@ -1028,17 +1036,12 @@ export function runBuildAllSteps(
       spawnSync(invocation.command, invocation.args, invocation.options));
   const timings: BuildAllTiming[] = [];
   let exitCode = 0;
-  if (profile === "full" || profile === "package") {
-    const buildPlan = resolveBuildAllTsdownPlan(profile, buildEnv, params.memoryLimit);
-    const heapShortfall = buildPlan.heapShortfall;
-    if (heapShortfall) {
-      if (heapShortfall.fatal) {
-        logger.error(heapShortfall.message);
-        return { exitCode: 1, timings };
-      }
-      logger.warn(heapShortfall.message);
+  if (heapShortfall) {
+    if (heapShortfall.fatal) {
+      logger.error(heapShortfall.message);
+      return { exitCode: 1, timings };
     }
-    buildEnv = buildPlan.env;
+    logger.warn(heapShortfall.message);
   }
   for (const step of steps) {
     const cacheStartedAt = now();

--- a/scripts/tsdown-build.mts
+++ b/scripts/tsdown-build.mts
@@ -1479,6 +1479,7 @@ export function resolveTsdownBuildPlan(params: TsdownBuildParams = {}) {
     resolvedMaxOldSpaceMb: maxOldSpaceMb,
   };
   return {
+    env: resolveTsdownEnv(params.env ?? process.env, preparedParams),
     maxOldSpaceMb,
     heapShortfall:
       budget.unresolvedCgroupMemory || isFullTsdownBuildPlan(params.args ?? [])

--- a/test/scripts/build-all.test.ts
+++ b/test/scripts/build-all.test.ts
@@ -377,35 +377,57 @@ describe("resolveBuildAllSteps", () => {
     expect(BUILD_ALL_PROFILES.ciArtifacts).not.toContain("tsdown-unified");
   });
 
-  it("admits package builds before their explicit clean step", () => {
+  it("cleans dist before the full package build steps", () => {
     const packageSteps = resolveBuildAllSteps("package");
     expect(packageSteps.map((step) => step.label)).toEqual([
       "clean:dist",
       ...resolveBuildAllSteps("full").map((step) => step.label),
     ]);
-    const runStep = vi.fn(() => ({ status: 0 }));
-
-    const result = runBuildAllSteps("package", {
-      cacheEnabled: false,
-      env: {},
-      logger: { error: vi.fn(), warn: vi.fn() },
-      memoryLimit: { cgroupMemoryLimitBytes: 4 * 1024 * 1024 * 1024 },
-      runStep,
-      steps: packageSteps,
-    });
-
-    expect(result.exitCode).toBe(1);
-    expect(runStep).not.toHaveBeenCalled();
   });
 
-  it("admits the complete default build once and freezes its heap for every child", () => {
-    const tsdownSteps = resolveBuildAllSteps("full").filter((step) =>
+  it.each(["full", "package", "ciArtifacts"])(
+    "refuses %s before any build step or cache work when memory is insufficient",
+    (profile) => {
+      const runStep = vi.fn(() => ({ status: 0 }));
+      const resolveCacheState = vi.fn(() => ({
+        cacheable: false,
+        fresh: false,
+        reason: "no-cache",
+      }));
+      const restoreCache = vi.fn();
+      const finalizeCache = vi.fn();
+      const logger = { error: vi.fn(), warn: vi.fn() };
+
+      const result = runBuildAllSteps(profile, {
+        env: {},
+        logger,
+        memoryLimit: { cgroupMemoryLimitBytes: 4 * 1024 * 1024 * 1024 },
+        resolveCacheState,
+        restoreCache,
+        finalizeCache,
+        runStep,
+      });
+
+      expect(result).toEqual({ exitCode: 1, timings: [] });
+      expect(runStep).not.toHaveBeenCalled();
+      expect(resolveCacheState).not.toHaveBeenCalled();
+      expect(restoreCache).not.toHaveBeenCalled();
+      expect(finalizeCache).not.toHaveBeenCalled();
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("Stopping before any build output is removed"),
+      );
+      expect(logger.warn).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["full", "package"])("admits %s once and freezes its heap for every child", (profile) => {
+    const tsdownSteps = resolveBuildAllSteps(profile).filter((step) =>
       step.label.startsWith("tsdown-"),
     );
     const tsdownInvocations: ReturnType<typeof resolveBuildAllStep>[] = [];
     const executionOrder: string[] = [];
     const restoreCache = vi.fn();
-    const result = runBuildAllSteps("full", {
+    const result = runBuildAllSteps(profile, {
       cacheEnabled: true,
       env: {},
       finalizeCache: vi.fn(),
@@ -445,6 +467,7 @@ describe("resolveBuildAllSteps", () => {
     expect(tsdownInvocations).toHaveLength(3);
     for (const invocation of tsdownInvocations) {
       expect(invocation.options.env.OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB).toBe("4352");
+      expect(invocation.options.env.NODE_OPTIONS).toBe("--max-old-space-size=4352");
     }
     expect(restoreCache).toHaveBeenCalledOnce();
     expect(executionOrder).toEqual([
@@ -456,23 +479,10 @@ describe("resolveBuildAllSteps", () => {
       "run:tsdown-unified",
     ]);
 
-    const fatalRunner = vi.fn(() => ({ status: 0 }));
-    const fatalResult = runBuildAllSteps("full", {
-      cacheEnabled: false,
-      env: {},
-      logger: { error: vi.fn(), warn: vi.fn() },
-      memoryLimit: { cgroupMemoryLimitBytes: 4 * 1024 * 1024 * 1024 },
-      now: () => 0,
-      resolveCacheState: () => ({ cacheable: false, fresh: false, reason: "no-cache" }),
-      runStep: fatalRunner,
-      steps: tsdownSteps,
-    });
-    expect(fatalResult.exitCode).toBe(1);
-    expect(fatalRunner).not.toHaveBeenCalled();
-
     const cacheDisabledRunner = vi.fn(() => ({ status: 0 }));
     runBuildAllSteps("ciArtifacts", {
       env: { OPENCLAW_BUILD_CACHE: "0" },
+      memoryLimit: { cgroupMemoryLimitBytes: 5 * 1024 * 1024 * 1024 },
       finalizeCache: vi.fn(),
       logger: { error: vi.fn(), warn: vi.fn() },
       now: () => 0,
@@ -495,14 +505,117 @@ describe("resolveBuildAllSteps", () => {
     expect(cacheDisabledRunner).toHaveBeenCalledOnce();
   });
 
-  it("skips heap admission for partial profiles", () => {
-    const partialEnv = { MARKER: "unchanged" };
-    expect(
-      resolveBuildAllTsdownPlan("qaRuntime", partialEnv, {
-        cgroupMemoryLimitBytes: 4 * 1024 * 1024 * 1024,
-      }),
-    ).toEqual({ env: partialEnv, heapShortfall: null });
-  });
+  it.each(["gatewayWatch", "qaRuntime", "sourcePerformance", "cliStartup"])(
+    "skips heap admission for partial profile %s",
+    (profile) => {
+      const partialEnv = { MARKER: "unchanged", NODE_OPTIONS: "--max-old-space-size=256" };
+      expect(
+        resolveBuildAllTsdownPlan(profile, partialEnv, {
+          cgroupMemoryLimitBytes: 4 * 1024 * 1024 * 1024,
+        }),
+      ).toEqual({ env: partialEnv, heapShortfall: null });
+      const runStep = vi.fn<
+        (invocation: ReturnType<typeof resolveBuildAllStep>) => { status: number }
+      >(() => ({ status: 0 }));
+      const result = runBuildAllSteps(profile, {
+        env: partialEnv,
+        logger: { error: vi.fn(), warn: vi.fn() },
+        memoryLimit: { cgroupMemoryLimitBytes: 4 * 1024 * 1024 * 1024 },
+        resolveCacheState: () => ({ cacheable: false, fresh: false, reason: "no-cache" }),
+        runStep,
+      });
+      expect(result.exitCode).toBe(0);
+      expect(runStep).toHaveBeenCalled();
+      for (const [invocation] of runStep.mock.calls) {
+        expect(invocation.options.env).toMatchObject(partialEnv);
+        expect(invocation.options.env.OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB).toBeUndefined();
+      }
+    },
+  );
+
+  it.each([
+    {
+      label: "cgroup cap",
+      env: {},
+      cgroupGiB: 7,
+      heapMb: 6400,
+      nodeOptions: "--max-old-space-size=6400",
+      warns: false,
+    },
+    {
+      label: "CI ambient heap above the cgroup budget",
+      env: { NODE_OPTIONS: "--max-old-space-size=8192" },
+      cgroupGiB: 7,
+      heapMb: 6400,
+      nodeOptions: "--max-old-space-size=6400",
+      warns: false,
+    },
+    {
+      label: "explicit override",
+      env: {
+        NODE_OPTIONS: "--trace-warnings --max-old-space-size=8192",
+        OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB: "4096",
+      },
+      cgroupGiB: 4,
+      heapMb: 4096,
+      nodeOptions: "--trace-warnings --max-old-space-size=4096",
+      warns: true,
+    },
+  ])(
+    "hands the cold ciArtifacts writer an effective child heap from $label",
+    ({ env, cgroupGiB, heapMb, nodeOptions, warns }) => {
+      const invocations: ReturnType<typeof resolveBuildAllStep>[] = [];
+      const logger = { error: vi.fn(), warn: vi.fn() };
+      const result = runBuildAllSteps("ciArtifacts", {
+        env,
+        logger,
+        memoryLimit: {
+          platform: "linux",
+          availableMemoryBytes: 16 * 1024 ** 3,
+          procMemTotalBytes: 16 * 1024 ** 3,
+          cgroupMemoryLimitBytes: cgroupGiB * 1024 ** 3,
+        },
+        resolveCacheState: () => ({ cacheable: true, fresh: false, reason: "missing-inputs" }),
+        finalizeCache: vi.fn(),
+        runStep(invocation) {
+          invocations.push(invocation);
+          return { status: 0 };
+        },
+      });
+      expect(result.exitCode).toBe(0);
+      const writer = expectDefined(
+        invocations.find((invocation) =>
+          invocation.args.includes("scripts/write-plugin-sdk-entry-dts.ts"),
+        ),
+        "SDK declaration writer invocation",
+      );
+      expect(writer.options.env.OPENCLAW_PLUGIN_SDK_CANONICAL_DTS).toBe("0");
+
+      // Probe the writer's actual launch environment without compiling the declaration graph.
+      // A CLI flag supplies an independent reference across Node versions' V8 overheads.
+      const probeArgs = ["-p", 'require("node:v8").getHeapStatistics().heap_size_limit'];
+      const probeOptions = {
+        ...writer.options,
+        stdio: "pipe" as const,
+        encoding: "utf8" as const,
+        timeout: 10_000,
+      };
+      const actual = spawnSync(writer.command, probeArgs, probeOptions);
+      const expected = spawnSync(
+        writer.command,
+        [`--max-old-space-size=${heapMb}`, ...probeArgs],
+        probeOptions,
+      );
+      expect(actual.status, actual.stderr).toBe(0);
+      expect(expected.status, expected.stderr).toBe(0);
+      expect(Number(actual.stdout)).toBe(Number(expected.stdout));
+      for (const invocation of invocations) {
+        expect(invocation.options.env.NODE_OPTIONS).toBe(nodeOptions);
+        expect(invocation.options.env.OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB).toBe(String(heapMb));
+      }
+      expect(logger.warn).toHaveBeenCalledTimes(warns ? 1 : 0);
+    },
+  );
 
   it("rebuilds runtime JS while reusing fresh declaration groups", () => {
     const ai = getBuildAllStep("tsdown-ai");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers running CI-artifact builds could have child processes ignore the build's resolved memory budget. The tsdown wrapper normalizes its own descendants, but the sibling SDK declaration writer—and its source-discovery child—inherit ambient `NODE_OPTIONS` instead. An ambient 8 GiB heap therefore remains 8 GiB even when the existing host/cgroup-aware policy resolves a smaller budget.

The original local SDK heap failure prompted this investigation. [The landed declaration-graph repair](https://github.com/openclaw/openclaw/pull/130986) separately removes duplicate compiler graphs; this PR preserves that fix and does not claim the SDK requires a larger heap. Related: [the existing cgroup-aware build memory policy](https://github.com/openclaw/openclaw/pull/123979).

## Why This Change Was Made

The common build orchestrator now resolves and admits one memory environment for full, package, and CI-artifact builds, then passes both normalized `NODE_OPTIONS` and the existing frozen-budget marker to child processes. CI-artifact admission happens before build steps or cache restoration. This reuses the canonical policy rather than adding an SDK-specific number, parser, self-respawn path, or retry.

Partial profiles retain their existing behavior. Main's updater-environment normalization, explicit declaration overrides, declaration-source discovery, and cache invalidation remain intact. No heap constants, configuration names, dependency versions, baselines, compiler options, or timeouts change.

## User Impact

Build phases consistently honor the existing resolved resource budget, including downward caps and explicit operator overrides. No Gateway runtime behavior or public SDK declarations change. The existing boundary-preparation runner's separate explicit root-shims override is outside this patch.

Constrained-build compatibility is intentional: `ciArtifacts` already invokes the normal tsdown wrapper, which applies the same unified-runtime admission threshold even when global declaration emission is disabled. This moves that existing refusal ahead of asset/cache work; it does not add an SDK-specific minimum. The documented `OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB` override remains the supported explicit opt-in to attempt a smaller budget, with the existing warning. Tests cover early refusal and override continuation.

## Evidence

- **Exact-head CI passed:** [run 33187758582, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33187758582), head `3c584871a21433795d4e7ccbeaa928605dab37f8`, including the required Actions-owned `openclaw/ci-gate`. [ClawSweeper's completed review](https://github.com/openclaw/openclaw/pull/131885#issuecomment-5454799161) found no code/security defects; its constrained-build compatibility question is addressed above.

- **Current-main failing/passing boundary proof:** with ambient `--max-old-space-size=8192` and a synthetic 7 GiB memory budget, the existing policy resolves 6400 MiB after headroom. Exact main orchestrator/tsdown sources at `3ab172649f7d7a8068935818180461b32e016176` launched a real Node heap probe using the SDK writer's environment with a V8 limit of **8384 MiB**, failing the expected-budget assertion. The candidate launches it with **6592 MiB**, matching an independent `--max-old-space-size=6400` CLI reference. V8 overhead is included in those observed limits; this is not a real-cgroup allocation benchmark.
- **240 tests passed** across the build-all, tsdown-build, and declaration-source-index suites, including no ambient heap, downward CI caps, explicit overrides, early refusal, partial profiles, updater normalization, and compiler graph siblings.
- Scoped changed checks passed: formatting, script and root-test typechecks, type-aware script lint, and the selected guards. Fresh isolated Codex **P0-only** autoreview found no actionable findings after the main integration.
- **Complete integrated CI-artifact build passed** on candidate `3c584871a21433795d4e7ccbeaa928605dab37f8`, Node **24.20.0**, after frozen-lockfile installation and with ambient heap overrides removed. All phases passed; reported phase total **14m 20.3s**, SDK generation **6m 7.8s**, and the unchanged startup-metadata step **64.2s** under its existing 120-second deadline. All **147 public SDK subpaths** passed the actual export/type/runtime gate; the public declaration graph is **3,422,235 / 5,315,536 bytes**. All **774 UI sidecars** verified; startup JS **345,403 B gzip** is below the unchanged **347,037 B** enforcement limit. No ineffective-dynamic-import diagnostic appeared. Timings are observations on a contended host, not a controlled benchmark.

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/build-all.test.ts test/scripts/tsdown-build.test.ts test/scripts/declaration-source-index.test.ts
```

```bash
node scripts/check-changed.mjs -- scripts/build-all.mts scripts/tsdown-build.mts test/scripts/build-all.test.ts docs/ci.md
```

```bash
env -u NODE_OPTIONS -u OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB pnpm build:ci-artifacts
```

Production/tooling: **+18/-14 (net +4)**. Tests: **+151/-38 (net +113)**. Documentation: **+8/-0**. The small tooling growth exposes the existing plan environment and its type contract while deleting duplicated admission branching.

AI-assisted; maintainer-owned change.
