### PR TITLE
fix(pr): stop review workflows after failed worktree prerequisites

### DIFF
--- a/scripts/pr-lib/review.sh
+++ b/scripts/pr-lib/review.sh
@@ -99,7 +99,7 @@ review_checkout_pr() {
 
 review_guard() {
   local pr="$1"
-  enter_worktree "$pr" false
+  enter_worktree "$pr" false || return 1
   require_artifact .local/review-mode.env
   require_artifact .local/pr-meta.env
 
@@ -244,13 +244,11 @@ review_validate_artifacts() {
   local pr="$1"
   # Callers use an OR-list to keep pre-mutation failures reversible; Bash disables
   # errexit within that context, so every artifact and exact-head guard must propagate.
-  enter_worktree "$pr" false || return 1
+  review_guard "$pr" || return 1
   require_artifact .local/review.md || return 1
   require_artifact .local/review.json || return 1
-  require_artifact .local/pr-meta.env || return 1
   require_artifact .local/pr-meta.json || return 1
 
-  review_guard "$pr" || return 1
   if [ "${REVIEW_MODE:-}" != "pr" ]; then
     echo "Review artifact validation requires the reviewed PR head, not main-baseline mode."
     return 1
@@ -270,8 +268,7 @@ review_tests() {
     exit 2
   fi
 
-  enter_worktree "$pr" false
-  review_guard "$pr"
+  review_guard "$pr" || return 1
 
   local target
   for target in "$@"; do

--- a/scripts/pr-lib/worktree.sh
+++ b/scripts/pr-lib/worktree.sh
@@ -31,7 +31,8 @@ EOF
 
 ensure_full_pr_worktree_checkout() {
   local sparse_checkout
-  sparse_checkout=$(git config --bool core.sparseCheckout 2>/dev/null || true)
+  # An unset key (exit 1) is normal; other Git failures must not skip materialization.
+  sparse_checkout=$(git config --bool core.sparseCheckout 2>/dev/null) || [ "$?" -eq 1 ] || return 1
   if [ "$sparse_checkout" = "true" ]; then
     # Prepare gates build the whole repository. Inherited sparse settings can
     # omit tracked transitive inputs and turn healthy PRs into false failures.
@@ -215,20 +216,23 @@ checkout_pr_worktree_target() {
 }
 
 enter_worktree() {
+  # OR-list callers disable errexit throughout this function; guard required steps explicitly.
   local pr="$1"
   local reset_to_main="${2:-false}"
   local invoke_cwd
   invoke_cwd="$PWD"
   local root
-  root=$(repo_root)
+  root=$(repo_root) || return 1
 
   if [ "$invoke_cwd" != "$root" ]; then
     echo "Detected non-root invocation cwd=$invoke_cwd, using canonical root $root"
   fi
 
-  cd "$root"
-  ensure_gh_api_auth
-  git -C "$root" fetch origin main
+  cd "$root" || return 1
+  ensure_gh_api_auth || return 1
+  # Fetch can launch helpers and mutate Git state even when it fails; leave validation first.
+  mark_pr_operation_side_effects_started || return 1
+  git -C "$root" fetch origin main || return 1
 
   # Resolve through the parent, never through the leaf: a missing directory has
   # no real path of its own, and resolving a leaf symlink would silently adopt
@@ -241,7 +245,7 @@ enter_worktree() {
   if [ ! -d "$dir" ] || [ -z "$resolved_dir" ] || ! worktree_is_registered "$resolved_dir"; then
     if [ -e "$dir" ] || { [ -n "$resolved_dir" ] && worktree_is_registered "$resolved_dir"; }; then
       echo "Pruning stale worktree registration for .worktrees/pr-$pr"
-      git -C "$root" worktree prune
+      git -C "$root" worktree prune || return 1
       remove_worktree_if_present "$dir"
       [ ! -e "$dir" ] || {
         echo "Refusing scripts/pr operation for PR #$pr: $dir is not a registered worktree and could not be cleared; scripts/pr refuses to mutate the shared canonical checkout." >&2
@@ -249,11 +253,11 @@ enter_worktree() {
       }
     fi
     # Per-PR locking makes resetting this script-owned branch namespace safe.
-    git -C "$root" worktree add "$dir" -B "temp/pr-$pr" origin/main
-    resolved_dir="$(resolve_existing_dir_path "$(dirname "$dir")")/pr-$pr"
+    git -C "$root" worktree add "$dir" -B "temp/pr-$pr" origin/main || return 1
+    resolved_dir="$(resolve_existing_dir_path "$(dirname "$dir")")/pr-$pr" || return 1
   fi
 
-  cd "$resolved_dir"
+  cd "$resolved_dir" || return 1
 
   # Containment, not repair: every mutation below runs against ambient cwd, so
   # prove Git resolves it to this worktree before any branch moves. A directory
@@ -266,9 +270,10 @@ enter_worktree() {
     return 1
   fi
 
+  # Fetch before replaying a journal or changing the tracked tree.
+  git fetch origin main || return 1
   recover_review_transition "$pr" || return 1
-  ensure_full_pr_worktree_checkout
-  git fetch origin main
+  ensure_full_pr_worktree_checkout || return 1
   if [ "$reset_to_main" = "true" ]; then
     checkout_pr_worktree_target "$pr" origin/main "temp/pr-$pr" || return 1
   fi

--- a/test/scripts/pr-operation-lock.test.ts
+++ b/test/scripts/pr-operation-lock.test.ts
@@ -6,6 +6,7 @@ import {
   type ChildProcess,
   type SpawnOptions,
 } from "node:child_process";
+import { once } from "node:events";
 import {
   chmodSync,
   cpSync,
@@ -25,6 +26,7 @@ import { pathToFileURL } from "node:url";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+import { validReview, writeReviewArtifacts } from "./pr-review-artifact-fixture.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const escapedPipeHolderPidFiles = new Set<string>();
@@ -81,14 +83,36 @@ function spawnDetached(command: string, args: readonly string[], options: SpawnO
   return child;
 }
 
+function createPrFixtureEnv(homeDir: string, path: string): NodeJS.ProcessEnv {
+  return {
+    HOME: homeDir,
+    XDG_CONFIG_HOME: join(homeDir, "config"),
+    TMPDIR: homeDir,
+    PATH: path,
+    LC_ALL: "C",
+    TZ: "UTC0",
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_ALLOW_PROTOCOL: "file",
+    GIT_TERMINAL_PROMPT: "0",
+    GIT_CONFIG_COUNT: "2",
+    GIT_CONFIG_KEY_0: "core.hooksPath",
+    GIT_CONFIG_VALUE_0: "/dev/null",
+    GIT_CONFIG_KEY_1: "commit.gpgSign",
+    GIT_CONFIG_VALUE_1: "false",
+  };
+}
+
 function createTemplateRepo() {
   const dir = mkdtempSync(join(tmpdir(), "openclaw-pr-operation-lock-template-"));
-  execFileSync("git", ["init", "-q", "-b", "main"], { cwd: dir });
-  execFileSync("git", ["config", "user.name", "OpenClaw Test"], { cwd: dir });
-  execFileSync("git", ["config", "user.email", "test@openclaw.invalid"], { cwd: dir });
+  // This shared template must not inherit the operator's Git hooks or identity.
+  const options = { cwd: dir, env: createPrFixtureEnv(dir, process.env.PATH ?? "") };
+  execFileSync("git", ["init", "-q", "-b", "main"], options);
+  execFileSync("git", ["config", "user.name", "OpenClaw Test"], options);
+  execFileSync("git", ["config", "user.email", "test@openclaw.invalid"], options);
   writeFileSync(join(dir, "base.txt"), "base\n");
-  execFileSync("git", ["add", "base.txt"], { cwd: dir });
-  execFileSync("git", ["commit", "-qm", "base"], { cwd: dir });
+  execFileSync("git", ["add", "base.txt"], options);
+  execFileSync("git", ["commit", "-qm", "base"], options);
   return dir;
 }
 
@@ -202,7 +226,7 @@ function writeEscapedPipeHolderLauncher(repoDir: string, pidFile: string) {
   ]);
 }
 
-function installPrCliFixture(repoDir: string) {
+function installPrCliFixture(repoDir: string, env?: NodeJS.ProcessEnv) {
   const files = [
     "scripts/pr",
     "scripts/watch-pr-ci.mjs",
@@ -212,6 +236,7 @@ function installPrCliFixture(repoDir: string) {
     "scripts/lib/plain-gh.sh",
     "scripts/lib/plain-gh.mjs",
     "scripts/lib/direct-run.mjs",
+    "scripts/lib/record-shared.mjs",
     "scripts/lib/tsx-cli-shim.mjs",
     "scripts/lib/local-check-runtime.mts",
     "scripts/tsx.mjs",
@@ -245,7 +270,7 @@ function installPrCliFixture(repoDir: string) {
   const binDir = join(repoDir, "isolated-bin");
   mkdirSync(binDir);
   for (const command of ["bash", "basename", "dirname", "git"]) {
-    const resolved = execFileSync("which", [command], { encoding: "utf8" }).trim();
+    const resolved = execFileSync("which", [command], { encoding: "utf8", env }).trim();
     symlinkSync(resolved, join(binDir, command));
   }
   return { binDir, cli };
@@ -563,14 +588,15 @@ async function cleanupRecordedProcessGroup(path: string, pgid?: number) {
   }
 }
 
-function readOperationProcessGroup(repoDir: string) {
-  if (!refExists(repoDir)) {
+function readOperationProcessGroup(repoDir: string, env?: NodeJS.ProcessEnv) {
+  if (!refExists(repoDir, lockRef, env)) {
     return undefined;
   }
   try {
-    const payload = execFileSync("git", ["cat-file", "blob", refOid(repoDir)], {
+    const payload = execFileSync("git", ["cat-file", "blob", refOid(repoDir, lockRef, env)], {
       cwd: repoDir,
       encoding: "utf8",
+      env,
     });
     const pgid = Number(/^version=3\nstate=active\npgid=([1-9][0-9]*)\n/u.exec(payload)?.[1]);
     return validProcessId(pgid) ? pgid : undefined;
@@ -583,28 +609,30 @@ async function cleanupController(
   repoDir: string,
   controller: ChildProcess,
   operationPgidFile?: string,
+  env?: NodeJS.ProcessEnv,
 ) {
   let pgid = operationPgidFile ? readProcessIdFile(operationPgidFile) : undefined;
-  pgid ??= readOperationProcessGroup(repoDir);
+  pgid ??= readOperationProcessGroup(repoDir, env);
   if (pgid) {
     await cleanupProcessGroup(pgid);
   }
   await cleanupChildren(controller);
   pgid = operationPgidFile ? readProcessIdFile(operationPgidFile) : undefined;
-  pgid ??= readOperationProcessGroup(repoDir);
+  pgid ??= readOperationProcessGroup(repoDir, env);
   if (pgid) {
     await cleanupProcessGroup(pgid);
   }
 }
 
-function refOid(repoDir: string, ref = lockRef) {
-  return execFileSync("git", ["rev-parse", ref], { cwd: repoDir, encoding: "utf8" }).trim();
+function refOid(repoDir: string, ref = lockRef, env?: NodeJS.ProcessEnv) {
+  return execFileSync("git", ["rev-parse", ref], { cwd: repoDir, encoding: "utf8", env }).trim();
 }
 
-function refExists(repoDir: string, ref = lockRef) {
+function refExists(repoDir: string, ref = lockRef, env?: NodeJS.ProcessEnv) {
   return (
     spawnSync("git", ["show-ref", "--verify", "--quiet", ref], {
       cwd: repoDir,
+      env,
     }).status === 0
   );
 }
@@ -689,6 +717,367 @@ describe("scripts/pr process-group platform guard", () => {
 
 const describePosix = process.platform === "win32" ? describe.skip : describe;
 describePosix("scripts/pr per-PR operation lock", () => {
+  it.each([
+    ...(["healthy", "first", "second"] as const).flatMap((failure) =>
+      [false, true].map((existing) => ({ command: "review-init" as const, failure, existing })),
+    ),
+    ...(["review-validate-artifacts", "review-guard", "review-tests"] as const).flatMap((command) =>
+      (["healthy", "first", "second", "auth"] as const).map((failure) => ({
+        command,
+        failure,
+        existing: true,
+      })),
+    ),
+  ])(
+    "$command requires fresh main before replacing PR artifacts ($failure, existing=$existing)",
+    async ({ command, failure, existing }) => {
+      const repoDir = createRepo();
+      const stateDir = join(repoDir, "fixture-state");
+      const homeDir = join(stateDir, "home");
+      const tmpDir = join(stateDir, "tmp");
+      mkdirSync(homeDir, { recursive: true });
+      mkdirSync(tmpDir, { recursive: true });
+      const setupEnv = createPrFixtureEnv(homeDir, process.env.PATH ?? "");
+      const { binDir, cli } = installPrCliFixture(repoDir, setupEnv);
+      const realGit = realpathSync(join(binDir, "git"));
+      // Only these real tools are reachable. rg/pnpm are required by the CLI
+      // preflight; these cases must stop before invoking either of them.
+      for (const command of [
+        "awk",
+        "cat",
+        "date",
+        "env",
+        "jq",
+        "mkdir",
+        "mktemp",
+        "mv",
+        "ps",
+        "rm",
+        "seq",
+        "sh",
+        "sleep",
+      ]) {
+        symlinkSync(
+          execFileSync("which", [command], { encoding: "utf8", env: setupEnv }).trim(),
+          join(binDir, command),
+        );
+      }
+      symlinkSync(process.execPath, join(binDir, "node"));
+      for (const command of ["rg", "pnpm"]) {
+        const stub = writeFixtureFile(binDir, command, [
+          "#!/bin/sh",
+          "echo 'unexpected command in review-init fixture' >&2",
+          "exit 99",
+        ]);
+        chmodSync(stub, 0o755);
+      }
+      const env: NodeJS.ProcessEnv = {
+        ...createPrFixtureEnv(homeDir, binDir),
+        TMPDIR: tmpDir,
+      };
+      const git = (...args: string[]) =>
+        execFileSync(realGit, args, { cwd: repoDir, env, encoding: "utf8", timeout: 5000 }).trim();
+      writeFileSync(
+        join(repoDir, ".git/info/exclude"),
+        "/.local/\n/.worktrees/\n/isolated-bin/\n/fixture-state/\n",
+      );
+      git("add", "scripts", ".github");
+      git("commit", "-qm", "test: unmodified public PR wrapper fixture");
+      const cachedMain = git("rev-parse", "HEAD");
+      const canonicalTree = git("rev-parse", "HEAD^{tree}");
+      const newCommit = (message: string) =>
+        execFileSync(realGit, ["commit-tree", canonicalTree, "-p", cachedMain], {
+          cwd: repoDir,
+          env,
+          input: message,
+          encoding: "utf8",
+          timeout: 5000,
+        }).trim();
+      const remoteMain = newCommit("new main\n");
+      const pullHead = newCommit("available PR\n");
+      const originDir = tempDirs.make("openclaw-pr-fetch-origin-");
+      git("clone", "--bare", "--no-local", pathToFileURL(repoDir).href, originDir);
+      git("remote", "add", "origin", pathToFileURL(originDir).href);
+      git("fetch", "origin", "main");
+      git(
+        "push",
+        "origin",
+        `${remoteMain}:refs/heads/main`,
+        `${remoteMain}:refs/heads/saved-main`,
+        `${pullHead}:refs/pull/42/head`,
+      );
+      // Pushing also updates tracking refs; restore the deliberately stale cache
+      // that a previous successful main fetch left before this invocation.
+      git("update-ref", "refs/remotes/origin/main", cachedMain);
+      git("update-ref", "refs/heads/pr-42", cachedMain);
+      expect(git("rev-parse", "refs/remotes/origin/main")).toBe(cachedMain);
+      expect(git("ls-remote", "origin", "refs/pull/42/head")).toBe(
+        `${pullHead}\trefs/pull/42/head`,
+      );
+      const worktreeDir = join(repoDir, ".worktrees/pr-42");
+      const localDir = join(worktreeDir, ".local");
+      const artifactNames = [
+        "pr-meta.json",
+        "pr-meta.env",
+        "review-context.env",
+        "review-mode.env",
+        "review.md",
+        "review.json",
+      ];
+      if (existing) {
+        git("worktree", "add", "-q", "-b", "temp/pr-42", worktreeDir, pullHead);
+        mkdirSync(localDir);
+        for (const artifact of artifactNames) {
+          writeFileSync(join(localDir, artifact), `prior ${artifact}\n`);
+        }
+      }
+      if (command !== "review-init") {
+        writeReviewArtifacts(worktreeDir, validReview(pullHead), { headSha: pullHead });
+      }
+      const priorArtifacts =
+        command === "review-init"
+          ? []
+          : artifactNames.map(
+              (name) => [name, readFileSync(join(localDir, name), "utf8")] as const,
+            );
+      const metadataPath = join(stateDir, "metadata.json");
+      writeFileSync(
+        metadataPath,
+        JSON.stringify({
+          number: 42,
+          title: "Fixture",
+          url: "https://example.invalid/pull/42",
+          state: "OPEN",
+          isDraft: false,
+          author: { login: "fixture-author" },
+          baseRefName: "main",
+          headRefName: "fixture-pr",
+          headRefOid: pullHead,
+          headRepository: {
+            name: "fixture",
+            nameWithOwner: "fixture/fixture",
+            url: "https://example.invalid/fixture",
+          },
+          headRepositoryOwner: { login: "fixture" },
+          body: "",
+          labels: [],
+          assignees: [],
+          changedFiles: 0,
+          additions: 0,
+          deletions: 0,
+          statusCheckRollup: [],
+          files: [],
+        }),
+      );
+      const gh = writeFixtureFile(binDir, "gh", [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        'case "$*" in',
+        '  "auth token") exit 1 ;;',
+        '  "api graphql -f query=query { viewer { login } } --jq .data.viewer.login")',
+        '    [ "$OPENCLAW_TEST_AUTH_FAILURE" != 1 ] || exit 1',
+        '    printf "fixture-user\\n" ;;',
+        '  "pr view 42 --json headRefOid"|"pr view 42 --json number,title,state,isDraft,author,baseRefName,headRefName,headRefOid,headRepository,headRepositoryOwner,url,body,labels,assignees,changedFiles,additions,deletions,statusCheckRollup,files")',
+        '    cat "$OPENCLAW_TEST_PR_METADATA" ;;',
+        '  *) echo "unexpected fixture gh request" >&2; exit 99 ;;',
+        "esac",
+      ]);
+      chmodSync(gh, 0o755);
+      const eventsPath = join(stateDir, "events");
+      const firstMainPath = join(stateDir, "first-main");
+      writeFileSync(eventsPath, "");
+      // The proxy delegates every Git operation and exit status unchanged.
+      // Armed failures remove only the owned remote ref after a successful real
+      // fetch, preserving the completed prefix's legitimate effects.
+      unlinkSync(join(binDir, "git"));
+      const gitProxy = writeFixtureFile(binDir, "git", [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        'original=("$@")',
+        'if [ "${1-}" = -C ]; then shift 2; fi',
+        'if [ "${1-}" = fetch ]; then',
+        '  result=0; "$OPENCLAW_TEST_REAL_GIT" "${original[@]}" || result=$?',
+        '  printf "fetch:%s:%s\\n" "${3-}" "$result" >> "$OPENCLAW_TEST_EVENTS"',
+        '  if [ "${3-}" = main ] && [ "$result" -eq 0 ] && [ "$OPENCLAW_TEST_FAILURE" = second ] && [ ! -e "$OPENCLAW_TEST_FIRST_MAIN" ]; then',
+        '    "$OPENCLAW_TEST_REAL_GIT" -C "$OPENCLAW_TEST_REPO" rev-parse refs/remotes/origin/main > "$OPENCLAW_TEST_FIRST_MAIN"',
+        '    "$OPENCLAW_TEST_REAL_GIT" --git-dir="$OPENCLAW_TEST_ORIGIN" update-ref -d refs/heads/main',
+        "  fi",
+        '  exit "$result"',
+        "fi",
+        'case "${1-} ${2-}" in',
+        '  "worktree add"|"checkout "*|"restore "*) printf "mutation:%s\\n" "$1" >> "$OPENCLAW_TEST_EVENTS" ;;',
+        "esac",
+        'exec "$OPENCLAW_TEST_REAL_GIT" "${original[@]}"',
+      ]);
+      chmodSync(gitProxy, 0o755);
+      if (failure === "first") {
+        git(`--git-dir=${originDir}`, "update-ref", "-d", "refs/heads/main");
+      }
+      const childEnv: NodeJS.ProcessEnv = {
+        ...env,
+        OPENCLAW_GH_BIN: gh,
+        OPENCLAW_TEST_PR_METADATA: metadataPath,
+        OPENCLAW_TEST_REAL_GIT: realGit,
+        OPENCLAW_TEST_REPO: repoDir,
+        OPENCLAW_TEST_ORIGIN: originDir,
+        OPENCLAW_TEST_EVENTS: eventsPath,
+        OPENCLAW_TEST_FIRST_MAIN: firstMainPath,
+        OPENCLAW_TEST_FAILURE: failure,
+        OPENCLAW_TEST_AUTH_FAILURE: failure === "auth" ? "1" : "0",
+      };
+      const controller = spawn(
+        cli,
+        [command, "42", ...(command === "review-tests" ? ["missing-fixture.test.ts"] : [])],
+        {
+          cwd: repoDir,
+          env: childEnv,
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
+      let output = "";
+      controller.stdout!.setEncoding("utf8");
+      controller.stderr!.setEncoding("utf8");
+      controller.stdout!.on("data", (chunk) => (output += chunk));
+      controller.stderr!.on("data", (chunk) => (output += chunk));
+      try {
+        await once(controller, "close", { signal: AbortSignal.timeout(20_000) });
+        const events = readFileSync(eventsPath, "utf8").trim().split("\n");
+        expect(git("ls-remote", "origin", "refs/pull/42/head"), output).toBe(
+          `${pullHead}\trefs/pull/42/head`,
+        );
+        expect.soft(controller.signalCode, output).toBeNull();
+        expect.soft(git("rev-parse", "HEAD")).toBe(cachedMain);
+        expect.soft(git("branch", "--show-current")).toBe("main");
+        expect.soft(git("write-tree")).toBe(canonicalTree);
+        expect.soft(git("diff", "--exit-code")).toBe("");
+        if (command !== "review-init") {
+          const fetches = events.filter((event) => event.startsWith("fetch:"));
+          expect
+            .soft(
+              events.filter((event) => event.startsWith("mutation:")),
+              output,
+            )
+            .toEqual([]);
+          expect.soft(git("-C", worktreeDir, "rev-parse", "HEAD")).toBe(pullHead);
+          expect.soft(git("-C", worktreeDir, "branch", "--show-current")).toBe("temp/pr-42");
+          expect.soft(git("rev-parse", "refs/heads/pr-42")).toBe(cachedMain);
+          for (const [name, contents] of priorArtifacts) {
+            expect.soft(readFileSync(join(localDir, name), "utf8"), name).toBe(contents);
+          }
+          // Authentication fails before fetch can launch helpers or mutate Git.
+          // Once fetching starts, later failure retains the native exact-owner lock.
+          const retained =
+            failure === "first" ||
+            failure === "second" ||
+            (command === "review-tests" && failure === "healthy");
+          expect.soft(refExists(repoDir, lockRef, childEnv), output).toBe(retained);
+          if (retained && refExists(repoDir, lockRef, childEnv)) {
+            expect(output).toContain(
+              `scripts/pr lock-recover 42 ${refOid(repoDir, lockRef, childEnv)} --confirmed-no-running-tools`,
+            );
+          }
+          if (failure !== "healthy") {
+            expect.soft(controller.exitCode, output).toBe(1);
+            expect.soft(output).not.toContain("review guard passed");
+            expect.soft(output).not.toContain("review artifacts validated");
+            expect.soft(output).not.toContain("review summary:");
+            expect.soft(output).not.toContain("Missing test target file:");
+            if (failure === "auth") {
+              expect.soft(fetches, output).toEqual([]);
+              expect.soft(output).toContain("GitHub CLI auth is not usable");
+            } else {
+              expect
+                .soft(fetches, output)
+                .toEqual(
+                  failure === "first" ? ["fetch:main:128"] : ["fetch:main:0", "fetch:main:128"],
+                );
+              expect.soft(output).toContain("couldn't find remote ref main");
+              const failedFetch = events.indexOf("fetch:main:128");
+              expect.soft(events.slice(failedFetch + 1), output).toEqual([]);
+            }
+            return;
+          }
+          // Exactly one initializer: a missed fault with four successful fetches
+          // is not accepted as the intentional two-fetch canonical path.
+          expect.soft(fetches, output).toEqual(["fetch:main:0", "fetch:main:0"]);
+          expect.soft(git("rev-parse", "refs/remotes/origin/main")).toBe(remoteMain);
+          expect.soft(output).toContain("review guard passed");
+          if (command === "review-tests") {
+            expect.soft(controller.exitCode, output).toBe(1);
+            expect.soft(output).toContain("Missing test target file: missing-fixture.test.ts");
+            expect.soft(output).not.toContain("unexpected command in review-init fixture");
+          } else {
+            expect.soft(controller.exitCode, output).toBe(0);
+            if (command === "review-validate-artifacts") {
+              expect.soft(output).toContain("review artifacts validated");
+              expect.soft(output).toContain("review summary:");
+            }
+          }
+          return;
+        }
+        if (failure === "healthy") {
+          expect(controller.exitCode, output).toBe(0);
+          expect(git("-C", worktreeDir, "rev-parse", "HEAD")).toBe(remoteMain);
+          expect(git("rev-parse", "refs/heads/pr-42")).toBe(pullHead);
+          expect(JSON.parse(readFileSync(join(localDir, "pr-meta.json"), "utf8"))).toMatchObject({
+            number: 42,
+            headRefOid: pullHead,
+          });
+          expect(readFileSync(join(localDir, "review-context.env"), "utf8")).toContain(
+            `MERGE_BASE=${cachedMain}`,
+          );
+          expect(readFileSync(join(localDir, "review-mode.env"), "utf8")).toContain(
+            "REVIEW_MODE=main",
+          );
+          expect(events.filter((event) => event.startsWith("fetch:"))).toEqual([
+            "fetch:main:0",
+            "fetch:main:0",
+            "fetch:pull/42/head:pr-42:0",
+          ]);
+          expect(refExists(repoDir, lockRef, childEnv), output).toBe(false);
+          return;
+        }
+        const failedFetch = events.indexOf("fetch:main:128");
+        expect.soft(failedFetch, output).toBeGreaterThanOrEqual(0);
+        expect.soft(events.slice(failedFetch + 1), output).toEqual([]);
+        expect.soft(controller.exitCode, output).toBe(1);
+        expect.soft(output).toContain("couldn't find remote ref main");
+        expect.soft(output).not.toContain("wrote=.local/pr-meta.json");
+        expect.soft(git("rev-parse", "refs/heads/pr-42")).toBe(cachedMain);
+        expect
+          .soft(git("rev-parse", "refs/remotes/origin/main"))
+          .toBe(failure === "first" ? cachedMain : remoteMain);
+        if (failure === "second") {
+          expect.soft(readFileSync(firstMainPath, "utf8").trim()).toBe(remoteMain);
+        }
+        if (existing) {
+          expect.soft(git("-C", worktreeDir, "rev-parse", "HEAD")).toBe(pullHead);
+          expect.soft(git("-C", worktreeDir, "branch", "--show-current")).toBe("temp/pr-42");
+        } else {
+          expect.soft(existsSync(worktreeDir)).toBe(failure === "second");
+          if (failure === "second") {
+            expect.soft(git("-C", worktreeDir, "rev-parse", "HEAD")).toBe(remoteMain);
+          }
+        }
+        for (const artifact of artifactNames) {
+          const path = join(localDir, artifact);
+          expect.soft(existsSync(path), artifact).toBe(existing);
+          if (existing) {
+            expect.soft(readFileSync(path, "utf8"), artifact).toBe(`prior ${artifact}\n`);
+          }
+        }
+        expect.soft(refExists(repoDir, lockRef, childEnv), output).toBe(true);
+        if (refExists(repoDir, lockRef, childEnv)) {
+          expect(output).toContain(
+            `scripts/pr lock-recover 42 ${refOid(repoDir, lockRef, childEnv)} --confirmed-no-running-tools`,
+          );
+        }
+      } finally {
+        await cleanupController(repoDir, controller, undefined, childEnv);
+      }
+    },
+    30_000,
+  );
   it("serializes the same PR and releases the waiter after SIGTERM", async () => {
     const repoDir = createRepo();
     const held = join(repoDir, "held");
@@ -1223,6 +1612,98 @@ describePosix("scripts/pr per-PR operation lock", () => {
       expect(result.stderr).not.toContain("Retaining the operation lock");
     }
   });
+  it.each([
+    ...["enter_worktree", "review_guard", "review_validate_artifacts"].flatMap((invocation) => [
+      { invocation, failure: "auth", code: 1, fetches: 0, retained: false },
+      { invocation, failure: "fetch-1", code: 130, fetches: 1, retained: true },
+      { invocation, failure: "fetch-1", code: 73, fetches: 1, retained: true },
+      { invocation, failure: "fetch-2", code: 143, fetches: 2, retained: true },
+      { invocation, failure: "fetch-2", code: 128, fetches: 2, retained: true },
+      { invocation, failure: "none", code: 0, fetches: 2, retained: false },
+    ]),
+    {
+      invocation: "review_validate_artifacts",
+      failure: "artifact",
+      code: 1,
+      fetches: 2,
+      retained: true,
+    },
+    { invocation: "enter_worktree", failure: "notification", code: 1, fetches: 0, retained: true },
+  ])(
+    "preserves native entry phase ownership for $invocation ($failure, $code)",
+    async ({ invocation, failure, code, fetches, retained }) => {
+      const repoDir = createRepo();
+      const git = (...args: string[]) =>
+        execFileSync("git", args, { cwd: repoDir, encoding: "utf8" }).trim();
+      git("remote", "add", "origin", repoDir);
+      git("checkout", "-qb", "sibling/work");
+      writeFileSync(join(repoDir, "base.txt"), "sibling\n");
+      git("commit", "-qam", "sibling fixture");
+      const head = git("rev-parse", "HEAD");
+      const worktree = join(repoDir, ".worktrees", "pr-42");
+      git("worktree", "add", "-qb", "temp/pr-42", worktree, head);
+      const review = validReview(head);
+      if (failure === "artifact") {
+        review.docs = "invalid";
+      }
+      writeReviewArtifacts(worktree, review, { headSha: head });
+      const traceFile = join(repoDir, "entry-commands.log");
+      const ownerFile = join(repoDir, "entry-owner-oid");
+      const result = await runSupervisedOperation(repoDir, "entry-validation.sh", [
+        `source '${join(repoRoot, "scripts/pr-lib/review.sh")}'`,
+        `script_parent_dir='${join(repoRoot, "scripts")}'`,
+        "acquire_pr_operation_lock 42",
+        `printf '%s\\n' "$PR_OPERATION_LOCK_OWNER_OID" > '${ownerFile}'`,
+        "begin_pr_operation_validation_phase",
+        ...(failure === "notification" ? ["OPENCLAW_PR_LOCK_NOTIFY_FD=invalid"] : []),
+        "fetch_count=0",
+        "gh_plain() {",
+        `  printf 'auth\\n' >> '${traceFile}'`,
+        `  return ${failure === "auth" ? code : 0}`,
+        "}",
+        "git() {",
+        `  printf 'git %s\\n' "$*" >> '${traceFile}'`,
+        '  case "$*" in fetch\\ *|-C\\ *\\ fetch\\ *)',
+        "    fetch_count=$((fetch_count + 1))",
+        `    if [ "fetch-$fetch_count" = '${failure}' ]; then`,
+        `      printf 'failed-fetch\\n' >> '${traceFile}'`,
+        `      return ${code}`,
+        "    fi ;;",
+        "  esac",
+        '  command git "$@"',
+        "}",
+        `${invocation} 42 || exit $?`,
+      ]);
+
+      expect.soft(result.status, `${result.stdout}\n${result.stderr}`).toBe(code === 0 ? 0 : 1);
+      const commands = readFileSync(traceFile, "utf8").trim().split("\n");
+      expect.soft(commands.filter((command) => command === "auth")).toHaveLength(1);
+      expect
+        .soft(commands.filter((command) => command.includes(" fetch origin main")))
+        .toHaveLength(fetches);
+      if (failure.startsWith("fetch-")) {
+        const failedAt = commands.indexOf("failed-fetch");
+        expect(failedAt).toBeGreaterThanOrEqual(0);
+        expect.soft(commands.slice(failedAt + 1)).toEqual([]);
+      }
+      if (invocation === "review_validate_artifacts") {
+        expect.soft(result.stdout.includes("review artifacts validated")).toBe(code === 0);
+      }
+      expect.soft(git("branch", "--show-current")).toBe("sibling/work");
+      expect.soft(git("rev-parse", "HEAD")).toBe(head);
+      expect.soft(git("-C", worktree, "branch", "--show-current")).toBe("temp/pr-42");
+      expect.soft(git("-C", worktree, "rev-parse", "HEAD")).toBe(head);
+      expect.soft(refExists(repoDir)).toBe(retained);
+      if (retained && refExists(repoDir)) {
+        const ownerOid = readFileSync(ownerFile, "utf8").trim();
+        expect(refOid(repoDir)).toBe(ownerOid);
+        expect(result.stderr).toContain(
+          `scripts/pr lock-recover 42 ${ownerOid} --confirmed-no-running-tools`,
+        );
+        recoverOperationLock(repoDir, ownerOid);
+      }
+    },
+  );
   it.each([
     { wrapper: "canonical", command: "merge-run", failure: "none" },
     { wrapper: "linked", command: "merge-run", failure: "none" },

--- a/test/scripts/pr-review-artifact-fixture.ts
+++ b/test/scripts/pr-review-artifact-fixture.ts
@@ -1,0 +1,93 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+export const REVIEWED_PR = 42;
+export const REVIEWED_HEAD = "b".repeat(40);
+
+export function validReview(headSha = REVIEWED_HEAD) {
+  return {
+    pr: { number: REVIEWED_PR, headSha },
+    recommendation: "NEEDS WORK",
+    findings: [] as Array<{
+      id: string;
+      title: string;
+      area: string;
+      fix: string;
+      severity: "BLOCKER" | "IMPORTANT" | "NIT";
+    }>,
+    nitSweep: {
+      performed: true,
+      status: "none",
+      summary: "No optional nits identified.",
+    },
+    behavioralSweep: {
+      performed: true,
+      status: "not_applicable",
+      summary: "No runtime behavior changed.",
+      silentDropRisk: "none",
+      branches: [] as unknown[],
+    },
+    issueValidation: {
+      performed: true,
+      source: "pr_body",
+      status: "unclear",
+      summary: "Review fixture.",
+    },
+    tests: {
+      ran: [],
+      gaps: [],
+      result: "pass",
+    },
+    docs: "not_applicable",
+    changelog: "not_required",
+  };
+}
+
+export type ReviewArtifactFixtureOptions = {
+  files?: string[];
+  markdownIdentityLine?: string;
+  metaEnvPrNumber?: number;
+  mode?: "pr" | "main";
+  headSha?: string;
+};
+
+export function writeReviewArtifacts(
+  fixtureRoot: string,
+  review: ReturnType<typeof validReview>,
+  options: ReviewArtifactFixtureOptions = {},
+) {
+  const headSha = options.headSha ?? REVIEWED_HEAD;
+  const localDir = join(fixtureRoot, ".local");
+  mkdirSync(localDir, { recursive: true });
+  writeFileSync(join(localDir, "review.json"), `${JSON.stringify(review)}\n`);
+  writeFileSync(
+    join(localDir, "review.md"),
+    [
+      options.markdownIdentityLine ?? `Review artifact for PR #${REVIEWED_PR} at ${headSha}`,
+      "A)",
+      "B)",
+      "C)",
+      "D)",
+      "E)",
+      "F)",
+      "G)",
+      "H)",
+      "I)",
+      "J)",
+    ].join("\n"),
+  );
+  writeFileSync(
+    join(localDir, "pr-meta.env"),
+    `PR_URL=https://example.invalid/pr/42\nPR_NUMBER=${options.metaEnvPrNumber ?? REVIEWED_PR}\nPR_HEAD_SHA=${headSha}\n`,
+  );
+  writeFileSync(
+    join(localDir, "pr-meta.json"),
+    `${JSON.stringify({
+      number: REVIEWED_PR,
+      headRefOid: headSha,
+      files: (options.files ?? []).map((path) => ({ path })),
+    })}\n`,
+  );
+
+  writeFileSync(join(localDir, "review-mode.env"), `REVIEW_MODE=${options.mode ?? "pr"}\n`);
+}

--- a/test/scripts/pr-review-artifact-validation.test.ts
+++ b/test/scripts/pr-review-artifact-validation.test.ts
@@ -3,6 +3,13 @@ import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+import {
+  REVIEWED_PR,
+  REVIEWED_HEAD,
+  validReview,
+  writeReviewArtifacts,
+  type ReviewArtifactFixtureOptions,
+} from "./pr-review-artifact-fixture.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const reviewScript = join(process.cwd(), "scripts/pr-lib/review.sh");
@@ -10,8 +17,6 @@ const reviewArtifactsScript = join(process.cwd(), "scripts/pr-lib/review-artifac
 const mergeScript = join(process.cwd(), "scripts/pr-lib/merge.sh");
 const describePosix = process.platform === "win32" ? describe.skip : describe;
 
-const REVIEWED_PR = 42;
-const REVIEWED_HEAD = "b".repeat(40);
 const REVIEWED_IDENTITY_LINE = `Review artifact for PR #${REVIEWED_PR} at ${REVIEWED_HEAD}`;
 const REVIEW_SHELL_COMMAND_SURFACE = [
   "rg() {",
@@ -24,45 +29,6 @@ const REVIEW_SHELL_COMMAND_SURFACE = [
   "}",
 ].join("\n");
 
-function validReview() {
-  return {
-    pr: { number: REVIEWED_PR, headSha: REVIEWED_HEAD },
-    recommendation: "NEEDS WORK",
-    findings: [] as Array<{
-      id: string;
-      title: string;
-      area: string;
-      fix: string;
-      severity: "BLOCKER" | "IMPORTANT" | "NIT";
-    }>,
-    nitSweep: {
-      performed: true,
-      status: "none",
-      summary: "No optional nits identified.",
-    },
-    behavioralSweep: {
-      performed: true,
-      status: "not_applicable",
-      summary: "No runtime behavior changed.",
-      silentDropRisk: "none",
-      branches: [] as unknown[],
-    },
-    issueValidation: {
-      performed: true,
-      source: "pr_body",
-      status: "unclear",
-      summary: "Review fixture.",
-    },
-    tests: {
-      ran: [],
-      gaps: [],
-      result: "pass",
-    },
-    docs: "not_applicable",
-    changelog: "not_required",
-  };
-}
-
 function validReadyReview() {
   const review = validReview();
   review.recommendation = "READY FOR /prepare-pr";
@@ -72,47 +38,13 @@ function validReadyReview() {
 
 function runValidation(
   review: ReturnType<typeof validReview>,
-  options: {
-    files?: string[];
+  options: ReviewArtifactFixtureOptions & {
     guardFailure?: boolean;
-    markdownIdentityLine?: string;
-    metaEnvPrNumber?: number;
-    mode?: "pr" | "main";
     orList?: boolean;
   } = {},
 ) {
   const fixtureRoot = tempDirs.make("openclaw-pr-review-validation-");
-  const localDir = join(fixtureRoot, ".local");
-  mkdirSync(localDir);
-  writeFileSync(join(localDir, "review.json"), `${JSON.stringify(review)}\n`);
-  writeFileSync(
-    join(localDir, "review.md"),
-    [
-      options.markdownIdentityLine ?? REVIEWED_IDENTITY_LINE,
-      "A)",
-      "B)",
-      "C)",
-      "D)",
-      "E)",
-      "F)",
-      "G)",
-      "H)",
-      "I)",
-      "J)",
-    ].join("\n"),
-  );
-  writeFileSync(
-    join(localDir, "pr-meta.env"),
-    `PR_URL=https://example.invalid/pr/42\nPR_NUMBER=${options.metaEnvPrNumber ?? REVIEWED_PR}\nPR_HEAD_SHA=${REVIEWED_HEAD}\n`,
-  );
-  writeFileSync(
-    join(localDir, "pr-meta.json"),
-    `${JSON.stringify({
-      number: REVIEWED_PR,
-      headRefOid: REVIEWED_HEAD,
-      files: (options.files ?? []).map((path) => ({ path })),
-    })}\n`,
-  );
+  writeReviewArtifacts(fixtureRoot, review, options);
 
   return spawnSync(
     "bash",
@@ -128,7 +60,7 @@ function runValidation(
         'rg() { case " $* " in *" -F "*) grep "$@";; *) grep -E "$@";; esac; }',
         options.guardFailure
           ? "review_guard() { REVIEW_MODE=pr; echo 'review head guard failed'; return 1; }"
-          : `review_guard() { REVIEW_MODE=${options.mode ?? "pr"}; }`,
+          : `review_guard() { enter_worktree 42 || return 1; REVIEW_MODE=${options.mode ?? "pr"}; }`,
         "print_review_stdout_summary() { :; }",
         options.orList ? "review_validate_artifacts 42 || exit 1" : "review_validate_artifacts 42",
       ].join("\n"),

--- a/test/scripts/pr-worktree-containment.test.ts
+++ b/test/scripts/pr-worktree-containment.test.ts
@@ -122,8 +122,8 @@ function runShell(fixture: Fixture, commands: string[], env?: NodeJS.ProcessEnv)
         'source "$2"',
         'source "$3"',
         'fixture_root="$4"',
-        'repo_root() { printf "%s\\n" "$fixture_root"; }',
-        "ensure_gh_api_auth() { :; }",
+        'script_parent_dir="$fixture_root"',
+        "gh_plain() { :; }",
         "mark_pr_operation_side_effects_started() { :; }",
         'pr_meta_json() { local head; head=$(git rev-parse refs/pull/42/head); jq -cn --arg head "$head" \'{number:42,title:"fixture",url:"https://example.invalid/42",state:"OPEN",isDraft:false,author:{login:"fixture"},baseRefName:"main",headRefName:"review/pr",headRefOid:$head,headRepository:{nameWithOwner:"fixture/repo",url:""},headRepositoryOwner:{login:"fixture"},additions:1,deletions:0,changedFiles:3}\'; }',
         ...commands,
@@ -143,7 +143,188 @@ function expectCanonicalCheckoutUnchanged(fixture: Fixture) {
   expect(git(fixture.root, "rev-parse", "HEAD")).toBe(fixture.siblingSha);
 }
 
+function traceEntryCommands(failure: string, code = 73) {
+  return [
+    "trace_command() {",
+    '  printf "%s\\n" "$*" >> "$fixture_root/commands.log"',
+    `  if ${failure}; then`,
+    '    printf "FAIL %s\\n" "$*" >> "$fixture_root/commands.log"',
+    '    if [ "$1" = pwd ]; then command "$@"; fi',
+    `    return ${code}`,
+    "  fi",
+    "}",
+    ...["git", "cd", "pwd", "mkdir", "rm", "mv", "trash"].map(
+      (name) => `${name}() { trace_command ${name} "$@" || return $?; command ${name} "$@"; }`,
+    ),
+    'gh_plain() { trace_command gh_plain "$@"; }',
+  ];
+}
+
+function expectEntryStopped(fixture: Fixture, result: ReturnType<typeof runShell>) {
+  const commands = readFileSync(join(fixture.root, "commands.log"), "utf8").trim().split("\n");
+  const failure = commands.findIndex((command) => command.startsWith("FAIL "));
+  expect(failure, commands.join("\n")).toBeGreaterThanOrEqual(0);
+  expect.soft(commands.slice(failure + 1), commands.join("\n")).toEqual([]);
+  expect.soft(result.status, `${result.stdout}\n${result.stderr}`).not.toBe(0);
+  expectCanonicalCheckoutUnchanged(fixture);
+}
+
+function reviewState(worktree: string) {
+  return {
+    head: git(worktree, "rev-parse", "HEAD"),
+    branch: git(worktree, "branch", "--show-current"),
+    index: git(worktree, "write-tree"),
+    status: git(worktree, "status", "--porcelain=v1"),
+    diff: git(worktree, "diff", "HEAD"),
+    journal: existsSync(join(worktree, ".local", "review-transition.json"))
+      ? readFileSync(join(worktree, ".local", "review-transition.json"), "utf8")
+      : null,
+  };
+}
+
 describePosix("scripts/pr worktree containment", () => {
+  for (const caller of ["enter_worktree 42 true || exit $?", "review_init 42"] as const) {
+    it.each([
+      {
+        name: "first fetch interrupted",
+        failure: '[ "$*" = "git -C $fixture_root fetch origin main" ]',
+        code: 130,
+      },
+      {
+        name: "first fetch Git error",
+        failure: '[ "$*" = "git -C $fixture_root fetch origin main" ]',
+        code: 128,
+      },
+      {
+        name: "second fetch interrupted",
+        failure: '[ "$*" = "git fetch origin main" ]',
+        code: 143,
+      },
+      { name: "second fetch Git error", failure: '[ "$*" = "git fetch origin main" ]', code: 73 },
+      { name: "GitHub auth failure", failure: '[ "$1" = gh_plain ]', code: 1 },
+    ])(`stops on $name without replaying a pending transition (${caller})`, ({ failure, code }) => {
+      const fixture = createReviewFixture();
+      const worktree = join(fixture.root, ".worktrees", "pr-42");
+      const setup = runShell(fixture, [
+        "review_init 42",
+        "review_checkout_pr 42",
+        "git checkout -B temp/pr-42",
+        `write_review_transition_journal 42 ${fixture.prASha} ${fixture.mainSha} branch temp/pr-42`,
+        `git restore --source=${fixture.mainSha} --staged --worktree -- transition-a.txt`,
+      ]);
+      expect(setup.status, `${setup.stdout}\n${setup.stderr}`).toBe(0);
+      const before = reviewState(worktree);
+      const result = runShell(fixture, [...traceEntryCommands(failure, code), caller]);
+
+      expectEntryStopped(fixture, result);
+      expect(reviewState(worktree)).toEqual(before);
+      if (failure.includes("gh_plain")) {
+        expect(result.stderr).toContain("GitHub CLI auth is not usable");
+      }
+    });
+  }
+
+  it.each([
+    {
+      name: "first fetch",
+      failure: '[ "$*" = "git -C $fixture_root fetch origin main" ]',
+      provisioned: false,
+    },
+    { name: "second fetch", failure: '[ "$*" = "git fetch origin main" ]', provisioned: true },
+    { name: "auth", failure: '[ "$1" = gh_plain ]', provisioned: false },
+  ])(
+    "stops cold entry on $name failure, retaining only completed provisioning",
+    ({ failure, provisioned }) => {
+      const fixture = createFixture();
+      const worktree = join(fixture.root, ".worktrees", "pr-42");
+      const result = runShell(fixture, [
+        ...traceEntryCommands(failure, 130),
+        "enter_worktree 42 true || exit $?",
+      ]);
+      expectEntryStopped(fixture, result);
+      expect(existsSync(worktree)).toBe(provisioned);
+      expect(existsSync(join(worktree, ".local"))).toBe(false);
+      if (provisioned) {
+        expect(git(worktree, "rev-parse", "HEAD")).toBe(fixture.mainSha);
+        expect(git(worktree, "branch", "--show-current")).toBe("temp/pr-42");
+      }
+    },
+  );
+
+  it.each([
+    {
+      name: "root resolution",
+      failure: '[ "$*" = "pwd" ] && [ "$PWD" = "$fixture_root" ]',
+      setup: [],
+    },
+    {
+      name: "canonical cd",
+      failure: '[ "$*" = "cd $fixture_root" ] && [ "$BASH_SUBSHELL" = 0 ]',
+      setup: [],
+    },
+    {
+      name: "stale registration prune",
+      failure: '[ "$*" = "git -C $fixture_root worktree prune" ]',
+      setup: [
+        "git worktree add .worktrees/pr-42 -b temp/pr-42 origin/main",
+        "rm -rf .worktrees/pr-42",
+      ],
+    },
+    {
+      name: "worktree add",
+      failure: '[[ "$*" == "git -C $fixture_root worktree add "* ]]',
+      setup: [],
+    },
+    {
+      name: "post-add parent resolution",
+      failure: '[ "$*" = "pwd -P" ] && [ "$PWD" = "$fixture_root/.worktrees" ]',
+      setup: [],
+    },
+    {
+      name: "worktree cd",
+      failure: '[ "$*" = "cd $fixture_root/.worktrees/pr-42" ] && [ "$BASH_SUBSHELL" = 0 ]',
+      setup: [],
+    },
+    {
+      name: "sparse conversion",
+      failure: '[ "$*" = "git sparse-checkout disable" ]',
+      setup: [
+        "git sparse-checkout init --no-cone",
+        "git sparse-checkout set --no-cone fixture.txt",
+      ],
+    },
+    {
+      name: "sparse config read",
+      failure: '[ "$*" = "git config --bool core.sparseCheckout" ]',
+      setup: [],
+    },
+    { name: "artifact directory", failure: '[ "$*" = "mkdir -p .local" ]', setup: [] },
+  ])("stops required entry steps on $name failure in an OR list", ({ failure, setup }) => {
+    const fixture = createFixture();
+    const result = runShell(fixture, [
+      ...setup,
+      ...traceEntryCommands(failure),
+      "enter_worktree 42 false || exit $?",
+    ]);
+    expectEntryStopped(fixture, result);
+    expect(existsSync(join(fixture.root, ".worktrees", "pr-42", ".local"))).toBe(false);
+  });
+
+  it("refuses provisioning when best-effort cleanup leaves the stale directory", () => {
+    const fixture = createFixture();
+    makeStaleWorktreeDir(fixture);
+    const marker = join(fixture.root, ".worktrees", "pr-42", "foreign-note");
+    writeFileSync(marker, "preserve me\n");
+    const result = runShell(fixture, [
+      ...traceEntryCommands('[ "$1" = trash ]'),
+      "enter_worktree 42 true || exit $?",
+    ]);
+    expectEntryStopped(fixture, result);
+    expect(result.stdout).toContain("failed to trash orphaned worktree dir");
+    expect(result.stderr).toContain("could not be cleared");
+    expect(readFileSync(marker, "utf8")).toBe("preserve me\n");
+  });
+
   it("stale .worktrees/pr-<N> directory does not clobber the canonical checkout", () => {
     const fixture = createFixture();
     makeStaleWorktreeDir(fixture);
@@ -204,13 +385,15 @@ describePosix("scripts/pr worktree containment", () => {
     expectCanonicalCheckoutUnchanged(fixture);
   });
 
-  it("reuses a properly registered PR worktree", () => {
+  it.each(["cold", "warm"])("enters a %s PR worktree and fetches in its Git context", (state) => {
     const fixture = createFixture();
     const expectedWorktree = join(fixture.root, ".worktrees", "pr-42");
-    git(fixture.root, "worktree", "add", expectedWorktree, "-b", "temp/pr-42", "origin/main");
+    if (state === "warm") {
+      git(fixture.root, "worktree", "add", expectedWorktree, "-b", "temp/pr-42", "origin/main");
+    }
 
     const result = runShell(fixture, [
-      "enter_worktree 42 false",
+      "enter_worktree 42 false || exit $?",
       'printf "cwd=%s\\n" "$PWD"',
       'printf "branch=%s\\n" "$(git branch --show-current)"',
       'printf "head=%s\\n" "$(git rev-parse HEAD)"',
@@ -220,6 +403,17 @@ describePosix("scripts/pr worktree containment", () => {
     expect(result.stdout).toContain(`cwd=${realpathSync(expectedWorktree)}`);
     expect(result.stdout).toContain("branch=temp/pr-42");
     expect(result.stdout).toContain(`head=${fixture.mainSha}`);
+    const fetchHead = git(
+      expectedWorktree,
+      "rev-parse",
+      "--path-format=absolute",
+      "--git-path",
+      "FETCH_HEAD",
+    );
+    expect(fetchHead).not.toBe(
+      git(fixture.root, "rev-parse", "--path-format=absolute", "--git-path", "FETCH_HEAD"),
+    );
+    expect(readFileSync(fetchHead, "utf8")).toContain(fixture.mainSha);
     expectCanonicalCheckoutUnchanged(fixture);
   });
 


### PR DESCRIPTION
Related: #132152 (failed prerequisites and duplicated guarded entry; operation-wide prepare refresh reuse remains open).

Tracking: umbreon-land.

## What Problem This Solves

Fixes an issue where maintainers running native PR review commands could receive success after authentication or a required main fetch failed. Bash disables implicit `errexit` inside functions called from OR lists, allowing later successful commands to hide the failed prerequisite. An existing transition journal could also replay before the worktree-local fetch failed.

The failure was encountered while validating the Apple ClawHub acknowledgement cleanup in #131979. That PR did not change these wrappers and its accepted validation used an uninterrupted retry; it is discovery context, not the source of this bug.

## Why This Change Was Made

`enter_worktree` now explicitly propagates required-step failures, records the start of side effects immediately before the first fetch, and completes the second fetch before journal recovery or sparse-checkout mutation. Both fetches remain necessary: the first supplies cold provisioning, and the second refreshes worktree-local `FETCH_HEAD`. A cold second-fetch failure may leave successfully provisioned state; this repair does not promise rollback.

Checked `review_guard` owns entry. Standalone guard, artifact validation, and review-tests use that same boundary once, removing the duplicate acquisition paths. This supersedes the earlier revision's public-dispatch placement and its auth-failure-as-success assumption: authentication failure must abort validation too. The real file-only bare-Git public-wrapper fixture and its environment isolation are retained, with expectations updated to the requested contract. Shared review-artifact setup is test-only.

The existing supervisor, exact-owner lock recovery, containment checks, and native landing algorithm are unchanged. Auth failure before side effects remains eligible for validation-phase release; once fetch has begun, later failure retains the exact lock and recovery guidance.

## User Impact

Maintainers receive a failure before dependent work can report success. Pending review transitions and existing review artifacts remain untouched when authentication or a mandatory main fetch fails. Healthy guarded workflows initialize once. No runtime feature, configuration, dependency, schema, release, changelog, or CI-cap change is included.

Broader composite `prepare-run` refresh reuse in #132152 remains separate work. The existing macOS process-group diagnostic gap also remains separate: one earlier unchanged cleanup case reported indeterminate group state and retained its fixture lock; focused and full retries passed. No permissive release heuristic or weakened assertion is introduced.

## Evidence

Historical before-fix proof remains available in the [original baseline run](https://github.com/openclaw/openclaw/actions/runs/33210061782/job/98981026269): four real Git fetch failures returned wrapper success and allowed dependent metadata work. The [partial repair run](https://github.com/openclaw/openclaw/actions/runs/33214985404/job/98996876274) exposed a swallowed fourth refresh inside validation. The prior [twelve-case hosted run](https://github.com/openclaw/openclaw/actions/runs/33219087515/job/99009351411) validated the earlier narrower revision, not this integrated auth/lock contract.

The inherited `ui-pages-e2e` root-budget failure is repaired on the refreshed main baseline by #132193's `ui-pages`/`ui-e2e` split. The 720-root cap is unchanged; the canonical core-boundary check passes locally. #132208 records the related [green rebase recovery](https://github.com/openclaw/openclaw/pull/132208#issuecomment-5458906858). This addresses the latest ClawSweeper rank-up request's inherited-gate repair; green required checks for the published head remain mandatory before landing.

Final combined local proof: all six PR-boundary suites passed (300 tests passed, one Linux-only zombie-process test skipped on macOS):

```bash
node scripts/run-vitest.mjs test/scripts/pr-worktree-containment.test.ts test/scripts/pr-operation-lock.test.ts test/scripts/pr-review-artifact-validation.test.ts test/scripts/pr-prepare-gates.test.ts test/scripts/pr-wrappers.test.ts test/scripts/pr-merge.test.ts
```

Changed-scope formatting, guards, test-root typecheck, and script lint passed:

```bash
node scripts/check-changed.mjs -- scripts/pr-lib/review.sh scripts/pr-lib/worktree.sh test/scripts/pr-operation-lock.test.ts test/scripts/pr-review-artifact-fixture.ts test/scripts/pr-review-artifact-validation.test.ts test/scripts/pr-worktree-containment.test.ts
```

Individual `bash -n` checks passed for the wrapper and both changed shell modules under system Bash 3.2 and Homebrew Bash 5.3; `git diff --cached --check` passed. Fresh structured Codex autoreview covered the entire six-file combined patch in one pass and reported no accepted/actionable P0 findings; that severity threshold is a scope limit, not an exhaustive certification. AI-assisted implementation and review.

Production LOC: +19/-17 (net +2, comprising four explanatory comments and net -2 executable lines). Tests/support: +798/-98 (net +700). The public fixture covers 18 cold/warm or guarded command cases; the connected suites also cover interrupted fetch statuses, required-step failures, journal preservation, worktree containment, native side-effect marking, and exact-owner recovery. An initial integration run had one test-table parse error; it was corrected after that process finished, then the full six-suite run passed. No live GitHub fault injection or exhaustive orphan-process census is claimed; real Git, Bash, native supervisor, and artifact-validator behavior are exercised in isolated fixtures. Live native review/prepare/merge and exact-head hosted CI remain the publication-to-landing gates.
