### PR TITLE
fix(macos): avoid publishing retired CUA startup endpoints

### DIFF
--- a/apps/macos/Sources/OpenClaw/CuaDriverHostCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/CuaDriverHostCoordinator.swift
@@ -399,6 +399,10 @@ final class CuaDriverHostCoordinator {
 
         let deadline = ContinuousClock.now + .seconds(10)
         while ContinuousClock.now < deadline {
+            let ready = await self.readinessProbe(socketDirectory.socketPath)
+            let permissions = ready ? await self.permissionSnapshot() : nil
+            // Either probe can suspend while disable or process exit retires this child.
+            // Revalidate before committing the snapshot or publishing availability.
             guard self.desiredEnabled,
                   let child = self.runningChild,
                   child.generation == generation,
@@ -407,8 +411,8 @@ final class CuaDriverHostCoordinator {
                 await self.ensureStopped()
                 return
             }
-            if await self.readinessProbe(socketDirectory.socketPath) {
-                self.lastPermissionSnapshot = await self.permissionSnapshot()
+            if let permissions {
+                self.lastPermissionSnapshot = permissions
                 self.setReadyEndpoint(CuaDriverWorkerEndpoint(
                     socketPath: socketDirectory.socketPath,
                     binaryPath: executableURL.path))

--- a/apps/macos/Tests/OpenClawIPCTests/CuaDriverHostCoordinatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CuaDriverHostCoordinatorTests.swift
@@ -27,6 +27,7 @@ struct CuaDriverHostCoordinatorTests {
         let launcher = CuaProcessLauncherProbe()
         var workerStops = 0
         let coordinator = CuaDriverHostCoordinator(
+            notificationCenter: NotificationCenter(),
             artifactURL: { executable },
             applicationSupportURL: { root },
             bundleIdentifier: { "ai.openclaw.test" },
@@ -34,6 +35,7 @@ struct CuaDriverHostCoordinatorTests {
                 launcher.launch(launch, onTermination: onTermination)
             },
             readinessProbe: { _ in true },
+            permissionSnapshot: { [:] },
             beforeDaemonStop: {
                 let allRunning = launcher.processes.allSatisfy(\.isRunning)
                 #expect(allRunning)
@@ -58,11 +60,12 @@ struct CuaDriverHostCoordinatorTests {
         #expect(launcher.processes.allSatisfy { !$0.isRunning })
     }
 
-    @Test func `elevation host refuses CUA enablement before spawning a child`() async throws {
+    @Test func `elevation host refuses CUA enablement before spawning a child`() async {
         let root = self.shortTemporaryDirectory("elevation-host")
         defer { try? FileManager.default.removeItem(at: root) }
         let launcher = CuaProcessLauncherProbe()
         let coordinator = CuaDriverHostCoordinator(
+            notificationCenter: NotificationCenter(),
             artifactURL: { root.appendingPathComponent("cua-driver") },
             applicationSupportURL: { root },
             bundleIdentifier: { "ai.openclaw.test" },
@@ -70,6 +73,7 @@ struct CuaDriverHostCoordinatorTests {
                 launcher.launch(launch, onTermination: onTermination)
             },
             readinessProbe: { _ in true },
+            permissionSnapshot: { [:] },
             enablementAllowed: {
                 AppLaunchRuntimePlan(arguments: ["OpenClaw", "--elevation-host"]).allowsCuaComputerControl
             })
@@ -80,6 +84,7 @@ struct CuaDriverHostCoordinatorTests {
         #expect(coordinator.workerEndpoint == nil)
 
         let normalCoordinator = CuaDriverHostCoordinator(
+            notificationCenter: NotificationCenter(),
             artifactURL: { root.appendingPathComponent("cua-driver") },
             applicationSupportURL: { root },
             bundleIdentifier: { "ai.openclaw.test" },
@@ -87,6 +92,7 @@ struct CuaDriverHostCoordinatorTests {
                 launcher.launch(launch, onTermination: onTermination)
             },
             readinessProbe: { _ in true },
+            permissionSnapshot: { [:] },
             enablementAllowed: {
                 AppLaunchRuntimePlan(arguments: ["OpenClaw"]).allowsCuaComputerControl
             })
@@ -154,13 +160,15 @@ struct CuaDriverHostCoordinatorTests {
         defer { try? FileManager.default.removeItem(at: root) }
         let launcher = CuaProcessLauncherProbe()
         let coordinator = CuaDriverHostCoordinator(
+            notificationCenter: NotificationCenter(),
             artifactURL: { root.appendingPathComponent("cua-driver") },
             applicationSupportURL: { root },
             bundleIdentifier: { "ai.openclaw.test" },
             processLauncher: { launch, onTermination in
                 launcher.launch(launch, onTermination: onTermination)
             },
-            readinessProbe: { _ in true })
+            readinessProbe: { _ in true },
+            permissionSnapshot: { [:] })
 
         await coordinator.setEnabled(true)
         let endpoint = try #require(coordinator.workerEndpoint)
@@ -182,13 +190,15 @@ struct CuaDriverHostCoordinatorTests {
         let stale = try CuaDriverHostCoordinator.createSocketDirectory(in: root)
         let launcher = CuaProcessLauncherProbe()
         let coordinator = CuaDriverHostCoordinator(
+            notificationCenter: NotificationCenter(),
             artifactURL: { root.appendingPathComponent("cua-driver") },
             applicationSupportURL: { root },
             bundleIdentifier: { "ai.openclaw.test" },
             processLauncher: { launch, onTermination in
                 launcher.launch(launch, onTermination: onTermination)
             },
-            readinessProbe: { _ in true })
+            readinessProbe: { _ in true },
+            permissionSnapshot: { [:] })
 
         await coordinator.setEnabled(true)
         #expect(!FileManager.default.fileExists(atPath: stale.url.path))
@@ -210,13 +220,15 @@ struct CuaDriverHostCoordinatorTests {
             encoding: .utf8)
         let launcher = CuaProcessLauncherProbe()
         let coordinator = CuaDriverHostCoordinator(
+            notificationCenter: NotificationCenter(),
             artifactURL: { executable },
             applicationSupportURL: { root },
             bundleIdentifier: { "ai.openclaw.test" },
             processLauncher: { launch, onTermination in
                 launcher.launch(launch, onTermination: onTermination)
             },
-            readinessProbe: { _ in true })
+            readinessProbe: { _ in true },
+            permissionSnapshot: { [:] })
 
         await coordinator.setEnabled(true)
 
@@ -233,13 +245,15 @@ struct CuaDriverHostCoordinatorTests {
         defer { try? FileManager.default.removeItem(at: root) }
         let launcher = CuaProcessLauncherProbe()
         let coordinator = CuaDriverHostCoordinator(
+            notificationCenter: NotificationCenter(),
             artifactURL: { executable },
             applicationSupportURL: { root },
             bundleIdentifier: { "ai.openclaw.test" },
             processLauncher: { launch, onTermination in
                 launcher.launch(launch, onTermination: onTermination)
             },
-            readinessProbe: { _ in true })
+            readinessProbe: { _ in true },
+            permissionSnapshot: { [:] })
 
         await coordinator.setEnabled(true)
 
@@ -260,6 +274,7 @@ struct CuaDriverHostCoordinatorTests {
         defer { try? FileManager.default.removeItem(at: root) }
         let launcher = CuaProcessLauncherProbe()
         let coordinator = CuaDriverHostCoordinator(
+            notificationCenter: NotificationCenter(),
             artifactURL: { executable },
             applicationSupportURL: { root },
             bundleIdentifier: { "ai.openclaw.test" },
@@ -274,7 +289,8 @@ struct CuaDriverHostCoordinatorTests {
                 try Data("incomplete".utf8).write(to: pidFile)
                 return launcher.launch(launch, onTermination: onTermination)
             },
-            readinessProbe: { _ in true })
+            readinessProbe: { _ in true },
+            permissionSnapshot: { [:] })
 
         await coordinator.setEnabled(true)
 
@@ -301,13 +317,15 @@ struct CuaDriverHostCoordinatorTests {
             encoding: .utf8)
         let launcher = CuaProcessLauncherProbe()
         let coordinator = CuaDriverHostCoordinator(
+            notificationCenter: NotificationCenter(),
             artifactURL: { expectedExecutable },
             applicationSupportURL: { root },
             bundleIdentifier: { "ai.openclaw.test" },
             processLauncher: { launch, onTermination in
                 launcher.launch(launch, onTermination: onTermination)
             },
-            readinessProbe: { _ in true })
+            readinessProbe: { _ in true },
+            permissionSnapshot: { [:] })
 
         await coordinator.setEnabled(true)
 
@@ -336,9 +354,11 @@ struct CuaDriverHostCoordinatorTests {
             encoding: .utf8)
         _ = try CuaDriverHostCoordinator.createSocketDirectory(in: root)
         let coordinator = CuaDriverHostCoordinator(
+            notificationCenter: NotificationCenter(),
             artifactURL: { executable },
             applicationSupportURL: { root },
-            bundleIdentifier: { "ai.openclaw.test" })
+            bundleIdentifier: { "ai.openclaw.test" },
+            permissionSnapshot: { [:] })
 
         await coordinator.shutdown()
 
@@ -441,10 +461,12 @@ struct CuaDriverHostCoordinatorTests {
     }
 
     @Test func `unexpected exits retry with a bounded budget while advertising unavailable`() async throws {
+        let delays = CuaRestartDelayProbe()
         let root = self.shortTemporaryDirectory("restart")
         defer { try? FileManager.default.removeItem(at: root) }
         let launcher = CuaProcessLauncherProbe()
         let coordinator = CuaDriverHostCoordinator(
+            notificationCenter: NotificationCenter(),
             artifactURL: { root.appendingPathComponent("cua-driver") },
             applicationSupportURL: { root },
             bundleIdentifier: { "ai.openclaw.test" },
@@ -452,7 +474,8 @@ struct CuaDriverHostCoordinatorTests {
                 launcher.launch(launch, onTermination: onTermination)
             },
             readinessProbe: { _ in true },
-            restartSleep: { _ in })
+            restartSleep: { delays.append($0) },
+            permissionSnapshot: { [:] })
 
         await coordinator.setEnabled(true)
         for expectedLaunchCount in 2...6 {
@@ -466,9 +489,118 @@ struct CuaDriverHostCoordinatorTests {
         for _ in 0..<100 {
             await Task.yield()
         }
+        #expect(delays.values == [.seconds(1), .seconds(2), .seconds(4), .seconds(8), .seconds(10)])
         #expect(launcher.launches.count == 6)
         #expect(coordinator.workerEndpoint == nil)
         await coordinator.setEnabled(false)
+    }
+
+    @Test(arguments: CuaStartupSuspension.allCases, [false, true])
+    func `retired startup never publishes availability or overwrites permissions`(
+        suspension: CuaStartupSuspension,
+        disable: Bool) async throws
+    {
+        let root = self.shortTemporaryDirectory("startup-race")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let notifications = NotificationCenter()
+        let launcher = CuaProcessLauncherProbe()
+        let probe = CuaStartupProbe(suspension: suspension)
+        let restartGate = AsyncTestGate()
+        let coordinator = CuaDriverHostCoordinator(
+            notificationCenter: notifications,
+            observeNotifications: true,
+            artifactURL: { root.appendingPathComponent("cua-driver") },
+            applicationSupportURL: { root },
+            bundleIdentifier: { "ai.openclaw.test" },
+            processLauncher: { launch, onTermination in
+                launcher.launch(launch, onTermination: onTermination)
+            },
+            readinessProbe: { _ in await probe.readiness() },
+            restartSleep: { _ in await restartGate.wait() },
+            permissionSnapshot: { await probe.permissions() })
+        var availability: [CuaDriverWorkerEndpoint?] = []
+        let observer = notifications.addObserver(
+            forName: .openclawCuaDriverAvailabilityChanged,
+            object: nil,
+            queue: nil)
+        { _ in
+            // Publication is synchronous on MainActor; an asynchronous observer would miss ready -> nil.
+            MainActor.assumeIsolated { availability.append(coordinator.workerEndpoint) }
+        }
+        defer { notifications.removeObserver(observer) }
+        let startup = Task { await coordinator.setEnabled(true) }
+        var disabling: Task<Void, Never>?
+        var replacement: Task<Void, Never>?
+        var failure: (any Error)?
+        do {
+            try #require(await self.waitUntil { probe.startupEntered })
+            let child = try #require(launcher.processes.first)
+            let launch = try #require(launcher.launches.first)
+            let socketIndex = try #require(launch.arguments.firstIndex(of: "--socket")) + 1
+            let retiredDirectory = URL(fileURLWithPath: launch.arguments[socketIndex]).deletingLastPathComponent()
+            #expect(FileManager.default.fileExists(atPath: retiredDirectory.path))
+
+            // Record a newer permission baseline while the old startup result is suspended.
+            probe.snapshot = [.accessibility: .granted, .screenRecording: .granted]
+            let expectedReads = probe.permissionReads + 1
+            notifications.post(name: .openclawPermissionsChanged, object: nil)
+            try #require(await self.waitUntil { probe.permissionReads == expectedReads })
+            if disable {
+                var disableEntered = false
+                disabling = Task { @MainActor in
+                    disableEntered = true
+                    // Same-actor call runs through desiredEnabled's update before its first suspension.
+                    await coordinator.setEnabled(false)
+                }
+                try #require(await self.waitUntil { disableEntered })
+            } else {
+                child.crash(status: 7)
+                try #require(await self.waitUntil {
+                    child.closeLivenessCount == 1 &&
+                        !FileManager.default.fileExists(atPath: retiredDirectory.path)
+                })
+            }
+            #expect(availability.isEmpty)
+            probe.releaseStartup.open()
+            await startup.value
+            await disabling?.value
+            #expect(coordinator.workerEndpoint == nil)
+            #expect(availability.isEmpty)
+            await coordinator.setEnabled(false)
+
+            // A stale snapshot would make this unchanged notification restart the next healthy child.
+            replacement = Task { await coordinator.setEnabled(true) }
+            try #require(await self.waitUntil { probe.replacementEntered })
+            let replacementReads = probe.permissionReads + 1
+            notifications.post(name: .openclawPermissionsChanged, object: nil)
+            try #require(await self.waitUntil { probe.permissionReads == replacementReads })
+            probe.releaseReplacement.open()
+            await replacement?.value
+            await coordinator.setEnabled(true)
+            #expect(launcher.launches.count == 2)
+            #expect(launcher.processes[1].closeLivenessCount == 0)
+            let endpoint = try #require(coordinator.workerEndpoint)
+            #expect(availability == [endpoint])
+        } catch {
+            failure = error
+        }
+        // Release and join every task even when a prerequisite assertion fails.
+        probe.releaseStartup.open()
+        probe.releaseReplacement.open()
+        await coordinator.shutdown()
+        restartGate.open()
+        await startup.value
+        await disabling?.value
+        await replacement?.value
+        if let failure { throw failure }
+    }
+
+    private func waitUntil(_ condition: @MainActor () -> Bool) async -> Bool {
+        let deadline = ContinuousClock.now + .seconds(2)
+        while !condition(), ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(1))
+        }
+        return condition()
     }
 
     @Test func `permission changes replace the daemon generation and endpoint`() async throws {
@@ -503,7 +635,8 @@ struct CuaDriverHostCoordinatorTests {
     }
 
     private func shortTemporaryDirectory(_ label: String) -> URL {
-        URL(fileURLWithPath: "/tmp/oc-cua-\(label)-\(UUID().uuidString.prefix(8))", isDirectory: true)
+        URL(fileURLWithPath: "/tmp", isDirectory: true).resolvingSymlinksInPath()
+            .appendingPathComponent("oc-cua-\(label)-\(UUID().uuidString.prefix(8))", isDirectory: true)
     }
 
     private func expectedExecutable(in root: URL, target: String) throws -> URL {
@@ -589,6 +722,68 @@ private final class CuaPermissionSnapshotProbe {
         .accessibility: .notGranted,
         .screenRecording: .notGranted,
     ]
+}
+
+enum CuaStartupSuspension: CaseIterable, Sendable {
+    case permissions
+    case readinessSuccess
+    case readinessFailure
+}
+
+@MainActor
+private final class CuaStartupProbe {
+    let releaseStartup = AsyncTestGate()
+    let releaseReplacement = AsyncTestGate()
+    private let suspension: CuaStartupSuspension
+    private var readinessReads = 0
+    private(set) var permissionReads = 0
+    private(set) var startupEntered = false
+    private(set) var replacementEntered = false
+    var snapshot: [Capability: CapabilityAuthorizationStatus] = [
+        .accessibility: .notGranted,
+        .screenRecording: .notGranted,
+    ]
+
+    init(suspension: CuaStartupSuspension) {
+        self.suspension = suspension
+    }
+
+    func readiness() async -> Bool {
+        self.readinessReads += 1
+        if self.readinessReads == 1 {
+            if self.suspension != .permissions {
+                self.startupEntered = true
+                await self.releaseStartup.wait()
+            }
+            return self.suspension != .readinessFailure
+        }
+        self.replacementEntered = true
+        await self.releaseReplacement.wait()
+        return true
+    }
+
+    func permissions() async -> [Capability: CapabilityAuthorizationStatus] {
+        self.permissionReads += 1
+        let snapshot = self.snapshot
+        if self.permissionReads == 1, self.suspension == .permissions {
+            self.startupEntered = true
+            await self.releaseStartup.wait()
+        }
+        return snapshot
+    }
+}
+
+private final class CuaRestartDelayProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var delays: [Duration] = []
+
+    var values: [Duration] {
+        self.lock.withLock { self.delays }
+    }
+
+    func append(_ delay: Duration) {
+        self.lock.withLock { self.delays.append(delay) }
+    }
 }
 
 @MainActor


### PR DESCRIPTION
Closes #131902

## What Problem This Solves

Resolves a problem where macOS computer control could advertise a CUA daemon endpoint after that daemon had exited or computer control had been disabled during startup. A retired startup could also retain stale permissions and cause an unnecessary replacement after the next healthy startup.

## Why This Change Was Made

The existing lifecycle owner, `CuaDriverHostCoordinator.ensureStarted`, checked enablement, child generation, and process liveness before awaited readiness and permission probes. Main-actor reentrancy could retire the child during either suspension. Startup now gathers those results locally, then runs the same ownership guard immediately before committing the permission snapshot and endpoint, with no intervening await.

This removes the ineffective pre-await guard placement without adding consumer guards, fallback paths, duplicate validation, timeouts, or new config. Production LOC: **+6/-2 (net +4)**; two local facts allow validation and publication to stay together, and two comment lines preserve the reentrancy invariant. Tests/support: **+205/-10 (net +195)**, including private notification/permission fixtures and two small existing formatting cleanups. The fixture isolation is separate from the production race repair.

Provenance: the affected code was introduced in feature PR #123635, commit `19ace6830b17a20cf5b103c1893a2c5d7bca6bc3` on 2026-08-14, authored and merged by @steipete. No installed-release regression interval is claimed.

## User Impact

Computer control will publish only the enabled, current live daemon's endpoint. Disabling or losing the child during startup cannot publish stale availability or overwrite the next startup's permission baseline. Restart limits and the 1/2/4/8/10-second backoffs are unchanged.

Release-note context: macOS computer control no longer publishes retired CUA startup endpoints after disable or daemon exit. No UI layout, setup, config, protocol, dependency, or storage changes.

## Evidence

The six-case owner-boundary regression covers permission suspension, successful readiness suspension, and unsuccessful readiness suspension against both crash and disable. Crash cases observe liveness closure and cleanup of the exact private socket directory before releasing startup. Disable entry is synchronized, and a synchronous private notification observer catches transient ready-to-nil publication. A later healthy startup verifies that stale permissions cannot cause a spurious replacement.

Before the production edit, two runs produced the same four failing variants and fourteen assertions; the two unsuccessful-readiness variants already passed. After the repair, all six pass. Final proof on this exact patch:

- SwiftPM build with tests: passed.
- 30 focused CUA, Peekaboo, and computer-control settings tests: passed; the optional live Peekaboo handshake was explicitly excluded.
- Changed-surface gate: passed, including 508 macOS Node/tooling tests, native lint, and schema guard.
- Pinned SwiftFormat/SwiftLint and `git diff --check`: passed.
- Fresh independent review: no accepted/actionable findings.

Exact commands:

```sh
swift build --package-path apps/macos --scratch-path apps/macos/.build --cache-path apps/macos/.build/cache --config-path apps/macos/.build/config --security-path apps/macos/.build/security --disable-dependency-cache --force-resolved-versions --build-tests --jobs 4
swift test --package-path apps/macos --scratch-path apps/macos/.build --cache-path apps/macos/.build/cache --config-path apps/macos/.build/config --security-path apps/macos/.build/security --disable-dependency-cache --force-resolved-versions --skip-build --no-parallel --filter 'CuaDriverHostCoordinatorTests|PeekabooBridgeHostCoordinatorTests|ComputerControlSettingsTests' --skip 'embedded runtime serves an exact socket handshake'
PATH="$PWD/.build/swift-tools:$PWD/node_modules/oxfmt/bin:$PATH" node scripts/check-changed.mjs -- apps/macos/Sources/OpenClaw/CuaDriverHostCoordinator.swift apps/macos/Tests/OpenClawIPCTests/CuaDriverHostCoordinatorTests.swift
.build/swift-tools/swiftformat --lint apps/macos/Sources/OpenClaw/CuaDriverHostCoordinator.swift apps/macos/Tests/OpenClawIPCTests/CuaDriverHostCoordinatorTests.swift --config config/swiftformat
.build/swift-tools/swiftlint lint --strict --quiet --config config/swiftlint.yml apps/macos/Sources/OpenClaw/CuaDriverHostCoordinator.swift apps/macos/Tests/OpenClawIPCTests/CuaDriverHostCoordinatorTests.swift
git diff --check
```

Proof limitations: no product app launch, live GUI/TCC observation, screenshots, or live operator state/Keychain access; the operator prohibited those actions. The approved substitute is deterministic injected owner-boundary red/green testing, not live proof. Local test loading required a relative Sparkle framework symlink within the isolated test bundle; no source workaround was added. Earlier tooling attempts encountered a missing formatter bin link and an unpinned host SwiftLint; the final gate used the installed formatter package and checksum-pinned native tools.

CI history and canonical resolution: landing exposed an actionlint 1.7.12 deadlock on GitHub's newer synthetic merge input: it wrote a 65,538-byte shell payload into StdinPipe before starting ShellCheck. The earlier PR-head local lint pass did not cover that input. This defect was independently repaired on main by [PR #131982](https://github.com/openclaw/openclaw/pull/131982), landed as [72ff36e97a93997f456af6ebd97bce65fd4b23a3](https://github.com/openclaw/openclaw/commit/72ff36e97a93997f456af6ebd97bce65fd4b23a3). Its canonical upstream pin contains the accepted stdin repair and is inherited unchanged. Our redundant CI commit, including its docs addition, was removed entirely. This PR neither introduces nor claims credit for that CI repair; its final diff is only the two CUA files, with no CI/docs/dependency delta.

The CUA-only candidate is `c8424dca51e4e743419758e9f7876b59a0c0bab5`, mechanically rebased onto `d549b12d186a98100c19e43153e9903161b1952a`. Both source/test blobs and stable patch ID `f65c3deb489a132171d6be6d1a6b7de83f1e0cd5` match the original verified repair. Pinned native lint and diff checks were repeated after rebase; the original behavioral proof remains applicable to the unchanged bytes. Fresh exact-head CI and Workflow Sanity must both succeed before native preparation; old-head runs are not current gate evidence. Results will be recorded in the [maintained proof comment](https://github.com/openclaw/openclaw/pull/131905#issuecomment-5455627641).

AI-assisted implementation, testing, review, and publication.
