### PR TITLE
fix(ci): prevent workflow lint stdin deadlock

### DIFF
--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -152,29 +152,25 @@ jobs:
           tar -xJf "${archive}" "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
           sudo install -m 0755 "shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
 
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "1.25.0"
+          cache: false
+
       - name: Install actionlint
         shell: bash
         run: |
           set -euo pipefail
-          ACTIONLINT_VERSION="1.7.12"
-          archive="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
-          base_url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}"
-          # GitHub release downloads occasionally return transient 5xx responses.
-          # Retry all curl errors here so workflow-sanity does not fail closed on
-          # a one-off release edge outage.
-          curl_args=(
-            --connect-timeout 10
-            --max-time 120
-            --retry 5
-            --retry-delay 2
-            --retry-all-errors
-            -sSfL
-          )
-          curl "${curl_args[@]}" -o "${archive}" "${base_url}/${archive}"
-          curl "${curl_args[@]}" -o checksums.txt "${base_url}/actionlint_${ACTIONLINT_VERSION}_checksums.txt"
-          grep " ${archive}\$" checksums.txt | sha256sum -c -
-          tar -xzf "${archive}" actionlint
-          sudo install -m 0755 actionlint /usr/local/bin/actionlint
+          # v1.7.12 writes ShellCheck stdin before starting it and deadlocks on large run blocks.
+          # Pin the upstream fix until a release includes rhysd/actionlint#651.
+          ACTIONLINT_REVISION="011a6d15e749bb3f2d771eed9c7aa0e7e3e10ee7"
+          export GOBIN="$RUNNER_TEMP/actionlint-bin"
+          go install "github.com/rhysd/actionlint/cmd/actionlint@${ACTIONLINT_REVISION}"
+          version="$("$GOBIN/actionlint" -version)"
+          printf '%s\n' "$version"
+          grep -Fxq "v1.7.13-0.20260419144658-${ACTIONLINT_REVISION:0:12}" <<< "$version"
+          echo "$GOBIN" >> "$GITHUB_PATH"
 
       - name: Lint workflows
         run: actionlint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
 
   # GitHub Actions linting
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.12
+    rev: 011a6d15e749bb3f2d771eed9c7aa0e7e3e10ee7 # ShellCheck stdin deadlock fix (#651)
     hooks:
       - id: actionlint
 

