### PR TITLE
refactor(macos): simplify readiness bookkeeping and discovery parsing

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
@@ -145,7 +145,6 @@ final class GatewayProcessManager {
     private var launchAgentEnableTask: Task<[UInt64: LaunchAgentEnableResult], Never>?
     private var launchAgentEnableCurrentRequest: LaunchAgentEnableRequest?
     private var launchAgentEnablePendingRequest: LaunchAgentEnableRequest?
-    private var launchAgentEnableSupersededInvocationIDs: Set<UInt64> = []
     private var launchAgentEnableNextInvocationID: UInt64 = 0
     private var launchAgentDisableTask: Task<Void, Never>?
     private var launchAgentDisableGeneration: UInt64?
@@ -252,9 +251,6 @@ final class GatewayProcessManager {
                 // older queued change so A -> B -> A cannot finish on B.
                 current.invocationIDs.append(invocationID)
                 self.launchAgentEnableCurrentRequest = current
-                if let pending = self.launchAgentEnablePendingRequest {
-                    self.launchAgentEnableSupersededInvocationIDs.formUnion(pending.invocationIDs)
-                }
                 self.launchAgentEnablePendingRequest = nil
             } else if var pending = self.launchAgentEnablePendingRequest,
                       pending.hasSameConfiguration(as: request)
@@ -262,16 +258,12 @@ final class GatewayProcessManager {
                 pending.invocationIDs.append(invocationID)
                 self.launchAgentEnablePendingRequest = pending
             } else {
-                if let pending = self.launchAgentEnablePendingRequest {
-                    self.launchAgentEnableSupersededInvocationIDs.formUnion(pending.invocationIDs)
-                }
                 self.launchAgentEnablePendingRequest = request
             }
             let results = await task.value
             return results[invocationID] ?? .skipped
         }
 
