### PR TITLE
fix(line): name the inline emoji LINE leaves as bare parentheses

### DIFF
--- a/docs/channels/line.md
+++ b/docs/channels/line.md
@@ -263,6 +263,10 @@ as untrusted.
   member who has not added the bot as a friend. If either lookup fails the raw
   id is used and the message is still delivered. Multi-person rooms have no name
   API, so they keep their room id.
+- LINE does not put an inline LINE emoji in the message text; it substitutes a
+  `()` placeholder and describes the emoji separately. Each one reaches the agent
+  as `[emoji]` so a message never arrives as bare parentheses. LINE reports no
+  name for these emoji, so they are not named individually.
 
 ## Structured rich messages
 

--- a/docs/channels/line.md
+++ b/docs/channels/line.md
@@ -263,10 +263,9 @@ as untrusted.
   member who has not added the bot as a friend. If either lookup fails the raw
   id is used and the message is still delivered. Multi-person rooms have no name
   API, so they keep their room id.
-- LINE does not put an inline LINE emoji in the message text; it substitutes a
-  `()` placeholder and describes the emoji separately. Each one reaches the agent
-  as `[emoji]` so a message never arrives as bare parentheses. LINE reports no
-  name for these emoji, so they are not named individually.
+- LINE describes inline emoji with metadata and alternative text. Empty `()`
+  alternatives reach the agent as `[emoji]`; meaningful alternatives such as
+  `(hello)` and parentheses typed by the sender are preserved.
 
 ## Structured rich messages
 

--- a/extensions/line/src/bot-handlers.test.ts
+++ b/extensions/line/src/bot-handlers.test.ts
@@ -186,7 +186,10 @@ const { buildLineMessageContextMock, buildLinePostbackContextMock } = vi.hoisted
   buildLinePostbackContextMock: vi.fn(async () => null as unknown),
 }));
 
