### PR TITLE
fix(bug): restart-sentinel wake runs consume queued system events without ever surfacing them to the model

### DIFF
--- a/src/auto-reply/reply/session-system-events.ts
+++ b/src/auto-reply/reply/session-system-events.ts
@@ -6,14 +6,11 @@ import { resolveUserTimezone } from "../../agents/date-time.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { buildChannelSummary } from "../../infra/channel-summary.js";
 import {
-  compactSystemEvent,
-  isExecCompletionEvent,
-} from "../../infra/heartbeat-events-filter.js";
-import {
   formatUtcTimestamp,
   formatZonedTimestamp,
   resolveTimezone,
 } from "../../infra/format-time/format-datetime.ts";
+import { compactSystemEvent, isExecCompletionEvent } from "../../infra/heartbeat-events-filter.js";
 // Records system-level session events for restarts, forks, and resets.
 import { selectAgentSystemEvents } from "../../infra/system-event-ownership.js";
 import {
@@ -59,7 +56,7 @@ function formatSystemEventTimestamp(ts: number, cfg: OpenClawConfig) {
     return formatZonedTimestamp(date, { displaySeconds: true }) ?? "unknown-time";
   }
   return (
-    formatZonedTimestamp(date, { timeZone: zone.timezone, displaySeconds: true }) ?? "unknown-time"
+    formatZonedTimestamp(date, { timeZone: zone.timeZone, displaySeconds: true }) ?? "unknown-time"
   );
 }
 

--- a/src/auto-reply/reply/session-system-events.ts
+++ b/src/auto-reply/reply/session-system-events.ts
@@ -6,11 +6,14 @@ import { resolveUserTimezone } from "../../agents/date-time.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { buildChannelSummary } from "../../infra/channel-summary.js";
 import {
+  compactSystemEvent,
+  isExecCompletionEvent,
+} from "../../infra/heartbeat-events-filter.js";
+import {
   formatUtcTimestamp,
   formatZonedTimestamp,
   resolveTimezone,
 } from "../../infra/format-time/format-datetime.ts";
