### PR TITLE
refactor(browser): split browser-tool.ts and retire its max-lines suppression

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -54,7 +54,7 @@ extensions/browser/src/browser-tool-binding.ts	3
 extensions/browser/src/browser-tool-session-tabs.ts	3
 extensions/browser/src/browser-tool.actions.ts	14
 extensions/browser/src/browser-tool.snapshot.ts	2
-extensions/browser/src/browser-tool.ts	18
+extensions/browser/src/browser-tool.ts	14
 extensions/browser/src/browser/bridge-server.ts	3
 extensions/browser/src/browser/cdp-page-session.ts	3
 extensions/browser/src/browser/cdp-proxy-bypass.ts	1

--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -11,7 +11,6 @@ extensions/anthropic/index.test.ts
 extensions/anthropic/register.runtime.ts
 extensions/anthropic/session-catalog.test.ts
 extensions/browser/src/browser-tool.test.ts
-extensions/browser/src/browser-tool.ts
 extensions/browser/src/browser/cdp.ts
 extensions/browser/src/browser/chrome-mcp.test.ts
 extensions/browser/src/browser/chrome.executables.ts

--- a/extensions/browser/src/browser-tool.lifecycle.ts
+++ b/extensions/browser/src/browser-tool.lifecycle.ts
@@ -1,0 +1,176 @@
+/** Browser tool lifecycle and host-local profile discovery/import actions. */
+import type { AgentToolResult } from "openclaw/plugin-sdk/agent-core";
+import type { BrowserProxyRequest } from "./browser-node-proxy.js";
+import { resolveBrowserBaseUrl } from "./browser-tool.routing.js";
+import {
+  browserDoctor,
+  browserImportProfile,
+  browserProfiles,
+  browserSystemProfiles,
+  browserStart,
+  browserStatus,
+  browserStop,
+  jsonResult,
+  normalizeOptionalString,
+} from "./browser-tool.runtime.js";
+import { parseSystemProfileDomains } from "./browser/system-profile-domains.js";
+
+const unavailableSystemProfiles = (unavailableReason: string) => ({
+  profiles: [],
+  unavailableReason,
+});
+
+/**
+ * Read importable system profiles from the host control server. Discovery must
+ * match where import runs (host-local), so it never uses a node proxy or the
+ * sandbox base URL. Other profile sources remain useful when host discovery
+ * is unavailable, so failures become an explicit degradation fact.
+ */
+async function readHostSystemProfiles(params: {
+  allowHostControl?: boolean;
+  sandboxBridgeUrl?: string;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}) {
+  if (params.allowHostControl === false) {
+    return unavailableSystemProfiles(
+      "Host system profile discovery is disabled by sandbox policy; enable host control to discover importable system profiles.",
+    );
+  }
+  let hostBaseUrl: string | undefined;
+  try {
+    hostBaseUrl = resolveBrowserBaseUrl({
+      target: "host",
+      sandboxBridgeUrl: params.sandboxBridgeUrl,
+      allowHostControl: params.allowHostControl,
+    });
+  } catch {
+    return unavailableSystemProfiles(
+      'Host browser control is unavailable; enable it and retry action=profiles target="host".',
+    );
+  }
+  try {
+    return {
+      profiles: await browserSystemProfiles(hostBaseUrl, {
+        timeoutMs: params.timeoutMs,
+        signal: params.signal,
+      }),
+      unavailableReason: undefined,
+    };
+  } catch {
+    params.signal?.throwIfAborted();
+    return unavailableSystemProfiles(
+      'Host system profile discovery failed; retry action=profiles target="host" after host browser control is available.',
+    );
+  }
+}
+
+export async function executeBrowserLifecycleAction({
+  action,
+  input: params,
+  baseUrl,
+  profile,
+  timeoutMs: toolTimeoutMs,
+  proxyRequest,
+  allowHostControl,
+  sandboxBridgeUrl,
+  signal,
+}: {
+  action: "doctor" | "status" | "start" | "stop" | "profiles" | "importprofile";
+  input: Record<string, unknown>;
+  baseUrl?: string;
+  profile?: string;
+  timeoutMs?: number;
+  proxyRequest: BrowserProxyRequest | null;
+  allowHostControl?: boolean;
+  sandboxBridgeUrl?: string;
+  signal?: AbortSignal;
+}): Promise<AgentToolResult<unknown>> {
+  const readBrowserStatus = async () =>
+    proxyRequest
+      ? await proxyRequest({
+          method: "GET",
+          path: "/",
+          profile,
+          timeoutMs: toolTimeoutMs,
+        })
+      : await browserStatus(baseUrl, {
+          profile,
+          timeoutMs: toolTimeoutMs,
+          signal,
+        });
+  switch (action) {
+    case "doctor":
+      return jsonResult(
+        proxyRequest
+          ? await proxyRequest({ method: "GET", path: "/doctor", profile })
+          : await browserDoctor(baseUrl, { profile, signal }),
+      );
+    case "status":
+      return jsonResult(await readBrowserStatus());
+    case "start":
+    case "stop": {
+      if (proxyRequest) {
+        await proxyRequest({
+          method: "POST",
+          path: `/${action}`,
+          profile,
+          timeoutMs: toolTimeoutMs,
+        });
+      } else {
+        const updateBrowser = action === "start" ? browserStart : browserStop;
+        await updateBrowser(baseUrl, { profile, timeoutMs: toolTimeoutMs, signal });
+      }
+      return jsonResult(await readBrowserStatus());
+    }
+    case "profiles": {
+      // Importable system profiles are host-local (import runs on the host),
+      // so read them from the host regardless of the profiles action target;
+      // never let a node proxy or sandbox describe the wrong Chrome profiles.
+      const { profiles: systemProfiles, unavailableReason: systemProfilesUnavailable } =
+        await readHostSystemProfiles({
+          allowHostControl,
+          sandboxBridgeUrl,
+          timeoutMs: toolTimeoutMs,
+          signal,
+        });
+      if (proxyRequest) {
+        const result = await proxyRequest({
+          method: "GET",
+          path: "/profiles",
+          timeoutMs: toolTimeoutMs,
+        });
+        return jsonResult({
+          ...(result && typeof result === "object" ? result : { profiles: result }),
+          systemProfiles,
+          ...(systemProfilesUnavailable ? { systemProfilesUnavailable } : {}),
+        });
+      }
+      return jsonResult({
+        profiles: await browserProfiles(baseUrl, {
+          timeoutMs: toolTimeoutMs,
+          signal,
+        }),
+        systemProfiles,
+        ...(systemProfilesUnavailable ? { systemProfilesUnavailable } : {}),
+      });
+    }
+    case "importprofile": {
+      if (proxyRequest) {
+        throw new Error("system profile import must run on the browser host");
+      }
+      const domains = parseSystemProfileDomains(params.domains);
+      return jsonResult(
+        await browserImportProfile(baseUrl, {
+          browser: normalizeOptionalString(params.browser) ?? "chrome",
+          systemProfile: normalizeOptionalString(params.systemProfile) ?? "Default",
+          into: normalizeOptionalString(params.into) ?? "imported",
+          domains,
+          signal,
+        }),
+      );
+    }
+    default:
+      throw new Error(`Unknown action: ${String(action)}`);
+  }
+}

