### PR TITLE
fix(ui): polish the mobile Inbox sheet

### DIFF
--- a/ui/src/components/sidebar-attention-layout.browser.test.ts
+++ b/ui/src/components/sidebar-attention-layout.browser.test.ts
@@ -96,7 +96,10 @@ describe.runIf("__vitest_browser__" in globalThis)("Inbox panel layout", () => {
         </div>
       </div>
     `;
-    document.body.append(fixture);
+    const shell = document.createElement("div");
+    shell.className = "shell shell--mobile-nav";
+    shell.append(fixture);
+    document.body.append(shell);
 
     await customElements.whenDefined("wa-tab-group");
     const group = fixture.querySelector<HTMLElement & { updateComplete: Promise<unknown> }>(
@@ -118,6 +121,7 @@ describe.runIf("__vitest_browser__" in globalThis)("Inbox panel layout", () => {
     const item = fixture.querySelector<HTMLElement>("[data-attention-kind]");
     const summary = fixture.querySelector<HTMLElement>(".sidebar-issues-panel__summary");
     const track = group!.shadowRoot?.querySelector<HTMLElement>(".tabs");
+    const tabs = Array.from(fixture.querySelectorAll<HTMLElement>("wa-tab.hub-tab"));
 
     expect(group?.scrollWidth).toBe(group?.clientWidth);
     expect(getComputedStyle(group!).overflowX).toBe("hidden");
@@ -130,6 +134,18 @@ describe.runIf("__vitest_browser__" in globalThis)("Inbox panel layout", () => {
     expect(Number.parseFloat(getComputedStyle(track!).borderBottomWidth)).toBeGreaterThan(0);
     expect(track!.getBoundingClientRect().width).toBeCloseTo(
       group!.getBoundingClientRect().width,
+      1,
+    );
+    const tabWidth = tabs[0]!.getBoundingClientRect().width;
+    expect(tabs.every((tab) => Math.abs(tab.getBoundingClientRect().width - tabWidth) < 1)).toBe(
+      true,
+    );
+    expect(tabs[0]!.getBoundingClientRect().left).toBeCloseTo(
+      track!.getBoundingClientRect().left,
+      1,
+    );
+    expect(tabs.at(-1)!.getBoundingClientRect().right).toBeCloseTo(
+      track!.getBoundingClientRect().right,
       1,
     );
     // Count badges render as pills separated from the tab label.
@@ -176,7 +192,7 @@ describe.runIf("__vitest_browser__" in globalThis)("Inbox panel layout", () => {
     expect(close.getBoundingClientRect().height).toBe(36);
     expect(getComputedStyle(close).borderTopWidth).toBe("1px");
     expect(getComputedStyle(close).borderRadius).toBe("9999px");
-    expect(getComputedStyle(close).backgroundColor).toBe("rgba(0, 0, 0, 0)");
+    expect(getComputedStyle(close).backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
     expect(getComputedStyle(panel).backgroundColor).toBe(getComputedStyle(header).backgroundColor);
     expect(getComputedStyle(header).backgroundColor).not.toBe(
       getComputedStyle(list).backgroundColor,

--- a/ui/src/components/sidebar-attention-layout.browser.test.ts
+++ b/ui/src/components/sidebar-attention-layout.browser.test.ts
@@ -172,10 +172,10 @@ describe.runIf("__vitest_browser__" in globalThis)("Inbox panel layout", () => {
     expect(dismiss.getBoundingClientRect().width).toBeGreaterThanOrEqual(40);
     expect(dismiss.getBoundingClientRect().height).toBeGreaterThanOrEqual(40);
     expect(dismissShown.getBoundingClientRect().height).toBeGreaterThanOrEqual(40);
-    expect(close.getBoundingClientRect().width).toBeGreaterThanOrEqual(44);
-    expect(close.getBoundingClientRect().height).toBeGreaterThanOrEqual(44);
-    expect(Number.parseFloat(getComputedStyle(close).borderTopWidth)).toBeGreaterThan(0);
-    expect(getComputedStyle(close).borderRadius).toBe("9999px");
+    expect(close.getBoundingClientRect().width).toBe(36);
+    expect(close.getBoundingClientRect().height).toBe(36);
+    expect(getComputedStyle(close).borderTopWidth).toBe("0px");
+    expect(getComputedStyle(close).backgroundColor).toBe("rgba(0, 0, 0, 0)");
     expect(getComputedStyle(panel).backgroundColor).toBe(getComputedStyle(header).backgroundColor);
     expect(getComputedStyle(header).backgroundColor).not.toBe(
       getComputedStyle(list).backgroundColor,

--- a/ui/src/components/sidebar-attention-layout.browser.test.ts
+++ b/ui/src/components/sidebar-attention-layout.browser.test.ts
@@ -174,7 +174,8 @@ describe.runIf("__vitest_browser__" in globalThis)("Inbox panel layout", () => {
     expect(dismissShown.getBoundingClientRect().height).toBeGreaterThanOrEqual(40);
     expect(close.getBoundingClientRect().width).toBe(36);
     expect(close.getBoundingClientRect().height).toBe(36);
-    expect(getComputedStyle(close).borderTopWidth).toBe("0px");
+    expect(getComputedStyle(close).borderTopWidth).toBe("1px");
+    expect(getComputedStyle(close).borderRadius).toBe("9999px");
     expect(getComputedStyle(close).backgroundColor).toBe("rgba(0, 0, 0, 0)");
     expect(getComputedStyle(panel).backgroundColor).toBe(getComputedStyle(header).backgroundColor);
     expect(getComputedStyle(header).backgroundColor).not.toBe(

--- a/ui/src/components/sidebar-attention-layout.browser.test.ts
+++ b/ui/src/components/sidebar-attention-layout.browser.test.ts
@@ -139,14 +139,19 @@ describe.runIf("__vitest_browser__" in globalThis)("Inbox panel layout", () => {
     expect(item!.getBoundingClientRect().right).toBeCloseTo(list!.getBoundingClientRect().right, 1);
   });
 
-  it("keeps mobile dismiss actions visible and touch-sized", () => {
+  it("keeps mobile controls touch-sized and the sheet header visually continuous", () => {
     const shell = document.createElement("div");
     shell.className = "shell shell--mobile-nav";
     shell.innerHTML = `
       <section class="sidebar-issues-panel">
+        <div class="sidebar-issues-panel__grabber"></div>
         <header class="sidebar-issues-panel__header">
           <button class="sidebar-issues-panel__dismiss-shown" type="button">Dismiss shown</button>
+          <button class="sidebar-brand__icon sidebar-issues-panel__mobile-close" type="button">
+            Close
+          </button>
         </header>
+        <div class="sidebar-issues-panel__list-wrap"></div>
         <div class="sidebar-issues-panel__summary">
           <button class="sidebar-issues-panel__dismiss" type="button">Dismiss</button>
         </div>
@@ -156,6 +161,10 @@ describe.runIf("__vitest_browser__" in globalThis)("Inbox panel layout", () => {
 
     const dismiss = shell.querySelector<HTMLElement>(".sidebar-issues-panel__dismiss")!;
     const dismissShown = shell.querySelector<HTMLElement>(".sidebar-issues-panel__dismiss-shown")!;
+    const close = shell.querySelector<HTMLElement>(".sidebar-issues-panel__mobile-close")!;
+    const panel = shell.querySelector<HTMLElement>(".sidebar-issues-panel")!;
+    const header = shell.querySelector<HTMLElement>(".sidebar-issues-panel__header")!;
+    const list = shell.querySelector<HTMLElement>(".sidebar-issues-panel__list-wrap")!;
     const style = getComputedStyle(dismiss);
 
     expect(style.opacity).toBe("1");
@@ -163,5 +172,13 @@ describe.runIf("__vitest_browser__" in globalThis)("Inbox panel layout", () => {
     expect(dismiss.getBoundingClientRect().width).toBeGreaterThanOrEqual(40);
     expect(dismiss.getBoundingClientRect().height).toBeGreaterThanOrEqual(40);
     expect(dismissShown.getBoundingClientRect().height).toBeGreaterThanOrEqual(40);
+    expect(close.getBoundingClientRect().width).toBeGreaterThanOrEqual(44);
+    expect(close.getBoundingClientRect().height).toBeGreaterThanOrEqual(44);
+    expect(Number.parseFloat(getComputedStyle(close).borderTopWidth)).toBeGreaterThan(0);
+    expect(getComputedStyle(close).borderRadius).toBe("9999px");
+    expect(getComputedStyle(panel).backgroundColor).toBe(getComputedStyle(header).backgroundColor);
+    expect(getComputedStyle(header).backgroundColor).not.toBe(
+      getComputedStyle(list).backgroundColor,
+    );
   });
 });

--- a/ui/src/e2e/mobile-inbox-sheet.e2e.test.ts
+++ b/ui/src/e2e/mobile-inbox-sheet.e2e.test.ts
@@ -39,6 +39,8 @@ suite.define(() => {
       startTop: number;
       finalTop: number;
       duration: number;
+      tabTrackWidth: number;
+      tabWidths: number[];
     }> = [];
 
     for (const theme of ["light", "dark"] as const) {
@@ -77,6 +79,10 @@ suite.define(() => {
         const close = element.querySelector<HTMLElement>(".sidebar-issues-panel__mobile-close")!;
         const header = element.querySelector<HTMLElement>(".sidebar-issues-panel__header")!;
         const list = element.querySelector<HTMLElement>(".sidebar-issues-panel__list-wrap")!;
+        const tabTrack = element
+          .querySelector<HTMLElement>(".sidebar-issues-panel__tabs")!
+          .shadowRoot!.querySelector<HTMLElement>(".tabs")!;
+        const tabs = Array.from(element.querySelectorAll<HTMLElement>("wa-tab.hub-tab"));
         return {
           closeBackground: getComputedStyle(close).backgroundColor,
           closeBorderRadius: getComputedStyle(close).borderRadius,
@@ -90,6 +96,8 @@ suite.define(() => {
           headerBackground: getComputedStyle(header).backgroundColor,
           listBackground: getComputedStyle(list).backgroundColor,
           startTop,
+          tabTrackWidth: tabTrack.getBoundingClientRect().width,
+          tabWidths: tabs.map((tab) => tab.getBoundingClientRect().width),
         };
       });
       results.push(result);
@@ -104,6 +112,18 @@ suite.define(() => {
               height: 30px;
               border: 0;
               background: transparent;
+            }
+            .shell--mobile-nav .sidebar-issues-panel__tabs::part(tabs) {
+              gap: var(--space-1);
+              padding-inline: 8px;
+            }
+            .shell--mobile-nav .sidebar-issues-panel__tabs wa-tab.hub-tab {
+              min-width: auto;
+              flex: 0 1 auto;
+            }
+            .shell--mobile-nav .sidebar-issues-panel__tabs wa-tab.hub-tab::part(base) {
+              width: auto;
+              justify-content: normal;
             }
             .shell--mobile-nav .sidebar-issues-panel__list-wrap { background: transparent; }
           `,
@@ -149,7 +169,11 @@ suite.define(() => {
       expect(result.closeHeight).toBe(36);
       expect(result.closeBorderWidth).toBe("1px");
       expect(result.closeBorderRadius).toBe("9999px");
-      expect(result.closeBackground).toBe("rgba(0, 0, 0, 0)");
+      expect(result.closeBackground).not.toBe("rgba(0, 0, 0, 0)");
+      expect(result.tabWidths).toHaveLength(4);
+      for (const tabWidth of result.tabWidths) {
+        expect(tabWidth).toBeCloseTo(result.tabTrackWidth / 4, 1);
+      }
     }
   });
 

--- a/ui/src/e2e/mobile-inbox-sheet.e2e.test.ts
+++ b/ui/src/e2e/mobile-inbox-sheet.e2e.test.ts
@@ -28,6 +28,7 @@ suite.define(() => {
   it("rises from the bottom with a continuous header and compact close control", async () => {
     const results: Array<{
       closeBackground: string;
+      closeBorderRadius: string;
       closeBorderWidth: string;
       closeHeight: number;
       closeWidth: number;
@@ -78,6 +79,7 @@ suite.define(() => {
         const list = element.querySelector<HTMLElement>(".sidebar-issues-panel__list-wrap")!;
         return {
           closeBackground: getComputedStyle(close).backgroundColor,
+          closeBorderRadius: getComputedStyle(close).borderRadius,
           closeBorderWidth: getComputedStyle(close).borderTopWidth,
           closeHeight: close.getBoundingClientRect().height,
           closeWidth: close.getBoundingClientRect().width,
@@ -145,7 +147,8 @@ suite.define(() => {
       expect(result.headerBackground).not.toBe(result.listBackground);
       expect(result.closeWidth).toBe(36);
       expect(result.closeHeight).toBe(36);
-      expect(result.closeBorderWidth).toBe("0px");
+      expect(result.closeBorderWidth).toBe("1px");
+      expect(result.closeBorderRadius).toBe("9999px");
       expect(result.closeBackground).toBe("rgba(0, 0, 0, 0)");
     }
   });

--- a/ui/src/e2e/mobile-inbox-sheet.e2e.test.ts
+++ b/ui/src/e2e/mobile-inbox-sheet.e2e.test.ts
@@ -1,0 +1,139 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+const viewport = { width: 390, height: 844 };
+const suite = createControlUiE2eSuite({
+  name: "Control UI mobile Inbox sheet",
+  startServerBeforeBrowser: true,
+  trackBrowserContexts: true,
+});
+
+async function setTheme(page: import("playwright").Page, theme: "dark" | "light") {
+  await page.emulateMedia({ colorScheme: theme });
+  await page.evaluate((nextTheme) => {
+    const root = document.documentElement;
+    root.dataset.themeMode = nextTheme;
+    root.dataset.themeResolved = nextTheme;
+    root.classList.toggle("wa-dark", nextTheme === "dark");
+    root.classList.toggle("wa-light", nextTheme === "light");
+    root.style.colorScheme = nextTheme;
+  }, theme);
+}
+
+suite.define(() => {
+  it("rises from the bottom with a continuous header and touch-sized close control", async () => {
+    const results: Array<{
+      closeBorderRadius: string;
+      closeHeight: number;
+      closeWidth: number;
+      easing: string;
+      sheetBackground: string;
+      headerBackground: string;
+      listBackground: string;
+      startTop: number;
+      finalTop: number;
+      duration: number;
+    }> = [];
+
+    for (const theme of ["light", "dark"] as const) {
+      const context = await suite.newBrowserContext({
+        colorScheme: theme,
+        locale: "en-US",
+        recordVideo: artifactDir
+          ? { dir: path.join(artifactDir, "video"), size: viewport }
+          : undefined,
+        reducedMotion: "no-preference",
+        serviceWorkers: "block",
+        viewport,
+      });
+      const page = await context.newPage();
+      await installMockGateway(page, { operatorScopes: ["operator.read", "operator.write"] });
+      await page.goto(`${suite.server.baseUrl}activity`);
+      await setTheme(page, theme);
+      await page.getByRole("button", { name: "Expand sidebar" }).click();
+      await page.locator(".nav-drawer").waitFor();
+      await page.locator(".sidebar-issues-button:visible").click();
+      const panel = page.locator("#sidebar-issues-panel");
+      await panel.waitFor({ state: "attached" });
+
+      const result = await panel.evaluate(async (element) => {
+        const animation = element.getAnimations().find((candidate) => {
+          const effect = candidate.effect;
+          return effect instanceof KeyframeEffect && effect.target === element;
+        });
+        if (!animation?.effect) {
+          throw new Error("Expected the mobile Inbox sheet entrance animation");
+        }
+        const timing = animation.effect.getComputedTiming();
+        const startTop = element.getBoundingClientRect().top;
+        await animation.finished;
+        const close = element.querySelector<HTMLElement>(".sidebar-issues-panel__mobile-close")!;
+        const header = element.querySelector<HTMLElement>(".sidebar-issues-panel__header")!;
+        const list = element.querySelector<HTMLElement>(".sidebar-issues-panel__list-wrap")!;
+        return {
+          closeBorderRadius: getComputedStyle(close).borderRadius,
+          closeHeight: close.getBoundingClientRect().height,
+          closeWidth: close.getBoundingClientRect().width,
+          duration: Number(timing.duration),
+          easing: getComputedStyle(element).animationTimingFunction,
+          finalTop: element.getBoundingClientRect().top,
+          sheetBackground: getComputedStyle(element).backgroundColor,
+          headerBackground: getComputedStyle(header).backgroundColor,
+          listBackground: getComputedStyle(list).backgroundColor,
+          startTop,
+        };
+      });
+      results.push(result);
+
+      if (artifactDir) {
+        await mkdir(artifactDir, { recursive: true });
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(artifactDir, `mobile-inbox-${theme}.png`),
+        });
+      }
+      await suite.closeBrowserContext(context);
+    }
+
+    for (const result of results) {
+      expect(result.startTop).toBeGreaterThan(result.finalTop + 100);
+      expect(result.duration).toBeGreaterThanOrEqual(200);
+      expect(result.duration).toBeLessThan(300);
+      expect(result.easing).toBe("cubic-bezier(0.32, 0.72, 0, 1)");
+      expect(result.sheetBackground).toBe(result.headerBackground);
+      expect(result.headerBackground).not.toBe(result.listBackground);
+      expect(result.closeWidth).toBeGreaterThanOrEqual(44);
+      expect(result.closeHeight).toBeGreaterThanOrEqual(44);
+      expect(result.closeBorderRadius).toBe("9999px");
+    }
+  });
+
+  it("removes sheet movement when reduced motion is requested", async () => {
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        reducedMotion: "reduce",
+        serviceWorkers: "block",
+        viewport,
+      },
+      async ({ page }) => {
+        await installMockGateway(page, { operatorScopes: ["operator.read", "operator.write"] });
+        await page.goto(`${suite.server.baseUrl}activity`);
+        await page.getByRole("button", { name: "Expand sidebar" }).click();
+        await page.locator(".nav-drawer").waitFor();
+        await page.locator(".sidebar-issues-button:visible").click();
+        const panel = page.locator("#sidebar-issues-panel");
+        await panel.waitFor();
+        expect(await panel.evaluate((element) => getComputedStyle(element).animationName)).toBe(
+          "none",
+        );
+      },
+    );
+  });
+});

--- a/ui/src/e2e/mobile-inbox-sheet.e2e.test.ts
+++ b/ui/src/e2e/mobile-inbox-sheet.e2e.test.ts
@@ -25,9 +25,10 @@ async function setTheme(page: import("playwright").Page, theme: "dark" | "light"
 }
 
 suite.define(() => {
-  it("rises from the bottom with a continuous header and touch-sized close control", async () => {
+  it("rises from the bottom with a continuous header and compact close control", async () => {
     const results: Array<{
-      closeBorderRadius: string;
+      closeBackground: string;
+      closeBorderWidth: string;
       closeHeight: number;
       closeWidth: number;
       easing: string;
@@ -42,6 +43,7 @@ suite.define(() => {
     for (const theme of ["light", "dark"] as const) {
       const context = await suite.newBrowserContext({
         colorScheme: theme,
+        deviceScaleFactor: 1,
         locale: "en-US",
         recordVideo: artifactDir
           ? { dir: path.join(artifactDir, "video"), size: viewport }
@@ -75,7 +77,8 @@ suite.define(() => {
         const header = element.querySelector<HTMLElement>(".sidebar-issues-panel__header")!;
         const list = element.querySelector<HTMLElement>(".sidebar-issues-panel__list-wrap")!;
         return {
-          closeBorderRadius: getComputedStyle(close).borderRadius,
+          closeBackground: getComputedStyle(close).backgroundColor,
+          closeBorderWidth: getComputedStyle(close).borderTopWidth,
           closeHeight: close.getBoundingClientRect().height,
           closeWidth: close.getBoundingClientRect().width,
           duration: Number(timing.duration),
@@ -91,11 +94,44 @@ suite.define(() => {
 
       if (artifactDir) {
         await mkdir(artifactDir, { recursive: true });
+        const previousStyle = await page.addStyleTag({
+          content: `
+            .shell--mobile-nav .sidebar-issues-panel { background: var(--bg-elevated); }
+            .shell--mobile-nav .sidebar-issues-panel__mobile-close {
+              width: 30px;
+              height: 30px;
+              border: 0;
+              background: transparent;
+            }
+            .shell--mobile-nav .sidebar-issues-panel__list-wrap { background: transparent; }
+          `,
+        });
         await page.screenshot({
           animations: "disabled",
           fullPage: true,
-          path: path.join(artifactDir, `mobile-inbox-${theme}.png`),
+          path: path.join(artifactDir, `mobile-inbox-before-${theme}.png`),
         });
+        const dismissShownBefore = await page
+          .locator(".sidebar-issues-panel__dismiss-shown")
+          .evaluate((element) => ({
+            fontSize: getComputedStyle(element).fontSize,
+            height: element.getBoundingClientRect().height,
+            lineHeight: getComputedStyle(element).lineHeight,
+          }));
+        await previousStyle.evaluate((element) => element.parentNode?.removeChild(element));
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(artifactDir, `mobile-inbox-after-${theme}.png`),
+        });
+        const dismissShownAfter = await page
+          .locator(".sidebar-issues-panel__dismiss-shown")
+          .evaluate((element) => ({
+            fontSize: getComputedStyle(element).fontSize,
+            height: element.getBoundingClientRect().height,
+            lineHeight: getComputedStyle(element).lineHeight,
+          }));
+        expect(dismissShownAfter).toEqual(dismissShownBefore);
       }
       await suite.closeBrowserContext(context);
     }
@@ -107,9 +143,10 @@ suite.define(() => {
       expect(result.easing).toBe("cubic-bezier(0.32, 0.72, 0, 1)");
       expect(result.sheetBackground).toBe(result.headerBackground);
       expect(result.headerBackground).not.toBe(result.listBackground);
-      expect(result.closeWidth).toBeGreaterThanOrEqual(44);
-      expect(result.closeHeight).toBeGreaterThanOrEqual(44);
-      expect(result.closeBorderRadius).toBe("9999px");
+      expect(result.closeWidth).toBe(36);
+      expect(result.closeHeight).toBe(36);
+      expect(result.closeBorderWidth).toBe("0px");
+      expect(result.closeBackground).toBe("rgba(0, 0, 0, 0)");
     }
   });
 

--- a/ui/src/styles/sidebar-issues.css
+++ b/ui/src/styles/sidebar-issues.css
@@ -138,7 +138,7 @@
   place-items: center;
   border: 1px solid var(--border);
   border-radius: var(--radius-full);
-  background: transparent;
+  background: color-mix(in srgb, var(--text) 3%, transparent);
   transition: transform 140ms var(--ease-out);
 }
 
@@ -193,6 +193,21 @@
   box-sizing: border-box;
   width: 100%;
   padding-inline: 8px;
+}
+
+.shell--mobile-nav .sidebar-issues-panel__tabs::part(tabs) {
+  gap: 0;
+  padding-inline: 0;
+}
+
+.shell--mobile-nav .sidebar-issues-panel__tabs wa-tab.hub-tab {
+  min-width: 0;
+  flex: 1 1 0;
+}
+
+.shell--mobile-nav .sidebar-issues-panel__tabs wa-tab.hub-tab::part(base) {
+  width: 100%;
+  justify-content: center;
 }
 
 .sidebar-issues-panel__tabs wa-tab.hub-tab::part(base) {

--- a/ui/src/styles/sidebar-issues.css
+++ b/ui/src/styles/sidebar-issues.css
@@ -136,7 +136,8 @@
   width: 36px;
   height: 36px;
   place-items: center;
-  border: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
   background: transparent;
   transition: transform 140ms var(--ease-out);
 }

--- a/ui/src/styles/sidebar-issues.css
+++ b/ui/src/styles/sidebar-issues.css
@@ -48,7 +48,8 @@
   padding-block-end: env(safe-area-inset-bottom, 0px);
   border-width: 1px 0 0;
   border-radius: var(--radius-xl) var(--radius-xl) 0 0;
-  animation: sidebar-issues-sheet-in 180ms var(--ease-out);
+  background: var(--secondary);
+  animation: sidebar-issues-sheet-in 240ms cubic-bezier(0.32, 0.72, 0, 1);
 }
 
 .shell--mobile-nav .sidebar-issues-panel__grabber {
@@ -132,7 +133,20 @@
 
 .shell--mobile-nav .sidebar-issues-panel__mobile-close {
   display: inline-grid;
+  width: 44px;
+  height: 44px;
   place-items: center;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  background: var(--bg-elevated);
+  transition:
+    background var(--duration-fast) ease,
+    color var(--duration-fast) ease,
+    transform 140ms var(--ease-out);
+}
+
+.shell--mobile-nav .sidebar-issues-panel__mobile-close:active {
+  transform: scale(0.97);
 }
 
 .shell--mobile-nav .sidebar-issues-panel__ask {
@@ -196,6 +210,7 @@
   min-height: 0;
   flex: 1 1 auto;
   overflow: hidden;
+  background: var(--bg-elevated);
 }
 
 .sidebar-issues-panel__list {

--- a/ui/src/styles/sidebar-issues.css
+++ b/ui/src/styles/sidebar-issues.css
@@ -133,16 +133,12 @@
 
 .shell--mobile-nav .sidebar-issues-panel__mobile-close {
   display: inline-grid;
-  width: 44px;
-  height: 44px;
+  width: 36px;
+  height: 36px;
   place-items: center;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-full);
-  background: var(--bg-elevated);
-  transition:
-    background var(--duration-fast) ease,
-    color var(--duration-fast) ease,
-    transform 140ms var(--ease-out);
+  border: 0;
+  background: transparent;
+  transition: transform 140ms var(--ease-out);
 }
 
 .shell--mobile-nav .sidebar-issues-panel__mobile-close:active {


### PR DESCRIPTION
Closes #132005

## What Problem This Solves

Fixes an issue where opening Inbox on mobile produced generic popover motion, a mismatched strip above the header in both themes, uneven tabs, and an ungrounded close affordance.

## Why This Change Was Made

In this PR, the mobile Inbox becomes a cohesive bottom sheet: it rises from below over 240ms with an iOS-style drawer curve, while the existing reduced-motion path removes positional movement. The grabber and header share one themed surface, the list retains its elevated surface, the four tabs divide the full width evenly, and the mobile-only close control uses the approved compact 36px circular treatment with an outline and subtle fill.

The change is limited to the mobile Inbox presentation. Desktop behavior is unchanged.

## User Impact

Mobile Inbox opens with clearer spatial continuity, consistent light and dark surfaces, evenly distributed tabs, and a compact close affordance that is easier to identify.

## Evidence

The reviewed head includes browser coverage for the bottom-up transform, 240ms drawer curve, reduced-motion behavior, themed surface continuity, equal-width tabs, and the outlined 36px close control at 390x844.

The before/after pairs below were captured in the same Chromium session with the same page state, 390x844 viewport, 1x device scale factor, 100% zoom, theme, fonts, and settled frame. The capture also verifies that `Dismiss shown` keeps identical computed height, font size, and line height.

| Before | After |
| --- | --- |
| Light: mismatched white grabber strip<br>![Light theme before](https://github.com/user-attachments/assets/a9cac182-bfc3-4069-9847-6e13eab2e398) | Light: continuous header surface, equal-width tabs, and subtly grounded close control<br>![Light theme after](https://github.com/user-attachments/assets/a890886f-7c14-492b-bca1-c29929c96f17) |
| Dark: upper strip breaks from the header<br>![Dark theme before](https://github.com/user-attachments/assets/a2753034-ae2d-4e65-8790-d06ef519d783) | Dark: continuous upper surface and compact outlined close control<br>![Dark theme after](https://github.com/user-attachments/assets/5ec2dffe-f0ea-4fcc-8c20-083c158ac818) |

Mobile motion recording, 390x844:

https://github.com/user-attachments/assets/706b795a-2f60-4fc6-9155-b5d009681bdb

Validation performed for this head:

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/mobile-inbox-sheet.e2e.test.ts ui/src/e2e/device-scope-upgrade.e2e.test.ts` (14 passed)
- `node scripts/check-changed.mjs -- ui/src/styles/sidebar-issues.css ui/src/components/sidebar-attention-layout.browser.test.ts ui/src/e2e/mobile-inbox-sheet.e2e.test.ts`
- Paired Chromium visual proof inspected in light and dark themes at 390x844, 1x scale
