### PR TITLE
fix(release): full verification fails as main comparison grows

### DIFF
--- a/scripts/release-plan-producer.mts
+++ b/scripts/release-plan-producer.mts
@@ -228,7 +228,15 @@ function verifyRemoteTooling(params: ReleasePlanSource, runGh: RunGh) {
     args = ["api", `repos/${REPOSITORY}/git/ref/tags/${tagRef}`, "--method", "GET"];
     failure = "protected release tooling tag is missing or unreadable";
   } else if (params.toolingFullRef === "refs/heads/main") {
-    args = ["api", `repos/${REPOSITORY}/compare/${sha}...main`, "--method", "GET"];
+    // Keep this bounded query identical to the verified child's cached identity request.
+    args = [
+      "api",
+      `repos/${REPOSITORY}/compare/${sha}...main`,
+      "--method",
+      "GET",
+      "--jq",
+      "{status}",
+    ];
     failure = "main release tooling ancestry could not be verified";
   } else {
     throw new Error("release tooling identity must be trusted main or an exact protected tag");

--- a/scripts/release-tooling-identity.mjs
+++ b/scripts/release-tooling-identity.mjs
@@ -364,6 +364,9 @@ export function verifyReleaseToolingIdentity({
           `repos/${normalizedRepository}/compare/${identity.sha}...main`,
           "--method",
           "GET",
+          // Full comparison patches can exceed the subprocess buffer; only ancestry status is used.
+          "--jq",
+          "{status}",
         ]),
         "main release tooling comparison",
       );

