### PR TITLE
refactor(ui): drop the reset-to-default icon from settings rows

### DIFF
--- a/ui/src/components/config-form-collection-defaults.browser.test.ts
+++ b/ui/src/components/config-form-collection-defaults.browser.test.ts
@@ -1,4 +1,4 @@
-// Control UI tests cover collection default provenance and restore behavior.
+// Control UI tests cover collection default provenance and editing behavior.
 import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
 import { renderArray, renderObject } from "./config-form.node.collection.ts";
@@ -13,15 +13,8 @@ function expectElement<T extends Element>(element: T | null | undefined, label: 
   return element;
 }
 
-function resetButton(container: ParentNode): HTMLButtonElement {
-  return expectElement(
-    container.querySelector<HTMLButtonElement>("button[aria-label='Reset to default']"),
-    "reset to default button",
-  );
-}
-
 describe("config form collection defaults", () => {
-  it("shows and restores optional JSON defaults without authoring the inherited value", () => {
+  it("shows and clears optional JSON defaults without authoring the inherited value", () => {
     const container = document.createElement("div");
     const onPatch = vi.fn();
     const schema = {
@@ -43,9 +36,13 @@ describe("config form collection defaults", () => {
     );
 
     expect(container.textContent).toContain('Default: {"mode":"balanced"}');
-    expectElement(container.querySelector<HTMLTextAreaElement>("textarea"), "explicit JSON").value =
-      '{\n  "mode": "custom"\n}';
-    resetButton(container).click();
+    const textarea = expectElement(
+      container.querySelector<HTMLTextAreaElement>("textarea"),
+      "explicit JSON",
+    );
+    expect(textarea.value).toBe('{\n  "mode": "custom"\n}');
+    textarea.value = "";
+    textarea.dispatchEvent(new Event("change", { bubbles: true }));
     expect(onPatch).toHaveBeenCalledWith(["payload"], undefined);
 
     onPatch.mockClear();
@@ -63,15 +60,14 @@ describe("config form collection defaults", () => {
     );
 
     expect(container.textContent).toContain('Using default: {"mode":"balanced"}');
-    expectElement(
-      container.querySelector<HTMLTextAreaElement>("textarea"),
-      "inherited JSON",
-    ).value = '{\n  "mode": "balanced"\n}';
-    expect(container.querySelector("button[aria-label='Reset to default']")).toBeNull();
+    expect(
+      expectElement(container.querySelector<HTMLTextAreaElement>("textarea"), "inherited JSON")
+        .value,
+    ).toBe('{\n  "mode": "balanced"\n}');
     expect(onPatch).not.toHaveBeenCalled();
   });
 
-  it("shows optional array defaults and keeps rejected restores in the DOM", () => {
+  it("shows optional array defaults and authors inherited items without dropping siblings", () => {
     const container = document.createElement("div");
     const onPatch = vi.fn(() => false);
     const schema = {
@@ -98,13 +94,10 @@ describe("config form collection defaults", () => {
 
     expect(container.textContent).toContain('Default: ["a","b"]');
     expect(container.textContent).toContain("1 item");
-    expectElement(container.querySelector<HTMLInputElement>("input"), "explicit array item").value =
-      "custom";
-    resetButton(container).click();
-    expect(onPatch).toHaveBeenCalledWith(["values"], undefined);
-    expect(container.textContent).toContain("1 item");
-    expectElement(container.querySelector<HTMLInputElement>("input"), "rejected array item").value =
-      "custom";
+    expect(
+      expectElement(container.querySelector<HTMLInputElement>("input"), "explicit array item")
+        .value,
+    ).toBe("custom");
 
     onPatch.mockClear();
     render(
@@ -128,7 +121,6 @@ describe("config form collection defaults", () => {
     const inheritedInputs = Array.from(container.querySelectorAll<HTMLInputElement>("input"));
     expect(inheritedInputs.map((input) => input.value)).toEqual(["", ""]);
     expect(inheritedInputs.map((input) => input.placeholder)).toEqual(["Default: a", "Default: b"]);
-    expect(container.querySelector("button[aria-label='Reset to default']")).toBeNull();
     expect(onPatch).not.toHaveBeenCalled();
 
     inheritedInputs[1]!.value = "custom";
@@ -193,7 +185,7 @@ describe("config form collection defaults", () => {
     );
   });
 
-  it("conceals sensitive collection defaults and disables restore until revealed", () => {
+  it("conceals sensitive collection defaults", () => {
     const container = document.createElement("div");
     const onPatch = vi.fn();
     const hints = {
@@ -224,7 +216,6 @@ describe("config form collection defaults", () => {
     );
 
     expect(container.textContent).not.toContain("default-secret");
-    expect(resetButton(container).disabled).toBe(true);
 
     render(
       renderArray(
@@ -249,10 +240,9 @@ describe("config form collection defaults", () => {
     );
 
     expect(container.textContent).not.toContain("default-token");
-    expect(resetButton(container).disabled).toBe(true);
   });
 
-  it("shows and restores a top-level object default without nesting the section", () => {
+  it("shows a top-level object default without nesting the section", () => {
     const container = document.createElement("div");
     const onPatch = vi.fn();
     const onRemove = vi.fn();
@@ -284,8 +274,6 @@ describe("config form collection defaults", () => {
 
     expect(container.textContent).toContain('Default: {"mode":"balanced"}');
     expect(container.querySelector("details")).toBeNull();
-    resetButton(container).click();
-    expect(onRemove).toHaveBeenCalledWith(["settings"]);
     expect(onPatch).not.toHaveBeenCalled();
 
     onPatch.mockClear();
@@ -309,7 +297,6 @@ describe("config form collection defaults", () => {
 
     expect(container.textContent).toContain('Using default: {"mode":"balanced"}');
     expect(container.querySelector("details")).toBeNull();
-    expect(container.querySelector("button[aria-label='Reset to default']")).toBeNull();
     expect(
       expectElement(container.querySelector<HTMLInputElement>("input"), "inherited mode")
         .placeholder,
@@ -344,11 +331,10 @@ describe("config form collection defaults", () => {
     );
 
     expect(container.textContent).not.toContain("default-secret");
-    expect(resetButton(container).disabled).toBe(true);
     expect(container.querySelector("details")).toBeNull();
   });
 
-  it("removes an optional object as one value and keeps inherited children inherited", () => {
+  it("keeps optional object children inherited until edited", () => {
     const container = document.createElement("div");
     const onPatch = vi.fn();
     const onRemove = vi.fn();
@@ -395,8 +381,6 @@ describe("config form collection defaults", () => {
       "explicit profile object",
     );
     expect(profile.textContent).toContain('Default: {"enabled":true,"mode":"balanced"}');
-    resetButton(profile).click();
-    expect(onRemove).toHaveBeenCalledWith(["settings", "profile"]);
     expect(onPatch).not.toHaveBeenCalled();
 
     onRemove.mockClear();
@@ -444,7 +428,6 @@ describe("config form collection defaults", () => {
       expectElement(modeRow.querySelector<HTMLInputElement>("input"), "inherited mode input")
         .placeholder,
     ).toBe("Default: balanced");
-    expect(inheritedProfile.querySelector("button[aria-label='Reset to default']")).toBeNull();
     expect(onRemove).not.toHaveBeenCalled();
 
     const modeInput = expectElement(
@@ -457,48 +440,5 @@ describe("config form collection defaults", () => {
       enabled: true,
       mode: "custom",
     });
-  });
-
-  it("deep-clones required collection defaults before restoring them", () => {
-    const container = document.createElement("div");
-    const onPatch = vi.fn();
-    const schemaDefault = { nested: { enabled: true } };
-
-    render(
-      renderObject(
-        {
-          schema: {
-            type: "object",
-            title: "Required object",
-            default: schemaDefault,
-            properties: {
-              nested: {
-                type: "object",
-                properties: {
-                  enabled: { type: "boolean" },
-                },
-              },
-            },
-          },
-          value: { nested: { enabled: false } },
-          path: ["settings", "requiredObject"],
-          hints: {},
-          unsupported: new Set(),
-          disabled: false,
-          isRequired: true,
-          onPatch,
-        },
-        renderNode,
-      ),
-      container,
-    );
-
-    resetButton(container).click();
-    expect(onPatch).toHaveBeenCalledWith(["settings", "requiredObject"], schemaDefault);
-    const restored = onPatch.mock.calls[0]?.[1] as typeof schemaDefault;
-    expect(restored).not.toBe(schemaDefault);
-    expect(restored.nested).not.toBe(schemaDefault.nested);
-    restored.nested.enabled = false;
-    expect(schemaDefault.nested.enabled).toBe(true);
   });
 });

--- a/ui/src/components/config-form-scalar-integrity.browser.test.ts
+++ b/ui/src/components/config-form-scalar-integrity.browser.test.ts
@@ -217,7 +217,6 @@ describe("config form scalar integrity", () => {
     expect(textInput.value).toBe("");
     expect(textInput.placeholder).toBe("Default: balanced");
     expect(container.textContent).toContain("Using default: balanced");
-    expect(container.querySelector("button[aria-label='Reset to default']")).toBeNull();
     expect(onPatch).not.toHaveBeenCalled();
     expect(onRemove).not.toHaveBeenCalled();
 
@@ -252,7 +251,27 @@ describe("config form scalar integrity", () => {
     expect(onPatch).toHaveBeenLastCalledWith(["retries"], 4);
   });
 
-  it("restores scalar and select defaults by removing optional overrides", () => {
+  it("shows the default description without a reset button on an overridden row", () => {
+    const container = document.createElement("div");
+    render(
+      renderTextInput({
+        schema: { type: "string", default: "balanced" },
+        value: "custom",
+        path: ["mode"],
+        hints: {},
+        unsupported: new Set(),
+        disabled: false,
+        inputType: "text",
+        onPatch: vi.fn(),
+      }),
+      container,
+    );
+
+    expect(container.textContent).toContain("Default: balanced");
+    expect(container.querySelector("button[aria-label='Reset to default']")).toBeNull();
+  });
+
+  it("restores scalar and select defaults through clearing and default selection", () => {
     const container = document.createElement("div");
     const onPatch = vi.fn();
     const onRemove = vi.fn();
@@ -271,14 +290,16 @@ describe("config form scalar integrity", () => {
       container,
     );
     expect(container.textContent).toContain("Default: 3");
-    expectElement(
-      container.querySelector<HTMLButtonElement>("button[aria-label='Reset to default']"),
-      "number reset",
-    ).click();
-    expect(onRemove).toHaveBeenCalledWith(["retries"]);
-    expect(onPatch).not.toHaveBeenCalled();
+    const numberInput = expectElement(
+      container.querySelector<HTMLInputElement>("input[type='number']"),
+      "number input",
+    );
+    numberInput.value = "";
+    numberInput.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(onPatch).toHaveBeenCalledWith(["retries"], undefined);
+    expect(onRemove).not.toHaveBeenCalled();
 
-    onRemove.mockClear();
+    onPatch.mockClear();
     render(
       renderSelect({
         schema: { type: "string", default: "balanced" },
@@ -712,7 +733,7 @@ describe("config form scalar integrity", () => {
     },
   );
 
-  it("keeps restore disabled while a sensitive value is concealed", () => {
+  it("conceals the default description while a sensitive value is concealed", () => {
     const container = document.createElement("div");
 
     render(
@@ -731,11 +752,6 @@ describe("config form scalar integrity", () => {
       container,
     );
 
-    const reset = expectElement(
-      container.querySelector<HTMLButtonElement>("button[aria-label='Reset to default']"),
-      "concealed sensitive reset",
-    );
-    expect(reset.disabled).toBe(true);
     expect(container.textContent).not.toContain("inherited");
   });
 

--- a/ui/src/components/config-form.node.collection.ts
+++ b/ui/src/components/config-form.node.collection.ts
@@ -38,7 +38,7 @@ import {
   getSensitiveRenderState,
   isAnySchema,
   jsonValue,
-  renderCollectionDefaultPresentation,
+  renderCollectionDefaultDescription,
   renderFlatDefaultRow,
   renderFieldRow,
   renderJsonTextareaControl,
@@ -98,7 +98,7 @@ export function renderObject(
     fallback && typeof fallback === "object" && !Array.isArray(fallback)
       ? (fallback as Record<string, unknown>)
       : {};
-  const defaultPresentation = renderCollectionDefaultPresentation(params, fallback);
+  const defaultDescription = renderCollectionDefaultDescription(params, fallback);
   const entries = objectPropertyKeys(schema)
     .map((key) => [key, objectPropertySchema(schema, key)] as const)
     .filter((entry): entry is readonly [string, ConfigNodeRenderParams["schema"]] =>
@@ -197,7 +197,7 @@ export function renderObject(
   // Top-level objects and label-less contexts emit rows directly into the
   // surrounding settings-group so row dividers stay sibling-driven.
   if (path.length === 1 || params.showLabel === false) {
-    return html`${path.length === 1 ? renderFlatDefaultRow(defaultPresentation) : nothing}${fields}`;
+    return html`${path.length === 1 ? renderFlatDefaultRow(defaultDescription) : nothing}${fields}`;
   }
 
   // Nested objects get collapsible treatment as an indented sub-block.
@@ -208,12 +208,11 @@ export function renderObject(
           <span class="settings-row__title">${label}</span>
           ${help ? html`<span class="settings-row__desc">${help}</span>` : nothing}
           ${schema.default !== undefined
-            ? html`<span class="settings-row__desc">${defaultPresentation.description}</span>`
+            ? html`<span class="settings-row__desc">${defaultDescription}</span>`
             : nothing}
           ${renderTags(tags)}
         </div>
         <div class="settings-row__control">
-          ${defaultPresentation.action}
           <span class="settings-row__chevron cfg-object__chevron">${icons.chevronDown}</span>
         </div>
       </summary>
@@ -272,7 +271,7 @@ export function renderArray(
     : Array.isArray(schema.default)
       ? schema.default
       : UNSET_ARRAY_SOURCE_IDENTITY;
-  const defaultPresentation = renderCollectionDefaultPresentation(params, arrayValue);
+  const defaultDescription = renderCollectionDefaultDescription(params, arrayValue);
   const rowIdentities = rowIdentitiesForArray(arrayValue);
   const {
     minItems: minimumItems,
@@ -356,7 +355,7 @@ export function renderArray(
             ? html`<span class="settings-row__desc">${help}</span>`
             : nothing}
           ${showHeaderMeta && schema.default !== undefined
-            ? html`<span class="settings-row__desc">${defaultPresentation.description}</span>`
+            ? html`<span class="settings-row__desc">${defaultDescription}</span>`
             : nothing}
           ${renderTags(tags)}
         </div>
@@ -366,7 +365,6 @@ export function renderArray(
               count: String(arrayValue.length),
             })}</span
           >
-          ${defaultPresentation.action}
           <button
             type="button"
             class="btn btn--sm"

--- a/ui/src/components/config-form.node.json.ts
+++ b/ui/src/components/config-form.node.json.ts
@@ -1,11 +1,10 @@
 // Control UI renderer for JSON-backed config form nodes.
-import { html, nothing, type TemplateResult } from "lit";
+import { nothing, type TemplateResult } from "lit";
 import {
   getSensitiveRenderState,
   jsonValue,
   renderFieldRow,
   renderJsonTextareaControl,
-  renderRestoreDefaultButton,
   renderSchemaDefaultDescription,
   type ConfigNodeRenderParams,
 } from "./config-form.node.shared.ts";
@@ -25,27 +24,21 @@ export function renderJsonTextarea(params: ConfigNodeRenderParams): TemplateResu
     revealSensitive: params.revealSensitive ?? false,
     isSensitivePathRevealed: params.isSensitivePathRevealed,
   });
-  const control = html`
-    ${renderJsonTextareaControl({
-      schema,
-      path,
-      ariaLabel: label,
-      descriptionId: helpId,
-      sourceValue: params.sourceIdentity ?? value,
-      rowIdentity: params.rowIdentity,
-      fallback,
-      rows: 3,
-      sensitiveState,
-      disabled,
-      isRequired: params.isRequired,
-      onToggleSensitivePath: params.onToggleSensitivePath,
-      onPatch,
-    })}
-    ${renderRestoreDefaultButton({
-      ...params,
-      disabled: disabled || sensitiveState.isRedacted,
-    })}
-  `;
+  const control = renderJsonTextareaControl({
+    schema,
+    path,
+    ariaLabel: label,
+    descriptionId: helpId,
+    sourceValue: params.sourceIdentity ?? value,
+    rowIdentity: params.rowIdentity,
+    fallback,
+    rows: 3,
+    sensitiveState,
+    disabled,
+    isRequired: params.isRequired,
+    onToggleSensitivePath: params.onToggleSensitivePath,
+    onPatch,
+  });
 
   return renderFieldRow({
     label,

--- a/ui/src/components/config-form.node.scalar.ts
+++ b/ui/src/components/config-form.node.scalar.ts
@@ -15,7 +15,6 @@ import {
   isSecretRefObject,
   jsonValue,
   renderFieldRow,
-  renderRestoreDefaultButton,
   renderSchemaDefaultDescription,
   renderSensitiveToggleButton,
   wrapSensitiveControl,
@@ -485,14 +484,6 @@ export function renderTextInput(
         </span>
       `
     : wrappedInput;
-  const control = html`
-    ${presentedInput}
-    ${renderRestoreDefaultButton({
-      ...params,
-      disabled: disabled || effectiveRedacted,
-    })}
-  `;
-
   return renderFieldRow({
     label,
     help,
@@ -500,7 +491,7 @@ export function renderTextInput(
     defaultDescription: effectiveRedacted ? nothing : renderSchemaDefaultDescription(schema, value),
     tags,
     showLabel,
-    control,
+    control: presentedInput,
   });
 }
 
@@ -623,7 +614,6 @@ export function renderNumberInput(params: ConfigNodeRenderParams): TemplateResul
     >
       +
     </button>
-    ${renderRestoreDefaultButton(params)}
   `;
 
   return renderFieldRow({

--- a/ui/src/components/config-form.node.shared.ts
+++ b/ui/src/components/config-form.node.shared.ts
@@ -266,36 +266,25 @@ export function renderFieldRow(params: {
   `;
 }
 
-export function renderFlatDefaultRow(presentation: {
-  description: TemplateResult | typeof nothing;
-  action: TemplateResult | typeof nothing;
-}): TemplateResult | typeof nothing {
-  if (presentation.description === nothing && presentation.action === nothing) {
+export function renderFlatDefaultRow(
+  description: TemplateResult | typeof nothing,
+): TemplateResult | typeof nothing {
+  if (description === nothing) {
     return nothing;
   }
   return html`
     <div class="settings-row">
-      ${presentation.description === nothing
-        ? nothing
-        : html`
-            <div class="settings-row__text">
-              <span class="settings-row__desc">${presentation.description}</span>
-            </div>
-          `}
-      ${presentation.action === nothing
-        ? nothing
-        : html`<div class="settings-row__control">${presentation.action}</div>`}
+      <div class="settings-row__text">
+        <span class="settings-row__desc">${description}</span>
+      </div>
     </div>
   `;
 }
 
-export function renderCollectionDefaultPresentation(
+export function renderCollectionDefaultDescription(
   params: ConfigNodeRenderParams,
   effectiveValue: unknown,
-): {
-  description: TemplateResult | typeof nothing;
-  action: TemplateResult | typeof nothing;
-} {
+): TemplateResult | typeof nothing {
   const redacted = getSensitiveRenderState({
     path: params.path,
     value: effectiveValue,
@@ -303,13 +292,7 @@ export function renderCollectionDefaultPresentation(
     revealSensitive: params.revealSensitive ?? false,
     isSensitivePathRevealed: params.isSensitivePathRevealed,
   }).isRedacted;
-  return {
-    description: redacted ? nothing : renderSchemaDefaultDescription(params.schema, params.value),
-    action: renderRestoreDefaultButton({
-      ...params,
-      disabled: params.disabled || redacted,
-    }),
-  };
+  return redacted ? nothing : renderSchemaDefaultDescription(params.schema, params.value);
 }
 
 export function renderSchemaDefaultDescription(
@@ -322,41 +305,6 @@ export function renderSchemaDefaultDescription(
   return html`${t(value === undefined ? "configForm.usingDefault" : "configForm.defaultValue", {
     value: formatConfigValueText(schema.default),
   })}`;
-}
-
-export function renderRestoreDefaultButton(
-  params: Pick<
-    ConfigNodeRenderParams,
-    "schema" | "value" | "path" | "disabled" | "isRequired" | "onPatch" | "onRemove"
-  >,
-): TemplateResult | typeof nothing {
-  if (params.schema.default === undefined || params.value === undefined) {
-    return nothing;
-  }
-  return html`
-    <openclaw-tooltip .content=${t("configForm.resetToDefault")}>
-      <button
-        type="button"
-        class="btn btn--icon"
-        aria-label=${t("configForm.resetToDefault")}
-        ?disabled=${params.disabled}
-        @click=${(event: Event) => {
-          event.stopPropagation();
-          if (params.isRequired) {
-            params.onPatch(params.path, structuredClone(params.schema.default));
-            return;
-          }
-          if (params.onRemove) {
-            params.onRemove(params.path);
-            return;
-          }
-          params.onPatch(params.path, undefined);
-        }}
-      >
-        ${icons.refresh}
-      </button>
-    </openclaw-tooltip>
-  `;
 }
 
 export function renderSegmentedControl(params: {

--- a/ui/src/components/config-form.node.ts
+++ b/ui/src/components/config-form.node.ts
@@ -12,7 +12,6 @@ import { renderNumberInput, renderSelect, renderTextInput } from "./config-form.
 import {
   renderFieldRow,
   isAnySchema,
-  renderRestoreDefaultButton,
   renderSchemaDefaultDescription,
   renderSegmentedControl,
   renderTags,
@@ -105,16 +104,13 @@ export function renderNode(params: ConfigNodeRenderParams): TemplateResult | typ
         defaultDescription: renderSchemaDefaultDescription(schema, value),
         tags,
         showLabel,
-        control: html`
-          ${renderSegmentedControl({
-            options: literals,
-            resolvedValue,
-            disabled,
-            ariaLabel: label,
-            onSelect: (literal) => onPatch(path, literal),
-          })}
-          ${renderRestoreDefaultButton(params)}
-        `,
+        control: renderSegmentedControl({
+          options: literals,
+          resolvedValue,
+          disabled,
+          ariaLabel: label,
+          onSelect: (literal) => onPatch(path, literal),
+        }),
       });
     }
 
@@ -170,16 +166,13 @@ export function renderNode(params: ConfigNodeRenderParams): TemplateResult | typ
         defaultDescription: renderSchemaDefaultDescription(schema, value),
         tags,
         showLabel,
-        control: html`
-          ${renderSegmentedControl({
-            options,
-            resolvedValue,
-            disabled,
-            ariaLabel: label,
-            onSelect: (option) => onPatch(path, option),
-          })}
-          ${renderRestoreDefaultButton(params)}
-        `,
+        control: renderSegmentedControl({
+          options,
+          resolvedValue,
+          disabled,
+          ariaLabel: label,
+          onSelect: (option) => onPatch(path, option),
+        }),
       });
     }
     return renderSelect({ ...params, options });
@@ -233,7 +226,6 @@ export function renderNode(params: ConfigNodeRenderParams): TemplateResult | typ
       checked: displayValue,
       disabled,
       onChange,
-      actions: renderRestoreDefaultButton(params),
     });
   }
 

--- a/ui/src/components/settings-ui.ts
+++ b/ui/src/components/settings-ui.ts
@@ -231,7 +231,6 @@ export function renderSettingsToggleRow(props: {
   /** Runs synchronously during direct activation for effects gated on user activation. */
   onAct?: (checked: boolean) => void;
   disabled?: boolean;
-  actions?: TemplateResult | typeof nothing;
 }): TemplateResult {
   const notifySwitchActivation = (event: MouseEvent | KeyboardEvent) => {
     const fromInput = event.composedPath().some((node) => node instanceof HTMLInputElement);
@@ -266,7 +265,6 @@ export function renderSettingsToggleRow(props: {
           : nothing}
       </div>
       <div class="settings-row__control">
-        ${props.actions ?? nothing}
         <wa-switch
           class="settings-toggle"
           size="s"
@@ -290,37 +288,6 @@ export function renderSettingsToggleRow(props: {
 
 export function renderSettingsDefaultDescription(value: string, overridden: boolean) {
   return html`${t(overridden ? "configForm.defaultValue" : "configForm.usingDefault", { value })}`;
-}
-
-export function renderSettingsDefaultState(props: {
-  value: string;
-  overridden: boolean;
-  disabled?: boolean;
-  onReset: () => void;
-}): {
-  description: TemplateResult;
-  action: TemplateResult | typeof nothing;
-} {
-  return {
-    description: renderSettingsDefaultDescription(props.value, props.overridden),
-    action: props.overridden
-      ? html`
-          <button
-            type="button"
-            class="btn btn--icon"
-            title=${t("configForm.resetToDefault")}
-            aria-label=${t("configForm.resetToDefault")}
-            ?disabled=${props.disabled ?? false}
-            @click=${(event: Event) => {
-              event.stopPropagation();
-              props.onReset();
-            }}
-          >
-            ${icons.refresh}
-          </button>
-        `
-      : nothing,
-  };
 }
 
 export function renderSettingsSegmented<T extends string>(props: {

--- a/ui/src/e2e/appearance-settings-defaults.e2e.test.ts
+++ b/ui/src/e2e/appearance-settings-defaults.e2e.test.ts
@@ -203,7 +203,6 @@ suite.define(() => {
     );
     const page = await context.newPage();
     const initialPrefs: Record<string, unknown> = {
-      chatSendShortcut: "modifier-enter",
       locale: "en",
       theme: "knot",
       themeMode: "dark",
@@ -225,10 +224,8 @@ suite.define(() => {
       const themeSection = page.locator("#settings-appearance-theme");
       const colorModeRow = settingsRow(page, "Color mode");
       const textSizeSection = page.locator("#settings-appearance-text-size");
-      const sendShortcutRow = settingsRow(page, "Send shortcut");
       const languageSelect = languageRow.locator("wa-select");
       const colorModeGroup = colorModeRow.locator("wa-radio-group");
-      const sendShortcutSelect = sendShortcutRow.locator("[data-settings-send-shortcut]");
 
       await expect.poll(() => selectValue(languageSelect)).toBe("en");
       await expect
@@ -242,27 +239,24 @@ suite.define(() => {
             .getAttribute("aria-pressed"),
         )
         .toBe("true");
-      await expect.poll(() => sendShortcutSelect.inputValue()).toBe("modifier-enter");
       await expect.poll(() => languageRow.textContent()).toContain("Default: System");
       await expect.poll(() => themeSection.textContent()).toContain("Default: Claw");
       await expect.poll(() => colorModeRow.textContent()).toContain("Default: System");
       await expect.poll(() => textSizeSection.textContent()).toContain("Default: 100%");
-      await expect.poll(() => sendShortcutRow.textContent()).toContain("Default: Enter");
       await expect.poll(() => page.locator("html").getAttribute("data-theme-mode")).toBe("dark");
 
       await page.evaluate(() => window.scrollTo(0, 0));
       await captureViewport(page, "01-explicit-overrides.png");
-      await sendShortcutRow.scrollIntoViewIfNeeded();
-      await captureViewport(page, "02-explicit-chat-override.png");
 
       const withoutLocale = { ...initialPrefs };
       delete withoutLocale.locale;
       await resetSyncedPreference({
         click: () =>
-          languageRow
-            .getByRole("button", { name: "Reset to default" })
-            .click()
-            .then(() => undefined),
+          languageSelect.evaluate((element) => {
+            const select = element as HTMLElement & { value: string };
+            select.value = "system";
+            select.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+          }),
         expectedKey: "locale",
         gateway,
         hash: "appearance-defaults-2",
@@ -300,18 +294,6 @@ suite.define(() => {
       await textSizeSection.locator(".settings-text-scale__btn", { hasText: "100%" }).click();
       await expect.poll(() => readPersistedSettings(page)).not.toHaveProperty("textScale");
 
-      await resetSyncedPreference({
-        click: () =>
-          sendShortcutRow
-            .getByRole("button", { name: "Reset to default" })
-            .click()
-            .then(() => undefined),
-        expectedKey: "chatSendShortcut",
-        gateway,
-        hash: "appearance-defaults-5",
-        remainingPrefs: {},
-      });
-
       await expect.poll(() => selectValue(languageSelect)).toBe("system");
       await expect
         .poll(() => themeSection.locator(".settings-theme-card--claw").getAttribute("aria-pressed"))
@@ -324,7 +306,6 @@ suite.define(() => {
             .getAttribute("aria-pressed"),
         )
         .toBe("true");
-      await expect.poll(() => sendShortcutSelect.inputValue()).toBe("enter");
 
       await page.reload();
       await waitForControlUiSettingsTakeover(page);
@@ -334,7 +315,6 @@ suite.define(() => {
       const reloadedThemeSection = page.locator("#settings-appearance-theme");
       const reloadedColorModeRow = settingsRow(page, "Color mode");
       const reloadedTextSizeSection = page.locator("#settings-appearance-text-size");
-      const reloadedSendShortcutRow = settingsRow(page, "Send shortcut");
 
       await expect.poll(() => selectValue(reloadedLanguageRow.locator("wa-select"))).toBe("system");
       await expect
@@ -352,9 +332,6 @@ suite.define(() => {
             .getAttribute("aria-pressed"),
         )
         .toBe("true");
-      await expect
-        .poll(() => reloadedSendShortcutRow.locator("[data-settings-send-shortcut]").inputValue())
-        .toBe("enter");
       await expect.poll(() => reloadedLanguageRow.textContent()).toContain("Using default: System");
       await expect.poll(() => reloadedThemeSection.textContent()).toContain("Using default: Claw");
       await expect
@@ -363,19 +340,11 @@ suite.define(() => {
       await expect
         .poll(() => reloadedTextSizeSection.textContent())
         .toContain("Using default: 100%");
-      await expect
-        .poll(() => reloadedSendShortcutRow.textContent())
-        .toContain("Using default: Enter");
-      await expect
-        .poll(() => page.getByRole("button", { name: "Reset to default" }).count())
-        .toBe(0);
       await expect.poll(() => readPersistedSettings(page)).not.toHaveProperty("textScale");
       await expect.poll(() => page.locator("html").getAttribute("data-theme-mode")).toBe("dark");
 
       await page.evaluate(() => window.scrollTo(0, 0));
       await captureViewport(page, "03-inherited-defaults.png");
-      await reloadedSendShortcutRow.scrollIntoViewIfNeeded();
-      await captureViewport(page, "04-inherited-chat-default.png");
     } finally {
       await context.close();
     }
@@ -637,7 +606,11 @@ suite.define(() => {
           .toContain("Stocké uniquement dans ce navigateur");
 
         await themeSection.locator(".settings-theme-card--claw").click();
-        await languageRow.locator("button.btn--icon").click();
+        await languageSelect.evaluate((element) => {
+          const select = element as HTMLElement & { value: string };
+          select.value = "system";
+          select.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+        });
         await followUpRow.locator("button.btn--sm").click();
 
         await expect

--- a/ui/src/e2e/config-form-defaults.e2e.test.ts
+++ b/ui/src/e2e/config-form-defaults.e2e.test.ts
@@ -36,7 +36,7 @@ function settingsRow(page: Page, title: string): Locator {
 }
 
 suite.define(() => {
-  it("shows defaults and removes restored optional overrides from config.set", async () => {
+  it("shows defaults and removes cleared optional scalars from config.set", async () => {
     await suite.withPage(
       {
         colorScheme: "dark",
@@ -155,9 +155,6 @@ suite.define(() => {
           .toContain('Default: {"enabled":true,"mode":"balanced"}');
         await expect.poll(() => retriesRow.getByRole("spinbutton").inputValue()).toBe("9");
         await expect.poll(() => tagsBlock.textContent()).toContain('Default: ["stable","default"]');
-        await expect
-          .poll(() => panel.getByRole("button", { name: "Reset to default" }).count())
-          .toBe(5);
 
         if (captureUiProofEnabled) {
           await mkdir(uiProofArtifactDir, { recursive: true });
@@ -168,38 +165,29 @@ suite.define(() => {
         }
 
         await gateway.deferNext("config.set");
-        await enabledRow.getByRole("button", { name: "Reset to default" }).click();
         await modeRow.locator("select").selectOption("__unset__");
-        await payloadRow.getByRole("button", { name: "Reset to default" }).click();
-        await profileBlock.getByRole("button", { name: "Reset to default" }).click();
-        await retriesRow.getByRole("button", { name: "Reset to default" }).click();
-        await tagsBlock.getByRole("button", { name: "Reset to default" }).click();
+        await retriesRow.getByRole("spinbutton").fill("");
 
         // Form mutations schedule config.set automatically; form mode has no manual Save control.
         const saved = requestRaw(await gateway.waitForRequest("config.set"));
-        expect(saved).toEqual({ runtime: { keep: "preserved" } });
+        expect(saved).toEqual({
+          runtime: {
+            enabled: false,
+            keep: "preserved",
+            payload: { mode: "custom" },
+            profile: { enabled: false, mode: "custom" },
+            tags: ["custom"],
+          },
+        });
         await expect
           .poll(() => page.locator("openclaw-settings-save-indicator").textContent())
           .toContain("Saving");
 
-        await expect.poll(() => enabledRow.textContent()).toContain("Using default: true");
         await expect.poll(() => modeRow.locator("select").inputValue()).toBe("__unset__");
-        await expect
-          .poll(() => payloadRow.textContent())
-          .toContain('Using default: {"mode":"balanced"}');
-        await expect
-          .poll(() => profileBlock.textContent())
-          .toContain('Using default: {"enabled":true,"mode":"balanced"}');
         await expect.poll(() => retriesRow.getByRole("spinbutton").inputValue()).toBe("");
         await expect
           .poll(() => retriesRow.getByRole("spinbutton").getAttribute("placeholder"))
           .toBe("Default: 3");
-        await expect
-          .poll(() => tagsBlock.textContent())
-          .toContain('Using default: ["stable","default"]');
-        await expect
-          .poll(() => panel.getByRole("button", { name: "Reset to default" }).count())
-          .toBe(0);
 
         const configGetsBeforeReload = (await gateway.getRequests("config.get")).length;
         await gateway.resolveDeferred("config.set");
@@ -212,31 +200,10 @@ suite.define(() => {
           .toBe(configGetsBeforeReload + 1);
 
         const reloadedPanel = page.locator("#config-section-panel");
-        const reloadedEnabledRow = settingsRow(page, "Enabled");
         const reloadedModeRow = settingsRow(page, "Mode");
-        const reloadedPayloadRow = settingsRow(page, "Payload");
-        const reloadedProfileBlock = reloadedPanel.locator("details.cfg-object").filter({
-          has: page
-            .locator(".cfg-object__summary .settings-row__title")
-            .getByText("Profile", { exact: true }),
-        });
         const reloadedRetriesRow = settingsRow(page, "Retries");
-        const reloadedTagsBlock = reloadedPanel.locator(".cfg-array").filter({ hasText: "Tags" });
-        await expect.poll(() => reloadedEnabledRow.textContent()).toContain("Using default: true");
         await expect.poll(() => reloadedModeRow.locator("select").inputValue()).toBe("__unset__");
-        await expect
-          .poll(() => reloadedPayloadRow.textContent())
-          .toContain('Using default: {"mode":"balanced"}');
-        await expect
-          .poll(() => reloadedProfileBlock.textContent())
-          .toContain('Using default: {"enabled":true,"mode":"balanced"}');
         await expect.poll(() => reloadedRetriesRow.getByRole("spinbutton").inputValue()).toBe("");
-        await expect
-          .poll(() => reloadedTagsBlock.textContent())
-          .toContain('Using default: ["stable","default"]');
-        await expect
-          .poll(() => reloadedPanel.getByRole("button", { name: "Reset to default" }).count())
-          .toBe(0);
 
         if (captureUiProofEnabled) {
           await reloadedPanel.screenshot({

--- a/ui/src/e2e/curated-settings-defaults.e2e.test.ts
+++ b/ui/src/e2e/curated-settings-defaults.e2e.test.ts
@@ -65,7 +65,6 @@ function settingsRow(page: Page, title: string): Locator {
 
 async function expectInherited(row: Locator, value: string) {
   await expect.poll(() => row.textContent()).toContain(`Using default: ${value}`);
-  await expect.poll(() => row.getByRole("button", { name: "Reset to default" }).count()).toBe(0);
 }
 
 suite.define(() => {
@@ -158,8 +157,8 @@ suite.define(() => {
         }
 
         const securitySavesBefore = (await gateway.getRequests("config.set")).length;
-        await browserRow.getByRole("button", { name: "Reset to default" }).click();
-        await profileRow.getByRole("button", { name: "Reset to default" }).click();
+        await browserRow.locator(".settings-row__title").click();
+        await profileRow.getByRole("radio", { name: "Full", exact: true }).click();
         await expectInherited(browserRow, "Enabled");
         await expectInherited(profileRow, "Full");
         await expect
@@ -215,8 +214,8 @@ suite.define(() => {
         }
 
         const modelSavesBefore = (await gateway.getRequests("config.set")).length;
-        await thinkingRow.getByRole("button", { name: "Reset to default" }).click();
-        await fastModeRow.getByRole("button", { name: "Reset to default" }).click();
+        await thinkingRow.getByRole("radio", { name: "Default", exact: true }).click();
+        await fastModeRow.getByRole("radio", { name: "Default", exact: true }).click();
         await expectInherited(thinkingRow, "Model policy");
         await expectInherited(fastModeRow, "Model policy");
         await expect

--- a/ui/src/e2e/memory-settings-defaults.e2e.test.ts
+++ b/ui/src/e2e/memory-settings-defaults.e2e.test.ts
@@ -1,4 +1,4 @@
-// Control UI tests cover Memory default provenance and persisted restore actions.
+// Control UI tests cover Memory default provenance and clearing optional overrides.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Locator, Page } from "playwright";
@@ -73,7 +73,7 @@ async function captureProof(page: Page, name: string, locator?: Locator) {
 }
 
 suite.define(() => {
-  it("persists engine and dreaming resets and reloads inherited defaults", async () => {
+  it("persists a cleared dreaming frequency and preserves the explicit engine across reload", async () => {
     await suite.withPage(
       {
         colorScheme: "dark",
@@ -128,11 +128,11 @@ suite.define(() => {
         await captureProof(page, "01-explicit-engine.png");
         await captureProof(page, "02-explicit-dreaming.png", scheduleSection(page));
 
-        await engineRow.getByRole("button", { name: "Reset to default" }).click();
-        await frequencyRow.getByRole("button", { name: "Reset to default" }).click();
+        await frequencyRow.getByRole("textbox").fill("");
+        await frequencyRow.getByRole("textbox").blur();
 
         const saved = requestRaw(await gateway.waitForRequest("config.set"));
-        expect(saved).not.toHaveProperty("plugins.slots.memory");
+        expect(saved).toHaveProperty("plugins.slots.memory", "memory-core");
         expect(saved).not.toHaveProperty("plugins.entries.memory-core.config.dreaming.frequency");
         expect(saved).toHaveProperty(
           "plugins.entries.memory-core.config.dreaming.verboseLogging",
@@ -147,7 +147,7 @@ suite.define(() => {
         const reloadedFrequencyRow = settingsRow(page, "Dreaming frequency");
         await expect
           .poll(() => reloadedEngineRow.textContent())
-          .toContain("Using default: OpenClaw Memory");
+          .toContain("Default: OpenClaw Memory");
         await expect
           .poll(() => reloadedFrequencyRow.textContent())
           .toContain("Using default: 0 3 * * *");
@@ -155,11 +155,7 @@ suite.define(() => {
         await expect
           .poll(() => reloadedFrequencyRow.getByRole("textbox").getAttribute("placeholder"))
           .toBe("0 3 * * *");
-        await expect
-          .poll(() => page.getByRole("button", { name: "Reset to default" }).count())
-          .toBe(1);
-
-        await captureProof(page, "03-inherited-engine.png");
+        await captureProof(page, "03-preserved-engine.png");
         await captureProof(page, "04-inherited-dreaming.png", scheduleSection(page));
       },
     );

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1538,7 +1538,6 @@ export const en: TranslationMap = {
     structuredSecretFile: "Structured value (SecretRef) - edit the config file directly",
     defaultValue: "Default: {value}",
     usingDefault: "Using default: {value}",
-    resetToDefault: "Reset to default",
     select: "Select...",
     enumOn: "On",
     enumOff: "Off",

--- a/ui/src/pages/agents/memory/memory-panel.test.ts
+++ b/ui/src/pages/agents/memory/memory-panel.test.ts
@@ -30,12 +30,6 @@ type TestMemoryPanel = HTMLElement & {
   applyGatewaySnapshot: (snapshot: ApplicationGatewaySnapshot) => void;
   loadAll: () => Promise<void>;
   openWikiPage: (lookup: string) => Promise<unknown>;
-  resetEnabledOverride: (configured: {
-    pluginId: string;
-    enabled: boolean;
-    overridden: boolean;
-    engineOff: boolean;
-  }) => Promise<void>;
   confirmDreamingTask: (
     task: (state: DreamingState) => Promise<boolean>,
     confirmation: ConfirmDialogOptions,
@@ -318,101 +312,7 @@ describe("AgentMemoryPanel gateway lifecycle", () => {
     });
   });
 
-  it("resets the config-only dreaming override to the enabled runtime default", async () => {
-    const client = {
-      request: vi.fn(async () => ({ dreaming: { enabled: true } })),
-    } as unknown as GatewayBrowserClient;
-    const context = contextWithGateway(client, true, {
-      plugins: {
-        entries: {
-          "memory-core": { config: { dreaming: { enabled: false } } },
-        },
-      },
-    });
-    const page = createPage(context);
-    document.body.append(page);
-    await page.updateComplete;
-
-    await page.resetEnabledOverride({
-      pluginId: "memory-core",
-      enabled: false,
-      overridden: true,
-      engineOff: false,
-    });
-
-    expect(context.runtimeConfig.patch).toHaveBeenCalledWith({
-      raw: {
-        plugins: {
-          entries: {
-            "memory-core": { config: { dreaming: { enabled: null } } },
-          },
-        },
-      },
-      note: "Dreaming settings reset to the plugin default.",
-      canDispatch: expect.any(Function),
-    });
-    expect(context.runtimeConfig.removeFormValue).not.toHaveBeenCalled();
-    expect(context.runtimeConfig.save).not.toHaveBeenCalled();
-    expect(context.runtimeConfig.refresh).toHaveBeenCalledOnce();
-  });
-
-  it("does not refresh the stale override when the minimal reset patch fails", async () => {
-    const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
-    const context = contextWithGateway(client, true, {
-      plugins: {
-        entries: {
-          "memory-core": { config: { dreaming: { enabled: false } } },
-        },
-      },
-    });
-    vi.mocked(context.runtimeConfig.patch).mockResolvedValue(false);
-    const page = createPage(context);
-    document.body.append(page);
-    await page.updateComplete;
-
-    await page.resetEnabledOverride({
-      pluginId: "memory-core",
-      enabled: false,
-      overridden: true,
-      engineOff: false,
-    });
-
-    expect(context.runtimeConfig.patch).toHaveBeenCalledOnce();
-    expect(context.runtimeConfig.removeFormValue).not.toHaveBeenCalled();
-    expect(context.runtimeConfig.save).not.toHaveBeenCalled();
-    expect(context.runtimeConfig.refresh).not.toHaveBeenCalled();
-  });
-
-  it("drops a successful reset completion after the agent scope changes", async () => {
-    const pending = deferred<boolean>();
-    const context = contextWithGateway({} as GatewayBrowserClient, true, {
-      plugins: {
-        entries: {
-          "memory-core": { config: { dreaming: { enabled: false } } },
-        },
-      },
-    });
-    vi.mocked(context.runtimeConfig.patch).mockReturnValue(pending.promise);
-    const page = createPage(context);
-    document.body.append(page);
-    await page.updateComplete;
-
-    const reset = page.resetEnabledOverride({
-      pluginId: "memory-core",
-      enabled: false,
-      overridden: true,
-      engineOff: false,
-    });
-    page.agentId = "support";
-    await page.updateComplete;
-    pending.resolve(true);
-    await reset;
-
-    expect(context.runtimeConfig.refresh).not.toHaveBeenCalled();
-    expect(page.dreaming.dreamingStatusError).toBeNull();
-  });
-
-  it("renders explicit engine Off as unavailable while preserving latent override reset", () => {
+  it("renders explicit engine Off as unavailable with a latent override", () => {
     const context = contextWithGateway({} as GatewayBrowserClient, true, {
       plugins: {
         slots: { memory: "none" },
@@ -435,7 +335,6 @@ describe("AgentMemoryPanel gateway lifecycle", () => {
     expect(container.querySelector<HTMLButtonElement>(".dreams__phase-toggle")?.disabled).toBe(
       true,
     );
-    expect(container.querySelector('button[aria-label="Reset to default"]')).not.toBeNull();
   });
 
   it("does not present cached runtime status after the memory engine switches Off", () => {
@@ -489,7 +388,7 @@ describe("AgentMemoryPanel gateway lifecycle", () => {
     ).toBe(true);
   });
 
-  it("omits default provenance and reset when engine Off has no latent override", () => {
+  it("omits default provenance when engine Off has no latent override", () => {
     const context = contextWithGateway({} as GatewayBrowserClient, true, {
       plugins: { slots: { memory: "none" } },
     });
@@ -501,7 +400,6 @@ describe("AgentMemoryPanel gateway lifecycle", () => {
     render(page.render(), container);
 
     expect(container.textContent).not.toContain("Using default: Enabled");
-    expect(container.querySelector('button[aria-label="Reset to default"]')).toBeNull();
     const toggle = container.querySelector<HTMLButtonElement>(".dreams__phase-toggle");
     expect(toggle?.disabled).toBe(true);
     toggle?.click();

--- a/ui/src/pages/agents/memory/memory-panel.ts
+++ b/ui/src/pages/agents/memory/memory-panel.ts
@@ -11,10 +11,9 @@ import {
   showConfirmDialog,
   type ConfirmDialogOptions,
 } from "../../../components/confirm-dialog.ts";
-import { renderSettingsDefaultState } from "../../../components/settings-ui.ts";
+import { renderSettingsDefaultDescription } from "../../../components/settings-ui.ts";
 import { t } from "../../../i18n/index.ts";
 import { currentConfigObject } from "../../../lib/config/config-state-model.ts";
-import { formatUiError } from "../../../lib/format-error.ts";
 import { formatTimeMs } from "../../../lib/format.ts";
 import { isPluginEnabledInConfigSnapshot } from "../../../lib/plugin-activation.ts";
 import { OpenClawLightDomElement } from "../../../lit/openclaw-element.ts";
@@ -394,74 +393,6 @@ class AgentMemoryPanel extends OpenClawLightDomElement {
     }
   }
 
-  private async removeEnabledOverride(
-    scope: DreamingTaskScope,
-    runtimeConfig: ApplicationContext["runtimeConfig"],
-  ): Promise<boolean> {
-    const { pluginId } = resolveConfiguredDreaming(currentConfigObject(runtimeConfig.state));
-    this.dreaming.dreamingModeSaving = true;
-    try {
-      const saved = await runtimeConfig.patch({
-        raw: {
-          plugins: {
-            entries: {
-              [pluginId]: { config: { dreaming: { enabled: null } } },
-            },
-          },
-        },
-        note: "Dreaming settings reset to the plugin default.",
-        canDispatch: () =>
-          this.isTaskScopeCurrent(scope) &&
-          this.context.runtimeConfig === runtimeConfig &&
-          canCallDreamingMethod(scope.state, "config.patch", "operator.admin"),
-      });
-      return saved;
-    } catch (error) {
-      if (this.isTaskScopeCurrent(scope) && this.context.runtimeConfig === runtimeConfig) {
-        this.dreaming.dreamingStatusError = formatUiError(
-          error,
-          t("dreaming.actions.updateFailed"),
-        );
-      }
-      return false;
-    } finally {
-      if (this.isTaskScopeCurrent(scope)) {
-        this.dreaming.dreamingModeSaving = false;
-      }
-    }
-  }
-
-  private async resetEnabledOverride(configured: ReturnType<typeof resolveConfiguredDreaming>) {
-    if (
-      !configured.overridden ||
-      this.dreaming.dreamingModeSaving ||
-      this.toggleConfirmOpen ||
-      !canCallDreamingMethod(this.dreaming, "config.patch", "operator.admin")
-    ) {
-      return;
-    }
-    this.dreaming.dreamingStatusError = null;
-    const scope = this.captureTaskScope();
-    const runtimeConfig = this.context.runtimeConfig;
-    if (!scope) {
-      return;
-    }
-    const updated = await this.removeEnabledOverride(scope, runtimeConfig);
-    if (!this.isTaskScopeCurrent(scope) || this.context.runtimeConfig !== runtimeConfig) {
-      return;
-    }
-    if (!updated) {
-      this.dreaming.dreamingStatusError ??= t("dreaming.actions.updateFailed");
-      return;
-    }
-    await runtimeConfig.refresh();
-    if (!this.isTaskScopeCurrent(scope) || this.context.runtimeConfig !== runtimeConfig) {
-      return;
-    }
-    this.syncConfigSnapshot();
-    await this.runDreamingTask(loadDreamingStatus, scope);
-  }
-
   private async openWikiPage(lookup: string): Promise<WikiPagePreview | null> {
     const scope = this.captureTaskScope();
     const client = scope?.state.client;
@@ -505,12 +436,6 @@ class AgentMemoryPanel extends OpenClawLightDomElement {
     const dreamingOn = dreamingStatus?.enabled ?? configuredDreaming.enabled;
     const loading = dreaming.dreamingStatusLoading || dreaming.dreamingModeSaving;
     const canUpdateConfig = canCallDreamingMethod(dreaming, "config.patch", "operator.admin");
-    const defaultState = renderSettingsDefaultState({
-      value: t("common.enabled"),
-      overridden: configuredDreaming.overridden,
-      disabled: loading || !canUpdateConfig,
-      onReset: () => void this.resetEnabledOverride(configuredDreaming),
-    });
     const refreshLoading = dreaming.dreamingStatusLoading || dreaming.dreamDiaryLoading;
     const selectedAgentId = dreaming.selectedAgentId ?? "";
 
@@ -528,9 +453,11 @@ class AgentMemoryPanel extends OpenClawLightDomElement {
             <span class="muted">
               ${configuredDreaming.engineOff
                 ? t("dreaming.header.engineOff")
-                : defaultState.description}
+                : renderSettingsDefaultDescription(
+                    t("common.enabled"),
+                    configuredDreaming.overridden,
+                  )}
             </span>
-            ${defaultState.action}
             <button
               class="dreams__phase-toggle ${dreamingOn ? "dreams__phase-toggle--on" : ""}"
               ?disabled=${!canUpdateConfig || loading || configuredDreaming.engineOff}

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -1218,7 +1218,6 @@ export class ConfigPage extends OpenClawLightDomElement {
         ? localePref.resetValue
         : undefined,
       onLocaleChange: (locale) => this.setLocale(locale),
-      resetLocale: () => this.resetLocale(),
       setTheme: (theme, transitionContext) => this.setTheme(theme, transitionContext),
       setThemeMode: (mode, transitionContext) => this.setThemeMode(mode, transitionContext),
       setAccent: (accent) =>
@@ -1299,7 +1298,6 @@ export class ConfigPage extends OpenClawLightDomElement {
       chatSendShortcutResetValue:
         chatSendShortcutPref.resetValue ?? UI_APPEARANCE_DEFAULTS.chatSendShortcut,
       setChatSendShortcut: (value) => this.setSetting("chatSendShortcut", value),
-      resetChatSendShortcut: () => this.resetSyncedAppearancePref("chatSendShortcut"),
       chatFollowUpMode: this.settings.chatFollowUpMode,
       chatFollowUpModeOverridden: chatFollowUpModePref.overridden,
       chatFollowUpModeProvenance: chatFollowUpModePref.provenance,
@@ -1423,7 +1421,6 @@ export class ConfigPage extends OpenClawLightDomElement {
           }
           runtimeConfig.patchForm(["browser", "enabled"], false);
         },
-        onBrowserEnabledReset: () => runtimeConfig.removeFormValue(["browser", "enabled"]),
         onToolProfileChange: (profile) => {
           if (profile === "full") {
             runtimeConfig.removeFormValue(["tools", "profile"]);
@@ -1431,7 +1428,6 @@ export class ConfigPage extends OpenClawLightDomElement {
           }
           runtimeConfig.patchForm(["tools", "profile"], profile);
         },
-        onToolProfileReset: () => runtimeConfig.removeFormValue(["tools", "profile"]),
         editor: renderConfig({ ...props, embeddedEditor: true }),
       });
     }

--- a/ui/src/pages/config/memory-defaults.test.ts
+++ b/ui/src/pages/config/memory-defaults.test.ts
@@ -1,26 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
-import {
-  dreamingConfigPath,
-  resetMemoryEngine,
-  resolveDreamingTimezoneDefault,
-} from "./memory-defaults.ts";
+import { describe, expect, it } from "vitest";
+import { dreamingConfigPath, resolveDreamingTimezoneDefault } from "./memory-defaults.ts";
 
 describe("memory curated defaults", () => {
-  it("resets the slot by removing only its authored key", () => {
-    const removeFormValue = vi.fn();
-    const config = { removeFormValue };
-
-    resetMemoryEngine(config);
-
-    expect(removeFormValue).toHaveBeenCalledWith(["plugins", "slots", "memory"]);
-  });
-
-  it("does not reset controls while their effective mutation gate is closed", () => {
-    const removeFormValue = vi.fn();
-    expect(resetMemoryEngine({ removeFormValue }, true)).toBe(false);
-    expect(removeFormValue).not.toHaveBeenCalled();
-  });
-
   it("builds the selected plugin's dreaming config path", () => {
     expect(dreamingConfigPath("memory-core", ["phases", "deep", "limit"])).toEqual([
       "plugins",

--- a/ui/src/pages/config/memory-defaults.ts
+++ b/ui/src/pages/config/memory-defaults.ts
@@ -1,15 +1,4 @@
 import { asNullableRecord as asConfigRecord } from "@openclaw/normalization-core/record-coerce";
-import type { RuntimeConfigCapability } from "../../lib/config/runtime-config-capability.ts";
-
-type ConfigRemover = Pick<RuntimeConfigCapability, "removeFormValue">;
-
-export function resetMemoryEngine(config: ConfigRemover, disabled = false): boolean {
-  if (disabled) {
-    return false;
-  }
-  config.removeFormValue(["plugins", "slots", "memory"]);
-  return true;
-}
 
 export function dreamingConfigPath(pluginId: string, path: readonly string[]) {
   return ["plugins", "entries", pluginId, "config", "dreaming", ...path];

--- a/ui/src/pages/config/memory-dreaming.test.ts
+++ b/ui/src/pages/config/memory-dreaming.test.ts
@@ -106,7 +106,6 @@ describe("renderDreamingSettings", () => {
     expect(rowFor(container, "Timezone").textContent).toContain("Using default: Asia/Singapore");
     expect(numberInput(container, "Lookback days").placeholder).toBe("2");
     expect(rowFor(container, "Lookback days").textContent).toContain("Using default: 2");
-    expect(container.querySelector('button[aria-label="Reset to default"]')).toBeNull();
   });
 
   it("shows the advanced execution model as the inherited model default", () => {
@@ -129,7 +128,10 @@ describe("renderDreamingSettings", () => {
       custom.dispatchEvent(new Event("change", { bubbles: true }));
     }
     expect(onPatch).toHaveBeenCalledWith(["model"], "vendor/model with spaces");
-    row.querySelector<HTMLButtonElement>('button[aria-label="Reset to default"]')?.click();
+    if (custom) {
+      custom.value = "";
+      custom.dispatchEvent(new Event("change", { bubbles: true }));
+    }
     expect(onPatch).toHaveBeenCalledWith(["model"], undefined);
 
     const inherited = renderInto({ execution: { defaults: { model: "openai/gpt-5.6" } } });
@@ -138,36 +140,7 @@ describe("renderDreamingSettings", () => {
     );
   });
 
-  it("resets explicit dreaming values by removing their owning config keys", () => {
-    const onPatch = vi.fn();
-    const container = renderInto(
-      {
-        frequency: "0 6 * * *",
-        verboseLogging: true,
-        storage: { mode: "both" },
-        phases: { light: { lookbackDays: 5 } },
-      },
-      onPatch,
-    );
-
-    for (const title of [
-      "Dreaming frequency",
-      "Verbose logging",
-      "Storage mode",
-      "Lookback days",
-    ]) {
-      rowFor(container, title)
-        .querySelector<HTMLButtonElement>('button[aria-label="Reset to default"]')
-        ?.click();
-    }
-
-    expect(onPatch).toHaveBeenCalledWith(["frequency"], undefined);
-    expect(onPatch).toHaveBeenCalledWith(["verboseLogging"], undefined);
-    expect(onPatch).toHaveBeenCalledWith(["storage", "mode"], undefined);
-    expect(onPatch).toHaveBeenCalledWith(["phases", "light", "lookbackDays"], undefined);
-  });
-
-  it("keeps malformed explicit values resettable while displaying runtime defaults", () => {
+  it("displays runtime defaults for malformed explicit values", () => {
     const onPatch = vi.fn();
     const container = renderInto(
       {
@@ -186,16 +159,11 @@ describe("renderDreamingSettings", () => {
     ]) {
       const row = rowFor(container, title);
       expect(row.textContent).toContain("Default:");
-      row.querySelector<HTMLButtonElement>('button[aria-label="Reset to default"]')?.click();
     }
     expect(numberInput(container, "Dreaming frequency").value).toBe("");
     expect(toggleStates(container)["Schedule/Verbose logging"]).toBe(false);
     expect(selectedSegment(container)).toBe("separate");
     expect(toggleStates(container)["Storage/Separate reports"]).toBe(false);
-    expect(onPatch).toHaveBeenCalledWith(["frequency"], undefined);
-    expect(onPatch).toHaveBeenCalledWith(["verboseLogging"], undefined);
-    expect(onPatch).toHaveBeenCalledWith(["storage", "mode"], undefined);
-    expect(onPatch).toHaveBeenCalledWith(["storage", "separateReports"], undefined);
   });
 
   it("locks every global dreaming control when config mutation is unavailable", () => {

--- a/ui/src/pages/config/memory-dreaming.ts
+++ b/ui/src/pages/config/memory-dreaming.ts
@@ -6,7 +6,7 @@ import { html, nothing, type TemplateResult } from "lit";
 import { renderModelPicker } from "../../components/model-picker.ts";
 import { providerIdFromModelRef } from "../../components/provider-icon.ts";
 import {
-  renderSettingsDefaultState,
+  renderSettingsDefaultDescription,
   renderSettingsRow,
   renderSettingsSection,
   renderSettingsSegmented,
@@ -330,19 +330,13 @@ function renderField(props: DreamingSettingsProps, spec: DreamingFieldSpec) {
               : spec.defaultLabelKey
                 ? t(spec.defaultLabelKey)
                 : "";
-  const defaultState = renderSettingsDefaultState({
-    value: defaultValue,
-    overridden,
-    disabled: props.disabled,
-    onReset: () => props.onPatch(spec.path, undefined),
-  });
+  const defaultDescription = renderSettingsDefaultDescription(defaultValue, overridden);
   if (spec.kind === "toggle") {
     return renderSettingsToggleRow({
       title: t(spec.labelKey),
-      description: html`${t(spec.helpKey)} ${defaultState.description}`,
+      description: html`${t(spec.helpKey)} ${defaultDescription}`,
       checked: typeof value === "boolean" ? value : spec.fallback,
       disabled: props.disabled,
-      actions: defaultState.action,
       onChange: (checked) => props.onPatch(spec.path, checked),
     });
   }
@@ -359,35 +353,31 @@ function renderField(props: DreamingSettingsProps, spec: DreamingFieldSpec) {
     const provider = providerIdFromModelRef(defaultValue);
     return renderSettingsRow({
       title: t(spec.labelKey),
-      description: html`${t(spec.helpKey)} ${defaultState.description}`,
-      control: html`
-        ${defaultState.action}
-        ${renderModelPicker({
-          label: t(spec.labelKey),
-          value: text,
-          options: [
-            {
-              value: "",
-              label: defaultValue,
-              ...(provider ? { provider } : {}),
-            },
-          ],
-          disabled: props.disabled,
-          custom: {
-            label: t("cron.form.customModel"),
-            placeholder: spec.placeholderKey ? t(spec.placeholderKey) : "",
-            commit: "change",
+      description: html`${t(spec.helpKey)} ${defaultDescription}`,
+      control: renderModelPicker({
+        label: t(spec.labelKey),
+        value: text,
+        options: [
+          {
+            value: "",
+            label: defaultValue,
+            ...(provider ? { provider } : {}),
           },
-          onChange: (model) => props.onPatch(spec.path, model.trim() || undefined),
-        })}
-      `,
+        ],
+        disabled: props.disabled,
+        custom: {
+          label: t("cron.form.customModel"),
+          placeholder: spec.placeholderKey ? t(spec.placeholderKey) : "",
+          commit: "change",
+        },
+        onChange: (model) => props.onPatch(spec.path, model.trim() || undefined),
+      }),
     });
   }
   return renderSettingsRow({
     title: t(spec.labelKey),
-    description: html`${t(spec.helpKey)} ${defaultState.description}`,
+    description: html`${t(spec.helpKey)} ${defaultDescription}`,
     control: html`
-      ${defaultState.action}
       <input
         class="settings-input"
         type=${spec.kind === "number" ? "number" : "text"}
@@ -428,12 +418,10 @@ function renderField(props: DreamingSettingsProps, spec: DreamingFieldSpec) {
 export function renderDreamingSettings(props: DreamingSettingsProps): TemplateResult {
   const storageModeValue = readAtPath(props.dreaming, ["storage", "mode"]);
   const storageMode = normalizeStorageMode(storageModeValue);
-  const storageDefaultState = renderSettingsDefaultState({
-    value: t("memoryPage.dreaming.storage.modes.separate"),
-    overridden: hasAtPath(props.dreaming, ["storage", "mode"]),
-    disabled: props.disabled,
-    onReset: () => props.onPatch(["storage", "mode"], undefined),
-  });
+  const storageDefaultDescription = renderSettingsDefaultDescription(
+    t("memoryPage.dreaming.storage.modes.separate"),
+    hasAtPath(props.dreaming, ["storage", "mode"]),
+  );
   return html`
     ${renderSettingsSection(
       {
@@ -451,22 +439,19 @@ export function renderDreamingSettings(props: DreamingSettingsProps): TemplateRe
         ${renderSettingsRow({
           title: t("memoryPage.dreaming.storage.modeLabel"),
           description: html`
-            ${t("memoryPage.dreaming.storage.modeHelp")} ${storageDefaultState.description}
+            ${t("memoryPage.dreaming.storage.modeHelp")} ${storageDefaultDescription}
           `,
           stacked: true,
-          control: html`
-            ${storageDefaultState.action}
-            ${renderSettingsSegmented<StorageMode>({
-              value: storageMode,
-              options: STORAGE_MODES.map((mode) => ({
-                value: mode,
-                label: t(`memoryPage.dreaming.storage.modes.${mode}`),
-              })),
-              ariaLabel: t("memoryPage.dreaming.storage.modeLabel"),
-              disabled: props.disabled,
-              onChange: (mode) => props.onPatch(["storage", "mode"], mode),
-            })}
-          `,
+          control: renderSettingsSegmented<StorageMode>({
+            value: storageMode,
+            options: STORAGE_MODES.map((mode) => ({
+              value: mode,
+              label: t(`memoryPage.dreaming.storage.modes.${mode}`),
+            })),
+            ariaLabel: t("memoryPage.dreaming.storage.modeLabel"),
+            disabled: props.disabled,
+            onChange: (mode) => props.onPatch(["storage", "mode"], mode),
+          }),
         })}
         ${renderField(props, {
           kind: "toggle",

--- a/ui/src/pages/config/memory-page.ts
+++ b/ui/src/pages/config/memory-page.ts
@@ -31,11 +31,7 @@ import {
 } from "../agents/memory/dreaming.ts";
 import "./memory-dreaming-page.ts";
 import "./memory-memories.ts";
-import {
-  dreamingConfigPath,
-  resetMemoryEngine,
-  resolveDreamingTimezoneDefault,
-} from "./memory-defaults.ts";
+import { dreamingConfigPath, resolveDreamingTimezoneDefault } from "./memory-defaults.ts";
 import { renderDreamingSettings, renderDreamingUnsupported } from "./memory-dreaming.ts";
 import { renderMemoryOverview, type MemoryOverviewStatus } from "./memory-overview.ts";
 import {
@@ -634,7 +630,6 @@ class MemorySettingsPage extends OpenClawLightDomElement {
   }
 
   override render() {
-    const runtimeConfig = this.context.runtimeConfig;
     const engineSelection = resolveMemoryEngineSelection(this.configObject);
     const engineMutationDisabled =
       this.mutationDisabled || (this.catalog.kind === "ready" && !this.catalog.mutationAllowed);
@@ -649,11 +644,6 @@ class MemorySettingsPage extends OpenClawLightDomElement {
       engineBusy: this.engineBusy || engineMutationDisabled,
       engineOutcome: this.engineOutcome,
       onEngineChange: (nextEngineId) => void this.changeEngine(nextEngineId, engineSelection),
-      onEngineReset: () => {
-        if (resetMemoryEngine(runtimeConfig, this.engineBusy || engineMutationDisabled)) {
-          this.engineOutcome = null;
-        }
-      },
       addons: buildMemoryAddonRows(this.catalog, {
         busy: this.addonBusy,
         errors: this.addonErrors,

--- a/ui/src/pages/config/memory.test.ts
+++ b/ui/src/pages/config/memory.test.ts
@@ -27,7 +27,6 @@ function createProps(overrides: Partial<MemoryViewProps> = {}): MemoryViewProps 
     engineBusy: false,
     engineOutcome: null,
     onEngineChange: vi.fn(),
-    onEngineReset: vi.fn(),
     addons: [
       {
         id: "active-memory",
@@ -143,61 +142,16 @@ describe("renderMemory", () => {
     expect(values).toContain("");
   });
 
-  it.each([
-    { selection: { kind: "off" } as const, value: "Off" },
-    {
-      selection: { kind: "pinned", engineId: "memory-core" } as const,
-      value: "memory-core",
-    },
-  ])("keeps reset available without a catalog for $selection.kind", ({ selection, value }) => {
-    const onEngineReset = vi.fn();
-    const container = renderInto(
-      createProps({
-        engineOptions: [],
-        engineSelection: selection,
-        engineState: "unknown",
-        onEngineReset,
-      }),
-    );
-
-    expect(container.textContent).toContain(`Default: OpenClaw Memory`);
-    expect(container.textContent).toContain(value);
-    container.querySelector<HTMLButtonElement>('button[aria-label="Reset to default"]')?.click();
-    expect(onEngineReset).toHaveBeenCalledOnce();
-  });
-
-  it("disables catalog-free reset when the effective mutation gate is closed", () => {
-    const onEngineReset = vi.fn();
-    const container = renderInto(
-      createProps({
-        engineOptions: [],
-        engineSelection: { kind: "off" },
-        engineState: "unknown",
-        engineBusy: true,
-        onEngineReset,
-      }),
-    );
-    const reset = container.querySelector<HTMLButtonElement>(
-      'button[aria-label="Reset to default"]',
-    );
-
-    expect(reset?.disabled).toBe(true);
-    reset?.click();
-    expect(onEngineReset).not.toHaveBeenCalled();
-  });
-
   it("reports whether the engine came from config or from the slot default", () => {
     const auto = renderInto(createProps());
     expect(auto.textContent).toContain("falls back to its default owner");
     expect(auto.textContent).toContain("Using default: OpenClaw Memory");
-    expect(auto.querySelector('button[aria-label="Reset to default"]')).toBeNull();
 
     const pinned = renderInto(
       createProps({ engineSelection: { kind: "pinned", engineId: "memory-core" } }),
     );
     expect(pinned.textContent).toContain("pinned in config");
     expect(pinned.textContent).toContain("Default: OpenClaw Memory");
-    expect(pinned.querySelector('button[aria-label="Reset to default"]')).not.toBeNull();
   });
 
   it("keeps a configured missing engine selected and labels it unavailable", () => {

--- a/ui/src/pages/config/memory.ts
+++ b/ui/src/pages/config/memory.ts
@@ -5,7 +5,7 @@ import type { AgentSelectOption } from "../../components/agent-select.ts";
 import { renderHubTabs } from "../../components/hub-tabs.ts";
 import {
   renderLearnMoreLink,
-  renderSettingsDefaultState,
+  renderSettingsDefaultDescription,
   renderSettingsRow,
   renderSettingsSection,
   renderSettingsSegmented,
@@ -164,7 +164,6 @@ type MemoryViewProps = {
   /** Distinguishes a rejected write from a committed write with a failed refresh. */
   engineOutcome: MemoryEngineOutcome | null;
   onEngineChange: (engineId: string | null) => void;
-  onEngineReset: () => void;
   addons: readonly MemoryAddonRow[];
   canToggleAddons: boolean;
   onAddonChange: (pluginId: string, enabled: boolean) => void;
@@ -211,12 +210,10 @@ function renderEngineSection(props: MemoryViewProps) {
   const defaultEngine =
     props.engineOptions.find((option) => option.id === DEFAULT_MEMORY_ENGINE_ID)?.label ??
     t("memoryPage.engine.openClawMemory");
-  const defaultState = renderSettingsDefaultState({
-    value: defaultEngine,
-    overridden: props.engineSelection.kind !== "auto",
-    disabled: props.engineBusy,
-    onReset: props.onEngineReset,
-  });
+  const defaultDescription = renderSettingsDefaultDescription(
+    defaultEngine,
+    props.engineSelection.kind !== "auto",
+  );
   if (props.engineOptions.length === 0) {
     return renderSettingsSection(
       { title: t("memoryPage.engine.title"), description: t("memoryPage.engine.description") },
@@ -224,12 +221,9 @@ function renderEngineSection(props: MemoryViewProps) {
         title: t("memoryPage.engine.rowTitle"),
         description: html`
           ${t("memoryPage.engine.catalogUnavailable")} ${t(engineHintKey(props.engineSelection))}
-          ${defaultState.description}
+          ${defaultDescription}
         `,
-        control: html`
-          ${defaultState.action}
-          ${renderSettingsValue(engineId ?? t("memoryPage.engine.off"), { mono: true })}
-        `,
+        control: renderSettingsValue(engineId ?? t("memoryPage.engine.off"), { mono: true }),
       }),
     );
   }
@@ -247,18 +241,15 @@ function renderEngineSection(props: MemoryViewProps) {
     html`
       ${renderSettingsRow({
         title: t("memoryPage.engine.rowTitle"),
-        description: html`${t(engineHintKey(props.engineSelection))} ${defaultState.description}`,
+        description: html`${t(engineHintKey(props.engineSelection))} ${defaultDescription}`,
         stacked: true,
-        control: html`
-          ${defaultState.action}
-          ${renderSettingsSegmented({
-            value: engineId ?? MEMORY_ENGINE_OFF,
-            options,
-            disabled: props.engineBusy,
-            ariaLabel: t("memoryPage.engine.rowTitle"),
-            onChange: (value) => props.onEngineChange(value || null),
-          })}
-        `,
+        control: renderSettingsSegmented({
+          value: engineId ?? MEMORY_ENGINE_OFF,
+          options,
+          disabled: props.engineBusy,
+          ariaLabel: t("memoryPage.engine.rowTitle"),
+          onChange: (value) => props.onEngineChange(value || null),
+        }),
       })}
       ${renderDisabledEngineRow(props, engineId)}
       ${props.engineOutcome === null

--- a/ui/src/pages/config/security.test.ts
+++ b/ui/src/pages/config/security.test.ts
@@ -169,7 +169,7 @@ describe("renderSecurity", () => {
     expect(page?.querySelector("[data-testid='security-editor']")).not.toBeNull();
   });
 
-  it("shows inherited defaults without reset actions", () => {
+  it("shows inherited default descriptions", () => {
     const container = document.createElement("div");
 
     render(
@@ -194,39 +194,5 @@ describe("renderSecurity", () => {
     expect(expectRowByTitle(container, "Tool profile").textContent).toContain(
       "Using default: Full",
     );
-    expect(container.querySelectorAll("button[aria-label='Reset to default']")).toHaveLength(0);
-  });
-
-  it("resets explicit browser and tool-profile overrides", () => {
-    const onBrowserEnabledReset = vi.fn();
-    const onToolProfileReset = vi.fn();
-    const container = document.createElement("div");
-
-    render(
-      renderSecurity(
-        createProps({
-          security: {
-            gatewayAuth: "token",
-            execPolicy: "allowlist",
-            browserEnabled: true,
-            browserEnabledOverridden: true,
-            toolProfile: "full",
-            toolProfileOverridden: true,
-          },
-          onBrowserEnabledReset,
-          onToolProfileReset,
-        }),
-      ),
-      container,
-    );
-
-    const browserRow = expectRowByTitle(container, "Browser enabled");
-    const profileRow = expectRowByTitle(container, "Tool profile");
-    expect(browserRow.textContent).toContain("Default: Enabled");
-    expect(profileRow.textContent).toContain("Default: Full");
-    browserRow.querySelector<HTMLButtonElement>("button[aria-label='Reset to default']")?.click();
-    profileRow.querySelector<HTMLButtonElement>("button[aria-label='Reset to default']")?.click();
-    expect(onBrowserEnabledReset).toHaveBeenCalledOnce();
-    expect(onToolProfileReset).toHaveBeenCalledOnce();
   });
 });

--- a/ui/src/pages/config/security.ts
+++ b/ui/src/pages/config/security.ts
@@ -4,7 +4,7 @@
 import { html, type TemplateResult } from "lit";
 import { icons } from "../../components/icons.ts";
 import {
-  renderSettingsDefaultState,
+  renderSettingsDefaultDescription,
   renderSettingsRow,
   renderSettingsSection,
   renderSettingsSegmented,
@@ -30,9 +30,7 @@ type SecurityViewProps = {
   canPairDevice: boolean;
   onPairMobile?: () => void;
   onBrowserEnabledToggle?: (enabled: boolean) => void;
-  onBrowserEnabledReset?: () => void;
   onToolProfileChange?: (profile: string) => void;
-  onToolProfileReset?: () => void;
   /** Embedded schema editor; it owns autosave status and the restart banner. */
   editor: TemplateResult;
 };
@@ -47,18 +45,6 @@ function renderSecurityOverview(props: SecurityViewProps) {
     toolProfileOverridden,
   } = props.security;
   const normalizedToolProfile = toolProfile.trim() || "full";
-  const browserDefaultState = renderSettingsDefaultState({
-    value: t("common.enabled"),
-    overridden: browserEnabledOverridden,
-    disabled: props.configBusy,
-    onReset: () => props.onBrowserEnabledReset?.(),
-  });
-  const toolProfileDefaultState = renderSettingsDefaultState({
-    value: t("agents.toolCatalog.profiles.full"),
-    overridden: toolProfileOverridden,
-    disabled: props.configBusy,
-    onReset: () => props.onToolProfileReset?.(),
-  });
   const profileOptions = PROFILE_OPTIONS.map((profile) => ({
     value: profile.id as string,
     label: t(profile.labelKey),
@@ -81,25 +67,24 @@ function renderSecurityOverview(props: SecurityViewProps) {
     }),
     renderSettingsToggleRow({
       title: t("quickSettings.security.browserEnabled"),
-      description: browserDefaultState.description,
+      description: renderSettingsDefaultDescription(t("common.enabled"), browserEnabledOverridden),
       checked: browserEnabled,
       disabled: props.configBusy,
-      actions: browserDefaultState.action,
       onChange: (enabled) => props.onBrowserEnabledToggle?.(enabled),
     }),
     renderSettingsRow({
       title: t("quickSettings.security.toolProfile"),
-      description: toolProfileDefaultState.description,
+      description: renderSettingsDefaultDescription(
+        t("agents.toolCatalog.profiles.full"),
+        toolProfileOverridden,
+      ),
       stacked: true,
-      control: html`
-        ${toolProfileDefaultState.action}
-        ${renderSettingsSegmented({
-          value: normalizedToolProfile,
-          options: profileOptions,
-          disabled: props.configBusy,
-          onChange: (profile) => props.onToolProfileChange?.(profile),
-        })}
-      `,
+      control: renderSettingsSegmented({
+        value: normalizedToolProfile,
+        options: profileOptions,
+        disabled: props.configBusy,
+        onChange: (profile) => props.onToolProfileChange?.(profile),
+      }),
     }),
     renderSettingsRow({
       title: t("devices.pairing.title"),

--- a/ui/src/pages/config/settings-select-row.ts
+++ b/ui/src/pages/config/settings-select-row.ts
@@ -1,5 +1,5 @@
 // Shared labeled select rendering for compact Control UI preference rows.
-import { html, nothing, type TemplateResult } from "lit";
+import { html } from "lit";
 import { renderSettingsRow } from "../../components/settings-ui.ts";
 
 export function renderSettingsSelectRow<T extends string>(params: {
@@ -9,13 +9,11 @@ export function renderSettingsSelectRow<T extends string>(params: {
   options: ReadonlyArray<{ value: T; label: string }>;
   onChange: (value: string) => void;
   description?: unknown;
-  actions?: TemplateResult | typeof nothing;
 }) {
   return renderSettingsRow({
     title: params.title,
     description: params.description,
     control: html`
-      ${params.actions ?? nothing}
       <select
         class="settings-select"
         ?data-settings-send-shortcut=${params.setting === "send-shortcut"}

--- a/ui/src/pages/config/view-appearance-preferences.ts
+++ b/ui/src/pages/config/view-appearance-preferences.ts
@@ -18,7 +18,7 @@ import { LOBSTER_PALETTE_LORE, lobsterPaletteName } from "../../components/lobst
 import { LOBSTER_PET_PALETTES } from "../../components/lobster-pet-palettes.ts";
 import "../../components/tooltip.ts";
 import {
-  renderSettingsDefaultState,
+  renderSettingsDefaultDescription,
   renderSettingsRow,
   renderSettingsToggleRow,
 } from "../../components/settings-ui.ts";
@@ -44,11 +44,10 @@ export function serverUiPrefProvenanceHint(provenance: ServerUiPrefProvenance): 
 }
 
 export function renderLanguageSection(props: ConfigProps) {
-  const defaultState = renderSettingsDefaultState({
-    value: props.localeResetValue ? languageLabel(props.localeResetValue) : t("common.system"),
-    overridden: props.localeOverridden,
-    onReset: props.resetLocale,
-  });
+  const defaultDescription = renderSettingsDefaultDescription(
+    props.localeResetValue ? languageLabel(props.localeResetValue) : t("common.system"),
+    props.localeOverridden,
+  );
   const provenance = serverUiPrefProvenanceHint(props.localeProvenance);
   return html`
     <section id=${APPEARANCE_SETTINGS_TARGET_IDS.language} class="settings-section">
@@ -58,11 +57,12 @@ export function renderLanguageSection(props: ConfigProps) {
       <div class="settings-group">
         ${renderSettingsRow({
           title: t("quickSettings.language"),
-          description: html`${defaultState.description} ${provenance}`,
-          control: html`
-            ${defaultState.action}
-            ${renderLanguageSelect(props.localeOverride, props.systemLocale, props.onLocaleChange)}
-          `,
+          description: html`${defaultDescription} ${provenance}`,
+          control: renderLanguageSelect(
+            props.localeOverride,
+            props.systemLocale,
+            props.onLocaleChange,
+          ),
         })}
       </div>
     </section>
@@ -191,33 +191,27 @@ export function renderChatPreferencesSection(
   const followUpDescription = props.chatFollowUpMode
     ? t("chat.followUpModeOverriding", { mode: serverQueueMode })
     : t("chat.followUpModeUsingServer", { mode: serverQueueMode });
-  const messageWidthDefaultState = renderSettingsDefaultState({
-    value: UI_APPEARANCE_DEFAULTS.chatMessageMaxWidth,
-    overridden: props.chatMessageMaxWidth !== undefined,
-    onReset: () => props.setChatMessageMaxWidth(undefined),
-  });
-  const sendShortcutDefaultState = renderSettingsDefaultState({
-    value:
-      props.chatSendShortcutResetValue === "modifier-enter"
-        ? t("chat.sendShortcutModifierEnter")
-        : t("chat.sendShortcutEnter"),
-    overridden: props.chatSendShortcutOverridden,
-    onReset: props.resetChatSendShortcut,
-  });
+  const messageWidthDefaultDescription = renderSettingsDefaultDescription(
+    UI_APPEARANCE_DEFAULTS.chatMessageMaxWidth,
+    props.chatMessageMaxWidth !== undefined,
+  );
+  const sendShortcutDefaultDescription = renderSettingsDefaultDescription(
+    props.chatSendShortcutResetValue === "modifier-enter"
+      ? t("chat.sendShortcutModifierEnter")
+      : t("chat.sendShortcutEnter"),
+    props.chatSendShortcutOverridden,
+  );
   const sendShortcutProvenance = serverUiPrefProvenanceHint(props.chatSendShortcutProvenance);
   const followUpProvenance = serverUiPrefProvenanceHint(props.chatFollowUpModeProvenance);
-  const catalogTargetDefaultState = renderSettingsDefaultState({
-    value: t("chat.catalogOpenTargetViewer"),
-    overridden: props.catalogOpenTarget !== UI_APPEARANCE_DEFAULTS.catalogOpenTarget,
-    onReset: () => props.setCatalogOpenTarget(UI_APPEARANCE_DEFAULTS.catalogOpenTarget),
-  });
-  const holdToRecordDefaultState = renderSettingsDefaultState({
-    value: t("common.enabled"),
-    overridden:
-      (props.composerHoldToRecord ?? UI_APPEARANCE_DEFAULTS.composerHoldToRecord) !==
+  const catalogTargetDefaultDescription = renderSettingsDefaultDescription(
+    t("chat.catalogOpenTargetViewer"),
+    props.catalogOpenTarget !== UI_APPEARANCE_DEFAULTS.catalogOpenTarget,
+  );
+  const holdToRecordDefaultDescription = renderSettingsDefaultDescription(
+    t("common.enabled"),
+    (props.composerHoldToRecord ?? UI_APPEARANCE_DEFAULTS.composerHoldToRecord) !==
       UI_APPEARANCE_DEFAULTS.composerHoldToRecord,
-    onReset: () => props.setComposerHoldToRecord?.(UI_APPEARANCE_DEFAULTS.composerHoldToRecord),
-  });
+  );
   return html`
     <section id=${APPEARANCE_SETTINGS_TARGET_IDS.chat} class="settings-section">
       <div class="settings-section__header">
@@ -227,15 +221,14 @@ export function renderChatPreferencesSection(
         ${renderSettingsRow({
           title: t("configView.chatPrefs.messageWidth"),
           description: html`${t("configView.chatPrefs.messageWidthHint")}<br />
-            ${messageWidthDefaultState.description} ${t("quickSettings.personal.browserOnly")}`,
-          control: html` ${messageWidthDefaultState.action} ${messageWidthInput} `,
+            ${messageWidthDefaultDescription} ${t("quickSettings.personal.browserOnly")}`,
+          control: messageWidthInput,
         })}
         ${renderSettingsSelectRow({
           title: t("chat.sendShortcut"),
           value: props.chatSendShortcut,
           setting: "send-shortcut",
-          description: html`${sendShortcutDefaultState.description} ${sendShortcutProvenance}`,
-          actions: sendShortcutDefaultState.action,
+          description: html`${sendShortcutDefaultDescription} ${sendShortcutProvenance}`,
           options: [
             { value: "enter", label: t("chat.sendShortcutEnter") },
             { value: "modifier-enter", label: t("chat.sendShortcutModifierEnter") },
@@ -283,9 +276,8 @@ export function renderChatPreferencesSection(
           title: t("chat.catalogOpenTarget"),
           value: props.catalogOpenTarget,
           setting: "catalog-open-target",
-          description: html`${catalogTargetDefaultState.description}
+          description: html`${catalogTargetDefaultDescription}
           ${t("quickSettings.personal.browserOnly")}`,
-          actions: catalogTargetDefaultState.action,
           options: [
             { value: "viewer", label: t("chat.catalogOpenTargetViewer") },
             { value: "terminal", label: t("chat.catalogOpenTargetTerminal") },
@@ -297,10 +289,9 @@ export function renderChatPreferencesSection(
           ? renderSettingsToggleRow({
               title: t("chat.composer.holdToRecordSetting"),
               description: html`${t("chat.composer.holdToRecordSettingDescription")}<br />
-                ${holdToRecordDefaultState.description} ${t("quickSettings.personal.browserOnly")}`,
+                ${holdToRecordDefaultDescription} ${t("quickSettings.personal.browserOnly")}`,
               checked: props.composerHoldToRecord ?? UI_APPEARANCE_DEFAULTS.composerHoldToRecord,
               onChange: props.setComposerHoldToRecord,
-              actions: holdToRecordDefaultState.action,
             })
           : nothing}
       </div>
@@ -316,16 +307,14 @@ export function renderLobsterPetSection(props: ConfigProps) {
   }
   const lobsterPetVisits = props.lobsterPetVisits ?? UI_APPEARANCE_DEFAULTS.lobsterPetVisits;
   const lobsterPetSounds = props.lobsterPetSounds ?? UI_APPEARANCE_DEFAULTS.lobsterPetSounds;
-  const lobsterVisitsDefaultState = renderSettingsDefaultState({
-    value: t("common.enabled"),
-    overridden: lobsterPetVisits !== UI_APPEARANCE_DEFAULTS.lobsterPetVisits,
-    onReset: () => props.setLobsterPetVisits?.(UI_APPEARANCE_DEFAULTS.lobsterPetVisits),
-  });
-  const lobsterSoundsDefaultState = renderSettingsDefaultState({
-    value: t("common.disabled"),
-    overridden: lobsterPetSounds !== UI_APPEARANCE_DEFAULTS.lobsterPetSounds,
-    onReset: () => props.setLobsterPetSounds?.(UI_APPEARANCE_DEFAULTS.lobsterPetSounds),
-  });
+  const lobsterVisitsDefaultDescription = renderSettingsDefaultDescription(
+    t("common.enabled"),
+    lobsterPetVisits !== UI_APPEARANCE_DEFAULTS.lobsterPetVisits,
+  );
+  const lobsterSoundsDefaultDescription = renderSettingsDefaultDescription(
+    t("common.disabled"),
+    lobsterPetSounds !== UI_APPEARANCE_DEFAULTS.lobsterPetSounds,
+  );
   const dexEntries = getLobsterdexEntries();
   const seenCount = LOBSTER_PET_PALETTES.filter((palette) => dexEntries.has(palette.id)).length;
   return html`
@@ -338,23 +327,21 @@ export function renderLobsterPetSection(props: ConfigProps) {
           title: t("quickSettings.appearance.lobsterVisits"),
           description: lobsterPetVisits
             ? html`${t("quickSettings.appearance.lobsterVisitsOn")}<br />
-                ${lobsterVisitsDefaultState.description} ${t("quickSettings.personal.browserOnly")}`
+                ${lobsterVisitsDefaultDescription} ${t("quickSettings.personal.browserOnly")}`
             : html`${t("quickSettings.appearance.lobsterVisitsOff")}<br />
-                ${lobsterVisitsDefaultState.description} ${t("quickSettings.personal.browserOnly")}`,
+                ${lobsterVisitsDefaultDescription} ${t("quickSettings.personal.browserOnly")}`,
           checked: lobsterPetVisits,
           onChange: (enabled) => props.setLobsterPetVisits?.(enabled),
-          actions: lobsterVisitsDefaultState.action,
         })}
         ${renderSettingsToggleRow({
           title: t("quickSettings.appearance.lobsterSounds"),
           description: lobsterPetSounds
             ? html`${t("quickSettings.appearance.lobsterSoundsOn")}<br />
-                ${lobsterSoundsDefaultState.description} ${t("quickSettings.personal.browserOnly")}`
+                ${lobsterSoundsDefaultDescription} ${t("quickSettings.personal.browserOnly")}`
             : html`${t("quickSettings.appearance.lobsterSoundsOff")}<br />
-                ${lobsterSoundsDefaultState.description} ${t("quickSettings.personal.browserOnly")}`,
+                ${lobsterSoundsDefaultDescription} ${t("quickSettings.personal.browserOnly")}`,
           checked: lobsterPetSounds,
           onChange: (enabled) => props.setLobsterPetSounds?.(enabled),
-          actions: lobsterSoundsDefaultState.action,
           onAct: (enabled) => {
             if (enabled) {
               previewLobsterChirp();
@@ -439,21 +426,19 @@ export function renderLobsterPetSection(props: ConfigProps) {
 
 export function renderSidebarPreferencesSection(props: ConfigProps) {
   const hiddenCatalogIds = [...props.hiddenSessionCatalogIds].toSorted();
-  const liveActivityDefaultState = renderSettingsDefaultState({
-    value: t("common.enabled"),
-    overridden: props.sidebarLiveActivity !== UI_APPEARANCE_DEFAULTS.sidebarLiveActivity,
-    onReset: () => props.setSidebarLiveActivity(UI_APPEARANCE_DEFAULTS.sidebarLiveActivity),
-  });
+  const liveActivityDefaultDescription = renderSettingsDefaultDescription(
+    t("common.enabled"),
+    props.sidebarLiveActivity !== UI_APPEARANCE_DEFAULTS.sidebarLiveActivity,
+  );
   // The delete dialog's "Don't ask me again" writes this off; this row is where
   // the operator turns it back on, so it has to stay next to the session prefs.
   const setSessionDeleteConfirm = props.setSessionDeleteConfirm;
   const sessionDeleteConfirm =
     props.sessionDeleteConfirm ?? UI_APPEARANCE_DEFAULTS.sessionDeleteConfirm;
-  const deleteConfirmDefaultState = renderSettingsDefaultState({
-    value: t("common.enabled"),
-    overridden: sessionDeleteConfirm !== UI_APPEARANCE_DEFAULTS.sessionDeleteConfirm,
-    onReset: () => setSessionDeleteConfirm?.(UI_APPEARANCE_DEFAULTS.sessionDeleteConfirm),
-  });
+  const deleteConfirmDefaultDescription = renderSettingsDefaultDescription(
+    t("common.enabled"),
+    sessionDeleteConfirm !== UI_APPEARANCE_DEFAULTS.sessionDeleteConfirm,
+  );
   return html`
     <section id=${APPEARANCE_SETTINGS_TARGET_IDS.sidebar} class="settings-section">
       <div class="settings-section__header">
@@ -464,19 +449,17 @@ export function renderSidebarPreferencesSection(props: ConfigProps) {
         ${renderSettingsToggleRow({
           title: t("configView.sidebarPrefs.liveActivity"),
           description: html`${t("configView.sidebarPrefs.liveActivityHint")}<br />
-            ${liveActivityDefaultState.description} ${t("quickSettings.personal.browserOnly")}`,
+            ${liveActivityDefaultDescription} ${t("quickSettings.personal.browserOnly")}`,
           checked: props.sidebarLiveActivity,
           onChange: props.setSidebarLiveActivity,
-          actions: liveActivityDefaultState.action,
         })}
         ${setSessionDeleteConfirm
           ? renderSettingsToggleRow({
               title: t("configView.sidebarPrefs.deleteConfirm"),
               description: html`${t("configView.sidebarPrefs.deleteConfirmHint")}<br />
-                ${deleteConfirmDefaultState.description} ${t("quickSettings.personal.browserOnly")}`,
+                ${deleteConfirmDefaultDescription} ${t("quickSettings.personal.browserOnly")}`,
               checked: sessionDeleteConfirm,
               onChange: setSessionDeleteConfirm,
-              actions: deleteConfirmDefaultState.action,
             })
           : nothing}
       </div>

--- a/ui/src/pages/config/view-types.ts
+++ b/ui/src/pages/config/view-types.ts
@@ -121,7 +121,6 @@ export type ConfigProps = {
   localeProvenance: ServerUiPrefProvenance;
   localeResetValue?: Locale;
   onLocaleChange: (locale: Locale | undefined) => void;
-  resetLocale: () => void;
   setTheme: (theme: ThemeName, context?: ThemeTransitionContext) => void;
   setThemeMode: (mode: ThemeMode, context?: ThemeTransitionContext) => void;
   setAccent: (accent: string | undefined) => void;
@@ -172,7 +171,6 @@ export type ConfigProps = {
   chatSendShortcutProvenance: ServerUiPrefProvenance;
   chatSendShortcutResetValue: ChatSendShortcut;
   setChatSendShortcut: (value: ChatSendShortcut) => void;
-  resetChatSendShortcut: () => void;
   chatFollowUpMode: ChatFollowUpMode | undefined;
   chatFollowUpModeOverridden: boolean;
   chatFollowUpModeProvenance: ServerUiPrefProvenance;

--- a/ui/src/pages/config/view.browser.test.ts
+++ b/ui/src/pages/config/view.browser.test.ts
@@ -71,7 +71,6 @@ describe("config view", () => {
     localeProvenance: "default" as const,
     localeResetValue: undefined,
     onLocaleChange: vi.fn(),
-    resetLocale: vi.fn(),
     setTheme: vi.fn(),
     setThemeMode: vi.fn(),
     setAccent: vi.fn(),
@@ -104,7 +103,6 @@ describe("config view", () => {
     chatSendShortcutProvenance: "default" as const,
     chatSendShortcutResetValue: "enter" as const,
     setChatSendShortcut: vi.fn(),
-    resetChatSendShortcut: vi.fn(),
     chatFollowUpMode: undefined,
     chatFollowUpModeOverridden: false,
     chatFollowUpModeProvenance: "default" as const,
@@ -324,7 +322,7 @@ describe("config view", () => {
     ).toEqual(["Open links in Control UI browser", "Browser Enabled"]);
   });
 
-  it("routes restore-default actions through config removal", () => {
+  it("routes scalar clears and default selections through config callbacks", () => {
     const onFormPatch = vi.fn();
     const onFormRemove = vi.fn();
     const { container } = renderConfigView({
@@ -359,11 +357,9 @@ describe("config view", () => {
     const retriesRow = Array.from(container.querySelectorAll<HTMLElement>(".settings-row")).find(
       (row) => row.textContent?.includes("Retries"),
     );
-    queryRequired(
-      retriesRow ?? container,
-      "button[aria-label='Reset to default']",
-      HTMLButtonElement,
-    ).click();
+    const retries = queryRequired(retriesRow ?? container, "input", HTMLInputElement);
+    retries.value = "";
+    retries.dispatchEvent(new Event("input", { bubbles: true }));
     expect(onFormRemove).toHaveBeenCalledWith(["gateway", "retries"]);
     expect(onFormPatch).not.toHaveBeenCalled();
 
@@ -1835,7 +1831,7 @@ describe("config view", () => {
     expect(findButtonByText(customContainer, "Claw").getAttribute("aria-pressed")).toBe("false");
   });
 
-  it("shows Appearance defaults without reset actions", () => {
+  it("shows Appearance default descriptions", () => {
     const { container } = renderConfigView({
       activeSection: "__appearance__",
       includeSections: ["__appearance__"],
@@ -1868,30 +1864,16 @@ describe("config view", () => {
     expect(
       [...lobsterPreviews].every((preview) => Boolean(preview.getAttribute("aria-label")?.trim())),
     ).toBe(true);
-    expect(container.querySelector('button[aria-label="Reset to default"]')).toBeNull();
   });
 
-  it("keeps direct Appearance defaults while resetting unrelated overrides independently", () => {
-    const resetLocale = vi.fn();
+  it("keeps direct Appearance default selections independent", () => {
     const setTheme = vi.fn();
     const setThemeMode = vi.fn();
     const setAccent = vi.fn();
     const setTextScale = vi.fn();
-    const setSidebarLiveActivity = vi.fn();
-    const setChatMessageMaxWidth = vi.fn();
-    const setChatSendShortcut = vi.fn();
-    const resetChatSendShortcut = vi.fn();
-    const setCatalogOpenTarget = vi.fn();
-    const setComposerHoldToRecord = vi.fn();
-    const setLobsterPetVisits = vi.fn();
-    const setLobsterPetSounds = vi.fn();
     const { container } = renderConfigView({
       activeSection: "__appearance__",
       includeSections: ["__appearance__"],
-      systemLocale: "de",
-      localeOverride: "pt-BR",
-      localeOverridden: true,
-      resetLocale,
       theme: "knot",
       themeOverridden: true,
       setTheme,
@@ -1904,30 +1886,7 @@ describe("config view", () => {
       textScale: 110,
       textScaleOverridden: true,
       setTextScale,
-      sidebarLiveActivity: false,
-      setSidebarLiveActivity,
-      chatMessageMaxWidth: "82%",
-      setChatMessageMaxWidth,
-      chatSendShortcut: "modifier-enter",
-      chatSendShortcutOverridden: true,
-      setChatSendShortcut,
-      resetChatSendShortcut,
-      catalogOpenTarget: "terminal",
-      setCatalogOpenTarget,
-      composerHoldToRecord: false,
-      setComposerHoldToRecord,
-      lobsterPetVisits: false,
-      setLobsterPetVisits,
-      lobsterPetSounds: true,
-      setLobsterPetSounds,
     });
-    const resetIn = (element: Element | null) => {
-      const button = element?.querySelector<HTMLButtonElement>(
-        'button[aria-label="Reset to default"]',
-      );
-      expect(button).not.toBeNull();
-      button?.click();
-    };
     const row = (title: string) =>
       Array.from(container.querySelectorAll<HTMLElement>(".settings-row")).find(
         (candidate) =>
@@ -1948,33 +1907,15 @@ describe("config view", () => {
       .find((button) => button.textContent?.includes("100%"))
       ?.click();
 
-    resetIn(container.querySelector("#settings-language .settings-row"));
-    resetIn(row("Show live agent activity in sidebar"));
-    resetIn(row("Message width"));
-    resetIn(row("Send shortcut"));
-    resetIn(row("Open external sessions in"));
-    resetIn(row("Hold microphone button to start dictation"));
-    resetIn(row("Lobster visits"));
-    resetIn(row("Lobster sounds"));
-
-    expect(resetLocale).toHaveBeenCalledOnce();
     expect(setTheme).toHaveBeenCalledWith("claw", expect.any(Object));
     expect(setThemeMode).toHaveBeenCalledWith("system", expect.any(Object));
     expect(setAccent).toHaveBeenCalledWith(undefined);
     expect(setTextScale).toHaveBeenCalledWith(100);
-    expect(setSidebarLiveActivity).toHaveBeenCalledWith(true);
-    expect(setChatMessageMaxWidth).toHaveBeenCalledWith(undefined);
-    expect(resetChatSendShortcut).toHaveBeenCalledOnce();
-    expect(setCatalogOpenTarget).toHaveBeenCalledWith("viewer");
-    expect(setComposerHoldToRecord).toHaveBeenCalledWith(true);
-    expect(setLobsterPetVisits).toHaveBeenCalledWith(true);
-    expect(setLobsterPetSounds).toHaveBeenCalledWith(false);
   });
 
-  it("keeps authored visual defaults direct while preserving chat preference resets", () => {
+  it("keeps authored visual defaults direct", () => {
     const setTheme = vi.fn();
     const setThemeMode = vi.fn();
-    const resetChatSendShortcut = vi.fn();
     const { container } = renderConfigView({
       activeSection: "__appearance__",
       includeSections: ["__appearance__"],
@@ -1989,7 +1930,6 @@ describe("config view", () => {
       chatSendShortcut: "enter",
       chatSendShortcutOverridden: true,
       chatSendShortcutProvenance: "synced",
-      resetChatSendShortcut,
     });
     const themeSection = queryRequired(container, "#settings-appearance-theme", HTMLElement);
     const shortcutRow = Array.from(container.querySelectorAll<HTMLElement>(".settings-row")).find(
@@ -2002,15 +1942,12 @@ describe("config view", () => {
     expect(shortcutRow?.textContent).toContain("Default: Enter");
     findButtonByText(themeSection, "Claw").click();
     themeSection.querySelector<HTMLElement>('wa-radio[value="system"]')?.click();
-    shortcutRow?.querySelector<HTMLButtonElement>("button[aria-label='Reset to default']")?.click();
 
     expect(setTheme).toHaveBeenCalledWith("claw", expect.any(Object));
     expect(setThemeMode).toHaveBeenCalledWith("system", expect.any(Object));
-    expect(resetChatSendShortcut).toHaveBeenCalledOnce();
   });
 
   it("renders rejected theme and locale edits as browser-only fallbacks", () => {
-    const resetLocale = vi.fn();
     const setTheme = vi.fn();
     const { container } = renderConfigView({
       activeSection: "__appearance__",
@@ -2019,7 +1956,6 @@ describe("config view", () => {
       localeOverridden: true,
       localeProvenance: "device-local",
       localeResetValue: "de",
-      resetLocale,
       theme: "knot",
       themeOverridden: true,
       themeProvenance: "device-local",
@@ -2051,10 +1987,8 @@ describe("config view", () => {
       themeSection.querySelector(".settings-theme-card--knot")?.getAttribute("aria-pressed"),
     ).toBe("true");
 
-    languageRow.querySelector<HTMLButtonElement>('button[aria-label="Reset to default"]')?.click();
     findButtonByText(themeSection, "Claw").click();
 
-    expect(resetLocale).toHaveBeenCalledOnce();
     expect(setTheme).toHaveBeenCalledWith("claw", expect.any(Object));
   });
 

--- a/ui/src/pages/labs/labs-page.test.ts
+++ b/ui/src/pages/labs/labs-page.test.ts
@@ -332,13 +332,10 @@ describe("LabsPage", () => {
     );
   });
 
-  it("shows default provenance without reset actions", async () => {
+  it("shows default provenance", async () => {
     const inherited = await mountPage({});
     expect(labRow(inherited.page, "Code Mode").textContent).toContain("Using default: Disabled");
     expect(labRow(inherited.page, "Swarm").textContent).toContain("Using default: Disabled");
-    expect(inherited.page.querySelectorAll("button[aria-label='Reset to default']")).toHaveLength(
-      0,
-    );
     inherited.provider.remove();
 
     const overridden = await mountPage({
@@ -349,9 +346,6 @@ describe("LabsPage", () => {
     });
     expect(labRow(overridden.page, "Code Mode").textContent).toContain("Default: Disabled");
     expect(labRow(overridden.page, "Swarm").textContent).toContain("Default: Disabled");
-    expect(overridden.page.querySelectorAll("button[aria-label='Reset to default']")).toHaveLength(
-      0,
-    );
   });
 
   it.each([{ model: "ollama/qwen3:8b" }, { model: { primary: "ollama/qwen3:8b", fallbacks: [] } }])(
@@ -369,7 +363,6 @@ describe("LabsPage", () => {
       const row = labRow(page, "Lean tools for local models");
 
       expect(row.textContent).toContain("Using default: Enabled");
-      expect(row.querySelector("button[aria-label='Reset to default']")).toBeNull();
     },
   );
 

--- a/ui/src/pages/model-providers/model-providers-page.test.ts
+++ b/ui/src/pages/model-providers/model-providers-page.test.ts
@@ -290,35 +290,6 @@ describe("ModelProvidersPage agent scope", () => {
     ]);
   });
 
-  it("keeps invalid explicit thinking and fast values resettable", async () => {
-    const { context, runtimeConfig } = createHarness("main");
-    runtimeConfig.state.configForm = {
-      agents: { defaults: { thinkingDefault: 42, fastModeDefault: "bogus" } },
-    } as unknown as typeof runtimeConfig.state.configForm;
-    const page = appendPage(context);
-    await waitForFast(() => expect(page.querySelector("#settings-model-behavior")).not.toBeNull());
-
-    const behavior = page.querySelector("#settings-model-behavior")!;
-    const groups = behavior.querySelectorAll<HTMLElement & { value: string }>("wa-radio-group");
-    expect([...groups].map((group) => group.value)).toEqual(["", ""]);
-    const resetButtons = behavior.querySelectorAll<HTMLButtonElement>(
-      'button[aria-label="Reset to default"]',
-    );
-    expect(resetButtons).toHaveLength(2);
-    resetButtons.forEach((button) => button.click());
-
-    expect(runtimeConfig.removeFormValue).toHaveBeenNthCalledWith(1, [
-      "agents",
-      "defaults",
-      "thinkingDefault",
-    ]);
-    expect(runtimeConfig.removeFormValue).toHaveBeenNthCalledWith(2, [
-      "agents",
-      "defaults",
-      "fastModeDefault",
-    ]);
-  });
-
   it("keeps a committed provider-key save successful when config refresh fails", async () => {
     const { context, runtimeConfig } = createHarness("main");
     runtimeConfig.refresh.mockImplementationOnce(async () => {

--- a/ui/src/pages/model-providers/view.test.ts
+++ b/ui/src/pages/model-providers/view.test.ts
@@ -208,15 +208,10 @@ describe("renderModelProviders", () => {
     expect(text(thinkingRow)).toContain("Default: Model policy");
     expect(text(fastRow)).toContain("Default: Model policy");
 
-    thinkingRow.querySelector<HTMLButtonElement>('button[aria-label="Reset to default"]')?.click();
-    fastRow.querySelector<HTMLButtonElement>('button[aria-label="Reset to default"]')?.click();
-    expect(onThinkingReset).toHaveBeenCalledOnce();
-    expect(onFastModeReset).toHaveBeenCalledOnce();
-
     selectSegment(thinkingRow.querySelector<SegmentedGroup>("wa-radio-group")!, "");
     selectSegment(fastRow.querySelector<SegmentedGroup>("wa-radio-group")!, "");
-    expect(onThinkingReset).toHaveBeenCalledTimes(2);
-    expect(onFastModeReset).toHaveBeenCalledTimes(2);
+    expect(onThinkingReset).toHaveBeenCalledOnce();
+    expect(onFastModeReset).toHaveBeenCalledOnce();
 
     render(
       renderModelProviders(
@@ -247,34 +242,6 @@ describe("renderModelProviders", () => {
     ).toBe(true);
     expect(text(inheritedThinking)).toContain("Using default: Model policy");
     expect(text(inheritedFast)).toContain("Using default: Model policy");
-    expect(
-      inheritedBehavior.querySelectorAll('button[aria-label="Reset to default"]'),
-    ).toHaveLength(0);
-  });
-
-  it("keeps invalid explicit model behavior values resettable", () => {
-    const onThinkingReset = vi.fn();
-    const onFastModeReset = vi.fn();
-    const container = mount(
-      props({
-        thinkingLevel: undefined,
-        thinkingOverridden: true,
-        fastMode: undefined,
-        fastModeOverridden: true,
-        onThinkingReset,
-        onFastModeReset,
-      }),
-    );
-    const behavior = container.querySelector("#settings-model-behavior")!;
-    const thinking = settingsRow(behavior, "Thinking");
-    const fast = settingsRow(behavior, "Fast mode");
-
-    expect(text(thinking)).toContain("Default: Model policy");
-    expect(text(fast)).toContain("Default: Model policy");
-    thinking.querySelector<HTMLButtonElement>('button[aria-label="Reset to default"]')?.click();
-    fast.querySelector<HTMLButtonElement>('button[aria-label="Reset to default"]')?.click();
-    expect(onThinkingReset).toHaveBeenCalledOnce();
-    expect(onFastModeReset).toHaveBeenCalledOnce();
   });
 
   it("restores controlled model behavior when a reset is rejected", () => {

--- a/ui/src/pages/model-providers/view.ts
+++ b/ui/src/pages/model-providers/view.ts
@@ -7,7 +7,7 @@ import { renderProviderBrandIcon } from "../../components/provider-icon.ts";
 import { renderProviderUsageDetails } from "../../components/provider-usage.ts";
 import {
   renderSettingsEmpty,
-  renderSettingsDefaultState,
+  renderSettingsDefaultDescription,
   renderSettingsGroup,
   renderSettingsPage,
   renderSettingsRow,
@@ -132,67 +132,55 @@ function renderModelBehavior(props: ModelProvidersViewProps) {
     props.thinkingLevel && !THINKING_LEVEL_SET.has(props.thinkingLevel)
       ? [...THINKING_LEVELS, props.thinkingLevel]
       : THINKING_LEVELS;
-  const thinkingDefault = renderSettingsDefaultState({
-    value: t("quickSettings.model.modelPolicy"),
-    overridden: props.thinkingOverridden,
-    disabled: props.configBusy,
-    onReset: props.onThinkingReset,
-  });
-  const fastDefault = renderSettingsDefaultState({
-    value: t("quickSettings.model.modelPolicy"),
-    overridden: props.fastModeOverridden,
-    disabled: props.configBusy,
-    onReset: props.onFastModeReset,
-  });
   const fastMode = props.fastMode === undefined ? "" : formatFastModeValue(props.fastMode);
   return html`
     <div id=${MODEL_SETTINGS_TARGET_IDS.behavior}>
       ${renderSettingsSection({ title: t("quickSettings.model.title") }, [
         renderSettingsRow({
           title: t("quickSettings.model.thinking"),
-          description: thinkingDefault.description,
-          control: html`
-            ${renderSettingsSegmented({
-              value: props.thinkingLevel ?? "",
-              options: [
-                { value: "", label: t("quickSettings.model.default") },
-                ...thinkingLevels.map((level) => ({
-                  value: level,
-                  label: THINKING_LEVEL_SET.has(level)
-                    ? t(`quickSettings.model.thinkingLevels.${level}`)
-                    : formatThinkingOverrideLabel(level),
-                })),
-              ],
-              disabled: props.configBusy,
-              onChange: (value, element) =>
-                value === "" ? props.onThinkingReset() : props.onThinkingChange(value, element),
-            })}
-            ${thinkingDefault.action}
-          `,
+          description: renderSettingsDefaultDescription(
+            t("quickSettings.model.modelPolicy"),
+            props.thinkingOverridden,
+          ),
+          control: renderSettingsSegmented({
+            value: props.thinkingLevel ?? "",
+            options: [
+              { value: "", label: t("quickSettings.model.default") },
+              ...thinkingLevels.map((level) => ({
+                value: level,
+                label: THINKING_LEVEL_SET.has(level)
+                  ? t(`quickSettings.model.thinkingLevels.${level}`)
+                  : formatThinkingOverrideLabel(level),
+              })),
+            ],
+            disabled: props.configBusy,
+            onChange: (value, element) =>
+              value === "" ? props.onThinkingReset() : props.onThinkingChange(value, element),
+          }),
         }),
         renderSettingsRow({
           title: t("quickSettings.model.fastMode"),
-          description: fastDefault.description,
-          control: html`
-            ${renderSettingsSegmented<"" | "auto" | "on" | "off">({
-              value: fastMode,
-              options: [
-                { value: "", label: t("quickSettings.model.default") },
-                { value: "auto", label: t("quickSettings.model.fastModes.auto") },
-                { value: "on", label: t("quickSettings.model.fastModes.fast") },
-                { value: "off", label: t("quickSettings.model.fastModes.standard") },
-              ],
-              disabled: props.configBusy,
-              onChange: (value) => {
-                if (value === "") {
-                  props.onFastModeReset();
-                } else if (value !== fastMode) {
-                  props.onFastModeChange(fastModeOptionValue(value));
-                }
-              },
-            })}
-            ${fastDefault.action}
-          `,
+          description: renderSettingsDefaultDescription(
+            t("quickSettings.model.modelPolicy"),
+            props.fastModeOverridden,
+          ),
+          control: renderSettingsSegmented<"" | "auto" | "on" | "off">({
+            value: fastMode,
+            options: [
+              { value: "", label: t("quickSettings.model.default") },
+              { value: "auto", label: t("quickSettings.model.fastModes.auto") },
+              { value: "on", label: t("quickSettings.model.fastModes.fast") },
+              { value: "off", label: t("quickSettings.model.fastModes.standard") },
+            ],
+            disabled: props.configBusy,
+            onChange: (value) => {
+              if (value === "") {
+                props.onFastModeReset();
+              } else if (value !== fastMode) {
+                props.onFastModeChange(fastModeOptionValue(value));
+              }
+            },
+          }),
         }),
       ])}
     </div>


### PR DESCRIPTION
## What Problem This Solves

Every overridden row in the Control UI settings surfaces rendered a circular "Reset to default" icon button. It is persistent chrome on an already dense surface, and it duplicated an affordance the controls themselves provide — the segmented `On / Off / Auto` groups, the `Default` options, the selects, and the clearable text/number inputs all reach the default value directly.

Two independent implementations rendered it:

- `renderRestoreDefaultButton` in `ui/src/components/config-form.node.shared.ts` — the schema-driven config form (segmented enums, selects, text/number inputs, JSON textareas, boolean toggle rows, object/array collection headers).
- The `action` branch of `renderSettingsDefaultState` in `ui/src/components/settings-ui.ts` — the hand-written settings pages (appearance prefs, security, memory, dreaming, model providers, agent memory panel).

## Why This Change Was Made

Maintainer decision: remove it everywhere rather than hide it behind hover, so there is one canonical path to a default value — pick it in the control. Deleting the button also removes a long dead-code chain of `onReset` props, controller methods, and reset-only wiring that existed solely to feed it. The `Default: x` / `Using default: x` descriptions stay; only the icon disappears.

## User Impact

Settings rows lose the trailing refresh icon. Reverting to a default is unchanged everywhere the control already exposes it:

| Surface | How you reach the default now |
| --- | --- |
| Segmented enums (`Native Commands`, tool profile, memory engine) | select the default option |
| Model thinking / fast mode | the existing explicit **Default** option (`onThinkingReset` / `onFastModeReset`) |
| Language | the existing **System** option (`setLocale(undefined)`) |
| Browser enabled, tool profile | selecting the default value already calls `removeFormValue` |
| Text / number / JSON config fields | clear the field — that still routes through `onRemove` |
| Chat message width, dreaming inputs | clear the field |
| Theme, accent, font, text size | unchanged `onReselect` gesture |

Two narrow cases now write the default value explicitly instead of deleting the config key. Effective behavior is identical, but the key stays present:

- **Memory engine** — the segmented control has no `auto` option, so picking the default engine writes `plugins.slots.memory` rather than removing it.
- **Chat send shortcut** — this was the only way to drop a personal override and fall back to the gateway-provided value; picking either option now always sets a personal preference.

Both are accepted tradeoffs of removing the control everywhere. If either matters, the fix belongs in that control (an `Auto` / `Use server value` option), not in a restored global icon.

## Evidence

Before / after — `/settings/automation`, the exact rows from the report, captured on the mocked Control UI dev server (`pnpm dev:ui:mock`) at 2x, dark theme:

**Before**

![Native Commands rows with the reset icon](https://github.com/user-attachments/assets/12ca0572-8feb-40cb-baee-358b4a81992d)

**After**

![Native Commands rows without the reset icon](https://github.com/user-attachments/assets/5ad3ce71-113a-4af5-aa63-48b3d349b43e)

No empty `settings-row__control` wrapper is left behind; the segmented group sits flush at the row edge.

Validation, all from a clean worktree:

- `node scripts/run-vitest.mjs ui/src/components` — 133 files, 1906 tests passed
- `node scripts/run-vitest.mjs ui/src/pages` — 371 files, 5911 tests passed
- Chromium E2E defaults lanes — 4 files, 10 tests passed
- `node scripts/check-changed.mjs` — format, typecheck, lint, guards, dead-export and i18n checks green
- Autoreview (Codex, `high`) on the full diff — clean, no accepted findings

LOC delta (judged, production vs test):

| | Added | Deleted | Net |
| --- | ---: | ---: | ---: |
| Production (18 files) | 215 | 498 | **−283** |
| Tests (15 files) | 104 | 581 | **−477** |
| Total | 319 | 1079 | **−760** |

### Deleted symbols

Helpers `renderRestoreDefaultButton`, `renderSettingsDefaultState`, `resetMemoryEngine`, type `ConfigRemover`; controller methods `AgentMemoryPanel.resetEnabledOverride` / `.removeEnabledOverride`; props `ConfigProps.resetLocale`, `ConfigProps.resetChatSendShortcut`, `SecurityViewProps.onBrowserEnabledReset`, `SecurityViewProps.onToolProfileReset`, `MemoryViewProps.onEngineReset`; the `actions` slots on `renderSettingsToggleRow` and `renderSettingsSelectRow`; i18n key `configForm.resetToDefault`. `renderCollectionDefaultPresentation` becomes `renderCollectionDefaultDescription` and returns only the description.

The shared `.btn--icon` styles and the `refresh` icon stay — other controls use both.
