### PR TITLE
fix(ui): avoid blank screen on first command palette open

### DIFF
--- a/ui/src/app/app-shell-command-palette-loading.ts
+++ b/ui/src/app/app-shell-command-palette-loading.ts
@@ -1,0 +1,17 @@
+import { html } from "lit";
+import { t } from "../i18n/index.ts";
+
+export function renderCommandPaletteLoading(onClose: () => void) {
+  const label = t("palette.placeholder");
+  return html`<openclaw-modal-dialog
+    class="cmd-palette-overlay palette"
+    label=${label}
+    style="--openclaw-modal-width: min(640px, calc(100vw - 32px));"
+    @modal-cancel=${onClose}
+  >
+    <div class="cmd-palette" role="status" aria-label=${t("common.loading")}>
+      <input class="cmd-palette__input" disabled placeholder=${label} />
+      <div class="cmd-palette__empty">${t("common.loading")}</div>
+    </div>
+  </openclaw-modal-dialog>`;
+}

--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -27,6 +27,7 @@ import { isTerminalAvailable } from "../lib/terminal-availability.ts";
 import type { NewSessionTarget } from "../pages/new-session/location.ts";
 import { pluginTabKey, pluginTabRefFromSearch } from "../pages/plugin/route.ts";
 import type { ShellRouteState } from "./app-host-route-state.ts";
+import { renderCommandPaletteLoading } from "./app-shell-command-palette-loading.ts";
 import type { OutboxStoreRuntime, StoredOutboxScopeHost } from "./app-shell-gateway.ts";
 import type { ApplicationRuntime } from "./bootstrap.ts";
 import type { ApplicationContext, ApplicationNavigationOptions } from "./context.ts";
@@ -241,6 +242,7 @@ export function renderApplicationShell(host: ShellViewHost) {
   const custodianPanelAvailable =
     // Scope-aware to match the store: admin-only, never advertisement alone.
     canCallGatewayMethod(gatewaySnapshot, "openclaw.chat", "operator.admin");
+  const lazyElementState = host.lazyCustomElements.visibleState;
   const activeRoute = host.routeState.routeId ?? "chat";
   const sessionRoute = isSessionRouteId(activeRoute);
   // Chat has an offline outbox, New Session keeps a local draft, and Appearance
@@ -441,7 +443,10 @@ export function renderApplicationShell(host: ShellViewHost) {
   // Optional tags stay mounted before definition. Lit replays their properties on upgrade,
   // and the upgraded panels catch the first toggle instead of dropping the event.
   return html`
-    ${renderLazyElementModal(host.lazyCustomElements)}
+    ${lazyElementState?.status === "loading" &&
+    lazyElementState.element === host.commandPaletteElement
+      ? renderCommandPaletteLoading(() => host.lazyCustomElements.close())
+      : renderLazyElementModal(host.lazyCustomElements)}
     ${isOptionalElementDefined(host.commandPaletteElement)
       ? html`<openclaw-command-palette
           .onNavigate=${(routeId: RouteId, options?: ApplicationNavigationOptions) =>

--- a/ui/src/e2e/command-palette-first-open.e2e.test.ts
+++ b/ui/src/e2e/command-palette-first-open.e2e.test.ts
@@ -1,0 +1,39 @@
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import {
+  createControlUiE2eSuite,
+  holdModuleResponse,
+} from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({ name: "command palette first open" });
+
+suite.define(() => {
+  it.each([
+    { height: 900, width: 1280 },
+    { height: 844, width: 390 },
+  ])("shows the palette shell while its module loads at $width px", async (viewport) => {
+    await suite.withPage({ viewport }, async ({ page }) => {
+      await installMockGateway(page);
+      const paletteModule = await holdModuleResponse(
+        page,
+        /\/assets\/command-palette-[^/?]+\.js(?:\?.*)?$/u,
+      );
+      await page.goto(`${suite.server.baseUrl}chat`);
+
+      try {
+        await page.keyboard.press("Control+K");
+        await paletteModule.request;
+
+        const shell = page.locator(".cmd-palette");
+        await shell.waitFor({ state: "visible" });
+        expect(await shell.getAttribute("aria-label")).toBe("Loading…");
+        expect(await page.locator(".lazy-view-state--loading").count()).toBe(0);
+
+        paletteModule.release();
+        await page.locator(".cmd-palette__input:not([disabled])").waitFor({ state: "visible" });
+      } finally {
+        paletteModule.release();
+      }
+    });
+  });
+});

--- a/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
+++ b/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
@@ -717,7 +717,7 @@ suite.define(() => {
     await page.keyboard.press("Meta+K");
     const palette = page.locator(".cmd-palette");
     const paletteDialog = page.locator("openclaw-modal-dialog.palette");
-    await palette.waitFor({ state: "visible" });
+    await page.locator(".cmd-palette__input:not([disabled])").waitFor({ state: "visible" });
     const paletteAnimationName = await palette.evaluate(
       (element) => getComputedStyle(element).animationName,
     );


### PR DESCRIPTION
Closes #132026

## What Problem This Solves

Fixes an issue where users opening the Control UI command palette for the first time would briefly see a generic blank-looking loading overlay while the deferred palette code loaded. The cold-open behavior affected keyboard, pointer, and mobile entry points; later opens were already immediate.

## Why This Change Was Made

The palette remains deferred so normal startup work does not increase. While that code loads, the existing shell now renders a small palette-shaped placeholder from already-loaded UI primitives, then replaces it with the complete interactive palette through the existing lazy-element lifecycle.

The change does not preload the palette, add startup requests, start data fetching earlier, or alter command behavior.

## User Impact

The first command-palette action now gives immediate, recognizable feedback on desktop and mobile. Users see the search-field shape and a clear loading row, followed in place by the ready palette.

## Evidence

- Production bundle measurements keep the palette chunk effectively unchanged: 17.21 kB raw and 5.80 kB compressed, compared with 5.81 kB before.
- Startup JavaScript increased by 217 bytes compressed and remains 437 bytes below the committed baseline and 1,013 bytes below the enforcement limit.
- With a controlled 300 ms palette-module delay, the previous first ready state appeared at 568 ms. The new shell appears at 188 ms, and the complete palette becomes ready at 548 ms.
- Browser regression coverage holds the palette module response, verifies the dedicated loading shell at 1280×900 and 390×844, then releases the response and waits for the enabled search field.
- The same coverage failed against the pre-fix source because no palette shell appeared while the module response was held.
- Existing overlay-motion coverage now waits for the complete palette before measuring its interaction-owned animation state.

Before, cold first open:

![Generic first-open loading overlay](https://github.com/user-attachments/assets/4518fe40-791a-40f8-9a0c-1f16033bfdb4)

After, desktop loading shell and ready palette:

![Desktop palette loading shell](https://github.com/user-attachments/assets/1dec5bd0-299d-4f59-bd57-9ccfb28facff)

![Desktop palette ready](https://github.com/user-attachments/assets/dd471a35-101b-4e14-b5ac-1aa388b9439f)

After, mobile loading shell and ready palette:

![Mobile palette loading shell](https://github.com/user-attachments/assets/35cea5cb-4481-412a-8101-723ceb506947)

![Mobile palette ready](https://github.com/user-attachments/assets/0a64b019-3807-49c5-b33b-01cb67a8e85c)
