### PR TITLE
fix(media): stop losing generated artifacts when the final delivery handoff fails

### DIFF
--- a/docs/automation/tasks.md
+++ b/docs/automation/tasks.md
@@ -159,6 +159,8 @@ result instead of misreporting the child execution as failed.
 Use `openclaw tasks list --status blocked` to find these tasks. They also remain
 in `--status succeeded` results because the underlying execution succeeded, and
 JSON output preserves the stored status plus the `blocked` terminal outcome.
+Blocked media-generation tasks retain bounded attachment references in the task
+result; use **Copy result** in the Control UI or `openclaw tasks show <lookup>`.
 
 Agent run completion is authoritative for active task records. A successful detached run finalizes as `succeeded`, ordinary run errors finalize as `failed`, timeouts finalize as `timed_out`, and cancel/abort outcomes finalize as `cancelled`. Once a task is terminal, later lifecycle signals do not downgrade it - an operator-cancelled or already-`failed`/`timed_out`/`lost` task stays that way even if a success signal arrives afterwards.
 

--- a/src/agents/tools/media-generate-background-completion.ts
+++ b/src/agents/tools/media-generate-background-completion.ts
@@ -1,0 +1,171 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import type { RequiredCompletionTerminalResult } from "../../tasks/task-completion-contract.js";
+import type { DeliveryContext } from "../../utils/delivery-context.types.js";
+import {
+  formatGeneratedAttachmentLines,
+  mediaUrlsFromGeneratedAttachments,
+  type AgentGeneratedAttachment,
+} from "../generated-attachments.js";
+import { formatAgentInternalEventsForPrompt, type AgentInternalEvent } from "../internal-events.js";
+import { deliverSubagentAnnouncement } from "../subagents/announce/subagent-announce-delivery.js";
+
+const log = createSubsystemLogger("agents/tools/media-generate-background-completion");
+// Only blocked results missed the requester; retain references instead of resending.
+// Match task-summary.ts TASK_RESULT_MAX_CHARS so authorized reads keep the full payload.
+const MEDIA_GENERATION_RETAINED_RESULT_MAX_CHARS = 4_000;
+
+export type MediaGenerationTaskHandle = {
+  taskId: string;
+  runId: string;
+  requesterSessionKey: string;
+  requesterAgentId?: string;
+  requesterOrigin?: DeliveryContext;
+  taskLabel: string;
+};
+
+export type MediaGenerationCompletionWakeOutcome =
+  | { status: "delivered" }
+  | { status: "pending" }
+  | { status: "permanent_failure" };
+
+export function retainBlockedMediaReferences(
+  terminalResult: RequiredCompletionTerminalResult | undefined,
+  attachments: AgentGeneratedAttachment[] | undefined,
+): RequiredCompletionTerminalResult | undefined {
+  if (terminalResult?.terminalOutcome !== "blocked") {
+    return terminalResult;
+  }
+  const referenceLines = formatGeneratedAttachmentLines(attachments);
+  if (referenceLines.length === 0) {
+    return terminalResult;
+  }
+  const terminalSummary = [
+    terminalResult.terminalSummary,
+    "Retained generated media:",
+    ...referenceLines,
+  ]
+    .filter((line): line is string => Boolean(line))
+    .join("\n");
+  return {
+    ...terminalResult,
+    terminalSummary: truncateUtf16Safe(terminalSummary, MEDIA_GENERATION_RETAINED_RESULT_MAX_CHARS),
+  };
+}
+
+function buildMediaGenerationReplyInstruction(params: {
+  status: "ok" | "error";
+  completionLabel: string;
+}) {
+  if (params.status === "ok") {
+    return [
+      `The ${params.completionLabel} is ready for the original chat.`,
+      "Follow the current visible-reply contract with a short user-facing caption and every structured generated attachment from this event.",
+      "Keep internal task/session details private and do not copy the internal event text verbatim.",
+    ].join(" ");
+  }
+  return [
+    `${params.completionLabel[0]?.toUpperCase() ?? "T"}${params.completionLabel.slice(1)} generation task failed for the original chat.`,
+    "Follow the current visible-reply contract with a concise user-facing failure message.",
+    "Keep internal task/session details private and do not copy the internal event text verbatim.",
+  ].join(" ");
+}
+
+export async function wakeMediaGenerationTaskCompletion(params: {
+  config?: OpenClawConfig;
+  handle: MediaGenerationTaskHandle | null;
+  status: "ok" | "error";
+  statusLabel: string;
+  result: string;
+  attachments?: AgentGeneratedAttachment[];
+  mediaUrls?: string[];
+  statsLine?: string;
+  eventSource: AgentInternalEvent["source"];
+  announceType: string;
+  toolName: string;
+  completionLabel: string;
+}): Promise<MediaGenerationCompletionWakeOutcome> {
+  if (!params.handle) {
+    return { status: "delivered" };
+  }
+  const announceId = `${params.toolName}:${params.handle.taskId}:${params.status}`;
+  const mediaUrls = Array.from(
+    new Set([
+      ...(params.mediaUrls ?? []),
+      ...mediaUrlsFromGeneratedAttachments(params.attachments),
+    ]),
+  );
+  const internalEvents: AgentInternalEvent[] = [
+    {
+      type: "task_completion",
+      source: params.eventSource,
+      childSessionKey: `${params.toolName}:${params.handle.taskId}`,
+      childSessionId: params.handle.taskId,
+      announceType: params.announceType,
+      taskLabel: params.handle.taskLabel,
+      status: params.status,
+      statusLabel: params.statusLabel,
+      result: params.result,
+      ...(params.attachments?.length ? { attachments: params.attachments } : {}),
+      ...(mediaUrls.length ? { mediaUrls } : {}),
+      ...(params.statsLine?.trim() ? { statsLine: params.statsLine } : {}),
+      replyInstruction: buildMediaGenerationReplyInstruction({
+        status: params.status,
+        completionLabel: params.completionLabel,
+      }),
+    },
+  ];
+  const triggerMessage =
+    formatAgentInternalEventsForPrompt(internalEvents) ||
+    `A ${params.completionLabel} generation task finished. Process the completion update now.`;
+  const delivery = await deliverSubagentAnnouncement({
+    requesterSessionKey: params.handle.requesterSessionKey,
+    requesterAgentId: params.handle.requesterAgentId,
+    targetRequesterSessionKey: params.handle.requesterSessionKey,
+    announceId,
+    triggerMessage,
+    steerMessage: triggerMessage,
+    internalEvents,
+    summaryLine: params.handle.taskLabel,
+    requesterSessionOrigin: params.handle.requesterOrigin,
+    requesterOrigin: params.handle.requesterOrigin,
+    completionDirectOrigin: params.handle.requesterOrigin,
+    directOrigin: params.handle.requesterOrigin,
+    sourceSessionKey: `${params.toolName}:${params.handle.taskId}`,
+    sourceTool: params.toolName,
+    requesterIsSubagent: false,
+    expectsCompletionMessage: true,
+    bestEffortDeliver: true,
+    directIdempotencyKey: announceId,
+  });
+  if (delivery.delivered) {
+    return { status: "delivered" };
+  }
+  if (
+    delivery.disposition === "session_queued" ||
+    delivery.reason === "completion_handoff_pending"
+  ) {
+    return { status: "pending" };
+  }
+  if (delivery.disposition === "ambiguous") {
+    log.warn("Media generation completion delivery stopped after terminal fallback", {
+      taskId: params.handle.taskId,
+      runId: params.handle.runId,
+      toolName: params.toolName,
+      error: delivery.error,
+    });
+    // Send evidence makes another attempt unsafe even when the transport's
+    // terminal acknowledgment failed, so settle without risking a duplicate.
+    return { status: "delivered" };
+  }
+  if (delivery.error) {
+    log.error("Media generation completion wake failed; requester session was not woken", {
+      taskId: params.handle.taskId,
+      runId: params.handle.runId,
+      toolName: params.toolName,
+      error: delivery.error,
+    });
+  }
+  return { status: "permanent_failure" };
+}

