### PR TITLE
chore(tui): reproduce delayed peer prompt ordering

### DIFF
--- a/src/tui/components/chat-log-run-state.test.ts
+++ b/src/tui/components/chat-log-run-state.test.ts
@@ -44,26 +44,51 @@ describe("ChatLog run state", () => {
     expect(rendered.indexOf("Streaming second reply.")).toBeLessThan(rendered.indexOf("Read File"));
   });
 
-  it("keeps a replacement final reply anchored when its previous reply is pruned", () => {
-    const chatLog = new ChatLog(20);
+  it.each([
+    { capacity: 20, previousReply: "retained" },
+    { capacity: 40, previousReply: "retained" },
+    { capacity: 20, previousReply: "pruned" },
+    { capacity: 40, previousReply: "pruned" },
+  ])(
+    "anchors every $previousReply final reply at capacity $capacity",
+    ({ capacity, previousReply }) => {
+      const chatLog = new ChatLog(capacity);
 
-    chatLog.finalizeAssistant("Previous completed reply.", "run-replaced");
-    for (let index = 0; index < 19; index += 1) {
-      chatLog.addSystem(`Retained notice ${index}.`);
-    }
-    chatLog.finalizeAssistant("Replacement completed reply.", "run-replaced");
-    chatLog.addLiveUser("Delayed replacement prompt.", {
-      messageId: "replacement-user",
-      runId: "run-replaced",
-    });
+      chatLog.finalizeAssistant("Previous completed reply.", "run-replaced");
+      if (previousReply === "pruned") {
+        for (let index = 0; index < capacity - 1; index += 1) {
+          chatLog.addSystem(`Retained notice ${index}.`);
+        }
+      }
+      chatLog.finalizeAssistant("Replacement completed reply.", "run-replaced");
+      const prompt = {
+        messageId: "replacement-user",
+        runId: "run-replaced",
+      };
+      chatLog.addLiveUser("Delayed replacement prompt.", prompt);
+      chatLog.addLiveUser("Delayed replacement prompt.", prompt);
 
-    const rendered = normalizeTestText(chatLog.render(120).join("\n"));
-    expect(chatLog.children).toHaveLength(20);
-    expect(rendered).not.toContain("Previous completed reply.");
-    expect(rendered.indexOf("Delayed replacement prompt.")).toBeLessThan(
-      rendered.indexOf("Replacement completed reply."),
-    );
-  });
+      const rendered = normalizeTestText(chatLog.render(120).join("\n"));
+      expect(rendered.split("Delayed replacement prompt.")).toHaveLength(2);
+      expect(rendered.split("Replacement completed reply.")).toHaveLength(2);
+      if (previousReply === "pruned") {
+        expect(chatLog.children).toHaveLength(capacity);
+        expect(rendered).not.toContain("Previous completed reply.");
+      } else {
+        expect(chatLog.children).toHaveLength(3);
+        expect(rendered.split("Previous completed reply.")).toHaveLength(2);
+        expect(rendered.indexOf("Delayed replacement prompt.")).toBeLessThan(
+          rendered.indexOf("Previous completed reply."),
+        );
+        expect(rendered.indexOf("Previous completed reply.")).toBeLessThan(
+          rendered.indexOf("Replacement completed reply."),
+        );
+      }
+      expect(rendered.indexOf("Delayed replacement prompt.")).toBeLessThan(
+        rendered.indexOf("Replacement completed reply."),
+      );
+    },
+  );
 
   it("infers active tool ownership after another finalized run leaves scrollback", () => {
     const chatLog = new ChatLog(20);

--- a/src/tui/tui-pty-assistant-fixture-test-support.ts
+++ b/src/tui/tui-pty-assistant-fixture-test-support.ts
@@ -1,5 +1,55 @@
 /** Generated-script fragment for assistant-specific PTY fixture messages. */
 export const TUI_PTY_ASSISTANT_FIXTURE_SCRIPT = `
+  let delayedPeerSessionKey: string | undefined;
+
+  function emitDelayedPeerReplies(backend: Pick<TuiBackend, "onEvent">, sessionKey: string) {
+    const runId = "peer-delayed-finals";
+    const timestamp = Date.now();
+    // Match the ID-less normal terminal and source-reply mirror producer shapes.
+    const normalFinal = {
+      event: "chat",
+      payload: {
+        runId, sessionKey, seq: 4, state: "final",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "PTY_PEER_NORMAL_REPLY" }],
+          timestamp,
+        },
+      },
+    };
+    const mirrorFinal = {
+      event: "chat",
+      payload: {
+        runId, sessionKey, seq: 1, state: "final",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "PTY_PEER_MIRROR_REPLY" }],
+          text: "PTY_PEER_MIRROR_REPLY",
+          timestamp,
+          stopReason: "stop",
+          usage: { input: 0, output: 0, totalTokens: 0 },
+        },
+      },
+    };
+    const prompt = {
+      event: "session.message",
+      payload: {
+        sessionKey, messageId: "peer-persisted-user", messageSeq: 1,
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "PTY_PEER_DELAYED_PROMPT" }],
+          timestamp,
+          __openclaw: { id: "peer-persisted-user", seq: 1, idempotencyKey: runId + ":user" },
+        },
+      },
+    };
+    for (const event of [normalFinal, mirrorFinal, mirrorFinal, prompt, prompt]) {
+      record("delayedPeerEvent", event);
+      backend.onEvent?.(event);
+    }
+    record("delayedPeerComplete", { runId, sessionKey });
+  }
+
   function assistantMessageFromSourceReplyPayloads(
     payloads: ReturnType<typeof buildEmbeddedRunPayloads>,
   ) {

--- a/src/tui/tui-pty-assistant-fixture-test-support.ts
+++ b/src/tui/tui-pty-assistant-fixture-test-support.ts
@@ -1,3 +1,88 @@
+import { expect } from "vitest";
+import {
+  readFixtureLog,
+  type StartTuiPtyFixture,
+  waitForSynchronizedFrameRows,
+} from "./tui-pty-harness-assertion-test-support.js";
+
+export async function exerciseDelayedPeerReplies(
+  startFixture: StartTuiPtyFixture,
+  startupTimeoutMs: number,
+  testTimeoutMs: number,
+) {
+  const peerFixture = await startFixture();
+  const markers = [
+    "PTY_PEER_DELAYED_PROMPT",
+    "PTY_PEER_NORMAL_REPLY",
+    "PTY_PEER_MIRROR_REPLY",
+  ] as const;
+  try {
+    await peerFixture.run.waitForOutput("local ready | idle", startupTimeoutMs);
+    await peerFixture.run.write("/session agent:main:delayed-peer-finals\r", { delay: false });
+    await waitForSynchronizedFrameRows(
+      peerFixture.run,
+      (rows) =>
+        rows.some((row) => row.includes("session agent:main:delayed-peer-finals")) &&
+        rows.some((row) => row.includes("local ready | idle")),
+      startupTimeoutMs,
+    );
+    await peerFixture.run.write("/gateway-status\r", { delay: false });
+    await peerFixture.waitForLogEntry((entry) => entry.method === "delayedPeerComplete");
+    const rows = await waitForSynchronizedFrameRows(
+      peerFixture.run,
+      (frame) =>
+        markers.every((marker) => frame.some((row) => row.includes(marker))) &&
+        frame.some((row) => row.includes("local ready | idle")),
+      testTimeoutMs,
+    );
+    const entries = await readFixtureLog(peerFixture.logPath);
+    const events = entries.filter((entry) => entry.method === "delayedPeerEvent");
+    const frame = rows.join("\n");
+    console.log(
+      `[behavior-evidence] tui-delayed-peer-finals ${JSON.stringify({
+        rows,
+        events,
+        terminalOutput: peerFixture.run.output(),
+      })}`,
+    );
+    expect(events).toHaveLength(5);
+    expect(entries.some((entry) => entry.method === "sendChat")).toBe(false);
+    for (const marker of markers) {
+      expect(frame.split(marker)).toHaveLength(2);
+    }
+    expect(frame.indexOf(markers[0])).toBeLessThan(frame.indexOf(markers[1]));
+    expect(frame.indexOf(markers[1])).toBeLessThan(frame.indexOf(markers[2]));
+  } finally {
+    await peerFixture.cleanup();
+  }
+}
+
+export async function exerciseLiveReplyRendering(
+  startFixture: StartTuiPtyFixture,
+  startupTimeoutMs: number,
+) {
+  const liveFixture = await startFixture({
+    env: { OPENCLAW_TUI_PTY_COLS: "220", OPENCLAW_TUI_PTY_ROWS: "50" },
+  });
+  try {
+    await liveFixture.run.waitForOutput("local ready", startupTimeoutMs);
+    await liveFixture.run.write("live reply dedupe proof: first\r", { delay: false });
+    await liveFixture.run.waitForOutput("TUI_LIVE_FIRST");
+    await liveFixture.run.write("live reply dedupe proof: second\r", { delay: false });
+    const rows = await waitForSynchronizedFrameRows(
+      liveFixture.run,
+      (frame) => frame.some((row) => row.includes("TUI_LIVE_SECOND")),
+      startupTimeoutMs,
+    );
+    const assistantRows = rows.filter(
+      (row) => row.includes("TUI_LIVE_FIRST") || row.includes("TUI_LIVE_SECOND"),
+    );
+    expect(assistantRows).toEqual(["TUI_LIVE_FIRST", "TUI_LIVE_SECOND"]);
+  } finally {
+    await liveFixture.cleanup();
+  }
+}
+
 /** Generated-script fragment for assistant-specific PTY fixture messages. */
 export const TUI_PTY_ASSISTANT_FIXTURE_SCRIPT = `
   let delayedPeerSessionKey: string | undefined;

--- a/src/tui/tui-pty-harness-fixture-test-support.ts
+++ b/src/tui/tui-pty-harness-fixture-test-support.ts
@@ -447,6 +447,10 @@ export async function writeTuiPtyFixtureScript(dir: string) {
         async loadHistory(opts: Parameters<TuiBackend["loadHistory"]>[0]) {
           const sessionKey = opts?.sessionKey ?? "main";
           record("loadHistory", { sessionKey });
+          if (sessionKey === "agent:main:delayed-peer-finals") {
+            delayedPeerSessionKey = sessionKey;
+            return { messages: [], sessionInfo: sessionEntry(sessionKey) };
+          }
           const gapHistory = loadGapHistory(sessionKey);
           if (gapHistory) { return gapHistory; }
           ${TUI_PTY_RECONNECT_FIXTURE.loadHistory}
@@ -579,6 +583,11 @@ export async function writeTuiPtyFixtureScript(dir: string) {
 
         async getGatewayStatus() {
           record("getGatewayStatus");
+          if (delayedPeerSessionKey) {
+            const sessionKey = delayedPeerSessionKey;
+            delayedPeerSessionKey = undefined;
+            emitDelayedPeerReplies(this, sessionKey);
+          }
           this.reconnectSessionSubscription();
           this.emitDisconnect();
           return gatewayStatus;

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -1,6 +1,10 @@
 // Exercises the fake-backend TUI PTY harness and visible terminal output.
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { sleep } from "../utils/sleep.js";
+import {
+  exerciseDelayedPeerReplies,
+  exerciseLiveReplyRendering,
+} from "./tui-pty-assistant-fixture-test-support.js";
 import { exerciseTuiCommandSurface } from "./tui-pty-command-surfaces-test-support.js";
 import {
   approveWorkspaceSkill,
@@ -12,7 +16,6 @@ import {
   objectFieldEquals,
   readFixtureLog,
   startTuiFixture,
-  waitForSynchronizedFrameRows,
   type FixtureLogEntry,
 } from "./tui-pty-harness-fixture-test-support.js";
 import { registerTuiReconnectTests } from "./tui-pty-reconnect-test-support.js";
@@ -113,53 +116,7 @@ describe.sequential("TUI PTY harness", () => {
 
   it(
     "orders a delayed peer prompt before every retained final reply",
-    async () => {
-      const peerFixture = await startTuiFixture();
-      const markers = [
-        "PTY_PEER_DELAYED_PROMPT",
-        "PTY_PEER_NORMAL_REPLY",
-        "PTY_PEER_MIRROR_REPLY",
-      ] as const;
-      try {
-        await peerFixture.run.waitForOutput("local ready | idle", STARTUP_TIMEOUT_MS);
-        await peerFixture.run.write("/session agent:main:delayed-peer-finals\r", { delay: false });
-        await waitForSynchronizedFrameRows(
-          peerFixture.run,
-          (rows) =>
-            rows.some((row) => row.includes("session agent:main:delayed-peer-finals")) &&
-            rows.some((row) => row.includes("local ready | idle")),
-          STARTUP_TIMEOUT_MS,
-        );
-        await peerFixture.run.write("/gateway-status\r", { delay: false });
-        await peerFixture.waitForLogEntry((entry) => entry.method === "delayedPeerComplete");
-        const rows = await waitForSynchronizedFrameRows(
-          peerFixture.run,
-          (frame) =>
-            markers.every((marker) => frame.some((row) => row.includes(marker))) &&
-            frame.some((row) => row.includes("local ready | idle")),
-          TEST_TIMEOUT_MS,
-        );
-        const entries = await readFixtureLog(peerFixture.logPath);
-        const events = entries.filter((entry) => entry.method === "delayedPeerEvent");
-        const frame = rows.join("\n");
-        console.log(
-          `[behavior-evidence] tui-delayed-peer-finals ${JSON.stringify({
-            rows,
-            events,
-            terminalOutput: peerFixture.run.output(),
-          })}`,
-        );
-        expect(events).toHaveLength(5);
-        expect(entries.some((entry) => entry.method === "sendChat")).toBe(false);
-        for (const marker of markers) {
-          expect(frame.split(marker)).toHaveLength(2);
-        }
-        expect(frame.indexOf(markers[0])).toBeLessThan(frame.indexOf(markers[1]));
-        expect(frame.indexOf(markers[1])).toBeLessThan(frame.indexOf(markers[2]));
-      } finally {
-        await peerFixture.cleanup();
-      }
-    },
+    () => exerciseDelayedPeerReplies(startTuiFixture, STARTUP_TIMEOUT_MS, TEST_TIMEOUT_MS),
     STARTUP_TEST_TIMEOUT_MS,
   );
 
@@ -411,28 +368,7 @@ describe.sequential("TUI PTY harness", () => {
 
   it(
     "renders each live assistant reply once without replaying stale history",
-    async () => {
-      const liveFixture = await startTuiFixture({
-        env: { OPENCLAW_TUI_PTY_COLS: "220", OPENCLAW_TUI_PTY_ROWS: "50" },
-      });
-      try {
-        await liveFixture.run.waitForOutput("local ready", STARTUP_TIMEOUT_MS);
-        await liveFixture.run.write("live reply dedupe proof: first\r", { delay: false });
-        await liveFixture.run.waitForOutput("TUI_LIVE_FIRST");
-        await liveFixture.run.write("live reply dedupe proof: second\r", { delay: false });
-        const rows = await waitForSynchronizedFrameRows(
-          liveFixture.run,
-          (frame) => frame.some((row) => row.includes("TUI_LIVE_SECOND")),
-          STARTUP_TIMEOUT_MS,
-        );
-        const assistantRows = rows.filter(
-          (row) => row.includes("TUI_LIVE_FIRST") || row.includes("TUI_LIVE_SECOND"),
-        );
-        expect(assistantRows).toEqual(["TUI_LIVE_FIRST", "TUI_LIVE_SECOND"]);
-      } finally {
-        await liveFixture.cleanup();
-      }
-    },
+    () => exerciseLiveReplyRendering(startTuiFixture, STARTUP_TIMEOUT_MS),
     STARTUP_TEST_TIMEOUT_MS,
   );
   // prettier-ignore

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -112,6 +112,58 @@ describe.sequential("TUI PTY harness", () => {
   });
 
   it(
+    "orders a delayed peer prompt before every retained final reply",
+    async () => {
+      const peerFixture = await startTuiFixture();
+      const markers = [
+        "PTY_PEER_DELAYED_PROMPT",
+        "PTY_PEER_NORMAL_REPLY",
+        "PTY_PEER_MIRROR_REPLY",
+      ] as const;
+      try {
+        await peerFixture.run.waitForOutput("local ready | idle", STARTUP_TIMEOUT_MS);
+        await peerFixture.run.write("/session agent:main:delayed-peer-finals\r", { delay: false });
+        await waitForSynchronizedFrameRows(
+          peerFixture.run,
+          (rows) =>
+            rows.some((row) => row.includes("session agent:main:delayed-peer-finals")) &&
+            rows.some((row) => row.includes("local ready | idle")),
+          STARTUP_TIMEOUT_MS,
+        );
+        await peerFixture.run.write("/gateway-status\r", { delay: false });
+        await peerFixture.waitForLogEntry((entry) => entry.method === "delayedPeerComplete");
+        const rows = await waitForSynchronizedFrameRows(
+          peerFixture.run,
+          (frame) =>
+            markers.every((marker) => frame.some((row) => row.includes(marker))) &&
+            frame.some((row) => row.includes("local ready | idle")),
+          TEST_TIMEOUT_MS,
+        );
+        const entries = await readFixtureLog(peerFixture.logPath);
+        const events = entries.filter((entry) => entry.method === "delayedPeerEvent");
+        const frame = rows.join("\n");
+        console.log(
+          `[behavior-evidence] tui-delayed-peer-finals ${JSON.stringify({
+            rows,
+            events,
+            terminalOutput: peerFixture.run.output(),
+          })}`,
+        );
+        expect(events).toHaveLength(5);
+        expect(entries.some((entry) => entry.method === "sendChat")).toBe(false);
+        for (const marker of markers) {
+          expect(frame.split(marker)).toHaveLength(2);
+        }
+        expect(frame.indexOf(markers[0])).toBeLessThan(frame.indexOf(markers[1]));
+        expect(frame.indexOf(markers[1])).toBeLessThan(frame.indexOf(markers[2]));
+      } finally {
+        await peerFixture.cleanup();
+      }
+    },
+    STARTUP_TEST_TIMEOUT_MS,
+  );
+
+  it(
     "renders a compact model and active thinking level in the footer",
     async () => {
       await compactFooterFixture.run.waitForOutput("gpt-5.6-sol high", STARTUP_TIMEOUT_MS);


### PR DESCRIPTION
Related: #131993

Related source contracts: #115219, #115377.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

**Do not merge: this is the test-only pre-fix reproduction stage, not a production repair.**

The normal hosted TUI unit suite now reproduces a late peer prompt appearing after the first of two retained replies from the same run. The native terminal regression has not executed: the current CI build step selects only two launcher canaries, not the new harness case.

## Why This Change Was Made

ChatLog keeps earlier finalized children visible while replacing their run-owned finalized set when another distinct final arrives. A later peer prompt can then anchor only to the newest reply. The baseline exercises that owner boundary before any production repair; it does not change transport, deduplication, persistence, defaults or streaming-reset policy.

The tests cover retained/pruned replies at capacities20/40 and a real-TUI/native-PTY scenario using ID-less normal/source-mirror finals, exact replay, then a sequenced persisted peer prompt and replay. The pending terminal oracle checks one latest completed synchronized frame, not accumulated redraw text.

This update repairs a baseline-authoring lint failure by moving two related assistant-rendering scenario bodies into existing test support. Test registrations, sequence, dimensions, assertions, deadlines and cleanup stay unchanged. It also removes the resulting unused import identified by independent review. No suppression, timeout increase, retry, workflow or extra runner is added.

## User Impact

No production or user-visible behavior change yet. Production LOC: +0/-0. Tests/support: +200/-43 across four existing files, including moved test bodies.

The purpose is to establish full rendering evidence before correcting conversation order. No affected stable version, frequency or severity is claimed. Existing source work in #115219 and #115377 supplies the ordering and multiple-final contracts. @Foxy6670's #103147 tool/history-segmentation work and #131869 worker snapshot replacement concern different ownership problems; no code was copied and no correctness or landing verdict on them is implied.

## Evidence

[CI33204451439](https://github.com/openclaw/openclaw/actions/runs/33204451439) completed on head c128b7cd08c7143dec39730f4a4de3701c8015dc. Its logs identify merge 9d4a87a775d4dbf54f156fbd787144dd737d78d5. The run is intentionally red: the two ordering regressions fail, so the aggregate gate fails; the other selected jobs passed. This is pre-fix evidence, not a production repair.

| Latest observed check | Result |
| --- | --- |
| [Normal TUI unit suite](https://github.com/openclaw/openclaw/actions/runs/33204451439/job/98962092775), retained finals at capacities 20/40 | Both fail at chat-log-run-state.test.ts:80:65: expected 244 less than 1, after positive presence/exact-once checks |
| Pruned earlier replies at capacities 20/40 | Both controls pass |
| Complete TUI unit result | 1,437 passed, 2 failed; existing reset, streaming, retraction and replay coverage passes |
| [Core lint](https://github.com/openclaw/openclaw/actions/runs/33204451439/job/98962091264) | Passed: the test-body extraction and unused-import cleanup resolve the baseline authoring failure |
| [Build-artifact PTY step](https://github.com/openclaw/openclaw/actions/runs/33204451439/job/98962090997) | Only two launcher canaries ran: 2 passed, 24 skipped. The new peer-order terminal case did not run |

The planner declares a full built-CLI PTY shard, but its downstream CI selection currently reduces dist-required work to the canary step. That routing gap is under separate investigation; this four-file test update does not repair or certify CI routing. No terminal screenshot/frame, real Gateway/provider timing or persistence result is available.

For this updated candidate, complete four-file independent source review and a four-pass Codex P2 review finished with no actionable findings. An earlier review found the unused import; the finding was accepted, corrected and the complete candidate re-reviewed. Default-cap credential scans and reviewer isolation remained intact. Exact-file formatting and all-four-file format checks passed, as did git diff --check. Final full diff SHA256: ad364e0f499de18b530d4388b43a287dc71653272b0549ad82a305d1cf327326.

Still required before production repair/landing: actually select the native harness case, retain its completed-frame ordering failure and controls, then verify the owner fix against the same tests. The existing native suite has four shared PTYs; these fresh assistant scenarios each add one case-owned PTY without changing lifecycle or dimensions. This is not a maximum for every other scenario in the suite.

The proposed focused terminal command remains unexecuted:

```sh
node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts src/tui/tui-pty-harness.e2e.test.ts
```

The fake-backend PTY route exercises real runTui, handlers and ChatLog; it does not prove physical Gateway queue timing, provider behavior or persistence. No production fix or issue closure is included.
