### PR TITLE
fix(ui): use full width for settings on mobile

### DIFF
--- a/scripts/lib/tsgo-core-test-shards.mts
+++ b/scripts/lib/tsgo-core-test-shards.mts
@@ -37,9 +37,14 @@ export const TSGO_CORE_TEST_SHARDS = [
   { name: "services", group: "src", config: "test/tsconfig/tsconfig.core.test.services.json" },
   { name: "other", group: "src", config: "test/tsconfig/tsconfig.core.test.other.json" },
   {
-    name: "ui-pages-e2e",
+    name: "ui-pages",
     group: "ui",
-    config: "test/tsconfig/tsconfig.core.test.ui-pages-e2e.json",
+    config: "test/tsconfig/tsconfig.core.test.ui-pages.json",
+  },
+  {
+    name: "ui-e2e",
+    group: "ui",
+    config: "test/tsconfig/tsconfig.core.test.ui-e2e.json",
   },
   { name: "ui-other", group: "ui", config: "test/tsconfig/tsconfig.core.test.ui-other.json" },
   {

--- a/test/tsconfig/tsconfig.core.test.ui-e2e.json
+++ b/test/tsconfig/tsconfig.core.test.ui-e2e.json
@@ -1,12 +1,10 @@
 {
   "extends": "./tsconfig.core.test.shard.json",
   "compilerOptions": {
-    "tsBuildInfoFile": "../../.artifacts/tsgo-cache/core-test-ui-pages-e2e.tsbuildinfo"
+    "tsBuildInfoFile": "../../.artifacts/tsgo-cache/core-test-ui-e2e.tsbuildinfo"
   },
   "include": [
     "../../ui/src/main.ts",
-    "../../ui/src/pages/**/*.test.ts",
-    "../../ui/src/pages/**/*.test.tsx",
     "../../ui/src/e2e/**/*.test.ts",
     "../../ui/src/e2e/**/*.test.tsx"
   ]

--- a/test/tsconfig/tsconfig.core.test.ui-pages.json
+++ b/test/tsconfig/tsconfig.core.test.ui-pages.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.core.test.shard.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "../../.artifacts/tsgo-cache/core-test-ui-pages.tsbuildinfo"
+  },
+  "include": [
+    "../../ui/src/main.ts",
+    "../../ui/src/pages/**/*.test.ts",
+    "../../ui/src/pages/**/*.test.tsx"
+  ]
+}

--- a/ui/src/e2e/appearance-control-layout.e2e.test.ts
+++ b/ui/src/e2e/appearance-control-layout.e2e.test.ts
@@ -71,7 +71,7 @@ suite.define(() => {
         const theme = page.locator("#settings-appearance-theme");
         const grid = theme.locator(".settings-theme-grid");
         for (const [width, expectedColumns] of [
-          [560, 2],
+          [560, 3],
           [320, 1],
         ] as const) {
           await page.setViewportSize({ height: 1000, width });

--- a/ui/src/e2e/settings-layout.e2e.test.ts
+++ b/ui/src/e2e/settings-layout.e2e.test.ts
@@ -98,6 +98,8 @@ const settingsRowRoutes = [
   "debug",
 ] as const satisfies readonly RouteId[];
 
+const mobileSettingsRoutes = [...settingsRowRoutes, "logs"] as const satisfies readonly RouteId[];
+
 const responsiveViewports = [
   { width: 390, height: 844 },
   { width: 768, height: 1024 },
@@ -106,66 +108,94 @@ const responsiveViewports = [
 ] as const;
 
 suite.define(() => {
-  it("uses the full settings content width on mobile without changing desktop insets", async () => {
+  it("aligns every mobile settings page with the topbar content", async () => {
     const context = await suite.browser.newContext({
       colorScheme: "dark",
       locale: "en-US",
       serviceWorkers: "block",
       viewport: { height: 844, width: 390 },
     });
-    const page = await context.newPage();
+    let page = await context.newPage();
     await installMockGateway(page);
 
     try {
+      const readShellInsets = (route: RouteId) =>
+        page.evaluate((activeRoute) => {
+          const content = document.querySelector<HTMLElement>("main.content");
+          const topbar = document.querySelector<HTMLElement>(".topbar");
+          if (!content || !topbar) {
+            throw new Error(`${activeRoute} settings shell did not render`);
+          }
+          return {
+            contentPaddingInline: Math.round(
+              Number.parseFloat(getComputedStyle(content).paddingLeft),
+            ),
+            topbarPaddingInline: Math.round(
+              Number.parseFloat(getComputedStyle(topbar).paddingLeft),
+            ),
+          };
+        }, route);
+
+      const layouts = [];
+      for (const route of mobileSettingsRoutes) {
+        const pathname = pathForRoute(route);
+        await page.goto(new URL(pathname, suite.server.baseUrl).toString());
+        await waitForControlUiRoute(page, { pathname, routeId: route });
+        await page.waitForTimeout(200);
+        layouts.push({ route, ...(await readShellInsets(route)) });
+      }
+      for (const layout of layouts) {
+        if (layout.contentPaddingInline !== 12 || layout.topbarPaddingInline !== 12) {
+          throw new Error(`${layout.route} settings shell alignment: ${JSON.stringify(layout)}`);
+        }
+      }
+
+      for (const route of ["appearance", "model-setup"] as const) {
+        await page.close();
+        page = await context.newPage();
+        await installMockGateway(page);
+        const pathname = pathForRoute(route);
+        await page.goto(new URL(pathname, suite.server.baseUrl).toString());
+        await waitForControlUiRoute(page, { pathname, routeId: route });
+        const header = page.locator(".content-header").last();
+        const workspace = page.locator(".settings-workspace").last();
+        await Promise.all([header.waitFor(), workspace.waitFor()]);
+        await expect
+          .poll(async () => {
+            const [headerBox, workspaceBox] = await Promise.all([
+              header.boundingBox(),
+              workspace.boundingBox(),
+            ]);
+            return headerBox && workspaceBox
+              ? {
+                  headerLeft: Math.round(headerBox.x),
+                  headerTop: Math.round(headerBox.y),
+                  workspaceLeft: Math.round(workspaceBox.x),
+                  workspaceRight: Math.round(workspaceBox.x + workspaceBox.width),
+                }
+              : null;
+          })
+          .toEqual({ headerLeft: 12, headerTop: 70, workspaceLeft: 12, workspaceRight: 378 });
+      }
+
+      await page.setViewportSize({ height: 900, width: 1440 });
       await page.goto(`${suite.server.baseUrl}settings/appearance`);
       await waitForControlUiRoute(page, {
         pathname: "/settings/appearance",
         routeId: "appearance",
       });
-
-      const readInsets = () =>
-        page.evaluate(() => {
-          const header = document.querySelector<HTMLElement>(".content-header");
-          const workspace = document.querySelector<HTMLElement>(".settings-workspace");
-          const settingsPage = document.querySelector<HTMLElement>(".settings-page");
-          const group = document.querySelector<HTMLElement>(".settings-group");
-          const configContent = document.querySelector<HTMLElement>(".config-content");
-          if (!header || !workspace || !settingsPage || !group || !configContent) {
-            throw new Error("Appearance settings layout did not render");
-          }
-          const headerBox = header.getBoundingClientRect();
-          const workspaceBox = workspace.getBoundingClientRect();
-          const pageBox = settingsPage.getBoundingClientRect();
-          const groupBox = group.getBoundingClientRect();
-          return {
-            configPadding: Math.round(
-              Number.parseFloat(getComputedStyle(configContent).paddingLeft),
-            ),
-            groupInset: Math.round(groupBox.x - workspaceBox.x),
-            headerPadding: Math.round(Number.parseFloat(getComputedStyle(header).paddingLeft)),
-            pagePadding: Math.round(Number.parseFloat(getComputedStyle(settingsPage).paddingLeft)),
-            pageInset: Math.round(pageBox.x - workspaceBox.x),
-            pageWidthDelta: Math.round(workspaceBox.width - pageBox.width),
-            headerWidthDelta: Math.round(workspaceBox.width - headerBox.width),
-          };
-        });
-
-      await expect.poll(readInsets).toEqual({
-        configPadding: 0,
-        groupInset: 0,
-        headerPadding: 0,
-        pagePadding: 0,
-        pageInset: 0,
-        pageWidthDelta: 0,
-        headerWidthDelta: 0,
-      });
-
-      await page.setViewportSize({ height: 900, width: 1440 });
-      await expect.poll(readInsets).toMatchObject({
-        configPadding: 22,
-        headerPadding: 16,
-        pagePadding: 16,
-      });
+      const desktopInsets = await page.evaluate(() => ({
+        configPadding: Number.parseFloat(
+          getComputedStyle(document.querySelector<HTMLElement>(".config-content")!).paddingLeft,
+        ),
+        headerPadding: Number.parseFloat(
+          getComputedStyle(document.querySelector<HTMLElement>(".content-header")!).paddingLeft,
+        ),
+        pagePadding: Number.parseFloat(
+          getComputedStyle(document.querySelector<HTMLElement>(".settings-page")!).paddingLeft,
+        ),
+      }));
+      expect(desktopInsets).toEqual({ configPadding: 22, headerPadding: 16, pagePadding: 16 });
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/settings-layout.e2e.test.ts
+++ b/ui/src/e2e/settings-layout.e2e.test.ts
@@ -157,7 +157,7 @@ suite.define(() => {
         const pathname = pathForRoute(route);
         await page.goto(new URL(pathname, suite.server.baseUrl).toString());
         await waitForControlUiRoute(page, { pathname, routeId: route });
-        await page.locator(".settings-workspace").last().waitFor();
+        await page.locator(".settings-workspace").last().waitFor({ state: "attached" });
         layouts.push({ route, ...(await readShellInsets(route)) });
       }
       for (const layout of layouts) {
@@ -171,7 +171,7 @@ suite.define(() => {
         await page.goto(new URL(pathname, suite.server.baseUrl).toString());
         await waitForControlUiRoute(page, { pathname, routeId: route });
         const settingsPage = page.locator(".settings-page").last();
-        await settingsPage.waitFor();
+        await settingsPage.waitFor({ state: "attached" });
         expect(
           await settingsPage.evaluate((element) =>
             Math.round(Number.parseFloat(getComputedStyle(element).paddingLeft)),

--- a/ui/src/e2e/settings-layout.e2e.test.ts
+++ b/ui/src/e2e/settings-layout.e2e.test.ts
@@ -158,24 +158,46 @@ suite.define(() => {
         await page.goto(new URL(pathname, suite.server.baseUrl).toString());
         await waitForControlUiRoute(page, { pathname, routeId: route });
         const header = page.locator(".content-header").last();
+        const title = header.locator(".page-title");
         const workspace = page.locator(".settings-workspace").last();
-        await Promise.all([header.waitFor(), workspace.waitFor()]);
+        const contentSurface = workspace.locator(
+          route === "appearance" ? ".settings-page" : ".model-setup",
+        );
+        await Promise.all([
+          header.waitFor(),
+          title.waitFor(),
+          workspace.waitFor(),
+          contentSurface.waitFor(),
+        ]);
         await expect
           .poll(async () => {
-            const [headerBox, workspaceBox] = await Promise.all([
+            const [headerBox, titleBox, workspaceBox, contentSurfaceBox] = await Promise.all([
               header.boundingBox(),
+              title.boundingBox(),
               workspace.boundingBox(),
+              contentSurface.boundingBox(),
             ]);
-            return headerBox && workspaceBox
+            return headerBox && titleBox && workspaceBox && contentSurfaceBox
               ? {
                   headerLeft: Math.round(headerBox.x),
                   headerTop: Math.round(headerBox.y),
+                  titleLeft: Math.round(titleBox.x),
                   workspaceLeft: Math.round(workspaceBox.x),
                   workspaceRight: Math.round(workspaceBox.x + workspaceBox.width),
+                  contentLeft: Math.round(contentSurfaceBox.x),
+                  contentRight: Math.round(contentSurfaceBox.x + contentSurfaceBox.width),
                 }
               : null;
           })
-          .toEqual({ headerLeft: 12, headerTop: 70, workspaceLeft: 12, workspaceRight: 378 });
+          .toEqual({
+            contentLeft: 12,
+            contentRight: 378,
+            headerLeft: 12,
+            headerTop: 70,
+            titleLeft: 12,
+            workspaceLeft: 12,
+            workspaceRight: 378,
+          });
       }
 
       await page.setViewportSize({ height: 900, width: 1440 });

--- a/ui/src/e2e/settings-layout.e2e.test.ts
+++ b/ui/src/e2e/settings-layout.e2e.test.ts
@@ -100,6 +100,22 @@ const settingsRowRoutes = [
 
 const mobileSettingsRoutes = [...settingsRowRoutes, "logs"] as const satisfies readonly RouteId[];
 
+const mobileStandaloneSettingsPageRoutes = [
+  "sessions",
+  "worktrees",
+  "usage",
+  "cron",
+  "tasks",
+  "memory-import",
+] as const satisfies readonly RouteId[];
+
+const mobileGeometryCases = [
+  { route: "appearance", contentSelector: ".settings-page" },
+  { route: "model-setup", contentSelector: ".model-setup" },
+  { route: "memory", contentSelector: ".memory-page__panel .settings-page" },
+  { route: "plugins", contentSelector: ".settings-page" },
+] as const satisfies ReadonlyArray<{ route: RouteId; contentSelector: string }>;
+
 const responsiveViewports = [
   { width: 390, height: 844 },
   { width: 768, height: 1024 },
@@ -141,7 +157,7 @@ suite.define(() => {
         const pathname = pathForRoute(route);
         await page.goto(new URL(pathname, suite.server.baseUrl).toString());
         await waitForControlUiRoute(page, { pathname, routeId: route });
-        await page.waitForTimeout(200);
+        await page.locator(".settings-workspace").last().waitFor();
         layouts.push({ route, ...(await readShellInsets(route)) });
       }
       for (const layout of layouts) {
@@ -150,7 +166,21 @@ suite.define(() => {
         }
       }
 
-      for (const route of ["appearance", "model-setup"] as const) {
+      for (const route of mobileStandaloneSettingsPageRoutes) {
+        const pathname = pathForRoute(route);
+        await page.goto(new URL(pathname, suite.server.baseUrl).toString());
+        await waitForControlUiRoute(page, { pathname, routeId: route });
+        const settingsPage = page.locator(".settings-page").last();
+        await settingsPage.waitFor();
+        expect(
+          await settingsPage.evaluate((element) =>
+            Math.round(Number.parseFloat(getComputedStyle(element).paddingLeft)),
+          ),
+          `${route} mobile page-owned inset`,
+        ).toBe(12);
+      }
+
+      for (const { route, contentSelector } of mobileGeometryCases) {
         await page.close();
         page = await context.newPage();
         await installMockGateway(page);
@@ -160,9 +190,7 @@ suite.define(() => {
         const header = page.locator(".content-header").last();
         const title = header.locator(".page-title");
         const workspace = page.locator(".settings-workspace").last();
-        const contentSurface = workspace.locator(
-          route === "appearance" ? ".settings-page" : ".model-setup",
-        );
+        const contentSurface = workspace.locator(contentSelector);
         await Promise.all([
           header.waitFor(),
           title.waitFor(),
@@ -199,6 +227,42 @@ suite.define(() => {
             workspaceRight: 378,
           });
       }
+
+      await page.goto(`${suite.server.baseUrl}settings/appearance`);
+      await waitForControlUiRoute(page, {
+        pathname: "/settings/appearance",
+        routeId: "appearance",
+      });
+      await page.locator(".topbar-nav-toggle").click();
+      await expect
+        .poll(() => page.locator(".shell").getAttribute("class"))
+        .toContain("shell--nav-drawer-open");
+      const settingsSidebar = page.locator(".settings-sidebar");
+      await settingsSidebar.getByRole("link", { name: "Ask OpenClaw" }).click();
+      await waitForControlUiRoute(page, { pathname: "/custodian", routeId: "custodian" });
+      const custodianInsets = await page.evaluate(() => {
+        const content = document.querySelector<HTMLElement>("main.content");
+        const column = document.querySelector<HTMLElement>(".custodian__column");
+        const topbar = document.querySelector<HTMLElement>(".topbar");
+        if (!content || !column || !topbar) {
+          throw new Error("Custodian settings route did not render");
+        }
+        const columnBox = column.getBoundingClientRect();
+        return {
+          columnLeft: Math.round(columnBox.left),
+          columnRight: Math.round(columnBox.right),
+          contentPaddingInline: Math.round(
+            Number.parseFloat(getComputedStyle(content).paddingLeft),
+          ),
+          topbarPaddingInline: Math.round(Number.parseFloat(getComputedStyle(topbar).paddingLeft)),
+        };
+      });
+      expect(custodianInsets).toEqual({
+        columnLeft: 12,
+        columnRight: 378,
+        contentPaddingInline: 0,
+        topbarPaddingInline: 12,
+      });
 
       await page.setViewportSize({ height: 900, width: 1440 });
       await page.goto(`${suite.server.baseUrl}settings/appearance`);

--- a/ui/src/e2e/settings-layout.e2e.test.ts
+++ b/ui/src/e2e/settings-layout.e2e.test.ts
@@ -206,20 +206,25 @@ suite.define(() => {
                   headerTop: Math.round(headerBox.y),
                   titleLeft: Math.round(titleBox.x),
                   workspaceLeft: Math.round(workspaceBox.x),
-                  workspaceRight: Math.round(workspaceBox.x + workspaceBox.width),
+                  workspaceRightInset: Math.round(
+                    document.documentElement.clientWidth - (workspaceBox.x + workspaceBox.width),
+                  ),
                   contentLeft: Math.round(contentSurfaceBox.x),
-                  contentRight: Math.round(contentSurfaceBox.x + contentSurfaceBox.width),
+                  contentRightInset: Math.round(
+                    document.documentElement.clientWidth -
+                      (contentSurfaceBox.x + contentSurfaceBox.width),
+                  ),
                 }
               : null;
           })
           .toEqual({
             contentLeft: 12,
-            contentRight: 378,
+            contentRightInset: 12,
             headerLeft: 12,
             headerTop: 70,
             titleLeft: 12,
             workspaceLeft: 12,
-            workspaceRight: 378,
+            workspaceRightInset: 12,
           });
       }
 
@@ -245,7 +250,9 @@ suite.define(() => {
         const columnBox = column.getBoundingClientRect();
         return {
           columnLeft: Math.round(columnBox.left),
-          columnRight: Math.round(columnBox.right),
+          columnRightInset: Math.round(
+            document.documentElement.clientWidth - columnBox.right,
+          ),
           contentPaddingInline: Math.round(
             Number.parseFloat(getComputedStyle(content).paddingLeft),
           ),
@@ -254,7 +261,7 @@ suite.define(() => {
       });
       expect(custodianInsets).toEqual({
         columnLeft: 12,
-        columnRight: 378,
+        columnRightInset: 12,
         contentPaddingInline: 0,
         topbarPaddingInline: 12,
       });

--- a/ui/src/e2e/settings-layout.e2e.test.ts
+++ b/ui/src/e2e/settings-layout.e2e.test.ts
@@ -106,6 +106,71 @@ const responsiveViewports = [
 ] as const;
 
 suite.define(() => {
+  it("uses the full settings content width on mobile without changing desktop insets", async () => {
+    const context = await suite.browser.newContext({
+      colorScheme: "dark",
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 844, width: 390 },
+    });
+    const page = await context.newPage();
+    await installMockGateway(page);
+
+    try {
+      await page.goto(`${suite.server.baseUrl}settings/appearance`);
+      await waitForControlUiRoute(page, {
+        pathname: "/settings/appearance",
+        routeId: "appearance",
+      });
+
+      const readInsets = () =>
+        page.evaluate(() => {
+          const header = document.querySelector<HTMLElement>(".content-header");
+          const workspace = document.querySelector<HTMLElement>(".settings-workspace");
+          const settingsPage = document.querySelector<HTMLElement>(".settings-page");
+          const group = document.querySelector<HTMLElement>(".settings-group");
+          const configContent = document.querySelector<HTMLElement>(".config-content");
+          if (!header || !workspace || !settingsPage || !group || !configContent) {
+            throw new Error("Appearance settings layout did not render");
+          }
+          const headerBox = header.getBoundingClientRect();
+          const workspaceBox = workspace.getBoundingClientRect();
+          const pageBox = settingsPage.getBoundingClientRect();
+          const groupBox = group.getBoundingClientRect();
+          return {
+            configPadding: Math.round(
+              Number.parseFloat(getComputedStyle(configContent).paddingLeft),
+            ),
+            groupInset: Math.round(groupBox.x - workspaceBox.x),
+            headerPadding: Math.round(Number.parseFloat(getComputedStyle(header).paddingLeft)),
+            pagePadding: Math.round(Number.parseFloat(getComputedStyle(settingsPage).paddingLeft)),
+            pageInset: Math.round(pageBox.x - workspaceBox.x),
+            pageWidthDelta: Math.round(workspaceBox.width - pageBox.width),
+            headerWidthDelta: Math.round(workspaceBox.width - headerBox.width),
+          };
+        });
+
+      await expect.poll(readInsets).toEqual({
+        configPadding: 0,
+        groupInset: 0,
+        headerPadding: 0,
+        pagePadding: 0,
+        pageInset: 0,
+        pageWidthDelta: 0,
+        headerWidthDelta: 0,
+      });
+
+      await page.setViewportSize({ height: 900, width: 1440 });
+      await expect.poll(readInsets).toMatchObject({
+        configPadding: 22,
+        headerPadding: 16,
+        pagePadding: 16,
+      });
+    } finally {
+      await context.close();
+    }
+  });
+
   it("uses the shared tab system for Communications without duplicate section help", async () => {
     const context = await suite.browser.newContext({
       colorScheme: "dark",

--- a/ui/src/e2e/settings-layout.e2e.test.ts
+++ b/ui/src/e2e/settings-layout.e2e.test.ts
@@ -193,31 +193,36 @@ suite.define(() => {
           contentSurface.waitFor(),
         ]);
         await expect
-          .poll(async () => {
-            const [headerBox, titleBox, workspaceBox, contentSurfaceBox, layoutViewportWidth] =
-              await Promise.all([
-                header.boundingBox(),
-                title.boundingBox(),
-                workspace.boundingBox(),
-                contentSurface.boundingBox(),
-                page.evaluate(() => document.documentElement.clientWidth),
-              ]);
-            return headerBox && titleBox && workspaceBox && contentSurfaceBox
-              ? {
-                  headerLeft: Math.round(headerBox.x),
-                  headerTop: Math.round(headerBox.y),
-                  titleLeft: Math.round(titleBox.x),
-                  workspaceLeft: Math.round(workspaceBox.x),
-                  workspaceRightInset: Math.round(
-                    layoutViewportWidth - (workspaceBox.x + workspaceBox.width),
-                  ),
-                  contentLeft: Math.round(contentSurfaceBox.x),
-                  contentRightInset: Math.round(
-                    layoutViewportWidth - (contentSurfaceBox.x + contentSurfaceBox.width),
-                  ),
-                }
-              : null;
-          })
+          .poll(() =>
+            page.evaluate((selector) => {
+              const scrollport = document.querySelector<HTMLElement>("main.content");
+              const headers = document.querySelectorAll<HTMLElement>(".content-header");
+              const workspaces = document.querySelectorAll<HTMLElement>(".settings-workspace");
+              const header = headers.item(headers.length - 1);
+              const workspace = workspaces.item(workspaces.length - 1);
+              const title = header?.querySelector<HTMLElement>(".page-title");
+              const contentSurface = workspace?.querySelector<HTMLElement>(selector);
+              if (!scrollport || !header || !title || !workspace || !contentSurface) {
+                return null;
+              }
+              const scrollportBox = scrollport.getBoundingClientRect();
+              const headerBox = header.getBoundingClientRect();
+              const titleBox = title.getBoundingClientRect();
+              const workspaceBox = workspace.getBoundingClientRect();
+              const contentSurfaceBox = contentSurface.getBoundingClientRect();
+              // clientWidth excludes a non-overlay scrollbar and its stable gutter.
+              const scrollportRight = scrollportBox.left + scrollport.clientWidth;
+              return {
+                headerLeft: Math.round(headerBox.left),
+                headerTop: Math.round(headerBox.top),
+                titleLeft: Math.round(titleBox.left),
+                workspaceLeft: Math.round(workspaceBox.left),
+                workspaceRightInset: Math.round(scrollportRight - workspaceBox.right),
+                contentLeft: Math.round(contentSurfaceBox.left),
+                contentRightInset: Math.round(scrollportRight - contentSurfaceBox.right),
+              };
+            }, contentSelector),
+          )
           .toEqual({
             contentLeft: 12,
             contentRightInset: 12,
@@ -251,9 +256,7 @@ suite.define(() => {
         const columnBox = column.getBoundingClientRect();
         return {
           columnLeft: Math.round(columnBox.left),
-          columnRightInset: Math.round(
-            document.documentElement.clientWidth - columnBox.right,
-          ),
+          columnRightInset: Math.round(document.documentElement.clientWidth - columnBox.right),
           contentPaddingInline: Math.round(
             Number.parseFloat(getComputedStyle(content).paddingLeft),
           ),
@@ -425,6 +428,30 @@ suite.define(() => {
           path: path.join(proofDir, "communications-voice.png"),
         });
       }
+
+      await page.setViewportSize({ height: 844, width: 390 });
+      await expect
+        .poll(() =>
+          page.evaluate(() => {
+            const content = document.querySelector<HTMLElement>("main.content");
+            const lead = document.querySelector<HTMLElement>(".config-lead");
+            const tabs = document.querySelector<HTMLElement>(
+              "wa-tab-group.config-sections-hub-tabs",
+            );
+            if (!content || !lead || !tabs) {
+              return null;
+            }
+            const contentBox = content.getBoundingClientRect();
+            const leadBox = lead.getBoundingClientRect();
+            const tabsBox = tabs.getBoundingClientRect();
+            return {
+              leadLeft: Math.round(leadBox.left),
+              leadRightInset: Math.round(contentBox.left + content.clientWidth - leadBox.right),
+              tabsLeft: Math.round(tabsBox.left),
+            };
+          }),
+        )
+        .toEqual({ leadLeft: 12, leadRightInset: 12, tabsLeft: 12 });
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/settings-layout.e2e.test.ts
+++ b/ui/src/e2e/settings-layout.e2e.test.ts
@@ -198,18 +198,24 @@ suite.define(() => {
               const scrollport = document.querySelector<HTMLElement>("main.content");
               const headers = document.querySelectorAll<HTMLElement>(".content-header");
               const workspaces = document.querySelectorAll<HTMLElement>(".settings-workspace");
-              const header = headers.item(headers.length - 1);
-              const workspace = workspaces.item(workspaces.length - 1);
-              const title = header?.querySelector<HTMLElement>(".page-title");
-              const contentSurface = workspace?.querySelector<HTMLElement>(selector);
-              if (!scrollport || !header || !title || !workspace || !contentSurface) {
+              const headerElement = headers.item(headers.length - 1);
+              const workspaceElement = workspaces.item(workspaces.length - 1);
+              const titleElement = headerElement?.querySelector<HTMLElement>(".page-title");
+              const surfaceElement = workspaceElement?.querySelector<HTMLElement>(selector);
+              if (
+                !scrollport ||
+                !headerElement ||
+                !titleElement ||
+                !workspaceElement ||
+                !surfaceElement
+              ) {
                 return null;
               }
               const scrollportBox = scrollport.getBoundingClientRect();
-              const headerBox = header.getBoundingClientRect();
-              const titleBox = title.getBoundingClientRect();
-              const workspaceBox = workspace.getBoundingClientRect();
-              const contentSurfaceBox = contentSurface.getBoundingClientRect();
+              const headerBox = headerElement.getBoundingClientRect();
+              const titleBox = titleElement.getBoundingClientRect();
+              const workspaceBox = workspaceElement.getBoundingClientRect();
+              const contentSurfaceBox = surfaceElement.getBoundingClientRect();
               // clientWidth excludes a non-overlay scrollbar and its stable gutter.
               const scrollportRight = scrollportBox.left + scrollport.clientWidth;
               return {

--- a/ui/src/e2e/settings-layout.e2e.test.ts
+++ b/ui/src/e2e/settings-layout.e2e.test.ts
@@ -194,12 +194,14 @@ suite.define(() => {
         ]);
         await expect
           .poll(async () => {
-            const [headerBox, titleBox, workspaceBox, contentSurfaceBox] = await Promise.all([
-              header.boundingBox(),
-              title.boundingBox(),
-              workspace.boundingBox(),
-              contentSurface.boundingBox(),
-            ]);
+            const [headerBox, titleBox, workspaceBox, contentSurfaceBox, layoutViewportWidth] =
+              await Promise.all([
+                header.boundingBox(),
+                title.boundingBox(),
+                workspace.boundingBox(),
+                contentSurface.boundingBox(),
+                page.evaluate(() => document.documentElement.clientWidth),
+              ]);
             return headerBox && titleBox && workspaceBox && contentSurfaceBox
               ? {
                   headerLeft: Math.round(headerBox.x),
@@ -207,12 +209,11 @@ suite.define(() => {
                   titleLeft: Math.round(titleBox.x),
                   workspaceLeft: Math.round(workspaceBox.x),
                   workspaceRightInset: Math.round(
-                    document.documentElement.clientWidth - (workspaceBox.x + workspaceBox.width),
+                    layoutViewportWidth - (workspaceBox.x + workspaceBox.width),
                   ),
                   contentLeft: Math.round(contentSurfaceBox.x),
                   contentRightInset: Math.round(
-                    document.documentElement.clientWidth -
-                      (contentSurfaceBox.x + contentSurfaceBox.width),
+                    layoutViewportWidth - (contentSurfaceBox.x + contentSurfaceBox.width),
                   ),
                 }
               : null;

--- a/ui/src/e2e/settings-layout.e2e.test.ts
+++ b/ui/src/e2e/settings-layout.e2e.test.ts
@@ -152,18 +152,13 @@ suite.define(() => {
           };
         }, route);
 
-      const layouts = [];
       for (const route of mobileSettingsRoutes) {
         const pathname = pathForRoute(route);
         await page.goto(new URL(pathname, suite.server.baseUrl).toString());
         await waitForControlUiRoute(page, { pathname, routeId: route });
-        await page.locator(".settings-workspace").last().waitFor({ state: "attached" });
-        layouts.push({ route, ...(await readShellInsets(route)) });
-      }
-      for (const layout of layouts) {
-        if (layout.contentPaddingInline !== 12 || layout.topbarPaddingInline !== 12) {
-          throw new Error(`${layout.route} settings shell alignment: ${JSON.stringify(layout)}`);
-        }
+        await expect
+          .poll(() => readShellInsets(route), { message: `${route} settings shell alignment` })
+          .toEqual({ contentPaddingInline: 12, topbarPaddingInline: 12 });
       }
 
       for (const route of mobileStandaloneSettingsPageRoutes) {

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -922,7 +922,7 @@
    of which tab is active so its title and actions do not jump by one space. */
 .shell--settings .content:has(.memory-page) .content-header.hub-page-header {
   max-width: 1120px;
-  padding-inline: var(--space-4);
+  padding-inline: var(--settings-header-inline-padding, var(--space-4));
 }
 
 .memory-page__panel .settings-page,

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -370,6 +370,13 @@ html.openclaw-native-macos body .shell--mobile-nav .topnav-shell__actions {
     padding-bottom: 0;
   }
 
+  /* Custodian owns its page inset and vertical rhythm. Keep the generic mobile
+     content rule below from stacking shell spacing onto that owner. */
+  main.content--custodian {
+    gap: 0;
+    padding: 0;
+  }
+
   .content {
     --content-inline-padding: 4px;
     padding: 4px var(--content-inline-padding) 16px;

--- a/ui/src/styles/plugins.css
+++ b/ui/src/styles/plugins.css
@@ -10,7 +10,7 @@
   width: 100%;
   max-width: 1120px;
   margin-inline: auto;
-  padding-inline: var(--space-4);
+  padding-inline: var(--settings-header-inline-padding, var(--space-4));
   display: flex;
   flex-direction: column;
   align-items: flex-start;

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -769,6 +769,10 @@ textarea.settings-input {
 /* ── Mobile ── */
 
 @media (max-width: 640px) {
+  .settings-page {
+    padding-inline: var(--space-3);
+  }
+
   .shell--settings .content:not(.content--custodian),
   .content:has(.plugins-hub-header) {
     --content-inline-padding: var(--space-3);

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -769,15 +769,17 @@ textarea.settings-input {
 /* ── Mobile ── */
 
 @media (max-width: 640px) {
-  .shell--settings .content,
+  .shell--settings .content:has(.settings-workspace),
   .content:has(.plugins-hub-header) {
     --content-inline-padding: var(--space-3);
+    --settings-header-inline-padding: 0;
     padding: var(--space-3) var(--space-3) var(--space-4);
   }
 
   .shell--settings .content:has(.settings-workspace) .content-header,
   .content:has(.plugins-hub-header) .content-header,
-  .settings-page,
+  .shell--settings .settings-page,
+  .content:has(.plugins-hub-header) .settings-page,
   .shell--settings .config-content {
     padding-inline: 0;
   }

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -784,7 +784,9 @@ textarea.settings-input {
   .content:has(.plugins-hub-header) .content-header,
   .shell--settings .settings-page,
   .content:has(.plugins-hub-header) .settings-page,
-  .shell--settings .config-content {
+  .shell--settings .config-content,
+  .shell--settings .config-lead,
+  .shell--settings .config-content-callout {
     padding-inline: 0;
   }
 

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -771,14 +771,13 @@ textarea.settings-input {
 @media (max-width: 640px) {
   .shell--settings .content,
   .content:has(.plugins-hub-header) {
+    --content-inline-padding: var(--space-3);
     padding: var(--space-3) var(--space-3) var(--space-4);
   }
 
-  .content:has(.settings-workspace .settings-page) .content-header,
-  .settings-page {
-    padding-inline: 0;
-  }
-
+  .shell--settings .content:has(.settings-workspace) .content-header,
+  .content:has(.plugins-hub-header) .content-header,
+  .settings-page,
   .shell--settings .config-content {
     padding-inline: 0;
   }

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -769,7 +769,7 @@ textarea.settings-input {
 /* ── Mobile ── */
 
 @media (max-width: 640px) {
-  .shell--settings .content:has(.settings-workspace),
+  .shell--settings .content:not(.content--custodian),
   .content:has(.plugins-hub-header) {
     --content-inline-padding: var(--space-3);
     --settings-header-inline-padding: 0;

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -769,8 +769,13 @@ textarea.settings-input {
 /* ── Mobile ── */
 
 @media (max-width: 640px) {
+  .content:has(.settings-workspace .settings-page) .content-header,
   .settings-page {
-    padding-inline: var(--space-3);
+    padding-inline: 0;
+  }
+
+  .shell--settings .config-content {
+    padding-inline: 0;
   }
 
   .settings-section__header:has(.settings-section__copy) {

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -769,6 +769,11 @@ textarea.settings-input {
 /* ── Mobile ── */
 
 @media (max-width: 640px) {
+  .shell--settings .content,
+  .content:has(.plugins-hub-header) {
+    padding: var(--space-3) var(--space-3) var(--space-4);
+  }
+
   .content:has(.settings-workspace .settings-page) .content-header,
   .settings-page {
     padding-inline: 0;


### PR DESCRIPTION
Closes #132013

## What Problem This Solves

Settings pages accumulated several horizontal insets on phones. Titles, section tabs, notices, and cards became narrower than the mobile application chrome, so controls and text wrapped earlier than necessary.

## What Changes

- Makes the mobile Settings shell the single owner of the 12 px horizontal inset used by the topbar.
- Removes duplicate mobile insets from Settings headers, page wrappers, schema-driven content, section tabs, and configuration notices.
- Carries the shared header inset through the Memory and Plugins hubs.
- Preserves the full-width reconnecting banner, the route-owned Custodian layout, card-internal spacing, and desktop geometry.
- Splits the oversized UI TypeScript test graph into bounded page and E2E shards without changing coverage.

## User Impact

Internal Settings pages use the available phone width consistently without touching the viewport edge. Titles, tabs, notices, and content align with the topbar across standard pages, Model Setup, Memory, and the Plugins hub.

## Evidence

The 390 x 844 contact sheets cover Appearance Theme, Appearance UI, Setup Wizard, and all Settings takeover routes: OpenClaw, Profile, Notifications, Connection, Channels, Communications, Talk, Devices, Cloud Workers, Agents, Labs, Models, MCP, Memory, Automation, Privacy & Security, Secrets, Approvals, Infrastructure, Advanced, Debug, Logs, Updates, About, Agent Defaults, Model Setup, Lobsterdex, and Plugins.

### Before, light

![All mobile Settings pages before the fix in light theme](https://github.com/user-attachments/assets/49fbcf08-b575-41fb-a020-87f76d2d964a)

### Corrected route layout, light

![All mobile Settings pages aligned to the topbar in light theme](https://github.com/user-attachments/assets/7f614ddb-160f-40a4-a66b-6ab09c2df658)

### Before, dark

![All mobile Settings pages before the fix in dark theme](https://github.com/user-attachments/assets/77cab425-8b07-46d6-b5d7-fc504155ca48)

### Corrected route layout, dark

![All mobile Settings pages aligned to the topbar in dark theme](https://github.com/user-attachments/assets/99c0ab8a-76c4-4bd4-8049-811244ceb0bb)

Browser regression coverage checks every internal Settings route at the phone breakpoint; standalone Settings page insets; visible header, workspace, and content geometry; the multi-section configuration tab strip; Memory and Plugins; Custodian navigation; the Appearance grid; and unchanged desktop insets.

[Exact-head GitHub CI](https://github.com/openclaw/openclaw/actions/runs/33221154350) passed at `b2c57695e613e9d1fe9f3408c54bdad2e056fbab`.
