### PR TITLE
test(discord): remove retired voice fixture aliases

### DIFF
--- a/extensions/discord/src/voice/manager.e2e.test-support.ts
+++ b/extensions/discord/src/voice/manager.e2e.test-support.ts
@@ -5,43 +5,9 @@ import type {
 } from "openclaw/plugin-sdk/realtime-voice";
 import { vi } from "vitest";
 import { ChannelType } from "../internal/discord.js";
-import { createVoiceCaptureState } from "./capture-state.js";
-import { createVoiceReceiveRecoveryState } from "./receive-recovery.js";
 
 export type MockCallSource = {
   mock: { calls: ArrayLike<ReadonlyArray<unknown>> };
-};
-
-type TestRealtimeSpeakerTurn = {
-  close: () => void;
-  sendInputAudio: (audio: Buffer) => void;
-};
-
-export type TestRealtimeSessionEntry = {
-  capture: Omit<ReturnType<typeof createVoiceCaptureState>, "activeCaptureStreams"> & {
-    activeCaptureStreams: Map<string, { generation: number; stream: unknown }>;
-  };
-  guildName?: string;
-  pendingRealtime?: unknown;
-  player: {
-    on: ReturnType<typeof vi.fn>;
-    play: ReturnType<typeof vi.fn>;
-    state: { status: string };
-    stop: ReturnType<typeof vi.fn>;
-  };
-  playbackQueue: Promise<void>;
-  processingQueue: Promise<void>;
-  realtime?: {
-    beginSpeakerTurn: (
-      context: { extraSystemPrompt?: string; senderIsOwner: boolean; speakerLabel: string },
-      userId: string,
-    ) => TestRealtimeSpeakerTurn;
-  };
-  receiveRecovery: ReturnType<typeof createVoiceReceiveRecoveryState>;
-  route?: { agentId?: string; sessionKey?: string };
-  stop: () => void;
-  transcripts?: { onUtterance?: (...args: unknown[]) => unknown; sessionId: string };
-  voiceSessionKey: string;
 };
 
 export type TestRealtimeBridgeParams = {

--- a/extensions/discord/src/voice/realtime-consults.test.ts
+++ b/extensions/discord/src/voice/realtime-consults.test.ts
@@ -115,7 +115,10 @@ defineDiscordVoiceTests(
         };
       });
       const { bridgeParams, entry, manager } = await createJoinedAgentProxyFixture({ client });
