### PR TITLE
fix(tooling): reap compiler descendants after declaration timeout

### DIFF
--- a/scripts/lib/managed-child-process.mts
+++ b/scripts/lib/managed-child-process.mts
@@ -249,6 +249,11 @@ export async function runManagedCommand({
   runTaskkill = spawnSync,
   onReady,
 }: RunManagedCommandOptions) {
+  // A shim can disappear during module loading, before we register a child.
+  // An IPC disconnect is permanent; never start new work for that launcher.
+  if (process.disconnect && !process.connected) {
+    return signalExitCode("SIGKILL");
+  }
   if (platform === "win32" && requireProcessTreeExit) {
     throw createManagedCommandUnsupportedTreeVerificationError();
   }
@@ -299,7 +304,9 @@ export async function runManagedCommand({
           clearTimeout(managedChild.forceKillTimer);
         }
         if (managedChild.receivedSignal) {
-          terminateManagedChild(child, "SIGKILL");
+          if (managedChild.receivedSignal !== "SIGKILL") {
+            terminateManagedChild(child, "SIGKILL");
+          }
           resolve(signalExitCode(managedChild.receivedSignal));
           return;
         }
@@ -478,6 +485,9 @@ function createManagedCommandCleanupError(
 }
 
 function installSignalHandlers() {
+  if (signalHandlers.size === 0) {
+    process.on("disconnect", handleParentDisconnect);
+  }
   for (const signal of FORWARDED_SIGNALS) {
     if (signalHandlers.has(signal)) {
       continue;
@@ -496,12 +506,27 @@ function removeSignalHandlersIfIdle() {
     process.off(signal, handler);
   }
   signalHandlers.clear();
+  process.off("disconnect", handleParentDisconnect);
+}
+
+function handleParentDisconnect() {
+  // The live IPC endpoint belongs to the spawning shim, unlike a polled PPID
+  // that can be reparented or reused. Only this owner's registered groups die.
+  forwardSignalToManagedChildren("SIGKILL");
 }
 
 function forwardSignalToManagedChildren(signal: NodeJS.Signals) {
   for (const managedChild of managedChildren) {
     managedChild.receivedSignal ??= signal;
     terminateManagedChild(managedChild.child, signal);
+    if (signal === "SIGKILL") {
+      managedChild.receivedSignal = signal;
+      if (managedChild.forceKillTimer) {
+        clearTimeout(managedChild.forceKillTimer);
+        managedChild.forceKillTimer = null;
+      }
+      continue;
+    }
     managedChild.forceKillTimer ??= setTimeout(() => {
       terminateManagedChild(managedChild.child, "SIGKILL");
     }, FORCE_KILL_DELAY_MS);

--- a/scripts/lib/tsx-cli-shim.mjs
+++ b/scripts/lib/tsx-cli-shim.mjs
@@ -135,7 +135,9 @@ async function runTsxCliShimInner(moduleUrl, options) {
         cwd: process.cwd(),
         detached,
         env: process.env,
-        stdio: "inherit",
+        // The implementation's managed commands must observe launcher loss even
+        // when an enclosing deadline SIGKILLs this shim before signal forwarding.
+        stdio: ["inherit", "inherit", "inherit", "ipc"],
       },
     );
     const result = await new Promise((resolve, reject) => {

--- a/test/scripts/managed-child-process.test.ts
+++ b/test/scripts/managed-child-process.test.ts
@@ -438,6 +438,48 @@ describe("managed-child-process", () => {
     expect(signals.map((signal) => process.listenerCount(signal))).toEqual(baseline);
   });
 
+  it("does not launch commands after its IPC launcher has disconnected", async () => {
+    const dir = createTempDir("openclaw-managed-disconnected-");
+    const marker = path.join(dir, "unexpected-command");
+    const runnerPath = path.join(dir, "runner.mjs");
+    const helperUrl = pathToFileURL(path.resolve("scripts/lib/managed-child-process.mts")).href;
+    fs.writeFileSync(
+      runnerPath,
+      `
+// Lose the launcher before importing the command owner, as during slow startup.
+await new Promise(resolve => {
+  process.once('disconnect', resolve);
+  process.send('ready');
+});
+const { runManagedCommand } = await import(${JSON.stringify(helperUrl)});
+process.exitCode = await runManagedCommand({
+  bin: process.execPath,
+  args: ['-e', ${JSON.stringify(`require('node:fs').writeFileSync(${JSON.stringify(marker)}, 'started')`)}],
+  shell: false,
+  stdio: 'ignore',
+});
+`,
+    );
+    const runner = spawn(process.execPath, [runnerPath], {
+      stdio: ["ignore", "ignore", "ignore", "ipc"],
+    });
+    const exited = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) =>
+      runner.once("exit", (code, signal) => resolve({ code, signal })),
+    );
+    const deadline = setTimeout(() => runner.kill("SIGKILL"), 5_000);
+    runner.once("message", () => runner.disconnect());
+    try {
+      expect(await exited).toEqual({ code: 137, signal: null });
+      expect(fs.existsSync(marker)).toBe(false);
+    } finally {
+      clearTimeout(deadline);
+      if (runner.exitCode === null && runner.signalCode === null) {
+        runner.kill("SIGKILL");
+      }
+      await exited;
+    }
+  });
+
   it("times out and kills managed command descendants", async () => {
     const dir = createTempDir("openclaw-managed-timeout-");
     const childPath = path.join(dir, "child.mjs");

--- a/test/scripts/prepare-extension-package-boundary-artifacts.test.ts
+++ b/test/scripts/prepare-extension-package-boundary-artifacts.test.ts
@@ -266,10 +266,11 @@ describe("prepare-extension-package-boundary-artifacts", () => {
       const descendantScript = [
         "const fs = require('node:fs');",
         "process.on('SIGTERM', () => {",
-        "  setTimeout(() => {",
+        // Exercise asynchronous draining without racing a second wall-clock deadline against grace.
+        "  setImmediate(() => {",
         `    fs.writeFileSync(${JSON.stringify(drainedPath)}, 'drained');`,
         "    process.exit(0);",
-        "  }, 50);",
+        "  });",
         "});",
         `fs.writeFileSync(${JSON.stringify(readyPath)}, 'ready');`,
         "setInterval(() => {}, 1000);",

--- a/test/scripts/run-oxlint.test.ts
+++ b/test/scripts/run-oxlint.test.ts
@@ -1,6 +1,6 @@
 // Run Oxlint tests cover run oxlint script behavior.
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
@@ -24,6 +24,8 @@ import {
   filterSparseMissingOxlintTargets,
   shouldPrepareExtensionPackageBoundaryArtifacts,
 } from "../../scripts/run-oxlint.mts";
+import { waitForPidFile } from "../helpers/process-wait.js";
+import { startProcessWatchdogFixture } from "../helpers/process-watchdog.js";
 import { createScriptTestHarness } from "./test-helpers.js";
 
 const { createTempDir } = createScriptTestHarness();
@@ -65,9 +67,10 @@ function createSignalRunner(mode: SignalScenario, target: string): void {
     const childScript = "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);";
     writeModule(target, [
       "import { spawn } from 'node:child_process';",
-      "import { writeFileSync } from 'node:fs';",
+      "import { writeFileSync, renameSync } from 'node:fs';",
       `const child = spawn(process.execPath, ['-e', ${JSON.stringify(childScript)}], { stdio: 'ignore' });`,
-      "writeFileSync(process.env.CHILD_PID_PATH, String(child.pid)); writeFileSync(process.env.READY_FILE, String(process.pid));",
+      // Publish only complete PIDs: an empty file parses as 0, which signals the caller's group.
+      "writeFileSync(process.env.CHILD_PID_PATH + '.tmp', String(child.pid)); renameSync(process.env.CHILD_PID_PATH + '.tmp', process.env.CHILD_PID_PATH); writeFileSync(process.env.READY_FILE, String(process.pid));",
       "process.on('SIGTERM', () => process.exit(0));",
       "setInterval(() => {}, 1000);",
     ]);
@@ -113,6 +116,7 @@ function runParentTerminationScenario(mode: SignalScenario) {
     "const waitPath = groupScenario ? process.env.CHILD_PID_PATH : process.env.READY_FILE;",
     "if (!(await waitFor(() => existsSync(waitPath)))) process.exit(2);",
     "const childPid = groupScenario ? Number(readFileSync(process.env.CHILD_PID_PATH, 'utf8')) : 0;",
+    "if (groupScenario && (!Number.isSafeInteger(childPid) || childPid <= 1)) process.exit(6);",
     "process.kill(process.pid, 'SIGTERM'); const status = await promise;",
     "if (process.env.MARKER_FILE && !existsSync(process.env.MARKER_FILE)) process.exit(3);",
     "if (groupScenario && !(await waitFor(() => { try { process.kill(childPid, 0); return false; } catch { return true; } }))) { process.kill(childPid, 'SIGKILL'); process.exit(5); }",
@@ -388,17 +392,17 @@ describe("run-oxlint", () => {
       const childPidPath = join(tempDir, "child.pid");
       let childPid = 0;
       const childScript = "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);";
-      try {
-        writeModule(runner, [
-          "import { spawn } from 'node:child_process';",
-          "import { writeFileSync } from 'node:fs';",
-          `const child = spawn(process.execPath, ['-e', ${JSON.stringify(childScript)}], { stdio: 'ignore' });`,
-          "writeFileSync(process.env.CHILD_PID_PATH, String(child.pid));",
-          "process.on('SIGTERM', () => process.exit(0));",
-          "setInterval(() => {}, 1000);",
-        ]);
+      writeModule(runner, [
+        "import { spawn } from 'node:child_process';",
+        "import { writeFileSync, renameSync } from 'node:fs';",
+        `const child = spawn(process.execPath, ['-e', ${JSON.stringify(childScript)}], { stdio: 'ignore' });`,
+        "writeFileSync(process.env.CHILD_PID_PATH + '.tmp', String(child.pid)); renameSync(process.env.CHILD_PID_PATH + '.tmp', process.env.CHILD_PID_PATH);",
+        "process.on('SIGTERM', () => process.exit(0));",
+        "setInterval(() => {}, 1000);",
+      ]);
 
-        const command = runShard({
+      const releaseAndWait = startProcessWatchdogFixture(() =>
+        runShard({
           env: {
             ...process.env,
             CHILD_PID_PATH: childPidPath,
@@ -409,15 +413,17 @@ describe("run-oxlint", () => {
           extraArgs: [],
           runner,
           shard: { name: "timeout-group-test", args: [] },
-        });
+        }),
+      );
 
-        await waitFor(() => existsSync(childPidPath), 15_000);
-        childPid = Number(readFileSync(childPidPath, "utf8"));
+      try {
+        childPid = await waitForPidFile(childPidPath, 15_000);
         expect(isProcessAlive(childPid)).toBe(true);
 
-        await expect(command).resolves.toBe(124);
+        await expect(releaseAndWait()).resolves.toBe(124);
         await waitFor(() => !isProcessAlive(childPid), 15_000);
       } finally {
+        await releaseAndWait();
         if (childPid && isProcessAlive(childPid)) {
           process.kill(childPid, "SIGKILL");
         }

--- a/test/scripts/run-tsgo-descendants.test.ts
+++ b/test/scripts/run-tsgo-descendants.test.ts
@@ -1,0 +1,247 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import net, { type Socket } from "node:net";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { pathToFileURL } from "node:url";
+import { describe, expect, it } from "vitest";
+import { waitForDead } from "../helpers/process-wait.js";
+import { createScriptTestHarness } from "./test-helpers.js";
+
+const { createTempDir } = createScriptTestHarness();
+const repo = process.cwd();
+type FixtureProcess = { role: string; pid: number; ppid: number; socket: Socket; closed: boolean };
+
+async function until(predicate: () => boolean, ms: number) {
+  const deadline = Date.now() + ms;
+  while (!predicate()) {
+    if (Date.now() >= deadline) return false;
+    await delay(10);
+  }
+  return true;
+}
+
+describe.skipIf(process.platform === "win32")("compiler descendant cleanup", () => {
+  it.each(["timeout", "abort", "signal"])(
+    "closes lint and its nested compiler after %s",
+    async (mode) => {
+      const dir = fs.realpathSync(createTempDir("openclaw-compiler-descendants-"));
+      const records: FixtureProcess[] = [];
+      const server = net.createServer((socket) => {
+        let buffer = "";
+        let record: FixtureProcess | undefined;
+        socket.on("data", (data) => {
+          buffer += data;
+          while (buffer.includes("\n")) {
+            const index = buffer.indexOf("\n");
+            const message = JSON.parse(buffer.slice(0, index)) as Omit<
+              FixtureProcess,
+              "socket" | "closed"
+            >;
+            buffer = buffer.slice(index + 1);
+            record = { ...message, socket, closed: false };
+            records.push(record);
+          }
+        });
+        socket.on("error", () => {});
+        socket.on("close", () => {
+          if (record) record.closed = true;
+        });
+      });
+      await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+      const address = server.address();
+      if (!address || typeof address === "string") throw new Error("Missing fixture address");
+      const port = address.port;
+      const preload = path.join(dir, "preload.mjs");
+      const prep = path.join(dir, "prepare.mjs");
+      const compiler = path.join(dir, "compiler.cjs");
+      const grandchild = path.join(dir, "grandchild.cjs");
+      const sentinel = path.join(dir, "sentinel.cjs");
+      const sibling = path.join(dir, "sibling.cjs");
+      const originalPrep = path.join(
+        repo,
+        "scripts/prepare-extension-package-boundary-artifacts.mts",
+      );
+      const roles = {
+        [path.join(repo, "scripts/run-oxlint.mjs")]: "lint-shim",
+        [path.join(repo, "scripts/run-oxlint.mts")]: "lint-implementation",
+        [path.join(repo, "scripts/run-tsgo.mjs")]: "compiler-shim",
+        [path.join(repo, "scripts/run-tsgo.mts")]: "compiler-implementation",
+        [prep]: "prepare",
+        [compiler]: "compiler",
+        [grandchild]: "grandchild",
+        [sentinel]: "sentinel",
+        [sibling]: "sibling",
+      };
+      fs.writeFileSync(
+        preload,
+        `
+import cp from 'node:child_process';
+import net from 'node:net';
+import { syncBuiltinESMExports } from 'node:module';
+const role = ${JSON.stringify(roles)}[process.argv[1]];
+if (role) {
+  const socket = net.connect(${port}, '127.0.0.1');
+  const send = message => socket.write(JSON.stringify(message) + '\\n');
+  socket.on('connect', () => { send({kind:'hello',role,pid:process.pid,ppid:process.ppid}); socket.unref(); });
+  socket.on('error', () => {});
+  let data = '';
+  let deadlineCallback;
+  if (role === 'prepare') {
+    const schedule = globalThis.setTimeout;
+    globalThis.setTimeout = (callback, ms, ...args) => {
+      if (ms === 300000) deadlineCallback = () => callback(...args);
+      return schedule(callback, ms, ...args);
+    };
+  }
+  socket.on('data', chunk => {
+    data += chunk;
+    while (data.includes('\\n')) {
+      const index = data.indexOf('\\n');
+      const command = data.slice(0,index); data = data.slice(index+1);
+      if (command === 'cleanup') process.exit(137);
+      if (command === 'fail') process.exit(2);
+      if (command === 'signal') process.kill(process.pid, 'SIGTERM');
+      if (command === 'timeout') deadlineCallback();
+    }
+  });
+  const originalSpawn = cp.spawn;
+  cp.spawn = (command, args, options) => {
+    if (role === 'compiler-implementation') {
+      command = process.execPath; args = [${JSON.stringify(compiler)}];
+    } else if (args?.includes(${JSON.stringify(originalPrep)})) {
+      args = args.map(arg => arg === ${JSON.stringify(originalPrep)} ? ${JSON.stringify(prep)} : arg);
+    } else if (role === 'lint-implementation' && !args?.includes(${JSON.stringify(prep)})) {
+      command = process.execPath; args = ['-e', 'console.log("FALSE_SUCCESS")'];
+    }
+    const child = originalSpawn(command, args, options);
+    return child;
+  };
+  syncBuiltinESMExports();
+}
+`,
+      );
+      const hang = `for (const signal of ['SIGTERM','SIGHUP','SIGINT']) process.on(signal,()=>{});\nsetInterval(()=>{},1000);\nsetTimeout(()=>process.exit(99),45000).unref();\n`;
+      fs.writeFileSync(grandchild, hang + 'console.log("grandchild holds stdout");\n');
+      fs.writeFileSync(
+        compiler,
+        hang +
+          `require('node:child_process').spawn(process.execPath,[${JSON.stringify(grandchild)}],{stdio:'inherit'});\n`,
+      );
+      fs.writeFileSync(sentinel, hang);
+      fs.writeFileSync(sibling, hang);
+      fs.writeFileSync(
+        prep,
+        `
+import {runNodeStep,runNodeStepsInParallel} from ${JSON.stringify(pathToFileURL(originalPrep).href)};
+try {
+  ${
+    mode === "abort"
+      ? `await runNodeStepsInParallel([
+    {label:'failing sibling',args:[${JSON.stringify(sibling)}],timeoutMs:60000},
+    {label:'plugin-sdk boundary dts',args:[${JSON.stringify(path.join(repo, "scripts/run-tsgo.mjs"))},'-p','tsconfig.plugin-sdk.dts.json'],timeoutMs:60000}
+  ]);`
+      : `await runNodeStep('plugin-sdk boundary dts',[${JSON.stringify(path.join(repo, "scripts/run-tsgo.mjs"))},'-p','tsconfig.plugin-sdk.dts.json'],300000);`
+  }
+  console.log('FALSE_SUCCESS');
+} catch(error) { console.error(error.message); process.exitCode=1; }
+`,
+      );
+      const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        NODE_OPTIONS: `--import=${pathToFileURL(preload).href}`,
+      };
+      delete env.OPENCLAW_TSGO_TIMEOUT_MS;
+      delete env.OPENCLAW_OXLINT_SKIP_PREPARE;
+      const sentinelChild = spawn(process.execPath, [sentinel], {
+        env,
+        stdio: "ignore",
+        detached: true,
+      });
+      const root = spawn(
+        process.execPath,
+        [
+          path.join(repo, "scripts/run-oxlint.mjs"),
+          "--tsconfig",
+          "config/tsconfig/oxlint.extensions.json",
+          "extensions",
+        ],
+        { env, stdio: ["ignore", "pipe", "pipe"], detached: true },
+      );
+      let output = "";
+      let result: { code: number | null; signal: NodeJS.Signals | null } | undefined;
+      root.stdout.on("data", (data) => (output += data));
+      root.stderr.on("data", (data) => (output += data));
+      root.on("close", (code, signal) => {
+        result = { code, signal };
+      });
+      try {
+        const ready = await until(
+          () =>
+            [
+              "grandchild",
+              "compiler",
+              "compiler-implementation",
+              "compiler-shim",
+              "prepare",
+              "sentinel",
+            ].every((role) => records.some((record) => record.role === role)),
+          15000,
+        );
+        expect(ready, records.map((r) => r.role).join(",")).toBe(true);
+        const target = records.find(
+          (record) => record.role === (mode === "abort" ? "sibling" : "prepare"),
+        );
+        if (!target) throw new Error("Missing control target");
+        target.socket.write(
+          (mode === "abort" ? "fail" : mode === "signal" ? "signal" : "timeout") + "\n",
+        );
+        const completed = await until(
+          () =>
+            Boolean(result) && records.filter((r) => r.role !== "sentinel").every((r) => r.closed),
+          4000,
+        );
+        expect(completed, output).toBe(true);
+        expect(result).toEqual({ code: 1, signal: null });
+        expect(output).toContain("[plugin-sdk boundary dts] grandchild holds stdout");
+        expect(output.trim().split("\n").at(-1)).toBe("[oxlint] FAILED (exit 1)");
+        expect(output).not.toContain("FALSE_SUCCESS");
+        for (const record of records.filter((r) => r.role !== "sentinel"))
+          await waitForDead(record.pid, 2000);
+        expect(records.find((r) => r.role === "sentinel")?.closed).toBe(false);
+        expect(sentinelChild.kill(0)).toBe(true);
+      } finally {
+        // Live private sockets identify these exact fixture instances; never signal saved PIDs.
+        for (const record of records.filter(
+          (r) => r.role === "grandchild" || r.role === "compiler",
+        )) {
+          if (!record.closed) record.socket.write("cleanup\n");
+        }
+        await until(
+          () =>
+            records
+              .filter((r) => r.role === "grandchild" || r.role === "compiler")
+              .every((r) => r.closed),
+          2000,
+        );
+        for (const record of records) if (!record.closed) record.socket.write("cleanup\n");
+        await until(() => records.every((r) => r.closed), 2000);
+        if (root.exitCode === null && root.signalCode === null) root.kill("SIGKILL");
+        if (sentinelChild.exitCode === null && sentinelChild.signalCode === null)
+          sentinelChild.kill("SIGKILL");
+        await until(() => result !== undefined, 2000);
+        const cleanup = records.map(({ role, pid, closed }) => ({ role, pid, closed }));
+        for (const record of records) record.socket.destroy();
+        await new Promise<void>((resolve, reject) =>
+          server.close((error) => (error ? reject(error) : resolve())),
+        );
+        expect(
+          cleanup.every((record) => record.closed),
+          "fixture cleanup",
+        ).toBe(true);
+        for (const record of records) await waitForDead(record.pid, 2000);
+      }
+    },
+    30000,
+  );
+});


### PR DESCRIPTION
Closes #131873

## What Problem This Solves

Fixes an issue where developers running lint would be left with a hanging wrapper and live compiler descendants after declaration preparation hit its existing five-minute timeout. The TypeScript implementation could be reparented to PID 1 while its compiler and grandchild kept the output pipe open. Sibling cancellation and preparation-parent termination exposed the same ownership gap.

## Why This Change Was Made

The launching JavaScript shim now gives its TypeScript implementation a dedicated IPC connection. The existing managed-process owner observes that connection closing, terminates only its registered child groups, and refuses to start more work if its launcher disappeared during module loading. The hard-kill path also clears pending escalation and avoids re-signaling a completed group.

This repairs the existing launch/lifetime boundary rather than searching process names, polling PPIDs, retaining recovery PIDs, adding another supervisor, or weakening declaration checks. Nested detached groups remain useful for standalone compiler isolation; a larger timeout or longer grace period would only move the failure. No timeout/heap defaults, dependencies, configuration, declaration generation, or Discord runtime behavior change.

Test-only cleanup removes two nearby races found during verification: partial PID-file publication could parse as PID 0, and timer-based fixture readiness/draining could race the watchdog. The tests now publish complete PIDs and use the existing readiness-gated watchdog helper.

Provenance: the detached shim boundary was introduced in #121005 (`c70aee247e83`, authored and merged by @steipete, 2026-08-09). #123975 (`ee6e0251b461`, authored by @jesse-merhi and merged by ClawSweeper, 2026-08-23; human automation trigger unknown) added standalone compiler cleanup but carried this hard-killed-shim gap forward.

## User Impact

Local declaration timeouts and cancellations release their compiler descendants and output pipes so the outer check exits nonzero with its final failure trailer. Unrelated Node/compiler jobs remain untouched. This is developer tooling only; no bot, channel, provider, or public configuration behavior changes.

Production/tooling: **+29/-2 (net +27)**, for the previously missing launcher-loss ownership connection and lifecycle handling in the existing owners. Tests: **+316/-20 (net +296)**. No parallel ownership abstraction or test-only production API was introduced.

## Evidence

AI-assisted implementation; independently reviewed with Codex. Autoreview completed successfully with no accepted/actionable findings at its default P0 threshold; the lead also inspected owner/caller/sibling source and dependency contracts.

A real-process fixture runs the maintained lint and TypeScript wrappers, substituting only expensive compilation/preparation work. It creates an owned compiler/grandchild retaining stdout, records actual spawn edges, and keeps an unrelated same-runtime sentinel alive. The timeout callback is triggered after readiness with its unchanged 300000ms value; this is not a claim of waiting five wall-clock minutes.

| Scenario | Before | After |
| --- | --- | --- |
| Declaration timeout | Implementation reparented to PID 1; compiler/grandchild survive; lint pipe remains open | Entire owned chain gone, lint exits 1, cleanup observed in 76ms |
| Sibling failure | Nested compiler descendants survive the outer one-second abort escalation | Entire owned chain gone, lint exits 1, cleanup observed in 1087ms |
| Preparation-parent SIGTERM | Compiler descendants survive parent shutdown | Entire owned chain gone, lint exits 1, cleanup observed in 1049ms |

All after-fix outputs end with `[oxlint] FAILED (exit 1)` and contain no false-success marker. The unrelated sentinel survives until explicit harness cleanup. Teardown uses live fixture control connections and verifies kernel process exit; no process-name sweep is used. The new regression tests fail on the original production files. A separate startup-disconnect comparison proves the original owner starts forbidden work, while the repaired owner starts nothing and returns 137.

Focused owner/sibling proof: **150 tests passed in six files (two routed shards)**.

```sh
node scripts/run-vitest.mjs test/scripts/run-tsgo-descendants.test.ts test/scripts/managed-child-process.test.ts test/scripts/run-tsgo.test.ts test/scripts/prepare-extension-package-boundary-artifacts.test.ts test/scripts/check-extension-package-tsc-boundary.test.ts test/scripts/run-oxlint.test.ts --reporter=verbose
```

Changed gate passed (script/test-root typechecks, lint, formatting, erasability and repository guards):

```sh
node scripts/check-changed.mjs -- scripts/lib/managed-child-process.mts scripts/lib/tsx-cli-shim.mjs test/scripts/managed-child-process.test.ts test/scripts/run-tsgo-descendants.test.ts test/scripts/run-oxlint.test.ts test/scripts/prepare-extension-package-boundary-artifacts.test.ts
```

Bun 1.4.0 successfully launches the real compiler and linter through `bun scripts/run-tsgo.mjs --version` and `bun scripts/run-oxlint.mjs --version`. Dependency inspection covers Node 24 IPC EOF/disconnect/refcount behavior and the installed native compiler's POSIX execve/inherited-stdio contract.

**Local proof gap, not hidden:** the additional unchanged `direct-run-entrypoints.test.ts` cache-preservation suite intermittently times out at its existing ten-second subprocess deadline on this macOS/Node 24.20.0 host. Both the original shim copied from HEAD and the raw-preload route (which bypasses the changed IPC owner) reproduce it. Native samples locate the delay after both expected snapshots print, in Node `CompileCacheHandler::Persist` → synchronous filesystem operations. No cache setting, deadline, or assertion was changed to hide that failure. Its fixture also needs separately tracked joined descendant teardown before directory removal; that follow-up is outside this compiler repair. Hosted exact-head checks remain required before landing.

The historical Discord worktree/logs were unavailable locally; fresh before/after reproduction independently establishes the defect. Native macOS process proof is complete; hosted Linux/Windows results will be recorded before landing. No claim is made that this contains arbitrary descendants that deliberately detach again or survives forcible termination of the managed implementation itself.

Hosted validation on exact head `7aab8c44daf4091fdde0f97f5e7dd04d6cfeac5c`: [CI run 33189559487](https://github.com/openclaw/openclaw/actions/runs/33189559487) completed successfully, including `openclaw/ci-gate`, Linux/Windows tests, build, typechecks, lint, and boundary gates. [Workflow Sanity run 33189521241](https://github.com/openclaw/openclaw/actions/runs/33189521241) is still pending in actionlint; this is not an all-checks-green or merge-ready claim.

**New integration blocker:** while checks were running, #131862 merged as `dd81c6aa1d1a59723d0a699a1dbd8a40544cf9b2` and substantially refactored the managed-command/preparation lifecycle for the same timeout symptom. This PR now conflicts in `scripts/lib/managed-child-process.mts` and `test/scripts/run-oxlint.test.ts`. The full-rollup watcher stopped with `CONFLICTING-MID-WAIT` (exit 14). The successful CI above proves this PR head before reconciling that new owner implementation; no rebase, semantic rewrite, or merge is claimed. Maintainer reconciliation is required before further landing work.
