### PR TITLE
fix(release): accept active publication transitions

### DIFF
--- a/scripts/lib/actions-artifact-archive.mjs
+++ b/scripts/lib/actions-artifact-archive.mjs
@@ -13,7 +13,13 @@ const ARTIFACT_DIGEST_RE = /^sha256:[0-9a-f]{64}$/u;
 const ARTIFACT_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9_.-]*$/u;
 const COMMIT_SHA_RE = /^[0-9a-f]{40}$/u;
 const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u;
-const ACTIVE_SAME_RUN_STATUSES = new Set(["in_progress", "waiting"]);
+const ACTIVE_SAME_RUN_STATUSES = new Set([
+  "in_progress",
+  "pending",
+  "queued",
+  "requested",
+  "waiting",
+]);
 const SUPPORTED_ZIP_FLAGS = 0x0808;
 const ZIP_DATA_DESCRIPTOR_FLAG = 0x0008;
 const ZIP_UTF8_FLAG = 0x0800;
@@ -737,9 +743,8 @@ export function validateActionsArtifactBinding(params) {
       throw new Error("Actions workflow run does not match the immutable publication tuple.");
     }
   } else if (expected.runAttempt === expected.consumerRunAttempt) {
-    // Environment protection reports the active workflow as waiting until the
-    // approval transition propagates. A failed attempt remains usable only
-    // because same-run policy separately requires its exact producer job to succeed.
+    // Environment protection can expose any nonterminal Actions transition
+    // while approval propagates. Exact producer-job success remains mandatory.
     const active = ACTIVE_SAME_RUN_STATUSES.has(run.status) && run.conclusion === null;
     const failed = run.status === "completed" && run.conclusion === "failure";
     if (!active && !failed) {

--- a/test/scripts/plugin-publication-artifact.test.ts
+++ b/test/scripts/plugin-publication-artifact.test.ts
@@ -749,22 +749,25 @@ describe("plugin publication artifact", () => {
     ).toThrow("producer job did not complete successfully");
   });
 
-  it("accepts an environment-waiting current producer attempt", () => {
-    const fixture = createFixture();
-    const workflowRun = JSON.parse(readFileSync(fixture.workflowRunPath, "utf8"));
-    workflowRun.status = "waiting";
-    workflowRun.conclusion = null;
-    writeFileSync(fixture.workflowRunPath, `${JSON.stringify(workflowRun)}\n`);
+  it.each(["waiting", "queued", "pending", "requested"])(
+    "accepts a null-conclusion %s current producer attempt",
+    (status) => {
+      const fixture = createFixture();
+      const workflowRun = JSON.parse(readFileSync(fixture.workflowRunPath, "utf8"));
+      workflowRun.status = status;
+      workflowRun.conclusion = null;
+      writeFileSync(fixture.workflowRunPath, `${JSON.stringify(workflowRun)}\n`);
 
-    expect(
-      verifyFixture(fixture, {
-        consumerRunAttempt: RUN_ATTEMPT,
-        producerJobName: PRODUCER_JOB_NAME,
-        runStatePolicy: "same-run-producer-success",
-        workflowJobsMetadataPath: fixture.workflowJobsPath,
-      }),
-    ).toMatchObject({ producerRunAttempt: RUN_ATTEMPT, producerRunId: RUN_ID });
-  });
+      expect(
+        verifyFixture(fixture, {
+          consumerRunAttempt: RUN_ATTEMPT,
+          producerJobName: PRODUCER_JOB_NAME,
+          runStatePolicy: "same-run-producer-success",
+          workflowJobsMetadataPath: fixture.workflowJobsPath,
+        }),
+      ).toMatchObject({ producerRunAttempt: RUN_ATTEMPT, producerRunId: RUN_ID });
+    },
+  );
 
   it("accepts a failed current attempt only when its exact producer job succeeded", () => {
     const fixture = createFixture();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the `2026.9.1-beta.1` plugin npm publication retry rejected immutable same-run artifacts while GitHub Actions briefly reported the protected-environment workflow as `queued`, `pending`, or `requested`.

Release evidence:
- Parent publish: https://github.com/openclaw/openclaw/actions/runs/33194947953
- Plugin npm child: https://github.com/openclaw/openclaw/actions/runs/33195308285
- Representative failure: https://github.com/openclaw/openclaw/actions/runs/33195308285/job/98932369448

## Why This Change Was Made

The verifier already accepts `in_progress`, environment `waiting`, and terminal `failure` for the exact current attempt. This extends the same null-conclusion active-state contract to GitHub's remaining nonterminal transition statuses. Exact run, attempt, SHA, ref, repository, workflow path, artifact identity, and successful producer-job checks remain mandatory.

## User Impact

Release retries can resume partially published plugin matrices through protected-environment state propagation without weakening immutable publication evidence. Candidate code, version, tag, and registry payloads are unchanged.

## Evidence

- Pre-fix: focused regression produced 3 expected failures for `queued`, `pending`, and `requested`.
- Post-fix: `node scripts/run-vitest.mjs test/scripts/plugin-publication-artifact.test.ts` passed 52/52.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts/lib/actions-artifact-archive.mjs` passed.
- Focused formatting and `git diff --check` passed.
- Autoreview: clean, no accepted/actionable findings, confidence 0.98.
- Root test typecheck could not run in the sparse GWT because unrelated Android/UI/QA source paths are excluded; exact-head CI remains required.
- Tooling production delta: +9/-4. Tests: +18/-15.

No changelog entry: release tooling only.
