### PR TITLE
fix(workers): recover workspace edits after Gateway restart

### DIFF
--- a/src/gateway/worker-environments/node-worker-tunnel.recovery.test.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.recovery.test.ts
@@ -1,0 +1,374 @@
+import fs from "node:fs/promises";
+import { createServer } from "node:http";
+import path from "node:path";
+import { describe, it, vi } from "vitest";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { NODE_WORKER_ENVIRONMENT_STOP_COMMAND } from "../../infra/node-commands.js";
+import { NodeWorkerWorkspaceRuntime } from "../../node-host/node-worker-workspace.js";
+import { runCommandWithTimeout } from "../../process/exec.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
+import { parseNodeWorkerWorkspaceExecInput } from "../../worker/node-workspace-protocol.js";
+import { createNodeWorkerTunnelManager } from "./node-worker-tunnel.js";
+import { BUILD, transport } from "./node-worker-tunnel.test-support.js";
+import {
+  createNodeWorkspaceTransferHttpCallback,
+  handleNodeWorkspaceTransferHttpRequest,
+} from "./node-workspace-transfer-http.js";
+import { createNodeWorkspaceTransferService } from "./node-workspace-transfer-service.js";
+import { REQUEST, seedSyncingPlacement } from "./placement-dispatch-test-fixtures.js";
+import { createHarness } from "./placement-dispatch-test-harness.js";
+import { createWorkerSessionPlacementStore } from "./placement-store.js";
+
+describe("node workspace result recovery across Gateway lifetimes", () => {
+  it.for([
+    { name: "remote edits without restart", restart: false, remoteEdit: true, localEdit: false },
+    {
+      name: "unchanged workspaces after restart",
+      restart: true,
+      remoteEdit: false,
+      localEdit: false,
+    },
+    { name: "remote edits after restart", restart: true, remoteEdit: true, localEdit: false },
+    { name: "Gateway edits after restart", restart: true, remoteEdit: false, localEdit: true },
+    {
+      name: "mixed edits and an advanced Gateway HEAD after restart",
+      restart: true,
+      remoteEdit: true,
+      localEdit: true,
+      commitLocal: true,
+    },
+    {
+      name: "conflicting edits after restart",
+      restart: true,
+      remoteEdit: true,
+      localEdit: true,
+      conflict: true,
+    },
+  ])(
+    "collects a terminal pending result with $name",
+    { timeout: 30_000 },
+    (scenario, { expect, onTestFinished, signal }) => {
+      const tempDirs = createTempDirTracker();
+      const phases: Array<{ phase: string; elapsedMs: number }> = [];
+      const startedAt = performance.now();
+      const phase = (name: string) =>
+        phases.push({ phase: name, elapsedMs: Math.round(performance.now() - startedAt) });
+      const operation = (async () => {
+        phase("setup");
+        const root = await fs.realpath(tempDirs.make("node-worker-pending-recovery-"));
+        const localPath = path.join(root, "gateway-workspace");
+        await fs.mkdir(localPath);
+        const git = async (...args: string[]) => {
+          const result = await runCommandWithTimeout(["git", "-C", localPath, ...args], {
+            timeoutMs: 10_000,
+            signal,
+          });
+          expect(result.code, result.stderr).toBe(0);
+          return result.stdout.trim();
+        };
+        await git("init", "--quiet");
+        await fs.writeFile(path.join(localPath, "result.txt"), "base\n");
+        // Local edits must stay inside the dispatch inventory to exercise accepted publication.
+        await fs.writeFile(path.join(localPath, "local.txt"), "local base\n");
+        await git("add", "result.txt", "local.txt");
+        await git(
+          "-c",
+          "user.name=Workspace Recovery Test",
+          "-c",
+          "user.email=workspace-recovery@example.invalid",
+          "commit",
+          "--quiet",
+          "-m",
+          "base",
+        );
+
+        const baseCommit = await git("rev-parse", "HEAD");
+        let database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: root } });
+        let placements = createWorkerSessionPlacementStore({ database });
+        let harness = createHarness(placements, { workspacePath: localPath });
+        const environment = {
+          ...harness.attached,
+          nodeDeviceId: "node-1",
+          sshEndpoint: null,
+          bootstrapReceipt: { ...BUILD, installKind: "bundle" as const },
+        };
+        const createTransfer = () =>
+          createNodeWorkspaceTransferService({
+            temporaryRoot: path.join(root, "gateway-transfer"),
+            getOwner: () => ({
+              environment,
+              credential: {
+                ownerEpoch: environment.ownerEpoch,
+                sessionId: REQUEST.sessionId,
+                expiresAtMs: Date.now() + 60_000,
+              },
+            }),
+          });
+        let transfer = createTransfer();
+        const server = createServer((req, res) => {
+          void handleNodeWorkspaceTransferHttpRequest({
+            req,
+            res,
+            clientIp: "127.0.0.1",
+            callback: createNodeWorkspaceTransferHttpCallback(transfer),
+          })
+            .then((handled) => {
+              if (!handled) {
+                res.writeHead(404).end();
+              }
+            })
+            .catch((error: unknown) => res.destroy(error instanceof Error ? error : undefined));
+        });
+        await new Promise<void>((resolve, reject) => {
+          server.once("error", reject);
+          server.listen(0, "127.0.0.1", resolve);
+        });
+        const address = server.address();
+        if (!address || typeof address === "string") {
+          throw new Error("workspace transfer server did not bind");
+        }
+        const gatewayUrl = `ws://127.0.0.1:${address.port}`;
+        const runtime = new NodeWorkerWorkspaceRuntime({
+          root: path.join(root, "node-workspaces"),
+        });
+        const nodeTransport = transport();
+        nodeTransport.invoke = async (request) => {
+          expect(request.isDispatchAuthorized()).toBe(true);
+          if (request.command === NODE_WORKER_ENVIRONMENT_STOP_COMMAND) {
+            return { ok: true, payloadJSON: "null" };
+          }
+          const input = parseNodeWorkerWorkspaceExecInput(JSON.stringify(request.params));
+          const result = await runtime.exec(input, request.signal, { url: gatewayUrl });
+          return { ok: true, payloadJSON: JSON.stringify(result) };
+        };
+        const createManager = () => {
+          const manager = createNodeWorkerTunnelManager({
+            gatewayDeviceId: "gateway-recovery-test",
+            getEnvironment: () => environment,
+            listEnvironments: () => [environment],
+            getTransport: () => nodeTransport,
+            launchNodeWorker: vi.fn(),
+            validateWorkerTurn: (claim) => placements.validateTurnClaim(claim),
+            workspaceTransfer: transfer,
+          });
+          manager.bindWorkspaceBindingResolver(async ({ sessionId, environmentId, ownerEpoch }) => {
+            const placement = placements.get(sessionId);
+            if (
+              !placement ||
+              (placement.state !== "active" && placement.state !== "draining") ||
+              placement.environmentId !== environmentId ||
+              placement.activeOwnerEpoch !== ownerEpoch
+            ) {
+              return undefined;
+            }
+            return {
+              localPath,
+              manifestRef: placement.workspaceBaseManifestRef,
+              remoteWorkspaceDir: placement.remoteWorkspaceDir,
+            };
+          });
+          return manager;
+        };
+        const startRequest = {
+          executionMode: "worker-turn" as const,
+          environmentId: environment.environmentId,
+          ownerEpoch: environment.ownerEpoch,
+          deviceId: environment.nodeDeviceId,
+          sessionId: REQUEST.sessionId,
+          expectedBuild: BUILD,
+        };
+        let manager = createManager();
+        let abortedStop: Promise<void> | undefined;
+        const abort = () => {
+          abortedStop = manager.stopAll();
+          void abortedStop.catch(() => undefined);
+        };
+        signal.addEventListener("abort", abort, { once: true });
+        try {
+          signal.throwIfAborted();
+          phase("sync");
+          const syncing = seedSyncingPlacement(placements, environment.environmentId);
+          const tunnel = await manager.start(startRequest);
+          const synced = await tunnel.syncWorkspace({
+            localPath,
+            sessionId: REQUEST.sessionId,
+            generation: syncing.generation,
+          });
+          await expect(
+            fs.readFile(path.join(synced.remoteWorkspaceDir, "result.txt"), "utf8"),
+          ).resolves.toBe("base\n");
+          const starting = placements.transition({
+            sessionId: REQUEST.sessionId,
+            from: "syncing",
+            to: "starting",
+            expectedGeneration: syncing.generation,
+            patch: {
+              workspaceBaseManifestRef: synced.manifestRef,
+              remoteWorkspaceDir: synced.remoteWorkspaceDir,
+            },
+          });
+          placements.transition({
+            sessionId: REQUEST.sessionId,
+            from: "starting",
+            to: "active",
+            expectedGeneration: starting.generation,
+            patch: { activeOwnerEpoch: environment.ownerEpoch },
+          });
+          const claim = placements.claimTurn({
+            ...REQUEST,
+            claimId: "terminal-claim",
+            runId: "terminal-run",
+            owner: {
+              kind: "worker",
+              environmentId: environment.environmentId,
+              ownerEpoch: environment.ownerEpoch,
+            },
+          });
+          if (scenario.remoteEdit) {
+            await fs.writeFile(
+              path.join(synced.remoteWorkspaceDir, "result.txt"),
+              "worker result\n",
+            );
+          }
+          if (scenario.localEdit) {
+            await fs.writeFile(path.join(localPath, "local.txt"), "Gateway edit\n");
+          }
+          if ("conflict" in scenario) {
+            await fs.writeFile(
+              path.join(synced.remoteWorkspaceDir, "local.txt"),
+              "worker conflict\n",
+            );
+          }
+          if ("commitLocal" in scenario) {
+            await git("add", "local.txt");
+            await git(
+              "-c",
+              "user.name=Workspace Recovery Test",
+              "-c",
+              "user.email=workspace-recovery@example.invalid",
+              "commit",
+              "--quiet",
+              "-m",
+              "Gateway edit",
+            );
+            expect(await git("rev-parse", "HEAD")).not.toBe(baseCommit);
+          }
+          // The terminal ACK persists the fence before any workspace result is staged.
+          placements.updateAckCursors({ claim, liveEvent: 1 });
+          const pendingBeforeRestart = placements.listPendingWorkspaceResults();
+          expect(pendingBeforeRestart).toMatchObject([
+            {
+              claimId: claim.claimId,
+              runId: claim.runId,
+              stagedResultRef: null,
+              workspaceAcceptedAtMs: null,
+            },
+          ]);
+          const originalInstanceId = placements.workspaceResultInstanceId();
+          if (scenario.restart) {
+            phase("reopen");
+            await manager.stopAll();
+            await expect(
+              tunnel.runWorkspaceCommand({ argv: ["true"], transportRetry: "never" }),
+            ).rejects.toThrow("authority closed");
+            expect(() =>
+              transfer.prepareUpload(environment.environmentId, synced.manifestRef),
+            ).toThrow("context is unavailable");
+            signal.throwIfAborted();
+            closeOpenClawStateDatabaseForTest();
+            database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: root } });
+            placements = createWorkerSessionPlacementStore({ database });
+            expect(placements.workspaceResultInstanceId()).not.toBe(originalInstanceId);
+            expect(placements.listPendingWorkspaceResults()).toEqual(pendingBeforeRestart);
+            expect(placements.get(REQUEST.sessionId)).toMatchObject({
+              lastLiveEventAckCursor: 1,
+              workspaceBaseManifestRef: synced.manifestRef,
+            });
+            transfer = createTransfer();
+            manager = createManager();
+            harness = createHarness(placements, { workspacePath: localPath });
+          } else {
+            placements.handoffWorkspaceResultRecovery(claim);
+          }
+          harness.markEnvironmentOwnerEpoch(environment.ownerEpoch);
+          vi.mocked(harness.environments.get).mockReturnValue(environment);
+          vi.mocked(harness.environments.startTunnel).mockImplementation(async () =>
+            manager.start(startRequest),
+          );
+          vi.mocked(harness.environments.stopTunnel).mockImplementation(async () =>
+            manager.stop(environment.environmentId),
+          );
+
+          phase("recover");
+          await harness.service.reconcile("startup");
+          signal.throwIfAborted();
+          phase("assert");
+
+          expect.soft(harness.reportWorkspaceResultRecoveryFailure.mock.calls).toEqual([]);
+          expect
+            .soft(await fs.readFile(path.join(localPath, "result.txt"), "utf8"))
+            .toBe(scenario.remoteEdit ? "worker result\n" : "base\n");
+          if (scenario.localEdit) {
+            expect
+              .soft(await fs.readFile(path.join(localPath, "local.txt"), "utf8"))
+              .toBe("Gateway edit\n");
+            expect
+              .soft(
+                await fs
+                  .readFile(path.join(synced.remoteWorkspaceDir, "local.txt"), "utf8")
+                  .catch(() => undefined),
+              )
+              .toBe("Gateway edit\n");
+          }
+          const remoteHead = await runCommandWithTimeout(
+            ["git", "-C", synced.remoteWorkspaceDir, "rev-parse", "--verify", "HEAD^{commit}"],
+            { timeoutMs: 10_000, signal },
+          );
+          expect.soft(remoteHead.code, remoteHead.stderr).toBe(0);
+          expect.soft(remoteHead.stdout.trim()).toBe(baseCommit);
+          if ("conflict" in scenario) {
+            const stagedResultRef = "refs/openclaw/worker-results/terminal-claim";
+            expect
+              .soft(harness.reportWorkspaceResultConflict)
+              .toHaveBeenCalledWith(
+                expect.objectContaining({ paths: ["local.txt"], stagedResultRef, totalCount: 1 }),
+              );
+            expect(await git("show", `${stagedResultRef}:local.txt`)).toBe("worker conflict");
+          } else {
+            expect.soft(harness.reportWorkspaceResultConflict).not.toHaveBeenCalled();
+          }
+          expect.soft(placements.listPendingWorkspaceResults()).toEqual([]);
+          expect.soft(placements.get(REQUEST.sessionId)).toMatchObject({
+            state: scenario.restart ? "reclaimed" : "active",
+            turnClaim: null,
+          });
+        } finally {
+          phase("cleanup");
+          signal.removeEventListener("abort", abort);
+          try {
+            await (abortedStop ?? manager.stopAll());
+          } finally {
+            server.closeAllConnections();
+            await new Promise<void>((resolve, reject) => {
+              server.close((error) => (error ? reject(error) : resolve()));
+            });
+            closeOpenClawStateDatabaseForTest();
+          }
+        }
+      })();
+      onTestFinished(async ({ task }) => {
+        // Vitest's timeout does not join the test body. Drain its commands and cleanup
+        // before deleting files or letting another case reuse the shared database owner.
+        await Promise.allSettled([operation]);
+        tempDirs.cleanup();
+        if (task.result?.state === "fail") {
+          console.info("recovery phases", scenario.name, phases);
+        }
+      });
+      return operation;
+    },
+  );
+});

