### PR TITLE
fix(macos): keep native test fixtures out of app state

### DIFF
--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -54,6 +54,14 @@ ledger and orphan cleanup across app instances, and port reservation inspects
 other profiles' Gateway service claims. Use a clean test account or VM when
 validation must not access or change operator state.
 
+## Native tests
+
+Run the full app suite only in disposable macOS CI or a VM without operator
+credentials or a live Gateway. A test filter or temporary `HOME` is not enough:
+preferences and Keychain use system services, and AppKit/WebKit tests can open
+windows and helper processes. Local subsets need a verified OS sandbox as well
+as test-owned resources. See [native test safety](https://docs.openclaw.ai/platforms/mac/dev-setup#run-native-tests-safely).
+
 ## Packaging flows
 
 Development bundle (signed but not notarized):

--- a/apps/macos/Sources/OpenClaw/DashboardManager.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardManager.swift
@@ -3,6 +3,7 @@ import Foundation
 import Observation
 import OpenClawKit
 import OSLog
+import WebKit
 
 private let dashboardManagerLogger = Logger(subsystem: "ai.openclaw", category: "DashboardManager")
 
@@ -10,6 +11,7 @@ private let dashboardManagerLogger = Logger(subsystem: "ai.openclaw", category: 
 @Observable
 final class DashboardManager {
     static let shared = DashboardManager(
+        websiteDataStore: .default(),
         automaticGatewayProfileRefreshEnabled:
         AppLaunchRuntimePlan.current.allowsGatewayUIKeychainAccess)
 
@@ -47,6 +49,7 @@ final class DashboardManager {
     @ObservationIgnored private let routeProbe: @Sendable () async -> Void
     @ObservationIgnored private let endpointStateProvider: @Sendable () async -> GatewayEndpointState
     @ObservationIgnored private let mainWindowAutosaveName: String
+    @ObservationIgnored private let websiteDataStore: WKWebsiteDataStore
     @ObservationIgnored private let observesGatewayChanges: Bool
     @ObservationIgnored private let automaticGatewayProfileRefreshEnabled: Bool
     private(set) var gatewayEntries: [DashboardGatewayEntry] = []
@@ -62,6 +65,7 @@ final class DashboardManager {
     private static let failureURL = URL(string: "about:blank")!
 
     private init(
+        websiteDataStore: WKWebsiteDataStore,
         authTokenProvider: @escaping @Sendable (GatewayConnection.Config) async -> String? = { config in
             await GatewayConnection.shared.controlUiAutoAuthToken(config: config)
         },
@@ -79,6 +83,7 @@ final class DashboardManager {
         automaticGatewayProfileRefreshEnabled: Bool = true,
         mainWindowAutosaveName: String = DashboardWindowLayout.windowFrameAutosaveName)
     {
+        self.websiteDataStore = websiteDataStore
         self.authTokenProvider = authTokenProvider
         self.routeProbe = routeProbe
         self.endpointStateProvider = endpointStateProvider
@@ -237,13 +242,11 @@ final class DashboardManager {
         guard self.controller === current else { return }
         self.switchGenerations[ObjectIdentifier(current)] = nil
         let window = current.detachWindowForReplacement()
-        let replacement = DashboardWindowController(
+        let replacement = self.makePrimaryController(
             url: url,
             auth: auth,
-            updater: self.updater,
-            updateBridgeEnabled: Self.updateBridgeEnabled(mode: mode),
+            mode: mode,
             tlsParams: tlsParams,
-            gatewaySnapshot: self.snapshot(for: .primary),
             reusingWindow: window)
         self.controller = replacement
         replacement.loadInBackground(url: url, auth: auth)
@@ -256,12 +259,10 @@ final class DashboardManager {
         guard self.controller === current else { return }
         self.switchGenerations[ObjectIdentifier(current)] = nil
         let window = current.detachWindowForReplacement()
-        let replacement = DashboardWindowController(
+        let replacement = self.makePrimaryController(
             url: Self.failureURL,
             auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil),
-            updater: self.updater,
-            updateBridgeEnabled: false,
-            gatewaySnapshot: self.snapshot(for: .primary),
+            mode: .unconfigured,
             reusingWindow: window)
         self.controller = replacement
         replacement.showFailure(
@@ -319,11 +320,10 @@ final class DashboardManager {
         } else if let controller {
             controller.show(url: url, auth: auth, updateBridgeEnabled: Self.updateBridgeEnabled(mode: mode))
         } else {
-            let controller = DashboardWindowController(
+            let controller = self.makePrimaryController(
                 url: url,
                 auth: auth,
-                updater: self.updater,
-                updateBridgeEnabled: Self.updateBridgeEnabled(mode: mode),
+                mode: mode,
                 tlsParams: endpoint.tls?.params)
             self.controller = controller
             controller.show(url: url, auth: auth)
@@ -344,13 +344,11 @@ final class DashboardManager {
               AppStateStore.shared.onboardingSeen,
               let (mode, url, auth, tlsParams) = self.immediateWindowConfiguration()
         else { return }
-        let controller = DashboardWindowController(
+        let controller = self.makePrimaryController(
             url: url,
             auth: auth,
-            updater: self.updater,
-            updateBridgeEnabled: Self.updateBridgeEnabled(mode: mode),
-            tlsParams: tlsParams,
-            gatewaySnapshot: self.snapshot(for: .primary))
+            mode: mode,
+            tlsParams: tlsParams)
         self.controller = controller
         controller.loadInBackground(url: url, auth: auth)
     }
@@ -407,13 +405,11 @@ final class DashboardManager {
         }
 
         dashboardManagerLogger.info("dashboard create window url=\(dashboardLogString(for: url), privacy: .public)")
-        let controller = DashboardWindowController(
+        let controller = self.makePrimaryController(
             url: url,
             auth: auth,
-            updater: self.updater,
-            updateBridgeEnabled: Self.updateBridgeEnabled(mode: mode),
-            tlsParams: endpoint.tls?.params,
-            gatewaySnapshot: self.snapshot(for: .primary))
+            mode: mode,
+            tlsParams: endpoint.tls?.params)
         self.controller = controller
         controller.show(url: url, auth: auth)
         self.rememberPresentedEndpoint(endpoint)
@@ -449,11 +445,10 @@ final class DashboardManager {
     func showFailure(_ error: Error) {
         let message = (error as NSError).localizedDescription
         dashboardManagerLogger.error("dashboard setup failed error=\(message, privacy: .public)")
-        let controller = self.controller ?? DashboardWindowController(
+        let controller = self.controller ?? self.makePrimaryController(
             url: Self.failureURL,
             auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil),
-            updater: self.updater,
-            updateBridgeEnabled: Self.updateBridgeEnabled(mode: AppStateStore.shared.connectionMode))
+            mode: .unconfigured)
         self.controller = controller
         // Keep observing while the failure page is up so a recovered tunnel
         // swaps the window back to the live dashboard.
@@ -711,6 +706,22 @@ final class DashboardManager {
         }
     }
 
+    private func makePrimaryController(
+        url: URL,
+        auth: DashboardWindowAuth,
+        mode: AppState.ConnectionMode,
+        tlsParams: GatewayTLSParams? = nil,
+        reusingWindow: NSWindow? = nil) -> DashboardWindowController
+    {
+        self.makeController(
+            configuration: WindowConfiguration(
+                url: url, auth: auth, tlsParams: tlsParams, mode: mode, displayName: "OpenClaw"),
+            target: .primary,
+            windowAutosaveName: self.mainWindowAutosaveName,
+            auxiliary: false,
+            reusingWindow: reusingWindow)
+    }
+
     private func makeController(
         configuration: WindowConfiguration,
         target: DashboardGatewayTarget,
@@ -719,29 +730,21 @@ final class DashboardManager {
         reusingWindow: NSWindow? = nil) -> DashboardWindowController
     {
         let primaryLocal = !auxiliary && target == .primary && configuration.mode == .local
-        if primaryLocal {
-            return DashboardWindowController(
-                url: configuration.url,
-                auth: configuration.auth,
-                updater: self.updater,
-                updateBridgeEnabled: Self.updateBridgeEnabled(mode: configuration.mode),
-                tlsParams: configuration.tlsParams,
-                gatewaySnapshot: self.snapshot(for: target),
-                windowTitle: configuration.displayName,
-                windowAutosaveName: windowAutosaveName,
-                reusingWindow: reusingWindow)
-        }
         return DashboardWindowController(
             url: configuration.url,
             auth: configuration.auth,
+            websiteDataStore: self.websiteDataStore,
             updater: self.updater,
-            updateBridgeEnabled: false,
+            updateBridgeEnabled: primaryLocal && Self.updateBridgeEnabled(mode: configuration.mode),
             tlsParams: configuration.tlsParams,
             gatewaySnapshot: self.snapshot(for: target),
             windowTitle: configuration.displayName,
             windowAutosaveName: windowAutosaveName,
             reusingWindow: reusingWindow,
-            requestBrowserProfileImportOffer: { _ in false })
+            requestBrowserProfileImportOffer: { shouldApply in
+                guard primaryLocal else { return false }
+                return await BrowserProfileImportModel.shared.requestAutomaticOfferIfEligible(while: shouldApply)
+            })
     }
 
     private func installAuxiliaryWindowCloseHandler(_ controller: DashboardWindowController, windowID: UUID) {
@@ -763,7 +766,7 @@ final class DashboardManager {
         case .primary:
             self.mainWindowAutosaveName
         case let .profile(profileID):
-            "OpenClawDashboardWindow-\(profileID)"
+            "\(self.mainWindowAutosaveName)-\(profileID)"
         }
     }
 
@@ -1176,6 +1179,7 @@ extension DashboardManager {
     /// Test instances skip `observeEndpointChanges()` so the shared endpoint
     /// store cannot race test-driven `handleEndpointState` calls.
     static func _testMake(
+        websiteDataStore: WKWebsiteDataStore = .nonPersistent(),
         authTokenProvider: @escaping @Sendable (GatewayConnection.Config) async -> String? = { $0.token },
         routeProbe: @escaping @Sendable () async -> Void = {},
         endpointStateProvider: @escaping @Sendable () async -> GatewayEndpointState = {
@@ -1191,6 +1195,7 @@ extension DashboardManager {
         -> DashboardManager
     {
         let manager = DashboardManager(
+            websiteDataStore: websiteDataStore,
             authTokenProvider: authTokenProvider,
             routeProbe: routeProbe,
             endpointStateProvider: endpointStateProvider,
@@ -1248,15 +1253,6 @@ extension DashboardManager {
         if target != .primary {
             self.displayedRouteRevision = nil
             self.displayedRouteAuthority = nil
-        }
-    }
-
-    static func _testAutosaveName(for target: DashboardGatewayTarget) -> String {
-        switch target {
-        case .primary:
-            DashboardWindowLayout.windowFrameAutosaveName
-        case let .profile(profileID):
-            "OpenClawDashboardWindow-\(profileID)"
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -112,17 +112,16 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
     init(
         url: URL,
         auth: DashboardWindowAuth,
+        websiteDataStore: WKWebsiteDataStore,
         updater: UpdaterProviding? = nil,
         updateBridgeEnabled: Bool = true,
         tlsParams: GatewayTLSParams? = nil,
         gatewaySnapshot: DashboardGatewaySnapshot? = nil,
         windowTitle: String = "OpenClaw",
-        windowAutosaveName: String = DashboardWindowLayout.windowFrameAutosaveName,
+        windowAutosaveName: String,
         reusingWindow: NSWindow? = nil,
         requestBrowserProfileImportOffer:
-        @escaping @MainActor (@escaping @MainActor () -> Bool) async -> Bool = { shouldApply in
-            await BrowserProfileImportModel.shared.requestAutomaticOfferIfEligible(while: shouldApply)
-        })
+        @escaping @MainActor (@escaping @MainActor () -> Bool) async -> Bool)
     {
         let shouldEnableUpdateBridge = updater?.isAvailable == true && updateBridgeEnabled
         self.currentURL = url
@@ -134,9 +133,8 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         self.updateBridgeEnabled = shouldEnableUpdateBridge
         self.requestBrowserProfileImportOffer = requestBrowserProfileImportOffer
 
-        let dataStore = WKWebsiteDataStore.default()
         let config = WKWebViewConfiguration()
-        config.websiteDataStore = dataStore
+        config.websiteDataStore = websiteDataStore
         config.preferences.isElementFullscreenEnabled = true
         config.preferences.javaScriptCanOpenWindowsAutomatically = false
         config.preferences.tabFocusesLinks = true
@@ -170,7 +168,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         // carries in-app navigation; the web titlebar buttons use this list.
         self.webView.allowsBackForwardNavigationGestures = true
 
-        let linkBrowser = DashboardLinkBrowserView(websiteDataStore: dataStore)
+        let linkBrowser = DashboardLinkBrowserView(websiteDataStore: websiteDataStore)
         let linkBrowserSplitView = DashboardLinkSplitView()
         let splitViewController = NSSplitViewController()
         splitViewController.splitView = linkBrowserSplitView

--- a/apps/macos/Sources/OpenClaw/ProcessInfo+OpenClaw.swift
+++ b/apps/macos/Sources/OpenClaw/ProcessInfo+OpenClaw.swift
@@ -13,11 +13,11 @@ extension ProcessInfo {
         return String(cString: raw) == "1"
     }
 
-    static func resolveStableNixSuite(bundleIdentifier: String?, isAppBundle: Bool) -> UserDefaults? {
+    static func resolveStableNixSuiteName(bundleIdentifier: String?, isAppBundle: Bool) -> String? {
         // The app's own defaults domain is already represented by AppDefaults.standard.
         // Passing that same identifier to suiteName triggers Foundation's nonsensical-suite warning.
         guard isAppBundle, bundleIdentifier != launchdLabel else { return nil }
-        return UserDefaults(suiteName: launchdLabel)
+        return launchdLabel
     }
 
     /// Nix deployments may write defaults into a stable suite (`ai.openclaw.mac`) even if the shipped
@@ -40,9 +40,9 @@ extension ProcessInfo {
 
     var isNixMode: Bool {
         let isAppBundle = Bundle.main.bundleURL.pathExtension == "app"
-        let stableSuite = Self.resolveStableNixSuite(
+        let stableSuite = Self.resolveStableNixSuiteName(
             bundleIdentifier: Bundle.main.bundleIdentifier,
-            isAppBundle: isAppBundle)
+            isAppBundle: isAppBundle).flatMap { UserDefaults(suiteName: $0) }
         return Self.resolveNixMode(
             environment: self.environment,
             standard: AppDefaults.standard,

--- a/apps/macos/Tests/OpenClawIPCTests/CommandResolverTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CommandResolverTests.swift
@@ -4,29 +4,31 @@ import Testing
 @testable import OpenClaw
 
 @Suite(.serialized) struct CommandResolverTests {
-    private func makeDefaults() -> UserDefaults {
+    private func makeDefaults() -> (suiteName: String, defaults: UserDefaults) {
         // Use a unique suite to avoid cross-suite concurrency on UserDefaults.standard.
-        UserDefaults(suiteName: "CommandResolverTests.\(UUID().uuidString)")!
+        let suiteName = "CommandResolverTests.\(UUID().uuidString)"
+        return (suiteName, UserDefaults(suiteName: suiteName)!)
     }
 
-    private func makeLocalDefaults() -> UserDefaults {
-        let defaults = self.makeDefaults()
-        defaults.set(AppState.ConnectionMode.local.rawValue, forKey: connectionModeKey)
-        return defaults
+    private func makeLocalDefaults() -> (suiteName: String, defaults: UserDefaults) {
+        let fixture = self.makeDefaults()
+        fixture.defaults.set(AppState.ConnectionMode.local.rawValue, forKey: connectionModeKey)
+        return fixture
     }
 
-    private func makeProjectRootWithPnpm() throws -> (tmp: URL, pnpmPath: URL) {
-        let tmp = try makeTempDirForTests()
-        let pnpmPath = tmp.appendingPathComponent("node_modules/.bin/pnpm")
+    private func makePnpm(in root: URL) throws -> URL {
+        let pnpmPath = root.appendingPathComponent("node_modules/.bin/pnpm")
         try makeExecutableForTests(at: pnpmPath)
-        return (tmp, pnpmPath)
+        return pnpmPath
     }
 
     @Test func `named profiles do not inherit the default development checkout`() throws {
         let home = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: home) }
         let checkout = home.appendingPathComponent("Projects/openclaw")
         try FileManager.default.createDirectory(at: checkout, withIntermediateDirectories: true)
-        let defaults = self.makeDefaults()
+        let (suiteName, defaults) = self.makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         let defaultProfile = AppProfile(environment: [:])
         let namedProfile = AppProfile(environment: ["OPENCLAW_PROFILE": "isolated"])
 
@@ -47,9 +49,11 @@ import Testing
     }
 
     @Test func `prefers open claw binary`() async throws {
-        let defaults = self.makeLocalDefaults()
+        let (suiteName, defaults) = self.makeLocalDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
 
         let tmp = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: tmp) }
 
         let openclawPath = tmp.appendingPathComponent("node_modules/.bin/openclaw")
         try makeExecutableForTests(at: openclawPath)
@@ -66,6 +70,7 @@ import Testing
 
     @Test func `source checkout worker uses the freshness aware runner`() async throws {
         let tmp = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: tmp) }
         let runner = tmp.appendingPathComponent("scripts/run-node.mjs")
         let sourceEntrypoint = tmp.appendingPathComponent("openclaw.mjs")
         let distEntrypoint = tmp.appendingPathComponent("dist/entry.js")
@@ -95,9 +100,11 @@ import Testing
     }
 
     @Test func `falls back to node and script`() async throws {
-        let defaults = self.makeLocalDefaults()
+        let (suiteName, defaults) = self.makeLocalDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
 
         let tmp = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: tmp) }
 
         let nodePath = tmp.appendingPathComponent("node_modules/.bin/node")
         let scriptPath = tmp.appendingPathComponent("bin/openclaw.js")
@@ -122,9 +129,11 @@ import Testing
     }
 
     @Test func `prefers open claw binary over pnpm`() async throws {
-        let defaults = self.makeLocalDefaults()
+        let (suiteName, defaults) = self.makeLocalDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
 
         let tmp = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: tmp) }
 
         let binDir = tmp.appendingPathComponent("bin")
         let openclawPath = binDir.appendingPathComponent("openclaw")
@@ -143,9 +152,11 @@ import Testing
     }
 
     @Test func `uses open claw binary without node runtime`() async throws {
-        let defaults = self.makeLocalDefaults()
+        let (suiteName, defaults) = self.makeLocalDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
 
         let tmp = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: tmp) }
 
         let binDir = tmp.appendingPathComponent("bin")
         let openclawPath = binDir.appendingPathComponent("openclaw")
@@ -162,8 +173,11 @@ import Testing
     }
 
     @Test func `falls back to pnpm`() async throws {
-        let defaults = self.makeLocalDefaults()
-        let (tmp, pnpmPath) = try self.makeProjectRootWithPnpm()
+        let (suiteName, defaults) = self.makeLocalDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let tmp = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let pnpmPath = try self.makePnpm(in: tmp)
 
         let cmd = await CommandResolver.openclawCommand(
             subcommand: "rpc",
@@ -176,8 +190,11 @@ import Testing
     }
 
     @Test func `pnpm keeps extra args after subcommand`() async throws {
-        let defaults = self.makeLocalDefaults()
-        let (tmp, pnpmPath) = try self.makeProjectRootWithPnpm()
+        let (suiteName, defaults) = self.makeLocalDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let tmp = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let pnpmPath = try self.makePnpm(in: tmp)
 
         let cmd = await CommandResolver.openclawCommand(
             subcommand: "health",
@@ -192,8 +209,10 @@ import Testing
     }
 
     @Test func `missing CLI explains install and source checkout paths`() async throws {
-        let defaults = self.makeLocalDefaults()
+        let (suiteName, defaults) = self.makeLocalDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         let tmp = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: tmp) }
         let binDir = tmp.appendingPathComponent("bin")
         let nodePath = binDir.appendingPathComponent("node")
         try makeExecutableForTests(at: nodePath)
@@ -215,6 +234,7 @@ import Testing
 
     @Test func `preferred paths start with project node bins`() throws {
         let tmp = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: tmp) }
 
         let first = CommandResolver.preferredPaths(
             home: FileManager().homeDirectoryForCurrentUser,
@@ -225,6 +245,7 @@ import Testing
 
     @Test func `managed install only precedes external installs after validation`() throws {
         let home = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: home) }
         let managedBin = home.appendingPathComponent(".openclaw/bin")
         try FileManager().createDirectory(at: managedBin, withIntermediateDirectories: true)
         let managedExecutable = managedBin.appendingPathComponent("openclaw")
@@ -312,6 +333,7 @@ import Testing
 
     @Test func `node manager runtimes precede system runtimes`() throws {
         let home = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: home) }
         let nodeManagerBin = home.appendingPathComponent(".nvm/versions/node/v22.22.3/bin")
         try makeExecutableForTests(at: nodeManagerBin.appendingPathComponent("node"))
 
@@ -327,6 +349,7 @@ import Testing
 
     @Test func `preferred paths include local user bin after system bins`() throws {
         let home = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: home) }
         let localBin = home.appendingPathComponent(".local/bin").path
         let paths = CommandResolver.preferredPaths(
             home: home,
@@ -355,8 +378,10 @@ import Testing
     }
 
     @Test func `validated CLI preference expires when the app requires a newer version`() throws {
-        let defaults = self.makeDefaults()
+        let (suiteName, defaults) = self.makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         let root = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: root) }
         let executable = root.appendingPathComponent("openclaw")
         FileManager().createFile(atPath: executable.path, contents: Data())
         try FileManager().setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
@@ -385,7 +410,8 @@ import Testing
     }
 
     @Test func `builds SSH command for remote mode`() async {
-        let defaults = self.makeDefaults()
+        let (suiteName, defaults) = self.makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         defaults.set(AppState.ConnectionMode.remote.rawValue, forKey: connectionModeKey)
         defaults.set("openclaw@example.com:2222", forKey: remoteTargetKey)
         defaults.set("/tmp/id_ed25519", forKey: remoteIdentityKey)
@@ -420,7 +446,8 @@ import Testing
     }
 
     @Test func `explicit SSH config host key policy omits strict override`() async {
-        let defaults = self.makeDefaults()
+        let (suiteName, defaults) = self.makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         defaults.set(AppState.ConnectionMode.remote.rawValue, forKey: connectionModeKey)
         defaults.set("gateway-alias", forKey: remoteTargetKey)
 
@@ -443,7 +470,8 @@ import Testing
     }
 
     @Test func `explicit SSH config replaces stale defaults with its host key policy`() async {
-        let defaults = self.makeDefaults()
+        let (suiteName, defaults) = self.makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         defaults.set(AppState.ConnectionMode.remote.rawValue, forKey: connectionModeKey)
         defaults.set("new-gateway-alias", forKey: remoteTargetKey)
         defaults.set("/tmp/stale-id", forKey: remoteIdentityKey)
@@ -476,7 +504,8 @@ import Testing
     }
 
     @Test func `explicit blank SSH config clears stale defaults`() {
-        let defaults = self.makeDefaults()
+        let (suiteName, defaults) = self.makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         defaults.set(AppState.ConnectionMode.remote.rawValue, forKey: connectionModeKey)
         defaults.set("stale-gateway-alias", forKey: remoteTargetKey)
         defaults.set("/tmp/stale-id", forKey: remoteIdentityKey)
@@ -499,10 +528,12 @@ import Testing
     }
 
     @Test func `remote SSH with explicit blank target fails closed`() async throws {
-        let defaults = self.makeDefaults()
+        let (suiteName, defaults) = self.makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         defaults.set(AppState.ConnectionMode.remote.rawValue, forKey: connectionModeKey)
         defaults.set("stale-gateway-alias", forKey: remoteTargetKey)
         let tmp = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: tmp) }
         let localOpenClaw = tmp.appendingPathComponent("node_modules/.bin/openclaw")
         try makeExecutableForTests(at: localOpenClaw)
 
@@ -527,10 +558,12 @@ import Testing
     }
 
     @Test func `direct remote route uses local CLI despite stale SSH defaults`() async throws {
-        let defaults = self.makeDefaults()
+        let (suiteName, defaults) = self.makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         defaults.set(AppState.ConnectionMode.remote.rawValue, forKey: connectionModeKey)
         defaults.set("stale-gateway-alias", forKey: remoteTargetKey)
         let tmp = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: tmp) }
         let localOpenClaw = tmp.appendingPathComponent("node_modules/.bin/openclaw")
         try makeExecutableForTests(at: localOpenClaw)
 
@@ -580,7 +613,8 @@ import Testing
     }
 
     @Test func `empty remote defaults fall back to config remote values`() {
-        let defaults = self.makeDefaults()
+        let (suiteName, defaults) = self.makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         defaults.set(AppState.ConnectionMode.remote.rawValue, forKey: connectionModeKey)
         defaults.set(" ", forKey: remoteTargetKey)
         defaults.set("", forKey: remoteIdentityKey)
@@ -608,11 +642,13 @@ import Testing
     }
 
     @Test func `config root local overrides remote defaults`() async throws {
-        let defaults = self.makeDefaults()
+        let (suiteName, defaults) = self.makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         defaults.set(AppState.ConnectionMode.remote.rawValue, forKey: connectionModeKey)
         defaults.set("openclaw@example.com:2222", forKey: remoteTargetKey)
 
         let tmp = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: tmp) }
 
         let openclawPath = tmp.appendingPathComponent("node_modules/.bin/openclaw")
         try makeExecutableForTests(at: openclawPath)
@@ -632,7 +668,8 @@ import Testing
     }
 
     @Test func `remote settings fall back to config ssh target`() {
-        let defaults = self.makeDefaults()
+        let (suiteName, defaults) = self.makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         let settings = CommandResolver.connectionSettings(
             defaults: defaults,
             configRoot: [

--- a/apps/macos/Tests/OpenClawIPCTests/CuaDriverHostCoordinatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CuaDriverHostCoordinatorTests.swift
@@ -21,7 +21,7 @@ struct CuaDriverHostCoordinatorTests {
     }
 
     @Test func `disabled host never spawns and enabled host publishes only a ready endpoint`() async throws {
-        let root = self.shortTemporaryDirectory("host")
+        let root = try ExecApprovalsSocketTestSupport.makeRoot()
         defer { try? FileManager.default.removeItem(at: root) }
         let executable = root.appendingPathComponent("cua-driver")
         let launcher = CuaProcessLauncherProbe()
@@ -60,8 +60,8 @@ struct CuaDriverHostCoordinatorTests {
         #expect(launcher.processes.allSatisfy { !$0.isRunning })
     }
 
-    @Test func `elevation host refuses CUA enablement before spawning a child`() async {
-        let root = self.shortTemporaryDirectory("elevation-host")
+    @Test func `elevation host refuses CUA enablement before spawning a child`() async throws {
+        let root = try ExecApprovalsSocketTestSupport.makeRoot()
         defer { try? FileManager.default.removeItem(at: root) }
         let launcher = CuaProcessLauncherProbe()
         let coordinator = CuaDriverHostCoordinator(
@@ -102,7 +102,7 @@ struct CuaDriverHostCoordinatorTests {
     }
 
     @Test func `socket directory is random owner-only and cleanup removes only its owned leaf`() throws {
-        let root = self.shortTemporaryDirectory("socket")
+        let root = try ExecApprovalsSocketTestSupport.makeRoot()
         defer { try? FileManager.default.removeItem(at: root) }
 
         let first = try CuaDriverHostCoordinator.createSocketDirectory(in: root)
@@ -156,7 +156,7 @@ struct CuaDriverHostCoordinatorTests {
     }
 
     @Test func `unexpected exit closes liveness and removes its socket directory`() async throws {
-        let root = self.shortTemporaryDirectory("exit-cleanup")
+        let root = try ExecApprovalsSocketTestSupport.makeRoot()
         defer { try? FileManager.default.removeItem(at: root) }
         let launcher = CuaProcessLauncherProbe()
         let coordinator = CuaDriverHostCoordinator(
@@ -185,7 +185,7 @@ struct CuaDriverHostCoordinatorTests {
     }
 
     @Test func `startup removes a preexisting owned directory without a live daemon`() async throws {
-        let root = self.shortTemporaryDirectory("startup-reap")
+        let root = try ExecApprovalsSocketTestSupport.makeRoot()
         defer { try? FileManager.default.removeItem(at: root) }
         let stale = try CuaDriverHostCoordinator.createSocketDirectory(in: root)
         let launcher = CuaProcessLauncherProbe()
@@ -206,13 +206,11 @@ struct CuaDriverHostCoordinatorTests {
     }
 
     @Test func `startup terminates a live owned daemon after its host is gone`() async throws {
-        let root = self.shortTemporaryDirectory("startup-orphan")
+        let root = try ExecApprovalsSocketTestSupport.makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
         let executable = try self.expectedExecutable(in: root, target: "/bin/sleep")
         let orphan = try self.startFakeDaemon(executable: executable, hostPID: Int32.max)
-        defer {
-            self.stopIfRunning(orphan)
-            try? FileManager.default.removeItem(at: root)
-        }
+        defer { self.stopIfRunning(orphan) }
         let stale = try CuaDriverHostCoordinator.createSocketDirectory(in: root)
         try String(orphan.processIdentifier).write(
             to: stale.url.appendingPathComponent("cua.pid"),
@@ -240,9 +238,9 @@ struct CuaDriverHostCoordinatorTests {
     @Test func `launch records the spawned daemon pid for later reaping`() async throws {
         // Without this record the reaper can only delete the directory and leaves the
         // privileged daemon running: `serve` ignores --pid-file and writes a global path.
-        let root = self.shortTemporaryDirectory("launch-pidfile")
-        let executable = try self.expectedExecutable(in: root, target: "/bin/sleep")
+        let root = try ExecApprovalsSocketTestSupport.makeRoot()
         defer { try? FileManager.default.removeItem(at: root) }
+        let executable = try self.expectedExecutable(in: root, target: "/bin/sleep")
         let launcher = CuaProcessLauncherProbe()
         let coordinator = CuaDriverHostCoordinator(
             notificationCenter: NotificationCenter(),
@@ -269,9 +267,9 @@ struct CuaDriverHostCoordinatorTests {
     }
 
     @Test func `launch without an authoritative pid record never becomes ready`() async throws {
-        let root = self.shortTemporaryDirectory("launch-pidfile-failure")
-        let executable = try self.expectedExecutable(in: root, target: "/bin/sleep")
+        let root = try ExecApprovalsSocketTestSupport.makeRoot()
         defer { try? FileManager.default.removeItem(at: root) }
+        let executable = try self.expectedExecutable(in: root, target: "/bin/sleep")
         let launcher = CuaProcessLauncherProbe()
         let coordinator = CuaDriverHostCoordinator(
             notificationCenter: NotificationCenter(),
@@ -303,13 +301,11 @@ struct CuaDriverHostCoordinatorTests {
     }
 
     @Test func `startup refuses to signal a pid owned by another executable`() async throws {
-        let root = self.shortTemporaryDirectory("startup-pid-reuse")
+        let root = try ExecApprovalsSocketTestSupport.makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
         let expectedExecutable = try self.expectedExecutable(in: root, target: "/bin/cat")
         let unrelated = try self.startSleep(executable: URL(fileURLWithPath: "/bin/sleep"))
-        defer {
-            self.stopIfRunning(unrelated)
-            try? FileManager.default.removeItem(at: root)
-        }
+        defer { self.stopIfRunning(unrelated) }
         let stale = try CuaDriverHostCoordinator.createSocketDirectory(in: root)
         try String(unrelated.processIdentifier).write(
             to: stale.url.appendingPathComponent("cua.pid"),
@@ -340,13 +336,11 @@ struct CuaDriverHostCoordinatorTests {
     }
 
     @Test func `teardown leaves no owned directories or live owned daemons`() async throws {
-        let root = self.shortTemporaryDirectory("teardown-reap")
+        let root = try ExecApprovalsSocketTestSupport.makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
         let executable = try self.expectedExecutable(in: root, target: "/bin/sleep")
         let orphan = try self.startFakeDaemon(executable: executable, hostPID: Int32.max)
-        defer {
-            self.stopIfRunning(orphan)
-            try? FileManager.default.removeItem(at: root)
-        }
+        defer { self.stopIfRunning(orphan) }
         let live = try CuaDriverHostCoordinator.createSocketDirectory(in: root)
         try String(orphan.processIdentifier).write(
             to: live.url.appendingPathComponent("cua.pid"),
@@ -368,7 +362,7 @@ struct CuaDriverHostCoordinatorTests {
     }
 
     @Test func `socket directory rejects a symlinked CUA root`() throws {
-        let root = self.shortTemporaryDirectory("unsafe")
+        let root = try ExecApprovalsSocketTestSupport.makeRoot()
         defer { try? FileManager.default.removeItem(at: root) }
         let openClaw = root.appendingPathComponent("OpenClaw", isDirectory: true)
         let redirected = root.appendingPathComponent("redirected", isDirectory: true)
@@ -385,7 +379,7 @@ struct CuaDriverHostCoordinatorTests {
     }
 
     @Test func `socket directory rejects a symlinked OpenClaw support root`() throws {
-        let root = self.shortTemporaryDirectory("unsafe-parent")
+        let root = try ExecApprovalsSocketTestSupport.makeRoot()
         defer { try? FileManager.default.removeItem(at: root) }
         let redirected = root.appendingPathComponent("redirected", isDirectory: true)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
@@ -462,7 +456,7 @@ struct CuaDriverHostCoordinatorTests {
 
     @Test func `unexpected exits retry with a bounded budget while advertising unavailable`() async throws {
         let delays = CuaRestartDelayProbe()
-        let root = self.shortTemporaryDirectory("restart")
+        let root = try ExecApprovalsSocketTestSupport.makeRoot()
         defer { try? FileManager.default.removeItem(at: root) }
         let launcher = CuaProcessLauncherProbe()
         let coordinator = CuaDriverHostCoordinator(
@@ -500,7 +494,7 @@ struct CuaDriverHostCoordinatorTests {
         suspension: CuaStartupSuspension,
         disable: Bool) async throws
     {
-        let root = self.shortTemporaryDirectory("startup-race")
+        let root = try ExecApprovalsSocketTestSupport.makeRoot()
         defer { try? FileManager.default.removeItem(at: root) }
         let notifications = NotificationCenter()
         let launcher = CuaProcessLauncherProbe()
@@ -604,7 +598,7 @@ struct CuaDriverHostCoordinatorTests {
     }
 
     @Test func `permission changes replace the daemon generation and endpoint`() async throws {
-        let root = self.shortTemporaryDirectory("permissions")
+        let root = try ExecApprovalsSocketTestSupport.makeRoot()
         defer { try? FileManager.default.removeItem(at: root) }
         let notifications = NotificationCenter()
         let permissions = CuaPermissionSnapshotProbe()
@@ -632,11 +626,6 @@ struct CuaDriverHostCoordinatorTests {
         #expect(try replacementEndpoint.environmentValue() != originalEnvironmentValue)
         #expect(!launcher.processes[0].isRunning)
         await coordinator.setEnabled(false)
-    }
-
-    private func shortTemporaryDirectory(_ label: String) -> URL {
-        URL(fileURLWithPath: "/tmp", isDirectory: true).resolvingSymlinksInPath()
-            .appendingPathComponent("oc-cua-\(label)-\(UUID().uuidString.prefix(8))", isDirectory: true)
     }
 
     private func expectedExecutable(in root: URL, target: String) throws -> URL {

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardGatewaysTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardGatewaysTests.swift
@@ -2,6 +2,7 @@ import AppKit
 import Foundation
 import OpenClawKit
 import Testing
+import WebKit
 @testable import OpenClaw
 
 struct DashboardGatewayCatalogTests {
@@ -136,8 +137,11 @@ struct DashboardGatewaysBridgeTests {
         let controller = DashboardWindowController(
             url: url,
             auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil),
+            websiteDataStore: .nonPersistent(),
             tlsParams: params,
-            windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)")
+            windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)",
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { controller.closeDashboard() }
 
         #expect(controller._testTLSParams == params)
         #expect(DashboardWindowController.isExpectedTLSAuthority(
@@ -239,24 +243,31 @@ struct DashboardManagerGatewayTargetTests {
     }
 
     @Test func `primary endpoint subscription does not mutate profile targeted main window`() async throws {
-        let url = try #require(URL(string: "http://127.0.0.1:60001/#token=current"))
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let replacementServer = try await DashboardHTTPFixture.start()
+        defer { replacementServer.stop() }
+        let studio = "studio-\(UUID().uuidString)"
+        let url = server.url("/#token=current")
         let controller = DashboardWindowController(
             url: url,
             auth: DashboardWindowAuth(
-                gatewayUrl: "ws://127.0.0.1:60001/",
+                gatewayUrl: server.websocketURL("/").absoluteString,
                 token: "current",
                 password: nil),
-            windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)")
-        controller.show()
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)",
+            requestBrowserProfileImportOffer: { _ in false })
         defer { controller.closeDashboard() }
-        let entries = DashboardGatewayTestEntries.withProfiles(["studio"])
+        controller.show()
+        let entries = DashboardGatewayTestEntries.withProfiles([studio])
         let manager = DashboardManager._testMake(gatewayEntriesProvider: { entries })
         manager._testSetController(controller)
-        manager._testSetMainTarget(.profile("studio"))
+        manager._testSetMainTarget(.profile(studio))
 
-        try await manager.handleEndpointState(.ready(
+        await manager.handleEndpointState(.ready(
             mode: .remote,
-            url: #require(URL(string: "ws://127.0.0.1:60002")),
+            url: replacementServer.websocketURL(""),
             token: "replacement",
             password: nil,
             routeRevision: 2))
@@ -266,13 +277,8 @@ struct DashboardManagerGatewayTargetTests {
 
         try await manager.show()
         #expect(manager._testController() === controller)
-        #expect(manager._testMainTarget() == .profile("studio"))
+        #expect(manager._testMainTarget() == .profile(studio))
         #expect(!manager.showConfiguredWindowIfPossible())
-    }
-
-    @Test func `profile dashboard autosave name is target specific`() {
-        #expect(DashboardManager._testAutosaveName(for: .profile("studio")) ==
-            "OpenClawDashboardWindow-studio")
     }
 
     @Test func `removed current profile requires target reconciliation`() {
@@ -289,34 +295,55 @@ struct DashboardManagerGatewayTargetTests {
     }
 
     @Test func `opening primary creates isolated auxiliary window`() async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let replacementServer = try await DashboardHTTPFixture.start()
+        defer { replacementServer.stop() }
+        let studio = "studio-\(UUID().uuidString)"
+        let dataStore = WKWebsiteDataStore.nonPersistent()
         let state = AppStateStore.shared
         let originalMode = state.connectionMode
         state.connectionMode = .local
         defer { state.connectionMode = originalMode }
-        let url = try #require(URL(string: "http://127.0.0.1:60001/#token=current"))
+        let url = server.url("/#token=current")
         let controller = DashboardWindowController(
             url: url,
             auth: DashboardWindowAuth(
-                gatewayUrl: "ws://127.0.0.1:60001/",
+                gatewayUrl: server.websocketURL("/").absoluteString,
                 token: "current",
                 password: nil),
-            windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)")
+            websiteDataStore: dataStore,
+            windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)",
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { controller.closeDashboard() }
         let frame = NSRect(x: 180, y: 180, width: 960, height: 720)
         controller.window?.setFrame(frame, display: false)
         controller.show()
         // CI display bounds clamp window frames during show, so preserve the post-clamp source frame.
         let sourceFrame = try #require(controller.window).frame
-        let entries = DashboardGatewayTestEntries.withProfiles(["studio"])
-        let manager = DashboardManager._testMake(gatewayEntriesProvider: { entries })
+        let entries = DashboardGatewayTestEntries.withProfiles([studio])
+        let manager = DashboardManager._testMake(
+            websiteDataStore: dataStore,
+            primaryEndpointProvider: { _ in
+                GatewayConnection.EndpointSnapshot(
+                    config: (url: replacementServer.websocketURL(), token: "primary-token", password: nil),
+                    routeAuthority: nil)
+            },
+            profileEndpointProvider: { profileID in
+                GatewayConnection.EndpointSnapshot(
+                    config: (url: server.websocketURL(), token: profileID, password: nil),
+                    routeAuthority: nil)
+            },
+            gatewayEntriesProvider: { entries })
         manager.configure(updater: DashboardGatewayTestUpdater())
         manager._testSetController(controller)
-        manager._testSetMainTarget(.profile("studio"))
+        manager._testSetMainTarget(.profile(studio))
         defer { manager.close() }
 
         await manager._testOpenWindow(for: .primary)
 
         #expect(manager._testController() === controller)
-        #expect(manager._testMainTarget() == .profile("studio"))
+        #expect(manager._testMainTarget() == .profile(studio))
         #expect(controller.window?.frame == sourceFrame)
         let auxiliaryWindows = manager._testAuxiliaryWindows()
         #expect(auxiliaryWindows.count == 1)
@@ -325,21 +352,53 @@ struct DashboardManagerGatewayTargetTests {
         #expect(auxiliary.controller !== controller)
         #expect(auxiliary.controller.window !== controller.window)
         #expect(auxiliary.controller.window?.frameAutosaveName != controller.window?.frameAutosaveName)
+        let primaryAutosaveName = try #require(auxiliary.controller.window?.frameAutosaveName)
+        #expect(primaryAutosaveName.hasPrefix("OpenClawDashboardWindow-Test-"))
         #expect(!auxiliary.controller._testUpdateBridgeAvailable)
+        #expect(auxiliary.controller.currentURL == replacementServer.url("/#token=primary-token"))
+        #expect(auxiliary.controller._testDashboardDataStore === dataStore)
+        #expect(!auxiliary.controller._testDashboardDataStore.isPersistent)
+        auxiliary.controller._testOpenLinkBrowser(server.url("/reader/auxiliary"))
+        #expect(auxiliary.controller._testLinkBrowserDataStore === dataStore)
+
+        let auxiliaryWindow = auxiliary.controller.window
+        await manager._testSwitchTarget(.profile(studio), in: auxiliary.controller)
+        let replacement = try #require(manager._testAuxiliaryWindows().first?.controller)
+        #expect(replacement !== auxiliary.controller)
+        #expect(replacement.window === auxiliaryWindow)
+        let profileAutosaveName = try #require(replacement.window?.frameAutosaveName)
+        #expect(profileAutosaveName.hasPrefix("\(primaryAutosaveName)-\(studio)-"))
+        #expect(replacement._testDashboardDataStore === dataStore)
+        replacement._testOpenLinkBrowser(server.url("/reader/replacement"))
+        #expect(replacement._testLinkBrowserDataStore === dataStore)
     }
 
     @Test func `concurrent switches keep the latest selection for one window`() async throws {
-        let gate = DashboardSwitchEndpointGate()
-        let sourceURL = try #require(URL(string: "http://127.0.0.1:60001/#token=current"))
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let replacementServer = try await DashboardHTTPFixture.start()
+        defer { replacementServer.stop() }
+        let currentServer = try await DashboardHTTPFixture.start()
+        defer { currentServer.stop() }
+        let firstID = "first-\(UUID().uuidString)"
+        let secondID = "second-\(UUID().uuidString)"
+        let gate = DashboardSwitchEndpointGate(
+            firstID: firstID,
+            firstURL: replacementServer.websocketURL(),
+            secondURL: currentServer.websocketURL())
+        let sourceURL = server.url("/#token=current")
         let controller = DashboardWindowController(
             url: sourceURL,
             auth: DashboardWindowAuth(
-                gatewayUrl: "ws://127.0.0.1:60001/",
+                gatewayUrl: server.websocketURL("/").absoluteString,
                 token: "current",
                 password: nil),
-            windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)")
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)",
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { controller.closeDashboard() }
         let originalWindow = try #require(controller.window)
-        let entries = DashboardGatewayTestEntries.withProfiles(["first", "second"])
+        let entries = DashboardGatewayTestEntries.withProfiles([firstID, secondID])
         let manager = DashboardManager._testMake(
             profileEndpointProvider: { profileID in
                 try await gate.endpoint(profileID)
@@ -349,40 +408,48 @@ struct DashboardManagerGatewayTargetTests {
         defer { manager.close() }
 
         let first = Task { @MainActor in
-            await manager._testSwitchTarget(.profile("first"), in: controller)
+            await manager._testSwitchTarget(.profile(firstID), in: controller)
         }
         await gate.waitUntilFirstRequested()
         let second = Task { @MainActor in
-            await manager._testSwitchTarget(.profile("second"), in: controller)
+            await manager._testSwitchTarget(.profile(secondID), in: controller)
         }
         await second.value
         await gate.releaseFirst()
         await first.value
 
-        #expect(manager._testMainTarget() == .profile("second"))
-        #expect(manager._testController()?.currentURL.port == 60003)
+        #expect(manager._testMainTarget() == .profile(secondID))
+        #expect(manager._testController()?.currentURL.port == Int(currentServer.port))
         #expect(manager._testController()?.window === originalWindow)
     }
 
     @Test func `main menu switch replaces the frontmost dashboard in place`() async throws {
-        let sourceURL = try #require(URL(string: "http://127.0.0.1:60001/#token=current"))
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let replacementServer = try await DashboardHTTPFixture.start()
+        defer { replacementServer.stop() }
+        let studio = "studio-\(UUID().uuidString)"
+        let sourceURL = server.url("/#token=current")
         let controller = DashboardWindowController(
             url: sourceURL,
             auth: DashboardWindowAuth(
-                gatewayUrl: "ws://127.0.0.1:60001/",
+                gatewayUrl: server.websocketURL("/").absoluteString,
                 token: "current",
                 password: nil),
-            windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)")
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)",
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { controller.closeDashboard() }
         let frame = NSRect(x: 190, y: 190, width: 940, height: 700)
         controller.window?.setFrame(frame, display: false)
         controller.show()
         // CI display bounds clamp window frames during show, so compare replacement against the actual source frame.
         let originalWindow = try #require(controller.window)
         let sourceFrame = originalWindow.frame
-        let entries = DashboardGatewayTestEntries.withProfiles(["studio"])
+        let entries = DashboardGatewayTestEntries.withProfiles([studio])
         let manager = DashboardManager._testMake(
             profileEndpointProvider: { profileID in
-                let url = try #require(URL(string: "ws://127.0.0.1:60002"))
+                let url = replacementServer.websocketURL("")
                 return GatewayConnection.EndpointSnapshot(
                     config: (url: url, token: profileID, password: nil),
                     routeAuthority: nil)
@@ -391,35 +458,55 @@ struct DashboardManagerGatewayTargetTests {
         manager._testSetController(controller)
         defer { manager.close() }
 
-        await manager._testSwitchFrontmostDashboard(to: .profile("studio"))
+        await manager._testSwitchFrontmostDashboard(to: .profile(studio))
 
-        #expect(manager._testMainTarget() == .profile("studio"))
-        #expect(manager.frontmostDashboardTarget == .profile("studio"))
+        #expect(manager._testMainTarget() == .profile(studio))
+        #expect(manager.frontmostDashboardTarget == .profile(studio))
         #expect(manager._testController() !== controller)
-        #expect(manager._testController()?.currentURL.port == 60002)
+        #expect(manager._testController()?.currentURL.port == Int(replacementServer.port))
         #expect(manager._testController()?.window === originalWindow)
         #expect(manager._testController()?.window?.frame == sourceFrame)
+        let profileAutosaveName = try #require(manager._testController()?.window?.frameAutosaveName)
+        #expect(profileAutosaveName.hasPrefix("OpenClawDashboardWindow-Test-"))
+        #expect(profileAutosaveName.hasSuffix("-\(studio)"))
     }
 
-    @Test func `main menu switch opens requested gateway when no dashboard exists`() async {
-        let entries = DashboardGatewayTestEntries.withProfiles(["studio"])
+    @Test func `main menu switch opens requested gateway when no dashboard exists`() async throws {
+        let replacementServer = try await DashboardHTTPFixture.start()
+        defer { replacementServer.stop() }
+        let studio = "studio"
+        let entries = DashboardGatewayTestEntries.withProfiles([studio])
+        let profileEndpoint: @Sendable (String) async throws -> GatewayConnection.EndpointSnapshot = { profileID in
+            GatewayConnection.EndpointSnapshot(
+                config: (url: replacementServer.websocketURL(""), token: profileID, password: nil),
+                routeAuthority: nil)
+        }
         let manager = DashboardManager._testMake(
-            profileEndpointProvider: { profileID in
-                let url = try #require(URL(string: "ws://127.0.0.1:60002"))
-                return GatewayConnection.EndpointSnapshot(
-                    config: (url: url, token: profileID, password: nil),
-                    routeAuthority: nil)
-            },
+            profileEndpointProvider: profileEndpoint,
             gatewayEntriesProvider: { entries })
         defer { manager.close() }
 
-        await manager._testSwitchFrontmostDashboard(to: .profile("studio"))
+        await manager._testSwitchFrontmostDashboard(to: .profile(studio))
 
         let windows = manager._testAuxiliaryWindows()
         #expect(windows.count == 1)
-        #expect(windows.first?.target == .profile("studio"))
+        #expect(windows.first?.target == .profile(studio))
         #expect(windows.first?.controller.isWindowOpen == true)
-        #expect(manager.frontmostDashboardTarget == .profile("studio"))
+        #expect(manager.frontmostDashboardTarget == .profile(studio))
+        let autosaveName = try #require(windows.first?.controller.window?.frameAutosaveName)
+        #expect(autosaveName.hasPrefix("OpenClawDashboardWindow-Test-"))
+        #expect(autosaveName.hasSuffix("-\(studio)"))
+
+        let otherManager = DashboardManager._testMake(
+            profileEndpointProvider: profileEndpoint,
+            gatewayEntriesProvider: { entries })
+        defer { otherManager.close() }
+        await otherManager._testOpenWindow(for: .profile(studio))
+        let otherAutosaveName = try #require(otherManager._testAuxiliaryWindows().first?.controller.window?
+            .frameAutosaveName)
+        #expect(otherAutosaveName.hasPrefix("OpenClawDashboardWindow-Test-"))
+        #expect(otherAutosaveName.hasSuffix("-\(studio)"))
+        #expect(otherAutosaveName != autosaveName)
     }
 }
 
@@ -446,18 +533,27 @@ private enum DashboardGatewayTestEntries {
 }
 
 private actor DashboardSwitchEndpointGate {
+    private let firstID: String
+    private let firstURL: URL
+    private let secondURL: URL
+
+    init(firstID: String, firstURL: URL, secondURL: URL) {
+        self.firstID = firstID
+        self.firstURL = firstURL
+        self.secondURL = secondURL
+    }
+
     private var firstRequested = false
     private var firstContinuation: CheckedContinuation<Void, Never>?
 
     func endpoint(_ profileID: String) async throws -> GatewayConnection.EndpointSnapshot {
-        if profileID == "first" {
+        if profileID == self.firstID {
             self.firstRequested = true
             await withCheckedContinuation { continuation in
                 self.firstContinuation = continuation
             }
         }
-        let port = profileID == "first" ? 60002 : 60003
-        let url = try #require(URL(string: "ws://127.0.0.1:\(port)"))
+        let url = profileID == self.firstID ? self.firstURL : self.secondURL
         return GatewayConnection.EndpointSnapshot(
             config: (url: url, token: profileID, password: nil),
             routeAuthority: nil)
@@ -500,6 +596,7 @@ struct DashboardPrimaryGatewayAdapterTests {
                     tls: DashboardGatewayTestTLS.route(fingerprint: fingerprint),
                     routeAuthority: nil)
             },
+            currentTLSFingerprint: { nil },
             persist: { _, fingerprint in
                 persistedFingerprints.append(fingerprint)
                 return true
@@ -696,6 +793,7 @@ struct DashboardGatewaySetupCoordinatorTests {
         var openedSettings = 0
         let adapter = DashboardPrimaryGatewayAdapter(
             state: state,
+            currentTLSFingerprint: { nil },
             persist: { _, fingerprint in
                 persistedFingerprints.append(fingerprint)
                 return true

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardHTTPFixture.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardHTTPFixture.swift
@@ -1,0 +1,141 @@
+import Foundation
+import Network
+
+/// A test owns the listener until `stop()`, after closing its dashboard windows.
+@MainActor
+final class DashboardHTTPFixture {
+    static let html = "<!doctype html><html><head><title>Dashboard fixture</title></head><body>Ready</body></html>"
+
+    private struct Client {
+        let connection: NWConnection
+        let timeout: DispatchWorkItem
+        var request = Data()
+    }
+
+    private let listener: NWListener
+    private var clients: [UUID: Client] = [:]
+    private var stopped = false
+    nonisolated let port: UInt16
+
+    private init(listener: NWListener, port: UInt16) {
+        self.listener = listener
+        self.port = port
+        self.listener.newConnectionHandler = { [weak self] connection in
+            MainActor.assumeIsolated {
+                guard let self else {
+                    connection.cancel()
+                    return
+                }
+                self.accept(connection)
+            }
+        }
+    }
+
+    static func start() async throws -> DashboardHTTPFixture {
+        let parameters = NWParameters.tcp
+        parameters.requiredLocalEndpoint = .hostPort(host: "127.0.0.1", port: .any)
+        let listener = try NWListener(using: parameters, on: .any)
+        listener.newConnectionHandler = { $0.cancel() }
+        listener.start(queue: .main)
+        do {
+            let deadline = ContinuousClock.now + .seconds(5)
+            while ContinuousClock.now < deadline {
+                try Task.checkCancellation()
+                switch listener.state {
+                case .ready:
+                    guard let port = listener.port, port.rawValue != 0 else {
+                        throw URLError(.cannotFindHost)
+                    }
+                    return DashboardHTTPFixture(listener: listener, port: port.rawValue)
+                case let .failed(error):
+                    throw error
+                case .cancelled:
+                    throw CancellationError()
+                default:
+                    try await Task.sleep(for: .milliseconds(10))
+                }
+            }
+            throw URLError(.timedOut)
+        } catch {
+            listener.cancel()
+            throw error
+        }
+    }
+
+    nonisolated func url(_ path: String = "/") -> URL {
+        URL(string: "http://127.0.0.1:\(self.port)\(path)")!
+    }
+
+    nonisolated func websocketURL(_ path: String = "/") -> URL {
+        URL(string: "ws://127.0.0.1:\(self.port)\(path)")!
+    }
+
+    func stop() {
+        guard !self.stopped else { return }
+        self.stopped = true
+        self.listener.cancel()
+        for id in Array(self.clients.keys) {
+            self.close(id)
+        }
+    }
+
+    private func accept(_ connection: NWConnection) {
+        guard !self.stopped, self.clients.count < 32 else {
+            connection.cancel()
+            return
+        }
+        let id = UUID()
+        let timeout = DispatchWorkItem { [weak self] in
+            MainActor.assumeIsolated { self?.close(id) }
+        }
+        self.clients[id] = Client(connection: connection, timeout: timeout)
+        connection.start(queue: .main)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5, execute: timeout)
+        self.receive(id)
+    }
+
+    private func receive(_ id: UUID) {
+        guard let client = self.clients[id] else { return }
+        // One bounded request per connection; neither slow clients nor a partial
+        // header can leave a receive alive beyond the connection's deadline.
+        client.connection.receive(minimumIncompleteLength: 1, maximumLength: 8192 - client.request.count) {
+            [weak self] data, _, complete, error in
+            MainActor.assumeIsolated {
+                guard let self, var client = self.clients[id] else { return }
+                if let data { client.request.append(data) }
+                self.clients[id] = client
+                if client.request.range(of: Data("\r\n\r\n".utf8)) != nil {
+                    self.respond(id)
+                } else if error != nil || complete || client.request.count >= 8192 {
+                    self.close(id)
+                } else {
+                    self.receive(id)
+                }
+            }
+        }
+    }
+
+    private func respond(_ id: UUID) {
+        guard let client = self.clients[id] else { return }
+        let body = Data(Self.html.utf8)
+        // No scripts, subresources, redirects, cookies, or gateway RPCs. The CSP
+        // also fences accidental page resource additions to this inert fixture.
+        let headers = [
+            "HTTP/1.1 200 OK",
+            "Content-Type: text/html; charset=utf-8",
+            "Content-Length: \(body.count)",
+            "Cache-Control: no-store",
+            "Content-Security-Policy: default-src 'none'",
+            "Connection: close",
+        ].joined(separator: "\r\n") + "\r\n\r\n"
+        client.connection.send(content: Data(headers.utf8) + body, completion: .contentProcessed { [weak self] _ in
+            MainActor.assumeIsolated { self?.close(id) }
+        })
+    }
+
+    private func close(_ id: UUID) {
+        guard let client = self.clients.removeValue(forKey: id) else { return }
+        client.timeout.cancel()
+        client.connection.cancel()
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardHTTPFixtureTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardHTTPFixtureTests.swift
@@ -1,0 +1,110 @@
+import Darwin
+import Foundation
+import Testing
+
+@MainActor
+struct DashboardHTTPFixtureTests {
+    @Test func `fixtures own distinct loopback endpoints serving inert HTML`() async throws {
+        let first = try await DashboardHTTPFixture.start()
+        defer { first.stop() }
+        let second = try await DashboardHTTPFixture.start()
+        defer { second.stop() }
+        #expect(first.port != second.port)
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.urlCache = nil
+        configuration.httpCookieStorage = nil
+        configuration.urlCredentialStorage = nil
+        configuration.connectionProxyDictionary = [:]
+        configuration.timeoutIntervalForRequest = 2
+        configuration.timeoutIntervalForResource = 5
+        let session = URLSession(configuration: configuration)
+        defer { session.invalidateAndCancel() }
+
+        for fixture in [first, second] {
+            let url = fixture.url("/control/chat?session=fixture#token=fixture-token")
+            #expect(url.host == "127.0.0.1")
+            #expect(url.port == Int(fixture.port))
+            #expect(url.path == "/control/chat")
+            #expect(url.query == "session=fixture")
+            #expect(url.fragment == "token=fixture-token")
+            #expect(fixture.websocketURL("/control/").scheme == "ws")
+            let (data, response) = try await session.data(from: url)
+            let http = try #require(response as? HTTPURLResponse)
+            #expect(http.statusCode == 200)
+            #expect(String(decoding: data, as: UTF8.self) == DashboardHTTPFixture.html)
+            #expect(http.value(forHTTPHeaderField: "Content-Security-Policy") == "default-src 'none'")
+            #expect(http.value(forHTTPHeaderField: "Set-Cookie") == nil)
+        }
+    }
+
+    @Test func `stopping a fixture closes unfinished clients and releases its listener`() async throws {
+        let fixture = try await DashboardHTTPFixture.start()
+        defer { fixture.stop() }
+        let descriptor = socket(AF_INET, SOCK_STREAM, 0)
+        try #require(descriptor >= 0)
+        defer { Darwin.close(descriptor) }
+        try #require(fcntl(descriptor, F_SETFL, O_NONBLOCK) == 0)
+        var noSignal: Int32 = 1
+        try #require(setsockopt(
+            descriptor, SOL_SOCKET, SO_NOSIGPIPE, &noSignal, socklen_t(MemoryLayout<Int32>.size)) == 0)
+        var address = sockaddr_in()
+        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = fixture.port.bigEndian
+        address.sin_addr.s_addr = inet_addr("127.0.0.1")
+        let connected = withUnsafePointer(to: &address) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.connect(descriptor, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        try #require(connected == 0 || errno == EINPROGRESS)
+        var writable = pollfd(fd: descriptor, events: Int16(POLLOUT), revents: 0)
+        let connectDeadline = ContinuousClock.now + .seconds(2)
+        while poll(&writable, 1, 0) == 0, ContinuousClock.now < connectDeadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        try #require(writable.revents & Int16(POLLOUT) != 0)
+        let partialHeader = Array("GET /pending HTTP/1.1\r\n".utf8)
+        let sent = partialHeader.withUnsafeBytes { Darwin.send(descriptor, $0.baseAddress, $0.count, 0) }
+        try #require(sent == partialHeader.count)
+
+        fixture.stop()
+        fixture.stop()
+        let deadline = ContinuousClock.now + .seconds(2)
+        var byte: UInt8 = 0
+        var closed = false
+        while ContinuousClock.now < deadline {
+            let received = Darwin.recv(descriptor, &byte, 1, 0)
+            if received == 0 || (received == -1 && errno == ECONNRESET) {
+                closed = true
+                break
+            }
+            try #require(received == -1 && (errno == EAGAIN || errno == EWOULDBLOCK))
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(closed)
+
+        let probe = socket(AF_INET, SOCK_STREAM, 0)
+        try #require(probe >= 0)
+        defer { Darwin.close(probe) }
+        try #require(fcntl(probe, F_SETFL, O_NONBLOCK) == 0)
+        let reconnected = withUnsafePointer(to: &address) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.connect(probe, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        try #require(reconnected == -1)
+        if errno == ECONNREFUSED { return }
+        try #require(errno == EINPROGRESS)
+        var probeEvents = pollfd(fd: probe, events: Int16(POLLOUT), revents: 0)
+        while poll(&probeEvents, 1, 0) == 0, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        try #require(probeEvents.revents != 0)
+        var socketError: Int32 = 0
+        var errorLength = socklen_t(MemoryLayout<Int32>.size)
+        try #require(getsockopt(probe, SOL_SOCKET, SO_ERROR, &socketError, &errorLength) == 0)
+        #expect(socketError == ECONNREFUSED)
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardReconnectTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardReconnectTests.swift
@@ -18,17 +18,24 @@ private actor DashboardReconnectAuthGate {
 @MainActor
 struct DashboardReconnectTests {
     @Test func `authenticated control reconnect recovers unchanged ready route`() async throws {
-        let url = try #require(URL(string: "http://127.0.0.1:60001/#token=route-a-device-token"))
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let replacementServer = try await DashboardHTTPFixture.start()
+        defer { replacementServer.stop() }
+        let url = server.url("/#token=route-a-device-token")
         let controller = DashboardWindowController(
             url: url,
             auth: DashboardWindowAuth(
-                gatewayUrl: "ws://127.0.0.1:60001/",
+                gatewayUrl: server.websocketURL("/").absoluteString,
                 token: "route-a-device-token",
                 password: nil),
-            windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)")
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)",
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { controller.closeDashboard() }
         controller.show()
         let authGate = DashboardReconnectAuthGate()
-        let socketURL = try #require(URL(string: "ws://127.0.0.1:60002"))
+        let socketURL = replacementServer.websocketURL("")
         let endpointState = GatewayEndpointState.ready(
             mode: .remote,
             url: socketURL,
@@ -59,6 +66,6 @@ struct DashboardReconnectTests {
         #expect(recoveredController !== failureController)
         #expect(!failureController.isWindowOpen)
         #expect(recoveredController.currentURL.absoluteString ==
-            "http://127.0.0.1:60002/#token=route-b-device-token")
+            replacementServer.url("/#token=route-b-device-token").absoluteString)
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowOwnershipTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowOwnershipTests.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Foundation
 import Testing
+import WebKit
 @testable import OpenClaw
 
 private actor DashboardWindowOwnershipAuthGate {
@@ -16,11 +17,16 @@ private actor DashboardWindowOwnershipAuthGate {
 }
 
 private actor DashboardWindowOwnershipEndpointGate {
+    private let firstURL: URL
     private var firstRequested = false
     private var firstContinuation: CheckedContinuation<Void, Never>?
 
+    init(firstURL: URL) {
+        self.firstURL = firstURL
+    }
+
     func authToken(for config: GatewayConnection.Config) async -> String? {
-        if config.url.port == 60002 {
+        if config.url == self.firstURL {
             self.firstRequested = true
             await withCheckedContinuation { continuation in
                 self.firstContinuation = continuation
@@ -105,20 +111,27 @@ struct DashboardWindowOwnershipTests {
         health: .ok)
 
     @Test func `disconnect and auth recovery preserve one native window`() async throws {
-        let url = try #require(URL(string: "http://127.0.0.1:60001/#token=before"))
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let replacementServer = try await DashboardHTTPFixture.start()
+        defer { replacementServer.stop() }
+        let url = server.url("/#token=before")
         let controller = DashboardWindowController(
             url: url,
             auth: DashboardWindowAuth(
-                gatewayUrl: "ws://127.0.0.1:60001/",
+                gatewayUrl: server.websocketURL("/").absoluteString,
                 token: "before",
                 password: nil),
-            windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)")
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)",
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { controller.closeDashboard() }
         controller.show()
         let originalWindow = try #require(controller.window)
         let gate = DashboardWindowOwnershipAuthGate()
-        let readyState = try GatewayEndpointState.ready(
+        let readyState = GatewayEndpointState.ready(
             mode: .remote,
-            url: #require(URL(string: "ws://127.0.0.1:60002")),
+            url: replacementServer.websocketURL(""),
             token: nil,
             password: nil,
             routeRevision: 2)
@@ -146,7 +159,7 @@ struct DashboardWindowOwnershipTests {
         #expect(recoveredController !== failureController)
         #expect(recoveredController.window === originalWindow)
         #expect(recoveredController.currentURL.absoluteString ==
-            "http://127.0.0.1:60002/#token=after")
+            replacementServer.url("/#token=after").absoluteString)
         let authScripts = recoveredController._testUserScripts
             .filter { $0.source.contains("__OPENCLAW_NATIVE_CONTROL_AUTH__") }
         #expect(authScripts.count == 1)
@@ -159,31 +172,40 @@ struct DashboardWindowOwnershipTests {
     }
 
     @Test func `overlapping endpoint updates cannot orphan a dashboard window`() async throws {
-        let url = try #require(URL(string: "http://127.0.0.1:60001/#token=initial"))
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let replacementServer = try await DashboardHTTPFixture.start()
+        defer { replacementServer.stop() }
+        let currentServer = try await DashboardHTTPFixture.start()
+        defer { currentServer.stop() }
+        let url = server.url("/#token=initial")
         let controller = DashboardWindowController(
             url: url,
             auth: DashboardWindowAuth(
-                gatewayUrl: "ws://127.0.0.1:60001/",
+                gatewayUrl: server.websocketURL("/").absoluteString,
                 token: "initial",
                 password: nil),
-            windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)")
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)",
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { controller.closeDashboard() }
         controller.show()
         let originalWindow = try #require(controller.window)
-        let gate = DashboardWindowOwnershipEndpointGate()
+        let gate = DashboardWindowOwnershipEndpointGate(firstURL: replacementServer.websocketURL(""))
         let manager = DashboardManager._testMake(
             authTokenProvider: { config in await gate.authToken(for: config) })
         manager._testSetController(controller)
         defer { manager.close() }
 
-        let staleState = try GatewayEndpointState.ready(
+        let staleState = GatewayEndpointState.ready(
             mode: .remote,
-            url: #require(URL(string: "ws://127.0.0.1:60002")),
+            url: replacementServer.websocketURL(""),
             token: nil,
             password: nil,
             routeRevision: 1)
-        let currentState = try GatewayEndpointState.ready(
+        let currentState = GatewayEndpointState.ready(
             mode: .remote,
-            url: #require(URL(string: "ws://127.0.0.1:60003")),
+            url: currentServer.websocketURL(""),
             token: nil,
             password: nil,
             routeRevision: 2)
@@ -200,7 +222,7 @@ struct DashboardWindowOwnershipTests {
         #expect(manager._testController() === currentController)
         #expect(currentController.window === originalWindow)
         #expect(currentController.currentURL.absoluteString ==
-            "http://127.0.0.1:60003/#token=current")
+            currentServer.url("/#token=current").absoluteString)
         let authScripts = currentController._testUserScripts
             .filter { $0.source.contains("__OPENCLAW_NATIVE_CONTROL_AUTH__") }
         #expect(authScripts.count == 1)
@@ -209,19 +231,24 @@ struct DashboardWindowOwnershipTests {
     }
 
     @Test func `reopening after credential changes isolates the privileged document`() async throws {
-        let url = try #require(URL(string: "http://127.0.0.1:60001/#token=before"))
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let url = server.url("/#token=before")
         let controller = DashboardWindowController(
             url: url,
             auth: DashboardWindowAuth(
-                gatewayUrl: "ws://127.0.0.1:60001/",
+                gatewayUrl: server.websocketURL("/").absoluteString,
                 token: "before",
                 password: nil),
-            windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)")
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)",
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { controller.closeDashboard() }
         controller.show()
         let originalWindow = try #require(controller.window)
         let originalDocument = controller._testDashboardWebViewIdentity
         originalWindow.orderOut(nil)
-        let endpointURL = try #require(URL(string: "ws://127.0.0.1:60001/"))
+        let endpointURL = server.websocketURL("/")
 
         let manager = DashboardManager._testMake(
             primaryEndpointProvider: { _ in
@@ -248,7 +275,11 @@ struct DashboardWindowOwnershipTests {
     }
 
     @Test func `replacing a key dashboard transfers keyboard ownership`() async throws {
-        let url = try #require(URL(string: "http://127.0.0.1:60001/#token=before"))
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let replacementServer = try await DashboardHTTPFixture.start()
+        defer { replacementServer.stop() }
+        let url = server.url("/#token=before")
         let originalWindow = DashboardWindowOwnershipTrackingWindow(
             contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
             styleMask: [.titled, .closable, .miniaturizable, .resizable],
@@ -257,11 +288,14 @@ struct DashboardWindowOwnershipTests {
         let controller = DashboardWindowController(
             url: url,
             auth: DashboardWindowAuth(
-                gatewayUrl: "ws://127.0.0.1:60001/",
+                gatewayUrl: server.websocketURL("/").absoluteString,
                 token: "before",
                 password: nil),
+            websiteDataStore: .nonPersistent(),
             windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)",
-            reusingWindow: originalWindow)
+            reusingWindow: originalWindow,
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { controller.closeDashboard() }
         controller.show()
         originalWindow.simulatesKeyWindow = true
 
@@ -269,9 +303,9 @@ struct DashboardWindowOwnershipTests {
         manager._testSetController(controller)
         defer { manager.close() }
 
-        try await manager.handleEndpointState(.ready(
+        await manager.handleEndpointState(.ready(
             mode: .remote,
-            url: #require(URL(string: "ws://127.0.0.1:60002/")),
+            url: replacementServer.websocketURL("/"),
             token: "after",
             password: nil,
             routeRevision: 2))
@@ -282,7 +316,13 @@ struct DashboardWindowOwnershipTests {
     }
 
     @Test func `stale async presentation cannot overwrite a newer endpoint`() async throws {
-        let url = try #require(URL(string: "http://127.0.0.1:60001/#token=initial"))
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let replacementServer = try await DashboardHTTPFixture.start()
+        defer { replacementServer.stop() }
+        let currentServer = try await DashboardHTTPFixture.start()
+        defer { currentServer.stop() }
+        let url = server.url("/#token=initial")
         let originalWindow = DashboardWindowOwnershipTrackingWindow(
             contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
             styleMask: [.titled, .closable, .miniaturizable, .resizable],
@@ -291,13 +331,16 @@ struct DashboardWindowOwnershipTests {
         let controller = DashboardWindowController(
             url: url,
             auth: DashboardWindowAuth(
-                gatewayUrl: "ws://127.0.0.1:60001/",
+                gatewayUrl: server.websocketURL("/").absoluteString,
                 token: "initial",
                 password: nil),
+            websiteDataStore: .nonPersistent(),
             windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)",
-            reusingWindow: originalWindow)
+            reusingWindow: originalWindow,
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { controller.closeDashboard() }
         controller.show()
-        let staleEndpointURL = try #require(URL(string: "ws://127.0.0.1:60002/"))
+        let staleEndpointURL = replacementServer.websocketURL("/")
         let gate = DashboardWindowOwnershipPresentationGate()
         let manager = DashboardManager._testMake(
             primaryEndpointProvider: { _ in
@@ -313,9 +356,9 @@ struct DashboardWindowOwnershipTests {
 
         let presentation = Task { @MainActor in try await manager.show() }
         await gate.waitUntilRequested()
-        try await manager.handleEndpointState(.ready(
+        await manager.handleEndpointState(.ready(
             mode: .remote,
-            url: #require(URL(string: "ws://127.0.0.1:60003/")),
+            url: currentServer.websocketURL("/"),
             token: "current",
             password: nil,
             routeRevision: 2))
@@ -328,20 +371,29 @@ struct DashboardWindowOwnershipTests {
         #expect(currentController.window === originalWindow)
         #expect(originalWindow.foregroundRequestCount > backgroundForegroundCount)
         #expect(currentController.currentURL.absoluteString ==
-            "http://127.0.0.1:60003/#token=current")
+            currentServer.url("/#token=current").absoluteString)
     }
 
     @Test func `hidden dashboard invalidates stale reopening authority`() async throws {
-        let url = try #require(URL(string: "http://127.0.0.1:60001/#token=initial"))
-        let staleEndpointURL = try #require(URL(string: "ws://127.0.0.1:60002/"))
-        let currentEndpointURL = try #require(URL(string: "ws://127.0.0.1:60003/"))
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let replacementServer = try await DashboardHTTPFixture.start()
+        defer { replacementServer.stop() }
+        let currentServer = try await DashboardHTTPFixture.start()
+        defer { currentServer.stop() }
+        let url = server.url("/#token=initial")
+        let staleEndpointURL = replacementServer.websocketURL("/")
+        let currentEndpointURL = currentServer.websocketURL("/")
         let controller = DashboardWindowController(
             url: url,
             auth: DashboardWindowAuth(
-                gatewayUrl: "ws://127.0.0.1:60001/",
+                gatewayUrl: server.websocketURL("/").absoluteString,
                 token: "initial",
                 password: nil),
-            windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)")
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)",
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { controller.closeDashboard() }
         controller.show()
         let originalWindow = try #require(controller.window)
         originalWindow.orderOut(nil)
@@ -376,18 +428,25 @@ struct DashboardWindowOwnershipTests {
         #expect(await gate.numberOfRequests() == 2)
         #expect(replacement.window === originalWindow)
         #expect(replacement.currentURL.absoluteString ==
-            "http://127.0.0.1:60003/#token=current")
+            currentServer.url("/#token=current").absoluteString)
     }
 
     @Test func `superseded endpoint failure preserves a newer live dashboard`() async throws {
-        let url = try #require(URL(string: "http://127.0.0.1:60001/#token=initial"))
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let currentServer = try await DashboardHTTPFixture.start()
+        defer { currentServer.stop() }
+        let url = server.url("/#token=initial")
         let controller = DashboardWindowController(
             url: url,
             auth: DashboardWindowAuth(
-                gatewayUrl: "ws://127.0.0.1:60001/",
+                gatewayUrl: server.websocketURL("/").absoluteString,
                 token: "initial",
                 password: nil),
-            windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)")
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)",
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { controller.closeDashboard() }
         controller.show()
         let originalWindow = try #require(controller.window)
         let gate = DashboardWindowOwnershipPresentationGate()
@@ -402,9 +461,9 @@ struct DashboardWindowOwnershipTests {
 
         let presentation = Task { @MainActor in try await manager.show() }
         await gate.waitUntilRequested()
-        try await manager.handleEndpointState(.ready(
+        await manager.handleEndpointState(.ready(
             mode: .remote,
-            url: #require(URL(string: "ws://127.0.0.1:60003/")),
+            url: currentServer.websocketURL("/"),
             token: "current",
             password: nil,
             routeRevision: 2))
@@ -415,11 +474,13 @@ struct DashboardWindowOwnershipTests {
         #expect(manager._testController() === currentController)
         #expect(currentController.window === originalWindow)
         #expect(currentController.currentURL.absoluteString ==
-            "http://127.0.0.1:60003/#token=current")
+            currentServer.url("/#token=current").absoluteString)
     }
 
-    @Test func `window handoff ignores a conflicting target autosave frame`() throws {
-        let url = try #require(URL(string: "http://127.0.0.1:60001/#token=before"))
+    @Test func `window handoff ignores a conflicting target autosave frame`() async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let url = server.url("/#token=before")
         let originalAutosaveName = "OpenClawDashboardWindow-Test-\(UUID().uuidString)"
         let targetAutosaveName = "OpenClawDashboardWindow-Test-\(UUID().uuidString)"
         defer {
@@ -439,10 +500,13 @@ struct DashboardWindowOwnershipTests {
         let controller = DashboardWindowController(
             url: url,
             auth: DashboardWindowAuth(
-                gatewayUrl: "ws://127.0.0.1:60001/",
+                gatewayUrl: server.websocketURL("/").absoluteString,
                 token: "before",
                 password: nil),
-            windowAutosaveName: originalAutosaveName)
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: originalAutosaveName,
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { controller.closeDashboard() }
         controller.show()
         let originalWindow = try #require(controller.window)
         let originalFrame = originalWindow.frame
@@ -450,11 +514,13 @@ struct DashboardWindowOwnershipTests {
         let replacement = DashboardWindowController(
             url: url,
             auth: DashboardWindowAuth(
-                gatewayUrl: "ws://127.0.0.1:60001/",
+                gatewayUrl: server.websocketURL("/").absoluteString,
                 token: "after",
                 password: nil),
+            websiteDataStore: .nonPersistent(),
             windowAutosaveName: targetAutosaveName,
-            reusingWindow: transferredWindow)
+            reusingWindow: transferredWindow,
+            requestBrowserProfileImportOffer: { _ in false })
         defer { replacement.closeDashboard() }
 
         #expect(replacement.window === originalWindow)
@@ -462,9 +528,13 @@ struct DashboardWindowOwnershipTests {
     }
 
     @Test func `concurrent explicit opens share one presentation owner`() async throws {
-        let endpointURL = try #require(URL(string: "ws://127.0.0.1:60004/"))
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let dataStore = WKWebsiteDataStore.nonPersistent()
+        let endpointURL = server.websocketURL("/")
         let gate = DashboardWindowOwnershipPresentationGate()
         let manager = DashboardManager._testMake(
+            websiteDataStore: dataStore,
             primaryEndpointProvider: { _ in
                 await gate.waitForRelease()
                 return GatewayConnection.EndpointSnapshot(
@@ -488,6 +558,32 @@ struct DashboardWindowOwnershipTests {
         let controller = try #require(manager._testController())
         #expect(controller.isWindowOpen)
         #expect(controller.currentURL.absoluteString ==
-            "http://127.0.0.1:60004/#token=shared")
+            server.url("/#token=shared").absoluteString)
+
+        let autosaveName = try #require(controller.window?.frameAutosaveName)
+        #expect(autosaveName.hasPrefix("OpenClawDashboardWindow-Test-"))
+        #expect(controller._testDashboardDataStore === dataStore)
+        #expect(!controller._testDashboardDataStore.isPersistent)
+        controller._testOpenLinkBrowser(server.url("/reader/first"))
+        #expect(controller._testLinkBrowserDataStore === dataStore)
+
+        await manager.handleEndpointState(.connecting(mode: .remote, detail: "Reconnecting"))
+        let failure = try #require(manager._testController())
+        #expect(failure !== controller)
+        #expect(failure._testDashboardDataStore === dataStore)
+        #expect(failure.window?.frameAutosaveName == autosaveName)
+
+        await manager.handleEndpointState(.ready(
+            mode: .remote,
+            url: endpointURL,
+            token: "recovered",
+            password: nil,
+            routeRevision: 2))
+        let recovered = try #require(manager._testController())
+        #expect(recovered !== failure)
+        #expect(recovered._testDashboardDataStore === dataStore)
+        #expect(recovered.window?.frameAutosaveName == autosaveName)
+        recovered._testOpenLinkBrowser(server.url("/reader/recovered"))
+        #expect(recovered._testLinkBrowserDataStore === dataStore)
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -79,27 +79,32 @@ struct DashboardWindowSmokeTests {
                 pressure: 1)
         }
 
-        dragRegion.mouseDown(with: try #require(mouseDownEvent(1)))
+        try dragRegion.mouseDown(with: #require(mouseDownEvent(1)))
 
         #expect(window.dragCount == 1)
         #expect(window.zoomCount == 0)
 
-        dragRegion.mouseDown(with: try #require(mouseDownEvent(2)))
+        try dragRegion.mouseDown(with: #require(mouseDownEvent(2)))
 
         #expect(window.dragCount == 1)
         #expect(window.zoomCount == 1)
     }
 
-    @Test func `dashboard window controller shows and closes`() throws {
-        let url = try #require(URL(string: "http://127.0.0.1:18789/control/#token=device-token"))
+    @Test func `dashboard window controller shows and closes`() async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let url = server.url("/control/#token=device-token")
         let windowAutosaveName = "OpenClawDashboardWindow-Test-\(UUID().uuidString)"
         let controller = DashboardWindowController(
             url: url,
             auth: DashboardWindowAuth(
-                gatewayUrl: "ws://127.0.0.1:18789/control/",
+                gatewayUrl: server.websocketURL("/control/").absoluteString,
                 token: "device-token",
                 password: nil),
-            windowAutosaveName: windowAutosaveName)
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: windowAutosaveName,
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { controller.closeDashboard() }
         controller.show()
         #expect(controller.window?.styleMask.contains(.titled) == true)
         #expect(controller.window?.styleMask.contains(.closable) == true)
@@ -214,12 +219,18 @@ struct DashboardWindowSmokeTests {
             isShowingFailurePage: true))
     }
 
-    @Test func `dashboard native command queues before page load`() throws {
-        let url = try #require(URL(string: "http://127.0.0.1:18789/control/"))
+    @Test func `dashboard native command queues before page load`() async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let url = server.url("/control/")
         let controller = DashboardWindowController(
             url: url,
-            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil))
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil),
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "",
+            requestBrowserProfileImportOffer: { _ in false })
 
+        defer { controller.closeDashboard() }
         controller.dispatchNativeCommand(.newSession)
         controller.dispatchNativeCommand(.commandPalette)
         controller.dispatchNativeCommand(.commandPalette)
@@ -289,26 +300,40 @@ struct DashboardWindowSmokeTests {
             to: localFile, dashboardURL: dashboard, isMainFrame: false, isTrustedDashboardSource: true))
     }
 
-    @Test func `dashboard navigation shortcuts target the focused browser`() throws {
-        let dashboard = try #require(URL(string: "http://127.0.0.1:18789/control/"))
+    @Test func `dashboard navigation shortcuts target the focused browser`() async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let readerServer = try await DashboardHTTPFixture.start()
+        defer { readerServer.stop() }
+        let dashboard = server.url("/control/")
         let controller = DashboardWindowController(
             url: dashboard,
-            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil))
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil),
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "",
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { controller.closeDashboard() }
         #expect(controller._testNavigationWebViewIdentity == controller._testDashboardWebViewIdentity)
 
-        try controller._testOpenLinkBrowser(#require(URL(string: "https://docs.openclaw.ai/")))
+        controller._testOpenLinkBrowser(readerServer.url("/docs/"))
         let linkWebView = try #require(controller._testLinkBrowserWebViewIdentity)
         #expect(controller._testFocusLinkBrowser())
         #expect(controller._testNavigationWebViewIdentity == linkWebView)
     }
 
     @Test func `browser import offer retries until the first completed inline browser request`() async throws {
-        let dashboard = try #require(URL(string: "http://127.0.0.1:18789/control/"))
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let readerServer = try await DashboardHTTPFixture.start()
+        defer { readerServer.stop() }
+        let dashboard = server.url("/control/")
         var requestCount = 0
         var firstRequestContinuation: CheckedContinuation<Bool, Never>?
         let controller = DashboardWindowController(
             url: dashboard,
             auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil),
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "",
             requestBrowserProfileImportOffer: { _ in
                 requestCount += 1
                 if requestCount == 1 {
@@ -323,7 +348,7 @@ struct DashboardWindowSmokeTests {
         controller.show()
         #expect(requestCount == 0)
 
-        let link = try #require(URL(string: "https://docs.openclaw.ai/"))
+        let link = readerServer.url("/docs/")
         controller._testOpenLinkBrowser(link)
         controller.update(
             url: dashboard,
@@ -355,17 +380,23 @@ struct DashboardWindowSmokeTests {
     }
 
     @Test func `browser import offer retries when onboarding completes with browser open`() async throws {
-        let dashboard = try #require(URL(string: "http://127.0.0.1:18789/control/"))
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let readerServer = try await DashboardHTTPFixture.start()
+        defer { readerServer.stop() }
+        let dashboard = server.url("/control/")
         let gate = DashboardBrowserImportGate()
         let controller = DashboardWindowController(
             url: dashboard,
             auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil),
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "",
             requestBrowserProfileImportOffer: { _ in gate.request() })
         defer { controller.closeDashboard() }
         let manager = DashboardManager._testMake()
         manager._testSetController(controller)
 
-        let link = try #require(URL(string: "https://docs.openclaw.ai/"))
+        let link = readerServer.url("/docs/")
         controller._testOpenLinkBrowser(link, requestBrowserProfileImportOffer: true)
         for _ in 0..<200 where gate.requestCount == 0 {
             await Task.yield()
@@ -387,13 +418,19 @@ struct DashboardWindowSmokeTests {
     }
 
     @Test func `closing inline browser invalidates an in-flight import offer`() async throws {
-        let dashboard = try #require(URL(string: "http://127.0.0.1:18789/control/"))
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let readerServer = try await DashboardHTTPFixture.start()
+        defer { readerServer.stop() }
+        let dashboard = server.url("/control/")
         var requestCount = 0
         var firstRequestContinuation: CheckedContinuation<Void, Never>?
         var firstRequestApplied: Bool?
         let controller = DashboardWindowController(
             url: dashboard,
             auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil),
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "",
             requestBrowserProfileImportOffer: { shouldApply in
                 requestCount += 1
                 if requestCount == 1 {
@@ -407,7 +444,7 @@ struct DashboardWindowSmokeTests {
             })
         defer { controller.closeDashboard() }
 
-        let link = try #require(URL(string: "https://docs.openclaw.ai/"))
+        let link = readerServer.url("/docs/")
         controller._testOpenLinkBrowser(link, requestBrowserProfileImportOffer: true)
         for _ in 0..<200 where firstRequestContinuation == nil {
             await Task.yield()
@@ -502,11 +539,19 @@ struct DashboardWindowSmokeTests {
             dashboardURL: dashboard))
     }
 
-    @Test func `dashboard link browser tabs preserve isolation and lifecycle`() throws {
-        let dashboard = try #require(URL(string: "http://127.0.0.1:18789/control/"))
+    @Test func `dashboard link browser tabs preserve isolation and lifecycle`() async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let readerServer = try await DashboardHTTPFixture.start()
+        defer { readerServer.stop() }
+        let dashboard = server.url("/control/")
         let controller = DashboardWindowController(
             url: dashboard,
-            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil))
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil),
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "",
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { controller.closeDashboard() }
         #expect(controller._testLinkBrowserIsCollapsed)
         #expect(controller._testLinkBrowserTabCount == 0)
         #expect(controller._testLinkBrowserActiveTabIndex == nil)
@@ -519,8 +564,8 @@ struct DashboardWindowSmokeTests {
         #expect(controller._testLinkBrowserTabBarHeight == 0)
         #expect(controller._testLinkBrowserToolbarHeight == DashboardWindowLayout.linkBrowserToolbarHeight)
 
-        let urlA = try #require(URL(string: "http://127.0.0.1:1/a"))
-        let urlB = try #require(URL(string: "http://127.0.0.1:1/b"))
+        let urlA = readerServer.url("/reader/a")
+        let urlB = readerServer.url("/reader/b")
         controller._testOpenLinkBrowser(urlA)
         #expect(controller._testLinkBrowserTabCount == 1)
         #expect(controller._testLinkBrowserTabURLs == [urlA])
@@ -578,7 +623,11 @@ struct DashboardWindowSmokeTests {
         #expect(controller._testLinkBrowserRepresentedURL == nil)
     }
 
-    @Test func `dashboard link browser opens half width and remembers resizable pane width`() throws {
+    @Test func `dashboard link browser opens half width and remembers resizable pane width`() async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let readerServer = try await DashboardHTTPFixture.start()
+        defer { readerServer.stop() }
         #expect(!DashboardWindowLayout.dividerMoved(from: nil, to: 100))
         #expect(!DashboardWindowLayout.dividerMoved(from: 100, to: 100))
         #expect(DashboardWindowLayout.dividerMoved(from: 100, to: 101))
@@ -591,75 +640,78 @@ struct DashboardWindowSmokeTests {
             dividerThickness: 1,
             persistedWidth: 400) == 400)
 
-        let defaults = UserDefaults.standard
         let key = DashboardWindowLayout.linkBrowserWidthDefaultsKey
-        let originalValue = defaults.object(forKey: key)
-        defaults.removeObject(forKey: key)
-        defer {
-            if let originalValue {
-                defaults.set(originalValue, forKey: key)
-            } else {
-                defaults.removeObject(forKey: key)
-            }
+        await TestIsolation.withUserDefaultsValues([key: nil]) {
+            let defaults = AppDefaults.standard
+            let dashboard = server.url("/control/")
+            let link = readerServer.url("/reader/half-width")
+            let controller = DashboardWindowController(
+                url: dashboard,
+                auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil),
+                websiteDataStore: .nonPersistent(),
+                windowAutosaveName: "",
+                requestBrowserProfileImportOffer: { _ in false })
+            controller.show()
+            defer { controller.closeDashboard() }
+            controller.window?.setContentSize(DashboardWindowLayout.windowSize)
+
+            controller._testOpenLinkBrowser(link)
+            let openedSplitWidth = controller._testLinkBrowserSplitWidth
+            let dividerThickness = controller._testLinkBrowserDividerThickness
+            let openedLinkBrowserWidth = controller._testLinkBrowserWidth
+            let expectedWidth = DashboardWindowLayout.linkBrowserWidth(
+                splitWidth: openedSplitWidth,
+                dividerThickness: dividerThickness,
+                persistedWidth: nil)
+            #expect(abs(openedLinkBrowserWidth - expectedWidth) < 1)
+            #expect(
+                openedSplitWidth - dividerThickness - openedLinkBrowserWidth >=
+                    DashboardWindowLayout.mainBrowserMinWidth)
+            #expect(controller._testLinkBrowserMaximumThickness == NSSplitViewItem.unspecifiedDimension)
+
+            defaults.set(Double(openedLinkBrowserWidth + 37), forKey: key)
+            controller._testCompleteLinkBrowserDividerDrag()
+            let resizedWidth = controller._testLinkBrowserWidth
+            #expect(abs(CGFloat(defaults.double(forKey: key)) - resizedWidth) < 1)
+            #expect(abs(CGFloat(defaults.double(forKey: key)) - openedLinkBrowserWidth - 37) >= 1)
+
+            controller._testCloseLinkBrowser()
+            controller.window?.setContentSize(DashboardWindowLayout.windowMinSize)
+            controller._testOpenLinkBrowser(link)
+            let compactExpectedWidth = DashboardWindowLayout.linkBrowserWidth(
+                splitWidth: controller._testLinkBrowserSplitWidth,
+                dividerThickness: controller._testLinkBrowserDividerThickness,
+                persistedWidth: resizedWidth)
+            #expect(abs(controller._testLinkBrowserWidth - compactExpectedWidth) < 1)
+            #expect(abs(CGFloat(defaults.double(forKey: key)) - resizedWidth) < 1)
+
+            controller._testCloseLinkBrowser()
+            controller.window?.setContentSize(DashboardWindowLayout.windowSize)
+            controller._testOpenLinkBrowser(link)
+            let restoredExpectedWidth = DashboardWindowLayout.linkBrowserWidth(
+                splitWidth: controller._testLinkBrowserSplitWidth,
+                dividerThickness: controller._testLinkBrowserDividerThickness,
+                persistedWidth: resizedWidth)
+            #expect(abs(controller._testLinkBrowserWidth - restoredExpectedWidth) < 1)
         }
-
-        let dashboard = try #require(URL(string: "http://127.0.0.1:18789/control/"))
-        let link = try #require(URL(string: "http://127.0.0.1:1/half-width"))
-        let controller = DashboardWindowController(
-            url: dashboard,
-            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil))
-        controller.show()
-        defer { controller.closeDashboard() }
-        controller.window?.setContentSize(DashboardWindowLayout.windowSize)
-
-        controller._testOpenLinkBrowser(link)
-        let openedSplitWidth = controller._testLinkBrowserSplitWidth
-        let dividerThickness = controller._testLinkBrowserDividerThickness
-        let openedLinkBrowserWidth = controller._testLinkBrowserWidth
-        let expectedWidth = DashboardWindowLayout.linkBrowserWidth(
-            splitWidth: openedSplitWidth,
-            dividerThickness: dividerThickness,
-            persistedWidth: nil)
-        #expect(abs(openedLinkBrowserWidth - expectedWidth) < 1)
-        #expect(
-            openedSplitWidth - dividerThickness - openedLinkBrowserWidth >=
-                DashboardWindowLayout.mainBrowserMinWidth)
-        #expect(controller._testLinkBrowserMaximumThickness == NSSplitViewItem.unspecifiedDimension)
-
-        defaults.set(Double(openedLinkBrowserWidth + 37), forKey: key)
-        controller._testCompleteLinkBrowserDividerDrag()
-        let resizedWidth = controller._testLinkBrowserWidth
-        #expect(abs(CGFloat(defaults.double(forKey: key)) - resizedWidth) < 1)
-        #expect(abs(CGFloat(defaults.double(forKey: key)) - openedLinkBrowserWidth - 37) >= 1)
-
-        controller._testCloseLinkBrowser()
-        controller.window?.setContentSize(DashboardWindowLayout.windowMinSize)
-        controller._testOpenLinkBrowser(link)
-        let compactExpectedWidth = DashboardWindowLayout.linkBrowserWidth(
-            splitWidth: controller._testLinkBrowserSplitWidth,
-            dividerThickness: controller._testLinkBrowserDividerThickness,
-            persistedWidth: resizedWidth)
-        #expect(abs(controller._testLinkBrowserWidth - compactExpectedWidth) < 1)
-        #expect(abs(CGFloat(defaults.double(forKey: key)) - resizedWidth) < 1)
-
-        controller._testCloseLinkBrowser()
-        controller.window?.setContentSize(DashboardWindowLayout.windowSize)
-        controller._testOpenLinkBrowser(link)
-        let restoredExpectedWidth = DashboardWindowLayout.linkBrowserWidth(
-            splitWidth: controller._testLinkBrowserSplitWidth,
-            dividerThickness: controller._testLinkBrowserDividerThickness,
-            persistedWidth: resizedWidth)
-        #expect(abs(controller._testLinkBrowserWidth - restoredExpectedWidth) < 1)
     }
 
-    @Test func `dashboard link browser reorders and closes other tabs`() throws {
-        let dashboard = try #require(URL(string: "http://127.0.0.1:18789/control/"))
+    @Test func `dashboard link browser reorders and closes other tabs`() async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let readerServer = try await DashboardHTTPFixture.start()
+        defer { readerServer.stop() }
+        let dashboard = server.url("/control/")
         let controller = DashboardWindowController(
             url: dashboard,
-            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil))
-        let urlA = try #require(URL(string: "https://127.0.0.1:1/a"))
-        let urlB = try #require(URL(string: "https://127.0.0.1:1/b"))
-        let urlC = try #require(URL(string: "https://127.0.0.1:1/c"))
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil),
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "",
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { controller.closeDashboard() }
+        let urlA = readerServer.url("/reader/a")
+        let urlB = readerServer.url("/reader/b")
+        let urlC = readerServer.url("/reader/c")
         controller._testOpenLinkBrowser(urlA)
         controller._testOpenLinkBrowser(urlB)
         controller._testOpenLinkBrowser(urlC)
@@ -717,11 +769,13 @@ struct DashboardWindowSmokeTests {
         }
     }
 
-    @Test func `dashboard link browser retires initial URL after later navigation`() throws {
-        let view = DashboardLinkBrowserView(websiteDataStore: .default())
+    @Test func `dashboard link browser retires initial URL after later navigation`() async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let view = DashboardLinkBrowserView(websiteDataStore: .nonPersistent())
         defer { view.closeBrowser() }
-        let requestedURL = try #require(URL(string: "http://127.0.0.1:1/short"))
-        let currentURL = try #require(URL(string: "http://127.0.0.1:1/final"))
+        let requestedURL = server.url("/reader/short")
+        let currentURL = server.url("/reader/final")
         view.open(requestedURL)
         let webView = try #require(view._testActiveWebView)
         let initialNavigation = NSObject()
@@ -748,12 +802,14 @@ struct DashboardWindowSmokeTests {
         #expect(view._testActiveWebView !== webView)
     }
 
-    @Test func `dashboard link browser retires initial URL when navigation is replaced`() throws {
-        let view = DashboardLinkBrowserView(websiteDataStore: .default())
+    @Test func `dashboard link browser retires initial URL when navigation is replaced`() async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let view = DashboardLinkBrowserView(websiteDataStore: .nonPersistent())
         defer { view.closeBrowser() }
-        let requestedURL = try #require(URL(string: "http://127.0.0.1:1/short"))
-        let redirectURL = try #require(URL(string: "http://127.0.0.1:1/redirect"))
-        let replacementURL = try #require(URL(string: "http://127.0.0.1:1/replacement"))
+        let requestedURL = server.url("/reader/short")
+        let redirectURL = server.url("/reader/redirect")
+        let replacementURL = server.url("/reader/replacement")
         view.open(requestedURL)
         let webView = try #require(view._testActiveWebView)
         view._testStartNavigation(NSObject(), in: webView)
@@ -767,11 +823,13 @@ struct DashboardWindowSmokeTests {
         #expect(view._testActiveWebView !== webView)
     }
 
-    @Test func `dashboard link browser retires initial URL when redirected navigation fails`() throws {
-        let view = DashboardLinkBrowserView(websiteDataStore: .default())
+    @Test func `dashboard link browser retires initial URL when redirected navigation fails`() async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let view = DashboardLinkBrowserView(websiteDataStore: .nonPersistent())
         defer { view.closeBrowser() }
-        let requestedURL = try #require(URL(string: "http://127.0.0.1:1/short"))
-        let redirectURL = try #require(URL(string: "http://127.0.0.1:1/redirect"))
+        let requestedURL = server.url("/reader/short")
+        let redirectURL = server.url("/reader/redirect")
         view.open(requestedURL)
         let webView = try #require(view._testActiveWebView)
         view._testStartNavigation(NSObject(), in: webView)
@@ -784,11 +842,13 @@ struct DashboardWindowSmokeTests {
         #expect(view._testActiveWebView !== webView)
     }
 
-    @Test func `dashboard link browser prefers current URL over initial alias`() throws {
-        let view = DashboardLinkBrowserView(websiteDataStore: .default())
+    @Test func `dashboard link browser prefers current URL over initial alias`() async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let view = DashboardLinkBrowserView(websiteDataStore: .nonPersistent())
         defer { view.closeBrowser() }
-        let requestedURL = try #require(URL(string: "http://127.0.0.1:1/short"))
-        let currentURL = try #require(URL(string: "http://127.0.0.1:1/final"))
+        let requestedURL = server.url("/reader/short")
+        let currentURL = server.url("/reader/final")
         view.open(requestedURL)
         let redirectedWebView = try #require(view._testActiveWebView)
         view.navigationWillStart(currentURL, in: redirectedWebView)
@@ -802,9 +862,12 @@ struct DashboardWindowSmokeTests {
         #expect(view._testActiveWebView === currentWebView)
     }
 
-    @Test func `dashboard link browser menu disables URL actions for blank tab`() throws {
-        let view = DashboardLinkBrowserView(websiteDataStore: .default())
-        let url = try #require(URL(string: "http://127.0.0.1:1/blank"))
+    @Test func `dashboard link browser menu disables URL actions for blank tab`() async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let view = DashboardLinkBrowserView(websiteDataStore: .nonPersistent())
+        defer { view.closeBrowser() }
+        let url = server.url("/reader/blank")
         view.open(url)
         let webView = try #require(view._testActiveWebView)
         #expect(webView.url == nil)
@@ -907,11 +970,17 @@ struct DashboardWindowSmokeTests {
         #expect(dashboardLogString(for: url) == "http://127.0.0.1:18789/control/")
     }
 
-    @Test func `dashboard native chrome clears both desktop sidebars`() throws {
-        let url = try #require(URL(string: "http://127.0.0.1:18789/control/"))
+    @Test func `dashboard native chrome clears both desktop sidebars`() async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let url = server.url("/control/")
         let controller = DashboardWindowController(
             url: url,
-            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil))
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil),
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "",
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { controller.closeDashboard() }
         let chromeScript = try #require(controller._testUserScripts.first {
             $0.source.contains("openclaw-native-macos-chrome")
         })
@@ -933,11 +1002,17 @@ struct DashboardWindowSmokeTests {
         #expect(chromeScript.isForMainFrameOnly)
     }
 
-    @Test func `dashboard advertises web titlebar chrome before document load`() throws {
-        let url = try #require(URL(string: "http://127.0.0.1:18789/control/"))
+    @Test func `dashboard advertises web titlebar chrome before document load`() async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let url = server.url("/control/")
         let controller = DashboardWindowController(
             url: url,
-            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil))
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil),
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "",
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { controller.closeDashboard() }
         let capabilityScript = try #require(controller._testUserScripts.first {
             $0.source.contains("__OPENCLAW_NATIVE_WEB_CHROME__")
         })
@@ -964,11 +1039,17 @@ struct DashboardWindowSmokeTests {
         #expect(!DashboardWindowController._testJavaScriptConfirmResult(for: .cancel))
     }
 
-    @Test func `dashboard failure state opens in dashboard window`() throws {
-        let url = try #require(URL(string: "http://127.0.0.1:18789/control/"))
+    @Test func `dashboard failure state opens in dashboard window`() async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let url = server.url("/control/")
         let controller = DashboardWindowController(
             url: url,
-            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil))
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil),
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "",
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { controller.closeDashboard() }
         controller.showFailure(
             title: "Dashboard unavailable",
             message: "Remote control tunnel failed",
@@ -979,49 +1060,59 @@ struct DashboardWindowSmokeTests {
         controller.closeDashboard()
     }
 
-    private func makeShownController() throws -> DashboardWindowController {
-        let url = try #require(URL(string: "http://127.0.0.1:60001/#token=device-token"))
+    private func makeShownController(server: DashboardHTTPFixture) -> DashboardWindowController {
+        let url = server.url("/#token=device-token")
         let controller = DashboardWindowController(
             url: url,
             auth: DashboardWindowAuth(
-                gatewayUrl: "ws://127.0.0.1:60001/",
+                gatewayUrl: server.websocketURL("/").absoluteString,
                 token: "device-token",
-                password: nil))
+                password: nil),
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "",
+            requestBrowserProfileImportOffer: { _ in false })
         controller.show()
         return controller
     }
 
     @Test func `dashboard follows ready endpoint to a new tunnel port`() async throws {
-        let controller = try makeShownController()
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let replacementServer = try await DashboardHTTPFixture.start()
+        defer { replacementServer.stop() }
+        let controller = self.makeShownController(server: server)
         defer { controller.closeDashboard() }
         let manager = DashboardManager._testMake()
         manager._testSetController(controller)
 
-        try await manager.handleEndpointState(.ready(
+        await manager.handleEndpointState(.ready(
             mode: .remote,
-            url: #require(URL(string: "ws://127.0.0.1:60002")),
+            url: replacementServer.websocketURL(""),
             token: "device-token",
             password: nil))
 
-        #expect(controller.currentURL.absoluteString == "http://127.0.0.1:60002/#token=device-token")
+        #expect(controller.currentURL.absoluteString == replacementServer.url("/#token=device-token").absoluteString)
         let authScripts = controller._testUserScripts
             .filter { $0.source.contains("__OPENCLAW_NATIVE_CONTROL_AUTH__") }
         #expect(authScripts.count == 1)
         // JSONSerialization escapes "/" so match on host:port, not the full origin.
-        #expect(authScripts.first?.source.contains("127.0.0.1:60002") == true)
-        #expect(authScripts.first?.source.contains("60001") == false)
+        #expect(authScripts.first?.source.contains("127.0.0.1:\(replacementServer.port)") == true)
+        #expect(authScripts.first?.source.contains(String(server.port)) == false)
     }
 
     @Test func `dashboard retires its web view while endpoint is unavailable`() async throws {
-        let controller = try makeShownController()
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let controller = self.makeShownController(server: server)
         defer { controller.closeDashboard() }
         let manager = DashboardManager._testMake()
         manager._testSetController(controller)
+        defer { manager.close() }
         let scriptsBefore = controller._testUserScripts
 
-        try await manager.handleEndpointState(.ready(
+        await manager.handleEndpointState(.ready(
             mode: .remote,
-            url: #require(URL(string: "ws://127.0.0.1:60001")),
+            url: server.websocketURL(""),
             token: "device-token",
             password: nil))
         await manager.handleEndpointState(.connecting(mode: .remote, detail: "Connecting…"))
@@ -1035,13 +1126,18 @@ struct DashboardWindowSmokeTests {
     }
 
     @Test func `same URL route revision recreates dashboard without prior token`() async throws {
-        let url = try #require(URL(string: "http://127.0.0.1:60001/#token=route-a-device-token"))
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let url = server.url("/#token=route-a-device-token")
         let controller = DashboardWindowController(
             url: url,
             auth: DashboardWindowAuth(
-                gatewayUrl: "ws://127.0.0.1:60001/",
+                gatewayUrl: server.websocketURL("/").absoluteString,
                 token: "route-a-device-token",
-                password: nil))
+                password: nil),
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "",
+            requestBrowserProfileImportOffer: { _ in false })
         controller.show()
         let authGate = DashboardRouteAuthGate(token: "route-a-device-token")
         let manager = DashboardManager._testMake(
@@ -1049,7 +1145,7 @@ struct DashboardWindowSmokeTests {
             routeProbe: { await authGate.probe() })
         manager._testSetController(controller)
         defer { manager._testController()?.closeDashboard() }
-        let socketURL = try #require(URL(string: "ws://127.0.0.1:60001"))
+        let socketURL = server.websocketURL("")
 
         await manager.handleEndpointState(.ready(
             mode: .remote,
@@ -1073,7 +1169,7 @@ struct DashboardWindowSmokeTests {
         #expect(routeBController !== routeAController)
         #expect(!routeAController.isWindowOpen)
         #expect(routeBController.currentURL.absoluteString ==
-            "http://127.0.0.1:60001/#token=route-b-device-token")
+            server.url("/#token=route-b-device-token").absoluteString)
         let scripts = routeBController._testUserScripts
             .filter { $0.source.contains("__OPENCLAW_NATIVE_CONTROL_AUTH__") }
         #expect(scripts.count == 1)
@@ -1082,13 +1178,18 @@ struct DashboardWindowSmokeTests {
     }
 
     @Test func `route change without fresh credential blanks prior dashboard`() async throws {
-        let url = try #require(URL(string: "http://127.0.0.1:60001/#token=route-a-device-token"))
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let url = server.url("/#token=route-a-device-token")
         let controller = DashboardWindowController(
             url: url,
             auth: DashboardWindowAuth(
-                gatewayUrl: "ws://127.0.0.1:60001/",
+                gatewayUrl: server.websocketURL("/").absoluteString,
                 token: "route-a-device-token",
-                password: nil))
+                password: nil),
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "",
+            requestBrowserProfileImportOffer: { _ in false })
         controller.show()
         let manager = DashboardManager._testMake(
             authTokenProvider: { _ in nil },
@@ -1096,9 +1197,9 @@ struct DashboardWindowSmokeTests {
         manager._testSetController(controller)
         defer { manager._testController()?.closeDashboard() }
 
-        try await manager.handleEndpointState(.ready(
+        await manager.handleEndpointState(.ready(
             mode: .remote,
-            url: #require(URL(string: "ws://127.0.0.1:60001")),
+            url: server.websocketURL(""),
             token: nil,
             password: nil,
             routeRevision: 2))
@@ -1113,19 +1214,27 @@ struct DashboardWindowSmokeTests {
     }
 
     @Test func `dashboard ignores endpoint changes while window is closed`() async throws {
-        let url = try #require(URL(string: "http://127.0.0.1:60001/#token=device-token"))
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let replacementServer = try await DashboardHTTPFixture.start()
+        defer { replacementServer.stop() }
+        let url = server.url("/#token=device-token")
         let controller = DashboardWindowController(
             url: url,
             auth: DashboardWindowAuth(
-                gatewayUrl: "ws://127.0.0.1:60001/",
+                gatewayUrl: server.websocketURL("/").absoluteString,
                 token: "device-token",
-                password: nil))
+                password: nil),
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "",
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { controller.closeDashboard() }
         let manager = DashboardManager._testMake()
         manager._testSetController(controller)
 
-        try await manager.handleEndpointState(.ready(
+        await manager.handleEndpointState(.ready(
             mode: .remote,
-            url: #require(URL(string: "ws://127.0.0.1:60002")),
+            url: replacementServer.websocketURL(""),
             token: "device-token",
             password: nil))
 

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketTestSupport.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketTestSupport.swift
@@ -4,10 +4,24 @@ import Foundation
 
 enum ExecApprovalsSocketTestSupport {
     static func makeRoot() throws -> URL {
-        let root = URL(fileURLWithPath: "/tmp/ocst-\(UUID().uuidString.prefix(12))", isDirectory: true)
-        try FileManager().createDirectory(
-            at: root, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
-        return root.resolvingSymlinksInPath()
+        let base = FileManager.default.temporaryDirectory.resolvingSymlinksInPath()
+        let template = base.appendingPathComponent("XXXXXX", isDirectory: true).path
+        // CuaDriverHostCoordinator.createSocketDirectory adds this 39-byte suffix.
+        // Reserve its full sun_path budget before mkdtemp creates any fixture state.
+        let longestSocketPath = template + "/OpenClaw/cua/0000000000000000/cua.sock"
+        guard longestSocketPath.utf8.count < MemoryLayout.size(ofValue: sockaddr_un().sun_path) else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(ENAMETOOLONG), userInfo: [
+                NSLocalizedDescriptionKey:
+                    "Native socket fixtures need a shorter test-owned TMPDIR in the disposable runner.",
+            ])
+        }
+        var bytes = Array(template.utf8CString)
+        return try bytes.withUnsafeMutableBufferPointer { buffer in
+            guard let created = mkdtemp(buffer.baseAddress!) else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+            return URL(fileURLWithPath: String(cString: created), isDirectory: true).resolvingSymlinksInPath()
+        }
     }
 
     static func makeServer(

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketTestSupportTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketTestSupportTests.swift
@@ -1,0 +1,47 @@
+import Darwin
+import Foundation
+import Testing
+@testable import OpenClaw
+
+struct ExecApprovalsSocketTestSupportTests {
+    @MainActor
+    @Test func `socket roots are private unique temporary children with room for CUA endpoints`() throws {
+        let fileManager = FileManager.default
+        let base = fileManager.temporaryDirectory.resolvingSymlinksInPath()
+        let first = try ExecApprovalsSocketTestSupport.makeRoot()
+        defer { try? fileManager.removeItem(at: first) }
+        let second = try ExecApprovalsSocketTestSupport.makeRoot()
+        defer { try? fileManager.removeItem(at: second) }
+        #expect(first != second)
+
+        for root in [first, second] {
+            #expect(root.path == root.resolvingSymlinksInPath().path)
+            #expect(root.deletingLastPathComponent().path == base.path)
+            let attributes = try fileManager.attributesOfItem(atPath: root.path)
+            #expect((attributes[.posixPermissions] as? NSNumber)?.intValue == 0o700)
+
+            let directory = try CuaDriverHostCoordinator.createSocketDirectory(in: root)
+            defer { CuaDriverHostCoordinator.cleanupSocketDirectory(directory) }
+            let descriptor = socket(AF_UNIX, SOCK_STREAM, 0)
+            try #require(descriptor >= 0)
+            defer { close(descriptor) }
+            var address = sockaddr_un()
+            address.sun_family = sa_family_t(AF_UNIX)
+            let capacity = MemoryLayout.size(ofValue: address.sun_path)
+            try #require(directory.socketPath.utf8.count < capacity)
+            directory.socketPath.withCString { source in
+                withUnsafeMutablePointer(to: &address.sun_path) {
+                    $0.withMemoryRebound(to: CChar.self, capacity: capacity) {
+                        _ = strcpy($0, source)
+                    }
+                }
+            }
+            let result = withUnsafePointer(to: &address) {
+                $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                    Darwin.bind(descriptor, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
+                }
+            }
+            #expect(result == 0)
+        }
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/ExecHostSocketCancellationTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecHostSocketCancellationTests.swift
@@ -112,7 +112,7 @@ struct ExecHostSocketCancellationTests {
 
     @Test
     func `cancelled native executor never starts a command`() async throws {
-        let root = try self.makeRoot()
+        let root = try ExecApprovalsSocketTestSupport.makeRoot()
         defer { try? FileManager.default.removeItem(at: root) }
         try self.seed(root)
         let sentinel = root.appendingPathComponent("unexpected")
@@ -131,7 +131,7 @@ struct ExecHostSocketCancellationTests {
         admissionDelay: Duration = .zero,
         _ body: (ExecApprovalsSocketServer, URL, CancellationFixture) async throws -> Void) async throws
     {
-        let root = try self.makeRoot()
+        let root = try ExecApprovalsSocketTestSupport.makeRoot()
         defer { try? FileManager.default.removeItem(at: root) }
         try self.seed(root)
         let fixture = try CancellationFixture(root: root)
@@ -159,13 +159,6 @@ struct ExecHostSocketCancellationTests {
             throw error
         }
         await fixture.cleanUp(server: server)
-    }
-
-    private func makeRoot() throws -> URL {
-        let root = URL(fileURLWithPath: "/tmp/oehc-\(UUID().uuidString.prefix(12))", isDirectory: true)
-        try FileManager.default.createDirectory(
-            at: root, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
-        return root.resolvingSymlinksInPath()
     }
 
     private func seed(_ root: URL) throws {

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayEnvironmentTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayEnvironmentTests.swift
@@ -143,8 +143,7 @@ struct GatewayEnvironmentTests {
             let defaultPort = GatewayEnvironment.gatewayPort()
             #expect(defaultPort == 18789)
 
-            UserDefaults.standard.set(19999, forKey: "gatewayPort")
-            defer { UserDefaults.standard.removeObject(forKey: "gatewayPort") }
+            AppDefaults.standard.set(19999, forKey: "gatewayPort")
             #expect(GatewayEnvironment.gatewayPort() == 19999)
         }
     }

--- a/apps/macos/Tests/OpenClawIPCTests/NixModeStableSuiteTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/NixModeStableSuiteTests.swift
@@ -4,45 +4,53 @@ import Testing
 
 @Suite(.serialized)
 struct NixModeStableSuiteTests {
-    @Test func `does not create a stable suite for the app's own bundle identifier`() {
-        #expect(ProcessInfo.resolveStableNixSuite(bundleIdentifier: launchdLabel, isAppBundle: true) == nil)
+    @Test func `does not select a stable suite for the app's own bundle identifier`() {
+        #expect(ProcessInfo.resolveStableNixSuiteName(bundleIdentifier: launchdLabel, isAppBundle: true) == nil)
     }
 
-    @Test func `creates a stable suite for renamed app bundles`() {
-        #expect(ProcessInfo.resolveStableNixSuite(
+    @Test func `selects the stable suite for renamed app bundles`() {
+        #expect(ProcessInfo.resolveStableNixSuiteName(
             bundleIdentifier: "ai.openclaw.mac.renamed",
-            isAppBundle: true) != nil)
+            isAppBundle: true) == launchdLabel)
     }
 
-    @Test func `does not create a stable suite outside app bundles`() {
-        #expect(ProcessInfo.resolveStableNixSuite(
+    @Test func `does not select a stable suite outside app bundles`() {
+        #expect(ProcessInfo.resolveStableNixSuiteName(
             bundleIdentifier: "ai.openclaw.mac.renamed",
             isAppBundle: false) == nil)
     }
 
-    @Test func `resolves from stable suite for app bundles`() throws {
-        let suite = try #require(UserDefaults(suiteName: launchdLabel))
+    @Test func `resolves Nix mode from independent defaults domains and environment`() throws {
+        let standardName = "NixModeStableSuiteTests.standard.\(UUID().uuidString)"
+        let standard = try #require(UserDefaults(suiteName: standardName))
+        defer { standard.removePersistentDomain(forName: standardName) }
+        let stableName = "NixModeStableSuiteTests.stable.\(UUID().uuidString)"
+        let stable = try #require(UserDefaults(suiteName: stableName))
+        defer { stable.removePersistentDomain(forName: stableName) }
         let key = "openclaw.nixMode"
-        let prev = suite.object(forKey: key)
-        defer {
-            if let prev {
-                suite.set(prev, forKey: key)
-            } else {
-                suite.removeObject(forKey: key)
-            }
+        let cases: [(environment: String?, standard: Bool, stable: Bool?, isApp: Bool, expected: Bool)] = [
+            (nil, false, nil, true, false),
+            (nil, false, false, true, false),
+            (nil, false, true, true, true),
+            (nil, false, true, false, false),
+            (nil, true, false, true, true),
+            (nil, true, true, false, true),
+            ("1", false, false, true, true),
+            ("1", false, nil, false, true),
+            ("0", false, false, true, false),
+            ("0", true, false, false, true),
+            ("0", false, true, true, true),
+            ("true", false, false, true, false),
+        ]
+        for input in cases {
+            standard.set(input.standard, forKey: key)
+            stable.set(input.stable ?? false, forKey: key)
+            #expect(ProcessInfo.resolveNixMode(
+                environment: input.environment.map { ["OPENCLAW_NIX_MODE": $0] } ?? [:],
+                standard: standard,
+                stableSuite: input.stable == nil ? nil : stable,
+                isAppBundle: input.isApp) == input.expected, "\(input)")
         }
-
-        suite.set(true, forKey: key)
-
-        let standard = try #require(UserDefaults(suiteName: "NixModeStableSuiteTests.\(UUID().uuidString)"))
-        #expect(!standard.bool(forKey: key))
-
-        let resolved = ProcessInfo.resolveNixMode(
-            environment: [:],
-            standard: standard,
-            stableSuite: suite,
-            isAppBundle: true)
-        #expect(resolved)
     }
 
     @Test func `detects SwiftPM and XCTest runners`() {
@@ -78,28 +86,5 @@ struct NixModeStableSuiteTests {
             processName: "OpenClaw",
             arguments: [],
             bundleURLs: []))
-    }
-
-    @Test func `ignores stable suite outside app bundles`() throws {
-        let suite = try #require(UserDefaults(suiteName: launchdLabel))
-        let key = "openclaw.nixMode"
-        let prev = suite.object(forKey: key)
-        defer {
-            if let prev {
-                suite.set(prev, forKey: key)
-            } else {
-                suite.removeObject(forKey: key)
-            }
-        }
-
-        suite.set(true, forKey: key)
-        let standard = try #require(UserDefaults(suiteName: "NixModeStableSuiteTests.\(UUID().uuidString)"))
-
-        let resolved = ProcessInfo.resolveNixMode(
-            environment: [:],
-            standard: standard,
-            stableSuite: suite,
-            isAppBundle: false)
-        #expect(!resolved)
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/PeekabooBridgeHostCoordinatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/PeekabooBridgeHostCoordinatorTests.swift
@@ -108,11 +108,9 @@ struct PeekabooBridgeHostCoordinatorTests {
     @Test(.enabled(if: ProcessInfo.processInfo.environment["OPENCLAW_PEEKABOO_HANDSHAKE_CLI"] != nil))
     func `embedded runtime serves an exact socket handshake`() async throws {
         let cliPath = try #require(ProcessInfo.processInfo.environment["OPENCLAW_PEEKABOO_HANDSHAKE_CLI"])
-        let socketPath = "/tmp/oc-pb-\(UUID().uuidString).sock"
-        defer {
-            try? FileManager.default.removeItem(atPath: socketPath)
-            try? FileManager.default.removeItem(atPath: "\(socketPath).lock")
-        }
+        let root = try ExecApprovalsSocketTestSupport.makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let socketPath = root.appendingPathComponent("bridge.sock").path
 
         let coordinator = PeekabooBridgeHostCoordinator(
             runtimeFactory: {
@@ -126,26 +124,32 @@ struct PeekabooBridgeHostCoordinatorTests {
             aliasManager: .init(targetSocketPath: socketPath, aliasSocketPaths: []))
         await coordinator.setEnabled(true)
 
-        let result = try await Task.detached {
-            let process = Process()
-            let stdout = Pipe()
-            let stderr = Pipe()
-            process.executableURL = URL(fileURLWithPath: cliPath)
-            process.arguments = ["bridge", "status", "--bridge-socket", socketPath, "--json"]
-            process.standardOutput = stdout
-            process.standardError = stderr
-            try process.run()
-            process.waitUntilExit()
-            return ProcessResult(
-                status: process.terminationStatus,
-                stdout: String(decoding: stdout.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self),
-                stderr: String(decoding: stderr.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self))
-        }.value
+        let result: ProcessResult
+        do {
+            result = try await Task.detached {
+                let process = Process()
+                let stdout = Pipe()
+                let stderr = Pipe()
+                process.executableURL = URL(fileURLWithPath: cliPath)
+                process.arguments = ["bridge", "status", "--bridge-socket", socketPath, "--json"]
+                process.standardOutput = stdout
+                process.standardError = stderr
+                try process.run()
+                process.waitUntilExit()
+                return ProcessResult(
+                    status: process.terminationStatus,
+                    stdout: String(decoding: stdout.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self),
+                    stderr: String(decoding: stderr.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self))
+            }.value
+        } catch {
+            await coordinator.shutdown()
+            throw error
+        }
+        await coordinator.shutdown()
         #expect(result.status == 0, Comment(rawValue: result.stderr))
         #expect(result.stdout.replacingOccurrences(of: "\\/", with: "/").contains(socketPath))
         #expect(result.stdout.contains("backgroundBridgeHost"))
 
-        await coordinator.shutdown()
         #expect(!FileManager.default.fileExists(atPath: socketPath))
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/RuntimeLocatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/RuntimeLocatorTests.swift
@@ -3,11 +3,8 @@ import Testing
 @testable import OpenClaw
 
 struct RuntimeLocatorTests {
-    private func makeTempExecutable(contents: String) throws -> URL {
-        let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager().createDirectory(at: dir, withIntermediateDirectories: true)
-        let path = dir.appendingPathComponent("node")
+    private func makeExecutable(in directory: URL, contents: String) throws -> URL {
+        let path = directory.appendingPathComponent("node")
         try contents.write(to: path, atomically: true, encoding: .utf8)
         try FileManager().setAttributes([.posixPermissions: 0o755], ofItemAtPath: path.path)
         return path
@@ -18,7 +15,9 @@ struct RuntimeLocatorTests {
         #!/bin/sh
         echo v22.22.3
         """
-        let node = try self.makeTempExecutable(contents: script)
+        let root = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let node = try self.makeExecutable(in: root, contents: script)
         let result = await RuntimeLocator.resolve(searchPaths: [node.deletingLastPathComponent().path])
         guard case let .success(res) = result else {
             Issue.record("Expected success, got \(result)")
@@ -34,7 +33,9 @@ struct RuntimeLocatorTests {
         /bin/sleep 2.1
         echo v22.22.3
         """
-        let node = try self.makeTempExecutable(contents: script)
+        let root = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let node = try self.makeExecutable(in: root, contents: script)
         let result = await RuntimeLocator.resolve(searchPaths: [node.deletingLastPathComponent().path])
         guard case let .success(resolution) = result else {
             Issue.record("Expected delayed version probe to succeed, got \(result)")
@@ -48,7 +49,9 @@ struct RuntimeLocatorTests {
         #!/bin/sh
         echo v22.22.2
         """
-        let node = try self.makeTempExecutable(contents: script)
+        let root = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let node = try self.makeExecutable(in: root, contents: script)
         let result = await RuntimeLocator.resolve(searchPaths: [node.deletingLastPathComponent().path])
         guard case let .failure(.unsupported(_, found, path, _)) = result else {
             Issue.record("Expected unsupported error, got \(result)")
@@ -63,7 +66,9 @@ struct RuntimeLocatorTests {
         #!/bin/sh
         echo v23.11.0
         """
-        let node = try self.makeTempExecutable(contents: script)
+        let root = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let node = try self.makeExecutable(in: root, contents: script)
         let result = await RuntimeLocator.resolve(searchPaths: [node.deletingLastPathComponent().path])
         guard case let .failure(.unsupported(_, found, path, _)) = result else {
             Issue.record("Expected unsupported error, got \(result)")
@@ -93,7 +98,9 @@ struct RuntimeLocatorTests {
         #!/bin/sh
         echo v18.2.0
         """
-        let node = try self.makeTempExecutable(contents: script)
+        let root = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let node = try self.makeExecutable(in: root, contents: script)
         let result = await RuntimeLocator.resolve(searchPaths: [node.deletingLastPathComponent().path])
         guard case let .failure(.unsupported(_, found, path, _)) = result else {
             Issue.record("Expected unsupported error, got \(result)")
@@ -108,7 +115,9 @@ struct RuntimeLocatorTests {
         #!/bin/sh
         echo node-version:unknown
         """
-        let node = try self.makeTempExecutable(contents: script)
+        let root = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let node = try self.makeExecutable(in: root, contents: script)
         let result = await RuntimeLocator.resolve(searchPaths: [node.deletingLastPathComponent().path])
         guard case let .failure(.versionParse(_, raw, path, _)) = result else {
             Issue.record("Expected versionParse error, got \(result)")
@@ -119,7 +128,9 @@ struct RuntimeLocatorTests {
     }
 
     @Test func `resolve rejects a failing node shim that prints a supported version`() async throws {
-        let node = try self.makeTempExecutable(contents: """
+        let root = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let node = try self.makeExecutable(in: root, contents: """
         #!/bin/sh
         echo v24.15.0
         exit 1

--- a/apps/macos/Tests/OpenClawIPCTests/SettingsDashboardHandoffTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/SettingsDashboardHandoffTests.swift
@@ -46,7 +46,11 @@ struct SettingsDashboardHandoffTests {
         let fallbackURL = try #require(URL(string: "http://127.0.0.1:18789/control/skills"))
         let controller = DashboardWindowController(
             url: baseURL,
-            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil))
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil),
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "",
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { controller.closeDashboard() }
         let navigation = DashboardNativeNavigation(path: "/skills", fallbackURL: fallbackURL)
 
         controller.dispatchNativeNavigation(navigation)
@@ -59,7 +63,11 @@ struct SettingsDashboardHandoffTests {
         let fallbackURL = try #require(URL(string: "http://127.0.0.1:18789/control/skills"))
         let controller = DashboardWindowController(
             url: baseURL,
-            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil))
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil),
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "",
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { controller.closeDashboard() }
 
         controller.dispatchNativeNavigation(DashboardNativeNavigation(
             path: "/skills",
@@ -77,15 +85,19 @@ struct SettingsDashboardHandoffTests {
 
     @Test func `newer Dashboard dispatch invalidates stale in-flight fallback`() throws {
         let baseURL = try #require(URL(string: "http://127.0.0.1:18789/control/"))
-        let first = DashboardNativeNavigation(
+        let first = try DashboardNativeNavigation(
             path: "/skills",
-            fallbackURL: try #require(URL(string: "http://127.0.0.1:18789/control/skills")))
-        let second = DashboardNativeNavigation(
+            fallbackURL: #require(URL(string: "http://127.0.0.1:18789/control/skills")))
+        let second = try DashboardNativeNavigation(
             path: "/cron",
-            fallbackURL: try #require(URL(string: "http://127.0.0.1:18789/control/cron")))
+            fallbackURL: #require(URL(string: "http://127.0.0.1:18789/control/cron")))
         let controller = DashboardWindowController(
             url: baseURL,
-            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil))
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil),
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "",
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { controller.closeDashboard() }
 
         controller.dispatchNativeNavigation(first)
         let staleGeneration = controller._testNavigationGeneration

--- a/apps/macos/Tests/OpenClawIPCTests/TestFSHelpers.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/TestFSHelpers.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 func makeTempDirForTests() throws -> URL {
-    let base = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+    let base = FileManager.default.temporaryDirectory
     let dir = base.appendingPathComponent(UUID().uuidString, isDirectory: true)
     try FileManager().createDirectory(at: dir, withIntermediateDirectories: true)
     return dir

--- a/apps/macos/Tests/OpenClawIPCTests/UpdateOrchestrationTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/UpdateOrchestrationTests.swift
@@ -390,16 +390,31 @@ struct UpdateOrchestrationTests {
         let url = try #require(URL(string: "http://127.0.0.1:18789/control/"))
         let auth = DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil)
         let available = TestUpdater(isAvailable: true)
-        let enabled = DashboardWindowController(url: url, auth: auth, updater: available)
+        let enabled = DashboardWindowController(
+            url: url,
+            auth: auth,
+            websiteDataStore: .nonPersistent(),
+            updater: available,
+            windowAutosaveName: "",
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { enabled.closeDashboard() }
         let disabled = DashboardWindowController(
             url: url,
             auth: auth,
-            updater: TestUpdater(isAvailable: false))
+            websiteDataStore: .nonPersistent(),
+            updater: TestUpdater(isAvailable: false),
+            windowAutosaveName: "",
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { disabled.closeDashboard() }
         let remote = DashboardWindowController(
             url: url,
             auth: auth,
+            websiteDataStore: .nonPersistent(),
             updater: available,
-            updateBridgeEnabled: false)
+            updateBridgeEnabled: false,
+            windowAutosaveName: "",
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { remote.closeDashboard() }
 
         #expect(enabled._testUpdateBridgeAvailable)
         #expect(!disabled._testUpdateBridgeAvailable)
@@ -605,13 +620,14 @@ struct UpdateOrchestrationTests {
             launchAgentWriteDisabled: false))
     }
 
-    @Test func `pending managed restart marker round trips`() {
-        CLIInstallPrompter.clearPendingManagedRestart()
-        #expect(!CLIInstallPrompter.hasPendingManagedRestart())
-        CLIInstallPrompter.setPendingManagedRestart()
-        #expect(CLIInstallPrompter.hasPendingManagedRestart())
-        CLIInstallPrompter.clearPendingManagedRestart()
-        #expect(!CLIInstallPrompter.hasPendingManagedRestart())
+    @Test func `pending managed restart marker round trips`() async {
+        await TestIsolation.withUserDefaultsValues([cliManagedRestartPendingKey: nil]) {
+            #expect(!CLIInstallPrompter.hasPendingManagedRestart())
+            CLIInstallPrompter.setPendingManagedRestart()
+            #expect(CLIInstallPrompter.hasPendingManagedRestart())
+            CLIInstallPrompter.clearPendingManagedRestart()
+            #expect(!CLIInstallPrompter.hasPendingManagedRestart())
+        }
     }
 
     @Test func `managed Gateway restart requires a new running process`() {

--- a/apps/macos/Tests/OpenClawIPCTests/UtilitiesTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/UtilitiesTests.swift
@@ -33,7 +33,9 @@ import Testing
     }
 
     @Test func `sanitized target strips leading SSH prefix`() throws {
-        let defaults = try #require(UserDefaults(suiteName: "UtilitiesTests.\(UUID().uuidString)"))
+        let suiteName = "UtilitiesTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         defaults.set(AppState.ConnectionMode.remote.rawValue, forKey: connectionModeKey)
         defaults.set("ssh  alice@example.com", forKey: remoteTargetKey)
 
@@ -43,8 +45,8 @@ import Testing
     }
 
     @Test func `gateway entrypoint prefers dist over bin`() throws {
-        let tmp = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let tmp = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: tmp) }
         let dist = tmp.appendingPathComponent("dist/index.js")
         let bin = tmp.appendingPathComponent("bin/openclaw.js")
         try FileManager().createDirectory(at: dist.deletingLastPathComponent(), withIntermediateDirectories: true)

--- a/docs/platforms/mac/dev-setup.md
+++ b/docs/platforms/mac/dev-setup.md
@@ -68,6 +68,28 @@ npm install -g openclaw@<version> --allow-scripts=openclaw
 OpenClaw lifecycle scripts for that install. Node remains the recommended
 runtime for the Gateway itself.
 
+## Run native tests safely
+
+Run the full macOS app test suite in a disposable macOS VM or CI worker with
+no operator credentials, config, or running Gateway. AppKit tests can show
+windows, and WebKit starts helper processes. A temporary `HOME`, `TMPDIR`, or
+named app profile alone is not a sandbox: fixed preferences domains and
+Keychain access can still reach macOS services outside those directories.
+
+On an operator desktop, run only an audited subset inside an OS sandbox that
+blocks operator files, preferences and Keychain services, unwanted network
+access, and desktop/helper processes. A Swift test filter is not itself an
+isolation boundary. If that boundary cannot be established, use the disposable
+macOS environment instead.
+
+Tests should own their resources: unique defaults suites with cleanup,
+nonpersistent WebKit data stores, ephemeral loopback fixture endpoints, and
+temporary files rooted in `FileManager.temporaryDirectory`. Unix-domain socket
+fixtures require a short test-owned `TMPDIR`; an overlong path fails rather than
+silently writing outside that directory. The cooperative `TestIsolation` helper
+serializes and restores participating tests' environment
+and defaults mutations; it does not isolate the process from the host.
+
 ## Troubleshooting
 
 ### Build fails: toolchain or SDK mismatch


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where developers running native macOS tests could reuse resources outside the test's ownership: the stable application preferences domain, persistent WebKit storage, live Gateway/public HTTP endpoints, and socket fixtures outside the selected temporary directory. Saving and restoring a preference does not prevent transient contamination, lost concurrent updates, or residue after interruption.

This is a maintainer-requested native test isolation repair, not a change to the SwiftPM CI backend.

## Why This Change Was Made

The repair moves resource selection to its actual owner instead of treating a temporary HOME or a cooperative test lock as a sandbox:

- Nix suite selection returns a name without opening preferences. The production Nix resolver still opens the same historical domain; value tests use independently named, cleaned-up defaults suites.
- DashboardManager owns the WebKit store through one controller-construction flow. Controllers require explicit stores, autosave names, and browser-import callbacks. Tests use nonpersistent stores, test-namespaced/empty autosave names, and owned ephemeral loopback HTTP fixtures serving inert HTML. Replacement and auxiliary windows retain the same ownership.
- Socket fixtures allocate exclusive 0700 directories below canonical TMPDIR using a short mkdtemp leaf. An overlong path fails before creation with actionable guidance; there is no escape to a shared /tmp fallback. Duplicate fixture-root factories are removed, and related defaults/file/process fixtures gain cleanup.

## User Impact

No intended change to the app's UI, production Nix behavior, persistent browser store, or historical production autosave names. Native tests are more deterministic and no longer need the repaired fixtures to borrow operator resources.

This does **not** make the entire native target safe on an operator desktop. AppKit/WebKit execution and remaining ambient app/service/storage paths still require disposable macOS or a separately audited restrictive OS sandbox. The developer guide now states that boundary. Shared TLS Keychain/legacy-preferences test isolation remains separate follow-up work.

## Evidence

- **Before/after regression:** in a default-deny macOS sandbox, the old socket-root factory attempted `/tmp/ocst-*` outside the permitted test root and failed with Cocoa 513 / POSIX EPERM. The same checked-in regression passed after the repair, including unique private roots, 0700 permissions, and actual AF_UNIX binds at CUA-generated socket paths. The source-closed harness copied the real filesystem method bodies verbatim; unrelated app/daemon lifecycle code was omitted, not mocked.
- **Nix:** five repaired tests passed, including the 12-row environment/defaults/app-bundle matrix. The original six tests passed in the same sandbox, demonstrating that their old assertions did not detect the unsafe resource ownership. The proof compiled the complete Foundation-only production source closure, not the full app target.
- **Fixture HTTP:** the actual new HTTP fixture served the expected inert HTML, no-store and restrictive CSP headers to a separate client allowed to reach only the fixture's exact ephemeral port, then shut down. The server was restricted to loopback bind/accept with no outbound connections.
- **Length rejection:** an overlong TMPDIR was rejected before fixture creation, with no fallback or residue.
- **Sandbox canary:** outside-root reads/writes and network operations were denied; preferences, Keychain, WindowServer and WebKit service lookups were unavailable. The outside-root canary remained unchanged.
- **Compile-only:** the full native app and all native test sources compiled successfully in a frozen native source copy with isolated build HOME/cache and Git credential helpers disabled (`swift build --build-tests --jobs 4`, 386.61 seconds). Neither the app nor the full suite was executed on the operator desktop. The copied source hashes were checked against the final patch.
- **Static:** all 22 changed Swift files passed SwiftFormat and parsing; the three changed production files passed the repository's configured SwiftLint lane. Native state-schema guard, documentation formatting, and `git diff --check` passed. A voluntary lint invocation over tests beyond the configured Sources-only lane reports test-style diagnostics; no suppressions or rule/budget changes were added.
- **Independent review:** fresh after-rebase static P0-only autoreview at `aeb5cf8448ec90a9d7fcaeab8bc9db2efb250c75` completed with exit 0 and no accepted/actionable findings (`scoped-clean`). This is not an all-priority audit or runtime proof.
- **Complete exact-head CI:** [CI 33213920863, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33213920863/attempts/2) completed **SUCCESS** at `aeb5cf8448ec90a9d7fcaeab8bc9db2efb250c75`, including reused successful jobs. The [macos-swift job 99002350082](https://github.com/openclaw/openclaw/actions/runs/33213920863/job/99002350082) passed 1879 app tests in 195 suites (135.754s), 1496 shared-kit tests in 112 suites (44.754s), three XCTest layout cases, and one isolated health-render test. [macos-node](https://github.com/openclaw/openclaw/actions/runs/33213920863/job/99002350963) and [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33213920863/job/99007827851) also succeeded. No local AppKit/full-suite run or visual capture is claimed; this is a nonvisual ownership refactor.
- **CI recovery:** normal Blacksmith macOS capacity was queued/unassigned, so the documented exact-head hosted fallback was used without runner, workflow, or backend changes. An earlier native job passed, but its overall run failed on a pre-existing UI `expect.poll` race and a Matrix binary download reset. One mechanical rebase incorporated the already-landed [UI assertion-context repair #132066](https://github.com/openclaw/openclaw/pull/132066), preserving the exact 24-file patch. Current-head attempt 1 passed the browser gates but hit another Matrix download reset and the native 30-minute job deadline. Read-only timing analysis found additional build overhead, with no specific test hang established. Exactly one failed-jobs retry is now fully green; no timeout, dependency, or backend change was made. The upstream wrong-variable diagnostic after the download failure is a separate follow-up, not its cause.

Production source files: **+53/-59 (net -6)**. Separating DEBUG test support gives runtime **net +1** and DEBUG support **net -7**: the single runtime line buys explicit manager-owned store propagation after consolidating eight controller-construction sites into one. Tests/test support: **+1111/-441 (net +670)**. Docs: **+30**. No dependency, schema, generated, baseline, or lockfile changes.

AI-assisted; reviewed against the resource-ownership boundary and verified with the restricted proof described above. Maintainer edits are allowed on the same-repository branch.
