### PR TITLE
fix(auto-reply): preserve successful compaction in terminal failures

### DIFF
--- a/src/agents/embedded-agent-runner/run.overflow-context-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-context-recovery.test.ts
@@ -119,6 +119,7 @@ function makeInput(overrides: RecoveryInputOverrides = {}): RecoveryInput {
       workspaceDir: "/tmp/workspace",
       prompt: "continue",
       timeoutMs: 1_000,
+      onAutoCompactionSucceeded: vi.fn(),
     },
     state: createEmbeddedRunContextRecoveryState(),
     contextEngine: {
@@ -536,6 +537,7 @@ describe("recoverEmbeddedRunOverflow", () => {
       expect.objectContaining({ compacted: true, ok: true }),
       undefined,
     );
+    expect(input.runParams.onAutoCompactionSucceeded).toHaveBeenCalledWith(1);
   });
 
   it("leaves overflow recovery to a transport-owning harness", async () => {

--- a/src/agents/embedded-agent-runner/run.timeout-context-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run.timeout-context-recovery.test.ts
@@ -65,6 +65,7 @@ function makeInput(overrides: RecoveryOverrides = {}): RecoveryInput {
       workspaceDir: "/tmp/workspace",
       prompt: "continue",
       timeoutMs: 1_000,
+      onAutoCompactionSucceeded: vi.fn(),
     },
     state,
     contextEngine: {
@@ -189,6 +190,7 @@ describe("recoverEmbeddedRunTimeout", () => {
       autoCompactionCount: 1,
       lastCompactionTokensAfter: 80_000,
     });
+    expect(input.runParams.onAutoCompactionSucceeded).toHaveBeenCalledWith(1);
     expect(input.armPostCompactionGuard).toHaveBeenCalledOnce();
     expect(input.prepareCompactedTranscriptRetry).toHaveBeenCalledOnce();
   });

--- a/src/agents/embedded-agent-runner/run/overflow-context-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/overflow-context-recovery.ts
@@ -320,7 +320,8 @@ export async function recoverEmbeddedRunOverflow(
           );
         }
       }