--- a/extensions/browser/src/browser-tool.routing.ts
+++ b/extensions/browser/src/browser-tool.routing.ts
@@ -1,0 +1,133 @@
+/** Browser tool host, sandbox, and node target resolution. */
+import { resolveBrowserNodeTarget } from "./browser-node-routing.js";
+import {
+  getRuntimeConfig,
+  listNodes,
+  resolveBrowserConfig,
+  resolveProfile,
+  getBrowserProfileCapabilities,
+} from "./browser-tool.runtime.js";
+
+export type BrowserNodeTarget = {
+  nodeId: string;
+  label?: string;
+  commands: string[];
+  pendingDeclaredCommands: string[];
+};
+
+export async function resolveBrowserToolNodeTarget(params: {
+  requestedNode?: string;
+  target?: "sandbox" | "host" | "node";
+  sandboxBridgeUrl?: string;
+  allowHostControl?: boolean;
+  signal?: AbortSignal;
+}): Promise<BrowserNodeTarget | null> {
+  if (params.allowHostControl === false) {
+    if (params.target === "node" || params.requestedNode) {
+      throw new Error("Node browser control is disabled by sandbox policy.");
+    }
+    return null;
+  }
+
+  const cfg = getRuntimeConfig();
+  const policy = cfg.gateway?.nodes?.browser;
+  const explicitTarget = params.target === "node";
+  const requestedNode = params.requestedNode?.trim();
+  if (policy?.mode === "off") {
+    resolveBrowserNodeTarget({ nodes: [], policy, requestedNode, explicitTarget });
+    return null;
+  }
+  if (params.sandboxBridgeUrl?.trim() && !explicitTarget && !requestedNode) {
+    return null;
+  }
+  if (params.target && !explicitTarget) {
+    return null;
+  }
+  if (policy?.mode === "manual" && !explicitTarget && !requestedNode && !policy.node?.trim()) {
+    return null;
+  }
+  const node = resolveBrowserNodeTarget({
+    nodes: await listNodes({}, params.signal),
+    policy,
+    requestedNode,
+    explicitTarget,
+    requireConnected: true,
+  });
+  return node
+    ? {
+        nodeId: node.nodeId,
+        label: node.displayName ?? node.remoteIp ?? node.nodeId,
+        commands: node.commands ?? [],
+        pendingDeclaredCommands: node.pendingDeclaredCommands ?? [],
+      }
+    : null;
+}
+
+export function resolveBrowserBaseUrl(params: {
+  target?: "sandbox" | "host";
+  sandboxBridgeUrl?: string;
+  allowHostControl?: boolean;
+}): string | undefined {
+  const cfg = getRuntimeConfig();
+  const resolved = resolveBrowserConfig(cfg.browser, cfg);
+  const normalizedSandbox = params.sandboxBridgeUrl?.trim() ?? "";
+  const target = params.target ?? (normalizedSandbox ? "sandbox" : "host");
+
+  if (target === "sandbox") {
+    if (!normalizedSandbox) {
+      throw new Error(
+        'Sandbox browser is unavailable. Enable agents.defaults.sandbox.browser.enabled or use target="host" if allowed.',
+      );
+    }
+    return normalizedSandbox.replace(/\/$/, "");
+  }
+
+  if (params.allowHostControl === false) {
+    throw new Error("Host browser control is disabled by sandbox policy.");
+  }
+  if (!resolved.enabled) {
+    throw new Error(
+      "Browser control is disabled. Set browser.enabled=true in ~/.openclaw/openclaw.json.",
+    );
+  }
+  return undefined;
+}
+
+const DEFAULT_EXISTING_SESSION_MANAGE_TIMEOUT_MS = 45_000;
+const EXISTING_SESSION_MANAGE_ACTIONS = new Set([
+  "status",
+  "start",
+  "stop",
+  "profiles",
+  "tabs",
+  "open",
+  "focus",
+  "close",
+]);
+
+function hasExistingSessionProfile(resolved: ReturnType<typeof resolveBrowserConfig>) {
+  return Object.keys(resolved.profiles).some((name) => {
+    const candidate = resolveProfile(resolved, name);
+    return candidate ? getBrowserProfileCapabilities(candidate).usesChromeMcp : false;
+  });
+}
+
+export function resolveBrowserToolTimeoutMs({
+  requestedTimeoutMs,
+  action,
+  isUserBrowserProfile,
+  resolvedBrowser,
+}: {
+  requestedTimeoutMs?: number;
+  action: string;
+  isUserBrowserProfile: boolean;
+  resolvedBrowser: ReturnType<typeof resolveBrowserConfig>;
+}) {
+  return (
+    requestedTimeoutMs ??
+    (EXISTING_SESSION_MANAGE_ACTIONS.has(action) &&
+    (isUserBrowserProfile || (action === "profiles" && hasExistingSessionProfile(resolvedBrowser)))
+      ? DEFAULT_EXISTING_SESSION_MANAGE_TIMEOUT_MS
+      : undefined)
+  );
+}

