### PR TITLE
fix: prompt cache collapses in long sessions — aggregate tool-result truncation rewrites already-sent history

### DIFF
--- a/src/agents/embedded-agent-runner/prompt-cache-observability.ts
+++ b/src/agents/embedded-agent-runner/prompt-cache-observability.ts
@@ -12,6 +12,7 @@ import { pruneMapToMaxSize } from "../../infra/map-size.js";
 import type { NormalizedUsage } from "../usage.js";
 
 type PromptCacheChangeCode =
+  | "aggregateToolResultTruncation"
   | "cacheRetention"
   | "model"
   | "streamStrategy"
@@ -308,6 +309,25 @@ export function beginPromptCacheObservation(params: {
     changes,
     previousCacheRead: previous?.lastCacheRead ?? null,
   };
+}
+
+export function recordAggregateTruncation(params: {
+  sessionId: string;
+  promptCacheKey?: string;
+  sessionKey?: string;
+}): void {
+  const tracker = trackers.get(buildTrackerKey(params));
+  const changes = tracker?.pendingChanges ?? [];
+  if (!tracker || changes.some((change) => change.code === "aggregateToolResultTruncation")) {
+    return;
+  }
+  tracker.pendingChanges = [
+    ...changes,
+    {
+      code: "aggregateToolResultTruncation",
+      detail: "aggregate tool-result truncation changed provider prompt",
+    },
+  ];
 }
 
 export function completePromptCacheObservation(params: {

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-submit.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-submit.test.ts
@@ -3,6 +3,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ImageContent } from "../../../llm/types.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import {
+  beginPromptCacheObservation,
+  completePromptCacheObservation,
+} from "../prompt-cache-observability.js";
+import {
   clearEmbeddedSessionPromptStates,
   getEmbeddedSessionPromptState,
 } from "../session-prompt-state.js";
@@ -199,5 +203,82 @@ describe("submitEmbeddedAttemptPrompt", () => {
     expect(
       originalHugeResult?.role === "toolResult" ? originalHugeResult.content : undefined,
     ).toEqual([{ type: "text", text: oversized }]);
+  });
+
+  it("records aggregate truncation on a provider-bound cache break", async () => {
+    const { activeSession } = createSession();
+    const input = createBaseInput();
+    const promptCacheKey = `${sessionId}:aggregate-truncation`;
+    const observation = {
+      sessionId,
+      promptCacheKey,
+      provider: "openai",
+      modelId: "gpt-5.4",
+      modelApi: "openai-responses",
+      streamStrategy: "boundary-aware:openai-responses",
+      systemPrompt: input.systemPrompt,
+      tools: [],
+    } as const;
+    beginPromptCacheObservation(observation);
+    completePromptCacheObservation({
+      sessionId,
+      promptCacheKey,
+      usage: { cacheRead: 8_000 },
+    });
+    beginPromptCacheObservation(observation);
+    activeSession.agent.state.messages = [
+      { role: "user", content: "call tools", timestamp: 1 },
+      {
+        role: "toolResult",
+        toolCallId: "aggregate-a",
+        toolName: "read",
+        content: [{ type: "text", text: "a".repeat(6_000) }],
+        isError: false,
+        timestamp: 2,
+      },
+      {
+        role: "toolResult",
+        toolCallId: "aggregate-b",
+        toolName: "read",
+        content: [{ type: "text", text: "b".repeat(6_000) }],
+        isError: false,
+        timestamp: 3,
+      },
+      // Real dispatch pins a non-tool carrier after tool results, so the fresh
+      // batch is not trailing-protected and aggregate recovery can engage.
+      { role: "user", content: "continue", timestamp: 4 },
+    ] as AgentMessage[];
+    activeSession.agent.streamFn = (() => undefined as never) as StreamFn;
+
+    await submitEmbeddedAttemptPrompt({
+      ...input,
+      attempt: { sessionId, promptCacheKey },
+      activeSession,
+      toolResultAggregateMaxChars: 6_000,
+      promptActiveSession: async () => {
+        await activeSession.agent.streamFn(
+          {} as never,
+          { messages: activeSession.messages } as never,
+          {} as never,
+        );
+      },
+    });
+
+    expect(
+      completePromptCacheObservation({
+        sessionId,
+        promptCacheKey,
+        usage: { cacheRead: 2_000 },
+      }),
+    ).toEqual({
+      previousCacheRead: 8_000,
+      cacheRead: 2_000,
+      changes: [
+        {
+          code: "aggregateToolResultTruncation",
+          detail: "aggregate tool-result truncation changed provider prompt",
+        },
+      ],
+    });
   });
 });

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-submit.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-submit.ts
@@ -13,6 +13,7 @@ import type { AgentMessage } from "../../runtime/index.js";
 import type { SandboxContext } from "../../sandbox/types.js";
 import type { AgentSession } from "../../sessions/index.js";
 import { ackPendingAgentSteeringItems } from "../../subagents/registry/subagent-registry.js";
