### PR TITLE
docs: prohibit publishing unreleased model identifiers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,6 +334,7 @@ Mechanics only; policy lives above.
 
 ## Security / Release
 
+- Never publish internal or unreleased model identifiers in code, fixtures, commits, PRs, issues, comments, logs, transcripts, or screenshots/video. Use synthetic identifiers in tests and stable public model IDs—or “Codex”—elsewhere. Sanitize copied commands and check diffs and proof artifacts before publishing.
 - Never commit real phone numbers, videos, credentials, live config.
 - Secrets: channel/provider creds in `~/.openclaw/credentials/`; shared model auth profiles in `~/.openclaw/state/openclaw.sqlite`, with agent-local profiles overriding the shared read-through base; see `docs/auth-credential-semantics.md`.
 - SecretRef failures isolate to the smallest known owning surface; unknown ownership fails closed. Gateway starts degraded (exact owner marked configured-unavailable, typed redacted diagnostic, no implicit credential fallback) rather than refusing startup, except for its own ingress protection or structurally invalid config. Doctor and status list every degraded owner. Full doctrine: `docs/gateway/secrets.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,7 +334,7 @@ Mechanics only; policy lives above.
 
 ## Security / Release
 
-- Never publish internal or unreleased model identifiers in code, fixtures, commits, PRs, issues, comments, logs, transcripts, or screenshots/video. Use synthetic identifiers in tests and stable public model IDs—or “Codex”—elsewhere. Sanitize copied commands and check diffs and proof artifacts before publishing.
+- Never publish internal or unreleased model identifiers in code, fixtures, commits, PRs, issues, comments, logs, transcripts, or screenshots/video. Use synthetic identifiers in fixtures; tests requiring real models must use stable public IDs. Elsewhere, use stable public model IDs—or “Codex”. Sanitize copied commands and check diffs and proof artifacts before publishing.
 - Never commit real phone numbers, videos, credentials, live config.
 - Secrets: channel/provider creds in `~/.openclaw/credentials/`; shared model auth profiles in `~/.openclaw/state/openclaw.sqlite`, with agent-local profiles overriding the shared read-through base; see `docs/auth-credential-semantics.md`.
 - SecretRef failures isolate to the smallest known owning surface; unknown ownership fails closed. Gateway starts degraded (exact owner marked configured-unavailable, typed redacted diagnostic, no implicit credential fallback) rather than refusing startup, except for its own ingress protection or structurally invalid config. Doctor and status list every degraded owner. Full doctrine: `docs/gateway/secrets.md`.


### PR DESCRIPTION
## What Problem This Solves

Repository agent guidance did not explicitly prohibit publishing internal or unreleased model identifiers, leaving code fixtures and copied proof artifacts without a clear repository-wide publication rule.

## Why This Change Was Made

Add one rule to `AGENTS.md` covering code, fixtures, commits, PRs, issues, comments, logs, transcripts, screenshots, and video. It directs agents to use synthetic fixture identifiers, stable public IDs when tests require real models, and stable public IDs or a generic agent name elsewhere, and to sanitize copied commands and inspect diffs and proof artifacts before publication. The existing `CLAUDE.md` symlink inherits the same rule without duplicating it.

## User Impact

No runtime or configuration changes. This is maintainer-requested agent guidance intended to prevent disclosure during contribution and proof workflows. AI-assisted with Codex.

## Evidence

- Reviewed the single-rule addition against existing agent and contributor guidance; no private model identifiers or examples are included.
- Verified `CLAUDE.md` still points to `AGENTS.md`.
- `pnpm docs:list`, `git diff --check`, and `node scripts/check-changed.mjs -- AGENTS.md` pass (docs-only lane, including formatting and repository guards).
- Independent Codex autoreview completed with no actionable findings.
- Production and test LOC are unchanged; one documentation line is added. Runtime tests and live UI proof do not apply to this guidance-only change.

## Review Follow-up

Addressed ClawSweeper’s finding and rank-up move by distinguishing synthetic fixtures from tests that require real models. Those tests must use stable public IDs, which preserves the existing public-model test guidance without creating any exception for internal or unreleased names.

The reviewer’s inability to fetch prior comments was an evidence gap in its environment: the maintainer workflow has now read the live PR comments and accounted for the current finding. This is an explicitly requested maintainer policy change, handled through the native review and landing workflow. No runtime security or configuration behavior changes.

CI recovery: rebased onto the workflow-lint deadlock fix already landed in #131982 after the earlier actionlint run and its retry stalled. This PR still contains only the agent-guidance change; it does not modify workflow configuration.
