### PR TITLE
fix(sandbox): preserve active runtimes during age pruning

### DIFF
--- a/docs/cli/sandbox.md
+++ b/docs/cli/sandbox.md
@@ -67,7 +67,11 @@ An explicit `--agent` is sufficient for multi-agent fleets with no implicit owne
 
 ## Why recreate is needed
 
-Updating sandbox config does not affect running containers: existing runtimes keep their old settings, and idle runtimes are only pruned after `prune.idleHours` (default 24h). Regularly used agents can keep stale runtimes alive indefinitely. `openclaw sandbox recreate` removes the old runtime so the next use rebuilds it from current config.
+Automatic pruning selects runtimes that exceed `prune.idleHours` (default 24h) or `prune.maxAgeDays` (default 7 days). It preserves runtimes while admitted commands, filesystem operations, or browser requests are active and checks again on a later pruning pass.
+
+Automatic configuration recycling also preserves active runtimes. Restricted dispatch still requires the current container configuration and refuses a retained runtime whose configuration differs. `openclaw sandbox recreate` explicitly removes the old runtime so the next use rebuilds it from current config; finish active work before using it.
+
+SSH and OpenShell cleanup uses the destination recorded when the runtime was created. Older registry entries without that destination, and OpenShell entries without an explicit gateway, require operator verification and manual backend cleanup. Changing current settings does not establish the old runtime's location. Verify the original target and back up any remote workspace data before removing it. Failed cleanup retains the registry entry for retry.
 
 <Tip>
 Prefer `openclaw sandbox recreate` over manual backend-specific cleanup. It uses the Gateway's runtime registry and avoids mismatches when scope or session keys change.

--- a/extensions/browser/src/browser/bridge-server.auth.test.ts
+++ b/extensions/browser/src/browser/bridge-server.auth.test.ts
@@ -1,5 +1,5 @@
 // Browser tests cover bridge server.auth plugin behavior.
-import { createServer } from "node:http";
+import { createServer, request } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { getBridgeAuthForPort } from "./bridge-auth-registry.js";
 import { startBrowserBridgeServer, stopBrowserBridgeServer } from "./bridge-server.js";
