### PR TITLE
fix(ui): retain confirmed owners across stale session lists

### DIFF
--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -178,7 +178,9 @@ export function createSessionCapability(
   ): SessionsListResult | null =>
     deletions.apply(
       mutations.applyConfirmedOwners(
-        mutations.applyConfirmedArchives(mutations.applyPendingRows(swarmActivity.decorate(result))),
+        mutations.applyConfirmedArchives(
+          mutations.applyPendingRows(swarmActivity.decorate(result)),
+        ),
         scope,
         requestRevision,
         agentId === undefined ? state.agentId : agentId,

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -172,9 +172,17 @@ export function createSessionCapability(
   const decorateRows = (
     result: SessionsListResult | null,
     owner = roster.primaryList(),
+    scope?: string,
+    requestRevision?: number,
+    agentId?: string | null,
   ): SessionsListResult | null =>
     deletions.apply(
-      mutations.applyConfirmedArchives(mutations.applyPendingRows(swarmActivity.decorate(result))),
+      mutations.applyConfirmedOwners(
+        mutations.applyConfirmedArchives(mutations.applyPendingRows(swarmActivity.decorate(result))),
+        scope,
+        requestRevision,
+        agentId === undefined ? state.agentId : agentId,
+      ),
       owner,
     );
 
@@ -211,6 +219,9 @@ export function createSessionCapability(
     observerError: () => sessionEventSubscriptionError,
     bootstrap: (scope, list) => sessionEventSubscription.ensure(scope, list),
     decorate: decorateRows,
+    observeCanonicalRows: (result, requestRevision, scope, agentId) =>
+      mutations.observeCanonicalOwners(result, requestRevision, scope, agentId),
+    retireCanonicalScope: (scope) => mutations.retireCanonicalOwnerScope(scope),
     reconcileList: (result, revision, agentId) =>
       permissions.reconcileList(
         deletions.reconcileList(result, revision, agentId),
@@ -252,7 +263,11 @@ export function createSessionCapability(
     connection,
     readState: () => state,
     publish,
-    refreshReplacement: roster.refreshReplacement,
+    refreshReplacement: (agentId, reconcileOwner) =>
+      reconcileOwner
+        ? roster.refreshOwnerAssignmentScopes(agentId)
+        : roster.refreshReplacement(agentId),
+    ownerAssignmentScopeRevisions: (agentId) => roster.ownerAssignmentScopeRevisions(agentId),
     refreshReplacementResult: roster.refreshReplacementResult,
     publishedRow: (key) => roster.publishedRow((row) => row.key === key),
     redecorateLists: () => roster.redecorateLists(),
@@ -408,6 +423,7 @@ export function createSessionCapability(
         state.agentId,
       );
     }
+    mutations.observeCanonicalOwnerEvent(reconciled.row, eventInfo?.agentId);
     let claimChanged = false;
     if (reconciled.applied && reconciled.key && eventInfo) {
       const claimKey = sessionClaimKey(reconciled.key, eventInfo.agentId);

--- a/ui/src/lib/sessions/list-options-owner-assignment.test.ts
+++ b/ui/src/lib/sessions/list-options-owner-assignment.test.ts
@@ -1,0 +1,489 @@
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { SessionsListResult } from "../../api/types.ts";
+import { createSessionCapability } from "./index.ts";
+
+function sessionsResult(sessions: SessionsListResult["sessions"], ts: number): SessionsListResult {
+  return {
+    ts,
+    path: "(multiple)",
+    count: sessions.length,
+    defaults: { modelProvider: null, model: null, contextTokens: null },
+    sessions,
+  };
+}
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (error: unknown) => void = () => undefined;
+  const promise = new Promise<T>((next, fail) => {
+    resolve = next;
+    reject = fail;
+  });
+  return { promise, reject, resolve };
+}
+
+function createSessions(
+  client: GatewayBrowserClient,
+  key: string,
+  subscribeEvents: Parameters<typeof createSessionCapability>[0]["subscribeEvents"] = () => () =>
+    undefined,
+) {
+  return createSessionCapability({
+    snapshot: {
+      client,
+      phase: "connected" as const,
+      sessionKey: key,
+      assistantAgentId: "main",
+      hello: null,
+      selfUser: null,
+    },
+    subscribe: () => () => undefined,
+    subscribeEvents,
+  });
+}
+
+describe("session owner assignment list reconciliation", () => {
+  it("keeps the confirmed owner and invalidates facets during reconciliation", async () => {
+    const key = "agent:main:owner-facet";
+    const ada = { type: "human" as const, id: "profile-ada", label: "Ada" };
+    const bob = { type: "human" as const, id: "profile-bob", label: "Bob" };
+    const assignedOwner = { actor: ada, assignedBy: ada, assignedAt: 20 };
+    const replacement = deferred<SessionsListResult>();
+    let listCalls = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.assignOwner") {
+        return { ok: true, key, owner: assignedOwner };
+      }
+      if (method === "sessions.list") {
+        listCalls += 1;
+        return listCalls === 1
+          ? {
+              ...sessionsResult(
+                [{ key, kind: "direct", updatedAt: 10, owner: { actor: bob, assignedBy: bob } }],
+                10,
+              ),
+              owners: [bob],
+            }
+          : await replacement.promise;
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const sessions = createSessions({ request } as unknown as GatewayBrowserClient, key);
+    await sessions.refresh({ agentId: "main", force: true });
+
+    await sessions.assignOwner(key, ada, { agentId: "main" });
+
+    expect(sessions.state.result?.sessions[0]?.owner).toEqual(assignedOwner);
+    expect(sessions.state.result?.owners).toBeUndefined();
+    replacement.resolve({
+      ...sessionsResult([{ key, kind: "direct", updatedAt: 20, owner: assignedOwner }], 20),
+      owners: [ada],
+    });
+    sessions.dispose();
+  });
+
+  it("protects direct list responses started before assignment", async () => {
+    const key = "agent:main:direct-owner";
+    const ada = { type: "human" as const, id: "profile-ada" };
+    const bob = { type: "human" as const, id: "profile-bob" };
+    const assignedOwner = { actor: ada, assignedBy: ada, assignedAt: 20 };
+    const staleList = deferred<SessionsListResult>();
+    let listCalls = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.assignOwner") {
+        return { ok: true, key, owner: assignedOwner };
+      }
+      if (method === "sessions.list") {
+        listCalls += 1;
+        return listCalls === 2
+          ? await staleList.promise
+          : sessionsResult([{ key, kind: "direct", updatedAt: 20, owner: assignedOwner }], 20);
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const sessions = createSessions({ request } as unknown as GatewayBrowserClient, key);
+    await sessions.refresh({ agentId: "main", force: true });
+    const directList = sessions.list({ agentId: "main" });
+    await vi.waitFor(() => expect(listCalls).toBe(2));
+
+    await sessions.assignOwner(key, ada, { agentId: "main" });
+    staleList.resolve(
+      sessionsResult(
+        [{ key, kind: "direct", updatedAt: 10, owner: { actor: bob, assignedBy: bob } }],
+        10,
+      ),
+    );
+
+    await expect(directList).resolves.toMatchObject({
+      sessions: [{ owner: assignedOwner }],
+    });
+    sessions.dispose();
+  });
+
+  it("accepts a newer owner event while assignment reconciliation is pending", async () => {
+    const key = "agent:main:event-owner";
+    const ada = { type: "human" as const, id: "profile-ada" };
+    const bob = { type: "human" as const, id: "profile-bob" };
+    const carol = { type: "human" as const, id: "profile-carol" };
+    const assignedOwner = { actor: ada, assignedBy: ada, assignedAt: 20 };
+    const newerOwner = { actor: carol, assignedBy: carol, assignedAt: 30 };
+    const replacement = deferred<SessionsListResult>();
+    let listener: Parameters<
+      Parameters<typeof createSessionCapability>[0]["subscribeEvents"]
+    >[0] = () => undefined;
+    let listCalls = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.assignOwner") {
+        return { ok: true, key, owner: assignedOwner };
+      }
+      if (method === "sessions.list") {
+        listCalls += 1;
+        return listCalls === 1
+          ? sessionsResult(
+              [{ key, kind: "direct", updatedAt: 10, owner: { actor: bob, assignedBy: bob } }],
+              10,
+            )
+          : await replacement.promise;
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const sessions = createSessions({ request } as unknown as GatewayBrowserClient, key, (next) => {
+      listener = next;
+      return () => undefined;
+    });
+    await sessions.refresh({ agentId: "main", force: true });
+    await sessions.assignOwner(key, ada, { agentId: "main" });
+
+    listener({
+      type: "event",
+      event: "sessions.changed",
+      seq: 1,
+      payload: {
+        key,
+        kind: "direct",
+        updatedAt: 30,
+        owner: newerOwner,
+        archived: false,
+        reason: "owner",
+      },
+    });
+
+    expect(sessions.state.result?.sessions[0]?.owner).toEqual(newerOwner);
+    replacement.resolve(
+      sessionsResult([{ key, kind: "direct", updatedAt: 30, owner: newerOwner }], 30),
+    );
+    sessions.dispose();
+  });
+
+  it.each([
+    { label: "without timestamps", assignedAt: undefined },
+    { label: "with tied timestamps", assignedAt: 20 },
+  ])("accepts a later assignment $label", async ({ assignedAt }) => {
+    const key = "agent:main:equal-assignment-revisions";
+    const ada = { type: "human" as const, id: "profile-ada", label: "Ada" };
+    const bob = { type: "human" as const, id: "profile-bob", label: "Bob" };
+    const carol = { type: "human" as const, id: "profile-carol", label: "Carol" };
+    const oldOwner = { actor: bob, assignedBy: bob, assignedAt: 10 };
+    const adaOwner = {
+      actor: ada,
+      assignedBy: ada,
+      ...(assignedAt === undefined ? {} : { assignedAt }),
+    };
+    const carolOwner = {
+      actor: carol,
+      assignedBy: carol,
+      ...(assignedAt === undefined ? {} : { assignedAt }),
+    };
+    const responses = [adaOwner, carolOwner];
+    let serverOwner: NonNullable<SessionsListResult["sessions"][number]["owner"]> = oldOwner;
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.assignOwner") {
+        const owner = responses.shift();
+        if (!owner) {
+          throw new Error("missing assignment response");
+        }
+        serverOwner = owner;
+        return { ok: true, key, owner };
+      }
+      if (method === "sessions.list") {
+        return sessionsResult([{ key, kind: "direct", updatedAt: 20, owner: serverOwner }], 20);
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const sessions = createSessions({ request } as unknown as GatewayBrowserClient, key);
+    await sessions.refresh({ agentId: "main", force: true });
+
+    await expect(sessions.assignOwner(key, ada, { agentId: "main" })).resolves.toEqual(adaOwner);
+    await expect(sessions.assignOwner(key, carol, { agentId: "main" })).resolves.toEqual(
+      carolOwner,
+    );
+    expect(sessions.state.result?.sessions[0]?.owner).toEqual(carolOwner);
+    sessions.dispose();
+  });
+
+  it("serializes assignment requests so responses cannot arrive out of order", async () => {
+    const key = "agent:main:reversed-assignments";
+    const ada = { type: "human" as const, id: "profile-ada", label: "Ada" };
+    const bob = { type: "human" as const, id: "profile-bob", label: "Bob" };
+    const carol = { type: "human" as const, id: "profile-carol", label: "Carol" };
+    const oldOwner = { actor: bob, assignedBy: bob, assignedAt: 10 };
+    const adaOwner = { actor: ada, assignedBy: ada, assignedAt: 20 };
+    const carolOwner = { actor: carol, assignedBy: carol, assignedAt: 30 };
+    const firstResponse = deferred<typeof adaOwner>();
+    const secondResponse = deferred<typeof carolOwner>();
+    let assignmentCalls = 0;
+    let serverOwner = oldOwner;
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.assignOwner") {
+        assignmentCalls += 1;
+        const call = assignmentCalls;
+        const owner = await (call === 1 ? firstResponse.promise : secondResponse.promise);
+        if (call === 2) {
+          serverOwner = owner;
+        }
+        return { ok: true, key, owner };
+      }
+      if (method === "sessions.list") {
+        return sessionsResult([{ key, kind: "direct", updatedAt: 20, owner: serverOwner }], 20);
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const sessions = createSessions({ request } as unknown as GatewayBrowserClient, key);
+    await sessions.refresh({ agentId: "main", force: true });
+
+    const first = sessions.assignOwner(key, ada, { agentId: "main" });
+    await vi.waitFor(() => expect(assignmentCalls).toBe(1));
+    const second = sessions.assignOwner(key, carol, { agentId: "main" });
+
+    firstResponse.resolve(adaOwner);
+    await expect(first).resolves.toEqual(adaOwner);
+    await vi.waitFor(() => expect(assignmentCalls).toBe(2));
+    secondResponse.resolve(carolOwner);
+    await expect(second).resolves.toEqual(carolOwner);
+    expect(sessions.state.result?.sessions[0]?.owner).toEqual(carolOwner);
+    sessions.dispose();
+  });
+
+  it("keeps an earlier successful assignment when the queued request fails", async () => {
+    const key = "agent:main:failed-queued-assignment";
+    const ada = { type: "human" as const, id: "profile-ada", label: "Ada" };
+    const carol = { type: "human" as const, id: "profile-carol", label: "Carol" };
+    const adaOwner = { actor: ada, assignedBy: ada };
+    const serverOwner = adaOwner;
+    let assignmentCalls = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.assignOwner") {
+        assignmentCalls += 1;
+        if (assignmentCalls === 2) {
+          throw new Error("assignment rejected");
+        }
+        return { ok: true, key, owner: adaOwner };
+      }
+      if (method === "sessions.list") {
+        return sessionsResult([{ key, kind: "direct", updatedAt: 20, owner: serverOwner }], 20);
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const sessions = createSessions({ request } as unknown as GatewayBrowserClient, key);
+    await sessions.refresh({ agentId: "main", force: true });
+
+    await expect(sessions.assignOwner(key, ada, { agentId: "main" })).resolves.toEqual(adaOwner);
+    await expect(sessions.assignOwner(key, carol, { agentId: "main" })).resolves.toBeNull();
+    expect(sessions.state.result?.sessions[0]?.owner).toEqual(adaOwner);
+    expect(assignmentCalls).toBe(2);
+    sessions.dispose();
+  });
+
+  it("refreshes an active owner filter that gains the assigned session", async () => {
+    const key = "agent:main:new-owner-filter";
+    const ada = { type: "human" as const, id: "profile-ada", label: "Ada" };
+    const bob = { type: "human" as const, id: "profile-bob", label: "Bob" };
+    const assignedOwner = { actor: ada, assignedBy: ada, assignedAt: 20 };
+    const replacement = deferred<SessionsListResult>();
+    const managedScope = { agentId: "main", ownerId: ada.id };
+    let managedCalls = 0;
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "sessions.assignOwner") {
+        return { ok: true, key, owner: assignedOwner };
+      }
+      if (method !== "sessions.list") {
+        throw new Error(`Unexpected request: ${method}`);
+      }
+      const managed =
+        typeof params === "object" &&
+        params !== null &&
+        "ownerId" in params &&
+        params.ownerId === ada.id;
+      if (!managed) {
+        return sessionsResult([{ key, kind: "direct", updatedAt: 20, owner: assignedOwner }], 20);
+      }
+      managedCalls += 1;
+      return managedCalls === 1
+        ? { ...sessionsResult([], 10), owners: [bob] }
+        : await replacement.promise;
+    });
+    const sessions = createSessions({ request } as unknown as GatewayBrowserClient, key);
+    const stop = sessions.subscribeList(managedScope, () => undefined);
+
+    await sessions.refreshList({ ...managedScope, force: true });
+    expect(sessions.listSnapshot(managedScope).result?.sessions).toHaveLength(0);
+
+    await sessions.assignOwner(key, ada, { agentId: "main" });
+
+    await vi.waitFor(() => expect(managedCalls).toBe(2));
+    expect(sessions.listSnapshot(managedScope).result?.owners).toBeUndefined();
+
+    replacement.resolve({
+      ...sessionsResult([{ key, kind: "direct", updatedAt: 20, owner: assignedOwner }], 20),
+      owners: [ada],
+    });
+    await vi.waitFor(() =>
+      expect(sessions.listSnapshot(managedScope).result?.sessions[0]?.owner).toEqual(assignedOwner),
+    );
+    stop();
+    sessions.dispose();
+  });
+
+  it("carries a newer owner through an older managed-list response", async () => {
+    const key = "agent:main:superseded-managed-owner";
+    const ada = { type: "human" as const, id: "profile-ada", label: "Ada" };
+    const bob = { type: "human" as const, id: "profile-bob", label: "Bob" };
+    const carol = { type: "human" as const, id: "profile-carol", label: "Carol" };
+    const oldOwner = { actor: bob, assignedBy: bob, assignedAt: 10 };
+    const assignedOwner = { actor: ada, assignedBy: ada, assignedAt: 20 };
+    const supersedingOwner = { actor: carol, assignedBy: carol, assignedAt: 30 };
+    const staleManagedResponse = deferred<SessionsListResult>();
+    const managedReplacement = deferred<SessionsListResult>();
+    const managedScope = { agentId: "main", search: "superseded-managed-owner" };
+    let managedCalls = 0;
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "sessions.assignOwner") {
+        return { ok: true, key, owner: assignedOwner };
+      }
+      if (method !== "sessions.list") {
+        throw new Error(`Unexpected request: ${method}`);
+      }
+      const managed =
+        typeof params === "object" &&
+        params !== null &&
+        "search" in params &&
+        params.search === managedScope.search;
+      if (!managed) {
+        return {
+          ...sessionsResult([{ key, kind: "direct", updatedAt: 30, owner: supersedingOwner }], 30),
+          owners: [carol],
+        };
+      }
+      managedCalls += 1;
+      if (managedCalls === 2) {
+        return await staleManagedResponse.promise;
+      }
+      if (managedCalls === 3) {
+        return await managedReplacement.promise;
+      }
+      return {
+        ...sessionsResult([{ key, kind: "direct", updatedAt: 10, owner: oldOwner }], 10),
+        owners: [ada, bob],
+      };
+    });
+    const sessions = createSessions({ request } as unknown as GatewayBrowserClient, key);
+    const stop = sessions.subscribeList(managedScope, () => undefined);
+
+    await sessions.refreshList({ ...managedScope, force: true });
+    const staleRefresh = sessions.refreshList({ ...managedScope, force: true });
+    await vi.waitFor(() => expect(managedCalls).toBe(2));
+    await sessions.assignOwner(key, ada, { agentId: "main" });
+
+    staleManagedResponse.resolve({
+      ...sessionsResult([{ key, kind: "direct", updatedAt: 10, owner: oldOwner }], 10),
+      owners: [ada, bob],
+    });
+    await vi.waitFor(() => expect(managedCalls).toBe(3));
+    expect(sessions.listSnapshot(managedScope).result?.sessions[0]?.owner).toEqual(
+      supersedingOwner,
+    );
+    expect(sessions.listSnapshot(managedScope).result?.owners).toBeUndefined();
+
+    managedReplacement.resolve({
+      ...sessionsResult([{ key, kind: "direct", updatedAt: 30, owner: supersedingOwner }], 30),
+      owners: [carol],
+    });
+    await staleRefresh;
+    expect(sessions.listSnapshot(managedScope).result?.owners).toEqual([carol]);
+    stop();
+    sessions.dispose();
+  });
+
+  it("retains the confirmed owner until the matching managed list catches up", async () => {
+    const key = "agent:main:managed-owner";
+    const ada = { type: "human" as const, id: "profile-ada", label: "Ada" };
+    const bob = { type: "human" as const, id: "profile-bob", label: "Bob" };
+    const oldOwner = { actor: bob, assignedBy: ada, assignedAt: 10 };
+    const assignedOwner = { actor: ada, assignedBy: ada, assignedAt: 20 };
+    const staleManagedResponse = deferred<SessionsListResult>();
+    const managedReplacement = deferred<SessionsListResult>();
+    const managedScope = { agentId: "main", search: "managed-owner" };
+    let managedCalls = 0;
+    let primaryCalls = 0;
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "sessions.assignOwner") {
+        return { ok: true, key, owner: assignedOwner };
+      }
+      if (method !== "sessions.list") {
+        throw new Error(`Unexpected request: ${method}`);
+      }
+      const managed =
+        typeof params === "object" &&
+        params !== null &&
+        "search" in params &&
+        params.search === managedScope.search;
+      if (!managed) {
+        primaryCalls += 1;
+        return {
+          ...sessionsResult([{ key, kind: "direct", updatedAt: 30, owner: assignedOwner }], 30),
+          owners: [ada],
+        };
+      }
+      managedCalls += 1;
+      if (managedCalls === 2) {
+        return await staleManagedResponse.promise;
+      }
+      if (managedCalls === 3) {
+        return await managedReplacement.promise;
+      }
+      return {
+        ...sessionsResult([{ key, kind: "direct", updatedAt: 10, owner: oldOwner }], 10),
+        owners: [ada, bob],
+      };
+    });
+    const sessions = createSessions({ request } as unknown as GatewayBrowserClient, key);
+    const stop = sessions.subscribeList(managedScope, () => undefined);
+
+    await sessions.refreshList({ ...managedScope, force: true });
+    const staleRefresh = sessions.refreshList({ ...managedScope, force: true });
+    await vi.waitFor(() => expect(managedCalls).toBe(2));
+    await expect(sessions.assignOwner(key, ada, { agentId: "main" })).resolves.toEqual(
+      assignedOwner,
+    );
+    await vi.waitFor(() => expect(primaryCalls).toBeGreaterThanOrEqual(1));
+
+    staleManagedResponse.resolve({
+      ...sessionsResult([{ key, kind: "direct", updatedAt: 10, owner: oldOwner }], 10),
+      owners: [ada, bob],
+    });
+    await vi.waitFor(() => expect(managedCalls).toBe(3));
+    expect(sessions.listSnapshot(managedScope).result?.sessions[0]?.owner).toEqual(assignedOwner);
+    expect(sessions.listSnapshot(managedScope).result?.owners).toBeUndefined();
+
+    managedReplacement.resolve({
+      ...sessionsResult([{ key, kind: "direct", updatedAt: 20, owner: assignedOwner }], 20),
+      owners: [ada],
+    });
+    await staleRefresh;
+    expect(sessions.listSnapshot(managedScope).result?.sessions[0]?.owner).toEqual(assignedOwner);
+    expect(sessions.listSnapshot(managedScope).result?.owners).toEqual([ada]);
+    stop();
+    sessions.dispose();
+  });
+});

