### PR TITLE
feat(hovercard): show the PR author beside the number

### DIFF
--- a/src/gateway/control-ui-contract.ts
+++ b/src/gateway/control-ui-contract.ts
@@ -66,6 +66,14 @@ type ControlUiSessionPullRequestChecks = {
 /** One GitHub pull request whose head is the session's working branch. */
 export type ControlUiSessionPullRequest = {
   number: number;
+  /**
+   * Author login from the list payload GitHub already returns; no extra call.
+   * Absent for a ghosted or deleted account. Deliberately login-only: the
+   * sibling GitHub-link hovercard inlines avatars server-side rather than
+   * hotlinking them, so a remote <img> here would leak a browser request to
+   * GitHub on every hover.
+   */
+  author?: { login: string };
   owner: string;
   repo: string;
   branch: string;

--- a/src/gateway/control-ui-session-prs.test.ts
+++ b/src/gateway/control-ui-session-prs.test.ts
@@ -97,6 +97,46 @@ describe("loadControlUiSessionPullRequests", () => {
     });
   });
 
+  it("carries the PR author from the list payload without another GitHub call", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      githubJson([
+        pullListItem({
+          merged_at: "2026-07-09T10:00:00Z",
+          user: {
+            login: "octocat",
+            avatar_url: "https://avatars.githubusercontent.com/u/583231?v=4",
+          },
+        }),
+      ]),
+    );
+
+    const result = await loadControlUiSessionPullRequests(
+      { sessionKey: "agent:main:main" },
+      { fetchImpl, resolveGitContext },
+    );
+
+    // Login only: avatar_url is deliberately dropped so the browser never hotlinks GitHub.
+    expect(result.pullRequests[0]?.author).toEqual({ login: "octocat" });
+    // Merged PRs skip the diff/checks calls, so the author must have come from the list.
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits the author when GitHub returns no user for the PR", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        githubJson([pullListItem({ merged_at: "2026-07-09T10:00:00Z", user: null })]),
+      );
+
+    const result = await loadControlUiSessionPullRequests(
+      { sessionKey: "agent:main:main" },
+      { fetchImpl, resolveGitContext },
+    );
+
+    expect(result.pullRequests).toHaveLength(1);
+    expect(result.pullRequests[0]?.author).toBeUndefined();
+  });
+
   it("retries stale optional authentication anonymously for session PRs", async () => {
     vi.stubEnv("GH_TOKEN", "stale-github-token");
     const fetchImpl = vi

--- a/src/gateway/control-ui-session-prs.test.ts
+++ b/src/gateway/control-ui-session-prs.test.ts
@@ -727,7 +727,10 @@ describe("loadControlUiSessionPullRequests", () => {
         headers: { "Content-Type": "application/json", "x-ratelimit-remaining": "0" },
       });
     const routes = [
-      { match: "/pulls?head=", response: () => githubJson([pullListItem()]) },
+      {
+        match: "/pulls?head=",
+        response: () => githubJson([pullListItem({ user: { login: "octocat" } })]),
+      },
       { match: "/pulls/103469", response: rateLimitedResponse },
       { match: "/check-runs", response: rateLimitedResponse },
     ];
@@ -748,6 +751,8 @@ describe("loadControlUiSessionPullRequests", () => {
         title: "fix(macos): tighten the link-browser tab header",
         url: "https://github.com/openclaw/openclaw/pull/103469",
         state: "open",
+        // The list fetch succeeded, so its author survives the degraded chip.
+        author: { login: "octocat" },
       },
     ]);
 

--- a/src/gateway/control-ui-session-prs.ts
+++ b/src/gateway/control-ui-session-prs.ts
@@ -56,6 +56,7 @@ type PullListItem = {
   owner: string;
   repo: string;
   state: ControlUiSessionPullRequest["state"];
+  author?: ControlUiSessionPullRequest["author"];
   headSha?: string;
   baseRef?: string;
   mergeCommitSha?: string;
@@ -351,6 +352,8 @@ function parsePullListItem(value: unknown): PullListItem | null {
   if (!number || !Number.isSafeInteger(number) || number < 1 || !title || !url || !owner || !repo) {
     return null;
   }
+  const user = isRecord(value.user) ? value.user : {};
+  const authorLogin = readOptionalGitHubString(user, "login");
   return {
     number,
     title,
@@ -358,6 +361,7 @@ function parsePullListItem(value: unknown): PullListItem | null {
     owner,
     repo,
     state: derivePullState(value),
+    ...(authorLogin ? { author: { login: authorLogin } } : {}),
     headSha: readOptionalGitHubString(head, "sha"),
     baseRef: readOptionalGitHubString(base, "ref"),
     mergeCommitSha: readOptionalGitHubString(value, "merge_commit_sha"),
@@ -490,6 +494,7 @@ async function finishPullRequest(
     title: item.title,
     url: item.url,
     state: item.state,
+    ...(item.author ? { author: item.author } : {}),
   };
   // Merged/closed chips render state only; diff counts and CI rollup are
   // live-work signals, so spend GitHub quota on open PRs alone.

--- a/src/gateway/control-ui-session-prs.ts
+++ b/src/gateway/control-ui-session-prs.ts
@@ -480,13 +480,12 @@ async function fetchChecks(
   }
 }
 
-async function finishPullRequest(
-  item: PullListItem,
-  branch: string,
-  fetchImpl: typeof fetch,
-  token: string | undefined,
-): Promise<ControlUiSessionPullRequest> {
-  const chip: ControlUiSessionPullRequest = {
+/**
+ * The facts a chip carries without spending quota on per-PR detail calls. The
+ * rate-limited path renders exactly this, so both callers share one shape.
+ */
+function stateOnlyPullRequestChip(item: PullListItem, branch: string): ControlUiSessionPullRequest {
+  return {
     number: item.number,
     owner: item.owner,
     repo: item.repo,
@@ -496,6 +495,15 @@ async function finishPullRequest(
     state: item.state,
     ...(item.author ? { author: item.author } : {}),
   };
+}
+
+async function finishPullRequest(
+  item: PullListItem,
+  branch: string,
+  fetchImpl: typeof fetch,
+  token: string | undefined,
+): Promise<ControlUiSessionPullRequest> {
+  const chip = stateOnlyPullRequestChip(item, branch);
   // Merged/closed chips render state only; diff counts and CI rollup are
   // live-work signals, so spend GitHub quota on open PRs alone.
   if (item.state !== "open" && item.state !== "draft") {
@@ -561,15 +569,9 @@ async function fetchBranchPullRequests(
     // keep the proven PR list as state-only chips instead of dropping it, or
     // a cold cache would show a Create PR row despite a known open PR.
     return {
-      pullRequests: capped.map((item) => ({
-        number: item.number,
-        owner: item.owner,
-        repo: item.repo,
-        branch: context.branch,
-        title: item.title,
-        url: item.url,
-        state: item.state,
-      })),
+      // Author and title came from the list fetch that already succeeded, so
+      // they survive here; only the per-PR detail facts are missing.
+      pullRequests: capped.map((item) => stateOnlyPullRequestChip(item, context.branch)),
       rateLimited: true,
       mergedHeads,
     };

--- a/ui/src/components/session-hovercard.test.ts
+++ b/ui/src/components/session-hovercard.test.ts
@@ -138,6 +138,47 @@ describe("renderSessionHovercard", () => {
     expect(container.querySelector("openclaw-viewer-avatar")).toBeNull();
   });
 
+  it("shows the PR author beside the number and omits it for a ghosted account", () => {
+    const container = document.createElement("div");
+    render(
+      renderSessionHovercard({
+        pullRequests: snapshot({
+          pullRequests: [
+            {
+              number: 201,
+              owner: "openclaw",
+              repo: "openclaw",
+              branch: "feature",
+              title: "Authored",
+              url: "https://github.com/openclaw/openclaw/pull/201",
+              state: "open",
+              author: { login: "octocat" },
+            },
+            {
+              number: 202,
+              owner: "openclaw",
+              repo: "openclaw",
+              branch: "feature",
+              title: "Ghosted",
+              url: "https://github.com/openclaw/openclaw/pull/202",
+              state: "merged",
+            },
+          ],
+        }),
+      }),
+      container,
+    );
+
+    const links = [...container.querySelectorAll<HTMLAnchorElement>(".session-hovercard__pr-row")];
+    expect(links[0]?.querySelector(".session-hovercard__pr-author")?.textContent?.trim()).toBe(
+      "octocat",
+    );
+    expect(links[0]?.getAttribute("aria-label")).toContain("Opened by octocat");
+    // A deleted or ghosted GitHub account leaves the row exactly as it was before.
+    expect(links[1]?.querySelector(".session-hovercard__pr-author")).toBeNull();
+    expect(links[1]?.getAttribute("aria-label")).not.toContain("Opened by");
+  });
+
   it("renders bounded flat PR rows with accessible state, CI, and diff facts", () => {
     const container = document.createElement("div");
     render(

--- a/ui/src/components/session-hovercard.test.ts
+++ b/ui/src/components/session-hovercard.test.ts
@@ -174,8 +174,12 @@ describe("renderSessionHovercard", () => {
       "octocat",
     );
     expect(links[0]?.getAttribute("aria-label")).toContain("Opened by octocat");
-    // A deleted or ghosted GitHub account leaves the row exactly as it was before.
-    expect(links[1]?.querySelector(".session-hovercard__pr-author")).toBeNull();
+    // A ghosted account keeps an empty author cell so the row geometry, and the
+    // flush-right diff column, match an authored row.
+    expect(links[1]?.querySelector(".session-hovercard__pr-author")?.textContent).toBe("");
+    expect(links[1]?.querySelector(".session-hovercard__pr-author")?.hasAttribute("title")).toBe(
+      false,
+    );
     expect(links[1]?.getAttribute("aria-label")).not.toContain("Opened by");
   });
 

--- a/ui/src/components/session-hovercard.ts
+++ b/ui/src/components/session-hovercard.ts
@@ -391,8 +391,11 @@ function renderSessionContext({
 }
 
 function renderPullRequestAuthor(author: ControlUiSessionPullRequest["author"]) {
+  // Each row is its own grid, so the cell is always emitted: dropping it would
+  // move the diff stats out of the trailing 1fr column and break the flush-right
+  // alignment that authored and authorless rows must share.
   if (!author) {
-    return nothing;
+    return html`<span class="session-hovercard__pr-author"></span>`;
   }
   return html`<span
     class="session-hovercard__pr-author"

--- a/ui/src/components/session-hovercard.ts
+++ b/ui/src/components/session-hovercard.ts
@@ -390,10 +390,24 @@ function renderSessionContext({
   </div>`;
 }
 
+function renderPullRequestAuthor(author: ControlUiSessionPullRequest["author"]) {
+  if (!author) {
+    return nothing;
+  }
+  return html`<span
+    class="session-hovercard__pr-author"
+    title=${t("sessionHovercard.pullRequestAuthorLabel", { login: author.login })}
+    >${author.login}</span
+  >`;
+}
+
 function renderPullRequestRow(pullRequest: ControlUiSessionPullRequest) {
   const state = pullRequestStateLabel(pullRequest.state);
   const checks = pullRequest.checks ? checksLabel(pullRequest.checks) : null;
   const details = [
+    pullRequest.author
+      ? t("sessionHovercard.pullRequestAuthorLabel", { login: pullRequest.author.login })
+      : null,
     checks,
     pullRequest.changedFiles === undefined ? null : changedFilesLabel(pullRequest.changedFiles),
     pullRequest.additions === undefined ? null : `+${pullRequest.additions.toLocaleString()}`,
@@ -419,7 +433,7 @@ function renderPullRequestRow(pullRequest: ControlUiSessionPullRequest) {
       >${pullRequestStateIcon(pullRequest.state)}</span
     >
     <span class="session-hovercard__pr-number">#${pullRequest.number}</span>
-    ${renderDiffStats(pullRequest)}
+    ${renderPullRequestAuthor(pullRequest.author)}${renderDiffStats(pullRequest)}
   </a>`;
 }
 

--- a/ui/src/e2e/session-progress-hovercard.e2e.test.ts
+++ b/ui/src/e2e/session-progress-hovercard.e2e.test.ts
@@ -68,6 +68,7 @@ async function emitPullRequestSnapshot(
             state: "open",
             title: "Restore the session hovercard",
             url: "https://github.com/openclaw/openclaw/pull/417",
+            author: { login: "steipete" },
           },
           {
             additions: 72,
@@ -334,6 +335,9 @@ suite.define(() => {
           .poll(() => card.locator(".session-progress-card__heading").textContent())
           .toContain("1/3");
         await expect.poll(() => card.locator(".session-hovercard__pr-row").count()).toBe(4);
+        await expect
+          .poll(() => card.locator(".session-hovercard__pr-author").first().textContent())
+          .toBe("steipete");
         await captureProof(page, "sidebar-row-hovercard-maximum.png");
         await expect
           .poll(() => card.locator(".session-hovercard__identity-row").textContent())

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -217,6 +217,7 @@ export const en: TranslationMap = {
     changedFile: "{count} file",
     changedFiles: "{count} files",
     pullRequestLabel: "Pull request #{number}, {state}",
+    pullRequestAuthorLabel: "Opened by {login}",
     states: {
       open: "Open",
       draft: "Draft",

--- a/ui/src/styles/chat/progress-card.css
+++ b/ui/src/styles/chat/progress-card.css
@@ -244,7 +244,8 @@
 
 .session-hovercard__pr-row {
   display: grid;
-  /* Author column is auto so a row without an author keeps the original layout. */
+  /* The author cell is always present (empty when unknown) so every row shares
+     one geometry and the diff stats stay in the trailing 1fr column. */
   grid-template-columns: var(--session-hovercard-context-icon-size) auto auto minmax(0, 1fr);
   align-items: center;
   column-gap: var(--space-2);

--- a/ui/src/styles/chat/progress-card.css
+++ b/ui/src/styles/chat/progress-card.css
@@ -230,10 +230,9 @@
   place-items: center;
 }
 
-.session-hovercard__pr-row,
 .session-hovercard__branch-row {
   display: grid;
-  grid-template-columns: var(--session-hovercard-context-icon-size) auto minmax(0, 1fr);
+  grid-template-columns: var(--session-hovercard-context-icon-size) minmax(0, 1fr) auto;
   align-items: center;
   column-gap: var(--space-2);
   min-width: 0;
@@ -244,14 +243,16 @@
 }
 
 .session-hovercard__pr-row {
+  display: grid;
+  /* Author column is auto so a row without an author keeps the original layout. */
+  grid-template-columns: var(--session-hovercard-context-icon-size) auto auto minmax(0, 1fr);
+  align-items: center;
+  column-gap: var(--space-2);
+  min-width: 0;
   font-family: var(--mono);
   font-size: var(--control-ui-text-xs);
   font-variant-numeric: tabular-nums;
   line-height: 1.35;
-}
-
-.session-hovercard__branch-row {
-  grid-template-columns: var(--session-hovercard-context-icon-size) minmax(0, 1fr) auto;
 }
 
 .session-hovercard__pr-state-icon,
@@ -310,6 +311,15 @@
 
 .session-hovercard__pr-state-icon {
   color: var(--session-pr-state-color, var(--muted));
+}
+
+.session-hovercard__pr-author {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 12ch;
+  color: var(--muted);
 }
 
 .session-hovercard__pr-row .session-hovercard__diff {


### PR DESCRIPTION
## What Problem This Solves

Session hovercard PR rows showed number, state, and diff stats only. A session touching several people's pull requests gave no hint who opened each one, so the rows read as anonymous work items — you had to open GitHub to answer "whose PR is this?".

## Why This Change Was Made

GitHub's pull list payload already includes `user`, and `parsePullListItem` was discarding it. Carrying the login through costs no extra API call and no additional GitHub quota, which matters on a hover surface that already has a rate-limit path.

The author is **login only, no avatar**, and that is the deliberate part. The sibling GitHub-link hovercard inlines avatars as data URLs fetched server-side rather than hotlinking them, so adding a remote `<img>` here would have leaked a browser request to GitHub on every hover — inconsistent with the neighbouring surface and a privacy regression for a passive UI element. I built the avatar version first, saw the mismatch against the sibling implementation, and removed it.

Co-authors are intentionally not fetched. They live in `Co-authored-by` commit trailers, so surfacing them means listing commits per PR — N extra calls per session on a quota-sensitive path. The hovercard's existing "with X, Y" participant list already carries who worked on the session, which for sessions we author is the same set of humans the trailers credit.

## User Impact

Each PR row in the session hovercard now reads `#417  steipete  7 files +128 −34`. Rows for a ghosted or deleted GitHub account render exactly as before. The login is in the row's accessible name as "Opened by {login}", and the author column is `auto`, so an authorless row keeps the original layout.

Production delta is +21 lines across four files; the rest is tests.

## Evidence

**Before** — PR rows carry no author.

![Before: hovercard PR rows without an author](https://github.com/user-attachments/assets/cde7fe1f-dc75-483a-9a5a-1e4c127ec9de)

**After** — `#417` shows its author beside the number.

![After: hovercard PR row showing the author login](https://github.com/user-attachments/assets/b29bdd0b-0560-49ae-9c5b-8fb57664cbda)

Both captured from the real Control UI in Chromium through the mocked-gateway E2E lane (`ui/src/e2e/session-progress-hovercard.e2e.test.ts`, `OPENCLAW_CAPTURE_UI_PROOF=1`). The "before" shot renders the same scenario against this branch's parent commit with both the component and the stylesheet reverted — an earlier revision of this PR posted a "before" that had reverted only the component while keeping the new CSS, which made authorless rows look misaligned in a way main never was. Note in the corrected pair that rows #418–#420 sit identically in both shots.

Local proof:

- `node scripts/run-vitest.mjs src/gateway/control-ui-session-prs.test.ts` — 21 passed, including a test asserting the author arrives from the list payload with exactly one fetch (merged PRs skip the diff/checks calls, so a second call would mean the author came from somewhere else), and one asserting a null `user` yields no author.
- `node scripts/run-vitest.mjs ui/src/components/session-hovercard.test.ts` — 17 passed, including author rendering, the accessible name, and the ghosted-account row.
- `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs ui/src/e2e/session-progress-hovercard.e2e.test.ts` — 8 passed.
- `node scripts/check-changed.mjs` — exit 0.
- Codex autoreview — no accepted or actionable findings.

Two self-inflicted gate failures were fixed rather than suppressed: my E2E addition pushed that file one line past the `max-lines` cap (tightened my own assertion instead of adding a suppression, which this repo bans), and splitting the shared `pr-row, branch-row` CSS rule left `.session-hovercard__branch-row` declared twice, which stylelint caught. The branch-row fix folds its later override into its base rule; the computed value is unchanged, since that override already won the cascade. jsdom does not apply stylesheets, so no test can assert grid columns — the equivalence is by construction and stated here rather than left implicit.

## Unblocking main

Main was already failing its own Control UI startup-JS budget before this branch. Measured directly: this PR's parent commit builds to 347441 B against a 347037 B enforcement limit, and main's own CI run on `a353550235a` fails the identical four jobs (`build-artifacts`, `checks-node-compact-large-1`, `checks-node-compact-large-6`, `openclaw/ci-gate`).

This change contributes 2 B of that — 347441 B at the parent versus 347443 B with the hovercard author.

The cause is not a single regression: 51 UI changes landed after the [#131602](https://github.com/openclaw/openclaw/pull/131602) baseline, each inside the 512 B per-change tolerance but roughly 980 B cumulatively, which is exactly the accumulation `check-control-ui-performance.mts` documents in its own tolerance comment. So the second commit re-records the baseline rather than reverting anything. Baseline growth is not self-approvable in this repo; this one is maintainer-approved.

## Review follow-ups

ClawSweeper raised two P2 findings on the first revision and both were real; `1877a57` fixes them.

The rate-limited path rebuilt each chip from a hand-written literal and dropped the author, so the login disappeared exactly when the UI was already degraded — even though it came from the list fetch that had already succeeded. That literal duplicated the one in `finishPullRequest`, so both now share `stateOnlyPullRequestChip` and the shape can no longer drift. Its regression test is the existing rate-limit test, extended to carry an author rather than a new near-duplicate case.

The author cell is now always emitted, empty for a ghosted account. Each PR row is its own grid container, so omitting the cell moved the diff stats out of the trailing `1fr` column and broke the flush-right alignment authored and authorless rows have to share. My original comment claimed an `auto` column preserved the old layout; that was wrong, and the misalignment was visible in the screenshot I had already reviewed and passed.