--- a/src/agents/tools/media-generate-background-shared.test.ts
+++ b/src/agents/tools/media-generate-background-shared.test.ts
@@ -355,6 +355,7 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
         model: "gpt-image-1",
         count: 1,
         wakeResult: "generated",
+        attachments: [{ type: "image" as const, path: "/tmp/proof.png" }],
       }),
     });
 
@@ -400,6 +401,7 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
         model: "gpt-image-1",
         count: 1,
         wakeResult: "generated",
+        attachments: [{ type: "image" as const, path: "/tmp/proof.png" }],
         mediaUrls: ["/tmp/proof.png"],
       }),
     });
@@ -410,6 +412,7 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
     expect(detachedTaskRuntimeMocks.completeTaskRunByRunId).toHaveBeenCalledWith(
       expect.objectContaining({
         terminalOutcome: "blocked",
+        terminalSummary: expect.stringContaining('path="/tmp/proof.png"'),
       }),
     );
     expect(
@@ -671,6 +674,7 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
         model: "gpt-image-1",
         count: 1,
         wakeResult: "generated",
+        attachments: [{ type: "image" as const, path: "/tmp/proof.png" }],
       }),
     });
 
@@ -689,8 +693,7 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
         count: 1,
         terminalResult: {
           terminalOutcome: "blocked",
-          terminalSummary:
-            "Required completion delivery failed before reaching the requester: requester wake failed.",
+          terminalSummary: expect.stringContaining('path="/tmp/proof.png"'),
         },
       }),
     );

