### PR TITLE
fix: dashboard asset retention delays gateway restarts

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -829,6 +829,8 @@ The Gateway serves static files from `dist/control-ui`:
 pnpm ui:build
 ```
 
+For bundled builds, the Gateway retains manifest-verified assets so already-open tabs can fetch older asset URLs after an update. The cache keeps at most three generations and 96 MiB total, preferring the current generation; older generations can be pruned sooner to meet the byte budget. Background startup preparation reuses verified inventories through publication and pruning instead of rereading unchanged retained assets at each step. Newly published assets are verified before reuse, including a concurrent publisher's winning copy. Configured `gateway.controlUi.root` builds do not use this cache.
+
 Optional absolute base (fixed asset URLs):
 
 ```bash

--- a/src/gateway/control-ui-asset-manifest.test.ts
+++ b/src/gateway/control-ui-asset-manifest.test.ts
@@ -33,9 +33,8 @@ describe("Control UI asset manifest", () => {
     "/assets/app.js",
   ])("rejects unsafe inventory path %s", (assetPath) => {
     const manifest = createControlUiAssetManifest([
-      { path: "assets/app.js", sha256: "a".repeat(64), size: 7 },
+      { path: assetPath, sha256: "a".repeat(64), size: 7 },
     ]);
-    manifest.assets[0] = { ...manifest.assets[0]!, path: assetPath };
 
     expect(parseControlUiAssetManifest(manifest)).toBeNull();
   });

--- a/src/gateway/control-ui-asset-retention.cancellation.test.ts
+++ b/src/gateway/control-ui-asset-retention.cancellation.test.ts
@@ -1,0 +1,168 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { createControlUiAssetRetention } from "./control-ui-asset-retention.js";
+import {
+  withRetentionFixture,
+  writeRetentionBuild,
+} from "./control-ui-asset-retention.test-support.js";
+
+const boundaries = [
+  "before-start",
+  "retained-read",
+  "source-read",
+  "asset-write",
+  "manifest-write",
+  "rename-issued",
+  "refresh",
+  "prune-issued",
+  "projection",
+] as const;
+
+describe.each(["signal", "predicate"] as const)(
+  "Control UI retention cancellation by %s",
+  (mode) => {
+    it.each(boundaries)("stops at %s and cleans only its staging", async (boundary) => {
+      await withRetentionFixture(async ({ root, cache, seed }) => {
+        const old = await seed("old");
+        const build =
+          boundary === "refresh"
+            ? old
+            : await writeRetentionBuild(path.join(root, "current"), "current");
+        const target = path.join(cache, build.manifest.generation);
+        const stale = [".staging-1-aaaa", ".staging-2-bbbb"].map((name) => path.join(cache, name));
+        for (const directory of stale) {
+          await fs.mkdir(directory);
+          await fs.utimes(directory, 0, 0);
+        }
+        const owner = createControlUiAssetRetention(build.root);
+        const controller = new AbortController();
+        let cancelled = false;
+        let published = false;
+        const pruned = new Set<string>();
+        const cancel = () => {
+          cancelled = true;
+          if (mode === "signal") {
+            controller.abort();
+          }
+        };
+        const original = {
+          readFile: fs.readFile,
+          writeFile: fs.writeFile,
+          open: fs.open,
+          rename: fs.rename,
+          lstat: fs.lstat,
+          rm: fs.rm,
+        };
+        vi.spyOn(fs, "readFile").mockImplementation(async (...args) => {
+          const result = await original.readFile(...args);
+          if (
+            (boundary === "retained-read" && args[0] === path.join(old.target, old.assetPath)) ||
+            (boundary === "refresh" && args[0] === path.join(build.root, "asset-manifest.json"))
+          ) {
+            cancel();
+          }
+          return result;
+        });
+        vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+          const handle = await original.open(...args);
+          const read = handle.readFile.bind(handle);
+          vi.spyOn(handle, "readFile").mockImplementation(async (...readArgs) => {
+            const result = await read(...readArgs);
+            if (boundary === "source-read") {
+              cancel();
+            }
+            return result;
+          });
+          return handle;
+        });
+        vi.spyOn(fs, "writeFile").mockImplementation(async (...args) => {
+          await original.writeFile(...args);
+          const file = args[0];
+          if (
+            boundary === "asset-write" &&
+            typeof file === "string" &&
+            file.includes(".staging-") &&
+            file.endsWith(build.assetPath)
+          ) {
+            cancel();
+          }
+          if (
+            boundary === "manifest-write" &&
+            typeof file === "string" &&
+            file.includes(".staging-") &&
+            file.endsWith("/asset-manifest.json")
+          ) {
+            cancel();
+          }
+        });
+        const renames = vi.spyOn(fs, "rename").mockImplementation(async (...args) => {
+          await original.rename(...args);
+          published = true;
+          if (boundary === "rename-issued") {
+            cancel();
+          }
+        });
+        const refreshes = vi.spyOn(fs, "utimes");
+        vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+          const result = await original.lstat(...args);
+          if (boundary === "projection" && pruned.size > 0 && args[0] === target) {
+            cancel();
+          }
+          return result;
+        });
+        vi.spyOn(fs, "rm").mockImplementation(async (...args) => {
+          await original.rm(...args);
+          const directory = args[0];
+          if (typeof directory === "string" && stale.includes(directory)) {
+            pruned.add(directory);
+            if (boundary === "prune-issued") {
+              cancel();
+            }
+          }
+        });
+        if (boundary === "before-start") {
+          cancel();
+        }
+        await expect(
+          owner.prepare(
+            mode === "signal" ? { signal: controller.signal } : { isCancelled: () => cancelled },
+          ),
+        ).rejects.toMatchObject({ name: "AbortError" });
+        expect(cancelled).toBe(true);
+        expect(published).toBe(["rename-issued", "prune-issued", "projection"].includes(boundary));
+        expect(pruned.size).toBe(
+          boundary === "projection" ? 2 : boundary === "prune-issued" ? 1 : 0,
+        );
+        expect(renames).toHaveBeenCalledTimes(published ? 1 : 0);
+        expect(refreshes).toHaveBeenCalledTimes(
+          ["prune-issued", "projection"].includes(boundary) ? 1 : 0,
+        );
+        vi.restoreAllMocks();
+        expect(
+          (await fs.readdir(cache)).filter(
+            (name) => name.startsWith(".staging-") && !stale.includes(path.join(cache, name)),
+          ),
+        ).toEqual([]);
+        for (const directory of stale) {
+          expect(
+            await fs.access(directory).then(
+              () => true,
+              () => false,
+            ),
+          ).toBe(!pruned.has(directory));
+        }
+        expect(await fs.readFile(path.join(old.target, old.assetPath), "utf8")).toContain("old");
+        if (boundary !== "refresh") {
+          expect(owner.resolveAsset(build.assetPath)).toBeNull();
+          expect(
+            await fs.access(target).then(
+              () => true,
+              () => false,
+            ),
+          ).toBe(published);
+        }
+      });
+    });
+  },
+);

