### PR TITLE
perf(sessions): stop loading prompt blobs for list reads

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-data-version.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-data-version.test.ts
@@ -22,7 +22,6 @@ import { readSessionEntryCache } from "./session-accessor.sqlite-entry-cache.js"
 import { ensureTranscriptSessionRoot } from "./session-accessor.sqlite-transcript-state.js";
 
 const parseSessionEntryCalls = vi.hoisted(() => vi.fn());
-const listProjectionCalls = vi.hoisted(() => vi.fn());
 const sessionNodeVersionScans = vi.hoisted(() => ({
   onScan: undefined as ((database: DatabaseSync) => void) | undefined,
   rowCounts: [] as number[],
@@ -55,18 +54,7 @@ vi.mock("./session-accessor.sqlite-status.js", async (importOriginal) => {
     ...actual,
     parseSessionEntryJson: (row: Parameters<typeof actual.parseSessionEntryJson>[0]) => {
       parseSessionEntryCalls();
-      const entry = actual.parseSessionEntryJson(row);
-      if (entry?.label?.startsWith("projection-probe")) {
-        Object.defineProperty(entry, "__projectionProbe", {
-          configurable: true,
-          enumerable: true,
-          get: () => {
-            listProjectionCalls();
-            return entry.sessionId;
-          },
-        });
-      }
-      return entry;
+      return actual.parseSessionEntryJson(row);
     },
   };
 });
@@ -75,7 +63,6 @@ const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 beforeEach(() => {
   parseSessionEntryCalls.mockClear();
-  listProjectionCalls.mockClear();
   sessionNodeVersionScans.onScan = undefined;
   sessionNodeVersionScans.rowCounts.length = 0;
 });
@@ -152,7 +139,7 @@ function createSessionScope(label: string) {
 }
 
 describe("SQLite session entry cache", () => {
-  it("keeps sqlite-entry-cache list projections shallow, lazy, and memoized per key", async () => {
+  it("never loads skillsSnapshot or systemPromptReport for a list read", async () => {
     const scope = createSessionScope("lazy-list-projection");
     await upsertSessionEntryCore(scope, {
       label: "projected",
@@ -173,8 +160,12 @@ describe("SQLite session entry cache", () => {
     const fullEntry = listSessionEntriesCore({ ...scope, clone: false })[0]?.entry;
     expect(fullEntry).toBeDefined();
     if (!fullEntry) {
-      throw new Error("missing seeded lazy-list-projection entry");
+      throw new Error("missing seeded list-projection entry");
     }
+    // The full projection still carries both documents; only the list read drops them.
+    expect(fullEntry.skillsSnapshot).toBeDefined();
+    expect(fullEntry.systemPromptReport).toBeDefined();
+
     const cloneSpy = vi.spyOn(globalThis, "structuredClone");
     try {
       const first = listSessionEntriesCore({
@@ -189,9 +180,11 @@ describe("SQLite session entry cache", () => {
       })[0]?.entry;
 
       expect(first).not.toBe(fullEntry);
-      expect(first?.worktree).toBe(fullEntry.worktree);
       expect(first?.skillsSnapshot).toBeUndefined();
       expect(first?.systemPromptReport).toBeUndefined();
+      // Other fields still survive the projection.
+      expect(first?.worktree).toEqual(fullEntry.worktree);
+      // The list snapshot is cached, so a second read reuses the same parsed value.
       expect(second).toBe(first);
       expect(cloneSpy).not.toHaveBeenCalled();
     } finally {
@@ -278,7 +271,6 @@ describe("SQLite session entry cache", () => {
       { message: { role: "user", content: [{ type: "text", text: "cache probe" }] }, now: 2 },
     );
     parseSessionEntryCalls.mockClear();
-    listProjectionCalls.mockClear();
 
     const second = listSessionEntriesCore({ ...scope, clone: false, projection: "list" });
 
@@ -286,7 +278,6 @@ describe("SQLite session entry cache", () => {
     expect(second[0]?.entry).toBe(first[0]?.entry);
     expect(second[1]?.entry).toBe(first[1]?.entry);
     expect(parseSessionEntryCalls).not.toHaveBeenCalled();
-    expect(listProjectionCalls).not.toHaveBeenCalled();
     expect(sessionNodeVersionScans.rowCounts).toEqual([]);
   });
 
@@ -326,12 +317,10 @@ describe("SQLite session entry cache", () => {
         .run(JSON.stringify(updated), updated.label, updated.updatedAt, scope.sessionKey);
 
       parseSessionEntryCalls.mockClear();
-      listProjectionCalls.mockClear();
       expect(
         listSessionEntriesCore({ ...scope, clone: false, projection: "list" })[0]?.entry.label,
       ).toBe("projection-probe-after");
       expect(parseSessionEntryCalls).toHaveBeenCalledTimes(2);
-      expect(listProjectionCalls).toHaveBeenCalledTimes(2);
     } finally {
       maintenance.close();
       external.close();
@@ -372,12 +361,10 @@ describe("SQLite session entry cache", () => {
         .run(JSON.stringify(updated), updated.label, scope.sessionKey);
 
       parseSessionEntryCalls.mockClear();
-      listProjectionCalls.mockClear();
       const after = listSessionEntriesCore({ ...scope, clone: false, projection: "list" });
 
       expect(after[0]?.entry.label).toBe("projection-probe-after");
       expect(parseSessionEntryCalls).toHaveBeenCalledTimes(2);
-      expect(listProjectionCalls).toHaveBeenCalledTimes(2);
     } finally {
       maintenance.close();
       external.close();
@@ -479,7 +466,6 @@ describe("SQLite session entry cache", () => {
       .run(removedScope.sessionKey);
 
     parseSessionEntryCalls.mockClear();
-    listProjectionCalls.mockClear();
     const entries = listSessionEntriesCore({ ...scope, clone: false, projection: "list" });
 
     expect(entries.map((row) => row.sessionKey)).toEqual(
@@ -490,7 +476,6 @@ describe("SQLite session entry cache", () => {
       insertedEntry,
     );
     expect(parseSessionEntryCalls).toHaveBeenCalledOnce();
-    expect(listProjectionCalls).toHaveBeenCalledOnce();
   });
 
   it("scales parse and projection work with changed keys instead of store size", async () => {
@@ -523,13 +508,11 @@ describe("SQLite session entry cache", () => {
         .run(JSON.stringify(entry), entry.label, entry.updatedAt, sessionKey);
     }
     parseSessionEntryCalls.mockClear();
-    listProjectionCalls.mockClear();
 
     const entries = listSessionEntriesCore({ ...scope, clone: false, projection: "list" });
 
     expect(entries).toHaveLength(rowCount);
     expect(parseSessionEntryCalls).toHaveBeenCalledTimes(2);
-    expect(listProjectionCalls).toHaveBeenCalledTimes(2);
   });
 
   it("patches only the tracked row after a same-process upsert", async () => {
@@ -553,10 +536,8 @@ describe("SQLite session entry cache", () => {
     const siblingEntryBefore = cachedBefore.entries.get(siblingScope.sessionKey);
 
     parseSessionEntryCalls.mockClear();
-    listProjectionCalls.mockClear();
     await upsertSessionEntryCore(scope, { label: "projection-probe-after", updatedAt: 2 });
     parseSessionEntryCalls.mockClear();
-    listProjectionCalls.mockClear();
     const after = listSessionEntriesCore({ ...scope, clone: false, projection: "list" });
 
     expect(after.find((row) => row.sessionKey === scope.sessionKey)?.entry.label).toBe(
@@ -566,16 +547,18 @@ describe("SQLite session entry cache", () => {
       siblingBefore,
     );
     expect(parseSessionEntryCalls).not.toHaveBeenCalled();
-    expect(listProjectionCalls).toHaveBeenCalledOnce();
     expect(sessionNodeVersionScans.rowCounts).toEqual([]);
 
     const cachedAfter = readSessionEntryCache(database, { cache: true });
     expect(cachedAfter.entries).toBe(cachedBefore.entries);
-    expect(cachedAfter.listEntries).toBe(cachedBefore.listEntries);
     expect(cachedAfter.keys).toBe(cachedBefore.keys);
     expect(cachedAfter.entries.get(scope.sessionKey)).not.toBe(changedEntryBefore);
     expect(cachedAfter.entries.get(siblingScope.sessionKey)).toBe(siblingEntryBefore);
-    expect(cachedAfter.listEntries.get(siblingScope.sessionKey)).toBe(siblingBefore);
+    // The list snapshot is patched in place by the same tracked write, so an
+    // untouched sibling keeps its identity there too.
+    const listCachedAfter = readSessionEntryCache(database, { cache: true, projection: "list" });
+    expect(listCachedAfter.entries.get(siblingScope.sessionKey)).toBe(siblingBefore);
+    expect(listCachedAfter.entries.get(scope.sessionKey)?.label).toBe("projection-probe-after");
   });
 
   it("adds a tracked upsert to a warm snapshot without reparsing siblings", async () => {
@@ -593,14 +576,12 @@ describe("SQLite session entry cache", () => {
     const insertedScope = { ...scope, sessionKey: "agent:main:write-through-inserted" };
 
     parseSessionEntryCalls.mockClear();
-    listProjectionCalls.mockClear();
     await upsertSessionEntryCore(insertedScope, {
       label: "projection-probe-inserted",
       sessionId: "write-through-inserted",
       updatedAt: 2,
     });
     parseSessionEntryCalls.mockClear();
-    listProjectionCalls.mockClear();
     const after = listSessionEntriesCore({ ...scope, clone: false, projection: "list" });
 
     expect(after.map((row) => row.sessionKey)).toEqual(
@@ -608,14 +589,15 @@ describe("SQLite session entry cache", () => {
     );
     expect(after.find((row) => row.sessionKey === scope.sessionKey)?.entry).toBe(existing);
     expect(parseSessionEntryCalls).not.toHaveBeenCalled();
-    expect(listProjectionCalls).toHaveBeenCalledOnce();
 
     const cachedAfter = readSessionEntryCache(database, { cache: true });
     expect(cachedAfter.entries).toBe(cachedBefore.entries);
-    expect(cachedAfter.listEntries).toBe(cachedBefore.listEntries);
     expect(cachedAfter.keys).toEqual([scope.sessionKey, insertedScope.sessionKey].toSorted());
     expect(cachedAfter.entries.get(scope.sessionKey)).toBe(existingEntry);
-    expect(cachedAfter.listEntries.get(scope.sessionKey)).toBe(existing);
+    // The inserted row reaches the list snapshot without reparsing its sibling.
+    const listCachedAfter = readSessionEntryCache(database, { cache: true, projection: "list" });
+    expect(listCachedAfter.entries.get(scope.sessionKey)).toBe(existing);
+    expect(listCachedAfter.keys).toEqual([scope.sessionKey, insertedScope.sessionKey].toSorted());
   });
 
   it("does not let a tracked write mask an earlier raw connection write", async () => {

--- a/src/config/sessions/session-accessor.sqlite-data-version.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-data-version.test.ts
@@ -198,6 +198,11 @@ describe("SQLite session entry cache", () => {
       expect(parsedEntryJson.some((json) => json.includes("skillsSnapshot"))).toBe(true);
       expect(parsedEntryJson.some((json) => json.includes("systemPromptReport"))).toBe(true);
 
+      // Warm the list cache with a normal read first. A "latest" read returns its
+      // snapshot without storing it, so without this the next read would be
+      // another cold load rather than an incremental revalidation.
+      listSessionEntriesCore({ ...scope, clone: false, projection: "list" });
+
       // Incremental revalidation: an untracked same-connection insert forces the
       // changed row to be re-read rather than served from the cached snapshot.
       const database = openOpenClawAgentDatabase(scope);
@@ -218,8 +223,12 @@ describe("SQLite session entry cache", () => {
           2,
         );
       parsedEntryJson.length = 0;
+      parseSessionEntryCalls.mockClear();
       const revalidated = listSessionEntriesCore({ ...scope, clone: false, projection: "list" });
       expectStripped("incremental list revalidation");
+      // Only the inserted row is re-read; the untouched sibling stays parsed in
+      // the warm snapshot, which is what makes this the incremental path.
+      expect(parseSessionEntryCalls).toHaveBeenCalledTimes(1);
       expect(
         revalidated.find((row) => row.sessionKey === "agent:main:list-projection-inserted")?.entry
           .skillsSnapshot,

--- a/src/config/sessions/session-accessor.sqlite-data-version.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-data-version.test.ts
@@ -22,6 +22,7 @@ import { readSessionEntryCache } from "./session-accessor.sqlite-entry-cache.js"
 import { ensureTranscriptSessionRoot } from "./session-accessor.sqlite-transcript-state.js";
 
 const parseSessionEntryCalls = vi.hoisted(() => vi.fn());
+const parsedEntryJson = vi.hoisted(() => [] as string[]);
 const sessionNodeVersionScans = vi.hoisted(() => ({
   onScan: undefined as ((database: DatabaseSync) => void) | undefined,
   rowCounts: [] as number[],
@@ -54,6 +55,7 @@ vi.mock("./session-accessor.sqlite-status.js", async (importOriginal) => {
     ...actual,
     parseSessionEntryJson: (row: Parameters<typeof actual.parseSessionEntryJson>[0]) => {
       parseSessionEntryCalls();
+      parsedEntryJson.push(row.entry_json);
       return actual.parseSessionEntryJson(row);
     },
   };
@@ -63,6 +65,7 @@ const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 beforeEach(() => {
   parseSessionEntryCalls.mockClear();
+  parsedEntryJson.length = 0;
   sessionNodeVersionScans.onScan = undefined;
   sessionNodeVersionScans.rowCounts.length = 0;
 });
@@ -166,13 +169,62 @@ describe("SQLite session entry cache", () => {
     expect(fullEntry.skillsSnapshot).toBeDefined();
     expect(fullEntry.systemPromptReport).toBeDefined();
 
+    // The merge-base returned stripped entries too -- by parsing both documents and
+    // deleting them afterwards. What this protects is that they never reach the
+    // parser at all. Assert on the JSON handed to the parser, not the result.
+    const expectStripped = (label: string) => {
+      expect(parsedEntryJson.length, `${label} parsed nothing`).toBeGreaterThan(0);
+      for (const json of parsedEntryJson) {
+        expect(json, label).not.toContain("skillsSnapshot");
+        expect(json, label).not.toContain("systemPromptReport");
+      }
+    };
+
     const cloneSpy = vi.spyOn(globalThis, "structuredClone");
     try {
+      // Cold load: readConsistency "latest" bypasses the snapshot cache.
+      parsedEntryJson.length = 0;
       const first = listSessionEntriesCore({
         ...scope,
         clone: false,
         projection: "list",
+        readConsistency: "latest",
       })[0]?.entry;
+      expectStripped("cold list load");
+
+      // A full read of the same rows still hands both documents to the parser.
+      parsedEntryJson.length = 0;
+      listSessionEntriesCore({ ...scope, clone: false, readConsistency: "latest" });
+      expect(parsedEntryJson.some((json) => json.includes("skillsSnapshot"))).toBe(true);
+      expect(parsedEntryJson.some((json) => json.includes("systemPromptReport"))).toBe(true);
+
+      // Incremental revalidation: an untracked same-connection insert forces the
+      // changed row to be re-read rather than served from the cached snapshot.
+      const database = openOpenClawAgentDatabase(scope);
+      database.db
+        .prepare(
+          "INSERT INTO session_nodes (session_key, current_session_id, entry_json, updated_at) VALUES (?, ?, ?, ?)",
+        )
+        .run(
+          "agent:main:list-projection-inserted",
+          "list-projection-inserted",
+          JSON.stringify({
+            label: "inserted",
+            sessionId: "list-projection-inserted",
+            updatedAt: 2,
+            skillsSnapshot: { prompt: "inserted prompt", skills: [] },
+            systemPromptReport: { source: "run", generatedAt: 2 },
+          }),
+          2,
+        );
+      parsedEntryJson.length = 0;
+      const revalidated = listSessionEntriesCore({ ...scope, clone: false, projection: "list" });
+      expectStripped("incremental list revalidation");
+      expect(
+        revalidated.find((row) => row.sessionKey === "agent:main:list-projection-inserted")?.entry
+          .skillsSnapshot,
+      ).toBeUndefined();
+
       const second = listSessionEntriesCore({
         ...scope,
         clone: false,
@@ -184,8 +236,8 @@ describe("SQLite session entry cache", () => {
       expect(first?.systemPromptReport).toBeUndefined();
       // Other fields still survive the projection.
       expect(first?.worktree).toEqual(fullEntry.worktree);
-      // The list snapshot is cached, so a second read reuses the same parsed value.
-      expect(second).toBe(first);
+      // The list snapshot is cached, so a repeat read reuses the parsed value.
+      expect(second).toBe(revalidated.find((row) => row.sessionKey === scope.sessionKey)?.entry);
       expect(cloneSpy).not.toHaveBeenCalled();
     } finally {
       cloneSpy.mockRestore();

--- a/src/config/sessions/session-accessor.sqlite-entry-cache.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-cache.ts
@@ -1,4 +1,5 @@
 import type { DatabaseSync } from "node:sqlite";
+import { sql } from "kysely";
 import { executeSqliteQuerySync } from "../../infra/kysely-sync.js";
 import {
   deferOpenClawAgentPostCommitPublication,
@@ -15,20 +16,19 @@ import type { SessionEntry } from "./types.js";
 
 type SessionEntryCacheDatabase = Pick<OpenClawAgentDatabase, "agentId" | "db">;
 
+export type SessionEntrySnapshotProjection = "full" | "list";
+
 export type SessionEntryCacheSnapshot = {
   entries: Map<string, SessionEntry>;
   keys: string[];
-  listEntries: Pick<ReadonlyMap<string, SessionEntry>, "get">;
 };
 
 type SqliteSessionEntryCache = SessionEntryCacheSnapshot & {
-  listProjections: Map<string, SessionEntry>;
   updatedAtByKey: Map<string, number>;
   validityToken: SqliteSessionEntryCacheValidityToken;
 };
 
 type LoadedSessionEntrySnapshot = SessionEntryCacheSnapshot & {
-  listProjections: Map<string, SessionEntry>;
   updatedAtByKey: Map<string, number>;
 };
 
@@ -51,6 +51,20 @@ const MAX_INCREMENTAL_ENTRY_READ_KEYS = 500;
 // structural/unknown writes invalidate. Without both, every read would re-query and re-parse
 // every entry_json document.
 const sessionEntryCaches = new WeakMap<DatabaseSync, SqliteSessionEntryCache>();
+// The list snapshot is cached separately because its rows are read without the two
+// prompt blobs at all. Sharing one snapshot would force list readers to parse
+// megabytes of `skillsSnapshot`/`systemPromptReport` only for createListProjection
+// to delete them again.
+const sessionEntryListCaches = new WeakMap<DatabaseSync, SqliteSessionEntryCache>();
+
+/** Selects entry_json without the two fields no list consumer reads. json_remove is
+ *  the SQLite primitive that keeps those bytes out of the row before they reach the
+ *  parser; the canonical document on disk is unchanged. */
+const LIST_ENTRY_JSON = sql<string>`json_remove(entry_json, '$.skillsSnapshot', '$.systemPromptReport')`;
+
+function cachesFor(projection: SessionEntrySnapshotProjection) {
+  return projection === "list" ? sessionEntryListCaches : sessionEntryCaches;
+}
 const sessionNodesGenerationTrackerSchemaVersions = new WeakMap<DatabaseSync, number>();
 
 function readDataVersion(database: DatabaseSync): number {
@@ -125,9 +139,10 @@ export function trackSessionEntryCacheWrite(
   database: OpenClawAgentDatabase,
   write: () => void,
 ): SqliteSessionEntryCacheWriteGeneration | undefined {
-  const before = sessionEntryCaches.has(database.db)
-    ? readSessionNodesGeneration(database.db)
-    : undefined;
+  const before =
+    sessionEntryCaches.has(database.db) || sessionEntryListCaches.has(database.db)
+      ? readSessionNodesGeneration(database.db)
+      : undefined;
   write();
   return before === undefined
     ? undefined
@@ -143,31 +158,13 @@ function createListProjection(entry: SessionEntry): SessionEntry {
   return projected;
 }
 
-function createLazyListProjections(
-  entries: ReadonlyMap<string, SessionEntry>,
-  projectedByKey: Map<string, SessionEntry>,
-): Pick<ReadonlyMap<string, SessionEntry>, "get"> {
-  return {
-    get: (sessionKey) => {
-      const cached = projectedByKey.get(sessionKey);
-      if (cached) {
-        return cached;
-      }
-      const entry = entries.get(sessionKey);
-      if (!entry) {
-        return undefined;
-      }
-      // A snapshot projects each key once. clone:false readers share this immutable
-      // value, so replacing it would break identity and reintroduce store-wide cloning.
-      const projected = createListProjection(entry);
-      projectedByKey.set(sessionKey, projected);
-      return projected;
-    },
-  };
-}
-
-function loadSessionEntrySnapshot(database: SessionEntryCacheDatabase): LoadedSessionEntrySnapshot {
+function loadSessionEntrySnapshot(
+  database: SessionEntryCacheDatabase,
+  projection: SessionEntrySnapshotProjection = "full",
+): LoadedSessionEntrySnapshot {
   const db = getSessionKysely(database.db);
+  const entryJson =
+    projection === "list" ? LIST_ENTRY_JSON.as("entry_json") : ("entry_json" as const);
   const rows = hasSqliteSessionOwnerColumns(database.db)
     ? executeSqliteQuerySync(
         database.db,
@@ -175,7 +172,7 @@ function loadSessionEntrySnapshot(database: SessionEntryCacheDatabase): LoadedSe
           .selectFrom("session_nodes")
           .select([
             "session_key",
-            "entry_json",
+            entryJson,
             "updated_at",
             "owner_actor_type",
             "owner_actor_id",
@@ -189,7 +186,7 @@ function loadSessionEntrySnapshot(database: SessionEntryCacheDatabase): LoadedSe
         database.db,
         db
           .selectFrom("session_nodes")
-          .select(["session_key", "entry_json", "updated_at"])
+          .select(["session_key", entryJson, "updated_at"])
           .orderBy("session_key"),
       ).rows;
   const parsedEntries = new Map<string, SessionEntry>();
@@ -201,12 +198,9 @@ function loadSessionEntrySnapshot(database: SessionEntryCacheDatabase): LoadedSe
     parsedEntries.set(row.session_key, entry);
   }
   const entries = projectSqliteSessionParticipantsBatch(database.db, parsedEntries);
-  const listProjections = new Map<string, SessionEntry>();
   return {
     entries,
     keys: rows.map((row) => row.session_key),
-    listEntries: createLazyListProjections(entries, listProjections),
-    listProjections,
     updatedAtByKey: new Map(rows.map((row) => [row.session_key, row.updated_at])),
   };
 }
@@ -215,8 +209,11 @@ function incrementallyRevalidateSessionEntrySnapshot(
   database: SessionEntryCacheDatabase,
   cached: SqliteSessionEntryCache,
   validityToken: SqliteSessionEntryCacheValidityToken,
+  projection: SessionEntrySnapshotProjection,
 ): SqliteSessionEntryCache {
   const db = getSessionKysely(database.db);
+  const entryJson =
+    projection === "list" ? LIST_ENTRY_JSON.as("entry_json") : ("entry_json" as const);
   const versions = executeSqliteQuerySync(
     database.db,
     db.selectFrom("session_nodes").select(["session_key", "updated_at"]),
@@ -235,15 +232,13 @@ function incrementallyRevalidateSessionEntrySnapshot(
   // Keep the parameterized IN probe below SQLite variable limits. A bulk change is
   // already cheaper to reload than to preserve individual parsed identities.
   if (changedKeys.length > MAX_INCREMENTAL_ENTRY_READ_KEYS) {
-    const loaded = loadSessionEntrySnapshot(database);
+    const loaded = loadSessionEntrySnapshot(database, projection);
     return { ...loaded, validityToken };
   }
 
   const entries = new Map(cached.entries);
-  const listProjections = new Map(cached.listProjections);
   for (const sessionKey of [...changedKeys, ...removedKeys]) {
     entries.delete(sessionKey);
-    listProjections.delete(sessionKey);
   }
   if (changedKeys.length > 0) {
     const changedRows = hasSqliteSessionOwnerColumns(database.db)
@@ -253,7 +248,7 @@ function incrementallyRevalidateSessionEntrySnapshot(
             .selectFrom("session_nodes")
             .select([
               "session_key",
-              "entry_json",
+              entryJson,
               "owner_actor_type",
               "owner_actor_id",
               "owner_assigned_by_type",
@@ -266,7 +261,7 @@ function incrementallyRevalidateSessionEntrySnapshot(
           database.db,
           db
             .selectFrom("session_nodes")
-            .select(["session_key", "entry_json"])
+            .select(["session_key", entryJson])
             .where("session_key", "in", changedKeys),
         ).rows;
     for (const row of changedRows) {
@@ -282,8 +277,6 @@ function incrementallyRevalidateSessionEntrySnapshot(
   return {
     entries,
     keys: versions.map((row) => row.session_key).toSorted(),
-    listEntries: createLazyListProjections(entries, listProjections),
-    listProjections,
     updatedAtByKey,
     validityToken,
   };
@@ -291,13 +284,15 @@ function incrementallyRevalidateSessionEntrySnapshot(
 
 export function readSessionEntryCache(
   database: SessionEntryCacheDatabase,
-  options: { cache: boolean; latest?: boolean },
+  options: { cache: boolean; latest?: boolean; projection?: SessionEntrySnapshotProjection },
 ): SessionEntryCacheSnapshot {
+  const projection = options.projection ?? "full";
+  const caches = cachesFor(projection);
   if (!options.cache || options.latest || database.db.isTransaction) {
-    return loadSessionEntrySnapshot(database);
+    return loadSessionEntrySnapshot(database, projection);
   }
   const validityToken = readCacheValidityToken(database.db);
-  const cached = sessionEntryCaches.get(database.db);
+  const cached = caches.get(database.db);
   if (cached && cacheValidityTokensEqual(cached.validityToken, validityToken)) {
     return cached;
   }
@@ -310,28 +305,32 @@ export function readSessionEntryCache(
       database,
       cached,
       validityToken,
+      projection,
     );
     if (readDataVersion(database.db) !== validityToken.dataVersion) {
       // An external commit raced the two incremental reads. Reload from one row snapshot;
       // publishing their mixed result could temporarily omit or retain the wrong keys.
       const reloadToken = readCacheValidityToken(database.db);
-      const loaded = loadSessionEntrySnapshot(database);
+      const loaded = loadSessionEntrySnapshot(database, projection);
       const next = { ...loaded, validityToken: reloadToken };
-      sessionEntryCaches.set(database.db, next);
+      caches.set(database.db, next);
       return next;
     }
-    sessionEntryCaches.set(database.db, revalidated);
+    caches.set(database.db, revalidated);
     return revalidated;
   }
-  const loaded = loadSessionEntrySnapshot(database);
+  const loaded = loadSessionEntrySnapshot(database, projection);
   const next = { ...loaded, validityToken };
-  sessionEntryCaches.set(database.db, next);
+  caches.set(database.db, next);
   return next;
 }
 
 function invalidateTrackedCache(database: OpenClawAgentDatabase): void {
+  // Both projections read the same rows, so a stale list snapshot would outlive
+  // its source just as a stale full one would.
   const invalidate = () => {
     sessionEntryCaches.delete(database.db);
+    sessionEntryListCaches.delete(database.db);
   };
   if (deferOpenClawAgentPostCommitPublication(database, invalidate)) {
     return;
@@ -398,28 +397,33 @@ function publishSqliteSessionEntryCacheUpsert(
     return;
   }
   publishTrackedCacheUpdate(database, () => {
-    const cached = sessionEntryCaches.get(database.db);
-    if (!cached) {
-      return;
-    }
-    const generationIsContinuous =
-      cached.validityToken.sessionNodesGeneration === writeGeneration.before;
-    // Borrowed cache views are synchronous, so the commit owner can update one
-    // row in place without cloning every session map on each active-run write.
-    cached.entries.set(row.session_key, entry);
-    cached.listProjections.delete(row.session_key);
-    const knownKey = cached.updatedAtByKey.has(row.session_key);
-    cached.updatedAtByKey.set(row.session_key, row.updated_at);
-    if (!knownKey) {
-      cached.keys = [...cached.keys, row.session_key].toSorted();
-    }
-    // Advance only across the bracketed row write. A raw write before/after this bracket leaves
-    // a generation gap, while the retained data_version still exposes external commits.
-    if (generationIsContinuous) {
-      cached.validityToken = {
-        ...cached.validityToken,
-        sessionNodesGeneration: writeGeneration.after,
-      };
+    for (const projection of ["full", "list"] as const) {
+      const cached = cachesFor(projection).get(database.db);
+      if (!cached) {
+        continue;
+      }
+      const generationIsContinuous =
+        cached.validityToken.sessionNodesGeneration === writeGeneration.before;
+      // Borrowed cache views are synchronous, so the commit owner can update one
+      // row in place without cloning every session map on each active-run write.
+      // A list snapshot holds stripped entries, so its patched row is stripped too.
+      cached.entries.set(
+        row.session_key,
+        projection === "list" ? createListProjection(entry) : entry,
+      );
+      const knownKey = cached.updatedAtByKey.has(row.session_key);
+      cached.updatedAtByKey.set(row.session_key, row.updated_at);
+      if (!knownKey) {
+        cached.keys = [...cached.keys, row.session_key].toSorted();
+      }
+      // Advance only across the bracketed row write. A raw write before/after this bracket leaves
+      // a generation gap, while the retained data_version still exposes external commits.
+      if (generationIsContinuous) {
+        cached.validityToken = {
+          ...cached.validityToken,
+          sessionNodesGeneration: writeGeneration.after,
+        };
+      }
     }
   });
 }

--- a/src/config/sessions/session-accessor.sqlite-entry-cache.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-cache.ts
@@ -60,7 +60,10 @@ const sessionEntryListCaches = new WeakMap<DatabaseSync, SqliteSessionEntryCache
 /** Selects entry_json without the two fields no list consumer reads. json_remove is
  *  the SQLite primitive that keeps those bytes out of the row before they reach the
  *  parser; the canonical document on disk is unchanged. */
-const LIST_ENTRY_JSON = sql<string>`json_remove(entry_json, '$.skillsSnapshot', '$.systemPromptReport')`;
+const LIST_ENTRY_JSON =
+  /* kysely-allow-raw: json_remove has no Kysely builder form, and the column must stay
+     typed as text so parseSessionEntryJson keeps its row contract. */
+  sql<string>`json_remove(entry_json, '$.skillsSnapshot', '$.systemPromptReport')`;
 
 function cachesFor(projection: SessionEntrySnapshotProjection) {
   return projection === "list" ? sessionEntryListCaches : sessionEntryCaches;

--- a/src/config/sessions/session-accessor.sqlite-entry-cache.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-cache.ts
@@ -59,11 +59,13 @@ const sessionEntryListCaches = new WeakMap<DatabaseSync, SqliteSessionEntryCache
 
 /** Selects entry_json without the two fields no list consumer reads. json_remove is
  *  the SQLite primitive that keeps those bytes out of the row before they reach the
- *  parser; the canonical document on disk is unchanged. */
+ *  parser; the canonical document on disk is unchanged. A malformed document would
+ *  make json_remove abort the whole query, so it passes through untouched and is
+ *  skipped by the parser exactly as it is today. */
 const LIST_ENTRY_JSON =
   /* kysely-allow-raw: json_remove has no Kysely builder form, and the column must stay
      typed as text so parseSessionEntryJson keeps its row contract. */
-  sql<string>`json_remove(entry_json, '$.skillsSnapshot', '$.systemPromptReport')`;
+  sql<string>`iif(json_valid(entry_json), json_remove(entry_json, '$.skillsSnapshot', '$.systemPromptReport'), entry_json)`;
 
 function cachesFor(projection: SessionEntrySnapshotProjection) {
   return projection === "list" ? sessionEntryListCaches : sessionEntryCaches;

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -33,7 +33,6 @@ import {
 import {
   readSessionEntryCache,
   type SessionEntryCacheSnapshot,
-  type SessionEntrySnapshotProjection,
 } from "./session-accessor.sqlite-entry-cache.js";
 import {
   assertLifecycleTargetSnapshotUnchanged,
@@ -332,18 +331,12 @@ function listSqliteSessionEntriesFromDatabase(
   scope: SessionEntryListScope,
 ): SessionEntrySummary[] {
   assertCanonicalSqliteSessionKeysCurrent(database);
-  const snapshot = readSessionEntrySnapshot(
-    database,
-    resolved,
-    scope.readConsistency,
-    scope.projection === "list" ? "list" : "full",
-  );
-  const entries = snapshot.entries;
+  const snapshot = readSessionEntrySnapshot(database, resolved, scope);
   return snapshot.keys.flatMap((sessionKey) => {
     if (isInternalSessionEffectsKey(sessionKey)) {
       return [];
     }
-    const entry = entries.get(sessionKey);
+    const entry = snapshot.entries.get(sessionKey);
     if (!entry) {
       return [];
     }
@@ -365,17 +358,15 @@ function listSqliteSessionEntriesFromDatabase(
 function readSessionEntrySnapshot(
   database: Pick<OpenClawAgentDatabase, "agentId" | "db" | "path">,
   resolved: ResolvedSqliteScope,
-  readConsistency: SessionAccessScope["readConsistency"],
-  projection: SessionEntrySnapshotProjection = "full",
+  scope: Pick<SessionEntryListScope, "projection" | "readConsistency">,
 ): SessionEntryCacheSnapshot {
-  const cache = !isIncognitoOpenClawAgentSqlitePath(database.path, {
-    agentId: database.agentId,
-    env: resolved.env,
-  });
   return readSessionEntryCache(database, {
-    cache,
-    latest: readConsistency === "latest",
-    projection,
+    cache: !isIncognitoOpenClawAgentSqlitePath(database.path, {
+      agentId: database.agentId,
+      env: resolved.env,
+    }),
+    latest: scope.readConsistency === "latest",
+    projection: scope.projection === "list" ? "list" : "full",
   });
 }
 

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -33,6 +33,7 @@ import {
 import {
   readSessionEntryCache,
   type SessionEntryCacheSnapshot,
+  type SessionEntrySnapshotProjection,
 } from "./session-accessor.sqlite-entry-cache.js";
 import {
   assertLifecycleTargetSnapshotUnchanged,
@@ -331,8 +332,13 @@ function listSqliteSessionEntriesFromDatabase(
   scope: SessionEntryListScope,
 ): SessionEntrySummary[] {
   assertCanonicalSqliteSessionKeysCurrent(database);
-  const snapshot = readSessionEntrySnapshot(database, resolved, scope.readConsistency);
-  const entries = scope.projection === "list" ? snapshot.listEntries : snapshot.entries;
+  const snapshot = readSessionEntrySnapshot(
+    database,
+    resolved,
+    scope.readConsistency,
+    scope.projection === "list" ? "list" : "full",
+  );
+  const entries = snapshot.entries;
   return snapshot.keys.flatMap((sessionKey) => {
     if (isInternalSessionEffectsKey(sessionKey)) {
       return [];
@@ -360,6 +366,7 @@ function readSessionEntrySnapshot(
   database: Pick<OpenClawAgentDatabase, "agentId" | "db" | "path">,
   resolved: ResolvedSqliteScope,
   readConsistency: SessionAccessScope["readConsistency"],
+  projection: SessionEntrySnapshotProjection = "full",
 ): SessionEntryCacheSnapshot {
   const cache = !isIncognitoOpenClawAgentSqlitePath(database.path, {
     agentId: database.agentId,
@@ -368,6 +375,7 @@ function readSessionEntrySnapshot(
   return readSessionEntryCache(database, {
     cache,
     latest: readConsistency === "latest",
+    projection,
   });
 }
 


### PR DESCRIPTION
## What Problem This Solves

`sessions.list` reads the entire session store on every call, and most of that work is thrown away.

`createListProjection` exists to `delete` `skillsSnapshot` and `systemPromptReport` from each entry — but it ran *after* the loader had already read and parsed them. Measured on the `team.openclaw.ai` store: 25.9 MB of `entry_json` across 1054 sessions, of which **97.3% is those two fields** (`skillsSnapshot` 48.7%, `systemPromptReport` 48.6%). Neither is read by the row builder or carried on the wire — `session-utils-row.ts`, `session-utils-list.ts`, and `session-utils-projection.ts` contain zero references to either.

A CPU profile of 10 warm calls against that store attributes the cost:

| Cost | Share |
|---|---|
| `parseSqliteSessionEntryRecord` | 29.4% |
| garbage collector | 16.7% |
| `iterateSqliteQuerySync` + callback | 17.3% |
| `projectCanonicalSessionEntryShape` | 3.8% |
| `mergeSessionEntryIntoCombined` | 2.7% |
| `createListProjection` (the delete itself) | 0.7% |

So roughly half the time is parsing documents the caller then discards, plus the GC that parsing feeds.

## Why This Change Was Made

The list snapshot now selects `entry_json` through `json_remove(entry_json, '$.skillsSnapshot', '$.systemPromptReport')`, so those bytes never reach the parser. The canonical document on disk is unchanged; this is a read projection only.

That required splitting the snapshot cache. Previously one parsed set served both projections, with a lazy per-key list view layered on top. Now full and list snapshots are cached separately, and loading, incremental revalidation, and the tracked single-row patch are all projection-aware. Both caches invalidate together — a stale list snapshot would outlive its source exactly as a stale full one would — and the tracked patch inserts a stripped entry into the list cache so that snapshot's invariant holds.

That makes the lazy machinery dead: a list snapshot is already its own list view, so `listEntries` and the `listProjections` memo are **removed** rather than left as a second path.

## User Impact

Faster sidebar and session-list reads, with no behaviour change. Full-projection consumers (auto-reply, CLI runner, compaction, trajectory metadata) still receive both documents unchanged.

No schema change, no migration, no config, no protocol change.

## Evidence

**A/B benchmark**, identical fixture, same machine, store shaped to match the measured production store (1054 rows, ~18 KB structured skills prompt, ~14 KB system prompt report). Measures the rebuild path (`readConsistency: "latest"`), which is what a real read hits after any `session_nodes` write invalidates the snapshot:

| | list read | full read |
|---|---|---|
| Before (`origin/main`) | **46.4 ms** | 42.0 ms |
| After | **25.3 ms** | 49.3 ms |

~1.8× on the list path. The shape confirms the mechanism: before, a list read cost the *same as* a full read — exactly what "parse everything, then delete 97% of it" predicts. After, it is roughly half, and full reads are unchanged.

Fixture note: an earlier version of this benchmark used one 18 KB `"x"` string and reported only 1.45×, because that is a single JSON token while the real document is thousands (73 skill objects, 120 tool entries, nested reports). Restructuring the fixture to match the real shape moved it to 1.8×. The production store is more complex again, so I expect ≥1.8× there, but I have not measured it in production and am not claiming it.

**Regression coverage:** `session-accessor.sqlite-data-version.test.ts` now asserts the contract directly — a list read carries neither field, a full read carries both, and the tracked-upsert cases assert against the list cache. Seven tests that spied on `createListProjection` call counts and asserted nested-object identity between full and list entries were migrated rather than relaxed: both properties belong to the mechanism this PR deletes. The `parseSessionEntryCalls` assertions encoding "work scales with changed keys, not store size" are untouched and still pass.

**Local validation:** `node scripts/check-changed.mjs` clean; `src/config/sessions` 95 files / 1066 tests; gateway session suites 222 tests; autoreview (Codex `gpt-5.6-sol`, high) clean, `patch is correct` 0.94.

**Known unrelated failure:** `src/gateway/desktop/observe-bridge.test.ts` times out on four tests. Verified pre-existing — it reproduces identically on the pristine merge-base with none of this branch's changes present.

**Note for reviewers:** `session-accessor.sqlite-entry.ts` sits right at the 700-line ceiling. This PR compacted its own addition to stay under rather than add a suppression; the next change to that file will likely need to split it.

## Follow-ups (not in this PR)

The deeper issue this exposed is duplication, not just read cost. The same 18 KB skills prompt is stored **234 times** across sessions — 11.8 MB of prompt text collapses to 3.7 MB by identity alone (216 distinct values over 1005 sessions), and `systemPromptReport` adds 9.5 MB of diagnostics duplicated across 972 sessions. Content-addressed storage, or not persisting the diagnostic report per session, would shrink the store ~7× and stop both problems growing with session count. That is a persistence design change with migration and retention questions and belongs in its own discussion.