--- a/src/agents/tools/media-generate-background-shared.ts
+++ b/src/agents/tools/media-generate-background-shared.ts
@@ -28,32 +28,23 @@ import {
   type RequiredCompletionTerminalResult,
 } from "../../tasks/task-completion-contract.js";
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
-import {
-  mediaUrlsFromGeneratedAttachments,
-  type AgentGeneratedAttachment,
-} from "../generated-attachments.js";
-import { formatAgentInternalEventsForPrompt, type AgentInternalEvent } from "../internal-events.js";
+import type { AgentGeneratedAttachment } from "../generated-attachments.js";
+import type { AgentInternalEvent } from "../internal-events.js";
 import { MEDIA_GENERATION_DELIVERING_COMPLETION_PROGRESS } from "../media-generation-task-status-shared.js";
-import {
-  deliverSubagentAnnouncement,
-  loadRequesterSessionEntry,
-} from "../subagents/announce/subagent-announce-delivery.js";
+import { loadRequesterSessionEntry } from "../subagents/announce/subagent-announce-delivery.js";
 import { resolveAnnounceOrigin } from "../subagents/announce/subagent-announce-origin.js";
+import {
+  type MediaGenerationCompletionWakeOutcome,
+  type MediaGenerationTaskHandle,
+  retainBlockedMediaReferences,
+  wakeMediaGenerationTaskCompletion,
+} from "./media-generate-background-completion.js";
+export type { MediaGenerationTaskHandle } from "./media-generate-background-completion.js";
 
 const log = createSubsystemLogger("agents/tools/media-generate-background-shared");
 const MEDIA_GENERATION_TASK_KEEPALIVE_INTERVAL_MS = 60_000;
 const MEDIA_GENERATION_COMPLETION_HANDOFF_RETRY_DELAYS_MS = [250, 500, 1_000, 2_000] as const;
 const MEDIA_GENERATION_COMPLETION_HANDOFF_TIMEOUT_MS = 120_000;
-
-/** Handle for a detached media generation task registered in the task ledger. */
-export type MediaGenerationTaskHandle = {
-  taskId: string;
-  runId: string;
-  requesterSessionKey: string;
-  requesterAgentId?: string;
-  requesterOrigin?: DeliveryContext;
-  taskLabel: string;
-};
 
 /** Schedules detached media generation work. */
 export type MediaGenerateBackgroundScheduler = (work: () => Promise<void>) => void;
@@ -143,11 +134,6 @@ type WakeMediaGenerationTaskCompletionParams = {
   mediaUrls?: string[];
   statsLine?: string;
 };