-vi.mock("./bot-message-context.js", () => ({
+vi.mock("./bot-message-context.js", async (importOriginal) => ({
+  // Reading a LINE text body is pure and is part of the behaviour these tests
+  // exercise, so it comes from the real module rather than a stub.
+  ...(await importOriginal<typeof import("./bot-message-context.js")>()),
   buildLineMessageContext: buildLineMessageContextMock,
   buildLinePostbackContext: buildLinePostbackContextMock,
   getLineSourceInfo: (source: {

--- a/extensions/line/src/bot-handlers.test.ts
+++ b/extensions/line/src/bot-handlers.test.ts
@@ -187,7 +187,7 @@ const { buildLineMessageContextMock, buildLinePostbackContextMock } = vi.hoisted
 }));
 
 vi.mock("./bot-message-context.js", async (importOriginal) => ({
-  // Reading a LINE text body is pure and is part of the behaviour these tests
+  // Reading a LINE text body is pure and is part of the behavior these tests
   // exercise, so it comes from the real module rather than a stub.
   ...(await importOriginal<typeof import("./bot-message-context.js")>()),
   buildLineMessageContext: buildLineMessageContextMock,

--- a/extensions/line/src/bot-handlers.test.ts
+++ b/extensions/line/src/bot-handlers.test.ts
@@ -878,7 +878,16 @@ describe("handleLineWebhookEvents", () => {
     await handleLineWebhookEvents(
       [
         createTestMessageEvent({
-          message: { id: "m-hist-1", type: "text", text: "first", quoteToken: "q-hist-1" },
+          message: {
+            id: "m-hist-1",
+            type: "text",
+            text: "() (hello)",
+            quoteToken: "q-hist-1",
+            emojis: [
+              { index: 0, length: 2, productId: "emoji-set", emojiId: "1" },
+              { index: 3, length: 7, productId: "emoji-set", emojiId: "2" },
+            ],
+          },
           timestamp: 1700000000000,
           source: { type: "group", groupId: "group-hist-1", userId: "user-one" },
           webhookEventId: "evt-hist-1",
@@ -895,7 +904,7 @@ describe("handleLineWebhookEvents", () => {
 
     expect(processMessage).not.toHaveBeenCalled();
     expect(groupHistories.get("group-hist-1")).toEqual([
-      expect.objectContaining({ sender: "Sora (user-one)", body: "first" }),
+      expect.objectContaining({ sender: "Sora (user-one)", body: "[emoji] (hello)" }),
       expect.objectContaining({ sender: "Sora (user-two)", body: "second" }),
     ]);
 
@@ -920,7 +929,7 @@ describe("handleLineWebhookEvents", () => {
     expect(buildLineMessageContextMock).toHaveBeenCalledWith(
       expect.objectContaining({
         inboundHistory: [
-          expect.objectContaining({ sender: "Sora (user-one)", body: "first" }),
+          expect.objectContaining({ sender: "Sora (user-one)", body: "[emoji] (hello)" }),
           expect.objectContaining({ sender: "Sora (user-two)", body: "second" }),
         ],
       }),

--- a/extensions/line/src/bot-handlers.ts
+++ b/extensions/line/src/bot-handlers.ts
@@ -44,6 +44,7 @@ import {
   buildLineMessageContext,
   buildLinePostbackContext,
   getLineSourceInfo,
+  readLineTextMessageBody,
   type LineInboundContext,
 } from "./bot-message-context.js";
 import { downloadLineMedia, isRetryableLineInboundMediaError } from "./download.js";
@@ -351,7 +352,7 @@ function resolveEventRawText(event: MessageEvent | PostbackEvent): string {
   if (event.type === "message") {
     const msg = event.message;
     if (msg.type === "text") {
-      return msg.text;
+      return readLineTextMessageBody(msg);
     }
     return "";
   }
@@ -372,7 +373,7 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
 
   const { isGroup, groupId, roomId } = getLineSourceInfo(event.source);
   if (isGroup && decision.access.activationAccess.shouldSkip) {
-    const rawText = message.type === "text" ? message.text : "";
+    const rawText = message.type === "text" ? readLineTextMessageBody(message) : "";
     const sourceInfo = getLineSourceInfo(event.source);
     logVerbose(`line: skipping group message (requireMention, not mentioned)`);
     const historyKey = groupId ?? roomId;

--- a/extensions/line/src/bot-message-context.test.ts
+++ b/extensions/line/src/bot-message-context.test.ts
@@ -14,7 +14,11 @@ import {
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { lineBindingsAdapter } from "./bindings.js";
-import { buildLineMessageContext, buildLinePostbackContext } from "./bot-message-context.js";
+import {
+  buildLineMessageContext,
+  buildLinePostbackContext,
+  readLineTextMessageBody,
+} from "./bot-message-context.js";
 import type { ResolvedLineAccount } from "./types.js";
 
 const logVerboseMock = vi.hoisted(() => vi.fn());
@@ -883,5 +887,96 @@ describe("buildLineMessageContext", () => {
       "U47f0bbc534dc503c4e4cadc86e619b63",
       expect.objectContaining({ groupId: "C5aeb18d690759492f1a8c391c37549a0" }),
     );
+  });
+
+  it("names an inline LINE emoji in the body the agent reads", async () => {
+    const event = createMessageEvent(
+      { type: "user", userId: "U1234567890abcdef1234567890abcdef" },
+      {
+        message: {
+          id: "1",
+          type: "text",
+          text: "()hello",
+          quoteToken: "quote-token",
+          emojis: [{ index: 0, length: 2, productId: "670e0cce840a8236ddd4ee4c", emojiId: "130" }],
+        },
+      },
+    );
+
+    const context = await buildLineMessageContext({
+      event,
+      allMedia: [],
+      cfg,
+      account,
+      commandAuthorized: true,
+    });
+
+    expect(context?.ctxPayload.BodyForAgent).toBe("[emoji]hello");
+    expect(context?.ctxPayload.RawBody).toBe("[emoji]hello");
+  });
+});
+
+describe("readLineTextMessageBody", () => {
+  const emojiBodyCases: {
+    name: string;
+    message: webhook.TextMessageContent;
+    expected: string;
+  }[] = [
+    {
+      name: "names the placeholder a LINE emoji leaves in the text",
+      message: {
+        id: "1",
+        type: "text",
+        text: "()hello",
+        quoteToken: "quote-token",
+        emojis: [{ index: 0, length: 2, productId: "670e0cce840a8236ddd4ee4c", emojiId: "130" }],
+      },
+      expected: "[emoji]hello",
+    },
+    {
+      name: "reads offsets as UTF-16 code units, not codepoints",
+      message: {
+        id: "1",
+        type: "text",
+        text: "\u{1F602}()",
+        quoteToken: "quote-token",
+        emojis: [{ index: 2, length: 2, productId: "670e0cce840a8236ddd4ee4c", emojiId: "123" }],
+      },
+      expected: "\u{1F602}[emoji]",
+    },
+    {
+      name: "names every emoji the message carries",
+      message: {
+        id: "1",
+        type: "text",
+        text: "()a()",
+        quoteToken: "quote-token",
+        emojis: [
+          { index: 0, length: 2, productId: "670e0cce840a8236ddd4ee4c", emojiId: "1" },
+          { index: 3, length: 2, productId: "670e0cce840a8236ddd4ee4c", emojiId: "2" },
+        ],
+      },
+      expected: "[emoji]a[emoji]",
+    },
+    {
+      name: "leaves parentheses the sender typed themselves alone",
+      message: {
+        id: "1",
+        type: "text",
+        text: "call foo() now ()",
+        quoteToken: "quote-token",
+        emojis: [{ index: 15, length: 2, productId: "670e0cce840a8236ddd4ee4c", emojiId: "1" }],
+      },
+      expected: "call foo() now [emoji]",
+    },
+    {
+      name: "leaves text alone when LINE reports no emoji",
+      message: { id: "1", type: "text", text: "()", quoteToken: "quote-token" },
+      expected: "()",
+    },
+  ];
+
+  it.each(emojiBodyCases)("$name", ({ message, expected }) => {
+    expect(readLineTextMessageBody(message)).toBe(expected);
   });
 });

--- a/extensions/line/src/bot-message-context.test.ts
+++ b/extensions/line/src/bot-message-context.test.ts
@@ -14,11 +14,7 @@ import {
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { lineBindingsAdapter } from "./bindings.js";
-import {
-  buildLineMessageContext,
-  buildLinePostbackContext,
-  readLineTextMessageBody,
-} from "./bot-message-context.js";
+import { buildLineMessageContext, buildLinePostbackContext } from "./bot-message-context.js";
 import type { ResolvedLineAccount } from "./types.js";
 
 const logVerboseMock = vi.hoisted(() => vi.fn());
@@ -889,94 +885,64 @@ describe("buildLineMessageContext", () => {
     );
   });
 
-  it("names an inline LINE emoji in the body the agent reads", async () => {
-    const event = createMessageEvent(
-      { type: "user", userId: "U1234567890abcdef1234567890abcdef" },
-      {
-        message: {
-          id: "1",
-          type: "text",
-          text: "()hello",
-          quoteToken: "quote-token",
-          emojis: [{ index: 0, length: 2, productId: "670e0cce840a8236ddd4ee4c", emojiId: "130" }],
-        },
-      },
-    );
-
-    const context = await buildLineMessageContext({
-      event,
-      allMedia: [],
-      cfg,
-      account,
-      commandAuthorized: true,
-    });
-
-    expect(context?.ctxPayload.BodyForAgent).toBe("[emoji]hello");
-    expect(context?.ctxPayload.RawBody).toBe("[emoji]hello");
-  });
-});
-
-describe("readLineTextMessageBody", () => {
-  const emojiBodyCases: {
-    name: string;
-    message: webhook.TextMessageContent;
-    expected: string;
-  }[] = [
+  it.each([
+    { text: "()hello", spans: [[0, 2]], expected: "[emoji]hello" },
+    { text: "(hello)", spans: [[0, 7]], expected: "(hello)" },
     {
-      name: "names the placeholder a LINE emoji leaves in the text",
-      message: {
-        id: "1",
-        type: "text",
-        text: "()hello",
-        quoteToken: "quote-token",
-        emojis: [{ index: 0, length: 2, productId: "670e0cce840a8236ddd4ee4c", emojiId: "130" }],
-      },
-      expected: "[emoji]hello",
+      text: "😂() (hello)",
+      spans: [
+        [2, 2],
+        [5, 7],
+      ],
+      expected: "😂[emoji] (hello)",
     },
+    { text: "call foo()", spans: [], expected: "call foo()" },
     {
-      name: "reads offsets as UTF-16 code units, not codepoints",
-      message: {
-        id: "1",
-        type: "text",
-        text: "\u{1F602}()",
-        quoteToken: "quote-token",
-        emojis: [{ index: 2, length: 2, productId: "670e0cce840a8236ddd4ee4c", emojiId: "123" }],
-      },
-      expected: "\u{1F602}[emoji]",
-    },
-    {
-      name: "names every emoji the message carries",
-      message: {
-        id: "1",
-        type: "text",
-        text: "()a()",
-        quoteToken: "quote-token",
-        emojis: [
-          { index: 0, length: 2, productId: "670e0cce840a8236ddd4ee4c", emojiId: "1" },
-          { index: 3, length: 2, productId: "670e0cce840a8236ddd4ee4c", emojiId: "2" },
-        ],
-      },
+      text: "()a()",
+      spans: [
+        [0, 2],
+        [3, 2],
+      ],
       expected: "[emoji]a[emoji]",
     },
+    { text: "call foo() now ()", spans: [[15, 2]], expected: "call foo() now [emoji]" },
     {
-      name: "leaves parentheses the sender typed themselves alone",
-      message: {
-        id: "1",
-        type: "text",
-        text: "call foo() now ()",
-        quoteToken: "quote-token",
-        emojis: [{ index: 15, length: 2, productId: "670e0cce840a8236ddd4ee4c", emojiId: "1" }],
-      },
-      expected: "call foo() now [emoji]",
+      text: "@openclaw3 ()",
+      spans: [[11, 2]],
+      expected: "@openclaw3 [emoji]",
+      mention: { mentionees: [{ type: "user" as const, index: 0, length: 10, isSelf: true }] },
     },
-    {
-      name: "leaves text alone when LINE reports no emoji",
-      message: { id: "1", type: "text", text: "()", quoteToken: "quote-token" },
-      expected: "()",
-    },
-  ];
+  ])(
+    "projects LINE emoji metadata without losing text: $text",
+    async ({ text, spans, expected, mention }) => {
+      const context = await buildLineMessageContext({
+        event: createMessageEvent(
+          { type: "user", userId: "user-1" },
+          {
+            message: {
+              id: "emoji-message",
+              type: "text",
+              text,
+              quoteToken: "quote-token",
+              emojis: spans.map(([index, length]) => ({
+                index,
+                length,
+                productId: "emoji-set",
+                emojiId: "1",
+              })),
+              mention,
+            },
+          },
+        ),
+        allMedia: [],
+        cfg,
+        account,
+        commandAuthorized: true,
+      });
 
-  it.each(emojiBodyCases)("$name", ({ message, expected }) => {
-    expect(readLineTextMessageBody(message)).toBe(expected);
-  });
+      expect(context?.ctxPayload.BodyForAgent).toBe(expected);
+      expect(context?.ctxPayload.RawBody).toBe(expected);
+      expect(context?.ctxPayload.CommandBody).toBe(mention ? "()" : text);
+    },
+  );
 });

--- a/extensions/line/src/bot-message-context.test.ts
+++ b/extensions/line/src/bot-message-context.test.ts
@@ -885,7 +885,12 @@ describe("buildLineMessageContext", () => {
     );
   });
 
-  it.each([
+  it.each<{
+    text: string;
+    spans: [number, number][];
+    expected: string;
+    mention?: webhook.TextMessageContent["mention"];
+  }>([
     { text: "()hello", spans: [[0, 2]], expected: "[emoji]hello" },
     { text: "(hello)", spans: [[0, 7]], expected: "(hello)" },
     {

--- a/extensions/line/src/bot-message-context.ts
+++ b/extensions/line/src/bot-message-context.ts
@@ -41,6 +41,7 @@ type EventSource = webhook.Source | undefined;
 type MessageEvent = webhook.MessageEvent;
 type PostbackEvent = webhook.PostbackEvent;
 type StickerEventMessage = webhook.StickerMessageContent;
+type TextEventMessage = webhook.TextMessageContent;
 
 type MediaRef = Pick<ChannelInboundMediaInput, "contentType" | "fileName"> & { path: string };
 
@@ -198,9 +199,28 @@ function describeLineSticker(sticker: StickerEventMessage): string {
   return description ? `[Sent a sticker: ${description}]` : "[Sent a sticker]";
 }
 
+// LINE writes every inline LINE emoji into the message text as a two-character
+// "()" placeholder and describes it only in `emojis`, so the raw text reaches the
+// agent as bare parentheses and an emoji-only message as nothing but "()". Each
+// span names itself instead. Offsets are UTF-16 code units, matching LINE's
+// mention contract, so they index the JS string directly; spans are replaced from
+// the end so the earlier offsets stay valid while the text grows.
+const LINE_EMOJI_PLACEHOLDER = "[emoji]";
+
+export function readLineTextMessageBody(message: TextEventMessage): string {
+  const spans = (message.emojis ?? [])
+    .filter((emoji) => emoji.index >= 0 && emoji.length > 0)
+    .toSorted((left, right) => right.index - left.index);
+  let text = message.text;
+  for (const span of spans) {
+    text = `${text.slice(0, span.index)}${LINE_EMOJI_PLACEHOLDER}${text.slice(span.index + span.length)}`;
+  }
+  return text;
+}
+
 function extractMessageText(message: MessageEvent["message"]): string {
   if (message.type === "text") {
-    return message.text;
+    return readLineTextMessageBody(message);
   }
   if (message.type === "location") {
     const loc = message;

--- a/extensions/line/src/bot-message-context.ts
+++ b/extensions/line/src/bot-message-context.ts
@@ -41,7 +41,6 @@ type EventSource = webhook.Source | undefined;
 type MessageEvent = webhook.MessageEvent;
 type PostbackEvent = webhook.PostbackEvent;
 type StickerEventMessage = webhook.StickerMessageContent;
-type TextEventMessage = webhook.TextMessageContent;
 
 type MediaRef = Pick<ChannelInboundMediaInput, "contentType" | "fileName"> & { path: string };
 
@@ -199,21 +198,14 @@ function describeLineSticker(sticker: StickerEventMessage): string {
   return description ? `[Sent a sticker: ${description}]` : "[Sent a sticker]";
 }
 
-// LINE writes every inline LINE emoji into the message text as a two-character
-// "()" placeholder and describes it only in `emojis`, so the raw text reaches the
-// agent as bare parentheses and an emoji-only message as nothing but "()". Each
-// span names itself instead. Offsets are UTF-16 code units, matching LINE's
-// mention contract, so they index the JS string directly; spans are replaced from
-// the end so the earlier offsets stay valid while the text grows.
-const LINE_EMOJI_PLACEHOLDER = "[emoji]";
-
-export function readLineTextMessageBody(message: TextEventMessage): string {
-  const spans = (message.emojis ?? [])
-    .filter((emoji) => emoji.index >= 0 && emoji.length > 0)
-    .toSorted((left, right) => right.index - left.index);
+export function readLineTextMessageBody(message: webhook.TextMessageContent): string {
   let text = message.text;
-  for (const span of spans) {
-    text = `${text.slice(0, span.index)}${LINE_EMOJI_PLACEHOLDER}${text.slice(span.index + span.length)}`;
+  // LINE can send an empty "()" alternative; retain meaningful alternatives.
+  // Replace from the end so LINE's UTF-16 offsets survive earlier replacements.
+  for (const { index, length } of (message.emojis ?? []).toSorted((a, b) => b.index - a.index)) {
+    if (index >= 0 && length === 2 && text.slice(index, index + length) === "()") {
+      text = `${text.slice(0, index)}[emoji]${text.slice(index + length)}`;
+    }
   }
   return text;
 }


### PR DESCRIPTION
Fixes #132082.

## What Problem This Solves

LINE can send an inline emoji as an empty `()` alternative plus an `emojis` metadata span. OpenClaw passed that placeholder directly into the agent body and pending group history. The shared LINE text reader now replaces only metadata-marked empty alternatives with `[emoji]`, preserving sender-typed parentheses and meaningful alternatives such as `(hello)`.

## Why This Change Was Made

The agent body, mention-pattern input, and pending history share that reader. Native mention removal still reads the original message independently: both metadata sets use offsets into the original UTF-16 string. Reverse-order replacement preserves earlier emoji offsets. No provider-name lookup or network request is added.

The maintainer repair narrows the submitted all-span replacement because LINE's own SDK explicitly documents `(hello)` as a seven-unit alternative. It also consolidates the new tests at the real message-context boundary and extends the existing pending-history scenario. Production is +16/-3 (net +13): one shared reader for a previously ignored webhook field and three existing callers. Tests are +82/-4; docs +3/-0. A guard at only one consumer would leave history and mention input inconsistent.

## User Impact

The agent sees that an unnamed LINE emoji was sent, while meaningful alternatives and surrounding text retain their original content. No new setup is required.

## Evidence

- Independently reproduced against unchanged main `83b61257d6e328d904e7ed0c99ee50b661bbfe6d`, using only an authored test overlay: three actual body assertions failed for empty alternatives, mixed astral/named text, and native mention text; two controls preserved named alternatives and ordinary parentheses. Original source/config hashes and clean state were restored.
- Final head `28fe96b996a867ef8c5abb5cc8b1b523f570cdfa` passed all 48 LINE files / 707 tests in [hosted LINE proof](https://github.com/openclaw/openclaw/actions/runs/33348409914/job/99357307534), including all seven context controls and normalized pending-history delivery into the next mentioned turn. The exact synthetic merge is `f89b87af6677c7da69cd520e88d3a72fce03a76b`. Test type checking also passed after correcting the tuple type in the new table. No fork code or configuration executed on the maintainer host.
- Contributor-observed live LINE payload `()hello` reached the original Gateway as `()hello`. Replaying the same captured signed request into a fresh-state Gateway built from the contributor's earlier branch produced `[emoji]hello` with the same message/idempotency identity. The last hop was loopback replay, not a fresh live-channel send, and this evidence was supplied by the contributor. The maintainer changes preserve that empty-alternative behavior and add the meaningful-alternative control.
- Direct dependency inspection: `@line/bot-sdk` 11.2.0 `textMessageContent.ts` and `emoji.ts`; official [LINE text webhook contract](https://developers.line.biz/en/reference/messaging-api/nojs/#wh-text) and [UTF-16 text counting](https://developers.line.biz/en/docs/messaging-api/text-character-count/).

Fresh complete-candidate Codex autoreview passed at the default P0 scope with no findings. [Final aggregate CI](https://github.com/openclaw/openclaw/actions/runs/33348409914) completed successfully on `28fe96b996a867ef8c5abb5cc8b1b523f570cdfa`; the final observed rollup has 143 successful, 41 skipped and one neutral check. The latest ClawSweeper review has no actionable code findings. Its growth item is accepted for the shared metadata owner described above; its dependency-inspection gap is resolved by the maintainer’s direct SDK source inspection.

Release-note context: preserve LINE inline emoji presence without losing meaningful alternatives. Thanks @edenfunf.