--- a/scripts/check-workflows.mts
+++ b/scripts/check-workflows.mts
@@ -7,7 +7,7 @@ import { mkdtempSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-const ACTIONLINT_VERSION = "1.7.12";
+const ACTIONLINT_REVISION = "011a6d15e749bb3f2d771eed9c7aa0e7e3e10ee7";
 const PRE_COMMIT_VERSION = "4.6.2";
 const WORKFLOW_DIR = ".github/workflows";
 
@@ -118,7 +118,7 @@ const workflows = workflowFiles();
 if (commandExists("actionlint")) {
   run("actionlint", workflows);
 } else if (commandExists("go", ["version"])) {
-  run("go", ["run", `github.com/rhysd/actionlint/cmd/actionlint@v${ACTIONLINT_VERSION}`]);
+  run("go", ["run", `github.com/rhysd/actionlint/cmd/actionlint@${ACTIONLINT_REVISION}`]);
 } else if (
   commandExists("pre-commit") ||
   commandExists("python3", ["-m", "pre_commit", "--version"]) ||
@@ -127,7 +127,7 @@ if (commandExists("actionlint")) {
   runPreCommitHook("actionlint", workflows);
 } else {
   console.error(
-    `[check-workflows] missing workflow linter: install actionlint, Go ${ACTIONLINT_VERSION} fallback support, or pre-commit.`,
+    `[check-workflows] missing workflow linter: install actionlint, Go for actionlint@${ACTIONLINT_REVISION}, or pre-commit.`,
   );
   process.exit(1);
 }

--- a/test/scripts/check-workflows.test.ts
+++ b/test/scripts/check-workflows.test.ts
@@ -25,6 +25,7 @@ describe("check-workflows", () => {
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("missing workflow linter");
     expect(result.stderr).toContain("install actionlint, Go");
+    expect(result.stderr).toContain("011a6d15e749bb3f2d771eed9c7aa0e7e3e10ee7");
   });
 
   it("uses the pinned go fallback and audits all workflows with zizmor", () => {
@@ -71,7 +72,7 @@ describe("check-workflows", () => {
 
     expect(result.status).toBe(0);
     expect(readFileSync(markerPath, "utf8")).toContain(
-      "github.com/rhysd/actionlint/cmd/actionlint@v1.7.12",
+      "github.com/rhysd/actionlint/cmd/actionlint@011a6d15e749bb3f2d771eed9c7aa0e7e3e10ee7",
     );
     const preCommitArgs = readFileSync(preCommitMarkerPath, "utf8");
     expect(preCommitArgs).toContain("run --config .pre-commit-config.yaml zizmor --files");

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -6316,7 +6316,7 @@ server.listen(0, "127.0.0.1", () => {
     expect(run).not.toContain("git fetch");
   });
 
-  it("bounds the workflow sanity tool downloads", () => {
+  it("bounds the workflow sanity ShellCheck download", () => {
     const workflow = readWorkflowSanityWorkflow();
     const shellcheckStep = expectDefined(
       workflow.jobs.actionlint.steps.find(
@@ -6324,21 +6324,38 @@ server.listen(0, "127.0.0.1", () => {
       ),
       "ShellCheck install step",
     );
-    const actionlintStep = expectDefined(
-      workflow.jobs.actionlint.steps.find(
-        (step: WorkflowStep) => step.name === "Install actionlint",
-      ),
-      "actionlint install step",
-    );
-
     expect(shellcheckStep.run).toContain("curl --connect-timeout 10 --max-time 120");
     expect(shellcheckStep.run).toContain("--retry 5 --retry-delay 2 --retry-all-errors");
-    expect(actionlintStep.run).toContain("--connect-timeout 10");
-    expect(actionlintStep.run).toContain("--max-time 120");
-    expect(actionlintStep.run).toContain("--retry 5");
-    expect(actionlintStep.run).toContain("--retry-delay 2");
-    expect(actionlintStep.run).toContain("--retry-all-errors");
-    expect(actionlintStep.run.match(/curl "\$\{curl_args\[@\]\}"/gu)).toHaveLength(2);
+  });
+
+  it("pins workflow and pre-commit actionlint to the large-stdin deadlock fix", () => {
+    const revision = "011a6d15e749bb3f2d771eed9c7aa0e7e3e10ee7";
+    const steps: WorkflowStep[] = readWorkflowSanityWorkflow().jobs.actionlint.steps;
+    const setupGo = expectDefined(
+      steps.find((step) => step.uses === SETUP_GO_V6),
+      "Go setup",
+    );
+    const install = expectDefined(
+      steps.find((step) => step.name === "Install actionlint"),
+      "actionlint install",
+    );
+
+    expect(setupGo.with).toEqual({ "go-version": "1.25.0", cache: false });
+    expect(steps.indexOf(setupGo)).toBeLessThan(steps.indexOf(install));
+    expect(install.run).toContain(`ACTIONLINT_REVISION="${revision}"`);
+    expect(install.run).toContain('export GOBIN="$RUNNER_TEMP/actionlint-bin"');
+    expect(install.run).toContain(
+      'go install "github.com/rhysd/actionlint/cmd/actionlint@${ACTIONLINT_REVISION}"',
+    );
+    expect(install.run).toContain('"$GOBIN/actionlint" -version');
+    expect(install.run).toContain("v1.7.13-0.20260419144658-${ACTIONLINT_REVISION:0:12}");
+    expect(install.run).toContain('echo "$GOBIN" >> "$GITHUB_PATH"');
+    const preCommit = parse(readFileSync(".pre-commit-config.yaml", "utf8"));
+    expect(
+      preCommit.repos.find(
+        (repo: { repo: string }) => repo.repo === "https://github.com/rhysd/actionlint",
+      ).rev,
+    ).toBe(revision);
   });
 
   it("runs committed generated baseline drift checks in workflow sanity", () => {

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -7325,8 +7325,6 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
     expect(publishOrchestration.env?.FULL_RELEASE_VALIDATION_RUN_ATTEMPT).toBe(
       "${{ needs.resolve_release_target.outputs.full_release_validation_run_attempt }}",
     );
-    // actionlint passes embedded scripts to ShellCheck through a 64 KiB pipe.
-    expect(Buffer.byteLength(publishOrchestration.run ?? "", "utf8")).toBeLessThan(64 * 1024);
     expect(publishOrchestration.run).toContain('"${target_sha}" != "${TARGET_SHA}"');
     expect(npmFullRun.env?.FULL_RELEASE_VALIDATION_RUN_ATTEMPT).toBe(
       "${{ inputs.full_release_validation_run_attempt }}",


### PR DESCRIPTION
Related: #131903 (draft-proof test performance landing blocked by Workflow Sanity)

## What Problem This Solves

Resolves a problem where Workflow Sanity hangs while linting the existing `Dispatch publish workflows` run block. The same actionlint version is also pinned in pre-commit and the local Go fallback, so retrying CI or using those installation paths does not repair the problem.

## Why This Change Was Made

Pin actionlint to upstream commit `011a6d15e749bb3f2d771eed9c7aa0e7e3e10ee7` at all three repository-owned installation surfaces. Workflow Sanity uses the existing SHA-pinned setup-go v7 action with Go **1.25.0**, exactly as required by upstream `go.mod`, and `cache: false`. It installs into runner temp, verifies `v1.7.13-0.20260419144658-011a6d15e749`, and adds that bin to `GITHUB_PATH`.

The root cause is upstream subprocess ownership: v1.7.12 writes all stdin into `StdinPipe` **before** starting ShellCheck. Input exceeding the pipe capacity therefore blocks before the reader exists. The fixed commit lets `exec.Cmd` copy stdin after starting the child. [Upstream PR #651](https://github.com/rhysd/actionlint/pull/651) merged on April 19; the [latest release v1.7.12](https://github.com/rhysd/actionlint/releases/tag/v1.7.12), verified during this repair, dates to March 30 and does not contain it.

Remove only actionlint's obsolete release-archive download/checksum path and the obsolete raw release-script size assertion. Keep the bounded, checksummed ShellCheck download, all lint/audit checks, installed-actionlint preference, and pre-commit fallback. Shrinking the release script or disabling ShellCheck would work around the wrong owner; neither is done here.

## User Impact

Maintainers and contributors using these owned installs can lint the complete workflows without this deadlock. There is no product runtime change or product dependency change. Release behavior and release workflow bytes, CHANGELOG, versions, schemas, protocol, live Gateway, and secrets are untouched. Existing externally installed actionlint remains operator-owned and may still need updating.

## Evidence

Personally inspected exact upstream source:

- [process.go:24–31](https://github.com/rhysd/actionlint/blob/011a6d15e749bb3f2d771eed9c7aa0e7e3e10ee7/process.go#L24-L31): `cmd.Stdin = strings.NewReader(e.stdin)` replaces the pre-start write.
- [process_test.go:179–220](https://github.com/rhysd/actionlint/blob/011a6d15e749bb3f2d771eed9c7aa0e7e3e10ee7/process_test.go#L179-L220): five concurrent 64 KiB stdin copies.
- [go.mod:3](https://github.com/rhysd/actionlint/blob/011a6d15e749bb3f2d771eed9c7aa0e7e3e10ee7/go.mod#L3): Go 1.25.0.

Local old-versus-fixed proof on `6ddb9f049fb3617fac38a34ea139f435d9133399`, macOS arm64 and installed ShellCheck 0.11.0:

- Installed actionlint v1.7.12 against `.github/workflows/openclaw-release-publish.yml`: no output, still hung at **20.006 seconds**; bounded probe killed its own process group.
- `GOBIN=<disposable-bin> GOTOOLCHAIN=go1.25.0 go install github.com/rhysd/actionlint/cmd/actionlint@011a6d15e749bb3f2d771eed9c7aa0e7e3e10ee7`: version output and Go build metadata identify **v1.7.13-0.20260419144658-011a6d15e749**.
- That exact binary against **all workflows**, with installed ShellCheck explicitly selected: **exit 0 in 5.128 seconds**. Repeated on the final patch: exit 0. A transparent stdin capture forwarding to real ShellCheck recorded **65,538 bytes** for the existing release block.
- The exact checked-in install step was executed in disposable runner temp with Go 1.25.0: version verification and `GITHUB_PATH` output passed.
- Upstream `GOTOOLCHAIN=go1.25.0 go test -run 'TestProcess' -timeout 30s .`: passed (0.595s), including the concurrent large-input regression.
- New/updated guards demonstrated **three intended failures before the fix**: old fallback revision, old diagnostic, and missing Go setup.
- `node scripts/run-vitest.mjs test/scripts/check-workflows.test.ts test/scripts/ci-workflow-guards.test.ts test/scripts/package-acceptance-workflow.test.ts test/scripts/check-composite-action-input-interpolation.test.ts test/scripts/check-no-conflict-markers.test.ts`: **367 passed, 2 skipped**, five files.
- `PATH=<fixed-bin>:$PATH pnpm check:workflows`: passed actionlint, zizmor, composite-input and conflict-marker checks.
- Targeted oxfmt and `git diff --check`: passed. Changed gate for the six explicit paths passed scripts/root-test typechecks, scripts lint, erasability and all selected guards on [Blacksmith Testbox run 33195535020](https://github.com/openclaw/openclaw/actions/runs/33195535020), delegated command exit 0 (5m20.619s). The one-shot lease is confirmed stopped; backing workflow cancellation during cleanup is not the command verdict.
- Deslop complete; fresh isolated Codex autoreview clean, no accepted/actionable findings. The reviewer could not independently retrieve pseudo-version metadata; the local exact build and executed installation above supply that proof.

Production LOC **0**. Workflow **+15/-19**; tooling/config **+4/-4**; tests **+33/-17**. The replacement pin/setup regression covers the owner contract without network installation in tests. No release authority was extracted or moved.

Hosted symptom: [pre-fix run](https://github.com/openclaw/openclaw/actions/runs/33193613190/job/98925129520) spent 377 seconds in lint before a newer main push cancelled it; this is cancellation evidence, not a claimed timeout. The vulnerable pin was carried forward by [#112963](https://github.com/openclaw/openclaw/pull/112963); the removed size workaround came from [#128391](https://github.com/openclaw/openclaw/pull/128391). [#110562](https://github.com/openclaw/openclaw/pull/110562) separately proposes bounding local subprocesses; it does not replace fixing the upstream deadlock.

AI-assisted maintainer repair, explicitly requested. Native prepare/merge and exact-head hosted CI will be recorded before landing.

Exact-head landing update: CI [33196019956](https://github.com/openclaw/openclaw/actions/runs/33196019956), Workflow Sanity [33196003010](https://github.com/openclaw/openclaw/actions/runs/33196003010), Testbox [33196020058](https://github.com/openclaw/openclaw/actions/runs/33196020058), ARM [33196019975](https://github.com/openclaw/openclaw/actions/runs/33196019975), and build artifacts [33196020050](https://github.com/openclaw/openclaw/actions/runs/33196020050) all passed on `9d81d12a723599482bdf8faa3a75688cf70e055c`. Hosted actionlint install took 9s; full lint took 7s. The interim pin is explicitly accepted under the maintainer request, addressing the latest ClawSweeper decision and rank-up move.