-      const realtime = entry.realtime as unknown as {
+      if (entry.realtimeLifecycle.status !== "active") {
+        throw new Error("expected active Discord realtime session");
+      }
+      const realtime = entry.realtimeLifecycle.instance as unknown as {
         playback: { enqueueExactSpeechMessage: (text: string) => void };
       };
       const connection = (entry as unknown as { connection: { destroy: ReturnType<typeof vi.fn> } })
@@ -125,7 +128,11 @@ defineDiscordVoiceTests(
       expect(Buffer.byteLength(accepted, "utf8")).toBe(32 * 1024);
 
       await manager.join({ guildId: "g2", channelId: "2001" });
-      const siblingRealtime = getSessionEntry(manager, "g2").realtime as unknown as {
+      const siblingEntry = getSessionEntry(manager, "g2");
+      if (siblingEntry.realtimeLifecycle.status !== "active") {
+        throw new Error("expected active sibling Discord realtime session");
+      }
+      const siblingRealtime = siblingEntry.realtimeLifecycle.instance as unknown as {
         playback: { enqueueExactSpeechMessage: (text: string) => void };
       };
 
@@ -157,7 +164,10 @@ defineDiscordVoiceTests(
 
     it("terminates realtime voice when retained exact speech exceeds the message budget", async () => {
       const { entry, manager } = await createJoinedAgentProxyFixture();
-      const realtime = entry.realtime as unknown as {
+      if (entry.realtimeLifecycle.status !== "active") {
+        throw new Error("expected active Discord realtime session");
+      }
+      const realtime = entry.realtimeLifecycle.instance as unknown as {
         playback: { enqueueExactSpeechMessage: (text: string) => void };
       };
       const connection = (entry as unknown as { connection: { destroy: ReturnType<typeof vi.fn> } })
@@ -328,7 +338,10 @@ defineDiscordVoiceTests(
 
     it("terminally satisfies a late native call for a cancelled forced consult", async () => {
       const { bridgeParams, entry } = await createJoinedAgentProxyFixture();
-      const realtime = entry.realtime as unknown as {
+      if (entry.realtimeLifecycle.status !== "active") {
+        throw new Error("expected active Discord realtime session");
+      }
+      const realtime = entry.realtimeLifecycle.instance as unknown as {
         harness: RealtimeVoiceSessionHarness;
       };
       const cancelled = realtime.harness.forcedConsults.prepare("cancelled question");
@@ -548,7 +561,7 @@ defineDiscordVoiceTests(
         config: { voice: { realtime: { debounceMs: 1 } } },
       });
       const ownerTurn = beginSpeakerTurn(entry);
-      ownerTurn?.close();
+      ownerTurn.close();
       beginSpeakerTurn(entry, { senderIsOwner: false });
 
       await emitFinalRealtimeUserTranscript(bridgeParams, "guest question");
@@ -575,11 +588,7 @@ defineDiscordVoiceTests(
           },
         },
       });
-      const ownerTurn = entry?.realtime?.beginSpeakerTurn(
-        { extraSystemPrompt: undefined, senderIsOwner: true, speakerLabel: "Owner" },
-        "u-owner",
-      );
-      ownerTurn?.sendInputAudio(Buffer.alloc(8));
+      beginSpeakerTurn(entry);
 
       expect(bridgeParams?.autoRespondToAudio).toBe(true);
       expect(bridgeParams?.interruptResponseOnInputAudio).toBe(false);
@@ -694,16 +703,8 @@ defineDiscordVoiceTests(
           },
         },
       });
-      const nonOwnerTurn = entry?.realtime?.beginSpeakerTurn(
-        { extraSystemPrompt: undefined, senderIsOwner: false, speakerLabel: "Guest" },
-        "u-guest",
-      );
-      nonOwnerTurn?.sendInputAudio(Buffer.alloc(8));
-      const ownerTurn = entry?.realtime?.beginSpeakerTurn(
-        { extraSystemPrompt: undefined, senderIsOwner: true, speakerLabel: "Owner" },
-        "u-owner",
-      );
-      ownerTurn?.sendInputAudio(Buffer.alloc(8));
+      beginSpeakerTurn(entry, { senderIsOwner: false });
+      beginSpeakerTurn(entry);
 
       void bridgeParams?.onToolCall?.(
         {
@@ -739,7 +740,7 @@ defineDiscordVoiceTests(
         },
       });
       const ownerTurn = beginSpeakerTurn(entry);
-      ownerTurn?.close();
+      ownerTurn.close();
       beginSpeakerTurn(entry, { senderIsOwner: false });
 
       void bridgeParams?.onToolCall?.(

--- a/extensions/discord/src/voice/realtime-playback.test.ts
+++ b/extensions/discord/src/voice/realtime-playback.test.ts
@@ -53,11 +53,7 @@ defineDiscordVoiceTests(
 
       expect(result.ok).toBe(true);
       const entry = getSessionEntry(manager);
-      const ownerTurn = entry?.realtime?.beginSpeakerTurn(
-        { extraSystemPrompt: undefined, senderIsOwner: true, speakerLabel: "Owner" },
-        "u-owner",
-      );
-      ownerTurn?.sendInputAudio(Buffer.alloc(8));
+      beginSpeakerTurn(entry);
       const providerOptions = requireRecord(
         lastMockCall(
           resolveConfiguredRealtimeVoiceProviderMock as unknown as MockCallSource,
@@ -226,7 +222,10 @@ defineDiscordVoiceTests(
 
     it("does not require speaker context for internal exact-speech consults", async () => {
       const { bridgeParams, entry } = await createJoinedAgentProxyFixture();
-      const realtime = entry.realtime as unknown as {
+      if (entry.realtimeLifecycle.status !== "active") {
+        throw new Error("expected active Discord realtime session");
+      }
+      const realtime = entry.realtimeLifecycle.instance as unknown as {
         playback: { enqueueExactSpeechMessage: (text: string) => void };
       };
       realtime.playback.enqueueExactSpeechMessage("already answered");
@@ -423,7 +422,10 @@ defineDiscordVoiceTests(
 
     it("drains a complete 6.8-second provider burst in order after backpressure and response completion", async () => {
       const { bridgeParams, entry, manager, player } = await createJoinedAgentProxyFixture();
-      const realtime = entry.realtime as unknown as {
+      if (entry.realtimeLifecycle.status !== "active") {
+        throw new Error("expected active Discord realtime session");
+      }
+      const realtime = entry.realtimeLifecycle.instance as unknown as {
         playback: { currentOutputStream: () => PassThrough | null };
       };
       // Real provider chunks are 400 ms; Discord's consumer has not drained any yet.
@@ -452,7 +454,10 @@ defineDiscordVoiceTests(
 
     it("does not let a cancelled response's drain resume or end a later response", async () => {
       const { bridgeParams, entry, manager, player } = await createJoinedAgentProxyFixture();
-      const realtime = entry.realtime as unknown as {
+      if (entry.realtimeLifecycle.status !== "active") {
+        throw new Error("expected active Discord realtime session");
+      }
+      const realtime = entry.realtimeLifecycle.instance as unknown as {
         playback: { currentOutputStream: () => PassThrough | null };
       };
       for (let index = 0; index < 17; index += 1) {
@@ -478,7 +483,10 @@ defineDiscordVoiceTests(
 
     it("releases queued speech after an encoder failure without waiting for a missing idle event", async () => {
       const { bridgeParams, entry, manager, player } = await createJoinedAgentProxyFixture();
-      const realtime = entry.realtime as unknown as {
+      if (entry.realtimeLifecycle.status !== "active") {
+        throw new Error("expected active Discord realtime session");
+      }
+      const realtime = entry.realtimeLifecycle.instance as unknown as {
         playback: { enqueueExactSpeechMessage: (text: string) => void };
       };
       realtime.playback.enqueueExactSpeechMessage("first answer");
@@ -515,7 +523,12 @@ defineDiscordVoiceTests(
       ],
     ])("retires each response once and plays a later response", async (outcome, terminalType) => {
       const { bridgeParams, entry, manager, player } = await createJoinedAgentProxyFixture();
-      const realtime = entry.realtime as unknown as { harness: RealtimeVoiceSessionHarness };
+      if (entry.realtimeLifecycle.status !== "active") {
+        throw new Error("expected active Discord realtime session");
+      }
+      const realtime = entry.realtimeLifecycle.instance as unknown as {
+        harness: RealtimeVoiceSessionHarness;
+      };
 
       bridgeParams.onEvent?.({
         direction: "server",

--- a/extensions/discord/src/voice/realtime-turns.test.ts
+++ b/extensions/discord/src/voice/realtime-turns.test.ts
@@ -120,19 +120,11 @@ defineDiscordVoiceTests(
       const { bridgeParams, entry } = await createJoinedAgentProxyFixture({
         config: { voice: { realtime: { debounceMs: 1 } } },
       });
-      const nonOwnerTurn = entry?.realtime?.beginSpeakerTurn(
-        { extraSystemPrompt: undefined, senderIsOwner: false, speakerLabel: "Guest" },
-        "u-guest",
-      );
-      nonOwnerTurn?.sendInputAudio(Buffer.alloc(8));
+      beginSpeakerTurn(entry, { senderIsOwner: false });
 
       await flushRealtimeForcedConsultTimers(() => {
         bridgeParams?.onTranscript?.("user", "non-owner question", true);
-        const ownerTurn = entry?.realtime?.beginSpeakerTurn(
-          { extraSystemPrompt: undefined, senderIsOwner: true, speakerLabel: "Owner" },
-          "u-owner",
-        );
-        ownerTurn?.sendInputAudio(Buffer.alloc(8));
+        beginSpeakerTurn(entry);
       });
 
       expect(realtimeSessionMock.handleBargeIn).not.toHaveBeenCalled();

--- a/extensions/discord/src/voice/segment.test.ts
+++ b/extensions/discord/src/voice/segment.test.ts
@@ -11,6 +11,7 @@ defineDiscordVoiceTests(
     createManager,
     entersStateMock,
     getSessionEntry,
+    getLastAudioPlayer,
     getVoiceReceive,
     lastTtsStreamArgs,
     loggerWarnMock,
@@ -209,6 +210,7 @@ defineDiscordVoiceTests(
         );
         await manager.join({ guildId: "g1", channelId: "1001" });
         const entry = getSessionEntry(manager);
+        const player = getLastAudioPlayer();
         entersStateMock.mockImplementation(async (_target, state, signal) => {
           if (state === (buffering ? "playing" : "idle")) {
             await new Promise<void>((_resolve, reject) => {
@@ -222,8 +224,8 @@ defineDiscordVoiceTests(
             });
           }
         });
-        entry.player.stop.mockImplementation(() => {
-          const idleHandler = entry.player.on.mock.calls.find(([event]) => event === "idle")?.[1];
+        player.stop.mockImplementation(() => {
+          const idleHandler = player.on.mock.calls.find(([event]) => event === "idle")?.[1];
           idleHandler?.();
           return true;
         });
@@ -246,7 +248,7 @@ defineDiscordVoiceTests(
         expect((await manager.leave({ guildId: "g1" })).ok).toBe(true);
         await entry.playbackQueue;
 
-        expect(entry.player.stop).toHaveBeenCalledOnce();
+        expect(player.stop).toHaveBeenCalledOnce();
         expect(release).toHaveBeenCalledOnce();
         expect(loggerWarnMock).not.toHaveBeenCalledWith(
           expect.stringContaining("discord voice: playback failed"),

--- a/extensions/discord/src/voice/voice-receive.test.ts
+++ b/extensions/discord/src/voice/voice-receive.test.ts
@@ -1,9 +1,10 @@
 import type { Readable } from "node:stream";
-import type { MockCallSource, TestRealtimeSessionEntry } from "./manager.e2e.test-support.js";
+import type { MockCallSource } from "./manager.e2e.test-support.js";
 import { defineDiscordVoiceTests } from "./voice-test-harness.test-support.js";
 
 defineDiscordVoiceTests(
   ({
+    PassThrough,
     VoiceOpcodes,
     expect,
     it,
@@ -27,6 +28,7 @@ defineDiscordVoiceTests(
     createFollowManager,
     expectConnectedStatus,
     getSessionEntry,
+    getLastAudioPlayer,
     getVoiceReceive,
     getVoiceFollowing,
     emitDecryptFailure,
@@ -79,7 +81,7 @@ defineDiscordVoiceTests(
         throw new Error("expected voice session for guild g1");
       }
       expect(entry.player.state.status).toBe("idle");
-      entry.player.state.status = "playing";
+      getLastAudioPlayer().state.status = "playing";
 
       await handleSpeakingStart(manager, entry, "u-denied");
 
@@ -207,9 +209,7 @@ defineDiscordVoiceTests(
       const manager = createManager();
 
       await manager.join({ guildId: "g1", channelId: "1001" });
-      const entry = getSessionEntry(manager) as TestRealtimeSessionEntry & {
-        sessionLifecycle: { status: "active" } | { status: "stopped"; reason: string };
-      };
+      const entry = getSessionEntry(manager);
       entry.sessionLifecycle = { status: "stopped", reason: "test" };
 
       emitDecryptFailure(manager);
@@ -839,7 +839,8 @@ defineDiscordVoiceTests(
 
         const entry = getSessionEntry(manager);
 
-        const firstStream = { destroy: vi.fn() };
+        const firstStream = new PassThrough();
+        const destroyFirstStream = vi.spyOn(firstStream, "destroy");
         entry.capture.activeSpeakers.add("u1");
         entry.capture.captureGenerations.set("u1", 1);
         entry.capture.activeCaptureStreams.set("u1", { generation: 1, stream: firstStream });
@@ -848,7 +849,7 @@ defineDiscordVoiceTests(
 
         await vi.advanceTimersByTimeAsync(2_500);
 
-        expect(firstStream.destroy).toHaveBeenCalledTimes(1);
+        expect(destroyFirstStream).toHaveBeenCalledTimes(1);
         expect(entry?.capture.activeSpeakers.has("u1")).toBe(false);
 
         const secondStream = {

--- a/extensions/discord/src/voice/voice-runtime.e2e.test.ts
+++ b/extensions/discord/src/voice/voice-runtime.e2e.test.ts
@@ -37,6 +37,7 @@ defineDiscordVoiceTests(
     makeVoiceConfig,
     createFollowManager,
     getSessionEntry,
+    getLastAudioPlayer,
     getVoiceReceive,
     beginSpeakerTurn,
     lastAgentCommandArgs,
@@ -78,7 +79,7 @@ defineDiscordVoiceTests(
         expect.objectContaining({ end: { behavior: "Manual" } }),
       );
       expect(agentCommandMock).toHaveBeenCalledOnce();
-      expect(entry.player.play).toHaveBeenCalledOnce();
+      expect(getLastAudioPlayer().play).toHaveBeenCalledOnce();
       expect((await manager.leave({ guildId: "g1" })).ok).toBe(true);
       expect(manager.status()).toEqual([]);
     });
@@ -414,7 +415,7 @@ defineDiscordVoiceTests(
       await entry.playbackQueue;
 
       expect(textToSpeechMock).toHaveBeenCalledOnce();
-      expect(entry.player.play).toHaveBeenCalledOnce();
+      expect(getLastAudioPlayer().play).toHaveBeenCalledOnce();
       expect(
         loggerWarnMock.mock.calls
           .map(([message]) => String(message))
@@ -463,7 +464,7 @@ defineDiscordVoiceTests(
       await entry.processingQueue;
       await entry.playbackQueue;
 
-      expect(entry.player.play).not.toHaveBeenCalled();
+      expect(getLastAudioPlayer().play).not.toHaveBeenCalled();
       expect(release).toHaveBeenCalledOnce();
     });
 
@@ -789,7 +790,7 @@ defineDiscordVoiceTests(
       await entry.processingQueue;
 
       expect(transcribeAudioFileMock).not.toHaveBeenCalled();
-      expect(entry.player.play).not.toHaveBeenCalled();
+      expect(getLastAudioPlayer().play).not.toHaveBeenCalled();
     });
 
     it("keeps followed-user voice state last-event-wins across a pending join", async () => {

--- a/extensions/discord/src/voice/voice-session.lifecycle.test.ts
+++ b/extensions/discord/src/voice/voice-session.lifecycle.test.ts
@@ -26,6 +26,7 @@ defineDiscordVoiceTests(
     createAgentProxyManager,
     expectConnectedStatus,
     getSessionEntry,
+    beginSpeakerTurn,
     getVoiceReceive,
     getLastAudioPlayer,
     expectOffEventWithFunction,
@@ -214,6 +215,7 @@ defineDiscordVoiceTests(
       });
 
       const entry = getSessionEntry(manager);
+      expect(entry.realtimeLifecycle.status).toBe("inactive");
       let resolveRealtimeReady!: () => void;
       const realtimeReady = new Promise<undefined>((resolve) => {
         resolveRealtimeReady = () => resolve(undefined);
@@ -223,7 +225,7 @@ defineDiscordVoiceTests(
       const upgrade = manager.join({ guildId: "g1", channelId: "1001" });
 
       await vi.waitFor(() => expect(createRealtimeVoiceBridgeSessionMock).toHaveBeenCalledTimes(1));
-      expect(entry.realtime).toBeUndefined();
+      expect(entry.realtimeLifecycle.status).toBe("starting");
 
       resolveRealtimeReady();
       const result = await upgrade;
@@ -237,7 +239,7 @@ defineDiscordVoiceTests(
         onStop,
         onUtterance,
       });
-      expect(entry.realtime).toBeTruthy();
+      expect(entry.realtimeLifecycle.status).toBe("active");
       const attempts = getVoiceReceive(manager).daveRecoveryAttempts;
       attempts.set("g1", Date.now());
 
@@ -249,7 +251,7 @@ defineDiscordVoiceTests(
       expect(stopNotesResult.ok).toBe(true);
       expect(entry.transcripts).toBeUndefined();
       expect(onStop).toHaveBeenCalledOnce();
-      expect(entry.realtime).toBeTruthy();
+      expect(entry.realtimeLifecycle.status).toBe("active");
       expect(realtimeSessionMock.close).not.toHaveBeenCalled();
       expect(attempts.has("g1")).toBe(true);
       expectConnectedStatus(manager, "1001");
@@ -278,20 +280,18 @@ defineDiscordVoiceTests(
       const upgrade = manager.join({ guildId: "g1", channelId: "1001" });
 
       await vi.waitFor(() => expect(createRealtimeVoiceBridgeSessionMock).toHaveBeenCalledTimes(1));
-      expect(entry.pendingRealtime).toBeTruthy();
-      expect(entry.realtime).toBeUndefined();
+      expect(entry.realtimeLifecycle.status).toBe("starting");
 
       entry.stop();
       expect(realtimeSessionMock.close).toHaveBeenCalled();
-      expect(entry.pendingRealtime).toBeUndefined();
-      expect(entry.realtime).toBeUndefined();
+      expect(entry.realtimeLifecycle.status).toBe("stopped");
 
       resolveRealtimeReady();
       const result = await upgrade;
 
       expect(result.ok).toBe(false);
       expect(result.message).toContain("stopped before startup completed");
-      expect(entry.realtime).toBeUndefined();
+      expect(entry.realtimeLifecycle.status).toBe("stopped");
     });
 
     it("detaches transcripts without leaving voice during pending realtime upgrade", async () => {
@@ -327,15 +327,13 @@ defineDiscordVoiceTests(
       expect(stopNotesResult.ok).toBe(true);
       expect(entry.transcripts).toBeUndefined();
       expect(onStop).toHaveBeenCalledOnce();
-      expect(entry.pendingRealtime).toBeTruthy();
-      expect(entry.realtime).toBeUndefined();
+      expect(entry.realtimeLifecycle.status).toBe("starting");
 
       resolveRealtimeReady();
       const result = await upgrade;
 
       expect(result.ok).toBe(true);
-      expect(entry.pendingRealtime).toBeUndefined();
-      expect(entry.realtime).toBeTruthy();
+      expect(entry.realtimeLifecycle.status).toBe("active");
       expectConnectedStatus(manager, "1001");
     });
 
@@ -397,11 +395,7 @@ defineDiscordVoiceTests(
       expect(realtimeSessionMock.close).not.toHaveBeenCalled();
       expect(player.stop).toHaveBeenCalledTimes(stopCallsBeforeTranscripts);
 
-      const turn = entry.realtime?.beginSpeakerTurn(
-        { extraSystemPrompt: undefined, senderIsOwner: true, speakerLabel: "Owner" },
-        "u-owner",
-      );
-      turn?.sendInputAudio(Buffer.alloc(3840));
+      const turn = beginSpeakerTurn(entry, { initialAudio: Buffer.alloc(3840) });
       bridgeParams?.onTranscript?.("user", "meeting note transcript", true);
 
       await vi.waitFor(() =>
@@ -420,7 +414,7 @@ defineDiscordVoiceTests(
           }),
         ),
       );
-      turn?.close();
+      turn.close();
     });
 
     it("destroys stale tracked voice connections before joining", async () => {
@@ -651,13 +645,10 @@ defineDiscordVoiceTests(
           },
         },
       });
-      const turn = entry.realtime?.beginSpeakerTurn(
-        { extraSystemPrompt: undefined, senderIsOwner: true, speakerLabel: "Owner" },
-        "u1",
-      );
+      const turn = beginSpeakerTurn(entry, { userId: "u1", initialAudio: null });
 
       bridgeParams?.audioSink?.sendAudio(Buffer.alloc(480));
-      turn?.sendInputAudio(Buffer.alloc(3840));
+      turn.sendInputAudio(Buffer.alloc(3840));
 
       expect(realtimeSessionMock.setMediaTimestamp).toHaveBeenCalledWith(0);
       expect(realtimeSessionMock.setMediaTimestamp).toHaveBeenCalledWith(10);
@@ -687,12 +678,7 @@ defineDiscordVoiceTests(
           },
         },
       });
-      const turn = entry.realtime?.beginSpeakerTurn(
-        { extraSystemPrompt: undefined, senderIsOwner: true, speakerLabel: "Owner" },
-        "u1",
-      );
-
-      turn?.sendInputAudio(Buffer.alloc(3840));
+      beginSpeakerTurn(entry, { userId: "u1", initialAudio: Buffer.alloc(3840) });
 
       expect(realtimeSessionMock.handleBargeIn).not.toHaveBeenCalled();
       expect(player.stop).not.toHaveBeenCalled();
@@ -712,13 +698,8 @@ defineDiscordVoiceTests(
           },
         },
       });
-      const turn = entry.realtime?.beginSpeakerTurn(
-        { extraSystemPrompt: undefined, senderIsOwner: true, speakerLabel: "Owner" },
-        "u1",
-      );
-
-      turn?.sendInputAudio(Buffer.alloc(3840));
-      turn?.close();
+      const turn = beginSpeakerTurn(entry, { userId: "u1", initialAudio: Buffer.alloc(3840) });
+      turn.close();
 
       expect(realtimeSessionMock.sendAudio).toHaveBeenCalledTimes(2);
       const trailingSilence = realtimeSessionMock.sendAudio.mock.calls.at(-1)?.[0] as
@@ -742,13 +723,8 @@ defineDiscordVoiceTests(
           },
         },
       });
-      const turn = entry.realtime?.beginSpeakerTurn(
-        { extraSystemPrompt: undefined, senderIsOwner: true, speakerLabel: "Owner" },
-        "u1",
-      );
-
-      turn?.sendInputAudio(Buffer.alloc(3840));
-      turn?.close();
+      const turn = beginSpeakerTurn(entry, { userId: "u1", initialAudio: Buffer.alloc(3840) });
+      turn.close();
 
       const trailingSilence = realtimeSessionMock.sendAudio.mock.calls.at(-1)?.[0] as
         | Buffer

--- a/extensions/discord/src/voice/voice-session.terminal.test.ts
+++ b/extensions/discord/src/voice/voice-session.terminal.test.ts
@@ -72,7 +72,7 @@ defineDiscordVoiceTests(
           provider.onClose?.(reason);
 
           expect(manager.status()).toEqual([]);
-          expect(entry.realtime).toBeUndefined();
+          expect(entry.realtimeLifecycle.status).toBe("stopped");
           expect(entry.transcripts).toBeUndefined();
           expect(onStop).toHaveBeenCalledExactlyOnceWith(undefined);
           expect(captureStream.destroy).toHaveBeenCalledOnce();
@@ -104,8 +104,8 @@ defineDiscordVoiceTests(
             { transcripts: replacementTranscripts },
           );
           const inputCalls = realtimeSessionMock.sendAudio.mock.calls.length;
-          turn?.sendInputAudio(Buffer.alloc(3840));
-          turn?.close();
+          turn.sendInputAudio(Buffer.alloc(3840));
+          turn.close();
           provider.onClose?.(reason);
           provider.onReady?.();
           provider.onEvent?.({ direction: "client", type: "session.reconnect.ready" });

--- a/extensions/discord/src/voice/voice-test-harness.test-support.ts
+++ b/extensions/discord/src/voice/voice-test-harness.test-support.ts
@@ -15,9 +15,9 @@ import {
   type MockCallSource,
   requireRecord,
   type TestRealtimeBridgeParams,
-  type TestRealtimeSessionEntry,
 } from "./manager.e2e.test-support.js";
 import { createVoiceReceiveRecoveryState, DECRYPT_FAILURE_WINDOW_MS } from "./receive-recovery.js";
+import type { VoiceRealtimeSpeakerContext, VoiceSessionEntry } from "./session.js";
 import { voiceTestMocks } from "./voice-test-mocks.test-support.js";
 
 const {
@@ -257,38 +257,12 @@ function buildVoiceTestHarness() {
   const getSessionEntry = (
     manager: InstanceType<typeof managerModule.DiscordVoiceManager>,
     guildId = "g1",
-  ): TestRealtimeSessionEntry => {
-    const entry = (
-      manager as unknown as { sessions: Map<string, TestRealtimeSessionEntry> }
-    ).sessions.get(guildId);
+  ): VoiceSessionEntry => {
+    const entry = (manager as unknown as { sessions: Map<string, VoiceSessionEntry> }).sessions.get(
+      guildId,
+    );
     if (!entry) {
       throw new Error(`expected Discord voice session for guild ${guildId}`);
-    }
-    if (!Object.hasOwn(entry, "realtime")) {
-      const realtimeLifecycle = () =>
-        (
-          entry as unknown as {
-            realtimeLifecycle:
-              | { status: "inactive" | "stopped" }
-              | { status: "starting" | "active"; instance: unknown };
-          }
-        ).realtimeLifecycle;
-      Object.defineProperties(entry, {
-        pendingRealtime: {
-          configurable: true,
-          get: () => {
-            const lifecycle = realtimeLifecycle();
-            return lifecycle.status === "starting" ? lifecycle.instance : undefined;
-          },
-        },
-        realtime: {
-          configurable: true,
-          get: () => {
-            const lifecycle = realtimeLifecycle();
-            return lifecycle.status === "active" ? lifecycle.instance : undefined;
-          },
-        },
-      });
     }
     return entry;
   };
@@ -319,16 +293,18 @@ function buildVoiceTestHarness() {
     ).following;
 
   const beginSpeakerTurn = (
-    entry: TestRealtimeSessionEntry,
-    params: {
-      extraSystemPrompt?: string;
-      senderIsOwner?: boolean;
-      speakerLabel?: string;
+    entry: VoiceSessionEntry,
+    params: Partial<VoiceRealtimeSpeakerContext> & {
       userId?: string;
+      initialAudio?: Buffer | null;
     } = {},
   ) => {
+    const lifecycle = entry.realtimeLifecycle;
+    if (lifecycle.status !== "active") {
+      throw new Error(`expected active Discord realtime session, got ${lifecycle.status}`);
+    }
     const senderIsOwner = params.senderIsOwner ?? true;
-    const turn = entry.realtime?.beginSpeakerTurn(
+    const turn = lifecycle.instance.beginSpeakerTurn(
       {
         extraSystemPrompt: params.extraSystemPrompt,
         senderIsOwner,
@@ -336,7 +312,10 @@ function buildVoiceTestHarness() {
       },
       params.userId ?? (senderIsOwner ? "u-owner" : "u-guest"),
     );
-    turn?.sendInputAudio(Buffer.alloc(8));
+    // Null preserves cases that start provider output before sending the first speaker audio.
+    if (params.initialAudio !== null) {
+      turn.sendInputAudio(params.initialAudio ?? Buffer.alloc(8));
+    }
     return turn;
   };
 


### PR DESCRIPTION
Related: [capture preservation through voice reconnects](https://github.com/openclaw/openclaw/pull/130860) and [terminal provider closure cleanup](https://github.com/openclaw/openclaw/pull/131548).

## What Problem This Solves

Maintainer-requested test-fixture cleanup: Discord voice tests were recreating retired `realtime` and `pendingRealtime` entry fields with an `Object.defineProperties` shim. That let fixtures continue using a parallel, weaker session shape rather than the lifecycle union used by production, obscuring the actual startup and teardown checkpoints.

## Why This Change Was Made

`getSessionEntry` now returns the production `VoiceSessionEntry` without mutating it. The duplicate `TestRealtimeSessionEntry` and speaker-turn shape are removed. Tests inspect `realtimeLifecycle` directly, and the existing `beginSpeakerTurn` helper narrows the active state and derives speaker context from production types. Existing mock handles supply mock-only operations instead of widening production types; the capture fixture uses a real stream with a recorded spy.

All existing tests are retained. Startup, terminal, reconnect, replacement, recording, speaker identity, exact audio buffers, and assertion/event ordering are preserved. The helper explicitly supports starting a turn without sending initial audio for the existing output-before-input regression.

Current `main` at `117078fedbf` and capture-preservation head `c3421dfcb6b37a8c5a3f14848623d0cb51f3fb58` both retained the aliases before this edit. [Coordination note](https://github.com/openclaw/openclaw/pull/130860#issuecomment-5454368522): this PR does not modify the capture-preservation branch or its runtime ownership work; its overlapping fixture changes will need the same canonical access when refreshed.

## User Impact

No user-visible or production behavior change. No configuration, schema, dependency, protocol, storage, or deployed-instance changes. No live production actions. This removes obsolete test scaffolding, not a public compatibility contract.

AI-assisted.

## Evidence

Before and after: **29 files / 321 tests passed**, including focused Discord voice and registered-provider transcript integration coverage. The unchanged real manager/provider/tool/SQLite transcript lifecycle integration additionally passed **3 tests**, proving replacement retirement, historical notes, finalization, and stale-provider isolation.

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs extensions/discord/src/voice test/transcripts-tool.discord-provider.integration.test.ts
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs test/transcripts-tool.discord-lifecycle.integration.test.ts
```

```bash
git diff --name-only -z | xargs -0 env OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/check-changed.mjs --
```

```bash
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo
```

Targeted formatting and `git diff --check` passed. The changed gate passed extension test types, typed lint for the initial nine files, plugin boundaries, ratchets, zero dead exports, and five doctor-contract guard tests. Full CI then identified four additional unbound-player assertions in the separate voice E2E consumer; these now use the same existing recorded player mock. All assertions and their ordering are retained. Typed lint of the entire Discord voice owner, including the E2E file, subsequently passed:

```bash
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/discord/src/voice/
```

Fresh independent Codex autoreview of the complete final ten-file diff reported no blocking findings. Manual test-audit/diff review checked preserved behavior and ordering.

**Clean Linux proof:** the final patch passed all **30 voice E2E tests plus 3 real transcript lifecycle integration tests**, with the normal E2E build prerequisite enabled, on provider `blacksmith-testbox`, lease `tbx_01m14rfs18t8pgxj44se5t8mtt`. [Backing Testbox run](https://github.com/openclaw/openclaw/actions/runs/33197324669). The wrapper returned `exitCode: 0`, `runStatus: succeeded`, and stopped the one-shot Testbox successfully. Blacksmith owns the delegated lease lifecycle, so its backing Actions step can appear cancelled after cleanup; the command verdict and timing JSON are the proof.

```bash
node scripts/crabbox-wrapper.mjs run --timing-json -- env CI=1 OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs extensions/discord/src/voice/voice-runtime.e2e.test.ts test/transcripts-tool.discord-lifecycle.integration.test.ts
```

Local proof gaps are recorded rather than hidden: an initial real-lifecycle run was stopped before test results (exit 143), then the unchanged suite passed locally. The separate E2E attempt hit an unrelated local `werift` / `@noble/curves` artifact-build mismatch. Using the existing focused-fixture build-skip option reached the source tests, but local cold tool-inventory construction timed out and a real-I/O wait was flaky under load. No dependency, timeout, assertion, runtime, or test-environment change was made to obtain the final clean-Linux pass; it used normal build setup and the exact unchanged fixtures. This is source/E2E integration evidence, not a claimed live Discord conversation.

ClawSweeper's requested exact-head failure attribution is addressed: the previous API-report and core-test-type failures were Git fetch timeouts before their checks ran; lint identified the four E2E mock assertions fixed in the follow-up commit. Fresh exact-head CI is required before landing.

Production LOC: **+0/-0**. Tests: **+87/-101**. Test support: **+17/-72**. Total: **-69 lines across ten test/support files**, with no removed test cases or new test-only production seams.
