### PR TITLE
test(exec): cover companion response loss without local replay

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/ExecHostSocketCancellationTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecHostSocketCancellationTests.swift
@@ -1,5 +1,6 @@
 import CryptoKit
 import Darwin
+import Dispatch
 import Foundation
 import OpenClawKit
 import Testing
@@ -14,9 +15,8 @@ struct ExecHostSocketCancellationTests {
 
     @Test
     func `normal request half-close still receives native execution result`() async throws {
-        try await self.withServer { server, root in
-            let client = try self.connect(root)
-            defer { close(client) }
+        try await self.withServer { server, root, fixture in
+            let client = fixture.client
             try self.send(command: ["/usr/bin/printf", "half-close-ok"], root: root, client: client)
             #expect(shutdown(client, SHUT_WR) == 0)
             let response = try await Task.detached {
@@ -33,47 +33,81 @@ struct ExecHostSocketCancellationTests {
     func `closed caller or server stops native command and its descendant`(
         _ cancellation: Cancellation, withTimeout: Bool) async throws
     {
-        try await self.withServer { server, root in
-            var client = try self.connect(root)
-            defer { if client >= 0 { close(client) } }
-            let parentFile = root.appendingPathComponent("parent.pid")
-            let childFile = root.appendingPathComponent("child.pid")
-            let sentinel = root.appendingPathComponent("sentinel")
-            // Publish the PID atomically: file creation alone can race the printf payload.
-            let command = [
-                "/bin/sh", "-c",
-                """
-                printf '%s' "$$" > '\(parentFile.path)'
-                /bin/sh -c '
-                  trap "" TERM
-                  printf "%s" "$$" > "\(childFile.path).tmp"
-                  /bin/mv "\(childFile.path).tmp" "\(childFile.path)"
-                  /bin/sleep 2
-                  /usr/bin/touch "\(sentinel.path)"
-                ' &
-                wait
-                """,
-            ]
-            try self.send(command: command, root: root, client: client, timeoutMs: withTimeout ? 10000 : nil)
-            #expect(shutdown(client, SHUT_WR) == 0)
-            try #require(await self.waitUntil { FileManager.default.fileExists(atPath: childFile.path) })
-            let parent = try self.readPID(parentFile)
-            let child = try self.readPID(childFile)
-            defer {
-                if kill(parent, 0) == 0 { kill(-parent, SIGKILL) }
-                if kill(child, 0) == 0 { kill(child, SIGKILL) }
-            }
+        // Exercise a valid startup slower than the old one-second assumption through the real callback.
+        let admissionDelay: Duration = cancellation == .serverStop && withTimeout ? .milliseconds(1200) : .zero
+        try await self.withServer(admissionDelay: admissionDelay) { server, root, fixture in
+            let sentAt = ContinuousClock.now
+            try self.send(
+                command: fixture.command, root: root, client: fixture.client, timeoutMs: withTimeout ? 10000 : nil)
+            #expect(shutdown(fixture.client, SHUT_WR) == 0)
+            let (parent, child) = try await fixture.waitForStart()
+            try #require(kill(parent, 0) == 0 && kill(child, 0) == 0, "\(fixture.diagnostics)")
+            try #require(fixture.response == nil, "\(fixture.diagnostics)")
+            #expect(ContinuousClock.now - sentAt >= admissionDelay)
+            #expect(!FileManager.default.fileExists(atPath: fixture.file("sentinel").path))
+            print("native ready after \(ContinuousClock.now - sentAt): \(fixture.diagnostics)")
+            // Start the sentinel clock and cancel without yielding; startup consumes none of its delay.
+            try Data("release".utf8).write(to: fixture.file("release"))
             switch cancellation {
             case .disconnect:
-                close(client)
-                client = -1
+                fixture.closeClient()
             case .serverStop:
                 server.stop()
             }
-            #expect(await self.waitUntil { self.isGone(parent) && self.isGone(child) })
+            #expect(await self.waitUntil {
+                TestProcessSupport.processIsGone(parent) && TestProcessSupport.processIsGone(child)
+            }, "\(fixture.diagnostics)")
             try await Task.sleep(for: .milliseconds(2200))
-            #expect(!FileManager.default.fileExists(atPath: sentinel.path))
+            #expect(!FileManager.default.fileExists(atPath: fixture.file("sentinel").path))
         }
+    }
+
+    @Test(arguments: [false, true])
+    func `native failure wakes readiness without a PID marker`(missingExecutable: Bool) async throws {
+        try await self.withServer { _, root, fixture in
+            let command = missingExecutable ? [root.appendingPathComponent("missing-executable").path] : []
+            try self.send(command: command, root: root, client: fixture.client)
+            do {
+                _ = try await fixture.waitForStart()
+                Issue.record("Early native failure must not count as readiness")
+            } catch let CancellationFixture.StartupFailure.terminal(diagnostics) {
+                #expect(diagnostics.contains("child.pid=<missing>"))
+                if missingExecutable {
+                    #expect(fixture.response?.payload?.success == false)
+                    #expect(fixture.response?.payload?.exitCode == 127)
+                } else {
+                    #expect(fixture.response?.error?.message == "command required")
+                }
+                print("native early failure: \(diagnostics)")
+            }
+        }
+    }
+
+    @Test
+    func `readiness watchdog drains an unpublished child before removing its root`() async throws {
+        var fixtureRoot: URL?
+        var witnessed: [pid_t] = []
+        do {
+            try await self.withServer { _, root, fixture in
+                fixtureRoot = root
+                try Data().write(to: fixture.file("hold-publication"))
+                try self.send(command: fixture.command, root: root, client: fixture.client, timeoutMs: nil)
+                try await fixture.wait(for: fixture.partialPublication)
+                witnessed = try ["parent.pid", "child.pid.tmp"].map {
+                    try #require(TestProcessSupport.pollPID(in: fixture.file($0)))
+                }
+                try #require(witnessed.allSatisfy { kill($0, 0) == 0 })
+                _ = try await fixture.waitForStart(watchdog: .milliseconds(50))
+                Issue.record("Unpublished child must not count as readiness")
+            }
+        } catch let CancellationFixture.StartupFailure.watchdog(diagnostics) {
+            #expect(diagnostics.contains("child.pid=<missing>"))
+            #expect(try diagnostics.contains("child.pid.tmp=\(#require(witnessed.last))"))
+            print("native publication watchdog: \(diagnostics)")
+        }
+        #expect(witnessed.count == 2)
+        #expect(witnessed.allSatisfy { TestProcessSupport.processIsGone($0) })
+        #expect(try !FileManager.default.fileExists(atPath: #require(fixtureRoot).path))
     }
 
     @Test
@@ -94,29 +128,37 @@ struct ExecHostSocketCancellationTests {
     }
 
     private func withServer(
-        _ body: (ExecApprovalsSocketServer, URL) async throws -> Void) async throws
+        admissionDelay: Duration = .zero,
+        _ body: (ExecApprovalsSocketServer, URL, CancellationFixture) async throws -> Void) async throws
     {
         let root = try self.makeRoot()
         defer { try? FileManager.default.removeItem(at: root) }
         try self.seed(root)
+        let fixture = try CancellationFixture(root: root)
         let server = ExecApprovalsSocketServer(
             socketPath: root.appendingPathComponent("exec.sock").path,
             token: "test-token",
             onPrompt: { _ in .deny },
             onExec: { request in
-                await ExecApprovalsStore.withStateDirectory(root) {
+                if admissionDelay > .zero { try? await Task.sleep(for: admissionDelay) }
+                let response = await ExecApprovalsStore.withStateDirectory(root) {
                     await ExecHostExecutor.handle(request)
                 }
+                fixture.record(response)
+                return response
             },
             onUnexpectedStop: { _ in })
         do {
             try #require(await server.start())
-            try await body(server, root)
+            try await fixture.wait(for: fixture.registered)
+            fixture.client = try self.connect(root)
+            try await body(server, root, fixture)
         } catch {
-            await server.stop().value
+            print("native fixture failure: \(fixture.diagnostics)")
+            await fixture.cleanUp(server: server)
             throw error
         }
-        await server.stop().value
+        await fixture.cleanUp(server: server)
     }
 
     private func makeRoot() throws -> URL {
@@ -188,15 +230,6 @@ struct ExecHostSocketCancellationTests {
         return try JSONDecoder().decode(ExecHostResponse.self, from: data)
     }
 
-    private func readPID(_ url: URL) throws -> pid_t {
-        try #require(pid_t(String(contentsOf: url, encoding: .utf8)))
-    }
-
-    private func isGone(_ pid: pid_t) -> Bool {
-        errno = 0
-        return kill(pid, 0) == -1 && errno == ESRCH
-    }
-
     private func waitUntil(_ condition: () -> Bool) async -> Bool {
         let deadline = ContinuousClock.now + .seconds(1)
         while ContinuousClock.now < deadline {
@@ -204,5 +237,170 @@ struct ExecHostSocketCancellationTests {
             try? await Task.sleep(for: .milliseconds(10))
         }
         return condition()
+    }
+}
+
+/// This observer owns only fixture markers and descriptors, never native execution.
+private final class CancellationFixture: @unchecked Sendable {
+    enum StartupFailure: Error {
+        case watchdog(String)
+        case terminal(String)
+    }
+
+    let root: URL
+    let registered = AsyncTestGate()
+    let partialPublication = AsyncTestGate()
+    private let startup = AsyncTestGate()
+    private let closed = AsyncTestGate()
+    private let source: DispatchSourceFileSystemObject
+    private let lock = NSLock()
+    private var terminalResponse: ExecHostResponse?
+    private var cleaningUp = false
+    var client: Int32 = -1
+
+    init(root: URL) throws {
+        self.root = root
+        let descriptor = open(root.path, O_EVTONLY | O_CLOEXEC)
+        guard descriptor >= 0 else { throw POSIXError(.EIO) }
+        self.source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: descriptor, eventMask: [.write, .rename], queue: .global(qos: .userInitiated))
+        self.source.setRegistrationHandler { [weak self] in
+            // Registration plus this snapshot closes the pre-registration lost-wakeup window.
+            self?.inspectMarkers()
+            self?.registered.open()
+        }
+        self.source.setEventHandler { [weak self] in self?.inspectMarkers() }
+        self.source.setCancelHandler { [closed] in
+            // Dispatch retains the descriptor until this handler; earlier close races fd reuse.
+            close(descriptor)
+            closed.open()
+        }
+        self.source.resume()
+    }
+
+    func file(_ name: String) -> URL {
+        self.root.appendingPathComponent(name)
+    }
+
+    var response: ExecHostResponse? {
+        self.lock.withLock { self.terminalResponse }
+    }
+
+    func record(_ response: ExecHostResponse) {
+        self.lock.withLock { self.terminalResponse = response }
+        self.startup.open()
+    }
+
+    private func pid(_ name: String) -> pid_t? {
+        guard let pid = TestProcessSupport.pollPID(in: self.file(name)), pid > 1 else { return nil }
+        return pid
+    }
+
+    private func inspectMarkers() {
+        if self.pid("parent.pid") != nil, self.pid("child.pid.tmp") != nil { self.partialPublication.open() }
+        if self.pid("parent.pid") != nil, self.pid("child.pid") != nil { self.startup.open() }
+        if self.lock.withLock({ self.cleaningUp }) { self.killWitnessedProcesses() }
+    }
+
+    var diagnostics: String {
+        let markers = ["parent.pid", "child.pid", "child.pid.tmp", "release", "abort", "sentinel"]
+            .map { name -> String in
+                let value = (try? String(contentsOf: self.file(name), encoding: .utf8)) ?? "<missing>"
+                return "\(name)=\(value)"
+            }.joined(separator: ", ")
+        let response = self.response.flatMap { try? JSONEncoder().encode($0) }
+            .flatMap { String(data: $0, encoding: .utf8) } ?? "<pending>"
+        return "\(self.root.lastPathComponent): \(markers); response=\(response)"
+    }
+
+    func wait(for gate: AsyncTestGate, watchdog: Duration = .seconds(10)) async throws {
+        // This bounds a handshake, not cancellation latency. Both race losers join on cancellation.
+        let signalled = try await withThrowingTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                await gate.wait()
+                return true
+            }
+            group.addTask {
+                try await Task.sleep(for: watchdog)
+                return false
+            }
+            defer { group.cancelAll() }
+            return try await group.next() ?? false
+        }
+        try Task.checkCancellation()
+        guard signalled else { throw StartupFailure.watchdog(self.diagnostics) }
+    }
+
+    func waitForStart(watchdog: Duration = .seconds(10)) async throws -> (parent: pid_t, child: pid_t) {
+        try await self.wait(for: self.startup, watchdog: watchdog)
+        guard self.response == nil, let parent = self.pid("parent.pid"), let child = self.pid("child.pid") else {
+            throw StartupFailure.terminal(self.diagnostics)
+        }
+        return (parent, child)
+    }
+
+    var command: [String] {
+        [
+            "/bin/sh", "-c",
+            """
+            printf '%s' "$$" > '\(self.file("parent.pid").path)'
+            [ -f '\(self.file("abort").path)' ] && exit 0
+            /bin/sh -c '
+              trap "" TERM
+              printf "%s" "$$" > "\(self.file("child.pid.tmp").path)"
+              if [ -f "\(self.file("hold-publication").path)" ]; then
+                : > "\(self.file("publication-held").path)"
+                while [ ! -f "\(self.file("abort").path)" ]; do /bin/sleep 0.01; done
+                exit 0
+              fi
+              /bin/mv "\(self.file("child.pid.tmp").path)" "\(self.file("child.pid").path)"
+              while [ ! -f "\(self.file("release").path)" ]; do
+                [ -f "\(self.file("abort").path)" ] && exit 0
+                /bin/sleep 0.01
+              done
+              [ -f "\(self.file("abort").path)" ] && exit 0
+              /bin/sleep 2
+              /usr/bin/touch "\(self.file("sentinel").path)"
+            ' &
+            wait
+            """,
+        ]
+    }
+
+    func closeClient() {
+        if self.client >= 0 {
+            close(self.client)
+            self.client = -1
+        }
+    }
+
+    private func killWitnessedProcesses() {
+        guard let parent = self.pid("parent.pid") else { return }
+        // Only marker-witnessed members of this fixture's native session may be killed.
+        for name in ["child.pid", "child.pid.tmp", "parent.pid"] {
+            if let pid = self.pid(name), getpgid(pid) == parent {
+                _ = kill(-parent, SIGKILL)
+                return
+            }
+        }
+    }
+
+    func cleanUp(server: ExecApprovalsSocketServer) async {
+        try? Data("abort".utf8).write(to: self.file("abort"))
+        self.closeClient()
+        let stopped = server.stop()
+        self.lock.withLock { self.cleaningUp = true }
+        // Keep watching late publications while cancellation drains. Kill before awaiting stop.
+        self.inspectMarkers()
+        await stopped.value
+        self.source.cancel()
+        // Cleanup also joins descriptor closure if the calling test task was cancelled.
+        await Task.detached { [closed] in await closed.wait() }.value
+        for name in ["parent.pid", "child.pid", "child.pid.tmp"] {
+            if let pid = self.pid(name) {
+                #expect(await TestProcessSupport.waitUntilGone(pid, timeout: .seconds(1)), "\(self.diagnostics)")
+            }
+        }
+        #expect(!FileManager.default.fileExists(atPath: self.file("exec.sock").path))
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/ExecHostTransportProofTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecHostTransportProofTests.swift
@@ -3,13 +3,12 @@ import OpenClawKit
 import Testing
 @testable import OpenClaw
 
-/// Opt-in, process-isolated proof. The socket accept task is detached, so a task-local
-/// store override alone cannot isolate the executor from the operator's approvals.
+/// Opt-in, process-isolated proof of real native execution after caller response loss.
 @Suite(.serialized)
 @MainActor
 struct ExecHostTransportProofTests {
     @Test(.enabled(if: ProcessInfo.processInfo.environment["OPENCLAW_EXEC_HOST_NATIVE_PROOF"] == "1"))
-    func `native execution survives lost response`() async throws {
+    func `native execution completes after caller response loss`() async throws {
         let environment = ProcessInfo.processInfo.environment
         let statePath = try #require(environment["OPENCLAW_STATE_DIR"])
         let state = URL(fileURLWithPath: statePath).resolvingSymlinksInPath()
@@ -34,19 +33,21 @@ struct ExecHostTransportProofTests {
                 agents: ["denied": ExecApprovalsAgent(security: .deny, ask: .off)]),
             stateDirectoryURL: state)
 
-        let server = ExecApprovalsPromptServer(
-            resolveSocketCredentials: { (socketPath, token) },
+        let server = ExecApprovalsSocketServer(
+            socketPath: socketPath,
+            token: token,
             onPrompt: { _ in
                 Issue.record("This proof must not request interactive approval")
                 return .deny
-            })
-        server.start()
+            },
+            onExec: { request in
+                await ExecApprovalsStore.withStateDirectory(state) {
+                    await ExecHostExecutor.handle(request)
+                }
+            },
+            onUnexpectedStop: { _ in Issue.record("Native proof socket stopped unexpectedly") })
         do {
-            let deadline = ContinuousClock.now + .seconds(5)
-            while !FileManager.default.fileExists(atPath: socketPath), ContinuousClock.now < deadline {
-                try await Task.sleep(for: .milliseconds(10))
-            }
-            try #require(FileManager.default.fileExists(atPath: socketPath))
+            try #require(await server.start())
             var repo = URL(fileURLWithPath: #filePath)
             for _ in 0..<5 {
                 repo.deleteLastPathComponent()
@@ -79,10 +80,10 @@ struct ExecHostTransportProofTests {
             #expect(log.contains("native START -> response dropped -> client null -> native COMPLETE"))
             #expect(log.contains("native success and policy denial verified"))
         } catch {
-            if let pending = server.stop() { await pending.value }
+            await server.stop().value
             throw error
         }
-        if let pending = server.stop() { await pending.value }
+        await server.stop().value
         #expect(!FileManager.default.fileExists(atPath: socketPath))
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/ExecHostTransportProofTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecHostTransportProofTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import OpenClawKit
+import Testing
+@testable import OpenClaw
+
+/// Opt-in, process-isolated proof. The socket accept task is detached, so a task-local
+/// store override alone cannot isolate the executor from the operator's approvals.
+@Suite(.serialized)
+@MainActor
+struct ExecHostTransportProofTests {
+    @Test(.enabled(if: ProcessInfo.processInfo.environment["OPENCLAW_EXEC_HOST_NATIVE_PROOF"] == "1"))
+    func `native execution survives lost response`() async throws {
+        let environment = ProcessInfo.processInfo.environment
+        let statePath = try #require(environment["OPENCLAW_STATE_DIR"])
+        let state = URL(fileURLWithPath: statePath).resolvingSymlinksInPath()
+        let root = state.deletingLastPathComponent()
+        try #require(root.deletingLastPathComponent().path == URL(fileURLWithPath: "/tmp").resolvingSymlinksInPath()
+            .path)
+        try #require(root.lastPathComponent.hasPrefix("oc-exec-native-"))
+        for key in ["HOME", "CFFIXED_USER_HOME", "OPENCLAW_HOME"] {
+            let value = try #require(environment[key])
+            try #require(URL(fileURLWithPath: value).resolvingSymlinksInPath().path == root
+                .appendingPathComponent("home").path)
+        }
+        try #require(ExecApprovalsStore.databaseURL().resolvingSymlinksInPath().path ==
+            ExecApprovalsSQLiteStore.databaseURL(stateDirectoryURL: state).resolvingSymlinksInPath().path)
+        let socketPath = root.appendingPathComponent("native.sock").path
+        let token = "exec-host-native-proof-token"
+        try ExecApprovalsSQLiteStore.write(
+            ExecApprovalsFile(
+                version: 1,
+                socket: ExecApprovalsSocketConfig(path: socketPath, token: token),
+                defaults: ExecApprovalsDefaults(security: .full, ask: .off, autoAllowSkills: false),
+                agents: ["denied": ExecApprovalsAgent(security: .deny, ask: .off)]),
+            stateDirectoryURL: state)
+
+        let server = ExecApprovalsPromptServer(
+            resolveSocketCredentials: { (socketPath, token) },
+            onPrompt: { _ in
+                Issue.record("This proof must not request interactive approval")
+                return .deny
+            })
+        server.start()
+        do {
+            let deadline = ContinuousClock.now + .seconds(5)
+            while !FileManager.default.fileExists(atPath: socketPath), ContinuousClock.now < deadline {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+            try #require(FileManager.default.fileExists(atPath: socketPath))
+            var repo = URL(fileURLWithPath: #filePath)
+            for _ in 0..<5 {
+                repo.deleteLastPathComponent()
+            }
+            let child = Process()
+            child.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            child.arguments = [
+                "node", "--import", "tsx",
+                repo.appendingPathComponent("src/infra/exec-host.native.test-support.ts").path,
+                root.path, socketPath,
+            ]
+            child.currentDirectoryURL = repo
+            child.environment = environment
+            let outputURL = root.appendingPathComponent("native-client.log")
+            FileManager.default.createFile(atPath: outputURL.path, contents: nil)
+            let output = try FileHandle(forWritingTo: outputURL)
+            defer { try? output.close() }
+            child.standardOutput = output
+            child.standardError = output
+            let exited = Task { @MainActor in
+                try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Int32, any Error>) in
+                    child.terminationHandler = { process in continuation.resume(returning: process.terminationStatus) }
+                    do { try child.run() } catch { continuation.resume(throwing: error) }
+                }
+            }
+            let exitCode = try await exited.value
+            try output.close()
+            let log = try String(contentsOf: outputURL, encoding: .utf8)
+            #expect(exitCode == 0, "TypeScript boundary proof failed: \(log)")
+            #expect(log.contains("native START -> response dropped -> client null -> native COMPLETE"))
+            #expect(log.contains("native success and policy denial verified"))
+        } catch {
+            if let pending = server.stop() { await pending.value }
+            throw error
+        }
+        if let pending = server.stop() { await pending.value }
+        #expect(!FileManager.default.fileExists(atPath: socketPath))
+    }
+}

--- a/config/knip.all-exports.config.ts
+++ b/config/knip.all-exports.config.ts
@@ -39,6 +39,8 @@ const ROOT_TEST_ENTRY_GLOBS = [
   "src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts}!",
   "scripts/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts}!",
   "test/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts}!",
+  // ExecHostTransportProofTests.swift launches this isolated native client by path.
+  "src/infra/exec-host.native.test-support.ts!",
   // Vitest loads these by configuration or module alias rather than imports.
   "test/setup*.ts!",
   "test/non-isolated-runner.ts!",

--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -1007,7 +1007,7 @@ Notes:
 - Client instance metadata, signed device identity, and pairing auth use separate state records; see [Headless identity state](#headless-identity-state).
 - Exec approvals are enforced locally via
   `~/.openclaw/state/openclaw.sqlite#exec_approvals_config` (see [Exec approvals](/tools/exec-approvals)).
-- On macOS, the headless node host executes `system.run` locally by default. Set `OPENCLAW_NODE_EXEC_HOST=app` to route `system.run` through the companion app exec host; add `OPENCLAW_NODE_EXEC_FALLBACK=0` to require the app host and fail closed if it is unavailable.
+- On macOS, the headless node host executes `system.run` locally by default. Set `OPENCLAW_NODE_EXEC_HOST=app` to require the companion app exec host, with no local fallback. `OPENCLAW_NODE_EXEC_FALLBACK` does not change current routing.
 - Add `--tls` / `--tls-fingerprint` when the Gateway WS uses TLS.
 
 ## Mac node mode

--- a/src/infra/exec-host.native.test-support.ts
+++ b/src/infra/exec-host.native.test-support.ts
@@ -10,6 +10,8 @@ import { requestExecHostViaSocket, type ExecHostRequest } from "./exec-host.js";
 
 const [rootArgument, nativeSocket] = process.argv.slice(2);
 assert.equal(process.env.OPENCLAW_EXEC_HOST_NATIVE_PROOF, "1");
+assert.ok(rootArgument, "Native proof requires an isolated root argument");
+assert.ok(nativeSocket, "Native proof requires a socket path argument");
 const root = await fs.realpath(rootArgument);
 assert.equal(path.dirname(root), await fs.realpath("/tmp"));
 assert.ok(path.basename(root).startsWith("oc-exec-native-"));
@@ -92,7 +94,7 @@ console.log("native success and policy denial verified");
 const proxySocket = path.join(root, "proxy.sock");
 const sockets: net.Socket[] = [];
 const closes: Promise<void>[] = [];
-const forwarded = createDeferred();
+const forwarded = createDeferred<net.Socket>();
 const nativeResponse = createDeferred<string>();
 const errors: Error[] = [];
 const order: string[] = [];
@@ -113,7 +115,7 @@ const proxy = net.createServer({ allowHalfOpen: true }, (client) => {
   client.pipe(upstream);
   client.once("end", () => {
     order.push("request-half-closed");
-    forwarded.resolve();
+    forwarded.resolve(client);
   });
   let response = "";
   upstream.setEncoding("utf8");
@@ -132,10 +134,10 @@ try {
     request,
     timeoutMs: 10_000,
   });
-  await withDeadline(forwarded.promise, 3_000);
+  const caller = await withDeadline(forwarded.promise, 3_000);
   await waitForStart();
   order.push("native-started");
-  sockets[0].end();
+  caller.end();
   order.push("response-dropped");
   assert.equal(await outcome, null);
   order.push("client-null");

--- a/src/infra/exec-host.native.test-support.ts
+++ b/src/infra/exec-host.native.test-support.ts
@@ -1,0 +1,179 @@
+// Launched only by ExecHostTransportProofTests in a fresh, process-isolated state root.
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import fs from "node:fs/promises";
+import net from "node:net";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { requestExecHostViaSocket, type ExecHostRequest } from "./exec-host.js";
+
+const [rootArgument, nativeSocket] = process.argv.slice(2);
+assert.equal(process.env.OPENCLAW_EXEC_HOST_NATIVE_PROOF, "1");
+const root = await fs.realpath(rootArgument);
+assert.equal(path.dirname(root), await fs.realpath("/tmp"));
+assert.ok(path.basename(root).startsWith("oc-exec-native-"));
+assert.equal(await fs.realpath(process.env.OPENCLAW_STATE_DIR!), path.join(root, "state"));
+const token = "exec-host-native-proof-token";
+const marker = path.join(root, "native-markers");
+const release = path.join(root, "release-child");
+await fs.rm(marker, { force: true });
+await fs.rm(release, { force: true });
+const request: ExecHostRequest = {
+  command: [
+    "/bin/sh",
+    "-c",
+    'printf "START\\n" >> "$1"; while [ ! -f "$2" ]; do /bin/sleep 0.01; done; printf "COMPLETE\\n" >> "$1"',
+    "exec-host-native-proof",
+    marker,
+    release,
+  ],
+  cwd: root,
+  timeoutMs: 5_000,
+  needsScreenRecording: false,
+};
+
+async function waitForStart() {
+  const deadline = Date.now() + 3_000;
+  while (Date.now() < deadline) {
+    try {
+      if ((await fs.readFile(marker, "utf8")) === "START\n") {
+        return;
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    }
+    await delay(10);
+  }
+  throw new Error("Native child did not write START before the response fault");
+}
+
+async function withDeadline<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error("Native proof deadline exceeded")), ms);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+const success = await requestExecHostViaSocket({
+  socketPath: nativeSocket,
+  token,
+  request: { command: ["/bin/echo", "native-success"], cwd: root, timeoutMs: 5_000 },
+  timeoutMs: 10_000,
+});
+assert.equal(success?.ok, true);
+if (success?.ok) {
+  assert.equal(success.payload.success, true);
+  assert.equal(success.payload.exitCode, 0);
+  assert.equal(success.payload.stdout, "native-success\n");
+}
+const denied = await requestExecHostViaSocket({
+  socketPath: nativeSocket,
+  token,
+  request: { ...request, agentId: "denied" },
+  timeoutMs: 10_000,
+});
+assert.equal(denied?.ok, false);
+if (denied && !denied.ok) {
+  assert.equal(denied.error.reason, "security=deny");
+}
+await assert.rejects(fs.stat(marker), { code: "ENOENT" });
+console.log("native success and policy denial verified");
+
+const proxySocket = path.join(root, "proxy.sock");
+const sockets: net.Socket[] = [];
+const closes: Promise<void>[] = [];
+const forwarded = Promise.withResolvers<void>();
+const nativeResponse = Promise.withResolvers<string>();
+const errors: Error[] = [];
+const order: string[] = [];
+function track(socket: net.Socket) {
+  sockets.push(socket);
+  closes.push(
+    new Promise<void>((resolve) => {
+      socket.once("close", resolve);
+    }),
+  );
+  socket.on("error", (error) => errors.push(error));
+}
+const proxy = net.createServer({ allowHalfOpen: true }, (client) => {
+  track(client);
+  const upstream = net.createConnection({ path: nativeSocket, allowHalfOpen: true });
+  track(upstream);
+  // pipe forwards the signed bytes unchanged and forwards the request's write EOF.
+  client.pipe(upstream);
+  client.once("end", () => {
+    order.push("request-half-closed");
+    forwarded.resolve();
+  });
+  let response = "";
+  upstream.setEncoding("utf8");
+  upstream.on("data", (chunk: string) => {
+    response += chunk;
+  });
+  upstream.once("end", () => nativeResponse.resolve(response));
+});
+try {
+  const listening = once(proxy, "listening");
+  proxy.listen(proxySocket);
+  await listening;
+  const outcome = requestExecHostViaSocket({
+    socketPath: proxySocket,
+    token,
+    request,
+    timeoutMs: 10_000,
+  });
+  await withDeadline(forwarded.promise, 3_000);
+  await waitForStart();
+  order.push("native-started");
+  sockets[0].end();
+  order.push("response-dropped");
+  assert.equal(await outcome, null);
+  order.push("client-null");
+  assert.equal(await fs.readFile(marker, "utf8"), "START\n");
+  await fs.writeFile(release, "finish\n");
+  // Keep draining the native connection: its terminal reply proves the executor
+  // awaited ShellExecutor and reaped the child, even though the caller lost it.
+  const response = JSON.parse(await withDeadline(nativeResponse.promise, 8_000)) as {
+    ok: boolean;
+    payload: { success: boolean; exitCode: number };
+  };
+  assert.equal(response.ok, true);
+  assert.equal(response.payload.success, true);
+  assert.equal(response.payload.exitCode, 0);
+  assert.equal(await fs.readFile(marker, "utf8"), "START\nCOMPLETE\n");
+  order.push("native-completed");
+  assert.deepEqual(order, [
+    "request-half-closed",
+    "native-started",
+    "response-dropped",
+    "client-null",
+    "native-completed",
+  ]);
+  assert.deepEqual(errors, []);
+  console.log("native START -> response dropped -> client null -> native COMPLETE");
+} finally {
+  await fs.writeFile(release, "finish\n");
+  try {
+    // Drain even after an assertion fails so the real native child is reaped.
+    if (sockets.length > 0) {
+      await withDeadline(nativeResponse.promise, 8_000);
+    }
+  } finally {
+    for (const socket of sockets) {
+      socket.destroy();
+    }
+    await Promise.all(closes);
+    await new Promise<void>((resolve, reject) => {
+      proxy.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}

--- a/src/infra/exec-host.native.test-support.ts
+++ b/src/infra/exec-host.native.test-support.ts
@@ -5,6 +5,7 @@ import fs from "node:fs/promises";
 import net from "node:net";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { requestExecHostViaSocket, type ExecHostRequest } from "./exec-host.js";
 
 const [rootArgument, nativeSocket] = process.argv.slice(2);
@@ -91,8 +92,8 @@ console.log("native success and policy denial verified");
 const proxySocket = path.join(root, "proxy.sock");
 const sockets: net.Socket[] = [];
 const closes: Promise<void>[] = [];
-const forwarded = Promise.withResolvers<void>();
-const nativeResponse = Promise.withResolvers<string>();
+const forwarded = createDeferred();
+const nativeResponse = createDeferred<string>();
 const errors: Error[] = [];
 const order: string[] = [];
 function track(socket: net.Socket) {

--- a/src/infra/exec-host.socket.test.ts
+++ b/src/infra/exec-host.socket.test.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert/strict";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import crypto from "node:crypto";
 import { once } from "node:events";
@@ -5,6 +6,7 @@ import fs from "node:fs/promises";
 import net from "node:net";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { withTestDir } from "../test-helpers/temp-dir.js";
 import { requestExecHostViaSocket, type ExecHostRequest } from "./exec-host.js";
 
@@ -171,11 +173,13 @@ describe.runIf(process.platform !== "win32")("exec host real UDS boundary", () =
           markers,
         ];
         const request = { command, cwd: dir, timeoutMs: 5_000, needsScreenRecording: false };
-        const release = Promise.withResolvers<void>();
+        const release = createDeferred();
         const childCloses: Promise<unknown>[] = [];
         onRequest(async (socket, received, id) => {
           expect(received).toEqual(request);
-          const child = spawn(received.command[0], received.command.slice(1), {
+          const [executable, ...args] = received.command;
+          assert.ok(executable, "Exec peer received an empty command");
+          const child = spawn(executable, args, {
             cwd: received.cwd!,
             env: { HOME: dir, PATH: "/usr/bin:/bin" },
             stdio: "pipe",

--- a/src/infra/exec-host.socket.test.ts
+++ b/src/infra/exec-host.socket.test.ts
@@ -1,0 +1,234 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import crypto from "node:crypto";
+import { once } from "node:events";
+import fs from "node:fs/promises";
+import net from "node:net";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { withTestDir } from "../test-helpers/temp-dir.js";
+import { requestExecHostViaSocket, type ExecHostRequest } from "./exec-host.js";
+
+const token = "exec-host-socket-test-token";
+const success = {
+  ok: true,
+  payload: { exitCode: 0, timedOut: false, success: true, stdout: "done\n", stderr: "" },
+};
+const denial = {
+  ok: false,
+  error: { code: "UNAVAILABLE", message: "Denied by host policy", reason: "security=deny" },
+};
+
+// This peer proves the TypeScript transport, not Swift policy or native execution.
+async function withExecPeer(
+  run: (peer: {
+    dir: string;
+    socketPath: string;
+    markers: string;
+    order: string[];
+    children: { child: ChildProcessWithoutNullStreams; closed: Promise<unknown> }[];
+    onRequest: (
+      handler: (socket: net.Socket, request: ExecHostRequest, id: string) => Promise<void>,
+    ) => void;
+  }) => Promise<void>,
+) {
+  await withTestDir({ prefix: "oc-exec-", parentDir: "/tmp" }, async (dir) => {
+    const socketPath = path.join(dir, "host.sock");
+    const markers = path.join(dir, "markers");
+    const order: string[] = [];
+    const sockets: net.Socket[] = [];
+    const closes: Promise<unknown>[] = [];
+    const children: { child: ChildProcessWithoutNullStreams; closed: Promise<unknown> }[] = [];
+    const tasks: Promise<void>[] = [];
+    const failures: unknown[] = [];
+    let handler: (socket: net.Socket, request: ExecHostRequest, id: string) => Promise<void>;
+    const server = net.createServer({ allowHalfOpen: true }, (socket) => {
+      sockets.push(socket);
+      closes.push(
+        new Promise<void>((resolve) => {
+          socket.once("close", resolve);
+        }),
+      );
+      socket.on("error", (error) => failures.push(error));
+      let wire = "";
+      socket.setEncoding("utf8");
+      socket.on("data", (chunk: string) => {
+        wire += chunk;
+      });
+      const task = (async () => {
+        await once(socket, "end");
+        order.push("request-half-closed");
+        expect(wire.endsWith("\n")).toBe(true);
+        expect(wire.trim().split("\n")).toHaveLength(1);
+        const envelope = JSON.parse(wire) as {
+          type: string;
+          id: string;
+          nonce: string;
+          ts: number;
+          hmac: string;
+          requestJson: string;
+        };
+        expect(envelope.type).toBe("exec");
+        expect(envelope.id).toMatch(/^[0-9a-f-]{36}$/);
+        expect(envelope.nonce).toMatch(/^[0-9a-f]{32}$/);
+        expect(Math.abs(Date.now() - envelope.ts)).toBeLessThan(10_000);
+        const hmac = crypto
+          .createHmac("sha256", token)
+          .update(`${envelope.nonce}:${envelope.ts}:${envelope.requestJson}`)
+          .digest("hex");
+        expect(envelope.hmac).toBe(hmac);
+        await handler(socket, JSON.parse(envelope.requestJson) as ExecHostRequest, envelope.id);
+      })().catch((error: unknown) => {
+        failures.push(error);
+        socket.destroy();
+      });
+      tasks.push(task);
+    });
+    try {
+      const listening = once(server, "listening");
+      server.listen(socketPath);
+      await listening;
+      await run({
+        dir,
+        socketPath,
+        markers,
+        order,
+        children,
+        onRequest: (next) => {
+          handler = next;
+        },
+      });
+      await Promise.all(tasks);
+      expect(failures).toEqual([]);
+    } finally {
+      for (const { child } of children) {
+        if (child.exitCode === null && child.signalCode === null) {
+          child.kill("SIGKILL");
+        }
+      }
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+      await Promise.all(children.map(({ closed }) => closed));
+      await Promise.all(closes);
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+}
+
+describe.runIf(process.platform !== "win32")("exec host real UDS boundary", () => {
+  it("characterizes a missing socket before any request can execute", async () => {
+    await withTestDir({ prefix: "oc-exec-", parentDir: "/tmp" }, async (dir) => {
+      const marker = path.join(dir, "never-started");
+      await expect(
+        requestExecHostViaSocket({
+          socketPath: path.join(dir, "missing.sock"),
+          token,
+          request: { command: ["/usr/bin/touch", marker] },
+          timeoutMs: 1_000,
+        }),
+      ).resolves.toBeNull();
+      await expect(fs.readdir(dir)).resolves.toEqual([]);
+    });
+  });
+
+  it.each([success, denial])(
+    "receives a complete response after request half-close: $ok",
+    async (response) => {
+      await withExecPeer(async ({ socketPath, onRequest, order }) => {
+        const request = {
+          command: ["/bin/echo", "done"],
+          cwd: "/tmp",
+          needsScreenRecording: false,
+        };
+        onRequest(async (socket, received, id) => {
+          expect(received).toEqual(request);
+          // Respond on a later event-loop turn: write EOF is not response EOF.
+          await new Promise<void>((resolve) => {
+            setImmediate(resolve);
+          });
+          order.push("response");
+          socket.end(`${JSON.stringify({ type: "exec-res", id, ...response })}\n`);
+        });
+        await expect(
+          requestExecHostViaSocket({ socketPath, token, request, timeoutMs: 1_000 }),
+        ).resolves.toEqual(response);
+        expect(order).toEqual(["request-half-closed", "response"]);
+      });
+    },
+  );
+
+  it.each(["close", "malformed matching response", "timeout"] as const)(
+    "characterizes null after a signed request starts a child and then %s",
+    async (fault) => {
+      await withExecPeer(async ({ dir, socketPath, markers, order, children, onRequest }) => {
+        const command = [
+          "/bin/sh",
+          "-c",
+          'printf "START\\n" >> "$1"; printf "START\\n"; read -r release; printf "COMPLETE\\n" >> "$1"',
+          "exec-host-proof",
+          markers,
+        ];
+        const request = { command, cwd: dir, timeoutMs: 5_000, needsScreenRecording: false };
+        const release = Promise.withResolvers<void>();
+        const childCloses: Promise<unknown>[] = [];
+        onRequest(async (socket, received, id) => {
+          expect(received).toEqual(request);
+          const child = spawn(received.command[0], received.command.slice(1), {
+            cwd: received.cwd!,
+            env: { HOME: dir, PATH: "/usr/bin:/bin" },
+            stdio: "pipe",
+          });
+          const closed = once(child, "close");
+          children.push({ child, closed });
+          childCloses.push(closed);
+          try {
+            const [started] = await Promise.race([
+              once(child.stdout, "data"),
+              closed.then(() => {
+                throw new Error("Child exited before START");
+              }),
+            ]);
+            expect(String(started)).toBe("START\n");
+            expect(await fs.readFile(markers, "utf8")).toBe("START\n");
+            order.push("child-started");
+            if (fault === "close") {
+              order.push("response-dropped");
+              socket.end();
+            } else if (fault === "malformed matching response") {
+              order.push("malformed-response");
+              socket.write(`${JSON.stringify({ type: "exec-res", id, ok: true })}\n`);
+            }
+            await release.promise;
+          } finally {
+            child.stdin.end("finish\n");
+            expect(await closed).toEqual([0, null]);
+          }
+          order.push("child-completed");
+        });
+        try {
+          // Characterization only: null currently conflates no delivery with lost outcome.
+          await expect(
+            requestExecHostViaSocket({ socketPath, token, request, timeoutMs: 1_000 }),
+          ).resolves.toBeNull();
+          order.push("client-null");
+          expect(await fs.readFile(markers, "utf8")).toBe("START\n");
+        } finally {
+          release.resolve();
+          await Promise.all(childCloses);
+        }
+        expect(await fs.readFile(markers, "utf8")).toBe("START\nCOMPLETE\n");
+        expect(order).toEqual([
+          "request-half-closed",
+          "child-started",
+          ...(fault === "timeout"
+            ? []
+            : [fault === "close" ? "response-dropped" : "malformed-response"]),
+          "client-null",
+          "child-completed",
+        ]);
+      });
+    },
+  );
+});

--- a/src/infra/jsonl-socket.test.ts
+++ b/src/infra/jsonl-socket.test.ts
@@ -7,20 +7,39 @@ import { createDeferred } from "../../test/helpers/promise.js";
 import { withTestDir } from "../test-helpers/temp-dir.js";
 import { requestJsonlSocket } from "./jsonl-socket.js";
 
-async function listenOnSocket(server: net.Server, socketPath: string): Promise<boolean> {
-  try {
+async function withSocketServer(
+  server: net.Server,
+  run: (socketPath: string) => Promise<void>,
+): Promise<void> {
+  // macOS sockaddr_un cannot hold the test runner's nested temporary path.
+  await withTestDir({ prefix: "oc-jsonl-", parentDir: "/tmp" }, async (dir) => {
+    const socketPath = path.join(dir, "socket.sock");
+    const sockets: net.Socket[] = [];
+    const closed: Promise<void>[] = [];
+    server.on("connection", (socket) => {
+      sockets.push(socket);
+      closed.push(
+        new Promise<void>((resolve) => {
+          socket.once("close", resolve);
+        }),
+      );
+    });
     await new Promise<void>((resolve, reject) => {
       server.once("error", reject);
       server.listen(socketPath, resolve);
     });
-    return true;
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code === "EPERM" || code === "EACCES") {
-      return false;
+    try {
+      await run(socketPath);
+    } finally {
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+      await Promise.all(closed);
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
     }
-    throw err;
-  }
+  });
 }
 
 function acceptDoneValue(msg: unknown): number | null | undefined {
@@ -30,85 +49,56 @@ function acceptDoneValue(msg: unknown): number | null | undefined {
 
 describe.runIf(process.platform !== "win32")("requestJsonlSocket", () => {
   it("ignores malformed and non-accepted lines until one is accepted", async () => {
-    await withTestDir({ prefix: "oc-js-" }, async (dir) => {
-      const socketPath = path.join(dir, "socket.sock");
-      const server = net.createServer((socket) => {
-        socket.on("data", () => {
-          socket.write("{bad json}\n");
-          socket.write('{"type":"ignore"}\n');
-          socket.write('{"type":"done","value":42}\n');
-        });
+    const server = net.createServer((socket) => {
+      socket.on("data", () => {
+        socket.write("{bad json}\n");
+        socket.write('{"type":"ignore"}\n');
+        socket.write('{"type":"done","value":42}\n');
       });
-      const listening = await listenOnSocket(server, socketPath);
-      if (!listening) {
-        return;
-      }
-
-      try {
-        await expect(
-          requestJsonlSocket({
-            socketPath,
-            requestLine: '{"hello":"world"}',
-            timeoutMs: 500,
-            accept: acceptDoneValue,
-          }),
-        ).resolves.toBe(42);
-      } finally {
-        server.close();
-      }
+    });
+    await withSocketServer(server, async (socketPath) => {
+      await expect(
+        requestJsonlSocket({
+          socketPath,
+          requestLine: '{"hello":"world"}',
+          timeoutMs: 500,
+          accept: acceptDoneValue,
+        }),
+      ).resolves.toBe(42);
     });
   });
 
   it("does not connect or send an already-aborted request", async () => {
-    await withTestDir({ prefix: "oc-js-" }, async (dir) => {
-      const socketPath = path.join(dir, "socket.sock");
-      const connected = vi.fn();
-      const server = net.createServer((socket) => {
-        connected();
-        socket.resume();
-        socket.on("end", () => socket.end('{"type":"done","value":7}\n'));
-      });
-      const listening = await listenOnSocket(server, socketPath);
-      if (!listening) {
-        return;
-      }
-
-      try {
-        await expect(
-          requestJsonlSocket({
-            socketPath,
-            requestLine: '{"hello":"world"}',
-            timeoutMs: 500,
-            accept: acceptDoneValue,
-            signal: AbortSignal.abort(),
-          }),
-        ).resolves.toBeNull();
-        expect(connected).not.toHaveBeenCalled();
-      } finally {
-        await new Promise<void>((resolve) => {
-          server.close(() => resolve());
-        });
-      }
+    const connected = vi.fn();
+    const server = net.createServer((socket) => {
+      connected();
+      socket.resume();
+      socket.on("end", () => socket.end('{"type":"done","value":7}\n'));
+    });
+    await withSocketServer(server, async (socketPath) => {
+      await expect(
+        requestJsonlSocket({
+          socketPath,
+          requestLine: '{"hello":"world"}',
+          timeoutMs: 500,
+          accept: acceptDoneValue,
+          signal: AbortSignal.abort(),
+        }),
+      ).resolves.toBeNull();
+      expect(connected).not.toHaveBeenCalled();
     });
   });
 
   it.each([false, true])("half-closes the request and settles after abort=%s", async (abort) => {
-    await withTestDir({ prefix: "oc-js-" }, async (dir) => {
-      const socketPath = path.join(dir, "socket.sock");
-      const received = createDeferred<{ socket: net.Socket; buffer: string }>();
-      const peers = new Set<net.Socket>();
-      const server = net.createServer({ allowHalfOpen: true }, (socket) => {
-        peers.add(socket);
-        let buffer = "";
-        socket.on("data", (chunk) => {
-          buffer += chunk.toString("utf8");
-        });
-        socket.on("end", () => received.resolve({ socket, buffer }));
+    const received = createDeferred<{ socket: net.Socket; buffer: string }>();
+    const server = net.createServer({ allowHalfOpen: true }, (socket) => {
+      let buffer = "";
+      socket.on("data", (chunk) => {
+        buffer += chunk.toString("utf8");
       });
-      const listening = await listenOnSocket(server, socketPath);
-      if (!listening) {
-        return;
-      }
+      socket.on("end", () => received.resolve({ socket, buffer }));
+    });
+    await withSocketServer(server, async (socketPath) => {
       const controller = new AbortController();
       const completed = vi.fn();
       const pending = requestJsonlSocket({
@@ -141,41 +131,19 @@ describe.runIf(process.platform !== "win32")("requestJsonlSocket", () => {
         expect(getEventListeners(controller.signal, "abort")).toEqual([]);
       } finally {
         controller.abort();
-        for (const socket of peers) {
-          socket.destroy();
-        }
         await pending;
-        await new Promise<void>((resolve) => {
-          server.close(() => resolve());
-        });
       }
     });
   });
 
   it("returns null on timeout and on socket errors", async () => {
-    await withTestDir({ prefix: "oc-js-" }, async (dir) => {
-      const socketPath = path.join(dir, "socket.sock");
-      const server = net.createServer(() => {
-        // Intentionally never reply.
-      });
-      const listening = await listenOnSocket(server, socketPath);
-      if (!listening) {
-        return;
-      }
-
-      try {
-        await expect(
-          requestJsonlSocket({
-            socketPath,
-            requestLine: "{}",
-            timeoutMs: 50,
-            accept: () => undefined,
-          }),
-        ).resolves.toBeNull();
-      } finally {
-        server.close();
-      }
-
+    let closedSocketPath = "";
+    const server = net.createServer({ allowHalfOpen: true }, (socket) => {
+      socket.resume();
+      // Intentionally keep the response side open after the request half-close.
+    });
+    await withSocketServer(server, async (socketPath) => {
+      closedSocketPath = socketPath;
       await expect(
         requestJsonlSocket({
           socketPath,
@@ -185,35 +153,33 @@ describe.runIf(process.platform !== "win32")("requestJsonlSocket", () => {
         }),
       ).resolves.toBeNull();
     });
+    await expect(
+      requestJsonlSocket({
+        socketPath: closedSocketPath,
+        requestLine: "{}",
+        timeoutMs: 50,
+        accept: () => undefined,
+      }),
+    ).resolves.toBeNull();
   });
 
   it("returns null when the socket closes without an accepted response", async () => {
-    await withTestDir({ prefix: "oc-js-" }, async (dir) => {
-      const socketPath = path.join(dir, "socket.sock");
-      const server = net.createServer((socket) => {
-        socket.on("data", () => {
-          socket.destroy();
-        });
+    const server = net.createServer((socket) => {
+      socket.on("data", () => {
+        socket.destroy();
       });
-      const listening = await listenOnSocket(server, socketPath);
-      if (!listening) {
-        return;
-      }
+    });
+    await withSocketServer(server, async (socketPath) => {
+      const startMs = Date.now();
+      const result = await requestJsonlSocket({
+        socketPath,
+        requestLine: "{}",
+        timeoutMs: 250,
+        accept: () => undefined,
+      });
 
-      try {
-        const startMs = Date.now();
-        const result = await requestJsonlSocket({
-          socketPath,
-          requestLine: "{}",
-          timeoutMs: 250,
-          accept: () => undefined,
-        });
-
-        expect(result).toBeNull();
-        expect(Date.now() - startMs).toBeLessThan(100);
-      } finally {
-        server.close();
-      }
+      expect(result).toBeNull();
+      expect(Date.now() - startMs).toBeLessThan(100);
     });
   });
 });

--- a/src/infra/jsonl-socket.test.ts
+++ b/src/infra/jsonl-socket.test.ts
@@ -1,7 +1,9 @@
 // Covers JSONL socket request framing and response handling.
 import { getEventListeners } from "node:events";
+import { syncBuiltinESMExports } from "node:module";
 import net from "node:net";
 import path from "node:path";
+import timers from "node:timers";
 import { describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { withTestDir } from "../test-helpers/temp-dir.js";
@@ -170,16 +172,27 @@ describe.runIf(process.platform !== "win32")("requestJsonlSocket", () => {
       });
     });
     await withSocketServer(server, async (socketPath) => {
-      const startMs = Date.now();
-      const result = await requestJsonlSocket({
-        socketPath,
-        requestLine: "{}",
-        timeoutMs: 250,
-        accept: () => undefined,
-      });
-
-      expect(result).toBeNull();
-      expect(Date.now() - startMs).toBeLessThan(100);
+      // Leave the deadline frozen: only the real socket close can settle this request.
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      const schedule = vi.spyOn(timers, "setTimeout").mockImplementation(setTimeout);
+      const clear = vi.spyOn(timers, "clearTimeout").mockImplementation(clearTimeout);
+      syncBuiltinESMExports();
+      try {
+        const pending = requestJsonlSocket({
+          socketPath,
+          requestLine: "{}",
+          timeoutMs: 250,
+          accept: () => undefined,
+        });
+        expect(vi.getTimerCount()).toBe(1);
+        await expect(pending).resolves.toBeNull();
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        schedule.mockRestore();
+        clear.mockRestore();
+        vi.useRealTimers();
+        syncBuiltinESMExports();
+      }
     });
   });
 });

--- a/src/node-host/invoke-system-run.socket.test.ts
+++ b/src/node-host/invoke-system-run.socket.test.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import crypto from "node:crypto";
 import { once } from "node:events";
@@ -65,7 +66,9 @@ describe.runIf(process.platform !== "win32")("enforced exec host transport bound
               );
               const request = JSON.parse(envelope.requestJson) as ExecHostRequest;
               expect(request.command).toEqual(command);
-              const child = spawn(request.command[0], request.command.slice(1), {
+              const [executable, ...args] = request.command;
+              assert.ok(executable, "Exec peer received an empty command");
+              const child = spawn(executable, args, {
                 cwd: dir,
                 env: { HOME: dir, PATH: "/usr/bin:/bin" },
                 stdio: "ignore",

--- a/src/node-host/invoke-system-run.socket.test.ts
+++ b/src/node-host/invoke-system-run.socket.test.ts
@@ -1,0 +1,161 @@
+import { spawn } from "node:child_process";
+import crypto from "node:crypto";
+import { once } from "node:events";
+import fs from "node:fs/promises";
+import net from "node:net";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { testing as approvalsTesting } from "../infra/exec-approvals-store.test-support.js";
+import { saveExecApprovals } from "../infra/exec-approvals.js";
+import { requestExecHostViaSocket, type ExecHostRequest } from "../infra/exec-host.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { withTestDir } from "../test-helpers/temp-dir.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { handleSystemRunInvoke } from "./invoke-system-run.js";
+
+describe.runIf(process.platform !== "win32")("enforced exec host transport boundary", () => {
+  it("does not replay locally when a completed execution loses its socket response", async () => {
+    await withTestDir({ prefix: "oc-run-", parentDir: "/tmp" }, async (dir) => {
+      await withEnvAsync(
+        { OPENCLAW_HOME: dir, OPENCLAW_STATE_DIR: path.join(dir, "state") },
+        async () => {
+          closeOpenClawStateDatabaseForTest();
+          approvalsTesting.reset();
+          const socketPath = path.join(dir, "host.sock");
+          const token = "enforced-exec-host-test-token";
+          const marker = path.join(dir, "executions");
+          const command = [
+            "/bin/sh",
+            "-c",
+            'printf "START\\nCOMPLETE\\n" >> "$1"',
+            "exec-proof",
+            marker,
+          ];
+          const order: string[] = [];
+          const sockets: net.Socket[] = [];
+          const closes: Promise<void>[] = [];
+          const failures: unknown[] = [];
+          let handler = Promise.resolve();
+          const server = net.createServer({ allowHalfOpen: true }, (socket) => {
+            sockets.push(socket);
+            closes.push(
+              new Promise<void>((resolve) => {
+                socket.once("close", resolve);
+              }),
+            );
+            socket.on("error", (error) => failures.push(error));
+            let wire = "";
+            socket.setEncoding("utf8");
+            socket.on("data", (chunk: string) => {
+              wire += chunk;
+            });
+            handler = (async () => {
+              await once(socket, "end");
+              const envelope = JSON.parse(wire) as {
+                nonce: string;
+                ts: number;
+                hmac: string;
+                requestJson: string;
+              };
+              expect(envelope.hmac).toBe(
+                crypto
+                  .createHmac("sha256", token)
+                  .update(`${envelope.nonce}:${envelope.ts}:${envelope.requestJson}`)
+                  .digest("hex"),
+              );
+              const request = JSON.parse(envelope.requestJson) as ExecHostRequest;
+              expect(request.command).toEqual(command);
+              const child = spawn(request.command[0], request.command.slice(1), {
+                cwd: dir,
+                env: { HOME: dir, PATH: "/usr/bin:/bin" },
+                stdio: "ignore",
+              });
+              expect(await once(child, "close")).toEqual([0, null]);
+              expect(await fs.readFile(marker, "utf8")).toBe("START\nCOMPLETE\n");
+              order.push("child-completed");
+              socket.end();
+              order.push("response-dropped");
+            })().catch((error: unknown) => {
+              failures.push(error);
+              socket.destroy();
+            });
+          });
+          try {
+            const listening = once(server, "listening");
+            server.listen(socketPath);
+            await listening;
+            saveExecApprovals({
+              version: 1,
+              socket: { path: socketPath, token },
+              defaults: { security: "full", ask: "off", autoAllowSkills: false },
+              agents: {},
+            });
+            const runCommand = vi.fn<Parameters<typeof handleSystemRunInvoke>[0]["runCommand"]>();
+            const sendInvokeResult = vi.fn();
+            const sendNodeEvent = vi.fn();
+            const sendExecFinishedEvent = vi.fn();
+            await handleSystemRunInvoke({
+              client: {
+                request: async () => {
+                  throw new Error("Unexpected Gateway request");
+                },
+              },
+              params: { command, cwd: dir, sessionKey: "agent:main:proof" },
+              skillBins: { current: async () => [] },
+              execHostEnforced: true,
+              // Production defaults this preference to true; enforcement still forbids replay.
+              execHostFallbackAllowed: true,
+              preferMacAppExecHost: true,
+              resolveExecSecurity: () => "full",
+              resolveExecAsk: () => "off",
+              isCmdExeInvocation: () => false,
+              sanitizeEnv: () => undefined,
+              getRuntimeConfig: () => ({}),
+              runCommand,
+              runViaMacAppExecHost: async ({ request }) => {
+                const response = await requestExecHostViaSocket({
+                  socketPath,
+                  token,
+                  request,
+                  timeoutMs: 2_000,
+                });
+                expect(response).toBeNull();
+                order.push("client-null");
+                return response;
+              },
+              sendInvokeResult,
+              sendNodeEvent,
+              sendExecFinishedEvent,
+              buildExecEventPayload: (payload) => payload,
+            });
+            await handler;
+            expect(failures).toEqual([]);
+            expect(order).toEqual(["child-completed", "response-dropped", "client-null"]);
+            expect(runCommand).not.toHaveBeenCalled();
+            expect(sendExecFinishedEvent).not.toHaveBeenCalled();
+            expect(sendInvokeResult).toHaveBeenCalledExactlyOnceWith(
+              expect.objectContaining({ ok: false }),
+            );
+            expect(sendNodeEvent).toHaveBeenCalledExactlyOnceWith(
+              expect.anything(),
+              "exec.denied",
+              expect.objectContaining({ host: "node" }),
+            );
+            expect(await fs.readFile(marker, "utf8")).toBe("START\nCOMPLETE\n");
+          } finally {
+            for (const socket of sockets) {
+              socket.destroy();
+            }
+            await handler;
+            await Promise.all(closes);
+            await new Promise<void>((resolve, reject) => {
+              server.close((error) => (error ? reject(error) : resolve()));
+            });
+            approvalsTesting.reset();
+            closeOpenClawStateDatabaseForTest();
+          }
+        },
+      );
+    });
+  });
+});


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/131650 (landed native caller-cancellation repair; response-outcome certainty remains separate).
Related: https://github.com/openclaw/openclaw/pull/111731 (separate proposal to replace nullable transport failures with exceptions; this PR adds boundary evidence without changing that API).

<details>
<summary>Additional instructions</summary>

Maintainer-requested tests and documentation work on a maintainer-editable branch in this repository. AI-assisted implementation and review.

</details>

## What Problem This Solves

The companion exec transport returns the same `null` when connection fails before sending and when a command has started but its response is lost. Existing socket and mocked adapter tests did not demonstrate this ambiguity across a witnessed execution, making it easy to mistake a missing result for proof that nothing ran. The nodes documentation also incorrectly said `OPENCLAW_NODE_EXEC_FALLBACK=0` was needed to require the app after selecting `OPENCLAW_NODE_EXEC_HOST=app`.

This PR adds boundary characterization and non-replay coverage. It does **not** claim to repair the nullable production outcome contract or demonstrate default-path duplicate execution.

## Why This Change Was Made

Use the real TypeScript Unix-socket requester, a real child for transport fault cases, and the real Swift socket server/executor for native proof. The native proxy preserves the authenticated request bytes and normal write half-close, witnesses `START`, drops the caller-facing response, and retains the native response reader until the command completes. This distinguishes lost-response ambiguity from native-disconnect cancellation.

Current production sets app preference only when app execution is enforced. The enforced-host boundary test asserts that losing a response after execution never falls through to local execution. Historical optional fallback shipped before `e4d67137db710178416a539756cac8086de3d26e` changed headless macOS routing in stable `v2026.2.22`; the docs now describe the reachable behavior without changing or removing any environment handling.

Validation also exposed an invalid one-second startup assumption in the recently landed native cancellation fixture, before cancellation was injected. Its test-only owner now registers PID-marker observation before sending, wakes on early real executor results, and holds the sentinel sequence until actual readiness. The existing one-second combined process-extinction assertion and 2.2-second sentinel observation remain intact. Failure cleanup drains the owned request, process group and observer before deleting the fixture root.

No production seam, runtime behavior, protocol, operator/runtime configuration, schema, dependency, approval policy or fallback mode is changed. HMAC/UID/TTL, native approval/cwd/policy checks and normal JSONL half-close remain owned by the existing production code. The removed paths are duplicated test PID/ESRCH readers, startup polling, and a fragile wall-clock EOF assertion—not runtime behavior.

## User Impact

Runtime behavior is unchanged. Maintainers gain direct evidence that absent companion output is not evidence of non-execution, plus regression coverage for enforced non-replay and normal response framing. Operators following [the nodes guide](https://docs.openclaw.ai/nodes) no longer receive the redundant fallback instruction.

The phase-bearing production result remains a separate follow-up: distinguish definite non-submission, submitted outcome unknown and caller cancellation, without treating cancellation as acknowledged rollback. This PR intentionally does not enable optional fallback or close that remaining outcome-reporting work.

## Evidence

Rebased onto `9a7de4daa8102a77c1b4280a2bf4a4d55ec2177c`; native tests were rebuilt against the landed cancellation owners, not reused from an old executable. This is provider-free IPC proof, not a Gateway/Control UI cancellation or screenshot claim.

| Boundary | Observed result |
| --- | --- |
| Missing Unix socket | Client returns `null` without execution. |
| Real child starts, then response EOF, malformed matching reply or timeout | Client also returns `null`; START was witnessed before the injected loss and the child was subsequently reaped. |
| Actual Swift execution through a proxy | START → caller-facing response loss → TypeScript client `null` → release → COMPLETE; the successful native response was drained separately. |
| Enforced app routing after completed execution loses its response | Exactly one witnessed execution; zero local `runCommand` calls. |
| Native success / native policy denial controls | Successful response preserved; denial did not create an execution marker. |
| Cancellation fixture with valid delayed admission | A controlled 1.2-second delay failed all four old startup checks before cancellation. Repaired readiness was observed at 2.17 seconds, then the unchanged extinction/sentinel assertions passed. |
| Early native failure / incomplete PID publication | Real invalid-command and missing-executable outcomes woke readiness; watchdog teardown removed witnessed processes, descriptors, sockets and roots. |

- **101 focused TypeScript tests passed**, including the newly landed abort/half-close checks and existing execution-policy tests.
- **508 macOS TypeScript CI tests passed** across 14 files and seven shards.
- **48 native tests passed in the original six-suite order**, plus the one-test real native transport proof. The focused readiness suite passed five test functions / nine parameterized invocations. All 20 recorded fixture PIDs were independently checked as `ESRCH`, and fixture roots/sockets were removed.
- Full native test build, pinned SwiftLint **0.65.0**, SwiftFormat **0.62.1**, relevant source/schema guards, and diff/format checks passed. No dependency pins or global tools were changed.
- The full changed-check invocation passed core types, core lint and its guards, then stopped at a local SwiftLint version mismatch. The checksum-verified pinned tools were installed task-locally; all remaining canonical app-lint, macOS CI and native-schema steps passed. This is **not** a claim of one all-green whole-gate invocation.
- Fresh managed Codex **whole-PR P0 review** passed against the pinned base, covering all eight changed files, including the CI repair and supplied owner context. No actionable P0 findings; this is not an all-priority review. The reviewer did not run tests.
- The lead independently reran the original native six-suite selection: **48 tests passed**, then reran the native transport proof: **1 test passed**. All ten PIDs and seven cancellation-fixture roots from that independent run were checked absent afterward.

Focused TypeScript command:

```bash
node scripts/run-vitest.mjs src/infra/exec-host.socket.test.ts src/infra/jsonl-socket.test.ts src/infra/exec-host.test.ts src/node-host/invoke-system-run.socket.test.ts src/node-host/invoke-system-run.test.ts
```

macOS TypeScript lane:

```bash
pnpm test:macos:ci
```

Native build used `swift build --build-tests --package-path apps/macos --force-resolved-versions --jobs 4` with task-owned scratch/cache/config/security paths. Native runs used `swift test --skip-build --package-path apps/macos --force-resolved-versions --no-parallel` and those same paths, first with the original six-suite filter below and then `ExecHostTransportProofTests`:

```text
ExecHostSocketCancellationTests|ExecApprovalsSocketAuthTests|ExecApprovalsPromptServerTests|ExecHostRequestEvaluatorTests|ExecHostCwdTests|ShellExecutorTimeoutTests
```

Each native invocation used a fresh mode-0700 `oc-exec-native-*` temporary root and explicit isolated `HOME`, `CFFIXED_USER_HOME`, `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR` and `TMPDIR`; the opt-in transport test additionally used `OPENCLAW_EXEC_HOST_NATIVE_PROOF=1`. Only PATH was inherited. No app bundle was launched and no operator services, saved credentials or live state were accessed.

**Runtime production LOC: +0/-0. Tests/support: +1,025/-175 (net +850). Test tooling: +2/-0. Docs: +1/-1. Total: +1,028/-176 (net +852), eight files.** The native fixture growth supplies registered readiness, terminal-result observation and failure-safe cleanup without a production test seam; it does not introduce a general-purpose framework.

**Best-fix verdict:** appropriate owner-boundary proof for the explicitly requested test/docs scope. A synthetic peer alone would not prove native policy/execution; a longer startup sleep would not establish readiness; and changing the production outcome API in this PR would exceed the approved scope. The nullable production ambiguity and any optional-host contract remain separate work.

### CI repair and review disposition

The initial ready-for-review CI attachment skipped every job; one close/reopen attached [CI run 33194771553](https://github.com/openclaw/openclaw/actions/runs/33194771553), which found two concrete test-tooling failures. The native proof client now asserts its required root/socket arguments before filesystem work and carries the actual caller socket through its existing deferred rather than inferring identity from `sockets[0]`. The verified Swift-launched executable is registered in `ROOT_TEST_ENTRY_GLOBS` in `config/knip.all-exports.config.ts`; this is a Knip test-tooling entry, not an operator/runtime configuration option, ignore entry, baseline change, or gate suppression. No production/runtime file changed.

On the exact repaired bytes, `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo` passed; `node --import ./scripts/tsx.mjs scripts/check-deadcode-unused-files.mts` passed with production and full-tree unused-file counts both zero. The actual native transport proof passed again with the changed TypeScript client; the unchanged Swift test executable matched its built sources. Targeted oxfmt/oxlint and `git diff --check` passed. A fresh managed whole-PR P0 review included the committed patch plus this repair (59,518-byte bundle) and found no actionable P0 defects; the reviewer ran no tests.

The ClawSweeper stored-data warning is not applicable: these opt-in fixtures use existing JSONL payloads, owned temporary markers, and the existing SQLite schema in an isolated test root. There is no runtime storage/schema/migration change. Its remaining CI and maintainer-completion items remain gated on the new exact head and native prepare/merge workflow.

### Current landing checkpoint

Merged by `steipete` through the normal native workflow as [adf5c6738216725f4f5f69b8ecada33e9e8a9752](https://github.com/openclaw/openclaw/commit/adf5c6738216725f4f5f69b8ecada33e9e8a9752), from the unchanged approved head `0ca329062cff04fb025678a19f2e7cd95f816e5b`. [Exact-head CI run 33197712856](https://github.com/openclaw/openclaw/actions/runs/33197712856), native review validation, and mandatory Testbox-mode preparation passed; native merge verification accepted the exact head. No rebase, extra source changes, strict-drift override or admin bypass was used. The prior raw-index checksum stop was an extra worker check, not a content mismatch or required semantic guard; canonical journal recovery completed after verified absence-only reconstruction. The landed diff is exactly eight files, +1,028/-176, with zero production runtime changes. [Recovery/proof checkpoint](https://github.com/openclaw/openclaw/pull/131961#issuecomment-5455798697); [native merge completion](https://github.com/openclaw/openclaw/pull/131961#issuecomment-5456499095).
