### PR TITLE
feat(visitor-access): internal Cloudflare Access visitor plugin

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -120,6 +120,10 @@
       - any-glob-to-any-file:
           - "extensions/bonjour/**"
           - "docs/gateway/bonjour.md"
+"plugin: visitor-access":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/visitor-access/**"
 "channel: imessage":
   - changed-files:
       - any-glob-to-any-file:

--- a/extensions/visitor-access/README.md
+++ b/extensions/visitor-access/README.md
@@ -1,0 +1,147 @@
+# Visitor Access
+
+Visitor Access is an internal OpenClaw plugin for granting individual people
+access to <https://team.openclaw.ai>. It manages one dedicated Cloudflare Access
+allow policy containing email addresses. Grants expire after 14 days by default;
+maintainers can refresh or revoke them with agent tools.
+
+The existing GitHub organization policy remains unchanged. Access allow policies
+combine with OR semantics, so adding a visitor does not change maintainer access.
+This package is private, built from source for the team deployment, and excluded
+from the OpenClaw npm release.
+
+## Configure the plugin
+
+Use a Cloudflare API token that can read and write Access policies in the target
+account. Enable the plugin in the source-built Gateway configuration:
+
+```json5
+{
+  plugins: {
+    entries: {
+      "visitor-access": {
+        enabled: true,
+        config: {
+          accountId: "<CLOUDFLARE_ACCOUNT_ID>",
+          appId: "<ACCESS_APPLICATION_ID>",
+          apiToken: "<RESOLVED_CLOUDFLARE_API_TOKEN>",
+          policyName: "Visitors (openclaw-managed)",
+          defaultTtlDays: 14,
+          maxVisitors: 50,
+        },
+      },
+    },
+  },
+}
+```
+
+Restart the Gateway after enabling the plugin or changing its configuration.
+Do not retarget `accountId`, `appId`, or `policyName` while grants exist: the
+durable records belong to that policy, and changing targets could leave the old
+policy granting access without expiry sweeps. Revoke grants before retargeting.
+Call `visitor_list` from a trusted, unsandboxed session to check policy access.
+The first invite creates the named policy if it does not exist.
+Tools require the running Gateway service; discovery alone never opens a separate
+grant manager. Tool calls and expiry sweeps share that service's mutation queue.
+
+| Field            | Required | Default                       | Constraints                             |
+| ---------------- | -------- | ----------------------------- | --------------------------------------- |
+| `accountId`      | Yes      | —                             | 1–128 letters, digits, `_`, or `-`.     |
+| `appId`          | Yes      | —                             | 1–128 letters, digits, `_`, or `-`.     |
+| `apiToken`       | Yes      | —                             | Nonempty resolved token string.         |
+| `policyName`     | No       | `Visitors (openclaw-managed)` | 1–200 characters; exact policy name.    |
+| `defaultTtlDays` | No       | `14`                          | Integer from 0 through 3650, or `null`. |
+| `maxVisitors`    | No       | `50`                          | Integer from 1 through 500.             |
+
+Use a secret reference value through your host or deployment's supported secret
+resolution path, then pass the resolved string as `apiToken`. This plugin does
+not resolve SecretRef objects itself. Do not paste a real token into chat or
+commit it to source control. See [Secrets](https://docs.openclaw.ai/gateway/secrets)
+for the host's supported credential surfaces.
+
+Setting `defaultTtlDays` to `0` or `null` does not silently create permanent
+grants: each invite must then supply positive `days` or explicitly set
+`forever: true`.
+
+## Invite, inspect, and revoke visitors
+
+| Tool             | Input                                                 | Result                                                                                  |
+| ---------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `visitor_invite` | `github` and/or `email`; optional `days` or `forever` | Adds a grant or refreshes an existing email's expiry.                                   |
+| `visitor_list`   | `{}`                                                  | Shows grant emails, GitHub logins, invite dates, expiry dates, and policy/record drift. |
+| `visitor_revoke` | `github` and/or `email`                               | Removes the matching visitor; an unknown email is a clean no-op.                        |
+
+For example, invite a visitor for seven days:
+
+```json
+{ "github": "octocat", "email": "visitor@example.com", "days": 7 }
+```
+
+Invite results identify the visitor, email, expiry, and login URL. A repeat invite
+for the same email refreshes its expiry rather than creating a second grant.
+Permanent access requires `forever: true`. Invites beyond `maxVisitors` are
+refused; revoke an existing visitor or deliberately raise the configured cap.
+
+Visitors log in at <https://team.openclaw.ai> with their own GitHub account. The
+GitHub identity provider authenticates accounts; the organization restriction
+lives in the maintainer Access policy. The visitor policy matches the verified
+email supplied by GitHub, so the invited email must belong to that account.
+
+When only `github` is supplied, the plugin looks up that account's public GitHub
+email. Many accounts have no public email. In that case, ask the visitor for the
+email on their GitHub account and pass it explicitly; the plugin cannot discover
+private account emails.
+
+## Expiry and drift
+
+Grants are recorded by lowercased email in the Gateway's durable keyed store.
+Cloudflare Access is the enforcement surface; the store records who was invited
+and when the grant expires. The store has a fixed cap of 500 records and does not
+automatically expire them: a record must remain until policy cleanup succeeds.
+
+An invite records the grant before calling Cloudflare. If that call fails, the
+record remains so a later list can expose the drift and a sweep can clean up any
+expired grant. Revoke removes policy access before deleting the record. Re-invite
+to retry an unsuccessful invite, or revoke to clean up its record.
+
+The plugin sweeps expired grants on Gateway startup and hourly while the Gateway
+runs. It removes each expired email from the named Access policy and the local
+record, then logs the removal. Expiry is best effort: the Gateway and Cloudflare
+API must be available, and a grant can remain allowed until a successful sweep.
+Use an explicit revoke to remove the email from the allow policy without waiting
+for the hourly sweep. This plugin does not separately revoke Access sessions.
+
+Both list and sweep compare policy emails with recorded grants. Emails added
+manually in the Cloudflare dashboard are reported as **unmanaged** and are never
+automatically deleted. Remove them with an explicit `visitor_revoke`. Recorded
+grants missing from the policy are reported as drift; invite again to restore
+access or revoke to remove the stale record.
+
+Each Cloudflare mutation reads the policy again before writing its full email
+include list. No include list is cached across calls. Keep one Gateway responsible
+for this policy and avoid concurrent dashboard edits: a full-list update cannot
+merge an external edit made between that read and write.
+
+## Trust model and boundaries
+
+**Anyone who can drive an unsandboxed session can manage visitors.** Tool
+availability relies on sandbox tool policy: these plugin tools are not in the
+sandbox's default allowlist, so guest sessions using that policy cannot call
+them. Custom overrides, including an empty `tools.sandbox.tools.allow` list or
+`alsoAllow` entries for these tools or `group:plugins`, can change this boundary.
+Do not allow these tools in guest or sandbox policies. The team's existing
+default `guest` role forces sandboxing for unknown authenticated users; this
+plugin does not change Gateway roles or authorization.
+
+The plugin only manages the policy whose name exactly matches `policyName`. It
+does not modify or reorder any other policy, including the maintainer organization
+policy. A matching policy whose decision is not `allow` causes a clear refusal.
+Cloudflare requests use app-scoped policy endpoints only: no identity-provider
+calls and no application mutations. Tokens are never logged or echoed, and fetch
+failures use generic diagnostics.
+Non-email include rules, nonempty require/exclude rules, or duplicate matching
+policy names also require operator inspection before the plugin will write.
+
+Identity-provider management, self-service signup queues, invitation email
+delivery, and deep SecretRef support are deliberately outside this plugin's
+scope. A maintainer approves each invitation through a trusted session.

--- a/extensions/visitor-access/api.ts
+++ b/extensions/visitor-access/api.ts
@@ -1,0 +1,10 @@
+export {
+  buildPluginConfigSchema,
+  definePluginEntry,
+  type AnyAgentTool,
+  type OpenClawPluginApi,
+  type OpenClawPluginToolContext,
+  type PluginLogger,
+} from "openclaw/plugin-sdk/plugin-entry";
+export type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+export { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";

--- a/extensions/visitor-access/index.test.ts
+++ b/extensions/visitor-access/index.test.ts
@@ -1,0 +1,295 @@
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import type {
+  AnyAgentTool,
+  OpenClawPluginApi,
+  OpenClawPluginService,
+  OpenClawPluginServiceContext,
+} from "openclaw/plugin-sdk/plugin-entry";
+import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
+import {
+  createPluginStateKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import plugin from "./index.js";
+import type { VisitorGrant } from "./src/visitors.js";
+
+const TOKEN = "visitor-test-token-never-echo";
+const DAY_MS = 86_400_000;
+const HOUR_MS = 3_600_000;
+const START_MS = Date.parse("2026-08-01T00:00:00.000Z");
+const policiesUrl =
+  "https://api.cloudflare.com/client/v4/accounts/test-account/access/apps/test-app/policies";
+
+function requestUrl(input: Parameters<typeof fetch>[0]): URL {
+  return new URL(input instanceof Request ? input.url : input);
+}
+
+function createPolicyFetch() {
+  let emails: string[] = [];
+  const fetcher = vi.fn<typeof fetch>(async (input, init) => {
+    const url = requestUrl(input);
+    if (!url.href.startsWith(policiesUrl)) {
+      throw new Error(`Unexpected test request: ${url}`);
+    }
+    const policy = {
+      id: "visitor-policy",
+      name: "Visitors (openclaw-managed)",
+      decision: "allow",
+      include: emails.map((email) => ({ email: { email } })),
+    };
+    if (init?.method === "GET") {
+      const result = url.search ? (emails.length ? [policy] : []) : policy;
+      return Response.json({ success: true, result });
+    }
+    if (init?.method === "DELETE") {
+      emails = [];
+    } else {
+      if (typeof init?.body !== "string") {
+        throw new Error("Expected a JSON policy body");
+      }
+      const body = JSON.parse(init.body) as {
+        include: Array<{ email: { email: string } }>;
+      };
+      emails = body.include.map((rule) => rule.email.email);
+    }
+    return Response.json({ success: true, result: {} });
+  });
+  return { fetcher, emails: () => emails };
+}
+
+describe("visitor-access plugin lifecycle", () => {
+  let stateDir: string;
+  let env: NodeJS.ProcessEnv;
+  const cleanups: Array<() => void | Promise<void>> = [];
+
+  beforeEach(() => {
+    resetPluginStateStoreForTests();
+    stateDir = realpathSync(mkdtempSync(path.join(tmpdir(), "visitor-access-test-")));
+    env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    vi.useFakeTimers({ toFake: ["Date", "setInterval", "clearInterval"] });
+    vi.setSystemTime(START_MS);
+  });
+
+  afterEach(async () => {
+    for (const cleanup of cleanups.splice(0)) {
+      await cleanup();
+    }
+    resetPluginStateStoreForTests();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  function registerPlugin() {
+    const tools = new Map<string, AnyAgentTool>();
+    const services: OpenClawPluginService[] = [];
+    const on = vi.fn<OpenClawPluginApi["on"]>();
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    const api = createTestPluginApi({
+      id: "visitor-access",
+      pluginConfig: { accountId: "test-account", appId: "test-app", apiToken: TOKEN },
+      logger,
+      on,
+      registerService: (service) => services.push(service),
+      registerTool: (registration) => {
+        const resolved =
+          typeof registration === "function"
+            ? registration({ sessionKey: "agent:main:maintainer" })
+            : registration;
+        for (const tool of Array.isArray(resolved) ? resolved : resolved ? [resolved] : []) {
+          tools.set(tool.name, tool);
+        }
+      },
+    });
+    api.runtime.state = {
+      ...api.runtime.state,
+      openKeyedStore: <T>(options: OpenKeyedStoreOptions) =>
+        createPluginStateKeyedStoreForTests<T>("visitor-access", { ...options, env }),
+    };
+    plugin.register(api);
+    const service = services[0];
+    if (!service) {
+      throw new Error("Plugin did not register its expiry service");
+    }
+    const context: OpenClawPluginServiceContext = { config: {}, stateDir, logger };
+    cleanups.push(() => service.stop?.(context));
+    const store = createPluginStateKeyedStoreForTests<VisitorGrant>("visitor-access", {
+      namespace: "visitor-grants",
+      maxEntries: 500,
+      overflowPolicy: "reject-new",
+      env,
+    });
+    return {
+      logger,
+      store,
+      start: () => service.start(context),
+      stop: () => service.stop?.(context),
+      gatewayStart: () => {
+        const hook = on.mock.calls.find(([name]) => name === "gateway_start")?.[1];
+        if (!hook) {
+          throw new Error("Plugin did not register its Gateway startup sweep");
+        }
+        const startHook = hook as (
+          event: { port: number },
+          context: { port?: number },
+        ) => void | Promise<void>;
+        return startHook({ port: 18789 }, {});
+      },
+      execute: (name: string, input: Record<string, unknown> = {}) => {
+        const tool = tools.get(name);
+        if (!tool) {
+          throw new Error(`Plugin did not register ${name}`);
+        }
+        return tool.execute("visitor-test-call", input);
+      },
+    };
+  }
+
+  it("keeps CLI metadata discovery free of runtime access and background work", () => {
+    const api = createTestPluginApi({ registrationMode: "cli-metadata" });
+    const runtime = vi.fn(() => {
+      throw new Error("Metadata discovery accessed runtime");
+    });
+    Object.defineProperty(api, "runtime", { get: runtime });
+    expect(() => plugin.register(api)).not.toThrow();
+    expect(runtime).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("revokes persisted expiries after restart, coalesces startup, and continues hourly", async () => {
+    const policy = createPolicyFetch();
+    vi.stubGlobal("fetch", policy.fetcher);
+    const first = registerPlugin();
+    await first.start();
+    await expect(
+      first.execute("visitor_invite", { email: "expired@example.test", days: 1 }),
+    ).resolves.toHaveProperty("details", {});
+    await expect(
+      first.execute("visitor_invite", { email: "active@example.test", days: 2 }),
+    ).resolves.toHaveProperty("details", {});
+    await first.stop();
+    resetPluginStateStoreForTests();
+    vi.setSystemTime(START_MS + DAY_MS + 1);
+    policy.fetcher.mockClear();
+
+    const restarted = registerPlugin();
+    await Promise.all([restarted.start(), restarted.gatewayStart()]);
+    expect(policy.emails()).toEqual(["active@example.test"]);
+    expect((await restarted.store.entries()).map((entry) => entry.key)).toEqual([
+      "active@example.test",
+    ]);
+    expect(policy.fetcher.mock.calls.filter(([url]) => requestUrl(url).search !== "")).toHaveLength(
+      1,
+    );
+    expect(restarted.logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("expired@example.test"),
+    );
+
+    vi.setSystemTime(START_MS + 2 * DAY_MS);
+    await vi.advanceTimersByTimeAsync(HOUR_MS);
+    expect(policy.emails()).toEqual([]);
+    expect(await restarted.store.entries()).toEqual([]);
+    await restarted.stop();
+    const callsAfterStop = policy.fetcher.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(2 * HOUR_MS);
+    expect(policy.fetcher).toHaveBeenCalledTimes(callsAfterStop);
+  });
+
+  it("stops the scheduler, aborts an in-flight sweep, and rejects retained tools", async () => {
+    const entered = createDeferred<AbortSignal>();
+    const fetcher = vi.fn<typeof fetch>((_url, init) => {
+      const signal = init?.signal;
+      if (!signal) {
+        throw new Error("Expiry requests must be cancellable");
+      }
+      return new Promise<Response>((_resolve, reject) => {
+        signal.addEventListener("abort", () => reject(new Error(`aborted ${TOKEN}`)), {
+          once: true,
+        });
+        entered.resolve(signal);
+      });
+    });
+    vi.stubGlobal("fetch", fetcher);
+    const registered = registerPlugin();
+    const starting = registered.start();
+    const signal = await entered.promise;
+    await registered.stop();
+    await starting;
+    expect(signal.aborted).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+    const callsAfterStop = fetcher.mock.calls.length;
+    const result = await registered.execute("visitor_invite", { email: "late@example.test" });
+    expect(result).toMatchObject({ details: { error: true } });
+    expect(fetcher).toHaveBeenCalledTimes(callsAfterStop);
+    expect(await registered.store.entries()).toEqual([]);
+    expect(JSON.stringify(result)).not.toContain(TOKEN);
+    expect(registered.logger.error).not.toHaveBeenCalled();
+  });
+
+  it("returns a redacted tool error while retaining the durable record after an ambiguous write", async () => {
+    const policy = createPolicyFetch();
+    vi.stubGlobal("fetch", policy.fetcher);
+    const registered = registerPlugin();
+    await registered.start();
+    policy.fetcher.mockImplementationOnce(async () => Response.json({ success: true, result: [] }));
+    policy.fetcher.mockImplementationOnce(async () => {
+      throw new Error(`Transport failure with Authorization: Bearer ${TOKEN}`);
+    });
+    const result = await registered.execute("visitor_invite", { email: "pending@example.test" });
+    expect(result).toMatchObject({ details: { error: true }, content: [{ type: "text" }] });
+    expect(JSON.stringify(result)).not.toContain(TOKEN);
+    expect(await registered.store.lookup("pending@example.test")).toMatchObject({
+      email: "pending@example.test",
+      invitedVia: "agent:main:maintainer",
+      expiresAt: START_MS + 14 * DAY_MS,
+    });
+  });
+
+  it("routes discovery tools through the Gateway owner and fences them after replacement", async () => {
+    const policy = createPolicyFetch();
+    vi.stubGlobal("fetch", policy.fetcher);
+    const owner = registerPlugin();
+    await owner.start();
+    let invite: AnyAgentTool | undefined;
+    const discovery = createTestPluginApi({
+      registrationMode: "tool-discovery",
+      registerTool(registration) {
+        const tools = typeof registration === "function" ? registration({}) : registration;
+        invite =
+          (Array.isArray(tools) ? tools : tools ? [tools] : []).find(
+            (tool) => tool.name === "visitor_invite",
+          ) ?? invite;
+      },
+    });
+    Object.defineProperty(discovery, "runtime", {
+      get() {
+        throw new Error("Discovery must use the active Gateway owner");
+      },
+    });
+    plugin.register(discovery);
+    if (!invite) {
+      throw new Error("Discovery did not register visitor_invite");
+    }
+    await expect(
+      invite.execute("invite", { email: "discovered@example.test" }),
+    ).resolves.toHaveProperty("details", {});
+    expect(await owner.store.lookup("discovered@example.test")).toBeDefined();
+    await owner.stop();
+    const replacement = registerPlugin();
+    await replacement.start();
+    const callsBeforeStaleTool = policy.fetcher.mock.calls.length;
+    await expect(invite.execute("stale", { email: "late@example.test" })).resolves.toHaveProperty(
+      "details.error",
+      true,
+    );
+    expect(policy.fetcher).toHaveBeenCalledTimes(callsBeforeStaleTool);
+    await expect(
+      replacement.execute("visitor_invite", { email: "current@example.test" }),
+    ).resolves.toHaveProperty("details", {});
+  });
+});

--- a/extensions/visitor-access/index.ts
+++ b/extensions/visitor-access/index.ts
@@ -1,0 +1,94 @@
+import { definePluginEntry, type OpenClawPluginApi } from "./api.js";
+import { VisitorPolicyClient } from "./src/cloudflare.js";
+import { visitorConfigSchema, visitorPluginSchema } from "./src/config.js";
+import { visitorErrorText } from "./src/errors.js";
+import { visitorRuntimeStore, type VisitorRuntime } from "./src/runtime.js";
+import { createVisitorTools } from "./src/tools.js";
+import { VisitorAccessService, type VisitorGrant } from "./src/visitors.js";
+
+function registerVisitorPlugin(api: OpenClawPluginApi): void {
+  if (api.registrationMode === "cli-metadata") {
+    return;
+  }
+  for (const name of ["visitor_invite", "visitor_revoke", "visitor_list"]) {
+    api.registerTool((ctx) => createVisitorTools(ctx).find((tool) => tool.name === name), { name });
+  }
+  if (api.registrationMode !== "full") {
+    return;
+  }
+  const config = visitorConfigSchema.parse(api.pluginConfig);
+  const lifetime = new AbortController();
+  const store = api.runtime.state.openKeyedStore<VisitorGrant>({
+    namespace: "visitor-grants",
+    // Fixed storage bound survives config reload; maxVisitors controls admission.
+    maxEntries: 500,
+    overflowPolicy: "reject-new",
+  });
+  const service = new VisitorAccessService(
+    config,
+    store,
+    new VisitorPolicyClient(config, fetch, lifetime.signal),
+    api.logger,
+    fetch,
+    lifetime.signal,
+  );
+  const runtime: VisitorRuntime = {
+    service,
+    errorText: (error) => visitorErrorText(error, config.apiToken),
+  };
+
+  let interval: ReturnType<typeof setInterval> | undefined;
+  let sweeping: Promise<void> | undefined;
+  let startupSweep: Promise<void> | undefined;
+  const sweep = () => {
+    sweeping ??= service
+      .sweep()
+      .catch((error: unknown) => {
+        if (!lifetime.signal.aborted) {
+          api.logger.error(
+            `visitor-access sweep failed: ${visitorErrorText(error, config.apiToken)}`,
+          );
+        }
+      })
+      .finally(() => {
+        sweeping = undefined;
+      });
+    return sweeping;
+  };
+  const start = () => {
+    lifetime.signal.throwIfAborted();
+    const active = visitorRuntimeStore.tryGetRuntime();
+    if (active && active !== runtime) {
+      throw new Error("A visitor-access Gateway service is already running.");
+    }
+    visitorRuntimeStore.setRuntime(runtime);
+    interval ??= setInterval(() => {
+      void sweep();
+    }, 3_600_000);
+    interval.unref();
+    return (startupSweep ??= sweep());
+  };
+  api.on("gateway_start", start);
+  // Services, unlike gateway hooks alone, stop on plugin hot replacement too.
+  api.registerService({
+    id: "visitor-access-expiry",
+    start,
+    async stop() {
+      clearInterval(interval);
+      interval = undefined;
+      lifetime.abort();
+      await service.waitForIdle();
+      if (visitorRuntimeStore.tryGetRuntime() === runtime) {
+        visitorRuntimeStore.clearRuntime();
+      }
+    },
+  });
+}
+
+export default definePluginEntry({
+  id: "visitor-access",
+  name: "Visitor Access",
+  description: "Internal Cloudflare Access visitor grants with managed expiry.",
+  configSchema: visitorPluginSchema,
+  register: registerVisitorPlugin,
+});

--- a/extensions/visitor-access/openclaw.plugin.json
+++ b/extensions/visitor-access/openclaw.plugin.json
@@ -1,0 +1,64 @@
+{
+  "id": "visitor-access",
+  "name": "Visitor Access",
+  "description": "Manage expiring visitor grants through one Cloudflare Access email policy.",
+  "activation": {
+    "onStartup": true
+  },
+  "contracts": {
+    "tools": ["visitor_invite", "visitor_revoke", "visitor_list"]
+  },
+  "uiHints": {
+    "apiToken": {
+      "label": "Cloudflare API token",
+      "sensitive": true
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["accountId", "appId", "apiToken"],
+    "properties": {
+      "accountId": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 128,
+        "pattern": "^[a-zA-Z0-9_-]+$",
+        "description": "Cloudflare account containing the Access application."
+      },
+      "appId": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 128,
+        "pattern": "^[a-zA-Z0-9_-]+$",
+        "description": "Access application whose dedicated visitor policy is managed."
+      },
+      "apiToken": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Resolved Cloudflare API token with Access policy read and write permissions."
+      },
+      "policyName": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200,
+        "default": "Visitors (openclaw-managed)",
+        "description": "Exact name of the only policy this plugin may manage."
+      },
+      "defaultTtlDays": {
+        "type": ["integer", "null"],
+        "minimum": 0,
+        "maximum": 3650,
+        "default": 14,
+        "description": "Default grant duration in days. Zero or null requires explicit days or forever on each invite."
+      },
+      "maxVisitors": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 500,
+        "default": 50,
+        "description": "Maximum number of visitor emails allowed by this plugin."
+      }
+    }
+  }
+}

--- a/extensions/visitor-access/package.json
+++ b/extensions/visitor-access/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@openclaw/visitor-access",
+  "version": "2026.8.1",
+  "private": true,
+  "description": "OpenClaw internal Cloudflare Access visitor grants plugin",
+  "type": "module",
+  "dependencies": {
+    "typebox": "1.3.16",
+    "zod": "4.4.3"
+  },
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/visitor-access/src/cloudflare.test.ts
+++ b/extensions/visitor-access/src/cloudflare.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it, vi } from "vitest";
+import { VisitorPolicyClient } from "./cloudflare.js";
+import type { VisitorAccessConfig } from "./config.js";
+import { VisitorAccessError } from "./errors.js";
+
+const config: VisitorAccessConfig = {
+  accountId: "account-id",
+  appId: "app-id",
+  apiToken: "test-token-never-echo",
+  policyName: "Visitors (openclaw-managed)",
+  defaultTtlDays: 14,
+  maxVisitors: 50,
+};
+const collectionUrl =
+  "https://api.cloudflare.com/client/v4/accounts/account-id/access/apps/app-id/policies";
+
+function namedPolicy(emails = ["first@example.com"]) {
+  return {
+    id: "visitor-policy",
+    name: config.policyName,
+    decision: "allow",
+    include: emails.map((email) => ({ email: { email } })),
+  };
+}
+
+function cloudflareResponse(result: unknown, resultInfo?: unknown) {
+  return Response.json({ success: true, result, result_info: resultInfo });
+}
+
+function fetchSequence(...responses: Response[]) {
+  const fetcher = vi.fn<typeof fetch>();
+  for (const response of responses) {
+    fetcher.mockResolvedValueOnce(response);
+  }
+  return fetcher;
+}
+
+function requestBody(fetcher: ReturnType<typeof fetchSequence>, index: number) {
+  const body = fetcher.mock.calls[index]?.[1]?.body;
+  if (typeof body !== "string") {
+    throw new Error("Expected a JSON request body");
+  }
+  return JSON.parse(body) as unknown;
+}
+
+describe("VisitorPolicyClient", () => {
+  it("creates only the named app policy when absent, leaving other policies untouched", async () => {
+    const maintainers = { id: "maintainers", name: "GitHub organization", decision: "allow" };
+    const fetcher = fetchSequence(
+      cloudflareResponse([maintainers]),
+      cloudflareResponse(namedPolicy()),
+    );
+    const client = new VisitorPolicyClient(config, fetcher);
+
+    await expect(client.update(() => ["first@example.com"])).resolves.toEqual([
+      "first@example.com",
+    ]);
+
+    expect(fetcher.mock.calls.map(([url, options]) => [url, options?.method])).toEqual([
+      [`${collectionUrl}?page=1&per_page=100`, "GET"],
+      [collectionUrl, "POST"],
+    ]);
+    expect(requestBody(fetcher, 1)).toEqual({
+      name: config.policyName,
+      decision: "allow",
+      include: [{ email: { email: "first@example.com" } }],
+    });
+  });
+
+  it("rereads the named policy and preserves dashboard grants and restrictions on update", async () => {
+    const original = namedPolicy();
+    const updated = {
+      ...namedPolicy(["first@example.com", "manual@example.com"]),
+      precedence: 9,
+      session_duration: "12h",
+      approval_required: true,
+      approval_groups: [{ approvals_needed: 1, email_addresses: ["approver@example.com"] }],
+      mfa_config: { mfa_disabled: false },
+      created_at: "2026-08-28T00:00:00Z",
+    };
+    const fetcher = fetchSequence(
+      cloudflareResponse([original]),
+      cloudflareResponse(original),
+      cloudflareResponse([updated]),
+      cloudflareResponse(updated),
+      cloudflareResponse(updated),
+    );
+    const client = new VisitorPolicyClient(config, fetcher);
+    await expect(client.read()).resolves.toEqual({
+      id: original.id,
+      emails: ["first@example.com"],
+    });
+
+    await expect(client.update((emails) => [...emails, "next@example.com"])).resolves.toEqual([
+      "first@example.com",
+      "manual@example.com",
+      "next@example.com",
+    ]);
+
+    expect(requestBody(fetcher, 4)).toEqual({
+      name: config.policyName,
+      decision: "allow",
+      include: ["first@example.com", "manual@example.com", "next@example.com"].map((email) => ({
+        email: { email },
+      })),
+      precedence: 9,
+      session_duration: "12h",
+      approval_required: true,
+      approval_groups: updated.approval_groups,
+      mfa_config: updated.mfa_config,
+    });
+    expect(fetcher.mock.calls[4]?.[0]).toBe(`${collectionUrl}/${original.id}`);
+    expect(fetcher.mock.calls[4]?.[1]?.method).toBe("PUT");
+  });
+
+  it.each([
+    ["deny decision", { decision: "deny" }],
+    ["non-email includes", { include: [{ everyone: {} }] }],
+    ["mixed email rules", { include: [{ email: { email: "first@example.com" }, everyone: {} }] }],
+    ["required restrictions", { require: [{ email_domain: { domain: "example.com" } }] }],
+    ["excluded identities", { exclude: [{ email: { email: "excluded@example.com" } }] }],
+    ["renamed policy", { name: "GitHub organization" }],
+    ["replaced policy", { id: "other-policy" }],
+  ])("refuses %s before running a change or writing Cloudflare", async (_name, override) => {
+    const policy = namedPolicy();
+    const fetcher = fetchSequence(
+      cloudflareResponse([policy]),
+      cloudflareResponse({ ...policy, ...override }),
+    );
+    const change = vi.fn(() => ["next@example.com"]);
+    await expect(new VisitorPolicyClient(config, fetcher).update(change)).rejects.toBeInstanceOf(
+      VisitorAccessError,
+    );
+    expect(change).not.toHaveBeenCalled();
+    expect(fetcher.mock.calls.every(([, options]) => options?.method === "GET")).toBe(true);
+  });
+
+  it("finds a policy on later pages and refuses duplicate configured names across pages", async () => {
+    const other = { id: "other", name: "Maintainers" };
+    const policy = namedPolicy();
+    const fetcher = fetchSequence(
+      cloudflareResponse([other], { total_pages: 2 }),
+      cloudflareResponse([policy], { total_pages: 2 }),
+      cloudflareResponse(policy),
+    );
+    await expect(new VisitorPolicyClient(config, fetcher).read()).resolves.toEqual({
+      id: policy.id,
+      emails: ["first@example.com"],
+    });
+    expect(fetcher.mock.calls[1]?.[0]).toBe(`${collectionUrl}?page=2&per_page=100`);
+
+    const duplicates = fetchSequence(
+      cloudflareResponse([policy], { total_pages: 2 }),
+      cloudflareResponse([{ ...policy, id: "duplicate" }], { total_pages: 2 }),
+    );
+    await expect(
+      new VisitorPolicyClient(config, duplicates).update(() => []),
+    ).rejects.toBeInstanceOf(VisitorAccessError);
+    expect(duplicates.mock.calls.every(([, options]) => options?.method === "GET")).toBe(true);
+  });
+
+  it("deletes only the named policy when its final email is removed", async () => {
+    const policy = namedPolicy();
+    const fetcher = fetchSequence(
+      cloudflareResponse([policy]),
+      cloudflareResponse(policy),
+      cloudflareResponse({ id: policy.id }),
+    );
+    await expect(new VisitorPolicyClient(config, fetcher).update(() => [])).resolves.toEqual([]);
+    expect(fetcher.mock.calls[2]?.[0]).toBe(`${collectionUrl}/${policy.id}`);
+    expect(fetcher.mock.calls[2]?.[1]?.method).toBe("DELETE");
+  });
+
+  it.each([{ emails: [] }, { emails: ["FIRST@example.com"] }])(
+    "avoids a write when normalized membership is unchanged: $emails",
+    async ({ emails }) => {
+      const policy = namedPolicy(emails);
+      const fetcher = emails.length
+        ? fetchSequence(cloudflareResponse([policy]), cloudflareResponse(policy))
+        : fetchSequence(cloudflareResponse([]));
+      const change = vi.fn(async (current: readonly string[]) => [...current]);
+      await expect(new VisitorPolicyClient(config, fetcher).update(change)).resolves.toEqual(
+        emails.map((email) => email.toLowerCase()),
+      );
+      expect(change).toHaveBeenCalledOnce();
+      expect(fetcher.mock.calls.every(([, options]) => options?.method === "GET")).toBe(true);
+    },
+  );
+
+  it("does not mutate Cloudflare when the durable change callback fails", async () => {
+    const fetcher = fetchSequence(cloudflareResponse([]));
+    await expect(
+      new VisitorPolicyClient(config, fetcher).update(async () => {
+        throw new VisitorAccessError("The grant store is unavailable");
+      }),
+    ).rejects.toBeInstanceOf(VisitorAccessError);
+    expect(fetcher).toHaveBeenCalledOnce();
+  });
+
+  it.each(["network", "http", "api", "json"])(
+    "never exposes token-bearing %s failures",
+    async (mode) => {
+      const fetcher = vi.fn<typeof fetch>();
+      if (mode === "network") {
+        fetcher.mockRejectedValueOnce(new Error(config.apiToken));
+      } else if (mode === "http") {
+        fetcher.mockResolvedValueOnce(new Response(config.apiToken, { status: 403 }));
+      } else if (mode === "api") {
+        fetcher.mockResolvedValueOnce(
+          Response.json({ success: false, errors: [{ message: config.apiToken }] }),
+        );
+      } else {
+        fetcher.mockResolvedValueOnce(new Response(config.apiToken));
+      }
+      const error = await new VisitorPolicyClient(config, fetcher)
+        .read()
+        .catch((cause: unknown) => cause);
+      expect(error).toBeInstanceOf(VisitorAccessError);
+      expect(String(error)).not.toContain(config.apiToken);
+      const options = fetcher.mock.calls[0]?.[1];
+      expect(options?.redirect).toBe("error");
+      expect(options?.signal).toBeInstanceOf(AbortSignal);
+    },
+  );
+
+  it("fences an obsolete service before the durable callback runs", async () => {
+    const abort = new AbortController();
+    const fetcher = vi.fn<typeof fetch>().mockImplementationOnce(async () => {
+      abort.abort();
+      return cloudflareResponse([]);
+    });
+    const change = vi.fn(() => ["next@example.com"]);
+    await expect(
+      new VisitorPolicyClient(config, fetcher, abort.signal).update(change),
+    ).rejects.toBeInstanceOf(VisitorAccessError);
+    expect(change).not.toHaveBeenCalled();
+    expect(fetcher.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
+  });
+});

--- a/extensions/visitor-access/src/cloudflare.ts
+++ b/extensions/visitor-access/src/cloudflare.ts
@@ -1,0 +1,184 @@
+import { z } from "zod";
+import type { VisitorAccessConfig } from "./config.js";
+import { VisitorAccessError } from "./errors.js";
+
+const policyReferenceSchema = z.object({
+  id: z
+    .string()
+    .min(1)
+    .max(128)
+    .refine((value) => value !== "." && value !== ".."),
+  name: z.string(),
+});
+const emailRuleSchema = z.strictObject({
+  email: z.strictObject({ email: z.email().max(254) }),
+});
+const managedPolicySchema = policyReferenceSchema
+  .extend({
+    decision: z.literal("allow"),
+    include: z.array(emailRuleSchema).max(10_000),
+    exclude: z.array(z.unknown()).max(0).optional(),
+    require: z.array(z.unknown()).max(0).optional(),
+  })
+  .passthrough();
+const responseSchema = z.object({
+  success: z.literal(true),
+  result: z.unknown(),
+  result_info: z
+    .object({
+      total_pages: z.number().int().nonnegative().optional(),
+      per_page: z.number().int().positive().optional(),
+    })
+    .optional(),
+});
+
+type ManagedPolicy = z.infer<typeof managedPolicySchema>;
+
+export class VisitorPolicyClient {
+  private readonly policiesUrl: string;
+
+  constructor(
+    private readonly config: VisitorAccessConfig,
+    private readonly fetcher: typeof fetch = fetch,
+    private readonly signal?: AbortSignal,
+  ) {
+    this.policiesUrl = `https://api.cloudflare.com/client/v4/accounts/${encodeURIComponent(config.accountId)}/access/apps/${encodeURIComponent(config.appId)}/policies`;
+  }
+
+  async read(): Promise<{ id: string; emails: string[] } | undefined> {
+    const policy = await this.readPolicy();
+    return policy ? { id: policy.id, emails: this.policyEmails(policy) } : undefined;
+  }
+
+  async update(
+    change: (emails: readonly string[]) => string[] | Promise<string[]>,
+  ): Promise<string[]> {
+    // Every mutation starts from Cloudflare, preserving dashboard edits made since
+    // the previous tool call. The service serializes its own mutations separately.
+    const policy = await this.readPolicy();
+    const current = policy ? this.policyEmails(policy) : [];
+    if (this.signal?.aborted) {
+      throw new VisitorAccessError("Visitor access is stopping; retry after the gateway starts.");
+    }
+    const emails = [...new Set(await change(current))];
+    if (emails.length === current.length && emails.every((email) => current.includes(email))) {
+      return emails;
+    }
+    if (policy && emails.length === 0) {
+      await this.request(`${this.policiesUrl}/${encodeURIComponent(policy.id)}`, "DELETE");
+      return emails;
+    }
+
+    const payload: Record<string, unknown> = { ...policy };
+    // Retain the policy's restrictions and precedence; only these response-only
+    // fields are omitted. Never reconstruct other app policies or their ordering.
+    for (const key of ["id", "account_id", "created_at", "updated_at"]) {
+      delete payload[key];
+    }
+    payload.name = this.config.policyName;
+    payload.decision = "allow";
+    payload.include = emails.map((email) => ({ email: { email } }));
+    const url = policy ? `${this.policiesUrl}/${encodeURIComponent(policy.id)}` : this.policiesUrl;
+    await this.request(url, policy ? "PUT" : "POST", payload);
+    return emails;
+  }
+
+  private policyEmails(policy: ManagedPolicy): string[] {
+    return [...new Set(policy.include.map((rule) => rule.email.email.toLowerCase()))];
+  }
+
+  private async readPolicy(): Promise<ManagedPolicy | undefined> {
+    let reference: z.infer<typeof policyReferenceSchema> | undefined;
+    for (let page = 1; page <= 100; page += 1) {
+      const response = await this.request(`${this.policiesUrl}?page=${page}&per_page=100`, "GET");
+      const policies = z.array(policyReferenceSchema).max(100).safeParse(response.result);
+      if (!policies.success) {
+        throw new VisitorAccessError(
+          "Cloudflare returned an invalid policy list; inspect the Access application.",
+        );
+      }
+      for (const policy of policies.data) {
+        if (policy.name !== this.config.policyName) {
+          continue;
+        }
+        if (reference) {
+          throw new VisitorAccessError(
+            "Multiple Access policies have the configured visitor policy name; make the name unique before retrying.",
+          );
+        }
+        reference = policy;
+      }
+      const totalPages = response.result_info?.total_pages;
+      const pageSize = response.result_info?.per_page ?? 100;
+      const complete =
+        totalPages === undefined ? policies.data.length < pageSize : page >= totalPages;
+      if (complete) {
+        if (!reference) {
+          return undefined;
+        }
+        // Fetch the selected policy after discovery so its identity and include
+        // rules are validated together immediately before the change callback.
+        const detail = await this.request(
+          `${this.policiesUrl}/${encodeURIComponent(reference.id)}`,
+          "GET",
+        );
+        const parsed = managedPolicySchema.safeParse(detail.result);
+        if (
+          !parsed.success ||
+          parsed.data.id !== reference.id ||
+          parsed.data.name !== this.config.policyName
+        ) {
+          throw new VisitorAccessError(
+            "The visitor policy changed or is not an email-only allow policy. Inspect its name, decision, include, require, and exclude rules before retrying.",
+          );
+        }
+        return parsed.data;
+      }
+    }
+    throw new VisitorAccessError(
+      "The Access application has too many policies to inspect safely; reduce its policy count before retrying.",
+    );
+  }
+
+  private async request(url: string, method: "GET" | "POST" | "PUT" | "DELETE", body?: unknown) {
+    let response: Response;
+    try {
+      response = await this.fetcher(url, {
+        method,
+        headers: {
+          Authorization: `Bearer ${this.config.apiToken}`,
+          "Content-Type": "application/json",
+        },
+        body: body === undefined ? undefined : JSON.stringify(body),
+        redirect: "error",
+        signal: this.signal
+          ? AbortSignal.any([this.signal, AbortSignal.timeout(30_000)])
+          : AbortSignal.timeout(30_000),
+      });
+    } catch {
+      throw new VisitorAccessError(
+        "Cloudflare request failed; check connectivity and retry. Policy state may need reconciliation.",
+      );
+    }
+    if (!response.ok) {
+      throw new VisitorAccessError(
+        `Cloudflare request failed (HTTP ${response.status}); check the token's Access policy permissions and retry.`,
+      );
+    }
+    let data: unknown;
+    try {
+      data = await response.json();
+    } catch {
+      throw new VisitorAccessError(
+        "Cloudflare returned an unreadable response; retry and inspect the visitor policy.",
+      );
+    }
+    const parsed = responseSchema.safeParse(data);
+    if (!parsed.success) {
+      throw new VisitorAccessError(
+        "Cloudflare did not confirm the request; inspect the visitor policy before retrying.",
+      );
+    }
+    return parsed.data;
+  }
+}

--- a/extensions/visitor-access/src/config.ts
+++ b/extensions/visitor-access/src/config.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+import { buildPluginConfigSchema } from "../api.js";
+
+export const visitorConfigSchema = z.strictObject({
+  accountId: z
+    .string()
+    .trim()
+    .min(1)
+    .max(128)
+    .regex(/^[a-zA-Z0-9_-]+$/),
+  appId: z
+    .string()
+    .trim()
+    .min(1)
+    .max(128)
+    .regex(/^[a-zA-Z0-9_-]+$/),
+  apiToken: z.string().min(1),
+  policyName: z.string().trim().min(1).max(200).default("Visitors (openclaw-managed)"),
+  defaultTtlDays: z.number().int().min(0).max(3650).nullable().default(14),
+  maxVisitors: z.number().int().min(1).max(500).default(50),
+});
+
+export type VisitorAccessConfig = z.output<typeof visitorConfigSchema>;
+
+export const visitorPluginSchema = buildPluginConfigSchema(visitorConfigSchema);

--- a/extensions/visitor-access/src/errors.ts
+++ b/extensions/visitor-access/src/errors.ts
@@ -1,0 +1,10 @@
+/** Only curated operator-facing messages cross the tool/log boundary. */
+export class VisitorAccessError extends Error {}
+
+export function visitorErrorText(error: unknown, apiToken: string): string {
+  const message =
+    error instanceof VisitorAccessError
+      ? error.message
+      : "Visitor access operation failed. Check gateway health and retry; use visitor_list to inspect drift.";
+  return message.replaceAll(apiToken, "[redacted]");
+}

