### PR TITLE
refactor(codex): simplify native override policy and tests

### DIFF
--- a/extensions/codex/src/app-server/app-server-policy.test.ts
+++ b/extensions/codex/src/app-server/app-server-policy.test.ts
@@ -1,7 +1,7 @@
 // Codex tests cover app server policy plugin behavior.
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
+import { withTempDir } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it, vi } from "vitest";
 import { resolveCodexAppServerForModelProvider } from "./app-server-policy.js";
 import { assertCodexModelBackedReviewerEffectiveConfig } from "./config-reviewer.js";
@@ -285,8 +285,7 @@ describe("Codex app-server policy", () => {
   });
 
   it("checks the actual app-server home instead of the caller's ambient Codex home", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-review-home-"));
-    try {
+    await withTempDir("openclaw-codex-review-home-", async (root) => {
       const ambientHome = path.join(root, "ambient");
       const effectiveHome = path.join(root, "effective");
       await Promise.all([
@@ -317,9 +316,7 @@ describe("Codex app-server policy", () => {
       });
 
       expect(resolved.approvalsReviewer).toBe("user");
-    } finally {
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   it("checks endpoint overrides applied to the actual app-server process", () => {
@@ -350,8 +347,7 @@ describe("Codex app-server policy", () => {
   it.each([["--profile", "work"], ["--profile=work"], ["-pwork"]])(
     "checks the selected native profile before trusting model-backed review: %j",
     async (...profileArgs) => {
-      const codexHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-review-profile-"));
-      try {
+      await withTempDir("openclaw-codex-review-profile-", async (codexHome) => {
         await fs.writeFile(
           path.join(codexHome, "work.config.toml"),
           'openai_base_url = "http://localhost:8080/v1"\n',
@@ -380,9 +376,7 @@ describe("Codex app-server policy", () => {
             env: {},
           }).approvalsReviewer,
         ).toBe("user");
-      } finally {
-        await fs.rm(codexHome, { recursive: true, force: true });
-      }
+      });
     },
   );
 

--- a/extensions/codex/src/app-server/config-reviewer.ts
+++ b/extensions/codex/src/app-server/config-reviewer.ts
@@ -83,17 +83,13 @@ export function canUseCodexModelBackedApprovalsReviewerForModel(
 ): boolean {
   const explicitProvider = params.modelProvider?.trim().toLowerCase();
   const inferredProvider = inferProviderFromModelRef(params.model);
-  if (explicitProvider && explicitProvider !== "codex") {
-    return (
-      isTrustedCodexModelBackedApprovalsReviewerProvider(explicitProvider, params) &&
-      (inferredProvider === undefined ||
-        isTrustedCodexModelBackedApprovalsReviewerProvider(inferredProvider, params))
-    );
+  if (explicitProvider && explicitProvider !== "codex" && explicitProvider !== "openai") {
+    return false;
   }
-  if (inferredProvider !== undefined) {
-    return isTrustedCodexModelBackedApprovalsReviewerProvider(inferredProvider, params);
-  }
-  return isTrustedCodexModelBackedApprovalsReviewerProvider(explicitProvider, params);
+  return (
+    (inferredProvider ?? explicitProvider) === "openai" &&
+    isTrustedCodexModelBackedOpenAIProvider(params)
+  );
 }
 
 function isTrustedCodexModelBackedOpenAIProvider(params: {
@@ -165,29 +161,6 @@ export function resolveCodexModelBackedReviewerPolicyContext(params: {
     modelProvider: params.nativeAuthProfile === true ? "openai" : undefined,
     model: params.model ?? params.bindingModel,
   };
-}
-
-function isCodexModelBackedApprovalsReviewerProvider(provider: string | undefined): boolean {
-  const normalized = provider?.trim().toLowerCase();
-  return normalized === "openai";
-}
-
-function isTrustedCodexModelBackedApprovalsReviewerProvider(
-  provider: string | undefined,
-  params: CodexModelBackedReviewerContext,
-): boolean {
-  return (
-    isCodexModelBackedApprovalsReviewerProvider(provider) &&
-    isTrustedCodexModelBackedOpenAIProvider({
-      config: params.config,
-      env: params.env,
-      model: params.model,
-      agentDir: params.agentDir,
-      codexConfigToml: params.codexConfigToml,
-      homeScope: params.homeScope,
-      codexArgs: params.codexArgs,
-    })
-  );
 }
 
 function readCodexBaseUrlOverridesForModelBackedReview(

--- a/extensions/codex/src/app-server/config-runtime.ts
+++ b/extensions/codex/src/app-server/config-runtime.ts
@@ -567,6 +567,10 @@ export function codexSandboxPolicyForTurn(
       continue;
     }
     const key = override.slice(0, separator).trim();
+    const isTmpdirExclusion = key === "sandbox_workspace_write.exclude_tmpdir_env_var";
+    if (!isTmpdirExclusion && key !== "sandbox_workspace_write.exclude_slash_tmp") {
+      continue;
+    }
     let value: unknown;
     try {
       // Match Codex's TOML value wrapper, including comments after booleans.
@@ -578,9 +582,9 @@ export function codexSandboxPolicyForTurn(
     if (typeof value !== "boolean") {
       continue;
     }
-    if (key === "sandbox_workspace_write.exclude_tmpdir_env_var") {
+    if (isTmpdirExclusion) {
       excludeTmpdirEnvVar = value;
-    } else if (key === "sandbox_workspace_write.exclude_slash_tmp") {
+    } else {
       excludeSlashTmp = value;
     }
   }

--- a/extensions/codex/src/app-server/native-app-server.test-support.ts
+++ b/extensions/codex/src/app-server/native-app-server.test-support.ts
@@ -1,0 +1,47 @@
+import fs from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { resolveManagedCodexNativeCommand } from "./managed-binary.js";
+
+/** The caller owns the canonical temporary root and joins children before removing it. */
+export async function createCodexNativeTestState(root: string) {
+  const home = path.join(root, "home");
+  const codexHome = path.join(home, ".codex");
+  const cwd = path.join(root, "workspace");
+  const tmp = path.join(root, "tmp");
+  await Promise.all([codexHome, cwd, tmp].map((dir) => fs.mkdir(dir, { recursive: true })));
+  const require = createRequire(import.meta.url);
+  const launcher = path.join(
+    path.dirname(require.resolve("@openai/codex/package.json")),
+    "bin/codex.js",
+  );
+  const command = resolveManagedCodexNativeCommand(launcher);
+  if (!command) {
+    throw new Error("Install the pinned @openai/codex platform package before native tests.");
+  }
+  const proxy = "http://127.0.0.1:9";
+  // Both native proofs use a child-only allowlist, never the operator's environment.
+  const env: NodeJS.ProcessEnv = {
+    PATH: [path.dirname(process.execPath), "/usr/bin", "/bin"].join(path.delimiter),
+    ...(process.platform === "win32" ? { SystemRoot: process.env.SystemRoot } : {}),
+    HOME: home,
+    USERPROFILE: home,
+    CODEX_HOME: codexHome,
+    TMPDIR: tmp,
+    TMP: tmp,
+    TEMP: tmp,
+    XDG_CONFIG_HOME: path.join(home, ".config"),
+    XDG_DATA_HOME: path.join(home, ".local/share"),
+    XDG_STATE_HOME: path.join(home, ".local/state"),
+    XDG_CACHE_HOME: path.join(home, ".cache"),
+    HTTP_PROXY: proxy,
+    HTTPS_PROXY: proxy,
+    ALL_PROXY: proxy,
+    http_proxy: proxy,
+    https_proxy: proxy,
+    all_proxy: proxy,
+    NO_PROXY: "127.0.0.1,localhost,::1",
+    no_proxy: "127.0.0.1,localhost,::1",
+  };
+  return { command, launcher, cwd, codexHome, tmp, env };
+}

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -2015,6 +2015,14 @@ describe("Codex app-server native code mode config", () => {
 });
 
 describe("Codex app-server turn input image sanitizing", () => {
+  const excludedTmpStart = {
+    args: [
+      "-csandbox_workspace_write.exclude_tmpdir_env_var=true",
+      "-csandbox_workspace_write.exclude_slash_tmp=true",
+      "app-server",
+    ],
+  };
+
   it.each([
     {
       name: "separate",
@@ -2024,8 +2032,7 @@ describe("Codex app-server turn input image sanitizing", () => {
         "--config",
         "sandbox_workspace_write.exclude_slash_tmp=true",
       ],
-      tmpdir: true,
-      slashTmp: true,
+      excluded: true,
     },
     {
       name: "attached short",
@@ -2033,8 +2040,7 @@ describe("Codex app-server turn input image sanitizing", () => {
         "-csandbox_workspace_write.exclude_tmpdir_env_var=true",
         "-c=sandbox_workspace_write.exclude_slash_tmp=true",
       ],
-      tmpdir: true,
-      slashTmp: true,
+      excluded: true,
     },
     {
       name: "mixed last true",
@@ -2043,8 +2049,7 @@ describe("Codex app-server turn input image sanitizing", () => {
         "-csandbox_workspace_write.exclude_tmpdir_env_var=true",
         "--config=sandbox_workspace_write.exclude_slash_tmp=true",
       ],
-      tmpdir: true,
-      slashTmp: true,
+      excluded: true,
     },
     {
       name: "mixed last false",
@@ -2055,8 +2060,7 @@ describe("Codex app-server turn input image sanitizing", () => {
         "--config=sandbox_workspace_write.exclude_slash_tmp=true",
         "-c=sandbox_workspace_write.exclude_slash_tmp=false",
       ],
-      tmpdir: false,
-      slashTmp: false,
+      excluded: false,
     },
     {
       name: "commented true across separate and attached forms",
@@ -2068,8 +2072,7 @@ describe("Codex app-server turn input image sanitizing", () => {
         "sandbox_workspace_write.exclude_slash_tmp = false # earlier",
         "-c=sandbox_workspace_write.exclude_slash_tmp = true # exclusion retained",
       ],
-      tmpdir: true,
-      slashTmp: true,
+      excluded: true,
     },
     {
       name: "commented false wins last",
@@ -2080,8 +2083,7 @@ describe("Codex app-server turn input image sanitizing", () => {
         "--config=sandbox_workspace_write.exclude_slash_tmp=true",
         "-csandbox_workspace_write.exclude_slash_tmp=false # explicit last value",
       ],
-      tmpdir: false,
-      slashTmp: false,
+      excluded: false,
     },
     {
       name: "quoted booleans remain strings",
@@ -2089,8 +2091,7 @@ describe("Codex app-server turn input image sanitizing", () => {
         '-csandbox_workspace_write.exclude_tmpdir_env_var="true" # not a boolean',
         "--config=sandbox_workspace_write.exclude_slash_tmp='true' # not a boolean",
       ],
-      tmpdir: false,
-      slashTmp: false,
+      excluded: false,
     },
     {
       name: "option value and terminator",
@@ -2100,12 +2101,11 @@ describe("Codex app-server turn input image sanitizing", () => {
         "--",
         "--config=sandbox_workspace_write.exclude_slash_tmp=true",
       ],
-      tmpdir: false,
-      slashTmp: false,
+      excluded: false,
     },
   ])(
     "carries native workspace temporary-root overrides into turn policy: $name",
-    ({ args, tmpdir, slashTmp }) => {
+    ({ args, excluded }) => {
       const request = buildTurnStartParams(createAttemptParams({ provider: "openai" }), {
         threadId: "thread-1",
         cwd: "/tmp/qa/workspace",
@@ -2118,8 +2118,8 @@ describe("Codex app-server turn input image sanitizing", () => {
         type: "workspaceWrite",
         writableRoots: ["/tmp/qa/workspace"],
         networkAccess: false,
-        excludeTmpdirEnvVar: tmpdir,
-        excludeSlashTmp: slashTmp,
+        excludeTmpdirEnvVar: excluded,
+        excludeSlashTmp: excluded,
       });
     },
   );
@@ -2146,13 +2146,7 @@ describe("Codex app-server turn input image sanitizing", () => {
       cwd: "/repo",
       appServer: {
         ...createAppServerOptions(),
-        start: {
-          args: [
-            "-csandbox_workspace_write.exclude_tmpdir_env_var=true",
-            "-csandbox_workspace_write.exclude_slash_tmp=true",
-            "app-server",
-          ],
-        },
+        start: excludedTmpStart,
       } as never,
       sandboxPolicy: {
         type: "workspaceWrite",
@@ -2178,13 +2172,7 @@ describe("Codex app-server turn input image sanitizing", () => {
       cwd: "/repo",
       appServer: {
         ...createNetworkProxyAppServerOptions(),
-        start: {
-          args: [
-            "-csandbox_workspace_write.exclude_tmpdir_env_var=true",
-            "-csandbox_workspace_write.exclude_slash_tmp=true",
-            "app-server",
-          ],
-        },
+        start: excludedTmpStart,
       } as never,
     });
 
@@ -2198,13 +2186,7 @@ describe("Codex app-server turn input image sanitizing", () => {
       cwd: "/repo",
       appServer: {
         ...createNetworkProxyAppServerOptions(),
-        start: {
-          args: [
-            "-csandbox_workspace_write.exclude_tmpdir_env_var=true",
-            "-csandbox_workspace_write.exclude_slash_tmp=true",
-            "app-server",
-          ],
-        },
+        start: excludedTmpStart,
       } as never,
       sandboxPolicy: {
         type: "externalSandbox",

--- a/extensions/codex/src/app-server/transport-stdio.config.test.ts
+++ b/extensions/codex/src/app-server/transport-stdio.config.test.ts
@@ -1,12 +1,11 @@
 import fs from "node:fs/promises";
-import { createRequire } from "node:module";
 import path from "node:path";
 import { createInterface } from "node:readline";
 import { withTempDir } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it, vi } from "vitest";
 import { withEphemeralCodexAuthStore } from "./auth-start-options.js";
-import type { CodexAppServerStartOptions } from "./config.js";
-import { resolveManagedCodexNativeCommand } from "./managed-binary.js";
+import type { CodexAppServerStartOptions } from "./config-contracts.js";
+import { createCodexNativeTestState } from "./native-app-server.test-support.js";
 import type { CodexConfigReadResponse, CodexInitializeResponse } from "./protocol.js";
 import { createStdioTransport } from "./transport-stdio.js";
 import { closeCodexAppServerTransportAndWait } from "./transport.js";
@@ -14,12 +13,110 @@ import { CODEX_APP_SERVER_VERSION } from "./version.js";
 
 vi.unmock("node:child_process");
 
-const require = createRequire(import.meta.url);
-const launcher = path.join(
-  path.dirname(require.resolve("@openai/codex/package.json")),
-  "bin/codex.js",
-);
 const baseUrl = "http://127.0.0.1:9/config-override-probe";
+const rootOverrides = [
+  "-c",
+  `openai_base_url=${JSON.stringify(baseUrl)}`,
+  "--config",
+  "model_reasoning_effort=high",
+];
+const mixedArgs = [
+  `-copenai_base_url=${JSON.stringify(baseUrl)}`,
+  "--config=model_reasoning_effort=low",
+  "--config=model_context_window=8192",
+  "-cmodel_auto_compact_token_limit=6000",
+  "--config=model_auto_compact_token_limit_scope=total",
+  "--disable",
+  "fast_mode",
+  "app-server",
+  "-c=model_reasoning_effort=high",
+  "--config",
+  'cli_auth_credentials_store="file"',
+  "--listen",
+  "stdio://",
+];
+const expectedConfig = {
+  openai_base_url: baseUrl,
+  model_reasoning_effort: "high",
+  cli_auth_credentials_store: "ephemeral",
+};
+const expectedMixedConfig = {
+  ...expectedConfig,
+  model_context_window: 8192,
+  model_auto_compact_token_limit: 6000,
+  model_auto_compact_token_limit_scope: "total",
+  features: { fast_mode: false },
+};
+
+type NativeConfigCase = {
+  name: string;
+  invocation: (
+    command: string,
+    launcher: string,
+  ) => Pick<CodexAppServerStartOptions, "command" | "args">;
+  expected: CodexConfigReadResponse["config"];
+  authProfileId?: null;
+  posixOnly?: boolean;
+};
+
+const cases: NativeConfigCase[] = [
+  {
+    name: "root overrides with injected auth",
+    invocation: (command) => ({
+      command,
+      args: [...rootOverrides, "app-server", "--listen", "stdio://"],
+    }),
+    expected: expectedConfig,
+  },
+  {
+    name: "mixed override spellings and last-value precedence",
+    invocation: (command) => ({ command, args: [...mixedArgs] }),
+    expected: expectedMixedConfig,
+  },
+  {
+    name: "wrapper prefix and option terminator",
+    invocation: (_command, launcher) => ({
+      command: process.execPath,
+      args: [launcher, ...mixedArgs, "--"],
+    }),
+    expected: expectedMixedConfig,
+  },
+  {
+    name: "shell-owned -c and -- prefix",
+    invocation: (command) => ({
+      command: "/bin/sh",
+      args: ["-c", 'exec "$@"', "--", command, ...mixedArgs, "--"],
+    }),
+    expected: expectedMixedConfig,
+    posixOnly: true,
+  },
+  {
+    name: "wrapper-supplied subcommand with marker-shaped root values",
+    invocation: (command) => ({
+      command: "/bin/sh",
+      args: [
+        "-c",
+        'exec "$@" app-server --listen stdio://',
+        "--",
+        command,
+        "--model",
+        "app-server",
+        "--image",
+        "photo.png",
+        "app-server",
+        ...rootOverrides,
+      ],
+    }),
+    expected: expectedConfig,
+    posixOnly: true,
+  },
+  {
+    name: "native-owned auth without injection",
+    invocation: (command) => ({ command, args: [...mixedArgs] }),
+    expected: { ...expectedMixedConfig, cli_auth_credentials_store: "file" },
+    authProfileId: null,
+  },
+];
 
 async function readNativeConfig(startOptions: CodexAppServerStartOptions, env: NodeJS.ProcessEnv) {
   const child = createStdioTransport(startOptions, env);
@@ -89,168 +186,34 @@ async function readNativeConfig(startOptions: CodexAppServerStartOptions, env: N
 }
 
 describe("Codex stdio effective configuration", () => {
-  it.for([
-    {
-      name: "root overrides with injected auth",
-      placement: "root",
-      authProfileId: undefined,
-      wrapped: false,
-      terminator: false,
-    },
-    {
-      name: "mixed override spellings and last-value precedence",
-      placement: "mixed",
-      authProfileId: undefined,
-      wrapped: false,
-      terminator: false,
-    },
-    {
-      name: "wrapper prefix and option terminator",
-      placement: "mixed",
-      authProfileId: undefined,
-      wrapped: "script",
-      terminator: true,
-    },
-    {
-      name: "shell-owned -c and -- prefix",
-      placement: "mixed",
-      authProfileId: undefined,
-      wrapped: "shell",
-      terminator: true,
-    },
-    {
-      name: "wrapper-supplied subcommand with marker-shaped root values",
-      placement: "root",
-      authProfileId: undefined,
-      wrapped: "implicit",
-      terminator: false,
-    },
-    {
-      name: "native-owned auth without injection",
-      placement: "mixed",
-      authProfileId: null,
-      wrapped: false,
-      terminator: false,
-    },
-  ] as const)(
-    "preserves $name",
-    { timeout: 75_000 },
-    async ({ placement, authProfileId, wrapped, terminator }, context) => {
-      if ((wrapped === "shell" || wrapped === "implicit") && process.platform === "win32") {
-        context.skip();
-      }
-      await withTempDir("openclaw-codex-config-", async (dir) => {
-        const home = await fs.realpath(dir);
-        const codexHome = path.join(home, ".codex");
-        const cwd = path.join(home, "workspace");
-        const tmp = path.join(home, "tmp");
-        await Promise.all([codexHome, cwd, tmp].map((entry) => fs.mkdir(entry)));
-        // No auth, inference, model discovery, or operator-home access is needed.
-        await fs.writeFile(
-          path.join(codexHome, "config.toml"),
-          'cli_auth_credentials_store="file"\n[features]\nrespect_system_proxy=false\n[analytics]\nenabled=false\n[feedback]\nenabled=false\n',
-        );
-        const proxy = "http://127.0.0.1:9";
-        const env: NodeJS.ProcessEnv = {
-          PATH: [path.dirname(process.execPath), "/usr/bin", "/bin"].join(path.delimiter),
-          ...(process.platform === "win32" ? { SystemRoot: process.env.SystemRoot } : {}),
-          HOME: home,
-          USERPROFILE: home,
-          CODEX_HOME: codexHome,
-          TMPDIR: tmp,
-          TMP: tmp,
-          TEMP: tmp,
-          XDG_CONFIG_HOME: path.join(home, ".config"),
-          XDG_DATA_HOME: path.join(home, ".local/share"),
-          XDG_STATE_HOME: path.join(home, ".local/state"),
-          XDG_CACHE_HOME: path.join(home, ".cache"),
-          HTTP_PROXY: proxy,
-          HTTPS_PROXY: proxy,
-          ALL_PROXY: proxy,
-          http_proxy: proxy,
-          https_proxy: proxy,
-          all_proxy: proxy,
-          NO_PROXY: "127.0.0.1,localhost,::1",
-          no_proxy: "127.0.0.1,localhost,::1",
-        };
-        const args =
-          placement === "root"
-            ? [
-                "-c",
-                `openai_base_url=${JSON.stringify(baseUrl)}`,
-                "--config",
-                "model_reasoning_effort=high",
-                ...(wrapped === "implicit" ? [] : ["app-server", "--listen", "stdio://"]),
-              ]
-            : [
-                `-copenai_base_url=${JSON.stringify(baseUrl)}`,
-                "--config=model_reasoning_effort=low",
-                "--config=model_context_window=8192",
-                "-cmodel_auto_compact_token_limit=6000",
-                "--config=model_auto_compact_token_limit_scope=total",
-                "--disable",
-                "fast_mode",
-                "app-server",
-                "-c=model_reasoning_effort=high",
-                "--config",
-                'cli_auth_credentials_store="file"',
-                "--listen",
-                "stdio://",
-              ];
-        const nativeCommand = resolveManagedCodexNativeCommand(launcher);
-        if (!nativeCommand) {
-          throw new Error(
-            "Install the pinned @openai/codex platform package before native config tests.",
-          );
-        }
-        const invocation =
-          wrapped === "implicit"
-            ? {
-                command: "/bin/sh",
-                prefix: [
-                  "-c",
-                  'exec "$@" app-server --listen stdio://',
-                  "--",
-                  nativeCommand,
-                  "--model",
-                  "app-server",
-                  "--image",
-                  "photo.png",
-                  "app-server",
-                ],
-              }
-            : wrapped === "shell"
-              ? { command: "/bin/sh", prefix: ["-c", 'exec "$@"', "--", nativeCommand] }
-              : wrapped === "script"
-                ? { command: process.execPath, prefix: [launcher] }
-                : { command: nativeCommand, prefix: [] };
-        const options: CodexAppServerStartOptions = {
-          transport: "stdio",
-          command: invocation.command,
-          commandSource: "config",
-          args: [...invocation.prefix, ...args, ...(terminator ? ["--"] : [])],
-          cwd,
-          headers: {},
-        };
-        const start = withEphemeralCodexAuthStore({ startOptions: options, authProfileId });
-        const { config } = await readNativeConfig(start, env);
-        expect(config).toMatchObject({
-          openai_base_url: baseUrl,
-          model_reasoning_effort: "high",
-          cli_auth_credentials_store: authProfileId === null ? "file" : "ephemeral",
-          ...(placement === "mixed"
-            ? {
-                model_context_window: 8192,
-                model_auto_compact_token_limit: 6000,
-                model_auto_compact_token_limit_scope: "total",
-                features: { fast_mode: false },
-              }
-            : {}),
-        });
-        await expect(fs.access(path.join(codexHome, "auth.json"))).rejects.toMatchObject({
-          code: "ENOENT",
-        });
+  it.for(cases)("preserves $name", { timeout: 75_000 }, async (testCase, context) => {
+    if (testCase.posixOnly && process.platform === "win32") {
+      context.skip();
+    }
+    await withTempDir("openclaw-codex-config-", async (dir) => {
+      const root = await fs.realpath(dir);
+      const { command, launcher, cwd, codexHome, env } = await createCodexNativeTestState(root);
+      // No auth, inference, model discovery, or operator-home access is needed.
+      await fs.writeFile(
+        path.join(codexHome, "config.toml"),
+        'cli_auth_credentials_store="file"\n[features]\nrespect_system_proxy=false\n[analytics]\nenabled=false\n[feedback]\nenabled=false\n',
+      );
+      const options: CodexAppServerStartOptions = {
+        ...testCase.invocation(command, launcher),
+        transport: "stdio",
+        commandSource: "config",
+        cwd,
+        headers: {},
+      };
+      const start = withEphemeralCodexAuthStore({
+        startOptions: options,
+        authProfileId: testCase.authProfileId,
       });
-    },
-  );
+      const { config } = await readNativeConfig(start, env);
+      expect(config).toMatchObject(testCase.expected);
+      await expect(fs.access(path.join(codexHome, "auth.json"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    });
+  });
 });

--- a/extensions/codex/src/app-server/transport-stdio.sandbox.test.ts
+++ b/extensions/codex/src/app-server/transport-stdio.sandbox.test.ts
@@ -1,8 +1,9 @@
 import fs from "node:fs/promises";
+import http from "node:http";
 import path from "node:path";
 import { createInterface } from "node:readline";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
-import { useAutoCleanupTempDirTracker, withServer } from "openclaw/plugin-sdk/test-env";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it, vi } from "vitest";
 import { resolveCodexAppServerRuntimeOptions } from "./config.js";
 import { createCodexNativeTestState } from "./native-app-server.test-support.js";
@@ -68,217 +69,229 @@ describe.skipIf(process.platform !== "darwin")("native Codex turn sandbox", () =
         await fs.unlink(target);
       }
       let requestCount = 0;
-      await withServer(
-        (req, res) => {
-          req.resume();
-          req.on("end", () => {
-            if (req.url !== "/v1/responses" || req.method !== "POST") {
-              res.writeHead(404).end();
-              return;
-            }
-            requestCount += 1;
-            const script = targets
-              .map(
-                (target, index) =>
-                  `if printf proof > '${target}'; then printf 'write-${index}:ok\\n'; else printf 'write-${index}:denied\\n'; fi`,
-              )
-              .join("; ");
-            const item =
-              requestCount === 1
-                ? {
-                    type: "function_call",
-                    call_id: "write-probe",
-                    name: "exec_command",
-                    arguments: JSON.stringify({
-                      cmd: script,
-                      shell: "/bin/sh",
-                      login: false,
-                      max_output_tokens: 1000,
-                    }),
-                  }
-                : {
-                    type: "message",
-                    role: "assistant",
-                    id: "done",
-                    content: [{ type: "output_text", text: "Probe complete." }],
-                  };
-            const events = [
-              { type: "response.created", response: { id: `response-${requestCount}` } },
-              { type: "response.output_item.done", item },
-              {
-                type: "response.completed",
-                response: {
-                  id: `response-${requestCount}`,
-                  usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
-                },
-              },
-            ];
-            res.writeHead(200, { "Content-Type": "text/event-stream" });
-            res.end(
-              events
-                .map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
-                .join(""),
-            );
-          });
-        },
-        async (baseUrl) => {
-          const config = [
-            'model="gpt-5.6-luna"',
-            'model_provider="loopback-fixture"',
-            'sandbox_mode="workspace-write"',
-            'approval_policy="on-request"',
-            'approvals_reviewer="user"',
-            'cli_auth_credentials_store="ephemeral"',
-            'web_search="disabled"',
-            "allow_login_shell=false",
-            "[features]",
-            "respect_system_proxy=false",
-            "shell_snapshot=false",
-            "code_mode=false",
-            "code_mode_only=false",
-            "[analytics]",
-            "enabled=false",
-            "[feedback]",
-            "enabled=false",
-            "[model_providers.loopback-fixture]",
-            'name="Loopback test fixture"',
-            `base_url="${baseUrl}/v1"`,
-            'wire_api="responses"',
-            "requires_openai_auth=false",
-            "supports_websockets=false",
-          ].join("\n");
-          await fs.writeFile(path.join(codexHome, "config.toml"), config);
-          const child = createStdioTransport(
-            { transport: "stdio", command, commandSource: "config", args, cwd, headers: {} },
-            { ...env, PATH: "/usr/bin:/bin", SHELL: "/bin/sh" },
-          );
-          const lines = createInterface({ input: child.stdout });
-          try {
-            const pending = new Map<
-              number,
-              { resolve: (value: unknown) => void; reject: (error: Error) => void }
-            >();
-            let nextId = 0;
-            let approvals = 0;
-            let commandOutput = "";
-            const { promise: completed, resolve: finishTurn } = createDeferred<unknown>();
-            const send = (message: object) => child.stdin.write(`${JSON.stringify(message)}\n`);
-            const request = (method: string, params: object) =>
-              new Promise<unknown>((resolve, reject) => {
-                const id = ++nextId;
-                pending.set(id, { resolve, reject });
-                send({ id, method, params });
-              });
-            child.stdin.on("error", () => {});
-            child.stderr.resume();
-            child.once("close", () => {
-              for (const waiter of pending.values()) {
-                waiter.reject(new Error("Native child closed"));
-              }
-            });
-            lines.on("line", (line) => {
-              const message = JSON.parse(line) as {
-                id?: number;
-                method?: string;
-                result?: unknown;
-                error?: unknown;
-                params?: { item?: { type: string; aggregatedOutput?: string }; turn?: unknown };
-              };
-              if (message.method && message.id !== undefined) {
-                approvals += 1;
-                send({
-                  id: message.id,
-                  result:
-                    message.method === "item/permissions/requestApproval"
-                      ? { permissions: {}, scope: "turn" }
-                      : { decision: "decline" },
-                });
-              } else if (message.id !== undefined) {
-                const waiter = pending.get(message.id);
-                pending.delete(message.id);
-                if (message.error) {
-                  waiter?.reject(new Error(JSON.stringify(message.error)));
-                } else {
-                  waiter?.resolve(message.result);
-                }
-              } else if (
-                message.method === "item/completed" &&
-                message.params?.item?.type === "commandExecution"
-              ) {
-                commandOutput += message.params.item.aggregatedOutput ?? "";
-              } else if (message.method === "turn/completed") {
-                finishTurn(message.params?.turn);
-              }
-            });
-            const initialized = await request("initialize", {
-              clientInfo: { name: "openclaw_sandbox_test", version: "1.0.0" },
-              capabilities: { experimentalApi: true },
-            });
-            expect(initialized).toMatchObject({
-              userAgent: expect.stringContaining(`/${CODEX_APP_SERVER_VERSION} `),
-            });
-            send({ method: "initialized", params: {} });
-            const thread = (await request("thread/start", {
-              cwd,
-              model: "gpt-5.6-luna",
-              modelProvider: "loopback-fixture",
-              approvalPolicy: "on-request",
-              approvalsReviewer: "user",
-              sandbox: "workspace-write",
-              ephemeral: true,
-            })) as { thread: { id: string }; sandbox: unknown };
-            expect(thread.sandbox).toMatchObject({
-              type: "workspaceWrite",
-              excludeTmpdirEnvVar: excluded,
-              excludeSlashTmp: excluded,
-            });
-            const appServer = resolveCodexAppServerRuntimeOptions({
-              env: {},
-              codexConfigToml: null,
-              requirementsToml: null,
-              pluginConfig: {
-                appServer: {
-                  command,
-                  args,
-                  sandbox: "workspace-write",
-                  approvalPolicy: "on-request",
-                  approvalsReviewer: "user",
-                },
-              },
-            });
-            const params = createCodexUserInputTestParams();
-            params.prompt = "Run the deterministic sandbox write probe.";
-            const turn = buildTurnStartParams(params, {
-              threadId: thread.thread.id,
-              cwd,
-              appServer,
-              preserveNativeTurnSettings: true,
-            });
-            await request("turn/start", turn);
-            expect(await completed).toMatchObject({ status: "completed" });
-            expect(approvals).toBe(0);
-            expect(requestCount).toBe(2);
-            if (excluded) {
-              expect(commandOutput).toMatch(/Operation not permitted|Permission denied/);
-            }
-            for (const [index, target] of targets.entries()) {
-              const writable = index === 0 || !excluded;
-              expect(commandOutput).toContain(`write-${index}:${writable ? "ok" : "denied"}`);
-              if (writable) {
-                expect(await fs.readFile(target, "utf8")).toBe("proof");
-              } else {
-                await expect(fs.access(target)).rejects.toMatchObject({ code: "ENOENT" });
-              }
-            }
-            await expect(fs.access(path.join(codexHome, "auth.json"))).rejects.toMatchObject({
-              code: "ENOENT",
-            });
-          } finally {
-            lines.close();
-            expect(await closeCodexAppServerTransportAndWait(child)).toBe(true);
+      const server = http.createServer((req, res) => {
+        req.resume();
+        req.on("end", () => {
+          if (req.url !== "/v1/responses" || req.method !== "POST") {
+            res.writeHead(404).end();
+            return;
           }
-        },
+          requestCount += 1;
+          const script = targets
+            .map(
+              (target, index) =>
+                `if printf proof > '${target}'; then printf 'write-${index}:ok\\n'; else printf 'write-${index}:denied\\n'; fi`,
+            )
+            .join("; ");
+          const item =
+            requestCount === 1
+              ? {
+                  type: "function_call",
+                  call_id: "write-probe",
+                  name: "exec_command",
+                  arguments: JSON.stringify({
+                    cmd: script,
+                    shell: "/bin/sh",
+                    login: false,
+                    max_output_tokens: 1000,
+                  }),
+                }
+              : {
+                  type: "message",
+                  role: "assistant",
+                  id: "done",
+                  content: [{ type: "output_text", text: "Probe complete." }],
+                };
+          const events = [
+            { type: "response.created", response: { id: `response-${requestCount}` } },
+            { type: "response.output_item.done", item },
+            {
+              type: "response.completed",
+              response: {
+                id: `response-${requestCount}`,
+                usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
+              },
+            },
+          ];
+          res.writeHead(200, { "Content-Type": "text/event-stream" });
+          res.end(
+            events
+              .map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
+              .join(""),
+          );
+        });
+      });
+      // Vitest deadlines do not unwind a stalled callback. Finish hooks own teardown
+      // in reverse order: native child, provider server, then temporary directories.
+      context.onTestFinished(async () => {
+        server.closeAllConnections();
+        if (server.listening) {
+          await new Promise<void>((resolve, reject) => {
+            server.close((error) => (error ? reject(error) : resolve()));
+          });
+        }
+      });
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Loopback fixture has no TCP address");
+      }
+      const config = [
+        'model="gpt-5.6-luna"',
+        'model_provider="loopback-fixture"',
+        'sandbox_mode="workspace-write"',
+        'approval_policy="on-request"',
+        'approvals_reviewer="user"',
+        'cli_auth_credentials_store="ephemeral"',
+        'web_search="disabled"',
+        "allow_login_shell=false",
+        "[features]",
+        "respect_system_proxy=false",
+        "shell_snapshot=false",
+        "code_mode=false",
+        "code_mode_only=false",
+        "[analytics]",
+        "enabled=false",
+        "[feedback]",
+        "enabled=false",
+        "[model_providers.loopback-fixture]",
+        'name="Loopback test fixture"',
+        `base_url="http://127.0.0.1:${address.port}/v1"`,
+        'wire_api="responses"',
+        "requires_openai_auth=false",
+        "supports_websockets=false",
+      ].join("\n");
+      await fs.writeFile(path.join(codexHome, "config.toml"), config);
+      const child = createStdioTransport(
+        { transport: "stdio", command, commandSource: "config", args, cwd, headers: {} },
+        { ...env, PATH: "/usr/bin:/bin", SHELL: "/bin/sh" },
       );
+      const lines = createInterface({ input: child.stdout });
+      context.onTestFinished(async () => {
+        lines.close();
+        expect(await closeCodexAppServerTransportAndWait(child)).toBe(true);
+      });
+      const pending = new Map<
+        number,
+        { resolve: (value: unknown) => void; reject: (error: Error) => void }
+      >();
+      let nextId = 0;
+      let approvals = 0;
+      let commandOutput = "";
+      const { promise: completed, resolve: finishTurn } = createDeferred<unknown>();
+      const send = (message: object) => child.stdin.write(`${JSON.stringify(message)}\n`);
+      const request = (method: string, params: object) =>
+        new Promise<unknown>((resolve, reject) => {
+          const id = ++nextId;
+          pending.set(id, { resolve, reject });
+          send({ id, method, params });
+        });
+      child.stdin.on("error", () => {});
+      child.stderr.resume();
+      child.once("close", () => {
+        for (const waiter of pending.values()) {
+          waiter.reject(new Error("Native child closed"));
+        }
+      });
+      lines.on("line", (line) => {
+        const message = JSON.parse(line) as {
+          id?: number;
+          method?: string;
+          result?: unknown;
+          error?: unknown;
+          params?: { item?: { type: string; aggregatedOutput?: string }; turn?: unknown };
+        };
+        if (message.method && message.id !== undefined) {
+          approvals += 1;
+          send({
+            id: message.id,
+            result:
+              message.method === "item/permissions/requestApproval"
+                ? { permissions: {}, scope: "turn" }
+                : { decision: "decline" },
+          });
+        } else if (message.id !== undefined) {
+          const waiter = pending.get(message.id);
+          pending.delete(message.id);
+          if (message.error) {
+            waiter?.reject(new Error(JSON.stringify(message.error)));
+          } else {
+            waiter?.resolve(message.result);
+          }
+        } else if (
+          message.method === "item/completed" &&
+          message.params?.item?.type === "commandExecution"
+        ) {
+          commandOutput += message.params.item.aggregatedOutput ?? "";
+        } else if (message.method === "turn/completed") {
+          finishTurn(message.params?.turn);
+        }
+      });
+      const initialized = await request("initialize", {
+        clientInfo: { name: "openclaw_sandbox_test", version: "1.0.0" },
+        capabilities: { experimentalApi: true },
+      });
+      expect(initialized).toMatchObject({
+        userAgent: expect.stringContaining(`/${CODEX_APP_SERVER_VERSION} `),
+      });
+      send({ method: "initialized", params: {} });
+      const thread = (await request("thread/start", {
+        cwd,
+        model: "gpt-5.6-luna",
+        modelProvider: "loopback-fixture",
+        approvalPolicy: "on-request",
+        approvalsReviewer: "user",
+        sandbox: "workspace-write",
+        ephemeral: true,
+      })) as { thread: { id: string }; sandbox: unknown };
+      expect(thread.sandbox).toMatchObject({
+        type: "workspaceWrite",
+        excludeTmpdirEnvVar: excluded,
+        excludeSlashTmp: excluded,
+      });
+      const appServer = resolveCodexAppServerRuntimeOptions({
+        env: {},
+        codexConfigToml: null,
+        requirementsToml: null,
+        pluginConfig: {
+          appServer: {
+            command,
+            args,
+            sandbox: "workspace-write",
+            approvalPolicy: "on-request",
+            approvalsReviewer: "user",
+          },
+        },
+      });
+      const params = createCodexUserInputTestParams();
+      params.prompt = "Run the deterministic sandbox write probe.";
+      const turn = buildTurnStartParams(params, {
+        threadId: thread.thread.id,
+        cwd,
+        appServer,
+        preserveNativeTurnSettings: true,
+      });
+      await request("turn/start", turn);
+      expect(await completed).toMatchObject({ status: "completed" });
+      expect(approvals).toBe(0);
+      expect(requestCount).toBe(2);
+      if (excluded) {
+        expect(commandOutput).toMatch(/Operation not permitted|Permission denied/);
+      }
+      for (const [index, target] of targets.entries()) {
+        const writable = index === 0 || !excluded;
+        expect(commandOutput).toContain(`write-${index}:${writable ? "ok" : "denied"}`);
+        if (writable) {
+          expect(await fs.readFile(target, "utf8")).toBe("proof");
+        } else {
+          await expect(fs.access(target)).rejects.toMatchObject({ code: "ENOENT" });
+        }
+      }
+      await expect(fs.access(path.join(codexHome, "auth.json"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
     },
   );
 });

--- a/extensions/codex/src/app-server/transport-stdio.sandbox.test.ts
+++ b/extensions/codex/src/app-server/transport-stdio.sandbox.test.ts
@@ -1,12 +1,11 @@
 import fs from "node:fs/promises";
-import http from "node:http";
-import { createRequire } from "node:module";
-import os from "node:os";
 import path from "node:path";
 import { createInterface } from "node:readline";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { useAutoCleanupTempDirTracker, withServer } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it, vi } from "vitest";
 import { resolveCodexAppServerRuntimeOptions } from "./config.js";
-import { resolveManagedCodexNativeCommand } from "./managed-binary.js";
+import { createCodexNativeTestState } from "./native-app-server.test-support.js";
 import { createStdioTransport } from "./transport-stdio.js";
 import { closeCodexAppServerTransportAndWait } from "./transport.js";
 import { buildTurnStartParams } from "./turn-params.js";
@@ -53,17 +52,11 @@ describe.skipIf(process.platform !== "darwin")("native Codex turn sandbox", () =
     "keeps temporary-root exclusions at the native execution boundary: $name",
     { timeout: 75_000 },
     async ({ args, excluded }, context) => {
-      const root = await fs.realpath(
-        await fs.mkdtemp(path.join(os.tmpdir(), "codex-turn-sandbox-")),
-      );
-      context.onTestFinished(() => fs.rm(root, { recursive: true, force: true }));
-      const slashTmp = await fs.realpath(await fs.mkdtemp("/tmp/codex-turn-denied-"));
-      context.onTestFinished(() => fs.rm(slashTmp, { recursive: true, force: true }));
-      const cwd = path.join(root, "workspace");
-      const home = path.join(root, "home");
-      const codexHome = path.join(home, ".codex");
-      const tmp = path.join(root, "tmp");
-      await Promise.all([cwd, codexHome, tmp].map((dir) => fs.mkdir(dir, { recursive: true })));
+      const tempDirs = useAutoCleanupTempDirTracker(context.onTestFinished);
+      const root = tempDirs.make("codex-turn-sandbox-");
+      const slashTmpRoot = await fs.realpath("/tmp");
+      const slashTmp = tempDirs.make("codex-turn-denied-", slashTmpRoot);
+      const { cwd, codexHome, tmp, command, env } = await createCodexNativeTestState(root);
       const targets = [
         path.join(cwd, "workspace.txt"),
         path.join(slashTmp, "slash-tmp.txt"),
@@ -75,264 +68,217 @@ describe.skipIf(process.platform !== "darwin")("native Codex turn sandbox", () =
         await fs.unlink(target);
       }
       let requestCount = 0;
-      const server = http.createServer((req, res) => {
-        req.resume();
-        req.on("end", () => {
-          if (req.url !== "/v1/responses" || req.method !== "POST") {
-            res.writeHead(404).end();
-            return;
-          }
-          requestCount += 1;
-          const script = targets
-            .map(
-              (target, index) =>
-                `if printf proof > '${target}'; then printf 'write-${index}:ok\\n'; else printf 'write-${index}:denied\\n'; fi`,
-            )
-            .join("; ");
-          const item =
-            requestCount === 1
-              ? {
-                  type: "function_call",
-                  call_id: "write-probe",
-                  name: "exec_command",
-                  arguments: JSON.stringify({
-                    cmd: script,
-                    shell: "/bin/sh",
-                    login: false,
-                    max_output_tokens: 1000,
-                  }),
-                }
-              : {
-                  type: "message",
-                  role: "assistant",
-                  id: "done",
-                  content: [{ type: "output_text", text: "Probe complete." }],
-                };
-          const events = [
-            { type: "response.created", response: { id: `response-${requestCount}` } },
-            { type: "response.output_item.done", item },
-            {
-              type: "response.completed",
-              response: {
-                id: `response-${requestCount}`,
-                usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
+      await withServer(
+        (req, res) => {
+          req.resume();
+          req.on("end", () => {
+            if (req.url !== "/v1/responses" || req.method !== "POST") {
+              res.writeHead(404).end();
+              return;
+            }
+            requestCount += 1;
+            const script = targets
+              .map(
+                (target, index) =>
+                  `if printf proof > '${target}'; then printf 'write-${index}:ok\\n'; else printf 'write-${index}:denied\\n'; fi`,
+              )
+              .join("; ");
+            const item =
+              requestCount === 1
+                ? {
+                    type: "function_call",
+                    call_id: "write-probe",
+                    name: "exec_command",
+                    arguments: JSON.stringify({
+                      cmd: script,
+                      shell: "/bin/sh",
+                      login: false,
+                      max_output_tokens: 1000,
+                    }),
+                  }
+                : {
+                    type: "message",
+                    role: "assistant",
+                    id: "done",
+                    content: [{ type: "output_text", text: "Probe complete." }],
+                  };
+            const events = [
+              { type: "response.created", response: { id: `response-${requestCount}` } },
+              { type: "response.output_item.done", item },
+              {
+                type: "response.completed",
+                response: {
+                  id: `response-${requestCount}`,
+                  usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
+                },
               },
-            },
-          ];
-          res.writeHead(200, { "Content-Type": "text/event-stream" });
-          res.end(
-            events
-              .map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
-              .join(""),
-          );
-        });
-      });
-      context.onTestFinished(async () => {
-        server.closeAllConnections();
-        if (server.listening) {
-          await new Promise<void>((resolve, reject) => {
-            server.close((error) => (error ? reject(error) : resolve()));
+            ];
+            res.writeHead(200, { "Content-Type": "text/event-stream" });
+            res.end(
+              events
+                .map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
+                .join(""),
+            );
           });
-        }
-      });
-      await new Promise<void>((resolve) => {
-        server.listen(0, "127.0.0.1", resolve);
-      });
-      const address = server.address();
-      if (!address || typeof address === "string") {
-        throw new Error("Loopback fixture has no TCP address");
-      }
-      const config = [
-        'model="gpt-5.6-luna"',
-        'model_provider="loopback-fixture"',
-        'sandbox_mode="workspace-write"',
-        'approval_policy="on-request"',
-        'approvals_reviewer="user"',
-        'cli_auth_credentials_store="ephemeral"',
-        'web_search="disabled"',
-        "allow_login_shell=false",
-        "[features]",
-        "respect_system_proxy=false",
-        "shell_snapshot=false",
-        "code_mode=false",
-        "code_mode_only=false",
-        "[analytics]",
-        "enabled=false",
-        "[feedback]",
-        "enabled=false",
-        "[model_providers.loopback-fixture]",
-        'name="Loopback test fixture"',
-        `base_url="http://127.0.0.1:${address.port}/v1"`,
-        'wire_api="responses"',
-        "requires_openai_auth=false",
-        "supports_websockets=false",
-      ].join("\n");
-      await fs.writeFile(path.join(codexHome, "config.toml"), config);
-      const require = createRequire(import.meta.url);
-      const launcher = path.join(
-        path.dirname(require.resolve("@openai/codex/package.json")),
-        "bin/codex.js",
-      );
-      const command = resolveManagedCodexNativeCommand(launcher);
-      if (!command) {
-        throw new Error("Pinned native Codex package is required");
-      }
-      const proxy = "http://127.0.0.1:9";
-      const env = {
-        PATH: "/usr/bin:/bin",
-        HOME: home,
-        USERPROFILE: home,
-        CODEX_HOME: codexHome,
-        TMPDIR: tmp,
-        TMP: tmp,
-        TEMP: tmp,
-        SHELL: "/bin/sh",
-        XDG_CONFIG_HOME: path.join(home, ".config"),
-        XDG_DATA_HOME: path.join(home, ".local/share"),
-        XDG_STATE_HOME: path.join(home, ".local/state"),
-        XDG_CACHE_HOME: path.join(home, ".cache"),
-        HTTP_PROXY: proxy,
-        HTTPS_PROXY: proxy,
-        ALL_PROXY: proxy,
-        http_proxy: proxy,
-        https_proxy: proxy,
-        all_proxy: proxy,
-        NO_PROXY: "127.0.0.1,localhost,::1",
-        no_proxy: "127.0.0.1,localhost,::1",
-      };
-      const child = createStdioTransport(
-        { transport: "stdio", command, commandSource: "config", args, cwd, headers: {} },
-        env,
-      );
-      const lines = createInterface({ input: child.stdout });
-      context.onTestFinished(async () => {
-        lines.close();
-        expect(await closeCodexAppServerTransportAndWait(child)).toBe(true);
-      });
-      const pending = new Map<
-        number,
-        { resolve: (value: unknown) => void; reject: (error: Error) => void }
-      >();
-      let nextId = 0;
-      let approvals = 0;
-      let commandOutput = "";
-      let finishTurn: (value: unknown) => void = () => {};
-      const completed = new Promise<unknown>((resolve) => {
-        finishTurn = resolve;
-      });
-      const send = (message: object) => child.stdin.write(`${JSON.stringify(message)}\n`);
-      const request = (method: string, params: object) =>
-        new Promise<unknown>((resolve, reject) => {
-          const id = ++nextId;
-          pending.set(id, { resolve, reject });
-          send({ id, method, params });
-        });
-      child.stdin.on("error", () => {});
-      child.stderr.resume();
-      child.once("close", () => {
-        for (const waiter of pending.values()) {
-          waiter.reject(new Error("Native child closed"));
-        }
-      });
-      lines.on("line", (line) => {
-        const message = JSON.parse(line) as {
-          id?: number;
-          method?: string;
-          result?: unknown;
-          error?: unknown;
-          params?: { item?: { type: string; aggregatedOutput?: string }; turn?: unknown };
-        };
-        if (message.method && message.id !== undefined) {
-          approvals += 1;
-          send({
-            id: message.id,
-            result:
-              message.method === "item/permissions/requestApproval"
-                ? { permissions: {}, scope: "turn" }
-                : { decision: "decline" },
-          });
-        } else if (message.id !== undefined) {
-          const waiter = pending.get(message.id);
-          pending.delete(message.id);
-          if (message.error) {
-            waiter?.reject(new Error(JSON.stringify(message.error)));
-          } else {
-            waiter?.resolve(message.result);
-          }
-        } else if (
-          message.method === "item/completed" &&
-          message.params?.item?.type === "commandExecution"
-        ) {
-          commandOutput += message.params.item.aggregatedOutput ?? "";
-        } else if (message.method === "turn/completed") {
-          finishTurn(message.params?.turn);
-        }
-      });
-      const initialized = await request("initialize", {
-        clientInfo: { name: "openclaw_sandbox_test", version: "1.0.0" },
-        capabilities: { experimentalApi: true },
-      });
-      expect(initialized).toMatchObject({
-        userAgent: expect.stringContaining(`/${CODEX_APP_SERVER_VERSION} `),
-      });
-      send({ method: "initialized", params: {} });
-      const thread = (await request("thread/start", {
-        cwd,
-        model: "gpt-5.6-luna",
-        modelProvider: "loopback-fixture",
-        approvalPolicy: "on-request",
-        approvalsReviewer: "user",
-        sandbox: "workspace-write",
-        ephemeral: true,
-      })) as { thread: { id: string }; sandbox: unknown };
-      expect(thread.sandbox).toMatchObject({
-        type: "workspaceWrite",
-        excludeTmpdirEnvVar: excluded,
-        excludeSlashTmp: excluded,
-      });
-      const appServer = resolveCodexAppServerRuntimeOptions({
-        env: {},
-        codexConfigToml: null,
-        requirementsToml: null,
-        pluginConfig: {
-          appServer: {
-            command,
-            args,
-            sandbox: "workspace-write",
-            approvalPolicy: "on-request",
-            approvalsReviewer: "user",
-          },
         },
-      });
-      const params = createCodexUserInputTestParams();
-      params.prompt = "Run the deterministic sandbox write probe.";
-      const turn = buildTurnStartParams(params, {
-        threadId: thread.thread.id,
-        cwd,
-        appServer,
-        preserveNativeTurnSettings: true,
-      });
-      await request("turn/start", turn);
-      expect(await completed).toMatchObject({ status: "completed" });
-      expect(approvals).toBe(0);
-      expect(requestCount).toBe(2);
-      expect(commandOutput).toContain("write-0:ok");
-      expect(await fs.readFile(targets[0], "utf8")).toBe("proof");
-      for (const [index, target] of targets.entries()) {
-        if (index === 0) {
-          continue;
-        }
-        expect(commandOutput).toContain(`write-${index}:${excluded ? "denied" : "ok"}`);
-        if (excluded) {
-          expect(commandOutput).toMatch(/Operation not permitted|Permission denied/);
-          await expect(fs.access(target)).rejects.toMatchObject({ code: "ENOENT" });
-        } else {
-          expect(await fs.readFile(target, "utf8")).toBe("proof");
-        }
-      }
-      await expect(fs.access(path.join(codexHome, "auth.json"))).rejects.toMatchObject({
-        code: "ENOENT",
-      });
+        async (baseUrl) => {
+          const config = [
+            'model="gpt-5.6-luna"',
+            'model_provider="loopback-fixture"',
+            'sandbox_mode="workspace-write"',
+            'approval_policy="on-request"',
+            'approvals_reviewer="user"',
+            'cli_auth_credentials_store="ephemeral"',
+            'web_search="disabled"',
+            "allow_login_shell=false",
+            "[features]",
+            "respect_system_proxy=false",
+            "shell_snapshot=false",
+            "code_mode=false",
+            "code_mode_only=false",
+            "[analytics]",
+            "enabled=false",
+            "[feedback]",
+            "enabled=false",
+            "[model_providers.loopback-fixture]",
+            'name="Loopback test fixture"',
+            `base_url="${baseUrl}/v1"`,
+            'wire_api="responses"',
+            "requires_openai_auth=false",
+            "supports_websockets=false",
+          ].join("\n");
+          await fs.writeFile(path.join(codexHome, "config.toml"), config);
+          const child = createStdioTransport(
+            { transport: "stdio", command, commandSource: "config", args, cwd, headers: {} },
+            { ...env, PATH: "/usr/bin:/bin", SHELL: "/bin/sh" },
+          );
+          const lines = createInterface({ input: child.stdout });
+          try {
+            const pending = new Map<
+              number,
+              { resolve: (value: unknown) => void; reject: (error: Error) => void }
+            >();
+            let nextId = 0;
+            let approvals = 0;
+            let commandOutput = "";
+            const { promise: completed, resolve: finishTurn } = createDeferred<unknown>();
+            const send = (message: object) => child.stdin.write(`${JSON.stringify(message)}\n`);
+            const request = (method: string, params: object) =>
+              new Promise<unknown>((resolve, reject) => {
+                const id = ++nextId;
+                pending.set(id, { resolve, reject });
+                send({ id, method, params });
+              });
+            child.stdin.on("error", () => {});
+            child.stderr.resume();
+            child.once("close", () => {
+              for (const waiter of pending.values()) {
+                waiter.reject(new Error("Native child closed"));
+              }
+            });
+            lines.on("line", (line) => {
+              const message = JSON.parse(line) as {
+                id?: number;
+                method?: string;
+                result?: unknown;
+                error?: unknown;
+                params?: { item?: { type: string; aggregatedOutput?: string }; turn?: unknown };
+              };
+              if (message.method && message.id !== undefined) {
+                approvals += 1;
+                send({
+                  id: message.id,
+                  result:
+                    message.method === "item/permissions/requestApproval"
+                      ? { permissions: {}, scope: "turn" }
+                      : { decision: "decline" },
+                });
+              } else if (message.id !== undefined) {
+                const waiter = pending.get(message.id);
+                pending.delete(message.id);
+                if (message.error) {
+                  waiter?.reject(new Error(JSON.stringify(message.error)));
+                } else {
+                  waiter?.resolve(message.result);
+                }
+              } else if (
+                message.method === "item/completed" &&
+                message.params?.item?.type === "commandExecution"
+              ) {
+                commandOutput += message.params.item.aggregatedOutput ?? "";
+              } else if (message.method === "turn/completed") {
+                finishTurn(message.params?.turn);
+              }
+            });
+            const initialized = await request("initialize", {
+              clientInfo: { name: "openclaw_sandbox_test", version: "1.0.0" },
+              capabilities: { experimentalApi: true },
+            });
+            expect(initialized).toMatchObject({
+              userAgent: expect.stringContaining(`/${CODEX_APP_SERVER_VERSION} `),
+            });
+            send({ method: "initialized", params: {} });
+            const thread = (await request("thread/start", {
+              cwd,
+              model: "gpt-5.6-luna",
+              modelProvider: "loopback-fixture",
+              approvalPolicy: "on-request",
+              approvalsReviewer: "user",
+              sandbox: "workspace-write",
+              ephemeral: true,
+            })) as { thread: { id: string }; sandbox: unknown };
+            expect(thread.sandbox).toMatchObject({
+              type: "workspaceWrite",
+              excludeTmpdirEnvVar: excluded,
+              excludeSlashTmp: excluded,
+            });
+            const appServer = resolveCodexAppServerRuntimeOptions({
+              env: {},
+              codexConfigToml: null,
+              requirementsToml: null,
+              pluginConfig: {
+                appServer: {
+                  command,
+                  args,
+                  sandbox: "workspace-write",
+                  approvalPolicy: "on-request",
+                  approvalsReviewer: "user",
+                },
+              },
+            });
+            const params = createCodexUserInputTestParams();
+            params.prompt = "Run the deterministic sandbox write probe.";
+            const turn = buildTurnStartParams(params, {
+              threadId: thread.thread.id,
+              cwd,
+              appServer,
+              preserveNativeTurnSettings: true,
+            });
+            await request("turn/start", turn);
+            expect(await completed).toMatchObject({ status: "completed" });
+            expect(approvals).toBe(0);
+            expect(requestCount).toBe(2);
+            if (excluded) {
+              expect(commandOutput).toMatch(/Operation not permitted|Permission denied/);
+            }
+            for (const [index, target] of targets.entries()) {
+              const writable = index === 0 || !excluded;
+              expect(commandOutput).toContain(`write-${index}:${writable ? "ok" : "denied"}`);
+              if (writable) {
+                expect(await fs.readFile(target, "utf8")).toBe("proof");
+              } else {
+                await expect(fs.access(target)).rejects.toMatchObject({ code: "ENOENT" });
+              }
+            }
+            await expect(fs.access(path.join(codexHome, "auth.json"))).rejects.toMatchObject({
+              code: "ENOENT",
+            });
+          } finally {
+            lines.close();
+            expect(await closeCodexAppServerTransportAndWait(child)).toBe(true);
+          }
+        },
+      );
     },
   );
 });


### PR DESCRIPTION
Related: [native Codex launch and turn override repair](https://github.com/openclaw/openclaw/pull/131745).

## What Problem This Solves

Maintainer-requested cleanup of the native override repair. The repair preserved important CLI and sandbox contracts, but left duplicate reviewer-policy plumbing and repeated native-test setup. This follow-up reduces that maintenance cost without deleting the behavior or real-process proof.

## Why This Change Was Made

Validate provider identity before one unchanged full reviewer-trust inspection, deleting two private wrappers and duplicate configuration inspection. Select the two supported temporary-root exclusion keys before TOML decoding rather than decoding unrelated configuration on every workspace-write turn.

The tests share isolated child filesystem/environment/native-binary setup, use existing temp-directory and deferred helpers, and describe native invocations and expected configurations directly. Native child and server teardown remains owned by Vitest finish hooks: callback `finally` cannot clean up a turn suspended past the test deadline. All six native configuration cases and all three macOS kernel cases remain; no production test seam was added.

The lossless argument scanner and both normalization boundaries are intentionally unchanged. Auth decoration enforces ephemeral storage last; physical spawn also covers native-owned authentication. Reviewer trust still checks every authored endpoint override, including shadowed ones—not just effective last-wins configuration.

**Production LOC:** +12/-35, net **-23**. **Tests and test support:** +228/-283, net **-55**, including the new 47-line shared fixture. **Total:** **78 fewer lines**.

## User Impact

No intended user-visible behavior change. Existing override ordering, wrapper arguments, native-owned authentication, ephemeral credential enforcement, reviewer trust, bounded-turn filtering, and temporary-root exclusions remain intact. No new configuration, environment option, dependency, schema, protocol, runtime enablement, or deployment.

## Evidence

**Inspectable proof and review resolution:** [final native terminal output, failing-before/passing-after timeout cleanup, and direct pinned Codex/Vitest source verification](https://github.com/openclaw/openclaw/pull/131918#issuecomment-5455657847).

- Unchanged baseline: **9 native cases passed**.
- Refactor: **510 focused tests passed in 8 suites**, repeated successfully after the CI-repair rebase.
- Final teardown correction: **6 native configuration cases and 3 real macOS kernel cases passed**, plus test types, canonical lint, and fresh restricted Codex autoreview with no blocking P0 findings.
- A real stalled-provider probe reached the native turn and its actual Vitest deadline. The same cleanup assertion failed before the correction (child and listener still alive), then passed afterward (both closed before rescue, native exit code 0, 404 ms after the deadline). The diagnostic fixture used an 8-second deadline; the committed native tests retain 75 seconds.
- Both production/test type lanes and all changed gates passed. One SDK declaration-preparation timeout was resolved by retrying the unchanged lint command, then completing the remaining guards; no timeout or gate was weakened.

Focused command:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/codex/src/app-server/auth-bridge.test.ts extensions/codex/src/app-server/config.test.ts extensions/codex/src/app-server/app-server-policy.test.ts extensions/codex/src/app-server/bounded-turn.test.ts extensions/codex/src/app-server/thread-lifecycle.test.ts extensions/codex/src/app-server/transport-stdio.test.ts extensions/codex/src/app-server/transport-stdio.config.test.ts extensions/codex/src/app-server/transport-stdio.sandbox.test.ts
```

Native proof uses pinned `@openai/codex` 0.150.1 with fresh task-owned HOME/state and an explicitly allowlisted, credential-free environment. Only model Responses is replaced with loopback HTTP; turn processing, approval handling, execution, and kernel enforcement are real. Assertions retain writable pre-controls, native thread policy, completed turns, zero approvals, two provider requests on completed runs, each target's actual contents/absence, and no `auth.json`.

The lead personally inspected sibling Codex source at `90854393966b21e9ebfd21b122334eb09a20c93d`; exact parser, turn-policy, writable-root, and stdin-shutdown citations are in the proof comment. Installed Vitest 4.1.11 source was also inspected for deadline and finish-hook ordering.

CI recovery required retries after GitHub history/API failures, then rebasing onto the [already-landed workflow-lint stdin-deadlock repair](https://github.com/openclaw/openclaw/pull/131982). The rebase itself preserved the cleanup diff byte-for-byte. The later test-only correction restored timeout-safe teardown without changing production code. No UI changed, no operator state was accessed, and no real provider credentials or inference service were used.
