### PR TITLE
refactor(meetings): share CLI descriptors with runtime registration

### DIFF
--- a/docs/plugins/sdk-entrypoints.md
+++ b/docs/plugins/sdk-entrypoints.md
@@ -310,9 +310,11 @@ CLI registration:
   `machineOutput({ argv, stdoutIsTTY })` resolver for JSON, JSONL, or other
   machine-readable stdout modes that are not selected solely by `--json`.
   Parse command tokens with `getRootOptionAwareCommandPath` from
-  `openclaw/plugin-sdk/cli-argv`. Keep the resolver in lightweight CLI metadata
-  and share it with full registration. Nested descriptors do not expose this
-  field.
+  `openclaw/plugin-sdk/cli-argv`. Keep the descriptor in a lightweight
+  plugin-local module and reuse it from both `cli-metadata.ts` and full
+  registration; do not import runtime barrels to construct metadata.
+  Meeting runtime shells accept that descriptor through `cli.descriptor`.
+  Nested descriptors do not expose `machineOutput`.
 - Use `api.registerNodeCliFeature(...)` for paired-node feature commands so
   they land under `openclaw nodes` (equivalent to
   `registerCli(registrar, { parentPath: ["nodes"], ... })`).

--- a/extensions/teams-meetings/index.test.ts
+++ b/extensions/teams-meetings/index.test.ts
@@ -2,8 +2,9 @@ import { ErrorCodes } from "openclaw/plugin-sdk/gateway-runtime";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
 import type { TranscriptSourceProvider } from "openclaw/plugin-sdk/transcripts";
