### PR TITLE
fix(compaction): record omitted images instead of dropping them silently

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1472,7 +1472,7 @@ packages/acp-core/src/runtime/session-identity.ts	2
 packages/acp-core/src/types.ts	2
 packages/agent-core/src/agent-loop.ts	3
 packages/agent-core/src/harness/compaction/branch-summarization.ts	1
-packages/agent-core/src/harness/compaction/compaction.ts	3
+packages/agent-core/src/harness/compaction/compaction.ts	2
 packages/agent-core/src/harness/messages.ts	3
 packages/agent-core/src/harness/session/session.ts	1
 packages/agent-core/src/harness/session/tool-result-pairing.ts	17

--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -20,7 +20,7 @@ The built-in summarizer accounts for Chinese, Japanese, and Korean (CJK) charact
 
 The full conversation history stays on disk. Compaction only changes what the model sees on the next turn.
 
-Built-in summarization receives text, not image pixels. Image-only user messages and tool results remain visible in its input as `[image data removed - already processed by model]`. Other omitted non-text input receives a similar marker, with at most two fixed markers per message. Custom compaction providers still receive the original message content.
+Built-in summarization receives text, not image pixels. Omitted images and other non-text input receive markers such as `[image data omitted from summary input]`, without claiming that a model processed the data. The first eight affected messages receive at most two fixed markers each; further omissions receive one aggregate statement. These additions, including newly retained role labels and separators, total at most 847 UTF-8 bytes per summarizer request and count toward token estimates. Existing text is not capped by this omission budget. Custom compaction providers still receive the original message content.
 
 <Note>
 New configs default `agents.defaults.compaction.mode` to `"safeguard"` (stricter guardrails, summary quality audits). Set `mode: "default"` explicitly to opt out.

--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -20,6 +20,8 @@ The built-in summarizer accounts for Chinese, Japanese, and Korean (CJK) charact
 
 The full conversation history stays on disk. Compaction only changes what the model sees on the next turn.
 
+Built-in summarization receives text, not image pixels. Image-only user messages and tool results remain visible in its input as `[image data removed - already processed by model]`. Other omitted non-text input receives a similar marker, with at most two fixed markers per message. Custom compaction providers still receive the original message content.
+
 <Note>
 New configs default `agents.defaults.compaction.mode` to `"safeguard"` (stricter guardrails, summary quality audits). Set `mode: "default"` explicitly to opt out.
 </Note>

