### PR TITLE
fix(buzz): persist account names during noninteractive setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **Buzz setup names:** preserve `channels add --name` in non-interactive setup, including environment-backed identities, without clearing existing names when the option is omitted or blank.
 - **Secret egress host binding:** bind each shared-store secret to exact HTTPS destination hosts across CLI, Gateway RPC, and Control UI so unbound sentinel substitution fails closed before plaintext egress.
 - **Release validation:** defer beta candidate Parallels smoke to postpublish `release:beta-smoke` by default, keep stable/full prepublish coverage, and bound nested release workflow monitors with explicit job timeouts.
 - **macOS app profiles:** isolate named app instances across state, preferences, Keychain, Gateway services, and duplicate-instance ownership while keeping host-global login and node services untouched.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Buzz setup names:** preserve `channels add --name` in non-interactive setup, including environment-backed identities, without clearing existing names when the option is omitted or blank.
 - **Secret egress host binding:** bind each shared-store secret to exact HTTPS destination hosts across CLI, Gateway RPC, and Control UI so unbound sentinel substitution fails closed before plaintext egress.
 - **Release validation:** defer beta candidate Parallels smoke to postpublish `release:beta-smoke` by default, keep stable/full prepublish coverage, and bound nested release workflow monitors with explicit job timeouts.
 - **macOS app profiles:** isolate named app instances across state, preferences, Keychain, Gateway services, and duplicate-instance ownership while keeping host-global login and node services untouched.

--- a/docs/channels/buzz.md
+++ b/docs/channels/buzz.md
@@ -464,6 +464,17 @@ export BUZZ_RELAY_URL="wss://buzz.example.com"
 export BUZZ_PRIVATE_KEY="nsec1..."
 ```
 
+With `BUZZ_PRIVATE_KEY` set, non-interactive setup can also save an account name:
+
+```bash
+openclaw channels add --channel buzz --name "Support bot" \
+  --relay-url wss://buzz.example.com --use-env
+```
+
+Omitting `--name` or supplying a blank name preserves the existing name. This
+command saves credentials and settings; use guided setup to discover and select
+rooms before starting a new bot.
+
 If a hosted workspace operator gives you an identity authorization value, set
 `channels.buzz.authTag` or `BUZZ_AUTH_TAG`. It can use the same plaintext or
 SecretRef forms as the private key. Treat this delegated, reusable value as a

--- a/extensions/buzz/src/setup-core.test.ts
+++ b/extensions/buzz/src/setup-core.test.ts
@@ -8,6 +8,30 @@ describe("buzzSetupContract", () => {
   });
 
   it.each([
+    { name: "  Named bot  ", expected: "Named bot" },
+    { name: "", expected: "Existing bot" },
+    { name: "   ", expected: "Existing bot" },
+    { name: undefined, expected: "Existing bot" },
+  ])(
+    "persists the supplied account name without clearing an omitted name: $name",
+    ({ name, expected }) => {
+      const cfg = {
+        channels: { buzz: { name: "Existing bot", groupPolicy: "allowlist" } },
+      } as OpenClawConfig;
+      const before = structuredClone(cfg);
+      const result = buzzSetupContract.applyAccountConfig({
+        cfg,
+        accountId: "default",
+        input: { name, relayUrl: "wss://buzz.example.com", privateKey: "11".repeat(32) },
+      });
+
+      expect(result.channels?.buzz?.name).toBe(expected);
+      expect(result.channels?.buzz?.groupPolicy).toBe("allowlist");
+      expect(cfg).toEqual(before);
+    },
+  );
+
+  it.each([
     {
       name: "plaintext private key",
       privateKey: "11".repeat(32),
@@ -91,10 +115,11 @@ describe("buzzSetupContract", () => {
     const result = buzzSetupContract.applyAccountConfig({
       cfg,
       accountId: "default",
-      input: { relayUrl: "wss://buzz.example.com", useEnv: true },
+      input: { relayUrl: "wss://buzz.example.com", useEnv: true, name: " Environment bot " },
     });
 
     expect(result.channels?.buzz).toEqual({
+      name: "Environment bot",
       enabled: true,
       relayUrl: "wss://buzz.example.com",
     });

--- a/extensions/buzz/src/setup-core.ts
+++ b/extensions/buzz/src/setup-core.ts
@@ -70,17 +70,23 @@ const buzzSetupAdapter: ChannelSetupAdapter<BuzzSetupInput> = {
     }
     return null;
   },
-  applyAccountConfig: ({ cfg, input }) => {
+  applyAccountConfig: ({ cfg, accountId, input }) => {
+    const namedConfig = applyAccountNameToChannelSection({
+      cfg,
+      channelKey: "buzz",
+      accountId,
+      name: input.name,
+    });
     const currentPrivateKey = resolveComparableCurrentKey(cfg);
     const nextPrivateKey = input.useEnv
       ? process.env.BUZZ_PRIVATE_KEY?.trim()
       : input.privateKey?.trim();
     const keepAuthTag = isSameBuzzIdentity(currentPrivateKey, nextPrivateKey);
-    const { privateKey: _privateKey, authTag, ...existing } = cfg.channels?.buzz ?? {};
+    const { privateKey: _privateKey, authTag, ...existing } = namedConfig.channels?.buzz ?? {};
     return {
-      ...cfg,
+      ...namedConfig,
       channels: {
-        ...cfg.channels,
+        ...namedConfig.channels,
         buzz: {
           ...existing,
           enabled: true,


### PR DESCRIPTION
## What Problem This Solves

Fixes #131994. Buzz non-interactive setup accepts `--name` but drops it while writing account configuration. Existing names stay unchanged, and a fresh environment-backed account gets no supplied name.

## Why This Change Was Made

Apply the existing shared account-naming helper inside the Buzz config writer, as guided setup and sibling channel writers already do. The CLI's prepare/apply owner correctly forwards the input; adding a second generic naming step there would duplicate plugin-owned behavior.

This preserves key/auth-tag handling, environment-backed key storage, unrelated settings, and the existing no-op for blank or omitted names. Named-account support remains separate under #130062.

Provenance: the config writer originates in Patrick-Erichsen's #113419, merged by @shakkernerd on 2026-07-26; the surrounding guided naming hook was added separately. No known-good released non-interactive behavior is claimed.

## User Impact

`openclaw channels add --channel buzz --name "Support bot" --relay-url wss://buzz.example.com --use-env` now saves the supplied trimmed name when the key environment variable is set. Guided setup remains the recommended path for discovering rooms; the headless command only stages credentials/settings.

