### PR TITLE
fix(macos): recover dashboard authentication after reconnect

### DIFF
--- a/apps/macos/Sources/OpenClaw/DashboardManager.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardManager.swift
@@ -42,9 +42,15 @@ final class DashboardManager {
     @ObservationIgnored private var displayedRouteAuthority: UInt64?
     @ObservationIgnored private var endpointGeneration: UInt64 = 0
     @ObservationIgnored private var presentationGeneration: UInt64 = 0
+    @ObservationIgnored private var controlUIAuthenticationState =
+        GatewayConnection.ControlUIAuthenticationState.pending
     @ObservationIgnored private var switchGenerations: [ObjectIdentifier: UInt64] = [:]
-    @ObservationIgnored private let authTokenProvider: @Sendable (GatewayConnection.Config) async -> String?
-    @ObservationIgnored private let routeProbe: @Sendable () async -> Void
+    @ObservationIgnored private let controlUIAccessProvider:
+        @Sendable (GatewayConnection.Config) async -> GatewayConnection.ControlUIAccessResolution?
+    @ObservationIgnored private let controlUIAuthenticationStream:
+        @Sendable () async -> AsyncStream<GatewayConnection.ControlUIAuthenticationState>
+    @ObservationIgnored private let controlUIAccessIsCurrent:
+        @Sendable (GatewayConnection.ControlUIAccessResolution) async -> Bool
     @ObservationIgnored private let endpointStateProvider: @Sendable () async -> GatewayEndpointState
     @ObservationIgnored private let mainWindowAutosaveName: String
     @ObservationIgnored private let observesGatewayChanges: Bool
@@ -62,15 +68,17 @@ final class DashboardManager {
     private static let failureURL = URL(string: "about:blank")!
 
     private init(
-        authTokenProvider: @escaping @Sendable (GatewayConnection.Config) async -> String? = { config in
-            await GatewayConnection.shared.controlUiAutoAuthToken(config: config)
+        controlUIAccessProvider: @escaping @Sendable (GatewayConnection.Config) async
+            -> GatewayConnection.ControlUIAccessResolution? = { config in
+            await GatewayConnection.shared.resolveControlUIAccess(config: config)
         },
-        routeProbe: @escaping @Sendable () async -> Void = {
-            _ = try? await GatewayConnection.shared.request(
-                method: "health",
-                params: nil,
-                timeoutMs: 3000,
-                retryTransportFailures: false)
+        controlUIAuthenticationStream: @escaping @Sendable () async
+            -> AsyncStream<GatewayConnection.ControlUIAuthenticationState> = {
+            await GatewayConnection.shared.subscribeControlUIAuthentication()
+        },
+        controlUIAccessIsCurrent: @escaping @Sendable (GatewayConnection.ControlUIAccessResolution) async
+            -> Bool = { resolution in
+            await GatewayConnection.shared.isCurrentControlUIAccessResolution(resolution)
         },
         endpointStateProvider: @escaping @Sendable () async -> GatewayEndpointState = {
             await GatewayEndpointStore.shared.currentState()
@@ -79,8 +87,9 @@ final class DashboardManager {
         automaticGatewayProfileRefreshEnabled: Bool = true,
         mainWindowAutosaveName: String = DashboardWindowLayout.windowFrameAutosaveName)
     {
-        self.authTokenProvider = authTokenProvider
-        self.routeProbe = routeProbe
+        self.controlUIAccessProvider = controlUIAccessProvider
+        self.controlUIAuthenticationStream = controlUIAuthenticationStream
+        self.controlUIAccessIsCurrent = controlUIAccessIsCurrent
         self.endpointStateProvider = endpointStateProvider
         self.mainWindowAutosaveName = mainWindowAutosaveName
         self.observesGatewayChanges = observeGatewayChanges
@@ -89,7 +98,6 @@ final class DashboardManager {
             let names: [Notification.Name] = [
                 MacGatewayProfileStore.didChangeNotification,
                 .openclawConfigDidChange,
-                .controlChannelStateDidChange,
             ]
             self.gatewayRefreshObservers = names.map { name in
                 NotificationCenter.default.addObserver(
@@ -99,9 +107,6 @@ final class DashboardManager {
                 { [weak self] _ in
                     Task { @MainActor [weak self] in
                         guard let self else { return }
-                        if name == .controlChannelStateDidChange {
-                            await self.handleControlChannelStateChange(ControlChannel.shared.state)
-                        }
                         await self.refreshGatewaySnapshots()
                     }
                 }
@@ -120,14 +125,27 @@ final class DashboardManager {
                 }
             }
         }
+        if observeGatewayChanges {
+            self.controlUIAuthenticationState = .pending
+            Task { [weak self] in
+                guard let stream = await self?.controlUIAuthenticationStream() else { return }
+                for await state in stream {
+                    guard let self else { return }
+                    self.controlUIAuthenticationState = state
+                    guard case .authenticated = state else { continue }
+                    Task { @MainActor [weak self] in
+                        await self?.handleControlUIAuthentication(state)
+                    }
+                }
+            }
+        }
     }
 
-    private func handleControlChannelStateChange(_ state: ControlChannel.ConnectionState) async {
-        guard state == .connected else { return }
-        // Endpoint readiness can precede device authentication. Reconcile the
-        // existing document after auth arrives without inventing a route change.
+    private func handleControlUIAuthentication(
+        _ authenticationState: GatewayConnection.ControlUIAuthenticationState) async
+    {
         let endpointState = await self.endpointStateProvider()
-        await self.handleEndpointState(endpointState)
+        await self.handleEndpointState(endpointState, authenticationState: authenticationState)
     }
 
     /// The card's native update path only makes sense when the app owns the
@@ -158,7 +176,10 @@ final class DashboardManager {
         }
     }
 
-    func handleEndpointState(_ state: GatewayEndpointState) async {
+    func handleEndpointState(
+        _ state: GatewayEndpointState,
+        authenticationState: GatewayConnection.ControlUIAuthenticationState? = nil) async
+    {
         // The shared endpoint stream owns only the main window's primary route.
         // Profile-targeted documents keep their saved endpoint and credentials.
         guard self.mainTarget == .primary else { return }
@@ -166,7 +187,7 @@ final class DashboardManager {
         let generation = self.endpointGeneration
         guard let controller, controller.isWindowOpen else { return }
         guard case let .ready(mode, url, token, password, routeRevision) = state else {
-            if controller.currentURL != Self.failureURL || controller.auth.hasCredential {
+            if controller.currentURL != Self.failureURL || controller.auth.isReady {
                 self.replaceWithRouteFailure(controller)
             }
             self.displayedRouteRevision = nil
@@ -175,14 +196,19 @@ final class DashboardManager {
         }
         let config: GatewayConnection.Config = (url, token, password)
         let tlsParams = Self.primaryTLSParams(for: config, mode: mode)
-        var authToken = await self.authTokenProvider(config)
+        let resolution = await self.controlUIAccessProvider(config)
         guard self.endpointTransitionIsCurrent(generation, controller: controller) else { return }
-        if authToken == nil, password?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty == nil {
-            await self.routeProbe()
-            guard self.endpointTransitionIsCurrent(generation, controller: controller) else { return }
-            authToken = await self.authTokenProvider(config)
-            guard self.endpointTransitionIsCurrent(generation, controller: controller) else { return }
+        if let authenticationState {
+            guard resolution?.authenticationState == authenticationState else { return }
         }
+        if let resolution {
+            guard self.controlUIAuthenticationState == resolution.authenticationState,
+                  await self.controlUIAccessIsCurrent(resolution),
+                  self.endpointTransitionIsCurrent(generation, controller: controller)
+            else { return }
+        }
+        let access = resolution?.access ?? .unavailable
+        let authToken = Self.controlUIToken(access)
         guard let dashboardURL = try? GatewayEndpointStore.dashboardURL(
             for: config,
             mode: mode,
@@ -190,19 +216,16 @@ final class DashboardManager {
         else {
             return
         }
-        let auth = DashboardWindowAuth(
-            gatewayUrl: Self.websocketURLString(for: dashboardURL),
-            token: authToken,
-            password: password?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty)
+        let auth = Self.windowAuth(for: dashboardURL, access: access)
         let routeChanged = self.displayedRouteRevision.map { $0 != routeRevision }
             ?? (routeRevision > 0) || !controller.hasTLSParams(tlsParams)
-        let credentialChanged = controller.auth.token != auth.token || controller.auth.password != auth.password
+        let credentialChanged = controller.auth != auth
         if routeChanged || credentialChanged {
             if routeChanged {
                 self.displayedRouteAuthority = nil
             }
             self.displayedRouteRevision = routeRevision
-            guard auth.hasCredential else {
+            guard auth.isReady else {
                 self.replaceWithRouteFailure(controller)
                 return
             }
@@ -219,7 +242,7 @@ final class DashboardManager {
             controller.setUpdateBridgeEnabled(Self.updateBridgeEnabled(mode: mode))
             return
         }
-        guard auth.hasCredential, controller.isWindowOpen else { return }
+        guard auth.isReady, controller.isWindowOpen else { return }
         dashboardManagerLogger.info(
             "dashboard endpoint changed; reloading url=\(dashboardLogString(for: dashboardURL), privacy: .public)")
         controller.update(url: dashboardURL, auth: auth, updateBridgeEnabled: Self.updateBridgeEnabled(mode: mode))
@@ -272,9 +295,6 @@ final class DashboardManager {
     }
 
     func presentDashboard() {
-        if self.showConfiguredWindowIfPossible() {
-            return
-        }
         guard self.presentationTask == nil else { return }
         let presentation = self.currentPresentationTask()
         Task { @MainActor [weak self] in
@@ -287,75 +307,19 @@ final class DashboardManager {
         }
     }
 
-    @discardableResult
-    func showConfiguredWindowIfPossible() -> Bool {
-        guard self.mainTarget == .primary else { return false }
-        let mode = AppStateStore.shared.connectionMode
-        guard let endpoint = Self.immediateDashboardEndpoint(mode: mode),
-              let url = try? GatewayEndpointStore.dashboardURL(
-                  for: endpoint.config,
-                  mode: mode,
-                  authToken: endpoint.config.token)
-        else {
-            return false
-        }
-        let config = endpoint.config
-        let auth = DashboardWindowAuth(
-            gatewayUrl: Self.websocketURLString(for: url),
-            token: config.token,
-            password: config.password?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty)
-        guard auth.hasCredential else {
-            return false
-        }
-        self.endpointGeneration &+= 1
-        if let controller, self.requiresIsolatedDashboardDocument(controller, auth: auth, endpoint: endpoint) {
-            self.replaceController(
-                controller,
-                url: url,
-                auth: auth,
-                mode: mode,
-                tlsParams: endpoint.tls?.params,
-                present: true)
-        } else if let controller {
-            controller.show(url: url, auth: auth, updateBridgeEnabled: Self.updateBridgeEnabled(mode: mode))
-        } else {
-            let controller = DashboardWindowController(
-                url: url,
-                auth: auth,
-                updater: self.updater,
-                updateBridgeEnabled: Self.updateBridgeEnabled(mode: mode),
-                tlsParams: endpoint.tls?.params)
-            self.controller = controller
-            controller.show(url: url, auth: auth)
-        }
-        self.rememberPresentedEndpoint(endpoint)
-        self.observeEndpointChanges()
-        Task { await self.refreshGatewaySnapshots() }
-        Task { _ = try? await ControlChannel.shared.health(timeout: 3) }
-        return true
-    }
-
     /// Preload failures stay invisible: navigation errors land in the
     /// controller's `showLoadFailure`, which never orders the window front, and
     /// preload skips `observeEndpointChanges()` so no observer path can call
     /// `showFailure`. The failure page is only seen on a later explicit show.
     func preloadIfConfigured() {
-        guard self.controller == nil,
-              AppStateStore.shared.onboardingSeen,
-              let (mode, url, auth, tlsParams) = self.immediateWindowConfiguration()
-        else { return }
-        let controller = DashboardWindowController(
-            url: url,
-            auth: auth,
-            updater: self.updater,
-            updateBridgeEnabled: Self.updateBridgeEnabled(mode: mode),
-            tlsParams: tlsParams,
-            gatewaySnapshot: self.snapshot(for: .primary))
-        self.controller = controller
-        controller.loadInBackground(url: url, auth: auth)
+        guard self.controller == nil, AppStateStore.shared.onboardingSeen else { return }
+        Task { @MainActor [weak self] in
+            guard let self, self.controller == nil else { return }
+            try? await self.showResolvedPrimaryDashboard(present: false)
+        }
     }
 
-    private func showResolvedPrimaryDashboard() async throws {
+    private func showResolvedPrimaryDashboard(present: Bool = true) async throws {
         let mode = AppStateStore.shared.connectionMode
         self.endpointGeneration &+= 1
         let generation = self.endpointGeneration
@@ -375,16 +339,53 @@ final class DashboardManager {
         }
         let config = endpoint.config
         dashboardManagerLogger.info("dashboard config url=\(config.url.absoluteString, privacy: .public)")
-        let token = await self.authTokenProvider(config)
+        guard let resolution = await self.controlUIAccessProvider(config) else {
+            throw NSError(
+                domain: "Dashboard",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Waiting for a fresh authenticated connection."])
+        }
+        guard self.controlUIAuthenticationState == resolution.authenticationState,
+              await self.controlUIAccessIsCurrent(resolution)
+        else {
+            throw SupersededDashboardPresentation()
+        }
+        let access = resolution.access
         guard self.presentationIsCurrent(generation, controller: originalController) else {
             throw SupersededDashboardPresentation()
         }
-        let url = try GatewayEndpointStore.dashboardURL(for: config, mode: mode, authToken: token)
-        let auth = DashboardWindowAuth(
-            gatewayUrl: Self.websocketURLString(for: url),
-            token: token,
-            password: config.password?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty)
+        let url = try GatewayEndpointStore.dashboardURL(
+            for: config,
+            mode: mode,
+            authToken: Self.controlUIToken(access))
+        let auth = Self.windowAuth(for: url, access: access)
+        guard auth.isReady else {
+            throw NSError(
+                domain: "Dashboard",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Waiting for a fresh authenticated connection."])
+        }
 
+        self.installResolvedDashboard(
+            url: url,
+            auth: auth,
+            endpoint: endpoint,
+            mode: mode,
+            present: present)
+        self.observeEndpointChanges()
+        await self.refreshGatewaySnapshots()
+
+        // Refresh the cached hello payload without blocking window creation.
+        Task { _ = try? await ControlChannel.shared.health(timeout: 3) }
+    }
+
+    private func installResolvedDashboard(
+        url: URL,
+        auth: DashboardWindowAuth,
+        endpoint: GatewayConnection.EndpointSnapshot,
+        mode: AppState.ConnectionMode,
+        present: Bool)
+    {
         if let controller, self.requiresIsolatedDashboardDocument(controller, auth: auth, endpoint: endpoint) {
             self.replaceController(
                 controller,
@@ -392,17 +393,17 @@ final class DashboardManager {
                 auth: auth,
                 mode: mode,
                 tlsParams: endpoint.tls?.params,
-                present: true)
+                present: present)
             self.rememberPresentedEndpoint(endpoint)
-            self.observeEndpointChanges()
-            await self.refreshGatewaySnapshots()
             return
         } else if let controller {
             dashboardManagerLogger.info("dashboard reuse window url=\(dashboardLogString(for: url), privacy: .public)")
-            controller.show(url: url, auth: auth, updateBridgeEnabled: Self.updateBridgeEnabled(mode: mode))
+            if present {
+                controller.show(url: url, auth: auth, updateBridgeEnabled: Self.updateBridgeEnabled(mode: mode))
+            } else {
+                controller.loadInBackground(url: url, auth: auth)
+            }
             self.rememberPresentedEndpoint(endpoint)
-            self.observeEndpointChanges()
-            await self.refreshGatewaySnapshots()
             return
         }
 
@@ -415,13 +416,12 @@ final class DashboardManager {
             tlsParams: endpoint.tls?.params,
             gatewaySnapshot: self.snapshot(for: .primary))
         self.controller = controller
-        controller.show(url: url, auth: auth)
+        if present {
+            controller.show(url: url, auth: auth)
+        } else {
+            controller.loadInBackground(url: url, auth: auth)
+        }
         self.rememberPresentedEndpoint(endpoint)
-        self.observeEndpointChanges()
-        await self.refreshGatewaySnapshots()
-
-        // Refresh the cached hello payload without blocking window creation.
-        Task { _ = try? await ControlChannel.shared.health(timeout: 3) }
     }
 
     func show(atPath path: String, search: String? = nil) async {
@@ -501,16 +501,14 @@ final class DashboardManager {
         guard self.openForCommandTask == nil else { return }
         self.openForCommandTask = Task { @MainActor in
             defer { self.openForCommandTask = nil }
-            if !self.showConfiguredWindowIfPossible() {
-                do {
-                    try await self.show()
-                } catch {
-                    guard !Task.isCancelled else { return }
-                    // Commands are moment-bound; drop them with the failed open.
-                    self.pendingOpenCommands = []
-                    self.showFailure(error)
-                    return
-                }
+            do {
+                try await self.show()
+            } catch {
+                guard !Task.isCancelled else { return }
+                // Commands are moment-bound; drop them with the failed open.
+                self.pendingOpenCommands = []
+                self.showFailure(error)
+                return
             }
             let commands = self.pendingOpenCommands
             self.pendingOpenCommands = []
@@ -679,12 +677,29 @@ final class DashboardManager {
             let mode = AppStateStore.shared.connectionMode
             let endpoint = try await self.primaryEndpoint(mode: mode)
             let config = endpoint.config
-            let token = await self.authTokenProvider(config)
-            let url = try GatewayEndpointStore.dashboardURL(for: config, mode: mode, authToken: token)
-            let auth = DashboardWindowAuth(
-                gatewayUrl: Self.websocketURLString(for: url),
-                token: token,
-                password: config.password?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty)
+            guard let resolution = await self.controlUIAccessProvider(config) else {
+                throw NSError(
+                    domain: "Dashboard",
+                    code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "Waiting for a fresh authenticated connection."])
+            }
+            guard self.controlUIAuthenticationState == resolution.authenticationState,
+                  await self.controlUIAccessIsCurrent(resolution)
+            else {
+                throw SupersededDashboardPresentation()
+            }
+            let access = resolution.access
+            let url = try GatewayEndpointStore.dashboardURL(
+                for: config,
+                mode: mode,
+                authToken: Self.controlUIToken(access))
+            let auth = Self.windowAuth(for: url, access: access)
+            guard auth.isReady else {
+                throw NSError(
+                    domain: "Dashboard",
+                    code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "Waiting for a fresh authenticated connection."])
+            }
             return WindowConfiguration(
                 url: url,
                 auth: auth,
@@ -799,6 +814,32 @@ final class DashboardManager {
         components.queryItems = nil
         components.fragment = nil
         return components.url?.absoluteString ?? dashboardURL.absoluteString
+    }
+
+    private static func controlUIToken(_ access: GatewayConnection.ControlUIAccess) -> String? {
+        guard case let .token(token) = access else { return nil }
+        return token
+    }
+
+    private static func windowAuth(
+        for dashboardURL: URL,
+        access: GatewayConnection.ControlUIAccess) -> DashboardWindowAuth
+    {
+        let gatewayURL = self.websocketURLString(for: dashboardURL)
+        return switch access {
+        case let .token(token):
+            DashboardWindowAuth(gatewayUrl: gatewayURL, token: token, password: nil)
+        case let .password(password):
+            DashboardWindowAuth(gatewayUrl: gatewayURL, token: nil, password: password)
+        case .noneRequired:
+            DashboardWindowAuth(
+                gatewayUrl: gatewayURL,
+                token: nil,
+                password: nil,
+                requirement: .none)
+        case .unavailable:
+            DashboardWindowAuth(gatewayUrl: gatewayURL, token: nil, password: nil)
+        }
     }
 
     private func primaryEndpoint(
@@ -945,24 +986,6 @@ extension DashboardManager {
             configuredFingerprint: mode == .remote
                 ? GatewayRemoteConfig.resolveTLSFingerprint(root: root)
                 : nil)?.params
-    }
-
-    private func immediateWindowConfiguration()
-        -> (AppState.ConnectionMode, URL, DashboardWindowAuth, GatewayTLSParams?)?
-    {
-        let mode = AppStateStore.shared.connectionMode
-        guard let endpoint = Self.immediateDashboardEndpoint(mode: mode),
-              let url = try? GatewayEndpointStore.dashboardURL(
-                  for: endpoint.config,
-                  mode: mode,
-                  authToken: endpoint.config.token)
-        else { return nil }
-        let config = endpoint.config
-        let auth = DashboardWindowAuth(
-            gatewayUrl: Self.websocketURLString(for: url),
-            token: config.token,
-            password: (config.password?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty))
-        return auth.hasCredential ? (mode, url, auth, endpoint.tls?.params) : nil
     }
 
     private func presentationIsCurrent(
@@ -1176,8 +1199,21 @@ extension DashboardManager {
     /// Test instances skip `observeEndpointChanges()` so the shared endpoint
     /// store cannot race test-driven `handleEndpointState` calls.
     static func _testMake(
-        authTokenProvider: @escaping @Sendable (GatewayConnection.Config) async -> String? = { $0.token },
-        routeProbe: @escaping @Sendable () async -> Void = {},
+        controlUIAccessProvider: @escaping @Sendable (GatewayConnection.Config) async
+            -> GatewayConnection.ControlUIAccessResolution? = { config in
+            let state = GatewayConnection.ControlUIAuthenticationState.authenticated(
+                routeGeneration: 1,
+                socketGeneration: 1)
+            if let token = config.token { return .init(authenticationState: state, access: .token(token)) }
+            if let password = config.password { return .init(authenticationState: state, access: .password(password)) }
+            return nil
+        },
+        controlUIAuthenticationStream: @escaping @Sendable () async
+            -> AsyncStream<GatewayConnection.ControlUIAuthenticationState> = {
+            AsyncStream { $0.finish() }
+        },
+        controlUIAccessIsCurrent: @escaping @Sendable (GatewayConnection.ControlUIAccessResolution) async
+            -> Bool = { _ in true },
         endpointStateProvider: @escaping @Sendable () async -> GatewayEndpointState = {
             .unavailable(mode: .unconfigured, reason: "not configured")
         },
@@ -1191,8 +1227,9 @@ extension DashboardManager {
         -> DashboardManager
     {
         let manager = DashboardManager(
-            authTokenProvider: authTokenProvider,
-            routeProbe: routeProbe,
+            controlUIAccessProvider: controlUIAccessProvider,
+            controlUIAuthenticationStream: controlUIAuthenticationStream,
+            controlUIAccessIsCurrent: controlUIAccessIsCurrent,
             endpointStateProvider: endpointStateProvider,
             observeGatewayChanges: observeGatewayChanges,
             automaticGatewayProfileRefreshEnabled: automaticGatewayProfileRefreshEnabled,
@@ -1231,8 +1268,13 @@ extension DashboardManager {
         await self.performSwitchFrontmostDashboard(to: target)
     }
 
-    func _testHandleControlChannelStateChange(_ state: ControlChannel.ConnectionState) async {
-        await self.handleControlChannelStateChange(state)
+    func _testHandleControlUIAuthentication(
+        _ state: GatewayConnection.ControlUIAuthenticationState = .authenticated(
+            routeGeneration: 1,
+            socketGeneration: 1)) async
+    {
+        self.controlUIAuthenticationState = state
+        await self.handleControlUIAuthentication(state)
     }
 
     func _testWindowTLSParams(for target: DashboardGatewayTarget) async throws -> GatewayTLSParams? {

--- a/apps/macos/Sources/OpenClaw/DashboardWindow.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindow.swift
@@ -90,13 +90,39 @@ struct DashboardLinkRequest: Equatable {
 }
 
 struct DashboardWindowAuth: Equatable {
+    enum Requirement: Equatable {
+        case credential
+        case none
+        case unavailable
+    }
+
     var gatewayUrl: String?
     var token: String?
     var password: String?
+    var requirement: Requirement
 
-    var hasCredential: Bool {
-        self.token?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false ||
-            self.password?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+    init(
+        gatewayUrl: String?,
+        token: String?,
+        password: String?,
+        requirement: Requirement? = nil)
+    {
+        self.gatewayUrl = gatewayUrl
+        self.token = token
+        self.password = password
+        self.requirement = requirement ?? ((token != nil || password != nil) ? .credential : .unavailable)
+    }
+
+    var isReady: Bool {
+        switch self.requirement {
+        case .credential:
+            self.token?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false ||
+                self.password?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+        case .none:
+            true
+        case .unavailable:
+            false
+        }
     }
 }
 

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -854,13 +854,14 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         url: URL,
         auth: DashboardWindowAuth)
     {
-        guard auth.hasCredential else { return }
+        guard auth.isReady else { return }
         let allowedOrigin = self.originString(for: url)
         let allowedPath = self.allowedPath(for: url)
         let payload: [String: Any?] = [
             "gatewayUrl": auth.gatewayUrl,
             "token": auth.token,
             "password": auth.password,
+            "clearCredentials": auth.requirement == .none,
         ]
         guard let data = try? JSONSerialization.data(withJSONObject: payload.compactMapValues { $0 }),
               let json = String(data: data, encoding: .utf8)

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -77,6 +77,25 @@ actor GatewayConnection {
         fileprivate let client: GatewayChannelActor
     }
 
+    /// Socket-owned authentication epoch. It changes even when the logical
+    /// ControlChannel state remains connected across a physical reconnect.
+    enum ControlUIAuthenticationState: Equatable, Sendable {
+        case pending
+        case authenticated(routeGeneration: UInt64, socketGeneration: UInt64)
+    }
+
+    enum ControlUIAccess: Equatable, Sendable {
+        case token(String)
+        case password(String)
+        case noneRequired
+        case unavailable
+    }
+
+    struct ControlUIAccessResolution: Equatable, Sendable {
+        let authenticationState: ControlUIAuthenticationState
+        let access: ControlUIAccess
+    }
+
     enum Method: String {
         case agent
         case status
@@ -171,6 +190,10 @@ actor GatewayConnection {
     private var lastRetiredSocketGeneration: UInt64?
 
     private var subscribers: [UUID: AsyncStream<GatewayPush>.Continuation] = [:]
+    private var controlUIAuthenticationState = ControlUIAuthenticationState.pending
+    private var controlUIAuthenticationSubscribers: [
+        UUID: AsyncStream<ControlUIAuthenticationState>.Continuation
+    ] = [:]
     var realtimeTalkSubscribers: [
         UInt64: [UUID: AsyncStream<GatewayPush>.Continuation]
     ] = [:]
@@ -937,6 +960,7 @@ extension GatewayConnection {
         self.finishRealtimeTalkSubscribers()
         self.resetSocketGeneration()
         self.lastSnapshot = nil
+        self.publishControlUIAuthentication(.pending)
         self.resetCanvasPluginSurfaceState()
         let client = self.configuredConnection?.client
         self.configuredConnection = nil
@@ -952,11 +976,22 @@ extension GatewayConnection {
     private func handle(
         push: GatewayPush,
         routeGeneration: UInt64,
-        socketGeneration: UInt64)
+        socketGeneration: UInt64) async
     {
         guard routeGeneration == self.routeGeneration,
               admitSocketGeneration(socketGeneration)
         else { return }
+        if case .snapshot = push,
+           let client = self.configuredConnection?.client,
+           await client.authBinding(ifCurrentConnectionGeneration: socketGeneration) != nil,
+           routeGeneration == self.routeGeneration,
+           self.configuredConnection?.client === client,
+           self.activeSocketGeneration == socketGeneration
+        {
+            self.publishControlUIAuthentication(.authenticated(
+                routeGeneration: routeGeneration,
+                socketGeneration: socketGeneration))
+        }
         broadcast(push)
     }
 
@@ -980,6 +1015,7 @@ extension GatewayConnection {
         else { return }
         self.finishRealtimeTalkSubscribers(socketGeneration: socketGeneration)
         self.lastSnapshot = nil
+        self.publishControlUIAuthentication(.pending)
         self.resetCanvasPluginSurfaceState()
     }
 }
@@ -1031,9 +1067,9 @@ extension GatewayConnection {
     func _test_handlePush(
         _ push: GatewayPush,
         routeGeneration: UInt64? = nil,
-        socketGeneration: UInt64)
+        socketGeneration: UInt64) async
     {
-        self.handle(
+        await self.handle(
             push: push,
             routeGeneration: routeGeneration ?? self.routeGeneration,
             socketGeneration: socketGeneration)
@@ -1105,13 +1141,38 @@ extension GatewayConnection {
 // MARK: - Snapshot cache and subscriptions
 
 extension GatewayConnection {
-    func controlUiAutoAuthToken(config: Config) async -> String? {
+    func resolveControlUIAccess(config: Config) async -> ControlUIAccessResolution? {
+        if let access = await self.controlUIAccess(config: config) {
+            return self.controlUIAccessResolution(access)
+        }
+        _ = try? await self.request(
+            method: Method.health.rawValue,
+            params: nil,
+            timeoutMs: 3000,
+            retryTransportFailures: false)
+        guard let access = await self.controlUIAccess(config: config) else { return nil }
+        return self.controlUIAccessResolution(access)
+    }
+
+    func isCurrentControlUIAccessResolution(_ resolution: ControlUIAccessResolution) -> Bool {
+        resolution.authenticationState == self.controlUIAuthenticationState
+    }
+
+    private func controlUIAccessResolution(_ access: ControlUIAccess) -> ControlUIAccessResolution? {
+        guard case .authenticated = self.controlUIAuthenticationState else { return nil }
+        return ControlUIAccessResolution(
+            authenticationState: self.controlUIAuthenticationState,
+            access: access)
+    }
+
+    private func controlUIAccess(config: Config) async -> ControlUIAccess? {
         guard let endpoint = try? await currentEndpoint(),
               endpoint.config.url == config.url,
               endpoint.config.token == config.token,
               endpoint.config.password == config.password,
               let client = self.configuredConnection?.client,
-              let socketGeneration = activeSocketGeneration,
+              case let .authenticated(routeGeneration, socketGeneration) = self.controlUIAuthenticationState,
+              routeGeneration == self.routeGeneration,
               controlUiRouteIsLive(
                   endpoint: endpoint,
                   client: client,
@@ -1131,25 +1192,61 @@ extension GatewayConnection {
 
         switch authBinding.source {
         case .sharedToken:
-            return config.token?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty
-        case .deviceToken:
-            guard let gatewayID = configuredConnection?.endpoint.deviceAuthGatewayID?
-                .trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty
-            else { return nil }
+            guard let token = config.token?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty else {
+                return .unavailable
+            }
+            return .token(token)
+        case .password:
+            guard let password = config.password?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty else {
+                return .unavailable
+            }
+            return .password(password)
+        case .deviceToken, .bootstrapToken:
             if let deviceToken = lastSnapshot?.auth["deviceToken"]?.value as? String,
                let token = deviceToken.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty
             {
-                return token
+                return .token(token)
             }
-            guard let identity = DeviceIdentityStore.loadOrCreatePersisted() else { return nil }
-            return DeviceAuthStore.loadToken(
+            guard authBinding.source == .deviceToken else { return .unavailable }
+            guard let gatewayID = configuredConnection?.endpoint.deviceAuthGatewayID?
+                .trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty
+            else { return .unavailable }
+            guard let identity = DeviceIdentityStore.loadOrCreatePersisted(),
+                  let token = DeviceAuthStore.loadToken(
                 deviceId: identity.deviceId,
                 role: "operator",
                 gatewayID: gatewayID)?.token
                 .trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty
-        case .bootstrapToken, .password, .none:
-            return nil
+            else { return .unavailable }
+            return .token(token)
+        case .none:
+            return .noneRequired
         }
+    }
+
+    func subscribeControlUIAuthentication() -> AsyncStream<ControlUIAuthenticationState> {
+        let id = UUID()
+        let state = self.controlUIAuthenticationState
+        let connection = self
+        return AsyncStream(bufferingPolicy: .bufferingNewest(1)) { continuation in
+            continuation.yield(state)
+            self.controlUIAuthenticationSubscribers[id] = continuation
+            continuation.onTermination = { @Sendable _ in
+                Task { await connection.removeControlUIAuthenticationSubscriber(id) }
+            }
+        }
+    }
+
+    private func publishControlUIAuthentication(_ state: ControlUIAuthenticationState) {
+        guard state != self.controlUIAuthenticationState else { return }
+        self.controlUIAuthenticationState = state
+        for continuation in self.controlUIAuthenticationSubscribers.values {
+            continuation.yield(state)
+        }
+    }
+
+    private func removeControlUIAuthenticationSubscriber(_ id: UUID) {
+        self.controlUIAuthenticationSubscribers[id] = nil
     }
 
     private func controlUiRouteIsLive(

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardGatewaysTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardGatewaysTests.swift
@@ -267,7 +267,6 @@ struct DashboardManagerGatewayTargetTests {
         try await manager.show()
         #expect(manager._testController() === controller)
         #expect(manager._testMainTarget() == .profile("studio"))
-        #expect(!manager.showConfiguredWindowIfPossible())
     }
 
     @Test func `profile dashboard autosave name is target specific`() {

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardReconnectTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardReconnectTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OpenClawKit
 import Testing
 @testable import OpenClaw
 
@@ -35,9 +36,19 @@ struct DashboardReconnectTests {
             token: nil,
             password: nil,
             routeRevision: 2)
+        let authentication = AsyncStream<GatewayConnection.ControlUIAuthenticationState>.makeStream(
+            bufferingPolicy: .bufferingNewest(1))
         let manager = DashboardManager._testMake(
-            authTokenProvider: { _ in await authGate.authToken() },
-            endpointStateProvider: { endpointState })
+            controlUIAccessProvider: { _ in
+                guard let token = await authGate.authToken() else { return nil }
+                return .init(
+                    authenticationState: .authenticated(routeGeneration: 1, socketGeneration: 2),
+                    access: .token(token))
+            },
+            controlUIAuthenticationStream: { authentication.stream },
+            endpointStateProvider: { endpointState },
+            observeGatewayChanges: true,
+            automaticGatewayProfileRefreshEnabled: false)
         manager._testSetController(controller)
         defer { manager._testController()?.closeDashboard() }
 
@@ -50,15 +61,58 @@ struct DashboardReconnectTests {
         #expect(manager._testController() === failureController)
 
         await authGate.replaceToken("route-b-device-token")
-        await manager._testHandleControlChannelStateChange(.connecting)
-        #expect(manager._testController() === failureController)
-
-        await manager._testHandleControlChannelStateChange(.connected)
+        authentication.continuation.yield(.authenticated(routeGeneration: 1, socketGeneration: 2))
+        try await AsyncTimeout.withTimeout(
+            seconds: 1,
+            onTimeout: { CancellationError() },
+            operation: {
+                while manager._testController() === failureController {
+                    await Task.yield()
+                }
+            })
 
         let recoveredController = try #require(manager._testController())
         #expect(recoveredController !== failureController)
         #expect(!failureController.isWindowOpen)
         #expect(recoveredController.currentURL.absoluteString ==
             "http://127.0.0.1:60002/#token=route-b-device-token")
+    }
+
+    @Test func `authenticated credentialless route recovers dashboard`() async throws {
+        let controller = DashboardWindowController(
+            url: try #require(URL(string: "about:blank")),
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil),
+            windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)")
+        controller.show()
+        let socketURL = try #require(URL(string: "ws://127.0.0.1:60003"))
+        let endpointState = GatewayEndpointState.ready(
+            mode: .remote,
+            url: socketURL,
+            token: nil,
+            password: nil,
+            routeRevision: 3)
+        let manager = DashboardManager._testMake(
+            controlUIAccessProvider: { _ in
+                .init(
+                    authenticationState: .authenticated(routeGeneration: 1, socketGeneration: 1),
+                    access: .noneRequired)
+            },
+            endpointStateProvider: { endpointState })
+        manager._testSetController(controller)
+        defer { manager._testController()?.closeDashboard() }
+
+        await manager._testHandleControlUIAuthentication()
+
+        let recovered = try #require(manager._testController())
+        #expect(recovered !== controller)
+        #expect(recovered.currentURL.absoluteString == "http://127.0.0.1:60003/")
+        #expect(recovered.auth.isReady)
+        let authScripts = recovered._testUserScripts
+            .filter { $0.source.contains("__OPENCLAW_NATIVE_CONTROL_AUTH__") }
+        #expect(authScripts.count == 1)
+        #expect(authScripts[0].source.contains("gatewayUrl"))
+        #expect(authScripts[0].source.contains("clearCredentials"))
+        #expect(!authScripts[0].source.contains("\"token\""))
+        #expect(!authScripts[0].source.contains("\"password\""))
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowOwnershipTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowOwnershipTests.swift
@@ -123,7 +123,12 @@ struct DashboardWindowOwnershipTests {
             password: nil,
             routeRevision: 2)
         let manager = DashboardManager._testMake(
-            authTokenProvider: { _ in await gate.authToken() },
+            controlUIAccessProvider: { _ in
+                guard let token = await gate.authToken() else { return nil }
+                return .init(
+                    authenticationState: .authenticated(routeGeneration: 1, socketGeneration: 1),
+                    access: .token(token))
+            },
             endpointStateProvider: { readyState })
         manager._testSetController(controller)
         defer { manager.close() }
@@ -141,7 +146,7 @@ struct DashboardWindowOwnershipTests {
         #expect(failureController.window === originalWindow)
 
         await gate.update("after")
-        await manager._testHandleControlChannelStateChange(.connected)
+        await manager._testHandleControlUIAuthentication()
         let recoveredController = try #require(manager._testController())
         #expect(recoveredController !== failureController)
         #expect(recoveredController.window === originalWindow)
@@ -153,7 +158,7 @@ struct DashboardWindowOwnershipTests {
         #expect(authScripts[0].source.contains("after"))
         #expect(!authScripts[0].source.contains("before"))
 
-        await manager._testHandleControlChannelStateChange(.connected)
+        await manager._testHandleControlUIAuthentication()
         #expect(manager._testController() === recoveredController)
         #expect(recoveredController.window === originalWindow)
     }
@@ -171,7 +176,12 @@ struct DashboardWindowOwnershipTests {
         let originalWindow = try #require(controller.window)
         let gate = DashboardWindowOwnershipEndpointGate()
         let manager = DashboardManager._testMake(
-            authTokenProvider: { config in await gate.authToken(for: config) })
+            controlUIAccessProvider: { config in
+                guard let token = await gate.authToken(for: config) else { return nil }
+                return .init(
+                    authenticationState: .authenticated(routeGeneration: 1, socketGeneration: 1),
+                    access: .token(token))
+            })
         manager._testSetController(controller)
         defer { manager.close() }
 

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -1045,8 +1045,13 @@ struct DashboardWindowSmokeTests {
         controller.show()
         let authGate = DashboardRouteAuthGate(token: "route-a-device-token")
         let manager = DashboardManager._testMake(
-            authTokenProvider: { _ in await authGate.authToken() },
-            routeProbe: { await authGate.probe() })
+            controlUIAccessProvider: { _ in
+                await authGate.probe()
+                guard let token = await authGate.authToken() else { return nil }
+                return .init(
+                    authenticationState: .authenticated(routeGeneration: 1, socketGeneration: 1),
+                    access: .token(token))
+            })
         manager._testSetController(controller)
         defer { manager._testController()?.closeDashboard() }
         let socketURL = try #require(URL(string: "ws://127.0.0.1:60001"))
@@ -1091,8 +1096,7 @@ struct DashboardWindowSmokeTests {
                 password: nil))
         controller.show()
         let manager = DashboardManager._testMake(
-            authTokenProvider: { _ in nil },
-            routeProbe: {})
+            controlUIAccessProvider: { _ in nil })
         manager._testSetController(controller)
         defer { manager._testController()?.closeDashboard() }
 

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlUIAuthTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlUIAuthTests.swift
@@ -3,10 +3,41 @@ import Testing
 @testable import OpenClaw
 @testable import OpenClawKit
 
+private final class ControlUIAuthAttemptCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    func next() -> Int {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        let current = self.value
+        self.value += 1
+        return current
+    }
+}
+
+private actor ControlUIAuthenticationIterator {
+    private var iterator: AsyncStream<GatewayConnection.ControlUIAuthenticationState>.Iterator
+
+    init(_ stream: AsyncStream<GatewayConnection.ControlUIAuthenticationState>) {
+        self.iterator = stream.makeAsyncIterator()
+    }
+
+    func next() async -> GatewayConnection.ControlUIAuthenticationState? {
+        var iterator = self.iterator
+        let state = await iterator.next()
+        self.iterator = iterator
+        return state
+    }
+}
+
 private func makeControlUIAuthSession(
-    issuedDeviceToken: String? = nil) -> GatewayTestWebSocketSession
+    issuedDeviceToken: String? = nil,
+    issuedDeviceTokens: [String] = []) -> GatewayTestWebSocketSession
 {
+    let attempts = ControlUIAuthAttemptCounter()
     GatewayTestWebSocketSession(taskFactory: {
+        let attempt = attempts.next()
         GatewayTestWebSocketTask(
             sendHook: { task, message, sendIndex in
                 guard sendIndex > 0,
@@ -21,7 +52,9 @@ private func makeControlUIAuthSession(
                 let id = task.snapshotConnectRequestID() ?? "connect"
                 return .data(GatewayWebSocketTestSupport.connectOkData(
                     id: id,
-                    deviceToken: issuedDeviceToken))
+                    deviceToken: issuedDeviceTokens.indices.contains(attempt)
+                        ? issuedDeviceTokens[attempt]
+                        : issuedDeviceToken))
             })
     })
 }
@@ -45,12 +78,7 @@ struct GatewayConnectionControlUIAuthTests {
             testEndpointProvider: { source.snapshot() },
             sessionBox: WebSocketSessionBox(session: makeControlUIAuthSession()))
 
-        #expect(await connection.controlUiAutoAuthToken(config: routeA) == nil)
-        _ = try await connection.request(
-            method: "health",
-            params: nil,
-            retryTransportFailures: false)
-        #expect(await connection.controlUiAutoAuthToken(config: routeA) == "shared-token")
+        #expect(await connection.resolveControlUIAccess(config: routeA)?.access == .token("shared-token"))
 
         let routeB = try controlUIRoute("ws://route-b.invalid", token: routeA.token)
         source.setEndpoint(.init(
@@ -59,9 +87,10 @@ struct GatewayConnectionControlUIAuthTests {
             deviceAuthGatewayID: "route-b"))
 
         // The old socket is still physically alive, but neither the old nor
-        // the newly selected route may borrow its credential.
-        #expect(await connection.controlUiAutoAuthToken(config: routeA) == nil)
-        #expect(await connection.controlUiAutoAuthToken(config: routeB) == nil)
+        // the newly selected route may borrow its credential. The resolver may
+        // establish fresh authority for the newly selected route.
+        #expect(await connection.resolveControlUIAccess(config: routeA) == nil)
+        #expect(await connection.resolveControlUIAccess(config: routeB)?.access == .token("shared-token"))
         await connection.shutdown()
     }
 
@@ -98,8 +127,8 @@ struct GatewayConnectionControlUIAuthTests {
                 params: nil,
                 retryTransportFailures: false)
             #expect(
-                await routeAConnection.controlUiAutoAuthToken(config: routeA) ==
-                    "route-a-device-token")
+                await routeAConnection.resolveControlUIAccess(config: routeA)?.access ==
+                    .token("route-a-device-token"))
             await routeAConnection.shutdown()
 
             let routeB = try controlUIRoute("ws://route-b.invalid")
@@ -116,7 +145,7 @@ struct GatewayConnectionControlUIAuthTests {
                 method: "health",
                 params: nil,
                 retryTransportFailures: false)
-            #expect(await routeBConnection.controlUiAutoAuthToken(config: routeB) == nil)
+            #expect(await routeBConnection.resolveControlUIAccess(config: routeB)?.access == .noneRequired)
             await routeBConnection.shutdown()
         }
     }
@@ -150,22 +179,80 @@ struct GatewayConnectionControlUIAuthTests {
                 params: nil,
                 retryTransportFailures: false)
             #expect(
-                await connection.controlUiAutoAuthToken(config: routeA) ==
-                    "route-a-issued-token")
+                await connection.resolveControlUIAccess(config: routeA)?.access ==
+                    .token("route-a-issued-token"))
 
             source.setEndpoint(.init(
                 config: routeA,
                 routeAuthority: 1,
                 deviceAuthGatewayID: "route-b"))
-            #expect(await connection.controlUiAutoAuthToken(config: routeA) == nil)
+            #expect(await connection.resolveControlUIAccess(config: routeA)?.access == .noneRequired)
 
             let routeB = try controlUIRoute("ws://route-b.invalid")
             source.setEndpoint(.init(
                 config: routeB,
                 routeAuthority: 2,
                 deviceAuthGatewayID: "route-b"))
-            #expect(await connection.controlUiAutoAuthToken(config: routeA) == nil)
-            #expect(await connection.controlUiAutoAuthToken(config: routeB) == nil)
+            #expect(await connection.resolveControlUIAccess(config: routeA) == nil)
+            #expect(await connection.resolveControlUIAccess(config: routeB)?.access == .noneRequired)
+            await connection.shutdown()
+        }
+    }
+
+    @Test func `control UI authentication follows every physical socket generation`() async throws {
+        let route = try controlUIRoute("ws://route-a.invalid")
+        let session = makeControlUIAuthSession(issuedDeviceTokens: ["device-a", "device-b"])
+        let stateDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: stateDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: stateDir) }
+
+        try await DeviceIdentityStore.withStateDirectory(stateDir) {
+            let identity = DeviceIdentityStore.loadOrCreate()
+            _ = DeviceAuthStore.storeToken(
+                deviceId: identity.deviceId,
+                role: "operator",
+                token: "device-seed",
+                gatewayID: "route-a")
+            let connection = GatewayConnection(
+                endpointProvider: {
+                    .init(config: route, routeAuthority: 1, deviceAuthGatewayID: "route-a")
+                },
+                activationBindingKeyProvider: { nil },
+                sessionBox: WebSocketSessionBox(session: session))
+            let stream = await connection.subscribeControlUIAuthentication()
+            let iterator = ControlUIAuthenticationIterator(stream)
+
+            #expect(await iterator.next() == .pending)
+            _ = try await connection.request(
+                method: "health",
+                params: nil,
+                retryTransportFailures: false)
+            #expect(await iterator.next() == .authenticated(routeGeneration: 1, socketGeneration: 1))
+            #expect(await connection.resolveControlUIAccess(config: route)?.access == .token("device-a"))
+
+            let firstSocket = try #require(session.latestTask())
+            try await AsyncTimeout.withTimeout(
+                seconds: 1,
+                onTimeout: { CancellationError() },
+                operation: {
+                    while !firstSocket.hasPendingReceiveHandler() {
+                        await Task.yield()
+                    }
+                })
+            firstSocket.emitReceiveFailure()
+
+            let reconnectStates = try await AsyncTimeout.withTimeout(
+                seconds: 2,
+                onTimeout: { CancellationError() },
+                operation: {
+                    [await iterator.next(), await iterator.next()]
+                })
+            #expect(reconnectStates == [
+                .pending,
+                .authenticated(routeGeneration: 1, socketGeneration: 2),
+            ])
+            #expect(await connection.resolveControlUIAccess(config: route)?.access == .token("device-b"))
             await connection.shutdown()
         }
     }

--- a/test/scripts/package-mac-app.test.ts
+++ b/test/scripts/package-mac-app.test.ts
@@ -1226,7 +1226,7 @@ describe("package-mac-app plist stamping", () => {
     const result = runHelper(`
       set -euo pipefail
       ROOT_DIR=${JSON.stringify(tempRoot)}
-      PATH=${JSON.stringify(`${toolsDir}:/usr/bin:/bin`)}
+      PATH=${JSON.stringify(toolsDir)}
       export COREPACK_HOME=${JSON.stringify(corepackHome)}
       export COREPACK_ENABLE_NETWORK=0
       ${helperBlock}

--- a/ui/src/app/settings.node.test.ts
+++ b/ui/src/app/settings.node.test.ts
@@ -22,6 +22,7 @@ import { resolveApplicationStartupSettings } from "./startup-settings.ts";
 describe("resolveApplicationStartupSettings", () => {
   beforeEach(() => {
     vi.stubGlobal("window", {});
+    vi.stubGlobal("sessionStorage", createStorageMock());
   });
 
   afterEach(() => {
@@ -55,6 +56,25 @@ describe("resolveApplicationStartupSettings", () => {
     expect(startup.pendingBootstrapToken).toBe("boot-456");
     expect(startup.pendingBootstrapProfile).toBeNull();
     expect(startup.location).toEqual({ pathname: "/dash", search: "", hash: "" });
+  });
+
+  it("clears persisted credentials for a native credentialless handoff", () => {
+    const gatewayUrl = "ws://127.0.0.1:18789";
+    setTestLocation({ protocol: "http:", host: "127.0.0.1:18789", pathname: "/" });
+    persistSessionToken(gatewayUrl, "stale-token");
+    window["__OPENCLAW_NATIVE_CONTROL_AUTH__"] = {
+      gatewayUrl,
+      clearCredentials: true,
+    };
+
+    const startup = resolveApplicationStartupSettings(
+      makeUiSettings(gatewayUrl, { token: "stale-token" }),
+      { pathname: "/", search: "", hash: "" },
+    );
+
+    expect(startup.settings.token).toBe("");
+    expect(startup.password).toBeNull();
+    expect(loadSettings().token).toBe("");
   });
 });
 

--- a/ui/src/app/startup-settings.ts
+++ b/ui/src/app/startup-settings.ts
@@ -7,7 +7,7 @@ import {
   type ControlUiBootstrapProfileHint,
 } from "../../../src/gateway/control-ui-bootstrap-contract.js";
 import { inferBasePathFromPathname, sessionRouteNamespaceFromPath } from "../app-route-paths.ts";
-import type { UiSettings } from "./settings.ts";
+import { persistSessionToken, type UiSettings } from "./settings.ts";
 
 type ApplicationStartupLocation = {
   pathname: string;
@@ -19,6 +19,7 @@ type NativeControlAuth = {
   gatewayUrl?: string | null;
   token?: string | null;
   password?: string | null;
+  clearCredentials?: boolean;
 };
 
 type ApplicationStartupSettings = {
@@ -96,9 +97,12 @@ export function resolveApplicationStartupSettings(
     const gatewayUrl = normalizeOptionalString(nativeAuth.gatewayUrl);
     const token = normalizeOptionalString(nativeAuth.token);
     const nativePassword = normalizeOptionalString(nativeAuth.password);
+    if (nativeAuth.clearCredentials && gatewayUrl) {
+      persistSessionToken(gatewayUrl, "");
+    }
     updateSettings({
       ...(gatewayUrl ? { gatewayUrl } : {}),
-      ...(token ? { token } : {}),
+      ...(token ? { token } : nativeAuth.clearCredentials ? { token: "" } : {}),
     });
     if (nativePassword) {
       password = nativePassword;


### PR DESCRIPTION
Closes #131937

## What Problem This Solves

Fixes an issue where the macOS dashboard could remain on “Dashboard reconnecting” after the same Gateway route had authenticated a replacement socket. It also fixes valid credentialless Gateway routes being rejected as if authentication were still missing.

## Why This Change Was Made

`GatewayConnection` now publishes the authenticated physical-socket generation and resolves a closed Control UI access result under the existing route, client, socket, and auth-binding fences. `DashboardManager` reacts to that owner-issued lifecycle instead of deduplicated `ControlChannel` state or a dashboard-owned retry loop; credentialless handoffs explicitly clear stale native UI credentials.

No config/env option, SQLite schema, or Gateway protocol surface is added.

## User Impact

The macOS dashboard recovers after authenticated reconnects on the same route, including device-token rotation, without polling or a second backoff loop. Explicit `gateway.auth.mode: "none"` routes can load while stale tab credentials are removed, and route changes still fail closed until the current socket proves its authority.

## Evidence

- Before: the source-level reproduction reaches `lost reconnect signal: healthy replacement socket leaves dashboard stuck` and `auth none: gateway accepts the client, but credential guard cannot recover`.
- After: `GatewayConnectionControlUIAuthTests` covers `pending -> authenticated generation 1 -> pending -> authenticated generation 2`, with issued device tokens changing from `device-a` to `device-b`; `DashboardReconnectTests` covers recovery from the failure document and credentialless auth injection.
- Exact owner refs: `apps/macos/Sources/OpenClaw/GatewayConnection.swift` (`ControlUIAuthenticationState`, `resolveControlUIAccess`, `subscribeControlUIAuthentication`), `apps/macos/Sources/OpenClaw/DashboardManager.swift` (generation-fenced reconciliation), and `ui/src/app/startup-settings.ts` (credentialless stale-token clearing).
- Provenance: `96f0983a85b5a7798d35e97d8f530fed9b567929`, `fc3f114a93189209ff9b0ee4c68df3c365a5589a`, and `de67565cda6be67d31fa31f2de2aff879d9eae06`.
- An independent adversarial review attempted to refute the analysis, confirmed the defect, and reviewed the final implementation with no remaining blockers.
- Passed: `node scripts/run-vitest.mjs src/gateway/auth.test.ts src/gateway/server/ws-connection/connect-policy.test.ts` (117/117), `node scripts/run-vitest.mjs ui/src/app/settings.node.test.ts` (17/17), `pnpm tsgo:ui`, and `node scripts/check-changed.mjs`.
- Native `swift test` and before/after screenshots were not feasible on this Linux host because Swift, AppKit, and WKWebView are unavailable; macOS CI owns the native execution proof.
