### PR TITLE
perf(test): run draft-proof variants concurrently

### DIFF
--- a/test/scripts/e2e-mock-config-limits.test.ts
+++ b/test/scripts/e2e-mock-config-limits.test.ts
@@ -1,10 +1,11 @@
 // E2E Mock Config Limits tests cover e2e mock config limits script behavior.
-import { type ChildProcess, spawn, spawnSync } from "node:child_process";
+import { type ChildProcess, execFile, spawn, spawnSync } from "node:child_process";
 import { once } from "node:events";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
+import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 import { validateToolArguments } from "../../packages/llm-core/src/validation.js";
 import { execSchema } from "../../src/agents/bash-tools.schemas.js";
@@ -146,140 +147,147 @@ async function withMockServer(
 }
 
 describe("mock OpenAI response markers", () => {
-  it.each([
+  it.concurrent.for([
     { api: "responses", stream: false },
     { api: "responses", stream: true },
     { api: "chat/completions", stream: false },
     { api: "chat/completions", stream: true },
-  ])("emits native exec draft-proof calls from $api (stream=$stream)", async ({ api, stream }) => {
-    await withMockServer(
-      mockOpenAiPath,
-      { MOCK_DRAFTPROOF_FINAL_DELAY_MS: "80" },
-      async (baseUrl) => {
-        const user = { role: "user", content: "return OPENCLAW_E2E_DRAFTPROOF" };
-        const tool = {
-          name: "exec",
-          description: "Execute a shell command",
-          parameters: execSchema,
-        };
-        const request = async (turns: unknown[]) => {
-          const response = await fetch(`${baseUrl}/v1/${api}`, {
-            method: "POST",
-            headers: { "content-type": "application/json" },
-            body: JSON.stringify({
-              [api === "responses" ? "input" : "messages"]: turns,
-              tools: [
-                api === "responses"
-                  ? { type: "function", ...tool }
-                  : { type: "function", function: tool },
-              ],
-              stream,
-            }),
-          });
-          expect(response.status).toBe(200);
-          if (!stream) {
-            return [await response.json()];
+  ])(
+    "emits native exec draft-proof calls from $api (stream=$stream)",
+    async ({ api, stream }, { expect }) => {
+      await withMockServer(
+        mockOpenAiPath,
+        { MOCK_DRAFTPROOF_FINAL_DELAY_MS: "80" },
+        async (baseUrl) => {
+          const user = { role: "user", content: "return OPENCLAW_E2E_DRAFTPROOF" };
+          const tool = {
+            name: "exec",
+            description: "Execute a shell command",
+            parameters: execSchema,
+          };
+          const request = async (turns: unknown[]) => {
+            const response = await fetch(`${baseUrl}/v1/${api}`, {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({
+                [api === "responses" ? "input" : "messages"]: turns,
+                tools: [
+                  api === "responses"
+                    ? { type: "function", ...tool }
+                    : { type: "function", function: tool },
+                ],
+                stream,
+              }),
+            });
+            expect(response.status).toBe(200);
+            if (!stream) {
+              return [await response.json()];
+            }
+            return (await response.text())
+              .split("\n\n")
+              .filter((line) => line.startsWith("data: ") && line !== "data: [DONE]")
+              .map((line) => JSON.parse(line.slice(6)));
+          };
+
+          const first = await request([user]);
+          let call;
+          let assistant;
+          if (api === "responses") {
+            const items = stream
+              ? first
+                  .filter((event) => event.type === "response.output_item.done")
+                  .map((event) => event.item)
+              : first[0].output;
+            expect(items).toHaveLength(2);
+            expect(items[0]).toMatchObject({
+              type: "message",
+              phase: "commentary",
+              content: [{ type: "output_text", text: "Checking the workspace before answering." }],
+            });
+            call = items[1];
+            expect(call).toMatchObject({ type: "function_call", name: "exec" });
+            assistant = items;
+          } else {
+            const messages = first.map((chunk) =>
+              stream ? chunk.choices[0].delta : chunk.choices[0].message,
+            );
+            const toolIndex = messages.findIndex((message) => message.tool_calls?.length);
+            expect(toolIndex).toBeGreaterThanOrEqual(0);
+            expect(
+              messages
+                .slice(0, toolIndex + 1)
+                .map((message) => message.content ?? "")
+                .join(""),
+            ).toBe("Checking the workspace before answering.");
+            expect(messages.slice(toolIndex + 1).some((message) => message.content)).toBe(false);
+            const toolCalls = messages[toolIndex].tool_calls;
+            expect(toolCalls).toHaveLength(1);
+            call = { ...toolCalls[0].function, call_id: toolCalls[0].id };
+            expect(call.name).toBe("exec");
+            assistant = [
+              {
+                role: "assistant",
+                content: "Checking the workspace before answering.",
+                tool_calls: toolCalls,
+              },
+            ];
           }
-          return (await response.text())
-            .split("\n\n")
-            .filter((line) => line.startsWith("data: ") && line !== "data: [DONE]")
-            .map((line) => JSON.parse(line.slice(6)));
-        };
 
-        const first = await request([user]);
-        let call;
-        let assistant;
-        if (api === "responses") {
-          const items = stream
-            ? first
-                .filter((event) => event.type === "response.output_item.done")
-                .map((event) => event.item)
-            : first[0].output;
-          expect(items).toHaveLength(2);
-          expect(items[0]).toMatchObject({
-            type: "message",
-            phase: "commentary",
-            content: [{ type: "output_text", text: "Checking the workspace before answering." }],
+          // A final marker also follows validation errors; prove the emitted call itself works.
+          const args = JSON.parse(call.arguments);
+          validateToolArguments(tool, {
+            type: "toolCall",
+            id: call.call_id,
+            name: call.name,
+            arguments: args,
           });
-          call = items[1];
-          expect(call).toMatchObject({ type: "function_call", name: "exec" });
-          assistant = items;
-        } else {
-          const messages = first.map((chunk) =>
-            stream ? chunk.choices[0].delta : chunk.choices[0].message,
-          );
-          const toolIndex = messages.findIndex((message) => message.tool_calls?.length);
-          expect(toolIndex).toBeGreaterThanOrEqual(0);
-          expect(
-            messages
-              .slice(0, toolIndex + 1)
-              .map((message) => message.content ?? "")
-              .join(""),
-          ).toBe("Checking the workspace before answering.");
-          expect(messages.slice(toolIndex + 1).some((message) => message.content)).toBe(false);
-          const toolCalls = messages[toolIndex].tool_calls;
-          expect(toolCalls).toHaveLength(1);
-          call = { ...toolCalls[0].function, call_id: toolCalls[0].id };
-          expect(call.name).toBe("exec");
-          assistant = [
-            {
-              role: "assistant",
-              content: "Checking the workspace before answering.",
-              tool_calls: toolCalls,
-            },
-          ];
-        }
+          expect(args.command).toBe("sleep 3 && echo openclaw-draft-proof");
+          let toolOutput = "openclaw-draft-proof\n";
+          // The command is POSIX shell syntax; Windows still covers HTTP and native validation.
+          if (process.platform !== "win32") {
+            const startedAt = performance.now();
+            // Keep the real shell wait without blocking the other draft-proof rows.
+            const execution = promisify(execFile)("bash", ["-c", args.command], {
+              encoding: "utf8",
+              timeout: 10_000,
+            });
+            const result = await execution;
+            expect(execution.child.exitCode, result.stderr).toBe(0);
+            expect(execution.child.signalCode).toBeNull();
+            expect(result.stdout).toBe(toolOutput);
+            expect(performance.now() - startedAt).toBeGreaterThanOrEqual(2_900);
+            toolOutput = result.stdout;
+          }
 
-        // A final marker also follows validation errors; prove the emitted call itself works.
-        const args = JSON.parse(call.arguments);
-        validateToolArguments(tool, {
-          type: "toolCall",
-          id: call.call_id,
-          name: call.name,
-          arguments: args,
-        });
-        expect(args.command).toBe("sleep 3 && echo openclaw-draft-proof");
-        let toolOutput = "openclaw-draft-proof\n";
-        // The command is POSIX shell syntax; Windows still covers HTTP and native validation.
-        if (process.platform !== "win32") {
-          const startedAt = performance.now();
-          const result = spawnSync("bash", ["-c", args.command], {
-            encoding: "utf8",
-            timeout: 10_000,
-          });
-          expect(result.status, result.stderr).toBe(0);
-          expect(result.signal).toBeNull();
-          expect(result.stdout).toBe(toolOutput);
-          expect(performance.now() - startedAt).toBeGreaterThanOrEqual(2_900);
-          toolOutput = result.stdout;
-        }
-
-        const finalStartedAt = performance.now();
-        const final = await request([
-          user,
-          ...assistant,
-          api === "responses"
-            ? { type: "function_call_output", call_id: call.call_id, output: toolOutput }
-            : { role: "tool", tool_call_id: call.call_id, content: toolOutput },
-        ]);
-        if (api === "responses") {
-          const response = stream
-            ? final.find((event) => event.type === "response.completed").response
-            : final[0];
-          expect(response.output[0].content[0].text).toBe("OPENCLAW_E2E_DRAFTPROOF");
-        } else {
-          expect(
-            final
-              .map((chunk) =>
-                stream ? (chunk.choices[0].delta.content ?? "") : chunk.choices[0].message.content,
-              )
-              .join(""),
-          ).toBe("OPENCLAW_E2E_DRAFTPROOF");
-          expect(performance.now() - finalStartedAt).toBeGreaterThanOrEqual(60);
-        }
-      },
-    );
-  });
+          const finalStartedAt = performance.now();
+          const final = await request([
+            user,
+            ...assistant,
+            api === "responses"
+              ? { type: "function_call_output", call_id: call.call_id, output: toolOutput }
+              : { role: "tool", tool_call_id: call.call_id, content: toolOutput },
+          ]);
+          if (api === "responses") {
+            const response = stream
+              ? final.find((event) => event.type === "response.completed").response
+              : final[0];
+            expect(response.output[0].content[0].text).toBe("OPENCLAW_E2E_DRAFTPROOF");
+          } else {
+            expect(
+              final
+                .map((chunk) =>
+                  stream
+                    ? (chunk.choices[0].delta.content ?? "")
+                    : chunk.choices[0].message.content,
+                )
+                .join(""),
+            ).toBe("OPENCLAW_E2E_DRAFTPROOF");
+            expect(performance.now() - finalStartedAt).toBeGreaterThanOrEqual(60);
+          }
+        },
+      );
+    },
+  );
 
   it("echoes dynamic OpenClaw E2E markers", async () => {
     await withMockServer(mockOpenAiPath, {}, async (baseUrl) => {


### PR DESCRIPTION
Related: #131636 (native exec draft-proof regression coverage).

## What Problem This Solves

The four draft-proof API/stream variants each execute a real three-second shell command sequentially, adding about twelve seconds of deliberate waiting to the tooling test file.

## Why This Change Was Made

Run only those four table rows concurrently with Vitest's `it.concurrent.for`, using each row's own `expect`. Await Node's real `execFile` promise instead of blocking the single worker with `spawnSync`; retain explicit zero exit status, null signal, exact stdout, command, and elapsed-time checks. Each row still owns a separate mock HTTP server and port, and the existing `finally` cleanup is joined. The remaining file tests stay serial.

No command shortening, fake timers, mocked HTTP/processes, shared server, removed cases, or weaker assertions. No production changes. AI-assisted with Codex.

## User Impact

No product behavior changes. The same regression coverage runs faster: whole-file mean wall time decreased from **20.165s to 10.395s**, saving **9.770s (48.45%)**. The separately filtered four-case group took **12.457s before / 3.195s after**, from Vitest's file start/end times.

## Evidence

Same task-owned Linux Blacksmith Testbox (4 exposed CPUs), Node 24.19.0 / pnpm 11.22.0, one Vitest worker; excluded A/B warmups followed by eight order-balanced pairs. Each invocation used a distinct filesystem module-cache path, both import diagnostics, and `/usr/bin/time -v`. All 16 measured runs passed all 23 tests. No samples discarded.

| Pair | Order | Before wall | After wall | Saving |
| --- | --- | ---: | ---: | ---: |
| 1 | AB | 19.06s | 10.02s | 9.04s |
| 2 | BA | 19.75s | 10.36s | 9.39s |
| 3 | AB | 18.97s | 10.30s | 8.67s |
| 4 | BA | 19.42s | 10.43s | 8.99s |
| 5 | BA | 21.40s | 10.59s | 10.81s |
| 6 | AB | 22.27s | 10.57s | 11.70s |
| 7 | BA | 20.79s | 10.38s | 10.41s |
| 8 | AB | 19.66s | 10.51s | 9.15s |

All 8/8 pairs improved; paired 95% interval for wall savings: 8.87–10.67s. Mean user/system CPU: 8.281/0.946s → 7.621/0.891s. GNU peak RSS: 628,202 → 628,178 KiB, effectively unchanged (per-process high-water metric, not aggregate concurrent RSS).

Process sampling at 50ms observed peak mock servers/bash/sleep children **1/1/1 → 4/4/4**, and total invocation descendants **8 → 17**. Concurrent ports were distinct, with no collision, output cross-talk, or surviving descendants. Row env is cloned, never mutated globally. The existing free-port helper releases its temporary reservation before spawn; each child's own readiness output prevents a bind failure from silently routing to another server.

Benchmark command (fresh `<sample>` for every invocation):

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 \
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/draftproof-performance/cache-<sample> \
OPENCLAW_VITEST_IMPORT_DURATIONS=1 \
OPENCLAW_VITEST_PRINT_IMPORT_BREAKDOWN=1 \
/usr/bin/time -v pnpm test test/scripts/e2e-mock-config-limits.test.ts \
  --maxWorkers=1 --reporter=verbose --reporter=json --outputFile=/tmp/draftproof-performance/<sample>.json
```

Testbox: `tbx_01m14jn9bz5cmmb8a2cw5w9mc6`, [environment run](https://github.com/openclaw/openclaw/actions/runs/33189364441). Benchmark source baseline: `221c89c1a20a3e3bd605774142725ed2812f97f7`.

Reversible mock-server faults (production bytes restored exactly after each):

- Invalid array command only for Responses nonstream: **that row failed actual schema validation; other three passed**.
- Wrong final marker only for Responses streaming: **that row failed its marker assertion; other three passed**.
- Missing final delay only for Chat streaming: **that row failed the unchanged >=60ms assertion; other three passed**.

All failed runs still joined cleanup and left zero server/bash descendants. Three subsequent full-file repetitions passed 23/23. Same-worker tooling siblings passed in original order and with shuffle seeds 17 and 91 (40 cases per run), plus the separately routed mock-config tests (4 cases). Local macOS baseline/candidate and shuffled siblings passed as well. No native Windows run was performed; its pre-existing HTTP/schema-only path is unchanged.

Complete changed gate passed:

```sh
OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs -- test/scripts/e2e-mock-config-limits.test.ts
```

The flag selects the supported local gate path; all classified checks ran, including test-root typecheck and scripts lint. Focused formatting and `git diff --check` passed. Test-audit and deslop found no removable coverage or extra cleanup. Fresh Codex autoreview: no accepted/actionable findings.

Production/tooling LOC: **+0/-0**. Tests: **+135/-127 (net +8)**; ignoring whitespace-only reindent, **+16/-8**. The larger raw diff is formatter indentation from the row-context callback. No config, dependencies, baselines, snapshots, persistence, protocol, or changelog changes.
