### PR TITLE
refactor(release): remove unused GitHub publisher helper

### DIFF
--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -1986,29 +1986,6 @@ jobs:
             echo "- GitHub release draft: https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG}" >> "$GITHUB_STEP_SUMMARY"
           }
 
-          publish_github_release() {
-            local expected_prerelease release_json
-            verify_release_tag_target
-            if is_android_release; then
-              verify_android_release_asset_contract
-            fi
-            if is_stable_release; then
-              verify_windows_release_asset_contract
-            fi
-            gh release edit "${RELEASE_TAG}" --repo "$GITHUB_REPOSITORY" --draft=false
-            release_json="$(gh release view "${RELEASE_TAG}" --repo "$GITHUB_REPOSITORY" --json isDraft,isPrerelease)"
-            expected_prerelease="false"
-            if [[ "${RELEASE_TAG}" == *"-alpha."* || "${RELEASE_TAG}" == *"-beta."* ]]; then
-              expected_prerelease="true"
-            fi
-            if [[ "$(printf '%s' "${release_json}" | jq -r '.isDraft')" != "false" ]] ||
-              [[ "$(printf '%s' "${release_json}" | jq -r '.isPrerelease')" != "${expected_prerelease}" ]]; then
-              echo "Published GitHub release state does not match the requested draft/prerelease classification." >&2
-              exit 1
-            fi
-            echo "- GitHub release: https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG}" >> "$GITHUB_STEP_SUMMARY"
-          }
-
           verify_android_release_asset_contract() {
             local actual_android_assets actual_digest expected_android_assets expected_digest expected_hash release_json verify_dir
             local -a required_assets=(


### PR DESCRIPTION
## What Problem This Solves

The release-publish dispatcher still contains an unreachable inline GitHub publisher alongside the active Docker-gated finalizer. Keeping both obscures which path owns publication and leaves obsolete release logic available to be mistaken for an active safeguard.

## Why This Change Was Made

Remove only the unused `publish_github_release()` definition and its separating blank line. Repository-wide caller searches and inspection of the complete dispatch block found no direct, exported, or dynamic invocation. Commit `6baf4dd15f5d29bd8de79db568f27d5a1f73b2c4` moved the last call to the dedicated `finalize_github_release` job after Docker succeeds.

The active Android and Windows asset verifier definitions and their promotion callers are unchanged. All release, approval, SHA, asset, permissions, and finalization policy remains unchanged. This is a maintainer-requested, AI-assisted dead-code cleanup, not a behavior change or linter repair.

Related context:
- #117252 moved publication behind successful Docker publication.
- #131911 was the native cleanup during which this unused definition was noticed.
- #131982 independently repaired actionlint's ShellCheck-stdin deadlock; this PR does not alter that repair or any linter pin.

## User Impact

No user-visible behavior changes. Release maintainers have one fewer obsolete publication path to read. The only change is 23 deleted workflow lines, with zero additions and zero test/test-support changes. No configuration, permissions, dependency, or changelog changes.

## Evidence

- Existing hermetic suite: `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts` — 205/205 tests passed after rebasing onto `72ee28b8538d716e8fcc0b8d10fc12e85c5409b6` (one shard, 91.90s wrapper). The first run was 204/205 after an unchanged preflight fixture timed out; the identical rerun passed with no source, environment, or timeout changes. Coverage includes Docker-gated finalization, release-note ordering, Windows/Android contracts, and authorization failures.
- Full workflow sanity: `node --import ./scripts/tsx.mjs scripts/check-workflows.mts`, with the canonical pinned actionlint revision `011a6d15e749bb3f2d771eed9c7aa0e7e3e10ee7` first on PATH — passed, including ShellCheck, zizmor, composite-action interpolation, and conflict-marker guards. The old Homebrew actionlint was not used.
- `./node_modules/.bin/oxfmt --check .github/workflows/openclaw-release-publish.yml` and `git diff --check` — passed.
- Byte-for-byte and parsed-YAML comparison confirmed the definition is the only change; `bash -n` accepted the dispatch block without executing it.
- Independent isolated Codex autoreview of the deletion — clean, no accepted/actionable findings. A fresh exact-head review is required before final landing.

No live release workflow was executed and no environment approval, package, release, or tag was published. Live publication is intentionally excluded: this is an unreachable-definition deletion, covered by hermetic tests, syntax/lint, and exact preservation checks. Exact-head PR CI and final landing proof will be recorded before merge.
