### PR TITLE
test: overlap independent CLI build admission outcomes

### DIFF
--- a/test/scripts/test-projects-build-admission.test.ts
+++ b/test/scripts/test-projects-build-admission.test.ts
@@ -4,8 +4,8 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createPatternFileHelper } from "../helpers/pattern-file.js";
 import { waitForChildClose, waitForDead, waitForPidFile } from "../helpers/process-wait.js";
-import { createDeferred } from "../helpers/promise.js";
-import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+import { createDeferred, withTestTimeout } from "../helpers/promise.js";
+import { createTempDirTracker, useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const commands = vi.hoisted(() => ({ prepare: vi.fn(), prepareE2e: vi.fn(), reader: vi.fn() }));
 vi.mock("../../scripts/lib/managed-child-process.mts", () => ({
@@ -175,25 +175,30 @@ syncBuiltinESMExports();\n`,
   ] as const)(
     "blocks %s CLI readers until successful build and preserves SIGTERM",
     async (_name, script, args, mode: "private-qa" | "runtime" = "private-qa") => {
-      for (const outcome of [0, 7, "SIGTERM"] as const) {
-        const root = tempDirs.make("plugin-build-cli-");
-        const pidFile = path.join(root, "build.pid");
-        const readersFile = path.join(root, "readers");
-        const builder = path.join(root, "build.mjs");
-        const preload = path.join(root, "preload.mjs");
-        fs.writeFileSync(
-          builder,
-          `import fs from 'node:fs';
+      const outcomes = [0, 7, "SIGTERM"] as const;
+      // Rows share hooks and module state; only their independent process trees overlap.
+      const results = await Promise.allSettled(
+        outcomes.map(async (outcome) => {
+          const scenarioDirs = createTempDirTracker();
+          const root = scenarioDirs.make("plugin-build-cli-");
+          try {
+            const pidFile = path.join(root, "build.pid");
+            const readersFile = path.join(root, "readers");
+            const builder = path.join(root, "build.mjs");
+            const preload = path.join(root, "preload.mjs");
+            fs.writeFileSync(
+              builder,
+              `import fs from 'node:fs';
 process.on('SIGTERM', () => process.exit(0));
 process.stdin.once('data', () => process.exit(${typeof outcome === "number" ? outcome : 0}));
 fs.writeFileSync(${JSON.stringify(pidFile)}, String(process.pid));
 process.stdin.resume();\n`,
-        );
-        // Keep the real managed process owner and CLI scheduler. Replace only
-        // heavyweight build/test executables at Node's child-process boundary.
-        fs.writeFileSync(
-          preload,
-          `import cp from 'node:child_process';
+            );
+            // Keep the real managed process owner and CLI scheduler. Replace only
+            // heavyweight build/test executables at Node's child-process boundary.
+            fs.writeFileSync(
+              preload,
+              `import cp from 'node:child_process';
 import fs from 'node:fs';
 import { syncBuiltinESMExports } from 'node:module';
 const spawn = cp.spawn;
@@ -206,48 +211,74 @@ cp.spawn = (bin, args, options) => {
   return spawn(bin, args, options);
 };
 syncBuiltinESMExports();\n`,
-        );
-        const child = spawn(
-          process.execPath,
-          ["--import", preload, path.resolve(script), ...args],
-          {
-            cwd: _name === "single" ? path.resolve("extensions/qa-lab") : process.cwd(),
-            env: { ...process.env, OPENCLAW_EXTENSION_BATCH_PARALLEL: "2" },
-            stdio: ["pipe", "pipe", "pipe"],
-          },
-        );
-        let output = "";
-        child.stdout.on("data", (data) => {
-          output += data;
-        });
-        child.stderr.on("data", (data) => {
-          output += data;
-        });
-        const closed = waitForChildClose(child);
-        let buildPid: number | undefined;
-        try {
-          buildPid = await waitForPidFile(pidFile, 5_000);
-          expect(fs.existsSync(readersFile)).toBe(false);
-          if (outcome === "SIGTERM") child.kill("SIGTERM");
-          else child.stdin.end("finish\n");
-          expect(await closed, output).toEqual({
-            code: outcome === "SIGTERM" ? 143 : outcome,
-            signal: null,
-          });
-          expect(fs.existsSync(readersFile), output).toBe(outcome === 0);
-          expect(output.match(new RegExp(`preparing ${mode} runtime`, "gu"))).toHaveLength(1);
-          await waitForDead(buildPid, 5_000);
-        } finally {
-          if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
-          if (buildPid) {
+            );
+            const child = spawn(
+              process.execPath,
+              ["--import", preload, path.resolve(script), ...args],
+              {
+                cwd: _name === "single" ? path.resolve("extensions/qa-lab") : process.cwd(),
+                env: { ...process.env, OPENCLAW_EXTENSION_BATCH_PARALLEL: "2" },
+                stdio: ["pipe", "pipe", "pipe"],
+              },
+            );
+            let output = "";
+            child.stdout.on("data", (data) => {
+              output += data;
+            });
+            child.stderr.on("data", (data) => {
+              output += data;
+            });
+            // Observe timeout failures immediately, but retain the actual close event
+            // so failed assertions still join cleanup before this outcome settles.
+            const closed = waitForChildClose(child).catch((error: unknown) => error);
+            const stopped = createDeferred();
+            child.once("close", () => stopped.resolve());
+            let buildPid: number | undefined;
             try {
-              process.kill(buildPid, "SIGKILL");
-            } catch {
-              /* Already exited. */
+              buildPid = await waitForPidFile(pidFile, 5_000);
+              expect(fs.existsSync(readersFile), `outcome=${outcome}`).toBe(false);
+              if (outcome === "SIGTERM") child.kill("SIGTERM");
+              else child.stdin.end("finish\n");
+              expect(await closed, `outcome=${outcome}\n${output}`).toEqual({
+                code: outcome === "SIGTERM" ? 143 : outcome,
+                signal: null,
+              });
+              expect(fs.existsSync(readersFile), `outcome=${outcome}\n${output}`).toBe(
+                outcome === 0,
+              );
+              expect(
+                output.match(new RegExp(`preparing ${mode} runtime`, "gu")),
+                `outcome=${outcome}`,
+              ).toHaveLength(1);
+              await waitForDead(buildPid, 5_000);
+            } finally {
+              if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+              if (!buildPid && fs.existsSync(pidFile)) {
+                buildPid = await waitForPidFile(pidFile, 5_000);
+              }
+              if (buildPid) {
+                try {
+                  process.kill(buildPid, "SIGKILL");
+                } catch {
+                  /* Already exited. */
+                }
+              }
+              try {
+                await withTestTimeout(stopped.promise, 5_000, `outcome=${outcome}: CLI cleanup`);
+              } finally {
+                if (buildPid) await waitForDead(buildPid, 5_000);
+              }
             }
+          } finally {
+            scenarioDirs.cleanup();
           }
-          await closed;
-        }
+        }),
+      );
+      for (const [index, result] of results.entries()) {
+        expect.soft(result, `outcome=${outcomes[index]}`).toEqual({
+          status: "fulfilled",
+          value: undefined,
+        });
       }
     },
   );


### PR DESCRIPTION
## What Problem This Solves

The CLI build-admission tests spend time running three independent process scenarios serially inside each table row. This adds avoidable latency to the tooling-isolated test lane.

## Why This Change Was Made

Overlap only exit 0, exit 7, and SIGTERM inside each of the eleven existing rows using `Promise.allSettled`. Keep rows serial because their hooks share argv, environment, mocks, and module state. Every scenario retains its own fixture root, builder/preload, PID/readers facts, CLI pipes/output, and joined cleanup. Outcome-labelled assertions report failures after all three finalizers finish.

This also joins the actual CLI close event and builder death after failed assertions before removing the scenario root. No production code, concurrency configuration, timeout deadline, module-reset behavior, or runtime contract changes. This is distinct from the previously rejected resetModules-only experiment.

## User Impact

No user-facing behavior change. Developer test latency improves while retaining all 61 registrations and all 33 real outcome executions. Production LOC: +0/-0. Tests: +87/-56 (net +31), for scenario ownership, joined failure cleanup, and labelled diagnostics.

## Evidence

AI-assisted implementation and isolated Codex review; no accepted/actionable P0 findings. Test-audit and deslop complete. Full changed gate passed. Local focused 61/61 and owner/sibling 406/406 passed, including shuffled seeds 17 and 91.

### Balanced benchmark

One task-owned Blacksmith Testbox (4 visible CPUs, Node v24.19.0, pnpm 11.22.0), source base `a939d4bdd811013e2e9469501a95d1f682f134f3`, one Vitest worker, distinct filesystem module cache for every invocation, import diagnostics enabled, `/usr/bin/time -v`, excluded A/B warmups. Eight pairs per scope in AB, BA, AB, BA, BA, AB, BA, AB order. No failed samples dropped. Run: https://github.com/openclaw/openclaw/actions/runs/33207023010. The Testbox lease was explicitly stopped after evidence collection; its workflow wrapper may show cancelled. Successful wrapper command exits and individual results, not that terminal workflow status, are the benchmark proof. Exact-head PR CI is separate.

| Scope | A wall | B wall | Saving | Favorable |
|---|---:|---:|---:|---:|
| Whole file | 51.236s | 48.601s | 2.635s / 5.14% | 7/8 |
| CLI runtime table | 5.377s | 3.756s | 1.621s / 30.14% | 8/8 |

| Pair | Whole A/B seconds | Filtered A/B seconds |
|---|---:|---:|
| 1 | 52.0373 / 51.3489 | 5.1264 / 3.4250 |
| 2 | 51.4738 / 48.2252 | 5.2807 / 3.4226 |
| 3 | 51.2279 / 50.1335 | 5.0450 / 3.8621 |
| 4 | 53.8486 / 47.4711 | 5.4163 / 3.3138 |
| 5 | 52.7672 / 53.0210 | 5.6181 / 4.9035 |
| 6 | 46.4722 / 43.3155 | 5.8146 / 3.8718 |
| 7 | 50.2283 / 48.3491 | 5.2587 / 3.6757 |
| 8 | 51.8311 / 46.9417 | 5.4570 / 3.5762 |

| Scope/variant | Vitest | Test body | Import | CPU user/system | Max RSS (KiB, mean) |
|---|---:|---:|---:|---:|---:|
| whole/A | 50.445s | 49.377s | 0.0519s | 53.014/2.439s | 685711 |
| whole/B | 47.816s | 46.824s | 0.0466s | 52.097/2.345s | 698114 |
| rows/A | 4.714s | 3.855s | 0.0424s | 6.384/1.191s | 487768 |
| rows/B | 3.050s | 2.109s | 0.0461s | 6.755/1.272s | 483918 |

Within the whole-file measurements, the sum of the eleven CLI row bodies fell from4.154s to2.085s.

Whole-file paired 95% t interval for the saving: 0.770–4.500s; filtered: 1.236–2.005s. These are measurements on this runner, not a universal CI speed claim. The process tradeoff is explicit: sampled descendant peak 9 → 12; whole-file peak aggregate process-tree RSS 1,021,812 → 1,237,172 KiB. No broader concurrent test registration.

The timed candidate was frozen before refinements to fallback PID readiness, cleanup-finally ordering, and soft outcome reporting. The first two affect only failure cleanup; soft reporting adds 33 synchronous assertion-context wrappers on passing runs. Process work, successful await order, and overlap are unchanged. Exact final-form process/fault and repeated tests are recorded below; the paired numbers are not relabelled as measurements of those later diagnostic refinements.

Reproduction command (use a distinct cache path for each A/B invocation):

```sh
/usr/bin/time -v env OPENCLAW_VITEST_MAX_WORKERS=1 \
  OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/admission-unique-cache \
  OPENCLAW_VITEST_IMPORT_DURATIONS=1 OPENCLAW_VITEST_PRINT_IMPORT_BREAKDOWN=1 \
  node scripts/run-vitest.mjs test/scripts/test-projects-build-admission.test.ts \
  --maxWorkers=1 --reporter=verbose
# Filtered scope adds: -t 'CLI runtime admission.*blocks'
```

### Final-form structure and reversible faults

Temporary observation-only instrumentation verified before and after: 33 CLI + 33 builder + 12 reader processes, 33 distinct roots and distinct PIDs, all 33 outcomes verified, outer-row overlap absent, scenario peak 1 → 3. All mode/script/cwd/argument cases remain. No test registration or five-second readiness/close/death deadline was removed or shortened.

Reversible production faults were applied only on the task-owned runner, one at a time:

| Fault | Distinct failure | Unaffected outcomes |
|---|---|---|
| Return from preparation before build completes | All 33 detect a reader before completion (`true` vs `false`) | All three outcomes remain observed in every row; this owner defect affects all three |
| Convert nonzero builder status to 0 | All eleven exit-7 scenarios see 0 instead of 7 | 22 exit-0/SIGTERM scenarios verify successfully |
| Convert signal status to 0 | All eleven SIGTERM scenarios see 0 instead of 143 | 22 numeric scenarios verify successfully |
| Remove SIGTERM forwarding/cancellation | All eleven SIGTERM scenarios hit the existing five-second close deadline | 22 numeric scenarios verify successfully |

Every injected-fault row joined its three finalizers, with no surviving CLI/builders/readers or fixture roots. Both production owners were byte-for-byte restored and hash-checked; the restored table passed all 33 outcomes. Instrumentation is not retained in the PR.

Final-form Linux: three whole-file repeats passed61/61; seven-file owner/sibling sets in normal order and shuffled seeds17/91 each passed406/406 (61 tooling-isolated +345 tooling). All49 monitored benchmark, structure/fault/restoration, repeat and sibling invocations had zero observed surviving descendants or fixture roots. The whole-file repeats took64.425s,48.722s,49.256s; these are validation timings, not additional paired samples. Raw per-case test bodies, import diagnostics, CPU/RSS, and lifecycle observations were retained as task evidence (217 artifacts). The Testbox sync commit differs from the source baseline only in this test; final test and all628 checked script/helper/config/dependency-manifest hashes match the local source.

Latest-main refresh to `02a162b8bf2`: admission runtime/helpers/config/dependencies unchanged. The declaration-owner arrival expanded managed-process coverage; the refreshed admission + managed-process + run-tsgo set passed127/127 with seed91. Fresh isolated Codex review again reports no actionable P0 findings. The complete changed gate also passed after this refresh.


### Repaired-main refresh and two-CPU runner proof

Refreshed onto repaired main `5b605da389460fd035d9a2031064ed949303b14f`; new head `5d9e4d2f8cce39ac25045de57fda7808a323bf27`. Rebase had no conflicts. Stable patch ID `61419e2058853ab837e9e4fff10e97062d56d4ff` and test SHA-256 `6d0987f4aa271e0d5e4b23daff33ca8310297eab1af2a1835357cc16dfcd1557` are unchanged; `git range-diff` reports equality. No test, production behavior, or assertion changed. The prior clean isolated Codex reviews therefore remain applicable; no redundant review was run for this byte-identical refresh.

ClawSweeper's smallest-runner resource move is now measured on a fresh Testbox: Node24.19.0/pnpm11.22.0; host4 CPUs, harness and children restricted to CPUs0–1; **nproc=2 and Node availableParallelism=2**, normal two-worker cap. This is a real two-CPU execution restriction, not the prior unrestricted four-CPU proof. No memory cgroup cap was imposed; RSS below is measured, not a claim of identical hosted hardware.

| Two-CPU measurement | Serial baseline | Accepted overlap |
|---|---:|---:|
| Table mean wall,8 balanced pairs |8.493s|7.427s|
| Table mean Vitest |7.543s|6.326s|
| Table mean test body |5.909s|4.579s|
| Table mean CPU user/system |8.338/1.459s|8.970/1.521s|
| Table peak aggregate process-tree RSS |955,224KiB|1,215,560KiB|
| Table peak descendants |9|13|
| Full8-file isolated lane |187/187|187/187|
| Full-lane peak aggregate RSS |2,085,304KiB|1,993,664KiB|
| Full-lane peak descendants |11|12|

The table saves **1.065s /12.54%**, with6/8 favorable pairs; warmups excluded, no failed samples dropped. Full-lane before/after59.189/54.342s are one validation run each, not a new paired speed benchmark. Sampled full-lane descendants were checked to stay within CPUs0–1. Three exact final-form whole-file repeats passed **61/61** in52.718,51.150,49.445s.

Instrumented two-CPU before/after runs retain **33 CLI +33 builder +12 reader processes**,33 distinct roots, all33 outcomes, outer rows serial, inner scenario peak1→3. All25 monitored invocations (warmups, paired table, whole-file, structure and full lane) had zero failures, surviving descendants, fixture roots or temporary-namespace contents. Existing four-fault proof is retained; this refresh changes none of its owners. Final target/runtime/helper hashes match locally and remotely, and the Testbox is stopped. Raw113 artifacts are retained locally.

Remote proof: https://github.com/openclaw/openclaw/actions/runs/33213447220 (Testbox lifecycle may show cancelled after explicit stop; command exits and retained results prove the runs). Fresh exact-head CI: https://github.com/openclaw/openclaw/actions/runs/33213456173. Its Linux build is green at **345,140B startup gzip**, below even the original **347,037B** limit. **Full exact-head CI completed SUCCESS** on this head. The latest21:45UTC ClawSweeper review requests only this CI and the compact-runner proof above; both are now satisfied. Proceeding through native prepare/merge without bypass.
