### PR TITLE
fix(release): resume partial plugin npm publication

### DIFF
--- a/.github/workflows/plugin-npm-release.yml
+++ b/.github/workflows/plugin-npm-release.yml
@@ -1160,7 +1160,7 @@ jobs:
           PACKAGE_NAME: ${{ matrix.plugin.packageName }}
           PACKAGE_VERSION: ${{ matrix.plugin.version }}
           PUBLISH_TAG: ${{ matrix.plugin.publishTag }}
-          RELEASE_PUBLISH_PARENT_STATE_POLICY: ${{ inputs.release_publish_run_id != '' && (github.actor == 'github-actions[bot]' && 'active' || 'manual-recovery') || '' }}
+          RELEASE_PUBLISH_PARENT_STATE_POLICY: ${{ inputs.release_publish_run_id != '' && (github.actor == 'github-actions[bot]' && 'active-or-failure' || 'manual-recovery') || '' }}
           RELEASE_PUBLISH_REF: ${{ inputs.release_publish_branch }}
           RELEASE_PUBLISH_FULL_REF: ${{ inputs.release_publish_full_ref }}
           RELEASE_PUBLISH_RUN_ATTEMPT: ${{ inputs.release_publish_run_attempt }}
@@ -1370,7 +1370,7 @@ jobs:
           OPENCLAW_RELEASE_PUBLISH_RUN_ATTEMPT: ${{ inputs.release_publish_run_attempt }}
           OPENCLAW_RELEASE_PUBLISH_REF: ${{ inputs.release_publish_branch }}
           OPENCLAW_RELEASE_PUBLISH_FULL_REF: ${{ inputs.release_publish_full_ref }}
-          OPENCLAW_RELEASE_PUBLISH_PARENT_STATE_POLICY: ${{ inputs.release_publish_run_id != '' && (github.actor == 'github-actions[bot]' && 'active' || 'manual-recovery') || '' }}
+          OPENCLAW_RELEASE_PUBLISH_PARENT_STATE_POLICY: ${{ inputs.release_publish_run_id != '' && (github.actor == 'github-actions[bot]' && 'active-or-failure' || 'manual-recovery') || '' }}
           OPENCLAW_RELEASE_TOOLING_ALLOW_PREVALIDATED_REF: "true"
           OPENCLAW_RELEASE_TOOLING_FULL_REF: ${{ github.ref }}
           OPENCLAW_RELEASE_TOOLING_IDENTITY_REQUIRED: "true"
@@ -1442,7 +1442,7 @@ jobs:
           PACKAGE_NAME: ${{ steps.publication_evidence.outputs.package_name }}
           PACKAGE_VERSION: ${{ steps.publication_evidence.outputs.package_version }}
           PUBLISH_TAG: ${{ steps.publication_evidence.outputs.publish_tag }}
-          RELEASE_PUBLISH_PARENT_STATE_POLICY: ${{ inputs.release_publish_run_id != '' && (github.actor == 'github-actions[bot]' && 'active' || 'manual-recovery') || '' }}
+          RELEASE_PUBLISH_PARENT_STATE_POLICY: ${{ inputs.release_publish_run_id != '' && (github.actor == 'github-actions[bot]' && 'active-or-failure' || 'manual-recovery') || '' }}
           RELEASE_PUBLISH_REF: ${{ inputs.release_publish_branch }}
           RELEASE_PUBLISH_FULL_REF: ${{ inputs.release_publish_full_ref }}
           RELEASE_PUBLISH_RUN_ID: ${{ inputs.release_publish_run_id }}

