### PR TITLE
fix(cron): current-session automations fail with "Channel is required" on webchat-only gateways

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -412,6 +412,8 @@ WebChat receives the committed `session.message` event immediately. The same ass
 
 If the bound conversation is an external channel, OpenClaw also performs its normal durable channel send. That send still happens at most once, and the required session commit does not create a second external message. A verified `message` tool send suppresses the automatic channel resend but does not suppress the session commit. The run is reported delivered only after both the external recipient handoff (when required) and the canonical session commit succeed.
 
+When the bound conversation has no external channel route — WebChat/Control UI conversations, or a gateway with no channel plugins configured — the session commit alone completes delivery and the run succeeds without attempting an external send. If the conversation does name an external route that cannot be resolved at run time, the committed result stays in the conversation and the run records the resolution failure as its delivery error: a delivery failure, not a turn failure.
+
 <Warning>
   Every outbound automation webhook uses the strict SSRF guard. Loopback,
   private/internal, link-local, and other special-use targets are refused by

--- a/src/cron/delivery-preview.test.ts
+++ b/src/cron/delivery-preview.test.ts
@@ -7,7 +7,8 @@ const mocks = vi.hoisted(() => ({
   resolveDeliveryTarget: vi.fn(),
 }));
 
-vi.mock("./isolated-agent/delivery-target.js", () => ({
+vi.mock("./isolated-agent/delivery-target.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./isolated-agent/delivery-target.js")>()),
   resolveDeliveryTarget: mocks.resolveDeliveryTarget,
 }));
 
@@ -98,6 +99,27 @@ describe("resolveCronDeliveryPreview", () => {
     expect(preview).toEqual({
       label: "none -> telegram:direct-123",
       detail: "explicit",
+    });
+  });
+
+  it("previews current-target announce with no external route as a conversation commit", async () => {
+    mocks.resolveDeliveryTarget.mockResolvedValueOnce({
+      ok: false,
+      channel: undefined,
+      mode: "implicit",
+      error: new Error("Channel is required (no configured channels detected)."),
+    });
+    const job = makeCronJob({
+      sessionTarget: "current",
+      sessionKey: "agent:main:dashboard:c5557dcf",
+      delivery: undefined,
+    });
+
+    const preview = await previewForJob(job);
+
+    expect(preview).toEqual({
+      label: "announce -> current session",
+      detail: "commits to this conversation (no external channel route)",
     });
   });
 

--- a/src/cron/delivery-preview.test.ts
+++ b/src/cron/delivery-preview.test.ts
@@ -123,6 +123,27 @@ describe("resolveCronDeliveryPreview", () => {
     });
   });
 
