### PR TITLE
fix(ui): keep board modes out of the mobile session topbar

### DIFF
--- a/ui/src/e2e/mobile-session-topbar.e2e.test.ts
+++ b/ui/src/e2e/mobile-session-topbar.e2e.test.ts
@@ -105,6 +105,7 @@ suite.define(() => {
           if (board) {
             expect(geometry.switcher).not.toBeNull();
             expect(geometry.switcher!.top).toBeGreaterThanOrEqual(geometry.row!.bottom - 0.1);
+            expect(geometry.switcher!.width).toBeLessThan(geometry.header!.width * 0.75);
           } else {
             expect(geometry.switcher).toBeNull();
             expect(geometry.header!.height).toBeCloseTo(52, 0);

--- a/ui/src/e2e/mobile-session-topbar.e2e.test.ts
+++ b/ui/src/e2e/mobile-session-topbar.e2e.test.ts
@@ -1,0 +1,118 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import {
+  chatSessionListResponse,
+  createChatFlowE2eSuite,
+  installMockGateway,
+} from "./chat-flow.test-support.ts";
+
+const suite = createChatFlowE2eSuite();
+const proofPhase = process.env.OPENCLAW_UI_PROOF_PHASE;
+const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "mobile-session-topbar");
+
+const session = {
+  key: "agent:main:session-a",
+  kind: "direct" as const,
+  label: "Coordinate the mobile session topbar redesign",
+  spawnedCwd: "/repo/openclaw",
+  createdActor: { type: "human" as const, id: "profile-ada", label: "Ada" },
+  owner: {
+    actor: { type: "human" as const, id: "profile-ada", label: "Ada" },
+  },
+  participants: [
+    { identity: { type: "profile" as const, id: "profile-bob" }, label: "Bob" },
+    { identity: { type: "agent" as const, id: "research" }, label: "Research" },
+  ],
+  participantCount: 2,
+  updatedAt: 1,
+};
+
+const boardSnapshot = {
+  sessionKey: session.key,
+  revision: 1,
+  tabs: [{ tabId: "main", title: "Main", position: 0, chatDock: "right" }],
+  widgets: [],
+};
+
+suite.define(() => {
+  for (const colorScheme of ["light", "dark"] as const) {
+    for (const board of [false, true]) {
+      it(`keeps the ${board ? "board" : "simple"} mobile topbar clean in ${colorScheme} mode`, async () => {
+        const context = await suite.newBrowserContext({
+          colorScheme,
+          locale: "en-US",
+          serviceWorkers: "block",
+          viewport: { width: 390, height: 844 },
+        });
+        const page = await context.newPage();
+        await installMockGateway(page, {
+          sessionKey: session.key,
+          presenceUsers: [
+            { self: true, id: "profile-ada", name: "Ada" },
+            { id: "profile-zoe", name: "Zoe", watchedSessions: [session.key] },
+          ],
+          featureMethods: board
+            ? ["board.get", "chat.metadata", "chat.startup"]
+            : ["chat.metadata", "chat.startup"],
+          methodResponses: {
+            "sessions.list": chatSessionListResponse([session], {
+              owners: [
+                { type: "human", id: "profile-ada", label: "Ada" },
+                { type: "human", id: "profile-zoe", label: "Zoe" },
+              ],
+            }),
+            ...(board ? { "board.get": boardSnapshot } : {}),
+          },
+        });
+
+        try {
+          await page.goto(`${suite.server.baseUrl}chat`);
+          const header = page.locator(".chat-pane__header").first();
+          await header.waitFor();
+          if (board) {
+            await page.getByRole("radiogroup", { name: "Session face" }).waitFor();
+          }
+          if (proofPhase) {
+            await mkdir(proofDir, { recursive: true });
+            await page.screenshot({
+              animations: "disabled",
+              path: path.join(
+                proofDir,
+                `${proofPhase}-${colorScheme}-${board ? "switcher" : "simple"}.png`,
+              ),
+            });
+          }
+
+          const geometry = await header.evaluate((element) => {
+            const row = element.querySelector<HTMLElement>(".chat-pane__topbar-row");
+            const people = element.querySelector<HTMLElement>(".chat-pane__people");
+            const switcher = element.querySelector<HTMLElement>(".chat-pane__face-switch");
+            const rect = (node: HTMLElement | null) =>
+              node?.getBoundingClientRect().toJSON() ?? null;
+            return {
+              header: rect(element),
+              row: rect(row),
+              people: rect(people),
+              switcher: rect(switcher),
+            };
+          });
+
+          expect(geometry.row).not.toBeNull();
+          expect(geometry.people).not.toBeNull();
+          expect(geometry.row!.right).toBeLessThanOrEqual(geometry.header!.right + 0.1);
+          expect(geometry.people!.right).toBeLessThanOrEqual(geometry.row!.right + 0.1);
+          if (board) {
+            expect(geometry.switcher).not.toBeNull();
+            expect(geometry.switcher!.top).toBeGreaterThanOrEqual(geometry.row!.bottom - 0.1);
+          } else {
+            expect(geometry.switcher).toBeNull();
+            expect(geometry.header!.height).toBeCloseTo(52, 0);
+          }
+        } finally {
+          await suite.closeBrowserContext(context);
+        }
+      });
+    }
+  }
+});

--- a/ui/src/e2e/mobile-session-topbar.e2e.test.ts
+++ b/ui/src/e2e/mobile-session-topbar.e2e.test.ts
@@ -98,14 +98,14 @@ suite.define(() => {
           const geometry = await header.evaluate((element) => {
             const row = element.querySelector<HTMLElement>(".chat-pane__topbar-row");
             const people = element.querySelector<HTMLElement>(".chat-pane__people");
-            const switcher = element.querySelector<HTMLElement>(".chat-pane__face-switch");
+            const faceSwitch = element.querySelector<HTMLElement>(".chat-pane__face-switch");
             const rect = (node: HTMLElement | null) =>
               node?.getBoundingClientRect().toJSON() ?? null;
             return {
               header: rect(element),
               row: rect(row),
               people: rect(people),
-              switcher: rect(switcher),
+              switcher: rect(faceSwitch),
             };
           });
 
@@ -122,6 +122,15 @@ suite.define(() => {
               .evaluateAll((nodes) => nodes.map((node) => node.getAttribute("value"))),
           ).toEqual(["chat", "dashboard"]);
           expect(await switcher.locator(".board-fullscreen-button").count()).toBe(0);
+          if (colorScheme === "light" && face === "chat") {
+            await page.setViewportSize({ width: 1280, height: 800 });
+            await switcher.locator('wa-radio[value="split"]').waitFor();
+            expect(
+              await header
+                .locator(".chat-pane__actions")
+                .evaluate((element) => getComputedStyle(element).marginLeft),
+            ).toBe("0px");
+          }
           if (face === "dashboard") {
             const [headerBox, boardBox] = await Promise.all([
               header.boundingBox(),

--- a/ui/src/e2e/mobile-session-topbar.e2e.test.ts
+++ b/ui/src/e2e/mobile-session-topbar.e2e.test.ts
@@ -32,13 +32,26 @@ const boardSnapshot = {
   sessionKey: session.key,
   revision: 1,
   tabs: [{ tabId: "main", title: "Main", position: 0, chatDock: "right" }],
-  widgets: [],
+  widgets: [
+    {
+      name: "progress",
+      tabId: "main",
+      title: "Progress",
+      contentKind: "html",
+      sizeW: 6,
+      sizeH: 4,
+      position: 0,
+      grantState: "pending",
+      revision: 1,
+      frameUrl: "about:blank#progress",
+    },
+  ],
 };
 
 suite.define(() => {
   for (const colorScheme of ["light", "dark"] as const) {
-    for (const board of [false, true]) {
-      it(`keeps the ${board ? "board" : "simple"} mobile topbar clean in ${colorScheme} mode`, async () => {
+    for (const face of ["chat", "dashboard"] as const) {
+      it(`keeps the mobile board topbar stable in ${colorScheme} ${face} mode`, async () => {
         const context = await suite.newBrowserContext({
           colorScheme,
           locale: "en-US",
@@ -52,9 +65,7 @@ suite.define(() => {
             { self: true, id: "profile-ada", name: "Ada" },
             { id: "profile-zoe", name: "Zoe", watchedSessions: [session.key] },
           ],
-          featureMethods: board
-            ? ["board.get", "chat.metadata", "chat.startup"]
-            : ["chat.metadata", "chat.startup"],
+          featureMethods: ["board.get", "chat.metadata", "chat.startup"],
           methodResponses: {
             "sessions.list": chatSessionListResponse([session], {
               owners: [
@@ -62,7 +73,7 @@ suite.define(() => {
                 { type: "human", id: "profile-zoe", label: "Zoe" },
               ],
             }),
-            ...(board ? { "board.get": boardSnapshot } : {}),
+            "board.get": boardSnapshot,
           },
         });
 
@@ -70,17 +81,17 @@ suite.define(() => {
           await page.goto(`${suite.server.baseUrl}chat`);
           const header = page.locator(".chat-pane__header").first();
           await header.waitFor();
-          if (board) {
-            await page.getByRole("radiogroup", { name: "Session face" }).waitFor();
+          const switcher = header.locator(".chat-pane__face-switch");
+          await switcher.waitFor();
+          if (face === "dashboard") {
+            await switcher.locator('wa-radio[value="dashboard"]').click();
+            await page.locator(".board-session-surface:not([hidden])").waitFor();
           }
           if (proofPhase) {
             await mkdir(proofDir, { recursive: true });
             await page.screenshot({
               animations: "disabled",
-              path: path.join(
-                proofDir,
-                `${proofPhase}-${colorScheme}-${board ? "switcher" : "simple"}.png`,
-              ),
+              path: path.join(proofDir, `${proofPhase}-${colorScheme}-${face}.png`),
             });
           }
 
@@ -102,13 +113,25 @@ suite.define(() => {
           expect(geometry.people).not.toBeNull();
           expect(geometry.row!.right).toBeLessThanOrEqual(geometry.header!.right + 0.1);
           expect(geometry.people!.right).toBeLessThanOrEqual(geometry.row!.right + 0.1);
-          if (board) {
-            expect(geometry.switcher).not.toBeNull();
-            expect(geometry.switcher!.top).toBeGreaterThanOrEqual(geometry.row!.bottom - 0.1);
-            expect(geometry.switcher!.width).toBeLessThan(geometry.header!.width * 0.75);
-          } else {
-            expect(geometry.switcher).toBeNull();
-            expect(geometry.header!.height).toBeCloseTo(52, 0);
+          expect(geometry.switcher).not.toBeNull();
+          expect(geometry.switcher!.top).toBeGreaterThanOrEqual(geometry.row!.bottom - 0.1);
+          expect(geometry.switcher!.width).toBeLessThan(geometry.header!.width * 0.75);
+          expect(
+            await switcher
+              .locator("wa-radio")
+              .evaluateAll((nodes) => nodes.map((node) => node.getAttribute("value"))),
+          ).toEqual(["chat", "dashboard"]);
+          expect(await switcher.locator(".board-fullscreen-button").count()).toBe(0);
+          if (face === "dashboard") {
+            const [headerBox, boardBox] = await Promise.all([
+              header.boundingBox(),
+              page
+                .locator(".board-session-surface:not([hidden]) openclaw-board-view")
+                .boundingBox(),
+            ]);
+            expect(headerBox).not.toBeNull();
+            expect(boardBox).not.toBeNull();
+            expect(boardBox!.y).toBeGreaterThanOrEqual(headerBox!.y + headerBox!.height + 11);
           }
         } finally {
           await suite.closeBrowserContext(context);

--- a/ui/src/pages/chat/board-session-surface.test.ts
+++ b/ui/src/pages/chat/board-session-surface.test.ts
@@ -82,6 +82,7 @@ describe("board session shell", () => {
     render(
       renderBoardViewSwitch({
         hasBoard: false,
+        narrow: false,
         face: "chat",
         dock: "right",
         canChangeDock: true,
@@ -110,6 +111,7 @@ describe("board session shell", () => {
     render(
       renderBoardViewSwitch({
         hasBoard: true,
+        narrow: false,
         face,
         dock,
         canChangeDock: true,
@@ -132,6 +134,7 @@ describe("board session shell", () => {
     render(
       renderBoardViewSwitch({
         hasBoard: true,
+        narrow: false,
         face: "dashboard",
         dock: "right",
         canChangeDock: false,
@@ -150,6 +153,29 @@ describe("board session shell", () => {
     expect(container.querySelector("wa-dropdown")).toBeNull();
   });
 
+  it("keeps the mobile switcher limited to Chat and Dashboard", () => {
+    const container = createContainer();
+    render(
+      renderBoardViewSwitch({
+        hasBoard: true,
+        narrow: true,
+        face: "dashboard",
+        dock: "right",
+        canChangeDock: true,
+        fullscreenControl: html`<button data-fullscreen></button>`,
+        onSelectMode: () => {},
+        onDockSideChange: () => {},
+      }),
+      container,
+    );
+
+    expect(
+      [...container.querySelectorAll("wa-radio")].map((radio) => radio.getAttribute("value")),
+    ).toEqual(["chat", "dashboard"]);
+    expect(container.querySelector("wa-dropdown")).toBeNull();
+    expect(container.querySelector("[data-fullscreen]")).toBeNull();
+  });
+
   it.each([
     ["chat", "right", true, false],
     ["dashboard", "right", true, true],
@@ -163,6 +189,7 @@ describe("board session shell", () => {
       render(
         renderBoardViewSwitch({
           hasBoard: true,
+          narrow: false,
           face,
           dock,
           canChangeDock,
@@ -197,6 +224,7 @@ describe("board session shell", () => {
     render(
       renderBoardViewSwitch({
         hasBoard: true,
+        narrow: false,
         face: "chat",
         dock: "right",
         canChangeDock: true,

--- a/ui/src/pages/chat/board-session-surface.ts
+++ b/ui/src/pages/chat/board-session-surface.ts
@@ -81,46 +81,21 @@ export function renderBoardViewSwitch(props: {
     return nothing;
   }
 
-  const mode: BoardViewMode = props.narrow
-    ? props.face
-    : props.face === "chat"
-      ? "chat"
-      : props.dock === "hidden"
-        ? "dashboard"
-        : "split";
-  const segmented = props.narrow
-    ? renderSettingsSegmented<BoardFace>({
-        value: props.face,
-        ariaLabel: t("chat.board.faceLabel"),
-        options: [
-          { value: "chat", label: t("chat.board.chatFace") },
-          { value: "dashboard", label: t("chat.board.dashboardFace") },
-        ],
-        onChange: (value) => props.onSelectMode(value),
-      })
-    : props.canChangeDock
-      ? renderSettingsSegmented<BoardViewMode>({
-          value: mode,
-          ariaLabel: t("chat.board.faceLabel"),
-          options: [
-            { value: "chat", label: t("chat.board.chatFace") },
-            { value: "split", label: t("chat.board.splitFace") },
-            { value: "dashboard", label: t("chat.board.dashboardFace") },
-          ],
-          onChange: (value) => props.onSelectMode(value),
-        })
-      : renderSettingsSegmented<BoardFace>({
-          value: props.face,
-          ariaLabel: t("chat.board.faceLabel"),
-          options: [
-            { value: "chat", label: t("chat.board.chatFace") },
-            { value: "dashboard", label: t("chat.board.dashboardFace") },
-          ],
-          onChange: (value) => props.onSelectMode(value),
-        });
+  const showSplit = !props.narrow && props.canChangeDock;
+  const mode: BoardViewMode =
+    props.face === "chat" ? "chat" : showSplit && props.dock !== "hidden" ? "split" : "dashboard";
+  const segmented = renderSettingsSegmented<BoardViewMode>({
+    value: mode,
+    ariaLabel: t("chat.board.faceLabel"),
+    options: [
+      { value: "chat", label: t("chat.board.chatFace") },
+      ...(showSplit ? [{ value: "split" as const, label: t("chat.board.splitFace") }] : []),
+      { value: "dashboard", label: t("chat.board.dashboardFace") },
+    ],
+    onChange: props.onSelectMode,
+  });
   const visibleDock = props.dock === "hidden" ? null : props.dock;
-  const showDockCaret =
-    !props.narrow && mode === "split" && props.canChangeDock && visibleDock !== null;
+  const showDockCaret = showSplit && mode === "split" && visibleDock !== null;
 
   return html`
     <div class="chat-pane__face-switch ${showDockCaret ? "chat-pane__face-switch--split" : ""}">

--- a/ui/src/pages/chat/board-session-surface.ts
+++ b/ui/src/pages/chat/board-session-surface.ts
@@ -69,6 +69,7 @@ function dockLabel(dock: BoardVisibleChatDock): string {
 
 export function renderBoardViewSwitch(props: {
   hasBoard: boolean;
+  narrow: boolean;
   face: BoardFace;
   dock: BoardTab["chatDock"];
   canChangeDock: boolean;
@@ -80,20 +81,15 @@ export function renderBoardViewSwitch(props: {
     return nothing;
   }
 
-  const mode: BoardViewMode =
-    props.face === "chat" ? "chat" : props.dock === "hidden" ? "dashboard" : "split";
-  const segmented = props.canChangeDock
-    ? renderSettingsSegmented<BoardViewMode>({
-        value: mode,
-        ariaLabel: t("chat.board.faceLabel"),
-        options: [
-          { value: "chat", label: t("chat.board.chatFace") },
-          { value: "split", label: t("chat.board.splitFace") },
-          { value: "dashboard", label: t("chat.board.dashboardFace") },
-        ],
-        onChange: (value) => props.onSelectMode(value),
-      })
-    : renderSettingsSegmented<BoardFace>({
+  const mode: BoardViewMode = props.narrow
+    ? props.face
+    : props.face === "chat"
+      ? "chat"
+      : props.dock === "hidden"
+        ? "dashboard"
+        : "split";
+  const segmented = props.narrow
+    ? renderSettingsSegmented<BoardFace>({
         value: props.face,
         ariaLabel: t("chat.board.faceLabel"),
         options: [
@@ -101,9 +97,30 @@ export function renderBoardViewSwitch(props: {
           { value: "dashboard", label: t("chat.board.dashboardFace") },
         ],
         onChange: (value) => props.onSelectMode(value),
-      });
+      })
+    : props.canChangeDock
+      ? renderSettingsSegmented<BoardViewMode>({
+          value: mode,
+          ariaLabel: t("chat.board.faceLabel"),
+          options: [
+            { value: "chat", label: t("chat.board.chatFace") },
+            { value: "split", label: t("chat.board.splitFace") },
+            { value: "dashboard", label: t("chat.board.dashboardFace") },
+          ],
+          onChange: (value) => props.onSelectMode(value),
+        })
+      : renderSettingsSegmented<BoardFace>({
+          value: props.face,
+          ariaLabel: t("chat.board.faceLabel"),
+          options: [
+            { value: "chat", label: t("chat.board.chatFace") },
+            { value: "dashboard", label: t("chat.board.dashboardFace") },
+          ],
+          onChange: (value) => props.onSelectMode(value),
+        });
   const visibleDock = props.dock === "hidden" ? null : props.dock;
-  const showDockCaret = mode === "split" && props.canChangeDock && visibleDock !== null;
+  const showDockCaret =
+    !props.narrow && mode === "split" && props.canChangeDock && visibleDock !== null;
 
   return html`
     <div class="chat-pane__face-switch ${showDockCaret ? "chat-pane__face-switch--split" : ""}">
@@ -143,7 +160,7 @@ export function renderBoardViewSwitch(props: {
             </wa-dropdown>
           `
         : nothing}
-      ${mode === "chat" ? nothing : props.fullscreenControl}
+      ${props.narrow || mode === "chat" ? nothing : props.fullscreenControl}
     </div>
   `;
 }

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -435,6 +435,7 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
           : nothing,
       faceControl: renderBoardViewSwitch({
         hasBoard: board.hasBoard,
+        narrow: this.narrow,
         face: board.face,
         dock: board.dock,
         canChangeDock: canChangeBoardDock,

--- a/ui/src/pages/chat/chat-pane-layout-render.ts
+++ b/ui/src/pages/chat/chat-pane-layout-render.ts
@@ -74,15 +74,19 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
       workspaceGit,
       sidebarLayout,
     );
+    const headerInPrimary = this.narrow || board.face === "dashboard";
     const chat = renderChat({
       ...chatProps,
       historyState: catalog ? undefined : state,
-      header: board.face === "dashboard" ? nothing : header,
+      header: headerInPrimary ? nothing : header,
     });
     // Keep this root stable across board face changes so the guarded board runtime
     // remains connected while Chat is active.
+    const boardPrimary = this.renderBoardPrimary(board, chat);
     const primary = html`<div class="chat-pane-primary-column">
-      ${board.face === "dashboard" ? header : nothing}${this.renderBoardPrimary(board, chat)}
+      ${this.narrow
+        ? html`<div class="chat-main__conversation-column">${header}${boardPrimary}</div>`
+        : html`${headerInPrimary ? header : nothing}${boardPrimary}`}
     </div>`;
     const discussion = this.buildSessionDiscussionPanel(state, state.sessionKey.trim());
     const discussionState = this.sessionDiscussionStates.get(state.sessionKey.trim());

--- a/ui/src/pages/chat/components/chat-pane-header.test.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.test.ts
@@ -391,14 +391,25 @@ describe("chat pane header", () => {
     expect(container.querySelector(".chat-pane__placement-chip")).toBeNull();
   });
 
-  it("places pane presence between the identity trail and face control", () => {
+  it("groups owner, participants, and viewers before the mobile face row", () => {
     const { container } = mountHeader({
+      narrow: true,
+      showOwnerChip: true,
+      session: row({
+        owner: { actor: { type: "human", id: "profile-ada", label: "Ada" } },
+        participants: [{ identity: { type: "profile", id: "profile-bob" }, label: "Bob" }],
+        participantCount: 1,
+      }),
       presence: html`<span data-slot="presence"></span>`,
       faceControl: html`<span data-slot="face"></span>`,
     });
-    const crumbs = container.querySelector(".chat-pane__crumbs");
-    expect(crumbs?.nextElementSibling?.getAttribute("data-slot")).toBe("presence");
-    expect(crumbs?.nextElementSibling?.nextElementSibling?.getAttribute("data-slot")).toBe("face");
+    const people = container.querySelector(".chat-pane__people");
+
+    expect(people?.querySelector("openclaw-session-owner-chip")).not.toBeNull();
+    expect(people?.querySelector(".chat-pane__participants")).not.toBeNull();
+    expect(people?.querySelector('[data-slot="presence"]')).not.toBeNull();
+    expect(container.querySelector(".chat-pane__topbar-row [data-slot=face]")).toBeNull();
+    expect(container.querySelector(".chat-pane__face-row [data-slot=face]")).not.toBeNull();
   });
 
   it("leads with the project, then a separator, then the session title", () => {

--- a/ui/src/pages/chat/components/chat-pane-header.test.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.test.ts
@@ -412,6 +412,38 @@ describe("chat pane header", () => {
     expect(container.querySelector(".chat-pane__face-row [data-slot=face]")).not.toBeNull();
   });
 
+  it("keeps desktop placement before presence and the face control", () => {
+    const { container } = mountHeader({
+      session: row({
+        placement: {
+          state: "active",
+          generation: 1,
+          createdAtMs: 1,
+          updatedAtMs: 1,
+          stateChangedAtMs: 1,
+          environmentId: "worker:one",
+          activeOwnerEpoch: 1,
+          workerBundleHash: "a".repeat(64),
+          workspaceBaseManifestRef: "base-manifest",
+          remoteWorkspaceDir: "/worker/repo",
+        },
+      }),
+      presence: html`<span data-slot="presence"></span>`,
+      faceControl: html`<span data-slot="face"></span>`,
+    });
+    const topbar = container.querySelector(".chat-pane__topbar-row");
+
+    expect(
+      [...(topbar?.children ?? [])]
+        .filter((element) =>
+          element.matches(
+            '.chat-pane__placement-control, [data-slot="presence"], [data-slot="face"]',
+          ),
+        )
+        .map((element) => element.getAttribute("data-slot") ?? "placement"),
+    ).toEqual(["placement", "presence", "face"]);
+  });
+
   it("leads with the project, then a separator, then the session title", () => {
     const { container } = mountHeader();
     const crumbs = container.querySelector(".chat-pane__crumbs");

--- a/ui/src/pages/chat/components/chat-pane-header.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.ts
@@ -418,204 +418,217 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
   const copied = props.copiedAction === "copy-path" || props.copiedAction === "copy-branch";
   const drawerLabel = props.navDrawerOpen ? t("nav.collapse") : t("nav.expand");
   const compactSessionActions = props.narrow && props.sessionMenuAction !== nothing;
+  const owner = renderStandalonePersonLink(
+    renderSessionOwnerChip(
+      props.showOwnerChip ? props.session?.owner?.actor : undefined,
+      "header",
+      props.session?.owner?.assignedAt !== undefined ? "owned" : "created",
+      props.ownerViewing,
+    ),
+    props.showOwnerChip
+      ? personActivityLink(
+          props.session?.owner?.actor.identity?.type === "profile"
+            ? props.session.owner.actor.identity.id
+            : undefined,
+          props.personActivity,
+        )
+      : null,
+  );
+  const participants =
+    props.showOwnerChip && props.session?.participants?.length
+      ? html`<openclaw-viewer-facepile
+          class="chat-pane__participants"
+          .staticParticipants=${props.session.participants}
+          .totalCount=${props.session.participantCount}
+          .maxVisible=${4}
+          .personActivity=${props.personActivity}
+          variant="session"
+        ></openclaw-viewer-facepile>`
+      : nothing;
+  const faceControl = props.faceControl ?? nothing;
 
   return html`
-    <div class="chat-pane__header" @mousedown=${beginNativeWindowDrag}>
-      ${props.mergedChrome
-        ? html`<openclaw-tooltip .content=${drawerLabel}>
-            <button
-              class="btn btn--ghost btn--icon chat-icon-btn chat-pane__nav-toggle"
-              type="button"
-              aria-label=${drawerLabel}
-              aria-expanded=${String(Boolean(props.navDrawerOpen))}
-              @click=${(event: MouseEvent) => {
-                window.dispatchEvent(
-                  new CustomEvent<ShellNavDrawerToggleDetail>(SHELL_NAV_DRAWER_TOGGLE_EVENT, {
-                    detail: { trigger: event.currentTarget as HTMLElement },
-                  }),
-                );
-              }}
-            >
-              ${icons.menu}
-            </button>
-          </openclaw-tooltip>`
-        : nothing}
-      ${props.session?.incognito
-        ? html`<span
-            class="chat-pane__incognito"
-            role="img"
-            aria-label=${t("chat.sessionHeader.incognito")}
-            title=${t("chat.sessionHeader.incognito")}
-            >${icons.lock}</span
-          >`
-        : nothing}
-      ${renderIdentityCrumbs(props, copied, copyPathLabel, copyBranchLabel)}
-      ${renderStandalonePersonLink(
-        renderSessionOwnerChip(
-          props.showOwnerChip ? props.session?.owner?.actor : undefined,
-          "header",
-          props.session?.owner?.assignedAt !== undefined ? "owned" : "created",
-          props.ownerViewing,
-        ),
-        props.showOwnerChip
-          ? personActivityLink(
-              props.session?.owner?.actor.identity?.type === "profile"
-                ? props.session.owner.actor.identity.id
-                : undefined,
-              props.personActivity,
-            )
-          : null,
-      )}
-      ${props.showOwnerChip && props.session?.participants?.length
-        ? html`<openclaw-viewer-facepile
-            class="chat-pane__participants"
-            .staticParticipants=${props.session.participants}
-            .totalCount=${props.session.participantCount}
-            .maxVisible=${4}
-            .personActivity=${props.personActivity}
-            variant="session"
-          ></openclaw-viewer-facepile>`
-        : nothing}
-      ${renderChatPanePlacement(props)} ${props.presence ?? nothing} ${props.faceControl ?? nothing}
-      ${props.sharingControl ?? nothing}
-      ${!props.catalog && props.branches.length > 1
-        ? html`
-            <openclaw-tooltip
-              .content=${props.branchSwitchDisabledReason ?? t("chat.sessionHeader.branches")}
-            >
-              <wa-dropdown
-                class="chat-pane__branches-menu"
-                placement="bottom-end"
-                @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
-                  const leafEntryId = event.detail.item.value;
-                  const branch = props.branches.find(
-                    (candidate) => candidate.leafEntryId === leafEntryId,
+    <div
+      class="chat-pane__header ${props.narrow && faceControl !== nothing
+        ? "chat-pane__header--with-face-row"
+        : ""}"
+      @mousedown=${beginNativeWindowDrag}
+    >
+      <div class="chat-pane__topbar-row">
+        ${props.mergedChrome
+          ? html`<openclaw-tooltip .content=${drawerLabel}>
+              <button
+                class="btn btn--ghost btn--icon chat-icon-btn chat-pane__nav-toggle"
+                type="button"
+                aria-label=${drawerLabel}
+                aria-expanded=${String(Boolean(props.navDrawerOpen))}
+                @click=${(event: MouseEvent) => {
+                  window.dispatchEvent(
+                    new CustomEvent<ShellNavDrawerToggleDetail>(SHELL_NAV_DRAWER_TOGGLE_EVENT, {
+                      detail: { trigger: event.currentTarget as HTMLElement },
+                    }),
                   );
-                  if (
-                    leafEntryId &&
-                    branch &&
-                    !branch.active &&
-                    !props.branchSwitchDisabledReason
-                  ) {
-                    props.onBranchSelect(leafEntryId);
-                  }
                 }}
               >
-                <button
-                  slot="trigger"
-                  class="btn btn--ghost btn--icon chat-icon-btn chat-pane__branches-trigger"
-                  type="button"
-                  ?disabled=${Boolean(props.branchSwitchDisabledReason)}
-                  aria-label=${t("chat.sessionHeader.branches")}
+                ${icons.menu}
+              </button>
+            </openclaw-tooltip>`
+          : nothing}
+        ${props.session?.incognito
+          ? html`<span
+              class="chat-pane__incognito"
+              role="img"
+              aria-label=${t("chat.sessionHeader.incognito")}
+              title=${t("chat.sessionHeader.incognito")}
+              >${icons.lock}</span
+            >`
+          : nothing}
+        ${renderIdentityCrumbs(props, copied, copyPathLabel, copyBranchLabel)}
+        <div class="chat-pane__people">${owner}${participants}${props.presence ?? nothing}</div>
+        ${renderChatPanePlacement(props)} ${props.narrow ? nothing : faceControl}
+        ${props.sharingControl ?? nothing}
+        ${!props.catalog && props.branches.length > 1
+          ? html`
+              <openclaw-tooltip
+                .content=${props.branchSwitchDisabledReason ?? t("chat.sessionHeader.branches")}
+              >
+                <wa-dropdown
+                  class="chat-pane__branches-menu"
+                  placement="bottom-end"
+                  @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
+                    const leafEntryId = event.detail.item.value;
+                    const branch = props.branches.find(
+                      (candidate) => candidate.leafEntryId === leafEntryId,
+                    );
+                    if (
+                      leafEntryId &&
+                      branch &&
+                      !branch.active &&
+                      !props.branchSwitchDisabledReason
+                    ) {
+                      props.onBranchSelect(leafEntryId);
+                    }
+                  }}
                 >
-                  ${icons.gitBranch}
+                  <button
+                    slot="trigger"
+                    class="btn btn--ghost btn--icon chat-icon-btn chat-pane__branches-trigger"
+                    type="button"
+                    ?disabled=${Boolean(props.branchSwitchDisabledReason)}
+                    aria-label=${t("chat.sessionHeader.branches")}
+                  >
+                    ${icons.gitBranch}
+                  </button>
+                  ${props.branches.map((branch) => {
+                    const relativeTime = branchRelativeTime(branch.updatedAt);
+                    return html`
+                      <wa-dropdown-item
+                        class="chat-pane__branch-item"
+                        value=${branch.leafEntryId}
+                        ?disabled=${branch.active || Boolean(props.branchSwitchDisabledReason)}
+                        data-active=${branch.active ? "true" : "false"}
+                      >
+                        <span class="chat-pane__branch-copy">
+                          <span class="chat-pane__branch-headline"
+                            >${branch.headline || t("chat.sessionHeader.untitledBranch")}</span
+                          >
+                          <span class="chat-pane__branch-meta"
+                            >${t(
+                              branch.messageCount === 1
+                                ? "chat.sessionHeader.oneMessage"
+                                : "chat.sessionHeader.messages",
+                              { count: String(branch.messageCount) },
+                            )}${relativeTime ? ` · ${relativeTime}` : ""}</span
+                          >
+                        </span>
+                        ${branch.active
+                          ? html`<span
+                              class="chat-pane__branch-active"
+                              aria-label=${t("chat.sessionHeader.activeBranch")}
+                              >${icons.check}</span
+                            >`
+                          : nothing}
+                      </wa-dropdown-item>
+                    `;
+                  })}
+                </wa-dropdown>
+              </openclaw-tooltip>
+            `
+          : nothing}
+        ${renderGatewayPicker(props)}
+        <div class="chat-pane__actions">
+          ${compactSessionActions ? nothing : props.panelActions}
+          ${compactSessionActions ? nothing : props.discussionAction}
+          ${props.catalog || compactSessionActions
+            ? nothing
+            : html`${props.diffAction} ${props.backgroundTasksAction} ${props.workspaceAction}
+              ${props.sessionRailAction}`}
+          ${props.onOpenSplitView && !compactSessionActions
+            ? html`<openclaw-tooltip .content=${t("chat.splitView.open")}>
+                <button
+                  class="btn btn--ghost btn--icon chat-icon-btn chat-open-split-view"
+                  type="button"
+                  aria-label=${t("chat.splitView.open")}
+                  @click=${props.onOpenSplitView}
+                >
+                  ${icons.columns2}
                 </button>
-                ${props.branches.map((branch) => {
-                  const relativeTime = branchRelativeTime(branch.updatedAt);
-                  return html`
-                    <wa-dropdown-item
-                      class="chat-pane__branch-item"
-                      value=${branch.leafEntryId}
-                      ?disabled=${branch.active || Boolean(props.branchSwitchDisabledReason)}
-                      data-active=${branch.active ? "true" : "false"}
-                    >
-                      <span class="chat-pane__branch-copy">
-                        <span class="chat-pane__branch-headline"
-                          >${branch.headline || t("chat.sessionHeader.untitledBranch")}</span
-                        >
-                        <span class="chat-pane__branch-meta"
-                          >${t(
-                            branch.messageCount === 1
-                              ? "chat.sessionHeader.oneMessage"
-                              : "chat.sessionHeader.messages",
-                            { count: String(branch.messageCount) },
-                          )}${relativeTime ? ` · ${relativeTime}` : ""}</span
-                        >
-                      </span>
-                      ${branch.active
-                        ? html`<span
-                            class="chat-pane__branch-active"
-                            aria-label=${t("chat.sessionHeader.activeBranch")}
-                            >${icons.check}</span
-                          >`
-                        : nothing}
-                    </wa-dropdown-item>
-                  `;
-                })}
-              </wa-dropdown>
-            </openclaw-tooltip>
-          `
-        : nothing}
-      ${renderGatewayPicker(props)}
-      <div class="chat-pane__actions">
-        ${compactSessionActions ? nothing : props.panelActions}
-        ${compactSessionActions ? nothing : props.discussionAction}
-        ${props.catalog || compactSessionActions
-          ? nothing
-          : html`${props.diffAction} ${props.backgroundTasksAction} ${props.workspaceAction}
-            ${props.sessionRailAction}`}
-        ${props.onOpenSplitView && !compactSessionActions
-          ? html`<openclaw-tooltip .content=${t("chat.splitView.open")}>
-              <button
-                class="btn btn--ghost btn--icon chat-icon-btn chat-open-split-view"
-                type="button"
-                aria-label=${t("chat.splitView.open")}
-                @click=${props.onOpenSplitView}
-              >
-                ${icons.columns2}
-              </button>
-            </openclaw-tooltip>`
-          : nothing}
-        ${!props.narrow && props.onSplitDown
-          ? html`<openclaw-tooltip .content=${t("chat.splitView.splitDown")}>
-              <button
-                class="btn btn--ghost btn--icon chat-icon-btn chat-pane__split-down"
-                type="button"
-                aria-label=${t("chat.splitView.splitDown")}
-                @click=${() => props.onSplitDown?.(props.paneId)}
-              >
-                ${icons.panelBottomOpen}
-              </button>
-            </openclaw-tooltip>`
-          : nothing}
-        ${!props.narrow && props.onSplitRight
-          ? html`<openclaw-tooltip .content=${t("chat.splitView.splitRight")}>
-              <button
-                class="btn btn--ghost btn--icon chat-icon-btn chat-pane__split-right"
-                type="button"
-                aria-label=${t("chat.splitView.splitRight")}
-                @click=${() => props.onSplitRight?.(props.paneId)}
-              >
-                ${icons.panelRightOpen}
-              </button>
-            </openclaw-tooltip>`
-          : nothing}
-        ${props.onClosePane
-          ? html`<openclaw-tooltip .content=${t("chat.splitView.closePane")}>
-              <button
-                class="btn btn--ghost btn--icon chat-icon-btn chat-pane__close-pane"
-                type="button"
-                aria-label=${t("chat.splitView.closePane")}
-                @click=${() => props.onClosePane?.(props.paneId)}
-              >
-                ${icons.x}
-              </button>
-            </openclaw-tooltip>`
-          : nothing}
-        ${props.mergedChrome && !compactSessionActions
-          ? html`<openclaw-tooltip .content=${t("chat.openCommandPalette")}>
-              <button
-                class="btn btn--ghost btn--icon chat-icon-btn chat-pane__palette-open"
-                type="button"
-                aria-label=${t("chat.openCommandPalette")}
-                @click=${() => window.dispatchEvent(new Event(COMMAND_PALETTE_OPEN_EVENT))}
-              >
-                ${icons.search}
-              </button>
-            </openclaw-tooltip>`
-          : nothing}
-        ${props.sessionMenuAction}
+              </openclaw-tooltip>`
+            : nothing}
+          ${!props.narrow && props.onSplitDown
+            ? html`<openclaw-tooltip .content=${t("chat.splitView.splitDown")}>
+                <button
+                  class="btn btn--ghost btn--icon chat-icon-btn chat-pane__split-down"
+                  type="button"
+                  aria-label=${t("chat.splitView.splitDown")}
+                  @click=${() => props.onSplitDown?.(props.paneId)}
+                >
+                  ${icons.panelBottomOpen}
+                </button>
+              </openclaw-tooltip>`
+            : nothing}
+          ${!props.narrow && props.onSplitRight
+            ? html`<openclaw-tooltip .content=${t("chat.splitView.splitRight")}>
+                <button
+                  class="btn btn--ghost btn--icon chat-icon-btn chat-pane__split-right"
+                  type="button"
+                  aria-label=${t("chat.splitView.splitRight")}
+                  @click=${() => props.onSplitRight?.(props.paneId)}
+                >
+                  ${icons.panelRightOpen}
+                </button>
+              </openclaw-tooltip>`
+            : nothing}
+          ${props.onClosePane
+            ? html`<openclaw-tooltip .content=${t("chat.splitView.closePane")}>
+                <button
+                  class="btn btn--ghost btn--icon chat-icon-btn chat-pane__close-pane"
+                  type="button"
+                  aria-label=${t("chat.splitView.closePane")}
+                  @click=${() => props.onClosePane?.(props.paneId)}
+                >
+                  ${icons.x}
+                </button>
+              </openclaw-tooltip>`
+            : nothing}
+          ${props.mergedChrome && !compactSessionActions
+            ? html`<openclaw-tooltip .content=${t("chat.openCommandPalette")}>
+                <button
+                  class="btn btn--ghost btn--icon chat-icon-btn chat-pane__palette-open"
+                  type="button"
+                  aria-label=${t("chat.openCommandPalette")}
+                  @click=${() => window.dispatchEvent(new Event(COMMAND_PALETTE_OPEN_EVENT))}
+                >
+                  ${icons.search}
+                </button>
+              </openclaw-tooltip>`
+            : nothing}
+          ${props.sessionMenuAction}
+        </div>
       </div>
+      ${props.narrow && faceControl !== nothing
+        ? html`<div class="chat-pane__face-row">${faceControl}</div>`
+        : nothing}
     </div>
   `;
 }

--- a/ui/src/pages/chat/components/chat-pane-header.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.ts
@@ -445,6 +445,7 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
           variant="session"
         ></openclaw-viewer-facepile>`
       : nothing;
+  const presence = props.presence ?? nothing;
   const faceControl = props.faceControl ?? nothing;
 
   return html`
@@ -484,9 +485,11 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
             >`
           : nothing}
         ${renderIdentityCrumbs(props, copied, copyPathLabel, copyBranchLabel)}
-        <div class="chat-pane__people">${owner}${participants}${props.presence ?? nothing}</div>
-        ${renderChatPanePlacement(props)} ${props.narrow ? nothing : faceControl}
-        ${props.sharingControl ?? nothing}
+        <div class="chat-pane__people">
+          ${owner}${participants}${props.narrow ? presence : nothing}
+        </div>
+        ${renderChatPanePlacement(props)} ${props.narrow ? nothing : presence}
+        ${props.narrow ? nothing : faceControl} ${props.sharingControl ?? nothing}
         ${!props.catalog && props.branches.length > 1
           ? html`
               <openclaw-tooltip

--- a/ui/src/styles/chat/board.css
+++ b/ui/src/styles/chat/board.css
@@ -27,7 +27,7 @@
   background: var(--panel);
 }
 
-.chat-pane__face-switch + .chat-pane__actions {
+.chat-pane__topbar-row:has(> .chat-pane__face-switch) > .chat-pane__actions {
   margin-left: 0;
 }
 

--- a/ui/src/styles/chat/composer-progress.css
+++ b/ui/src/styles/chat/composer-progress.css
@@ -70,20 +70,7 @@
     > .chat-pane__header
     .chat-pane__face-row
     .chat-pane__face-switch {
-    width: 100%;
     margin-left: 0;
-  }
-
-  .chat-main__conversation-column > .chat-pane__header .chat-pane__face-row .settings-segmented {
-    flex: 1 1 auto;
-  }
-
-  .chat-main__conversation-column
-    > .chat-pane__header
-    .chat-pane__face-row
-    .settings-segmented__btn {
-    flex: 1 1 0;
-    justify-content: center;
   }
 
   .chat-main__conversation-column > .agent-chat__search-bar {

--- a/ui/src/styles/chat/composer-progress.css
+++ b/ui/src/styles/chat/composer-progress.css
@@ -12,6 +12,10 @@
     );
   }
 
+  .chat-main__conversation-column:has(> .chat-pane__header--with-face-row) {
+    --chat-mobile-pane-header-height: 94px;
+  }
+
   .chat-main__conversation > .chat-thread {
     padding-top: calc(var(--chat-mobile-pane-header-height, 48px) + clamp(20px, 3vh, 28px));
   }
@@ -27,6 +31,59 @@
       max(var(--chat-mobile-edge-inset, 4px), var(--safe-area-right, 0px));
     overflow: visible;
     background: transparent;
+  }
+
+  .chat-main__conversation-column > .chat-pane__header .chat-pane__topbar-row {
+    display: flex;
+    width: 100%;
+    min-height: 52px;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .chat-main__conversation-column > .chat-pane__header--with-face-row {
+    flex-direction: column;
+    gap: 0;
+  }
+
+  .chat-main__conversation-column > .chat-pane__header .chat-pane__people {
+    display: flex;
+    flex: 0 0 auto;
+    align-items: center;
+  }
+
+  .chat-main__conversation-column > .chat-pane__header .chat-pane__people > * {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .chat-main__conversation-column > .chat-pane__header .chat-pane__face-row {
+    display: flex;
+    width: 100%;
+    min-height: 42px;
+    align-items: center;
+    justify-content: center;
+    padding-inline: 4px;
+  }
+
+  .chat-main__conversation-column
+    > .chat-pane__header
+    .chat-pane__face-row
+    .chat-pane__face-switch {
+    width: 100%;
+    margin-left: 0;
+  }
+
+  .chat-main__conversation-column > .chat-pane__header .chat-pane__face-row .settings-segmented {
+    flex: 1 1 auto;
+  }
+
+  .chat-main__conversation-column
+    > .chat-pane__header
+    .chat-pane__face-row
+    .settings-segmented__btn {
+    flex: 1 1 0;
+    justify-content: center;
   }
 
   .chat-main__conversation-column > .agent-chat__search-bar {

--- a/ui/src/styles/chat/composer-progress.css
+++ b/ui/src/styles/chat/composer-progress.css
@@ -16,6 +16,12 @@
     --chat-mobile-pane-header-height: 94px;
   }
 
+  .chat-main__conversation-column
+    > .chat-pane__header--with-face-row
+    + .board-session-surface:not([hidden]) {
+    padding-top: calc(var(--chat-mobile-pane-header-height) + 12px);
+  }
+
   .chat-main__conversation > .chat-thread {
     padding-top: calc(var(--chat-mobile-pane-header-height, 48px) + clamp(20px, 3vh, 28px));
   }
@@ -70,7 +76,44 @@
     > .chat-pane__header
     .chat-pane__face-row
     .chat-pane__face-switch {
+    width: min(220px, calc(100% - 24px));
+    min-height: 36px;
+    padding: 2px;
     margin-left: 0;
+    border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+    border-radius: var(--radius-full);
+    background: color-mix(in srgb, var(--panel-strong) 88%, transparent);
+    -webkit-backdrop-filter: blur(8px);
+    backdrop-filter: blur(8px);
+  }
+
+  .chat-main__conversation-column > .chat-pane__header .chat-pane__face-row .settings-segmented {
+    width: 100%;
+    min-height: 30px;
+    padding: 0;
+    border: 0;
+  }
+
+  .chat-main__conversation-column
+    > .chat-pane__header
+    .chat-pane__face-row
+    .settings-segmented::part(radios) {
+    display: flex;
+    width: 100%;
+    flex-wrap: nowrap;
+    gap: 2px;
+  }
+
+  .chat-main__conversation-column
+    > .chat-pane__header
+    .chat-pane__face-row
+    .settings-segmented__btn {
+    flex: 1 1 0;
+    min-width: 0;
+    min-height: 30px;
+    justify-content: center;
+    padding: 0 8px;
+    border-radius: var(--radius-full);
   }
 
   .chat-main__conversation-column > .agent-chat__search-bar {

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -179,6 +179,14 @@ openclaw-chat-pane {
   -webkit-user-select: none;
 }
 
+.chat-pane__topbar-row {
+  display: contents;
+}
+
+.chat-pane__face-row {
+  display: contents;
+}
+
 /* Identity trail: project, then session. One flex row owns the alignment of
    every segment, so the 26px project chip and the 12px text segments centre on
    a single line and a future parent-session segment inherits it for free. */
@@ -585,6 +593,10 @@ openclaw-chat-pane {
   display: inline-flex;
   flex: 0 0 auto;
   align-items: center;
+}
+
+.chat-pane__people {
+  display: contents;
 }
 
 .chat-pane__actions {


### PR DESCRIPTION
Closes #132006

## What Problem This Solves

Fixes an issue where board-enabled mobile sessions crowded navigation, session identity, people, and view controls into one topbar row. The mode control could also move when switching views and overlap the first Dashboard card.

## Why This Change Was Made

The canonical session header now keeps one clean primary row for navigation, project/session identity, and a single creator/participant/viewer group. Mobile board sessions use a stable, centered Chat/Dashboard pill in its own row below the topbar; Split and fullscreen remain desktop-only. Dashboard content reserves the header clearance, while Chat keeps the lightweight floating treatment over the transcript.

Desktop keeps its existing Chat/Split/Dashboard controls and layout.

## User Impact

Mobile sessions retain the circular navigation button and readable two-line identity in every board mode. Chat and Dashboard are equally sized inside a compact, legible pill that stays in the same position during mode changes, and Dashboard cards no longer begin underneath it.

## Evidence

All screenshots use a 390x844 Chromium viewport and were inspected after capture. These are the final approved states.

### Light theme

| Chat | Dashboard |
| --- | --- |
| ![Mobile Chat topbar in light theme](https://github.com/user-attachments/assets/be65306a-79c9-4830-973d-2919d5d803a2) | ![Mobile Dashboard topbar and reserved card clearance in light theme](https://github.com/user-attachments/assets/48516ab3-13e1-4ca1-8923-2fefe6bb0a2e) |

### Dark theme

| Chat | Dashboard |
| --- | --- |
| ![Mobile Chat topbar in dark theme](https://github.com/user-attachments/assets/65ef7364-d0e9-4acc-865a-cbb4722838cc) | ![Mobile Dashboard topbar and reserved card clearance in dark theme](https://github.com/user-attachments/assets/f4f4256c-f1ec-4642-bd8c-ebc63eaec3bf) |

Validation:

- `OPENCLAW_UI_PROOF_PHASE=final node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/mobile-session-topbar.e2e.test.ts` (4 passed)
- `node scripts/run-vitest.mjs ui/src/pages/chat/board-session-surface.test.ts ui/src/pages/chat/chat-pane-board.test.ts ui/src/pages/chat/components/chat-pane-header.test.ts` (97 passed)
- `pnpm ui:build` (passed)
- Targeted formatting and diff checks (passed)
- Structured review found no blocking issues.
