### PR TITLE
fix(plugins): retire loader cache with runtime registrations

### DIFF
--- a/src/plugins/loader-cache.ts
+++ b/src/plugins/loader-cache.ts
@@ -1,18 +1,14 @@
-import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { PluginLoaderCacheState } from "./loader-cache-state.js";
 import { resolvePluginLoadCacheContext } from "./loader-load-context.js";
 import type { PluginLoadOptions } from "./loader-types.js";
 import { clearPluginRuntimeArtifactResolutionMemo } from "./plugin-runtime-artifact-resolution.js";
+import { isPluginRegistryRetired } from "./registry-lifecycle.js";
 import type { PluginRegistry } from "./registry-types.js";
 
 const MAX_PLUGIN_REGISTRY_CACHE_ENTRIES = 128;
 
-export const pluginLoaderCacheState = resolveGlobalSingleton(
-  Symbol.for("openclaw.plugins.loader-cache-state"),
-  () => new PluginLoaderCacheState<PluginRegistry>(MAX_PLUGIN_REGISTRY_CACHE_ENTRIES),
-  // Runtime retirement closes registrations even when the load options stay unchanged.
-  (cache) => cache.clearCachedRegistries(),
-  "plugin-registry",
+export const pluginLoaderCacheState = new PluginLoaderCacheState<PluginRegistry>(
+  MAX_PLUGIN_REGISTRY_CACHE_ENTRIES,
 );
 
 export function setCachedPluginRegistry(cacheKey: string, registry: PluginRegistry): void {
@@ -20,7 +16,10 @@ export function setCachedPluginRegistry(cacheKey: string, registry: PluginRegist
 }
 
 export function getReusableCachedPluginRegistry(cacheKey: string): PluginRegistry | undefined {
-  return pluginLoaderCacheState.get(cacheKey);
+  const registry = pluginLoaderCacheState.get(cacheKey);
+  // Both replacement and terminal cleanup retire registrations. Never reactivate
+  // their closed resources from a cache hit; the loader must register fresh ones.
+  return registry && !isPluginRegistryRetired(registry) ? registry : undefined;
 }
 
 /** Registry reuse is off for explicit opt-outs and for raw env-substituted config loads. */

--- a/src/plugins/loader-cache.ts
+++ b/src/plugins/loader-cache.ts
@@ -1,3 +1,4 @@
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { PluginLoaderCacheState } from "./loader-cache-state.js";
 import { resolvePluginLoadCacheContext } from "./loader-load-context.js";
 import type { PluginLoadOptions } from "./loader-types.js";
@@ -6,8 +7,12 @@ import type { PluginRegistry } from "./registry-types.js";
 
 const MAX_PLUGIN_REGISTRY_CACHE_ENTRIES = 128;
 
-export const pluginLoaderCacheState = new PluginLoaderCacheState<PluginRegistry>(
-  MAX_PLUGIN_REGISTRY_CACHE_ENTRIES,
+export const pluginLoaderCacheState = resolveGlobalSingleton(
+  Symbol.for("openclaw.plugins.loader-cache-state"),
+  () => new PluginLoaderCacheState<PluginRegistry>(MAX_PLUGIN_REGISTRY_CACHE_ENTRIES),
+  // Runtime retirement closes registrations even when the load options stay unchanged.
+  (cache) => cache.clearCachedRegistries(),
+  "plugin-registry",
 );
 
 export function setCachedPluginRegistry(cacheKey: string, registry: PluginRegistry): void {

--- a/src/plugins/loader.registration.test-utils.ts
+++ b/src/plugins/loader.registration.test-utils.ts
@@ -1051,7 +1051,7 @@ describe("loadOpenClawPlugins", () => {
     expect(getDetachedTaskLifecycleRuntimeRegistration()).toBeUndefined();
   });
 
-  it("restores cached detached task runtime registrations on cache hits", () => {
+  it("restores detached task runtime registrations after registry replacement", () => {
     useNoBundledPlugins();
     const plugin = writePlugin({
       id: "cached-detached-runtime",
@@ -1096,7 +1096,7 @@ describe("loadOpenClawPlugins", () => {
     expect(getDetachedTaskLifecycleRuntimeRegistration()?.pluginId).toBe("cached-detached-runtime");
   });
 
-  it("restores cached legacy internal hook registrations on cache hits", async () => {
+  it("restores legacy internal hook registrations after registry replacement", async () => {
     useNoBundledPlugins();
     const plugin = writePlugin({
       id: "cached-legacy-hook",
@@ -1139,7 +1139,7 @@ describe("loadOpenClawPlugins", () => {
     expect(cachedEvent.messages).toEqual(["cached-hook-fired"]);
   });
 
-  it("restores cached command and interactive handler registrations on cache hits", () => {
+  it("preserves commands and interactive handlers across cache hits and registry replacement", () => {
     useNoBundledPlugins();
     const plugin = writePlugin({
       id: "cached-command-interactive",
@@ -1228,7 +1228,7 @@ describe("loadOpenClawPlugins", () => {
     expect(getDetachedTaskLifecycleRuntimeRegistration()).toBeUndefined();
   });
 
-  it("restores cached memory capability public artifacts on cache hits", async () => {
+  it("restores memory capability public artifacts with a fresh registry after replacement", async () => {
     useNoBundledPlugins();
     const workspaceDir = makePluginLoaderTempDir();
     const absolutePath = path.join(workspaceDir, "MEMORY.md");
@@ -1289,7 +1289,9 @@ describe("loadOpenClawPlugins", () => {
     setActivePluginRegistry(createEmptyPluginRegistry());
 
     const second = loadOpenClawPlugins(options);
-    expect(second).toBe(first);
+    // Scalar comparisons avoid materializing the registry's lazy runtime in failure output.
+    expect(second === first).toBe(false);
+    expect(loadOpenClawPlugins(options) === second).toBe(true);
     await expect(listActiveMemoryPublicArtifacts({ cfg: {} as never })).resolves.toEqual(
       expectedArtifacts,
     );

--- a/src/plugins/loader.runtime-registry.test.ts
+++ b/src/plugins/loader.runtime-registry.test.ts
@@ -36,6 +36,7 @@ import {
   clearActivePluginRegistry,
   getActivePluginRegistry,
   setActivePluginRegistry,
+  stageActivePluginRegistry,
 } from "./runtime.js";
 import type { PluginRuntime } from "./runtime/types.js";
 
@@ -94,7 +95,8 @@ describe("cached plugin load failures", () => {
     );
 
     const active = createEmptyPluginRegistry();
-    setActivePluginRegistry(active, "existing-registry");
+    // Staging preserves the cached generation until a successor commits its retirement.
+    stageActivePluginRegistry(active, "existing-registry", "default");
 
     expect(() => load({ ...options, throwOnLoadError: true })).toThrow(
       "cached registration failed",
@@ -398,55 +400,73 @@ describe("resolveRuntimePluginRegistry", () => {
 });
 
 describe("clearPluginRegistryLoadCache", () => {
-  it("rebuilds plugin registrations after runtime retirement with unchanged load options", async () => {
-    useNoBundledPlugins();
-    const plugin = writePlugin({
-      id: "retirement-probe",
-      body: `module.exports = {
+  it.each(["clear", "replacement"])(
+    "rebuilds plugin registrations after runtime %s with unchanged load options",
+    async (retirement) => {
+      useNoBundledPlugins();
+      const plugin = writePlugin({
         id: "retirement-probe",
-        register(api) {
-          let closed = false;
-          api.registerRuntimeLifecycle({ id: "close", cleanup() { closed = true; } });
-          api.registerTool({
-            name: "retirement_probe", description: "Read fixture lifetime",
-            parameters: { type: "object", properties: {} },
-            execute() { return { content: [{ type: "text", text: closed ? "closed" : "live" }] }; },
-          });
+        body: `module.exports = {
+          id: "retirement-probe",
+          register(api) {
+            let closed = false;
+            api.registerRuntimeLifecycle({ id: "close", cleanup() { closed = true; } });
+            api.registerTool({
+              name: "retirement_probe", description: "Read fixture lifetime",
+              parameters: { type: "object", properties: {} },
+              execute() { return { content: [{ type: "text", text: closed ? "closed" : "live" }] }; },
+            });
+          },
+        };`,
+      });
+      writeFileSync(
+        path.join(plugin.dir, "openclaw.plugin.json"),
+        JSON.stringify({
+          id: plugin.id,
+          configSchema: { type: "object", additionalProperties: false, properties: {} },
+          contracts: { tools: ["retirement_probe"] },
+        }),
+      );
+      const options = {
+        config: {
+          plugins: {
+            allow: [plugin.id],
+            load: { paths: [plugin.file] },
+            slots: { memory: "none" },
+          },
         },
-      };`,
-    });
-    writeFileSync(
-      path.join(plugin.dir, "openclaw.plugin.json"),
-      JSON.stringify({
-        id: plugin.id,
-        configSchema: { type: "object", additionalProperties: false, properties: {} },
-        contracts: { tools: ["retirement_probe"] },
-      }),
-    );
-    const options = {
-      config: {
-        plugins: { allow: [plugin.id], load: { paths: [plugin.file] }, slots: { memory: "none" } },
-      },
-    };
-    const read = async (registry: ReturnType<typeof loadOpenClawPlugins>) => {
-      const tool = registry.tools[0]!.factory({ config: options.config });
-      if (!tool || Array.isArray(tool)) {
-        throw new Error("expected one lifetime probe tool");
+      };
+      const read = async (registry: ReturnType<typeof loadOpenClawPlugins>) => {
+        const tool = registry.tools[0]!.factory({ config: options.config });
+        if (!tool || Array.isArray(tool)) {
+          throw new Error("expected one lifetime probe tool");
+        }
+        return await tool.execute("probe", {});
+      };
+      const original = loadOpenClawPlugins(options);
+      expect(loadOpenClawPlugins(options)).toBe(original);
+      expect(await read(original)).toMatchObject({ content: [{ text: "live" }] });
+
+      if (retirement === "clear") {
+        await clearActivePluginRegistry();
+      } else {
+        const replacementOptions = { ...options, workspaceDir: makePluginLoaderTempDir() };
+        const replacement = loadOpenClawPlugins(replacementOptions);
+        expect(replacement).not.toBe(original);
+        expect(await read(replacement)).toMatchObject({ content: [{ text: "live" }] });
+        await vi.waitFor(async () => {
+          expect(await read(original)).toMatchObject({ content: [{ text: "closed" }] });
+        });
+        expect(loadOpenClawPlugins(replacementOptions)).toBe(replacement);
       }
-      return await tool.execute("probe", {});
-    };
-    const original = loadOpenClawPlugins(options);
-    expect(loadOpenClawPlugins(options)).toBe(original);
-    expect(await read(original)).toMatchObject({ content: [{ text: "live" }] });
 
-    await clearActivePluginRegistry();
-
-    expect(await read(original)).toMatchObject({ content: [{ text: "closed" }] });
-    const reloaded = loadOpenClawPlugins(options);
-    expect(await read(reloaded)).toMatchObject({ content: [{ text: "live" }] });
-    expect(reloaded).not.toBe(original);
-    expect(loadOpenClawPlugins(options)).toBe(reloaded);
-  });
+      expect(await read(original)).toMatchObject({ content: [{ text: "closed" }] });
+      const reloaded = loadOpenClawPlugins(options);
+      expect(await read(reloaded)).toMatchObject({ content: [{ text: "live" }] });
+      expect(reloaded).not.toBe(original);
+      expect(loadOpenClawPlugins(options)).toBe(reloaded);
+    },
+  );
 
   it("preserves plugin-owned runtime registries while invalidating load snapshots", () => {
     registerEmbeddingProvider({

--- a/src/plugins/loader.runtime-registry.test.ts
+++ b/src/plugins/loader.runtime-registry.test.ts
@@ -429,8 +429,10 @@ describe("clearPluginRegistryLoadCache", () => {
       },
     };
     const read = async (registry: ReturnType<typeof loadOpenClawPlugins>) => {
-      const tool = await registry.tools[0]!.factory({ config: options.config });
-      if (!tool || Array.isArray(tool)) throw new Error("expected one lifetime probe tool");
+      const tool = registry.tools[0]!.factory({ config: options.config });
+      if (!tool || Array.isArray(tool)) {
+        throw new Error("expected one lifetime probe tool");
+      }
       return await tool.execute("probe", {});
     };
     const original = loadOpenClawPlugins(options);

--- a/src/plugins/loader.runtime-registry.test.ts
+++ b/src/plugins/loader.runtime-registry.test.ts
@@ -1,4 +1,6 @@
 // Verifies plugin loader runtime registry behavior.
+import { writeFileSync } from "node:fs";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createPluginMetadataSnapshot } from "../config/plugin-auto-enable.test-helpers.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -30,7 +32,11 @@ import {
 import { buildMemoryPromptSection, registerMemoryCapability } from "./memory-state.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 import { createEmptyPluginRegistry } from "./registry.js";
-import { getActivePluginRegistry, setActivePluginRegistry } from "./runtime.js";
+import {
+  clearActivePluginRegistry,
+  getActivePluginRegistry,
+  setActivePluginRegistry,
+} from "./runtime.js";
 import type { PluginRuntime } from "./runtime/types.js";
 
 afterEach(() => {
@@ -392,6 +398,54 @@ describe("resolveRuntimePluginRegistry", () => {
 });
 
 describe("clearPluginRegistryLoadCache", () => {
+  it("rebuilds plugin registrations after runtime retirement with unchanged load options", async () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "retirement-probe",
+      body: `module.exports = {
+        id: "retirement-probe",
+        register(api) {
+          let closed = false;
+          api.registerRuntimeLifecycle({ id: "close", cleanup() { closed = true; } });
+          api.registerTool({
+            name: "retirement_probe", description: "Read fixture lifetime",
+            parameters: { type: "object", properties: {} },
+            execute() { return { content: [{ type: "text", text: closed ? "closed" : "live" }] }; },
+          });
+        },
+      };`,
+    });
+    writeFileSync(
+      path.join(plugin.dir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id: plugin.id,
+        configSchema: { type: "object", additionalProperties: false, properties: {} },
+        contracts: { tools: ["retirement_probe"] },
+      }),
+    );
+    const options = {
+      config: {
+        plugins: { allow: [plugin.id], load: { paths: [plugin.file] }, slots: { memory: "none" } },
+      },
+    };
+    const read = async (registry: ReturnType<typeof loadOpenClawPlugins>) => {
+      const tool = await registry.tools[0]!.factory({ config: options.config });
+      if (!tool || Array.isArray(tool)) throw new Error("expected one lifetime probe tool");
+      return await tool.execute("probe", {});
+    };
+    const original = loadOpenClawPlugins(options);
+    expect(loadOpenClawPlugins(options)).toBe(original);
+    expect(await read(original)).toMatchObject({ content: [{ text: "live" }] });
+
+    await clearActivePluginRegistry();
+
+    expect(await read(original)).toMatchObject({ content: [{ text: "closed" }] });
+    const reloaded = loadOpenClawPlugins(options);
+    expect(await read(reloaded)).toMatchObject({ content: [{ text: "live" }] });
+    expect(reloaded).not.toBe(original);
+    expect(loadOpenClawPlugins(options)).toBe(reloaded);
+  });
+
   it("preserves plugin-owned runtime registries while invalidating load snapshots", () => {
     registerEmbeddingProvider({
       id: "still-live",


### PR DESCRIPTION
## What Problem This Solves

Reloading unchanged plugin options could reactivate a registry whose tools had already been closed, after either terminal cleanup or replacement by another registry. Clearing only the process singleton at shutdown missed the A → B → A replacement path.

## Why This Change Was Made

The loader cache now consults the runtime owner's existing retirement fact at its canonical reuse boundary. A retired registry is a cache miss, so the normal loader creates fresh registrations. Both runtime loading and CLI metadata loading already use this boundary. Live-generation reuse, in-flight reentry guards, explicit management refresh and metadata lifetimes stay unchanged.

This replaces the incomplete terminal-only singleton hook. There is no new lifecycle API, consumer-specific workaround, retry, TTL, polling, configuration, persistent state, dependency override or fallback. The latest ClawSweeper replacement-path finding is addressed directly.

## User Impact

After cleanup or replacement, loading the same plugin configuration creates fresh working tools. A healthy active registry still reuses its existing registrations.

## Evidence

The existing real CJS-plugin regression now covers both terminal clear and replacement. It observes actual tool output and cleanup, without mocking the loader: A live → B live → A closed → fresh A live. It also verifies healthy B reuse and same-generation reuse. The replacement case failed before the correction by returning `closed`; both cases now pass. The cached-load-error fixture stages its control registry without prematurely retiring the generation whose strict-error behavior it tests.

A clean Blacksmith run passed all 67 focused owner/sibling tests, formatting, a full build, and a standalone no-Vitest/no-module-mocks CJS-plugin proof. The standalone trace was A live → B live → A closed → A2 live → B closed → A2 closed → A3 live, with fresh replacement/terminal registrations and live-generation reuse asserted. No provider inference or operator Gateway was used. [Build and real plugin proof](https://github.com/openclaw/openclaw/actions/runs/33217425298).

The subsequent changed-file gate in that run failed because the remote environment compared this branch to a newer main snapshot, yielding unrelated assertion-baseline differences. That overall command is not reported green. The separate canonical changed-file gate binds the actual branch base, with unchanged policy and source-tree checks. [Changed-file gate environment](https://github.com/openclaw/openclaw/actions/runs/33217912322). It passed in one uninterrupted invocation (13m6.903s command, exit 0), including all 14 core test type programs, scoped lint, dead exports and remaining guards. The complete tracked-source tree matched before and after. Both proof leases are stopped.

The first hosted full bundled suite on the retirement-aware correction stalled. A clean controlled comparison isolated it to an obsolete memory-artifact test that expected a retired registry to be reused; formatting the failed registry-identity assertion stalled while inspecting lazy runtime objects. Keeping the same expectation but comparing a boolean exposed the failure normally (206 passed, one failed). The existing test now requires a fresh registry after replacement, preserves public-artifact checks, and verifies subsequent healthy-generation reuse. Adjacent test names now describe their actual replacement path. No production, timeout, mocking or guard change was needed.

The updated regression fails against the pre-fix cache owner. The complete canonical bundled suite then passes all 207 tests in its original order on the final candidate. [Clean regression and bundled-suite proof](https://github.com/openclaw/openclaw/actions/runs/33220375306). The same uninterrupted invocation passed the complete changed-file gate (exit 0; 13m17.010s command), including all selected core/test type programs, lint, dead exports and remaining guards. The final tracked-source tree matched before and after; the lease is stopped. New complete-delta isolated review found no actionable P0 issue. Pre-refresh tested tracked-source tree: `91697edf53159f7cf41e3eda2bc22a1cefcc7c55`.

Earlier build/standalone proof tracked-source tree: `63d34f6c87399e6dde7a66ab94272f9e925e1d07`, matched to the complete local candidate. Fresh complete-delta isolated Codex review reported no actionable P0 issue. Earlier terminal-only proofs are retained as history and are not substituted for the new replacement proof. Individual exact-head CI and native landing gates remain required; no full release verification claim. AI-assisted.

Production +5/-1 (net +4); tests +85/-7 (net +78). The four added production lines connect the cache's reuse decision to the existing retirement owner, with the ownership comment retained. The obsolete singleton path is removed. No config, schema, protocol, public API or dependency surface changes.

The subsequent hosted run on `09e855bb27df6becbb3ed6d0887fad3260dda74b` passed the bundled-protocol job but failed the unrelated UI typecheck shard boundary: 724 roots exceeded the unchanged 720 cap in its generated merge with main. [Failed boundary job](https://github.com/openclaw/openclaw/actions/runs/33221242997/job/99015684159). Main already repaired this in #132193 (`249c248285b03eacc1fdcb9153bc47c6c3a2ec20`), whose [exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33220614783).

The branch is refreshed onto that actual CI correction at `ba37156bba7e40a56ac3ef4476ed8460af283c60`. The complete PR patch and all three changed source-file hashes are byte-identical before and after refresh; loader owner/caller/sibling files are unchanged on the new base. This is a justified base integration, with no new repair code or cap increase in this PR. Earlier artifact proof remains identified by its original tree; new exact-head hosted CI is required for this integration. No frozen release candidate or tooling selector was changed.
