### PR TITLE
fix(scripts): prevent lint limits from slowing declaration preparation

### DIFF
--- a/scripts/run-oxlint.mts
+++ b/scripts/run-oxlint.mts
@@ -278,7 +278,8 @@ async function main(
   }
 
   if (needsArtifactPreparation) {
-    await prepareExtensionPackageBoundaryArtifacts(env);
+    // Declaration compilation owns its Go policy; lint limits belong to the oxlint child.
+    await prepareExtensionPackageBoundaryArtifacts(localEnv);
   }
 
   const status = await runManagedCommand({

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -190,6 +190,8 @@ describe("gateway server chat", () => {
       });
       return await run(dir);
     } finally {
+      // Dispatch can outlive its RPC; keep its store selected until retained work settles.
+      await waitForFast(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
       testState.sessionStorePath = undefined;
       await removeTempDir(dir);
     }
@@ -2623,6 +2625,60 @@ describe("gateway server chat", () => {
       await removeTempDir(dir);
     }
   });
+
+  test.each(["return", "throw"] as const)(
+    "retains the session fixture while admitted dispatch settles after callback %s",
+    async (outcome) => {
+      const runId = `idem-fixture-dispatch-${outcome}`;
+      const dispatchStarted = createDeferred();
+      const releaseDispatch = createDeferred();
+      const callbackFinished = createDeferred();
+      const callbackError = new Error("fixture callback failed");
+      let fixtureDir = "";
+      let storePath = "";
+      dispatchInboundMessageMock.mockImplementationOnce(async () => {
+        dispatchStarted.resolve();
+        await releaseDispatch.promise;
+        return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } };
+      });
+      const fixture = withMainSessionStore(async (dir) => {
+        fixtureDir = dir;
+        storePath = path.join(dir, "sessions.json");
+        try {
+          await sendChatAndExpectStarted(runId, "hold fixture dispatch open");
+          await dispatchStarted.promise;
+          if (outcome === "throw") {
+            throw callbackError;
+          }
+          return "fixture result";
+        } finally {
+          callbackFinished.resolve();
+        }
+      });
+      const completion = Promise.allSettled([fixture]);
+      try {
+        await callbackFinished.promise;
+        // Let the fixture's finally run while the admitted dispatch is still held.
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        expect(getActiveGatewayRootWorkCount()).toBeGreaterThan(0);
+        expect(testState.sessionStorePath).toBe(storePath);
+        expect((await fs.stat(fixtureDir)).isDirectory()).toBe(true);
+      } finally {
+        releaseDispatch.resolve();
+        await completion;
+        await waitForFast(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+      }
+      expect(await completion).toEqual([
+        outcome === "throw"
+          ? { status: "rejected", reason: callbackError }
+          : { status: "fulfilled", value: "fixture result" },
+      ]);
+      expect(testState.sessionStorePath).toBeUndefined();
+      await expect(fs.stat(fixtureDir)).rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
 
   test("agent.wait ignores stale agent snapshots while same-runId chat.send is active", async () => {
     await withMainSessionStore(async () => {

--- a/test/scripts/local-check-runtime.test.ts
+++ b/test/scripts/local-check-runtime.test.ts
@@ -342,38 +342,95 @@ describe("local-check-runtime", () => {
     expect(env.GOMEMLIMIT).toBe("5GiB");
   });
 
-  it("passes the throttled Go concurrency limit to the oxlint child", () => {
-    const cwd = createTempDir("openclaw-oxlint-go-limit-");
-    const binDir = path.join(cwd, "node_modules", ".bin");
-    const capturePath = path.join(cwd, "gomaxprocs.txt");
-    const oxlintPath = path.join(binDir, "oxlint");
-    fs.mkdirSync(binDir, { recursive: true });
-    fs.writeFileSync(
-      oxlintPath,
-      "#!/usr/bin/env node\nrequire('node:fs').writeFileSync(process.env.CAPTURE_PATH, process.env.GOMAXPROCS || '');\n",
-      "utf8",
-    );
-    fs.chmodSync(oxlintPath, 0o755);
-    const env: NodeJS.ProcessEnv = {
-      ...process.env,
-      CAPTURE_PATH: capturePath,
-      OPENCLAW_LOCAL_CHECK: "1",
-      OPENCLAW_LOCAL_CHECK_MODE: "throttled",
-      OPENCLAW_OXLINT_SKIP_PREPARE: "1",
-    };
-    delete env.GOMAXPROCS;
+  it.each([
+    {
+      name: "default Go settings",
+      goEnv: { GOMAXPROCS: undefined, GOGC: undefined, GOMEMLIMIT: undefined },
+      prepGoEnv: { GOMAXPROCS: null, GOGC: null, GOMEMLIMIT: null },
+      lintGoEnv: {
+        GOMAXPROCS: String(Math.min(2, Math.max(1, os.availableParallelism()))),
+        GOGC: "30",
+        GOMEMLIMIT: "3GiB",
+      },
+    },
+    {
+      name: "explicit user Go settings",
+      goEnv: { GOMAXPROCS: "3", GOGC: "80", GOMEMLIMIT: "5GiB" },
+      prepGoEnv: { GOMAXPROCS: "3", GOGC: "80", GOMEMLIMIT: "5GiB" },
+      lintGoEnv: { GOMAXPROCS: "3", GOGC: "80", GOMEMLIMIT: "5GiB" },
+    },
+  ])(
+    "keeps prep and oxlint resource policies separate with $name",
+    ({ goEnv, prepGoEnv, lintGoEnv }) => {
+      const cwd = createTempDir("openclaw-oxlint-go-limit-");
+      const binDir = path.join(cwd, "node_modules", ".bin");
+      const tsxDir = path.join(cwd, "node_modules", "tsx");
+      const scriptsDir = path.join(cwd, "scripts");
+      const capturePath = path.join(cwd, "children.jsonl");
+      const oxlintPath = path.join(binDir, "oxlint");
+      fs.mkdirSync(binDir, { recursive: true });
+      fs.mkdirSync(tsxDir, { recursive: true });
+      fs.mkdirSync(scriptsDir, { recursive: true });
+      // Prep's raw --import tsx resolves here; the fixture needs only native ESM.
+      fs.writeFileSync(
+        path.join(tsxDir, "package.json"),
+        '{"type":"module","exports":"./index.js"}\n',
+      );
+      fs.writeFileSync(path.join(tsxDir, "index.js"), "export {};\n");
+      const captureSource = `
+const goEnv = Object.fromEntries(["GOMAXPROCS", "GOGC", "GOMEMLIMIT"].map(key => [key, process.env[key] ?? null]));
+fs.appendFileSync(process.env.CAPTURE_PATH, JSON.stringify({ step, goEnv, args: process.argv.slice(2) }) + "\\n");
+`;
+      fs.writeFileSync(
+        path.join(scriptsDir, "prepare-extension-package-boundary-artifacts.mts"),
+        `import fs from "node:fs";\nconst step = "prep";\n${captureSource}`,
+        "utf8",
+      );
+      fs.writeFileSync(
+        oxlintPath,
+        `#!/usr/bin/env node\nconst fs = require("node:fs");\nconst step = "lint";\n${captureSource}`,
+        "utf8",
+      );
+      fs.chmodSync(oxlintPath, 0o755);
+      const env = makeEnv({
+        CAPTURE_PATH: capturePath,
+        OPENCLAW_OXLINT_SKIP_PREPARE: undefined,
+        ...goEnv,
+      });
 
-    const result = spawnSync(
-      process.execPath,
-      [path.resolve("scripts/run-oxlint.mjs"), "--tsconfig", "config/tsconfig/oxlint.core.json"],
-      { cwd, encoding: "utf8", env },
-    );
+      const result = spawnSync(
+        process.execPath,
+        [
+          path.resolve("scripts/run-oxlint.mjs"),
+          "--tsconfig",
+          "config/tsconfig/oxlint.extensions.json",
+        ],
+        { cwd, encoding: "utf8", env },
+      );
 
-    expect(result.status, result.stderr).toBe(0);
-    expect(fs.readFileSync(capturePath, "utf8")).toBe(
-      String(Math.min(2, Math.max(1, os.availableParallelism()))),
-    );
-  });
+      expect(result.status, result.stderr).toBe(0);
+      const children = fs
+        .readFileSync(capturePath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      expect(children).toEqual([
+        { step: "prep", goEnv: prepGoEnv, args: [] },
+        {
+          step: "lint",
+          goEnv: lintGoEnv,
+          args: [
+            "--tsconfig",
+            "config/tsconfig/oxlint.extensions.json",
+            "--type-aware",
+            "--report-unused-disable-directives-severity",
+            "error",
+            "--threads=1",
+          ],
+        },
+      ]);
+    },
+  );
 
   it("allows forcing full-speed oxlint runs on roomy hosts", () => {
     const { args, env } = applyLocalOxlintPolicy(


### PR DESCRIPTION
Closes #132042 — targeted plugin lint leaks Go limits into declaration preparation.

Related: #131862 — already-merged declaration timeout teardown repair, distinct from this compilation-policy defect.

AI-assisted with Codex; source, child-process behavior, and regression evidence inspected.

<details>
<summary>Additional instructions</summary>

This branch is in the main repository and is available for maintainer edits.

</details>

## What Problem This Solves

Fixes an issue where developers running targeted plugin lint could hit the declaration-preparation deadline because the compiler inherited lint-specific resource limits, even on a host where its normal policy would allow a full-speed build.

## Why This Change Was Made

The targeted lint wrapper now passes the original local environment to declaration preparation and retains the derived lint environment for oxlint. The compiler remains the owner of its Go resource policy, matching the existing sharded lint path; explicit user overrides and constrained-host defaults are preserved. This is one executable argument change plus an ownership comment, with no new policy, timeout, dependency, configuration, or production cleanup behavior.

## User Impact

Targeted plugin lint no longer imposes its own Go limits on prerequisite declaration generation. Actual lint remains throttled as before. There is no bot runtime, provider, or channel behavior change, and this does not claim to fix every cause of slow preparation.

## Evidence

The existing CLI fixture now records preparation and lint children in order, checking all three Go settings and the lint arguments for both default and explicit-user environments. Before the repair, the default case failed on leaked `GOMAXPROCS=2`, `GOGC=30`, and `GOMEMLIMIT=3GiB`; the explicit-user case passed. No production test seam was added.

- Fresh `node scripts/run-vitest.mjs test/scripts/local-check-runtime.test.ts`: **27/27 passed** on Node 26.7.0. Prior Node 24.20.0 owner proof also passed 27/27.
- Prior `node scripts/check-changed.mjs -- scripts/run-oxlint.mts test/scripts/local-check-runtime.test.ts`: **exit 0**, including scripts/root-test types, formatting, targeted script lint, and selected guards. The reviewed source bytes remained unchanged through commit hooks.
- Publication-phase isolated Codex autoreview in `--mode uncommitted`: **scoped-clean**, no accepted/actionable P0 findings. `git diff --check` passed.

Ordinary cold root declaration compilation through the real preparation-step and tsgo wrappers, using unchanged 300,000-ms deadlines and fresh isolated outputs, on Node 24.20.0/macOS 27:

| Environment | Observed result | Host load | Output |
| --- | --- | --- | --- |
| Inherited lint Go limits | Timeout at 300 seconds | 127–145 | 5,774 declarations; no build info |
| Compiler-owned policy | Exit 0 in 84.7 seconds | 140–154 | All 8,158 declarations and build info |

The completed declarations were byte-identical to the independently completed output. Both runs stopped all owned descendants without manual cleanup. These are measurements on a contended host, not CI timing thresholds. Profiled comparisons are excluded from ordinary timing proof: the pinned upstream compiler's diagnostic path forces two additional GCs after emission.

**Known limits and required follow-through:** The repaired full cold targeted lint completed both Go declaration builds, then failed the unchanged `plugin-sdk boundary root shims timed out after 300000ms` phase (TypeScript 6.0.3/tsdown 0.22.14, host load 147–182). All owned descendants stopped. Full local lint is **not green**; exact-head CI declaration/build/lint proof must pass before landing, and related failures must be diagnosed rather than bypassed.

Separately, the broader uninstrumented cleanup suite passed 159/160: an untouched nested-resistant managed-child case observed a PID at return without capturing its state. The original first-two cases and eight ordered pairs passed, and a final native-instrumented aggregate passed 160/160 with all 21 assertion PIDs absent, but instrumentation can affect scheduling. This does **not** resolve the original observation. Follow-up: **Capture intermittent nested timeout PID survival** with actual process-state evidence on recurrence. That managed-only case does not call the changed lint wrapper; no cleanup owner or assertion changed. Another separately recorded follow-up, **Review declaration success-path process ownership**, concerns normally exiting fixture leaders with surviving ignored-stdio descendants; it is not an installed-compiler behavior claim or part of this repair.

Tooling LOC: **+2/-1**, net +1 ownership comment; executable LOC neutral. CLI tests: **+88/-31**, extending the existing fixture. Gateway test fixture/regressions: **+56/-0**; no additional production changes. No changelog, lockfile, baseline, skip, deadline, or configuration changes.

### CI follow-up: retain session fixtures through dispatch cleanup

Fixture repair: [566e08c3c84](https://github.com/openclaw/openclaw/commit/566e08c3c84d85b9cf458be68f4eeec8ccb178c9).

The original head's [compact-small-7 failure](https://github.com/openclaw/openclaw/actions/runs/33203199989/job/98957732639) was the settled-ownership subscription in `agent.wait ignores lifecycle completion while same-runId chat.send is active`. Build, types, lint, and plugin-boundary CI passed on that head; this gateway shard and its aggregate gate failed.

Controlled scheduling in the immediately preceding abort test proved that `withMainSessionStore` could clear its selected store and delete its directory while a Gateway root and session admission were still live. Holding the existing mocked transcript-persistence callback until the next test's admission then produced a real append with the **previous run's idempotency key in the next fixture's SQLite store**. The fixture reused the same fake session ID, so late target resolution crossed the test boundary.

The fixture now waits for the existing Gateway root-work drain signal in `finally` before clearing or removing its state. Two regression cases cover callback return and callback throw, retain the store while admitted dispatch is held, preserve the callback result/error, and verify eventual teardown after release. The original adjacent tests, lifecycle timestamps, event predicates, and semantic assertions are unchanged. No production test seam, retry, deadline increase, or forced reset was added.

- Pre-fix: `node scripts/run-vitest.mjs src/gateway/server.chat.gateway-server-chat.test.ts -t 'retains the session fixture|agent.wait ignores (stale agent snapshots|lifecycle completion)'` — both new fixture cases failed because the store selection was already cleared while a root was live; the original adjacent pair passed.
- Fixed: `node scripts/run-vitest.mjs src/gateway/server.chat.gateway-server-chat.test.ts src/gateway/test-helpers.server-rpc.test.ts` — **68/68 passed**, including the complete original file order and both queued-SQLite-write helper contracts.
- The first scoped gate passed guards, formatting, and core-test types, then flagged an implicit return from the new Promise executor. Its block-body correction changed no scheduling or assertions. The focused regression plus original adjacent pair passed again: **4/4**.
- Final `node scripts/check-changed.mjs -- src/gateway/server.chat.gateway-server-chat.test.ts`: **exit 0**, including all guards, formatting, core-test types, and targeted lint.
- Fresh isolated Codex autoreview of the complete three-file candidate in `--mode uncommitted`, pinned to the PR merge base: **scoped-clean**, no actionable P0 findings; full affected-file and owner datasets included.

All CI-repair proof above used Node **24.20.0**; the original CI runner used **24.19**. Temporary scheduling instrumentation was removed. The earlier diagnostic run's separate cold-start RPC timeout remains recorded locally; it was not retried into a claimed repair.

**Disposition limit:** the controlled cross-test append proves the fixture lifetime defect, but the original settled-ownership predicate still passed in that controlled run. This is not a claim that the exact CI timeout mechanism was reproduced. New exact-head CI and maintainer disposition remain required before landing; the separate full-local-lint and managed-child cleanup limitations above are unchanged.
