### PR TITLE
fix(update): dev upgrades exhaust small POSIX temporary filesystems

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -292,7 +292,14 @@ returns the latest sentinel.
     Dev only.
   </Step>
   <Step title="Preflight build (dev only)">
-    Runs the TypeScript build in a temp worktree. If the tip fails, walks back up to 10 commits to find the newest buildable commit. Content-addressed declaration outputs from the successful candidate are reused by the final checkout build; rebased source changes automatically invalidate the affected cache groups. Set `OPENCLAW_UPDATE_PREFLIGHT_LINT=1` to also run lint during this preflight; lint runs in constrained serial mode because user update hosts are often smaller than CI runners.
+    Installs dependencies, builds, and validates config in a temporary worktree. On POSIX, staging uses a private directory in the checkout's existing ignored `.artifacts` area. By default, the full workspace stays on the checkout filesystem, not a potentially small system temporary filesystem. An existing `.artifacts` redirect is honored as an operator storage choice, just like the build cache. Existing checkout, parent, and artifact directory permissions are not changed. Windows keeps its short system-drive staging path.
+
+    The updater attempts to remove staging before changing the live checkout; cleanup failures remain visible in the update result. If an interruption leaves staging behind, artifact-area staging does not dirty the checkout or block the next update's clean check.
+
+    If a candidate fails, walks back up to 10 commits to find the newest buildable commit. Confirmed ENOSPC storage failures stop immediately with `preflight-insufficient-space`; free space on the preflight staging and package-manager store filesystems before retrying. Shared package-manager stores are not deleted. Content-addressed declaration outputs from the successful candidate are reused by the final checkout build; rebased source changes automatically invalidate the affected cache groups. Set `OPENCLAW_UPDATE_PREFLIGHT_LINT=1` to also run lint during this preflight; lint runs in constrained serial mode because user update hosts are often smaller than CI runners.
+
+    The updater already running owns staging. Updating to a commit with this repair cannot change an older published updater's first hop; that default path requires a published baseline containing the repair.
+
   </Step>
   <Step title="Rebase">
     Rebases onto the selected commit (dev only).

--- a/docs/install/update-troubleshooting.md
+++ b/docs/install/update-troubleshooting.md
@@ -36,6 +36,12 @@ the CLI fallback on the Gateway host.
 ## Reason codes
 
 - `dirty`, `no-upstream`: repair the source checkout before retrying.