+import { recordAggregateTruncation } from "../prompt-cache-observability.js";
 import { normalizeAssistantReplayContent } from "../replay-history.js";
 import { updateActiveEmbeddedRunSnapshot } from "../runs.js";
 import {
@@ -69,7 +70,10 @@ type SteeringLease = {
 type TrajectoryRecorder = ReturnType<typeof createTrajectoryRuntimeRecorder>;
 
 export async function submitEmbeddedAttemptPrompt(input: {
-  attempt: Pick<EmbeddedRunAttemptParams, "sessionId" | "userTurnTranscriptRecorder">;
+  attempt: Pick<
+    EmbeddedRunAttemptParams,
+    "promptCacheKey" | "sessionId" | "sessionKey" | "userTurnTranscriptRecorder"
+  >;
   activeSession: PromptSubmissionSession;
   appendContext?: string;
   contextTokenBudget: number;
@@ -111,6 +115,9 @@ export async function submitEmbeddedAttemptPrompt(input: {
         providerPromptHistoryTruncation.messages !== messages
           ? providerPromptHistoryTruncation.messages
           : messages;
+      if (providerPromptHistoryTruncation.aggregateTruncatedCount > 0) {
+        recordAggregateTruncation(attempt);
+      }
       // Mark the current turn sent at provider dispatch so late media appends
       // instead of rewriting its prompt-cache slot (#99495).
       markSessionUserTurnsSent(input.sessionPromptState, providerMessages);

--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -1792,6 +1792,59 @@ describe("truncateOversizedToolResultsInSession", () => {
     expect(originalEvent?.message).toEqual(original);
   });
 
+  it("reduces aggregate-only frozen history on the recovery branch", async () => {
+    const dir = await createTmpDir();
+    const storePath = path.join(dir, "sessions.json");
+    const sessionId = "runtime-sqlite-frozen-aggregate-recovery";
+    const sessionKey = "agent:main:frozen-aggregate-recovery";
+    const sessionFile = formatSqliteSessionFileMarker({
+      agentId: "main",
+      sessionId,
+      storePath,
+    });
+    const scope = { agentId: "main", sessionId, sessionKey, storePath };
+    await replaceSessionEntry({ sessionKey, storePath }, {
+      sessionFile,
+      sessionId,
+      updatedAt: 10,
+    } as SessionStoreEntry);
+    await appendTranscriptMessage(scope, { message: makeUserMessage("run tools") });
+    // Each result stays under the per-result cap; only the aggregate is over.
+    const frozenResults = [
+      makeToolResult("a".repeat(6_000), "frozen_agg_1"),
+      makeToolResult("b".repeat(6_000), "frozen_agg_2"),
+      makeToolResult("c".repeat(6_000), "frozen_agg_3"),
+    ];
+    for (const message of frozenResults) {
+      await appendTranscriptMessage(scope, { message });
+    }
+    const projectionState = createPromptProjectionStateForTest();
+    // Dispatch under a loose budget freezes every result at full text.
+    truncateOversizedToolResultsInMessages(frozenResults, 128_000, 8_000, 48_000, projectionState);
+    expect(projectionState.frozen.size).toBe(3);
+
+    // A provider context failure then demands recovery under a tighter budget:
+    // frozen history is the only reducible mass and must still shrink.
+    const result = await truncateOversizedToolResultsInActiveTarget({
+      scope: { ...scope, sessionFile },
+      contextWindowTokens: 128_000,
+      maxCharsOverride: 8_000,
+      aggregateMaxCharsOverride: 6_000,
+      projectionState,
+    });
+
+    expect(result.truncated).toBe(true);
+    const recovered = SessionManager.open(scope)
+      .getBranch()
+      .filter((entry) => entry.type === "message" && entry.message.role === "toolResult")
+      .map((entry) => (entry.type === "message" ? entry.message : undefined));
+    const totalChars = recovered.reduce(
+      (sum, message) => sum + (message ? getToolResultTextLength(message) : 0),
+      0,
+    );
+    expect(totalChars).toBeLessThan(18_000);
+  });
+
   it("honors SQLite leaf controls when truncating runtime transcripts", async () => {
     const dir = await createTmpDir();
     const storePath = path.join(dir, "sessions.json");

--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -1011,8 +1011,9 @@ describe("truncateOversizedToolResultsInMessages", () => {
     );
     expect(freshResult?.role).toBe("toolResult");
     expect(second.messages.slice(0, history.length)).toEqual(first.messages);
-    expect(freshResult && getFirstToolResultText(freshResult)).toBe("");
-    expect(totalChars).toBeLessThanOrEqual(32_000);
+    // Tiny fresh output fits inside the retained elision-notice floor.
+    expect(freshResult && getFirstToolResultText(freshResult)).toBe("ABC");
+    expect(totalChars).toBeLessThanOrEqual(32_100);
   });
 
   it("recovers from a fresh tool result before frozen history through a runtime carrier", () => {
@@ -1075,10 +1076,12 @@ describe("truncateOversizedToolResultsInMessages", () => {
       0,
     );
     expect(historicalResults).toEqual(firstHistoricalResults);
-    expect(freshResult && getFirstToolResultText(freshResult)).toBe("");
+    const freshNotice = freshResult ? getFirstToolResultText(freshResult) : "";
+    expect(freshNotice).not.toBe("");
+    expect(freshNotice).toContain("truncated");
     expect(second.aggregateTruncatedCount).toBeGreaterThan(0);
     expect(second.aggregatePressureEngaged).toBe(true);
-    expect(totalChars).toBeLessThanOrEqual(32_000);
+    expect(totalChars).toBeLessThanOrEqual(32_100);
   });
 
   it("recovers from multiple fresh tool results before frozen history and queued steering", () => {
@@ -1128,10 +1131,13 @@ describe("truncateOversizedToolResultsInMessages", () => {
     );
 
     expect(second.messages.slice(0, history.length)).toEqual(first.messages);
-    expect(freshResults.map(getFirstToolResultText)).toEqual(["", ""]);
+    for (const notice of freshResults.map(getFirstToolResultText)) {
+      expect(notice).not.toBe("");
+      expect(notice).toContain("truncated");
+    }
     expect(second.aggregateTruncatedCount).toBeGreaterThan(0);
     expect(second.aggregatePressureEngaged).toBe(true);
-    expect(totalChars).toBeLessThanOrEqual(32_000);
+    expect(totalChars).toBeLessThanOrEqual(32_200);
   });
 
   it("allows aggregate overflow rather than rewriting frozen history", () => {
@@ -1187,7 +1193,8 @@ describe("truncateOversizedToolResultsInMessages", () => {
         (message) => message.role === "toolResult" && message.toolCallId.startsWith("history_"),
       ),
     ).toEqual(first.messages.filter((message) => message.role === "toolResult"));
-    expect(freshText).toBe("");
+    expect(freshText).not.toBe("");
+    expect(freshText).toContain("truncated");
     expect(second.aggregateTruncatedCount).toBeGreaterThan(0);
     expect(second.aggregatePressureEngaged).toBe(true);
     expect(totalChars).toBeGreaterThan(100);
@@ -1236,8 +1243,9 @@ describe("truncateOversizedToolResultsInMessages", () => {
     );
     expect(freshResult?.role).toBe("toolResult");
     expect(second.messages.slice(0, history.length)).toEqual(first.messages);
-    expect(freshText).toBe("");
-    expect(totalChars).toBeLessThanOrEqual(32_000);
+    expect(freshText).not.toBe("");
+    expect(freshText).toContain("truncated");
+    expect(totalChars).toBeLessThanOrEqual(32_100);
   });
 
   it("leaves fresh trailing batches intact when only they exceed the aggregate budget", () => {

--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -905,6 +905,51 @@ describe("truncateOversizedToolResultsInMessages", () => {
     ).toEqual(projected.messages.slice(1));
   });
 
+  it("keeps frozen aggregate projections byte-identical when a later turn exceeds the budget", () => {
+    const projectionState = createPromptProjectionStateForTest();
+    const history = [
+      makeToolResult("a".repeat(4_000), "history_1"),
+      makeToolResult("b".repeat(4_000), "history_2"),
+      makeUserMessage("continue"),
+    ];
+    const first = truncateOversizedToolResultsInMessages(
+      history,
+      128_000,
+      8_000,
+      12_000,
+      projectionState,
+    );
+    const frozenBytes = first.messages.map((message) => JSON.stringify(message));
+    const runtimeContextMessage = buildRuntimeContextCustomMessage("runtime context refresh");
+    if (!runtimeContextMessage) {
+      throw new Error("expected runtime context message");
+    }
+
+    const second = truncateOversizedToolResultsInMessages(
+      [
+        ...history,
+        makeAssistantMessage("running exec"),
+        makeToolResult("c".repeat(6_000), "current"),
+        runtimeContextMessage,
+      ],
+      128_000,
+      8_000,
+      12_000,
+      projectionState,
+    );
+
+    expect(first.aggregateTruncatedCount).toBe(0);
+    expect(second.aggregateTruncatedCount).toBeGreaterThan(0);
+    expect(
+      second.messages.slice(0, history.length).map((message) => JSON.stringify(message)),
+    ).toEqual(frozenBytes);
+    const current = second.messages.find(
+      (message): message is ToolResultMessage =>
+        message.role === "toolResult" && message.toolCallId === "current",
+    );
+    expect(current && getToolResultTextLength(current)).toBeLessThan(6_000);
+  });
+
   it("shrinks #99495 frozen bytes monotonically only under a tighter hard cap", () => {
     const state = getEmbeddedSessionPromptState("session-99495-shrink").toolResults;
     const history = [
@@ -922,8 +967,12 @@ describe("truncateOversizedToolResultsInMessages", () => {
     expect(relaxed.messages).toEqual(shrunk.messages);
   });
 
-  it("preserves fresh trailing tool results when aggregate history is already saturated", () => {
+  it("clears a fresh trailing result before rewriting saturated frozen history", () => {
     const projectionState = createPromptProjectionStateForTest();
+    const runtimeContextMessage = buildRuntimeContextCustomMessage("runtime context refresh");
+    if (!runtimeContextMessage) {
+      throw new Error("expected runtime context message");
+    }
     const history: AgentMessage[] = [];
     for (let index = 0; index < 50; index++) {
       history.push(makeAssistantMessage(`call ${index}`));
@@ -942,25 +991,31 @@ describe("truncateOversizedToolResultsInMessages", () => {
 
     const freshOutput = "ABC";
     const second = truncateOversizedToolResultsInMessages(
-      [...history, makeAssistantMessage("running exec"), makeToolResult(freshOutput, "fresh_exec")],
+      [
+        ...history,
+        makeAssistantMessage("running exec"),
+        makeToolResult(freshOutput, "fresh_exec"),
+        runtimeContextMessage,
+      ],
       1_000_000,
       8_000,
       32_000,
       projectionState,
     );
 
-    const freshResult = second.messages.at(-1);
+    const freshResult = second.messages.at(-2);
     const totalChars = second.messages.reduce(
       (sum, message) =>
         sum + (message.role === "toolResult" ? getToolResultTextLength(message) : 0),
       0,
     );
     expect(freshResult?.role).toBe("toolResult");
-    expect(freshResult && getFirstToolResultText(freshResult)).toBe(freshOutput);
+    expect(second.messages.slice(0, history.length)).toEqual(first.messages);
+    expect(freshResult && getFirstToolResultText(freshResult)).toBe("");
     expect(totalChars).toBeLessThanOrEqual(32_000);
   });
 
-  it("preserves fresh tool results through a trailing runtime context carrier", () => {
+  it("recovers from a fresh tool result before frozen history through a runtime carrier", () => {
     const projectionState = createPromptProjectionStateForTest();
     const history: AgentMessage[] = [];
     for (let index = 0; index < 50; index++) {
@@ -1010,32 +1065,23 @@ describe("truncateOversizedToolResultsInMessages", () => {
       (message): message is ToolResultMessage =>
         message.role === "toolResult" && message.toolCallId.startsWith("history_"),
     );
-    const firstHistoricalLengths = new Map(
-      first.messages.flatMap((message) =>
-        message.role === "toolResult" && message.toolCallId.startsWith("history_")
-          ? [[message.toolCallId, getToolResultTextLength(message)] as const]
-          : [],
-      ),
+    const firstHistoricalResults = first.messages.filter(
+      (message): message is ToolResultMessage =>
+        message.role === "toolResult" && message.toolCallId.startsWith("history_"),
     );
     const totalChars = second.messages.reduce(
       (sum, message) =>
         sum + (message.role === "toolResult" ? getToolResultTextLength(message) : 0),
       0,
     );
-    expect(freshResult && getFirstToolResultText(freshResult)).toBe(freshOutput);
-    expect(
-      historicalResults.some(
-        (message) =>
-          getToolResultTextLength(message) <
-          (firstHistoricalLengths.get(message.toolCallId) ?? Number.POSITIVE_INFINITY),
-      ),
-    ).toBe(true);
+    expect(historicalResults).toEqual(firstHistoricalResults);
+    expect(freshResult && getFirstToolResultText(freshResult)).toBe("");
     expect(second.aggregateTruncatedCount).toBeGreaterThan(0);
     expect(second.aggregatePressureEngaged).toBe(true);
     expect(totalChars).toBeLessThanOrEqual(32_000);
   });
 
-  it("preserves multiple fresh tool results before queued steering", () => {
+  it("recovers from multiple fresh tool results before frozen history and queued steering", () => {
     const projectionState = createPromptProjectionStateForTest();
     const history: AgentMessage[] = [];
     for (let index = 0; index < 50; index++) {
@@ -1075,37 +1121,20 @@ describe("truncateOversizedToolResultsInMessages", () => {
       (message): message is ToolResultMessage =>
         message.role === "toolResult" && message.toolCallId.startsWith("fresh_"),
     );
-    const historicalResults = second.messages.filter(
-      (message): message is ToolResultMessage =>
-        message.role === "toolResult" && message.toolCallId.startsWith("history_"),
-    );
-    const firstHistoricalLengths = new Map(
-      first.messages.flatMap((message) =>
-        message.role === "toolResult" && message.toolCallId.startsWith("history_")
-          ? [[message.toolCallId, getToolResultTextLength(message)] as const]
-          : [],
-      ),
-    );
     const totalChars = second.messages.reduce(
       (sum, message) =>
         sum + (message.role === "toolResult" ? getToolResultTextLength(message) : 0),
       0,
     );
 
-    expect(freshResults.map(getFirstToolResultText)).toEqual(freshOutputs);
-    expect(
-      historicalResults.some(
-        (message) =>
-          getToolResultTextLength(message) <
-          (firstHistoricalLengths.get(message.toolCallId) ?? Number.POSITIVE_INFINITY),
-      ),
-    ).toBe(true);
+    expect(second.messages.slice(0, history.length)).toEqual(first.messages);
+    expect(freshResults.map(getFirstToolResultText)).toEqual(["", ""]);
     expect(second.aggregateTruncatedCount).toBeGreaterThan(0);
     expect(second.aggregatePressureEngaged).toBe(true);
     expect(totalChars).toBeLessThanOrEqual(32_000);
   });
 
-  it("shrinks deferred fresh results when frozen history cannot satisfy the hard cap", () => {
+  it("allows aggregate overflow rather than rewriting frozen history", () => {
     const projectionState = createPromptProjectionStateForTest();
     const history: AgentMessage[] = [
       makeToolResult("a".repeat(4_000), "history_a"),
@@ -1116,10 +1145,10 @@ describe("truncateOversizedToolResultsInMessages", () => {
       history,
       1_000_000,
       8_000,
-      100,
+      10_000,
       projectionState,
     );
-    expect(first.aggregatePressureEngaged).toBe(true);
+    expect(first.aggregatePressureEngaged).toBe(false);
 
     const freshOutput = "OC99241_HARD_CAP_SENTINEL_".padEnd(4_000, "f");
     const runtimeContextMessage = buildRuntimeContextCustomMessage("hard-cap runtime context");
@@ -1153,15 +1182,23 @@ describe("truncateOversizedToolResultsInMessages", () => {
       0,
     );
 
-    expect(freshText.length).toBeGreaterThan(0);
-    expect(freshText.length).toBeLessThan(freshOutput.length);
+    expect(
+      second.messages.filter(
+        (message) => message.role === "toolResult" && message.toolCallId.startsWith("history_"),
+      ),
+    ).toEqual(first.messages.filter((message) => message.role === "toolResult"));
+    expect(freshText).toBe("");
     expect(second.aggregateTruncatedCount).toBeGreaterThan(0);
     expect(second.aggregatePressureEngaged).toBe(true);
-    expect(totalChars).toBeLessThanOrEqual(100);
+    expect(totalChars).toBeGreaterThan(100);
   });
 
-  it("caps oversized fresh trailing tool results without clearing them for aggregate recovery", () => {
+  it("clears an oversized fresh result before rewriting saturated frozen history", () => {
     const projectionState = createPromptProjectionStateForTest();
+    const runtimeContextMessage = buildRuntimeContextCustomMessage("runtime context refresh");
+    if (!runtimeContextMessage) {
+      throw new Error("expected runtime context message");
+    }
     const history: AgentMessage[] = [];
     for (let index = 0; index < 50; index++) {
       history.push(makeAssistantMessage(`call ${index}`));
@@ -1169,13 +1206,20 @@ describe("truncateOversizedToolResultsInMessages", () => {
     }
     history.push(makeUserMessage("run large command"));
 
-    truncateOversizedToolResultsInMessages(history, 1_000_000, 8_000, 32_000, projectionState);
+    const first = truncateOversizedToolResultsInMessages(
+      history,
+      1_000_000,
+      8_000,
+      32_000,
+      projectionState,
+    );
 
     const second = truncateOversizedToolResultsInMessages(
       [
         ...history,
         makeAssistantMessage("running exec"),
         makeToolResult("z".repeat(20_000), "fresh_large_exec"),
+        runtimeContextMessage,
       ],
       1_000_000,
       8_000,
@@ -1183,7 +1227,7 @@ describe("truncateOversizedToolResultsInMessages", () => {
       projectionState,
     );
 
-    const freshResult = second.messages.at(-1);
+    const freshResult = second.messages.at(-2);
     const freshText = freshResult ? getFirstToolResultText(freshResult) : "";
     const totalChars = second.messages.reduce(
       (sum, message) =>
@@ -1191,9 +1235,8 @@ describe("truncateOversizedToolResultsInMessages", () => {
       0,
     );
     expect(freshResult?.role).toBe("toolResult");
-    expect(freshText.length).toBeGreaterThan(0);
-    expect(freshText.length).toBeLessThanOrEqual(8_000);
-    expect(freshText).toContain("truncated");
+    expect(second.messages.slice(0, history.length)).toEqual(first.messages);
+    expect(freshText).toBe("");
     expect(totalChars).toBeLessThanOrEqual(32_000);
   });
 

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -891,9 +891,11 @@ function projectToolResultBranch(params: {
       return {
         ...entry,
         message,
-        // Frozen bytes are immutable even when a stored replacement merges to the
-        // current message; eliding them would rewrite provider-sent prompt bytes.
-        aggregateEligible: !key || !frozen,
+        // Frozen bytes are immutable on dispatch projections; eliding them would
+        // rewrite provider-sent prompt bytes. Recovery projections (frozenOnly)
+        // run after a provider context failure, so the cached prefix is already
+        // forfeit and frozen history must stay reducible.
+        aggregateEligible: params.frozenOnly || !key || !frozen,
       };
     }),
   };

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -734,7 +734,6 @@ type ToolResultBranchEntry = {
   type: string;
   message?: AgentMessage;
   aggregateEligible?: boolean;
-  deferAggregateRecovery?: boolean;
 };
 
 type ToolResultReplacement = {
@@ -866,7 +865,6 @@ function projectToolResultBranch(params: {
     messageEntries.map((entry) => entry.message),
     params.projectionState,
   );
-  const hasFrozenProjectionBaseline = params.projectionState.frozen.size > 0;
   let messageIndex = 0;
   return {
     keys,
@@ -893,10 +891,9 @@ function projectToolResultBranch(params: {
       return {
         ...entry,
         message,
-        aggregateEligible:
-          !key || !frozen || (projected !== undefined && message === entry.message),
-        // Reduce frozen history first so steering cannot make fresh output disappear.
-        deferAggregateRecovery: key !== undefined && hasFrozenProjectionBaseline && !frozen,
+        // Frozen bytes are immutable even when a stored replacement merges to the
+        // current message; eliding them would rewrite provider-sent prompt bytes.
+        aggregateEligible: !key || !frozen,
       };
     }),
   };
@@ -932,7 +929,6 @@ function buildAggregateToolResultReplacements(params: {
               spillSourceMessage: params.spillSourceBranch?.[index]?.message ?? message,
               textLength: getToolResultTextBudget(message),
               aggregateEligible: entry.aggregateEligible !== false,
-              deferredByFreshProjection: entry.deferAggregateRecovery === true,
               protectedByTrailingBatch: params.protectedEntryIds?.has(entry.id) ?? false,
             },
           ]
@@ -958,14 +954,11 @@ function buildAggregateToolResultReplacements(params: {
 
   let remainingReduction = totalChars - params.aggregateBudgetChars;
   const replacements = new Map<string, ToolResultReplacement>();
-  // Frozen projections shrink first; stable sorting preserves the original oldest-first order.
-  const recoveryCandidates = candidates
-    .filter((candidate) => !candidate.protectedByTrailingBatch)
-    .toSorted(
-      (left, right) =>
-        Number(left.deferredByFreshProjection) - Number(right.deferredByFreshProjection) ||
-        Number(right.aggregateEligible) - Number(left.aggregateEligible),
-    );
+  // Frozen prompt bytes are immutable. Recover only from unsent tail results;
+  // allow budget overflow when frozen history alone exceeds the aggregate cap.
+  const recoveryCandidates = candidates.filter(
+    (candidate) => candidate.aggregateEligible && !candidate.protectedByTrailingBatch,
+  );
 
   // Trim all older entries before clearing any, so fresh output and spill pointers stay recoverable.
   for (const clear of [false, true]) {

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -974,9 +974,14 @@ function buildAggregateToolResultReplacements(params: {
       const spillMarkers = resolveAggregateElisionMarkers(candidate.spillSourceMessage);
       let message: AgentMessage;
       if (clear) {
+        // Cleared fresh results keep a visible elision notice on projection
+        // paths; an empty tool result reads as failure and loses rerun guidance.
+        const noticeFloor = params.protectedEntryIds
+          ? estimateToolResultTextChars(spillMarkers?.compact ?? AGGREGATE_ELISION_MARKER)
+          : 0;
         message = clearToolResultText(
           candidate.message,
-          Math.max(0, baseTextLength - remainingReduction),
+          Math.max(noticeFloor, baseTextLength - remainingReduction),
           spillMarkers,
         );
       } else {

--- a/src/context-engine/types.ts
+++ b/src/context-engine/types.ts
@@ -249,6 +249,7 @@ type ContextEnginePromptCacheUsage = {
 };
 
 type ContextEnginePromptCacheObservationChangeCode =
+  | "aggregateToolResultTruncation"
   | "cacheRetention"
   | "model"
   | "streamStrategy"


### PR DESCRIPTION
Closes #132008

## What Problem This Solves

Long sessions under aggregate tool-result pressure lose their provider prompt cache almost entirely. Each turn the aggregate budget is recomputed and the planner elides a previously-untouched **older** tool result, rewriting mid-transcript bytes and invalidating the cached prefix for every item after it. In the observed live session (`openai-responses` provider), cached tokens pinned at exactly 27,136 while the prompt grew from 302k to 327k tokens — a ~4% cache hit rate, with ~295k tokens re-billed every turn to save ~2k chars of context.

Wire evidence (body-dump diff of two consecutive turns, identical `prompt_cache_key`): of 721 input items, only the tail runtime-context carrier and one mid-transcript tool result (same `call_id`, output shrunk 2,248 chars by fresh elision markers) differed. Cumulative content before that item matches the 27,136-token cached floor exactly. Corroborating: the same session hit 99.9% cached on the two turns where no new elision fired, and an append-only subagent session cached at 95% — the caching machinery works; the re-elision breaks it.

## Why This Change Was Made

`ToolResultPromptProjectionState` already freezes elided results so they never re-shrink, and `deferAggregateRecovery` was meant to order recovery — but the aggregate planner only *sorted* by those flags and still admitted frozen (already provider-sent) entries as victims. This PR makes the invariant hard: **frozen prompt bytes are immutable**. Aggregate recovery draws only from unsent results (`aggregateEligible` is now a filter, not a sort key; the existing trailing-batch protection for the current turn's final tool batch is unchanged), and the aggregate budget may be exceeded, bounded, when frozen history alone exceeds it — true context overflow remains handled by the existing preflight recovery and compaction routes. Trading bounded aggregate overflow against destroying the cached prefix is the correct trade by orders of magnitude.

The failure mode was foreseen (the freeze mechanism exists) but the mitigation was incomplete and invisible: none of the existing prompt-cache cache-break change codes fire for aggregate elision. This PR also records a new `aggregateToolResultTruncation` change code from the provider-bound transform (only when aggregate truncation actually occurred), so cache-break diagnostics can attribute this class of break.

## User Impact

- Long sessions keep their prompt cache once the aggregate tool-result budget engages, instead of dropping to single-digit hit rates. In the observed session this is roughly a 25x cost reduction on cache-capable providers (all providers benefit — the projection runs on messages before transport serialization).
- Under aggregate pressure, savings now come from the most recent (uncached, about-to-be-billed) results; the current turn's trailing tool batch keeps its existing protection, and fresh results ahead of the tail-pinned runtime-context carrier absorb the elision, with the existing marker instructing a rerun.
- `OPENCLAW_LOG_LEVEL=debug` cache-break diagnostics now name aggregate truncation as a break cause.

Known limitations (documented, unchanged from before): projection state is process-local, so a gateway restart can cause one cache break on the first turn (then monotonic again); the per-result hard-cap shrink path (#99495) and mid-turn overflow recovery may still rewrite history when the context genuinely cannot fit — both pre-existing, deliberate behaviors.

## Evidence

Regression test fails on pristine HEAD with only the production fix stashed (`history_1` flips from full text to truncated), passes with the fix:

```
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/tool-result-truncation.test.ts
# HEAD:  Tests  1 failed | 69 passed (70)
# fix:   Tests  70 passed (70)
```

Also passing: `run/attempt-prompt-submit.test.ts` (4/4, proves the change code is recorded through the real provider transform into `completePromptCacheObservation`), `prompt-cache-observability.test.ts` (14/14), `node scripts/run-oxlint.mjs src/agents`, `pnpm run tsgo:prod`, `oxfmt`.

Behavior proof through the exact PR code path (`truncateOversizedToolResultsInMessages` with shared session projection state, consecutive turns, aggregate budget exceeded on turn 2):

```
=== PRISTINE HEAD ===
turn1 items=3 aggregateElided=0 (prompt sent, prefix now cached)
  turn2 REWROTE previously-sent item[0]: {"role":"toolResult","toolCallId":"call_history_1",...
turn2 aggregateElided=1 rewrittenPreviouslySentItems=1
RESULT: FAIL — 1 previously-sent item(s) rewritten; cache prefix invalidated at first rewrite

=== WITH FIX ===
turn1 items=3 aggregateElided=0 (prompt sent, prefix now cached)
turn2 aggregateElided=1 rewrittenPreviouslySentItems=0
RESULT: PASS — previously-sent prompt bytes unchanged; cache prefix survives aggregate pressure
```

### Live provider proof (real transport, current head)

Both projected turns were sent to a real caching provider (DeepSeek official API, chosen because it reports `prompt_cache_hit_tokens` explicitly) through the exact PR code path: `truncateOversizedToolResultsInMessages` with a shared session projection state produced each turn's messages, which were serialized verbatim into the request. Same scenario both runs: two 8k-char tool results sent on turn 1 (under the 24k aggregate budget, so they become frozen provider-sent history), then a fresh 12k-char tool result on turn 2 pushes over the budget. Key redacted (`sk-****6f01`).

With this PR (head of this branch):

```
turn1: POST https://api.deepseek.com/chat/completions requestChars=16348
turn1: usage={"prompt_tokens":5035,...,"prompt_cache_hit_tokens":0,"prompt_cache_miss_tokens":5035}
turn2: POST https://api.deepseek.com/chat/completions requestChars=24434
turn2: usage={"prompt_tokens":7034,...,"prompt_cache_hit_tokens":4992,"prompt_cache_miss_tokens":2042}
turn2 aggregateElided=1 rewrittenPreviouslySentItems=0
turn2 fresh output readable: startsWithPayload=true projectedChars=7970 (raw 12000)
RESULT: PASS — frozen history byte-identical, fresh output readable, provider cache hit covers the prior prompt
```

Pristine main, same scenario, same session (its identical turn-1 prefix was already server-cached from the run above — which sharpens the contrast):

```
turn1: usage={"prompt_tokens":5035,...,"prompt_cache_hit_tokens":4992,"prompt_cache_miss_tokens":43}
turn2: usage={"prompt_tokens":7550,...,"prompt_cache_hit_tokens":0,"prompt_cache_miss_tokens":7550}
turn2 aggregateElided=1 rewrittenPreviouslySentItems=1
RESULT: FAIL — main re-elided a previously-sent item; the provider cache missed entirely on turn 2
```

Main rewrites one already-sent tool result and the real provider re-bills the entire 7,550-token prompt (`prompt_cache_hit_tokens: 0`); with the fix the same pressure elides the fresh tail instead, previously-sent bytes stay identical, the fresh output remains readable (head+tail projection with marker), and the provider serves 4,992 of 5,035 prior prompt tokens from cache.

Rebased onto current main; upstream's new projection-state reclamation tests (`freezes #99495 ambiguous-key projections across filtered history`, `reclaims #99495 state from canonical compaction`) pass with the fix. `node scripts/run-oxlint.mjs` boundary preparation currently fails on upstream `packages/markdown-core` / `src/tui` type errors that exist on main and are untouched by this PR.

Production delta: the truncation repair is net −5 lines; the observability change code adds the remainder. Tests +~130.

This PR was AI-assisted (diagnosed from live wire captures; implemented and reviewed with agent tooling; human-verified).

## Maintainer verification

Exact-main and exact-head runs used the real embedded `openclaw agent exec` path with OpenRouter Kimi K2.5. The agent issued four separate 30,000-character `exec` results, then one more result on the next model step. A 32,000-token runtime budget set the per-result cap to 16,000 characters and the aggregate cap to 64,000 characters.

- Exact current main at the run freeze (`feb1161a1e6456050bd495452aaf8a9409053296`) finished `DONE` with five successful calls, but the fifth result changed the first two already-sent projections from `16,000 / 16,000` characters to `69 / 15,931`. Provider cache reuse stayed at the stable-prefix floor: `6,400 → 6,656` cached tokens.
- Exact PR head (`0a9c6394d4a8f8b2ec47af83dc45d2937571f780`) finished `DONE` with five successful calls, kept all four frozen projections byte-identical at 16,000 characters, and advanced provider cache reuse to 24,576 cached tokens after the fifth result.
- Current main later advanced through unrelated commits. At `9f7105d29651892b570d877bc5137c49b2a23348`, the truncation producer, prompt-submit owner, projection state, cache observation, stream settlement, and context-engine types remain byte-identical to the live-red revision.
- Focused verification passed 100 tests across tool-result truncation, overflow recovery, provider submission, and prompt-cache observability. The conflict-free current-main merge result passes the same 100 tests.
