### PR TITLE
feat(browser): expose the page errors action

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -824,7 +824,7 @@ Compared to the managed `openclaw` profile, existing-session drivers are more co
 - **Actions** - `click`, `type`, `hover`, `scrollIntoView`, `drag`, and `select` require snapshot refs (no CSS selectors). `click-coords` clicks visible viewport coordinates and does not require a snapshot ref. `click` is left-button only (no button overrides or modifiers). `type` does not support `slowly=true`; use `fill` or `press`. `press` does not support `delayMs`. `type`, `hover`, `scrollIntoView`, `drag`, `select`, and `fill` do not support per-call `timeoutMs` overrides; `evaluate` does. `select` accepts a single value. `batch` is not supported; send actions individually.
 - **Wait / upload / dialog** - `wait --url` supports exact, substring, and glob patterns (same as managed); `wait --load networkidle` is not supported on existing-session profiles (it works on managed and raw/remote CDP profiles). Upload hooks require `ref` or `inputRef`, one file at a time, no CSS `element`. Dialog hooks do not support timeout overrides or `dialogId`.
 - **Dialog visibility** - Managed browser action responses include `blockedByDialog` and `browserState.dialogs.pending` when an action opens a modal dialog; snapshots also include pending dialog state. Respond with `browser dialog --accept/--dismiss --dialog-id <id>` while a dialog is pending. Dialogs handled outside OpenClaw appear under `browserState.dialogs.recent`.
-- **Playwright-only features** - PDF export, download interception, `responsebody`, and the agent actions `requests`, `text`, and `emulate` require a Playwright-backed profile, such as the managed `openclaw` profile. Use `snapshot` to inspect an existing-session page.
+- **Playwright-only features** - PDF export, download interception, `responsebody`, and the agent actions `requests`, `errors`, `text`, and `emulate` require a Playwright-backed profile, such as the managed `openclaw` profile. Use `snapshot` to inspect an existing-session page.
 
 </Accordion>
 
@@ -921,15 +921,16 @@ Security guidance:
 
 The agent gets **one tool** for browser automation:
 
-- `browser` - doctor/status/start/stop/tabs/open/focus/close/snapshot/screenshot/navigate/act/requests/text/emulate
+- `browser` - doctor/status/start/stop/tabs/open/focus/close/snapshot/screenshot/navigate/act/requests/errors/text/emulate
 
 How it maps:
 
 - `browser snapshot` returns a stable UI tree (AI or ARIA).
 - Snapshot `query` keeps lines containing **all** whitespace-separated query tokens, ignoring case. Matching lines retain element refs; the result reports the match count and respects `maxChars`. It searches the returned snapshot, so increase the snapshot scope if the source was truncated.
 - `browser requests` reads the collected network log. Optional `filter` matches a substring in the URL or resource type; `limit` keeps the most recent entries (default 50). Results report `total` matching collected requests and `returned` entries; the output budget may reduce that count further. `clear=true` clears the entire collected log after reading, including entries omitted by filtering or limits.
+- `browser errors` reads collected page errors. `limit` keeps the most recent entries (default 50). Results report `total` collected errors and `returned` entries; the output budget may reduce that count further. `clear=true` clears the entire collected log after reading, including entries omitted by limits. Page errors remain untrusted external content.
 - `browser text` extracts visible prose using the first explicit `selector` match, otherwise the first `article`, `main`, or `body`. `maxChars` must be positive; it defaults to and cannot exceed 40,000 characters. The tool's output budget may truncate further. Page text remains untrusted external content.
-- `browser emulate` applies one or more of `device` (a Playwright device name), `colorScheme` (`dark`, `light`, `no-preference`, or `none` to clear), `timezoneId`, and `locale`. Settings apply in that order and return an `applied` list; they are not atomic. These three actions support local and node targets but not Chrome MCP existing-session profiles.
+- `browser emulate` applies one or more of `device` (a Playwright device name), `colorScheme` (`dark`, `light`, `no-preference`, or `none` to clear), `timezoneId`, and `locale`. Settings apply in that order and return an `applied` list; they are not atomic. These four actions support local and node targets but not Chrome MCP existing-session profiles.
 - `browser navigate` also returns the loaded page's snapshot inline (efficient
   interactive tier, so the payload stays compact and bounded), so the agent
   does not need a follow-up snapshot call. Batch `act` results that report a

