### PR TITLE
fix(channels): preserve ingress retry facts after shutdown

### DIFF
--- a/src/channels/message/ingress-drain.ts
+++ b/src/channels/message/ingress-drain.ts
@@ -151,9 +151,13 @@ export function createChannelIngressDrain<
     // Retire before abort so replacements recover; Set.delete makes disposal repeat safe.
     // Claim-token fencing prevents this owner from settling a recovered claim.
     deregisterLiveIngressDrainInstance(ownerId);
-    const reason = toErrorObject(options.abortSignal?.reason, "ingress-drain-aborted");
+    const reason = disposed
+      ? new Error("ingress-drain-disposed")
+      : toErrorObject(options.abortSignal?.reason, "ingress-drain-aborted");
     for (const state of activeByClaim.values()) {
       if (state.phase === "dispatching" || state.phase === "deferred") {
+        // Retire stall detection without blocking a late terminal claim write.
+        clearStallTimer(state);
         state.abortController.abort(reason);
       }
     }
@@ -354,7 +358,8 @@ export function createChannelIngressDrain<
         }
       },
       onDeferredHeartbeat: () => {
-        if (state.phase === "deferred" && !state.guillotined && !state.superseded) {
+        // Abort also covers disposal; retired callbacks cannot restart the watchdog.
+        if (state.phase === "deferred" && !state.abortController.signal.aborted) {
           armStallWatchdog(state);
         }
       },
@@ -673,18 +678,10 @@ export function createChannelIngressDrain<
     dispose: () => {
       disposed = true;
       options.abortSignal?.removeEventListener("abort", abortActiveClaims);
-      deregisterLiveIngressDrainInstance(ownerId);
+      abortActiveClaims();
       // Snapshot: removeActive mutates activeByClaim during this sweep.
       const activeStates = Array.from(activeByClaim.values());
       for (const state of activeStates) {
-        clearStallTimer(state);
-        if (state.phase === "dispatching" || state.phase === "deferred") {
-          try {
-            state.abortController.abort(new Error("ingress-drain-disposed"));
-          } catch {
-            // ignore
-          }
-        }
         removeActive(state);
       }
     },

--- a/src/channels/message/ingress-drain.watchdog.test.ts
+++ b/src/channels/message/ingress-drain.watchdog.test.ts
@@ -1,3 +1,4 @@
+import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import type { ChannelIngressDispatchLifecycle } from "./ingress-drain-lifecycle.js";
@@ -8,12 +9,38 @@ import {
   withTempState,
 } from "./ingress-drain.test-helpers.js";
 
+async function deferNext(
+  queue: ReturnType<typeof createTestIngressQueue>,
+  abortSignal?: AbortSignal,
+  adoptionStallTimeoutMs = 1_000,
+) {
+  const lifecycles: ChannelIngressDispatchLifecycle[] = [];
+  const drain = createChannelIngressDrain({
+    queue,
+    abortSignal,
+    adoptionStallTimeoutMs,
+    dispatchClaimedEvent: async (_event, lifecycle) => {
+      lifecycles.push(lifecycle);
+      return { kind: "deferred" };
+    },
+  });
+  await drain.drainOnce();
+  await drain.waitForIdle();
+  const lifecycle = expectDefined(lifecycles[0], "deferred lifecycle");
+  return {
+    drain,
+    lifecycle,
+    heartbeat: expectDefined(lifecycle.onDeferredHeartbeat, "deferred heartbeat"),
+  };
+}
+
 describe("channel ingress drain watchdog", () => {
   beforeEach(() => {
     vi.useFakeTimers();
   });
 
   afterEach(() => {
+    vi.clearAllTimers();
     vi.useRealTimers();
     closeOpenClawStateDatabaseForTest();
   });
@@ -105,6 +132,114 @@ describe("channel ingress drain watchdog", () => {
         },
       ]);
       drain.dispose();
+    });
+  });
+
+  it.each([
+    { stop: "dispose", heartbeat: "none" },
+    { stop: "dispose", heartbeat: "late" },
+    { stop: "dispose", heartbeat: "reentrant" },
+    { stop: "abort", heartbeat: "none" },
+    { stop: "abort", heartbeat: "late" },
+    { stop: "abort", heartbeat: "reentrant" },
+  ])("preserves retry facts after $stop (heartbeat: $heartbeat)", async ({ stop, heartbeat }) => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue(stateDir);
+      await queue.enqueue("retired", { text: "deferred" }, { laneKey: "lane" });
+      const abort = new AbortController();
+      const owner = await deferNext(queue, abort.signal);
+      try {
+        const before = await queue.listClaims();
+        expect(before).toHaveLength(1);
+        if (heartbeat === "reentrant") {
+          owner.lifecycle.abortSignal.addEventListener("abort", owner.heartbeat, { once: true });
+        }
+        if (stop === "dispose") {
+          owner.drain.dispose();
+        } else {
+          abort.abort(new Error("monitor stopped"));
+        }
+        expect(owner.lifecycle.abortSignal.aborted).toBe(true);
+        const stoppedTimers = vi.getTimerCount();
+        if (heartbeat === "late") {
+          owner.heartbeat();
+        }
+        const lateTimers = vi.getTimerCount();
+        await vi.advanceTimersByTimeAsync(1_100);
+        expect(await queue.listClaims()).toEqual(before);
+        expect(await queue.listPending()).toEqual([]);
+        expect(await queue.listFailed?.()).toEqual([]);
+        expect(lateTimers).toBe(stoppedTimers);
+
+        // A real late adoption still commits; stopping only retires watchdog work.
+        await owner.lifecycle.onAdopted();
+        expect((await queue.enqueue("retired", { text: "duplicate" })).kind).toBe("completed");
+      } finally {
+        owner.drain.dispose();
+      }
+    });
+  });
+
+  it.each([
+    { terminal: "cancelled", attempts: 0, lastError: undefined },
+    { terminal: "abandoned", attempts: 1, lastError: "turn-abandoned" },
+    { terminal: "failed", attempts: 1, lastError: "provider failed" },
+  ])(
+    "records a late $terminal outcome after disposal",
+    async ({ terminal, attempts, lastError }) => {
+      await withTempState(async (stateDir) => {
+        const queue = createTestIngressQueue(stateDir);
+        await queue.enqueue("terminal", { text: "deferred" }, { laneKey: "lane" });
+        const owner = await deferNext(queue);
+        try {
+          owner.drain.dispose();
+          if (terminal === "cancelled") {
+            await expectDefined(owner.lifecycle.onCancelled, "cancel callback")();
+          } else if (terminal === "abandoned") {
+            await owner.lifecycle.onAbandoned();
+          } else {
+            await expectDefined(
+              owner.lifecycle.onFailed,
+              "failure callback",
+            )(new Error("provider failed"));
+          }
+          owner.heartbeat();
+          await vi.advanceTimersByTimeAsync(1_100);
+          expect(await queue.listClaims()).toEqual([]);
+          const pending = await queue.listPending();
+          expect(pending).toHaveLength(1);
+          expect(pending[0]?.attempts).toBe(attempts);
+          expect(pending[0]?.lastError).toBe(lastError);
+        } finally {
+          owner.drain.dispose();
+        }
+      });
+    },
+  );
+
+  it("keeps a successor claim fenced from retired callbacks", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createTestIngressQueue(stateDir);
+      await queue.enqueue("replacement", { text: "deferred" }, { laneKey: "lane" });
+      const old = await deferNext(queue);
+      const retired = await queue.listClaims();
+      old.drain.dispose();
+      const next = await deferNext(queue, undefined, 60_000);
+      try {
+        const before = await queue.listClaims();
+        expect(before).toHaveLength(1);
+        expect(before[0]?.claim.token).not.toBe(retired[0]?.claim.token);
+        old.heartbeat();
+        await vi.advanceTimersByTimeAsync(1_100);
+        expect(await queue.listClaims()).toEqual(before);
+        expect(await queue.listPending()).toEqual([]);
+        await expect(old.lifecycle.onAdopted()).rejects.toSatisfy(isIngressAdoptionLostError);
+        await next.lifecycle.onAdopted();
+        expect((await queue.enqueue("replacement", { text: "duplicate" })).kind).toBe("completed");
+      } finally {
+        old.drain.dispose();
+        next.drain.dispose();
+      }
     });
   });
 


