### PR TITLE
fix(exec): inherit configured host for per-call auto

### DIFF
--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -43,7 +43,7 @@ Run in a pseudo-terminal when available. Use for TTY-only CLIs, coding agents, a
 </ParamField>
 
 <ParamField path="host" type="'auto' | 'sandbox' | 'gateway' | 'node'" default="auto">
-Where to execute. `auto` resolves to `sandbox` when a sandbox runtime is active and `gateway` otherwise.
+Where to execute. Omit `host` or use `auto` to inherit the configured exec host, including agent and session overrides. When that configured host is also `auto`, it resolves to `sandbox` when a sandbox runtime is active and `gateway` otherwise. A session that requires a sandbox stays sandboxed regardless of the configured host.
 </ParamField>
 
 <ParamField path="security" type="'deny' | 'allowlist' | 'full'">

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -268,7 +268,8 @@ export function resolveExecTarget(params: {
   }
   // Session isolation outranks every agent, session, and request-scoped host preference.
   const configuredTarget = sandboxRequired ? "auto" : (params.configuredTarget ?? "auto");
-  const requestedTarget = params.requestedTarget ?? null;
+  const requestedTarget =
+    params.requestedTarget === "auto" ? null : (params.requestedTarget ?? null);
   if (sandboxRequired && (requestedTarget === "gateway" || requestedTarget === "node")) {
     throw registerTrustedToolNoStartError(
       new Error(

--- a/src/agents/bash-tools.exec-target.test.ts
+++ b/src/agents/bash-tools.exec-target.test.ts
@@ -177,35 +177,30 @@ describe("resolveExecTarget", () => {
     );
   });
 
-  it("allows explicit auto request when configured host is auto", () => {
-    expectExecTarget(
-      resolveExecTarget({
-        configuredTarget: "auto",
-        requestedTarget: "auto",
-        elevatedRequested: false,
-        sandboxAvailable: true,
-      }),
-      {
-        configuredTarget: "auto",
-        requestedTarget: "auto",
-        selectedTarget: "auto",
-        effectiveHost: "sandbox",
-      },
-    );
-  });
-
-  it("requires an exact match for non-auto configured targets", () => {
-    expect(() =>
-      resolveExecTarget({
-        configuredTarget: "gateway",
-        requestedTarget: "auto",
-        elevatedRequested: false,
-        sandboxAvailable: true,
-      }),
-    ).toThrow(
-      "exec host not allowed (requested auto; configured host is gateway; set tools.exec.host=auto to allow this override).",
-    );
-  });
+  it.each([
+    { configuredTarget: "auto" as const, sandboxAvailable: true, effectiveHost: "sandbox" },
+    { configuredTarget: "sandbox" as const, sandboxAvailable: true, effectiveHost: "sandbox" },
+    { configuredTarget: "gateway" as const, sandboxAvailable: true, effectiveHost: "gateway" },
+    { configuredTarget: "node" as const, sandboxAvailable: false, effectiveHost: "node" },
+  ])(
+    "treats requested auto as no override of configured host=$configuredTarget",
+    ({ configuredTarget, sandboxAvailable, effectiveHost }) => {
+      expectExecTarget(
+        resolveExecTarget({
+          configuredTarget,
+          requestedTarget: "auto",
+          elevatedRequested: false,
+          sandboxAvailable,
+        }),
+        {
+          configuredTarget,
+          requestedTarget: null,
+          selectedTarget: configuredTarget,
+          effectiveHost,
+        },
+      );
+    },
+  );
 
   it("allows exact node matches", () => {
     expectExecTarget(

--- a/src/agents/bash-tools.exec-target.test.ts
+++ b/src/agents/bash-tools.exec-target.test.ts
@@ -178,27 +178,27 @@ describe("resolveExecTarget", () => {
   });
 
   it.each([
-    { configuredTarget: "auto" as const, sandboxAvailable: true, effectiveHost: "sandbox" },
-    { configuredTarget: "sandbox" as const, sandboxAvailable: true, effectiveHost: "sandbox" },
-    { configuredTarget: "gateway" as const, sandboxAvailable: true, effectiveHost: "gateway" },
-    { configuredTarget: "node" as const, sandboxAvailable: false, effectiveHost: "node" },
-  ])(
-    "treats requested auto as no override of configured host=$configuredTarget",
-    ({ configuredTarget, sandboxAvailable, effectiveHost }) => {
-      expectExecTarget(
-        resolveExecTarget({
-          configuredTarget,
-          requestedTarget: "auto",
-          elevatedRequested: false,
-          sandboxAvailable,
-        }),
-        {
-          configuredTarget,
-          requestedTarget: null,
-          selectedTarget: configuredTarget,
-          effectiveHost,
-        },
+    ["auto", true, false, "sandbox"],
+    ["auto", false, false, "gateway"],
+    ["sandbox", true, false, "sandbox"],
+    ["gateway", true, false, "gateway"],
+    ["gateway", false, false, "gateway"],
+    ["node", false, false, "node"],
+    ["sandbox", true, true, "gateway"],
+    ["node", true, true, "node"],
+  ] as const)(
+    "inherits configured host=%s for auto (sandbox=%s, elevated=%s)",
+    (configuredTarget, sandboxAvailable, elevatedRequested, effectiveHost) => {
+      const result = resolveExecTarget({
+        configuredTarget,
+        requestedTarget: "auto",
+        elevatedRequested,
+        sandboxAvailable,
+      });
+      expect(result).toEqual(
+        resolveExecTarget({ configuredTarget, elevatedRequested, sandboxAvailable }),
       );
+      expect(result.effectiveHost).toBe(effectiveHost);
     },
   );
 
@@ -315,12 +315,18 @@ describe("resolveExecTarget", () => {
       },
     );
 
-    it.each(["gateway", "node"] as const)(
-      "keeps an implicit request sandboxed despite configured host=%s",
-      (host) => {
+    it.each([
+      { host: "gateway", requestedTarget: undefined },
+      { host: "gateway", requestedTarget: "auto" },
+      { host: "node", requestedTarget: undefined },
+      { host: "node", requestedTarget: "auto" },
+    ] as const)(
+      "keeps requested=$requestedTarget sandboxed despite configured host=$host",
+      ({ host, requestedTarget }) => {
         expect(
           resolveExecTarget({
             configuredTarget: host,
+            requestedTarget,
             elevatedRequested: false,
             sandboxAvailable: true,
             sandboxRequired: true,
@@ -343,15 +349,19 @@ describe("resolveExecTarget", () => {
       ).toThrow(/sandbox|required|elevated/i);
     });
 
-    it("fails closed when the required sandbox runtime is unavailable", () => {
-      expect(() =>
-        resolveExecTarget({
-          configuredTarget: "auto",
-          elevatedRequested: false,
-          sandboxAvailable: false,
-          sandboxRequired: true,
-        }),
-      ).toThrow(/sandbox|required|unavailable/i);
-    });
+    it.each([undefined, "auto"] as const)(
+      "fails closed with requested=%s when the required sandbox is unavailable",
+      (requestedTarget) => {
+        expect(() =>
+          resolveExecTarget({
+            configuredTarget: "auto",
+            elevatedRequested: false,
+            sandboxAvailable: false,
+            sandboxRequired: true,
+            requestedTarget,
+          }),
+        ).toThrow(/sandbox|required|unavailable/i);
+      },
+    );
   });
 });

--- a/src/agents/bash-tools.exec.resolve-env-hook.test.ts
+++ b/src/agents/bash-tools.exec.resolve-env-hook.test.ts
@@ -235,7 +235,7 @@ describe("exec resolve_exec_env hook wiring", () => {
     });
   });
 
-  it("forwards filtered plugin env to node host requests", async () => {
+  it("inherits configured node for auto while forwarding filtered plugin env", async () => {
     installResolveExecEnvHook({
       NODE_HOST_SAFE: "yes",
       LD_PRELOAD: "/tmp/preload.dylib",
@@ -252,6 +252,7 @@ describe("exec resolve_exec_env hook wiring", () => {
       },
     });
     await tool.execute("call-node", {
+      host: "auto",
       command: "echo ok",
       env: { REQUEST_SAFE: "request" },
     });
@@ -275,6 +276,8 @@ describe("exec resolve_exec_env hook wiring", () => {
       sender: { id: "ou_node" },
     });
     expect(mocks.nodeHostParams[0]?.env).not.toHaveProperty("LD_PRELOAD");
+    expect(mocks.gatewayParams).toHaveLength(0);
+    expect(mocks.spawnInputs).toHaveLength(0);
   });
 
   it("does not forward configured gateway cwd defaults to node host requests", async () => {
@@ -690,7 +693,7 @@ describe("exec resolve_exec_env hook wiring", () => {
     });
   });
 
-  it("forwards private env preparation through the lazy exec tool", async () => {
+  it("inherits configured gateway for auto through lazy exec preparation", async () => {
     mocks.hookRunner = {
       hasHooks: vi.fn(
         (hookName: string) => hookName === "resolve_exec_env" || hookName === "before_tool_call",
@@ -719,6 +722,7 @@ describe("exec resolve_exec_env hook wiring", () => {
     await expectDefined(definition, "definition test invariant").execute(
       "call-lazy",
       {
+        host: "auto",
         command: "echo ok",
         env: { REQUEST_SAFE: "request" },
         yieldMs: 120_000,

--- a/src/agents/bash-tools.schemas.ts
+++ b/src/agents/bash-tools.schemas.ts
@@ -53,7 +53,7 @@ export const execSchema = Type.Object({
     }),
   ),
   host: optionalStringEnum(EXEC_TOOL_HOST_VALUES, {
-    description: "Exec host/target (auto|sandbox|gateway|node).",
+    description: "Exec host/target. Omit or use auto to inherit the configured host.",
   }),
   security: Type.Optional(
     Type.String({

--- a/src/agents/bash-tools.schemas.ts
+++ b/src/agents/bash-tools.schemas.ts
@@ -53,7 +53,7 @@ export const execSchema = Type.Object({
     }),
   ),
   host: optionalStringEnum(EXEC_TOOL_HOST_VALUES, {
-    description: "Exec host/target. Omit or use auto to inherit the configured host.",
+    description: "Omit or use auto to inherit the configured host.",
   }),
   security: Type.Optional(
     Type.String({


### PR DESCRIPTION
Closes #126822
Closes #124349

## What Problem This Solves

Fixes an issue where agents using a concrete `tools.exec.host` setting could have ordinary exec calls rejected whenever the model included `host: "auto"`. The request was treated as a conflicting host override even though `auto` asks OpenClaw to use the configured target.

## Why This Change Was Made

The shared exec target resolver now normalizes a per-call `auto` target to no override before authorization and routing. The configured target remains authoritative, while explicit `sandbox`, `gateway`, and `node` requests continue through the existing cross-host policy checks.

This owner-level normalization covers both execution and preparation without adding an elevation-sensitive authorization exception.

## User Impact

Operators can keep a concrete exec host such as `gateway` without model-generated `host: "auto"` denying otherwise valid commands or pushing them toward the broader `tools.exec.host=auto` workaround.

## Original submission evidence

### Pre-fix regression

The replacement resolver matrix failed on the old implementation for all four configured targets:

- configured `auto`: returned requested `auto` instead of normalizing it
- configured `sandbox`: rejected requested `auto`
- configured `gateway`: rejected requested `auto`
- configured `node`: rejected requested `auto`

### Exact-path runtime proof

Using an isolated OpenClaw state directory and the real patched exec tool:

- configured `gateway` plus per-call `host: "auto"` ran a real subprocess and returned `status: "completed"`
- configured `gateway` plus per-call `host: "node"` was rejected with `exec host not allowed` before execution

### Tests and gates

- `pnpm test src/agents/bash-tools.exec-target.test.ts`: 25 passed
- `pnpm test src/agents/bash-tools.exec.resolve-env-hook.test.ts src/agents/exec-defaults.test.ts`: 40 passed
- `node scripts/check-changed.mjs -- src/agents/bash-tools.exec-runtime.ts src/agents/bash-tools.exec-target.test.ts`: passed
- Codex autoreview against the committed branch: no findings, patch correct with 0.99 confidence
- Secret and PII review: repository scrubber found no known secret values; TruffleHog found zero verified or unverified secrets; exact diff contained no local paths, email addresses, or credential markers

Production delta is +2/-1. Test delta is +24/-29.

## AI Assistance

AI-assisted. I reviewed the implementation, understand the target-policy change, and verified the behavior and security boundary described above.


## Maintainer verification and release note

The prepared candidate retains Omar's shared resolver repair and clarifies configured-host inheritance in the exec docs and model-facing tool schema. Existing regression coverage now also proves required sandbox isolation, elevated routing, lazy preparation, and node dispatch for per-call auto. No new config, dependency, or wider cross-host permission is introduced.

Final candidate: 141 schema and host-routing tests passed. The earlier 72 focused tests and changed-file format/type/lint/guard checks also passed; CI exposed a prompt-size budget overrun in the expanded description, fixed by shortening that wording without raising the budget. A real built Gateway and paired headless Linux Node completed an actual exec `system.run` with configured node plus per-call auto; explicit node-to-gateway requests remained denied. The macOS companion/Ollama model loop was not exercised. Fresh Codex autoreview is clean.

[Detailed before/after proof, commands, source review, limitations, and CI](https://github.com/openclaw/openclaw/pull/132100#issuecomment-5458960826).

Final delta: production +3/-2 (net +1 for the formatter-wrapped normalization), tests +52/-43 (net +9), docs +1/-1. Release note: models may supply per-call auto without overriding the configured exec host or causing a false policy denial. Thanks @omarshahine.