-      input.state.autoCompactionCount += 1;
+      const compactionCount = ++input.state.autoCompactionCount;
+      input.runParams.onAutoCompactionSucceeded?.(compactionCount);
       input.armPostCompactionGuard();
       if (parkedWorkBlocksContinuation) {
         log.warn(

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -386,6 +386,8 @@ export type RunEmbeddedAgentParams = {
   onToolResult?: (payload: ReplyPayload) => void | Promise<void>;
   /** Synchronous private observer for the sanitized per-tool result. */
   onAgentToolResult?: (event: { toolName: string; result: unknown; isError: boolean }) => void;
+  /** Reports a committed generic recovery compaction before its retry starts. */
+  onAutoCompactionSucceeded?: (count: number) => void;
   onAgentEvent?: (evt: EmbeddedAgentEvent) => void | Promise<void>;
   onToolStreamBoundary?: () => void | Promise<void>;
   /**

--- a/src/agents/embedded-agent-runner/run/timeout-context-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/timeout-context-recovery.ts
@@ -92,7 +92,8 @@ export async function recoverEmbeddedRunTimeout(
     return false;
   }
 
-  input.state.autoCompactionCount += 1;
+  const compactionCount = ++input.state.autoCompactionCount;
+  input.runParams.onAutoCompactionSucceeded?.(compactionCount);
   const tokensAfter = timeoutCompactResult.result?.tokensAfter;
   if (typeof tokensAfter === "number" && Number.isFinite(tokensAfter) && tokensAfter >= 0) {
     input.state.lastCompactionTokensAfter = Math.floor(tokensAfter);

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -277,6 +277,8 @@ export function buildTtsSupplementMediaPayload(payload: ReplyPayload): ReplyPayl
 
 /** WeakMap-backed metadata attached to payload objects without changing wire shape. */
 export type ReplyPayloadMetadata = {
+  /** The model failed after a committed recovery compaction in the same turn. */
+  postCompactionModelFailure?: true;
   assistantMessageIndex?: number;
   /** Persisted assistant speech facts; never serialized into channel payloads. */
   tts?: AssistantDeliveryTtsFacts;

--- a/src/auto-reply/reply/agent-runner-embedded-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-embedded-candidate.ts
@@ -45,7 +45,10 @@ export async function runEmbeddedFallbackCandidate(
     notifyUserAboutCompaction: boolean;
     messageToolDeliveryState: MessageToolDeliveryState;
     githubPublicationAvailable: boolean;
-    onCompactionCount: (count: number) => void;
+    onCompactionFacts: (facts: {
+      totalCount: number;
+      postCompactionModelAttempted: boolean;
+    }) => void;
   },
 ): Promise<{
   result: Awaited<ReturnType<typeof runEmbeddedAgent>>;
@@ -131,6 +134,7 @@ export async function runEmbeddedFallbackCandidate(
         })
       : undefined;
   let attemptCompactionCount = 0;
+  let postCompactionModelAttempted = false;
   const lifecycleBackstop = createAgentLifecycleTerminalBackstop({
     runId: params.runId,
     sessionKey: turn.sessionKey,
@@ -203,6 +207,9 @@ export async function runEmbeddedFallbackCandidate(
         suppressAssistantErrorPersistence: params.suppressAssistantErrorPersistenceForCandidate,
         onAssistantErrorMessagePersisted: params.onAssistantErrorMessagePersisted,
         prepareAssistantTranscriptMessage: turn.opts?.prepareAssistantTranscriptMessage,
+        onAutoCompactionSucceeded: (count) => {
+          attemptCompactionCount = Math.max(attemptCompactionCount, count);
+        },
         toolResultFormat: (() => {
           const channel = resolveMessageChannel(turn.sessionCtx.Surface, turn.sessionCtx.Provider);
           return !channel || isMarkdownCapableMessageChannel(channel) ? "markdown" : "plain";
@@ -231,7 +238,12 @@ export async function runEmbeddedFallbackCandidate(
             params.onLifecycleGeneration(info.lifecycleGeneration);
           }
         },
-        onExecutionPhase: params.signalExecutionPhaseForTyping,
+        onExecutionPhase: (info) => {
+          if (info.phase === "model_call_started" && attemptCompactionCount > 0) {
+            postCompactionModelAttempted = true;
+          }
+          params.signalExecutionPhaseForTyping(info);
+        },
         onLaneWait: ({ waiting }) => {
           const replyOperation = turn.replyOperation;
           if (waiting && replyOperation) {
@@ -401,7 +413,10 @@ export async function runEmbeddedFallbackCandidate(
       ),
     };
   } finally {
-    params.onCompactionCount(attemptCompactionCount);
+    params.onCompactionFacts({
+      totalCount: attemptCompactionCount,
+      postCompactionModelAttempted,
+    });
     revokeMessageActionTurnCapability(messageActionTurnCapability);
   }
 }

--- a/src/auto-reply/reply/agent-runner-error-handler.ts
+++ b/src/auto-reply/reply/agent-runner-error-handler.ts
@@ -117,6 +117,12 @@ export async function handleAgentExecutionError(params: {
 }): Promise<ErrorAction> {
   const turn = params.turn;
   const err = params.error;
+  // A failed candidate leaves its backstop pending; settlement takes it before later work.
+  // This keeps session-override failures from being mislabeled as model failures.
+  const postCompactionModelFailure =
+    params.state.postCompactionModelAttempted && params.state.pendingLifecycleTerminal
+      ? true
+      : undefined;
   const takePendingLifecycleTerminal = () => {
     const terminal =
       params.state.pendingLifecycleTerminal?.backstop ??
@@ -435,6 +441,7 @@ export async function handleAgentExecutionError(params: {
     return {
       kind: "final",
       payload: markAgentRunFailureReplyPayload({ text: providerRequestError.userMessage }),
+      postCompactionModelFailure,
     };
   }
   defaultRuntime.error(`Embedded agent failed before reply: ${message}`);
@@ -523,5 +530,6 @@ export async function handleAgentExecutionError(params: {
         ? { presentation: externalRunFailureReply.presentation }
         : {}),
     }),
+    postCompactionModelFailure,
   };
 }

--- a/src/auto-reply/reply/agent-runner-execute.ts
+++ b/src/auto-reply/reply/agent-runner-execute.ts
@@ -16,6 +16,7 @@ import {
   type RunReplyAgentParams,
 } from "./agent-runner-core.js";
 import { executeAgentTurn } from "./agent-runner-execution.js";
+import { markPostCompactionModelFailurePayload } from "./agent-runner-failure-reply.js";
 import { runMemoryFlushIfNeeded, runSessionCompactionIfNeeded } from "./agent-runner-memory.js";
 import { finalizeReplyAgentRun } from "./agent-runner-result.js";
 import { buildThreadingToolContext } from "./agent-runner-utils.js";
@@ -93,6 +94,20 @@ type ExecutePreparedReplyAgentRunInput = Pick<
   turnAdoptionLifecycle: NonNullable<RunReplyAgentParams["opts"]>["turnAdoptionLifecycle"];
   typingSignals: TypingSignaler;
 };
+
+function markPostCompactionFailureResult(
+  result: ReplyPayload | ReplyPayload[] | undefined,
+  postCompactionModelFailure: true | undefined,
+): ReplyPayload | ReplyPayload[] | undefined {
+  if (Array.isArray(result)) {
+    return result.map((payload) =>
+      markPostCompactionModelFailurePayload(postCompactionModelFailure, payload),
+    );
+  }
+  return result
+    ? markPostCompactionModelFailurePayload(postCompactionModelFailure, result)
+    : result;
+}
 
 export async function executePreparedReplyAgentRun(
   context: ExecutePreparedReplyAgentRunInput,
@@ -388,12 +403,15 @@ export async function executePreparedReplyAgentRun(
     }
     return returnWithQueuedFollowupDrain(
       runOutcome.outcome.kind === "rejected"
-        ? runOutcome.outcome.payload
+        ? markPostCompactionModelFailurePayload(
+            runOutcome.outcome.postCompactionModelFailure,
+            runOutcome.outcome.payload,
+          )
         : { text: SILENT_REPLY_TOKEN },
     );
   }
 
-  return await finalizeReplyAgentRun({
+  const result = await finalizeReplyAgentRun({
     activeIsNewSession,
     activeSessionEntry,
     activeSessionStore,
@@ -429,6 +447,7 @@ export async function executePreparedReplyAgentRun(
     storePath,
     typingSignals,
   });
+  return markPostCompactionFailureResult(result, runOutcome.outcome.postCompactionModelFailure);
 }
 
 export function createReplyAgentRestartRecoveryController(

--- a/src/auto-reply/reply/agent-runner-execution-compaction.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-compaction.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
+import { BILLING_ERROR_USER_MESSAGE } from "../../agents/failover/user-copy.js";
 import { resetLogger, setLoggerOverride } from "../../logging/logger.js";
 import { loggingState } from "../../logging/state.js";
+import * as autoFallback from "./agent-runner-auto-fallback.js";
 import {
   setupAgentRunnerExecutionTestState,
   getExecuteAgentTurnForTest,
@@ -132,6 +134,162 @@ describe("executeAgentTurn: compaction events", () => {
       loggingState.rawConsole = null;
       setLoggerOverride(null);
       resetLogger();
+    }
+  });
+
+  it("carries committed compaction through exhausted model failure", async () => {
+    state.runEmbeddedAgentMock
+      .mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+        params.onAutoCompactionSucceeded?.(1);
+        throw new Error("LLM request timed out.");
+      })
+      .mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+        params.onExecutionPhase?.({ phase: "model_call_started" });
+        return {
+          payloads: [{ text: BILLING_ERROR_USER_MESSAGE, isError: true }],
+          meta: { error: { kind: "billing", message: "billing unavailable" } },
+        };
+      });
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => {
+      await params
+        .run("openai", "gpt-5.5", initialFallbackAttemptOptions(params))
+        .catch(() => undefined);
+      return {
+        outcome: "exhausted",
+        result: await params.run(
+          "anthropic",
+          "claude-sonnet-4-6",
+          initialFallbackAttemptOptions(params),
+        ),
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        attempts: [
+          {
+            provider: "openai",
+            model: "gpt-5.5",
+            error: "LLM request timed out.",
+            reason: "timeout",
+          },
+          {
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+            error: "billing unavailable",
+            reason: "billing",
+          },
+        ],
+      };
+    });
+
+    const result = await executeTestTurn();
+
+    expect(result).toMatchObject({
+      kind: "success",
+      autoCompactionCount: 1,
+      postCompactionModelFailure: true,
+    });
+  });
+
+  it("carries committed compaction into a later CLI fallback failure", async () => {
+    state.isCliProviderMock.mockImplementation((provider: unknown) => provider === "claude-cli");
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      params.onAutoCompactionSucceeded?.(1);
+      throw new Error("retry transcript preparation failed");
+    });
+    state.runCliAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      params.onExecutionPhase?.({ phase: "process_spawned" });
+      return {
+        payloads: [{ text: BILLING_ERROR_USER_MESSAGE, isError: true }],
+        meta: { error: { kind: "billing", message: "billing unavailable" } },
+      };
+    });
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => {
+      await params
+        .run("openai", "gpt-5.5", initialFallbackAttemptOptions(params))
+        .catch(() => undefined);
+      return {
+        outcome: "exhausted",
+        result: await params.run(
+          "claude-cli",
+          "claude-sonnet-4-6",
+          initialFallbackAttemptOptions(params),
+        ),
+        provider: "claude-cli",
+        model: "claude-sonnet-4-6",
+        attempts: [
+          {
+            provider: "openai",
+            model: "gpt-5.5",
+            error: "retry transcript preparation failed",
+            reason: "unknown",
+          },
+          {
+            provider: "claude-cli",
+            model: "claude-sonnet-4-6",
+            error: "billing unavailable",
+            reason: "billing",
+          },
+        ],
+      };
+    });
+
+    const result = await executeTestTurn();
+
+    expect(result).toMatchObject({
+      kind: "success",
+      autoCompactionCount: 1,
+      postCompactionModelFailure: true,
+    });
+  });
+
+  it("does not create the failure fact before the compacted retry reaches the model", async () => {
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      params.onAutoCompactionSucceeded?.(1);
+      throw new Error("retry transcript preparation failed");
+    });
+
+    const result = await executeTestTurn();
+
+    expect(result).toMatchObject({ kind: "final" });
+    expect(result.postCompactionModelFailure).toBeUndefined();
+  });
+
+  it("keeps successful compacted retries out of the failure fact", async () => {
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      params.onAutoCompactionSucceeded?.(1);
+      params.onExecutionPhase?.({ phase: "model_call_started" });
+      return {
+        payloads: [{ text: "recovered" }],
+        meta: { agentMeta: { compactionCount: 1 } },
+      };
+    });
+
+    const result = await executeTestTurn();
+
+    expect(result).toMatchObject({
+      kind: "success",
+      autoCompactionCount: 1,
+      runResult: { payloads: [{ text: "recovered" }] },
+    });
+    expect(result.postCompactionModelFailure).toBeUndefined();
+  });
+
+  it("keeps session settlement failures out of the model failure fact", async () => {
+    const settleSessionOverride = vi
+      .spyOn(autoFallback, "clearRecoveredAutoFallbackPrimaryProbeSelection")
+      .mockRejectedValueOnce(new Error("session override settlement failed"));
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      params.onAutoCompactionSucceeded?.(1);
+      params.onExecutionPhase?.({ phase: "model_call_started" });
+      return { payloads: [{ text: "recovered" }], meta: {} };
+    });
+
+    try {
+      const result = await executeTestTurn();
+
+      expect(result).toMatchObject({ kind: "final" });
+      expect(result.postCompactionModelFailure).toBeUndefined();
+    } finally {
+      settleSessionOverride.mockRestore();
     }
   });
 