-import { assert, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import plugin from "./index.js";
+import { TEAMS_MEETINGS_CLI_METADATA } from "./src/cli-output-mode.js";
 
 const MEETING_URL =
   "https://teams.microsoft.com/l/meetup-join/19%3ameeting_owned%40thread.v2/0?context=%7b%7d";
@@ -160,35 +161,8 @@ describe("Microsoft Teams meetings plugin surface", () => {
       ].toSorted(),
     );
     expect(tools.map((tool) => tool.name)).toEqual(["teams_meetings"]);
-    expect(cli).toEqual([
-      {
-        commands: ["teamsmeetings"],
-        descriptors: [
-          {
-            name: "teamsmeetings",
-            description: "Join and manage Microsoft Teams meeting guests",
-            hasSubcommands: true,
-            machineOutput: expect.any(Function),
-          },
-        ],
-      },
-    ]);
-    const descriptor = cli[0]?.descriptors?.[0];
-    assert(
-      descriptor && "machineOutput" in descriptor && typeof descriptor.machineOutput === "function",
-    );
-    for (const [args, expected] of [
-      [[], false],
-      [["status"], true],
-      [["--log-level", "debug", "future-action"], true],
-    ] as const) {
-      expect(
-        descriptor.machineOutput({
-          argv: ["node", "openclaw", "teamsmeetings", ...args],
-          stdoutIsTTY: false,
-        }),
-      ).toBe(expected);
-    }
+    expect(cli).toEqual([expect.objectContaining({ commands: ["teamsmeetings"] })]);
+    expect(cli[0]?.descriptors?.[0]).toBe(TEAMS_MEETINGS_CLI_METADATA.descriptor);
     expect(nodeCommands).toEqual([
       expect.objectContaining({ command: "teamsmeetings.chrome", cap: "teams-meetings" }),
     ]);

--- a/extensions/teams-meetings/index.ts
+++ b/extensions/teams-meetings/index.ts
@@ -2,6 +2,7 @@ import { MeetingPlatformAdapter } from "openclaw/plugin-sdk/meeting-runtime";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { Type } from "typebox";
+import { TEAMS_MEETINGS_CLI_METADATA } from "./src/cli-output-mode.js";
 import { teamsMeetingsConfig } from "./src/config.js";
 import { TeamsMeetingsInvalidRequestError, teamsMeetingsInvalidRequest } from "./src/errors.js";
 import { handleTeamsMeetingsNodeHostCommand } from "./src/node-host.js";
@@ -48,6 +49,7 @@ export default MeetingPlatformAdapter.createPluginShellEntry({
   createNodePolicy: createTeamsMeetingsNodeInvokePolicy,
   registerNodeWhen: () => true,
   cli: {
+    descriptor: TEAMS_MEETINGS_CLI_METADATA.descriptor,
     load: async () => (await import("./src/cli.js")).registerTeamsMeetingsCli,
   },
 });

--- a/extensions/zoom-meetings/index.test.ts
+++ b/extensions/zoom-meetings/index.test.ts
@@ -2,8 +2,9 @@ import { ErrorCodes } from "openclaw/plugin-sdk/gateway-runtime";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
 import type { TranscriptSourceProvider } from "openclaw/plugin-sdk/transcripts";
-import { assert, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import plugin from "./index.js";
+import { ZOOM_MEETINGS_CLI_METADATA } from "./src/cli-output-mode.js";
 
 const MEETING_URL = "https://zoom.us/j/12345678901?pwd=owned";
 
@@ -159,35 +160,8 @@ describe("Zoom meetings plugin surface", () => {
       ].toSorted(),
     );
     expect(tools.map((tool) => tool.name)).toEqual(["zoom_meetings"]);
-    expect(cli).toEqual([
-      {
-        commands: ["zoommeetings"],
-        descriptors: [
-          {
-            name: "zoommeetings",
-            description: "Join and manage Zoom meeting guests",
-            hasSubcommands: true,
-            machineOutput: expect.any(Function),
-          },
-        ],
-      },
-    ]);
-    const descriptor = cli[0]?.descriptors?.[0];
-    assert(
-      descriptor && "machineOutput" in descriptor && typeof descriptor.machineOutput === "function",
-    );
-    for (const [args, expected] of [
-      [[], false],
-      [["status"], true],
-      [["--log-level", "debug", "future-action"], true],
-    ] as const) {
-      expect(
-        descriptor.machineOutput({
-          argv: ["node", "openclaw", "zoommeetings", ...args],
-          stdoutIsTTY: false,
-        }),
-      ).toBe(expected);
-    }
+    expect(cli).toEqual([expect.objectContaining({ commands: ["zoommeetings"] })]);
+    expect(cli[0]?.descriptors?.[0]).toBe(ZOOM_MEETINGS_CLI_METADATA.descriptor);
     expect(nodeCommands).toEqual([
       expect.objectContaining({ command: "zoommeetings.chrome", cap: "zoom-meetings" }),
     ]);

--- a/extensions/zoom-meetings/index.ts
+++ b/extensions/zoom-meetings/index.ts
@@ -1,6 +1,7 @@
 import { MeetingPlatformAdapter } from "openclaw/plugin-sdk/meeting-runtime";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { Type } from "typebox";
+import { ZOOM_MEETINGS_CLI_METADATA } from "./src/cli-output-mode.js";
 import { zoomMeetingsConfig } from "./src/config.js";
 import { ZoomMeetingsInvalidRequestError, zoomMeetingsInvalidRequest } from "./src/errors.js";
 import { handleZoomMeetingsNodeHostCommand } from "./src/node-host.js";
@@ -41,6 +42,7 @@ export default MeetingPlatformAdapter.createPluginShellEntry({
   createNodePolicy: createZoomMeetingsNodeInvokePolicy,
   registerNodeWhen: (config) => config.enabled,
   cli: {
+    descriptor: ZOOM_MEETINGS_CLI_METADATA.descriptor,
     load: async () => (await import("./src/cli.js")).registerZoomMeetingsCli,
   },
 });

--- a/src/meeting-bot/plugin-shell.ts
+++ b/src/meeting-bot/plugin-shell.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
-import { getRootOptionAwareCommandPath } from "../infra/cli-root-options.js";
 import type { OpenClawPluginApi } from "../plugins/plugin-api.types.js";
+import type { OpenClawPluginCliRootCommandDescriptor } from "../plugins/plugin-registration.types.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { createMeetingRealtimeEngineBindings } from "./agent-consult.js";
 import {
@@ -151,6 +151,7 @@ type MeetingPluginShellEntryOptions<
   | "unknownActionMessage"
 > & {
   cli: {
+    descriptor: OpenClawPluginCliRootCommandDescriptor;
     load(): Promise<(params: { program: Command; config: Config }) => void>;
   };
   browserGuestLabel: string;
@@ -197,16 +198,9 @@ export function createMeetingPluginShellEntry<
       }),
     registerCli: (api, config) => {
       api.registerCli(async ({ program }) => (await loadCli())({ program, config }), {
-        commands: [methodPrefix],
-        descriptors: [
-          {
-            name: methodPrefix,
-            description: `Join and manage ${options.browserGuestLabel} guests`,
-            hasSubcommands: true,
-            machineOutput: ({ argv }: { argv: readonly string[] }) =>
-              getRootOptionAwareCommandPath(argv, 2).length === 2,
-          },
-        ],
+        commands: [options.cli.descriptor.name],
+        // Share the metadata descriptor so help and runtime output policy cannot drift.
+        descriptors: [options.cli.descriptor],
       });
     },
   });


