### PR TITLE
fix(release): trust historical validation tooling independently

### DIFF
--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -1202,22 +1202,21 @@ jobs:
           EXPECTED_SHA="$(git rev-parse HEAD)"
           MANIFEST_FILE="full-release-validation/full-release-validation-manifest.json"
           export EXPECTED_SHA MANIFEST_FILE
-          trusted_workflow_commit_ref="refs/remotes/origin/main"
+          trusted_main_ref="refs/remotes/origin/main"
           if [[ "${TRUSTED_WORKFLOW_FULL_REF}" =~ ^refs/tags/release-publish/[a-f0-9]{12}-[1-9][0-9]*$ ]]; then
-            trusted_workflow_commit_ref="refs/tags/${TRUSTED_WORKFLOW_REF}"
+            trusted_publisher_ref="refs/tags/${TRUSTED_WORKFLOW_REF}"
             timeout --signal=TERM --kill-after=10s 120s git fetch --filter=blob:none --no-tags origin \
-              "+${TRUSTED_WORKFLOW_FULL_REF}:${trusted_workflow_commit_ref}"
-            if [[ "$(git rev-parse "${trusted_workflow_commit_ref}^{commit}")" != "${WORKFLOW_SHA}" ]]; then
+              "+${TRUSTED_WORKFLOW_FULL_REF}:${trusted_publisher_ref}"
+            if [[ "$(git rev-parse "${trusted_publisher_ref}^{commit}")" != "${WORKFLOW_SHA}" ]]; then
               echo "Trusted release-publish tag moved after workflow dispatch." >&2
               exit 1
             fi
-          else
-            timeout --signal=TERM --kill-after=10s 120s git fetch --filter=blob:none --no-tags origin \
-              +refs/heads/main:refs/remotes/origin/main
           fi
-          TRUSTED_MAIN_REF="${trusted_workflow_commit_ref}" \
+          timeout --signal=TERM --kill-after=10s 120s git fetch --filter=blob:none --no-tags origin \
+            "+refs/heads/main:${trusted_main_ref}"
+          TRUSTED_MAIN_REF="${trusted_main_ref}" \
             gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${FULL_RELEASE_VALIDATION_RUN_ID}/attempts/${FULL_RELEASE_VALIDATION_RUN_ATTEMPT}" | \
-            TRUSTED_MAIN_REF="${trusted_workflow_commit_ref}" \
+            TRUSTED_MAIN_REF="${trusted_main_ref}" \
             node trusted-workflow/scripts/validate-full-release-validation-evidence.mjs
           node "$STRICT_VALIDATOR_FILE" \
             --validate-run "$FULL_RELEASE_VALIDATION_RUN_ID" \

--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -674,20 +674,19 @@ jobs:
             ls -la "${RUNNER_TEMP}/full-release-validation-manifest" >&2 || true
             exit 1
           fi
-          trusted_workflow_commit_ref="refs/remotes/origin/main"
+          trusted_main_ref="refs/remotes/origin/main"
           if [[ "${TRUSTED_WORKFLOW_FULL_REF}" =~ ^refs/tags/release-publish/[a-f0-9]{12}-[1-9][0-9]*$ ]]; then
-            trusted_workflow_commit_ref="refs/tags/${TRUSTED_WORKFLOW_REF}"
+            trusted_publisher_ref="refs/tags/${TRUSTED_WORKFLOW_REF}"
             git fetch --no-tags origin \
-              "+${TRUSTED_WORKFLOW_FULL_REF}:${trusted_workflow_commit_ref}"
-            if [[ "$(git rev-parse "${trusted_workflow_commit_ref}^{commit}")" != "${GITHUB_SHA}" ]]; then
+              "+${TRUSTED_WORKFLOW_FULL_REF}:${trusted_publisher_ref}"
+            if [[ "$(git rev-parse "${trusted_publisher_ref}^{commit}")" != "${GITHUB_SHA}" ]]; then
               echo "Trusted release-publish tag moved after workflow dispatch." >&2
               exit 1
             fi
-          else
-            git fetch --no-tags origin \
-              +refs/heads/main:refs/remotes/origin/main
           fi
-          TRUSTED_MAIN_REF="${trusted_workflow_commit_ref}" \
+          git fetch --no-tags origin \
+            "+refs/heads/main:${trusted_main_ref}"
+          TRUSTED_MAIN_REF="${trusted_main_ref}" \
             MANIFEST_FILE="$manifest" \
             node "$VALIDATOR_FILE" < "$RUN_JSON_FILE"
           node "$STRICT_VALIDATOR_FILE" \