--- a/src/auto-reply/reply/agent-runner-execution-provider-failures.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-provider-failures.test.ts
@@ -970,6 +970,7 @@ describe("executeAgentTurn: provider failures", () => {
 
     const result = await executeTestTurn({
       sessionCtx: createDirectFailureSessionCtx("telegram"),
+      opts: { runId: "direct-provider-request-error" },
     });
 
     expect(result.kind).toBe("final");
@@ -978,6 +979,17 @@ describe("executeAgentTurn: provider failures", () => {
       expect(result.payload.text).not.toContain("/new");
       expect(result.payload.text).not.toBe(GENERIC_RUN_FAILURE_TEXT);
     }
+    const emitAgentEvent = vi.mocked((await import("../../infra/agent-events.js")).emitAgentEvent);
+    const terminal = emitAgentEvent.mock.calls
+      .map(([event]) => event)
+      .find(
+        (event) =>
+          event.runId === "direct-provider-request-error" &&
+          event.stream === "lifecycle" &&
+          event.data.phase === "error",
+      );
+    expect(terminal).toBeDefined();
+    expect(terminal?.data.fallbackExhaustedFailure).not.toBe(true);
   });
 
   it("surfaces billing guidance for Volcengine Coding Plan subscription failures before reply", async () => {

--- a/src/auto-reply/reply/agent-runner-execution.test-support.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test-support.ts
@@ -345,12 +345,18 @@ export async function getExecuteAgentTurnForTest() {
         directlySentBlockKeys: outcome.directlySentBlockKeys,
         directlySentBlockPayloads: outcome.directlySentBlockPayloads,
         terminalFailurePayload: outcome.terminalFailurePayload,
+        postCompactionModelFailure: outcome.postCompactionModelFailure,
       };
     }
     if (outcome.kind === "rejected") {
-      return { kind: "final" as const, payload: outcome.payload };
+      return {
+        kind: "final" as const,
+        payload: outcome.payload,
+        postCompactionModelFailure: outcome.postCompactionModelFailure,
+      };
     }
-    return { kind: "final" as const, payload: { text: "NO_REPLY" } };
+    const payload: ReplyPayload = { text: "NO_REPLY" };
+    return { kind: "final" as const, payload };
   };
 }
 
