### PR TITLE
improve(ui): polish person activity hovercard hierarchy

### DIFF
--- a/ui/src/components/elapsed-time.ts
+++ b/ui/src/components/elapsed-time.ts
@@ -1,13 +1,15 @@
 // Live elapsed-time label that ticks once per second while the work runs.
 import { html, nothing } from "lit";
 import { property } from "lit/decorators.js";
-import { formatDurationCompact } from "../lib/format.ts";
+import { formatDurationCompact, formatDurationHuman } from "../lib/format.ts";
 import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
 import { PollController } from "../lit/poll-controller.ts";
 
 class ElapsedTime extends OpenClawLightDomContentsElement {
   @property({ type: Number }) startMs: number | null = null;
   @property({ type: Number }) endMs: number | null = null;
+  @property({ type: String }) minimumUnit: "second" | "minute" = "second";
+  @property({ type: Boolean }) singleUnit = false;
 
   private readonly polling = new PollController(this, 1_000, () => this.requestUpdate(), false);
 
@@ -35,8 +37,13 @@ class ElapsedTime extends OpenClawLightDomContentsElement {
       return nothing;
     }
     const end = this.endMs ?? Date.now();
-    // Sub-second elapsed reads as "1s", not a millisecond counter.
-    return html`${formatDurationCompact(Math.max(1_000, end - start))}`;
+    const minimumMs = this.minimumUnit === "minute" ? 60_000 : 1_000;
+    const elapsedMs = Math.max(minimumMs, end - start);
+    return html`${this.singleUnit
+      ? formatDurationHuman(elapsedMs)
+      : formatDurationCompact(
+          this.minimumUnit === "minute" ? Math.floor(elapsedMs / 60_000) * 60_000 : elapsedMs,
+        )}`;
   }
 }
 

--- a/ui/src/components/person-activity-card.ts
+++ b/ui/src/components/person-activity-card.ts
@@ -177,12 +177,14 @@ function renderSessions(
                 >
                 <span class="person-activity-card__session-copy"
                   ><span
-                    class="hover-marquee"
-                    data-hover-marquee-delay="250"
-                    data-hover-marquee-extra-shift="18"
+                    class="person-activity-card__session-name ${recent
+                      ? "hover-marquee"
+                      : "person-activity-card__session-name--multiline"}"
+                    data-hover-marquee-delay=${recent ? "250" : nothing}
+                    data-hover-marquee-extra-shift=${recent ? "18" : nothing}
                     >${resolveSessionDisplayName(row.key, row)}</span
                   >
