### PR TITLE
fix(qa): restore macOS Crabline artifact publication

### DIFF
--- a/extensions/qa-lab/package.json
+++ b/extensions/qa-lab/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@copilotkit/aimock": "1.39.0",
     "@modelcontextprotocol/sdk": "1.30.0",
-    "@openclaw/crabline": "0.1.17",
+    "@openclaw/crabline": "0.1.19",
     "playwright-core": "1.62.1",
     "semver": "7.8.5",
     "ws": "8.21.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1647,8 +1647,8 @@ importers:
         specifier: 1.30.0
         version: 1.30.0(supports-color@10.2.2)(zod@4.4.3)
       '@openclaw/crabline':
-        specifier: 0.1.17
-        version: 0.1.17
+        specifier: 0.1.19
+        version: 0.1.19
       playwright-core:
         specifier: 1.62.1
         version: 1.62.1
@@ -4293,8 +4293,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@openclaw/crabline@0.1.17':
-    resolution: {integrity: sha512-tMjpIhzJvCulDA6mYL8nOA6XExWXZoBOrD4XgL3gsNdEDAWY4FCaHYyNCXwKPU2QSs78FU0xZ3NIQRr9ErHRpQ==}
+  '@openclaw/crabline@0.1.19':
+    resolution: {integrity: sha512-qDAwSTffMSJxHgaHQwNockE/90ae4YERSuizJgfzT9kwmkyzMi1R0dlTuMla5IRWNVvL2RYbj9q/tMsQG+zOeQ==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -11634,7 +11634,7 @@ snapshots:
   '@openai/codex@0.150.1-win32-x64':
     optional: true
 
-  '@openclaw/crabline@0.1.17':
+  '@openclaw/crabline@0.1.19':
     dependencies:
       '@types/node': 22.20.1
       commander: 15.0.0
@@ -11643,7 +11643,7 @@ snapshots:
       picocolors: 1.1.1
       proper-lockfile: 4.1.2
       re2js: 2.8.6
-      ws: 8.21.1
+      ws: 8.21.3
       yaml: 2.9.0
       zod: 4.4.3
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,7 @@ packages:
 minimumReleaseAge: 2880
 
 minimumReleaseAgeExclude:
+  - "@openclaw/crabline@0.1.19"
   - "@openclaw/fs-safe@0.5.5"
   - "@openclaw/libterminal@0.3.2"
   - "@openclaw/proxyline@0.3.4"


### PR DESCRIPTION
Related: [Crabline #280 — restrictive macOS ancestor ACL support](https://github.com/openclaw/crabline/pull/280) and [Crabline #286 — cancellation-safe recorder rejection handling](https://github.com/openclaw/crabline/pull/286).

## What Problem This Solves

Fixes an issue where developers running Crabline-backed QA from a macOS checkout could finish scenarios but fail artifact publication when their home ancestor carried the normal `group:everyone deny delete` ACL. OpenClaw still pins Crabline 0.1.17.

The old classifier also missed ACL entries when extended attributes made `ls` display `@` instead of `+`. Adopting the owner fix addresses both the false rejection and that connected grant-detection gap.

## Why This Change Was Made

Adopt published, verified `@openclaw/crabline@0.1.19` in QA Lab and its integrity-pinned lockfile snapshot. Keep OpenClaw's repository-relative artifact root and the dependency's canonical publication path; no consumer workaround, ACL stripping, vendor patch, retry, or filesystem-guard bypass is added.

We deliberately did not adopt 0.1.18 after independently reproducing its pre-aborted WhatsApp recorder rejection. That owner defect was fixed and released as 0.1.19 before this adoption. The shared waiter now observes the already-started promise before checking pre-abortion, preserving prompt cancellation and observer-safe shutdown.

The maintainer explicitly approved the exact-version `minimumReleaseAgeExclude` entry for this source-reviewed, integrity/provenance-verified corrective release. Only 0.1.19 is exempt; the global 48-hour guard remains unchanged. Crabline's `ws` dependency resolves to 8.21.3, already used by QA Lab. Unrelated resolver esbuild churn was removed, and a full parsed comparison proved every other manifest, lockfile, and workspace value unchanged.

## User Impact

Artifact publication works beneath understood, non-propagating deny-only macOS ancestor ACLs without changing the operator's home ACL. Private storage remains ACL-free with owner-only directory permissions and `0600` files. Granting, mixed, propagating, unknown/unverifiable ACLs, unsafe ownership/modes, and existing identity/claim violations remain rejected. A legitimate `0775` ancestor rejection is not excused by a deny ACL.

This is a three-file dependency adoption with no OpenClaw runtime or test source changes. Manifest/configuration delta is +2/-1; lockfile delta is +6/-6. The sole net configuration line is the approved exact-version quarantine exception. Regression coverage remains with the upstream ACL/publication owner rather than a duplicated OpenClaw parser or test-only seam.

## Evidence

### Dependency and native behavior

- [Crabline 0.1.19 release](https://github.com/openclaw/crabline/releases/tag/v0.1.19), commit `08e609fc567566100460e738033f8af66b0db141`. [Release workflow attempt 2](https://github.com/openclaw/crabline/actions/runs/33194312171/attempts/2) verified the same immutable artifact after npm processing outlasted attempt 1's post-upload verification window; no tag movement or package replacement occurred.
- npm `latest`, publication time, tarball integrity, and provenance were verified. The downloaded tarball's SHA-512 matches the new lockfile, and the QA importer resolves installed 0.1.19 with private-file bytes matching that verified tarball.
- Native macOS (Darwin 25.6.0), Node 24.20.0, umask `022`: original missing/existing-parent cases under the actual unchanged home ACL reject on 0.1.17. Installed 0.1.19 passes both cases with owner-only parents and `0600` files; home ACL/mode/UID/inode unchanged.
- Published and installed 0.1.19 each produced all 22 expected native publication/removal outcomes: plain/private ancestors and non-propagating denies accepted; delete-child/add-file/write-security/chown grants, mixed/inheritable ACLs, non-sticky `0775`/`0777`, and an immediate parent symlink rejected. Sticky-boundary protection and secured cleanup remained functional.
- Seven earlier native inheritance/permission cases passed against the unchanged ACL classifier: inherited-origin deny accepted; four propagation forms rejected before creation; actual denied directory creation preserved `EACCES`; newline-containing pathname text was not misread as ACL policy. All synthetic fixtures were cleaned.
- The downloaded 0.1.19 waiter also preserves the pre-abort reason without an orphaned rejection. Upstream's real Baileys encrypted compressed-frame regression failed before the correction and passed after; 9 cancellation/acceptance cases, 57 wire tests, lint/build, full CI, and release verification passed there.

### OpenClaw adoption checks

- `pnpm install --frozen-lockfile` passed, including all 1626 supply-chain-policy checks.
- Direct exact-pin guard passed across 632 specs/179 manifests; metadata formatting and `git diff --check` passed.
- Fresh independent Codex autoreview of the final three-file candidate reported no accepted/actionable findings at its default P0 scope.
- Final bounded artifact-consumer rerun on installed 0.1.19 passed all 3 selected cases (28 intentionally not selected), after disk recovery; no cache/identity mock or assertion weakening was added.

Local command for the bounded artifact consumer cases:

```bash
node scripts/run-vitest.mjs extensions/qa-lab/src/suite.test.ts -t 'writes standalone evidence|can return evidence without writing duplicate|distinguishes partial Markdown'
```

```bash
node --import ./scripts/tsx.mjs scripts/check-dependency-pins.mts
```

### Proof limits and required CI

Local whole-build/changed-gate and SDK declaration/typecheck attempts are **not claimed green**: the interrupted build left incomplete/mixed declarations, and subsequent regeneration/test work hit host disk exhaustion. The jobs were stopped and task-generated output was cleared; no source casts, ignored errors, type loosening, or timeout increase was used. Clean exact-head PR CI must supply the complete SDK/type/build and recorder integration proof before landing.

Source inspection confirms canonical PR CI's root-global fallback appends every extension config, including `vitest.extension-qa.config.ts` without a test-name filter. That shard prebuilds private QA and runs the real `suite.test.ts` Crabline artifact-writer case plus `crabline-transport.test.ts` and `crabline-transport-readiness.test.ts`. Its successful final-head execution must be verified, not inferred from a generic manual CI run. Linux CI is not substituted for native macOS ACL proof.

Local real-recorder integration was not run because Crabline's account-home lock namespace is not redirected by `HOME` or replaced by `CRABLINE_RECORDER_LOCK_DIR`. No identity mock was added to bypass that boundary. No full QA, dev Gateway, real provider/channel calls, credentials, remote-box lease, or external proof-asset upload was used for the adoption. The existing Gmail repair remains separate and untouched.

### Completed exact-head CI

[Canonical CI 33201679321, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33201679321/attempts/2) and the [current required gate](https://github.com/openclaw/openclaw/actions/runs/33201679321/job/98960851505) passed on `ea1c49b4508da9d7d687d5fa6e4a83c83780213a`, including dist/built-artifact and production/test-type checks. The initial build stopped before installation/compilation at existing base-fetch timeouts; only failed jobs were rerun.

The inspected [actual QA execution](https://github.com/openclaw/openclaw/actions/runs/33201679321/job/98953139740) passed **218 files / 3,019 tests** with successful private-QA preparation and no test filters: `suite.test.ts` **31/31**, including the real Crabline artifact-writer case; transport **19/19**; readiness **2/2**. That successful attempt-1 job was retained into attempt 2, not freshly rerun. These hosted results supply the previously pending clean SDK/type/build and recorder-integration proof; they do not relabel the interrupted local attempts as passing or substitute Linux for native ACL verification.

The [maintainer source/provenance response](https://github.com/openclaw/openclaw/pull/132035#issuecomment-5456851457) addresses both ClawSweeper rank-up moves and records the exact package identity, retained rejection contract, approved exception, and proof limits.

AI-assisted maintainer change.