--- a/extensions/browser/index.test.ts
+++ b/extensions/browser/index.test.ts
@@ -342,6 +342,7 @@ describe("browser plugin", () => {
       "close",
       "console",
       "requests",
+      "errors",
       "text",
       "emulate",
       "dialog",
@@ -402,7 +403,17 @@ describe("browser plugin", () => {
     const actions = (properties.action as { enum?: string[] }).enum;
     const actKinds = (properties.kind as { enum?: string[] }).enum;
 
-    expect(actions).not.toEqual(expect.arrayContaining(["pdf", "download", "waitfordownload"]));
+    for (const action of [
+      "pdf",
+      "download",
+      "waitfordownload",
+      "requests",
+      "errors",
+      "text",
+      "emulate",
+    ]) {
+      expect(actions).not.toContain(action);
+    }
     expect(actions).toEqual(expect.arrayContaining(["snapshot", "screenshot"]));
     expect(actKinds).not.toContain("batch");
     expect((properties.actions as { description?: string }).description).toBeUndefined();

--- a/extensions/browser/skills/browser-automation/SKILL.md
+++ b/extensions/browser/skills/browser-automation/SKILL.md
@@ -37,6 +37,7 @@ Use this skill when you need the `browser` tool for anything beyond a single pag
    - Use `action="emulate"` with `device`, `colorScheme`, `timezoneId`, or `locale` when testing those settings; snapshot again afterward. Existing-session profiles do not support emulation.
 5. Report real blockers:
    - Debug network failures with `action="requests"`, optional URL/type `filter`, and `limit` (default 50 recent entries). `clear=true` clears the collected log after reading. Use a managed profile; existing-session profiles do not support this log.
+   - Debug page errors with `action="errors"` and `limit` (default 50 recent entries). `clear=true` clears the collected log after reading. Existing-session profiles do not support this log.
    - If the page needs login, permission, captcha, 2FA, camera/microphone approval, or another manual step, stop and tell the user exactly what is needed.
    - Do not claim the browser is not logged in just because the current page shows a permission or onboarding dialog. Inspect the visible UI first.
 

--- a/extensions/browser/src/browser-tool-binding.ts
+++ b/extensions/browser/src/browser-tool-binding.ts
@@ -51,6 +51,7 @@ export const BROWSER_TAB_BOUND_ACTIONS = [
   "close",
   "console",
   "requests",
+  "errors",
   "text",
   "emulate",
   "dialog",

--- a/extensions/browser/src/browser-tool-description.ts
+++ b/extensions/browser/src/browser-tool-description.ts
@@ -42,6 +42,9 @@ export function describeBrowserTool(opts: {
           "Use requests for the recent network log; filter matches URL/type, limit defaults to 50, and clear=true clears the collected log after reading.",
         ]
       : []),
+    ...(actions.has("errors")
+      ? ["Use errors for page errors; limit defaults to 50, clear=true clears after reading."]
+      : []),
     ...(actions.has("emulate")
       ? [
           "Use emulate with device, colorScheme, timezoneId, or locale; at least one setting is required.",

--- a/extensions/browser/src/browser-tool.actions.ts
+++ b/extensions/browser/src/browser-tool.actions.ts
@@ -14,6 +14,7 @@ import {
   browserAct,
   browserConsoleMessages,
   browserRequests,
+  browserErrors,
   browserPageText,
   browserEmulateSetting,
   browserDownload,
@@ -28,6 +29,7 @@ import {
 } from "./browser-tool.runtime.js";
 import {
   appendNavigatedPageState,
+  formatBrowserDebugLogResult,
   wrapBrowserExternalJson,
   wrapBrowserExternalText,
 } from "./browser-tool.snapshot.js";
@@ -47,6 +49,7 @@ const browserToolActionDeps = {
   browserAct,
   browserConsoleMessages,
   browserRequests,
+  browserErrors,
   browserPageText,
   browserEmulateSetting,
   browserDownload,
@@ -364,44 +367,34 @@ export async function executeRequestsAction(
         profile,
         signal,
       });
-  const total = result.requests.length;
-  const requests = result.requests.slice(-limit);
-  const payload = () => ({
-    ok: result.ok,
-    targetId: result.targetId,
-    url: result.url,
-    total,
-    returned: requests.length,
-    truncated: requests.length < total,
-    requests,
-  });
-  let wrapped = wrapBrowserExternalJson({
-    kind: "requests",
-    payload: payload(),
-    includeWarning: false,
-  });
-  // Keep complete records: a large URL must not turn the log into partial JSON
-  // or make the reported returned count exceed what the model actually sees.
-  while (wrapped.truncated && requests.length > 0) {
-    requests.shift();
-    wrapped = wrapBrowserExternalJson({
-      kind: "requests",
-      payload: payload(),
-      includeWarning: false,
-    });
-  }
-  return {
-    content: [{ type: "text", text: wrapped.wrappedText }],
-    details: {
-      ...wrapped.safeDetails,
-      ok: result.ok,
-      targetId: result.targetId,
-      url: result.url,
-      total,
-      returned: requests.length,
-      truncated: requests.length < total || wrapped.truncated,
-    },
-  };
+  return formatBrowserDebugLogResult("requests", result, result.requests, limit);
+}
+
+/** Read recent page errors, keeping counts aligned with the bounded payload. */
+export async function executeErrorsAction(
+  params: Parameters<typeof executeConsoleAction>[0],
+): Promise<AgentToolResult<unknown>> {
+  const { input, baseUrl, profile, proxyRequest, signal } = params;
+  const targetId = normalizeOptionalString(input.targetId);
+  const clear = typeof input.clear === "boolean" ? input.clear : undefined;
+  const limit =
+    readPositiveIntegerParam(input, "limit", { message: "limit must be a positive integer." }) ??
+    50;
+  const result = proxyRequest
+    ? ((await proxyRequest({
+        method: "GET",
+        path: "/errors",
+        profile,
+        query: { targetId, clear },
+        // SAFETY: The proxy dispatches the same /errors route as the typed local client.
+      })) as Awaited<ReturnType<typeof browserErrors>>)
+    : await browserToolActionDeps.browserErrors(baseUrl, {
+        targetId,
+        clear,
+        profile,
+        signal,
+      });
+  return formatBrowserDebugLogResult("errors", result, result.errors, limit);
 }
 
 /** Extract visible page prose with the same trust boundary as snapshots. */

--- a/extensions/browser/src/browser-tool.runtime.ts
+++ b/extensions/browser/src/browser-tool.runtime.ts
@@ -47,6 +47,7 @@ export {
   browserArmFileChooser,
   browserConsoleMessages,
   browserRequests,
+  browserErrors,
   browserPageText,
   browserEmulateSetting,
   browserDownload,

--- a/extensions/browser/src/browser-tool.schema.test.ts
+++ b/extensions/browser/src/browser-tool.schema.test.ts
@@ -118,6 +118,7 @@ describe("browser tool schema", () => {
     const schema = createBrowserToolSchema(resolveBrowserToolCapabilities({ tabBound }));
     for (const args of [
       { action: "requests", targetId: "t1", filter: "fetch", clear: true, limit: 10 },
+      { action: "errors", targetId: "t1", clear: true, limit: 10 },
       { action: "text", targetId: "t1", selector: "article", maxChars: 1000 },
       {
         action: "emulate",
@@ -133,6 +134,8 @@ describe("browser tool schema", () => {
     }
     expect(Value.Check(schema, { action: "emulate", colorScheme: "invalid" })).toBe(false);
     expect(Value.Check(schema, { action: "requests", clear: "true" })).toBe(false);
+    expect(Value.Check(schema, { action: "errors", clear: "true" })).toBe(false);
+    expect(Value.Check(schema, { action: "errors", limit: 0 })).toBe(false);
   });
 
   it("hides Playwright-only actions for an existing-session binding", () => {
@@ -143,11 +146,20 @@ describe("browser tool schema", () => {
         supportsDownloads: false,
         supportsPdf: false,
         supportsRequests: false,
+        supportsErrors: false,
         supportsPageText: false,
         supportsEmulation: false,
       },
     });
-    for (const action of ["requests", "text", "emulate", "pdf", "download", "waitfordownload"]) {
+    for (const action of [
+      "requests",
+      "errors",
+      "text",
+      "emulate",
+      "pdf",
+      "download",
+      "waitfordownload",
+    ]) {
       expect(capabilities.actions).not.toContain(action);
     }
     expect(capabilities.actions).toContain("snapshot");

--- a/extensions/browser/src/browser-tool.schema.ts
+++ b/extensions/browser/src/browser-tool.schema.ts
@@ -49,6 +49,7 @@ const BROWSER_TOOL_ACTIONS = [
   "navigate",
   "console",
   "requests",
+  "errors",
   "text",
   "emulate",
   "pdf",
@@ -89,7 +90,7 @@ export function resolveBrowserToolCapabilities(params?: {
     Partial<
       Pick<
         BrowserProfileCapabilities,
-        "supportsRequests" | "supportsPageText" | "supportsEmulation"
+        "supportsRequests" | "supportsErrors" | "supportsPageText" | "supportsEmulation"
       >
     >;
 }): BrowserToolCapabilities {
@@ -101,6 +102,7 @@ export function resolveBrowserToolCapabilities(params?: {
       (action) =>
         (profileCapabilities?.supportsPdf !== false || action !== "pdf") &&
         (profileCapabilities?.supportsRequests !== false || action !== "requests") &&
+        (profileCapabilities?.supportsErrors !== false || action !== "errors") &&
         (profileCapabilities?.supportsPageText !== false || action !== "text") &&
         (profileCapabilities?.supportsEmulation !== false || action !== "emulate") &&
         (profileCapabilities?.supportsDownloads !== false ||
@@ -184,7 +186,7 @@ export function createBrowserToolSchema(capabilities: BrowserToolCapabilities) {
       kind: stringEnum(capabilities.actKinds, { description: actKindDescription }),
       ...actProperties,
     },
-    { description: "Nested action=act request." },
+    { description: "Nested act request." },
   );
   return Type.Object({
     action: stringEnum(capabilities.actions),

--- a/extensions/browser/src/browser-tool.snapshot.ts
+++ b/extensions/browser/src/browser-tool.snapshot.ts
@@ -28,12 +28,20 @@ import { finalizeRoleSnapshot, findRoleSnapshotLineRef } from "./browser/pw-role
 import { neutralizeMediaDirectives } from "./browser/vision.js";
 import { formatErrorMessage } from "./infra/errors.js";
 
-type BrowserExternalJsonKind = "snapshot" | "console" | "requests" | "tabs" | "act" | "download";
+type BrowserExternalJsonKind =
+  | "snapshot"
+  | "console"
+  | "requests"
+  | "errors"
+  | "tabs"
+  | "act"
+  | "download";
 
 const BROWSER_EXTERNAL_JSON_TRUNCATION_MARKERS = {
   snapshot: "\n[truncated — retry with a smaller maxChars or limit]",
   console: "\n[truncated — retry with a stricter level or targetId]",
   requests: "\n[truncated — retry with a narrower filter or smaller limit]",
+  errors: "\n[truncated — retry with a smaller limit]",
   tabs: "\n[truncated — retry with action=snapshot and a specific targetId]",
   act: "\n[truncated — inspect the affected targetId with action=snapshot]",
   download: "\n[truncated — retry with a specific targetId and download ref]",
@@ -118,6 +126,46 @@ export function wrapBrowserExternalJson(params: {
         kind: params.kind,
         wrapped: true,
       },
+    },
+  };
+}
+
+/** Keep debug log counts aligned with complete records inside the output budget. */
+export function formatBrowserDebugLogResult(
+  kind: "requests" | "errors",
+  result: { ok: true; targetId: string; url?: string },
+  entries: unknown[],
+  limit: number,
+): AgentToolResult<unknown> {
+  const total = entries.length;
+  const records = entries.slice(-limit);
+  const details = () => ({
+    ok: result.ok,
+    targetId: result.targetId,
+    url: result.url,
+    total,
+    returned: records.length,
+    truncated: records.length < total,
+  });
+  const wrap = () =>
+    wrapBrowserExternalJson({
+      kind,
+      payload: { ...details(), [kind]: records },
+      includeWarning: false,
+    });
+  let wrapped = wrap();
+  // Drop whole records so large URLs or stacks cannot leave partial JSON or
+  // report more returned entries than the model actually receives.
+  while (wrapped.truncated && records.length > 0) {
+    records.shift();
+    wrapped = wrap();
+  }
+  return {
+    content: [{ type: "text", text: wrapped.wrappedText }],
+    details: {
+      ...wrapped.safeDetails,
+      ...details(),
+      truncated: records.length < total || wrapped.truncated,
     },
   };
 }

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -86,6 +86,13 @@ const browserActionsMocks = vi.hoisted(() => ({
       requests: [],
     }),
   ),
+  browserErrors: vi.fn(
+    async (..._args: unknown[]): Promise<Record<string, unknown>> => ({
+      ok: true,
+      targetId: "t1",
+      errors: [],
+    }),
+  ),
   browserPageText: vi.fn(
     async (..._args: unknown[]): Promise<Record<string, unknown>> => ({
       ok: true,
@@ -300,6 +307,7 @@ vi.mock("./browser-tool.runtime.js", async () => {
         supportsDownloads: !existingSession,
         supportsPdf: !existingSession,
         supportsRequests: !existingSession,
+        supportsErrors: !existingSession,
         supportsPageText: !existingSession,
         supportsEmulation: !existingSession,
       };
@@ -4663,6 +4671,81 @@ describe("browser observation actions and tab previews", () => {
     expect(result.details).toMatchObject({ total: 3, returned: 1, truncated: true });
   });
 
+  it.each([
+    ["host", undefined],
+    ["node", undefined],
+    ["host", 2],
+    ["node", 2],
+  ] as const)("bounds and wraps recent errors on %s (limit=%s)", async (target, limit) => {
+    const errors = Array.from({ length: 60 }, (_, index) => ({
+      message: `page-error-${index}`,
+      name: "Error",
+      stack: `Error: page-error-${index}`,
+      timestamp: "2026-08-28T00:00:00.000Z",
+    }));
+    const payload = { ok: true, targetId: "canonical", url: "https://example.com", errors };
+    if (target === "node") {
+      mockSingleBrowserProxyNode();
+      gatewayMocks.callGatewayTool.mockResolvedValueOnce({ payload: { result: payload } });
+    } else {
+      browserActionsMocks.browserErrors.mockResolvedValueOnce(payload);
+    }
+    const result = await createBrowserTool().execute("errors", {
+      action: "errors",
+      target,
+      targetId: "t1",
+      profile: "openclaw",
+      clear: true,
+      limit,
+    });
+    const returned = limit ?? 50;
+    const text = firstResultText(result);
+    expect(text).toContain("<<<EXTERNAL_UNTRUSTED_CONTENT");
+    expect(text).not.toContain(`"message": "page-error-${59 - returned}"`);
+    expect(text).toContain(`"message": "page-error-${60 - returned}"`);
+    expect(text).toContain('"message": "page-error-59"');
+    expect(result.details).toMatchObject({
+      total: 60,
+      returned,
+      truncated: true,
+      externalContent: { untrusted: true, kind: "errors", wrapped: true },
+      browserTab: { targetId: "canonical", url: payload.url },
+    });
+    expect(result.details).not.toHaveProperty("errors");
+    if (target === "node") {
+      expect(nodeInvokeCall(0).request.params).toMatchObject({
+        method: "GET",
+        path: "/errors",
+        profile: "openclaw",
+        query: { targetId: "t1", clear: true },
+      });
+    } else {
+      expect(browserActionsMocks.browserErrors).toHaveBeenCalledWith(
+        undefined,
+        expect.objectContaining({ targetId: "t1", profile: "openclaw", clear: true }),
+      );
+    }
+  });
+
+  it("keeps error counts truthful when the text budget drops oversized records", async () => {
+    browserActionsMocks.browserErrors.mockResolvedValueOnce({
+      ok: true,
+      targetId: "t1",
+      errors: [
+        { message: "old" },
+        { message: "large", stack: "x".repeat(20_000) },
+        { message: "latest" },
+      ],
+    });
+    const result = await createBrowserTool().execute("errors", { action: "errors", limit: 2 });
+    const text = firstResultText(result);
+    expect(text.length).toBeLessThanOrEqual(16_000);
+    expect(text).toContain('"returned": 1');
+    expect(text).toContain('"message": "latest"');
+    expect(text).not.toContain('"message": "large"');
+    expect(result.details).toMatchObject({ total: 3, returned: 1, truncated: true });
+  });
+
   it.each(["host", "node"])("extracts and bounds untrusted page text on %s", async (target) => {
     const payload = {
       ok: true,
@@ -4739,7 +4822,7 @@ describe("browser observation actions and tab previews", () => {
     ).rejects.toThrow("positive integer");
   });
 
-  it.each(["requests", "text", "emulate"])(
+  it.each(["requests", "errors", "text", "emulate"])(
     "gives recovery guidance for existing-session %s",
     async (action) => {
       setResolvedBrowserProfiles({ user: { driver: "existing-session", attachOnly: true } });

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -24,6 +24,7 @@ import {
   executeDownloadAction,
   executeEmulateAction,
   executeRequestsAction,
+  executeErrorsAction,
   executeTextAction,
   executeTabsAction,
   formatBrowserExternalToolResult,
@@ -563,7 +564,7 @@ export function createBrowserTool(opts?: {
       if (
         !proxyRequest &&
         isUserBrowserProfile &&
-        ["requests", "text", "emulate"].includes(action)
+        ["requests", "errors", "text", "emulate"].includes(action)
       ) {
         throw new Error(
           `action=${action} is not supported for existing-session profiles; use action=snapshot to inspect this page, or select a managed browser profile for ${action}.`,
@@ -1026,14 +1027,15 @@ export function createBrowserTool(opts?: {
           return result;
         }
         case "requests":
+        case "errors":
         case "text":
         case "emulate": {
-          const execute =
-            action === "requests"
-              ? executeRequestsAction
-              : action === "text"
-                ? executeTextAction
-                : executeEmulateAction;
+          const execute = {
+            requests: executeRequestsAction,
+            errors: executeErrorsAction,
+            text: executeTextAction,
+            emulate: executeEmulateAction,
+          }[action];
           const result = await execute({ input: params, baseUrl, profile, proxyRequest, signal });
           sessionTabs.touch(
             readStringValue(asNullableRecord(result.details)?.targetId) ??
@@ -1155,6 +1157,7 @@ export function createBrowserTool(opts?: {
         "snapshot",
         "text",
         "requests",
+        "errors",
         "console",
         "emulate",
         "act",

--- a/extensions/browser/src/browser/client-actions-observe.ts
+++ b/extensions/browser/src/browser/client-actions-observe.ts
@@ -7,7 +7,11 @@
 import type { BrowserActionPathResult } from "./client-actions-types.js";
 import { buildProfileQuery, withBaseUrl } from "./client-actions-url.js";
 import { fetchBrowserJson } from "./client-fetch.js";
-import type { BrowserConsoleMessage, BrowserNetworkRequest } from "./pw-session.js";
+import type {
+  BrowserConsoleMessage,
+  BrowserNetworkRequest,
+  BrowserPageError,
+} from "./pw-session.js";
 
 function buildQuerySuffix(params: Array<[string, string | boolean | undefined]>): string {
   const query = new URLSearchParams();
@@ -60,6 +64,27 @@ export async function browserRequests(
     ["profile", opts.profile],
   ]);
   return await fetchBrowserJson(withBaseUrl(baseUrl, `/requests${suffix}`), {
+    timeoutMs: 20000,
+    signal: opts.signal,
+  });
+}
+
+/** Read the collected page error log for a tab. */
+export async function browserErrors(
+  baseUrl: string | undefined,
+  opts: {
+    clear?: boolean;
+    targetId?: string;
+    profile?: string;
+    signal?: AbortSignal;
+  } = {},
+): Promise<{ ok: true; errors: BrowserPageError[]; targetId: string; url?: string }> {
+  const suffix = buildQuerySuffix([
+    ["clear", opts.clear],
+    ["targetId", opts.targetId],
+    ["profile", opts.profile],
+  ]);
+  return await fetchBrowserJson(withBaseUrl(baseUrl, `/errors${suffix}`), {
     timeoutMs: 20000,
     signal: opts.signal,
   });

--- a/extensions/browser/src/browser/client-actions.ts
+++ b/extensions/browser/src/browser/client-actions.ts
@@ -15,6 +15,7 @@ export {
 export {
   browserConsoleMessages,
   browserRequests,
+  browserErrors,
   browserPageText,
   browserEmulateSetting,
   browserPdfSave,

--- a/extensions/browser/src/browser/client.test.ts
+++ b/extensions/browser/src/browser/client.test.ts
@@ -7,6 +7,7 @@ import {
   browserArmFileChooser,
   browserConsoleMessages,
   browserRequests,
+  browserErrors,
   browserPageText,
   browserEmulateSetting,
   browserNavigate,
@@ -142,7 +143,15 @@ describe("browser client", () => {
       body: { targetId: "t1", name: "iPhone 15" },
       profile,
     });
-    expect(calls).toHaveLength(3);
+    await browserErrors(baseUrl, { targetId: "tab & one", clear: false, profile });
+    expect(calls).toHaveLength(4);
+    const errorsUrl = new URL(calls[3]!.url);
+    expect(errorsUrl.pathname).toBe("/errors");
+    expect(Object.fromEntries(errorsUrl.searchParams)).toEqual({
+      targetId: "tab & one",
+      clear: "false",
+      profile,
+    });
     const requestUrl = new URL(calls[0]!.url);
     expect(requestUrl.pathname).toBe("/requests");
     expect(Object.fromEntries(requestUrl.searchParams)).toEqual({

--- a/extensions/browser/src/browser/profile-capabilities.ts
+++ b/extensions/browser/src/browser/profile-capabilities.ts
@@ -28,6 +28,7 @@ export type BrowserProfileCapabilities = {
   supportsDownloads: boolean;
   supportsPdf: boolean;
   supportsRequests: boolean;
+  supportsErrors: boolean;
   supportsPageText: boolean;
   supportsEmulation: boolean;
   requiresCompleteTargetEnumeration: boolean;
@@ -42,6 +43,7 @@ export function getBrowserProfileCapabilities(
     supportsDownloads: profile.driver !== "existing-session",
     supportsPdf: profile.driver !== "existing-session",
     supportsRequests: profile.driver !== "existing-session",
+    supportsErrors: profile.driver !== "existing-session",
     supportsPageText: profile.driver !== "existing-session",
     supportsEmulation: profile.driver !== "existing-session",
     requiresCompleteTargetEnumeration: profile.driver === "extension",

--- a/extensions/browser/src/browser/routes/agent.debug.ts
+++ b/extensions/browser/src/browser/routes/agent.debug.ts
@@ -109,6 +109,7 @@ export function registerBrowserAgentDebugRoutes(
       ctx,
       targetId,
       feature: "page errors",
+      existingSessionUnsupported: EXISTING_SESSION_LIMITS.errors,
       collect: async ({ cdpUrl, targetId: targetIdValue, pw }) =>
         await pw.getPageErrorsViaPlaywright({
           cdpUrl,

--- a/extensions/browser/src/browser/routes/agent.text.test.ts
+++ b/extensions/browser/src/browser/routes/agent.text.test.ts
@@ -68,7 +68,7 @@ describe("browser page text route", () => {
     expect(pageText).not.toHaveBeenCalled();
   });
 
-  it.each(["text", "requests"])(
+  it.each(["text", "requests", "errors"])(
     "rejects existing-session %s with a supported alternative",
     async (route) => {
       setBrowserControlServerProfiles(
@@ -81,6 +81,7 @@ describe("browser page text route", () => {
       expect(await response.json()).toMatchObject({ error: expect.stringContaining("snapshot") });
       expect(pageText).not.toHaveBeenCalled();
       expect(networkRequests).not.toHaveBeenCalled();
+      expect(pwMocks.getPageErrorsViaPlaywright).not.toHaveBeenCalled();
     },
   );
 });

--- a/extensions/browser/src/browser/routes/existing-session-limits.ts
+++ b/extensions/browser/src/browser/routes/existing-session-limits.ts
@@ -50,6 +50,8 @@ export const EXISTING_SESSION_LIMITS = {
       "selector/frame snapshots are not supported for existing-session profiles; snapshot the whole page and use refs.",
   },
   responseBody: "response body is not supported for existing-session profiles yet.",
+  errors:
+    "errors is not supported for existing-session profiles; use a managed browser profile to collect page errors, or snapshot to inspect the current page.",
   requests:
     "requests is not supported for existing-session profiles; use a managed browser profile to collect network requests, or snapshot to inspect the current page.",
   text: "text is not supported for existing-session profiles; use snapshot to read the page, or switch to a managed browser profile for text extraction.",


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #131592: the control service has always collected page errors (`GET /errors`, Playwright `pageerror` buffer), but the agent tool never exposed them — agents debugging a page had `console` and (since #131592) `requests`, with no way to read uncaught exceptions.

## Why This Change Was Made

Adds `action="errors"` following the `requests` precedent exactly: typed client action, local + node-proxy execution, default 50 newest entries with whole-record output-budget reduction and total/returned/truncated metadata, untrusted-content wrapping, session tab activity, and the `browserTab` card descriptor. Existing-session Chrome DevTools MCP profiles hide the action from the schema and the route returns recovery guidance if called anyway. A shared `formatBrowserDebugLogResult` helper in the snapshot module now owns the identical bounding/wrapping for both log actions — the actions module is net negative and the exact-copy path that would have breached the 700-line budget was refactored away instead of suppressed.

## User Impact

Agents can read uncaught page errors (and clear the buffer) without leaving the browser tool, on managed, remote-CDP, and node-proxied profiles.

## Evidence

- Real Chrome smoke (isolated temp profile, authenticated loopback bridge): actual JS `pageerror` → Playwright buffer → `GET /errors` → agent tool; verified error text, wrapping, `browserTab`, clear-then-empty-read semantics.
- `node scripts/run-vitest.mjs extensions/browser`: 197 files / 2,976 tests passed.
- `node scripts/check-changed.mjs` over all 19 changed files: green (guards, typechecks, lint, cycles, formatting); no suppressions added.
- Codex autoreview (three passes across the iterations): clean, no accepted findings.
- Schema byte budget verified against sibling Codex source (`codex-rs/tools/src/json_schema.rs` description-stripping threshold); descriptions shortened, tests kept.

LOC: production +131/−49 (net +82, the new capability), tests +121/−5, docs +5/−3.