@@ -422,6 +428,7 @@ export type EmbeddedAgentParams = {
   onPartialReply?: (payload: { text?: string; mediaUrls?: string[] }) => Promise<void> | void;
   onAssistantMessageStart?: () => Promise<void> | void;
   onToolResult?: (payload: { text?: string; mediaUrls?: string[] }) => Promise<void> | void;
+  onAutoCompactionSucceeded?: (count: number) => void;
   onReasoningStream?: (payload: {
     text?: string;
     mediaUrls?: string[];

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -312,6 +312,7 @@ async function executeAgentTurnInternalWithRetryState(
     deferredLifecycle,
     lifecycleGeneration,
     autoCompactionCount,
+    postCompactionModelAttempted: false,
     attemptedRuntimeProvider: fallbackProvider,
     attemptedRuntimeModel: fallbackModel,
     bootstrapPromptWarningSignaturesSeen: resolveBootstrapWarningSignaturesSeen(
@@ -439,6 +440,7 @@ async function executeAgentTurnInternalWithRetryState(
         payload: markAgentRunFailureReplyPayload({
           text: "⚠️ Context overflow — this conversation is too large for the model. Use /new to start a fresh session.",
         }),
+        postCompactionModelFailure: fallbackCycleState.postCompactionModelAttempted || undefined,
       };
     }
   }
@@ -515,6 +517,9 @@ async function executeAgentTurnInternalWithRetryState(
       (payload): payload is ReplyPayload => payload !== undefined,
     ),
     ...(terminalFailurePayload ? { terminalFailurePayload } : {}),
+    ...(terminalRunFailed && fallbackCycleState.postCompactionModelAttempted
+      ? { postCompactionModelFailure: true as const }
+      : {}),
   };
 }
 
@@ -635,6 +640,9 @@ async function executeAgentTurnOutcome(params: AgentTurnParams): Promise<AgentTu
           kind: "rejected",
           payload: internal.payload,
           resolved: internal.resolved,
+          ...(internal.postCompactionModelFailure
+            ? { postCompactionModelFailure: internal.postCompactionModelFailure }
+            : {}),
         },
       };
     }