--- a/src/gateway/worker-environments/node-worker-tunnel.test.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.test.ts
@@ -319,20 +319,19 @@ describe("node worker tunnel manager", () => {
   });
 
   it.each(["success", "failure"] as const)(
-    "keeps same-owner starts behind restored workspace validation on %s",
+    "keeps same-owner starts behind workspace restoration on %s",
     async (outcome) => {
       const record = environment();
       const validation = createDeferred();
       const manifest = { version: 1 as const, baseCommit: null, entries: [] };
       const rawManifest = serializeWorkerWorkspaceManifest(manifest);
       const manifestRef = `sha256:${createHash("sha256").update(rawManifest).digest("hex")}`;
-      const outputs = [`quiesced ${"c".repeat(32)}`, manifestRef, ""];
       const nodeTransport = transport();
       const invoke = vi.fn(async () => ({
         ok: true,
         payloadJSON: JSON.stringify({
           workspaceDir: "/node/workspace",
-          stdout: outputs.shift() ?? "",
+          stdout: "",
           stderr: "",
           code: 0,
           signal: null,
@@ -341,18 +340,14 @@ describe("node worker tunnel manager", () => {
         }),
       }));
       nodeTransport.invoke = invoke;
-      const prepareSync = vi.fn(async () => {
+      const restore = vi.fn(async () => {
         await validation.promise;
         if (outcome === "failure") {
-          throw new Error("restored workspace validation failed");
+          throw new Error("workspace restoration failed");
         }
-        return {
-          snapshot: { manifest, manifestRef, rawManifest, root: "/gateway/workspace" },
-          token: "restore-token",
-        };
       });
       const transfer = workspaceTransfer();
-      transfer.prepareSync = prepareSync;
+      transfer.restore = restore;
       const manager = createNodeWorkerTunnelManager({
         gatewayDeviceId: "gateway-device-1",
         getEnvironment: () => record,
@@ -368,7 +363,7 @@ describe("node worker tunnel manager", () => {
         remoteWorkspaceDir: "/node/workspace",
       }));
       const first = manager.start(startRequest());
-      await vi.waitFor(() => expect(prepareSync).toHaveBeenCalledOnce());
+      await vi.waitFor(() => expect(restore).toHaveBeenCalledOnce());
       expect(manager.status("environment-1")).toBe("connecting");
       const second = manager.start(startRequest());
       const secondSettled = vi.fn();
@@ -383,13 +378,7 @@ describe("node worker tunnel manager", () => {
       expect(results.map((result) => result.status)).toEqual([expectedStatus, expectedStatus]);
       expect(manager.status("environment-1")).toBe(outcome === "success" ? "connected" : "stopped");
       if (outcome === "success") {
-        expect(invoke).toHaveBeenCalledWith(
-          expect.objectContaining({
-            params: expect.objectContaining({
-              argv: expect.arrayContaining(["all", manifestRef.slice("sha256:".length)]),
-            }),
-          }),
-        );
+        expect(invoke).not.toHaveBeenCalled();
       }
     },
   );
@@ -399,7 +388,6 @@ describe("node worker tunnel manager", () => {
     const manifest = { version: 1 as const, baseCommit: null, entries: [] };
     const rawManifest = serializeWorkerWorkspaceManifest(manifest);
     const manifestRef = `sha256:${createHash("sha256").update(rawManifest).digest("hex")}`;
-    const outputs = [`quiesced ${"c".repeat(32)}`, manifestRef, ""];
     let launchEligible = true;
     const invoke = vi.fn(
       async (request: Parameters<NodeWorkerSupervisorTransport["invoke"]>[0]) => {
@@ -412,7 +400,7 @@ describe("node worker tunnel manager", () => {
           ok: true,
           payloadJSON: JSON.stringify({
             workspaceDir: "/node/workspace",
-            stdout: outputs.shift() ?? "",
+            stdout: "",
             stderr: "",
             code: 0,
             signal: null,
@@ -422,17 +410,9 @@ describe("node worker tunnel manager", () => {
         };
       },
     );
-    const prepareSync = vi.fn(async () => ({
-      snapshot: {
-        manifest,
-        manifestRef,
-        rawManifest,
-        root: "/gateway/workspace",
-      },
-      token: "restore-token",
-    }));
+    const restore = vi.fn(async () => {});
     const transfer = {
-      prepareSync,
+      restore,
       close: vi.fn(async () => {}),
       revoke: vi.fn(),
     } as unknown as NodeWorkspaceTransferService;
@@ -496,14 +476,13 @@ describe("node worker tunnel manager", () => {
       ownerEpoch: record.ownerEpoch,
       sessionId: "session-1",
     });
-    expect(prepareSync).toHaveBeenCalledWith(
+    expect(restore).toHaveBeenCalledWith(
       expect.objectContaining({
         environmentId: "environment-1",
         generation: record.ownerEpoch,
         localPath: "/gateway/workspace",
       }),
     );
-    expect(outputs).toEqual([]);
   });
 
   it("keeps the process timeout inside the node transport deadline", async () => {
@@ -511,7 +490,6 @@ describe("node worker tunnel manager", () => {
     const manifest = { version: 1 as const, baseCommit: null, entries: [] };
     const rawManifest = serializeWorkerWorkspaceManifest(manifest);
     const manifestRef = `sha256:${createHash("sha256").update(rawManifest).digest("hex")}`;
-    const validationOutputs = [`quiesced ${"c".repeat(32)}`, manifestRef, ""];
     let commandTimeoutMs: number | undefined;
     let transportTimeoutMs: number | undefined;
     const nodeTransport = transport();
@@ -537,7 +515,7 @@ describe("node worker tunnel manager", () => {
         ok: true,
         payloadJSON: JSON.stringify({
           workspaceDir: "/node/workspace",
-          stdout: validationOutputs.shift() ?? "",
+          stdout: "",
           stderr: "",
           code: 0,
           signal: null,
@@ -547,15 +525,7 @@ describe("node worker tunnel manager", () => {
       };
     });
     const transfer = workspaceTransfer();
-    transfer.prepareSync = vi.fn(async () => ({
-      snapshot: {
-        manifest,
-        manifestRef,
-        rawManifest,
-        root: "/gateway/workspace",
-      },
-      token: "restore-token",
-    }));
+    transfer.restore = vi.fn(async () => {});
     const manager = createNodeWorkerTunnelManager({
       gatewayDeviceId: "gateway-device-1",
       getEnvironment: () => record,
@@ -582,7 +552,6 @@ describe("node worker tunnel manager", () => {
     expect(commandTimeoutMs).toBe(60_000);
     expect(transportTimeoutMs).toBeGreaterThan(60_000);
     expect(transportTimeoutMs).toBeLessThanOrEqual(65_000);
-    expect(validationOutputs).toEqual([]);
   });
 
   it("preserves a typed workspace transfer cause from the node", async () => {
@@ -836,7 +805,6 @@ describe("node worker tunnel manager", () => {
         currentRaw: raw,
         stagingRoot: localPath,
       })),
-      getSnapshot: vi.fn(() => ({ manifest, manifestRef: baseManifestRef, rawManifest: raw })),
       publishSnapshot,
       close: vi.fn(async () => {}),
       revoke: vi.fn(),

--- a/src/gateway/worker-environments/node-worker-tunnel.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.ts
@@ -268,8 +268,8 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
   const createHandle = (
     entry: NodeTunnelEntry,
     restoredWorkspace: NodeWorkerWorkspaceBinding | undefined,
-  ): { handle: WorkerTurnTunnelHandle; validateRestoredWorkspace: () => Promise<void> } => {
-    const { validateRestoredWorkspace, ...workspaceActions } = createNodeWorkerWorkspaceActions({
+  ): { handle: WorkerTurnTunnelHandle; restoreWorkspace: () => Promise<void> } => {
+    const { restoreWorkspace, ...workspaceActions } = createNodeWorkerWorkspaceActions({
       environmentId: entry.environmentId,
       ownerEpoch: entry.ownerEpoch,
       sessionId: entry.sessionId,
@@ -329,7 +329,7 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
         await stopEntry(entry);
       },
     };
-    return { handle, validateRestoredWorkspace };
+    return { handle, restoreWorkspace };
   };
 
   function stopEntry(entry: NodeTunnelEntry, reason?: WorkerTunnelStopReason): Promise<void> {
@@ -496,7 +496,7 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
           ) {
             throw new Error("node worker tunnel owner binding changed within one epoch");
           }
-          return current.readiness.promise; // Share restored-workspace validation without false readiness.
+          return current.readiness.promise; // Share workspace restoration without false readiness.
         }
       }
       const readiness = createDeferredCore<WorkerTurnTunnelHandle>();
@@ -532,7 +532,7 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
           return;
         }
         const created = createHandle(entry, restoredWorkspace);
-        await created.validateRestoredWorkspace();
+        await created.restoreWorkspace();
         if (!isLiveEntry(entry)) {
           return;
         }

--- a/src/gateway/worker-environments/node-worker-workspace-actions.ts
+++ b/src/gateway/worker-environments/node-worker-workspace-actions.ts
@@ -14,7 +14,6 @@ import {
   type WorkspaceHashMemo,
   type WorkspaceReconcileMetrics,
 } from "./workspace-hash-memo.js";
-import { serializeWorkerWorkspaceManifest } from "./workspace-manifest.js";
 import { createWorkerWorkspaceQuiescence } from "./workspace-quiescence.js";
 import {
   applyStagedWorkerWorkspace,
@@ -33,7 +32,7 @@ export type NodeWorkerWorkspaceBinding = {
 type NodeWorkerWorkspaceActions = Pick<
   WorkerWorkspaceTunnelHandle,
   "runWorkspaceCommand" | "syncWorkspace" | "quiesceWorkspace" | "reconcileWorkspace"
-> & { validateRestoredWorkspace: () => Promise<void> };
+> & { restoreWorkspace: () => Promise<void> };
 
 export function createNodeWorkerWorkspaceActions(params: {
   environmentId: string;
@@ -61,39 +60,16 @@ export function createNodeWorkerWorkspaceActions(params: {
     sharedHost: true,
     runWorkspaceCommand: exec,
   });
-  const validateRestoredWorkspace = async (): Promise<void> => {
-    if (!restoredWorkspace) {
-      return;
-    }
-    const prepared = await params.workspaceTransfer.prepareSync({
-      environmentId: params.environmentId,
-      ownerEpoch: params.ownerEpoch,
-      sessionId: params.sessionId,
-      generation: params.ownerEpoch,
-      localPath: restoredWorkspace.localPath,
-      // The transfer service re-reads the durable environment and credential together.
-      // This closure fences the exact in-memory tunnel instance without duplicating that read.
-      isAuthorized: params.isOwnerCurrent,
-      signal: params.ownerSignal,
-    });
-    params.workspaceTransfer.revoke(params.environmentId, prepared.token);
-    if (prepared.snapshot.manifestRef !== restoredWorkspace.manifestRef) {
-      throw new Error("Gateway workspace changed before node tunnel recovery");
-    }
-    const quiescence = await quiesceWorkspace(restoredWorkspace.remoteWorkspaceDir);
-    try {
-      const remoteManifestRef = await workspace.captureManifest(
-        restoredWorkspace.remoteWorkspaceDir,
-        prepared.snapshot.manifest.baseCommit,
-        restoredWorkspace.manifestRef,
-      );
-      if (remoteManifestRef !== restoredWorkspace.manifestRef) {
-        throw new Error("Node workspace changed before tunnel recovery");
-      }
-    } finally {
-      await quiescence.resume();
-    }
-  };
+  const transferOwner = (localPath: string) => ({
+    environmentId: params.environmentId,
+    ownerEpoch: params.ownerEpoch,
+    sessionId: params.sessionId,
+    generation: params.ownerEpoch,
+    localPath,
+    // Durable transfer ownership and the exact tunnel instance must both remain live.
+    isAuthorized: params.isOwnerCurrent,
+    signal: params.ownerSignal,
+  });
   // Same placement-lifetime memo contract as the SSH tunnel owner: stat-identity
   // keys self-invalidate on change, and without this owner every turn re-hashes
   // the full managed worktree during prepare/apply/verify.
@@ -163,17 +139,10 @@ export function createNodeWorkerWorkspaceActions(params: {
         if (accepted.manifestRef === expectedRemoteRef) {
           return;
         }
-        const baseSnapshot = params.workspaceTransfer.getSnapshot(
+        const token = await params.workspaceTransfer.publishSnapshot(
           params.environmentId,
-          request.baseManifestRef,
+          accepted,
         );
-        const token = params.workspaceTransfer.publishSnapshot(params.environmentId, {
-          manifest: accepted.manifest,
-          manifestRef: accepted.manifestRef,
-          rawManifest: serializeWorkerWorkspaceManifest(accepted.manifest),
-          root: await fsp.realpath(request.localPath),
-          ...(baseSnapshot?.packPath ? { packPath: baseSnapshot.packPath } : {}),
-        });
         try {
           const published = await exec({
             argv: ["openclaw-internal-workspace-transfer"],
@@ -256,21 +225,20 @@ export function createNodeWorkerWorkspaceActions(params: {
     }
   };
   return {
-    validateRestoredWorkspace,
+    restoreWorkspace: async () => {
+      if (restoredWorkspace) {
+        // Recovery collects deltas against the authenticated uploaded base; neither
+        // workspace must still equal that base when this transfer owner is restored.
+        await params.workspaceTransfer.restore(transferOwner(restoredWorkspace.localPath));
+      }
+    },
     runWorkspaceCommand: exec,
     syncWorkspace: async (request) => {
       workspaceReady = true;
       try {
-        const prepared = await params.workspaceTransfer.prepareSync({
-          environmentId: params.environmentId,
-          ownerEpoch: params.ownerEpoch,
-          sessionId: params.sessionId,
-          generation: params.ownerEpoch,
-          localPath: request.localPath,
-          // Durable owner state is revalidated by the transfer service after every awaited I/O.
-          isAuthorized: params.isOwnerCurrent,
-          signal: params.ownerSignal,
-        });
+        const prepared = await params.workspaceTransfer.prepareSync(
+          transferOwner(request.localPath),
+        );
         try {
           const originStartedAt = performance.now();
           const origin = await workspace.trySyncWorkspace(request, prepared.snapshot.manifestRef);

--- a/src/gateway/worker-environments/node-workspace-transfer-service.test.ts
+++ b/src/gateway/worker-environments/node-workspace-transfer-service.test.ts
@@ -13,7 +13,6 @@ import type { ResolvedGatewayAuth } from "../auth.js";
 import { createGatewayHttpServer } from "../server-http.js";
 import { createNodeWorkspaceTransferHttpCallback } from "./node-workspace-transfer-http.js";
 import { createNodeWorkspaceTransferService } from "./node-workspace-transfer-service.js";
-import { serializeWorkerWorkspaceManifest } from "./workspace-manifest.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const resolvedAuth: ResolvedGatewayAuth = { mode: "none", allowTailscale: false };
@@ -371,16 +370,32 @@ describe("node workspace transfer service", () => {
         prepared.snapshot.manifestRef,
       );
       service.revoke("environment-1", resetUploadToken);
-      const acceptedToken = service.publishSnapshot("environment-1", {
+      const acceptedToken = await service.publishSnapshot("environment-1", {
         manifest: uploaded.current,
         manifestRef: uploaded.currentManifestRef,
-        rawManifest: serializeWorkerWorkspaceManifest(uploaded.current),
-        root: localPath,
       });
-      expect(service.getSnapshot("environment-1", prepared.snapshot.manifestRef)).toBeDefined();
+      const admitted = service.authorize({
+        token: prepared.token,
+        route: {
+          kind: "manifest",
+          direction: "download",
+          environmentId: "environment-1",
+          manifestRef: prepared.snapshot.manifestRef,
+        },
+      });
+      expect(admitted && service.snapshot(admitted)).toBeDefined();
       service.revoke("environment-1", prepared.token);
-      expect(service.getSnapshot("environment-1", prepared.snapshot.manifestRef)).toBeUndefined();
-      expect(service.getSnapshot("environment-1", uploaded.currentManifestRef)).toBeDefined();
+      expect(admitted && service.snapshot(admitted)).toBeUndefined();
+      const accepted = service.authorize({
+        token: acceptedToken,
+        route: {
+          kind: "manifest",
+          direction: "download",
+          environmentId: "environment-1",
+          manifestRef: uploaded.currentManifestRef,
+        },
+      });
+      expect(accepted && service.snapshot(accepted)).toBeDefined();
       service.revoke("environment-1", acceptedToken);
 
       const authorityRetry = writeFaults.blockNextRetry();
@@ -657,49 +672,58 @@ describe("node workspace transfer service", () => {
     await service.closeAll();
   });
 
-  it("rejects a retained tunnel callback after durable transfer ownership changes", async () => {
-    const root = tempDirs.make("node-workspace-transfer-owner-");
-    const localPath = path.join(root, "workspace");
-    await fs.mkdir(localPath);
-    const environment = {
-      ownerEpoch: 1,
-      attachedSessionIds: ["session-owner"],
-      destroyRequestedAtMs: null,
-      state: "attached",
-    };
-    const service = createNodeWorkspaceTransferService({
-      getOwner: () => ({
-        credential: {
-          ownerEpoch: 1,
-          expiresAtMs: Date.now() + 60_000,
-          sessionId: "session-owner",
-        },
-        environment,
-      }),
-      temporaryRoot: path.join(root, "transfer-tmp"),
-    });
-    const prepared = await service.prepareSync({
-      environmentId: "environment-owner",
-      ownerEpoch: 1,
-      sessionId: "session-owner",
-      generation: 1,
-      localPath,
-      isAuthorized: () => true,
-    });
-    const authorization = service.authorize({
-      token: prepared.token,
-      route: {
-        kind: "manifest",
-        direction: "download",
+  it.each(["sync", "restore"] as const)(
+    "rejects a retained %s callback after durable transfer ownership changes",
+    async (mode) => {
+      const root = tempDirs.make("node-workspace-transfer-owner-");
+      const localPath = path.join(root, "workspace");
+      await fs.mkdir(localPath);
+      const environment = {
+        ownerEpoch: 1,
+        attachedSessionIds: ["session-owner"],
+        destroyRequestedAtMs: null,
+        state: "attached",
+      };
+      const service = createNodeWorkspaceTransferService({
+        getOwner: () => ({
+          credential: {
+            ownerEpoch: 1,
+            expiresAtMs: Date.now() + 60_000,
+            sessionId: "session-owner",
+          },
+          environment,
+        }),
+        temporaryRoot: path.join(root, "transfer-tmp"),
+      });
+      const request = {
         environmentId: "environment-owner",
-        manifestRef: prepared.snapshot.manifestRef,
-      },
-    });
-    expect(authorization).toBeDefined();
+        ownerEpoch: 1,
+        sessionId: "session-owner",
+        generation: 1,
+        localPath,
+        isAuthorized: () => true,
+      };
+      const prepared = mode === "sync" ? await service.prepareSync(request) : undefined;
+      if (!prepared) {
+        await service.restore(request);
+      }
+      const baseManifestRef = prepared?.snapshot.manifestRef ?? `sha256:${"a".repeat(64)}`;
+      const token = service.prepareUpload(request.environmentId, baseManifestRef);
+      const authorization = service.authorize({
+        token,
+        route: {
+          kind: "reconcile",
+          direction: "upload",
+          environmentId: request.environmentId,
+          baseManifestRef,
+        },
+      });
+      expect(authorization).toBeDefined();
 
-    environment.ownerEpoch += 1;
+      environment.ownerEpoch += 1;
 
-    expect(service.isAuthorizationCurrent(authorization!)).toBe(false);
-    await service.closeAll();
-  });
+      expect(service.isAuthorizationCurrent(authorization!)).toBe(false);
+      await service.closeAll();
+    },
+  );
 });

--- a/src/gateway/worker-environments/node-workspace-transfer-service.ts
+++ b/src/gateway/worker-environments/node-workspace-transfer-service.ts
@@ -7,6 +7,7 @@ import { isPathInside } from "../../infra/fs-safe.js";
 import { KeyedAsyncQueue } from "../../plugin-sdk/keyed-async-queue.js";
 import type { NodeWorkspaceTransferHttpRoute } from "./node-workspace-transfer-http-contract.js";
 import {
+  prepareNodeWorkspaceTransferPack,
   prepareNodeWorkspaceTransferSnapshot,
   type NodeWorkspaceTransferSnapshot,
 } from "./node-workspace-transfer-snapshot.js";
@@ -20,6 +21,7 @@ import {
   MAX_RECONCILIATION_ENTRIES,
   MAX_RECONCILIATION_TOTAL_BYTES,
   parseWorkerWorkspaceManifest,
+  serializeWorkerWorkspaceManifest,
   type WorkerWorkspaceManifest,
   type WorkerWorkspaceManifestEntry,
 } from "./workspace-manifest.js";
@@ -69,7 +71,7 @@ type DownloadCapability = {
   ownerEpoch: number;
   sessionId: string;
   generation: number;
-  manifestRef: string;
+  snapshot: NodeWorkspaceTransferSnapshot;
   expiresAtMs: number;
 };
 
@@ -93,8 +95,7 @@ type TransferContext = {
   generation: number;
   localPath: string;
   temporaryRoot: string;
-  currentManifestRef: string;
-  snapshots: Map<string, NodeWorkspaceTransferSnapshot>;
+  snapshot?: NodeWorkspaceTransferSnapshot;
   downloads: Map<string, DownloadCapability>;
   upload?: UploadOperation;
   abortController: AbortController;
@@ -314,7 +315,10 @@ export function createNodeWorkspaceTransferService(options: {
       }
     });
 
-  const mintDownload = (context: TransferContext, manifestRef: string): string => {
+  const mintDownload = (
+    context: TransferContext,
+    snapshot: NodeWorkspaceTransferSnapshot,
+  ): string => {
     const credential = currentOwner(context)?.credential;
     const nowMs = now();
     if (!credential) {
@@ -325,6 +329,7 @@ export function createNodeWorkspaceTransferService(options: {
       throw new Error("Worker workspace transfer credential is expired");
     }
     const token = mintNodeWorkspaceTransferToken();
+    context.snapshot = snapshot;
     context.downloads.set(token, {
       direction: "download",
       token,
@@ -332,22 +337,10 @@ export function createNodeWorkspaceTransferService(options: {
       ownerEpoch: context.ownerEpoch,
       sessionId: context.sessionId,
       generation: context.generation,
-      manifestRef,
+      snapshot,
       expiresAtMs,
     });
     return token;
-  };
-
-  const pruneSnapshots = (context: TransferContext): void => {
-    const retained = new Set([
-      context.currentManifestRef,
-      ...[...context.downloads.values()].map((download) => download.manifestRef),
-    ]);
-    for (const manifestRef of context.snapshots.keys()) {
-      if (!retained.has(manifestRef)) {
-        context.snapshots.delete(manifestRef);
-      }
-    }
   };
 
   const authorizationCurrent = (authorization: TransferAuthorization): boolean => {
@@ -380,22 +373,18 @@ export function createNodeWorkspaceTransferService(options: {
       return false;
     }
     if (route.kind === "manifest" || route.kind === "pack") {
-      return route.manifestRef === capability.manifestRef;
+      return route.manifestRef === capability.snapshot.manifestRef;
     }
     if (route.kind !== "blob") {
       return false;
     }
-    return Boolean(
-      context.snapshots
-        .get(capability.manifestRef)
-        ?.manifest.entries.some((entry) => entry.type === "file" && entry.sha256 === route.sha256),
+    return capability.snapshot.manifest.entries.some(
+      (entry) => entry.type === "file" && entry.sha256 === route.sha256,
     );
   };
 
-  return {
-    initialize: ensureTemporaryRoot,
-
-    async prepareSync(params: {
+  const withNewContext = async <T>(
+    params: {
       environmentId: string;
       ownerEpoch: number;
       sessionId: string;
@@ -403,49 +392,66 @@ export function createNodeWorkspaceTransferService(options: {
       localPath: string;
       isAuthorized: () => boolean;
       signal?: AbortSignal;
-    }) {
-      return await contextOperations.enqueue(params.environmentId, async () => {
-        const previous = contexts.get(params.environmentId);
-        if (previous) {
-          await closeContext(previous);
+    },
+    prepare: (context: TransferContext) => Promise<T>,
+  ): Promise<T> =>
+    await contextOperations.enqueue(params.environmentId, async () => {
+      const previous = contexts.get(params.environmentId);
+      if (previous) {
+        await closeContext(previous);
+      }
+      await ensureTemporaryRoot();
+      const abortController = new AbortController();
+      const context: TransferContext = {
+        ...params,
+        localPath: await fsp.realpath(params.localPath),
+        temporaryRoot: await fsp.mkdtemp(path.join(temporaryBaseRoot, "context-")),
+        downloads: new Map(),
+        abortController,
+      };
+      if (params.signal) {
+        const abortFromOwner = () => abortController.abort(params.signal!.reason);
+        params.signal.addEventListener("abort", abortFromOwner, { once: true });
+        context.stopWatchingOwnerSignal = () =>
+          params.signal?.removeEventListener("abort", abortFromOwner);
+        if (params.signal.aborted) {
+          abortFromOwner();
         }
-        await ensureTemporaryRoot();
-        const abortController = new AbortController();
-        const context: TransferContext = {
-          ...params,
-          localPath: await fsp.realpath(params.localPath),
-          temporaryRoot: await fsp.mkdtemp(path.join(temporaryBaseRoot, "context-")),
-          currentManifestRef: "",
-          snapshots: new Map(),
-          downloads: new Map(),
-          abortController,
-        };
-        if (params.signal) {
-          const abortFromOwner = () => abortController.abort(params.signal!.reason);
-          params.signal.addEventListener("abort", abortFromOwner, { once: true });
-          context.stopWatchingOwnerSignal = () =>
-            params.signal?.removeEventListener("abort", abortFromOwner);
-          if (params.signal.aborted) {
-            abortFromOwner();
-          }
+      }
+      contexts.set(context.environmentId, context);
+      try {
+        if (!isCurrentContext(context)) {
+          throw new Error("Node workspace transfer owner is no longer current");
         }
-        try {
-          const snapshot = await prepareNodeWorkspaceTransferSnapshot({
-            localPath: context.localPath,
-            temporaryRoot: context.temporaryRoot,
-            signal: AbortSignal.any([
-              context.abortController.signal,
-              AbortSignal.timeout(TRANSFER_TIMEOUT_MS),
-            ]),
-          });
-          context.snapshots.set(snapshot.manifestRef, snapshot);
-          context.currentManifestRef = snapshot.manifestRef;
-          contexts.set(context.environmentId, context);
-          return { snapshot, token: mintDownload(context, snapshot.manifestRef) };
-        } catch (error) {
-          await closeContext(context);
-          throw error;
+        const result = await prepare(context);
+        if (!isCurrentContext(context)) {
+          throw new Error("Node workspace transfer owner is no longer current");
         }
+        return result;
+      } catch (error) {
+        await closeContext(context);
+        throw error;
+      }
+    });
+
+  return {
+    initialize: ensureTemporaryRoot,
+
+    async restore(params: Parameters<typeof withNewContext>[0]): Promise<void> {
+      await withNewContext(params, async () => {});
+    },
+
+    async prepareSync(params: Parameters<typeof withNewContext>[0]) {
+      return await withNewContext(params, async (context) => {
+        const snapshot = await prepareNodeWorkspaceTransferSnapshot({
+          localPath: context.localPath,
+          temporaryRoot: context.temporaryRoot,
+          signal: AbortSignal.any([
+            context.abortController.signal,
+            AbortSignal.timeout(TRANSFER_TIMEOUT_MS),
+          ]),
+        });
+        return { snapshot, token: mintDownload(context, snapshot) };
       });
     },
 
@@ -495,30 +501,39 @@ export function createNodeWorkspaceTransferService(options: {
       return operation.uploaded;
     },
 
-    getSnapshot(
+    async publishSnapshot(
       environmentId: string,
-      manifestRef: string,
-    ): NodeWorkspaceTransferSnapshot | undefined {
-      return contexts.get(environmentId)?.snapshots.get(manifestRef);
-    },
-
-    publishSnapshot(environmentId: string, snapshot: NodeWorkspaceTransferSnapshot): string {
+      snapshot: Pick<NodeWorkspaceTransferSnapshot, "manifest" | "manifestRef">,
+    ): Promise<string> {
       const context = contexts.get(environmentId);
       if (!context || !isCurrentContext(context)) {
         throw new Error("Node workspace transfer context is unavailable");
       }
-      context.snapshots.set(snapshot.manifestRef, snapshot);
-      context.currentManifestRef = snapshot.manifestRef;
-      pruneSnapshots(context);
-      return mintDownload(context, snapshot.manifestRef);
+      // Reuse packs by immutable base commit, not mutable worktree manifest. Recovery
+      // rebuilds the authenticated base pack even when the Gateway HEAD has advanced.
+      const packPath =
+        context.snapshot?.manifest.baseCommit === snapshot.manifest.baseCommit
+          ? context.snapshot.packPath
+          : await prepareNodeWorkspaceTransferPack({
+              root: context.localPath,
+              baseCommit: snapshot.manifest.baseCommit,
+              temporaryRoot: context.temporaryRoot,
+              signal: AbortSignal.any([
+                context.abortController.signal,
+                AbortSignal.timeout(TRANSFER_TIMEOUT_MS),
+              ]),
+            });
+      return mintDownload(context, {
+        ...snapshot,
+        rawManifest: serializeWorkerWorkspaceManifest(snapshot.manifest),
+        root: context.localPath,
+        packPath,
+      });
     },
 
     revoke(environmentId: string, token: string): void {
       const context = contexts.get(environmentId);
       context?.downloads.delete(token);
-      if (context) {
-        pruneSnapshots(context);
-      }
       if (context?.upload?.token === token && context.upload.state === "ready") {
         context.upload = undefined;
       }
@@ -575,7 +590,7 @@ export function createNodeWorkspaceTransferService(options: {
       ) {
         return undefined;
       }
-      return authorization.context.snapshots.get(authorization.capability.manifestRef);
+      return authorization.capability.snapshot;
     },
 
     blob(
@@ -588,12 +603,12 @@ export function createNodeWorkspaceTransferService(options: {
       ) {
         return undefined;
       }
-      const snapshot = authorization.context.snapshots.get(authorization.capability.manifestRef);
+      const snapshot = authorization.capability.snapshot;
       const sha256 = authorization.route.sha256;
-      const entry = snapshot?.manifest.entries.find(
+      const entry = snapshot.manifest.entries.find(
         (candidate) => candidate.type === "file" && candidate.sha256 === sha256,
       );
-      return snapshot && entry?.type === "file"
+      return entry?.type === "file"
         ? { path: entryPath(snapshot.root, entry.path), size: entry.size, sha256: entry.sha256 }
         : undefined;
     },

--- a/src/gateway/worker-environments/node-workspace-transfer-snapshot.ts
+++ b/src/gateway/worker-environments/node-workspace-transfer-snapshot.ts
@@ -69,11 +69,27 @@ export async function prepareNodeWorkspaceTransferSnapshot(params: {
     includePaths = manifestPaths;
   }
   const actual = await readActualWorkspaceManifest({ root, baseCommit, includePaths });
-  let packPath: string | undefined;
+  const packPath = await prepareNodeWorkspaceTransferPack({ ...params, root, baseCommit });
+  return {
+    ...actual,
+    rawManifest: serializeWorkerWorkspaceManifest(actual.manifest),
+    root,
+    ...(packPath ? { packPath } : {}),
+  };
+}
+
+export async function prepareNodeWorkspaceTransferPack(params: {
+  root: string;
+  baseCommit: string | null;
+  temporaryRoot: string;
+  signal?: AbortSignal;
+}): Promise<string | undefined> {
+  const { baseCommit, root } = params;
   if (baseCommit) {
+    const temporaryRoot = await fsp.mkdtemp(path.join(params.temporaryRoot, "pack-"));
     const signal = params.signal ?? AbortSignal.timeout(TRANSFER_TIMEOUT_MS);
-    const objectListPath = path.join(params.temporaryRoot, "base-objects");
-    packPath = path.join(params.temporaryRoot, "base.pack");
+    const objectListPath = path.join(temporaryRoot, "base-objects");
+    const packPath = path.join(temporaryRoot, "base.pack");
     await runWorkspaceInventoryCommandToFile({
       argv: [
         "git",
@@ -97,11 +113,7 @@ export async function prepareNodeWorkspaceTransferSnapshot(params: {
       timeoutMs: TRANSFER_TIMEOUT_MS,
       maxOutputBytes: MAX_WORKSPACE_INVENTORY_TOTAL_BYTES,
     });
+    return packPath;
   }
-  return {
-    ...actual,
-    rawManifest: serializeWorkerWorkspaceManifest(actual.manifest),
-    root,
-    ...(packPath ? { packPath } : {}),
-  };
+  return undefined;
 }


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/131713 — cloud workspace results remain stuck after Gateway restart.

AI-assisted implementation and verification.

## What Problem This Solves

Fixes an issue where users restarting a Gateway after a completed cloud-worker turn could leave legitimate workspace edits stranded behind the pending-result fence. Changes made on either the Gateway or the worker since the last accepted baseline prevented recovery from reaching reconciliation.

## Why This Change Was Made

Restoring an authenticated transfer owner is different from performing an initial workspace synchronization. Recovery now reconstructs the transfer context from the durable, authenticated uploaded baseline without requiring either current workspace to still equal that baseline. The existing three-way reconciliation owner then stages, applies, accepts, and releases the pending result.

This removes the duplicate current-workspace equality gate and the transfer snapshot registry/sentinel bookkeeping. Download capabilities own their exact snapshot; Git pack reuse is keyed by the immutable base commit. Current-owner checks after awaited work, credential/session/environment/generation binding, transfer limits and hash checks, keep-local conflict policy, and claim/result fences remain intact. No configuration, schema, dependency, or protocol changes are included.

## User Impact

Pending workspace edits can be recovered after a Gateway restart, including independent local edits, remote edits, advanced local Git HEAD, and conflicts that retain the local version.

**Draft / landing hold:** this is file-recovery proof, not a claim that cloud-session restart semantics are fully repaired. A separate original-order live run exposed generic restart recovery admitting a new worker allocation after an already completed model turn. Stronger regressions also show that marking the session done at worker ACK loses channel-final custody or fails graceful-restart and local-harness/remote-exec paths. That prototype was rejected and is not included here. Durable completed-result/finalization ownership needs the repository's explicit persistence-design approval before implementation. Keep this PR draft while that connected restart outcome is resolved or the owner explicitly accepts a bounded landing scope.

## Evidence

The candidate is `4ea8185019bc6e5c37b3ebbff7122b2b1d821672`.

Before the repair, the real Git/filesystem/loopback-transfer/SQLite-reopen regression passed the unchanged-workspace controls and failed the dirty-restart cases at the restored-workspace equality gate. After the repair, 52 tests across five owner/sibling files passed:

```bash
node scripts/run-vitest.mjs src/gateway/worker-environments/node-worker-tunnel.recovery.test.ts src/gateway/worker-environments/node-worker-tunnel.test.ts src/gateway/worker-environments/node-worker-tunnel.lifecycle.test.ts src/gateway/worker-environments/node-workspace-transfer-service.test.ts src/gateway/worker-environments/placement-dispatch-staged-results.test.ts --reporter=verbose
```

The relevant changed checks, formatting, lint, types, whitespace checks, and `pnpm build` passed on this candidate. Independent restricted Codex autoreview reported no actionable findings before commit. A then-current unrelated test import failure was resolved by rebasing over the canonical fix in https://github.com/openclaw/openclaw/pull/131442, not by changing the test environment.

Live proof used an isolated development Gateway, real OpenAI API-key inference, and a public Git fixture on Hetzner. After a real remote write and terminal ACK, a task-owned proxy rejected the exact result upload with HTTP 503. The Gateway was crashed only after the durable pending-result fence and rejected upload were observed. On restart, both expected files were recovered with exact hashes, the pending fence cleared, the turn claim released, and the original placement reclaimed; this was observed by 74 seconds after the crash. The original lease was released. Generic recovery's subsequent unwanted allocation was separately aborted and reclaimed; it is the landing hold described above, not omitted from the result.

The unchanged normal path also completed two real AWS turns through the corrected upstream command runner: Gateway-provided input reached the worker, the expected Git HEAD and absence of standing cloud/forge keys were checked by an actual command, and both returned files matched exactly. The repeated turn preserved all three files and completed in 25.5 seconds. Both AWS leases used for installation and cloud-turn proof were released. These observations do not establish a provider performance ranking: the host had severe disk pressure, and cold provisioning included artifact download and package installation.

Proof limits: the live worker package was the frozen baseline archive while the Gateway ran this candidate; this patch changes Gateway-side recovery. Existing real-browser captures show the restart flow, but fresh browser verification is currently blocked by the extension relay timing out. No screenshot/video upload is claimed in this draft. The full cloud-provider matrix and completed-turn restart behavior are not yet verified.

Production LOC: +148/-153 (**net -5**). Tests/test support: +460/-94 (**net +366**). Existing documentation describes the preserved three-way and restart contract: https://docs.openclaw.ai/gateway/cloud-workers.