--- a/extensions/browser/src/browser-tool.screenshot.ts
+++ b/extensions/browser/src/browser-tool.screenshot.ts
@@ -1,0 +1,231 @@
+/** Browser tool screenshot capture, private vision output, and explicit sharing hints. */
+import type { AgentToolResult } from "openclaw/plugin-sdk/agent-core";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import type { BrowserProxyRequest } from "./browser-node-proxy.js";
+import {
+  browserScreenshotAction,
+  describeImageFile,
+  getRuntimeConfig,
+  imageResultFromFile,
+  jsonResult,
+  readStringParam,
+  readStringValue,
+  resolveRuntimeImageSanitization,
+  saveMediaBuffer,
+  stageBrowserScreenshotForSharing,
+} from "./browser-tool.runtime.js";
+import { DEFAULT_BROWSER_SCREENSHOT_TIMEOUT_MS } from "./browser/constants.js";
+import { normalizeBrowserScreenshot } from "./browser/screenshot.js";
+import { describeBrowserScreenshot, neutralizeMediaDirectives } from "./browser/vision.js";
+import { wrapExternalContent } from "./sdk-security-runtime.js";
+
+export type BrowserScreenshotOptions = {
+  agentId?: string;
+  agentDir?: string;
+  workspaceDir?: string;
+  activeModel?: {
+    provider?: string;
+    model?: string;
+  };
+  screenshotResultMode?: "image" | "path";
+  persistScreenshot?: (params: {
+    sourcePath: string;
+    type: "png" | "jpeg";
+    targetId?: string;
+  }) => Promise<string>;
+  mediaScope?: {
+    sessionKey?: string;
+    channel?: string;
+    chatType?: string;
+  };
+};
+
+function formatScreenshotShareHint(filePath: string): string {
+  return `[Screenshot saved to ${JSON.stringify(filePath)}. A sanitized outbound copy is ready at this path for explicit sharing.]`;
+}
+
+const SCREENSHOT_SHARE_UNAVAILABLE =
+  "[Screenshot sharing is unavailable because an outbound copy could not be prepared.]";
+
+export async function executeScreenshotAction({
+  input: params,
+  baseUrl,
+  profile,
+  requestedTimeoutMs,
+  proxyRequest,
+  signal,
+  onTabActivity,
+  opts,
+}: {
+  input: Record<string, unknown>;
+  baseUrl?: string;
+  profile?: string;
+  requestedTimeoutMs?: number;
+  proxyRequest: BrowserProxyRequest | null;
+  signal?: AbortSignal;
+  onTabActivity: (targetId: string | undefined) => void;
+  opts?: BrowserScreenshotOptions;
+}): Promise<AgentToolResult<unknown>> {
+  const targetId = readStringParam(params, "targetId");
+  const fullPage = Boolean(params.fullPage);
+  const ref = readStringParam(params, "ref");
+  const element = readStringParam(params, "element");
+  const labels = typeof params.labels === "boolean" ? params.labels : undefined;
+  const type = params.type === "jpeg" ? "jpeg" : "png";
+  const effectiveTimeoutMs = requestedTimeoutMs ?? DEFAULT_BROWSER_SCREENSHOT_TIMEOUT_MS;
+  const result = proxyRequest
+    ? ((await proxyRequest({
+        method: "POST",
+        path: "/screenshot",
+        profile,
+        timeoutMs: effectiveTimeoutMs,
+        body: {
+          targetId,
+          fullPage,
+          ref,
+          element,
+          type,
+          labels,
+          timeoutMs: effectiveTimeoutMs,
+        },
+        // SAFETY: The browser proxy preserves the /screenshot response contract used by the local client.
+      })) as Awaited<ReturnType<typeof browserScreenshotAction>>)
+    : await browserScreenshotAction(baseUrl, {
+        targetId,
+        fullPage,
+        ref,
+        element,
+        type,
+        labels,
+        timeoutMs: effectiveTimeoutMs,
+        profile,
+        signal,
+      });
+  onTabActivity(readStringValue(result.targetId) ?? targetId);
+  if (opts?.screenshotResultMode === "path") {
+    const artifactPath = opts.persistScreenshot
+      ? await opts.persistScreenshot({
+          sourcePath: result.path,
+          type,
+          targetId: readStringValue(result.targetId) ?? targetId,
+        })
+      : result.path;
+    if (artifactPath.length > 4_096) {
+      throw new Error("Browser screenshot artifact path exceeds 4096 characters");
+    }
+    // SAFETY: Screenshot responses are records; optional fields are narrowed before use.
+    const resultRecord = result as Record<string, unknown>;
+    const resultTargetId = readStringValue(resultRecord.targetId) ?? targetId;
+    const resultUrl = readStringValue(resultRecord.url);
+    return jsonResult({
+      ok: resultRecord.ok === true,
+      path: artifactPath,
+      ...(resultTargetId ? { targetId: truncateUtf16Safe(resultTargetId, 256) } : {}),
+      ...(resultUrl ? { url: truncateUtf16Safe(resultUrl, 2_048) } : {}),
+      ...(Array.isArray(resultRecord.annotations)
+        ? { annotationCount: resultRecord.annotations.length }
+        : {}),
+      media: { outbound: false },
+    });
+  }
+  const screenshotPath = result.path;
+  const screenshotCfg = getRuntimeConfig();
+  const imageSanitization = resolveRuntimeImageSanitization();
+  let shareHint = SCREENSHOT_SHARE_UNAVAILABLE;
+  try {
+    // The original result remains private. Only this bounded outbound
+    // copy may cross the sandbox boundary after an explicit message call.
+    const sharePath = await stageBrowserScreenshotForSharing(
+      screenshotPath,
+      imageSanitization?.maxDimensionPx,
+    );
+    shareHint = formatScreenshotShareHint(sharePath);
+  } catch {
+    // Screenshot viewing remains useful when optional outbound staging fails.
+  }
+  // Screenshots stay in the tool result for agent vision, but channel
+  // delivery must remain an explicit outbound-delivery action.
+  const screenshotDetails = {
+    // SAFETY: Preserve the screenshot response fields without changing their types or values.
+    ...(result as Record<string, unknown>),
+    media: { outbound: false },
+  };
+  try {
+    const described = await describeBrowserScreenshot(
+      {
+        cfg: screenshotCfg,
+        filePath: screenshotPath,
+        agentDir: opts?.agentDir,
+        agentId: opts?.agentId,
+        workspaceDir: opts?.workspaceDir,
+        activeModel: opts?.activeModel,
+        mediaScope: opts?.mediaScope,
+        imageSanitization,
+      },
+      {
+        describeImageFile,
+        normalizeBrowserScreenshot,
+        saveMediaBuffer,
+      },
+    );
+    if (described) {
+      const analyzedBy =
+        described.provider && described.model
+          ? `${described.provider}/${described.model}`
+          : "media image understanding";
+      const headerLines = [`[analyzed by ${analyzedBy}]`];
+      // Vision model descriptions contain web page content which is
+      // untrusted external input — wrap it the same way snapshot and
+      // tabs results are wrapped to mitigate prompt injection.
+      const wrappedDescription = wrapExternalContent(
+        neutralizeMediaDirectives(described.text.trim()),
+        {
+          source: "browser",
+          includeWarning: true,
+        },
+      );
+      const text = `${headerLines.join("\n")}\n${wrappedDescription}\n${shareHint}`;
+      return {
+        content: [{ type: "text", text }],
+        details: {
+          // SAFETY: Preserve the screenshot response fields without changing their types or values.
+          ...(result as Record<string, unknown>),
+          // Do NOT include details.media here — the vision path returns
+          // a text description as the deliverable output. Exposing the raw
+          // screenshot as media would cause channel delivery to auto-send
+          // potentially sensitive page content. The text block carries the
+          // staged outbound-copy path for an explicit outbound-delivery send.
+          vision: {
+            provider: described.provider,
+            model: described.model,
+            decision: described.decision,
+          },
+        },
+      };
+    }
+  } catch (err) {
+    // Fall back to returning the raw image block so the agent loop can
+    // still recover. Provider/runtime errors are untrusted page input;
+    // preserve their trust boundary and defang reply-media directives.
+    const rawReason = err instanceof Error ? err.message : String(err);
+    const reason = wrapExternalContent(neutralizeMediaDirectives(rawReason), {
+      source: "browser",
+      includeWarning: false,
+    });
+    const extraText = `[browser screenshot vision failed: ${reason}]\n${shareHint}`;
+    return await imageResultFromFile({
+      label: "browser:screenshot",
+      path: screenshotPath,
+      extraText,
+      details: screenshotDetails,
+      imageSanitization,
+    });
+  }
+  return await imageResultFromFile({
+    label: "browser:screenshot",
+    path: screenshotPath,
+    extraText: shareHint,
+    details: screenshotDetails,
+    imageSanitization,
+  });
+}

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -11,7 +11,6 @@ import {
   createBrowserNodeProxyRequest,
   createBrowserNodeSessionTabRoute,
 } from "./browser-node-proxy.js";
