### PR TITLE
fix(agents): show Claude CLI replies while they stream

### DIFF
--- a/src/agents/cli-output-records.ts
+++ b/src/agents/cli-output-records.ts
@@ -561,7 +561,12 @@ export function parseClaudeCliStreamingDelta(params: {
   ) {
     return null;
   }
-  const snapshot = collectCliText(params.parsed.message);
+  const content = Array.isArray(params.parsed.message.content) ? params.parsed.message.content : [];
+  const snapshot = content
+    .map((block) =>
+      isRecord(block) && block.type === "text" && typeof block.text === "string" ? block.text : "",
+    )
+    .join("");
   // The delivery lane is append-only. Emit only cumulative suffixes and let
   // a divergent revision defer to the terminal result instead of duplicating text.
   return snapshot.startsWith(params.previousText)

--- a/src/agents/cli-output-records.ts
+++ b/src/agents/cli-output-records.ts
@@ -536,25 +536,37 @@ export function parseClaudeCliStreamingDelta(params: {
   backend: CliBackendConfig;
   providerId: string;
   parsed: Record<string, unknown>;
+  previousText: string;
 }): string | null {
   if (!supportsCliJsonlToolEvents(params)) {
     return null;
   }
-  if (params.parsed.type !== "stream_event" || !isRecord(params.parsed.event)) {
+  if (params.parsed.type === "stream_event" && isRecord(params.parsed.event)) {
+    const event = params.parsed.event;
+    if (event.type !== "content_block_delta" || !isRecord(event.delta)) {
+      return null;
+    }
+    const delta = event.delta;
+    return delta.type === "text_delta" && typeof delta.text === "string" && delta.text
+      ? delta.text
+      : null;
+  }
+  if (
+    // `--include-partial-messages` marks cumulative assistant snapshots with an explicit null.
+    !isClaudeStreamJsonDialect(params) ||
+    params.parsed.type !== "assistant" ||
+    isClaudeSubagentRecord(params.parsed) ||
+    !isRecord(params.parsed.message) ||
+    params.parsed.message.stop_reason !== null
+  ) {
     return null;
   }
-  const event = params.parsed.event;
-  if (event.type !== "content_block_delta" || !isRecord(event.delta)) {
-    return null;
-  }
-  const delta = event.delta;
-  if (delta.type !== "text_delta" || typeof delta.text !== "string") {
-    return null;
-  }
-  if (!delta.text) {
-    return null;
-  }
-  return delta.text;
+  const snapshot = collectCliText(params.parsed.message);
+  // The delivery lane is append-only. Emit only cumulative suffixes and let
+  // a divergent revision defer to the terminal result instead of duplicating text.
+  return snapshot.startsWith(params.previousText)
+    ? snapshot.slice(params.previousText.length) || null
+    : null;
 }
 
 const GEMINI_CLI_ERROR_EVENT_FALLBACK = "Gemini CLI emitted an error event.";

--- a/src/agents/cli-output-snapshots.test.ts
+++ b/src/agents/cli-output-snapshots.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+import { createCliJsonlStreamingParser } from "./cli-output-stream.js";
+
+const BACKEND = {
+  command: "claude",
+  output: "jsonl",
+  jsonlDialect: "claude-stream-json",
+} as const;
+
+function joinJsonlFrames(...frames: unknown[]) {
+  return frames.map((frame) => JSON.stringify(frame)).join("\n");
+}
+
+function claudeTextDelta(text: string) {
+  return {
+    type: "stream_event",
+    event: { type: "content_block_delta", delta: { type: "text_delta", text } },
+  };
+}
+
+function claudePartialSnapshot(id: string, content: unknown[]) {
+  return { type: "assistant", message: { id, content, stop_reason: null } };
+}
+
+describe("Claude CLI assistant snapshots", () => {
+  it("streams cumulative snapshots as incremental deltas", () => {
+    const deltas: Array<{ text: string; delta: string }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: BACKEND,
+      providerId: "claude-cli",
+      onAssistantDelta: ({ text, delta }) => deltas.push({ text, delta }),
+    });
+
+    parser.push(
+      joinJsonlFrames(
+        claudePartialSnapshot("msg-1", [{ type: "text", text: "Hello" }]),
+        claudePartialSnapshot("msg-1", [{ type: "text", text: "Hello world" }]),
+        { type: "result", subtype: "success", result: "Hello world" },
+      ),
+    );
+    parser.finish();
+
+    expect(deltas).toEqual([
+      { text: "Hello", delta: "Hello" },
+      { text: "Hello world", delta: " world" },
+    ]);
+    expect(parser.getOutput()?.text).toBe("Hello world");
+  });
+
+  it("deduplicates stream-event text repeated by a snapshot", () => {
+    const deltas: Array<{ text: string; delta: string }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: BACKEND,
+      providerId: "claude-cli",
+      onAssistantDelta: ({ text, delta }) => deltas.push({ text, delta }),
+    });
+
+    parser.push(
+      joinJsonlFrames(
+        claudeTextDelta("Hi"),
+        claudePartialSnapshot("msg-1", [{ type: "text", text: "Hi" }]),
+        claudePartialSnapshot("msg-1", [{ type: "text", text: "Hi there" }]),
+        { type: "result", subtype: "success", result: "Hi there" },
+      ),
+    );
+    parser.finish();
+
+    expect(deltas).toEqual([
+      { text: "Hi", delta: "Hi" },
+      { text: "Hi there", delta: " there" },
+    ]);
+    expect(parser.getOutput()?.text).toBe("Hi there");
+  });
+
+  it("keeps commentary, tools, and later assistant text in their lanes", () => {
+    const commentary: string[] = [];
+    const tools: string[] = [];
+    const deltas: Array<{ text: string; delta: string }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: BACKEND,
+      providerId: "claude-cli",
+      onAssistantDelta: ({ text, delta }) => deltas.push({ text, delta }),
+      onCommentaryText: (text) => commentary.push(text),
+      onToolUseStart: (tool) => tools.push(tool.name),
+    });
+
+    parser.push(
+      joinJsonlFrames(
+        claudePartialSnapshot("msg-before-tool", [{ type: "text", text: "Inspecting now." }]),
+        claudePartialSnapshot("msg-before-tool", [
+          { type: "text", text: "Inspecting now." },
+          { type: "tool_use", id: "tool-1", name: "Read", input: {} },
+        ]),
+        claudePartialSnapshot("msg-after-tool", [{ type: "text", text: "Done." }]),
+        { type: "result", subtype: "success", result: "Done." },
+      ),
+    );
+    parser.finish();
+
+    expect(commentary).toEqual(["Inspecting now."]);
+    expect(tools).toEqual(["Read"]);
+    expect(deltas).toEqual([{ text: "Done.", delta: "Done." }]);
+    expect(parser.getOutput()?.text).toBe("Done.");
+  });
+
+  it("preserves tool-split snapshots when commentary is disabled", () => {
+    const deltas: Array<{ text: string; delta: string }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: BACKEND,
+      providerId: "claude-cli",
+      onAssistantDelta: ({ text, delta }) => deltas.push({ text, delta }),
+    });
+
+    parser.push(
+      joinJsonlFrames(
+        claudePartialSnapshot("msg-before-tool", [{ type: "text", text: "Inspecting now." }]),
+        claudePartialSnapshot("msg-before-tool", [
+          { type: "text", text: "Inspecting now." },
+          { type: "tool_use", id: "tool-1", name: "Read", input: {} },
+        ]),
+        claudePartialSnapshot("msg-after-tool", [{ type: "text", text: "Done." }]),
+        { type: "result", subtype: "success", result: "Done." },
+      ),
+    );
+    parser.finish();
+
+    expect(deltas).toEqual([
+      { text: "Inspecting now.", delta: "Inspecting now." },
+      { text: "Inspecting now.\n\nDone.", delta: "\n\nDone." },
+    ]);
+    expect(parser.getOutput()?.text).toBe("Inspecting now.\n\nDone.");
+  });
+
+  it("routes leading tagged reasoning before visible snapshot text", () => {
+    const thinking: string[] = [];
+    const visible: string[] = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: BACKEND,
+      providerId: "claude-cli",
+      onAssistantDelta: ({ delta }) => visible.push(delta),
+      onThinkingDelta: ({ delta }) => thinking.push(delta),
+    });
+
+    parser.push(
+      joinJsonlFrames(
+        claudePartialSnapshot("msg-1", [
+          { type: "text", text: "<thinking>Private.</thinking>Visible." },
+        ]),
+        { type: "result", subtype: "success", result: "<thinking>Private.</thinking>Visible." },
+      ),
+    );
+    parser.finish();
+
+    expect(thinking).toEqual(["Private."]);
+    expect(visible).toEqual(["Visible."]);
+    expect(parser.getOutput()?.text).toBe("Visible.");
+  });
+
+  it.each([
+    {
+      name: "missing stop reason",
+      record: {
+        type: "assistant",
+        message: { id: "msg-1", content: [{ type: "text", text: "x" }] },
+      },
+    },
+    {
+      name: "terminal stop reason",
+      record: {
+        type: "assistant",
+        message: { id: "msg-1", content: [{ type: "text", text: "x" }], stop_reason: "end_turn" },
+      },
+    },
+    {
+      name: "subagent parent",
+      record: {
+        ...claudePartialSnapshot("msg-1", [{ type: "text", text: "x" }]),
+        parent_tool_use_id: "tool-parent",
+      },
+    },
+    {
+      name: "tool-only snapshot",
+      record: claudePartialSnapshot("msg-1", [
+        { type: "tool_use", id: "tool-1", name: "Read", input: {} },
+      ]),
+    },
+  ])("does not stream a snapshot with $name", ({ record }) => {
+    const deltas: string[] = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: BACKEND,
+      providerId: "claude-cli",
+      onAssistantDelta: ({ delta }) => deltas.push(delta),
+    });
+
+    parser.push(JSON.stringify(record));
+    parser.finish();
+
+    expect(deltas).toEqual([]);
+  });
+});

