### PR TITLE
fix(line): give the agent the selection a postback carries

### DIFF
--- a/extensions/line/src/bot-message-context.test.ts
+++ b/extensions/line/src/bot-message-context.test.ts
@@ -374,6 +374,57 @@ describe("buildLineMessageContext", () => {
     expect(context?.ctxPayload.CommandAuthorized).toBe(true);
   });
 
+  // Shapes observed on a live channel: a datetime picker tapped in LINE for macOS,
+  // and LINE's documented rich-menu switch payload.
+  const postbackSelectionCases: {
+    name: string;
+    postback: PostbackEvent["postback"];
+    expected: string;
+  }[] = [
+    {
+      name: "datetime picker",
+      postback: { data: "probe_deadline", params: { datetime: "2026-08-15T01:48" } },
+      expected: "probe_deadline datetime=2026-08-15T01:48",
+    },
+    {
+      name: "rich menu switch",
+      postback: {
+        data: "menu",
+        params: { status: "SUCCESS", newRichMenuAliasId: "richmenu-alias-b" },
+      },
+      expected: "menu newRichMenuAliasId=richmenu-alias-b status=SUCCESS",
+    },
+    {
+      name: "picker dismissed without a value",
+      postback: { data: "probe_deadline", params: { date: "   " } },
+      expected: "probe_deadline",
+    },
+    {
+      name: "device control",
+      postback: { data: "line.action=volume_up&line.device=Living%20Room" },
+      expected: "line action volume_up device Living Room",
+    },
+  ];
+
+  it.each(postbackSelectionCases)(
+    "gives the agent what the user picked in a $name postback",
+    async ({ postback, expected }) => {
+      const event = createPostbackEvent({ type: "user", userId: "user-pb" }, { postback });
+
+      const context = await buildLinePostbackContext({
+        event,
+        cfg,
+        account,
+        commandAuthorized: true,
+      });
+
+      expect(context?.ctxPayload.BodyForAgent).toBe(expected);
+      // The callback token stays verbatim so command gating keeps matching on it.
+      expect(context?.ctxPayload.RawBody).toBe(postback.data);
+      expect(context?.ctxPayload.CommandBody).toBe(postback.data);
+    },
+  );
+
   it("sets CommandAuthorized=false when not authorized", async () => {
     const event = createMessageEvent({ type: "user", userId: "user-noauth" });
 

--- a/extensions/line/src/bot-message-context.ts
+++ b/extensions/line/src/bot-message-context.ts
@@ -34,6 +34,7 @@ import type { ResolvedLineAccount } from "./types.js";
 type EventSource = webhook.Source | undefined;
 type MessageEvent = webhook.MessageEvent;
 type PostbackEvent = webhook.PostbackEvent;
+type PostbackContent = PostbackEvent["postback"];
 type StickerEventMessage = webhook.StickerMessageContent;
 
 interface MediaRef {
@@ -206,6 +207,29 @@ function describeStickerKeywords(sticker: StickerEventMessage): string {
   }
 
   return "";
+}
+
+function describeLineDeviceAction(data: string): string {
+  const searchParams = new URLSearchParams(data);
+  const action = searchParams.get("line.action") ?? "";
+  const device = searchParams.get("line.device");
+  return device ? `line action ${action} device ${device}` : `line action ${action}`;
+}
+
+// postback.data is only the opaque token the bot sent; LINE returns what the user
+// actually chose in postback.params (a datetime picker's date/time/datetime, a rich
+// menu switch's alias and status), sorted here so one selection is always the same
+// prompt bytes. Without it a completed pick reaches the agent as a bare token.
+function describeLinePostback(postback: PostbackContent, data: string): string {
+  const described = data.includes("line.action=") ? describeLineDeviceAction(data) : data;
+  const selection = Object.entries(postback.params ?? {})
+    .toSorted(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+    .flatMap(([key, value]) => {
+      const picked = normalizeOptionalString(value);
+      return picked ? [`${key}=${picked}`] : [];
+    })
+    .join(" ");
+  return selection ? `${described} ${selection}` : described;
 }
 
 function extractMessageText(message: MessageEvent["message"]): string {
@@ -529,17 +553,13 @@ export async function buildLinePostbackContext(params: {
   });
 
   const timestamp = event.timestamp;
-  const rawData = event.postback?.data?.trim() ?? "";
-  if (!rawData) {
+  // parseLineWebhookBody casts JSON straight to the SDK type, so keep reading the
+  // payload defensively even though PostbackContent declares data as required.
+  const rawBody = event.postback?.data?.trim() ?? "";
+  if (!rawBody) {
     return null;
   }
-  let rawBody = rawData;
-  if (rawData.includes("line.action=")) {
-    const searchParams = new URLSearchParams(rawData);
-    const action = searchParams.get("line.action") ?? "";
-    const device = searchParams.get("line.device");
-    rawBody = device ? `line action ${action} device ${device}` : `line action ${action}`;
-  }
+  const agentBody = describeLinePostback(event.postback, rawBody);
 
   const messageSid = event.replyToken ? `postback:${event.replyToken}` : `postback:${timestamp}`;
   const finalized = await finalizeLineInboundContext({
@@ -549,6 +569,7 @@ export async function buildLinePostbackContext(params: {
     route,
     source: { userId, groupId, roomId, isGroup, peerId },
     rawBody,
+    agentBody,
     timestamp,
     messageSid,
     commandAuthorized,

--- a/extensions/line/src/bot-message-context.ts
+++ b/extensions/line/src/bot-message-context.ts
@@ -34,7 +34,6 @@ import type { ResolvedLineAccount } from "./types.js";
 type EventSource = webhook.Source | undefined;
 type MessageEvent = webhook.MessageEvent;
 type PostbackEvent = webhook.PostbackEvent;
-type PostbackContent = PostbackEvent["postback"];
 type StickerEventMessage = webhook.StickerMessageContent;
 
 interface MediaRef {
@@ -207,29 +206,6 @@ function describeStickerKeywords(sticker: StickerEventMessage): string {
   }
 
   return "";
-}
-
-function describeLineDeviceAction(data: string): string {
-  const searchParams = new URLSearchParams(data);
-  const action = searchParams.get("line.action") ?? "";
-  const device = searchParams.get("line.device");
-  return device ? `line action ${action} device ${device}` : `line action ${action}`;
-}
-
-// postback.data is only the opaque token the bot sent; LINE returns what the user
-// actually chose in postback.params (a datetime picker's date/time/datetime, a rich
-// menu switch's alias and status), sorted here so one selection is always the same
-// prompt bytes. Without it a completed pick reaches the agent as a bare token.
-function describeLinePostback(postback: PostbackContent, data: string): string {
-  const described = data.includes("line.action=") ? describeLineDeviceAction(data) : data;
-  const selection = Object.entries(postback.params ?? {})
-    .toSorted(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
-    .flatMap(([key, value]) => {
-      const picked = normalizeOptionalString(value);
-      return picked ? [`${key}=${picked}`] : [];
-    })
-    .join(" ");
-  return selection ? `${described} ${selection}` : described;
 }
 
 function extractMessageText(message: MessageEvent["message"]): string {
@@ -553,13 +529,27 @@ export async function buildLinePostbackContext(params: {
   });
 
   const timestamp = event.timestamp;
-  // parseLineWebhookBody casts JSON straight to the SDK type, so keep reading the
-  // payload defensively even though PostbackContent declares data as required.
   const rawBody = event.postback?.data?.trim() ?? "";
   if (!rawBody) {
     return null;
   }
-  const agentBody = describeLinePostback(event.postback, rawBody);
+  let agentBody = rawBody;
+  if (rawBody.includes("line.action=")) {
+    const searchParams = new URLSearchParams(rawBody);
+    const action = searchParams.get("line.action") ?? "";
+    const device = searchParams.get("line.device");
+    agentBody = device ? `line action ${action} device ${device}` : `line action ${action}`;
+  }
+  // LINE returns picker and rich-menu choices separately from callback data.
+  // Sort them for stable prompt bytes, but keep rawBody unchanged for command auth.
+  for (const [key, value] of Object.entries(event.postback.params ?? {}).toSorted(
+    ([left], [right]) => (left < right ? -1 : left > right ? 1 : 0),
+  )) {
+    const picked = normalizeOptionalString(value);
+    if (picked) {
+      agentBody += ` ${key}=${picked}`;
+    }
+  }
 
   const messageSid = event.replyToken ? `postback:${event.replyToken}` : `postback:${timestamp}`;
   const finalized = await finalizeLineInboundContext({


### PR DESCRIPTION
Fixes #132000

## What Problem This Solves

LINE sends a picker or rich-menu choice in `postback.params`, separate from the callback token in `postback.data`.

OpenClaw read only the callback token. A user could confirm a datetime in LINE, but the agent received only `probe_deadline` and could not see the selected value.

## Why This Change Was Made

`buildLinePostbackContext` now appends sorted, nonblank `postback.params` entries to `agentBody`.

The command boundary stays unchanged:

- `agentBody` contains the callback token and the user's selection.
- `rawBody` remains the original callback token.
- `commandBody` continues to derive from `rawBody`.

This is one generic projection for every LINE postback parameter shape. It covers datetime picker `date`, `time`, and `datetime` values plus rich-menu `newRichMenuAliasId` and `status` values without action-specific parsing.

The maintainer repair removed two one-use formatter helpers from the contributor patch. Final production change: +17/−6, net +11. Regression tests: +51/−0.

## User Impact

| Action | Before | After |
| --- | --- | --- |
| Pick a datetime | `probe_deadline` | `probe_deadline datetime=2026-08-15T01:48` |
| Switch a rich menu | `menu` | `menu newRichMenuAliasId=richmenu-alias-b status=SUCCESS` |
| Dismiss a picker | `probe_deadline` | `probe_deadline` |
| Use a device callback | Agent sees readable device action, but command data is mutated | Agent sees the same readable action while command data stays verbatim |

## Evidence

### Real LINE event

The reporter sent a valid datetime-picker quick reply, selected a datetime in LINE for macOS, and captured the signed postback. LINE supplied:

```json
{"data":"probe_deadline","params":{"datetime":"2026-08-15T01:48"}}
```

The pre-fix turn recorded `probe_deadline`. Replaying that event through the contributor patch recorded `probe_deadline datetime=2026-08-15T01:48`.

### Exact-head signed replay

A maintainer replayed one byte-identical signed, capture-shaped postback through the real LINE HTTP signature and parsing path on both revisions.

- Main `4bc4ad35fa1cc665070f111a9f9e821689937835`: HTTP 200; model body `probe_deadline`.
- Head `04ea53a33ffdee32c8317656fad11b21e8de614d`: HTTP 200; model body `probe_deadline datetime=2026-08-15T01:48`.
- Both runs used payload SHA-256 `9ba1dc184ece35ef788927e57c3961c504b0049ab07dd23e3c8786fe04b559eb`.
- Both runs kept raw and command bodies as `probe_deadline`.

### Regression proof

The owner-boundary regression failed on main for the intended reasons:

- datetime selection missing from the agent body;
- rich-menu selection missing from the agent body;
- device callback data changed before command handling.

The repaired exact head passes:

- `node scripts/run-vitest.mjs extensions/line/src/bot-message-context.test.ts extensions/line/src/bot-handlers.test.ts` — 57 tests.
- `node scripts/run-vitest.mjs extensions/line` — 580 tests in 38 files.
- Focused format and type-aware Oxlint.
- Conflict, max-lines, assertion-safety, coercion-helper, plugin-boundary, and import-cycle checks.

Hosted CI owns the extension production and test type checks for this head.