--- a/src/gateway/control-ui-asset-retention.integrity.test.ts
+++ b/src/gateway/control-ui-asset-retention.integrity.test.ts
@@ -1,0 +1,113 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { createControlUiAssetRetention } from "./control-ui-asset-retention.js";
+import {
+  withRetentionFixture,
+  writeRetentionBuild,
+} from "./control-ui-asset-retention.test-support.js";
+
+describe("Control UI retained integrity", () => {
+  it.each([
+    "digest",
+    "size",
+    "missing",
+    "manifest",
+    "directory-name",
+    "asset-symlink",
+    "manifest-symlink",
+    "directory-symlink",
+  ] as const)("rejects cached %s corruption without disturbing outside bytes", async (fault) => {
+    await withRetentionFixture(async ({ root, cache, seed }) => {
+      const cached = await seed("cached");
+      let cachedDirectory = cached.target;
+      const asset = path.join(cached.target, cached.assetPath);
+      const manifest = path.join(cached.target, "asset-manifest.json");
+      const outside = path.join(root, "outside");
+      await fs.cp(cached.target, outside, { recursive: true });
+      switch (fault) {
+        case "digest":
+          await fs.writeFile(asset, Buffer.alloc(cached.manifest.assets[0]!.size, 120));
+          break;
+        case "size":
+          await fs.writeFile(asset, "short");
+          break;
+        case "missing":
+          await fs.rm(asset);
+          break;
+        case "manifest":
+          await fs.writeFile(manifest, "{");
+          break;
+        case "directory-name":
+          cachedDirectory = path.join(cache, "0".repeat(64));
+          await fs.rename(cached.target, cachedDirectory);
+          break;
+        case "asset-symlink":
+          await fs.rm(asset);
+          await fs.symlink(path.join(outside, cached.assetPath), asset);
+          break;
+        case "manifest-symlink":
+          await fs.rm(manifest);
+          await fs.symlink(path.join(outside, "asset-manifest.json"), manifest);
+          break;
+        case "directory-symlink":
+          await fs.rm(cached.target, { recursive: true });
+          await fs.symlink(outside, cached.target, "dir");
+          break;
+      }
+      const current = await writeRetentionBuild(path.join(root, "current"), "current");
+      const owner = createControlUiAssetRetention(current.root);
+      let checkedAdmission = false;
+      const readFile = fs.readFile;
+      vi.spyOn(fs, "readFile").mockImplementation(async (...args) => {
+        if (args[0] === path.join(current.root, "asset-manifest.json")) {
+          checkedAdmission = true;
+          expect(owner.resolveAsset(cached.assetPath)).toBeNull();
+        }
+        return readFile(...args);
+      });
+      await owner.prepare();
+      expect(checkedAdmission).toBe(true);
+      expect(owner.resolveAsset(cached.assetPath)).toBeNull();
+      expect(owner.resolveAsset(current.assetPath)).not.toBeNull();
+      expect(await fs.readFile(path.join(outside, cached.assetPath), "utf8")).toContain("cached");
+      expect((await fs.readdir(cache)).includes(path.basename(cachedDirectory))).toBe(
+        fault === "directory-symlink",
+      );
+    });
+  });
+
+  it.each(["leaf-symlink", "parent-escape", "inode-swap"] as const)(
+    "refuses source %s before publication",
+    async (fault) => {
+      await withRetentionFixture(async ({ root, cache }) => {
+        const build = await writeRetentionBuild(path.join(root, "build"), "source");
+        const source = path.join(build.root, build.assetPath);
+        const outside = path.join(root, "outside");
+        await fs.cp(build.root, outside, { recursive: true });
+        if (fault === "leaf-symlink") {
+          await fs.rm(source);
+          await fs.symlink(path.join(outside, build.assetPath), source);
+        } else if (fault === "parent-escape") {
+          await fs.rm(path.join(build.root, "assets"), { recursive: true });
+          await fs.symlink(path.join(outside, "assets"), path.join(build.root, "assets"), "dir");
+        } else {
+          const open = fs.open;
+          vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+            const handle = await open(...args);
+            await fs.rename(source, `${source}.old`);
+            await fs.copyFile(path.join(outside, build.assetPath), source);
+            return handle;
+          });
+        }
+        const owner = createControlUiAssetRetention(build.root);
+        await expect(owner.prepare()).rejects.toThrow(
+          fault === "inode-swap" ? "changed while being retained" : "Unsafe Control UI asset",
+        );
+        expect(owner.resolveAsset(build.assetPath)).toBeNull();
+        expect(await fs.readdir(cache)).toEqual([]);
+        expect(await fs.readFile(path.join(outside, build.assetPath), "utf8")).toContain("source");
+      });
+    },
+  );
+});

