### PR TITLE
fix(system-agent): isolate Codex sessions per conversation

### DIFF
--- a/src/system-agent/agent-turn.test.ts
+++ b/src/system-agent/agent-turn.test.ts
@@ -219,7 +219,7 @@ describe("runSystemAgentTurn", () => {
     expect(session.cliSession).toBeUndefined();
   });
 
-  it("uses a distinct transcript for each chat session", async () => {
+  it("isolates conversation identities and resumes the same transcript", async () => {
     useTempStateDir();
     const config = {
       agents: { defaults: { model: { primary: "openai/gpt-5.5" } } },
@@ -233,26 +233,20 @@ describe("runSystemAgentTurn", () => {
       readConfigFileSnapshot: vi.fn(async () => configSnapshot(config)) as never,
     };
 
-    await runSystemAgentTurnWithDeps(
-      {
-        input: "hello",
-        overview,
-        surface: "gateway",
-        approvalArmed: false,
-        session: first,
-      },
-      deps,
+    for (const session of [first, second, first]) {
+      await runSystemAgentTurnWithDeps(
+        { input: "hello", overview, surface: "gateway", approvalArmed: false, session },
+        deps,
+      );
+    }
+
+    const [firstCall, secondCall, resumedCall] = mocks.runEmbeddedAgent.mock.calls.map(
+      ([params]) => params,
     );
-    await runSystemAgentTurnWithDeps(
-      {
-        input: "hello",
-        overview,
-        surface: "gateway",
-        approvalArmed: false,
-        session: second,
-      },
-      deps,
-    );
+    expect(firstCall?.sessionKey).toBe(`agent:openclaw:${first.sessionId}`);
+    expect(secondCall?.sessionKey).toBe(`agent:openclaw:${second.sessionId}`);
+    expect(resumedCall?.sessionKey).toBe(firstCall?.sessionKey);
+    expect(resumedCall?.sessionManager).toBe(first.sessionManager);
 
     const firstPath = requireValue(
       mocks.runEmbeddedAgent.mock.calls[0]?.[0]?.sessionFile,
@@ -321,7 +315,8 @@ describe("runSystemAgentTurn", () => {
       agentDir,
       authProfileId: "claude-cli:ops",
       agentId: "openclaw",
-      sessionKey: "agent:openclaw:main",
+      sessionKey: `agent:openclaw:${session.sessionId}`,
+      runtimePolicySessionKey: "agent:openclaw:main",
       sessionId: session.sessionId,
       workspaceDir: path.join(stateDir, "openclaw", "workspace"),
       sessionFile: `in-memory:${session.sessionId}`,
@@ -813,7 +808,8 @@ describe("runSystemAgentTurn", () => {
       authProfileIdSource: "user",
       agentHarnessRuntimeOverride: "codex",
       agentId: "openclaw",
-      sessionKey: "agent:openclaw:main",
+      sessionKey: `agent:openclaw:${session.sessionId}`,
+      sandboxSessionKey: "agent:openclaw:main",
       sessionId: session.sessionId,
       workspaceDir: path.join(stateDir, "openclaw", "workspace"),
       sessionFile: `in-memory:${session.sessionId}`,

--- a/src/system-agent/agent-turn.ts
+++ b/src/system-agent/agent-turn.ts
@@ -9,7 +9,7 @@ import { normalizeCliModel } from "../agents/cli-runner/helpers.js";
 import { SessionManager } from "../agents/sessions/index.js";
 import { resolveStateDir } from "../config/paths.js";
 import type { CliSessionBinding } from "../config/sessions.js";
-import { buildAgentMainSessionKey } from "../routing/session-key.js";
+import { buildAgentMainSessionKey, toAgentStoreSessionKey } from "../routing/session-key.js";
 import { SYSTEM_AGENT_ID } from "./agent-id.js";
 import { SYSTEM_AGENT_SYSTEM_PROMPT } from "./assistant-prompts.js";
 import { SystemAgentInferenceUnavailableError } from "./inference-error.js";
@@ -312,9 +312,15 @@ async function runSystemAgentTurnWithDeps(
     SYSTEM_AGENT_ID,
     "system-agent.turn",
   );
+  // Conversation identity owns runner continuity; the main key remains policy-only.
+  // Sharing the runner key lets another conversation replace its generation.
+  const policySessionKey = buildAgentMainSessionKey({ agentId: SYSTEM_AGENT_ID });
   const shared = {
     sessionId: params.session.sessionId,
-    sessionKey: buildAgentMainSessionKey({ agentId: SYSTEM_AGENT_ID }),
+    sessionKey: toAgentStoreSessionKey({
+      agentId: SYSTEM_AGENT_ID,
+      requestKey: params.session.sessionId,
+    }),
     agentId: SYSTEM_AGENT_ID,
     trigger: "manual" as const,
     sessionFile: `in-memory:${params.session.sessionId}`,
@@ -372,6 +378,7 @@ async function runSystemAgentTurnWithDeps(
           systemAgentTool,
           ...(cliToolAvailability ? { cliToolAvailability } : {}),
           ...(previousBinding ? { cliSessionBinding: previousBinding } : {}),
+          runtimePolicySessionKey: policySessionKey,
           disableCliLiveSession: true,
           cleanupCliLiveSessionOnRunEnd: true,
         })) as EmbeddedRunResult;
@@ -406,6 +413,7 @@ async function runSystemAgentTurnWithDeps(
         model: plan.model,
         agentDir: plan.agentDir,
         agentHarnessRuntimeOverride: plan.agentHarnessRuntimeOverride,
+        sandboxSessionKey: policySessionKey,
         ...(expectedAgentHarnessRuntimeArtifact ? { expectedAgentHarnessRuntimeArtifact } : {}),
         ...(plan.authProfileId
           ? { authProfileId: plan.authProfileId, authProfileIdSource: "user" as const }


### PR DESCRIPTION
[AI-assisted]

## What Problem This Solves

Fixes #131807. Independent in-memory System Agent conversations already have separate session IDs, but the turn producer supplies the same `agent:openclaw:main` runner key. This patch restores @IWhatsskill's original intent: a stable, conversation-owned runner identity.

## Why This Change Was Made

Derive the runner key from the existing conversation session ID with `toAgentStoreSessionKey`. Preserve `agent:openclaw:main` solely for sandbox/tool policy through the existing embedded and CLI policy-key parameters.

This is deliberately limited to `src/system-agent/agent-turn.ts` and its existing test file. The earlier Gateway shutdown, registry cleanup, auth/config persistence, and release-fixture work has been removed from this PR and preserved separately. No new framework, configuration option, or storage/schema change.

## User Impact

Independent conversations receive distinct runner identities; later turns in the same conversation retain that identity and transcript. Existing sandbox/tool policy is unchanged.

## Evidence

Current head: `a69ba1d9998607d00892b028e6a3ac1f471fbf9e`.

- Production: **+10/−2**. Tests: **+18/−22**. **2 files, +28/−24 total** (previous iteration: 43 files, +2,013/−188).
- No new test cases, files, or suites. The existing transcript test now interleaves A→B→A; existing CLI/embedded route tests verify policy identity remains unchanged.
- All three modified cases failed against the baseline's shared-key behavior; all **22 owner tests pass** with the fix. This is source-contract regression proof, not a claim that the historical provider error was re-observed on current main.
- Fresh P2 autoreview: **scoped-clean**, confidence **0.96**.
- Applicable local checks: passed; the isolated checkout used the repository-pinned dependencies.
- Exact-head live conversation/continuity proof: passed on the real built runtime: A/B/A/B produced four replies, two distinct conversation keys/native threads, and correct thread resume plus marker recall for both conversations (Codex 0.153.0, openai/gpt-5.2). Temporary oracle only; no extra committed tests.
- Exact-head hosted CI: terminal success, run [33906849132](https://github.com/openclaw/openclaw/actions/runs/33906849132), attempt 1.

### Exact-head proof record — September 4, 2026

This addresses the current review’s stale-head evidence gap and its rank-up request without another code change. The real Gateway/Codex scenario ran at 18:33 UTC on the narrow head; both runtime build stamps identify `a69ba1d9998607d00892b028e6a3ac1f471fbf9e`. The isolated live test completed successfully (one selected case passed; two unrelated cases skipped).

```json
{
  "exactHead": "a69ba1d9998607d00892b028e6a3ac1f471fbf9e",
  "successfulReplies": 4,
  "distinctConversationKeys": 2,
  "distinctNativeThreads": 2,
  "resumedOwnThreads": 2,
  "recalledOwnMarkers": 2
}
```

The temporary oracle sent `openclaw.chat` requests A1 → B1 → A2 → B2 through the real Gateway. It checked successful replies, observed distinct `thread_ready` session keys and native thread IDs for A/B, then checked that A2/B2 reused their own original key/thread and returned their own marker. The verdict was emitted only after those assertions passed. The temporary oracle was removed afterward; no additional tests were committed.

Policy separation is covered by the existing CLI and embedded owner tests: the runner receives the conversation key, while `runtimePolicySessionKey` and `sandboxSessionKey` retain `agent:openclaw:main`. Those assertions passed in the 22/22 owner suite. This is explicit source-contract coverage for both routes, not a claim that the live scenario exercised the CLI route.

No shutdown, cancellation, persistence, or cross-restart claim is made for this narrow patch. The earlier broad-head evidence is superseded for this PR.

## Worked on by

- @VACInc
- @steipete

---
[View the OpenClaw team session](https://team.openclaw.ai/chat/roboclaw/dashboard/b293e929-6155-48c5-af3f-f591a1cc3b68)