-
-type MediaGenerationCompletionWakeOutcome =
-  | { status: "delivered" }
-  | { status: "pending" }
-  | { status: "permanent_failure" };
 
 type MediaGenerationTaskLifecycle = {
   createTaskRun: (params: CreateMediaGenerationTaskRunParams) => MediaGenerationTaskHandle | null;
@@ -383,24 +369,6 @@ function failMediaGenerationTaskRun(params: {
   }
 }
 
-function buildMediaGenerationReplyInstruction(params: {
-  status: "ok" | "error";
-  completionLabel: string;
-}) {
-  if (params.status === "ok") {
-    return [
-      `The ${params.completionLabel} is ready for the original chat.`,
-      "Follow the current visible-reply contract with a short user-facing caption and every structured generated attachment from this event.",
-      "Keep internal task/session details private and do not copy the internal event text verbatim.",
-    ].join(" ");
-  }
-  return [
-    `${params.completionLabel[0]?.toUpperCase() ?? "T"}${params.completionLabel.slice(1)} generation task failed for the original chat.`,
-    "Follow the current visible-reply contract with a concise user-facing failure message.",
-    "Keep internal task/session details private and do not copy the internal event text verbatim.",
-  ].join(" ");
-}
-
 /** Creates the default microtask scheduler for detached media generation jobs. */
 export function createDefaultMediaGenerateBackgroundScheduler(params: {
   toolName: string;
@@ -580,6 +548,7 @@ export function scheduleMediaGenerationTaskCompletion<
         },
       );
     }
