### PR TITLE
fix(daemon): preserve recovery after Startup entry removal

### DIFF
--- a/src/cli/daemon-cli/shared.test.ts
+++ b/src/cli/daemon-cli/shared.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
 import {
   filterContainerGenericHints,
-  parsePortFromArgs,
   renderRuntimeHints,
   renderGatewayServiceStartHints,
   resolveRuntimeStatusColor,
@@ -19,17 +18,6 @@ describe("resolveRuntimeStatusColor", () => {
   it("falls back to warning color for unexpected states", () => {
     expect(resolveRuntimeStatusColor("degraded")).toBe(theme.warn);
     expect(resolveRuntimeStatusColor(undefined)).toBe(theme.muted);
-  });
-});
-
-describe("parsePortFromArgs", () => {
-  it("rejects inline port values with trailing equals-separated text", () => {
-    expect(parsePortFromArgs(["--port=123=bad"])).toBeNull();
-  });
-
-  it("accepts valid inline and space-separated port values", () => {
-    expect(parsePortFromArgs(["--port=14720"])).toBe(14_720);
-    expect(parsePortFromArgs(["--port", "14721"])).toBe(14_721);
   });
 });
 

--- a/src/cli/daemon-cli/shared.ts
+++ b/src/cli/daemon-cli/shared.ts
@@ -71,11 +71,6 @@ export function resolveRuntimeStatusColor(status: string | undefined): (value: s
         : theme.warn;
 }
 
-/** Extract `--port` from service ProgramArguments. */
-export function parsePortFromArgs(programArguments: string[] | undefined): number | null {
-  return parseTcpPortFromArgs(programArguments);
-}
-
 /** Pick the best local probe host for a configured Gateway bind mode. */
 export function pickProbeHostForBind(
   bindMode: string,
@@ -88,12 +83,9 @@ export function pickProbeHostForBind(
   if (bindMode === "tailnet") {
     return tailnetIPv4 ?? "127.0.0.1";
   }
-  if (bindMode === "lan") {
-    // Same as call.ts: self-connections should always target loopback.
-    // bind=lan controls which interfaces the server listens on (0.0.0.0),
-    // but co-located CLI probes should connect via 127.0.0.1.
-    return "127.0.0.1";
-  }
+  // Same as call.ts: self-connections should always target loopback.
+  // bind=lan controls which interfaces the server listens on (0.0.0.0),
+  // but co-located CLI probes should connect via 127.0.0.1.
   return "127.0.0.1";
 }
 
@@ -255,7 +247,7 @@ export async function resolveGatewayLifecycleContext(
   })
     .readBestEffortConfig()
     .catch(() => undefined);
-  const port = parsePortFromArgs(command?.programArguments) ?? resolveGatewayPort(config, env);
+  const port = parseTcpPortFromArgs(command?.programArguments) ?? resolveGatewayPort(config, env);
   return { port, env, command };
 }
 

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -56,6 +56,7 @@ import {
   readGatewayRestartHandoffSync,
   type GatewayRestartHandoff,
 } from "../../infra/restart-handoff.js";
