### PR TITLE
fix(webchat): announce attachment failures before long replies

### DIFF
--- a/ui/src/e2e/chat-attachment-announcement.e2e.test.ts
+++ b/ui/src/e2e/chat-attachment-announcement.e2e.test.ts
@@ -1,0 +1,111 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({ name: "Attachment failure announcements" });
+const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const proofDir = path.join(process.cwd(), ".artifacts/control-ui-e2e/attachment-announcement");
+
+suite.define(() => {
+  it.each(["ordinary", "completed"])(
+    "announces a long %s reply's named failure without announcing initial history",
+    async (flow) => {
+      await suite.withPage(
+        { locale: "en-US", serviceWorkers: "block", viewport: { width: 1280, height: 900 } },
+        async ({ page }) => {
+          const content = (label: string) => [
+            { type: "text", text: "Here is the requested summary. ".repeat(25) },
+            {
+              type: "attachment_error",
+              attachment: { code: "file-not-found", kind: "document", label },
+            },
+          ];
+          const existing = {
+            role: "assistant",
+            content: content("previous.pdf"),
+            timestamp: 1,
+            __openclaw: { id: "existing-reply", seq: 1 },
+          };
+          const gateway = await installMockGateway(page, { historyMessages: [existing] });
+          await page.goto(`${suite.server.baseUrl}chat`);
+          await page
+            .locator(".chat-assistant-attachment-card", { hasText: "previous.pdf" })
+            .waitFor();
+          const announcement = page.locator(".chat-transcript-announcement");
+          expect(await announcement.getAttribute("role")).toBe("status");
+          expect(await announcement.getAttribute("aria-live")).toBe("polite");
+          expect(await announcement.getAttribute("aria-atomic")).toBe("true");
+          expect(await announcement.textContent()).toBe("");
+          if (captureProof) {
+            await mkdir(proofDir, { recursive: true });
+            await page.screenshot({ path: path.join(proofDir, `${flow}-initial.png`) });
+          }
+
+          let runId: string | undefined;
+          if (flow === "completed") {
+            await page
+              .locator(".agent-chat__composer-combobox textarea")
+              .fill("Send the summary PDF");
+            await page.getByRole("button", { name: "Send message" }).click();
+            const request = await gateway.waitForRequest("chat.send");
+            expect(request.params).toMatchObject({
+              sessionKey: "main",
+              message: "Send the summary PDF",
+              deliver: false,
+              idempotencyKey: expect.any(String),
+            });
+            runId = (request.params as { idempotencyKey: string }).idempotencyKey;
+          }
+          const reply = {
+            role: "assistant",
+            content: content("missing.pdf"),
+            timestamp: Date.now(),
+            ...(runId ? { runId, phase: "final_answer" } : {}),
+            __openclaw: { id: "appended-reply", seq: 3 },
+          };
+          await gateway.setHistoryMessages([existing, reply]);
+          if (runId) {
+            await gateway.emitGatewayEvent("chat", {
+              message: reply,
+              runId,
+              sessionKey: "main",
+              state: "final",
+            });
+          } else {
+            await gateway.emitGatewayEvent("session.message", {
+              message: reply,
+              messageId: "appended-reply",
+              messageSeq: 3,
+              sessionKey: "main",
+              activeRunIds: [],
+              hasActiveRun: false,
+            });
+          }
+          const card = page.locator(".chat-assistant-attachment-card", { hasText: "missing.pdf" });
+          await card.waitFor();
+          await card.scrollIntoViewIfNeeded();
+          const cardText = await card.textContent();
+          expect(cardText).toContain("Not sent");
+          expect(cardText).toContain("File not found. Check the path and try again.");
+          await expect.poll(() => announcement.textContent()).not.toBe("");
+          const text = (await announcement.textContent()) ?? "";
+          if (captureProof) {
+            const stage = text.includes("missing.pdf") ? "after" : "before";
+            await page.screenshot({ path: path.join(proofDir, `${flow}-${stage}.png`) });
+            await writeFile(
+              path.join(proofDir, `${flow}-${stage}.json`),
+              JSON.stringify({ flow, text, length: text.length, card: cardText }, null, 2),
+            );
+          }
+          expect(text).toContain(
+            "missing.pdf: Not sent. File not found. Check the path and try again.",
+          );
+          expect(text).toContain("Here is the requested summary.");
+          expect(text.length).toBe(500);
+        },
+      );
+    },
+  );
+});

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -1749,109 +1749,155 @@ describe("chat transcript rendering", () => {
     );
   });
 
