### PR TITLE
fix(codex): MCP server-glob toolsAllow entries drop the whole server from the Codex tool surface

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -2003,6 +2003,92 @@ describe("Codex app-server dynamic tool build", () => {
     expect(messageOnlyTools.map((tool) => tool.name)).toEqual(["message"]);
   });
 
+  it("resolves an MCP server-glob toolsAllow entry against materialized bundle-mcp tool names", async () => {
+    const outlookSendMail = createRuntimeDynamicTool("outlook__send_mail");
+    const outlookReadMail = createRuntimeDynamicTool("outlook__read_mail");
+    const otherServerTool = createRuntimeDynamicTool("weather__forecast");
+    setOpenClawCodingToolsFactoryForTests(() => [
+      outlookSendMail,
+      outlookReadMail,
+      otherServerTool,
+    ]);
+    const workspaceDir = path.join(tempDir, "mcp-glob-workspace");
+    const params = createParams(path.join(tempDir, "mcp-glob-session.jsonl"), workspaceDir);
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    params.toolsAllow = ["outlook__*"];
+
+    const tools = await buildDynamicToolsForTest(params, workspaceDir, {
+      nativeToolSurfaceEnabled: false,
+    });
+
+    // Documented server-glob syntax (docs/gateway/config-tools.md) must match every tool
+    // materialized under that server's safe name prefix, and must not leak an unrelated
+    // server's tools in (known-bad control for "glob support became allow-everything").
+    expect(tools.map((tool) => tool.name).toSorted()).toEqual([
+      "outlook__read_mail",
+      "outlook__send_mail",
+    ]);
+
+    const exactOnlyTools = await buildDynamicToolsForTest(
+      { ...params, toolsAllow: ["outlook__send_mail"] },
+      workspaceDir,
+      { nativeToolSurfaceEnabled: false },
+    );
+    expect(exactOnlyTools.map((tool) => tool.name)).toEqual(["outlook__send_mail"]);
+
+    // A list with only blank entries allowed nothing before glob support and
+    // must still allow nothing: the policy matcher alone would read it as allow-all.
+    const blankOnlyTools = await buildDynamicToolsForTest(
+      { ...params, toolsAllow: ["   "] },
+      workspaceDir,
+      { nativeToolSurfaceEnabled: false },
+    );
+    expect(blankOnlyTools).toEqual([]);
+  });
+
+  it("does not let a glob allow entry carry shell aliases that only an exact exec entry unlocks", async () => {
+    setOpenClawCodingToolsFactoryForTests(() => [
+      createRuntimeDynamicTool("exec_helper"),
+      createRuntimeDynamicTool("sandbox_exec"),
+      createRuntimeDynamicTool("sandbox_process"),
+    ]);
+    const workspaceDir = path.join(tempDir, "mcp-glob-alias-workspace");
+    const params = createParams(path.join(tempDir, "mcp-glob-alias-session.jsonl"), workspaceDir);
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    params.toolsAllow = ["exec_*"];
+
+    const tools = await buildDynamicToolsForTest(params, workspaceDir, {
+      nativeToolSurfaceEnabled: false,
+    });
+
+    // `exec_*` matches the MCP-style name but is not the canonical `exec` entry
+    // that preserves the sandbox shell aliases.
+    expect(tools.map((tool) => tool.name)).toEqual(["exec_helper"]);
+  });
+
+  it("preserves shell aliases for a group:runtime allow entry the same way an exact exec entry does", async () => {
+    setOpenClawCodingToolsFactoryForTests(() => [
+      createRuntimeDynamicTool("exec"),
+      createRuntimeDynamicTool("sandbox_exec"),
+      createRuntimeDynamicTool("weather__forecast"),
+    ]);
+    const workspaceDir = path.join(tempDir, "group-runtime-workspace");
+    const params = createParams(path.join(tempDir, "group-runtime-session.jsonl"), workspaceDir);
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    params.toolsAllow = ["group:runtime"];
+
+    const tools = await buildDynamicToolsForTest(params, workspaceDir, {
+      nativeToolSurfaceEnabled: false,
+    });
+
+    const names = tools.map((tool) => tool.name);
+    expect(names).toEqual(expect.arrayContaining(["exec", "sandbox_exec"]));
+    expect(names).not.toContain("weather__forecast");
+  });
+
   it("exposes Docker sandbox shell tools when native Code Mode cannot honor sandbox paths", async () => {
     setOpenClawCodingToolsFactoryForTests(() => [
       createRuntimeDynamicTool("exec"),

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -20,7 +20,7 @@ import {
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { resolveAgentDir } from "openclaw/plugin-sdk/agent-runtime";
 import { runWithCronCreatorAuthorityCapabilityResolver } from "openclaw/plugin-sdk/codex-mcp-projection";
-import { isToolAllowed } from "openclaw/plugin-sdk/sandbox";
+import { isRuntimeToolAllowed, isToolAllowed } from "openclaw/plugin-sdk/sandbox";
 import {
   isCodexRemoteExecPlacementSandbox,
   readCodexPluginConfig,
@@ -940,7 +940,14 @@ function resolveCodexNativeExecutionPolicyForDynamicTools(
     readRuntimeSessionEntry: true,
   });
 }
-/** Applies a normalized tool allowlist while preserving shell aliases for exec/process. */
+/**
+ * Applies the run's tool allowlist while preserving shell aliases for exec/process.
+ * Tool names are matched through `isRuntimeToolAllowed`, the same runtime matcher every
+ * other `toolsAllow` consumer uses, so a documented `<server>__*` MCP-server-glob entry
+ * (docs/gateway/config-tools.md), a `group:*` entry and a hook-merged intersection all
+ * resolve here the way they do elsewhere — an exact-string `Set` cannot match a glob
+ * entry against a per-tool materialized MCP name.
+ */
 function filterCodexDynamicToolsForAllowlist<T extends { name: string }>(
   tools: T[],
   toolsAllow?: string[],
@@ -954,23 +961,36 @@ function filterCodexDynamicToolsForAllowlist<T extends { name: string }>(
   if (hasWildcardCodexToolsAllow(toolsAllow)) {
     return tools;
   }
-  const allowSet = new Set(
-    toolsAllow.map((name) => normalizeCodexDynamicToolName(name)).filter(Boolean),
-  );
+  // A list with only blank entries allowed nothing before glob support and must
+  // still allow nothing: the runtime matcher reads a policy with no usable pattern
+  // as "no allow policy" (allow everything).
+  const allow = toolsAllow.map((name) => normalizeCodexDynamicToolName(name)).filter(Boolean);
+  if (allow.length === 0) {
+    return [];
+  }
+  const matchesAllow = (name: string) => isRuntimeToolAllowed(name, toolsAllow);
+  // Shell aliases stay gated on a canonical `exec` / `process` entry (exact or via a
+  // `group:*`), never on a glob such as `exec*` — and every merged restriction must
+  // still allow the canonical name.
+  const literalAllow = allow.filter((entry) => !entry.includes("*"));
+  const allowsCanonical = (name: string) =>
+    literalAllow.length > 0 &&
+    isRuntimeToolAllowed(name, literalAllow) &&
+    isRuntimeToolAllowed(name, toolsAllow);
+  const execAllowed = allowsCanonical("exec");
+  const processAllowed = execAllowed || allowsCanonical("process");
   return tools.filter((tool) => {
     const normalized = normalizeCodexDynamicToolName(tool.name);
     return (
-      allowSet.has(normalized) ||
-      (normalized === "sandbox_exec" && allowSet.has("exec")) ||
-      (normalized === "sandbox_process" && (allowSet.has("exec") || allowSet.has("process"))) ||
-      (normalized === CODEX_GATEWAY_EXEC_DYNAMIC_TOOL_NAME && allowSet.has("exec")) ||
-      (normalized === CODEX_GATEWAY_PROCESS_DYNAMIC_TOOL_NAME &&
-        (allowSet.has("exec") || allowSet.has("process"))) ||
-      (normalized === CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME && allowSet.has("exec"))
+      matchesAllow(normalized) ||
+      (normalized === "sandbox_exec" && execAllowed) ||
+      (normalized === "sandbox_process" && processAllowed) ||
+      (normalized === CODEX_GATEWAY_EXEC_DYNAMIC_TOOL_NAME && execAllowed) ||
+      (normalized === CODEX_GATEWAY_PROCESS_DYNAMIC_TOOL_NAME && processAllowed) ||
+      (normalized === CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME && execAllowed)
     );
   });
 }
-/** Detects the wildcard allowlist marker after Codex tool-name normalization. */
 function hasWildcardCodexToolsAllow(toolsAllow: string[]): boolean {
   return toolsAllow.some((name) => normalizeCodexDynamicToolName(name) === "*");
 }

--- a/src/plugin-sdk/sandbox.ts
+++ b/src/plugin-sdk/sandbox.ts
@@ -54,6 +54,10 @@ export {
   shellEscape,
   uploadDirectoryToSshTarget,
 } from "../agents/sandbox.js";
+// Runtime `toolsAllow` matching (globs, `group:*` expansion, hook-merged
+// intersections, empty list = deny) for plugins that filter their own tool
+// surface against the run's allowlist.
+export { isRuntimeToolAllowed } from "../agents/tool-policy-match.js";
 
 export {
   runPluginCommandWithTimeout,


### PR DESCRIPTION
Related: #113341

## What Problem This Solves

Fixes an issue where operators who scope a Codex agent's `tools.allow` to one MCP server with the documented server-glob syntax (`docs/gateway/config-tools.md`, e.g. `outlook__*`) would lose that server entirely: the server stays connected and explicitly allowed, but the dynamic-tool bridge outputs none of its tools for the Codex turn, and nothing in the filter reports the drop. The only discoverable workaround was widening `tools.allow` to `*`, which also re-admits the native shell and file tools the operator was scoping away from.

## Why This Change Was Made

Changed: `extensions/codex/src/app-server/dynamic-tool-build.ts` (`filterCodexDynamicToolsForAllowlist` only) and `src/plugin-sdk/sandbox.ts` (one re-export: `isRuntimeToolAllowed`). Not changed: how MCP servers are attached to a Codex turn, the `message` forced-allow path, the shared matcher itself.

**The fix.** This PR changes this filter to route through the existing shared matcher instead of a private exact-string match. `filterCodexDynamicToolsForAllowlist` (`extensions/codex/src/app-server/dynamic-tool-build.ts`) matched `toolsAllow` entries against the per-tool materialized MCP names (`<server>__<tool>`) with an exact-string `Set`, so a glob entry could never match. This change matches through `isRuntimeToolAllowed` (`src/agents/tool-policy-match.ts`, the matcher `src/agents/command/attempt-execution.ts` already applies to the same `toolsAllow` value; re-exported here from the existing `openclaw/plugin-sdk/sandbox` subpath next to `isToolAllowed`). Reusing the shared matcher is what makes a server glob such as `outlook__*` (documented in `docs/gateway/config-tools.md`) resolve. 

**What else changes because the shared matcher is used.** The goal is semantic parity with the shared matcher (the consumer at `src/agents/command/attempt-execution.ts`; matcher tests in `src/agents/tool-policy.test.ts` and `src/plugins/hooks.phase-hooks.test.ts`). That parity changes how two other entry shapes are read in this filter, and both are listed here rather than left implicit: a `group:*` entry now expands through `expandToolGroups` as it does for every other consumer (it previously matched nothing, dropping every tool); and when several `before_prompt_build` hooks each cap the allowlist, every cap is applied (`readToolAllowlistIntersection`, previously the flattened list was read as one union). Concretely: `["group:runtime"]` exposed no tool before and now exposes `exec`/`process` and their sandbox aliases; `web_*` from one hook plus `*_search` from another exposed `web_fetch` before and now exposes only `web_search`. Both are corrections to what existing policy semantics already promise for those entry shapes (`src/agents/tool-policy.test.ts`, `src/plugins/hooks.phase-hooks.test.ts`), and they are visible only to a Codex configuration that already used those shapes and got nothing, or a union, from this filter. Both are inseparable from choosing the shared matcher over a private one, which is why they are in this PR rather than a follow-up.



**Guardrails kept on purpose.** Two guardrails keep the reuse from widening anything, each with its own test: a list that contains only blank entries still allows nothing (the matcher alone would read it as "no allow policy"), and the sandbox / gateway / node `exec` and `process` aliases are preserved by a canonical `exec` / `process` entry — exact or via a group — while a glob such as `exec_*` matches only the tool names it spells out. The global `*` entry keeps its own early path, returning the full tool set (aliases included) exactly as before. The change is limited to the Codex dynamic-tool allowlist filter and the one SDK re-export it needs; how MCP servers are attached to a Codex turn, and the `message` tool's forced-allow path, are out of scope and unchanged.

## User Impact

Operators can scope a Codex agent to a single MCP server with `tools.allow: ["<server>__*"]` (a server glob) and the dynamic-tool bridge now outputs that server's tools for the Codex turn, without widening the allowlist to the global `*`. Exact entries and the global `*` keep their existing behavior (both take the unchanged early paths in the filter, covered by the existing tests in the same file); the shell-alias rule is covered by the two new alias tests below.

## Evidence

Unit evidence — `pnpm exec vitest run extensions/codex/src/app-server/dynamic-tool-build.test.ts` at `3ba07ee133cb` (94/94 passed, run from the repository root). New cases: `resolves an MCP server-glob toolsAllow entry against materialized bundle-mcp tool names` (server glob, exact entry, blank-only list), `does not let a glob allow entry carry shell aliases that only an exact exec entry unlocks`, `preserves shell aliases for a group:runtime allow entry the same way an exact exec entry does`. They cover: a server glob keeps that server's tools and drops another server's; an exact entry keeps only itself; a blank-only list allows nothing; `exec_*` does not carry the shell aliases; `group:runtime` does. The server-glob test fails against the unpatched source. The global `*` and exact-entry paths are exercised by the existing cases in the same file (`toolsAllow = ["*"]` / single exact names), which still pass. The hook-cap intersection is not re-tested in this file: it is the shared matcher's own behavior, covered by `src/plugins/hooks.phase-hooks.test.ts` ("preserves overlapping glob restrictions": `web_*` + `*_search` keep `web_search` only), and this PR only routes the Codex filter through that matcher.

Real behavior proof (bridge level; the `## Real behavior proof` heading below is the fixed field name the repository's proof policy reads) — ClawProof final proof `20260828t164703z-proof-4fb874e4`, baseline `26442aadaa3d` vs candidate `3ba07ee133cb`, pasted in full in the next section. The capture drives the exported `buildDynamicTools()` before and after the patch and records the list of dynamic tools the bridge outputs; MCP-materialized tools are injected through `dynamicToolBuildState.openClawCodingToolsFactory` (`extensions/codex/src/app-server/dynamic-tool-build-state.ts`), the seam the module's tests use via `setOpenClawCodingToolsFactoryForTests`, so the filtering decision is the production matcher's. It stops at the bridge: a live Codex app-server turn against a real MCP process is not captured. The `group:*`, hook-cap and alias cases are unit-only. The third scenario is named `unrelated-server-name-known-bad-control` in the capture; it checks isolation (`weather__*` must not expose any `outlook` tool), and after the patch it also exposes `weather__forecast`, the same repair on a second server.

| `toolsAllow` | before | after |
| --- | --- | --- |
| `["outlook__*"]` | `[]` | `outlook__read_mail`, `outlook__send_mail` |
| `["outlook__send_mail"]` | `outlook__send_mail` | `outlook__send_mail` |
| `["weather__*"]` | `[]` | `weather__forecast` |
| `["   "]` | `[]` | `[]` |

## Real behavior proof

Behavior addressed: with `tools.allow: ["outlook__*"]` the Codex dynamic-tool bridge exposes the `outlook` MCP server's tools instead of dropping the whole server; Controls: an exact entry and a blank-only list behave as before; a second server's glob (`weather__*`) now resolves to that server's own tool and still exposes none of `outlook`'s (before the patch it resolved to nothing, the same defect).
Real environment tested: Linux x86_64, node v24.18.0, patch at `3ba07ee133cb`

Exact steps or command run after this patch:

```sh
clawproof work start codex-mcp-scoped-allowlist-fail-closed --baseline 26442aadaa3d4d9d8fe9c2c23eef40b416c40e77
git -C ~/.clawproof/work-items/codex-mcp-scoped-allowlist-fail-closed/after reset --hard 3ba07ee133cb7e711f0fb793163ea8fe56e90503
clawproof build plan codex-mcp-scoped-allowlist-fail-closed --worktree before --apply
clawproof build plan codex-mcp-scoped-allowlist-fail-closed --worktree after --apply
clawproof prove codex-mcp-scoped-allowlist-fail-closed --scenario default --final --problem-file docs/work-items/codex-mcp-scoped-allowlist-fail-closed/proof/problem.md
ocw proof import codex-mcp-scoped-allowlist-fail-closed
# each side runs the same harness against its own checkout:
# PROOF_MODULE=extensions/codex/src/app-server/dynamic-tool-build.ts node --import tsx proof/harness.mjs
```

Before (pre-fix):

```text
===== BEFORE (baseline 26442aadaa3d, unfixed source) =====
--- harness.stderr ---
[harness: importing [REDACTED:path]/before/extensions/codex/src/app-server/dynamic-tool-build.ts]
[harness: running server-glob-toolsAllow-outlook-star]
[harness: running exact-toolsAllow-single-tool-known-good-control]
[harness: running unrelated-server-name-known-bad-control]
[harness: running blank-only-toolsAllow-fail-closed-control]
--- harness.stdout ---
{
  "moduleUnderTest": "extensions/codex/src/app-server/dynamic-tool-build.ts",
  "results": [
    {
      "case": "server-glob-toolsAllow-outlook-star",
      "description": "operator writes the documented outlook__* server-glob entry",
      "toolsAllow": [
        "outlook__*"
      ],
      "survivingToolNames": [],
      "error": null
    },
    {
      "case": "exact-toolsAllow-single-tool-known-good-control",
      "description": "operator writes an exact materialized tool name (must keep working)",
      "toolsAllow": [
        "outlook__send_mail"
      ],
      "survivingToolNames": [
        "outlook__send_mail"
      ],
      "error": null
    },
    {
      "case": "unrelated-server-name-known-bad-control",
      "description": "operator allowlists a different server; must not leak outlook tools in",
      "toolsAllow": [
        "weather__*"
      ],
      "survivingToolNames": [],
      "error": null
    },
    {
      "case": "blank-only-toolsAllow-fail-closed-control",
      "description": "operator writes an allowlist with only a blank entry; nothing may be exposed",
      "toolsAllow": [
        "   "
      ],
      "survivingToolNames": [],
      "error": null
    }
  ]
}

```

Evidence after fix:

```text
===== AFTER (candidate 3ba07ee133cb, fix applied) =====
--- harness.stderr ---
[harness: importing [REDACTED:path]/after/extensions/codex/src/app-server/dynamic-tool-build.ts]
[harness: running server-glob-toolsAllow-outlook-star]
[harness: running exact-toolsAllow-single-tool-known-good-control]
[harness: running unrelated-server-name-known-bad-control]
[harness: running blank-only-toolsAllow-fail-closed-control]
--- harness.stdout ---
{
  "moduleUnderTest": "extensions/codex/src/app-server/dynamic-tool-build.ts",
  "results": [
    {
      "case": "server-glob-toolsAllow-outlook-star",
      "description": "operator writes the documented outlook__* server-glob entry",
      "toolsAllow": [
        "outlook__*"
      ],
      "survivingToolNames": [
        "outlook__read_mail",
        "outlook__send_mail"
      ],
      "error": null
    },
    {
      "case": "exact-toolsAllow-single-tool-known-good-control",
      "description": "operator writes an exact materialized tool name (must keep working)",
      "toolsAllow": [
        "outlook__send_mail"
      ],
      "survivingToolNames": [
        "outlook__send_mail"
      ],
      "error": null
    },
    {
      "case": "unrelated-server-name-known-bad-control",
      "description": "operator allowlists a different server; must not leak outlook tools in",
      "toolsAllow": [
        "weather__*"
      ],
      "survivingToolNames": [
        "weather__forecast"
      ],
      "error": null
    },
    {
      "case": "blank-only-toolsAllow-fail-closed-control",
      "description": "operator writes an allowlist with only a blank entry; nothing may be exposed",
      "toolsAllow": [
        "   "
      ],
      "survivingToolNames": [],
      "error": null
    }
  ]
}
```

Observed result after fix: `server-glob-toolsAllow-outlook-star` keeps `outlook__read_mail` and `outlook__send_mail` (before: `[]`); the exact-entry control still keeps only `outlook__send_mail`; the `weather__*` control keeps `weather__forecast` and nothing from `outlook` (before: `[]`, the same defect on a second server); the blank-only control still keeps nothing.
What was not tested: a live Codex app-server turn against a real MCP server process. The harness drives the exported `buildDynamicTools()` with MCP-materialized dynamic tools injected through the module's own `openClawCodingToolsFactory` seam (the same seam its behavioral tests use), so the filtering decision comes from the unmodified production matcher; tool execution and the MCP transport are outside this capture.