### PR DESCRIPTION
Closes #131920

## What Problem This Solves

Resolves a problem where stopping a durable channel-ingress owner could leave or recreate an adoption timeout that consumes a retry attempt after shutdown. Upstream abort left an existing watchdog armed, and a retained deferred-heartbeat callback could create another watchdog after disposal.

## Why This Change Was Made

Use the existing handler abort signal as the authority for deferred liveness, and share pre-adoption retirement between upstream abort and disposal. That owner now clears the stall timer before notifying abort listeners. Disposal then removes active bookkeeping and claim refresh timers as before.

Terminal settlement remains separate: a real late adoption, cancellation, abandonment, or failure can still make its first claim-token-fenced write after shutdown. Replacement claims remain protected. This removes duplicated shutdown logic without new flags, configuration, schema changes, retry policy, or compatibility paths.

## User Impact

A stopped ingress owner no longer creates a synthetic handler timeout from stale liveness work. Active deferred waits still extend their watchdog, and silent live handlers still follow the existing retry policy. This protects retry accounting during shutdown/recovery; it is not a claim that ordinary channel messages were lost or that a stale owner could overwrite a replacement claim.

## Evidence

The exact regression table fails on baseline `dfe93b936eb06cc10e43a823df3689dc8e273475` in four cases, including upstream abort with no heartbeat. It separately exercises disposal/upstream abort with no heartbeat, a delayed heartbeat, and a synchronous heartbeat from an abort listener. Controls preserve late terminal settlement and replacement fencing.