### PR DESCRIPTION
Related: #131719 (the canonical Teams/Zoom CLI metadata import fix).

## What Problem This Solves

PR #131719 already fixed the Teams and Zoom metadata import leak. This maintainer-requested follow-up prevents the lightweight CLI metadata and full runtime registration from drifting apart as command descriptions or output policy evolve. It does not claim another startup performance fix.

## Why This Change Was Made

Both plugins now supply their existing lightweight metadata descriptor to the shared meeting shell through `cli.descriptor`. The shell consumes that descriptor instead of synthesizing a second copy. Lazy CLI loading is unchanged, and main's lightweight metadata modules, erased API types, no-op registrars, and import barriers remain intact. No SDK exports or compatibility shim are added; the meeting shell entry API is beta-only.

## User Impact

Behavior is preserved: command names, descriptions, machine-output policy, and gateway/tool/node registration remain the same. Plugin maintainers now have one descriptor owner for metadata and full registration. Google Meet's distinct output policy is unchanged.

AI-assisted with Codex. The implementation and owner boundary have been inspected and are understood.

## Evidence

Implementation proof on prior head `5847b3d8440f90bf65fc7f0f59805e2f000d497d` (retained as patch-identical evidence, not rerun on the synchronized head):

- The new descriptor-identity assertions failed on the current-main shell: 2 expected failures, with the other 17 registration tests passing. Vitest reported that the compared values had no visual difference, but failed `Object.is` equality. These are ownership-regression assertions, not a claim that the import leak still exists on main.
- The full focused command below passed **42 tests across six files** after descriptor injection.
- `pnpm install --frozen-lockfile` passed after rebasing onto the dependency refresh.
- `pnpm build` passed with unchanged guards: 37m25.6s phase total / 37m56.6s elapsed. The normal metadata phase ran in 33.4s after build-cache restoration. No ineffective dynamic-import warnings appeared.
- A separate fresh `node --import ./scripts/tsx.mjs scripts/write-cli-startup-metadata.ts` run passed in 30.69s after moving only the task-generated metadata output aside. No renderer overrides, skipped plugins, or timeout changes. All help surfaces and seven precomputed subcommand entries were generated; `nodes canvas` remains present.
- A separate isolated `node openclaw.mjs nodes --help` flow, using the generator's environment whitelist and an unchanged 120000ms deadline, exited 0 in 31.03s with no stderr. It observed both Teams/Zoom source metadata paths, retained `canvas`, and matched fresh generated help. This is a behavior proof, not a controlled benchmark.
- The six-file scoped check passed on rerun, including types, lint, import-cycle, schema/storage, and security guards. The first attempt timed out in the plugin SDK declaration prerequisite at its unchanged 300000ms deadline; the exact lint wrapper retry and subsequent full scoped run passed without source, timeout, baseline, or dependency changes. Formatting and `git diff --check` passed.
- Fresh managed Codex autoreview found no accepted/actionable findings (default P0 scope).

```bash
node scripts/run-vitest.mjs extensions/teams-meetings/src/cli-output-mode.test.ts extensions/teams-meetings/index.test.ts extensions/zoom-meetings/src/cli-output-mode.test.ts extensions/zoom-meetings/index.test.ts extensions/google-meet/src/cli-output-mode.test.ts src/infra/cli-root-options.test.ts
```

Scoped check command:

```bash
node scripts/check-changed.mjs -- docs/plugins/sdk-entrypoints.md extensions/teams-meetings/index.ts extensions/teams-meetings/index.test.ts extensions/zoom-meetings/index.ts extensions/zoom-meetings/index.test.ts src/meeting-bot/plugin-shell.ts
```