-                  ${recent && row.updatedAt != null
+                  ${row.updatedAt != null
                     ? html`<span class="person-activity-card__session-age"
                         >${elapsed(row.updatedAt, "single-unit")}</span
                       >`

--- a/ui/src/components/person-activity-card.ts
+++ b/ui/src/components/person-activity-card.ts
@@ -1,8 +1,14 @@
 import { html, nothing } from "lit";
+import { keyed } from "lit/directives/keyed.js";
+import { ref } from "lit/directives/ref.js";
 import { repeat } from "lit/directives/repeat.js";
 import type { GatewaySessionRow } from "../api/types.ts";
 import { i18n, t } from "../i18n/index.ts";
-import { startHoverMarqueeFromEvent, stopHoverMarqueeFromEvent } from "../lib/hover-marquee.ts";
+import {
+  restartHoverMarqueeIfActive,
+  startHoverMarqueeFromEvent,
+  stopHoverMarqueeFromEvent,
+} from "../lib/hover-marquee.ts";
 import { shouldHandleNavigationClick } from "../lib/navigation-click.ts";
 import type { PresenceViewer } from "../lib/presence-users.ts";
 import { resolveSessionDisplayName } from "../lib/session-display.ts";
@@ -152,6 +158,16 @@ function renderSessions(
             sessions.slice(0, 3),
             ({ row, agentId }) => sessionIdentity(row.key, agentId, input),
             ({ row, agentId }) => {
+              const displayName = resolveSessionDisplayName(row.key, row);
+              const name = html`<span
+                ${recent ? ref(restartHoverMarqueeIfActive) : nothing}
+                class="person-activity-card__session-name ${recent
+                  ? "hover-marquee"
+                  : "person-activity-card__session-name--multiline"}"
+                data-hover-marquee-delay=${recent ? "250" : nothing}
+                data-hover-marquee-extra-shift=${recent ? "18" : nothing}
+                >${displayName}</span
+              >`;
               const target = sessionNavigationTarget({
                 face: resolveSessionPreferredFace(row),
                 sessionKey: row.key,
@@ -165,6 +181,8 @@ function renderSessions(
                 href=${target.href}
                 @mouseenter=${startHoverMarqueeFromEvent}
                 @mouseleave=${stopHoverMarqueeFromEvent}
+                @focusin=${startHoverMarqueeFromEvent}
+                @focusout=${stopHoverMarqueeFromEvent}
                 @click=${(event: MouseEvent) => {
                   if (!shouldHandleNavigationClick(event)) {
                     return;
@@ -176,14 +194,7 @@ function renderSessions(
                   >${icons.messageSquare}</span
                 >
                 <span class="person-activity-card__session-copy"
-                  ><span
-                    class="person-activity-card__session-name ${recent
-                      ? "hover-marquee"
-                      : "person-activity-card__session-name--multiline"}"
-                    data-hover-marquee-delay=${recent ? "250" : nothing}
-                    data-hover-marquee-extra-shift=${recent ? "18" : nothing}
-                    >${resolveSessionDisplayName(row.key, row)}</span
-                  >
+                  >${recent ? keyed(displayName, name) : name}
                   ${row.updatedAt != null
                     ? html`<span class="person-activity-card__session-age"
                         >${elapsed(row.updatedAt, "single-unit")}</span

--- a/ui/src/components/person-activity-card.ts
+++ b/ui/src/components/person-activity-card.ts
@@ -2,6 +2,7 @@ import { html, nothing } from "lit";
 import { repeat } from "lit/directives/repeat.js";
 import type { GatewaySessionRow } from "../api/types.ts";
 import { i18n, t } from "../i18n/index.ts";
+import { startHoverMarqueeFromEvent, stopHoverMarqueeFromEvent } from "../lib/hover-marquee.ts";
 import { shouldHandleNavigationClick } from "../lib/navigation-click.ts";
 import type { PresenceViewer } from "../lib/presence-users.ts";
 import { resolveSessionDisplayName } from "../lib/session-display.ts";
@@ -90,13 +91,20 @@ function observedTimestamp(values: (number | undefined)[], order: "first" | "las
   return known.length ? (order === "first" ? Math.min(...known) : Math.max(...known)) : undefined;
 }
 
-function elapsed(timestamp: number) {
+function elapsed(
+  timestamp: number,
+  display: "compact" | "minute-compact" | "single-unit" = "compact",
+) {
   const date = new Date(timestamp);
   return html`<time
     datetime=${date.toISOString()}
     title=${date.toLocaleString(i18n.getLocale())}
-    aria-label=${date.toLocaleString(i18n.getLocale())}
-    ><openclaw-elapsed-time .startMs=${timestamp}></openclaw-elapsed-time
+    aria-label=${display === "minute-compact" ? nothing : date.toLocaleString(i18n.getLocale())}
+    ><openclaw-elapsed-time
+      .startMs=${timestamp}
+      .minimumUnit=${display === "minute-compact" ? "minute" : "second"}
+      .singleUnit=${display === "single-unit"}
+    ></openclaw-elapsed-time
   ></time>`;
 }
 
@@ -132,6 +140,9 @@ function renderSessions(
   input: PersonCardInput,
   recent: boolean,
 ) {
+  if (!recent && sessions.length === 0) {
+    return nothing;
+  }
   const title = t(recent ? "presence.card.recentSessions" : "presence.card.viewingNow");
   return html`<section class="person-activity-card__section">
     <h3>${title}</h3>
@@ -150,8 +161,10 @@ function renderSessions(
                 mainKey: input.mainKey,
               });
               return html`<a
-                class="person-activity-card__session"
+                class="person-activity-card__session session-row-host"
                 href=${target.href}
+                @mouseenter=${startHoverMarqueeFromEvent}
+                @mouseleave=${stopHoverMarqueeFromEvent}
                 @click=${(event: MouseEvent) => {
                   if (!shouldHandleNavigationClick(event)) {
                     return;
@@ -163,11 +176,15 @@ function renderSessions(
                   >${icons.messageSquare}</span
                 >
                 <span class="person-activity-card__session-copy"
-                  ><span>${resolveSessionDisplayName(row.key, row)}</span> ${recent &&
-                  row.updatedAt != null
-                    ? html`<small
-                        >${t("presence.card.sessionUpdated")} ${elapsed(row.updatedAt)}
-                        ${t("presence.card.ago")}</small
+                  ><span
+                    class="hover-marquee"
+                    data-hover-marquee-delay="250"
+                    data-hover-marquee-extra-shift="18"
+                    >${resolveSessionDisplayName(row.key, row)}</span
+                  >
+                  ${recent && row.updatedAt != null
+                    ? html`<span class="person-activity-card__session-age"
+                        >${elapsed(row.updatedAt, "single-unit")}</span
                       >`
                     : nothing}</span
                 >
@@ -236,17 +253,13 @@ export function renderPersonActivityCard(input: PersonCardInput) {
       <div>
         <h2>${user.name ?? user.email ?? t("presence.card.person")}</h2>
         <span class="person-activity-card__status"
-          ><span aria-hidden="true"></span>${t("presence.rosterTitle")}</span
+          ><span aria-hidden="true"></span>${onlineSince === undefined
+            ? t("presence.rosterTitle")
+            : html`${t("presence.card.onlineFor")} ${elapsed(onlineSince, "minute-compact")}`}</span
         >
       </div>
     </header>
     <dl class="person-activity-card__facts">
-      <div>
-        <dt>${t("presence.card.onlineFor")}</dt>
-        <dd>
-          ${onlineSince === undefined ? t("presence.card.notObserved") : elapsed(onlineSince)}
-        </dd>
-      </div>
       ${where.length || zones.length
         ? html`<div>
             <dt>${t("presence.card.where")}</dt>

--- a/ui/src/e2e/people-activity-card.e2e.test.ts
+++ b/ui/src/e2e/people-activity-card.e2e.test.ts
@@ -14,8 +14,12 @@ const suite = createChatFlowE2eSuite();
 const selected = "agent:main:card-selected";
 const watched = "agent:main:card-viewing";
 const proofDirectory = path.resolve(".artifacts/control-ui-e2e/people-activity-cards");
+const recentLabel =
+  "Review the complete cross-platform launch readiness checklist before release";
+const updatedRecentLabel = `${recentLabel} with every regional owner`;
+const focusUpdatedRecentLabel = `${updatedRecentLabel} and final approval`;
 
-function scenario() {
+function scenario(recentSessionLabel = recentLabel) {
   const now = Date.now();
   return {
     sessionKey: selected,
@@ -45,7 +49,7 @@ function scenario() {
         {
           key: "agent:main:card-recent",
           kind: "direct",
-          label: "Design notes",
+          label: recentSessionLabel,
           updatedAt: now - 120_000,
           createdActor: { type: "human", id: "alice" },
         },
@@ -73,6 +77,21 @@ async function expectInlineLastActivity(card: Locator) {
       return { time: time.getBoundingClientRect().top, suffix: range.getBoundingClientRect().top };
     });
   expect(Math.abs(positions.time - positions.suffix)).toBeLessThan(2);
+}
+
+async function expectMultilineTitle(title: Locator) {
+  const layout = await title.evaluate((element) => {
+    const style = getComputedStyle(element);
+    return {
+      lineClamp: style.getPropertyValue("-webkit-line-clamp"),
+      renderedLines:
+        element.getBoundingClientRect().height / Number.parseFloat(style.lineHeight),
+      whiteSpace: style.whiteSpace,
+    };
+  });
+  expect(layout.lineClamp).toBe("2");
+  expect(layout.renderedLines).toBeGreaterThan(1.5);
+  expect(layout.whiteSpace).toBe("normal");
 }
 
 async function capturePeopleCard(page: Page, filename: string) {
@@ -120,7 +139,7 @@ suite.define(() => {
             expect.arrayContaining([
               expect.stringContaining("Release checklist"),
               expect.stringContaining("Main Session"),
-              expect.stringContaining("Design notes"),
+              expect.stringContaining(recentLabel),
               expect.stringContaining("View activity"),
             ]),
           );
@@ -135,6 +154,45 @@ suite.define(() => {
         await page.mouse.move(bounds.x + bounds.width + 4, bounds.y + bounds.height / 2);
         await page.mouse.move(cardBounds.x + 8, cardBounds.y + 20);
         expect(await card.count()).toBe(1);
+        const recent = card
+          .getByRole("heading", { name: "Recent sessions" })
+          .locator("..")
+          .getByRole("link");
+        const recentTitle = recent.locator(".person-activity-card__session-name");
+        await recent.hover();
+        const initialShift = await recentTitle.evaluate((element) =>
+          element.style.getPropertyValue("--hover-marquee-shift"),
+        );
+        expect(initialShift).not.toBe("");
+        const listRequests = (await gateway.getRequests("sessions.list")).length;
+        const updatedScenario = scenario(updatedRecentLabel);
+        await gateway.setMethodResponse(
+          "sessions.list",
+          updatedScenario.methodResponses["sessions.list"],
+        );
+        await gateway.emitGatewayEvent("sessions.changed", {
+          reason: "update",
+          sessionKey: "agent:main:card-recent",
+        });
+        await expect
+          .poll(async () => (await gateway.getRequests("sessions.list")).length)
+          .toBeGreaterThan(listRequests);
+        await expect.poll(() => recentTitle.textContent()).toBe(updatedRecentLabel);
+        await expect
+          .poll(() =>
+            recentTitle.evaluate((element) =>
+              element.style.getPropertyValue("--hover-marquee-shift"),
+            ),
+          )
+          .not.toBe(initialShift);
+        await page.mouse.move(cardBounds.x + 8, cardBounds.y + 20);
+        await expect
+          .poll(() =>
+            recentTitle.evaluate((element) =>
+              element.classList.contains("hover-marquee--scrolling"),
+            ),
+          )
+          .toBe(false);
         await person.focus();
         await page.keyboard.press("Tab");
         const session = card.getByRole("link", { name: "Release checklist" });
@@ -161,6 +219,53 @@ suite.define(() => {
           )
           .toBe("bob");
         expect(await session.evaluate((element) => document.activeElement === element)).toBe(true);
+        await page.keyboard.press("Tab");
+        await page.keyboard.press("Tab");
+        await expect
+          .poll(() => recent.evaluate((element) => document.activeElement === element))
+          .toBe(true);
+        await expect
+          .poll(() =>
+            recentTitle.evaluate((element) =>
+              element.classList.contains("hover-marquee--scrolling"),
+            ),
+          )
+          .toBe(true);
+        const focusedShift = await recentTitle.evaluate((element) =>
+          element.style.getPropertyValue("--hover-marquee-shift"),
+        );
+        const focusedListRequests = (await gateway.getRequests("sessions.list")).length;
+        const focusUpdatedScenario = scenario(focusUpdatedRecentLabel);
+        await gateway.setMethodResponse(
+          "sessions.list",
+          focusUpdatedScenario.methodResponses["sessions.list"],
+        );
+        await gateway.emitGatewayEvent("sessions.changed", {
+          reason: "update",
+          sessionKey: "agent:main:card-recent",
+        });
+        await expect
+          .poll(async () => (await gateway.getRequests("sessions.list")).length)
+          .toBeGreaterThan(focusedListRequests);
+        await expect.poll(() => recentTitle.textContent()).toBe(focusUpdatedRecentLabel);
+        await expect
+          .poll(() =>
+            recentTitle.evaluate((element) =>
+              element.style.getPropertyValue("--hover-marquee-shift"),
+            ),
+          )
+          .not.toBe(focusedShift);
+        await expect
+          .poll(() =>
+            recentTitle.evaluate((element) =>
+              element.classList.contains("hover-marquee--scrolling"),
+            ),
+          )
+          .toBe(true);
+        await page.keyboard.press("Tab");
+        await page.emulateMedia({ reducedMotion: "reduce" });
+        await expectMultilineTitle(recentTitle);
+        await page.emulateMedia({ reducedMotion: "no-preference" });
         await page.keyboard.press("Escape");
         await expect.poll(() => card.count()).toBe(0);
         expect(await person.evaluate((element) => document.activeElement === element)).toBe(true);
@@ -185,7 +290,7 @@ suite.define(() => {
         hasTouch: true,
         isMobile: true,
         colorScheme: "dark",
-        reducedMotion: "reduce",
+        reducedMotion: "no-preference",
         locale: "en-US",
         serviceWorkers: "block",
         viewport: { width: 390, height: 650 },
@@ -219,6 +324,14 @@ suite.define(() => {
         expect(bounds!.y + bounds!.height).toBeLessThanOrEqual(650);
         const session = card.getByRole("link", { name: "Release checklist" });
         await session.click({ trial: true });
+        const recent = card.getByRole("link", { name: recentLabel });
+        const recentTitle = recent.locator(".person-activity-card__session-name");
+        await expectMultilineTitle(recentTitle);
+        await recent.focus();
+        expect(await recentTitle.evaluate((element) => getComputedStyle(element).textIndent)).toBe(
+          "0px",
+        );
+        await expectMultilineTitle(recentTitle);
         await expectInlineLastActivity(card);
         await capturePeopleCard(page, "touch-dark-open.png");
         await session.tap();

--- a/ui/src/e2e/people-activity-card.e2e.test.ts
+++ b/ui/src/e2e/people-activity-card.e2e.test.ts
@@ -14,8 +14,7 @@ const suite = createChatFlowE2eSuite();
 const selected = "agent:main:card-selected";
 const watched = "agent:main:card-viewing";
 const proofDirectory = path.resolve(".artifacts/control-ui-e2e/people-activity-cards");
-const recentLabel =
-  "Review the complete cross-platform launch readiness checklist before release";
+const recentLabel = "Review the complete cross-platform launch readiness checklist before release";
 const updatedRecentLabel = `${recentLabel} with every regional owner`;
 const focusUpdatedRecentLabel = `${updatedRecentLabel} and final approval`;
 
@@ -84,8 +83,7 @@ async function expectMultilineTitle(title: Locator) {
     const style = getComputedStyle(element);
     return {
       lineClamp: style.getPropertyValue("-webkit-line-clamp"),
-      renderedLines:
-        element.getBoundingClientRect().height / Number.parseFloat(style.lineHeight),
+      renderedLines: element.getBoundingClientRect().height / Number.parseFloat(style.lineHeight),
       whiteSpace: style.whiteSpace,
     };
   });

--- a/ui/src/lib/hover-marquee.test.ts
+++ b/ui/src/lib/hover-marquee.test.ts
@@ -61,6 +61,19 @@ describe("hover marquee", () => {
     expect(label.style.getPropertyValue("--hover-marquee-duration")).toBe("300ms");
   });
 
+  it("supports a faster delayed reveal beyond a faded edge", () => {
+    const { row, label } = buildRow({ textWidth: 320, labelWidth: 180 });
+    label.dataset.hoverMarqueeDelay = "250";
+    label.dataset.hoverMarqueeExtraShift = "18";
+    enter(row);
+    expect(label.style.getPropertyValue("--hover-marquee-shift")).toBe("-158px");
+    expect(label.style.getPropertyValue("--hover-marquee-duration")).toBe("1975ms");
+    vi.advanceTimersByTime(249);
+    expect(label.classList.contains("hover-marquee--scrolling")).toBe(false);
+    vi.advanceTimersByTime(1);
+    expect(label.classList.contains("hover-marquee--scrolling")).toBe(true);
+  });
+
   it("leaves labels that fit untouched", () => {
     const { row, label } = buildRow({ textWidth: 120, labelWidth: 180 });
     enter(row);

--- a/ui/src/lib/hover-marquee.ts
+++ b/ui/src/lib/hover-marquee.ts
@@ -62,12 +62,14 @@ function startHoverMarquee(host: HTMLElement): void {
   // row actions, so a cached width would drift. A negative mid-transition
   // indent (re-hover while snapping back) shrinks scrollWidth; add it back.
   const indent = Number.parseFloat(getComputedStyle(label).textIndent) || 0;
-  const shift = label.scrollWidth - indent - label.clientWidth;
-  if (shift <= 1) {
+  const overflow = label.scrollWidth - indent - label.clientWidth;
+  if (overflow <= 1) {
     label.style.removeProperty("--hover-marquee-shift");
     label.style.removeProperty("--hover-marquee-duration");
     return;
   }
+  const extraShift = Number(label.dataset.hoverMarqueeExtraShift ?? 0);
+  const shift = overflow + (Number.isFinite(extraShift) ? Math.max(0, extraShift) : 0);
   const durationMs = Math.max(
     MARQUEE_MIN_DURATION_MS,
     Math.round((shift / MARQUEE_SPEED_PX_PER_SEC) * 1000),
@@ -75,12 +77,16 @@ function startHoverMarquee(host: HTMLElement): void {
   label.style.setProperty("--hover-marquee-shift", `${-shift}px`);
   label.style.setProperty("--hover-marquee-duration", `${durationMs}ms`);
   // Keep quick pointer passes quiet; leaving before the timer fires cancels it.
+  const hoverDelay = Number(label.dataset.hoverMarqueeDelay);
   pendingMarquees.set(
     label,
-    window.setTimeout(() => {
-      pendingMarquees.delete(label);
-      label.classList.add("hover-marquee--scrolling");
-    }, MARQUEE_HOVER_DELAY_MS),
+    window.setTimeout(
+      () => {
+        pendingMarquees.delete(label);
+        label.classList.add("hover-marquee--scrolling");
+      },
+      Number.isFinite(hoverDelay) ? Math.max(0, hoverDelay) : MARQUEE_HOVER_DELAY_MS,
+    ),
   );
 }
 

--- a/ui/src/lib/hover-marquee.ts
+++ b/ui/src/lib/hover-marquee.ts
@@ -9,6 +9,10 @@ const MARQUEE_HOVER_DELAY_MS = 500;
 const pendingMarquees = new WeakMap<HTMLElement, number>();
 let marqueeResizeObserver: ResizeObserver | undefined;
 
+function isMarqueeHostActive(host: HTMLElement): boolean {
+  return host.matches(":hover") || host.matches(":focus-within");
+}
+
 function findMarqueeLabel(host: HTMLElement): HTMLElement | null {
   return host.classList.contains("hover-marquee")
     ? host
@@ -35,7 +39,7 @@ function observeMarquee(label: HTMLElement): void {
         }
         const resizedLabel = entry.target;
         const host = resizedLabel.closest<HTMLElement>(".session-row-host");
-        if (!host?.matches(":hover")) {
+        if (!host || !isMarqueeHostActive(host)) {
           marqueeResizeObserver?.unobserve(resizedLabel);
           continue;
         }
@@ -112,14 +116,25 @@ export function stopHoverMarqueeFromEvent(event: Event): void {
   }
 }
 
-export function restartHoverMarqueeIfHovered(element: Element | undefined): void {
+function restartHoverMarqueeWhen(
+  element: Element | undefined,
+  isActive: (host: HTMLElement) => boolean,
+): void {
   if (!(element instanceof HTMLElement)) {
     return;
   }
   queueMicrotask(() => {
     const host = element.isConnected ? element.closest<HTMLElement>(".session-row-host") : null;
-    if (host?.matches(":hover")) {
+    if (host && isActive(host)) {
       startHoverMarquee(host);
     }
   });
+}
+
+export function restartHoverMarqueeIfHovered(element: Element | undefined): void {
+  restartHoverMarqueeWhen(element, (host) => host.matches(":hover"));
+}
+
+export function restartHoverMarqueeIfActive(element: Element | undefined): void {
+  restartHoverMarqueeWhen(element, isMarqueeHostActive);
 }

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1001,6 +1001,7 @@ openclaw-session-progress-hovercard-provider {
 }
 
 .person-activity-card__header .viewer-avatar--footer {
+  flex-shrink: 0;
   width: 34.5px;
   height: 34.5px;
   font-size: calc(12px * var(--control-ui-text-scale));

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1144,6 +1144,21 @@ openclaw-session-progress-hovercard-provider {
   mask-image: linear-gradient(to right, black calc(100% - 18px), transparent 100%);
 }
 
+@media (hover: none), (pointer: coarse), (prefers-reduced-motion: reduce) {
+  .person-activity-card__session-name.hover-marquee {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    overflow-wrap: anywhere;
+    white-space: normal;
+    text-indent: 0;
+    transition: none;
+    -webkit-mask-image: none;
+    mask-image: none;
+  }
+}
+
 .person-activity-card__session-age {
   justify-self: end;
   font-size: calc(11px * var(--control-ui-text-scale));

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1120,15 +1120,23 @@ openclaw-session-progress-hovercard-provider {
   overflow-wrap: normal;
 }
 
-.person-activity-card__session-copy > span {
+.person-activity-card__session-name {
   display: block;
   min-width: 0;
   overflow: hidden;
   font-weight: 500;
-  white-space: nowrap;
 }
 
-.person-activity-card__session-copy > .hover-marquee {
+.person-activity-card__session-name--multiline {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  overflow-wrap: anywhere;
+}
+
+.person-activity-card__session-name.hover-marquee {
+  white-space: nowrap;
   color: var(--text);
   text-overflow: clip;
   -webkit-mask-image: linear-gradient(to right, black calc(100% - 18px), transparent 100%);

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -978,6 +978,10 @@ openclaw-session-progress-hovercard-provider {
   pointer-events: auto;
 }
 
+.person-activity-hovercard {
+  width: min(304px, calc(100vw - 24px));
+}
+
 .person-activity-card {
   font-size: calc(12px * var(--control-ui-text-scale));
   line-height: 1.5;
@@ -987,16 +991,18 @@ openclaw-session-progress-hovercard-provider {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 16px 16px 12px;
+  padding: 15px 16px 12px;
 }
 
 .person-activity-card__header > div {
+  display: grid;
+  gap: 4px;
   min-width: 0;
 }
 
 .person-activity-card__header .viewer-avatar--footer {
-  width: 32px;
-  height: 32px;
+  width: 34.5px;
+  height: 34.5px;
   font-size: calc(12px * var(--control-ui-text-scale));
   /* The base ring color assumes the sidebar surface; blend with the popover. */
   border-color: var(--session-hovercard-surface);
@@ -1012,13 +1018,16 @@ openclaw-session-progress-hovercard-provider {
   overflow-wrap: anywhere;
   font-size: calc(14px * var(--control-ui-text-scale));
   font-weight: 600;
+  line-height: 1;
 }
 
 .person-activity-card__status {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
+  gap: 3px;
   color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
 }
 
 .person-activity-card__status > span {
@@ -1042,8 +1051,15 @@ openclaw-session-progress-hovercard-provider {
 }
 
 .person-activity-card__facts dt,
+.person-activity-card h3 {
+  color: var(--muted);
+  font-size: inherit;
+  font-weight: 400;
+}
+
 .person-activity-card__muted,
-.person-activity-card small {
+.person-activity-card small,
+.person-activity-card__session-age {
   color: var(--muted);
 }
 
@@ -1052,6 +1068,15 @@ openclaw-session-progress-hovercard-provider {
   gap: 3px;
   margin: 0;
   overflow-wrap: anywhere;
+}
+
+.person-activity-card__facts dd > span {
+  font-weight: 500;
+}
+
+.person-activity-card__facts time,
+.person-activity-card__session-age {
+  font-variant-numeric: tabular-nums;
 }
 
 .person-activity-card small {
@@ -1067,9 +1092,6 @@ openclaw-session-progress-hovercard-provider {
 
 .person-activity-card h3 {
   margin-bottom: 6px;
-  color: var(--muted);
-  font-size: inherit;
-  font-weight: 500;
 }
 
 .person-activity-card__sessions {
@@ -1079,7 +1101,7 @@ openclaw-session-progress-hovercard-provider {
 
 .person-activity-card__session {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 8px;
   padding: 6px;
   margin: 0 -6px;
@@ -1089,15 +1111,35 @@ openclaw-session-progress-hovercard-provider {
 }
 
 .person-activity-card__session-copy {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
   min-width: 0;
-  overflow-wrap: anywhere;
+  overflow-wrap: normal;
 }
 
 .person-activity-card__session-copy > span {
-  display: -webkit-box;
+  display: block;
+  min-width: 0;
   overflow: hidden;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.person-activity-card__session-copy > .hover-marquee {
+  color: var(--text);
+  text-overflow: clip;
+  -webkit-mask-image: linear-gradient(to right, black calc(100% - 18px), transparent 100%);
+  mask-image: linear-gradient(to right, black calc(100% - 18px), transparent 100%);
+}
+
+.person-activity-card__session-age {
+  justify-self: end;
+  font-size: calc(11px * var(--control-ui-text-scale));
+  font-weight: 400;
+  white-space: nowrap;
 }
 
 .person-activity-card__session-icon {
@@ -1112,11 +1154,19 @@ openclaw-session-progress-hovercard-provider {
   height: 14px;
 }
 
+.person-activity-card footer {
+  padding: 0;
+}
+
 .person-activity-card footer a {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  width: 100%;
+  min-height: 36px;
+  padding: 8px 16px;
   color: var(--text);
+  font-weight: 500;
   text-decoration: none;
 }
 

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1152,6 +1152,7 @@ openclaw-session-progress-hovercard-provider {
 
 .person-activity-card__session-icon {
   flex: none;
+  align-self: flex-start;
   margin-top: 2px;
   color: var(--muted);
 }

--- a/ui/src/test-helpers/app-sidebar-cases/presence.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/presence.ts
@@ -167,21 +167,22 @@ describe("AppSidebar viewer presence", () => {
       expect(document.querySelector(".person-activity-hovercard")).not.toBeNull(),
     );
     const card = document.querySelector<HTMLElement>(".person-activity-hovercard")!;
-    expect(card.querySelectorAll("dt")).toHaveLength(3);
+    expect(card.querySelectorAll("dt")).toHaveLength(2);
+    expect(card.querySelector(".person-activity-card__status")?.textContent?.trim()).toBe("Online");
     const facts = card.querySelectorAll("dd");
-    expect(facts[0]?.textContent?.trim()).toBe("Not observed yet");
-    expect([...facts[1]!.querySelectorAll("span")].map((node) => node.textContent)).toEqual([
+    expect([...facts[0]!.querySelectorAll("span")].map((node) => node.textContent)).toEqual([
       "Mac · macOS · Control UI",
       "iPhone · iOS · Control UI",
     ]);
-    expect(facts[1]?.querySelector("small")?.textContent).toBe("Reported time zone: Europe/Paris");
-    expect(facts[2]?.textContent?.trim()).toBe("Not observed yet");
+    expect(facts[0]?.querySelector("small")?.textContent).toBe("Reported time zone: Europe/Paris");
+    expect(facts[1]?.textContent?.trim()).toBe("Not observed yet");
     const sections = card.querySelectorAll("section");
     expect(sections[0]?.querySelectorAll("a")).toHaveLength(1);
     expect(sections[0]?.textContent).toContain("Visible 0");
     expect(sections[0]?.querySelector("a")?.getAttribute("href")).toBe("/chat/research/watched");
     expect(sections[1]?.querySelectorAll("a")).toHaveLength(3);
-    expect(sections[1]?.textContent).toContain("Session updated");
+    expect(sections[1]?.textContent).not.toContain("Session updated");
+    expect(sections[1]?.querySelectorAll(".person-activity-card__session-age")).toHaveLength(3);
     for (const hidden of [
       "secret-title",
       "private-tab",
@@ -231,6 +232,11 @@ describe("AppSidebar viewer presence", () => {
       expect(document.querySelector(".person-activity-hovercard")).not.toBeNull(),
     );
     const card = document.querySelector<HTMLElement>(".person-activity-hovercard")!;
+    await vi.waitFor(() =>
+      expect(card.querySelector(".person-activity-card__status")?.textContent?.trim()).toBe(
+        "Online for 1m",
+      ),
+    );
     const sessionLink = card.querySelector<HTMLAnchorElement>(".person-activity-card__session")!;
     sessionLink.focus();
     gateway.publishEvent("presence", {
@@ -248,6 +254,9 @@ describe("AppSidebar viewer presence", () => {
     );
     gateway.publishEvent("presence", { presence: [{ ...alice, watchedSessions: [] }, bob] });
     await sidebar.updateComplete;
+    expect([...card.querySelectorAll("h3")].map((heading) => heading.textContent)).toEqual([
+      "Recent sessions",
+    ]);
     expect(document.activeElement?.getAttribute("href")).toBe(sessionLink.getAttribute("href"));
     expect(document.activeElement?.closest("section")?.querySelector("h3")?.textContent).toBe(
       "Recent sessions",


### PR DESCRIPTION
Closes #132069

## What Problem This Solves

The person activity hovercard makes presence and session activity harder to scan than necessary: online duration is separated from status, metadata competes for attention, an empty “Viewing now” section can remain visible, and long session titles are clipped without a reliable reveal path on every input mode.

## Why This Change Was Made

This PR applies the approved calmer hierarchy while keeping the existing card structure and width. It places live duration in the status line, unifies metadata labels, separates the time zone, right-aligns compact session ages, removes an empty “Viewing now” section, and turns the activity footer into one full-row target.

Recent titles remain compact on pointer devices and reveal their clipped text on hover or keyboard focus. Touch, coarse-pointer, and reduced-motion surfaces retain a two-line wrapped title instead of depending on animation. Active titles are remeasured when session data changes, and the avatar keeps its intended size beside very long names.

## User Impact

Operators can understand a person's current presence and recent activity at a glance, open activity from the full footer row, and read long session titles with pointer, keyboard, touch, or reduced-motion preferences.

## Evidence

The visual comparisons were captured from the running Control UI. “Before” is `origin/main`; the pictured “After” state is `01fbfa829bbc01f6150bf4a84c5fafe8e09d5011`. The final head preserves that approved hierarchy, adds the avatar shrink guard, and covers long-title hover, keyboard, touch, reduced-motion, and live-update behavior in exact-head browser CI.

### Complete card

| Theme | Before | After |
| --- | --- | --- |
| Light | ![Light theme hovercard before](https://github.com/user-attachments/assets/49906fb8-a5fa-4301-8429-29fb8528120a) | ![Light theme hovercard after](https://github.com/user-attachments/assets/4208012b-2e35-49e4-8ba3-77da3e69427e) |
| Dark | ![Dark theme hovercard before](https://github.com/user-attachments/assets/2a4ec52d-ad9b-4487-9856-be40ac7d9fb6) | ![Dark theme hovercard after](https://github.com/user-attachments/assets/ba29503a-6870-49bb-8919-df7066ba4095) |

The after state puts the live duration beside the green status dot (`Online for 50m`), keeps reported location metadata quiet, and moves compact session ages to a right-aligned column.

### Full-row “View activity” hover

| Theme | Before | After |
| --- | --- | --- |
| Light | ![Light theme footer hover before](https://github.com/user-attachments/assets/127d72df-6f05-4adb-8edf-4942fd3908c3) | ![Light theme full footer row hover after](https://github.com/user-attachments/assets/1c0fc54a-d7a0-4c75-aed7-caab4e168e0a) |
| Dark | ![Dark theme footer hover before](https://github.com/user-attachments/assets/e518e4e3-574a-48bd-a2c5-af638e3536c5) | ![Dark theme full footer row hover after](https://github.com/user-attachments/assets/d6533b91-b2a7-4724-ab30-661ca82a53d2) |

The after state gives the complete footer row one continuous hover target instead of highlighting only the link's inline content.

### Long “Viewing now” title

| Theme | Before | After |
| --- | --- | --- |
| Light | ![Light theme long title before](https://github.com/user-attachments/assets/993ad95e-21f8-4066-8f84-79f1405fbda5) | ![Light theme two-line Viewing now title with top-aligned icon and relative time after](https://github.com/user-attachments/assets/8ef201a7-f805-42aa-8029-9b9cafe2c5c2) |
| Dark | ![Dark theme long title before](https://github.com/user-attachments/assets/8bab7871-8ef9-4efa-ad02-ff8bb6e8a702) | ![Dark theme two-line Viewing now title with top-aligned icon and relative time after](https://github.com/user-attachments/assets/def01bdd-3489-49f6-bb48-531179defb85) |

The after state gives the current session title up to two lines while keeping its relative time aligned at the right, matching the recent-session rows.

### Empty “Viewing now” state

| Theme | Before | After |
| --- | --- | --- |
| Light | ![Light theme empty Viewing now section before](https://github.com/user-attachments/assets/25934cf0-c684-4419-ac64-c20509d8c72c) | ![Light theme with empty Viewing now section removed after](https://github.com/user-attachments/assets/13e2c7ca-1a9c-44d7-a332-8f16f374aea8) |
| Dark | ![Dark theme empty Viewing now section before](https://github.com/user-attachments/assets/109fafae-4a41-426c-b8fa-e45d0dcfd8fc) | ![Dark theme with empty Viewing now section removed after](https://github.com/user-attachments/assets/5caae566-5ef8-4116-8a03-5e4845fbd647) |

The complete-card matrix shows “Viewing now” when sessions are present; this matrix confirms the section disappears entirely when the person is not viewing a visible session.