--- a/extensions/visitor-access/src/runtime.ts
+++ b/extensions/visitor-access/src/runtime.ts
@@ -1,0 +1,14 @@
+import { createPluginRuntimeStore } from "../api.js";
+import type { VisitorAccessService } from "./visitors.js";
+
+export type VisitorRuntime = {
+  service: VisitorAccessService;
+  errorText: (error: unknown) => string;
+};
+
+// Discovery registries can load separate module instances. Only the Gateway
+// service publishes this slot, so all tools share its queue and lifetime.
+export const visitorRuntimeStore = createPluginRuntimeStore<VisitorRuntime>({
+  key: "plugin-runtime:visitor-access:active",
+  errorMessage: "Start the Gateway with visitor-access enabled before managing visitors.",
+});

--- a/extensions/visitor-access/src/tools.ts
+++ b/extensions/visitor-access/src/tools.ts
@@ -1,0 +1,94 @@
+import { Type } from "typebox";
+import type { AnyAgentTool, OpenClawPluginToolContext } from "../api.js";
+import { visitorRuntimeStore } from "./runtime.js";
+import type { VisitorAccessService } from "./visitors.js";
+
+const identityFields = {
+  github: Type.Optional(
+    Type.String({ description: "GitHub login, without @.", minLength: 1, maxLength: 39 }),
+  ),
+  email: Type.Optional(
+    Type.String({
+      description: "Verified email on the visitor's GitHub account.",
+      minLength: 1,
+      maxLength: 254,
+    }),
+  ),
+};
+
+export function createVisitorTools(context: OpenClawPluginToolContext): AnyAgentTool[] {
+  let runtime = visitorRuntimeStore.tryGetRuntime();
+  const definitions = [
+    {
+      name: "visitor_invite",
+      label: "Invite visitor",
+      description:
+        "Grant or renew visitor access to team.openclaw.ai. Provide email or GitHub login; private GitHub emails require explicit email. Grants expire after the configured duration (14 days by default); forever must be explicit.",
+      parameters: Type.Object(
+        {
+          ...identityFields,
+          days: Type.Optional(
+            Type.Integer({
+              minimum: 1,
+              maximum: 3650,
+              description: "Grant duration in days; cannot be combined with forever.",
+            }),
+          ),
+          forever: Type.Optional(
+            Type.Boolean({ description: "Explicitly grant access without expiry." }),
+          ),
+        },
+        { additionalProperties: false },
+      ),
+      run: (service: VisitorAccessService, raw: unknown) =>
+        service.invite(raw, context.sessionKey ?? context.agentId),
+    },
+    {
+      name: "visitor_revoke",
+      label: "Revoke visitor",
+      description:
+        "Remove visitor access by email or GitHub login. GitHub login removes all recorded grants for that login. Explicit email can also remove an unmanaged policy entry. Already absent grants are a no-op.",
+      parameters: Type.Object(identityFields, { additionalProperties: false }),
+      run: (service: VisitorAccessService, raw: unknown) => service.revoke(raw),
+    },
+    {
+      name: "visitor_list",
+      label: "List visitors",
+      description:
+        "List recorded visitor grants, invitation and expiry dates, and drift from the Access policy. Unmanaged policy emails are reported and retained; missing policy emails are never automatically restored.",
+      parameters: Type.Object({}, { additionalProperties: false }),
+      run: (service: VisitorAccessService) => service.list(),
+    },
+  ];
+  return definitions.map(({ name, label, description, parameters, run }) => ({
+    name,
+    label,
+    description,
+    parameters,
+    async execute(_id, raw) {
+      // Bind once; a retained tool cannot inherit a replacement service's lifetime.
+      runtime ??= visitorRuntimeStore.tryGetRuntime();
+      if (!runtime) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: "Start the Gateway with visitor-access enabled before managing visitors.",
+            },
+          ],
+          details: { error: true },
+          isError: true,
+        };
+      }
+      try {
+        return { content: [{ type: "text", text: await run(runtime.service, raw) }], details: {} };
+      } catch (error) {
+        return {
+          content: [{ type: "text", text: runtime.errorText(error) }],
+          details: { error: true },
+          isError: true,
+        };
+      }
+    },
+  }));
+}