+import { parseTcpPortFromArgs } from "../../infra/tcp-port.js";
 import {
   inspectWindowsGatewayFirewall,
   type WindowsGatewayFirewallDiagnostic,
@@ -70,7 +71,7 @@ import { createLazyPromise } from "../../shared/lazy-promise.js";
 import { VERSION } from "../../version.js";
 import { resolveGatewayLocalPortOverride } from "../gateway-port-option.js";
 import { parseTimeoutMsWithFallback } from "../parse-timeout.js";
-import { normalizeListenerAddress, parsePortFromArgs, pickProbeHostForBind } from "./shared.js";
+import { normalizeListenerAddress, pickProbeHostForBind } from "./shared.js";
 import type { GatewayRpcOpts } from "./types.js";
 
 type ConfigSummary = {
@@ -404,7 +405,7 @@ async function resolveGatewayStatusSummary(params: {
   rpcUrlOverride?: string;
   localPortOverride?: number;
 }): Promise<ResolvedGatewayStatus> {
-  const portFromArgs = parsePortFromArgs(params.commandProgramArguments);
+  const portFromArgs = parseTcpPortFromArgs(params.commandProgramArguments);
   const daemonPort =
     params.localPortOverride ??
     portFromArgs ??

--- a/src/cli/update-cli/update-command-lease.test.ts
+++ b/src/cli/update-cli/update-command-lease.test.ts
@@ -179,10 +179,17 @@ function expectSuccess(lane: Lane): void {
 
 describe("update orchestration lifecycle ownership", () => {
   it.each(["resume", "current-process", "repair"] as const)(
-    "%s releases ownership for fresh doctor and strict validation",
+    "%s keeps plugin mutation exclusive and releases ownership for fresh doctor and strict validation",
     async (lane) => {
       await writeScenario(lane, {
         hostVersion: lane === "repair" ? undefined : "1.0.0",
+      });
+      mocks.plugins.mockImplementationOnce(async () => {
+        const result = await runExec(process.execPath, [entrypoint, "probe"], {
+          timeoutMs: 15_000,
+        });
+        expect(result.stdout).toBe("excluded");
+        return pluginResult;
       });
       await invoke(lane);
       expectSuccess(lane);
@@ -198,22 +205,6 @@ describe("update orchestration lifecycle ownership", () => {
           expect.objectContaining({ shouldRestart: false }),
         );
       }
-    },
-  );
-
-  it.each(["resume", "current-process", "repair"] as const)(
-    "%s keeps plugin mutation exclusive to its parent",
-    async (lane) => {
-      await writeScenario(lane);
-      mocks.plugins.mockImplementationOnce(async () => {
-        const result = await runExec(process.execPath, [entrypoint, "probe"], {
-          timeoutMs: 15_000,
-        });
-        expect(result.stdout).toBe("excluded");
-        return pluginResult;
-      });
-      await invoke(lane);
-      expectSuccess(lane);
       expect(mocks.plugins).toHaveBeenCalledOnce();
       const after = await runExec(process.execPath, [entrypoint, "probe"], { timeoutMs: 15_000 });
       expect(after.stdout).toBe("acquired");

--- a/src/commands/doctor-update.test.ts
+++ b/src/commands/doctor-update.test.ts
@@ -543,25 +543,60 @@ describe("maybeOfferUpdateBeforeDoctor", () => {
     },
   );
 
-  it.each([{ kind: "foreign" as const }, { kind: "unresolved" as const, fingerprint: "opaque" }])(
-    "does not stop, repair or activate a $kind service",
-    async (verdict) => {
+  const nonActivatingServices: Array<
+    Parameters<typeof mockManagedService>[0] & {
+      name: string;
+      policy: { allowGatewayServiceRepair: boolean; allowGatewayActivation: boolean };
+    }
+  > = [
+    {
+      name: "foreign service",
+      verdict: { kind: "foreign" },
+      running: true,
+      policy: { allowGatewayServiceRepair: false, allowGatewayActivation: false },
+    },
+    {
+      name: "unresolved service",
+      verdict: { kind: "unresolved", fingerprint: "opaque" },
+      running: true,
+      policy: { allowGatewayServiceRepair: false, allowGatewayActivation: false },
+    },
+    {
+      name: "stopped owned service permitting definition repair",
+      verdict: { kind: "owned", refreshDefinition: true, fingerprint: "opaque" },
+      running: false,
+      policy: { allowGatewayServiceRepair: true, allowGatewayActivation: false },
+    },
+    {
+      name: "unavailable inspection with a visible skip",
+      verdict: {
+        kind: "unavailable",
+        message:
+          "Gateway service management skipped; inspect service access before restarting manually.",
+      },
+      running: true,
+      policy: { allowGatewayServiceRepair: false, allowGatewayActivation: false },
+    },
+  ];
+  it.each(nonActivatingServices)(
+    "updates without stopping or activating a $name",
+    async ({ verdict, running, policy }) => {
       mockGitCheckout();
-      mockManagedService({ verdict });
+      mockManagedService({ verdict, running });
       mockUpdateResult({ status: "ok", mode: "git", root: "/repo/link" });
 
       await expect(runOffer({ confirm: vi.fn().mockResolvedValue(true) })).resolves.toEqual({
         updated: true,
         handled: true,
       });
-      expect(mocks.runGatewayUpdate).toHaveBeenCalledWith(
-        expect.objectContaining({
-          allowGatewayServiceRepair: false,
-          allowGatewayActivation: false,
-        }),
-      );
+      expect(mocks.runGatewayUpdate).toHaveBeenCalledOnce();
+      expect(mocks.runGatewayUpdate).toHaveBeenCalledWith(expect.objectContaining(policy));
+      expect(mocks.gitMutationPolicy).toHaveBeenCalledWith(policy);
       expect(mocks.stopGatewayService).not.toHaveBeenCalled();
       expect(mocks.restartUpdatedGateway).not.toHaveBeenCalled();
+      if (verdict.kind === "unavailable") {
+        expect(mocks.note).toHaveBeenCalledWith(verdict.message, "Update");
+      }
     },
   );
 
@@ -614,50 +649,6 @@ describe("maybeOfferUpdateBeforeDoctor", () => {
       }
     },
   );
-
-  it("repairs without activating a stopped gateway owned by this checkout", async () => {
-    mockGitCheckout();
-    mockManagedService({
-      verdict: { kind: "owned", refreshDefinition: true, fingerprint: "opaque" },
-      running: false,
-    });
-    mockUpdateResult({ status: "ok", mode: "git", root: "/repo/link" });
-
-    await expect(runOffer({ confirm: vi.fn().mockResolvedValue(true) })).resolves.toEqual({
-      updated: true,
-      handled: true,
-    });
-
-    expect(mocks.runGatewayUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        allowGatewayServiceRepair: true,
-        allowGatewayActivation: false,
-      }),
-    );
-    expect(mocks.restartUpdatedGateway).not.toHaveBeenCalled();
-  });
-
-  it("updates with a visible skip when service inspection is unavailable", async () => {
-    const message =
-      "Gateway service management skipped; inspect service access before restarting manually.";
-    mockGitCheckout();
-    mockManagedService({ verdict: { kind: "unavailable", message } });
-    mockUpdateResult({ status: "ok", mode: "git", root: "/repo/link" });
-
-    await expect(runOffer({ confirm: vi.fn().mockResolvedValue(true) })).resolves.toEqual({
-      updated: true,
-      handled: true,
-    });
-
-    expect(mocks.note).toHaveBeenCalledWith(message, "Update");
-    expect(mocks.runGatewayUpdate).toHaveBeenCalledOnce();
-    expect(mocks.gitMutationPolicy).toHaveBeenCalledWith({
-      allowGatewayServiceRepair: false,
-      allowGatewayActivation: false,
-    });
-    expect(mocks.stopGatewayService).not.toHaveBeenCalled();
-    expect(mocks.restartUpdatedGateway).not.toHaveBeenCalled();
-  });
 
   it("leaves the stopped gateway down when a git mutation throws without recovery proof", async () => {
     mockGitCheckout();

--- a/src/daemon/schtasks-control.ts
+++ b/src/daemon/schtasks-control.ts
@@ -24,7 +24,6 @@ import {
 } from "./schtasks-process.js";
 import {
   assertSchtasksAvailable,
-  hasScheduledTaskRunningEvidence,
   isRegisteredScheduledTask,
   isScheduledTaskDefinitelyNotRunning,
   isStartupEntryInstalled,
@@ -383,28 +382,30 @@ export async function restartRegisteredScheduledTask(params: {
     scriptPath: resolveTaskScriptPath(params.env),
     ...(params.onRunMutation ? { onMutation: params.onRunMutation } : {}),
   });
-  const startupEntryInstalled = await isStartupEntryInstalled(params.env);
-  const hasRunningEvidence = startupEntryInstalled
-    ? activation === "scheduled-task" && (await waitForScheduledTaskRunningEvidence(params.env))
-    : await hasScheduledTaskRunningEvidence(params.env);
   // A direct launch is the replacement fallback; keep it available at the next login.
-  if (
-    params.mode.kind === "fallback-takeover" &&
-    startupEntryInstalled &&
+  const shouldRemoveStartup =
     activation === "scheduled-task" &&
-    !hasRunningEvidence
+    !params.preserveDefinition &&
+    (await isStartupEntryInstalled(params.env));
+  if (
+    activation === "scheduled-task" &&
+    (params.mode.kind === "fallback-takeover" || shouldRemoveStartup)
   ) {
-    await execSchtasks(["/End", "/TN", taskName]);
-    const failedRuntime = await resolveFallbackRuntime(params.env, undefined, "control").catch(
-      () => null,
-    );
-    if (failedRuntime?.status === "running" && failedRuntime.pid) {
-      await terminateGatewayProcessTree(failedRuntime.pid, 300);
+    // Captured takeover owns the settling wait even if Startup vanished or its profile changed.
+    const hasRunningEvidence = await waitForScheduledTaskRunningEvidence(params.env);
+    if (params.mode.kind === "fallback-takeover" && !hasRunningEvidence) {
+      await execSchtasks(["/End", "/TN", taskName]);
+      const failedRuntime = await resolveFallbackRuntime(params.env, undefined, "control").catch(
+        () => null,
+      );
+      if (failedRuntime?.status === "running" && failedRuntime.pid) {
+        await terminateGatewayProcessTree(failedRuntime.pid, 300);
+      }
+      throw new Error("Replacement Windows Scheduled Task did not produce running evidence.");
     }
-    throw new Error("Replacement Windows Scheduled Task did not produce running evidence.");
-  }
-  if (startupEntryInstalled && hasRunningEvidence && !params.preserveDefinition) {
-    await removeStartupEntries(params.env, params.stdout);
+    if (shouldRemoveStartup && hasRunningEvidence) {
+      await removeStartupEntries(params.env, params.stdout);
+    }
   }
   params.stdout.write(`${formatLine("Restarted Scheduled Task", taskName)}\n`);
   return { outcome: "completed" };

--- a/src/daemon/schtasks-install.ts
+++ b/src/daemon/schtasks-install.ts
@@ -123,9 +123,7 @@ async function writeScheduledTaskScript({
   scriptPath: string;
   taskLaunchPath: string;
   taskDescription: string;
-  taskEnv: GatewayServiceEnv;
 }> {
-  await assertSchtasksAvailable().catch(() => undefined);
   const taskEnv = resolveScheduledTaskRenderEnv(env, environment);
   const scriptPath = resolveTaskScriptPath(taskEnv);
   const taskLaunchPath = resolveTaskLauncherScriptPath(taskEnv, scriptPath);
@@ -148,7 +146,7 @@ async function writeScheduledTaskScript({
       encodeWindowsLauncherScript({ format: "vbs", content: launcher }),
     );
   }
-  return { scriptPath, taskLaunchPath, taskDescription, taskEnv };
+  return { scriptPath, taskLaunchPath, taskDescription };
 }
 
 export async function stageScheduledTask({

--- a/src/daemon/schtasks-runtime.ts
+++ b/src/daemon/schtasks-runtime.ts
@@ -154,7 +154,7 @@ function createStartupEntryRemovalError(error: unknown): Error {
   );
 }
 
-export async function hasScheduledTaskRunningEvidence(env: GatewayServiceEnv): Promise<boolean> {
+async function hasScheduledTaskRunningEvidence(env: GatewayServiceEnv): Promise<boolean> {
   const runtime = await readScheduledTaskRuntime(env).catch(() => null);
   if (runtime?.status !== "running") {
     return false;

--- a/src/daemon/schtasks.install.test.ts
+++ b/src/daemon/schtasks.install.test.ts
@@ -9,6 +9,7 @@ import {
   installScheduledTask,
   readScheduledTaskCommand,
   resolveTaskScriptPath,
+  stageScheduledTask,
   uninstallScheduledTask,
 } from "./schtasks.js";
 import { auditGatewayServiceConfig, SERVICE_AUDIT_CODES } from "./service-audit.js";
@@ -97,28 +98,39 @@ describe("installScheduledTask", () => {
     });
   }
 
-  function expectInitialTaskQueries(taskName = "OpenClaw Gateway"): void {
-    expect(schtasksCalls[0]).toEqual(["/Query"]);
-    expect(schtasksCalls[1]).toEqual(["/Query", "/TN", taskName]);
+  function expectInitialTaskQuery(taskName = "OpenClaw Gateway"): void {
+    expect(schtasksCalls[0]).toEqual(["/Query", "/TN", taskName]);
   }
 
   function expectTaskRunCall(index: number, taskName = "OpenClaw Gateway"): void {
     expect(schtasksCalls[index]).toEqual(["/Run", "/TN", taskName]);
   }
 
-  it("redirects stdin from NUL so a hidden service console is never interactive (#112173)", async () => {
-    await withUserProfileDir(async (_tmpDir, env) => {
-      const { scriptPath } = await installDefaultGatewayTask(env);
-      const script = decodeWindowsLauncherScript({ buffer: await fs.readFile(scriptPath) });
-      expect(script).toContain("node gateway.js < NUL");
+  it.each(["install", "stage"])(
+    "%s redirects stdin from NUL so a hidden service console is never interactive (#112173)",
+    async (mode) => {
+      await withUserProfileDir(async (_tmpDir, env) => {
+        const writeTask = mode === "stage" ? stageScheduledTask : installScheduledTask;
+        const { scriptPath } = await writeTask({
+          env,
+          stdout: new PassThrough(),
+          programArguments: ["node", "gateway.js"],
+          environment: {},
+        });
+        if (mode === "stage") {
+          expect(schtasksCalls).toEqual([]);
+        }
+        const script = decodeWindowsLauncherScript({ buffer: await fs.readFile(scriptPath) });
+        expect(script).toContain("node gateway.js < NUL");
 
-      const parsed = await readScheduledTaskCommand(env);
-      expect(parsed).toStrictEqual({
-        programArguments: ["node", "gateway.js"],
-        sourcePath: scriptPath,
+        const parsed = await readScheduledTaskCommand(env);
+        expect(parsed).toStrictEqual({
+          programArguments: ["node", "gateway.js"],
+          sourcePath: scriptPath,
+        });
       });
-    });
-  });
+    },
+  );
 
   it("writes version-free gateway and node descriptions", async () => {
     await withUserProfileDir(async (_tmpDir, env) => {
@@ -231,18 +243,17 @@ describe("installScheduledTask", () => {
         sourcePath: scriptPath,
       });
 
-      expect(schtasksCalls[0]).toEqual(["/Query"]);
-      expect(schtasksCalls[1]).toEqual(["/Query", "/TN", "OpenClaw Gateway"]);
-      expect(schtasksCalls[2]?.[0]).toBe("/Change");
+      expect(schtasksCalls[0]).toEqual(["/Query", "/TN", "OpenClaw Gateway"]);
+      expect(schtasksCalls[1]?.[0]).toBe("/Change");
       // Battery-flag XML re-apply runs between /Change and /Run on upgrades.
-      expect(schtasksCalls[3]?.slice(0, 5)).toEqual([
+      expect(schtasksCalls[2]?.slice(0, 5)).toEqual([
         "/Create",
         "/F",
         "/TN",
         "OpenClaw Gateway",
         "/XML",
       ]);
-      expect(schtasksCalls[4]).toEqual(["/Run", "/TN", "OpenClaw Gateway"]);
+      expect(schtasksCalls[3]).toEqual(["/Run", "/TN", "OpenClaw Gateway"]);
     });
   });
 
@@ -280,19 +291,19 @@ describe("installScheduledTask", () => {
 
   it("uses /Create when the task does not exist yet", async () => {
     await withUserProfileDir(async (_tmpDir, env) => {
-      schtasksResponses.push(okSchtasksResponse, missingTaskResponse);
+      schtasksResponses.push(missingTaskResponse);
 
       await installDefaultGatewayTask(env);
 
-      expectInitialTaskQueries();
-      expect(schtasksCalls[2]?.[0]).toBe("/Create");
-      expectTaskRunCall(3);
+      expectInitialTaskQuery();
+      expect(schtasksCalls[1]?.[0]).toBe("/Create");
+      expectTaskRunCall(2);
     });
   });
 
   it("creates hidden launcher Windows tasks when requested", async () => {
     await withUserProfileDir(async (_tmpDir, env) => {
-      schtasksResponses.push(okSchtasksResponse, missingTaskResponse);
+      schtasksResponses.push(missingTaskResponse);
 
       const { scriptPath } = await installDefaultGatewayTask({
         ...env,
@@ -304,23 +315,23 @@ describe("installScheduledTask", () => {
       const rawLauncher = await fs.readFile(launcherPath);
       const launcher = decodeWindowsLauncherScript({ buffer: rawLauncher });
 
-      expectInitialTaskQueries();
+      expectInitialTaskQuery();
       // wscript only accepts UTF-16 LE with BOM or ANSI; UTF-16 keeps CJK paths intact.
       expect(rawLauncher.subarray(0, 2)).toEqual(Buffer.from([0xff, 0xfe]));
       // `/Create /XML` argv shape: ["/Create", "/F", "/TN", "<name>", "/XML", "<path>", "/RU", "<user>", "/NP"].
       // The XML payload is what carries the SC, RL, TR, and battery settings now.
-      expect(schtasksCalls[2]?.slice(0, 5)).toEqual([
+      expect(schtasksCalls[1]?.slice(0, 5)).toEqual([
         "/Create",
         "/F",
         "/TN",
         "OpenClaw Gateway",
         "/XML",
       ]);
-      expect(schtasksCalls[2]?.slice(6)).toEqual(["/RU", "WORKSTATION\\alice", "/NP"]);
+      expect(schtasksCalls[1]?.slice(6)).toEqual(["/RU", "WORKSTATION\\alice", "/NP"]);
       expect(launcher).toContain("WScript.Shell");
       expect(launcher).toContain(scriptPath);
       expect(launcher).toContain(`Run """${scriptPath}""", 0, False`);
-      expectTaskRunCall(3);
+      expectTaskRunCall(2);
     });
   });
 
@@ -328,7 +339,7 @@ describe("installScheduledTask", () => {
     await withUserProfileDir(async (tmpDir, _env) => {
       const cjkProfileDir = path.join(tmpDir, "苗振");
       await fs.mkdir(cjkProfileDir, { recursive: true });
-      schtasksResponses.push(okSchtasksResponse, missingTaskResponse);
+      schtasksResponses.push(missingTaskResponse);
 
       const { scriptPath } = await installDefaultGatewayTask({
         USERPROFILE: cjkProfileDir,
@@ -349,7 +360,7 @@ describe("installScheduledTask", () => {
   it("fails the install instead of writing an unrepresentable cmd launcher", async () => {
     await withUserProfileDir(async (_tmpDir, env) => {
       resolveWindowsOemEncodingMock.mockReturnValue("gbk");
-      schtasksResponses.push(okSchtasksResponse, missingTaskResponse);
+      schtasksResponses.push(missingTaskResponse);
 
       await expect(
         installScheduledTask({
@@ -365,7 +376,7 @@ describe("installScheduledTask", () => {
 
   it("uses the hidden launcher for generated Windows gateway service installs", async () => {
     await withUserProfileDir(async (_tmpDir, env) => {
-      schtasksResponses.push(okSchtasksResponse, missingTaskResponse);
+      schtasksResponses.push(missingTaskResponse);
       const callerEnv: Record<string, string | undefined> = {
         ...env,
         HOME: env.USERPROFILE,
@@ -397,20 +408,20 @@ describe("installScheduledTask", () => {
       const script = decodeWindowsLauncherScript({ buffer: await fs.readFile(scriptPath) });
       const launcher = decodeWindowsLauncherScript({ buffer: await fs.readFile(launcherPath) });
 
-      expect(schtasksCalls[2]?.slice(0, 5)).toEqual([
+      expect(schtasksCalls[1]?.slice(0, 5)).toEqual([
         "/Create",
         "/F",
         "/TN",
         "OpenClaw Custom Gateway",
         "/XML",
       ]);
-      expect(schtasksCalls[2]?.slice(6)).toEqual(["/RU", "WORKSTATION\\alice", "/NP"]);
-      const captured = xmlPayloadCaptures.find((entry) => entry.index === 2);
+      expect(schtasksCalls[1]?.slice(6)).toEqual(["/RU", "WORKSTATION\\alice", "/NP"]);
+      const captured = xmlPayloadCaptures.find((entry) => entry.index === 1);
       expect(captured?.xml).toContain("gateway.vbs</Command>");
       expect(script).toContain('set "OPENCLAW_WINDOWS_TASK_NAME=OpenClaw Custom Gateway"');
       expect(launcher).toContain("WScript.Shell");
       expect(launcher).toContain(`Run """${scriptPath}""", 0, False`);
-      expectTaskRunCall(3, "OpenClaw Custom Gateway");
+      expectTaskRunCall(2, "OpenClaw Custom Gateway");
     });
   });
 
@@ -456,7 +467,7 @@ describe("installScheduledTask", () => {
 
   it("creates the Scheduled Task via XML with battery start/continue enabled (#59299)", async () => {
     await withUserProfileDir(async (_tmpDir, env) => {
-      schtasksResponses.push(okSchtasksResponse, missingTaskResponse);
+      schtasksResponses.push(missingTaskResponse);
 
       await installDefaultGatewayTask({
         ...env,
@@ -467,11 +478,11 @@ describe("installScheduledTask", () => {
       // `/Create` must use `/XML <path>` so battery flags can be set; the
       // CLI flag form (`/SC ONLOGON /RL LIMITED /TR ...`) cannot express
       // `DisallowStartIfOnBatteries`/`StopIfGoingOnBatteries`.
-      const createCall = schtasksCalls[2];
+      const createCall = schtasksCalls[1];
       expect(createCall?.[0]).toBe("/Create");
       expect(createCall).toContain("/XML");
 
-      const captured = xmlPayloadCaptures.find((entry) => entry.index === 2);
+      const captured = xmlPayloadCaptures.find((entry) => entry.index === 1);
       expect(captured).toBeDefined();
       const xml = captured?.xml ?? "";
       expect(xml).toContain("<DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>");
@@ -486,7 +497,7 @@ describe("installScheduledTask", () => {
 
   it("omits /RU for workgroup accounts so schtasks can use the current local user", async () => {
     await withUserProfileDir(async (_tmpDir, env) => {
-      schtasksResponses.push(okSchtasksResponse, missingTaskResponse);
+      schtasksResponses.push(missingTaskResponse);
 
       await installDefaultGatewayTask({
         ...env,
@@ -494,22 +505,21 @@ describe("installScheduledTask", () => {
         USERNAME: "alice",
       });
 
-      expectInitialTaskQueries();
-      const createCall = schtasksCalls[2];
+      expectInitialTaskQuery();
+      const createCall = schtasksCalls[1];
       expect(createCall?.slice(0, 5)).toEqual(["/Create", "/F", "/TN", "OpenClaw Gateway", "/XML"]);
       expect(createCall).not.toContain("/RU");
-      const captured = xmlPayloadCaptures.find((entry) => entry.index === 2);
+      const captured = xmlPayloadCaptures.find((entry) => entry.index === 1);
       expect(captured?.xml).toContain("<UserId>alice</UserId>");
       expect(captured?.xml).not.toContain("<GroupId>S-1-5-32-545</GroupId>");
-      expectTaskRunCall(3);
+      expectTaskRunCall(2);
     });
   });
 
   it("re-applies the XML on /Change so upgraded tasks adopt battery flags (#59299)", async () => {
     await withUserProfileDir(async (_tmpDir, env) => {
-      // /Query yes, /Query /TN yes, /Change ok, /Create /XML ok (upgrade), /Run ok.
+      // /Query /TN yes, /Change ok, /Create /XML ok (upgrade), /Run ok.
       schtasksResponses.push(
-        okSchtasksResponse,
         okSchtasksResponse,
         okSchtasksResponse,
         okSchtasksResponse,
@@ -518,31 +528,30 @@ describe("installScheduledTask", () => {
 
       await installDefaultGatewayTask(env);
 
-      expectInitialTaskQueries();
-      expect(schtasksCalls[2]?.[0]).toBe("/Change");
-      expect(schtasksCalls[3]?.slice(0, 5)).toEqual([
+      expectInitialTaskQuery();
+      expect(schtasksCalls[1]?.[0]).toBe("/Change");
+      expect(schtasksCalls[2]?.slice(0, 5)).toEqual([
         "/Create",
         "/F",
         "/TN",
         "OpenClaw Gateway",
         "/XML",
       ]);
-      const upgradeCapture = xmlPayloadCaptures.find((entry) => entry.index === 3);
+      const upgradeCapture = xmlPayloadCaptures.find((entry) => entry.index === 2);
       expect(upgradeCapture).toBeDefined();
       const upgradeXml = upgradeCapture?.xml ?? "";
       expect(upgradeXml).toContain(
         "<DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>",
       );
       expect(upgradeXml).toContain("<StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>");
-      expectTaskRunCall(4);
+      expectTaskRunCall(3);
     });
   });
 
   it("updates existing tasks to use the hidden launcher when requested", async () => {
     await withUserProfileDir(async (_tmpDir, env) => {
-      // /Query, /Query /TN, /Change (TR-only), /Create /XML (upgrade re-apply), /Run.
+      // /Query /TN, /Change (TR-only), /Create /XML (upgrade re-apply), /Run.
       schtasksResponses.push(
-        okSchtasksResponse,
         okSchtasksResponse,
         okSchtasksResponse,
         okSchtasksResponse,
@@ -557,45 +566,44 @@ describe("installScheduledTask", () => {
       });
       const launcherPath = scriptPath.replace(/\.cmd$/i, ".vbs");
 
-      expectInitialTaskQueries();
-      expect(schtasksCalls[2]).toEqual([
+      expectInitialTaskQuery();
+      expect(schtasksCalls[1]).toEqual([
         "/Change",
         "/TN",
         "OpenClaw Gateway",
         "/TR",
         expect.stringContaining("gateway.vbs"),
       ]);
-      expect(schtasksCalls[2]?.[4]).toContain(launcherPath);
+      expect(schtasksCalls[1]?.[4]).toContain(launcherPath);
       // Upgrade XML re-apply runs after /Change so older tasks pick up battery flags.
-      expect(schtasksCalls[3]?.slice(0, 5)).toEqual([
+      expect(schtasksCalls[2]?.slice(0, 5)).toEqual([
         "/Create",
         "/F",
         "/TN",
         "OpenClaw Gateway",
         "/XML",
       ]);
-      expectTaskRunCall(4);
+      expectTaskRunCall(3);
     });
   });
 
   it("falls back to /Create when /Change fails on an existing task", async () => {
     await withUserProfileDir(async (_tmpDir, env) => {
-      schtasksResponses.push(okSchtasksResponse, okSchtasksResponse, accessDeniedResponse);
+      schtasksResponses.push(okSchtasksResponse, accessDeniedResponse);
 
       await installDefaultGatewayTask(env);
 
-      expectInitialTaskQueries();
-      expect(schtasksCalls[2]?.[0]).toBe("/Change");
-      expect(schtasksCalls[3]?.[0]).toBe("/Create");
-      expectTaskRunCall(4);
+      expectInitialTaskQuery();
+      expect(schtasksCalls[1]?.[0]).toBe("/Change");
+      expect(schtasksCalls[2]?.[0]).toBe("/Create");
+      expectTaskRunCall(3);
     });
   });
 
   it("throws when /Run fails after updating an existing task", async () => {
     await withUserProfileDir(async (_tmpDir, env) => {
-      // /Query, /Query /TN, /Change, /Create XML upgrade re-apply, /Run (fails).
+      // /Query /TN, /Change, /Create XML upgrade re-apply, /Run (fails).
       schtasksResponses.push(
-        okSchtasksResponse,
         okSchtasksResponse,
         okSchtasksResponse,
         okSchtasksResponse,
@@ -606,29 +614,24 @@ describe("installScheduledTask", () => {
         "schtasks run failed: ERROR: Access is denied.",
       );
 
-      expectInitialTaskQueries();
-      expect(schtasksCalls[2]?.[0]).toBe("/Change");
-      expect(schtasksCalls[3]?.[0]).toBe("/Create");
-      expectTaskRunCall(4);
+      expectInitialTaskQuery();
+      expect(schtasksCalls[1]?.[0]).toBe("/Change");
+      expect(schtasksCalls[2]?.[0]).toBe("/Create");
+      expectTaskRunCall(3);
     });
   });
 
   it("throws when /Run fails after creating a new task", async () => {
     await withUserProfileDir(async (_tmpDir, env) => {
-      schtasksResponses.push(
-        okSchtasksResponse,
-        missingTaskResponse,
-        okSchtasksResponse,
-        accessDeniedResponse,
-      );
+      schtasksResponses.push(missingTaskResponse, okSchtasksResponse, accessDeniedResponse);
 
       await expect(installDefaultGatewayTask(env)).rejects.toThrow(
         "schtasks run failed: ERROR: Access is denied.",
       );
 
-      expectInitialTaskQueries();
-      expect(schtasksCalls[2]?.[0]).toBe("/Create");
-      expectTaskRunCall(3);
+      expectInitialTaskQuery();
+      expect(schtasksCalls[1]?.[0]).toBe("/Create");
+      expectTaskRunCall(2);
     });
   });
 

--- a/src/daemon/schtasks.startup-fallback.test.ts
+++ b/src/daemon/schtasks.startup-fallback.test.ts
@@ -243,14 +243,13 @@ function useListenerBackedFallbackOwnership(): void {
   vi.spyOn(process, "platform", "get").mockReturnValue("linux");
 }
 
-function addStartupFallbackMissingResponses(
-  extraResponses: Array<{ code: number; stdout: string; stderr: string }> = [],
-) {
-  schtasksResponses.push(
-    { code: 0, stdout: "", stderr: "" },
-    { code: 1, stdout: "", stderr: "not found" },
-    ...extraResponses,
-  );
+function addMissingTaskInstallResponses(responses: typeof schtasksResponses): void {
+  schtasksResponses.push({ code: 1, stdout: "", stderr: "not found" }, ...responses);
+}
+
+function addStartupFallbackMissingResponses(extraResponses: typeof schtasksResponses = []) {
+  schtasksResponses.push({ code: 0, stdout: "", stderr: "" });
+  addMissingTaskInstallResponses(extraResponses);
 }
 
 function installGatewayScheduledTask(
@@ -291,7 +290,7 @@ function fastForwardTaskStartWait(): void {
 }
 
 function addAcceptedRunNeverStartsResponses(): void {
-  addStartupFallbackMissingResponses([
+  addMissingTaskInstallResponses([
     { code: 0, stdout: "", stderr: "" },
     { code: 0, stdout: "", stderr: "" },
     { code: 0, stdout: "", stderr: "" },
@@ -321,13 +320,10 @@ function addSuccessfulScheduledTaskRestartResponses(
   }
 }
 
-function notYetRunTaskQueryOutput() {
-  return [
-    "Status: Ready",
-    "Last Run Time: 11/30/1999 12:00:00 AM",
-    "Last Run Result: 267011",
-    "",
-  ].join("\r\n");
+function notYetRunTaskQueryOutput(lastRunTime = "11/30/1999 12:00:00 AM") {
+  return ["Status: Ready", `Last Run Time: ${lastRunTime}`, "Last Run Result: 267011", ""].join(
+    "\r\n",
+  );
 }
 
 function cleanExitTaskQueryOutput(lastRunTime = "5/2/2026 2:41:39 PM") {
@@ -335,7 +331,7 @@ function cleanExitTaskQueryOutput(lastRunTime = "5/2/2026 2:41:39 PM") {
 }
 
 function addAcceptedRunCleanExitResponses(initialOutput = cleanExitTaskQueryOutput()): void {
-  addStartupFallbackMissingResponses([
+  addMissingTaskInstallResponses([
     { code: 0, stdout: "", stderr: "" },
     { code: 0, stdout: "", stderr: "" },
     { code: 0, stdout: "", stderr: "" },
@@ -603,9 +599,7 @@ describe("Windows startup fallback", () => {
 
   it("falls back to a Startup-folder launcher when schtasks create is denied", async () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
-      addStartupFallbackMissingResponses([
-        { code: 5, stdout: "", stderr: "ERROR: Access is denied." },
-      ]);
+      addMissingTaskInstallResponses([{ code: 5, stdout: "", stderr: "ERROR: Access is denied." }]);
 
       const stdout = new PassThrough();
       let printed = "";
@@ -630,9 +624,7 @@ describe("Windows startup fallback", () => {
 
   it("uses a hidden Startup-folder launcher when requested", async () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
-      addStartupFallbackMissingResponses([
-        { code: 5, stdout: "", stderr: "ERROR: Access is denied." },
-      ]);
+      addMissingTaskInstallResponses([{ code: 5, stdout: "", stderr: "ERROR: Access is denied." }]);
 
       const result = await installGatewayScheduledTask({
         ...env,
@@ -657,7 +649,7 @@ describe("Windows startup fallback", () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
       const startupEntryPath = await writeStartupFallbackEntry(env);
       const hiddenStartupEntryPath = await writeStartupFallbackEntry(env, "vbs");
-      addStartupFallbackMissingResponses([
+      addMissingTaskInstallResponses([
         { code: 0, stdout: "", stderr: "" },
         { code: 0, stdout: "", stderr: "" },
         { code: 0, stdout: "", stderr: "" },
@@ -682,35 +674,70 @@ describe("Windows startup fallback", () => {
     });
   });
 
-  it("takes over from a running Startup-folder fallback before removing its launcher", async () => {
-    useListenerBackedFallbackOwnership();
-    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
-      const startupEntryPath = await writeStartupFallbackEntry(env);
-      findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4242]);
-      inspectPortUsageMock
-        .mockResolvedValueOnce({
-          port: 18789,
-          status: "busy",
-          listeners: [{ pid: 4242, command: "node.exe" }],
-          hints: [],
-        })
-        .mockResolvedValue({ port: 18789, status: "free", listeners: [], hints: [] });
-      addStartupFallbackMissingResponses([
-        { code: 0, stdout: "", stderr: "" },
-        { code: 0, stdout: "", stderr: "" },
-        { code: 0, stdout: "", stderr: "" },
-        { code: 0, stdout: runningTaskQueryOutput(), stderr: "" },
-        { code: 0, stdout: "", stderr: "" },
-        { code: 0, stdout: runningTaskQueryOutput(), stderr: "" },
-      ]);
-      addSuccessfulScheduledTaskRestartResponses();
+  it.each([false, true])(
+    "takes over from a running Startup-folder fallback after delayed task readiness (Startup removed after capture: %s)",
+    async (removeAfterCapture) => {
+      useListenerBackedFallbackOwnership();
+      await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+        const startupEntryPath = await writeStartupFallbackEntry(env);
+        await writeGatewayScript(env);
+        findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4242]);
+        inspectPortUsageMock
+          .mockResolvedValueOnce({
+            port: 18789,
+            status: "busy",
+            listeners: [{ pid: 4242, command: "node.exe" }],
+            hints: [],
+          })
+          .mockImplementationOnce(async (port) => {
+            // The preflight runs after the old fallback's command and ownership were captured.
+            if (removeAfterCapture) {
+              await fs.unlink(startupEntryPath);
+            }
+            return { port, status: "free", listeners: [], hints: [] };
+          })
+          .mockResolvedValue({ port: 18789, status: "free", listeners: [], hints: [] });
+        addMissingTaskInstallResponses([
+          { code: 0, stdout: "", stderr: "" },
+          { code: 0, stdout: "", stderr: "" },
+          { code: 0, stdout: "", stderr: "" },
+          { code: 0, stdout: runningTaskQueryOutput(), stderr: "" },
+          { code: 0, stdout: "", stderr: "" }, // takeover /End
+          { code: 0, stdout: "", stderr: "" }, // takeover /Run
+        ]);
+        const startupProgress = notYetRunTaskQueryOutput("4/15/2026 11:42:31 PM");
+        // A fresh run timestamp proves launch progress, but running evidence arrives one poll later.
+        for (const output of [
+          notYetRunTaskQueryOutput(),
+          startupProgress,
+          startupProgress,
+          runningTaskQueryOutput(),
+        ]) {
+          schtasksResponses.push(
+            { code: 0, stdout: "", stderr: "" },
+            { code: 0, stdout: output, stderr: "" },
+          );
+        }
+        const stdout = new PassThrough();
+        let printed = "";
+        stdout.on("data", (chunk) => {
+          printed += String(chunk);
+        });
 
-      await installGatewayScheduledTask(env);
+        await expect(installGatewayScheduledTask(env, stdout)).resolves.toEqual({
+          scriptPath: resolveTaskScriptPath(env),
+        });
 
-      expectGatewayTermination(4242);
-      await expect(fs.access(startupEntryPath)).rejects.toThrow();
-    });
-  });
+        expectGatewayTermination(4242);
+        expect(spawn).not.toHaveBeenCalled();
+        expect(schtasksResponses).toEqual([]);
+        expect(sleepMock.mock.calls).toEqual([[250], [250]]);
+        expect(printed).toContain("Restarted Scheduled Task");
+        expect(printed.includes("Removed Windows login item")).toBe(!removeAfterCapture);
+        await expect(fs.access(startupEntryPath)).rejects.toThrow();
+      });
+    },
+  );
 
   it("migrates an exact persisted wrapper that owns the replacement port", async () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
@@ -773,7 +800,7 @@ describe("Windows startup fallback", () => {
           listeners: [],
           hints: [],
         }));
-      addStartupFallbackMissingResponses([
+      addMissingTaskInstallResponses([
         { code: 0, stdout: "", stderr: "" },
         { code: 0, stdout: "", stderr: "" },
         { code: 0, stdout: "", stderr: "" },
@@ -886,7 +913,7 @@ describe("Windows startup fallback", () => {
         }
         return makeSpawnSyncResult();
       });
-      addStartupFallbackMissingResponses([
+      addMissingTaskInstallResponses([
         { code: 0, stdout: "", stderr: "" },
         { code: 0, stdout: "", stderr: "" },
         { code: 0, stdout: "", stderr: "" },
@@ -996,7 +1023,7 @@ describe("Windows startup fallback", () => {
             }
           : { port, status: "free", listeners: [], hints: [] };
       });
-      addStartupFallbackMissingResponses([
+      addMissingTaskInstallResponses([
         { code: 0, stdout: "", stderr: "" },
         { code: 0, stdout: "", stderr: "" },
         { code: 0, stdout: "", stderr: "" },
@@ -1034,7 +1061,7 @@ describe("Windows startup fallback", () => {
             : [],
         hints: [],
       }));
-      addStartupFallbackMissingResponses([
+      addMissingTaskInstallResponses([
         { code: 0, stdout: "", stderr: "" },
         { code: 0, stdout: "", stderr: "" },
         { code: 0, stdout: "", stderr: "" },
@@ -1094,7 +1121,7 @@ describe("Windows startup fallback", () => {
         listeners: [],
         hints: [],
       }));
-      addStartupFallbackMissingResponses([
+      addMissingTaskInstallResponses([
         { code: 0, stdout: "", stderr: "" },
         { code: 0, stdout: "", stderr: "" },
         { code: 0, stdout: "", stderr: "" },
@@ -1156,7 +1183,7 @@ describe("Windows startup fallback", () => {
         ],
         hints: [],
       });
-      addStartupFallbackMissingResponses([
+      addMissingTaskInstallResponses([
         { code: 0, stdout: "", stderr: "" },
         { code: 0, stdout: "", stderr: "" },
         { code: 0, stdout: "", stderr: "" },
@@ -1322,7 +1349,7 @@ describe("Windows startup fallback", () => {
         })
         .mockResolvedValue({ port: 18789, status: "free", listeners: [], hints: [] });
       fastForwardTaskStartWait();
-      addStartupFallbackMissingResponses([
+      addMissingTaskInstallResponses([
         { code: 0, stdout: "", stderr: "" },
         { code: 0, stdout: "", stderr: "" },
         { code: 0, stdout: "", stderr: "" },
@@ -1344,57 +1371,106 @@ describe("Windows startup fallback", () => {
     });
   });
 
-  it("relaunches the fallback when replacement running evidence never appears", async () => {
-    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
-      const startupEntryPath = await writeStartupFallbackEntry(env);
-      await writeGatewayScript(env);
-      vi.spyOn(process, "platform", "get").mockReturnValue("win32");
-      let processQueries = 0;
-      spawnSync.mockImplementation((command, args) => {
-        if (
-          command === getWindowsPowerShellExePath() &&
-          Array.isArray(args) &&
-          args.includes(NODE_PROCESS_QUERY)
-        ) {
-          processQueries += 1;
-          return makeSpawnSyncResult({
-            stdout: JSON.stringify(
-              processQueries < 3
-                ? [
-                    {
-                      ProcessId: 4242,
-                      CommandLine:
-                        '"C:\\Program Files\\nodejs\\node.exe" "C:\\Users\\steipete\\AppData\\Roaming\\npm\\node_modules\\openclaw\\dist\\index.js" gateway --port 18789',
-                    },
-                    { ProcessId: 9999, CommandLine: "powershell.exe" },
-                  ]
-                : [{ ProcessId: 9999, CommandLine: "powershell.exe" }],
-            ),
-          });
+  it.each([false, true])(
+    "relaunches the fallback when replacement running evidence never appears (Startup removed after capture: %s)",
+    async (removeAfterCapture) => {
+      await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+        const startupEntryPath = await writeStartupFallbackEntry(env);
+        await writeGatewayScript(env);
+        vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+        let fallbackAlive = true;
+        let replacementAlive = true;
+        inspectPortUsageMock.mockImplementationOnce(async (port) => {
+          // Replacement preflight follows capture of the old fallback's command and PID.
+          if (removeAfterCapture) {
+            await fs.unlink(startupEntryPath);
+          }
+          return { port, status: "free", listeners: [], hints: [] };
+        });
+        spawnSync.mockImplementation((command, args) => {
+          if (
+            command === getWindowsPowerShellExePath() &&
+            Array.isArray(args) &&
+            args.includes(NODE_PROCESS_QUERY)
+          ) {
+            return makeSpawnSyncResult({
+              stdout: JSON.stringify(
+                fallbackAlive
+                  ? [
+                      {
+                        ProcessId: 4242,
+                        CommandLine:
+                          '"C:\\Program Files\\nodejs\\node.exe" "C:\\Users\\steipete\\AppData\\Roaming\\npm\\node_modules\\openclaw\\dist\\index.js" gateway --port 18789',
+                      },
+                      { ProcessId: 9999, CommandLine: "powershell.exe" },
+                    ]
+                  : [
+                      // A late replacement can survive /End and still require owned teardown.
+                      ...(replacementAlive &&
+                      schtasksCalls.filter((call) => call[0] === "/End").length === 2
+                        ? [{ ProcessId: 5151, CommandLine: "node gateway.js --port 18789" }]
+                        : []),
+                      { ProcessId: 9999, CommandLine: "powershell.exe" },
+                    ],
+              ),
+            });
+          }
+          if (command.endsWith("taskkill.exe")) {
+            if (args?.includes("4242")) {
+              fallbackAlive = false;
+            }
+            if (args?.includes("5151")) {
+              replacementAlive = false;
+            }
+          }
+          return makeSpawnSyncResult();
+        });
+        fastForwardTaskStartWait();
+        addMissingTaskInstallResponses([
+          { code: 0, stdout: "", stderr: "" },
+          { code: 0, stdout: "", stderr: "" },
+          { code: 0, stdout: "", stderr: "" },
+          { code: 0, stdout: runningTaskQueryOutput(), stderr: "" },
+        ]);
+        const failedTaskQuery = "Status: Ready\r\nLast Run Result: 1\r\n";
+        schtasksResponses.push(
+          { code: 0, stdout: "", stderr: "" }, // /End
+          { code: 0, stdout: "", stderr: "" }, // /Run
+          { code: 0, stdout: "", stderr: "" }, // availability
+          { code: 0, stdout: failedTaskQuery, stderr: "" }, // launch observation: other
+          { code: 0, stdout: "", stderr: "" },
+          { code: 0, stdout: failedTaskQuery, stderr: "" }, // takeover verification
+        );
+        const stdout = new PassThrough();
+        let printed = "";
+        stdout.on("data", (chunk) => {
+          printed += String(chunk);
+        });
+
+        await expect(installGatewayScheduledTask(env, stdout)).rejects.toThrow(
+          "Replacement Windows Scheduled Task did not produce running evidence",
+        );
+
+        expectStartupFallbackSpawn();
+        expect(spawn).toHaveBeenCalledTimes(1);
+        expect(spawn.mock.calls[0]?.[0]).toBe("C:\\Program Files\\nodejs\\node.exe");
+        expect(spawn.mock.calls[0]?.[1]).not.toContain("gateway.js");
+        expectTaskkillPid(4242);
+        expectTaskkillPid(5151);
+        expect(fallbackAlive).toBe(false);
+        expect(replacementAlive).toBe(false);
+        expect(schtasksCalls.at(-1)).toEqual(["/End", "/TN", "OpenClaw Gateway"]);
+        expect(printed).not.toContain("Restarted Scheduled Task");
+        expect(schtasksCalls.filter((call) => call.includes("/V"))).toHaveLength(4);
+        expect(sleepMock).toHaveBeenCalledWith(250);
+        if (removeAfterCapture) {
+          await expect(fs.access(startupEntryPath)).rejects.toThrow();
+        } else {
+          await expect(fs.access(startupEntryPath)).resolves.toBeUndefined();
         }
-        return makeSpawnSyncResult();
       });
-      fastForwardTaskStartWait();
-      addStartupFallbackMissingResponses([
-        { code: 0, stdout: "", stderr: "" },
-        { code: 0, stdout: "", stderr: "" },
-        { code: 0, stdout: "", stderr: "" },
-        { code: 0, stdout: runningTaskQueryOutput(), stderr: "" },
-      ]);
-      addSuccessfulScheduledTaskRestartResponses(
-        [notYetRunTaskQueryOutput()],
-        notYetRunTaskQueryOutput(),
-      );
-
-      await expect(installGatewayScheduledTask(env)).rejects.toThrow(
-        "Replacement Windows Scheduled Task did not produce running evidence",
-      );
-
-      expectStartupFallbackSpawn();
-      expect(processQueries).toBeGreaterThanOrEqual(4);
-      await expect(fs.access(startupEntryPath)).resolves.toBeUndefined();
-    });
-  });
+    },
+  );
 
   it("re-probes the captured fallback port after a transient config reload", async () => {
     useListenerBackedFallbackOwnership();
@@ -1423,7 +1499,7 @@ describe("Windows startup fallback", () => {
               hints: [],
             };
       });
-      addStartupFallbackMissingResponses([
+      addMissingTaskInstallResponses([
         { code: 0, stdout: "", stderr: "" },
         { code: 0, stdout: "", stderr: "" },
         { code: 0, stdout: "", stderr: "" },
@@ -1478,12 +1554,17 @@ describe("Windows startup fallback", () => {
           );
         const before = await snapshot();
         await writeGatewayScript(env);
-        addSuccessfulScheduledTaskRestartResponses();
+        addSuccessfulScheduledTaskRestartResponses([
+          notYetRunTaskQueryOutput(),
+          runningTaskQueryOutput(),
+        ]);
 
         await restartScheduledTask({ env, stdout: new PassThrough(), preserveDefinition });
 
         if (preserveDefinition) {
           expect(await snapshot()).toEqual(before);
+          expect(sleepMock).not.toHaveBeenCalled();
+          expect(schtasksCalls.filter((call) => call.includes("/V"))).toHaveLength(1);
         } else {
           for (const file of files) {
             await expect(fs.access(file)).rejects.toThrow();
@@ -1583,9 +1664,7 @@ describe("Windows startup fallback", () => {
 
   it("falls back to a Startup-folder launcher when schtasks create returns Spanish access denied", async () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
-      addStartupFallbackMissingResponses([
-        { code: 1, stdout: "", stderr: "Error: Acceso denegado." },
-      ]);
+      addMissingTaskInstallResponses([{ code: 1, stdout: "", stderr: "Error: Acceso denegado." }]);
 
       await installGatewayScheduledTask(env);
 
@@ -1596,7 +1675,7 @@ describe("Windows startup fallback", () => {
 
   it("falls back to a Startup-folder launcher when schtasks create returns localized access denied", async () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
-      addStartupFallbackMissingResponses([{ code: 1, stdout: "", stderr: "错误: 拒绝访问。" }]);
+      addMissingTaskInstallResponses([{ code: 1, stdout: "", stderr: "错误: 拒绝访问。" }]);
 
       await installGatewayScheduledTask(env);
 
@@ -1607,7 +1686,7 @@ describe("Windows startup fallback", () => {
 
   it("falls back to a Startup-folder launcher when schtasks create hangs", async () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
-      addStartupFallbackMissingResponses([
+      addMissingTaskInstallResponses([
         { code: 124, stdout: "", stderr: "schtasks timed out after 15000ms" },
       ]);
 
@@ -1621,7 +1700,6 @@ describe("Windows startup fallback", () => {
   it("falls back to a Startup-folder launcher when schtasks availability is slow", async () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
       schtasksResponses.push(
-        { code: 124, stdout: "", stderr: "schtasks produced no output for 30000ms" },
         { code: 124, stdout: "", stderr: "schtasks produced no output for 30000ms" },
         { code: 124, stdout: "", stderr: "schtasks produced no output for 30000ms" },
       );
@@ -1766,25 +1844,32 @@ describe("Windows startup fallback", () => {
 
   it("does not relaunch the task script when schtasks shows startup progress after /Run", async () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
-      addStartupFallbackMissingResponses([
+      addMissingTaskInstallResponses([
         { code: 0, stdout: "", stderr: "" },
         { code: 0, stdout: "", stderr: "" },
         { code: 0, stdout: "", stderr: "" },
         { code: 0, stdout: notYetRunTaskQueryOutput(), stderr: "" },
+        { code: 0, stdout: "", stderr: "" },
         {
           code: 0,
-          stdout: [
-            "Status: Ready",
-            "Last Run Time: 4/15/2026 11:42:31 PM",
-            "Last Run Result: 267011",
-            "",
-          ].join("\r\n"),
+          stdout: notYetRunTaskQueryOutput("4/15/2026 11:42:31 PM"),
           stderr: "",
         },
       ]);
+      const expectedCommandCount = schtasksResponses.length;
 
       await installGatewayScheduledTask(env);
 
+      expect(schtasksCalls).toHaveLength(expectedCommandCount);
+      expect(schtasksResponses).toEqual([]);
+      expect(schtasksCalls.slice(-4)).toEqual([
+        ["/Query"],
+        ["/Query", "/TN", "OpenClaw Gateway", "/V", "/FO", "LIST"],
+        ["/Query"],
+        ["/Query", "/TN", "OpenClaw Gateway", "/V", "/FO", "LIST"],
+      ]);
+      expect(sleepMock).toHaveBeenCalledTimes(1);
+      expect(sleepMock).toHaveBeenCalledWith(250);
       expect(spawn).not.toHaveBeenCalled();
     });
   });
@@ -2012,30 +2097,24 @@ describe("Windows startup fallback", () => {
     });
   });
 
-  it("treats an installed Startup-folder launcher as loaded", async () => {
-    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
-      addStartupFallbackMissingResponses();
-      await writeStartupFallbackEntry(env);
+  it.each([false, true])(
+    "treats a Startup cmd entry as installed until removed (hidden launcher=%s)",
+    async (hidden) => {
+      await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+        const taskEnv = hidden ? { ...env, OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER: "1" } : env;
+        addMissingTaskInstallResponses([]);
+        const startupEntryPath = await writeStartupFallbackEntry(env);
 
-      await expect(isScheduledTaskInstalled({ env })).resolves.toBe(true);
-    });
-  });
+        await expect(isScheduledTaskInstalled({ env: taskEnv })).resolves.toBe(true);
+        expect(schtasksCalls).toEqual([["/Query", "/TN", "OpenClaw Gateway"]]);
+        expect(schtasksResponses).toEqual([]);
 
-  it("keeps legacy Startup-folder cmd entries visible after hidden launcher opt-in", async () => {
-    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
-      addStartupFallbackMissingResponses();
-      await writeStartupFallbackEntry(env);
-
-      await expect(
-        isScheduledTaskInstalled({
-          env: {
-            ...env,
-            OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER: "1",
-          },
-        }),
-      ).resolves.toBe(true);
-    });
-  });
+        await fs.unlink(startupEntryPath);
+        addMissingTaskInstallResponses([]);
+        await expect(isScheduledTaskInstalled({ env: taskEnv })).resolves.toBe(false);
+      });
+    },
+  );
 
   it("removes legacy Startup-folder cmd entries after hidden launcher opt-in", async () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
@@ -2323,6 +2402,7 @@ describe("Windows startup fallback", () => {
       });
 
       expectStartupFallbackSpawn();
+      expect(schtasksCalls.filter((call) => call.includes("/V"))).toHaveLength(2);
     });
   });
 

--- a/src/daemon/schtasks.stop.test.ts
+++ b/src/daemon/schtasks.stop.test.ts
@@ -703,8 +703,6 @@ describe("Scheduled Task stop/restart cleanup", () => {
         ["/Run", "/TN", "OpenClaw Gateway"],
         ["/Query"],
         ["/Query", "/TN", "OpenClaw Gateway", "/V", "/FO", "LIST"],
-        ["/Query"],
-        ["/Query", "/TN", "OpenClaw Gateway", "/V", "/FO", "LIST"],
       ]);
     });
   });
@@ -729,8 +727,6 @@ describe("Scheduled Task stop/restart cleanup", () => {
         ["/Query", "/TN", "OpenClaw Node"],
         ["/End", "/TN", "OpenClaw Node"],
         ["/Run", "/TN", "OpenClaw Node"],
-        ["/Query"],
-        ["/Query", "/TN", "OpenClaw Node", "/V", "/FO", "LIST"],
         ["/Query"],
         ["/Query", "/TN", "OpenClaw Node", "/V", "/FO", "LIST"],
       ]);

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -30,8 +30,7 @@ import {
 import { isNonMinimalServicePathEntry, normalizeServicePathEntry } from "./service-path-policy.js";
 import type { GatewayServiceEnvironmentValueSource } from "./service-types.js";
 import { execSystemctlUser } from "./systemd-exec.js";
-import { resolveSystemdServiceName } from "./systemd-service-files.js";
-import { resolveSystemdUserUnitPath } from "./systemd.js";
+import { resolveSystemdServiceName, resolveSystemdUnitPath } from "./systemd-service-files.js";
 
 export type GatewayServiceCommand = {
   programArguments: string[];
@@ -188,7 +187,7 @@ async function auditSystemdUnit(
   issues: ServiceConfigIssue[],
   timeoutMs?: number,
 ) {
-  const unitPath = resolveSystemdUserUnitPath(env);
+  const unitPath = resolveSystemdUnitPath(env);
   let content;
   try {
     content = await fs.readFile(unitPath, "utf8");

--- a/src/daemon/systemd-definition-mutation.test.ts
+++ b/src/daemon/systemd-definition-mutation.test.ts
@@ -123,6 +123,24 @@ describe.skipIf(process.platform === "win32")("systemd definition mutation owner
     });
   }
 
+  function afterUnitTemporaryWrite(fault: () => void | Promise<void>) {
+    const writeFile = fs.writeFile.bind(fs);
+    vi.spyOn(fs, "writeFile").mockImplementation(async (...args) => {
+      await writeFile(...args);
+      if (
+        typeof args[0] === "string" &&
+        args[0].startsWith(`${unitPath}.`) &&
+        args[0].endsWith(".tmp")
+      ) {
+        await fault();
+      }
+    });
+  }
+
+  async function expectNoTemporaryFiles(directory: string) {
+    expect((await fs.readdir(directory)).filter((file) => file.endsWith(".tmp"))).toEqual([]);
+  }
+
   it.each(["unit", "state", "ancestor"])(
     "publishes a first unit through a %s directory alias discovered by the manager",
     async (alias) => {
@@ -410,7 +428,7 @@ describe.skipIf(process.platform === "win32")("systemd definition mutation owner
       }
       expect(await fs.readFile(shared, "utf8")).toContain("30s");
       for (const directory of [path.dirname(unitPath), stateDir]) {
-        expect((await fs.readdir(directory)).filter((file) => file.endsWith(".tmp"))).toEqual([]);
+        await expectNoTemporaryFiles(directory);
       }
     },
   );
@@ -510,16 +528,8 @@ describe.skipIf(process.platform === "win32")("systemd definition mutation owner
         await mutation.publish(unitPath, "managed definition", 0o644);
         await mutation.restore(extra, null);
         expect(await fs.readFile(extra, "utf8")).toContain("OWNER=first");
-        const writeFile = fs.writeFile.bind(fs);
-        vi.spyOn(fs, "writeFile").mockImplementation(async (...args) => {
-          await writeFile(...args);
-          if (
-            typeof args[0] === "string" &&
-            args[0].startsWith(`${unitPath}.`) &&
-            args[0].endsWith(".tmp")
-          ) {
-            await writeFile(extra, "[Service]\nEnvironment=OWNER=second\n");
-          }
+        afterUnitTemporaryWrite(async () => {
+          await fs.writeFile(extra, "[Service]\nEnvironment=OWNER=second\n");
         });
         await expect(mutation.publish(unitPath, "must not publish", 0o644)).rejects.toThrow(
           "changed during publication",
@@ -528,9 +538,7 @@ describe.skipIf(process.platform === "win32")("systemd definition mutation owner
       expect(await fs.readFile(unitPath, "utf8")).toBe("managed definition");
       expect(await fs.readFile(extra, "utf8")).toContain("OWNER=second");
       expect(await fs.readFile(environmentPath, "utf8")).toBe("OPERATOR=preserved\n");
-      expect(
-        (await fs.readdir(path.dirname(unitPath))).filter((file) => file.endsWith(".tmp")),
-      ).toEqual([]);
+      await expectNoTemporaryFiles(path.dirname(unitPath));
     },
   );
 
@@ -568,9 +576,7 @@ describe.skipIf(process.platform === "win32")("systemd definition mutation owner
       );
     });
     expect(await fs.readFile(target, "utf8")).toBe("operator edit");
-    expect(
-      (await fs.readdir(path.dirname(target))).filter((file) => file.endsWith(".tmp")),
-    ).toEqual([]);
+    await expectNoTemporaryFiles(path.dirname(target));
   });
 
   it.each(
@@ -608,9 +614,7 @@ describe.skipIf(process.platform === "win32")("systemd definition mutation owner
         await expect(fs.stat(target)).rejects.toMatchObject({ code: "ENOENT" });
       }
       expect(await fs.readFile(extra, "utf8")).toContain("OWNER=second");
-      expect(
-        (await fs.readdir(path.dirname(target))).filter((file) => file.endsWith(".tmp")),
-      ).toEqual([]);
+      await expectNoTemporaryFiles(path.dirname(target));
     },
   );
 
@@ -653,7 +657,7 @@ describe.skipIf(process.platform === "win32")("systemd definition mutation owner
         }
       }
       for (const directory of [path.dirname(unitPath), stateDir]) {
-        expect((await fs.readdir(directory)).filter((file) => file.endsWith(".tmp"))).toEqual([]);
+        await expectNoTemporaryFiles(directory);
       }
     },
   );
@@ -706,16 +710,8 @@ describe.skipIf(process.platform === "win32")("systemd definition mutation owner
 
   it("cleans unpublished temporary files after a write failure", async () => {
     await fs.writeFile(unitPath, "previous definition");
-    const writeFile = fs.writeFile.bind(fs);
-    vi.spyOn(fs, "writeFile").mockImplementation(async (...args) => {
-      await writeFile(...args);
-      if (
-        typeof args[0] === "string" &&
-        args[0].startsWith(`${unitPath}.`) &&
-        args[0].endsWith(".tmp")
-      ) {
-        throw new Error("write failed");
-      }
+    afterUnitTemporaryWrite(() => {
+      throw new Error("write failed");
     });
     await expect(
       withSystemdDefinitionMutation(env, env, (mutation) =>
@@ -723,9 +719,7 @@ describe.skipIf(process.platform === "win32")("systemd definition mutation owner
       ),
     ).rejects.toThrow("write failed");
     expect(await fs.readFile(unitPath, "utf8")).toBe("previous definition");
-    expect(
-      (await fs.readdir(path.dirname(unitPath))).filter((file) => file.endsWith(".tmp")),
-    ).toEqual([]);
+    await expectNoTemporaryFiles(path.dirname(unitPath));
   });
 
   it("rejects manager definition path changes during publication", async () => {
@@ -738,16 +732,8 @@ describe.skipIf(process.platform === "win32")("systemd definition mutation owner
 
     await expect(
       withSystemdDefinitionMutation(env, env, async (mutation) => {
-        const writeFile = fs.writeFile.bind(fs);
-        vi.spyOn(fs, "writeFile").mockImplementation(async (...args) => {
-          await writeFile(...args);
-          if (
-            typeof args[0] === "string" &&
-            args[0].startsWith(`${unitPath}.`) &&
-            args[0].endsWith(".tmp")
-          ) {
-            managerDefinition(unitPath, [second]);
-          }
+        afterUnitTemporaryWrite(() => {
+          managerDefinition(unitPath, [second]);
         });
         await mutation.publish(unitPath, "must not publish", 0o644);
       }),

--- a/src/daemon/systemd-service-files.ts
+++ b/src/daemon/systemd-service-files.ts
@@ -41,10 +41,6 @@ export function resolveSystemdUnitPath(env: GatewayServiceEnv): string {
   return resolveSystemdUnitPathForName(env, resolveSystemdServiceName(env));
 }
 
-export function resolveSystemdUserUnitPath(env: GatewayServiceEnv): string {
-  return resolveSystemdUnitPath(env);
-}
-
 // Unit file parsing/rendering: see systemd-unit.ts
 
 type SystemdEnvironmentFileSpec = string | [string, boolean];
@@ -455,9 +451,7 @@ export function resolveLegacyNodeSystemdEnvironmentFilePath(params: {
   if (params.environment?.OPENCLAW_SERVICE_KIND?.trim() !== "node") {
     return null;
   }
-  const legacyPath = path.join(params.stateDir, SYSTEMD_GATEWAY_DOTENV_FILENAME);
-  const currentPath = resolveSystemdEnvironmentFilePath(params);
-  return legacyPath === currentPath ? null : legacyPath;
+  return path.join(params.stateDir, SYSTEMD_GATEWAY_DOTENV_FILENAME);
 }
 
 export function isNodeSystemdEnvironment(env: GatewayServiceEnv): boolean {

--- a/src/daemon/systemd-system.test.ts
+++ b/src/daemon/systemd-system.test.ts
@@ -203,28 +203,12 @@ describe("system systemd ownership", () => {
     }
   });
 
-  it("fails closed when the system manager cannot be queried", async () => {
-    state.systemctl = {
-      stdout: "",
-      stderr: "Failed to connect to bus: Permission denied",
-      code: 1,
-      termination: "exit",
-    };
-
-    await expect(assertNoSystemSystemdOwnership("openclaw-gateway.service")).rejects.toMatchObject({
-      ownership: {
-        status: "unverifiable",
-        unitName: "openclaw-gateway.service",
-        operation: "systemctl",
-        detail: "Failed to connect to bus: Permission denied",
-      },
-    });
-  });
-
   it.each([
+    "Failed to connect to bus: Permission denied",
     "spawn systemctl ENOENT",
     "systemctl not available",
     "System has not been booted with systemd as init system",
+    "Failed to connect to bus: No such file or directory",
   ])("fails closed when manager absence cannot be proven: %s", async (detail) => {
     state.systemctl = { stdout: "", stderr: detail, code: 1, termination: "exit" };
 
@@ -237,23 +221,6 @@ describe("system systemd ownership", () => {
       },
     });
     expect(fs.lstat).not.toHaveBeenCalled();
-  });
-
-  it("does not mistake a missing system bus for a missing unit", async () => {
-    state.systemctl = {
-      stdout: "",
-      stderr: "Failed to connect to bus: No such file or directory",
-      code: 1,
-      termination: "exit",
-    };
-
-    await expect(assertNoSystemSystemdOwnership("openclaw-gateway.service")).rejects.toMatchObject({
-      ownership: {
-        status: "unverifiable",
-        operation: "systemctl",
-        detail: "Failed to connect to bus: No such file or directory",
-      },
-    });
   });
 
   it.each(["exit", "timeout", "signal"] as const)(

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -91,6 +91,7 @@ vi.mock("./exec-file.js", () => {
 
 import { splitArgsPreservingQuotes } from "./arg-split.js";
 import * as systemdExec from "./systemd-exec.js";
+import { resolveSystemdUnitPath } from "./systemd-service-files.js";
 import { parseSystemdEnvAssignments, parseSystemdExecStart } from "./systemd-unit.js";
 import {
   findInstalledSystemdGatewayScope,
@@ -105,7 +106,6 @@ import {
   readSystemdServiceExecStart,
   restartSystemdService,
   resolveSystemdUserServiceAccount,
-  resolveSystemdUserUnitPath,
   startSystemdService,
   stageSystemdService,
   stopSystemdService,
@@ -1430,7 +1430,7 @@ describe("readSystemdServiceRuntime", () => {
   });
 });
 
-describe("resolveSystemdUserUnitPath", () => {
+describe("resolveSystemdUnitPath", () => {
   it.each([
     {
       name: "uses default service name when OPENCLAW_PROFILE is unset",
@@ -1468,7 +1468,7 @@ describe("resolveSystemdUserUnitPath", () => {
       expected: "/home/test/.config/systemd/user/custom-unit.service",
     },
   ])("$name", ({ env, expected }) => {
-    expect(resolveSystemdUserUnitPath(env)).toBe(expected);
+    expect(resolveSystemdUnitPath(env)).toBe(expected);
   });
 });
 
@@ -2021,7 +2021,7 @@ describe("readSystemdServiceExecStart", () => {
   it("reads manager-expanded EnvironmentFile globs in deterministic precedence order", async () => {
     const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-systemd-glob-"));
     const env = { HOME: home };
-    const unitPath = resolveSystemdUserUnitPath(env);
+    const unitPath = resolveSystemdUnitPath(env);
     const environmentDir = path.join(home, "env.d");
     try {
       await fs.mkdir(path.dirname(unitPath), { recursive: true });
@@ -2309,7 +2309,7 @@ describe("stageSystemdService", () => {
       OPENCLAW_STATE_DIR: stateDir,
       OPENCLAW_SYSTEMD_UNIT: "openclaw-gateway-stage-test",
     };
-    const unitPath = resolveSystemdUserUnitPath(env);
+    const unitPath = resolveSystemdUnitPath(env);
     const envFilePath = path.join(stateDir, "gateway.systemd.env");
     const nodeEnvFilePath = path.join(stateDir, "node.systemd.env");
 
@@ -3067,7 +3067,7 @@ describe("systemd service install and uninstall", () => {
       OPENCLAW_SYSTEMD_UNIT: "openclaw-node",
       OPENCLAW_SERVICE_KIND: "node",
     };
-    const unitPath = resolveSystemdUserUnitPath(env);
+    const unitPath = resolveSystemdUnitPath(env);
     const nodeEnvFilePath = path.join(stateDir, "node.systemd.env");
 
     try {
@@ -3580,7 +3580,7 @@ describe("uninstallUserSystemdGatewayUnit", () => {
     const tempHomeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-user-unit-"));
     const home = path.join(tempHomeRoot, "home");
     const env = { HOME: home };
-    const unitPath = resolveSystemdUserUnitPath(env);
+    const unitPath = resolveSystemdUnitPath(env);
     try {
       await fs.mkdir(path.dirname(unitPath), { recursive: true });
       await run({ env, unitPath });

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -20,10 +20,7 @@ export {
 } from "./systemd-lifecycle.js";
 export { enableSystemdUserLinger, readSystemdUserLingerStatus } from "./systemd-linger.js";
 export { isSystemdServiceEnabled, readSystemdServiceRuntime } from "./systemd-runtime.js";
-export {
-  readSystemdServiceExecStart,
-  resolveSystemdUserUnitPath,
-} from "./systemd-service-files.js";
+export { readSystemdServiceExecStart } from "./systemd-service-files.js";
 export {
   findInstalledSystemdGatewayScope,
   findSystemdGatewayInstallation,

--- a/src/infra/tcp-port.test.ts
+++ b/src/infra/tcp-port.test.ts
@@ -22,7 +22,9 @@ describe("parseTcpPort", () => {
 });
 
 describe("parseTcpPortFromArgs", () => {
-  it("uses the last valid port flag from repeated CLI arguments", () => {
+  it("accepts inline and spaced flags and uses the last valid port", () => {
+    expect(parseTcpPortFromArgs(["--port=14720"])).toBe(14_720);
+    expect(parseTcpPortFromArgs(["--port", "14721"])).toBe(14_721);
     expect(parseTcpPortFromArgs(["gateway", "--port", "18789", "--port", "19001"])).toBe(19001);
     expect(parseTcpPortFromArgs(["gateway", "--port=18789", "--port=19002"])).toBe(19002);
     expect(parseTcpPortFromArgs(["gateway", "--port", "18789", "--port=19003"])).toBe(19003);
@@ -31,6 +33,7 @@ describe("parseTcpPortFromArgs", () => {
   it("keeps best-effort parsing when repeated flags contain invalid values", () => {
     expect(parseTcpPortFromArgs(["gateway", "--port=invalid", "--port", "19004"])).toBe(19004);
     expect(parseTcpPortFromArgs(["gateway", "--port", "19005", "--port=invalid"])).toBe(19005);
+    expect(parseTcpPortFromArgs(["--port=123=bad"])).toBeNull();
   });
 
   it("does not reinterpret a consumed port value as another flag", () => {

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -256,6 +256,26 @@ function isProcessRunning(pid: number): boolean {
   }
 }
 
+async function stopUpgradeSurvivorSupervisor(supervisor: ChildProcess, pidPath: string) {
+  try {
+    if (supervisor.exitCode === null && supervisor.signalCode === null) {
+      supervisor.kill("SIGTERM");
+      await waitForProcessExit(supervisor).catch(() => undefined);
+    }
+  } finally {
+    // Read the owned fixture's publication during cleanup even if readiness failed
+    // before the test learned the descendant PID.
+    if (existsSync(pidPath)) {
+      const pid = Number(readFileSync(pidPath, "utf8").trim());
+      if (Number.isSafeInteger(pid) && pid > 1 && isProcessRunning(pid)) {
+        try {
+          process.kill(pid, "SIGKILL");
+        } catch {}
+      }
+    }
+  }
+}
+
 function writeTermIgnoringDescendant(workDir: string): string {
   const descendantPath = join(workDir, "descendant.mjs");
   writeFileSync(
@@ -3631,13 +3651,15 @@ setInterval(() => {}, 1_000);
           },
           stdio: "ignore",
         });
-        let descendantPid: number | undefined;
         try {
           for (let attempt = 0; attempt < 100 && !existsSync(statePath); attempt += 1) {
             await delay(10);
           }
-          expect(existsSync(statePath)).toBe(true);
-          descendantPid = Number.parseInt(readFileSync(descendantPidPath, "utf8"), 10);
+          expect(
+            existsSync(statePath),
+            `${supervisorPath}: readiness missing (exit=${supervisor.exitCode}, signal=${supervisor.signalCode})`,
+          ).toBe(true);
+          const descendantPid = Number.parseInt(readFileSync(descendantPidPath, "utf8"), 10);
           expect(descendantPid).toBeGreaterThan(1);
           expect(isProcessRunning(descendantPid)).toBe(true);
 
@@ -3649,15 +3671,7 @@ setInterval(() => {}, 1_000);
           }
           expect(isProcessRunning(descendantPid)).toBe(false);
         } finally {
-          if (supervisor.exitCode === null && supervisor.signalCode === null) {
-            supervisor.kill("SIGTERM");
-            await waitForProcessExit(supervisor).catch(() => undefined);
-          }
-          if (descendantPid !== undefined && isProcessRunning(descendantPid)) {
-            try {
-              process.kill(descendantPid, "SIGKILL");
-            } catch {}
-          }
+          await stopUpgradeSurvivorSupervisor(supervisor, descendantPidPath);
         }
       }
     },
@@ -3725,23 +3739,14 @@ if (starts === 1) {
           },
           stdio: "ignore",
         });
-        let descendantPid: number | undefined;
         try {
           expect(await waitForProcessExit(supervisor)).toBe(0);
-          descendantPid = Number.parseInt(readFileSync(descendantPidPath, "utf8"), 10);
+          const descendantPid = Number.parseInt(readFileSync(descendantPidPath, "utf8"), 10);
           expect(descendantPid).toBeGreaterThan(1);
           expect(readFileSync(startsPath, "utf8")).toBe("xx");
           expect(readFileSync(replacementPath, "utf8")).toBe("drained");
         } finally {
-          if (supervisor.exitCode === null && supervisor.signalCode === null) {
-            supervisor.kill("SIGTERM");
-            await waitForProcessExit(supervisor).catch(() => undefined);
-          }
-          if (descendantPid !== undefined && isProcessRunning(descendantPid)) {
-            try {
-              process.kill(descendantPid, "SIGKILL");
-            } catch {}
-          }
+          await stopUpgradeSurvivorSupervisor(supervisor, descendantPidPath);
         }
       }
     },


### PR DESCRIPTION
Related: [sealed-service updates](https://github.com/openclaw/openclaw/pull/131021).

## What Problem This Solves

Fixes an issue where Windows fallback migration could report completion after its Startup entry disappeared, even when the replacement was not running. The old implementation tied takeover verification to current file presence instead of the running fallback already captured by the installation operation.

This cleanup also removes discarded Task Scheduler probes, internal port/unit-path wrappers and repeated test scaffolding.

## Why This Change Was Made

Separate the decision to remove a Startup definition from the requirement to verify a captured takeover. Every takeover now uses the existing readiness waiter and unchanged polling/deadline settings, whether or not its Startup entry remains. Delayed legitimate startup can settle; a failed replacement follows the existing task-ending, owned-process teardown and captured-command restoration path instead of falling through to completion.

Standard no-Startup and preserved-definition restarts skip verification that has no consumer. File staging no longer performs an ignored scheduler-availability query. Internal callers use the canonical port parser and systemd unit-path resolver. Lease, ownership-diagnostic and mutation-fault tests share setup without losing their distinct scenarios. The nearby process-supervision fixture cleanup rereads its own published descendant PID even if an earlier readiness assertion failed.

## User Impact

Windows service maintenance avoids unnecessary queries while retaining seal, ownership, activation and recovery boundaries. A disappearing Startup entry no longer bypasses takeover verification. Configuration/environment materialization, ports, public CLI/config shapes, dependencies, pnpm policy, persistence, package fixtures and operator services are unchanged.

The patch is **net -8 lines: production +32/-50 (-18), tests/support +428/-418 (+10)**. Most fixture savings fund the new success/failure regression coverage; no assertions or budgets were weakened to reduce the count. Three duplicate lease orchestration runs are removed, with exclusive mutation and fresh-child acquisition now checked together in each retained lane. Parser assertions move to their canonical owner.

## Evidence

- **980 targeted local cases passed:** 127 CLI/status/port, 489 daemon/ownership, 152 update/lease/Doctor, and 212 process/script-fixture cases.
- Missing-Startup failure regression: failed before the repair because installation resolved instead of rejecting; passed afterward, including late replacement teardown, restoration of the captured executable and absence of restart-success output.
- Delayed-start regression: exposed premature rejection in the intermediate single-observation approach; both Startup-present and Startup-removed rows pass with the canonical waiter. This was caught before publication, not a claimed shipped regression.
- Local changed gates, root-test gates, and final focused core/service-test typechecks and lint passed. Fresh isolated Codex review through P1, with complete takeover owner/caller context, found no actionable findings.
- The patch-identical rebase onto current main integrated cleanly. Refreshed runtime/status and script-fixture tests, core/service/CLI/root-test typechecks and formatting passed on `d0bafa1a73575f4cb8a586ed5d3d71e5e86f74fd`. The full local `pnpm build` passed with the source frozen and zero ineffective-dynamic-import warnings.
- **Exact-head CI passed:** [CI run 33205353814](https://github.com/openclaw/openclaw/actions/runs/33205353814), attempt 1, head `d0bafa1a73575f4cb8a586ed5d3d71e5e86f74fd`.
- **Native Windows proof passed:** [Windows run 33206527659](https://github.com/openclaw/openclaw/actions/runs/33206527659), attempt 1, with [inspected proof and cleanup artifact](https://github.com/openclaw/openclaw/actions/runs/33206527659/artifacts/9700167612). The artifact identifies the exact PR head and proves install/stop/start/restart/stop/uninstall with three distinct PIDs, port release/rebind, interactive least-privilege registration, unchanged default task, detached direct/batch fallback launches, missing-file/executable and ACL-denied failures, and final task/process cleanup. All five integration-file cases passed; the native lifecycle case ran in an interactive Windows session.
- The initial [Blacksmith native attempt](https://github.com/openclaw/openclaw/actions/runs/33205478767) failed its mandatory preflight because the runner had session 0 and no interactive user. Native execution was skipped, cleanup was verified, and no success is claimed for that attempt. The same code and unchanged workflow then passed on its supported `windows-2025` runner; no guard, budget or dependency policy was changed.
- **ClawSweeper disposition:** exact-head native lifecycle evidence is attached; no code findings remain. The optional native delayed-takeover/failed-restoration trace is not included: the existing native harness does not deterministically inject these scheduler/file-removal races. Those cases have failing/passing owner-boundary regression proof and are explicitly not described as native race reproduction.

Validation history: the first broader run timed out in an unchanged installer strict-config-validation case; the unchanged replay passed all 125 CLI cases plus 27 Doctor cases. An existing process-supervision fixture also missed its readiness marker on one run; subsequent full fixture runs passed. Neither timeout/readiness budget was increased, and neither timing cause is claimed fixed. Cold config validation and fixture startup timing remain named follow-ups. Superseded local builds were cancelled during repair and are not passing build evidence.

The proposed Linux D-Bus fixture deduplication is deliberately excluded: two fresh Testbox acquisition attempts failed with HTTP 429 before package proof could run. The original fixture remains byte-identical to the base, and no historical package or pnpm qualification artifact is claimed as proof. A separate follow-up must run fresh root-owned-file and mount scenarios before making that change.
