### PR TITLE
fix(system-agent): system-agent turns fail with stale Codex session generation when two conversations run

### DIFF
--- a/src/system-agent/agent-turn.test.ts
+++ b/src/system-agent/agent-turn.test.ts
@@ -7,6 +7,8 @@ import { testing as cliBackendsTesting } from "../agents/cli-backends.test-suppo
 import { fingerprintResolvedProviderAuth } from "../agents/execution-auth-binding.js";
 import { createSystemAgentTool } from "../agents/tools/system-agent-tool.js";
 import type { OpenClawConfig } from "../config/types.js";
+import { toAgentStoreSessionKey } from "../routing/session-key.js";
+import { SYSTEM_AGENT_ID } from "./agent-id.js";
 import {
   cleanupSystemAgentSession,
   createSystemAgentSession,
@@ -265,6 +267,25 @@ describe("runSystemAgentTurn", () => {
     expect(firstPath).toBe(`in-memory:${first.sessionId}`);
     expect(secondPath).toBe(`in-memory:${second.sessionId}`);
     expect(firstPath).not.toBe(secondPath);
+    const firstSessionKey = requireValue(
+      mocks.runEmbeddedAgent.mock.calls[0]?.[0]?.sessionKey,
+      "missing first embedded session key",
+    );
+    const secondSessionKey = requireValue(
+      mocks.runEmbeddedAgent.mock.calls[1]?.[0]?.sessionKey,
+      "missing second embedded session key",
+    );
+    expect(firstSessionKey).toBe(
+      toAgentStoreSessionKey({ agentId: SYSTEM_AGENT_ID, requestKey: first.sessionId }),
+    );
+    expect(secondSessionKey).toBe(
+      toAgentStoreSessionKey({ agentId: SYSTEM_AGENT_ID, requestKey: second.sessionId }),
+    );
+    // Independent conversations must not share one runner key, or the first
+    // Codex session-generation fence invalidates every later conversation.
+    expect(firstSessionKey).not.toBe(secondSessionKey);
+    expect(firstSessionKey).not.toBe("agent:openclaw:main");
+    expect(secondSessionKey).not.toBe("agent:openclaw:main");
     expect(first.sessionManager).not.toBe(second.sessionManager);
     await cleanupSystemAgentSession(first);
     expect(first.sessionManager).toBeUndefined();
@@ -321,7 +342,10 @@ describe("runSystemAgentTurn", () => {
       agentDir,
       authProfileId: "claude-cli:ops",
       agentId: "openclaw",
-      sessionKey: "agent:openclaw:main",
+      sessionKey: toAgentStoreSessionKey({
+        agentId: SYSTEM_AGENT_ID,
+        requestKey: session.sessionId,
+      }),
       sessionId: session.sessionId,
       workspaceDir: path.join(stateDir, "openclaw", "workspace"),
       sessionFile: `in-memory:${session.sessionId}`,
@@ -812,7 +836,10 @@ describe("runSystemAgentTurn", () => {
       authProfileIdSource: "user",
       agentHarnessRuntimeOverride: "codex",
       agentId: "openclaw",
-      sessionKey: "agent:openclaw:main",
+      sessionKey: toAgentStoreSessionKey({
+        agentId: SYSTEM_AGENT_ID,
+        requestKey: session.sessionId,
+      }),
       sessionId: session.sessionId,
       workspaceDir: path.join(stateDir, "openclaw", "workspace"),
       sessionFile: `in-memory:${session.sessionId}`,

--- a/src/system-agent/agent-turn.ts
+++ b/src/system-agent/agent-turn.ts
@@ -9,7 +9,7 @@ import { normalizeCliModel } from "../agents/cli-runner/helpers.js";
 import { SessionManager } from "../agents/sessions/index.js";
 import { resolveStateDir } from "../config/paths.js";
 import type { CliSessionBinding } from "../config/sessions.js";
-import { buildAgentMainSessionKey } from "../routing/session-key.js";
+import { toAgentStoreSessionKey } from "../routing/session-key.js";
 import { SYSTEM_AGENT_ID } from "./agent-id.js";
 import { SYSTEM_AGENT_SYSTEM_PROMPT } from "./assistant-prompts.js";
 import { SystemAgentInferenceUnavailableError } from "./inference-error.js";
@@ -314,7 +314,13 @@ async function runSystemAgentTurnWithDeps(
   );
   const shared = {
     sessionId: params.session.sessionId,
-    sessionKey: buildAgentMainSessionKey({ agentId: SYSTEM_AGENT_ID }),
+    // Derive the runner key from this conversation's in-memory session id so
+    // independent system-agent conversations do not share one Codex session
+    // generation fence (see issue #131807).
+    sessionKey: toAgentStoreSessionKey({
+      agentId: SYSTEM_AGENT_ID,
+      requestKey: params.session.sessionId,
+    }),
     agentId: SYSTEM_AGENT_ID,
     trigger: "manual" as const,
     sessionFile: `in-memory:${params.session.sessionId}`,


### PR DESCRIPTION
Closes #131807

Supersedes #131843, which ClawSweeper auto-closed with a "cannot reproduce on current main" verdict. That verdict is disproven below with a deterministic probe against current `main` (`6ddb9f049fb`). The close could not be reopened (GitHub rejects the reopen with HTTP 422), so this PR carries the same one-commit fix plus the new evidence.

## What Problem This Solves

Fixes an issue where OpenClaw system-agent conversations would fail every turn before inference with `Codex session generation is no longer current` as soon as one conversation completed a turn through the Codex embedded harness. The system-agent surface then reported that working inference was unavailable and suggested running onboarding, even though the configured route, endpoint, and authentication were healthy.

## Why This Change Was Made

Every system-agent conversation creates a distinct in-memory session id and transcript, but all of them supply the same durable runner key `agent:openclaw:main`. Codex binds its physical session generation to that key on the first turn, so any other conversation reusing the key is deterministically rejected at the session-binding boundary before any provider request.

The fix derives the runner key from each conversation's own in-memory session id via `toAgentStoreSessionKey({ agentId: SYSTEM_AGENT_ID, requestKey: session.sessionId })`. Keys remain stable within one conversation (resume still works) while independent conversations no longer share one generation fence. The synthetic `openclaw` agent identity is preserved, and the helper falls back to the `main` key when no request key is present. The TUI session catalog (`tui-backend.ts`) intentionally keeps its own single-session key — it is a display surface with a fixed `openclaw` session id and does not feed the Codex runner boundary.

## User Impact

Operators can run multiple independent system-agent conversations through the Codex embedded harness without the second conversation invalidating the first. System-agent turns no longer surface a false "inference unavailable / run onboarding" error when the route is healthy.

## Evidence

### 1. The bug still reproduces on current main (deterministic probe)

The auto-close reasoned that `extensions/codex/src/app-server/run-attempt-connection.ts` already remaps ephemeral stable-key runs to per-session physical identities. That remap is gated on a condition system-agent runs never satisfy:

```ts
if (
  bindingIdentity.kind === "session" &&
  bindingIdentity.sessionKey &&
  (params.sessionTarget?.storePath || params.config?.session?.store)   // <-- gate
) { … authority === "ephemeral" remap … }
```

System-agent runs supply neither: `src/system-agent/agent-turn.ts` passes an in-memory `sessionManager` (dispatch becomes caller-owned, no `sessionTarget` with `storePath`) and no `config.session.store`. The Codex regression test cited by the close (`run-attempt.test.ts` "starts sequential ephemeral generations that share a stable session key") explicitly sets both `params.sessionTarget.storePath` and `params.config.session.store`, i.e. it exercises the gated path, not the system-agent shape.

A probe replicating the exact system-agent run shape (unique `sessionId` per conversation, shared `agent:openclaw:main` key, `sessionFile: in-memory:<sessionId>`, no store path) against current `main` `6ddb9f049fb`:

```text
[probe] conversation B REJECTED: Codex session generation is no longer current: openclaw-bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb
 ✓ extensions/codex/src/app-server/system-agent-shape.probe.test.ts (1 passed)
```

Conversation B is rejected before inference while conversation A succeeds — exactly the reported failure.

### 2. Focused regression (this PR)

`src/system-agent/agent-turn.test.ts` — 22/22 tests pass. Two independent conversations now receive runner keys derived from their own session ids; the keys differ from each other and from `agent:openclaw:main`; turns within one conversation stay on its key.

### 3. Dependency-injected trace through the real turn pipeline

Runtime trace through the real production turn pipeline (`createSystemAgentSession` → `runSystemAgentTurn` dependency-injection boundary, Node 24.15.0), with the runner boundary enforcing the documented Codex session-generation fence. Session IDs redacted:

```text
== two independent system-agent conversations ==
A turn 1: OK (reply="SYSTEM_HELPER_OK")
B turn 1: OK (reply="SYSTEM_HELPER_OK")
B turn 2 (resume): OK (reply="SYSTEM_HELPER_OK")
A turn 2 (resume): OK (reply="SYSTEM_HELPER_OK")
== runner session keys bound at the Codex boundary ==
agent:openclaw:openclaw-04ab… -> openclaw-04ab…
agent:openclaw:openclaw-a97a… -> openclaw-a97a…
distinct keys: 2 (expected 2)
shared legacy key present: false (expected false)
PROOF RESULT: PASS — conversations isolated, resume stable, failure mode reproduced
```

### 4. Live gateway run (built artifact)

The real built gateway (`OpenClaw 2026.8.1`, `pnpm build` completed, 16 plugins including `codex`) booted with an isolated state dir and two independent operator connections driving `openclaw.chat` through the raw Gateway WebSocket protocol. Both conversations progressed through the complete pre-inference pipeline to the real provider HTTP boundary — the stage after session-key binding (the reported bug fails before any provider request). A successful live Codex reply is not reachable from this contributor environment: the direct OpenAI endpoint is region-blocked (`HTTP 403: Country, region, or territory not supported`) and the locally available corporate relay lacks the `responses` API required by Codex app-server 0.146 (`413`/`404` traces on request).

### CI note

`checks-node-compact-small-43` timed out once in `test/scripts/dev-tooling-safety.test.ts` (unrelated suite; passes locally 60/60). Branch rebased onto current `origin/main` for a fresh run.