@@ -651,11 +659,20 @@ async function executeAgentTurnOutcome(params: AgentTurnParams): Promise<AgentTu
       internal.fallbackModel ??
       internal.result.meta?.agentMeta?.model ??
       executionParams.followupRun.run.model;
+    const terminalStatus = internal.terminalFailurePayload
+      ? {
+          status: "failed" as const,
+          terminalFailurePayload: internal.terminalFailurePayload,
+          ...(internal.postCompactionModelFailure
+            ? { postCompactionModelFailure: internal.postCompactionModelFailure }
+            : {}),
+        }
+      : { status: "ok" as const };
     return {
       runId,
       outcome: {
         kind: "settled",
-        status: internal.terminalFailurePayload ? "failed" : "ok",
+        ...terminalStatus,
         ...(abortReason ? { abortReason } : {}),
         result: internal.result,
         resolved: { provider, model },
@@ -667,7 +684,6 @@ async function executeAgentTurnOutcome(params: AgentTurnParams): Promise<AgentTu
         didLogHeartbeatStrip: internal.didLogHeartbeatStrip,
         directlySentBlockKeys: internal.directlySentBlockKeys,
         directlySentBlockPayloads: internal.directlySentBlockPayloads,
-        terminalFailurePayload: internal.terminalFailurePayload,
       },
     };
   } catch (error) {

--- a/src/auto-reply/reply/agent-runner-execution.types.ts
+++ b/src/auto-reply/reply/agent-runner-execution.types.ts
@@ -38,16 +38,17 @@ export type AgentTurnInternalResult =
       directlySentBlockPayloads?: ReplyPayload[];
       /** Prepared terminal failure, appended only after delivery evidence settles. */
       terminalFailurePayload?: ReplyPayload;
+      postCompactionModelFailure?: true;
     }
   | {
       kind: "final";
       payload: ReplyPayload;
       resolved?: { provider: string; model: string };
+      postCompactionModelFailure?: true;
     };
 
