### PR TITLE
improve(ui): clarify picker selection and keyboard focus

### DIFF
--- a/ui/src/app/app-shell-chrome.ts
+++ b/ui/src/app/app-shell-chrome.ts
@@ -499,7 +499,8 @@ export class ShellChromeOwner {
     this.requestLazyElement(KEYBOARD_SHORTCUTS_ELEMENT, descriptor);
   };
 
-  /** Open overlays and editable controls own Escape before settings can exit. */
+  // Open controls own Escape. Slotted options hide their listbox in shadow DOM,
+  // so recognize the open select host before Settings can consume the key.
   shouldIgnoreSettingsEscape(event: KeyboardEvent): boolean {
     const host = this.host;
     const overlaySnapshot = host.context?.overlays.snapshot;
@@ -517,7 +518,7 @@ export class ShellChromeOwner {
     return (
       target instanceof Element &&
       target.closest(
-        "input, textarea, select, [contenteditable], dialog, [role='dialog'], [role='menu'], [role='listbox']",
+        "input, textarea, select, wa-select[open], [contenteditable], dialog, [role='dialog'], [role='menu'], [role='listbox']",
       ) !== null
     );
   }

--- a/ui/src/e2e/board-mcp-app.e2e.test.ts
+++ b/ui/src/e2e/board-mcp-app.e2e.test.ts
@@ -243,9 +243,16 @@ describeControlUiE2e("Control UI dashboard MCP Apps", () => {
     await openDashboard(page);
     await expect
       .poll(async () => (await gateway.getRequests("board.widget.appView")).length, {
-        timeout: 10_000,
+        timeout: 15_000,
       })
-      .toBeGreaterThan(0);
+      .toBe(2);
+    // Renewal replaces the iframe. The new-binding request follows teardown,
+    // so wait for it before sampling the replacement's rendered background.
+    await expect
+      .poll(async () =>
+        (await gateway.getRequests("mcp.app.view")).map((request) => request.params),
+      )
+      .toContainEqual({ sessionKey, viewId: "renewed-view" });
     await waitForMountedApp(page);
     const widgetBackgrounds = await page.evaluate(() => {
       const widgetElement = document.querySelector<HTMLElement>('[data-test-id="board-widget"]');
@@ -262,11 +269,6 @@ describeControlUiE2e("Control UI dashboard MCP Apps", () => {
     });
     expect(widgetBackgrounds.frame).toBe(widgetBackgrounds.widget);
     expect(widgetBackgrounds.frame).not.toBe("rgba(0, 0, 0, 0)");
-    await expect
-      .poll(async () => (await gateway.getRequests("board.widget.appView")).length, {
-        timeout: 15_000,
-      })
-      .toBe(2);
     expect((await gateway.getRequests("board.widget.appView"))[0]?.params).toEqual({
       sessionKey,
       name: "app-0",

--- a/ui/src/e2e/channel-wizard-option-contrast.e2e.test.ts
+++ b/ui/src/e2e/channel-wizard-option-contrast.e2e.test.ts
@@ -20,7 +20,7 @@ const proofDirectory = path.join(
 );
 
 suite.define(() => {
-  it("keeps active option subtext as legible as its label", async () => {
+  it("keeps option subtext legible and keyboard focus visible in forced colors", async () => {
     await suite.withPage(
       {
         colorScheme: "dark",
@@ -29,7 +29,7 @@ suite.define(() => {
         viewport: { height: 900, width: 1280 },
       },
       async ({ page }) => {
-        await installMockGateway(page, {
+        const gateway = await installMockGateway(page, {
           featureMethods: ["channels.status", "channels.pairing.list", "wizard.start"],
           methodResponses: {
             "channels.status": {
@@ -114,6 +114,23 @@ suite.define(() => {
         }
 
         expect(colors.description).toBe(colors.label);
+
+        await page.emulateMedia({ forcedColors: "active" });
+        await page.keyboard.press("ArrowDown");
+        const nextOption = picker.getByRole("option", { name: "Add another iMessage account" });
+        await expect
+          .poll(() => nextOption.evaluate((option) => option.matches(":focus-visible")))
+          .toBe(true);
+        expect(
+          await nextOption.evaluate((option) => {
+            const style = getComputedStyle(option);
+            return style.outlineStyle !== "none" && Number.parseFloat(style.outlineWidth) >= 2;
+          }),
+        ).toBe(true);
+        expect(await activeOption.getAttribute("aria-selected")).toBe("true");
+        await page.keyboard.press("Enter");
+        const answer = await gateway.waitForRequest("wizard.next");
+        expect(answer.params).toMatchObject({ answer: { value: "another" } });
       },
     );
   });

--- a/ui/src/e2e/sidebar-settings.e2e.test.ts
+++ b/ui/src/e2e/sidebar-settings.e2e.test.ts
@@ -12,6 +12,40 @@ import {
 const suite = createSidebarCustomizationSuite("Control UI sidebar settings mocked Gateway E2E");
 
 suite.define(() => {
+  it("dismisses an open font picker before exiting Settings with Escape", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1440 },
+    });
+    const page = await context.newPage();
+    await installMockGateway(page);
+    try {
+      await page.goto(`${suite.server.baseUrl}new`);
+      await page.locator(".new-session-page__message").waitFor({ state: "visible" });
+      await page.keyboard.press("Control+Shift+,");
+      const { sidebar } = await waitForControlUiSettingsTakeover(page);
+      const picker = page.locator("#settings-font-chat");
+      await picker.click();
+      const selected = picker.locator("wa-option:state(selected)");
+      await selected.waitFor({ state: "visible" });
+      const selectedValue = await selected.getAttribute("value");
+      await page.keyboard.press("ArrowDown");
+      await page.keyboard.press("Escape");
+      await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/appearance");
+      await expect.poll(() => picker.getAttribute("open")).toBeNull();
+      expect(await selected.getAttribute("value")).toBe(selectedValue);
+      expect(
+        await picker.locator('input[role="combobox"]').evaluate((input) => input.matches(":focus")),
+      ).toBe(true);
+      await sidebar.locator(".settings-sidebar__item").first().focus();
+      await page.keyboard.press("Escape");
+      await expect.poll(() => new URL(page.url()).pathname).toBe("/new");
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
   it.each([
     { state: "ready", pending: false, focusSearch: false },
     { state: "pending with trigger focus", pending: true, focusSearch: false },

--- a/ui/src/e2e/theme-muted-contrast.e2e.test.ts
+++ b/ui/src/e2e/theme-muted-contrast.e2e.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { finishElementAnimations } from "../test-helpers/animations.ts";
 import { controlUiBundledGatewayUrl, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -41,9 +42,10 @@ const surfaceTokens = ["--bg", "--bg-elevated", "--bg-muted", "--card", "--panel
 function themeConfigResponse(
   family: "claw" | "knot" | "dash" | "absolutely" | "tide" | "beacon" | "phosphor",
   mode: "dark" | "light",
+  accent?: string,
 ) {
   const config = {
-    ui: { prefs: { ...(family === "claw" ? {} : { theme: family }), themeMode: mode } },
+    ui: { prefs: { ...(family === "claw" ? {} : { theme: family }), themeMode: mode, accent } },
   };
   const hash = `theme-contrast-${family}-${mode}`;
   return {
@@ -82,9 +84,15 @@ function parseRenderedColor(color: string): RenderedColor {
     /^rgba?\(\s*(\d+(?:\.\d+)?)\s*,\s*(\d+(?:\.\d+)?)\s*,\s*(\d+(?:\.\d+)?)(?:\s*,\s*(\d*\.?\d+))?\s*\)$/u.exec(
       trimmed,
     );
-  if (rgb) {
-    const [red, green, blue] = rgb.slice(1, 4).map(Number);
-    const alpha = rgb[4] === undefined ? 1 : Number(rgb[4]);
+  const srgb = /^color\(srgb\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)(?:\s*\/\s*([\d.]+))?\s*\)$/u.exec(
+    trimmed,
+  );
+  const rendered = rgb ?? srgb;
+  if (rendered) {
+    const [red, green, blue] = rendered
+      .slice(1, 4)
+      .map((value) => Number(value) * (srgb ? 255 : 1));
+    const alpha = rendered[4] === undefined ? 1 : Number(rendered[4]);
     if (
       red !== undefined &&
       green !== undefined &&
@@ -144,9 +152,18 @@ const suite = createControlUiE2eSuite({
 });
 
 suite.define(() => {
-  it.each(themeCases)(
-    "keeps the real $resolved appearance selection at WCAG AA",
-    async ({ family, mode, resolved }) => {
+  it.each(
+    themeCases.flatMap(({ family, mode, resolved }) =>
+      (family === "claw" ? [undefined, "#000000", "#ffffff"] : [undefined]).map((accent) => ({
+        family,
+        mode,
+        resolved,
+        accent,
+      })),
+    ),
+  )(
+    "keeps $resolved appearance and picker states legible (accent $accent)",
+    async ({ family, mode, resolved, accent }) => {
       const context = await suite.newBrowserContext({
         colorScheme: mode,
         locale: "en-US",
@@ -171,7 +188,7 @@ suite.define(() => {
       const page = await context.newPage();
       const gateway = await installMockGateway(page, {
         methodResponses: {
-          "config.get": themeConfigResponse(initialFamily, mode),
+          "config.get": themeConfigResponse(initialFamily, mode, accent),
         },
       });
 
@@ -183,7 +200,7 @@ suite.define(() => {
         await selectedCard.waitFor({ state: "visible" });
         await gateway.waitForRequest("config.get");
         const initialConfigGets = (await gateway.getRequests("config.get")).length;
-        const committed = themeConfigResponse(family, mode);
+        const committed = themeConfigResponse(family, mode, accent);
         await gateway.deferNext("config.patch");
         await selectedCard.click();
         const patch = await gateway.waitForRequest("config.patch");
@@ -290,17 +307,78 @@ suite.define(() => {
           `${resolved}: actual rendered muted Appearance description, including ancestor backgrounds and opacity`,
         ).toBeGreaterThanOrEqual(4.5);
 
+        const picker = page.locator("#settings-font-chat");
+        await picker.click();
+        const selected = picker.locator("wa-option:state(selected)");
+        await selected.waitFor({ state: "visible" });
+        const optionPaint = async (option: typeof selected) => {
+          await option.evaluate(finishElementAnimations);
+          return option.evaluate((element) => {
+            const style = getComputedStyle(element);
+            return {
+              background: style.backgroundColor,
+              label: getComputedStyle(element.querySelector(".picker-select__label")!).color,
+              description: getComputedStyle(element.querySelector(".picker-select__description")!)
+                .color,
+              outline: style.outlineStyle,
+              outlineWidth: Number.parseFloat(style.outlineWidth),
+              outlineColor: style.outlineColor,
+            };
+          });
+        };
+        // Options are slotted into a shadow listbox: light-DOM ancestors miss its painted surface.
+        const listboxBackground = await picker
+          .locator('[part="listbox"]')
+          .evaluate((element) => getComputedStyle(element).backgroundColor);
+        const assertOptionContrast = async (option: typeof selected) => {
+          const paint = await optionPaint(option);
+          const background = compositeColor(
+            parseRenderedColor(paint.background),
+            parseRenderedColor(listboxBackground),
+          );
+          for (const text of [paint.label, paint.description]) {
+            expect(
+              contrastRatio(text, background),
+              `${resolved} picker text`,
+            ).toBeGreaterThanOrEqual(4.5);
+          }
+          return { paint, background };
+        };
+        const selectedValue = await selected.getAttribute("value");
+        const initialPaint = await optionPaint(selected);
+        await page.keyboard.press("ArrowDown");
+        const current = picker.locator("wa-option:state(current)");
+        await expect.poll(() => current.getAttribute("value")).not.toBe(selectedValue);
+        expect(await selected.getAttribute("value")).toBe(selectedValue);
+        await expect
+          .poll(async () => (await optionPaint(selected)).background)
+          .toBe(initialPaint.background);
+        await assertOptionContrast(selected);
+        const focused = await assertOptionContrast(current);
+        expect(focused.paint.outline).not.toBe("none");
+        expect(focused.paint.outlineWidth).toBeGreaterThanOrEqual(2);
+        expect(
+          contrastRatio(focused.paint.outlineColor, focused.background),
+        ).toBeGreaterThanOrEqual(3);
+        await picker.locator('wa-option[value="system"]').hover();
+        await assertOptionContrast(picker.locator('wa-option[value="system"]'));
+        await page.keyboard.press("Escape");
+        expect(new URL(page.url()).pathname).toBe("/settings/appearance");
+        expect(await selected.getAttribute("value")).toBe(selectedValue);
+
         if (captureUiProof) {
           await mkdir(proofDirectory, { recursive: true });
+          const proofName = accent ? `${resolved}-${accent.slice(1)}` : resolved;
           await page.screenshot({
             animations: "disabled",
             fullPage: true,
-            path: path.join(proofDirectory, `${resolved}.png`),
+            path: path.join(proofDirectory, `${proofName}.png`),
           });
           await writeFile(
-            path.join(proofDirectory, `${resolved}.json`),
+            path.join(proofDirectory, `${proofName}.json`),
             `${JSON.stringify(
               {
+                accent,
                 description: {
                   background: descriptionBackground,
                   contrast: Number(descriptionContrast.toFixed(3)),

--- a/ui/src/styles/select-picker.css
+++ b/ui/src/styles/select-picker.css
@@ -1,7 +1,3 @@
-wa-select.settings-select {
-  --wa-form-control-activated-color: var(--primary);
-}
-
 wa-select.settings-select::part(combobox) {
   min-height: var(--settings-control-height);
   padding-inline: 10px;
@@ -42,6 +38,9 @@ wa-select.settings-select::part(listbox) {
 }
 
 wa-select.settings-select wa-option {
+  --wa-form-control-activated-color: var(--bg-hover);
+  --wa-color-neutral-fill-normal: var(--bg-hover);
+
   padding: 6px 8px;
   border-radius: calc(var(--radius-md) - 4px);
   font-size: var(--control-ui-text-md);
@@ -49,18 +48,20 @@ wa-select.settings-select wa-option {
   cursor: var(--cursor-action);
 }
 
-/* The roving "current" option already carries the accent fill; the global
-   :focus-visible accent outline on top of it is pure noise. */
+/* Selection stays visible while keyboard focus moves. Text-backed focus ink
+   also remains visible with black/white custom accents. */
 wa-select.settings-select wa-option:focus-visible {
-  outline: none;
+  outline: 2px solid var(--text);
+  outline-offset: -2px;
 }
 
-wa-select.settings-select wa-option:state(current) {
-  color: var(--primary-foreground);
+wa-select.settings-select wa-option:state(selected) {
+  background: color-mix(in srgb, var(--accent) 12%, var(--bg-elevated));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 60%, transparent);
 }
 
-.picker-select__option {
-  color: var(--text);
+wa-select.settings-select wa-option::part(checked-icon) {
+  color: color-mix(in srgb, var(--text) 80%, var(--accent));
 }
 
 .picker-select [slot="start"] {
@@ -85,14 +86,14 @@ wa-select.settings-select wa-option:state(current) {
 .picker-select__description {
   min-width: 0;
   overflow: hidden;
-  color: var(--muted);
+  color: color-mix(in srgb, var(--muted) 80%, var(--text));
   font-size: 0.75rem;
   line-height: 1.2;
   text-overflow: ellipsis;
   white-space: normal;
 }
 
-.picker-select__option:state(current) .picker-select__description {
+.picker-select__option:is(:state(current), :state(selected)) .picker-select__description {
   color: inherit;
 }
 
@@ -117,8 +118,7 @@ wa-select.settings-select wa-option:state(current) {
   display: none;
 }
 
-/* Forced colors suppresses the box-shadow ring and accent fill that stand in
-   for the outlines removed above, so restore system-color outlines there. */
+/* System colors replace decorative fills/shadows; keep keyboard focus explicit. */
 @media (forced-colors: active) {
   wa-select.settings-select[open]::part(combobox),
   wa-select.settings-select:focus-within::part(combobox) {
@@ -128,6 +128,5 @@ wa-select.settings-select wa-option:state(current) {
 
   wa-select.settings-select wa-option:focus-visible {
     outline: 2px solid SelectedItem;
-    outline-offset: 2px;
   }
 }

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -3,7 +3,7 @@
  * One structural pattern for every settings surface:
  *   .settings-page > .settings-section > .settings-group > .settings-row
  *
- * Rules (see ui/docs/settings-design.md):
+ * Rules (see ui/docs/design-system/settings-design.md):
  * - Sections are typography (heading outside any surface), not chrome.
  * - Exactly one level of elevation: the group. Never nest a card in a group.
  * - Status is a dot + plain text, never a colored pill.


### PR DESCRIPTION
Closes #131995

## What Problem This Solves

Shared pickers make the roving keyboard option the prominent state, while the committed selection can lose its highlight as focus moves. Typography also looks louder than neighboring Appearance controls. The original muted-on-accent subtext bug is already fixed by #131402; this is the maintainer-approved refinement on top of it.

The real screenshot flow also exposed a connected bug: Escape from a font option exits Settings instead of only dismissing the popup.

## Why This Change Was Made

Use one shared picker treatment: a quiet theme-aware tint/inset border for selection, neutral hover/current fill, brighter secondary text, and a distinct text-backed keyboard outline. The checkmark remains legible with black/white custom accents. Keep all existing dimensions, spacing, typography, corners, menu collision bounds, and overlay elevation.

The shared Settings Escape owner now recognizes an open Web Awesome select host. Slotted options hide their listbox in shadow DOM, and the shell's earlier document listener otherwise consumes Escape first. No per-picker handlers or changes to closed-trigger behavior. Also correct one stale settings-design comment link.

**Scope:** no new config, APIs, dependencies, schemas, persistence behavior, or component. Native selects retain platform rendering. Shared font/model/channel/wizard/workboard picker consumers inherit the CSS fix.

**Production LOC:** +19/-19, net 0. **Tests:** +151/-20, net +131 (includes the CI sequencing repair below). Removed the inverse current-row ink override and redundant option-color rule. Existing theme/browser fixtures absorb the regression coverage.

## User Impact

Selected choices remain recognizable while browsing other options with the keyboard. Picker labels and descriptions remain readable, and the visual treatment fits neighboring settings. Escape closes the open picker without losing the Settings page or changing its value.

## Evidence

AI-assisted; source, dependency contracts, tests, and every attached screenshot were inspected.

### Real before/after

Captured from a real, task-isolated loopback Gateway with Chromium on [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/33198096702), lease `tbx_01m14s1y28nwdvf9993bj77jfz` (stopped). No operator Gateway/state, mocked transport, injected CSS, or generated mockups. Baseline CSS comes from `f7c5bd30730c726cf586fdbfbbbaea7133f2d72b`, already including #131402. Candidate UI was rebuilt before capture.

| Before | After |
| --- | --- |
| ![Before: saturated selected row in surrounding Appearance settings](https://github.com/user-attachments/assets/c8da91bf-3f2d-45d0-ab4c-4e40fb682a71) | ![After: quieter selected row matching neighboring settings](https://github.com/user-attachments/assets/039d4884-d509-4660-81cc-b175021f1cde) |

![The selected Atkinson option stays highlighted while Fraunces has keyboard focus](https://github.com/user-attachments/assets/15547e05-efb8-4a84-82c1-95b9a7785a5c)

### Behavioral proof

- Before: the theme browser regression observed selected fill changing from `rgb(217, 119, 87)` to transparent on ArrowDown. The independent Escape regression observed `/new` instead of `/settings/appearance`.
- After: **44 browser tests passed** in one final run. Coverage: all 14 built-in theme/mode combinations plus black/white custom accents in both modes, rendered selected/current/hover text contrast, distinct focus, forced colors, wizard answer submission, font persistence, Settings Escape ownership, and neighboring Inbox behavior.
- **29 local unit tests passed** for shared picker and native shell/editor/modal siblings.
- UI build/performance checks, UI typecheck, scoped oxlint/stylelint/format, `git diff --check`, and fresh Codex Autoreview passed. Autoreview reported no accepted/actionable findings.

Commands:

```sh
pnpm ui:build
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/theme-muted-contrast.e2e.test.ts ui/src/e2e/channel-wizard-option-contrast.e2e.test.ts ui/src/e2e/sidebar-settings.e2e.test.ts ui/src/e2e/theme-typography.e2e.test.ts
node scripts/run-vitest.mjs ui/src/app/app-host-native-shell.test.ts ui/src/components/select-picker.test.ts
node scripts/run-tsgo.mjs -p tsconfig.ui.json
```

**Local environment limitation:** the local UI build/browser attempt and full `check:changed` hit actual `ENOSPC`; the latter failed writing a core-test `.tsbuildinfo`, not a source diagnostic. Browser/build proof therefore ran on Testbox; the non-incremental UI typecheck and scoped lint/unit checks passed locally. Exact-head hosted CI remains the final merge gate.

### Owner/dependency evidence

`view-appearance.ts` → `renderPicker` → `select-picker.css`; sibling adapters `model-picker.ts`, `channel-picker.ts`, `wizard-step-controls.ts`, and `workboard-select.ts`. Installed Web Awesome option/select source confirms separate selected/current states, the checked-icon part, reflected open attribute, and ArrowDown-versus-Enter behavior. Styling the committed `:state(selected)` is deliberate; `[selected]` is only the initial/default input.

The Escape guard was carried forward in #117103 (`7bae24760b09`, authored and merged by @steipete, 2026-07-31); that is guard provenance, not a claim that the refactor introduced the interaction defect. The fix stays at the shared shell boundary. A generic composed-path rewrite was considered but would also change closed shadow-input Escape behavior, which this PR intentionally preserves.



### CI repair / ClawSweeper rank-up follow-through

The failed [UI E2E shard](https://github.com/openclaw/openclaw/actions/runs/33199817651/job/98946293681) was traced to an existing `board-mcp-app.e2e.test.ts` ordering race, not the picker change. Its 7-second fixture lease renews 5 seconds before expiry; the 2211ms failure sampled the iframe between teardown and replacement.

Commit `38544d320f3ad3620dd33f797b35d36530c517ab` moves the existing renewal wait before color sampling and requires the recorded `mcp.app.view` request for `renewed-view`, which the owner emits after removing the old frame. All existing color/request assertions remain; no production code, retries, or expanded overall wait budget. The four-case dashboard E2E file passes locally, UI typecheck/scoped lint pass, and a fresh Autoreview of this test-only repair is clean. Exact-head CI is running again.

This directly addresses the latest ClawSweeper rank-up request to resolve the failed shard. No re-review request is needed for a fresh review followed only by its requested CI repair.
