### PR TITLE
fix(config): preserve authored model rows during sparse patches

### DIFF
--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -654,6 +654,11 @@ in `replacePaths`; nested arrays under array entries use `[]`, such as
 silently clobbering routing or allowlist arrays. Use `config.apply` when you
 intend to replace the full config.
 
+Arrays of objects with stable `id` fields merge by ID unless their path appears
+in `replacePaths`. These updates preserve authored fields in untouched entries;
+runtime defaults, such as model catalog compatibility and context budgets, are
+not saved into sibling entries. Explicitly configured values remain authoritative.
+
 ## Environment variables
 
 OpenClaw reads env vars from the parent process plus:

--- a/src/gateway/server-methods/config.test.ts
+++ b/src/gateway/server-methods/config.test.ts
@@ -753,6 +753,17 @@ describe("config.patch model input normalization", () => {
       },
     };
 
+    const sourceConfig = structuredClone(storedConfig);
+    expectDefined(sourceConfig.models?.providers?.myproxy?.models[0], "source model").id = "latest";
+    configWriteMocks.readConfigFileSnapshotForWrite.mockImplementationOnce(async () => {
+      const result = currentWriteSnapshot();
+      result.snapshot.sourceConfig = sourceConfig;
+      result.snapshot.resolved = sourceConfig;
+      result.snapshot.parsed = sourceConfig;
+      result.snapshot.raw = JSON.stringify(sourceConfig);
+      return result;
+    });
+
     const harness = await invokeConfigPatch({
       raw: {
         models: {

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -1063,11 +1063,18 @@ export const configHandlers: GatewayRequestHandlers = {
       respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, formatErrorMessage(error)));
       return;
     }
-    const merged = applyMergePatch(snapshot.config, normalizedPatch, {
+    // Merge authored rows first; merging runtime rows would persist catalog defaults
+    // from untouched siblings whenever an ID-keyed array changes.
+    const sourceConfig = normalizeSubmittedConfigModelRefs(
+      snapshot.sourceConfig,
+      modelIdNormalizationPolicies,
+    );
+    const mergedSource = applyMergePatch(sourceConfig, normalizedPatch, {
       // Arrays with stable ids behave like maps for partial control-plane edits.
       mergeObjectArraysById: true,
       replaceArrayPaths: replacePaths,
     });
+    const merged = applyMergePatch(snapshot.config, createMergePatch(sourceConfig, mergedSource));
     const schemaPatch = loadSchemaWithPlugins();
     const restoredMerge = restoreRedactedValues(merged, snapshot.config, schemaPatch.uiHints);
     if (!restoredMerge.ok) {

--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -13,7 +13,7 @@ import {
   getActiveSecretsRuntimeSnapshot,
   prepareSecretsRuntimeSnapshot,
 } from "../secrets/runtime.js";
-import { deleteTestEnvValue } from "../test-utils/env.js";
+import { deleteTestEnvValue, withEnvAsync } from "../test-utils/env.js";
 import {
   connectOk,
   installGatewayTestHooks,
@@ -644,6 +644,73 @@ describe("gateway config methods", () => {
       resetConfigRuntimeState();
     }
   });
+
+  it.each([false, true])(
+    "keeps model ID patches source-owned (authored compat: %s)",
+    async (authoredCompat) => {
+      await withEnvAsync(
+        {
+          OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
+          OPENCLAW_BUNDLED_PLUGINS_DIR: path.resolve(import.meta.dirname, "../../extensions"),
+        },
+        async () => {
+          const { resetConfigRuntimeState } = await import("../config/config.js");
+          const configIo = await import("../config/io.js");
+          const actualIo =
+            await vi.importActual<typeof import("../config/io.js")>("../config/io.js");
+          // The shared server fixture composes snapshots without catalog materialization.
+          // Exercise the real read/write owner so runtime defaults can reach the RPC merge.
+          const snapshotRead = vi
+            .spyOn(configIo, "readConfigFileSnapshotForWrite")
+            .mockImplementation(actualIo.readConfigFileSnapshotForWrite);
+          const original = await getCurrentConfigObject();
+          const textModel = {
+            id: "gpt-5.6-luna",
+            name: "Text model",
+            ...(authoredCompat ? { compat: { supportsStore: false } } : {}),
+          };
+          try {
+            await writeJsonFile(original.path, {
+              gateway: { reload: { mode: "off" } },
+              models: {
+                providers: {
+                  openai: { models: [textModel, { id: "gpt-image-1", name: "Image model" }] },
+                },
+              },
+            });
+            resetConfigRuntimeState();
+            const before = await actualIo.readConfigFileSnapshot();
+            expect(before.issues).toEqual([]);
+            const runtimeModel = before.config.models?.providers?.openai?.models[0];
+            expect(runtimeModel?.contextTokens).toBeGreaterThan(0);
+            expect(runtimeModel?.compat).toBeDefined();
+
+            const imageModel = {
+              id: "gpt-image-1",
+              name: "Image model",
+              baseUrl: "http://127.0.0.1:44080/v1",
+            };
+            const res = await rpcReq(requireWs(), "config.patch", {
+              raw: JSON.stringify({ models: { providers: { openai: { models: [imageModel] } } } }),
+              baseHash: await getConfigHash(),
+            });
+            expect(res.error).toBeUndefined();
+            expect(res.ok).toBe(true);
+            const persisted = JSON.parse(await fs.readFile(original.path, "utf-8"));
+            expect(persisted.models.providers.openai.models).toEqual([textModel, imageModel]);
+
+            const after = await actualIo.readConfigFileSnapshot();
+            expect(after.valid).toBe(true);
+            expect(after.config.models?.providers?.openai?.models[0]).toEqual(runtimeModel);
+          } finally {
+            snapshotRead.mockRestore();
+            await restoreConfigFileForTest(original);
+            resetConfigRuntimeState();
+          }
+        },
+      );
+    },
+  );
 
   it("redacts browser cdpUrl credentials from config.get responses", async () => {
     const { createConfigIO, resetConfigRuntimeState } = await import("../config/config.js");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators patching one model row would persist catalog defaults into untouched sibling rows. The public RPC succeeded while converting runtime-derived metadata into authored configuration.

## Why This Change Was Made

Normalize and merge the authored source rows first, then project that edit onto the existing runtime snapshot using the canonical merge-patch helpers. The sparse-patch API owns which entries were actually submitted. Full config.set/config.apply submissions retain their distinct whole-config contract; validation, redaction, CAS, no-op handling, hashless preferences, array safeguards and persistence remain under their existing owners.

No configuration option, schema/protocol, dependency, version, tag or release-selector change. AI-assisted.

## User Impact

Sparse model patches keep untouched authored rows sparse, preserve explicit compat settings, and continue to materialize current catalog defaults at runtime. Manifest-backed alias IDs normalize before matching, preventing duplicate rows. The configuration guide now explains this existing stable-ID contract.

## Evidence

Two schema-valid public WebSocket regressions failed before the production change: updating the image row persisted text-row context/cost/input/maxTokens/reasoning/thinking/compat defaults. Both passed unchanged after repair, including explicitly authored `supportsStore: false`, persisted disk state and rematerialized runtime metadata. The alias regression now distinguishes authored alias from canonical runtime ID.

```sh
node scripts/run-vitest.mjs src/gateway/server.config-patch.test.ts src/gateway/server-methods/config.test.ts src/gateway/server-methods/config.shared-auth.test.ts src/config/config.plugin-validation.test.ts src/config/validation.channel-metadata.test.ts src/config/merge-patch.test.ts src/config/merge-patch.proto-pollution.test.ts src/config/io.runtime-snapshot-write.test.ts
```

Clean Linux remote proof: 242 tests passed across eight files, full pnpm build passed, and the complete changed-file gate passed against frozen base 5b6ef55fc796c291469cd5b301270b87506c76b0. The first broad gate used the wrong shallow-history base and failed on unrelated paths; the corrected frozen-base invocation passed. The initial fixture-only failures are not represented as bug reproduction. Final tested-file hashes exactly match this commit. [Proof environment](https://github.com/openclaw/openclaw/actions/runs/33201433868); its lease was stopped after completed command proof. Fresh P0-threshold Codex autoreview found no accepted/actionable findings; no implementation changes followed.

The WebSocket harness uses actual config I/O, bundled manifests, public revision tokens, the persistence writer and reread, but mocks unrelated owners and sets reload.mode=off for persistence isolation. Existing hot-apply and sibling tests pass. This is not a fully unmocked standalone Gateway or provider session. No operator Gateway or live state was touched.

Production: +8/-1 (net +7); tests +79/-1; docs +5. The seven production lines preserve the authored/runtime ownership distinction before existing validation and write projection. No new helper/export, fallback or metadata denylist. Config surface added/removed: 0. Persistence behavior changed: sparse ID-array edits no longer copy runtime defaults into unedited authored rows.

Named documentation follow-up: the existing replacePaths paragraph describes shrinking arrays, although source/tests also guard removed entries without a length reduction; its nested-array example also merits correction separately.

Closes #132079.

Additional standalone proof now passes on the exact same source/build. A fresh Blacksmith environment built the full repository successfully (4m37.8s), then launched the built `openclaw.mjs gateway run` CLI with temporary home/state/workspace, an independently allocated loopback port, auth mode none, and default reload behavior. Public WebSocket config.get/config.patch succeeded; the Gateway logged successful hot reload; disk retained exactly the sparse text row with explicit supportsStore=false plus the submitted image row; rematerialized text metadata retained its 272000 context budget. The Gateway shut down cleanly. No test mocks, reload override or provider inference operation was used. [Proof environment](https://github.com/openclaw/openclaw/actions/runs/33208625690), standalone command21.51s/exit0.

The first additional local attempt timed out during startup and is not passing proof. The first clean remote attempt called startGatewayServer directly, which omitted the managed restart owner and correctly rejected applying an irreversible reload after persistence; it also exposed a source-plugin CJS/ESM import limitation. The successful retry used the normal built CLI entry point with unchanged production code and the already-proven build. No timeout, dependency, auth or native gate relaxation.

Exact-head [CI33207771878](https://github.com/openclaw/openclaw/actions/runs/33207771878) completed successfully on `4f7394bb601a5fd886e8058f43b26cee90c9b3e9`, attempt1. Draft-skipped33207743792 is excluded.
