### PR TITLE
chore(release): diagnose classic onboarding hook state

### DIFF
--- a/scripts/e2e/lib/release-scenarios/assertions.mjs
+++ b/scripts/e2e/lib/release-scenarios/assertions.mjs
@@ -86,11 +86,50 @@ function assertOpenAiEnvRef() {
   assert(!readStateText().includes(rawKey), "raw OpenAI key was persisted");
 }
 
+function summarizeKnownValue(value, knownValues) {
+  if (value === undefined) {
+    return "missing";
+  }
+  return knownValues.includes(value) ? value : "unexpected";
+}
+
+function summarizeBoolean(value) {
+  if (value === true || value === false) {
+    return value;
+  }
+  return value === undefined ? "missing" : "unexpected";
+}
+
+function sessionMemoryHookConfigProjection(cfg) {
+  const wizard = cfg?.wizard;
+  const hooks = cfg?.hooks;
+  const internal = hooks?.internal;
+  const sessionMemory = internal?.entries?.["session-memory"];
+  return {
+    wizard: {
+      present: wizard !== undefined,
+      lastRunCommand: summarizeKnownValue(wizard?.lastRunCommand, ["onboard", "configure"]),
+      lastRunMode: summarizeKnownValue(wizard?.lastRunMode, ["local", "remote"]),
+    },
+    hooks: {
+      present: hooks !== undefined,
+      internalPresent: internal !== undefined,
+      internalEnabled: summarizeBoolean(internal?.enabled),
+      sessionMemoryPresent: sessionMemory !== undefined,
+      sessionMemoryEnabled: summarizeBoolean(sessionMemory?.enabled),
+    },
+  };
+}
+
 function assertSessionMemoryHookEnabled() {
   const cfg = readJson(configPath());
-  assert(
-    cfg.hooks?.internal?.entries?.["session-memory"]?.enabled === true,
-    "session-memory hook was not enabled",
+  if (cfg?.hooks?.internal?.entries?.["session-memory"]?.enabled === true) {
+    return;
+  }
+  throw new Error(
+    `session-memory hook was not enabled. Onboarding config projection: ${JSON.stringify(
+      sessionMemoryHookConfigProjection(cfg),
+    )}`,
   );
 }
 

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -122,22 +122,6 @@ const finalizeSetupWizard = vi.hoisted(() =>
 const listChannelPlugins = vi.hoisted(() => vi.fn(() => []));
 const logConfigUpdated = vi.hoisted(() => vi.fn(() => {}));
 const setupInternalHooks = vi.hoisted(() => vi.fn(async (cfg) => cfg));
-const enableDefaultOnboardingInternalHooks = vi.hoisted(() =>
-  vi.fn((cfg) => ({
-    ...cfg,
-    hooks: {
-      ...(cfg as { hooks?: Record<string, unknown> }).hooks,
-      internal: {
-        ...(cfg as { hooks?: { internal?: Record<string, unknown> } }).hooks?.internal,
-        entries: {
-          ...(cfg as { hooks?: { internal?: { entries?: Record<string, unknown> } } }).hooks
-            ?.internal?.entries,
-          "session-memory": { enabled: true },
-        },
-      },
-    },
-  })),
-);
 const detectSetupMigrationSources = vi.hoisted(() => vi.fn(async () => []));
 const listSetupMigrationOptions = vi.hoisted(() =>
   vi.fn<ListSetupMigrationOptions>(async () => []),
@@ -413,8 +397,8 @@ vi.mock("../commands/health.js", () => ({
   healthCommandNonExiting: healthCommand,
 }));
 
-vi.mock("../commands/onboard-hooks.js", () => ({
-  enableDefaultOnboardingInternalHooks,
+vi.mock("../commands/onboard-hooks.js", async (importActual) => ({
+  ...(await importActual<typeof import("../commands/onboard-hooks.js")>()),
   setupInternalHooks,
 }));
 
@@ -1307,41 +1291,25 @@ describe("runSetupWizard", () => {
   it("auto-enables the bundled session-memory hook without showing the hooks screen", async () => {
     replaceConfigFile.mockClear();
     setupInternalHooks.mockClear();
-    enableDefaultOnboardingInternalHooks.mockClear();
     const prompter = buildWizardPrompter({});
     const runtime = createRuntime({ throwsOnExit: true });
 
     await runWizard({}, runtime, prompter);
 
     expect(setupInternalHooks).not.toHaveBeenCalled();
-    expect(enableDefaultOnboardingInternalHooks).toHaveBeenCalledOnce();
-    const finalCallIndex = replaceConfigFile.mock.calls.length - 1;
-    const replaceParams = requireRecord(
-      getMockCallArg(replaceConfigFile, finalCallIndex, 0, "final config replacement"),
-      "final config replacement params",
-    );
-    const nextConfig = requireRecord(replaceParams.nextConfig, "next config");
-    const hooks = requireRecord(nextConfig.hooks, "next config hooks");
-    const internal = requireRecord(hooks.internal, "next config internal hooks");
-    const entries = requireRecord(internal.entries, "next config hook entries");
-    expect(entries["session-memory"]).toEqual({ enabled: true });
+    expect(persistedWizardConfigs().at(-1)?.hooks?.internal?.entries?.["session-memory"]).toEqual({
+      enabled: true,
+    });
   });
 
   it("does not auto-enable default hooks when skipHooks is set", async () => {
     replaceConfigFile.mockClear();
-    enableDefaultOnboardingInternalHooks.mockClear();
     const prompter = buildWizardPrompter({});
     const runtime = createRuntime({ throwsOnExit: true });
 
     await runWizard({ skipHooks: true }, runtime, prompter);
 
-    expect(enableDefaultOnboardingInternalHooks).not.toHaveBeenCalled();
-    const finalCallIndex = replaceConfigFile.mock.calls.length - 1;
-    const replaceParams = requireRecord(
-      getMockCallArg(replaceConfigFile, finalCallIndex, 0, "final config replacement"),
-      "final config replacement params",
-    );
-    expect(requireRecord(replaceParams.nextConfig, "next config").hooks).toBeUndefined();
+    expect(persistedWizardConfigs().at(-1)?.hooks).toBeUndefined();
   });
 
   it("persists the first security acknowledgement", async () => {

--- a/test/scripts/release-scenarios-assertions.test.ts
+++ b/test/scripts/release-scenarios-assertions.test.ts
@@ -112,6 +112,48 @@ describe("release scenario assertions", () => {
     }
   });
 
+  it("reports bounded onboarding hook diagnostics without leaking unrelated config", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "openclaw-release-scenarios-"));
+    const configPath = path.join(root, "openclaw.json");
+    const secretSentinel = "release-diagnostic-secret-sentinel";
+
+    try {
+      writeJson(configPath, {
+        wizard: {
+          lastRunCommand: "onboard",
+          lastRunMode: "local",
+          lastRunVersion: secretSentinel,
+        },
+        hooks: {
+          internal: {
+            enabled: true,
+            entries: {
+              "unrelated-hook": { token: secretSentinel },
+            },
+          },
+        },
+        env: {
+          vars: {
+            OPENCLAW_TEST_SECRET: secretSentinel,
+          },
+        },
+      });
+
+      const result = runAssertion(["assert-session-memory-hook-enabled"], {
+        OPENCLAW_CONFIG_PATH: configPath,
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(
+        'Onboarding config projection: {"wizard":{"present":true,"lastRunCommand":"onboard","lastRunMode":"local"},"hooks":{"present":true,"internalPresent":true,"internalEnabled":true,"sessionMemoryPresent":false,"sessionMemoryEnabled":"missing"}}',
+      );
+      expect(result.stderr).not.toContain(secretSentinel);
+      expect(result.stderr.length).toBeLessThan(4 * 1024);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   it("scans large request logs for image describe responses", () => {
     const root = mkdtempSync(path.join(tmpdir(), "openclaw-release-scenarios-"));
     const outputPath = path.join(root, "describe.json");


### PR DESCRIPTION
## What Problem This Solves

Release package validation reported only that the `session-memory` hook was not enabled. That left the classic onboarding route and persisted hook shape invisible while debugging the current package. The classic wizard unit test also replaced the default-hook helper it intended to verify.

## Why This Change Was Made

Exercise the real default-hook helper in the classic wizard test and assert the final persisted configuration. On release assertion failure, emit only a fixed-shape, bounded projection of onboarding route metadata and hook presence/enabled state; unrelated configuration values are never included.

## User Impact

No production behavior change. Maintainers get actionable, sanitized diagnostics when current-package classic onboarding validation fails.

## Evidence

- Regression proof: the new diagnostic test failed against the prior assertion because stderr contained only `session-memory hook was not enabled`.
- Exact-head focused Vitest: 86 tests passed (`src/wizard/setup.test.ts`, `test/scripts/release-scenarios-assertions.test.ts`).
- Formatting, targeted oxlint, Docker E2E boundary lint, script erasability, dead-code export scan, and diff checks passed.
- Fresh Sol high autoreview: clean, no actionable findings.
- Candidate failure evidence: Testbox run `33189004985` used candidate SHA `fa68ddb2`, not PR head `77ea606c01a278c066be528a31c46e2afc48fc05`. It passed package build, tarball integrity, package install, mock provider startup, and interactive typed onboarding before failing the existing session-memory assertion. This is not exact-head validation and does not establish the root cause; the PR adds bounded diagnostics for the next exact merged-main run.
- `check:changed` passed every gate through core tsgo graph validation, then the core-test typecheck hit the shared install blocker: `ui/vite.config.ts` cannot resolve declarations for `pako` because `@types/pako` is missing. This is unrelated to the PR diff.
- Production LOC: 0. Tooling: +42/-3. Tests: +48/-38.
- No changelog entry: test and diagnostic tooling only.




