### PR TITLE
improve(test): reduce channel consent fixture overhead

### DIFF
--- a/src/plugins/update-channel.consent.test.ts
+++ b/src/plugins/update-channel.consent.test.ts
@@ -55,7 +55,13 @@ describe("channel migration artifact consent", () => {
     }
     writeArtifact(installedDir, "1.0.0", ["existing-provider"]);
     writeArtifact(stagedDir, "2.0.0", ["existing-provider", "new-provider"]);
-    const env = { ...process.env, OPENCLAW_STATE_DIR: path.join(root, "state"), HOME: root };
+    const env = {
+      ...process.env,
+      OPENCLAW_STATE_DIR: path.join(root, "state"),
+      HOME: root,
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_DISABLE_BUNDLED_SOURCE_OVERLAYS: "1",
+    };
     const previousSurface = resolvePluginArtifactDeclaredSurface(installedDir, env);
     const config: OpenClawConfig = {
       plugins: {


### PR DESCRIPTION
Related: #131301 (explicit plugin capability consent during update and repair).

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled through this repository-owned branch.

</details>

## What Problem This Solves

The new channel-migration consent tests repeatedly scan the checkout's unrelated bundled plugin inventory. This adds about 1.4 seconds to the complete 15-case file on a prepared Linux CI machine.

## Why This Change Was Made

Use the existing empty-bundle environment settings already used by the sibling capability-consent tests. Each case still creates independent installed and staged plugin artifacts and uses real manifest discovery, ownership resolution, consent callbacks, final-stage rereading, and acceptance-record construction. The existing installer mocks, case matrix, assertions, cleanup, and timeouts are unchanged. Production is unchanged.

## User Impact

No operator behavior changes. The complete consent test file runs faster while retaining npm, ClawHub, and fallback coverage for absent, accepted, stale, replaced, and throwing consent. This is a maintainer-requested, AI-assisted test-performance change using Codex.

## Evidence

Benchmark and fault proof: [Blacksmith Testbox run](https://github.com/openclaw/openclaw/actions/runs/33185633068), lease `tbx_01m14g0d190wscmwkj1fa0kq9a`, 16 vCPU, Node 24.19.0, pnpm 11.22.0, Vitest 4.1.11. Base `3ab172649f7d7a8068935818180461b32e016176`; affected test/production owner unchanged through the refreshed PR base.

The whole-file command used the repository's plugins CI routing, one worker, a distinct filesystem-module cache path for every run, import diagnostics, and GNU time. Both warmups were excluded. Order was AB, BA, AB, BA, BA, AB, BA, AB. No samples were discarded.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 \
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/codex-performance-plugin-update/consent-bench/1-A-cache \
OPENCLAW_VITEST_IMPORT_DURATIONS=1 \
OPENCLAW_VITEST_PRINT_IMPORT_BREAKDOWN=1 \
/usr/bin/time -v pnpm test src/plugins/update-channel.consent.test.ts \
  --maxWorkers=1 --reporter=verbose
```

| Pair | Order | Original wall (s) | Candidate wall (s) | Saved (s) |
| --- | --- | ---: | ---: | ---: |
| 1 | AB | 8.90 | 6.97 | 1.93 |
| 2 | BA | 7.84 | 7.13 | 0.71 |
| 3 | AB | 9.06 | 6.87 | 2.19 |
| 4 | BA | 9.01 | 6.94 | 2.07 |
| 5 | BA | 7.46 | 6.22 | 1.24 |
| 6 | AB | 7.34 | 6.23 | 1.11 |
| 7 | BA | 8.14 | 6.17 | 1.97 |
| 8 | AB | 8.28 | 8.14 | 0.14 |

Mean whole-file wall: **8.254 → 6.834 s**, saving **1.420 s / 17.2%**, with **8/8 directional pairs**. Paired 95% t interval: **0.800–2.040 s saved**; exact one-sided sign-flip p=0.00390625. The last pair is retained despite its smaller gain.

| Mean metric | Original | Candidate |
| --- | ---: | ---: |
| Vitest duration | 4.029 s | 2.474 s |
| Test bodies | 1.780 s | 0.170 s |
| Imports | 1.325 s | 1.311 s |
| Transform | 1.786 s | 1.796 s |
| Setup | 0.703 s | 0.743 s |
| User CPU | 9.268 s | 7.355 s |
| System CPU | 0.808 s | 0.628 s |
| CPU utilization | 121.6% | 116.4% |
| Maximum RSS | 837,892 KiB | 644,690 KiB |
| Files / tests / workers | 1 / 15 / 1 | 1 / 15 / 1 |

All 240 measured case executions passed. No test subprocess, browser, socket, or database fixture was removed; all 30 installed/staged subject artifacts remain independent. Imports are unchanged; the retained import report shows its default top ten entries, not a complete module count. The saving comes from reducing unrelated fixture inventory, not moving cost into setup or imports.

**Fault proof:** temporarily replaced the real final staged-artifact inspection in `src/plugins/capability-consent.ts` with the earlier inspection result. The changed test failed exactly the npm, ClawHub, and fallback `replaced` cases with `expected true to be false` at the update-result assertion; the other 12 passed. Restored production SHA-256 `176616b754b884e4c19884c3189e3d66961614ca8a45557759761108cdd6a94d` exactly, then all 15 passed. No mutation is retained.

**Coverage and order:** the three-file owner/sibling scope passed all 204 tests normally and with `--sequence.shuffle --sequence.seed=1729` and `--sequence.seed=20260828` on the same Testbox. It also passed all 204 tests on refreshed main before commit:

```sh
pnpm test src/plugins/update-channel.consent.test.ts \
  src/plugins/capability-consent.test.ts src/plugins/update.test.ts --maxWorkers=1
```

Test-audit: retained source-attempt consent ownership, staged replacement rejection, acceptance integrity, denial retention, callback-error propagation, independent fixtures, and cleanup. No new production seam or broader mock. Diff-scoped deslop and fresh Codex autoreview found no actionable issues. Targeted formatting and `git diff --check` pass. Production LOC **+0/-0**; tests **+7/-1**.

The complete `pnpm check:changed -- src/plugins/update-channel.consent.test.ts` gate passed on a fresh validation Testbox: [changed-gate run](https://github.com/openclaw/openclaw/actions/runs/33186394518). This included all 14 test typecheck graphs, the full Knip scans, targeted lint, formatting, and repository guards. Both task-owned Testboxes are stopped. This validation host was separate from the single-host A/B experiment and was not used in the benchmark comparison.
