### PR TITLE
fix(doctor): preserve large media migration timestamps

### DIFF
--- a/src/infra/state-migrations.media-persistence.test.ts
+++ b/src/infra/state-migrations.media-persistence.test.ts
@@ -449,6 +449,49 @@ describe("legacy media persistence doctor migration", () => {
     expect(await migrateLegacyMediaPersistence({ env })).toEqual({ changes: [], warnings: [] });
   });
 
+  it("migrates when valid transcript created_at rows have an unsafe aggregate", async () => {
+    const stateDir = makeTempDir(tempDirs, "media-persistence-large-created-at-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const legacyMediaPaths = ["/media/a.png", "/media/b.png"];
+    const databasePath = createLegacyDatabaseFixture({
+      env,
+      eventsBySession: {
+        unsafe: legacyMediaPaths.map((mediaPath, index) =>
+          createEvent({
+            id: `event-${index + 1}`,
+            parentId: index === 0 ? null : "event-1",
+            timestamp: (index + 1) * 1000,
+            message: { role: "user", content: `message ${index + 1}`, MediaPath: mediaPath },
+          }),
+        ),
+      },
+    });
+    const largeCreatedAt = Math.floor(Number.MAX_SAFE_INTEGER / 2) + 100;
+    expect(largeCreatedAt * 2).toBeGreaterThan(Number.MAX_SAFE_INTEGER);
+    const { DatabaseSync } = requireNodeSqlite();
+    const database = new DatabaseSync(databasePath);
+    database
+      .prepare("UPDATE transcript_events SET created_at = ? WHERE session_id = ?")
+      .run(largeCreatedAt, "unsafe");
+    database.close();
+
+    expect((await migrateLegacyMediaPersistence({ env })).warnings).toEqual([]);
+
+    const snapshot = readDatabaseSnapshot(databasePath);
+    expect(snapshot.version.user_version).toBe(OPENCLAW_AGENT_SCHEMA_VERSION);
+    expect(snapshot.rows.map((row) => row.created_at)).toEqual([largeCreatedAt, largeCreatedAt]);
+    const messages = snapshot.rows.map(
+      (row) => (JSON.parse(row.event_json) as FixtureEvent).message,
+    );
+    expect(messages).toEqual(
+      legacyMediaPaths.map((mediaPath) =>
+        expect.objectContaining({
+          __openclaw: { media: [expect.objectContaining({ path: mediaPath })] },
+        }),
+      ),
+    );
+  });
+
   it("upgrades the existing v14 structural schema before the media cutover", async () => {
     const stateDir = makeTempDir(tempDirs, "media-persistence-v14-");
     const env = { OPENCLAW_STATE_DIR: stateDir };

--- a/src/infra/state-migrations.media-persistence.ts
+++ b/src/infra/state-migrations.media-persistence.ts
@@ -293,16 +293,7 @@ function scanTrajectoryRows(params: {
   return changedRows;
 }
 
-type MediaSourceVersion = {
-  dataVersion: number;
-  trajectoryBytes: number;
-  trajectoryRows: number;
-  transcriptBytes: number;
-  transcriptCreatedAt: string;
-  transcriptRows: number;
-};
-
-function readMediaSourceVersion(database: DatabaseSync): MediaSourceVersion {
+function readMediaSourceVersion(database: DatabaseSync) {
   const dataVersionRow = database.prepare("PRAGMA data_version").get();
   const counts = database
     .prepare(
@@ -317,19 +308,19 @@ function readMediaSourceVersion(database: DatabaseSync): MediaSourceVersion {
   const number = (value: unknown): number =>
     typeof value === "bigint" ? Number(value) : typeof value === "number" ? value : 0;
   const count = (key: string): number => number(isRecord(counts) ? counts[key] : undefined);
-  const text = (key: string): string => {
-    const value = isRecord(counts) ? counts[key] : undefined;
-    return typeof value === "string" ? value : "0";
-  };
   return {
     dataVersion: number(isRecord(dataVersionRow) ? dataVersionRow.data_version : undefined),
     trajectoryBytes: count("trajectory_bytes"),
     trajectoryRows: count("trajectory_rows"),
     transcriptBytes: count("transcript_bytes"),
-    transcriptCreatedAt: text("transcript_created_at"),
+    transcriptCreatedAt: String(
+      (isRecord(counts) ? counts.transcript_created_at : undefined) ?? "0",
+    ),
     transcriptRows: count("transcript_rows"),
   };
 }
+
+type MediaSourceVersion = ReturnType<typeof readMediaSourceVersion>;
 
 function mediaSourceDriftMessage(
   pathname: string,

--- a/src/infra/state-migrations.media-persistence.ts
+++ b/src/infra/state-migrations.media-persistence.ts
@@ -298,7 +298,7 @@ type MediaSourceVersion = {
   trajectoryBytes: number;
   trajectoryRows: number;
   transcriptBytes: number;
-  transcriptCreatedAt: number;
+  transcriptCreatedAt: string;
   transcriptRows: number;
 };
 
@@ -309,7 +309,7 @@ function readMediaSourceVersion(database: DatabaseSync): MediaSourceVersion {
       `SELECT
         (SELECT COUNT(*) FROM transcript_events) AS transcript_rows,
         (SELECT COALESCE(SUM(LENGTH(event_json)), 0) FROM transcript_events) AS transcript_bytes,
-        (SELECT COALESCE(SUM(created_at), 0) FROM transcript_events) AS transcript_created_at,
+        (SELECT CAST(COALESCE(SUM(created_at), 0) AS TEXT) FROM transcript_events) AS transcript_created_at,
         (SELECT COUNT(*) FROM trajectory_runtime_events) AS trajectory_rows,
         (SELECT COALESCE(SUM(LENGTH(event_json)), 0) FROM trajectory_runtime_events) AS trajectory_bytes`,
     )
@@ -317,12 +317,16 @@ function readMediaSourceVersion(database: DatabaseSync): MediaSourceVersion {
   const number = (value: unknown): number =>
     typeof value === "bigint" ? Number(value) : typeof value === "number" ? value : 0;
   const count = (key: string): number => number(isRecord(counts) ? counts[key] : undefined);
+  const text = (key: string): string => {
+    const value = isRecord(counts) ? counts[key] : undefined;
+    return typeof value === "string" ? value : "0";
+  };
   return {
     dataVersion: number(isRecord(dataVersionRow) ? dataVersionRow.data_version : undefined),
     trajectoryBytes: count("trajectory_bytes"),
     trajectoryRows: count("trajectory_rows"),
     transcriptBytes: count("transcript_bytes"),
-    transcriptCreatedAt: count("transcript_created_at"),
+    transcriptCreatedAt: text("transcript_created_at"),
     transcriptRows: count("transcript_rows"),
   };
 }

--- a/src/infra/state-migrations.media-persistence.ts
+++ b/src/infra/state-migrations.media-persistence.ts
@@ -726,3 +726,4 @@ export async function migrateLegacyMediaPersistence(
   }
   return { changes, warnings };
 }
+

--- a/src/infra/state-migrations.media-persistence.ts
+++ b/src/infra/state-migrations.media-persistence.ts
@@ -726,4 +726,3 @@ export async function migrateLegacyMediaPersistence(
   }
   return { changes, warnings };
 }
-


### PR DESCRIPTION
## Why

Doctor must migrate persisted databases containing valid SQLite integers even when aggregate timestamp fingerprints exceed JavaScript's safe integer range. Without preserving the aggregate exactly, `doctor --fix` exits before committing the schema migration.

## Failure scenario

During a schema 16 to 18 media-persistence migration, Doctor reads `SUM(created_at)` as part of its before/after source-drift fingerprint. A database with enough valid timestamp rows can produce an aggregate larger than `Number.MAX_SAFE_INTEGER`. Node SQLite then throws before the migration transaction can commit:

```text
RangeError: Value is too large to be represented as a JavaScript number: 26433743215323619
```

The individual timestamps remain valid SQLite integers; only their aggregate exceeds JavaScript's safe integer range.

## What changed

- return the `SUM(created_at)` migration fingerprint as SQLite text
- compare the exact text value before and after migration
- leave the remaining bounded count fingerprints unchanged

## Validation

- `oxfmt --check src/infra/state-migrations.media-persistence.ts`
- no tests added