### PR TITLE
fix(release): distinguish CSS colors from issue references

### DIFF
--- a/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
+++ b/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
@@ -479,28 +479,28 @@ function sectionFor(changelog, version) {
 }
 
 function referencesIn(text) {
-  const references = [];
-  for (const match of text.matchAll(
-    /(?<![A-Za-z0-9_.&-])(?:(?<owner>[A-Za-z0-9_.-]+)\/(?<name>[A-Za-z0-9_.-]+))?#(?<number>\d+)/g,
-  )) {
-    const qualifiedRepository = match.groups?.owner
-      ? `${match.groups.owner}/${match.groups.name}`.toLowerCase()
-      : undefined;
-    if (!qualifiedRepository || qualifiedRepository === repo) {
-      references.push(Number(match.groups?.number));
-    }
-  }
-  return references;
+  return referenceLabelsIn(text)
+    .filter((reference) => reference.startsWith("#"))
+    .map((reference) => Number(reference.slice(1)));
 }
 
 function referenceLabelsIn(text) {
+  const hexColor = String.raw`#(?:[A-Fa-f0-9]{8}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{4}|[A-Fa-f0-9]{3})(?![A-Za-z0-9_])`;
+  // Mask only custom-property color values/transitions, never the rest of a line:
+  // a following issue ref must still participate in release attribution.
+  const source = text.replace(
+    new RegExp(
+      String.raw`--[\w-]+(?:[ \t]*:[ \t]*|[ \t]+)${hexColor}(?:[ \t]*(?:->|→)[ \t]*${hexColor})*`,
+      "g",
+    ),
+    " ",
+  );
   const labels = [];
-  for (const match of text.matchAll(
-    /(?<![A-Za-z0-9_.&-])(?:(?<owner>[A-Za-z0-9_.-]+)\/(?<name>[A-Za-z0-9_.-]+))?#(?<number>\d+)/g,
+  // Issue ids are complete positive decimal tokens, not hex prefixes or zero-padded colors.
+  for (const match of source.matchAll(
+    /(?<![A-Za-z0-9_.&-])(?<repository>[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)?#(?<number>[1-9]\d*)(?![A-Za-z0-9_])/g,
   )) {
-    const qualifiedRepository = match.groups?.owner
-      ? `${match.groups.owner}/${match.groups.name}`
-      : undefined;
+    const qualifiedRepository = match.groups?.repository;
     labels.push(
       !qualifiedRepository || qualifiedRepository.toLowerCase() === repo
         ? `#${match.groups?.number}`
@@ -2280,23 +2280,22 @@ export function ledgerChecks(section, pullRequests, nodes, directCommits, shippe
     }
   }
   const editorialProse = section.source.slice(0, ledgerStart);
+  const editorialReferences = new Set(referencesIn(editorialProse));
   for (const entry of pullRequests) {
-    if (
-      !entry.editorialEligible &&
-      new RegExp(`(?<![A-Za-z0-9_./-])#${entry.number}\\b`).test(editorialProse)
-    ) {
+    if (!entry.editorialEligible && editorialReferences.has(entry.number)) {
       errors.push(
         `editorial release prose references non-editorial ${entry.type} PR #${entry.number} (${entry.type})`,
       );
     }
   }
   const editorialLines = editorialProse.split("\n");
-  for (const entry of pullRequests) {
-    for (const line of editorialLines) {
-      if (
-        !new RegExp(`(?<![A-Za-z0-9_./-])#${entry.number}\\b`).test(line) ||
-        !line.startsWith("- ")
-      ) {
+  for (const line of editorialLines) {
+    if (!line.startsWith("- ")) {
+      continue;
+    }
+    const lineReferences = new Set(referencesIn(line));
+    for (const entry of pullRequests) {
+      if (!lineReferences.has(entry.number)) {
         continue;
       }
       for (const handle of entry.thanks) {
@@ -2304,11 +2303,6 @@ export function ledgerChecks(section, pullRequests, nodes, directCommits, shippe
           errors.push(`missing editorial Thanks @${handle} for PR #${entry.number}`);
         }
       }
-    }
-  }
-  for (const line of editorialLines) {
-    if (!line.startsWith("- ")) {
-      continue;
     }
     for (const handle of directCommitCreditsForLine(line, directCommits)) {
       if (!line.toLowerCase().includes(`@${handle.toLowerCase()}`)) {

--- a/test/scripts/verify-release-notes.test.ts
+++ b/test/scripts/verify-release-notes.test.ts
@@ -16,6 +16,7 @@ import {
   githubApiWithSnapshot,
   highlightCountError,
   isEligibleHandle,
+  ledgerChecks,
   parseArgs,
   persistGithubSnapshot,
   pullRequestTitleFromCommitSubject,
@@ -866,6 +867,95 @@ describe("release-note verification", () => {
     ].join("\n");
 
     expect(releaseNoteReferences(section, baselines)).toEqual([1, 3]);
+  });
+
+  it.each([
+    {
+      name: "CSS palette comparisons in a commit message",
+      source: [
+        "fix(control-ui): darken the Absolutely surface ramp (#130239)",
+        "",
+        "--bg #262624 sat above Dash #1a1210, Claw #0e1015, and Knot #080808.",
+        "Steps the ramp down (--bg #262624 -> #1c1c1a).",
+      ].join("\n"),
+      expected: [130239],
+    },
+    {
+      name: "issue refs after CSS colors on the same line",
+      source: "--bg #262624 (fixes #123), refs #1234, #123456, and #12345678.",
+      expected: [123, 1234, 123456, 12345678],
+    },
+    {
+      name: "short and alpha CSS values and numeric color transitions",
+      source:
+        "--fg: #123; --border:#1234; --bg #123456 -> #654321; --alpha: #12345678 → #87654321. (#456)",
+      expected: [456],
+    },
+    {
+      name: "qualified references beside CSS values",
+      source: "OpenClaw/OpenClaw#123 --bg #262624; openclaw/openclaw#456 and Other/Repo#123456.",
+      expected: [123, 456],
+    },
+    {
+      name: "ordinary Markdown and code references",
+      source:
+        "**PR #123**; `#456`; [#789](https://github.com/openclaw/openclaw/issues/789)\n```text\n#123456\n```\n`--bg: #262624` (#1234)",
+      expected: [123, 456, 789, 123456, 1234],
+    },
+    {
+      name: "complete numeric reference tokens",
+      source:
+        "#1a1210 #0e1015 #080808 #fff #123abc #456_def &#123; file#456; #123 #1234 #123456 #12345678",
+      expected: [123, 1234, 123456, 12345678],
+    },
+    {
+      name: "non-color custom-property prose and cross-line references",
+      source: "--bg fixes #123; --border relates to #456.\n--bg\n#789",
+      expected: [123, 456, 789],
+    },
+  ])("extracts release references from $name", ({ source, expected }) => {
+    expect(releaseNoteReferences(source, [])).toEqual(expected);
+  });
+
+  it.each([
+    { reference: "", expected: [] },
+    {
+      reference: " (fixes #262624)",
+      expected: [
+        "editorial release prose references non-editorial chore PR #262624 (chore)",
+        "missing editorial Thanks @alice for PR #262624",
+      ],
+    },
+  ])("validates editorial credit after a CSS color: '$reference'", ({ reference, expected }) => {
+    const source = [
+      "## 2026.8.1",
+      "### Highlights",
+      "- One.",
+      "- Two.",
+      "- Three.",
+      "- Four.",
+      "- Five.",
+      "### Changes",
+      "### Fixes",
+      `- Set --bg #262624${reference}.`,
+      "### Complete contribution record",
+      `This audited record covers the complete base..${"a".repeat(40)} history: 1 merged PR.`,
+      "#### Pull requests",
+      "- **PR #262624** Thanks @alice.",
+    ].join("\n");
+    const entry = {
+      number: 262624,
+      title: "chore: unrelated tooling",
+      type: "chore",
+      editorialEligible: false,
+      externalReferences: [],
+      linkedIssues: [],
+      thanks: ["alice"],
+    };
+
+    expect(
+      ledgerChecks({ source }, [entry], new Map([[262624, { __typename: "PullRequest" }]]), []),
+    ).toEqual(expected);
   });
 
   it("records a canonical target SHA when --target is symbolic", () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where release-note verification treated CSS hex colors in commit messages as issue references, causing false unresolved-reference and contributor-credit errors. The actual palette-change commit a868258156a6708dd798deb3d43d3a4277a4d511 produced seven references instead of its single PR reference.

## Why This Change Was Made

Use one canonical scanner for reference numbers, labels, and editorial checks. Exclude only immediate CSS custom-property hex values and explicit color transitions; retain genuine references later on the same line, qualified references, and references inside Markdown/code. This replaces duplicated scanners and editorial regexes. The release-only workaround discarded legitimate later references and is superseded by this repair.

No dependencies, configuration, versions, tags, release selectors, publication, or changelog generation changes. This is a bounded maintainer-requested release-tooling repair. AI-assisted.

## User Impact

Maintainers can verify release history containing CSS color descriptions without losing actual issue references or attributing colors to contributors. Unmarked positive numeric hashes remain issue references; this deliberately does not attempt to parse arbitrary CSS.

## Evidence

Before the repair, the actual commit body returned `[130239,262624,1,0,80808,262624,1]`; now it returns `[130239]`. `--bg #262624 (fixes #123)` now returns `[123]`; the earlier release-only workaround returned no references. A separate complete-module probe compares frozen main, the release workaround, and this source across the real commit body and same-line, qualified, numeric-length, and inline/fenced-code preservation scenarios; all five fixed-source scenarios pass.

```sh
node scripts/run-vitest.mjs test/scripts/verify-release-notes.test.ts test/scripts/release-notes-ledger.test.ts
```

54 tests passed (41 verifier, 13 ledger), including four real CLI subprocess cases. The new scanner regressions failed on unchanged production; the new editorial regression separately reproduced false eligibility/credit errors before repair. Scoped formatting, lint, syntax, and test type checks passed. Fresh complete-diff Codex autoreview reported no accepted/actionable findings at its default P0 threshold; no source changes followed review.

Local full changed-gate proof is not claimed: the inherited dependency installation is stale and its pinned pnpm launcher is missing. Hosted CI must provide the dependency-correct gates before native landing. No dependencies were patched to accommodate the host.

Production tooling: +26/-32 (net -6). Tests: +90/-0. Removed one duplicate extraction loop, two editorial regex checks, and one duplicate line loop. CSS hex lengths follow the [CSS Color specification](https://www.w3.org/TR/css-color-4/#hex-notation).

Provenance: the decimal-prefix scanner originates in f684527085ebeeeff0de13e62decb0c5b1bd4457 (Vincent Koc, June 17); later repository qualification and entity handling retained it. The duplicate label scanner was added in #103222. Existing malformed closing-keyword tokenization is a named follow-up: `closingReferencesIn` can truncate `fixes #123abc` before canonical scanning. This repair covers color/reference ownership without changing closing-keyword syntax.

Exact-head hosted CI completed successfully on `f0239cdddb64a911a7b61df7a7b787d19fa00100`: [CI33206642775](https://github.com/openclaw/openclaw/actions/runs/33206642775), attempt 1. The draft-skipped run is excluded. Native maintainer review artifacts validated; hosted prepare/merge gates remain mandatory.