+  it("keeps unavailable external plugin routes fail-closed", async () => {
+    mocks.resolveDeliveryTarget.mockResolvedValueOnce({
+      ok: false,
+      channel: "unavailable-plugin",
+      mode: "implicit",
+      error: new Error("Channel plugin unavailable"),
+    });
+    const job = makeCronJob({
+      sessionTarget: "current",
+      sessionKey: "agent:main:dashboard:c5557dcf",
+      delivery: undefined,
+    });
+
+    const preview = await previewForJob(job);
+
+    expect(preview).toEqual({
+      label: "announce -> last",
+      detail: "last -> no route, will fail-closed: Channel plugin unavailable",
+    });
+  });
+
   it("does not describe unresolved no-delivery message-tool targets as fail-closed", async () => {
     mocks.resolveDeliveryTarget.mockResolvedValueOnce({
       ok: false,

--- a/src/cron/delivery-preview.ts
+++ b/src/cron/delivery-preview.ts
@@ -2,7 +2,10 @@
 import { resolveDefaultAgentId } from "../agents/agent-scope-config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { hasExplicitCronDeliveryTarget, resolveCronDeliveryPlan } from "./delivery-plan.js";
-import { resolveDeliveryTarget } from "./isolated-agent/delivery-target.js";
+import {
+  resolveDeliveryTarget,
+  resolvedDeliveryTargetsExternalChannel,
+} from "./isolated-agent/delivery-target.js";
 import { resolveCronDeliverySessionKey } from "./session-target.js";
 import type { CronDeliveryPreview, CronJob } from "./types.js";
 
@@ -68,6 +71,18 @@ async function resolveCronDeliveryPreview(params: {
     { dryRun: true },
   );
   if (!resolved.ok) {
+    if (
+      params.job.sessionTarget === "current" &&
+      plan.mode === "announce" &&
+      !resolvedDeliveryTargetsExternalChannel(resolved)
+    ) {
+      // Mirrors runtime: a current-target completion with no external channel
+      // route commits durably to its own conversation instead of failing.
+      return {
+        label: "announce -> current session",
+        detail: "commits to this conversation (no external channel route)",
+      };
+    }
     // Preview mirrors runtime fail-closed behavior for "last" delivery so the
     // UI can show unresolved routes before the cron job actually runs.
     return {

--- a/src/cron/isolated-agent/current-session-completion.ts
+++ b/src/cron/isolated-agent/current-session-completion.ts
@@ -3,7 +3,6 @@ import {
   createOutboundPayloadPlan,
   projectOutboundPayloadPlanForMirror,
 } from "../../infra/outbound/payloads.js";
-import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { commitBackgroundResultToSession } from "../../sessions/background-session-result.js";
 import { createCronExecutionId } from "../run-id.js";
 import {
@@ -11,10 +10,11 @@ import {
   resolveDirectCronTranscriptMirrorText,
 } from "./delivery-dispatch-awareness.js";
 import type { DispatchCronDeliveryParams } from "./delivery-dispatch-types.js";
+import { resolvedDeliveryTargetsExternalChannel } from "./delivery-target.js";
 
 type CurrentSessionCompletionResult =
   | { ok: false; reason: string }
-  | { ok: true; requiresExternalDelivery: boolean };
+  | { ok: true; requiresExternalDelivery: boolean; deliveryError?: string };
 
 export async function commitCurrentSessionCronCompletion(
   params: DispatchCronDeliveryParams,
@@ -56,9 +56,17 @@ export async function commitCurrentSessionCronCompletion(
   if (params.resolvedDelivery.ok) {
     return { ok: true, requiresExternalDelivery: true };
   }
-  const sourceChannel = parseAgentSessionKey(sourceSessionKey)?.rest.split(":")[0];
-  if (params.resolvedDelivery.channel === "webchat" || sourceChannel === "webchat") {
-    return { ok: true, requiresExternalDelivery: false };
+  // The completion is durably committed to the target conversation. When the
+  // failed resolution names an external channel route, that route still owed a
+  // send — report it as a delivery failure without failing the committed turn.
+  // With no external route (internal webchat/Control UI conversations, or a
+  // gateway with no channels configured), the commit IS the delivery.
+  if (resolvedDeliveryTargetsExternalChannel(params.resolvedDelivery)) {
+    return {
+      ok: true,
+      requiresExternalDelivery: false,
+      deliveryError: params.resolvedDelivery.error.message,
+    };
   }
-  return { ok: false, reason: params.resolvedDelivery.error.message };
+  return { ok: true, requiresExternalDelivery: false };
 }

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -3535,33 +3535,36 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(deliverOutboundPayloads).not.toHaveBeenCalled();
   });
 
-  it("keeps a committed current-target run successful when its external route fails to resolve", async () => {
-    const params = makeBaseParams({
-      synthesizedText: "committed but undeliverable externally",
-      sessionTarget: "current",
-      runStartedAt: 1_500,
-    });
-    params.resolvedDelivery = {
-      ok: false,
-      channel: "telegram",
-      to: undefined,
-      accountId: undefined,
-      threadId: undefined,
-      mode: "implicit",
-      error: new Error("Target is required"),
-    };
+  it.each(["telegram", "unavailable-plugin"])(
+    "keeps a committed current-target run successful when its %s route fails to resolve",
+    async (channel) => {
+      const params = makeBaseParams({
+        synthesizedText: "committed but undeliverable externally",
+        sessionTarget: "current",
+        runStartedAt: 1_500,
+      });
+      params.resolvedDelivery = {
+        ok: false,
+        channel,
+        to: undefined,
+        accountId: undefined,
+        threadId: undefined,
+        mode: "implicit",
+        error: new Error("Target is required"),
+      };
 
-    const state = await dispatchCronDelivery(params);
+      const state = await dispatchCronDelivery(params);
 
-    expect(state.result).toBeUndefined();
-    expect(state).toMatchObject({
-      delivered: false,
-      deliveryAttempted: true,
-      deliveryError: "Target is required",
-    });
-    expect(commitBackgroundResultToSessionMock).toHaveBeenCalledTimes(1);
-    expect(deliverOutboundPayloads).not.toHaveBeenCalled();
-  });
+      expect(state.result).toBeUndefined();
+      expect(state).toMatchObject({
+        delivered: false,
+        deliveryAttempted: true,
+        deliveryError: "Target is required",
+      });
+      expect(commitBackgroundResultToSessionMock).toHaveBeenCalledTimes(1);
+      expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+    },
+  );
 
   it("requires the current-session commit in addition to one external delivery", async () => {
     const params = makeBaseParams({

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -3496,6 +3496,73 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(deliverOutboundPayloads).not.toHaveBeenCalled();
   });
 
+  it("commits a current-target completion on a webchat-only gateway with no configured channels", async () => {
+    // Regression: a Control UI dashboard session key does not contain
+    // "webchat", and a gateway without external channel plugins resolves no
+    // channel at all. The committed completion is the delivery; the run must
+    // not fail as a delivery-target error.
+    const params = makeBaseParams({
+      synthesizedText: "scheduled dashboard report",
+      sessionTarget: "current",
+      runStartedAt: 1_000,
+    });
+    const dashboardSessionKey = "agent:main:dashboard:c5557dcf-54bf-46b0-9bf2-a1f6ad1d0667";
+    (params.job as { sessionKey?: string }).sessionKey = dashboardSessionKey;
+    params.sourceSessionKey = dashboardSessionKey;
+    params.resolvedDelivery = {
+      ok: false,
+      channel: undefined,
+      to: undefined,
+      accountId: undefined,
+      threadId: undefined,
+      mode: "implicit",
+      error: new Error(
+        "Channel is required (no configured channels detected). Run openclaw channels add to configure one, or pass --channel <channel> after enabling a channel. Use openclaw channels list --all to see available channel ids. Set delivery.channel explicitly or use a main session with a previous channel.",
+      ),
+    };
+
+    const state = await dispatchCronDelivery(params);
+
+    expect(state.result).toBeUndefined();
+    expect(state).toMatchObject({ delivered: true, deliveryAttempted: true });
+    expect(state.deliveryError).toBeUndefined();
+    expect(commitBackgroundResultToSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: dashboardSessionKey,
+        text: "scheduled dashboard report",
+      }),
+    );
+    expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+  });
+
+  it("keeps a committed current-target run successful when its external route fails to resolve", async () => {
+    const params = makeBaseParams({
+      synthesizedText: "committed but undeliverable externally",
+      sessionTarget: "current",
+      runStartedAt: 1_500,
+    });
+    params.resolvedDelivery = {
+      ok: false,
+      channel: "telegram",
+      to: undefined,
+      accountId: undefined,
+      threadId: undefined,
+      mode: "implicit",
+      error: new Error("Target is required"),
+    };
+
+    const state = await dispatchCronDelivery(params);
+
+    expect(state.result).toBeUndefined();
+    expect(state).toMatchObject({
+      delivered: false,
+      deliveryAttempted: true,
+      deliveryError: "Target is required",
+    });
+    expect(commitBackgroundResultToSessionMock).toHaveBeenCalledTimes(1);
+    expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+  });
+
   it("requires the current-session commit in addition to one external delivery", async () => {
     const params = makeBaseParams({
       synthesizedText: "durable external completion",

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -705,7 +705,13 @@ export async function dispatchCronDelivery(
       }
       params.queueSourceSessionMessageToolAwareness = undefined;
       if (!completion.requiresExternalDelivery) {
-        recordDelivery("delivered");
+        // A deliveryError means the conversation's external route failed to
+        // resolve; the committed turn keeps its ok status with the failure
+        // recorded, instead of collapsing into a run error.
+        recordDelivery(
+          completion.deliveryError ? "not-delivered" : "delivered",
+          completion.deliveryError,
+        );
         return null;
       }
       // The source transcript is committed. External custody remains required

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -16,6 +16,7 @@ import { resolveSessionDeliveryTarget } from "../../infra/outbound/targets-sessi
 import { normalizeAccountId } from "../../routing/session-key.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
+import { isDeliverableMessageChannel } from "../../utils/message-channel.js";
 import { resolveCronStoredDeliveryContext } from "../delivery-context.js";
 import { resolveCronAgentSessionKey } from "./session-key.js";
 
@@ -38,6 +39,18 @@ export type DeliveryTargetResolution =
       mode: "explicit" | "implicit";
       error: Error;
     };
+
+/**
+ * Returns whether a delivery resolution names an external deliverable channel
+ * route. Internal surfaces (webchat/Control UI) and resolutions that found no
+ * channel at all have no external route: their conversations render from
+ * durable session history, so nothing outside the Gateway carries the message.
+ */
+export function resolvedDeliveryTargetsExternalChannel(
+  resolution: DeliveryTargetResolution,
+): boolean {
+  return resolution.channel !== undefined && isDeliverableMessageChannel(resolution.channel);
+}
 
 const targetsRuntimeLoader = createLazyImportLoader(
   () => import("../../infra/outbound/targets.runtime.js"),

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -16,7 +16,7 @@ import { resolveSessionDeliveryTarget } from "../../infra/outbound/targets-sessi
 import { normalizeAccountId } from "../../routing/session-key.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
-import { isDeliverableMessageChannel } from "../../utils/message-channel.js";
+import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";
 import { resolveCronStoredDeliveryContext } from "../delivery-context.js";
 import { resolveCronAgentSessionKey } from "./session-key.js";
 
@@ -41,15 +41,15 @@ export type DeliveryTargetResolution =
     };
 
 /**
- * Returns whether a delivery resolution names an external deliverable channel
- * route. Internal surfaces (webchat/Control UI) and resolutions that found no
- * channel at all have no external route: their conversations render from
- * durable session history, so nothing outside the Gateway carries the message.
+ * Returns whether a delivery resolution names an external channel route.
+ * Registration is intentionally irrelevant: an unavailable plugin route still
+ * owes delivery. Only webchat/Control UI and an absent route are satisfied by
+ * the durable session commit alone.
  */
 export function resolvedDeliveryTargetsExternalChannel(
   resolution: DeliveryTargetResolution,
 ): boolean {
-  return resolution.channel !== undefined && isDeliverableMessageChannel(resolution.channel);
+  return resolution.channel !== undefined && resolution.channel !== INTERNAL_MESSAGE_CHANNEL;
 }
 
 const targetsRuntimeLoader = createLazyImportLoader(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a scheduled automation (agentTurn, sessionTarget `current`, default delivery mode `announce`) owned by a webchat/Control UI dashboard session would fail its entire run with "Channel is required (no configured channels detected)" on a gateway with no external channel plugins configured. The job auto-disabled and its report never reached the operator — a silent failure on the default path, discoverable only via the "Automation attached" badge — even though the turn result had already committed durably to the target conversation.

## Why This Change Was Made

The current-session completion decided whether an external announce was still owed by string-matching `webchat` against the session-key prefix, which misses Control UI dashboard sessions (`agent:<id>:dashboard:<uuid>`), and the resulting delivery-target error was exempt from the #94058 turn-success preservation. The fix decides external-delivery necessity from the delivery resolution's recorded route instead: a failed resolution that names no deliverable external channel has nothing external backing the conversation, so the committed completion *is* the delivery and the run succeeds; a failed resolution that does name an external channel keeps the run successful and records the failure as the run's delivery error, distinguishing "turn succeeded, delivery failed" from "turn failed". The delivery preview mirrors the same rule instead of showing "will fail-closed" for these jobs.

## User Impact

Operators running webchat-only gateways (no external channel plugins) can now schedule current-session automations with default settings: the result appears in the target conversation, the run records `succeeded`, and one-shot jobs clean up normally instead of auto-disabling with an error. When an external channel *is* configured but announce delivery fails, the run still succeeds and surfaces a distinct delivery error rather than masking the completed turn.

## Evidence

- New regression coverage: `src/cron/delivery-preview.test.ts` and `src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts` — the new tests were verified to fail on pre-fix code and pass with the fix; the two touched suites pass in full on the rebased head `6997a0cc675` (168 tests).
- `check:changed` passes on the rebased head.
- Structured autoreview (Codex, gpt-5.6-sol) on the rebased branch diff: clean, no findings.
- Live-verified on an isolated no-channel gateway built from the pre-rebase head `3f98ec98b61`: created a dashboard session, scheduled a one-shot current-target agentTurn automation with default delivery; the run committed its result to the conversation transcript, persisted `lastRunStatus=succeeded`, and the job auto-deleted (auto-delete only occurs after a successful run). The branch was subsequently rebased onto current main (delivery bookkeeping there was refactored by #131228); post-rebase behavior is bound by the unit suites above, not by this live run.
- The external-route-named-but-unresolvable case is covered by unit tests only (`delivery-dispatch.double-announce.test.ts`): the turn stays `ok` with the resolution failure recorded as the run's delivery error; completion follows the strict/best-effort delivery policy from #131228.