@@ -86,6 +86,82 @@ describe("startBrowserBridgeServer auth", () => {
       { authPassword: "secret-password" },
       { "x-openclaw-password": "secret-password" },
     );
+  });
+
+  it("releases admitted requests and rejects new work during runtime recycling", async () => {
+    const release = vi.fn(async () => {});
+    const acquireRequestActivity = vi
+      .fn<() => Promise<{ release(): Promise<void> } | null>>()
+      .mockResolvedValueOnce({ release })
+      .mockResolvedValueOnce(null);
+    const bridge = await startBrowserBridgeServer({
+      resolved: buildResolvedConfig(),
+      authToken: "secret-token",
+      acquireRequestActivity,
+    });
+    servers.push({ stop: () => stopBrowserBridgeServer(bridge.server) });
+
+    const headers = { Authorization: "Bearer secret-token" };
+    expect((await fetch(`${bridge.baseUrl}/?profile=missing`, { headers })).status).toBe(404);
+    expect(release).toHaveBeenCalledOnce();
+    expect((await fetch(`${bridge.baseUrl}/?profile=missing`, { headers })).status).toBe(503);
+    expect(acquireRequestActivity).toHaveBeenCalledTimes(2);
+  });
+
+  it("releases activity acquired after the client disconnects", async () => {
+    const admission = deferred();
+    const release = vi.fn(async () => {});
+    const acquireRequestActivity = vi.fn(async () => {
+      await admission.promise;
+      return { release };
+    });
+    const bridge = await startBrowserBridgeServer({
+      resolved: buildResolvedConfig(),
+      authToken: "secret-token",
+      acquireRequestActivity,
+    });
+    servers.push({ stop: () => stopBrowserBridgeServer(bridge.server) });
+
+    const pending = request(`${bridge.baseUrl}/?profile=missing`, {
+      headers: { Authorization: "Bearer secret-token" },
+    });
+    pending.on("error", () => {});
+    pending.end();
+    await vi.waitFor(() => expect(acquireRequestActivity).toHaveBeenCalledOnce());
+    pending.destroy();
+    admission.resolve();
+
+    await vi.waitFor(() => expect(release).toHaveBeenCalledOnce());
+  });
+
+  it("holds activity until a disconnected route settles", async () => {
+    const attachStarted = deferred();
+    const releaseAttach = deferred();
+    const release = vi.fn(async () => {});
+    const bridge = await startBrowserBridgeServer({
+      resolved: buildResolvedConfig(),
+      authToken: "secret-token",
+      acquireRequestActivity: async () => ({ release }),
+      onEnsureAttachTarget: async () => {
+        attachStarted.resolve();
+        await releaseAttach.promise;
+      },
+    });
+    servers.push({ stop: () => stopBrowserBridgeServer(bridge.server) });
+
+    const abort = new AbortController();
+    const pending = fetch(`${bridge.baseUrl}/start`, {
+      method: "POST",
+      headers: { Authorization: "Bearer secret-token" },
+      signal: abort.signal,
+    });
+    await attachStarted.promise;
+    abort.abort();
+    await expect(pending).rejects.toThrow();
+    expect(release).not.toHaveBeenCalled();
+
+    releaseAttach.resolve();
+    await vi.waitFor(() => expect(release).toHaveBeenCalledOnce());
   });
 
   it("requires auth params", async () => {

--- a/extensions/browser/src/browser/bridge-server.ts
+++ b/extensions/browser/src/browser/bridge-server.ts
@@ -6,12 +6,13 @@
  */
 import type { Server } from "node:http";
 import type { AddressInfo } from "node:net";
-import express from "express";
+import express, { type NextFunction, type Request, type Response } from "express";
 import { isLoopbackHost } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { deleteBridgeAuthForPort, setBridgeAuthForPort } from "./bridge-auth-registry.js";
 import type { ResolvedBrowserConfig } from "./config.js";
 import { listenBrowserHttpServer } from "./http-listen.js";
+import type { BrowserRequest, BrowserRouteHandler, BrowserRouteRegistrar } from "./routes/types.js";
 import { stopBrowserBridgeRuntime } from "./runtime-lifecycle.js";
 import type { BrowserServerState, ProfileContext } from "./server-context.js";
 import {
@@ -87,6 +88,7 @@ export async function startBrowserBridgeServer(params: {
   port?: number;
   authToken?: string;
   authPassword?: string;
+  acquireRequestActivity?: () => Promise<{ release(): Promise<void> } | null>;
   onEnsureAttachTarget?: (profile: ProfileContext["profile"]) => Promise<void>;
   resolveSandboxNoVncToken?: (token: string) => ResolvedNoVncObserver | null;
 }): Promise<BrowserBridge> {
@@ -106,28 +108,67 @@ export async function startBrowserBridgeServer(params: {
   }
   installBrowserAuthMiddleware(app, { token: authToken, password: authPassword });
 
+  const wrapRequest = (
+    run: (req: Request, res: Response, signal: AbortSignal) => void | Promise<void>,
+  ) => {
+    return (req: Request, res: Response, next: NextFunction) => {
+      const abort = new AbortController();
+      const abortRequest = () => abort.abort(new Error("Browser bridge request disconnected."));
+      const abortIncompleteResponse = () => {
+        if (!res.writableFinished) {
+          abortRequest();
+        }
+      };
+      req.once("aborted", abortRequest);
+      res.once("close", abortIncompleteResponse);
+      void (async () => {
+        let activity: { release(): Promise<void> } | null = null;
+        try {
+          activity = (await params.acquireRequestActivity?.()) ?? null;
+          if (params.acquireRequestActivity && !activity) {
+            if (!abort.signal.aborted && !res.destroyed) {
+              res.status(503).send("Sandbox browser is being recycled; retry the request.");
+            }
+            return;
+          }
+          if (abort.signal.aborted || req.aborted || res.destroyed) {
+            return;
+          }
+          await run(req, res, abort.signal);
+        } finally {
+          req.off("aborted", abortRequest);
+          res.off("close", abortIncompleteResponse);
+          await activity?.release();
+        }
+      })().catch(next);
+    };
+  };
+
   if (params.resolveSandboxNoVncToken) {
-    app.get("/sandbox/novnc", (req, res) => {
-      if (!hasVerifiedBrowserAuth(req)) {
-        res.status(401).send("Unauthorized");
-        return;
-      }
-      res.setHeader("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
-      res.setHeader("Pragma", "no-cache");
-      res.setHeader("Expires", "0");
-      res.setHeader("Referrer-Policy", "no-referrer");
-      const rawToken = normalizeOptionalString(req.query?.token);
-      if (!rawToken) {
-        res.status(400).send("Missing token");
-        return;
-      }
-      const resolved = params.resolveSandboxNoVncToken?.(rawToken);
-      if (!resolved) {
-        res.status(404).send("Invalid or expired token");
-        return;
-      }
-      res.type("html").status(200).send(buildNoVncBootstrapHtml(resolved));
-    });
+    app.get(
+      "/sandbox/novnc",
+      wrapRequest((req, res) => {
+        if (!hasVerifiedBrowserAuth(req)) {
+          res.status(401).send("Unauthorized");
+          return;
+        }
+        res.setHeader("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
+        res.setHeader("Pragma", "no-cache");
+        res.setHeader("Expires", "0");
+        res.setHeader("Referrer-Policy", "no-referrer");
+        const rawToken = normalizeOptionalString(req.query?.token);
+        if (!rawToken) {
+          res.status(400).send("Missing token");
+          return;
+        }
+        const resolved = params.resolveSandboxNoVncToken?.(rawToken);
+        if (!resolved) {
+          res.status(404).send("Invalid or expired token");
+          return;
+        }
+        res.type("html").status(200).send(buildNoVncBootstrapHtml(resolved));
+      }),
+    );
   }
 
   const state: BrowserServerState = {
@@ -145,7 +186,22 @@ export async function startBrowserBridgeServer(params: {
     getState: () => state,
     onEnsureAttachTarget: params.onEnsureAttachTarget,
   });
-  registerBrowserRoutes(app, ctx);
+  const wrapBrowserRoute = (handler: BrowserRouteHandler) =>
+    wrapRequest(async (req, res, signal) => {
+      const browserRequest: BrowserRequest = {
+        params: req.params,
+        query: req.query,
+        body: req.body,
+        signal,
+      };
+      await handler(browserRequest, res);
+    });
+  const routeRegistrar: BrowserRouteRegistrar = {
+    get: (path, handler) => app.get(path, wrapBrowserRoute(handler)),
+    post: (path, handler) => app.post(path, wrapBrowserRoute(handler)),
+    delete: (path, handler) => app.delete(path, wrapBrowserRoute(handler)),
+  };
+  registerBrowserRoutes(routeRegistrar, ctx);
 
   const server = await listenBrowserHttpServer(app, port, host);
 

--- a/extensions/browser/src/browser/routes/types.ts
+++ b/extensions/browser/src/browser/routes/types.ts
@@ -6,7 +6,7 @@
  */
 /** Request shape consumed by browser route handlers. */
 export type BrowserRequest = {
-  params: Record<string, string>;
+  params: Record<string, string | string[]>;
   query: Record<string, unknown>;
   body?: unknown;
   /**
@@ -25,7 +25,10 @@ export type BrowserResponse = {
 };
 
 /** Async route handler signature shared by HTTP and in-process dispatch. */
-type BrowserRouteHandler = (req: BrowserRequest, res: BrowserResponse) => void | Promise<void>;
+export type BrowserRouteHandler = (
+  req: BrowserRequest,
+  res: BrowserResponse,
+) => void | Promise<void>;
 
 /** Minimal registrar interface implemented by HTTP and test dispatchers. */
 export type BrowserRouteRegistrar = {

--- a/extensions/codex/src/app-server/sandbox-exec-server/http.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/http.ts
@@ -50,10 +50,11 @@ export async function httpRequest(
   if (request.streamResponse) {
     return await runStreamingSandboxHttpRequest(execServer, notifications, requestId, request);
   }
-  const result = await runSandboxHttpRequest(execServer, {
-    ...request,
-    streamResponse: false,
-  });
+  const result = await runSandboxHttpRequest(
+    execServer,
+    { ...request, streamResponse: false },
+    notifications.signal,
+  );
   return result;
 }
 
@@ -89,11 +90,13 @@ function assertSandboxHttpRequestTargetAllowed(url: string): void {
 async function runSandboxHttpRequest(
   execServer: OpenClawExecServer,
   params: SandboxHttpRequest,
+  signal: AbortSignal,
 ): Promise<JsonObject & { status: number; headers: HttpHeader[]; bodyBase64: string }> {
   const result = await execServer.backend.runShellCommand({
     script: SANDBOX_HTTP_REQUEST_SCRIPT,
     stdin: JSON.stringify(params),
     allowFailure: true,
+    signal,
   });
   if (result.code !== 0) {
     const stderr = result.stderr.toString("utf8").trim();
@@ -127,6 +130,7 @@ async function runStreamingSandboxHttpRequest(
     workdir: execServer.sandbox.containerWorkdir,
     env: remoteExec.env,
     usePty: false,
+    signal: notifications.signal,
   });
   const lifecycle = { failed: false };
   const owner = await spawnSandboxChild({

--- a/extensions/codex/src/app-server/sandbox-exec-server/processes.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/processes.ts
@@ -47,6 +47,7 @@ export async function startProcess(
     tty,
     pipeStdin,
     terminationRequested: false,
+    abortController: new AbortController(),
     child: null,
     waiters: [],
     emitNotification: notify,
@@ -130,6 +131,7 @@ async function runProcess(
     // backend for a PTY can produce commands such as `docker exec -t`, which
     // require this process itself to own a real TTY.
     usePty: false,
+    signal: managed.abortController.signal,
   });
   if (managed.terminationRequested) {
     await backend.finalizeExec?.({
@@ -330,6 +332,7 @@ export async function terminateProcess(
   }
   const running = !managed.exited;
   managed.terminationRequested = true;
+  managed.abortController.abort();
   await managed.startPromise?.catch(() => undefined);
   if (managed.child) {
     await managed.child.terminate();

--- a/extensions/codex/src/app-server/sandbox-exec-server/types.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/types.ts
@@ -84,6 +84,7 @@ export type ManagedProcess = {
   tty: boolean;
   pipeStdin: boolean;
   terminationRequested: boolean;
+  abortController: AbortController;
   child: SandboxChildOwner | null;
   startPromise?: Promise<void>;
   evictionTimer?: ReturnType<typeof setTimeout>;

--- a/extensions/openshell/src/backend.ts
+++ b/extensions/openshell/src/backend.ts
@@ -273,9 +273,30 @@ export function createOpenShellSandboxBackendManager(params: {
         configLabelMatch: entry.image === configuredSource,
       };
     },
-    async removeRuntime({ entry, config }) {
+    async removeRuntime({ entry }) {
+      const metadata = entry.cleanupMetadata;
+      const command = metadata?.command?.trim();
+      const gateway = metadata?.gateway?.trim();
+      const gatewayEndpoint = metadata?.gatewayEndpoint?.trim();
+      const workspace = metadata?.workspace?.trim();
+      if (
+        metadata?.locatorVersion !== "1" ||
+        !command ||
+        (!gateway && !gatewayEndpoint) ||
+        !workspace
+      ) {
+        throw new Error(
+          `OpenShell sandbox runtime ${entry.containerName} has no authoritative cleanup locator; remove it manually after selecting its original gateway and workspace.`,
+        );
+      }
+      const recordedConfig = resolveOpenShellPluginConfig({
+        command,
+        ...(gateway ? { gateway } : {}),
+        ...(gatewayEndpoint ? { gatewayEndpoint } : {}),
+        workspace,
+      });
       const execContext: OpenShellExecContext = {
-        config: resolveOpenShellPluginConfigFromConfig(config, params.pluginConfig),
+        config: recordedConfig,
         sandboxName: entry.containerName,
       };
       const result = await runOpenShellCli({
@@ -349,6 +370,15 @@ class OpenShellSandboxBackendImpl {
       mode: this.params.execContext.config.mode,
       configLabel: this.params.execContext.config.from,
       configLabelKind: "Source",
+      cleanupMetadata: {
+        locatorVersion: "1",
+        command: this.params.execContext.config.command,
+        gateway: this.params.execContext.config.gateway ?? "",
+        gatewayEndpoint: this.params.execContext.config.gatewayEndpoint ?? "",
+        workspace:
+          this.params.execContext.config.workspace ??
+          (process.env.OPENSHELL_WORKSPACE?.trim() || "default"),
+      },
       workdirValidation: "backend",
       validateWorkdir: async (workdir) => await this.validateWorkdir(workdir),
       workdirRoots: [this.params.remoteWorkspaceDir, this.params.remoteAgentWorkspaceDir],

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -137,6 +137,18 @@ function resetOpenShellBackendMocks() {
   );
 }
 
+function createOpenShellCleanupMetadata(
+  config = resolveOpenShellPluginConfig({ command: "/usr/local/bin/openshell", gateway: "lab" }),
+) {
+  return {
+    locatorVersion: "1",
+    command: config.command,
+    gateway: config.gateway ?? "",
+    gatewayEndpoint: config.gatewayEndpoint ?? "",
+    workspace: config.workspace ?? "default",
+  };
+}
+
 describe("openshell cli helpers", () => {
   const originalEnv = { ...process.env };
 
@@ -575,7 +587,7 @@ describe("openshell backend manager", () => {
     },
   );
 
-  it("removes runtimes using the current OpenShell control-plane configuration", async () => {
+  it("removes runtimes using their recorded OpenShell control plane", async () => {
     cliMocks.runOpenShellCli.mockResolvedValue({
       code: 0,
       stdout: "",
@@ -589,25 +601,16 @@ describe("openshell backend manager", () => {
       }),
     });
 
-    await manager.removeRuntime({
-      entry: createOpenShellRuntimeEntryFixture("openclaw-session-5678"),
-      config: {},
-    });
-
     const expectedConfig = resolveOpenShellPluginConfig({
       command: "/usr/local/bin/openshell",
       gateway: "lab",
+      workspace: "default",
     });
-    expect(cliMocks.runOpenShellCli).toHaveBeenCalledWith({
-      context: {
-        sandboxName: "openclaw-session-5678",
-        config: expectedConfig,
-      },
-      args: ["sandbox", "delete", "openclaw-session-5678"],
-    });
-
     await manager.removeRuntime({
-      entry: createOpenShellRuntimeEntryFixture("openclaw-session-5678"),
+      entry: {
+        ...createOpenShellRuntimeEntryFixture("openclaw-session-5678"),
+        cleanupMetadata: createOpenShellCleanupMetadata(),
+      },
       config: {
         plugins: {
           entries: {
@@ -627,14 +630,35 @@ describe("openshell backend manager", () => {
     expect(cliMocks.runOpenShellCli).toHaveBeenLastCalledWith({
       context: {
         sandboxName: "openclaw-session-5678",
-        config: resolveOpenShellPluginConfig({
-          command: "/opt/openshell/bin/openshell",
-          gateway: "research",
-          workspace: "team-1",
-        }),
+        config: expectedConfig,
       },
       args: ["sandbox", "delete", "openclaw-session-5678"],
     });
+  });
+
+  it("refuses to delete an OpenShell runtime without an authoritative locator", async () => {
+    const manager = createOpenShellSandboxBackendManager({
+      pluginConfig: resolveOpenShellPluginConfig({ command: "openshell" }),
+    });
+
+    await expect(
+      manager.removeRuntime({
+        entry: createOpenShellRuntimeEntryFixture("openclaw-session-legacy"),
+        config: {},
+      }),
+    ).rejects.toThrow("has no authoritative cleanup locator");
+    await expect(
+      manager.removeRuntime({
+        entry: {
+          ...createOpenShellRuntimeEntryFixture("openclaw-session-ambient"),
+          cleanupMetadata: createOpenShellCleanupMetadata(
+            resolveOpenShellPluginConfig({ command: "openshell" }),
+          ),
+        },
+        config: {},
+      }),
+    ).rejects.toThrow("has no authoritative cleanup locator");
+    expect(cliMocks.runOpenShellCli).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -653,7 +677,10 @@ describe("openshell backend manager", () => {
 
     await expect(
       manager.removeRuntime({
-        entry: createOpenShellRuntimeEntryFixture("openclaw-session-5678"),
+        entry: {
+          ...createOpenShellRuntimeEntryFixture("openclaw-session-5678"),
+          cleanupMetadata: createOpenShellCleanupMetadata(),
+        },
         config: {},
       }),
     ).rejects.toThrow(expected);

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -876,6 +876,7 @@ export async function runExecProcess({
         workdir: opts.containerWorkdir ?? opts.sandbox.containerWorkdir,
         env: shellRuntimeEnv,
         usePty: opts.usePty,
+        signal: initialStartupSignal,
       });
       sandboxFinalizeToken = backendExecSpec.finalizeToken;
       assertSandboxCurrent = backendExecSpec.assertCurrent;

--- a/src/agents/bash-tools.shared.ts
+++ b/src/agents/bash-tools.shared.ts
@@ -34,6 +34,7 @@ export type BashSandboxConfig = {
     workdir?: string;
     env: Record<string, string>;
     usePty: boolean;
+    signal?: AbortSignal;
   }) => Promise<SandboxBackendExecSpec>;
   finalizeExec?: (params: {
     status: "completed" | "failed";

--- a/src/agents/sandbox.resolveSandboxContext.test.ts
+++ b/src/agents/sandbox.resolveSandboxContext.test.ts
@@ -10,8 +10,18 @@ import type { SkillUsagePath } from "../skills/types.js";
 import { registerSandboxBackend } from "./sandbox/backend.js";
 import { ensureSandboxWorkspaceForSession, resolveSandboxContext } from "./sandbox/context.js";
 import { isSandboxProvisioningError } from "./sandbox/provisioning-error.js";
+import type { SandboxRegistryEntry } from "./sandbox/registry.js";
 
-const updateRegistryMock = vi.hoisted(() => vi.fn());
+const registryEntries = vi.hoisted(() => new Map<string, SandboxRegistryEntry>());
+const updateRegistryMock = vi.hoisted(() =>
+  vi.fn(async (entry: SandboxRegistryEntry) => {
+    registryEntries.set(entry.containerName, entry);
+    return entry;
+  }),
+);
+const readRegistryEntryMock = vi.hoisted(() =>
+  vi.fn(async (name: string) => registryEntries.get(name) ?? null),
+);
 const readRegisteredSandboxRuntimeIdsMock = vi.hoisted(() => vi.fn(async () => [] as string[]));
 const syncSkillsToWorkspaceMock = vi.hoisted(() =>
   vi.fn<() => Promise<SkillUsagePath[]>>(async () => []),
@@ -34,7 +44,9 @@ const containerEngineMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("./sandbox/registry.js", () => ({
+  readRegistryEntry: readRegistryEntryMock,
   readRegisteredSandboxRuntimeIds: readRegisteredSandboxRuntimeIdsMock,
+  resolveSandboxRegistryLifecycleId: (entry: unknown) => JSON.stringify(entry),
   updateRegistry: updateRegistryMock,
 }));
 
@@ -65,6 +77,10 @@ vi.mock("../skills/runtime/remote.js", () => ({
 vi.mock("../skills/loading/workspace-skill-sync.runtime.js", () => ({
   syncWorkspaceSkills: syncSkillsToWorkspaceMock,
 }));
+
+async function emptyShellCommand() {
+  return { stdout: Buffer.alloc(0), stderr: Buffer.alloc(0), code: 0 };
+}
 
 let sandboxFixtureRoot = "";
 let sandboxFixtureCount = 0;
@@ -128,11 +144,7 @@ describe("resolveSandboxContext", () => {
         env: process.env,
         stdinMode: "pipe-closed" as const,
       }),
-      runShellCommand: async () => ({
-        stdout: Buffer.alloc(0),
-        stderr: Buffer.alloc(0),
-        code: 0,
-      }),
+      runShellCommand: emptyShellCommand,
     }));
     const restore = registerSandboxBackend("test-off-backend", backendFactory);
     try {
@@ -190,11 +202,7 @@ describe("resolveSandboxContext", () => {
         env: {},
         stdinMode: "pipe-closed" as const,
       }),
-      runShellCommand: async () => ({
-        stdout: Buffer.alloc(0),
-        stderr: Buffer.alloc(0),
-        code: 0,
-      }),
+      runShellCommand: emptyShellCommand,
     }));
     const restore = registerSandboxBackend("required-backend", backendFactory);
     const warnLogs = createWarnLogCapture("openclaw-required-sandbox-workspace");
@@ -293,11 +301,7 @@ describe("resolveSandboxContext", () => {
         env: process.env,
         stdinMode: "pipe-closed" as const,
       }),
-      runShellCommand: async () => ({
-        stdout: Buffer.alloc(0),
-        stderr: Buffer.alloc(0),
-        code: 0,
-      }),
+      runShellCommand: emptyShellCommand,
     }));
     const restore = registerSandboxBackend("test-backend", {
       factory: backendFactory,
@@ -377,11 +381,7 @@ describe("resolveSandboxContext", () => {
           env: process.env,
           stdinMode: "pipe-closed",
         }),
-        runShellCommand: async () => ({
-          stdout: Buffer.alloc(0),
-          stderr: Buffer.alloc(0),
-          code: 0,
-        }),
+        runShellCommand: emptyShellCommand,
       };
     });
     try {
@@ -526,11 +526,7 @@ describe("resolveSandboxContext", () => {
         env: process.env,
         stdinMode: "pipe-closed" as const,
       }),
-      runShellCommand: async () => ({
-        stdout: Buffer.alloc(0),
-        stderr: Buffer.alloc(0),
-        code: 0,
-      }),
+      runShellCommand: emptyShellCommand,
     }));
     try {
       const cfg: OpenClawConfig = {
@@ -578,11 +574,7 @@ describe("resolveSandboxContext", () => {
         env: process.env,
         stdinMode: "pipe-closed" as const,
       }),
-      runShellCommand: async () => ({
-        stdout: Buffer.alloc(0),
-        stderr: Buffer.alloc(0),
-        code: 0,
-      }),
+      runShellCommand: emptyShellCommand,
     }));
     try {
       const cfg: OpenClawConfig = {
@@ -629,11 +621,7 @@ describe("resolveSandboxContext", () => {
         env: process.env,
         stdinMode: "pipe-closed" as const,
       }),
-      runShellCommand: async () => ({
-        stdout: Buffer.alloc(0),
-        stderr: Buffer.alloc(0),
-        code: 0,
-      }),
+      runShellCommand: emptyShellCommand,
       createFsBridge: () => {
         throw bridgeFailure;
       },
@@ -682,11 +670,7 @@ describe("resolveSandboxContext", () => {
         env: process.env,
         stdinMode: "pipe-closed" as const,
       }),
-      runShellCommand: async () => ({
-        stdout: Buffer.alloc(0),
-        stderr: Buffer.alloc(0),
-        code: 0,
-      }),
+      runShellCommand: emptyShellCommand,
     }));
     const restore = registerSandboxBackend("docker", backendFactory);
     try {
@@ -738,11 +722,7 @@ describe("resolveSandboxContext", () => {
         env: process.env,
         stdinMode: "pipe-closed" as const,
       }),
-      runShellCommand: async () => ({
-        stdout: Buffer.alloc(0),
-        stderr: Buffer.alloc(0),
-        code: 0,
-      }),
+      runShellCommand: emptyShellCommand,
     }));
     const restore = registerSandboxBackend("podman", backendFactory);
     try {
@@ -800,11 +780,7 @@ describe("resolveSandboxContext", () => {
         env: process.env,
         stdinMode: "pipe-closed",
       }),
-      runShellCommand: async () => ({
-        stdout: Buffer.alloc(0),
-        stderr: Buffer.alloc(0),
-        code: 0,
-      }),
+      runShellCommand: emptyShellCommand,
     }));
     try {
       const cfg: OpenClawConfig = {

--- a/src/agents/sandbox/backend-handle.types.ts
+++ b/src/agents/sandbox/backend-handle.types.ts
@@ -65,10 +65,14 @@ export type SandboxBackendHandle = {
   id: SandboxBackendId;
   runtimeId: string;
   runtimeLabel: string;
+  /** Exact provider target + runtime identity used by lifecycle coordination. */
+  runtimeActivityKey?: string;
   workdir: string;
   env?: Record<string, string>;
   configLabel?: string;
   configLabelKind?: string;
+  /** Provider-owned locator required to remove this exact runtime after config changes. */
+  cleanupMetadata?: Record<string, string>;
   /**
    * Remote backends own cwd existence checks because valid runtime paths may
    * not exist in the local workspace mirror. Backend validation must be paired
@@ -89,6 +93,7 @@ export type SandboxBackendHandle = {
     workdir?: string;
     env: Record<string, string>;
     usePty: boolean;
+    signal?: AbortSignal;
   }): Promise<SandboxBackendExecSpec>;
   finalizeExec?: (params: {
     status: "completed" | "failed";

--- a/src/agents/sandbox/backend.ts
+++ b/src/agents/sandbox/backend.ts
@@ -24,11 +24,15 @@ import { SandboxRuntimeRetiredError } from "./provisioning-error.js";
 import {
   assertSandboxRegistryEntryCurrent,
   completeSandboxRegistryReservation,
+  readRegistryEntry,
   reserveSandboxRegistryEntry,
+  resolveSandboxRegistryLifecycleId,
   updateRegistry,
   withSandboxRegistryEntryLock,
   type SandboxRegistryEntry,
 } from "./registry.js";
+import { coordinateSandboxBackendHandle } from "./runtime-activity.js";
+import { withSandboxScopeLock } from "./scope-lock.js";
 import {
   createSshSandboxBackend,
   resolveSshRuntimePaths,
@@ -176,6 +180,28 @@ export function requireSandboxBackendFactory(id: string): SandboxBackendFactory 
 export async function createSandboxBackend(
   params: CreateSandboxBackendParams,
 ): Promise<SandboxBackendHandle> {
+  return withSandboxScopeLock(params.scopeKey, async () => {
+    const backend = await createSandboxBackendLifecycle(params);
+    const backendWithFsBridge = backend.createFsBridge
+      ? backend
+      : { ...backend, createFsBridge: (await import("./fs-bridge.js")).createSandboxFsBridge };
+    const registered = await readRegistryEntry(backend.runtimeId);
+    if (!registered) {
+      throw new Error("Sandbox runtime was removed before provisioning completed.");
+    }
+    const lifecycleId = resolveSandboxRegistryLifecycleId(registered);
+    return coordinateSandboxBackendHandle(backendWithFsBridge, async () => {
+      const current = await readRegistryEntry(backend.runtimeId);
+      if (!current || resolveSandboxRegistryLifecycleId(current) !== lifecycleId) {
+        throw new Error("Sandbox runtime was recycled before the operation started.");
+      }
+    });
+  });
+}
+
+async function createSandboxBackendLifecycle(
+  params: CreateSandboxBackendParams,
+): Promise<SandboxBackendHandle> {
   const factory = requireSandboxBackendFactory(params.cfg.backend);
   const reserveRuntimeId = resolveSandboxBackendRegistration(params.cfg.backend)?.reserveRuntimeId;
   const toEntry = (backend: SandboxBackendHandle): SandboxRegistryEntry => ({
@@ -187,6 +213,7 @@ export async function createSandboxBackend(
     lastUsedAtMs: Date.now(),
     image: backend.configLabel ?? params.cfg.docker.image,
     configLabelKind: backend.configLabelKind ?? "Image",
+    cleanupMetadata: backend.cleanupMetadata,
   });
   if (!reserveRuntimeId) {
     const backend = await factory(params);

--- a/src/agents/sandbox/browser.activity.test.ts
+++ b/src/agents/sandbox/browser.activity.test.ts
@@ -1,0 +1,117 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { buildBrowserTestConfig } from "./browser.create.test-helpers.js";
+
+const { startBridge } = vi.hoisted(() => ({
+  startBridge:
+    vi.fn<typeof import("../../plugin-sdk/browser-bridge.js").startBrowserBridgeServer>(),
+}));
+vi.mock("../../plugin-sdk/browser-bridge.js", () => ({
+  startBrowserBridgeServer: startBridge,
+  stopBrowserBridgeServer: vi.fn(),
+}));
+vi.mock("../../plugin-sdk/browser-profiles.js", () => ({
+  DEFAULT_BROWSER_ACTION_TIMEOUT_MS: 60_000,
+  DEFAULT_BROWSER_EVALUATE_ENABLED: true,
+  DEFAULT_OPENCLAW_BROWSER_COLOR: "#FF4500",
+  DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME: "openclaw",
+  resolveProfile: (
+    resolved: import("../../plugin-sdk/browser-types.js").ResolvedBrowserConfig,
+    name: string,
+  ) => resolved.profiles[name] ?? null,
+}));
+vi.mock("./docker.js", async () => ({
+  resolveDockerEnvPolicyEpoch: (await import("./sanitize-env-vars.js")).resolveDockerEnvPolicyEpoch,
+  dockerContainerState: async () => ({ exists: true, running: true }),
+  readDockerContainerEnvVar: async () => "test-browser-relay-secret",
+  readDockerContainerLabel: async () => "existing-browser-config",
+  readDockerPort: async (_name: string, port: number) => (port === 9222 ? 49100 : 49101),
+  execDocker: () => {
+    throw new Error("Existing hot browser must not be recreated");
+  },
+}));
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+let stateDir: string;
+let server: Server;
+
+beforeEach(async () => {
+  vi.resetModules();
+  stateDir = tempDirs.make("openclaw-browser-activity-");
+  vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+  server = createServer();
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const port = (server.address() as AddressInfo).port;
+  startBridge.mockImplementation(async ({ resolved }) => ({
+    server,
+    port,
+    baseUrl: `http://127.0.0.1:${port}`,
+    state: { resolved },
+  }));
+});
+
+afterEach(async () => {
+  const { closeOpenClawStateDatabaseForTest } = await import("../../state/openclaw-state-db.js");
+  closeOpenClawStateDatabaseForTest();
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+  vi.unstubAllEnvs();
+});
+
+it("keeps a reused CDP bridge authorized when noVNC is disabled, but rejects a replacement", async () => {
+  const { ensureSandboxBrowser } = await import("./browser.js");
+  const { buildSandboxContainerName, slugifySessionKey } = await import("./shared.js");
+  const { readBrowserRegistryEntry, removeBrowserRegistryEntry, updateBrowserRegistry } =
+    await import("./registry.js");
+  const cfg = buildBrowserTestConfig(true);
+  const scopeKey = "agent:main:browser-activity";
+  const containerName = buildSandboxContainerName(
+    cfg.browser.containerPrefix,
+    slugifySessionKey(scopeKey),
+  );
+  const entry = {
+    containerName,
+    sessionKey: scopeKey,
+    createdAtMs: Date.now() - 60_000,
+    lastUsedAtMs: Date.now(),
+    image: cfg.browser.image,
+    configHash: "existing-browser-config",
+    cdpPort: 49100,
+    noVncPort: 49101,
+  };
+  await updateBrowserRegistry(entry);
+  const params = {
+    scopeKey,
+    workspaceDir: stateDir,
+    agentWorkspaceDir: stateDir,
+    cfg,
+    bridgeAuth: { token: "test-bridge-token" },
+  };
+  const initial = await ensureSandboxBrowser(params);
+  const acquire = startBridge.mock.calls[0]?.[0].acquireRequestActivity;
+  if (!acquire) {
+    throw new Error("Browser must register request activity admission");
+  }
+  const initialLease = await acquire();
+  expect(initialLease).not.toBeNull();
+  await initialLease?.release();
+
+  cfg.browser.noVncEnabled = false;
+  const reused = await ensureSandboxBrowser(params);
+  expect(reused?.bridgeUrl).toBe(initial?.bridgeUrl);
+  expect(reused?.noVncUrl).toBeUndefined();
+  expect(startBridge).toHaveBeenCalledOnce();
+  expect((await readBrowserRegistryEntry(containerName))?.noVncPort).toBeUndefined();
+  const reusedLease = await acquire();
+  expect(reusedLease).not.toBeNull();
+  await reusedLease?.release();
+
+  await removeBrowserRegistryEntry(containerName);
+  await updateBrowserRegistry({ ...entry, createdAtMs: entry.createdAtMs + 1 });
+  await expect(acquire()).rejects.toThrow("was recycled");
+});

--- a/src/agents/sandbox/browser.create.test-helpers.ts
+++ b/src/agents/sandbox/browser.create.test-helpers.ts
@@ -1,0 +1,50 @@
+import type { SandboxConfig } from "./types.js";
+
+export function buildBrowserTestConfig(noVncEnabled: boolean): SandboxConfig {
+  return {
+    mode: "all",
+    backend: "docker",
+    scope: "session",
+    workspaceAccess: "none",
+    workspaceRoot: "/tmp/openclaw-sandboxes",
+    dockerTmpfsSource: "default",
+    docker: {
+      image: "openclaw-sandbox:bookworm-slim",
+      containerPrefix: "openclaw-sbx-",
+      workdir: "/workspace",
+      readOnlyRoot: true,
+      tmpfs: ["/tmp", "/var/tmp", "/run"],
+      network: "none",
+      capDrop: ["ALL"],
+      env: { LANG: "C.UTF-8" },
+    },
+    ssh: {
+      command: "ssh",
+      workspaceRoot: "/tmp/openclaw-sandboxes",
+      strictHostKeyChecking: true,
+      updateHostKeys: true,
+    },
+    browser: {
+      enabled: true,
+      image: "openclaw-sandbox-browser:bookworm-slim",
+      containerPrefix: "openclaw-sbx-browser-",
+      network: "openclaw-sandbox-browser",
+      cdpPort: 9222,
+      vncPort: 5900,
+      noVncPort: 6080,
+      headless: false,
+      noVncEnabled,
+      allowHostControl: false,
+      autoStart: true,
+      autoStartTimeoutMs: 12_000,
+    },
+    tools: {
+      allow: ["browser"],
+      deny: [],
+    },
+    prune: {
+      idleHours: 24,
+      maxAgeDays: 7,
+    },
+  };
+}

--- a/src/agents/sandbox/browser.create.test.ts
+++ b/src/agents/sandbox/browser.create.test.ts
@@ -6,6 +6,7 @@ import type { AddressInfo, Socket } from "node:net";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { buildBrowserTestConfig as buildConfig } from "./browser.create.test-helpers.js";
 import {
   computeSandboxBrowserConfigHash,
   SANDBOX_DOCKER_EXPLICIT_ENV_POLICY_EPOCH,
@@ -35,6 +36,7 @@ const dockerMocks = vi.hoisted(() => ({
 
 const registryMocks = vi.hoisted(() => ({
   readBrowserRegistry: vi.fn(),
+  removeBrowserRegistryEntry: vi.fn(),
   updateBrowserRegistry: vi.fn(),
 }));
 
@@ -63,6 +65,12 @@ vi.mock("./docker.js", async () => {
 
 vi.mock("./registry.js", () => ({
   readBrowserRegistry: registryMocks.readBrowserRegistry,
+  readBrowserRegistryEntry: async (containerName: string) =>
+    ((await registryMocks.readBrowserRegistry()).entries as Array<{ containerName: string }>).find(
+      (entry) => entry.containerName === containerName,
+    ) ?? null,
+  removeBrowserRegistryEntry: registryMocks.removeBrowserRegistryEntry,
+  resolveSandboxBrowserRegistryLifecycleId: (entry: unknown) => JSON.stringify(entry),
   updateBrowserRegistry: registryMocks.updateBrowserRegistry,
 }));
 
@@ -109,55 +117,6 @@ async function loadFreshBrowserModulesForTest() {
   vi.resetModules();
   ({ BROWSER_BRIDGES } = await import("./browser-bridges.js"));
   ({ ensureSandboxBrowser } = await import("./browser.js"));
-}
-
-function buildConfig(noVncEnabled: boolean): SandboxConfig {
-  return {
-    mode: "all",
-    backend: "docker",
-    scope: "session",
-    workspaceAccess: "none",
-    workspaceRoot: "/tmp/openclaw-sandboxes",
-    dockerTmpfsSource: "default",
-    docker: {
-      image: "openclaw-sandbox:bookworm-slim",
-      containerPrefix: "openclaw-sbx-",
-      workdir: "/workspace",
-      readOnlyRoot: true,
-      tmpfs: ["/tmp", "/var/tmp", "/run"],
-      network: "none",
-      capDrop: ["ALL"],
-      env: { LANG: "C.UTF-8" },
-    },
-    ssh: {
-      command: "ssh",
-      workspaceRoot: "/tmp/openclaw-sandboxes",
-      strictHostKeyChecking: true,
-      updateHostKeys: true,
-    },
-    browser: {
-      enabled: true,
-      image: "openclaw-sandbox-browser:bookworm-slim",
-      containerPrefix: "openclaw-sbx-browser-",
-      network: "openclaw-sandbox-browser",
-      cdpPort: 9222,
-      vncPort: 5900,
-      noVncPort: 6080,
-      headless: false,
-      noVncEnabled,
-      allowHostControl: false,
-      autoStart: true,
-      autoStartTimeoutMs: 12_000,
-    },
-    tools: {
-      allow: ["browser"],
-      deny: [],
-    },
-    prune: {
-      idleHours: 24,
-      maxAgeDays: 7,
-    },
-  };
 }
 
 function computeTestBrowserHash(params: {
@@ -232,6 +191,18 @@ function requireValue<T>(value: T | null | undefined, label: string): T {
   return value;
 }
 
+function browserRegistryEntry(image: string, overrides: Record<string, unknown> = {}) {
+  return {
+    containerName: "openclaw-sbx-browser-session-test-0661d10a",
+    sessionKey: "session:test",
+    createdAtMs: 1,
+    lastUsedAtMs: 2,
+    image,
+    cdpPort: 49100,
+    ...overrides,
+  };
+}
+
 function latestBridgeResolved(): Record<string, unknown> {
   const params = bridgeMocks.startBrowserBridgeServer.mock.calls.at(-1)?.[0];
   if (!params || typeof params !== "object") {
@@ -259,6 +230,7 @@ describe("ensureSandboxBrowser create args", () => {
     dockerMocks.readDockerContainerLabel.mockClear();
     dockerMocks.readDockerPort.mockClear();
     registryMocks.readBrowserRegistry.mockClear();
+    registryMocks.removeBrowserRegistryEntry.mockClear();
     registryMocks.updateBrowserRegistry.mockClear();
     bridgeMocks.startBrowserBridgeServer.mockClear();
     bridgeMocks.stopBrowserBridgeServer.mockClear();
@@ -287,7 +259,7 @@ describe("ensureSandboxBrowser create args", () => {
       return null;
     });
     registryMocks.readBrowserRegistry.mockResolvedValue({ entries: [] });
-    registryMocks.updateBrowserRegistry.mockResolvedValue(undefined);
+    registryMocks.updateBrowserRegistry.mockImplementation(async (entry) => entry);
     bridgeMocks.startBrowserBridgeServer.mockResolvedValue({
       server: { listening: true } as never,
       port: 19000,
@@ -445,6 +417,27 @@ describe("ensureSandboxBrowser create args", () => {
     );
   });
 
+  it("retires a surviving registry identity before recreating a missing browser", async () => {
+    const cfg = buildConfig(false);
+    registryMocks.readBrowserRegistry.mockResolvedValue({
+      entries: [browserRegistryEntry(cfg.browser.image)],
+    });
+
+    await ensureTestSandboxBrowser({
+      scopeKey: "session:test",
+      workspaceDir: "/tmp/workspace",
+      agentWorkspaceDir: "/tmp/workspace",
+      cfg,
+    });
+
+    expect(registryMocks.removeBrowserRegistryEntry).toHaveBeenCalledWith(
+      "openclaw-sbx-browser-session-test-0661d10a",
+    );
+    expect(registryMocks.removeBrowserRegistryEntry.mock.invocationCallOrder[0]).toBeLessThan(
+      registryMocks.updateBrowserRegistry.mock.invocationCallOrder[0] ?? Number.MAX_SAFE_INTEGER,
+    );
+  });
+
   it("recreates a cold browser container when the shared args epoch changes", async () => {
     const cfg = buildConfig(false);
     const oldHash = computeTestBrowserHash({
@@ -455,17 +448,7 @@ describe("ensureSandboxBrowser create args", () => {
     dockerMocks.readDockerContainerEnvVar.mockResolvedValue("existing-cdp-token");
     dockerMocks.readDockerContainerLabel.mockResolvedValue(oldHash);
     registryMocks.readBrowserRegistry.mockResolvedValue({
-      entries: [
-        {
-          containerName: "openclaw-sbx-browser-session-test-0661d10a",
-          sessionKey: "session:test",
-          createdAtMs: 1,
-          lastUsedAtMs: 0,
-          image: cfg.browser.image,
-          configHash: oldHash,
-          cdpPort: 49100,
-        },
-      ],
+      entries: [browserRegistryEntry(cfg.browser.image, { lastUsedAtMs: 0, configHash: oldHash })],
     });
     BROWSER_BRIDGES.set("session:test", {
       containerName: "openclaw-sbx-browser-session-test-0661d10a",
@@ -501,15 +484,7 @@ describe("ensureSandboxBrowser create args", () => {
     dockerMocks.readDockerContainerLabel.mockResolvedValue(oldHash);
     registryMocks.readBrowserRegistry.mockResolvedValue({
       entries: [
-        {
-          containerName: "openclaw-sbx-browser-session-test-0661d10a",
-          sessionKey: "session:test",
-          createdAtMs: 1,
-          lastUsedAtMs: Date.now(),
-          image: cfg.browser.image,
-          configHash: oldHash,
-          cdpPort: 49100,
-        },
+        browserRegistryEntry(cfg.browser.image, { lastUsedAtMs: Date.now(), configHash: oldHash }),
       ],
     });
 

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -54,7 +54,19 @@ import {
   NOVNC_PASSWORD_ENV_KEY,
   issueNoVncObserverToken,
 } from "./novnc-auth.js";
-import { readBrowserRegistry, updateBrowserRegistry } from "./registry.js";
+import {
+  readBrowserRegistryEntry,
+  removeBrowserRegistryEntry,
+  resolveSandboxBrowserRegistryLifecycleId,
+  updateBrowserRegistry,
+} from "./registry.js";
+import {
+  activateSandboxRuntimeActivity,
+  resolveSandboxRuntimeActivityKey,
+  tryAcquireSandboxRuntimeActivity,
+  tryWithSandboxRuntimeMutations,
+} from "./runtime-activity.js";
+import { withSandboxScopeLock } from "./scope-lock.js";
 import { buildSandboxContainerName, resolveSandboxAgentId, slugifySessionKey } from "./shared.js";
 import { isToolAllowed } from "./tool-policy.js";
 import type { SandboxBrowserContext, SandboxConfig } from "./types.js";
@@ -259,15 +271,18 @@ export async function ensureSandboxBrowser(
   // Independent agent runs can converge on one Docker resource. Serialize the
   // full lifecycle so followers re-read container and bridge state after the
   // preceding create, start, or replacement has settled.
-  return await browserContainerLifecycleQueue.enqueue(containerName, async () => {
-    return await ensureSandboxBrowserContainer(params, containerName);
-  });
+  return await withSandboxScopeLock(params.scopeKey, () =>
+    browserContainerLifecycleQueue.enqueue(containerName, () =>
+      ensureSandboxBrowserContainer(params, containerName),
+    ),
+  );
 }
 
 async function ensureSandboxBrowserContainer(
   params: EnsureSandboxBrowserParams,
   containerName: string,
 ): Promise<SandboxBrowserContext> {
+  const activityKey = resolveSandboxRuntimeActivityKey("docker", containerName);
   let existing = BROWSER_BRIDGES.get(params.scopeKey);
   const stopExistingForContainer = async () => {
     await stopCachedBrowserBridgesForContainer(containerName);
@@ -315,6 +330,7 @@ async function ensureSandboxBrowserContainer(
   let running = state.running;
   let currentHash: string | null = null;
   let hashMismatch = false;
+  const registryEntry = await readBrowserRegistryEntry(containerName);
   const noVncEnabled = isNoVncEnabled(params.cfg.browser);
   let noVncPassword: string | undefined;
   let cdpAuthToken: string | undefined;
@@ -330,16 +346,28 @@ async function ensureSandboxBrowserContainer(
       defaultRuntime.log(
         `Removing stale sandbox browser container ${containerName} because it lacks the current CDP relay auth contract; it will be recreated.`,
       );
-      await stopExistingForContainer();
-      await execDocker(["rm", "-f", containerName], { allowFailure: true });
+      const removal = await tryWithSandboxRuntimeMutations([activityKey], async (lifecycle) => {
+        await stopExistingForContainer();
+        const result = await execDocker(["rm", "-f", containerName], { allowFailure: true });
+        if (result.code !== 0) {
+          throw new Error(
+            `Failed to remove stale sandbox browser ${containerName}: ${result.stderr.trim()}`,
+          );
+        }
+        await removeBrowserRegistryEntry(containerName);
+        lifecycle.retire();
+      });
+      if (!removal.acquired) {
+        throw new Error(
+          `Sandbox browser ${containerName} is active and lacks the current authentication contract; retry after its requests finish.`,
+        );
+      }
       hasContainer = false;
       running = false;
     }
   }
 
   if (hasContainer) {
-    const registry = await readBrowserRegistry();
-    const registryEntry = registry.entries.find((entry) => entry.containerName === containerName);
     currentHash = await readDockerContainerLabel(containerName, "openclaw.configHash");
     hashMismatch = !currentHash || currentHash !== expectedHash;
     if (!currentHash) {
@@ -365,14 +393,41 @@ async function ensureSandboxBrowserContainer(
           `Sandbox browser config changed for ${containerName} (recently used). Recreate to apply: ${hint}`,
         );
       } else {
-        await stopExistingForContainer();
-        await execDocker(["rm", "-f", containerName], { allowFailure: true });
-        hasContainer = false;
-        running = false;
+        const removal = await tryWithSandboxRuntimeMutations([activityKey], async (lifecycle) => {
+          await stopExistingForContainer();
+          const result = await execDocker(["rm", "-f", containerName], { allowFailure: true });
+          if (result.code !== 0) {
+            throw new Error(
+              `Failed to remove stale sandbox browser ${containerName}: ${result.stderr.trim()}`,
+            );
+          }
+          await removeBrowserRegistryEntry(containerName);
+          lifecycle.retire();
+        });
+        if (removal.acquired) {
+          hasContainer = false;
+          running = false;
+        } else {
+          defaultRuntime.log(
+            `Retaining sandbox browser ${containerName} with its previous configuration because it is active.`,
+          );
+        }
       }
     }
   }
 
+  if (!hasContainer && registryEntry) {
+    const retirement = await tryWithSandboxRuntimeMutations([activityKey], async (lifecycle) => {
+      await stopExistingForContainer();
+      await removeBrowserRegistryEntry(containerName);
+      lifecycle.retire();
+    });
+    if (!retirement.acquired) {
+      throw new Error(
+        `Sandbox browser ${containerName} is missing while prior activity is still settling; retry after it finishes.`,
+      );
+    }
+  }
   if (!hasContainer) {
     if (noVncEnabled) {
       noVncPassword = generateNoVncPassword();
@@ -511,6 +566,24 @@ async function ensureSandboxBrowserContainer(
 
   const bridge = canReuse ? (existing?.bridge ?? null) : null;
 
+  const registered = await updateBrowserRegistry({
+    containerName,
+    sessionKey: params.scopeKey,
+    createdAtMs: now,
+    lastUsedAtMs: now,
+    image: browserImage,
+    configHash: hashMismatch && running ? (currentHash ?? undefined) : expectedHash,
+    cdpPort: mappedCdp,
+    noVncPort: mappedNoVnc ?? undefined,
+  });
+  const browserLifecycleId = resolveSandboxBrowserRegistryLifecycleId(registered);
+  const assertBrowserCurrent = async () => {
+    const current = await readBrowserRegistryEntry(containerName);
+    if (!current || resolveSandboxBrowserRegistryLifecycleId(current) !== browserLifecycleId) {
+      throw new Error("Sandbox browser was recycled before the request started.");
+    }
+  };
+  const bridgeActivityGeneration = activateSandboxRuntimeActivity(activityKey);
   const ensureBridge = async () => {
     if (bridge) {
       return bridge;
@@ -547,6 +620,12 @@ async function ensureSandboxBrowserContainer(
       }),
       authToken: desiredAuthToken,
       authPassword: desiredAuthPassword,
+      acquireRequestActivity: () =>
+        tryAcquireSandboxRuntimeActivity(
+          activityKey,
+          bridgeActivityGeneration,
+          assertBrowserCurrent,
+        ),
       onEnsureAttachTarget,
       resolveSandboxNoVncToken: consumeNoVncObserverToken,
     });
@@ -561,17 +640,6 @@ async function ensureSandboxBrowserContainer(
       authPassword: desiredAuthPassword,
     });
   }
-
-  await updateBrowserRegistry({
-    containerName,
-    sessionKey: params.scopeKey,
-    createdAtMs: now,
-    lastUsedAtMs: now,
-    image: browserImage,
-    configHash: hashMismatch && running ? (currentHash ?? undefined) : expectedHash,
-    cdpPort: mappedCdp,
-    noVncPort: mappedNoVnc ?? undefined,
-  });
 
   const noVncUrl =
     mappedNoVnc && noVncEnabled

--- a/src/agents/sandbox/docker-backend.ts
+++ b/src/agents/sandbox/docker-backend.ts
@@ -25,6 +25,7 @@ import {
   validateSandboxContainerEngineTarget,
 } from "./docker.js";
 import type { SandboxRegistryEntry } from "./registry.js";
+import { resolveSandboxRuntimeActivityKey } from "./runtime-activity.js";
 
 type ContainerExecFinalizeToken = () => Promise<void>;
 
@@ -134,6 +135,11 @@ function createContainerSandboxBackendHandle(params: {
     id: params.engine.id,
     runtimeId: params.containerName,
     runtimeLabel: params.containerName,
+    runtimeActivityKey: resolveSandboxRuntimeActivityKey(
+      params.engine.id,
+      params.containerName,
+      params.podmanTarget?.key,
+    ),
     workdir: params.workdir,
     env: params.env,
     configLabel: params.image,

--- a/src/agents/sandbox/docker.config-hash-recreate.test-helpers.ts
+++ b/src/agents/sandbox/docker.config-hash-recreate.test-helpers.ts
@@ -1,0 +1,85 @@
+import type { SandboxConfig } from "./types.js";
+
+export type SpawnCall = {
+  command: string;
+  args: string[];
+  globalArgs: string[];
+  envFileContents?: string;
+};
+
+export function configurePodmanMachineFixture(state: {
+  podmanInfo: string;
+  podmanConnections: string;
+  podmanMachines: string;
+}): void {
+  state.podmanInfo = "true\ttrue\t\t5.0.0\n";
+  state.podmanConnections = JSON.stringify([
+    {
+      Name: "podman-machine-default",
+      URI: "ssh://core@127.0.0.1:60000/run/user/501/podman/podman.sock",
+      Identity: "/tmp/podman-machine-default",
+      Default: true,
+    },
+  ]);
+  state.podmanMachines = JSON.stringify([
+    {
+      Name: "podman-machine-default",
+      Running: true,
+      IdentityPath: "/tmp/podman-machine-default",
+      Port: 60000,
+      RemoteUsername: "core",
+    },
+  ]);
+}
+
+export function createSandboxConfig(
+  dns: string[],
+  binds?: string[],
+  workspaceAccess: "rw" | "ro" | "none" = "rw",
+  env: Record<string, string> = { LANG: "C.UTF-8" },
+): SandboxConfig {
+  return {
+    mode: "all",
+    backend: "docker",
+    scope: "shared",
+    workspaceAccess,
+    workspaceRoot: "~/.openclaw/sandboxes",
+    dockerTmpfsSource: "default",
+    docker: {
+      image: "openclaw-sandbox:test",
+      containerPrefix: "oc-test-",
+      workdir: "/workspace",
+      readOnlyRoot: true,
+      tmpfs: ["/tmp", "/var/tmp", "/run"],
+      network: "none",
+      capDrop: ["ALL"],
+      env,
+      dns,
+      extraHosts: ["host.docker.internal:host-gateway"],
+      binds: binds ?? ["/tmp/workspace:/workspace:rw"],
+      dangerouslyAllowReservedContainerTargets: true,
+    },
+    ssh: {
+      command: "ssh",
+      workspaceRoot: "/tmp/openclaw-sandboxes",
+      strictHostKeyChecking: true,
+      updateHostKeys: true,
+    },
+    browser: {
+      enabled: false,
+      image: "openclaw-browser:test",
+      containerPrefix: "oc-browser-",
+      network: "openclaw-sandbox-browser",
+      cdpPort: 9222,
+      vncPort: 5900,
+      noVncPort: 6080,
+      headless: true,
+      noVncEnabled: false,
+      allowHostControl: false,
+      autoStart: false,
+      autoStartTimeoutMs: 5000,
+    },
+    tools: { allow: [], deny: [] },
+    prune: { idleHours: 24, maxAgeDays: 7 },
+  };
+}

--- a/src/agents/sandbox/docker.config-hash-recreate.test.ts
+++ b/src/agents/sandbox/docker.config-hash-recreate.test.ts
@@ -10,16 +10,14 @@ import {
   SANDBOX_DOCKER_EXPLICIT_ENV_POLICY_EPOCH,
 } from "./config-hash.js";
 import { SANDBOX_DOCKER_CREATE_ARGS_EPOCH } from "./constants.js";
+import {
+  configurePodmanMachineFixture,
+  createSandboxConfig,
+  type SpawnCall,
+} from "./docker.config-hash-recreate.test-helpers.js";
 import { collectDockerFlagValues } from "./test-args.js";
 import type { SandboxConfig } from "./types.js";
 import { SANDBOX_MOUNT_FORMAT_VERSION } from "./workspace-mounts.js";
-
-type SpawnCall = {
-  command: string;
-  args: string[];
-  globalArgs: string[];
-  envFileContents?: string;
-};
 
 const spawnState = vi.hoisted(() => ({
   calls: [] as SpawnCall[],
@@ -43,27 +41,6 @@ const runtimeMocks = vi.hoisted(() => ({
 }));
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
-
-function usePodmanMachine() {
-  spawnState.podmanInfo = "true\ttrue\t\t5.0.0\n";
-  spawnState.podmanConnections = JSON.stringify([
-    {
-      Name: "podman-machine-default",
-      URI: "ssh://core@127.0.0.1:60000/run/user/501/podman/podman.sock",
-      Identity: "/tmp/podman-machine-default",
-      Default: true,
-    },
-  ]);
-  spawnState.podmanMachines = JSON.stringify([
-    {
-      Name: "podman-machine-default",
-      Running: true,
-      IdentityPath: "/tmp/podman-machine-default",
-      Port: 60000,
-      RemoteUsername: "core",
-    },
-  ]);
-}
 
 vi.mock("./registry.js", () => ({
   readRegistryEntry: registryMocks.readRegistryEntry,
@@ -170,6 +147,7 @@ vi.mock("../../process/exec.js", async (importOriginal) => ({
 let ensureSandboxContainer: typeof import("./docker.js").ensureSandboxContainer;
 let resolveDockerEnvPolicyEpoch: typeof import("./docker.js").resolveDockerEnvPolicyEpoch;
 let PODMAN_SANDBOX_ENGINE: typeof import("./docker.js").PODMAN_SANDBOX_ENGINE;
+let runtimeActivity: typeof import("./runtime-activity.js");
 
 beforeAll(async () => {
   vi.resetModules();
@@ -184,59 +162,8 @@ beforeAll(async () => {
   }));
   ({ ensureSandboxContainer, resolveDockerEnvPolicyEpoch, PODMAN_SANDBOX_ENGINE } =
     await import("./docker.js"));
+  runtimeActivity = await import("./runtime-activity.js");
 });
-
-function createSandboxConfig(
-  dns: string[],
-  binds?: string[],
-  workspaceAccess: "rw" | "ro" | "none" = "rw",
-  env: Record<string, string> = { LANG: "C.UTF-8" },
-): SandboxConfig {
-  return {
-    mode: "all",
-    backend: "docker",
-    scope: "shared",
-    workspaceAccess,
-    workspaceRoot: "~/.openclaw/sandboxes",
-    dockerTmpfsSource: "default",
-    docker: {
-      image: "openclaw-sandbox:test",
-      containerPrefix: "oc-test-",
-      workdir: "/workspace",
-      readOnlyRoot: true,
-      tmpfs: ["/tmp", "/var/tmp", "/run"],
-      network: "none",
-      capDrop: ["ALL"],
-      env,
-      dns,
-      extraHosts: ["host.docker.internal:host-gateway"],
-      binds: binds ?? ["/tmp/workspace:/workspace:rw"],
-      dangerouslyAllowReservedContainerTargets: true,
-    },
-    ssh: {
-      command: "ssh",
-      workspaceRoot: "/tmp/openclaw-sandboxes",
-      strictHostKeyChecking: true,
-      updateHostKeys: true,
-    },
-    browser: {
-      enabled: false,
-      image: "openclaw-browser:test",
-      containerPrefix: "oc-browser-",
-      network: "openclaw-sandbox-browser",
-      cdpPort: 9222,
-      vncPort: 5900,
-      noVncPort: 6080,
-      headless: true,
-      noVncEnabled: false,
-      allowHostControl: false,
-      autoStart: false,
-      autoStartTimeoutMs: 5000,
-    },
-    tools: { allow: [], deny: [] },
-    prune: { idleHours: 24, maxAgeDays: 7 },
-  };
-}
 
 async function ensureSandboxCreateCallForTest(params: {
   cfg: SandboxConfig;
@@ -303,6 +230,67 @@ describe("ensureSandboxContainer config-hash recreation", () => {
     expect(spawnState.calls.filter((call) => call.args[0] === "create")).toHaveLength(1);
     expect(spawnState.calls.filter((call) => call.args[0] === "start")).toHaveLength(1);
     expect(registryMocks.updateRegistry).toHaveBeenCalledTimes(2);
+  });
+
+  it("retires a surviving registry identity before recreating a missing container", async () => {
+    const workspaceDir = tempDirs.make("openclaw-docker-mounts-");
+    const cfg = createSandboxConfig([], [`${workspaceDir}:/workspace:rw`]);
+    spawnState.containerExists = false;
+    spawnState.inspectRunning = false;
+    registryMocks.readRegistryEntry.mockResolvedValue({
+      containerName: "oc-test-shared",
+      backendId: "docker",
+      sessionKey: "shared",
+      createdAtMs: 1,
+      lastUsedAtMs: 2,
+      image: cfg.docker.image,
+    });
+
+    await ensureSandboxContainer({
+      scopeKey: "shared",
+      workspaceDir,
+      agentWorkspaceDir: workspaceDir,
+      cfg,
+    });
+
+    expect(registryMocks.removeRegistryEntry).toHaveBeenCalledWith("oc-test-shared");
+    expect(registryMocks.removeRegistryEntry.mock.invocationCallOrder[0]).toBeLessThan(
+      registryMocks.updateRegistry.mock.invocationCallOrder[0] ?? Number.MAX_SAFE_INTEGER,
+    );
+  });
+
+  it("does not recreate a missing container while prior activity is settling", async () => {
+    const workspaceDir = tempDirs.make("openclaw-docker-mounts-");
+    const cfg = createSandboxConfig([], [`${workspaceDir}:/workspace:rw`]);
+    spawnState.containerExists = false;
+    spawnState.inspectRunning = false;
+    registryMocks.readRegistryEntry.mockResolvedValue({
+      containerName: "oc-test-shared",
+      backendId: "docker",
+      sessionKey: "shared",
+      createdAtMs: 1,
+      lastUsedAtMs: 2,
+      image: cfg.docker.image,
+    });
+    const key = runtimeActivity.resolveSandboxRuntimeActivityKey("docker", "oc-test-shared");
+    const lease = await runtimeActivity.tryAcquireSandboxRuntimeActivity(
+      key,
+      runtimeActivity.activateSandboxRuntimeActivity(key),
+    );
+
+    try {
+      await expect(
+        ensureSandboxContainer({
+          scopeKey: "shared",
+          workspaceDir,
+          agentWorkspaceDir: workspaceDir,
+          cfg,
+        }),
+      ).rejects.toThrow("prior activity is still settling");
+      expect(spawnState.calls.some((call) => call.args[0] === "create")).toBe(false);
+    } finally {
+      await lease?.release();
+    }
   });
 
   it("uses the canonical non-shared scope for Docker names, labels, and registry identity", async () => {
@@ -497,32 +485,46 @@ describe("ensureSandboxContainer config-hash recreation", () => {
     expect(registryMocks.updateRegistry.mock.calls.at(-1)?.[0]?.configHash).toBe(oldHash);
   });
 
-  it("rejects a hot stale container when current config is required", async () => {
-    const workspaceDir = tempDirs.make("openclaw-docker-mounts-");
-    const cfg = createSandboxConfig([], [`${workspaceDir}:/workspace:rw`], "rw", {});
-    spawnState.labelHash = "stale-hash";
-    registryMocks.readRegistryEntry.mockResolvedValue({
-      containerName: "oc-test-shared",
-      sessionKey: "shared",
-      createdAtMs: 1,
-      lastUsedAtMs: Date.now(),
-      image: cfg.docker.image,
-      configHash: "stale-hash",
-    });
+  it.each([false, true])(
+    "rejects a stale container when current config is required (active lease: %s)",
+    async (activeLease) => {
+      const workspaceDir = tempDirs.make("openclaw-docker-mounts-");
+      const cfg = createSandboxConfig([], [`${workspaceDir}:/workspace:rw`], "rw", {});
+      spawnState.labelHash = "stale-hash";
+      registryMocks.readRegistryEntry.mockResolvedValue({
+        containerName: "oc-test-shared",
+        sessionKey: "shared",
+        createdAtMs: 1,
+        lastUsedAtMs: activeLease ? 0 : Date.now(),
+        image: cfg.docker.image,
+        configHash: "stale-hash",
+      });
 
-    await expect(
-      ensureSandboxContainer({
-        scopeKey: "shared",
-        workspaceDir,
-        agentWorkspaceDir: workspaceDir,
-        cfg,
-        requireCurrentConfig: true,
-      }),
-    ).rejects.toThrow("restricted dispatch requires the current container config");
-    expect(spawnState.calls.some((call) => call.args[0] === "rm")).toBe(false);
-    expect(spawnState.calls.some((call) => call.args[0] === "create")).toBe(false);
-    expect(registryMocks.updateRegistry).not.toHaveBeenCalled();
-  });
+      const key = runtimeActivity.resolveSandboxRuntimeActivityKey("docker", "oc-test-shared");
+      const lease = activeLease
+        ? await runtimeActivity.tryAcquireSandboxRuntimeActivity(
+            key,
+            runtimeActivity.activateSandboxRuntimeActivity(key),
+          )
+        : null;
+      try {
+        await expect(
+          ensureSandboxContainer({
+            scopeKey: "shared",
+            workspaceDir,
+            agentWorkspaceDir: workspaceDir,
+            cfg,
+            requireCurrentConfig: true,
+          }),
+        ).rejects.toThrow("restricted dispatch requires the current container config");
+        expect(spawnState.calls.some((call) => call.args[0] === "rm")).toBe(false);
+        expect(spawnState.calls.some((call) => call.args[0] === "create")).toBe(false);
+        expect(registryMocks.updateRegistry).not.toHaveBeenCalled();
+      } finally {
+        await lease?.release();
+      }
+    },
+  );
 
   it("recreates shared container when previously filtered explicit env becomes allowed", async () => {
     const workspaceDir = tempDirs.make("openclaw-docker-mounts-");
@@ -811,7 +813,7 @@ describe("ensureSandboxContainer config-hash recreation", () => {
 
   it("rejects a Podman runtime recorded for a different engine target", async () => {
     const cfg = createSandboxConfig([]);
-    usePodmanMachine();
+    configurePodmanMachineFixture(spawnState);
     registryMocks.readRegistryEntry.mockResolvedValue({
       containerName: "oc-test-podman-shared",
       backendId: "podman",
@@ -1078,7 +1080,7 @@ describe("ensureSandboxContainer config-hash recreation", () => {
     const cfg = createSandboxConfig([]);
     const workspaceDir = path.join(os.homedir(), "openclaw-podman-workspace");
     cfg.docker.binds = [`${workspaceDir}:/workspace:rw`];
-    usePodmanMachine();
+    configurePodmanMachineFixture(spawnState);
     spawnState.inspectRunning = false;
     registryMocks.readRegistryEntry.mockResolvedValue(null);
 
@@ -1099,7 +1101,7 @@ describe("ensureSandboxContainer config-hash recreation", () => {
 
   it("rejects Podman Machine bind sources outside the default home share", async () => {
     const cfg = createSandboxConfig([]);
-    usePodmanMachine();
+    configurePodmanMachineFixture(spawnState);
     spawnState.inspectRunning = false;
     registryMocks.readRegistryEntry.mockResolvedValue(null);
 

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -30,6 +30,10 @@ import {
 } from "./podman-runtime.js";
 import { readRegistryEntry, removeRegistryEntry, updateRegistry } from "./registry.js";
 import {
+  resolveSandboxRuntimeActivityKey,
+  tryWithSandboxRuntimeMutations,
+} from "./runtime-activity.js";
+import {
   resolveDockerEnvPolicyEpoch,
   sanitizeExplicitSandboxEnvVars,
 } from "./sanitize-env-vars.js";
@@ -663,10 +667,47 @@ async function ensureSandboxContainerLifecycle(
             : {}),
         });
       } else {
-        await execContainer(engine, ["rm", "-f", containerName], { allowFailure: true });
-        hasContainer = false;
-        running = false;
+        const removal = await tryWithSandboxRuntimeMutations(
+          [resolveSandboxRuntimeActivityKey(engine.id, containerName, params.podmanTarget?.key)],
+          async (lifecycle) => {
+            const result = await execContainer(engine, ["rm", "-f", containerName], {
+              allowFailure: true,
+            });
+            if (result.code !== 0) {
+              throw new Error(
+                `Failed to remove stale sandbox ${containerName}: ${result.stderr.trim()}`,
+              );
+            }
+            await removeRegistryEntry(containerName);
+            lifecycle.retire();
+          },
+        );
+        if (removal.acquired) {
+          hasContainer = false;
+          running = false;
+        } else {
+          handleHotSandboxConfigMismatch({
+            containerName,
+            scope: params.cfg.scope,
+            sessionKey: params.scopeKey,
+            requireCurrentConfig: params.requireCurrentConfig,
+          });
+        }
       }
+    }
+  }
+  if (!hasContainer && existingRegistryEntry) {
+    const retirement = await tryWithSandboxRuntimeMutations(
+      [resolveSandboxRuntimeActivityKey(engine.id, containerName, params.podmanTarget?.key)],
+      async (lifecycle) => {
+        await removeRegistryEntry(containerName);
+        lifecycle.retire();
+      },
+    );
+    if (!retirement.acquired) {
+      throw new Error(
+        `Sandbox ${containerName} is missing while prior activity is still settling; retry after it finishes.`,
+      );
     }
   }
   if (!hasContainer) {

--- a/src/agents/sandbox/prune.activity.test.ts
+++ b/src/agents/sandbox/prune.activity.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import type { SandboxBackendHandle } from "./backend-handle.types.js";
+import { resolveSandboxFileIdentity, SANDBOX_FILE_IDENTITY } from "./file-mutation-identity.js";
+import type { SandboxFsBridge } from "./fs-bridge.types.js";
+
+const { defaultFsBridge } = vi.hoisted(() => ({ defaultFsBridge: vi.fn() }));
+vi.mock("./fs-bridge.js", () => ({ createSandboxFsBridge: defaultFsBridge }));
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+let stateDir: string;
+
+beforeEach(() => {
+  vi.resetModules();
+  stateDir = tempDirs.make("openclaw-prune-activity-");
+  vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+  vi.useFakeTimers({ toFake: ["Date"] });
+  vi.setSystemTime(new Date("2026-09-13T00:00:00Z"));
+});
+
+afterEach(async () => {
+  const { closeOpenClawStateDatabaseForTest } = await import("../../state/openclaw-state-db.js");
+  closeOpenClawStateDatabaseForTest();
+  vi.useRealTimers();
+  vi.unstubAllEnvs();
+});
+
+describe("sandbox prune activity coordination", () => {
+  it.each([
+    { reserved: false, operation: "exec" },
+    { reserved: true, operation: "exec" },
+    { reserved: false, operation: "custom-fs" },
+    { reserved: false, operation: "default-fs" },
+  ])(
+    "preserves $operation work and prunes after settlement (reserved: $reserved)",
+    async ({ reserved, operation }) => {
+      const { setRuntimeConfigSnapshot } = await import("../../config/config.js");
+      const { resolveSandboxConfigForAgent } = await import("./config.js");
+      const { createSandboxBackend, registerSandboxBackend } = await import("./backend.js");
+      const { readRegistryEntry, updateRegistry } = await import("./registry.js");
+      const { maybePruneSandboxes } = await import("./prune.js");
+      const backendId = "test-prune-activity";
+      const runtimeId = "old-active-runtime";
+      const config = {
+        agents: {
+          defaults: {
+            sandbox: {
+              mode: "all" as const,
+              backend: backendId,
+              scope: "session" as const,
+              prune: { idleHours: 24, maxAgeDays: 7 },
+            },
+          },
+        },
+      };
+      setRuntimeConfigSnapshot(config);
+      const cfg = resolveSandboxConfigForAgent(config);
+      await updateRegistry({
+        containerName: runtimeId,
+        backendId,
+        sessionKey: "agent:main:main",
+        createdAtMs: Date.now() - 8 * 86_400_000,
+        lastUsedAtMs: Date.now(),
+        image: cfg.docker.image,
+        ...(reserved ? { runtimeState: "ready" as const, workspaceDir: stateDir } : {}),
+      });
+      const rawHandle: SandboxBackendHandle = {
+        id: backendId,
+        runtimeId,
+        runtimeLabel: runtimeId,
+        workdir: stateDir,
+        async buildExecSpec() {
+          return { argv: ["true"], env: {}, stdinMode: "pipe-closed" };
+        },
+        async runShellCommand() {
+          return { stdout: Buffer.alloc(0), stderr: Buffer.alloc(0), code: 0 };
+        },
+      };
+      const started = createDeferredCore();
+      const settled = createDeferredCore();
+      class FileBridge implements SandboxFsBridge {
+        private readonly physicalPath = "/workspace/physical";
+        resolvePath() {
+          return { relativePath: "alias", containerPath: "/workspace/alias" };
+        }
+        [SANDBOX_FILE_IDENTITY]() {
+          return this.physicalPath;
+        }
+        async resolvePinnedMutationTarget() {
+          return { policyPath: this.physicalPath, pinnedPath: this.physicalPath };
+        }
+        async readDirectory() {
+          return [{ name: this.physicalPath, isDirectory: false }];
+        }
+        async readFile() {
+          return Buffer.alloc(0);
+        }
+        async writeFile() {
+          // No shell command is active while this filesystem operation awaits its next stage.
+          started.resolve();
+          await settled.promise;
+        }
+        async mkdirp() {}
+        async remove() {}
+        async rename() {}
+        async stat() {
+          return null;
+        }
+      }
+      defaultFsBridge.mockImplementation(() => new FileBridge());
+      if (operation === "custom-fs") {
+        rawHandle.createFsBridge = () => new FileBridge();
+      }
+      const removeRuntime = vi.fn(async () => {});
+      const factory = async () => rawHandle;
+      const manager = {
+        describeRuntime: async () => ({ running: true, configLabelMatch: true }),
+        removeRuntime,
+      };
+      const restore = registerSandboxBackend(
+        backendId,
+        reserved ? { factory, manager, reserveRuntimeId: () => runtimeId } : { factory, manager },
+      );
+      try {
+        const backend = await createSandboxBackend({
+          sessionKey: "agent:main:main",
+          scopeKey: "agent:main:main",
+          cfg,
+          workspaceDir: stateDir,
+          agentWorkspaceDir: stateDir,
+        });
+        let release: () => Promise<void>;
+        if (operation === "exec") {
+          const exec = await backend.buildExecSpec({ command: "hold", env: {}, usePty: false });
+          release = async () => {
+            await backend.finalizeExec?.({
+              status: "completed",
+              exitCode: 0,
+              timedOut: false,
+              token: exec.finalizeToken,
+            });
+          };
+        } else {
+          const { createSandboxFsBridge } = await import("./fs-bridge.js");
+          const bridgeParams = {
+            sandbox: {
+              workspaceDir: stateDir,
+              agentWorkspaceDir: stateDir,
+              workspaceAccess: "rw" as const,
+              containerName: runtimeId,
+              containerWorkdir: "/workspace",
+              docker: cfg.docker,
+              backend,
+            },
+          };
+          const bridge =
+            backend.createFsBridge?.(bridgeParams) ?? createSandboxFsBridge(bridgeParams);
+          expect(await bridge.readDirectory?.({ filePath: "." })).toEqual([
+            { name: "/workspace/physical", isDirectory: false },
+          ]);
+          expect(
+            await bridge.resolvePinnedMutationTarget?.({ filePath: "alias", action: "write" }),
+          ).toEqual({ policyPath: "/workspace/physical", pinnedPath: "/workspace/physical" });
+          expect(await resolveSandboxFileIdentity({ bridge, filePath: "alias" })).toBe(
+            "/workspace/physical",
+          );
+          const write = bridge.writeFile({ filePath: "alias", data: "content" });
+          await started.promise;
+          release = async () => {
+            settled.resolve();
+            await write;
+          };
+        }
+        try {
+          await maybePruneSandboxes(cfg);
+          expect(removeRuntime).not.toHaveBeenCalled();
+          expect(await readRegistryEntry(runtimeId)).not.toBeNull();
+        } finally {
+          await release();
+        }
+        vi.setSystemTime(Date.now() + 5 * 60_000);
+        await maybePruneSandboxes(cfg);
+        expect(removeRuntime).toHaveBeenCalledOnce();
+        expect(await readRegistryEntry(runtimeId)).toBeNull();
+        await expect(
+          backend.buildExecSpec({ command: "stale", env: {}, usePty: false }),
+        ).rejects.toThrow("was recycled");
+      } finally {
+        restore();
+      }
+    },
+  );
+});

--- a/src/agents/sandbox/prune.test.ts
+++ b/src/agents/sandbox/prune.test.ts
@@ -172,6 +172,52 @@ describe("maybePruneSandboxes", () => {
     );
   });
 
+  it.each(["scope", "activity"])(
+    "continues container and browser cleanup after a lock failure (%s)",
+    async (boundary) => {
+      const lock =
+        boundary === "scope"
+          ? vi.spyOn(await import("./scope-lock.js"), "withSandboxScopeLock")
+          : vi.spyOn(await import("./runtime-activity.js"), "tryWithSandboxRuntimeMutations");
+      lock.mockRejectedValueOnce(
+        Object.assign(new Error("file lock stale"), { code: "file_lock_stale" }),
+      );
+      const entry = {
+        containerName: "sandbox-1",
+        backendId: "docker",
+        sessionKey: "agent:main:main",
+        createdAtMs: Date.now() - 4 * 60 * 60 * 1000,
+        lastUsedAtMs: Date.now() - 2 * 60 * 60 * 1000,
+        image: "openclaw-sandbox:bookworm-slim",
+      };
+      registryMocks.readRegistry.mockResolvedValue({
+        entries: [entry, { ...entry, containerName: "sandbox-2" }],
+      });
+      registryMocks.readBrowserRegistry.mockResolvedValue({
+        entries: [{ ...entry, containerName: "browser-1", cdpPort: 9222 }],
+      });
+
+      try {
+        await maybePruneSandboxes(buildPruneConfig());
+
+        expect(
+          backendMocks.removeRuntime.mock.calls.map(([params]) => params.entry.containerName),
+        ).toEqual(["sandbox-2", "browser-1"]);
+        expect(registryMocks.removeRegistryEntry).toHaveBeenCalledExactlyOnceWith(
+          expect.objectContaining({ containerName: "sandbox-2" }),
+        );
+        expect(registryMocks.removeBrowserRegistryEntry).toHaveBeenCalledExactlyOnceWith(
+          expect.objectContaining({ containerName: "browser-1" }),
+        );
+        expect(runtimeMocks.error).toHaveBeenCalledWith(
+          "Sandbox prune failed to remove sandbox-1: file lock stale",
+        );
+      } finally {
+        lock.mockRestore();
+      }
+    },
+  );
+
   it("does not destroy a runtime refreshed after the pruning snapshot", async () => {
     const now = Date.now();
     const snapshot = {

--- a/src/agents/sandbox/prune.test.ts
+++ b/src/agents/sandbox/prune.test.ts
@@ -51,14 +51,13 @@ vi.mock("./docker-backend.js", () => ({
 vi.mock("./registry.js", () => ({
   readBrowserRegistry: registryMocks.readBrowserRegistry,
   readRegistry: registryMocks.readRegistry,
-  removeBrowserRegistryEntry: registryMocks.removeBrowserRegistryEntry,
-  removeRegistryEntry: registryMocks.removeRegistryEntry,
+  removeBrowserRegistryEntryIfUnchanged: registryMocks.removeBrowserRegistryEntry,
   removeSandboxRegistryRuntime: async (
     entry: SandboxRegistryEntry,
     removeRuntime: (current: SandboxRegistryEntry) => Promise<void>,
   ) => {
     await removeRuntime(entry);
-    await registryMocks.removeRegistryEntry(entry.containerName);
+    await registryMocks.removeRegistryEntry(entry);
   },
 }));
 
@@ -128,13 +127,16 @@ describe("maybePruneSandboxes", () => {
     runtimeMocks.error.mockReset();
     bridgeMocks.stopBrowserBridgeServer.mockReset().mockResolvedValue(undefined);
 
-    configMocks.getRuntimeConfig.mockReturnValue({});
+    configMocks.getRuntimeConfig.mockReturnValue({
+      agents: { defaults: { sandbox: { prune: { idleHours: 1, maxAgeDays: 0 } } } },
+    });
     registryMocks.readBrowserRegistry.mockResolvedValue({ entries: [] });
     registryMocks.readRegistry.mockResolvedValue({
       entries: [
         {
           containerName: "sandbox-1",
           backendId: "docker",
+          sessionKey: "agent:main:main",
           createdAtMs: Date.now() - 4 * 60 * 60 * 1000,
           lastUsedAtMs: Date.now() - 2 * 60 * 60 * 1000,
           image: "openclaw-sandbox:bookworm-slim",
@@ -151,12 +153,15 @@ describe("maybePruneSandboxes", () => {
     await maybePruneSandboxes(buildPruneConfig());
 
     expect(backendMocks.removeRuntime).toHaveBeenCalledTimes(1);
-    expect(registryMocks.removeRegistryEntry).toHaveBeenCalledWith("sandbox-1");
+    expect(registryMocks.removeRegistryEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ containerName: "sandbox-1" }),
+    );
+    expect(backendMocks.removeRuntime.mock.invocationCallOrder[0]).toBeLessThan(
+      registryMocks.removeRegistryEntry.mock.invocationCallOrder[0] ?? Number.MAX_SAFE_INTEGER,
+    );
   });
 
-  it("keeps the registry entry when runtime removal fails", async () => {
-    // The registry is the retry source; keep it until the backend confirms the
-    // runtime was removed.
+  it("retains the cleanup locator when runtime removal fails", async () => {
     backendMocks.removeRuntime.mockRejectedValueOnce(new Error("docker rm failed"));
 
     await maybePruneSandboxes(buildPruneConfig());
@@ -167,13 +172,37 @@ describe("maybePruneSandboxes", () => {
     );
   });
 
+  it("does not destroy a runtime refreshed after the pruning snapshot", async () => {
+    const now = Date.now();
+    const snapshot = {
+      containerName: "sandbox-refreshed",
+      backendId: "docker",
+      sessionKey: "agent:main:main",
+      createdAtMs: now - 4 * 60 * 60 * 1000,
+      lastUsedAtMs: now - 2 * 60 * 60 * 1000,
+      image: "openclaw-sandbox:bookworm-slim",
+      registryGeneration: 1,
+    };
+    registryMocks.readRegistry
+      .mockResolvedValueOnce({ entries: [snapshot] })
+      .mockResolvedValueOnce({
+        entries: [{ ...snapshot, lastUsedAtMs: now, registryGeneration: 2 }],
+      });
+
+    await maybePruneSandboxes(buildPruneConfig());
+
+    expect(backendMocks.removeRuntime).not.toHaveBeenCalled();
+    expect(registryMocks.removeRegistryEntry).not.toHaveBeenCalled();
+  });
+
   it("keeps the registry entry when its sandbox backend plugin is unavailable", async () => {
     backendMocks.getSandboxBackendManager.mockReturnValueOnce(null);
-    registryMocks.readRegistry.mockResolvedValueOnce({
+    registryMocks.readRegistry.mockResolvedValue({
       entries: [
         {
           containerName: "openshell-1",
           backendId: "openshell",
+          sessionKey: "agent:main:main",
           createdAtMs: Date.now() - 4 * 60 * 60 * 1000,
           lastUsedAtMs: Date.now() - 2 * 60 * 60 * 1000,
           image: "openclaw",
@@ -190,11 +219,12 @@ describe("maybePruneSandboxes", () => {
   });
 
   it("prunes entries with out-of-range registry timestamps", async () => {
-    registryMocks.readRegistry.mockResolvedValueOnce({
+    registryMocks.readRegistry.mockResolvedValue({
       entries: [
         {
           containerName: "sandbox-out-of-range",
           backendId: "docker",
+          sessionKey: "agent:main:main",
           createdAtMs: Date.now(),
           lastUsedAtMs: Number.MAX_SAFE_INTEGER,
           image: "openclaw-sandbox:bookworm-slim",
@@ -205,7 +235,9 @@ describe("maybePruneSandboxes", () => {
     await maybePruneSandboxes(buildPruneConfig());
 
     expect(backendMocks.removeRuntime).toHaveBeenCalledTimes(1);
-    expect(registryMocks.removeRegistryEntry).toHaveBeenCalledWith("sandbox-out-of-range");
+    expect(registryMocks.removeRegistryEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ containerName: "sandbox-out-of-range" }),
+    );
   });
 
   it("keeps browser runtime and registry state until bridge cleanup can retry", async () => {

--- a/src/agents/sandbox/prune.ts
+++ b/src/agents/sandbox/prune.ts
@@ -68,19 +68,19 @@ async function pruneSandboxRegistryEntries<TEntry extends SandboxRegistryEntry>(
     if (!shouldPruneSandboxEntry(resolvePruneConfig(params.config, entry), now, entry)) {
       continue;
     }
-    await withSandboxScopeLock(entry.sessionKey, async () => {
-      await tryWithSandboxRuntimeMutations([params.runtimeKey(entry)], async (lifecycle) => {
-        const current = (await params.read()).entries.find(
-          (candidate) => candidate.containerName === entry.containerName,
-        );
-        if (
-          !current ||
-          current.registryGeneration !== entry.registryGeneration ||
-          !shouldPruneSandboxEntry(resolvePruneConfig(params.config, current), now, current)
-        ) {
-          return;
-        }
-        try {
+    try {
+      await withSandboxScopeLock(entry.sessionKey, async () => {
+        await tryWithSandboxRuntimeMutations([params.runtimeKey(entry)], async (lifecycle) => {
+          const current = (await params.read()).entries.find(
+            (candidate) => candidate.containerName === entry.containerName,
+          );
+          if (
+            !current ||
+            current.registryGeneration !== entry.registryGeneration ||
+            !shouldPruneSandboxEntry(resolvePruneConfig(params.config, current), now, current)
+          ) {
+            return;
+          }
           await params.remove(current);
           if (
             !(await params.read()).entries.some(
@@ -89,19 +89,19 @@ async function pruneSandboxRegistryEntries<TEntry extends SandboxRegistryEntry>(
           ) {
             lifecycle.retire();
           }
-        } catch (error) {
-          const message =
-            error instanceof Error
-              ? error.message
-              : typeof error === "string"
-                ? error
-                : JSON.stringify(error);
-          defaultRuntime.error?.(
-            `Sandbox prune failed to remove ${entry.containerName}: ${message ?? "unknown error"}`,
-          );
-        }
+        });
       });
-    });
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : typeof error === "string"
+            ? error
+            : JSON.stringify(error);
+      defaultRuntime.error?.(
+        `Sandbox prune failed to remove ${entry.containerName}: ${message ?? "unknown error"}`,
+      );
+    }
   }
 }
 

--- a/src/agents/sandbox/prune.ts
+++ b/src/agents/sandbox/prune.ts
@@ -5,26 +5,38 @@ import { asDateTimestampMs } from "@openclaw/normalization-core/number-coercion"
  * Removes stale runtime containers and browser bridges on a best-effort schedule.
  */
 import { getRuntimeConfig } from "../../config/config.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { defaultRuntime } from "../../runtime.js";
 import { getSandboxBackendManager, usesSandboxRuntimeReservations } from "./backend.js";
 import { stopCachedBrowserBridgesForContainer } from "./browser-bridges.js";
+import { resolveSandboxConfigForAgent } from "./config.js";
 import { dockerSandboxBackendManager } from "./docker-backend.js";
 import {
   readBrowserRegistry,
   readRegistry,
-  removeBrowserRegistryEntry,
+  removeBrowserRegistryEntryIfUnchanged,
   removeSandboxRegistryRuntime,
   type SandboxBrowserRegistryEntry,
   type SandboxRegistryEntry,
 } from "./registry.js";
+import {
+  resolveSandboxRuntimeActivityKey,
+  tryWithSandboxRuntimeMutations,
+} from "./runtime-activity.js";
+import { withSandboxScopeLock } from "./scope-lock.js";
+import { resolveSandboxAgentId } from "./shared.js";
 import type { SandboxConfig } from "./types.js";
 
 let lastPruneAtMs = 0;
 
 type PruneableRegistryEntry = Pick<
   SandboxRegistryEntry,
-  "containerName" | "backendId" | "createdAtMs" | "lastUsedAtMs"
+  "containerName" | "backendId" | "sessionKey" | "createdAtMs" | "lastUsedAtMs"
 >;
+
+function resolvePruneConfig(config: OpenClawConfig, entry: PruneableRegistryEntry) {
+  return resolveSandboxConfigForAgent(config, resolveSandboxAgentId(entry.sessionKey));
+}
 
 function shouldPruneSandboxEntry(cfg: SandboxConfig, now: number, entry: PruneableRegistryEntry) {
   const idleHours = cfg.prune.idleHours;
@@ -45,45 +57,66 @@ function shouldPruneSandboxEntry(cfg: SandboxConfig, now: number, entry: Pruneab
 
 /** Removes expired registry entries and their backing runtime resources. */
 async function pruneSandboxRegistryEntries<TEntry extends SandboxRegistryEntry>(params: {
-  cfg: SandboxConfig;
+  config: OpenClawConfig;
+  runtimeKey: (entry: TEntry) => string;
   read: () => Promise<{ entries: TEntry[] }>;
-  remove: (
-    entry: TEntry,
-    shouldRemove: (current: SandboxRegistryEntry) => boolean,
-  ) => Promise<void>;
+  remove: (entry: TEntry) => Promise<void>;
 }) {
   const now = Date.now();
-  if (params.cfg.prune.idleHours === 0 && params.cfg.prune.maxAgeDays === 0) {
-    return;
-  }
   const registry = await params.read();
   for (const entry of registry.entries) {
-    if (!shouldPruneSandboxEntry(params.cfg, now, entry)) {
+    if (!shouldPruneSandboxEntry(resolvePruneConfig(params.config, entry), now, entry)) {
       continue;
     }
-    try {
-      await params.remove(entry, (current) => shouldPruneSandboxEntry(params.cfg, now, current));
-    } catch (error) {
-      const message =
-        error instanceof Error
-          ? error.message
-          : typeof error === "string"
-            ? error
-            : JSON.stringify(error);
-      defaultRuntime.error?.(
-        `Sandbox prune failed to remove ${entry.containerName}: ${message ?? "unknown error"}`,
-      );
-    }
+    await withSandboxScopeLock(entry.sessionKey, async () => {
+      await tryWithSandboxRuntimeMutations([params.runtimeKey(entry)], async (lifecycle) => {
+        const current = (await params.read()).entries.find(
+          (candidate) => candidate.containerName === entry.containerName,
+        );
+        if (
+          !current ||
+          current.registryGeneration !== entry.registryGeneration ||
+          !shouldPruneSandboxEntry(resolvePruneConfig(params.config, current), now, current)
+        ) {
+          return;
+        }
+        try {
+          await params.remove(current);
+          if (
+            !(await params.read()).entries.some(
+              (candidate) => candidate.containerName === current.containerName,
+            )
+          ) {
+            lifecycle.retire();
+          }
+        } catch (error) {
+          const message =
+            error instanceof Error
+              ? error.message
+              : typeof error === "string"
+                ? error
+                : JSON.stringify(error);
+          defaultRuntime.error?.(
+            `Sandbox prune failed to remove ${entry.containerName}: ${message ?? "unknown error"}`,
+          );
+        }
+      });
+    });
   }
 }
 
 /** Prunes ordinary sandbox runtime containers from the configured backend manager. */
-async function pruneSandboxContainers(cfg: SandboxConfig) {
-  const config = getRuntimeConfig();
+async function pruneSandboxContainers(config: OpenClawConfig) {
   await pruneSandboxRegistryEntries<SandboxRegistryEntry>({
-    cfg,
+    config,
+    runtimeKey: (entry) =>
+      resolveSandboxRuntimeActivityKey(
+        entry.backendId ?? "docker",
+        entry.containerName,
+        entry.backendTarget?.key,
+      ),
     read: readRegistry,
-    remove: (entry, shouldRemove) =>
+    remove: (entry) =>
       removeSandboxRegistryRuntime(
         entry,
         async (current) => {
@@ -94,19 +127,22 @@ async function pruneSandboxContainers(cfg: SandboxConfig) {
               `Sandbox backend "${backendId}" is unavailable; enable its plugin before removing this runtime.`,
             );
           }
-          await manager.removeRuntime({ entry: current, config });
+          await manager.removeRuntime({
+            entry: current,
+            config,
+            agentId: resolveSandboxAgentId(current.sessionKey),
+          });
         },
         {
           reserveRuntime: usesSandboxRuntimeReservations(entry.backendId ?? "docker"),
-          shouldRemove,
+          shouldRemove: (current) => current.registryGeneration === entry.registryGeneration,
         },
       ),
   });
 }
 
 /** Prunes browser bridge containers and closes matching in-process bridge servers. */
-async function pruneSandboxBrowsers(cfg: SandboxConfig) {
-  const config = getRuntimeConfig();
+async function pruneSandboxBrowsers(config: OpenClawConfig) {
   await pruneSandboxRegistryEntries<
     SandboxBrowserRegistryEntry & {
       backendId?: string;
@@ -114,7 +150,8 @@ async function pruneSandboxBrowsers(cfg: SandboxConfig) {
       configLabelKind?: string;
     }
   >({
-    cfg,
+    config,
+    runtimeKey: (entry) => resolveSandboxRuntimeActivityKey("docker", entry.containerName),
     read: readBrowserRegistry,
     remove: async (entry) => {
       await stopCachedBrowserBridgesForContainer(entry.containerName);
@@ -127,21 +164,22 @@ async function pruneSandboxBrowsers(cfg: SandboxConfig) {
         },
         config,
       });
-      await removeBrowserRegistryEntry(entry.containerName);
+      await removeBrowserRegistryEntryIfUnchanged(entry);
     },
   });
 }
 
 /** Runs sandbox pruning at most once per throttle window. */
-export async function maybePruneSandboxes(cfg: SandboxConfig) {
+export async function maybePruneSandboxes(_cfg: SandboxConfig) {
   const now = Date.now();
   if (now - lastPruneAtMs < 5 * 60 * 1000) {
     return;
   }
   lastPruneAtMs = now;
   try {
-    await pruneSandboxContainers(cfg);
-    await pruneSandboxBrowsers(cfg);
+    const config = getRuntimeConfig();
+    await pruneSandboxContainers(config);
+    await pruneSandboxBrowsers(config);
   } catch (error) {
     const message =
       error instanceof Error

--- a/src/agents/sandbox/registry.test.ts
+++ b/src/agents/sandbox/registry.test.ts
@@ -139,6 +139,65 @@ describe("registry race safety", () => {
     });
   });
 
+  it("preserves the physical runtime locator across usage updates", async () => {
+    await updateRegistry(
+      containerEntry({
+        backendId: "ssh",
+        cleanupMetadata: {
+          locatorVersion: "1",
+          target: "original.example",
+          workspaceRoot: "/srv/original",
+        },
+      }),
+    );
+    await updateRegistry(
+      containerEntry({
+        backendId: "ssh",
+        lastUsedAtMs: 2,
+        cleanupMetadata: {
+          locatorVersion: "1",
+          target: "replacement.example",
+          workspaceRoot: "/srv/replacement",
+        },
+      }),
+    );
+
+    await expect(readRegistryEntry("container-a")).resolves.toMatchObject({
+      lastUsedAtMs: 2,
+      cleanupMetadata: {
+        locatorVersion: "1",
+        target: "original.example",
+        workspaceRoot: "/srv/original",
+      },
+    });
+  });
+
+  it("does not infer a legacy cleanup locator from current configuration after restart", async () => {
+    const entry = containerEntry({ backendId: "ssh" });
+    await updateRegistry(entry);
+    await updateRegistry({
+      ...entry,
+      lastUsedAtMs: 2,
+      cleanupMetadata: {
+        locatorVersion: "1",
+        target: "changed.example",
+        workspaceRoot: "/srv/changed",
+      },
+    });
+    closeOpenClawStateDatabaseForTest();
+    expect((await readRegistryEntry(entry.containerName))?.cleanupMetadata).toBeUndefined();
+    await updateRegistry({
+      ...entry,
+      lastUsedAtMs: 3,
+      cleanupMetadata: {
+        locatorVersion: "1",
+        target: "original.example",
+        workspaceRoot: "/srv/original",
+      },
+    });
+    expect((await readRegistryEntry(entry.containerName))?.cleanupMetadata).toBeUndefined();
+  });
+
   it("reads registered runtime IDs for one backend and scope newest first", async () => {
     await updateRegistry(
       containerEntry({

--- a/src/agents/sandbox/registry.ts
+++ b/src/agents/sandbox/registry.ts
@@ -4,6 +4,7 @@
  * Tracks runtime and browser containers in the shared state DB.
  */
 import { createHash } from "node:crypto";
+import { stableStringify } from "@openclaw/normalization-core";
 import type { Insertable, Selectable, Updateable } from "kysely";
 import { withFileLock } from "../../infra/file-lock.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
@@ -29,6 +30,9 @@ export type SandboxRegistryEntry = {
   workspaceDir?: string;
   /** Present only for backends that reserve their generation before provisioning. */
   runtimeState?: "pending" | "ready" | "removing" | "removing-pending";
+  /** Existing row revision used to fence destructive lifecycle cleanup. */
+  registryGeneration?: number;
+  cleanupMetadata?: Record<string, string>;
 };
 
 type SandboxRegistry = {
@@ -44,6 +48,8 @@ export type SandboxBrowserRegistryEntry = {
   configHash?: string;
   cdpPort: number;
   noVncPort?: number;
+  /** Existing row revision used to fence destructive lifecycle cleanup. */
+  registryGeneration?: number;
 };
 
 type SandboxBrowserRegistry = {
@@ -57,6 +63,26 @@ type SandboxRegistryDatabase = Pick<OpenClawStateKyselyDatabase, "sandbox_regist
 type SandboxRegistryRow = Selectable<SandboxRegistryTable>;
 type SandboxRegistryInsert = Insertable<SandboxRegistryTable>;
 type SandboxRegistryUpdate = Updateable<SandboxRegistryTable>;
+
+/** Stable persisted identity for one physical runtime lifecycle. */
+export function resolveSandboxRegistryLifecycleId(entry: SandboxRegistryEntry): string {
+  const { lastUsedAtMs: _lastUsedAtMs, registryGeneration: _generation, ...identity } = entry;
+  return stableStringify(identity);
+}
+
+/** Stable persisted identity for one physical browser-runtime lifecycle. */
+export function resolveSandboxBrowserRegistryLifecycleId(
+  entry: SandboxBrowserRegistryEntry,
+): string {
+  // noVNC visibility can change while the same CDP runtime and bridge remain active.
+  const {
+    lastUsedAtMs: _lastUsedAtMs,
+    registryGeneration: _generation,
+    noVncPort: _noVncPort,
+    ...identity
+  } = entry;
+  return stableStringify(identity);
+}
 
 function getSandboxRegistryKysely(db: import("node:sqlite").DatabaseSync) {
   return getNodeSqliteKysely<SandboxRegistryDatabase>(db);
@@ -96,6 +122,7 @@ function rowToContainerEntry(row: SandboxRegistryRow): SandboxRegistryEntry | nu
     ...(row.runtime_label != null ? { runtimeLabel: row.runtime_label } : {}),
     ...(row.config_label_kind != null ? { configLabelKind: row.config_label_kind } : {}),
     ...(row.config_hash != null ? { configHash: row.config_hash } : {}),
+    registryGeneration: row.updated_at,
   } as SandboxRegistryEntry);
 }
 
@@ -117,21 +144,24 @@ function rowToBrowserEntry(row: SandboxRegistryRow): SandboxBrowserRegistryEntry
     cdpPort: row.cdp_port ?? Number(payload.cdpPort ?? 0),
     ...(row.no_vnc_port != null ? { noVncPort: row.no_vnc_port } : {}),
     ...(row.config_hash != null ? { configHash: row.config_hash } : {}),
+    registryGeneration: row.updated_at,
   } as SandboxBrowserRegistryEntry;
 }
 
 function containerEntryToRow(entry: SandboxRegistryEntry, existing?: SandboxRegistryEntry | null) {
   const next: SandboxRegistryEntry = {
     ...entry,
-    backendId: entry.backendId ?? existing?.backendId,
-    backendTarget: entry.backendTarget ?? existing?.backendTarget,
-    runtimeLabel: entry.runtimeLabel ?? existing?.runtimeLabel,
+    backendId: existing?.backendId ?? entry.backendId,
+    backendTarget: existing?.backendTarget ?? entry.backendTarget,
+    runtimeLabel: existing?.runtimeLabel ?? entry.runtimeLabel,
+    sessionKey: existing?.sessionKey ?? entry.sessionKey,
     createdAtMs: existing?.createdAtMs ?? entry.createdAtMs,
     image: existing?.image ?? entry.image,
     configLabelKind: entry.configLabelKind ?? existing?.configLabelKind,
     configHash: entry.configHash ?? existing?.configHash,
     runtimeState: entry.runtimeState ?? existing?.runtimeState,
     workspaceDir: existing?.workspaceDir ?? entry.workspaceDir,
+    cleanupMetadata: existing ? existing.cleanupMetadata : entry.cleanupMetadata,
   };
   return {
     registry_kind: "container",
@@ -146,8 +176,8 @@ function containerEntryToRow(entry: SandboxRegistryEntry, existing?: SandboxRegi
     config_hash: next.configHash ?? null,
     cdp_port: null,
     no_vnc_port: null,
-    entry_json: JSON.stringify(next),
-    updated_at: Date.now(),
+    entry_json: JSON.stringify({ ...next, registryGeneration: undefined }),
+    updated_at: Math.max(Date.now(), (existing?.registryGeneration ?? 0) + 1),
   } satisfies SandboxRegistryInsert;
 }
 
@@ -174,8 +204,8 @@ function browserEntryToRow(
     config_hash: next.configHash ?? null,
     cdp_port: next.cdpPort,
     no_vnc_port: next.noVncPort ?? null,
-    entry_json: JSON.stringify(next),
-    updated_at: Date.now(),
+    entry_json: JSON.stringify({ ...next, registryGeneration: undefined }),
+    updated_at: Math.max(Date.now(), (existing?.registryGeneration ?? 0) + 1),
   } satisfies SandboxRegistryInsert;
 }
 
@@ -290,16 +320,21 @@ function readRegistryRowFromDb(
   );
 }
 
-function removeRegistryRow(kind: SandboxRegistryKind, containerName: string): void {
-  runOpenClawStateWriteTransaction(({ db }) => {
+function removeRegistryRow(
+  kind: SandboxRegistryKind,
+  containerName: string,
+  registryGeneration?: number,
+): boolean {
+  return runOpenClawStateWriteTransaction(({ db }) => {
     const stateDb = getSandboxRegistryKysely(db);
-    executeSqliteQuerySync(
-      db,
-      stateDb
-        .deleteFrom("sandbox_registry_entries")
-        .where("registry_kind", "=", kind)
-        .where("container_name", "=", containerName),
-    );
+    let query = stateDb
+      .deleteFrom("sandbox_registry_entries")
+      .where("registry_kind", "=", kind)
+      .where("container_name", "=", containerName);
+    if (registryGeneration !== undefined) {
+      query = query.where("updated_at", "=", registryGeneration);
+    }
+    return executeSqliteQuerySync(db, query).numAffectedRows === 1n;
   });
 }
 
@@ -331,6 +366,14 @@ export async function readRegistryEntry(
   return entry ? normalizeSandboxRegistryEntry(entry) : null;
 }
 
+/** Reads one registered browser sandbox by container name. */
+export async function readBrowserRegistryEntry(
+  containerName: string,
+): Promise<SandboxBrowserRegistryEntry | null> {
+  const row = readRegistryRow("browser", containerName);
+  return row ? rowToBrowserEntry(row) : null;
+}
+
 /** Reads registered runtime IDs for one backend-owned sandbox scope, newest first. */
 export async function readRegisteredSandboxRuntimeIds(params: {
   backendId: string;
@@ -348,11 +391,12 @@ export function insertSandboxRegistryEntryIfMissing(entry: SandboxRegistryEntry)
 }
 
 /** Creates or updates one sandbox runtime registry entry, preserving immutable creation fields. */
-export async function updateRegistry(entry: SandboxRegistryEntry) {
+export async function updateRegistry(entry: SandboxRegistryEntry): Promise<void> {
   runOpenClawStateWriteTransaction(({ db }) => {
     const existingRow = readRegistryRowFromDb(db, "container", entry.containerName);
     const existing = existingRow ? rowToContainerEntry(existingRow) : null;
-    insertRegistryRow(db, containerEntryToRow(entry, existing));
+    const row = containerEntryToRow(entry, existing);
+    insertRegistryRow(db, row);
   });
 }
 
@@ -543,15 +587,24 @@ export function insertSandboxBrowserRegistryEntryIfMissing(
 }
 
 /** Creates or updates one browser sandbox registry entry, preserving immutable creation fields. */
-export async function updateBrowserRegistry(entry: SandboxBrowserRegistryEntry) {
-  runOpenClawStateWriteTransaction(({ db }) => {
+export async function updateBrowserRegistry(
+  entry: SandboxBrowserRegistryEntry,
+): Promise<SandboxBrowserRegistryEntry> {
+  return runOpenClawStateWriteTransaction(({ db }) => {
     const existingRow = readRegistryRowFromDb(db, "browser", entry.containerName);
     const existing = existingRow ? rowToBrowserEntry(existingRow) : null;
-    insertRegistryRow(db, browserEntryToRow(entry, existing));
+    const row = browserEntryToRow(entry, existing);
+    insertRegistryRow(db, row);
+    return rowToBrowserEntry(readRegistryRowFromDb(db, "browser", entry.containerName)!)!;
   });
 }
 
 /** Removes one browser sandbox registry entry by container name. */
 export async function removeBrowserRegistryEntry(containerName: string) {
   removeRegistryRow("browser", containerName);
+}
+
+/** Removes one browser row only if no use or reprovision updated it since the snapshot. */
+export async function removeBrowserRegistryEntryIfUnchanged(entry: SandboxBrowserRegistryEntry) {
+  return removeRegistryRow("browser", entry.containerName, entry.registryGeneration);
 }

--- a/src/agents/sandbox/runtime-activity.test.ts
+++ b/src/agents/sandbox/runtime-activity.test.ts
@@ -1,0 +1,201 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import type { SandboxBackendHandle } from "./backend-handle.types.js";
+import { SANDBOX_STATE_DIR } from "./constants.js";
+import {
+  coordinateSandboxBackendHandle,
+  resolveSandboxRuntimeActivityKey,
+  tryWithSandboxRuntimeMutations,
+} from "./runtime-activity.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function createHandle(runtimeId = "runtime"): SandboxBackendHandle {
+  return {
+    id: "test",
+    runtimeId,
+    runtimeLabel: runtimeId,
+    workdir: "/workspace",
+    async buildExecSpec() {
+      return { argv: ["true"], env: {}, stdinMode: "pipe-closed", finalizeToken: "raw" };
+    },
+    async finalizeExec() {},
+    async runShellCommand() {
+      return { stdout: Buffer.alloc(0), stderr: Buffer.alloc(0), code: 0 };
+    },
+  };
+}
+
+describe("sandbox runtime activity", () => {
+  it("makes active work visible to automatic pruning in another process", async () => {
+    const runtimeId = `cross-process-${process.pid}-${Date.now()}`;
+    const childSource = String.raw`
+      const { coordinateSandboxBackendHandle } = await import("./src/agents/sandbox/runtime-activity.ts");
+      const runtimeId = process.argv[1];
+      const backend = coordinateSandboxBackendHandle({
+        id: "test",
+        runtimeId,
+        runtimeLabel: runtimeId,
+        workdir: "/workspace",
+        async buildExecSpec() { return { argv: ["true"], env: {}, stdinMode: "pipe-closed" }; },
+        async runShellCommand() { return { stdout: Buffer.alloc(0), stderr: Buffer.alloc(0), code: 0 }; },
+      });
+      const spec = await backend.buildExecSpec({ command: "hold", env: {}, usePty: false });
+      process.stdout.write("ready\n");
+      process.stdin.resume();
+      process.stdin.once("end", async () => {
+        await backend.finalizeExec?.({ status: "completed", exitCode: 0, timedOut: false, token: spec.finalizeToken });
+        process.stdout.write("released\n");
+      });
+    `;
+    const child = spawn(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "--eval", childSource, runtimeId],
+      {
+        cwd: process.cwd(),
+        env: { ...process.env, OPENCLAW_STATE_DIR: path.dirname(SANDBOX_STATE_DIR) },
+        stdio: ["pipe", "pipe", "inherit"],
+      },
+    );
+    await once(child.stdout, "data");
+    const key = resolveSandboxRuntimeActivityKey("test", runtimeId);
+
+    await expect(tryWithSandboxRuntimeMutations([key], async () => undefined)).resolves.toEqual({
+      acquired: false,
+    });
+
+    child.stdin.end();
+    await once(child.stdout, "data");
+    await once(child, "exit");
+    await expect(tryWithSandboxRuntimeMutations([key], async () => "removed")).resolves.toEqual({
+      acquired: true,
+      value: "removed",
+    });
+  });
+
+  it("admits concurrent activity for one runtime across processes", async () => {
+    const runtimeId = `concurrent-${process.pid}-${Date.now()}`;
+    const childSource = String.raw`
+      const { coordinateSandboxBackendHandle } = await import("./src/agents/sandbox/runtime-activity.ts");
+      const runtimeId = process.argv[1];
+      const backend = coordinateSandboxBackendHandle({
+        id: "test",
+        runtimeId,
+        runtimeLabel: runtimeId,
+        workdir: "/workspace",
+        async buildExecSpec() { return { argv: ["true"], env: {}, stdinMode: "pipe-closed" }; },
+        async runShellCommand() { return { stdout: Buffer.alloc(0), stderr: Buffer.alloc(0), code: 0 }; },
+      });
+      const spec = await backend.buildExecSpec({ command: "hold", env: {}, usePty: false });
+      process.stdout.write("ready\n");
+      process.stdin.resume();
+      process.stdin.once("end", async () => {
+        await backend.finalizeExec?.({ status: "completed", exitCode: 0, timedOut: false, token: spec.finalizeToken });
+      });
+    `;
+    const start = () =>
+      spawn(
+        process.execPath,
+        ["--import", "tsx", "--input-type=module", "--eval", childSource, runtimeId],
+        {
+          cwd: process.cwd(),
+          env: { ...process.env, OPENCLAW_STATE_DIR: path.dirname(SANDBOX_STATE_DIR) },
+          stdio: ["pipe", "pipe", "inherit"],
+        },
+      );
+    const first = start();
+    await once(first.stdout, "data");
+    const second = start();
+    await expect(
+      Promise.race([
+        once(second.stdout, "data").then(() => true),
+        new Promise<false>((resolve) => {
+          setTimeout(() => resolve(false), 2_000);
+        }),
+      ]),
+    ).resolves.toBe(true);
+
+    first.stdin.end();
+    second.stdin.end();
+    await Promise.all([once(first, "exit"), once(second, "exit")]);
+  });
+
+  it("rejects a handle after its shared runtime generation changes", async () => {
+    const dir = tempDirs.make("openclaw-runtime-generation-");
+    const generationPath = path.join(dir, "generation");
+    await fs.writeFile(generationPath, "first", "utf8");
+    const backend = coordinateSandboxBackendHandle(
+      createHandle(`shared-${Date.now()}`),
+      async () => {
+        if ((await fs.readFile(generationPath, "utf8")) !== "first") {
+          throw new Error("Sandbox runtime was recycled before the operation started.");
+        }
+      },
+    );
+
+    await fs.writeFile(generationPath, "second", "utf8");
+    await expect(
+      backend.buildExecSpec({ command: "stale", env: {}, usePty: false }),
+    ).rejects.toThrow("was recycled");
+  });
+
+  it("retires a runtime generation after active execution releases", async () => {
+    const runtimeId = `retire-${Date.now()}`;
+    const raw = createHandle(runtimeId);
+    const backend = coordinateSandboxBackendHandle(raw);
+    const first = await backend.buildExecSpec({ command: "first", env: {}, usePty: false });
+    const key = resolveSandboxRuntimeActivityKey(backend.id, backend.runtimeId);
+    await expect(tryWithSandboxRuntimeMutations([key], async () => undefined)).resolves.toEqual({
+      acquired: false,
+    });
+    await backend.finalizeExec?.({
+      status: "completed",
+      exitCode: 0,
+      timedOut: false,
+      token: first.finalizeToken,
+    });
+    await expect(
+      tryWithSandboxRuntimeMutations([key], async (lifecycle) => lifecycle.retire()),
+    ).resolves.toMatchObject({ acquired: true });
+    await expect(
+      backend.buildExecSpec({ command: "stale", env: {}, usePty: false }),
+    ).rejects.toThrow("was recycled");
+    const fresh = coordinateSandboxBackendHandle(createHandle(runtimeId));
+    const freshExec = await fresh.buildExecSpec({ command: "fresh", env: {}, usePty: false });
+    expect(freshExec).toMatchObject({ argv: ["true"] });
+    await fresh.finalizeExec?.({
+      status: "completed",
+      exitCode: 0,
+      timedOut: false,
+      token: freshExec.finalizeToken,
+    });
+  });
+
+  it("releases the execution lease when backend finalization fails", async () => {
+    const raw = createHandle(`finalize-${Date.now()}`);
+    raw.finalizeExec = vi.fn(async () => {
+      throw new Error("finalize failed");
+    });
+    const backend = coordinateSandboxBackendHandle(raw);
+    const exec = await backend.buildExecSpec({ command: "true", env: {}, usePty: false });
+
+    await expect(
+      backend.finalizeExec?.({
+        status: "failed",
+        exitCode: 1,
+        timedOut: false,
+        token: exec.finalizeToken,
+      }),
+    ).rejects.toThrow("finalize failed");
+    await expect(
+      tryWithSandboxRuntimeMutations(
+        [resolveSandboxRuntimeActivityKey(backend.id, backend.runtimeId)],
+        async () => "removed",
+      ),
+    ).resolves.toEqual({ acquired: true, value: "removed" });
+  });
+});

--- a/src/agents/sandbox/runtime-activity.ts
+++ b/src/agents/sandbox/runtime-activity.ts
@@ -1,0 +1,345 @@
+/** Coordinates admitted sandbox operations with destructive runtime lifecycle changes. */
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { createAbortError } from "../../infra/abort-signal.js";
+import { sleepWithAbort } from "../../infra/backoff.js";
+import {
+  acquireFileLock,
+  FILE_LOCK_TIMEOUT_ERROR_CODE,
+  type FileLockHandle,
+} from "../../infra/file-lock.js";
+import { resolveGlobalMap } from "../../shared/global-singleton.js";
+import type {
+  SandboxBackendCommandParams,
+  SandboxBackendHandle,
+  SandboxBackendExecSpec,
+} from "./backend-handle.types.js";
+import { SANDBOX_STATE_DIR } from "./constants.js";
+import { resolveSandboxFileIdentity, SANDBOX_FILE_IDENTITY } from "./file-mutation-identity.js";
+import type { SandboxFsBridge } from "./fs-bridge.types.js";
+import { hashTextSha256 } from "./hash.js";
+
+type RuntimeActivityLease = { release(): Promise<void> };
+type RuntimeActivityState = { generation: number; retired: boolean };
+type RuntimeGenerationCheck = () => Promise<void>;
+type CoordinatedExec = {
+  lease: RuntimeActivityLease;
+  rawToken: unknown;
+};
+
+const runtimeActivityStates = resolveGlobalMap<string, RuntimeActivityState>(
+  Symbol.for("openclaw.sandboxRuntimeActivityStates"),
+  "close-and-restart",
+);
+const coordinatedExecs = new Map<object, CoordinatedExec>();
+const coordinatedHandles = new WeakMap<SandboxBackendHandle, SandboxBackendHandle>();
+const RETRY_MS = 25;
+const STALE_MS = 60 * 60 * 1000;
+const LOCK_OPTIONS = {
+  retries: { retries: 0, factor: 1, minTimeout: 0, maxTimeout: 0 },
+  stale: STALE_MS,
+  staleRecovery: "fail-closed",
+} as const;
+
+export function resolveSandboxRuntimeActivityKey(
+  backendId: string,
+  runtimeId: string,
+  target?: string,
+): string {
+  return JSON.stringify([backendId.trim().toLowerCase(), target ?? "local", runtimeId]);
+}
+
+function getRuntimeActivityState(key: string): RuntimeActivityState {
+  const state = runtimeActivityStates.get(key) ?? { generation: 0, retired: false };
+  runtimeActivityStates.set(key, state);
+  return state;
+}
+
+function lockDirectory(): string {
+  return path.join(SANDBOX_STATE_DIR, "locks", "runtime");
+}
+
+function lockPath(key: string, suffix: string): string {
+  return path.join(lockDirectory(), `runtime-${hashTextSha256(key)}.${suffix}.jsonl`);
+}
+
+function runtimeActivityPath(key: string): string {
+  return lockPath(key, `activity-${randomUUID()}`);
+}
+
+function isLockBusy(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === FILE_LOCK_TIMEOUT_ERROR_CODE
+  );
+}
+
+async function acquireRuntimeGate(
+  key: string,
+  wait: boolean,
+  signal?: AbortSignal,
+): Promise<FileLockHandle | null> {
+  while (true) {
+    if (signal?.aborted) {
+      throw createAbortError("Sandbox runtime operation was aborted");
+    }
+    try {
+      return await acquireFileLock(lockPath(key, "gate"), LOCK_OPTIONS);
+    } catch (error) {
+      if (!isLockBusy(error)) {
+        throw error;
+      }
+      if (!wait) {
+        return null;
+      }
+      await sleepWithAbort(RETRY_MS, signal);
+    }
+  }
+}
+
+function assertLocalGeneration(key: string, generation: number): void {
+  const state = getRuntimeActivityState(key);
+  if (state.retired || state.generation !== generation) {
+    throw new Error("Sandbox runtime was recycled before the operation started.");
+  }
+}
+
+async function assertCurrentGeneration(
+  key: string,
+  generation: number,
+  assertSharedCurrent?: RuntimeGenerationCheck,
+): Promise<void> {
+  assertLocalGeneration(key, generation);
+  await assertSharedCurrent?.();
+  assertLocalGeneration(key, generation);
+}
+
+async function acquireActivity(
+  key: string,
+  generation: number,
+  assertSharedCurrent?: RuntimeGenerationCheck,
+  signal?: AbortSignal,
+  wait = true,
+): Promise<RuntimeActivityLease | null> {
+  await assertCurrentGeneration(key, generation, assertSharedCurrent);
+  const gate = await acquireRuntimeGate(key, wait, signal);
+  if (!gate) {
+    return null;
+  }
+  let activity: FileLockHandle | undefined;
+  try {
+    activity = await acquireFileLock(runtimeActivityPath(key), LOCK_OPTIONS);
+    await assertCurrentGeneration(key, generation, assertSharedCurrent);
+    return activity;
+  } catch (error) {
+    await activity?.release();
+    throw error;
+  } finally {
+    await gate.release();
+  }
+}
+
+async function withRuntimeActivity<T>(
+  key: string,
+  generation: number,
+  assertSharedCurrent: RuntimeGenerationCheck | undefined,
+  signal: AbortSignal | undefined,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const lease = await acquireActivity(key, generation, assertSharedCurrent, signal);
+  try {
+    return await operation();
+  } finally {
+    await lease?.release();
+  }
+}
+
+async function hasActiveRuntimeLease(key: string): Promise<boolean> {
+  let names: string[];
+  try {
+    names = await fs.readdir(lockDirectory());
+  } catch (error) {
+    if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+  const prefix = `runtime-${hashTextSha256(key)}.activity-`;
+  for (const name of names) {
+    if (!name.startsWith(prefix) || !name.endsWith(".jsonl.lock")) {
+      continue;
+    }
+    try {
+      const probe = await acquireFileLock(
+        path.join(lockDirectory(), name.slice(0, -".lock".length)),
+        LOCK_OPTIONS,
+      );
+      await probe.release();
+    } catch (error) {
+      if (isLockBusy(error)) {
+        return true;
+      }
+      throw error;
+    }
+  }
+  return false;
+}
+
+async function releaseLocks(leases: readonly FileLockHandle[]): Promise<void> {
+  for (const lease of leases.toReversed()) {
+    await lease.release();
+  }
+}
+
+export async function tryWithSandboxRuntimeMutations<T>(
+  keys: readonly string[],
+  mutate: (lifecycle: { retire(): void }) => Promise<T>,
+): Promise<{ acquired: false } | { acquired: true; value: T }> {
+  const uniqueKeys = Array.from(new Set(keys)).toSorted();
+  const leases: FileLockHandle[] = [];
+  try {
+    for (const key of uniqueKeys) {
+      const lease = await acquireRuntimeGate(key, false);
+      if (!lease) {
+        return { acquired: false };
+      }
+      leases.push(lease);
+    }
+    if ((await Promise.all(uniqueKeys.map(hasActiveRuntimeLease))).some(Boolean)) {
+      return { acquired: false };
+    }
+    const retire = () => {
+      for (const key of uniqueKeys) {
+        getRuntimeActivityState(key).retired = true;
+      }
+    };
+    return { acquired: true, value: await mutate({ retire }) };
+  } finally {
+    await releaseLocks(leases);
+  }
+}
+
+export async function tryAcquireSandboxRuntimeActivity(
+  key: string,
+  generation: number,
+  assertSharedCurrent?: RuntimeGenerationCheck,
+): Promise<RuntimeActivityLease | null> {
+  return await acquireActivity(key, generation, assertSharedCurrent, undefined, false);
+}
+
+function wrapFsBridge(
+  key: string,
+  generation: number,
+  assertSharedCurrent: RuntimeGenerationCheck | undefined,
+  bridge: SandboxFsBridge,
+): SandboxFsBridge {
+  const wrap =
+    <TParams extends { signal?: AbortSignal }, TResult>(
+      operation: (params: TParams) => Promise<TResult>,
+    ) =>
+    async (params: TParams) =>
+      await withRuntimeActivity(key, generation, assertSharedCurrent, params.signal, () =>
+        operation(params),
+      );
+  const coordinated = {
+    resolvePath: (params: Parameters<SandboxFsBridge["resolvePath"]>[0]) =>
+      bridge.resolvePath(params),
+    [SANDBOX_FILE_IDENTITY]: wrap(async (params: Parameters<SandboxFsBridge["readFile"]>[0]) =>
+      resolveSandboxFileIdentity({ bridge, ...params }),
+    ),
+    ...(bridge.resolvePinnedMutationTarget
+      ? { resolvePinnedMutationTarget: wrap(bridge.resolvePinnedMutationTarget.bind(bridge)) }
+      : {}),
+    ...(bridge.readDirectory ? { readDirectory: wrap(bridge.readDirectory.bind(bridge)) } : {}),
+    readFile: wrap(bridge.readFile.bind(bridge)),
+    ...(bridge.copyFile ? { copyFile: wrap(bridge.copyFile.bind(bridge)) } : {}),
+    writeFile: wrap(bridge.writeFile.bind(bridge)),
+    ...(bridge.createFileExclusive
+      ? { createFileExclusive: wrap(bridge.createFileExclusive.bind(bridge)) }
+      : {}),
+    mkdirp: wrap(bridge.mkdirp.bind(bridge)),
+    remove: wrap(bridge.remove.bind(bridge)),
+    rename: wrap(bridge.rename.bind(bridge)),
+    stat: wrap(bridge.stat.bind(bridge)),
+  };
+  return coordinated;
+}
+
+export function coordinateSandboxBackendHandle(
+  handle: SandboxBackendHandle,
+  assertSharedCurrent?: RuntimeGenerationCheck,
+): SandboxBackendHandle {
+  const existing = coordinatedHandles.get(handle);
+  if (existing) {
+    return existing;
+  }
+  const key =
+    handle.runtimeActivityKey ?? resolveSandboxRuntimeActivityKey(handle.id, handle.runtimeId);
+  const generation = activateSandboxRuntimeActivity(key);
+  const coordinated: SandboxBackendHandle = {
+    ...handle,
+    ...(handle.validateWorkdir
+      ? {
+          validateWorkdir: (workdir) =>
+            withRuntimeActivity(key, generation, assertSharedCurrent, undefined, () =>
+              handle.validateWorkdir!(workdir),
+            ),
+        }
+      : {}),
+    async buildExecSpec(params): Promise<SandboxBackendExecSpec> {
+      const lease = await acquireActivity(key, generation, assertSharedCurrent, params.signal);
+      try {
+        const spec = await handle.buildExecSpec(params);
+        const token = {};
+        coordinatedExecs.set(token, { lease: lease!, rawToken: spec.finalizeToken });
+        return { ...spec, finalizeToken: token };
+      } catch (error) {
+        await lease?.release();
+        throw error;
+      }
+    },
+    async finalizeExec(params) {
+      const tokenObject =
+        params.token && typeof params.token === "object" ? params.token : undefined;
+      const token = tokenObject ? coordinatedExecs.get(tokenObject) : undefined;
+      if (!token) {
+        await handle.finalizeExec?.(params);
+        return;
+      }
+      try {
+        await handle.finalizeExec?.({ ...params, token: token.rawToken });
+      } finally {
+        if (tokenObject) {
+          coordinatedExecs.delete(tokenObject);
+        }
+        await token.lease.release();
+      }
+    },
+    async runShellCommand(params: SandboxBackendCommandParams) {
+      return await withRuntimeActivity(key, generation, assertSharedCurrent, params.signal, () =>
+        handle.runShellCommand(params),
+      );
+    },
+    ...(handle.createFsBridge
+      ? {
+          createFsBridge: (params) =>
+            wrapFsBridge(key, generation, assertSharedCurrent, handle.createFsBridge!(params)),
+        }
+      : {}),
+  };
+  coordinatedHandles.set(handle, coordinated);
+  coordinatedHandles.set(coordinated, coordinated);
+  return coordinated;
+}
+
+export function activateSandboxRuntimeActivity(key: string): number {
+  const state = getRuntimeActivityState(key);
+  if (state.retired) {
+    state.retired = false;
+    state.generation += 1;
+  }
+  return state.generation;
+}

--- a/src/agents/sandbox/scope-lock.ts
+++ b/src/agents/sandbox/scope-lock.ts
@@ -1,0 +1,24 @@
+/** Serializes deterministic sandbox scope provisioning and cleanup across processes. */
+import path from "node:path";
+import { acquireFileLock } from "../../infra/file-lock.js";
+import { SANDBOX_STATE_DIR } from "./constants.js";
+import { hashTextSha256 } from "./hash.js";
+
+const RETRIES = 60 * 60 * 10;
+
+export async function withSandboxScopeLock<T>(scopeKey: string, run: () => Promise<T>): Promise<T> {
+  const key = scopeKey.trim() || "main";
+  const lock = await acquireFileLock(
+    path.join(SANDBOX_STATE_DIR, "locks", "scope", `scope-${hashTextSha256(key)}.jsonl`),
+    {
+      retries: { retries: RETRIES, factor: 1, minTimeout: 100, maxTimeout: 100 },
+      stale: 0,
+      staleRecovery: "remove-if-definitely-stale",
+    },
+  );
+  try {
+    return await run();
+  } finally {
+    await lock.release();
+  }
+}

--- a/src/agents/sandbox/ssh-backend.test.ts
+++ b/src/agents/sandbox/ssh-backend.test.ts
@@ -79,6 +79,14 @@ function createSession() {
   };
 }
 
+function createSshCleanupMetadata(params?: { target?: string; workspaceRoot?: string }) {
+  return {
+    locatorVersion: "1",
+    target: params?.target ?? "peter@example.com:2222",
+    workspaceRoot: params?.workspaceRoot ?? "/remote/openclaw",
+  };
+}
+
 const requireRecord = createRequireRecord("object", "expected-label");
 
 function requireMockRecordArg(mock: ReturnType<typeof vi.fn>, callIndex: number, label: string) {
@@ -343,6 +351,7 @@ describe("ssh sandbox backend", () => {
           lastUsedAtMs: 1,
           image: "peter@example.com:2222",
           configLabelKind: "Target",
+          cleanupMetadata: createSshCleanupMetadata(),
         },
         config,
       }),
@@ -378,6 +387,7 @@ describe("ssh sandbox backend", () => {
         lastUsedAtMs: 1,
         image: "peter@example.com:2222",
         configLabelKind: "Target",
+        cleanupMetadata: createSshCleanupMetadata(),
       },
       config,
     });
@@ -385,7 +395,10 @@ describe("ssh sandbox backend", () => {
     expect(sshMocks.createSshSandboxSessionFromSettings).toHaveBeenCalledTimes(1);
   });
 
-  it("removes runtimes by deleting the remote scope root", async () => {
+  it("removes runtimes through their recorded SSH target and workspace root", async () => {
+    const config = createConfig();
+    config.agents!.defaults!.sandbox!.ssh!.target = "new@example.com:22";
+    config.agents!.defaults!.sandbox!.ssh!.workspaceRoot = "/new/openclaw";
     await sshSandboxBackendManager.removeRuntime({
       entry: {
         containerName: "openclaw-ssh-worker-abcd1234",
@@ -396,13 +409,43 @@ describe("ssh sandbox backend", () => {
         lastUsedAtMs: 1,
         image: "peter@example.com:2222",
         configLabelKind: "Target",
+        cleanupMetadata: createSshCleanupMetadata({
+          target: "old@example.com:2222",
+          workspaceRoot: "/old/openclaw",
+        }),
       },
-      config: createConfig(),
+      config,
     });
 
+    const sessionSettings = requireMockRecordArg(
+      sshMocks.createSshSandboxSessionFromSettings,
+      0,
+      "ssh session settings",
+    );
+    expect(sessionSettings.target).toBe("old@example.com:2222");
     const commandParams = requireSshRunCommandParams();
     expect(commandParams.allowFailure).toBe(true);
     expect(commandParams.remoteCommand).toContain('rm -rf -- "$1"');
+    expect(commandParams.remoteCommand).toContain("/old/openclaw/openclaw-ssh-agent-worker");
+  });
+
+  it("refuses to remove an SSH runtime without an authoritative locator", async () => {
+    await expect(
+      sshSandboxBackendManager.removeRuntime({
+        entry: {
+          containerName: "openclaw-ssh-worker-abcd1234",
+          backendId: "ssh",
+          runtimeLabel: "openclaw-ssh-worker-abcd1234",
+          sessionKey: "agent:worker",
+          createdAtMs: 1,
+          lastUsedAtMs: 1,
+          image: "peter@example.com:2222",
+          configLabelKind: "Target",
+        },
+        config: createConfig(),
+      }),
+    ).rejects.toThrow("has no authoritative cleanup locator");
+    expect(sshMocks.createSshSandboxSessionFromSettings).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -428,6 +471,7 @@ describe("ssh sandbox backend", () => {
             lastUsedAtMs: 1,
             image: "peter@example.com:2222",
             configLabelKind: "Target",
+            cleanupMetadata: createSshCleanupMetadata(),
           },
           config: createConfig(),
         }),

--- a/src/agents/sandbox/ssh-backend.ts
+++ b/src/agents/sandbox/ssh-backend.ts
@@ -67,18 +67,22 @@ export const sshSandboxBackendManager: SandboxBackendManager = {
   async removeRuntime({ entry, config, agentId }) {
     const effectiveAgentId = agentId ?? resolveSandboxAgentId(entry.sessionKey);
     const cfg = resolveSandboxConfigForAgent(config, effectiveAgentId);
-    if (cfg.backend !== "ssh" || !cfg.ssh.target) {
-      return;
+    const target = entry.cleanupMetadata?.target?.trim();
+    const workspaceRoot = entry.cleanupMetadata?.workspaceRoot?.trim();
+    if (entry.cleanupMetadata?.locatorVersion !== "1" || !target || !workspaceRoot) {
+      throw new Error(
+        `SSH sandbox runtime ${entry.containerName} has no authoritative cleanup locator; remove the recorded runtime manually after verifying its original target.`,
+      );
     }
     assertSshSandboxSecretOwnerAvailable({
       config,
       scope: cfg.scope,
       agentId: effectiveAgentId,
     });
-    const runtimePaths = resolveSshRuntimePaths(cfg.ssh.workspaceRoot, entry.sessionKey);
+    const runtimePaths = resolveSshRuntimePaths(workspaceRoot, entry.sessionKey);
     const session = await createSshSandboxSessionFromSettings({
       ...cfg.ssh,
-      target: cfg.ssh.target,
+      target,
     });
     try {
       const result = await runSshSandboxCommand({
@@ -110,7 +114,7 @@ async function createSshSandboxBackendInternal(
   if (!target) {
     throw new Error('Sandbox backend "ssh" requires agents.defaults.sandbox.ssh.target.');
   }
-  return createRemoteShellSandboxBackend(params, {
+  const backend = await createRemoteShellSandboxBackend(params, {
     backendId: "ssh",
     configLabel: target,
     configLabelKind: "Target",
@@ -129,6 +133,14 @@ async function createSshSandboxBackendInternal(
       };
     },
   });
+  return {
+    ...backend,
+    cleanupMetadata: {
+      locatorVersion: "1",
+      target,
+      workspaceRoot: params.cfg.ssh.workspaceRoot,
+    },
+  };
 }
 
 /** Create a static SSH sandbox using the shared remote workspace lifecycle. */

--- a/src/plugin-sdk/browser-bridge.ts
+++ b/src/plugin-sdk/browser-bridge.ts
@@ -22,6 +22,7 @@ type BrowserBridgeFacadeModule = {
     port?: number;
     authToken?: string;
     authPassword?: string;
+    acquireRequestActivity?: () => Promise<{ release(): Promise<void> } | null>;
     onEnsureAttachTarget?: (profile: unknown) => Promise<void>;
     resolveSandboxNoVncToken?: (token: string) => { noVncPort: number; password?: string } | null;
   }): Promise<BrowserBridge>;


### PR DESCRIPTION
## What Problem This Solves

Age-based sandbox pruning can terminate real work while it is still running. This change keeps active runtimes owned through execution, stream and finalization settlement, rather than treating age or process exit alone as permission to remove them.

Closes #131935.

## User Impact

Active sandbox work is protected across the relevant backends, including filesystem operations and browser response settlement. Automatic pruning skips busy scopes without blocking unrelated provisioning; existing current-config confinement and manual recreation behavior remain intact.

## Why This Change Was Made

This PR is deliberately narrowed to active-work lifetime protection. Its additional remote-locator and upgrade redesign has been removed without undoing accepted main behavior. Physical destination binding, mutable remote endpoint identity, reservation cleanup metadata and supported legacy retirement are deferred follow-up work—not a new deletion policy silently introduced here.

Handle-local finalization and scope admission retain ownership through final settlement. Independent review also found and prompted a fix for browser HTTP response backpressure. The CI follow-up extracts unchanged diagnostics and places outcome types in a shared leaf module to satisfy line-count and both dependency-cycle checks without weakening gates.

## Evidence

Final head: `9f1ae8f954a56f874a7130e37727a9b020fecf6e`  
Final tree: `5cf76f819b0e5c579cb383574b7f442d644f7af2`

- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/35119044774) completed successfully, with no failed or pending jobs at closeout.
- Real Docker red/green: main killed a running five-second command after 75 ms (exit 137); the candidate completed normally (exit 0), retained the container and SQLite row while active, then removed both after settlement.
- Real-process/SQLite entrypoint coverage and a real paused HTTP client receiving a 16 MiB response exercise lifetime and final-response ownership.
- Workboard proof exercised the registered dispatch adapter, actual sandbox workspace-authority resolution, SQLite and Docker: current config launched once; aged active stale config refused before launch. Request context and launch hook were synthetic, not model inference or a network Gateway-client proof.
- Separate qualification phases passed: 283 tests in 15 files on the narrowed implementation; 11 browser tests after its correction; 68 tests in six files for the final diagnostics/shared-type follow-up. These are separate receipts, not one combined test run.
- Affected lint/types, full architecture checks (both cycle graphs zero), current line-count guard and full builds passed. Fresh independent reviews completed with no accepted actionable findings after repairs.
- Live SSH/OpenShell integration is not claimed; source contracts and regressions were inspected. There is no visual UI change requiring screenshot proof.

[Detailed proof and scope notes](https://github.com/openclaw/openclaw/pull/131941#issuecomment-5697861578). Unchanged Talk/memory timing failures were investigated; the final exact-head CI run passed without relaxing their assertions.

Worked on by: @vyctorbrzezowski. Finishing commits contain the requested co-author trailer. The PR remains open, with its existing review state preserved; no merge, auto-merge, deployment or main push was performed.

---
[View the OpenClaw team session](https://team.openclaw.ai/chat/roboclaw/dashboard/57a5739f-fa89-44ca-9deb-a643fadbe638)
