### PR TITLE
refactor(channels): share progress draft lifecycle decisions

### DIFF
--- a/src/channels/progress-draft-compositor.ts
+++ b/src/channels/progress-draft-compositor.ts
@@ -286,6 +286,32 @@ export function createChannelProgressDraftCompositor(params: {
     clearTimeoutFn,
   });
 
+  const startAndRender = async (options?: { flush?: boolean }): Promise<boolean> => {
+    const alreadyStarted = gate.hasStarted;
+    if (!alreadyStarted) {
+      lastStartRendered = false;
+    }
+    await gate.startNow();
+    if (!gate.hasStarted) {
+      return false;
+    }
+    // Startup already rendered; preserve its acceptance without publishing twice.
+    return alreadyStarted ? await render(options) : lastStartRendered;
+  };
+
+  const renderAfterRetraction = async (): Promise<boolean> => {
+    if (!gate.hasStarted) {
+      return false;
+    }
+    const rendered = await render();
+    if (rendered || formatDraftText()) {
+      return rendered;
+    }
+    lastRenderedText = "";
+    await params.deleteCurrent?.();
+    return true;
+  };
+
   /**
    * Commentary line identity. An explicit item id owns its line. Without one,
    * providers stream cumulative snapshots ("Checking" → "Checking the
@@ -391,15 +417,7 @@ export function createChannelProgressDraftCompositor(params: {
       return shouldStoreLine ? await publish() : false;
     }
     if (options?.startImmediately || params.shouldStartNow?.(line)) {
-      const alreadyStarted = gate.hasStarted;
-      if (!alreadyStarted) {
-        lastStartRendered = false;
-      }
-      await gate.startNow();
-      if (!gate.hasStarted) {
-        return false;
-      }
-      return alreadyStarted ? await render() : lastStartRendered;
+      return await startAndRender();
     }
     const alreadyStarted = gate.hasStarted;
     const progressActive = await gate.noteWork();
@@ -491,15 +509,8 @@ export function createChannelProgressDraftCompositor(params: {
         return false;
       }
       if (options?.startImmediately) {
-        const alreadyStarted = gate.hasStarted;
-        if (!alreadyStarted) {
-          lastStartRendered = false;
-        }
-        await gate.startNow();
-        if (!gate.hasStarted) {
-          return false;
-        }
-        return alreadyStarted ? await render({ flush: true }) : lastStartRendered;
+        // Explicit activity flushes even after startup; other updates can batch.
+        return await startAndRender({ flush: true });
       }
       const alreadyStarted = gate.hasStarted;
       const progressActive = await gate.noteWork();
@@ -526,26 +537,9 @@ export function createChannelProgressDraftCompositor(params: {
       planSteps = steps && steps.length > 0 ? steps.map((entry) => ({ ...entry })) : undefined;
       planExplanation = options?.explanation?.replace(/\s+/g, " ").trim() ?? "";
       if (!planSteps && !planExplanation) {
-        if (!gate.hasStarted) {
-          return false;
-        }
-        const rendered = await render();
-        if (rendered || formatDraftText()) {
-          return rendered;
-        }
-        lastRenderedText = "";
-        await params.deleteCurrent?.();
-        return true;
+        return await renderAfterRetraction();
       }
-      const alreadyStarted = gate.hasStarted;
-      if (!alreadyStarted) {
-        lastStartRendered = false;
-      }
-      await gate.startNow();
-      if (!gate.hasStarted) {
-        return false;
-      }
-      return alreadyStarted ? await render() : lastStartRendered;
+      return await startAndRender();
     },
     async pushPreambleHeadline(text?: string, options?: { itemId?: string }) {
       if (!params.active || params.mode !== "progress" || progressSuppressed) {
@@ -577,16 +571,7 @@ export function createChannelProgressDraftCompositor(params: {
         preambleItemId = undefined;
         preambleAt = undefined;
         clearPreambleExpiryTimer();
-        if (!gate.hasStarted) {
-          return false;
-        }
-        const rendered = await render();
-        if (rendered || formatDraftText()) {
-          return rendered;
-        }
-        lastRenderedText = "";
-        await params.deleteCurrent?.();
-        return true;
+        return await renderAfterRetraction();
       }
       const isNewPreambleItem = Boolean(itemId && itemId !== preambleItemId);
       if (isNewPreambleItem) {
@@ -709,15 +694,7 @@ export function createChannelProgressDraftCompositor(params: {
         lastIdLessCommentaryId = lineId;
         lastIdLessCommentaryBare = bareNormalized;
       }
-      const alreadyStarted = gate.hasStarted;
-      if (!alreadyStarted) {
-        lastStartRendered = false;
-      }
-      await gate.startNow();
-      if (!gate.hasStarted) {
-        return false;
-      }
-      return alreadyStarted ? await render() : lastStartRendered;
+      return await startAndRender();
     },
   };
 }

--- a/src/channels/progress-draft-compositor.visibility.test.ts
+++ b/src/channels/progress-draft-compositor.visibility.test.ts
@@ -1,17 +1,27 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { createChannelProgressDraftCompositor } from "./progress-draft-compositor.js";
 
 const DEFAULT_PROGRESS_DRAFT_INITIAL_DELAY_MS = 1_500;
 
-function createProgress(update: () => Promise<boolean | void> | boolean | void) {
+function createProgress(
+  update: () => Promise<boolean | void> | boolean | void,
+  overrides?: Pick<
+    Parameters<typeof createChannelProgressDraftCompositor>[0],
+    "entry" | "deleteCurrent"
+  >,
+) {
   return createChannelProgressDraftCompositor({
-    entry: { streaming: { mode: "progress", progress: { label: "Working" } } },
+    entry: { streaming: { mode: "progress", progress: { label: "Working", commentary: true } } },
     mode: "progress",
     active: true,
     seed: "test",
     update,
+    ...overrides,
   });
 }
+
+type Progress = ReturnType<typeof createProgress>;
 
 describe("progress draft visibility", () => {
   afterEach(() => {
@@ -47,12 +57,88 @@ describe("progress draft visibility", () => {
     expect(progress.isVisible).toBe(true);
   });
 
-  it("does not dedupe a rejected update", async () => {
-    const update = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true);
-    const progress = createProgress(update);
+  describe.each<{
+    name: string;
+    push: (progress: Progress) => Promise<boolean>;
+    repeatFlush?: boolean;
+  }>([
+    {
+      name: "tool",
+      push: (progress) => progress.pushToolProgress("🛠️ Exec", { startImmediately: true }),
+    },
+    {
+      name: "activity",
+      push: (progress) => progress.noteActivity({ startImmediately: true }),
+      repeatFlush: true,
+    },
+    {
+      name: "plan",
+      push: (progress) => progress.pushPlanProgress([{ step: "Inspect", status: "in_progress" }]),
+    },
+    {
+      name: "commentary",
+      push: (progress) => progress.pushCommentaryProgress("Inspecting", { itemId: "commentary-1" }),
+    },
+  ])("$name progress", ({ push, repeatFlush }) => {
+    it("retries rejected updates with the caller's flush behavior", async () => {
+      const update = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+      const progress = createProgress(update);
 
-    expect(await progress.pushToolProgress("🛠️ Exec", { startImmediately: true })).toBe(false);
-    expect(await progress.pushToolProgress("🛠️ Exec", { startImmediately: true })).toBe(true);
-    expect(update).toHaveBeenCalledTimes(2);
+      expect(await push(progress)).toBe(false);
+      expect(progress.isVisible).toBe(false);
+      expect(await push(progress)).toBe(true);
+      expect(progress.isVisible).toBe(true);
+      expect(update.mock.calls.map(([, options]) => options.flush)).toEqual([true, repeatFlush]);
+    });
+
+    it("reports no progress when final delivery cancels pending startup", async () => {
+      const started = createDeferred();
+      const accepted = createDeferred<boolean>();
+      const progress = createProgress(() => {
+        started.resolve();
+        return accepted.promise;
+      });
+      const result = push(progress);
+      await started.promise;
+      progress.markFinalReplyStarted();
+      accepted.resolve(true);
+
+      expect(await result).toBe(false);
+      expect(progress.hasStarted).toBe(false);
+      expect(progress.isVisible).toBe(false);
+    });
+  });
+
+  it.each<{
+    name: string;
+    stage: (progress: Progress) => Promise<boolean>;
+    clear: (progress: Progress) => Promise<boolean>;
+  }>([
+    {
+      name: "plan",
+      stage: (progress) => progress.pushPlanProgress([{ step: "Inspect", status: "in_progress" }]),
+      clear: (progress) => progress.pushPlanProgress(),
+    },
+    {
+      name: "preamble",
+      stage: (progress) => progress.pushPreambleHeadline("Inspecting", { itemId: "preamble-1" }),
+      clear: (progress) => progress.pushPreambleHeadline("", { itemId: "preamble-1" }),
+    },
+  ])("deletes a draft emptied by $name retraction only after startup", async ({ stage, clear }) => {
+    const deleteCurrent = vi.fn();
+    const progress = createProgress(vi.fn(), {
+      entry: { streaming: { mode: "progress", progress: { label: false } } },
+      deleteCurrent,
+    });
+
+    expect(await clear(progress)).toBe(false);
+    expect(deleteCurrent).not.toHaveBeenCalled();
+    await stage(progress);
+    await progress.start();
+    expect(progress.isVisible).toBe(true);
+
+    expect(await clear(progress)).toBe(true);
+    expect(deleteCurrent).toHaveBeenCalledTimes(1);
+    expect(progress.isVisible).toBe(false);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Progress drafts repeat the same startup acceptance and retraction decisions across several update paths. This maintainer-requested cleanup reduces the places that must stay synchronized when maintaining progress delivery.

## Why This Change Was Made

Keep these decisions inside the existing transport-neutral compositor: one immediate-start flow for tool, activity, plan, and commentary updates, and one retraction flow for plans and preambles. Preserve the distinct delayed-work and commentary-removal paths, callback acceptance, cancellation after awaited startup, and activity's explicit repeat flush.

AI-assisted implementation and validation using Codex.

Production LOC: +33/-56 (net -23). Tests: +94/-8 (net +86), extending the existing visibility suite rather than adding a new harness or production test seam.

## User Impact

No intended user-visible behavior change. No public API, message content, transport policy, configuration, or storage changes.

## Evidence

- Original production: 111 tests passed across six owner/controller files. The expanded visibility suite then passed all 14 cases against unchanged production (nine additional cases).
- Refactored production: the same six files passed 120 tests, covering compositor/gate lifecycle plus Telegram, Matrix, and Discord controllers. The visibility table exercises all four immediate-start callers, rejected-then-accepted updates, caller-specific flush behavior, cancellation while startup awaits, and final-empty plan/preamble retraction.
- Core production and canonical messaging-test typechecks, scoped typed lint, formatting, and whitespace checks passed.
- Full two-file Codex autoreview and an independent exact-commit source review reported no actionable findings on `6440ba62b7494174202d85a59984bf1521fcec4f`.

This is deterministic owner/controller test evidence, not a live authenticated channel run.
