### PR TITLE
refactor(sessions): simplify participant attribution flows

### DIFF
--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { Value } from "typebox/value";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import {
   configureExecutionDecisionWorkSink,
   type ExecutionDecisionWork,
@@ -13,6 +14,7 @@ import type { ChannelMessagingAdapter } from "../channels/plugins/types.public.j
 import type { OpenClawConfig } from "../config/config.js";
 import {
   appendTranscriptMessage,
+  listSessionParticipantsReadOnly,
   upsertSessionEntryCore,
 } from "../config/sessions/session-accessor.js";
 import { createSessionVisibilityChecker } from "../plugin-sdk/session-visibility.js";
@@ -23,6 +25,7 @@ import {
   resetGatewayWorkAdmission,
 } from "../process/gateway-work-admission.js";
 import { runWithGatewayRootWorkAdmissionForTest } from "../process/gateway-work-admission.test-helpers.js";
+import { disposeOpenClawAgentDatabaseByPath } from "../state/openclaw-agent-db.js";
 import { createTestRegistry } from "../test-utils/channel-plugins.js";
 
 const callGatewayMock = vi.fn();
@@ -60,6 +63,8 @@ import { createSessionsHistoryTool } from "./tools/sessions-history-tool.js";
 import { createSessionsListTool } from "./tools/sessions-list-tool.js";
 import { createSessionsSearchTool } from "./tools/sessions-search-tool.js";
 import { createSessionsSendTool } from "./tools/sessions-send-tool.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 const TEST_CONFIG = {
   session: {
@@ -434,11 +439,12 @@ describe("sessions tools", () => {
   });
 
   it("sessions_list forwards mailbox filters and includes messages", async () => {
+    const storePath = path.join(tempDirs.make("openclaw-sessions-list-"), "sessions.json");
     callGatewayMock.mockImplementation(async (opts: unknown) => {
       const request = opts as { method?: string };
       if (request.method === "sessions.list") {
         return {
-          path: "/tmp/sessions.json",
+          path: storePath,
           sessions: [
             {
               key: "agent:main:main",
@@ -1324,6 +1330,79 @@ describe("sessions tools", () => {
       clearDecisionSink();
     }
   });
+
+  it.each([
+    { timeoutSeconds: 0, admitted: true },
+    { timeoutSeconds: 1, admitted: true },
+    { timeoutSeconds: 0, admitted: false },
+    { timeoutSeconds: 1, admitted: false },
+  ])(
+    "records exactly one cross-agent contribution at the original prompt time only after admission (timeoutSeconds: $timeoutSeconds, admitted: $admitted)",
+    async ({ timeoutSeconds, admitted }) => {
+      const storePath = path.join(
+        tempDirs.make("openclaw-session-send-participant-"),
+        "agents",
+        "research",
+        "agent",
+        "openclaw-agent.sqlite",
+      );
+      const scope = { agentId: "research", sessionKey: "agent:research:main", storePath };
+      const sessionId = "participant-target";
+      const promptedAt = 1_000;
+      const clock = vi.spyOn(Date, "now").mockReturnValue(promptedAt);
+      try {
+        await upsertSessionEntryCore(scope, { sessionId, updatedAt: 1 });
+        callGatewayMock.mockImplementation(async (opts: unknown) => {
+          const request = opts as GatewayCall;
+          if (request.method === "sessions.resolve") {
+            return { key: scope.sessionKey, agentId: scope.agentId };
+          }
+          if (request.method === "agent") {
+            clock.mockReturnValue(promptedAt + 100);
+            if (!admitted) {
+              throw new Error("admission rejected");
+            }
+            return { runId: "participant-run", status: "accepted" };
+          }
+          if (request.method === "agent.wait") {
+            return { status: "ok" };
+          }
+          return { messages: [] };
+        });
+        const tool = createSessionsSendTool({
+          agentSessionKey: "agent:main:main",
+          expectedTargetSessionId: sessionId,
+          config: { ...TEST_CONFIG, session: { ...TEST_CONFIG.session, store: storePath } },
+          callGateway: callGatewayMock,
+        });
+        const result = await tool.execute("participant-send", {
+          sessionKey: scope.sessionKey,
+          message: "Review this input",
+          timeoutSeconds,
+        });
+        expect(result.details).toMatchObject(
+          admitted
+            ? { status: timeoutSeconds === 0 ? "accepted" : "no_reply", runId: "participant-run" }
+            : { status: "error", error: "admission rejected" },
+        );
+        expect(listSessionParticipantsReadOnly(scope).get(scope.sessionKey) ?? []).toEqual(
+          admitted
+            ? [
+                {
+                  identity: { type: "agent", id: "main" },
+                  contributionCount: 1,
+                  firstPromptedAt: promptedAt,
+                  lastPromptedAt: promptedAt,
+                },
+              ]
+            : [],
+        );
+      } finally {
+        clock.mockRestore();
+        disposeOpenClawAgentDatabaseByPath(storePath);
+      }
+    },
+  );
 
   it("sessions_send returns pending agent error diagnostics on timeout", async () => {
     const calls: Array<{ method?: string; params?: unknown }> = [];

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -103,25 +103,6 @@ const SessionsSendToolSchema = Type.Object({
 
 const log = createSubsystemLogger("agents/sessions-send");
 
-function recordSessionsSendParticipant(params: {
-  cfg: OpenClawConfig;
-  requesterAgentId: string;
-  sessionKey: string;
-  targetAgentId: string;
-  promptedAt: number;
-}): void {
-  recordSessionParticipantBestEffort({
-    identity: { type: "agent", id: params.requesterAgentId },
-    promptedAt: params.promptedAt,
-    agentId: params.targetAgentId,
-    sessionKey: params.sessionKey,
-    storePath: resolveSessionStorePathCore(params.cfg.session?.store, {
-      agentId: params.targetAgentId,
-    }),
-    onError: (error) => log.warn("failed to record session participant", { error }),
-  });
-}
-
 const SessionsSendDeliverySchema = Type.Object(
   {
     status: Type.Union([Type.Literal("pending"), Type.Literal("skipped")]),
@@ -1139,38 +1120,44 @@ export function createSessionsSendTool(opts?: {
             });
           };
 
+          const start = await startAgentRun({
+            callGateway: gatewayCall,
+            runId,
+            sendParams,
+            sessionKey: displayKey,
+            deliveryTimeoutMs: announceTimeoutMs,
+            ...(timeoutSeconds === 0
+              ? {
+                  allowActiveRunQueueDelivery: true,
+                  // An exact-incarnation grant authorizes only this target. Never
+                  // reroute a worker-owned send to a durable Cron parent outside
+                  // the scoped lifecycle admission or replace its stable key.
+                  allowActiveRunQueueFallback: !expectedSessionId,
+                  expectedSessionId,
+                }
+              : {}),
+          });
+          if (!start.ok) {
+            return start.result;
+          }
+          const acceptedTargetSessionKey = start.a2aSessionKey ?? resolvedKey;
+          recordSessionToolActionFact({
+            operation: "send",
+            fact: "committed",
+            targetAgentId,
+            targetSessionKey: acceptedTargetSessionKey,
+          });
+          recordSessionParticipantBestEffort({
+            identity: { type: "agent", id: requesterAgentId },
+            promptedAt,
+            agentId: targetAgentId,
+            sessionKey: acceptedTargetSessionKey,
+            storePath: resolveSessionStorePathCore(cfg.session?.store, { agentId: targetAgentId }),
+            onError: (error) => log.warn("failed to record session participant", { error }),
+          });
+          runId = start.runId;
+          const watchField = registerWatchIfRequested(acceptedTargetSessionKey);
           if (timeoutSeconds === 0) {
-            const start = await startAgentRun({
-              callGateway: gatewayCall,
-              runId,
-              sendParams,
-              sessionKey: displayKey,
-              deliveryTimeoutMs: announceTimeoutMs,
-              allowActiveRunQueueDelivery: true,
-              // An exact-incarnation grant authorizes only this target. Never
-              // reroute a worker-owned send to a durable Cron parent outside
-              // the scoped lifecycle admission or replace its stable key.
-              allowActiveRunQueueFallback: !expectedSessionId,
-              expectedSessionId,
-            });
-            if (!start.ok) {
-              return start.result;
-            }
-            recordSessionToolActionFact({
-              operation: "send",
-              fact: "committed",
-              targetAgentId,
-              targetSessionKey: start.a2aSessionKey ?? resolvedKey,
-            });
-            recordSessionsSendParticipant({
-              promptedAt,
-              cfg,
-              requesterAgentId,
-              sessionKey: start.a2aSessionKey ?? resolvedKey,
-              targetAgentId,
-            });
-            runId = start.runId;
-            const watchField = registerWatchIfRequested(start.a2aSessionKey ?? resolvedKey);
             if (!start.activeRunQueue) {
               startA2AFlow(undefined, runId, start.a2aSessionKey, start.a2aDisplayKey, true);
             }
@@ -1183,31 +1170,6 @@ export function createSessionsSendTool(opts?: {
             });
           }
 
-          const start = await startAgentRun({
-            callGateway: gatewayCall,
-            runId,
-            sendParams,
-            sessionKey: displayKey,
-            deliveryTimeoutMs: announceTimeoutMs,
-          });
-          if (!start.ok) {
-            return start.result;
-          }
-          recordSessionToolActionFact({
-            operation: "send",
-            fact: "committed",
-            targetAgentId,
-            targetSessionKey: start.a2aSessionKey ?? resolvedKey,
-          });
-          recordSessionsSendParticipant({
-            promptedAt,
-            cfg,
-            requesterAgentId,
-            sessionKey: start.a2aSessionKey ?? resolvedKey,
-            targetAgentId,
-          });
-          runId = start.runId;
-          const watchField = registerWatchIfRequested(resolvedKey);
           const result = await waitForAgentRunAndReadUpdatedAssistantReply({
             runId,
             sessionKey: resolvedKey,

--- a/src/gateway/session-identity-projection.ts
+++ b/src/gateway/session-identity-projection.ts
@@ -154,19 +154,14 @@ export function projectSessionParticipants(
   entry: SessionEntry | undefined,
   userProfileIdentityById: Map<string, SessionActorProfileIdentity | undefined> | undefined,
   cfg: OpenClawConfig,
-): NonNullable<SessionEntry["participants"]> {
+): Map<string, SessionParticipant> {
   const identities = userProfileIdentityById ?? new Map();
-  const participants = entry?.participants?.map(({ identity }) =>
-    projectParticipant(identity, identities, cfg),
-  );
-  return [
-    ...new Map(
-      (participants ?? []).map((participant) => [
-        JSON.stringify(participant.identity),
-        participant,
-      ]),
-    ).values(),
-  ];
+  const participants = new Map<string, SessionParticipant>();
+  for (const { identity } of entry?.participants ?? []) {
+    const participant = projectParticipant(identity, identities, cfg);
+    participants.set(JSON.stringify(participant.identity), participant);
+  }
+  return participants;
 }
 
 /** Participation, creation, and responsibility are associations, never access grants. */
@@ -187,7 +182,7 @@ export function projectSessionPeople(
     ),
   ];
   const people = new Map<string, SessionPerson>();
-  for (const participant of [...participants, ...actors]) {
+  for (const participant of [...participants.values(), ...actors]) {
     const identity = participant?.identity;
     if (identity?.type === "profile") {
       people.set(identity.id, {

--- a/src/gateway/session-utils-list.ts
+++ b/src/gateway/session-utils-list.ts
@@ -332,9 +332,8 @@ function filterSessionEntries(params: {
       const viewerOwns =
         effectiveOwner?.identity?.type === "profile" &&
         effectiveOwner.identity.id === involvingActorId;
-      const viewerParticipates = projectSessionParticipants(entry, identities, cfg).some(
-        (participant) =>
-          participant.identity.type === "profile" && participant.identity.id === involvingActorId,
+      const viewerParticipates = projectSessionParticipants(entry, identities, cfg).has(
+        JSON.stringify({ type: "profile", id: involvingActorId }),
       );
       if (!viewerOwns && !viewerParticipates) {
         continue;

--- a/src/gateway/session-utils-owners.test.ts
+++ b/src/gateway/session-utils-owners.test.ts
@@ -352,7 +352,7 @@ it("filters immutable creator and effective owner separately while preserving pr
   });
 });
 
-it("projects participant identities and filters sessions involving the viewer", () => {
+it("deduplicates participants in order, excludes the owner, and filters sessions involving the viewer", () => {
   const store: Record<string, SessionEntry> = {
     "agent:main:owned": {
       createdActor: { type: "human", id: "profile-ada" },
@@ -366,13 +366,15 @@ it("projects participant identities and filters sessions involving the viewer", 
       createdActor: { type: "human", id: "profile-bob" },
       createdVia: "operator",
       participants: [
+        { identity: { type: "profile", id: "profile-bob" } },
         { identity: { type: "agent", id: "research" } },
         { identity: { type: "profile", id: "profile-carol" } },
         { identity: { type: "profile", id: "profile-dana" } },
         { identity: { type: "profile", id: "profile-erin" } },
         { identity: { type: "profile", id: "profile-ada" } },
+        { identity: { type: "agent", id: "research" } },
       ],
-      participantCount: 5,
+      participantCount: 7,
       sessionId: "session-participating",
       updatedAt: 2,
     },

--- a/src/gateway/session-utils-row.ts
+++ b/src/gateway/session-utils-row.ts
@@ -115,9 +115,10 @@ export function buildGatewaySessionRow(params: {
     entry,
     params.rowContext?.userProfileIdentityById,
     cfg,
-  ).filter(
-    (participant) => JSON.stringify(participant.identity) !== JSON.stringify(owner?.actor.identity),
   );
+  if (owner?.actor.identity) {
+    participants.delete(JSON.stringify(owner.actor.identity));
+  }
   const observerDigest =
     entry?.observerDigest &&
     // Strictly newer: a run end and restart can share a millisecond, and the
@@ -457,8 +458,8 @@ export function buildGatewaySessionRow(params: {
       hasSessionCreatorProfileProvenance(entry),
     ),
     owner,
-    participants: participants.length ? participants.slice(0, 4) : undefined,
-    participantCount: participants.length || undefined,
+    participants: participants.size ? [...participants.values()].slice(0, 4) : undefined,
+    participantCount: participants.size || undefined,
     createdAt: entry?.createdAt,
     forkSource: entry?.forkSource,
     previousSessionId: entry?.previousSessionId,

--- a/src/sessions/session-lifecycle-events.ts
+++ b/src/sessions/session-lifecycle-events.ts
@@ -1,5 +1,6 @@
 /** Session lifecycle event broadcast to observers when a session is created or linked. */
 import { resolveGlobalSet, resolveGlobalSingleton } from "../shared/global-singleton.js";
+import { notifyListeners, registerListener } from "../shared/listeners.js";
 export type SessionLifecycleEvent = {
   sessionKey: string;
   agentId?: string;
@@ -52,29 +53,17 @@ export function readSessionLifecycleVersion(): number {
 
 /** Registers a session lifecycle listener. */
 export function onSessionLifecycleEvent(listener: SessionLifecycleListener): () => void {
-  SESSION_LIFECYCLE_LISTENERS.add(listener);
-  return () => {
-    SESSION_LIFECYCLE_LISTENERS.delete(listener);
-  };
+  return registerListener(SESSION_LIFECYCLE_LISTENERS, listener);
 }
 
 /** Emits a best-effort session lifecycle event to all listeners. */
 export function emitSessionLifecycleEvent(event: SessionLifecycleEvent): void {
   SESSION_LIFECYCLE_STATE.version += 1;
-  for (const listener of SESSION_LIFECYCLE_LISTENERS) {
-    try {
-      listener(event);
-    } catch {
-      // Best-effort, do not propagate listener errors.
-    }
-  }
+  notifyListeners(SESSION_LIFECYCLE_LISTENERS, event);
 }
 
 export function onSessionIdentityMutation(listener: SessionIdentityMutationListener): () => void {
-  SESSION_IDENTITY_MUTATION_LISTENERS.add(listener);
-  return () => {
-    SESSION_IDENTITY_MUTATION_LISTENERS.delete(listener);
-  };
+  return registerListener(SESSION_IDENTITY_MUTATION_LISTENERS, listener);
 }
 
 /** Monotonic fence for projections that consume session identities across owner boundaries. */
@@ -84,11 +73,5 @@ export function readSessionIdentityMutationVersion(): number {
 
 export function emitSessionIdentityMutation(mutation: SessionIdentityMutation): void {
   SESSION_IDENTITY_MUTATION_STATE.version += 1;
-  for (const listener of SESSION_IDENTITY_MUTATION_LISTENERS) {
-    try {
-      listener(mutation);
-    } catch {
-      // Session persistence already succeeded; one observer must not block the rest.
-    }
-  }
+  notifyListeners(SESSION_IDENTITY_MUTATION_LISTENERS, mutation);
 }

--- a/src/state/user-profile-events.ts
+++ b/src/state/user-profile-events.ts
@@ -1,4 +1,5 @@
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import { notifyListeners, registerListener } from "../shared/listeners.js";
 
 const changes = resolveGlobalSingleton(Symbol.for("openclaw.userProfileChanges"), () => ({
   version: 0,
@@ -10,20 +11,11 @@ export function readUserProfileVersion(): number {
 }
 
 export function onUserProfilesChanged(listener: () => void): () => void {
-  changes.listeners.add(listener);
-  return () => {
-    changes.listeners.delete(listener);
-  };
+  return registerListener(changes.listeners, listener);
 }
 
 /** No profile data crosses this notification; readers reapply their own visibility policy. */
 export function emitUserProfilesChanged(): void {
   changes.version += 1;
-  for (const listener of changes.listeners) {
-    try {
-      listener();
-    } catch {
-      /* Persistence already committed. */
-    }
-  }
+  notifyListeners(changes.listeners, undefined);
 }

--- a/ui/src/components/session-owner-chip.ts
+++ b/ui/src/components/session-owner-chip.ts
@@ -91,7 +91,9 @@ function ownerHue(id: string): number {
   return Math.abs(hash) % 360;
 }
 
-export function renderSessionOwnerMenuAvatar(owner: SessionOwnerOption) {
+export function renderSessionOwnerAvatar(
+  owner: Pick<SessionOwnerOption, "id" | "label" | "avatarUrl" | "identity">,
+) {
   return html`<openclaw-viewer-avatar
     .identity=${owner.identity}
     .user=${{
@@ -157,18 +159,7 @@ class SessionOwnerChip extends OpenClawLightDomElement {
         aria-label=${accessibleLabel}
         title=${accessibleLabel}
         >${avatar?.kind === "profile"
-          ? html`<openclaw-viewer-avatar
-              .identity=${owner.identity}
-              .user=${{
-                id: owner.id,
-                name: owner.label,
-                avatarUrl: owner.avatarUrl,
-                watchedSessions: [],
-              }}
-              .markAsViewer=${false}
-              variant="session"
-              aria-hidden="true"
-            ></openclaw-viewer-avatar>`
+          ? renderSessionOwnerAvatar({ ...owner, id: owner.id })
           : initials}</span
       >
     `;

--- a/ui/src/components/session-owner-menu.ts
+++ b/ui/src/components/session-owner-menu.ts
@@ -2,7 +2,7 @@ import { html, nothing } from "lit";
 import { ref } from "lit/directives/ref.js";
 import { t } from "../i18n/index.ts";
 import { icons } from "./icons.ts";
-import { renderSessionOwnerMenuAvatar, type SessionOwnerOption } from "./session-owner-chip.ts";
+import { renderSessionOwnerAvatar, type SessionOwnerOption } from "./session-owner-chip.ts";
 import { syncDropdownItemRadio } from "./web-awesome.ts";
 
 type SessionOwnerAssignment = Pick<SessionOwnerOption, "type" | "id">;
@@ -42,7 +42,7 @@ export function renderSessionOwnerAssignmentOptions(
         title=${title}
       >
         <span slot="icon" class="session-menu__icon" aria-hidden="true"
-          >${renderSessionOwnerMenuAvatar(owner)}</span
+          >${renderSessionOwnerAvatar(owner)}</span
         >
         <span class="session-menu__text">${owner.label ?? owner.id}</span>
         ${checked

--- a/ui/src/components/viewer-facepile.test.ts
+++ b/ui/src/components/viewer-facepile.test.ts
@@ -160,26 +160,35 @@ type ViewerFacepileElement = HTMLElement & {
   updateComplete: Promise<boolean>;
 };
 
-it("keeps session facepiles as plain non-interactive avatar clusters", async () => {
-  const facepile = document.createElement("openclaw-viewer-facepile") as ViewerFacepileElement;
-  facepile.presencePayload = {
-    presence: [
-      {
-        instanceId: "alice-1",
-        user: { id: "alice", name: "Alice" },
-        watchedSessions: [],
-      },
-    ],
-  };
-  document.body.append(facepile);
+it.each(["first", "second"])(
+  "merges device presence into one non-interactive face watching %s",
+  async (session) => {
+    const facepile = document.createElement("openclaw-viewer-facepile") as ViewerFacepileElement;
+    facepile.sessionKey = `agent:main:${session}`;
+    facepile.presencePayload = {
+      presence: [
+        {
+          instanceId: "alice-1",
+          user: { id: "alice", name: "Alice" },
+          watchedSessions: ["agent:main:first"],
+        },
+        {
+          instanceId: "alice-2",
+          user: { id: "alice", name: "Alice" },
+          watchedSessions: ["agent:main:second"],
+        },
+      ],
+    };
+    document.body.append(facepile);
 
-  await vi.waitFor(async () => {
-    await facepile.updateComplete;
-    expect(facepile.querySelector(".viewer-facepile")).not.toBeNull();
-  });
-  expect(facepile.querySelector("button")).toBeNull();
-  expect(facepile.querySelectorAll("openclaw-tooltip")).toHaveLength(1);
-});
+    await vi.waitFor(async () => {
+      await facepile.updateComplete;
+      expect(facepile.querySelector(".viewer-facepile")).not.toBeNull();
+    });
+    expect(facepile.querySelector("button")).toBeNull();
+    expect(facepile.querySelectorAll("openclaw-tooltip")).toHaveLength(1);
+  },
+);
 
 it("renders ordered static participant actors without presence filtering", async () => {
   // SAFETY: the registered custom element exposes the tested reactive properties.

--- a/ui/src/components/viewer-facepile.ts
+++ b/ui/src/components/viewer-facepile.ts
@@ -4,11 +4,10 @@ import type {
   SessionParticipant,
   SessionParticipantIdentity,
 } from "../../../packages/gateway-protocol/src/schema/session-participant.js";
-import { readPresenceEntries } from "../app/user-profile.ts";
 import { t } from "../i18n/index.ts";
 import {
   presenceViewerLabel,
-  projectPresenceEntries,
+  projectPresencePayload,
   type PresenceViewer,
 } from "../lib/presence-users.ts";
 import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
@@ -93,8 +92,8 @@ class ViewerFacepile extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) personActivity?: PersonActivityRouting;
 
   override render() {
-    const projection = projectPresenceEntries(
-      readPresenceEntries(this.presencePayload) ?? [],
+    const projection = projectPresencePayload(
+      this.presencePayload,
       this.selfUserId,
       this.selfInstanceId,
     );

--- a/ui/src/lib/presence-users.ts
+++ b/ui/src/lib/presence-users.ts
@@ -80,14 +80,6 @@ function projectPresenceViewers(
   };
 }
 
-export function projectPresenceEntries(
-  entries: readonly PresenceEntry[],
-  authenticatedSelfUserId?: string,
-  selfInstanceId?: string,
-) {
-  return projectPresenceViewers(entries, authenticatedSelfUserId, selfInstanceId);
-}
-
 let cachedPresencePayload: unknown;
 let cachedAuthenticatedSelfUserId: string | undefined;
 let cachedSelfInstanceId: string | undefined;

--- a/ui/src/pages/activity/activity-page.ts
+++ b/ui/src/pages/activity/activity-page.ts
@@ -42,11 +42,7 @@ import {
 import { renderRunInspector } from "./run-inspector-view.ts";
 import { SessionActivityController } from "./session-activity-controller.ts";
 import { renderSessionActivityView } from "./session-activity-view.ts";
-import {
-  resolveActivityIdentity,
-  sessionActivitySearch,
-  type SessionActivityFilters,
-} from "./session-activity.ts";
+import { sessionActivitySearch, type SessionActivityFilters } from "./session-activity.ts";
 import {
   parseActivityEvent,
   updateToolActivity,
@@ -596,20 +592,12 @@ class ActivityPage extends OpenClawLightDomElement {
       onScroll: (event) => this.streamFollow.handleScroll(event),
     });
     const mode = this.routeData?.mode ?? "live";
-    const sessionRows = this.sessionActivity.result?.sessions ?? [];
     const filters =
       this.routeData.mode === "sessions"
         ? this.routeData.filters
         : ({ personId: null, query: "", time: "7d" } satisfies SessionActivityFilters);
     const presenceViewers = projectPresencePayload(this.presencePayload).users;
     const selectedProfileId = this.sessionActivity.result?.involvingProfileId ?? filters.personId;
-    const currentIdentity = selectedProfileId
-      ? resolveActivityIdentity(
-          selectedProfileId,
-          this.presencePayload,
-          this.sessionActivity.result?.people,
-        )
-      : null;
     const body = html`
       ${mode === "run"
         ? nothing
@@ -637,8 +625,6 @@ class ActivityPage extends OpenClawLightDomElement {
               expandedAutomationDays: this.expandedAutomationDays,
               filters: { ...filters, personId: selectedProfileId },
               presenceViewers,
-              retainedIdentity: currentIdentity,
-              rows: sessionRows,
               result: this.sessionActivity.result,
               loading: this.sessionActivity.loading,
               error: this.sessionActivity.error,

--- a/ui/src/pages/activity/session-activity-view.test.ts
+++ b/ui/src/pages/activity/session-activity-view.test.ts
@@ -30,9 +30,12 @@ function row(
   } satisfies GatewaySessionRow;
 }
 
-function props(
-  overrides: Partial<Parameters<typeof renderSessionActivityView>[0]> = {},
-): Parameters<typeof renderSessionActivityView>[0] {
+function props({
+  rows = [],
+  ...overrides
+}: Partial<Parameters<typeof renderSessionActivityView>[0]> & {
+  rows?: GatewaySessionRow[];
+} = {}): Parameters<typeof renderSessionActivityView>[0] {
   return {
     context: {
       basePath: "",
@@ -44,13 +47,11 @@ function props(
     } as unknown as ApplicationContext,
     filters: { personId: null, query: "", time: "7d" as const },
     presenceViewers: [] as PresenceViewer[],
-    retainedIdentity: null,
-    rows: [] as GatewaySessionRow[],
     result: {
       ts: 1,
       path: "",
-      count: overrides.rows?.length ?? 0,
-      sessions: [...(overrides.rows ?? [])],
+      count: rows.length,
+      sessions: rows,
       defaults: { model: null, modelProvider: null, contextTokens: null },
       people: [
         {
@@ -236,38 +237,92 @@ describe("session activity people filter", () => {
     ).toBe("1");
   });
 
-  it("shows the client IP and self-reported time zone on the device row", () => {
-    const container = document.createElement("div");
-    document.body.append(container);
-
-    render(
-      renderSessionActivityView(
-        props({
-          filters: { personId: "online", query: "", time: "7d" },
-          retainedIdentity: {
+  it.each([false, true])(
+    "keeps online identity details and only known watched sessions in recency order (facet present: %s)",
+    (hasFacet) => {
+      const container = document.createElement("div");
+      document.body.append(container);
+      const input = props({
+        filters: { personId: "online", query: "", time: "7d" },
+        rows: [
+          row("agent:main:first", { id: "online" }, 10),
+          row("agent:main:second", { id: "online" }, 20),
+          row("agent:main:unwatched", { id: "online" }, 30),
+        ],
+        presenceViewers: [
+          {
             id: "online",
-            name: "Online person",
-            watchedSessions: [],
+            email: "online@example.test",
+            watchedSessions: ["agent:main:first", "agent:main:second", "missing"],
             entries: [
               {
-                host: "openclaw-control-ui",
+                host: "Alice's Mac",
                 platform: "Win32",
                 deviceFamily: "Mac16,6",
                 ip: "203.0.113.7",
                 timeZone: "Europe/Vienna",
-                ts: Date.now(),
+                lastInputSeconds: 30,
+                ts: 10,
               },
+              { host: "Alice's phone", ts: 20 },
             ],
           },
-        }),
-      ),
-      container,
-    );
+        ],
+      });
+      if (!hasFacet) {
+        input.result!.people = [];
+      }
+      render(renderSessionActivityView(input), container);
+      const identity = container.querySelector('[data-activity-identity="online"]');
+      // A sparse online identity wins as a whole, without borrowing the facet's label.
+      expect(identity?.querySelector("h2")?.textContent).toBe("online@example.test");
+      expect(identity?.textContent).toContain("Online");
+      expect(
+        [...container.querySelectorAll(".activity-feed__device-name")].map((device) =>
+          device.textContent?.trim(),
+        ),
+      ).toEqual(["Alice's Mac", "Alice's phone"]);
+      const device = identity?.querySelector(".activity-feed__device")?.textContent;
+      expect(device).toContain("203.0.113.7");
+      expect(device).toContain("Europe/Vienna");
+      expect(
+        [...container.querySelectorAll(".activity-feed__viewing-list [data-activity-session]")].map(
+          (session) => session.getAttribute("data-activity-session"),
+        ),
+      ).toEqual(["agent:main:second", "agent:main:first"]);
+    },
+  );
 
-    const device = container.querySelector(".activity-feed__device")?.textContent;
-    expect(device).toContain("203.0.113.7");
-    expect(device).toContain("Europe/Vienna");
-  });
+  it.each(["offline", "unknown", "Offline"])(
+    "resolves the selected %s identity only from an exact server profile facet",
+    (personId) => {
+      const container = document.createElement("div");
+      document.body.append(container);
+      const input = props({
+        filters: { personId, query: "", time: "7d" },
+        rows: [
+          row("Visible session", { id: personId, label: "Row actor" }, 10, {
+            participants: [{ identity: { type: "profile", id: personId }, label: "Preview actor" }],
+          }),
+        ],
+      });
+      render(renderSessionActivityView({ ...input, result: undefined, loading: true }), container);
+      expect(container.querySelector(".activity-feed__not-found")).toBeNull();
+      expect(container.querySelector('[role="status"]')?.textContent).toContain("Loading");
+
+      render(renderSessionActivityView(input), container);
+      if (personId === "offline") {
+        const identity = container.querySelector('[data-activity-identity="offline"]');
+        expect(identity?.querySelector("h2")?.textContent).toBe("Offline person");
+        expect(identity?.textContent).toContain("Offline");
+        expect(identity?.querySelector(".activity-feed__viewing-list")).toBeNull();
+      } else {
+        expect(container.querySelector(".activity-feed__not-found")).not.toBeNull();
+        expect(container.querySelector("[data-activity-identity]")).toBeNull();
+        expect(container.querySelector("[data-activity-session]")).toBeNull();
+      }
+    },
+  );
 
   it("selecting Everyone clears the person while preserving the other filters", () => {
     const onFiltersChange = vi.fn();
@@ -277,7 +332,6 @@ describe("session activity people filter", () => {
       renderSessionActivityView(
         props({
           filters: { personId: "online", query: "release", time: "30d" },
-          retainedIdentity: { id: "online", name: "Online person", watchedSessions: [] },
           rows: [row("Release session", { id: "online", label: "Online person" }, Date.now())],
           onFiltersChange,
         }),
@@ -351,7 +405,7 @@ describe("session activity automation grouping", () => {
       { filters: { personId: null, query: "Automation", time: "7d" as const } },
       {
         filters: { personId: "owner", query: "", time: "7d" as const },
-        retainedIdentity: { id: "owner", name: "Owner", watchedSessions: [] },
+        presenceViewers: [{ id: "owner", name: "Owner", watchedSessions: [] }],
       },
     ]) {
       render(

--- a/ui/src/pages/activity/session-activity-view.ts
+++ b/ui/src/pages/activity/session-activity-view.ts
@@ -35,8 +35,6 @@ type SessionActivityViewProps = {
   expandedAutomationDays: ReadonlySet<string>;
   filters: SessionActivityFilters;
   presenceViewers: readonly PresenceViewer[];
-  retainedIdentity: PresenceViewer | null;
-  rows: readonly GatewaySessionRow[];
   result?: SessionsListResult;
   loading: boolean;
   error?: string;
@@ -419,8 +417,12 @@ function renderIdentityHeader(
 
 export function renderSessionActivityView(props: SessionActivityViewProps) {
   const projection = projectSessionActivity(props.result);
-  const identity = props.retainedIdentity;
   const onlineById = new Map(props.presenceViewers.map((person) => [person.id, person]));
+  const identity = props.filters.personId
+    ? (onlineById.get(props.filters.personId) ??
+      projection.people.find((person) => person.id === props.filters.personId) ??
+      null)
+    : null;
   const people = projection.people.map((person) => {
     const online = onlineById.get(person.id);
     return online ? { ...person, ...online, count: person.count } : person;
@@ -479,7 +481,7 @@ export function renderSessionActivityView(props: SessionActivityViewProps) {
           : nothing}
         ${props.result && props.filters.personId
           ? identity
-            ? renderIdentityHeader(props.context, identity, props.rows)
+            ? renderIdentityHeader(props.context, identity, projection.sessions)
             : html`<section class="activity-feed__not-found" role="status">
                 <h2>${t("activityFeed.notFoundTitle")}</h2>
                 <p>${t("activityFeed.notFoundDescription")}</p>

--- a/ui/src/pages/activity/session-activity.test.ts
+++ b/ui/src/pages/activity/session-activity.test.ts
@@ -3,8 +3,6 @@ import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
 import {
   parseSessionActivityFilters,
   projectSessionActivity,
-  resolveActivityIdentity,
-  resolveViewingNow,
   sessionActivitySearch,
 } from "./session-activity.ts";
 
@@ -73,55 +71,5 @@ describe("session activity projection", () => {
     const search = sessionActivitySearch(filters);
     expect(search).toBe("?time=30d&person=profile%2Fa&q=release+notes");
     expect(parseSessionActivityFilters(search)).toEqual(filters);
-  });
-});
-
-describe("per-person activity projection", () => {
-  const rows: GatewaySessionRow[] = [
-    { key: "agent:main:first", kind: "direct", updatedAt: 10 },
-    { key: "agent:main:second", kind: "direct", updatedAt: 20 },
-  ];
-  it("keeps presence details and resolves only known watched sessions", () => {
-    const identity = resolveActivityIdentity(
-      "alice",
-      {
-        presence: [
-          {
-            instanceId: "alice-laptop",
-            host: "Alice's Mac",
-            lastInputSeconds: 30,
-            ts: 10,
-            user: { id: "alice", name: "Alice", email: "alice@example.test" },
-            watchedSessions: ["agent:main:first", "missing"],
-          },
-          {
-            instanceId: "alice-phone",
-            host: "Alice's phone",
-            ts: 20,
-            user: { id: "alice", name: "Alice" },
-            watchedSessions: ["agent:main:second"],
-          },
-        ],
-      },
-      people,
-    );
-    expect(identity).toMatchObject({
-      id: "alice",
-      email: "alice@example.test",
-      watchedSessions: ["agent:main:first", "agent:main:second", "missing"],
-    });
-    expect(identity?.entries?.map((entry) => entry.host)).toEqual(["Alice's Mac", "Alice's phone"]);
-    expect(resolveViewingNow(identity!, rows).map((row) => row.key)).toEqual([
-      "agent:main:second",
-      "agent:main:first",
-    ]);
-  });
-  it("uses the server profile facet for offline identities", () => {
-    expect(resolveActivityIdentity("alice", { presence: [] }, people)).toMatchObject({
-      id: "alice",
-      name: "Alice",
-      watchedSessions: [],
-    });
-    expect(resolveActivityIdentity("unknown", { presence: [] }, people)).toBeNull();
   });
 });

--- a/ui/src/pages/activity/session-activity.ts
+++ b/ui/src/pages/activity/session-activity.ts
@@ -2,7 +2,7 @@ import { buildControlUiResourcePath } from "../../../../src/gateway/control-ui-r
 import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
 import { ACTIVITY_PERSON_PARAM } from "../../app-route-paths.ts";
 import { readAvatarGatewayContext } from "../../lib/identity-avatar-context.ts";
-import { projectPresencePayload, type PresenceViewer } from "../../lib/presence-users.ts";
+import type { PresenceViewer } from "../../lib/presence-users.ts";
 
 export const ACTIVITY_TIME_FILTERS = ["24h", "7d", "30d", "all"] as const;
 export type ActivityTimeFilter = (typeof ACTIVITY_TIME_FILTERS)[number];
@@ -136,26 +136,6 @@ export function projectSessionActivity(
     sessions: visible,
     timeCount: result?.peopleSessionCount ?? visible.length,
   };
-}
-
-export function resolveActivityIdentity(
-  userId: string,
-  presencePayload: unknown,
-  people: SessionsListResult["people"],
-): PresenceViewer | null {
-  const online = projectPresencePayload(presencePayload).users.find((user) => user.id === userId);
-  if (online) {
-    return online;
-  }
-  const person = people?.find((candidate) => candidate.identity.id === userId);
-  return person
-    ? {
-        id: person.identity.id,
-        name: person.label,
-        avatarUrl: person.avatarUrl,
-        watchedSessions: [],
-      }
-    : null;
 }
 
 export function resolveViewingNow(


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/130986 (participant identity and Activity attribution repair).

## What Problem This Solves

The participant-attribution repair left duplicate acceptance handling and presentation plumbing that made the same invariants harder to maintain. This is the requested behavior-preserving simplification follow-up, not another identity or storage redesign.

## Why This Change Was Made

Waited and fire-and-forget `sessions_send` now share dispatch, accepted-action recording, participant recording, and watch registration. Mode-specific queue options, exact-incarnation restrictions, original input time, final-target selection, and A2A behavior stay unchanged. The one-use participant-forwarding wrapper is gone.

Activity owns selected-person presentation in its view instead of passing parallel identity and row projections. Session rows retain their existing identity-keyed participant map through membership checks and owner exclusion. Owner avatars, event publishers, and facepiles reuse their existing render, listener, and presence-projection helpers rather than duplicate them.

Production: **+72 / −190 = −118 lines** across 13 files. Tests: **+197 / −105 = +92 lines** across 5 files. Overall: **26 fewer lines**, with useful resolver coverage moved to rendered boundaries rather than discarded. The unused-export gate also caught the old presence-entry wrapper after its last caller moved; that wrapper is deleted, not allowlisted.

## User Impact

No intended user-visible or visual change. Profile/native/legacy namespaces, canonical aliases, unknown historical times, contribution counts, visibility-before-pagination, participant bounds, and post-commit publication remain unchanged. There are no schema, protocol, configuration, dependency, or migration changes. The independently owned creator-authorization, transcript-sender, SDK, and readiness work is not included.

A baseline test also exposed a hardcoded `/tmp/sessions.json` fixture that read an unrelated schema-17 database. The fixture now uses the existing tracked temporary-directory helper. The unrelated database was not deleted, changed, or migrated.

## Evidence

- Before editing runtime code, the focused baseline passed after the isolated test-fixture repair; the initial failure is retained as evidence of that test defect.
- After the refactor, 198 focused tests passed across lifecycle/profile publication, Gateway projection/cache invalidation, session tools, Activity, avatars, and presence. The three browser-only cases skipped by the jsdom lane are run separately in Chromium.
- New accepted/rejected, waited/fire-and-forget cases inspect real SQLite participant records and protect exactly-once contribution recording at the original input timestamp. Existing Gateway coverage now also checks duplicate insertion order and owner exclusion before the four-avatar preview.
- Fresh isolated Codex autoreview completed with no actionable P0 findings; the lead separately inspected the complete affected production modules, callers, consumers, and existing tests.

- All three real-Chromium geometry cases passed before and after. The final presence/Activity UI selections were rerun after deleting the orphaned wrapper.
- The complete changed-file gate passed: core, core-test, and UI typechecks; targeted lint/format; unused-export, i18n, schema-version, and architecture guards.
- `pnpm build` and `pnpm ui:build` passed, including SDK export checks and Control UI asset/performance limits. Full-build startup JavaScript was 345,392 B gzip against the unchanged 347,037 B limit; zero ineffective dynamic-import warnings.
- This is a behavior-neutral refactor: no new live provider/channel or migration claims, and no visual redesign. Existing rendered-boundary tests and real-browser geometry checks protect the unchanged UI.

<details>
<summary>Exact local validation commands</summary>

```bash
node scripts/run-vitest.mjs src/sessions/session-lifecycle-events.test.ts src/state/user-profiles.test.ts src/gateway/session-utils-owners.test.ts src/gateway/server-methods/sessions-list-cache.runner-availability.test.ts src/agents/openclaw-tools.sessions.test.ts ui/src/pages/activity/session-activity.test.ts ui/src/pages/activity/session-activity-view.test.ts ui/src/pages/activity/session-activity-controller.test.ts ui/src/components/session-owner-chip.test.ts ui/src/components/session-owner-chip.browser.test.ts ui/src/components/viewer-facepile.test.ts ui/src/lib/identity-avatar.test.ts ui/src/lib/session-viewer-presence.test.ts ui/src/pages/chat/components/chat-pane-header-identity.test.ts
```

```bash
node scripts/run-vitest.mjs ui/src/pages/activity/session-activity.test.ts ui/src/pages/activity/session-activity-view.test.ts ui/src/pages/activity/session-activity-controller.test.ts ui/src/components/session-owner-chip.test.ts ui/src/components/session-owner-chip.browser.test.ts ui/src/components/viewer-facepile.test.ts ui/src/lib/identity-avatar.test.ts ui/src/lib/session-viewer-presence.test.ts ui/src/pages/chat/components/chat-pane-header-identity.test.ts
```

```bash
pnpm --dir ui test src/components/session-owner-chip.browser.test.ts --project browser
```

```bash
node scripts/check-changed.mjs -- src/agents/openclaw-tools.sessions.test.ts src/agents/tools/sessions-send-tool.ts src/gateway/session-identity-projection.ts src/gateway/session-utils-list.ts src/gateway/session-utils-owners.test.ts src/gateway/session-utils-row.ts src/sessions/session-lifecycle-events.ts src/state/user-profile-events.ts ui/src/components/session-owner-chip.ts ui/src/components/session-owner-menu.ts ui/src/components/viewer-facepile.test.ts ui/src/components/viewer-facepile.ts ui/src/lib/presence-users.ts ui/src/pages/activity/activity-page.ts ui/src/pages/activity/session-activity-view.test.ts ui/src/pages/activity/session-activity-view.ts ui/src/pages/activity/session-activity.test.ts ui/src/pages/activity/session-activity.ts
```

```bash
pnpm ui:build
```

```bash
pnpm build
```

</details>
