### PR TITLE
fix(ui): refresh stale mobile transcript bundles

### DIFF
--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -246,7 +246,6 @@ describe("production lint suppressions", () => {
         "src/tasks/task-registry.sqlite.shared.ts|typescript/no-unnecessary-type-parameters|1",
         "src/test-utils/vitest-mock-fn.ts|typescript/no-explicit-any|1",
         "src/utils.ts|typescript/no-unnecessary-type-parameters|1",
-        "ui/public/sw.js|unicorn/require-post-message-target-origin|1",
         // oxlint misreads CanvasRenderingContext2D.fill(path) as Array.fill.
         "ui/src/components/mascot-canvas.ts|unicorn/no-array-fill-with-reference-type|1",
       ]),

--- a/ui/public/sw.js
+++ b/ui/public/sw.js
@@ -12,6 +12,30 @@ const CACHE_VERSION =
     : URL_CACHE_VERSION) || "dev";
 const CACHE_NAME = `${CACHE_PREFIX}${CACHE_VERSION}`;
 const CONTROL_CACHE_LIMIT = 3;
+const CLIENT_VERSION_TIMEOUT_MS = 1_000;
+
+function isControlUiChatClient(url) {
+  const clientUrl = new URL(url);
+  const scopeUrl = new URL(self.registration.scope);
+  const scopePath = scopeUrl.pathname.endsWith("/") ? scopeUrl.pathname : `${scopeUrl.pathname}/`;
+  return (
+    clientUrl.origin === scopeUrl.origin &&
+    (clientUrl.pathname === scopeUrl.pathname || clientUrl.pathname === `${scopePath}chat`)
+  );
+}
+
+function readClientVersion(client) {
+  return new Promise((resolve) => {
+    const channel = new MessageChannel();
+    const timeout = setTimeout(() => resolve(null), CLIENT_VERSION_TIMEOUT_MS);
+    channel.port1.addEventListener("message", (event) => {
+      clearTimeout(timeout);
+      resolve(typeof event.data?.version === "string" ? event.data.version : null);
+    });
+    channel.port1.start();
+    client.postMessage({ type: "sw-version-probe", version: CACHE_VERSION }, [channel.port2]);
+  });
+}
 
 // Minimal app-shell files to precache.
 const PRECACHE_URLS = ["./"];
@@ -39,17 +63,22 @@ self.addEventListener("activate", (event) => {
           controlKeys.filter((key) => !retained.has(key)).map((key) => caches.delete(key)),
         ),
       ]);
-      // Enumerate after claim so a concurrent reload receives the activation event
-      // instead of leaving the new document unaware of the replacement worker.
+      // A suspended mobile page can miss a one-shot update message. Current
+      // documents answer the probe; only stale or suspended chat documents reload.
       const windowClients = await self.clients.matchAll({
         type: "window",
         includeUncontrolled: true,
       });
 
-      for (const client of windowClients) {
-        // oxlint-disable-next-line unicorn/require-post-message-target-origin -- Service Worker Client.postMessage does not take targetOrigin.
-        client.postMessage({ type: "sw-updated", version: CACHE_VERSION });
-      }
+      await Promise.allSettled(
+        windowClients
+          .filter((client) => isControlUiChatClient(client.url))
+          .map(async (client) => {
+            if ((await readClientVersion(client)) !== CACHE_VERSION) {
+              await client.navigate(client.url);
+            }
+          }),
+      );
     })(),
   );
 });