-export type SettledAgentTurn = {
+type SettledAgentTurnBase = {
   kind: "settled";
-  status: "ok" | "failed";
   abortReason?: "user" | "restart";
   result: Awaited<ReturnType<typeof runEmbeddedAgent>>;
   resolved: { provider: string; model: string };
@@ -56,8 +57,21 @@ export type SettledAgentTurn = {
   didLogHeartbeatStrip: boolean;
   directlySentBlockKeys?: Set<string>;
   directlySentBlockPayloads?: ReplyPayload[];
-  terminalFailurePayload?: ReplyPayload;
 };
+
+export type SettledAgentTurn = SettledAgentTurnBase &
+  (
+    | {
+        status: "ok";
+        terminalFailurePayload?: never;
+        postCompactionModelFailure?: never;
+      }
+    | {
+        status: "failed";
+        terminalFailurePayload: ReplyPayload;
+        postCompactionModelFailure?: true;
+      }
+  );
 
 /** Closed result shared by foreground and queued agent-turn callers. */
 export type AgentTurnExecutionResult = {
@@ -69,6 +83,7 @@ export type AgentTurnExecutionResult = {
         kind: "rejected";
         payload: ReplyPayload;
         resolved?: { provider: string; model: string };
+        postCompactionModelFailure?: true;
       };
 };
 

--- a/src/auto-reply/reply/agent-runner-failure-reply.ts
+++ b/src/auto-reply/reply/agent-runner-failure-reply.ts
@@ -35,7 +35,13 @@ import { resolveSilentReplyPolicy } from "../../config/silent-reply.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { buildCodexLoginRecovery } from "../codex-login-recovery.js";
-import { markReplyPayloadForSourceSuppressionDelivery } from "../reply-payload.js";
+import {
+  copyReplyPayloadMetadata,
+  getReplyPayloadMetadata,
+  isReplyPayloadTerminalContent,
+  markReplyPayloadForSourceSuppressionDelivery,
+  setReplyPayloadMetadata,
+} from "../reply-payload.js";
 import type { TemplateContext } from "../templating.js";
 import type { VerboseLevel } from "../thinking.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
@@ -309,6 +315,28 @@ export function markAgentRunFailureReplyPayload<T extends ReplyPayload>(payload:
     marked.isError = true;
   }
   return marked;
+}
+
+export function markPostCompactionModelFailurePayload(
+  postCompactionModelFailure: true | undefined,
+  payload: ReplyPayload,
+): ReplyPayload {
+  return postCompactionModelFailure === true &&
+    payload.isError === true &&
+    isReplyPayloadTerminalContent(payload) &&
+    typeof payload.text === "string"
+    ? setReplyPayloadMetadata(payload, { postCompactionModelFailure: true })
+    : payload;
+}
+
+export function renderPostCompactionModelFailurePayload(payload: ReplyPayload): ReplyPayload {
+  return getReplyPayloadMetadata(payload)?.postCompactionModelFailure === true &&
+    typeof payload.text === "string"
+    ? copyReplyPayloadMetadata(payload, {
+        ...payload,
+        text: `⚠️ Context compaction succeeded, but the later model request still failed. ${payload.text.replace(/^⚠️\s*/u, "")}`,
+      })
+    : payload;
 }
 
 export function buildTerminalAgentRunFailureReplyPayload(params: {

--- a/src/auto-reply/reply/agent-runner-fallback-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-fallback-candidate.ts
@@ -232,6 +232,16 @@ export async function runAgentFallbackCandidates(params: AgentFallbackCycleParam
           markAutoFallbackPrimaryProbe({ probe: activeProbe, sessionKey: turn.sessionKey });
         }
         turn.opts?.onModelSelected?.({ provider, model, thinkLevel: candidateThinkLevel });
+        const signalExecutionPhaseForCandidate: AgentFallbackCandidateCommonParams["signalExecutionPhaseForTyping"] =
+          (info) => {
+            if (
+              params.state.autoCompactionCount > 0 &&
+              (info.phase === "model_call_started" || info.phase === "process_spawned")
+            ) {
+              params.state.postCompactionModelAttempted = true;
+            }
+            params.signalExecutionPhaseForTyping(info);
+          };
         const common = {
           preparedRunAdmission: params.preparedRunAdmission,
           turn,
@@ -259,7 +269,7 @@ export async function runAgentFallbackCandidates(params: AgentFallbackCycleParam
           bootstrapContextRunKind,
           bootstrapPromptWarningSignaturesSeen: params.state.bootstrapPromptWarningSignaturesSeen,
           currentTurnImages: params.currentTurnImages,
-          signalExecutionPhaseForTyping: params.signalExecutionPhaseForTyping,
+          signalExecutionPhaseForTyping: signalExecutionPhaseForCandidate,
           notifyAgentRunStart: params.notifyAgentRunStart,
           preserveProgressCallbackStartOrder,
           presentation: params.presentation,
@@ -303,8 +313,9 @@ export async function runAgentFallbackCandidates(params: AgentFallbackCycleParam
           },
           notifyUserAboutCompaction: params.notifyUserAboutCompaction,
           messageToolDeliveryState,
-          onCompactionCount: (count) => {
-            params.state.autoCompactionCount += count;
+          onCompactionFacts: (facts) => {
+            params.state.autoCompactionCount += facts.totalCount;
+            params.state.postCompactionModelAttempted ||= facts.postCompactionModelAttempted;
           },
         });
         params.state.bootstrapPromptWarningSignaturesSeen =

--- a/src/auto-reply/reply/agent-runner-fallback-cycle.types.ts
+++ b/src/auto-reply/reply/agent-runner-fallback-cycle.types.ts
@@ -57,6 +57,7 @@ export type AgentFallbackCycleState = {
   deferredLifecycle: DeferredEmbeddedRunLifecycleManager;
   lifecycleGeneration: string;
   autoCompactionCount: number;
+  postCompactionModelAttempted: boolean;
   attemptedRuntimeProvider: string;
   attemptedRuntimeModel: string;
   bootstrapPromptWarningSignaturesSeen: string[];

--- a/src/auto-reply/reply/agent-runner-fallback-settlement.ts
+++ b/src/auto-reply/reply/agent-runner-fallback-settlement.ts
@@ -118,6 +118,7 @@ export async function settleAgentFallbackCycle(params: {
           activeSessionEntry: turn.getActiveSessionEntry(),
         }),
       }),
+      postCompactionModelFailure: cycle.state.postCompactionModelAttempted || undefined,
     };
   }
   if (embeddedError?.kind === "role_ordering") {
@@ -131,6 +132,7 @@ export async function settleAgentFallbackCycle(params: {
           ? renderControlUiAgentFailureCopy(embeddedErrorText)
           : PROVIDER_CONVERSATION_STATE_ERROR_USER_MESSAGE,
       }),
+      postCompactionModelFailure: cycle.state.postCompactionModelAttempted || undefined,
     };
   }
   const sourceReplyPolicy = turn.sessionKey