--- a/test/scripts/release-plan-producer.test.ts
+++ b/test/scripts/release-plan-producer.test.ts
@@ -6,13 +6,13 @@ import {
   mkdirSync,
   readFileSync,
   readdirSync,
-  realpathSync,
   rmSync,
   statSync,
   symlinkSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
+import { createRequire } from "node:module";
 import { dirname, join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { parse } from "yaml";
@@ -322,6 +322,11 @@ type YamlPackageHarnessParams = {
 
 function runYamlPackageSubprocess(
   options: {
+    main?: {
+      intent: "diagnostic" | "main-qualification";
+      validationIntent?: MainQualificationValidationIntent;
+      comparisonStatus: string;
+    };
     beforeProduce?: (params: YamlPackageHarnessParams) => string;
     environment?: (params: YamlPackageHarnessParams) => Record<string, string>;
     mutate?: (params: YamlPackageHarnessParams) => void;
@@ -342,7 +347,9 @@ function runYamlPackageSubprocess(
     };
   }
   const packageRoot = join(fixture.root, "node_modules/yaml");
-  cpSync(realpathSync(resolve("node_modules/yaml")), packageRoot, { recursive: true });
+  cpSync(dirname(createRequire(import.meta.url).resolve("yaml/package.json")), packageRoot, {
+    recursive: true,
+  });
   const sentinelPath = join(fixture.root, "yaml-executed");
   const tempRoot = join(fixture.root, "yaml-temp");
   mkdirSync(tempRoot);
@@ -356,20 +363,23 @@ ${options.beforeImport?.(params) ?? ""}
 const { produceReleasePlan } = await import("./scripts/release-plan-producer.mts");
 ${options.beforeProduce?.(params) ?? ""}
 
-const toolingFullRef = ${JSON.stringify(fixture.toolingFullRef)};
+const toolingFullRef = ${JSON.stringify(options.main ? "refs/heads/main" : fixture.toolingFullRef)};
 const toolingSha = ${JSON.stringify(fixture.toolingSha)};
-produceReleasePlan({
+const plan = produceReleasePlan({
   repoRoot: ${JSON.stringify(fixture.root)},
-  intent: "publish",
+  intent: ${JSON.stringify(options.main?.intent ?? "publish")},
+  validationIntent: ${JSON.stringify(options.main?.validationIntent)},
   candidateSha: ${JSON.stringify(fixture.candidateSha)},
-  candidateRef: ${JSON.stringify(fixture.candidateRef)},
+  candidateRef: ${JSON.stringify(options.main ? fixture.candidateSha : fixture.candidateRef)},
   toolingSha,
   toolingFullRef,
   runGh: () => JSON.stringify({
+    status: ${JSON.stringify(options.main?.comparisonStatus)},
     ref: toolingFullRef,
     object: { type: "commit", sha: ${JSON.stringify(options.remoteToolingSha?.(params) ?? fixture.toolingSha)} },
   }),
 });
+process.stdout.write(JSON.stringify(plan));
 const moduleApi = await import("node:module");
 const harnessRequire = moduleApi.createRequire(import.meta.url);
 const leakedSnapshotCache = Object.keys(harnessRequire.cache).filter(path =>
@@ -586,7 +596,7 @@ describe("release plan producer", () => {
     });
   });
 
-  it("produces tagless diagnostics from trusted main or protected tooling", () => {
+  it("produces tagless diagnostics from protected tooling", () => {
     const fixture = createFixtureRepo();
     expect(produceReleasePlan(sourceParams(fixture, "diagnostic"))).toMatchObject({
       candidate_sha: fixture.candidateSha,
@@ -603,25 +613,64 @@ describe("release plan producer", () => {
         soak: true,
       },
     });
+  });
 
-    expect(
-      produceReleasePlan({
-        ...sourceParams(fixture, "diagnostic"),
-        toolingFullRef: "refs/heads/main",
-        runGh: (args) => {
-          expect(args[1]).toBe(`repos/openclaw/openclaw/compare/${fixture.toolingSha}...main`);
-          return JSON.stringify({ status: "identical" });
+  it.each([
+    ["diagnostic", undefined, "ahead", "diagnostic-full", "full", true],
+    ["main-qualification", "main-daily", "identical", "main-daily", "beta", false],
+    ["main-qualification", "main-weekly", "ahead", "main-weekly", "full", true],
+  ] as const)(
+    "produces trusted-main %s/%s with %s ancestry through the verified child",
+    (intent, validationIntent, comparisonStatus, expectedIntent, profile, soak) => {
+      const { result, fixture } = runYamlPackageSubprocess({
+        main: { intent, validationIntent, comparisonStatus },
+      });
+      expect(result.stderr).toBe("");
+      expect(result.status).toBe(0);
+      expect(JSON.parse(result.stdout)).toMatchObject({
+        candidate_sha: fixture.candidateSha,
+        purpose: intent,
+        tag: null,
+        target_context_ref: fixture.candidateSha,
+        tooling: { ref: "refs/heads/main", sha: fixture.toolingSha },
+        validation: {
+          intent: expectedIntent,
+          profile,
+          soak,
+          allowed_groups: ["all", "ci", "package"],
         },
-      }),
-    ).toMatchObject({
-      purpose: "diagnostic",
-      tag: null,
-      target_context_ref: fixture.candidateSha,
-      tooling: {
-        ref: "refs/heads/main",
-        sha: fixture.toolingSha,
+      });
+    },
+  );
+
+  it.each(["diverged", "behind"])(
+    "rejects %s main ancestry before the verified child",
+    (comparisonStatus) => {
+      const { result } = runYamlPackageSubprocess({
+        main: { intent: "diagnostic", comparisonStatus },
+      });
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        "main release tooling SHA is not reachable from current main",
+      );
+    },
+  );
+
+  it("rejects an uncached request from verified tooling", () => {
+    const { result } = runYamlPackageSubprocess({
+      mutateTooling: (fixture) => {
+        const corePath = join(fixture.root, "scripts/release-plan-producer-core.mts");
+        writeFileSync(
+          corePath,
+          readFileSync(corePath, "utf8").replace(
+            "const params = { ...request.params, runGh: runtime.runGh };",
+            'runtime.runGh(["api", "repos/openclaw/openclaw"]);\nconst params = { ...request.params, runGh: runtime.runGh };',
+          ),
+        );
       },
     });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("verified child rejected an uncached GitHub request");
   });
 
   it("requires main qualification producers to choose daily or weekly", () => {

--- a/test/scripts/release-tooling-identity.test.ts
+++ b/test/scripts/release-tooling-identity.test.ts
@@ -206,6 +206,14 @@ describe("release tooling identity", () => {
           workflowSha: SHA,
         }),
       ).toMatchObject({ route: "main", sha: SHA });
+      expect(runGh).toHaveBeenCalledWith([
+        "api",
+        `repos/openclaw/openclaw/compare/${SHA}...main`,
+        "--method",
+        "GET",
+        "--jq",
+        "{status}",
+      ]);
     },
   );
 


### PR DESCRIPTION
## What Problem This Solves

Release maintainers could not start Full Release Validation after main advanced, even though the pinned tooling SHA remained a valid ancestor. [Full Release Validation 33199799850](https://github.com/openclaw/openclaw/actions/runs/33199799850), targeting `81310caf8d28805ce8a13b04f0a0cf139a8da604` with tooling `5b6ef55fc796c291469cd5b301270b87506c76b0`, failed before product validation began.

This repair also covers the coupled release-plan bootstrap/verified-child route. Fixing only the shared verifier changed its GitHub argument array while the producer still cached the response under the old array. Even a small valid comparison then failed with `verified child rejected an uncached GitHub request`.

## Why This Change Was Made

Both owners now request only `{status}` with `gh --jq`, before output crosses their existing 1 MiB subprocess pipes. The bootstrap retains the response under exactly the query the verified child uses. The two literal query definitions deliberately remain separate: importing repository helpers before bootstrap verification would violate the hermetic trust boundary.

No buffer increase, retry, uncached request allowance, new export, or test-only production seam. The exactly-one-request cache, accepted `ahead`/`identical` statuses, protected lightweight tag checks, verified tooling closure, and YAML package attestation remain unchanged.

## User Impact

Full Release Validation and trusted-main diagnostic/daily/weekly release-plan generation can use correctly pinned tooling after main moves. No product runtime, configuration, package, version, or release identity changes.

## Evidence

- Before production editing, three new real `runYamlPackageSubprocess` cases failed at head `e2ce2b2aaebaa78b6f99197e623627c05444b655`: diagnostic/ahead, main-daily/identical, and main-weekly/ahead. A temporary observation-only test hook exposed the underlying child cause, `verified child rejected an uncached GitHub request`; the hook was removed and is not shipped.
- These cases now pass through the actual bootstrap, retained tooling loader, byte-attested YAML 2.9.0 package, exact request cache, and verified child. The old direct-core main diagnostic assertion was replaced, rather than retained as duplicate evidence.
- Added real subprocess rejection coverage for diverged/behind main and an uncached child request; existing protected-tag, moved/forged SHA, ambient tooling, symlink/import, YAML tampering/cache/loader, and lock/inventory coverage remains.
- Live before/after probe with the same frozen tooling SHA: unprojected capture failed `ENOBUFS` after 1,078,414 bytes; projected output was 24 bytes containing `{"status":"ahead"}`. The repaired shared verifier then accepted the real GitHub ancestry response. The earlier 1,042,412-byte observation remains historical evidence; live main has advanced since.
- GitHub CLI's [API projection contract](https://cli.github.com/manual/gh_api) and Node's [synchronous subprocess buffer contract](https://nodejs.org/api/child_process.html#child_processexecfilesyncfile-args-options) were checked; no dependency changes.

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/release-plan-producer.test.ts -t 'trusted-main|main ancestry|uncached request|conflicting platform|recomputed locks'
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/release-tooling-identity.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts/release-plan-producer.mts scripts/release-tooling-identity.mjs test/scripts/release-plan-producer.test.ts test/scripts/release-tooling-identity.test.ts
```

Local verification: **8/8 focused producer cases and 33/33 verifier cases passed**. The broader producer invocation recorded 40 passing cases before its existing full-repository inventory fixture spent over five minutes in `git checkout` filesystem waits. That task-owned invocation was stopped and cleaned up; the bounded rerun additionally passed the remaining platform/lock cases. Across those invocations, 42 of 43 producer cases were observed passing; the current-repository inventory test remains a local proof gap, not a claimed full-suite pass.

Formatting, focused lint, and all 13 prescribed non-type guards passed. `check:changed` could not launch the pinned pnpm 11.22.0 binary (`ENOENT`). Direct script/test typechecks reached the inherited stale dependencies and failed outside these four files: installed `markdown-it` 14.3.0 vs required 15.0.0, `pi-tui` 0.82.1 vs required 0.84.2, stale crabline/acpx/Google exports, and missing pako declarations. No dependency install, patch, buffer workaround, or broad host build was used. Fresh exact-head CI must supply dependency-correct full validation. Full Release Validation has not been redispatched from this unlanded tooling branch; this proof does not claim a completed release validation or publication.

Production/runtime LOC: 0. Release tooling: +12/-1 (net +11); tests/test support: +79/-22 (net +57). The tooling growth is two projection arguments at each isolated query owner, two invariant comments, and formatter expansion of the producer argument array. No new control flow or abstraction. The test harness resolves the installed YAML package through its exported package manifest so a linked checkout uses the same canonical fixture without modifying installed dependencies.

Regression provenance: the shared unprojected comparison came from [#126881](https://github.com/openclaw/openclaw/pull/126881), commit `fa86caf94f64c66c3fed4955cb763ed6c4e80055`; the producer/cache boundary came from [#127008](https://github.com/openclaw/openclaw/pull/127008), commit `1da74794b6083a4975a3e892f852a9c881a3a027`. Both were authored and merged by @vincentkoc on August 21. The verifier-only change in this PR exposed their request-key coupling. AI-assisted repair.

ClawSweeper follow-through: the 19:26 UTC review now correctly identifies this coupling; its producer alignment and real subprocess regression requests are addressed in this PR. Treating it as an independent follow-up was incorrect because its exact cached query and the shared verifier are coupled. Required checks must bind the new head; the earlier green run only covers the superseded head. Native landing remains paused for maintainer review; this update does not authorize or perform a merge.

The latest ClawSweeper review is less than 12 hours old and this follow-up implements its finding and rank-up moves. No redundant re-review command is needed under repository policy; the complete branch receives fresh Codex autoreview and the new head must receive green CI before native landing. The suggested shared helper was deliberately not added because bootstrap code must not import unverified repository helpers.

Fresh Codex autoreview of the complete two-commit branch against PR base `3bef170ece896879a2de080147a371df01a79ee7` passed with no accepted/actionable findings at the configured P0 threshold. Reviewed head: `15f724d192d12c888602320324a5a20ae9584a18`. The earlier local-only review is not used as whole-PR proof.

Exact new-head CI: [CI 33205676059](https://github.com/openclaw/openclaw/actions/runs/33205676059) is attached to `15f724d192d12c888602320324a5a20ae9584a18` (pull_request, queued at handoff). Draft push run 33205640848 was skipped as expected; it is not validation proof. GitHub computed merge ref `0500f4b9044dbc4600f5839bcd1187e865f081c9` before the PR was marked ready. The PR remains OPEN and unmerged, auto-merge is disabled, and native landing is paused for maintainer review and green CI.


### Final landing verification

The maintainer explicitly resumed native landing after reviewing the coupled repair. All four approved source hashes match head `15f724d192d12c888602320324a5a20ae9584a18`. Fresh complete-branch Codex autoreview is clean at P0; the delivery owner independently inspected the producer, verifier, core, both tests, YAML and subprocess contracts, and reran live frozen-ancestor verification successfully.

[Exact-head CI 33205676059](https://github.com/openclaw/openclaw/actions/runs/33205676059) completed successfully. [The tooling job](https://github.com/openclaw/openclaw/actions/runs/33205676059/job/98966261609) explicitly passed the complete producer suite, including the current-publisher inventory case that was interrupted locally. The job completed 69 files / 2,012 tests with one unrelated skipped test. The interrupted local run is still not represented as green.

The earlier paused/verifier-only readiness statements above are historical and superseded by this complete repair and exact-head evidence. Native preparation/merge remains required; no release publication or full validation dispatch is performed by this PR.