-        self.launchAgentEnableSupersededInvocationIDs.removeAll(keepingCapacity: true)
         self.launchAgentEnablePendingRequest = request
         let task = Task { @MainActor in
             await self.drainLaunchAgentEnableRequests()
@@ -295,7 +287,6 @@ final class GatewayProcessManager {
         var results: [UInt64: LaunchAgentEnableResult] = [:]
         while let request = self.launchAgentEnablePendingRequest {
             self.launchAgentEnablePendingRequest = nil
-            self.launchAgentEnableSupersededInvocationIDs.subtract(request.invocationIDs)
             self.launchAgentEnableCurrentRequest = request
             let result = await self.performLaunchAgentEnable(request)
             let completedRequest = self.launchAgentEnableCurrentRequest ?? request
@@ -304,11 +295,6 @@ final class GatewayProcessManager {
             }
             self.launchAgentEnableCurrentRequest = nil
         }
-        for invocationID in self.launchAgentEnableSupersededInvocationIDs {
-            guard results[invocationID] == nil else { continue }
-            results[invocationID] = .skipped
-        }
-        self.launchAgentEnableSupersededInvocationIDs.removeAll(keepingCapacity: true)
         // Clear the task before returning. A later caller then starts a fresh drain instead of
         // joining a completed task after the final pending-request check.
         self.launchAgentEnableTask = nil
@@ -937,11 +923,7 @@ extension GatewayProcessManager {
 
     private func probeFailureDisposition(_ error: Error) -> GatewayProbeFailureDisposition {
         if self.probeFailureIsCancellation(error) { return .retryWithoutRepair }
-        if let response = error as? GatewayResponseError,
-           response.code.uppercased() == "UNAVAILABLE"
-        {
-            return .retryWithoutRepair
-        }
+        if self.probeFailureShowsStartupProgress(error) { return .retryWithoutRepair }
         if error is GatewayHealthProbeTimeout { return .retryWithRepair }
         let nsError = error as NSError
         guard nsError.domain == NSURLErrorDomain else { return .fail }

--- a/apps/macos/Sources/OpenClawDiscovery/GatewayDiscoveryModel.swift
+++ b/apps/macos/Sources/OpenClawDiscovery/GatewayDiscoveryModel.swift
@@ -469,55 +469,29 @@ public final class GatewayDiscoveryModel {
     }
 
     public static func parseGatewayTXT(_ txt: [String: String]) -> GatewayTXT {
-        var lanHost: String?
-        var tailnetDns: String?
-        var sshPort = 22
-        var gatewayPort: Int?
-        var gatewayTls = false
-        var gatewayDirectReachable = false
-        var cliPath: String?
+        func nonEmptyString(_ key: String) -> String? {
+            guard let value = txt[key]?.trimmingCharacters(in: .whitespacesAndNewlines) else { return nil }
+            return value.isEmpty ? nil : value
+        }
 
-        if let value = txt["lanHost"] {
-            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-            lanHost = trimmed.isEmpty ? nil : trimmed
+        func positiveInteger(_ key: String) -> Int? {
+            guard let value = nonEmptyString(key), let parsed = Int(value), parsed > 0 else { return nil }
+            return parsed
         }
-        if let value = txt["tailnetDns"] {
-            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-            tailnetDns = trimmed.isEmpty ? nil : trimmed
-        }
-        if let value = txt["sshPort"],
-           let parsed = Int(value.trimmingCharacters(in: .whitespacesAndNewlines)),
-           parsed > 0
-        {
-            sshPort = parsed
-        }
-        if let value = txt["gatewayPort"],
-           let parsed = Int(value.trimmingCharacters(in: .whitespacesAndNewlines)),
-           parsed > 0
-        {
-            gatewayPort = parsed
-        }
-        if let value = txt["gatewayTls"] {
-            let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-            gatewayTls = normalized == "1" || normalized == "true" || normalized == "yes"
-        }
-        if let value = txt["gatewayDirectReachable"] {
-            let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-            gatewayDirectReachable = normalized == "1" || normalized == "true" || normalized == "yes"
-        }
-        if let value = txt["cliPath"] {
-            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-            cliPath = trimmed.isEmpty ? nil : trimmed
+
+        func booleanValue(_ key: String) -> Bool {
+            guard let normalized = nonEmptyString(key)?.lowercased() else { return false }
+            return normalized == "1" || normalized == "true" || normalized == "yes"
         }
 
         return GatewayTXT(
-            lanHost: lanHost,
-            tailnetDns: tailnetDns,
-            sshPort: sshPort,
-            gatewayPort: gatewayPort,
-            gatewayTls: gatewayTls,
-            gatewayDirectReachable: gatewayDirectReachable,
-            cliPath: cliPath)
+            lanHost: nonEmptyString("lanHost"),
+            tailnetDns: nonEmptyString("tailnetDns"),
+            sshPort: positiveInteger("sshPort") ?? 22,
+            gatewayPort: positiveInteger("gatewayPort"),
+            gatewayTls: booleanValue("gatewayTls"),
+            gatewayDirectReachable: booleanValue("gatewayDirectReachable"),
+            cliPath: nonEmptyString("cliPath"))
     }
 
     public static func buildSSHTarget(user: String, host: String, port: Int) -> String {

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayDiscoveryModelTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayDiscoveryModelTests.swift
@@ -108,15 +108,40 @@ struct GatewayDiscoveryModelTests {
         #expect(parsed.gatewayTls)
         #expect(parsed.gatewayDirectReachable)
         #expect(parsed.cliPath == "/opt/openclaw")
+
+        let portCases: [(String, Int?)] = [
+            ("", nil), (" \t\n", nil), ("0", nil), ("-1", nil), ("nope", nil), ("1.5", nil),
+            ("1", 1), (" 2222 ", 2222), ("18799", 18799), ("65535", 65535),
+            ("\t65536\n", 65536), ("+70000", 70000),
+        ]
+        for (value, expected) in portCases {
+            let ports = GatewayDiscoveryModel.parseGatewayTXT(["sshPort": value, "gatewayPort": value])
+            #expect(ports.sshPort == (expected ?? 22))
+            #expect(ports.gatewayPort == expected)
+        }
+        let booleanCases = [
+            ("1", true), (" true ", true), (" yes ", true), ("\tTrUe\n", true), (" YES ", true),
+            ("", false), (" \t\n", false), ("0", false), ("false", false), ("no", false),
+            ("on", false), ("2", false), ("trueish", false),
+        ]
+        for (value, expected) in booleanCases {
+            let flags = GatewayDiscoveryModel.parseGatewayTXT([
+                "gatewayTls": value,
+                "gatewayDirectReachable": value,
+            ])
+            #expect(flags.gatewayTls == expected)
+            #expect(flags.gatewayDirectReachable == expected)
+        }
     }
 
-    @Test func `parses gateway TXT defaults`() {
-        let parsed = GatewayDiscoveryModel.parseGatewayTXT([
-            "lanHost": "  ",
-            "tailnetDns": "\n",
-            "gatewayPort": "nope",
-            "sshPort": "nope",
-        ])
+    @Test(arguments: [nil, "", " \t\r\n"] as [String?])
+    func `parses gateway TXT defaults`(_ value: String?) {
+        let fields = [
+            "lanHost", "tailnetDns", "sshPort", "gatewayPort",
+            "gatewayTls", "gatewayDirectReachable", "cliPath",
+        ]
+        let parsed = GatewayDiscoveryModel.parseGatewayTXT(
+            Dictionary(uniqueKeysWithValues: fields.map { ($0, value) }).compactMapValues { $0 })
         #expect(parsed.lanHost == nil)
         #expect(parsed.tailnetDns == nil)
         #expect(parsed.sshPort == 22)

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
@@ -265,7 +265,7 @@ struct GatewayProcessManagerTests {
                 !GatewayLaunchAgentManager.testingDaemonCommandCallsSnapshot().isEmpty
             }
             let stale = Task { @MainActor in
-                await manager._testEnableLaunchAgentIfNeeded(
+                await manager._testEnableLaunchAgentIfNeededInstalled(
                     bundlePath: "/Applications/OpenClaw.app",
                     port: stalePort)
             }
@@ -279,7 +279,7 @@ struct GatewayProcessManagerTests {
                     port: newestPort)
             }
             #expect(await current.value == nil)
-            #expect(await stale.value == nil)
+            #expect(await stale.value == false)
             #expect(await newest.value == nil)
 
             let finalInstallPorts = GatewayLaunchAgentManager.testingDaemonCommandCallsSnapshot()
@@ -410,12 +410,7 @@ struct GatewayProcessManagerTests {
         let port = 19099
         let url = try #require(URL(string: "ws://example.invalid"))
         let (_, connection, manager) = self.makeGatewayReadinessFixture(url: url) {
-            GatewayTestWebSocketTask(
-                sendHook: { task, message, sendIndex in
-                    guard sendIndex > 0 else { return }
-                    guard let id = GatewayWebSocketTestSupport.requestID(from: message) else { return }
-                    task.emitReceiveSuccess(.data(GatewayWebSocketTestSupport.okResponseData(id: id)))
-                })
+            self.gatewayTask(healthSucceedsAfter: 0)
         }
         let descriptor = self.gatewayDescriptor(pid: 4242)
 
@@ -803,12 +798,7 @@ struct GatewayProcessManagerTests {
     @Test func `routine readiness preserves an attached gateway and control channel`() async throws {
         let url = try #require(URL(string: "ws://127.0.0.1:9"))
         let (_, connection, manager) = self.makeGatewayReadinessFixture(url: url) {
-            GatewayTestWebSocketTask(
-                sendHook: { task, message, sendIndex in
-                    guard sendIndex > 0 else { return }
-                    guard let id = GatewayWebSocketTestSupport.requestID(from: message) else { return }
-                    task.emitReceiveSuccess(.data(GatewayWebSocketTestSupport.okResponseData(id: id)))
-                })
+            self.gatewayTask(healthSucceedsAfter: 0)
         }
         manager.setTestingDesiredActive(true)
         manager.setTestingLastFailureReason("health failed")
@@ -843,12 +833,7 @@ struct GatewayProcessManagerTests {
         let port = try self.availableGatewayPort()
         let url = try #require(URL(string: "ws://example.invalid"))
         let (_, connection, manager) = self.makeGatewayReadinessFixture(url: url) {
-            GatewayTestWebSocketTask(
-                sendHook: { task, message, sendIndex in
-                    guard sendIndex > 0 else { return }
-                    guard let id = GatewayWebSocketTestSupport.requestID(from: message) else { return }
-                    task.emitReceiveSuccess(.data(GatewayWebSocketTestSupport.okResponseData(id: id)))
-                })
+            self.gatewayTask(healthSucceedsAfter: 0)
         }
 
         try await self.withLaunchAgentEnvironment(
@@ -929,12 +914,7 @@ struct GatewayProcessManagerTests {
         let port = GatewayEnvironment.gatewayPort()
         let url = try #require(URL(string: "ws://127.0.0.1:9"))
         let (_, connection, manager) = self.makeGatewayReadinessFixture(url: url) {
-            GatewayTestWebSocketTask(
-                sendHook: { task, message, sendIndex in
-                    guard sendIndex > 0 else { return }
-                    guard let id = GatewayWebSocketTestSupport.requestID(from: message) else { return }
-                    task.emitReceiveSuccess(.data(GatewayWebSocketTestSupport.okResponseData(id: id)))
-                })
+            self.gatewayTask(healthSucceedsAfter: 0)
         }
         let descriptor = self.gatewayDescriptor(pid: 4242)
 


### PR DESCRIPTION
## What Problem This Solves

The native Gateway readiness/discovery owners retained duplicate representations of the same decisions: superseded launch requests were tracked separately even though both result consumers already resolve missing results as skipped, and TXT fields repeated the same parsing rules. This is a bounded maintainability follow-up, not a new readiness behavior or a replacement for signed-app proof.

## Why This Change Was Made

Remove the superseded-invocation set and its maintenance, keeping the existing per-invocation result dictionary as the canonical result flow. Reuse the existing `UNAVAILABLE` classifier, consolidate TXT parsing into reused function-local operations, and replace four copied successful-health hooks with the existing fixture.

The current/pending request queue, A→B→A coalescing, generation/revision authority, PID ownership, cancellation ordering, retries, failure publication, and cleanup remain unchanged. The outer typed health deadline and its `timeoutMs: 0`/`retryTransportFailures: false` request are byte-identical. Discovery initialization and `start()`/`stop()` lifecycle code are also byte-identical.

## User Impact

No intended user-visible behavior change and no new configuration, API, dependency, persistence, or protocol surface. TXT parsing retains SSH port 22 by default, optional Gateway ports, positive-`Int` acceptance (including values above 65535), trimmed strings, and the existing `1`/`true`/`yes` boolean rules.

Production changes are **+19/−63 (net −44 lines)**. Tests are **+38/−33 (net +5 lines)**: shared fixtures remove duplication while public-entry preservation cases cover the parser and superseded-caller result. Overall net −39 lines.

## Evidence

The strengthened preservation tests passed on baseline production before the refactor, then passed again after it: **104 tests across five native suites**, including Gateway process management, launch-agent management, discovery, and control connections. These are behavior-preservation tests, not claimed before-fix failures.

The existing queued-change/A→B→A scenario now verifies that the discarded request reports `installed == false`. Parser cases cover missing/blank values, invalid/zero/negative/positive-above-65535 ports, and mixed-case truthy/false inputs. Existing ordering, cancellation, PID replacement, attachment, and lifecycle assertions remain.

Fresh Codex-backed autoreview completed clean with no findings; the final patch matches its frozen review input. Release compilation of `OpenClaw` passed (511.16s), proving production builds without DEBUG test helpers. Focused SwiftFormat/strict SwiftLint checks passed. The repository changed-check gate also passed, including **508 additional tests across seven Vitest shards** and the native schema guard. Both SwiftPM lockfiles are unchanged.

Recorded commands below normalize only the task-owned external scratch root to `$PROOF_ROOT`:

```bash
swift test --package-path apps/macos --scratch-path "$PROOF_ROOT/.build" --cache-path "$PROOF_ROOT/swift-cache" --force-resolved-versions --skip-update --build-system native --parallel --filter 'GatewayProcessManagerTests|GatewayLaunchAgentManagerTests|GatewayDiscoveryModelTests|GatewayConnectionControlTests'
```

```bash
swift build --package-path apps/macos --scratch-path "$PROOF_ROOT/.build" --cache-path "$PROOF_ROOT/swift-cache" --force-resolved-versions --skip-update --build-system native --product OpenClaw --configuration release
```

```bash
PATH="$PROOF_ROOT/swift-tools:$PATH" node scripts/check-changed.mjs -- apps/macos/Sources/OpenClaw/GatewayProcessManager.swift apps/macos/Sources/OpenClawDiscovery/GatewayDiscoveryModel.swift apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift apps/macos/Tests/OpenClawIPCTests/GatewayDiscoveryModelTests.swift
```

```bash
git diff --check
```

Initial attempts stopped before test execution: dependency resolution required the canonical `.build/checkouts` scratch layout, and the Xcode beta default build engine produced an XCTest bundle unable to load Sparkle. SwiftPM's native build engine passed with the same compiler, package pins, assertions, and parallel execution; no loader override or bundle patch was used. The first changed-check attempt rejected host SwiftLint 0.65.1, so repository-pinned 0.65.0 was installed into task scratch and the gate was rerun successfully.

**Proof limits:** no signed product app or real Gateway was launched for this behavior-neutral follow-up. The earlier signed-app readiness/recovery UI proof remains blocked on a clean stock-security macOS GUI environment; native tests and synthetic peers do not satisfy that proof. No operator Gateway, global tunnel ledger, saved credential, VM, or unrelated service was changed.
