### PR TITLE
fix(macos): MCP Apps stay inside the dashboard

### DIFF
--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -936,7 +936,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
             return false
         }
         let components = url.path.split(separator: "/", omittingEmptySubsequences: true)
-        return components == ["mcp-app-sandbox"] || (components.count == 4 &&
+        return url.path(percentEncoded: true) == "/mcp-app-sandbox" || (components.count == 4 &&
             components[0] == "embed" &&
             (components[1] == "channel" || components[1] == "thread"))
     }

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -936,9 +936,9 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
             return false
         }
         let components = url.path.split(separator: "/", omittingEmptySubsequences: true)
-        return components.count == 4 &&
+        return components == ["mcp-app-sandbox"] || (components.count == 4 &&
             components[0] == "embed" &&
-            (components[1] == "channel" || components[1] == "thread")
+            (components[1] == "channel" || components[1] == "thread"))
     }
 
     static func shouldAllowBrowserNavigation(to url: URL, isMainFrame: Bool) -> Bool {

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -645,7 +645,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
     static func isTrustedLinkSource(_ sourceURL: URL?, dashboardURL: URL) -> Bool {
         guard let sourceURL, sameOrigin(sourceURL, dashboardURL) else { return false }
         let allowedPath = Self.allowedPath(for: dashboardURL)
-        return allowedPath == "/" || sourceURL.path.hasPrefix(allowedPath)
+        return allowedPath == "/" || sourceURL.path(percentEncoded: true).hasPrefix(allowedPath)
     }
 
     static func shouldAllowEditorURLLaunch(
@@ -894,7 +894,8 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
     }
 
     static func allowedPath(for url: URL) -> String {
-        let path = url.path.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Match location.pathname; URL.path decodes escapes and removes the mount's trailing slash.
+        let path = url.path(percentEncoded: true).trimmingCharacters(in: .whitespacesAndNewlines)
         guard !path.isEmpty else { return "/" }
         return path.hasSuffix("/") ? path : path + "/"
     }

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardHTTPFixture.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardHTTPFixture.swift
@@ -13,11 +13,15 @@ final class DashboardHTTPFixture {
     }
 
     private let listener: NWListener
+    private let responseHTML: String
+    private let contentSecurityPolicy: String
     private var clients: [UUID: Client] = [:]
     private var stopped = false
     nonisolated let port: UInt16
 
-    private init(listener: NWListener, port: UInt16) {
+    private init(listener: NWListener, port: UInt16, html: String, contentSecurityPolicy: String) {
+        self.responseHTML = html
+        self.contentSecurityPolicy = contentSecurityPolicy
         self.listener = listener
         self.port = port
         self.listener.newConnectionHandler = { [weak self] connection in
@@ -31,7 +35,10 @@ final class DashboardHTTPFixture {
         }
     }
 
-    static func start() async throws -> DashboardHTTPFixture {
+    static func start(
+        html: String = DashboardHTTPFixture.html,
+        contentSecurityPolicy: String = "default-src 'none'") async throws -> DashboardHTTPFixture
+    {
         let parameters = NWParameters.tcp
         parameters.requiredLocalEndpoint = .hostPort(host: "127.0.0.1", port: .any)
         let listener = try NWListener(using: parameters, on: .any)
@@ -46,7 +53,11 @@ final class DashboardHTTPFixture {
                     guard let port = listener.port, port.rawValue != 0 else {
                         throw URLError(.cannotFindHost)
                     }
-                    return DashboardHTTPFixture(listener: listener, port: port.rawValue)
+                    return DashboardHTTPFixture(
+                        listener: listener,
+                        port: port.rawValue,
+                        html: html,
+                        contentSecurityPolicy: contentSecurityPolicy)
                 case let .failed(error):
                     throw error
                 case .cancelled:
@@ -117,15 +128,15 @@ final class DashboardHTTPFixture {
 
     private func respond(_ id: UUID) {
         guard let client = self.clients[id] else { return }
-        let body = Data(Self.html.utf8)
-        // No scripts, subresources, redirects, cookies, or gateway RPCs. The CSP
-        // also fences accidental page resource additions to this inert fixture.
+        let body = Data(self.responseHTML.utf8)
+        // Existing callers stay inert; navigation tests explicitly opt into
+        // their own scripts and loopback-only frame origins.
         let headers = [
             "HTTP/1.1 200 OK",
             "Content-Type: text/html; charset=utf-8",
             "Content-Length: \(body.count)",
             "Cache-Control: no-store",
-            "Content-Security-Policy: default-src 'none'",
+            "Content-Security-Policy: \(self.contentSecurityPolicy)",
             "Connection: close",
         ].joined(separator: "\r\n") + "\r\n\r\n"
         client.connection.send(content: Data(headers.utf8) + body, completion: .contentProcessed { [weak self] _ in

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardSandboxNavigationTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardSandboxNavigationTests.swift
@@ -1,0 +1,129 @@
+import AppKit
+import Foundation
+import Testing
+import WebKit
+@testable import OpenClaw
+
+@Suite(.serialized)
+@MainActor
+struct DashboardSandboxNavigationTests {
+    @Test(arguments: [
+        "https://widgets.example/mcp-app-sandbox?csp=encoded",
+        "http://127.0.0.1:18790/mcp-app-sandbox?csp=encoded",
+    ])
+    func `sandbox navigation requires a trusted dashboard subframe`(_ address: String) throws {
+        let dashboard = try #require(URL(string: "https://openclaw.example/control/"))
+        let sandbox = try #require(URL(string: address))
+        #expect(DashboardWindowController.shouldAllowNavigation(
+            to: sandbox, dashboardURL: dashboard, isMainFrame: false, isTrustedDashboardSource: true))
+        #expect(!DashboardWindowController.shouldAllowNavigation(
+            to: sandbox, dashboardURL: dashboard, isMainFrame: true, isTrustedDashboardSource: true))
+        #expect(!DashboardWindowController.shouldAllowNavigation(
+            to: sandbox, dashboardURL: dashboard, isMainFrame: false, isTrustedDashboardSource: false))
+    }
+
+    @Test(arguments: [
+        "https://widgets.example/mcp-app",
+        "https://widgets.example/mcp-app-sandbox/",
+        "https://widgets.example//mcp-app-sandbox",
+        "https://widgets.example/%6dcp-app-sandbox",
+        "https://widgets.example/mcp-app-sandbox%2f",
+        "file:///mcp-app-sandbox",
+        "custom://widgets.example/mcp-app-sandbox",
+    ])
+    func `sandbox navigation rejects noncanonical or unsafe URLs`(_ address: String) throws {
+        let dashboard = try #require(URL(string: "https://openclaw.example/control/"))
+        let sandbox = try #require(URL(string: address))
+        #expect(!DashboardWindowController.shouldAllowNavigation(
+            to: sandbox, dashboardURL: dashboard, isMainFrame: false, isTrustedDashboardSource: true))
+    }
+
+    @Test func `sandbox navigation rejects user information`() throws {
+        let dashboard = try #require(URL(string: "https://openclaw.example/control/"))
+        var sandbox = try #require(URLComponents(string: "https://widgets.example/mcp-app-sandbox"))
+        sandbox.user = "fixture-user"
+        #expect(try !DashboardWindowController.shouldAllowNavigation(
+            to: #require(sandbox.url), dashboardURL: dashboard, isMainFrame: false, isTrustedDashboardSource: true))
+        sandbox.user = nil
+        sandbox.password = "fixture-password"
+        #expect(try !DashboardWindowController.shouldAllowNavigation(
+            to: #require(sandbox.url), dashboardURL: dashboard, isMainFrame: false, isTrustedDashboardSource: true))
+    }
+
+    @Test(arguments: ["/control/", "/team%20space/"])
+    func `dashboard source trust preserves the browser pathname`(_ mountPath: String) throws {
+        let dashboard = try #require(URL(string: "https://openclaw.example\(mountPath)"))
+        let descendant = try #require(URL(string: "chat", relativeTo: dashboard)?.absoluteURL)
+        #expect(DashboardWindowController.allowedPath(for: dashboard) == mountPath)
+        #expect(DashboardWindowController.isTrustedLinkSource(dashboard, dashboardURL: dashboard))
+        #expect(DashboardWindowController.isTrustedLinkSource(descendant, dashboardURL: dashboard))
+        let encodedSeparator = try #require(URL(string: "https://openclaw.example\(mountPath.dropLast())%2Fchat"))
+        #expect(!DashboardWindowController.isTrustedLinkSource(encodedSeparator, dashboardURL: dashboard))
+    }
+
+    @Test func `dashboard WebKit loads the isolated sandbox and its inner document`() async throws {
+        let sandbox = try await DashboardHTTPFixture.start(
+            html: """
+            <!doctype html><body><script>
+            addEventListener('message', event => {
+              if (event.source !== parent || event.data !== 'load-app') return;
+              const inner = document.createElement('iframe');
+              inner.sandbox = 'allow-scripts';
+              inner.srcdoc = '<body>MCP App rendered<script>parent.postMessage("app-ready", "*")<\\/script>';
+              addEventListener('message', reply => {
+                if (reply.source === inner.contentWindow && reply.data === 'app-ready') {
+                  parent.postMessage({ready: true, nativeAuth: !!window.__OPENCLAW_NATIVE_CONTROL_AUTH__}, '*');
+                }
+              });
+              document.body.append(inner);
+            });
+            parent.postMessage('proxy-ready', '*');
+            </script>
+            """,
+            contentSecurityPolicy: "default-src 'none'; script-src 'unsafe-inline'; frame-src 'self'")
+        defer { sandbox.stop() }
+        let sandboxURL = sandbox.url("/mcp-app-sandbox?csp=encoded")
+        let dashboard = try await DashboardHTTPFixture.start(
+            html: """
+            <!doctype html><body><h1>Dashboard</h1><script>
+            const frame = document.createElement('iframe');
+            frame.sandbox = 'allow-scripts allow-same-origin allow-forms';
+            frame.referrerPolicy = 'origin';
+            document.body.append(frame);
+            addEventListener('message', event => {
+              if (event.source !== frame.contentWindow) return;
+              if (event.data === 'proxy-ready') frame.contentWindow.postMessage('load-app', '*');
+              else if (event.data.ready) {
+                document.body.dataset.appReady = String(!event.data.nativeAuth);
+              }
+            });
+            frame.src = '\(sandboxURL.absoluteString)';
+            </script>
+            """,
+            contentSecurityPolicy:
+            "default-src 'none'; script-src 'unsafe-inline'; frame-src http://127.0.0.1:\(sandbox.port)")
+        defer { dashboard.stop() }
+        let dashboardURL = dashboard.url("/control/")
+        let controller = DashboardWindowController(
+            url: dashboardURL,
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: "fixture-only", password: nil),
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "",
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { controller.closeDashboard() }
+        controller.loadInBackground(url: dashboardURL, auth: controller.auth)
+        let deadline = ContinuousClock.now + .seconds(10)
+        var rendered = false
+        while ContinuousClock.now < deadline {
+            if await (try? controller.webView.evaluateJavaScript("document.body.dataset.appReady")) as? String ==
+                "true"
+            {
+                rendered = true
+                break
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        #expect(rendered, "The real navigation delegate must admit the outer sandbox and nested srcdoc handshake")
+        #expect(controller.webView.url == dashboardURL)
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -305,6 +305,8 @@ struct DashboardWindowSmokeTests {
         let sandbox = try #require(URL(
             string: "https://widgets.example/mcp-app-sandbox?csp=encoded"))
         let unrelatedPath = try #require(URL(string: "https://widgets.example/mcp-app"))
+        let trailingSlash = try #require(URL(string: "https://widgets.example/mcp-app-sandbox/"))
+        let repeatedSlash = try #require(URL(string: "https://widgets.example//mcp-app-sandbox"))
 
         #expect(DashboardWindowController.shouldAllowNavigation(
             to: sandbox, dashboardURL: dashboard, isMainFrame: false, isTrustedDashboardSource: true))
@@ -314,6 +316,16 @@ struct DashboardWindowSmokeTests {
             to: sandbox, dashboardURL: dashboard, isMainFrame: false, isTrustedDashboardSource: false))
         #expect(!DashboardWindowController.shouldAllowNavigation(
             to: unrelatedPath,
+            dashboardURL: dashboard,
+            isMainFrame: false,
+            isTrustedDashboardSource: true))
+        #expect(!DashboardWindowController.shouldAllowNavigation(
+            to: trailingSlash,
+            dashboardURL: dashboard,
+            isMainFrame: false,
+            isTrustedDashboardSource: true))
+        #expect(!DashboardWindowController.shouldAllowNavigation(
+            to: repeatedSlash,
             dashboardURL: dashboard,
             isMainFrame: false,
             isTrustedDashboardSource: true))

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -300,37 +300,6 @@ struct DashboardWindowSmokeTests {
             to: localFile, dashboardURL: dashboard, isMainFrame: false, isTrustedDashboardSource: true))
     }
 
