### PR TITLE
fix(ui): make lobster visits less frequent

### DIFF
--- a/docs/web/lobster.md
+++ b/docs/web/lobster.md
@@ -22,7 +22,9 @@ Hover over a visitor and it will tell you its name.
 
 Sometimes. That is the point.
 
-The lobster is a guest, not furniture. It wanders in when it feels like it, stays a while, and leaves. Some sessions it never shows up at all. There is exactly one situation where it always appears: **when your Gateway disconnects**, the lobster comes out and paces, visibly worried, until the connection is back. If the lobster looks stressed, check your Gateway.
+The lobster is a guest, not furniture. Half of session/page-load rolls skip scheduled visits entirely. Otherwise, the first visit starts after 2–10 minutes, with 30–60-minute gaps between visits. Familiarity adjusts those timings: new visitors arrive later, while familiar ones arrive sooner and return a little more often.
+
+Status visits keep their own schedule: **when your Gateway disconnects**, the lobster comes out and paces, visibly worried, until the connection is back. During runs lasting more than ten minutes, it settles in for a quiet vigil. The visits toggle and dismissals still take precedence.
 
 ## Things you can do
 

--- a/docs/web/lobster.md
+++ b/docs/web/lobster.md
@@ -22,7 +22,7 @@ Hover over a visitor and it will tell you its name.
 
 Sometimes. That is the point.
 
-The lobster is a guest, not furniture. Half of session/page-load rolls skip scheduled visits entirely. Otherwise, the first visit starts after 2–10 minutes, with 30–60-minute gaps between visits. Familiarity adjusts those timings: new visitors arrive later, while familiar ones arrive sooner and return a little more often.
+The lobster is a guest, not furniture. Half of session/page-load rolls skip scheduled visits entirely. Otherwise, the base first-arrival delay is 2–10 minutes, with 30–60-minute gaps between visits. Familiarity adjusts those timings: new visitors arrive after 2.6–13 minutes, while familiar ones arrive after 1.4–7 minutes and return after 24–48 minutes.
 
 Status visits keep their own schedule: **when your Gateway disconnects**, the lobster comes out and paces, visibly worried, until the connection is back. During runs lasting more than ten minutes, it settles in for a quiet vigil. The visits toggle and dismissals still take precedence.
 

--- a/docs/web/lobster.md
+++ b/docs/web/lobster.md
@@ -22,7 +22,7 @@ Hover over a visitor and it will tell you its name.
 
 Sometimes. That is the point.
 
-The lobster is a guest, not furniture. Half of session/page-load rolls skip scheduled visits entirely. Otherwise, the base first-arrival delay is 2–10 minutes, with 30–60-minute gaps between visits. Familiarity adjusts those timings: new visitors arrive after 2.6–13 minutes, while familiar ones arrive after 1.4–7 minutes and return after 24–48 minutes.
+The lobster is a guest, not furniture. Half of session/page-load rolls skip scheduled visits entirely. Otherwise, the base first-arrival delay is 2–10 minutes, with 30–60-minute gaps between visits. Familiarity adjusts those timings: new visitors arrive after 2.6–13 minutes, while familiar ones arrive after 1.4–7 minutes and return after 24–48 minutes. Frequent dismissals can make a visitor wary, extending its return gaps by another 70%.
 
 Status visits keep their own schedule: **when your Gateway disconnects**, the lobster comes out and paces, visibly worried, until the connection is back. During runs lasting more than ten minutes, it settles in for a quiet vigil. The visits toggle and dismissals still take precedence.
 

--- a/ui/src/components/lobster-pet-plans.ts
+++ b/ui/src/components/lobster-pet-plans.ts
@@ -179,13 +179,13 @@ export const BAR_ZONE = [18, 50] as const;
 export const BAR_MAX_SCALE = 1.7;
 
 // Visit cadence: seeded per load, the pet is a guest, not a fixture. A share
-// of loads gets no visit at all; the rest get a first arrival within minutes,
+// of loads gets no visit at all; the rest get a delayed first arrival,
 // stays of a few minutes, and long gaps between returns. Disconnects summon
 // the pet regardless of schedule (unless dismissed or disabled).
-export const VISIT_SHY_CHANCE = 0.25;
-export const VISIT_FIRST_DELAY_MS = [15_000, 180_000] as const;
+export const VISIT_SHY_CHANCE = 0.5;
+export const VISIT_FIRST_DELAY_MS = [120_000, 600_000] as const;
 export const VISIT_STAY_MS = [90_000, 300_000] as const;
-export const VISIT_GAP_MS = [360_000, 1_080_000] as const;
+export const VISIT_GAP_MS = [1_800_000, 3_600_000] as const;
 
 // Rare-event loads, planned per seed so tests can probe them purely: a molt
 // load sheds its shell during the first idle act and sizes up one tier; a

--- a/ui/src/components/lobster-pet.test.ts
+++ b/ui/src/components/lobster-pet.test.ts
@@ -86,10 +86,9 @@ async function advanceUntil(
   return predicate();
 }
 