--- a/ui/src/lib/sessions/list-options-owner-assignment.test.ts
+++ b/ui/src/lib/sessions/list-options-owner-assignment.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { SessionsListResult } from "../../api/types.ts";
-import { createSessionCapability } from "./index.ts";
+import { createTestSessionCapability as createSessionCapability } from "./session-capability.test-support.ts";
 
 function sessionsResult(sessions: SessionsListResult["sessions"], ts: number): SessionsListResult {
   return {

--- a/ui/src/lib/sessions/session-deletions.ts
+++ b/ui/src/lib/sessions/session-deletions.ts
@@ -53,7 +53,7 @@ type DeletionHost = {
     scope: NonNullable<ReturnType<SessionConnectionOwner["capture"]>>,
     agentId?: string | null,
   ) => Promise<boolean>;
-  retire: (key: string) => void;
+  retire: (key: string, agentId?: string | null) => void;
 };
 
 export function createSessionDeletions(host: DeletionHost) {
@@ -175,7 +175,7 @@ export function createSessionDeletions(host: DeletionHost) {
     }
     deletion.rows = new WeakMap();
     if (deletion.owner.active === deletion) {
-      host.retire(key);
+      host.retire(key, deletion.target.agentId);
     }
     publish(deletion);
   };

--- a/ui/src/lib/sessions/session-list-scope.ts
+++ b/ui/src/lib/sessions/session-list-scope.ts
@@ -1,0 +1,12 @@
+import { normalizeAgentId } from "./session-key.ts";
+
+export function sessionListAgentMatches(
+  queryAgentId: string | undefined,
+  agentId: string | null | undefined,
+): boolean {
+  return (
+    !agentId?.trim() ||
+    !queryAgentId ||
+    normalizeAgentId(queryAgentId) === normalizeAgentId(agentId)
+  );
+}

--- a/ui/src/lib/sessions/session-mutations.ts
+++ b/ui/src/lib/sessions/session-mutations.ts
@@ -682,10 +682,13 @@ export function createSessionMutations(host: SessionMutationsHost) {
       return optimisticUnread.apply(optimisticPins.apply(result));
     },
     applyConfirmedArchives: archiveState.apply,
-    applyConfirmedOwners: ownerAssignments.decorate,
-    observeCanonicalOwners: ownerAssignments.observeCanonical,
-    observeCanonicalOwnerEvent: ownerAssignments.observeRow,
-    retireCanonicalOwnerScope: ownerAssignments.retireScope,
+    applyConfirmedOwners: (...args: Parameters<typeof ownerAssignments.decorate>) =>
+      ownerAssignments.decorate(...args),
+    observeCanonicalOwners: (...args: Parameters<typeof ownerAssignments.observeCanonical>) =>
+      ownerAssignments.observeCanonical(...args),
+    observeCanonicalOwnerEvent: (...args: Parameters<typeof ownerAssignments.observeRow>) =>
+      ownerAssignments.observeRow(...args),
+    retireCanonicalOwnerScope: (scope: string) => ownerAssignments.retireScope(scope),
     observeArchiveState: archiveState.observe,
     reset,
     retireModelOverride,

--- a/ui/src/lib/sessions/session-mutations.ts
+++ b/ui/src/lib/sessions/session-mutations.ts
@@ -15,7 +15,6 @@ import {
 import type { SessionPatch, SessionPatchOptions, SessionPatchResult } from "./patch.ts";
 import { createSessionArchiveState } from "./session-archive-state.ts";
 import type {
-  SessionCapability,
   SessionConnectionOwner,
   SessionConnectionScope,
   SessionCreateReconciliation,
@@ -23,7 +22,8 @@ import type {
   SessionResetResult,
   SessionState,
 } from "./session-capability.ts";
-import { areUiSessionKeysEquivalent } from "./session-key.ts";
+import { areUiSessionKeysEquivalent, parseAgentSessionKey } from "./session-key.ts";
+import { createSessionOwnerAssignmentOverlay } from "./session-owner-assignment-overlay.ts";
 import type { SessionPermissionClaim } from "./session-permission-projection.ts";
 import { requestSessionPatch, requestSessionReset } from "./session-requests.ts";
 import type { SessionRefreshOutcome } from "./session-roster-refresh.ts";
@@ -37,7 +37,14 @@ type SessionMutationsHost = {
   connection: SessionConnectionOwner;
   readState: () => SessionState;
   publish: (state: SessionState, errorSource?: "session-observer" | "operation") => void;
-  refreshReplacement: SessionCapability["refreshReplacement"];
+  refreshReplacement: (
+    agentId?: string | null,
+    reconcileOwner?: boolean,
+  ) => Promise<SessionsListResult | null | void>;
+  ownerAssignmentScopeRevisions: (agentId?: string | null) => {
+    revision: number;
+    scopes: ReadonlyMap<string, number>;
+  };
   refreshReplacementResult: (
     agentId?: string | null,
     isErrorCurrent?: () => boolean,
@@ -133,6 +140,7 @@ export function createSessionMutations(host: SessionMutationsHost) {
   const archiveState = createSessionArchiveState(host.publishedRow, () =>
     host.publish({ ...host.readState() }),
   );
+  const ownerAssignments = createSessionOwnerAssignmentOverlay();
   const preparedWorkSessionKeys = new Set<string>();
   const pendingCreatedModelOverrides = new Set<string>();
 
@@ -607,41 +615,59 @@ export function createSessionMutations(host: SessionMutationsHost) {
     }
   };
 
-  const assignOwner = async (
+  const assignOwner = (
     key: string,
     owner: SessionsAssignOwnerParams["owner"],
     options: { agentId?: string | null } = {},
   ): Promise<SessionOwner | null> => {
-    const scope = host.connection.capture();
-    if (!scope) {
-      return null;
-    }
-    try {
-      const result = await scope.client.request<SessionsAssignOwnerResult>("sessions.assignOwner", {
-        key,
-        owner,
-        ...(options.agentId ? { agentId: options.agentId } : {}),
-      });
-      if (!host.connection.isCurrent(scope)) {
+    const targetAgentId =
+      parseAgentSessionKey(key)?.agentId ?? options.agentId ?? host.publishedRow(key)?.agentId;
+    return ownerAssignments.enqueue(key, targetAgentId, async () => {
+      const scope = host.connection.capture();
+      if (!scope) {
         return null;
       }
-      patchRowLocal(result.key, { owner: result.owner });
-      return result.owner;
-    } catch (error) {
-      if (host.connection.isCurrent(scope)) {
-        host.publish({ ...host.readState(), error: formatUiError(error) }, "operation");
+      try {
+        const result = await scope.client.request<SessionsAssignOwnerResult>(
+          "sessions.assignOwner",
+          {
+            key,
+            owner,
+            ...(targetAgentId ? { agentId: targetAgentId } : {}),
+          },
+        );
+        if (!host.connection.isCurrent(scope)) {
+          return null;
+        }
+        const assignmentScope = host.ownerAssignmentScopeRevisions(targetAgentId);
+        const confirmedOwner = ownerAssignments.confirm(
+          result.key,
+          result.owner,
+          assignmentScope.revision,
+          assignmentScope.scopes,
+          host.publishedRow(result.key)?.sessionId,
+          targetAgentId,
+        );
+        host.redecorateLists();
+        void host.refreshReplacement(targetAgentId, true);
+        return confirmedOwner;
+      } catch (error) {
+        if (host.connection.isCurrent(scope)) {
+          host.publish({ ...host.readState(), error: formatUiError(error) }, "operation");
+        }
+        return null;
       }
-      return null;
-    }
+    });
   };
 
   return {
     create,
     createResult,
     reconcileConfirmedPreviousConnection,
-    retireDeletedSession(this: void, key: string) {
+    retireDeletedSession(this: void, key: string, agentId?: string | null) {
       host.retirePullRequestSummary(key);
       archiveState.clear(key);
+      ownerAssignments.retire(key, agentId);
       preparedWorkSessionKeys.delete(key.trim());
       setModelOverride(key, undefined);
     },
@@ -656,6 +682,10 @@ export function createSessionMutations(host: SessionMutationsHost) {
       return optimisticUnread.apply(optimisticPins.apply(result));
     },
     applyConfirmedArchives: archiveState.apply,
+    applyConfirmedOwners: ownerAssignments.decorate,
+    observeCanonicalOwners: ownerAssignments.observeCanonical,
+    observeCanonicalOwnerEvent: ownerAssignments.observeRow,
+    retireCanonicalOwnerScope: ownerAssignments.retireScope,
     observeArchiveState: archiveState.observe,
     reset,
     retireModelOverride,
@@ -681,6 +711,7 @@ export function createSessionMutations(host: SessionMutationsHost) {
       optimisticPins.clear();
       optimisticUnread.clear();
       archiveState.clearAll();
+      ownerAssignments.clear();
       preparedWorkSessionKeys.clear();
       const state = host.readState();
       host.publish({ ...state, modelOverrides: {} });
@@ -691,6 +722,7 @@ export function createSessionMutations(host: SessionMutationsHost) {
       optimisticPins.clear();
       optimisticUnread.clear();
       archiveState.clearAll();
+      ownerAssignments.clear();
       preparedWorkSessionKeys.clear();
     },
   };

--- a/ui/src/lib/sessions/session-owner-assignment-overlay.test.ts
+++ b/ui/src/lib/sessions/session-owner-assignment-overlay.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SessionsListResult } from "../../api/types.ts";
+import { createSessionOwnerAssignmentOverlay } from "./session-owner-assignment-overlay.ts";
+
+function result(ownerId: string, assignedAt: number): SessionsListResult {
+  return {
+    ts: assignedAt,
+    path: "(multiple)",
+    count: 1,
+    defaults: { modelProvider: null, model: null, contextTokens: null },
+    sessions: [
+      {
+        key: "agent:main:owned",
+        kind: "direct",
+        updatedAt: assignedAt,
+        owner: {
+          actor: { type: "human", id: ownerId },
+          assignedBy: { type: "human", id: ownerId },
+          assignedAt,
+        },
+      },
+    ],
+  };
+}
+
+describe("session owner assignment overlay", () => {
+  it("cancels queued assignments when the connection state is cleared", async () => {
+    const overlay = createSessionOwnerAssignmentOverlay();
+    let releaseFirst: () => void = () => undefined;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let runs = 0;
+    const first = overlay.enqueue("agent:main:owned", "main", async () => {
+      runs += 1;
+      await firstGate;
+      return "first";
+    });
+    const second = overlay.enqueue("agent:main:owned", "main", async () => {
+      runs += 1;
+      return "second";
+    });
+    await vi.waitFor(() => expect(runs).toBe(1));
+
+    overlay.clear();
+    releaseFirst();
+
+    await expect(first).resolves.toBe("first");
+    await expect(second).resolves.toBeNull();
+    expect(runs).toBe(1);
+  });
+
+  it("keeps the confirmed owner until older same-scope requests settle", () => {
+    const overlay = createSessionOwnerAssignmentOverlay();
+    const confirmed = result("profile-ada", 20).sessions[0]!.owner!;
+    overlay.confirm("agent:main:owned", confirmed, 1, new Map([["primary", 1]]), undefined, "main");
+
+    overlay.observeCanonical(result("profile-bob", 10), 1, "primary", "main");
+    expect(overlay.decorate(result("profile-bob", 10))?.sessions[0]?.owner).toEqual(confirmed);
+
+    overlay.observeCanonical(result("profile-ada", 20), 2, "primary", "main");
+    expect(overlay.decorate(result("profile-bob", 10))?.sessions[0]?.owner?.actor.id).toBe(
+      "profile-bob",
+    );
+  });
+
+  it("does not retire a claim for an older session incarnation", () => {
+    const overlay = createSessionOwnerAssignmentOverlay();
+    const confirmed = result("profile-ada", 20).sessions[0]!.owner!;
+    overlay.confirm("agent:main:owned", confirmed, 1, new Map([["primary", 1]]), "new", "main");
+    const stale = result("profile-bob", 10);
+    stale.sessions[0]!.sessionId = "old";
+
+    overlay.observeCanonical(stale, 1, "primary", "main");
+    overlay.decorate(stale, "primary", 1, "main");
+
+    const current = result("profile-bob", 10);
+    current.sessions[0]!.sessionId = "new";
+    expect(overlay.decorate(current, "primary", 1, "main")?.sessions[0]?.owner).toEqual(confirmed);
+  });
+});

--- a/ui/src/lib/sessions/session-owner-assignment-overlay.ts
+++ b/ui/src/lib/sessions/session-owner-assignment-overlay.ts
@@ -1,0 +1,190 @@
+import type { SessionOwner } from "../../../../packages/gateway-protocol/src/index.js";
+import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
+import { normalizeAgentId, normalizeDefaultMainSessionAliasForUi } from "./session-key.ts";
+
+type ConfirmedOwnerClaim = {
+  confirmedAtRevision: number;
+  id: string;
+  owner: SessionOwner;
+  scopeRevisions: Map<string, number>;
+  sessionId?: string;
+};
+
+function assignmentKey(key: string, agentId?: string | null): string {
+  return `${normalizeDefaultMainSessionAliasForUi(key)}\0agent:${normalizeAgentId(agentId ?? "")}`;
+}
+
+function rowAssignmentKey(row: GatewaySessionRow, agentId?: string | null): string {
+  return assignmentKey(row.key, row.agentId ?? agentId);
+}
+
+function ownersMatch(left: SessionOwner | undefined, right: SessionOwner): boolean {
+  return (
+    left?.actor.type === right.actor.type &&
+    left.actor.id === right.actor.id &&
+    left.assignedBy?.type === right.assignedBy?.type &&
+    left.assignedBy?.id === right.assignedBy?.id &&
+    left.assignedAt === right.assignedAt
+  );
+}
+
+export function createSessionOwnerAssignmentOverlay() {
+  const assignmentQueues = new Map<string, Promise<unknown>>();
+  const claims = new Map<string, ConfirmedOwnerClaim>();
+  let queueEpoch = 0;
+
+  const enqueue = <T>(
+    key: string,
+    agentId: string | null | undefined,
+    run: () => Promise<T>,
+  ): Promise<T | null> => {
+    const id = assignmentKey(key, agentId);
+    const previous = assignmentQueues.get(id) ?? Promise.resolve();
+    const epoch = queueEpoch;
+    const current = previous
+      .catch(() => undefined)
+      .then(() => (epoch === queueEpoch ? run() : null));
+    assignmentQueues.set(id, current);
+    const retire = () => {
+      if (assignmentQueues.get(id) === current) {
+        assignmentQueues.delete(id);
+      }
+    };
+    void current.then(retire, retire);
+    return current;
+  };
+
+  return {
+    enqueue,
+    confirm(
+      key: string,
+      owner: SessionOwner,
+      confirmedAtRevision: number,
+      scopeRevisions: ReadonlyMap<string, number>,
+      sessionId?: string,
+      agentId?: string | null,
+    ): SessionOwner {
+      const id = assignmentKey(key, agentId);
+      claims.set(id, {
+        confirmedAtRevision,
+        id,
+        owner,
+        scopeRevisions: new Map(scopeRevisions),
+        ...(sessionId ? { sessionId } : {}),
+      });
+      return owner;
+    },
+    retire(key: string, agentId?: string | null): void {
+      claims.delete(assignmentKey(key, agentId));
+    },
+    clear(): void {
+      queueEpoch += 1;
+      assignmentQueues.clear();
+      claims.clear();
+    },
+    decorate(
+      result: SessionsListResult | null,
+      scope?: string,
+      requestRevision?: number,
+      agentId?: string | null,
+    ): SessionsListResult | null {
+      if (!result || claims.size === 0) {
+        return result;
+      }
+      let invalidateOwners = scope
+        ? [...claims.values()].some((claim) => {
+            const scopeRevision = claim.scopeRevisions.get(scope);
+            if (scopeRevision === undefined) {
+              return false;
+            }
+            const row = result.sessions.find(
+              (candidate) => rowAssignmentKey(candidate, agentId) === claim.id,
+            );
+            if (claim.sessionId && row?.sessionId && claim.sessionId !== row.sessionId) {
+              return false;
+            }
+            return (
+              !ownersMatch(row?.owner, claim.owner) &&
+              !(requestRevision !== undefined && requestRevision > scopeRevision && !row)
+            );
+          })
+        : false;
+      const sessions = result.sessions.map((row) => {
+        const id = rowAssignmentKey(row, agentId);
+        const claim = claims.get(id);
+        if (!claim) {
+          return row;
+        }
+        if (claim.sessionId && row.sessionId && claim.sessionId !== row.sessionId) {
+          return row;
+        }
+        if (ownersMatch(row.owner, claim.owner)) {
+          return row;
+        }
+        invalidateOwners = true;
+        return { ...row, owner: claim.owner };
+      });
+      return invalidateOwners ? { ...result, sessions, owners: undefined } : result;
+    },
+    observeCanonical(
+      result: SessionsListResult | null,
+      requestRevision: number,
+      scope: string | undefined,
+      agentId?: string | null,
+    ): void {
+      if (!scope) {
+        return;
+      }
+      for (const [id, claim] of claims) {
+        const scopeRevision = claim.scopeRevisions.get(scope);
+        const row = result?.sessions.find(
+          (candidate) => rowAssignmentKey(candidate, agentId) === id,
+        );
+        if (requestRevision <= claim.confirmedAtRevision) {
+          continue;
+        }
+        if (claim.sessionId && row?.sessionId && claim.sessionId !== row.sessionId) {
+          claims.delete(id);
+          continue;
+        }
+        if (row?.owner && !ownersMatch(row.owner, claim.owner)) {
+          claim.owner = row.owner;
+          if (row.sessionId) {
+            claim.sessionId = row.sessionId;
+          }
+        }
+        if (scopeRevision !== undefined) {
+          claim.scopeRevisions.delete(scope);
+        }
+        if (claim.scopeRevisions.size === 0) {
+          claims.delete(id);
+        }
+      }
+    },
+    observeRow(row: GatewaySessionRow | undefined, agentId?: string | null): void {
+      if (!row) {
+        return;
+      }
+      const id = rowAssignmentKey(row, agentId);
+      const claim = claims.get(id);
+      if (!claim) {
+        return;
+      }
+      if (claim.sessionId && row.sessionId && claim.sessionId !== row.sessionId) {
+        claims.delete(id);
+      } else if (row.owner && !ownersMatch(row.owner, claim.owner)) {
+        claim.owner = row.owner;
+        if (row.sessionId) {
+          claim.sessionId = row.sessionId;
+        }
+      }
+    },
+    retireScope(scope: string): void {
+      for (const [key, claim] of claims) {
+        if (claim.scopeRevisions.delete(scope) && claim.scopeRevisions.size === 0) {
+          claims.delete(key);
+        }
+      }
+    },
+  };
+}

--- a/ui/src/lib/sessions/session-roster-refresh.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.ts
@@ -28,6 +28,7 @@ import {
   sessionListQueryAgentId,
   type QueuedSessionRefresh,
 } from "./session-list-query.ts";
+import { sessionListAgentMatches } from "./session-list-scope.ts";
 import {
   buildSessionListParams,
   normalizeManagedSessionListQuery,
@@ -132,12 +133,9 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
   const directListRequests = new Map<string, { agentId?: string; revision: number }>();
 
   const activeManagedLists = (): ManagedSessionList[] =>
-    [...managedLists.values()].filter((entry) => entry.listeners.size > 0 || entry.pending);
-
-  const matchesAgent = (queryAgentId: string | undefined, agentId: string | null | undefined) =>
-    !agentId?.trim() ||
-    !queryAgentId ||
-    normalizeAgentId(queryAgentId) === normalizeAgentId(agentId);
+    [...managedLists.values()].filter(
+      (entry) => entry.listeners.size > 0 || entry.pending !== null,
+    );
 
   const publishManagedList = (entry: ManagedSessionList, snapshot: SessionListSnapshot): void => {
     entry.snapshot = snapshot;
@@ -733,9 +731,9 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     refreshReplacement: (agentId?: string | null) => refreshReplacementOwned(agentId),
     async refreshOwnerAssignmentScopes(agentId?: string | null): Promise<void> {
       const refreshes = activeManagedLists()
-        .filter((entry) => matchesAgent(sessionListQueryAgentId(entry.query), agentId))
+        .filter((entry) => sessionListAgentMatches(sessionListQueryAgentId(entry.query), agentId))
         .map((entry) => refreshManagedList(entry, { append: false, invalidated: true }));
-      if (matchesAgent(lastListOptions.agentId, agentId)) {
+      if (sessionListAgentMatches(lastListOptions.agentId, agentId)) {
         refreshes.push(refreshReplacementOwned().then(() => undefined));
       }
       await Promise.all(refreshes);
@@ -744,14 +742,18 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       return {
         revision: requestRevision,
         scopes: new Map([
-          ...(matchesAgent(lastListOptions.agentId, agentId)
+          ...(sessionListAgentMatches(lastListOptions.agentId, agentId)
             ? ([[PRIMARY_LIST_SCOPE, requestRevision]] as const)
             : []),
           ...[...directListRequests].flatMap(([scope, request]) =>
-            matchesAgent(request.agentId, agentId) ? [[scope, request.revision] as const] : [],
+            sessionListAgentMatches(request.agentId, agentId)
+              ? [[scope, request.revision] as const]
+              : [],
           ),
           ...activeManagedLists()
-            .filter((entry) => matchesAgent(sessionListQueryAgentId(entry.query), agentId))
+            .filter((entry) =>
+              sessionListAgentMatches(sessionListQueryAgentId(entry.query), agentId),
+            )
             .map((entry) => [managedSessionListScope(entry), requestRevision] as const),
         ]),
       };

--- a/ui/src/lib/sessions/session-roster-refresh.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.ts
@@ -48,7 +48,17 @@ type SessionRosterRefreshHost = {
   decorate: (
     result: SessionsListResult | null,
     owner: { scope: SessionListScope },
+    scope?: string,
+    requestRevision?: number,
+    agentId?: string | null,
   ) => SessionsListResult | null;
+  observeCanonicalRows: (
+    result: SessionsListResult | null,
+    requestRevision: number,
+    scope?: string,
+    agentId?: string | null,
+  ) => void;
+  retireCanonicalScope: (scope: string) => void;
   reconcileList: (
     result: SessionsListResult | null,
     issuedRevision: number,
@@ -61,6 +71,8 @@ type SessionRosterRefreshHost = {
     observed?: SessionsListResult | null,
   ) => void;
 };
+
+const PRIMARY_LIST_SCOPE = "primary";
 
 type ManagedSessionListRefresh = {
   append: boolean;
@@ -95,6 +107,10 @@ function sessionListAgentMatcher(agentId?: string | null) {
     !normalized || !queryAgentId?.trim() || normalizeAgentId(queryAgentId) === normalized;
 }
 
+function managedSessionListScope(entry: ManagedSessionList): string {
+  return `managed:${entry.key}`;
+}
+
 export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
   let gatewayAvailable = isGatewayAvailable(host.snapshot());
   let requestRevision = 0;
@@ -113,6 +129,15 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     typeof document !== "undefined" && typeof globalThis.addEventListener === "function";
   let pageActive = !observesPageLifecycle || document.visibilityState !== "hidden";
   const managedLists = new Map<string, ManagedSessionList>();
+  const directListRequests = new Map<string, { agentId?: string; revision: number }>();
+
+  const activeManagedLists = (): ManagedSessionList[] =>
+    [...managedLists.values()].filter((entry) => entry.listeners.size > 0 || entry.pending);
+
+  const matchesAgent = (queryAgentId: string | undefined, agentId: string | null | undefined) =>
+    !agentId?.trim() ||
+    !queryAgentId ||
+    normalizeAgentId(queryAgentId) === normalizeAgentId(agentId);
 
   const publishManagedList = (entry: ManagedSessionList, snapshot: SessionListSnapshot): void => {
     entry.snapshot = snapshot;
@@ -163,6 +188,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       const release = () => {
         if (entry.listeners.size === 0 && managedLists.get(entry.key) === entry) {
           entry.coordinator.dispose();
+          host.retireCanonicalScope(managedSessionListScope(entry));
           managedLists.delete(entry.key);
         }
       };
@@ -224,6 +250,12 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
           if (!response) {
             throw new Error("The session query did not return a result. Try again.");
           }
+          host.observeCanonicalRows(
+            response,
+            issuedRevision,
+            next.append ? undefined : managedSessionListScope(entry),
+            sessionListQueryAgentId(entry.query),
+          );
           const result = host.reconcileList(
             response,
             issuedRevision,
@@ -234,7 +266,13 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
             result && next.append && requestParams.offset && previous
               ? appendSessionResults(previous, result)
               : reconcileRosterPresentationMetadata(result, previous);
-          const decorated = host.decorate(nextResult, entry);
+          const decorated = host.decorate(
+            nextResult,
+            entry,
+            next.append ? undefined : managedSessionListScope(entry),
+            issuedRevision,
+            sessionListQueryAgentId(entry.query) ?? null,
+          );
           if (decorated) {
             entry.retainedLimit = Math.max(entry.retainedLimit, decorated.sessions.length);
           }
@@ -284,19 +322,33 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     if (!scope) {
       return null;
     }
+    const issuedRevision = ++requestRevision;
+    const listScope = `direct:${issuedRevision}`;
+    directListRequests.set(listScope, {
+      revision: issuedRevision,
+      ...(options.agentId ? { agentId: options.agentId } : {}),
+    });
     try {
-      const issuedRevision = ++requestRevision;
       const result = await requestSessionList(scope.client, options);
-      return host.connection.isCurrent(scope)
-        ? host.decorate(host.reconcileList(result ?? null, issuedRevision, options.agentId), {
-            scope: options,
-          })
-        : null;
+      if (!host.connection.isCurrent(scope)) {
+        return null;
+      }
+      host.observeCanonicalRows(result ?? null, issuedRevision, listScope, options.agentId);
+      return host.decorate(
+        host.reconcileList(result ?? null, issuedRevision, options.agentId),
+        { scope: options },
+        listScope,
+        issuedRevision,
+        options.agentId,
+      );
     } catch (error) {
       if (!host.connection.isCurrent(scope)) {
         return null;
       }
       throw error;
+    } finally {
+      directListRequests.delete(listScope);
+      host.retireCanonicalScope(listScope);
     }
   };
 
@@ -348,6 +400,12 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       if (!isCurrent()) {
         return null;
       }
+      host.observeCanonicalRows(
+        result,
+        issuedRevision,
+        append ? undefined : PRIMARY_LIST_SCOPE,
+        requestOptions.agentId,
+      );
       result = host.reconcileList(result, issuedRevision, requestOptions.agentId);
       const currentState = host.readState();
       const mergeWithCurrent = append && typeof requestOptions.offset === "number";
@@ -377,7 +435,13 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
         primaryList = { scope: durableListOptions };
       }
       primaryList.scope = append ? lastListOptions : durableListOptions;
-      nextResult = host.decorate(nextResult, primaryList);
+      nextResult = host.decorate(
+        nextResult,
+        primaryList,
+        append ? undefined : PRIMARY_LIST_SCOPE,
+        issuedRevision,
+        requestOptions.agentId,
+      );
       host.onCanonicalList(nextResult, issuedRevision, requestOptions.agentId, result);
       const state = host.readState();
       const error = host.observerError();
@@ -667,6 +731,31 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       return refreshInternal(options, true);
     },
     refreshReplacement: (agentId?: string | null) => refreshReplacementOwned(agentId),
+    async refreshOwnerAssignmentScopes(agentId?: string | null): Promise<void> {
+      const refreshes = activeManagedLists()
+        .filter((entry) => matchesAgent(sessionListQueryAgentId(entry.query), agentId))
+        .map((entry) => refreshManagedList(entry, { append: false, invalidated: true }));
+      if (matchesAgent(lastListOptions.agentId, agentId)) {
+        refreshes.push(refreshReplacementOwned().then(() => undefined));
+      }
+      await Promise.all(refreshes);
+    },
+    ownerAssignmentScopeRevisions(agentId?: string | null) {
+      return {
+        revision: requestRevision,
+        scopes: new Map([
+          ...(matchesAgent(lastListOptions.agentId, agentId)
+            ? ([[PRIMARY_LIST_SCOPE, requestRevision]] as const)
+            : []),
+          ...[...directListRequests].flatMap(([scope, request]) =>
+            matchesAgent(request.agentId, agentId) ? [[scope, request.revision] as const] : [],
+          ),
+          ...activeManagedLists()
+            .filter((entry) => matchesAgent(sessionListQueryAgentId(entry.query), agentId))
+            .map((entry) => [managedSessionListScope(entry), requestRevision] as const),
+        ]),
+      };
+    },
     refreshReplacementResult,
     publishedSession,
     publishedRow: (matches: (row: GatewaySessionRow, agentId?: string | null) => boolean) =>
@@ -675,12 +764,24 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
      * reaches the archived/all snapshots too, not just the primary state. */
     redecorateLists() {
       const state = host.readState();
-      const result = host.decorate(state.result, primaryList);
+      const result = host.decorate(
+        state.result,
+        primaryList,
+        PRIMARY_LIST_SCOPE,
+        undefined,
+        state.agentId,
+      );
       if (result !== state.result) {
         host.publish({ ...state, result });
       }
       for (const entry of managedLists.values()) {
-        const decorated = host.decorate(entry.snapshot.result, entry);
+        const decorated = host.decorate(
+          entry.snapshot.result,
+          entry,
+          managedSessionListScope(entry),
+          undefined,
+          sessionListQueryAgentId(entry.query) ?? null,
+        );
         if (decorated !== entry.snapshot.result) {
           publishManagedList(entry, { ...entry.snapshot, result: decorated });
         }
@@ -705,6 +806,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       queuedExplicitRefresh?.completions.forEach(({ complete }) => complete(null));
       queuedExplicitRefresh = null;
       eventRefreshQueued = false;
+      directListRequests.clear();
       for (const entry of managedLists.values()) {
         entry.coordinator.reset();
         entry.pending = entry.queued = null;
@@ -727,6 +829,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       inFlight = null;
       queuedExplicitRefresh?.completions.forEach(({ complete }) => complete(null));
       queuedExplicitRefresh = null;
+      directListRequests.clear();
       for (const entry of managedLists.values()) {
         entry.coordinator.dispose();
         entry.listeners.clear();

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -1557,7 +1557,9 @@ class SessionsPage extends OpenClawLightDomElement {
               }
               break;
             case "assign-owner":
-              void this.context?.sessions.assignOwner(row.key, action.owner);
+              void this.context?.sessions.assignOwner(row.key, action.owner, {
+                agentId: row.agentId,
+              });
               break;
             case "stop-cloud-worker":
               void this.stopCloudWorker(row);

--- a/ui/src/pako.d.ts
+++ b/ui/src/pako.d.ts
@@ -1,0 +1,8 @@
+declare module "pako" {
+  type CompressionLevel = -1 | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+
+  export function gzip(
+    data: string | ArrayBuffer | Uint8Array,
+    options?: { legacyHash?: boolean; level?: CompressionLevel },
+  ): Uint8Array;
+}


### PR DESCRIPTION
Closes #132058

## What Problem This Solves

Fixes an issue where users assigning a session owner could see an older in-flight roster restore the previous owner. If the automatic follow-up refresh failed, the wrong owner and owner facets could remain visible.

## Why This Change Was Made

The session capability now owns one causal assignment fence per agent/session across primary, managed, and direct list scopes. It serializes same-session assignments, overlays only responses issued before confirmation, accepts later canonical rows/events, refreshes active owner filters, and retires all claims on connection changes.

The Sessions page now carries the row agent identity into assignment so global aliases remain isolated. This also adds a narrow declaration for the existing `pako` gzip API because current `main` typechecking otherwise fails at `ui/vite.config.ts:9`; no runtime dependency changes.

## User Impact

A confirmed owner remains stable while older roster requests finish, including filtered and paginated session views. Newer assignments from another client still supersede the local claim, and owner filters/facets converge without a reload.

## Evidence

- Before: focused regression failed with `expected profile-bob to be profile-ada` after list → assignment → stale list settlement.
- After: `node scripts/run-vitest.mjs ui/src/lib/sessions/list-options-owner-assignment.test.ts ui/src/lib/sessions/session-owner-assignment-overlay.test.ts ui/src/lib/sessions/list-options.test.ts ui/src/lib/sessions/index-list.test.ts ui/src/lib/sessions/connection-hydration.test.ts ui/src/pages/sessions/sessions-page.test.ts` passed 105 tests.
- `node scripts/check-changed.mjs` passed, including typechecks, lint, and import-cycle checks.
- Exact owner boundaries: `ui/src/lib/sessions/session-owner-assignment-overlay.ts`, `ui/src/lib/sessions/session-roster-refresh.ts:229-362`, `ui/src/lib/sessions/session-mutations.ts:603-646`.
- Regression coverage includes primary, managed, direct, filtered, concurrent, reconnect, newer-event, alias/session identity, and facet behavior in `ui/src/lib/sessions/list-options-owner-assignment.test.ts` and `ui/src/lib/sessions/session-owner-assignment-overlay.test.ts`.
- The diagnosis and causal ordering were independently verified by a second adversarial review that attempted to refute the bug and confirmed it.
- Existing related PR #125815 was inspected; this change additionally covers direct lists, agent/global identity, alias serialization, and freshness-aware scope retirement.
- Visual proof was not captured because the defect is a timing race requiring controlled overlapping RPCs; the boundary tests execute the exact user-visible state transition deterministically.