### PR TITLE
fix(plugins): consolidate setup errors and roll back failed channels

### DIFF
--- a/src/plugins/loader-channel-runtime.ts
+++ b/src/plugins/loader-channel-runtime.ts
@@ -47,8 +47,8 @@ export function loadSetupRuntimeChannelCandidate(params: {
   if (!registrationPlan.loadSetupEntry || !manifestRecord.setupSource) {
     return false;
   }
-  const setupRegistration = resolveSetupChannelRegistration(params.mod);
-  if (setupRegistration.loadError) {
+  // Registration rollback can restore record fields, so read them only when reporting.
+  const recordSetupFailure = (error: unknown, phase: "load" | "register", message: string) => {
     recordPluginError({
       logger: params.logger,
       registry: registryBuilder.registry,
@@ -56,12 +56,16 @@ export function loadSetupRuntimeChannelCandidate(params: {
       seenIds: params.seenIds,
       pluginId: record.id,
       origin: params.candidateOrigin,
-      phase: "load",
-      error: setupRegistration.loadError,
-      logPrefix: `[plugins] ${record.id} failed to load setup entry from ${record.source}: `,
-      diagnosticMessagePrefix: "failed to load setup entry: ",
+      phase,
+      error,
+      logPrefix: `[plugins] ${record.id} ${message} from ${record.source}: `,
+      diagnosticMessagePrefix: `${message}: `,
       diagnosticCode: "channel-setup-failure",
     });
+  };
+  const setupRegistration = resolveSetupChannelRegistration(params.mod);
+  if (setupRegistration.loadError) {
+    recordSetupFailure(setupRegistration.loadError, "load", "failed to load setup entry");
     return true;
   }
   if (!setupRegistration.plugin) {
@@ -122,19 +126,7 @@ export function loadSetupRuntimeChannelCandidate(params: {
         () => params.loadPluginModule(safeRuntimeSource) as OpenClawPluginModule,
       );
     } catch (error) {
-      recordPluginError({
-        logger: params.logger,
-        registry: registryBuilder.registry,
-        record,
-        seenIds: params.seenIds,
-        pluginId: record.id,
-        origin: params.candidateOrigin,
-        phase: "load",
-        error,
-        logPrefix: `[plugins] ${record.id} failed to load setup-runtime entry from ${record.source}: `,
-        diagnosticMessagePrefix: "failed to load setup-runtime entry: ",
-        diagnosticCode: "channel-setup-failure",
-      });
+      recordSetupFailure(error, "load", "failed to load setup-runtime entry");
       return true;
     }
     const runtimeRegistration = resolveBundledRuntimeChannelRegistration(runtimeMod);
@@ -149,19 +141,7 @@ export function loadSetupRuntimeChannelCandidate(params: {
         runtimeRegistration.setChannelRuntime(api.runtime);
         runtimeSetterApplied = true;
       } catch (error) {
-        recordPluginError({
-          logger: params.logger,
-          registry: registryBuilder.registry,
-          record,
-          seenIds: params.seenIds,
-          pluginId: record.id,
-          origin: params.candidateOrigin,
-          phase: "load",
-          error,
-          logPrefix: `[plugins] ${record.id} failed to apply setup-runtime channel runtime from ${record.source}: `,
-          diagnosticMessagePrefix: "failed to apply setup-runtime channel runtime: ",
-          diagnosticCode: "channel-setup-failure",
-        });
+        recordSetupFailure(error, "load", "failed to apply setup-runtime channel runtime");
         return true;
       }
     }
@@ -169,19 +149,11 @@ export function loadSetupRuntimeChannelCandidate(params: {
       registration: runtimeRegistration,
     });
     if (runtimePluginRegistration.loadError) {
-      recordPluginError({
-        logger: params.logger,
-        registry: registryBuilder.registry,
-        record,
-        seenIds: params.seenIds,
-        pluginId: record.id,
-        origin: params.candidateOrigin,
-        phase: "load",
-        error: runtimePluginRegistration.loadError,
-        logPrefix: `[plugins] ${record.id} failed to load setup-runtime channel entry from ${record.source}: `,
-        diagnosticMessagePrefix: "failed to load setup-runtime channel entry: ",
-        diagnosticCode: "channel-setup-failure",
-      });
+      recordSetupFailure(
+        runtimePluginRegistration.loadError,
+        "load",
+        "failed to load setup-runtime channel entry",
+      );
       return true;
     }
     if (runtimePluginRegistration.plugin) {
@@ -225,19 +197,7 @@ export function loadSetupRuntimeChannelCandidate(params: {
     try {
       mergedSetupRegistration.setChannelRuntime?.(api.runtime);
     } catch (error) {
-      recordPluginError({
-        logger: params.logger,
-        registry: registryBuilder.registry,
-        record,
-        seenIds: params.seenIds,
-        pluginId: record.id,
-        origin: params.candidateOrigin,
-        phase: "load",
-        error,
-        logPrefix: `[plugins] ${record.id} failed to apply setup channel runtime from ${record.source}: `,
-        diagnosticMessagePrefix: "failed to apply setup channel runtime: ",
-        diagnosticCode: "channel-setup-failure",
-      });
+      recordSetupFailure(error, "load", "failed to apply setup channel runtime");
       return true;
     }
   }
@@ -251,38 +211,21 @@ export function loadSetupRuntimeChannelCandidate(params: {
       );
     } catch (error) {
       registryBuilder.rollbackPluginGlobalSideEffects(record.id, record);
-      recordPluginError({
-        logger: params.logger,
-        registry: registryBuilder.registry,
-        record,
-        seenIds: params.seenIds,
-        pluginId: record.id,
-        origin: params.candidateOrigin,
-        phase: "register",
+      recordSetupFailure(
         error,
-        logPrefix: `[plugins] ${record.id} failed to register setup-runtime channel side effects from ${record.source}: `,
-        diagnosticMessagePrefix: "failed to register setup-runtime channel side effects: ",
-        diagnosticCode: "channel-setup-failure",
-      });
+        "register",
+        "failed to register setup-runtime channel side effects",
+      );
       return true;
     }
   }
   try {
     api.registerChannel(mergedSetupPlugin);
   } catch (error) {
-    recordPluginError({
-      logger: params.logger,
-      registry: registryBuilder.registry,
-      record,
-      seenIds: params.seenIds,
-      pluginId: record.id,
-      origin: params.candidateOrigin,
-      phase: "load",
-      error,
-      logPrefix: `[plugins] ${record.id} failed to register setup channel from ${record.source}: `,
-      diagnosticMessagePrefix: "failed to register setup channel: ",
-      diagnosticCode: "channel-setup-failure",
-    });
+    // Setup-runtime registration may already have added contributions.
+    // Roll them back before recording the channel registration failure.
+    registryBuilder.rollbackPluginGlobalSideEffects(record.id, record);
+    recordSetupFailure(error, "load", "failed to register setup channel");
     return true;
   }
   registryBuilder.registry.plugins.push(record);

--- a/src/plugins/loader.hooks-and-runtime.test-utils.ts
+++ b/src/plugins/loader.hooks-and-runtime.test-utils.ts
@@ -592,12 +592,19 @@ ${channelPluginSource({
       ids: ["setup-runtime-error-test", "setup-runtime-helper-test"],
     });
 
-    expect(registry.plugins.find((entry) => entry.id === "setup-runtime-error-test")?.status).toBe(
-      "error",
+    expect(registry.plugins.find((entry) => entry.id === "setup-runtime-error-test")).toMatchObject(
+      {
+        status: "error",
+        failurePhase: "load",
+        error: expect.stringContaining("broken setup runtime setter"),
+      },
     );
-    expect(
-      registry.plugins.find((entry) => entry.id === "setup-runtime-error-test")?.error,
-    ).toContain("broken setup runtime setter");
+    expect(registry.diagnostics).toContainEqual(
+      expect.objectContaining({
+        pluginId: "setup-runtime-error-test",
+        code: "channel-setup-failure",
+      }),
+    );
     expect(registry.plugins.find((entry) => entry.id === "setup-runtime-helper-test")?.status).toBe(
       "loaded",
     );
@@ -627,11 +634,18 @@ ${channelPluginSource({
     });
 
     expect(
-      registry.plugins.find((entry) => entry.id === "setup-runtime-route-error-test")?.status,
-    ).toBe("error");
-    expect(
-      registry.plugins.find((entry) => entry.id === "setup-runtime-route-error-test")?.error,
-    ).toContain("broken setup-runtime registrar");
+      registry.plugins.find((entry) => entry.id === "setup-runtime-route-error-test"),
+    ).toMatchObject({
+      status: "error",
+      failurePhase: "register",
+      error: expect.stringContaining("broken setup-runtime registrar"),
+    });
+    expect(registry.diagnostics).toContainEqual(
+      expect.objectContaining({
+        pluginId: "setup-runtime-route-error-test",
+        code: "channel-setup-failure",
+      }),
+    );
     expect(registry.httpRoutes.some((route) => route.path === "/setup-runtime-route-error")).toBe(
       false,
     );
@@ -791,7 +805,7 @@ ${channelPluginSource({
     });
   });
 
-  it("records a diagnostic when registerChannel throws in the setup-entry path", () => {
+  it("rolls back setup registrations and records a diagnostic when registerChannel throws", () => {
     useNoBundledPlugins();
     const brokenDir = createSetupFailureFixture({
       id: "register-channel-throws-test",
@@ -805,6 +819,13 @@ ${channelPluginSource({
   });
   module.exports = {
     kind: "bundled-channel-setup-entry",
+    registerSetupRuntime(api) {
+      api.registerHttpRoute({
+        path: "/register-channel-throws-route",
+        auth: "gateway",
+        handler: async () => true,
+      });
+    },
     loadSetupPlugin: () => ({
       id: "register-channel-throws-test",
       meta: {
@@ -846,6 +867,9 @@ ${channelPluginSource({
       pluginId: "register-channel-throws-test",
       message: "failed to register setup channel",
     });
+    expect(
+      registry.httpRoutes.some((route) => route.path === "/register-channel-throws-route"),
+    ).toBe(false);
     // The healthy plugin loaded AFTER the broken one must still be present.
     const healthyChannel = registry.channels.find(
       (entry) => entry.plugin.id === "healthy-after-register-throw-chat",


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested cleanup of channel setup loading. Seven failure paths repeated identical diagnostic context and message formatting, making the setup sequence harder to follow. Review also exposed a nearby rollback defect: setup-runtime contributions could survive when the later channel registration failed.

## Why This Change Was Made

Use one private, owner-local reporter that delegates to the existing canonical plugin error recorder. Each failure path retains its exact message, phase, diagnostic code, and return behavior. Record fields are read when reporting, after registration rollback when applicable; timestamps and diagnostic mutations remain owned by the existing recorder.

The final channel-registration catch now invokes the existing registry rollback owner before reporting, matching the full-runtime and CLI registration paths. This removes contributions already registered by setup-runtime when later channel normalization throws.

Production: +26/-83, net **-57 lines**. Test support: +35/-11, net **+24 lines**. Two existing failure cases now also check phase and diagnostic attribution; a third reproduces and prevents the late-registration route leak. No test cases or production seams were added.

## User Impact

Failed channel setup no longer leaves setup-runtime HTTP routes registered after channel registration throws. The failure is still diagnosed and healthy sibling plugins continue loading. Existing message text and failure phases remain unchanged. No config, storage, security policy, plugin SDK, or import-boundary changes. AI-assisted.

## Evidence

- Before edits, 29 setup-loader and record tests passed; unrelated loader cases were filtered out.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/plugins/loader.test.ts src/plugins/loader-records.test.ts -t 'setup|bundled runtime setter|plugin loader records'`
- Source review traced setup loading, the runtime/CLI siblings, canonical error recording, and record restoration during rollback.
- The existing channel-registration failure fixture was extended to register a route first. Before the rollback repair, it failed because the route remained present; after the repair, the same case passed and the healthy sibling still loaded.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/plugins/loader.test.ts -t 'rolls back setup registrations and records a diagnostic when registerChannel throws'`: before **1 failed**, after **1 passed**.

- Final focused proof: **48 tests passed** across setup loading, error records, and CLI metadata (23 + 6 + 19). Unrelated loader cases remained filtered out.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/plugins/loader.test.ts src/plugins/loader-records.test.ts src/plugins/loader.cli-metadata.test.ts -t 'setup|bundled runtime setter|plugin loader records|plugin loader CLI metadata'`
- Owning `plugins-platform` TypeScript graph, scoped typed lint, formatting, and `git diff --check` passed.
- Full final-diff Codex autoreview and a separate independent review of exact commit `952837623c3cb185882f19f8fc8b0ca7ba4267de` completed without actionable findings. Hosted CI is pending.

The missing rollback was carried forward by the loader split in #108513 (`ab3f057cfd57`); this is not a claim that the split originally introduced it. Proof exercises the real loader boundary with local generated plugin fixtures, not authenticated provider/channel delivery.
