### PR TITLE
fix: native fs-safe opt-in fails in bundled installs

### DIFF
--- a/docs/gateway/security/secure-file-operations.md
+++ b/docs/gateway/security/secure-file-operations.md
@@ -13,9 +13,10 @@ It is a **library guardrail** for trusted OpenClaw code that receives untrusted 
 
 OpenClaw sets fs-safe's optional native helper to **off** by default:
 
-- native platform packages are optional and may be absent from minimal installs;
 - the guarded JavaScript paths support OpenClaw's normal filesystem operations;
 - disabling native loading keeps runtime behavior deterministic across desktop, Docker, CI, and bundled-app environments.
+
+The OpenClaw package includes fs-safe's prebuilt native helpers for Linux x64/arm64 (glibc and musl), macOS x64/arm64, and Windows x64. No separate platform package, download, or compiler is needed. Loading these helpers remains optional.
 
 OpenClaw only changes the _default_. An explicit setting always wins:
 
@@ -23,7 +24,7 @@ OpenClaw only changes the _default_. An explicit setting always wins:
 # Default OpenClaw behavior: guarded JavaScript fs-safe paths.
 OPENCLAW_FS_SAFE_NATIVE_MODE=off
 
-# Prefer native primitives when the platform package is installed.
+# Prefer native primitives when the bundled platform helper loads.
 OPENCLAW_FS_SAFE_NATIVE_MODE=auto
 
 # Fail closed when an operation needs native support and the binding is unavailable.
@@ -52,15 +53,17 @@ This covers OpenClaw's normal threat model: trusted gateway code handling untrus
 
 ## What native acceleration adds
 
-The optional platform package provides policy-free filesystem primitives used by fs-safe for create-only writes, guarded hard-link publication, asynchronous sidecar creation, and explicit no-replace rename publication. Linux uses `openat2` and `renameat2`; macOS uses descriptor-relative component checks and `renameatx_np`; Windows uses handle-relative operations and replacement-disabled rename.
+The bundled native helper provides policy-free filesystem primitives used by fs-safe for create-only writes, guarded hard-link publication, asynchronous sidecar creation, and explicit no-replace rename publication. Linux uses `openat2` and `renameat2`; macOS uses descriptor-relative component checks and `renameatx_np`; Windows uses handle-relative operations and replacement-disabled rename.
 
 The TypeScript layer still owns policy, validation, retries, cleanup, and fallback decisions. Native support narrows filesystem race windows; it does not turn fs-safe into a sandbox.
 
-If your deployment requires those native primitives, install the matching optional platform package and set:
+If your package deployment requires those native primitives, set:
 
 ```bash
 OPENCLAW_FS_SAFE_NATIVE_MODE=require
 ```
+
+In `require` mode, an unavailable or unloadable helper causes `helper-unavailable` instead of silently using the JavaScript path. Standalone portable worker bundles do not carry these native assets; their managed launch environment does not forward fs-safe mode overrides.
 
 ## Plugin and core guidance
 

--- a/test/scripts/tsdown-config.test.ts
+++ b/test/scripts/tsdown-config.test.ts
@@ -1,5 +1,8 @@
 // Tsdown config tests protect package artifact build contracts.
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { build } from "tsdown";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -39,7 +42,162 @@ const isWorkerRsyncReceiverConfig = (config: TsdownConfig) =>
 const isWorkerBuildConfig = (config: TsdownConfig) =>
   isWorkerDeployConfig(config) || isWorkerRsyncReceiverConfig(config);
 
