### PR TITLE
fix(ios): report session mutation failures

### DIFF
--- a/apps/ios/Sources/Design/CommandCenterTab.swift
+++ b/apps/ios/Sources/Design/CommandCenterTab.swift
@@ -373,6 +373,19 @@ struct CommandCenterTab: View {
             VStack(spacing: 10) {
                 self.cardHeader(title: "Recent sessions")
 
+                if let sessionMutationErrorText = self.dashboardModel.sessionMutationErrorText {
+                    CommandEmptyStateRow(
+                        icon: "exclamationmark.triangle.fill",
+                        title: "Session update failed",
+                        detail: .verbatim(sessionMutationErrorText))
+                }
+                if let sessionErrorText = self.dashboardModel.sessionErrorText {
+                    CommandEmptyStateRow(
+                        icon: "exclamationmark.triangle.fill",
+                        title: "Sessions unavailable",
+                        detail: .verbatim(sessionErrorText))
+                }
+
                 if self.recentSessionPreviewSessions.isEmpty {
                     CommandEmptyStateRow(
                         icon: self.gatewayConnected ? "bubble.left.and.text.bubble.right.fill" : "wifi.slash",
@@ -561,7 +574,7 @@ struct CommandCenterTab: View {
         archived: Bool? = nil,
         unread: Bool? = nil)
     {
-        self.performSessionMutation { transport in
+        self.performSessionMutation(mutationKey: session.key) { transport in
             try await transport.patchSession(
                 key: session.key,
                 expectedSessionID: archived == nil ? nil : session.sessionId,
@@ -574,13 +587,13 @@ struct CommandCenterTab: View {
     }
 
     private func deleteSession(_ session: OpenClawChatSessionEntry) {
-        self.performSessionMutation(resetActiveSessionKey: session.key) { transport in
+        self.performSessionMutation(mutationKey: session.key, resetActiveSessionKey: session.key) { transport in
             try await transport.deleteSession(key: session.key)
         }
     }
 
     private func archiveSession(_ session: OpenClawChatSessionEntry) {
-        self.performSessionMutation(resetActiveSessionKey: session.key) { transport in
+        self.performSessionMutation(mutationKey: session.key, resetActiveSessionKey: session.key) { transport in
             try await transport.patchSession(
                 key: session.key,
                 expectedSessionID: session.sessionId,
@@ -594,28 +607,29 @@ struct CommandCenterTab: View {
 
     private func forkSession(_ session: OpenClawChatSessionEntry) {
         Task {
-            do {
-                let key = try await self.appModel.makeChatTransport().forkSession(
-                    parentKey: session.key,
-                    fromLastCompleted: session.hasActiveRun == true)
-                await self.dashboardModel.refreshSessions(appModel: self.appModel)
-                self.open(.chat(key))
-            } catch {}
+            await self.dashboardModel.performSessionMutation(
+                appModel: self.appModel,
+                mutationKey: session.key,
+                operation: { transport in
+                    try await transport.forkSession(
+                        parentKey: session.key,
+                        fromLastCompleted: session.hasActiveRun == true)
+                },
+                onSuccess: { key in self.open(.chat(key)) })
         }
     }
 
     private func performSessionMutation(
+        mutationKey: String,
         resetActiveSessionKey: String? = nil,
         _ operation: @escaping (any OpenClawChatTransport) async throws -> Void)
     {
         Task {
-            do {
-                try await operation(self.appModel.makeChatTransport())
-                if resetActiveSessionKey == self.appModel.chatSessionKey {
-                    self.appModel.focusChatSession(nil)
-                }
-                await self.dashboardModel.refreshSessions(appModel: self.appModel)
-            } catch {}
+            _ = await self.dashboardModel.performSessionMutation(
+                appModel: self.appModel,
+                mutationKey: mutationKey,
+                resetActiveSessionKey: resetActiveSessionKey,
+                operation: operation)
         }
     }
 

--- a/apps/ios/Sources/RootSidebar.swift
+++ b/apps/ios/Sources/RootSidebar.swift
@@ -371,7 +371,7 @@ struct RootSidebar: View {
         let sections = self.visibleSessionSections
         let selectedSessionKey = self.resolvedSelectedSessionKey
         VStack(alignment: .leading, spacing: 6) {
-            if let sessionErrorText = self.model.sessionErrorText {
+            if let sessionErrorText = self.model.sessionMutationErrorText ?? self.model.sessionErrorText {
                 Text(verbatim: sessionErrorText)
                     .font(OpenClawType.captionMedium)
                     .foregroundStyle(OpenClawBrand.warn)
@@ -812,52 +812,55 @@ struct RootSidebar: View {
         archived: Bool? = nil,
         unread: Bool? = nil)
     {
-        Task {
-            do {
-                try await self.appModel.makeChatTransport().patchSession(
-                    key: session.key,
-                    expectedSessionID: archived == nil ? nil : session.sessionId,
-                    label: label,
-                    category: category,
-                    pinned: pinned,
-                    archived: archived,
-                    unread: unread)
-                if archived == true, session.key == self.appModel.chatSessionKey {
-                    self.appModel.focusChatSession(nil)
-                }
-                await self.model.refreshSessions(appModel: self.appModel)
-            } catch {
-                self.model.reportSessionError(error)
-            }
+        self.performSessionMutation(
+            mutationKey: session.key,
+            resetActiveSessionKey: archived == true ? session.key : nil)
+        { transport in
+            try await transport.patchSession(
+                key: session.key,
+                expectedSessionID: archived == nil ? nil : session.sessionId,
+                label: label,
+                category: category,
+                pinned: pinned,
+                archived: archived,
+                unread: unread)
         }
     }
 
     private func deleteSession(_ session: OpenClawChatSessionEntry) {
-        Task {
-            do {
-                try await self.appModel.makeChatTransport().deleteSession(key: session.key)
-                if session.key == self.appModel.chatSessionKey {
-                    self.appModel.focusChatSession(nil)
-                }
-                await self.model.refreshSessions(appModel: self.appModel)
-            } catch {
-                self.model.reportSessionError(error)
-            }
+        self.performSessionMutation(mutationKey: session.key, resetActiveSessionKey: session.key) { transport in
+            try await transport.deleteSession(key: session.key)
         }
     }
 
     private func forkSession(_ session: OpenClawChatSessionEntry) {
         Task {
-            do {
-                let key = try await self.appModel.makeChatTransport().forkSession(
-                    parentKey: session.key,
-                    fromLastCompleted: session.hasActiveRun == true)
-                self.appModel.openChat(sessionKey: key)
-                self.selectSidebarDestination(.chat)
-                await self.model.refreshSessions(appModel: self.appModel)
-            } catch {
-                self.model.reportSessionError(error)
-            }
+            await self.model.performSessionMutation(
+                appModel: self.appModel,
+                mutationKey: session.key,
+                operation: { transport in
+                    try await transport.forkSession(
+                        parentKey: session.key,
+                        fromLastCompleted: session.hasActiveRun == true)
+                },
+                onSuccess: { key in
+                    self.appModel.openChat(sessionKey: key)
+                    self.selectSidebarDestination(.chat)
+                })
+        }
+    }
+
+    private func performSessionMutation(
+        mutationKey: String,
+        resetActiveSessionKey: String? = nil,
+        _ operation: @escaping (any OpenClawChatTransport) async throws -> Void)
+    {
+        Task {
+            _ = await self.model.performSessionMutation(
+                appModel: self.appModel,
+                mutationKey: mutationKey,
+                resetActiveSessionKey: resetActiveSessionKey,
+                operation: operation)
         }
     }
 

--- a/apps/ios/Sources/RootSidebarModel.swift
+++ b/apps/ios/Sources/RootSidebarModel.swift
@@ -189,8 +189,12 @@ final class RootSidebarModel {
     private(set) var cronJobs: [CronJob] = []
     private(set) var isRefreshing = false
     private(set) var sessionErrorText: String?
+    private(set) var sessionMutationErrorText: String?
     private(set) var isSessionRosterComplete = true
     private var rosterGeneration = 0
+    private var sessionMutationGenerations: [String: UInt64] = [:]
+    private var sessionMutationErrorKey: String?
+    private var sessionMutationOwnerID: String?
     private var dashboardGeneration = 0
     private var sessionObserverVisibility = false
     private var sessionObserverGeneration: UInt64 = 0
@@ -226,6 +230,7 @@ final class RootSidebarModel {
     }
 
     func refresh(appModel: NodeAppModel) async {
+        self.updateSessionMutationOwner(appModel.chatViewModelIdentityID)
         self.rosterGeneration &+= 1
         let rosterGeneration = self.rosterGeneration
         self.dashboardGeneration &+= 1
@@ -264,6 +269,7 @@ final class RootSidebarModel {
     }
 
     func refreshSessions(appModel: NodeAppModel) async {
+        self.updateSessionMutationOwner(appModel.chatViewModelIdentityID)
         self.rosterGeneration &+= 1
         let rosterGeneration = self.rosterGeneration
         self.isRefreshing = true
@@ -483,8 +489,53 @@ final class RootSidebarModel {
         return false
     }
 
-    func reportSessionError(_ error: any Error) {
-        self.sessionErrorText = error.localizedDescription
+    @discardableResult
+    func performSessionMutation<Result>(
+        appModel: NodeAppModel,
+        mutationKey: String,
+        resetActiveSessionKey: String? = nil,
+        operation: (any OpenClawChatTransport) async throws -> Result,
+        onSuccess: (Result) -> Void = { _ in }) async -> Bool
+    {
+        let ownerID = appModel.chatViewModelIdentityID
+        self.updateSessionMutationOwner(ownerID)
+        self.sessionMutationGenerations[mutationKey, default: 0] &+= 1
+        let mutationGeneration = self.sessionMutationGenerations[mutationKey]
+        do {
+            let result = try await operation(appModel.makeChatTransport())
+            guard ownerID == appModel.chatViewModelIdentityID else {
+                await self.refreshSessions(appModel: appModel)
+                return false
+            }
+            if mutationGeneration == self.sessionMutationGenerations[mutationKey],
+               self.sessionMutationErrorKey == mutationKey
+            {
+                self.sessionMutationErrorKey = nil
+                self.sessionMutationErrorText = nil
+            }
+            if resetActiveSessionKey == appModel.chatSessionKey {
+                appModel.focusChatSession(nil)
+            }
+            onSuccess(result)
+            await self.refreshSessions(appModel: appModel)
+            return true
+        } catch {
+            if ownerID == appModel.chatViewModelIdentityID,
+               mutationGeneration == self.sessionMutationGenerations[mutationKey]
+            {
+                self.sessionMutationErrorKey = mutationKey
+                self.sessionMutationErrorText = error.localizedDescription
+            }
+            return false
+        }
+    }
+
+    private func updateSessionMutationOwner(_ ownerID: String) {
+        guard self.sessionMutationOwnerID != ownerID else { return }
+        self.sessionMutationOwnerID = ownerID
+        self.sessionMutationGenerations.removeAll()
+        self.sessionMutationErrorKey = nil
+        self.sessionMutationErrorText = nil
     }
 
     static func tokenUsageSummary(

--- a/apps/ios/Tests/RootTabsSourceGuardTests.swift
+++ b/apps/ios/Tests/RootTabsSourceGuardTests.swift
@@ -4,6 +4,12 @@ import Testing
 @testable import OpenClaw
 
 struct RootTabsSourceGuardTests {
+    private struct SessionMutationFailure: LocalizedError {
+        let message: String
+
+        var errorDescription: String? { self.message }
+    }
+
     @Test func `inactive scenes clear voice wake toast and camera flash`() throws {
         let source = try String(contentsOf: Self.rootTabsSourceURL(), encoding: .utf8)
         let rootAppearLifecycle = try Self.extract(
@@ -57,11 +63,15 @@ struct RootTabsSourceGuardTests {
         let refreshSessions = try Self.extract(
             source,
             from: "func refreshSessions(appModel: NodeAppModel) async {",
-            to: "func reportSessionError(_ error: any Error) {")
+            to: "@discardableResult")
         let rosterOwner = try Self.extract(
             source,
             from: "private func applyRoster(_ roster: ChatSessionRosterSnapshot) {",
             to: "private func loadRoster(")
+        let errorOwner = try Self.extract(
+            source,
+            from: "func performSessionMutation<Result>(",
+            to: "static func tokenUsageSummary(")
         let rosterCommit = try #require(refresh.range(of: "self.applyRoster(loadedRoster)"))
         let dashboardWait = try #require(refresh.range(of: "let loadedDashboard = await dashboard"))
 
@@ -81,6 +91,18 @@ struct RootTabsSourceGuardTests {
         #expect(source.contains("case .cancelled:\n            return"))
         #expect(rosterCommit.lowerBound < dashboardWait.lowerBound)
         #expect(source.contains("allowCachedFallback: false"))
+        #expect(errorOwner.contains("self.sessionMutationGenerations[mutationKey, default: 0] &+= 1"))
+        #expect(errorOwner.contains("mutationGeneration == self.sessionMutationGenerations[mutationKey]"))
+        #expect(errorOwner.contains("let ownerID = appModel.chatViewModelIdentityID"))
+        #expect(errorOwner.contains("self.updateSessionMutationOwner(ownerID)"))
+        #expect(errorOwner.contains("guard ownerID == appModel.chatViewModelIdentityID"))
+        #expect(errorOwner.contains("if ownerID == appModel.chatViewModelIdentityID,"))
+        let success = try #require(errorOwner.range(of: "onSuccess(result)"))
+        let successTail = errorOwner[success.upperBound...]
+        #expect(successTail.contains("await self.refreshSessions(appModel: appModel)"))
+        #expect(!errorOwner.contains("self.rosterGeneration &+= 1"))
+        #expect(refresh.contains("self.updateSessionMutationOwner(appModel.chatViewModelIdentityID)"))
+        #expect(refreshSessions.contains("self.updateSessionMutationOwner(appModel.chatViewModelIdentityID)"))
     }
 
     @Test func `sidebar refresh owner tracks sessions and periodically refreshes attention`() throws {
@@ -113,7 +135,7 @@ struct RootTabsSourceGuardTests {
         let observerApply = try Self.extract(
             sidebarSource,
             from: "private func handleSessionEvent(",
-            to: "func reportSessionError(")
+            to: "@discardableResult")
         let refreshIdentity = try Self.extract(
             appModelSource,
             from: "var chatViewModelIdentityID: String",
@@ -179,6 +201,173 @@ struct RootTabsSourceGuardTests {
         #expect(source.contains("self.isSearchFocused = false"))
         #expect(defaultSession.contains("ChatSessionSidebarModel.selectedSessionKey("))
         #expect(defaultSession.contains("sessions.first { $0.key == mainKey }"))
+    }
+
+    @Test func `overview session mutations use the shared error owner and render its failure`() throws {
+        let source = try String(contentsOf: Self.commandCenterSourceURL(), encoding: .utf8)
+        let actions = try Self.extract(
+            source,
+            from: "actions: CommandSessionActions(",
+            to: "private func cardHeader(title: String)")
+        let recentSessions = try Self.extract(
+            source,
+            from: "private var recentSessions: some View",
+            to: "private func cardHeader(title: String)")
+        let fork = try Self.extract(
+            source,
+            from: "private func forkSession(_ session: OpenClawChatSessionEntry)",
+            to: "private func performSessionMutation(")
+        let mutations = try Self.extract(
+            source,
+            from: "private func performSessionMutation(",
+            to: "private static func sessionChoices(")
+
+        #expect(recentSessions.contains("self.dashboardModel.sessionMutationErrorText"))
+        #expect(recentSessions.contains("detail: .verbatim(sessionMutationErrorText)"))
+        #expect(recentSessions.contains("self.dashboardModel.sessionErrorText"))
+        #expect(recentSessions.contains("if self.recentSessionPreviewSessions.isEmpty"))
+        #expect(!recentSessions.contains("else if self.recentSessionPreviewSessions.isEmpty"))
+        #expect(actions.contains("rename: { self.patchSession("))
+        #expect(actions.contains("toggleArchived: { self.archiveSession("))
+        #expect(actions.contains("delete: { self.deleteSession("))
+        #expect(actions.contains("fork: { self.forkSession("))
+        #expect(fork.contains("self.dashboardModel.performSessionMutation("))
+        #expect(mutations.contains("self.dashboardModel.performSessionMutation("))
+        #expect(!fork.contains("catch {}"))
+        #expect(!mutations.contains("catch {}"))
+    }
+
+    @Test @MainActor func `shared session mutation owner reports rejected overview actions without changing roster`() async {
+        let appModel = NodeAppModel()
+        appModel.enterAppleReviewDemoMode()
+        let model = RootSidebarModel()
+        await model.refreshSessions(appModel: appModel)
+        let originalKeys = model.sessions.map(\.key)
+
+        for action in ["rename", "archive", "delete"] {
+            let message = "\(action) rejected"
+            let result = await model.performSessionMutation(
+                appModel: appModel,
+                mutationKey: "session",
+                operation: { _ in throw SessionMutationFailure(message: message) })
+
+            #expect(!result)
+            #expect(model.sessions.map(\.key) == originalKeys)
+            #expect(model.sessionMutationErrorText == message)
+        }
+    }
+
+    @Test @MainActor func `successful session mutation clears an earlier failure`() async {
+        let appModel = NodeAppModel()
+        appModel.enterAppleReviewDemoMode()
+        let model = RootSidebarModel()
+        let rejected = await model.performSessionMutation(
+            appModel: appModel,
+            mutationKey: "session",
+            operation: { _ in throw SessionMutationFailure(message: "rename rejected") })
+
+        let result = await model.performSessionMutation(
+            appModel: appModel,
+            mutationKey: "session",
+            operation: { _ in })
+
+        #expect(!rejected)
+        #expect(result)
+        #expect(model.sessionMutationErrorText == nil)
+    }
+
+    @Test @MainActor func `older mutation completion cannot clear a newer rejection`() async {
+        let appModel = NodeAppModel()
+        appModel.enterAppleReviewDemoMode()
+        let model = RootSidebarModel()
+        let started = AsyncStream<Void>.makeStream(bufferingPolicy: .bufferingNewest(1))
+        let release = AsyncStream<Void>.makeStream(bufferingPolicy: .bufferingNewest(1))
+
+        let olderSuccess = Task {
+            await model.performSessionMutation(
+                appModel: appModel,
+                mutationKey: "session",
+                operation: { _ in
+                    started.continuation.yield()
+                    var iterator = release.stream.makeAsyncIterator()
+                    _ = await iterator.next()
+                })
+        }
+        var startedIterator = started.stream.makeAsyncIterator()
+        _ = await startedIterator.next()
+        let newerFailure = await model.performSessionMutation(
+            appModel: appModel,
+            mutationKey: "session",
+            operation: { _ in throw SessionMutationFailure(message: "delete rejected") })
+        release.continuation.yield()
+        let olderResult = await olderSuccess.value
+
+        #expect(!newerFailure)
+        #expect(olderResult)
+        #expect(model.sessionMutationErrorText == "delete rejected")
+    }
+
+    @Test @MainActor func `fork success cannot navigate after the session owner changes`() async {
+        let appModel = NodeAppModel()
+        let model = RootSidebarModel()
+        var openedKey: String?
+
+        let result = await model.performSessionMutation(
+            appModel: appModel,
+            mutationKey: "session",
+            operation: { _ in
+                appModel.enterAppleReviewDemoMode()
+                return "old-gateway-fork"
+            },
+            onSuccess: { openedKey = $0 })
+
+        #expect(!result)
+        #expect(openedKey == nil)
+    }
+
+    @Test @MainActor func `old owner mutation failure stays out of the new owner`() async {
+        let appModel = NodeAppModel()
+        let model = RootSidebarModel()
+
+        let result = await model.performSessionMutation(
+            appModel: appModel,
+            mutationKey: "session",
+            operation: { _ in
+                appModel.enterAppleReviewDemoMode()
+                throw SessionMutationFailure(message: "old gateway rejected")
+            })
+
+        #expect(!result)
+        #expect(model.sessionMutationErrorText == nil)
+    }
+
+    @Test @MainActor func `session refresh clears a failure owned by the previous gateway`() async {
+        let appModel = NodeAppModel()
+        let model = RootSidebarModel()
+        _ = await model.performSessionMutation(
+            appModel: appModel,
+            mutationKey: "session",
+            operation: { _ in throw SessionMutationFailure(message: "old gateway rejected") })
+        #expect(model.sessionMutationErrorText == "old gateway rejected")
+
+        appModel.enterAppleReviewDemoMode()
+        await model.refreshSessions(appModel: appModel)
+
+        #expect(model.sessionMutationErrorText == nil)
+    }
+
+    @Test @MainActor func `refresh failure after an applied mutation does not report the mutation as rejected`() async {
+        let appModel = NodeAppModel()
+        let model = RootSidebarModel()
+
+        let result = await model.performSessionMutation(
+            appModel: appModel,
+            mutationKey: "session",
+            operation: { _ in })
+
+        #expect(result)
+        #expect(model.sessionMutationErrorText == nil)
+        #expect(model.sessionErrorText != nil)
     }
 
     @Test func `settings about page shows concise public device details`() throws {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionManagementViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionManagementViews.swift
@@ -236,9 +236,9 @@ struct ChatSessionInspectorSheet: View {
                     self.timestampRow("Run ended", self.details.endedAt)
                 }
 
-                if let errorText {
+                if let errorText = self.errorText ?? self.viewModel.errorText {
                     Section {
-                        Text(errorText)
+                        Text(verbatim: errorText)
                             .font(OpenClawChatTypography.caption)
                             .foregroundStyle(OpenClawChatTheme.danger)
                     }
@@ -260,6 +260,7 @@ struct ChatSessionInspectorSheet: View {
                     self.errorText = error.localizedDescription
                 }
             }
+            .onAppear { self.viewModel.errorText = nil }
             .onChange(of: self.viewModel.sessions) {
                 if let refreshed = self.viewModel.sessions.first(where: { $0.key == self.displayedSession.key }) {
                     self.displayedSession = refreshed

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift
@@ -65,6 +65,13 @@ public struct ChatSessionsSheet: View {
     public var body: some View {
         NavigationStack {
             List(selection: self.$selectedSessionKeys) {
+                if let errorText = self.viewModel.errorText {
+                    Section {
+                        Text(verbatim: errorText)
+                            .font(OpenClawChatTypography.caption)
+                            .foregroundStyle(OpenClawChatTheme.danger)
+                    }
+                }
                 Section {
                     ForEach(self.displayedSessions) { session in
                         self.sessionRow(session)
@@ -129,6 +136,7 @@ public struct ChatSessionsSheet: View {
                 await self.refreshScopedSessionsIfNeeded(debounce: !self.trimmedSearchText.isEmpty)
             }
             .onAppear {
+                self.viewModel.errorText = nil
                 self.viewModel.refreshSessions(limit: OpenClawChatViewModel.sessionListFetchLimit)
             }
             .onChange(of: self.scope) {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatSheetsSourceGuardTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatSheetsSourceGuardTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+
+struct ChatSheetsSourceGuardTests {
+    @Test func `session sheet renders individual action failures while open`() throws {
+        let source = try String(contentsOf: Self.chatSheetsSourceURL(), encoding: .utf8)
+        let inspector = try String(contentsOf: Self.inspectorSourceURL(), encoding: .utf8)
+
+        #expect(source.contains("if let errorText = self.viewModel.errorText"))
+        #expect(source.contains("Text(verbatim: errorText)"))
+        #expect(source.contains(".foregroundStyle(OpenClawChatTheme.danger)"))
+        #expect(source.contains("self.viewModel.errorText = nil"))
+        #expect(inspector.contains("self.errorText ?? self.viewModel.errorText"))
+        #expect(inspector.contains("Text(verbatim: errorText)"))
+    }
+
+    private static func chatSheetsSourceURL() -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/OpenClawChatUI/ChatSheets.swift")
+    }
+
+    private static func inspectorSourceURL() -> URL {
+        self.chatSheetsSourceURL()
+            .deletingLastPathComponent()
+            .appendingPathComponent("ChatSessionManagementViews.swift")
+    }
+}


### PR DESCRIPTION
Closes #132031

## What Problem This Solves

Fixes an issue where iOS users renaming, archiving, deleting, or forking a session from Overview received no visible outcome when the Gateway rejected the request. The menu or confirmation closed while the unchanged session remained.

## Why This Change Was Made

Overview and the sidebar now use the same `RootSidebarModel` mutation owner. It records owner-scoped, latest-per-session mutation failures separately from roster refresh failures, revalidates gateway/agent identity before navigation, and renders errors in Overview and the sidebar. The Threads sheet and inspector also render their existing session-action error while open.

## User Impact

Rejected session actions now explain why they did not apply. Successful actions still refresh without cached fallback, and a refresh failure after an applied mutation is reported as a roster problem rather than falsely calling the mutation rejected.

## Evidence

- Focused regression before/after: `before=false`, `after=true`; current main has the silent Overview paths, while this head routes them through the shared owner and renders the resulting error.
- Regression coverage: `apps/ios/Tests/RootTabsSourceGuardTests.swift:199-386` covers rename/archive/delete/fork wiring, rejected mutations preserving the roster, stale completion ordering, gateway/agent owner changes, success clearing prior errors, and post-success refresh failure.
- Sheet coverage: `apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatSheetsSourceGuardTests.swift:1-30` verifies visible action errors in Threads and Thread Info.
- Runtime refs: `apps/ios/Sources/Design/CommandCenterTab.swift:371-637`; `apps/ios/Sources/RootSidebarModel.swift:187-540`; `apps/ios/Sources/RootSidebar.swift:369-866`.
- Gateway rejection refs: `src/gateway/sessions-patch.ts:286`; `src/gateway/server-methods/sessions-patch-archive.ts:62`; `src/gateway/server-methods/sessions-delete.ts:307`.
- Independent adversarial verification attempted to refute the analysis and confirmed the bug.
- Checks: focused before/after reproduction passed; `node scripts/check-changed.mjs` passed on Testbox run `33199485370`.
- Visual proof is not attached because this Linux host has no Swift/Xcode or iOS simulator; simulator compilation/tests remain covered by the PR iOS CI lane.

Production LOC: +181/-68 (net +113). The added state is required to distinguish mutation rejection from roster refresh failure, scope errors to gateway/agent ownership, and prevent stale same-session results from overwriting newer outcomes; sidebar duplicate executors were removed.