Current head: `742930a8239ddb68f8d4cf1d4cee29ad7427fdf6`, mechanically rebased onto `d549b12d186a98100c19e43153e9903161b1952a` to inherit the actionlint deadlock repair in #131982. The exact six-file delta is unchanged: `git range-diff` reports equality, stable patch-id is `52d60e31a336bd8bb2f47e62176169f21e9cde41`, and all six changed file blobs are identical to the prior head. This PR does not edit workflows or dependencies.

Fresh proof on the synchronized head: the same focused command passed all 42 tests in 64.91s; six-file formatting and `git diff --check` passed; fresh managed Codex autoreview is clean. A normal frozen install was needed for inherited lockfile changes. Its first process stalled after lifecycle completion while optional platform downloads failed; the owned process was stopped, and the one unchanged `pnpm install --frozen-lockfile` retry passed. The expensive build, scoped check, generator, and real nodes-help results above remain accurately labeled prior-head proof. New exact-head hosted CI is green (run 33201435026, attempt 2); Workflow Sanity 33201435056 and the native hosted verifier also passed.

CI recovery context: original full CI passed on the prior head. Workflow Sanity deadlocked in actionlint v1.7.12; its logs and matching upstream input establish the already-fixed issue in #131982. One close/reopen attempt still selected GitHub's stale workflow definition. The mechanical synchronization preserves this PR's patch while loading main's canonical fix; no audit gates or timeouts are weakened.

Historical leak-repair proof is retained separately; it is not presented as fresh evidence or a benchmark comparison against current main.

Production LOC: +9/-11 (net -2). Tests: +8/-60 (net -52). Docs: +5/-3. Six changed files. The existing metadata tests retain descriptor fields, import barriers, no-op registrar behavior, and arbitrary future-action output checks; registration tests now require exact descriptor identity instead of duplicating those policy assertions.

After the lease-protected sync, GitHub produced [startup_failure run 33201246717](https://github.com/openclaw/openclaw/actions/runs/33201246717) with no jobs. After verifying that merge preview `243066ee2fafccb40591284005616e5180e80eda` contains Setup Go and the fixed actionlint revision, one repo-prescribed close/reopen was used for this new startup failure. The recovered exact-head checks are now green.

The synchronized-head [Workflow Sanity run 33201435056](https://github.com/openclaw/openclaw/actions/runs/33201435056) has now passed. Setup Go and the fixed actionlint installation succeeded; `Lint workflows` finished in 7 seconds, followed by successful zizmor and remaining audits. The new [full CI run 33201435026](https://github.com/openclaw/openclaw/actions/runs/33201435026) completed attempt 1 with 164 successful jobs and 17 intentional skips. Its build-artifacts job failed before Node setup/build because the existing base commit could not be fetched within five unchanged 30-second fetch attempts; the CI gate reported that failure. The failed job log is retained; the later missing artifact follows from the build never starting. A targeted rerun was refused while the workflow was active. Once terminal, `gh run rerun 33201435026 --failed` started [attempt 2](https://github.com/openclaw/openclaw/actions/runs/33201435026/attempts/2), preserving successful results. Attempt 2 passed: 166 successful jobs and 17 intentional skips, including ci-gate job 98959641188. The previously failing base fetch passed; the normal cached build step completed in 2m15s, followed by generated-asset checks, CLI help/status/Bun smokes, and built-artifact checks. No source, helper timeout, or guard changes.

Latest ClawSweeper review (2026-08-28T19:18:27.726Z) covers the exact synchronized head and has no findings. Its rank-up request for terminal green checks is complete. Fresh native review artifacts recommend `READY FOR /prepare-pr`; the matching parent authorization was verified before native prepare/merge.

Landed via native prepare and squash merge as [4395a0cc3e6a162ff7ab0afc5c0aa7f7bec18597](https://github.com/openclaw/openclaw/commit/4395a0cc3e6a162ff7ab0afc5c0aa7f7bec18597). [Native completion receipt](https://github.com/openclaw/openclaw/pull/131946#issuecomment-5456969835). Post-merge verification confirms the exact six-file patch-id, identical reviewed file contents, and no metadata-owner, workflow, dependency, schema, or guard deltas.
