### PR TITLE
docs: friendlier security and first-touch pages

### DIFF
--- a/docs/channels/groups.md
+++ b/docs/channels/groups.md
@@ -520,9 +520,9 @@ Group/channel tool restrictions are applied in addition to global/agent tool pol
 
 When `channels.whatsapp.groups`, `channels.telegram.groups`, or `channels.imessage.groups` is configured, the keys act as a group allowlist. Use `"*"` to allow all groups while still setting default mention behavior.
 
-<Warning>
+<Note>
 Common confusion: DM pairing approval is not the same as group authorization. For channels that support DM pairing, the pairing store unlocks DMs only. Group commands still require explicit group sender authorization from config allowlists such as `groupAllowFrom` or the documented config fallback for that channel.
-</Warning>
+</Note>
 
 Common intents (copy/paste):
 

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -1,9 +1,18 @@
 ---
-summary: "Security considerations and threat model for running an AI gateway with shell access"
+summary: "Trust model, safe defaults, and hardening guidance for running OpenClaw"
 read_when:
   - Adding features that widen access or automation
+  - Reviewing OpenClaw security posture or hardening a deployment
 title: "Security"
 ---
+
+OpenClaw ships with conservative defaults: the Gateway binds to loopback, unknown DM senders only ever receive a pairing code, and groups are allowlisted and mention-gated. If you run OpenClaw for yourself or with your team and keep those defaults, you are already in good shape - and one command tells you if you have drifted:
+
+```bash
+openclaw security audit
+```
+
+The rest of this page is the deep end: the trust model, what the audit checks, and how to harden further as you expose more surface.
 
 <Note>
   **One trust boundary per gateway.** This guidance assumes one trusted

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -6,7 +6,7 @@ read_when:
 title: "Security"
 ---
 