--- a/src/auto-reply/reply/agent-runner.final-media-runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.final-media-runreplyagent.test.ts
@@ -67,6 +67,7 @@ vi.mock("../../media/outbound-attachment.js", () => ({
 vi.mock("./agent-runner-failure-reply.js", () => ({
   buildEmptyInteractiveReplyPayload: vi.fn(() => undefined),
   buildKnownAgentRunFailureReplyPayload: vi.fn(() => undefined),
+  markPostCompactionModelFailurePayload: (_failure: true | undefined, payload: unknown) => payload,
 }));
 
 vi.mock("./agent-runner-execution.js", () => ({

--- a/src/auto-reply/reply/dispatch-from-config.choose-route.ts
+++ b/src/auto-reply/reply/dispatch-from-config.choose-route.ts
@@ -21,6 +21,7 @@ import {
   setReplyPayloadMetadata,
   type ReplyPayload,
 } from "../reply-payload.js";
+import { renderPostCompactionModelFailurePayload } from "./agent-runner-failure-reply.js";
 import { createBlockReplyContentKey } from "./block-reply-pipeline.js";
 import type { CommandSessionMetadataChange } from "./command-session-metadata.js";
 import {
@@ -316,7 +317,7 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
         suppressionReason: preparation.reason,
       };
     }
-    const payload = preparation.payload;
+    const payload = renderPostCompactionModelFailurePayload(preparation.payload);
     const payloadMetadata = getReplyPayloadMetadata(payload);
     const expectedWriterRunId = normalizeOptionalString(params.replyOptions?.runId);
     const expectedLifecycleRevision = sessionStoreEntry.entry?.lifecycleRevision;

--- a/src/auto-reply/reply/dispatch-from-config.terminal-recovery.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.terminal-recovery.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { BILLING_ERROR_USER_MESSAGE } from "../../agents/failover/user-copy.js";
 import { readAgentRunTerminalOutcome } from "../../channels/turn/agent-run-terminal-outcome.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { setReplyPayloadMetadata } from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
 import {
   createDispatcher,
@@ -98,6 +100,22 @@ describe("dispatchReplyFromConfig terminal visible admission recovery", () => {
     expect(readAgentRunTerminalOutcome(result)).toBe("completed");
     expect(replyResolver).toHaveBeenCalledTimes(1);
     expect(dispatchParams.dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders post-compaction context after dispatcher normalization", async () => {
+    const dispatchParams = createVisibleDispatchParams(async () =>
+      setReplyPayloadMetadata(
+        { text: BILLING_ERROR_USER_MESSAGE, isError: true },
+        { postCompactionModelFailure: true },
+      ),
+    );
+
+    await dispatchReplyFromConfig(dispatchParams);
+
+    expect(dispatchParams.dispatcher.sendFinalReply).toHaveBeenCalledWith({
+      text: `⚠️ Context compaction succeeded, but the later model request still failed. ${BILLING_ERROR_USER_MESSAGE.replace(/^⚠️\s*/u, "")}`,
+      isError: true,
+    });
   });
 
   it("records a failed reply operation when recovering a visible partial", async () => {

--- a/src/auto-reply/reply/followup-delivery.channel.test.ts
+++ b/src/auto-reply/reply/followup-delivery.channel.test.ts
@@ -10,7 +10,7 @@ import {
 import { setReplyPayloadMetadata } from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
 import { resolveFollowupDeliveryPayloads } from "./followup-delivery-payloads.js";
-import { deliverFollowupDecision } from "./followup-delivery.js";
+import { deliverFollowupDecision, resolveFollowupDeliveryDecision } from "./followup-delivery.js";
 import type { AdmittedFollowupTurn } from "./followup-turn-admission.js";
 
 const channelState = vi.hoisted(() => ({
@@ -139,6 +139,30 @@ afterEach(() => {
 });
 
 describe("follow-up delivery channel boundary", () => {
+  it("renders post-compaction model failures after queued payload selection", () => {
+    const decision = resolveFollowupDeliveryDecision({
+      turn: createTurn({ messageProvider: "discord", originatingChannel: "discord" }),
+      execution: {
+        runId: "run-1",
+        outcome: {
+          kind: "rejected",
+          payload: { text: "⚠️ Provider billing failed.", isError: true },
+          postCompactionModelFailure: true,
+        },
+      },
+    });
+
+    expect(decision).toMatchObject({
+      kind: "deliver",
+      payloads: [
+        {
+          text: "⚠️ Context compaction succeeded, but the later model request still failed. Provider billing failed.",
+          isError: true,
+        },
+      ],
+    });
+  });
+
   it.each([
     { mode: "first", duplicate: "media" },
     { mode: "batched", duplicate: "media" },

--- a/src/auto-reply/reply/followup-delivery.ts
+++ b/src/auto-reply/reply/followup-delivery.ts
@@ -24,7 +24,11 @@ import {
 import type { ReplyPayload } from "../types.js";
 import { normalizeAssistantFinalDeliveryText } from "./agent-runner-core.js";
 import type { AgentTurnExecutionResult } from "./agent-runner-execution.types.js";
-import { buildEmptyInteractiveReplyPayload } from "./agent-runner-failure-reply.js";
+import {
+  buildEmptyInteractiveReplyPayload,
+  markPostCompactionModelFailurePayload,
+  renderPostCompactionModelFailurePayload,
+} from "./agent-runner-failure-reply.js";
 import type { AccountedAgentTurn } from "./agent-runner-result-accounting.js";
 import { appendUsageLine, resolveResponseUsageLine } from "./agent-runner-usage-line.js";
 import { resolveFollowupDeliveryPayloads } from "./followup-delivery-payloads.js";
@@ -88,6 +92,13 @@ export function resolveFollowupDeliveryDecision(params: {
   ) {
     return { kind: "suppress", reason: "aborted" };
   }
+  const postCompactionModelFailure = execution.outcome.postCompactionModelFailure;
+  const renderFailurePayloads = (payloads: ReplyPayload[]) =>
+    payloads.map((payload) =>
+      renderPostCompactionModelFailurePayload(
+        markPostCompactionModelFailurePayload(postCompactionModelFailure, payload),
+      ),
+    );
   const sourcePolicy = resolveSourceReplyVisibilityPolicy({
     cfg: turn.config,
     ctx: {
@@ -131,12 +142,14 @@ export function resolveFollowupDeliveryDecision(params: {
     ) {
       return { kind: "suppress", reason: "message-tool-only" };
     }
-    const payloads = resolveFollowupDeliveryPayloads({
-      ...deliveryContext,
-      payloads: [execution.outcome.payload],
-      reasoningPayloadsEnabled: opts?.reasoningPayloadsEnabled === true,
-      commentaryPayloadsEnabled: opts?.commentaryPayloadsEnabled === true,
-    });
+    const payloads = renderFailurePayloads(
+      resolveFollowupDeliveryPayloads({
+        ...deliveryContext,
+        payloads: [execution.outcome.payload],
+        reasoningPayloadsEnabled: opts?.reasoningPayloadsEnabled === true,
+        commentaryPayloadsEnabled: opts?.commentaryPayloadsEnabled === true,
+      }),
+    );
     return payloads.length > 0
       ? {
           kind: "deliver",
@@ -284,6 +297,7 @@ export function resolveFollowupDeliveryDecision(params: {
   if (responseUsageLine) {
     payloads = appendUsageLine(payloads, responseUsageLine);
   }
+  payloads = renderFailurePayloads(payloads);
   if (sourcePolicy.sourceReplyDeliveryMode === "message_tool_only") {
     const explicitlyDeliverable = payloads.filter(
       (payload) => getReplyPayloadMetadata(payload)?.deliverDespiteSourceReplySuppression === true,


### PR DESCRIPTION
## Summary

- Preserve a successful recovery compaction when a later model attempt fails.
- Keep the existing safe billing, timeout, authentication, or overflow guidance.
- Leave successful model turns and non-model settlement failures unchanged.

Fixes #67750.

## Problem

The embedded runner could commit recovery compaction and then fail on a later model request. The terminal reply kept the provider guidance but lost the successful-compaction fact. Users could not tell that recovery had already reduced the conversation.

## Root cause

Recovery owned the committed compaction count, but a thrown model attempt had no completed run result. The fact therefore stopped before `AgentTurnExecutionResult`. Foreground and queued replies also normalize terminal payloads at different final boundaries, so text added earlier can be replaced.

## Fix

- Report committed timeout and overflow recovery compactions synchronously.
- Mark a post-compaction attempt only when an embedded model call or CLI process starts.
- Carry `postCompactionModelFailure?: true` only on failed execution-result variants.
- Keep candidate, fallback, and session-settlement state out of `ReplyOperation`.
- Attach private reply-payload metadata, then render after the final foreground or queued normalization boundary.
- Preserve direct provider retry grace; only exhausted fallback chains use the existing exhaustion lifecycle fact.

## Live proof

The same Telegram Test Server direct-message contract ran against current main before repair and against live-proven head `f9a60932745f8cd9751b0a6260e5948b5da8f3d0` after repair. Current head `0d25fe8951362a4d204d7d9593ba7ec722ae0b51` is a patch-identical rebase onto the main commit that repaired the unrelated shutdown test.

The controlled model sequence was:

1. Seed reply succeeds.
2. The next request reports context overflow.
3. The compaction summary succeeds.
4. The compacted retry times out.
5. The next provider attempt reports a billing failure and the fallback chain ends.

Current main sent only the billing guidance. The repaired head sent:

> ⚠️ Context compaction succeeded, but the later model request still failed. API provider returned a billing error — your API key has run out of credits or has an insufficient balance. Check your provider's billing dashboard and top up or switch to a different API key.

Telegram event evidence, five controlled `/v1/responses` requests, the Gateway compaction log, and cleanup checks all matched the same run. Main advanced after the red run, but no later commit changed an affected owner file or this contract.

## Verification

- Focused embedded-runner tests: 45 passed.
- Focused auto-reply tests: 181 passed.
- Regression proof covers embedded-to-embedded and embedded-to-CLI fallback order.
- False-positive proof covers pre-model retry preparation, model success, and session-override settlement failure.
- Exact-head `node scripts/check-changed.mjs` passed, including production and test type checks and all changed-file lint shards.
- Exact-head private QA build passed on two dependency-ready Linux hosts.
- Telegram Test Server doctor and exact-head live proof passed.
- `git diff --check` passed.

## Shape and production

- Owner: embedded recovery records compaction; fallback execution records a later model start; `AgentTurnExecutionResult` owns the terminal fact.
- Closed modes: success and abort cannot carry the fact; rejected or failed settlement may carry it.
- Removed: the PR's `ReplyOperation` side state, structured failure-context object, duplicate fallback projection, and candidate-local sibling gap.
- Production: +160/-24, net +136. The remaining growth is the typed producer-to-result custody plus the two distinct final normalization consumers. The absorbing refactor removed duplicate side state before accepting this delta.
- Tests and test support: +227/-3, net +224.

## Overlap

- PR #132704 also changes timeout recovery, but it owns requester-abandonment lifecycle during retry preparation. This PR owns the committed-compaction fact after a later model failure.