--- a/src/gateway/control-ui-asset-retention.publication.test.ts
+++ b/src/gateway/control-ui-asset-retention.publication.test.ts
@@ -1,0 +1,268 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { createControlUiAssetRetention } from "./control-ui-asset-retention.js";
+import {
+  withRetentionFixture,
+  writeRetentionBuild,
+} from "./control-ui-asset-retention.test-support.js";
+
+describe("Control UI retained publication", () => {
+  it.each(["removed", "replaced-valid", "symlink"] as const)(
+    "rechecks a %s current target before refreshing it",
+    async (mutation) => {
+      await withRetentionFixture(async ({ root, cache, seed }) => {
+        const current = await seed("current");
+        const sibling = await seed("sibling");
+        const outside = path.join(root, "outside");
+        await fs.cp(current.root, outside, { recursive: true });
+        await fs.utimes(outside, 1_700_000_100, 1_700_000_100);
+        const outsideBefore = await fs.stat(outside);
+        const contents = await fs.readFile(path.join(current.root, current.assetPath));
+        const targetAsset = path.join(current.target, current.assetPath);
+        const siblingAsset = path.join(sibling.target, sibling.assetPath);
+        const reads = new Map([
+          [targetAsset, 0],
+          [siblingAsset, 0],
+        ]);
+        const refreshReads: number[] = [];
+        const readFile = fs.readFile;
+        const utimes = fs.utimes;
+        let mutated = false;
+        vi.spyOn(fs, "readFile").mockImplementation(async (...args) => {
+          const result = await readFile(...args);
+          const file = args[0];
+          if (typeof file === "string" && reads.has(file)) {
+            reads.set(file, reads.get(file)! + 1);
+          }
+          if (!mutated && file === path.join(current.root, "asset-manifest.json")) {
+            mutated = true;
+            if (mutation === "removed") {
+              await fs.rm(current.target, { recursive: true });
+            } else {
+              await fs.rename(current.target, path.join(root, "displaced"));
+              if (mutation === "replaced-valid") {
+                await fs.cp(current.root, current.target, { recursive: true });
+              } else {
+                await fs.symlink(outside, current.target, "dir");
+              }
+            }
+          }
+          return result;
+        });
+        vi.spyOn(fs, "utimes").mockImplementation(async (...args) => {
+          if (args[0] === current.target) {
+            refreshReads.push(reads.get(targetAsset)!);
+          }
+          return utimes(...args);
+        });
+        const owner = createControlUiAssetRetention(current.root);
+        if (mutation === "symlink") {
+          await expect(owner.prepare()).rejects.toThrow();
+          expect(refreshReads).toEqual([]);
+        } else {
+          await owner.prepare();
+          expect(owner.resolveAsset(current.assetPath)?.filePath).toBe(targetAsset);
+          expect(refreshReads).toEqual([2]);
+          expect(reads.get(targetAsset)).toBe(2);
+        }
+        expect(mutated).toBe(true);
+        expect(reads.get(siblingAsset)).toBe(1);
+        vi.restoreAllMocks();
+        expect(await fs.readFile(targetAsset)).toEqual(contents);
+        expect(await fs.readFile(path.join(outside, current.assetPath))).toEqual(contents);
+        expect((await fs.stat(outside)).mtimeMs).toBe(outsideBefore.mtimeMs);
+        expect((await fs.readdir(cache)).toSorted()).toEqual(
+          [current.manifest.generation, sibling.manifest.generation].toSorted(),
+        );
+      });
+    },
+  );
+
+  it.each(["same", "different"] as const)(
+    "coordinates native concurrent %s-target publication without losing the winner",
+    async (kind) => {
+      await withRetentionFixture(async ({ root, cache, seed }) => {
+        const old = [await seed("old-a"), await seed("old-b")];
+        const a = await writeRetentionBuild(path.join(root, "a"), "a");
+        const b = kind === "same" ? a : await writeRetentionBuild(path.join(root, "b"), "b");
+        const owners = [
+          createControlUiAssetRetention(a.root),
+          createControlUiAssetRetention(b.root),
+        ];
+        const barrier = createDeferred();
+        let arrivals = 0;
+        const rename = fs.rename;
+        const errors: string[] = [];
+        vi.spyOn(fs, "rename").mockImplementation(async (...args) => {
+          // Both preparers reach real rename from their own completed staging tree.
+          if (++arrivals === 2) {
+            barrier.resolve();
+          }
+          await barrier.promise;
+          try {
+            await rename(...args);
+          } catch (error) {
+            errors.push((error as NodeJS.ErrnoException).code!);
+            throw error;
+          }
+        });
+        const results = await Promise.allSettled(owners.map((owner) => owner.prepare()));
+        expect(results.map((result) => result.status)).toEqual(["fulfilled", "fulfilled"]);
+        expect(arrivals).toBe(2);
+        if (kind === "same") {
+          expect(errors).toHaveLength(1);
+          expect(["EEXIST", "ENOTEMPTY"]).toContain(errors[0]);
+        } else {
+          expect(errors).toEqual([]);
+        }
+        for (const [index, owner] of owners.entries()) {
+          const build = index === 0 ? a : b;
+          expect(
+            await fs.readFile(owner.resolveAsset(build.assetPath)!.filePath, "utf8"),
+          ).toContain(index === 0 || kind === "same" ? '"a"' : '"b"');
+        }
+        const entries = await fs.readdir(cache);
+        expect(entries).toHaveLength(3);
+        expect(entries.some((entry) => entry.startsWith(".staging-"))).toBe(false);
+        if (kind === "different") {
+          expect(entries).toContain(a.manifest.generation);
+          expect(entries).toContain(b.manifest.generation);
+          expect(old.filter((build) => entries.includes(build.manifest.generation))).toHaveLength(
+            1,
+          );
+        }
+      });
+    },
+  );
+
+  it.each([
+    ["EEXIST", "valid"],
+    ["ENOTEMPTY", "valid"],
+    ["EEXIST", "digest"],
+    ["ENOTEMPTY", "digest"],
+    ["EEXIST", "manifest"],
+    ["ENOTEMPTY", "manifest"],
+    ["EEXIST", "symlink"],
+    ["ENOTEMPTY", "symlink"],
+    ["EACCES", "valid"],
+  ] as const)("handles %s only when its exact winner is %s", async (code, integrity) => {
+    await withRetentionFixture(async ({ root, cache }) => {
+      const build = await writeRetentionBuild(path.join(root, "build"), "winner");
+      const target = path.join(cache, build.manifest.generation);
+      const collision = Object.assign(new Error("rename failed"), { code });
+      vi.spyOn(fs, "rename").mockImplementation(async () => {
+        if (integrity === "symlink") {
+          await fs.symlink(build.root, target, "dir");
+        } else {
+          await fs.cp(build.root, target, { recursive: true });
+          if (integrity === "digest") {
+            await fs.writeFile(
+              path.join(target, build.assetPath),
+              Buffer.alloc(build.manifest.assets[0]!.size, 120),
+            );
+          }
+          if (integrity === "manifest") {
+            await fs.writeFile(path.join(target, "asset-manifest.json"), "{");
+          }
+        }
+        throw collision;
+      });
+      const owner = createControlUiAssetRetention(build.root);
+      if (integrity === "valid" && code !== "EACCES") {
+        await owner.prepare();
+        expect(owner.resolveAsset(build.assetPath)?.filePath).toBe(
+          path.join(target, build.assetPath),
+        );
+      } else {
+        await expect(owner.prepare()).rejects.toBe(collision);
+        expect(owner.resolveAsset(build.assetPath)).toBeNull();
+      }
+      // A failed loser owns its staging only, including when the winner is invalid.
+      expect(await fs.readdir(cache)).toEqual([build.manifest.generation]);
+    });
+  });
+
+  it("verifies its newly published target before adopting it", async () => {
+    await withRetentionFixture(async ({ root, cache }) => {
+      const build = await writeRetentionBuild(path.join(root, "build"), "new");
+      const rename = fs.rename;
+      vi.spyOn(fs, "rename").mockImplementation(async (...args) => {
+        await rename(...args);
+        await fs.writeFile(
+          path.join(cache, build.manifest.generation, build.assetPath),
+          Buffer.alloc(build.manifest.assets[0]!.size, 120),
+        );
+      });
+      const owner = createControlUiAssetRetention(build.root);
+      await expect(owner.prepare()).rejects.toThrow("Invalid retained Control UI generation");
+      expect(owner.resolveAsset(build.assetPath)).toBeNull();
+      expect(await fs.readdir(cache)).toEqual([build.manifest.generation]);
+    });
+  });
+
+  it("revalidates a replaced directory instead of trusting an old verified record", async () => {
+    await withRetentionFixture(async ({ root, seed }) => {
+      const old = await seed("old");
+      const build = await writeRetentionBuild(path.join(root, "build"), "new");
+      const readFile = fs.readFile;
+      vi.spyOn(fs, "readFile").mockImplementation(async (...args) => {
+        const result = await readFile(...args);
+        if (args[0] === path.join(build.root, "asset-manifest.json")) {
+          await fs.rename(old.target, path.join(root, "previous-inode"));
+          await fs.cp(old.root, old.target, { recursive: true });
+          await fs.writeFile(
+            path.join(old.target, old.assetPath),
+            Buffer.alloc(old.manifest.assets[0]!.size, 120),
+          );
+        }
+        return result;
+      });
+      const owner = createControlUiAssetRetention(build.root);
+      await owner.prepare();
+      expect(owner.resolveAsset(old.assetPath)).toBeNull();
+      expect(owner.resolveAsset(build.assetPath)).not.toBeNull();
+      await expect(fs.access(old.target)).rejects.toMatchObject({ code: "ENOENT" });
+    });
+  });
+
+  it.each(["replace-evicted", "remove-survivor"] as const)(
+    "respects a concurrent %s after its pruning inventory",
+    async (mutation) => {
+      await withRetentionFixture(async ({ root, cache, seed }) => {
+        const current = await seed("current");
+        const history = [await seed("a"), await seed("b"), await seed("c")].toSorted((a, b) =>
+          a.manifest.generation.localeCompare(b.manifest.generation),
+        );
+        const victim = mutation === "replace-evicted" ? history[2]! : history[0]!;
+        const stale = path.join(cache, ".staging-1-aaaa");
+        await fs.mkdir(stale);
+        await fs.utimes(stale, 0, 0);
+        const rm = fs.rm;
+        let raced = false;
+        vi.spyOn(fs, "rm").mockImplementation(async (...args) => {
+          await rm(...args);
+          if (args[0] === stale) {
+            raced = true;
+            await fs.rename(victim.target, path.join(root, "concurrently-removed"));
+            if (mutation === "replace-evicted") {
+              await fs.cp(victim.root, victim.target, { recursive: true });
+            }
+          }
+        });
+        const owner = createControlUiAssetRetention(current.root);
+        await owner.prepare();
+        expect(raced).toBe(true);
+        expect(owner.resolveAsset(victim.assetPath)).toBeNull();
+        expect(owner.resolveAsset(current.assetPath)).not.toBeNull();
+        expect(
+          await fs.access(victim.target).then(
+            () => true,
+            () => false,
+          ),
+        ).toBe(mutation === "replace-evicted");
+      });
+    },
+  );
+});

--- a/src/gateway/control-ui-asset-retention.test-support.ts
+++ b/src/gateway/control-ui-asset-retention.test-support.ts
@@ -1,0 +1,89 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import { syncBuiltinESMExports } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { vi } from "vitest";
+import { withEnvAsync } from "../test-utils/env.js";
+import {
+  CONTROL_UI_ASSET_MANIFEST_FILENAME,
+  CONTROL_UI_ASSET_MANIFEST_VERSION,
+  hashControlUiAssetManifestEntries,
+  type ControlUiAssetManifestEntry,
+} from "./control-ui-asset-manifest.js";
+
+export function createRetentionManifest(entries: ControlUiAssetManifestEntry[]) {
+  const assets = entries.toSorted((left, right) => left.path.localeCompare(right.path));
+  return {
+    version: CONTROL_UI_ASSET_MANIFEST_VERSION,
+    generation: hashControlUiAssetManifestEntries(assets),
+    assets,
+  };
+}
+
+export async function writeRetentionBuild(
+  root: string,
+  label: string,
+  options: { size?: number; corrupt?: boolean; assetPath?: string } = {},
+) {
+  const assetPath = options.assetPath ?? `assets/panel-${label}.js`;
+  const contents =
+    options.size === undefined
+      ? Buffer.from(`export const panel = ${JSON.stringify(label)};\n`)
+      : Buffer.alloc(options.size, label.charCodeAt(0));
+  await fs.mkdir(path.dirname(path.join(root, assetPath)), { recursive: true });
+  await fs.writeFile(path.join(root, assetPath), contents);
+  const manifest = createRetentionManifest([
+    {
+      path: assetPath,
+      sha256: options.corrupt
+        ? "0".repeat(64)
+        : createHash("sha256").update(contents).digest("hex"),
+      size: contents.byteLength,
+    },
+  ]);
+  await fs.writeFile(
+    path.join(root, CONTROL_UI_ASSET_MANIFEST_FILENAME),
+    `${JSON.stringify(manifest)}\n`,
+  );
+  return { root, assetPath, manifest };
+}
+
+export async function withRetentionFixture(
+  run: (fixture: {
+    root: string;
+    cache: string;
+    seed: (
+      label: string,
+      options?: Parameters<typeof writeRetentionBuild>[2],
+    ) => Promise<Awaited<ReturnType<typeof writeRetentionBuild>> & { target: string }>;
+  }) => Promise<void>,
+) {
+  const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-retention-")));
+  const state = path.join(root, "state");
+  const cache = path.join(state, "cache", "control-ui-assets");
+  try {
+    await withEnvAsync({ OPENCLAW_STATE_DIR: state }, async () => {
+      await fs.mkdir(cache, { recursive: true });
+      await run({
+        root,
+        cache,
+        seed: async (label, options) => {
+          const build = await writeRetentionBuild(
+            path.join(root, `build-${label}`),
+            label,
+            options,
+          );
+          const target = path.join(cache, build.manifest.generation);
+          await fs.cp(build.root, target, { recursive: true });
+          await fs.utimes(target, 1_700_000_000, 1_700_000_000);
+          return { ...build, target };
+        },
+      });
+    });
+  } finally {
+    vi.restoreAllMocks();
+    syncBuiltinESMExports();
+    await fs.rm(root, { recursive: true, force: true });
+  }
+}

