### PR TITLE
perf(test): overlap escaped-output cleanup regressions

### DIFF
--- a/test/scripts/managed-child-process.test.ts
+++ b/test/scripts/managed-child-process.test.ts
@@ -1,6 +1,7 @@
 // Managed Child Process tests cover managed child process script behavior.
 import { spawn } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { pathToFileURL } from "node:url";
@@ -768,10 +769,14 @@ ${publishReadyPidScript(2)}
     expect(isProcessAlive(childPid)).toBe(false);
   });
 
-  posixIt.each(["timeout", "sibling failure"])(
+  posixIt.concurrent.for(["timeout", "sibling failure"])(
     "fails closed within the cleanup budget when an escaped child holds output after $0",
-    async (mode) => {
-      const dir = createTempDir("openclaw-managed-held-output-");
+    { timeout: 25_000 },
+    async (mode, { expect }) => {
+      // Concurrent rows own their roots; the shared afterEach can run while a sibling is alive.
+      const dir = fs.mkdtempSync(
+        path.join(fs.realpathSync(os.tmpdir()), "openclaw-managed-held-output-"),
+      );
       const pidPath = path.join(dir, "escaped.pid");
       const parentPidPath = path.join(dir, "parent.pid");
       const failPath = path.join(dir, "fail");
@@ -853,10 +858,13 @@ require('node:child_process').spawn(process.execPath, ['-e', ${JSON.stringify(le
           process.kill(escapedPid, "SIGKILL");
           await waitForDead(escapedPid, 2_000);
         }
-        if (child?.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+        if (child?.exitCode === null && child.signalCode === null) {
+          child.kill("SIGKILL");
+          await waitForDead(expectProcessPid(child.pid), 2_000);
+        }
+        fs.rmSync(dir, { recursive: true, force: true });
       }
     },
-    25_000,
   );
 
   posixIt("waits through transient indeterminate process-group state", async () => {


### PR DESCRIPTION
Related: #131862 (managed cleanup regression coverage), #131903 (test-performance campaign).

## What Problem This Solves

Developers running the managed-child regression file wait for two independent escaped-output cleanup failures serially. Both deliberately consume real production cleanup budgets, so shortening those waits would remove the behavior being tested.

## Why This Change Was Made

Run only the existing timeout and sibling-failure rows concurrently with Vitest `concurrent.for` and row-local `expect`. Each owns a canonical temporary root and removes it only after watchdog completion and process cleanup. The fallback parent kill is now explicitly joined. All other cases remain serial, including the process-global signal, environment and output spies.

## User Impact

No product behavior changes. On one Blacksmith Testbox, mean whole-file wall time falls from **54.733s to 48.500s**, saving **6.233s (11.39%)**, favorable in **8/8 pairs**. All 41 tests remain. Production/tooling LOC +0/-0; tests +13/-5 (net +8).

## Evidence

AI-assisted, with fresh Codex autoreview reporting no actionable findings. Test-audit and deslop completed. No new production seam, fake timer, shortened budget, mocked process, removed assertion, dependency, snapshot or baseline change.

Benchmark: Node 24.19.0, pnpm 11.22.0, four exposed CPUs on one task-owned `blacksmith-testbox` lease `tbx_01m14t2xqghmt0prcjv4168tgh`; [environment workflow](https://github.com/openclaw/openclaw/actions/runs/33199458034). Excluded A/B warmups, eight order-balanced pairs for each scope, one Vitest worker, a distinct module cache per invocation, both import diagnostics, GNU `/usr/bin/time -v`. No samples dropped. Command: `pnpm test test/scripts/managed-child-process.test.ts --maxWorkers=1 --reporter=verbose --reporter=json`; span adds `-t 'fails closed within the cleanup budget'`.

| Scope | Wall A/B | Vitest A/B | Body/file span A/B | Import A/B | User CPU A/B | System CPU A/B | Max RSS A/B |
|---|---:|---:|---:|---:|---:|---:|---:|
| Whole file | 54.733/48.500s | 50.292/44.193s | 49.936/43.834s | 0.100/0.098s | 6.832/6.455s | 0.666/0.672s | 320.8/317.8 MiB |
| Two rows | 21.101/14.833s | 16.538/10.471s | 16.157/10.110s | 0.107/0.095s | 5.381/5.100s | 0.324/0.295s | 319.0/317.2 MiB |

RSS is GNU per-process maximum RSS, not summed concurrent memory. Body/file span is Vitest elapsed test time; overlapping individual row durations are not summed.

| Pair | Order | Whole baseline | Whole candidate | Span baseline | Span candidate |
|---|---|---:|---:|---:|---:|
| 1 | AB | 54.768s | 48.493s | 22.208s | 15.018s |
| 2 | BA | 55.310s | 48.947s | 21.223s | 15.332s |
| 3 | AB | 55.004s | 48.587s | 21.417s | 14.801s |
| 4 | BA | 54.261s | 48.056s | 20.843s | 14.740s |
| 5 | AB | 54.653s | 48.601s | 20.795s | 14.595s |
| 6 | BA | 54.532s | 48.635s | 20.663s | 14.742s |
| 7 | AB | 54.754s | 48.599s | 20.940s | 14.749s |
| 8 | BA | 54.584s | 48.082s | 20.715s | 14.683s |

The timeout row still verifies `EPROCESSGROUP_CLEANUP_FAILED`, both owned pipes destroyed, dead parent, live escaped child, and the original 12-second ceiling. The sibling row still verifies primary-first `AggregateError` details, the same liveness and elapsed assertions, and completion of blocked cleanup. Both kill and wait for escaped children before deleting their distinct canonical roots.

Runtime instrumentation observed synchronous watchdog start/restore pairs (`[100]`, then `[100,30000]`), unchanged stdout/stderr and environment state, two overlapping held-output parents, and independently completed row cleanup. Every monitored benchmark/fault run ended with zero observed live descendants and held-output roots. Peak sampled held-output parent/escaped counts: **1/1 -> 2/2**. Filtered invocation descendant peak **8 -> 10**; whole-file peak remains **17** because an unchanged test launches 12 children.

Reversible production faults on the same Testbox:

| Fault | Concurrent pair | Existing nested/descendant siblings |
|---|---|---|
| Remove owned pipe destruction | Only timeout fails its destroyed assertion; sibling passes | Not needed |
| Drop cleanup-error aggregation | Only sibling fails AggregateError assertion; timeout passes | Not needed |
| Remove cancellation join | Both pass | 8 fail |
| Remove process-group drain budget | Both pass | 5 fail, 3 pass |
| Remove force delay | Both pass | 7 fail, 1 passes |

The pair has an upper time bound, not a minimum-grace assertion; the sibling tests supply that complementary coverage. Exact production bytes were restored after every mutation, then the restored pair passed. No production fault is retained.

The first changed gate caught the unsupported TypeScript `for(name, fn, numericTimeout)` overload. The final declaration places `{ timeout: 25_000 }` before the callback. Direct execution of Vitest 4.1.11's actual `parseArguments` proves both forms register the identical callback and timeout; no benchmark sample was discarded. Instrumented final-form execution also asserts each registered task timeout is 25,000 ms.

Local proof: final focused 41/41; six-file shuffled sibling runs 166/166 at seeds 17 and 91; complete `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs -- test/scripts/managed-child-process.test.ts`; formatter and `git diff --check`. Fresh Codex autoreview is clean. Final-form Linux proof: three full-file repeats (41/41 each), plus the six-file sibling set in original order and shuffled seeds 17/91 (166/166 each). Every monitored invocation ended with zero observed live descendants and held-output roots. Sibling command: `pnpm test test/scripts/managed-child-process.test.ts test/scripts/prepare-extension-package-boundary-artifacts.test.ts test/scripts/run-oxlint.test.ts test/scripts/bundled-plugin-assets.test.ts test/scripts/vitest-process-group.test.ts test/helpers/process-wait.test.ts --maxWorkers=1`; shuffled runs add `--sequence.shuffle --sequence.seed=<seed>`. Hosted exact-head CI is required before native landing. Native Windows was not run; the pre-existing POSIX skip remains unchanged.

