### PR TITLE
fix(agents): preserve native runtime auth across catalog refresh

### DIFF
--- a/src/agents/harness-runtimes.ts
+++ b/src/agents/harness-runtimes.ts
@@ -38,7 +38,7 @@ function parseConfiguredModelRef(
   return parseModelCatalogRef(value) ?? undefined;
 }
 
-function resolveConfiguredModelHarnessRuntime(params: {
+export function resolveConfiguredModelHarnessRuntime(params: {
   config: OpenClawConfig;
   includeImplicitRuntimePreferences: boolean;
   modelRef: string;

--- a/src/agents/prepared-model-catalog-worker.integration.test.ts
+++ b/src/agents/prepared-model-catalog-worker.integration.test.ts
@@ -42,9 +42,14 @@ import {
 } from "./prepared-model-runtime.js";
 import { resetPreparedModelRuntimeSnapshotsForTest } from "./prepared-model-runtime.test-support.js";
 import { AuthStorage } from "./sessions/auth-storage.js";
+import {
+  markPluginMetadataSnapshotProvided,
+  writeSyntheticAuthDiscoveryFixture,
+} from "./test-helpers/prepared-model-catalog-worker-fixture.js";
 
 const PROVIDER_ID = "worker-catalog-fixture";
 const HARNESS_ID = "worker-catalog-fixture-harness";
+const UNRELATED_SYNTHETIC_AUTH_ID = `${PROVIDER_ID}-unrelated-harness`;
 const SHARED_AUTH_PROVIDER_ID = `${PROVIDER_ID}-shared-auth`;
 const PLUGIN_ID = "worker-catalog-fixture";
 const PROFILE_ID = `${SHARED_AUTH_PROVIDER_ID}:named`;
@@ -99,6 +104,12 @@ function writeFixturePlugin(params: {
   const pluginDir = path.join(params.root, "plugin");
   fs.mkdirSync(pluginDir, { recursive: true });
   const pluginFile = path.join(pluginDir, "index.cjs");
+  writeSyntheticAuthDiscoveryFixture({
+    root: params.root,
+    pluginDir,
+    harnessId: HARNESS_ID,
+    unrelatedId: UNRELATED_SYNTHETIC_AUTH_ID,
+  });
   fs.writeFileSync(
     pluginFile,
     `const fs = require("node:fs");
@@ -205,6 +216,9 @@ module.exports = {
     JSON.stringify({
       id: PLUGIN_ID,
       providers: [PROVIDER_ID],
+      cliBackends: [HARNESS_ID, UNRELATED_SYNTHETIC_AUTH_ID],
+      syntheticAuthRefs: [HARNESS_ID, UNRELATED_SYNTHETIC_AUTH_ID],
+      providerCatalogEntry: "./provider-discovery.cjs",
       configSchema: { type: "object", additionalProperties: false, properties: {} },
       contracts: { externalAuthProviders: [PROVIDER_ID] },
       modelCatalog: { discovery: { [PROVIDER_ID]: "runtime" }, runtimeAugment: true },
@@ -313,11 +327,28 @@ async function createStaticSnapshot(
   options?: {
     hydrateExternalCliProviderIds?: readonly string[];
     metadataWorkspace?: "gateway" | "none" | "activation";
+    provideMetadataToWorker?: boolean;
   },
 ) {
   const fixture = createCatalogFixture(spinMs, envOverride, options);
   const { agentDir, workspaceDir, config, env, root } = fixture;
   let current = true;
+  const loadedMetadataSnapshot = options?.metadataWorkspace
+    ? loadPluginMetadataSnapshot({
+        config:
+          options.metadataWorkspace === "activation"
+            ? { ...config, plugins: { ...config.plugins, entries: {} } }
+            : config,
+        env,
+        ...(options.metadataWorkspace === "gateway"
+          ? { workspaceDir: path.join(root, "gateway-workspace") }
+          : {}),
+      })
+    : undefined;
+  const providedMetadataSnapshot =
+    options?.provideMetadataToWorker && loadedMetadataSnapshot
+      ? markPluginMetadataSnapshotProvided(loadedMetadataSnapshot)
+      : loadedMetadataSnapshot;
   const build = await startSerializedSnapshotBuild(
     { agentId: "main", agentDir, inheritedAuthDir: agentDir, workspaceDir, config, env },
     new Map(),
@@ -326,18 +357,7 @@ async function createStaticSnapshot(
     () => current,
     false,
     undefined,
-    options?.metadataWorkspace
-      ? loadPluginMetadataSnapshot({
-          config:
-            options.metadataWorkspace === "activation"
-              ? { ...config, plugins: { ...config.plugins, entries: {} } }
-              : config,
-          env,
-          ...(options.metadataWorkspace === "gateway"
-            ? { workspaceDir: path.join(root, "gateway-workspace") }
-            : {}),
-        })
-      : undefined,
+    providedMetadataSnapshot,
   ).pending;
   return {
     ...fixture,
@@ -507,6 +527,34 @@ describe("prepared model catalog worker boundary", () => {
         id: "account-scoped-model",
       }),
     );
+  });
+
+  it("preserves exact configured native auth across a full catalog refresh", async () => {
+    const fixture = await createStaticSnapshot(
+      0,
+      {},
+      {
+        metadataWorkspace: "none",
+        provideMetadataToWorker: true,
+      },
+    );
+    const syntheticAuthProbePath = path.join(fixture.root, "synthetic-auth-probes.txt");
+
+    expect(fixture.snapshot.authModes[HARNESS_ID]).toBe("api_key");
+    expect(fixture.snapshot.authModes[PROVIDER_ID]).toBeUndefined();
+    fs.rmSync(fixture.externalAuthPath);
+    fs.writeFileSync(syntheticAuthProbePath, "", "utf8");
+    await loadPreparedModelRuntimeAuth(fixture.snapshot, { providerIds: [] });
+    fs.writeFileSync(syntheticAuthProbePath, "", "utf8");
+
+    const catalog = await fixture.snapshot.loadFullModelCatalog?.({ refresh: true });
+    const fullAuth = getPreparedModelFullCatalogAuth(catalog!);
+
+    expect(fs.readFileSync(syntheticAuthProbePath, "utf8").trim().split("\n")).toEqual([
+      HARNESS_ID,
+    ]);
+    expect(fullAuth?.authModes[HARNESS_ID]).toBe("api_key");
+    expect(fullAuth?.authModes[PROVIDER_ID]).toBeUndefined();
   });
 
   it("refreshes durable auth before provider hooks decide catalog membership", async () => {

--- a/src/agents/prepared-model-runtime.configured.ts
+++ b/src/agents/prepared-model-runtime.configured.ts
@@ -19,6 +19,7 @@ import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.typ
 import { resolveAgentEntry } from "./agent-scope-config.js";
 import { buildInlineProviderModels } from "./embedded-agent-runner/model.inline-provider.js";
 import type { StaticModelIdMatcher } from "./embedded-agent-runner/model.static-id.js";
+import { resolveConfiguredModelHarnessRuntime } from "./harness-runtimes.js";
 import type { ModelCatalogEntry } from "./model-catalog.js";
 import type { AuthStorageData } from "./sessions/auth-storage.js";
 import { resolveEffectiveAgentRuntime } from "./thinking-runtime.js";
@@ -89,6 +90,7 @@ export function collectPreparedModelRuntimeProviderIds(
   credentials: Readonly<AuthStorageData>,
   includeCredentialProviders: boolean,
   configuredModelRefs: readonly ConfiguredModelRef[] = collectConfiguredModelRefs(config),
+  agentId?: string,
 ): string[] {
   const providerIds = new Set<string>();
   const addProviderId = (value: string) => {
@@ -107,6 +109,14 @@ export function collectPreparedModelRuntimeProviderIds(
     if (separator > 0) {
       addProviderId(ref.value.slice(0, separator));
     }
+    addProviderId(
+      resolveConfiguredModelHarnessRuntime({
+        config,
+        modelRef: ref.value,
+        agentId,
+        includeImplicitRuntimePreferences: false,
+      }) ?? "",
+    );
   }
   return [...providerIds].toSorted((left, right) => left.localeCompare(right));
 }

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -139,6 +139,7 @@ function prepareAgentFacts(
           credentials,
           catalogMode === "live",
           rawConfiguredModelRefs,
+          input.agentId,
         ),
         ...parseConfiguredModelVisibilityEntries({
           cfg: input.config,
@@ -248,8 +249,14 @@ export async function prepareWorkspaceBuildGroup(
     };
     const configuredProviderIds = [
       ...new Set([
-        ...collectPreparedModelRuntimeProviderIds(input.config, {}, false),
         ...inputs.flatMap(({ config, agentId }) => [
+          ...collectPreparedModelRuntimeProviderIds(
+            config,
+            {},
+            false,
+            collectPreparedModelRuntimeConfiguredRefs(config, agentId),
+            agentId,
+          ),
           ...parseConfiguredModelVisibilityEntries({ cfg: config, agentId }).providerWildcards,
         ]),
         ...(options.providerDiscoveryProviderIds ?? []).map(normalizeProviderId).filter(Boolean),

--- a/src/agents/prepared-model-runtime.test-harness.ts
+++ b/src/agents/prepared-model-runtime.test-harness.ts
@@ -68,6 +68,7 @@ const preparedModelRuntimeMocks = vi.hoisted(() => ({
     entries: [],
     routeVariants: [],
   })),
+  runtimeSyntheticAuthProviderRefs: [] as string[],
   resolveAmbientCredentials: vi.fn((..._args: unknown[]) => ({})),
   resolveStaticCatalogModel: vi.fn<StaticCatalogResolver>(() => undefined),
   warn: vi.fn(),
@@ -167,7 +168,8 @@ vi.mock("./agent-model-discovery.js", () => ({
 }));
 
 vi.mock("../plugins/synthetic-auth.runtime.js", () => ({
-  resolveRuntimeSyntheticAuthProviderRefs: () => [],
+  resolveRuntimeSyntheticAuthProviderRefs: () =>
+    preparedModelRuntimeMocks.runtimeSyntheticAuthProviderRefs,
 }));
 
 vi.mock("./agent-scope.js", () => ({
@@ -373,6 +375,7 @@ export function resetPreparedModelRuntimeHarness(): void {
     entries: [],
     routeVariants: [],
   });
+  preparedModelRuntimeMocks.runtimeSyntheticAuthProviderRefs = [];
   preparedModelRuntimeMocks.resolveAmbientCredentials.mockReset().mockReturnValue({});
   preparedModelRuntimeMocks.resolveStaticCatalogModel.mockReset().mockReturnValue(undefined);
   preparedModelRuntimeMocks.createStaticCatalogResolver

--- a/src/agents/prepared-model-runtime.test.ts
+++ b/src/agents/prepared-model-runtime.test.ts
@@ -343,11 +343,15 @@ describe("prepared model runtime snapshots", () => {
           {
             id: "selected",
             model: { primary: "anthropic/claude-sonnet-5" },
+            models: {
+              "anthropic/claude-sonnet-5": { agentRuntime: { id: "selected-runtime" } },
+            },
             modelPolicy: { allow: ["vllm/*"] },
           },
           {
             id: "sibling",
             model: { primary: "ollama/sibling" },
+            models: { "ollama/sibling": { agentRuntime: { id: "sibling-runtime" } } },
             modelPolicy: { allow: ["sibling-only/*"] },
           },
         ],
@@ -359,6 +363,7 @@ describe("prepared model runtime snapshots", () => {
         },
       },
     } as OpenClawConfig;
+    mocks.runtimeSyntheticAuthProviderRefs = ["selected-runtime", "sibling-runtime"];
 
     await publishPreparedModelRuntimeSnapshot({
       agentId: "selected",
@@ -370,8 +375,11 @@ describe("prepared model runtime snapshots", () => {
       config,
       "/tmp/prepared-model-runtime-selected-provider-scope",
       expect.objectContaining({
-        providerDiscoveryProviderIds: ["anthropic", "custom", "openai", "vllm"],
+        providerDiscoveryProviderIds: ["anthropic", "custom", "openai", "selected-runtime", "vllm"],
       }),
+    );
+    expect(mocks.resolveAmbientCredentials).toHaveBeenCalledWith(
+      expect.objectContaining({ syntheticAuthProviderRefs: ["selected-runtime"] }),
     );
   });
 

--- a/src/agents/test-helpers/prepared-model-catalog-worker-fixture.ts
+++ b/src/agents/test-helpers/prepared-model-catalog-worker-fixture.ts
@@ -1,0 +1,36 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
+
+export function writeSyntheticAuthDiscoveryFixture(params: {
+  root: string;
+  pluginDir: string;
+  harnessId: string;
+  unrelatedId: string;
+}): void {
+  const probePath = path.join(params.root, "synthetic-auth-probes.txt");
+  fs.writeFileSync(
+    path.join(params.pluginDir, "provider-discovery.cjs"),
+    `const fs = require("node:fs");
+module.exports = {
+  id: ${JSON.stringify(params.harnessId)},
+  hookAliases: [${JSON.stringify(params.unrelatedId)}],
+  label: "Worker catalog fixture synthetic auth",
+  auth: [],
+  resolveSyntheticAuth({ provider }) {
+    fs.appendFileSync(${JSON.stringify(probePath)}, provider + "\\n");
+    return provider === ${JSON.stringify(params.harnessId)}
+      ? { apiKey: "native-login-not-real", source: "fixture native login", mode: "oauth" }
+      : undefined;
+  },
+};
+`,
+    "utf8",
+  );
+}
+
+export function markPluginMetadataSnapshotProvided(
+  snapshot: PluginMetadataSnapshot,
+): PluginMetadataSnapshot {
+  return { ...snapshot, registrySource: "provided", registryDiagnostics: [] };
+}


### PR DESCRIPTION
Related: #129326
Regression after #129624

## What Problem This Solves

An explicitly configured native agent runtime (for example, Claude CLI) could authenticate and expose its models at startup, then lose them after a full model-catalog refresh. The refresh scoped synthetic-auth discovery only by the logical model provider, so it omitted the exact runtime that owned the model's authentication.

## Why This Change Was Made

The prepared provider-ref producer now carries the exact, explicitly selected `agentRuntime` ID alongside each configured model's logical provider. It does this in both per-agent and workspace-live scopes.

The worker's exact filtering remains unchanged. As a result:

- a direct Anthropic API route does not probe or inherit Claude CLI auth;
- sibling-agent runtimes do not leak into the selected agent's scope;
- implicit runtime preferences do not enlarge refresh scope;
- no startup auth is merged over a newer worker generation.

This is a generic 17-line net production change. It adds no provider-specific literals and does not change config, storage, credentials, the worker protocol, or catalog consumers.

## User Impact

Models routed through an authenticated native runtime remain available after catalog refreshes and model-picker reloads. Direct API routes, unrelated providers, disabled or missing native runtimes, and sibling agents retain their existing isolation.

## Evidence

- Pre-fix regression tests on `a3c445d04b`: **54 passed / 2 failed**. Full refresh probed no configured native runtime, and the selected live scope omitted its runtime ID.
- Final focused tests: **56 / 56 passed** across the real catalog worker lifecycle and prepared runtime scopes.
- Broader affected-surface suite: **193 / 193 passed** across eight agent, gateway, and Anthropic files.
- `pnpm check:changed`: passed, including formatting, core/test typechecks, lint, plugin boundaries, dead-code checks, and **0 runtime import cycles**.
- `pnpm build`: passed, including bundled and external plugins plus Control UI.
- [Inspectable redacted live-Gateway transcript](https://github.com/openclaw/openclaw/pull/131931#issuecomment-5456926099): Opus and Sonnet stayed available across prepared/default/full-refresh/prepared/default reads; a real native Opus turn returned `OK`; an independent real-Gateway auth probe showed selected-runtime only, zero probes for the direct route, and sibling-runtime only.
- Independent final Codex review: no P0-P2 findings; direct Anthropic, selected-runtime, sibling-runtime, worker metadata handoff, and test causality were checked separately.
- Ownership precedent: Codex keeps [catalog refresh/application in ModelsManager](https://github.com/openai/codex/blob/92f887ec35098c479dbe7f0d48d23f7f955055a0/codex-rs/models-manager/src/manager.rs#L412-L434) and [shared auth state in AuthManager](https://github.com/openai/codex/blob/92f887ec35098c479dbe7f0d48d23f7f955055a0/codex-rs/login/src/auth/manager.rs#L2030-L2051), matching this producer-owned fix rather than a consumer-side auth merge.

## Maintainer Verification

- Exact current main `4bc4ad35fa1cc665070f111a9f9e821689937835`: prepared and default reads started available, but full refresh and later reads marked both configured native models unavailable. A real native Opus turn still returned `OK`, proving the refresh lost working auth scope.
- Exact PR head `0b187489af973a4a38a841d9dd1a8d84b35d50ec`: the full build passed. Opus and Sonnet stayed available across prepared, default, full-refresh, prepared, and default reads. A real native Opus turn returned `OK`.
- Scope isolation: the selected agent probed only its selected runtime, the direct route probed no native runtime, and the sibling agent probed only its sibling runtime.
- Regression proof: exact current-main production failed the two new assertions with 54 passing tests; exact PR head passed all 56 focused tests.
- Review and CI: immutable local ClawSweeper passed with 0 findings, security cleared, no owner decision, and 0 rank-up moves. Exact-head `openclaw/ci-gate` passed in run `33192727018`.
- Judged line count: production +19/-2 (net +17); tests and test support +109/-14 (net +95). The production growth carries the missing prepared owner fact without adding a consumer fallback.

AI-assisted: yes. Root-cause analysis and solution design were independently reviewed by Codex, Claude Fable, and Claude Opus; the final implementation and claims were verified against repository tests and an isolated live gateway.
