### PR TITLE
fix(agent): stop aborting healthy model responses as idle timeouts while the provider stream is still active

### DIFF
--- a/extensions/amazon-bedrock/stream.runtime.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.test.ts
@@ -937,7 +937,7 @@ describe("Bedrock Fable contract", () => {
       unsubscribe();
     }
 
-    expect(activityCount).toBeGreaterThan(0);
+    expect(activityCount).toBe(3);
   });
 });
 

--- a/extensions/amazon-bedrock/stream.runtime.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.test.ts
@@ -919,6 +919,18 @@ describe("Bedrock Fable contract", () => {
             delta: { text: "buffered output" },
           },
         },
+        {
+          metadata: {
+            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            metrics: { latencyMs: 1 },
+          },
+        },
+        {
+          metadata: {
+            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            metrics: { latencyMs: 1 },
+          },
+        },
         { messageStop: { stopReason: "end_turn" } },
       ]),
     } as never);
@@ -937,7 +949,7 @@ describe("Bedrock Fable contract", () => {
       unsubscribe();
     }
 
-    expect(activityCount).toBe(3);
+    expect(activityCount).toBe(5);
   });
 });
 

--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -177,9 +177,7 @@ const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOptions> =
     // Claude classifiers may refuse after partial output. Hold every event until
     // messageStop proves the response is safe to expose.
     const refusalBuffer = usesClaudeStreamingRefusalBedrockContract(model)
-      ? createDeferredEventBuffer<AssistantMessageEvent>(stream, () =>
-          notifyLlmRequestActivity(options.signal),
-        )
+      ? createDeferredEventBuffer<AssistantMessageEvent>(stream)
       : undefined;
     const eventSink = refusalBuffer ?? stream;
 