+function nativeAssetInventory(directory: string) {
+  return fs
+    .readdirSync(directory, { recursive: true, encoding: "utf8" })
+    .filter((file) => fs.statSync(path.join(directory, file)).isFile())
+    .toSorted()
+    .map((file) => ({
+      file,
+      sha256: createHash("sha256")
+        .update(fs.readFileSync(path.join(directory, file)))
+        .digest("hex"),
+    }));
+}
+
+const FS_SAFE_CALLER_PROBE = `
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+const [entry, observer, rootDir, mode, outcome] = process.argv.slice(1);
+const { root } = await import(pathToFileURL(entry).href);
+const { configureFsSafeNative, getFsSafeNativeConfig, FsSafeError } = await import(pathToFileURL(observer).href);
+assert.equal(getFsSafeNativeConfig().mode, mode === "configured" ? "off" : mode);
+if (mode === "configured") configureFsSafeNative({ mode: "require" });
+const scoped = await root(rootDir);
+if (outcome === "missing") {
+  await assert.rejects(scoped.write("proof.txt", "native proof"), (error) => {
+    assert(error instanceof FsSafeError);
+    assert.equal(error.code, "helper-unavailable");
+    assert.equal(error.cause?.code, "MODULE_NOT_FOUND");
+    return true;
+  });
+  assert.deepEqual(fs.readdirSync(rootDir), []);
+} else {
+  await scoped.write("proof.txt", "native proof");
+  await scoped.create("created.txt", "create proof");
+  assert.equal(fs.readFileSync(path.join(rootDir, "proof.txt"), "utf8"), "native proof");
+  assert.equal(fs.readFileSync(path.join(rootDir, "created.txt"), "utf8"), "create proof");
+}
+const loaded = Object.keys(createRequire(import.meta.url).cache).filter((file) => file.endsWith("fs-safe-native.node"));
+assert.equal(loaded.length, outcome === "native" ? 1 : 0);
+if (loaded.length) assert(loaded[0].startsWith(path.dirname(rootDir) + path.sep));
+`;
+
 describe("tsdown config", () => {
+  it.each(["runtime", "worker"])(
+    "preserves native fs-safe assets and policy in relocated %s output",
+    async (target) => {
+      const temporaryRoot = fs.realpathSync(createTempDir("openclaw-tsdown-fs-safe-"));
+      const sourceRoot = path.join(temporaryRoot, "build");
+      const relocatedRoot = path.join(temporaryRoot, "relocated");
+      const require = createRequire(import.meta.url);
+      const nativeSource = path.join(
+        path.dirname(require.resolve("@openclaw/fs-safe/package.json")),
+        "dist/native",
+      );
+      const sdkSource = path.resolve("src/plugin-sdk/memory-core-host-engine-fs.ts");
+      const observerSource = path.join(temporaryRoot, "observer.ts");
+      fs.writeFileSync(
+        observerSource,
+        [
+          `export { root } from ${JSON.stringify(sdkSource)};`,
+          `export { configureFsSafeNative, getFsSafeNativeConfig } from ${JSON.stringify(require.resolve("@openclaw/fs-safe/config"))};`,
+          `export { FsSafeError } from ${JSON.stringify(require.resolve("@openclaw/fs-safe/errors"))};`,
+        ].join("\n"),
+      );
+      const worker = target === "worker";
+      const selected = configs.find(
+        worker ? isWorkerDeployConfig : (config) => config.name === TSDOWN_UNIFIED_CONFIG_GROUP,
+      );
+      expect(selected).toBeDefined();
+      // Deliberately not named dist: the dependency's URL is relative to the
+      // emitted loader, including the worker's extra directory component.
+      const bundles = await build({
+        ...selected,
+        config: false,
+        entry: worker
+          ? { "worker/worker": observerSource }
+          : { "plugin-sdk/memory-core-host-engine-fs": sdkSource, observer: observerSource },
+        outDir: path.join(sourceRoot, "output"),
+        dts: false,
+        logLevel: "silent",
+      });
+      try {
+        fs.writeFileSync(path.join(sourceRoot, "package.json"), '{"type":"module"}');
+        fs.renameSync(sourceRoot, relocatedRoot);
+        const entry = path.join(
+          relocatedRoot,
+          worker ? "output/worker/worker.mjs" : "output/plugin-sdk/memory-core-host-engine-fs.js",
+        );
+        const observer = worker ? entry : path.join(relocatedRoot, "output/observer.js");
+        const nativeOutput = path.join(
+          relocatedRoot,
+          worker ? "output/dist/native" : "dist/native",
+        );
+        const probe = (
+          name: string,
+          mode: string,
+          outcome: string,
+          override: NodeJS.ProcessEnv = {},
+        ) => {
+          const rootDir = path.join(relocatedRoot, name);
+          fs.mkdirSync(rootDir);
+          const result = spawnSync(
+            process.execPath,
+            [
+              "--input-type=module",
+              "--eval",
+              FS_SAFE_CALLER_PROBE,
+              entry,
+              observer,
+              rootDir,
+              mode,
+              outcome,
+            ],
+            {
+              cwd: relocatedRoot,
+              encoding: "utf8",
+              timeout: 30_000,
+              env: {
+                PATH: process.env.PATH,
+                SystemRoot: process.env.SystemRoot,
+                WINDIR: process.env.WINDIR,
+                HOME: temporaryRoot,
+                USERPROFILE: temporaryRoot,
+                TMPDIR: temporaryRoot,
+                TMP: temporaryRoot,
+                TEMP: temporaryRoot,
+                ...override,
+              },
+            },
+          );
+          expect(result.error, name).toBeUndefined();
+          expect(result.status, `${name}\n${result.stdout}\n${result.stderr}`).toBe(0);
+        };
+        for (const key of ["FS_SAFE_NATIVE_MODE", "OPENCLAW_FS_SAFE_NATIVE_MODE"]) {
+          probe(key, "require", "native", { [key]: "require" });
+        }
+        probe("shared-config", "configured", "native");
+        probe("default", "off", "fallback");
+        const assets = nativeAssetInventory(nativeSource);
+        expect(assets).toHaveLength(7);
+        expect(nativeAssetInventory(nativeOutput)).toEqual(assets);
+        fs.rmSync(nativeOutput, { recursive: true });
+        probe("missing", "require", "missing", { FS_SAFE_NATIVE_MODE: "require" });
+        for (const mode of ["off", "auto"]) {
+          probe(mode, mode, "fallback", { FS_SAFE_NATIVE_MODE: mode });
+        }
+      } finally {
+        for (const bundle of bundles) {
+          await bundle[Symbol.asyncDispose]();
+        }
+      }
+    },
+  );
+
   it.each(
     ["runtime", "declarations", "worker", "receiver"].flatMap((target) =>
       [false, true].map((verbose) => ({ target, verbose })),

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,6 +1,6 @@
 // tsdown config defines package build entrypoints and output options.
 import fs from "node:fs";
-import { isBuiltin } from "node:module";
+import { createRequire, isBuiltin } from "node:module";
 import path from "node:path";
 import type { UserConfig } from "tsdown";
 import {
@@ -171,11 +171,24 @@ function nodeBuildConfig(
   };
 }
 
+function fsSafeNativeCopy(entryDirectory: string): UserConfig["copy"] {
+  const packageRoot = path.dirname(
+    createRequire(import.meta.url).resolve("@openclaw/fs-safe/package.json"),
+  );
+  return ({ outDir }) => ({
+    from: path.join(packageRoot, "dist/native"),
+    // fs-safe resolves ../dist/native from its emitted loader. Preserve that
+    // layout, including the inline worker's extra directory, and every target.
+    to: path.resolve(outDir, entryDirectory, "..", "dist"),
+  });
+}
+
 function workerDeployBuildConfig(): UserConfig {
   return {
     name: TSDOWN_UNIFIED_CONFIG_GROUP,
     entry: { "worker/worker": "src/worker/worker-deploy-entry.ts" },
     outDir: "dist",
+    copy: fsSafeNativeCopy("worker"),
     dts: false,
     env,
     define: {
@@ -760,6 +773,7 @@ const configs = [
       // and bundled hooks in one graph so runtime singletons are emitted once.
       entry: unifiedDistEntries,
       deps: unifiedDeps,
+      copy: fsSafeNativeCopy("."),
       plugins: [createStateSchemaInlinePlugin()],
     },
     false,


### PR DESCRIPTION
Closes #131938

## What Problem This Solves

Fixes an issue where operators explicitly opting into fs-safe native mode would encounter `helper-unavailable` during compiled OpenClaw filesystem writes, even though the matching native binary worked through the installed dependency package.

This is the bundled-loader issue discovered while checking the Mac worker recovery work in https://github.com/openclaw/openclaw/pull/131466, not a demonstrated default Mac worker failure. That PR's recovery/elevation producer decisions are not part of this change.

## Why This Change Was Made

Keep fs-safe and its subpaths in the existing shared core/SDK/plugin graph, and use tsdown's maintained directory-copy support to carry every pinned native binary into the relative layout expected by the relocated loader. The same small build helper handles shared root chunks (`dist/native`) and the nested packaged worker (`dist/dist/native`), following resolved output directories rather than assuming a build working directory.

No runtime loader, fallback, dependency, platform selector, native-mode default, operator option, or elevation policy changes. Partial externalization would split configuration/error/loader identity; a consumer fallback would conceal the missing asset producer and weaken the purpose of required mode. Existing package inclusion and regular-file inventory already cover the added assets.

The native migration in https://github.com/openclaw/openclaw/pull/113705 (0d7fb8eb392fa59714d7bcec3f112898c31441a9; authored and merged by @steipete, 2026-07-28) carried forward the earlier always-bundle policy without asset materialization. This repair does not attribute the defect to the separate Mac worker PR.

## User Impact

Explicit `FS_SAFE_NATIVE_MODE=require` and `OPENCLAW_FS_SAFE_NATIVE_MODE=require` work through the bundled OpenClaw filesystem caller on supported native targets. Default native-off behavior is unchanged; genuinely missing or unloadable assets still fail closed in required mode, while `auto` retains its existing JavaScript fallback.

The docs now describe bundled prebuilds rather than nonexistent optional platform-package installation. Standalone portable worker deployments still transport only their existing two JavaScript files and do not inherit fs-safe native-mode overrides; expanding that artifact contract is not part of this fix.

Runtime production LOC: +0/-0. Build tooling: +15/-1 (net +14), shared by the two required output layouts. Tests: +158/-0. Docs: +7/-4. The build growth supplies the previously missing asset producer; no obsolete runtime path exists to remove. Keeping all seven targets in both layouts adds 32,466,720 uncompressed bytes (about 31 MiB); no architecture pruning or symlink-based packaging shortcut is introduced.

## Evidence

AI-assisted implementation with direct dependency/build-source inspection and independent Codex autoreview.

- **Fail before / pass after:** `node scripts/run-vitest.mjs test/scripts/tsdown-config.test.ts` failed both newly authored real-build relocation cases at the intended `helper-unavailable` / `MODULE_NOT_FOUND` boundary before the production change; afterward all 17 tests passed.
- **Sibling and default contracts:** `node scripts/run-vitest.mjs src/infra/tsdown-config.test.ts src/infra/fs-safe-defaults.test.ts src/plugin-sdk/fs-safe-compat.test.ts` passed all 30 tests.
- **Changed gates:** `node scripts/check-changed.mjs -- tsdown.config.ts test/scripts/tsdown-config.test.ts docs/gateway/security/secure-file-operations.md` passed selected typechecks, lint, formatting, and the runtime import-cycle check (0 cycles). No gate, suppression, or baseline was weakened.
- **Canonical build:** `pnpm build` passed all runtime, declaration, postbuild, SDK export, and Control UI build phases; zero `INEFFECTIVE_DYNAMIC_IMPORT` diagnostics. The local rebuild took 41m 42.8s, including slow prior-generated-output cleanup; it completed without bypasses.
- **Package file inclusion:** `npm pack --dry-run --ignore-scripts --offline --json` included all 14 native files. This was file-inclusion inspection, not an npm installation or publication.
- **Actual compiled caller, not direct dependency-only proof:** after the complete build, the 9,957 selected runtime/package-manifest files were copied to a fresh synthetic location, relocated again, and run without `node_modules`. The existing compiled `dist/plugin-sdk/memory-core-host-engine-fs.js` write/create caller passed 21/21 scenarios across the retained Node 24.19.0 arm64 and x64 executables and Bun 1.4.0 arm64. Each runtime covered default/off, both required-mode aliases, and missing-assets require/auto/off behavior. Required-mode success loaded exactly the matching OpenClaw `dist/native` addon; removing those assets failed closed without creating target files.
- **Asset and loader provenance:** every target binary in both output locations is SHA-256-identical to the installed fs-safe 0.5.6 payload. The candidate compiled loader is byte-identical to the retained failing b3c8c4fe66c loader (SHA-256 `36a5a4ec6dffd15a872be457e02b4b24f1a06bf18c483adec36936c836200e13`), proving that success comes from carrying the assets rather than modifying or faking the loader.

| Runtime | Before: actual bundled write | After: relocated caller scenarios |
| --- | --- | --- |
| Node 24.19.0 / Darwin arm64 | `helper-unavailable` / `MODULE_NOT_FOUND` | 7/7 pass |
| Node 24.19.0 / Darwin x64 | `helper-unavailable` / `MODULE_NOT_FOUND` | 7/7 pass |
| Bun 1.4.0 / Darwin arm64 | `helper-unavailable` / `MODULE_NOT_FOUND` | 7/7 pass |

Scope and proof limits: native execution was verified on Darwin arm64/x64; Linux/Windows binaries were verified for complete, unchanged delivery, not executed here. The nested-worker regression compiles a representative real SDK caller with the production worker configuration; it is not a live managed-worker run. No app/Gateway, Keychain, operator-state, production-database, portable-worker deployment, signing, or elevation/admission operation was performed. The latest stable package inspected still uses fs-safe 0.4.1, so this is not a claim of a default-worker regression in that release.

Named follow-up: the separate Mac worker verifier is not on current main and its direct-package hash section does not prove the bundled loader. Its owner should reuse the compiled SDK write/create proof under each packaged Node. That verifier and the strict per-architecture materialization/elevation decision remain outside this PR.