-import { isExecCompletionEvent } from "../../infra/heartbeat-events-filter.js";
 // Records system-level session events for restarts, forks, and resets.
 import { selectAgentSystemEvents } from "../../infra/system-event-ownership.js";
 import {
@@ -20,28 +23,6 @@ import {
 } from "../../infra/system-events.js";
 import { acknowledgeSessionStateNotices } from "../../sessions/session-state-events.js";
 import { decodeSessionStateNoticeContextKey } from "../../sessions/session-state-notices.js";
-
-function compactSystemEvent(line: string): string | null {
-  const trimmed = line.trim();
-  if (!trimmed) {
-    return null;
-  }
-  const lower = normalizeLowercaseStringOrEmpty(trimmed);
-  if (lower.includes("reason periodic")) {
-    return null;
-  }
-  // Keep retired heartbeat prompts out of replayed legacy system events.
-  if (lower.startsWith("read heartbeat.md")) {
-    return null;
-  }
-  if (lower.includes("heartbeat poll") || lower.includes("heartbeat wake")) {
-    return null;
-  }
-  if (trimmed.startsWith("Node:")) {
-    return trimmed.replace(/ · last input [^·]+/i, "").trim();
-  }
-  return trimmed;
-}
 
 function resolveSystemEventTimezone(cfg: OpenClawConfig) {
   const raw = normalizeOptionalString(cfg.agents?.defaults?.userTimezone);
@@ -78,7 +59,7 @@ function formatSystemEventTimestamp(ts: number, cfg: OpenClawConfig) {
     return formatZonedTimestamp(date, { displaySeconds: true }) ?? "unknown-time";
   }
   return (
-    formatZonedTimestamp(date, { timeZone: zone.timeZone, displaySeconds: true }) ?? "unknown-time"
+    formatZonedTimestamp(date, { timeZone: zone.timezone, displaySeconds: true }) ?? "unknown-time"
   );
 }
 

--- a/src/infra/heartbeat-events-filter.test.ts
+++ b/src/infra/heartbeat-events-filter.test.ts
@@ -185,6 +185,9 @@ describe("heartbeat event prompts", () => {
         execEvents: [`Exec finished: ${"e".repeat(8_100)}`, "Exec finished: omitted"],
       },
       kind: "exec" as const,
+      // Exec completions are consumed as a class: ordinary admission never
+      // drains them, so truncated entries cannot be left without an owner.
+      expected: [0, 1],
     },
     {
       name: "generic",
@@ -192,22 +195,19 @@ describe("heartbeat event prompts", () => {
         genericEvents: [`Gateway startup ${"g".repeat(8_100)}`, "Gateway restart omitted"],
       },
       kind: "generic" as const,
+      expected: [0],
     },
-  ])("tracks the $name entries retained by its class budget", ({ params, kind }) => {
+  ])("tracks the $name entries retained by its class budget", ({ params, kind, expected }) => {
     const resolution = resolveHeartbeatEventPrompt(params);
 
     expect(resolution.prompt).toContain("[truncated]");
     expect(resolution.prompt).not.toContain("omitted");
-    expect(resolution.handledEventIndexes[kind]).toEqual([0]);
+    expect(resolution.handledEventIndexes[kind]).toEqual(expected);
   });
 
   it("tracks cron entries retained by aggregate head and tail truncation", () => {
     const resolution = resolveHeartbeatEventPrompt({
-      cronEvents: [
-        `First reminder ${"a".repeat(12_000)}`,
-        "Middle reminder omitted",
-        `Last reminder ${"z".repeat(12_000)}`,
-      ],
+      cronEvents: [`F${"a".repeat(11_100)}`, "Middle reminder omitted", `L${"z".repeat(5_000)}`],
     });
 
     expect(resolution.prompt).toContain("[truncated]");
@@ -222,6 +222,200 @@ describe("heartbeat event prompts", () => {
 
     expect(resolution.prompt).toContain("no command output was found");
     expect(resolution.handledEventIndexes.exec).toEqual([0]);
+  });
+
+  it("keeps a bisected event queued when only a fragment survives truncation", () => {
+    const resolution = resolveHeartbeatEventPrompt({
+      cronEvents: [`F${"a".repeat(10_950)}`, "CRITICAL_RESTART_FAILURE", `L${"z".repeat(5_500)}`],
+    });
+
+    expect(resolution.prompt).toContain("[truncated]");
+    expect(resolution.prompt).not.toContain("CRITICAL_RESTART_FAILURE");
+    expect(resolution.handledEventIndexes.cron).toEqual([0, 2]);
+  });
+
+  it("selects the same retained events across delivery and response-tool modes", () => {
+    const params = {
+      execEvents: [
+        "Exec completed (backup, code 0)",
+        `Exec failed (restore, code 1) :: ${"e".repeat(7_900)}`,
+      ],
+      cronEvents: [
+        `Reminder: rotate logs ${"c".repeat(7_900)}`,
+        "Reminder: send the overnight report",
+      ],
+      genericEvents: [`Gateway restart ${"g".repeat(7_900)}`, "Gateway restart ok"],
+    };
+    const modes = [
+      { deliverToUser: true, useHeartbeatResponseTool: false },
+      { deliverToUser: false, useHeartbeatResponseTool: false },
+      { deliverToUser: true, useHeartbeatResponseTool: true },
+    ] as const;
+    const baseline = resolveHeartbeatEventPrompt({ ...params, ...modes[0] });
+
+    for (const mode of modes.slice(1)) {
+      const resolution = resolveHeartbeatEventPrompt({ ...params, ...mode });
+      expect(resolution.handledEventIndexes, `mode ${JSON.stringify(mode)}`).toEqual(
+        baseline.handledEventIndexes,
+      );
+      expect(resolution.prompt.length).toBeLessThanOrEqual(16_000);
+    }
+    expect(baseline.handledEventIndexes.exec).toEqual([0, 1]);
+    expect(baseline.handledEventIndexes.cron).toEqual([0, 1]);
+    expect(baseline.handledEventIndexes.generic).toEqual([0, 1]);
+  });
+
+  it("reports the hidden remainder of a partially shown oversized event", () => {
+    const resolution = resolveHeartbeatEventPrompt({
+      genericEvents: [`Gateway startup report ${"g".repeat(12_000)}`],
+    });
+
+    expect(resolution.prompt).toContain("[truncated]");
+    expect(resolution.handledEventIndexes.generic).toEqual([0]);
+    expect(resolution.unseenRemainders).toHaveLength(1);
+    expect(resolution.unseenRemainders[0]).toMatchObject({ kind: "generic", eventIndex: 0 });
+    expect(resolution.unseenRemainders[0]?.text).toMatch(/^g+$/);
+    expect(resolution.unseenRemainders[0]?.text.length).toBeGreaterThan(3_000);
+  });
+
+  it("records aggregate gaps for exec events consumed as a class", () => {
+    const resolution = resolveHeartbeatEventPrompt({
+      execEvents: [
+        `Exec completed (one, code 0) :: ${"a".repeat(2_900)}`,
+        `Exec completed (two, code 0) :: ${"b".repeat(2_900)}`,
+        `Exec completed (three, code 0) :: ${"c".repeat(2_900)}`,
+      ],
+      cronEvents: ["Reminder: rotate logs"],
+      genericEvents: ["Gateway restart ok"],
+    });
+
+    expect(resolution.handledEventIndexes.exec).toEqual([0, 1, 2]);
+    const remainderTexts = resolution.unseenRemainders
+      .filter((remainder) => remainder.kind === "exec")
+      .map((remainder) => remainder.text);
+    expect(remainderTexts.join("").length).toBeGreaterThan(500);
+    expect(remainderTexts.some((text) => text.includes("bbb"))).toBe(true);
+    expect(remainderTexts.some((text) => text.includes("ccc"))).toBe(true);
+    // Exactly one continuation per partially shown exec entry: the single
+    // collector must not duplicate entries also consumed as a class, and the
+    // fully shown first entry needs no continuation.
+    expect(remainderTexts).toHaveLength(2);
+  });
+
+  it("conserves content across both truncation stages for an oversized exec event", () => {
+    const event = `Exec completed (big, code 0) :: ${"Z".repeat(16_400)}`;
+    const resolution = resolveHeartbeatEventPrompt({
+      execEvents: [event],
+      cronEvents: ["Reminder: rotate logs"],
+      genericEvents: ["Gateway restart ok"],
+    });
+
+    expect(resolution.handledEventIndexes.exec).toEqual([0]);
+    expect(
+      resolution.unseenRemainders.filter((remainder) => remainder.kind === "exec"),
+    ).toHaveLength(1);
+    const remainder = resolution.unseenRemainders.find((r) => r.kind === "exec")?.text ?? "";
+    // Shown chunk + remainder covers the original output exactly once.
+    const shown = (resolution.prompt.match(/Z/g) ?? []).length;
+    expect(shown + (remainder.match(/Z/g) ?? []).length).toBe(16_400);
+  });
+
+  it("advances an oversized generic event across successive wakes", () => {
+    const event = `Gateway status ${"Z".repeat(20_000)}`;
+    const first = resolveHeartbeatEventPrompt({ genericEvents: [event] });
+
+    // First wake surfaces a chunk and reports the exact unseen remainder.
+    expect(first.handledEventIndexes.generic).toEqual([0]);
+    const remainder = first.unseenRemainders.find((r) => r.kind === "generic")?.text ?? "";
+    expect(remainder.length).toBeGreaterThan(1_000);
+    const shown = (first.prompt.match(/Z/g) ?? []).length;
+    expect(shown + remainder.length).toBe(20_000);
+
+    // Feeding the remainder back surfaces strictly more content.
+    const second = resolveHeartbeatEventPrompt({
+      genericEvents: [event.slice(0, event.length - remainder.length), remainder],
+    });
+    const secondShown = (second.prompt.match(/Z/g) ?? []).length;
+    expect(secondShown).toBeGreaterThan(0);
+    const totalShownAfterTwo = shown + secondShown;
+    expect(totalShownAfterTwo).toBeGreaterThan(shown);
+  });
+
+  it("keeps a full composed batch within the aggregate limit with a missing-output exec", () => {
+    const resolution = resolveHeartbeatEventPrompt({
+      execEvents: [
+        "Exec failed (audit, code 1)",
+        `Exec completed (logs, code 0) :: ${"L".repeat(7_000)}`,
+      ],
+      cronEvents: [`Reminder: send the overnight report ${"R".repeat(7_000)}`],
+      genericEvents: [`Gateway restart ${"G".repeat(7_000)}`],
+    });
+
+    expect(resolution.prompt.length).toBeLessThanOrEqual(16_000);
+    expect(resolution.prompt).toContain("without captured stdout/stderr");
+    expect(resolution.handledEventIndexes.exec).toEqual([0, 1]);
+  });
+
+  it("keeps combined truncation gaps in source order", () => {
+    const resolution = resolveHeartbeatEventPrompt({
+      cronEvents: ["Reminder: rotate logs"],
+      genericEvents: [`${"A".repeat(7_900)}${"B".repeat(4_500)}`],
+    });
+
+    expect(resolution.prompt).toContain("[truncated]");
+    const genericRemainder = resolution.unseenRemainders.find(
+      (remainder) => remainder.kind === "generic",
+    );
+    expect(genericRemainder?.text).toMatch(/^A+B+$/);
+    expect(genericRemainder?.text.length).toBeGreaterThan(4_000);
+  });
+
+  it("decides silence once for a quiet exec plus reminder batch", () => {
+    const resolution = resolveHeartbeatEventPrompt({
+      execEvents: ["Exec completed (abc12345, code 0)"],
+      cronEvents: ["Reminder: send the overnight report"],
+      deliverToUser: true,
+      useHeartbeatResponseTool: false,
+    });
+
+    expect(resolution.prompt).toContain("Reminder: send the overnight report");
+    expect(resolution.prompt).toContain("no command output was found");
+    expect(resolution.prompt).not.toContain("Reply NO_REPLY only");
+    expect(resolution.handledEventIndexes.exec).toEqual([0]);
+    expect(resolution.handledEventIndexes.cron).toEqual([0]);
+    expect(
+      resolution.prompt.match(/reply NO_REPLY/g)?.length ?? 0,
+      "the batch completion policy mentions NO_REPLY exactly once",
+    ).toBe(1);
+  });
+
+  it("keeps the silence decision for a quiet-only batch", () => {
+    const resolution = resolveHeartbeatEventPrompt({
+      execEvents: ["Exec completed (abc12345, code 0)"],
+      cronEvents: [""],
+      deliverToUser: true,
+      useHeartbeatResponseTool: false,
+    });
+
+    expect(resolution.prompt).toContain("no command output was found");
+    expect(resolution.prompt).toContain("no event content was found");
+    expect(resolution.prompt).toContain("Reply NO_REPLY");
+    expect(resolution.handledEventIndexes.exec).toEqual([0]);
+    expect(resolution.handledEventIndexes.cron).toEqual([0]);
+  });
+
+  it("decides silence once for an internal-only mixed batch", () => {
+    const resolution = resolveHeartbeatEventPrompt({
+      execEvents: ["Exec completed (abc12345, code 0)"],
+      cronEvents: ["Reminder: send the overnight report"],
+      deliverToUser: false,
+      useHeartbeatResponseTool: false,
+    });
+
+    expect(resolution.prompt).toContain("Reminder: send the overnight report");
+    expect(resolution.prompt).not.toContain("Please relay this reminder");
+    expect(resolution.prompt).not.toContain("Reply NO_REPLY only");
+    expect(resolution.prompt).toContain("reply NO_REPLY");
   });
 
   it("embeds generic system events in the heartbeat prompt", () => {

--- a/src/infra/heartbeat-events-filter.test.ts
+++ b/src/infra/heartbeat-events-filter.test.ts
@@ -1,11 +1,17 @@
 // Covers heartbeat event prompt filtering.
 import { describe, expect, it } from "vitest";
 import {
-  buildHeartbeatEventPrompt,
   isCronSystemEvent,
   isExecCompletionEvent,
   isRelayableExecCompletionEvent,
+  resolveHeartbeatEventPrompt,
 } from "./heartbeat-events-filter.js";
+
+function buildHeartbeatEventPrompt(
+  params: Parameters<typeof resolveHeartbeatEventPrompt>[0],
+): string {
+  return resolveHeartbeatEventPrompt(params).prompt;
+}
 
 describe("heartbeat event prompts", () => {
   it.each([
@@ -170,6 +176,52 @@ describe("heartbeat event prompts", () => {
     expect(prompt.length).toBeLessThanOrEqual(16_000);
     expect(prompt).toContain("[truncated]");
     expect(prompt).toContain("Please relay this reminder to the user");
+  });
+
+  it.each([
+    {
+      name: "exec",
+      params: {
+        execEvents: [`Exec finished: ${"e".repeat(8_100)}`, "Exec finished: omitted"],
+      },
+      kind: "exec" as const,
+    },
+    {
+      name: "generic",
+      params: {
+        genericEvents: [`Gateway startup ${"g".repeat(8_100)}`, "Gateway restart omitted"],
+      },
+      kind: "generic" as const,
+    },
+  ])("tracks the $name entries retained by its class budget", ({ params, kind }) => {
+    const resolution = resolveHeartbeatEventPrompt(params);
+
+    expect(resolution.prompt).toContain("[truncated]");
+    expect(resolution.prompt).not.toContain("omitted");
+    expect(resolution.handledEventIndexes[kind]).toEqual([0]);
+  });
+
+  it("tracks cron entries retained by aggregate head and tail truncation", () => {
+    const resolution = resolveHeartbeatEventPrompt({
+      cronEvents: [
+        `First reminder ${"a".repeat(12_000)}`,
+        "Middle reminder omitted",
+        `Last reminder ${"z".repeat(12_000)}`,
+      ],
+    });
+
+    expect(resolution.prompt).toContain("[truncated]");
+    expect(resolution.prompt).not.toContain("Middle reminder omitted");
+    expect(resolution.handledEventIndexes.cron).toEqual([0, 2]);
+  });
+
+  it("keeps metadata-only exec completions explicitly handled", () => {
+    const resolution = resolveHeartbeatEventPrompt({
+      execEvents: ["Exec completed (abc12345, code 0)"],
+    });
+
+    expect(resolution.prompt).toContain("no command output was found");
+    expect(resolution.handledEventIndexes.exec).toEqual([0]);
   });
 
   it("embeds generic system events in the heartbeat prompt", () => {

--- a/src/infra/heartbeat-events-filter.test.ts
+++ b/src/infra/heartbeat-events-filter.test.ts
@@ -1,6 +1,7 @@
 // Covers heartbeat event prompt filtering.
 import { describe, expect, it } from "vitest";
 import {
+  buildHeartbeatEventPrompt,
   buildCronEventPrompt,
   buildExecEventPrompt,
   buildSystemEventPrompt,
@@ -127,6 +128,19 @@ describe("heartbeat event prompts", () => {
     expect(prompt).toContain("heartbeat_respond");
     expect(prompt).toContain("notify=false");
     expect(prompt).not.toContain("HEARTBEAT_OK");
+  });
+
+  it("composes generic, exec, and cron events in one heartbeat prompt", () => {
+    const prompt = buildHeartbeatEventPrompt({
+      execEvents: ["Exec failed (backup, code 1) :: backup failed"],
+      cronEvents: ["Cron: send the overnight report"],
+      genericEvents: ["Gateway restart ok"],
+    });
+
+    expect(prompt).toContain("Multiple heartbeat events were triggered");
+    expect(prompt).toContain("backup failed");
+    expect(prompt).toContain("Cron: send the overnight report");
+    expect(prompt).toContain("Gateway restart ok");
   });
 
   it("embeds generic system events in the heartbeat prompt", () => {

--- a/src/infra/heartbeat-events-filter.test.ts
+++ b/src/infra/heartbeat-events-filter.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildCronEventPrompt,
   buildExecEventPrompt,
+  buildSystemEventPrompt,
   isCronSystemEvent,
   isExecCompletionEvent,
   isRelayableExecCompletionEvent,
@@ -126,6 +127,33 @@ describe("heartbeat event prompts", () => {
     expect(prompt).toContain("heartbeat_respond");
     expect(prompt).toContain("notify=false");
     expect(prompt).not.toContain("HEARTBEAT_OK");
+  });
+
+  it("embeds generic system events in the heartbeat prompt", () => {
+    const prompt = buildSystemEventPrompt(["Gateway restart ok"]);
+
+    expect(prompt).toContain("Gateway restart ok");
+    expect(prompt).toContain("user-facing follow-up");
+  });
+
+  it("keeps generic system prompt output bounded", () => {
+    const prompt = buildSystemEventPrompt(["x".repeat(8_100)]);
+
+    expect(prompt).toContain("[truncated]");
+    expect(prompt.length).toBeLessThan(8_500);
+  });
+
+  it("compacts legacy heartbeat metadata in generic system prompts", () => {
+    const prompt = buildSystemEventPrompt([
+      "Node: connected · last input 2026-08-29T00:00:00Z",
+      "heartbeat poll: noop",
+      "Gateway restart ok",
+    ]);
+
+    expect(prompt).toContain("Node: connected");
+    expect(prompt).not.toContain("last input");
+    expect(prompt).not.toContain("heartbeat poll");
+    expect(prompt).toContain("Gateway restart ok");
   });
 });
 

--- a/src/infra/heartbeat-events-filter.test.ts
+++ b/src/infra/heartbeat-events-filter.test.ts
@@ -2,9 +2,6 @@
 import { describe, expect, it } from "vitest";
 import {
   buildHeartbeatEventPrompt,
-  buildCronEventPrompt,
-  buildExecEventPrompt,
-  buildSystemEventPrompt,
   isCronSystemEvent,
   isExecCompletionEvent,
   isRelayableExecCompletionEvent,
@@ -39,7 +36,7 @@ describe("heartbeat event prompts", () => {
       unexpected: ["Please relay this reminder to the user"],
     },
   ])("$name", ({ events, opts, expected, unexpected }) => {
-    const prompt = buildCronEventPrompt(events, opts);
+    const prompt = buildHeartbeatEventPrompt({ cronEvents: events, ...opts });
     for (const part of expected) {
       expect(prompt).toContain(part);
     }
@@ -98,7 +95,7 @@ describe("heartbeat event prompts", () => {
       unexpected: ["Please relay the command output to the user"],
     },
   ])("$name", ({ events, opts, expected, unexpected }) => {
-    const prompt = buildExecEventPrompt(events, opts);
+    const prompt = buildHeartbeatEventPrompt({ execEvents: events, ...opts });
     for (const part of expected) {
       expect(prompt).toContain(part);
     }
@@ -108,14 +105,19 @@ describe("heartbeat event prompts", () => {
   });
 
   it("truncates oversized user-relay exec prompt output", () => {
-    const prompt = buildExecEventPrompt([`Exec finished: ${"x".repeat(8_100)}`]);
+    const prompt = buildHeartbeatEventPrompt({
+      execEvents: [`Exec finished: ${"x".repeat(8_100)}`],
+    });
 
     expect(prompt).toContain("[truncated]");
     expect(prompt.length).toBeLessThan(8_500);
   });
 
   it("uses heartbeat_respond for empty cron events in response-tool mode", () => {
-    const prompt = buildCronEventPrompt([""], { useHeartbeatResponseTool: true });
+    const prompt = buildHeartbeatEventPrompt({
+      cronEvents: [""],
+      useHeartbeatResponseTool: true,
+    });
 
     expect(prompt).toContain("heartbeat_respond");
     expect(prompt).toContain("notify=false");
@@ -123,7 +125,10 @@ describe("heartbeat event prompts", () => {
   });
 
   it("uses heartbeat_respond for quiet exec completion events in response-tool mode", () => {
-    const prompt = buildExecEventPrompt([""], { useHeartbeatResponseTool: true });
+    const prompt = buildHeartbeatEventPrompt({
+      execEvents: [""],
+      useHeartbeatResponseTool: true,
+    });
 
     expect(prompt).toContain("heartbeat_respond");
     expect(prompt).toContain("notify=false");
@@ -143,26 +148,52 @@ describe("heartbeat event prompts", () => {
     expect(prompt).toContain("Gateway restart ok");
   });
 
+  it("bounds mixed heartbeat event prompts with one aggregate limit", () => {
+    const prompt = buildHeartbeatEventPrompt({
+      execEvents: [`Exec failed (backup, code 1) :: ${"e".repeat(9_000)}`],
+      cronEvents: [`Reminder: ${"c".repeat(9_000)}`],
+      genericEvents: [`Gateway restart ${"g".repeat(9_000)}`],
+    });
+
+    expect(prompt.length).toBeLessThanOrEqual(16_000);
+    expect(prompt).toContain("[truncated]");
+    expect(prompt).toContain("An async command");
+    expect(prompt).toContain("A scheduled reminder");
+    expect(prompt).toContain("A system event");
+  });
+
+  it("bounds a single untagged cron event prompt", () => {
+    const prompt = buildHeartbeatEventPrompt({
+      cronEvents: [`Reminder: ${"c".repeat(20_000)}`],
+    });
+
+    expect(prompt.length).toBeLessThanOrEqual(16_000);
+    expect(prompt).toContain("[truncated]");
+    expect(prompt).toContain("Please relay this reminder to the user");
+  });
+
   it("embeds generic system events in the heartbeat prompt", () => {
-    const prompt = buildSystemEventPrompt(["Gateway restart ok"]);
+    const prompt = buildHeartbeatEventPrompt({ genericEvents: ["Gateway restart ok"] });
 
     expect(prompt).toContain("Gateway restart ok");
     expect(prompt).toContain("user-facing follow-up");
   });
 
   it("keeps generic system prompt output bounded", () => {
-    const prompt = buildSystemEventPrompt(["x".repeat(8_100)]);
+    const prompt = buildHeartbeatEventPrompt({ genericEvents: ["x".repeat(8_100)] });
 
     expect(prompt).toContain("[truncated]");
     expect(prompt.length).toBeLessThan(8_500);
   });
 
   it("compacts legacy heartbeat metadata in generic system prompts", () => {
-    const prompt = buildSystemEventPrompt([
-      "Node: connected · last input 2026-08-29T00:00:00Z",
-      "heartbeat poll: noop",
-      "Gateway restart ok",
-    ]);
+    const prompt = buildHeartbeatEventPrompt({
+      genericEvents: [
+        "Node: connected · last input 2026-08-29T00:00:00Z",
+        "heartbeat poll: noop",
+        "Gateway restart ok",
+      ],
+    });
 
     expect(prompt).toContain("Node: connected");
     expect(prompt).not.toContain("last input");
@@ -259,14 +290,14 @@ describe("isExecCompletionEvent", () => {
 describe("buildExecEventPrompt truncation", () => {
   it("does not split surrogate pairs in long event text", () => {
     const safePrefix = "x".repeat(7_999);
-    const result = buildExecEventPrompt([`${safePrefix}🚀tail`]);
+    const result = buildHeartbeatEventPrompt({ execEvents: [`${safePrefix}🚀tail`] });
 
     expect(result).toContain(`${safePrefix}\n\n[truncated]`);
     expect(result).not.toContain("🚀tail");
   });
 
   it("passes through short event text unchanged", () => {
-    const result = buildExecEventPrompt(["hello"]);
+    const result = buildHeartbeatEventPrompt({ execEvents: ["hello"] });
     expect(result).toContain("hello");
     expect(result).not.toContain("[truncated]");
   });

--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -29,23 +29,61 @@ type EventPromptSpan = {
   eventIndex: number;
   start: number;
   end: number;
+  /**
+   * Length in the pre-truncation source. Retention decisions compare against
+   * this even after later stages clip `end`, so gap attribution survives both
+   * truncation stages.
+   */
+  originalLength: number;
 };
 
 type EventPromptText = {
   text: string;
   spans: EventPromptSpan[];
   implicitEventIndexes: number[];
+  /** Event content that truncation dropped, keyed by event index. */
+  unseenEventSuffixes: Map<number, string>;
+};
+
+type UnseenEventRemainder = {
+  kind: HeartbeatEventClass;
+  eventIndex: number;
+  text: string;
 };
 
 type HeartbeatEventPromptSection = EventPromptText & {
   kind: HeartbeatEventClass;
+  /** Whether the section carries event content the user may need delivered. */
+  hasDeliverableContent: boolean;
+  /**
+   * Framing appended after the event content. It is excluded from truncation
+   * budget math so the retained-event selection cannot depend on delivery or
+   * response-tool mode.
+   */
+  suffix: string;
 };
 
 export type HeartbeatEventPromptResolution = {
   prompt: string;
   handledEventIndexes: Record<HeartbeatEventClass, number[]>;
+  /**
+   * Content of handled events that truncation hid from the model. Callers must
+   * re-queue these remainders when consuming the originals so partially shown
+   * events are never silently dropped.
+   */
+  unseenRemainders: UnseenEventRemainder[];
 };
 
+/**
+ * Reserved framing budget so a section's truncation boundary (and therefore
+ * which events count as surfaced) is identical across delivery modes.
+ */
+const MAX_SECTION_SUFFIX_CHARS = 256;
+
+/**
+ * An event counts as surfaced only when at least half of its content survives
+ * truncation; a bisected fragment must never mark the whole entry handled.
+ */
 function joinEventPromptLines(lines: readonly (string | null)[]): EventPromptText {
   let text = "";
   const spans: EventPromptSpan[] = [];
@@ -60,9 +98,10 @@ function joinEventPromptLines(lines: readonly (string | null)[]): EventPromptTex
     }
     const start = text.length;
     text += line;
-    spans.push({ eventIndex, start, end: text.length });
+    const end = text.length;
+    spans.push({ eventIndex, start, end, originalLength: end - start });
   }
-  return { text, spans, implicitEventIndexes };
+  return { text, spans, implicitEventIndexes, unseenEventSuffixes: new Map() };
 }
 
 function truncateEventPromptText(value: EventPromptText, maxChars: number): EventPromptText {
@@ -70,13 +109,27 @@ function truncateEventPromptText(value: EventPromptText, maxChars: number): Even
     return value;
   }
   const text = truncateUtf16Safe(value.text, maxChars);
+  const unseenEventSuffixes = new Map(value.unseenEventSuffixes);
+  for (const span of value.spans) {
+    if (span.end > text.length && span.start < text.length) {
+      unseenEventSuffixes.set(
+        span.eventIndex,
+        (unseenEventSuffixes.get(span.eventIndex) ?? "") + value.text.slice(text.length, span.end),
+      );
+    } else if (span.start >= text.length) {
+      // Wholly dropped events keep their full text unseen; the caller decides
+      // whether they count as handled at all.
+      unseenEventSuffixes.set(span.eventIndex, value.text.slice(span.start, span.end));
+    }
+  }
   return {
     text: `${text}\n\n[truncated]`,
-    spans: value.spans.flatMap((span) => {
-      const end = Math.min(span.end, text.length);
-      return span.start < end ? [{ ...span, end }] : [];
-    }),
+    // Spans survive every truncation stage (with clipped ends) so later stages
+    // can still attribute hidden ranges to their events; handling is decided
+    // per consumer against originalLength, not by dropping metadata here.
+    spans: value.spans.map((span) => ({ ...span, end: Math.min(span.end, text.length) })),
     implicitEventIndexes: value.implicitEventIndexes,
+    unseenEventSuffixes,
   };
 }
 
@@ -85,17 +138,28 @@ function wrapEventPromptText(params: {
   prefix: string;
   eventText: EventPromptText;
   suffix: string;
+  hasDeliverableContent?: boolean;
+  /**
+   * When set, the suffix is subtracted from the truncation budget (its length
+   * is part of the constant section reserve) instead of being appended past the
+   * bounded body, so composed batches never exceed the aggregate limit.
+   */
+  boundSuffix?: boolean;
 }): HeartbeatEventPromptSection {
   const offset = params.prefix.length;
+  const suffix = params.boundSuffix ? params.suffix : "";
   return {
     kind: params.kind,
-    text: `${params.prefix}${params.eventText.text}${params.suffix}`,
+    text: `${params.prefix}${params.eventText.text}${suffix}`,
+    suffix: params.boundSuffix ? "" : params.suffix,
     spans: params.eventText.spans.map((span) => ({
       ...span,
       start: span.start + offset,
       end: span.end + offset,
     })),
     implicitEventIndexes: params.eventText.implicitEventIndexes,
+    unseenEventSuffixes: params.eventText.unseenEventSuffixes,
+    hasDeliverableContent: params.hasDeliverableContent ?? params.eventText.text.length > 0,
   };
 }
 
@@ -103,12 +167,16 @@ function buildImplicitEventPromptSection(params: {
   kind: HeartbeatEventClass;
   text: string;
   eventCount: number;
+  hasDeliverableContent?: boolean;
 }): HeartbeatEventPromptSection {
   return {
     kind: params.kind,
     text: params.text,
+    suffix: "",
     spans: [],
     implicitEventIndexes: Array.from({ length: params.eventCount }, (_, index) => index),
+    unseenEventSuffixes: new Map(),
+    hasDeliverableContent: params.hasDeliverableContent ?? false,
   };
 }
 
@@ -172,10 +240,14 @@ function buildCronEventPrompt(
   opts?: {
     deliverToUser?: boolean;
     useHeartbeatResponseTool?: boolean;
+    standalone?: boolean;
   },
 ): HeartbeatEventPromptSection {
   const deliverToUser = opts?.deliverToUser ?? true;
   const useHeartbeatResponseTool = opts?.useHeartbeatResponseTool ?? false;
+  // Standalone sections carry their own completion directive; composed batches
+  // decide silence once for the whole turn.
+  const standalone = opts?.standalone ?? true;
   const eventText = joinEventPromptLines(pendingEvents.map((event) => event.trim() || null));
   if (!eventText.text) {
     const completionInstruction = useHeartbeatResponseTool
@@ -185,7 +257,9 @@ function buildCronEventPrompt(
         : `Handle this internally and reply ${SILENT_REPLY_TOKEN} when nothing needs user-facing follow-up.`;
     return buildImplicitEventPromptSection({
       kind: "cron",
-      text: `A scheduled cron event was triggered, but no event content was found. ${completionInstruction}`,
+      text: `A scheduled cron event was triggered, but no event content was found.${
+        standalone ? ` ${completionInstruction}` : ""
+      }`,
       eventCount: pendingEvents.length,
     });
   }
@@ -193,18 +267,27 @@ function buildCronEventPrompt(
     kind: "cron",
     prefix: "A scheduled reminder has been triggered. The reminder content is:\n\n",
     eventText,
-    suffix: deliverToUser
-      ? "\n\nPlease relay this reminder to the user in a helpful and friendly way."
-      : "\n\nHandle this reminder internally. Do not relay it to the user unless explicitly requested.",
+    suffix: standalone
+      ? deliverToUser
+        ? "\n\nPlease relay this reminder to the user in a helpful and friendly way."
+        : "\n\nHandle this reminder internally. Do not relay it to the user unless explicitly requested."
+      : "",
   });
 }
 
 function buildExecEventPrompt(
   pendingEvents: string[],
-  opts?: { deliverToUser?: boolean; useHeartbeatResponseTool?: boolean },
+  opts?: {
+    deliverToUser?: boolean;
+    useHeartbeatResponseTool?: boolean;
+    standalone?: boolean;
+  },
 ): HeartbeatEventPromptSection {
   const deliverToUser = opts?.deliverToUser ?? true;
   const useHeartbeatResponseTool = opts?.useHeartbeatResponseTool ?? false;
+  // Standalone sections carry their own completion directive; composed batches
+  // decide silence once for the whole turn.
+  const standalone = opts?.standalone ?? true;
   const formatted = formatExecEventPromptText(pendingEvents);
   const eventText = truncateEventPromptText(formatted, MAX_EXEC_EVENT_PROMPT_CHARS);
   if (!eventText.text) {
@@ -213,21 +296,28 @@ function buildExecEventPrompt(
       : `Reply ${SILENT_REPLY_TOKEN} only.`;
     return buildImplicitEventPromptSection({
       kind: "exec",
-      text: `An async command completion event was triggered, but no command output was found. ${completionInstruction} Do not mention, summarize, or reuse output from any earlier run.`,
+      text: `An async command completion event was triggered, but no command output was found.${
+        standalone ? ` ${completionInstruction}` : ""
+      } Do not mention, summarize, or reuse output from any earlier run.`,
       eventCount: pendingEvents.length,
     });
   }
   if (!deliverToUser) {
-    const text = useHeartbeatResponseTool
-      ? "An async command completion event was triggered, but user delivery is disabled for this run. " +
-        `Handle the result internally. ${HEARTBEAT_RESPONSE_TOOL_INSTRUCTIONS} ` +
-        "Do not mention, summarize, or reuse command output."
-      : "An async command completion event was triggered, but user delivery is disabled for this run. " +
-        `Handle the result internally and reply ${SILENT_REPLY_TOKEN} only. Do not mention, summarize, or reuse command output.`;
+    const text =
+      "An async command completion event was triggered, but user delivery is disabled for this run. " +
+      (useHeartbeatResponseTool
+        ? standalone
+          ? `Handle the result internally. ${HEARTBEAT_RESPONSE_TOOL_INSTRUCTIONS} `
+          : ""
+        : standalone
+          ? `Handle the result internally and reply ${SILENT_REPLY_TOKEN} only. `
+          : "") +
+      "Do not mention, summarize, or reuse command output.";
     return buildImplicitEventPromptSection({
       kind: "exec",
       text,
       eventCount: pendingEvents.length,
+      hasDeliverableContent: true,
     });
   }
   if (formatted.hasMissingOutputFailure) {
@@ -239,6 +329,9 @@ function buildExecEventPrompt(
       suffix:
         "\n\nTell the user the command completed without captured output and include the exit status or signal. " +
         "Do not ask the user to provide missing logs, and do not try to retrieve logs from an exec/session id.",
+      // Constant suffix reserve keeps composed-batch budgeting (and therefore
+      // the retained selection) independent of this mode-dependent instruction.
+      boundSuffix: !standalone,
     });
   }
   return wrapEventPromptText({
@@ -246,15 +339,17 @@ function buildExecEventPrompt(
     prefix:
       "An async command you ran earlier has completed. The command completion details are:\n\n",
     eventText,
-    suffix:
-      "\n\nPlease relay the command output to the user in a helpful way. If the command succeeded, share the relevant output. " +
-      "If it failed, explain what went wrong.",
+    suffix: standalone
+      ? "\n\nPlease relay the command output to the user in a helpful way. If the command succeeded, share the relevant output. " +
+        "If it failed, explain what went wrong."
+      : "",
   });
 }
 
 type TruncatedHeartbeatEventPromptSection = {
   text: string;
   handledEventIndexes: number[];
+  unseenEventSuffixes: Map<number, string>;
 };
 
 function truncateHeartbeatEventPromptSection(
@@ -279,14 +374,48 @@ function truncateHeartbeatEventPromptSection(
     }
   }
   const handledEventIndexes = new Set(section.implicitEventIndexes);
+  const unseenEventSuffixes = new Map(section.unseenEventSuffixes);
   for (const span of section.spans) {
-    if (retainedRanges.some((range) => span.start < range.end && span.end > range.start)) {
+    let retainedChars = 0;
+    let unseenGap = "";
+    let covered = span.start;
+    // Retained ranges are ordered head-then-tail; walk them to collect both the
+    // retained length and the gap content truncation hid from this event.
+    for (const range of retainedRanges) {
+      const overlapStart = Math.max(span.start, range.start);
+      const overlapEnd = Math.min(span.end, range.end);
+      if (overlapEnd > overlapStart) {
+        retainedChars += overlapEnd - overlapStart;
+        if (overlapStart > covered) {
+          unseenGap += section.text.slice(covered, overlapStart);
+        }
+        covered = Math.max(covered, overlapEnd);
+      }
+    }
+    if (covered < span.end) {
+      unseenGap += section.text.slice(covered, span.end);
+    }
+    if (unseenGap) {
+      // Record every aggregate gap regardless of the retained threshold: exec
+      // entries are consumed as a class, so even a mostly hidden span needs its
+      // gap re-queued. The aggregate gap sits before any class-cap suffix, so
+      // the combined remainder keeps source order.
+      unseenEventSuffixes.set(
+        span.eventIndex,
+        unseenGap + (unseenEventSuffixes.get(span.eventIndex) ?? ""),
+      );
+    }
+    // An event the model saw any part of is surfaced, together with its exact
+    // hidden remainder; this keeps oversized entries making bounded progress
+    // across successive wakes instead of stalling below a half-retained bar.
+    if (retainedChars > 0) {
       handledEventIndexes.add(span.eventIndex);
     }
   }
   return {
     text,
     handledEventIndexes: [...handledEventIndexes].toSorted((left, right) => left - right),
+    unseenEventSuffixes,
   };
 }
 
@@ -298,19 +427,25 @@ export function resolveHeartbeatEventPrompt(params: {
   deliverToUser?: boolean;
   useHeartbeatResponseTool?: boolean;
 }): HeartbeatEventPromptResolution {
-  const opts = {
-    deliverToUser: params.deliverToUser,
-    useHeartbeatResponseTool: params.useHeartbeatResponseTool,
-  };
+  const deliverToUser = params.deliverToUser ?? true;
+  const useHeartbeatResponseTool = params.useHeartbeatResponseTool ?? false;
+  const opts = { deliverToUser, useHeartbeatResponseTool };
+  const hasExecEvents = (params.execEvents?.length ?? 0) > 0;
+  const hasCronEvents = (params.cronEvents?.length ?? 0) > 0;
+  const hasGenericEvents = (params.genericEvents?.length ?? 0) > 0;
+  // The completion policy is decided once for a composed batch, so no section
+  // carries its own silence or relay directive in that mode.
+  const composedBatch = [hasExecEvents, hasCronEvents, hasGenericEvents].filter(Boolean).length > 1;
+  const sectionOpts = composedBatch ? { ...opts, standalone: false } : opts;
   const sections: HeartbeatEventPromptSection[] = [];
-  if (params.execEvents?.length) {
-    sections.push(buildExecEventPrompt([...params.execEvents], opts));
+  if (hasExecEvents) {
+    sections.push(buildExecEventPrompt([...(params.execEvents ?? [])], sectionOpts));
   }
-  if (params.cronEvents?.length) {
-    sections.push(buildCronEventPrompt([...params.cronEvents], opts));
+  if (hasCronEvents) {
+    sections.push(buildCronEventPrompt([...(params.cronEvents ?? [])], sectionOpts));
   }
-  if (params.genericEvents?.length) {
-    sections.push(buildSystemEventPrompt([...params.genericEvents], opts));
+  if (hasGenericEvents) {
+    sections.push(buildSystemEventPrompt([...(params.genericEvents ?? [])], sectionOpts));
   }
   if (sections.length === 0) {
     sections.push(buildSystemEventPrompt([], opts));
@@ -320,46 +455,119 @@ export function resolveHeartbeatEventPrompt(params: {
     cron: [],
     generic: [],
   };
+  const unseenRemainders: UnseenEventRemainder[] = [];
+  // One collector per section: exec entries are additionally consumed as a
+  // class via allEventIndexes below, so their remainders must be gathered from
+  // every handled index exactly once.
+  const collectRemainders = (
+    section: HeartbeatEventPromptSection,
+    truncated: TruncatedHeartbeatEventPromptSection,
+  ) => {
+    for (const index of truncated.handledEventIndexes) {
+      const unseen = truncated.unseenEventSuffixes.get(index);
+      if (unseen) {
+        unseenRemainders.push({ kind: section.kind, eventIndex: index, text: unseen });
+      }
+    }
+  };
   if (sections.length === 1) {
     const section = sections[0];
     if (!section) {
-      return { prompt: "", handledEventIndexes };
+      return { prompt: "", handledEventIndexes, unseenRemainders: [] };
     }
+    // Reserve a constant framing budget so the truncation boundary never
+    // depends on the mode-dependent suffix the model actually receives.
     const truncated = truncateHeartbeatEventPromptSection(
       section,
-      MAX_HEARTBEAT_EVENT_PROMPT_CHARS,
+      MAX_HEARTBEAT_EVENT_PROMPT_CHARS - MAX_SECTION_SUFFIX_CHARS,
     );
-    handledEventIndexes[section.kind] = truncated.handledEventIndexes;
-    return { prompt: truncated.text, handledEventIndexes };
+    if (hasExecEvents) {
+      handledEventIndexes.exec = allEventIndexes(params.execEvents);
+    } else {
+      handledEventIndexes[section.kind] = truncated.handledEventIndexes;
+    }
+    collectRemainders(section, {
+      ...truncated,
+      handledEventIndexes: hasExecEvents
+        ? allEventIndexes(params.execEvents)
+        : truncated.handledEventIndexes,
+    });
+    return { prompt: truncated.text + section.suffix, handledEventIndexes, unseenRemainders };
   }
+  const batchCompletionInstruction = useHeartbeatResponseTool
+    ? HEARTBEAT_RESPONSE_TOOL_INSTRUCTIONS
+    : deliverToUser
+      ? sections.some((section) => section.hasDeliverableContent)
+        ? "Handle every event above. Relay the reminders and command results that need the user's attention, and reply " +
+          `${SILENT_REPLY_TOKEN} only if nothing needs user-facing follow-up.`
+        : `Reply ${SILENT_REPLY_TOKEN} only after handling the events above.`
+      : `Handle every event above internally. Do not relay anything to the user unless explicitly requested, and reply ${SILENT_REPLY_TOKEN} when done.`;
   const header =
     "Multiple heartbeat events were triggered. Assess each event and handle every event shown below.";
   const separator = "\n\n";
+  // Reserve the longest possible completion instruction so the per-section
+  // budget (and therefore the retained-event selection) is identical across
+  // relay, internal-only, and response-tool modes.
   const sectionBudget = Math.max(
     1,
     Math.floor(
-      (MAX_HEARTBEAT_EVENT_PROMPT_CHARS - header.length - separator.length * sections.length) /
+      (MAX_HEARTBEAT_EVENT_PROMPT_CHARS -
+        header.length -
+        MAX_BATCH_COMPLETION_INSTRUCTION_CHARS -
+        separator.length * (sections.length + 1)) /
         sections.length,
     ),
   );
   const truncatedSections = sections.map((section) => {
     const truncated = truncateHeartbeatEventPromptSection(section, sectionBudget);
-    handledEventIndexes[section.kind] = truncated.handledEventIndexes;
-    return truncated.text;
+    const effectiveHandled =
+      section.kind === "exec" && hasExecEvents
+        ? allEventIndexes(params.execEvents)
+        : truncated.handledEventIndexes;
+    handledEventIndexes[section.kind] = effectiveHandled;
+    collectRemainders(section, { ...truncated, handledEventIndexes: effectiveHandled });
+    return truncated.text + section.suffix;
   });
   return {
-    prompt: [header, ...truncatedSections].join(separator),
+    prompt: [header, ...truncatedSections, batchCompletionInstruction].join(separator),
     handledEventIndexes,
+    unseenRemainders,
   };
+}
+
+const MAX_BATCH_COMPLETION_INSTRUCTION_CHARS = Math.max(
+  HEARTBEAT_RESPONSE_TOOL_INSTRUCTIONS.length,
+  `Handle every event above. Relay the reminders and command results that need the user's attention, and reply ${SILENT_REPLY_TOKEN} only if nothing needs user-facing follow-up.`
+    .length,
+  `Reply ${SILENT_REPLY_TOKEN} only after handling the events above.`.length,
+  `Handle every event above internally. Do not relay anything to the user unless explicitly requested, and reply ${SILENT_REPLY_TOKEN} when done.`
+    .length,
+);
+
+/**
+ * Exec completion entries are consumed as a class whenever their section is
+ * present: rendering truncation bounds what the model sees, but ordinary reply
+ * admission never drains exec completions, so per-entry retention would strand
+ * truncated entries with no future owner.
+ */
+function allEventIndexes(events: readonly string[] | undefined): number[] {
+  return Array.from({ length: events?.length ?? 0 }, (_, index) => index);
 }
 
 /** Build a heartbeat prompt for system events that are not owned by exec or cron. */
 function buildSystemEventPrompt(
   pendingEvents: string[],
-  opts?: { deliverToUser?: boolean; useHeartbeatResponseTool?: boolean },
+  opts?: {
+    deliverToUser?: boolean;
+    useHeartbeatResponseTool?: boolean;
+    standalone?: boolean;
+  },
 ): HeartbeatEventPromptSection {
   const deliverToUser = opts?.deliverToUser ?? true;
   const useHeartbeatResponseTool = opts?.useHeartbeatResponseTool ?? false;
+  // Standalone sections carry their own completion directive; composed batches
+  // decide silence once for the whole turn.
+  const standalone = opts?.standalone ?? true;
   const eventText = truncateEventPromptText(
     joinEventPromptLines(pendingEvents.map(compactSystemEvent)),
     MAX_SYSTEM_EVENT_PROMPT_CHARS,
@@ -370,7 +578,9 @@ function buildSystemEventPrompt(
       : `Reply ${SILENT_REPLY_TOKEN} only.`;
     return buildImplicitEventPromptSection({
       kind: "generic",
-      text: `A system event was triggered, but no event content was found. ${completionInstruction}`,
+      text: `A system event was triggered, but no event content was found.${
+        standalone ? ` ${completionInstruction}` : ""
+      }`,
       eventCount: pendingEvents.length,
     });
   }
@@ -381,13 +591,15 @@ function buildSystemEventPrompt(
     kind: "generic",
     prefix: "A system event was triggered. The event details are:\n\n",
     eventText,
-    suffix: deliverToUser
-      ? "\n\nAssess whether this event needs user-facing follow-up. If it does, explain it helpfully; otherwise " +
-        completionInstruction +
-        "."
-      : "\n\nHandle this event internally. Do not relay it to the user unless explicitly requested. " +
-        completionInstruction +
-        ".",
+    suffix: standalone
+      ? deliverToUser
+        ? "\n\nAssess whether this event needs user-facing follow-up. If it does, explain it helpfully; otherwise " +
+          completionInstruction +
+          "."
+        : "\n\nHandle this event internally. Do not relay it to the user unless explicitly requested. " +
+          completionInstruction +
+          "."
+      : "",
   });
 }
 

--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -1,6 +1,6 @@
 // Filters heartbeat event text before it is added to prompts.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   HEARTBEAT_RESPONSE_TOOL_INSTRUCTIONS,
   isHeartbeatAcknowledgementText,
@@ -9,6 +9,7 @@ import { HEARTBEAT_TOKEN, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 
 const MAX_EXEC_EVENT_PROMPT_CHARS = 8_000;
 const MAX_SYSTEM_EVENT_PROMPT_CHARS = 8_000;
+const MAX_HEARTBEAT_EVENT_PROMPT_CHARS = 16_000;
 export const HEARTBEAT_DELIVERY_CONTEXT_KEY_PREFIX = "heartbeat-delivery:";
 const STRUCTURED_EXEC_COMPLETION_EVENT_RE =
   /^exec (completed|failed) \(([a-z0-9_-]{1,64}), (code -?\d+|signal [^)]+)\)(?: :: ([\s\S]*))?$/i;
@@ -79,7 +80,7 @@ function formatExecEventPromptText(pendingEvents: string[]): {
 // Build a dynamic prompt for cron events by embedding the actual event content.
 // This ensures the model sees the reminder text directly instead of relying on
 // "shown in the system messages above" which may not be visible in context.
-export function buildCronEventPrompt(
+function buildCronEventPrompt(
   pendingEvents: string[],
   opts?: {
     deliverToUser?: boolean;
@@ -111,7 +112,7 @@ export function buildCronEventPrompt(
   );
 }
 
-export function buildExecEventPrompt(
+function buildExecEventPrompt(
   pendingEvents: string[],
   opts?: { deliverToUser?: boolean; useHeartbeatResponseTool?: boolean },
 ): string {
@@ -181,16 +182,42 @@ export function buildHeartbeatEventPrompt(params: {
   if (params.genericEvents?.length) {
     sections.push(buildSystemEventPrompt([...params.genericEvents], opts));
   }
-  return sections.length > 1
-    ? [
-        "Multiple heartbeat events were triggered. Assess each event and handle every event shown below.",
-        ...sections,
-      ].join("\n\n")
-    : (sections[0] ?? buildSystemEventPrompt([], opts));
+  if (sections.length === 0) {
+    return buildSystemEventPrompt([], opts);
+  }
+  if (sections.length === 1) {
+    return truncateHeartbeatEventPromptSection(sections[0], MAX_HEARTBEAT_EVENT_PROMPT_CHARS);
+  }
+  const header =
+    "Multiple heartbeat events were triggered. Assess each event and handle every event shown below.";
+  const separator = "\n\n";
+  const sectionBudget = Math.max(
+    1,
+    Math.floor(
+      (MAX_HEARTBEAT_EVENT_PROMPT_CHARS - header.length - separator.length * sections.length) /
+        sections.length,
+    ),
+  );
+  return [
+    header,
+    ...sections.map((section) => truncateHeartbeatEventPromptSection(section, sectionBudget)),
+  ].join(separator);
+}
+
+function truncateHeartbeatEventPromptSection(section: string, maxChars: number): string {
+  if (section.length <= maxChars) {
+    return section;
+  }
+  const marker = "\n\n[truncated]\n\n";
+  const bodyBudget = Math.max(0, maxChars - marker.length);
+  const headBudget = Math.ceil(bodyBudget * 0.7);
+  const tailBudget = bodyBudget - headBudget;
+  const tail = tailBudget > 0 ? sliceUtf16Safe(section, -tailBudget) : "";
+  return `${truncateUtf16Safe(section, headBudget)}${marker}${tail}`;
 }
 
 /** Build a heartbeat prompt for system events that are not owned by exec or cron. */
-export function buildSystemEventPrompt(
+function buildSystemEventPrompt(
   pendingEvents: string[],
   opts?: { deliverToUser?: boolean; useHeartbeatResponseTool?: boolean },
 ): string {

--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -186,7 +186,9 @@ export function buildHeartbeatEventPrompt(params: {
     return buildSystemEventPrompt([], opts);
   }
   if (sections.length === 1) {
-    return truncateHeartbeatEventPromptSection(sections[0], MAX_HEARTBEAT_EVENT_PROMPT_CHARS);
+    const [onlySection] = sections;
+    if (!onlySection) return buildSystemEventPrompt([], opts);
+    return truncateHeartbeatEventPromptSection(onlySection, MAX_HEARTBEAT_EVENT_PROMPT_CHARS);
   }
   const header =
     "Multiple heartbeat events were triggered. Assess each event and handle every event shown below.";

--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -23,6 +23,95 @@ type StructuredExecCompletionEvent = {
   succeeded: boolean;
 };
 
+type HeartbeatEventClass = "exec" | "cron" | "generic";
+
+type EventPromptSpan = {
+  eventIndex: number;
+  start: number;
+  end: number;
+};
+
+type EventPromptText = {
+  text: string;
+  spans: EventPromptSpan[];
+  implicitEventIndexes: number[];
+};
+
+type HeartbeatEventPromptSection = EventPromptText & {
+  kind: HeartbeatEventClass;
+};
+
+export type HeartbeatEventPromptResolution = {
+  prompt: string;
+  handledEventIndexes: Record<HeartbeatEventClass, number[]>;
+};
+
+function joinEventPromptLines(lines: readonly (string | null)[]): EventPromptText {
+  let text = "";
+  const spans: EventPromptSpan[] = [];
+  const implicitEventIndexes: number[] = [];
+  for (const [eventIndex, line] of lines.entries()) {
+    if (!line) {
+      implicitEventIndexes.push(eventIndex);
+      continue;
+    }
+    if (text) {
+      text += "\n";
+    }
+    const start = text.length;
+    text += line;
+    spans.push({ eventIndex, start, end: text.length });
+  }
+  return { text, spans, implicitEventIndexes };
+}
+
+function truncateEventPromptText(value: EventPromptText, maxChars: number): EventPromptText {
+  if (value.text.length <= maxChars) {
+    return value;
+  }
+  const text = truncateUtf16Safe(value.text, maxChars);
+  return {
+    text: `${text}\n\n[truncated]`,
+    spans: value.spans.flatMap((span) => {
+      const end = Math.min(span.end, text.length);
+      return span.start < end ? [{ ...span, end }] : [];
+    }),
+    implicitEventIndexes: value.implicitEventIndexes,
+  };
+}
+
+function wrapEventPromptText(params: {
+  kind: HeartbeatEventClass;
+  prefix: string;
+  eventText: EventPromptText;
+  suffix: string;
+}): HeartbeatEventPromptSection {
+  const offset = params.prefix.length;
+  return {
+    kind: params.kind,
+    text: `${params.prefix}${params.eventText.text}${params.suffix}`,
+    spans: params.eventText.spans.map((span) => ({
+      ...span,
+      start: span.start + offset,
+      end: span.end + offset,
+    })),
+    implicitEventIndexes: params.eventText.implicitEventIndexes,
+  };
+}
+
+function buildImplicitEventPromptSection(params: {
+  kind: HeartbeatEventClass;
+  text: string;
+  eventCount: number;
+}): HeartbeatEventPromptSection {
+  return {
+    kind: params.kind,
+    text: params.text,
+    spans: [],
+    implicitEventIndexes: Array.from({ length: params.eventCount }, (_, index) => index),
+  };
+}
+
 function parseStructuredExecCompletionEvent(evt: string): StructuredExecCompletionEvent | null {
   const trimmed = evt.trim();
   const match = STRUCTURED_EXEC_COMPLETION_EVENT_RE.exec(trimmed);
@@ -52,29 +141,27 @@ export function isRelayableExecCompletionEvent(evt: string): boolean {
   return !parsed.succeeded;
 }
 
-function formatExecEventPromptText(pendingEvents: string[]): {
-  text: string;
+function formatExecEventPromptText(pendingEvents: string[]): EventPromptText & {
   hasMissingOutputFailure: boolean;
 } {
   let hasMissingOutputFailure = false;
-  const lines = pendingEvents.flatMap((event) => {
-    const parsed = parseStructuredExecCompletionEvent(event);
-    if (!parsed) {
-      const trimmed = event.trim();
-      return trimmed ? [trimmed] : [];
-    }
-    if (parsed.output) {
-      return [parsed.raw];
-    }
-    if (parsed.succeeded) {
-      return [];
-    }
-    hasMissingOutputFailure = true;
-    return [
-      `Exec ${parsed.action} (${parsed.id}, ${parsed.result}) without captured stdout/stderr.`,
-    ];
-  });
-  return { text: lines.join("\n").trim(), hasMissingOutputFailure };
+  const eventText = joinEventPromptLines(
+    pendingEvents.map((event) => {
+      const parsed = parseStructuredExecCompletionEvent(event);
+      if (!parsed) {
+        return event.trim() || null;
+      }
+      if (parsed.output) {
+        return parsed.raw;
+      }
+      if (parsed.succeeded) {
+        return null;
+      }
+      hasMissingOutputFailure = true;
+      return `Exec ${parsed.action} (${parsed.id}, ${parsed.result}) without captured stdout/stderr.`;
+    }),
+  );
+  return { ...eventText, hasMissingOutputFailure };
 }
 
 // Build a dynamic prompt for cron events by embedding the actual event content.
@@ -86,93 +173,136 @@ function buildCronEventPrompt(
     deliverToUser?: boolean;
     useHeartbeatResponseTool?: boolean;
   },
-): string {
+): HeartbeatEventPromptSection {
   const deliverToUser = opts?.deliverToUser ?? true;
   const useHeartbeatResponseTool = opts?.useHeartbeatResponseTool ?? false;
-  const eventText = pendingEvents.join("\n").trim();
-  if (!eventText) {
+  const eventText = joinEventPromptLines(pendingEvents.map((event) => event.trim() || null));
+  if (!eventText.text) {
     const completionInstruction = useHeartbeatResponseTool
       ? HEARTBEAT_RESPONSE_TOOL_INSTRUCTIONS
       : deliverToUser
         ? `Reply ${SILENT_REPLY_TOKEN}.`
         : `Handle this internally and reply ${SILENT_REPLY_TOKEN} when nothing needs user-facing follow-up.`;
-    return `A scheduled cron event was triggered, but no event content was found. ${completionInstruction}`;
+    return buildImplicitEventPromptSection({
+      kind: "cron",
+      text: `A scheduled cron event was triggered, but no event content was found. ${completionInstruction}`,
+      eventCount: pendingEvents.length,
+    });
   }
-  if (!deliverToUser) {
-    return (
-      "A scheduled reminder has been triggered. The reminder content is:\n\n" +
-      eventText +
-      "\n\nHandle this reminder internally. Do not relay it to the user unless explicitly requested."
-    );
-  }
-  return (
-    "A scheduled reminder has been triggered. The reminder content is:\n\n" +
-    eventText +
-    "\n\nPlease relay this reminder to the user in a helpful and friendly way."
-  );
+  return wrapEventPromptText({
+    kind: "cron",
+    prefix: "A scheduled reminder has been triggered. The reminder content is:\n\n",
+    eventText,
+    suffix: deliverToUser
+      ? "\n\nPlease relay this reminder to the user in a helpful and friendly way."
+      : "\n\nHandle this reminder internally. Do not relay it to the user unless explicitly requested.",
+  });
 }
 
 function buildExecEventPrompt(
   pendingEvents: string[],
   opts?: { deliverToUser?: boolean; useHeartbeatResponseTool?: boolean },
-): string {
+): HeartbeatEventPromptSection {
   const deliverToUser = opts?.deliverToUser ?? true;
   const useHeartbeatResponseTool = opts?.useHeartbeatResponseTool ?? false;
-  const { text: rawEventText, hasMissingOutputFailure } = formatExecEventPromptText(pendingEvents);
-  const eventText =
-    rawEventText.length > MAX_EXEC_EVENT_PROMPT_CHARS
-      ? `${truncateUtf16Safe(rawEventText, MAX_EXEC_EVENT_PROMPT_CHARS)}\n\n[truncated]`
-      : rawEventText;
-  if (!eventText) {
+  const formatted = formatExecEventPromptText(pendingEvents);
+  const eventText = truncateEventPromptText(formatted, MAX_EXEC_EVENT_PROMPT_CHARS);
+  if (!eventText.text) {
     const completionInstruction = useHeartbeatResponseTool
       ? HEARTBEAT_RESPONSE_TOOL_INSTRUCTIONS
       : `Reply ${SILENT_REPLY_TOKEN} only.`;
-    return `An async command completion event was triggered, but no command output was found. ${completionInstruction} Do not mention, summarize, or reuse output from any earlier run.`;
+    return buildImplicitEventPromptSection({
+      kind: "exec",
+      text: `An async command completion event was triggered, but no command output was found. ${completionInstruction} Do not mention, summarize, or reuse output from any earlier run.`,
+      eventCount: pendingEvents.length,
+    });
   }
   if (!deliverToUser) {
-    if (useHeartbeatResponseTool) {
-      return (
-        "An async command completion event was triggered, but user delivery is disabled for this run. " +
+    const text = useHeartbeatResponseTool
+      ? "An async command completion event was triggered, but user delivery is disabled for this run. " +
         `Handle the result internally. ${HEARTBEAT_RESPONSE_TOOL_INSTRUCTIONS} ` +
         "Do not mention, summarize, or reuse command output."
-      );
+      : "An async command completion event was triggered, but user delivery is disabled for this run. " +
+        `Handle the result internally and reply ${SILENT_REPLY_TOKEN} only. Do not mention, summarize, or reuse command output.`;
+    return buildImplicitEventPromptSection({
+      kind: "exec",
+      text,
+      eventCount: pendingEvents.length,
+    });
+  }
+  if (formatted.hasMissingOutputFailure) {
+    return wrapEventPromptText({
+      kind: "exec",
+      prefix:
+        "An async command you ran earlier completed without captured stdout/stderr. The completion details are:\n\n",
+      eventText,
+      suffix:
+        "\n\nTell the user the command completed without captured output and include the exit status or signal. " +
+        "Do not ask the user to provide missing logs, and do not try to retrieve logs from an exec/session id.",
+    });
+  }
+  return wrapEventPromptText({
+    kind: "exec",
+    prefix:
+      "An async command you ran earlier has completed. The command completion details are:\n\n",
+    eventText,
+    suffix:
+      "\n\nPlease relay the command output to the user in a helpful way. If the command succeeded, share the relevant output. " +
+      "If it failed, explain what went wrong.",
+  });
+}
+
+type TruncatedHeartbeatEventPromptSection = {
+  text: string;
+  handledEventIndexes: number[];
+};
+
+function truncateHeartbeatEventPromptSection(
+  section: HeartbeatEventPromptSection,
+  maxChars: number,
+): TruncatedHeartbeatEventPromptSection {
+  const retainedRanges: Array<{ start: number; end: number }> = [];
+  let text = section.text;
+  if (section.text.length <= maxChars) {
+    retainedRanges.push({ start: 0, end: section.text.length });
+  } else {
+    const marker = "\n\n[truncated]\n\n";
+    const bodyBudget = Math.max(0, maxChars - marker.length);
+    const headBudget = Math.ceil(bodyBudget * 0.7);
+    const head = truncateUtf16Safe(section.text, headBudget);
+    const tailBudget = bodyBudget - headBudget;
+    const tail = tailBudget > 0 ? sliceUtf16Safe(section.text, -tailBudget) : "";
+    text = `${head}${marker}${tail}`;
+    retainedRanges.push({ start: 0, end: head.length });
+    if (tail) {
+      retainedRanges.push({ start: section.text.length - tail.length, end: section.text.length });
     }
-    return (
-      "An async command completion event was triggered, but user delivery is disabled for this run. " +
-      `Handle the result internally and reply ${SILENT_REPLY_TOKEN} only. Do not mention, summarize, or reuse command output.`
-    );
   }
-  if (hasMissingOutputFailure) {
-    return (
-      "An async command you ran earlier completed without captured stdout/stderr. The completion details are:\n\n" +
-      eventText +
-      "\n\n" +
-      "Tell the user the command completed without captured output and include the exit status or signal. " +
-      "Do not ask the user to provide missing logs, and do not try to retrieve logs from an exec/session id."
-    );
+  const handledEventIndexes = new Set(section.implicitEventIndexes);
+  for (const span of section.spans) {
+    if (retainedRanges.some((range) => span.start < range.end && span.end > range.start)) {
+      handledEventIndexes.add(span.eventIndex);
+    }
   }
-  return (
-    "An async command you ran earlier has completed. The command completion details are:\n\n" +
-    eventText +
-    "\n\n" +
-    "Please relay the command output to the user in a helpful way. If the command succeeded, share the relevant output. " +
-    "If it failed, explain what went wrong."
-  );
+  return {
+    text,
+    handledEventIndexes: [...handledEventIndexes].toSorted((left, right) => left - right),
+  };
 }
 
 /** Compose every event class inspected by one heartbeat into a single model turn. */
-export function buildHeartbeatEventPrompt(params: {
+export function resolveHeartbeatEventPrompt(params: {
   execEvents?: readonly string[];
   cronEvents?: readonly string[];
   genericEvents?: readonly string[];
   deliverToUser?: boolean;
   useHeartbeatResponseTool?: boolean;
-}): string {
+}): HeartbeatEventPromptResolution {
   const opts = {
     deliverToUser: params.deliverToUser,
     useHeartbeatResponseTool: params.useHeartbeatResponseTool,
   };
-  const sections: string[] = [];
+  const sections: HeartbeatEventPromptSection[] = [];
   if (params.execEvents?.length) {
     sections.push(buildExecEventPrompt([...params.execEvents], opts));
   }
@@ -183,14 +313,24 @@ export function buildHeartbeatEventPrompt(params: {
     sections.push(buildSystemEventPrompt([...params.genericEvents], opts));
   }
   if (sections.length === 0) {
-    return buildSystemEventPrompt([], opts);
+    sections.push(buildSystemEventPrompt([], opts));
   }
+  const handledEventIndexes: HeartbeatEventPromptResolution["handledEventIndexes"] = {
+    exec: [],
+    cron: [],
+    generic: [],
+  };
   if (sections.length === 1) {
-    const [onlySection] = sections;
-    if (!onlySection) {
-      return buildSystemEventPrompt([], opts);
+    const section = sections[0];
+    if (!section) {
+      return { prompt: "", handledEventIndexes };
     }
-    return truncateHeartbeatEventPromptSection(onlySection, MAX_HEARTBEAT_EVENT_PROMPT_CHARS);
+    const truncated = truncateHeartbeatEventPromptSection(
+      section,
+      MAX_HEARTBEAT_EVENT_PROMPT_CHARS,
+    );
+    handledEventIndexes[section.kind] = truncated.handledEventIndexes;
+    return { prompt: truncated.text, handledEventIndexes };
   }
   const header =
     "Multiple heartbeat events were triggered. Assess each event and handle every event shown below.";
@@ -202,64 +342,53 @@ export function buildHeartbeatEventPrompt(params: {
         sections.length,
     ),
   );
-  return [
-    header,
-    ...sections.map((section) => truncateHeartbeatEventPromptSection(section, sectionBudget)),
-  ].join(separator);
-}
-
-function truncateHeartbeatEventPromptSection(section: string, maxChars: number): string {
-  if (section.length <= maxChars) {
-    return section;
-  }
-  const marker = "\n\n[truncated]\n\n";
-  const bodyBudget = Math.max(0, maxChars - marker.length);
-  const headBudget = Math.ceil(bodyBudget * 0.7);
-  const tailBudget = bodyBudget - headBudget;
-  const tail = tailBudget > 0 ? sliceUtf16Safe(section, -tailBudget) : "";
-  return `${truncateUtf16Safe(section, headBudget)}${marker}${tail}`;
+  const truncatedSections = sections.map((section) => {
+    const truncated = truncateHeartbeatEventPromptSection(section, sectionBudget);
+    handledEventIndexes[section.kind] = truncated.handledEventIndexes;
+    return truncated.text;
+  });
+  return {
+    prompt: [header, ...truncatedSections].join(separator),
+    handledEventIndexes,
+  };
 }
 
 /** Build a heartbeat prompt for system events that are not owned by exec or cron. */
 function buildSystemEventPrompt(
   pendingEvents: string[],
   opts?: { deliverToUser?: boolean; useHeartbeatResponseTool?: boolean },
-): string {
+): HeartbeatEventPromptSection {
   const deliverToUser = opts?.deliverToUser ?? true;
   const useHeartbeatResponseTool = opts?.useHeartbeatResponseTool ?? false;
-  const rawEventText = pendingEvents
-    .map(compactSystemEvent)
-    .filter((event): event is string => event !== null)
-    .join("\n");
-  const eventText =
-    rawEventText.length > MAX_SYSTEM_EVENT_PROMPT_CHARS
-      ? `${truncateUtf16Safe(rawEventText, MAX_SYSTEM_EVENT_PROMPT_CHARS)}\n\n[truncated]`
-      : rawEventText;
-  if (!eventText) {
+  const eventText = truncateEventPromptText(
+    joinEventPromptLines(pendingEvents.map(compactSystemEvent)),
+    MAX_SYSTEM_EVENT_PROMPT_CHARS,
+  );
+  if (!eventText.text) {
     const completionInstruction = useHeartbeatResponseTool
       ? HEARTBEAT_RESPONSE_TOOL_INSTRUCTIONS
       : `Reply ${SILENT_REPLY_TOKEN} only.`;
-    return `A system event was triggered, but no event content was found. ${completionInstruction}`;
+    return buildImplicitEventPromptSection({
+      kind: "generic",
+      text: `A system event was triggered, but no event content was found. ${completionInstruction}`,
+      eventCount: pendingEvents.length,
+    });
   }
   const completionInstruction = useHeartbeatResponseTool
     ? HEARTBEAT_RESPONSE_TOOL_INSTRUCTIONS
     : `reply ${SILENT_REPLY_TOKEN} when nothing needs user-facing follow-up`;
-  if (!deliverToUser) {
-    return (
-      "A system event was triggered. The event details are:\n\n" +
-      eventText +
-      "\n\nHandle this event internally. Do not relay it to the user unless explicitly requested. " +
-      completionInstruction +
-      "."
-    );
-  }
-  return (
-    "A system event was triggered. The event details are:\n\n" +
-    eventText +
-    "\n\nAssess whether this event needs user-facing follow-up. If it does, explain it helpfully; otherwise " +
-    completionInstruction +
-    "."
-  );
+  return wrapEventPromptText({
+    kind: "generic",
+    prefix: "A system event was triggered. The event details are:\n\n",
+    eventText,
+    suffix: deliverToUser
+      ? "\n\nAssess whether this event needs user-facing follow-up. If it does, explain it helpfully; otherwise " +
+        completionInstruction +
+        "."
+      : "\n\nHandle this event internally. Do not relay it to the user unless explicitly requested. " +
+        completionInstruction +
+        ".",
+  });
 }
 
 const HEARTBEAT_OK_PREFIX = normalizeLowercaseStringOrEmpty(HEARTBEAT_TOKEN);

--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -8,6 +8,7 @@ import {
 import { HEARTBEAT_TOKEN, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 
 const MAX_EXEC_EVENT_PROMPT_CHARS = 8_000;
+const MAX_SYSTEM_EVENT_PROMPT_CHARS = 8_000;
 export const HEARTBEAT_DELIVERY_CONTEXT_KEY_PREFIX = "heartbeat-delivery:";
 const STRUCTURED_EXEC_COMPLETION_EVENT_RE =
   /^exec (completed|failed) \(([a-z0-9_-]{1,64}), (code -?\d+|signal [^)]+)\)(?: :: ([\s\S]*))?$/i;
@@ -158,9 +159,51 @@ export function buildExecEventPrompt(
   );
 }
 
+/** Build a heartbeat prompt for system events that are not owned by exec or cron. */
+export function buildSystemEventPrompt(
+  pendingEvents: string[],
+  opts?: { deliverToUser?: boolean; useHeartbeatResponseTool?: boolean },
+): string {
+  const deliverToUser = opts?.deliverToUser ?? true;
+  const useHeartbeatResponseTool = opts?.useHeartbeatResponseTool ?? false;
+  const rawEventText = pendingEvents
+    .map(compactSystemEvent)
+    .filter((event): event is string => event !== null)
+    .join("\n");
+  const eventText =
+    rawEventText.length > MAX_SYSTEM_EVENT_PROMPT_CHARS
+      ? `${truncateUtf16Safe(rawEventText, MAX_SYSTEM_EVENT_PROMPT_CHARS)}\n\n[truncated]`
+      : rawEventText;
+  if (!eventText) {
+    const completionInstruction = useHeartbeatResponseTool
+      ? HEARTBEAT_RESPONSE_TOOL_INSTRUCTIONS
+      : `Reply ${SILENT_REPLY_TOKEN} only.`;
+    return `A system event was triggered, but no event content was found. ${completionInstruction}`;
+  }
+  const completionInstruction = useHeartbeatResponseTool
+    ? HEARTBEAT_RESPONSE_TOOL_INSTRUCTIONS
+    : `reply ${SILENT_REPLY_TOKEN} when nothing needs user-facing follow-up`;
+  if (!deliverToUser) {
+    return (
+      "A system event was triggered. The event details are:\n\n" +
+      eventText +
+      "\n\nHandle this event internally. Do not relay it to the user unless explicitly requested. " +
+      completionInstruction +
+      "."
+    );
+  }
+  return (
+    "A system event was triggered. The event details are:\n\n" +
+    eventText +
+    "\n\nAssess whether this event needs user-facing follow-up. If it does, explain it helpfully; otherwise " +
+    completionInstruction +
+    "."
+  );
+}
+
 const HEARTBEAT_OK_PREFIX = normalizeLowercaseStringOrEmpty(HEARTBEAT_TOKEN);
 
-function isHeartbeatNoiseEvent(evt: string): boolean {
+export function isHeartbeatNoiseEvent(evt: string): boolean {
   const lower = normalizeLowercaseStringOrEmpty(evt);
   if (!lower) {
     return false;
@@ -172,6 +215,27 @@ function isHeartbeatNoiseEvent(evt: string): boolean {
     lower.includes("heartbeat poll") ||
     lower.includes("heartbeat wake")
   );
+}
+
+export function compactSystemEvent(line: string): string | null {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const lower = normalizeLowercaseStringOrEmpty(trimmed);
+  if (lower.includes("reason periodic")) {
+    return null;
+  }
+  if (lower.startsWith("read heartbeat.md")) {
+    return null;
+  }
+  if (lower.includes("heartbeat poll") || lower.includes("heartbeat wake")) {
+    return null;
+  }
+  if (trimmed.startsWith("Node:")) {
+    return trimmed.replace(/ · last input [^·]+/i, "").trim();
+  }
+  return trimmed;
 }
 
 export function isExecCompletionEvent(evt: string): boolean {

--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -187,7 +187,9 @@ export function buildHeartbeatEventPrompt(params: {
   }
   if (sections.length === 1) {
     const [onlySection] = sections;
-    if (!onlySection) return buildSystemEventPrompt([], opts);
+    if (!onlySection) {
+      return buildSystemEventPrompt([], opts);
+    }
     return truncateHeartbeatEventPromptSection(onlySection, MAX_HEARTBEAT_EVENT_PROMPT_CHARS);
   }
   const header =

--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -159,6 +159,36 @@ export function buildExecEventPrompt(
   );
 }
 
+/** Compose every event class inspected by one heartbeat into a single model turn. */
+export function buildHeartbeatEventPrompt(params: {
+  execEvents?: readonly string[];
+  cronEvents?: readonly string[];
+  genericEvents?: readonly string[];
+  deliverToUser?: boolean;
+  useHeartbeatResponseTool?: boolean;
+}): string {
+  const opts = {
+    deliverToUser: params.deliverToUser,
+    useHeartbeatResponseTool: params.useHeartbeatResponseTool,
+  };
+  const sections: string[] = [];
+  if (params.execEvents?.length) {
+    sections.push(buildExecEventPrompt([...params.execEvents], opts));
+  }
+  if (params.cronEvents?.length) {
+    sections.push(buildCronEventPrompt([...params.cronEvents], opts));
+  }
+  if (params.genericEvents?.length) {
+    sections.push(buildSystemEventPrompt([...params.genericEvents], opts));
+  }
+  return sections.length > 1
+    ? [
+        "Multiple heartbeat events were triggered. Assess each event and handle every event shown below.",
+        ...sections,
+      ].join("\n\n")
+    : (sections[0] ?? buildSystemEventPrompt([], opts));
+}
+
 /** Build a heartbeat prompt for system events that are not owned by exec or cron. */
 export function buildSystemEventPrompt(
   pendingEvents: string[],

--- a/src/infra/heartbeat-runner-delivery.ts
+++ b/src/infra/heartbeat-runner-delivery.ts
@@ -19,6 +19,8 @@ import {
 import { resolveMirroredTranscriptText } from "../config/sessions/transcript-mirror.js";
 import { mergeSessionEntry } from "../config/sessions/types.js";
 import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
+import { acknowledgeSessionStateNotices } from "../sessions/session-state-events.js";
+import { decodeSessionStateNoticeContextKey } from "../sessions/session-state-notices.js";
 import { formatErrorMessage } from "./errors.js";
 import {
   normalizeHeartbeatReply,
@@ -48,8 +50,12 @@ import {
   type NormalizedOutboundPayload,
 } from "./outbound/payloads.js";
 import type { buildOutboundSessionContext } from "./outbound/session-context.js";
-import { withSystemEventOwner } from "./system-event-ownership.js";
-import { consumeSelectedSystemEventEntries, enqueueSystemEvent } from "./system-events.js";
+import { resolveSystemEventOwnerAgentId, withSystemEventOwner } from "./system-event-ownership.js";
+import {
+  consumeSelectedSystemEventEntries,
+  enqueueSystemEvent,
+  type SystemEvent,
+} from "./system-events.js";
 
 const log = heartbeatLog;
 
@@ -293,7 +299,47 @@ export async function finalizeHeartbeatOutcome(params: {
       params.wake.preflight.shouldInspectPendingEvents &&
       params.prepared.inspectedSystemEventsToConsume.length
     ) {
-      consumeSelectedSystemEventEntries(sessionKey, params.prepared.inspectedSystemEventsToConsume);
+      // Consume the selected originals first: an occurrence replaced mid-turn
+      // is skipped here, and the freed slots keep continuation inserts from
+      // evicting unrelated queued entries at the capacity bound.
+      const consumed = consumeSelectedSystemEventEntries(
+        sessionKey,
+        params.prepared.inspectedSystemEventsToConsume,
+      );
+      // Partially shown events must not lose their truncation-hidden content:
+      // re-queue each remainder, but only for originals this run actually
+      // transitioned, and carrying the source owner so another agent sharing
+      // the queue can never claim the continuation.
+      const consumedEventIds = new Set(consumed.map((entry) => entry.id));
+      for (const { event: sourceEvent, remainder } of params.prepared.partialEventRemainders) {
+        if (!consumedEventIds.has(sourceEvent.id)) {
+          continue;
+        }
+        const continuationOptions: {
+          sessionKey: string;
+          contextKey?: string;
+          deliveryContext?: NonNullable<SystemEvent["deliveryContext"]>;
+        } = {
+          sessionKey,
+          ...(sourceEvent.contextKey ? { contextKey: sourceEvent.contextKey } : {}),
+          ...(sourceEvent.deliveryContext ? { deliveryContext: sourceEvent.deliveryContext } : {}),
+        };
+        const sourceOwnerAgentId = resolveSystemEventOwnerAgentId(sourceEvent);
+        enqueueSystemEvent(
+          remainder,
+          sourceOwnerAgentId
+            ? withSystemEventOwner(continuationOptions, sourceOwnerAgentId)
+            : continuationOptions,
+        );
+      }
+      const sessionStateTargets = consumed
+        .map((entry) =>
+          entry.contextKey ? decodeSessionStateNoticeContextKey(entry.contextKey) : undefined,
+        )
+        .filter((target): target is string => target !== undefined);
+      if (sessionStateTargets.length > 0) {
+        acknowledgeSessionStateNotices(sessionKey, sessionStateTargets);
+      }
     }
     return { status: "ran", durationMs: Date.now() - startedAt } as const;
   };

--- a/src/infra/heartbeat-runner-execution.ts
+++ b/src/infra/heartbeat-runner-execution.ts
@@ -68,6 +68,7 @@ import {
 import {
   resolveHeartbeatPreflight,
   resolveHeartbeatRunPrompt,
+  selectHeartbeatEventOwnership,
   selectSystemEventsConsumedByHeartbeat,
   shouldPreflightWakeBeforeBusy,
 } from "./heartbeat-runner-prompt.js";
@@ -96,6 +97,7 @@ import {
   resolveHeartbeatDeliveryTargetWithSessionRoute,
   resolveHeartbeatSenderContext,
 } from "./outbound/targets.js";
+import { resolveSystemEventDeliveryContext } from "./system-events.js";
 
 const log = heartbeatLog;
 const CRON_COMMAND_LANE: string = CommandLane.Cron;
@@ -389,6 +391,17 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
   // a new session ID (empty transcript) each run, avoiding the cost of
   // sending the full conversation history (~100K tokens) to the LLM.
   // Delivery routing uses the selected conversation, not the fresh execution row.
+  // Ownership is resolved before delivery so the wake's turn-source route follows
+  // exactly the events this turn surfaces; a cap-omitted entry must not retarget
+  // the reply away from the events actually shown.
+  const eventOwnership = selectHeartbeatEventOwnership({ preflight, heartbeat });
+  const ownedEventEntrySet = new Set([
+    ...eventOwnership.handledSystemEvents,
+    ...eventOwnership.genericEvents,
+  ]);
+  const ownedTurnSourceDeliveryContext = resolveSystemEventDeliveryContext(
+    preflight.pendingEventEntries.filter((event) => ownedEventEntrySet.has(event)),
+  );
   const delivery = await resolveHeartbeatDeliveryTargetWithSessionRoute({
     cfg,
     agentId,
@@ -397,9 +410,7 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
     currentSessionKey: sessionKey,
     // A base queue's route stays excluded; events on the actual isolated queue
     // own their route, including exec completion after the base route moves.
-    turnSource: preflight.session.inspectsRunQueue
-      ? preflight.turnSourceDeliveryContext
-      : undefined,
+    turnSource: preflight.session.inspectsRunQueue ? ownedTurnSourceDeliveryContext : undefined,
   });
   // Routeless ambient polls are pure model burn, but only they may skip:
   // triggered wakes (hook/manual/cron/exec), polls with queued events, and
@@ -462,6 +473,7 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
     scheduledTasks,
     heartbeatScratchContent: preflight.heartbeatScratchContent,
     useHeartbeatResponseTool: useHeartbeatResponseToolPrompt,
+    ownership: eventOwnership,
   });
 
   const runSessionKey = run.sessionKey;
@@ -553,6 +565,7 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
         scheduledTasks,
         heartbeatScratchContent: preflight.heartbeatScratchContent,
         useHeartbeatResponseTool: useHeartbeatResponseToolPrompt,
+        ownership: eventOwnership,
       });
     }
   }
@@ -569,13 +582,20 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
     runSessionKey,
     outboundPolicySessionKey,
     ...heartbeatRunPrompt,
-    inspectedSystemEventsToConsume: selectSystemEventsConsumedByHeartbeat({
-      preflight,
-      hasExecCompletion,
-      hasCronEvents,
-      hasGenericEvents,
-      handledSystemEvents,
-    }),
+    partialEventRemainders: eventOwnership.partialEventRemainders,
+    // Scheduled-task turns render only the task prompt; every queued event keeps
+    // its own owner (generic entries still reach reply admission via the handoff)
+    // instead of being consumed unseen.
+    inspectedSystemEventsToConsume:
+      scheduledTasks.length > 0
+        ? []
+        : selectSystemEventsConsumedByHeartbeat({
+            preflight,
+            hasExecCompletion,
+            hasCronEvents,
+            hasGenericEvents,
+            handledSystemEvents,
+          }),
   } as const;
 }
 

--- a/src/infra/heartbeat-runner-execution.ts
+++ b/src/infra/heartbeat-runner-execution.ts
@@ -68,6 +68,7 @@ import {
 import {
   resolveHeartbeatPreflight,
   resolveHeartbeatRunPrompt,
+  selectSystemEventsConsumedByHeartbeat,
   shouldPreflightWakeBeforeBusy,
 } from "./heartbeat-runner-prompt.js";
 import {
@@ -555,6 +556,8 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
       });
     }
   }
+  const { hasExecCompletion, hasCronEvents, hasGenericEvents, handledSystemEvents } =
+    heartbeatRunPrompt;
   return {
     kind: "ready",
     ...preflight.session,
@@ -566,6 +569,13 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
     runSessionKey,
     outboundPolicySessionKey,
     ...heartbeatRunPrompt,
+    inspectedSystemEventsToConsume: selectSystemEventsConsumedByHeartbeat({
+      preflight,
+      hasExecCompletion,
+      hasCronEvents,
+      hasGenericEvents,
+      handledSystemEvents,
+    }),
   } as const;
 }
 

--- a/src/infra/heartbeat-runner-mixed-events.test.ts
+++ b/src/infra/heartbeat-runner-mixed-events.test.ts
@@ -89,11 +89,67 @@ describe("heartbeat mixed event ownership", () => {
 
       expect(resolution.prompt).toContain("Gateway restart ok");
       expect(resolution.prompt).toContain(testCase.expectedSpecialized);
+      expect(
+        resolution.genericEvents.map((event) => event.text),
+        "the composed prompt owns generic rendering, so admission gets nothing to re-render",
+      ).toEqual([]);
       expect(consumed.map((event) => event.text)).toEqual([
         "Gateway restart ok",
         testCase.specialized,
       ]);
       expect(peekSystemEvents(sessionKey)).toEqual(["Gateway restart ok", testCase.specialized]);
+    });
+  });
+
+  it("keeps periodic wakes handing generic events to reply admission", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: { every: "5m", target: "none" },
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: "-100155462274",
+      });
+      enqueueSystemEvent("Gateway restart ok", { sessionKey });
+
+      const preflight = await resolveHeartbeatPreflight({
+        cfg,
+        agentId: "main",
+        heartbeat: cfg.agents?.defaults?.heartbeat,
+        source: "interval",
+        reason: "interval",
+      });
+      const resolution = resolveHeartbeatRunPrompt({
+        cfg,
+        heartbeat: cfg.agents?.defaults?.heartbeat,
+        preflight,
+        canRelayToUser: true,
+        startedAt: Date.now(),
+        scheduledTasks: [],
+        useHeartbeatResponseTool: false,
+      });
+      const consumed = selectSystemEventsConsumedByHeartbeat({
+        preflight,
+        hasExecCompletion: resolution.hasExecCompletion,
+        hasCronEvents: resolution.hasCronEvents,
+        hasGenericEvents: resolution.hasGenericEvents,
+        handledSystemEvents: resolution.handledSystemEvents,
+      });
+
+      expect(preflight.shouldInspectPendingEvents).toBe(false);
+      expect(resolution.prompt).not.toContain("Gateway restart ok");
+      expect(resolution.genericEvents.map((event) => event.text)).toEqual(["Gateway restart ok"]);
+      expect(consumed).toEqual([]);
+      expect(peekSystemEvents(sessionKey)).toEqual(["Gateway restart ok"]);
     });
   });
 
@@ -147,9 +203,24 @@ describe("heartbeat mixed event ownership", () => {
       expect(resolution.prompt).toContain("[truncated]");
       expect(resolution.prompt).not.toContain(omittedEvent);
       expect(consumed.map((event) => event.text)).toEqual([oversizedEvent]);
+      expect(resolution.partialEventRemainders).toHaveLength(1);
+      expect(resolution.partialEventRemainders[0]?.event.text).toBe(oversizedEvent);
+      expect(resolution.partialEventRemainders[0]?.remainder).toMatch(/^x+$/);
 
+      // Mirror terminal consumption: re-queue the truncation-hidden remainder,
+      // then consume the surfaced originals.
+      for (const { event, remainder } of resolution.partialEventRemainders) {
+        enqueueSystemEvent(remainder, {
+          sessionKey,
+          ...(event.contextKey ? { contextKey: event.contextKey } : {}),
+        });
+      }
       consumeSelectedSystemEventEntries(sessionKey, consumed);
-      expect(peekSystemEvents(sessionKey)).toEqual([omittedEvent]);
+      const queued = peekSystemEvents(sessionKey);
+      expect(queued[0]).toBe(omittedEvent);
+      expect(queued.length).toBe(2);
+      expect(queued[1]).toMatch(/^x+$/);
+      expect(queued[1]!.length).toBeGreaterThan(50);
     });
   });
 });

--- a/src/infra/heartbeat-runner-mixed-events.test.ts
+++ b/src/infra/heartbeat-runner-mixed-events.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveMainSessionKey } from "../config/sessions/main-session.js";
+import {
+  resolveHeartbeatPreflight,
+  resolveHeartbeatRunPrompt,
+  selectSystemEventsConsumedByHeartbeat,
+} from "./heartbeat-runner-prompt.js";
+import {
+  seedMainSessionStore,
+  setupTelegramHeartbeatPluginRuntimeForTests,
+  withTempHeartbeatSandbox,
+} from "./heartbeat-runner.test-utils.js";
+import { enqueueSystemEvent, peekSystemEvents, resetSystemEventsForTest } from "./system-events.js";
+
+beforeEach(() => {
+  setupTelegramHeartbeatPluginRuntimeForTests();
+  resetSystemEventsForTest();
+});
+
+describe("heartbeat mixed event ownership", () => {
+  it.each([
+    {
+      name: "exec wake",
+      source: "exec-event" as const,
+      reason: "exec-event",
+      specialized: "Exec failed (backup, code 1) :: backup failed",
+      expectedSpecialized: "backup failed",
+    },
+    {
+      name: "cron wake",
+      source: "cron" as const,
+      reason: "cron:overnight-report",
+      specialized: "Reminder: Send the overnight report",
+      expectedSpecialized: "Reminder: Send the overnight report",
+    },
+  ])("composes and consumes generic events with a $name", async (testCase) => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: { every: "5m", target: "none" },
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastTo: "-100155462274",
+      });
+      enqueueSystemEvent("Gateway restart ok", { sessionKey });
+      enqueueSystemEvent(testCase.specialized, {
+        sessionKey,
+        ...(testCase.source === "cron" ? { contextKey: "cron:overnight-report" } : {}),
+      });
+
+      const preflight = await resolveHeartbeatPreflight({
+        cfg,
+        agentId: "main",
+        heartbeat: cfg.agents?.defaults?.heartbeat,
+        source: testCase.source,
+        reason: testCase.reason,
+      });
+      const resolution = resolveHeartbeatRunPrompt({
+        cfg,
+        heartbeat: cfg.agents?.defaults?.heartbeat,
+        preflight,
+        canRelayToUser: true,
+        startedAt: Date.now(),
+        scheduledTasks: [],
+        useHeartbeatResponseTool: false,
+      });
+      const consumed = selectSystemEventsConsumedByHeartbeat({
+        preflight,
+        hasExecCompletion: resolution.hasExecCompletion,
+        hasCronEvents: resolution.hasCronEvents,
+        hasGenericEvents: resolution.hasGenericEvents,
+      });
+
+      expect(resolution.prompt).toContain("Gateway restart ok");
+      expect(resolution.prompt).toContain(testCase.expectedSpecialized);
+      expect(consumed.map((event) => event.text)).toEqual([
+        "Gateway restart ok",
+        testCase.specialized,
+      ]);
+      expect(peekSystemEvents(sessionKey)).toEqual(["Gateway restart ok", testCase.specialized]);
+    });
+  });
+});
+
+afterEach(() => {
+  resetSystemEventsForTest();
+  vi.restoreAllMocks();
+});

--- a/src/infra/heartbeat-runner-mixed-events.test.ts
+++ b/src/infra/heartbeat-runner-mixed-events.test.ts
@@ -49,6 +49,7 @@ describe("heartbeat mixed event ownership", () => {
       const sessionKey = resolveMainSessionKey(cfg);
       await seedMainSessionStore(storePath, cfg, {
         lastChannel: "telegram",
+        lastProvider: "telegram",
         lastTo: "-100155462274",
       });
       enqueueSystemEvent("Gateway restart ok", { sessionKey });

--- a/src/infra/heartbeat-runner-mixed-events.test.ts
+++ b/src/infra/heartbeat-runner-mixed-events.test.ts
@@ -11,7 +11,12 @@ import {
   setupTelegramHeartbeatPluginRuntimeForTests,
   withTempHeartbeatSandbox,
 } from "./heartbeat-runner.test-utils.js";
-import { enqueueSystemEvent, peekSystemEvents, resetSystemEventsForTest } from "./system-events.js";
+import {
+  consumeSelectedSystemEventEntries,
+  enqueueSystemEvent,
+  peekSystemEvents,
+  resetSystemEventsForTest,
+} from "./system-events.js";
 
 beforeEach(() => {
   setupTelegramHeartbeatPluginRuntimeForTests();
@@ -79,6 +84,7 @@ describe("heartbeat mixed event ownership", () => {
         hasExecCompletion: resolution.hasExecCompletion,
         hasCronEvents: resolution.hasCronEvents,
         hasGenericEvents: resolution.hasGenericEvents,
+        handledSystemEvents: resolution.handledSystemEvents,
       });
 
       expect(resolution.prompt).toContain("Gateway restart ok");
@@ -88,6 +94,62 @@ describe("heartbeat mixed event ownership", () => {
         testCase.specialized,
       ]);
       expect(peekSystemEvents(sessionKey)).toEqual(["Gateway restart ok", testCase.specialized]);
+    });
+  });
+
+  it("leaves generic events omitted by the prompt budget queued", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: { every: "5m", target: "none" },
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+      const oversizedEvent = `Gateway startup report ${"x".repeat(8_100)}`;
+      const omittedEvent = "Gateway restart ok";
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: "-100155462274",
+      });
+      enqueueSystemEvent(oversizedEvent, { sessionKey });
+      enqueueSystemEvent(omittedEvent, { sessionKey });
+
+      const preflight = await resolveHeartbeatPreflight({
+        cfg,
+        agentId: "main",
+        heartbeat: cfg.agents?.defaults?.heartbeat,
+        source: "hook",
+        reason: "gateway-restart",
+      });
+      const resolution = resolveHeartbeatRunPrompt({
+        cfg,
+        heartbeat: cfg.agents?.defaults?.heartbeat,
+        preflight,
+        canRelayToUser: true,
+        startedAt: Date.now(),
+        scheduledTasks: [],
+        useHeartbeatResponseTool: false,
+      });
+      const consumed = selectSystemEventsConsumedByHeartbeat({
+        preflight,
+        hasExecCompletion: resolution.hasExecCompletion,
+        hasCronEvents: resolution.hasCronEvents,
+        hasGenericEvents: resolution.hasGenericEvents,
+        handledSystemEvents: resolution.handledSystemEvents,
+      });
+
+      expect(resolution.prompt).toContain("[truncated]");
+      expect(resolution.prompt).not.toContain(omittedEvent);
+      expect(consumed.map((event) => event.text)).toEqual([oversizedEvent]);
+
+      consumeSelectedSystemEventEntries(sessionKey, consumed);
+      expect(peekSystemEvents(sessionKey)).toEqual([omittedEvent]);
     });
   });
 });

--- a/src/infra/heartbeat-runner-prompt.ts
+++ b/src/infra/heartbeat-runner-prompt.ts
@@ -142,8 +142,8 @@ export async function resolveHeartbeatPreflight(params: {
     shouldInspectPendingEvents,
     authoritativeScheduledTick:
       typeof params.scheduledEveryMs === "number" &&
-      Number.isSafeInteger(scheduledEveryMs) &&
-      scheduledEveryMs > 0,
+      Number.isSafeInteger(params.scheduledEveryMs) &&
+      params.scheduledEveryMs > 0,
     ...(monitorScratch?.jobId
       ? {
           scratchJobId: monitorScratch.jobId,
@@ -208,6 +208,11 @@ type HeartbeatPromptResolution = {
    * heartbeat delivery path after a successful run.
    */
   genericEvents: SystemEvent[];
+  /**
+   * Truncation-hidden content of handled entries; terminal consumption re-queues
+   * these remainders so partially shown events are never silently dropped.
+   */
+  partialEventRemainders: Array<{ event: SystemEvent; remainder: string }>;
 };
 
 /** Appends monitor scratch prose to the generated heartbeat prompt. */
@@ -222,37 +227,44 @@ function appendHeartbeatScratch(prompt: string, heartbeatScratchContent?: string
   return `${prompt}\n\nHeartbeat monitor scratch:\n${directives}`;
 }
 
-export function resolveHeartbeatRunPrompt(params: {
-  cfg: OpenClawConfig;
+export type HeartbeatEventOwnership = {
+  hasExecCompletion: boolean;
+  hasCronEvents: boolean;
+  hasGenericEvents: boolean;
+  /** Retained entries the composed prompt surfaces; consumed after a successful run. */
+  handledSystemEvents: SystemEvent[];
+  /**
+   * Generic entries the composed prompt did not embed. Reply admission renders
+   * and consumes exactly this selection; embedded entries are consumed by the
+   * heartbeat delivery path after a successful run.
+   */
+  genericEvents: SystemEvent[];
+  /**
+   * Truncation-hidden content of handled entries. Consuming a partially shown
+   * event must re-queue its remainder so no queued content is silently dropped.
+   */
+  partialEventRemainders: Array<{ event: SystemEvent; remainder: string }>;
+};
+
+/**
+ * Resolve which queued entries this turn owns before delivery is known: the
+ * retained selection does not depend on relay or response-tool flags, so the
+ * wake's turn-source delivery context can follow exactly the surfaced events.
+ */
+export function selectHeartbeatEventOwnership(params: {
   heartbeat?: HeartbeatConfig;
   preflight: HeartbeatPreflight;
-  canRelayToUser: boolean;
-  startedAt: number;
-  scheduledTasks: readonly HeartbeatScheduledTask[];
-  heartbeatScratchContent?: string;
-  useHeartbeatResponseTool: boolean;
-}): HeartbeatPromptResolution {
+}): HeartbeatEventOwnership {
   const pendingEventEntries = params.preflight.pendingEventEntries;
   const cronEventEntries = pendingEventEntries.filter(
     (event) =>
       (params.preflight.isCronWake || event.contextKey?.startsWith("cron:")) &&
       isCronSystemEvent(event.text),
   );
-  const shouldInspectExecEvents =
-    params.preflight.shouldInspectPendingEvents &&
-    !(
-      params.heartbeat?.isolatedSession === true &&
-      params.preflight.isWakePayload &&
-      !params.preflight.isCronWake &&
-      !params.preflight.session.entry?.heartbeatIsolatedBaseSessionKey
-    );
-  const execEventEntries = shouldInspectExecEvents
+  const execEventEntries = shouldInspectExecEventEntries(params)
     ? pendingEventEntries.filter((event) => isExecCompletionEvent(event.text))
     : [];
   const hasExecCompletion = execEventEntries.length > 0;
-  const hasRelayableExecCompletion =
-    params.canRelayToUser &&
-    execEventEntries.some((event) => isRelayableExecCompletionEvent(event.text));
   const hasCronEvents = cronEventEntries.length > 0;
   const genericEventEntries = params.preflight.shouldInspectPendingEvents
     ? pendingEventEntries.filter(
@@ -275,6 +287,85 @@ export function resolveHeartbeatRunPrompt(params: {
           !isExecCompletionEvent(event.text) &&
           !(params.preflight.isCronWake || event.contextKey?.startsWith("cron:")),
       );
+  const eventPromptResolution =
+    hasExecCompletion || hasCronEvents || hasGenericEvents
+      ? resolveHeartbeatEventPrompt({
+          execEvents: execEventEntries.map((event) => event.text),
+          cronEvents: cronEventEntries.map((event) => event.text),
+          genericEvents: genericEventEntries.map((event) => event.text),
+        })
+      : undefined;
+  const handledEventEntries = eventPromptResolution
+    ? [
+        ...eventPromptResolution.handledEventIndexes.exec.map((index) => execEventEntries[index]),
+        ...eventPromptResolution.handledEventIndexes.cron.map((index) => cronEventEntries[index]),
+        ...eventPromptResolution.handledEventIndexes.generic.map(
+          (index) => genericEventEntries[index],
+        ),
+      ].filter((event): event is SystemEvent => event !== undefined)
+    : [];
+  const handledEventEntrySet = new Set(handledEventEntries);
+  const remainderEventsByKind: Record<"exec" | "cron" | "generic", readonly SystemEvent[]> = {
+    exec: execEventEntries,
+    cron: cronEventEntries,
+    generic: genericEventEntries,
+  };
+  const partialEventRemainders = (eventPromptResolution?.unseenRemainders ?? []).flatMap(
+    (remainder) => {
+      const event = remainderEventsByKind[remainder.kind][remainder.eventIndex];
+      return event ? [{ event, remainder: remainder.text }] : [];
+    },
+  );
+  return {
+    hasExecCompletion,
+    hasCronEvents,
+    hasGenericEvents,
+    handledSystemEvents: pendingEventEntries.filter((event) => handledEventEntrySet.has(event)),
+    genericEvents: deferredGenericEvents,
+    partialEventRemainders,
+  };
+}
+
+export function resolveHeartbeatRunPrompt(params: {
+  cfg: OpenClawConfig;
+  heartbeat?: HeartbeatConfig;
+  preflight: HeartbeatPreflight;
+  canRelayToUser: boolean;
+  startedAt: number;
+  scheduledTasks: readonly HeartbeatScheduledTask[];
+  heartbeatScratchContent?: string;
+  useHeartbeatResponseTool: boolean;
+  ownership?: HeartbeatEventOwnership;
+}): HeartbeatPromptResolution {
+  const pendingEventEntries = params.preflight.pendingEventEntries;
+  const ownership =
+    params.ownership ??
+    selectHeartbeatEventOwnership({ preflight: params.preflight, heartbeat: params.heartbeat });
+  const { hasExecCompletion, hasCronEvents, hasGenericEvents } = ownership;
+  const { handledSystemEvents } = ownership;
+  const execEventEntries = shouldInspectExecEventEntries(params)
+    ? pendingEventEntries.filter((event) => isExecCompletionEvent(event.text))
+    : [];
+  const cronEventEntries = pendingEventEntries.filter(
+    (event) =>
+      (params.preflight.isCronWake || event.contextKey?.startsWith("cron:")) &&
+      isCronSystemEvent(event.text),
+  );
+  const genericEventEntries = params.preflight.shouldInspectPendingEvents
+    ? pendingEventEntries.filter(
+        (event) =>
+          !isExecCompletionEvent(event.text) &&
+          !(
+            (params.preflight.isCronWake || event.contextKey?.startsWith("cron:")) &&
+            isCronSystemEvent(event.text)
+          ) &&
+          !isHeartbeatNoiseEvent(event.text),
+      )
+    : [];
+  const hasRelayableExecCompletion =
+    params.canRelayToUser &&
+    execEventEntries.some((event) => isRelayableExecCompletionEvent(event.text));
+  const deferredGenericEvents = ownership.genericEvents;
   if (params.scheduledTasks.length > 0) {
     const taskList = params.scheduledTasks
       .map((task) => `- ${task.name}: ${task.prompt}`)
@@ -297,6 +388,7 @@ ${completionInstruction}`;
       handledSystemEvents: [],
       usesHeartbeatResponseTool: params.useHeartbeatResponseTool,
       genericEvents: deferredGenericEvents,
+      partialEventRemainders: [],
     };
   }
 
@@ -316,19 +408,6 @@ ${completionInstruction}`;
     (baseUsesHeartbeatResponseTool
       ? resolveHeartbeatResponseToolPrompt(params.cfg, params.heartbeat)
       : resolveConfiguredHeartbeatPrompt(params.cfg, params.heartbeat));
-  const handledEventEntries = eventPromptResolution
-    ? [
-        ...eventPromptResolution.handledEventIndexes.exec.map((index) => execEventEntries[index]),
-        ...eventPromptResolution.handledEventIndexes.cron.map((index) => cronEventEntries[index]),
-        ...eventPromptResolution.handledEventIndexes.generic.map(
-          (index) => genericEventEntries[index],
-        ),
-      ].filter((event): event is SystemEvent => event !== undefined)
-    : [];
-  const handledEventEntrySet = new Set(handledEventEntries);
-  const handledSystemEvents = pendingEventEntries.filter((event) =>
-    handledEventEntrySet.has(event),
-  );
   const basePromptWithDirectives = appendHeartbeatScratch(
     basePrompt,
     params.heartbeatScratchContent,
@@ -342,7 +421,23 @@ ${completionInstruction}`;
     handledSystemEvents,
     usesHeartbeatResponseTool: baseUsesHeartbeatResponseTool,
     genericEvents: deferredGenericEvents,
+    partialEventRemainders: ownership.partialEventRemainders,
   };
+}
+
+function shouldInspectExecEventEntries(params: {
+  heartbeat?: HeartbeatConfig;
+  preflight: HeartbeatPreflight;
+}): boolean {
+  return (
+    params.preflight.shouldInspectPendingEvents &&
+    !(
+      params.heartbeat?.isolatedSession === true &&
+      params.preflight.isWakePayload &&
+      !params.preflight.isCronWake &&
+      !params.preflight.session.entry?.heartbeatIsolatedBaseSessionKey
+    )
+  );
 }
 
 export function selectSystemEventsConsumedByHeartbeat(params: {

--- a/src/infra/heartbeat-runner-prompt.ts
+++ b/src/infra/heartbeat-runner-prompt.ts
@@ -9,12 +9,12 @@ import { readHeartbeatMonitorScratch } from "../cron/scratch-store.js";
 import { resolveCronJobsStorePathFromConfig } from "../cron/store.js";
 import { formatErrorMessage } from "./errors.js";
 import {
-  buildCronEventPrompt,
-  buildExecEventPrompt,
   isCronSystemEvent,
   isExecCompletionEvent,
   isHeartbeatDeliveryAwarenessEvent,
+  isHeartbeatNoiseEvent,
   isRelayableExecCompletionEvent,
+  resolveHeartbeatEventPrompt,
 } from "./heartbeat-events-filter.js";
 import {
   heartbeatLog,
@@ -109,8 +109,10 @@ export async function resolveHeartbeatPreflight(params: {
   const hasTaggedCronEvents = pendingEventEntries.some((event) =>
     event.contextKey?.startsWith("cron:"),
   );
-  // The selected queue follows isolated execution into reply admission; the base queue does not.
-  const shouldInspectWakePendingEvents = wakeFlags.isWakePayload && session.inspectsRunQueue;
+  // Wake-triggered runs inspect the queue they will drain. Restart and hook
+  // producers enqueue on the configured/base session even when the model turn
+  // runs in a fresh isolated `:heartbeat` session.
+  const shouldInspectWakePendingEvents = wakeFlags.isWakePayload;
   const shouldInspectPendingEvents =
     wakeFlags.isExecEventWake ||
     wakeFlags.isCronWake ||
@@ -140,8 +142,8 @@ export async function resolveHeartbeatPreflight(params: {
     shouldInspectPendingEvents,
     authoritativeScheduledTick:
       typeof params.scheduledEveryMs === "number" &&
-      Number.isSafeInteger(params.scheduledEveryMs) &&
-      params.scheduledEveryMs > 0,
+      Number.isSafeInteger(scheduledEveryMs) &&
+      scheduledEveryMs > 0,
     ...(monitorScratch?.jobId
       ? {
           scratchJobId: monitorScratch.jobId,
@@ -197,9 +199,15 @@ type HeartbeatPromptResolution = {
   hasExecCompletion: boolean;
   hasRelayableExecCompletion: boolean;
   hasCronEvents: boolean;
+  hasGenericEvents: boolean;
+  handledSystemEvents: SystemEvent[];
   usesHeartbeatResponseTool: boolean;
+  /**
+   * Generic entries the composed prompt did not embed. Reply admission renders
+   * and consumes exactly this selection; embedded entries are consumed by the
+   * heartbeat delivery path after a successful run.
+   */
   genericEvents: SystemEvent[];
-  inspectedSystemEventsToConsume: SystemEvent[];
 };
 
 /** Appends monitor scratch prose to the generated heartbeat prompt. */
@@ -225,27 +233,48 @@ export function resolveHeartbeatRunPrompt(params: {
   useHeartbeatResponseTool: boolean;
 }): HeartbeatPromptResolution {
   const pendingEventEntries = params.preflight.pendingEventEntries;
-  const genericEvents: SystemEvent[] = [];
-  const cronEvents: SystemEvent[] = [];
-  const execEvents: SystemEvent[] = [];
-  const cronNoise: SystemEvent[] = [];
-  // Select once: admission owns generic text; completed delivery owns dedicated
-  // prompts and filtered cron noise. Late arrivals retain their queue identities.
-  for (const event of pendingEventEntries) {
-    if (isExecCompletionEvent(event.text)) {
-      if (params.preflight.shouldInspectPendingEvents) {
-        execEvents.push(event);
-      }
-    } else if (params.preflight.isCronWake || event.contextKey?.startsWith("cron:")) {
-      (isCronSystemEvent(event.text) ? cronEvents : cronNoise).push(event);
-    } else {
-      genericEvents.push(event);
-    }
-  }
-  const hasExecCompletion = execEvents.length > 0;
+  const cronEventEntries = pendingEventEntries.filter(
+    (event) =>
+      (params.preflight.isCronWake || event.contextKey?.startsWith("cron:")) &&
+      isCronSystemEvent(event.text),
+  );
+  const shouldInspectExecEvents =
+    params.preflight.shouldInspectPendingEvents &&
+    !(
+      params.heartbeat?.isolatedSession === true &&
+      params.preflight.isWakePayload &&
+      !params.preflight.isCronWake &&
+      !params.preflight.session.entry?.heartbeatIsolatedBaseSessionKey
+    );
+  const execEventEntries = shouldInspectExecEvents
+    ? pendingEventEntries.filter((event) => isExecCompletionEvent(event.text))
+    : [];
+  const hasExecCompletion = execEventEntries.length > 0;
   const hasRelayableExecCompletion =
-    params.canRelayToUser && execEvents.some((event) => isRelayableExecCompletionEvent(event.text));
-  const hasCronEvents = cronEvents.length > 0;
+    params.canRelayToUser &&
+    execEventEntries.some((event) => isRelayableExecCompletionEvent(event.text));
+  const hasCronEvents = cronEventEntries.length > 0;
+  const genericEventEntries = params.preflight.shouldInspectPendingEvents
+    ? pendingEventEntries.filter(
+        (event) =>
+          !isExecCompletionEvent(event.text) &&
+          !(
+            (params.preflight.isCronWake || event.contextKey?.startsWith("cron:")) &&
+            isCronSystemEvent(event.text)
+          ) &&
+          !isHeartbeatNoiseEvent(event.text),
+      )
+    : [];
+  const hasGenericEvents = genericEventEntries.length > 0;
+  // When the composed prompt embeds generic events it is their only rendering
+  // owner; otherwise the generic selection stays with reply admission.
+  const deferredGenericEvents = params.preflight.shouldInspectPendingEvents
+    ? []
+    : pendingEventEntries.filter(
+        (event) =>
+          !isExecCompletionEvent(event.text) &&
+          !(params.preflight.isCronWake || event.contextKey?.startsWith("cron:")),
+      );
   if (params.scheduledTasks.length > 0) {
     const taskList = params.scheduledTasks
       .map((task) => `- ${task.name}: ${task.prompt}`)
@@ -264,32 +293,42 @@ ${completionInstruction}`;
       hasExecCompletion: false,
       hasRelayableExecCompletion: false,
       hasCronEvents: false,
+      hasGenericEvents: false,
+      handledSystemEvents: [],
       usesHeartbeatResponseTool: params.useHeartbeatResponseTool,
-      genericEvents,
-      inspectedSystemEventsToConsume: cronNoise,
+      genericEvents: deferredGenericEvents,
     };
   }
 
   const baseUsesHeartbeatResponseTool = params.useHeartbeatResponseTool;
-  const basePrompt = hasExecCompletion
-    ? buildExecEventPrompt(
-        execEvents.map((event) => event.text),
-        {
+  const eventPromptResolution =
+    hasExecCompletion || hasCronEvents || hasGenericEvents
+      ? resolveHeartbeatEventPrompt({
+          execEvents: execEventEntries.map((event) => event.text),
+          cronEvents: cronEventEntries.map((event) => event.text),
+          genericEvents: genericEventEntries.map((event) => event.text),
           deliverToUser: params.canRelayToUser,
           useHeartbeatResponseTool: baseUsesHeartbeatResponseTool,
-        },
-      )
-    : hasCronEvents
-      ? buildCronEventPrompt(
-          cronEvents.map((event) => event.text),
-          {
-            deliverToUser: params.canRelayToUser,
-            useHeartbeatResponseTool: baseUsesHeartbeatResponseTool,
-          },
-        )
-      : baseUsesHeartbeatResponseTool
-        ? resolveHeartbeatResponseToolPrompt(params.cfg, params.heartbeat)
-        : resolveConfiguredHeartbeatPrompt(params.cfg, params.heartbeat);
+        })
+      : undefined;
+  const basePrompt =
+    eventPromptResolution?.prompt ??
+    (baseUsesHeartbeatResponseTool
+      ? resolveHeartbeatResponseToolPrompt(params.cfg, params.heartbeat)
+      : resolveConfiguredHeartbeatPrompt(params.cfg, params.heartbeat));
+  const handledEventEntries = eventPromptResolution
+    ? [
+        ...eventPromptResolution.handledEventIndexes.exec.map((index) => execEventEntries[index]),
+        ...eventPromptResolution.handledEventIndexes.cron.map((index) => cronEventEntries[index]),
+        ...eventPromptResolution.handledEventIndexes.generic.map(
+          (index) => genericEventEntries[index],
+        ),
+      ].filter((event): event is SystemEvent => event !== undefined)
+    : [];
+  const handledEventEntrySet = new Set(handledEventEntries);
+  const handledSystemEvents = pendingEventEntries.filter((event) =>
+    handledEventEntrySet.has(event),
+  );
   const basePromptWithDirectives = appendHeartbeatScratch(
     basePrompt,
     params.heartbeatScratchContent,
@@ -299,11 +338,43 @@ ${completionInstruction}`;
     hasExecCompletion,
     hasRelayableExecCompletion,
     hasCronEvents,
+    hasGenericEvents,
+    handledSystemEvents,
     usesHeartbeatResponseTool: baseUsesHeartbeatResponseTool,
-    genericEvents,
-    inspectedSystemEventsToConsume: [
-      ...cronNoise,
-      ...(hasExecCompletion ? execEvents : cronEvents),
-    ],
+    genericEvents: deferredGenericEvents,
   };
+}
+
+export function selectSystemEventsConsumedByHeartbeat(params: {
+  preflight: HeartbeatPreflight;
+  hasExecCompletion: boolean;
+  hasCronEvents: boolean;
+  hasGenericEvents: boolean;
+  handledSystemEvents: readonly SystemEvent[];
+}): SystemEvent[] {
+  const { preflight } = params;
+  if (!preflight.shouldInspectPendingEvents || preflight.pendingEventEntries.length === 0) {
+    return [];
+  }
+  if (
+    preflight.isExecEventWake &&
+    !params.hasExecCompletion &&
+    !params.hasCronEvents &&
+    (!params.hasGenericEvents || !preflight.isWakePayload)
+  ) {
+    return [];
+  }
+  if (
+    preflight.isWakePayload &&
+    !params.hasExecCompletion &&
+    !params.hasCronEvents &&
+    !params.hasGenericEvents &&
+    preflight.pendingEventEntries.some((event) => isExecCompletionEvent(event.text))
+  ) {
+    return [];
+  }
+  if (params.hasExecCompletion || params.hasCronEvents || params.hasGenericEvents) {
+    return [...params.handledSystemEvents];
+  }
+  return preflight.pendingEventEntries;
 }

--- a/src/infra/heartbeat-runner.event-routing.test.ts
+++ b/src/infra/heartbeat-runner.event-routing.test.ts
@@ -354,18 +354,16 @@ describe("Heartbeat event routing", () => {
       if (queue === "legacy") {
         expect(legacyRowRemovedAtReply).toBe(true);
       }
-      if (queue === "base") {
-        expect(formatted ?? "").not.toContain(generic);
-        expect(peekSystemEvents(queueKey)).toEqual(queuedBefore);
-      } else {
-        expect(formatted).toContain(generic);
-        expect(formatted).not.toContain(completion);
-        expect(formatted).not.toContain(reminder);
-        expect(peekSystemEvents(queueKey)).toEqual(dedicated === "exec" ? [reminder] : []);
-      }
+      // The composed wake prompt is the only rendering owner: the model turn
+      // embeds the queue's events, reply admission renders nothing for the
+      // wake, and the surfaced selection is consumed after the successful run.
+      expect(context.Body).toContain(generic);
+      expect(formatted ?? "").not.toContain(generic);
+      expect(formatted ?? "").not.toContain(completion);
+      expect(formatted ?? "").not.toContain(reminder);
+      expect(peekSystemEvents(queueKey)).toEqual([]);
       if (dedicated !== "none") {
         expect(context.Body).toContain(dedicated === "exec" ? completion : reminder);
-        expect(context.Body).not.toContain(generic);
       }
       expect(readSessionStoreForTest(storePath)[baseKey]?.sessionId).toBe("base-conversation");
     });

--- a/src/infra/heartbeat-runner.ghost-reminder.test.ts
+++ b/src/infra/heartbeat-runner.ghost-reminder.test.ts
@@ -658,7 +658,7 @@ describe("Ghost reminder bug (issue #13317)", () => {
     expect(sendTelegram).toHaveBeenCalled();
   });
 
-  it("consumes exec completion entries without dropping later generic events", async () => {
+  it("composes and consumes exec completion entries together with later generic events", async () => {
     const { result, calledCtx, sessionKey } = await runHeartbeatCase({
       tmpPrefix: "openclaw-exec-preserve-generic-",
       replyText: "Deploy succeeded",
@@ -674,8 +674,12 @@ describe("Ghost reminder bug (issue #13317)", () => {
     expect(result.status).toBe("ran");
     expect(calledCtx?.InternalTurnSource).toBe("exec");
     expect(calledCtx?.Body).toContain("deploy succeeded");
-    expect(calledCtx?.Body).not.toContain("Node connected");
-    expect(peekSystemEvents(sessionKey)).toEqual(["Node connected"]);
+    expect(calledCtx?.Body).toContain("Node connected");
+    expect(
+      calledCtx?.Body?.match(/Node connected/g)?.length ?? 0,
+      "the generic event reaches the model turn exactly once",
+    ).toBe(1);
+    expect(peekSystemEvents(sessionKey)).toEqual([]);
   });
 
   it("ignores an acknowledged exec-event wake without consuming unrelated events", async () => {

--- a/src/infra/heartbeat-runner.identity.test.ts
+++ b/src/infra/heartbeat-runner.identity.test.ts
@@ -150,8 +150,12 @@ describe("runHeartbeatOnce identity", () => {
         AgentId: "hooks",
         SessionKey: "global",
       });
-      expect(systemEventBlocks).toHaveLength(1);
-      expect(systemEventBlocks[0]).toContain("Mapped hook wake");
+      // The composed wake prompt owns rendering; the admission-side drain at
+      // the reply boundary renders nothing for this turn.
+      expect(systemEventBlocks[0]).toBeUndefined();
+      expect(replySpy.mock.calls[0]?.[0]).toMatchObject({
+        Body: expect.stringContaining("Mapped hook wake"),
+      });
       expect(peekSystemEventEntries("global")).toEqual([]);
     });
   });
@@ -203,9 +207,13 @@ describe("runHeartbeatOnce identity", () => {
         AgentId: "alpha",
         SessionKey: "global",
       });
-      // The first targeted wake must not drain the other agent's queued event.
-      expect(systemEventBlocks[0]).toContain("Hook Alpha: done");
-      expect(systemEventBlocks[0]).not.toContain("Hook Beta: done");
+      // The first targeted wake must not surface or drain the other agent's
+      // queued event; its own event renders through the composed wake prompt.
+      expect(systemEventBlocks[0]).toBeUndefined();
+      expect(replySpy.mock.calls[0]?.[0]).toMatchObject({
+        Body: expect.stringContaining("Hook Alpha: done"),
+      });
+      expect(replySpy.mock.calls[0]?.[0].Body).not.toContain("Hook Beta: done");
       expect(peekSystemEventEntries("global").map((event) => event.text)).toEqual([
         "Hook Beta: done",
       ]);
@@ -224,8 +232,11 @@ describe("runHeartbeatOnce identity", () => {
 
       expect(betaResult.status).toBe("ran");
       expect(replySpy).toHaveBeenCalledTimes(2);
-      expect(systemEventBlocks[1]).toContain("Hook Beta: done");
-      expect(systemEventBlocks[1]).not.toContain("Hook Alpha: done");
+      expect(systemEventBlocks[1]).toBeUndefined();
+      expect(replySpy.mock.calls[1]?.[0]).toMatchObject({
+        Body: expect.stringContaining("Hook Beta: done"),
+      });
+      expect(replySpy.mock.calls[1]?.[0].Body).not.toContain("Hook Alpha: done");
       expect(peekSystemEventEntries("global")).toEqual([]);
     });
   });

--- a/src/infra/heartbeat-runner.wake-delivery.test.ts
+++ b/src/infra/heartbeat-runner.wake-delivery.test.ts
@@ -1,0 +1,547 @@
+// Covers wake-run delivery routing and isolated wake event ownership.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveMainSessionKey } from "../config/sessions/main-session.js";
+import { runHeartbeatOnce } from "./heartbeat-runner.js";
+import {
+  getFirstReplyContext,
+  mockCallAt,
+  seedMainSessionStore,
+  seedSessionStore,
+  setupTelegramHeartbeatPluginRuntimeForTests,
+  withTempHeartbeatSandbox,
+  type HeartbeatReplyContext,
+} from "./heartbeat-runner.test-utils.js";
+import { selectAgentSystemEvents, withSystemEventOwner } from "./system-event-ownership.js";
+import {
+  consumeSelectedSystemEventEntries,
+  enqueueSystemEvent,
+  peekSystemEventEntries,
+  peekSystemEvents,
+  resetSystemEventsForTest,
+} from "./system-events.js";
+
+beforeEach(() => {
+  setupTelegramHeartbeatPluginRuntimeForTests();
+  resetSystemEventsForTest();
+});
+
+afterEach(() => {
+  resetSystemEventsForTest();
+  vi.restoreAllMocks();
+});
+
+describe("heartbeat wake delivery ownership", () => {
+  const createConfig = async (params: {
+    tmpDir: string;
+    storePath: string;
+    target?: "telegram" | "none";
+    isolatedSession?: boolean;
+  }): Promise<{ cfg: OpenClawConfig; sessionKey: string }> => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          workspace: params.tmpDir,
+          heartbeat: {
+            every: "5m",
+            target: params.target ?? "telegram",
+            ...(params.isolatedSession === true ? { isolatedSession: true } : {}),
+          },
+        },
+      },
+      channels: { telegram: { allowFrom: ["*"] } },
+      session: { store: params.storePath },
+    };
+    const sessionKey = await seedMainSessionStore(params.storePath, cfg, {
+      lastChannel: "telegram",
+      lastProvider: "telegram",
+      lastTo: "-100155462274",
+    });
+    return { cfg, sessionKey };
+  };
+
+  const createLastTargetConfig = (params: {
+    tmpDir: string;
+    storePath: string;
+    isolatedSession?: boolean;
+  }): OpenClawConfig => ({
+    agents: {
+      defaults: {
+        workspace: params.tmpDir,
+        heartbeat: {
+          every: "5m",
+          target: "last",
+          ...(params.isolatedSession === true ? { isolatedSession: true } : {}),
+        },
+      },
+    },
+    channels: { telegram: { allowFrom: ["*"] } },
+    session: { store: params.storePath },
+  });
+
+  const writeTelegramSessionStore = async (
+    storePath: string,
+    sessionKey: string,
+    overrides: Record<string, unknown>,
+  ): Promise<void> => {
+    await seedSessionStore(storePath, sessionKey, {
+      sessionId: "sid",
+      updatedAt: Date.now(),
+      lastChannel: "telegram",
+      lastProvider: "telegram",
+      lastTo: "-100155462274",
+      ...overrides,
+    });
+  };
+
+  const expectTelegramSend = (
+    sendTelegram: ReturnType<typeof vi.fn>,
+    params: {
+      to: string;
+      text: string;
+      messageThreadId?: number;
+    },
+  ) => {
+    expect(sendTelegram).toHaveBeenCalledTimes(1);
+    const [to, text, options] = mockCallAt(sendTelegram, 0, "Telegram send");
+    expect(to).toBe(params.to);
+    expect(text).toBe(params.text);
+    expect((options as { messageThreadId?: number } | undefined)?.messageThreadId).toBe(
+      params.messageThreadId,
+    );
+  };
+
+  it("consumes surfaced generic wake context while deferring base-session exec completions", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const execCompletion = "exec finished: webhook-triggered backup completed";
+      const { cfg, sessionKey } = await createConfig({
+        tmpDir,
+        storePath,
+        target: "none",
+        isolatedSession: true,
+      });
+      const getReplySpy = vi.fn().mockResolvedValue({ text: "Handled internally" });
+      const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1", chatId: "155462274" });
+      enqueueSystemEvent("Gateway restart ok", { sessionKey });
+      enqueueSystemEvent(execCompletion, { sessionKey });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        source: "hook",
+        intent: "immediate",
+        reason: "hook:wake",
+        deps: {
+          getReplyFromConfig: getReplySpy,
+          telegram: sendTelegram,
+        },
+      });
+
+      const calledCtx: HeartbeatReplyContext | null =
+        getReplySpy.mock.calls.length === 0 ? null : getFirstReplyContext(getReplySpy);
+      expect(result.status).toBe("ran");
+      expect(calledCtx?.InternalTurnSource).toBe("heartbeat");
+      expect(calledCtx?.Body).toContain("Gateway restart ok");
+      expect(calledCtx?.Body).not.toContain(execCompletion);
+      expect(peekSystemEvents(sessionKey)).toEqual([execCompletion]);
+    });
+  });
+
+  it("routes wake-triggered heartbeat replies using queued system-event delivery context", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "last",
+            },
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+      await writeTelegramSessionStore(storePath, sessionKey, {});
+
+      const sendTelegram = vi.fn().mockResolvedValue({
+        messageId: "m1",
+        chatId: "-100155462274",
+      });
+      replySpy.mockResolvedValue({ text: "Restart complete" });
+      enqueueSystemEvent("Gateway restart ok", {
+        sessionKey,
+        deliveryContext: {
+          channel: "telegram",
+          to: "-100155462274",
+          threadId: 42,
+        },
+      });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        source: "hook",
+        intent: "immediate",
+        reason: "wake",
+        deps: {
+          getReplyFromConfig: replySpy,
+          telegram: sendTelegram,
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      expect(getFirstReplyContext(replySpy).Body).toContain("Gateway restart ok");
+      expectTelegramSend(sendTelegram, {
+        to: "-100155462274",
+        text: "Restart complete",
+        messageThreadId: 42,
+      });
+      expect(peekSystemEvents(sessionKey)).toEqual([]);
+    });
+  });
+
+  it("does not reuse stale turn-source routing for isolated wake runs", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = createLastTargetConfig({ tmpDir, storePath, isolatedSession: true });
+      const sessionKey = resolveMainSessionKey(cfg);
+      await writeTelegramSessionStore(storePath, sessionKey, { lastTo: "-100155462274" });
+
+      const sendTelegram = vi.fn().mockResolvedValue({
+        messageId: "m1",
+        chatId: "-100155462274",
+      });
+      replySpy.mockResolvedValue({ text: "Restart complete" });
+      enqueueSystemEvent("Gateway restart ok", {
+        sessionKey,
+        deliveryContext: {
+          channel: "telegram",
+          to: "-100999999999",
+          threadId: 42,
+        },
+      });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        source: "hook",
+        intent: "immediate",
+        reason: "wake",
+        deps: {
+          getReplyFromConfig: replySpy,
+          telegram: sendTelegram,
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      expect(getFirstReplyContext(replySpy).Body).toContain("Gateway restart ok");
+      expect(getFirstReplyContext(replySpy).SessionKey).toBe(`${sessionKey}:heartbeat`);
+      expectTelegramSend(sendTelegram, {
+        to: "-100155462274",
+        text: "Restart complete",
+      });
+    });
+  });
+
+  it("keeps output-bearing exec-event delivery pinned to the original Telegram topic when session route drifts", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "last",
+            },
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = "agent:main:telegram:group:-1003774691294:topic:47";
+      await writeTelegramSessionStore(storePath, sessionKey, {
+        lastTo: "telegram:-1003774691294:topic:2175",
+        lastThreadId: 2175,
+      });
+
+      const sendTelegram = vi.fn().mockResolvedValue({
+        messageId: "m1",
+        chatId: "-1003774691294",
+      });
+      const getReplySpy = vi.fn().mockResolvedValue({
+        text: "The review-worker spawn finished successfully.",
+      });
+      enqueueSystemEvent("Exec completed (review-run, code 0) :: review-worker spawn finished", {
+        sessionKey,
+        deliveryContext: {
+          channel: "telegram",
+          to: "telegram:-1003774691294:topic:47",
+          threadId: 47,
+        },
+      });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        sessionKey,
+        reason: "exec-event",
+        deps: {
+          getReplyFromConfig: getReplySpy,
+          telegram: sendTelegram,
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      expectTelegramSend(sendTelegram, {
+        to: "telegram:-1003774691294:topic:47",
+        text: "The review-worker spawn finished successfully.",
+        messageThreadId: 47,
+      });
+    });
+  });
+
+  it("suppresses metadata-only successful exec completions", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "last",
+            },
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = "agent:main:telegram:group:-1003774691294:topic:47";
+      await writeTelegramSessionStore(storePath, sessionKey, {
+        lastTo: "telegram:-1003774691294:topic:2175",
+        lastThreadId: 2175,
+      });
+
+      const sendTelegram = vi.fn();
+      const getReplySpy = vi.fn().mockResolvedValue({
+        text: "HEARTBEAT_OK",
+      });
+      enqueueSystemEvent("Exec completed (review-run, code 0)", {
+        sessionKey,
+        deliveryContext: {
+          channel: "telegram",
+          to: "telegram:-1003774691294:topic:47",
+          threadId: 47,
+        },
+      });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        sessionKey,
+        reason: "exec-event",
+        deps: {
+          getReplyFromConfig: getReplySpy,
+          telegram: sendTelegram,
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      expect(getFirstReplyContext(getReplySpy).Body).toContain("no command output was found");
+      expect(sendTelegram).not.toHaveBeenCalled();
+    });
+  });
+
+  it("re-queues the truncation-hidden tail of a partially shown wake event", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const { cfg, sessionKey } = await createConfig({ tmpDir, storePath });
+      const oversized = `Gateway restart report ${"x".repeat(12_000)}`;
+      enqueueSystemEvent(oversized, { sessionKey });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        source: "hook",
+        intent: "immediate",
+        reason: "hook:wake",
+        deps: {
+          getReplyFromConfig: replySpy,
+          telegram: vi.fn().mockResolvedValue({ messageId: "m1", chatId: "155462274" }),
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      expect(getFirstReplyContext(replySpy).Body).toContain("[truncated]");
+      const queued = peekSystemEvents(sessionKey);
+      expect(queued.length).toBe(1);
+      expect(queued[0]).toMatch(/^x+$/);
+      expect(queued[0]!.length).toBeGreaterThan(1_000);
+    });
+  });
+
+  it("keeps the re-queued remainder owned by the source agent", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const { cfg, sessionKey } = await createConfig({ tmpDir, storePath });
+      const oversized = `Gateway restart report ${"x".repeat(12_000)}`;
+      enqueueSystemEvent(oversized, withSystemEventOwner({ sessionKey }, "main"));
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        source: "hook",
+        intent: "immediate",
+        reason: "hook:wake",
+        deps: {
+          getReplyFromConfig: replySpy,
+          telegram: vi.fn().mockResolvedValue({ messageId: "m1", chatId: "155462274" }),
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      const continuation = peekSystemEventEntries(sessionKey);
+      expect(continuation.length).toBe(1);
+      expect(
+        selectAgentSystemEvents(continuation, "main").map((entry) => entry.text),
+        "the source agent still sees its continuation",
+      ).toHaveLength(1);
+      expect(
+        selectAgentSystemEvents(continuation, "beta"),
+        "another agent sharing the queue can never claim the continuation",
+      ).toHaveLength(0);
+    });
+  });
+
+  it("does not evict unrelated queued events when inserting a continuation at capacity", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const { cfg, sessionKey } = await createConfig({ tmpDir, storePath });
+      for (let index = 0; index < 19; index += 1) {
+        enqueueSystemEvent(`heartbeat poll ${index}`, { sessionKey });
+      }
+      enqueueSystemEvent(`Exec completed (report, code 0) :: ${"o".repeat(12_000)}`, {
+        sessionKey,
+      });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        source: "exec-event",
+        reason: "exec-event",
+        deps: {
+          getReplyFromConfig: replySpy,
+          telegram: vi.fn().mockResolvedValue({ messageId: "m1", chatId: "155462274" }),
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      const queued = peekSystemEvents(sessionKey);
+      expect(queued.length).toBe(20);
+      expect(queued.filter((entry) => entry.startsWith("heartbeat poll")).length).toBe(19);
+      expect(queued.at(-1)).toMatch(/^o+$/);
+    });
+  });
+
+  it("does not re-queue a remainder when the original was replaced mid-turn", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const { cfg, sessionKey } = await createConfig({ tmpDir, storePath });
+      const oversized = `Gateway restart report ${"x".repeat(12_000)}`;
+      enqueueSystemEvent(oversized, { sessionKey });
+      replySpy.mockImplementation(async () => {
+        // The event is replaced while the model turn is running; finalization
+        // must not resurrect its captured remainder as a stale continuation.
+        consumeSelectedSystemEventEntries(sessionKey, peekSystemEventEntries(sessionKey));
+        return { text: "HEARTBEAT_OK" };
+      });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        source: "hook",
+        intent: "immediate",
+        reason: "hook:wake",
+        deps: {
+          getReplyFromConfig: replySpy,
+          telegram: vi.fn().mockResolvedValue({ messageId: "m1", chatId: "155462274" }),
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      expect(peekSystemEvents(sessionKey)).toEqual([]);
+    });
+  });
+
+  it("keeps queued reminders unconsumed when a task wake runs the task prompt", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = createLastTargetConfig({ tmpDir, storePath });
+      const sessionKey = resolveMainSessionKey(cfg);
+      await writeTelegramSessionStore(storePath, sessionKey, {});
+      const reminder = "Reminder: review the scheduled report";
+      const generic = "Gateway restart ok";
+      enqueueSystemEvent(reminder, { sessionKey, contextKey: "cron:owner-report" });
+      enqueueSystemEvent(generic, { sessionKey });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        source: "interval",
+        intent: "task",
+        reason: "heartbeat-task:job-rotate-logs",
+        tasks: [
+          { jobId: "job-rotate-logs", name: "rotate-logs", prompt: "Rotate the workspace logs" },
+        ],
+        deps: {
+          getReplyFromConfig: replySpy,
+          telegram: vi.fn().mockResolvedValue({ messageId: "m1", chatId: "-100155462274" }),
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      const body = getFirstReplyContext(replySpy).Body ?? "";
+      expect(body).toContain("rotate-logs");
+      expect(body).not.toContain(reminder);
+      expect(body).not.toContain(generic);
+      expect(peekSystemEvents(sessionKey)).toEqual([reminder, generic]);
+    });
+  });
+
+  it("keeps Telegram topic routing for isolated scheduled heartbeats", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = createLastTargetConfig({ tmpDir, storePath, isolatedSession: true });
+      const sessionKey = resolveMainSessionKey(cfg);
+      await writeTelegramSessionStore(storePath, sessionKey, {
+        lastTo: "-100155462274",
+        deliveryContext: {
+          channel: "telegram",
+          to: "-100155462274",
+          threadId: 42,
+        },
+        chatType: "group",
+      });
+
+      const sendTelegram = vi.fn().mockResolvedValue({
+        messageId: "m1",
+        chatId: "-100155462274",
+      });
+      replySpy.mockResolvedValue({ text: "Topic heartbeat" });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        reason: "timer",
+        deps: {
+          getReplyFromConfig: replySpy,
+          telegram: sendTelegram,
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      const replyCtx = getFirstReplyContext(replySpy);
+      expect(replyCtx.SessionKey).toBe(`${sessionKey}:heartbeat`);
+      expect(replyCtx.MessageThreadId).toBe(42);
+      expectTelegramSend(sendTelegram, {
+        to: "-100155462274",
+        text: "Topic heartbeat",
+        messageThreadId: 42,
+      });
+    });
+  });
+});

--- a/test/e2e/qa-lab/runtime/gateway-heartbeat-session-routing.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-heartbeat-session-routing.e2e.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import { createServer, type ServerResponse } from "node:http";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { markCompleteReplyConfig } from "../../../../src/auto-reply/reply/get-reply-fast-path.test-support.js";
 import {
   clearConfigCache,
   clearRuntimeConfigSnapshot,
@@ -21,7 +22,12 @@ import {
 } from "../../../../src/gateway/test-helpers.e2e.js";
 import { buildMockOpenAiResponsesProvider } from "../../../../src/gateway/test-openai-responses-model.js";
 import { resetAgentEventsForTest } from "../../../../src/infra/agent-events.js";
-import { peekSystemEvents, resetSystemEventsForTest } from "../../../../src/infra/system-events.js";
+import {
+  consumeSelectedSystemEventEntries,
+  peekSystemEventEntries,
+  peekSystemEvents,
+  resetSystemEventsForTest,
+} from "../../../../src/infra/system-events.js";
 import { resetTaskRegistryForTests } from "../../../../src/tasks/task-runtime.test-helpers.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../../../../src/test-utils/env.js";
 import { normalizeSessionDeliveryState } from "../../../../src/utils/delivery-context.shared.js";
@@ -208,7 +214,7 @@ describe("Gateway heartbeat session routing", () => {
 
   it(
     "routes monitor and explicit wakes while preserving prompt-omitted events",
-    { timeout: 90_000 },
+    { timeout: 120_000 },
     async () => {
       const envSnapshot = captureEnv([...ISOLATED_GATEWAY_ENV_KEYS]);
       const tempHome = tempDirs.make("openclaw-gateway-heartbeat-routing-");
@@ -264,6 +270,10 @@ describe("Gateway heartbeat session routing", () => {
       const overflowEvent = `${overflowEventPrefix} ${"x".repeat(8_100)}`;
       const overflowOmittedEvent = nextId("overflow-omitted-event");
       const overflowReply = nextId("overflow-heartbeat-reply");
+      const sharedOverflowEventPrefix = nextId("shared-overflow-visible-event");
+      const sharedOverflowEvent = `${sharedOverflowEventPrefix} ${"y".repeat(8_100)}`;
+      const sharedOmittedEvent = nextId("shared-overflow-omitted-event");
+      const sharedOverflowReply = nextId("shared-overflow-reply");
       const mainSessionKey = "agent:main:main";
       const mainSessionId = nextId("main-session");
       const providerRequests: Array<Record<string, unknown>> = [];
@@ -287,11 +297,14 @@ describe("Gateway heartbeat session routing", () => {
             response,
             serialized.includes(overflowEventPrefix)
               ? overflowReply
-              : serialized.includes(configuredEvent)
-                ? configuredReply
-                : serialized.includes(explicitQueuedEvent) || serialized.includes(explicitWakeText)
-                  ? explicitReply
-                  : nextId("unexpected-heartbeat-reply"),
+              : serialized.includes(sharedOverflowEventPrefix)
+                ? sharedOverflowReply
+                : serialized.includes(configuredEvent)
+                  ? configuredReply
+                  : serialized.includes(explicitQueuedEvent) ||
+                      serialized.includes(explicitWakeText)
+                    ? explicitReply
+                    : nextId("unexpected-heartbeat-reply"),
           );
         })().catch((error: unknown) => {
           response.writeHead(500).end(error instanceof Error ? error.message : String(error));
@@ -371,6 +384,7 @@ describe("Gateway heartbeat session routing", () => {
         if (!runtimeConfig) {
           throw new Error("gateway runtime config snapshot was not initialized");
         }
+        markCompleteReplyConfig(runtimeConfig, { runtimeMode: "full" });
         const client = gateway.client;
 
         const seedSession = async (params: {
@@ -470,7 +484,8 @@ describe("Gateway heartbeat session routing", () => {
                 runId: configuredRun.runId,
                 limit: 1,
               });
-              return history.entries.find((entry) => entry.runId === configuredRun.runId);
+              const entry = history.entries.find((e) => e.runId === configuredRun.runId);
+              return entry;
             },
             { timeout: 15_000, interval: 50 },
           )
@@ -480,6 +495,10 @@ describe("Gateway heartbeat session routing", () => {
           .toBeGreaterThan(configuredRequestBaseline);
         const configuredRequest = JSON.stringify(providerRequests[configuredRequestBaseline]);
         expect(configuredRequest).toContain(configuredEvent);
+        expect(
+          configuredRequest.split(configuredEvent).length - 1,
+          "the queued event reaches the shared-session model turn exactly once",
+        ).toBe(1);
         await expect
           .poll(() => peekSystemEvents(configuredSessionKey).includes(configuredEvent), {
             timeout: 15_000,
@@ -541,6 +560,11 @@ describe("Gateway heartbeat session routing", () => {
         const explicitRequest = JSON.stringify(providerRequests[explicitRequestBaseline]);
         expect(explicitRequest).toContain(explicitQueuedEvent);
         expect(explicitRequest).toContain(explicitWakeText);
+        expect(
+          explicitRequest.split(explicitQueuedEvent).length - 1,
+          "the shared-session wake renders the queued event exactly once",
+        ).toBe(1);
+        expect(explicitRequest.split(explicitWakeText).length - 1).toBe(1);
         await expect
           .poll(
             () => {
@@ -592,6 +616,64 @@ describe("Gateway heartbeat session routing", () => {
         expect((await readDeliveryTrace(deliveryTracePath)).map((entry) => entry.to)).not.toContain(
           "main-destination",
         );
+
+        // Shared-session overflow: the bounded composed prompt is the only
+        // rendering owner, so the represented event reaches the model turn
+        // exactly once and the cap-omitted event stays queued.
+        await expect(
+          client.request<{ ok: boolean }>("system-event", {
+            text: sharedOverflowEvent,
+            sessionKey: configuredSessionKey,
+            wake: false,
+          }),
+        ).resolves.toEqual({ ok: true });
+        const sharedOverflowBaseline = providerRequests.length;
+        await expect(
+          client.request<{ ok: boolean }>("system-event", {
+            text: sharedOmittedEvent,
+            sessionKey: configuredSessionKey,
+            wake: true,
+          }),
+        ).resolves.toEqual({ ok: true });
+        await expect
+          .poll(() => providerRequests.length, { timeout: 15_000, interval: 50 })
+          .toBeGreaterThan(sharedOverflowBaseline);
+        const sharedOverflowRequest = JSON.stringify(providerRequests[sharedOverflowBaseline]);
+        expect(sharedOverflowRequest).toContain(sharedOverflowEventPrefix);
+        expect(sharedOverflowRequest).not.toContain(sharedOmittedEvent);
+        expect(
+          sharedOverflowRequest.split(sharedOverflowEventPrefix).length - 1,
+          "the shared-session wake renders the represented event exactly once",
+        ).toBe(1);
+        await expect
+          .poll(() => peekSystemEvents(configuredSessionKey).includes(sharedOverflowEvent), {
+            timeout: 15_000,
+            interval: 50,
+          })
+          .toBe(false);
+        // The oversized event was partially shown, so its truncation-hidden
+        // tail re-queues as a continuation next to the cap-omitted event.
+        const sharedQueuedAfterOverflow = peekSystemEvents(configuredSessionKey);
+        expect(sharedQueuedAfterOverflow).toHaveLength(2);
+        expect(sharedQueuedAfterOverflow).toContain(sharedOmittedEvent);
+        expect(sharedQueuedAfterOverflow.find((entry) => entry !== sharedOmittedEvent)).toMatch(
+          /^y+$/,
+        );
+        await expect
+          .poll(() => readDeliveryTrace(deliveryTracePath), { timeout: 15_000, interval: 50 })
+          .toHaveLength(3);
+        expect((await readDeliveryTrace(deliveryTracePath)).at(-1)).toEqual({
+          accountId: "default",
+          text: sharedOverflowReply,
+          threadId: null,
+          to: "configured-destination",
+        });
+        // Leave the configured queue empty for the isolated restart below.
+        consumeSelectedSystemEventEntries(
+          configuredSessionKey,
+          peekSystemEventEntries(configuredSessionKey),
+        );
+        expect(peekSystemEvents(configuredSessionKey)).toEqual([]);
 
         await disconnectGatewayClient(client);
         await gateway.server.close({ reason: "Restart with isolated heartbeat session enabled" });
@@ -665,10 +747,17 @@ describe("Gateway heartbeat session routing", () => {
             interval: 50,
           })
           .toBe(false);
-        expect(peekSystemEvents(configuredSessionKey)).toEqual([overflowOmittedEvent]);
+        // The oversized event was partially shown, so its truncation-hidden
+        // tail re-queues as a continuation next to the cap-omitted event.
+        const isolatedQueuedAfterOverflow = peekSystemEvents(configuredSessionKey);
+        expect(isolatedQueuedAfterOverflow).toHaveLength(2);
+        expect(isolatedQueuedAfterOverflow).toContain(overflowOmittedEvent);
+        expect(isolatedQueuedAfterOverflow.find((entry) => entry !== overflowOmittedEvent)).toMatch(
+          /^x+$/,
+        );
         await expect
           .poll(() => readDeliveryTrace(deliveryTracePath), { timeout: 15_000, interval: 50 })
-          .toHaveLength(3);
+          .toHaveLength(4);
         expect((await readDeliveryTrace(deliveryTracePath)).at(-1)).toEqual({
           accountId: "default",
           text: overflowReply,

--- a/test/e2e/qa-lab/runtime/gateway-heartbeat-session-routing.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-heartbeat-session-routing.e2e.test.ts
@@ -207,7 +207,7 @@ describe("Gateway heartbeat session routing", () => {
   afterEach(resetGatewayState);
 
   it(
-    "routes monitor wakes through heartbeat.session while preserving explicit wake sessions",
+    "routes monitor and explicit wakes while preserving prompt-omitted events",
     { timeout: 90_000 },
     async () => {
       const envSnapshot = captureEnv([...ISOLATED_GATEWAY_ENV_KEYS]);
@@ -260,6 +260,10 @@ describe("Gateway heartbeat session routing", () => {
       const explicitQueuedEvent = nextId("explicit-queued-event");
       const explicitWakeText = nextId("explicit-wake-event");
       const explicitReply = nextId("explicit-heartbeat-reply");
+      const overflowEventPrefix = nextId("overflow-visible-event");
+      const overflowEvent = `${overflowEventPrefix} ${"x".repeat(8_100)}`;
+      const overflowOmittedEvent = nextId("overflow-omitted-event");
+      const overflowReply = nextId("overflow-heartbeat-reply");
       const mainSessionKey = "agent:main:main";
       const mainSessionId = nextId("main-session");
       const providerRequests: Array<Record<string, unknown>> = [];
@@ -281,11 +285,13 @@ describe("Gateway heartbeat session routing", () => {
           const serialized = JSON.stringify(body);
           writeAssistantResponse(
             response,
-            serialized.includes(configuredEvent)
-              ? configuredReply
-              : serialized.includes(explicitQueuedEvent) || serialized.includes(explicitWakeText)
-                ? explicitReply
-                : nextId("unexpected-heartbeat-reply"),
+            serialized.includes(overflowEventPrefix)
+              ? overflowReply
+              : serialized.includes(configuredEvent)
+                ? configuredReply
+                : serialized.includes(explicitQueuedEvent) || serialized.includes(explicitWakeText)
+                  ? explicitReply
+                  : nextId("unexpected-heartbeat-reply"),
           );
         })().catch((error: unknown) => {
           response.writeHead(500).end(error instanceof Error ? error.message : String(error));
@@ -586,6 +592,89 @@ describe("Gateway heartbeat session routing", () => {
         expect((await readDeliveryTrace(deliveryTracePath)).map((entry) => entry.to)).not.toContain(
           "main-destination",
         );
+
+        await disconnectGatewayClient(client);
+        await gateway.server.close({ reason: "Restart with isolated heartbeat session enabled" });
+        gateway = undefined;
+        resetGatewayState();
+
+        const isolatedConfig: OpenClawConfig = {
+          ...config,
+          agents: {
+            ...config.agents,
+            defaults: {
+              ...config.agents?.defaults,
+              heartbeat: {
+                ...config.agents?.defaults?.heartbeat,
+                isolatedSession: true,
+              },
+            },
+          },
+        };
+        gateway = await startGatewayWithClient({
+          cfg: isolatedConfig,
+          configPath,
+          token,
+          clientDisplayName: "vitest-gateway-heartbeat-overflow-routing",
+        });
+        const isolatedRuntimeConfig = getRuntimeConfigSnapshot();
+        if (!isolatedRuntimeConfig) {
+          throw new Error("isolated Gateway runtime config snapshot was not initialized");
+        }
+        markCompleteReplyConfig(isolatedRuntimeConfig, { runtimeMode: "full" });
+        const isolatedClient = gateway.client;
+        await seedSession({
+          sessionId: configuredSessionId,
+          sessionKey: configuredSessionKey,
+          to: "configured-destination",
+        });
+
+        await expect(
+          isolatedClient.request<{ ok: boolean }>("system-event", {
+            text: overflowEvent,
+            sessionKey: configuredSessionKey,
+            wake: false,
+          }),
+        ).resolves.toEqual({ ok: true });
+        expect(peekSystemEvents(configuredSessionKey)).toEqual([overflowEvent]);
+
+        const overflowRequestBaseline = providerRequests.length;
+        await expect(
+          isolatedClient.request<{ ok: boolean }>("system-event", {
+            text: overflowOmittedEvent,
+            sessionKey: configuredSessionKey,
+            wake: true,
+          }),
+        ).resolves.toEqual({ ok: true });
+        await expect
+          .poll(() => providerRequests.length, { timeout: 15_000, interval: 50 })
+          .toBeGreaterThan(overflowRequestBaseline);
+        const overflowRequest = JSON.stringify(providerRequests[overflowRequestBaseline]);
+        expect(overflowRequest).toContain(overflowEventPrefix);
+        expect(overflowRequest).not.toContain(overflowOmittedEvent);
+        expect(
+          loadSessionEntry({
+            agentId: "main",
+            sessionKey: `${configuredSessionKey}:heartbeat`,
+            readConsistency: "latest",
+          })?.heartbeatIsolatedBaseSessionKey,
+        ).toBe(configuredSessionKey);
+        await expect
+          .poll(() => peekSystemEvents(configuredSessionKey).includes(overflowEvent), {
+            timeout: 15_000,
+            interval: 50,
+          })
+          .toBe(false);
+        expect(peekSystemEvents(configuredSessionKey)).toEqual([overflowOmittedEvent]);
+        await expect
+          .poll(() => readDeliveryTrace(deliveryTracePath), { timeout: 15_000, interval: 50 })
+          .toHaveLength(3);
+        expect((await readDeliveryTrace(deliveryTracePath)).at(-1)).toEqual({
+          accountId: "default",
+          text: overflowReply,
+          threadId: null,
+          to: "configured-destination",
+        });
       } finally {
         if (gateway) {
           await disconnectGatewayClient(gateway.client);


### PR DESCRIPTION
Closes #131855

## What Problem This Solves

Fixes an issue where a gateway restart recovery wake could consume its queued
system event without showing the restart result to the heartbeat model. The
same loss occurred when the restart event was coalesced with an exec completion
or tagged cron reminder, and when a bounded event prompt omitted a later queued
event after reaching its character cap.

This update also repairs the two ownership defects from the September 5 review:
on shared sessions the queued generic events were rendered twice (composed
heartbeat prompt plus reply admission's `System:` prelude) and admission could
consume events the prompt cap had omitted, and a quiet metadata-only exec
completion could silence a coalesced reminder that still required delivery.

## Why This Change Was Made

Heartbeat prompt resolution composes every inspected event class (generic, exec,
and cron) into one bounded model turn while preserving each class's existing
delivery semantics. The prompt owner tracks which original event ranges survive
both class-level and aggregate truncation, maps those retained ranges back to
the original queued entries, and passes that exact set to the terminal
consumption owner.

Rendering and consumption now have exactly one owner per turn. The composed
prompt is the only renderer for the event classes it embeds, and current main's
prepared-event handoff (`withReplySystemEventContext`) is the single selection
boundary: reply admission receives only the generic entries the composed prompt
did not embed (empty for isolated runs), so nothing is rendered twice and
cap-omitted events stay queued for a later ordinary turn instead of being
silently consumed. Periodic heartbeats keep handing their generic selection to
admission, and delivery-awareness events keep waiting for the ordinary target
session turn.

The completion policy is now decided once per batch. Standalone event prompts
keep their existing instructions, but a composed multi-class batch carries a
single completion instruction: relaying is allowed whenever any shown event
needs user delivery, and silence applies only when nothing in the batch does.
A metadata-only successful exec completion no longer injects a per-section
"Reply NO_REPLY only" directive that could suppress a coalesced reminder while
both were marked handled.

## User Impact

Restart notes, exec results, and cron reminders that arrive together are visible
to the model in the heartbeat turn that owns them, exactly once. Events shown to
the model are consumed after a successful run, while events omitted by the
bounded prompt stay queued for a later turn on both shared and isolated
sessions. Mixed batches no longer carry contradictory silence and relay
instructions, so a reminder arriving next to a quiet exec completion is still
delivered. Deferred exec completions, delivery-awareness events, and periodic
heartbeat behavior keep their existing owners and lifecycle.

## Evidence

- Real Gateway E2E (`test/e2e/qa-lab/runtime/gateway-heartbeat-session-routing.e2e.test.ts`) passed through the production gateway restarted twice, the heartbeat scheduler, configured/explicit/main sessions, a loopback OpenAI Responses provider capturing every model request, a real outbound channel plugin, transcript persistence, and terminal queue checks. Partially shown oversized events are consumed together with a re-queued continuation carrying their truncation-hidden tail, so no queued content is dropped. Continuations preserve the source entry's agent-owner metadata (another agent sharing the queue can never claim them), are inserted only after the selected originals are consumed (no capacity-bound eviction of unrelated entries), are created only for occurrences the run actually transitioned (replaced originals leave no stale text), and combine class-cap suffixes with aggregate gaps in source order; exec entries consumed as a class also record their aggregate gaps. Shared-session provider requests contain each queued restart/wake event exactly once, and a dedicated shared-session overflow phase verifies that a prompt-cap-omitted event stays queued while the represented oversized event is consumed after delivery. The isolated overflow phase keeps verifying `:heartbeat` base-session ownership and omitted-event retention.
- Focused Vitest (project-shard runner): `heartbeat-events-filter.test.ts` 65 passed; `heartbeat-runner-mixed-events.test.ts`, `heartbeat-runner.ghost-reminder.test.ts`, the new `heartbeat-runner.wake-delivery.test.ts`, and the owner-boundary suite `heartbeat-runner.event-routing.test.ts` pass together with the admission suites (`session.test.ts`, `get-reply-run.media-only.test.ts`, 381 passed). Regressions cover the single batch completion policy for a quiet-exec-plus-reminder batch, the admission handoff receiving no generic selection while the composed prompt owns rendering, periodic wakes still handing generic events to admission, exact-once generic rendering on exec wakes, task-prompt turns leaving queued reminders unconsumed, exec sections consuming completions as a class so truncated entries are never stranded, mode-parity of the retained selection across relay/internal/response-tool settings, the ≥50%-retention fragment rule, continuation re-queueing of truncation-hidden tails, agent-owner preservation on continuations (source agent sees its continuation, a sibling agent's selection rejects it), capacity-bound insertion without evicting unrelated queued entries, no continuation for mid-turn replaced occurrences, aggregate-gap recording for class-consumed exec events, source-ordered combined gaps with distinguishable content, exact content conservation across both truncation stages (shown chunk plus recorded remainder equals the original), bounded successive-wake progress for oversized events (each wake surfaces a chunk and re-queues the exact remainder), a single continuation collector per class (no duplicated continuations), and the missing-output exec suffix included in the constant aggregate budget so full batches stay within the limit.
- `pnpm tsgo:core` passed; scoped `oxlint` and `oxfmt --check` over all changed files passed; `git diff --check` clean.
- `node scripts/check-changed.mjs` core/testRoot/tooling plan: all guards pass (conflict markers, max-lines ratchet, changelog attributions, boundaries, schema, import cycles) except `typecheck core tests`, which fails on `src/gateway/session-history-state.test.ts` — a stale history fixture inherited from this branch's merge-base and already fixed on `main` by #139794; CI evaluates the merged result and is unaffected.

## Review Metrics

Production delta remains focused on the heartbeat event ownership path
(prompt composition, exact selection handoff, and terminal consumption) plus a
single-sourced `compactSystemEvent`. It adds no config, schema, persistence
format, public API, compatibility path, or fallback. Tests cover multi-class
composition and consumption, prompt-cap retention, shared-session exact
occurrence counts through the provider boundary, batch completion policy,
deferred isolated-session ownership, and the real Gateway routing path.
