### PR TITLE
docs: add DingTalk guide and compatibility warning

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -36,6 +36,10 @@
       - any-glob-to-any-file:
           - "extensions/a2a/**"
           - "docs/channels/a2a.md"
+"channel: dingtalk":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/channels/dingtalk-connector.md"
 "channel: discord":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -4,6 +4,10 @@
     "target": "OpenClaw"
   },
   {
+    "source": "DingTalk",
+    "target": "钉钉"
+  },
+  {
     "source": "macOS platform notes",
     "target": "macOS 平台说明"
   },

--- a/docs/channels/dingtalk-connector.md
+++ b/docs/channels/dingtalk-connector.md
@@ -1,0 +1,36 @@
+---
+summary: "Find the DingTalk team's external plugin, setup guide, and compatibility requirements"
+read_when:
+  - You want to connect OpenClaw to DingTalk
+  - You need the DingTalk plugin's installation guide or compatibility status
+title: "DingTalk"
+---
+
+The DingTalk team maintains the external
+`@dingtalk-real-ai/dingtalk-connector` plugin for direct messages and group chats.
+It connects through DingTalk's Stream API. The plugin is maintained outside
+OpenClaw and is not bundled with the core install.
+
+## Compatibility
+
+DingTalk plugin **0.8.25** does not start with OpenClaw **2026.8.1-beta.3** or
+the current 2026.8.1 source. It imports the removed
+`openclaw/plugin-sdk/channel-runtime` entry point. Its declared
+`openclaw >=2026.4.9` peer dependency does not capture this incompatibility.
+
+Wait for a compatible DingTalk release before enabling it on those hosts.
+DingTalk is not offered in OpenClaw's default onboarding catalog while this
+published-package compatibility gap remains.
+
+## Install and configure
+
+Follow the [DingTalk plugin setup guide](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/blob/main/README.en.md)
+for supported host versions, QR authorization, and manual bot configuration.
+Check the [published package](https://www.npmjs.com/package/@dingtalk-real-ai/dingtalk-connector)
+and its release notes before installing or upgrading.
+
+DingTalk credentials, permissions, access policies, and bot behavior belong to
+the external plugin. Use its documentation for the installed version.
+The plugin and channel ID are both `dingtalk-connector`.
+
+For generic plugin lifecycle commands, see [Manage plugins](/plugins/manage-plugins).

--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -57,6 +57,7 @@ install. Channels marked "official plugin" install with one command
 
 ### Related communication plugins
 
+- [DingTalk](/channels/dingtalk-connector) - The DingTalk team's external plugin; check its compatibility requirements before installing.
 - [Voice Call](/plugins/voice-call) - Telephony via Plivo, Telnyx, or Twilio (official plugin).
 
 ## Group join introductions

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1200,6 +1200,7 @@
               {
                 "group": "Regional platforms",
                 "pages": [
+                  "channels/dingtalk-connector",
                   "channels/line",
                   "channels/wechat",
                   "channels/wecom",


### PR DESCRIPTION
## What Problem This Solves

Users looking for DingTalk cannot find the vendor-maintained plugin from OpenClaw's channel documentation. Adding it directly to default onboarding would currently be misleading: the latest published DingTalk package, 0.8.25, loads its entry point but fails when the channel starts on OpenClaw 2026.8.1-beta.3 because it imports the removed `openclaw/plugin-sdk/channel-runtime` subpath.

## Why This Change Was Made

Add a DingTalk page, a Regional platforms navigation entry, and a channel-overview link to the vendor's setup guide and npm package. The page states the verified compatibility limit and keeps vendor configuration ownership explicit. Add the matching channel label routing and Chinese glossary term.

This PR deliberately does not promote 0.8.25 into the trusted official external catalog. Catalog membership would offer an installation that cannot start on the current host. Follow-up promotion needs a compatible published DingTalk artifact, an exact npm version/integrity pin, and cold onboarding/install/start proof. The upstream SDK migration is tracked in https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/656 and the routing follow-up in https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/657; neither open PR is a published release.

## User Impact

DingTalk is discoverable from the docs without implying that the current published package works on the 2026.8.1 host or that OpenClaw maintains the plugin. The default onboarding catalog and installation trust policy stay unchanged.

## Evidence

- Inspected npm 0.8.25 metadata, integrity-verified tarball, published README, plugin manifest, and the actual channel startup import chain. The plugin and channel ID are both `dingtalk-connector`.
- Secretless Linux AWS package reproduction with Node 24.19.0, OpenClaw 2026.8.1-beta.3, and DingTalk 0.8.25: importing `dist/index.mjs` succeeds; invoking the published `gateway.startAccount` with a pre-aborted signal and fixture credentials fails before connecting with `ERR_PACKAGE_PATH_NOT_EXPORTED` for `./plugin-sdk/channel-runtime`. Run `run_3de86afc0eb6`; lease stopped. The first combined npm install rejects the plugin's peer range against the prerelease host; the diagnostic rerun uses `--legacy-peer-deps` only to reach and prove the independent runtime failure, not as a recommended install workaround.
- No authenticated DingTalk connection or message delivery was attempted. No plugin implementation, runtime config, persistence, dependency, or catalog change is included.

Validation passed: `node scripts/check-changed.mjs -- .github/labeler.yml docs/.i18n/glossary.zh-CN.json docs/channels/dingtalk-connector.md docs/channels/index.md docs/docs.json`; `node scripts/write-official-channel-catalog.mjs --check`; focused MDX and docs-format checks; `node scripts/docs-link-audit.mjs` (6,924 internal links, zero broken); `node --import ./scripts/tsx.mjs scripts/check-docs-i18n-glossary.mts --base origin/main`; `node scripts/docs-list.js`; `git diff --check`; Codex autoreview (no actionable findings).

Production code: +0/-0. Tests: +0/-0. Documentation and metadata: +46/-0 across five files. No test-only production seams or generated-catalog edits.

### Maintainer verification of the review concern

The published-package claim was independently rechecked outside the review worker's DNS-restricted environment. The primary npm metadata identifies version 0.8.25 and integrity `sha512-rRl1g6s+hwoRjnr08acbD/x5VIvE8vyhlFfiaDIT88te9UZgsamrmBxaqdzznRwVH2MTr4mLe8YZBJ2qjtsd2A==`. The downloaded tarball matched that integrity. Its `dist/message-handler-BU5DyGGZ.mjs:209` imports the removed subpath; `dist/runtime-DvcaQdQ3.mjs:914` reaches that chunk from the channel monitor. The published peer range is `>=2026.4.9`.

The isolated Node probe observed:

```text
host=2026.8.1-beta.3 plugin=0.8.25 channelRuntimeExport=null
index.mjs: loaded
gateway.startAccount: ERR_PACKAGE_PATH_NOT_EXPORTED (./plugin-sdk/channel-runtime)
```

Primary sources: [npm metadata](https://registry.npmjs.org/@dingtalk-real-ai%2fdingtalk-connector/0.8.25), [published tarball](https://registry.npmjs.org/@dingtalk-real-ai/dingtalk-connector/-/dingtalk-connector-0.8.25.tgz), [vendor's English guide](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/blob/main/README.en.md).

The maintainer decision is to land documentation only and leave the official onboarding catalog unchanged. The vendor artifact needs a compatible release before catalog promotion. No ClawHub scan or trust gate is bypassed.

Required [CI run 33196248199](https://github.com/openclaw/openclaw/actions/runs/33196248199) passed `openclaw/ci-gate` for `9c8f4ea4bc05c368907f4df6a430f1f00fcad9e0`.

AI-assisted with Codex.
