### PR TITLE
fix(ui): recover when the managed CLI is missing

### DIFF
--- a/apps/linux/src-tauri/src/cli.rs
+++ b/apps/linux/src-tauri/src/cli.rs
@@ -4,11 +4,14 @@ use std::ffi::OsString;
 use std::fmt;
 use std::path::PathBuf;
 use std::process::{Command, Output, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 #[derive(Clone, Debug)]
 pub struct OpenClawCli {
     executable: PathBuf,
     openclaw_home: PathBuf,
+    available: Arc<AtomicBool>,
 }
 
 #[derive(Debug)]
@@ -61,7 +64,12 @@ impl OpenClawCli {
         Self {
             executable,
             openclaw_home,
+            available: Arc::new(AtomicBool::new(true)),
         }
+    }
+
+    pub fn is_available(&self) -> bool {
+        self.available.load(Ordering::Acquire)
     }
 
     fn verify(&self) -> Result<(), CliError> {
@@ -92,9 +100,15 @@ impl OpenClawCli {
         I: IntoIterator<Item = S>,
         S: AsRef<std::ffi::OsStr>,
     {
-        self.command(args)?
-            .output()
-            .map_err(|error| CliError::Spawn(format!("Failed to run OpenClaw CLI: {error}")))
+        let mut command = self.command(args)?;
+        command.stdout(Stdio::piped()).stderr(Stdio::piped());
+        let child = command.spawn().map_err(|error| {
+            self.available.store(false, Ordering::Release);
+            CliError::Spawn(format!("Failed to run OpenClaw CLI: {error}"))
+        })?;
+        child.wait_with_output().map_err(|error| {
+            CliError::Spawn(format!("Failed to read OpenClaw CLI output: {error}"))
+        })
     }
 
     pub fn json<T, I, S>(&self, args: I) -> Result<(T, Output), CliError>
@@ -159,7 +173,8 @@ pub fn openclaw_home() -> Result<PathBuf, CliError> {
 
 #[cfg(test)]
 mod tests {
-    use super::output_tail;
+    use super::{output_tail, OpenClawCli};
+    use std::path::PathBuf;
 
     #[test]
     fn output_tail_keeps_the_last_twelve_nonempty_lines() {
@@ -174,5 +189,17 @@ mod tests {
 
         assert_eq!(output_tail(output.as_bytes()), Some(expected));
         assert_eq!(output_tail(b"\n  \n"), None);
+    }
+
+    #[test]
+    fn missing_executable_invalidates_the_cached_cli() {
+        let cli = OpenClawCli::new(
+            PathBuf::from("openclaw-test-executable-that-does-not-exist"),
+            PathBuf::new(),
+        );
+
+        assert!(cli.is_available());
+        assert!(cli.output(["--version"]).is_err());
+        assert!(!cli.is_available());
     }
 }

--- a/apps/linux/src-tauri/src/main.rs
+++ b/apps/linux/src-tauri/src/main.rs
@@ -459,11 +459,7 @@ impl DesktopState {
         let cli = match self.resolve_cli() {
             Ok(cli) => cli,
             Err(CliError::Missing) => {
-                app.state::<gateway_ws::GatewayClient>()
-                    .clear_configuration(app);
-                let snapshot = GatewaySnapshot::missing_cli();
-                self.update_tray(&snapshot);
-                return Ok(snapshot);
+                return self.show_missing_cli(app, explicit_local, None);
             }
             Err(error) => return Err(error.to_string()),
         };
@@ -485,7 +481,7 @@ impl DesktopState {
         let navigated = self.navigate_local(app, &ready.dashboard_url, false, None, true, true)?;
         self.update_tray(&ready.snapshot);
         if navigated {
-            self.start_watchdog(app.clone());
+            self.start_watchdog(app.clone(), cli);
         }
         Ok(ready.snapshot)
     }
@@ -547,7 +543,7 @@ impl DesktopState {
             })?;
         self.update_tray(&ready.snapshot);
         if navigated {
-            self.start_watchdog(app.clone());
+            self.start_watchdog(app.clone(), cli);
         }
         Ok(ready.snapshot)
     }
@@ -581,7 +577,7 @@ impl DesktopState {
         let navigated = self.navigate_local(app, &ready.dashboard_url, false, None, true, true)?;
         self.update_tray(&ready.snapshot);
         if navigated {
-            self.start_watchdog(app.clone());
+            self.start_watchdog(app.clone(), cli);
         }
         Ok(ready.snapshot)
     }
@@ -746,7 +742,14 @@ impl DesktopState {
     }
 
     pub(crate) fn resolve_cli(&self) -> Result<OpenClawCli, CliError> {
-        if let Some(cli) = self.inner.cli.lock().expect("CLI mutex poisoned").clone() {
+        if let Some(cli) = self
+            .inner
+            .cli
+            .lock()
+            .expect("CLI mutex poisoned")
+            .clone()
+            .filter(OpenClawCli::is_available)
+        {
             return Ok(cli);
         }
         let cli = OpenClawCli::discover()?;
@@ -774,6 +777,39 @@ impl DesktopState {
             .as_ref()
         {
             tray.update(snapshot);
+        }
+    }
+
+    fn show_missing_cli(
+        &self,
+        app: &AppHandle,
+        force: bool,
+        expected_generation: Option<u64>,
+    ) -> Result<GatewaySnapshot, String> {
+        let snapshot = GatewaySnapshot::missing_cli();
+        match self.show_local(app, "missingCli", force, expected_generation) {
+            Ok(false) => return Ok(snapshot),
+            Ok(true) => {}
+            Err(error) => {
+                self.update_tray(&snapshot);
+                return Err(error);
+            }
+        }
+        app.state::<gateway_ws::GatewayClient>()
+            .clear_configuration(app);
+        self.update_tray(&snapshot);
+        Ok(snapshot)
+    }
+
+    fn show_cli_recovery_error(&self, app: &AppHandle, generation: u64, error: CliError) {
+        let mut snapshot = GatewaySnapshot::missing_cli();
+        snapshot.status = "CLI unavailable".to_string();
+        snapshot.detail = Some(error.to_string());
+        if !matches!(
+            self.show_local(app, "error", false, Some(generation)),
+            Ok(false)
+        ) {
+            self.update_tray(&snapshot);
         }
     }
 
@@ -902,7 +938,7 @@ impl DesktopState {
             .is_ok_and(|navigation| navigation.watchdog_is_current(generation))
     }
 
-    fn start_watchdog(&self, app: AppHandle) {
+    fn start_watchdog(&self, app: AppHandle, mut cli: OpenClawCli) {
         let generation = {
             let Ok(mut navigation) = self.inner.navigation.lock() else {
                 return;
@@ -919,9 +955,6 @@ impl DesktopState {
                 return;
             }
             let Ok(_operation) = state.inner.operation.try_lock() else {
-                continue;
-            };
-            let Ok(cli) = state.resolve_cli() else {
                 continue;
             };
             let snapshot = match gateway::status(&cli) {
@@ -958,6 +991,19 @@ impl DesktopState {
                     return;
                 }
                 if let Ok(_operation) = state.inner.operation.try_lock() {
+                    if !cli.is_available() {
+                        match state.resolve_cli() {
+                            Ok(discovered) => cli = discovered,
+                            Err(error) => {
+                                if matches!(error, CliError::Missing) {
+                                    let _ = state.show_missing_cli(&app, false, Some(generation));
+                                } else {
+                                    state.show_cli_recovery_error(&app, generation, error);
+                                }
+                                return;
+                            }
+                        }
+                    }
                     let snapshot = match gateway::status(&cli) {
                         Ok(snapshot) => snapshot,
                         Err(error) => GatewaySnapshot::reconnecting(error),

--- a/apps/linux/src-tauri/src/main.rs
+++ b/apps/linux/src-tauri/src/main.rs
@@ -787,28 +787,24 @@ impl DesktopState {
         expected_generation: Option<u64>,
     ) -> Result<GatewaySnapshot, String> {
         let snapshot = GatewaySnapshot::missing_cli();
-        match self.show_local(app, "missingCli", force, expected_generation) {
-            Ok(false) => return Ok(snapshot),
-            Ok(true) => {}
-            Err(error) => {
-                self.update_tray(&snapshot);
-                return Err(error);
-            }
+        let navigation = self.show_local(app, "missingCli", force, expected_generation);
+        if !local_recovery_owns_gateway(&navigation) {
+            return Ok(snapshot);
         }
         app.state::<gateway_ws::GatewayClient>()
             .clear_configuration(app);
         self.update_tray(&snapshot);
-        Ok(snapshot)
+        navigation.map(|_| snapshot)
     }
 
     fn show_cli_recovery_error(&self, app: &AppHandle, generation: u64, error: CliError) {
         let mut snapshot = GatewaySnapshot::missing_cli();
         snapshot.status = "CLI unavailable".to_string();
         snapshot.detail = Some(error.to_string());
-        if !matches!(
-            self.show_local(app, "error", false, Some(generation)),
-            Ok(false)
-        ) {
+        let navigation = self.show_local(app, "error", false, Some(generation));
+        if local_recovery_owns_gateway(&navigation) {
+            app.state::<gateway_ws::GatewayClient>()
+                .clear_configuration(app);
             self.update_tray(&snapshot);
         }
     }
@@ -1057,9 +1053,16 @@ fn local_mode(snapshot: &GatewaySnapshot) -> &'static str {
     }
 }
 
+fn local_recovery_owns_gateway(navigation: &Result<bool, String>) -> bool {
+    !matches!(navigation, Ok(false))
+}
+
 #[cfg(test)]
 mod navigation_tests {
-    use super::{is_active_onboarding_url, is_release_version, NavigationState, Url};
+    use super::{
+        is_active_onboarding_url, is_release_version, local_recovery_owns_gateway, NavigationState,
+        Url,
+    };
 
     #[test]
     fn only_active_onboarding_preserves_the_dashboard_during_reconnect() {
@@ -1141,6 +1144,15 @@ mod navigation_tests {
 
         assert!(!navigation.permit_local(false, None));
         assert!(navigation.remote_dashboard);
+    }
+
+    #[test]
+    fn local_recovery_clears_retained_gateway_unless_remote_navigation_won() {
+        assert!(local_recovery_owns_gateway(&Ok(true)));
+        assert!(local_recovery_owns_gateway(&Err(
+            "local navigation failed".to_string()
+        )));
+        assert!(!local_recovery_owns_gateway(&Ok(false)));
     }
 
     #[test]

--- a/apps/linux/ui/main.js
+++ b/apps/linux/ui/main.js
@@ -593,7 +593,15 @@ void refreshGateways();
 window.setInterval(() => void refreshGateways(), 2000);
 
 const mode = new URLSearchParams(window.location.search).get("mode");
-if (mode === "reconnecting") {
+if (mode === "missingCli") {
+  render({
+    description: "Install the OpenClaw CLI to connect to a local Gateway.",
+    dot: "idle",
+    eyebrow: "CLI REQUIRED",
+    showInstall: true,
+    title: "OpenClaw needs the CLI",
+  });
+} else if (mode === "reconnecting") {
   render({
     activity: "Retrying every few seconds…",
     description: "The gateway connection dropped. OpenClaw will restore the dashboard automatically.",

--- a/test/linux-dashboard-recovery.test.ts
+++ b/test/linux-dashboard-recovery.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import vm from "node:vm";
+import { test } from "vitest";
+
+const dashboardSource = readFileSync(new URL("../apps/linux/ui/main.js", import.meta.url), "utf8");
+
+function fakeElement() {
+  const classes = new Set(["hidden"]);
+  return {
+    className: "",
+    classList: {
+      contains: (name: string) => classes.has(name),
+      toggle(name: string, force?: boolean) {
+        const enabled = force ?? !classes.has(name);
+        if (enabled) classes.add(name);
+        else classes.delete(name);
+      },
+    },
+    disabled: false,
+    textContent: "",
+    value: "stable",
+    addEventListener() {},
+    append() {},
+    removeAttribute() {},
+    replaceChildren() {},
+    setAttribute() {},
+  };
+}
+
+test("missing CLI mode offers installation without retrying bootstrap", async () => {
+  const elements = new Map<string, ReturnType<typeof fakeElement>>();
+  const invoked: string[] = [];
+  const document = {
+    createElement: fakeElement,
+    querySelector(selector: string) {
+      if (!elements.has(selector)) elements.set(selector, fakeElement());
+      return elements.get(selector);
+    },
+  };
+  const window = {
+    __TAURI__: {
+      core: {
+        invoke(command: string) {
+          invoked.push(command);
+          if (command === "discover_gateways") return Promise.resolve([]);
+          return Promise.resolve({ phase: "connected" });
+        },
+      },
+      event: { listen: async () => () => {} },
+    },
+    location: { search: "?mode=missingCli" },
+    setInterval() {},
+  };
+
+  await vm.runInNewContext(`(async () => { ${dashboardSource}\n})()`, {
+    document,
+    URLSearchParams,
+    window,
+  });
+
+  assert.equal(elements.get("#title")?.textContent, "OpenClaw needs the CLI");
+  assert.equal(elements.get("#install-controls")?.classList.contains("hidden"), false);
+  assert.equal(invoked.includes("bootstrap"), false);
+});
+
+test("CLI recovery errors offer both retry and reinstall", async () => {
+  const elements = new Map<string, ReturnType<typeof fakeElement>>();
+  const document = {
+    createElement: fakeElement,
+    querySelector(selector: string) {
+      if (!elements.has(selector)) elements.set(selector, fakeElement());
+      return elements.get(selector);
+    },
+  };
+  const window = {
+    __TAURI__: {
+      core: { invoke: () => Promise.resolve([]) },
+      event: { listen: async () => () => {} },
+    },
+    location: { search: "?mode=error" },
+    setInterval() {},
+  };
+
+  await vm.runInNewContext(`(async () => { ${dashboardSource}\n})()`, {
+    document,
+    URLSearchParams,
+    window,
+  });
+
+  assert.equal(elements.get("#primary-action")?.textContent, "Try again");
+  assert.equal(elements.get("#action-controls")?.classList.contains("hidden"), false);
+  assert.equal(elements.get("#install-controls")?.classList.contains("hidden"), false);
+});


### PR DESCRIPTION
Closes #131971

## What Problem This Solves

Fixes an issue where Linux users choosing **Open Dashboard** could remain on a passive “Reconnecting” screen when no usable local `openclaw` executable was available. The same dead end could appear if a previously resolved CLI disappeared during watchdog recovery.

## Why This Change Was Made

The native desktop now routes missing-CLI state through the existing navigation lock and generation arbitration into the install-capable local screen. CLI handles are invalidated only after an actual spawn failure, allowing the watchdog to rediscover once without filesystem polling, automatic installation, or a parallel recovery path. Allowed local recovery also clears any retained Gateway client even if local navigation fails; a newer remote selection remains the only cleanup escape.

## User Impact

**Open Dashboard**, dashboard deep links, and Quick Chat dashboard actions now offer **Install OpenClaw** when the local CLI is missing instead of promising retries that cannot succeed. If a cached CLI disappears, reconnection ends in either the install screen or an error with both retry and reinstall actions, while a newer remote selection remains authoritative.

## Evidence

- The focused renderer regression failed before the fix and now passes 2/2 cases, covering missing-CLI installation and retry-plus-reinstall error exits.
- The native desktop suite previously passed 130 tests, including cached-handle invalidation and existing navigation-generation and remote-arbitration coverage. A focused Rust regression now covers retained-connection cleanup versus the remote-selection escape.
- Fresh exact-head CI is green on `6376b2edbb1aa072b8dddbcfdf56ac73a1af2498`, including the Linux companion build, the macOS companion test, Workflow Sanity, `build-artifacts`, and the aggregate `openclaw/ci-gate`.
- Judged LOC: production +97/-29 (net +68); tests +121/-2 (net +119), including Rust `#[cfg(test)]` hunks. The production growth carries the shared spawn-failure fact and the canonical DesktopState transition; no config, schema, protocol, persistence, dependency, or compatibility surface is added.
- Live graphical capture was not available on this host. The real renderer script was exercised in the focused DOM harness, and hosted CI builds and tests the native companion.
