### PR TITLE
fix(ui): compact mobile session actions

### DIFF
--- a/config/control-ui-startup-budget-baseline.json
+++ b/config/control-ui-startup-budget-baseline.json
@@ -1,5 +1,5 @@
 {
-  "startupJsGzipBytes": 346461,
-  "reason": "standing-grant scope line + grants ledger (#131602); recorded at the CI e2e-lane build (346461 B) — checks-ui and local builds of the same tree measure ~600 B less, beyond the 64 B variance allowance",
+  "startupJsGzipBytes": 347255,
+  "reason": "compact mobile session sharing with preserved draft state and a bounded member drilldown; recorded at the CI build-artifacts lane (347255 B)",
   "updatedAt": "2026-08-28"
 }

--- a/ui/src/e2e/mobile-chat-session-menu.e2e.test.ts
+++ b/ui/src/e2e/mobile-chat-session-menu.e2e.test.ts
@@ -40,7 +40,7 @@ suite.define(() => {
             {
               ...sessionRow(sessionKey, "Mobile menu", Date.parse("2026-08-28T12:00:00.000Z")),
               sharingRole: "owner",
-              visibility: "shared",
+              visibility: "draft",
             },
           ]),
           "session.members.listEvidence": {
@@ -49,7 +49,11 @@ suite.define(() => {
             members: [],
             identities: [
               { type: "human", id: "owner", label: "Owner" },
-              { type: "human", id: "vyctor", label: "Vyctor" },
+              ...Array.from({ length: 30 }, (_, index) => ({
+                type: "human" as const,
+                id: `member-${index}`,
+                label: `Member ${index}`,
+              })),
             ],
             role: "owner",
             allowedVisibilities: ["shared", "read-only", "suggest", "draft"],
@@ -87,12 +91,62 @@ suite.define(() => {
           .poll(() => page.getByRole("button", { name: "Session sharing" }).count())
           .toBe(0);
         await menuHost.locator('wa-dropdown-item[value="compact:open-sharing"]').click();
-        await menuHost.locator('wa-dropdown-item[value="visibility:shared"]').waitFor();
+        const publish = menuHost.locator(".chat-pane__publish-draft");
+        await publish.waitFor();
         await menuHost.getByText("Members", { exact: true }).waitFor();
+        await expect
+          .poll(() => menu.evaluate((element) => Math.round(element.getBoundingClientRect().height)))
+          .toBeLessThanOrEqual(421);
+        await expect.poll(() => menu.evaluate((element) => element.scrollHeight)).toBeGreaterThan(
+          await menu.evaluate((element) => element.clientHeight),
+        );
+        await expect
+          .poll(() =>
+            publish.evaluate((element) => Math.round(element.getBoundingClientRect().height)),
+          )
+          .toBe(34);
         await captureUiProof(page, `mobile-more-sharing-followup-after-${colorScheme}.png`);
       } finally {
         await context.close();
       }
     },
   );
+
+  it("keeps the mobile draft indicator for non-manager sessions", async () => {
+    const sessionKey = "agent:main:mobile-member-draft";
+    const context = await suite.browser.newContext({
+      hasTouch: true,
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 844, width: 390 },
+    });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      allowedSessionVisibilities: ["shared", "read-only", "suggest", "draft"],
+      featureMethods: ["chat.metadata", "chat.startup", "session.visibility.set"],
+      operatorScopes: ["operator.read"],
+      sessionKey,
+      methodResponses: {
+        "sessions.list": sessionsListResponse([
+          {
+            ...sessionRow(sessionKey, "Member draft", Date.parse("2026-08-28T12:00:00.000Z")),
+            sharingRole: "member",
+            visibility: "draft",
+          },
+        ]),
+      },
+    });
+
+    try {
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
+      await page.locator(".chat-pane__draft-indicator").waitFor();
+      await page.getByRole("button", { name: "Actions for Member draft" }).click();
+      const menuHost = page.locator("openclaw-chat-header-session-menu");
+      await expect
+        .poll(() => menuHost.locator('wa-dropdown-item[value="compact:open-sharing"]').count())
+        .toBe(0);
+    } finally {
+      await context.close();
+    }
+  });
 });

