### PR TITLE
fix(release): preserve package budget after native assets

### DIFF
--- a/scripts/lib/npm-pack-budget.mts
+++ b/scripts/lib/npm-pack-budget.mts
@@ -1,13 +1,8 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { resolveNpmJsonEntries } from "./npm-json-output.mts";
 
-// 2026.3.12 ballooned to ~213.6 MiB unpacked and correlated with low-memory
-// startup/doctor OOM reports. 2026.4.12 intentionally stages Matrix runtime
-// dependencies, including crypto wasm, so packaged installs do not miss Docker
-// and gateway runtime dependencies. Keep the budget below the 2026.3.12 bloat
-// level while allowing that mirrored runtime surface and the installed agent's
-// bundled user documentation.
-// Preserve the existing headroom after the accepted dual-layout fs-safe native payload.
+// The accepted dual-layout fs-safe native payload brings the package to ~231.8 MiB.
+// Keep narrow headroom for build variance while still catching renewed pack bloat.
 const NPM_PACK_UNPACKED_SIZE_BUDGET_BYTES = 235 * 1024 * 1024;
 
 function formatMiB(bytes: number): string {

--- a/scripts/lib/npm-pack-budget.mts
+++ b/scripts/lib/npm-pack-budget.mts
@@ -7,7 +7,8 @@ import { resolveNpmJsonEntries } from "./npm-json-output.mts";
 // and gateway runtime dependencies. Keep the budget below the 2026.3.12 bloat
 // level while allowing that mirrored runtime surface and the installed agent's
 // bundled user documentation.
-const NPM_PACK_UNPACKED_SIZE_BUDGET_BYTES = 204 * 1024 * 1024;
+// Preserve the existing headroom after the accepted dual-layout fs-safe native payload.
+const NPM_PACK_UNPACKED_SIZE_BUDGET_BYTES = 235 * 1024 * 1024;
 
 function formatMiB(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;

--- a/scripts/test-install-sh-docker.sh
+++ b/scripts/test-install-sh-docker.sh
@@ -118,7 +118,7 @@ const packJsonFile = process.argv[3];
 const raw = readFileSync(packJsonFile, "utf8") || "[]";
 const parsed = JSON.parse(raw);
 const budgetOverride = process.env.OPENCLAW_INSTALL_SMOKE_PACK_UNPACKED_BUDGET_BYTES;
-// Preserve the existing headroom after the accepted dual-layout fs-safe native payload.
+// Match release-check headroom above the accepted dual-layout fs-safe native payload.
 const budgetBytes = budgetOverride ? Number(budgetOverride) : 235 * 1024 * 1024;
 if (!Number.isFinite(budgetBytes)) {
   throw new Error(

--- a/scripts/test-install-sh-docker.sh
+++ b/scripts/test-install-sh-docker.sh
@@ -118,7 +118,8 @@ const packJsonFile = process.argv[3];
 const raw = readFileSync(packJsonFile, "utf8") || "[]";
 const parsed = JSON.parse(raw);
 const budgetOverride = process.env.OPENCLAW_INSTALL_SMOKE_PACK_UNPACKED_BUDGET_BYTES;
-const budgetBytes = budgetOverride ? Number(budgetOverride) : 204 * 1024 * 1024;
+// Preserve the existing headroom after the accepted dual-layout fs-safe native payload.
+const budgetBytes = budgetOverride ? Number(budgetOverride) : 235 * 1024 * 1024;
 if (!Number.isFinite(budgetBytes)) {
   throw new Error(
     `OPENCLAW_INSTALL_SMOKE_PACK_UNPACKED_BUDGET_BYTES must be numeric, got ${JSON.stringify(

--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -913,9 +913,9 @@ describe("collectPackUnpackedSizeErrors", () => {
 
   it("flags oversized pack results that risk low-memory startup failures", () => {
     expect(
-      collectPackUnpackedSizeErrors([makePackResult("openclaw-2026.3.12.tgz", 224_002_564)]),
+      collectPackUnpackedSizeErrors([makePackResult("openclaw-2026.3.12.tgz", 247_463_937)]),
     ).toEqual([
-      "openclaw-2026.3.12.tgz unpackedSize 224002564 bytes (213.6 MiB) exceeds budget 213909504 bytes (204.0 MiB). Investigate duplicate channel shims, copied extension trees, or other accidental pack bloat before release.",
+      "openclaw-2026.3.12.tgz unpackedSize 247463937 bytes (236.0 MiB) exceeds budget 246415360 bytes (235.0 MiB). Investigate duplicate channel shims, copied extension trees, or other accidental pack bloat before release.",
     ]);
   });
 

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -1250,7 +1250,7 @@ printf 'status=%s\\n' "$status"
 
     expect(script).toContain("assert_pack_unpacked_size_budget");
     expect(script).toContain('assert_pack_unpacked_size_budget "update" "$pack_json_file"');
-    expect(script).toContain("204 * 1024 * 1024");
+    expect(script).toContain("235 * 1024 * 1024");
     expect(script).toContain("install smoke cannot verify pack budget");
   });
 


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation rejects the current package at 231.8 MiB against the old 204 MiB unpacked-size ceiling. The package growth is not accidental bloat: #131939 added 32,466,720 bytes of explicitly accepted, two-layout fs-safe native assets, while both package-budget owners retained the pre-change ceiling.

## Why This Change Was Made

Raise both canonical release checks by exactly 31 MiB, from 204 MiB to 235 MiB. This absorbs only the accepted native payload and preserves approximately the same 3 MiB of headroom the old package had. The override, fail-closed missing-size behavior, and diagnostic remain unchanged.

## User Impact

No runtime or published-package bytes change. Release validation can accept the deliberately expanded package while continuing to detect future pack growth.

## Evidence

- Frozen candidate `4bc4ad35fa1cc665070f111a9f9e821689937835`: 243,103,642 bytes (231.8 MiB), rejected against 213,909,504 bytes (204 MiB) in [Release Checks 33209168017](https://github.com/openclaw/openclaw/actions/runs/33209168017/job/98980747836).
- Candidate inventory: `dist/native` + `dist/dist/native` contain 32,466,720 bytes, matching #131939's accepted package contract.
- The same candidate produces no budget errors under the repaired 246,415,360-byte ceiling.
- `node scripts/run-vitest.mjs test/release-check.test.ts test/scripts/test-install-sh-docker.test.ts --reporter=verbose`: 150 passed.
- `git diff --check`: passed.

Production LOC: +0/-0. Release tooling: +4/-2. Tests: +3/-3.

AI-assisted: yes.
