### PR TITLE
fix(onboard): enable default hooks in guided setup

### DIFF
--- a/src/commands/onboard-guided.custodian.test.ts
+++ b/src/commands/onboard-guided.custodian.test.ts
@@ -349,6 +349,29 @@ describe("runGuidedOnboarding custodian flow", () => {
     );
   });
 
+  it.each([
+    ["enables default hooks", {}, true],
+    ["preserves --skip-hooks", { skipHooks: true }, undefined],
+  ] as const)("%s in the persisted setup config", async (_label, opts, expectedEnabled) => {
+    const applySetup = vi.fn<NonNullable<GuidedOnboardingDeps["applySetup"]>>(async (params) => {
+      const sourceConfig = localOnboarding.persisted.config ?? {};
+      localOnboarding.persisted.config =
+        params.finalizeConfig?.(sourceConfig, sourceConfig) ?? sourceConfig;
+      return setupApplyResult();
+    });
+    const deps = setupDeps({ prompter: createWizardPrompter(), applySetup });
+
+    await runGuidedOnboarding(
+      { acceptRisk: true, workspace: "/tmp/work", ...opts },
+      makeRuntime(),
+      deps,
+    );
+
+    expect(
+      localOnboarding.persisted.config?.hooks?.internal?.entries?.["session-memory"]?.enabled,
+    ).toBe(expectedEnabled);
+  });
+
   it("resumes an interrupted gateway install using its approved workspace", async () => {
     const first = setupDeps({
       prompter: createWizardPrompter(),

--- a/src/commands/onboard-guided.ts
+++ b/src/commands/onboard-guided.ts
@@ -25,6 +25,7 @@ import {
   type SetupCandidateFailure,
   tryCandidate,
 } from "./onboard-guided-manual.js";
+import { enableDefaultOnboardingInternalHooks } from "./onboard-hooks.js";
 import {
   hasInteractiveOnboardingTty,
   runInteractiveOnboarding,
@@ -596,6 +597,7 @@ async function runGuidedOnboardingFlow(
           ...(localSetup?.status === "pending"
             ? { assertCommitPreconditions: assertLocalSetupOwner }
             : {}),
+          ...(!opts.skipHooks ? { finalizeConfig: enableDefaultOnboardingInternalHooks } : {}),
           surface: "cli",
           runtime,
         }),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where successful local guided onboarding could finish without enabling the default session-memory hook, even though classic and non-interactive onboarding apply that default.

## Why This Change Was Made

Guided onboarding now passes the existing default-hook normalizer through the setup owner's `finalizeConfig` contract, so the mutation runs against the config held by the final write lock. `--skip-hooks` continues to omit the finalizer.

This is a guided-onboarding fix only. It does not claim to explain or repair the historical classic-onboarding FRV failure.

## User Impact

Fresh guided setups enable session memory by default. Operators who use `--skip-hooks` keep the current opt-out behavior.

## Evidence

- Pre-fix regression: `enables default hooks in the persisted setup config` failed because the persisted session-memory entry was `undefined`.
- Post-fix focused tests: 90 passed across `onboard-guided.custodian`, `setup-apply`, and `onboard-hooks`.
- Exact-head type checks: core production and the commands-test project passed.
- Exact-head targeted oxlint, oxfmt, `git diff --check`, and deslop passed.
- Fresh Sol autoreview: no accepted/actionable findings.
- LOC: production +2/-0; tests +23/-0; changelog +0/-0.

The aggregate `check-changed` run passed formatting, lint-adjacent guards, core production typecheck, dead-export, dependency, boundary, and schema checks. Its full core-test typecheck then reached an unrelated shared-install error in untouched `ui/vite.config.ts`: missing declarations for `pako`. The commands-test project containing this regression passes independently.

A real interactive guided-flow persistence run was not executed because that path requires provider activation plus a machine-level Gateway install/restart, which would be an inappropriate side effect from this isolated review worktree. The focused guided-flow test exercises the `finalizeConfig` persistence boundary, while `setup-apply` coverage proves that finalizer runs against the source config held by the commit lock.

AI-assisted: yes.