-import { resolveBrowserNodeTarget } from "./browser-node-routing.js";
 import { applyBrowserTabToolBinding, parseBrowserTabToolBinding } from "./browser-tool-binding.js";
 import { describeBrowserTool } from "./browser-tool-description.js";
 import {
@@ -29,6 +28,13 @@ import {
   executeTabsAction,
   formatBrowserExternalToolResult,
 } from "./browser-tool.actions.js";
+import { executeBrowserLifecycleAction } from "./browser-tool.lifecycle.js";
+import {
+  resolveBrowserBaseUrl,
+  resolveBrowserToolNodeTarget,
+  resolveBrowserToolTimeoutMs,
+  type BrowserNodeTarget,
+} from "./browser-tool.routing.js";
 import {
   type AnyAgentTool,
   BrowserToolOutputSchema,
@@ -39,75 +45,31 @@ import {
   browserArmDialog,
   browserArmFileChooser,
   browserCloseTab,
-  browserDoctor,
   browserFocusTab,
-  browserImportProfile,
   browserNavigate,
   browserOpenTab,
   browserPdfSave,
-  browserProfiles,
-  browserSystemProfiles,
-  browserScreenshotAction,
-  browserStart,
-  browserStatus,
-  browserStop,
-  describeImageFile,
   getRuntimeConfig,
   getBrowserProfileCapabilities,
-  imageResultFromFile,
   jsonResult,
-  listNodes,
   normalizeOptionalString,
   readPositiveIntegerParam,
   readStringParam,
   readStringValue,
   resolveBrowserConfig,
   resolveExistingUploadPaths,
-  resolveRuntimeImageSanitization,
   resolveProfile,
-  saveMediaBuffer,
-  stageBrowserScreenshotForSharing,
   touchSessionBrowserTab,
   trackSessionBrowserTab,
   untrackSessionBrowserTab,
 } from "./browser-tool.runtime.js";
+import {
+  executeScreenshotAction,
+  type BrowserScreenshotOptions,
+} from "./browser-tool.screenshot.js";
 import { appendNavigatedPageState, executeSnapshotAction } from "./browser-tool.snapshot.js";
 import { resolveBrowserNavigationTimeoutMs } from "./browser/act-policy.js";
-import { DEFAULT_BROWSER_SCREENSHOT_TIMEOUT_MS } from "./browser/constants.js";
 import { parseBrowserNavigationUrl } from "./browser/navigation-guard.js";
-import { normalizeBrowserScreenshot } from "./browser/screenshot.js";
-import { parseSystemProfileDomains } from "./browser/system-profile-domains.js";
-import { describeBrowserScreenshot, neutralizeMediaDirectives } from "./browser/vision.js";
-import { wrapExternalContent } from "./sdk-security-runtime.js";
-
-const browserToolDeps = {
-  browserAct,
-  browserArmDialog,
-  browserArmFileChooser,
-  browserCloseTab,
-  browserDoctor,
-  browserFocusTab,
-  browserImportProfile,
-  browserNavigate,
-  browserOpenTab,
-  browserPdfSave,
-  browserProfiles,
-  browserSystemProfiles,
-  browserScreenshotAction,
-  browserStart,
-  browserStatus,
-  browserStop,
-  describeImageFile,
-  getRuntimeConfig,
-  imageResultFromFile,
-  listNodes,
-  normalizeBrowserScreenshot,
-  saveMediaBuffer,
-  stageBrowserScreenshotForSharing,
-  touchSessionBrowserTab,
-  trackSessionBrowserTab,
-  untrackSessionBrowserTab,
-};
 
 function withBrowserTabDetails(
   result: AgentToolResult<unknown>,
@@ -163,13 +125,6 @@ function readTargetUrlParam(params: Record<string, unknown>) {
   parseBrowserNavigationUrl(targetUrl);
   return targetUrl;
 }
-
-function formatScreenshotShareHint(filePath: string): string {
-  return `[Screenshot saved to ${JSON.stringify(filePath)}. A sanitized outbound copy is ready at this path for explicit sharing.]`;
-}
-
-const SCREENSHOT_SHARE_UNAVAILABLE =
-  "[Screenshot sharing is unavailable because an outbound copy could not be prepared.]";
 
 const LEGACY_BROWSER_ACT_REQUEST_KEYS = [
   "kind",
@@ -244,160 +199,6 @@ function readActRequestParam(params: Record<string, unknown>) {
   return request as Parameters<typeof browserAct>[1];
 }
 
-type BrowserNodeTarget = {
-  nodeId: string;
-  label?: string;
-  commands: string[];
-  pendingDeclaredCommands: string[];
-};
-
-async function resolveBrowserToolNodeTarget(params: {
-  requestedNode?: string;
-  target?: "sandbox" | "host" | "node";
-  sandboxBridgeUrl?: string;
-  allowHostControl?: boolean;
-  signal?: AbortSignal;
-}): Promise<BrowserNodeTarget | null> {
-  if (params.allowHostControl === false) {
-    if (params.target === "node" || params.requestedNode) {
-      throw new Error("Node browser control is disabled by sandbox policy.");
-    }
-    return null;
-  }
-
-  const cfg = browserToolDeps.getRuntimeConfig();
-  const policy = cfg.gateway?.nodes?.browser;
-  const explicitTarget = params.target === "node";
-  const requestedNode = params.requestedNode?.trim();
-  if (policy?.mode === "off") {
-    resolveBrowserNodeTarget({ nodes: [], policy, requestedNode, explicitTarget });
-    return null;
-  }
-  if (params.sandboxBridgeUrl?.trim() && !explicitTarget && !requestedNode) {
-    return null;
-  }
-  if (params.target && !explicitTarget) {
-    return null;
-  }
-  if (policy?.mode === "manual" && !explicitTarget && !requestedNode && !policy.node?.trim()) {
-    return null;
-  }
-  const node = resolveBrowserNodeTarget({
-    nodes: await browserToolDeps.listNodes({}, params.signal),
-    policy,
-    requestedNode,
-    explicitTarget,
-    requireConnected: true,
-  });
-  return node
-    ? {
-        nodeId: node.nodeId,
-        label: node.displayName ?? node.remoteIp ?? node.nodeId,
-        commands: node.commands ?? [],
-        pendingDeclaredCommands: node.pendingDeclaredCommands ?? [],
-      }
-    : null;
-}
-
-function resolveBrowserBaseUrl(params: {
-  target?: "sandbox" | "host";
-  sandboxBridgeUrl?: string;
-  allowHostControl?: boolean;
-}): string | undefined {
-  const cfg = getRuntimeConfig();
-  const resolved = resolveBrowserConfig(cfg.browser, cfg);
-  const normalizedSandbox = params.sandboxBridgeUrl?.trim() ?? "";
-  const target = params.target ?? (normalizedSandbox ? "sandbox" : "host");
-
-  if (target === "sandbox") {
-    if (!normalizedSandbox) {
-      throw new Error(
-        'Sandbox browser is unavailable. Enable agents.defaults.sandbox.browser.enabled or use target="host" if allowed.',
-      );
-    }
-    return normalizedSandbox.replace(/\/$/, "");
-  }
-
-  if (params.allowHostControl === false) {
-    throw new Error("Host browser control is disabled by sandbox policy.");
-  }
-  if (!resolved.enabled) {
-    throw new Error(
-      "Browser control is disabled. Set browser.enabled=true in ~/.openclaw/openclaw.json.",
-    );
-  }
-  return undefined;
-}
-
-const unavailableSystemProfiles = (unavailableReason: string) => ({
-  profiles: [],
-  unavailableReason,
-});
-
-/**
- * Read importable system profiles from the host control server. Discovery must
- * match where import runs (host-local), so it never uses a node proxy or the
- * sandbox base URL. Other profile sources remain useful when host discovery
- * is unavailable, so failures become an explicit degradation fact.
- */
-async function readHostSystemProfiles(params: {
-  allowHostControl?: boolean;
-  sandboxBridgeUrl?: string;
-  timeoutMs?: number;
-  signal?: AbortSignal;
-}) {
-  if (params.allowHostControl === false) {
-    return unavailableSystemProfiles(
-      "Host system profile discovery is disabled by sandbox policy; enable host control to discover importable system profiles.",
-    );
-  }
-  let hostBaseUrl: string | undefined;
-  try {
-    hostBaseUrl = resolveBrowserBaseUrl({
-      target: "host",
-      sandboxBridgeUrl: params.sandboxBridgeUrl,
-      allowHostControl: params.allowHostControl,
-    });
-  } catch {
-    return unavailableSystemProfiles(
-      'Host browser control is unavailable; enable it and retry action=profiles target="host".',
-    );
-  }
-  try {
-    return {
-      profiles: await browserToolDeps.browserSystemProfiles(hostBaseUrl, {
-        timeoutMs: params.timeoutMs,
-        signal: params.signal,
-      }),
-      unavailableReason: undefined,
-    };
-  } catch {
-    params.signal?.throwIfAborted();
-    return unavailableSystemProfiles(
-      'Host system profile discovery failed; retry action=profiles target="host" after host browser control is available.',
-    );
-  }
-}
-
-const DEFAULT_EXISTING_SESSION_MANAGE_TIMEOUT_MS = 45_000;
-const EXISTING_SESSION_MANAGE_ACTIONS = new Set([
-  "status",
-  "start",
-  "stop",
-  "profiles",
-  "tabs",
-  "open",
-  "focus",
-  "close",
-]);
-
-function hasExistingSessionProfile(resolved: ReturnType<typeof resolveBrowserConfig>) {
-  return Object.keys(resolved.profiles).some((name) => {
-    const candidate = resolveProfile(resolved, name);
-    return candidate ? getBrowserProfileCapabilities(candidate).usesChromeMcp : false;
-  });
-}
-
 function readToolTimeoutMs(params: Record<string, unknown>) {
   return readPositiveIntegerParam(params, "timeoutMs", {
     message: "timeoutMs must be a positive integer.",
@@ -405,31 +206,15 @@ function readToolTimeoutMs(params: Record<string, unknown>) {
 }
 
 /** Create the Browser tool exposed to agents. */
-export function createBrowserTool(opts?: {
-  sandboxBridgeUrl?: string;
-  allowHostControl?: boolean;
-  agentSessionKey?: string;
-  agentId?: string;
-  agentDir?: string;
-  workspaceDir?: string;
-  activeModel?: {
-    provider?: string;
-    model?: string;
-  };
-  screenshotResultMode?: "image" | "path";
-  persistScreenshot?: (params: {
-    sourcePath: string;
-    type: "png" | "jpeg";
-    targetId?: string;
-  }) => Promise<string>;
-  mediaScope?: {
-    sessionKey?: string;
-    channel?: string;
-    chatType?: string;
-  };
-  runToolBinding?: unknown;
-  toolCapabilities?: BrowserToolCapabilities;
-}): AnyAgentTool {
+export function createBrowserTool(
+  opts?: BrowserScreenshotOptions & {
+    sandboxBridgeUrl?: string;
+    allowHostControl?: boolean;
+    agentSessionKey?: string;
+    runToolBinding?: unknown;
+    toolCapabilities?: BrowserToolCapabilities;
+  },
+): AnyAgentTool {
   const bindingResult =
     opts?.runToolBinding === undefined
       ? undefined
@@ -440,7 +225,7 @@ export function createBrowserTool(opts?: {
   const capabilities =
     opts?.toolCapabilities ??
     (() => {
-      const config = browserToolDeps.getRuntimeConfig();
+      const config = getRuntimeConfig();
       const boundProfile =
         bindingResult?.ok && bindingResult.binding.target === "host"
           ? resolveProfile(
@@ -480,7 +265,7 @@ export function createBrowserTool(opts?: {
       const requestedNode = readStringParam(params, "node");
       const requestedTimeoutMs = readToolTimeoutMs(params);
       let target = readStringParam(params, "target") as "sandbox" | "host" | "node" | undefined;
-      const runtimeConfig = browserToolDeps.getRuntimeConfig();
+      const runtimeConfig = getRuntimeConfig();
       const resolvedBrowser = resolveBrowserConfig(runtimeConfig.browser, runtimeConfig);
       const effectiveProfile = requestedProfile ?? resolvedBrowser.defaultProfile;
       const resolvedProfile = resolveProfile(resolvedBrowser, effectiveProfile);
@@ -571,13 +356,12 @@ export function createBrowserTool(opts?: {
         );
       }
       const nodeRoute = nodeTarget ? createBrowserNodeSessionTabRoute(nodeTarget) : undefined;
-      const toolTimeoutMs =
-        requestedTimeoutMs ??
-        (EXISTING_SESSION_MANAGE_ACTIONS.has(action) &&
-        (isUserBrowserProfile ||
-          (action === "profiles" && hasExistingSessionProfile(resolvedBrowser)))
-          ? DEFAULT_EXISTING_SESSION_MANAGE_TIMEOUT_MS
-          : undefined);
+      const toolTimeoutMs = resolveBrowserToolTimeoutMs({
+        requestedTimeoutMs,
+        action,
+        isUserBrowserProfile,
+        resolvedBrowser,
+      });
       const sessionTabs = createBrowserToolSessionTabs({
         sessionKey: opts?.agentSessionKey,
         requestedProfile: profile,
@@ -589,21 +373,8 @@ export function createBrowserTool(opts?: {
           return route?.status === "resolved" ? route.profile : undefined;
         },
         isHostFallbackActive: proxyRequest?.isHostFallbackActive,
-        registry: browserToolDeps,
+        registry: { touchSessionBrowserTab, trackSessionBrowserTab, untrackSessionBrowserTab },
       });
-      const readBrowserStatus = async () =>
-        proxyRequest
-          ? await proxyRequest({
-              method: "GET",
-              path: "/",
-              profile,
-              timeoutMs: toolTimeoutMs,
-            })
-          : await browserToolDeps.browserStatus(baseUrl, {
-              profile,
-              timeoutMs: toolTimeoutMs,
-              signal,
-            });
       const executeTrackedTabRequest = async (
         path: string,
         body: Record<string, unknown>,
@@ -621,76 +392,22 @@ export function createBrowserTool(opts?: {
 
       switch (action) {
         case "doctor":
-          return jsonResult(
-            proxyRequest
-              ? await proxyRequest({ method: "GET", path: "/doctor", profile })
-              : await browserToolDeps.browserDoctor(baseUrl, { profile, signal }),
-          );
         case "status":
-          return jsonResult(await readBrowserStatus());
         case "start":
-        case "stop": {
-          if (proxyRequest) {
-            await proxyRequest({
-              method: "POST",
-              path: `/${action}`,
-              profile,
-              timeoutMs: toolTimeoutMs,
-            });
-          } else {
-            const updateBrowser =
-              action === "start" ? browserToolDeps.browserStart : browserToolDeps.browserStop;
-            await updateBrowser(baseUrl, { profile, timeoutMs: toolTimeoutMs, signal });
-          }
-          return jsonResult(await readBrowserStatus());
-        }
-        case "profiles": {
-          // Importable system profiles are host-local (import runs on the host),
-          // so read them from the host regardless of the profiles action target;
-          // never let a node proxy or sandbox describe the wrong Chrome profiles.
-          const { profiles: systemProfiles, unavailableReason: systemProfilesUnavailable } =
-            await readHostSystemProfiles({
-              allowHostControl: opts?.allowHostControl,
-              sandboxBridgeUrl: opts?.sandboxBridgeUrl,
-              timeoutMs: toolTimeoutMs,
-              signal,
-            });
-          if (proxyRequest) {
-            const result = await proxyRequest({
-              method: "GET",
-              path: "/profiles",
-              timeoutMs: toolTimeoutMs,
-            });
-            return jsonResult({
-              ...(result && typeof result === "object" ? result : { profiles: result }),
-              systemProfiles,
-              ...(systemProfilesUnavailable ? { systemProfilesUnavailable } : {}),
-            });
-          }
-          return jsonResult({
-            profiles: await browserToolDeps.browserProfiles(baseUrl, {
-              timeoutMs: toolTimeoutMs,
-              signal,
-            }),
-            systemProfiles,
-            ...(systemProfilesUnavailable ? { systemProfilesUnavailable } : {}),
+        case "stop":
+        case "profiles":
+        case "importprofile":
+          return await executeBrowserLifecycleAction({
+            action,
+            input: params,
+            baseUrl,
+            profile,
+            timeoutMs: toolTimeoutMs,
+            proxyRequest,
+            allowHostControl: opts?.allowHostControl,
+            sandboxBridgeUrl: opts?.sandboxBridgeUrl,
+            signal,
           });
-        }
-        case "importprofile": {
-          if (proxyRequest) {
-            throw new Error("system profile import must run on the browser host");
-          }
-          const domains = parseSystemProfileDomains(params.domains);
-          return jsonResult(
-            await browserToolDeps.browserImportProfile(baseUrl, {
-              browser: normalizeOptionalString(params.browser) ?? "chrome",
-              systemProfile: normalizeOptionalString(params.systemProfile) ?? "Default",
-              into: normalizeOptionalString(params.into) ?? "imported",
-              domains,
-              signal,
-            }),
-          );
-        }
         case "tabs":
           return await executeTabsAction({
             baseUrl,
@@ -711,7 +428,7 @@ export function createBrowserTool(opts?: {
                 body: { url: targetUrl, ...(label ? { label } : {}) },
                 timeoutMs: toolTimeoutMs,
               })
-            : await browserToolDeps.browserOpenTab(baseUrl, targetUrl, {
+            : await browserOpenTab(baseUrl, targetUrl, {
                 profile,
                 label,
                 timeoutMs: toolTimeoutMs,
@@ -722,7 +439,7 @@ export function createBrowserTool(opts?: {
               await nodeRoute.closeTarget({ targetId, profile: openedProfile });
               return;
             }
-            await browserToolDeps.browserCloseTab(baseUrl, targetId, {
+            await browserCloseTab(baseUrl, targetId, {
               profile: openedProfile,
               timeoutMs: toolTimeoutMs,
             });
@@ -745,7 +462,7 @@ export function createBrowserTool(opts?: {
                 body: { targetId },
                 timeoutMs: toolTimeoutMs,
               })
-            : await browserToolDeps.browserFocusTab(baseUrl, targetId, {
+            : await browserFocusTab(baseUrl, targetId, {
                 profile,
                 timeoutMs: toolTimeoutMs,
                 signal,
@@ -778,12 +495,12 @@ export function createBrowserTool(opts?: {
             return jsonResult(result);
           }
           const result = targetId
-            ? await browserToolDeps.browserCloseTab(baseUrl, targetId, {
+            ? await browserCloseTab(baseUrl, targetId, {
                 profile,
                 timeoutMs: toolTimeoutMs,
                 signal,
               })
-            : await browserToolDeps.browserAct(
+            : await browserAct(
                 baseUrl,
                 { kind: "close" },
                 {
@@ -804,166 +521,17 @@ export function createBrowserTool(opts?: {
             signal,
             onTabActivity: sessionTabs.touch,
           });
-        case "screenshot": {
-          const targetId = readStringParam(params, "targetId");
-          const fullPage = Boolean(params.fullPage);
-          const ref = readStringParam(params, "ref");
-          const element = readStringParam(params, "element");
-          const labels = typeof params.labels === "boolean" ? params.labels : undefined;
-          const type = params.type === "jpeg" ? "jpeg" : "png";
-          const effectiveTimeoutMs = requestedTimeoutMs ?? DEFAULT_BROWSER_SCREENSHOT_TIMEOUT_MS;
-          const result = proxyRequest
-            ? ((await proxyRequest({
-                method: "POST",
-                path: "/screenshot",
-                profile,
-                timeoutMs: effectiveTimeoutMs,
-                body: {
-                  targetId,
-                  fullPage,
-                  ref,
-                  element,
-                  type,
-                  labels,
-                  timeoutMs: effectiveTimeoutMs,
-                },
-              })) as Awaited<ReturnType<typeof browserScreenshotAction>>)
-            : await browserToolDeps.browserScreenshotAction(baseUrl, {
-                targetId,
-                fullPage,
-                ref,
-                element,
-                type,
-                labels,
-                timeoutMs: effectiveTimeoutMs,
-                profile,
-                signal,
-              });
-          sessionTabs.touch(readStringValue(result.targetId) ?? targetId);
-          if (opts?.screenshotResultMode === "path") {
-            const artifactPath = opts.persistScreenshot
-              ? await opts.persistScreenshot({
-                  sourcePath: result.path,
-                  type,
-                  targetId: readStringValue(result.targetId) ?? targetId,
-                })
-              : result.path;
-            if (artifactPath.length > 4_096) {
-              throw new Error("Browser screenshot artifact path exceeds 4096 characters");
-            }
-            const resultRecord = result as Record<string, unknown>;
-            const resultTargetId = readStringValue(resultRecord.targetId) ?? targetId;
-            const resultUrl = readStringValue(resultRecord.url);
-            return jsonResult({
-              ok: resultRecord.ok === true,
-              path: artifactPath,
-              ...(resultTargetId ? { targetId: truncateUtf16Safe(resultTargetId, 256) } : {}),
-              ...(resultUrl ? { url: truncateUtf16Safe(resultUrl, 2_048) } : {}),
-              ...(Array.isArray(resultRecord.annotations)
-                ? { annotationCount: resultRecord.annotations.length }
-                : {}),
-              media: { outbound: false },
-            });
-          }
-          const screenshotPath = result.path;
-          const screenshotCfg = browserToolDeps.getRuntimeConfig();
-          const imageSanitization = resolveRuntimeImageSanitization();
-          let shareHint = SCREENSHOT_SHARE_UNAVAILABLE;
-          try {
-            // The original result remains private. Only this bounded outbound
-            // copy may cross the sandbox boundary after an explicit message call.
-            const sharePath = await browserToolDeps.stageBrowserScreenshotForSharing(
-              screenshotPath,
-              imageSanitization?.maxDimensionPx,
-            );
-            shareHint = formatScreenshotShareHint(sharePath);
-          } catch {
-            // Screenshot viewing remains useful when optional outbound staging fails.
-          }
-          // Screenshots stay in the tool result for agent vision, but channel
-          // delivery must remain an explicit outbound-delivery action.
-          const screenshotDetails = {
-            ...(result as Record<string, unknown>),
-            media: { outbound: false },
-          };
-          try {
-            const described = await describeBrowserScreenshot(
-              {
-                cfg: screenshotCfg,
-                filePath: screenshotPath,
-                agentDir: opts?.agentDir,
-                agentId: opts?.agentId,
-                workspaceDir: opts?.workspaceDir,
-                activeModel: opts?.activeModel,
-                mediaScope: opts?.mediaScope,
-                imageSanitization,
-              },
-              {
-                describeImageFile: browserToolDeps.describeImageFile,
-                normalizeBrowserScreenshot: browserToolDeps.normalizeBrowserScreenshot,
-                saveMediaBuffer: browserToolDeps.saveMediaBuffer,
-              },
-            );
-            if (described) {
-              const analyzedBy =
-                described.provider && described.model
-                  ? `${described.provider}/${described.model}`
-                  : "media image understanding";
-              const headerLines = [`[analyzed by ${analyzedBy}]`];
-              // Vision model descriptions contain web page content which is
-              // untrusted external input — wrap it the same way snapshot and
-              // tabs results are wrapped to mitigate prompt injection.
-              const wrappedDescription = wrapExternalContent(
-                neutralizeMediaDirectives(described.text.trim()),
-                {
-                  source: "browser",
-                  includeWarning: true,
-                },
-              );
-              const text = `${headerLines.join("\n")}\n${wrappedDescription}\n${shareHint}`;
-              return {
-                content: [{ type: "text", text }],
-                details: {
-                  ...(result as Record<string, unknown>),
-                  // Do NOT include details.media here — the vision path returns
-                  // a text description as the deliverable output. Exposing the raw
-                  // screenshot as media would cause channel delivery to auto-send
-                  // potentially sensitive page content. The text block carries the
-                  // staged outbound-copy path for an explicit outbound-delivery send.
-                  vision: {
-                    provider: described.provider,
-                    model: described.model,
-                    decision: described.decision,
-                  },
-                },
-              };
-            }
-          } catch (err) {
-            // Fall back to returning the raw image block so the agent loop can
-            // still recover. Provider/runtime errors are untrusted page input;
-            // preserve their trust boundary and defang reply-media directives.
-            const rawReason = err instanceof Error ? err.message : String(err);
-            const reason = wrapExternalContent(neutralizeMediaDirectives(rawReason), {
-              source: "browser",
-              includeWarning: false,
-            });
-            const extraText = `[browser screenshot vision failed: ${reason}]\n${shareHint}`;
-            return await browserToolDeps.imageResultFromFile({
-              label: "browser:screenshot",
-              path: screenshotPath,
-              extraText,
-              details: screenshotDetails,
-              imageSanitization,
-            });
-          }
-          return await browserToolDeps.imageResultFromFile({
-            label: "browser:screenshot",
-            path: screenshotPath,
-            extraText: shareHint,
-            details: screenshotDetails,
-            imageSanitization,
+        case "screenshot":
+          return await executeScreenshotAction({
+            input: params,
+            baseUrl,
+            profile,
+            requestedTimeoutMs,
+            proxyRequest,
+            signal,
+            onTabActivity: sessionTabs.touch,
+            opts,
           });
-        }
         case "navigate": {
           const targetUrl = readTargetUrlParam(params);
           const targetId = readStringParam(params, "targetId");
@@ -983,7 +551,7 @@ export function createBrowserTool(opts?: {
                 },
                 timeoutMs,
               })
-            : await browserToolDeps.browserNavigate(baseUrl, {
+            : await browserNavigate(baseUrl, {
                 url: targetUrl,
                 targetId,
                 timeoutMs,
@@ -1052,7 +620,7 @@ export function createBrowserTool(opts?: {
                 profile,
                 body: { targetId },
               })) as Awaited<ReturnType<typeof browserPdfSave>>)
-            : await browserToolDeps.browserPdfSave(baseUrl, { targetId, profile, signal });
+            : await browserPdfSave(baseUrl, { targetId, profile, signal });
           sessionTabs.touch(readStringValue(result.targetId) ?? targetId);
           return {
             content: [{ type: "text" as const, text: `FILE:${result.path}` }],
@@ -1095,8 +663,7 @@ export function createBrowserTool(opts?: {
           return await executeTrackedTabRequest(
             "/hooks/file-chooser",
             request,
-            async () =>
-              await browserToolDeps.browserArmFileChooser(baseUrl, { ...request, profile, signal }),
+            async () => await browserArmFileChooser(baseUrl, { ...request, profile, signal }),
           );
         }
         case "dialog": {
@@ -1108,8 +675,7 @@ export function createBrowserTool(opts?: {
           return await executeTrackedTabRequest(
             "/hooks/dialog",
             request,
-            async () =>
-              await browserToolDeps.browserArmDialog(baseUrl, { ...request, profile, signal }),
+            async () => await browserArmDialog(baseUrl, { ...request, profile, signal }),
           );
         }
         case "act": {
@@ -1167,4 +733,3 @@ export function createBrowserTool(opts?: {
     },
   };
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

`extensions/browser/src/browser-tool.ts` was a grandfathered oversized module carrying `/* oxlint-disable max-lines */` with a TODO to split it. Repo policy treats those suppressions as debt: split the file, remove the suppression and its baseline entry.

## Why This Change Was Made

Behavior-neutral extraction along the module's real seams, following the existing `browser-tool.actions.ts`/`browser-tool.snapshot.ts` pattern:

- `browser-tool.routing.ts` — host/sandbox/node target resolution, existing-session management-timeout selection
- `browser-tool.lifecycle.ts` — doctor/status/start/stop/profiles/importprofile and host-only profile discovery
- `browser-tool.screenshot.ts` — screenshot capture, path-mode output, vision/image results, outbound-sharing hints
- `browser-tool.ts` keeps tool assembly, capabilities/binding, per-call orchestration, and the browserTab result wrapper

No schema, action, output, cancellation, session-tab, or package-export changes; the runtime barrel (`browser-tool.runtime.ts`) is untouched so existing test mocking seams keep working; no tests modified. The `max-lines` suppression and its `config/max-lines-baseline.txt` entry are deleted (886 grandfathered entries remain repo-wide); the assertion-safety baseline shrinks 18→14 for this file with the four moved screenshot assertions carrying precise SAFETY comments. Shrink-only ratchet maintenance, no new or relocated suppressions.

## User Impact

None at runtime — maintainability refactor completing the TODO the browser-tool work kept bumping into.

## Evidence

- Full `extensions/browser` suite green on the rebased head (197 files / 2,976 tests; the intermittent native-host launcher test passes on an uncontended host and its flakiness is a named follow-up: retain `error.code`/`signal` in that assertion's diagnostics).
- `node scripts/check-changed.mjs` over the six changed paths: green (typecheck, lint, ratchets, zero runtime import cycles).
- Full `pnpm build` clean with the moved module boundaries; no `[INEFFECTIVE_DYNAMIC_IMPORT]`.
- TypeScript syntax-tree token comparison of all 24 moved action case bodies and four moved helpers against the originals (formatting/comment-normalized): identical.
- Codex autoreview on the split: clean, no accepted findings.

LOC: production +601/−496 (net +105 — extraction signatures, imports, and wiring; logic moved, not rewritten), tests 0, ratchet config net −1.
