### PR TITLE
test: overlap independent Vitest progress scenarios

### DIFF
--- a/test/scripts/run-vitest-progress.test.ts
+++ b/test/scripts/run-vitest-progress.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, describe, it, vi } from "vitest";
 import {
   resolveVitestCliEntry,
   resolveVitestNodeArgs,
@@ -14,8 +14,7 @@ import { withTestTimeout } from "../helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const repoRoot = path.resolve(import.meta.dirname, "../..");
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
-const posixIt = process.platform === "win32" ? it.skip : it;
+const posixDescribe = process.platform === "win32" ? describe.skip : describe.concurrent;
 const ioTimeoutMs = 15_000;
 const silenceMs = 1_000;
 
@@ -29,23 +28,25 @@ async function waitForRealIo(ready: () => boolean, description: string) {
   }
 }
 
-posixIt.each([false, true])(
+posixDescribe.each([false, true])(
   "keeps real case progress alive across watchdog windows, then stall=%s",
-  async (stall) => {
-    const root = tempDirs.make("oc-vt-progress-");
-    fs.symlinkSync(
-      path.join(repoRoot, "node_modules"),
-      path.join(root, "node_modules"),
-      "junction",
-    );
-    const configPath = path.join(root, "vitest.config.mjs");
-    // Vitest can batch a case result until later task activity. A file boundary
-    // explicitly flushes updates, so waiting for its case line cannot deadlock
-    // against the next case's release barrier.
-    for (let index = 0; index < 5; index++) {
-      fs.writeFileSync(
-        path.join(root, `progress-${index}.test.ts`),
-        `import fs from "node:fs";
+  (stall) => {
+    const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+    it("reports the expected outcome and stops its process group", async ({ expect }) => {
+      const root = tempDirs.make("oc-vt-progress-");
+      fs.symlinkSync(
+        path.join(repoRoot, "node_modules"),
+        path.join(root, "node_modules"),
+        "junction",
+      );
+      const configPath = path.join(root, "vitest.config.mjs");
+      // Vitest can batch a case result until later task activity. A file boundary
+      // explicitly flushes updates, so waiting for its case line cannot deadlock
+      // against the next case's release barrier.
+      for (let index = 0; index < 5; index++) {
+        fs.writeFileSync(
+          path.join(root, `progress-${index}.test.ts`),
+          `import fs from "node:fs";
 import { expect, it } from "vitest";
 import { waitForFile } from ${JSON.stringify(path.join(repoRoot, "test/helpers/process-wait.ts"))};
 const index = ${index};
@@ -57,11 +58,11 @@ it("real progress " + index, async () => {
   expect(index).toBeLessThan(5);
 });
 `,
-      );
-    }
-    fs.writeFileSync(
-      configPath,
-      `import tooling from ${JSON.stringify(path.join(repoRoot, "test/vitest/vitest.tooling.config.ts"))};
+        );
+      }
+      fs.writeFileSync(
+        configPath,
+        `import tooling from ${JSON.stringify(path.join(repoRoot, "test/vitest/vitest.tooling.config.ts"))};
 import { BaseSequencer } from "vitest/node";
 class OrderedFixtures extends BaseSequencer {
   async sort(files) { return [...files].sort((a, b) => a.moduleId.localeCompare(b.moduleId)); }
@@ -78,97 +79,101 @@ export default {
   },
 };
 `,
-    );
-    const env = { ...process.env };
-    for (const key of Object.keys(env)) {
-      if (key.startsWith("VITEST") || key.startsWith("OPENCLAW_")) {
-        delete env[key];
+      );
+      const env = { ...process.env };
+      for (const key of Object.keys(env)) {
+        if (key.startsWith("VITEST") || key.startsWith("OPENCLAW_")) {
+          delete env[key];
+        }
       }
-    }
-    Object.assign(env, {
-      AI_AGENT: "vitest-progress-test",
-      GITHUB_ACTIONS: "false",
-      NO_COLOR: "1",
-      FORCE_COLOR: "0",
-      OPENCLAW_VITEST_FS_MODULE_CACHE_PATH: path.join(root, "module-cache"),
-      OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS: String(silenceMs),
-      OPENCLAW_VITEST_NO_OUTPUT_HEARTBEAT_MS: "400",
-    });
-
-    // The watchdog captures timer functions during synchronous registration.
-    // Uninstall immediately: transport, readiness, diagnostics and group joins
-    // must use real timers, while the watchdog retains its own Sinon clock.
-    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
-    const { clock } = setTimeout as typeof setTimeout & { clock: { tick(ms: number): void } };
-    const onNoOutputTimeout = vi.fn();
-    let watched: ReturnType<typeof spawnWatchedVitestProcess>;
-    try {
-      watched = spawnWatchedVitestProcess({
-        pnpmArgs: [
-          "exec",
-          "node",
-          ...resolveVitestNodeArgs(env),
-          resolveVitestCliEntry(),
-          "run",
-          "--config",
-          configPath,
-        ],
-        spawnParams: { cwd: repoRoot, ...resolveVitestSpawnParams(env) },
-        env,
-        onNoOutputTimeout,
+      Object.assign(env, {
+        AI_AGENT: "vitest-progress-test",
+        GITHUB_ACTIONS: "false",
+        NO_COLOR: "1",
+        FORCE_COLOR: "0",
+        OPENCLAW_VITEST_FS_MODULE_CACHE_PATH: path.join(root, "module-cache"),
+        OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS: String(silenceMs),
+        OPENCLAW_VITEST_NO_OUTPUT_HEARTBEAT_MS: "400",
       });
-    } finally {
-      vi.useRealTimers();
-    }
-    let output = "";
-    watched.child.stdout!.on("data", (chunk: string) => {
-      output += chunk;
-    });
-    watched.child.stderr!.on("data", (chunk: string) => {
-      output += chunk;
-    });
-    const casePassed = (index: number) =>
-      output
-        .split("\n")
-        .some((line) => line.includes("✓") && line.includes(` > real progress ${index} `));
-    let workerPid: number | undefined;
-    try {
-      for (let index = 0; index < 4; index++) {
-        const readyPath = path.join(root, `ready-${index}`);
-        await waitForRealIo(() => fs.existsSync(readyPath), `case ${index} readiness\n${output}`);
-        workerPid = Number(fs.readFileSync(readyPath, "utf8"));
-        clock.tick(600);
-        expect(onNoOutputTimeout, output).not.toHaveBeenCalled();
-        fs.writeFileSync(path.join(root, `release-${index}`), "");
-        // File barriers never enter the watched pipes. Only Vitest's completed
-        // case output can reset the watchdog before the next 600ms advance.
+
+      // Register and uninstall without awaiting so each watchdog captures its
+      // own Sinon clock. Transport, readiness, diagnostics and process-group
+      // joins must use real timers while the watchdog retains its fake clock.
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      const { clock } = setTimeout as typeof setTimeout & { clock: { tick(ms: number): void } };
+      const onNoOutputTimeout = vi.fn();
+      let watched: ReturnType<typeof spawnWatchedVitestProcess>;
+      try {
+        watched = spawnWatchedVitestProcess({
+          pnpmArgs: [
+            "exec",
+            "node",
+            ...resolveVitestNodeArgs(env),
+            resolveVitestCliEntry(),
+            "run",
+            "--config",
+            configPath,
+          ],
+          spawnParams: { cwd: repoRoot, ...resolveVitestSpawnParams(env) },
+          env,
+          onNoOutputTimeout,
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+      let output = "";
+      watched.child.stdout!.on("data", (chunk: string) => {
+        output += chunk;
+      });
+      watched.child.stderr!.on("data", (chunk: string) => {
+        output += chunk;
+      });
+      const casePassed = (index: number) =>
+        output
+          .split("\n")
+          .some((line) => line.includes("✓") && line.includes(` > real progress ${index} `));
+      let workerPid: number | undefined;
+      try {
+        for (let index = 0; index < 4; index++) {
+          const readyPath = path.join(root, `ready-${index}`);
+          await waitForRealIo(() => fs.existsSync(readyPath), `case ${index} readiness\n${output}`);
+          workerPid = Number(fs.readFileSync(readyPath, "utf8"));
+          clock.tick(600);
+          expect(onNoOutputTimeout, output).not.toHaveBeenCalled();
+          fs.writeFileSync(path.join(root, `release-${index}`), "");
+          // File barriers never enter the watched pipes. Only Vitest's completed
+          // case output can reset the watchdog before the next 600ms advance.
+          await waitForRealIo(
+            () => casePassed(index),
+            `Vitest completion for case ${index}\n${output}`,
+          );
+        }
         await waitForRealIo(
-          () => casePassed(index),
-          `Vitest completion for case ${index}\n${output}`,
+          () => fs.existsSync(path.join(root, "ready-4")),
+          "final case readiness",
         );
-      }
-      await waitForRealIo(() => fs.existsSync(path.join(root, "ready-4")), "final case readiness");
-      expect(isProcessAlive(watched.child.pid!)).toBe(true);
-      expect(onNoOutputTimeout).not.toHaveBeenCalled();
-      if (stall) {
-        clock.tick(silenceMs - 1);
+        expect(isProcessAlive(watched.child.pid!)).toBe(true);
         expect(onNoOutputTimeout).not.toHaveBeenCalled();
-        clock.tick(1);
-        expect(onNoOutputTimeout).toHaveBeenCalledOnce();
-      } else {
-        fs.writeFileSync(path.join(root, "release-4"), "");
+        if (stall) {
+          clock.tick(silenceMs - 1);
+          expect(onNoOutputTimeout).not.toHaveBeenCalled();
+          clock.tick(1);
+          expect(onNoOutputTimeout).toHaveBeenCalledOnce();
+        } else {
+          fs.writeFileSync(path.join(root, "release-4"), "");
+        }
+        const result = await watched.completion;
+        // Vitest's logger handles SIGTERM and exits with 128 + 15, rather than
+        // leaving Node to report a signal-only exit (as a bare silent child does).
+        expect(result, output).toEqual({ code: stall ? 143 : 0, signal: null });
+        expect(casePassed(4)).toBe(!stall);
+        expect(isProcessAlive(watched.child.pid!)).toBe(false);
+        expect(isProcessAlive(workerPid!)).toBe(false);
+      } finally {
+        watched.teardown();
+        forceKillVitestProcessGroup(watched.child);
+        await withTestTimeout(watched.completion, ioTimeoutMs, "owned Vitest group did not stop");
       }
-      const result = await watched.completion;
-      // Vitest's logger handles SIGTERM and exits with 128 + 15, rather than
-      // leaving Node to report a signal-only exit (as a bare silent child does).
-      expect(result, output).toEqual({ code: stall ? 143 : 0, signal: null });
-      expect(casePassed(4)).toBe(!stall);
-      expect(isProcessAlive(watched.child.pid!)).toBe(false);
-      expect(isProcessAlive(workerPid!)).toBe(false);
-    } finally {
-      watched.teardown();
-      forceKillVitestProcessGroup(watched.child);
-      await withTestTimeout(watched.completion, ioTimeoutMs, "owned Vitest group did not stop");
-    }
+    });
   },
 );


### PR DESCRIPTION
Related: #131868 (real Vitest progress regression), #132039 (managed-child performance work).

## What Problem This Solves

Developers running the real Vitest progress regression wait for two independent child scenarios serially. Both need their own real Vitest startup, files, output and watchdog checks; those costs can overlap without reducing the proof.

## Why This Change Was Made

Run the existing success/stall scenarios in two concurrent Vitest suites, each owning its own temporary-directory tracker and afterEach cleanup. Keep the original scenario names and use task-local expect contexts. Fake timers are installed, captured and uninstalled synchronously before the first await: each watchdog retains a separate Sinon clock while transport, diagnostics and process joins use real timers.

A bare concurrent test table would be unsafe: its shared afterEach tracker could delete the other scenario's live fixtures. No production API, timer injection seam, dependency or runner/config change is needed.

## User Impact

No product-runtime behavior changes. On one Blacksmith Testbox, whole-file wall time falls from **6.889s to 5.727s**, saving **1.162s (16.87%)**, favorable in **8/8 balanced pairs**. Both existing tests remain. Production/tooling LOC +0/-0; tests +115/-110 (net +5), mostly indentation from the owning suite.

## Evidence

AI-assisted. Test-audit and deslop complete; fresh isolated Codex autoreview found no P0 findings at its default threshold. Complete changed gate and local focused/shuffled proof pass.

One task-owned Blacksmith Testbox (`tbx_01m14xvvk5az3keer2nt002ne7`), [environment workflow](https://github.com/openclaw/openclaw/actions/runs/33204476982). Excluded A/B warmups, eight balanced A/B pairs per scope, one outer worker, distinct outer module caches, both import diagnostics, GNU `/usr/bin/time -v`. Command: `pnpm test test/scripts/run-vitest-progress.test.ts --maxWorkers=1 --reporter=verbose --reporter=json`; span adds `-t 'keeps real case progress alive'`. The entire file is these two scenarios, so whole-file and span select identical coverage; both requested measurements are retained. No failed or slow samples dropped.

| Scope | Wall A/B | Vitest A/B | Body span A/B | Import A/B | User CPU A/B | System CPU A/B | Max RSS A/B |
|---|---:|---:|---:|---:|---:|---:|---:|
| whole | 6.889/5.727s | 2.486/1.550s | 2.006/1.100s | 0.202/0.182s | 7.324/7.069s | 0.546/0.501s | 331.8/335.8 MiB |
| rows | 7.036/5.843s | 2.564/1.510s | 2.029/1.057s | 0.237/0.179s | 7.481/7.117s | 0.554/0.522s | 335.2/337.3 MiB |

Body span is Vitest elapsed test time, not the sum of overlapping row durations. GNU maximum RSS is a per-process maximum, not aggregate concurrent memory. Process monitoring observes one to two overlapping fixture Vitest children; their unchanged thread pool means recorded worker PIDs can equal their child PID. Two total child launches, ten fixture files, separate root/config/cache/env/output/clock/spies, five readiness barriers per scenario, four real case-output/release pairs, final success versus stall, exit 0 versus 143, liveness assertions and process-group cleanup all remain.

Reversible production faults:

- Disable watchdog reset on child output: healthy scenario fails its no-timeout assertion after real case 0 output.
- Disable no-output SIGTERM: stalled scenario survives to its fixture deadline and fails with exit 1 instead of 143.
- Remove completion's process-group kill/join: the thread-based progress pair still passes, while the existing `run-vitest.test.ts` residual-descendant scenario fails its `groupStopped` liveness assertion. The progress pair alone does not prove residual-process cleanup; the sibling supplies that complementary proof.

Exact production bytes restored after each fault; restored progress pair passes. No observed live descendants or progress roots remain after monitored invocations. No production mutations retained.

Local commands: `node scripts/run-vitest.mjs test/scripts/run-vitest-progress.test.ts --maxWorkers=1`; seven-file shuffled siblings at seed 17 (158/158); `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs -- test/scripts/run-vitest-progress.test.ts`; formatter and `git diff --check`. The sibling set includes run-vitest, process-group, process-diagnostics, reporter configuration, process-wait and temp-dir tests.

Native Windows is not run; the existing POSIX skip is preserved. No UI or live Gateway change, so screenshots are not applicable. Linux final-form proof: three focused repeats (2/2 each), plus all seven sibling files in original order and shuffled seeds 17/91 (158/158 each). Three instrumented runs verified distinct captured clocks and all ten readiness events; both scenario finish orders occurred without cross-root cleanup. Remote production and final test SHA-256 hashes match local; 213 raw artifacts retained locally. Testbox stopped and confirmed completed. Exact-head hosted CI and native landing remain required.
