### PR TITLE
fix(subagents): recognize requester replies when retrying settle-wake delivery

### DIFF
--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -4386,6 +4386,17 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       expected: deliveredRequesterFinal,
     },
     {
+      name: "accepts a yielded requester final already committed by automatic delivery",
+      response: {
+        result: {
+          payloads: [],
+          deliveryStatus: { status: "sent", succeeded: true, resultCount: 1 },
+        },
+      },
+      requireVisibleReply: true,
+      expected: deliveredRequesterFinal,
+    },
+    {
       name: "rejects a yielded turn without a result",
       response: {},
       requireVisibleReply: true,
@@ -4478,6 +4489,28 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         result: {
           payloads: [{ text: "never delivered" }],
           deliveryStatus: { status: "suppressed", succeeded: true, resultCount: 0 },
+        },
+      },
+      requireVisibleReply: true,
+      expected: missingRequesterFinal,
+    },
+    {
+      name: "rejects an empty successful automatic delivery receipt",
+      response: {
+        result: {
+          payloads: [],
+          deliveryStatus: { status: "sent", succeeded: true, resultCount: 0 },
+        },
+      },
+      requireVisibleReply: true,
+      expected: missingRequesterFinal,
+    },
+    {
+      name: "rejects a malformed automatic delivery receipt",
+      response: {
+        result: {
+          payloads: [],
+          deliveryStatus: { status: "sent", succeeded: true, resultCount: "1" },
         },
       },
       requireVisibleReply: true,

--- a/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
@@ -17,6 +17,7 @@ import {
   isGatewayMessageChannel,
   normalizeMessageChannel,
 } from "../../../utils/message-channel.js";
+import { normalizeAgentRunTerminalDeliverySnapshot } from "../../agent-run-terminal-delivery.js";
 import {
   getAgentCommandDeliveryFailure,
   getGatewayAgentResult,
@@ -533,14 +534,18 @@ export async function sendSubagentAnnounceDirectly(params: {
         error: "completion agent did not use the message tool for message-tool-only delivery",
       };
     }
+    const terminalDelivery = normalizeAgentRunTerminalDeliverySnapshot(
+      directAnnounceResult?.deliveryStatus,
+    );
     const requesterVisibleFinalDelivered = Boolean(
       directAnnounceResult &&
       (hasMessagingToolDeliveryToSource(directAnnounceResult, deliveryTarget, {
         requireFinalReply: true,
       }) ||
         (shouldDeliverAgentFinal &&
-          hasVisibleNonSilentGatewayPayload &&
-          directAnnounceResult.deliveryStatus?.status !== "suppressed")),
+          ((hasVisibleNonSilentGatewayPayload &&
+            directAnnounceResult.deliveryStatus?.status !== "suppressed") ||
+            (terminalDelivery?.status === "sent" && terminalDelivery.resultCount > 0)))),
     );
     const hasVisibleCompletionReply =
       requesterVisibleFinalDelivered ||


### PR DESCRIPTION
## What problem this solves

Fixes #131965.

A yielded requester's settle wake can successfully deliver its visible final, then report `visible_reply_missing` because the already-sent payload was removed from the returned payload list after streaming. The durable retry owner interprets that false negative as an undelivered wake and can repeat the same completion up to three times.

This reproduced in Full Release Validation job [99066956526](https://github.com/openclaw/openclaw/actions/runs/33239717262/job/99066956526) at `214d55e`: GPT-5.6 Sol produced the exact parent and child nonces and every provider request returned HTTP 200, but all three requester-settle attempts were classified `visible_reply_missing` and the registry ended `delivery.status=failed`. Terra and Luna passed the same handoff.

## Root cause and fix

The delivery owner already returns an authoritative bounded terminal receipt: `deliveryStatus.status === "sent"` with a positive `resultCount`. `sendSubagentAnnounceDirectly` only credited a retained visible payload or a source-matched message-tool receipt, so it discarded that automatic-delivery fact when streaming had consumed the payload.

The fix reuses `normalizeAgentRunTerminalDeliverySnapshot` and credits only a validated `sent` receipt with `resultCount > 0`. Suppressed, failed, empty, and malformed receipts still fail closed. This removes the earlier transcript-history reconstruction and its duplicate visibility classifier entirely.

## Evidence

Red proof against the pre-fix base:

```text
accepts a yielded requester final already committed by automatic delivery
AssertionError: expected delivered:false to match delivered:true
```

Passing proof at this head:

```text
subagent-announce-delivery.test.ts: 192 passed
subagent-announce.requester-settle-wake.test.ts: 37 passed
```

`check-changed` passed formatting, focused lint, core typecheck, boundary/ratchet/dead-export gates. Core-test typecheck was blocked only by the shared checkout's stale dependency tree missing the existing `pako` declaration package; worktree policy forbids dependency reconciliation there. Exact-head hosted CI is the remaining clean-environment proof.

Production delta: +7/-2. Tests: +33/-0.

The contributor's original diagnosis and reproduction are retained and credited via the PR and commit co-author trailer.


### Real delivery-boundary trace at this head (3de1a1a2)

After-fix trace through the real delivery boundary, at the current head — production gateway in-process, real BigModel glm-5.3-flash turns, production registry/transcript/reader seams, and a real outbound channel delivery (loopback webhook through the plugin registry) that commits the durable-send receipt the new branch trusts:

```text
[00:00.020] rig — local webhook receiver listening on 127.0.0.1:62928 (outbound channel target)
[00:21.999] rig — injected outbound channel "evidence-webhook" into the in-process plugin registry
[00:22.000] rig — production gateway started; LLM provider = BigModel anthropic endpoint (model glm-5.3-flash) at open.bigmodel.cn
[00:22.122] worktree — head=3de1a1a2ebee1b17d3f258aac55fbda7b3deea460 branch=
[00:36.164] requester session — real agent turn completed on session agent:main:evidence-settle-wake-97o3rz (BigModel) — session store entry + transcript persisted by the gateway
[00:36.185] registry — production registry row settled + yielded wake armed (requesterSettleWake: requesterYieldBatch=true, rearmGeneration=1)
[00:36.229] registry transition — wake batch state transitioned (status=dispatching, attemptCount=1)
[00:54.192] registry complete — wake batch completed; requesterSettleWake cleared (delivery: delivered=true, path=direct)
[00:54.192] wake drive — maybeWakeRequesterAfterAllChildrenSettled returned true after one real delivery attempt
[00:54.203] transcript read-back — production reader seam returned 4 rows; persisted wake rows=1, assistant rows=2
[00:54.207] no-retry proof — second drive returned false with no new transition/complete callbacks and wake rows stable at 1 (batch already settled; no retry scheduled)
```

```text
```text
persisted requester wake : 1 user row(s) keyed announce:requester-settle:… in the real session transcript
actual requester reply   : 2 assistant row(s) written by the real agent turn (BigModel glm-5.3-flash)
retry suppression        : second drive of maybeWakeRequesterAfterAllChildrenSettled is a no-op; wake rows stay 1; batch state cleared
```

The wake turn runs with no tools allowed, so `delivered=true` here is the receipt branch itself: the terminal delivery snapshot (`status: "sent"`, `resultCount > 0`) committed by the production durable send through the injected outbound channel. Full trace: `evidence/runs/132032-settle-wake-trace-3de1a1a2.md` in the rig directory.


Refreshed at `3de1a1a2` (rebase onto current main): the same rig run reproduces at the new base — `delivered=true, path=direct` via the receipt branch, second drive a no-op, wake rows stable at 1. Trace: `evidence/runs/132032-settle-wake-trace-3de1a1a2.md`.
