### PR TITLE
fix: restart continuation never runs for agents without a heartbeat schedule

### DIFF
--- a/src/infra/heartbeat-runner.targeted-unscheduled-wake.test.ts
+++ b/src/infra/heartbeat-runner.targeted-unscheduled-wake.test.ts
@@ -266,6 +266,68 @@ describe("startHeartbeatRunner targeted unscheduled wake dispatch", () => {
     runner.stop();
   });
 
+  it("runs one targeted restart-sentinel wake when heartbeat cadence is disabled", async () => {
+    useFakeHeartbeatTime();
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = await expectWakeDispatch({
+      cfg: {
+        agents: { defaults: { heartbeat: { every: "0m" } }, list: [{ id: "main" }] },
+      } as OpenClawConfig,
+      runSpy,
+      wake: {
+        source: "restart-sentinel",
+        intent: "immediate",
+        reason: "wake",
+        sessionKey: "agent:main:main",
+        coalesceMs: 0,
+      },
+      expectedCall: {
+        agentId: "main",
+        source: "restart-sentinel",
+        intent: "immediate",
+        reason: "wake",
+        sessionKey: "agent:main:main",
+      },
+    });
+    runner.stop();
+  });
+
+  it.each([
+    {
+      name: "without a session target",
+      wake: { agentId: "main", sessionKey: undefined },
+    },
+    {
+      name: "with event intent",
+      wake: { agentId: "main", sessionKey: "agent:main:main", intent: "event" as const },
+    },
+    {
+      name: "with a non-wake reason",
+      wake: { agentId: "main", sessionKey: "agent:main:main", reason: "manual" },
+    },
+  ])("rejects an unscheduled restart-sentinel wake $name", async ({ wake }) => {
+    useFakeHeartbeatTime();
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = startHeartbeatRunner({
+      cfg: {
+        agents: { defaults: { heartbeat: { every: "0m" } }, list: [{ id: "main" }] },
+      } as OpenClawConfig,
+      runOnce: runSpy,
+    });
+
+    requestHeartbeat({
+      source: "restart-sentinel",
+      intent: "immediate",
+      reason: "wake",
+      ...wake,
+      coalesceMs: 0,
+    });
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(runSpy).not.toHaveBeenCalled();
+    runner.stop();
+  });
+
   it("rejects targeted hook wakes for unconfigured agents", async () => {
     useFakeHeartbeatTime();
     const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });

--- a/src/infra/heartbeat-wake-policy.ts
+++ b/src/infra/heartbeat-wake-policy.ts
@@ -73,6 +73,7 @@ export function isTargetedUnscheduledWake(params: TargetedUnscheduledWakeParams)
   switch (params.source) {
     case "manual":
     case "notifications-event":
+    case "restart-sentinel":
       return params.intent === "immediate" && hasSessionTarget && reason === "wake";
     case "hook":
       return params.intent === "immediate" && (reason?.startsWith("hook:") ?? false);


### PR DESCRIPTION
Closes #131850

## What Problem This Solves

Restart recovery queues a continuation and requests an immediate, session-targeted heartbeat wake. A configured agent with recurring heartbeat cadence disabled had no scheduled runner entry, and the shared unscheduled-wake policy rejected the `restart-sentinel` source. The Gateway consumed the restart sentinel, but no agent turn processed the queued note.

## Root cause

`isTargetedUnscheduledWake` is the canonical admission owner for targeted events when no recurring schedule exists. It admitted the same restricted shape for manual and notification wakes, but omitted the restart-sentinel producer.

## Fix

- Admit `restart-sentinel` only with immediate intent, a session target, and reason `wake`.
- Keep restart provenance instead of making the producer impersonate another wake source.
- Cover successful dispatch plus missing-session, wrong-intent, and wrong-reason rejection at the scheduler boundary.

## Evidence

- Exact task-start main `22975b110167533cdb106219a9fa4e194589e920`: an isolated Gateway reached ready with `heartbeat.every: "0m"`, consumed the staged restart sentinel, and made zero model-provider requests.
- Exact head `4a5ed52b83fc883d22e922549014a2fbc5b0e0f4`: the same isolated restart flow made exactly one provider request, and that request contained the unique continuation note.
- The added positive regression test fails on the pre-fix policy with `expected "vi.fn()" to be called 1 times, but got 0 times`.
- `node scripts/run-vitest.mjs src/infra/heartbeat-runner.targeted-unscheduled-wake.test.ts src/gateway/server-restart-sentinel.test.ts`: 17 + 75 tests passed.
- Focused formatting, Oxlint, max-lines, assertion-safety, coercion-helper, database-first, import-cycle, and test-temp guards passed.

## Scope

- Production: +1 line in the canonical wake-policy switch.
- Tests: +62 lines at the scheduler boundary.
- No config, schema, protocol, storage, or user-interface surface changes.

AI-assisted contribution: the public author states that an AI coding agent prepared the original patch and the human operator reviewed it.