--- a/packages/agent-core/src/harness/compaction/compaction-image-tokens.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction-image-tokens.test.ts
@@ -141,8 +141,8 @@ describe.each([false, true])("image omission through compaction (split turn: %s)
       expect(preparation.value.firstKeptEntryId).toBe(lastEntry.id);
 
       const model: Model = {
-        id: "summary-model",
-        name: "Summary Model",
+        id: "umbreon-latest",
+        name: "Umbreon Latest",
         api: "test-api",
         provider: "test-provider",
         baseUrl: "https://example.test",

--- a/packages/agent-core/src/harness/compaction/compaction-image-tokens.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction-image-tokens.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "vitest";
-import type { ImageContent } from "../../llm.js";
+import type { AssistantMessage, ImageContent, Model } from "../../llm.js";
 import type { AgentMessage } from "../../types.js";
+import { buildSessionContext } from "../session/session.js";
 import type { SessionTreeEntry } from "../types.js";
-import { estimateTokens, findCutPoint } from "./compaction.js";
+import { compact, estimateTokens, findCutPoint, prepareCompaction } from "./compaction.js";
 
 const IMAGE_PAYLOAD = "a".repeat(1_500_000);
 
@@ -29,7 +30,7 @@ function toolResultImage(timestamp: number): AgentMessage {
   };
 }
 
-function assistantText(text: string, timestamp: number): AgentMessage {
+function assistantText(text: string, timestamp: number): AssistantMessage {
   return {
     role: "assistant",
     content: [{ type: "text", text }],
@@ -103,4 +104,106 @@ describe("findCutPoint with image-heavy recent turns", () => {
     expect(textResult.firstKeptEntryIndex).toBeGreaterThan(0);
     expect(imageResult.firstKeptEntryIndex).toBe(textResult.firstKeptEntryIndex);
   });
+});
+
+describe.each([false, true])("image omission through compaction (split turn: %s)", (splitTurn) => {
+  it.each(["user", "toolResult"] as const)(
+    "records an image-only %s message in summary input and rebuilt context",
+    async (role) => {
+      const messages: AgentMessage[] =
+        role === "user"
+          ? [userImage(1)]
+          : [
+              userText("Inspect the screenshot", 1),
+              {
+                ...assistantText("", 2),
+                content: [{ type: "toolCall", id: "call-1", name: "screenshot", arguments: {} }],
+                stopReason: "toolUse",
+              },
+              toolResultImage(3),
+            ];
+      messages.push(assistantText("The screenshot was inspected", 4));
+      if (!splitTurn) {
+        messages.push(userText("Continue with the next task", 5));
+      }
+      const entries = messages.map(messageEntry);
+      const originalEntries = structuredClone(entries);
+      const lastEntry = entries.at(-1);
+      const preparation = prepareCompaction(entries, {
+        enabled: true,
+        reserveTokens: 1_000,
+        keepRecentTokens: 1,
+      });
+      if (!preparation.ok || !preparation.value || !lastEntry) {
+        throw new Error("expected image history to be compactable");
+      }
+      expect(preparation.value.isSplitTurn).toBe(splitTurn);
+      expect(preparation.value.firstKeptEntryId).toBe(lastEntry.id);
+
+      const model: Model = {
+        id: "summary-model",
+        name: "Summary Model",
+        api: "test-api",
+        provider: "test-provider",
+        baseUrl: "https://example.test",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 100_000,
+        maxTokens: 8_000,
+      };
+      const prompts: string[] = [];
+      const result = await compact(
+        preparation.value,
+        model,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        {
+          completeSimple: async (_model, context) => {
+            const content = context.messages[0]?.content;
+            if (!Array.isArray(content) || content.length !== 1 || content[0]?.type !== "text") {
+              throw new Error("expected one text-only summarization input");
+            }
+            prompts.push(content[0].text);
+            // Echo only the supplied conversation: the callback cannot invent an omission fact.
+            const conversation = content[0].text
+              .split("<conversation>\n")[1]
+              ?.split("\n</conversation>")[0];
+            return assistantText(conversation || "No conversation content", 6);
+          },
+        },
+      );
+      if (!result.ok) {
+        throw result.error;
+      }
+      const marker = "[image data removed - already processed by model]";
+      expect(prompts).toHaveLength(1);
+      expect
+        .soft(prompts[0])
+        .toContain(`${role === "user" ? "[User]" : "[Tool result]"}: ${marker}`);
+      expect(prompts[0]).not.toContain(IMAGE_PAYLOAD);
+
+      const context = buildSessionContext([
+        ...entries,
+        {
+          type: "compaction",
+          id: "compaction-1",
+          parentId: lastEntry.id,
+          timestamp: new Date(7).toISOString(),
+          ...result.value,
+        },
+      ]);
+      expect.soft(context.messages[0]).toMatchObject({
+        role: "compactionSummary",
+        summary: expect.stringContaining(marker),
+      });
+      expect(context.messages.at(-1)).toEqual(messages.at(-1));
+      expect(JSON.stringify(context.messages)).not.toContain(IMAGE_PAYLOAD);
+      expect(entries).toEqual(originalEntries);
+    },
+  );
 });

--- a/packages/agent-core/src/harness/compaction/compaction-image-tokens.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction-image-tokens.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { AssistantMessage, ImageContent, Model } from "../../llm.js";
+import type { AgentCoreCompletionRuntimeDeps } from "../../runtime-deps.js";
 import type { AgentMessage } from "../../types.js";
 import { buildSessionContext } from "../session/session.js";
 import type { SessionTreeEntry } from "../types.js";
+import { generateBranchSummary } from "./branch-summarization.js";
 import { compact, estimateTokens, findCutPoint, prepareCompaction } from "./compaction.js";
 
 const IMAGE_PAYLOAD = "a".repeat(1_500_000);
@@ -50,6 +52,21 @@ function assistantText(text: string, timestamp: number): AssistantMessage {
   };
 }
 
+function summaryModel(contextWindow = 100_000): Model {
+  return {
+    id: "summary-model",
+    name: "Summary Model",
+    api: "test-api",
+    provider: "test-provider",
+    baseUrl: "https://example.test",
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow,
+    maxTokens: 2048,
+  };
+}
+
 function messageEntry(message: AgentMessage, index: number): SessionTreeEntry {
   return {
     type: "message",
@@ -76,7 +93,17 @@ describe("estimateTokens image accounting", () => {
     const toolTokens = estimateTokens(toolResultImage(1));
 
     expect(userTokens).toBe(toolTokens);
-    expect(userTokens).toBe(2_000);
+    // The 2,000-token image pressure is separate from the summary omission record.
+    expect(userTokens).toBe(2_000 + 14);
+    expect(
+      estimateTokens({
+        role: "custom",
+        content: [imageBlock()],
+        timestamp: 1,
+        customType: "image",
+        display: true,
+      }),
+    ).toBe(userTokens);
   });
 });
 
@@ -90,7 +117,7 @@ describe("findCutPoint with image-heavy recent turns", () => {
   });
 
   it("matches the cut point of an equivalent text-cost control", () => {
-    const equivalentText = "x".repeat(8_000);
+    const equivalentText = "x".repeat(8_056);
     const imageEntries = buildTranscript([userImage(10), userImage(20), userImage(30)]);
     const textEntries = buildTranscript([
       userText(equivalentText, 10),
@@ -106,104 +133,195 @@ describe("findCutPoint with image-heavy recent turns", () => {
   });
 });
 
-describe.each([false, true])("image omission through compaction (split turn: %s)", (splitTurn) => {
-  it.each(["user", "toolResult"] as const)(
-    "records an image-only %s message in summary input and rebuilt context",
-    async (role) => {
-      const messages: AgentMessage[] =
-        role === "user"
-          ? [userImage(1)]
-          : [
-              userText("Inspect the screenshot", 1),
-              {
-                ...assistantText("", 2),
-                content: [{ type: "toolCall", id: "call-1", name: "screenshot", arguments: {} }],
-                stopReason: "toolUse",
-              },
-              toolResultImage(3),
-            ];
-      messages.push(assistantText("The screenshot was inspected", 4));
-      if (!splitTurn) {
-        messages.push(userText("Continue with the next task", 5));
-      }
-      const entries = messages.map(messageEntry);
-      const originalEntries = structuredClone(entries);
-      const lastEntry = entries.at(-1);
-      const preparation = prepareCompaction(entries, {
-        enabled: true,
-        reserveTokens: 1_000,
-        keepRecentTokens: 1,
-      });
-      if (!preparation.ok || !preparation.value || !lastEntry) {
-        throw new Error("expected image history to be compactable");
-      }
-      expect(preparation.value.isSplitTurn).toBe(splitTurn);
-      expect(preparation.value.firstKeptEntryId).toBe(lastEntry.id);
+describe.each([
+  { splitTurn: false, completed: false },
+  { splitTurn: false, completed: true },
+  { splitTurn: true, completed: true },
+])(
+  "image omission through compaction (split: $splitTurn, completed: $completed)",
+  ({ splitTurn, completed }) => {
+    it.each(["user", "toolResult"] as const)(
+      "records an image-only %s message in summary input and rebuilt context",
+      async (role) => {
+        const messages: AgentMessage[] =
+          role === "user"
+            ? [userImage(1)]
+            : [
+                userText("Inspect the screenshot", 1),
+                {
+                  ...assistantText("", 2),
+                  content: [{ type: "toolCall", id: "call-1", name: "screenshot", arguments: {} }],
+                  stopReason: "toolUse",
+                },
+                toolResultImage(3),
+              ];
+        if (completed) {
+          messages.push(assistantText("The screenshot was inspected", 4));
+        }
+        if (!splitTurn) {
+          messages.push(userText("Continue with the next task", 5));
+        }
+        const entries = messages.map(messageEntry);
+        const originalEntries = structuredClone(entries);
+        const lastEntry = entries.at(-1);
+        const preparation = prepareCompaction(entries, {
+          enabled: true,
+          reserveTokens: 1_000,
+          keepRecentTokens: 1,
+        });
+        if (!preparation.ok || !preparation.value || !lastEntry) {
+          throw new Error("expected image history to be compactable");
+        }
+        expect(preparation.value.isSplitTurn).toBe(splitTurn);
+        expect(preparation.value.firstKeptEntryId).toBe(lastEntry.id);
 
-      const model: Model = {
-        id: "umbreon-latest",
-        name: "Umbreon Latest",
-        api: "test-api",
-        provider: "test-provider",
-        baseUrl: "https://example.test",
-        reasoning: false,
-        input: ["text"],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 100_000,
-        maxTokens: 8_000,
-      };
-      const prompts: string[] = [];
-      const result = await compact(
-        preparation.value,
-        model,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        {
-          completeSimple: async (_model, context) => {
-            const content = context.messages[0]?.content;
-            if (!Array.isArray(content) || content.length !== 1 || content[0]?.type !== "text") {
-              throw new Error("expected one text-only summarization input");
-            }
-            prompts.push(content[0].text);
-            // Echo only the supplied conversation: the callback cannot invent an omission fact.
-            const conversation = content[0].text
-              .split("<conversation>\n")[1]
-              ?.split("\n</conversation>")[0];
-            return assistantText(conversation || "No conversation content", 6);
+        const model = summaryModel();
+        const prompts: string[] = [];
+        const result = await compact(
+          preparation.value,
+          model,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          {
+            completeSimple: async (_model, context) => {
+              const content = context.messages[0]?.content;
+              if (!Array.isArray(content) || content.length !== 1 || content[0]?.type !== "text") {
+                throw new Error("expected one text-only summarization input");
+              }
+              prompts.push(content[0].text);
+              // Echo only the supplied conversation: the callback cannot invent an omission fact.
+              const conversation = content[0].text
+                .split("<conversation>\n")[1]
+                ?.split("\n</conversation>")[0];
+              return assistantText(conversation || "No conversation content", 6);
+            },
           },
-        },
-      );
-      if (!result.ok) {
-        throw result.error;
-      }
-      const marker = "[image data removed - already processed by model]";
-      expect(prompts).toHaveLength(1);
-      expect
-        .soft(prompts[0])
-        .toContain(`${role === "user" ? "[User]" : "[Tool result]"}: ${marker}`);
-      expect(prompts[0]).not.toContain(IMAGE_PAYLOAD);
+        );
+        if (!result.ok) {
+          throw result.error;
+        }
+        const marker = "[image data omitted from summary input]";
+        expect(prompts).toHaveLength(1);
+        expect
+          .soft(prompts[0])
+          .toContain(`${role === "user" ? "[User]" : "[Tool result]"}: ${marker}`);
+        expect(prompts[0]).not.toContain(IMAGE_PAYLOAD);
+        expect(prompts[0]).not.toContain("already processed by model");
 
-      const context = buildSessionContext([
-        ...entries,
-        {
-          type: "compaction",
-          id: "compaction-1",
-          parentId: lastEntry.id,
-          timestamp: new Date(7).toISOString(),
-          ...result.value,
+        const context = buildSessionContext([
+          ...entries,
+          {
+            type: "compaction",
+            id: "compaction-1",
+            parentId: lastEntry.id,
+            timestamp: new Date(7).toISOString(),
+            ...result.value,
+          },
+        ]);
+        expect.soft(context.messages[0]).toMatchObject({
+          role: "compactionSummary",
+          summary: expect.stringContaining(marker),
+        });
+        expect(context.messages.at(-1)).toEqual(messages.at(-1));
+        expect(JSON.stringify(context.messages)).not.toContain(IMAGE_PAYLOAD);
+        expect(entries).toEqual(originalEntries);
+      },
+    );
+  },
+);
+
+describe.each(["ordinary", "split", "branch"] as const)("%s summary omission budget", (mode) => {
+  it.each(["image", "audio"])(
+    "bounds many %s messages at the completion boundary",
+    async (type) => {
+      const model = summaryModel(type === "image" ? 1_000_000 : 8192);
+      const messages: AgentMessage[] = [
+        userText("Inspect attachments", 0),
+        ...Array.from(
+          { length: 200 },
+          (_, i) =>
+            ({
+              role: "toolResult",
+              toolCallId: `call-${i}`,
+              toolName: "inspect",
+              isError: false,
+              timestamp: i + 1,
+              content: [{ type, data: "PAYLOAD_SENTINEL", mimeType: "image/png" }],
+            }) as AgentMessage,
+        ),
+      ];
+      const entries = messages.map(messageEntry);
+      const conversations: string[] = [];
+      const runtime: AgentCoreCompletionRuntimeDeps = {
+        completeSimple: async (_model, context) => {
+          const content = context.messages[0]?.content;
+          if (!Array.isArray(content) || content[0]?.type !== "text") {
+            throw new Error("expected summary prompt");
+          }
+          const conversation = content[0].text
+            .split("<conversation>\n")[1]
+            ?.split("\n</conversation>")[0];
+          if (!conversation) {
+            throw new Error("expected conversation");
+          }
+          conversations.push(conversation);
+          return assistantText("Summary", 202);
         },
-      ]);
-      expect.soft(context.messages[0]).toMatchObject({
-        role: "compactionSummary",
-        summary: expect.stringContaining(marker),
-      });
-      expect(context.messages.at(-1)).toEqual(messages.at(-1));
-      expect(JSON.stringify(context.messages)).not.toContain(IMAGE_PAYLOAD);
-      expect(entries).toEqual(originalEntries);
+      };
+      let result;
+      if (mode === "branch") {
+        result = await generateBranchSummary(entries, {
+          model,
+          apiKey: "test-key",
+          signal: new AbortController().signal,
+          runtime,
+        });
+      } else {
+        entries.push(
+          messageEntry(
+            mode === "split" ? assistantText("Retained answer", 201) : userText("Next task", 201),
+            entries.length,
+          ),
+        );
+        const preparation = prepareCompaction(entries, {
+          enabled: true,
+          reserveTokens: 1000,
+          keepRecentTokens: 1,
+        });
+        if (!preparation.ok || !preparation.value) {
+          throw new Error("expected compactable history");
+        }
+        expect(preparation.value.isSplitTurn).toBe(mode === "split");
+        result = await compact(
+          preparation.value,
+          model,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          runtime,
+        );
+      }
+      expect(result.ok).toBe(true);
+      expect(conversations).toHaveLength(1);
+      const conversation = conversations[0];
+      if (!conversation) {
+        throw new Error("expected captured conversation");
+      }
+      expect(
+        Buffer.byteLength(conversation) - Buffer.byteLength("[User]: Inspect attachments"),
+      ).toBeLessThanOrEqual(847);
+      expect(conversation.match(/\[Tool result\]:/g)).toHaveLength(8);
+      expect(
+        conversation.split("[More image/non-text data omitted from summary input]"),
+      ).toHaveLength(2);
+      expect(conversation).not.toMatch(/PAYLOAD_SENTINEL|already processed by model/);
     },
   );
 });

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -37,7 +37,7 @@ import {
   extractSummaryText,
   type FileOperations,
   formatFileOperations,
-  getCompactionContentBlockText,
+  getCompactionContent,
   mergeSummaryFileOperations,
   serializeConversation,
   stringifyCompactionValue,
@@ -278,18 +278,16 @@ export function shouldCompact(
 export const IMAGE_BLOCK_TOKENS = 2_000;
 const IMAGE_BLOCK_CHARS = IMAGE_BLOCK_TOKENS * CHARS_PER_TOKEN_ESTIMATE;
 
-function countContentBlockChars(
-  content: Array<{ type: string; content?: unknown; text?: string }>,
+function countContentChars(
+  content: string | Array<{ type: string; content?: unknown; text?: string }>,
 ): number {
-  let chars = 0;
-  for (const block of content) {
-    if (block.type === "image") {
-      chars += IMAGE_BLOCK_CHARS;
-    } else {
-      chars += estimateStringChars(getCompactionContentBlockText(block));
-    }
-  }
-  return chars;
+  const { text, omissionText } = getCompactionContent(content);
+  const images =
+    typeof content === "string" ? 0 : content.filter((block) => block.type === "image").length;
+  // Charge the largest role/separator even for mixed text. Any suppressed message's
+  // minimum 56-character charge also covers the serializer's single 55-character overflow.
+  const omissionChars = omissionText ? omissionText.length + "\n\n[Tool result]: ".length : 0;
+  return estimateStringChars(text) + images * IMAGE_BLOCK_CHARS + omissionChars;
 }
 
 /** Estimate token count for one message using a conservative character heuristic. */
@@ -301,17 +299,6 @@ export function estimateTokens(message: AgentMessage): number {
   const harnessMessage = message as HarnessMessage;
 
   switch (harnessMessage.role) {
-    case "user": {
-      const content = (
-        harnessMessage as { content: string | Array<{ type: string; text?: string }> }
-      ).content;
-      if (typeof content === "string") {
-        chars = estimateStringChars(content);
-      } else if (Array.isArray(content)) {
-        chars = countContentBlockChars(content);
-      }
-      return Math.ceil(chars / CHARS_PER_TOKEN_ESTIMATE);
-    }
     case "assistant": {
       const assistant = harnessMessage;
       for (const block of assistant.content) {
@@ -327,13 +314,10 @@ export function estimateTokens(message: AgentMessage): number {
       }
       return Math.ceil(chars / CHARS_PER_TOKEN_ESTIMATE);
     }
+    case "user":
     case "custom":
     case "toolResult": {
-      if (typeof harnessMessage.content === "string") {
-        chars = estimateStringChars(harnessMessage.content);
-      } else {
-        chars = countContentBlockChars(harnessMessage.content);
-      }
+      chars = countContentChars(harnessMessage.content);
       return Math.ceil(chars / CHARS_PER_TOKEN_ESTIMATE);
     }
     case "bashExecution": {

--- a/packages/agent-core/src/harness/compaction/utils.test.ts
+++ b/packages/agent-core/src/harness/compaction/utils.test.ts
@@ -1,6 +1,7 @@
 import type { Message } from "@openclaw/llm-core";
 import { describe, expect, it } from "vitest";
 import type { AgentMessage } from "../../types.js";
+import { estimateTokens } from "./compaction.js";
 import {
   computeFileLists,
   createFileOps,
@@ -159,11 +160,14 @@ describe("serializeConversation", () => {
       ] as unknown as Message[]);
       const label = `[${role === "user" ? "User" : "Tool result"}]: `;
       const markers =
-        "[image data removed - already processed by model]\n" +
-        "[non-text data removed - already processed by model]\n";
+        "[image data omitted from summary input]\n" +
+        "[non-text data omitted from summary input]\n";
 
       expect(serialized).toBe(`${label}${markers}${textOnly.slice(label.length)}`);
-      expect(serialized.length - textOnly.length).toBe(103);
+      expect(serialized.length - textOnly.length).toBe(83);
+      expect(estimateTokens({ role, content } as unknown as AgentMessage)).toBe(
+        1_000 * 2_000 + Math.ceil((`start ${toolText}`.length + 99) / 4),
+      );
       expect(serialized).toContain("start ");
       expect(serialized).toContain("ERROR: terminal failure");
       expect(serialized).not.toMatch(/SENTINEL|other-media-/);
@@ -178,11 +182,60 @@ describe("serializeConversation", () => {
         content: [{ type: "audio", data: "AUDIO_PAYLOAD_SENTINEL" }],
       } as unknown as Message;
       const empty = { role, content: [{ type: "text", text: "" }] } as Message;
-      const expected = `[${role === "user" ? "User" : "Tool result"}]: [non-text data removed - already processed by model]`;
+      const expected = `[${role === "user" ? "User" : "Tool result"}]: [non-text data omitted from summary input]`;
 
       expect(serializeConversation([empty, message, empty, message])).toBe(
         `${expected}\n\n${expected}`,
       );
+    },
+  );
+
+  it.each(["user", "toolResult"] as const)(
+    "caps omission additions across %s messages, including empty-message wrappers",
+    (role) => {
+      const baseline: Message = { role: "user", content: "existing text", timestamp: 0 };
+      const aggregate = "[More image/non-text data omitted from summary input]";
+      for (const categories of [["image"], ["audio"], ["image", "audio"]]) {
+        for (const caption of ["", "caption 🚀"]) {
+          for (const count of [200, 8, 9, 10_000]) {
+            const messages = Array.from({ length: count }, () => ({
+              role,
+              content: [
+                { type: "text", text: caption },
+                ...categories.map((type) => ({ type, data: "PAYLOAD_SENTINEL" })),
+              ],
+            })) as unknown as Message[];
+            const textOnly = messages.map(() => ({ role, content: caption })) as Message[];
+            const serialized = serializeConversation([baseline, ...messages, baseline]);
+            const control = serializeConversation([baseline, ...textOnly, baseline]);
+            const addedBytes = Buffer.byteLength(serialized) - Buffer.byteLength(control);
+            expect(addedBytes).toBeLessThanOrEqual(847);
+            const estimatedTokens = messages.reduce(
+              (total, message) => total + estimateTokens(message),
+              0,
+            );
+            expect(estimatedTokens).toBeGreaterThanOrEqual(Math.ceil(addedBytes / 4));
+            if (role === "toolResult" && !caption && categories.length === 2 && count > 8) {
+              expect(addedBytes).toBe(847);
+            }
+            expect(serialized.split(aggregate)).toHaveLength(count > 8 ? 2 : 1);
+            expect(serialized.match(/\[(?:image|non-text) data omitted/g)).toHaveLength(
+              Math.min(count, 8) * categories.length,
+            );
+            expect(serialized.match(/caption 🚀/g)?.length ?? 0).toBe(caption ? count : 0);
+            expect(serialized).toContain("[User]: existing text");
+            expect(serialized).not.toContain("PAYLOAD_SENTINEL");
+          }
+        }
+      }
+      const images = Array.from({ length: 8 }, () => ({
+        role,
+        content: [{ type: "image", data: "PAYLOAD_SENTINEL" }],
+      }));
+      const lateOther = { role, content: [{ type: "audio", data: "LATE_PAYLOAD_SENTINEL" }] };
+      const serialized = serializeConversation([...images, lateOther] as unknown as Message[]);
+      expect(serialized).toContain(aggregate);
+      expect(serialized).not.toContain("SENTINEL");
     },
   );
 

--- a/packages/agent-core/src/harness/compaction/utils.test.ts
+++ b/packages/agent-core/src/harness/compaction/utils.test.ts
@@ -142,23 +142,47 @@ describe("serializeConversation", () => {
           type: "image",
           data: "IMAGE_PAYLOAD_SENTINEL",
           mimeType: "PRIVATE_MIME_SENTINEL",
+          text: "IMAGE_TEXT_SENTINEL",
         })),
         ...Array.from({ length: 1_000 }, (_, i) => ({
-          type: `other-media-${i}`,
+          type: `other-media-${i}-${"x".repeat(1_000)}`,
           data: "OTHER_PAYLOAD_SENTINEL",
+          text: "OTHER_TEXT_SENTINEL",
+          content: "OTHER_CONTENT_SENTINEL",
+          thinking: "PRIVATE_REASONING_SENTINEL",
         })),
         { type: "text", text: toolText },
       ];
       const serialized = serializeConversation([{ role, content }] as unknown as Message[]);
+      const textOnly = serializeConversation([
+        { role, content: content.filter((block) => block.type === "text") },
+      ] as unknown as Message[]);
+      const label = `[${role === "user" ? "User" : "Tool result"}]: `;
+      const markers =
+        "[image data removed - already processed by model]\n" +
+        "[non-text data removed - already processed by model]\n";
 
-      expect(serialized.split("[image data removed - already processed by model]")).toHaveLength(2);
-      expect(serialized.split("[non-text data removed - already processed by model]")).toHaveLength(
-        2,
-      );
+      expect(serialized).toBe(`${label}${markers}${textOnly.slice(label.length)}`);
+      expect(serialized.length - textOnly.length).toBe(103);
       expect(serialized).toContain("start ");
       expect(serialized).toContain("ERROR: terminal failure");
       expect(serialized).not.toMatch(/SENTINEL|other-media-/);
-      expect(serialized.length).toBeLessThan(role === "user" ? toolText.length + 120 : 2_200);
+    },
+  );
+
+  it.each(["user", "toolResult"] as const)(
+    "keeps non-text-only %s messages distinct from empty messages",
+    (role) => {
+      const message = {
+        role,
+        content: [{ type: "audio", data: "AUDIO_PAYLOAD_SENTINEL" }],
+      } as unknown as Message;
+      const empty = { role, content: [{ type: "text", text: "" }] } as Message;
+      const expected = `[${role === "user" ? "User" : "Tool result"}]: [non-text data removed - already processed by model]`;
+
+      expect(serializeConversation([empty, message, empty, message])).toBe(
+        `${expected}\n\n${expected}`,
+      );
     },
   );
 

--- a/packages/agent-core/src/harness/compaction/utils.test.ts
+++ b/packages/agent-core/src/harness/compaction/utils.test.ts
@@ -132,6 +132,36 @@ describe("file operation provenance", () => {
 });
 
 describe("serializeConversation", () => {
+  it.each(["user", "toolResult"] as const)(
+    "bounds omission markers per %s message without losing mixed text or leaking metadata",
+    (role) => {
+      const toolText = `${"progress ".repeat(400)}ERROR: terminal failure`;
+      const content = [
+        { type: "text", text: "start " },
+        ...Array.from({ length: 1_000 }, () => ({
+          type: "image",
+          data: "IMAGE_PAYLOAD_SENTINEL",
+          mimeType: "PRIVATE_MIME_SENTINEL",
+        })),
+        ...Array.from({ length: 1_000 }, (_, i) => ({
+          type: `other-media-${i}`,
+          data: "OTHER_PAYLOAD_SENTINEL",
+        })),
+        { type: "text", text: toolText },
+      ];
+      const serialized = serializeConversation([{ role, content }] as unknown as Message[]);
+
+      expect(serialized.split("[image data removed - already processed by model]")).toHaveLength(2);
+      expect(serialized.split("[non-text data removed - already processed by model]")).toHaveLength(
+        2,
+      );
+      expect(serialized).toContain("start ");
+      expect(serialized).toContain("ERROR: terminal failure");
+      expect(serialized).not.toMatch(/SENTINEL|other-media-/);
+      expect(serialized.length).toBeLessThan(role === "user" ? toolText.length + 120 : 2_200);
+    },
+  );
+
   it("omits provider thinking while preserving visible assistant state", () => {
     const messages: Message[] = [
       {

--- a/packages/agent-core/src/harness/compaction/utils.ts
+++ b/packages/agent-core/src/harness/compaction/utils.ts
@@ -200,7 +200,7 @@ function truncateForSummary(text: string, maxChars: number): string {
 }
 
 /** Extract text that compaction both estimates and includes in summary prompts. */
-export function getCompactionContentBlockText(block: {
+function getCompactionContentBlockText(block: {
   type: string;
   content?: unknown;
   text?: string;
@@ -217,33 +217,49 @@ export function getCompactionContentBlockText(block: {
     : "";
 }
 
+/** Project summary content once so rendering and token accounting share omission facts. */
+export function getCompactionContent(
+  content: string | Array<{ type: string; content?: unknown; text?: string }>,
+): { text: string; omissionText: string } {
+  const omissions = new Set<string>();
+  const text =
+    typeof content === "string"
+      ? content
+      : content
+          .map((block) => {
+            const blockText = getCompactionContentBlockText(block);
+            if (block.type !== "text" && !blockText) {
+              // This projection knows only what it omits, not whether a model processed it.
+              omissions.add(
+                block.type === "image"
+                  ? "[image data omitted from summary input]"
+                  : "[non-text data omitted from summary input]",
+              );
+            }
+            return blockText;
+          })
+          .join("");
+  return { text, omissionText: [...omissions].join("\n") };
+}
+
+const MAX_OMISSION_MESSAGES = 8;
+const OMISSION_OVERFLOW = "[More image/non-text data omitted from summary input]";
+
 /** Serialize LLM messages to plain text for summarization prompts. */
 export function serializeConversation(messages: Message[]): string {
   const parts: string[] = [];
+  let omissionMessages = 0;
 
   for (const msg of messages) {
     if (msg.role === "user" || msg.role === "toolResult") {
-      const omissions = new Set<string>();
-      const text =
-        typeof msg.content === "string"
-          ? msg.content
-          : msg.content
-              .map((block) => {
-                const blockText = getCompactionContentBlockText(block);
-                if (block.type !== "text" && !blockText) {
-                  // Reuse history-image-prune's vocabulary, capped at two fixed markers per message.
-                  omissions.add(
-                    block.type === "image"
-                      ? "[image data removed - already processed by model]"
-                      : "[non-text data removed - already processed by model]",
-                  );
-                }
-                return blockText;
-              })
-              .join("");
-      // Keep omission facts outside tool-text truncation and token estimation.
+      const { text, omissionText } = getCompactionContent(msg.content);
+      // Fixed ASCII bounds additions to 8 * (82 markers + 17 wrapper) + 55 overflow = 847 bytes.
+      // Keep the aggregate outside truncation too; later omissions must never disappear silently.
+      if (omissionText && omissionMessages++ === MAX_OMISSION_MESSAGES) {
+        parts.push(OMISSION_OVERFLOW);
+      }
       const content = [
-        ...omissions,
+        omissionMessages <= MAX_OMISSION_MESSAGES ? omissionText : "",
         msg.role === "toolResult" ? truncateForSummary(text, TOOL_RESULT_MAX_CHARS) : text,
       ]
         .filter(Boolean)

--- a/packages/agent-core/src/harness/compaction/utils.ts
+++ b/packages/agent-core/src/harness/compaction/utils.ts
@@ -222,13 +222,34 @@ export function serializeConversation(messages: Message[]): string {
   const parts: string[] = [];
 
   for (const msg of messages) {
-    if (msg.role === "user") {
-      const content =
+    if (msg.role === "user" || msg.role === "toolResult") {
+      const omissions = new Set<string>();
+      const text =
         typeof msg.content === "string"
           ? msg.content
-          : msg.content.map(getCompactionContentBlockText).join("");
+          : msg.content
+              .map((block) => {
+                const blockText = getCompactionContentBlockText(block);
+                if (block.type !== "text" && !blockText) {
+                  // Reuse history-image-prune's vocabulary, capped at two fixed markers per message.
+                  omissions.add(
+                    block.type === "image"
+                      ? "[image data removed - already processed by model]"
+                      : "[non-text data removed - already processed by model]",
+                  );
+                }
+                return blockText;
+              })
+              .join("");
+      // Keep omission facts outside tool-text truncation and token estimation.
+      const content = [
+        ...omissions,
+        msg.role === "toolResult" ? truncateForSummary(text, TOOL_RESULT_MAX_CHARS) : text,
+      ]
+        .filter(Boolean)
+        .join("\n");
       if (content) {
-        parts.push(`[User]: ${content}`);
+        parts.push(`[${msg.role === "user" ? "User" : "Tool result"}]: ${content}`);
       }
     } else if (msg.role === "assistant") {
       const textParts: string[] = [];
@@ -250,11 +271,6 @@ export function serializeConversation(messages: Message[]): string {
       }
       if (toolCalls.length > 0) {
         parts.push(`[Assistant tool calls]: ${toolCalls.join("; ")}`);
-      }
-    } else if (msg.role === "toolResult") {
-      const content = msg.content.map(getCompactionContentBlockText).join("");
-      if (content) {
-        parts.push(`[Tool result]: ${truncateForSummary(content, TOOL_RESULT_MAX_CHARS)}`);
       }
     }
   }


### PR DESCRIPTION
## What Problem This Solves

When a session was compacted, images vanished from the summarization input with **no trace**. The compaction serializer returned an empty string for image blocks, and the surrounding logic then skipped now-empty user messages and tool results entirely — so an image-only turn (or an image-only tool result, e.g. a screenshot) contributed *nothing* to the summary and left no marker. After compaction the model could not distinguish "an image was here and was omitted" from "no image ever existed", which is exactly the silent-drop class the repo doctrine ranks worst: an action must end in a visible outcome or a **recorded** non-outcome.

Confirmed reachable on shipped `v2026.7.1-2`, not just `main`.

## Why This Change Was Made

The canonical serializer now records the omission before the empty-content check, so the fact survives instead of the content being dropped. Deliberately minimal and bounded:

- The image marker is **byte-for-byte** the literal already used by `history-image-prune` (`[image data removed - already processed by model]`) rather than a second dialect; other omitted non-text blocks use the same shape with `non-text data`. (Agent-core cannot import the host runner, so the literal is duplicated, not shared.)
- Built-in summarizer input receives **at most 847 added UTF-8 bytes of omission records per request**, including newly retained role labels and separators: the first eight affected messages receive deduped markers, later omissions receive one aggregate statement, and the records count toward token estimates without asserting prior model processing. No image data or metadata is ever rendered. An earlier revision of this body claimed only a per-message bound; that was wrong, because nothing capped the number of messages. Deep review measured the unbounded growth (~59 bytes per image-only message) and the prompt-wide cap was added in response.
- Markers are emitted **outside** tool-text truncation, so a long tool result cannot truncate away the omission fact.
- A duplicate tool-result serialization branch was removed in favour of one combined user/tool-result path.

Why the nearby correct-looking code doesn't already cover this: `history-image-prune` does insert proper markers, but its transform rewrites the *provider projection*, whereas compaction re-reads the original manager branch via `sessionManager.getBranch()`. The compaction safeguard preserves the last three user turns with placeholders but still routes older messages and split-turn prefixes through the defective serializer.

## User Impact

After a compaction, summaries and rebuilt context state that an image was omitted instead of silently losing it. Thresholds, retention, summarizer instructions, original transcript rows, schema, and persistence ownership are untouched, and custom compaction providers (which receive original arrays) are unaffected. Token accounting does change: omission records are now included in the estimate rather than left outside it. This establishes request bytes and deterministic replay plumbing; it does not guarantee what a model retains in its generated summary.

## Evidence

- Failing-first through real `prepareCompaction` → `compact` → `buildSessionContext` with an image-only user message, an image-only tool result, and a split-turn prefix (pre-fix: image serializes to `""`, no marker anywhere in the summarization input or rebuilt context).
- Deep review kept the production fix unchanged and added a follow-up that **enforces the exact marker bounds** as a test invariant; it attempted and failed to construct a counterexample that renders payload/metadata into a marker.
- Assistant private-reasoning omission, the safeguard's last-three-turns placeholders, and `history-image-prune`'s own marker path verified untouched.
- Post-rebase agent-core compaction suites green; explicit-path changed-file gate exit 0; two Codex autoreviews clean.

