### PR TITLE
fix(gateway): retain rejecting resolver ownership across dispatch

### DIFF
--- a/src/agents/subagents/registry/subagent-gateway-context-binding.test.ts
+++ b/src/agents/subagents/registry/subagent-gateway-context-binding.test.ts
@@ -28,8 +28,12 @@ describe("subagent Gateway context binding", () => {
       const second = createSubagentRunRecord({ runId: "run-second" });
       const firstContext = { owner: "gateway-a" } as never;
       const secondContext = { owner: "gateway-b" } as never;
-      if (mode !== "first-unbound") bindGatewayContextResolver(first, () => firstContext);
-      if (mode !== "second-unbound") bindGatewayContextResolver(second, () => secondContext);
+      if (mode !== "first-unbound") {
+        bindGatewayContextResolver(first, () => firstContext);
+      }
+      if (mode !== "second-unbound") {
+        bindGatewayContextResolver(second, () => secondContext);
+      }
 
       const shared = getSharedGatewayContextResolver([first, second]);
       expect(shared).toBeTypeOf("function");

--- a/src/agents/subagents/registry/subagent-gateway-context-binding.test.ts
+++ b/src/agents/subagents/registry/subagent-gateway-context-binding.test.ts
@@ -21,16 +21,30 @@ describe("subagent Gateway context binding", () => {
     expect(getGatewayContextResolver(restored)).toBeUndefined();
   });
 
-  it("refuses to select one Gateway for a mixed-owner settle batch", () => {
-    const first = createSubagentRunRecord({ runId: "run-first" });
-    const second = createSubagentRunRecord({ runId: "run-second" });
-    const firstContext = { owner: "gateway-a" } as never;
-    const secondContext = { owner: "gateway-b" } as never;
-    bindGatewayContextResolver(first, () => firstContext);
-    bindGatewayContextResolver(second, () => secondContext);
+  it.each(["distinct", "first-unbound", "second-unbound"])(
+    "rejects a %s settle batch without losing its binding",
+    (mode) => {
+      const first = createSubagentRunRecord({ runId: "run-first" });
+      const second = createSubagentRunRecord({ runId: "run-second" });
+      const firstContext = { owner: "gateway-a" } as never;
+      const secondContext = { owner: "gateway-b" } as never;
+      if (mode !== "first-unbound") bindGatewayContextResolver(first, () => firstContext);
+      if (mode !== "second-unbound") bindGatewayContextResolver(second, () => secondContext);
 
-    expect(getGatewayContextResolver(first)?.()).toBe(firstContext);
-    expect(getGatewayContextResolver(second)?.()).toBe(secondContext);
+      const shared = getSharedGatewayContextResolver([first, second]);
+      expect(shared).toBeTypeOf("function");
+      expect(shared?.()).toBeUndefined();
+    },
+  );
+
+  it("preserves a shared owner and leaves wholly unbound batches unbound", () => {
+    const first = {};
+    const second = {};
+    const resolver = () => ({ owner: "gateway-a" }) as never;
+    expect(getSharedGatewayContextResolver([])).toBeUndefined();
     expect(getSharedGatewayContextResolver([first, second])).toBeUndefined();
+    bindGatewayContextResolver(first, resolver);
+    bindGatewayContextResolver(second, resolver);
+    expect(getSharedGatewayContextResolver([first, second])).toBe(resolver);
   });
 });

--- a/src/agents/subagents/spawn/subagent-spawn-gateway.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-gateway.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { withPluginRuntimeGatewayRequestScope } from "../../../plugins/runtime/gateway-request-scope.js";
+import { withGatewayToolCallerIdentity } from "../../tools/gateway-caller-context.js";
+import { setSubagentSpawnDepsForTest } from "./subagent-spawn-deps.js";
+import { callNativeSubagentGateway } from "./subagent-spawn-gateway.js";
+
+vi.mock("./subagent-spawn.runtime.js", async () => {
+  const dispatch = await import("../../../gateway/server-plugin-in-process-dispatch.js");
+  const scopes = await import("../../../gateway/method-scopes.js");
+  return {
+    ...scopes,
+    dispatchGatewayMethodInProcess: dispatch.dispatchGatewayMethodInProcess,
+    hasInProcessGatewayContext: () => Boolean(dispatch.getInProcessGatewayRequestContext()),
+    callGateway: vi.fn(),
+    ensureContextEnginesInitialized: vi.fn(),
+    forkSessionEntryFromParent: vi.fn(),
+    getGlobalHookRunner: vi.fn(),
+    getRuntimeConfig: vi.fn(),
+    loadPreparedModelCatalog: vi.fn(),
+    resolveProviderRefOwnership: vi.fn(),
+    resolveContextEngine: vi.fn(),
+  };
+});
+
+vi.mock("../../tools/gateway.js", () => ({ callGatewayTool: vi.fn() }));
+
+afterEach(() => setSubagentSpawnDepsForTest());
+
+describe("native subagent Gateway transport ownership", () => {
+  it.each(["caller", "captured", "scoped"])(
+    "rejects a retired %s binding without opening a socket",
+    async (binding) => {
+      const callGateway = vi.fn(
+        async <T>() => ({ runId: "wrong-gateway", status: "accepted" }) as T,
+      );
+      setSubagentSpawnDepsForTest({ callGateway });
+      const resolver = () => undefined;
+      const launch = () =>
+        callNativeSubagentGateway(
+          {
+            method: "agent",
+            params: { message: "must not launch", idempotencyKey: "closed-owner" },
+          },
+          undefined,
+          binding === "captured" ? resolver : undefined,
+        );
+      const result =
+        binding === "caller"
+          ? withGatewayToolCallerIdentity(
+              { agentId: "main", sessionKey: "agent:main:main", gatewayContextResolver: resolver },
+              launch,
+            )
+          : binding === "scoped"
+            ? withPluginRuntimeGatewayRequestScope(
+                { resolveGatewayContext: resolver, isWebchatConnect: () => false },
+                launch,
+              )
+            : launch();
+
+      await expect(result).rejects.toThrow("instance binding");
+      expect(callGateway).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps socket dispatch available when no Gateway owner was bound", async () => {
+    const callGateway = vi.fn(async <T>() => ({ runId: "remote-run", status: "accepted" }) as T);
+    setSubagentSpawnDepsForTest({ callGateway });
+
+    await expect(
+      callNativeSubagentGateway({
+        method: "agent",
+        params: { message: "standalone", idempotencyKey: "remote-run" },
+      }),
+    ).resolves.toEqual({
+      response: { runId: "remote-run", status: "accepted" },
+      taskRowOwnership: "gateway_best_effort",
+    });
+    expect(callGateway).toHaveBeenCalledOnce();
+  });
+});

--- a/src/agents/subagents/spawn/subagent-spawn-gateway.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-gateway.test.ts
@@ -30,10 +30,13 @@ describe("native subagent Gateway transport ownership", () => {
   it.each(["caller", "captured", "scoped"])(
     "rejects a retired %s binding without opening a socket",
     async (binding) => {
-      const callGateway = vi.fn(
-        async <T>() => ({ runId: "wrong-gateway", status: "accepted" }) as T,
-      );
-      setSubagentSpawnDepsForTest({ callGateway });
+      const callGateway = vi.fn<() => void>();
+      setSubagentSpawnDepsForTest({
+        callGateway: async <T>() => {
+          callGateway();
+          return { runId: "wrong-gateway", status: "accepted" } as T;
+        },
+      });
       const resolver = () => undefined;
       const launch = () =>
         callNativeSubagentGateway(
@@ -63,8 +66,13 @@ describe("native subagent Gateway transport ownership", () => {
   );
 
   it("keeps socket dispatch available when no Gateway owner was bound", async () => {
-    const callGateway = vi.fn(async <T>() => ({ runId: "remote-run", status: "accepted" }) as T);
-    setSubagentSpawnDepsForTest({ callGateway });
+    const callGateway = vi.fn<() => void>();
+    setSubagentSpawnDepsForTest({
+      callGateway: async <T>() => {
+        callGateway();
+        return { runId: "remote-run", status: "accepted" } as T;
+      },
+    });
 
     await expect(
       callNativeSubagentGateway({

--- a/src/agents/subagents/spawn/subagent-spawn-gateway.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-gateway.ts
@@ -2,9 +2,11 @@ import { setTimeout as delay } from "node:timers/promises";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import type { AgentRuntimeIdentity } from "../../../gateway/agent-runtime-identity-token.js";
 import { withInProcessAgentRuntimeIdentity } from "../../../gateway/in-process-agent-runtime-identity.js";
+import type { GatewayContextResolver } from "../../../gateway/server-methods/types.js";
 import { isGatewayRpcUnavailableError } from "../../../gateway/transport-error.js";
 import type { WorkerTurnExecutionIdentity } from "../../../gateway/worker-environments/placement-turn-claim-events.js";
 import { getActiveAgentRunDelegatedAuthority } from "../../../infra/agent-run-registry.js";
+import { getPluginRuntimeGatewayRequestScope } from "../../../plugins/runtime/gateway-request-scope.js";
 import { getGatewayToolCallerIdentity } from "../../tools/gateway-caller-context.js";
 import { runWithGatewaySessionSpawnContext } from "../../tools/gateway-session-spawn-context.js";
 import { runWithGatewaySessionSpawnParentExecutionIdentity } from "../../tools/gateway-session-spawn-execution-identity.js";
@@ -31,7 +33,10 @@ type SubagentGatewayDispatchMode = "in_process" | "out_of_process";
 async function callSubagentGatewayWithDispatchMode(
   params: Parameters<typeof callGateway>[0],
   authorization?: SubagentLaunchAuthorization,
-  options?: { agentRunTracking?: "native_subagent" },
+  options?: {
+    agentRunTracking?: "native_subagent";
+    gatewayContextResolver?: GatewayContextResolver;
+  },
 ): Promise<{ response: SubagentGatewayResponse; dispatchMode: SubagentGatewayDispatchMode }> {
   const { sessionSpawnContext, parentExecutionIdentityToken } =
     readSubagentGatewayExecutionIdentity(params) ?? {};
@@ -56,8 +61,13 @@ async function callSubagentGatewayWithDispatchMode(
   const allowModelOverride = authorization !== undefined;
   const deps = getSubagentSpawnDeps();
   const gatewayCaller = getGatewayToolCallerIdentity();
+  const gatewayContextResolver =
+    options?.gatewayContextResolver ??
+    gatewayCaller?.gatewayContextResolver ??
+    getPluginRuntimeGatewayRequestScope()?.resolveGatewayContext;
+  // A closed owner still requires in-process rejection, never a new socket route.
   const hasInProcessGateway =
-    deps.hasInProcessGatewayContext() || Boolean(gatewayCaller?.gatewayContextResolver?.());
+    gatewayContextResolver !== undefined || deps.hasInProcessGatewayContext();
   const needsOutOfProcessModelOverrideAuth = allowModelOverride && !hasInProcessGateway;
   const scopes =
     params.scopes ??
@@ -113,9 +123,7 @@ async function callSubagentGatewayWithDispatchMode(
             expectFinal: request.expectFinal,
             ...(allowModelOverride ? { allowSyntheticModelOverride: true } : {}),
             ...(options?.agentRunTracking ? { agentRunTracking: options.agentRunTracking } : {}),
-            ...(gatewayCaller?.gatewayContextResolver
-              ? { resolveGatewayContext: gatewayCaller.gatewayContextResolver }
-              : {}),
+            ...(gatewayContextResolver ? { resolveGatewayContext: gatewayContextResolver } : {}),
             ...(forceSyntheticClient ? { forceSyntheticClient: true } : {}),
             ...(typeof request.timeoutMs === "number" ? { timeoutMs: request.timeoutMs } : {}),
             ...(scopes != null ? { syntheticScopes: scopes } : {}),
@@ -219,12 +227,14 @@ export async function callSubagentGateway(
 export async function callNativeSubagentGateway(
   params: Parameters<typeof callGateway>[0],
   authorization?: SubagentLaunchAuthorization,
+  gatewayContextResolver?: GatewayContextResolver,
 ): Promise<{
   response: SubagentGatewayResponse;
   taskRowOwnership: "required" | "gateway_best_effort";
 }> {
   const result = await callSubagentGatewayWithDispatchMode(params, authorization, {
     agentRunTracking: "native_subagent",
+    gatewayContextResolver,
   });
   return {
     response: result.response,

--- a/src/agents/subagents/spawn/subagent-spawn.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.ts
@@ -402,6 +402,7 @@ export async function spawnSubagentDirect(
           },
         ),
         childLaunch.authorization,
+        gatewayContextResolver,
       );
 
     const emitSpawnLifecycleHooks = createSubagentSpawnLifecycleEmitter({

--- a/src/gateway/server-plugin-in-process-dispatch.authorization.test.ts
+++ b/src/gateway/server-plugin-in-process-dispatch.authorization.test.ts
@@ -159,82 +159,97 @@ describe("typed in-process agent authorization", () => {
     });
   });
 
-  it("does not fall back to ambient scope when an explicit Gateway binding is retired", async () => {
-    const ambient = createContext();
-    ambient.getGatewayMethodRegistry = () =>
-      createGatewayMethodRegistry([
-        {
-          name: "sessions.list",
-          scope: "operator.read",
-          owner: { kind: "core", area: "sessions" },
-          handler: ({ respond }: GatewayRequestHandlerOptions) => {
-            respond(true, { sessions: [] });
+  it.each(["explicit", "scoped"])(
+    "does not fall back to ambient scope when a %s Gateway binding is retired",
+    async (binding) => {
+      const ambient = createContext();
+      ambient.getGatewayMethodRegistry = () =>
+        createGatewayMethodRegistry([
+          {
+            name: "sessions.list",
+            scope: "operator.read",
+            owner: { kind: "core", area: "sessions" },
+            handler: ({ respond }: GatewayRequestHandlerOptions) => {
+              respond(true, { sessions: [] });
+            },
           },
-        },
-      ]);
+        ]);
 
-    await withPluginRuntimeGatewayRequestScope(
-      {
-        context: ambient,
-        isWebchatConnect: () => false,
-      },
-      async () =>
-        await expect(
+      await withPluginRuntimeGatewayRequestScope(
+        {
+          context: ambient,
+          ...(binding === "scoped" ? { resolveGatewayContext: () => undefined } : {}),
+          isWebchatConnect: () => false,
+        },
+        async () =>
+          await expect(
+            dispatchGatewayMethodInProcess(
+              "sessions.list",
+              {},
+              {
+                forceSyntheticClient: true,
+                ...(binding === "explicit" ? { resolveGatewayContext: () => undefined } : {}),
+                syntheticScopes: ["operator.read"],
+              },
+            ),
+          ).rejects.toThrow("instance binding"),
+      );
+    },
+  );
+
+  it.each(["explicit", "scoped"])(
+    "carries a %s Gateway binding into the session mutation commit guard",
+    async (binding) => {
+      const admitted = createContext();
+      const replacement = createContext();
+      let current = admitted;
+      let committed = false;
+      const setupStarted = createDeferredCore();
+      const releaseSetup = createDeferredCore();
+      admitted.getGatewayMethodRegistry = () =>
+        createGatewayMethodRegistry([
+          {
+            name: "sessions.create",
+            scope: "operator.write",
+            owner: { kind: "core", area: "sessions" },
+            handler: async ({
+              respond,
+              sessionMutationCommitGuard,
+            }: GatewayRequestHandlerOptions) => {
+              setupStarted.resolve();
+              await releaseSetup.promise;
+              sessionMutationCommitGuard?.();
+              committed = true;
+              respond(true, { key: "agent:main:dashboard:child" });
+            },
+          },
+        ]);
+
+      const dispatch = withPluginRuntimeGatewayRequestScope(
+        {
+          context: admitted,
+          isWebchatConnect: () => false,
+          ...(binding === "scoped" ? { resolveGatewayContext: () => current } : {}),
+        },
+        () =>
           dispatchGatewayMethodInProcess(
-            "sessions.list",
-            {},
+            "sessions.create",
+            { agentId: "main" },
             {
               forceSyntheticClient: true,
-              resolveGatewayContext: () => undefined,
-              syntheticScopes: ["operator.read"],
+              ...(binding === "explicit" ? { resolveGatewayContext: () => current } : {}),
+              syntheticScopes: ["operator.write"],
             },
           ),
-        ).rejects.toThrow("instance binding"),
-    );
-  });
+      );
+      await setupStarted.promise;
+      current = replacement;
+      releaseSetup.resolve();
 
-  it("carries an explicit Gateway binding into the session mutation commit guard", async () => {
-    const admitted = createContext();
-    const replacement = createContext();
-    let current = admitted;
-    let committed = false;
-    const setupStarted = createDeferredCore();
-    const releaseSetup = createDeferredCore();
-    admitted.getGatewayMethodRegistry = () =>
-      createGatewayMethodRegistry([
-        {
-          name: "sessions.create",
-          scope: "operator.write",
-          owner: { kind: "core", area: "sessions" },
-          handler: async ({
-            respond,
-            sessionMutationCommitGuard,
-          }: GatewayRequestHandlerOptions) => {
-            setupStarted.resolve();
-            await releaseSetup.promise;
-            sessionMutationCommitGuard?.();
-            committed = true;
-            respond(true, { key: "agent:main:dashboard:child" });
-          },
-        },
-      ]);
-
-    const dispatch = dispatchGatewayMethodInProcess(
-      "sessions.create",
-      { agentId: "main" },
-      {
-        forceSyntheticClient: true,
-        resolveGatewayContext: () => current,
-        syntheticScopes: ["operator.write"],
-      },
-    );
-    await setupStarted.promise;
-    current = replacement;
-    releaseSetup.resolve();
-
-    await expect(dispatch).rejects.toThrow("current gateway instance binding");
-    expect(committed).toBe(false);
-  });
+      await expect(dispatch).rejects.toThrow("current gateway instance binding");
+      expect(committed).toBe(false);
+    },
+  );
 
   it("composes caller authority into the session mutation commit guard", async () => {
     const admitted = createContext();

--- a/src/gateway/server-plugin-in-process-dispatch.ts
+++ b/src/gateway/server-plugin-in-process-dispatch.ts
@@ -88,6 +88,7 @@ type DispatchGatewayMethodInProcessOptions = {
 };
 
 type ResolvedInProcessGatewayDispatch = {
+  assertContextCurrent: () => void;
   client: NonNullable<GatewayRequestOptions["client"]>;
   context: GatewayRequestContext;
   delegatedToolPolicyHandoffId?: string;
@@ -131,7 +132,9 @@ function resolveInProcessGatewayDispatch(
             ? undefined
             : (explicitSystemActor ?? { kind: "system" })))
     : (scopedRoleActor ?? explicitSystemActor);
-  const context = getInProcessGatewayRequestContext(options?.resolveGatewayContext);
+  // The router installs a nested scope; retain the admitted resolver for later commit checks.
+  const resolveGatewayContext = options?.resolveGatewayContext ?? scope?.resolveGatewayContext;
+  const context = getInProcessGatewayRequestContext(resolveGatewayContext);
   const isWebchatConnect = scope?.isWebchatConnect ?? (() => false);
   if (!context) {
     throw new Error(
@@ -244,6 +247,13 @@ function resolveInProcessGatewayDispatch(
     throw new Error(`In-process gateway dispatch requires a scoped client (method: ${method}).`);
   }
   return {
+    assertContextCurrent: () => {
+      if ((resolveGatewayContext ? resolveGatewayContext() : scope?.context) !== context) {
+        throw new Error(
+          `In-process gateway dispatch requires a current gateway instance binding (method: ${method}).`,
+        );
+      }
+    },
     client:
       options?.forceSyntheticClient === true ? syntheticClient : (scopedClient ?? syntheticClient),
     context,
@@ -277,22 +287,6 @@ export async function dispatchGatewayMethodInProcessRaw(
   options?: DispatchGatewayMethodInProcessOptions,
 ): Promise<GatewayMethodDispatchResponse> {
   return await withInProcessGatewayDispatch(method, options, async (resolved) => {
-    const assertGatewayContextCurrent = options?.resolveGatewayContext
-      ? () => {
-          if (options.resolveGatewayContext?.() !== resolved.context) {
-            throw new Error(
-              `In-process gateway dispatch requires a current gateway instance binding (method: ${method}).`,
-            );
-          }
-        }
-      : undefined;
-    const sessionMutationCommitGuard =
-      assertGatewayContextCurrent || options?.sessionMutationCommitGuard
-        ? () => {
-            assertGatewayContextCurrent?.();
-            options?.sessionMutationCommitGuard?.();
-          }
-        : undefined;
     return await dispatchGatewayRequestInProcessRaw(method, params, {
       client: resolved.client,
       context: resolved.context,
@@ -302,7 +296,10 @@ export async function dispatchGatewayMethodInProcessRaw(
       onAccepted: options?.onAccepted,
       onSignalAbort: options?.onSignalAbort,
       requestIdPrefix: "plugin-subagent",
-      ...(sessionMutationCommitGuard ? { sessionMutationCommitGuard } : {}),
+      sessionMutationCommitGuard: () => {
+        resolved.assertContextCurrent();
+        options?.sessionMutationCommitGuard?.();
+      },
       timeoutMs: options?.timeoutMs,
       ...(options?.signal ? { signal: options.signal } : {}),
     });
@@ -317,7 +314,7 @@ export function getInProcessGatewayRequestContext(
     return resolveGatewayContext();
   }
   const scope = getPluginRuntimeGatewayRequestScope();
-  return scope?.resolveGatewayContext?.() ?? scope?.context;
+  return scope?.resolveGatewayContext ? scope.resolveGatewayContext() : scope?.context;
 }
 
 export async function dispatchGatewayMethodInProcess<T>(
@@ -328,20 +325,11 @@ export async function dispatchGatewayMethodInProcess<T>(
   if (method === "agent" || method === "agent.wait") {
     return await withInProcessGatewayDispatch(method, options, async (resolved) => {
       const { createInternalAgentTurnFacade } = await loadInternalAgentTurnFacade();
-      const assertContextCurrent = () => {
-        if (
-          getInProcessGatewayRequestContext(options?.resolveGatewayContext) !== resolved.context
-        ) {
-          throw new Error(
-            `In-process gateway dispatch requires a current gateway instance binding (method: ${method}).`,
-          );
-        }
-      };
       const facade = createInternalAgentTurnFacade({
-        assertContextCurrent,
+        assertContextCurrent: resolved.assertContextCurrent,
         client: resolved.client,
         getContext: () => {
-          assertContextCurrent();
+          resolved.assertContextCurrent();
           return resolved.context;
         },
         ...(resolved.context.getGatewayMethodRegistry

--- a/src/plugins/runtime/gateway-request-scope.ts
+++ b/src/plugins/runtime/gateway-request-scope.ts
@@ -82,9 +82,10 @@ export function getSharedGatewayContextResolver(
   owners: readonly object[],
 ): GatewayContextResolver | undefined {
   const first = owners[0] ? gatewayContextResolvers.get(owners[0]) : undefined;
-  return first && owners.every((owner) => gatewayContextResolvers.get(owner) === first)
+  // Absence permits ambient routing; incompatible owners must retain a rejecting binding.
+  return owners.every((owner) => gatewayContextResolvers.get(owner) === first)
     ? first
-    : undefined;
+    : () => undefined;
 }
 
 /**


### PR DESCRIPTION
## What Problem This Solves

Closed or incompatible Gateway owners could be mistaken for absent ownership, allowing a queued subagent launch or completion batch to reach an ambient Gateway or open a new socket. An awaited session mutation could also lose the original scoped binding when the router installed its nested request scope.

## Why This Change Was Made

Preserve resolver presence at the batch producer and native transport selector, and capture the explicit/scoped resolver once at dispatch admission. One owner-held assertion now serves both raw session commit guards and the typed agent facade. Wholly unbound standalone callers retain the documented WebSocket path. No retry, alternate authorization route, provider special case or compatibility layer is added.

The earlier binding producer came from #126122 (f2297701dd345247d9e3ae8fa6516a6c1aaf75fb). This repair preserves Vincent Koc's coauthor credit from the prior release repair. Adjacent heartbeat/visible-spawn and registry-control-message PRs #126790 and #131455 remain separate scopes.

## User Impact

Retained work receives a visible unavailable-instance rejection after its owner closes or changes, instead of running against another Gateway. Session writes revalidate the owner after awaited preparation. Ordinary owner-bound and wholly unbound paths keep their existing behavior.

## Evidence

Clean Linux Blacksmith Testbox proof passed 297 tests across 11 owner/sibling files and a full build. Production is unchanged from that run. Subsequent type checks and changed-file guards passed across documented retries: the first run found generic test-mock typing errors; the next passed all 14 core test type programs but found test-only brace/await lint issues; the final run passed all 32 affected tests, scoped lint, and remaining guards. This was not one uninterrupted green changed-file invocation. Both proof leases were stopped. [Build/test environment](https://github.com/openclaw/openclaw/actions/runs/33201820345), [type/guard environment](https://github.com/openclaw/openclaw/actions/runs/33203334821).

Fresh Codex autoreview of the complete repair and subsequent mechanical test corrections reported no accepted/actionable findings at the default P0 threshold. No production changes followed. Owner-boundary integration proof is not a live authenticated provider/channel session or full release matrix; exact PR-head hosted CI and native maintainer gates remain required. AI-assisted. No config option, schema, protocol, dependency, version, tag or selector changes.

Eight regression cases failed before repair: mixed-owner batches (three), retired native bindings from caller/captured/scope (three), scoped ambient fallback and scoped session commit (two). Regressions exercise the real router/dispatcher and commit guard; the native fixture replaces the unused socket/spawn dependencies. The initial attempt to reread ambient scope failed the new commit test; capture at admission fixed it.

```sh
node scripts/run-vitest.mjs src/agents/subagents/registry/subagent-gateway-context-binding.test.ts src/agents/subagents/spawn/subagent-spawn-gateway.test.ts src/gateway/server-plugin-in-process-dispatch.authorization.test.ts src/plugins/runtime/gateway-request-scope.test.ts src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts src/agents/subagents/registry/subagent-registry-lifecycle.test.ts src/agents/subagents/spawn/subagent-spawn.in-process-gateway.test.ts
```

Production +37/-37 (net 0); tests +197/-76 (net +121). Duplicate dispatcher checks are replaced by one captured-owner assertion. Existing documented in-process/standalone routing contract is restored; no new operator setup.

Additional standalone owner proof passes outside Vitest, with no module mocks. A fresh clean Blacksmith build passed (3m51.1s). The actual native adapter rejected captured/caller/scoped closed bindings before opening any socket; a wholly-unbound control made two connections to an isolated local socket, proving that ordinary standalone routing remained available. A mixed owner batch retained a rejecting binding. A real local CJS plugin then returned live → closed → live across load/cache reuse, actual cleanup, and identical reload; the new registry remained cached within its live generation. No provider inference operation was included.

[Standalone proof environment](https://github.com/openclaw/openclaw/actions/runs/33209896225), combined command6m35.76s/exit0. This supplemental run contains the two independent lifecycle repairs (#132090 and #132093); every changed file matches its split PR byte for byte. Full remote tracked-tree identity matched the reviewed combined source (`e4b4aa953a50422957ab0f80b5eafed214759aef`), and the build left tracked source unchanged. Individual PR CI remains required on each exact head. Existing router/commit-race tests provide the raw/typed dispatch coverage; the standalone probe is not an authenticated provider/channel session.

Historical hosted gate failure: [CI33209587443](https://github.com/openclaw/openclaw/actions/runs/33209587443), attempt1 on `e40722da478fdccba419e38b27d3db055b3152c3`, failed build-artifacts and four execution/check jobs (plus the aggregate gate). The blocking failure is the Control UI startup JS gzip budget, before lifecycle assertions. [Exact-job diagnosis and review follow-through](https://github.com/openclaw/openclaw/pull/132090#issuecomment-5457830196). Standalone proof does not waive this red gate.

## Current integration status

The canonical UI fixes and the real Linux process-group repair #132230 are now on main. This branch was refreshed onto `80944da38fc8049ccafacb86d1860be85ab071ea` specifically so its CI consumes those repairs. New head: `5445fcf81564b0f38cee30f199eb93becbddaae8`, replacing `0ebabfb16a2d2e3cd767fc4dfd346b6d1019446d` with an exact lease. All seven authored files and the complete PR patch are byte-identical to the previously reviewed and tested source; Vincent Koc's trailer is retained.

[Exact refreshed CI 33224764519](https://github.com/openclaw/openclaw/actions/runs/33224764519) completed successfully on that exact head, including `openclaw/ci-gate`. The earlier QA failures remain failed evidence; #132230's green CI was not substituted for this PR's required gate. Native main/head review guards and complete review artifacts have been refreshed and validated.
