### PR TITLE
fix(qa): retain WhatsApp lease and auth until Gateway stops

### DIFF
--- a/extensions/qa-lab/src/live-transports/whatsapp/adapter.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/adapter.runtime.test.ts
@@ -1,0 +1,364 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import { expectDefined } from "@openclaw/normalization-core";
+import type {
+  WhatsAppQaDriverObservedMessage,
+  WhatsAppQaDriverSession,
+} from "@openclaw/whatsapp/api.js";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { runExec } from "openclaw/plugin-sdk/process-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createQaBusState } from "../../bus-state.js";
+import { createQaTransportAdapter } from "../../qa-transport-registry.js";
+import { runQaFlowSuiteCleanupPlan } from "../../suite.js";
+import { createTempDirHarness } from "../../temp-dir.test-helper.js";
+import { whatsappQaCliRegistration } from "./cli.js";
+import type { WhatsAppQaRuntimeEnv } from "./whatsapp-live.contracts.js";
+
+const mocks = vi.hoisted(() => ({
+  acquireLease: vi.fn(),
+  heartbeat: vi.fn<() => Promise<void>>(),
+  heartbeatStop: vi.fn<() => Promise<void>>(),
+  release: vi.fn<() => Promise<void>>(),
+  startDriver: vi.fn<({ authDir }: { authDir: string }) => Promise<WhatsAppQaDriverSession>>(),
+  closeDriver: vi.fn<() => Promise<void>>(),
+}));
+
+vi.mock("../shared/credential-lease.runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../shared/credential-lease.runtime.js")>();
+  return {
+    ...actual,
+    acquireQaCredentialLease: mocks.acquireLease,
+    startQaCredentialLeaseHeartbeat(
+      lease: Parameters<typeof actual.startQaCredentialLeaseHeartbeat>[0],
+    ) {
+      const heartbeat = actual.startQaCredentialLeaseHeartbeat(lease);
+      return {
+        ...heartbeat,
+        async stop() {
+          await heartbeat.stop();
+          await mocks.heartbeatStop();
+        },
+      };
+    },
+  };
+});
+
+vi.mock("./whatsapp-live.driver.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./whatsapp-live.driver.js")>()),
+  startWhatsAppQaDriverSessionWithRetry: mocks.startDriver,
+}));
+
+vi.mock("openclaw/plugin-sdk/process-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/process-runtime")>();
+  return { ...actual, runExec: vi.fn(actual.runExec) };
+});
+
+const execFileAsync = promisify(execFile);
+const tempDirs = createTempDirHarness();
+const fakeAuth = '{"fixture":"not-a-whatsapp-session"}\n';
+let fixtureRoot: string;
+let authRoot: string | undefined;
+let credentialPayload: WhatsAppQaRuntimeEnv;
+let created: Awaited<ReturnType<typeof createQaTransportAdapter>> | undefined;
+let observed: WhatsAppQaDriverObservedMessage[];
+
+async function createAdapter() {
+  created = await createQaTransportAdapter(
+    {
+      channelId: "whatsapp",
+      driver: "live",
+      outputDir: fixtureRoot,
+      state: createQaBusState(),
+    },
+    [expectDefined(whatsappQaCliRegistration.adapterFactory, "WhatsApp adapter factory")],
+  );
+  return created;
+}
+
+async function expectResourcesRetained(sutAuthDir: string) {
+  expect.soft(mocks.release, "shared credential must remain leased").not.toHaveBeenCalled();
+  expect.soft(mocks.heartbeatStop, "lease heartbeat must remain active").not.toHaveBeenCalled();
+  for (const dir of [sutAuthDir, path.join(expectDefined(authRoot, "auth root"), "driver-auth")]) {
+    await expect.soft(fs.readFile(path.join(dir, "creds.json"), "utf8")).resolves.toBe(fakeAuth);
+  }
+}
+
+beforeEach(async () => {
+  vi.resetAllMocks();
+  authRoot = undefined;
+  created = undefined;
+  observed = [];
+  fixtureRoot = await fs.realpath(await tempDirs.makeTempDir("whatsapp-qa-cleanup-"));
+  await fs.writeFile(path.join(fixtureRoot, "creds.json"), fakeAuth);
+  const archive = path.join(fixtureRoot, "auth.tgz");
+  await execFileAsync("tar", ["-czf", archive, "-C", fixtureRoot, "creds.json"]);
+  const archiveBase64 = await fs.readFile(archive, "base64");
+  credentialPayload = {
+    driverPhoneE164: "+15550000001",
+    sutPhoneE164: "+15550000002",
+    driverAuthArchiveBase64: archiveBase64,
+    sutAuthArchiveBase64: archiveBase64,
+  };
+  mocks.acquireLease.mockResolvedValue({
+    kind: "whatsapp",
+    source: "convex",
+    heartbeatIntervalMs: 100,
+    heartbeat: mocks.heartbeat,
+    release: mocks.release,
+    payload: credentialPayload,
+  });
+  mocks.startDriver.mockImplementation(async ({ authDir }) => {
+    authRoot = await fs.realpath(path.dirname(authDir));
+    return {
+      close: mocks.closeDriver,
+      getObservedMessages: () => observed,
+      sendContact: async () => ({}),
+      sendLocation: async () => ({}),
+      sendMedia: async () => ({}),
+      sendPoll: async () => ({}),
+      sendReaction: async () => ({}),
+      sendSticker: async () => ({}),
+      sendText: async () => ({}),
+      waitForMessage: async () => {
+        throw new Error("unexpected driver message wait");
+      },
+    };
+  });
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+});
+
+afterEach(async () => {
+  try {
+    if (created) {
+      const cleanup = created.cleanupWithoutGateway();
+      await vi.advanceTimersByTimeAsync(500);
+      await cleanup;
+    }
+  } finally {
+    vi.restoreAllMocks();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    if (authRoot) {
+      await fs.rm(authRoot, { recursive: true, force: true });
+    }
+    await tempDirs.cleanup();
+  }
+});
+
+describe("WhatsApp QA adapter cleanup through the suite", () => {
+  it.each([
+    "none",
+    "gateway stop",
+    "driver close",
+    "heartbeat request",
+    "heartbeat stop",
+    "lease release",
+  ] as const)(
+    "keeps lease and auth until terminal Gateway teardown (failure: %s)",
+    async (failureAt) => {
+      const transport = await createAdapter();
+      const cfg = transport.adapter.createGatewayConfig({ baseUrl: "http://127.0.0.1:1" });
+      const sutAuthDir = await fs.realpath(
+        expectDefined(cfg.channels?.whatsapp?.accounts?.sut?.authDir, "SUT auth directory"),
+      );
+      await expectResourcesRetained(sutAuthDir);
+      if (failureAt === "heartbeat request") {
+        mocks.heartbeat.mockRejectedValueOnce(new Error("heartbeat request failed"));
+      }
+      const lastReply: WhatsAppQaDriverObservedMessage = {
+        kind: "text",
+        fromPhoneE164: "+15550000002",
+        observedAt: new Date().toISOString(),
+        text: "last reply before cleanup",
+      };
+      observed.push(lastReply);
+      await vi.advanceTimersByTimeAsync(500);
+      expect(transport.adapter.state.getSnapshot().messages.map(({ text }) => text)).toEqual([
+        "last reply before cleanup",
+      ]);
+      if (failureAt === "heartbeat request") {
+        await expect(transport.adapter.waitForCondition(() => true)).rejects.toThrow(
+          'Credential lease heartbeat failed for kind "whatsapp": heartbeat request failed',
+        );
+      }
+
+      const failure = new Error(`${failureAt} failed`);
+      if (failureAt === "driver close") {
+        mocks.closeDriver.mockRejectedValueOnce(failure);
+      } else if (failureAt === "heartbeat stop") {
+        mocks.heartbeatStop.mockRejectedValueOnce(failure);
+      } else if (failureAt === "lease release") {
+        mocks.release.mockRejectedValueOnce(failure);
+      }
+      const gatewayStopped = createDeferred<void>();
+      const stopStarted = createDeferred<void>();
+      const stopGateway = vi.fn(async () => {
+        stopStarted.resolve();
+        await gatewayStopped.promise;
+        if (failureAt === "gateway stop") {
+          throw failure;
+        }
+      });
+      const cleanup = runQaFlowSuiteCleanupPlan({
+        cleanupTransportBeforeGatewayStop: transport.cleanupBeforeGatewayStop,
+        cleanupTransportAfterGatewayStop: transport.cleanupAfterGatewayStop,
+        stopGateway,
+        disposeAgentHarnesses: async () => {},
+        finishLab: async () => {},
+      });
+      try {
+        // The active polling sleep must drain before the driver or Gateway closes.
+        await vi.advanceTimersByTimeAsync(499);
+        expect(mocks.closeDriver).not.toHaveBeenCalled();
+        expect(stopGateway).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(1);
+        await stopStarted.promise;
+        expect(mocks.closeDriver).toHaveBeenCalledOnce();
+        await expectResourcesRetained(sutAuthDir);
+        mocks.heartbeat.mockClear();
+        observed.push({ ...lastReply, text: "must not poll after cleanup" });
+        await vi.advanceTimersByTimeAsync(1_000);
+        if (failureAt !== "heartbeat request") {
+          expect
+            .soft(mocks.heartbeat, "heartbeat continues while Gateway stop is pending")
+            .toHaveBeenCalled();
+        }
+        expect(transport.adapter.state.getSnapshot().messages).toHaveLength(1);
+      } finally {
+        gatewayStopped.resolve();
+        await cleanup;
+      }
+      const failures = await cleanup;
+      const phase =
+        failureAt === "gateway stop"
+          ? "gateway stop"
+          : failureAt === "driver close"
+            ? "transport before gateway stop"
+            : "transport after gateway stop";
+      expect(failures).toEqual(
+        failureAt === "none" || failureAt === "heartbeat request"
+          ? []
+          : [{ phase, error: failure }],
+      );
+      if (failureAt === "gateway stop") {
+        await expectResourcesRetained(sutAuthDir);
+        mocks.heartbeat.mockClear();
+        await vi.advanceTimersByTimeAsync(100);
+        expect
+          .soft(mocks.heartbeat, "failed Gateway stop must retain heartbeat")
+          .toHaveBeenCalled();
+      } else {
+        expect(mocks.heartbeatStop).toHaveBeenCalledOnce();
+        expect(mocks.release).toHaveBeenCalledOnce();
+        await expect(fs.stat(expectDefined(authRoot, "auth root"))).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+        mocks.heartbeat.mockClear();
+        await vi.advanceTimersByTimeAsync(100);
+        expect(mocks.heartbeat).not.toHaveBeenCalled();
+      }
+    },
+  );
+
+  it("stops the heartbeat and releases the lease when the auth root cannot be created", async () => {
+    vi.spyOn(fs, "mkdtemp").mockRejectedValueOnce(new Error("auth root creation failed"));
+
+    await expect(createAdapter()).rejects.toThrow("auth root creation failed");
+
+    expect(mocks.startDriver).not.toHaveBeenCalled();
+    expect(runExec).not.toHaveBeenCalled();
+    expect(mocks.heartbeatStop).toHaveBeenCalledOnce();
+    expect(mocks.release).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(mocks.heartbeat).not.toHaveBeenCalled();
+  });
+
+  it("does not leave a pending auth unpack able to recreate the root after rollback", async () => {
+    credentialPayload.driverAuthArchiveBase64 = Buffer.from("not a tar archive").toString("base64");
+    const mkdir = fs.mkdir.bind(fs);
+    const resumeSutMkdir = createDeferred<void>();
+    const driverUnpackFailed = createDeferred<void>();
+    const sutExtracted = createDeferred<void>();
+    let pendingSutUnpack: Promise<void> | undefined;
+    vi.spyOn(fs, "mkdir").mockImplementation(async (dir, options) => {
+      if (path.basename(String(dir)) === "sut-auth") {
+        pendingSutUnpack = sutExtracted.promise;
+        await resumeSutMkdir.promise;
+      }
+      return await mkdir(dir, options);
+    });
+    const realRunExec = expectDefined(vi.mocked(runExec).getMockImplementation(), "real exec");
+    vi.mocked(runExec).mockImplementation(async (command, args, options) => {
+      const archive = args[1];
+      if (command === "tar" && archive && path.basename(archive) === "driver-auth.tgz") {
+        authRoot = await fs.realpath(path.dirname(archive));
+      }
+      try {
+        return await realRunExec(command, args, options);
+      } finally {
+        if (archive && path.basename(archive) === "driver-auth.tgz") {
+          driverUnpackFailed.resolve();
+        }
+        if (args[0] === "-xzf" && archive && path.basename(archive) === "sut-auth.tgz") {
+          sutExtracted.resolve();
+        }
+      }
+    });
+
+    const initialization = expect(createAdapter()).rejects.toThrow(/tar/);
+    try {
+      await driverUnpackFailed.promise;
+      await vi.advanceTimersByTimeAsync(0);
+      // Either avoid starting the second unpack or drain it before releasing resources.
+      if (pendingSutUnpack) {
+        expect
+          .soft(mocks.release, "rollback must retain the lease while auth staging is pending")
+          .not.toHaveBeenCalled();
+      }
+    } finally {
+      // If rollback already started, finish it before allowing the delayed writer to resume.
+      if (mocks.release.mock.calls.length > 0) {
+        await initialization;
+      }
+      resumeSutMkdir.resolve();
+      await pendingSutUnpack;
+      await initialization;
+    }
+    expect(mocks.startDriver).not.toHaveBeenCalled();
+    expect(mocks.heartbeatStop).toHaveBeenCalledOnce();
+    expect(mocks.release).toHaveBeenCalledOnce();
+    await expect(fs.stat(expectDefined(authRoot, "auth root"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it.each(["none", "heartbeat stop", "lease release"] as const)(
+    "immediately removes auth and releases the lease after initialization fails (cleanup failure: %s)",
+    async (failureAt) => {
+      mocks.startDriver.mockImplementation(async ({ authDir }) => {
+        authRoot = await fs.realpath(path.dirname(authDir));
+        await expectResourcesRetained(path.join(authRoot, "sut-auth"));
+        throw new Error("driver initialization failed");
+      });
+      if (failureAt === "heartbeat stop") {
+        mocks.heartbeatStop.mockRejectedValueOnce(new Error("heartbeat stop failed"));
+      } else if (failureAt === "lease release") {
+        mocks.release.mockRejectedValueOnce(new Error("lease release failed"));
+      }
+      await expect(createAdapter()).rejects.toThrow(
+        failureAt === "none" ? "driver initialization failed" : `${failureAt} failed`,
+      );
+      expect(mocks.heartbeatStop).toHaveBeenCalledOnce();
+      expect(mocks.release).toHaveBeenCalledOnce();
+      await expect(fs.stat(expectDefined(authRoot, "auth root"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      mocks.heartbeat.mockClear();
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(mocks.heartbeat).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/extensions/qa-lab/src/live-transports/whatsapp/adapter.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/adapter.runtime.ts
@@ -49,22 +49,19 @@ export async function createWhatsAppQaTransportAdapter(
     authRoot = await fs.mkdtemp(
       path.join(resolvePreferredOpenClawTmpDir(), "openclaw-whatsapp-qa-adapter-"),
     );
-    const [unpackedDriverAuthDir, unpackedSutAuthDir] = await Promise.all([
-      unpackWhatsAppAuthArchive({
-        archiveBase64: runtimeEnv.driverAuthArchiveBase64,
-        clearSignalSessions: true,
-        label: "driver-auth",
-        parentDir: authRoot,
-      }),
-      unpackWhatsAppAuthArchive({
-        archiveBase64: runtimeEnv.sutAuthArchiveBase64,
-        clearSignalSessions: true,
-        label: "sut-auth",
-        parentDir: authRoot,
-      }),
-    ]);
-    driverAuthDir = unpackedDriverAuthDir;
-    sutAuthDir = unpackedSutAuthDir;
+    // Unpack sequentially so rollback cannot remove authRoot while another unpack is writing.
+    driverAuthDir = await unpackWhatsAppAuthArchive({
+      archiveBase64: runtimeEnv.driverAuthArchiveBase64,
+      clearSignalSessions: true,
+      label: "driver-auth",
+      parentDir: authRoot,
+    });
+    sutAuthDir = await unpackWhatsAppAuthArchive({
+      archiveBase64: runtimeEnv.sutAuthArchiveBase64,
+      clearSignalSessions: true,
+      label: "sut-auth",
+      parentDir: authRoot,
+    });
     driver = await startWhatsAppQaDriverSessionWithRetry({ authDir: driverAuthDir });
   } catch (error) {
     try {
@@ -225,18 +222,18 @@ export async function createWhatsAppQaTransportAdapter(
     async cleanup() {
       stopped = true;
       await polling.catch(() => undefined);
-      // Credential and auth cleanup must run even when the live driver cannot close cleanly.
+      await getDriver().close();
+    },
+    async cleanupAfterGatewayStop() {
+      // The Gateway still uses SUT auth and the shared lease after the driver closes.
+      // Release them only after the suite confirms Gateway teardown succeeded.
       try {
-        await getDriver().close();
+        await heartbeat.stop();
       } finally {
         try {
-          await heartbeat.stop();
+          await lease.release();
         } finally {
-          try {
-            await lease.release();
-          } finally {
-            await fs.rm(authRoot, { force: true, recursive: true });
-          }
+          await fs.rm(authRoot, { force: true, recursive: true });
         }
       }
     },


### PR DESCRIPTION
Closes #131839
Related #131643 (separate Gateway startup ownership gap).

## What Problem This Solves

Fixes an issue where operators running WhatsApp QA could release the shared driver/SUT accounts and lose their auth files while the child Gateway was still shutting down. Failed auth staging could also leave files behind after initialization rollback.

## Why This Change Was Made

The WhatsApp adapter now uses the existing two-phase cleanup contract: drain polling and close the driver before Gateway stop, then stop lease renewal, release the shared credential, and remove auth only after the suite's terminal-stop boundary. Sequential archive staging prevents rollback from racing a still-pending auth writer; nested `finally` blocks retain the existing cleanup guarantees.

This stays inside the WhatsApp adapter. A new shared guard or parallel cleanup framework would duplicate the suite/registry ownership already used by Slack and Telegram. The separate missing-Gateway-handle startup failure remains owned by #131740 and #131643; this PR does not claim to repair it.

## User Impact

Source-checkout WhatsApp QA retains auth files and credential ownership while Gateway stop is pending or rejects. Initialization failures before a Gateway exists release resources immediately without a late staging write recreating the deleted directory. There are no new options, dependencies, schema changes, or protocol changes, and normal installed WhatsApp messaging behavior is unchanged.

## Evidence

Production LOC: +21/-24 (net -3). Tests: +364/-0. Only the WhatsApp adapter and its regression test change.

The original teardown reproduction produced five intended failures: premature credential release, stopped lease renewal, and missing auth files while Gateway stop remained pending. The initialization reproduction separately caught release with auth staging pending and a recreated auth root after rollback. The regression runs through the actual adapter, registry, suite cleanup owner, heartbeat scheduler, filesystem, and `tar`, using synthetic auth archives and controlled external driver/lease boundaries.

Live-proof limit: real QA credentials, live WhatsApp accounts, and operator Gateway/state access were explicitly prohibited for this task. Gateway stop is a controlled callback; these results do not claim a live WhatsApp round trip or actual child-process termination.

Provenance: the early cleanup was carried forward by af71400c8eb6e50e81b9944ac78c9ee6d6373ceb / #108429 (July 15, 2026), authored and merged by Dallin Romney (@RomneyDa). The same early cleanup exists in stable tag v2026.7.1-2. Older blame reaches a shallow-history boundary, so this is not a claim that #108429 introduced the original bug.

AI-assisted with Codex; source and evidence reviewed by the task owner. No real credentials or real auth payloads are included.

Fresh proof at `284f977bb3c2213184cf88b0c9bc938fb7db7267`, rebased onto `117078fedbf69fcafd143b594c2db323df325102` (Node 24.20.0, macOS 27.0):

```bash
node scripts/run-vitest.mjs extensions/qa-lab/src/live-transports/whatsapp/adapter.runtime.test.ts extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts extensions/qa-lab/src/live-transports/whatsapp/whatsapp-boundary.test.ts extensions/qa-lab/src/live-transports/shared/credential-lease.runtime.test.ts extensions/qa-lab/src/live-transports/telegram/adapter.runtime.test.ts extensions/qa-lab/src/live-transports/slack/adapter.runtime.test.ts extensions/qa-lab/src/qa-transport-registry.test.ts extensions/qa-lab/src/suite.test.ts extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts extensions/qa-lab/src/suite-runtime-parity-runner.cleanup.test.ts extensions/qa-lab/src/channel-driver-lifecycle.test.ts --no-isolate
```

```bash
node scripts/run-vitest.mjs extensions/qa-lab/src/suite.test.ts --no-isolate
```

The combined run passed 159/160 tests, including all 11 new WhatsApp cases; the unchanged Crabline artifact test hit its local Telegram readiness timeout. The suite-only rerun passed 31/31 without edits, timeout increases, or assertion changes. The earlier pre-rebase combined run passed 160/160. The transient Crabline readiness failure and earlier artifact-cleanup `ENOTEMPTY` remain separate follow-ups, not fixes claimed here.

Fresh isolated Codex autoreview was clean with no accepted/actionable findings. Both file hashes are unchanged across commit and rebase, so that review still covers the published patch.


Local changed-gate limitation (subsequently covered by the exact-head CI and focused guard results below):

```bash
node scripts/check-changed.mjs -- extensions/qa-lab/src/live-transports/whatsapp/adapter.runtime.ts extensions/qa-lab/src/live-transports/whatsapp/adapter.runtime.test.ts
```

The changed gate passed formatting, production and test typechecking, the doctor contract tests, dead-export scans, and its preceding static guards. Lint setup then failed before reaching lint diagnostics: `plugin-sdk boundary dts timed out after 300000ms`.

The single targeted retry used the same settings and failed at the same prerequisite:

```bash
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/qa-lab/src/live-transports/whatsapp/adapter.runtime.test.ts extensions/qa-lab/src/live-transports/whatsapp/adapter.runtime.ts
```

Neither attempt completed lint. The changed gate's remaining database-first legacy-store, media-download-helper, runtime-sidecar-loader, and import-cycle checks were not reached on this head. All owned compiler descendants left by the timeouts were stopped and verified gone. No timeout was increased and no checker, baseline, suppression, dependency, or source workaround was applied. The cause of the timeouts is not established as environmental. Publication did not waive these gates. The exact-head Linux CI and remaining focused guard results below now supply the missing proof; the two local attempts still did not complete lint.


Exact-head Linux CI completed successfully at the same unchanged candidate: [run 33189161446](https://github.com/openclaw/openclaw/actions/runs/33189161446).

| Gate | Observed result |
| --- | --- |
| [Required openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33189161446/job/98913425274) | Success |
| [Declaration preparation and plugin package compilation](https://github.com/openclaw/openclaw/actions/runs/33189161446/job/98910013067) | Canonical preparation completed in 211465ms; all 123 plugins compiled, including QA Lab; canary passed |
| [Lint and formatting](https://github.com/openclaw/openclaw/actions/runs/33189161446/job/98910012722) | Actual extension/script lint completed successfully after declaration preparation; formatting passed |
| [Production types](https://github.com/openclaw/openclaw/actions/runs/33189161446/job/98910012589) / [test types](https://github.com/openclaw/openclaw/actions/runs/33189161446/job/98910012688) | Success |
| [Build artifacts](https://github.com/openclaw/openclaw/actions/runs/33189161446/job/98910011730) | Build and runtime verification passed |
| [Changed-plugin tests and full Node build](https://github.com/openclaw/openclaw/actions/runs/33189161446/job/98910012522) | 3011/3011 tests across 216 files, including all 11 new WhatsApp cases; full Node build passed |
| [Runtime architecture](https://github.com/openclaw/openclaw/actions/runs/33189161446/job/98910013172) | Database-first and import-cycle guards passed |

The two remaining tail guards are not run by this CI graph. Each was run separately on the unchanged candidate and passed:

```bash
node --import ./scripts/tsx.mjs scripts/check-media-download-helper-roundtrip.mts
```

```bash
node --import ./scripts/tsx.mjs scripts/check-runtime-sidecar-loaders.mts
```

Exact-head CI was followed with the repository watcher, which exited successfully with `GREEN`:

```bash
node scripts/watch-pr-ci.mjs 131893 284f977bb3c2213184cf88b0c9bc938fb7db7267
```

The [latest ClawSweeper review](https://github.com/openclaw/openclaw/pull/131893#issuecomment-5455030739) reviewed this exact head and found no actionable or security findings. It has no explicit Rank-up moves list; both Before merge items requested successful exact-head CI completion, now satisfied. No source edits, gate overrides, or re-review request were needed. Native preparation and merge remain subject to the parent maintainer's final verification.