-    @Test func `dashboard permits only trusted MCP App sandbox subframes`() throws {
-        let dashboard = try #require(URL(string: "https://openclaw.example/control/"))
-        let sandbox = try #require(URL(
-            string: "https://widgets.example/mcp-app-sandbox?csp=encoded"))
-        let unrelatedPath = try #require(URL(string: "https://widgets.example/mcp-app"))
-        let trailingSlash = try #require(URL(string: "https://widgets.example/mcp-app-sandbox/"))
-        let repeatedSlash = try #require(URL(string: "https://widgets.example//mcp-app-sandbox"))
-
-        #expect(DashboardWindowController.shouldAllowNavigation(
-            to: sandbox, dashboardURL: dashboard, isMainFrame: false, isTrustedDashboardSource: true))
-        #expect(!DashboardWindowController.shouldAllowNavigation(
-            to: sandbox, dashboardURL: dashboard, isMainFrame: true, isTrustedDashboardSource: true))
-        #expect(!DashboardWindowController.shouldAllowNavigation(
-            to: sandbox, dashboardURL: dashboard, isMainFrame: false, isTrustedDashboardSource: false))
-        #expect(!DashboardWindowController.shouldAllowNavigation(
-            to: unrelatedPath,
-            dashboardURL: dashboard,
-            isMainFrame: false,
-            isTrustedDashboardSource: true))
-        #expect(!DashboardWindowController.shouldAllowNavigation(
-            to: trailingSlash,
-            dashboardURL: dashboard,
-            isMainFrame: false,
-            isTrustedDashboardSource: true))
-        #expect(!DashboardWindowController.shouldAllowNavigation(
-            to: repeatedSlash,
-            dashboardURL: dashboard,
-            isMainFrame: false,
-            isTrustedDashboardSource: true))
-    }
-
     @Test func `dashboard navigation shortcuts target the focused browser`() async throws {
         let server = try await DashboardHTTPFixture.start()
         defer { server.stop() }

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -300,6 +300,25 @@ struct DashboardWindowSmokeTests {
             to: localFile, dashboardURL: dashboard, isMainFrame: false, isTrustedDashboardSource: true))
     }
 