-  it("announces named attachment failures in ordinary and completed-run assistant rows", () => {
-    const transcript = createTestTranscript();
-    const container = document.createElement("div");
-    const existing = {
-      testVirtualRow: true,
-      testVirtualKey: "assistant-existing",
-      testVirtualRole: "assistant",
-      role: "assistant",
-      content: "Existing answer",
-    };
-    const renderMessages = (messages: unknown[]) =>
-      renderChatInto(container, { transcript, messages });
+  it.each(["ordinary", "active", "completed"])(
+    "announces named attachment failures within the cap in %s assistant rows",
+    (flow) => {
+      const transcript = createTestTranscript();
+      const container = document.createElement("div");
+      const existing = {
+        testVirtualRow: true,
+        testVirtualKey: "assistant-existing",
+        testVirtualRole: "assistant",
+        role: "assistant",
+        content: "Existing answer",
+      };
+      const renderMessages = (messages: unknown[]) =>
+        renderChatInto(container, { transcript, messages });
 
-    renderMessages([existing]);
-    const attachmentOnly = {
-      testVirtualRow: true,
-      testVirtualKey: "assistant-missing-attachment",
-      testVirtualRole: "assistant",
-      role: "assistant",
-      content: [
-        {
-          type: "attachment_error",
-          attachment: { code: "file-not-found", kind: "document", label: "missing.pdf" },
-        },
-      ],
-    };
-    renderMessages([existing, attachmentOnly]);
-    expect(container.querySelector(".chat-transcript-announcement")?.textContent).toBe(
-      "missing.pdf: Not sent. File not found. Check the path and try again.",
-    );
-
-    const mixed = {
-      testVirtualRow: true,
-      testVirtualKey: "assistant-mixed-attachments",
-      testVirtualRole: "assistant",
-      role: "assistant",
-      content: [
-        { type: "text", text: "Partial result" },
-        {
-          type: "attachment_error",
-          attachment: {
-            code: "unsupported-format",
-            kind: "document",
-            label: "settings.toml",
+      renderMessages([existing]);
+      expect(container.querySelector(".chat-transcript-announcement")?.textContent).toBe("");
+      const attachmentOnly = {
+        testVirtualRow: true,
+        testVirtualKey: "assistant-missing-attachment",
+        testVirtualRole: "assistant",
+        role: "assistant",
+        content: [
+          {
+            type: "attachment_error",
+            attachment: { code: "file-not-found", kind: "document", label: "missing.pdf" },
           },
-        },
-      ],
-    };
-    renderMessages([existing, attachmentOnly, mixed]);
-    expect(container.querySelector(".chat-transcript-announcement")?.textContent).toBe(
-      "Partial result settings.toml: Not sent. Rejected by the local attachment allowlist. Send a supported file type.",
-    );
+        ],
+      };
+      renderMessages([existing, attachmentOnly]);
+      expect(container.querySelector(".chat-transcript-announcement")?.textContent).toBe(
+        "missing.pdf: Not sent. File not found. Check the path and try again.",
+      );
 
-    const runBoundary = {
-      kind: "group" as const,
-      key: "group:user:attachment-run",
-      role: "user" as const,
-      messages: [
-        {
-          key: "user:attachment-run",
-          message: {
-            role: "user",
-            content: "Send the attachment",
-            __openclaw: {
-              id: "user:attachment-run",
-              idempotencyKey: "attachment-run:user",
+      const mixed = {
+        testVirtualRow: true,
+        testVirtualKey: "assistant-mixed-attachments",
+        testVirtualRole: "assistant",
+        role: "assistant",
+        content: [
+          { type: "text", text: "Partial result" },
+          {
+            type: "attachment_error",
+            attachment: {
+              code: "unsupported-format",
+              kind: "document",
+              label: "settings.toml",
             },
           },
-        },
-      ],
-      timestamp: 1,
-      isStreaming: false,
-    };
-    const completedFailure = {
-      kind: "group" as const,
-      key: "group:assistant:attachment-run",
-      role: "assistant" as const,
-      messages: [
-        {
-          key: "assistant:attachment-run",
-          message: {
-            role: "assistant",
-            content: attachmentOnly.content,
-            runId: "attachment-run",
+        ],
+      };
+      renderMessages([existing, attachmentOnly, mixed]);
+      const mixedAnnouncement = container.querySelector(
+        ".chat-transcript-announcement",
+      )?.textContent;
+
+      const runBoundary = {
+        kind: "group" as const,
+        key: "group:user:attachment-run",
+        role: "user" as const,
+        messages: [
+          {
+            key: "user:attachment-run",
+            message: {
+              role: "user",
+              content: "Send the attachment",
+              __openclaw: {
+                id: "user:attachment-run",
+                idempotencyKey: "attachment-run:user",
+              },
+            },
           },
-        },
-      ],
-      timestamp: 2,
-      isStreaming: false,
-      runId: "attachment-run",
-    };
-    vi.mocked(chatThread.buildCachedChatItems).mockReturnValue([
-      runBoundary,
-      completedFailure,
-    ] as ReturnType<typeof chatThread.buildCachedChatItems>);
-    renderChatInto(container, {
-      transcript,
-      messages: [runBoundary, completedFailure],
-    });
-    expect(container.querySelector(".chat-transcript-announcement")?.textContent).toBe(
-      "missing.pdf: Not sent. File not found. Check the path and try again.",
-    );
-  });
+        ],
+        timestamp: 1,
+        isStreaming: false,
+      };
+      const completedFailure = {
+        kind: "group" as const,
+        key: "group:assistant:attachment-run",
+        role: "assistant" as const,
+        messages: [
+          {
+            key: "assistant:attachment-run",
+            message: {
+              role: "assistant",
+              content: attachmentOnly.content,
+              runId: "attachment-run",
+            },
+          },
+        ],
+        timestamp: 2,
+        isStreaming: false,
+        runId: "attachment-run",
+      };
+      vi.mocked(chatThread.buildCachedChatItems).mockReturnValue([
+        runBoundary,
+        completedFailure,
+      ] as ReturnType<typeof chatThread.buildCachedChatItems>);
+      renderChatInto(container, {
+        transcript,
+        messages: [runBoundary, completedFailure],
+      });
+      expect(container.querySelector(".chat-transcript-announcement")?.textContent).toBe(
+        "missing.pdf: Not sent. File not found. Check the path and try again.",
+      );
+
+      for (const [index, prose] of [
+        "Here is the requested summary. ".repeat(25),
+        `${"x".repeat(430)}🦞${"y".repeat(100)}`,
+      ].entries()) {
+        const message = {
+          role: "assistant",
+          content: [{ type: "text", text: prose }, ...attachmentOnly.content],
+          runId: "attachment-run",
+        };
+        const reply = {
+          ...completedFailure,
+          key: `group:assistant:long-${index}`,
+          messages: [{ key: `assistant:long-${index}`, message }],
+          isStreaming: flow === "active",
+        };
+        const items = flow === "ordinary" ? [reply] : [runBoundary, reply];
+        vi.mocked(chatThread.buildCachedChatItems).mockReturnValue(items);
+        renderChatInto(container, { transcript, messages: items });
+        const announcement = expectDefined(
+          container.querySelector(".chat-transcript-announcement")?.textContent,
+          "attachment failure announcement",
+        );
+        expect(announcement).toContain(
+          "missing.pdf: Not sent. File not found. Check the path and try again.",
+        );
+        expect(announcement).toContain(prose.slice(0, 30));
+        expect(announcement.length).toBe(index === 0 ? 500 : 499);
+        expect(announcement).not.toMatch(/[\uD800-\uDFFF]/u);
+
+        vi.mocked(chatThread.buildCachedChatItems).mockReturnValue([
+          ...items.slice(0, -1),
+          { ...reply, messages: [{ key: `assistant:long-${index}`, message: mixed }] },
+        ]);
+        renderChatInto(container, { transcript, messages: [mixed] });
+        expect(container.querySelector(".chat-transcript-announcement")?.textContent).toBe(
+          announcement,
+        );
+      }
+      expect(mixedAnnouncement).toBe(
+        "settings.toml: Not sent. Rejected by the local attachment allowlist. Send a supported file type. Partial result",
+      );
+    },
+  );
 
   it("announces a run preamble and its later terminal answer separately", () => {
     const transcript = createTestTranscript();

--- a/ui/src/pages/chat/components/chat-transcript-announcement.ts
+++ b/ui/src/pages/chat/components/chat-transcript-announcement.ts
@@ -35,7 +35,7 @@ function assistantMessageAttachmentFailureText(message: unknown): string | null 
 function assistantMessageAnnouncementText(message: unknown): string | null {
   const text = extractTextCached(message)?.trim();
   const failureText = assistantMessageAttachmentFailureText(message);
-  return [text, failureText].filter(Boolean).join(" ") || null;
+  return [failureText, text].filter(Boolean).join(" ") || null;
 }
 
 function assistantGroupAnnouncementSource(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users relying on the Control UI's live announcements would hear only the reply prose when a long assistant answer also contained a failed attachment. The visible attachment card correctly said the file was not sent, but the bounded announcement could omit that outcome entirely.

## Why This Change Was Made

The canonical announcement composer now places the named, actionable attachment failure before ordinary reply text. Ordinary, active and completed-run rows share that owner, so the fix is a single ordering change with no extra state, fallback or configuration. The existing 500 UTF-16-unit cap, surrogate-safe truncation, quiet initial history and stable-message deduplication remain intact.

Production LOC: +1/-1 (net 0). Tests cover all three row paths plus the production-bundle browser flow. No layout, Gateway protocol, provider, delivery or persistence behavior changes.

Provenance: the prose-first composition was introduced in #131826 (merge 8bd895862d13c46618d8a331998970c2f3ea7180, 2026-08-28). Code author, PR author and merger: @vyctorbrzezowski. This repair preserves that PR's named failure cards. Separate pipeline-stage work in #131812 is unaffected.

## User Impact

Failed files are announced with their name, failure status and actionable reason even beside a long answer. Ordinary answer text still uses the remaining announcement budget. This is the release-note context for the fix.

## Evidence

Completed proof: all 310 chat-view tests; two focused attachment-rendering/normalization siblings; two Chromium E2E cases; the full three-path changed-file gate (including core-test/UI typechecking, lint, i18n and repository-wide guards); and an independent Codex review with no actionable findings.

The regression fails on the original composer in all three row paths. The real Chromium app with a mocked Gateway also fails before the fix for ordinary delivery and a completed composer-initiated run: the visible card is correct, but the 500-character live region contains only prose. After the repair, the live region starts with `missing.pdf: Not sent. File not found. Check the path and try again.` while staying within the same cap.

Browser proof observes the actual polite, atomic live-region DOM; it does not claim a real screen reader spoke the text or a live model/provider delivered a file. The signed-in Chrome relay is disconnected, so the browser proof uses isolated Chromium and synthetic fixtures.

The Vitest browser runs passed both assertions but emitted a slow-fork-shutdown warning. A separate recorded production-bundle run passed both flows and verified clean Chromium exit, closed owned port and removed temporary build directory. The warning remains a test-runner follow-up, not a product-failure claim. The first changed gate caught a test-library mismatch and a missing UI dependency link in the isolated checkout; both were corrected without changing dependencies, and the complete gate then passed.

Before (visible card already correct; live-region text omitted the failure):

![Before: attachment card beside long reply](https://github.com/user-attachments/assets/1b509d09-aef1-4c49-88a0-ac1a007b7cc6)

After (same visual layout; live-region text now begins with the failure):

![After: unchanged attachment card with corrected announcement](https://github.com/user-attachments/assets/4fc09805-4bbb-4cce-b0e8-5774f6195740)

Recorded composer-to-final flow (synthetic fixtures, unchanged visual layout):

https://github.com/user-attachments/assets/4ef09b08-191e-4cb9-90fa-a35fd64f4464