--- a/ui/public/sw.js
+++ b/ui/public/sw.js
@@ -18,10 +18,27 @@ function isControlUiChatClient(url) {
   const clientUrl = new URL(url);
   const scopeUrl = new URL(self.registration.scope);
   const scopePath = scopeUrl.pathname.endsWith("/") ? scopeUrl.pathname : `${scopeUrl.pathname}/`;
+  const chatPath = `${scopePath}chat`;
   return (
     clientUrl.origin === scopeUrl.origin &&
-    (clientUrl.pathname === scopeUrl.pathname || clientUrl.pathname === `${scopePath}chat`)
+    (clientUrl.pathname === scopeUrl.pathname ||
+      clientUrl.pathname === chatPath ||
+      clientUrl.pathname.startsWith(`${chatPath}/`))
   );
+}
+
+async function markClientReload(client) {
+  const cache = await caches.open(CACHE_NAME);
+  const guardUrl = new URL(".__openclaw__/service-worker-reload", self.registration.scope);
+  guardUrl.searchParams.set("client", client.id);
+  const guardRequest = new Request(guardUrl);
+  if (await cache.match(guardRequest)) {
+    return false;
+  }
+  // Persist before navigation so repeated activation of the same build cannot
+  // loop a document that keeps receiving stale HTML.
+  await cache.put(guardRequest, new Response(CACHE_VERSION));
+  return true;
 }
 
 function readClientVersion(client) {
@@ -74,8 +91,13 @@ self.addEventListener("activate", (event) => {
         windowClients
           .filter((client) => isControlUiChatClient(client.url))
           .map(async (client) => {
-            if ((await readClientVersion(client)) !== CACHE_VERSION) {
-              await client.navigate(client.url);
+            if (
+              (await readClientVersion(client)) !== CACHE_VERSION &&
+              (await markClientReload(client))
+            ) {
+              // Navigation starts synchronously; activation must not stay alive
+              // indefinitely waiting for a document that never finishes loading.
+              void client.navigate(client.url).catch(() => undefined);
             }
           }),
       );

--- a/ui/src/app/service-worker-cache.test.ts
+++ b/ui/src/app/service-worker-cache.test.ts
@@ -10,9 +10,18 @@ const here = path.dirname(fileURLToPath(import.meta.url));
 const serviceWorkerPath = path.join(here, "../../public/sw.js");
 
 describe("Control UI service worker cache versioning", () => {
-  it("broadcasts updated versions to uncontrolled window clients during activation", async () => {
+  it("reloads uncontrolled window clients during activation", async () => {
     const serviceWorkerSource = fs.readFileSync(serviceWorkerPath, "utf8");
-    const windowClient = { postMessage: vi.fn() };
+    const windowClient = {
+      url: "https://control.example/chat",
+      postMessage: vi.fn(),
+      navigate: vi.fn(async () => undefined),
+    };
+    const siblingClient = {
+      url: "https://control.example/other-app",
+      postMessage: vi.fn(),
+      navigate: vi.fn(async () => undefined),
+    };
     const matchedClients = createDeferred<Array<typeof windowClient>>();
     const listeners = new Map<string, Array<(event: ActivateEventStub) => void>>();
     const cacheDelete = vi.fn(async () => true);
@@ -42,9 +51,18 @@ describe("Control UI service worker cache versioning", () => {
     };
     const context = vm.createContext({
       URL,
+      MessageChannel: UnresponsiveMessageChannel,
       caches,
+      clearTimeout,
       fetch: vi.fn(),
-      self: serviceWorkerGlobal,
+      setTimeout,
+      self: {
+        ...serviceWorkerGlobal,
+        registration: {
+          scope: "https://control.example/",
+          showNotification: vi.fn(),
+        },
+      },
     });
 
     new vm.Script(serviceWorkerSource, { filename: "ui/public/sw.js" }).runInContext(context);
@@ -65,19 +83,64 @@ describe("Control UI service worker cache versioning", () => {
     await Promise.resolve();
 
     expect(activationSettled).toBe(false);
-    expect(windowClient.postMessage).not.toHaveBeenCalled();
+    expect(windowClient.navigate).not.toHaveBeenCalled();
 
-    matchedClients.resolve([windowClient]);
+    matchedClients.resolve([windowClient, siblingClient]);
     await activationPromise;
 
     expect(clients.matchAll).toHaveBeenCalledWith({ type: "window", includeUncontrolled: true });
     expect(clients.claim).toHaveBeenCalledBefore(clients.matchAll);
     expect(cacheDelete).toHaveBeenCalledWith("openclaw-control-oldest");
-    expect(windowClient.postMessage).toHaveBeenCalledWith({
-      type: "sw-updated",
-      version: "new-build",
+    expect(windowClient.postMessage).toHaveBeenCalledOnce();
+    expect(windowClient.navigate).toHaveBeenCalledExactlyOnceWith(windowClient.url);
+    expect(siblingClient.postMessage).not.toHaveBeenCalled();
+    expect(siblingClient.navigate).not.toHaveBeenCalled();
+  });
+
+  it("keeps a current document mounted during activation", async () => {
+    const serviceWorkerSource = fs.readFileSync(serviceWorkerPath, "utf8");
+    const listeners = new Map<string, Array<(event: ActivateEventStub) => void>>();
+    const navigate = vi.fn(async () => undefined);
+    const clients = {
+      claim: vi.fn(async () => undefined),
+      matchAll: vi.fn(async () => [
+        {
+          url: "https://control.example/chat",
+          postMessage: vi.fn((_message: unknown, ports: MessagePort[]) => {
+            ports[0]?.postMessage({ version: "new-build" });
+          }),
+          navigate,
+        },
+      ]),
+    };
+    const context = vm.createContext({
+      URL,
+      MessageChannel,
+      caches: { delete: vi.fn(), keys: vi.fn(async () => []), open: vi.fn() },
+      clearTimeout,
+      fetch: vi.fn(),
+      setTimeout,
+      self: {
+        addEventListener(type: string, listener: (event: ActivateEventStub) => void) {
+          listeners.set(type, [...(listeners.get(type) ?? []), listener]);
+        },
+        clients,
+        location: { href: "https://control.example/sw.js?v=new-build" },
+        registration: { scope: "https://control.example/", showNotification: vi.fn() },
+        skipWaiting: vi.fn(),
+      },
     });
-    expect(windowClient.postMessage.mock.calls[0]).toHaveLength(1);
+    new vm.Script(serviceWorkerSource, { filename: "ui/public/sw.js" }).runInContext(context);
+    let activationPromise: Promise<unknown> | undefined;
+
+    listeners.get("activate")?.[0]?.({
+      waitUntil(promise: Promise<unknown>) {
+        activationPromise = promise;
+      },
+    });
+
+    await expect(activationPromise).resolves.toBeUndefined();
+    expect(navigate).not.toHaveBeenCalled();
   });
 });
 
@@ -508,6 +571,11 @@ describe("Control UI service worker notification scope", () => {
 type ActivateEventStub = {
   waitUntil(promise: Promise<unknown>): void;
 };
+
+class UnresponsiveMessageChannel {
+  port1 = { addEventListener() {}, start() {} };
+  port2 = {};
+}
 
 type NotificationClickScenario = {
   name: string;

--- a/ui/src/app/service-worker-cache.test.ts
+++ b/ui/src/app/service-worker-cache.test.ts
@@ -10,21 +10,39 @@ const here = path.dirname(fileURLToPath(import.meta.url));
 const serviceWorkerPath = path.join(here, "../../public/sw.js");
 
 describe("Control UI service worker cache versioning", () => {
-  it("reloads uncontrolled window clients during activation", async () => {
+  it("reloads stale root and chat clients once while excluding other pages", async () => {
     const serviceWorkerSource = fs.readFileSync(serviceWorkerPath, "utf8");
-    const windowClient = {
-      url: "https://control.example/chat",
+    const client = (id: string, url: string) => ({
+      id,
+      url,
       postMessage: vi.fn(),
       navigate: vi.fn(async () => undefined),
-    };
-    const siblingClient = {
-      url: "https://control.example/other-app",
-      postMessage: vi.fn(),
-      navigate: vi.fn(async () => undefined),
-    };
-    const matchedClients = createDeferred<Array<typeof windowClient>>();
+    });
+    const staleClients = [
+      client("root", "https://control.example/openclaw/"),
+      client("chat", "https://control.example/openclaw/chat"),
+      client(
+        "chat-deep-link",
+        "https://control.example/openclaw/chat/main/session?mode=compact#latest",
+      ),
+    ];
+    const excludedClients = [
+      client("settings", "https://control.example/openclaw/settings/appearance"),
+      client("chat-sibling", "https://control.example/openclaw/chatty"),
+      client("cross-origin", "https://other.example/openclaw/chat/main/session"),
+    ];
+    const matchedClients = createDeferred<Array<ReturnType<typeof client>>>();
     const listeners = new Map<string, Array<(event: ActivateEventStub) => void>>();
     const cacheDelete = vi.fn(async () => true);
+    const reloadMarkers = new Set<string>();
+    const reloadCache = {
+      match: vi.fn(async (request: Request) =>
+        reloadMarkers.has(request.url) ? new Response("new-build") : undefined,
+      ),
+      put: vi.fn(async (request: Request) => {
+        reloadMarkers.add(request.url);
+      }),
+    };
     const clients = {
       claim: vi.fn(async () => undefined),
       matchAll: vi.fn(() => matchedClients.promise),
@@ -38,20 +56,22 @@ describe("Control UI service worker cache versioning", () => {
         "openclaw-control-new-build",
         "other-cache",
       ]),
-      open: vi.fn(),
+      open: vi.fn(async () => reloadCache),
     };
     const serviceWorkerGlobal = {
       addEventListener(type: string, listener: (event: ActivateEventStub) => void) {
         listeners.set(type, [...(listeners.get(type) ?? []), listener]);
       },
       clients,
-      location: { href: "https://control.example/sw.js?v=new-build" },
+      location: { href: "https://control.example/openclaw/sw.js?v=new-build" },
       registration: { showNotification: vi.fn() },
       skipWaiting: vi.fn(),
     };
     const context = vm.createContext({
       URL,
       MessageChannel: UnresponsiveMessageChannel,
+      Request,
+      Response,
       caches,
       clearTimeout,
       fetch: vi.fn(),
@@ -59,7 +79,7 @@ describe("Control UI service worker cache versioning", () => {
       self: {
         ...serviceWorkerGlobal,
         registration: {
-          scope: "https://control.example/",
+          scope: "https://control.example/openclaw/",
           showNotification: vi.fn(),
         },
       },
@@ -83,18 +103,33 @@ describe("Control UI service worker cache versioning", () => {
     await Promise.resolve();
 
     expect(activationSettled).toBe(false);
-    expect(windowClient.navigate).not.toHaveBeenCalled();
+    expect(staleClients[0]?.navigate).not.toHaveBeenCalled();
 
-    matchedClients.resolve([windowClient, siblingClient]);
+    matchedClients.resolve([...staleClients, ...excludedClients]);
     await activationPromise;
 
     expect(clients.matchAll).toHaveBeenCalledWith({ type: "window", includeUncontrolled: true });
     expect(clients.claim).toHaveBeenCalledBefore(clients.matchAll);
     expect(cacheDelete).toHaveBeenCalledWith("openclaw-control-oldest");
-    expect(windowClient.postMessage).toHaveBeenCalledOnce();
-    expect(windowClient.navigate).toHaveBeenCalledExactlyOnceWith(windowClient.url);
-    expect(siblingClient.postMessage).not.toHaveBeenCalled();
-    expect(siblingClient.navigate).not.toHaveBeenCalled();
+    for (const staleClient of staleClients) {
+      expect(staleClient.postMessage).toHaveBeenCalledOnce();
+      expect(staleClient.navigate).toHaveBeenCalledExactlyOnceWith(staleClient.url);
+    }
+    for (const excludedClient of excludedClients) {
+      expect(excludedClient.postMessage).not.toHaveBeenCalled();
+      expect(excludedClient.navigate).not.toHaveBeenCalled();
+    }
+
+    listeners.get("activate")?.[0]?.({
+      waitUntil(promise: Promise<unknown>) {
+        activationPromise = promise;
+      },
+    });
+    await activationPromise;
+    for (const staleClient of staleClients) {
+      expect(staleClient.postMessage).toHaveBeenCalledTimes(2);
+      expect(staleClient.navigate).toHaveBeenCalledOnce();
+    }
   });
 
   it("keeps a current document mounted during activation", async () => {
@@ -105,7 +140,8 @@ describe("Control UI service worker cache versioning", () => {
       claim: vi.fn(async () => undefined),
       matchAll: vi.fn(async () => [
         {
-          url: "https://control.example/chat",
+          id: "current-chat-deep-link",
+          url: "https://control.example/chat/main/session",
           postMessage: vi.fn((_message: unknown, ports: MessagePort[]) => {
             ports[0]?.postMessage({ version: "new-build" });
           }),

--- a/ui/src/e2e/chat-agent-run-transcript.e2e.test.ts
+++ b/ui/src/e2e/chat-agent-run-transcript.e2e.test.ts
@@ -95,198 +95,228 @@ suite.define(() => {
     await context.close();
   });
 
-  it("renders each run as one linear response with actions only on its terminal text", async () => {
-    const context = await suite.browser.newContext({ viewport: { height: 900, width: 1200 } });
-    const page = await context.newPage();
-    const firstRunId = "run-composed-first";
-    const secondRunId = "run-composed-second";
-    const toolOnlyRunId = "run-tool-only";
-    const commentaryToolRunId = "run-commentary-tool-only";
-    await installMockGateway(page, {
-      historyMessages: [
-        transcriptMessage("user", "Create the launch card.", `${firstRunId}:user`, "user-1", 1),
-        transcriptMessage(
-          "assistant",
-          "I’ll create the launch card and check the existing style first.",
-          firstRunId,
-          "assistant-1",
-          2,
-        ),
-        {
-          ...transcriptMessage(
+  it.each([
+    { viewport: "desktop-dark", width: 1200, height: 900, theme: "dark" },
+    { viewport: "mobile-dark", width: 390, height: 844, theme: "dark" },
+    { viewport: "mobile-light", width: 390, height: 844, theme: "light" },
+  ] as const)(
+    "renders each run as one linear response on $viewport",
+    async ({ viewport, width, height, theme }) => {
+      const isMobile = viewport.startsWith("mobile");
+      const context = await suite.browser.newContext({
+        colorScheme: theme,
+        hasTouch: isMobile,
+        isMobile,
+        viewport: { height, width },
+      });
+      const page = await context.newPage();
+      const firstRunId = "run-composed-first";
+      const secondRunId = "run-composed-second";
+      const toolOnlyRunId = "run-tool-only";
+      const commentaryToolRunId = "run-commentary-tool-only";
+      await installMockGateway(page, {
+        historyMessages: [
+          transcriptMessage("user", "Create the launch card.", `${firstRunId}:user`, "user-1", 1),
+          transcriptMessage(
             "assistant",
-            [
-              {
-                type: "toolCall",
-                id: "call-read",
-                name: "read",
-                arguments: { path: "ui/src/styles/chat.css" },
-              },
-            ],
+            "I’ll create the launch card and check the existing style first.",
             firstRunId,
-            "tool-call-1",
-            3,
+            "assistant-1",
+            2,
           ),
-        },
-        {
-          ...transcriptMessage(
-            "toolResult",
-            [{ type: "text", text: "Existing card styles loaded." }],
-            firstRunId,
-            "tool-result-1",
-            4,
-          ),
-          toolCallId: "call-read",
-          toolName: "read",
-        },
-        transcriptMessage(
-          "assistant",
-          "The first draft matches the transcript rhythm. I’ll render the asset now.",
-          firstRunId,
-          "assistant-2",
-          5,
-        ),
-        {
-          ...transcriptMessage(
+          {
+            ...transcriptMessage(
+              "assistant",
+              [
+                {
+                  type: "toolCall",
+                  id: "call-read",
+                  name: "read",
+                  arguments: { path: "ui/src/styles/chat.css" },
+                },
+              ],
+              firstRunId,
+              "tool-call-1",
+              3,
+            ),
+          },
+          {
+            ...transcriptMessage(
+              "toolResult",
+              [{ type: "text", text: "Existing card styles loaded." }],
+              firstRunId,
+              "tool-result-1",
+              4,
+            ),
+            toolCallId: "call-read",
+            toolName: "read",
+          },
+          transcriptMessage(
             "assistant",
-            [
-              {
-                type: "toolCall",
-                id: "call-render",
-                name: "exec",
-                arguments: { command: "render launch-card.svg" },
-              },
-            ],
+            "The first draft matches the transcript rhythm. I’ll render the asset now.",
             firstRunId,
-            "tool-call-2",
-            6,
+            "assistant-2",
+            5,
           ),
-        },
-        {
-          ...transcriptMessage(
-            "toolResult",
-            [{ type: "text", text: "Rendered launch-card.svg" }],
+          {
+            ...transcriptMessage(
+              "assistant",
+              [
+                {
+                  type: "toolCall",
+                  id: "call-render",
+                  name: "exec",
+                  arguments: { command: "render launch-card.svg" },
+                },
+              ],
+              firstRunId,
+              "tool-call-2",
+              6,
+            ),
+          },
+          {
+            ...transcriptMessage(
+              "toolResult",
+              [{ type: "text", text: "Rendered launch-card.svg" }],
+              firstRunId,
+              "tool-result-2",
+              7,
+            ),
+            toolCallId: "call-render",
+            toolName: "exec",
+          },
+          transcriptMessage(
+            "assistant",
+            "The launch card is ready: MEDIA:./launch-card.svg",
             firstRunId,
-            "tool-result-2",
-            7,
+            "assistant-3",
+            8,
           ),
-          toolCallId: "call-render",
-          toolName: "exec",
-        },
-        transcriptMessage(
-          "assistant",
-          "The launch card is ready: MEDIA:./launch-card.svg",
-          firstRunId,
-          "assistant-3",
-          8,
-        ),
-        transcriptMessage("user", "Now write the caption.", `${secondRunId}:user`, "user-2", 9),
-        transcriptMessage(
-          "assistant",
-          "Caption ready for the second run.",
-          secondRunId,
-          "assistant-4",
-          10,
-        ),
-        transcriptMessage("user", "Check without replying.", `${toolOnlyRunId}:user`, "user-3", 11),
-        {
-          ...transcriptMessage(
-            "toolResult",
-            [{ type: "text", text: "Tool-only result" }],
-            toolOnlyRunId,
-            "tool-result-3",
-            12,
+          transcriptMessage("user", "Now write the caption.", `${secondRunId}:user`, "user-2", 9),
+          transcriptMessage(
+            "assistant",
+            "Caption ready for the second run.",
+            secondRunId,
+            "assistant-4",
+            10,
           ),
-          toolCallId: "call-tool-only",
-          toolName: "read",
-        },
-        transcriptMessage(
-          "user",
-          "Inspect and stop after the tool.",
-          `${commentaryToolRunId}:user`,
-          "user-4",
-          13,
-        ),
-        transcriptMessage(
-          "assistant",
-          "I’ll inspect the current state first.",
-          commentaryToolRunId,
-          "assistant-5",
-          14,
-        ),
-        {
-          ...transcriptMessage(
-            "toolResult",
-            [{ type: "text", text: "Commentary-led tool-only result" }],
+          transcriptMessage(
+            "user",
+            "Check without replying.",
+            `${toolOnlyRunId}:user`,
+            "user-3",
+            11,
+          ),
+          {
+            ...transcriptMessage(
+              "toolResult",
+              [{ type: "text", text: "Tool-only result" }],
+              toolOnlyRunId,
+              "tool-result-3",
+              12,
+            ),
+            toolCallId: "call-tool-only",
+            toolName: "read",
+          },
+          transcriptMessage(
+            "user",
+            "Inspect and stop after the tool.",
+            `${commentaryToolRunId}:user`,
+            "user-4",
+            13,
+          ),
+          transcriptMessage(
+            "assistant",
+            "I’ll inspect the current state first.",
             commentaryToolRunId,
-            "tool-result-4",
-            15,
+            "assistant-5",
+            14,
           ),
-          toolCallId: "call-commentary-tool-only",
-          toolName: "read",
-        },
-      ],
-    });
+          {
+            ...transcriptMessage(
+              "toolResult",
+              [{ type: "text", text: "Commentary-led tool-only result" }],
+              commentaryToolRunId,
+              "tool-result-4",
+              15,
+            ),
+            toolCallId: "call-commentary-tool-only",
+            toolName: "read",
+          },
+        ],
+      });
 
-    await page.goto(`${suite.server.baseUrl}chat`);
-    const transcript = page.locator(".chat-thread-inner");
-    await transcript.getByText("Caption ready for the second run.", { exact: true }).waitFor();
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const transcript = page.locator(".chat-thread-inner");
+      await transcript.getByText("Caption ready for the second run.", { exact: true }).waitFor();
+      const artifactDir = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
+      if (artifactDir) {
+        await fs.mkdir(artifactDir, { recursive: true });
+        const firstNarration = transcript.getByText(
+          "I’ll create the launch card and check the existing style first.",
+          { exact: true },
+        );
+        await firstNarration.scrollIntoViewIfNeeded();
+        await firstNarration.click();
+        await transcript.screenshot({ path: path.join(artifactDir, `transcript-${viewport}.png`) });
+      }
 
-    const assistantGroups = page.locator(".chat-group.assistant");
-    expect(await assistantGroups.count()).toBe(4);
-    const firstRun = assistantGroups.filter({
-      hasText: "I’ll create the launch card and check the existing style first.",
-    });
-    expect(await firstRun.count()).toBe(1);
-    const artifactDir = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
-    if (artifactDir) {
-      await fs.mkdir(artifactDir, { recursive: true });
-      await firstRun.screenshot({ path: path.join(artifactDir, "agent-run-transcript.png") });
-    }
-    expect(await firstRun.locator(".chat-sender-name").count()).toBe(1);
-    expect(await firstRun.locator(".chat-group-footer-actions").count()).toBe(1);
-    expect(await firstRun.locator(".chat-message-actions-row").count()).toBe(0);
-    expect(await firstRun.locator(".chat-group-footer-actions button").count()).toBe(2);
-    expect(
-      await firstRun
-        .locator(".chat-group-footer-actions button")
-        .evaluateAll((buttons) => buttons.map((button) => button.getAttribute("aria-label"))),
-    ).toEqual(["Reply to message", "Copy as markdown"]);
+      const assistantGroups = page.locator(".chat-group.assistant");
+      expect(await assistantGroups.count()).toBe(4);
+      const firstRun = assistantGroups.filter({
+        hasText: "I’ll create the launch card and check the existing style first.",
+      });
+      expect(await firstRun.count()).toBe(1);
+      if (artifactDir) {
+        await firstRun.screenshot({
+          path: path.join(artifactDir, `agent-run-transcript-${viewport}.png`),
+        });
+      }
+      expect(await firstRun.locator(".chat-sender-name").count()).toBe(1);
+      expect(await firstRun.locator(".chat-group-footer-actions").count()).toBe(1);
+      expect(await firstRun.locator(".chat-message-actions-row").count()).toBe(0);
+      expect(await firstRun.locator(".chat-group-footer-actions button").count()).toBe(2);
+      expect(
+        await firstRun
+          .locator(".chat-group-footer-actions button")
+          .evaluateAll((buttons) => buttons.map((button) => button.getAttribute("aria-label"))),
+      ).toEqual(["Reply to message", "Copy as markdown"]);
 
-    const orderedContent = await firstRun.locator(".chat-bubble").evaluateAll((bubbles) =>
-      bubbles.map((bubble) => ({
-        messageId: bubble.getAttribute("data-message-id"),
-        text: bubble.textContent?.replace(/\s+/gu, " ").trim(),
-      })),
-    );
-    expect(orderedContent).toEqual([
-      expect.objectContaining({ text: expect.stringContaining("I’ll create the launch card") }),
-      expect.objectContaining({ text: expect.stringContaining("Read") }),
-      expect.objectContaining({ text: expect.stringContaining("The first draft matches") }),
-      expect.objectContaining({ text: expect.stringContaining("render launch-card.svg") }),
-      expect.objectContaining({ text: expect.stringContaining("The launch card is ready") }),
-    ]);
-    expect(
-      await firstRun.getByText("Caption ready for the second run.", { exact: true }).count(),
-    ).toBe(0);
-    const toolOnlyRun = page.locator(
-      `.chat-group.assistant[data-chat-row-key*="${toolOnlyRunId}"]`,
-    );
-    expect(await toolOnlyRun.count()).toBe(1);
-    expect(await toolOnlyRun.locator(".chat-group-footer-actions").count()).toBe(0);
-    const commentaryToolRun = page.locator(
-      `.chat-group.assistant[data-chat-row-key*="${commentaryToolRunId}"]`,
-    );
-    expect(await commentaryToolRun.count()).toBe(1);
-    expect(
-      await commentaryToolRun
-        .getByText("I’ll inspect the current state first.", { exact: true })
-        .count(),
-    ).toBe(1);
-    expect(await commentaryToolRun.locator(".chat-group-footer-actions").count()).toBe(0);
+      const orderedContent = await firstRun.locator(".chat-bubble").evaluateAll((bubbles) =>
+        bubbles.map((bubble) => ({
+          messageId: bubble.getAttribute("data-message-id"),
+          text: bubble.textContent?.replace(/\s+/gu, " ").trim(),
+        })),
+      );
+      expect(orderedContent).toEqual([
+        expect.objectContaining({ text: expect.stringContaining("I’ll create the launch card") }),
+        expect.objectContaining({ text: expect.stringContaining("Read") }),
+        expect.objectContaining({ text: expect.stringContaining("The first draft matches") }),
+        expect.objectContaining({ text: expect.stringContaining("render launch-card.svg") }),
+        expect.objectContaining({ text: expect.stringContaining("The launch card is ready") }),
+      ]);
+      expect(
+        await firstRun.getByText("Caption ready for the second run.", { exact: true }).count(),
+      ).toBe(0);
+      const toolOnlyRun = page.locator(
+        `.chat-group.assistant[data-chat-row-key*="${toolOnlyRunId}"]`,
+      );
+      expect(await toolOnlyRun.count()).toBe(1);
+      expect(await toolOnlyRun.locator(".chat-group-footer-actions").count()).toBe(0);
+      const commentaryToolRun = page.locator(
+        `.chat-group.assistant[data-chat-row-key*="${commentaryToolRunId}"]`,
+      );
+      expect(await commentaryToolRun.count()).toBe(1);
+      expect(
+        await commentaryToolRun
+          .getByText("I’ll inspect the current state first.", { exact: true })
+          .count(),
+      ).toBe(1);
+      expect(await commentaryToolRun.locator(".chat-group-footer-actions").count()).toBe(0);
 
-    await context.close();
-  });
+      await context.close();
+    },
+  );
 
   it("keeps the run row identity when a hidden heartbeat boundary reaches history", async () => {
     const context = await suite.browser.newContext({ viewport: { height: 900, width: 1200 } });

--- a/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
@@ -123,7 +123,10 @@ suite.define(() => {
       sessionInfo: { key: sessionKey, hasActiveRun: false, activeRunIds: [], status: "done" },
     });
     await gateway.emitGatewayEvent("chat", { sessionKey, runId, state: "final", message: reply });
-    await currentPage.getByText(reply.content, { exact: true }).waitFor();
+    const replyBody = currentPage
+      .locator(".chat-group.assistant")
+      .getByText(reply.content, { exact: true });
+    await replyBody.waitFor();
     const elapsedLabel = currentPage.locator(".chat-work-group .chat-activity-group__label");
     await elapsedLabel.waitFor();
     expect.soft(await elapsedLabel.textContent()).toBe("Worked for 13s");
@@ -131,7 +134,7 @@ suite.define(() => {
 
     await currentPage.reload();
     await gateway.waitForRequest("chat.startup");
-    await currentPage.getByText(reply.content, { exact: true }).waitFor();
+    await replyBody.waitFor();
     await elapsedLabel.waitFor();
     expect(await elapsedLabel.textContent()).toBe("Worked for 13s");
     expect(await currentPage.locator(".chat-group.user").count()).toBe(2);

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -28,6 +28,9 @@ if (isProd && "serviceWorker" in navigator) {
     if (controlUiWorkerActivationRetires(event.data)) {
       window.location.reload();
     }
+    if (event.data?.type === "sw-version-probe") {
+      event.ports[0]?.postMessage({ version: currentControlUiBuildId });
+    }
   });
   void navigator.serviceWorker
     .register(swUrl, { updateViaCache: "none" })

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -63,6 +63,7 @@ import { ChatStateController } from "./chat-state-controller.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 import { requestChatPageUpdate } from "./chat-state-render.ts";
 import { resolveChatAgentId } from "./chat-state-route.ts";
+import { getChatComposerState } from "./components/chat-composer-state.ts";
 import type { ChatPaneHeaderAction } from "./components/chat-pane-header.ts";
 import type { ChatSessionSharingState } from "./components/chat-session-sharing.ts";
 import { ChatTranscriptController } from "./components/chat-transcript-controller.ts";
@@ -77,10 +78,26 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
   // The first Lit update must render even while hidden; later hidden work parks.
   // Disconnect releases the waiter so reconnect can schedule in its new lifecycle.
   private hiddenUpdateResume: (() => void) | undefined;
-  private readonly handleVisibilityChange = () =>
-    document.visibilityState === "hidden" && this.state?.chatStreamRenderFrame != null
-      ? requestChatPageUpdate(this.state)
-      : this.hiddenUpdateResume?.();
+  private readonly handleVisibilityChange = () => {
+    if (document.visibilityState !== "hidden") {
+      this.hiddenUpdateResume?.();
+      return;
+    }
+    const state = this.state;
+    if (!state) {
+      return;
+    }
+    const liveDraft = getChatComposerState(this.paneId).composerTextarea?.value;
+    const draftChanged = liveDraft !== undefined && liveDraft !== state.chatMessage;
+    if (draftChanged) {
+      // Page suspension can interrupt IME before compositionend; commit the
+      // live textarea while visibility change can still reach browser storage.
+      state.handleChatDraftChange(liveDraft);
+    }
+    if (draftChanged || state.chatStreamRenderFrame != null) {
+      requestChatPageUpdate(state);
+    }
+  };
   override connectedCallback() {
     document.addEventListener("visibilitychange", this.handleVisibilityChange);
     super.connectedCallback();

--- a/ui/src/pages/chat/chat-pane-lifecycle.test.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.test.ts
@@ -19,7 +19,6 @@ import { ChatPaneBase } from "./chat-pane-base.ts";
 import { createTestChatPane, type TestChatPane } from "./chat-pane.test-support.ts";
 import { applySelectedChatAgent } from "./chat-session.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
-import { getChatComposerState, resetChatComposerState } from "./components/chat-composer-state.ts";
 import {
   dismissConfirmedActionPopovers,
   openChatRewindConfirmation,
@@ -708,7 +707,6 @@ function createConfirmationOwner() {
 afterEach(() => {
   vi.useRealTimers();
   vi.restoreAllMocks();
-  resetChatComposerState();
   for (const owner of confirmationOwners) {
     dismissConfirmedActionPopovers(owner);
     owner.remove();
@@ -776,43 +774,6 @@ describe("chat pane presentation teardown", () => {
 });
 
 describe("chat pane connection lifecycle", () => {
-  it("commits the live composer draft before a hidden document can suspend", async () => {
-    let visibilityState: DocumentVisibilityState = "visible";
-    vi.spyOn(document, "visibilityState", "get").mockImplementation(() => visibilityState);
-    const { pane, requestUpdate, state } = createTestChatPane({
-      client: { request: vi.fn() } as unknown as GatewayBrowserClient,
-      sessions: {} as SessionCapability,
-    });
-    const lifecycle = pane as TestChatPane & {
-      hasUpdated: boolean;
-      paneId: string;
-      render: () => unknown;
-    };
-    lifecycle.render = () => null;
-    const textarea = document.createElement("textarea");
-    textarea.value = "Draft still being composed";
-    getChatComposerState(lifecycle.paneId).composerTextarea = textarea;
-    state.chatMessage = "Draft still being";
-    state.handleChatDraftChange = vi.fn((next: string) => {
-      state.chatMessage = next;
-    });
-    ChatPaneBase.prototype.connectedCallback.call(lifecycle);
-    await lifecycle.updateComplete;
-
-    visibilityState = "hidden";
-    document.dispatchEvent(new Event("visibilitychange"));
-
-    expect(state.handleChatDraftChange).toHaveBeenCalledExactlyOnceWith(textarea.value);
-    expect(state.chatMessage).toBe(textarea.value);
-    expect(requestUpdate).toHaveBeenCalledOnce();
-
-    visibilityState = "visible";
-    document.dispatchEvent(new Event("visibilitychange"));
-    await lifecycle.updateComplete;
-    Object.defineProperty(lifecycle, "isConnected", { configurable: true, value: false });
-    ChatPaneBase.prototype.disconnectedCallback.call(lifecycle);
-  });
-
   it("renders once while initially hidden, then reconciles hidden invalidations", async () => {
     let visibilityState: DocumentVisibilityState = "hidden";
     vi.spyOn(document, "visibilityState", "get").mockImplementation(() => visibilityState);

--- a/ui/src/pages/chat/chat-pane-lifecycle.test.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.test.ts
@@ -19,6 +19,7 @@ import { ChatPaneBase } from "./chat-pane-base.ts";
 import { createTestChatPane, type TestChatPane } from "./chat-pane.test-support.ts";
 import { applySelectedChatAgent } from "./chat-session.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
+import { getChatComposerState, resetChatComposerState } from "./components/chat-composer-state.ts";
 import {
   dismissConfirmedActionPopovers,
   openChatRewindConfirmation,
@@ -707,6 +708,7 @@ function createConfirmationOwner() {
 afterEach(() => {
   vi.useRealTimers();
   vi.restoreAllMocks();
+  resetChatComposerState();
   for (const owner of confirmationOwners) {
     dismissConfirmedActionPopovers(owner);
     owner.remove();
@@ -774,6 +776,43 @@ describe("chat pane presentation teardown", () => {
 });
 
 describe("chat pane connection lifecycle", () => {
+  it("commits the live composer draft before a hidden document can suspend", async () => {
+    let visibilityState: DocumentVisibilityState = "visible";
+    vi.spyOn(document, "visibilityState", "get").mockImplementation(() => visibilityState);
+    const { pane, requestUpdate, state } = createTestChatPane({
+      client: { request: vi.fn() } as unknown as GatewayBrowserClient,
+      sessions: {} as SessionCapability,
+    });
+    const lifecycle = pane as TestChatPane & {
+      hasUpdated: boolean;
+      paneId: string;
+      render: () => unknown;
+    };
+    lifecycle.render = () => null;
+    const textarea = document.createElement("textarea");
+    textarea.value = "Draft still being composed";
+    getChatComposerState(lifecycle.paneId).composerTextarea = textarea;
+    state.chatMessage = "Draft still being";
+    state.handleChatDraftChange = vi.fn((next: string) => {
+      state.chatMessage = next;
+    });
+    ChatPaneBase.prototype.connectedCallback.call(lifecycle);
+    await lifecycle.updateComplete;
+
+    visibilityState = "hidden";
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(state.handleChatDraftChange).toHaveBeenCalledExactlyOnceWith(textarea.value);
+    expect(state.chatMessage).toBe(textarea.value);
+    expect(requestUpdate).toHaveBeenCalledOnce();
+
+    visibilityState = "visible";
+    document.dispatchEvent(new Event("visibilitychange"));
+    await lifecycle.updateComplete;
+    Object.defineProperty(lifecycle, "isConnected", { configurable: true, value: false });
+    ChatPaneBase.prototype.disconnectedCallback.call(lifecycle);
+  });
+
   it("renders once while initially hidden, then reconciles hidden invalidations", async () => {
     let visibilityState: DocumentVisibilityState = "hidden";
     vi.spyOn(document, "visibilityState", "get").mockImplementation(() => visibilityState);

--- a/ui/src/pages/chat/chat-pane-suspension.test.ts
+++ b/ui/src/pages/chat/chat-pane-suspension.test.ts
@@ -1,0 +1,52 @@
+/* @vitest-environment jsdom */
+/* @vitest-environment-options {"url":"http://chat-pane-suspension.test/"} */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { SessionCapability } from "../../lib/sessions/index.ts";
+import { ChatPaneBase } from "./chat-pane-base.ts";
+import { createTestChatPane, type TestChatPane } from "./chat-pane.test-support.ts";
+import { getChatComposerState, resetChatComposerState } from "./components/chat-composer-state.ts";
+
+afterEach(() => {
+  resetChatComposerState();
+  vi.restoreAllMocks();
+});
+
+describe("chat pane suspension", () => {
+  it("commits the live composer draft before a hidden document can suspend", async () => {
+    let visibilityState: DocumentVisibilityState = "visible";
+    vi.spyOn(document, "visibilityState", "get").mockImplementation(() => visibilityState);
+    const { pane, requestUpdate, state } = createTestChatPane({
+      client: { request: vi.fn() } as unknown as GatewayBrowserClient,
+      sessions: {} as SessionCapability,
+    });
+    const lifecycle = pane as TestChatPane & {
+      paneId: string;
+      render: () => unknown;
+    };
+    lifecycle.render = () => null;
+    const textarea = document.createElement("textarea");
+    textarea.value = "Draft still being composed";
+    getChatComposerState(lifecycle.paneId).composerTextarea = textarea;
+    state.chatMessage = "Draft still being";
+    state.handleChatDraftChange = vi.fn((next: string) => {
+      state.chatMessage = next;
+    });
+    ChatPaneBase.prototype.connectedCallback.call(lifecycle);
+    await lifecycle.updateComplete;
+
+    visibilityState = "hidden";
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(state.handleChatDraftChange).toHaveBeenCalledExactlyOnceWith(textarea.value);
+    expect(state.chatMessage).toBe(textarea.value);
+    expect(requestUpdate).toHaveBeenCalledOnce();
+
+    visibilityState = "visible";
+    document.dispatchEvent(new Event("visibilitychange"));
+    await lifecycle.updateComplete;
+    Object.defineProperty(lifecycle, "isConnected", { configurable: true, value: false });
+    ChatPaneBase.prototype.disconnectedCallback.call(lifecycle);
+  });
+});


### PR DESCRIPTION
Closes #132023

## What Problem This Solves

A mobile Control UI page suspended across a Gateway update can miss the service worker's one-shot update message and keep running an older transcript bundle. That can render one agent run as several responses after the page resumes.

## Why This Change Was Made

The service worker now probes same-origin Control UI documents at the application root and across the complete `/chat` route namespace. Documents on the current build stay mounted; stale or unresponsive documents reload once into the current bundle.

The reload owner now:

- preserves the client's full URL, including query and fragment;
- excludes settings, sibling paths, and cross-origin pages;
- records one reload attempt per browser client and target build before navigation, preventing repeated activation loops;
- does not keep service-worker activation open while a navigation finishes; and
- flushes the live composer value when the document becomes hidden, including text still in IME composition before suspension.

Transcript grouping remains owned by the existing run-level composition path; this PR adds no mobile-specific grouping implementation.

## User Impact

Users resuming a stale mobile chat page receive the current transcript renderer without losing an unsent composer draft. Narration, tool calls, and the final answer remain one response, with Reply and Copy owned only by terminal text.

## Evidence

- Service-worker activation coverage includes configured mount roots, exact chat routes, nested chat deep links, query and fragment preservation, current documents, repeated activation, same-origin non-chat exclusions, segment-boundary exclusions, and cross-origin exclusions.
- Composer lifecycle coverage verifies that the live textarea value is committed before a hidden document can be suspended.
- The earlier transcript fixture covers desktop dark, mobile dark, and mobile light at 390x844, with one assistant frame, ordered tool activity, and one terminal action owner.
- GitHub CI is green on the current head.

| Before: mobile page on stale bundle | After: mobile page on current bundle |
| --- | --- |
| ![Before dark](https://github.com/user-attachments/assets/eb33238b-e1af-4d17-bf2f-04a44bd11efd) | ![After dark](https://github.com/user-attachments/assets/cb506f13-9b20-4689-9f93-a76f246c347c) |
| ![Before light](https://github.com/user-attachments/assets/1e85a3ec-f1e4-4476-9631-c9a544894aca) | ![After light](https://github.com/user-attachments/assets/3dd89466-36dd-4fd9-9f84-78344241dc2c) |

All screenshots use the same deterministic mocked-Gateway transcript at 390x844 and were inspected after capture. They demonstrate transcript grouping and action ownership; they are not service-worker activation evidence.

Production LOC: `+81/-10` (net `+71`). The growth adds the version handshake, route boundary, one-shot reload ownership, and suspension-time draft preservation. Tests: `+379/-191` (net `+188`, with most churn from parameterizing the existing transcript fixture).
