### PR TITLE
fix: declaration steps succeed with lingering subprocesses

### DIFF
--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -125,6 +125,13 @@ do not restrict the [SSH backend's Gateway host](/gateway/sandboxing#ssh-backend
 
 ## Shared test state and process helpers
 
+Plugin SDK declaration preparation and `scripts/run-tsgo.mjs` require child work
+to finish before reporting success. On POSIX, each verifies its own managed
+process group: leftover children are terminated and the command fails instead of
+allowing artifact stamps or downstream checks to proceed. Windows retains normal
+joined-launcher completion because strict group verification is unsupported there.
+This does not detect descendants that deliberately leave the managed groups.
+
 On POSIX hosts, the Vitest wrapper gives each invocation an owned temporary
 namespace through `TMPDIR`, `TMP`, and `TEMP`. Fallback SQLite state stays available
 across shared-worker files and module resets, then the wrapper removes the namespace

--- a/scripts/prepare-extension-package-boundary-artifacts.mts
+++ b/scripts/prepare-extension-package-boundary-artifacts.mts
@@ -714,6 +714,8 @@ export async function runNodeStep(
     env: params.env ? { ...process.env, ...params.env } : process.env,
     shell: false,
     stdio: ["ignore", "pipe", "pipe"],
+    // Artifact writers must finish before stamps, dependent readers, or lock release.
+    requireProcessTreeExit: process.platform !== "win32",
     timeoutMs: resolvedTimeoutMs,
     signal: params.abortController?.signal,
     abortKillGraceMs: Math.max(

--- a/scripts/run-tsgo.mts
+++ b/scripts/run-tsgo.mts
@@ -81,6 +81,8 @@ async function main(): Promise<void> {
       bin: tsgoPath,
       args: finalArgs,
       env,
+      // The compiler owns a nested group that outer preparation cannot verify.
+      requireProcessTreeExit: process.platform !== "win32",
       timeoutMs,
     });
   } catch (error) {

--- a/test/scripts/managed-child-process.test.ts
+++ b/test/scripts/managed-child-process.test.ts
@@ -934,7 +934,7 @@ require('node:child_process').spawn(process.execPath, ['-e', ${JSON.stringify(le
     expect(isProcessAlive(childPid)).toBe(false);
   });
 
-  it("allows bounded retry output and normal long-running work to complete", async () => {
+  it("allows bounded retry output to complete", async () => {
     await expect(
       runManagedCommand({
         bin: process.execPath,
@@ -947,6 +947,9 @@ require('node:child_process').spawn(process.execPath, ['-e', ${JSON.stringify(le
         timeoutMs: 1_000,
       }),
     ).resolves.toBe(0);
+  });
+
+  posixIt("allows strict normal long-running work to complete", async () => {
     await expect(
       runManagedCommand({
         bin: process.execPath,
@@ -976,17 +979,14 @@ require('node:child_process').spawn(process.execPath, ['-e', ${JSON.stringify(le
     expect(isProcessAlive(childPid)).toBe(false);
   });
 
-  posixIt("rejects and drains descendants left after a successful leader exit", async () => {
-    const dir = createTempDir("openclaw-managed-lingering-");
-    const descendantPidPath = path.join(dir, "descendant.pid");
-    let descendantPid = 0;
-    try {
-      await expect(
-        runManagedCommand({
-          bin: process.execPath,
-          args: [
-            "-e",
-            `
+  posixIt.each(["managed", "preparation"])(
+    "rejects and drains descendants left after a successful leader exit through %s",
+    async (runner) => {
+      const dir = createTempDir("openclaw-managed-lingering-");
+      const descendantPidPath = path.join(dir, "descendant.pid");
+      const args = [
+        "-e",
+        `
 const { spawn } = require("node:child_process");
 const child = spawn(process.execPath, [
   "-e",
@@ -995,22 +995,41 @@ const child = spawn(process.execPath, [
 ], { stdio: ["ignore", "ignore", "ignore", "ipc"] });
 child.once("message", () => process.exit(0));
 `,
-            descendantPidPath,
-          ],
-          requireProcessTreeExit: true,
-          shell: false,
-          stdio: "ignore",
-          timeoutMs: 1_000,
-        }),
-      ).rejects.toMatchObject({ code: "EPROCESSGROUP_CLEANUP_FAILED" });
-      descendantPid = Number(fs.readFileSync(descendantPidPath, "utf8"));
-      expect(isProcessAlive(descendantPid)).toBe(false);
-    } finally {
-      if (descendantPid && isProcessAlive(descendantPid)) {
-        process.kill(descendantPid, "SIGKILL");
+        descendantPidPath,
+      ];
+      try {
+        const command =
+          runner === "preparation"
+            ? runNodeStep("lingering-prep", args, 1_000)
+            : runManagedCommand({
+                bin: process.execPath,
+                args,
+                requireProcessTreeExit: true,
+                shell: false,
+                stdio: "ignore",
+                timeoutMs: 1_000,
+              });
+        const failure = await command.catch((error: unknown) => error);
+        const descendantPid = Number(fs.readFileSync(descendantPidPath, "utf8"));
+        expect.soft(failure).toMatchObject({ code: "EPROCESSGROUP_CLEANUP_FAILED" });
+        expect
+          .soft(
+            isProcessAlive(descendantPid),
+            `descendant ${descendantPid} must be absent at settlement`,
+          )
+          .toBe(false);
+      } finally {
+        // Recover the recorded PID even when an unexpected success fails the assertion.
+        if (fs.existsSync(descendantPidPath)) {
+          const descendantPid = Number(fs.readFileSync(descendantPidPath, "utf8"));
+          if (Number.isSafeInteger(descendantPid) && descendantPid > 1) {
+            if (isProcessAlive(descendantPid)) process.kill(descendantPid, "SIGKILL");
+            await waitForDead(descendantPid, 2_000);
+          }
+        }
       }
-    }
-  });
+    },
+  );
 
   posixIt(
     "kills managed child process group descendants when the runner is terminated",

--- a/test/scripts/run-tsgo.test.ts
+++ b/test/scripts/run-tsgo.test.ts
@@ -10,10 +10,27 @@ import {
   shouldSkipSparseTsgoGuardError,
 } from "../../scripts/lib/tsgo-sparse-guard.mts";
 import { resolveTsgoTimeoutMs } from "../../scripts/run-tsgo.mts";
-import { waitForChildClose, waitForDead, waitForPidFile } from "../helpers/process-wait.js";
+import {
+  isProcessAlive,
+  waitForChildClose,
+  waitForDead,
+  waitForPidFile,
+} from "../helpers/process-wait.js";
 import { createScriptTestHarness } from "./test-helpers.js";
 
 const { createTempDir } = createScriptTestHarness();
+
+it("runs the installed compiler version through the real tsgo wrapper", () => {
+  const result = spawnSync(process.execPath, [path.resolve("scripts/run-tsgo.mjs"), "--version"], {
+    encoding: "utf8",
+    timeout: 25_000,
+    killSignal: "SIGKILL",
+  });
+
+  expect(result.error).toBeUndefined();
+  expect(result.status).toBe(0);
+  expect(result.stdout).toMatch(/^Version \d/m);
+}, 30_000);
 
 describe("run-tsgo sparse guard", () => {
   it("ends sparse-checkout failures with the stable failure trailer", () => {
@@ -303,6 +320,59 @@ describe.skipIf(process.platform === "win32")("run-tsgo watchdog", () => {
       reapFakeTsgo(cwd);
     }
   }
+
+  it("rejects and drains compiler descendants left after a successful leader exit", async () => {
+    const cwd = createTempDir("openclaw-run-tsgo-lingering-");
+    const descendantPidPath = path.join(cwd, "descendant.pid");
+    writeFakeTsgo(
+      cwd,
+      `#!/usr/bin/env node
+const fs = require("node:fs");
+const { spawn } = require("node:child_process");
+fs.writeFileSync("fake-tsgo.pid", String(process.pid));
+const child = spawn(process.execPath, ["-e", ${JSON.stringify(`
+const fs = require("node:fs");
+setInterval(() => {}, 1000);
+fs.writeFileSync(process.argv[1], String(process.pid));
+process.send("ready");
+process.disconnect();
+`)}, ${JSON.stringify(descendantPidPath)}], { stdio: ["ignore", "ignore", "ignore", "ipc"] });
+child.once("message", () => process.exit(0));
+`,
+    );
+    let observedPids: Array<number | undefined> = [];
+    let liveBeforeTeardown: number[] = [];
+    try {
+      const result = runFakeTsgo(cwd, undefined, (pid) => {
+        observedPids = [
+          pid,
+          fs.existsSync(descendantPidPath)
+            ? Number(fs.readFileSync(descendantPidPath, "utf8"))
+            : undefined,
+        ];
+        liveBeforeTeardown = observedPids.filter(
+          (owned): owned is number => owned !== undefined && isProcessAlive(owned),
+        );
+      });
+      expect(result.error).toBeUndefined();
+      expect(
+        observedPids.every((pid) => pid !== undefined && Number.isSafeInteger(pid) && pid > 1),
+      ).toBe(true);
+      expect.soft(result.status).toBe(1);
+      expect.soft(result.stderr).toContain("EPROCESSGROUP_CLEANUP_FAILED");
+      expect
+        .soft(liveBeforeTeardown, "compiler descendants must be absent before fixture teardown")
+        .toEqual([]);
+    } finally {
+      for (const pidFile of [descendantPidPath, path.join(cwd, "fake-tsgo.pid")]) {
+        if (!fs.existsSync(pidFile)) continue;
+        const pid = Number(fs.readFileSync(pidFile, "utf8"));
+        if (!Number.isSafeInteger(pid) || pid <= 1) continue;
+        if (isProcessAlive(pid)) process.kill(pid, "SIGKILL");
+        await waitForDead(pid, 2_000);
+      }
+    }
+  }, 30_000);
 
   it.each([{ bound: "0" }, { bound: "abc" }])(
     "explains a rejected OPENCLAW_TSGO_TIMEOUT_MS of $bound instead of crashing",


### PR DESCRIPTION
Closes #132053.
Related: [the earlier SDK timeout cleanup repair](https://github.com/openclaw/openclaw/pull/131862).

## What Problem This Solves

Resolves a problem where declaration preparation could report success after a zero-exit leader left owned subprocesses running with ignored stdio. Preparation uses success as an artifact barrier before freshness stamps, dependent readers, and writer-lock release, so accepting unfinished work is the wrong ownership contract.

This is a confirmed process fixture, **not a recurrence of the original compiler timeout leak** or evidence of real declaration corruption. The installed native-preview launcher execves or synchronously joins the compiler. Zero-exit acceptance without group verification predates the timeout repair and is present in the inspected `v2026.7.1` preparation code.

## Why This Change Was Made

Both preparation and `run-tsgo` now opt into the existing strict POSIX completion verifier. They own different process groups: a controlled prep-only patch passed the prep regression but still failed the real compiler-wrapper regression. Reusing the verifier at both owners is the narrow fix; changing the shared default would affect unrelated commands and unconditionally enabling it would reject Windows before spawn.

The verifier drains leftover same-group processes and rejects with `EPROCESSGROUP_CLEANUP_FAILED`, rather than converting forced cleanup into success. Windows keeps its existing joined-launcher behavior. This is group verification, not recursive containment of arbitrary detached descendants.

The existing lingering-child test is reused for prep, its failure cleanup now recovers the recorded PID even when an assertion fails, and strict clean-completion coverage is correctly POSIX-only. A portable real compiler-version case protects normal wrapper execution. The completion contract and platform limits are documented in the testing reference.

Production/tooling: **+4/-0 (net +4)**, consisting of two executable opt-ins and two ownership comments. Tests: **+117/-28 (net +89)**. Docs: **+7/-0**. No new lifecycle implementation, removed runtime path, global default, configuration, dependency, timeout, grace, or resource-policy change. AI-assisted implementation and independent review.

## User Impact

On POSIX, declaration/typecheck commands cannot report clean completion while their own managed group remains active. Normal compiler completion continues to work. There is no gateway runtime or channel behavior change, and no new operator setting.

The separate declaration resource-policy work, nested-timeout race investigation, and WhatsApp patch are not included or declared resolved here.

## Evidence

**Failing before the fix:** new real-child caller regressions produced **2 failures / 2 passes** with unchanged production on Node 26.7.0. Prep resolved with a descendant alive; the real `run-tsgo.mjs` wrapper returned zero with its compiler descendant alive. Exact fixture PIDs were recovered and cleaned after observation. With only the prep opt-in, the compiler regression still failed (**1 failure / 3 passes**). With both opt-ins, all four selected cases passed.

**Fixed candidate:** **15 focused tests across 3 files passed independently on both Node 24.20.0 and Node 26.7.0/macOS 27**, covering both callers, strict helper cleanup, clean completion, disappearing-group handling, Windows pre-spawn refusal, serial preparation, timer saturation, and unchanged watchdog opt-in:

```bash
node scripts/run-vitest.mjs test/scripts/managed-child-process.test.ts test/scripts/run-tsgo.test.ts test/scripts/prepare-extension-package-boundary-artifacts.test.ts -t 'rejects and drains.*successful leader exit|runs the installed compiler version|allows bounded retry output|allows strict normal long-running|accepts a process group that vanishes|refuses strict Windows commands|leaves a completing tsgo alone|clamps oversized prep step timers|runs boundary prep steps serially|passes step-specific environment overrides|keeps the watchdog opt-in'
```

**Standalone real-process proof on Node 24:** the original fixture was copied unchanged into an isolated directory. Hardened prep rejected, reported the owned group terminated, and had **zero survivors at return**; its independent control stayed alive. The generic default runner still returned zero with two survivors, proving that the shared default was not changed. All exact fixture PIDs were removed afterward; that manual cleanup is not counted as baseline production cleanup.

**Real compiler proof:** a small declaration compile through `runNodeStep -> run-tsgo.mjs -> run-tsgo.mts -> installed native-preview` completed with the expected declaration bytes and nonempty build-info file present at return. No profiler or policy override was used. The installed launcher and exact Node child-process exit/close implementation were inspected directly.

**Scoped gates passed**, including both script and root-test typechecks through the now-strict real compiler owner, script lint, formatting, erasability, and repository guards:

```bash
node scripts/check-changed.mjs -- docs/reference/test.md scripts/prepare-extension-package-boundary-artifacts.mts scripts/run-tsgo.mts test/scripts/managed-child-process.test.ts test/scripts/run-tsgo.test.ts
```

Fresh isolated Codex autoreview returned **scoped-clean with no accepted/actionable P0 findings**. `git diff --check` passed.

**Limits:** native Windows execution and a full local SDK declaration build were not run. Windows's existing non-strict branch is preserved and its strict-refusal unit contract passed; the new real-version test is portable, not claimed as native Windows proof here. The seven nested-timeout matrix rows were deliberately excluded from the focused local run to avoid conflating the independently active race investigation with this completion-only repair. Hosted exact-head CI remains the required landing gate; no checks will be bypassed.