--- a/src/gateway/control-ui-asset-retention.test.ts
+++ b/src/gateway/control-ui-asset-retention.test.ts
@@ -1,188 +1,245 @@
-import { createHash } from "node:crypto";
+import crypto from "node:crypto";
 import fs from "node:fs/promises";
+import { syncBuiltinESMExports } from "node:module";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { withEnvAsync } from "../test-utils/env.js";
-import {
-  CONTROL_UI_ASSET_MANIFEST_FILENAME,
-  CONTROL_UI_ASSET_MANIFEST_VERSION,
-  hashControlUiAssetManifestEntries,
-  type ControlUiAssetManifestEntry,
-} from "./control-ui-asset-manifest.js";
+import { CONTROL_UI_ASSET_MANIFEST_FILENAME } from "./control-ui-asset-manifest.js";
 import { createControlUiAssetRetention } from "./control-ui-asset-retention.js";
-
-function createControlUiAssetManifest(entries: ControlUiAssetManifestEntry[]) {
-  const assets = entries.toSorted((left, right) => left.path.localeCompare(right.path));
-  return {
-    version: CONTROL_UI_ASSET_MANIFEST_VERSION,
-    generation: hashControlUiAssetManifestEntries(assets),
-    assets,
-  };
-}
-
-async function writeBuild(root: string, label: string, corrupt = false): Promise<string> {
-  const assetPath = `assets/panel-${label}.js`;
-  const contents = Buffer.from(`export const panel = ${JSON.stringify(label)};\n`);
-  await fs.mkdir(path.join(root, "assets"), { recursive: true });
-  await fs.writeFile(path.join(root, assetPath), contents);
-  const manifest = createControlUiAssetManifest([
-    {
-      path: assetPath,
-      sha256: corrupt ? "0".repeat(64) : createHash("sha256").update(contents).digest("hex"),
-      size: contents.byteLength,
-    },
-  ]);
-  await fs.writeFile(
-    path.join(root, CONTROL_UI_ASSET_MANIFEST_FILENAME),
-    `${JSON.stringify(manifest)}\n`,
-  );
-  return assetPath;
-}
+import {
+  createRetentionManifest,
+  withRetentionFixture,
+  writeRetentionBuild,
+} from "./control-ui-asset-retention.test-support.js";
 
 describe("Control UI asset retention", () => {
-  it("keeps the current and two prior verified generations", async () => {
-    const fixture = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-control-ui-retention-"));
-    const stateDir = path.join(fixture, "state");
-    try {
-      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
-        const builds: Array<{ assetPath: string; root: string }> = [];
-        for (const label of ["a", "b", "c", "d"]) {
-          const root = path.join(fixture, `build-${label}`);
-          const assetPath = await writeBuild(root, label);
-          const retention = createControlUiAssetRetention(root);
-          await retention.prepare();
-          builds.push({ assetPath, root });
-          await new Promise((resolve) => {
-            setTimeout(resolve, 5);
-          });
-        }
-
-        const current = createControlUiAssetRetention(builds[3]!.root);
-        await current.prepare();
-        expect(current.resolveAsset(builds[0]!.assetPath)).toBeNull();
-        for (const build of builds.slice(1)) {
-          const retained = current.resolveAsset(build.assetPath);
-          expect(retained).not.toBeNull();
-          expect(await fs.readFile(retained!.filePath, "utf8")).toContain(
-            path.basename(build.root).slice(-1),
-          );
-        }
-      });
-    } finally {
-      await fs.rm(fixture, { recursive: true, force: true });
-    }
-  });
-
-  it("defers cached-generation verification until preparation", async () => {
-    const fixture = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-control-ui-deferred-"));
-    const stateDir = path.join(fixture, "state");
-    try {
-      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
-        const firstRoot = path.join(fixture, "build-a");
-        const firstAsset = await writeBuild(firstRoot, "a");
-        await createControlUiAssetRetention(firstRoot).prepare();
-
-        const secondRoot = path.join(fixture, "build-b");
-        await writeBuild(secondRoot, "b");
-        const retention = createControlUiAssetRetention(secondRoot);
-
-        expect(retention.resolveAsset(firstAsset)).toBeNull();
-        await retention.prepare();
-        expect(retention.resolveAsset(firstAsset)).not.toBeNull();
-      });
-    } finally {
-      await fs.rm(fixture, { recursive: true, force: true });
-    }
-  });
-
-  it("stops before copying when its lifecycle is cancelled", async () => {
-    const fixture = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-control-ui-cancelled-"));
+  it("verifies each retained asset once per preparation", async () => {
+    const fixture = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-retention-io-")),
+    );
     try {
       await withEnvAsync({ OPENCLAW_STATE_DIR: path.join(fixture, "state") }, async () => {
-        const root = path.join(fixture, "build");
-        await writeBuild(root, "cancelled");
-        const controller = new AbortController();
-        controller.abort();
-
-        await expect(
-          createControlUiAssetRetention(root).prepare({ signal: controller.signal }),
-        ).rejects.toMatchObject({ name: "AbortError" });
+        const retainedPaths = new Set<string>();
+        let expectedBytes = 0;
+        let root = "";
+        for (const label of ["a", "b", "c"]) {
+          root = path.join(fixture, label);
+          const { assetPath: asset } = await writeRetentionBuild(root, label);
+          const owner = createControlUiAssetRetention(root);
+          await owner.prepare();
+          const retained = owner.resolveAsset(asset)!;
+          retainedPaths.add(retained.filePath);
+          expectedBytes += (await fs.stat(retained.filePath)).size;
+        }
+        const counts = { lstats: 0, reads: 0, readBytes: 0, hashes: 0, hashBytes: 0 };
+        const buffers = new WeakSet<object>();
+        const readFile = fs.readFile;
+        const lstat = fs.lstat;
+        const hash = crypto.createHash;
+        vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+          if (typeof args[0] === "string" && retainedPaths.has(args[0])) {
+            counts.lstats++;
+          }
+          return lstat(...args);
+        });
+        vi.spyOn(fs, "readFile").mockImplementation(async (...args) => {
+          const result = await readFile(...args);
+          if (
+            typeof args[0] === "string" &&
+            retainedPaths.has(args[0]) &&
+            Buffer.isBuffer(result)
+          ) {
+            counts.reads++;
+            counts.readBytes += result.byteLength;
+            buffers.add(result);
+          }
+          return result;
+        });
+        vi.spyOn(crypto, "createHash").mockImplementation((...args) => {
+          const instance = hash(...args);
+          const update = instance.update.bind(instance);
+          instance.update = (data, ...rest) => {
+            if (typeof data === "object" && buffers.has(data)) {
+              counts.hashes++;
+              counts.hashBytes += data.byteLength;
+            }
+            return update(data, ...rest);
+          };
+          return instance;
+        });
+        syncBuiltinESMExports();
+        const owner = createControlUiAssetRetention(root);
+        try {
+          await owner.prepare();
+        } finally {
+          vi.restoreAllMocks();
+          syncBuiltinESMExports();
+        }
+        expect(counts).toEqual({
+          lstats: 3,
+          reads: 3,
+          readBytes: expectedBytes,
+          hashes: 3,
+          hashBytes: expectedBytes,
+        });
+        for (const retained of retainedPaths) {
+          expect(owner.resolveAsset(`assets/${path.basename(retained)}`)?.filePath).toBe(retained);
+        }
       });
     } finally {
+      vi.restoreAllMocks();
+      syncBuiltinESMExports();
       await fs.rm(fixture, { recursive: true, force: true });
     }
+  });
+
+  it("keeps the current and two prior generations with deterministic mtime ties", async () => {
+    await withRetentionFixture(async ({ seed, cache }) => {
+      const builds = [await seed("a"), await seed("b"), await seed("c"), await seed("d")] as const;
+      const [current, ...previous] = builds;
+      const future = new Date("2099-01-01T00:00:00Z");
+      for (const build of previous) {
+        await fs.utimes(build.target, future, future);
+      }
+      const expected = previous
+        .toSorted((a, b) => a.manifest.generation.localeCompare(b.manifest.generation))
+        .slice(0, 2);
+      const owner = createControlUiAssetRetention(current.root);
+      await owner.prepare();
+      expect((await fs.readdir(cache)).toSorted()).toEqual(
+        [current, ...expected].map((b) => b.manifest.generation).toSorted(),
+      );
+      for (const build of builds) {
+        const kept = build === current || expected.includes(build);
+        expect(owner.resolveAsset(build.assetPath) !== null).toBe(kept);
+      }
+    });
+  });
+
+  it("enforces the exact aggregate 96 MiB edge and gives current bytes priority", async () => {
+    await withRetentionFixture(async ({ seed, cache }) => {
+      const older = await seed("a", { size: 48 * 1024 * 1024 });
+      const current = await seed("b", { size: 48 * 1024 * 1024 });
+      const owner = createControlUiAssetRetention(current.root);
+      await owner.prepare();
+      expect(owner.resolveAsset(older.assetPath)).not.toBeNull();
+      expect(owner.resolveAsset(current.assetPath)).not.toBeNull();
+      expect(await fs.readdir(cache)).toHaveLength(2);
+      const tiny = await seed("c", { size: 1 });
+      const next = createControlUiAssetRetention(tiny.root);
+      await next.prepare();
+      expect(next.resolveAsset(older.assetPath)).toBeNull();
+      expect(next.resolveAsset(current.assetPath)).not.toBeNull();
+      expect(next.resolveAsset(tiny.assetPath)).not.toBeNull();
+      expect(await fs.readdir(cache)).toHaveLength(2);
+    });
+  });
+
+  it("projects survivors by mtime even when selection prioritizes the current generation", async () => {
+    await withRetentionFixture(async ({ seed }) => {
+      const previous = await seed("previous", { assetPath: "assets/shared.js" });
+      const current = await seed("current", { assetPath: "assets/shared.js" });
+      const future = new Date("2099-01-01T00:00:00Z");
+      await fs.utimes(previous.target, future, future);
+      const owner = createControlUiAssetRetention(current.root);
+      await owner.prepare();
+      expect(owner.resolveAsset(current.assetPath)?.filePath).toBe(
+        path.join(previous.target, previous.assetPath),
+      );
+    });
+  });
+
+  it("publishes through a symlinked state-directory ancestor using the canonical retained root", async () => {
+    await withRetentionFixture(async ({ root, cache }) => {
+      const alias = path.join(root, "alias");
+      await fs.symlink(root, alias, "dir");
+      const build = await writeRetentionBuild(path.join(root, "build"), "current");
+      await withEnvAsync({ OPENCLAW_STATE_DIR: path.join(alias, "state") }, async () => {
+        const owner = createControlUiAssetRetention(build.root);
+        await owner.prepare();
+        expect(owner.resolveAsset(build.assetPath)?.rootRealPath).toBe(
+          path.join(cache, build.manifest.generation),
+        );
+      });
+    });
+  });
+
+  it("defers verification, exposes verified fallback during copy failure, and retries rejected preparation", async () => {
+    await withRetentionFixture(async ({ root, seed, cache }) => {
+      const old = await seed("old");
+      const current = await writeRetentionBuild(path.join(root, "current"), "current", {
+        corrupt: true,
+      });
+      const owner = createControlUiAssetRetention(current.root);
+      expect(owner.resolveAsset(old.assetPath)).toBeNull();
+      const open = fs.open;
+      const observed = vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+        expect(owner.resolveAsset(old.assetPath)?.filePath).toBe(
+          path.join(old.target, old.assetPath),
+        );
+        return open(...args);
+      });
+      const preparing = owner.prepare();
+      expect(owner.prepare()).toBe(preparing);
+      await expect(preparing).rejects.toThrow("changed while being retained");
+      expect(observed).toHaveBeenCalled();
+      expect(owner.resolveAsset(old.assetPath)).not.toBeNull();
+      expect(await fs.readdir(cache)).toEqual([old.manifest.generation]);
+      await writeRetentionBuild(current.root, "current");
+      await owner.prepare();
+      expect(owner.resolveAsset(current.assetPath)).not.toBeNull();
+    });
   });
 
   it("skips generations larger than the hard cache budget before reading assets", async () => {
-    const fixture = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-control-ui-oversized-"));
-    const stateDir = path.join(fixture, "state");
-    try {
-      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
-        const root = path.join(fixture, "build");
-        await fs.mkdir(root, { recursive: true });
-        const manifest = createControlUiAssetManifest(
-          ["a", "b"].map((label) => ({
-            path: `assets/${label}.js`,
-            sha256: "0".repeat(64),
-            size: 50 * 1024 * 1024,
-          })),
-        );
-        await fs.writeFile(
-          path.join(root, CONTROL_UI_ASSET_MANIFEST_FILENAME),
-          `${JSON.stringify(manifest)}\n`,
-        );
-
-        const retention = createControlUiAssetRetention(root);
-        await retention.prepare();
-
-        expect(retention.resolveAsset("assets/a.js")).toBeNull();
-        expect(await fs.readdir(path.join(stateDir, "cache", "control-ui-assets"))).toEqual([]);
-      });
-    } finally {
-      await fs.rm(fixture, { recursive: true, force: true });
-    }
+    await withRetentionFixture(async ({ root, cache }) => {
+      const manifest = createRetentionManifest(
+        ["a", "b"].map((label) => ({
+          path: `assets/${label}.js`,
+          sha256: "0".repeat(64),
+          size: 50 * 1024 * 1024,
+        })),
+      );
+      await fs.writeFile(
+        path.join(root, CONTROL_UI_ASSET_MANIFEST_FILENAME),
+        JSON.stringify(manifest),
+      );
+      const owner = createControlUiAssetRetention(root);
+      await owner.prepare();
+      expect(owner.resolveAsset("assets/a.js")).toBeNull();
+      expect(await fs.readdir(cache)).toEqual([]);
+    });
   });
 