--- a/scripts/lib/actions-artifact-archive.mjs
+++ b/scripts/lib/actions-artifact-archive.mjs
@@ -738,9 +738,12 @@ export function validateActionsArtifactBinding(params) {
     }
   } else if (expected.runAttempt === expected.consumerRunAttempt) {
     // Environment protection reports the active workflow as waiting until the
-    // approval transition propagates, even while the approved consumer runs.
-    if (!ACTIVE_SAME_RUN_STATUSES.has(run.status) || run.conclusion !== null) {
-      throw new Error("Current producer workflow attempt must still be active.");
+    // approval transition propagates. A failed attempt remains usable only
+    // because same-run policy separately requires its exact producer job to succeed.
+    const active = ACTIVE_SAME_RUN_STATUSES.has(run.status) && run.conclusion === null;
+    const failed = run.status === "completed" && run.conclusion === "failure";
+    if (!active && !failed) {
+      throw new Error("Current producer workflow attempt must still be active or failed.");
     }
   } else if (
     run.status !== "completed" ||

--- a/scripts/release-tooling-identity.d.mts
+++ b/scripts/release-tooling-identity.d.mts
@@ -31,7 +31,11 @@ export function verifyReleaseToolingIdentity(
   input: ReleaseToolingIdentityInput & {
     repository: string;
     releasePublishFullRef?: string;
-    releasePublishParentStatePolicy?: "active" | "active-or-success" | "manual-recovery";
+    releasePublishParentStatePolicy?:
+      | "active"
+      | "active-or-failure"
+      | "active-or-success"
+      | "manual-recovery";
     releasePublishRef?: string;
     releasePublishRunAttempt?: string;
     releasePublishRunId?: string;
@@ -42,7 +46,11 @@ export function verifyReleaseToolingIdentity(
 export function validateReleasePublishParentRun(input: {
   identity: Pick<ReleaseToolingIdentity, "fullRef" | "ref" | "sha">;
   releasePublishFullRef: string;
-  releasePublishParentStatePolicy: "active" | "active-or-success" | "manual-recovery";
+  releasePublishParentStatePolicy:
+    | "active"
+    | "active-or-failure"
+    | "active-or-success"
+    | "manual-recovery";
   releasePublishRef: string;
   releasePublishRunAttempt: string;
   releasePublishRunId: string;

--- a/scripts/release-tooling-identity.mjs
+++ b/scripts/release-tooling-identity.mjs
@@ -11,6 +11,7 @@ const DIRECT_WORKFLOW_REF_PATTERN =
   /^(?:main|release\/[0-9]{4}\.(?:[1-9]|1[0-2])\.[1-9][0-9]*|extended-stable\/[0-9]{4}\.(?:[1-9]|1[0-2])\.33|tideclaw\/alpha\/[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4}Z)$/u;
 const RELEASE_PUBLISH_PARENT_STATE_POLICIES = new Set([
   "active",
+  "active-or-failure",
   "active-or-success",
   "manual-recovery",
 ]);
@@ -272,6 +273,7 @@ export function validateReleasePublishParentRun({
   const completedFailure = run?.status === "completed" && run?.conclusion === "failure";
   if (
     !active &&
+    !(parentStatePolicy === "active-or-failure" && completedFailure) &&
     !(parentStatePolicy === "active-or-success" && completedSuccess) &&
     !(parentStatePolicy === "manual-recovery" && (completedSuccess || completedFailure))
   ) {

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2042,7 +2042,7 @@ describe("package acceptance workflow", () => {
       "${{ inputs.release_publish_full_ref }}",
     );
     expect(evidenceStep.env?.RELEASE_PUBLISH_PARENT_STATE_POLICY).toBe(
-      "${{ inputs.release_publish_run_id != '' && (github.actor == 'github-actions[bot]' && 'active' || 'manual-recovery') || '' }}",
+      "${{ inputs.release_publish_run_id != '' && (github.actor == 'github-actions[bot]' && 'active-or-failure' || 'manual-recovery') || '' }}",
     );
     expect(evidenceStep.run).toContain("node scripts/release-tooling-identity.mjs verify");
     expect(evidenceStep.run).toContain('--workflow-ref "$WORKFLOW_HEAD_BRANCH"');
@@ -2105,7 +2105,7 @@ describe("package acceptance workflow", () => {
       OPENCLAW_RELEASE_PUBLISH_REF: "${{ inputs.release_publish_branch }}",
       OPENCLAW_RELEASE_PUBLISH_FULL_REF: "${{ inputs.release_publish_full_ref }}",
       OPENCLAW_RELEASE_PUBLISH_PARENT_STATE_POLICY:
-        "${{ inputs.release_publish_run_id != '' && (github.actor == 'github-actions[bot]' && 'active' || 'manual-recovery') || '' }}",
+        "${{ inputs.release_publish_run_id != '' && (github.actor == 'github-actions[bot]' && 'active-or-failure' || 'manual-recovery') || '' }}",
       OPENCLAW_RELEASE_TOOLING_ALLOW_PREVALIDATED_REF: "true",
       OPENCLAW_RELEASE_TOOLING_FULL_REF: "${{ github.ref }}",
       OPENCLAW_RELEASE_TOOLING_IDENTITY_REQUIRED: "true",
@@ -2118,7 +2118,7 @@ describe("package acceptance workflow", () => {
     expect(bootstrapPublish.env).toMatchObject({
       GH_TOKEN: "${{ github.token }}",
       RELEASE_PUBLISH_PARENT_STATE_POLICY:
-        "${{ inputs.release_publish_run_id != '' && (github.actor == 'github-actions[bot]' && 'active' || 'manual-recovery') || '' }}",
+        "${{ inputs.release_publish_run_id != '' && (github.actor == 'github-actions[bot]' && 'active-or-failure' || 'manual-recovery') || '' }}",
       RELEASE_PUBLISH_RUN_ATTEMPT: "${{ inputs.release_publish_run_attempt }}",
       RELEASE_PUBLISH_RUN_ID: "${{ inputs.release_publish_run_id }}",
       RELEASE_PUBLISH_REF: "${{ inputs.release_publish_branch }}",
@@ -2140,6 +2140,15 @@ describe("package acceptance workflow", () => {
     expect(bootstrapPublish.run).toContain(
       '--release-publish-full-ref "$RELEASE_PUBLISH_FULL_REF"',
     );
+
+    const oidcCheck = workflowStep(pluginPublishJob, "Check OIDC npm package version");
+    expect(oidcCheck.run).toContain('npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version');
+    expect(oidcCheck.run).toContain("already_published=true");
+    expect(oidcPublish.if).toContain(
+      "steps.npm_package_version.outputs.already_published != 'true'",
+    );
+    const oidcReadback = workflowStep(pluginPublishJob, "Verify OIDC published runtime");
+    expect(oidcReadback.if).toBe("steps.publication_evidence.outputs.publish_route == 'npm-oidc'");
 
     const pluginWrapper = readFileSync("scripts/plugin-npm-publish.sh", "utf8");
     expect(pluginWrapper).toContain('--release-publish-ref "${OPENCLAW_RELEASE_PUBLISH_REF:-}"');

--- a/test/scripts/plugin-publication-artifact.test.ts
+++ b/test/scripts/plugin-publication-artifact.test.ts
@@ -766,6 +766,34 @@ describe("plugin publication artifact", () => {
     ).toMatchObject({ producerRunAttempt: RUN_ATTEMPT, producerRunId: RUN_ID });
   });
 
+  it("accepts a failed current attempt only when its exact producer job succeeded", () => {
+    const fixture = createFixture();
+    const workflowRun = JSON.parse(readFileSync(fixture.workflowRunPath, "utf8"));
+    workflowRun.status = "completed";
+    workflowRun.conclusion = "failure";
+    writeFileSync(fixture.workflowRunPath, `${JSON.stringify(workflowRun)}\n`);
+
+    expect(
+      verifyFixture(fixture, {
+        consumerRunAttempt: RUN_ATTEMPT,
+        producerJobName: PRODUCER_JOB_NAME,
+        runStatePolicy: "same-run-producer-success",
+        workflowJobsMetadataPath: fixture.workflowJobsPath,
+      }),
+    ).toMatchObject({ producerRunAttempt: RUN_ATTEMPT, producerRunId: RUN_ID });
+
+    workflowRun.conclusion = "cancelled";
+    writeFileSync(fixture.workflowRunPath, `${JSON.stringify(workflowRun)}\n`);
+    expect(() =>
+      verifyFixture(fixture, {
+        consumerRunAttempt: RUN_ATTEMPT,
+        producerJobName: PRODUCER_JOB_NAME,
+        runStatePolicy: "same-run-producer-success",
+        workflowJobsMetadataPath: fixture.workflowJobsPath,
+      }),
+    ).toThrow("Current producer workflow attempt must still be active or failed.");
+  });
+
   it("retries bounded metadata, attempt, and archive failures against the exact run attempt", async () => {
     const zip = createZip([{ bytes: Buffer.from("proof"), name: "proof.txt" }]);
     const artifactMetadata = {

--- a/test/scripts/release-tooling-identity.test.ts
+++ b/test/scripts/release-tooling-identity.test.ts
@@ -308,6 +308,10 @@ describe("release tooling identity", () => {
   it.each([
     ["active", "in_progress", null, true],
     ["active", "completed", "success", false],
+    ["active-or-failure", "in_progress", null, true],
+    ["active-or-failure", "completed", "failure", true],
+    ["active-or-failure", "completed", "success", false],
+    ["active-or-failure", "completed", "cancelled", false],
     ["active-or-success", "in_progress", null, true],
     ["active-or-success", "completed", "success", true],
     ["active-or-success", "completed", "failure", false],


### PR DESCRIPTION
## What Problem This Solves

Fixes a release publication failure where one plugin npm matrix job could make the parent workflow terminal, causing later jobs to reject immutable artifacts produced successfully in the same exact attempt. The `2026.9.1-beta.1` publish partially completed before this cascade, leaving some plugins live while core remained unpublished.

## Why This Change Was Made

Same-run artifact verification now accepts an enclosing workflow attempt that is either still active or terminal `failure`, while continuing to require the exact run, attempt, SHA, ref, repository, artifact identity, and unique successful producer job. Bot-dispatched plugin publication uses the matching `active-or-failure` parent policy; core publication policy is unchanged.

Already-published plugin versions remain idempotent: npm OIDC jobs read back the exact version, skip mutation when present, and still verify the published runtime. ClawHub authentication failures are independent and intentionally excluded because this release dispatch uses `wait_for_clawhub=false`.

## User Impact

Release operators can safely resume a partially completed plugin npm matrix without moving the release tag, changing the version, or republishing packages that are already live. There is no product runtime change.

## Evidence

- Failed release parent: https://github.com/openclaw/openclaw/actions/runs/33189431530
- Representative cascade failures: https://github.com/openclaw/openclaw/actions/runs/33189776836/job/98913817106 and https://github.com/openclaw/openclaw/actions/runs/33189776836/job/98913817211
- Pre-fix focused regression run: 7 failed, 284 passed; failures matched the active-only artifact and parent-state contracts.
- Post-fix focused regression run: 291 passed:
  `node scripts/run-vitest.mjs test/scripts/plugin-publication-artifact.test.ts test/scripts/release-tooling-identity.test.ts test/scripts/package-acceptance-workflow.test.ts`
- `actionlint .github/workflows/plugin-npm-release.yml`
- Changed-file formatting and `git diff --check`
- Autoreview: clean, no actionable findings, overall correctness 0.98.

Production/tooling LOC: +21/-8 (net +13) | Tests: +44/-3. The tooling growth is the explicit fail-closed state policy and type contract; candidate product code is untouched.
