### PR TITLE
fix: fork from here returns an unreadable child for incognito sessions

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-message-cut.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-message-cut.test.ts
@@ -646,6 +646,51 @@ describe("SQLite session message cuts", () => {
     expect(loadSessionEntry(scope)?.lifecycleRevision).toBe("source-lifecycle-revision");
   });
 
+  it("preserves incognito identity when forking a message cut", async () => {
+    const env = { ...process.env, OPENCLAW_STATE_DIR: tempDirs.make("openclaw-incognito-fork-") };
+    const sourceKey = "agent:main:dashboard:incognito-source";
+    const targetKey = "agent:main:dashboard:incognito-target";
+    const scope = {
+      agentId,
+      env,
+      sessionId: "incognito-source",
+      sessionKey: sourceKey,
+    };
+    await upsertSessionEntryCore(scope, {
+      incognito: true,
+      lifecycleRevision: "incognito-source-revision",
+      sessionId: scope.sessionId,
+      updatedAt: Date.now(),
+    });
+    await appendTranscriptEvent(scope, {
+      type: "session",
+      id: scope.sessionId,
+      version: 3,
+      timestamp: "2026-07-18T00:00:00.000Z",
+    });
+    await appendTranscriptMessage(scope, {
+      eventId: "incognito-user",
+      message: { role: "user", content: "incognito prompt" },
+      now: Date.parse("2026-07-18T00:00:01.000Z"),
+      parentId: null,
+    });
+
+    const result = await forkSessionAtMessage({
+      agentId,
+      env,
+      entryId: "incognito-user",
+      sessionKey: sourceKey,
+      targetKey,
+    });
+
+    expect(result.status).toBe("created");
+    if (result.status !== "created") {
+      throw new Error("expected incognito fork result");
+    }
+    expect(result.entry.incognito).toBe(true);
+    expect(loadSessionEntry({ agentId, env, sessionKey: targetKey })?.incognito).toBe(true);
+  });
+
   it.each([
     ["unknown", "missing-entry"],
     ["assistant-1", "not-user-message"],

--- a/src/config/sessions/session-accessor.sqlite-message-cut.ts
+++ b/src/config/sessions/session-accessor.sqlite-message-cut.ts
@@ -521,6 +521,7 @@ function cloneMessageCutSessionEntry(params: {
     : params.currentEntry;
   return {
     ...baseEntry,
+    ...(params.currentEntry.incognito ? { incognito: true as const } : {}),
     sessionId: params.nextSessionId,
     lifecycleRevision: params.forked ? randomUUID() : params.currentEntry.lifecycleRevision,
     updatedAt: Date.now(),

--- a/src/gateway/server-methods/sessions-rewind.test.ts
+++ b/src/gateway/server-methods/sessions-rewind.test.ts
@@ -544,6 +544,58 @@ describe("session message-cut methods", () => {
     expect(mocks.readMediaBuffer).toHaveBeenCalledTimes(4);
   });
 
+  it("keeps an incognito fork addressable through the gateway", async () => {
+    const incognitoKey = "agent:main:dashboard:incognito-rewind-handler";
+    const incognitoSessionId = "incognito-rewind-handler-source";
+    const scope = {
+      agentId: "main",
+      sessionId: incognitoSessionId,
+      sessionKey: incognitoKey,
+    };
+    await upsertSessionEntryCore(scope, {
+      incognito: true,
+      lifecycleRevision: "incognito-rewind-handler-revision",
+      sessionId: incognitoSessionId,
+      updatedAt: Date.now(),
+    });
+    await appendTranscriptEvent(scope, {
+      type: "session",
+      id: incognitoSessionId,
+      version: 3,
+    });
+    await appendTranscriptMessage(scope, {
+      eventId: "incognito-user-entry",
+      message: { role: "user", content: "incognito edit me" },
+      parentId: null,
+    });
+
+    const respond = vi.fn();
+    await expectDefined(
+      sessionRewindHandlers["sessions.fork"],
+      "sessions.fork handler",
+    )({
+      req: { id: "incognito-fork-request" } as never,
+      params: { sessionKey: incognitoKey, entryId: "incognito-user-entry" },
+      respond,
+      context: context(),
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        sessionKey: expect.stringMatching(/^agent:main:dashboard:incognito-/u),
+      }),
+      undefined,
+    );
+    const payload = respond.mock.calls[0]?.[1] as { sessionKey?: string } | undefined;
+    const childKey = payload?.sessionKey ?? "";
+    expect(loadSessionEntry({ agentId: "main", sessionKey: childKey })).toMatchObject({
+      incognito: true,
+    });
+  });
+
   it.each([
     ["sessions.rewind", "user-entry", "Rewind"],
     ["sessions.branches.switch", "off-path-entry", "Branch switch"],

--- a/src/gateway/server-methods/sessions-rewind.ts
+++ b/src/gateway/server-methods/sessions-rewind.ts
@@ -19,6 +19,7 @@ import {
   type SessionMessageCutMutationResult,
 } from "../../config/sessions/session-accessor.js";
 import { MEDIA_MAX_BYTES, readMediaBuffer } from "../../media/store.js";
+import { isIncognitoSessionKey } from "../../routing/session-key.js";
 import {
   isCompetingSessionWorkAdmissionActive,
   runExclusiveSessionLifecycleMutation,
@@ -363,7 +364,12 @@ async function mutateSessionAtMessage(
         return;
       }
       const targetKey =
-        action === "fork" ? buildDashboardSessionKey(current.target.agentId) : current.canonicalKey;
+        action === "fork"
+          ? buildDashboardSessionKey(current.target.agentId, {
+              incognito:
+                current.entry.incognito === true || isIncognitoSessionKey(current.canonicalKey),
+            })
+          : current.canonicalKey;
       const expectedState = {
         sessionId: current.entry.sessionId,
         lifecycleRevision: current.entry.lifecycleRevision,

--- a/test/e2e/qa-lab/runtime/gateway-incognito-fork-proof.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-incognito-fork-proof.e2e.test.ts
@@ -1,0 +1,100 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  appendTranscriptEvent,
+  appendTranscriptMessage,
+  loadSessionEntry,
+  loadTranscriptEvents,
+  upsertSessionEntryCore,
+} from "../../../../src/config/sessions/session-accessor.js";
+import {
+  disconnectGatewayClient,
+  startGatewayWithClient,
+} from "../../../../src/gateway/test-helpers.e2e.js";
+import { installGatewayTestHooks } from "../../../../src/gateway/test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+const TOKEN = "qa-incognito-fork-proof-token";
+
+describe("Gateway incognito fork product proof", () => {
+  it("returns a readable incognito child over the live Gateway RPC", async () => {
+    const stateDir = process.env.OPENCLAW_STATE_DIR;
+    if (!stateDir) {
+      throw new Error("OPENCLAW_STATE_DIR is required");
+    }
+    const sourceKey = "agent:main:dashboard:incognito-proof-source";
+    const sourceSessionId = "incognito-proof-source";
+    const sourceScope = {
+      agentId: "main",
+      sessionKey: sourceKey,
+      sessionId: sourceSessionId,
+    };
+    await upsertSessionEntryCore(sourceScope, {
+      incognito: true,
+      sessionId: sourceSessionId,
+      updatedAt: Date.now(),
+    });
+    await appendTranscriptEvent(sourceScope, {
+      type: "session",
+      id: sourceSessionId,
+      version: 3,
+    });
+    await appendTranscriptMessage(sourceScope, {
+      eventId: "incognito-proof-prefix",
+      message: { role: "user", content: "prefix" },
+      parentId: null,
+    });
+    await appendTranscriptMessage(sourceScope, {
+      eventId: "incognito-proof-user",
+      message: { role: "user", content: "proof" },
+      parentId: "incognito-proof-prefix",
+    });
+
+    const started = await startGatewayWithClient({
+      cfg: {
+        agents: { list: [{ id: "main", default: true }] },
+        gateway: { auth: { mode: "token", token: TOKEN } },
+      },
+      configPath: path.join(stateDir, "openclaw.json"),
+      token: TOKEN,
+      clientDisplayName: "incognito-fork-proof",
+      scopes: ["operator.read", "operator.write"],
+    });
+    try {
+      const response = await started.client.request<{
+        sessionKey: string;
+        editorText?: string;
+      }>("sessions.fork", { sessionKey: sourceKey, entryId: "incognito-proof-user" });
+      const childKey = response.sessionKey;
+      const childEntry = loadSessionEntry({ agentId: "main", sessionKey: childKey });
+      const childEvents = await loadTranscriptEvents({
+        agentId: "main",
+        sessionKey: childKey,
+        sessionId: childEntry?.sessionId ?? "",
+      });
+      const childEventIds = childEvents.flatMap((event) =>
+        event && typeof event === "object" && "id" in event && typeof event.id === "string"
+          ? [event.id]
+          : [],
+      );
+      console.log(
+        JSON.stringify({
+          gatewayRpc: "sessions.fork",
+          ok: true,
+          sourceKey,
+          childKey,
+          childReadable: childEntry?.sessionId !== undefined,
+          childIncognito: childEntry?.incognito === true,
+          childEventIds,
+        }),
+      );
+      expect(childKey).toMatch(/^agent:main:dashboard:incognito-/u);
+      expect(childEntry).toMatchObject({ incognito: true });
+      expect(childEventIds).toEqual([childEntry?.sessionId, "incognito-proof-prefix"]);
+    } finally {
+      await disconnectGatewayClient(started.client);
+      await started.server.close({ reason: "incognito fork proof complete" });
+    }
+  });
+});


### PR DESCRIPTION
Related: #131954

## What Problem This Solves

Fixes an issue where users who fork an incognito dashboard session from a selected message receive a child key that cannot be loaded by the normal session accessor.

## Why This Change Was Made

Message-cut forks now generate an incognito-shaped dashboard key when the source is incognito and carry the source entry's incognito identity into the new SQLite row. Durable-session behavior and the existing storage/schema contract are unchanged.

## User Impact

The returned child remains addressable, keeps the incognito lifecycle, and retains the transcript prefix before the selected user message while leaving the source session unchanged.

## Evidence

### Automated regression

- `pnpm exec vitest run src/config/sessions/session-accessor.sqlite-message-cut.test.ts src/gateway/server-methods/sessions-rewind.test.ts`
- 54 tests passed, including direct SQLite fork identity coverage and the real `sessions.fork` gateway handler path.

### Scope and risk

- No schema, config, protocol, or migration changes.
- Only fork target-key classification and cloned session-entry identity are changed; rewind, branch switching, durable forks, and the source transcript remain unchanged.
### Real Gateway behavior proof

- Exact head: `f53b9b436dc210f401950ef36eacce00f02aace1`
- Command: `OPENCLAW_E2E_SKIP_BUILD=1 OPENCLAW_E2E_WORKERS=1 OPENCLAW_E2E_VERBOSE=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts test/e2e/qa-lab/runtime/gateway-incognito-fork-proof.e2e.test.ts`
- Harness: an ephemeral loopback Gateway with token auth and a connected `GatewayClient`; the source session and transcript were seeded in SQLite, then the real `sessions.fork` RPC was invoked.
- Redacted runtime output:

```json
{"gatewayRpc":"sessions.fork","ok":true,"sourceKey":"agent:main:dashboard:incognito-proof-source","childKey":"agent:main:dashboard:incognito-fbcfa48e-1058-48c2-bf31-d41aa0d34b6a","childReadable":true,"childIncognito":true}
```

The returned key resolved through the normal session accessor, preserved the incognito key shape, and the cloned child entry retained `incognito: true`. No external service or secret was used.
### Exact-head real Gateway proof (committed)

The proof harness is now committed at `test/e2e/qa-lab/runtime/gateway-incognito-fork-proof.e2e.test.ts` in `4b418d3c78e28adcd1f4cea89f50c1d53e54ee82`. It starts an ephemeral loopback Gateway, connects with the real `GatewayClient`, invokes `sessions.fork`, and loads the returned child through the normal session accessor and transcript reader.

Command:

```bash
OPENCLAW_E2E_SKIP_BUILD=1 OPENCLAW_E2E_WORKERS=1 OPENCLAW_E2E_VERBOSE=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts test/e2e/qa-lab/runtime/gateway-incognito-fork-proof.e2e.test.ts
```

Redacted output from the exact head:

```json
{"gatewayRpc":"sessions.fork","ok":true,"sourceKey":"agent:main:dashboard:incognito-proof-source","childKey":"agent:main:dashboard:incognito-46a19de8-db32-45df-93a7-52af0d62c605","childReadable":true,"childIncognito":true,"childEventIds":["953c3562-dd2f-4970-9f4c-f39631f01051","incognito-proof-prefix"]}
```

The child key resolved normally, retained `incognito: true`, and contained the transcript prefix before the selected message.