-  it("refuses to publish bytes that do not match the build manifest", async () => {
-    const fixture = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-control-ui-corrupt-"));
-    try {
-      await withEnvAsync({ OPENCLAW_STATE_DIR: path.join(fixture, "state") }, async () => {
-        const root = path.join(fixture, "build");
-        await writeBuild(root, "corrupt", true);
-
-        await expect(createControlUiAssetRetention(root).prepare()).rejects.toThrow(
-          "changed while being retained",
-        );
-      });
-    } finally {
-      await fs.rm(fixture, { recursive: true, force: true });
-    }
-  });
-
-  it("does not serve cached bytes changed after publication", async () => {
-    const fixture = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-control-ui-tampered-"));
-    const stateDir = path.join(fixture, "state");
-    try {
-      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
-        const originalRoot = path.join(fixture, "build-original");
-        const assetPath = await writeBuild(originalRoot, "original");
-        const originalRetention = createControlUiAssetRetention(originalRoot);
-        await originalRetention.prepare();
-        const retained = originalRetention.resolveAsset(assetPath);
-        expect(retained).not.toBeNull();
-
-        const original = await fs.readFile(retained!.filePath);
-        await fs.writeFile(retained!.filePath, Buffer.alloc(original.byteLength, 0x78));
-
-        const currentRoot = path.join(fixture, "build-current");
-        await writeBuild(currentRoot, "current");
-        const currentRetention = createControlUiAssetRetention(currentRoot);
-        await currentRetention.prepare();
-        expect(currentRetention.resolveAsset(assetPath)).toBeNull();
-      });
-    } finally {
-      await fs.rm(fixture, { recursive: true, force: true });
-    }
+  it("prunes only generations and stale staging directories", async () => {
+    await withRetentionFixture(async ({ seed, cache, root }) => {
+      const current = await seed("current");
+      const names = [".staging-1-aaaa", ".staging-2-bbbb", "unrelated", "e".repeat(64)] as const;
+      for (const name of names) {
+        await fs.mkdir(path.join(cache, name));
+      }
+      const now = Date.now();
+      vi.spyOn(Date, "now").mockReturnValue(now);
+      await fs.utimes(
+        path.join(cache, names[0]),
+        new Date(now - 3_600_000),
+        new Date(now - 3_600_000),
+      );
+      await fs.utimes(
+        path.join(cache, names[1]),
+        new Date(now - 3_599_000),
+        new Date(now - 3_599_000),
+      );
+      await fs.writeFile(path.join(root, "sentinel"), "outside");
+      await fs.symlink(root, path.join(cache, "f".repeat(64)), "dir");
+      await createControlUiAssetRetention(current.root).prepare();
+      expect((await fs.readdir(cache)).toSorted()).toEqual(
+        [current.manifest.generation, names[1], names[2], "f".repeat(64)].toSorted((left, right) =>
+          left.localeCompare(right),
+        ),
+      );
+      expect(await fs.readFile(path.join(root, "sentinel"), "utf8")).toBe("outside");
+    });
   });
 });

