### PR TITLE
fix(ci): finish watcher waits after successful reruns

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -120,9 +120,11 @@ verifying the successful exact-head attempt, its complete same-name job group,
 and direct job evidence that every queued alias has no runner or executed
 steps. Each poll permits at most 32 direct alias lookups, and evidence requests
 share the remaining watcher timeout. Groups exceeding that lookup budget remain
-pending with a warning. Active retries, unrelated checks, and ambiguous or
-incomplete evidence still block completion. This is an observation of CI state,
-not atomic merge authorization.
+pending with a warning. Before applying that proof, the watcher refreshes the
+PR head, state, and check rollup, then rechecks the attached run. Proof applies
+only to checks that still have the verified name and queued state. Active
+retries, unrelated checks, and ambiguous or incomplete evidence still block
+completion. This is an observation of CI state, not atomic merge authorization.
 
 `--completion ci-run` waits only for the attached CI workflow. Callers must
 separately verify required checks; CI success does not override another

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -118,9 +118,11 @@ GitHub can retain queued rerun placeholders while omitting the successful
 same-name job from the rollup. The watcher reconciles a placeholder only after
 verifying the successful exact-head attempt, its complete same-name job group,
 and direct job evidence that every queued alias has no runner or executed
-steps. Active retries, unrelated checks, and ambiguous or incomplete evidence
-still block completion. This is an observation of CI state, not atomic merge
-authorization.
+steps. Each poll permits at most 32 direct alias lookups, and evidence requests
+share the remaining watcher timeout. Groups exceeding that lookup budget remain
+pending with a warning. Active retries, unrelated checks, and ambiguous or
+incomplete evidence still block completion. This is an observation of CI state,
+not atomic merge authorization.
 
 `--completion ci-run` waits only for the attached CI workflow. Callers must
 separately verify required checks; CI success does not override another

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -101,6 +101,32 @@ and reserves native-memory headroom. If the default budget cannot fit the build,
 it stops before build steps or cache restoration; `OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB`
 remains the explicit operator override for attempting a different budget.
 
+## Watching pull request CI
+
+From a source checkout with an authenticated `gh` CLI, wait for one exact
+pull-request head:
+
+```bash
+node scripts/watch-pr-ci.mjs <pr-number> <full-head-sha>
+```
+
+The default `rollup` mode waits for the attached CI workflow to succeed and
+for the remaining rollup checks to finish without failures. Supersession stays
+within workflow identity; `Auto response` is excluded from the wait.
+
+GitHub can retain queued rerun placeholders while omitting the successful
+same-name job from the rollup. The watcher reconciles a placeholder only after
+verifying the successful exact-head attempt, its complete same-name job group,
+and direct job evidence that every queued alias has no runner or executed
+steps. Active retries, unrelated checks, and ambiguous or incomplete evidence
+still block completion. This is an observation of CI state, not atomic merge
+authorization.
+
+`--completion ci-run` waits only for the attached CI workflow. Callers must
+separately verify required checks; CI success does not override another
+required check. The native `scripts/pr` merge flow uses this mode and then
+performs its own required-check verification before merging.
+
 ## PR context and evidence
 
 External contributor PRs run a PR context and evidence gate from