+    terminalResult = retainBlockedMediaReferences(terminalResult, executed.attachments);
     try {
       params.lifecycle.completeTaskRun({
         handle: params.handle,
@@ -602,104 +571,6 @@ export function scheduleMediaGenerationTaskCompletion<
   };
   // Detached completion needs its own transcript lock after the parent attempt exits.
   params.scheduleBackgroundWork(() => runWithoutOwnedSessionTranscriptWrites(runBackgroundWork));
-}
-
-async function wakeMediaGenerationTaskCompletion(params: {
-  config?: OpenClawConfig;
-  handle: MediaGenerationTaskHandle | null;
-  status: "ok" | "error";
-  statusLabel: string;
-  result: string;
-  attachments?: AgentGeneratedAttachment[];
-  mediaUrls?: string[];
-  statsLine?: string;
-  eventSource: AgentInternalEvent["source"];
-  announceType: string;
-  toolName: string;
-  completionLabel: string;
-}): Promise<MediaGenerationCompletionWakeOutcome> {
-  if (!params.handle) {
-    return { status: "delivered" };
-  }
-  const announceId = `${params.toolName}:${params.handle.taskId}:${params.status}`;
-  const mediaUrls = Array.from(
-    new Set([
-      ...(params.mediaUrls ?? []),
-      ...mediaUrlsFromGeneratedAttachments(params.attachments),
-    ]),
-  );
-  const internalEvents: AgentInternalEvent[] = [
-    {
-      type: "task_completion",
-      source: params.eventSource,
-      childSessionKey: `${params.toolName}:${params.handle.taskId}`,
-      childSessionId: params.handle.taskId,
-      announceType: params.announceType,
-      taskLabel: params.handle.taskLabel,
-      status: params.status,
-      statusLabel: params.statusLabel,
-      result: params.result,
-      ...(params.attachments?.length ? { attachments: params.attachments } : {}),
-      ...(mediaUrls.length ? { mediaUrls } : {}),
-      ...(params.statsLine?.trim() ? { statsLine: params.statsLine } : {}),
-      replyInstruction: buildMediaGenerationReplyInstruction({
-        status: params.status,
-        completionLabel: params.completionLabel,
-      }),
-    },
-  ];
-  const triggerMessage =
-    formatAgentInternalEventsForPrompt(internalEvents) ||
-    `A ${params.completionLabel} generation task finished. Process the completion update now.`;
-  const delivery = await deliverSubagentAnnouncement({
-    requesterSessionKey: params.handle.requesterSessionKey,
-    requesterAgentId: params.handle.requesterAgentId,
-    targetRequesterSessionKey: params.handle.requesterSessionKey,
-    announceId,
-    triggerMessage,
-    steerMessage: triggerMessage,
-    internalEvents,
-    summaryLine: params.handle.taskLabel,
-    requesterSessionOrigin: params.handle.requesterOrigin,
-    requesterOrigin: params.handle.requesterOrigin,
-    completionDirectOrigin: params.handle.requesterOrigin,
-    directOrigin: params.handle.requesterOrigin,
-    sourceSessionKey: `${params.toolName}:${params.handle.taskId}`,
-    sourceTool: params.toolName,
-    requesterIsSubagent: false,
-    expectsCompletionMessage: true,
-    bestEffortDeliver: true,
-    directIdempotencyKey: announceId,
-  });
-  if (delivery.delivered) {
-    return { status: "delivered" };
-  }
-  if (
-    delivery.disposition === "session_queued" ||
-    delivery.reason === "completion_handoff_pending"
-  ) {
-    return { status: "pending" };
-  }
-  if (delivery.disposition === "ambiguous") {
-    log.warn("Media generation completion delivery stopped after terminal fallback", {
-      taskId: params.handle.taskId,
-      runId: params.handle.runId,
-      toolName: params.toolName,
-      error: delivery.error,
-    });
-    // Send evidence makes another attempt unsafe even when the transport's
-    // terminal acknowledgment failed, so settle without risking a duplicate.
-    return { status: "delivered" };
-  }
-  if (delivery.error) {
-    log.error("Media generation completion wake failed; requester session was not woken", {
-      taskId: params.handle.taskId,
-      runId: params.handle.runId,
-      toolName: params.toolName,
-      error: delivery.error,
-    });
-  }
-  return { status: "permanent_failure" };
 }
 
 /** Creates a tool-specific detached media generation lifecycle facade. */

--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -39,6 +39,11 @@ import type { GatewayClient, RespondFn } from "./types.js";
 
 const stateDirEnvSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
 const cancelSessionMock = vi.fn();
+const mainSessionTaskScope = {
+  requesterSessionKey: "agent:main:main",
+  ownerKey: "agent:main:main",
+  scopeKind: "session",
+} as const;
 type TaskResponsePayload = {
   tasks?: Array<Record<string, unknown>>;
   task?: Record<string, unknown>;
@@ -642,9 +647,7 @@ describe("tasks gateway handlers", () => {
   it("gets completed tasks with stable completed status", async () => {
     const task = createTaskRecord({
       runtime: "cli",
-      requesterSessionKey: "agent:main:main",
-      ownerKey: "agent:main:main",
-      scopeKind: "session",
+      ...mainSessionTaskScope,
       runId: "run-completed",
       task: "Done task",
       status: "succeeded",
@@ -657,6 +660,8 @@ describe("tasks gateway handlers", () => {
     expect(payload?.task?.title).toBe("Done task");
     expect(payload?.task?.prompt).toBe("Done task");
   });
+
+  const cliStaleResult = { runtime: "cli", progressSummary: "CLI stale progress" } as const;
 
   it.each([
     {
@@ -682,17 +687,21 @@ describe("tasks gateway handlers", () => {
     },
     {
       label: "CLI completion",
-      runtime: "cli",
-      progressSummary: "CLI stale progress",
+      ...cliStaleResult,
       terminalSummary: "CLI canonical result",
       expected: "CLI canonical result",
     },
     {
       label: "CLI sanitized terminal result",
-      runtime: "cli",
-      progressSummary: "CLI stale progress",
+      ...cliStaleResult,
       terminalSummary: "Exec denied (gateway id=req-1, approval-timeout): bash -lc ls",
       expected: "Command did not run: approval timed out.",
+    },
+    {
+      label: "CLI blocked media references",
+      ...cliStaleResult,
+      terminalSummary: 'Delivery failed.\nRetained media: path="/tmp/proof.png"',
+      expected: 'Delivery failed. Retained media: path="/tmp/proof.png"',
     },
     {
       label: "cron progress fallback",
@@ -749,9 +758,7 @@ describe("tasks gateway handlers", () => {
   it("keeps bounded prompts lookup-only", async () => {
     const task = createTaskRecord({
       runtime: "cli",
-      requesterSessionKey: "agent:main:main",
-      ownerKey: "agent:main:main",
-      scopeKind: "session",
+      ...mainSessionTaskScope,
       task: `Inspect the task prompt ${"x".repeat(5_000)}`,
       status: "running",
       deliveryStatus: "pending",
@@ -777,9 +784,7 @@ describe("tasks gateway handlers", () => {
     ].join("\n");
     const task = createTaskRecord({
       runtime: "cli",
-      requesterSessionKey: "agent:main:main",
-      ownerKey: "agent:main:main",
-      scopeKind: "session",
+      ...mainSessionTaskScope,
       task: `${visiblePrompt}\n${INTERNAL_RUNTIME_CONTEXT_BEGIN}\nhidden\n${INTERNAL_RUNTIME_CONTEXT_END}`,
       status: "running",
       deliveryStatus: "pending",
@@ -793,9 +798,7 @@ describe("tasks gateway handlers", () => {
   it("sanitizes task text before exposing SDK summaries", async () => {
     const task = createTaskRecord({
       runtime: "cli",
-      requesterSessionKey: "agent:main:main",
-      ownerKey: "agent:main:main",
-      scopeKind: "session",
+      ...mainSessionTaskScope,
       runId: "run-sanitized",
       label:
         "Compile artifact\nOpenClaw runtime context (internal): Keep internal details private.",


### PR DESCRIPTION
**TL;DR:** generated image, video, and music references remain recoverable from the authorized task result when the final completion handoff is permanently blocked.

Closes #131900

## What Problem This Solves

Media generation can finish successfully while the final completion handoff fails. The shared lifecycle then finalized the task with only a generic blocked-delivery reason, discarding the structured attachment references that were already available at that owner boundary. The operator saw a failed task but had no path or filename to recover the generated output.

## Why This Change Was Made

The shared media completion lifecycle is the architectural owner. It now appends a bounded projection of the structured generated attachments only when delivery is blocked, before the canonical task record becomes terminal. Successful delivery remains byte-for-byte on its existing path.

The completion-delivery implementation moved from `src/agents/tools/media-generate-background-shared.ts` into `src/agents/tools/media-generate-background-completion.ts`, keeping one canonical task-handle type and one completion flow. It reuses the repository's existing attachment formatter, task ledger, authorized `tasks.get` projection, Tasks **Copy result** action, and `openclaw tasks show <lookup>` CLI surface. No custom artifact service, download RPC, retention queue, plugin, external platform, or paid service is needed.

## User Impact

If generated media cannot be handed back to the requester, the blocked task result retains a bounded attachment reference such as its generated path. Operators can copy the result in Control UI or inspect it with `openclaw tasks show <lookup>`. Image, music, and video generation share this lifecycle. Normal successful delivery is unchanged.

## Evidence

### Regression reproduction

On the pre-fix main baseline used for this repair, adding the recovery assertion made this focused case fail because the terminal summary did not contain `path="/tmp/proof.png"`:

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/agents/tools/media-generate-background-shared.test.ts -t 'records a blocked stale cron completion without raw media fallback'
```

Result: **1 failed, 26 skipped**, with the retained-path assertion missing. The same owner case passes after this repair, together with the thrown-wake blocked branch.

### Final-head validation

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 pnpm test src/agents/tools/media-generate-background-shared.test.ts src/gateway/server-methods/tasks.test.ts
```

Result: **59/59 passed** (27 media lifecycle, 32 Gateway task projection).

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/pages/tasks/tasks.e2e.test.ts
```

Result: **4/4 passed** against the built Control UI, including copying retained results through the fallback path.

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 pnpm check:changed
```

Result: **passed** on the rebased final tree, including formatting, policy ratchets, core and core-test typechecks, changed-file lint, dead exports, import cycles, and storage/media guards.

```sh
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --max-priority P1 --stream-engine-output
```

Result: **no accepted/actionable P0/P1 findings**; patch correct at 0.93 confidence.

### Visual proof

Before — the copied blocked result contains only the handoff failure and no recoverable media reference:

![Before: copied blocked task result in the Control UI chat composer without a generated path](https://github.com/user-attachments/assets/b028eddd-7b58-4b81-8c90-9d813b49b674)

After — the same browser proof carries the retained `path="/tmp/proof.png"` through the Tasks copy action into the real chat composer:

![After: copied blocked task result in the Control UI chat composer with the retained generated path](https://github.com/user-attachments/assets/06291622-9a7b-4842-ab28-df43995b3f1c)

The before/after captures used the mocked-Gateway Control UI proof harness to deterministically induce the otherwise rare permanent handoff failure. The committed UI fixture was restored unchanged after capture; the full existing Tasks E2E suite passes above.

### Scope and LOC

- Production TypeScript: **+182/-140 (net +42)**. The growth is the bounded retention capability plus an explicit completion-owner extraction from the oversized shared module.
- Tests: **+24/-18 (net +6)**, including the owner failure paths and authorized Gateway result projection. Repeated main-session fixture fields were consolidated to stay within the file's lint cap.
- Docs: **+2**.
- No protocol, config/default, UI implementation, dependency, plugin SDK, SQLite schema, or persistence-contract change.

## Landing notes

- Rebased the single repair commit onto current `origin/main`; the stale caller-controlled `sourceChannel` path is gone, matching the current completion contract.
- Removed the duplicate media task-handle type and retained one canonical definition.
- Added the bounded-retention invariant comment at the lifecycle owner, tied to the task-summary cap.
- Added the blocked-media case to the existing Gateway runtime-result projection table.
- Removed unused `wakeResult` test noise and aligned the implementation with structured attachments rather than reparsing wake text.
- Documented recovery through Tasks **Copy result** and `openclaw tasks show <lookup>`.
- Added the requested thrown-wake blocked branch while preserving the existing stale-cron permanent-handoff regression.
- Audited test value: reverted fixture-only UI churn, retained the behavior-level owner and projection tests, and ran the unchanged full Tasks browser E2E.
- Root cause: the completion lifecycle discarded attachment facts while producing its terminal blocked summary. Canonical fix: retain those facts at that producer boundary, not in a downstream UI or fallback reader.
- Removed/superseded paths: no bearer ticket, artifact download RPC, durable redrive/retention queue, sidecar, or parallel recovery flow remains in this repair.
- Sibling coverage: image, music, and video use the same shared completion lifecycle and attachment formatter.
- Latest ClawSweeper rank-up move asked for a redacted provider-backed induced permanent failure plus an authorized read, or explicit acceptance of focused regression proof. This PR explicitly accepts the focused regression as sufficient: deterministic owner tests prove both blocked completion branches, the Gateway table proves the authorized result projection, and browser proof verifies the operator copy surface. A live provider run was not used because safely inducing a permanent final-handoff failure is not available in that flow.

- Exact-head CI completed green after the last review snapshot, so the remaining merge-readiness items are resolved: the required `openclaw/ci-gate` check succeeded on `64ff7488bf7e` (the only non-success contexts are skipped jobs, a neutral CodeQL run, and one duplicate ClawSweeper Dispatch cancelled by its own concurrency group next to a successful sibling), and the net +42 production lines stay confined to the canonical blocked-completion recovery path described under Scope and LOC.

## Risk and coverage

- A generated filename, path, or delivery error containing a failover-classifier token such as `rate_limit`, `quota_exceeded`, or `overloaded` could still be replaced by the shared canned error during task-result sanitization. That is an existing cross-runtime sanitizer contract, not introduced here; it needs a separate owner-level follow-up rather than widening this media retention repair.
- Retaining a local or remote path makes the reference recoverable but does not guarantee that a different operator host can directly open that path. This change preserves the existing generated reference; it does not add transport or artifact hosting.
- Provider-backed live generation was not run. Coverage instead includes the pre-fix failing reproduction, final-head media lifecycle and authorized Gateway projection tests, built-Control-UI E2E, screenshots, `check:changed`, and independent autoreview.
- Successful handoff behavior is explicitly covered and remains unchanged; retained references are added only to blocked terminal results and are capped at 4,000 characters.

Worked on by:

- @jalehman