Production LOC: +10/-4 (net +6); tests +26/-1; docs +11. The production growth is the missing invocation of the existing naming owner, not a new policy or configuration option.

## Evidence

- Actual public Buzz plugin through core prepare/apply: supplied-name assertion fails on main 0313c2dbc4234df6801626c6441a731dc5de5a19 and passes with the fix; input config remains unchanged.
- Regression RED: two intended failures (plaintext rename and environment-backed name), eight passing controls.
- GREEN: 23 tests across setup-core, setup-surface, and setup-verify; existing identity, SecretRef, retry, and guided setup behavior remains covered.
- Independent isolated Codex review: no actionable findings.
- Formatting, docs listing, diff checks, the full changed-file gate, and the ordinary runtime build pass.
- The actual compiled CLI was run in four fresh isolated homes. Before the fix, plaintext and environment-backed supplied names failed while omitted/blank controls passed. The repaired runtime passes all four, preserves the correct key-storage semantics and unrelated policy, and does not expose keys through public config output. No model or real operator state was used.
- Tested runtime: 04bc4ece6fd5e53a8f98fcb0f02f7eb3d75fc779, with successful [CI33197799699](https://github.com/openclaw/openclaw/actions/runs/33197799699). Final head d2dfd5368dd7131eda0c1ef3ec0ccddff07909c3 differs only by removing the root changelog line; all runtime/test/build inputs remain identical. [Final CI33199078534](https://github.com/openclaw/openclaw/actions/runs/33199078534) completed successfully.

An initial CLI harness incorrectly compared redacted public key output with stored plaintext. Direct inspection of the documented redaction contract and private fixture store showed the key was correct. The corrected unchanged-name assertions fail on the baseline and pass on the repair; storage is checked privately and non-disclosure through the public command is explicitly asserted.

No dependency, database migration, new config option, or native Buzz messaging capability is added. Native prepare reserves the root changelog for release generation; the user-facing entry is retained here instead. Latest ClawSweeper review18:31 found no actionable code issue; its compiled CLI and exact-head CI requests are both satisfied.

## Release note

- **Buzz setup names:** preserve `channels add --name` in non-interactive setup, including environment-backed identities, without clearing existing names when the option is omitted or blank.
