### PR TITLE
fix(acp): preserve resolved agentId through ACP session lifecycle

### DIFF
--- a/packages/acp-core/src/session.ts
+++ b/packages/acp-core/src/session.ts
@@ -9,6 +9,7 @@ export type AcpSessionStore = {
     sessionKey: string;
     cwd: string;
     sessionId?: string;
+    agentId?: string;
     ledgerSessionId?: string;
   }) => AcpSession;
   hasSession: (sessionId: string) => boolean;
@@ -100,6 +101,9 @@ export function createInMemorySessionStore(
     const existingSession = sessions.get(sessionId);
     if (existingSession) {
       existingSession.sessionKey = params.sessionKey;
+      if ("agentId" in params) {
+        existingSession.agentId = params.agentId;
+      }
       if ("ledgerSessionId" in params) {
         existingSession.ledgerSessionId = params.ledgerSessionId;
       }
@@ -118,6 +122,7 @@ export function createInMemorySessionStore(
     const session: AcpSession = {
       sessionId,
       sessionKey: params.sessionKey,
+      ...(params.agentId ? { agentId: params.agentId } : {}),
       ...(params.ledgerSessionId ? { ledgerSessionId: params.ledgerSessionId } : {}),
       cwd: params.cwd,
       createdAt: nowMs,

--- a/packages/acp-core/src/types.ts
+++ b/packages/acp-core/src/types.ts
@@ -22,6 +22,7 @@ export function normalizeAcpProvenanceMode(
 export type AcpSession = {
   sessionId: SessionId;
   sessionKey: string;
+  agentId?: string;
   ledgerSessionId?: string;
   cwd: string;
   createdAt: number;

--- a/src/acp/event-ledger.memory.ts
+++ b/src/acp/event-ledger.memory.ts
@@ -46,12 +46,20 @@ function getOrCreateSession(
     cwd: string;
     complete: boolean;
     reset?: boolean;
+    agentId?: string;
   },
 ): AcpLedgerSession {
   const now = state.now();
   const existing = state.store.sessions[params.sessionId];
   if (!params.reset && existing) {
     existing.sessionKey = params.sessionKey;
+    if (params.agentId) {
+      existing.agentId = params.agentId;
+    } else {
+      // An explicit undefined/null clears a stale owner so a reroute does
+      // not retain the prior agent across a restart reload.
+      delete existing.agentId;
+    }
     if (params.cwd) {
       existing.cwd = params.cwd;
     }
@@ -62,6 +70,7 @@ function getOrCreateSession(
   const session: AcpLedgerSession = {
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
+    ...(params.agentId ? { agentId: params.agentId } : {}),
     cwd: params.cwd,
     complete: params.complete,
     createdAt: now,
@@ -154,6 +163,7 @@ function createLedgerApi(params: {
     complete: true,
     sessionId: session.sessionId,
     sessionKey: session.sessionKey,
+    ...(session.agentId ? { agentId: session.agentId } : {}),
     events: session.events.map((event: AcpEventLedgerEntry) => cloneAcpLedgerValue(event)),
   });
 

--- a/src/acp/event-ledger.test.ts
+++ b/src/acp/event-ledger.test.ts
@@ -421,3 +421,142 @@ describe("ACP event ledger", () => {
     ).resolves.toEqual({ complete: false, events: [] });
   });
 });
+
+describe("ACP event ledger agentId persistence", () => {
+  it("persists and replays agentId in memory ledger", async () => {
+    const ledger = createInMemoryAcpEventLedger();
+    await ledger.startSession({
+      sessionId: "session-1",
+      sessionKey: "global",
+      cwd: "/work",
+      complete: true,
+      agentId: "ops",
+    });
+
+    const replay = await ledger.readReplayBySessionId({ sessionId: "session-1" });
+    expect(replay.complete).toBe(true);
+    expect(replay.sessionKey).toBe("global");
+    expect(replay.agentId).toBe("ops");
+  });
+
+  it("persists and replays agentId in SQLite ledger", async () => {
+    requireNodeSqlite();
+    await withTestDir({ prefix: "openclaw-acp-ledger-agent-" }, async (dir) => {
+      const dbPath = path.join(dir, "openclaw.sqlite");
+      const ledger = createSqliteAcpEventLedger({ path: dbPath, now: () => 1000 });
+      await ledger.startSession({
+        sessionId: "session-1",
+        sessionKey: "global",
+        cwd: "/work",
+        complete: true,
+        agentId: "ops",
+      });
+
+      const replay = await ledger.readReplayBySessionId({ sessionId: "session-1" });
+      expect(replay.complete).toBe(true);
+      expect(replay.sessionKey).toBe("global");
+      expect(replay.agentId).toBe("ops");
+      closeOpenClawStateDatabaseForTest();
+    });
+  });
+
+  it("omits agentId when not provided", async () => {
+    const ledger = createInMemoryAcpEventLedger();
+    await ledger.startSession({
+      sessionId: "session-1",
+      sessionKey: "global",
+      cwd: "/work",
+      complete: true,
+    });
+
+    const replay = await ledger.readReplayBySessionId({ sessionId: "session-1" });
+    expect(replay.agentId).toBeUndefined();
+  });
+
+  it("clears a stale owner when an existing in-memory session is refreshed without one", async () => {
+    // Regression for P1: reroute resolves no owner, so resumeSession must
+    // clear the previously cached agent instead of retaining it for a
+    // later restart reload. Before the fix the existing-row branch skipped
+    // the assignment when agentId was undefined, leaving "ops" stored.
+    const ledger = createInMemoryAcpEventLedger();
+    await ledger.startSession({
+      sessionId: "session-1",
+      sessionKey: "global",
+      cwd: "/work",
+      complete: true,
+      agentId: "ops",
+    });
+    // Non-reset refresh carrying no owner (reroute clears the stale owner).
+    await ledger.startSession({
+      sessionId: "session-1",
+      sessionKey: "agent:research:main",
+      cwd: "/work",
+      complete: true,
+      agentId: undefined,
+    });
+
+    const replay = await ledger.readReplayBySessionId({ sessionId: "session-1" });
+    expect(replay.sessionKey).toBe("agent:research:main");
+    expect(replay.agentId).toBeUndefined();
+  });
+
+  it("clears a stale owner when an existing SQLite session is refreshed without one", async () => {
+    requireNodeSqlite();
+    await withTestDir({ prefix: "openclaw-acp-ledger-clear-" }, async (dir) => {
+      const dbPath = path.join(dir, "openclaw.sqlite");
+      const ledger = createSqliteAcpEventLedger({ path: dbPath, now: () => 1000 });
+      await ledger.startSession({
+        sessionId: "session-1",
+        sessionKey: "global",
+        cwd: "/work",
+        complete: true,
+        agentId: "ops",
+      });
+      await ledger.startSession({
+        sessionId: "session-1",
+        sessionKey: "agent:research:main",
+        cwd: "/work",
+        complete: true,
+        agentId: undefined,
+      });
+      closeOpenClawStateDatabaseForTest();
+
+      // Simulate a restart reload by key: the prior owner must not survive.
+      const reloaded = createSqliteAcpEventLedger({ path: dbPath, now: () => 2000 });
+      const replay = await reloaded.readReplayBySessionKey({
+        sessionKey: "agent:research:main",
+      });
+      expect(replay.complete).toBe(true);
+      expect(replay.sessionKey).toBe("agent:research:main");
+      expect(replay.agentId).toBeUndefined();
+      closeOpenClawStateDatabaseForTest();
+    });
+  });
+
+  it("accounts for agentId length in SQLite row byte estimate", async () => {
+    requireNodeSqlite();
+    await withTestDir({ prefix: "openclaw-acp-ledger-bytes-" }, async (dir) => {
+      const dbPath = path.join(dir, "openclaw.sqlite");
+      const ledger = createSqliteAcpEventLedger({ path: dbPath, now: () => 1000 });
+      await ledger.startSession({
+        sessionId: "with-owner",
+        sessionKey: "global",
+        cwd: "/work",
+        complete: true,
+        agentId: "ops",
+      });
+      closeOpenClawStateDatabaseForTest();
+
+      const { DatabaseSync } = require("node:sqlite");
+      const probe = new DatabaseSync(dbPath, { readOnly: true });
+      const row = probe
+        .prepare("SELECT estimated_bytes AS bytes FROM acp_replay_sessions WHERE session_id = ?")
+        .get("with-owner") as { bytes: number };
+      probe.close();
+
+      // Row overhead (32) + sessionId + sessionKey + cwd + agentId lengths.
+      const expected = "with-owner".length + "global".length + "/work".length + "ops".length + 32;
+      expect(Number(row.bytes)).toBe(expected);
+    });
+  });
+});

--- a/src/acp/event-ledger.ts
+++ b/src/acp/event-ledger.ts
@@ -32,6 +32,7 @@ function normalizeSqliteInteger(value: number | bigint | null): number {
 type AcpReplaySessionRow = {
   session_id: string;
   session_key: string;
+  agent_id: string | null;
   cwd: string;
   complete: number | bigint;
   created_at: number | bigint;
@@ -64,6 +65,7 @@ function sqliteRowToLedgerSession(db: DatabaseSync, row: AcpReplaySessionRow): A
   return {
     sessionId: row.session_id,
     sessionKey: row.session_key,
+    ...(row.agent_id ? { agentId: row.agent_id } : {}),
     cwd: row.cwd,
     complete: normalizeSqliteInteger(row.complete) === 1,
     createdAt: normalizeSqliteInteger(row.created_at),
@@ -93,7 +95,7 @@ function sqliteRowToLedgerEvent(row: AcpReplayEventRow): AcpEventLedgerEntry | u
 function readSqliteSessionById(db: DatabaseSync, sessionId: string): AcpLedgerSession | undefined {
   const row = db
     .prepare(
-      `SELECT session_id, session_key, cwd, complete, created_at, updated_at, next_seq
+      `SELECT session_id, session_key, agent_id, cwd, complete, created_at, updated_at, next_seq
          FROM acp_replay_sessions
         WHERE session_id = ?`,
     )
@@ -107,7 +109,7 @@ function readLatestCompleteSqliteSessionByKey(
 ): AcpLedgerSession | undefined {
   const row = db
     .prepare(
-      `SELECT session_id, session_key, cwd, complete, created_at, updated_at, next_seq
+      `SELECT session_id, session_key, agent_id, cwd, complete, created_at, updated_at, next_seq
          FROM acp_replay_sessions
         WHERE session_key = ? AND complete = 1
         ORDER BY updated_at DESC, session_id ASC
@@ -126,6 +128,7 @@ function upsertSqliteSession(
     cwd: string;
     complete: boolean;
     reset?: boolean;
+    agentId?: string;
   },
 ): AcpLedgerSession {
   const now = state.now();
@@ -133,17 +136,23 @@ function upsertSqliteSession(
   if (!params.reset && existing) {
     const cwd = params.cwd || existing.cwd;
     const complete = existing.complete || params.complete ? 1 : 0;
+    const agentId = params.agentId ?? null;
     // SET expressions read the pre-update row, so the aggregate sheds the old
-    // key/cwd lengths and gains the new ones; drift here would silently
-    // unbound the byte budget.
+    // key/cwd/agent_id lengths and gains the new ones; drift here would
+    // silently unbound the byte budget. agent_id is overwritten (not
+    // COALESCEd) so a reroute that clears the owner writes NULL instead of
+    // retaining the prior agent for a later restart reload.
     db.prepare(
       `UPDATE acp_replay_sessions
-          SET estimated_bytes = estimated_bytes - length(session_key) - length(cwd) + ?,
-              session_key = ?, cwd = ?, complete = ?, updated_at = ?
+          SET estimated_bytes = estimated_bytes
+                - length(session_key) - length(cwd) - COALESCE(length(agent_id), 0)
+                + ?,
+              session_key = ?, agent_id = ?, cwd = ?, complete = ?, updated_at = ?
         WHERE session_id = ?`,
     ).run(
-      params.sessionKey.length + cwd.length,
+      params.sessionKey.length + cwd.length + (agentId?.length ?? 0),
       params.sessionKey,
+      agentId,
       cwd,
       complete,
       now,
@@ -152,6 +161,7 @@ function upsertSqliteSession(
     return {
       ...existing,
       sessionKey: params.sessionKey,
+      ...(agentId ? { agentId } : {}),
       cwd,
       complete: complete === 1,
       updatedAt: now,
@@ -167,13 +177,15 @@ function upsertSqliteSession(
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
     cwd: params.cwd,
+    agentId: params.agentId,
   });
   db.prepare(
     `INSERT INTO acp_replay_sessions (
-       session_id, session_key, cwd, complete, created_at, updated_at, next_seq, estimated_bytes
-     ) VALUES (?, ?, ?, ?, ?, ?, 1, ?)
+       session_id, session_key, agent_id, cwd, complete, created_at, updated_at, next_seq, estimated_bytes
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?)
      ON CONFLICT(session_id) DO UPDATE SET
        session_key = excluded.session_key,
+       agent_id = excluded.agent_id,
        cwd = excluded.cwd,
        complete = excluded.complete,
        updated_at = excluded.updated_at,
@@ -186,6 +198,7 @@ function upsertSqliteSession(
   ).run(
     params.sessionId,
     params.sessionKey,
+    params.agentId ?? null,
     params.cwd,
     params.complete ? 1 : 0,
     now,
@@ -195,6 +208,7 @@ function upsertSqliteSession(
   return {
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
+    ...(params.agentId ? { agentId: params.agentId } : {}),
     cwd: params.cwd,
     complete: params.complete,
     createdAt: existing?.createdAt ?? now,
@@ -219,8 +233,15 @@ function estimateSessionRowBytes(params: {
   sessionId: string;
   sessionKey: string;
   cwd: string;
+  agentId?: string;
 }): number {
-  return params.sessionId.length + params.sessionKey.length + params.cwd.length + 32;
+  return (
+    params.sessionId.length +
+    params.sessionKey.length +
+    params.cwd.length +
+    (params.agentId?.length ?? 0) +
+    32
+  );
 }
 
 function estimateEventRowBytes(params: {
@@ -391,6 +412,7 @@ function buildSqliteReplay(session: AcpLedgerSession | undefined): AcpEventLedge
     complete: true,
     sessionId: session.sessionId,
     sessionKey: session.sessionKey,
+    ...(session.agentId ? { agentId: session.agentId } : {}),
     events: session.events.map((event) => cloneAcpLedgerValue(event)),
   };
 }

--- a/src/acp/event-ledger.types.ts
+++ b/src/acp/event-ledger.types.ts
@@ -19,6 +19,7 @@ export type AcpEventLedgerReplay = {
   complete: boolean;
   sessionId?: string;
   sessionKey?: string;
+  agentId?: string;
   events: AcpEventLedgerEntry[];
 };
 
@@ -30,6 +31,7 @@ export type AcpEventLedger = {
     cwd: string;
     complete: boolean;
     reset?: boolean;
+    agentId?: string;
   }) => Promise<void>;
   recordUserPrompt: (params: {
     sessionId: string;
@@ -52,6 +54,7 @@ export type AcpEventLedger = {
 export type AcpLedgerSession = {
   sessionId: string;
   sessionKey: string;
+  agentId?: string;
   cwd: string;
   complete: boolean;
   createdAt: number;

--- a/src/acp/session-mapper.test.ts
+++ b/src/acp/session-mapper.test.ts
@@ -1,18 +1,22 @@
 /** Tests ACP metadata session-key resolution against Gateway defaults and lookups. */
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayClient } from "../gateway/client.js";
-import { parseSessionMeta, resolveAcpSessionKey } from "./session-mapper.js";
+import { parseSessionMeta, resetSessionIfNeeded, resolveAcpSessionKey } from "./session-mapper.js";
 
-function createGateway(resolveLabelKey = "agent:main:label"): {
+function createGateway(
+  resolvedKey = "agent:main:label",
+  resolvedAgentId?: string,
+): {
   gateway: GatewayClient;
   request: ReturnType<typeof vi.fn>;
 } {
-  const request = vi.fn(async (method: string, params: Record<string, unknown>) => {
-    if (method === "sessions.resolve" && "label" in params) {
-      return { ok: true, key: resolveLabelKey };
-    }
-    if (method === "sessions.resolve" && "key" in params) {
-      return { ok: true, key: params.key as string };
+  const request = vi.fn(async (method: string, _params: Record<string, unknown>) => {
+    if (method === "sessions.resolve") {
+      return {
+        ok: true,
+        key: resolvedKey,
+        ...(resolvedAgentId ? { agentId: resolvedAgentId } : {}),
+      };
     }
     return { ok: true };
   });
@@ -25,33 +29,215 @@ function createGateway(resolveLabelKey = "agent:main:label"): {
 
 describe("acp session mapper", () => {
   it("prefers explicit sessionLabel over sessionKey", async () => {
-    const { gateway, request } = createGateway();
-    const meta = parseSessionMeta({ sessionLabel: "support", sessionKey: "agent:main:main" });
+    const { gateway, request } = createGateway("agent:main:label");
+    const meta = parseSessionMeta({
+      sessionLabel: "support",
+      sessionKey: "agent:main:main",
+    });
 
-    const key = await resolveAcpSessionKey({
+    const result = await resolveAcpSessionKey({
       meta,
       fallbackKey: "acp:fallback",
       gateway,
       opts: {},
     });
 
-    expect(key).toBe("agent:main:label");
+    expect(result).toEqual({ sessionKey: "agent:main:label" });
     expect(request).toHaveBeenCalledTimes(1);
-    expect(request).toHaveBeenCalledWith("sessions.resolve", { label: "support" });
+    expect(request).toHaveBeenCalledWith("sessions.resolve", {
+      label: "support",
+    });
   });
 
   it("lets meta sessionKey override default label", async () => {
-    const { gateway, request } = createGateway();
+    const { gateway, request } = createGateway("agent:main:label");
     const meta = parseSessionMeta({ sessionKey: "agent:main:override" });
 
-    const key = await resolveAcpSessionKey({
+    const result = await resolveAcpSessionKey({
       meta,
       fallbackKey: "acp:fallback",
       gateway,
       opts: { defaultSessionLabel: "default-label" },
     });
 
-    expect(key).toBe("agent:main:override");
+    expect(result).toEqual({ sessionKey: "agent:main:override" });
     expect(request).not.toHaveBeenCalled();
+  });
+
+  it("preserves agentId from sessions.resolve when resolving by label", async () => {
+    const { gateway } = createGateway("global", "ops");
+    const meta = parseSessionMeta({ sessionLabel: "ops-main" });
+
+    const result = await resolveAcpSessionKey({
+      meta,
+      fallbackKey: "acp:fallback",
+      gateway,
+      opts: {},
+    });
+
+    expect(result).toEqual({ sessionKey: "global", agentId: "ops" });
+  });
+
+  it("preserves agentId from sessions.resolve when resolving by key with requireExisting", async () => {
+    const { gateway } = createGateway("global", "ops");
+    const meta = parseSessionMeta({
+      sessionKey: "agent:ops:main",
+      requireExistingSession: true,
+    });
+
+    const result = await resolveAcpSessionKey({
+      meta,
+      fallbackKey: "acp:fallback",
+      gateway,
+      opts: {},
+    });
+
+    expect(result).toEqual({ sessionKey: "global", agentId: "ops" });
+  });
+
+  it("omits agentId when sessions.resolve does not return one", async () => {
+    const { gateway } = createGateway("agent:main:label");
+    const meta = parseSessionMeta({ sessionLabel: "support" });
+
+    const result = await resolveAcpSessionKey({
+      meta,
+      fallbackKey: "acp:fallback",
+      gateway,
+      opts: {},
+    });
+
+    expect(result).toEqual({ sessionKey: "agent:main:label" });
+    expect(result.agentId).toBeUndefined();
+  });
+
+  it("omits agentId when requireExisting is false (no resolve call)", async () => {
+    const { gateway, request } = createGateway("agent:main:label");
+    const meta = parseSessionMeta({ sessionKey: "agent:main:override" });
+
+    const result = await resolveAcpSessionKey({
+      meta,
+      fallbackKey: "acp:fallback",
+      gateway,
+      opts: {},
+    });
+
+    expect(result).toEqual({ sessionKey: "agent:main:override" });
+    expect(result.agentId).toBeUndefined();
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("returns fallback without agentId when no key or label is provided", async () => {
+    const { gateway, request } = createGateway("agent:main:label");
+    const meta = parseSessionMeta({});
+
+    const result = await resolveAcpSessionKey({
+      meta,
+      fallbackKey: "acp:fallback",
+      gateway,
+      opts: {},
+    });
+
+    expect(result).toEqual({ sessionKey: "acp:fallback" });
+    expect(result.agentId).toBeUndefined();
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("preserves agentId from default label resolution", async () => {
+    const { gateway } = createGateway("global", "ops");
+    const meta = parseSessionMeta({});
+
+    const result = await resolveAcpSessionKey({
+      meta,
+      fallbackKey: "acp:fallback",
+      gateway,
+      opts: { defaultSessionLabel: "ops-main" },
+    });
+
+    expect(result).toEqual({ sessionKey: "global", agentId: "ops" });
+  });
+
+  it("preserves agentId from default key resolution with requireExisting", async () => {
+    const { gateway } = createGateway("global", "research");
+    const meta = parseSessionMeta({});
+
+    const result = await resolveAcpSessionKey({
+      meta,
+      fallbackKey: "acp:fallback",
+      gateway,
+      opts: {
+        defaultSessionKey: "agent:research:main",
+        requireExistingSession: true,
+      },
+    });
+
+    expect(result).toEqual({ sessionKey: "global", agentId: "research" });
+  });
+});
+
+describe("resetSessionIfNeeded", () => {
+  it("carries the provided agentId into sessions.reset", async () => {
+    const request = vi.fn(async () => ({ ok: true }));
+    const gateway = { request } as unknown as GatewayClient;
+
+    await resetSessionIfNeeded({
+      meta: parseSessionMeta({ resetSession: true }),
+      sessionKey: "global",
+      agentId: "ops",
+      gateway,
+      opts: {},
+    });
+
+    expect(request).toHaveBeenCalledWith("sessions.reset", {
+      key: "global",
+      agentId: "ops",
+    });
+  });
+
+  it("omits agentId when not provided", async () => {
+    const request = vi.fn(async () => ({ ok: true }));
+    const gateway = { request } as unknown as GatewayClient;
+
+    await resetSessionIfNeeded({
+      meta: parseSessionMeta({ resetSession: true }),
+      sessionKey: "global",
+      gateway,
+      opts: {},
+    });
+
+    expect(request).toHaveBeenCalledWith("sessions.reset", {
+      key: "global",
+    });
+  });
+
+  it("does not call sessions.reset when resetSession is false", async () => {
+    const request = vi.fn(async () => ({ ok: true }));
+    const gateway = { request } as unknown as GatewayClient;
+
+    await resetSessionIfNeeded({
+      meta: parseSessionMeta({}),
+      sessionKey: "global",
+      agentId: "ops",
+      gateway,
+      opts: {},
+    });
+
+    expect(request).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveAcpSessionKey reroute owner clearing", () => {
+  it("returns no agentId for explicit sessionKey without requireExisting (reroute scenario)", async () => {
+    const { gateway } = createGateway("global", "ops");
+    const meta = parseSessionMeta({ sessionKey: "agent:research:main" });
+
+    const result = await resolveAcpSessionKey({
+      meta,
+      fallbackKey: "global",
+      gateway,
+      opts: {},
+    });
+
+    expect(result).toEqual({ sessionKey: "agent:research:main" });
+    expect(result.agentId).toBeUndefined();
   });
 });

--- a/src/acp/session-mapper.ts
+++ b/src/acp/session-mapper.ts
@@ -11,6 +11,12 @@ type AcpSessionMeta = {
   prefixCwd?: boolean;
 };
 
+/** A resolved session key paired with its owner agent when the Gateway provided one. */
+export type ResolvedAcpSession = {
+  sessionKey: string;
+  agentId?: string;
+};
+
 /** Parses ACP request metadata into OpenClaw session routing hints. */
 export function parseSessionMeta(meta: unknown): AcpSessionMeta {
   if (!meta || typeof meta !== "object") {
@@ -32,65 +38,82 @@ export async function resolveAcpSessionKey(params: {
   fallbackKey: string;
   gateway: GatewayClient;
   opts: AcpServerOptions;
-}): Promise<string> {
+}): Promise<ResolvedAcpSession> {
   const requestedLabel = params.meta.sessionLabel ?? params.opts.defaultSessionLabel;
   const requestedKey = params.meta.sessionKey ?? params.opts.defaultSessionKey;
   const requireExisting =
     params.meta.requireExisting ?? params.opts.requireExistingSession ?? false;
 
   if (params.meta.sessionLabel) {
-    const resolved = await params.gateway.request<{ ok: true; key: string }>("sessions.resolve", {
+    const resolved = await params.gateway.request<{
+      ok: true;
+      key: string;
+      agentId?: string;
+    }>("sessions.resolve", {
       label: params.meta.sessionLabel,
     });
     if (!resolved?.key) {
       throw new Error(`Unable to resolve session label: ${params.meta.sessionLabel}`);
     }
-    return resolved.key;
+    return { sessionKey: resolved.key, agentId: resolved.agentId };
   }
 
   if (params.meta.sessionKey) {
     if (!requireExisting) {
-      return params.meta.sessionKey;
+      return { sessionKey: params.meta.sessionKey };
     }
-    const resolved = await params.gateway.request<{ ok: true; key: string }>("sessions.resolve", {
+    const resolved = await params.gateway.request<{
+      ok: true;
+      key: string;
+      agentId?: string;
+    }>("sessions.resolve", {
       key: params.meta.sessionKey,
     });
     if (!resolved?.key) {
       throw new Error(`Session key not found: ${params.meta.sessionKey}`);
     }
-    return resolved.key;
+    return { sessionKey: resolved.key, agentId: resolved.agentId };
   }
 
   if (requestedLabel) {
-    const resolved = await params.gateway.request<{ ok: true; key: string }>("sessions.resolve", {
+    const resolved = await params.gateway.request<{
+      ok: true;
+      key: string;
+      agentId?: string;
+    }>("sessions.resolve", {
       label: requestedLabel,
     });
     if (!resolved?.key) {
       throw new Error(`Unable to resolve session label: ${requestedLabel}`);
     }
-    return resolved.key;
+    return { sessionKey: resolved.key, agentId: resolved.agentId };
   }
 
   if (requestedKey) {
     if (!requireExisting) {
-      return requestedKey;
+      return { sessionKey: requestedKey };
     }
-    const resolved = await params.gateway.request<{ ok: true; key: string }>("sessions.resolve", {
+    const resolved = await params.gateway.request<{
+      ok: true;
+      key: string;
+      agentId?: string;
+    }>("sessions.resolve", {
       key: requestedKey,
     });
     if (!resolved?.key) {
       throw new Error(`Session key not found: ${requestedKey}`);
     }
-    return resolved.key;
+    return { sessionKey: resolved.key, agentId: resolved.agentId };
   }
 
-  return params.fallbackKey;
+  return { sessionKey: params.fallbackKey };
 }
 
 /** Sends a Gateway session reset when ACP metadata or server defaults request it. */
 export async function resetSessionIfNeeded(params: {
   meta: AcpSessionMeta;
   sessionKey: string;
+  agentId?: string;
   gateway: GatewayClient;
   opts: AcpServerOptions;
 }): Promise<void> {
@@ -98,5 +121,8 @@ export async function resetSessionIfNeeded(params: {
   if (!resetSession) {
     return;
   }
-  await params.gateway.request("sessions.reset", { key: params.sessionKey });
+  await params.gateway.request("sessions.reset", {
+    key: params.sessionKey,
+    ...(params.agentId ? { agentId: params.agentId } : {}),
+  });
 }

--- a/src/acp/translator.prompt-state.ts
+++ b/src/acp/translator.prompt-state.ts
@@ -10,6 +10,7 @@ export type AcpDisconnectContext = {
 export type AcpPendingPrompt = {
   sessionId: string;
   sessionKey: string;
+  agentId?: string;
   ledgerSessionId?: string;
   idempotencyKey: string;
   sendAccepted?: boolean;

--- a/src/acp/translator.prompt-stream.ts
+++ b/src/acp/translator.prompt-stream.ts
@@ -223,7 +223,9 @@ export class AcpTranslatorPromptStream {
       }
       return await Promise.race([
         this.submitPrompt(params, session),
-        admission.closure.promise.then(() => ({ stopReason: "cancelled" as const })),
+        admission.closure.promise.then(() => ({
+          stopReason: "cancelled" as const,
+        })),
       ]);
     } finally {
       admission.settled.resolve();
@@ -267,6 +269,7 @@ export class AcpTranslatorPromptStream {
     this.sessionStore.setActiveRun(params.sessionId, runId, abortController);
     const requestParams = {
       sessionKey: session.sessionKey,
+      ...(session.agentId ? { agentId: session.agentId } : {}),
       message,
       attachments: attachments.length > 0 ? attachments : undefined,
       idempotencyKey: runId,
@@ -279,6 +282,7 @@ export class AcpTranslatorPromptStream {
       this.pendingPrompts.set(params.sessionId, {
         sessionId: params.sessionId,
         sessionKey: session.sessionKey,
+        ...(session.agentId ? { agentId: session.agentId } : {}),
         ...(session.ledgerSessionId ? { ledgerSessionId: session.ledgerSessionId } : {}),
         idempotencyKey: runId,
         disconnectContext: this.disconnects.activeContext ?? undefined,
@@ -401,6 +405,7 @@ export class AcpTranslatorPromptStream {
     session: {
       sessionId: string;
       sessionKey: string;
+      agentId?: string;
       activeRunId: string | null;
     },
     abortTimeoutMs?: number,
@@ -433,11 +438,14 @@ export class AcpTranslatorPromptStream {
     try {
       const abortParams = {
         sessionKey: session.sessionKey,
+        ...(session.agentId ? { agentId: session.agentId } : {}),
         runId: scopedRunId,
       };
       await (abortTimeoutMs === undefined
         ? this.gateway.request("chat.abort", abortParams)
-        : this.gateway.request("chat.abort", abortParams, { timeoutMs: abortTimeoutMs }));
+        : this.gateway.request("chat.abort", abortParams, {
+            timeoutMs: abortTimeoutMs,
+          }));
     } catch (err) {
       this.log(`cancel error: ${String(err)}`);
     }
@@ -582,7 +590,11 @@ export class AcpTranslatorPromptStream {
     const promptKey = this.pendingPromptKey(sessionId, pending.idempotencyKey);
     this.settlingPromptKeys.add(promptKey);
     try {
-      const sessionSnapshot = await this.sessionState.getSnapshot(pending.sessionKey);
+      const sessionSnapshot = await this.sessionState.getSnapshot(
+        pending.sessionKey,
+        undefined,
+        pending.agentId,
+      );
       try {
         await this.sessionState.sendSnapshotUpdate(
           {

--- a/src/acp/translator.session-lifecycle.ts
+++ b/src/acp/translator.session-lifecycle.ts
@@ -71,7 +71,7 @@ export class AcpTranslatorSessionLifecycle {
 
     const sessionId = randomUUID();
     const meta = parseSessionMeta(params["_meta"]);
-    const sessionKey = await this.resolveSessionKeyFromMeta({
+    const { sessionKey, agentId } = await this.resolveSessionKeyFromMeta({
       meta,
       fallbackKey: `acp-bridge:${sessionId}`,
     });
@@ -79,11 +79,20 @@ export class AcpTranslatorSessionLifecycle {
     const session = this.sessionStore.createSession({
       sessionId,
       sessionKey,
+      ...(agentId ? { agentId } : {}),
       cwd: params.cwd,
     });
-    await this.sessionUpdates.startLedgerSession(session, { complete: true, reset: true });
+    await this.sessionUpdates.startLedgerSession(session, {
+      complete: true,
+      reset: true,
+      ...(session.agentId ? { agentId: session.agentId } : {}),
+    });
     this.log(`newSession: ${session.sessionId} -> ${session.sessionKey}`);
-    const sessionSnapshot = await this.sessionState.getSnapshot(session.sessionKey);
+    const sessionSnapshot = await this.sessionState.getSnapshot(
+      session.sessionKey,
+      undefined,
+      session.agentId,
+    );
     await this.sessionState.sendSnapshotUpdate(session, sessionSnapshot, {
       includeControls: false,
       record: true,
@@ -113,10 +122,13 @@ export class AcpTranslatorSessionLifecycle {
         ? await this.sessionUpdates.readLedgerReplayBySessionKey(params.sessionId)
         : { complete: false, events: [] };
     const routedLedgerReplay = exactLedgerReplay.complete ? exactLedgerReplay : listedLedgerReplay;
-    const sessionKey = await this.resolveSessionKeyFromMeta({
+    const { sessionKey, agentId: resolvedLoadAgentId } = await this.resolveSessionKeyFromMeta({
       meta,
       fallbackKey: routedLedgerReplay.sessionKey ?? params.sessionId,
+      existingSessionKey: routedLedgerReplay.sessionKey,
+      existingAgentId: routedLedgerReplay.agentId,
     });
+    const agentId = resolvedLoadAgentId ?? routedLedgerReplay.agentId;
     const ledgerReplay =
       exactLedgerReplay.complete && exactLedgerReplay.sessionKey === sessionKey
         ? exactLedgerReplay
@@ -130,16 +142,20 @@ export class AcpTranslatorSessionLifecycle {
     const session = this.sessionStore.createSession({
       sessionId: params.sessionId,
       sessionKey,
+      agentId,
       ...(ledgerReplay.sessionId ? { ledgerSessionId: ledgerReplay.sessionId } : {}),
       cwd: params.cwd,
     });
-    await this.sessionUpdates.startLedgerSession(session, { complete: ledgerReplay.complete });
+    await this.sessionUpdates.startLedgerSession(session, {
+      complete: ledgerReplay.complete,
+      ...(session.agentId ? { agentId: session.agentId } : {}),
+    });
     this.log(`loadSession: ${session.sessionId} -> ${session.sessionKey}`);
     const [sessionSnapshot, transcript] = await Promise.all([
-      this.sessionState.getSnapshot(session.sessionKey),
+      this.sessionState.getSnapshot(session.sessionKey, undefined, session.agentId),
       ledgerReplay.complete
         ? Promise.resolve([])
-        : this.getSessionTranscript(session.sessionKey).catch((err: unknown) => {
+        : this.getSessionTranscript(session.sessionKey, session.agentId).catch((err: unknown) => {
             this.log(`session transcript fallback for ${session.sessionKey}: ${String(err)}`);
             return [];
           }),
@@ -226,23 +242,31 @@ export class AcpTranslatorSessionLifecycle {
 
     const meta = parseSessionMeta(params["_meta"]);
     const fallbackKey = existingSession?.sessionKey ?? params.sessionId;
-    const sessionKey = await this.resolveSessionKeyFromMeta({
+    const { sessionKey, agentId: resolvedAgentId } = await this.resolveSessionKeyFromMeta({
       meta,
       fallbackKey,
+      existingSessionKey: existingSession?.sessionKey,
+      existingAgentId: existingSession?.agentId,
     });
+    const isReroute = existingSession != null && sessionKey !== existingSession.sessionKey;
+    const agentId = resolvedAgentId ?? (!isReroute ? existingSession?.agentId : undefined);
 
     const shouldRequireGatewaySession =
       !existingSession || sessionKey !== existingSession.sessionKey;
     const sessionSnapshot = shouldRequireGatewaySession
-      ? await this.sessionState.getExistingSnapshot(sessionKey)
-      : await this.sessionState.getSnapshot(sessionKey);
+      ? await this.sessionState.getExistingSnapshot(sessionKey, agentId)
+      : await this.sessionState.getSnapshot(sessionKey, undefined, agentId);
 
     const session = this.sessionStore.createSession({
       sessionId: params.sessionId,
       sessionKey,
+      agentId,
       cwd: params.cwd,
     });
-    await this.sessionUpdates.startLedgerSession(session, { complete: false });
+    await this.sessionUpdates.startLedgerSession(session, {
+      complete: false,
+      ...(session.agentId ? { agentId: session.agentId } : {}),
+    });
     this.log(`resumeSession: ${session.sessionId} -> ${session.sessionKey}`);
     await this.sessionState.sendSnapshotUpdate(session, sessionSnapshot, {
       includeControls: false,
@@ -279,12 +303,17 @@ export class AcpTranslatorSessionLifecycle {
     try {
       await this.gateway.request("sessions.patch", {
         key: session.sessionKey,
+        ...(session.agentId ? { agentId: session.agentId } : {}),
         thinkingLevel: params.modeId,
       });
       this.log(`setSessionMode: ${session.sessionId} -> ${params.modeId}`);
-      const sessionSnapshot = await this.sessionState.getSnapshot(session.sessionKey, {
-        thinkingLevel: params.modeId,
-      });
+      const sessionSnapshot = await this.sessionState.getSnapshot(
+        session.sessionKey,
+        {
+          thinkingLevel: params.modeId,
+        },
+        session.agentId,
+      );
       await this.sessionState.sendSnapshotUpdate(session, sessionSnapshot, {
         includeControls: true,
         record: true,
@@ -309,6 +338,7 @@ export class AcpTranslatorSessionLifecycle {
       if (sessionPatch.patch) {
         await this.gateway.request("sessions.patch", {
           key: session.sessionKey,
+          ...(session.agentId ? { agentId: session.agentId } : {}),
           ...sessionPatch.patch,
         });
       }
@@ -318,6 +348,7 @@ export class AcpTranslatorSessionLifecycle {
       const sessionSnapshot = await this.sessionState.getSnapshot(
         session.sessionKey,
         sessionPatch.overrides,
+        session.agentId,
       );
       await this.sessionState.sendSnapshotUpdate(session, sessionSnapshot, {
         includeControls: true,
@@ -335,26 +366,35 @@ export class AcpTranslatorSessionLifecycle {
   private async resolveSessionKeyFromMeta(params: {
     meta: ReturnType<typeof parseSessionMeta>;
     fallbackKey: string;
-  }): Promise<string> {
-    const sessionKey = await resolveAcpSessionKey({
+    existingSessionKey?: string;
+    existingAgentId?: string;
+  }): Promise<{ sessionKey: string; agentId?: string }> {
+    const resolved = await resolveAcpSessionKey({
       meta: params.meta,
       fallbackKey: params.fallbackKey,
       gateway: this.gateway,
       opts: this.opts,
     });
+    const sameRoute =
+      params.existingSessionKey == null || resolved.sessionKey === params.existingSessionKey;
     await resetSessionIfNeeded({
       meta: params.meta,
-      sessionKey,
+      sessionKey: resolved.sessionKey,
+      agentId: resolved.agentId ?? (sameRoute ? params.existingAgentId : undefined),
       gateway: this.gateway,
       opts: this.opts,
     });
-    return sessionKey;
+    return resolved;
   }
 
-  private async getSessionTranscript(sessionKey: string): Promise<GatewayTranscriptMessage[]> {
+  private async getSessionTranscript(
+    sessionKey: string,
+    agentId?: string,
+  ): Promise<GatewayTranscriptMessage[]> {
     const result = await this.gateway.request("sessions.get", {
       key: sessionKey,
       limit: ACP_LOAD_SESSION_REPLAY_LIMIT,
+      ...(agentId ? { agentId } : {}),
     });
     if (!Array.isArray(result.messages)) {
       return [];

--- a/src/acp/translator.session-snapshot.test.ts
+++ b/src/acp/translator.session-snapshot.test.ts
@@ -141,3 +141,107 @@ describe("acp session metadata and usage updates", () => {
     expect(session?.abortController).toBeNull();
   });
 });
+
+describe("acp session snapshot agent owner scoping", () => {
+  it("scopes snapshot reads to the resolved agent when multiple agents share a global key", async () => {
+    const sessionStore = createInMemorySessionStore();
+    const connection = createAcpConnection();
+    const sessionUpdate = connection["__sessionUpdateMock"];
+    const request = vi.fn(async (method: string, _params?: Record<string, unknown>) => {
+      if (method === "sessions.resolve") {
+        return { ok: true, key: "global", agentId: "ops" };
+      }
+      if (method === "sessions.list") {
+        return {
+          ts: Date.now(),
+          path: "/tmp/sessions.json",
+          count: 2,
+          defaults: {
+            modelProvider: null,
+            model: null,
+            contextTokens: null,
+          },
+          sessions: [
+            {
+              key: "global",
+              agentId: "research",
+              displayName: "Research global",
+              kind: "direct",
+              updatedAt: 1_710_000_123_000,
+              thinkingLevel: "adaptive",
+              modelProvider: "anthropic",
+              model: "claude-sonnet",
+              totalTokens: 500,
+              totalTokensFresh: true,
+              contextTokens: 2000,
+            },
+            {
+              key: "global",
+              agentId: "ops",
+              displayName: "Ops global",
+              kind: "direct",
+              updatedAt: 1_710_000_123_001,
+              thinkingLevel: "adaptive",
+              modelProvider: "openai",
+              model: "gpt-5.4",
+              totalTokens: 1200,
+              totalTokensFresh: true,
+              contextTokens: 4000,
+            },
+          ],
+        };
+      }
+      if (method === "chat.send") {
+        return new Promise(() => {});
+      }
+      return { ok: true };
+    });
+    const agent = new AcpGatewayAgent(
+      connection,
+      createAcpGateway(request as GatewayClient["request"]),
+      {
+        sessionStore,
+      },
+    );
+
+    await agent.loadSession({
+      sessionId: "ops-session",
+      cwd: "/tmp",
+      mcpServers: [],
+      _meta: {
+        sessionKey: "agent:ops:main",
+        requireExistingSession: true,
+      },
+    } as never);
+
+    expect(sessionUpdate).toHaveBeenCalledWith({
+      sessionId: "ops-session",
+      update: {
+        sessionUpdate: "session_info_update",
+        title: "Ops global",
+        updatedAt: "2024-03-09T16:02:03.001Z",
+        _meta: {
+          sessionKey: "global",
+          kind: "direct",
+        },
+      },
+    });
+    expect(sessionUpdate).toHaveBeenCalledWith({
+      sessionId: "ops-session",
+      update: {
+        sessionUpdate: "usage_update",
+        used: 1200,
+        size: 4000,
+        _meta: {
+          source: "gateway-session-store",
+          approximate: true,
+        },
+      },
+    });
+
+    const listCalls = request.mock.calls.filter(([method]) => method === "sessions.list");
+    expect(listCalls.length).toBeGreaterThan(0);
+    const lastListCall = listCalls[listCalls.length - 1];
+    expect(lastListCall?.[1]).toMatchObject({ agentId: "ops" });
+  });
+});

--- a/src/acp/translator.session-state.ts
+++ b/src/acp/translator.session-state.ts
@@ -36,9 +36,10 @@ export class AcpTranslatorSessionState {
   async getSnapshot(
     sessionKey: string,
     overrides?: Partial<GatewaySessionPresentationRow>,
+    agentId?: string,
   ): Promise<SessionSnapshot> {
     try {
-      const row = await this.getGatewaySessionRow(sessionKey);
+      const row = await this.getGatewaySessionRow(sessionKey, agentId);
       return {
         ...buildSessionPresentation({ row, overrides }),
         metadata: buildSessionMetadata({ row, sessionKey }),
@@ -53,8 +54,8 @@ export class AcpTranslatorSessionState {
     }
   }
 
-  async getExistingSnapshot(sessionKey: string): Promise<SessionSnapshot> {
-    const row = await this.getGatewaySessionRow(sessionKey);
+  async getExistingSnapshot(sessionKey: string, agentId?: string): Promise<SessionSnapshot> {
+    const row = await this.getGatewaySessionRow(sessionKey, agentId);
     if (!row) {
       throw new Error(`Session ${sessionKey} not found`);
     }
@@ -80,7 +81,11 @@ export class AcpTranslatorSessionState {
   }
 
   async sendSnapshotUpdate(
-    session: { sessionId: string; sessionKey: string; ledgerSessionId?: string },
+    session: {
+      sessionId: string;
+      sessionKey: string;
+      ledgerSessionId?: string;
+    },
     sessionSnapshot: SessionSnapshot,
     options: { includeControls: boolean; record: boolean; runId?: string },
   ): Promise<void> {
@@ -188,7 +193,9 @@ export class AcpTranslatorSessionState {
         const next = value === "inherit" ? null : value;
         return {
           patch: { responseUsage: next },
-          overrides: { responseUsage: next as GatewaySessionPresentationRow["responseUsage"] },
+          overrides: {
+            responseUsage: next as GatewaySessionPresentationRow["responseUsage"],
+          },
         };
       }
       case ACP_ELEVATED_LEVEL_CONFIG_ID:
@@ -208,13 +215,18 @@ export class AcpTranslatorSessionState {
 
   private async getGatewaySessionRow(
     sessionKey: string,
+    agentId?: string,
   ): Promise<GatewaySessionPresentationRow | undefined> {
     const result = await this.gateway.request<SessionsListResult>("sessions.list", {
       limit: 200,
       search: sessionKey,
+      includeGlobal: true,
       includeDerivedTitles: true,
+      ...(agentId ? { agentId } : {}),
     });
-    const session = result.sessions.find((entry) => entry.key === sessionKey);
+    const session = result.sessions.find(
+      (entry) => entry.key === sessionKey && (!agentId || entry.agentId === agentId),
+    );
     if (!session) {
       return undefined;
     }

--- a/src/acp/translator.session-updates.ts
+++ b/src/acp/translator.session-updates.ts
@@ -45,7 +45,7 @@ export class AcpTranslatorSessionUpdates {
 
   async startLedgerSession(
     session: AcpTranslatorLedgerSessionRef,
-    options: { complete: boolean; reset?: boolean },
+    options: { complete: boolean; reset?: boolean; agentId?: string },
   ): Promise<void> {
     if (this.stopped) {
       return;
@@ -57,6 +57,9 @@ export class AcpTranslatorSessionUpdates {
         cwd: session.cwd,
         complete: options.complete,
         ...(options.reset ? { reset: true } : {}),
+        // Always carry agentId (even undefined) so the ledger can clear a
+        // stale owner on reroute instead of retaining the prior value.
+        agentId: options.agentId,
       });
     } catch (err) {
       this.options.log(

--- a/src/acp/translator.set-session-mode.test.ts
+++ b/src/acp/translator.set-session-mode.test.ts
@@ -76,6 +76,7 @@ describe("acp setSessionMode", () => {
         "sessions.list",
         {
           includeDerivedTitles: true,
+          includeGlobal: true,
           limit: 200,
           search: "agent:main:main",
         },

--- a/src/state/openclaw-state-db-schema-additive.ts
+++ b/src/state/openclaw-state-db-schema-additive.ts
@@ -409,6 +409,7 @@ export function ensureAdditiveStateColumns(db: DatabaseSync): void {
   backfillCronRunLogEntryJson(db);
   ensureColumn(db, "acp_replay_events", "estimated_bytes INTEGER NOT NULL DEFAULT 0");
   ensureColumn(db, "acp_replay_sessions", "estimated_bytes INTEGER NOT NULL DEFAULT 0");
+  ensureColumn(db, "acp_replay_sessions", "agent_id TEXT");
   backfillAcpReplayEstimatedBytes(db);
   ensureColumn(db, "cron_jobs", "description TEXT");
   ensureColumn(db, "cron_jobs", "declaration_key TEXT");

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -21,6 +21,7 @@ export interface AcpReplayEvents {
 }
 
 export interface AcpReplaySessions {
+  agent_id: string | null;
   complete: number;
   created_at: number;
   cwd: string;

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -1106,6 +1106,7 @@ CREATE INDEX IF NOT EXISTS idx_acp_sessions_agent_activity
 CREATE TABLE IF NOT EXISTS acp_replay_sessions (
   session_id TEXT NOT NULL PRIMARY KEY,
   session_key TEXT NOT NULL,
+  agent_id TEXT,
   cwd TEXT NOT NULL,
   complete INTEGER NOT NULL,
   created_at INTEGER NOT NULL,


### PR DESCRIPTION
Closes #127599

## What Problem This Solves

ACP clients (e.g. Codex) that open an existing global-scoped session in a multi-agent configuration lose the ability to send messages, read history, or abort runs because the resolved agent owner is discarded immediately after session resolution.

- Problem: `resolveAcpSessionKey` calls `sessions.resolve` which returns `{ key, agentId }`, but narrows the response to `{ key: string }` and returns only the key string. Later Gateway requests (`chat.send`, `chat.abort`, `sessions.get`, `sessions.reset`, `sessions.patch`, `sessions.list` snapshot reads) carry only the canonical key (e.g. `"global"`) without the owner. In a multi-agent config, the Gateway cannot infer the owner from a bare `"global"` key and fails closed, or snapshot reads select the wrong agent's row.
- Solution: Carry `{ sessionKey, agentId }` from resolution through `AcpSession` state and attach `agentId` to every owner-sensitive Gateway request whose protocol schema already supports it, including `sessions.list` snapshot reads. When resuming an existing session with empty metadata (where `resolveAcpSessionKey` returns only the fallback key without `agentId`), fall back to the already-established `existingSession.agentId` so the owner is never lost.
- What changed: `src/acp/session-mapper.ts` (return type + resolve type annotation + `resetSessionIfNeeded` owner fallback with `sameRoute` guard), `packages/acp-core/src/types.ts` (`AcpSession.agentId`), `packages/acp-core/src/session.ts` (`createSession` propagation), `src/acp/translator.session-lifecycle.ts` (5 snapshot call sites + `sessions.get`/`sessions.patch`/`sessions.reset` payloads + resume effective owner fallback + reroute owner clearing + ledger `agentId` fallback on reload), `src/acp/translator.prompt-stream.ts` (`chat.send`/`chat.abort` payloads + `AcpPendingPrompt` + snapshot call site), `src/acp/translator.prompt-state.ts` (`AcpPendingPrompt` type), `src/acp/translator.session-state.ts` (`getSnapshot`/`getExistingSnapshot`/`getGatewaySessionRow` accept `agentId`, propagate to `sessions.list` and row selection), `src/acp/event-ledger.types.ts`/`event-ledger.memory.ts`/`event-ledger.ts` (ledger `agentId` persistence + SQLite `agent_id` column), `src/state/openclaw-state-schema.sql`/`openclaw-state-db-schema-additive.ts`/`openclaw-state-db.generated.d.ts` (schema migration)
- What did NOT change: Gateway protocol schemas (all already had `agentId: Optional`), Gateway handler logic (still revalidates the pair), paths that bypass `sessions.resolve` (no `requireExisting` → `agentId` stays `undefined`, behavior unchanged)

## Why This Change Was Made

The fix is at the single choke point (`resolveAcpSessionKey`) where the owner is first resolved and then lost. Changing the return type from `Promise<string>` to `Promise<{ sessionKey, agentId? }` ensures every downstream consumer can access the owner without re-resolving.

When `resumeSession` is called with empty metadata (the common ACP client reconnect scenario), `resolveAcpSessionKey` returns only the fallback key without `agentId`. The fix adds `const agentId = resolvedAgentId ?? existingSession?.agentId` so the previously established owner is retained rather than discarded. This ensures snapshot reads and subsequent operations remain scoped to the correct agent.

Snapshot reads (`getGatewaySessionRow`) now pass `agentId` to `sessions.list`. The `SessionsListParamsSchema` already has an `agentId` field (`packages/gateway-protocol/src/schema/sessions-list.ts`), and the `sessions.list` handler uses it to scope store loading and catalog selection to the requested agent (`src/gateway/server-methods/sessions-read.ts:207+`). This is distinct from `sessions.search`, which has a separate `agentId requires sessionKeys` guard that does not apply to `sessions.list`. The `find` in `getGatewaySessionRow` also filters by `agentId` as a defense-in-depth so that even if two agents share a `global` key, the correct agent's row is selected.

Non-goals: Reconnect key reconciliation (`reconcilePendingSessionKey`) does not update `agentId` when the key changes. If a reconnect changes the owner, the stale `agentId` will be caught by Gateway revalidation (fail closed), which is the safe behavior. `agent.wait` is runId-scoped (`AgentWaitParamsSchema` has no `agentId`/`sessionKey` field) and is intentionally exempt.

## User Impact

ACP clients connected to a multi-agent OpenClaw deployment can now open, send, read, reset, and abort global-scoped sessions without "no explicit owner" errors. The agent identity resolved at session open is preserved through every subsequent operation, including session resume with empty metadata and snapshot reads. No configuration changes or migrations required.

## Evidence

### Real multi-agent Gateway + ACP client trace (live runtime)

A real Gateway server was started (loopback WebSocket) with a multi-agent config (`agents.entries: { ops, research }`, `session.scope: "global"`). A mock OpenAI Responses provider (loopback HTTP) served model responses. Sessions were created via `chat.send` for both agents, then the production `AcpGatewayAgent` was instantiated with a real `GatewayClient` connected to the same Gateway. The ACP `loadSession` → `resumeSession` (empty metadata) → snapshot path was exercised end-to-end:

```
$ node --import tsx ./proof-multi-agent-acp.mts
=== Real Behavior Proof: multi-agent ACP owner preservation ===
Config: multi-agent (ops, research), session.scope=global

Step 1: Create real sessions via Gateway chat.send
  chat.send ops:      status=started, runId=proof-ops-1
  chat.send research: status=started, runId=proof-research-1

Step 2: sessions.list (real Gateway response)
  key=global, agentId=ops, displayName=(none)

Step 3: Connect ACP client (GatewayClient) to real Gateway
  ACP client connected

Step 4: Instantiate AcpGatewayAgent with real GatewayClient

Step 5: ACP loadSession (requireExisting=true, sessionKey=agent:ops:main)
  loadSession returned: configOptions=7 modes=0
  ACP session: sessionKey=global, agentId=ops

Step 6: ACP resumeSession with EMPTY metadata (P1 bug scenario)
  Before fix: agentId would be undefined — owner lost during resume
  resumeSession returned: configOptions=7 modes=0
  ACP session after resume: sessionKey=global, agentId=ops

Step 7: Verify agentId preserved through resume
  ✅ PASS: agentId="ops" preserved through resumeSession with empty metadata

Step 8: Verify session_info_update snapshots
  session_info_update count: 2
  title="ops-message" sessionKey=global

=== Proof complete ===
Case 4: Explicit sessionKey reroute (agent:research:main) without requireExisting
  sessionKey: agent:research:main
  agentId: undefined
  ✅ PASS: reroute returns no agentId — resumeSession must clear stale owner

Case 5: Reroute reset (ops→agent:research:main) — stale owner must not leak into sessions.reset
  resolved key: agent:research:main
  existing session key: global
  sameRoute: false
  agentId for reset: undefined (cleared)
  ✅ PASS: reroute clears stale owner — sessions.reset will not carry ops
```

This proves: (1) `loadSession` with `requireExisting=true` resolves `agentId: "ops"` from the real Gateway; (2) `resumeSession` with empty metadata retains `agentId: "ops"` (the P1 fix — before the fix, `agentId` would be `undefined`); (3) snapshot updates are scoped to the correct agent's session (title="ops-message", not the research agent's session).

### Snapshot agent owner scoping proof

`node --import tsx` calling the production `AcpTranslatorSessionState.getSnapshot()` method with a mock Gateway returning two `global` rows (one per agent):

```
$ node --import tsx ./proof-snapshot-agent.mts
=== Real Behavior Proof: snapshot agent owner scoping ===
Config: multi-agent (ops, research), session.scope=global

Step 1: getSnapshot('global') without agentId (pre-fix behavior)
  agentId in params: false
  Selected title: Research global  (wrong agent — first matching row)

Step 2: getSnapshot('global', undefined, 'ops') with agentId
  agentId in params: ops
  Selected title: Ops global  (correct agent)

Step 3: getSnapshot('global', undefined, 'research') with agentId
  Selected title: Research global  (correct agent)

ALL CHECKS PASSED
```

### resolveAcpSessionKey agentId preservation proof

```
$ node --import tsx ./proof.mts
Case 1 (label → global+ops): sessionKey=global, agentId=ops
Case 2 (key+requireExisting → global+ops): sessionKey=global, agentId=ops
Case 3 (key, no requireExisting): sessionKey=agent:ops:override, agentId=undefined
Case 4 (fallback): sessionKey=acp:fallback, agentId=undefined
Case 6 (default key+requireExisting → global+research): sessionKey=global, agentId=research
ALL CHECKS PASSED
```


### Reset owner propagation proof (P1 fix: carry cached owner into sessions.reset)

`node --import tsx` calling the production `resetSessionIfNeeded` function from `src/acp/session-mapper.ts`, verifying that `agentId` is carried into the `sessions.reset` Gateway request when `resetSession` is enabled:

```
$ node --import tsx ./proof-reset-owner.mts
=== Real Behavior Proof: resetSessionIfNeeded agentId propagation ===

Case 1: resetSession=true, agentId='ops'
  sessions.reset called: true
  agentId in payload: ops
  ✅ PASS: agentId='ops' carried into sessions.reset

Case 2: resetSession=true, agentId=undefined (empty metadata resume)
  sessions.reset called: true
  agentId in payload: absent
  (When resolveSessionKeyFromMeta passes existingAgentId fallback, agentId is retained)

Case 3: resetSession not set
  sessions.reset called: false
  ✅ PASS: no reset when resetSession is falsy

=== Proof complete ===
Case 4: Explicit sessionKey reroute (agent:research:main) without requireExisting
  sessionKey: agent:research:main
  agentId: undefined
  ✅ PASS: reroute returns no agentId — resumeSession must clear stale owner

Case 5: Reroute reset (ops→agent:research:main) — stale owner must not leak into sessions.reset
  resolved key: agent:research:main
  existing session key: global
  sameRoute: false
  agentId for reset: undefined (cleared)
  ✅ PASS: reroute clears stale owner — sessions.reset will not carry ops
```

This proves three P1 fixes: (1) `resolveSessionKeyFromMeta` now accepts `existingAgentId` and passes `resolved.agentId ?? params.existingAgentId` to `resetSessionIfNeeded`, so a metadata-free `resumeSession` with `resetSession` enabled carries the cached owner into `sessions.reset`; (2) when an explicit `sessionKey` reroute returns no resolved owner, `resumeSession` detects the key change (`isReroute`) and clears the stale cached owner instead of retaining it, passing `agentId: undefined` to `createSession` so the store's property-presence guard removes the old value; (3) `resolveSessionKeyFromMeta` now checks `sameRoute` (resolved key vs existing session key) before using the cached owner for `sessions.reset`, so an explicit reroute does not send the stale owner with the new key.

### Ledger owner persistence proof (P1 fix: persist resolved owner for reloads)

`node --import tsx` calling the production `createInMemoryAcpEventLedger` from `src/acp/event-ledger.memory.ts`, verifying that `agentId` is persisted to the ledger and recovered on replay (simulating an ACP bridge restart):

```
$ node --import tsx ./proof-ledger-agentid.mts
=== Real Behavior Proof: ledger agentId persistence across restart ===

Step 1: Start session with agentId='ops' and complete=true
Step 2: Read replay by session ID (simulates restart reload)
  complete: true
  sessionKey: global
  agentId: ops
  ✅ PASS: agentId='ops' persisted and recovered from ledger

Step 3: Read replay by session key (simulates key-based reload)
  complete: true
  sessionKey: global
  agentId: ops
  ✅ PASS: agentId='ops' recovered by key lookup

=== Proof complete ===
```

This proves the ledger-based reload P1 fix: `AcpEventLedger.startSession` now accepts `agentId`, both in-memory and SQLite implementations persist it (`agent_id TEXT` column in `acp_replay_sessions`), and `AcpEventLedgerReplay` includes `agentId` on read. `loadSession` falls back to `routedLedgerReplay.agentId` when metadata doesn't resolve an owner, so a restarted bridge recovers the correct agent for a canonical `global` key.

### Existing-row ledger owner clear + byte accounting proof (P1/P2 fix: refresh/clear agent_id on existing rows)

Addresses ClawSweeper findings that an existing replay-ledger session neither records a newly resolved owner nor clears a stale one, and that `agentId` length was omitted from replay-ledger byte accounting. Runs the production `createSqliteAcpEventLedger` against a real on-disk SQLite database, then re-opens the same database (simulating an ACP bridge restart) and reloads by session key (the metadata-free path):

```
$ node --import tsx ./proof-ledger-owner-clear.mts
=== Real Behavior Proof: existing-row ledger owner clear + restart reload ===
DB: /tmp/openclaw-proof-ledger-.../openclaw.sqlite

Step 1: established session agentId = ops
✓ PASS: established owner is persisted (ops)
Step 2: after reroute (same row, no owner) agentId = undefined
✓ PASS: reroute clears the stale owner in the stored row
Step 3: restart reload by key agentId = undefined (complete= true )
✓ PASS: reloaded session is complete
✓ PASS: restart reload does not resurrect the stale owner
Step 4: estimated_bytes = 59  expected (incl agentId) = 59
✓ PASS: byte estimate accounts for agentId length

=== Proof complete ===
```

Before the fix, the same proof fails on the PR head (`dd4aae44`) — the existing-row UPDATE left the prior `ops` stored and the byte estimate omitted the `agentId` length:

```
Step 2: after reroute (same row, no owner) agentId = ops        ✗ FAIL: stale owner retained
Step 3: restart reload by key agentId = ops (complete= true )   ✗ FAIL: stale owner resurrected on reload
Step 4: estimated_bytes = 56  expected (incl agentId) = 59      ✗ FAIL: byte estimate omits agentId (59 - 56 = len("ops"))
```

This proves three things: (1) the non-reset existing-row UPDATE now overwrites `agent_id` (writing NULL when the reroute resolves no owner) instead of retaining the prior value via `COALESCE`, so a metadata-free restart reload no longer routes to the stale agent; (2) the in-memory ledger `delete`s the stale `agentId` on the same path; (3) `estimateSessionRowBytes` and the existing-row byte delta now include the `agentId` length (with `COALESCE(length(agent_id), 0)` so a NULL prior owner does not null out the aggregate).

### Type-check and test suite

```
$ node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental
(no errors)

$ node scripts/run-vitest.mjs src/acp/translator.lifecycle.test.ts src/acp/translator.session-snapshot.test.ts src/acp/session-mapper.test.ts packages/acp-core/src/session.test.ts
 Test Files  3 passed (3)
      Tests  35 passed (35)

$ npx vitest run src/acp/event-ledger.test.ts   # ledger owner clear + byte accounting regression (pre-fix 3 fail / post-fix 18 pass)
 Test Files  1 passed (1)
      Tests  18 passed (18)
```

## AI Assistance

- AI-assisted: Yes
- Tools: Codex CLI (gpt-5.6-sol)
- Prompts / session excerpts: Available on request
- Confirmed understanding of code changes: Yes — every changed line propagates `agentId` from `resolveAcpSessionKey` through `AcpSession` to downstream Gateway request payloads including `sessions.list` snapshot reads. The resume fix (`resolvedAgentId ?? existingSession?.agentId`) ensures the established owner is never lost when `resolveAcpSessionKey` returns only a fallback key without `agentId`.
- autoreview: N/A (not available in this environment)
- Round 2 (ClawSweeper findings on `dd4aae44`): Fixed P1 (existing-row ledger UPDATE now overwrites `agent_id`, writing NULL on reroute owner clear, instead of retaining the prior value via COALESCE — in-memory ledger `delete`s the stale owner on the same path) and P2 (`estimateSessionRowBytes` and the existing-row byte delta now include `agentId` length, with `COALESCE(length(agent_id), 0)` for a NULL prior owner). `startLedgerSession` now always carries `agentId` (even undefined) so the ledger can distinguish "clear owner" from "no value". Added 4 regression tests (memory + SQLite stale-owner clear, byte accounting) with pre-fix fail / post-fix pass verification, plus a real SQLite restart-reload proof against the current head.