@@ -308,6 +306,7 @@ const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOptions> =
 
       let sawMessageStop = false;
       for await (const item of { [Symbol.asyncIterator]: () => responseIterator }) {
+        notifyLlmRequestActivity(options.signal);
         if (item.messageStart) {
           if (item.messageStart.role !== ConversationRole.ASSISTANT) {
             throw new Error(

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -7,6 +7,7 @@ import { gzipSync } from "node:zlib";
 import { expectDefined } from "@openclaw/normalization-core";
 import { toErrorObject as toLintErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import type { Model, ProviderContext } from "openclaw/plugin-sdk/llm";
+import { onLlmRequestActivity } from "openclaw/plugin-sdk/provider-stream-shared";
 import { withProviderAcceptanceObserver } from "openclaw/plugin-sdk/provider-transport-runtime";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetGoogleVertexAdcState } from "./google-oauth.test-support.js";
@@ -480,6 +481,25 @@ describe("google transport stream", () => {
     vi.doUnmock("openclaw/plugin-sdk/provider-transport-runtime");
     vi.doUnmock("google-auth-library");
     vi.resetModules();
+  });
+
+  it("reports every parsed Google SSE chunk as request activity", async () => {
+    const chunks = [
+      { usageMetadata: { totalTokenCount: 1 } },
+      { candidates: [{ finishReason: "STOP" }] },
+    ];
+    guardedFetchMock.mockResolvedValueOnce(buildSseResponse(chunks));
+    const controller = new AbortController();
+    const onActivity = vi.fn();
+    const unsubscribe = onLlmRequestActivity(controller.signal, onActivity);
+
+    try {
+      await runGeminiStreamResult({ options: { signal: controller.signal } });
+    } finally {
+      unsubscribe();
+    }
+
+    expect(onActivity).toHaveBeenCalledTimes(chunks.length);
   });
 
   it("resolves qualified AI Studio video after payload hooks and preserves part order", async () => {

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -24,6 +24,7 @@ import {
   providerOperationRetryConfig,
   resolveProviderRequestHeaders,
 } from "openclaw/plugin-sdk/provider-http";
+import { notifyLlmRequestActivity } from "openclaw/plugin-sdk/provider-stream-shared";
 import {
   buildGuardedModelFetch,
   coerceTransportToolCallArguments,
@@ -1552,6 +1553,7 @@ function createGoogleTransportStreamFn(kind: CanonicalGoogleTransportApi): Strea
                 yield* sse.chunks;
               })(sse.firstChunk);
         for await (const chunk of chunks) {
+          notifyLlmRequestActivity(options?.signal);
           output.responseId ||= chunk.responseId;
           const responseModel = normalizeOptionalString(chunk.modelVersion);
           if (

--- a/extensions/ollama/src/stream.runtime.ts
+++ b/extensions/ollama/src/stream.runtime.ts
@@ -19,7 +19,10 @@ import { createAssistantMessageEventStream, transformMessages } from "openclaw/p
 import type { ProviderRuntimeModel } from "openclaw/plugin-sdk/plugin-entry";
 import { isNonSecretApiKeyMarker } from "openclaw/plugin-sdk/provider-auth";
 import { readProviderResponseErrorText } from "openclaw/plugin-sdk/provider-http";
-import { createPlainTextToolCallCompatWrapper } from "openclaw/plugin-sdk/provider-stream-shared";
+import {
+  createPlainTextToolCallCompatWrapper,
+  notifyLlmRequestActivity,
+} from "openclaw/plugin-sdk/provider-stream-shared";
 import {
   describeUnsupportedToolResultMedia,
   extractToolResultText,
@@ -1228,6 +1231,7 @@ function createRawOllamaStreamFn(
 
           for await (const chunk of parseNdjsonStream(reader)) {
             throwIfOllamaStreamAborted(options?.signal);
+            notifyLlmRequestActivity(options?.signal);
             if (finalResponse) {
               throw new Error(MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE);
             }

--- a/extensions/ollama/src/stream.test.ts
+++ b/extensions/ollama/src/stream.test.ts
@@ -2,6 +2,7 @@
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import { expectDefined } from "@openclaw/normalization-core";
+import { onLlmRequestActivity } from "openclaw/plugin-sdk/provider-stream-shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
@@ -523,6 +524,9 @@ describe("createOllamaStreamFn thinking events", () => {
       makeOllamaResponse({ content: "" }),
     ];
     const refreshTimeout = vi.fn();
+    const controller = new AbortController();
+    const onActivity = vi.fn();
+    const unsubscribe = onLlmRequestActivity(controller.signal, onActivity);
     fetchWithSsrFGuardMock.mockResolvedValue({
       response: new Response(makeNdjsonBody(chunks), { status: 200 }),
       release: vi.fn(async () => undefined),
@@ -533,16 +537,21 @@ describe("createOllamaStreamFn thinking events", () => {
     const stream = streamFn(
       STREAM_MODEL as never,
       { messages: [{ role: "user", content: "test" }] } as never,
-      {},
+      { signal: controller.signal },
     );
 
     const events: Array<{ type: string }> = [];
-    for await (const event of stream as AsyncIterable<{ type: string }>) {
-      events.push(event);
+    try {
+      for await (const event of stream as AsyncIterable<{ type: string }>) {
+        events.push(event);
+      }
+    } finally {
+      unsubscribe();
     }
 
     expect(events.some((event) => event.type === "done")).toBe(true);
     expect(refreshTimeout).toHaveBeenCalledTimes(chunks.length);
+    expect(onActivity).toHaveBeenCalledTimes(chunks.length);
   });
 
   it("redacts reflected credentials from a real non-2xx Ollama response", async () => {

--- a/packages/ai/src/providers/anthropic.sse-parse-error.test.ts
+++ b/packages/ai/src/providers/anthropic.sse-parse-error.test.ts
@@ -107,8 +107,8 @@ describe("Anthropic malformed SSE frames", () => {
   });
 
   it("keeps a response alive while Anthropic sends protocol pings", async () => {
-    const idleTimeoutMs = 300;
-    const finalResponseDelayMs = 450;
+    const idleTimeoutMs = 1_000;
+    const finalResponseDelayMs = 1_200;
     let pingCount = 0;
     const server = createServer((request, response) => {
       response.writeHead(200, {
@@ -146,7 +146,7 @@ describe("Anthropic malformed SSE frames", () => {
         streamWithIdleTimeout(streamAnthropic as never, idleTimeoutMs, onIdleTimeout)(
           makeModel(`http://127.0.0.1:${address.port}`),
           context,
-          { apiKey: "test-api-key", maxRetries: 0 },
+          { apiKey: "test-api-key" },
         ),
       )) as ReturnType<typeof streamAnthropic>;
       for await (const event of stream) {

--- a/packages/ai/src/providers/anthropic.sse-parse-error.test.ts
+++ b/packages/ai/src/providers/anthropic.sse-parse-error.test.ts
@@ -1,7 +1,8 @@
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import Anthropic from "@anthropic-ai/sdk";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { streamWithIdleTimeout } from "../../../../src/agents/embedded-agent-runner/run/llm-idle-timeout.js";
 import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../transports/transport-utils.js";
 import type { Context, Model } from "../types.js";
 import { streamAnthropic } from "./anthropic.js";
@@ -103,6 +104,67 @@ describe("Anthropic malformed SSE frames", () => {
 
     expect(result.stopReason).toBe("stop");
     expect(result.errorMessage).toBeUndefined();
+  });
+
+  it("keeps a response alive while Anthropic sends protocol pings", async () => {
+    const idleTimeoutMs = 300;
+    const finalResponseDelayMs = 450;
+    let pingCount = 0;
+    const server = createServer((request, response) => {
+      response.writeHead(200, {
+        "content-type": "text/event-stream",
+        "cache-control": "no-cache",
+      });
+      const writeFrame = ([event, data]: (typeof WELL_FORMED_FRAMES)[number]) => {
+        response.write(`event: ${event}\ndata: ${data}\n\n`);
+      };
+      writeFrame(WELL_FORMED_FRAMES[0]);
+      const pingTimer = setInterval(() => {
+        pingCount += 1;
+        response.write('event: ping\ndata: {"type":"ping"}\n\n');
+      }, 20);
+      const finalTimer = setTimeout(() => {
+        clearInterval(pingTimer);
+        for (const frame of WELL_FORMED_FRAMES.slice(1)) {
+          writeFrame(frame);
+        }
+        response.end();
+      }, finalResponseDelayMs);
+      response.on("close", () => {
+        clearInterval(pingTimer);
+        clearTimeout(finalTimer);
+      });
+      void request.resume();
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const address = server.address() as AddressInfo;
+    try {
+      const onIdleTimeout = vi.fn();
+      const stream = (await Promise.resolve(
+        streamWithIdleTimeout(streamAnthropic as never, idleTimeoutMs, onIdleTimeout)(
+          makeModel(`http://127.0.0.1:${address.port}`),
+          context,
+          { apiKey: "test-api-key", maxRetries: 0 },
+        ),
+      )) as ReturnType<typeof streamAnthropic>;
+      for await (const event of stream) {
+        // The idle watchdog guards consumer waits between provider events.
+        void event;
+      }
+      const result = await stream.result();
+
+      expect(result.stopReason).toBe("stop");
+      expect(result.content).toEqual([expect.objectContaining({ type: "text", text: "ok" })]);
+      expect(onIdleTimeout).not.toHaveBeenCalled();
+      expect(pingCount).toBeGreaterThan(0);
+      expect(finalResponseDelayMs).toBeGreaterThan(idleTimeoutMs);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
   });
 
   it.each([

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -299,6 +299,7 @@ const ANTHROPIC_MESSAGE_EVENTS: ReadonlySet<string> = new Set([
 async function* iterateAnthropicEvents(
   response: Response,
   requireMessageStop = false,
+  signal?: AbortSignal,
 ): AsyncGenerator<RawMessageStreamEvent> {
   if (!response.body) {
     throw new Error("Attempted to iterate over an Anthropic response with no body");
@@ -311,17 +312,21 @@ async function* iterateAnthropicEvents(
       throw new Error(sse.data);
     }
 
-    if (!ANTHROPIC_MESSAGE_EVENTS.has(sse.event ?? "")) {
-      continue;
-    }
-
+    const isMessageEvent = ANTHROPIC_MESSAGE_EVENTS.has(sse.event ?? "");
     try {
       const event = parseJsonWithRepair(sse.data) as RawMessageStreamEvent;
+      notifyLlmRequestActivity(signal);
+      if (!isMessageEvent) {
+        continue;
+      }
       if (event.type === "message_stop") {
         sawMessageEnd = true;
       }
       yield event;
     } catch (error) {
+      if (!isMessageEvent) {
+        continue;
+      }
       // Frame payloads carry model output, so surface the shared malformed-fragment
       // error instead of echoing them. The SyntaxError stays reachable on `cause`.
       if (error instanceof SyntaxError) {
@@ -366,9 +371,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicComp
     // Classifier refusals can invalidate partial output, so no event is safe
     // to expose until the terminal stop reason is known.
     const refusalBuffer = usesClaudeStreamingRefusalContract(model)
-      ? createDeferredEventBuffer<AssistantMessageEvent>(stream, () =>
-          notifyLlmRequestActivity(requestOptions?.signal),
-        )
+      ? createDeferredEventBuffer<AssistantMessageEvent>(stream)
       : undefined;
     const eventSink = refusalBuffer ?? stream;
     // Fallback-served turns bill at the serving model's rates; a boundary
@@ -475,7 +478,11 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicComp
       const compactionCapture = createCompactionCapture(output, model, requestOptions);
       const requireMessageStop = refusalBuffer !== undefined || isDirectAnthropicModel(model);
 
-      for await (const event of iterateAnthropicEvents(response, requireMessageStop)) {
+      for await (const event of iterateAnthropicEvents(
+        response,
+        requireMessageStop,
+        requestOptions?.signal,
+      )) {
         // A serving-model fallback replaces the initial snapshot; report only once at completion.
         inputTransformations = readAnthropicInputTransformations(event) ?? inputTransformations;
         if (event.type === "message_start") {

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -312,21 +312,18 @@ async function* iterateAnthropicEvents(
       throw new Error(sse.data);
     }
 
-    const isMessageEvent = ANTHROPIC_MESSAGE_EVENTS.has(sse.event ?? "");
+    notifyLlmRequestActivity(signal);
+    if (!ANTHROPIC_MESSAGE_EVENTS.has(sse.event ?? "")) {
+      continue;
+    }
+
     try {
       const event = parseJsonWithRepair(sse.data) as RawMessageStreamEvent;
-      notifyLlmRequestActivity(signal);
-      if (!isMessageEvent) {
-        continue;
-      }
       if (event.type === "message_stop") {
         sawMessageEnd = true;
       }
       yield event;
     } catch (error) {
-      if (!isMessageEvent) {
-        continue;
-      }
       // Frame payloads carry model output, so surface the shared malformed-fragment
       // error instead of echoing them. The SyntaxError stays reachable on `cause`.
       if (error instanceof SyntaxError) {

--- a/packages/ai/src/providers/google-shared.test.ts
+++ b/packages/ai/src/providers/google-shared.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, it, vi } from "vitest";
 import { withProviderAcceptanceObserver } from "../transports/transport-stream-shared.js";
 import type { Model } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
+import { onLlmRequestActivity } from "../utils/llm-request-activity.js";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../utils/system-prompt-cache-boundary.js";
 import {
   buildGoogleGenerateContentParams,
@@ -269,6 +270,33 @@ async function runGoogleFixture(
 }
 
 describe("consumeGoogleGenerateContentStream", () => {
+  it("reports every parsed Google response as request activity", async () => {
+    const controller = new AbortController();
+    const onActivity = vi.fn();
+    const unsubscribe = onLlmRequestActivity(controller.signal, onActivity);
+    const output = createOutput();
+    const stream = new AssistantMessageEventStream();
+    const responses = [
+      googleResponse({ usageMetadata: { totalTokenCount: 1 } }),
+      googleResponse({ finishReason: FinishReason.STOP }),
+    ];
+
+    try {
+      await consumeGoogleGenerateContentStream({
+        chunks: chunks(responses),
+        model,
+        output,
+        stream,
+        signal: controller.signal,
+        nextToolCallId: (name) => `generated-${name}`,
+      });
+    } finally {
+      unsubscribe();
+    }
+
+    expect(onActivity).toHaveBeenCalledTimes(responses.length);
+  });
+
   it("projects text, thinking, tool calls, response id, and usage into one stream", async () => {
     const { output, events } = await consumeGoogleFixture(
       [

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -38,6 +38,7 @@ import type {
   StreamOptions,
 } from "../types.js";
 import type { AssistantMessageEventStream } from "../utils/event-stream.js";
+import { notifyLlmRequestActivity } from "../utils/llm-request-activity.js";
 import { sortPromptCacheToolsByName } from "../utils/prompt-cache-stability.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { stripSystemPromptCacheBoundary } from "../utils/system-prompt-cache-boundary.js";
@@ -804,6 +805,7 @@ export async function consumeGoogleGenerateContentStream<T extends GoogleApiType
   };
 
   for await (const chunk of params.chunks) {
+    notifyLlmRequestActivity(params.signal);
     params.output.responseId ||= chunk.responseId;
     const responseModel = chunk.modelVersion?.trim();
     if (

--- a/packages/ai/src/providers/mistral.test.ts
+++ b/packages/ai/src/providers/mistral.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { configureAiTransportHost } from "../host.js";
 import { withProviderAcceptanceObserver } from "../transports/transport-stream-shared.js";
 import type { Context, Model } from "../types.js";
+import { onLlmRequestActivity } from "../utils/llm-request-activity.js";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../utils/system-prompt-cache-boundary.js";
 
 const mistralMockState = vi.hoisted(() => ({
@@ -239,6 +240,35 @@ describe("Mistral provider", () => {
 
   afterEach(() => {
     configureAiTransportHost({});
+  });
+
+  it("reports every parsed Mistral event as request activity", async () => {
+    const events = [
+      { data: { id: "resp-activity", model: "mistral-large-latest", choices: [], usage: {} } },
+      {
+        data: {
+          id: "resp-activity",
+          model: "mistral-large-latest",
+          choices: [{ finishReason: "stop", delta: { content: "ok" } }],
+        },
+      },
+    ];
+    mistralMockState.streamResult = {
+      async *[Symbol.asyncIterator]() {
+        yield* events;
+      },
+    };
+    const controller = new AbortController();
+    const onActivity = vi.fn();
+    const unsubscribe = onLlmRequestActivity(controller.signal, onActivity);
+
+    try {
+      await runMistralFixture(context, { signal: controller.signal });
+    } finally {
+      unsubscribe();
+    }
+
+    expect(onActivity).toHaveBeenCalledTimes(events.length);
   });
 
   it("reports the real HTTP response captured by the Mistral HTTPClient hook", async () => {

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -39,6 +39,7 @@ import {
   parseStreamingJson,
   type ToolArgumentPreviewSchedule,
 } from "../utils/json-parse.js";
+import { notifyLlmRequestActivity } from "../utils/llm-request-activity.js";
 import { sortPromptCacheToolsByName } from "../utils/prompt-cache-stability.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { createSseByteGuard } from "../utils/streaming-byte-guard.js";
@@ -200,7 +201,7 @@ export const streamMistral: StreamFunction<"mistral-conversations", MistralOptio
         });
       }
       stream.push({ type: "start", partial: output });
-      await consumeChatStream(model, output, stream, mistralStream);
+      await consumeChatStream(model, output, stream, mistralStream, options?.signal);
 
       if (options?.signal?.aborted) {
         throw transportAbortError(options.signal);
@@ -399,6 +400,7 @@ async function consumeChatStream(
   output: AssistantMessage,
   stream: AssistantMessageEventStream,
   mistralStream: AsyncIterable<CompletionEvent>,
+  signal?: AbortSignal,
 ): Promise<void> {
   let currentBlock: TextContent | ThinkingContent | null = null;
   let terminalFinishReason: string | undefined;
@@ -589,6 +591,7 @@ async function consumeChatStream(
   };
 
   for await (const event of mistralStream) {
+    notifyLlmRequestActivity(signal);
     const chunk = event.data;
     // Mistral's streamed CompletionChunk carries an id field. Keep the first non-empty one,
     // mirroring how OpenAI-style streaming exposes a stable response identifier per stream.

--- a/packages/ai/src/transports/anthropic-transport-stream.test.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.test.ts
@@ -11,6 +11,7 @@ import {
   getAiTransportHost,
   type AiInlineContentBlock,
 } from "../host.js";
+import { onLlmRequestActivity } from "../utils/llm-request-activity.js";
 import { createCompactionCapture } from "./anthropic-compaction-replay.js";
 import { resolveCompactionReplayPressure } from "./provider-compaction-replay.js";
 import { withProviderAcceptanceObserver } from "./transport-stream-shared.js";
@@ -1650,6 +1651,30 @@ describe("anthropic transport stream", () => {
 
     expect(result.stopReason).toBe("error");
     expect(result.errorMessage).toBe("OpenClaw transport error: malformed_streaming_fragment");
+  });
+
+  it("reports every parsed Anthropic event as request activity", async () => {
+    const events = [
+      anthropicMessageStart({ id: "msg_activity", usage: {} }),
+      { type: "ping" },
+      { type: "message_stop" },
+    ];
+    guardedFetchMock.mockResolvedValueOnce(createSseResponse(events));
+    const controller = new AbortController();
+    const onActivity = vi.fn();
+    const unsubscribe = onLlmRequestActivity(controller.signal, onActivity);
+
+    try {
+      await runTransportStream(
+        makeAnthropicTransportModel(),
+        { messages: [{ role: "user", content: "hello" }] } as AnthropicStreamContext,
+        { apiKey: "sk-ant-api", signal: controller.signal } as AnthropicStreamOptions,
+      );
+    } finally {
+      unsubscribe();
+    }
+
+    expect(onActivity).toHaveBeenCalledTimes(events.length);
   });
 
   it.each([

--- a/packages/ai/src/transports/anthropic-transport-stream.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.ts
@@ -1157,9 +1157,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
       // Classifier refusals can invalidate partial output, so no event is safe
       // to expose until the terminal stop reason is known.
       const refusalBuffer = usesClaudeStreamingRefusalContract(model)
-        ? createDeferredEventBuffer<AssistantMessageEvent>(stream, () =>
-            notifyLlmRequestActivity(options?.signal),
-          )
+        ? createDeferredEventBuffer<AssistantMessageEvent>(stream)
         : undefined;
       const eventSink = refusalBuffer ?? stream;
       // Fallback-served turns bill at the serving model's rates; a boundary
@@ -1360,6 +1358,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
         for await (const event of anthropicStream) {
           // A serving-model fallback replaces the initial snapshot; report only once at completion.
           inputTransformations = readAnthropicInputTransformations(event) ?? inputTransformations;
+          notifyLlmRequestActivity(transportOptions.signal);
           if (event.type === "error") {
             const error = event.error as { message?: string } | undefined;
             throw new Error(error?.message || "Anthropic Messages stream failed");


### PR DESCRIPTION
Closes #131927

## What Problem This Solves

A healthy model response could be aborted and retried while its provider was still sending protocol activity that produced no consumer-visible assistant event. Anthropic `ping` frames reproduce the failure; usage, metadata, hidden-reasoning, and bookkeeping events exposed the same missing handoff in Google, Mistral, Amazon Bedrock, and Ollama streams.

## Why This Change Was Made

`streamWithIdleTimeout` owns timeout policy, cancellation, rearming, and cleanup. Provider parsers own the stronger fact that their transport has advanced. The watchdog already subscribes to the request signal's activity channel, but the affected providers did not notify it until visible output—or, on refusal-buffered paths, until deferred output was pushed.

The canonical fix uses the existing `notifyLlmRequestActivity` seam at each provider owner. Direct Anthropic reports each decoded SSE record before event-name filtering; the managed Anthropic, Google, Mistral, Bedrock, and Ollama paths report each parsed provider item. This matches existing OpenAI transport behavior without changing timeout values, teaching the watchdog about providers, or counting arbitrary network bytes.

Late and incomplete refusal-buffer callbacks were removed from internal callers. The callback parameter itself remains available because it is a shipped public Plugin SDK contract.

## User Impact

Long responses stay alive while providers emit pings, hidden reasoning, usage, or metadata, avoiding false idle aborts and unnecessary paid retries. A transport that emits no frames still reaches the existing idle timeout.

## Evidence

### Regression reproduction

The behavioral test uses a real loopback TCP/SSE server, the pinned Anthropic SDK, the production direct provider, and the production idle wrapper. It sends `message_start`, then pings every 20 ms beyond a 1,000 ms idle window, then valid text after 1,200 ms.

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs \
  packages/ai/src/providers/anthropic.sse-parse-error.test.ts \
  -t "keeps a response alive while Anthropic sends protocol pings"
```

- Exact current `origin/main`, with only the regression test applied in an isolated worktree: failed as intended after 1.124s with `LLM idle timeout (1s): no response from model`.
- Rebased PR head: passed in 1.275s; one test passed and eight were filtered.

### Dependency and sibling contracts

- `@anthropic-ai/sdk` is pinned at 0.120.0. Direct inspection of its installed source and official `sdk-v0.120.0` source confirms `Stream.rawEvents` yields decoded SSE records before JSON parsing/event-name filtering, while the ordinary iterator explicitly drops `ping`.
- The locked AWS Bedrock types require metadata `usage` and `metrics`; the regression fixture supplies both.
- Existing OpenAI transports already report hidden/bookkeeping events as request activity.
- Direct inspection of sibling Codex `codex-rs/codex-client/src/sse.rs:18-44` confirms its idle timeout wraps each parsed SSE event wait. The Codex app-server path remains separate from this watchdog.

### Focused and sibling tests

```bash
OPENCLAW_TEST_PROJECTS_PARALLEL=1 OPENCLAW_VITEST_MAX_WORKERS=2 \
  node scripts/run-vitest.mjs \
  extensions/amazon-bedrock/stream.runtime.test.ts \
  extensions/google/transport-stream.test.ts \
  extensions/ollama/src/stream.test.ts \
  packages/ai/src/providers/anthropic.sse-parse-error.test.ts \
  packages/ai/src/providers/google-shared.test.ts \
  packages/ai/src/providers/mistral.test.ts \
  packages/ai/src/transports/anthropic-transport-stream.test.ts \
  src/agents/embedded-agent-runner/run/llm-idle-timeout.test.ts \
  src/agents/embedded-agent-runner/run/llm-idle-timeout.abort.test.ts \
  src/agents/embedded-agent-runner/stream-resolution.activity.test.ts
```

Result: passed all four routed Vitest shards. This covers the seven changed provider owners plus watchdog reset, cancellation, and composed-signal forwarding.

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 pnpm check:changed
```

Result: passed formatting, core/core-test/extension typechecks, changed-file lint, architecture/dependency/database guards, import-cycle checks, and selected plugin contract tests.

Also passed:

- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --max-priority P1` — scoped-clean, no accepted/actionable findings.

### Scope and LOC

- Production: 7 files, +25/-12 (net +13)
- Tests: 7 files, +191/-5 (net +186)
- Config/schema/docs/generated/lockfile: unchanged

Positive production growth is the explicit activity handoff and necessary signal threading across seven independent parser/SDK owners. No shared wrapper spans those boundaries; central HTTP-byte accounting would miss non-fetch transports and weaken the accepted transport-event invariant.

### Live-proof gap

No `ANTHROPIC_API_KEY` is available on this box, so an authenticated Anthropic smoke could not run. More importantly, a live request cannot deterministically force only heartbeat activity beyond the idle window. The loopback test is therefore the end-to-end regression proof. No screenshot was uploaded because this is stream lifecycle behavior, not a visual surface.

## Landing notes

- X-ray adjustment 1 — rebased the branch onto current `origin/main`; both newer Anthropic input-transformation lines remain intact alongside the liveness handoff.
- X-ray adjustment 2 — simplified direct Anthropic handling: notify at the decoded SSE-record boundary before filtering, restored the original message-event parse/error path, and removed the asymmetric swallow branch.
- X-ray adjustment 3 — intentionally skipped deleting `onBufferedEvent` and its test. The optional callback shipped through public `openclaw/plugin-sdk/provider-stream-shared` in stable releases from `v2026.7.1` through `v2026.9.1`; its test protects external source compatibility. Internal callers no longer depend on it. Removal requires the Plugin SDK compatibility/deprecation process.
- X-ray adjustment 4 — proved the loopback regression fails on current main for the intended timeout and passes on the rebased head.
- Optional docs wording — skipped. Existing docs say the watchdog aborts when no response chunks arrive; the operator-visible behavior and configuration are unchanged.
- ClawSweeper Rank-up move — completed. The latest durable review requested confirmation of `@anthropic-ai/sdk@0.120.0` raw-event behavior; installed and official tagged source were inspected directly and confirm the contract above.

## Risk and coverage

What else could break: a stream that sends endless decoded keepalives can now remain alive until the outer run budget instead of being retried by the idle watchdog. That is intentional transport-liveness semantics and matches the existing OpenAI behavior. Truly silent streams still time out; caller aborts, total run budgets, malformed message-event errors, and provider terminal errors retain their existing paths.

Evidence against regressions: the watchdog implementation is unchanged; activity only rearms while it is waiting for the provider; exact request-signal identity is preserved through direct and composed paths; provider-owner tests cover every added handoff; cancellation and true-idle sibling tests pass; final autoreview is clean.

Remaining uncovered: production frequency is not measured, no authenticated provider smoke ran because credentials were unavailable, and no real provider API can guarantee the controlled heartbeat cadence needed to reproduce the bug.