-// Seed 42's visit schedule is not shy and first arrives at ~89s; jump past
-// the maximum first-arrival delay so tests start with a perched pet.
+// Cover the maximum first-arrival delay, including the shy familiarity tier.
 async function arrive(element: LobsterPetElement): Promise<void> {
-  await advanceUntil(element, () => spritePresent(element), 200_000);
+  await advanceUntil(element, () => spritePresent(element), 800_000);
 }
 
 async function startVigilOnlyRun(
@@ -212,18 +211,21 @@ describe("lobster pet element", () => {
     await element.updateComplete;
 
     expect(spritePresent(element)).toBe(false);
+    await vi.advanceTimersByTimeAsync(120_000);
+    await element.updateComplete;
+    expect(spritePresent(element)).toBe(false);
     await arrive(element);
     expect(element.querySelector(".lobster-pet__svg")).not.toBeNull();
     expect(spriteClasses(element)).toContain("lobster-pet--idle");
     expect(["ledge", "bar"]).toContain(element.getAttribute("data-spot"));
   });
 
-  it("shy seeds never visit on their own", async () => {
+  it.each([7, 191])("shy seed %s never visits on its own", async (seed) => {
     vi.useFakeTimers();
-    const element = createPet(7);
+    const element = createPet(seed);
     await element.updateComplete;
 
-    const arrived = await advanceUntil(element, () => spritePresent(element), 600_000);
+    const arrived = await advanceUntil(element, () => spritePresent(element), 800_000);
     expect(arrived).toBe(false);
   });
 
@@ -235,7 +237,8 @@ describe("lobster pet element", () => {
     const departed = await advanceUntil(element, () => !spritePresent(element), 400_000);
     expect(departed).toBe(true);
 
-    const returned = await advanceUntil(element, () => spritePresent(element), 1_300_000);
+    expect(await advanceUntil(element, () => spritePresent(element), 1_200_000)).toBe(false);
+    const returned = await advanceUntil(element, () => spritePresent(element), 2_500_000);
     expect(returned).toBe(true);
   });
 
@@ -448,7 +451,7 @@ describe("lobster pet element", () => {
     const gone = await advanceUntil(element, () => !spritePresent(element), 5_000);
     expect(gone).toBe(true);
 
-    const returned = await advanceUntil(element, () => spritePresent(element), 1_300_000);
+    const returned = await advanceUntil(element, () => spritePresent(element), 3_700_000);
     expect(returned).toBe(true);
   });
 
@@ -994,7 +997,7 @@ describe("lobster plans", () => {
 });
 
 describe("rare lobster loads", () => {
-  // Probe seeds (deterministic per stream): 644 hosts the Elder; 191 rolls
+  // Probe seeds (deterministic per stream): 644 hosts the Elder; 636 rolls
   // an old-friend return plus a balloon entrance; 4689 hatches a shiny variant;
   // 104 is a shy load that beaches a bottle at ~194s; 37 is a shy load with
   // a snail crossing at ~407s.
@@ -1019,15 +1022,14 @@ describe("rare lobster loads", () => {
       "openclaw.control.lobsterdex.v1",
       JSON.stringify({
         gold: { firstSeenAt: 1, name: "Goldenrod" },
-        // Sorts after "gold" (as retired tangerine did) so probe seed 191 keeps
-        // picking index 0 = gold from the sorted candidate list.
+        // Sorts after "gold" so seed 636 picks gold from the sorted candidates.
         watermelon: { firstSeenAt: 2, name: "Pips" },
       }),
     );
-    const element = createPet(191);
+    const element = createPet(636);
     await arrive(element);
 
-    // The seeded crimson look is repainted as the remembered gold visitor.
+    // The seeded look is repainted as the remembered gold visitor.
     expect(spriteClasses(element)).toContain("lobster-pet--palette-gold");
     expect(element.querySelector(".lobster-pet")?.getAttribute("title")).toBe(
       "Goldenrod · an old friend",

--- a/ui/src/components/lobster-pet.test.ts
+++ b/ui/src/components/lobster-pet.test.ts
@@ -369,7 +369,7 @@ describe("lobster pet element", () => {
     expect(gone).toBe(true);
 
     // Dismissal outlasts later scheduled visits and even offline summons.
-    const revisited = await advanceUntil(element, () => spritePresent(element), 2_400_000);
+    const revisited = await advanceUntil(element, () => spritePresent(element), 3_700_000);
     expect(revisited).toBe(false);
     element.mode = "offline";
     await element.updateComplete;


### PR DESCRIPTION
## What Problem This Solves

Control UI lobster visitors appear too frequently during ordinary use. Scheduled visits previously occurred on 75% of session/page-load rolls, started after a base delay of 15 seconds–3 minutes, and returned after 6–18 minutes. Familiarity made them more frequent for long-time users.

## Why This Change Was Made

Tune the existing resident scheduler: 50% of rolls now skip scheduled visits, the base first-arrival range is 2–10 minutes, and return gaps are 30–60 minutes. Existing familiarity multipliers still apply. New visitors arrive after 2.6–13 minutes; familiar visitors arrive after 1.4–7 minutes and return after 24–48 minutes. Frequent dismissals can make any visitor wary, extending those return gaps by another 70%.

This is a maintainer-requested cadence adjustment. The scheduler remains the sole owner of ordinary arrivals; the Lobsterdex still records actual arrivals and retains existing collection data. No new configuration, storage, dependency, protocol, or scheduling path. Visit duration, disconnect summons, long-run vigils, rare passers/bottles, working-claw surprises, the Appearance toggle, and dismissal controls are unchanged. AI-assisted.

## User Impact

The sidebar lobster becomes an occasional visitor, with longer quiet stretches, without disabling visits or losing the collection. The guide describes both base and familiarity-adjusted timings.

## Evidence

- Extended existing component tests for the delayed first arrival, newly quiet seed, and longer return gap. These three checks fail against the former production constants and pass after the change.
- `node scripts/run-vitest.mjs ui/src/components/lobster-pet.test.ts ui/src/components/lobster-dex.test.ts ui/src/components/lobster-pet-variants.test.ts`: 76 passed after rebase, including actual arrival recording, variants, dismissals, disabled visits, offline summons, and vigil outcomes.
- `env -u OPENCLAW_TESTBOX node scripts/check-changed.mjs -- ui/src/components/lobster-pet-plans.ts ui/src/components/lobster-pet.test.ts docs/web/lobster.md`: passed. An earlier remote attempt was interrupted during cleanup and is not counted as passing proof.
- `pnpm check:docs` passed, including MDX, all internal links, and configuration examples.
- Full `pnpm build` passed before rebase; `pnpm ui:build` passed again after rebase, including performance budgets and finalized asset sidecars. Fresh Codex autoreview through P2 and the follow-up documentation review found no actionable findings. `git diff --check` passed.
- Production LOC: +4/-4 (net 0); tests +16/-14 (net +2); documentation +3/-1 (net +2).
- The first CI run hit the unrelated concurrent image-action test failure. Rebased onto its independently landed repair, #132066; no duplicate CI fix is included here. Final-head hosted CI is required before landing.

### Running Control UI

Real Chrome, a task-isolated loopback Gateway, fresh task state, and ordinary navigation. No forced lobster state or clock changes. The bundled baseline produced an idle visitor at about 236 seconds after page load. The candidate development UI connected to the same isolated Gateway remained quiet through the observed 5-minute window, then arrived naturally at about 795 seconds after page navigation (a sampled 603-second delay after the pet mounted). The arrival was recorded in the Lobsterdex and familiarity counter. These are separate randomized loads; the screenshots demonstrate the live surfaces, while the component tests prove the cadence distributions and longer return gaps. This is browser/development-UI proof, not an exact-head packaged release test; no provider inference was needed for the changed pet scheduler.

Before — bundled baseline, resident visible above the account footer:

![Before: sidebar lobster visitor](https://github.com/user-attachments/assets/7b4b8551-7fd1-47df-80d2-48f9180263ef)

After — candidate UI, quiet sidebar:

![After: quieter sidebar](https://github.com/user-attachments/assets/28fab63b-beaa-462c-8ea6-fef30f2d05e4)

### Review follow-through

The initial ClawSweeper timing finding is addressed: the guide now labels the base range and states the effective new/familiar visitor timings. The late wary-modifier finding is also addressed: the guide explains the additional 70% return delay after frequent dismissals. Running browser captures are included above. Maintainer handling is explicit in the requested fix-and-land workflow. The review's local Corepack restriction does not apply to the successful local changed-file check or hosted docs check.

### Separate follow-up: intermittent durable draft reload

The first run on `326b367` passed the main UI suite, real-Gateway UI E2E, and all other selected lanes, but [E2E shard 12](https://github.com/openclaw/openclaw/actions/runs/33207989879/job/98974169340) failed `new-session-page.draft-handoff.e2e.test.ts:69`: page B restored stale text after a successful committed-newer-draft read and reload. This happens before page A consumes its stale navigation handoff. The relevant test, helper, persistence owner, and store are unchanged from main. The exact unchanged E2E passes four local runs.

Follow-up: trace durable draft write IDs/revisions and controller lifecycle generations if this recurs. A late conflict can reactivate a disconnected draft controller, but that is a source-level suspect, not a proven cause of this CI failure. No timeout increase, assertion weakening, or unrelated persistence change is included. The bounded failed-job rerun passed on that unchanged head; this does not establish that the underlying intermittent issue is repaired. This PR still requires a successful hosted gate before landing.

### Final documentation follow-up

`75c9dab` only qualifies the existing wary return multiplier. Runtime and test files are byte-identical to the previously verified `326b367`. Fresh `pnpm check:docs`, `git diff --check`, and Codex autoreview passed for this sentence. Final-head CI: [run 33213587480](https://github.com/openclaw/openclaw/actions/runs/33213587480).
