### PR TITLE
refactor(macos): simplify exec approval socket ownership

### DIFF
--- a/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
@@ -245,104 +245,6 @@ func execHostTimestampIsFresh(
     return true
 }
 
-enum ExecApprovalsSocketClient {
-    private struct TimeoutError: LocalizedError {
-        var message: String
-        var errorDescription: String? {
-            self.message
-        }
-    }
-
-    static func requestDecision(
-        socketPath: String,
-        token: String,
-        request: ExecApprovalPromptRequest,
-        timeoutMs: Int = 15000) async -> ExecApprovalDecision?
-    {
-        let trimmedPath = socketPath.trimmingCharacters(in: .whitespacesAndNewlines)
-        let trimmedToken = token.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedPath.isEmpty, !trimmedToken.isEmpty else { return nil }
-        do {
-            return try await AsyncTimeout.withTimeoutMs(
-                timeoutMs: timeoutMs,
-                onTimeout: {
-                    TimeoutError(message: "exec approvals socket timeout")
-                },
-                operation: {
-                    try await Task.detached {
-                        try self.requestDecisionSync(
-                            socketPath: trimmedPath,
-                            token: trimmedToken,
-                            request: request,
-                            timeoutMs: timeoutMs)
-                    }.value
-                })
-        } catch {
-            return nil
-        }
-    }
-
-    private static func requestDecisionSync(
-        socketPath: String,
-        token: String,
-        request: ExecApprovalPromptRequest,
-        timeoutMs: Int) throws -> ExecApprovalDecision?
-    {
-        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
-        guard fd >= 0 else {
-            throw NSError(domain: "ExecApprovals", code: 1, userInfo: [
-                NSLocalizedDescriptionKey: "socket create failed",
-            ])
-        }
-        defer { close(fd) }
-        try configureSocketTimeouts(fd, timeoutMs: timeoutMs)
-
-        var addr = sockaddr_un()
-        addr.sun_family = sa_family_t(AF_UNIX)
-        let maxLen = MemoryLayout.size(ofValue: addr.sun_path)
-        if socketPath.utf8.count >= maxLen {
-            throw NSError(domain: "ExecApprovals", code: 2, userInfo: [
-                NSLocalizedDescriptionKey: "socket path too long",
-            ])
-        }
-        socketPath.withCString { cstr in
-            withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
-                let raw = UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: Int8.self)
-                strncpy(raw, cstr, maxLen - 1)
-            }
-        }
-        let size = socklen_t(MemoryLayout.size(ofValue: addr))
-        let result = withUnsafePointer(to: &addr) { ptr in
-            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { rebound in
-                connect(fd, rebound, size)
-            }
-        }
-        if result != 0 {
-            throw NSError(domain: "ExecApprovals", code: 3, userInfo: [
-                NSLocalizedDescriptionKey: "socket connect failed",
-            ])
-        }
-
-        let handle = FileHandle(fileDescriptor: fd, closeOnDealloc: false)
-
-        let message = ExecApprovalSocketRequest(
-            type: "request",
-            token: token,
-            id: UUID().uuidString,
-            request: request)
-        let data = try JSONEncoder().encode(message)
-        var payload = data
-        payload.append(0x0A)
-        try handle.write(contentsOf: payload)
-
-        guard let line = try readLineFromSocket(fd, maxBytes: 256_000),
-              let lineData = line.data(using: .utf8)
-        else { return nil }
-        let response = try JSONDecoder().decode(ExecApprovalSocketDecision.self, from: lineData)
-        return response.decision
-    }
-}
-
 @MainActor
 final class ExecApprovalsPromptServer {
     static let shared = ExecApprovalsPromptServer()
@@ -441,13 +343,9 @@ final class ExecApprovalsPromptServer {
                     await server.stop().value
                     return
                 }
-                guard ready else {
-                    await server.stop().value
-                    continue
-                }
                 // The accept loop can fail after signaling readiness but before
                 // this task resumes. Do not install an already-dead listener.
-                guard server.isListening else {
+                guard ready, server.isListening else {
                     await server.stop().value
                     continue
                 }
@@ -494,105 +392,6 @@ final class ExecApprovalsPromptServer {
         self.server?.failForTesting()
     }
 
-    static func _testPrecancelledSocketStart(
-        socketPath: String) async -> (ready: Bool, preservedExistingListener: Bool)
-    {
-        let sentinel = ExecApprovalsSocketServer(
-            socketPath: socketPath,
-            token: "sentinel-token",
-            onPrompt: { _ in nil },
-            onExec: { request in
-                await ExecHostExecutor.handle(request)
-            },
-            onUnexpectedStop: { _ in })
-        guard await sentinel.start() else {
-            sentinel.stop()
-            return (false, false)
-        }
-
-        let socketServer = ExecApprovalsSocketServer(
-            socketPath: socketPath,
-            token: "test-token",
-            onPrompt: { _ in nil },
-            onExec: { request in
-                await ExecHostExecutor.handle(request)
-            },
-            onUnexpectedStop: { _ in })
-        let startup = Task.detached {
-            withUnsafeCurrentTask { task in
-                task?.cancel()
-            }
-            return await socketServer.start()
-        }
-        let ready = await startup.value
-        socketServer.stop()
-        let preservedExistingListener = sentinel.isListening &&
-            (try? ExecApprovalsSocketPathGuard.pathKind(at: socketPath)) == .socket
-        sentinel.stop()
-        return (ready, preservedExistingListener)
-    }
-
-    static func _testSocketLeaseHandoff(
-        socketPath: String) async -> (
-        replacementBlockedWhileOwned: Bool,
-        replacementStartedAfterRelease: Bool,
-        replacementHasDistinctIdentity: Bool,
-        replacementPreserved: Bool)
-    {
-        let first = ExecApprovalsSocketServer(
-            socketPath: socketPath,
-            token: "first-token",
-            onPrompt: { _ in nil },
-            onExec: { request in
-                await ExecHostExecutor.handle(request)
-            },
-            onUnexpectedStop: { _ in })
-        guard await first.start() else {
-            first.stop()
-            return (false, false, false, false)
-        }
-        let firstIdentity = try? ExecApprovalsSocketPathGuard.socketIdentity(at: socketPath)
-
-        let replacement = ExecApprovalsSocketServer(
-            socketPath: socketPath,
-            token: "replacement-token",
-            onPrompt: { _ in nil },
-            onExec: { request in
-                await ExecHostExecutor.handle(request)
-            },
-            onUnexpectedStop: { _ in })
-        let replacementBlockedWhileOwned = await !replacement.start()
-        await first.stop().value
-        let replacementStartedAfterRelease = await replacement.start()
-        let replacementIdentity = try? ExecApprovalsSocketPathGuard.socketIdentity(at: socketPath)
-        let currentIdentity = try? ExecApprovalsSocketPathGuard.socketIdentity(at: socketPath)
-        let result = (
-            replacementBlockedWhileOwned: replacementBlockedWhileOwned,
-            replacementStartedAfterRelease: replacementStartedAfterRelease,
-            replacementHasDistinctIdentity: firstIdentity != nil &&
-                replacementIdentity != nil &&
-                firstIdentity != replacementIdentity,
-            replacementPreserved: replacement.isListening && currentIdentity == replacementIdentity)
-        replacement.stop()
-        return result
-    }
-
-    static func _testExecHostTimestampFailureReason(_ timestamp: Int) async -> String? {
-        let server = ExecApprovalsSocketServer(
-            socketPath: "",
-            token: "test-token",
-            onPrompt: { _ in nil },
-            onExec: { _ in
-                ExecHostResponse(
-                    type: "exec-res",
-                    id: "unexpected-execution",
-                    ok: true,
-                    payload: nil,
-                    error: nil)
-            },
-            onUnexpectedStop: { _ in })
-        return await server.testExecHostTimestampFailureReason(timestamp)
-    }
     #endif
 }
 

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsSocketServer.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsSocketServer.swift
@@ -108,9 +108,7 @@ final class ExecApprovalsSocketServer: @unchecked Sendable {
     private let onExec: @Sendable (ExecHostRequest) async -> ExecHostResponse
     private let onUnexpectedStop: @Sendable (ExecApprovalsSocketServer) -> Void
     private let stateLock = NSLock()
-    private var socketFD: Int32 = -1
-    private var socketIdentity: ExecApprovalsSocketPathIdentity?
-    private var socketLifecycleLease: ExecApprovalsSocketLifecycleLease?
+    private var openedSocket: OpenedSocket?
     private var acceptTask: Task<Void, Never>?
     private var clients: [UUID: ExecApprovalsSocketClientSession] = [:]
     private var shutdownTask: Task<Void, Never>?
@@ -131,7 +129,7 @@ final class ExecApprovalsSocketServer: @unchecked Sendable {
     }
 
     var isListening: Bool {
-        self.stateLock.withLock { self.isRunning && self.socketFD >= 0 }
+        self.stateLock.withLock { self.isRunning && self.openedSocket != nil }
     }
 
     func start() async -> Bool {
@@ -141,7 +139,7 @@ final class ExecApprovalsSocketServer: @unchecked Sendable {
             return true
         }
         guard shouldStart else {
-            return self.stateLock.withLock { self.socketFD >= 0 }
+            return self.stateLock.withLock { self.openedSocket != nil }
         }
 
         return await withCheckedContinuation { continuation in
@@ -172,15 +170,15 @@ final class ExecApprovalsSocketServer: @unchecked Sendable {
             self.acceptTask = nil
             let clients = Array(self.clients.values)
             self.clients.removeAll()
-            let lifecycleLease = self.socketLifecycleLease
-            self.socketLifecycleLease = nil
+            let openedSocket = self.openedSocket
+            self.openedSocket = nil
             acceptTask?.cancel()
             for client in clients {
                 client.cancel()
             }
-            self.closeOwnedSocket(fd: self.socketFD, identity: self.socketIdentity, lifecycleLease: nil)
-            self.socketFD = -1
-            self.socketIdentity = nil
+            if let openedSocket {
+                self.closeOwnedSocket(openedSocket)
+            }
             // Hold the path lease until all admitted work has unwound. A new
             // listener must not overlap commands still owned by this generation.
             let shutdownTask = Task.detached {
@@ -188,7 +186,7 @@ final class ExecApprovalsSocketServer: @unchecked Sendable {
                 for client in clients {
                     await client.wait()
                 }
-                lifecycleLease?.release()
+                openedSocket?.lifecycleLease.release()
             }
             self.shutdownTask = shutdownTask
             return shutdownTask
@@ -197,16 +195,7 @@ final class ExecApprovalsSocketServer: @unchecked Sendable {
 
     private func runAcceptLoop(onReady: @escaping @Sendable (Bool) -> Void) async {
         let shouldOpen = self.stateLock.withLock { self.isRunning && !Task.isCancelled }
-        guard shouldOpen else {
-            self.stateLock.withLock {
-                self.isRunning = false
-                self.acceptTask = nil
-            }
-            onReady(false)
-            return
-        }
-
-        guard let openedSocket = self.openSocket() else {
+        guard shouldOpen, let openedSocket = self.openSocket() else {
             self.stateLock.withLock {
                 self.isRunning = false
                 self.acceptTask = nil
@@ -218,16 +207,12 @@ final class ExecApprovalsSocketServer: @unchecked Sendable {
 
         let shouldAccept = self.stateLock.withLock {
             guard self.isRunning, !Task.isCancelled else { return false }
-            self.socketFD = fd
-            self.socketIdentity = openedSocket.identity
-            self.socketLifecycleLease = openedSocket.lifecycleLease
+            self.openedSocket = openedSocket
             return true
         }
         guard shouldAccept else {
-            self.closeOwnedSocket(
-                fd: fd,
-                identity: openedSocket.identity,
-                lifecycleLease: openedSocket.lifecycleLease)
+            self.closeOwnedSocket(openedSocket)
+            openedSocket.lifecycleLease.release()
             onReady(false)
             return
         }
@@ -248,7 +233,7 @@ final class ExecApprovalsSocketServer: @unchecked Sendable {
                 break
             }
             self.stateLock.withLock {
-                guard self.isRunning, self.socketFD == fd else {
+                guard self.isRunning, self.openedSocket?.fd == fd else {
                     close(client)
                     return
                 }
@@ -278,28 +263,19 @@ final class ExecApprovalsSocketServer: @unchecked Sendable {
         }
     }
 
-    private func closeOwnedSocket(
-        fd: Int32,
-        identity: ExecApprovalsSocketPathIdentity?,
-        lifecycleLease: ExecApprovalsSocketLifecycleLease?)
-    {
-        if fd >= 0 {
-            _ = shutdown(fd, SHUT_RDWR)
-            close(fd)
+    private func closeOwnedSocket(_ socket: OpenedSocket) {
+        _ = shutdown(socket.fd, SHUT_RDWR)
+        close(socket.fd)
+        do {
+            // The caller retains the lease through this identity check and unlink;
+            // shutdown also keeps it until admitted work has drained.
+            try ExecApprovalsSocketPathGuard.removeSocket(
+                at: self.socketPath,
+                ifIdentityMatches: socket.identity)
+        } catch {
+            self.logger
+                .warning("exec approvals socket cleanup failed: \(error.localizedDescription, privacy: .public)")
         }
-        if !self.socketPath.isEmpty, let identity {
-            do {
-                // Keep the cross-process lease through the identity check and
-                // unlink so no replacement can bind between those operations.
-                try ExecApprovalsSocketPathGuard.removeSocket(
-                    at: self.socketPath,
-                    ifIdentityMatches: identity)
-            } catch {
-                self.logger
-                    .warning("exec approvals socket cleanup failed: \(error.localizedDescription, privacy: .public)")
-            }
-        }
-        lifecycleLease?.release()
     }
 
     #if DEBUG
@@ -315,7 +291,12 @@ final class ExecApprovalsSocketServer: @unchecked Sendable {
         do {
             try ExecApprovalsSocketPathGuard.hardenParentDirectory(for: self.socketPath)
             lifecycleLease = try ExecApprovalsSocketLifecycleLease.acquire(for: self.socketPath)
-            try ExecApprovalsSocketPathGuard.removeExistingSocket(at: self.socketPath)
+            do {
+                try ExecApprovalsSocketPathGuard.removeExistingSocket(at: self.socketPath)
+            } catch {
+                lifecycleLease.release()
+                throw error
+            }
         } catch {
             self.logger
                 .error("exec approvals socket path hardening failed: \(error.localizedDescription, privacy: .public)")
@@ -373,27 +354,21 @@ final class ExecApprovalsSocketServer: @unchecked Sendable {
             lifecycleLease.release()
             return nil
         }
+        let openedSocket = OpenedSocket(fd: fd, identity: identity, lifecycleLease: lifecycleLease)
         if chmod(self.socketPath, 0o600) != 0 {
             self.logger.error("exec approvals socket chmod failed")
-            self.closeOwnedSocket(
-                fd: fd,
-                identity: identity,
-                lifecycleLease: lifecycleLease)
+            self.closeOwnedSocket(openedSocket)
+            lifecycleLease.release()
             return nil
         }
         if listen(fd, 16) != 0 {
             self.logger.error("exec approvals socket listen failed")
-            self.closeOwnedSocket(
-                fd: fd,
-                identity: identity,
-                lifecycleLease: lifecycleLease)
+            self.closeOwnedSocket(openedSocket)
+            lifecycleLease.release()
             return nil
         }
         self.logger.info("exec approvals socket listening at \(self.socketPath, privacy: .public)")
-        return OpenedSocket(
-            fd: fd,
-            identity: identity,
-            lifecycleLease: lifecycleLease)
+        return openedSocket
     }
 
     private func handleClient(handle: FileHandle) async {
@@ -434,7 +409,7 @@ final class ExecApprovalsSocketServer: @unchecked Sendable {
                 let request = try JSONDecoder().decode(ExecHostSocketRequest.self, from: data)
                 let response = await self.handleExecRequest(request)
                 try Task.checkCancellation()
-                try self.sendExecResponse(handle: handle, response: response)
+                try self.sendResponse(handle: handle, response: response)
                 return
             }
         } catch {
@@ -451,15 +426,11 @@ final class ExecApprovalsSocketServer: @unchecked Sendable {
         decision: ExecApprovalDecision) throws
     {
         let response = ExecApprovalSocketDecision(type: "decision", id: id, decision: decision)
-        let data = try JSONEncoder().encode(response)
-        var payload = data
-        payload.append(0x0A)
-        try handle.write(contentsOf: payload)
+        try self.sendResponse(handle: handle, response: response)
     }
 
-    private func sendExecResponse(handle: FileHandle, response: ExecHostResponse) throws {
-        let data = try JSONEncoder().encode(response)
-        var payload = data
+    private func sendResponse(handle: FileHandle, response: some Encodable) throws {
+        var payload = try JSONEncoder().encode(response)
         payload.append(0x0A)
         try handle.write(contentsOf: payload)
     }
@@ -510,19 +481,6 @@ final class ExecApprovalsSocketServer: @unchecked Sendable {
             payload: response.payload,
             error: response.error)
     }
-
-    #if DEBUG
-    func testExecHostTimestampFailureReason(_ timestamp: Int) async -> String? {
-        let response = await self.handleExecRequest(ExecHostSocketRequest(
-            type: "exec",
-            id: "timestamp-test",
-            nonce: "nonce",
-            ts: timestamp,
-            hmac: "unauthenticated",
-            requestJson: #"{"command":["/usr/bin/true"]}"#))
-        return response.error?.reason
-    }
-    #endif
 
     private func hmacHex(nonce: String, ts: Int, requestJson: String) -> String {
         let key = SymmetricKey(data: Data(self.token.utf8))

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsPromptServerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsPromptServerTests.swift
@@ -6,20 +6,6 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct ExecApprovalsPromptServerTests {
-    private func makeShortSocketRoot() throws -> URL {
-        let root = URL(fileURLWithPath: "/tmp", isDirectory: true)
-            .appendingPathComponent("ocps-\(UUID().uuidString.prefix(12))", isDirectory: true)
-        try FileManager().createDirectory(
-            at: root,
-            withIntermediateDirectories: false,
-            attributes: [.posixPermissions: 0o700])
-        let socketPath = root.appendingPathComponent("exec-approvals.sock").path
-        guard socketPath.utf8.count < MemoryLayout.size(ofValue: sockaddr_un().sun_path) else {
-            throw POSIXError(.ENAMETOOLONG)
-        }
-        return root
-    }
-
     private final class SequenceCredentialsProbe: @unchecked Sendable {
         private let lock = NSLock()
         private let socketPath: String
@@ -93,7 +79,7 @@ struct ExecApprovalsPromptServerTests {
 
     @Test
     func `prompt server reloads credentials after an unavailable approvals read`() async throws {
-        let root = try self.makeShortSocketRoot()
+        let root = try ExecApprovalsSocketTestSupport.makeRoot()
         let socketPath = root.appendingPathComponent("exec-approvals.sock").path
         defer { try? FileManager().removeItem(at: root) }
 
@@ -104,7 +90,6 @@ struct ExecApprovalsPromptServerTests {
             retryDelay: .milliseconds(10),
             resolveSocketCredentials: { probe.resolve() },
             onPrompt: { _ in .allowOnce })
-        defer { server.stop() }
 
         server.start()
         #expect(!FileManager().fileExists(atPath: socketPath))
@@ -114,11 +99,12 @@ struct ExecApprovalsPromptServerTests {
         #expect(snapshot.count >= 2)
         #expect(!snapshot.resolvedOnMain)
         #expect(decision == .allowOnce)
+        await server.stop()?.value
     }
 
     @Test
     func `stopping prompt server prevents a blocked resolver from installing a socket`() async throws {
-        let root = try self.makeShortSocketRoot()
+        let root = try ExecApprovalsSocketTestSupport.makeRoot()
         let socketPath = root.appendingPathComponent("exec-approvals.sock").path
         defer { try? FileManager().removeItem(at: root) }
 
@@ -140,31 +126,38 @@ struct ExecApprovalsPromptServerTests {
 
         #expect(probe.snapshot().completed)
         #expect(!FileManager().fileExists(atPath: socketPath))
-        let decision = await ExecApprovalsSocketClient.requestDecision(
+        let decision = await ExecApprovalsSocketTestSupport.requestDecision(
             socketPath: socketPath,
             token: "current-token",
-            request: ExecApprovalPromptRequest(command: "echo stopped"),
             timeoutMs: 100)
         #expect(decision == nil)
     }
 
     @Test
     func `pre-cancelled socket startup does not listen`() async throws {
-        let root = try self.makeShortSocketRoot()
+        let root = try ExecApprovalsSocketTestSupport.makeRoot()
         let socketPath = root.appendingPathComponent("exec-approvals.sock").path
         defer { try? FileManager().removeItem(at: root) }
 
-        let result = await ExecApprovalsPromptServer._testPrecancelledSocketStart(
-            socketPath: socketPath)
+        let sentinel = ExecApprovalsSocketTestSupport.makeServer(socketPath: socketPath)
+        #expect(await sentinel.start())
+        let server = ExecApprovalsSocketTestSupport.makeServer(socketPath: socketPath)
+        let ready = await Task.detached {
+            withUnsafeCurrentTask { $0?.cancel() }
+            return await server.start()
+        }.value
+        await server.stop().value
 
-        #expect(!result.ready)
-        #expect(result.preservedExistingListener)
+        #expect(!ready)
+        #expect(sentinel.isListening)
+        #expect((try? ExecApprovalsSocketPathGuard.pathKind(at: socketPath)) == .socket)
+        await sentinel.stop().value
         #expect(!FileManager().fileExists(atPath: socketPath))
     }
 
     @Test
     func `prompt server retries after a transient socket startup failure`() async throws {
-        let root = try self.makeShortSocketRoot()
+        let root = try ExecApprovalsSocketTestSupport.makeRoot()
         let socketURL = root.appendingPathComponent("exec-approvals.sock")
         _ = FileManager().createFile(atPath: socketURL.path, contents: Data("occupied".utf8))
         defer { try? FileManager().removeItem(at: root) }
@@ -176,23 +169,28 @@ struct ExecApprovalsPromptServerTests {
             retryDelay: .milliseconds(10),
             resolveSocketCredentials: { probe.resolve() },
             onPrompt: { _ in .allowOnce })
-        defer { server.stop() }
 
         server.start()
         let observedRetry = await self.waitUntil { probe.snapshot().count >= 2 }
         #expect(observedRetry)
-        try FileManager().removeItem(at: socketURL)
+        do {
+            try FileManager().removeItem(at: socketURL)
+        } catch {
+            await server.stop()?.value
+            throw error
+        }
 
         let decision = await self.waitForDecision(
             socketPath: socketURL.path,
             token: "current-token")
         #expect(probe.snapshot().count >= 2)
         #expect(decision == .allowOnce)
+        await server.stop()?.value
     }
 
     @Test
     func `prompt server restarts after its active listener stops unexpectedly`() async throws {
-        let root = try self.makeShortSocketRoot()
+        let root = try ExecApprovalsSocketTestSupport.makeRoot()
         let socketPath = root.appendingPathComponent("exec-approvals.sock").path
         defer { try? FileManager().removeItem(at: root) }
 
@@ -203,7 +201,6 @@ struct ExecApprovalsPromptServerTests {
             retryDelay: .milliseconds(10),
             resolveSocketCredentials: { probe.resolve() },
             onPrompt: { _ in .allowOnce })
-        defer { server.stop() }
 
         server.start()
         let initialDecision = await self.waitForDecision(
@@ -219,15 +216,15 @@ struct ExecApprovalsPromptServerTests {
             token: "current-token")
         #expect(probe.snapshot().count > initialResolveCount)
         #expect(recoveredDecision == .allowOnce)
+        await server.stop()?.value
     }
 
     private func waitForDecision(socketPath: String, token: String) async -> ExecApprovalDecision? {
         for _ in 0..<100 {
             try? await Task.sleep(for: .milliseconds(10))
-            if let decision = await ExecApprovalsSocketClient.requestDecision(
+            if let decision = await ExecApprovalsSocketTestSupport.requestDecision(
                 socketPath: socketPath,
                 token: token,
-                request: ExecApprovalPromptRequest(command: "echo ready"),
                 timeoutMs: 100)
             {
                 return decision

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketAuthTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketAuthTests.swift
@@ -22,9 +22,36 @@ struct ExecApprovalsSocketAuthTests {
     }
 
     @Test
-    func `minimum timestamp is rejected before authentication without overflow`() async {
+    func `minimum timestamp is rejected before authentication without overflow`() async throws {
         #expect(!execHostTimestampIsFresh(nowMs: 1_700_000_000_000, requestMs: Int.min))
-        #expect(await ExecApprovalsPromptServer._testExecHostTimestampFailureReason(Int.min) == "ttl")
+        let root = try ExecApprovalsSocketTestSupport.makeRoot()
+        defer { try? FileManager().removeItem(at: root) }
+        let socketPath = root.appendingPathComponent("exec.sock").path
+        let server = ExecApprovalsSocketTestSupport.makeServer(socketPath: socketPath)
+        do {
+            try #require(await server.start())
+            let payload = try JSONEncoder().encode(ExecHostRequest(command: ["/usr/bin/true"]))
+            let requestJson = try #require(String(data: payload, encoding: .utf8))
+            let response = try await ExecApprovalsSocketTestSupport.roundTrip(
+                socketPath: socketPath,
+                message: ExecHostSocketRequest(
+                    type: "exec",
+                    id: "timestamp-test",
+                    nonce: "nonce",
+                    ts: Int.min,
+                    hmac: "unauthenticated",
+                    requestJson: requestJson),
+                response: ExecHostResponse.self)
+            #expect(response.type == "exec-res")
+            #expect(response.id == "timestamp-test")
+            #expect(!response.ok)
+            #expect(response.error?.code == "INVALID_REQUEST")
+            #expect(response.error?.reason == "ttl")
+        } catch {
+            await server.stop().value
+            throw error
+        }
+        await server.stop().value
     }
 
     @Test
@@ -46,11 +73,11 @@ struct ExecApprovalsSocketAuthTests {
     func `exec host limiter keeps escaped output below the jsonl cap`() throws {
         let escaped = String(repeating: "\u{0}", count: 2 * 1024 * 1024)
         let limited = ExecHostOutputLimiter.truncate(escaped)
-        let response = EncodedExecHostResponse(
+        let response = ExecHostResponse(
             type: "exec-res",
             id: "test",
             ok: true,
-            payload: EncodedExecHostRunResult(
+            payload: ExecHostRunResult(
                 exitCode: 0,
                 timedOut: false,
                 success: true,
@@ -184,21 +211,4 @@ struct ExecApprovalsSocketAuthTests {
         askFallback: .deny,
         autoAllowSkills: false,
         allowlistRules: [])
-
-    private struct EncodedExecHostResponse: Codable {
-        var type: String
-        var id: String
-        var ok: Bool
-        var payload: EncodedExecHostRunResult?
-        var error: String?
-    }
-
-    private struct EncodedExecHostRunResult: Codable {
-        var exitCode: Int?
-        var timedOut: Bool
-        var success: Bool
-        var stdout: String
-        var stderr: String
-        var error: String?
-    }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketPathGuardTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketPathGuardTests.swift
@@ -266,22 +266,65 @@ struct ExecApprovalsSocketPathGuardTests {
 
     @Test
     func `socket lease blocks replacement until current owner releases`() async throws {
-        let root = URL(fileURLWithPath: "/tmp", isDirectory: true)
-            .appendingPathComponent("ocsl-\(UUID().uuidString.prefix(12))", isDirectory: true)
+        let root = try ExecApprovalsSocketTestSupport.makeRoot()
         defer { try? FileManager().removeItem(at: root) }
-        try FileManager().createDirectory(
-            at: root,
-            withIntermediateDirectories: false,
-            attributes: [.posixPermissions: 0o700])
-        let socketPath = root.appendingPathComponent("exec-approvals.sock").path
-        #expect(socketPath.utf8.count < MemoryLayout.size(ofValue: sockaddr_un().sun_path))
+        let socketPath = root.appendingPathComponent("exec.sock").path
+        let started = AsyncStream<Void>.makeStream()
+        let release = AsyncStream<Void>.makeStream()
+        let released = Task.detached { for await _ in release.stream {} }
+        defer { release.continuation.finish() }
+        let first = ExecApprovalsSocketTestSupport.makeServer(socketPath: socketPath) { _ in
+            // Hold admitted work through cancellation so stop must retain its lease until drain.
+            started.continuation.yield()
+            await released.value
+            return .allowOnce
+        }
+        let replacement = ExecApprovalsSocketTestSupport.makeServer(socketPath: socketPath)
+        var request: Task<ExecApprovalDecision?, Never>?
+        do {
+            try #require(await first.start())
+            let firstIdentity = try #require(try ExecApprovalsSocketPathGuard.socketIdentity(at: socketPath))
+            #expect(await !replacement.start())
+            request = Task {
+                await ExecApprovalsSocketTestSupport.requestDecision(socketPath: socketPath, timeoutMs: 1000)
+            }
+            let admitted = await withTaskGroup(of: Bool.self) { group in
+                group.addTask {
+                    var iterator = started.stream.makeAsyncIterator()
+                    return await iterator.next() != nil
+                }
+                group.addTask {
+                    try? await Task.sleep(for: .seconds(1))
+                    return false
+                }
+                defer { group.cancelAll() }
+                return await group.next() ?? false
+            }
+            try #require(admitted)
 
-        let result = await ExecApprovalsPromptServer._testSocketLeaseHandoff(socketPath: socketPath)
+            let drain = first.stop()
+            #expect(!first.isListening)
+            #expect(try ExecApprovalsSocketPathGuard.pathKind(at: socketPath) == .missing)
+            #expect(await !replacement.start())
+            release.continuation.finish()
+            await drain.value
 
-        #expect(result.replacementBlockedWhileOwned)
-        #expect(result.replacementStartedAfterRelease)
-        #expect(result.replacementHasDistinctIdentity)
-        #expect(result.replacementPreserved)
+            #expect(await replacement.start())
+            let replacementIdentity = try #require(try ExecApprovalsSocketPathGuard.socketIdentity(at: socketPath))
+            #expect(firstIdentity != replacementIdentity)
+            await first.stop().value
+            #expect(replacement.isListening)
+            #expect(try ExecApprovalsSocketPathGuard.socketIdentity(at: socketPath) == replacementIdentity)
+        } catch {
+            release.continuation.finish()
+            await first.stop().value
+            await replacement.stop().value
+            _ = await request?.value
+            throw error
+        }
+        await first.stop().value
+        await replacement.stop().value
+        _ = await request?.value
     }
 
     @Test

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketTestSupport.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketTestSupport.swift
@@ -1,0 +1,85 @@
+import Darwin
+import Foundation
+@testable import OpenClaw
+
+enum ExecApprovalsSocketTestSupport {
+    static func makeRoot() throws -> URL {
+        let root = URL(fileURLWithPath: "/tmp/ocst-\(UUID().uuidString.prefix(12))", isDirectory: true)
+        try FileManager().createDirectory(
+            at: root, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        return root.resolvingSymlinksInPath()
+    }
+
+    static func makeServer(
+        socketPath: String,
+        onPrompt: @escaping @Sendable (ExecApprovalPromptRequest) async -> ExecApprovalDecision? = { _ in .deny })
+        -> ExecApprovalsSocketServer
+    {
+        ExecApprovalsSocketServer(
+            socketPath: socketPath,
+            token: "test-token",
+            onPrompt: onPrompt,
+            onExec: { _ in
+                ExecHostResponse(type: "exec-res", id: "test", ok: true, payload: nil, error: nil)
+            },
+            onUnexpectedStop: { _ in })
+    }
+
+    static func requestDecision(
+        socketPath: String,
+        token: String = "test-token",
+        timeoutMs: Int = 100) async -> ExecApprovalDecision?
+    {
+        let response = try? await self.roundTrip(
+            socketPath: socketPath,
+            message: ExecApprovalSocketRequest(
+                type: "request",
+                token: token,
+                id: UUID().uuidString,
+                request: ExecApprovalPromptRequest(command: "echo ready")),
+            response: ExecApprovalSocketDecision.self,
+            timeoutMs: timeoutMs)
+        return response?.decision
+    }
+
+    static func roundTrip<Response: Decodable & Sendable>(
+        socketPath: String,
+        message: some Encodable & Sendable,
+        response: Response.Type,
+        timeoutMs: Int = 1000) async throws -> Response
+    {
+        try await Task.detached {
+            let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+            guard fd >= 0 else { throw POSIXError(.EIO) }
+            defer { close(fd) }
+            try configureSocketTimeouts(fd, timeoutMs: timeoutMs)
+            var noSigPipe: Int32 = 1
+            guard setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, socklen_t(MemoryLayout<Int32>.size)) == 0
+            else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO) }
+
+            var address = sockaddr_un()
+            address.sun_family = sa_family_t(AF_UNIX)
+            let capacity = MemoryLayout.size(ofValue: address.sun_path)
+            guard socketPath.utf8.count < capacity else { throw POSIXError(.ENAMETOOLONG) }
+            socketPath.withCString { source in
+                withUnsafeMutablePointer(to: &address.sun_path) {
+                    $0.withMemoryRebound(to: CChar.self, capacity: capacity) {
+                        _ = strcpy($0, source)
+                    }
+                }
+            }
+            let connected = withUnsafePointer(to: &address) {
+                $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                    connect(fd, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
+                }
+            }
+            guard connected == 0 else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO) }
+
+            var payload = try JSONEncoder().encode(message)
+            payload.append(0x0A)
+            try FileHandle(fileDescriptor: fd, closeOnDealloc: false).write(contentsOf: payload)
+            guard let line = try readLineFromSocket(fd, maxBytes: 256_000) else { throw POSIXError(.ECONNRESET) }
+            return try JSONDecoder().decode(response, from: Data(line.utf8))
+        }.value
+    }
+}


### PR DESCRIPTION
Related: #131650

<details>
<summary>Additional instructions</summary>

Maintainer-owned branch; maintainers can update it. AI-assisted cleanup and review.

</details>

## What Problem This Solves

The native exec approval socket still carried test-only requester/scenario code in production, and its listener lifetime was represented by three fields that had to be updated together. This made the recently repaired cancellation boundary harder to audit and maintain.

## Why This Change Was Made

Keep the existing descriptor, path identity and lease together as one `OpenedSocket` owner, consolidate identical startup cleanup and JSONL response encoding, and move obsolete test orchestration into narrower shared test support. Listener close/unlink remains synchronous, while lease release stays explicitly after accepted work drains; cancellation, approval and wire behavior are unchanged.

## User Impact

No intended user-visible behavior change or operator action. Normal request write-half-close still receives a response; cancellation and app shutdown still stop the owned native command tree. UID/HMAC/TTL, approval/cwd revalidation, process-group cleanup, and partial-start failure handling remain intact.

The cleanup does not alter the executor result shape, TypeScript transport outcomes, config/schema/protocol/dependencies, UI presentation or the separately owned hosting work. The already-landed atomic PID fixture repair is in the base, not this diff.

**LOC, with test scaffolding classified honestly:**

| Category | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Active runtime | 43 | 77 | **−34** |
| Tests and test-only support | 203 | 277 | **−74** |
| Total | 246 | 354 | **−108** |

Raw directories: production-source **−243** and test-target **+135**. The production-source reduction includes 98 lines of unused test-only client and 111 lines of DEBUG scenario scaffolding; those are not claimed as 209 lines of active-runtime simplification. There are six changed files.

## Evidence

Four independent cleanup reviews covered reuse, simplification, efficiency and ownership. The chosen shape removes duplicate representations and obsolete test facades, not lifetime states. Deliberately retained: client `cancelled`/`finished` distinction, write-filter EOF monitoring, synchronous stop plus asynchronous drain, startup-generation fencing, and bounded unexpected-stop fault injection. Executor response redesign, UI cleanup and delimiter-scan optimization were kept out of scope.

### Boundary tests

**74 native tests across eight suites passed**, including the complete timeout/no-timeout × disconnect/server-stop matrix and `ExecHostCwdTests`.

- Lease handoff now uses a real admitted request held during cancellation: replacement remains blocked during drain and succeeds afterward, without timers serving as readiness signals.
- Minimum timestamp rejection now crosses a real Unix socket and proves `INVALID_REQUEST`/`ttl` precedes an invalid HMAC. The old two-layer DEBUG trampoline is deleted.
- Pre-cancelled startup and socket identity preservation are asserted directly by tests, not tuples returned from production facades.
- The escaped-output size test encodes the real wire DTOs instead of maintaining copies.

The first baseline/candidate runs on the older base both hit the already-known empty-PID fixture race. Advancing to the existing main snapshot containing the hosting fix resolved it; the cleanup files remained byte-identical across that fast-forward. No fixture fix was duplicated, timeout raised, or assertion weakened.

### Signed live sweep

Provider-free proof used the real `handleInvoke(system.run)` → authenticated local socket → Developer-ID-signed companion → native process-group flow, with fresh task-owned profiles/state/ports, `--background-only --attach-only`, and no operator app/Gateway/state changes.

| Case | Signed baseline | Fresh signed cleanup candidate |
| --- | --- | --- |
| Normal JSONL write-half-close | Successful command and response | Successful command and response |
| Cancel with execution timeout | Parent/child stopped; no sentinel | Parent/child gone at first approximately 250 ms check; no sentinel or stale reply |
| Cancel without execution timeout | Same behavior | Same behavior; independent of command deadline |
| App SIGTERM | App/command tree stopped; no sentinel | Same behavior; existing unavailable result, not a false success |

PID readiness was published atomically. Negative observation windows covered 3.7 seconds after the witnessed child start, exceeding the three-second sentinel delay; process extinction and sentinel absence were independently rechecked. Both task-owned apps and sockets were stopped/removed afterward.

The baseline used the retained signed cancellation artifact; its targeted native owner code matched the pre-cleanup owner. The candidate was freshly built on `46ae614e0d9de0efcf63b795fd725c010dc042ea` plus this six-file cleanup. Xcode 26.6 / Swift 6.3.3, native SwiftPM backend, unchanged committed package pins, and `codesign --verify --deep --strict` passed. The supported debug MLX-helper omission was used. This is native IPC/process proof, not a visual UI change or a generic CLI-help smoke.

The initial multi-process live driver hit a cold source-import harness timeout before the next native command started. Reusing one warmed dispatcher for the full sweep removed repeated compilation; command deadlines and assertions stayed unchanged.

### Checks and review

- Pinned SwiftFormat **0.62.1** and SwiftLint **0.65.0** passed on touched native files.
- Native source/localization verification, conflict-marker/native-schema guards and `git diff --check` passed; no inventory or package lock changed.
- The changed-gate plan was inspected. Focused native proof was run locally; full hosted macOS CI remains the merge gate, rather than rerunning unrelated local TypeScript macOS suites by default.
- Fresh Codex autoreview of this exact six-file diff reported no accepted/actionable **P0** findings. The reviewer did not execute the tests; the executions above supply runtime proof.

Native test filter:

```text
ExecApprovalsPromptServerTests|ExecApprovalsSocketPathGuardTests|ExecApprovalsSocketAuthTests|ExecHostSocketCancellationTests|ExecHostRequestEvaluatorTests|ExecApprovalPromptLayoutTests|ShellExecutorTimeoutTests|ExecHostCwdTests
```

Tests used `swift test --build-system native --skip-update --no-parallel` in a task-owned package copy with committed pins compared before/after, avoiding SwiftPM metadata-only locked-resolution churn without changing repository dependencies.

Frozen source manifest: `cf2d87ed52795ab5ddeca05eefff012e1de6071727c66519a0256c4396babf5b` across all six files. Signed artifacts and raw task-local logs are retained; no private profile paths, credentials, images or transcripts are published.

### Landing validation

Mechanically rebased onto `86789b6823cdf276c22d2e466c0dd6be7406cc3c` to consume the merged [actionlint stdin deadlock repair, #131982](https://github.com/openclaw/openclaw/pull/131982). New head: `5c363aa0c2a1b34f7e2b27e73ad03c0597f1187b`. The complete six-file patch and all six frozen hashes are unchanged; no product or workflow fix was added here. Retained signed/live proof was not rerun after this mechanical refresh; intervening cancellation owners/callers are unchanged.

Fresh [Workflow Sanity 33199238772](https://github.com/openclaw/openclaw/actions/runs/33199238772) passed on attempt 1, with actionlint completing in four seconds. Fresh [CI 33199238793](https://github.com/openclaw/openclaw/actions/runs/33199238793) passed on attempt 1, including `macos-swift`, `macos-node` and `openclaw/ci-gate`. Canonical native prepare/merge completed successfully. The prior original-head CI passed, while both old Workflow Sanity attempts were canceled after a reproducible tool deadlock. Neither old proof nor the repair PR's green CI substitutes for this head's gates.

The [latest ClawSweeper review](https://github.com/openclaw/openclaw/pull/131911#issuecomment-5455630182) found no introduced actionable defect. Its request to complete Workflow Sanity is satisfied. The maintainer explicitly requested cleanup, live proof and landing; the unchanged reviewed delta needs no duplicate review request for a mechanical refresh. Native review guards are regenerated normally.

Merged at [6eb9ef23247c9f8da29003a26e7e849d8e6892f7](https://github.com/openclaw/openclaw/commit/6eb9ef23247c9f8da29003a26e7e849d8e6892f7); all six landed file hashes match the frozen manifest. [Native merge receipt](https://github.com/openclaw/openclaw/pull/131911#issuecomment-5456399729). See the [maintainer proof/status comment](https://github.com/openclaw/openclaw/pull/131911#issuecomment-5455714101) for exact commands, CI state, source equivalence, honest LOC classification and retained-proof limitations. A user-approved child-only Git transport v0 override recovered local v2 negotiation stalls on the same HTTPS origin/auth/TLS path; no persistent config or gate was changed.
