### PR TITLE
fix(openshell): prevent mirror data loss through workspace aliases

### DIFF
--- a/extensions/openshell/src/backend.exec-workdir.test.ts
+++ b/extensions/openshell/src/backend.exec-workdir.test.ts
@@ -748,8 +748,9 @@ describe("openshell backend exec workdir validation", () => {
   });
 
   it.each([
-    { label: "a host workspace", sharedHost: true, sharedRuntime: false },
-    { label: "a remote runtime", sharedHost: false, sharedRuntime: true },
+    { label: "a host workspace", host: "same", sharedRuntime: false },
+    { label: "a symlink-aliased host workspace", host: "alias", sharedRuntime: false },
+    { label: "a remote runtime", host: "different", sharedRuntime: true },
   ])("holds $label until command execution and publication finish", async (scenario) => {
     const workspaces = await Promise.all(
       ["first", "second"].map(async (label) =>
@@ -762,12 +763,21 @@ describe("openshell backend exec workdir validation", () => {
     tempWorkspaces.push(...workspaces);
     const firstWorkspace = expectDefined(workspaces[0], "first OpenShell workspace");
     const secondWorkspace = expectDefined(workspaces[1], "second OpenShell workspace");
+    const secondWorkspaceDir =
+      scenario.host === "same"
+        ? firstWorkspace.dir
+        : scenario.host === "alias"
+          ? path.join(secondWorkspace.dir, "alias")
+          : secondWorkspace.dir;
+    if (scenario.host === "alias") {
+      await fs.symlink(firstWorkspace.dir, secondWorkspaceDir, "junction");
+    }
     const first = await createOpenShellBackendFixture({
       workspaceDir: firstWorkspace.dir,
       scopeKey: "agent:workspace:first",
     });
     const second = await createOpenShellBackendFixture({
-      workspaceDir: (scenario.sharedHost ? firstWorkspace : secondWorkspace).dir,
+      workspaceDir: secondWorkspaceDir,
       scopeKey: scenario.sharedRuntime ? "agent:workspace:first" : "agent:workspace:second",
     });
 

--- a/extensions/openshell/src/backend.ts
+++ b/extensions/openshell/src/backend.ts
@@ -23,6 +23,7 @@ import {
   shellEscape,
   withTempWorkspace,
 } from "openclaw/plugin-sdk/sandbox";
+import { canonicalPathFromExistingAncestor } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { OpenShellFsBridgeContext, OpenShellSandboxBackend } from "./backend.types.js";
 import {
@@ -421,7 +422,8 @@ class OpenShellSandboxBackendImpl {
   private async acquireWorkspaceLease(): Promise<OpenShellWorkspaceLease> {
     const { config, sandboxName } = this.params.execContext;
     const keys = [
-      `host:${path.resolve(this.params.createParams.workspaceDir)}`,
+      // Mirror publication owns the physical directory, so aliases must share its host lease.
+      `host:${await canonicalPathFromExistingAncestor(this.params.createParams.workspaceDir)}`,
       `runtime:${JSON.stringify([
         config.gatewayEndpoint ?? "",
         config.gateway ?? "",


### PR DESCRIPTION
Closes #131676

## What Problem This Solves

Fixes an issue where concurrent writable OpenShell mirror sandboxes could silently delete completed workspace changes when two configured workspace paths were symlink aliases of the same physical directory.

## Why This Change Was Made

The in-process mirror lease used lexical absolute paths, so aliases of one directory acquired different host leases even though both finalizers published into the same physical directory. The lease now uses the existing plugin SDK canonicalization helper to identify the physical workspace through its nearest existing ancestor. This preserves the established behavior for workspace paths that do not exist yet while making symlink aliases share one lease.

The existing serialization table now covers identical host paths, symlink-aliased host paths, and shared remote runtimes. Disjoint host paths remain covered by the adjacent parallelism test.

## User Impact

Writable OpenShell mirror operations within one Gateway process now serialize when their workspace paths resolve through symlinks to the same physical directory, preventing stale snapshot publication from removing a completed change. Remote mode, read-only publication, external editors, and coordination across separate Gateway processes are unchanged.

No configuration, SQLite schema, protocol, or migration changes are required. Workspace paths that are created lazily retain their prior behavior.

## Evidence

Regression proof before the production change:

```text
FAIL holds 'a symlink-aliased host workspace' until command execution and publication finish
expected CLI calls: ["get"]
received CLI calls: ["get", "get"]
Tests: 1 failed, 42 passed
```

Focused proof at the final branch diff:

```text
node scripts/run-vitest.mjs extensions/openshell/src/backend.exec-workdir.test.ts --reporter=dot
Test Files  1 passed (1)
Tests       43 passed (43)
```

Full OpenShell plugin suite:

```text
node scripts/run-vitest.mjs extensions/openshell/src --reporter=dot
Test Files  6 passed (6)
Tests       147 passed (147)
```

Real OpenShell + Podman behavior proof used the installed OpenShell gateway, its mTLS registration, and Podman's Docker-compatible API. The gateway was started only for the run and restored to its prior stopped state afterward.

```text
TMPDIR=/tmp DOCKER_HOST=<Podman API socket> \
  OPENCLAW_E2E_OPENSHELL_CONFIG_HOME=<existing config home> \
  OPENCLAW_E2E_SKIP_BUILD=1 pnpm test:e2e:openshell

PASS mirror stress  251057ms
PASS remote stress  176021ms
Test Files  1 passed (1)
Tests       5 passed (5)
```

Additional validation:

```text
node scripts/check-changed.mjs
PASS

autoreview --mode local --max-priority P2
No P0-P2 findings; patch correct (confidence 0.91)
```

Production LOC: +3/-1 (net +2)  
Tests: +13/-3 (net +10)
