### PR TITLE
fix(slack): mark partially unavailable thread files

### DIFF
--- a/extensions/slack/src/monitor/message-handler/prepare-content.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-content.ts
@@ -24,6 +24,31 @@ const MAX_SLACK_UNAVAILABLE_FILE_TEXT_CHARS = 2000;
 
 const loadSlackMediaModule = createLazyRuntimeModule(() => import("../media.js"));
 
+export function formatSlackUnavailableMedia(params: {
+  body: string;
+  files?: (SlackFile & { reason: string })[];
+  unavailableMediaCount: number;
+  prependUnavailable?: boolean;
+}): string {
+  let fileReferences = params.files
+    ?.map((file) => `${formatSlackFileReference(file)} unavailable (${file.reason})`)
+    .join(", ");
+  if (fileReferences && fileReferences.length > MAX_SLACK_UNAVAILABLE_FILE_TEXT_CHARS) {
+    fileReferences = `${truncateUtf16Safe(fileReferences, MAX_SLACK_UNAVAILABLE_FILE_TEXT_CHARS)}; … (file references truncated)`;
+  }
+  const fileBlock = fileReferences ? `[Slack file: ${fileReferences}]` : undefined;
+  const body = [params.body, fileBlock].filter(Boolean).join("\n");
+  if (params.unavailableMediaCount === 0) {
+    return body;
+  }
+  const notice = `[slack ${
+    params.unavailableMediaCount > 1 ? `${params.unavailableMediaCount} attachments` : "attachment"
+  } unavailable]`;
+  return params.prependUnavailable
+    ? [notice, fileBlock, params.body].filter(Boolean).join("\n")
+    : formatInboundMediaUnavailableText({ body, notice });
+}
+
 function collectUniqueSlackMentionIds(texts: Array<string | undefined>): string[] {
   const seen = new Set<string>();
   const mentionIds: string[] = [];
@@ -120,14 +145,6 @@ export async function resolveSlackMessageContent(params: {
   const effectiveDirectMedia = attachmentContent?.media.length ? attachmentContent.media : null;
   const mediaPlaceholder = effectiveDirectMedia?.map((item) => item.placeholder).join(" ");
 
-  let fileOnlyFallback = attachmentContent?.files
-    ?.map((file) => `${formatSlackFileReference(file)} unavailable (${file.reason})`)
-    .join(", ");
-  // Excess files remain accounted for without adding an unbounded prompt block.
-  if (fileOnlyFallback && fileOnlyFallback.length > MAX_SLACK_UNAVAILABLE_FILE_TEXT_CHARS) {
-    fileOnlyFallback = `${truncateUtf16Safe(fileOnlyFallback, MAX_SLACK_UNAVAILABLE_FILE_TEXT_CHARS)}; … (file references truncated)`;
-  }
-
   let botAttachmentText: string | undefined;
   if (params.isBotMessage && !attachmentContent?.text) {
     const botAttachmentTextParts: string[] = [];
@@ -175,24 +192,14 @@ export async function resolveSlackMessageContent(params: {
   const renderedAttachmentText = renderSlackUserMentions(textParts[1], renderedMentions);
   const renderedBotAttachmentText = renderSlackUserMentions(textParts[2], renderedMentions);
 
-  let rawBody =
-    [
-      renderedMessageText,
-      renderedAttachmentText,
-      renderedBotAttachmentText,
-      mediaPlaceholder,
-      fileOnlyFallback ? `[Slack file: ${fileOnlyFallback}]` : undefined,
-    ]
+  const body =
+    [renderedMessageText, renderedAttachmentText, renderedBotAttachmentText, mediaPlaceholder]
       .filter(Boolean)
       .join("\n") || "";
-  const unavailableMediaCount = attachmentContent?.unavailableMediaCount ?? 0;
-  if (unavailableMediaCount > 0) {
-    rawBody = formatInboundMediaUnavailableText({
-      body: rawBody,
-      notice: `[slack ${
-        unavailableMediaCount > 1 ? `${unavailableMediaCount} attachments` : "attachment"
-      } unavailable]`,
-    });
-  }
+  const rawBody = formatSlackUnavailableMedia({
+    body,
+    files: attachmentContent?.files,
+    unavailableMediaCount: attachmentContent?.unavailableMediaCount ?? 0,
+  });
   return rawBody ? { rawBody, effectiveDirectMedia } : null;
 }

--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts
@@ -160,9 +160,13 @@ describe("resolveSlackThreadContextData", () => {
       hydrates: true,
     },
   ])("$title", async ({ sessionState, sessionLastInteractionAt, hydrates }) => {
-    const resolveSlackMedia = vi
-      .spyOn(mediaModule, "resolveSlackMedia")
-      .mockResolvedValue(starterMedia);
+    const resolveSlackAttachmentContent = vi
+      .spyOn(mediaModule, "resolveSlackAttachmentContent")
+      .mockResolvedValue({
+        text: "",
+        media: starterMedia,
+        unavailableMediaCount: 0,
+      });
     const { result } = await resolveAllowlistedThreadContext({
       repliesMessages: [],
       threadStarter: { text: "starter with image", userId: "U1", files: starterFiles },
@@ -173,7 +177,7 @@ describe("resolveSlackThreadContextData", () => {
     });
 
     expect(result.threadStarterMedia).toEqual(hydrates ? starterMedia : null);
-    expect(resolveSlackMedia).toHaveBeenCalledTimes(hydrates ? 1 : 0);
+    expect(resolveSlackAttachmentContent).toHaveBeenCalledTimes(hydrates ? 1 : 0);
   });
 
   it("omits non-allowlisted starter, follow-ups, and unrelated current-bot replies", async () => {

--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
@@ -19,6 +19,7 @@ import type { SlackMonitorContext } from "../context.js";
 import type { SlackEventScope } from "../event-scope.js";
 import type { SlackMediaResult } from "../media-types.js";
 import { resolveSlackThreadHistory, type SlackThreadStarter } from "../thread.js";
+import { formatSlackUnavailableMedia } from "./prepare-content.js";
 import {
   applySlackThreadHistoryFilterPolicy,
   ensureSlackThreadHistoryHasBotRoot,
@@ -273,13 +274,23 @@ export async function resolveSlackThreadContextData(params: {
       starter.files &&
       starter.files.length > 0
     ) {
-      const { resolveSlackMedia } = await loadSlackMediaModule();
-      threadStarterMedia = await resolveSlackMedia({
+      const { resolveSlackAttachmentContent } = await loadSlackMediaModule();
+      const attachmentContent = await resolveSlackAttachmentContent({
         files: starter.files,
         client: params.eventScope?.client ?? params.ctx.app.client,
         token: params.ctx.botToken,
         maxBytes: params.ctx.mediaMaxBytes,
       });
+      threadStarterMedia = attachmentContent?.media.length ? attachmentContent.media : null;
+      if (attachmentContent) {
+        threadStarterBody = formatSlackUnavailableMedia({
+          body: threadStarterBody,
+          files: attachmentContent.files,
+          unavailableMediaCount: attachmentContent.unavailableMediaCount,
+          // Prompt serialization truncates long starter bodies from the tail.
+          prependUnavailable: true,
+        });
+      }
       if (threadStarterMedia) {
         const starterPlaceholders = threadStarterMedia.map((item) => item.placeholder).join(", ");
         logVerbose(`slack: hydrated thread starter file ${starterPlaceholders} from root message`);
@@ -321,8 +332,21 @@ export async function resolveSlackThreadContextData(params: {
       limit: threadInitialHistoryLimit,
     });
 
+    const enrichedStarter =
+      starter && threadStarterBody && threadStarterBody !== starter.text
+        ? { ...starter, text: threadStarterBody, ts: currentBotRootTs }
+        : null;
+    const threadHistoryWithEnrichedRoot =
+      enrichedStarter && !threadHistory.some((entry) => entry.ts === currentBotRootTs)
+        ? [
+            enrichedStarter,
+            ...(threadHistory.length >= threadInitialHistoryLimit
+              ? threadHistory.slice(1)
+              : threadHistory),
+          ]
+        : threadHistory;
     const threadHistoryWithBotRoot = ensureSlackThreadHistoryHasBotRoot({
-      history: threadHistory,
+      history: threadHistoryWithEnrichedRoot,
       includeBotStarterAsRootContext,
       threadStarter: starter ? { ...starter, ts: currentBotRootTs } : null,
     });
@@ -405,7 +429,11 @@ export async function resolveSlackThreadContextData(params: {
         const msgSenderName = isCurrentBot
           ? "Bot (this assistant)"
           : (msgUser?.name ?? (historyMsg.botId ? `Bot (${historyMsg.botId})` : "Unknown"));
-        const msgWithId = `${historyMsg.text}\n[slack message id: ${historyMsg.ts ?? "unknown"} channel: ${params.message.channel}]`;
+        const historyBody =
+          historyMsg.ts === currentBotRootTs && threadStarterBody
+            ? threadStarterBody
+            : historyMsg.text;
+        const msgWithId = `${historyBody}\n[slack message id: ${historyMsg.ts ?? "unknown"} channel: ${params.message.channel}]`;
         historyParts.push(
           formatInboundEnvelope({
             channel: "Slack",

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -3428,6 +3428,94 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
     );
   });
 
+  it("keeps unavailable thread-root files visible beside hydrated media", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) =>
+      (typeof input === "string" ? input : input instanceof URL ? input.href : input.url).includes(
+        "missing.pdf",
+      )
+        ? new Response("Not Found", { status: 404 })
+        : new Response(Buffer.from("image contents"), {
+            status: 200,
+            headers: { "content-type": "image/png" },
+          }),
+    ) as typeof fetch;
+    let downloadedPaths: string[] = [];
+    const rootMessage = {
+      text: `${"Root context. ".repeat(200)}Inspect both attachments`,
+      user: "U1",
+      ts: "760.000",
+      files: [
+        {
+          id: "FAVAILABLE",
+          name: "available.png",
+          mimetype: "image/png",
+          url_private_download: "https://files.slack.com/available.png",
+        },
+        {
+          id: "FMISSING",
+          name: "missing.pdf",
+          mimetype: "application/pdf",
+          url_private_download: "https://files.slack.com/missing.pdf",
+        },
+      ],
+    };
+    const replies = vi.fn(async (params: { limit?: number }) => ({
+      messages:
+        params.limit === 1
+          ? [rootMessage]
+          : Array.from({ length: 21 }, (_, index) => ({
+              text: `Prior reply ${index}`,
+              user: "U1",
+              ts: `760.${String(index + 100).padStart(3, "0")}`,
+            })),
+      response_metadata: { next_cursor: "" },
+    }));
+    const { storePath } = storeFixture.makeTmpStorePath();
+    const cfg = {
+      session: { store: storePath },
+      channels: { slack: { enabled: true, replyToMode: "all", groupPolicy: "open" } },
+    } as OpenClawConfig;
+    const slackCtx = createThreadSlackCtx({ cfg, replies });
+    slackCtx.resolveUserName = async () => ({ name: "Alice" });
+    slackCtx.resolveChannelName = async () => ({ name: "general", type: "channel" });
+
+    try {
+      const prepared = await prepareThreadMessage(slackCtx, {
+        channel: "CROOTPARTIAL",
+        text: "Please use the files from the root",
+        ts: "761.000",
+        thread_ts: "760.000",
+      });
+
+      assertPrepared(prepared);
+      downloadedPaths =
+        prepared.ctxPayload.media?.flatMap((media) => (media.path ? [media.path] : [])) ?? [];
+      expect(prepared.ctxPayload.media).toHaveLength(1);
+      expect(prepared.ctxPayload.media?.[0]).toMatchObject({
+        contentType: "image/png",
+        fileName: "available.png",
+      });
+      expect(prepared.ctxPayload.ThreadStarterBody).toMatch(/^\[slack attachment unavailable\]/);
+      expect(prepared.ctxPayload.ThreadStarterBody).toContain(
+        "missing.pdf (application/pdf, fileId: FMISSING) unavailable (",
+      );
+      expect(prepared.ctxPayload.ThreadStarterBody).toContain("HTTP 404");
+      expect(prepared.ctxPayload.ThreadStarterBody).toContain("Inspect both attachments");
+      expect(prepared.ctxPayload.ThreadStarterBody?.slice(0, 2_000)).toContain("missing.pdf");
+      expect(prepared.ctxPayload.ThreadHistoryBody).toContain(
+        "missing.pdf (application/pdf, fileId: FMISSING) unavailable (",
+      );
+      expect(prepared.ctxPayload.ThreadHistoryBody).toContain("HTTP 404");
+      expect(prepared.ctxPayload.ThreadHistoryBody?.match(/\[slack message id:/g)).toHaveLength(20);
+      expect(prepared.ctxPayload.RawBody).not.toContain("missing.pdf");
+      expect(prepared.ctxPayload.CommandBody).toBe("Please use the files from the root");
+    } finally {
+      globalThis.fetch = originalFetch;
+      await Promise.all(downloadedPaths.map((filePath) => fs.rm(filePath, { force: true })));
+    }
+  });
+
   it("skips loading thread history when thread session already exists in store (bloat fix)", async () => {
     const { storePath } = storeFixture.makeTmpStorePath();
     const cfg = {


### PR DESCRIPTION
Closes #131889

## What Problem This Solves

Fixes an issue where a new or reset Slack thread could inherit only the successfully downloaded subset of its root attachments without telling the agent that sibling files were unavailable. The agent could therefore answer a request about all root files using incomplete input.

## Why This Change Was Made

Thread-root hydration now consumes the same closed attachment result and bounded, sanitized unavailable-file formatter used for current Slack messages. The enriched root is retained in both starter and initial-history context, including when the root falls outside the bounded history window, while successful media remains attached and reply-local `RawBody` and `CommandBody` remain unchanged. Production delta is +39 lines: the added owner-boundary accounting and bounded root-history preservation cannot be expressed by a consumer guard. No config, schema, environment, or protocol surface changes.

## User Impact

When one inherited root file downloads and another does not, the agent receives the successful file plus the failed file name, bounded failure reason, and aggregate unavailable notice. Existing one-time hydration behavior for new, outbound-only, and reset sessions is preserved.

## Evidence

- Before: `node scripts/run-vitest.mjs extensions/slack/src/monitor/message-handler/prepare.test.ts -t "keeps unavailable thread-root files visible beside hydrated media"` failed because `ThreadStarterBody` was only the original root text and omitted `missing.pdf`.
- After: the same focused test passes with one available image, `missing.pdf`, `HTTP 404`, and `[slack attachment unavailable]` present in bounded starter/history context; the 20-message history cap remains intact (`extensions/slack/src/monitor/message-handler/prepare.test.ts:3431`).
- Owner path: `extensions/slack/src/monitor/message-handler/prepare-thread-context.ts:268-298`, `extensions/slack/src/monitor/message-handler/prepare-thread-context.ts:335-349`, and `extensions/slack/src/monitor/message-handler/prepare-thread-context.ts:432-436`. Shared bounded renderer: `extensions/slack/src/monitor/message-handler/prepare-content.ts:27-58`.
- Provenance: root hydration originated in `578ac9f1a992be567352d2b983b329bce1d66a5d`, one-time session gating in `a6e19fe014de267bb3cde5bbc3f24c50d0e3ed63`, and current-message unavailable accounting in `8c203185d7edb9840baecf9ebfca4d3eae0170b2` plus `46ca7d1f279192b9b547f861a0c1c990a9982d86`.
- A second independent adversarial review attempted to refute the analysis and confirmed the bug. Fresh strict diff reviews found and resolved prompt truncation, starter suppression, and history-cap edge cases; final review reported no findings.
- Checks: focused regression (1/1), full `prepare.test.ts` (158/158), full `prepare-thread-context.test.ts` (23/23), and `node scripts/check-changed.mjs`.
- Live Slack verification was not run because no authorized test workspace/channel credentials were available; the regression uses the real fetch/storage/preparation path with mocked Slack transport responses.