### PR TITLE
fix(agents): show token limits for rejected model requests

### DIFF
--- a/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
@@ -211,7 +211,7 @@ describe("formatAssistantErrorText", () => {
 
     const userFacing = formatUserFacingAssistantErrorText(msg);
     expect(userFacing).toBe(
-      "LLM request rejected: max_tokens is 384000, above the provider maximum of 65536. Lower max_tokens and try again.",
+      "LLM request rejected: configured maxTokens is 384000, above the provider maximum of 65536. Lower maxTokens and try again.",
     );
     expect(userFacing).not.toContain("deepseek-v4-flash:0731");
   });
@@ -233,7 +233,7 @@ describe("formatAssistantErrorText", () => {
 
     const userFacing = formatUserFacingAssistantErrorText(msg);
     expect(userFacing).toBe(
-      "LLM request rejected: max_tokens is 384000, above the provider maximum of 65536. Lower max_tokens and try again.",
+      "LLM request rejected: configured maxTokens is 384000, above the provider maximum of 65536. Lower maxTokens and try again.",
     );
     expect(userFacing).not.toContain("deepseek-v4-flash:0731");
   });
@@ -244,10 +244,10 @@ describe("formatAssistantErrorText", () => {
     );
 
     expect(formatAssistantErrorText(msg)).toBe(
-      "LLM request rejected: max_tokens is 384000, above the provider maximum of 65536. Lower max_tokens and try again.",
+      "LLM request rejected: configured maxTokens is 384000, above the provider maximum of 65536. Lower maxTokens and try again.",
     );
     expect(formatUserFacingAssistantErrorText(msg)).toBe(
-      "LLM request rejected: max_tokens is 384000, above the provider maximum of 65536. Lower max_tokens and try again.",
+      "LLM request rejected: configured maxTokens is 384000, above the provider maximum of 65536. Lower maxTokens and try again.",
     );
   });
   it("sanitizes Codex error-prefixed JSON payloads", () => {

--- a/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
@@ -197,6 +197,59 @@ describe("formatAssistantErrorText", () => {
       "LLM request failed: provider rejected the request schema or tool payload.",
     );
   });
+  it("surfaces allowlisted token limits from structured provider messages", () => {
+    const msg = makeAssistantError(
+      JSON.stringify({
+        type: "error",
+        error: {
+          type: "invalid_request_error",
+          message:
+            "max_tokens (384000) exceeds model's maximum output tokens (65536) for model deepseek-v4-flash:0731",
+        },
+      }),
+    );
+
+    const userFacing = formatUserFacingAssistantErrorText(msg);
+    expect(userFacing).toBe(
+      "LLM request rejected: max_tokens is 384000, above the provider maximum of 65536. Lower max_tokens and try again.",
+    );
+    expect(userFacing).not.toContain("deepseek-v4-flash:0731");
+  });
+
+  it("surfaces token limits from structured error bodies", () => {
+    const msg = makeAssistantMessageFixture({
+      errorMessage: "400 Param Incorrect",
+      errorCode: "400",
+      errorBody: JSON.stringify({
+        type: "error",
+        error: {
+          type: "invalid_request_error",
+          message:
+            "max_tokens (384000) exceeds model's maximum output tokens (65536) for model deepseek-v4-flash:0731",
+        },
+      }),
+      content: [],
+    });
+
+    const userFacing = formatUserFacingAssistantErrorText(msg);
+    expect(userFacing).toBe(
+      "LLM request rejected: max_tokens is 384000, above the provider maximum of 65536. Lower max_tokens and try again.",
+    );
+    expect(userFacing).not.toContain("deepseek-v4-flash:0731");
+  });
+
+  it("surfaces token limits from provider-wrapped HTTP errors", () => {
+    const msg = makeAssistantError(
+      "OpenAI API error (400): max_tokens (384000) exceeds model's maximum output tokens (65536)",
+    );
+
+    expect(formatAssistantErrorText(msg)).toBe(
+      "LLM request rejected: max_tokens is 384000, above the provider maximum of 65536. Lower max_tokens and try again.",
+    );
+    expect(formatUserFacingAssistantErrorText(msg)).toBe(
+      "LLM request rejected: max_tokens is 384000, above the provider maximum of 65536. Lower max_tokens and try again.",
+    );
+  });
   it("sanitizes Codex error-prefixed JSON payloads", () => {
     const msg = makeAssistantError(
       'Codex error: {"type":"error","error":{"message":"Something exploded","type":"server_error"},"sequence_number":2}',

--- a/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
@@ -238,11 +238,11 @@ describe("formatAssistantErrorText", () => {
     expect(userFacing).not.toContain("deepseek-v4-flash:0731");
   });
 
-  it("surfaces token limits from provider-wrapped HTTP errors", () => {
-    const msg = makeAssistantError(
-      "OpenAI API error (400): max_tokens (384000) exceeds model's maximum output tokens (65536)",
-    );
-
+  it.each([
+    "OpenAI API error (400): max_tokens (384000) exceeds model's maximum output tokens (65536)",
+    "Error: OpenAI API error (400): max_tokens (384000) exceeds model's maximum output tokens (65536)",
+  ])("surfaces token limits from provider-wrapped HTTP error %s", (raw) => {
+    const msg = makeAssistantError(raw);
     expect(formatAssistantErrorText(msg)).toBe(
       "LLM request rejected: configured maxTokens is 384000, above the provider maximum of 65536. Lower maxTokens and try again.",
     );

--- a/src/agents/embedded-agent-helpers/error-text.ts
+++ b/src/agents/embedded-agent-helpers/error-text.ts
@@ -4,6 +4,7 @@ import type { AssistantMessage } from "../../llm/types.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
   extractLeadingHttpStatus,
+  extractProviderWrappedHttpStatus,
   formatRawAssistantErrorForUi,
   isGenericProviderInternalError,
   parseApiErrorInfo,
@@ -27,6 +28,7 @@ import {
   isLikelyHttpErrorText,
   isRawApiErrorPayload,
   isStreamingJsonParseError,
+  renderFormatErrorCopy,
   renderRateLimitOrOverloadedCopy,
 } from "../failover/user-copy.js";
 import { formatSandboxToolPolicyBlockedMessage } from "../sandbox/runtime-status.js";
@@ -36,8 +38,6 @@ const log = createSubsystemLogger("errors");
 const sandboxToolPolicyAuditMessages = new WeakSet<AssistantMessage>();
 export const GENERIC_ASSISTANT_ERROR_TEXT = "LLM request failed.";
 export const SYNTHESIZED_TIMEOUT_ERROR_TEXT = "LLM request timed out.";
-const PROVIDER_SCHEMA_REJECTION_USER_TEXT =
-  "LLM request failed: provider rejected the request schema or tool payload.";
 const MODEL_NOT_FOUND_USER_TEXT =
   "The selected model was not found by the provider. Check the model id or choose a different model.";
 const TOOL_CALL_INPUT_MISSING_RE =
@@ -75,6 +75,12 @@ export function formatAssistantErrorText(
     ...buildAssistantFailoverSignal(msg, { provider: providerOwner }),
     message: raw,
   });
+  const wrappedFormatCopy = extractProviderWrappedHttpStatus(raw)
+    ? renderFormatErrorCopy(raw)
+    : undefined;
+  if (wrappedFormatCopy?.startsWith("LLM request rejected:")) {
+    return wrappedFormatCopy;
+  }
   const unknownTool =
     raw.match(/unknown tool[:\s]+["']?([a-z0-9_-]+)["']?/i) ??
     raw.match(/tool\s+["']?([a-z0-9_-]+)["']?\s+(?:not found|is not available)/i);
@@ -250,7 +256,7 @@ export function formatAssistantErrorText(
   }
 
   if (providerRuntimeFailureKind === "schema") {
-    return PROVIDER_SCHEMA_REJECTION_USER_TEXT;
+    return renderFormatErrorCopy(raw);
   }
 
   if (isRawApiErrorPayload(raw) || isLikelyHttpErrorText(raw)) {
@@ -298,14 +304,31 @@ export function formatUserFacingAssistantErrorText(
   const friendlyError = formatAssistantErrorText(msg, opts);
   const rawError = msg.errorMessage?.trim();
   const rawPassthrough = isRawAssistantErrorPassthrough({ friendlyError, rawError });
-  const parsedErrorType = parseApiErrorInfo(rawError ?? "")?.type?.toLowerCase() ?? "";
+  const parsedApiError = parseApiErrorInfo(rawError ?? "");
+  const parsedErrorType = parsedApiError?.type?.toLowerCase() ?? "";
+  const parsedErrorBody = parseApiErrorInfo(
+    typeof msg.errorBody === "string" ? msg.errorBody.trim() : "",
+  );
+  const parsedErrorBodyType = parsedErrorBody?.type?.toLowerCase() ?? "";
+  const structuredSchemaDetail = parsedErrorType.includes("invalid_request")
+    ? parsedApiError?.message
+    : parsedErrorBodyType.includes("invalid_request")
+      ? parsedErrorBody?.message
+      : undefined;
   const rawProviderSchemaError =
     friendlyError?.startsWith("LLM request rejected:") ||
-    parsedErrorType.includes("invalid_request");
-  const safeFriendlyError = rawPassthrough
-    ? rawProviderSchemaError
-      ? PROVIDER_SCHEMA_REJECTION_USER_TEXT
-      : undefined
-    : friendlyError;
+    parsedErrorType.includes("invalid_request") ||
+    parsedErrorBodyType.includes("invalid_request");
+  const schemaFriendlyError =
+    friendlyError === "LLM request failed: provider rejected the request schema or tool payload." ||
+    friendlyError?.startsWith("LLM request rejected:");
+  const safeFriendlyError =
+    structuredSchemaDetail && schemaFriendlyError
+      ? renderFormatErrorCopy(structuredSchemaDetail)
+      : rawPassthrough
+        ? rawProviderSchemaError
+          ? renderFormatErrorCopy(parsedApiError?.message ?? "")
+          : undefined
+        : friendlyError;
   return (safeFriendlyError || GENERIC_ASSISTANT_ERROR_TEXT).trim();
 }

--- a/src/agents/embedded-agent-helpers/error-text.ts
+++ b/src/agents/embedded-agent-helpers/error-text.ts
@@ -3,8 +3,8 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { AssistantMessage } from "../../llm/types.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
+  extractErrorHttpStatus,
   extractLeadingHttpStatus,
-  extractProviderWrappedHttpStatus,
   formatRawAssistantErrorForUi,
   isGenericProviderInternalError,
   parseApiErrorInfo,
@@ -28,6 +28,7 @@ import {
   isLikelyHttpErrorText,
   isRawApiErrorPayload,
   isStreamingJsonParseError,
+  PROVIDER_SCHEMA_REJECTION_USER_TEXT,
   renderFormatErrorCopy,
   renderRateLimitOrOverloadedCopy,
 } from "../failover/user-copy.js";
@@ -70,17 +71,19 @@ export function formatAssistantErrorText(
   if (!raw) {
     return "LLM request failed with an unknown error.";
   }
+  const formatCopy = renderFormatErrorCopy(raw);
+  const formatStatus = extractErrorHttpStatus(raw)?.code;
+  if (
+    (formatStatus === 400 || formatStatus === 422) &&
+    formatCopy !== PROVIDER_SCHEMA_REJECTION_USER_TEXT
+  ) {
+    return formatCopy;
+  }
   const providerOwner = opts?.providerOwner?.id ?? opts?.provider;
   const providerRuntimeFailureKind = classifyProviderRuntimeFailureKind({
     ...buildAssistantFailoverSignal(msg, { provider: providerOwner }),
     message: raw,
   });
-  const wrappedFormatCopy = extractProviderWrappedHttpStatus(raw)
-    ? renderFormatErrorCopy(raw)
-    : undefined;
-  if (wrappedFormatCopy?.startsWith("LLM request rejected:")) {
-    return wrappedFormatCopy;
-  }
   const unknownTool =
     raw.match(/unknown tool[:\s]+["']?([a-z0-9_-]+)["']?/i) ??
     raw.match(/tool\s+["']?([a-z0-9_-]+)["']?\s+(?:not found|is not available)/i);
@@ -256,7 +259,7 @@ export function formatAssistantErrorText(
   }
 
   if (providerRuntimeFailureKind === "schema") {
-    return renderFormatErrorCopy(raw);
+    return formatCopy;
   }
 
   if (isRawApiErrorPayload(raw) || isLikelyHttpErrorText(raw)) {
@@ -304,30 +307,19 @@ export function formatUserFacingAssistantErrorText(
   const friendlyError = formatAssistantErrorText(msg, opts);
   const rawError = msg.errorMessage?.trim();
   const rawPassthrough = isRawAssistantErrorPassthrough({ friendlyError, rawError });
-  const parsedApiError = parseApiErrorInfo(rawError ?? "");
-  const parsedErrorType = parsedApiError?.type?.toLowerCase() ?? "";
-  const parsedErrorBody = parseApiErrorInfo(
-    typeof msg.errorBody === "string" ? msg.errorBody.trim() : "",
-  );
-  const parsedErrorBodyType = parsedErrorBody?.type?.toLowerCase() ?? "";
-  const structuredSchemaDetail = parsedErrorType.includes("invalid_request")
-    ? parsedApiError?.message
-    : parsedErrorBodyType.includes("invalid_request")
-      ? parsedErrorBody?.message
-      : undefined;
-  const rawProviderSchemaError =
-    friendlyError?.startsWith("LLM request rejected:") ||
-    parsedErrorType.includes("invalid_request") ||
-    parsedErrorBodyType.includes("invalid_request");
+  const structuredSchemaDetail = [
+    parseApiErrorInfo(rawError ?? ""),
+    parseApiErrorInfo(typeof msg.errorBody === "string" ? msg.errorBody.trim() : ""),
+  ].find((error) => error?.type?.toLowerCase().includes("invalid_request"))?.message;
   const schemaFriendlyError =
-    friendlyError === "LLM request failed: provider rejected the request schema or tool payload." ||
+    friendlyError === PROVIDER_SCHEMA_REJECTION_USER_TEXT ||
     friendlyError?.startsWith("LLM request rejected:");
   const safeFriendlyError =
     structuredSchemaDetail && schemaFriendlyError
       ? renderFormatErrorCopy(structuredSchemaDetail)
       : rawPassthrough
-        ? rawProviderSchemaError
-          ? renderFormatErrorCopy(parsedApiError?.message ?? "")
+        ? schemaFriendlyError
+          ? PROVIDER_SCHEMA_REJECTION_USER_TEXT
           : undefined
         : friendlyError;
   return (safeFriendlyError || GENERIC_ASSISTANT_ERROR_TEXT).trim();

--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -287,6 +287,58 @@ describe("buildEmbeddedRunPayloads", () => {
     expectNoPayloadTextContaining(payloads, "LLM request rejected");
   });
 
+  it("surfaces actionable numeric provider limits without replaying the raw error", () => {
+    const rawError =
+      "400 max_tokens (384000) exceeds model's maximum output tokens (65536) for model deepseek-v4-flash:0731";
+    const payloads = buildPayloads({
+      lastAssistant: makeAssistant({
+        stopReason: "error",
+        errorMessage: rawError,
+        content: [{ type: "text", text: rawError }],
+      }),
+    });
+
+    expectSinglePayloadSummary(payloads, {
+      text: "LLM request rejected: max_tokens is 384000, above the provider maximum of 65536. Lower max_tokens and try again.",
+      isError: true,
+    });
+    expectNoPayloadTextContaining(payloads, "deepseek-v4-flash:0731");
+  });
+
+  it("keeps numeric limits generic for non-token parameters", () => {
+    const rawError = "400 account_id (1234567890123456) exceeds maximum length (8)";
+    const payloads = buildPayloads({
+      lastAssistant: makeAssistant({
+        stopReason: "error",
+        errorMessage: rawError,
+        content: [{ type: "text", text: rawError }],
+      }),
+    });
+
+    expectSinglePayloadSummary(payloads, {
+      text: "LLM request failed: provider rejected the request schema or tool payload.",
+      isError: true,
+    });
+    expectNoPayloadTextContaining(payloads, "1234567890123456");
+  });
+
+  it("does not infer a token maximum from unrelated trailing digits", () => {
+    const rawError = "400 max_tokens 384000 exceeds maximum for model gpt-5";
+    const payloads = buildPayloads({
+      lastAssistant: makeAssistant({
+        stopReason: "error",
+        errorMessage: rawError,
+        content: [{ type: "text", text: rawError }],
+      }),
+    });
+
+    expectSinglePayloadSummary(payloads, {
+      text: "LLM request failed: provider rejected the request schema or tool payload.",
+      isError: true,
+    });
+    expectNoPayloadTextContaining(payloads, "provider maximum of 5");
+  });
+
   it("surfaces /new guidance for terminal thinking-signature replay failures", () => {
     const rawError =
       '{"type":"error","error":{"type":"invalid_request_error","message":"messages.1.content.1: Invalid `signature` in `thinking` block"}}';

--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -299,7 +299,7 @@ describe("buildEmbeddedRunPayloads", () => {
     });
 
     expectSinglePayloadSummary(payloads, {
-      text: "LLM request rejected: max_tokens is 384000, above the provider maximum of 65536. Lower max_tokens and try again.",
+      text: "LLM request rejected: configured maxTokens is 384000, above the provider maximum of 65536. Lower maxTokens and try again.",
       isError: true,
     });
     expectNoPayloadTextContaining(payloads, "deepseek-v4-flash:0731");

--- a/src/agents/failover/user-copy.test.ts
+++ b/src/agents/failover/user-copy.test.ts
@@ -10,6 +10,8 @@ import {
 } from "./user-copy.js";
 
 describe("failover user copy", () => {
+  const tokenLimitCopy =
+    "LLM request rejected: configured maxTokens is 384000, above the provider maximum of 65536. Lower maxTokens and try again.";
   it("renders transient copy from the classified reason", () => {
     const raw = "429 Too Many Requests: model overloaded";
     expect(renderRateLimitOrOverloadedCopy({ reason: "rate_limit", raw })).toBe(
@@ -29,29 +31,20 @@ describe("failover user copy", () => {
     ).toBe("⚠️ rate limit: service overloaded, try again in 30 seconds");
   });
 
-  it("surfaces token limits through common Error HTTP wrappers", () => {
-    const expected =
-      "LLM request rejected: configured maxTokens is 384000, above the provider maximum of 65536. Lower maxTokens and try again.";
-    expect(
-      renderFormatErrorCopy(
-        "Error: 400 max_tokens (384000) exceeds model's maximum output tokens (65536)",
-      ),
-    ).toBe(expected);
-    expect(
-      renderFormatErrorCopy(
-        "OpenAI API error (400): max_tokens (384000) exceeds model's maximum output tokens (65536)",
-      ),
-    ).toBe(expected);
-    expect(
-      renderFormatErrorCopy(
-        "Azure OpenAI API error (400): max_tokens (384000) exceeds model's maximum output tokens (65536)",
-      ),
-    ).toBe(expected);
-    expect(
-      renderFormatErrorCopy(
-        "OpenAI API error (400): 400 max_tokens (384000) exceeds model's maximum output tokens (65536)",
-      ),
-    ).toBe(expected);
+  it.each([
+    "Error: 400 max_tokens (384000) exceeds model's maximum output tokens (65536)",
+    "OpenAI API error (400): max_output_tokens (384000) exceeds model's maximum output tokens (65536)",
+    "Azure OpenAI API error (400): max_completion_tokens (384000) exceeds model's maximum output tokens (65536)",
+    "OpenAI API error (400): 400 max_new_tokens (384000) exceeds model's maximum output tokens (65536)",
+  ])("surfaces token limits from %s", (raw) => {
+    expect(renderFormatErrorCopy(raw)).toBe(tokenLimitCopy);
+  });
+
+  it("keeps overlong provider-controlled limit text generic", () => {
+    const raw = `400 max_tokens (384000) exceeds ${"x".repeat(301)} maximum output tokens (65536)`;
+    expect(renderFormatErrorCopy(raw)).toBe(
+      "LLM request failed: provider rejected the request schema or tool payload.",
+    );
   });
 
   it("renders structured cooldown durations and exhausted model sets", () => {

--- a/src/agents/failover/user-copy.test.ts
+++ b/src/agents/failover/user-copy.test.ts
@@ -31,7 +31,7 @@ describe("failover user copy", () => {
 
   it("surfaces token limits through common Error HTTP wrappers", () => {
     const expected =
-      "LLM request rejected: max_tokens is 384000, above the provider maximum of 65536. Lower max_tokens and try again.";
+      "LLM request rejected: configured maxTokens is 384000, above the provider maximum of 65536. Lower maxTokens and try again.";
     expect(
       renderFormatErrorCopy(
         "Error: 400 max_tokens (384000) exceeds model's maximum output tokens (65536)",

--- a/src/agents/failover/user-copy.test.ts
+++ b/src/agents/failover/user-copy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   BILLING_ERROR_USER_MESSAGE,
+  renderFormatErrorCopy,
   renderBillingReplyCopy,
   renderCliTimeoutReplyCopy,
   renderMissingApiKeyReplyCopy,
@@ -26,6 +27,31 @@ describe("failover user copy", () => {
         raw: "429 rate limit: service overloaded, try again in 30 seconds",
       }),
     ).toBe("⚠️ rate limit: service overloaded, try again in 30 seconds");
+  });
+
+  it("surfaces token limits through common Error HTTP wrappers", () => {
+    const expected =
+      "LLM request rejected: max_tokens is 384000, above the provider maximum of 65536. Lower max_tokens and try again.";
+    expect(
+      renderFormatErrorCopy(
+        "Error: 400 max_tokens (384000) exceeds model's maximum output tokens (65536)",
+      ),
+    ).toBe(expected);
+    expect(
+      renderFormatErrorCopy(
+        "OpenAI API error (400): max_tokens (384000) exceeds model's maximum output tokens (65536)",
+      ),
+    ).toBe(expected);
+    expect(
+      renderFormatErrorCopy(
+        "Azure OpenAI API error (400): max_tokens (384000) exceeds model's maximum output tokens (65536)",
+      ),
+    ).toBe(expected);
+    expect(
+      renderFormatErrorCopy(
+        "OpenAI API error (400): 400 max_tokens (384000) exceeds model's maximum output tokens (65536)",
+      ),
+    ).toBe(expected);
   });
 
   it("renders structured cooldown durations and exhausted model sets", () => {

--- a/src/agents/failover/user-copy.ts
+++ b/src/agents/failover/user-copy.ts
@@ -3,6 +3,7 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   extractLeadingHttpStatus,
+  extractProviderWrappedHttpStatus,
   formatRawAssistantErrorForUi,
   isCloudflareOrHtmlErrorPage,
   isGenericProviderInternalError,
@@ -52,6 +53,10 @@ const CONTEXT_OVERFLOW_ERROR_HEAD_RE =
   /^(?:context overflow:|request_too_large\b|request size exceeds\b|request exceeds the maximum size\b|context length exceeded\b|maximum context length\b|prompt is too long\b|exceeds model context window\b)/i;
 const NON_ERROR_PROVIDER_PAYLOAD_MAX_LENGTH = 16_384;
 const NON_ERROR_PROVIDER_PAYLOAD_PREFIX_RE = /^codex\s*error(?:\s+\d{3})?[:\s-]+/i;
+const PROVIDER_SCHEMA_REJECTION_USER_TEXT =
+  "LLM request failed: provider rejected the request schema or tool payload.";
+const PROVIDER_OUTPUT_TOKEN_LIMIT_RE =
+  /^['"]?(max_(?:tokens|output_tokens|completion_tokens|new_tokens))['"]?\s*(?:[:=]\s*)?\(?(\d[\d,]*)\)?\s+exceeds?\b.{0,120}?\b(?:maximum|max|limit)\b(?:\s+(?:output\s+)?tokens?)?(?:\s+(?:is|of)|\s*[:=])?\s*\(?(\d[\d,]*)\)?(?:\D|$)/i;
 
 /** Format billing copy with optional provider/model and credential context. */
 export function formatBillingErrorMessage(
@@ -75,6 +80,27 @@ export function formatBillingErrorMessage(
 }
 
 export const BILLING_ERROR_USER_MESSAGE = formatBillingErrorMessage();
+
+/** Surface only bounded numeric limit facts, never arbitrary provider-controlled error text. */
+export function renderFormatErrorCopy(raw: string): string {
+  const trimmed = raw.trim();
+  const providerWrappedStatus = extractProviderWrappedHttpStatus(trimmed);
+  const normalized = providerWrappedStatus ? trimmed : trimmed.replace(ERROR_PREFIX_RE, "").trim();
+  const providerWrappedRest = providerWrappedStatus?.rest;
+  const candidate =
+    extractLeadingHttpStatus(normalized)?.rest ??
+    (providerWrappedRest ? extractLeadingHttpStatus(providerWrappedRest)?.rest : undefined) ??
+    providerWrappedRest ??
+    extractProviderWrappedHttpStatus(normalized)?.rest ??
+    normalized;
+  const match = candidate.length <= 300 ? candidate.match(PROVIDER_OUTPUT_TOKEN_LIMIT_RE) : null;
+  const [, parameter, value, maximum] = match ?? [];
+  if (!parameter || !value || !maximum) {
+    return PROVIDER_SCHEMA_REJECTION_USER_TEXT;
+  }
+  const normalizedParameter = parameter.toLowerCase();
+  return `LLM request rejected: ${normalizedParameter} is ${value}, above the provider maximum of ${maximum}. Lower ${normalizedParameter} and try again.`;
+}
 
 function extractProviderRateLimitMessage(raw: string): string | undefined {
   const withoutPrefix = raw.replace(ERROR_PREFIX_RE, "").trim();
@@ -109,7 +135,7 @@ function renderRateLimitBaseCopy(context: FailoverUserCopyContext): string {
 const FAILOVER_REASON_BASE_COPY = {
   auth: () => AUTH_INVALID_TOKEN_USER_TEXT,
   auth_permanent: () => AUTH_INVALID_TOKEN_USER_TEXT,
-  format: () => "LLM request failed: provider rejected the request schema or tool payload.",
+  format: (context) => renderFormatErrorCopy(context.raw ?? ""),
   rate_limit: renderRateLimitBaseCopy,
   overloaded: (context) =>
     MODEL_CAPACITY_ERROR_RE.test(context.raw ?? "")

--- a/src/agents/failover/user-copy.ts
+++ b/src/agents/failover/user-copy.ts
@@ -98,8 +98,7 @@ export function renderFormatErrorCopy(raw: string): string {
   if (!parameter || !value || !maximum) {
     return PROVIDER_SCHEMA_REJECTION_USER_TEXT;
   }
-  const normalizedParameter = parameter.toLowerCase();
-  return `LLM request rejected: ${normalizedParameter} is ${value}, above the provider maximum of ${maximum}. Lower ${normalizedParameter} and try again.`;
+  return `LLM request rejected: configured maxTokens is ${value}, above the provider maximum of ${maximum}. Lower maxTokens and try again.`;
 }
 
 function extractProviderRateLimitMessage(raw: string): string | undefined {

--- a/src/agents/failover/user-copy.ts
+++ b/src/agents/failover/user-copy.ts
@@ -2,8 +2,8 @@ import { stableStringify } from "@openclaw/normalization-core";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
+  extractErrorHttpStatus,
   extractLeadingHttpStatus,
-  extractProviderWrappedHttpStatus,
   formatRawAssistantErrorForUi,
   isCloudflareOrHtmlErrorPage,
   isGenericProviderInternalError,
@@ -53,10 +53,10 @@ const CONTEXT_OVERFLOW_ERROR_HEAD_RE =
   /^(?:context overflow:|request_too_large\b|request size exceeds\b|request exceeds the maximum size\b|context length exceeded\b|maximum context length\b|prompt is too long\b|exceeds model context window\b)/i;
 const NON_ERROR_PROVIDER_PAYLOAD_MAX_LENGTH = 16_384;
 const NON_ERROR_PROVIDER_PAYLOAD_PREFIX_RE = /^codex\s*error(?:\s+\d{3})?[:\s-]+/i;
-const PROVIDER_SCHEMA_REJECTION_USER_TEXT =
+export const PROVIDER_SCHEMA_REJECTION_USER_TEXT =
   "LLM request failed: provider rejected the request schema or tool payload.";
 const PROVIDER_OUTPUT_TOKEN_LIMIT_RE =
-  /^['"]?(max_(?:tokens|output_tokens|completion_tokens|new_tokens))['"]?\s*(?:[:=]\s*)?\(?(\d[\d,]*)\)?\s+exceeds?\b.{0,120}?\b(?:maximum|max|limit)\b(?:\s+(?:output\s+)?tokens?)?(?:\s+(?:is|of)|\s*[:=])?\s*\(?(\d[\d,]*)\)?(?:\D|$)/i;
+  /^['"]?max_(?:tokens|output_tokens|completion_tokens|new_tokens)['"]?\s*(?:[:=]\s*)?\(?(\d[\d,]*)\)?\s+exceeds?\b.{0,120}?\b(?:maximum|max|limit)\b(?:\s+(?:output\s+)?tokens?)?(?:\s+(?:is|of)|\s*[:=])?\s*\(?(\d[\d,]*)\)?(?:\D|$)/i;
 
 /** Format billing copy with optional provider/model and credential context. */
 export function formatBillingErrorMessage(
@@ -84,18 +84,12 @@ export const BILLING_ERROR_USER_MESSAGE = formatBillingErrorMessage();
 /** Surface only bounded numeric limit facts, never arbitrary provider-controlled error text. */
 export function renderFormatErrorCopy(raw: string): string {
   const trimmed = raw.trim();
-  const providerWrappedStatus = extractProviderWrappedHttpStatus(trimmed);
-  const normalized = providerWrappedStatus ? trimmed : trimmed.replace(ERROR_PREFIX_RE, "").trim();
-  const providerWrappedRest = providerWrappedStatus?.rest;
-  const candidate =
-    extractLeadingHttpStatus(normalized)?.rest ??
-    (providerWrappedRest ? extractLeadingHttpStatus(providerWrappedRest)?.rest : undefined) ??
-    providerWrappedRest ??
-    extractProviderWrappedHttpStatus(normalized)?.rest ??
-    normalized;
+  const normalized =
+    extractErrorHttpStatus(trimmed)?.rest ?? trimmed.replace(ERROR_PREFIX_RE, "").trim();
+  const candidate = extractErrorHttpStatus(normalized)?.rest ?? normalized;
   const match = candidate.length <= 300 ? candidate.match(PROVIDER_OUTPUT_TOKEN_LIMIT_RE) : null;
-  const [, parameter, value, maximum] = match ?? [];
-  if (!parameter || !value || !maximum) {
+  const [, value, maximum] = match ?? [];
+  if (!value || !maximum) {
     return PROVIDER_SCHEMA_REJECTION_USER_TEXT;
   }
   return `LLM request rejected: configured maxTokens is ${value}, above the provider maximum of ${maximum}. Lower maxTokens and try again.`;


### PR DESCRIPTION
Closes #131797

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

An OpenAI-compatible provider can reject a request when the configured output-token count exceeds the model's server-side limit. OpenClaw replaced that useful error with generic schema/tool-payload text, so operators could not see which value to change.

## Why This Change Was Made

The transport already retains a bounded, redacted provider error for classification. The shared agent safe-copy layer discarded both numeric limits when it classified the HTTP 400 response as a format error.

The shared format-error renderer now recognizes only four output-token wire fields and two bounded numeric values. It converts those facts to guidance for OpenClaw's documented `maxTokens` field. Every other format error keeps the existing generic text, so provider model ids, request ids, bodies, and arbitrary text remain private.

The renderer also normalizes direct HTTP errors, provider SDK wrappers, and nested `Error:` wrappers through one path.

## User Impact

Operators now see `configured maxTokens is 384000, above the provider maximum of 65536` and can lower the setting immediately. This change does not alter model catalogs, token defaults, request clamping, provider routing, or fallback policy.

## Evidence

- Live red/green proof used the same real isolated Gateway, production agent/model rejection path, and controlled OpenAI-compatible endpoint. The endpoint received `POST /v1/chat/completions` with `max_tokens: 384000` and returned HTTP 400 with a provider maximum of `65536`.
- Current `main` at `09be104e941c1b791fa4ceac71f0e801fd9370ac` showed only `LLM request failed: provider rejected the request schema or tool payload.`
- Exact PR head `7b289133198f661c5e16df8f57e5c1c4f98feb7d` showed both limits and told the operator to lower `maxTokens`.
- The proof used model and request sentinels. Neither sentinel appeared in visible output.
- Focused owner and sibling tests passed: 156 tests across the format-copy, assistant formatter, terminal payload, and context-overflow suites.
- Targeted Oxfmt, Oxlint, conflict-marker, max-lines, assertion-safety, coercion-helper, import-cycle, deprecated-API, and `git diff --check` checks passed.
- Judged line delta: production +34; tests +124. The production growth adds the bounded safe-copy capability and replaces duplicated wrapper handling with one normalizer.