A real-clock production-drain/SQLite probe reproduces the disposal and upstream-abort failures before the patch and passes all four cases after it. An isolated built Gateway before/after proof reproduced the shutdown defect on the baseline and passed all four candidate scenarios. The final rebased head was then rebuilt and passed those same four scenarios again on a fresh Linux worker.

Root cause and owner: `src/channels/message/ingress-drain.ts`. A callback checked deferred phase and two retirement reasons rather than the already authoritative abort signal. The shared abort path also omitted existing watchdog cleanup. The first terminal-write-after-stop behavior in `ingress-claim-writes.ts` is intentional and unchanged.

Production LOC: +8/-11 (net -3). Tests: +135/-0. Removed path: duplicate pre-adoption abort loop in disposal.

Provenance: the retained-heartbeat path was introduced in #127950 by code/PR author @edenfunf and merged by @obviyus on August 28, 2026; the older upstream-abort path is also repaired. No stable-release regression is asserted. Related #125385 concerns long-wait heartbeat support and is not closed by this focused repair.

Focused proof: 80/80 tests across the watchdog, drain, cancellation, supersede, monitor, and lane suites; 4/4 real-clock SQLite scenarios; Codex autoreview with no actionable findings. All planned format/lint/type/architecture stages have passing evidence. The initial changed-check wrapper stopped at a missing isolated-worktree UI dependency link; after wiring the existing matching install, the failed type stage and all remaining canonical stages passed, without source or dependency changes. The first wrapper run is not represented as exit zero.

## Final Gateway proof and maintainer judgment

The final source under test is `c36bf1974de8566e42e8e20d5a476ff8a0877bf1`. The [fresh isolated worker run](https://github.com/openclaw/openclaw/actions/runs/33200422938) used workflow tooling commit `d43520b04c2985cbfe284fb9392d24fdbc40ebfb`; that tooling identity is distinct from the tested source. Frozen install passed, the canonical build passed in 294.87 seconds, and the real Gateway proof passed in 18.24 seconds. Full content/blob/mode guards matched all 34,743 tracked files before install, before and after build, after proof, and at completion.

The actual Gateway channel stop/start flow, public SDK ingress monitor, production drain, and real SQLite queue showed:

| Scenario | Observed result |
| --- | --- |
| Live deferred heartbeat, then silence | Heartbeat extends liveness; silence still invokes normal retry policy. |
| Stop, then invoke a retained heartbeat | Claim remains unchanged at attempts=0; no new pending retry or timeout log. |
| Replace claim, then invoke stale lifecycle callbacks | Replacement claim and token remain unchanged. |
| Stop, then deliver the first legitimate cancellation | Terminal settlement succeeds without consuming a retry attempt. |

The earlier [Linux baseline/candidate run](https://github.com/openclaw/openclaw/actions/runs/33198781792) proved the opposite shutdown result on baseline `dfe93b936eb06cc10e43a823df3689dc8e273475`: a stale heartbeat created a pending retry and incremented attempts. The final run above repeats the candidate only, after a mechanical rebase; the two changed source/test files stayed byte-identical.

Compact redacted final verdict:

```json
{"head":"c36bf1974de8566e42e8e20d5a476ff8a0877bf1","verdict":"candidate-gateway-ingress-proof-passed","cases":4,"passed":4,"realGateway":true,"realSQLite":true,"watchdogMs":1000,"retiredAfter":{"claims":1,"pending":0,"attempts":0,"timeoutLogs":0},"sourceUnchanged":true,"gatewayStopped":true,"remainingOwnedNodeProcesses":[]}
```

Proof archive SHA-256: `2bf94682c5b4fe8744d85d3e408e5fc0d55ceba8d4ff6feaec354c34c132ee96` (1,184,097 bytes), retrieved and verified locally. Both owned workers are stopped. This is synthetic retained-callback fault injection with the existing private QA queue-provisioning seam and a one-second watchdog; no external channel transport, model call, ordinary shutdown-frequency, or message-loss claim is made. An earlier local candidate build failed from disk exhaustion before Gateway startup; its failed receipt is preserved and is not counted as proof.

This completes the production-boundary evidence and explicit proof-sufficiency judgment requested by the latest ClawSweeper review and its rank-up move. The drain's shared abort owner is the correct repair boundary: it retires watchdogs before abort listeners run, while preserving the independently token-fenced first terminal write. No review finding is deferred and no proof requirement is waived.

The rebase incorporates the already-landed actionlint repair #131982; no CI change is bundled here. [Workflow Sanity on the final head](https://github.com/openclaw/openclaw/actions/runs/33200047709) passed with ShellCheck enabled. Fresh Codex autoreview found no actionable issues. Exact-head [required CI](https://github.com/openclaw/openclaw/actions/runs/33200047669) passed on that same final head.

AI-assisted.