--- a/extensions/visitor-access/src/visitors.test.ts
+++ b/extensions/visitor-access/src/visitors.test.ts
@@ -1,0 +1,438 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginStateKeyedStore } from "../api.js";
+import { VisitorPolicyClient } from "./cloudflare.js";
+import type { VisitorAccessConfig } from "./config.js";
+import { VisitorAccessError } from "./errors.js";
+import { VisitorAccessService, type VisitorGrant } from "./visitors.js";
+
+const NOW = Date.parse("2026-08-28T12:00:00.000Z");
+const DAY_MS = 86_400_000;
+const config: VisitorAccessConfig = {
+  accountId: "test-account",
+  appId: "test-app",
+  apiToken: "test-token",
+  policyName: "Visitors (openclaw-managed)",
+  defaultTtlDays: 14,
+  maxVisitors: 50,
+};
+const policiesPath = "/client/v4/accounts/test-account/access/apps/test-app/policies";
+
+function requestUrl(input: Parameters<typeof fetch>[0]): URL {
+  return new URL(input instanceof Request ? input.url : input);
+}
+
+type PolicyFixture = {
+  id: string;
+  name: string;
+  decision: string;
+  include: { email: { email: string } }[];
+};
+
+function visitorGrant(email: string, overrides: Partial<VisitorGrant> = {}): VisitorGrant {
+  return { email, createdAt: NOW - DAY_MS, expiresAt: NOW + DAY_MS, ...overrides };
+}
+
+function visitorFixture(
+  options: {
+    config?: Partial<VisitorAccessConfig>;
+    grants?: VisitorGrant[];
+    emails?: string[];
+    githubEmail?: string | null;
+  } = {},
+) {
+  const resolved = { ...config, ...options.config };
+  const grants = new Map(options.grants?.map((grant) => [grant.email, grant]));
+  const store: PluginStateKeyedStore<VisitorGrant> = {
+    async register(key, grant) {
+      grants.set(key, structuredClone(grant));
+    },
+    async registerIfAbsent(key, grant) {
+      if (grants.has(key)) {
+        return false;
+      }
+      grants.set(key, structuredClone(grant));
+      return true;
+    },
+    async lookup(key) {
+      return structuredClone(grants.get(key));
+    },
+    async consume(key) {
+      const grant = grants.get(key);
+      grants.delete(key);
+      return structuredClone(grant);
+    },
+    async delete(key) {
+      return grants.delete(key);
+    },
+    async entries() {
+      return [...grants].map(([key, value]) => ({
+        key,
+        value: structuredClone(value),
+        createdAt: value.createdAt,
+      }));
+    },
+    async clear() {
+      grants.clear();
+    },
+  };
+  const cloudflare: {
+    policy: PolicyFixture | undefined;
+    failWrites: boolean;
+    loseWriteResponse: boolean;
+    beforeWrite: () => Promise<void>;
+  } = {
+    policy: options.emails?.length
+      ? {
+          id: "visitors",
+          name: resolved.policyName,
+          decision: "allow",
+          include: options.emails.map((email) => ({ email: { email } })),
+        }
+      : undefined,
+    failWrites: false,
+    loseWriteResponse: false,
+    beforeWrite: async () => {},
+  };
+  const response = (result: unknown) => Response.json({ success: true, result });
+  const fetcher = vi.fn<typeof fetch>(async (input, init) => {
+    const url = requestUrl(input);
+    const method = init?.method ?? "GET";
+    if (url.origin === "https://api.github.com") {
+      if (!/^\/users\/[a-z0-9-]+$/.test(url.pathname) || method !== "GET") {
+        throw new Error("Unexpected GitHub request");
+      }
+      return Response.json({ email: options.githubEmail ?? null });
+    }
+    if (url.origin !== "https://api.cloudflare.com" || !url.pathname.startsWith(policiesPath)) {
+      throw new Error("Unexpected Cloudflare endpoint");
+    }
+    if (method === "GET") {
+      if (url.pathname === policiesPath) {
+        return response(cloudflare.policy ? [cloudflare.policy] : []);
+      }
+      if (url.pathname === `${policiesPath}/visitors` && cloudflare.policy) {
+        return response(cloudflare.policy);
+      }
+      throw new Error("Unknown policy read");
+    }
+    await cloudflare.beforeWrite();
+    if (cloudflare.failWrites) {
+      return new Response("Unavailable", { status: 503 });
+    }
+    if (method === "DELETE" && url.pathname === `${policiesPath}/visitors`) {
+      cloudflare.policy = undefined;
+    } else if (
+      (method === "POST" && url.pathname === policiesPath) ||
+      (method === "PUT" && url.pathname === `${policiesPath}/visitors`)
+    ) {
+      if (typeof init?.body !== "string") {
+        throw new Error("Expected a JSON policy");
+      }
+      const body = JSON.parse(init.body) as Omit<PolicyFixture, "id">;
+      cloudflare.policy = { ...body, id: "visitors" };
+    } else {
+      throw new Error("Unexpected policy mutation");
+    }
+    if (cloudflare.loseWriteResponse) {
+      throw new Error("Connection lost after Cloudflare committed the policy");
+    }
+    return response(cloudflare.policy ?? { id: "visitors" });
+  });
+  const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+  const service = new VisitorAccessService(
+    resolved,
+    store,
+    new VisitorPolicyClient(resolved, fetcher),
+    logger,
+    fetcher,
+  );
+  return {
+    cloudflare,
+    fetcher,
+    grants,
+    logger,
+    service,
+    emails: () => cloudflare.policy?.include.map((rule) => rule.email.email) ?? [],
+    mutations: () =>
+      fetcher.mock.calls.filter(([, init]) => init?.method !== "GET" && init?.method),
+  };
+}
+
+describe("VisitorAccessService", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves public GitHub email, records a default-expiring grant, and explains login", async () => {
+    const fixture = visitorFixture({ githubEmail: "Visitor@Example.com" });
+
+    const result = await fixture.service.invite({ github: "Visitor" }, "session:maintainer");
+
+    expect(fixture.emails()).toEqual(["visitor@example.com"]);
+    expect(fixture.grants.get("visitor@example.com")).toEqual({
+      email: "visitor@example.com",
+      githubLogin: "visitor",
+      invitedVia: "session:maintainer",
+      createdAt: NOW,
+      expiresAt: NOW + 14 * DAY_MS,
+    });
+    expect(fixture.fetcher.mock.calls[0]?.[0]).toBe("https://api.github.com/users/visitor");
+    expect(result).toContain("@visitor");
+    expect(result).toContain("visitor@example.com");
+    expect(result).toContain("2026-09-11T12:00:00.000Z");
+    expect(result).toContain("https://team.openclaw.ai");
+    expect(result).toContain("GitHub account");
+  });
+
+  it("asks for an explicit account email when GitHub has no public email, without granting access", async () => {
+    const fixture = visitorFixture({ githubEmail: null });
+
+    await expect(fixture.service.invite({ github: "private-visitor" })).rejects.toThrow(
+      /Ask the visitor.*email.*GitHub account.*email explicitly/,
+    );
+
+    expect(fixture.emails()).toEqual([]);
+    expect(fixture.grants.size).toBe(0);
+    expect(fixture.mutations()).toEqual([]);
+  });
+
+  it("uses an explicit normalized email without consulting GitHub", async () => {
+    const fixture = visitorFixture();
+
+    await fixture.service.invite({
+      github: "Private-Visitor",
+      email: " Visitor@Example.com ",
+      days: 3,
+    });
+
+    expect(fixture.grants.get("visitor@example.com")).toMatchObject({
+      githubLogin: "private-visitor",
+      expiresAt: NOW + 3 * DAY_MS,
+    });
+    expect(fixture.emails()).toEqual(["visitor@example.com"]);
+    expect(
+      fixture.fetcher.mock.calls.every(
+        ([url]) => requestUrl(url).origin === "https://api.cloudflare.com",
+      ),
+    ).toBe(true);
+  });
+
+  it.each([
+    {},
+    { email: "not-an-email" },
+    { email: "a@example.com\nBcc:other@example.com" },
+    { github: "../other" },
+    { email: "visitor@example.com", days: 0 },
+  ])("rejects invalid identity or duration before writing any grant: %j", async (input) => {
+    const fixture = visitorFixture();
+    await expect(fixture.service.invite(input)).rejects.toBeInstanceOf(VisitorAccessError);
+    expect(fixture.fetcher).not.toHaveBeenCalled();
+    expect(fixture.grants.size).toBe(0);
+  });
+
+  it.each([0, null])(
+    "requires explicit forever when the default duration is %s",
+    async (defaultTtlDays) => {
+      const fixture = visitorFixture({ config: { defaultTtlDays } });
+      await expect(fixture.service.invite({ email: "visitor@example.com" })).rejects.toThrow(
+        /forever/,
+      );
+      expect(fixture.grants.size).toBe(0);
+      expect(fixture.mutations()).toEqual([]);
+
+      const result = await fixture.service.invite({ email: "visitor@example.com", forever: true });
+      expect(fixture.grants.get("visitor@example.com")?.expiresAt).toBeNull();
+      expect(result).toContain("never");
+      await expect(
+        fixture.service.invite({ email: "visitor@example.com", forever: true, days: 1 }),
+      ).rejects.toThrow(/days.*forever/);
+    },
+  );
+
+  it("counts managed and unmanaged grants toward admission while allowing an existing grant to renew", async () => {
+    const previous = visitorGrant("visitor@example.com", { githubLogin: "visitor" });
+    const fixture = visitorFixture({
+      config: { maxVisitors: 2 },
+      grants: [previous],
+      emails: [previous.email, "manual@example.com"],
+    });
+    await expect(fixture.service.invite({ email: "third@example.com" })).rejects.toThrow(/limit/);
+    expect(fixture.emails()).toEqual([previous.email, "manual@example.com"]);
+    expect(fixture.grants.size).toBe(1);
+
+    vi.setSystemTime(NOW + DAY_MS);
+    await fixture.service.invite({ email: "VISITOR@example.com", days: 4 });
+    expect(fixture.grants.get(previous.email)).toMatchObject({
+      createdAt: previous.createdAt,
+      githubLogin: "visitor",
+      expiresAt: NOW + 5 * DAY_MS,
+    });
+    expect(fixture.emails()).toEqual([previous.email, "manual@example.com"]);
+    expect(fixture.grants.size).toBe(1);
+  });
+
+  it("revokes by recorded GitHub login even after that account hides its public email", async () => {
+    const grants = ["first@example.com", "second@example.com"].map((email) =>
+      visitorGrant(email, { githubLogin: "visitor" }),
+    );
+    const fixture = visitorFixture({
+      grants,
+      emails: [...grants.map((grant) => grant.email), "manual@example.com"],
+    });
+
+    const result = await fixture.service.revoke({ github: "Visitor" });
+
+    expect(fixture.emails()).toEqual(["manual@example.com"]);
+    expect(fixture.grants.size).toBe(0);
+    expect(result).toContain("@visitor (2 recorded emails)");
+    expect(
+      fixture.fetcher.mock.calls.every(
+        ([url]) => requestUrl(url).origin !== "https://api.github.com",
+      ),
+    ).toBe(true);
+  });
+
+  it("explicitly revokes unmanaged emails and makes a repeated revoke a clean no-op", async () => {
+    const fixture = visitorFixture({ emails: ["manual@example.com"] });
+    await expect(fixture.service.revoke({ email: "manual@example.com" })).resolves.toContain(
+      "Revoked",
+    );
+    expect(fixture.emails()).toEqual([]);
+    expect(fixture.grants.size).toBe(0);
+    const writes = fixture.mutations().length;
+
+    await expect(fixture.service.revoke({ email: "manual@example.com" })).resolves.toMatch(
+      /nothing to revoke/,
+    );
+    expect(fixture.mutations()).toHaveLength(writes);
+  });
+
+  it("rejects an empty revoke without deleting email-only grant records", async () => {
+    const grant = visitorGrant("visitor@example.com");
+    const fixture = visitorFixture({ grants: [grant], emails: [grant.email] });
+
+    await expect(fixture.service.revoke({})).rejects.toBeInstanceOf(VisitorAccessError);
+
+    expect(fixture.emails()).toEqual([grant.email]);
+    expect(fixture.grants.get(grant.email)).toEqual(grant);
+    expect(fixture.fetcher).not.toHaveBeenCalled();
+  });
+
+  it("sweeps expired grants while preserving unexpired, forever, and unmanaged access", async () => {
+    const expired = visitorGrant("expired@example.com", { expiresAt: NOW });
+    const active = visitorGrant("active@example.com");
+    const forever = visitorGrant("forever@example.com", { expiresAt: null });
+    const fixture = visitorFixture({
+      grants: [expired, active, forever],
+      emails: [expired.email, active.email, forever.email, "manual@example.com"],
+    });
+
+    await fixture.service.sweep();
+
+    expect(fixture.emails()).toEqual([active.email, forever.email, "manual@example.com"]);
+    expect([...fixture.grants.values()]).toEqual([active, forever]);
+    expect(fixture.logger.info).toHaveBeenCalledWith(expect.stringContaining(expired.email));
+    expect(fixture.logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/unmanaged.*manual@example.com.*retained/),
+    );
+  });
+
+  it("reports both drift directions and dates without restoring or deleting dashboard changes", async () => {
+    const missing = visitorGrant("missing@example.com", { githubLogin: "visitor" });
+    const fixture = visitorFixture({ grants: [missing], emails: ["manual@example.com"] });
+
+    const result = await fixture.service.list();
+    await fixture.service.sweep();
+
+    expect(result).toContain("1 unmanaged, 1 missing from policy");
+    expect(result).toMatch(
+      /missing@example.com.*@visitor.*2026-08-27T12:00:00.000Z.*2026-08-29T12:00:00.000Z.*MISSING FROM POLICY/,
+    );
+    expect(result).toMatch(/manual@example.com.*UNMANAGED/);
+    expect(fixture.emails()).toEqual(["manual@example.com"]);
+    expect(fixture.grants.get(missing.email)).toEqual(missing);
+    expect(fixture.mutations()).toEqual([]);
+    expect(fixture.logger.warn).toHaveBeenCalledWith(
+      expect.stringMatching(/missing@example.com.*missing from policy/),
+    );
+  });
+
+  it("bounds list output when dashboard edits exceed the visitor cap", async () => {
+    const fixture = visitorFixture({
+      config: { maxVisitors: 2 },
+      emails: ["a@example.com", "b@example.com", "c@example.com"],
+    });
+
+    const result = await fixture.service.list();
+
+    expect(result).toContain("3 unmanaged");
+    expect(result.match(/UNMANAGED/g)).toHaveLength(2);
+    expect(result).toContain("1 entries omitted");
+    expect(fixture.emails()).toHaveLength(3);
+    expect(fixture.mutations()).toEqual([]);
+  });
+
+  it.each(["revoke", "sweep"] as const)(
+    "retains expiry records after a failed Cloudflare %s so cleanup can retry",
+    async (operation) => {
+      const expired = visitorGrant("expired@example.com", { expiresAt: NOW });
+      const fixture = visitorFixture({ grants: [expired], emails: [expired.email] });
+      fixture.cloudflare.failWrites = true;
+
+      await expect(
+        operation === "revoke"
+          ? fixture.service.revoke({ email: expired.email })
+          : fixture.service.sweep(),
+      ).rejects.toBeInstanceOf(VisitorAccessError);
+
+      expect(fixture.grants.get(expired.email)).toEqual(expired);
+      expect(fixture.emails()).toEqual([expired.email]);
+      fixture.cloudflare.failWrites = false;
+      await fixture.service.sweep();
+      expect(fixture.grants.size).toBe(0);
+      expect(fixture.emails()).toEqual([]);
+    },
+  );
+
+  it("keeps an expiry cleanup record when Cloudflare grants access but its response is lost", async () => {
+    const fixture = visitorFixture();
+    fixture.cloudflare.loseWriteResponse = true;
+
+    await expect(
+      fixture.service.invite({ email: "visitor@example.com", days: 1 }),
+    ).rejects.toBeInstanceOf(VisitorAccessError);
+
+    expect(fixture.emails()).toEqual(["visitor@example.com"]);
+    expect(fixture.grants.get("visitor@example.com")?.expiresAt).toBe(NOW + DAY_MS);
+    fixture.cloudflare.loseWriteResponse = false;
+    vi.setSystemTime(NOW + DAY_MS);
+    await fixture.service.sweep();
+    expect(fixture.grants.size).toBe(0);
+    expect(fixture.emails()).toEqual([]);
+  });
+
+  it("serializes concurrent invites so a delayed policy write cannot lose another visitor", async () => {
+    const fixture = visitorFixture();
+    const writing = createDeferred<void>();
+    const release = createDeferred<void>();
+    fixture.cloudflare.beforeWrite = async () => {
+      writing.resolve();
+      await release.promise;
+    };
+    const first = fixture.service.invite({ email: "first@example.com" });
+    await writing.promise;
+    const second = fixture.service.invite({ email: "second@example.com" });
+    release.resolve();
+
+    await Promise.all([first, second]);
+
+    expect(fixture.emails()).toEqual(["first@example.com", "second@example.com"]);
+    expect([...fixture.grants.keys()]).toEqual(["first@example.com", "second@example.com"]);
+  });
+});

