### PR TITLE
fix(hooks): report the actual wake enqueue outcome

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -733,7 +733,7 @@ limits, routing policy, and error responses.
       --data '{"text":"The sample import completed","mode":"now","agentId":"main"}'
     ```
 
-    HTTP `200` with `{ "ok": true, "mode": "now" }` means the event was enqueued and a wake was requested, not that a heartbeat completed. Use `mode: "next-heartbeat"` to enqueue without requesting an immediate wake.
+    HTTP `200` includes `eventOutcome: "queued"` when the queue accepts the wake or `eventOutcome: "coalesced"` when the same wake is already the queue's most recent pending event. With `mode: "now"`, a wake is requested in either case; the response does not mean a heartbeat completed. Use `mode: "next-heartbeat"` to avoid requesting an immediate wake.
 
     A supplied `agentId` must name a configured agent. Supply it explicitly when the fleet has no implicit or retained legacy owner. A caller-selected `sessionKey` requires `mode: "now"`, `hooks.allowRequestSessionKey: true`, and the configured prefix policy; deferred wakes use the main session.
 
@@ -755,7 +755,7 @@ limits, routing policy, and error responses.
 
     Persistent mapped hooks require a stable mapping `sessionKey` or `hooks.defaultSessionKey`. Template-derived keys require the same caller-key opt-in and prefix policy as request keys.
 
-    `forEach: "<key>"` fans out over a top-level payload array. Each item sees a one-element array, so the Gmail preset's `messages[0]` means the current email. Agent fan-out admission answers after at most about 8 seconds of dispatch waiting; pending items continue in the background and a partial batch returns non-2xx. Retrying the same batch reuses pending or admitted agent items while the bounded in-memory replay cache retains them. It is not durable exactly-once delivery, and mapped wake actions are not deduplicated. The reference covers batch caps and response shapes.
+    `forEach: "<key>"` fans out over a top-level payload array. Each item sees a one-element array, so the Gmail preset's `messages[0]` means the current email. Agent fan-out admission answers after at most about 8 seconds of dispatch waiting; pending items continue in the background and a partial batch returns non-2xx. Retrying the same batch reuses pending or admitted agent items while the bounded in-memory replay cache retains them. It is not durable exactly-once delivery; mapped wake actions have no replay identity, and the queue may coalesce repeated wakes. The reference covers batch caps and response shapes.
 
   </Accordion>
 </AccordionGroup>

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1130,11 +1130,11 @@ Gmail-path mappings receive a larger derived allowance described below. Generic
 hooks parse JSON but do not require the JSON content-type header; the TaskFlow
 plugin does enforce it.
 
-| Endpoint             | Payload and result                                                                                                                                                                                                                                        |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `POST /hooks/wake`   | Required nonempty `text`; optional `mode` (`"now"` default or `"next-heartbeat"`), `agentId`, `sessionKey`. Returns `200 { ok: true, mode }` after enqueueing the system event. `now` also requests a heartbeat; neither result proves the heartbeat ran. |
-| `POST /hooks/agent`  | [Agent payload](/gateway/configuration-reference#hook-agent-payload). Returns `200 { ok: true, runId }` after session/global placement admission, not completion.                                                                                         |
-| `POST /hooks/<name>` | First matching mapping produces wake/agent actions. No matching mapping returns `404`; no actions returns `204`. Agent fan-out has the [batch response contract](/gateway/configuration-reference#hook-retries-and-fan-out).                              |
+| Endpoint             | Payload and result                                                                                                                                                                                                                                                                                                                                                                                     |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `POST /hooks/wake`   | Required nonempty `text`; optional `mode` (`"now"` default or `"next-heartbeat"`), `agentId`, `sessionKey`. Returns `200 { ok: true, mode, eventOutcome }`; `eventOutcome` is `"queued"` when the queue accepts the wake or `"coalesced"` when the same wake is already the queue's most recent pending event. `now` requests a heartbeat in either case; the result does not prove the heartbeat ran. |
+| `POST /hooks/agent`  | [Agent payload](/gateway/configuration-reference#hook-agent-payload). Returns `200 { ok: true, runId }` after session/global placement admission, not completion.                                                                                                                                                                                                                                      |
+| `POST /hooks/<name>` | First matching mapping produces wake/agent actions. No matching mapping returns `404`; no actions returns `204`. Agent fan-out has the [batch response contract](/gateway/configuration-reference#hook-retries-and-fan-out).                                                                                                                                                                           |
 
 The direct `/wake` and `/agent` endpoints take precedence over mappings with
 those names. `/hooks` itself has no action.
@@ -1294,8 +1294,10 @@ pending items return non-2xx with `ok: false`, an incomplete-batch `error`, admi
 Agent fan-out derives replay identity from each rendered action even without an
 explicit idempotency key. Identical retries reconcile pending/admitted items
 within the cache lifetime; keep transforms deterministic for retries. Wake
-actions enqueue immediately and have no replay identity, including mixed
-wake/agent batches. This is not durable exactly-once processing.
+actions dispatch immediately and have no replay identity, including mixed
+wake/agent batches. Their response includes `eventOutcome: "queued"` if any wake
+was accepted by its queue, or `"coalesced"` if every wake was coalesced by its queue.
+This is not durable exactly-once processing.
 
 ### Gmail integration
 

--- a/src/gateway/server-http.hooks-delivery.test.ts
+++ b/src/gateway/server-http.hooks-delivery.test.ts
@@ -37,7 +37,7 @@ function createDeliveryHandler(params?: {
   mappings?: HookMappingResolved[];
   agentPolicy?: Partial<HooksConfigResolved["agentPolicy"]>;
 }) {
-  const dispatchWakeHook = vi.fn();
+  const dispatchWakeHook = vi.fn(() => ({ eventOutcome: "queued" as const }));
   const dispatchAgentHook = vi.fn((_value: HookAgentDispatchPayload) => ({
     ok: true as const,
     runId: "run-1",

--- a/src/gateway/server-http.hooks-request-timeout.test.ts
+++ b/src/gateway/server-http.hooks-request-timeout.test.ts
@@ -38,7 +38,7 @@ describe("createHooksRequestHandler timeout status mapping", () => {
 
   test("returns 408 for request body timeout", async () => {
     readJsonBodyMock.mockResolvedValue({ ok: false, error: "request body timeout" });
-    const dispatchWakeHook = vi.fn();
+    const dispatchWakeHook = vi.fn(() => ({ eventOutcome: "queued" as const }));
     const dispatchAgentHook = vi.fn(() => ({ ok: true as const, runId: "run-1" }));
     const handler = createHooksHandler({ dispatchWakeHook, dispatchAgentHook });
     const tasks: Promise<boolean>[] = [];

--- a/src/gateway/server-http.test-harness.ts
+++ b/src/gateway/server-http.test-harness.ts
@@ -228,7 +228,7 @@ export function createHooksHandler(
       error: vi.fn(),
     } as unknown as ReturnType<typeof createSubsystemLogger>,
     getClientIpConfig: options.getClientIpConfig,
-    dispatchWakeHook: options.dispatchWakeHook ?? (() => {}),
+    dispatchWakeHook: options.dispatchWakeHook ?? (() => ({ eventOutcome: "queued" })),
     dispatchAgentHook: options.dispatchAgentHook ?? (() => ({ ok: true, runId: "run-1" })),
   });
 }

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -524,11 +524,20 @@ describe("gateway server hooks", () => {
         sessionKey: "hook:wake:direct",
       });
       expect(direct.status).toBe(200);
+      await expect(direct.json()).resolves.toMatchObject({ eventOutcome: "queued" });
+      const directDuplicate = await postHook(port, "/hooks/wake", {
+        text: "Direct wake",
+        sessionKey: "hook:wake:direct",
+      });
+      await expect(directDuplicate.json()).resolves.toMatchObject({ eventOutcome: "coalesced" });
       expect(await waitForSystemEventTexts("agent:main:hook:wake:direct")).toEqual(["Direct wake"]);
       drainSystemEvents("agent:main:hook:wake:direct");
 
       const mapped = await postHook(port, "/hooks/mapped-wake", { subject: "Email" });
       expect(mapped.status).toBe(200);
+      await expect(mapped.json()).resolves.toMatchObject({ eventOutcome: "queued" });
+      const mappedDuplicate = await postHook(port, "/hooks/mapped-wake", { subject: "Email" });
+      await expect(mappedDuplicate.json()).resolves.toMatchObject({ eventOutcome: "coalesced" });
       await waitForSystemEventTexts("agent:hooks:hook:wake:fixed");
       const mappedEvents = peekSystemEventEntries("agent:hooks:hook:wake:fixed");
       expect(mappedEvents).toHaveLength(1);

--- a/src/gateway/server/hooks-request-handler.fanout.test.ts
+++ b/src/gateway/server/hooks-request-handler.fanout.test.ts
@@ -45,13 +45,16 @@ function createGmailHooksConfig(): HooksConfigResolved {
 }
 
 function createFanOutHandler(params?: {
+  dispatchWakeHook?: Parameters<typeof createHooksRequestHandler>[0]["dispatchWakeHook"];
   dispatchAgentHook?: (
     value: HookAgentDispatchPayload,
   ) => HookAgentDispatchResult | Promise<HookAgentDispatchResult>;
   hooksConfig?: HooksConfigResolved;
   fanoutResponseDeadlineMs?: number;
 }) {
-  const dispatchWakeHook = vi.fn();
+  const dispatchWakeHook = vi.fn(
+    params?.dispatchWakeHook ?? (() => ({ eventOutcome: "queued" as const })),
+  );
   const dispatchAgentHook = vi.fn(
     params?.dispatchAgentHook ??
       ((value: HookAgentDispatchPayload) => ({
@@ -238,7 +241,13 @@ describe("hook fan-out dispatch", () => {
       fs.mkdirSync(path.join(transformsDir, "hooks", "transforms"), { recursive: true });
       fs.writeFileSync(
         path.join(transformsDir, "hooks", "transforms", "mixed.mjs"),
-        'export default (ctx) => ctx.payload.messages[0].kind === "wake" ? { kind: "wake", text: `wake:${ctx.payload.messages[0].id}` } : {};',
+        [
+          'export default (ctx) => ctx.payload.messages[0].kind === "wake"',
+          ' ? { kind: "wake", text: `wake:${ctx.payload.messages[0].id}` }',
+          ' : ctx.payload.messages[0].kind === "invalid-agent"',
+          '   ? { channel: "missing-channel" }',
+          "   : {};",
+        ].join(""),
       );
       const canonical = createHooksConfig();
       const hooksConfig: HooksConfigResolved = {
@@ -267,23 +276,58 @@ describe("hook fan-out dispatch", () => {
           allowedSessionKeyPrefixes: ["hook:gmail:"],
         },
       };
-      const { handler, dispatchAgentHook, dispatchWakeHook } = createFanOutHandler({ hooksConfig });
+      let coalesceWakes = false;
+      const { handler, dispatchAgentHook, dispatchWakeHook } = createFanOutHandler({
+        hooksConfig,
+        dispatchWakeHook: (value) => ({
+          eventOutcome: coalesceWakes || value.text === "wake:w1" ? "coalesced" : "queued",
+        }),
+      });
 
       const response = await postGmailPayload(handler, {
         messages: [
           { id: "w1", kind: "wake" },
+          { id: "w2", kind: "wake" },
           { id: "a1", kind: "agent" },
         ],
       });
 
       expect(response.res.statusCode).toBe(200);
-      expect(dispatchWakeHook).toHaveBeenCalledTimes(1);
+      expect(JSON.parse(response.getBody())).toMatchObject({ eventOutcome: "queued" });
+      expect(dispatchWakeHook).toHaveBeenCalledTimes(2);
       expect(dispatchWakeHook.mock.calls[0]?.[0]).toMatchObject({ text: "wake:w1" });
       expect(dispatchAgentHook).toHaveBeenCalledTimes(1);
       expect(dispatchAgentHook.mock.calls[0]?.[0]).toMatchObject({
         message: "agent:a1",
         sessionKey: "hook:gmail:a1",
       });
+
+      coalesceWakes = true;
+      const replay = await postGmailPayload(handler, {
+        messages: [
+          { id: "w1", kind: "wake" },
+          { id: "w2", kind: "wake" },
+          { id: "a1", kind: "agent" },
+        ],
+      });
+      expect(JSON.parse(replay.getBody())).toMatchObject({ eventOutcome: "coalesced" });
+      expect(dispatchWakeHook).toHaveBeenCalledTimes(4);
+      expect(dispatchAgentHook).toHaveBeenCalledTimes(1);
+
+      coalesceWakes = false;
+      const invalid = await postGmailPayload(handler, {
+        messages: [
+          { id: "w3", kind: "wake" },
+          { id: "a2", kind: "invalid-agent" },
+        ],
+      });
+      expect(invalid.res.statusCode).toBe(400);
+      expect(JSON.parse(invalid.getBody())).toMatchObject({
+        ok: false,
+        eventOutcome: "queued",
+      });
+      expect(dispatchWakeHook).toHaveBeenCalledTimes(5);
+      expect(dispatchAgentHook).toHaveBeenCalledTimes(1);
     } finally {
       fs.rmSync(transformsDir, { recursive: true, force: true });
     }

--- a/src/gateway/server/hooks-request-handler.ts
+++ b/src/gateway/server/hooks-request-handler.ts
@@ -88,23 +88,23 @@ async function settleFanOutDispatches(
   }
 }
 
-function sendAgentDispatchResult(res: ServerResponse, result: HookAgentDispatchResult) {
+function sendAgentResult(
+  res: ServerResponse,
+  result: HookAgentDispatchResult & Partial<WakeResult>,
+) {
   if (result.ok) {
-    sendJson(res, 200, { ok: true, runId: result.runId });
+    sendJson(res, 200, result);
     return;
   }
-  sendJson(res, result.statusCode, {
-    ok: false,
-    error: result.error,
-    ...(result.runId ? { runId: result.runId } : {}),
-  });
+  const { statusCode, ...body } = result;
+  sendJson(res, statusCode, body);
 }
 
-function sendFanOutDispatchResult(res: ServerResponse, settled: FanOutSettled[]) {
+function sendFanOutResult(res: ServerResponse, settled: FanOutSettled[], wake?: WakeResult) {
   const first = settled[0];
   if (settled.length === 1 && first !== undefined && first !== FAN_OUT_PENDING) {
     // Single-item batches keep the exact single-dispatch response shape.
-    sendAgentDispatchResult(res, first);
+    sendAgentResult(res, { ...first, ...wake });
     return;
   }
   const runIds: string[] = [];
@@ -120,7 +120,8 @@ function sendFanOutDispatchResult(res: ServerResponse, settled: FanOutSettled[])
     }
   }
   if (failures.length === 0 && pending === 0) {
-    sendJson(res, 200, { ok: true, runId: runIds[0], runIds, dispatched: runIds.length });
+    const result = { ok: true, runId: runIds[0], runIds, dispatched: runIds.length };
+    sendJson(res, 200, { ...result, ...wake });
     return;
   }
   // A non-2xx makes the producer redeliver the batch; already-dispatched items
@@ -131,6 +132,7 @@ function sendFanOutDispatchResult(res: ServerResponse, settled: FanOutSettled[])
     error: `hook fan-out incomplete: ${runIds.length}/${settled.length} dispatched, ${failures.length} failed, ${pending} pending`,
     runIds,
     ...(failures.length > 0 ? { errors: failures.slice(0, 5).map((entry) => entry.error) } : {}),
+    ...wake,
   });
 }
 
@@ -141,11 +143,13 @@ export type HookClientIpConfig = Readonly<{
 
 export type HooksRequestHandler = (req: IncomingMessage, res: ServerResponse) => Promise<boolean>;
 
+type WakeResult = { eventOutcome: "queued" | "coalesced" };
+
 type HookDispatchers = {
   dispatchWakeHook: (
     value: { text: string; mode: "now" | "next-heartbeat"; sessionKey?: string },
     agentId: string,
-  ) => void;
+  ) => WakeResult;
   dispatchAgentHook: (
     value: HookAgentDispatchPayload,
   ) => HookAgentDispatchResult | Promise<HookAgentDispatchResult>;
@@ -396,6 +400,10 @@ export function createHooksRequestHandler(
       headers,
     });
     const now = Date.now();
+    // Later mapped validation errors must report any wake outcome that already occurred.
+    let wakeResult: WakeResult | undefined;
+    const sendHookError = (error: string) =>
+      sendJson(res, 400, { ok: false, error, ...wakeResult });
     const resolveDispatchSessionKeyOrRespond = (
       sessionKeyValue: string,
       targetAgentId: string,
@@ -406,7 +414,7 @@ export function createHooksRequestHandler(
       });
       const allowedPrefixes = hooksConfig.sessionPolicy.allowedSessionKeyPrefixes;
       if (allowedPrefixes && !isSessionKeyAllowedByPrefix(dispatchSessionKey, allowedPrefixes)) {
-        sendJson(res, 400, { ok: false, error: getHookSessionKeyPrefixError(allowedPrefixes) });
+        sendHookError(getHookSessionKeyPrefixError(allowedPrefixes));
         return null;
       }
       return dispatchSessionKey;
@@ -417,23 +425,21 @@ export function createHooksRequestHandler(
     ): Extract<HookTargetAgentResolution, { ok: true }> | null => {
       const resolution = resolveEffectiveHookTargetAgentId(hooksConfig, agentId, source);
       if (!resolution.ok) {
-        sendJson(res, 400, { ok: false, error: resolution.error });
+        sendHookError(resolution.error);
         return null;
       }
       if (!isHookAgentAllowed(hooksConfig, resolution.effectiveAgentId)) {
-        sendJson(res, 400, { ok: false, error: getHookAgentPolicyError() });
+        sendHookError(getHookAgentPolicyError());
         return null;
       }
       return resolution;
     };
-    // Dispatches one wake action; returns false when an error response was
-    // already sent. Callers own the success response so fan-out mappings can
-    // dispatch several wakes before answering once.
-    const dispatchWakeActionOrRespond = (
+    // Callers own the success response so mappings can dispatch several wakes first.
+    const dispatchWake = (
       value: Parameters<HookDispatchers["dispatchWakeHook"]>[0],
       targetAgentId: string,
       source: HookSessionKeySource,
-    ): boolean => {
+    ): WakeResult | null => {
       let dispatchSessionKey: string | undefined;
       if (value.sessionKey) {
         const sessionKey = resolveHookSessionKey({
@@ -442,27 +448,20 @@ export function createHooksRequestHandler(
           sessionKey: value.sessionKey,
         });
         if (!sessionKey.ok) {
-          sendJson(res, 400, { ok: false, error: sessionKey.error });
-          return false;
+          sendHookError(sessionKey.error);
+          return null;
         }
         const resolvedSessionKey = resolveDispatchSessionKeyOrRespond(
           sessionKey.value,
           targetAgentId,
         );
         if (resolvedSessionKey === null) {
-          return false;
+          return null;
         }
         dispatchSessionKey = resolvedSessionKey;
       }
-      dispatchWakeHook(
-        {
-          text: value.text,
-          mode: value.mode,
-          ...(dispatchSessionKey ? { sessionKey: dispatchSessionKey } : {}),
-        },
-        targetAgentId,
-      );
-      return true;
+      const dispatchValue = { ...value, sessionKey: dispatchSessionKey };
+      return dispatchWakeHook(dispatchValue, targetAgentId);
     };
 
     if (subPath === "wake") {
@@ -475,10 +474,11 @@ export function createHooksRequestHandler(
       if (!target) {
         return true;
       }
-      if (!dispatchWakeActionOrRespond(normalized.value, target.effectiveAgentId, "request")) {
+      const directWakeResult = dispatchWake(normalized.value, target.effectiveAgentId, "request");
+      if (!directWakeResult) {
         return true;
       }
-      sendJson(res, 200, { ok: true, mode: normalized.value.mode });
+      sendJson(res, 200, { ok: true, mode: normalized.value.mode, ...directWakeResult });
       return true;
     }
 
@@ -542,7 +542,7 @@ export function createHooksRequestHandler(
       });
       const replay = resolveHookReplay(replayKey, now);
       if (replay) {
-        sendAgentDispatchResult(res, await replay);
+        sendAgentResult(res, await replay);
         return true;
       }
       const dispatchSessionKey = resolveDispatchSessionKeyOrRespond(
@@ -563,7 +563,7 @@ export function createHooksRequestHandler(
           externalContentSource: "webhook",
         }),
       );
-      sendAgentDispatchResult(res, dispatched);
+      sendAgentResult(res, dispatched);
       return true;
     }
 
@@ -605,7 +605,7 @@ export function createHooksRequestHandler(
           ): (() => HookAgentDispatchResult | Promise<HookAgentDispatchResult>) | null => {
             const channel = resolveHookChannel(action.channel);
             if (!channel) {
-              sendJson(res, 400, { ok: false, error: getHookChannelError() });
+              sendHookError(getHookChannelError());
               return null;
             }
             const deliver = resolveHookDeliver(action.deliver);
@@ -621,11 +621,9 @@ export function createHooksRequestHandler(
               !action.sessionKey &&
               !hooksConfig.sessionPolicy.defaultSessionKey
             ) {
-              sendJson(res, 400, {
-                ok: false,
-                error:
-                  "sessionKey or hooks.defaultSessionKey is required when mapped hook sessionMode is persistent",
-              });
+              sendHookError(
+                "sessionKey or hooks.defaultSessionKey is required when mapped hook sessionMode is persistent",
+              );
               return null;
             }
             const sessionKey = resolveHookSessionKey({
@@ -634,7 +632,7 @@ export function createHooksRequestHandler(
               sessionKey: action.sessionKey,
             });
             if (!sessionKey.ok) {
-              sendJson(res, 400, { ok: false, error: sessionKey.error });
+              sendHookError(sessionKey.error);
               return null;
             }
             const dispatchSessionKey = resolveDispatchSessionKeyOrRespond(
@@ -707,9 +705,9 @@ export function createHooksRequestHandler(
           };
 
           // One pass over every action so a per-item transform emitting mixed
-          // kinds loses nothing: wakes enqueue immediately (no replay
+          // kinds loses nothing: wakes dispatch immediately (no replay
           // identity — a producer retry after a partial agent failure
-          // re-enqueues them), agents collect for dispatch.
+          // dispatches them again), agents collect for dispatch.
           const dispatches: Array<
             () => HookAgentDispatchResult | Promise<HookAgentDispatchResult>
           > = [];
@@ -720,13 +718,16 @@ export function createHooksRequestHandler(
               if (!target) {
                 return true;
               }
-              const dispatched = dispatchWakeActionOrRespond(
+              const dispatched = dispatchWake(
                 { text: action.text, mode: action.mode, sessionKey: action.sessionKey },
                 target.effectiveAgentId,
                 action.sessionKeySource === "static" ? "mapping-static" : "mapping-templated",
               );
               if (!dispatched) {
                 return true;
+              }
+              if (!wakeResult || dispatched.eventOutcome === "queued") {
+                wakeResult = dispatched;
               }
               wakeMode = action.mode;
               continue;
@@ -738,22 +739,20 @@ export function createHooksRequestHandler(
             dispatches.push(prepared);
           }
           if (dispatches.length === 0) {
-            sendJson(res, 200, { ok: true, mode: wakeMode ?? "now" });
+            sendJson(res, 200, { ok: true, mode: wakeMode ?? "now", ...wakeResult });
             return true;
           }
           if (!mapped.fanout) {
             // Non-fanout mappings produce exactly one action.
             const dispatched = await dispatches[0]!();
-            sendAgentDispatchResult(res, dispatched);
+            sendAgentResult(res, { ...dispatched, ...wakeResult });
             return true;
           }
-          sendFanOutDispatchResult(
-            res,
-            await settleFanOutDispatches(
-              dispatches.map((dispatch) => Promise.resolve(dispatch())),
-              fanoutResponseDeadlineMs,
-            ),
+          const settled = await settleFanOutDispatches(
+            dispatches.map((dispatch) => Promise.resolve(dispatch())),
+            fanoutResponseDeadlineMs,
           );
+          sendFanOutResult(res, settled, wakeResult);
           return true;
         }
       } catch (err) {

--- a/src/gateway/server/hooks.agent-trust.test.ts
+++ b/src/gateway/server/hooks.agent-trust.test.ts
@@ -235,8 +235,10 @@ describe("dispatchAgentHook trust handling", () => {
       },
     });
 
-    dispatchWakeHook({ text: "Mapped wake", mode: "now" }, "molty");
+    enqueueSystemEventMock.mockReturnValue(false);
+    const result = dispatchWakeHook({ text: "Mapped wake", mode: "now" }, "molty");
 
+    expect(result).toEqual({ eventOutcome: "coalesced" });
     expect(resolveAgentMainSessionKeyMock).toHaveBeenCalledWith({
       cfg: expect.any(Object),
       agentId: "molty",

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -273,7 +273,7 @@ export function createGatewayHookDispatcher(params: {
     });
     const sessionKey = target.eventSessionKey;
     const eventOptions = { sessionKey };
-    enqueueSystemEvent(
+    const queued = enqueueSystemEvent(
       value.text,
       isUnscopedSessionKeySentinel(sessionKey)
         ? withSystemEventOwner(eventOptions, agentId)
@@ -287,6 +287,7 @@ export function createGatewayHookDispatcher(params: {
         ...target.heartbeatTarget,
       });
     }
+    return { eventOutcome: queued ? "queued" : "coalesced" } as const;
   };
 
   const dispatchAgentHook = async (

--- a/test/e2e/qa-lab/runtime/gateway-http-apis.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-http-apis.e2e.test.ts
@@ -266,7 +266,11 @@ describe("Gateway HTTP API product proof", () => {
         body: JSON.stringify({ text: "Gateway HTTP QA wake", mode: "next-heartbeat" }),
       });
       expect(authenticatedWake.response.status).toBe(200);
-      expect(authenticatedWake.body).toEqual({ ok: true, mode: "next-heartbeat" });
+      expect(authenticatedWake.body).toEqual({
+        ok: true,
+        mode: "next-heartbeat",
+        eventOutcome: "queued",
+      });
       expect(peekSystemEventEntries(mainSessionKey).map((event) => event.text)).toEqual([
         "Gateway HTTP QA wake",
       ]);


### PR DESCRIPTION
Closes #131950

## What Problem This Solves

Repeated `POST /hooks/wake` calls returned indistinguishable successful responses even when the queue accepted the first wake and coalesced the second. Mixed mapped batches could also dispatch a wake and then omit that already-recorded outcome when a later action failed validation.

## Why This Change Was Made

The hook dispatcher now preserves the queue owner's enqueue result and exposes `eventOutcome: "queued" | "coalesced"` in direct and mapped wake responses. Mapped batches report `queued` if any wake was accepted and `coalesced` if every wake was coalesced. Partial error responses retain the outcome of wakes that already occurred.

`mode: "now"` still requests a heartbeat in either case, so a repeated immediate wake can activate an earlier deferred event. Queue deduplication, persistence, and replay semantics are unchanged.

## User Impact

Hook producers can distinguish a new queue insertion from benign coalescing without treating coalescence as a retryable error. Existing successful requests remain HTTP 200 and retain their existing response keys.

## Evidence

- The queue owner returns `true` for an accepted wake and `false` for a coalesced wake; the previous handler discarded that result.
- Direct and mapped regressions cover consecutive `queued` then `coalesced` responses while retaining one pending event.
- Mixed fan-out coverage proves `queued` when any wake is accepted, `coalesced` when all wakes coalesce, and preservation of `eventOutcome` when a later mapped action returns HTTP 400.
- Dispatcher coverage proves a coalesced `mode: "now"` wake still requests a heartbeat.
- Validation requires exact-head GitHub CI and the repository's remote preparation gate before landing.
