### PR TITLE
fix(test): await Gateway readiness and finish lifecycle cleanup

### DIFF
--- a/test/helpers/openclaw-test-instance.test.ts
+++ b/test/helpers/openclaw-test-instance.test.ts
@@ -1,12 +1,15 @@
 // OpenClaw test instance tests cover spawned test instance lifecycle.
 import { EventEmitter } from "node:events";
 import fs from "node:fs/promises";
+import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
+import { setTimeout as delay } from "node:timers/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createOpenClawTestInstance, testing } from "./openclaw-test-instance.js";
 import { isProcessAlive } from "./process-wait.js";
+import { createDeferred } from "./promise.js";
 
 const MIGRATION_CONVERGENCE_REFUSAL =
   "OpenClaw plugin migration inputs changed during startup convergence;";
@@ -14,6 +17,8 @@ const RESTART_MARKER =
   "[openclaw-test-instance] restarting gateway after migration convergence refusal";
 const fakeInstances: Awaited<ReturnType<typeof createOpenClawTestInstance>>[] = [];
 const fakeRoots: string[] = [];
+const fakeOperations: Promise<unknown>[] = [];
+const fakeControls: Awaited<ReturnType<typeof createGatewayControl>>[] = [];
 
 type FakeGatewayAttempt = {
   argv: string[];
@@ -25,26 +30,143 @@ type FakeGatewayAttempt = {
 };
 
 afterEach(async () => {
-  await Promise.allSettled(fakeInstances.splice(0).map((instance) => instance.cleanup()));
-  await Promise.allSettled(fakeRoots.splice(0).map((root) => fs.rm(root, { recursive: true })));
+  const controls = fakeControls.splice(0);
+  for (const control of controls) {
+    control.unblock();
+  }
+  await Promise.allSettled(fakeOperations.splice(0));
+  const results = await Promise.allSettled(
+    fakeInstances.splice(0).map(async (instance) => {
+      // Baseline failures can spawn after cleanup has already marked itself done.
+      try {
+        await instance.stopGateway();
+        await instance.cleanup();
+      } catch (error) {
+        fakeInstances.push(instance);
+        throw error;
+      }
+    }),
+  );
+  const controlResults = await Promise.allSettled(
+    controls.map(async (control) => {
+      try {
+        await control.close();
+      } catch (error) {
+        fakeControls.push(control);
+        throw error;
+      }
+    }),
+  );
+  const failures = [...results, ...controlResults].flatMap((result) =>
+    result.status === "rejected" ? [result.reason] : [],
+  );
+  if (failures.length > 0) {
+    throw new AggregateError(failures, "fake Gateway cleanup failed; owners and roots retained");
+  }
+  await Promise.all(fakeRoots.splice(0).map((root) => fs.rm(root, { recursive: true })));
 });
 
-async function createFakeGateway(sequence: string, startTimeoutMs = 1_000, stopTimeoutMs = 1_500) {
+function trackOperation<T>(operation: Promise<T>): Promise<T> {
+  fakeOperations.push(operation.catch(() => undefined));
+  return operation;
+}
+
+async function createGatewayControl() {
+  const reached = createDeferred<void>();
+  const released = createDeferred<void>();
+  const launches: number[] = [];
+  const observers = { beforeRelease: () => {}, onLaunch: () => {} };
+  const server = createServer((request, response) => {
+    const url = new URL(request.url ?? "/", "http://127.0.0.1");
+    if (url.pathname === "/wait") {
+      reached.resolve();
+      void released.promise.then(() => response.end("released"));
+      return;
+    }
+    if (url.pathname === "/release") {
+      observers.beforeRelease();
+      released.resolve();
+    } else if (url.pathname === "/launch") {
+      launches.push(Number(url.searchParams.get("pid")));
+      observers.onLaunch();
+    }
+    response.end("ok");
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("control server has no port");
+  }
+  const url = `http://127.0.0.1:${address.port}`;
+  const control = {
+    url,
+    reached: reached.promise,
+    launches,
+    observers,
+    unblock: () => released.resolve(),
+    release: async () => {
+      const response = await fetch(`${url}/release`);
+      await response.text();
+    },
+    close: async () => {
+      released.resolve();
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    },
+  };
+  fakeControls.push(control);
+  return control;
+}
+
+async function createFakeGateway(
+  sequence: string,
+  startTimeoutMs = 1_000,
+  stopTimeoutMs = 1_500,
+  control?: { url: string; holdPreparation?: boolean },
+) {
   const cwd = await fs.mkdtemp(path.join(tmpdir(), "openclaw-test-instance-gateway-"));
   fakeRoots.push(cwd);
   const distDir = path.join(cwd, "dist");
   const tracePath = path.join(cwd, "attempts.jsonl");
+  // Diagnostic runs keep these receipts outside Vitest's disposable temp tree.
+  const processReceipt = `
+const registry = ${JSON.stringify(process.env.OPENCLAW_HELPER_PROOF_PID_REGISTRY ?? null)};
+function recordFixtureProcess(pid) {
+  if (!registry) return;
+  let identity;
+  try {
+    identity = execFileSync("/bin/ps", ["-p", String(pid), "-o", "pgid=", "-o", "lstart=", "-o", "command="], { encoding: "utf8", env: { PATH: "/usr/bin:/bin", LC_ALL: "C", TZ: "UTC" }, timeout: 1_000 }).trim();
+  } catch (error) {
+    if (error.status === 1) return;
+    throw error;
+  }
+  appendFileSync(registry, JSON.stringify({ pid, cwd: process.cwd(), identity }) + "\\n");
+}
+recordFixtureProcess(process.pid);
+`;
   await fs.mkdir(distDir);
   await Promise.all([
-    fs.writeFile(path.join(distDir, ".buildstamp"), ""),
-    fs.writeFile(path.join(distDir, ".runtime-postbuildstamp"), ""),
+    ...(control?.holdPreparation
+      ? []
+      : [
+          fs.writeFile(path.join(distDir, ".buildstamp"), ""),
+          fs.writeFile(path.join(distDir, ".runtime-postbuildstamp"), ""),
+        ]),
     fs.writeFile(
       path.join(distDir, "index.mjs"),
       `
-import { spawn } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
 import { createServer } from "node:http";
+${processReceipt}
 const tracePath = process.env.OPENCLAW_FAKE_GATEWAY_TRACE;
+const controlUrl = process.env.OPENCLAW_FAKE_GATEWAY_CONTROL;
+if (controlUrl) await (await fetch(controlUrl + "/launch?pid=" + process.pid)).text();
 const countPath = tracePath + ".count";
 let attempt = 1;
 try { attempt = Number(readFileSync(countPath, "utf8")) + 1; } catch {}
@@ -53,42 +175,59 @@ const argv = process.argv.slice(2);
 const port = Number(argv[argv.indexOf("--port") + 1]);
 const env = Object.fromEntries(["HOME", "OPENCLAW_CONFIG_PATH", "OPENCLAW_GATEWAY_TOKEN", "OPENCLAW_STATE_DIR"].map((key) => [key, process.env[key]]));
 appendFileSync(tracePath, JSON.stringify({ argv, config: JSON.parse(readFileSync(process.env.OPENCLAW_CONFIG_PATH, "utf8")), cwd: process.cwd(), env, pid: process.pid, port }) + "\\n");
-const action = (process.env.OPENCLAW_FAKE_GATEWAY_SEQUENCE || "ready").split(",")[attempt - 1] || "ready";
-const [kind, delay] = action.split(":");
-if (delay) await new Promise((resolve) => setTimeout(resolve, Number(delay)));
+const kind = (process.env.OPENCLAW_FAKE_GATEWAY_SEQUENCE || "ready").split(",")[attempt - 1] || "ready";
 process.stdout.write("fake gateway attempt " + attempt + "\\n");
 const refusal = ${JSON.stringify(MIGRATION_CONVERGENCE_REFUSAL)};
 if (kind === "refuse") { process.stderr.write(refusal + " fixture\\n"); process.exit(1); }
-if (kind === "late-refuse") { spawn(process.execPath, ["-e", 'setTimeout(() => process.stderr.write(process.argv[1]), 50)', refusal + " delayed fixture\\n"], { stdio: ["ignore", "ignore", "inherit"] }); process.exit(1); }
+if (kind === "late-refuse") { const delayed = spawn(process.execPath, ["-e", 'setTimeout(() => process.stderr.write(process.argv[1]), 50)', refusal + " delayed fixture\\n"], { stdio: ["ignore", "ignore", "inherit"] }); recordFixtureProcess(delayed.pid); process.exit(1); }
 if (kind === "resist-after-exit") {
   const resistant = spawn(process.execPath, ["-e", 'const fs = require("node:fs");fs.writeFileSync(process.argv[1], String(process.pid));process.on("SIGTERM", () => fs.appendFileSync(process.argv[2], "SIGTERM"));process.send("ready");setInterval(() => {}, 1_000);', tracePath + ".resistant-pid", tracePath + ".signals"], { stdio: ["ignore", "ignore", "inherit", "ipc"] });
   await new Promise((resolve) => resistant.once("message", resolve));
+  recordFixtureProcess(resistant.pid);
   process.stderr.write("unrelated startup failure\\n"); process.exit(1);
 }
-if (kind === "terminal-drain") {
+if (kind === "terminal-drain" || kind === "refusal-drain") {
   const draining = spawn(process.execPath, ["-e", 'const fs = require("node:fs");const release = process.argv[1];const deadline = Date.now() + 5_000;const timer = setInterval(() => { if (fs.existsSync(release) || Date.now() >= deadline) clearInterval(timer); }, 10);', tracePath + ".draining-release"], { detached: true, stdio: ["ignore", "ignore", "inherit"] });
   draining.unref();
+  recordFixtureProcess(draining.pid);
   writeFileSync(tracePath + ".draining-pid", String(draining.pid));
-  process.stderr.write("terminal startup failure\\n"); process.exit(7);
+  process.stderr.write(kind === "refusal-drain" ? refusal + " held fixture\\n" : "terminal startup failure\\n"); process.exit(kind === "refusal-drain" ? 1 : 7);
 }
 if (kind === "near") { process.stderr.write(refusal.slice(0, -1) + " fixture\\n"); process.exit(1); }
 if (kind === "stdout") { process.stdout.write(refusal + " fixture\\n"); process.exit(1); }
 if (kind === "status2") { process.stderr.write(refusal + " fixture\\n"); process.exit(2); }
 if (kind === "signal") { process.stderr.write(refusal + " fixture\\n"); process.kill(process.pid, "SIGTERM"); }
 if (kind === "unrelated") { process.stderr.write("unrelated startup failure\\n"); process.exit(1); }
-if (kind === "hang") { process.on("SIGTERM", () => process.exit(0)); setInterval(() => {}, 1_000); } else {
-  const server = createServer((req, res) => { res.writeHead(req.url === "/readyz" ? 200 : 404, { "content-type": "application/json" }); res.end(JSON.stringify({ ready: req.url === "/readyz" })); });
-  process.on("SIGTERM", () => server.close(() => process.exit(0))); server.listen(port, "127.0.0.1");
-}
+const server = createServer(async (req, res) => {
+  if (req.url === "/readyz" && kind === "held-ready") await (await fetch(controlUrl + "/wait")).text();
+  res.writeHead(req.url === "/readyz" ? 200 : 404, { "content-type": "application/json" });
+  res.end(JSON.stringify({ ready: req.url === "/readyz" && kind !== "never-ready" }));
+});
+process.on("SIGTERM", () => server.close(() => process.exit(0))); server.listen(port, "127.0.0.1");
 `,
     ),
   ]);
+  if (control?.holdPreparation) {
+    await fs.mkdir(path.join(cwd, "scripts"));
+    // This is a fixture bootstrap, not the repository's build entrypoint.
+    await fs.writeFile(
+      path.join(cwd, "scripts", "run-node.mjs"),
+      `import { appendFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+${processReceipt}
+await (await fetch(${JSON.stringify(`${control.url}/wait`)})).text();
+writeFileSync("dist/.buildstamp", "");
+writeFileSync("dist/.runtime-postbuildstamp", "");
+`,
+    );
+  }
   const instance = await createOpenClawTestInstance({
     name: `fake-gateway-${path.basename(cwd)}`,
     cwd,
     env: {
       OPENCLAW_FAKE_GATEWAY_SEQUENCE: sequence,
       OPENCLAW_FAKE_GATEWAY_TRACE: tracePath,
+      OPENCLAW_FAKE_GATEWAY_CONTROL: control?.url,
     },
     startTimeoutMs,
     stopTimeoutMs,
@@ -127,6 +266,108 @@ function createGatewayProcessState(
 }
 
 describe("openclaw test instance", () => {
+  it("joins concurrent starts until the real readiness response arrives", async () => {
+    const control = await createGatewayControl();
+    const { instance } = await createFakeGateway("held-ready", 1_000, 1_500, control);
+    const firstStart = trackOperation(instance.startGateway());
+    await Promise.race([control.reached, firstStart]);
+
+    let secondSettled = false;
+    let settledBeforeReady: boolean | undefined;
+    const secondStart = trackOperation(
+      instance.startGateway().finally(() => {
+        secondSettled = true;
+      }),
+    );
+    // Observe at a real HTTP boundary before the child's held /readyz can reply.
+    control.observers.beforeRelease = () => {
+      settledBeforeReady = secondSettled;
+    };
+    await control.release();
+    await Promise.all([firstStart, secondStart]);
+
+    expect(settledBeforeReady).toBe(false);
+    expect(control.launches).toHaveLength(1);
+    expect(instance.child?.pid).toBe(control.launches[0]);
+    const response = await fetch(`http://127.0.0.1:${instance.port}/readyz`);
+    expect(await response.json()).toEqual({ ready: true });
+  });
+
+  it("orders a new start after an intervening stop instead of joining the earlier start", async () => {
+    const control = await createGatewayControl();
+    const { instance } = await createFakeGateway("held-ready,ready", 1_000, 1_500, control);
+    const firstStart = trackOperation(instance.startGateway());
+    await Promise.race([control.reached, firstStart]);
+    const stopped = trackOperation(instance.stopGateway());
+    const secondStart = trackOperation(instance.startGateway());
+
+    await control.release();
+    await Promise.allSettled([firstStart]);
+    await stopped;
+    await secondStart;
+
+    expect(control.launches).toHaveLength(2);
+    expect(control.launches[1]).not.toBe(control.launches[0]);
+    expect(isProcessAlive(control.launches[0]!)).toBe(false);
+    expect(instance.child?.pid).toBe(control.launches[1]);
+    const response = await fetch(`http://127.0.0.1:${instance.port}/readyz`);
+    expect(await response.json()).toEqual({ ready: true });
+  });
+
+  it("starts a ready replacement after a real readiness deadline expires", async () => {
+    const control = await createGatewayControl();
+    const { instance } = await createFakeGateway("never-ready,ready", 1_000, 1_500, control);
+    await expect(trackOperation(instance.startGateway())).rejects.toThrow(
+      "timeout waiting for gateway readiness",
+    );
+    const firstPid = control.launches[0];
+    expect(firstPid).toBeTypeOf("number");
+
+    await trackOperation(instance.startGateway());
+    const response = await fetch(`http://127.0.0.1:${instance.port}/readyz`);
+    expect(await response.json()).toEqual({ ready: true });
+    expect(control.launches).toHaveLength(2);
+    expect(control.launches[1]).not.toBe(firstPid);
+    expect(instance.child?.pid).toBe(control.launches[1]);
+    expect(isProcessAlive(firstPid as number)).toBe(false);
+  });
+
+  it.each(["stopGateway", "cleanup"] as const)(
+    "does not launch after %s settles during entrypoint preparation",
+    async (method) => {
+      const control = await createGatewayControl();
+      const { instance } = await createFakeGateway("ready", 1_000, 1_500, {
+        url: control.url,
+        holdPreparation: true,
+      });
+      const firstStart = trackOperation(instance.startGateway());
+      await Promise.race([control.reached, firstStart]);
+      let teardownSettled = false;
+      let launchedAfterTeardown = false;
+      control.observers.onLaunch = () => {
+        launchedAfterTeardown ||= teardownSettled;
+      };
+      const teardown = trackOperation(
+        instance[method]().finally(() => {
+          teardownSettled = true;
+        }),
+      );
+
+      // A valid owner may join startup or cancel this instance. Release preparation
+      // before joining teardown so either policy can complete without a deadlock.
+      await control.release();
+      const [, stopped] = await Promise.allSettled([firstStart, teardown]);
+      expect(stopped.status).toBe("fulfilled");
+      expect(launchedAfterTeardown).toBe(false);
+      expect(instance.child).toBeUndefined();
+      await instance.cleanup();
+      await expectPathMissing(instance.state.root);
+      for (const pid of control.launches) {
+        expect(isProcessAlive(pid)).toBe(false);
+      }
+    },
+  );
+
   it("classifies only exact stderr convergence refusals with status 1", () => {
     const classify = testing.isGatewayMigrationConvergenceRefusal;
     expect(classify(1, null, `notice\n${MIGRATION_CONVERGENCE_REFUSAL} retry\n`)).toBe(true);
@@ -178,17 +419,66 @@ describe("openclaw test instance", () => {
     expect(instance.logs().split(RESTART_MARKER)).toHaveLength(2);
   });
 
-  it("bounds migration retries by one startup deadline", async () => {
-    const { instance, readAttempts } = await createFakeGateway("refuse:200,hang", 500);
-    const startedAt = Date.now();
-    await expect(instance.startGateway()).rejects.toThrow("timeout waiting for gateway readiness");
-    const attempts = await readAttempts();
-    // A loaded runner may consume the deadline before observing the first refusal.
-    // The restart-path tests above require two attempts when that refusal arrives in time.
-    expect(attempts.length).toBeGreaterThanOrEqual(1);
-    expect(attempts.length).toBeLessThanOrEqual(2);
-    expect(Date.now() - startedAt).toBeLessThan(650);
-  });
+  it.runIf(process.platform !== "win32")(
+    "preserves an eligible refusal when its startup deadline expires during stdio drain",
+    async () => {
+      const startupBudgetMs = 500;
+      const control = await createGatewayControl();
+      const { instance, tracePath, readAttempts } = await createFakeGateway(
+        "refusal-drain,ready",
+        startupBudgetMs,
+        1_500,
+        control,
+      );
+      const exited = createDeferred<{
+        code: number | null;
+        signal: NodeJS.Signals | null;
+        at: number;
+      }>();
+      control.observers.onLaunch = () => {
+        const leader = instance.child;
+        if (!leader) {
+          exited.reject(new Error("fixture launched without a process owner"));
+          return;
+        }
+        leader.once("exit", (code, signal) => exited.resolve({ code, signal, at: Date.now() }));
+      };
+      let startupSettled = false;
+      const startup = trackOperation(
+        instance.startGateway().finally(() => {
+          startupSettled = true;
+        }),
+      );
+      try {
+        const firstExit = await Promise.race([exited.promise, startup]);
+        expect(firstExit).toMatchObject({ code: 1, signal: null });
+        if (!firstExit) throw new Error("startup settled before the fixture leader exited");
+        // The startup clock precedes leader exit. Holding stdio for a full budget
+        // after that event expires retry admission without measuring cold launch time.
+        const admissionExpiredAt = firstExit.at + startupBudgetMs;
+        while (Date.now() < admissionExpiredAt) {
+          await delay(admissionExpiredAt - Date.now());
+        }
+        const drainingPid = Number(await fs.readFile(`${tracePath}.draining-pid`, "utf8"));
+        expect(instance.child?.stderr.closed).toBe(false);
+        expect(isProcessAlive(drainingPid)).toBe(true);
+        expect(startupSettled).toBe(false);
+
+        await fs.writeFile(`${tracePath}.draining-release`, "");
+        await expect(startup).rejects.toThrow(
+          "gateway exited before readiness (code=1 signal=null)",
+        );
+        expect(instance.logs()).toContain(MIGRATION_CONVERGENCE_REFUSAL);
+        expect(instance.logs()).not.toContain(RESTART_MARKER);
+        expect(await readAttempts()).toHaveLength(1);
+        expect(instance.child).toBeUndefined();
+        await expect.poll(() => isProcessAlive(drainingPid), { timeout: 500 }).toBe(false);
+      } finally {
+        await fs.writeFile(`${tracePath}.draining-release`, "");
+        await Promise.allSettled([startup]);
+      }
+    },
+  );
 
   it.runIf(process.platform !== "win32")(
     "SIGKILLs a TERM-resistant gateway group before releasing state",

--- a/test/helpers/openclaw-test-instance.test.ts
+++ b/test/helpers/openclaw-test-instance.test.ts
@@ -18,7 +18,17 @@ const RESTART_MARKER =
 const fakeInstances: Awaited<ReturnType<typeof createOpenClawTestInstance>>[] = [];
 const fakeRoots: string[] = [];
 const fakeOperations: Promise<unknown>[] = [];
-const fakeControls: Awaited<ReturnType<typeof createGatewayControl>>[] = [];
+const fakeControls: FakeGatewayControl[] = [];
+
+type FakeGatewayControl = {
+  url: string;
+  reached: Promise<void>;
+  launches: number[];
+  observers: { beforeRelease: () => void; onLaunch: () => void };
+  unblock: () => void;
+  release: () => Promise<void>;
+  close: () => Promise<void>;
+};
 
 type FakeGatewayAttempt = {
   argv: string[];
@@ -71,7 +81,7 @@ function trackOperation<T>(operation: Promise<T>): Promise<T> {
   return operation;
 }
 
-async function createGatewayControl() {
+async function createGatewayControl(): Promise<FakeGatewayControl> {
   const reached = createDeferred<void>();
   const released = createDeferred<void>();
   const launches: number[] = [];

--- a/test/helpers/openclaw-test-instance.ts
+++ b/test/helpers/openclaw-test-instance.ts
@@ -476,8 +476,30 @@ export async function createOpenClawTestInstance(
     stateEnv: state.env,
     extraEnv: options.env ?? {},
   });
-  let child: OpenClawTestProcess | undefined;
+  let child: { process: OpenClawTestProcess; ready: boolean } | undefined;
   let cleaned = false;
+  let operation: { kind: "start" | "stop" | "cleanup"; promise: Promise<void> } | undefined;
+  const enqueue = (kind: NonNullable<typeof operation>["kind"], action: () => Promise<void>) => {
+    if (operation?.kind === kind) {
+      return operation.promise;
+    }
+    // Claim ordering before preparation can yield. Teardown joins pending startup,
+    // and another start cannot borrow readiness from a child being stopped.
+    const next = {
+      kind,
+      promise: Promise.resolve(operation?.promise)
+        .catch(() => undefined)
+        .then(action),
+    };
+    operation = next;
+    const release = () => {
+      if (operation === next) {
+        operation = undefined;
+      }
+    };
+    void next.promise.then(release, release);
+    return next.promise;
+  };
   const stopTimeoutMs = options.stopTimeoutMs ?? GATEWAY_STOP_TIMEOUT_MS;
   const spawnGatewayProcess = (args: string[], attemptStderr: string[]): OpenClawTestProcess => {
     const next = spawn("node", args, {
@@ -501,10 +523,28 @@ export async function createOpenClawTestInstance(
     stopOptions: GatewayProcessStopOptions = {},
   ): Promise<boolean> => {
     const closed = await stopGatewayProcess(target, deadline, stopTimeoutMs, stopOptions);
-    if (closed && child === target) {
+    if (closed && child?.process === target) {
       child = undefined;
     }
     return closed;
+  };
+  const stopGatewayChild = async (stopOptions: GatewayProcessStopOptions = {}) => {
+    const target = child;
+    if (!target) {
+      return;
+    }
+    // A failed stop retains ownership, never the old readiness observation.
+    target.ready = false;
+    const closed = await releaseGatewayChild(
+      target.process,
+      Date.now() + stopTimeoutMs * 2,
+      stopOptions,
+    );
+    if (!closed) {
+      throw new Error(
+        `gateway process did not close before stop deadline\n${formatLogs(stdout, stderr)}`,
+      );
+    }
   };
 
   const instance: OpenClawTestInstance = {
@@ -520,7 +560,7 @@ export async function createOpenClawTestInstance(
     stdout,
     stderr,
     get child() {
-      return child;
+      return child?.process;
     },
     env,
     entrypoint: () => resolveGatewayEntrypoint(cwd),
@@ -533,92 +573,79 @@ export async function createOpenClawTestInstance(
         timeoutMs: commandOptions.timeoutMs ?? COMMAND_TIMEOUT_MS,
       });
     },
-    startGateway: async () => {
-      if (child && !hasChildExited(child)) {
-        return;
-      }
-      const entrypoint = await resolveGatewayEntrypoint(cwd);
-      const gatewayArgs = [
-        ...entrypoint,
-        "gateway",
-        "--port",
-        String(port),
-        "--bind",
-        "loopback",
-        "--allow-unconfigured",
-        ...(options.gatewayArgs ?? []),
-      ];
-      const deadline = Date.now() + (options.startTimeoutMs ?? GATEWAY_START_TIMEOUT_MS);
-      let restarts = 0;
-
-      if (child) {
-        const staleChild = child;
-        const closed = await releaseGatewayChild(staleChild, deadline, {
-          forceWindowsTree: true,
-        });
-        if (!closed) {
-          throw new Error(
-            `gateway process did not close before restart deadline\n${formatLogs(stdout, stderr)}`,
-          );
+    startGateway: () =>
+      enqueue("start", async () => {
+        if (cleaned) {
+          throw new Error("cannot start a cleaned test instance");
         }
-      }
-
-      while (true) {
-        const remainingMs = deadline - Date.now();
-        if (remainingMs <= 0) {
-          throw new Error(
-            `timeout waiting for gateway readiness on port ${port}\n${formatLogs(stdout, stderr)}`,
-          );
-        }
-        const attemptStderr = createBoundedStringLog();
-        const attempt = spawnGatewayProcess(gatewayArgs, attemptStderr);
-        child = attempt;
-        try {
-          await waitForGatewayReady(attempt, stdout, stderr, port, remainingMs);
+        if (child?.ready && !hasChildExited(child.process)) {
           return;
-        } catch (err) {
-          const exitCode = attempt.exitCode;
-          const signalCode = attempt.signalCode;
-          const closed = await releaseGatewayChild(attempt, deadline, {
-            forceWindowsTree: true,
-          });
-          const shouldRestart =
-            restarts < GATEWAY_MIGRATION_CONVERGENCE_MAX_RESTARTS &&
-            isGatewayMigrationConvergenceRefusal(
-              exitCode,
-              signalCode,
-              readLogBuffer(attemptStderr),
+        }
+        const entrypoint = await resolveGatewayEntrypoint(cwd);
+        const gatewayArgs = [
+          ...entrypoint,
+          "gateway",
+          "--port",
+          String(port),
+          "--bind",
+          "loopback",
+          "--allow-unconfigured",
+          ...(options.gatewayArgs ?? []),
+        ];
+        await stopGatewayChild({ forceWindowsTree: true });
+        const deadline = Date.now() + (options.startTimeoutMs ?? GATEWAY_START_TIMEOUT_MS);
+        let restarts = 0;
+
+        while (true) {
+          const remainingMs = deadline - Date.now();
+          if (remainingMs <= 0) {
+            throw new Error(
+              `timeout waiting for gateway readiness on port ${port}\n${formatLogs(stdout, stderr)}`,
             );
-          if (shouldRestart && Date.now() < deadline) {
-            if (closed) {
+          }
+          const attemptStderr = createBoundedStringLog();
+          const attempt = spawnGatewayProcess(gatewayArgs, attemptStderr);
+          const owner = { process: attempt, ready: false };
+          child = owner;
+          try {
+            await waitForGatewayReady(attempt, stdout, stderr, port, remainingMs);
+            owner.ready = true;
+            return;
+          } catch (err) {
+            const exitCode = attempt.exitCode;
+            const signalCode = attempt.signalCode;
+            // Startup expiry stops retry admission, not ownership cleanup. Use the
+            // same separate shutdown budget as explicit stop, retaining failed owners.
+            const closed = await releaseGatewayChild(attempt, Date.now() + stopTimeoutMs * 2, {
+              forceWindowsTree: true,
+            });
+            const shouldRestart =
+              restarts < GATEWAY_MIGRATION_CONVERGENCE_MAX_RESTARTS &&
+              isGatewayMigrationConvergenceRefusal(
+                exitCode,
+                signalCode,
+                readLogBuffer(attemptStderr),
+              );
+            if (shouldRestart && closed && Date.now() < deadline) {
               restarts += 1;
               appendLogChunk(stderr, GATEWAY_MIGRATION_CONVERGENCE_RESTART_MARKER);
               continue;
             }
+            throw err;
           }
-          throw err;
         }
-      }
-    },
-    stopGateway: async () => {
-      const target = child;
-      if (!target) {
-        return;
-      }
-      const closed = await releaseGatewayChild(target, Date.now() + stopTimeoutMs * 2);
-      if (!closed) {
-        throw new Error(`gateway process did not close before stop deadline\n${instance.logs()}`);
-      }
-    },
+      }),
+    stopGateway: () => enqueue("stop", stopGatewayChild),
     logs: () => formatLogs(stdout, stderr),
-    cleanup: async () => {
-      if (cleaned) {
-        return;
-      }
-      await instance.stopGateway();
-      await state.cleanup();
-      cleaned = true;
-    },
+    cleanup: () =>
+      enqueue("cleanup", async () => {
+        if (cleaned) {
+          return;
+        }
+        await stopGatewayChild();
+        await state.cleanup();
+        cleaned = true;
+      }),
   };
 
   return instance;


### PR DESCRIPTION
Related: #131783

## What Problem This Solves

Resolves a problem where Gateway test instances could report startup success before actual readiness, retain an unready child after a startup timeout, or launch a child after teardown had already returned. The same cleanup boundary could exhaust the startup deadline while inherited output streams were still open.

## Why This Change Was Made

One per-instance lifecycle owner now orders start, stop, and cleanup before preparation yields. Concurrent adjacent starts join the same readiness operation; a start after an intervening stop gets a new operation. Readiness belongs to the exact child and is invalidated when stopping begins. Failed-start cleanup and stale-child drain use the existing separate shutdown budget, while migration retries still share the original startup deadline and preserve the original error.

The old cold-wall-clock deadline assertion is replaced with a real eligible refusal whose descendant holds stderr past retry admission. The regression requires cleanup to finish without a late retry or an incorrectly rewritten error. Obsolete delayed/hanging fixture actions are removed. No product runtime, protocol, configuration, storage, or dependency behavior changes.

## User Impact

Test infrastructure only: callers can await actual readiness and teardown without racing process ownership. Production LOC is unchanged. Test support is +106/-79 (net +27); regression tests and fixtures are +327/-27. The small tagged operation tail consolidates the unsynchronized lifecycle methods rather than introducing a general queue abstraction.

## Evidence

Current head `13d6a2493a6bb7f524712e9b8a64246cfb9476c7` passed [CI run 33192867705](https://github.com/openclaw/openclaw/actions/runs/33192867705), completed August 28 at 17:33:49 UTC. The complete 117-job inventory has 100 successful and 17 intentionally skipped jobs, including the successful final CI gate; no failed or pending job remains.

- [Test-type check 98926923456](https://github.com/openclaw/openclaw/actions/runs/33192867705/job/98926923456) passed all extension, script, and root-test type programs. The earlier run caught a circular inferred return type in the new control fixture. The follow-up names the existing control-handle type and annotates the registry and factory return, with no runtime, assertion, or timeout change.
- [Tooling shard 98926925094](https://github.com/openclaw/openclaw/actions/runs/33192867705/job/98926925094) ran all 26 final helper cases in complete-file original order on Linux Node 24.19.0. The held-stderr deadline regression passed in 599ms, TERM-resistant cleanup in 147ms, and inherited-stdio replacement in 349ms. The whole shard passed 68 files / 1,068 tests, including managed-child cleanup siblings. Normal frozen-lock installation and canonical runtime preparation completed; the logs identify executed merge `99985ee52332c00f0d6aab2165b58735281a95e3`. Both complete type and runtime logs were personally read.
- Before implementation, four real-child cases failed on the unchanged helper: concurrent startup returned before a held HTTP readiness response; restart reused an unready child after timeout; stop and cleanup each settled before a late launch. The repaired owner passed these cases plus a start-stop-start ordering control.
- The final deadline regression also failed on the old helper at its intended pending-startup assertion, after proving an eligible exit, open stderr and a live inherited-stream holder. All owned processes were verified gone after cleanup.
- An earlier test-file variant passed all 26 cases on macOS Node 24.20.0 with historical matching dependencies. The final local full-file attempt produced no test result: the canonical runner's existing 120-second no-output watchdog stopped during import. It was not counted as a pass or assertion failure; no timeout increase or retry was used. Source overlays, existing caches and process groups were verified restored. Subsequent hosted runs exercised the final test file, including the current typed head above.
- Fresh full-candidate independent P2 review returned no actionable findings across the complete helper, tests, cleanup/state owners and callers. The review wrapper then failed saving its report because the output directory was absent; the validated result and unchanged source were independently verified and preserved. This is not recorded as a successful wrapper run. Focused formatting and diff checks passed. The previously failing static gate is now independently green on the current head.

The inherited-stdio deadline case is POSIX-only because Windows tree termination intentionally kills the detached descendant. Existing simulated Windows taskkill and cross-platform migration coverage remain; this is not a claim of a real Windows run. Readiness invalidation when a failed stop retains a still-live child is source-reviewed; no artificial kill stub or zero-budget fixture was added to force that rare branch.

The failure was found in [CI run 33175281174](https://github.com/openclaw/openclaw/actions/runs/33175281174), job 98862359629, executed merge `ed822ba355cbfe360ef9d948664b8d36053eb45d`. It is independent of the LS production change. This PR does not claim to fix the unrelated local import watchdog stop. The latest ClawSweeper review of this exact head found no actionable source or security defect and requested complete exact-head checks plus maintainer handling. Those checks are now green; this maintainer-directed repair is proceeding through the normal guarded landing workflow, not ClawSweeper automerge.