--- a/extensions/visitor-access/src/visitors.ts
+++ b/extensions/visitor-access/src/visitors.ts
@@ -1,0 +1,274 @@
+import { z } from "zod";
+import type { PluginLogger, PluginStateKeyedStore } from "../api.js";
+import type { VisitorPolicyClient } from "./cloudflare.js";
+import type { VisitorAccessConfig } from "./config.js";
+import { VisitorAccessError } from "./errors.js";
+
+export type VisitorGrant = {
+  email: string;
+  githubLogin?: string;
+  invitedVia?: string;
+  createdAt: number;
+  expiresAt: number | null;
+};
+
+const emailSchema = z
+  .string()
+  .trim()
+  .max(254)
+  .pipe(z.email())
+  .transform((email) => email.toLowerCase());
+const identityFields = {
+  github: z
+    .string()
+    .trim()
+    .regex(/^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$/)
+    .transform((login) => login.toLowerCase())
+    .optional(),
+  email: emailSchema.optional(),
+};
+const revokeSchema = z.strictObject(identityFields);
+const inviteSchema = z.strictObject({
+  ...identityFields,
+  days: z.number().int().min(1).max(3650).optional(),
+  forever: z.boolean().optional(),
+});
+const githubSchema = z.object({ email: z.string().nullable() });
+const DAY_MS = 86_400_000;
+const LIST_MAX_CHARS = 12_000;
+
+function parseVisitorInput<T>(schema: z.ZodType<T>, raw: unknown): T {
+  const result = schema.safeParse(raw);
+  if (!result.success) {
+    throw new VisitorAccessError(
+      "Invalid visitor input. Use a valid email or GitHub login, days from 1 to 3650, or forever: true.",
+    );
+  }
+  return result.data;
+}
+
+function expiryText(expiresAt: number | null): string {
+  return expiresAt === null ? "never (explicit forever grant)" : new Date(expiresAt).toISOString();
+}
+
+export class VisitorAccessService {
+  private pending: Promise<unknown> = Promise.resolve();
+
+  constructor(
+    private readonly config: VisitorAccessConfig,
+    private readonly store: PluginStateKeyedStore<VisitorGrant>,
+    private readonly policy: VisitorPolicyClient,
+    private readonly logger: PluginLogger,
+    private readonly fetcher: typeof fetch = fetch,
+    private readonly signal?: AbortSignal,
+  ) {}
+
+  // One queue owns the policy read/modify/write and its corresponding durable record.
+  // Cloudflare has no cross-store transaction; keep records until revocation succeeds.
+  private serialize<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.pending.then(() => {
+      this.signal?.throwIfAborted();
+      return operation();
+    });
+    this.pending = result.catch(() => {});
+    return result;
+  }
+
+  async waitForIdle(): Promise<void> {
+    await this.pending;
+  }
+
+  private async resolveEmail(input: { email?: string; github?: string }): Promise<string> {
+    if (input.email) {
+      return input.email;
+    }
+    if (!input.github) {
+      throw new VisitorAccessError("Provide an email or GitHub login.");
+    }
+    let response: Response;
+    let body: unknown;
+    try {
+      response = await this.fetcher(
+        `https://api.github.com/users/${encodeURIComponent(input.github)}`,
+        {
+          headers: {
+            Accept: "application/vnd.github+json",
+            "User-Agent": "OpenClaw-visitor-access",
+          },
+          redirect: "error",
+          signal: this.signal
+            ? AbortSignal.any([this.signal, AbortSignal.timeout(15_000)])
+            : AbortSignal.timeout(15_000),
+        },
+      );
+      if (!response.ok) {
+        throw new Error("GitHub lookup failed");
+      }
+      body = await response.json();
+    } catch {
+      throw new VisitorAccessError(
+        "GitHub email lookup failed. Check the login and retry, or pass email explicitly.",
+      );
+    }
+    const result = githubSchema.safeParse(body);
+    if (!result.success || result.data.email === null) {
+      throw new VisitorAccessError(
+        "No public GitHub email is available. Ask the visitor for the email on their GitHub account, or pass email explicitly.",
+      );
+    }
+    return parseVisitorInput(emailSchema, result.data.email);
+  }
+
+  invite(raw: unknown, invitedVia?: string): Promise<string> {
+    return this.serialize(async () => {
+      const input = parseVisitorInput(inviteSchema, raw);
+      if (input.forever && input.days !== undefined) {
+        throw new VisitorAccessError("Choose days or forever: true, not both.");
+      }
+      const days = input.days ?? this.config.defaultTtlDays;
+      let expiresAt: number | null = null;
+      if (!input.forever) {
+        if (!days) {
+          throw new VisitorAccessError(
+            "No default duration is configured. Pass days or explicitly pass forever: true.",
+          );
+        }
+        expiresAt = Date.now() + days * DAY_MS;
+      }
+      const email = await this.resolveEmail(input);
+      const now = Date.now();
+      const previous = await this.store.lookup(email);
+      const githubLogin = input.github ?? previous?.githubLogin;
+      const provenance = invitedVia?.slice(0, 256) ?? previous?.invitedVia;
+      const grant: VisitorGrant = {
+        email,
+        ...(githubLogin ? { githubLogin } : {}),
+        ...(provenance ? { invitedVia: provenance } : {}),
+        createdAt: previous?.createdAt ?? now,
+        expiresAt,
+      };
+      await this.policy.update(async (emails) => {
+        const entries = await this.store.entries();
+        const known = new Set([...emails, ...entries.map((entry) => entry.key)]);
+        if (!known.has(email) && known.size >= this.config.maxVisitors) {
+          throw new VisitorAccessError(
+            `Visitor limit (${this.config.maxVisitors}) reached. Revoke an existing visitor before inviting another.`,
+          );
+        }
+        // Persist first: even a lost API response must leave an expiry cleanup record.
+        await this.store.register(email, grant);
+        return [...new Set([...emails, email])];
+      });
+      const who = grant.githubLogin ? `@${grant.githubLogin} (${email})` : email;
+      return `Invited ${who}. Expires: ${expiryText(grant.expiresAt)}. Log in at https://team.openclaw.ai with your GitHub account using this verified email.`;
+    });
+  }
+
+  revoke(raw: unknown): Promise<string> {
+    return this.serialize(async () => {
+      const input = parseVisitorInput(revokeSchema, raw);
+      if (!input.email && !input.github) {
+        throw new VisitorAccessError("Provide an email or GitHub login.");
+      }
+      const entries = await this.store.entries();
+      const matching = input.email
+        ? [input.email]
+        : entries
+            .filter((entry) => entry.value.githubLogin === input.github)
+            .map((entry) => entry.key);
+      const targets = new Set(matching.length ? matching : [await this.resolveEmail(input)]);
+      let removed = false;
+      await this.policy.update((emails) => {
+        removed =
+          emails.some((email) => targets.has(email)) ||
+          entries.some((entry) => targets.has(entry.key));
+        return emails.filter((email) => !targets.has(email));
+      });
+      for (const email of targets) {
+        await this.store.delete(email);
+      }
+      const who =
+        targets.size > 1
+          ? `@${input.github} (${targets.size} recorded emails)`
+          : [...targets].join(", ");
+      return removed
+        ? `Revoked visitor access for ${who}.`
+        : `No visitor grant found for ${who}; nothing to revoke.`;
+    });
+  }
+
+  list(): Promise<string> {
+    return this.serialize(async () => {
+      const policy = await this.policy.read();
+      const emails = new Set(policy?.emails ?? []);
+      const entries = await this.store.entries();
+      const managed = new Set(entries.map((entry) => entry.key));
+      const unmanaged = [...emails].filter((email) => !managed.has(email)).toSorted();
+      const missing = entries.filter((entry) => !emails.has(entry.key)).length;
+      const summary = `Visitors: ${entries.length} recorded; ${emails.size} in policy. Drift: ${unmanaged.length} unmanaged, ${missing} missing from policy.`;
+      const lines = [summary];
+      const rows = entries
+        .toSorted((a, b) => a.key.localeCompare(b.key))
+        .map(({ value: grant }) => {
+          const state = !emails.has(grant.email)
+            ? "MISSING FROM POLICY"
+            : grant.expiresAt !== null && grant.expiresAt <= Date.now()
+              ? "EXPIRED; awaiting sweep"
+              : "managed";
+          return `${grant.email} | ${grant.githubLogin ? `@${grant.githubLogin}` : "GitHub unknown"} | invited ${new Date(grant.createdAt).toISOString()} | expires ${expiryText(grant.expiresAt)} | ${state}`;
+        });
+      rows.push(
+        ...unmanaged.map(
+          (email) => `${email} | UNMANAGED: no KV record; retained until explicit revoke.`,
+        ),
+      );
+      let length = summary.length;
+      let shown = 0;
+      for (const row of rows.slice(0, this.config.maxVisitors)) {
+        if (length + row.length + 1 > LIST_MAX_CHARS - 120) {
+          break;
+        }
+        lines.push(row);
+        length += row.length + 1;
+        shown++;
+      }
+      if (shown < rows.length) {
+        lines.push(
+          `${rows.length - shown} entries omitted by output limits. Inspect the Access policy and revoke by explicit email.`,
+        );
+      }
+      return lines.join("\n");
+    });
+  }
+
+  sweep(): Promise<void> {
+    return this.serialize(async () => {
+      const entries = await this.store.entries();
+      const expired = new Set(
+        entries
+          .filter(({ value }) => value.expiresAt !== null && value.expiresAt <= Date.now())
+          .map((entry) => entry.key),
+      );
+      const managed = new Set(entries.map((entry) => entry.key));
+      await this.policy.update((emails) => {
+        for (const email of emails) {
+          if (!managed.has(email)) {
+            this.logger.warn(`visitor-access: unmanaged policy email ${email}; retained.`);
+          }
+        }
+        for (const { key } of entries) {
+          if (!emails.includes(key) && !expired.has(key)) {
+            this.logger.warn(
+              `visitor-access: ${key} is recorded but missing from policy; invite again to restore access or revoke to remove the record.`,
+            );
+          }
+        }
+        return emails.filter((email) => !expired.has(email));
+      });
+      for (const email of expired) {
+        await this.store.delete(email);
+        this.logger.info(`visitor-access: expired grant removed for ${email}.`);
+      }
+    });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -340,6 +340,7 @@
     "!dist/extensions/twitch/**",
     "!dist/extensions/venice/**",
     "!dist/extensions/vercel-ai-gateway/**",
+    "!dist/extensions/visitor-access/**",
     "!dist/extensions/voice-call/**",
     "!dist/extensions/volcengine/**",
     "!dist/extensions/voyage/**",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1987,6 +1987,19 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/visitor-access:
+    dependencies:
+      typebox:
+        specifier: 1.3.16
+        version: 1.3.16
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/voice-call:
     dependencies:
       typebox:

--- a/src/plugins/contracts/boundary-invariants.test.ts
+++ b/src/plugins/contracts/boundary-invariants.test.ts
@@ -25,6 +25,7 @@ const BUNDLED_TYPED_HOOK_REGISTRATION_FILES = [
   "extensions/memory-core/src/dreaming.ts",
   "extensions/memory-lancedb/index.ts",
   "extensions/onepassword/index.ts",
+  "extensions/visitor-access/index.ts",
   "extensions/workboard/index.ts",
 ] as const;
 const BUNDLED_TYPED_HOOK_REGISTRATION_GUARDS = {
@@ -40,6 +41,7 @@ const BUNDLED_TYPED_HOOK_REGISTRATION_GUARDS = {
   "extensions/memory-core/index.ts": ["before_agent_reply", "before_prompt_build"],
   "extensions/memory-lancedb/index.ts": ["agent_end", "before_prompt_build", "session_end"],
   "extensions/onepassword/index.ts": ["before_tool_call", "tool_result_persist"],
+  "extensions/visitor-access/index.ts": ["gateway_start"],
   "extensions/workboard/index.ts": ["agent_end", "gateway_start", "gateway_stop", "subagent_ended"],
 } as const satisfies Record<
   (typeof BUNDLED_TYPED_HOOK_REGISTRATION_FILES)[number],


### PR DESCRIPTION
## What Problem This Solves

team.openclaw.ai sits behind Cloudflare Access with a single allow policy: membership in the openclaw GitHub org. There is no way to let a non-org member in — no visitor tier, no expiry, no operator surface. Granting someone temporary access today means hand-editing the Access app in the Cloudflare dashboard and remembering to undo it.

The gateway side of visitor support already shipped: `gateway.roles` with `default: "guest"` gives unknown authenticated users view-only access to others' sessions, a single allowed agent, and forced per-principal sandboxing (#128548, #129926, #130229, #131147, #131156). What was missing was the front door.

## Why This Change Was Made

This adds `extensions/visitor-access`, an **internal** plugin (monorepo, excluded from the npm release via the `files` exclusion; `"private": true` following the `qa-channel` pattern). Because team builds from source, landing on main deploys it there via the hourly updater with no packaging work.

Mechanism: the plugin manages exactly one app-scoped Access allow-policy — an email include-list found strictly by its configured name. Access ORs allow policies, so the maintainer org policy is never read, written, or reordered. Visitors authenticate with their own GitHub account: the GitHub IdP authenticates any GitHub account (the org restriction lives in the policy, not the IdP), so no IdP changes are needed and `auto_redirect_to_identity` stays on — zero UX change for maintainers.

Three agent tools: `visitor_invite` (email or GitHub login; public-email resolution with an actionable error when the email is private; default 14-day expiry, `forever` must be explicit), `visitor_revoke`, `visitor_list` (includes drift reporting). Grants live in the plugin keyed store; an hourly sweep plus gateway-start sweep removes expired emails from the policy. Records are persisted before the Cloudflare write so a lost API response still leaves a cleanup record for the next sweep. All policy mutations reread fresh state first, so dashboard edits between calls are preserved; emails added by hand in the dashboard are reported as unmanaged and never auto-deleted.

Trust model (also in the README): plugin tools are not in the sandbox tool allowlist and guest sessions are always sandboxed, so guests cannot reach these tools; anyone who can drive an unsandboxed session (maintainers, by role policy) can manage visitors. The API token is config-supplied and redacted from all error text.

## User Impact

Maintainer-only, team-infrastructure feature. Not part of the npm release; no user-facing OpenClaw behavior changes. Operators of other deployments can enable it with their own Cloudflare account/app IDs.

## Evidence

- 45 tests across 3 files (`pnpm test extensions/visitor-access`), covering create-if-missing, tamper refusal (non-allow decision, non-email rules, duplicate policy names), invite idempotency and expiry refresh, private-email guidance, maxVisitors cap, revoke by login/email, sweep expiry vs unmanaged retention.
- **Live proof against the production team Access app** using the plugin's own client: initial read absent → invite creates the policy with the test email (verified by independent reread, policy id `0b9863cf…`) → revoke empties and deletes the policy → final read absent. App state verified byte-identical afterward: one policy (`OpenClaw Maintainers (org)=allow`), same IdP allowlist, autoredirect unchanged.
- `CI=true pnpm check:changed` exit 0; `pnpm build` exit 0 with dist entrypoints present and no `INEFFECTIVE_DYNAMIC_IMPORT`; oxlint clean; autoreview clean.
- Deliberately not built (stated non-goals in README): signup/request queue, IdP management, SecretRef deep resolution.
