### PR TITLE
fix(browser): report native hosts with missing runtime targets

### DIFF
--- a/docs/tools/chrome-extension.md
+++ b/docs/tools/chrome-extension.md
@@ -178,6 +178,13 @@ openclaw browser extension status
 openclaw browser extension status --json
 ```
 
+An `owned` registration is not necessarily launchable. Status reports a filesystem
+readiness snapshot of its registered runtime and native entry. It does not execute
+either target or verify that its code will run successfully. If an upgrade removes
+either target, rerun `openclaw browser extension install` to repair the owned
+registration. Ownership checks still refuse foreign or malformed manifests and
+launchers.
+
 Remove only OpenClaw-owned native-host manifests and launchers:
 
 ```bash

--- a/extensions/browser/src/browser/extension-install-layout.test.ts
+++ b/extensions/browser/src/browser/extension-install-layout.test.ts
@@ -1,0 +1,379 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  assertOwnedPath,
+  chromeProductRoots,
+  discoverChromeExtensionIds,
+  generateChromeExtensionIdForPath,
+  installStableChromeExtension,
+  stableChromeExtensionDir,
+} from "./extension-install-layout.js";
+import {
+  browserExtensionStatus,
+  installChromeExtensionBootstrap,
+  resolveChromeExtensionLoadPath,
+} from "./extension-install.js";
+import {
+  createExtensionInstallFixtures,
+  FOUNDATION_STORE_ID,
+  predictedId,
+  writeSecurePreferences,
+} from "./extension-install.test-support.js";
+
+const ID_A = "abcdefghijklmnopabcdefghijklmnop";
+const { fixture, cleanup } = createExtensionInstallFixtures();
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await cleanup();
+});
+
+function statsWithUid<T extends Awaited<ReturnType<typeof fs.lstat>>>(info: T, uid: number): T {
+  return new Proxy(info, {
+    get(target, property) {
+      if (property === "uid") {
+        return uid;
+      }
+      const value = Reflect.get(target, property, target);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}
+
+describe.runIf(process.platform !== "win32")("extension install ownership policy", () => {
+  it("allows only explicit read-only root-owned inputs", async () => {
+    const target = "/opt/openclaw/native-host-entry.js";
+    const getuidSpy = vi.spyOn(process, "getuid").mockReturnValue(1000);
+    const lstatSpy = vi.spyOn(fs, "lstat").mockResolvedValue({
+      isDirectory: () => false,
+      isFile: () => true,
+      isSymbolicLink: () => false,
+      mode: 0o100644,
+      uid: 0,
+    } as Awaited<ReturnType<typeof fs.lstat>>);
+    const realpathSpy = vi.spyOn(fs, "realpath").mockResolvedValue(target);
+    try {
+      await expect(
+        assertOwnedPath(target, "file", { allowRootOwner: true }),
+      ).resolves.toBeUndefined();
+      await expect(assertOwnedPath(target, "file")).rejects.toThrow("foreign owner");
+    } finally {
+      realpathSpy.mockRestore();
+      lstatSpy.mockRestore();
+      getuidSpy.mockRestore();
+    }
+  });
+
+  it.each([
+    { label: "root-owned state", uid: 0, mode: 0o100600, allowRootOwner: false },
+    { label: "foreign-owned input", uid: 2000, mode: 0o100600, allowRootOwner: true },
+    { label: "root-owned group-writable input", uid: 0, mode: 0o100660, allowRootOwner: true },
+    { label: "user-owned world-writable input", uid: 1000, mode: 0o100602, allowRootOwner: false },
+  ])("rejects $label", async ({ uid, mode, allowRootOwner }) => {
+    const target = "/opt/openclaw/unsafe";
+    const getuidSpy = vi.spyOn(process, "getuid").mockReturnValue(1000);
+    const lstatSpy = vi.spyOn(fs, "lstat").mockResolvedValue({
+      isDirectory: () => false,
+      isFile: () => true,
+      isSymbolicLink: () => false,
+      mode,
+      uid,
+    } as Awaited<ReturnType<typeof fs.lstat>>);
+    const realpathSpy = vi.spyOn(fs, "realpath").mockResolvedValue(target);
+    try {
+      await expect(assertOwnedPath(target, "file", { allowRootOwner })).rejects.toThrow(
+        uid !== 1000 && !(allowRootOwner && uid === 0) ? "foreign owner" : "group/world-writable",
+      );
+    } finally {
+      realpathSpy.mockRestore();
+      lstatSpy.mockRestore();
+      getuidSpy.mockRestore();
+    }
+  });
+
+  it("installs from a package-shaped root-owned tree into user-owned state", async () => {
+    const value = await fixture();
+    const chromium = chromeProductRoots(value.deps).find((root) => root.product === "chromium");
+    if (!chromium) {
+      throw new Error("missing Chromium fixture root");
+    }
+    await fs.mkdir(chromium.userDataDir, { recursive: true, mode: 0o700 });
+    const userUid = process.getuid?.() ?? 1000;
+    const packageRoot = path.join(value.root, "package");
+    const canonicalNodePath = await fs.realpath(value.deps.nodePath);
+    const realLstat = fs.lstat.bind(fs);
+    const lstatSpy = vi.spyOn(fs, "lstat").mockImplementation(async (target) => {
+      const info = await realLstat(target);
+      const resolved = path.resolve(String(target));
+      const rootOwned =
+        resolved.startsWith(`${packageRoot}${path.sep}`) || resolved === canonicalNodePath;
+      return statsWithUid(info, rootOwned ? 0 : userUid);
+    });
+    try {
+      let now = 0;
+      const status = await installChromeExtensionBootstrap({
+        bundledDir: value.bundledDir,
+        pluginRoot: value.pluginRoot,
+        waitMs: 1_000,
+        deps: {
+          ...value.deps,
+          now: () => now,
+          sleep: async (ms) => {
+            now += ms;
+          },
+        },
+      });
+
+      expect(status.installedCopy).toMatchObject({ present: true, owned: true });
+      expect(status.registrations.find((entry) => entry.product === "chromium")?.state).toBe(
+        "owned",
+      );
+    } finally {
+      lstatSpy.mockRestore();
+    }
+  });
+});
+
+describe("stable extension copy", () => {
+  it("atomically replaces only its owned runtime copy with private modes", async () => {
+    const value = await fixture();
+    const installed = await installStableChromeExtension(value.bundledDir, value.deps);
+    await fs.writeFile(
+      path.join(value.bundledDir, "background.js"),
+      "export const updated = true;\n",
+    );
+    await installStableChromeExtension(value.bundledDir, value.deps);
+
+    expect(await fs.readFile(path.join(installed, "background.js"), "utf8")).toContain("updated");
+    expect(await fs.readFile(path.join(installed, ".openclaw-owned.json"), "utf8")).toContain(
+      '"owner":"openclaw"',
+    );
+    expect(await fs.readdir(path.join(installed, "modules"))).toEqual(["runtime.js"]);
+    expect(await fs.readdir(installed)).not.toContain("sidepanel.html");
+    if (process.platform !== "win32") {
+      expect((await fs.stat(installed)).mode & 0o777).toBe(0o700);
+      expect((await fs.stat(path.join(installed, "background.js"))).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it("refuses a foreign target and symlinked source content", async () => {
+    const value = await fixture();
+    const target = stableChromeExtensionDir(value.deps);
+    await fs.mkdir(target, { recursive: true, mode: 0o700 });
+    await expect(installStableChromeExtension(value.bundledDir, value.deps)).rejects.toThrow(
+      "foreign Chrome extension directory",
+    );
+
+    await fs.rm(target, { recursive: true, force: true });
+    await fs.symlink(
+      path.join(value.bundledDir, "background.js"),
+      path.join(value.bundledDir, "link.js"),
+    );
+    await expect(installStableChromeExtension(value.bundledDir, value.deps)).rejects.toThrow(
+      "Refusing symlink",
+    );
+  });
+
+  it("keeps path read-only and prefers the installed copy", async () => {
+    const value = await fixture();
+    await expect(resolveChromeExtensionLoadPath(value.bundledDir, value.deps)).resolves.toBe(
+      await fs.realpath(value.bundledDir),
+    );
+    expect(await fs.stat(value.stateDir).catch(() => null)).toBeNull();
+    const installed = await installStableChromeExtension(value.bundledDir, value.deps);
+    await expect(resolveChromeExtensionLoadPath(value.bundledDir, value.deps)).resolves.toBe(
+      installed,
+    );
+  });
+});
+
+describe("deterministic unpacked extension ID", () => {
+  it("matches Chromium's published POSIX and Windows path vectors", () => {
+    expect(generateChromeExtensionIdForPath("/path/to/file.ext", "linux")).toBe(
+      "lnkgfdknojmdambfcanadbhmfjfljobb",
+    );
+    expect(generateChromeExtensionIdForPath("/path/to/file.ext", "win32")).toBe(
+      "jjlkojfgbeklddcpckipekckcmgcbfjn",
+    );
+  });
+
+  it("normalizes only a lowercase Windows drive letter", () => {
+    expect(generateChromeExtensionIdForPath("c:\\OpenClaw\\extension", "win32")).toBe(
+      generateChromeExtensionIdForPath("C:\\OpenClaw\\extension", "win32"),
+    );
+  });
+});
+
+describe("Secure Preferences discovery", () => {
+  it("discovers multiple exact unpacked IDs and ignores name, location, and path lookalikes", async () => {
+    const value = await fixture();
+    const installed = await installStableChromeExtension(value.bundledDir, value.deps);
+    const chrome = chromeProductRoots(value.deps).find((root) => root.product === "chrome");
+    if (!chrome) {
+      throw new Error("missing Chrome fixture root");
+    }
+    const installedId = await predictedId(installed, value.deps.platform);
+    const bundledId = await predictedId(value.bundledDir, value.deps.platform);
+    await writeSecurePreferences({
+      userDataDir: chrome.userDataDir,
+      profile: "Default",
+      entries: {
+        [installedId]: { location: 4, path: installed, manifest: { name: "Not OpenClaw" } },
+        [FOUNDATION_STORE_ID]: {
+          location: 1,
+          from_webstore: true,
+          path: path.join(value.root, "foreign-store-lookalike"),
+        },
+        ["p".repeat(32)]: { location: 1, path: installed, manifest: { name: "OpenClaw" } },
+      },
+    });
+    await writeSecurePreferences({
+      userDataDir: chrome.userDataDir,
+      profile: "Profile 1",
+      entries: {
+        [bundledId]: { location: 4, path: value.bundledDir },
+        [FOUNDATION_STORE_ID]: { location: 1, from_webstore: false },
+        ["o".repeat(32)]: { location: 4, path: path.join(value.root, "lookalike") },
+      },
+    });
+
+    const result = await discoverChromeExtensionIds({
+      approvedDirs: [installed, value.bundledDir],
+      storeExtensionId: FOUNDATION_STORE_ID,
+      deps: value.deps,
+    });
+
+    expect(result.discovered.map((entry) => [entry.profile, entry.extensionId])).toEqual([
+      ["Default", installedId],
+      ["Profile 1", bundledId],
+    ]);
+    for (const entry of result.discovered) {
+      expect(entry.extensionId).toBe(
+        generateChromeExtensionIdForPath(entry.extensionPath, value.deps.platform),
+      );
+    }
+    expect(result.storeDiscovered).toEqual([
+      expect.objectContaining({
+        profile: "Default",
+        extensionId: FOUNDATION_STORE_ID,
+      }),
+    ]);
+    expect(result.discovered.map((entry) => entry.extensionId)).not.toContain(FOUNDATION_STORE_ID);
+  });
+
+  it("rejects a recorded ID that does not match the canonical approved path", async () => {
+    const value = await fixture();
+    const installed = await installStableChromeExtension(value.bundledDir, value.deps);
+    const chrome = chromeProductRoots(value.deps).find((root) => root.product === "chrome");
+    if (!chrome) {
+      throw new Error("missing Chrome fixture root");
+    }
+    const expected = await predictedId(installed, value.deps.platform);
+    await writeSecurePreferences({
+      userDataDir: chrome.userDataDir,
+      profile: "Default",
+      entries: { [ID_A]: { location: 4, path: installed } },
+    });
+
+    const result = await discoverChromeExtensionIds({
+      approvedDirs: [installed],
+      deps: value.deps,
+    });
+
+    expect(result.discovered).toEqual([]);
+    expect(result.identityMismatches).toHaveLength(1);
+    expect(result.issues[0]).toContain(`does not match predicted ID ${expected}`);
+  });
+
+  it("fails closed on malformed, oversized, locked, and symlinked profile metadata", async () => {
+    const value = await fixture();
+    const chrome = chromeProductRoots(value.deps).find((root) => root.product === "chrome");
+    if (!chrome) {
+      throw new Error("missing Chrome fixture root");
+    }
+    const malformed = await writeSecurePreferences({
+      userDataDir: chrome.userDataDir,
+      profile: "Default",
+      entries: {},
+    });
+    await fs.writeFile(malformed, "{partial", { mode: 0o600 });
+    const profileLink = path.join(chrome.userDataDir, "Profile 2");
+    await fs.symlink(path.join(chrome.userDataDir, "Default"), profileLink);
+    const oversized = await writeSecurePreferences({
+      userDataDir: chrome.userDataDir,
+      profile: "Profile 3",
+      entries: {},
+    });
+    await fs.truncate(oversized, 32 * 1024 * 1024 + 1);
+    const canLockFile = process.platform !== "win32" && process.getuid?.() !== 0;
+    if (canLockFile) {
+      const locked = await writeSecurePreferences({
+        userDataDir: chrome.userDataDir,
+        profile: "Profile 4",
+        entries: {},
+      });
+      await fs.chmod(locked, 0o000);
+    }
+
+    const result = await discoverChromeExtensionIds({
+      approvedDirs: [value.bundledDir],
+      deps: value.deps,
+    });
+    expect(result.discovered).toEqual([]);
+    expect(result.issues.join("\n")).toContain("Default");
+    expect(result.issues.join("\n")).toContain("Profile 3");
+    if (canLockFile) {
+      expect(result.issues.join("\n")).toContain("Profile 4");
+    }
+  });
+
+  it("does not approve a foreign stable copy in status discovery", async () => {
+    const value = await fixture();
+    const target = stableChromeExtensionDir(value.deps);
+    await fs.mkdir(target, { recursive: true, mode: 0o700 });
+    await fs.writeFile(path.join(target, "manifest.json"), "{}\n", { mode: 0o600 });
+    const chrome = chromeProductRoots(value.deps).find((root) => root.product === "chrome");
+    if (!chrome) {
+      throw new Error("missing Chrome fixture root");
+    }
+    await writeSecurePreferences({
+      userDataDir: chrome.userDataDir,
+      profile: "Default",
+      entries: { [await predictedId(target, value.deps.platform)]: { location: 4, path: target } },
+    });
+
+    const status = await browserExtensionStatus({
+      bundledDir: value.bundledDir,
+      deps: value.deps,
+    });
+
+    expect(status.discovered).toEqual([]);
+    expect(status.manualSetupRequired).toBe(true);
+    expect(status.issues.join("\n")).toContain("not OpenClaw-owned");
+  });
+});
+
+describe("platform roots", () => {
+  it("maps Chrome, Chrome for Testing, and Chromium profile roots on every supported OS", async () => {
+    const linux = await fixture("linux");
+    expect(chromeProductRoots(linux.deps).map((entry) => entry.product)).toEqual([
+      "chrome",
+      "chrome-for-testing",
+      "chromium",
+    ]);
+    const mac = await fixture("darwin");
+    expect(chromeProductRoots(mac.deps).map((entry) => entry.product)).toEqual([
+      "chrome",
+      "chrome-for-testing",
+      "chrome-for-testing",
+      "chromium",
+    ]);
+    const windows = await fixture("win32");
+    expect(chromeProductRoots(windows.deps).map((entry) => entry.userDataDir)).toEqual([
+      path.join(windows.deps.env.LOCALAPPDATA, "Google", "Chrome", "User Data"),
+      path.join(windows.deps.env.LOCALAPPDATA, "Google", "Chrome for Testing", "User Data"),
+      path.join(windows.deps.env.LOCALAPPDATA, "Chromium", "User Data"),
+    ]);
+  });
+});

--- a/extensions/browser/src/browser/extension-install.test-support.ts
+++ b/extensions/browser/src/browser/extension-install.test-support.ts
@@ -1,0 +1,74 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { generateChromeExtensionIdForPath } from "./extension-install-layout.js";
+
+export const FOUNDATION_STORE_ID = "kcdjddhmeafeomebliikmbpblkmkfoig";
+
+export async function predictedId(candidate: string, platform: NodeJS.Platform = process.platform) {
+  return generateChromeExtensionIdForPath(await fs.realpath(candidate), platform);
+}
+
+export function createExtensionInstallFixtures() {
+  const tempRoots: string[] = [];
+
+  async function fixture(platform: NodeJS.Platform = "linux") {
+    const root = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-extension-install-")),
+    );
+    tempRoots.push(root);
+    const homeDir = path.join(root, "home");
+    const stateDir = path.join(homeDir, ".openclaw");
+    const bundledDir = path.join(root, "package", "extensions", "browser", "chrome-extension");
+    const pluginRoot = path.dirname(bundledDir);
+    const nativeHostPath = path.join(root, "package", "native-host-entry.js");
+    await fs.mkdir(path.join(bundledDir, "modules"), { recursive: true, mode: 0o700 });
+    await fs.mkdir(homeDir, { recursive: true, mode: 0o700 });
+    await fs.writeFile(path.join(bundledDir, "manifest.json"), '{"manifest_version":3}\n');
+    await fs.writeFile(path.join(bundledDir, "background.js"), "export {};\n");
+    await fs.writeFile(path.join(bundledDir, "modules", "runtime.js"), "export {};\n");
+    await fs.writeFile(path.join(bundledDir, "modules", "runtime.test.ts"), "throw new Error();\n");
+    await fs.writeFile(path.join(bundledDir, "sidepanel.html"), "must not ship\n");
+    await fs.writeFile(nativeHostPath, "export {};\n", { mode: 0o600 });
+    const nodePath = path.join(root, "bin", "node");
+    await fs.mkdir(path.dirname(nodePath), { recursive: true, mode: 0o700 });
+    await fs.writeFile(nodePath, "#!/bin/sh\nexit 0\n", { mode: 0o700 });
+    const deps = {
+      platform,
+      homeDir,
+      stateDir,
+      env: {
+        HOME: homeDir,
+        LOCALAPPDATA: path.join(homeDir, "AppData", "Local"),
+      },
+      nativeHostPath,
+      // A fixture-owned interpreter keeps assertOwnedPath hermetic: the host's
+      // process.execPath can be group/world-writable (GitHub hostedtoolcache),
+      // which install correctly refuses and every registration test then fails.
+      nodePath,
+    };
+    return { root, homeDir, stateDir, bundledDir, pluginRoot, nativeHostPath, deps };
+  }
+
+  async function cleanup() {
+    await Promise.all(
+      tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
+    );
+  }
+
+  return { fixture, cleanup };
+}
+
+export async function writeSecurePreferences(params: {
+  userDataDir: string;
+  profile: string;
+  entries: Record<string, unknown>;
+}) {
+  const profileDir = path.join(params.userDataDir, params.profile);
+  await fs.mkdir(profileDir, { recursive: true, mode: 0o700 });
+  const file = path.join(profileDir, "Secure Preferences");
+  await fs.writeFile(file, JSON.stringify({ extensions: { settings: params.entries } }), {
+    mode: 0o600,
+  });
+  return file;
+}

--- a/extensions/browser/src/browser/extension-install.test.ts
+++ b/extensions/browser/src/browser/extension-install.test.ts
@@ -1017,6 +1017,211 @@ describe("native host registration", () => {
     });
     await expect(fs.readFile(manifest.path, "utf8")).resolves.toContain(movedNativeHost);
   });
+
+  it.for([
+    { target: "nodePath", failure: "missing", recovery: "repair" },
+    { target: "nativeHostPath", failure: "missing", recovery: "install" },
+    { target: "nodePath", failure: "missing", recovery: "uninstall" },
+    { target: "nodePath", failure: "non-executable", recovery: "repair" },
+    {
+      target: "nativeHostPath",
+      failure: "unreadable",
+      recovery: "install",
+    },
+    { target: "nativeHostPath", failure: "directory", recovery: "repair" },
+    { target: "nodePath", failure: "symlink", recovery: "install" },
+    { target: "nativeHostPath", failure: "unsafe-mode", recovery: "repair" },
+    { target: "nodePath", failure: "relative", recovery: "repair" },
+  ] as const)(
+    "keeps an owned $failure $target non-ready and allows $recovery",
+    async ({ target, failure, recovery }, { skip }) => {
+      if (process.platform === "win32" || (failure === "unreadable" && process.getuid?.() === 0)) {
+        skip();
+      }
+      const value = await fixture();
+      const versionDir = path.join(value.root, "runtime's version '1");
+      await fs.mkdir(versionDir, { mode: 0o700 });
+      const registeredDeps = {
+        ...value.deps,
+        nodePath: path.join(versionDir, "node"),
+        nativeHostPath: path.join(versionDir, "native-host-entry.js"),
+        env: {
+          ...value.deps.env,
+          OPENCLAW_CONFIG_PATH: path.join(value.root, "config's dir", "openclaw.json"),
+        },
+      };
+      const executed = path.join(value.root, "target-executed");
+      await fs.writeFile(value.deps.nodePath, `#!/bin/sh\n: > '${executed}'\nexit 1\n`);
+      await fs.writeFile(
+        value.nativeHostPath,
+        `import { writeFileSync } from 'node:fs';\nwriteFileSync(${JSON.stringify(executed)}, 'executed');\n`,
+      );
+      // Both replacement paths stay available while the registered version disappears.
+      await fs.copyFile(value.deps.nodePath, registeredDeps.nodePath);
+      await fs.copyFile(value.nativeHostPath, registeredDeps.nativeHostPath);
+      const chromium = chromeProductRoots(value.deps).find((root) => root.product === "chromium");
+      if (!chromium) {
+        throw new Error("missing Chromium fixture root");
+      }
+      await writeSecurePreferences({
+        userDataDir: chromium.userDataDir,
+        profile: "Default",
+        entries: { [FOUNDATION_STORE_ID]: { location: 1, from_webstore: true } },
+      });
+      const params = { bundledDir: value.bundledDir, pluginRoot: value.pluginRoot, waitMs: 1_000 };
+      const before = await installChromeExtensionBootstrap({ ...params, deps: registeredDeps });
+      expect(before.manualSetupRequired, before.issues.join("\n")).toBe(false);
+      const registration = before.registrations.find((entry) => entry.product === "chromium");
+      if (!registration) {
+        throw new Error("missing Chromium fixture registration");
+      }
+      const manifestBytes = await fs.readFile(registration.manifestPath, "utf8");
+      const manifest = JSON.parse(manifestBytes) as { path: string };
+      let launcherBytes = await fs.readFile(manifest.path, "utf8");
+      const deps = {
+        ...registeredDeps,
+        nodePath: value.deps.nodePath,
+        nativeHostPath: value.nativeHostPath,
+      };
+      await expect(browserExtensionStatus({ ...params, deps })).resolves.toMatchObject({
+        manualSetupRequired: false,
+        issues: [],
+      });
+      const registeredTarget = registeredDeps[target];
+      if (failure === "relative") {
+        const relativeTarget = path.relative(process.cwd(), registeredTarget);
+        await fs.access(relativeTarget, fs.constants.X_OK);
+        const quoteTarget = (target: string) => `'${target.replaceAll("'", `'"'"'`)}'`;
+        const relativeLauncher = launcherBytes.replace(
+          quoteTarget(registeredTarget),
+          quoteTarget(relativeTarget),
+        );
+        expect(relativeLauncher).not.toBe(launcherBytes);
+        launcherBytes = relativeLauncher;
+        await fs.writeFile(manifest.path, launcherBytes);
+      } else if (failure === "missing" || failure === "directory" || failure === "symlink") {
+        await fs.rename(registeredTarget, `${registeredTarget}.removed`);
+        if (failure === "directory") {
+          await fs.mkdir(registeredTarget, { mode: 0o700 });
+        } else if (failure === "symlink") {
+          await fs.symlink(deps[target], registeredTarget);
+        }
+      } else {
+        await fs.chmod(
+          registeredTarget,
+          failure === "non-executable" ? 0o600 : failure === "unreadable" ? 0o000 : 0o666,
+        );
+      }
+
+      const broken = await browserExtensionStatus({ ...params, deps });
+      expect(broken.manualSetupRequired).toBe(true);
+      const brokenRegistration = broken.registrations.find((entry) => entry.product === "chromium");
+      if (!brokenRegistration?.issue) {
+        throw new Error("missing Chromium fixture registration issue");
+      }
+      expect(brokenRegistration).toMatchObject({
+        state: "owned",
+        extensionIds: registration.extensionIds,
+      });
+      expect(brokenRegistration.issue).toContain("openclaw browser extension install");
+      expect(brokenRegistration.issue.length).toBeLessThan(200);
+      expect(broken.issues).toEqual([`Chromium: ${brokenRegistration.issue}`]);
+      expect(JSON.stringify(broken)).not.toMatch(/pairingString|token|Bearer|runtime's version/u);
+      expect(brokenRegistration.issue).not.toContain(value.root);
+      expect(await fs.readFile(registration.manifestPath, "utf8")).toBe(manifestBytes);
+      expect(await fs.readFile(manifest.path, "utf8")).toBe(launcherBytes);
+      expect(existsSync(executed)).toBe(false);
+
+      if (failure === "non-executable" || failure === "unreadable") {
+        const onProgress = vi.fn();
+        const reinstall = await installChromeExtensionBootstrap({
+          ...params,
+          deps: registeredDeps,
+          onProgress,
+        });
+        expect(reinstall.manualSetupRequired).toBe(true);
+        expect(onProgress).not.toHaveBeenCalledWith(
+          expect.stringContaining("Native bootstrap is ready"),
+        );
+        expect(reinstall.issues.join("\n")).toContain("pre-registration refused");
+        expect(await fs.readFile(registration.manifestPath, "utf8")).toBe(manifestBytes);
+        expect(await fs.readFile(manifest.path, "utf8")).toBe(launcherBytes);
+      }
+
+      if (recovery === "uninstall") {
+        await expect(uninstallChromeExtensionNativeHosts({ deps })).resolves.toEqual({
+          removed: [registration.manifestPath, manifest.path],
+          refused: [],
+          manualRequired: false,
+        });
+        expect(existsSync(registration.manifestPath)).toBe(false);
+        expect(existsSync(manifest.path)).toBe(false);
+        return;
+      }
+      if (recovery === "repair") {
+        await expect(repairOwnedChromeExtensionNativeHosts({ ...params, deps })).resolves.toEqual({
+          changes: ["Repaired Chromium OpenClaw native messaging registration."],
+          warnings: [],
+        });
+      } else {
+        expect(
+          (await installChromeExtensionBootstrap({ ...params, deps })).manualSetupRequired,
+        ).toBe(false);
+      }
+      const repaired = await browserExtensionStatus({ ...params, deps });
+      expect(repaired.manualSetupRequired).toBe(false);
+      expect(repaired.issues).toEqual([]);
+      expect(repaired.registrations).toEqual(before.registrations);
+      expect(await fs.readFile(registration.manifestPath, "utf8")).toBe(manifestBytes);
+      expect((await fs.stat(registration.manifestPath)).mode & 0o777).toBe(0o600);
+      expect((await fs.stat(manifest.path)).mode & 0o777).toBe(0o700);
+      expect(existsSync(executed)).toBe(false);
+    },
+  );
+
+  it("keeps an unavailable unused host as a warning after repairing the discovered product", async () => {
+    const value = await fixture();
+    const roots = chromeProductRoots(value.deps);
+    const chrome = roots.find((root) => root.product === "chrome");
+    const chromium = roots.find((root) => root.product === "chromium");
+    if (!chrome || !chromium) {
+      throw new Error("missing browser fixture roots");
+    }
+    await fs.mkdir(chrome.userDataDir, { recursive: true, mode: 0o700 });
+    const installed = await installStableChromeExtension(value.bundledDir, value.deps);
+    await writeSecurePreferences({
+      userDataDir: chromium.userDataDir,
+      profile: "Default",
+      entries: {
+        [await predictedId(installed, value.deps.platform)]: { location: 4, path: installed },
+      },
+    });
+    const params = { bundledDir: value.bundledDir, pluginRoot: value.pluginRoot, waitMs: 1_000 };
+    const before = await installChromeExtensionBootstrap({ ...params, deps: value.deps });
+    expect(before.manualSetupRequired).toBe(false);
+    expect(before.registrations.filter((entry) => entry.state === "owned")).toHaveLength(2);
+    const nodePath = `${value.deps.nodePath}-replacement`;
+    await fs.rename(value.deps.nodePath, nodePath);
+    const deps = { ...value.deps, nodePath };
+    const broken = await browserExtensionStatus({ ...params, deps });
+    expect(broken.manualSetupRequired).toBe(true);
+    await expect(repairOwnedChromeExtensionNativeHosts({ ...params, deps })).resolves.toEqual({
+      changes: ["Repaired Chromium OpenClaw native messaging registration."],
+      warnings: [],
+    });
+    const repaired = await browserExtensionStatus({ ...params, deps });
+    expect(repaired.manualSetupRequired).toBe(false);
+    expect(repaired.registrations.find((entry) => entry.product === "chromium")).toEqual(
+      before.registrations.find((entry) => entry.product === "chromium"),
+    );
+    const unused = repaired.registrations.find((entry) => entry.product === "chrome");
+    if (!unused) {
+      throw new Error("missing Chrome fixture registration");
+    }
+    expect(unused.state).toBe("owned");
+    expect(unused.issue).toContain("openclaw browser extension install");
+    expect(repaired.issues).toEqual([`Google Chrome: ${unused.issue}`]);
+  });
 });
 
 describe("platform roots", () => {

--- a/extensions/browser/src/browser/extension-install.test.ts
+++ b/extensions/browser/src/browser/extension-install.test.ts
@@ -6,9 +6,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { relayTestKey } from "../../chrome-extension/relay-key.test-support.js";
 import {
-  assertOwnedPath,
   chromeProductRoots,
-  discoverChromeExtensionIds,
   generateChromeExtensionIdForPath,
   installStableChromeExtension,
   stableChromeExtensionDir,
@@ -18,72 +16,19 @@ import {
   installChromeExtensionBootstrap,
   normalizeExtensionInstallWaitMs,
   repairOwnedChromeExtensionNativeHosts,
-  resolveChromeExtensionLoadPath,
   uninstallChromeExtensionNativeHosts,
 } from "./extension-install.js";
+import {
+  createExtensionInstallFixtures,
+  FOUNDATION_STORE_ID,
+  predictedId,
+  writeSecurePreferences,
+} from "./extension-install.test-support.js";
 
-const ID_A = "abcdefghijklmnopabcdefghijklmnop";
-const FOUNDATION_STORE_ID = "kcdjddhmeafeomebliikmbpblkmkfoig";
 // Changed-file CI runs source tests without dist; full-build lanes exercise the real native host.
 const BUILT_NATIVE_HOST_PATH = path.resolve("dist/extensions/browser/native-host-entry.js");
-const tempRoots: string[] = [];
+const { fixture, cleanup } = createExtensionInstallFixtures();
 const fileModesToRestore: Array<{ target: string; mode: number }> = [];
-
-async function predictedId(candidate: string, platform: NodeJS.Platform = process.platform) {
-  return generateChromeExtensionIdForPath(await fs.realpath(candidate), platform);
-}
-
-async function fixture(platform: NodeJS.Platform = "linux") {
-  const root = await fs.realpath(
-    await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-extension-install-")),
-  );
-  tempRoots.push(root);
-  const homeDir = path.join(root, "home");
-  const stateDir = path.join(homeDir, ".openclaw");
-  const bundledDir = path.join(root, "package", "extensions", "browser", "chrome-extension");
-  const pluginRoot = path.dirname(bundledDir);
-  const nativeHostPath = path.join(root, "package", "native-host-entry.js");
-  await fs.mkdir(path.join(bundledDir, "modules"), { recursive: true, mode: 0o700 });
-  await fs.mkdir(homeDir, { recursive: true, mode: 0o700 });
-  await fs.writeFile(path.join(bundledDir, "manifest.json"), '{"manifest_version":3}\n');
-  await fs.writeFile(path.join(bundledDir, "background.js"), "export {};\n");
-  await fs.writeFile(path.join(bundledDir, "modules", "runtime.js"), "export {};\n");
-  await fs.writeFile(path.join(bundledDir, "modules", "runtime.test.ts"), "throw new Error();\n");
-  await fs.writeFile(path.join(bundledDir, "sidepanel.html"), "must not ship\n");
-  await fs.writeFile(nativeHostPath, "export {};\n", { mode: 0o600 });
-  const nodePath = path.join(root, "bin", "node");
-  await fs.mkdir(path.dirname(nodePath), { recursive: true, mode: 0o700 });
-  await fs.writeFile(nodePath, "#!/bin/sh\nexit 0\n", { mode: 0o700 });
-  const deps = {
-    platform,
-    homeDir,
-    stateDir,
-    env: {
-      HOME: homeDir,
-      LOCALAPPDATA: path.join(homeDir, "AppData", "Local"),
-    },
-    nativeHostPath,
-    // A fixture-owned interpreter keeps assertOwnedPath hermetic: the host's
-    // process.execPath can be group/world-writable (GitHub hostedtoolcache),
-    // which install correctly refuses and every registration test then fails.
-    nodePath,
-  };
-  return { root, homeDir, stateDir, bundledDir, pluginRoot, nativeHostPath, deps };
-}
-
-async function writeSecurePreferences(params: {
-  userDataDir: string;
-  profile: string;
-  entries: Record<string, unknown>;
-}) {
-  const profileDir = path.join(params.userDataDir, params.profile);
-  await fs.mkdir(profileDir, { recursive: true, mode: 0o700 });
-  const file = path.join(profileDir, "Secure Preferences");
-  await fs.writeFile(file, JSON.stringify({ extensions: { settings: params.entries } }), {
-    mode: 0o600,
-  });
-  return file;
-}
 
 async function rewriteRegistrationOrigins(manifestPath: string, origins: string[]) {
   const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8")) as {
@@ -115,9 +60,7 @@ afterEach(async () => {
       .splice(0)
       .map(({ target, mode }) => fs.chmod(target, mode).catch(() => undefined)),
   );
-  await Promise.all(
-    tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
-  );
+  await cleanup();
 });
 
 async function makeTestFilePrivate(target: string): Promise<void> {
@@ -128,331 +71,6 @@ async function makeTestFilePrivate(target: string): Promise<void> {
   fileModesToRestore.push({ target, mode });
   await fs.chmod(target, mode & ~0o022);
 }
-
-function statsWithUid<T extends Awaited<ReturnType<typeof fs.lstat>>>(info: T, uid: number): T {
-  return new Proxy(info, {
-    get(target, property) {
-      if (property === "uid") {
-        return uid;
-      }
-      const value = Reflect.get(target, property, target);
-      return typeof value === "function" ? value.bind(target) : value;
-    },
-  });
-}
-
-describe.runIf(process.platform !== "win32")("extension install ownership policy", () => {
-  it("allows only explicit read-only root-owned inputs", async () => {
-    const target = "/opt/openclaw/native-host-entry.js";
-    const getuidSpy = vi.spyOn(process, "getuid").mockReturnValue(1000);
-    const lstatSpy = vi.spyOn(fs, "lstat").mockResolvedValue({
-      isDirectory: () => false,
-      isFile: () => true,
-      isSymbolicLink: () => false,
-      mode: 0o100644,
-      uid: 0,
-    } as Awaited<ReturnType<typeof fs.lstat>>);
-    const realpathSpy = vi.spyOn(fs, "realpath").mockResolvedValue(target);
-    try {
-      await expect(
-        assertOwnedPath(target, "file", { allowRootOwner: true }),
-      ).resolves.toBeUndefined();
-      await expect(assertOwnedPath(target, "file")).rejects.toThrow("foreign owner");
-    } finally {
-      realpathSpy.mockRestore();
-      lstatSpy.mockRestore();
-      getuidSpy.mockRestore();
-    }
-  });
-
-  it.each([
-    { label: "root-owned state", uid: 0, mode: 0o100600, allowRootOwner: false },
-    { label: "foreign-owned input", uid: 2000, mode: 0o100600, allowRootOwner: true },
-    { label: "root-owned group-writable input", uid: 0, mode: 0o100660, allowRootOwner: true },
-    { label: "user-owned world-writable input", uid: 1000, mode: 0o100602, allowRootOwner: false },
-  ])("rejects $label", async ({ uid, mode, allowRootOwner }) => {
-    const target = "/opt/openclaw/unsafe";
-    const getuidSpy = vi.spyOn(process, "getuid").mockReturnValue(1000);
-    const lstatSpy = vi.spyOn(fs, "lstat").mockResolvedValue({
-      isDirectory: () => false,
-      isFile: () => true,
-      isSymbolicLink: () => false,
-      mode,
-      uid,
-    } as Awaited<ReturnType<typeof fs.lstat>>);
-    const realpathSpy = vi.spyOn(fs, "realpath").mockResolvedValue(target);
-    try {
-      await expect(assertOwnedPath(target, "file", { allowRootOwner })).rejects.toThrow(
-        uid !== 1000 && !(allowRootOwner && uid === 0) ? "foreign owner" : "group/world-writable",
-      );
-    } finally {
-      realpathSpy.mockRestore();
-      lstatSpy.mockRestore();
-      getuidSpy.mockRestore();
-    }
-  });
-
-  it("installs from a package-shaped root-owned tree into user-owned state", async () => {
-    const value = await fixture();
-    const chromium = chromeProductRoots(value.deps).find((root) => root.product === "chromium");
-    if (!chromium) {
-      throw new Error("missing Chromium fixture root");
-    }
-    await fs.mkdir(chromium.userDataDir, { recursive: true, mode: 0o700 });
-    const userUid = process.getuid?.() ?? 1000;
-    const packageRoot = path.join(value.root, "package");
-    const canonicalNodePath = await fs.realpath(value.deps.nodePath);
-    const realLstat = fs.lstat.bind(fs);
-    const lstatSpy = vi.spyOn(fs, "lstat").mockImplementation(async (target) => {
-      const info = await realLstat(target);
-      const resolved = path.resolve(String(target));
-      const rootOwned =
-        resolved.startsWith(`${packageRoot}${path.sep}`) || resolved === canonicalNodePath;
-      return statsWithUid(info, rootOwned ? 0 : userUid);
-    });
-    try {
-      let now = 0;
-      const status = await installChromeExtensionBootstrap({
-        bundledDir: value.bundledDir,
-        pluginRoot: value.pluginRoot,
-        waitMs: 1_000,
-        deps: {
-          ...value.deps,
-          now: () => now,
-          sleep: async (ms) => {
-            now += ms;
-          },
-        },
-      });
-
-      expect(status.installedCopy).toMatchObject({ present: true, owned: true });
-      expect(status.registrations.find((entry) => entry.product === "chromium")?.state).toBe(
-        "owned",
-      );
-    } finally {
-      lstatSpy.mockRestore();
-    }
-  });
-});
-
-describe("stable extension copy", () => {
-  it("atomically replaces only its owned runtime copy with private modes", async () => {
-    const value = await fixture();
-    const installed = await installStableChromeExtension(value.bundledDir, value.deps);
-    await fs.writeFile(
-      path.join(value.bundledDir, "background.js"),
-      "export const updated = true;\n",
-    );
-    await installStableChromeExtension(value.bundledDir, value.deps);
-
-    expect(await fs.readFile(path.join(installed, "background.js"), "utf8")).toContain("updated");
-    expect(await fs.readFile(path.join(installed, ".openclaw-owned.json"), "utf8")).toContain(
-      '"owner":"openclaw"',
-    );
-    expect(await fs.readdir(path.join(installed, "modules"))).toEqual(["runtime.js"]);
-    expect(await fs.readdir(installed)).not.toContain("sidepanel.html");
-    if (process.platform !== "win32") {
-      expect((await fs.stat(installed)).mode & 0o777).toBe(0o700);
-      expect((await fs.stat(path.join(installed, "background.js"))).mode & 0o777).toBe(0o600);
-    }
-  });
-
-  it("refuses a foreign target and symlinked source content", async () => {
-    const value = await fixture();
-    const target = stableChromeExtensionDir(value.deps);
-    await fs.mkdir(target, { recursive: true, mode: 0o700 });
-    await expect(installStableChromeExtension(value.bundledDir, value.deps)).rejects.toThrow(
-      "foreign Chrome extension directory",
-    );
-
-    await fs.rm(target, { recursive: true, force: true });
-    await fs.symlink(
-      path.join(value.bundledDir, "background.js"),
-      path.join(value.bundledDir, "link.js"),
-    );
-    await expect(installStableChromeExtension(value.bundledDir, value.deps)).rejects.toThrow(
-      "Refusing symlink",
-    );
-  });
-
-  it("keeps path read-only and prefers the installed copy", async () => {
-    const value = await fixture();
-    await expect(resolveChromeExtensionLoadPath(value.bundledDir, value.deps)).resolves.toBe(
-      await fs.realpath(value.bundledDir),
-    );
-    expect(await fs.stat(value.stateDir).catch(() => null)).toBeNull();
-    const installed = await installStableChromeExtension(value.bundledDir, value.deps);
-    await expect(resolveChromeExtensionLoadPath(value.bundledDir, value.deps)).resolves.toBe(
-      installed,
-    );
-  });
-});
-
-describe("deterministic unpacked extension ID", () => {
-  it("matches Chromium's published POSIX and Windows path vectors", () => {
-    expect(generateChromeExtensionIdForPath("/path/to/file.ext", "linux")).toBe(
-      "lnkgfdknojmdambfcanadbhmfjfljobb",
-    );
-    expect(generateChromeExtensionIdForPath("/path/to/file.ext", "win32")).toBe(
-      "jjlkojfgbeklddcpckipekckcmgcbfjn",
-    );
-  });
-
-  it("normalizes only a lowercase Windows drive letter", () => {
-    expect(generateChromeExtensionIdForPath("c:\\OpenClaw\\extension", "win32")).toBe(
-      generateChromeExtensionIdForPath("C:\\OpenClaw\\extension", "win32"),
-    );
-  });
-});
-
-describe("Secure Preferences discovery", () => {
-  it("discovers multiple exact unpacked IDs and ignores name, location, and path lookalikes", async () => {
-    const value = await fixture();
-    const installed = await installStableChromeExtension(value.bundledDir, value.deps);
-    const chrome = chromeProductRoots(value.deps).find((root) => root.product === "chrome");
-    if (!chrome) {
-      throw new Error("missing Chrome fixture root");
-    }
-    const installedId = await predictedId(installed, value.deps.platform);
-    const bundledId = await predictedId(value.bundledDir, value.deps.platform);
-    await writeSecurePreferences({
-      userDataDir: chrome.userDataDir,
-      profile: "Default",
-      entries: {
-        [installedId]: { location: 4, path: installed, manifest: { name: "Not OpenClaw" } },
-        [FOUNDATION_STORE_ID]: {
-          location: 1,
-          from_webstore: true,
-          path: path.join(value.root, "foreign-store-lookalike"),
-        },
-        ["p".repeat(32)]: { location: 1, path: installed, manifest: { name: "OpenClaw" } },
-      },
-    });
-    await writeSecurePreferences({
-      userDataDir: chrome.userDataDir,
-      profile: "Profile 1",
-      entries: {
-        [bundledId]: { location: 4, path: value.bundledDir },
-        [FOUNDATION_STORE_ID]: { location: 1, from_webstore: false },
-        ["o".repeat(32)]: { location: 4, path: path.join(value.root, "lookalike") },
-      },
-    });
-
-    const result = await discoverChromeExtensionIds({
-      approvedDirs: [installed, value.bundledDir],
-      storeExtensionId: FOUNDATION_STORE_ID,
-      deps: value.deps,
-    });
-
-    expect(result.discovered.map((entry) => [entry.profile, entry.extensionId])).toEqual([
-      ["Default", installedId],
-      ["Profile 1", bundledId],
-    ]);
-    for (const entry of result.discovered) {
-      expect(entry.extensionId).toBe(
-        generateChromeExtensionIdForPath(entry.extensionPath, value.deps.platform),
-      );
-    }
-    expect(result.storeDiscovered).toEqual([
-      expect.objectContaining({
-        profile: "Default",
-        extensionId: FOUNDATION_STORE_ID,
-      }),
-    ]);
-    expect(result.discovered.map((entry) => entry.extensionId)).not.toContain(FOUNDATION_STORE_ID);
-  });
-
-  it("rejects a recorded ID that does not match the canonical approved path", async () => {
-    const value = await fixture();
-    const installed = await installStableChromeExtension(value.bundledDir, value.deps);
-    const chrome = chromeProductRoots(value.deps).find((root) => root.product === "chrome");
-    if (!chrome) {
-      throw new Error("missing Chrome fixture root");
-    }
-    const expected = await predictedId(installed, value.deps.platform);
-    await writeSecurePreferences({
-      userDataDir: chrome.userDataDir,
-      profile: "Default",
-      entries: { [ID_A]: { location: 4, path: installed } },
-    });
-
-    const result = await discoverChromeExtensionIds({
-      approvedDirs: [installed],
-      deps: value.deps,
-    });
-
-    expect(result.discovered).toEqual([]);
-    expect(result.identityMismatches).toHaveLength(1);
-    expect(result.issues[0]).toContain(`does not match predicted ID ${expected}`);
-  });
-
-  it("fails closed on malformed, oversized, locked, and symlinked profile metadata", async () => {
-    const value = await fixture();
-    const chrome = chromeProductRoots(value.deps).find((root) => root.product === "chrome");
-    if (!chrome) {
-      throw new Error("missing Chrome fixture root");
-    }
-    const malformed = await writeSecurePreferences({
-      userDataDir: chrome.userDataDir,
-      profile: "Default",
-      entries: {},
-    });
-    await fs.writeFile(malformed, "{partial", { mode: 0o600 });
-    const profileLink = path.join(chrome.userDataDir, "Profile 2");
-    await fs.symlink(path.join(chrome.userDataDir, "Default"), profileLink);
-    const oversized = await writeSecurePreferences({
-      userDataDir: chrome.userDataDir,
-      profile: "Profile 3",
-      entries: {},
-    });
-    await fs.truncate(oversized, 32 * 1024 * 1024 + 1);
-    const canLockFile = process.platform !== "win32" && process.getuid?.() !== 0;
-    if (canLockFile) {
-      const locked = await writeSecurePreferences({
-        userDataDir: chrome.userDataDir,
-        profile: "Profile 4",
-        entries: {},
-      });
-      await fs.chmod(locked, 0o000);
-    }
-
-    const result = await discoverChromeExtensionIds({
-      approvedDirs: [value.bundledDir],
-      deps: value.deps,
-    });
-    expect(result.discovered).toEqual([]);
-    expect(result.issues.join("\n")).toContain("Default");
-    expect(result.issues.join("\n")).toContain("Profile 3");
-    if (canLockFile) {
-      expect(result.issues.join("\n")).toContain("Profile 4");
-    }
-  });
-
-  it("does not approve a foreign stable copy in status discovery", async () => {
-    const value = await fixture();
-    const target = stableChromeExtensionDir(value.deps);
-    await fs.mkdir(target, { recursive: true, mode: 0o700 });
-    await fs.writeFile(path.join(target, "manifest.json"), "{}\n", { mode: 0o600 });
-    const chrome = chromeProductRoots(value.deps).find((root) => root.product === "chrome");
-    if (!chrome) {
-      throw new Error("missing Chrome fixture root");
-    }
-    await writeSecurePreferences({
-      userDataDir: chrome.userDataDir,
-      profile: "Default",
-      entries: { [await predictedId(target, value.deps.platform)]: { location: 4, path: target } },
-    });
-
-    const status = await browserExtensionStatus({
-      bundledDir: value.bundledDir,
-      deps: value.deps,
-    });
-
-    expect(status.discovered).toEqual([]);
-    expect(status.manualSetupRequired).toBe(true);
-    expect(status.issues.join("\n")).toContain("not OpenClaw-owned");
-  });
-});
 
 describe("native host registration", () => {
   it.runIf(existsSync(BUILT_NATIVE_HOST_PATH))(
@@ -1091,7 +709,8 @@ describe("native host registration", () => {
       if (failure === "relative") {
         const relativeTarget = path.relative(process.cwd(), registeredTarget);
         await fs.access(relativeTarget, fs.constants.X_OK);
-        const quoteTarget = (target: string) => `'${target.replaceAll("'", `'"'"'`)}'`;
+        const quoteTarget = (launcherTarget: string) =>
+          `'${launcherTarget.replaceAll("'", `'"'"'`)}'`;
         const relativeLauncher = launcherBytes.replace(
           quoteTarget(registeredTarget),
           quoteTarget(relativeTarget),
@@ -1221,30 +840,6 @@ describe("native host registration", () => {
     expect(unused.state).toBe("owned");
     expect(unused.issue).toContain("openclaw browser extension install");
     expect(repaired.issues).toEqual([`Google Chrome: ${unused.issue}`]);
-  });
-});
-
-describe("platform roots", () => {
-  it("maps Chrome, Chrome for Testing, and Chromium profile roots on every supported OS", async () => {
-    const linux = await fixture("linux");
-    expect(chromeProductRoots(linux.deps).map((entry) => entry.product)).toEqual([
-      "chrome",
-      "chrome-for-testing",
-      "chromium",
-    ]);
-    const mac = await fixture("darwin");
-    expect(chromeProductRoots(mac.deps).map((entry) => entry.product)).toEqual([
-      "chrome",
-      "chrome-for-testing",
-      "chrome-for-testing",
-      "chromium",
-    ]);
-    const windows = await fixture("win32");
-    expect(chromeProductRoots(windows.deps).map((entry) => entry.userDataDir)).toEqual([
-      path.join(windows.deps.env.LOCALAPPDATA, "Google", "Chrome", "User Data"),
-      path.join(windows.deps.env.LOCALAPPDATA, "Google", "Chrome for Testing", "User Data"),
-      path.join(windows.deps.env.LOCALAPPDATA, "Chromium", "User Data"),
-    ]);
   });
 });
 

--- a/extensions/browser/src/browser/extension-install.ts
+++ b/extensions/browser/src/browser/extension-install.ts
@@ -136,16 +136,16 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 }
 
-function launcherMatchesOrigins(params: {
+function parseOwnedLauncherTargets(params: {
   content: string;
   manifestPath: string;
   launcherPath: string;
   origins: string[];
-}): boolean {
+}): string[] | undefined {
   const quotedValue = String.raw`'(?:[^'\r\n]|'"'"')*'`;
   const command = [
-    quotedValue,
-    quotedValue,
+    `(${quotedValue})`,
+    `(${quotedValue})`,
     escapeRegExp(shellQuote("--manifest")),
     escapeRegExp(shellQuote(params.manifestPath)),
     escapeRegExp(shellQuote("--launcher")),
@@ -159,7 +159,11 @@ function launcherMatchesOrigins(params: {
     `^#!/bin/sh\\n${escapeRegExp(OWNED_LAUNCHER_MARKER)}\\nexport OPENCLAW_STATE_DIR=${quotedValue}\\n(?:export OPENCLAW_CONFIG_PATH=${quotedValue}\\n)?exec ${command} "\\$@"\\n$`,
     "u",
   );
-  return pattern.test(params.content);
+  // Decode only shellQuote's two target words after the entire ownership grammar matches.
+  return pattern
+    .exec(params.content)
+    ?.slice(1)
+    .map((value) => value.slice(1, -1).replaceAll(`'"'"'`, "'"));
 }
 
 async function assertPrivateNativeHostFile(
@@ -177,6 +181,15 @@ async function assertPrivateNativeHostFile(
   }
 }
 
+async function assertNativeHostTarget(target: string, accessMode: number): Promise<void> {
+  // Registered targets must not depend on Chrome's working directory.
+  if (!path.isAbsolute(target)) {
+    throw new Error("native host target must be an absolute path");
+  }
+  await assertOwnedPath(target, "file", { allowRootOwner: true });
+  await fs.access(target, accessMode);
+}
+
 async function resolveLauncherInstall(params: {
   manifestPath: string;
   pluginRoot: string;
@@ -186,8 +199,8 @@ async function resolveLauncherInstall(params: {
   const launcherPath = launcherPathForManifest(params.manifestPath, params.deps);
   const nodePath = await fs.realpath(params.deps.nodePath ?? process.execPath);
   const nativeHostPath = await resolveNativeHostPath(params.pluginRoot, params.deps.nativeHostPath);
-  await assertOwnedPath(nodePath, "file", { allowRootOwner: true });
-  await assertOwnedPath(nativeHostPath, "file", { allowRootOwner: true });
+  await assertNativeHostTarget(nodePath, fs.constants.X_OK);
+  await assertNativeHostTarget(nativeHostPath, fs.constants.R_OK);
   const command = [
     nodePath,
     nativeHostPath,
@@ -275,14 +288,24 @@ async function inspectRegistration(
       throw new Error("native host manifest does not contain exact allowed origins");
     }
     await assertPrivateNativeHostFile(expectedLauncher, true, deps.platform ?? process.platform);
-    const launcherMatches = launcherMatchesOrigins({
+    const launcherTargets = parseOwnedLauncherTargets({
       content: await fs.readFile(expectedLauncher, "utf8"),
       manifestPath,
       launcherPath: expectedLauncher,
       origins: stringOrigins,
     });
-    if (!launcherMatches) {
+    if (!launcherTargets) {
       throw new Error("native host launcher and manifest origins do not match");
+    }
+    // Removed package versions break readiness, not ownership or managed repair/removal.
+    let issue: string | undefined;
+    try {
+      for (const [index, target] of launcherTargets.entries()) {
+        await assertNativeHostTarget(target, index === 0 ? fs.constants.X_OK : fs.constants.R_OK);
+      }
+    } catch {
+      issue =
+        "registered native host runtime or entry is unavailable or unsafe; run openclaw browser extension install";
     }
     return {
       product: root.product,
@@ -290,6 +313,7 @@ async function inspectRegistration(
       manifestPath,
       extensionIds: ids.toSorted(),
       state: "owned",
+      issue,
     };
   } catch (error) {
     return {
@@ -516,20 +540,11 @@ export async function browserExtensionStatus(params: {
       : await Promise.all(
           chromeProductRoots(deps).map((root) => inspectRegistration(root, deps, predictedIds)),
         );
-  const missingRegistration = chromeProductRoots(deps).some((root) => {
+  const unavailableRegistration = registrations.some((registration) => {
     const productWasDiscovered =
-      discovery.discovered.some((entry) => entry.product === root.product) ||
-      discovery.storeDiscovered.some((entry) => entry.product === root.product);
-    if (!productWasDiscovered) {
-      return false;
-    }
-    const manifestPath = path.join(root.nativeManifestDir, `${BROWSER_NATIVE_HOST_NAME}.json`);
-    const registration = registrations.find((entry) => entry.manifestPath === manifestPath);
-    return (
-      registration?.state !== "owned" ||
-      JSON.stringify(registration.extensionIds) !==
-        JSON.stringify(expectedExtensionIds(predictedIds))
-    );
+      discovery.discovered.some((entry) => entry.product === registration.product) ||
+      discovery.storeDiscovered.some((entry) => entry.product === registration.product);
+    return productWasDiscovered && (registration.state !== "owned" || Boolean(registration.issue));
   });
   return {
     platform,
@@ -545,7 +560,7 @@ export async function browserExtensionStatus(params: {
       (installedCopy.present && !installedCopy.owned) ||
       (discovery.discovered.length === 0 && discovery.storeDiscovered.length === 0) ||
       discovery.identityMismatches.length > 0 ||
-      missingRegistration,
+      unavailableRegistration,
     issues: [
       ...(installedCopy.present && !installedCopy.owned
         ? [`Chrome extension copy is not OpenClaw-owned: ${installedPath}`]

--- a/scripts/check-no-random-messaging-tmp.mts
+++ b/scripts/check-no-random-messaging-tmp.mts
@@ -3,6 +3,7 @@
 // Blocks host-random tmpdir usage in messaging/channel runtime sources.
 import ts from "typescript";
 import { runCallsiteGuard } from "./lib/callsite-guard.mts";
+import { classifyBundledExtensionSourcePath } from "./lib/extension-source-classifier.mts";
 import {
   collectCallExpressionLines,
   runAsScript,
@@ -81,6 +82,8 @@ export async function main() {
   await runCallsiteGuard({
     importMetaUrl: import.meta.url,
     sourceRoots: messagingTmpdirGuardSourceRoots,
+    skipRelativePath: (relPath) =>
+      relPath.startsWith("extensions/") && classifyBundledExtensionSourcePath(relPath).isTestLike,
     findCallLines: findMessagingTmpdirCallLines,
     header: "Found os.tmpdir()/tmpdir() usage in messaging/channel runtime sources:",
     footer:

--- a/test/scripts/check-no-random-messaging-tmp.test.ts
+++ b/test/scripts/check-no-random-messaging-tmp.test.ts
@@ -1,11 +1,62 @@
 // Check No Random Messaging Tmp tests cover check no random messaging tmp script behavior.
-import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   findMessagingTmpdirCallLines,
+  main,
   messagingTmpdirGuardSourceRoots,
 } from "../../scripts/check-no-random-messaging-tmp.mts";
+import * as repoRoot from "../../scripts/lib/repo-root.mjs";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 describe("check-no-random-messaging-tmp", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+  afterEach(() => vi.restoreAllMocks());
+
+  it("allows plugin test support while rejecting runtime tmpdir calls through the guard", async () => {
+    const root = tempDirs.make("openclaw-messaging-tmp-guard-");
+    vi.spyOn(repoRoot, "resolveRepoRoot").mockReturnValue(root);
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitError = new Error("guard exit");
+    const exit = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw exitError;
+    });
+    const writeSource = (relativePath: string) => {
+      const filePath = path.join(root, relativePath);
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.writeFileSync(filePath, 'import os from "node:os";\nconst dir = os.tmpdir();\n');
+    };
+
+    writeSource("extensions/browser/src/browser/extension-install.test-support.ts");
+    await main();
+    expect(exit).not.toHaveBeenCalled();
+    expect(errorLog).not.toHaveBeenCalled();
+
+    const runtimePaths = [
+      "src/channels/runtime.ts",
+      "extensions/browser/runtime-api.ts",
+      "extensions/browser/src/browser/runtime.ts",
+    ];
+    runtimePaths.forEach(writeSource);
+    await expect(main()).rejects.toBe(exitError);
+    expect(exit).toHaveBeenCalledExactlyOnceWith(1);
+    expect(errorLog).toHaveBeenCalledTimes(5);
+    expect(errorLog).toHaveBeenNthCalledWith(
+      1,
+      "Found os.tmpdir()/tmpdir() usage in messaging/channel runtime sources:",
+    );
+    expect(
+      errorLog.mock.calls
+        .slice(1, -1)
+        .map(([message]) => message)
+        .toSorted(),
+    ).toEqual(runtimePaths.map((relativePath) => `- ${relativePath}:2`).toSorted());
+    expect(errorLog).toHaveBeenLastCalledWith(
+      "Use resolvePreferredOpenClawTmpDir() or plugin-sdk temp helpers instead of host tmp defaults.",
+    );
+  });
+
   it("finds os.tmpdir calls imported from node:os", () => {
     const source = `
       import os from "node:os";

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -25,6 +25,7 @@ import {
   isProviderAdvertised,
   parseProvidersFromHelp,
 } from "../../scripts/crabbox-wrapper-providers.mts";
+import { isProcessAlive } from "../helpers/process-wait.js";
 import { makeTempDir, useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const tempDirs: string[] = [];
@@ -643,15 +644,6 @@ async function waitForProcessExit(
   ]);
 }
 
-function isProcessAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 async function runSignalCleanupProof(sendSignals: (pid: number) => Promise<void>): Promise<void> {
   const root = mkdtempSync(path.join(tmpdir(), "openclaw-crabbox-descendant-"));
   tempDirs.push(root);
@@ -678,8 +670,8 @@ async function runSignalCleanupProof(sendSignals: (pid: number) => Promise<void>
     const runnerExit = waitForProcessExit(runner);
     await sendSignals(runner.pid!);
     await expect(runnerExit).resolves.toEqual({ status: 143, signal: null });
-    // The wrapper waits for the detached process group to disappear before exit.
-    // A live PID here would expose the cleanup-ordering regression this proves.
+    // Check immediately after wrapper exit for executing descendants.
+    // Linux zombies are already terminated even while their PIDs await reaping.
     expect(isProcessAlive(descendantPid)).toBe(false);
   } finally {
     if (runner.pid && isProcessAlive(runner.pid)) {


### PR DESCRIPTION
Closes #131837 — [Chrome native-host false readiness after runtime removal](https://github.com/openclaw/openclaw/issues/131837).

## What Problem This Solves

Chrome native-host status could report automatic bootstrap ready after an upgrade removed the interpreter or native entry recorded in an otherwise owned launcher. Manifest ownership, private modes, exact origins and launcher grammar were checked, but the two recorded runtime targets were not.

## Why This Change Was Made

Ownership and filesystem readiness are separate facts. The existing strict launcher parser now recovers its two target paths only after the complete ownership grammar matches. Installation and inspection share canonical file, ownership, permission and access validation. An unavailable target leaves the registration `owned`, with a bounded repair hint, so the existing installer, Doctor repair and uninstall can still manage it.

Status consumes that inspection result instead of repeating root lookups and origin comparisons. The old Boolean launcher matcher and duplicated readiness checks are removed; there is no execution probe, fallback, new configuration option, protocol change or public JSON field/enum.

## User Impact

A discovered browser with an unavailable recorded interpreter or entry now reports repair-required rather than automatic readiness. Healthy registrations, exact origins, Store trust, file/link/ownership guards and the warning-only policy for unused browsers are preserved. Installation also refuses to announce readiness for unusable selected targets.

This is deliberately a read-only filesystem snapshot, not a claim that native code, the relay or a browser connection has executed successfully. The [Chrome extension status guide](https://docs.openclaw.ai/tools/chrome-extension#status-and-removal) explains the distinction and managed reinstall path.

## Evidence

The final reviewed head is `9370eb26653fb6912340e95c28ac8bd5c471f7cf`. [Exact-head CI run 33200003796](https://github.com/openclaw/openclaw/actions/runs/33200003796) is green, including typed lint, type checks and the repaired boundary/process tests. Fresh independent Codex autoreview of the complete candidate reported no accepted/actionable findings at its P0 threshold.

The added installer regressions failed on pre-fix code. They cover missing, non-executable, unreadable, directory, symlink, unsafe-mode and relative recorded targets; quoted paths; read-only status and credential-free diagnostics; managed repair/reinstall/removal; and unused-browser warnings. An additional pre-fix reproduction caught the incorrect install-ready progress message for inaccessible selected targets.

### Exact-source native-host verification

A full `pnpm build` passed at `3586ad9e010e57b21b5d053568ebad36e405f020`; subsequent changes are test/support and CI-guard work. The final candidate and pinned pre-fix parent `9a7de4daa8102a77c1b4280a2bf4a4d55ec2177c` were then independently built with the repository's `sourcePerformance` profile on Node 24.20.0. This produces the normal backend runtime/assets/metadata without declaration-only or UI work. Runtime equivalence to the prior full build was checked, not assumed.

The original built-host test executed with its **unchanged 10000ms subprocess deadline**, framing, nonce, pairing and custom-context assertions:

| Run | Observed result |
|---|---|
| Exact candidate, selected case | Passed in **5051ms** |
| Exact pre-fix parent, selected case | Passed in **4676ms** |
| Restored candidate, six browser suites | **124 passed, zero skipped**; built-host case passed in **4261ms** |

The native entry's 820-file static-import subset and 3735-file literal-reference closure had identical bytes and resolutions across candidate/base and the prior full runtime. SDK aliases, workspace/bare dependencies and plugin/config metadata were also compared. Differences outside that closure were the reviewed installer change, its generated worker copy and dependent chunk references; build identity/help banners remained truthful. Original/base artifacts were preserved separately and the complete candidate artifact inventory was restored and reverified. No source, dependency, Node/library identity or generated asset drift remained.

Commands below used the pinned Node 24.20.0 interpreter and the existing repository wrappers:

```bash
node --import ./scripts/tsx.mjs scripts/build-all.mts sourcePerformance
```

```bash
node scripts/run-vitest.mjs extensions/browser/src/browser/extension-install.test.ts -t 'launches with the exact custom installation context when Chrome has no selectors'
```

```bash
node scripts/run-vitest.mjs extensions/browser/src/browser/extension-install.test.ts extensions/browser/src/browser/extension-install-layout.test.ts extensions/browser/src/browser/extension-native-host.test.ts extensions/browser/src/cli/browser-cli-extension.test.ts extensions/browser/src/doctor-browser.test.ts extensions/browser/chrome-extension/modules/native-bootstrap.test.ts
```

The compiled public CLI also passed the final candidate's isolated macOS flow with synthetic Chrome metadata and two disposable interpreter copies: **install → ready; remove the registered interpreter → owned/non-ready; reinstall → ready**. Status did not rewrite registration bytes, exact origins and private modes were preserved, no relay credential was created, and all fixtures/children were cleaned up.

### CI repairs and review disposition

The installer test was split along its layout/registration boundary without dropping any of its 45 cases. The extracted fixture uses per-file cleanup ownership. CI also exposed a duplicated PID-existence predicate in the Crabbox tests; it now reuses the canonical zombie-aware liveness helper without changing immediate assertions, signals or deadlines. The full local Crabbox/PID suites passed 261 tests, and Linux CI executed all 241 Crabbox cases successfully, including both previously failing signal-cleanup cases. The historical failed PID state was not captured, so zombie causation is not asserted.

The messaging temp guard initially misclassified the extracted plugin test-support file as runtime. It now uses the existing canonical plugin test classifier through its existing skip hook; core runtime, plugin runtime and runtime-API barrels remain guarded. The real guard and new boundary regression were demonstrated failing before and passing after the fix; all 10 guard/classifier tests and owning type checks passed. No scanner/classifier, allowlist, suppression or baseline was weakened.

The ClawSweeper rank-up validation request is addressed by exact-head green CI and the executed candidate/base proof above. Its serialized-state warning points to **moved disposable test fixtures**, not application persistence: no stored schema, manifest format or migration contract changed. The requested maintainer behavior is intentional: an owned but unavailable launcher must require repair, not claim readiness.

### Limits and follow-ups

Earlier runs hit the original 10-second native-host deadline; a longer diagnostic returned a frame at 11.583 seconds. That failure **did not reproduce in the finite candidate/base pair**. These were fresh-process tests on a loaded host, not controlled cold-cache measurements; no contention diagnosis or startup-performance fix is claimed. No deadline, assertion or artifact gate was changed.

Normal browser CI explicitly skipped the conditional built-host case because that shard has no runtime-artifact prerequisite. It is **not** counted as native execution proof here; the local six-suite run executed it. Named follow-up: make that integration-test CI coverage explicit using the existing artifact/prerequisite mechanisms.

Local SDK declaration preparation previously timed out at its existing 300000ms limit. That tooling issue is not claimed fixed; stock exact-head CI completed typed lint and type checks. No timeout, cache stamp or gate was bypassed.

Real operator registrations, Chrome, Gateway and services were deliberately untouched. The CLI/native-IPC proof uses only disposable fixtures and is not live authenticated Chrome/relay proof. This remains separate from [the standalone extension-relay work](https://github.com/openclaw/openclaw/pull/128379).

Judged LOC: runtime **+38/-23 (net +15)**; CI tooling **+3/-0**; tests **+646/-424**; test support **+74/-0**; docs **+7/-0**. Test moves are not runtime growth. The runtime growth supplies shared target validation and ownership-preserving health reporting; redundant readiness checks were removed. The three tooling lines connect an existing canonical classifier rather than adding another naming policy.

Provenance: the unchecked-target ownership path dates to [zero-click browser bootstrap](https://github.com/openclaw/openclaw/pull/121586), authored and merged by @steipete on 2026-08-11, and was carried forward by [Store bootstrap](https://github.com/openclaw/openclaw/pull/124775), also authored and merged by @steipete on 2026-08-16. Pinned-base blame attributes the owned return to `fada06727788` and strict matcher to `63a3a958f4f0`. No specific stable-release impact is asserted.

AI-assisted investigation and implementation. No agent transcripts or credentials are included.