--- a/src/gateway/control-ui-asset-retention.ts
+++ b/src/gateway/control-ui-asset-retention.ts
@@ -1,6 +1,6 @@
 // Retains bounded, manifest-verified Control UI generations for already-open documents.
 import { createHash, randomUUID } from "node:crypto";
-import { constants as fsConstants, type Dirent } from "node:fs";
+import { constants as fsConstants, type Dirent, type Stats } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
@@ -26,8 +26,7 @@ type RetainedGeneration = {
   bytes: number;
   directory: string;
   generation: string;
-  manifest: ControlUiAssetManifest;
-  modifiedAtMs: number;
+  stats: Stats;
   realPath: string;
 };
 
@@ -58,62 +57,33 @@ function throwIfCancelled(operation?: RetentionOperation): void {
   }
 }
 
-async function readManifestFile(
-  manifestPath: string,
-  operation?: RetentionOperation,
-): Promise<ControlUiAssetManifest | null> {
-  try {
-    throwIfCancelled(operation);
-    const stats = await fs.lstat(manifestPath);
-    if (stats.isSymbolicLink() || !stats.isFile() || stats.size > CONTROL_UI_MANIFEST_MAX_BYTES) {
-      return null;
-    }
-    const contents = await fs.readFile(manifestPath, {
-      encoding: "utf8",
-      signal: operation?.signal,
-    });
-    throwIfCancelled(operation);
-    return parseControlUiAssetManifest(JSON.parse(contents));
-  } catch {
-    throwIfCancelled(operation);
-    return null;
-  }
-}
-
 async function readCachedGeneration(
-  cacheRealPath: string,
-  entry: Dirent,
+  directory: string,
   operation?: RetentionOperation,
 ): Promise<RetainedGeneration | null> {
-  if (
-    !entry.isDirectory() ||
-    entry.isSymbolicLink() ||
-    !CONTROL_UI_GENERATION_PATTERN.test(entry.name)
-  ) {
-    return null;
-  }
-  const directory = path.join(cacheRealPath, entry.name);
   try {
     throwIfCancelled(operation);
-    const realPath = await fs.realpath(directory);
-    if (!isWithinDir(cacheRealPath, realPath)) {
+    const stats = await fs.lstat(directory);
+    if (stats.isSymbolicLink() || !stats.isDirectory()) {
       return null;
     }
-    const manifest = await readManifestFile(
-      path.join(realPath, CONTROL_UI_ASSET_MANIFEST_FILENAME),
-      operation,
-    );
-    if (!manifest || manifest.generation !== entry.name) {
+    const realPath = await fs.realpath(directory);
+    if (!isWithinDir(path.dirname(directory), realPath)) {
+      return null;
+    }
+    const manifest = await readAssetManifest(realPath, operation);
+    if (manifest.generation !== path.basename(directory)) {
       return null;
     }
     for (const asset of manifest.assets) {
       throwIfCancelled(operation);
       const assetPath = path.join(realPath, asset.path);
-      const stats = await fs.lstat(assetPath);
+      const assetStats = await fs.lstat(assetPath);
+      throwIfCancelled(operation);
       if (
-        stats.isSymbolicLink() ||
-        !stats.isFile() ||
-        stats.size !== asset.size ||
+        assetStats.isSymbolicLink() ||
+        !assetStats.isFile() ||
+        assetStats.size !== asset.size ||
         createHash("sha256")
           .update(await fs.readFile(assetPath, { signal: operation?.signal }))
           .digest("hex") !== asset.sha256
@@ -121,13 +91,17 @@ async function readCachedGeneration(
         return null;
       }
     }
+    const currentStats = await fs.lstat(directory);
+    throwIfCancelled(operation);
+    if (!sameDirectory(stats, currentStats)) {
+      return null;
+    }
     return {
       assetPaths: new Set(manifest.assets.map((asset) => asset.path)),
       bytes: manifest.assets.reduce((total, asset) => total + asset.size, 0),
       directory,
       generation: manifest.generation,
-      manifest,
-      modifiedAtMs: (await fs.stat(realPath)).mtimeMs,
+      stats: currentStats,
       realPath,
     };
   } catch {
@@ -136,10 +110,28 @@ async function readCachedGeneration(
   }
 }
 
-async function loadCachedGenerations(
+function sameDirectory(left: Stats, right: Stats): boolean {
+  return (
+    right.isDirectory() &&
+    !right.isSymbolicLink() &&
+    left.dev === right.dev &&
+    left.ino === right.ino
+  );
+}
+
+function compareGenerations(left: RetainedGeneration, right: RetainedGeneration): number {
+  return (
+    right.stats.mtimeMs - left.stats.mtimeMs || left.generation.localeCompare(right.generation)
+  );
+}
+
+async function readCacheInventory(
   cacheDir: string,
   operation?: RetentionOperation,
-): Promise<RetainedGeneration[]> {
+  verified: RetainedGeneration[] = [],
+) {
+  const generations: RetainedGeneration[] = [];
+  const directories = new Map<string, Stats>();
   let cacheRealPath: string;
   let entries: Dirent[];
   try {
@@ -148,35 +140,53 @@ async function loadCachedGenerations(
     entries = await fs.readdir(cacheRealPath, { withFileTypes: true });
   } catch {
     throwIfCancelled(operation);
-    return [];
+    return { generations, directories };
   }
-  const generations: RetainedGeneration[] = [];
+  const known = new Map(verified.map((generation) => [generation.generation, generation]));
   for (const entry of entries) {
     throwIfCancelled(operation);
-    const generation = await readCachedGeneration(cacheRealPath, entry, operation);
+    if (!entry.isDirectory() || entry.isSymbolicLink()) {
+      continue;
+    }
+    const directory = path.join(cacheRealPath, entry.name);
+    const stats = await fs.lstat(directory).catch(() => null);
+    if (!stats || !stats.isDirectory() || stats.isSymbolicLink()) {
+      continue;
+    }
+    directories.set(directory, stats);
+    if (!CONTROL_UI_GENERATION_PATTERN.test(entry.name)) {
+      continue;
+    }
+    const previous = known.get(entry.name);
+    // Published directories are immutable. Refresh membership/mtime, but only
+    // verify bytes for a new directory identity during this preparation.
+    const generation =
+      previous && sameDirectory(previous.stats, stats)
+        ? { ...previous, stats }
+        : await readCachedGeneration(directory, operation);
     if (generation) {
       generations.push(generation);
     }
   }
-  return generations.toSorted(
-    (left, right) =>
-      right.modifiedAtMs - left.modifiedAtMs || left.generation.localeCompare(right.generation),
-  );
+  throwIfCancelled(operation);
+  return { generations: generations.toSorted(compareGenerations), directories };
 }
 
-async function readCurrentManifest(
+async function readAssetManifest(
   root: string,
   operation?: RetentionOperation,
 ): Promise<ControlUiAssetManifest> {
   const manifestPath = path.join(root, CONTROL_UI_ASSET_MANIFEST_FILENAME);
   throwIfCancelled(operation);
   const stats = await fs.lstat(manifestPath);
+  throwIfCancelled(operation);
   if (stats.isSymbolicLink() || !stats.isFile() || stats.size > CONTROL_UI_MANIFEST_MAX_BYTES) {
     throw new Error(`Invalid Control UI asset manifest: ${manifestPath}`);
   }
   const manifest = parseControlUiAssetManifest(
     JSON.parse(await fs.readFile(manifestPath, { encoding: "utf8", signal: operation?.signal })),
   );
+  throwIfCancelled(operation);
   if (!manifest) {
     throw new Error(`Invalid Control UI asset manifest: ${manifestPath}`);
   }
@@ -230,17 +240,27 @@ async function readVerifiedAsset(params: {
 async function publishGeneration(params: {
   cacheDir: string;
   manifest: ControlUiAssetManifest;
+  verified?: RetainedGeneration;
   operation?: RetentionOperation;
   root: string;
-}): Promise<void> {
-  const target = path.join(params.cacheDir, params.manifest.generation);
-  if (
-    (await loadCachedGenerations(params.cacheDir, params.operation)).some(
-      (entry) => entry.generation === params.manifest.generation,
-    )
-  ) {
+}): Promise<RetainedGeneration> {
+  const target = path.join(await fs.realpath(params.cacheDir), params.manifest.generation);
+  // Another preparer may prune or replace the target after the initial inventory.
+  const stats = await fs.lstat(target).catch((error: unknown) => {
+    if (!isErrno(error) || error.code !== "ENOENT") {
+      throw error;
+    }
+    return null;
+  });
+  const verified =
+    stats &&
+    (params.verified && sameDirectory(params.verified.stats, stats)
+      ? params.verified
+      : await readCachedGeneration(target, params.operation));
+  if (verified) {
+    throwIfCancelled(params.operation);
     await fs.utimes(target, new Date(), new Date());
-    return;
+    return verified;
   }
 
   const staging = path.join(params.cacheDir, `.staging-${process.pid}-${randomUUID()}`);
@@ -257,7 +277,9 @@ async function publishGeneration(params: {
         rootRealPath,
       });
       const destination = path.join(staging, entry.path);
+      throwIfCancelled(params.operation);
       await fs.mkdir(path.dirname(destination), { recursive: true, mode: 0o700 });
+      throwIfCancelled(params.operation);
       await fs.writeFile(destination, contents, {
         mode: 0o600,
         signal: params.operation?.signal,
@@ -269,21 +291,25 @@ async function publishGeneration(params: {
       `${JSON.stringify(params.manifest)}\n`,
       { mode: 0o600, signal: params.operation?.signal },
     );
+    throwIfCancelled(params.operation);
+    let collision: NodeJS.ErrnoException | undefined;
     try {
       await fs.rename(staging, target);
     } catch (error) {
-      if (!isErrno(error) || error.code !== "EEXIST") {
+      // Node forwards native rename errno; nonempty directory collisions are
+      // ENOTEMPTY on macOS and may be EEXIST on other filesystems.
+      if (!isErrno(error) || (error.code !== "EEXIST" && error.code !== "ENOTEMPTY")) {
         throw error;
       }
-      if (
-        !(await loadCachedGenerations(params.cacheDir, params.operation)).some(
-          (entry) => entry.generation === params.manifest.generation,
-        )
-      ) {
-        throw error;
-      }
+      collision = error;
     }
+    const published = await readCachedGeneration(target, params.operation);
+    if (!published) {
+      throw collision ?? new Error(`Invalid retained Control UI generation: ${target}`);
+    }
+    throwIfCancelled(params.operation);
     await fs.utimes(target, new Date(), new Date());
+    return published;
   } finally {
     await fs.rm(staging, { recursive: true, force: true });
   }
@@ -292,59 +318,67 @@ async function publishGeneration(params: {
 async function pruneRetainedGenerations(params: {
   cacheDir: string;
   currentGeneration?: string;
-  maxBytes: number;
-  maxGenerations: number;
+  verified: RetainedGeneration[];
   now: number;
   operation?: RetentionOperation;
-}): Promise<void> {
-  const generations = (await loadCachedGenerations(params.cacheDir, params.operation)).toSorted(
-    (left, right) => {
-      if (left.generation === params.currentGeneration) {
-        return -1;
-      }
-      if (right.generation === params.currentGeneration) {
-        return 1;
-      }
-      return (
-        right.modifiedAtMs - left.modifiedAtMs || left.generation.localeCompare(right.generation)
-      );
-    },
-  );
+}): Promise<RetainedGeneration[]> {
+  const inventory = await readCacheInventory(params.cacheDir, params.operation, params.verified);
+  const generations = inventory.generations.toSorted((left, right) => {
+    if (left.generation === params.currentGeneration) {
+      return -1;
+    }
+    if (right.generation === params.currentGeneration) {
+      return 1;
+    }
+    return compareGenerations(left, right);
+  });
   const retained = new Set<string>();
   let retainedBytes = 0;
   for (const generation of generations) {
     if (
-      retained.size < params.maxGenerations &&
-      retainedBytes + generation.bytes <= params.maxBytes
+      retained.size < CONTROL_UI_RETAINED_GENERATION_LIMIT &&
+      retainedBytes + generation.bytes <= CONTROL_UI_RETAINED_ASSET_MAX_BYTES
     ) {
       retained.add(generation.generation);
       retainedBytes += generation.bytes;
     }
   }
 
-  let entries: Dirent[];
-  try {
-    entries = await fs.readdir(params.cacheDir, { withFileTypes: true });
-  } catch {
-    return;
-  }
-  for (const entry of entries) {
+  for (const [target, stats] of inventory.directories) {
     throwIfCancelled(params.operation);
-    const generation = CONTROL_UI_GENERATION_PATTERN.test(entry.name);
+    const name = path.basename(target);
+    const generation = CONTROL_UI_GENERATION_PATTERN.test(name);
     const staleStaging =
-      CONTROL_UI_STAGING_PATTERN.test(entry.name) &&
-      params.now - (await fs.lstat(path.join(params.cacheDir, entry.name))).mtimeMs >=
-        CONTROL_UI_STAGING_MAX_AGE_MS;
-    if ((!generation || retained.has(entry.name)) && !staleStaging) {
+      CONTROL_UI_STAGING_PATTERN.test(name) &&
+      params.now - stats.mtimeMs >= CONTROL_UI_STAGING_MAX_AGE_MS;
+    if ((!generation || retained.has(name)) && !staleStaging) {
       continue;
     }
-    const target = path.join(params.cacheDir, entry.name);
-    const stats = await fs.lstat(target).catch(() => null);
-    if (!stats || stats.isSymbolicLink() || !stats.isDirectory()) {
+    const currentStats = await fs.lstat(target).catch(() => null);
+    throwIfCancelled(params.operation);
+    // Never remove a replacement or a generation refreshed by another preparer.
+    // Publications after this inventory belong to a later pruning pass.
+    if (
+      !currentStats ||
+      !sameDirectory(stats, currentStats) ||
+      stats.mtimeMs !== currentStats.mtimeMs
+    ) {
       continue;
     }
     await fs.rm(target, { recursive: true, force: true });
   }
+  const survivors: RetainedGeneration[] = [];
+  for (const generation of inventory.generations) {
+    if (!retained.has(generation.generation)) {
+      continue;
+    }
+    const stats = await fs.lstat(generation.directory).catch(() => null);
+    throwIfCancelled(params.operation);
+    if (stats && sameDirectory(generation.stats, stats)) {
+      survivors.push({ ...generation, stats });
+    }
+  }
+  return survivors.toSorted(compareGenerations);
 }
 
 export function createControlUiAssetRetention(root: string): ControlUiAssetRetention {
@@ -358,22 +392,32 @@ export function createControlUiAssetRetention(root: string): ControlUiAssetReten
         throwIfCancelled(operation);
         await fs.mkdir(cacheDir, { recursive: true, mode: 0o700 });
         await fs.chmod(cacheDir, 0o700);
-        generations = await loadCachedGenerations(cacheDir, operation);
-        const manifest = await readCurrentManifest(root, operation);
+        const inventory = await readCacheInventory(cacheDir, operation);
+        throwIfCancelled(operation);
+        generations = inventory.generations;
+        const verified = [...generations];
+        const manifest = await readAssetManifest(root, operation);
         const manifestBytes = manifest.assets.reduce((total, asset) => total + asset.size, 0);
         if (manifestBytes <= CONTROL_UI_RETAINED_ASSET_MAX_BYTES) {
-          await publishGeneration({ cacheDir, manifest, operation, root });
+          const published = await publishGeneration({
+            cacheDir,
+            manifest,
+            operation,
+            root,
+            verified: verified.find((entry) => entry.generation === manifest.generation),
+          });
+          verified.push(published);
         }
-        await pruneRetainedGenerations({
+        const survivors = await pruneRetainedGenerations({
           cacheDir,
+          verified,
           currentGeneration:
             manifestBytes <= CONTROL_UI_RETAINED_ASSET_MAX_BYTES ? manifest.generation : undefined,
-          maxBytes: CONTROL_UI_RETAINED_ASSET_MAX_BYTES,
-          maxGenerations: CONTROL_UI_RETAINED_GENERATION_LIMIT,
           now: Date.now(),
           operation,
         });
-        generations = await loadCachedGenerations(cacheDir, operation);
+        throwIfCancelled(operation);
+        generations = survivors;
       })().catch((error: unknown) => {
         preparing = undefined;
         throw error;


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled so maintainers can help update this branch.

</details>

## What Problem This Solves

Fixes an issue where Gateway restarts could be delayed for minutes while the Control UI's retained asset cache was prepared after startup. One preparation reread and hashed every retained asset four times; the asset sidecar held legitimate root work for that entire operation. The observed root eventually released normally—this was unnecessary I/O, not an admission leak or idle deadlock.

Related context: [retaining Control UI routes across updates (#129922)](https://github.com/openclaw/openclaw/pull/129922). All four scans were present in its initial retention implementation, [baf06ed4f997](https://github.com/openclaw/openclaw/commit/baf06ed4f997e0cb28a5cf8bf0de9d9816572ed7), authored and merged by `roboclaw-bot` (clear code provenance; human automation trigger not established).

## Why This Change Was Made

Carry a preparation-local verified generation inventory through publication, pruning, and final resolution, refreshing directory identity/membership without rehashing unchanged generations. Verify only newly discovered, replaced, published, or collision-winning targets, while preserving the existing atomic copy/staging path and all integrity/cancellation checks.

Publication handles both `EEXIST` and native `ENOTEMPTY`, rejects invalid winners and unrelated errors, and checks target identity before refreshing it: another preparer may have removed or replaced the current target since the first scan. Pruning does not delete a replacement based on stale inventory, and final projection excludes removed/replaced survivors. Current and cached manifests now share one reader instead of duplicate validation logic.

## User Impact

Retained dashboard assets become available with substantially less startup filesystem work, reducing the time that preparation can defer a restart. The current generation plus available history remains subject to the same **three-generation / 96 MiB** limits. Size/digest/path containment, symlink/no-follow/inode checks, current-generation priority, staging cleanup, early verified-history fallback, and cancellation are preserved.

No new configuration, timeout, admission bypass, schema, dependency, or storage policy. The existing lock-free cache still does not promise globally atomic disk bounds across simultaneous independent publishers.

## Evidence

### Before/after owner proof

A real-filesystem synthetic cache with **3 generations × 1,161 assets**, **75,360,000 asset bytes**, and five fresh-owner samples on Node 24.20.0 produced:

| Per preparation | Before | After |
| --- | ---: | ---: |
| Retained asset lstat/read/hash iterations | 13,932 | 3,483 |
| Asset bytes read and hashed | 301,440,000 | 75,360,000 |
| Median observed duration | 153.79 s | 20.23 s |

The deterministic improvement is **75% less retained-asset I/O and hashing**. These timings came from a heavily loaded macOS host whose load varied; they are not a portable speedup guarantee. The observer passed through actual filesystem and hash operations, and every retained asset remained resolvable.

The checked-in I/O regression failed before the repair: **12 reads/hashes and 312 bytes**, versus **3 and 78 bytes** expected. It passes after the repair. Native concurrent-publication probes previously rejected one publisher with `ENOTEMPTY`; repaired runs on Node 24 and Node 26 let both callers succeed with one verified winner and no leaked staging.

```bash
node scripts/run-vitest.mjs src/gateway/control-ui-asset-retention.test.ts -t 'verifies each retained asset once per preparation'
```

### Boundary and sibling coverage

**324 tests across eight files passed**, including 61 focused retention/manifest cases: byte/count bounds and timestamp ties; malformed, missing, truncated, and same-size corrupted data; symlink/containment/inode cases; valid/invalid race winners; target eviction/replacement before refresh; concurrent pruning; single-flight/retry; and signal/predicate cancellation during reads, writes, rename, pruning, and projection.

```bash
node scripts/run-vitest.mjs src/gateway/control-ui-asset-retention.test.ts src/gateway/control-ui-asset-retention.cancellation.test.ts src/gateway/control-ui-asset-retention.integrity.test.ts src/gateway/control-ui-asset-retention.publication.test.ts src/gateway/control-ui-asset-manifest.test.ts src/gateway/server-control-ui-root.resolve.test.ts src/gateway/server-startup-post-attach.test.ts src/gateway/control-ui.http.test.ts
```

A separate real retention + Gateway admission-wrapper proof observed one active root during verification and zero after both completion and cancellation, with successful retry and no leaked staging. This is owner/wrapper proof, not a full live Gateway restart.

On the refreshed head, `pnpm build`, fresh-cache full core types, all 14 core-test type shards, targeted type-aware lint, formatting, and the selected boundary guards passed. The initial incremental typecheck reused diagnostics from the earlier dependency layout; fresh compiler state resolved that without a networking-code workaround. The old private-helper test import is already fixed on the rebased main baseline. Fresh independent Codex review reported no actionable findings at its P0 threshold.

### Real Gateway and browser proof

The actual built Gateway passed isolated startup, retained-asset HTTP checks, an owned-process restart, and genuine dashboard reconnection, with its bundled root auto-discovered and no `gateway.controlUi.root` override. The fixture held three complete verified generations totaling **76,150,060 bytes**; prior-only assets returned HTTP 200 with the exact expected bytes/digests before and after restart. Health/readiness passed, both asset-sidecar spans completed without retention-failure warnings, and the owned Gateway/temporary state were cleaned up.

The existing old-document/unvisited-lazy-module E2E additionally passed in **Chromium and WebKit**. See the [inspected live-proof comment and exact browser commands](https://github.com/openclaw/openclaw/pull/131930#issuecomment-5455579888).

These captures show the **repaired candidate before and after its isolated restart**, not a pre-fix/post-fix latency comparison. The video is trimmed to the reconnect/recovery flow; only synthetic test diagnostics are shown.

![Repaired candidate before the isolated Gateway restart](https://github.com/user-attachments/assets/e119087b-f280-4e9f-b6a6-578e7405026b)

![Reconnected dashboard showing the synthetic restart receipt](https://github.com/user-attachments/assets/3b6103b1-9897-4962-b7cb-2e145895d4a7)

https://github.com/user-attachments/assets/900b6c39-23c1-4916-8d60-e6118e76788d

Final head `1a168af1150941c8985ab78a74f3bb32deb8db17` has green [CI 33199050431](https://github.com/openclaw/openclaw/actions/runs/33199050431) and [Workflow Sanity 33199050524](https://github.com/openclaw/openclaw/actions/runs/33199050524). A mechanical rebase incorporated the already-landed actionlint deadlock repair; the retained-asset patch is unchanged. The full build, clean 324-test sibling run, types/lint, and actual Gateway restart/browser proof were refreshed on this head (three complete generations, 76,256,626 bytes). The [updated proof comment](https://github.com/openclaw/openclaw/pull/131930#issuecomment-5455579888) records exact commands, recovery history, current-head proof, review resolution, and known limits. The approved media above remains from the original reviewed head; new captures remain local. Native prepare/merge remain enforced; no skipped draft run or failed gate is waived.

### Scope

Production **+157/-113 (net +44)**; tests/support **+852/-158**; docs **+2**. Consolidating duplicate manifest readers removed 26 avoidable production lines. Remaining growth preserves directory-identity, native-collision, and cancellation guarantees when eliminating the repeated scans. No test-only production seam was added.

AI-assisted implementation and independent review. No agent transcripts or private operator traces are included.