+    @Test func `dashboard permits only trusted MCP App sandbox subframes`() throws {
+        let dashboard = try #require(URL(string: "https://openclaw.example/control/"))
+        let sandbox = try #require(URL(
+            string: "https://widgets.example/mcp-app-sandbox?csp=encoded"))
+        let unrelatedPath = try #require(URL(string: "https://widgets.example/mcp-app"))
+
+        #expect(DashboardWindowController.shouldAllowNavigation(
+            to: sandbox, dashboardURL: dashboard, isMainFrame: false, isTrustedDashboardSource: true))
+        #expect(!DashboardWindowController.shouldAllowNavigation(
+            to: sandbox, dashboardURL: dashboard, isMainFrame: true, isTrustedDashboardSource: true))
+        #expect(!DashboardWindowController.shouldAllowNavigation(
+            to: sandbox, dashboardURL: dashboard, isMainFrame: false, isTrustedDashboardSource: false))
+        #expect(!DashboardWindowController.shouldAllowNavigation(
+            to: unrelatedPath,
+            dashboardURL: dashboard,
+            isMainFrame: false,
+            isTrustedDashboardSource: true))
+    }
+
     @Test func `dashboard navigation shortcuts target the focused browser`() async throws {
         let server = try await DashboardHTTPFixture.start()
         defer { server.stop() }


### PR DESCRIPTION
Related: #111687 (shared dashboard sandbox)
Related: #111883 (trusted native discussion embeds)

## What Problem This Solves

MCP Apps in the macOS dashboard lose their inline view when the required dedicated-origin sandbox loads. Older app builds could send the rejected navigation to the default browser; current main cancels it. The native navigation allowlist recognized ClickClack embeds but omitted the shared MCP App sandbox route.

Native validation also exposed a second failure at non-root dashboard mounts: Foundation's `URL.path` removes `/control/`'s trailing slash, causing the dashboard's own root document to fail its trusted-source check. Decoding percent escapes also disagreed with the browser pathname used by native authentication injection.

## Why This Change Was Made

The native dashboard remains the navigation-policy owner. It now admits only the literal percent-encoded `/mcp-app-sandbox` path after the existing HTTP(S), nonempty-host, no-userinfo, trusted-dashboard-source, and subframe gates. The source-trust and native-auth mount checks consistently use the browser's encoded pathname, preserving trailing slashes and encoded mount names without admitting encoded-separator lookalikes.

No hostname-specific exceptions, configuration options, alternate navigation paths, or new production helpers are added. Main-frame navigation, native bridge main-frame/origin checks, and existing ClickClack behavior remain intact.

## User Impact

MCP Apps and board widgets using the shared sandbox remain inside the macOS dashboard. Dashboards mounted below a path, including encoded mount names, can correctly recognize their own root document and inject native authentication there.

Credit: Omar Shahine (@omarshahine) supplied the original MCP sandbox repair and live macOS diagnosis.

## Evidence

- Rebased onto current main, preserving the recently landed nonpersistent WebKit/loopback test isolation changes.
- Real WebKit regression: the production `DashboardWindowController` loads a dashboard on one temporary loopback port, admits the dedicated sandbox on a second port, completes an inner sandboxed `srcdoc` postMessage handshake, keeps the top-level dashboard URL unchanged, and confirms the outer sandbox has no injected native credential object.
- Red/green proof for the route exception: temporarily removing only the MCP sandbox allowance produced three failures, including the real WebKit handshake, while the pathname tests stayed green. Restoring the allowance passed the same suite.
- Before the mount-path correction, that native regression failed. Navigation tracing showed the expected dashboard source frame was rejected by the normalized pathname comparison. After correction, the native handshake passed.
- `swift test --package-path apps/macos --build-system native --filter 'Dashboard(WindowSmoke|SandboxNavigation)Tests'`: 42 tests passed. The native build backend matches CI's documented Sparkle test-bundle workaround.
- Policy coverage includes distinct HTTP/HTTPS sandbox origins; main-frame and untrusted-source rejection; exact/trailing/repeated/percent-encoded path cases; username/password, file, and custom-scheme rejection; literal and encoded dashboard mounts; encoded-separator rejection; and existing ClickClack/native bridge siblings.
- `./scripts/format-swift.sh macos` and `./scripts/lint-swift.sh macos`: passed with the repository-pinned SwiftFormat 0.62.1 and SwiftLint 0.65.0.
- Production LOC: +5/-4 (net +1, solely the comment explaining Foundation pathname normalization); executable production LOC is unchanged. Tests/support: +147/-7.
- Fresh structured Codex autoreview and an independent source/dependency/sibling review found no actionable issues.
- Original author live proof: Omar rebuilt, signed, and installed the app against the affected remote dashboard and reported inline rendering after the fix. The maintainer proof above uses real WebKit with synthetic local pages; it is not an authenticated MCP provider session. Screenshots of the private operator dashboard were not available for this pass, so no private dashboard capture is published.

ClawSweeper's requested rebase and focused validation are addressed. Exact-head CI and the native landing result are recorded in the maintainer landing comment.

Follow-up: MCP-declared HTTP(S) descendant frame domains are still subject to the existing native trusted-main-source gate. This change deliberately preserves that separate boundary; any expansion needs its own native/CSP proof.
