### PR TITLE
fix(ui): release queued sends from recorded idle state

### DIFF
--- a/ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts
@@ -3,6 +3,7 @@ import { controlUiBundledSettingsStorageKey } from "../test-helpers/control-ui-e
 import {
   SESSION_DRAG_MIME,
   captureSessionAccessibilityProof,
+  captureUiProof,
   chatSessionListResponse,
   controlUiSessionPath,
   createChatFlowE2eSuite,
@@ -765,7 +766,7 @@ suite.define(() => {
     }
   });
 
-  it("flips a sidebar short route before any list refresh and refreshes only for an outbox", async () => {
+  it("releases a retained queued send after the canonical session list records idle", async () => {
     const context = await suite.newBrowserContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -774,12 +775,40 @@ suite.define(() => {
     const page = await context.newPage();
     const firstKey = "agent:main:thread:aaaaaaaa-1111-4111-8111-111111111111";
     const secondKey = "agent:main:thread:bbbbbbbb-2222-4222-8222-222222222222";
-    const sessions = chatSessionListResponse([
-      { key: firstKey, kind: "direct", label: "Instant A", updatedAt: 2 },
+    const activeSessions = chatSessionListResponse([
+      {
+        key: firstKey,
+        kind: "direct",
+        label: "Instant A",
+        updatedAt: 2,
+        activeRunIds: ["server-run"],
+        hasActiveRun: true,
+        status: "running",
+      },
+      { key: secondKey, kind: "direct", label: "Instant B", updatedAt: 1 },
+    ]);
+    const idleSessions = chatSessionListResponse([
+      {
+        key: firstKey,
+        kind: "direct",
+        label: "Instant A",
+        updatedAt: 3,
+        activeRunIds: [],
+        hasActiveRun: false,
+        lastRunId: "server-run",
+        status: "done",
+      },
       { key: secondKey, kind: "direct", label: "Instant B", updatedAt: 1 },
     ]);
     const gateway = await installMockGateway(page, {
-      methodResponses: { "sessions.list": sessions },
+      methodResponses: {
+        "chat.history": {
+          messages: [],
+          sessionInfo: { hasActiveRun: false, status: "done" },
+          thinkingLevel: null,
+        },
+        "sessions.list": activeSessions,
+      },
       sessionKey: firstKey,
     });
 
@@ -857,9 +886,18 @@ suite.define(() => {
       await expect
         .poll(async () => (await gateway.getRequests("sessions.list")).length)
         .toBe(emptyOutboxListCount + 1);
-      if (emptyOutboxListRequests.length === 0) {
-        await gateway.resolveDeferred("sessions.list", sessions);
-      }
+      const queued = page.locator(".chat-queue").getByText("flush after idle reconciliation");
+      await queued.waitFor();
+      expect(await gateway.getRequests("chat.send")).toHaveLength(0);
+      await captureUiProof(suite, page, "queued-idle-release", "01-queued-before-idle.png");
+      await gateway.resolveDeferred("sessions.list", idleSessions);
+      const send = await gateway.waitForRequest("chat.send");
+      expect(requireRecord(send.params)).toMatchObject({
+        message: "flush after idle reconciliation",
+        sessionKey: firstKey,
+      });
+      await queued.waitFor({ state: "detached" });
+      await captureUiProof(suite, page, "queued-idle-release", "02-sent-after-idle.png");
     } finally {
       await suite.closeBrowserContext(context);
     }

--- a/ui/src/pages/chat/chat-pane-context.ts
+++ b/ui/src/pages/chat/chat-pane-context.ts
@@ -10,6 +10,7 @@ import { loadSettings } from "../../app/settings.ts";
 import { readPresenceEntries } from "../../app/user-profile.ts";
 import { createGatewayConnectionLifecycle } from "../../lib/gateway-connection-lifecycle.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
+import { isSessionRunActive } from "../../lib/session-run-state.ts";
 import { parseCatalogSessionKey } from "../../lib/sessions/catalog-key.ts";
 import { resolveSessionKey } from "../../lib/sessions/index.ts";
 import {
@@ -31,7 +32,7 @@ import {
 } from "./chat-pane-state.ts";
 import { markQueuedChatSendsWaitingForReconnect } from "./chat-queue.ts";
 import { stopChatRealtimeTalk } from "./chat-realtime.ts";
-import { retryReconnectableQueuedChatSends } from "./chat-send-actions.ts";
+import { flushChatQueueForEvent, retryReconnectableQueuedChatSends } from "./chat-send-actions.ts";
 import { retireChatModelSelectionOwnership } from "./chat-session.ts";
 import {
   refreshChatModelAuthStatus,
@@ -56,6 +57,8 @@ import { reconcileWaitingApprovalsFromSnapshot } from "./tool-stream-status.ts";
 export abstract class ChatPaneContext extends ChatPaneLifecycle {
   private gatewayConnectionLifecycle?: ReturnType<typeof createGatewayConnectionLifecycle>;
   private outboxRecoveryReady = false;
+  // Capability identity matters because a replacement restarts its canonical revision at zero.
+  private canonicalSessionList?: { sessions: ApplicationContext["sessions"]; revision: number };
 
   protected placementComposerPresentation(
     row: GatewaySessionRow | undefined,
@@ -167,6 +170,14 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
     if (!state) {
       return;
     }
+    const canonicalListRevision = this.context.sessions.canonicalListRevision;
+    const canonicalListPublished =
+      this.canonicalSessionList?.sessions === this.context.sessions &&
+      canonicalListRevision > this.canonicalSessionList.revision;
+    this.canonicalSessionList = {
+      sessions: this.context.sessions,
+      revision: canonicalListRevision,
+    };
     const selectedSessionDeleted = this.context.sessions.deletionState(
       state.sessionKey,
       resolveChatAgentId(state),
@@ -217,10 +228,22 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
     this.reconcileWaitingApprovalSnapshot();
     if (reconciledLocalCompletion) {
       void retryReconnectableQueuedChatSends(state);
-    } else if (this.presented) {
+      return;
+    }
+    if (this.presented) {
       // Share the event handler's frame; synchronous roster publication must
       // not force a transcript redraw for every incoming session update.
       requestChatPageUpdate(state, "animation-frame");
+    }
+    // The canonical list is the only authoritative idle signal without a local run
+    // identity; the drain's never-attempted fast path trusts the row it publishes.
+    if (
+      canonicalListPublished &&
+      selectedSession &&
+      !isSessionRunActive(selectedSession) &&
+      state.chatQueue.length > 0
+    ) {
+      void flushChatQueueForEvent(state);
     }
   }
 

--- a/ui/src/pages/chat/chat-pane-recovery.test.ts
+++ b/ui/src/pages/chat/chat-pane-recovery.test.ts
@@ -1,14 +1,89 @@
 /* @vitest-environment jsdom */
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
+import { captureChatOutboxAdmission } from "../../lib/chat/outbox-store.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
+import { createStorageMock } from "../../test-helpers/storage.ts";
+import { makeChatHost } from "./chat-host.test-support.ts";
 import {
   createSessionCapabilityFixture,
   createTestChatPane,
   type TestChatPane,
 } from "./chat-pane.test-support.ts";
+import type { ChatPageHost } from "./chat-state-host.ts";
+import { admitStoredChatComposerQueueItem } from "./composer-persistence.ts";
+
+afterEach(() => vi.unstubAllGlobals());
+
+function sessionsResult(row: GatewaySessionRow): SessionsListResult {
+  return {
+    ts: 0,
+    path: "",
+    count: 1,
+    defaults: { modelProvider: null, model: null, contextTokens: null },
+    sessions: [row],
+  };
+}
+
+function createQueuedSendRecoveryFixture() {
+  vi.stubGlobal("sessionStorage", createStorageMock());
+  const listRefresh = createDeferred<SessionsListResult>();
+  const active: GatewaySessionRow = {
+    key: "agent:main",
+    kind: "direct",
+    updatedAt: 10,
+    activeRunIds: ["server-run"],
+    hasActiveRun: true,
+    status: "running",
+  };
+  const idle: GatewaySessionRow = {
+    ...active,
+    updatedAt: 11,
+    activeRunIds: [],
+    hasActiveRun: false,
+    lastRunId: "server-run",
+    status: "done",
+  };
+  const host = makeChatHost({
+    chatQueue: [
+      {
+        id: "queued-after-server-run",
+        text: "send after idle",
+        createdAt: 1,
+        sendAttempts: 0,
+        sendRunId: "queued-send-run",
+        sendState: "waiting-idle",
+        sessionKey: "agent:main",
+      },
+    ],
+    requestHandlers: {
+      "sessions.list": () => listRefresh.promise,
+      "chat.history": { messages: [], sessionInfo: idle },
+      "chat.send": { runId: "queued-send-run", status: "ok" },
+    },
+    sessionsResult: sessionsResult(active),
+  });
+  const admission = captureChatOutboxAdmission(host, host.sessionKey);
+  expect(admitStoredChatComposerQueueItem(host, admission, host.chatQueue[0]!)).toBe(true);
+  const { pane } = createTestChatPane({ client: host.client!, sessions: host.sessions });
+  pane.state = host as unknown as ChatPageHost;
+  pane.applySessionsState(host.sessions.state);
+  const unsubscribe = host.sessions.subscribe((state) => pane.applySessionsState(state));
+  return {
+    idle,
+    host,
+    listRefresh,
+    pane,
+    dispose: () => {
+      pane.active = false;
+      unsubscribe();
+      host.sessions.dispose();
+    },
+  };
+}
 
 function advertiseSessionRecovery(pane: TestChatPane) {
   pane.context.gateway.snapshot.hello = {
@@ -47,6 +122,45 @@ describe("chat pane session recovery", () => {
 
     expect(state.chatRunId).toBeNull();
     expect(state.chatStream).toBeNull();
+  });
+
+  it("releases a restored queued send when the canonical session state records idle", async () => {
+    const fixture = createQueuedSendRecoveryFixture();
+    try {
+      fixture.pane.active = true;
+      await vi.waitFor(() =>
+        expect(fixture.host.request.mock.calls.map(([method]) => method)).toEqual([
+          "sessions.list",
+        ]),
+      );
+
+      fixture.listRefresh.resolve(sessionsResult(fixture.idle));
+      await vi.waitFor(() => expect(fixture.host.chatQueue).toEqual([]));
+
+      expect(
+        fixture.host.request.mock.calls.filter(([method]) => method === "chat.send"),
+      ).toHaveLength(1);
+    } finally {
+      fixture.dispose();
+    }
+  });
+
+  it("keeps a queued send parked after a non-canonical idle publication", async () => {
+    const fixture = createQueuedSendRecoveryFixture();
+    try {
+      fixture.host.sessions.reconcile(fixture.idle);
+      await Promise.resolve();
+
+      expect(fixture.host.sessions.canonicalListRevision).toBe(0);
+      expect(fixture.host.chatQueue).toHaveLength(1);
+      expect(
+        fixture.host.request.mock.calls.filter(
+          ([method]) => method === "chat.history" || method === "chat.send",
+        ),
+      ).toEqual([]);
+    } finally {
+      fixture.dispose();
+    }
   });
 
   it("recovers a tombstoned session into a fresh continuing session", async () => {


### PR DESCRIPTION
Closes #131933

## What Problem This Solves

Returning to a retained conversation could leave a restored queued message parked after its first drain observed a stale active session row, even though a later canonical `sessions.list` publication recorded the conversation idle. With no further wakeup, the message could remain silent until unrelated activity caused it to send later.

## Why This Change Was Made

The chat pane now records canonical session-list publication revisions and wakes the selected session's outbox when a newer canonical row is idle and queued work exists. The existing serialized outbox drain remains the delivery owner: it still reconciles `chat.history`, blocks stale-active state, and uses the existing idempotency key before sending.

This is the owner-boundary fix because the pane consumes the canonical row that the drain's fast path trusts. Sequencing only the retained-pane activation refresh would cover one call ordering but would leave later canonical publications from observer recovery or delayed refreshes unable to wake the queue.

## User Impact

Restored queued messages resume promptly after the authoritative session list records the conversation idle, instead of silently waiting for another event.

## Evidence

- Pre-fix proof on the rebased candidate: with only the production hunk reversed, `releases a restored queued send when the canonical session state records idle` fails because the queue remains `waiting-idle` and no send occurs.
- Focused owner and sibling tests: 357 passed across `ui/src/pages/chat/chat-pane-recovery.test.ts` and `ui/src/pages/chat/chat-send.test.ts`.
- Real-browser mocked-Gateway E2E: retained pane restored a durable queued row, confirmed zero sends while the canonical row was active, then observed exactly one `chat.send` after the deferred canonical list published idle (1 passed, 9 filtered).
- `pnpm check:changed`: passed all selected UI/core test formatting, type, lint, i18n, dead-export, and guard checks.
- Independent autoreview: scoped clean at P1; no accepted/actionable findings.

Queued before canonical idle publication:

![Queued send remains parked while the canonical row is active](https://github.com/user-attachments/assets/9e662099-37f5-4cf1-8fb8-e66edcc7a128)

Sent after canonical idle publication:

![Queued send appears in the transcript after canonical idle publication](https://github.com/user-attachments/assets/ff81df13-0bf8-43a5-ade3-cb6fd8918832)

## Landing notes

- X-ray adjustment 1 — rebased onto `origin/main`; retained `deletionState(...)`, animation-frame `requestChatPageUpdate(...)`, and the separate recovery-scope-ready retry.
- X-ray adjustment 2 — flattened the local-completion branch with an early return and documented both capability-replacement revision reset and the canonical-list wake invariant.
- X-ray adjustment 3 — replaced exact RPC-sequence coupling with queue-empty plus exactly-one-send assertions; exercised the real `activeChanged(true)` path; added a negative non-canonical publication case; added retained-pane browser E2E proof.
- X-ray adjustment 4 — ran the requested focused tests and changed-files gate on the rebased head.
- ClawSweeper rank-up — applied both moves: current-main rebase preserves both distinct wake paths, and the active-to-idle regression was rerun on exact head `bad71db0f3077c1ec7c3d5974fc8b6cee23c9fb5`.

Exact local commands and results:

- `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs ui/src/pages/chat/chat-pane-recovery.test.ts ui/src/pages/chat/chat-send.test.ts` — 2 files, 357 tests passed.
- `OPENCLAW_CAPTURE_UI_PROOF=1 OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts -t "releases a retained queued send after the canonical session list records idle"` — 1 passed, 9 filtered; both captures opened and inspected.
- `OPENCLAW_VITEST_MAX_WORKERS=2 pnpm check:changed` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --max-priority P1 --prompt "Review PR #131948 for queued-send lifecycle correctness, canonical session-list ownership, duplicate-send/active-run safety, and test quality after the X-ray adjustments. Treat ui/AGENTS.md and root Repair Doctrine as governing policy." --output /tmp/x131948-autoreview.txt --json-output /tmp/x131948-autoreview.json --stream-engine-output` — scoped clean, no findings.
- `git diff --check origin/main...HEAD` — passed.

Production LOC: +25/-2 (net +23). Tests: +160/-8 (net +152). The production growth is the bounded capability-identity/revision fact needed at the pane-to-session owner boundary; delivery logic remains in the existing drain.

## Risk and coverage

What else could break: a canonical publication can add a `chat.history` reconciliation for a parked attempted item; hidden retained panes can also wake their own durable outbox; and a stale idle row could otherwise risk an early send.

Evidence it does not: the wake is gated to a newer canonical revision, the selected idle row, and a non-empty queue. The serialized drain revalidates history and current busy state, existing active-row, split-pane FIFO, and cross-agent isolation tests all pass, and the browser scenario observed zero sends before the idle publication and exactly one afterward.

What remains uncovered: this is deterministic mocked-Gateway browser proof, not a live provider or live Gateway recording. The changed path is browser-side orchestration with no external API dependency; the mock controls the required `sessions.list` completion race precisely. A failed canonical list still leaves the queue parked until a later successful publication or event, unchanged from `main`.


Exact-head CI: [run 33795702767](https://github.com/openclaw/openclaw/actions/runs/33795702767) — completed successfully on `bad71db0f3077c1ec7c3d5974fc8b6cee23c9fb5` (93 jobs passed, 13 intentionally skipped, zero failures).