+- `preflight-insufficient-space`: free space on the filesystems containing
+  preflight staging (the checkout's `.artifacts` area on POSIX) and the
+  package-manager store, then retry. The updater stops on
+  confirmed ENOSPC instead of trying older commits; it does not delete shared
+  package-manager stores. See [Git checkout flow](/cli/update#git-checkout-flow)
+  for staging placement and the older published-updater limitation.
 - `deps-install-failed`, `build-failed`, `ui-build-failed`: inspect the failing
   step, fix the dependency or build error, then retry.
 - `global-install-failed`: retry after checking package-manager ownership and

--- a/src/cli/update-cli/progress.test.ts
+++ b/src/cli/update-cli/progress.test.ts
@@ -41,6 +41,14 @@ describe("update failure hints", () => {
     vi.restoreAllMocks();
   });
 
+  it("explains capacity exhaustion without blaming candidate commits", () => {
+    const result = makeResult("preflight-insufficient-space", "", "git");
+    const output = renderResult(result);
+    expect(output).toContain("Free space");
+    expect(output).toContain("preflight staging and package-manager store");
+    expect(output).toContain("rerun the update");
+  });
+
   it("returns a package-manager bootstrap hint for pnpm npm-bootstrap failures", () => {
     const result = {
       status: "error",

--- a/src/cli/update-cli/progress.ts
+++ b/src/cli/update-cli/progress.ts
@@ -51,6 +51,12 @@ function inferUpdateFailureHints(result: UpdateRunResult): string[] {
   if (result.status !== "error") {
     return [];
   }
+  if (result.reason === "preflight-insufficient-space") {
+    return [
+      "Free space on the preflight staging and package-manager store filesystems, then rerun the update.",
+      "Preflight stopped because storage was exhausted; trying another commit would not repair it.",
+    ];
+  }
   if (result.reason === "pnpm-corepack-missing") {
     return [
       "This pnpm checkout could not auto-enable pnpm because corepack is missing.",

--- a/src/infra/update-runner-git-preflight.ts
+++ b/src/infra/update-runner-git-preflight.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
+import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
 import { trimLogTail } from "./restart-sentinel.js";
 import { DEV_BRANCH, resolveDevUpstreamRefs } from "./update-channels.js";
 import { resolveDevUpdateTargetRevision, type DevUpdateTarget } from "./update-dev-target.js";
@@ -28,7 +28,7 @@ import type {
 
 const PREFLIGHT_MAX_COMMITS = 10;
 const PREFLIGHT_TEMP_PREFIX =
-  process.platform === "win32" ? "ocu-pf-" : "openclaw-update-preflight-";
+  process.platform === "win32" ? "ocu-pf-" : ".openclaw-update-preflight-";
 const PREFLIGHT_WORKTREE_DIRNAME = process.platform === "win32" ? "wt" : "worktree";
 const PREFLIGHT_CLEANUP_TIMEOUT_MS = 60_000;
 const WINDOWS_PREFLIGHT_BASE_DIR = "ocu";
@@ -99,13 +99,17 @@ function resolvePreflightWorktreeDir(preflightRoot: string) {
   return path.join(preflightRoot, PREFLIGHT_WORKTREE_DIRNAME);
 }
 
-async function createPreflightRoot() {
+async function createPreflightRoot(gitRoot: string) {
   if (process.platform === "win32" && path.sep === "\\") {
     const baseDir = path.win32.join(process.env.SystemDrive ?? "C:", WINDOWS_PREFLIGHT_BASE_DIR);
     await fs.mkdir(baseDir, { recursive: true });
     return fs.mkdtemp(path.win32.join(baseDir, PREFLIGHT_TEMP_PREFIX));
   }
-  return fs.mkdtemp(path.join(os.tmpdir(), PREFLIGHT_TEMP_PREFIX));
+  // Ignored artifact storage keeps interrupted worktrees out of Git status.
+  // Honor existing redirects like build-all-cache; only the mkdtemp child is private.
+  const artifactRoot = path.join(await fs.realpath(gitRoot), ".artifacts");
+  await fs.mkdir(artifactRoot, { recursive: true });
+  return fs.mkdtemp(path.join(artifactRoot, PREFLIGHT_TEMP_PREFIX));
 }
 
 async function removePathRecursive(target: string) {
@@ -306,113 +310,111 @@ async function resolveUpstreamCandidates(params: {
   };
 }
 
-async function testPreflightCandidates(params: {
+type PreflightCandidateResult =
+  | { status: "ok"; selectedSha: string }
+  | { status: "manager-unavailable"; reason: string }
+  | { status: "failed" | "insufficient-space" };
+
+function classifyPreflightFailure(step: UpdateStepResult): "failed" | "insufficient-space" {
+  // pnpm reports filesystem errors on stdout by default. Require the storage
+  // diagnostic: ENOSPC also covers inotify limits.
+  const output = stripAnsi(`${step.stdoutTail ?? ""}\n${step.stderrTail ?? ""}`);
+  return /^\s*(?:\[(?:ERR_PNPM_)?ENOSPC\][^\r\n]*|(?:Error:\s*)?)ENOSPC: no space left on device(?:,|$)/m.test(
+    output,
+  )
+    ? "insufficient-space"
+    : "failed";
+}
+
+async function testPreflightCandidate(params: {
   gitRoot: string;
   worktreeDir: string;
-  candidates: string[];
+  sha: string;
   runCommand: CommandRunner;
   timeoutMs: number;
   defaultCommandEnv: NodeJS.ProcessEnv | undefined;
   steps: UpdateStepResult[];
   step: StepFactory;
-}): Promise<{
-  selectedSha: string | null;
-  managerReason: string | null;
-  sawOtherFailure: boolean;
-}> {
-  let selectedSha: string | null = null;
-  let managerReason: string | null = null;
-  let sawOtherFailure = false;
-  for (const sha of params.candidates) {
-    const shortSha = sha.slice(0, 8);
-    if (!(await resetPreflightCandidateWorktree(params.worktreeDir, shortSha, params.step))) {
-      sawOtherFailure = true;
-      continue;
-    }
-    const checkoutStep = await runStep(
-      params.step(
-        `preflight checkout (${shortSha})`,
-        ["git", "-C", params.worktreeDir, "checkout", "--detach", sha],
-        params.worktreeDir,
-      ),
-    );
-    if (checkoutStep.exitCode !== 0) {
-      sawOtherFailure = true;
-      continue;
-    }
-    const manager = await resolveUpdateBuildManager(
-      params.runCommand,
-      params.worktreeDir,
-      params.timeoutMs,
-      params.defaultCommandEnv,
-      "require-preferred",
-    );
-    if (manager.kind === "missing-required") {
-      managerReason = manager.reason;
-      params.steps.push({
-        name: `preflight package manager (${shortSha})`,
-        command: `resolve ${manager.preferred} package manager`,
-        cwd: params.worktreeDir,
-        durationMs: 0,
-        exitCode: 1,
-        stderrTail: managerReason,
-      });
-      continue;
-    }
-    try {
-      const preferIgnoreScripts = shouldInstallWithoutScriptsOnWindows(manager.manager);
-      const ignoreScriptsArgv = managerInstallIgnoreScriptsArgs(manager.manager);
-      const installArgv =
-        preferIgnoreScripts && ignoreScriptsArgv
-          ? ignoreScriptsArgv
-          : managerInstallArgs(manager.manager, {
-              compatFallback: manager.fallback && manager.manager === "npm",
-            });
-      const installName = preferIgnoreScripts
-        ? `preflight deps install (ignore scripts) (${shortSha})`
-        : `preflight deps install (${shortSha})`;
-      const installEnv = await resolveInstallEnv(
-        manager.manager,
-        manager.env ?? params.defaultCommandEnv,
-        params.worktreeDir,
-        params.runCommand,
-        params.timeoutMs,
-      );
-      const installStep = await runStep(
-        params.step(installName, installArgv, params.worktreeDir, installEnv),
-      );
-      if (installStep.exitCode !== 0) {
-        sawOtherFailure = true;
-        continue;
-      }
-      const runCandidateCheck = async (name: string, argv: string[], env?: NodeJS.ProcessEnv) => {
-        const check = params.step(`preflight ${name} (${shortSha})`, argv, params.worktreeDir, env);
-        return (await runStep(check)).exitCode === 0;
-      };
-      const buildArgs = managerScriptArgs(manager.manager, "build");
-      const buildEnv = resolveBuildEnv(
-        manager.env ?? params.defaultCommandEnv,
-        path.join(params.gitRoot, ".artifacts", "build-all-cache"),
-      );
-      const configCommand = ["config", "validate", "--json"];
-      const configArgs = managerScriptArgs(manager.manager, "openclaw", configCommand);
-      const lintArgs = managerScriptArgs(manager.manager, "lint");
-      if (
-        !(await runCandidateCheck("build", buildArgs, buildEnv)) ||
-        !(await runCandidateCheck("config validate", configArgs, manager.env)) ||
-        (shouldRunDevPreflightLint() &&
-          !(await runCandidateCheck("lint", lintArgs, resolveDevPreflightLintEnv(manager.env))))
-      ) {
-        sawOtherFailure = true;
-        continue;
-      }
-      selectedSha = sha;
-      break;
-    } finally {
-      await manager.cleanup?.();
-    }
+}): Promise<PreflightCandidateResult> {
+  const shortSha = params.sha.slice(0, 8);
+  if (!(await resetPreflightCandidateWorktree(params.worktreeDir, shortSha, params.step))) {
+    return { status: "failed" };
   }
-  return { selectedSha, managerReason, sawOtherFailure };
+  const runCandidateCheck = async (name: string, argv: string[], env?: NodeJS.ProcessEnv) => {
+    const check = params.step(`preflight ${name} (${shortSha})`, argv, params.worktreeDir, env);
+    const result = await runStep(check);
+    return result.exitCode === 0 ? null : result;
+  };
+  const checkout = await runCandidateCheck("checkout", [
+    "git",
+    "-C",
+    params.worktreeDir,
+    "checkout",
+    "--detach",
+    params.sha,
+  ]);
+  if (checkout) {
+    return { status: classifyPreflightFailure(checkout) };
+  }
+  const manager = await resolveUpdateBuildManager(
+    params.runCommand,
+    params.worktreeDir,
+    params.timeoutMs,
+    params.defaultCommandEnv,
+    "require-preferred",
+  );
+  if (manager.kind === "missing-required") {
+    params.steps.push({
+      name: `preflight package manager (${shortSha})`,
+      command: `resolve ${manager.preferred} package manager`,
+      cwd: params.worktreeDir,
+      durationMs: 0,
+      exitCode: 1,
+      stderrTail: manager.reason,
+    });
+    return { status: "manager-unavailable", reason: manager.reason };
+  }
+  try {
+    const preferIgnoreScripts = shouldInstallWithoutScriptsOnWindows(manager.manager);
+    const ignoreScriptsArgv = managerInstallIgnoreScriptsArgs(manager.manager);
+    const installArgv =
+      preferIgnoreScripts && ignoreScriptsArgv
+        ? ignoreScriptsArgv
+        : managerInstallArgs(manager.manager, {
+            compatFallback: manager.fallback && manager.manager === "npm",
+          });
+    const installName = preferIgnoreScripts ? "deps install (ignore scripts)" : "deps install";
+    const installEnv = await resolveInstallEnv(
+      manager.manager,
+      manager.env ?? params.defaultCommandEnv,
+      params.worktreeDir,
+      params.runCommand,
+      params.timeoutMs,
+    );
+    const buildArgs = managerScriptArgs(manager.manager, "build");
+    const buildEnv = resolveBuildEnv(
+      manager.env ?? params.defaultCommandEnv,
+      path.join(params.gitRoot, ".artifacts", "build-all-cache"),
+    );
+    const configArgs = managerScriptArgs(manager.manager, "openclaw", [
+      "config",
+      "validate",
+      "--json",
+    ]);
+    const lintArgs = managerScriptArgs(manager.manager, "lint");
+    const failure =
+      (await runCandidateCheck(installName, installArgv, installEnv)) ??
+      (await runCandidateCheck("build", buildArgs, buildEnv)) ??
+      (await runCandidateCheck("config validate", configArgs, manager.env)) ??
+      (shouldRunDevPreflightLint()
+        ? await runCandidateCheck("lint", lintArgs, resolveDevPreflightLintEnv(manager.env))
+        : null);
+    return failure
+      ? { status: classifyPreflightFailure(failure) }
+      : { status: "ok", selectedSha: params.sha };
+  } finally {
+    await manager.cleanup?.();
+  }
 }
 
 export async function runGitDevPreflight(params: {
@@ -470,7 +472,7 @@ export async function runGitDevPreflight(params: {
     localDevBranchExists = upstream.localDevBranchExists;
   }
 
-  const preflightRoot = await createPreflightRoot();
+  const preflightRoot = await createPreflightRoot(params.gitRoot);
   const worktreeDir = resolvePreflightWorktreeDir(preflightRoot);
   const worktreeStep = await runStep(
     params.step(
@@ -484,9 +486,19 @@ export async function runGitDevPreflight(params: {
     return { status: "error", reason: "preflight-worktree-failed" };
   }
 
-  let tested: Awaited<ReturnType<typeof testPreflightCandidates>>;
+  let tested: PreflightCandidateResult | undefined;
   try {
-    tested = await testPreflightCandidates({ ...params, worktreeDir, candidates });
+    for (const sha of candidates) {
+      const candidate = await testPreflightCandidate({ ...params, worktreeDir, sha });
+      if (candidate.status === "ok" || candidate.status === "insufficient-space") {
+        tested = candidate;
+        break;
+      }
+      // A missing manager must not hide another candidate's checkout/build failure.
+      if (tested?.status !== "failed") {
+        tested = candidate;
+      }
+    }
   } finally {
     const removeStep = await runStep({
       ...params.step(
@@ -515,13 +527,15 @@ export async function runGitDevPreflight(params: {
       .catch(() => null);
     await removePathRecursive(preflightRoot);
   }
-  if (!tested.selectedSha) {
+  if (tested?.status !== "ok") {
     return {
       status: "error",
       reason:
-        tested.managerReason && !tested.sawOtherFailure
-          ? tested.managerReason
-          : "preflight-no-good-commit",
+        tested?.status === "insufficient-space"
+          ? "preflight-insufficient-space"
+          : tested?.status === "manager-unavailable"
+            ? tested.reason
+            : "preflight-no-good-commit",
     };
   }
   return {

--- a/src/infra/update-runner-git-preflight.ts
+++ b/src/infra/update-runner-git-preflight.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
+import { hasErrnoCode } from "./errno.js";
 import { trimLogTail } from "./restart-sentinel.js";
 import { DEV_BRANCH, resolveDevUpstreamRefs } from "./update-channels.js";
 import { resolveDevUpdateTargetRevision, type DevUpdateTarget } from "./update-dev-target.js";
@@ -100,16 +101,14 @@ function resolvePreflightWorktreeDir(preflightRoot: string) {
 }
 
 async function createPreflightRoot(gitRoot: string) {
-  if (process.platform === "win32" && path.sep === "\\") {
-    const baseDir = path.win32.join(process.env.SystemDrive ?? "C:", WINDOWS_PREFLIGHT_BASE_DIR);
-    await fs.mkdir(baseDir, { recursive: true });
-    return fs.mkdtemp(path.win32.join(baseDir, PREFLIGHT_TEMP_PREFIX));
-  }
-  // Ignored artifact storage keeps interrupted worktrees out of Git status.
+  // On POSIX, ignored artifact storage keeps interrupted worktrees out of Git status.
   // Honor existing redirects like build-all-cache; only the mkdtemp child is private.
-  const artifactRoot = path.join(await fs.realpath(gitRoot), ".artifacts");
-  await fs.mkdir(artifactRoot, { recursive: true });
-  return fs.mkdtemp(path.join(artifactRoot, PREFLIGHT_TEMP_PREFIX));
+  const baseDir =
+    process.platform === "win32" && path.sep === "\\"
+      ? path.win32.join(process.env.SystemDrive ?? "C:", WINDOWS_PREFLIGHT_BASE_DIR)
+      : path.join(await fs.realpath(gitRoot), ".artifacts");
+  await fs.mkdir(baseDir, { recursive: true });
+  return fs.mkdtemp(path.join(baseDir, PREFLIGHT_TEMP_PREFIX));
 }
 
 async function removePathRecursive(target: string) {
@@ -319,11 +318,16 @@ function classifyPreflightFailure(step: UpdateStepResult): "failed" | "insuffici
   // pnpm reports filesystem errors on stdout by default. Require the storage
   // diagnostic: ENOSPC also covers inotify limits.
   const output = stripAnsi(`${step.stdoutTail ?? ""}\n${step.stderrTail ?? ""}`);
-  return /^\s*(?:\[(?:ERR_PNPM_)?ENOSPC\][^\r\n]*|(?:Error:\s*)?)ENOSPC: no space left on device(?:,|$)/m.test(
-    output,
-  )
-    ? "insufficient-space"
-    : "failed";
+  const nodeNoSpace =
+    /^\s*(?:\[(?:ERR_PNPM_)?ENOSPC\][^\r\n]*|(?:Error:\s*)?)ENOSPC: no space left on device(?:,|$)/m.test(
+      output,
+    );
+  // Git uses strerror without an errno token; require a complete operation diagnostic.
+  const gitNoSpace =
+    /^(?:fatal|error): (?:cannot|could not|unable to) [^\r\n]+: No space left on device$/m.test(
+      output,
+    );
+  return nodeNoSpace || gitNoSpace ? "insufficient-space" : "failed";
 }
 
 async function testPreflightCandidate(params: {
@@ -472,7 +476,17 @@ export async function runGitDevPreflight(params: {
     localDevBranchExists = upstream.localDevBranchExists;
   }
 
-  const preflightRoot = await createPreflightRoot(params.gitRoot);
+  let preflightRoot: string;
+  try {
+    preflightRoot = await createPreflightRoot(params.gitRoot);
+  } catch (error) {
+    return {
+      status: "error",
+      reason: hasErrnoCode(error, "ENOSPC")
+        ? "preflight-insufficient-space"
+        : "preflight-worktree-failed",
+    };
+  }
   const worktreeDir = resolvePreflightWorktreeDir(preflightRoot);
   const worktreeStep = await runStep(
     params.step(
@@ -483,7 +497,13 @@ export async function runGitDevPreflight(params: {
   );
   if (worktreeStep.exitCode !== 0) {
     await removePathRecursive(preflightRoot);
-    return { status: "error", reason: "preflight-worktree-failed" };
+    return {
+      status: "error",
+      reason:
+        classifyPreflightFailure(worktreeStep) === "insufficient-space"
+          ? "preflight-insufficient-space"
+          : "preflight-worktree-failed",
+    };
   }
 
   let tested: PreflightCandidateResult | undefined;

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -1571,6 +1571,213 @@ describe("runGatewayUpdate", () => {
     expect(preflightInstallCommands).toEqual(["pnpm install"]);
   });
 
+  it.runIf(process.platform !== "win32").each([false, true])(
+    "stages dev preflight in artifact storage without dirtying the checkout (redirected: %s)",
+    async (redirected) => {
+      const parent = path.join(tempDir, "parent");
+      const checkout = path.join(parent, "checkout");
+      const alias = path.join(tempDir, "checkout-link");
+      const artifacts = redirected
+        ? path.join(tempDir, "external-artifacts")
+        : path.join(checkout, ".artifacts");
+      await writePreflightPackageManagerFixture(checkout, "pnpm@10.0.0");
+      await fs.copyFile(path.join(tempDir, "openclaw.mjs"), path.join(checkout, "openclaw.mjs"));
+      await runRealGit(checkout, "init", "--initial-branch=main");
+      await runRealGit(checkout, "config", "user.name", "OpenClaw Test");
+      await runRealGit(checkout, "config", "user.email", "openclaw@example.com");
+      await fs.symlink(checkout, alias, "dir");
+      await fs.mkdir(artifacts);
+      await fs.copyFile(
+        new URL("../../.gitignore", import.meta.url),
+        path.join(checkout, ".gitignore"),
+      );
+      if (redirected) {
+        await fs.symlink(artifacts, path.join(checkout, ".artifacts"), "dir");
+        // Directory ignores do not hide symlinks; track the operator's redirect
+        // so this fixture starts clean without altering the repository ignore rules.
+        await runRealGit(checkout, "add", ".artifacts");
+      }
+      await runRealGit(checkout, "add", ".gitignore", "package.json", "openclaw.mjs");
+      await runRealGit(checkout, "commit", "-m", "artifact storage");
+      const targetSha = await runRealGit(checkout, "rev-parse", "HEAD");
+      await fs.writeFile(path.join(artifacts, "keep.txt"), "existing artifact\n");
+      await fs.chmod(checkout, 0o755);
+      await fs.chmod(artifacts, 0o750);
+      const parentMode = (await fs.stat(parent)).mode & 0o777;
+      const artifactDevice = (await fs.stat(artifacts)).dev;
+      const initialStatus = await runRealGit(checkout, "status", "--porcelain");
+      expect(initialStatus).toBe("");
+      const runner = createRealGitUpdateRunner();
+      const preflightRoots: string[] = [];
+      const modes: number[] = [];
+      const devices: number[] = [];
+      const stagedStatuses: string[] = [];
+      try {
+        await fs.chmod(parent, 0o555);
+        const result = await runGatewayUpdate({
+          cwd: alias,
+          channel: "dev",
+          devTarget: { mode: "detached", ref: targetSha },
+          timeoutMs: 5000,
+          runCommand: async (argv, options) => {
+            if (
+              argv[0] === "pnpm" &&
+              argv[1] === "install" &&
+              options.cwd &&
+              options.cwd !== checkout
+            ) {
+              const root = await fs.realpath(path.dirname(options.cwd));
+              preflightRoots.push(root);
+              const stat = await fs.stat(root);
+              modes.push(stat.mode & 0o777);
+              devices.push(stat.dev);
+              stagedStatuses.push(await runRealGit(checkout, "status", "--porcelain"));
+            }
+            return runner(argv, options);
+          },
+          beforeGitMutation: async () => {
+            for (const root of preflightRoots) {
+              expect(await pathExists(root)).toBe(false);
+            }
+            expect(await runRealGit(checkout, "status", "--porcelain")).toBe("");
+          },
+        });
+        expect(result.status).toBe("ok");
+        expect(stagedStatuses).toEqual([initialStatus]);
+        expect(preflightRoots).toHaveLength(1);
+        for (const root of preflightRoots) {
+          expect(root.startsWith(`${artifacts}${path.sep}`)).toBe(true);
+        }
+        expect(modes).toEqual([0o700]);
+        expect(devices).toEqual([artifactDevice]);
+        expect((await fs.stat(checkout)).mode & 0o777).toBe(0o755);
+        expect((await fs.stat(parent)).mode & 0o777).toBe(0o555);
+        expect((await fs.stat(artifacts)).mode & 0o777).toBe(0o750);
+        expect(await fs.readdir(artifacts)).toEqual(["keep.txt"]);
+        expect(await runRealGit(checkout, "worktree", "list", "--porcelain")).not.toContain(
+          preflightRoots[0],
+        );
+      } finally {
+        await fs.chmod(parent, parentMode);
+      }
+    },
+  );
+
+  it.each([
+    {
+      command: "pnpm install",
+      stdout: "[ENOSPC] ENOSPC: no space left on device, write",
+      stderr: "",
+      capacity: true,
+    },
+    {
+      command: "pnpm install",
+      stdout:
+        "[ERR_PNPM_ENOSPC] [importPackage /checkout/node_modules/package] ENOSPC: no space left on device, copyfile 'store' -> 'package'",
+      stderr: "",
+      capacity: true,
+    },
+    {
+      command: "pnpm build",
+      stdout: "",
+      stderr: "Error: ENOSPC: no space left on device, write",
+      capacity: true,
+    },
+    {
+      command: "pnpm install",
+      stdout: "",
+      stderr:
+        "\u001b[31m[ERR_PNPM_ENOSPC]\u001b[0m ENOSPC: no space left on device, copyfile 'store' -> 'package'",
+      capacity: true,
+    },
+    {
+      command: "pnpm install",
+      stdout: "[ERR_SQLITE_ERROR] disk I/O error",
+      stderr: "",
+      capacity: false,
+    },
+    {
+      command: "pnpm build",
+      stdout: "",
+      stderr: "Error: ENOSPC: System limit for number of file watchers reached, watch 'src'",
+      capacity: false,
+    },
+    { command: "pnpm install", stdout: "", stderr: "ERR_PNPM_NETWORK", capacity: false },
+    {
+      command: "pnpm build",
+      stdout: "",
+      stderr: "test expected ENOSPC or disk full",
+      capacity: false,
+    },
+  ])(
+    "handles dev preflight failure without misclassifying capacity: $command $stdout $stderr",
+    async ({ command, stdout, stderr, capacity }) => {
+      await setupGitPackageManagerFixture();
+      let failed = false;
+      const { runCommand, calls } = createDevGitRunner({
+        onCommand: (key, options) => {
+          if (key === `git -C ${tempDir} rev-list --max-count=10 upstream123`) {
+            return { stdout: "upstream123\nolder123\n" };
+          }
+          const matchesCommand =
+            key === command ||
+            (command === "pnpm install" && key === "pnpm install --ignore-scripts");
+          if (matchesCommand && options?.cwd !== tempDir && !failed) {
+            failed = true;
+            return { code: 1, stdout, stderr };
+          }
+          return undefined;
+        },
+      });
+      const beforeGitMutation = vi.fn<() => Promise<void>>();
+      const result = await runWithCommand(runCommand, { channel: "dev", beforeGitMutation });
+      const candidates = result.steps.filter((step) => step.name.startsWith("preflight checkout"));
+      expect(candidates).toHaveLength(capacity ? 1 : 2);
+      expect(result.status).toBe(capacity ? "error" : "ok");
+      expect(result.reason).toBe(capacity ? "preflight-insufficient-space" : undefined);
+      expect(beforeGitMutation).toHaveBeenCalledTimes(capacity ? 0 : 1);
+      expect(result.steps).toContainEqual(
+        expect.objectContaining({
+          exitCode: 1,
+          stdoutTail: stdout || null,
+          stderrTail: stderr || null,
+        }),
+      );
+      for (const candidate of candidates) {
+        expect(await pathExists(path.dirname(candidate.cwd))).toBe(false);
+      }
+      expect(calls).toContain(`git -C ${tempDir} worktree prune`);
+      if (!capacity) {
+        expect(calls).toContain(`git -C ${tempDir} rebase older123`);
+      }
+    },
+  );
+
+  it("removes partial staging when preflight worktree creation fails", async () => {
+    await setupGitPackageManagerFixture();
+    const roots: string[] = [];
+    const { runCommand } = createDevGitRunner({
+      onCommand: async (key) => {
+        if (key.startsWith(`git -C ${tempDir} worktree add --detach `)) {
+          await writePreflightPackageManagerFixtureFromWorktreeAdd(key);
+          const worktree = /worktree add --detach (\S+)/u.exec(key)?.[1];
+          if (!worktree) {
+            throw new Error(`missing worktree path: ${key}`);
+          }
+          roots.push(path.dirname(worktree));
+          return { code: 128, stderr: "fatal: unable to create file: No space left on device" };
+        }
+        return undefined;
+      },
+    });
+    const result = await runWithCommand(runCommand, { channel: "dev" });
+    expect(result).toMatchObject({ status: "error", reason: "preflight-worktree-failed" });
+    expect(roots).toHaveLength(1);
+    for (const root of roots) {
+      expect(await pathExists(root)).toBe(false);
+    }
+  });
+
   it("continues dev preflight after one candidate is missing its package manager", async () => {
     await setupGitCheckout({ packageManager: "npm@10.0.0" });
     await setupUiIndex();
@@ -2129,6 +2336,47 @@ describe("runGatewayUpdate", () => {
     expect(cleanupStep?.exitCode).toBe(0);
     expect(cleanupTimeouts[0]).toBeLessThanOrEqual(60_000);
     expect(cleanupStep?.stderrTail ?? "").toContain("fallback cleanup removed preflight tree");
+  });
+
+  it("retains failed preflight cleanup diagnostics and still prunes worktree metadata", async () => {
+    await setupGitPackageManagerFixture();
+    const remove = fs.rm.bind(fs);
+    let preflightRoot: string | undefined;
+    const rmSpy = vi.spyOn(fs, "rm").mockImplementation(async (target, options) => {
+      if (typeof target === "string" && preflightRoot && target.startsWith(preflightRoot)) {
+        throw Object.assign(new Error("permission denied"), { code: "EACCES" });
+      }
+      return remove(target, options);
+    });
+    const { runCommand, calls } = createDevGitRunner({
+      onCommand: (key, options) => {
+        if (key.startsWith("pnpm install") && options?.cwd && options.cwd !== tempDir) {
+          preflightRoot = path.dirname(options.cwd);
+        }
+        if (key.startsWith(`git -C ${tempDir} worktree remove --force `)) {
+          return { code: 1, stderr: "error: failed to delete worktree: Permission denied" };
+        }
+        return undefined;
+      },
+    });
+    try {
+      const result = await runWithCommand(runCommand, { channel: "dev" });
+      expect(result.status).toBe("error");
+      expect(result.steps).toContainEqual(
+        expect.objectContaining({
+          name: "preflight cleanup",
+          exitCode: 1,
+          stderrTail: "error: failed to delete worktree: Permission denied",
+        }),
+      );
+      expect(calls).toContain(`git -C ${tempDir} worktree prune`);
+      expect(preflightRoot && (await pathExists(preflightRoot))).toBe(true);
+    } finally {
+      rmSpy.mockRestore();
+      if (preflightRoot) {
+        await remove(preflightRoot, { recursive: true, force: true });
+      }
+    }
   });
 
   it.each([

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -1664,6 +1664,31 @@ describe("runGatewayUpdate", () => {
   );
 
   it.each([
+    { operation: "mkdir", code: "ENOSPC", reason: "preflight-insufficient-space" },
+    { operation: "mkdtemp", code: "ENOSPC", reason: "preflight-insufficient-space" },
+    { operation: "mkdir", code: "EACCES", reason: "preflight-worktree-failed" },
+    { operation: "mkdtemp", code: "EROFS", reason: "preflight-worktree-failed" },
+  ] as const)(
+    "returns a structured preflight failure when $operation rejects with $code",
+    async ({ operation, code, reason }) => {
+      await setupGitPackageManagerFixture();
+      const { runCommand } = createDevGitRunner();
+      const beforeGitMutation = vi.fn<() => Promise<void>>();
+      const allocator = vi
+        .spyOn(fs, operation)
+        .mockRejectedValueOnce(Object.assign(new Error("preflight allocation failed"), { code }));
+      try {
+        await expect(
+          runWithCommand(runCommand, { channel: "dev", beforeGitMutation }),
+        ).resolves.toMatchObject({ status: "error", reason });
+        expect(beforeGitMutation).not.toHaveBeenCalled();
+      } finally {
+        allocator.mockRestore();
+      }
+    },
+  );
+
+  it.each([
     {
       command: "pnpm install",
       stdout: "[ENOSPC] ENOSPC: no space left on device, write",
@@ -1707,6 +1732,18 @@ describe("runGatewayUpdate", () => {
       command: "pnpm build",
       stdout: "",
       stderr: "test expected ENOSPC or disk full",
+      capacity: false,
+    },
+    {
+      command: "pnpm build",
+      stdout: "",
+      stderr: "test expected fatal: unable to create file: No space left on device",
+      capacity: false,
+    },
+    {
+      command: "pnpm build",
+      stdout: "",
+      stderr: "fatal: unable to create file: No space left on device (expected)",
       capacity: false,
     },
   ])(
@@ -1753,30 +1790,52 @@ describe("runGatewayUpdate", () => {
     },
   );
 
-  it("removes partial staging when preflight worktree creation fails", async () => {
-    await setupGitPackageManagerFixture();
-    const roots: string[] = [];
-    const { runCommand } = createDevGitRunner({
-      onCommand: async (key) => {
-        if (key.startsWith(`git -C ${tempDir} worktree add --detach `)) {
-          await writePreflightPackageManagerFixtureFromWorktreeAdd(key);
-          const worktree = /worktree add --detach (\S+)/u.exec(key)?.[1];
-          if (!worktree) {
-            throw new Error(`missing worktree path: ${key}`);
+  it.each([
+    {
+      stderr: "fatal: unable to create file: No space left on device",
+      reason: "preflight-insufficient-space",
+    },
+    {
+      stderr: "error: cannot create directory at 'src': No space left on device",
+      reason: "preflight-insufficient-space",
+    },
+    {
+      stderr: "fatal: could not create leading directories of 'worktree': No space left on device",
+      reason: "preflight-insufficient-space",
+    },
+    {
+      stderr: "fatal: unable to create file: Permission denied",
+      reason: "preflight-worktree-failed",
+    },
+  ])(
+    "classifies preflight worktree creation failure and removes partial staging: $stderr",
+    async ({ stderr, reason }) => {
+      await setupGitPackageManagerFixture();
+      const roots: string[] = [];
+      const { runCommand } = createDevGitRunner({
+        onCommand: async (key) => {
+          if (key.startsWith(`git -C ${tempDir} worktree add --detach `)) {
+            await writePreflightPackageManagerFixtureFromWorktreeAdd(key);
+            const worktree = /worktree add --detach (\S+)/u.exec(key)?.[1];
+            if (!worktree) {
+              throw new Error(`missing worktree path: ${key}`);
+            }
+            roots.push(path.dirname(worktree));
+            return { code: 128, stderr };
           }
-          roots.push(path.dirname(worktree));
-          return { code: 128, stderr: "fatal: unable to create file: No space left on device" };
-        }
-        return undefined;
-      },
-    });
-    const result = await runWithCommand(runCommand, { channel: "dev" });
-    expect(result).toMatchObject({ status: "error", reason: "preflight-worktree-failed" });
-    expect(roots).toHaveLength(1);
-    for (const root of roots) {
-      expect(await pathExists(root)).toBe(false);
-    }
-  });
+          return undefined;
+        },
+      });
+      const beforeGitMutation = vi.fn<() => Promise<void>>();
+      const result = await runWithCommand(runCommand, { channel: "dev", beforeGitMutation });
+      expect(result).toMatchObject({ status: "error", reason });
+      expect(beforeGitMutation).not.toHaveBeenCalled();
+      expect(roots).toHaveLength(1);
+      for (const root of roots) {
+        expect(await pathExists(root)).toBe(false);
+      }
+    },
+  );
 
   it("continues dev preflight after one candidate is missing its package manager", async () => {
     await setupGitCheckout({ packageManager: "npm@10.0.0" });

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -1580,7 +1580,7 @@ describe("runGatewayUpdate", () => {
       const artifacts = redirected
         ? path.join(tempDir, "external-artifacts")
         : path.join(checkout, ".artifacts");
-      await writePreflightPackageManagerFixture(checkout, "pnpm@10.0.0");
+      await writePreflightPackageManagerFixture(checkout);
       await fs.copyFile(path.join(tempDir, "openclaw.mjs"), path.join(checkout, "openclaw.mjs"));
       await runRealGit(checkout, "init", "--initial-branch=main");
       await runRealGit(checkout, "config", "user.name", "OpenClaw Test");


### PR DESCRIPTION
Closes #131989 — POSIX dev-update preflight exhausts a small system tmpfs and retries capacity failures.

## What Problem This Solves

Fixes an issue where operators updating to the dev channel could exhaust a small POSIX temporary filesystem despite having ample space on the checkout volume. The updater then tried older commits against the same exhausted storage and eventually reported `preflight-no-good-commit`, obscuring the actionable cause.

## Why This Change Was Made

Stage the private preflight worktree in the checkout's existing ignored `.artifacts` area, honoring an existing artifact redirect without changing directory permissions. Record storage exhaustion at the preflight owner and stop candidate walkback; preserve ordinary candidate failures, missing-manager precedence, Windows short paths, reset/clean isolation, and cleanup/pruning.

A direct hidden child of the checkout was rejected because an interrupted update would leave untracked staging that blocks the next update's clean-check. The existing artifact area solves both placement and interruption without a new ignore rule, consumer exception, cleanup registry, or configuration switch.

The structured capacity outcome covers all producer boundaries: Node `ENOSPC` from artifact allocation, Git's exact `No space left on device` worktree-creation diagnostics, and candidate command output. Other allocation failures remain structured as `preflight-worktree-failed`; watcher-limit ENOSPC, generic SQLite I/O, network failures, and arbitrary prose remain ordinary candidate failures.

## User Impact

POSIX dev updates no longer put the candidate workspace and filesystem-local package store on the system temporary volume by default. Confirmed storage exhaustion produces recovery guidance to free the staging/store filesystems rather than blaming candidate commits. The updater does not delete shared package stores or change existing checkout, parent, or artifact-directory permissions.

This fixes the updater containing this code, not an already-running historical binary. The published `2026.7.1-2` first hop remains unchanged until an operator installs a later updater containing the repair. No release, version bump, dependency change, schema change, or new configuration/environment option is included.

## Evidence

- **Exact head:** `cadf8cd5f7c7c1e31a3d97024e9627645666fd83`.
- Original Parallels Ubuntu reproduction: literal public `openclaw@2026.7.1-2`, default small `/tmp` tmpfs, and free checkout-volume storage. pnpm reported `[ENOSPC] ENOSPC: no space left on device, write`; later candidates degraded into package-store SQLite I/O failures. A separate 8 GB build-memory guard was not bypassed.
- Pre-fix owner regressions captured seven intended failures: `mkdir`/`mkdtemp` ENOSPC escaped instead of resolving, non-capacity allocation errors escaped instead of remaining structured, and three standard Git worktree no-space diagnostics returned the generic reason. All eleven selected negative/neighbor controls passed before production changed.
- Final owner suite passed **123/123** tests. It covers default and redirected artifact storage, real Git cleanliness and device placement, private child permissions, allocation ENOSPC, structured EACCES/EROFS, Git worktree ENOSPC variants, partial-root cleanup, candidate classification, failed cleanup diagnostics, and CLI recovery text.
- Complete changed-file gate passed, including formatting, core and test typechecks, lint, dead exports, import cycles, dependency/boundary guards, and `git diff --check`. Fresh full-branch P0 autoreview completed in ten validated chunks with no actionable findings.
- [Exact-head CI run 33238189571](https://github.com/openclaw/openclaw/actions/runs/33238189571) is green.
- Canonical package preparation built version `2026.8.1` from the exact clean head. Core SHA-256: `ae387577b4cd9c2f28e4435347c5bbff4b05d58e5c9588c731f6cae039f4fa73`; the sole reviewed companion was `@openclaw/codex@2026.8.1`, with source identity pinned to the same SHA.
- Exact-head Ubuntu proof passed through the installed candidate updater's real unpinned `update --channel dev`. The admitted fixture preserved the original **3,878,404,096-byte `/tmp` tmpfs** with real 12 GB RAM and no guest `TMPDIR`, heap, source-ref, runtime, or validation workaround.
- During the live preflight, `/tmp` was tmpfs device `48`; the checkout and active worktree `.artifacts/.openclaw-update-preflight-*/worktree` were ext4 device `2050`. Candidate dependency installation, build, config validation, staging cleanup, final dependency installation/build, and Doctor all passed. No candidate failed or was retried.
- The update selected public-main commit `9323d427b8255b2ae72452875ad6800f049c279b`, then npm staged and atomically swapped the global package root to that exact clean source checkout. Build identity, launcher, runtime stamps, Control UI, channel `dev`, pnpm dependency state, and source ancestry passed.
- Native Codex turns passed before and after the update with no fallback. Config, workspace, marker, provider/model, runtime ID, and the earlier session row were preserved. The unrelated dirty checkout retained HEAD, status, and protected-file SHA-256 exactly.
- Persistent Parallels SDK transport completed **351/351** requests across two retained-handle generations with zero unknown outcomes and zero timeouts. Both carriers closed cleanly. The VM returned to the original power-off snapshot, 8192 MB, stopped; no task Gateway, helper, credential file/FIFO, or transport process remained.
- Latest ClawSweeper P1 is addressed: allocator and worktree-creation ENOSPC now share the documented structured outcome, with focused regressions. Its exact-head packaged-trace rank-up move is also complete. No re-review was requested because the review is under 12 hours old and the only later behavior change is the reviewed finding plus its tests.
- The separate package-to-Git source-link defect is already fixed on current `main` by [#131043](https://github.com/openclaw/openclaw/pull/131043) / commit `b85a049da5e8cc4b96c64846a45c645258c43586`. This PR inherits that exact checkout/SHA/runtime verifier unchanged and no longer claims ownership of #132283.

Focused commands:

```bash
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-pr132085-enospc-parent node scripts/run-vitest.mjs src/infra/update-runner.test.ts src/cli/update-cli/progress.test.ts
```

```bash
node scripts/check-changed.mjs
```

```bash
node scripts/watch-pr-ci.mjs 132085 cadf8cd5f7c7c1e31a3d97024e9627645666fd83
```

Production LOC: **+153/-113 (net +40)**. Tests: **+315/-0**. Docs: **+14/-1**. Production growth implements the checkout-owned private allocator, closed capacity outcome across allocation/worktree/candidate boundaries, and actionable recovery guidance while replacing the former parallel candidate-failure flags. No test-only production seam was added.

Provenance: `ff3d8cab2bc98b5b8a2c098dfc442b56ab328640` (2026-01-22, authored/committed by @steipete) introduced system-temporary staging and candidate walkback. This repair preserves later manager-failure precedence and candidate reset/clean isolation.

Related but not closed: #121685 (pre-mutation capacity admission) and #125416 (operation-aware capacity assessment). Those broader product/design requests are not implemented by this focused owner repair.

AI-assisted implementation; maintainer-directed investigation and verification.