-OpenClaw ships with conservative defaults: the Gateway binds to loopback, unknown DM senders only ever receive a pairing code, and groups are allowlisted and mention-gated. If you run OpenClaw for yourself or with your team and keep those defaults, you are already in good shape - and one command tells you if you have drifted:
+OpenClaw ships with conservative defaults. On a regular host install the Gateway binds to loopback; most chat channels answer an unknown DM sender with a pairing code instead of processing the message; and group access is allowlisted, usually behind a mention gate. The exceptions are deliberate and documented: container images default to an exposed bind (pair that with auth - see the [exposure runbook](/gateway/security/exposure-runbook)), and a few workspace channels such as ClickClack trust workspace membership by default - each channel page states its exact defaults. Run on those defaults and you are in good shape, and one command tells you if you have drifted:
 
 ```bash
 openclaw security audit

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1416,12 +1416,12 @@ Model Q&A - defaults, selection, aliases, switching, failover, auth profiles - l
 
 <AccordionGroup>
   <Accordion title="Is it safe to expose OpenClaw to inbound DMs?">
-    Treat inbound DMs as untrusted input. Defaults reduce risk:
+    Yes - the defaults are built for this. A stranger who DMs your bot never reaches the model:
 
     - Default behavior on DM-capable channels is **pairing**: unknown senders receive a pairing code and their message is not processed. Approve with `openclaw pairing approve --channel <channel> [--account <id>] <code>`. Pending requests are capped at **3 per channel**; check `openclaw pairing list --channel <channel> [--account <id>]` if a code did not arrive.
     - Opening DMs publicly requires explicit opt-in (`dmPolicy: "open"` and allowlist `"*"`).
 
-    Run `openclaw doctor` to surface risky DM policies.
+    Run `openclaw doctor` to confirm your DM policies look the way you expect.
 
   </Accordion>
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1416,12 +1416,12 @@ Model Q&A - defaults, selection, aliases, switching, failover, auth profiles - l
 
 <AccordionGroup>
   <Accordion title="Is it safe to expose OpenClaw to inbound DMs?">
-    Yes - the defaults are built for this. A stranger who DMs your bot never reaches the model:
+    Yes - on channels that default to **pairing** (most DM-capable channels), a stranger who DMs your bot never reaches the model:
 
-    - Default behavior on DM-capable channels is **pairing**: unknown senders receive a pairing code and their message is not processed. Approve with `openclaw pairing approve --channel <channel> [--account <id>] <code>`. Pending requests are capped at **3 per channel**; check `openclaw pairing list --channel <channel> [--account <id>]` if a code did not arrive.
+    - With the pairing default, unknown senders receive a pairing code and their message is not processed. Approve with `openclaw pairing approve --channel <channel> [--account <id>] <code>`. Pending requests are capped at **3 per channel**; check `openclaw pairing list --channel <channel> [--account <id>]` if a code did not arrive.
     - Opening DMs publicly requires explicit opt-in (`dmPolicy: "open"` and allowlist `"*"`).
 
-    Run `openclaw doctor` to confirm your DM policies look the way you expect.
+    A few workspace channels ship different defaults - ClickClack, for example, allows workspace members by default. Check your channel's page, and run `openclaw doctor` to confirm your DM policies look the way you expect.
 
   </Accordion>
 

--- a/docs/start/openclaw.md
+++ b/docs/start/openclaw.md
@@ -8,9 +8,9 @@ title: "Personal assistant setup"
 
 OpenClaw is a self-hosted gateway that connects Discord, Google Chat, iMessage, Matrix, Microsoft Teams, Signal, Slack, Telegram, WhatsApp, Zalo, and more to AI agents. This guide covers the "personal assistant" setup: a dedicated WhatsApp number that behaves like your always-on AI assistant. Setting up a shared gateway for several people instead? See [Team setup](/start/teams).
 
-## Safety first
+## Good defaults first
 
-Giving an agent a channel puts it in a position to run commands on your machine (depending on your tool policy), read/write files in your workspace, and send messages back out via any connected channel. Start conservative:
+A connected agent is a capable one: depending on your tool policy it can run commands, work with files in its workspace, and message people on your behalf. The defaults keep that power scoped to you; a few settings are worth confirming up front:
 
 - Always set `channels.whatsapp.allowFrom` (never run open-to-the-world on your personal Mac).
 - Use a dedicated WhatsApp number for the assistant.


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #132012: the security page still reads like a policy document on arrival — the title drops straight into a trust-model callout and seven scope bullets, with the reassuring parts (safe defaults, the one-command audit) buried below. The first-touch guides have the same tone problem in miniature: the inbound-DM FAQ answer opens with "Treat inbound DMs as untrusted input" before mentioning that the defaults already handle strangers, and the personal guide's "Safety first" section leads with everything an agent could do to your machine.

## Why This Change Was Made

Lead with what is already true, then teach the deep end. The security page now opens with three sentences of reality — conservative defaults, what they cover, and `openclaw security audit` as the drift check — before the trust-model note and scope reference. The DM FAQ answers the question asked ("Yes — the defaults are built for this") with the same facts as before. The personal guide's section becomes "Good defaults first," framing the same checklist as confirming defaults rather than defusing a hazard. The informational pairing-vs-group-authorization callout in Groups drops from a yellow warning to a note; the genuinely footgun warnings (sandbox `groupScope` boundary, Control UI host-shell/embed/tokenless-auth) stay as warnings on purpose. An audit found no `<Danger>` blocks anywhere and no remaining warnings on landing/start/FAQ/pairing pages.

## User Impact

A newcomer clicking Security sees "you are already in good shape" plus one command before any policy text; the substance — trust boundaries, adversarial-tenant limits, hardening — is unchanged and one scroll away. No configuration guidance changed.

## Evidence

`pnpm docs:check-mdx`, `docs:check-links` (0 broken), `format:docs:check`, `docs:check-i18n-glossary`, `git diff --check` — all green. Before = live docs.openclaw.ai, after = `mint dev` on this branch.

**Security page opening**

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/dbb4c909-95b8-4292-abb1-ee61f29341ef) | ![after](https://github.com/user-attachments/assets/ad57fc16-36c4-411f-a8da-7f32ca160d92) |

**Personal assistant guide — "Safety first" → "Good defaults first"**

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/94e90d0c-2477-4baa-881d-6d839b0616b3) | ![after](https://github.com/user-attachments/assets/66f25596-e9b6-4934-8e90-dcaf362b93cb) |