--- a/scripts/validate-full-release-validation-evidence.mjs
+++ b/scripts/validate-full-release-validation-evidence.mjs
@@ -230,19 +230,20 @@ export function validateFullReleaseValidationEvidence({
       `SHA-pinned validation target ref mismatch: expected ${expectedTargetSha}, got ${displayValue(manifest.targetRef)}.`,
     );
   }
-  if (protectedTag) {
-    if (run.headSha !== expectedTrustedWorkflowSha) {
-      throw new Error(
-        `Protected-tag release evidence workflow SHA ${run.headSha} does not match trusted tooling ${expectedTrustedWorkflowSha}.`,
-      );
-    }
-    return { run, source: "sha-pinned-protected-tag" };
+  // The protected tag authenticates the current publisher. An older validation
+  // producer remains trusted only through its independent current-main lineage.
+  const historicalProtectedProducer = protectedTag && run.headSha !== expectedTrustedWorkflowSha;
+  if ((historicalProtectedProducer || !protectedTag) && !isTrustedMainAncestor?.(run.headSha)) {
+    const subject = protectedTag
+      ? "Protected-tag release evidence workflow SHA"
+      : "SHA-pinned validation workflow";
+    throw new Error(`${subject} ${run.headSha} is not reachable from current main.`);
   }
-  if (!isTrustedMainAncestor?.(run.headSha)) {
-    throw new Error(
-      `SHA-pinned validation workflow ${run.headSha} is not reachable from current main.`,
-    );
-  }
+  const source = protectedTag
+    ? historicalProtectedProducer
+      ? "sha-pinned-protected-tag-main-ancestor"
+      : "sha-pinned-protected-tag"
+    : "sha-pinned-main";
   if (Object.hasOwn(manifest, "evidenceReuse")) {
     const reuse = manifest.evidenceReuse;
     const exactTarget =
@@ -292,7 +293,7 @@ export function validateFullReleaseValidationEvidence({
       throw new Error("SHA-pinned validation evidence reuse failed strict chain validation.");
     }
   }
-  return { run, source: "sha-pinned-main" };
+  return { run, source };
 }
 
 /**

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2189,7 +2189,10 @@ describe("package acceptance workflow", () => {
         TRUSTED_WORKFLOW_SHA: "${{ github.workflow_sha }}",
       });
       expect(step.run).toContain("^refs/tags/release-publish/[a-f0-9]{12}-[1-9][0-9]*$");
-      expect(step.run).toContain('TRUSTED_MAIN_REF="${trusted_workflow_commit_ref}"');
+      expect(step.run).toContain('trusted_publisher_ref="refs/tags/${TRUSTED_WORKFLOW_REF}"');
+      expect(step.run).toContain('git rev-parse "${trusted_publisher_ref}^{commit}")" != "${');
+      expect(step.run).toContain('"+refs/heads/main:${trusted_main_ref}"');
+      expect(step.run).toContain('TRUSTED_MAIN_REF="${trusted_main_ref}"');
       expect(step.run).toContain('--trusted-workflow-ref "$TRUSTED_WORKFLOW_REF"');
       expect(step.run).toContain('--trusted-workflow-full-ref "$TRUSTED_WORKFLOW_FULL_REF"');
       expect(step.run).toContain('--trusted-workflow-sha "$TRUSTED_WORKFLOW_SHA"');

--- a/test/scripts/validate-full-release-validation-evidence.test.ts
+++ b/test/scripts/validate-full-release-validation-evidence.test.ts
@@ -8,6 +8,7 @@ import {
 
 const targetSha = "b".repeat(40);
 const workflowSha = "a".repeat(40);
+const publisherWorkflowSha = "c".repeat(40);
 const pinnedBranch = `release-ci/${workflowSha.slice(0, 12)}-1783705000000`;
 
 function releaseRun(overrides: Record<string, unknown> = {}) {
@@ -143,7 +144,32 @@ describe("full release validation evidence", () => {
     expect(isTrustedMainAncestor).not.toHaveBeenCalled();
   });
 
-  it("rejects protected-tag evidence from a same-name branch or older ancestor", () => {
+  it("accepts historical SHA-pinned evidence from trusted main under a protected publisher", () => {
+    const isTrustedMainAncestor = vi.fn(() => true);
+    const validateEvidenceReuseStrictly = vi.fn(() => strictEvidenceReuse());
+    const trustedWorkflowRef = `release-publish/${publisherWorkflowSha.slice(0, 12)}-123`;
+    const result = validateFullReleaseValidationEvidence({
+      run: releaseRun(),
+      manifest: releaseManifest({ evidenceReuse: exactTargetEvidenceReuse() }),
+      expectedRepository: "openclaw/openclaw",
+      expectedRunId: "123",
+      expectedTargetSha: targetSha,
+      expectedTrustedWorkflowFullRef: `refs/tags/${trustedWorkflowRef}`,
+      expectedTrustedWorkflowSha: publisherWorkflowSha,
+      isTrustedMainAncestor,
+      validateEvidenceReuseStrictly,
+    });
+
+    expect(result.source).toBe("sha-pinned-protected-tag-main-ancestor");
+    expect(isTrustedMainAncestor).toHaveBeenCalledWith(workflowSha);
+    expect(validateEvidenceReuseStrictly).toHaveBeenCalledWith({
+      repository: "openclaw/openclaw",
+      runId: "123",
+      targetSha,
+    });
+  });
+
+  it("rejects protected-tag evidence from a same-name branch or untrusted ancestor", () => {
     const trustedWorkflowRef = `release-publish/${workflowSha.slice(0, 12)}-123`;
     expect(() =>
       validateFullReleaseValidationEvidence({
@@ -176,9 +202,9 @@ describe("full release validation evidence", () => {
         expectedTargetSha: targetSha,
         expectedTrustedWorkflowFullRef: `refs/tags/${trustedWorkflowRef}`,
         expectedTrustedWorkflowSha: workflowSha,
-        isTrustedMainAncestor: () => true,
+        isTrustedMainAncestor: () => false,
       }),
-    ).toThrow("does not match trusted tooling");
+    ).toThrow("not reachable from current main");
 
     expect(() =>
       validateFullReleaseValidationEvidence({


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-publication blocker where a protected current publisher could not consume an already successful, SHA-pinned Full Release Validation run produced by older trusted tooling on main. The validator incorrectly required the publisher tooling SHA and the historical validation tooling SHA to be identical.

## Why This Change Was Made

The current publisher remains authenticated by its exact protected lightweight tag and SHA. The validation producer is verified independently through its canonical `release-ci/<sha>-<timestamp>` branch, exact manifest v3 identity, strict evidence chain, and ancestry from current trusted main.

This keeps the publisher and validation identities separate without weakening either boundary. Non-ancestor producers, same-name branches, and branch/manifest mismatches continue to fail closed.

## User Impact

Release operators can resume the existing `2026.9.1-beta.1` publication using successful immutable validation evidence instead of rerunning unrelated newer harness lanes. There is no product runtime change.

## Evidence

- Pre-fix regression failed because historical validation tooling `d5412d73acfba6d5c85448fee05c75322d9719aa` did not equal the protected publisher tooling SHA.
- `node scripts/run-vitest.mjs test/scripts/validate-full-release-validation-evidence.test.ts test/scripts/package-acceptance-workflow.test.ts` - 235/235 passed.
- `pnpm lint:scripts` - passed.
- `pnpm format:check -- .github/workflows/openclaw-release-publish.yml .github/workflows/openclaw-npm-release.yml scripts/validate-full-release-validation-evidence.mjs test/scripts/validate-full-release-validation-evidence.test.ts test/scripts/package-acceptance-workflow.test.ts` - passed.
- `actionlint -shellcheck= .github/workflows/openclaw-release-publish.yml .github/workflows/openclaw-npm-release.yml` - passed. Homebrew actionlint's shellcheck integration deadlocked twice with zero CPU/children; script lint and workflow contract tests cover the changed shell.
- Autoreview: clean, no actionable findings, 0.94 confidence.
- Tooling production delta: net 0 lines across workflows and validator. Tests: +29 net lines.

Release evidence retained unchanged:

- Release SHA: `1d96e5aee2d49cde999ed055eda113e2523a7b5c`
- Successful release FRV: `33165617935`, attempt 1
- Historical validation Tooling SHA: `d5412d73acfba6d5c85448fee05c75322d9719aa`
