### PR TITLE
fix(linux): authorize tray gateway stop

### DIFF
--- a/apps/linux/src-tauri/src/gateway.rs
+++ b/apps/linux/src-tauri/src/gateway.rs
@@ -62,11 +62,11 @@ pub enum GatewayAction {
 }
 
 impl GatewayAction {
-    fn command(self) -> &'static str {
+    fn command_args(self) -> &'static [&'static str] {
         match self {
-            Self::Start => "start",
-            Self::Stop => "stop",
-            Self::Restart => "restart",
+            Self::Start => &["start"],
+            Self::Stop => &["stop", "--force"], // Tray click supplies required non-interactive authorization.
+            Self::Restart => &["restart"],
         }
     }
 }
@@ -191,11 +191,11 @@ pub fn ensure_ready(cli: &OpenClawCli) -> Result<ReadyGateway, String> {
     }
 
     if !snapshot.installed {
-        run_service_command(cli, "install")?;
+        run_service_command(cli, &["install"])?;
         snapshot = status(cli)?;
     }
     if !snapshot.running {
-        run_service_command(cli, "start")?;
+        run_service_command(cli, &["start"])?;
     }
 
     snapshot = wait_until_reachable(cli)?;
@@ -219,7 +219,7 @@ fn wait_until_reachable(cli: &OpenClawCli) -> Result<GatewaySnapshot, String> {
 }
 
 pub fn act(cli: &OpenClawCli, action: GatewayAction) -> Result<GatewaySnapshot, String> {
-    run_service_command(cli, action.command())?;
+    run_service_command(cli, action.command_args())?;
     if matches!(action, GatewayAction::Stop) {
         return status(cli);
     }
@@ -295,8 +295,13 @@ fn dashboard_token(dashboard_url: &str) -> Result<Option<String>, String> {
 }
 
 #[cfg(test)]
-mod dashboard_tests {
-    use super::dashboard_token;
+mod tests {
+    use super::{dashboard_token, GatewayAction};
+
+    #[test]
+    fn stop_carries_non_interactive_authorization() {
+        assert_eq!(GatewayAction::Stop.command_args(), ["stop", "--force"]);
+    }
 
     #[test]
     fn extracts_and_decodes_dashboard_fragment_token() {
@@ -322,9 +327,9 @@ mod dashboard_tests {
     }
 }
 
-fn run_service_command(cli: &OpenClawCli, action: &str) -> Result<(), String> {
+fn run_service_command(cli: &OpenClawCli, args: &[&str]) -> Result<(), String> {
     let (response, output) = cli
-        .json::<CommandResponse, _, _>(["gateway", action, "--json"])
+        .json::<CommandResponse, _, _>([&["gateway"][..], args, &["--json"][..]].concat())
         .map_err(|error| error.to_string())?;
     if response.ok && output.status.success() {
         return Ok(());
@@ -332,5 +337,5 @@ fn run_service_command(cli: &OpenClawCli, action: &str) -> Result<(), String> {
     Err(response
         .error
         .or(response.message)
-        .unwrap_or_else(|| format!("Gateway {action} failed.")))
+        .unwrap_or_else(|| format!("Gateway {} failed.", args[0])))
 }


### PR DESCRIPTION
Closes #131932

## What Problem This Solves

Linux companion users choosing **Stop Gateway** from the tray hit the CLI's non-interactive stop guard, saw a connection failure, and left the Gateway running. The companion launches the CLI with null stdin, but its Stop argv omitted the documented `--force` authorization.

## Why This Change Was Made

The Linux companion now gives only `GatewayAction::Stop` the `--force` tail. `run_service_command` remains the single owner of the common `gateway … --json` framing, so Install, Start, and Restart keep byte-identical argv. The focused test protects the authorization decision, and the inline comment records why the otherwise-dangerous-looking flag belongs here.

Maintainer decision: an explicit Stop selection in the local Linux companion is operator authorization for this non-interactive CLI invocation. The CLI guard remains unchanged for shells, agents, and other automation.

## User Impact

Linux users can stop their local Gateway from the tray as documented. This repairs behavior now present in stable builds: the app reaches the visible stopped state instead of showing an error while the service remains running.

## Evidence

Source path:

- Tray dispatch: `apps/linux/src-tauri/src/tray.rs:384-386`
- Null stdin and piped output: `apps/linux/src-tauri/src/cli.rs:86-105`
- Stop authorization tail and canonical framing: `apps/linux/src-tauri/src/gateway.rs:64-71,221-226,330-340`
- Focused regression: `apps/linux/src-tauri/src/gateway.rs:297-304`
- CLI guard: `src/cli/daemon-cli/lifecycle.ts:476-484`
- Local-only Tauri capability: `apps/linux/src-tauri/tauri.conf.json:39-64`

Box results, run serially:

- `cargo +stable fmt --check` — pass.
- `cargo +stable test --locked --all-targets gateway::tests::stop_carries_non_interactive_authorization -- --exact` — 1 passed.
- `cargo +stable test --locked --all-targets` — 146 passed, 1 ignored Linux/D-Bus integration.
- `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/cli/daemon-cli/lifecycle.test.ts` — 45 passed, including blocked unforced and allowed forced non-interactive Stop.
- `node scripts/check-changed.mjs --dry-run -- apps/linux/src-tauri/src/gateway.rs` — selected the `apps` lane.
- `OPENCLAW_VITEST_MAX_WORKERS=2 pnpm check:changed` — pass.
- `cargo +stable build --locked --bin openclaw-desktop` — pass.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --max-priority P1 …` — scoped-clean, no accepted/actionable P0/P1 findings.

Desktop E2E used the real compiled companion, an isolated X11/D-Bus session, the standard StatusNotifier host, and a controlled CLI service boundary:

- `xvfb-run -a -s '-screen 0 1280x1024x24' dbus-run-session -- /tmp/x131934-proof/probe.sh apps/linux/src-tauri/target/debug/openclaw-desktop`
- The same `com.canonical.dbusmenu.Event` activation of the real **Stop Gateway** item was run against baseline and fixed binaries.
- Baseline: child argv was `gateway stop --json`, stdin resolved to `/dev/null`, stdout was non-TTY, the controlled service remained running, and the app rendered its connection-error state.
- Fixed: child argv was `gateway stop --force --json`, stdin resolved to `/dev/null`, stdout was non-TTY, the controlled service transitioned to stopped, the native menu reported `Gateway: Stopped`, and the app rendered its stopped state.

Before — baseline tray Stop failure:

![Baseline Linux tray Stop renders a connection issue](https://github.com/user-attachments/assets/d4fc4aa6-7e57-4f9c-820b-d271266d1eec)

After — fixed tray Stop reaches the stopped state:

![Fixed Linux tray Stop renders OpenClaw standing by](https://github.com/user-attachments/assets/e35c8026-e206-4b2b-a9c0-5b7b65bef77d)

Security boundary — an HTTP dashboard attempted `gateway_action("stop")`; Tauri rejected it before any Stop service I/O, and the CLI log contained no Stop invocation until the native tray event:

![Nonlocal dashboard gateway action rejected by Tauri capability](https://github.com/user-attachments/assets/29596a3f-cda0-47f5-b035-b8d1d368c330)

Production LOC: +11/-11 (net 0). Tests: +6/-1 (net +5).

## Landing notes

- Rebased the branch onto the fetched `origin/main` before validation; the rebase was clean.
- X-ray adjustment — invariant comment: added at the Stop mapping so future cleanup does not remove required authorization.
- X-ray adjustment — duplicated framing: restored `gateway` and `--json` ownership to `run_service_command`; action tails contain only action-specific arguments; fallback error naming uses `args[0]`.
- X-ray adjustment — focused test: renamed to `stop_carries_non_interactive_authorization` and removed unrelated Start/Restart constant assertions.
- X-ray adjustment — stale body references: refreshed all source references to current lines.
- ClawSweeper Rank-up — nearest unauthorized principal: applied. The navigated HTTP dashboard's direct Tauri invocation was denied by the local-only capability before service I/O; evidence is attached above.
- ClawSweeper Rank-up — redacted real desktop evidence: applied. The isolated desktop run used the real tray menu, verified null stdin and exact argv, and reached the visible stopped state; before/after evidence is attached above.
- ClawSweeper Rank-up — local authorization boundary: applied. This maintainer accepts the existing local-only companion capability plus an explicit Stop selection as the authorization boundary for this forced invocation; no shell, agent, remote dashboard, or generic automation path is widened.
- Best-fix verdict: best. Weakening the CLI guard, inventing a caller identity/env bypass, allocating a pseudo-TTY, or treating Stop as uninstall would move policy to the wrong owner or change product semantics.

## Risk and coverage

What else could break: a future bundled local page could intentionally invoke `gateway_action("stop")`; today the bundled page only invokes Start (`apps/linux/ui/main.js:470-481,611-620`), while remote dashboard content is rejected by Tauri. Install, Start, and Restart retain their prior argv. `--force` is consumed only by the CLI authorization gate and does not change stop signal/drain semantics.

Evidence it does not: full Linux Rust tests, focused CLI lifecycle tests, changed-file checks, independent autoreview, real baseline/fixed tray events, native menu state, final UI state, and explicit nonlocal rejection all pass on the rebased head.

What remains uncovered: the desktop E2E used a controlled CLI/service boundary, not the box's real systemd user service. Stopping the shared operator Gateway is forbidden, and the private proof session does not own that service. The existing CLI lifecycle suite separately proves that forced non-interactive Stop reaches the managed service boundary. Exact-head GitHub CI passed, including the required [`openclaw/ci-gate`](https://github.com/openclaw/openclaw/actions/runs/33796248055/job/100787489125).

