### PR TITLE
fix(ui): keep chat image browser checks stable during concurrent tests

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -2277,7 +2277,9 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     }
   });
 
-  it("keeps managed image actions anchored around tiny rendered images", async () => {
+  // Concurrent siblings clear Vitest's ambient test when they finish. Bind polls
+  // to this test so an awaited hover cannot lose its assertion context.
+  it("keeps managed image actions anchored around tiny rendered images", async (context) => {
     const page = await openBrowserPage(1280, 900);
     try {
       await page.setContent(
@@ -2317,7 +2319,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         </body></html>`,
       );
       const frames = page.locator(".chat-image-frame--managed");
-      await expect.poll(() => frames.count()).toBe(2);
+      await context.expect.poll(() => frames.count()).toBe(2);
       const frameRows = await frames.evaluateAll((elements) =>
         elements.map((element) => {
           const box = element.getBoundingClientRect();
@@ -2328,7 +2330,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       for (const [index, expectedWidth] of [160, 84].entries()) {
         const frame = frames.nth(index);
         await frame.hover();
-        await expect
+        await context.expect
           .poll(() => frame.evaluate((element) => getComputedStyle(element, "::after").opacity))
           .toBe("1");
         const geometry = await frame.evaluate((element) => {


### PR DESCRIPTION
Related: #131811 (chat image presentation and controls).

<details>
<summary>Additional instructions</summary>

Maintainer-requested test repair; this branch is in the upstream repository and maintainers can push to it.

</details>

## What Problem This Solves

Resolves a problem where the full responsive-chat browser test file fails in `checks-node-compact-large-9`, while the tiny-image case passes in isolation. The test loses its Vitest assertion context after an overlapping sibling finishes.

## Why This Change Was Made

Use `context.expect` for both polling assertions in the existing tiny-image test. Its imported global `expect.poll` depended on Vitest's ambient current-test slot, which any concurrent sibling completion clears. All polling, geometry assertions, browser cleanup, timeouts, and concurrent scheduling remain unchanged; no production code changes.

The reduced failing pair is `keeps attached images within narrow message lanes` followed by `keeps managed image actions anchored around tiny rendered images`. The narrow-image test completes normally with awaited cleanup; it does not leak an unfinished browser continuation. The test defect is the tiny-image test producing assertions from shared ambient state after awaited browser operations. Installed Vitest 4.1.11 source confirms the runner clears that slot on completion, whereas callback-context `expect` closes over the owning task. This uses the [existing Vitest test-context API](https://vitest.dev/guide/test-context#expect), also used by the concurrent Retry-color test in this file.

Provenance: introduced by `4788f764f578b28c6ab26ee19b941a940632ffe0` in #131811 on 2026-08-28 (code/PR author and merger: @vyctorbrzezowski). The subsequent failed-attachment polling is behind `FULL_APP_TEST_OPTIONS.concurrent: false`; the toast changes do not introduce the assertion race.

## User Impact

No user-visible behavior changes. Developers retain the full managed-image layout checks without an order-dependent CI failure. Production LOC: +0/-0. Tests: +5/-3, including the explanation of assertion ownership.

## Evidence

Baseline: `54f0322557d38123febe934b482e019e16758511`.

| Execution | Before | After |
| --- | --- | --- |
| Full file, default concurrency | 110 passed, tiny-image failed with `expect.poll() must be called inside a test` | 111 passed, three consecutive runs |
| Tiny-image isolation | 1 passed | 1 passed |
| Narrow-image + tiny-image pair, default concurrency | Narrow-image passed; tiny-image failed | 2 passed |
| Same pair, `--maxConcurrency=1` (diagnostic only) | 2 passed | Concurrency is unchanged by the patch |

Temporary diagnostic trace, removed from the patch:

```text
TRACE before count keeps managed image actions anchored around tiny rendered images
PASS keeps attached images within narrow message lanes
TRACE after hover undefined
FAIL keeps managed image actions anchored around tiny rendered images
Error: expect.poll() must be called inside a test
```

Commands:

```sh
node scripts/run-vitest.mjs ui/src/pages/chat/chat-responsive.browser.test.ts
node scripts/run-vitest.mjs ui/src/pages/chat/chat-responsive.browser.test.ts -t 'tiny rendered'
node scripts/run-vitest.mjs ui/src/pages/chat/chat-responsive.browser.test.ts -t 'keeps attached images within narrow message lanes|tiny rendered'
node scripts/run-vitest.mjs ui/src/pages/chat/chat-responsive.browser.test.ts -t 'keeps attached images within narrow message lanes|tiny rendered' --maxConcurrency=1
for run in 1 2 3; do
  node scripts/run-vitest.mjs ui/src/pages/chat/chat-responsive.browser.test.ts || exit $?
done
node scripts/check-changed.mjs
git diff --check
```

Final-patch full-file durations: 41.85s, 44.45s, 42.31s; all 111 tests passed each time. The existing browser test supplies regression coverage; no duplicate test or production seam was added. No visual artifact is needed because rendered behavior is unchanged.

Changed gate: `node scripts/check-changed.mjs` exited 0, including typechecking and lint. The first implementation used destructured `expect`, passed browser proof, but hit `eslint(no-shadow)`; the final patch uses the existing sibling convention `context.expect`, without a lint suppression.
Codex autoreview: exit 0, no accepted/actionable findings. AI-assisted repair; the dependency contract and original execution-order trace were inspected directly.