--- a/scripts/watch-pr-ci.mts
+++ b/scripts/watch-pr-ci.mts
@@ -226,15 +226,22 @@ const newerJob = (a: JobIdentity, b: JobIdentity) =>
 export function classifyRollup(
   rollup: RollupPayload | null | undefined,
   runs: RunListItem[] = [],
-  reconciledChecks: ReadonlySet<number> = new Set(),
+  reconciledChecks: ReadonlyMap<number, string> = new Map(),
 ) {
   const rawNodes = rollup?.contexts?.nodes ?? [];
   const hiddenContextCount = Math.max(
     0,
     (rollup?.contexts?.totalCount ?? rawNodes.length) - rawNodes.length,
   );
+  const isReconciledPlaceholder = (check: RollupCheck) =>
+    check.databaseId !== undefined &&
+    check.name !== undefined &&
+    check.name.length > 0 &&
+    check.status === "QUEUED" &&
+    check.conclusion === null &&
+    reconciledChecks.get(check.databaseId) === check.name;
   const newestRunByWorkflow = new Map<number, number>();
-  const bestByJob = new Map<string, JobIdentity>();
+  const bestByJob = new Map<string, JobIdentity & { reconciled: boolean }>();
   for (const check of rawNodes) {
     const identity = checkRunIdentity(check);
     if (!identity) {
@@ -246,7 +253,8 @@ export function classifyRollup(
     );
     if (check.name && typeof check.databaseId === "number") {
       const key = `${identity.workflowId}:${check.name}`;
-      const candidate = { runId: identity.runId, checkId: check.databaseId };
+      const reconciled = isReconciledPlaceholder(check);
+      const candidate = { runId: identity.runId, checkId: check.databaseId, reconciled };
       const best = bestByJob.get(key);
       if (!best || newerJob(candidate, best)) {
         bestByJob.set(key, candidate);
@@ -265,14 +273,22 @@ export function classifyRollup(
     if (!identity) {
       return true;
     }
-    if (check.databaseId !== undefined && reconciledChecks.has(check.databaseId)) {
+    // Proof covers the queued observation, not a later name or outcome of the same ID.
+    if (isReconciledPlaceholder(check)) {
       reconciledCount += 1;
       supersededCount += 1;
       return false;
     }
     if (check.name && typeof check.databaseId === "number") {
       const best = bestByJob.get(`${identity.workflowId}:${check.name}`);
-      if (best && newerJob(best, { runId: identity.runId, checkId: check.databaseId })) {
+      // A removed placeholder cannot hide a verified sibling that changed in this
+      // attempt. Uncovered earlier attempts and newer runs retain normal supersession.
+      const changedAlias = reconciledChecks.has(check.databaseId);
+      if (
+        best &&
+        !(best.reconciled && best.runId === identity.runId && changedAlias) &&
+        newerJob(best, { runId: identity.runId, checkId: check.databaseId })
+      ) {
         supersededCount += 1;
         return false;
       }
@@ -334,16 +350,15 @@ export function classifyRollup(
         supersededCount,
       };
     }
-    // Reconciliation can explain a stale aggregate, never unknown sibling outcomes.
-    const unknownOutcome =
-      reconciledCount > 0 &&
-      checks.some((check) =>
-        check.kind === "StatusContext"
-          ? check.state !== "SUCCESS"
-          : check.status !== "COMPLETED" ||
-            !["SUCCESS", "SKIPPED", "NEUTRAL"].includes(check.conclusion ?? ""),
-      );
-    if (pendingCount > 0 || unknownOutcome) {
+    // A refresh can invalidate every alias proof. Unknown outcomes still block,
+    // even when no placeholder was removed from this snapshot.
+    const hasUnresolvedChecks = checks.some((check) =>
+      check.kind === "StatusContext"
+        ? check.state !== "SUCCESS"
+        : check.status !== "COMPLETED" ||
+          !["SUCCESS", "SKIPPED", "NEUTRAL"].includes(check.conclusion ?? ""),
+    );
+    if (hasUnresolvedChecks) {
       return { verdict: "PENDING", pendingCount, failingNames: [], supersededCount };
     }
     // GitHub's aggregate permanently counts superseded cancellations. With full visibility,
@@ -351,6 +366,17 @@ export function classifyRollup(
     return { verdict: "GREEN", pendingCount, failingNames: [], supersededCount };
   }
   return { verdict: "PENDING", pendingCount, failingNames: [], supersededCount };
+}
+
+function ghReadOptions(deadline?: number) {
+  if (deadline === undefined) {
+    return GH_READ_OPTIONS;
+  }
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) {
+    throw new Error("watcher evidence deadline elapsed");
+  }
+  return { ...GH_READ_OPTIONS, timeout: Math.min(GH_READ_OPTIONS.timeout, remaining) };
 }
 
 const readPr = (pr: number, repo: string) =>
@@ -369,20 +395,46 @@ const findRun = (repo: string, sha: string, after?: number) =>
     RunListSchema.parse(execGhJson(buildFindRunArgs(repo, sha), GH_READ_OPTIONS)),
     after,
   );
-const findTargetRuns = (repo: string, sha: string) =>
+const findTargetRuns = (repo: string, sha: string, deadline?: number) =>
   RunListSchema.parse(
     execGhJson(
       ["api", `repos/${repo}/actions/runs?event=pull_request_target&head_sha=${sha}&per_page=100`],
-      GH_READ_OPTIONS,
+      ghReadOptions(deadline),
     ),
   );
-const readRun = (repo: string, runId: number) =>
+const readRun = (repo: string, runId: number, deadline?: number) =>
   RunStatusSchema.parse(
     execGhJson(
       `run view ${runId} --repo ${repo} --json status,conclusion`.split(" "),
-      GH_READ_OPTIONS,
+      ghReadOptions(deadline),
     ),
   );
+
+function classifyPrRollup(
+  pr: RollupPage,
+  repo: string,
+  headSha: string,
+  reconciledChecks?: ReadonlyMap<number, string>,
+  deadline?: number,
+) {
+  const result = classifyRollup(pr.statusCheckRollup, [], reconciledChecks);
+  if (
+    result.verdict !== "FAILING" ||
+    !pr.statusCheckRollup?.contexts?.nodes?.some(
+      (check) =>
+        check.conclusion === "CANCELLED" &&
+        check.checkSuite?.workflowRun?.event === "pull_request_target" &&
+        checkRunIdentity(check),
+    )
+  ) {
+    return result;
+  }
+  return classifyRollup(
+    pr.statusCheckRollup,
+    findTargetRuns(repo, headSha, deadline),
+    reconciledChecks,
+  );
+}
 
 function readQueuedPlaceholderEvidence(
   repo: string,
@@ -391,7 +443,7 @@ function readQueuedPlaceholderEvidence(
   rollup: RollupPayload,
   deadline: number,
 ) {
-  const reconciled = new Set<number>();
+  const reconciled = new Map<number, string>();
   const contexts = rollup.contexts;
   const nodes = contexts?.nodes ?? [];
   if (
@@ -418,16 +470,8 @@ function readQueuedPlaceholderEvidence(
   const runPath = `repos/${repo}/actions/runs/${attached.id}`;
   // Request current evidence through the shared gh seam; the final run read must
   // not deliberately reuse the snapshot from before job collection.
-  const readEvidence = (endpoint: string) => {
-    const remaining = deadline - Date.now();
-    if (remaining <= 0) {
-      throw new Error("queued-alias evidence deadline elapsed");
-    }
-    return execGhJson(["api", endpoint, "-H", "Cache-Control: max-age=0"], {
-      ...GH_READ_OPTIONS,
-      timeout: Math.min(GH_READ_OPTIONS.timeout, remaining),
-    });
-  };
+  const readEvidence = (endpoint: string) =>
+    execGhJson(["api", endpoint, "-H", "Cache-Control: max-age=0"], ghReadOptions(deadline));
   const readCompletedRun = () => CompletedRunSchema.parse(readEvidence(runPath));
   const run = readCompletedRun();
   if (
@@ -505,8 +549,9 @@ function readQueuedPlaceholderEvidence(
       );
     });
     if (unexecuted) {
-      for (const check of checks) {
-        reconciled.add(check.id);
+      // The refreshed rollup can reveal an alias omitted from the first snapshot.
+      for (const alias of aliases) {
+        reconciled.set(alias.id, name);
       }
     }
   }
@@ -514,7 +559,7 @@ function readQueuedPlaceholderEvidence(
   // completion after a newer attempt starts while the job pages are being read.
   const current = readCompletedRun();
   if (JSON.stringify(current) !== JSON.stringify(run)) {
-    return new Set<number>();
+    return new Map<number, string>();
   }
   return reconciled;
 }
@@ -588,7 +633,7 @@ export function collectRollupContexts(
   };
 }
 
-function readRollup(pr: number, repo: string) {
+function readRollup(pr: number, repo: string, deadline?: number) {
   const [owner, name] = repo.split("/");
   return (
     collectRollupContexts((cursor) => {
@@ -607,7 +652,9 @@ function readRollup(pr: number, repo: string) {
       if (cursor !== null) {
         queryArgs.push("-f", `cursor=${cursor}`);
       }
-      const response = RollupResponseSchema.safeParse(execGhJson(queryArgs, GH_READ_OPTIONS));
+      const response = RollupResponseSchema.safeParse(
+        execGhJson(queryArgs, ghReadOptions(deadline)),
+      );
       return response.success ? response.data.data.repository?.pullRequest : undefined;
     }) ?? {}
   );
@@ -738,28 +785,15 @@ async function main(argv = process.argv.slice(2)) {
           }
           return undefined;
         }
-        const pr = readRollup(args.pr, args.repo);
+        let pr = readRollup(args.pr, args.repo);
         const blocked = precheck(pr, args.headSha, true);
         if (blocked !== null) {
           return blocked;
         }
-        let targetRuns: RunListItem[] = [];
-        let result = classifyRollup(pr.statusCheckRollup);
-        if (
-          result.verdict === "FAILING" &&
-          pr.statusCheckRollup?.contexts?.nodes?.some(
-            (check) =>
-              check.conclusion === "CANCELLED" &&
-              check.checkSuite?.workflowRun?.event === "pull_request_target" &&
-              checkRunIdentity(check),
-          )
-        ) {
-          targetRuns = findTargetRuns(args.repo, args.headSha);
-          result = classifyRollup(pr.statusCheckRollup, targetRuns);
-        }
+        let result = classifyPrRollup(pr, args.repo, args.headSha);
         lastState = pr.statusCheckRollup?.state ?? "NONE";
         lastPending = result.pendingCount;
-        const run = result.verdict === "FAILING" ? undefined : readRun(args.repo, runId);
+        let run = result.verdict === "FAILING" ? undefined : readRun(args.repo, runId);
         if (
           result.verdict === "PENDING" &&
           result.pendingCount > 0 &&
@@ -774,8 +808,20 @@ async function main(argv = process.argv.slice(2)) {
             pr.statusCheckRollup,
             watchDeadline,
           );
-          result = classifyRollup(pr.statusCheckRollup, targetRuns, reconciled);
+          if (reconciled.size > 0) {
+            // The evidence scan may span pushes or new checks. Reobserve the PR
+            // before applying proof, then retain the ordinary final CI-run check.
+            pr = readRollup(args.pr, args.repo, watchDeadline);
+            const currentBlocked = precheck(pr, args.headSha, true);
+            if (currentBlocked !== null) {
+              return currentBlocked;
+            }
+            result = classifyPrRollup(pr, args.repo, args.headSha, reconciled, watchDeadline);
+            run =
+              result.verdict === "FAILING" ? undefined : readRun(args.repo, runId, watchDeadline);
+          }
         }
+        lastState = pr.statusCheckRollup?.state ?? "NONE";
         lastPending = result.pendingCount;
         console.log(
           `STATUS state=${lastState} pending=${lastPending} superseded=${result.supersededCount}`,

--- a/scripts/watch-pr-ci.mts
+++ b/scripts/watch-pr-ci.mts
@@ -120,6 +120,7 @@ const FAILURE_CONCLUSIONS = new Set([
   "TIMED_OUT",
 ]);
 const ROLLUP_QUERY = `query($owner:String!,$name:String!,$pr:Int!,$cursor:String){repository(owner:$owner,name:$name){pullRequest(number:$pr){state mergeable headRefOid statusCheckRollup{state contexts(first:100,after:$cursor){totalCount pageInfo{hasNextPage endCursor} nodes{kind:__typename ... on CheckRun{name status conclusion databaseId checkSuite{workflowRun{databaseId event workflow{databaseId}}}} ... on StatusContext{context state}}}}}}}`;
+const MAX_ALIAS_READS_PER_POLL = 32;
 const GH_READ_OPTIONS = {
   stdio: ["ignore", "pipe", "pipe"],
   timeout: 60_000,
@@ -388,6 +389,7 @@ function readQueuedPlaceholderEvidence(
   headSha: string,
   attached: RunListItem,
   rollup: RollupPayload,
+  deadline: number,
 ) {
   const reconciled = new Set<number>();
   const contexts = rollup.contexts;
@@ -416,8 +418,16 @@ function readQueuedPlaceholderEvidence(
   const runPath = `repos/${repo}/actions/runs/${attached.id}`;
   // Request current evidence through the shared gh seam; the final run read must
   // not deliberately reuse the snapshot from before job collection.
-  const readEvidence = (endpoint: string) =>
-    execGhJson(["api", endpoint, "-H", "Cache-Control: max-age=0"], GH_READ_OPTIONS);
+  const readEvidence = (endpoint: string) => {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      throw new Error("queued-alias evidence deadline elapsed");
+    }
+    return execGhJson(["api", endpoint, "-H", "Cache-Control: max-age=0"], {
+      ...GH_READ_OPTIONS,
+      timeout: Math.min(GH_READ_OPTIONS.timeout, remaining),
+    });
+  };
   const readCompletedRun = () => CompletedRunSchema.parse(readEvidence(runPath));
   const run = readCompletedRun();
   if (
@@ -451,6 +461,7 @@ function readQueuedPlaceholderEvidence(
     job.run_id === run.id && job.run_attempt === run.run_attempt && job.head_sha === headSha;
   const unassignedQueued = (job: z.infer<typeof AttemptJobSchema>) =>
     job.status === "queued" && job.conclusion === null && job.runner_id === null;
+  let remainingAliasReads = MAX_ALIAS_READS_PER_POLL;
   for (const name of new Set(queued.map((check) => check.name))) {
     const checks = queued.filter((check) => check.name === name);
     const siblings = jobs.filter((job) => job.name === name);
@@ -474,9 +485,16 @@ function readQueuedPlaceholderEvidence(
     ) {
       continue;
     }
+    // One request per alias can outlive a poll or exhaust API quota. Oversized
+    // groups stay pending; partial verification never proves supersession.
+    if (aliases.length > remainingAliasReads) {
+      console.log("WARN queued-alias evidence exceeds the per-poll request budget");
+      continue;
+    }
     // The list can copy executed steps onto queued aliases, including ones absent
     // from GraphQL. Prove the entire group unexecuted before dropping any visible ID.
     const unexecuted = aliases.every((alias) => {
+      remainingAliasReads -= 1;
       const direct = AttemptJobSchema.parse(readEvidence(`repos/${repo}/actions/jobs/${alias.id}`));
       return (
         direct.id === alias.id &&
@@ -754,6 +772,7 @@ async function main(argv = process.argv.slice(2)) {
             args.headSha,
             attached,
             pr.statusCheckRollup,
+            watchDeadline,
           );
           result = classifyRollup(pr.statusCheckRollup, targetRuns, reconciled);
         }

--- a/scripts/watch-pr-ci.mts
+++ b/scripts/watch-pr-ci.mts
@@ -79,6 +79,31 @@ const RunListSchema = z
 const RunStatusSchema = z
   .object({ status: optionalString, conclusion: optionalNullable(z.string()) })
   .catch({});
+const evidenceId = z.number().int().positive();
+const CompletedRunSchema = z.object({
+  id: evidenceId,
+  workflow_id: evidenceId,
+  head_sha: z.string(),
+  run_attempt: evidenceId,
+  path: z.literal(".github/workflows/ci.yml"),
+  status: z.literal("completed"),
+  conclusion: z.literal("success"),
+});
+const AttemptJobSchema = z.object({
+  id: evidenceId,
+  run_id: evidenceId,
+  run_attempt: evidenceId,
+  head_sha: z.string(),
+  name: z.string().min(1),
+  status: z.string(),
+  conclusion: z.string().nullable(),
+  runner_id: evidenceId.nullable(),
+  steps: z.array(z.object({ status: z.string(), conclusion: z.string().nullable() })),
+});
+const AttemptJobsPageSchema = z.object({
+  total_count: z.number().int().nonnegative().max(1_000),
+  jobs: z.array(AttemptJobSchema).max(100),
+});
 
 type RollupCheck = z.infer<typeof RollupCheckSchema>;
 type RollupPayload = z.infer<typeof RollupPayloadSchema>;
@@ -197,7 +222,11 @@ function checkRunIdentity(check: RollupCheck) {
 const newerJob = (a: JobIdentity, b: JobIdentity) =>
   a.runId !== b.runId ? a.runId > b.runId : a.checkId > b.checkId;
 
-export function classifyRollup(rollup: RollupPayload | null | undefined, runs: RunListItem[] = []) {
+export function classifyRollup(
+  rollup: RollupPayload | null | undefined,
+  runs: RunListItem[] = [],
+  reconciledChecks: ReadonlySet<number> = new Set(),
+) {
   const rawNodes = rollup?.contexts?.nodes ?? [];
   const hiddenContextCount = Math.max(
     0,
@@ -224,6 +253,7 @@ export function classifyRollup(rollup: RollupPayload | null | undefined, runs: R
     }
   }
   let supersededCount = 0;
+  let reconciledCount = 0;
   // Re-triggers leave every prior run's check runs on the SHA forever and GitHub's aggregate
   // counts them. A check is superseded when a newer same-workflow check shares its name
   // (GitHub's latest-name-wins semantics), or when its cancelled workflow has a newer run.
@@ -233,6 +263,11 @@ export function classifyRollup(rollup: RollupPayload | null | undefined, runs: R
     const identity = checkRunIdentity(check);
     if (!identity) {
       return true;
+    }
+    if (check.databaseId !== undefined && reconciledChecks.has(check.databaseId)) {
+      reconciledCount += 1;
+      supersededCount += 1;
+      return false;
     }
     if (check.name && typeof check.databaseId === "number") {
       const best = bestByJob.get(`${identity.workflowId}:${check.name}`);
@@ -274,7 +309,11 @@ export function classifyRollup(rollup: RollupPayload | null | undefined, runs: R
   if (rollup?.state === "SUCCESS") {
     return { verdict: "GREEN", pendingCount, failingNames: [], supersededCount };
   }
-  if (rollup?.state === "ERROR" || rollup?.state === "FAILURE") {
+  if (
+    rollup?.state === "ERROR" ||
+    rollup?.state === "FAILURE" ||
+    (rollup?.state === "PENDING" && reconciledCount > 0)
+  ) {
     if (failingChecks.length > 0) {
       return {
         verdict: "FAILING",
@@ -294,7 +333,16 @@ export function classifyRollup(rollup: RollupPayload | null | undefined, runs: R
         supersededCount,
       };
     }
-    if (pendingCount > 0) {
+    // Reconciliation can explain a stale aggregate, never unknown sibling outcomes.
+    const unknownOutcome =
+      reconciledCount > 0 &&
+      checks.some((check) =>
+        check.kind === "StatusContext"
+          ? check.state !== "SUCCESS"
+          : check.status !== "COMPLETED" ||
+            !["SUCCESS", "SKIPPED", "NEUTRAL"].includes(check.conclusion ?? ""),
+      );
+    if (pendingCount > 0 || unknownOutcome) {
       return { verdict: "PENDING", pendingCount, failingNames: [], supersededCount };
     }
     // GitHub's aggregate permanently counts superseded cancellations. With full visibility,
@@ -334,6 +382,124 @@ const readRun = (repo: string, runId: number) =>
       GH_READ_OPTIONS,
     ),
   );
+
+function readQueuedPlaceholderEvidence(
+  repo: string,
+  headSha: string,
+  attached: RunListItem,
+  rollup: RollupPayload,
+) {
+  const reconciled = new Set<number>();
+  const contexts = rollup.contexts;
+  const nodes = contexts?.nodes ?? [];
+  if (
+    !["FAILURE", "ERROR", "PENDING"].includes(rollup.state ?? "") ||
+    contexts?.totalCount !== nodes.length ||
+    contexts.pageInfo?.hasNextPage !== false
+  ) {
+    return reconciled;
+  }
+  const queued = nodes.flatMap((check) => {
+    const identity = checkRunIdentity(check);
+    return check.status === "QUEUED" &&
+      check.conclusion === null &&
+      check.name &&
+      check.databaseId !== undefined &&
+      identity?.runId === attached.id &&
+      identity.workflowId === attached.workflow_id
+      ? [{ name: check.name, id: check.databaseId }]
+      : [];
+  });
+  if (queued.length === 0) {
+    return reconciled;
+  }
+  const runPath = `repos/${repo}/actions/runs/${attached.id}`;
+  // Request current evidence through the shared gh seam; the final run read must
+  // not deliberately reuse the snapshot from before job collection.
+  const readEvidence = (endpoint: string) =>
+    execGhJson(["api", endpoint, "-H", "Cache-Control: max-age=0"], GH_READ_OPTIONS);
+  const readCompletedRun = () => CompletedRunSchema.parse(readEvidence(runPath));
+  const run = readCompletedRun();
+  if (
+    run.id !== attached.id ||
+    run.head_sha !== headSha ||
+    run.workflow_id !== attached.workflow_id
+  ) {
+    return reconciled;
+  }
+  const jobs: z.infer<typeof AttemptJobSchema>[] = [];
+  let totalCount: number | undefined;
+  // Attempt-specific pagination is bounded like the rollup; incomplete or duplicate
+  // pages cannot establish that no active/failed same-name sibling exists.
+  for (let page = 1; page <= 10; page += 1) {
+    const response = AttemptJobsPageSchema.parse(
+      readEvidence(`${runPath}/attempts/${run.run_attempt}/jobs?per_page=100&page=${page}`),
+    );
+    totalCount ??= response.total_count;
+    if (response.total_count !== totalCount || response.jobs.length === 0) {
+      return reconciled;
+    }
+    jobs.push(...response.jobs);
+    if (jobs.length >= totalCount) {
+      break;
+    }
+  }
+  if (jobs.length !== totalCount || new Set(jobs.map((job) => job.id)).size !== jobs.length) {
+    return reconciled;
+  }
+  const sameAttempt = (job: z.infer<typeof AttemptJobSchema>) =>
+    job.run_id === run.id && job.run_attempt === run.run_attempt && job.head_sha === headSha;
+  const unassignedQueued = (job: z.infer<typeof AttemptJobSchema>) =>
+    job.status === "queued" && job.conclusion === null && job.runner_id === null;
+  for (const name of new Set(queued.map((check) => check.name))) {
+    const checks = queued.filter((check) => check.name === name);
+    const siblings = jobs.filter((job) => job.name === name);
+    const aliases = siblings.filter(unassignedQueued);
+    const executed = siblings.filter((job) => !unassignedQueued(job));
+    const replacement = executed[0];
+    if (
+      executed.length !== 1 ||
+      !replacement ||
+      !siblings.every(sameAttempt) ||
+      !checks.every((check) => aliases.some((job) => job.id === check.id)) ||
+      replacement.status !== "completed" ||
+      replacement.conclusion !== "success" ||
+      replacement.runner_id === null ||
+      replacement.steps.length === 0 ||
+      replacement.steps.some(
+        (step) =>
+          step.status !== "completed" ||
+          !["success", "skipped", "neutral"].includes(step.conclusion ?? ""),
+      )
+    ) {
+      continue;
+    }
+    // The list can copy executed steps onto queued aliases, including ones absent
+    // from GraphQL. Prove the entire group unexecuted before dropping any visible ID.
+    const unexecuted = aliases.every((alias) => {
+      const direct = AttemptJobSchema.parse(readEvidence(`repos/${repo}/actions/jobs/${alias.id}`));
+      return (
+        direct.id === alias.id &&
+        direct.name === name &&
+        sameAttempt(direct) &&
+        unassignedQueued(direct) &&
+        direct.steps.length === 0
+      );
+    });
+    if (unexecuted) {
+      for (const check of checks) {
+        reconciled.add(check.id);
+      }
+    }
+  }
+  // Reruns reuse a run ID. Evidence from the completed attempt cannot authorize
+  // completion after a newer attempt starts while the job pages are being read.
+  const current = readCompletedRun();
+  if (JSON.stringify(current) !== JSON.stringify(run)) {
+    return new Set<number>();
+  }
+  return reconciled;
+}
 
 export function classifyRunAttachment(runId: number, run: RunStatus, after?: number) {
   if (run.conclusion === "skipped") {
@@ -399,7 +565,7 @@ export function collectRollupContexts(
     ...firstPage,
     statusCheckRollup: {
       ...firstPage.statusCheckRollup,
-      contexts: { ...firstContexts, nodes },
+      contexts: { ...firstContexts, nodes, pageInfo },
     },
   };
 }
@@ -506,7 +672,7 @@ async function main(argv = process.argv.slice(2)) {
             if (classification.warning) {
               console.log(classification.warning);
             }
-            return { runId: candidate.id };
+            return { run: candidate };
           }
         }
       } catch (error) {
@@ -524,7 +690,8 @@ async function main(argv = process.argv.slice(2)) {
   if ("exitCode" in attachment) {
     return attachment.exitCode;
   }
-  const { runId } = attachment;
+  const attached = attachment.run;
+  const runId = attached.id;
   console.log(`ATTACHED run=${runId} url=https://github.com/${args.repo}/actions/runs/${runId}`);
 
   const watchDeadline = Date.now() + args.timeout * 1000;
@@ -558,6 +725,7 @@ async function main(argv = process.argv.slice(2)) {
         if (blocked !== null) {
           return blocked;
         }
+        let targetRuns: RunListItem[] = [];
         let result = classifyRollup(pr.statusCheckRollup);
         if (
           result.verdict === "FAILING" &&
@@ -568,9 +736,27 @@ async function main(argv = process.argv.slice(2)) {
               checkRunIdentity(check),
           )
         ) {
-          result = classifyRollup(pr.statusCheckRollup, findTargetRuns(args.repo, args.headSha));
+          targetRuns = findTargetRuns(args.repo, args.headSha);
+          result = classifyRollup(pr.statusCheckRollup, targetRuns);
         }
         lastState = pr.statusCheckRollup?.state ?? "NONE";
+        lastPending = result.pendingCount;
+        const run = result.verdict === "FAILING" ? undefined : readRun(args.repo, runId);
+        if (
+          result.verdict === "PENDING" &&
+          result.pendingCount > 0 &&
+          run?.status === "completed" &&
+          run.conclusion === "success" &&
+          pr.statusCheckRollup
+        ) {
+          const reconciled = readQueuedPlaceholderEvidence(
+            args.repo,
+            args.headSha,
+            attached,
+            pr.statusCheckRollup,
+          );
+          result = classifyRollup(pr.statusCheckRollup, targetRuns, reconciled);
+        }
         lastPending = result.pendingCount;
         console.log(
           `STATUS state=${lastState} pending=${lastPending} superseded=${result.supersededCount}`,
@@ -578,13 +764,12 @@ async function main(argv = process.argv.slice(2)) {
         if (result.verdict === "FAILING") {
           return emit(`FAILING checks=${result.failingNames.join(", ")}`, 15);
         }
-        const run = readRun(args.repo, runId);
-        if (run.status === "completed" && run.conclusion !== "success") {
+        if (run?.status === "completed" && run.conclusion !== "success") {
           return emit(`FAILING checks=CI workflow (${run.conclusion ?? "unknown"})`, 15);
         }
         if (
           result.verdict === "GREEN" &&
-          run.status === "completed" &&
+          run?.status === "completed" &&
           run.conclusion === "success"
         ) {
           return emit("GREEN", 0);

--- a/test/fixtures/watch-pr-ci-queued-placeholder.json
+++ b/test/fixtures/watch-pr-ci-queued-placeholder.json
@@ -1,0 +1,780 @@
+{
+  "provenance": {
+    "source": "https://github.com/openclaw/openclaw/pull/131617",
+    "captured": "2026-08-28",
+    "head": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+    "endpoints": [
+      "GET /repos/openclaw/openclaw/actions/runs/33155056361",
+      "GET /repos/openclaw/openclaw/actions/runs/33155056361/attempts/3/jobs?per_page=100&page={1,2,3}",
+      "GET /repos/openclaw/openclaw/actions/jobs/{id} for all 14 queued config-64 aliases",
+      "GraphQL pullRequest(number:131617).statusCheckRollup.contexts(first:100,after:$cursor)"
+    ],
+    "trimming": "Keep config-62, queued config-64 and CI gate from 239 rollup nodes. Keep config-62 and ALL 15 config-64 jobs from 207 attempt jobs, in captured order. Counts/pageInfo describe the trimmed single page. Remove nonconsumed fields only. No successful config-64 CheckRun exists in the captured rollup.",
+    "inconsistency": "Four queued config-64 aliases on the last list page have 14 completed steps identical to executed job 98802098754; the other ten list aliases and ALL fourteen direct responses have steps []. Both observations are preserved. No list ordering or placeholder semantics are inferred.",
+    "replay": "Captured PR state remains MERGED here. Tests change only lifecycle state to OPEN for historical watcher replay; counterexamples explicitly mutate that baseline."
+  },
+  "graphql": {
+    "data": {
+      "repository": {
+        "pullRequest": {
+          "headRefOid": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+          "mergeable": "UNKNOWN",
+          "state": "MERGED",
+          "statusCheckRollup": {
+            "state": "FAILURE",
+            "contexts": {
+              "totalCount": 3,
+              "pageInfo": {
+                "hasNextPage": false,
+                "endCursor": null
+              },
+              "nodes": [
+                {
+                  "checkSuite": {
+                    "databaseId": 89847956309,
+                    "workflowRun": {
+                      "databaseId": 33155056361,
+                      "event": "pull_request",
+                      "workflow": {
+                        "databaseId": 209874334
+                      }
+                    }
+                  },
+                  "conclusion": "SUCCESS",
+                  "databaseId": 98802098742,
+                  "kind": "CheckRun",
+                  "name": "checks-node-changed-extensions-config-62",
+                  "status": "COMPLETED"
+                },
+                {
+                  "checkSuite": {
+                    "databaseId": 89847956309,
+                    "workflowRun": {
+                      "databaseId": 33155056361,
+                      "event": "pull_request",
+                      "workflow": {
+                        "databaseId": 209874334
+                      }
+                    }
+                  },
+                  "conclusion": null,
+                  "databaseId": 98802098786,
+                  "kind": "CheckRun",
+                  "name": "checks-node-changed-extensions-config-64",
+                  "status": "QUEUED"
+                },
+                {
+                  "checkSuite": {
+                    "databaseId": 89847956309,
+                    "workflowRun": {
+                      "databaseId": 33155056361,
+                      "event": "pull_request",
+                      "workflow": {
+                        "databaseId": 209874334
+                      }
+                    }
+                  },
+                  "conclusion": "SUCCESS",
+                  "databaseId": 98802776296,
+                  "kind": "CheckRun",
+                  "name": "openclaw/ci-gate",
+                  "status": "COMPLETED"
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  },
+  "run": {
+    "id": 33155056361,
+    "head_sha": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+    "run_attempt": 3,
+    "status": "completed",
+    "conclusion": "success",
+    "updated_at": "2026-08-28T08:55:04Z",
+    "path": ".github/workflows/ci.yml",
+    "workflow_id": 209874334,
+    "check_suite_id": 89847956309
+  },
+  "jobs": {
+    "total_count": 16,
+    "jobs": [
+      {
+        "id": 98802098559,
+        "run_id": 33155056361,
+        "run_attempt": 3,
+        "head_sha": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+        "name": "checks-node-changed-extensions-config-64",
+        "status": "queued",
+        "conclusion": null,
+        "runner_id": null,
+        "steps": []
+      },
+      {
+        "id": 98802098584,
+        "run_id": 33155056361,
+        "run_attempt": 3,
+        "head_sha": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+        "name": "checks-node-changed-extensions-config-64",
+        "status": "queued",
+        "conclusion": null,
+        "runner_id": null,
+        "steps": []
+      },
+      {
+        "id": 98802098611,
+        "run_id": 33155056361,
+        "run_attempt": 3,
+        "head_sha": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+        "name": "checks-node-changed-extensions-config-64",
+        "status": "queued",
+        "conclusion": null,
+        "runner_id": null,
+        "steps": []
+      },
+      {
+        "id": 98802098636,
+        "run_id": 33155056361,
+        "run_attempt": 3,
+        "head_sha": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+        "name": "checks-node-changed-extensions-config-64",
+        "status": "queued",
+        "conclusion": null,
+        "runner_id": null,
+        "steps": []
+      },
+      {
+        "id": 98802098678,
+        "run_id": 33155056361,
+        "run_attempt": 3,
+        "head_sha": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+        "name": "checks-node-changed-extensions-config-64",
+        "status": "queued",
+        "conclusion": null,
+        "runner_id": null,
+        "steps": []
+      },
+      {
+        "id": 98802098679,
+        "run_id": 33155056361,
+        "run_attempt": 3,
+        "head_sha": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+        "name": "checks-node-changed-extensions-config-64",
+        "status": "queued",
+        "conclusion": null,
+        "runner_id": null,
+        "steps": []
+      },
+      {
+        "id": 98802098684,
+        "run_id": 33155056361,
+        "run_attempt": 3,
+        "head_sha": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+        "name": "checks-node-changed-extensions-config-64",
+        "status": "queued",
+        "conclusion": null,
+        "runner_id": null,
+        "steps": []
+      },
+      {
+        "id": 98802098721,
+        "run_id": 33155056361,
+        "run_attempt": 3,
+        "head_sha": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+        "name": "checks-node-changed-extensions-config-64",
+        "status": "queued",
+        "conclusion": null,
+        "runner_id": null,
+        "steps": []
+      },
+      {
+        "id": 98802098729,
+        "run_id": 33155056361,
+        "run_attempt": 3,
+        "head_sha": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+        "name": "checks-node-changed-extensions-config-64",
+        "status": "queued",
+        "conclusion": null,
+        "runner_id": null,
+        "steps": []
+      },
+      {
+        "id": 98802098737,
+        "run_id": 33155056361,
+        "run_attempt": 3,
+        "head_sha": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+        "name": "checks-node-changed-extensions-config-64",
+        "status": "queued",
+        "conclusion": null,
+        "runner_id": null,
+        "steps": []
+      },
+      {
+        "id": 98802098738,
+        "run_id": 33155056361,
+        "run_attempt": 3,
+        "head_sha": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+        "name": "checks-node-changed-extensions-config-64",
+        "status": "queued",
+        "conclusion": null,
+        "runner_id": null,
+        "steps": [
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          }
+        ]
+      },
+      {
+        "id": 98802098742,
+        "run_id": 33155056361,
+        "run_attempt": 3,
+        "head_sha": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+        "name": "checks-node-changed-extensions-config-62",
+        "status": "completed",
+        "conclusion": "success",
+        "runner_id": 1014005924,
+        "steps": [
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          }
+        ]
+      },
+      {
+        "id": 98802098747,
+        "run_id": 33155056361,
+        "run_attempt": 3,
+        "head_sha": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+        "name": "checks-node-changed-extensions-config-64",
+        "status": "queued",
+        "conclusion": null,
+        "runner_id": null,
+        "steps": [
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          }
+        ]
+      },
+      {
+        "id": 98802098754,
+        "run_id": 33155056361,
+        "run_attempt": 3,
+        "head_sha": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+        "name": "checks-node-changed-extensions-config-64",
+        "status": "completed",
+        "conclusion": "success",
+        "runner_id": 1014005923,
+        "steps": [
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          }
+        ]
+      },
+      {
+        "id": 98802098759,
+        "run_id": 33155056361,
+        "run_attempt": 3,
+        "head_sha": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+        "name": "checks-node-changed-extensions-config-64",
+        "status": "queued",
+        "conclusion": null,
+        "runner_id": null,
+        "steps": [
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          }
+        ]
+      },
+      {
+        "id": 98802098786,
+        "run_id": 33155056361,
+        "run_attempt": 3,
+        "head_sha": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+        "name": "checks-node-changed-extensions-config-64",
+        "status": "queued",
+        "conclusion": null,
+        "runner_id": null,
+        "steps": [
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "skipped"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          },
+          {
+            "status": "completed",
+            "conclusion": "success"
+          }
+        ]
+      }
+    ]
+  },
+  "directJobs": [
+    {
+      "id": 98802098559,
+      "run_id": 33155056361,
+      "run_attempt": 3,
+      "head_sha": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+      "name": "checks-node-changed-extensions-config-64",
+      "status": "queued",
+      "conclusion": null,
+      "runner_id": null,
+      "steps": []
+    },
+    {
+      "id": 98802098584,
+      "run_id": 33155056361,
+      "run_attempt": 3,
+      "head_sha": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+      "name": "checks-node-changed-extensions-config-64",
+      "status": "queued",
+      "conclusion": null,
+      "runner_id": null,
+      "steps": []
+    },
+    {
+      "id": 98802098611,
+      "run_id": 33155056361,
+      "run_attempt": 3,
+      "head_sha": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+      "name": "checks-node-changed-extensions-config-64",
+      "status": "queued",
+      "conclusion": null,
+      "runner_id": null,
+      "steps": []
+    },
+    {
+      "id": 98802098636,
+      "run_id": 33155056361,
+      "run_attempt": 3,
+      "head_sha": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+      "name": "checks-node-changed-extensions-config-64",
+      "status": "queued",
+      "conclusion": null,
+      "runner_id": null,
+      "steps": []
+    },
+    {
+      "id": 98802098678,
+      "run_id": 33155056361,
+      "run_attempt": 3,
+      "head_sha": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+      "name": "checks-node-changed-extensions-config-64",
+      "status": "queued",
+      "conclusion": null,
+      "runner_id": null,
+      "steps": []
+    },
+    {
+      "id": 98802098679,
+      "run_id": 33155056361,
+      "run_attempt": 3,
+      "head_sha": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+      "name": "checks-node-changed-extensions-config-64",
+      "status": "queued",
+      "conclusion": null,
+      "runner_id": null,
+      "steps": []
+    },
+    {
+      "id": 98802098684,
+      "run_id": 33155056361,
+      "run_attempt": 3,
+      "head_sha": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+      "name": "checks-node-changed-extensions-config-64",
+      "status": "queued",
+      "conclusion": null,
+      "runner_id": null,
+      "steps": []
+    },
+    {
+      "id": 98802098721,
+      "run_id": 33155056361,
+      "run_attempt": 3,
+      "head_sha": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+      "name": "checks-node-changed-extensions-config-64",
+      "status": "queued",
+      "conclusion": null,
+      "runner_id": null,
+      "steps": []
+    },
+    {
+      "id": 98802098729,
+      "run_id": 33155056361,
+      "run_attempt": 3,
+      "head_sha": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+      "name": "checks-node-changed-extensions-config-64",
+      "status": "queued",
+      "conclusion": null,
+      "runner_id": null,
+      "steps": []
+    },
+    {
+      "id": 98802098737,
+      "run_id": 33155056361,
+      "run_attempt": 3,
+      "head_sha": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+      "name": "checks-node-changed-extensions-config-64",
+      "status": "queued",
+      "conclusion": null,
+      "runner_id": null,
+      "steps": []
+    },
+    {
+      "id": 98802098738,
+      "run_id": 33155056361,
+      "run_attempt": 3,
+      "head_sha": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+      "name": "checks-node-changed-extensions-config-64",
+      "status": "queued",
+      "conclusion": null,
+      "runner_id": null,
+      "steps": []
+    },
+    {
+      "id": 98802098747,
+      "run_id": 33155056361,
+      "run_attempt": 3,
+      "head_sha": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+      "name": "checks-node-changed-extensions-config-64",
+      "status": "queued",
+      "conclusion": null,
+      "runner_id": null,
+      "steps": []
+    },
+    {
+      "id": 98802098759,
+      "run_id": 33155056361,
+      "run_attempt": 3,
+      "head_sha": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+      "name": "checks-node-changed-extensions-config-64",
+      "status": "queued",
+      "conclusion": null,
+      "runner_id": null,
+      "steps": []
+    },
+    {
+      "id": 98802098786,
+      "run_id": 33155056361,
+      "run_attempt": 3,
+      "head_sha": "baa73943fbcd7b47f5432d36d4d242f8170dc141",
+      "name": "checks-node-changed-extensions-config-64",
+      "status": "queued",
+      "conclusion": null,
+      "runner_id": null,
+      "steps": []
+    }
+  ]
+}

--- a/test/scripts/watch-pr-ci.test.ts
+++ b/test/scripts/watch-pr-ci.test.ts
@@ -50,11 +50,13 @@ function replayPlaceholder(
   fixture = structuredClone(placeholderFixture),
   evidence: {
     runSnapshots?: unknown[];
+    runViewSnapshots?: unknown[];
     jobPages?: unknown[];
     directJobs?: unknown[];
     merged?: boolean;
     watchTimeout?: number;
     delayFirstAlias?: boolean;
+    afterAliasScan?: unknown;
   } = {},
 ) {
   const root = tempDirs.make("openclaw-watch-pr-ci-replay-");
@@ -72,10 +74,15 @@ const args = process.argv.slice(2);
 const calls = fs.readFileSync(${JSON.stringify(calls)}, "utf8").trim().split("\\n").filter(Boolean).map(JSON.parse);
 fs.appendFileSync(${JSON.stringify(calls)}, JSON.stringify(args) + "\\n");
 const runPath = "repos/openclaw/openclaw/actions/runs/33155056361";
+const scanned = calls.some((call) => call[1]?.startsWith("repos/openclaw/openclaw/actions/jobs/"));
+const currentGraphql = scanned && fixture.afterAliasScan !== undefined ? fixture.afterAliasScan : fixture.graphql;
 let value;
-if (args[0] === "pr" && args[1] === "view") value = fixture.graphql.data.repository.pullRequest;
-else if (args[0] === "run" && args[1] === "view") value = fixture.run;
-else if (args[0] === "api" && args[1] === "graphql") value = fixture.graphql;
+if (args[0] === "pr" && args[1] === "view") value = currentGraphql.data.repository.pullRequest;
+else if (args[0] === "run" && args[1] === "view") {
+  const reads = calls.filter((call) => call[0] === "run" && call[1] === "view").length;
+  value = fixture.runViewSnapshots?.[Math.min(reads, fixture.runViewSnapshots.length - 1)] ?? fixture.run;
+}
+else if (args[0] === "api" && args[1] === "graphql") value = currentGraphql;
 else if (args.includes("repos/openclaw/openclaw/actions/workflows/ci.yml/runs")) value = { workflow_runs: [fixture.run] };
 else if (args[1] === runPath) {
   const reads = calls.filter((call) => call[1] === runPath).length;
@@ -249,7 +256,8 @@ esac
         expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
         expect(result.stdout).toContain(`pending=0 superseded=${observed}`);
         expect(result.stdout).toContain("GREEN");
-        // Cost and ordering matter: only one attempt scan, direct proof, then run revalidation.
+        // Cost and ordering matter: direct proof precedes run revalidation and
+        // a fresh PR snapshot, followed by the ordinary final CI-run check.
         const calls: string[][] = result.calls
           .trim()
           .split("\n")
@@ -259,8 +267,17 @@ esac
         expect(directReads.map((call) => Number(call[1]?.split("/").at(-1))).toSorted()).toEqual(
           fixture.directJobs.map((job) => job.id).toSorted(),
         );
-        expect(calls.at(-1)?.[1]).toBe("repos/openclaw/openclaw/actions/runs/33155056361");
-        expect(calls.at(-1)).toContain("Cache-Control: max-age=0");
+        const finalEvidenceRead = calls.findLastIndex(
+          (call) => call[1] === "repos/openclaw/openclaw/actions/runs/33155056361",
+        );
+        expect(finalEvidenceRead).toBeGreaterThan(
+          calls.findLastIndex((call) => call[1]?.includes("/actions/jobs/")),
+        );
+        expect(calls[finalEvidenceRead]).toContain("Cache-Control: max-age=0");
+        expect(calls.findLastIndex((call) => call[1] === "graphql")).toBeGreaterThan(
+          finalEvidenceRead,
+        );
+        expect(calls.at(-1)?.slice(0, 2)).toEqual(["run", "view"]);
       },
     );
 
@@ -303,6 +320,145 @@ esac
         .split("\n")
         .map((line) => JSON.parse(line));
       expect(calls.filter((call) => call[1]?.includes("/actions/jobs/"))).toHaveLength(1);
+    });
+
+    it.each([
+      {
+        label: "moved head",
+        patch: { headRefOid: sha, statusCheckRollup: null },
+        exitCode: 11,
+        output: "HEAD-MOVED",
+      },
+      { label: "closed PR", patch: { state: "CLOSED" }, exitCode: 10, output: "PR-CLOSED" },
+      {
+        label: "conflicting PR",
+        patch: { mergeable: false },
+        exitCode: 14,
+        output: "CONFLICTING-MID-WAIT",
+      },
+    ])("rechecks a $label after alias verification", ({ patch, exitCode, output }) => {
+      const fixture = structuredClone(placeholderFixture);
+      const afterAliasScan = structuredClone(fixture.graphql);
+      afterAliasScan.data.repository.pullRequest.state = "OPEN";
+      Object.assign(afterAliasScan.data.repository.pullRequest, patch);
+      const result = replayPlaceholder(fixture, { afterAliasScan, watchTimeout: 5 });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(exitCode);
+      expect(result.stdout).toContain(output);
+      expect(result.stdout).not.toContain("GREEN");
+    });
+
+    it.each([
+      { label: "pending", status: "QUEUED", conclusion: null, exitCode: 16 },
+      { label: "failed", status: "COMPLETED", conclusion: "FAILURE", exitCode: 15 },
+    ])(
+      "observes a new $label required check after alias verification",
+      ({ status, conclusion, exitCode }) => {
+        const fixture = structuredClone(placeholderFixture);
+        const afterAliasScan = structuredClone(fixture.graphql);
+        afterAliasScan.data.repository.pullRequest.state = "OPEN";
+        const contexts = afterAliasScan.data.repository.pullRequest.statusCheckRollup.contexts;
+        Object.assign(contexts, {
+          totalCount: contexts.totalCount + 1,
+          nodes: [
+            ...contexts.nodes,
+            { kind: "CheckRun", name: "new required check", status, conclusion },
+          ],
+        });
+        const result = replayPlaceholder(fixture, { afterAliasScan, watchTimeout: 5 });
+        expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(exitCode);
+        expect(result.stdout).not.toContain("GREEN");
+      },
+    );
+
+    it.each([
+      { label: "starts running", patch: { status: "IN_PROGRESS" }, exitCode: 16 },
+      { label: "fails", patch: { status: "COMPLETED", conclusion: "FAILURE" }, exitCode: 15 },
+      {
+        label: "loses its conclusion",
+        patch: { status: "COMPLETED", conclusion: null },
+        exitCode: 16,
+      },
+      { label: "is renamed", patch: { name: "different required check" }, exitCode: 16 },
+    ])("does not reuse proof when an alias $label", ({ patch, exitCode }) => {
+      const fixture = structuredClone(placeholderFixture);
+      const afterAliasScan = structuredClone(fixture.graphql);
+      afterAliasScan.data.repository.pullRequest.state = "OPEN";
+      const alias =
+        afterAliasScan.data.repository.pullRequest.statusCheckRollup.contexts.nodes.find(
+          (check) => check.databaseId === 98802098786,
+        );
+      assert(alias);
+      Object.assign(alias, patch);
+      const result = replayPlaceholder(fixture, { afterAliasScan, watchTimeout: 5 });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(exitCode);
+      expect(result.stdout).not.toContain("GREEN");
+    });
+
+    it.each(
+      [
+        { status: "IN_PROGRESS", conclusion: null, exitCode: 16 },
+        { status: "COMPLETED", conclusion: "FAILURE", exitCode: 15 },
+      ].flatMap((outcome) =>
+        [false, true].map((initiallyVisible) => ({ ...outcome, initiallyVisible })),
+      ),
+    )(
+      "keeps a changed lower-ID alias blocking ($status, initially visible: $initiallyVisible)",
+      ({ status, conclusion, exitCode, initiallyVisible }) => {
+        const fixture = structuredClone(placeholderFixture);
+        const contexts = fixture.graphql.data.repository.pullRequest.statusCheckRollup.contexts;
+        const queued = contexts.nodes.find((check) => check.databaseId === 98802098786);
+        assert(queued);
+        const lower = { ...queued, databaseId: 98802098559 };
+        if (initiallyVisible) {
+          contexts.nodes.push(lower);
+          contexts.totalCount += 1;
+        }
+        const afterAliasScan = structuredClone(fixture.graphql);
+        afterAliasScan.data.repository.pullRequest.state = "OPEN";
+        const refreshed = afterAliasScan.data.repository.pullRequest.statusCheckRollup.contexts;
+        if (!initiallyVisible) {
+          refreshed.nodes.push(lower);
+          refreshed.totalCount += 1;
+        }
+        const changed = refreshed.nodes.find((check) => check.databaseId === lower.databaseId);
+        assert(changed);
+        Object.assign(changed, { status, conclusion });
+        const result = replayPlaceholder(fixture, { afterAliasScan, watchTimeout: 5 });
+        expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(exitCode);
+        expect(result.stdout).not.toContain("GREEN");
+      },
+    );
+
+    it.each([33155056361, 33155056360])(
+      "still supersedes an older failed check from run %s",
+      (runId) => {
+        const fixture = structuredClone(placeholderFixture);
+        const contexts = fixture.graphql.data.repository.pullRequest.statusCheckRollup.contexts;
+        const queued = contexts.nodes.find((check) => check.databaseId === 98802098786);
+        assert(queued);
+        const older = structuredClone(queued);
+        Object.assign(older, {
+          databaseId: 98790000000,
+          status: "COMPLETED",
+          conclusion: "FAILURE",
+        });
+        older.checkSuite.workflowRun.databaseId = runId;
+        contexts.nodes.push(older);
+        contexts.totalCount += 1;
+        const result = replayPlaceholder(fixture, { watchTimeout: 5 });
+        expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+        expect(result.stdout).toContain("GREEN");
+      },
+    );
+
+    it("rechecks the attached run after refreshing the PR snapshot", () => {
+      const fixture = structuredClone(placeholderFixture);
+      const result = replayPlaceholder(fixture, {
+        runViewSnapshots: [fixture.run, fixture.run, { status: "in_progress", conclusion: null }],
+        watchTimeout: 5,
+      });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(16);
+      expect(result.stdout).not.toContain("GREEN");
     });
 
     it("keeps the captured merged PR closed", () => {

--- a/test/scripts/watch-pr-ci.test.ts
+++ b/test/scripts/watch-pr-ci.test.ts
@@ -53,6 +53,8 @@ function replayPlaceholder(
     jobPages?: unknown[];
     directJobs?: unknown[];
     merged?: boolean;
+    watchTimeout?: number;
+    delayFirstAlias?: boolean;
   } = {},
 ) {
   const root = tempDirs.make("openclaw-watch-pr-ci-replay-");
@@ -85,14 +87,17 @@ else if (args[1]?.startsWith(runPath + "/attempts/3/jobs?per_page=100&page=")) {
   if (value === undefined) throw new Error("missing attempt jobs page");
 }
 else if (args[1]?.startsWith("repos/openclaw/openclaw/actions/jobs/")) {
-  const jobIds = ${JSON.stringify(placeholderFixture.directJobs.map((job) => job.id))};
-  value = fixture.directJobs[jobIds.indexOf(Number(args[1].split("/").at(-1)))];
+  const jobIds = ${JSON.stringify(fixture.directJobs.map((job) => job.id))};
+  const jobId = Number(args[1].split("/").at(-1));
+  if (fixture.delayFirstAlias && jobId === jobIds[0]) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 2_000);
+  value = fixture.directJobs[jobIds.indexOf(jobId)];
   if (value === undefined) throw new Error("missing direct job response");
 }
 else throw new Error("unexpected gh invocation: " + JSON.stringify(args));
 console.log(JSON.stringify(value));
 `,
     placeholderFixture.run.head_sha,
+    evidence.watchTimeout === undefined ? [] : ["--timeout", String(evidence.watchTimeout)],
   );
   return { ...result, calls: readFileSync(calls, "utf8") };
 }
@@ -240,7 +245,7 @@ esac
           rollup.contexts.nodes.push({ ...queuedCheck, databaseId: 98802098559 });
           rollup.contexts.totalCount += 1;
         }
-        const result = replayPlaceholder(fixture);
+        const result = replayPlaceholder(fixture, { watchTimeout: 5 });
         expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
         expect(result.stdout).toContain(`pending=0 superseded=${observed}`);
         expect(result.stdout).toContain("GREEN");
@@ -258,6 +263,47 @@ esac
         expect(calls.at(-1)).toContain("Cache-Control: max-age=0");
       },
     );
+
+    it.each([
+      { aliasCount: 32, exitCode: 0 },
+      { aliasCount: 33, exitCode: 16 },
+    ])("bounds direct verification of a $aliasCount-alias group", ({ aliasCount, exitCode }) => {
+      const fixture = structuredClone(placeholderFixture);
+      const alias = fixture.directJobs[0];
+      assert(alias);
+      for (let index = fixture.directJobs.length; index < aliasCount; index += 1) {
+        const extra = { ...alias, id: 1_000_000 + index };
+        fixture.jobs.jobs.push(extra);
+        fixture.directJobs.push(extra);
+      }
+      fixture.jobs.total_count = fixture.jobs.jobs.length;
+      const result = replayPlaceholder(fixture, { watchTimeout: exitCode === 0 ? 5 : 1 });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(exitCode);
+      const calls: string[][] = result.calls
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      const directReads = calls.filter((call) => call[1]?.includes("/actions/jobs/"));
+      expect(directReads).toHaveLength(exitCode === 0 ? aliasCount : 0);
+      if (exitCode !== 0) {
+        expect(result.stdout).toContain("pending=1");
+        expect(result.stdout).not.toContain("GREEN");
+      }
+    });
+
+    it("bounds a slow alias read by the remaining watcher deadline", () => {
+      const result = replayPlaceholder(structuredClone(placeholderFixture), {
+        delayFirstAlias: true,
+      });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(16);
+      expect(result.stdout).toContain("pending=1");
+      expect(result.stdout).not.toContain("GREEN");
+      const calls: string[][] = result.calls
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      expect(calls.filter((call) => call[1]?.includes("/actions/jobs/"))).toHaveLength(1);
+    });
 
     it("keeps the captured merged PR closed", () => {
       const result = replayPlaceholder(structuredClone(placeholderFixture), { merged: true });
@@ -301,6 +347,7 @@ esac
     ])("requires direct unexecuted-job proof: %s", (_label, patch) => {
       const fixture = structuredClone(placeholderFixture);
       const result = replayPlaceholder(fixture, {
+        watchTimeout: 5,
         directJobs: fixture.directJobs.map((job) =>
           job.id === 98802098786 ? { ...job, ...patch } : job,
         ),
@@ -341,6 +388,7 @@ esac
     ])("rejects changed run evidence after collecting jobs: %s", (_label, patch) => {
       const fixture = structuredClone(placeholderFixture);
       const result = replayPlaceholder(fixture, {
+        watchTimeout: 5,
         runSnapshots: [fixture.run, { ...fixture.run, ...patch }],
       });
       expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(16);
@@ -436,7 +484,7 @@ esac
         totalCount: contexts.totalCount + 1,
         nodes: [...contexts.nodes, sibling],
       });
-      const result = replayPlaceholder(fixture);
+      const result = replayPlaceholder(fixture, { watchTimeout: 5 });
       expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(exitCode);
       expect(result.stdout).not.toContain("GREEN");
     });
@@ -495,7 +543,10 @@ esac
         if (scenario === "missing page") jobPages.pop();
         if (scenario === "changed count") lastPage.total_count += 1;
         if (scenario === "over limit") firstPage.total_count = 1_001;
-        const result = replayPlaceholder(fixture, { jobPages });
+        const result = replayPlaceholder(fixture, {
+          jobPages,
+          watchTimeout: scenario === "complete" ? 5 : 1,
+        });
         expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(
           scenario === "complete" ? 0 : 16,
         );

--- a/test/scripts/watch-pr-ci.test.ts
+++ b/test/scripts/watch-pr-ci.test.ts
@@ -1,5 +1,6 @@
+import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { chmodSync, writeFileSync } from "node:fs";
+import { chmodSync, readFileSync, writeFileSync } from "node:fs";
 import { delimiter, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -13,10 +14,88 @@ import {
   sanitizeCheckName,
   selectRunAfter,
 } from "../../scripts/watch-pr-ci.mts";
+import placeholderFixture from "../fixtures/watch-pr-ci-queued-placeholder.json" with { type: "json" };
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const sha = "a".repeat(40);
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function runWatcher(ghScript: string, headSha = sha, options: string[] = []) {
+  const binDir = tempDirs.make("openclaw-watch-pr-ci-");
+  const ghPath = join(binDir, "gh");
+  writeFileSync(ghPath, ghScript);
+  chmodSync(ghPath, 0o755);
+  return spawnSync(
+    process.execPath,
+    [
+      "scripts/watch-pr-ci.mjs",
+      "42",
+      headSha,
+      "--attach-timeout",
+      "1",
+      "--timeout",
+      "1",
+      "--interval",
+      "1",
+      ...options,
+    ],
+    {
+      encoding: "utf8",
+      env: { ...process.env, PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}` },
+    },
+  );
+}
+
+function replayPlaceholder(
+  fixture = structuredClone(placeholderFixture),
+  evidence: {
+    runSnapshots?: unknown[];
+    jobPages?: unknown[];
+    directJobs?: unknown[];
+    merged?: boolean;
+  } = {},
+) {
+  const root = tempDirs.make("openclaw-watch-pr-ci-replay-");
+  const payload = join(root, "payload.json");
+  const calls = join(root, "calls.jsonl");
+  // The live capture is merged. Only lifecycle is reopened for the historical watch.
+  if (!evidence.merged) fixture.graphql.data.repository.pullRequest.state = "OPEN";
+  writeFileSync(payload, JSON.stringify({ ...fixture, ...evidence }));
+  writeFileSync(calls, "");
+  const result = runWatcher(
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const fixture = JSON.parse(fs.readFileSync(${JSON.stringify(payload)}, "utf8"));
+const args = process.argv.slice(2);
+const calls = fs.readFileSync(${JSON.stringify(calls)}, "utf8").trim().split("\\n").filter(Boolean).map(JSON.parse);
+fs.appendFileSync(${JSON.stringify(calls)}, JSON.stringify(args) + "\\n");
+const runPath = "repos/openclaw/openclaw/actions/runs/33155056361";
+let value;
+if (args[0] === "pr" && args[1] === "view") value = fixture.graphql.data.repository.pullRequest;
+else if (args[0] === "run" && args[1] === "view") value = fixture.run;
+else if (args[0] === "api" && args[1] === "graphql") value = fixture.graphql;
+else if (args.includes("repos/openclaw/openclaw/actions/workflows/ci.yml/runs")) value = { workflow_runs: [fixture.run] };
+else if (args[1] === runPath) {
+  const reads = calls.filter((call) => call[1] === runPath).length;
+  value = fixture.runSnapshots?.[Math.min(reads, fixture.runSnapshots.length - 1)] ?? fixture.run;
+}
+else if (args[1]?.startsWith(runPath + "/attempts/3/jobs?per_page=100&page=")) {
+  const page = Number(new URLSearchParams(args[1].split("?")[1]).get("page"));
+  value = (fixture.jobPages ?? [fixture.jobs])[page - 1];
+  if (value === undefined) throw new Error("missing attempt jobs page");
+}
+else if (args[1]?.startsWith("repos/openclaw/openclaw/actions/jobs/")) {
+  const jobIds = ${JSON.stringify(placeholderFixture.directJobs.map((job) => job.id))};
+  value = fixture.directJobs[jobIds.indexOf(Number(args[1].split("/").at(-1)))];
+  if (value === undefined) throw new Error("missing direct job response");
+}
+else throw new Error("unexpected gh invocation: " + JSON.stringify(args));
+console.log(JSON.stringify(value));
+`,
+    placeholderFixture.run.head_sha,
+  );
+  return { ...result, calls: readFileSync(calls, "utf8") };
+}
 
 describe("watch-pr-ci", () => {
   it("parses defaults and overrides", () => {
@@ -111,10 +190,7 @@ describe("watch-pr-ci", () => {
   it.skipIf(process.platform === "win32")(
     "attaches to real CI when a newer draft workflow was skipped",
     () => {
-      const binDir = tempDirs.make("openclaw-watch-pr-ci-");
-      const ghPath = join(binDir, "gh");
-      writeFileSync(
-        ghPath,
+      const result = runWatcher(
         `#!/usr/bin/env bash
 case "$1 $2" in
   "pr view") printf '{"state":"OPEN","mergeable":true,"headRefOid":"${sha}"}\\n' ;;
@@ -134,28 +210,8 @@ case "$1 $2" in
   *) printf 'unexpected gh invocation: %s\\n' "$*" >&2; exit 2 ;;
 esac
 `,
-      );
-      chmodSync(ghPath, 0o755);
-
-      const result = spawnSync(
-        process.execPath,
-        [
-          "scripts/watch-pr-ci.mjs",
-          "42",
-          sha,
-          "--completion",
-          "ci-run",
-          "--attach-timeout",
-          "1",
-          "--timeout",
-          "1",
-          "--interval",
-          "1",
-        ],
-        {
-          encoding: "utf8",
-          env: { ...process.env, PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}` },
-        },
+        sha,
+        ["--completion", "ci-run"],
       );
 
       expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
@@ -163,6 +219,290 @@ esac
       expect(result.stdout).toContain("GREEN");
     },
   );
+
+  describe.skipIf(process.platform === "win32")("queued placeholder CLI evidence", () => {
+    it.each([
+      { state: "FAILURE", observed: 1 },
+      { state: "PENDING", observed: 1 },
+      { state: "FAILURE", observed: 2 },
+    ])(
+      "reconciles the captured queued group with aggregate $state and $observed observed checks",
+      ({ state, observed }) => {
+        const fixture = structuredClone(placeholderFixture);
+        const rollup = fixture.graphql.data.repository.pullRequest.statusCheckRollup;
+        rollup.state = state;
+        if (observed === 2) {
+          // Synthetic visibility of another captured alias proves group reads are shared.
+          const queuedCheck = rollup.contexts.nodes.find(
+            (check) => check.databaseId === 98802098786,
+          );
+          assert(queuedCheck);
+          rollup.contexts.nodes.push({ ...queuedCheck, databaseId: 98802098559 });
+          rollup.contexts.totalCount += 1;
+        }
+        const result = replayPlaceholder(fixture);
+        expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+        expect(result.stdout).toContain(`pending=0 superseded=${observed}`);
+        expect(result.stdout).toContain("GREEN");
+        // Cost and ordering matter: only one attempt scan, direct proof, then run revalidation.
+        const calls: string[][] = result.calls
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line));
+        expect(calls.filter((call) => call[1]?.includes("/attempts/"))).toHaveLength(1);
+        const directReads = calls.filter((call) => call[1]?.includes("/actions/jobs/"));
+        expect(directReads.map((call) => Number(call[1]?.split("/").at(-1))).toSorted()).toEqual(
+          fixture.directJobs.map((job) => job.id).toSorted(),
+        );
+        expect(calls.at(-1)?.[1]).toBe("repos/openclaw/openclaw/actions/runs/33155056361");
+        expect(calls.at(-1)).toContain("Cache-Control: max-age=0");
+      },
+    );
+
+    it("keeps the captured merged PR closed", () => {
+      const result = replayPlaceholder(structuredClone(placeholderFixture), { merged: true });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(10);
+      expect(result.stdout).toContain("PR-CLOSED state=MERGED");
+      expect(result.calls).not.toContain("/actions/");
+    });
+
+    it.each([
+      ["no same-name replacement", { name: "different job" }],
+      ["active replacement", { status: "in_progress", conclusion: null }],
+      ["failed replacement", { conclusion: "failure" }],
+      ["unexecuted replacement", { runner_id: null, steps: [] }],
+      ["another attempt", { run_attempt: 2 }],
+      ["another run", { run_id: 33155056362 }],
+      ["another head", { head_sha: sha }],
+      ["missing attempt", { run_attempt: undefined }],
+    ])("keeps pending for %s in the attempt list", (_label, patch) => {
+      const fixture = structuredClone(placeholderFixture);
+      Object.assign(
+        fixture.jobs.jobs.find((job) => job.id === 98802098754)!,
+        patch,
+      );
+      const result = replayPlaceholder(fixture);
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(16);
+      expect(result.stdout).not.toContain("GREEN");
+    });
+
+    it.each([
+      ["assigned queued job", { runner_id: 123 }],
+      ["executed steps", { steps: [{ status: "completed", conclusion: "success" }] }],
+      ["missing steps", { steps: undefined }],
+      ["missing runner", { runner_id: undefined }],
+      ["different check ID", { id: 98802098787 }],
+      ["different name", { name: "different job" }],
+      ["different run", { run_id: 33155056362 }],
+      ["different head", { head_sha: sha }],
+      ["different attempt", { run_attempt: 4 }],
+      ["active job", { status: "in_progress" }],
+      ["failed job", { conclusion: "failure" }],
+    ])("requires direct unexecuted-job proof: %s", (_label, patch) => {
+      const fixture = structuredClone(placeholderFixture);
+      const result = replayPlaceholder(fixture, {
+        directJobs: fixture.directJobs.map((job) =>
+          job.id === 98802098786 ? { ...job, ...patch } : job,
+        ),
+      });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(16);
+      expect(result.stdout).not.toContain("GREEN");
+    });
+
+    it.each([
+      ["executed", { steps: [{ status: "completed", conclusion: "success" }] }],
+      ["active", { status: "in_progress", runner_id: 123 }],
+      ["failed", { status: "completed", conclusion: "failure" }],
+      ["malformed", { run_attempt: undefined }],
+    ])("keeps the group pending when a non-rollup sibling is %s", (_label, patch) => {
+      const fixture = structuredClone(placeholderFixture);
+      const result = replayPlaceholder(fixture, {
+        directJobs: fixture.directJobs.map((job) =>
+          job.id === 98802098559 ? { ...job, ...patch } : job,
+        ),
+      });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(16);
+      expect(result.stdout).not.toContain("GREEN");
+    });
+
+    it.each([
+      ["missing ID", { id: undefined }],
+      ["missing head", { head_sha: undefined }],
+      ["missing workflow", { workflow_id: undefined }],
+      ["missing attempt", { run_attempt: undefined }],
+      ["different workflow", { workflow_id: 1 }],
+      ["different workflow path", { path: ".github/workflows/other.yml" }],
+      ["different head", { head_sha: sha }],
+      ["different run", { id: 33155056362 }],
+      ["active newer attempt", { run_attempt: 4, status: "in_progress", conclusion: null }],
+      ["failed newer attempt", { run_attempt: 4, conclusion: "failure" }],
+      ["cancelled newer attempt", { run_attempt: 4, conclusion: "cancelled" }],
+      ["successful newer attempt", { run_attempt: 4 }],
+    ])("rejects changed run evidence after collecting jobs: %s", (_label, patch) => {
+      const fixture = structuredClone(placeholderFixture);
+      const result = replayPlaceholder(fixture, {
+        runSnapshots: [fixture.run, { ...fixture.run, ...patch }],
+      });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(16);
+      expect(result.stdout).not.toContain("GREEN");
+    });
+
+    it.each([
+      { status: "in_progress", conclusion: null },
+      { status: "completed", conclusion: "failure" },
+      { status: "completed", conclusion: "success" },
+    ])(
+      "does not ignore an extra $status/$conclusion same-name sibling",
+      ({ status, conclusion }) => {
+        const fixture = structuredClone(placeholderFixture);
+        const replacement = fixture.jobs.jobs.find((job) => job.id === 98802098754);
+        assert(replacement);
+        const result = replayPlaceholder(fixture, {
+          jobPages: [
+            {
+              total_count: fixture.jobs.total_count + 1,
+              jobs: [...fixture.jobs.jobs, { ...replacement, id: 98802098799, status, conclusion }],
+            },
+          ],
+        });
+        expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(16);
+      },
+    );
+
+    it.each([
+      [
+        "unrelated workflow",
+        { checkSuite: { workflowRun: { databaseId: 33155056361, workflow: { databaseId: 1 } } } },
+      ],
+      [
+        "unrelated run",
+        {
+          checkSuite: {
+            workflowRun: { databaseId: 33155056362, workflow: { databaseId: 209874334 } },
+          },
+        },
+      ],
+      ["missing check ID", { databaseId: undefined }],
+      ["App check without lineage", { checkSuite: undefined }],
+      ["in-progress check", { status: "IN_PROGRESS" }],
+      [
+        "required status context",
+        { kind: "StatusContext", context: "required status", state: "PENDING" },
+      ],
+    ])("does not reconcile %s", (_label, patch) => {
+      const fixture = structuredClone(placeholderFixture);
+      const queuedCheck =
+        fixture.graphql.data.repository.pullRequest.statusCheckRollup.contexts.nodes.find(
+          (check) => check.databaseId === 98802098786,
+        );
+      assert(queuedCheck);
+      Object.assign(queuedCheck, patch);
+      const result = replayPlaceholder(fixture);
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(16);
+      expect(result.calls).not.toContain("/attempts/");
+    });
+
+    it.each([
+      [
+        "pending required App check",
+        { kind: "CheckRun", name: "required App", status: "QUEUED" },
+        16,
+      ],
+      [
+        "failed required App check",
+        { kind: "CheckRun", name: "required App", status: "COMPLETED", conclusion: "FAILURE" },
+        15,
+      ],
+      [
+        "pending required status context",
+        { kind: "StatusContext", context: "required status", state: "EXPECTED" },
+        16,
+      ],
+      [
+        "failed required status context",
+        { kind: "StatusContext", context: "required status", state: "FAILURE" },
+        15,
+      ],
+      [
+        "unknown completed conclusion",
+        { kind: "CheckRun", name: "required App", status: "COMPLETED" },
+        16,
+      ],
+    ] as const)("keeps %s independently blocking", (_label, sibling, exitCode) => {
+      const fixture = structuredClone(placeholderFixture);
+      const contexts = fixture.graphql.data.repository.pullRequest.statusCheckRollup.contexts;
+      // Synthetic counterexamples add a separate, lineage-less required context.
+      Object.assign(contexts, {
+        totalCount: contexts.totalCount + 1,
+        nodes: [...contexts.nodes, sibling],
+      });
+      const result = replayPlaceholder(fixture);
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(exitCode);
+      expect(result.stdout).not.toContain("GREEN");
+    });
+
+    it.each(["unknown", "truncated", "unfinished pagination", "missing count"])(
+      "does not green an %s rollup",
+      (scenario) => {
+        const fixture = structuredClone(placeholderFixture);
+        const rollup = fixture.graphql.data.repository.pullRequest.statusCheckRollup;
+        if (scenario === "unknown") rollup.state = "UNKNOWN";
+        else if (scenario === "truncated") rollup.contexts.totalCount += 1;
+        else if (scenario === "missing count")
+          Object.assign(rollup.contexts, { totalCount: undefined });
+        else rollup.contexts.pageInfo.hasNextPage = true;
+        const result = replayPlaceholder(fixture);
+        expect(result.status, `${result.stdout}\n${result.stderr}`).not.toBe(0);
+        expect(result.stdout).not.toContain("GREEN");
+        expect(result.calls).not.toContain("/attempts/");
+      },
+    );
+
+    it.each(["in_progress", "queued", "completed"])(
+      "avoids evidence scans on routine %s polls",
+      (status) => {
+        const fixture = structuredClone(placeholderFixture);
+        fixture.run.status = status;
+        if (status === "completed") {
+          const rollup = fixture.graphql.data.repository.pullRequest.statusCheckRollup;
+          rollup.state = "SUCCESS";
+          rollup.contexts.nodes = rollup.contexts.nodes.slice(0, 1);
+          rollup.contexts.totalCount = 1;
+        }
+        const result = replayPlaceholder(fixture);
+        expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(
+          status === "completed" ? 0 : 16,
+        );
+        expect(result.calls).not.toContain("/attempts/");
+        expect(result.calls).not.toContain("/actions/jobs/");
+      },
+    );
+
+    it.each(["complete", "missing page", "changed count", "duplicate IDs", "over limit"])(
+      "requires complete bounded attempt pagination: %s",
+      (scenario) => {
+        const fixture = structuredClone(placeholderFixture);
+        // Synthetic pagination padding from the captured successful sibling; IDs/names
+        // are deliberately unique so the target group only appears on the second page.
+        const padding = Array.from({ length: 100 }, (_, index) => ({
+          ...fixture.jobs.jobs.find((job) => job.id === 98802098742)!,
+          id: scenario === "duplicate IDs" ? 1_000 : 1_000 + index,
+          name: `pagination sibling ${index}`,
+        }));
+        const firstPage = { total_count: 100 + fixture.jobs.total_count, jobs: padding };
+        const lastPage = { total_count: firstPage.total_count, jobs: fixture.jobs.jobs };
+        const jobPages = [firstPage, lastPage];
+        if (scenario === "missing page") jobPages.pop();
+        if (scenario === "changed count") lastPage.total_count += 1;
+        if (scenario === "over limit") firstPage.total_count = 1_001;
+        const result = replayPlaceholder(fixture, { jobPages });
+        expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(
+          scenario === "complete" ? 0 : 16,
+        );
+        if (scenario === "complete") expect(result.calls).toContain("per_page=100&page=2");
+      },
+    );
+  });
 
   it("sanitizes untrusted check names for terminal output", () => {
     expect(sanitizeCheckName("plain ASCII / check (1)")).toBe("plain ASCII / check (1)");


### PR DESCRIPTION
Closes #131924 (CI watcher stalls after successful reruns).

Related: [skill/Gmail dependency repair, where the watcher stall was observed](https://github.com/openclaw/openclaw/pull/131617).

<details>
<summary>Additional instructions</summary>

Maintainers can update this same-repository branch.

</details>

## What Problem This Solves

Fixes an issue where maintainers waiting for PR CI would remain stuck after a successful rerun when GitHub retained queued duplicate checks. The default watcher reported `STATUS state=FAILURE pending=1 superseded=8` even though the executed jobs and exact-head GitHub Actions-owned gate had succeeded.

## Why This Change Was Made

The successful same-name job is absent from GitHub's rollup, so changing newest-check-ID precedence cannot repair the input. The watcher now reconciles only positively identified queued aliases using the attached run's successful exact-head attempt, the complete same-name job group, direct unexecuted-job evidence for every alias, and a final run revalidation. Direct alias verification is capped at 32 requests per poll, and the evidence scan shares the remaining watcher timeout; oversized groups remain pending with a warning. Ordinary workflow/name supersession, required-check handling, and `ci-run` mode remain intact; no success becomes blanket green. Before applying proof, the watcher refreshes the PR/check snapshot and rechecks the attached run. Changed aliases remain visible, and a removed placeholder cannot hide a covered sibling that became active or failed.

This also documents the distinction between default rollup completion and the narrower CI-run wait used by the native merge flow. It does not change binary-probe caching, gateway behavior, configuration, dependencies, or merge authority.

## User Impact

The reproduced completed rerun now finishes the watcher instead of timing out. Active retries, failed or unrelated checks, identity-less App checks, required status contexts, missing identities, and incomplete evidence remain blocking. This is maintainer tooling only; there is no bot runtime behavior change.

## Evidence

The 2026-08-28 live capture is from [CI run 33155056361 attempt 3](https://github.com/openclaw/openclaw/actions/runs/33155056361/attempts/3) at head `baa73943fbcd7b47f5432d36d4d242f8170dc141`. Required check `98802776296` is completed/success from GitHub Actions app ID `15368`. Executed config-64 job `98802098754` succeeded, but GraphQL exposes queued alias `98802098786` instead. All 14 queued aliases were verified through their direct job endpoints. The checked-in fixture preserves every related alias and the observed list/direct step inconsistency.

The identical full API snapshot—239 rollup contexts, 207 attempt jobs and 14 direct responses—produces:

```text
Before: STATUS state=FAILURE pending=1 superseded=8; TIMEOUT; exit 16
After:  STATUS state=FAILURE pending=0 superseded=9; GREEN; exit 0
```

The original PR has merged; historical replay changes only its lifecycle from MERGED to OPEN. The real current CLI still returns `PR-CLOSED state=MERGED` with exit 10. This is live API evidence plus a faithful CLI replay, not a claim of live CLI success on an open PR.

Local verification:

- `node scripts/run-vitest.mjs test/scripts/watch-pr-ci.test.ts test/scripts/pr-merge.test.ts -t 'watch-pr-ci|pending required checks|exact-head required CI is failing|default immediate pinned squash merge'` — 127 passed: all 124 watcher cases plus 3 native merge-caller cases; 60 unrelated caller cases excluded by the filter. The original placeholder, request-budget, stale-head, changed-sibling, and unknown-outcome regressions each failed before their correction. The captured 14-alias group, 32-alias boundary, and legitimate older-attempt supersession remain green.
- `node scripts/check-changed.mjs -- scripts/watch-pr-ci.mts test/scripts/watch-pr-ci.test.ts test/fixtures/watch-pr-ci-queued-placeholder.json` — passed, including script/test type checks and script lint.
- `pnpm docs:list`, `node_modules/.bin/oxfmt --check docs/ci.md`, and `git diff --check` — passed.
- Independent Codex autoreview of the complete final patch — no actionable P0–P2 findings.

Production LOC: +278/-28 (net +250). Tests: +574/-27 (net +547), plus 780 fixture lines; docs +30. Production growth supplies the missing attempt/job evidence boundary: the prior rollup input cannot distinguish this case by reordering existing checks. No compatibility or alternate merge path was added.

The [ClawSweeper request-budget finding](https://github.com/openclaw/openclaw/pull/131926#issuecomment-5455908004) is addressed by [the bounded-evidence follow-up](https://github.com/openclaw/openclaw/commit/e3881933fce7cf64075d0e728460c560b20cacc3). Its oversized-group and slow-read regressions returned GREEN before the correction and now remain pending/time out without unbounded direct lookups. The [final snapshot/supersession follow-up](https://github.com/openclaw/openclaw/commit/19ee8abe0c4d4486266ed5408a1a35dff5f46d11) also addresses the later stale-head finding. Full-capture replay now returns HEAD-MOVED (11), not GREEN, when the PR changes during verification; closed/conflicting PRs and newly pending/failed checks are likewise observed. A higher-ID removed alias cannot suppress a changed lower-ID sibling, including one only revealed by the refresh. Unknown outcomes cannot justify overriding a failed aggregate.

Before that follow-up, [CI attempt 4](https://github.com/openclaw/openclaw/actions/runs/33193263330/attempts/4) passed on head `4edd90b3a9e534f8ef9ecada11761be3426f64fe`. Attempts 2 and 3 terminated the plugin lint process with exit 143 and no lint diagnostic; the diagnostic rerun passed without changing timeouts, runner policy, or merge gates.

Limits: reconciliation requires complete bounded evidence (up to 1,000 jobs and 32 direct alias lookups per poll); evidence requests consume the remaining watcher timeout, and oversized groups remain pending. Ordinary polls do not scan job evidence. Freshness requests use the existing shared transport. API/cache delays and the race after a final read remain observational limitations; native required checks, not this watcher, authorize a merge. No live gateway or UI proof is applicable.

AI-assisted implementation and independent review.


