### PR TITLE
refactor(cli): simplify message result rendering

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2589,7 +2589,7 @@ src/commands/export-trajectory.ts	1
 src/commands/gateway-health-auth-diagnostic.ts	2
 src/commands/gateway-presence.ts	1
 src/commands/gateway-status/helpers.ts	11
-src/commands/message-format.ts	21
+src/commands/message-format.ts	20
 src/commands/message.ts	4
 src/commands/models/fallbacks-shared.ts	2
 src/commands/models/list.model-projection.ts	1

--- a/src/commands/message-format.ts
+++ b/src/commands/message-format.ts
@@ -43,14 +43,14 @@ type FormatOpts = {
   displayLimit?: number;
 };
 
-function renderObjectSummary(payload: unknown, opts: FormatOpts): string[] {
+function renderObjectSummary(payload: unknown, opts: FormatOpts): string {
   if (!payload || typeof payload !== "object") {
-    return [String(payload)];
+    return String(payload);
   }
   const obj = payload as Record<string, unknown>;
   const keys = Object.keys(obj);
   if (keys.length === 0) {
-    return [theme.muted("(empty)")];
+    return theme.muted("(empty)");
   }
 
   const rows = keys.slice(0, 20).map((k) => {
@@ -79,19 +79,17 @@ function renderObjectSummary(payload: unknown, opts: FormatOpts): string[] {
                         : "unknown";
     return { Key: k, Value: shortenText(value, 96) };
   });
-  return [
-    renderTable({
-      width: opts.width,
-      columns: [
-        { key: "Key", header: "Key", minWidth: 16 },
-        { key: "Value", header: "Value", flex: true, minWidth: 24 },
-      ],
-      rows,
-    }).trimEnd(),
-  ];
+  return renderTable({
+    width: opts.width,
+    columns: [
+      { key: "Key", header: "Key", minWidth: 16 },
+      { key: "Value", header: "Value", flex: true, minWidth: 24 },
+    ],
+    rows,
+  }).trimEnd();
 }
 
-function renderMessageList(messages: unknown[], opts: FormatOpts, emptyLabel: string): string[] {
+function renderMessageList(messages: unknown[], opts: FormatOpts, emptyLabel: string): string {
   const cap = opts.displayLimit ?? 25;
   const rows = messages.slice(0, cap).map((m) => {
     const msg = m as Record<string, unknown>;
@@ -123,43 +121,19 @@ function renderMessageList(messages: unknown[], opts: FormatOpts, emptyLabel: st
   });
 
   if (rows.length === 0) {
-    return [theme.muted(emptyLabel)];
+    return theme.muted(emptyLabel);
   }
 
-  return [
-    renderTable({
-      width: opts.width,
-      columns: [
-        { key: "Time", header: "Time", minWidth: 14 },
-        { key: "Author", header: "Author", minWidth: 10 },
-        { key: "Text", header: "Text", flex: true, minWidth: 24 },
-        { key: "Id", header: "Id", minWidth: 10 },
-      ],
-      rows,
-    }).trimEnd(),
-  ];
-}
-
-function renderMessagesFromPayload(payload: unknown, opts: FormatOpts): string[] | null {
-  if (!payload || typeof payload !== "object") {
-    return null;
-  }
-  const messages = (payload as { messages?: unknown }).messages;
-  if (!Array.isArray(messages)) {
-    return null;
-  }
-  return renderMessageList(messages, opts, "No messages.");
-}
-
-function renderPinsFromPayload(payload: unknown, opts: FormatOpts): string[] | null {
-  if (!payload || typeof payload !== "object") {
-    return null;
-  }
-  const pins = (payload as { pins?: unknown }).pins;
-  if (!Array.isArray(pins)) {
-    return null;
-  }
-  return renderMessageList(pins, opts, "No pins.");
+  return renderTable({
+    width: opts.width,
+    columns: [
+      { key: "Time", header: "Time", minWidth: 14 },
+      { key: "Author", header: "Author", minWidth: 10 },
+      { key: "Text", header: "Text", flex: true, minWidth: 24 },
+      { key: "Id", header: "Id", minWidth: 10 },
+    ],
+    rows,
+  }).trimEnd();
 }
 
 function extractDiscordSearchResultsMessages(results: unknown): unknown[] | null {
@@ -182,7 +156,7 @@ function extractDiscordSearchResultsMessages(results: unknown): unknown[] | null
   return flattened;
 }
 
-function renderReactions(payload: unknown, opts: FormatOpts): string[] | null {
+function renderReactions(payload: unknown, opts: FormatOpts): string | null {
   if (!payload || typeof payload !== "object") {
     return null;
   }
@@ -228,20 +202,18 @@ function renderReactions(payload: unknown, opts: FormatOpts): string[] | null {
   });
 
   if (rows.length === 0) {
-    return [theme.muted("No reactions.")];
+    return theme.muted("No reactions.");
   }
 
-  return [
-    renderTable({
-      width: opts.width,
-      columns: [
-        { key: "Emoji", header: "Emoji", minWidth: 8 },
-        { key: "Count", header: "Count", align: "right", minWidth: 6 },
-        { key: "Users", header: "Users", flex: true, minWidth: 20 },
-      ],
-      rows,
-    }).trimEnd(),
-  ];
+  return renderTable({
+    width: opts.width,
+    columns: [
+      { key: "Emoji", header: "Emoji", minWidth: 8 },
+      { key: "Count", header: "Count", align: "right", minWidth: 6 },
+      { key: "Users", header: "Users", flex: true, minWidth: 20 },
+    ],
+    rows,
+  }).trimEnd();
 }
 
 /**
@@ -253,17 +225,11 @@ function renderPaginationHint(payload: unknown, muted: (text: string) => string)
     return null;
   }
   const obj = payload as Record<string, unknown>;
-  if (obj.hasMore === true) {
-    return muted(
-      "More results available. Use --limit to fetch more, or --json for the raw cursor.",
-    );
-  }
-  if (typeof obj.nextBatch === "string" && obj.nextBatch) {
-    return muted(
-      "More results available. Use --limit to fetch more, or --json for the raw cursor.",
-    );
-  }
-  if (typeof obj["@odata.nextLink"] === "string" && obj["@odata.nextLink"]) {
+  if (
+    obj.hasMore === true ||
+    (typeof obj.nextBatch === "string" && obj.nextBatch) ||
+    (typeof obj["@odata.nextLink"] === "string" && obj["@odata.nextLink"])
+  ) {
     return muted(
       "More results available. Use --limit to fetch more, or --json for the raw cursor.",
     );
@@ -414,30 +380,22 @@ export function formatMessageCliText(
   }
 
   const reactionsTable = renderReactions(payload, formatOpts);
-  if (reactionsTable && result.action === "reactions") {
+  if (reactionsTable !== null && result.action === "reactions") {
     lines.push(heading("Reactions"));
-    lines.push(reactionsTable[0] ?? "");
+    lines.push(reactionsTable);
     return lines;
   }
 
-  if (result.action === "read") {
-    const messagesTable = renderMessagesFromPayload(payload, formatOpts);
-    if (messagesTable) {
-      lines.push(heading("Messages"));
-      lines.push(messagesTable[0] ?? "");
-      const hint = renderPaginationHint(payload, muted);
-      if (hint) {
-        lines.push(hint);
-      }
-      return lines;
-    }
-  }
-
-  if (result.action === "list-pins") {
-    const pinsTable = renderPinsFromPayload(payload, formatOpts);
-    if (pinsTable) {
-      lines.push(heading("Pinned messages"));
-      lines.push(pinsTable[0] ?? "");
+  if (result.action === "read" || result.action === "list-pins") {
+    const read = result.action === "read";
+    const messages =
+      payload && typeof payload === "object"
+        ? (payload as { messages?: unknown; pins?: unknown })[read ? "messages" : "pins"]
+        : undefined;
+    if (Array.isArray(messages)) {
+      const table = renderMessageList(messages, formatOpts, read ? "No messages." : "No pins.");
+      lines.push(heading(read ? "Messages" : "Pinned messages"));
+      lines.push(table);
       const hint = renderPaginationHint(payload, muted);
       if (hint) {
         lines.push(hint);
@@ -451,7 +409,7 @@ export function formatMessageCliText(
     const list = extractDiscordSearchResultsMessages(results);
     if (list) {
       lines.push(heading("Search results"));
-      lines.push(renderMessageList(list, formatOpts, "No results.")[0] ?? "");
+      lines.push(renderMessageList(list, formatOpts, "No results."));
       // Discord's approximate result count cannot prove another page exists.
       const hint = renderPaginationHint(payload, muted) ?? renderPaginationHint(results, muted);
       if (hint) {
@@ -464,11 +422,9 @@ export function formatMessageCliText(
   // Generic success + compact details table.
   lines.push(ok(`✅ ${result.action} via ${resolveChannelLabel(result.channel)}.`));
   const summary = renderObjectSummary(payload, formatOpts);
-  if (summary.length) {
-    lines.push("");
-    lines.push(...summary);
-    lines.push("");
-    lines.push(muted("Tip: use --json for full output."));
-  }
+  lines.push("");
+  lines.push(summary);
+  lines.push("");
+  lines.push(muted("Tip: use --json for full output."));
   return lines;
 }


### PR DESCRIPTION
## What Problem This Solves

The message CLI's human-readable formatter wraps individual table strings in arrays, then immediately unwraps them at its call sites. Message reads and pinned-message lists also repeat the same payload extraction, table rendering, and pagination flow. This is a bounded, maintainer-requested, AI-assisted internal cleanup.

## Why This Change Was Made

Return one string from each private single-table renderer, remove the two one-use payload adapters, and keep read/pins rendering in one local flow. The public formatter still returns the same list of output lines. Repeated pagination-hint returns share their existing short-circuit condition.

Production changes are +56/-100, net -44 lines in one file. The assertion-safety baseline also tightens this file's count from 21 to 20 because the duplicate adapter casts disappear. No replacement abstraction or new export is introduced.

## User Impact

No intended behavior change. Preserve empty output lines, empty-result messages, null versus empty-string handling, table formatting, limits, pagination precedence, reaction evaluation order, and existing send/poll/failure output. CLI flags, parsing, exit status, JSON output, plugin APIs, configuration, and persistence are untouched.

## Evidence

- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/commands/message-format.test.ts src/commands/message.test.ts`: 51 tests passed across two existing suites.
- Actual before/after formatter comparison against base `0313c2dbc4234df6801626c6441a731dc5de5a19`: 356 fixtures across four terminal widths, seven limits, and plain/colored output produced 19,936 matching cases. Public output bytes, thrown error names/messages, and payload-read order matched. The probe imported the real formatter dependencies and used an isolated fixture channel registry, without contacting channel services.
- Scoped `oxfmt --check`, core oxlint, and `git diff --check` passed.
- Initial CI correctly caught the stale assertion budget (`20 < 21`). The owned baseline entry is now 20; the full assertion-safety guard against the frozen base passes. No guard was weakened or unrelated baseline entry pruned.
- Isolated precommit Codex review of the complete two-file change, independent owner/caller review, and a distinct read-only review of exact commit `7ad4711bb1cee4a6e0dcea246fc95f9aa3773541` found no actionable issues.
- No test files changed. Existing formatter and message-command tests are retained.