--- a/src/agents/cli-output-snapshots.test.ts
+++ b/src/agents/cli-output-snapshots.test.ts
@@ -131,6 +131,36 @@ describe("Claude CLI assistant snapshots", () => {
     expect(parser.getOutput()?.text).toBe("Inspecting now.\n\nDone.");
   });
 
+  it("keeps nested tool-result text out of the visible snapshot", () => {
+    const deltas: string[] = [];
+    const toolResults: unknown[] = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: BACKEND,
+      providerId: "claude-cli",
+      onAssistantDelta: ({ delta }) => deltas.push(delta),
+      onToolResult: ({ result }) => toolResults.push(result),
+    });
+    const secret = "private tool result";
+
+    parser.push(
+      JSON.stringify(
+        claudePartialSnapshot("msg-1", [
+          { type: "text", text: "Visible." },
+          {
+            type: "mcp_tool_result",
+            tool_use_id: "tool-1",
+            content: [{ type: "text", text: secret }],
+          },
+        ]),
+      ),
+    );
+    parser.finish();
+
+    expect(deltas).toEqual(["Visible."]);
+    expect(toolResults).toEqual([[{ type: "text", text: secret }]]);
+    expect(deltas.join("")).not.toContain(secret);
+  });
+
   it("routes leading tagged reasoning before visible snapshot text", () => {
     const thinking: string[] = [];
     const visible: string[] = [];

--- a/src/agents/cli-output-stream.ts
+++ b/src/agents/cli-output-stream.ts
@@ -117,6 +117,8 @@ export function createCliJsonlStreamingParser(params: CliJsonlStreamingParserOpt
   let assistantText = "";
   let customThinkingText = "";
   let pendingClaudeText = "";
+  let currentClaudeMessageId: string | undefined;
+  let currentClaudeMessageText = "";
   let pendingMessageSeparator = false;
   let currentMessageStart = 0;
   let segmentStart = 0;
@@ -234,6 +236,15 @@ export function createCliJsonlStreamingParser(params: CliJsonlStreamingParserOpt
     currentTaggedReasoningText = "";
   };
 
+  const beginClaudeMessage = (messageId?: string) => {
+    beginTaggedReasoningMessage();
+    pendingMessageSeparator = true;
+    previousMessageHadToolUse = currentMessageHadToolUse;
+    currentMessageHadToolUse = false;
+    currentClaudeMessageId = messageId;
+    currentClaudeMessageText = "";
+  };
+
   const handleCustomJsonlEvent = (event: CliBackendParsedJsonlEvent) => {
     const state: CliEventProjectionState = {
       assistantText,
@@ -336,6 +347,17 @@ export function createCliJsonlStreamingParser(params: CliJsonlStreamingParserOpt
       isRecord(parsed.message) &&
       !isClaudeSubagentRecord(parsed)
     ) {
+      if (claudeStreamJson) {
+        const messageId = typeof parsed.message.id === "string" ? parsed.message.id : undefined;
+        if (messageId && messageId !== currentClaudeMessageId) {
+          // A stream delta can precede the first identified snapshot for the same message.
+          if (currentClaudeMessageId === undefined) {
+            currentClaudeMessageId = messageId;
+          } else {
+            beginClaudeMessage(messageId);
+          }
+        }
+      }
       resumeCheckpointId = pickCliResumeCheckpointId({ ...params, parsed }) ?? resumeCheckpointId;
       params.onAssistantMessage?.(parsed.message);
       if (claudeStreamJson && isClaudeSyntheticNoResponse(parsed)) {
@@ -469,10 +491,8 @@ export function createCliJsonlStreamingParser(params: CliJsonlStreamingParserOpt
       // boundary so accumulated text joins with a paragraph break instead of
       // gluing the pre-tool text to the next message's first delta.
       if (evt.type === "message_start") {
-        beginTaggedReasoningMessage();
-        pendingMessageSeparator = true;
-        previousMessageHadToolUse = currentMessageHadToolUse;
-        currentMessageHadToolUse = false;
+        const message = isRecord(evt.message) ? evt.message : undefined;
+        beginClaudeMessage(typeof message?.id === "string" ? message.id : undefined);
       } else if (evt.type === "message_stop") {
         finishTaggedReasoningMessage();
       }
@@ -504,6 +524,21 @@ export function createCliJsonlStreamingParser(params: CliJsonlStreamingParserOpt
       });
     }
 
+    const delta = parseClaudeCliStreamingDelta({
+      backend: params.backend,
+      providerId: params.providerId,
+      parsed,
+      previousText: currentClaudeMessageText,
+    });
+    if (delta) {
+      currentClaudeMessageText = `${currentClaudeMessageText}${delta}`;
+      if (claudeStreamJson) {
+        routeTaggedReasoningDeltas(taggedReasoningRouter.push(delta));
+      } else {
+        emitClaudeVisibleText(delta);
+      }
+    }
+
     if (params.onToolUseStart || params.onToolResult) {
       dispatchGeminiCliStreamingToolEvent({
         backend: params.backend,
@@ -515,21 +550,26 @@ export function createCliJsonlStreamingParser(params: CliJsonlStreamingParserOpt
       });
     }
     if (claudeStreamJson || params.onToolUseStart || params.onToolResult) {
+      const onToolUseStart =
+        claudeStreamJson && parsed.type === "assistant"
+          ? (tool: Parameters<NonNullable<typeof params.onToolUseStart>>[0]) => {
+              sawToolUseSinceText = true;
+              currentMessageHadToolUse = true;
+              if (classifyClaudeCommentary) {
+                flushPendingClaudeCommentaryText();
+              }
+              params.onToolUseStart?.(tool);
+            }
+          : params.onToolUseStart;
       dispatchClaudeCliStreamingToolEvent({
         backend: params.backend,
         providerId: params.providerId,
         parsed,
         tracker: toolTracker,
-        onToolUseStart: params.onToolUseStart,
+        onToolUseStart,
         onToolResult: params.onToolResult,
       });
     }
-
-    const delta = parseClaudeCliStreamingDelta({
-      backend: params.backend,
-      providerId: params.providerId,
-      parsed,
-    });
     if (!delta) {
       if (
         isGeminiStreamJsonDialect(params) &&
@@ -558,13 +598,7 @@ export function createCliJsonlStreamingParser(params: CliJsonlStreamingParserOpt
           usage,
         };
       }
-      return;
     }
-    if (claudeStreamJson) {
-      routeTaggedReasoningDeltas(taggedReasoningRouter.push(delta));
-      return;
-    }
-    emitClaudeVisibleText(delta);
   };
 
   const handleJsonlLine = (rawLine: string) => {


### PR DESCRIPTION
Closes #86050

AI-assisted repair.

## What Problem This Solves

Fixes an issue where Claude CLI users saw no partial reply text in connected chat clients when Claude emitted top-level assistant snapshots during a turn.

## Why This Change Was Made

The CLI JSONL parser accepted nested text deltas but dropped valid cumulative assistant snapshots marked with `stop_reason: null`. The parser now converts only direct visible text blocks and only the new suffix through the existing delta, reasoning, commentary, tool, and terminal-result paths.

The repair stays in the shared CLI parser. It does not add a WebChat, terminal UI, provider, or config workaround.

## User Impact

Claude CLI replies can become visible while the turn is still running. Final replies remain single messages and do not repeat text already streamed.

## Evidence

- Red on exact main `ca7e9e1412884774045b8f58e0cd0372415a40f7`: a credential-free CLI child emitted one valid assistant snapshot, then the same terminal result. The real Gateway client received no pre-final delta and one final message.
- Green on exact head `706cb5c196be934dca1ad555ced781e46f60312c`: the identical input produced one pre-final delta, one final event, no post-final delta, and one assistant history message.
- Anti-cheat: the fake CLI derived `CLAUDE-SNAPSHOT-1D5EE5DA2D` from the actual runner input, and the proof checked the captured prompt.
- Focused parser, framing, reasoning, error, Gemini, tool, and runner suites: 271 tests passed across ten files.
- Tool-output isolation regression: an explicit-null snapshot with direct visible text plus nested MCP tool-result text emits only the visible text; tool content stays in the tool-result lane.
- Exact-head build and CLI smoke passed. Local formatting, Oxlint, import-cycle, dead-code, assertion, max-line, coercion, dependency, plugin-boundary, database-first, and runtime-sidecar guards passed.

Production delta: +51 lines. Test delta: +230 lines. The production growth records message-local snapshot state and preserves existing tool/commentary boundaries; no separate delivery path was added.

## Maintainer Authorization

@obviyus requested landing of this parser-owned repair. The message-local suffix tracker remains the single snapshot/delta path, and exact-head CI plus local ClawSweeper review are green.