--- a/ui/src/e2e/mobile-chat-session-menu.e2e.test.ts
+++ b/ui/src/e2e/mobile-chat-session-menu.e2e.test.ts
@@ -95,11 +95,13 @@ suite.define(() => {
         await publish.waitFor();
         await menuHost.getByText("Members", { exact: true }).waitFor();
         await expect
-          .poll(() => menu.evaluate((element) => Math.round(element.getBoundingClientRect().height)))
+          .poll(() =>
+            menu.evaluate((element) => Math.round(element.getBoundingClientRect().height)),
+          )
           .toBeLessThanOrEqual(421);
-        await expect.poll(() => menu.evaluate((element) => element.scrollHeight)).toBeGreaterThan(
-          await menu.evaluate((element) => element.clientHeight),
-        );
+        await expect
+          .poll(() => menu.evaluate((element) => element.scrollHeight))
+          .toBeGreaterThan(await menu.evaluate((element) => element.clientHeight));
         await expect
           .poll(() =>
             publish.evaluate((element) => Math.round(element.getBoundingClientRect().height)),

--- a/ui/src/e2e/mobile-chat-session-menu.e2e.test.ts
+++ b/ui/src/e2e/mobile-chat-session-menu.e2e.test.ts
@@ -64,10 +64,16 @@ suite.define(() => {
         const menuHost = page.locator("openclaw-chat-header-session-menu");
         await menu.waitFor({ state: "visible" });
         const rootItems = menuHost.locator(":scope > wa-dropdown > wa-dropdown-item");
-        const minimumHeights = await rootItems.evaluateAll((items) =>
-          items.map((item) => getComputedStyle(item).minHeight),
-        );
-        expect(minimumHeights).toEqual(minimumHeights.map(() => "40px"));
+        await expect
+          .poll(() =>
+            rootItems.evaluateAll((items) =>
+              items.map((item) => Math.round(item.getBoundingClientRect().height)),
+            ),
+          )
+          .toEqual(Array.from({ length: 15 }, () => 34));
+        await expect
+          .poll(() => menu.evaluate((element) => element.getBoundingClientRect().height))
+          .toBeLessThan(550);
         const deleteIconColor = await menuHost
           .locator('wa-dropdown-item[value="delete"] .session-menu__icon')
           .evaluate((element) => getComputedStyle(element).color);
@@ -75,7 +81,7 @@ suite.define(() => {
           .locator('wa-dropdown-item[value="delete"] .session-menu__text')
           .evaluate((element) => getComputedStyle(element).color);
         expect(deleteIconColor).toBe(deleteLabelColor);
-        await captureUiProof(page, `mobile-more-after-${colorScheme}.png`);
+        await captureUiProof(page, `mobile-more-followup-after-${colorScheme}.png`);
 
         await expect
           .poll(() => page.getByRole("button", { name: "Session sharing" }).count())
@@ -83,7 +89,7 @@ suite.define(() => {
         await menuHost.locator('wa-dropdown-item[value="compact:open-sharing"]').click();
         await menuHost.locator('wa-dropdown-item[value="visibility:shared"]').waitFor();
         await menuHost.getByText("Members", { exact: true }).waitFor();
-        await captureUiProof(page, `mobile-more-sharing-after-${colorScheme}.png`);
+        await captureUiProof(page, `mobile-more-sharing-followup-after-${colorScheme}.png`);
       } finally {
         await context.close();
       }

--- a/ui/src/e2e/mobile-chat-session-menu.e2e.test.ts
+++ b/ui/src/e2e/mobile-chat-session-menu.e2e.test.ts
@@ -1,0 +1,92 @@
+import { expect, it } from "vitest";
+import {
+  captureUiProof,
+  controlUiSessionUrl,
+  createSessionManagementE2eSuite,
+  installMockGateway,
+  sessionRow,
+  sessionsListResponse,
+} from "./session-management.test-support.ts";
+
+const suite = createSessionManagementE2eSuite(true);
+
+suite.define(() => {
+  it.each(["light", "dark"] as const)(
+    "keeps mobile sharing inside the %s session More menu",
+    async (colorScheme) => {
+      const sessionKey = "agent:main:mobile-more";
+      const context = await suite.browser.newContext({
+        colorScheme,
+        hasTouch: true,
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 844, width: 390 },
+      });
+      const page = await context.newPage();
+      await installMockGateway(page, {
+        allowedSessionVisibilities: ["shared", "read-only", "suggest", "draft"],
+        featureMethods: [
+          "chat.metadata",
+          "chat.startup",
+          "session.visibility.set",
+          "session.members.listEvidence",
+          "session.members.add",
+          "session.members.remove",
+        ],
+        operatorScopes: ["operator.read", "operator.write"],
+        sessionKey,
+        methodResponses: {
+          "sessions.list": sessionsListResponse([
+            {
+              ...sessionRow(sessionKey, "Mobile menu", Date.parse("2026-08-28T12:00:00.000Z")),
+              sharingRole: "owner",
+              visibility: "shared",
+            },
+          ]),
+          "session.members.listEvidence": {
+            sessionKey,
+            owner: { type: "human", id: "owner", label: "Owner" },
+            members: [],
+            identities: [
+              { type: "human", id: "owner", label: "Owner" },
+              { type: "human", id: "vyctor", label: "Vyctor" },
+            ],
+            role: "owner",
+            allowedVisibilities: ["shared", "read-only", "suggest", "draft"],
+          },
+        },
+      });
+
+      try {
+        await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
+        await page.getByRole("button", { name: "Actions for Mobile menu" }).click();
+        const menu = page.getByRole("menu", { name: "Actions for Mobile menu" });
+        const menuHost = page.locator("openclaw-chat-header-session-menu");
+        await menu.waitFor({ state: "visible" });
+        const rootItems = menuHost.locator(":scope > wa-dropdown > wa-dropdown-item");
+        const minimumHeights = await rootItems.evaluateAll((items) =>
+          items.map((item) => getComputedStyle(item).minHeight),
+        );
+        expect(minimumHeights).toEqual(minimumHeights.map(() => "40px"));
+        const deleteIconColor = await menuHost
+          .locator('wa-dropdown-item[value="delete"] .session-menu__icon')
+          .evaluate((element) => getComputedStyle(element).color);
+        const deleteLabelColor = await menuHost
+          .locator('wa-dropdown-item[value="delete"] .session-menu__text')
+          .evaluate((element) => getComputedStyle(element).color);
+        expect(deleteIconColor).toBe(deleteLabelColor);
+        await captureUiProof(page, `mobile-more-after-${colorScheme}.png`);
+
+        await expect
+          .poll(() => page.getByRole("button", { name: "Session sharing" }).count())
+          .toBe(0);
+        await menuHost.locator('wa-dropdown-item[value="compact:open-sharing"]').click();
+        await menuHost.locator('wa-dropdown-item[value="visibility:shared"]').waitFor();
+        await menuHost.getByText("Members", { exact: true }).waitFor();
+        await captureUiProof(page, `mobile-more-sharing-after-${colorScheme}.png`);
+      } finally {
+        await context.close();
+      }
+    },
+  );
+});

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -47,7 +47,10 @@ import {
   resolveChatPaneParentSession,
   resolveChatPaneWorkspace,
 } from "./components/chat-pane-header.ts";
-import { renderChatSessionSharing } from "./components/chat-session-sharing.ts";
+import {
+  canManageChatSessionSharing,
+  renderChatSessionSharing,
+} from "./components/chat-session-sharing.ts";
 import type { SessionWorkspaceProps } from "./components/chat-session-workspace.ts";
 import { renderContinueInTerminalDialog } from "./components/continue-in-terminal-dialog.ts";
 import { hasAbortableSessionRun } from "./run-lifecycle.ts";
@@ -491,7 +494,10 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
         },
         onDockSideChange: (dock) => this.handleBoardDockChange(dock),
       }),
-      sharingControl: sharing && !this.narrow ? renderChatSessionSharing(sharing) : nothing,
+      sharingControl:
+        sharing && (!this.narrow || !canManageChatSessionSharing(sharing.session))
+          ? renderChatSessionSharing(sharing)
+          : nothing,
       sessionMenuAction:
         row && this.state
           ? html`<openclaw-chat-header-session-menu

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -1,7 +1,7 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { html, nothing } from "lit";
 import { buildControlUiResourcePath } from "../../../../src/gateway/control-ui-resource-routes.js";
-import type { GatewaySessionRow } from "../../api/types.ts";
+import type { GatewaySessionRow, SessionVisibility } from "../../api/types.ts";
 import { resolveControlUiAuthCandidates } from "../../app/control-ui-auth.ts";
 import { isNativeLocalGateway } from "../../app/native-editor-locality.runtime.ts";
 import { hasOperatorAdminAccess } from "../../app/operator-access.ts";
@@ -178,6 +178,30 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
       sharingReadAccess.allowed || sharingVisibilityAccess.allowed
         ? undefined
         : sharingReadAccess.reason;
+    const sharing =
+      sharingMethodsSupported && row
+        ? {
+            session: row,
+            state: this.sessionSharingStates.get(this.sessionSharingCacheKey(row.key)),
+            allowedVisibilities: sharingSnapshot.hello?.policy?.allowedSessionVisibilities,
+            membersAvailable: sharingReadAccess.allowed,
+            openDisabledReason: sharingOpenDisabledReason,
+            visibilityDisabledReason: sharingVisibilityAccess.allowed
+              ? undefined
+              : sharingVisibilityAccess.reason,
+            memberAddDisabledReason: sharingMemberAddAccess.allowed
+              ? undefined
+              : sharingMemberAddAccess.reason,
+            memberRemoveDisabledReason: sharingMemberRemoveAccess.allowed
+              ? undefined
+              : sharingMemberRemoveAccess.reason,
+            onOpen: () => void this.loadSessionSharing(row),
+            onVisibilityChange: (visibility: SessionVisibility) =>
+              void this.setSessionVisibility(row, visibility),
+            onMemberChange: (identityId: string, member: boolean) =>
+              void this.setSessionMember(row, identityId, member),
+          }
+        : null;
     const renameAccess = row
       ? readSessionMethodAccess(this.context.gateway.snapshot, {
           method: "sessions.patch",
@@ -467,31 +491,7 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
         },
         onDockSideChange: (dock) => this.handleBoardDockChange(dock),
       }),
-      sharingControl: sharingMethodsSupported
-        ? renderChatSessionSharing({
-            session: row,
-            state: row
-              ? this.sessionSharingStates.get(this.sessionSharingCacheKey(row.key))
-              : undefined,
-            allowedVisibilities: sharingSnapshot.hello?.policy?.allowedSessionVisibilities,
-            membersAvailable: sharingReadAccess.allowed,
-            openDisabledReason: sharingOpenDisabledReason,
-            visibilityDisabledReason: sharingVisibilityAccess.allowed
-              ? undefined
-              : sharingVisibilityAccess.reason,
-            memberAddDisabledReason: sharingMemberAddAccess.allowed
-              ? undefined
-              : sharingMemberAddAccess.reason,
-            memberRemoveDisabledReason: sharingMemberRemoveAccess.allowed
-              ? undefined
-              : sharingMemberRemoveAccess.reason,
-            onOpen: () => row && void this.loadSessionSharing(row),
-            onVisibilityChange: (visibility) =>
-              row && void this.setSessionVisibility(row, visibility),
-            onMemberChange: (identityId, member) =>
-              row && void this.setSessionMember(row, identityId, member),
-          })
-        : nothing,
+      sharingControl: sharing && !this.narrow ? renderChatSessionSharing(sharing) : nothing,
       sessionMenuAction:
         row && this.state
           ? html`<openclaw-chat-header-session-menu
@@ -518,6 +518,7 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
               .panelActions=${panelMenuActions}
               .layoutActions=${layoutMenuActions}
               .statusActions=${this.compactHeaderStatusActions()}
+              .sharing=${sharing}
               .groups=${knownGroups}
               .ownerOptions=${ownerOptions}
               .selfOwner=${selfOwner}

--- a/ui/src/pages/chat/components/chat-header-session-menu.test.ts
+++ b/ui/src/pages/chat/components/chat-header-session-menu.test.ts
@@ -603,6 +603,11 @@ describe("chat header session menu", () => {
     await compact.updateComplete;
     expect(onOpen).toHaveBeenCalledOnce();
     expect(
+      compact
+        .querySelector("wa-dropdown")
+        ?.classList.contains("chat-header-session-menu--compact-sharing"),
+    ).toBe(true);
+    expect(
       Array.from(
         compact.querySelectorAll<MenuItemElement>(":scope > wa-dropdown > wa-dropdown-item"),
       ).map(itemLabel),

--- a/ui/src/pages/chat/components/chat-header-session-menu.test.ts
+++ b/ui/src/pages/chat/components/chat-header-session-menu.test.ts
@@ -608,9 +608,7 @@ describe("chat header session menu", () => {
       ).map(itemLabel),
     ).toEqual(["Back", "Publish draft", "Read-only", "Suggest", "Draft", "Vyctor"]);
     expect(
-      compact
-        .querySelector(".chat-pane__publish-draft")
-        ?.classList.contains("session-menu__item"),
+      compact.querySelector(".chat-pane__publish-draft")?.classList.contains("session-menu__item"),
     ).toBe(true);
     select(compact, "visibility:read-only");
     expect(onVisibilityChange).toHaveBeenCalledWith("read-only");

--- a/ui/src/pages/chat/components/chat-header-session-menu.test.ts
+++ b/ui/src/pages/chat/components/chat-header-session-menu.test.ts
@@ -576,7 +576,7 @@ describe("chat header session menu", () => {
         key: "agent:main:shared",
         kind: "direct",
         updatedAt: 1,
-        visibility: "shared",
+        visibility: "draft",
         sharingRole: "owner",
       },
       state: {
@@ -606,7 +606,12 @@ describe("chat header session menu", () => {
       Array.from(
         compact.querySelectorAll<MenuItemElement>(":scope > wa-dropdown > wa-dropdown-item"),
       ).map(itemLabel),
-    ).toEqual(["Back", "Shared", "Read-only", "Suggest", "Draft", "Vyctor"]);
+    ).toEqual(["Back", "Publish draft", "Read-only", "Suggest", "Draft", "Vyctor"]);
+    expect(
+      compact
+        .querySelector(".chat-pane__publish-draft")
+        ?.classList.contains("session-menu__item"),
+    ).toBe(true);
     select(compact, "visibility:read-only");
     expect(onVisibilityChange).toHaveBeenCalledWith("read-only");
   });

--- a/ui/src/pages/chat/components/chat-header-session-menu.test.ts
+++ b/ui/src/pages/chat/components/chat-header-session-menu.test.ts
@@ -19,13 +19,14 @@ import {
 } from "../chat-pane.test-support.ts";
 import type { ChatPageHost } from "../chat-state-host.ts";
 import { createBackgroundTasksProps } from "./chat-background-tasks.ts";
-import "./chat-header-session-menu.ts";
 import type {
   HeaderMenuAction,
   HeaderMenuActionKind,
   HeaderMenuQuickAction,
   HeaderMenuStatusAction,
 } from "./chat-header-session-menu.ts";
+import "./chat-header-session-menu.ts";
+import type { ChatSessionSharingProps } from "./chat-session-sharing.ts";
 import { createSessionWorkspaceProps } from "./chat-session-workspace.ts";
 
 type HeaderMenuElement = HTMLElement & { updateComplete: Promise<boolean> };
@@ -69,6 +70,7 @@ async function mountMenu(
     panelActions?: HeaderMenuQuickAction[];
     layoutActions?: HeaderMenuQuickAction[];
     statusActions?: HeaderMenuStatusAction[];
+    sharing?: ChatSessionSharingProps | null;
     ownerOptions?: SessionOwnerOption[];
     selfOwner?: SessionOwnerOption | null;
     currentOwnerId?: string | null;
@@ -107,6 +109,7 @@ async function mountMenu(
       .panelActions=${options.panelActions ?? []}
       .layoutActions=${options.layoutActions ?? []}
       .statusActions=${options.statusActions ?? []}
+      .sharing=${options.sharing ?? null}
       .groups=${["Projects"]}
       .ownerOptions=${options.ownerOptions ?? []}
       .selfOwner=${options.selfOwner ?? null}
@@ -563,6 +566,49 @@ describe("chat header session menu", () => {
       kind: "assign-owner",
       owner: { type: "human", id: "profile-ada" },
     });
+  });
+
+  it("drills into session sharing only from the compact menu", async () => {
+    const onOpen = vi.fn();
+    const onVisibilityChange = vi.fn();
+    const sharing = {
+      session: {
+        key: "agent:main:shared",
+        kind: "direct",
+        updatedAt: 1,
+        visibility: "shared",
+        sharingRole: "owner",
+      },
+      state: {
+        loading: false,
+        result: {
+          sessionKey: "agent:main:shared",
+          owner: { type: "human", id: "owner", label: "Owner" },
+          members: [],
+          identities: [{ type: "human", id: "vyctor", label: "Vyctor" }],
+          role: "owner",
+          allowedVisibilities: ["shared", "read-only", "suggest", "draft"],
+        },
+      },
+      onOpen,
+      onVisibilityChange,
+      onMemberChange: vi.fn(),
+    } satisfies ChatSessionSharingProps;
+
+    const desktop = await mountMenu({ sharing });
+    expect(desktop.textContent).not.toContain("Session sharing");
+
+    const compact = await mountMenu({ compact: true, sharing });
+    select(compact, "compact:open-sharing");
+    await compact.updateComplete;
+    expect(onOpen).toHaveBeenCalledOnce();
+    expect(
+      Array.from(
+        compact.querySelectorAll<MenuItemElement>(":scope > wa-dropdown > wa-dropdown-item"),
+      ).map(itemLabel),
+    ).toEqual(["Back", "Shared", "Read-only", "Suggest", "Draft", "Vyctor"]);
+    select(compact, "visibility:read-only");
+    expect(onVisibilityChange).toHaveBeenCalledWith("read-only");
   });
 
   it("pins and disables onboarding view preferences", async () => {

--- a/ui/src/pages/chat/components/chat-header-session-menu.ts
+++ b/ui/src/pages/chat/components/chat-header-session-menu.ts
@@ -398,7 +398,7 @@ class ChatHeaderSessionMenu extends OpenClawLightDomElement {
       this.statusActions[0]?.tone;
     return html`
       <wa-dropdown
-        class=${`session-menu chat-header-session-menu${this.compact ? " chat-header-session-menu--compact" : ""}`}
+        class=${`session-menu chat-header-session-menu${this.compact ? " chat-header-session-menu--compact" : ""}${this.compact && this.compactView === "sharing" ? " chat-header-session-menu--compact-sharing" : ""}`}
         placement="bottom-end"
         aria-label=${menuLabel}
         @keydown=${(event: KeyboardEvent) => {

--- a/ui/src/pages/chat/components/chat-header-session-menu.ts
+++ b/ui/src/pages/chat/components/chat-header-session-menu.ts
@@ -17,6 +17,12 @@ import {
 import type { SessionOwnerOption } from "../../../components/session-owner-chip.ts";
 import { t } from "../../../i18n/index.ts";
 import { OpenClawLightDomElement } from "../../../lit/openclaw-element.ts";
+import {
+  canManageChatSessionSharing,
+  renderChatSessionSharing,
+  selectChatSessionSharingItem,
+  type ChatSessionSharingProps,
+} from "./chat-session-sharing.ts";
 
 export type HeaderMenuAction = SessionManagementAction | { kind: "continue-in-terminal" };
 export type HeaderMenuActionKind = HeaderMenuAction["kind"];
@@ -40,7 +46,7 @@ export type HeaderMenuStatusAction = {
 
 const EMPTY_SETTINGS = {} as UiSettings;
 
-type CompactMenuView = CompactSessionMenuView | "panels" | "layout" | "view";
+type CompactMenuView = CompactSessionMenuView | "panels" | "layout" | "sharing" | "view";
 type MenuSelectEvent = CustomEvent<{ item: { value?: string } }> & {
   currentTarget: HTMLElement & { open: boolean };
 };
@@ -48,6 +54,7 @@ type MenuSelectEvent = CustomEvent<{ item: { value?: string } }> & {
 const COMPACT_MENU_VIEW_BY_VALUE: Record<string, CompactMenuView> = {
   "compact:open-layout": "layout",
   "compact:open-panels": "panels",
+  "compact:open-sharing": "sharing",
   "compact:open-view": "view",
 };
 
@@ -61,6 +68,7 @@ class ChatHeaderSessionMenu extends OpenClawLightDomElement {
   @property({ attribute: false }) panelActions: HeaderMenuQuickAction[] = [];
   @property({ attribute: false }) layoutActions: HeaderMenuQuickAction[] = [];
   @property({ attribute: false }) statusActions: HeaderMenuStatusAction[] = [];
+  @property({ attribute: false }) sharing: ChatSessionSharingProps | null = null;
   @property({ attribute: false }) groups: readonly string[] = [];
   @property({ attribute: false }) ownerOptions: readonly SessionOwnerOption[] = [];
   @property({ attribute: false }) selfOwner: SessionOwnerOption | null = null;
@@ -129,6 +137,8 @@ class ChatHeaderSessionMenu extends OpenClawLightDomElement {
         compactView === "group"
       ) {
         this.managementActions.prepareCompactView(compactView);
+      } else if (compactView === "sharing" && !this.sharing?.openDisabledReason) {
+        this.sharing?.onOpen();
       }
       void this.updateComplete.then(() => {
         this.querySelector<HTMLElement>("wa-dropdown-item:not([disabled])")?.focus();
@@ -172,6 +182,12 @@ class ChatHeaderSessionMenu extends OpenClawLightDomElement {
         this.onSettingsChange({
           chatPersistCommentary: this.settings.chatPersistCommentary === false,
         });
+      }
+      return;
+    }
+    if (value.startsWith("visibility:") || value.startsWith("member:")) {
+      if (this.sharing) {
+        selectChatSessionSharingItem(this.sharing, value);
       }
       return;
     }
@@ -289,12 +305,13 @@ class ChatHeaderSessionMenu extends OpenClawLightDomElement {
     ) {
       return this.managementActions.renderCompactView(this.compactView);
     }
-    const body =
-      this.compactView === "panels"
-        ? this.renderQuickActionItems("panels", this.panelActions, true)
-        : this.compactView === "layout"
-          ? this.renderQuickActionItems("layout", this.layoutActions, true)
-          : this.renderViewSubmenu(true);
+    const body = html`${this.compactView === "panels"
+      ? this.renderQuickActionItems("panels", this.panelActions, true)
+      : this.compactView === "layout"
+        ? this.renderQuickActionItems("layout", this.layoutActions, true)
+        : this.compactView === "sharing" && this.sharing
+          ? renderChatSessionSharing(this.sharing, true)
+          : this.renderViewSubmenu(true)}`;
     return renderCompactSessionMenuFrame(body);
   }
 
@@ -333,6 +350,14 @@ class ChatHeaderSessionMenu extends OpenClawLightDomElement {
         : nothing}
       ${this.renderQuickActions("panels", this.panelActions)}
       ${this.renderQuickActions("layout", this.layoutActions)}
+      ${this.compact && this.sharing?.session && canManageChatSessionSharing(this.sharing.session)
+        ? this.renderCompactNavigationItem(
+            "sharing",
+            t("chat.sessionSharing.menu"),
+            icons.users,
+            Boolean(this.sharing.openDisabledReason),
+          )
+        : nothing}
       ${this.compact
         ? this.renderCompactNavigationItem("view", t("chat.view.menu"), icons.eye)
         : html`<wa-dropdown-item class="session-menu__item">

--- a/ui/src/pages/chat/components/chat-session-sharing.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.ts
@@ -104,7 +104,7 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps, inline 
             ?disabled=${Boolean(props.visibilityDisabledReason)}
             title=${props.visibilityDisabledReason ?? nothing}
           >
-            <span>${t("chat.sessionSharing.publishDraft")}</span>
+            <span class="session-menu__text">${t("chat.sessionSharing.publishDraft")}</span>
             <span slot="details" aria-hidden="true">${icons.users}</span>
           </wa-dropdown-item>
           <div class="session-menu__separator" role="separator"></div>`

--- a/ui/src/pages/chat/components/chat-session-sharing.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.ts
@@ -100,7 +100,7 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps, inline 
     ${canPublish
       ? html`<wa-dropdown-item
             value="visibility:shared"
-            class="chat-pane__publish-draft"
+            class="session-menu__item chat-pane__publish-draft"
             ?disabled=${Boolean(props.visibilityDisabledReason)}
             title=${props.visibilityDisabledReason ?? nothing}
           >

--- a/ui/src/pages/chat/components/chat-session-sharing.ts
+++ b/ui/src/pages/chat/components/chat-session-sharing.ts
@@ -15,7 +15,7 @@ export type ChatSessionSharingState = {
   error?: string;
 };
 
-type ChatSessionSharingProps = {
+export type ChatSessionSharingProps = {
   session: GatewaySessionRow | undefined;
   state: ChatSessionSharingState | undefined;
   allowedVisibilities?: readonly SessionVisibility[];
@@ -43,13 +43,35 @@ function sharingIcon(visibility: SessionVisibility): TemplateResult {
   return visibility === "shared" ? icons.users : icons.lock;
 }
 
+export function selectChatSessionSharingItem(
+  props: ChatSessionSharingProps,
+  value: string | undefined,
+): void {
+  const members = new Set(props.state?.result?.members.map((member) => member.identityId) ?? []);
+  if (value?.startsWith("visibility:")) {
+    if (!props.visibilityDisabledReason) {
+      props.onVisibilityChange(value.slice("visibility:".length) as SessionVisibility);
+    }
+    return;
+  }
+  if (!value?.startsWith("member:")) {
+    return;
+  }
+  const identityId = value.slice("member:".length);
+  const member = !members.has(identityId);
+  const disabledReason = member ? props.memberAddDisabledReason : props.memberRemoveDisabledReason;
+  if (!disabledReason) {
+    props.onMemberChange(identityId, member);
+  }
+}
+
 export function canManageChatSessionSharing(
   session: Pick<GatewaySessionRow, "sharingRole">,
 ): boolean {
   return session.sharingRole === "admin" || session.sharingRole === "owner";
 }
 
-export function renderChatSessionSharing(props: ChatSessionSharingProps) {
+export function renderChatSessionSharing(props: ChatSessionSharingProps, inline = false) {
   const session = props.session;
   if (!session) {
     return nothing;
@@ -74,6 +96,91 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps) {
   const visibilityOptions = allowed.filter((option) => !canPublish || option !== "shared");
   const shouldCapMembers =
     membersAvailable && visibilityOptions.length + identities.length + (canPublish ? 1 : 0) > 12;
+  const content = html`
+    ${canPublish
+      ? html`<wa-dropdown-item
+            value="visibility:shared"
+            class="chat-pane__publish-draft"
+            ?disabled=${Boolean(props.visibilityDisabledReason)}
+            title=${props.visibilityDisabledReason ?? nothing}
+          >
+            <span>${t("chat.sessionSharing.publishDraft")}</span>
+            <span slot="details" aria-hidden="true">${icons.users}</span>
+          </wa-dropdown-item>
+          <div class="session-menu__separator" role="separator"></div>`
+      : nothing}
+    <div class="chat-pane__sharing-title chat-pane__sharing-visibility-title">
+      ${t("chat.sessionSharing.visibility")}
+    </div>
+    ${visibilityOptions.map(
+      (option) => html`
+        <wa-dropdown-item
+          class="session-menu__item chat-pane__sharing-visibility-item"
+          value=${`visibility:${option}`}
+          ?disabled=${option === visibility || Boolean(props.visibilityDisabledReason)}
+          title=${props.visibilityDisabledReason ?? nothing}
+        >
+          <span class="session-menu__text">${t(VISIBILITY_LABEL_KEYS[option])}</span>
+          ${option === visibility
+            ? html`<span slot="details" aria-hidden="true">${icons.check}</span>`
+            : nothing}
+        </wa-dropdown-item>
+      `,
+    )}
+    ${membersAvailable
+      ? html`
+          <div class="chat-pane__sharing-title chat-pane__sharing-members-title">
+            ${t("chat.sessionSharing.members")}
+          </div>
+          ${props.state?.loading
+            ? html`<div class="chat-pane__sharing-status">${t("common.loading")}</div>`
+            : identities.length > 0
+              ? identities.map((identity) => {
+                  const disabledReason = members.has(identity.id)
+                    ? props.memberRemoveDisabledReason
+                    : props.memberAddDisabledReason;
+                  return html`
+                    <wa-dropdown-item
+                      class="session-menu__item chat-pane__sharing-member"
+                      value=${`member:${identity.id}`}
+                      ?disabled=${Boolean(disabledReason)}
+                      title=${disabledReason ?? nothing}
+                    >
+                      <span slot="icon" class="chat-pane__sharing-member-icon" aria-hidden="true">
+                        ${identity.type === "human"
+                          ? renderSessionOwnerChip(identity, "header")
+                          : icons.bot}
+                      </span>
+                      <span
+                        class="session-menu__text chat-pane__sharing-member-label"
+                        title=${disabledReason ? nothing : (identity.label ?? identity.id)}
+                        >${identity.label ?? identity.id}</span
+                      >
+                      ${members.has(identity.id)
+                        ? html`<span
+                            slot="details"
+                            class="session-menu__check"
+                            aria-label=${t("chat.sessionSharing.selected")}
+                            >${icons.check}</span
+                          >`
+                        : nothing}
+                    </wa-dropdown-item>
+                  `;
+                })
+              : html`<div class="chat-pane__sharing-status">
+                  ${t("chat.sessionSharing.noPeople")}
+                </div>`}
+        `
+      : nothing}
+    ${props.state?.error
+      ? html`<div class="chat-pane__sharing-status chat-pane__sharing-status--error" role="alert">
+          ${props.state.error}
+        </div>`
+      : nothing}
+  `;
+  if (inline) {
+    return content;
+  }
   return html`
     <wa-dropdown
       class="chat-pane__sharing-menu ${shouldCapMembers ? "chat-pane__sharing-menu--capped" : ""}"
@@ -84,23 +191,7 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps) {
         }
       }}
       @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
-        const value = event.detail.item.value;
-        if (value?.startsWith("visibility:")) {
-          if (!props.visibilityDisabledReason) {
-            props.onVisibilityChange(value.slice("visibility:".length) as SessionVisibility);
-          }
-          return;
-        }
-        if (value?.startsWith("member:")) {
-          const identityId = value.slice("member:".length);
-          const member = !members.has(identityId);
-          const disabledReason = member
-            ? props.memberAddDisabledReason
-            : props.memberRemoveDisabledReason;
-          if (!disabledReason) {
-            props.onMemberChange(identityId, member);
-          }
-        }
+        selectChatSessionSharingItem(props, event.detail.item.value);
       }}
     >
       <button
@@ -116,86 +207,7 @@ export function renderChatSessionSharing(props: ChatSessionSharingProps) {
       >
         ${sharingIcon(visibility)}
       </button>
-      ${canPublish
-        ? html`<wa-dropdown-item
-              value="visibility:shared"
-              class="chat-pane__publish-draft"
-              ?disabled=${Boolean(props.visibilityDisabledReason)}
-              title=${props.visibilityDisabledReason ?? nothing}
-            >
-              <span>${t("chat.sessionSharing.publishDraft")}</span>
-              <span slot="details" aria-hidden="true">${icons.users}</span>
-            </wa-dropdown-item>
-            <div class="session-menu__separator" role="separator"></div>`
-        : nothing}
-      <div class="chat-pane__sharing-title chat-pane__sharing-visibility-title">
-        ${t("chat.sessionSharing.visibility")}
-      </div>
-      ${visibilityOptions.map(
-        (option) => html`
-          <wa-dropdown-item
-            class="session-menu__item chat-pane__sharing-visibility-item"
-            value=${`visibility:${option}`}
-            ?disabled=${option === visibility || Boolean(props.visibilityDisabledReason)}
-            title=${props.visibilityDisabledReason ?? nothing}
-          >
-            <span>${t(VISIBILITY_LABEL_KEYS[option])}</span>
-            ${option === visibility
-              ? html`<span slot="details" aria-hidden="true">${icons.check}</span>`
-              : nothing}
-          </wa-dropdown-item>
-        `,
-      )}
-      ${membersAvailable
-        ? html`
-            <div class="chat-pane__sharing-title chat-pane__sharing-members-title">
-              ${t("chat.sessionSharing.members")}
-            </div>
-            ${props.state?.loading
-              ? html`<div class="chat-pane__sharing-status">${t("common.loading")}</div>`
-              : identities.length > 0
-                ? identities.map((identity) => {
-                    const disabledReason = members.has(identity.id)
-                      ? props.memberRemoveDisabledReason
-                      : props.memberAddDisabledReason;
-                    return html`
-                      <wa-dropdown-item
-                        class="session-menu__item chat-pane__sharing-member"
-                        value=${`member:${identity.id}`}
-                        ?disabled=${Boolean(disabledReason)}
-                        title=${disabledReason ?? nothing}
-                      >
-                        <span slot="icon" class="chat-pane__sharing-member-icon" aria-hidden="true">
-                          ${identity.type === "human"
-                            ? renderSessionOwnerChip(identity, "header")
-                            : icons.bot}
-                        </span>
-                        <span
-                          class="chat-pane__sharing-member-label"
-                          title=${disabledReason ? nothing : (identity.label ?? identity.id)}
-                          >${identity.label ?? identity.id}</span
-                        >
-                        ${members.has(identity.id)
-                          ? html`<span
-                              slot="details"
-                              class="session-menu__check"
-                              aria-label=${t("chat.sessionSharing.selected")}
-                              >${icons.check}</span
-                            >`
-                          : nothing}
-                      </wa-dropdown-item>
-                    `;
-                  })
-                : html`<div class="chat-pane__sharing-status">
-                    ${t("chat.sessionSharing.noPeople")}
-                  </div>`}
-          `
-        : nothing}
-      ${props.state?.error
-        ? html`<div class="chat-pane__sharing-status chat-pane__sharing-status--error" role="alert">
-            ${props.state.error}
-          </div>`
-        : nothing}
+      ${content}
     </wa-dropdown>
   `;
 }

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -824,7 +824,7 @@ openclaw-chat-pane {
 }
 
 .chat-header-session-menu--compact-sharing::part(menu) {
-  max-height: min(420px, 60vh);
+  height: min(420px, 60vh);
 }
 
 .continue-in-terminal-dialog__card {

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -823,7 +823,7 @@ openclaw-chat-pane {
   overflow-y: auto;
 }
 
-.chat-header-session-menu--compact:has(.chat-pane__sharing-title)::part(menu) {
+.chat-header-session-menu--compact-sharing::part(menu) {
   max-height: min(420px, 60vh);
 }
 

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -823,6 +823,10 @@ openclaw-chat-pane {
   overflow-y: auto;
 }
 
+.chat-header-session-menu--compact:has(.chat-pane__sharing-title)::part(menu) {
+  max-height: min(420px, 60vh);
+}
+
 .continue-in-terminal-dialog__card {
   display: grid;
   gap: 18px;

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -766,7 +766,8 @@ openclaw-chat-pane {
 }
 
 .chat-header-session-menu--compact .session-menu__item {
-  min-height: 40px;
+  flex: 0 0 34px;
+  min-height: 34px;
 }
 
 .chat-header-session-menu__trigger {

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -766,7 +766,7 @@ openclaw-chat-pane {
 }
 
 .chat-header-session-menu--compact .session-menu__item {
-  min-height: 44px;
+  min-height: 40px;
 }
 
 .chat-header-session-menu__trigger {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2589,7 +2589,8 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
   cursor: not-allowed;
 }
 
-.session-menu__item--destructive {
+.session-menu__item--destructive,
+.session-menu__item--destructive .session-menu__icon {
   color: var(--danger);
 }
 


### PR DESCRIPTION
Closes #132019

## What Problem This Solves

On mobile, the session More menu occupied most of the screen while visibility and member controls remained in a separate header action. The Delete icon also did not visually match its destructive label.

## Why This Change Was Made

The mobile More menu now uses a consistent 34px row rhythm and includes Visibility and Members in a focused sharing drilldown. It reuses the existing sharing renderer and callbacks, preserves the read-only draft indicator for non-managers, and keeps large member lists within the established mobile height limit. The desktop sharing control is unchanged.

## User Impact

Mobile users get a denser session action menu, one fewer header icon, and direct access to Visibility and Members from More. Draft state remains visible to members, large sharing lists stay scrollable, and Delete is consistently recognizable as destructive.

## Evidence

The before-and-after captures below were recorded at 390x844 in light and dark themes and inspected after capture.

### Before

Light:

![Mobile More menu before, light](https://github.com/user-attachments/assets/fa2b96d2-df57-4090-b45b-e81ac11ee6bd)

Dark:

![Mobile More menu before, dark](https://github.com/user-attachments/assets/fbc84df7-395e-40a9-9b9c-13d0a42226c5)

### After

Light:

![Mobile More menu after, light](https://github.com/user-attachments/assets/eee3f3dd-9e79-477e-a4e3-a5c94be43b22)

Dark:

![Mobile More menu after, dark](https://github.com/user-attachments/assets/44f61b74-26f0-43de-9c24-1db1bfe1e550)

Sharing drilldown, light:

![Mobile sharing submenu after, light](https://github.com/user-attachments/assets/6537a7e2-c3ab-4c5a-a8e5-8648322ab2c1)

Sharing drilldown, dark:

![Mobile sharing submenu after, dark](https://github.com/user-attachments/assets/f63bcee6-218d-41d0-995c-b5d522b938d5)

Validation:

- Required CI passed on the exact head.
- Component coverage verifies the compact sharing drilldown and draft-publish action.
- Browser coverage verifies 34px rows, destructive styling, the non-manager draft indicator, and scrolling for a 30-member sharing list in light and dark themes.
