### PR TITLE
fix(line): give the agent the names LINE knows, not raw ids

### DIFF
--- a/docs/channels/line.md
+++ b/docs/channels/line.md
@@ -185,6 +185,12 @@ as untrusted.
 - Media downloads are capped by `channels.line.mediaMaxMb` (default 10).
 - Inbound media is saved under `~/.openclaw/media/inbound/` before it is passed
   to the agent, matching the shared media store used by other channel plugins.
+- LINE webhooks carry ids but no names, so the sender's display name and the
+  group's name are fetched once and cached for five minutes. Group and room
+  members are read through their conversation, which is the only way to see a
+  member who has not added the bot as a friend. If either lookup fails the raw
+  id is used and the message is still delivered. Multi-person rooms have no name
+  API, so they keep their room id.
 
 ## Structured rich messages
 

--- a/extensions/line/src/bot-handlers.join-intro.test.ts
+++ b/extensions/line/src/bot-handlers.join-intro.test.ts
@@ -139,7 +139,12 @@ describe("LINE group join introductions", () => {
 
   it("keeps an honest thin snapshot when the group summary request fails", async () => {
     getGroupSummary.mockRejectedValue(new Error("LINE unavailable"));
-    await handleLineWebhookEvents([joinEvent(sources[0])], createContext());
+    // A group nothing has resolved before, so the answer comes from this failed
+    // request rather than a name the name cache still remembers.
+    await handleLineWebhookEvents(
+      [joinEvent({ type: "group", groupId: `C${"d".repeat(32)}` })],
+      createContext(),
+    );
 
     const params = reportJoin.mock.calls[0]?.[0];
     if (!params) {

--- a/extensions/line/src/bot-handlers.test.ts
+++ b/extensions/line/src/bot-handlers.test.ts
@@ -861,36 +861,66 @@ describe("handleLineWebhookEvents", () => {
     expect(buildLineMessageContextMock).not.toHaveBeenCalled();
   });
 
-  it("records unmentioned group messages as pending history", async () => {
+  it("keeps matching display names distinct in pending group history", async () => {
     const processMessage = vi.fn();
     const groupHistories = new Map<string, HistoryEntry[]>();
-    getUserDisplayNameMock.mockResolvedValueOnce("Sora");
-    const event = createTestMessageEvent({
-      message: { id: "m-hist-1", type: "text", text: "hello history", quoteToken: "q-hist-1" },
-      timestamp: 1700000000000,
-      source: { type: "group", groupId: "group-hist-1", userId: "user-hist" },
-      webhookEventId: "evt-hist-1",
+    getUserDisplayNameMock.mockResolvedValue("Sora");
+    const context = createLineWebhookTestContext({
+      processMessage,
+      groupPolicy: "open",
+      requireMention: true,
+      groupHistories,
     });
 
     await handleLineWebhookEvents(
-      [event],
-      createLineWebhookTestContext({
-        processMessage,
-        groupPolicy: "open",
-        groupHistories,
-      }),
+      [
+        createTestMessageEvent({
+          message: { id: "m-hist-1", type: "text", text: "first", quoteToken: "q-hist-1" },
+          timestamp: 1700000000000,
+          source: { type: "group", groupId: "group-hist-1", userId: "user-one" },
+          webhookEventId: "evt-hist-1",
+        }),
+        createTestMessageEvent({
+          message: { id: "m-hist-2", type: "text", text: "second", quoteToken: "q-hist-2" },
+          timestamp: 1700000001000,
+          source: { type: "group", groupId: "group-hist-1", userId: "user-two" },
+          webhookEventId: "evt-hist-2",
+        }),
+      ],
+      context,
     );
 
     expect(processMessage).not.toHaveBeenCalled();
-    const entries = groupHistories.get("group-hist-1");
-    expect(entries).toHaveLength(1);
-    const entry = entries?.[0];
-    expect(entry?.sender).toBe("Sora");
-    expect(entry?.body).toBe("hello history");
-    expect(entry?.timestamp).toBe(1700000000000);
-    expect(getUserDisplayNameMock).toHaveBeenCalledWith(
-      "user-hist",
-      expect.objectContaining({ groupId: "group-hist-1" }),
+    expect(groupHistories.get("group-hist-1")).toEqual([
+      expect.objectContaining({ sender: "Sora (user-one)", body: "first" }),
+      expect.objectContaining({ sender: "Sora (user-two)", body: "second" }),
+    ]);
+
+    await handleLineWebhookEvents(
+      [
+        createTestMessageEvent({
+          message: {
+            id: "m-hist-mention",
+            type: "text",
+            text: "@Bot summarize",
+            quoteToken: "q-hist-mention",
+            mention: { mentionees: [{ index: 0, length: 4, type: "user", isSelf: true }] },
+          },
+          timestamp: 1700000002000,
+          source: { type: "group", groupId: "group-hist-1", userId: "user-three" },
+          webhookEventId: "evt-hist-mention",
+        }),
+      ],
+      context,
+    );
+
+    expect(buildLineMessageContextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        inboundHistory: [
+          expect.objectContaining({ sender: "Sora (user-one)", body: "first" }),
+          expect.objectContaining({ sender: "Sora (user-two)", body: "second" }),
+        ],
+      }),
     );
   });
 

--- a/extensions/line/src/bot-handlers.test.ts
+++ b/extensions/line/src/bot-handlers.test.ts
@@ -155,6 +155,7 @@ const { readAllowFromStoreMock, upsertPairingRequestMock } = vi.hoisted(() => ({
   upsertPairingRequestMock: vi.fn(async (_args: unknown) => ({ code: "CODE", created: true })),
 }));
 const downloadLineMediaMock = vi.hoisted(() => vi.fn());
+const getUserDisplayNameMock = vi.hoisted(() => vi.fn(async (userId: string) => userId));
 
 vi.mock("openclaw/plugin-sdk/conversation-runtime", () => ({
   resolvePairingIdLabel: () => "lineUserId",
@@ -168,6 +169,8 @@ vi.mock("./download.js", async (importActual) => ({
 }));
 
 vi.mock("./send.js", () => ({
+  getLineGroupName: vi.fn(),
+  getUserDisplayName: getUserDisplayNameMock,
   pushMessageLine: pairingDeliveryMocks.pushMessageLine,
   replyMessageLine: pairingDeliveryMocks.replyMessageLine,
 }));
@@ -351,6 +354,8 @@ describe("handleLineWebhookEvents", () => {
     downloadLineMediaMock.mockImplementation(async () => {
       throw new Error("downloadLineMedia should not be called from bot-handlers tests");
     });
+    getUserDisplayNameMock.mockReset();
+    getUserDisplayNameMock.mockImplementation(async (userId: string) => userId);
   });
   it("blocks group messages when groupPolicy is disabled", async () => {
     const processMessage = vi.fn();
@@ -859,6 +864,7 @@ describe("handleLineWebhookEvents", () => {
   it("records unmentioned group messages as pending history", async () => {
     const processMessage = vi.fn();
     const groupHistories = new Map<string, HistoryEntry[]>();
+    getUserDisplayNameMock.mockResolvedValueOnce("Sora");
     const event = createTestMessageEvent({
       message: { id: "m-hist-1", type: "text", text: "hello history", quoteToken: "q-hist-1" },
       timestamp: 1700000000000,
@@ -879,9 +885,13 @@ describe("handleLineWebhookEvents", () => {
     const entries = groupHistories.get("group-hist-1");
     expect(entries).toHaveLength(1);
     const entry = entries?.[0];
-    expect(entry?.sender).toBe("user:user-hist");
+    expect(entry?.sender).toBe("Sora");
     expect(entry?.body).toBe("hello history");
     expect(entry?.timestamp).toBe(1700000000000);
+    expect(getUserDisplayNameMock).toHaveBeenCalledWith(
+      "user-hist",
+      expect.objectContaining({ groupId: "group-hist-1" }),
+    );
   });
 
   it("keeps a group message recorded during a mention turn instead of clearing it", async () => {

--- a/extensions/line/src/bot-handlers.ts
+++ b/extensions/line/src/bot-handlers.ts
@@ -49,7 +49,7 @@ import {
 import { downloadLineMedia, isRetryableLineInboundMediaError } from "./download.js";
 import { reserveLineGroupHistory } from "./group-history.js";
 import { resolveLineGroupConfigEntry } from "./group-keys.js";
-import { getLineGroupName, pushMessageLine, replyMessageLine } from "./send.js";
+import { getLineGroupName, getUserDisplayName, pushMessageLine, replyMessageLine } from "./send.js";
 import type { LineGroupConfig, ResolvedLineAccount } from "./types.js";
 import type { LineWebhookTurnAdoptionLifecycle } from "./webhook-spool.js";
 
@@ -399,11 +399,20 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
     const historyKey = groupId ?? roomId;
     const senderId = sourceInfo.userId ?? "unknown";
     if (historyKey && context.groupHistories) {
+      const sender = sourceInfo.userId
+        ? await getUserDisplayName(sourceInfo.userId, {
+            cfg,
+            accountId: account.accountId,
+            channelAccessToken: account.channelAccessToken,
+            groupId,
+            roomId,
+          })
+        : senderId;
       createChannelHistoryWindow({ historyMap: context.groupHistories }).record({
         historyKey,
         limit: context.historyLimit ?? DEFAULT_GROUP_HISTORY_LIMIT,
         entry: {
-          sender: `user:${senderId}`,
+          sender,
           body: rawText || `<${message.type}>`,
           timestamp: event.timestamp,
         },

--- a/extensions/line/src/bot-handlers.ts
+++ b/extensions/line/src/bot-handlers.ts
@@ -399,7 +399,7 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
     const historyKey = groupId ?? roomId;
     const senderId = sourceInfo.userId ?? "unknown";
     if (historyKey && context.groupHistories) {
-      const sender = sourceInfo.userId
+      const displayName = sourceInfo.userId
         ? await getUserDisplayName(sourceInfo.userId, {
             cfg,
             accountId: account.accountId,
@@ -408,6 +408,8 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
             roomId,
           })
         : senderId;
+      // History has one sender string; keep the stable ID when display names collide.
+      const sender = displayName === senderId ? senderId : `${displayName} (${senderId})`;
       createChannelHistoryWindow({ historyMap: context.groupHistories }).record({
         historyKey,
         limit: context.historyLimit ?? DEFAULT_GROUP_HISTORY_LIMIT,

--- a/extensions/line/src/bot-handlers.ts
+++ b/extensions/line/src/bot-handlers.ts
@@ -49,7 +49,7 @@ import {
 import { downloadLineMedia, isRetryableLineInboundMediaError } from "./download.js";
 import { reserveLineGroupHistory } from "./group-history.js";
 import { resolveLineGroupConfigEntry } from "./group-keys.js";
-import { getLineGroupSummary, pushMessageLine, replyMessageLine } from "./send.js";
+import { getLineGroupName, pushMessageLine, replyMessageLine } from "./send.js";
 import type { LineGroupConfig, ResolvedLineAccount } from "./types.js";
 import type { LineWebhookTurnAdoptionLifecycle } from "./webhook-spool.js";
 
@@ -535,19 +535,14 @@ async function handleJoinEvent(event: JoinEvent, context: LineHandlerContext): P
     resolveRoomContext: async () => {
       // LINE cannot retrieve prior messages, and multi-person rooms have no name API.
       const roomContext = { historyUnavailable: true };
-      if (!groupId) {
-        return roomContext;
-      }
-      try {
-        const summary = await getLineGroupSummary(groupId, {
-          cfg,
-          accountId: account.accountId,
-          channelAccessToken: account.channelAccessToken,
-        });
-        return { ...roomContext, title: summary.groupName };
-      } catch {
-        return roomContext;
-      }
+      const title = groupId
+        ? await getLineGroupName(groupId, {
+            cfg,
+            accountId: account.accountId,
+            channelAccessToken: account.channelAccessToken,
+          })
+        : undefined;
+      return title ? { ...roomContext, title } : roomContext;
     },
   });
 }

--- a/extensions/line/src/bot-message-context.test.ts
+++ b/extensions/line/src/bot-message-context.test.ts
@@ -111,6 +111,8 @@ describe("buildLineMessageContext", () => {
 
   beforeEach(async () => {
     logVerboseMock.mockClear();
+    getUserProfileMock.mockClear();
+    getLineGroupNameMock.mockClear();
     toInboundMediaFactsWithMetadataMock.mockClear();
     setActivePluginRegistry(
       createTestRegistry([

--- a/extensions/line/src/bot-message-context.test.ts
+++ b/extensions/line/src/bot-message-context.test.ts
@@ -18,6 +18,10 @@ import { buildLineMessageContext, buildLinePostbackContext } from "./bot-message
 import type { ResolvedLineAccount } from "./types.js";
 
 const logVerboseMock = vi.hoisted(() => vi.fn());
+const getUserProfileMock = vi.hoisted(() =>
+  vi.fn(async () => null as { displayName: string } | null),
+);
+const getLineGroupNameMock = vi.hoisted(() => vi.fn(async () => undefined as string | undefined));
 const toInboundMediaFactsWithMetadataMock = vi.hoisted(() => vi.fn());
 
 vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
@@ -28,6 +32,14 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
     toInboundMediaFactsWithMetadata: toInboundMediaFactsWithMetadataMock,
   };
 });
+
+// Names are LINE API reads; the context under test only cares what it does with
+// the answers, so the two lookups are stubbed and the default answer is "unknown",
+// which is what an unreachable or unauthorized LINE account produces.
+vi.mock("./send.js", () => ({
+  getUserProfile: getUserProfileMock,
+  getLineGroupName: getLineGroupNameMock,
+}));
 
 vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/runtime-env")>(
@@ -188,7 +200,12 @@ describe("buildLineMessageContext", () => {
       account,
       commandAuthorized: true,
     });
-    const baselineLog = String(logVerboseMock.mock.calls[0]?.[0]);
+    // Identity lookups log their own misses, so select the preview line by shape
+    // rather than by call order.
+    const baselineLog =
+      logVerboseMock.mock.calls
+        .map((call) => String(call[0]))
+        .find((line) => line.includes('preview="')) ?? "";
     const baselinePreview = baselineLog.match(/preview="(.*)"$/)?.[1] ?? "";
     const markerIndex = baselinePreview.indexOf("BODY_MARKER");
     expect(markerIndex).toBeGreaterThanOrEqual(0);
@@ -625,5 +642,68 @@ describe("buildLineMessageContext", () => {
     expect(context?.route.agentId).toBe("codex");
     expect(context?.route.sessionKey).toBe("agent:codex:acp:binding:line:default:test123");
     expect(context?.route.matchedBy).toBe("binding.channel");
+  });
+
+  it("gives the agent the sender's and the group's name instead of their ids", async () => {
+    getUserProfileMock.mockResolvedValueOnce({ displayName: "Sora" });
+    getLineGroupNameMock.mockResolvedValueOnce("Release Squad");
+
+    const event = createMessageEvent({
+      type: "group",
+      groupId: "C5aeb18d690759492f1a8c391c37549a0",
+      userId: "U47f0bbc534dc503c4e4cadc86e619b63",
+    });
+    const context = await buildLineMessageContext({
+      event,
+      allMedia: [],
+      cfg,
+      account,
+      commandAuthorized: true,
+    });
+
+    expect(context?.ctxPayload.SenderName).toBe("Sora");
+    expect(context?.ctxPayload.GroupSubject).toBe("Release Squad");
+    expect(context?.ctxPayload.ConversationLabel).toBe("Release Squad");
+    // The envelope the agent reads names the speaker rather than their raw id.
+    expect(context?.ctxPayload.Body).toContain("Sora");
+    expect(context?.ctxPayload.Body).not.toContain("user:U47f0bbc534dc503c4e4cadc86e619b63");
+  });
+
+  it("falls back to the raw ids when LINE will not name the sender or the group", async () => {
+    const event = createMessageEvent({
+      type: "group",
+      groupId: "C5aeb18d690759492f1a8c391c37549a0",
+      userId: "U47f0bbc534dc503c4e4cadc86e619b63",
+    });
+    const context = await buildLineMessageContext({
+      event,
+      allMedia: [],
+      cfg,
+      account,
+      commandAuthorized: true,
+    });
+
+    expect(context?.ctxPayload.SenderName).toBeUndefined();
+    expect(context?.ctxPayload.GroupSubject).toBe("C5aeb18d690759492f1a8c391c37549a0");
+  });
+
+  it("asks LINE for the sender's profile through the conversation they wrote in", async () => {
+    const event = createMessageEvent({
+      type: "group",
+      groupId: "C5aeb18d690759492f1a8c391c37549a0",
+      userId: "U47f0bbc534dc503c4e4cadc86e619b63",
+    });
+    await buildLineMessageContext({
+      event,
+      allMedia: [],
+      cfg,
+      account,
+      commandAuthorized: true,
+    });
+
+    expect(getUserProfileMock).toHaveBeenCalledWith(
+      "U47f0bbc534dc503c4e4cadc86e619b63",
+      expect.objectContaining({ groupId: "C5aeb18d690759492f1a8c391c37549a0" }),
+    );
   });
 });

--- a/extensions/line/src/bot-message-context.ts
+++ b/extensions/line/src/bot-message-context.ts
@@ -29,6 +29,7 @@ import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runti
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { normalizeAllowFrom } from "./bot-access.js";
 import { resolveLineGroupConfigEntry } from "./group-keys.js";
+import { getLineGroupName, getUserProfile } from "./send.js";
 import type { ResolvedLineAccount } from "./types.js";
 
 type EventSource = webhook.Source | undefined;
@@ -272,13 +273,33 @@ async function finalizeLineInboundContext(params: {
   buildContext?: typeof buildChannelInboundEventContext;
 }) {
   const senderId = params.source.userId ?? "unknown";
-  const senderLabel = params.source.userId ? `user:${params.source.userId}` : "unknown";
+  const clientOpts = {
+    cfg: params.cfg,
+    accountId: params.account.accountId,
+    channelAccessToken: params.account.channelAccessToken,
+  };
+  // A LINE webhook carries no display name and no group name, so both are
+  // separate lookups. They are cached, they run in parallel, and either one
+  // failing degrades to the raw id rather than failing the turn.
+  const [senderName, groupName] = await Promise.all([
+    params.source.userId
+      ? getUserProfile(params.source.userId, {
+          ...clientOpts,
+          groupId: params.source.groupId,
+          roomId: params.source.roomId,
+        }).then((profile) => profile?.displayName)
+      : undefined,
+    params.source.groupId ? getLineGroupName(params.source.groupId, clientOpts) : undefined,
+  ]);
+  const senderLabel =
+    senderName ?? (params.source.userId ? `user:${params.source.userId}` : "unknown");
   const conversationLabel = params.source.isGroup
-    ? params.source.groupId
-      ? `group:${params.source.groupId}`
-      : params.source.roomId
-        ? `room:${params.source.roomId}`
-        : "unknown-group"
+    ? (groupName ??
+      (params.source.groupId
+        ? `group:${params.source.groupId}`
+        : params.source.roomId
+          ? `room:${params.source.roomId}`
+          : "unknown-group"))
     : senderLabel;
   const address = params.source.groupId
     ? `line:group:${params.source.groupId}`
@@ -303,6 +324,7 @@ async function finalizeLineInboundContext(params: {
     chatType: params.source.isGroup ? "group" : "direct",
     sender: {
       id: senderId,
+      name: senderName,
     },
     previousTimestamp,
     envelope: envelopeOptions,
@@ -315,7 +337,7 @@ async function finalizeLineInboundContext(params: {
     messageId: params.messageSid,
     timestamp: params.timestamp,
     from: address,
-    sender: { id: senderId },
+    sender: { id: senderId, name: senderName },
     conversation: {
       kind: params.source.isGroup ? "group" : "direct",
       id: params.source.peerId,
@@ -340,7 +362,7 @@ async function finalizeLineInboundContext(params: {
     extra: {
       ...params.locationContext,
       GroupSubject: params.source.isGroup
-        ? (params.source.groupId ?? params.source.roomId)
+        ? (groupName ?? params.source.groupId ?? params.source.roomId)
         : undefined,
       GroupSystemPrompt: params.source.isGroup
         ? normalizeOptionalString(

--- a/extensions/line/src/monitor.ts
+++ b/extensions/line/src/monitor.ts
@@ -177,7 +177,7 @@ export async function monitorLineProvider(
       // The inbound context already resolved the sender's name for the agent;
       // reading it back costs nothing instead of asking LINE a second time.
       logVerbose(
-        `line: received message from ${ctxPayload.SenderName ?? ctxPayload.From} (${ctxPayload.From})`,
+        `line: received message from ${ctxPayload.SenderName ?? ctx.userId ?? ctxPayload.From} (${ctxPayload.From})`,
       );
       let replyTokenUsed = false;
       let turnAdopted = false;

--- a/extensions/line/src/monitor.ts
+++ b/extensions/line/src/monitor.ts
@@ -36,7 +36,6 @@ import {
   createFlexMessage,
   createLocationMessage,
   createQuickReplyItems,
-  getUserDisplayName,
   pushMessagesLine,
   replyMessageLine,
   showLoadingAnimation,
@@ -167,10 +166,6 @@ export async function monitorLineProvider(
 
       const shouldShowLoading = Boolean(ctx.userId && !ctx.isGroup);
 
-      const displayNamePromise = ctx.userId
-        ? getUserDisplayName(ctx.userId, { cfg: config, accountId: ctx.accountId })
-        : Promise.resolve(ctxPayload.From);
-
       const stopLoading = shouldShowLoading
         ? startLineLoadingKeepalive({
             cfg: config,
@@ -179,8 +174,11 @@ export async function monitorLineProvider(
           })
         : null;
 
-      const displayName = await displayNamePromise;
-      logVerbose(`line: received message from ${displayName} (${ctxPayload.From})`);
+      // The inbound context already resolved the sender's name for the agent;
+      // reading it back costs nothing instead of asking LINE a second time.
+      logVerbose(
+        `line: received message from ${ctxPayload.SenderName ?? ctxPayload.From} (${ctxPayload.From})`,
+      );
       let replyTokenUsed = false;
       let turnAdopted = false;
       const ingressLifecycle = deliveryControl.turnAdoptionLifecycle;

--- a/extensions/line/src/send.identity.test.ts
+++ b/extensions/line/src/send.identity.test.ts
@@ -114,11 +114,31 @@ describe("LINE identity lookups", () => {
   });
 
   it("degrades to no profile when LINE cannot answer", async () => {
-    getGroupMemberProfileMock.mockRejectedValueOnce(new Error("404 not found"));
+    getGroupMemberProfileMock.mockRejectedValue(new Error("404 not found"));
 
     await expect(
       sendModule.getUserProfile("Umissing", { cfg: LINE_TEST_CFG, groupId: "Cgroup2" }),
     ).resolves.toBeNull();
+    await expect(
+      sendModule.getUserProfile("Umissing", { cfg: LINE_TEST_CFG, groupId: "Cgroup2" }),
+    ).resolves.toBeNull();
+
+    expect(getGroupMemberProfileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps profile cache entries scoped to their conversation endpoint", async () => {
+    getGroupMemberProfileMock.mockResolvedValueOnce({ displayName: "Group Sora" });
+    getRoomMemberProfileMock.mockResolvedValueOnce({ displayName: "Room Sora" });
+
+    await expect(
+      sendModule.getUserProfile("Ushared", { cfg: LINE_TEST_CFG, groupId: "Cshared" }),
+    ).resolves.toMatchObject({ displayName: "Group Sora" });
+    await expect(
+      sendModule.getUserProfile("Ushared", { cfg: LINE_TEST_CFG, roomId: "Rshared" }),
+    ).resolves.toMatchObject({ displayName: "Room Sora" });
+
+    expect(getGroupMemberProfileMock).toHaveBeenCalledTimes(1);
+    expect(getRoomMemberProfileMock).toHaveBeenCalledTimes(1);
   });
 
   it("resolves a group name once and serves the rest from cache", async () => {
@@ -134,11 +154,32 @@ describe("LINE identity lookups", () => {
     expect(getGroupSummaryMock).toHaveBeenCalledTimes(1);
   });
 
+  it("coalesces concurrent group-name cache misses", async () => {
+    let resolveSummary: (summary: { groupId: string; groupName: string }) => void = () => {};
+    getGroupSummaryMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveSummary = resolve;
+      }),
+    );
+
+    const first = sendModule.getLineGroupName("Cconcurrent", { cfg: LINE_TEST_CFG });
+    const second = sendModule.getLineGroupName("Cconcurrent", { cfg: LINE_TEST_CFG });
+    expect(getGroupSummaryMock).toHaveBeenCalledTimes(1);
+
+    resolveSummary({ groupId: "Cconcurrent", groupName: "Release Squad" });
+    await expect(Promise.all([first, second])).resolves.toEqual(["Release Squad", "Release Squad"]);
+  });
+
   it("degrades to no group name when the summary call fails", async () => {
-    getGroupSummaryMock.mockRejectedValueOnce(new Error("403 forbidden"));
+    getGroupSummaryMock.mockRejectedValue(new Error("403 forbidden"));
 
     await expect(
       sendModule.getLineGroupName("Cforbidden", { cfg: LINE_TEST_CFG }),
     ).resolves.toBeUndefined();
+    await expect(
+      sendModule.getLineGroupName("Cforbidden", { cfg: LINE_TEST_CFG }),
+    ).resolves.toBeUndefined();
+
+    expect(getGroupSummaryMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/line/src/send.identity.test.ts
+++ b/extensions/line/src/send.identity.test.ts
@@ -1,0 +1,144 @@
+// Line tests cover how inbound identity lookups pick their LINE endpoint.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  getProfileMock,
+  getGroupMemberProfileMock,
+  getRoomMemberProfileMock,
+  getGroupSummaryMock,
+  MessagingApiClientMock,
+  requireRuntimeConfigMock,
+  resolveLineAccountMock,
+  resolveLineChannelAccessTokenMock,
+  logVerboseMock,
+} = vi.hoisted(() => {
+  const getProfileMockLocal = vi.fn();
+  const getGroupMemberProfileMockLocal = vi.fn();
+  const getRoomMemberProfileMockLocal = vi.fn();
+  const getGroupSummaryMockLocal = vi.fn();
+  return {
+    getProfileMock: getProfileMockLocal,
+    getGroupMemberProfileMock: getGroupMemberProfileMockLocal,
+    getRoomMemberProfileMock: getRoomMemberProfileMockLocal,
+    getGroupSummaryMock: getGroupSummaryMockLocal,
+    MessagingApiClientMock: vi.fn(function () {
+      return {
+        getProfile: getProfileMockLocal,
+        getGroupMemberProfile: getGroupMemberProfileMockLocal,
+        getRoomMemberProfile: getRoomMemberProfileMockLocal,
+        getGroupSummary: getGroupSummaryMockLocal,
+      };
+    }),
+    requireRuntimeConfigMock: vi.fn((cfg: unknown) => cfg ?? {}),
+    resolveLineAccountMock: vi.fn(() => ({ accountId: "default" })),
+    resolveLineChannelAccessTokenMock: vi.fn(() => "line-token"),
+    logVerboseMock: vi.fn(),
+  };
+});
+
+vi.mock("@line/bot-sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@line/bot-sdk")>();
+  return {
+    ...actual,
+    messagingApi: { ...actual.messagingApi, MessagingApiClient: MessagingApiClientMock },
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/plugin-config-runtime", () => ({
+  requireRuntimeConfig: requireRuntimeConfigMock,
+}));
+
+vi.mock("./accounts.js", () => ({
+  resolveLineAccount: resolveLineAccountMock,
+}));
+
+vi.mock("./channel-access-token.js", () => ({
+  resolveLineChannelAccessToken: resolveLineChannelAccessTokenMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/runtime-env")>(
+    "openclaw/plugin-sdk/runtime-env",
+  );
+  return { ...actual, logVerbose: logVerboseMock };
+});
+
+const LINE_TEST_CFG = { channels: { line: { accounts: { default: {} } } } };
+
+describe("LINE identity lookups", () => {
+  let sendModule: typeof import("./send.js");
+
+  beforeEach(async () => {
+    sendModule = await import("./send.js");
+    getProfileMock.mockReset();
+    getGroupMemberProfileMock.mockReset();
+    getRoomMemberProfileMock.mockReset();
+    getGroupSummaryMock.mockReset();
+  });
+
+  // A member who has not added the bot as a friend is invisible to the plain
+  // profile endpoint, so the conversation the message came from decides which
+  // endpoint can answer at all.
+  const memberProfileCases = [
+    {
+      name: "asks the group endpoint for a group member",
+      userId: "Ugroupmember",
+      scope: { groupId: "Cgroup1" },
+      endpoint: () => getGroupMemberProfileMock,
+      args: ["Cgroup1", "Ugroupmember"],
+    },
+    {
+      name: "asks the room endpoint for a room member",
+      userId: "Uroommember",
+      scope: { roomId: "Rroom1" },
+      endpoint: () => getRoomMemberProfileMock,
+      args: ["Rroom1", "Uroommember"],
+    },
+    {
+      name: "asks the plain profile endpoint in a direct message",
+      userId: "Udirect",
+      scope: {},
+      endpoint: () => getProfileMock,
+      args: ["Udirect"],
+    },
+  ];
+
+  it.each(memberProfileCases)("$name", async ({ userId, scope, endpoint, args }) => {
+    const target = endpoint();
+    target.mockResolvedValueOnce({ displayName: "Sora", userId });
+
+    const profile = await sendModule.getUserProfile(userId, { cfg: LINE_TEST_CFG, ...scope });
+
+    expect(profile?.displayName).toBe("Sora");
+    expect(target).toHaveBeenCalledWith(...args);
+  });
+
+  it("degrades to no profile when LINE cannot answer", async () => {
+    getGroupMemberProfileMock.mockRejectedValueOnce(new Error("404 not found"));
+
+    await expect(
+      sendModule.getUserProfile("Umissing", { cfg: LINE_TEST_CFG, groupId: "Cgroup2" }),
+    ).resolves.toBeNull();
+  });
+
+  it("resolves a group name once and serves the rest from cache", async () => {
+    getGroupSummaryMock.mockResolvedValue({ groupId: "Cnamed", groupName: "Release Squad" });
+
+    await expect(sendModule.getLineGroupName("Cnamed", { cfg: LINE_TEST_CFG })).resolves.toBe(
+      "Release Squad",
+    );
+    await expect(sendModule.getLineGroupName("Cnamed", { cfg: LINE_TEST_CFG })).resolves.toBe(
+      "Release Squad",
+    );
+
+    expect(getGroupSummaryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("degrades to no group name when the summary call fails", async () => {
+    getGroupSummaryMock.mockRejectedValueOnce(new Error("403 forbidden"));
+
+    await expect(
+      sendModule.getLineGroupName("Cforbidden", { cfg: LINE_TEST_CFG }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -34,11 +34,20 @@ type QuickReply = messagingApi.QuickReply;
 type QuickReplyItem = messagingApi.QuickReplyItem;
 type LineLocation = NonNullable<LineChannelData["location"]>;
 
-const userProfileCache = new Map<
-  string,
-  { displayName: string; pictureUrl?: string; fetchedAt: number }
->();
-const groupNameCache = new Map<string, { groupName: string; fetchedAt: number }>();
+type LineUserProfile = { displayName: string; pictureUrl?: string };
+type LineIdentityCache<T> = {
+  values: Map<string, { value: T; fetchedAt: number }>;
+  pending: Map<string, Promise<T>>;
+};
+
+const profileCache: LineIdentityCache<LineUserProfile | null> = {
+  values: new Map(),
+  pending: new Map(),
+};
+const groupNameCache: LineIdentityCache<string | undefined> = {
+  values: new Map(),
+  pending: new Map(),
+};
 const PROFILE_CACHE_TTL_MS = 5 * 60 * 1000;
 const PROFILE_CACHE_MAX_ENTRIES = 1000;
 const LINE_FLEX_ALT_TEXT_LIMIT = 1500;
@@ -48,30 +57,47 @@ const LINE_LOCATION_LABEL_LIMIT = 100;
 const LINE_PROVIDER_RESPONSE_MAX_BYTES = 16 * 1024;
 
 // Refresh insertion order so overflow evicts expired entries first, then the oldest live fetch.
-function rememberLineIdentity<T extends { fetchedAt: number }>(
-  cache: Map<string, T>,
-  key: string,
-  value: T,
-): void {
-  cache.delete(key);
-  cache.set(key, value);
-  if (cache.size <= PROFILE_CACHE_MAX_ENTRIES) {
+function rememberLineIdentity<T>(cache: LineIdentityCache<T>, key: string, value: T): void {
+  const entry = { value, fetchedAt: Date.now() };
+  cache.values.delete(key);
+  cache.values.set(key, entry);
+  if (cache.values.size <= PROFILE_CACHE_MAX_ENTRIES) {
     return;
   }
-  for (const [cachedKey, cached] of cache) {
-    if (value.fetchedAt - cached.fetchedAt >= PROFILE_CACHE_TTL_MS) {
-      cache.delete(cachedKey);
+  for (const [cachedKey, cached] of cache.values) {
+    if (entry.fetchedAt - cached.fetchedAt >= PROFILE_CACHE_TTL_MS) {
+      cache.values.delete(cachedKey);
     }
   }
-  pruneMapToMaxSize(cache, PROFILE_CACHE_MAX_ENTRIES);
+  pruneMapToMaxSize(cache.values, PROFILE_CACHE_MAX_ENTRIES);
 }
 
-function readLineIdentityCache<T extends { fetchedAt: number }>(
-  cache: Map<string, T>,
+async function loadLineIdentity<T>(
+  cache: LineIdentityCache<T>,
   key: string,
-): T | undefined {
-  const cached = cache.get(key);
-  return cached && Date.now() - cached.fetchedAt < PROFILE_CACHE_TTL_MS ? cached : undefined;
+  load: () => Promise<T>,
+): Promise<T> {
+  const cached = cache.values.get(key);
+  if (cached && Date.now() - cached.fetchedAt < PROFILE_CACHE_TTL_MS) {
+    return cached.value;
+  }
+  const pending = cache.pending.get(key);
+  if (pending) {
+    return await pending;
+  }
+  const lookup = load().then((value) => {
+    rememberLineIdentity(cache, key, value);
+    return value;
+  });
+  cache.pending.set(key, lookup);
+  pruneMapToMaxSize(cache.pending, PROFILE_CACHE_MAX_ENTRIES);
+  try {
+    return await lookup;
+  } finally {
+    if (cache.pending.get(key) === lookup) {
+      cache.pending.delete(key);
+    }
+  }
 }
 
 interface LineSendOpts {
@@ -641,15 +667,20 @@ export async function showLoadingAnimation(
   }
 }
 
-async function getLineGroupSummary(
-  groupId: string,
-  opts: LineClientOpts,
-): Promise<messagingApi.GroupSummaryResponse> {
-  const { client } = createLineMessagingClient(opts);
-  return await client.getGroupSummary(groupId);
-}
-
 export type LineConversationScope = { groupId?: string; roomId?: string };
+
+function lineProfileCacheKey(
+  accountId: string,
+  userId: string,
+  scope: LineConversationScope,
+): string {
+  const conversation = scope.groupId
+    ? ["group", scope.groupId]
+    : scope.roomId
+      ? ["room", scope.roomId]
+      : ["direct"];
+  return JSON.stringify([accountId, "profile", ...conversation, userId]);
+}
 
 // A group or room member who has not added the bot as a friend is invisible to
 // the plain profile endpoint, so the sender's conversation decides which one can
@@ -672,33 +703,29 @@ function fetchLineMemberProfile(
 export async function getUserProfile(
   userId: string,
   opts: LineClientOpts & { useCache?: boolean } & LineConversationScope,
-): Promise<{ displayName: string; pictureUrl?: string } | null> {
+): Promise<LineUserProfile | null> {
   const useCache = opts.useCache ?? true;
-
-  if (useCache) {
-    const cached = readLineIdentityCache(userProfileCache, userId);
-    if (cached) {
-      return { displayName: cached.displayName, pictureUrl: cached.pictureUrl };
-    }
-  }
-
   try {
-    // Client construction resolves the account token and can throw, so it stays
-    // inside the guard: an unresolvable name degrades to the raw id, never to a
-    // failed inbound turn.
-    const { client } = createLineMessagingClient(opts);
-    const profile = await fetchLineMemberProfile(client, userId, opts);
-    const result = {
-      displayName: profile.displayName,
-      pictureUrl: profile.pictureUrl,
+    // Client construction resolves the canonical account for the cache key and
+    // can throw; an unresolvable name must never cost the inbound turn.
+    const { account, token } = resolveLineMessagingAccount(opts);
+    const cacheKey = lineProfileCacheKey(account.accountId, userId, opts);
+    const load = async () => {
+      try {
+        const client = new messagingApi.MessagingApiClient({ channelAccessToken: token });
+        const profile = await fetchLineMemberProfile(client, userId, opts);
+        return { displayName: profile.displayName, pictureUrl: profile.pictureUrl };
+      } catch (err) {
+        logVerbose(`line: failed to fetch profile for ${userId}: ${String(err)}`);
+        return null;
+      }
     };
-
-    rememberLineIdentity(userProfileCache, userId, {
-      ...result,
-      fetchedAt: Date.now(),
-    });
-
-    return result;
+    if (!useCache) {
+      const profile = await load();
+      rememberLineIdentity(profileCache, cacheKey, profile);
+      return profile;
+    }
+    return await loadLineIdentity(profileCache, cacheKey, load);
   } catch (err) {
     logVerbose(`line: failed to fetch profile for ${userId}: ${String(err)}`);
     return null;
@@ -719,18 +746,19 @@ export async function getLineGroupName(
   groupId: string,
   opts: LineClientOpts,
 ): Promise<string | undefined> {
-  const cached = readLineIdentityCache(groupNameCache, groupId);
-  if (cached) {
-    return cached.groupName;
-  }
   try {
-    const summary = await getLineGroupSummary(groupId, opts);
-    const groupName = summary.groupName.trim();
-    if (!groupName) {
-      return undefined;
-    }
-    rememberLineIdentity(groupNameCache, groupId, { groupName, fetchedAt: Date.now() });
-    return groupName;
+    const { account, token } = resolveLineMessagingAccount(opts);
+    const cacheKey = JSON.stringify([account.accountId, "group", groupId]);
+    return await loadLineIdentity(groupNameCache, cacheKey, async () => {
+      try {
+        const client = new messagingApi.MessagingApiClient({ channelAccessToken: token });
+        const summary = await client.getGroupSummary(groupId);
+        return summary.groupName.trim() || undefined;
+      } catch (err) {
+        logVerbose(`line: failed to fetch group summary for ${groupId}: ${String(err)}`);
+        return undefined;
+      }
+    });
   } catch (err) {
     logVerbose(`line: failed to fetch group summary for ${groupId}: ${String(err)}`);
     return undefined;

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -38,6 +38,7 @@ const userProfileCache = new Map<
   string,
   { displayName: string; pictureUrl?: string; fetchedAt: number }
 >();
+const groupNameCache = new Map<string, { groupName: string; fetchedAt: number }>();
 const PROFILE_CACHE_TTL_MS = 5 * 60 * 1000;
 const PROFILE_CACHE_MAX_ENTRIES = 1000;
 const LINE_FLEX_ALT_TEXT_LIMIT = 1500;
@@ -46,22 +47,31 @@ const LINE_LOCATION_LABEL_LIMIT = 100;
 // delivery, while rejected responses keep their status with prefix-only diagnostics.
 const LINE_PROVIDER_RESPONSE_MAX_BYTES = 16 * 1024;
 
-function cacheUserProfile(
-  userId: string,
-  profile: { displayName: string; pictureUrl?: string; fetchedAt: number },
+// Refresh insertion order so overflow evicts expired entries first, then the oldest live fetch.
+function rememberLineIdentity<T extends { fetchedAt: number }>(
+  cache: Map<string, T>,
+  key: string,
+  value: T,
 ): void {
-  // Refresh insertion order so overflow evicts expired entries first, then the oldest live fetch.
-  userProfileCache.delete(userId);
-  userProfileCache.set(userId, profile);
-  if (userProfileCache.size <= PROFILE_CACHE_MAX_ENTRIES) {
+  cache.delete(key);
+  cache.set(key, value);
+  if (cache.size <= PROFILE_CACHE_MAX_ENTRIES) {
     return;
   }
-  for (const [key, cached] of userProfileCache) {
-    if (profile.fetchedAt - cached.fetchedAt >= PROFILE_CACHE_TTL_MS) {
-      userProfileCache.delete(key);
+  for (const [cachedKey, cached] of cache) {
+    if (value.fetchedAt - cached.fetchedAt >= PROFILE_CACHE_TTL_MS) {
+      cache.delete(cachedKey);
     }
   }
-  pruneMapToMaxSize(userProfileCache, PROFILE_CACHE_MAX_ENTRIES);
+  pruneMapToMaxSize(cache, PROFILE_CACHE_MAX_ENTRIES);
+}
+
+function readLineIdentityCache<T extends { fetchedAt: number }>(
+  cache: Map<string, T>,
+  key: string,
+): T | undefined {
+  const cached = cache.get(key);
+  return cached && Date.now() - cached.fetchedAt < PROFILE_CACHE_TTL_MS ? cached : undefined;
 }
 
 interface LineSendOpts {
@@ -631,7 +641,7 @@ export async function showLoadingAnimation(
   }
 }
 
-export async function getLineGroupSummary(
+async function getLineGroupSummary(
   groupId: string,
   opts: LineClientOpts,
 ): Promise<messagingApi.GroupSummaryResponse> {
@@ -639,29 +649,51 @@ export async function getLineGroupSummary(
   return await client.getGroupSummary(groupId);
 }
 
+export type LineConversationScope = { groupId?: string; roomId?: string };
+
+// A group or room member who has not added the bot as a friend is invisible to
+// the plain profile endpoint, so the sender's conversation decides which one can
+// answer. Reading the wrong one returns 404 for exactly the people whose names
+// matter most in a group.
+function fetchLineMemberProfile(
+  client: messagingApi.MessagingApiClient,
+  userId: string,
+  scope: LineConversationScope,
+): Promise<{ displayName: string; pictureUrl?: string }> {
+  if (scope.groupId) {
+    return client.getGroupMemberProfile(scope.groupId, userId);
+  }
+  if (scope.roomId) {
+    return client.getRoomMemberProfile(scope.roomId, userId);
+  }
+  return client.getProfile(userId);
+}
+
 export async function getUserProfile(
   userId: string,
-  opts: LineClientOpts & { useCache?: boolean },
+  opts: LineClientOpts & { useCache?: boolean } & LineConversationScope,
 ): Promise<{ displayName: string; pictureUrl?: string } | null> {
   const useCache = opts.useCache ?? true;
 
   if (useCache) {
-    const cached = userProfileCache.get(userId);
-    if (cached && Date.now() - cached.fetchedAt < PROFILE_CACHE_TTL_MS) {
+    const cached = readLineIdentityCache(userProfileCache, userId);
+    if (cached) {
       return { displayName: cached.displayName, pictureUrl: cached.pictureUrl };
     }
   }
 
-  const { client } = createLineMessagingClient(opts);
-
   try {
-    const profile = await client.getProfile(userId);
+    // Client construction resolves the account token and can throw, so it stays
+    // inside the guard: an unresolvable name degrades to the raw id, never to a
+    // failed inbound turn.
+    const { client } = createLineMessagingClient(opts);
+    const profile = await fetchLineMemberProfile(client, userId, opts);
     const result = {
       displayName: profile.displayName,
       pictureUrl: profile.pictureUrl,
     };
 
-    cacheUserProfile(userId, {
+    rememberLineIdentity(userProfileCache, userId, {
       ...result,
       fetchedAt: Date.now(),
     });
@@ -673,7 +705,34 @@ export async function getUserProfile(
   }
 }
 
-export async function getUserDisplayName(userId: string, opts: LineClientOpts): Promise<string> {
+export async function getUserDisplayName(
+  userId: string,
+  opts: LineClientOpts & LineConversationScope,
+): Promise<string> {
   const profile = await getUserProfile(userId, opts);
   return profile?.displayName ?? userId;
+}
+
+// LINE never puts the group name in a webhook, and multi-person rooms have no
+// name endpoint at all, so only groups can be named and only by asking.
+export async function getLineGroupName(
+  groupId: string,
+  opts: LineClientOpts,
+): Promise<string | undefined> {
+  const cached = readLineIdentityCache(groupNameCache, groupId);
+  if (cached) {
+    return cached.groupName;
+  }
+  try {
+    const summary = await getLineGroupSummary(groupId, opts);
+    const groupName = summary.groupName.trim();
+    if (!groupName) {
+      return undefined;
+    }
+    rememberLineIdentity(groupNameCache, groupId, { groupName, fetchedAt: Date.now() });
+    return groupName;
+  } catch (err) {
+    logVerbose(`line: failed to fetch group summary for ${groupId}: ${String(err)}`);
+    return undefined;
+  }
 }


### PR DESCRIPTION
Fixes #132098

## What Problem This Solves

In a LINE group the agent was told who was speaking with a raw user id, and which group it was in with a raw group id.

This is the envelope the model reads, from the gateway's own inbound log before this change:

```
preview="[LINE group:C5aeb18d690759492f1a8c391c37549a0 Sat 2026-08-29 04:46:18 GMT+8] U47f0bbc534dc503c4e4cadc86e619b63: openclaw please confirm you can see this group message"
```

In a group with several people the model cannot tell them apart, cannot address anyone by name, and cannot say which room it is in. The same ids reach `SenderName` (never set at all for LINE), `GroupSubject`, and `ConversationLabel`, so a LINE group session is also titled with its hex id — the exact outcome `src/config/sessions/metadata.ts:205` warns about when it says an "old opaque route id will keep winning in UI".

Every other channel passes a name here: Telegram `msg.chat.title`, Feishu `groupName || ctx.chatId`, Nextcloud Talk `roomName || roomToken`, Buzz `roomName`, Zalo-user `groupName`. LINE was the only one passing an identifier.

## Why This Change Was Made

The plugin already knew both names and threw them away.

`getUserDisplayName` was called on every single inbound message in `monitor.ts`, and its only consumer was the verbose log line on the very next statement. The group name was fetched too, but only once at join time to build the join-intro prompt, and then discarded.

So this moves the lookups to where the inbound context is built — the place that actually needs them — and has that log line read the resolved fact back instead of asking LINE a second time. `monitor.ts` and the join path both get smaller as a result, and the group-name lookup now has one owner instead of two call sites.

The sender lookup also had to change endpoint, and this is the part that is easy to get wrong. `client.getProfile` only answers for users who have added the bot as a friend. In a group or a room the correct calls are `getGroupMemberProfile(groupId, userId)` and `getRoomMemberProfile(roomId, userId)`; using the plain endpoint returns 404 for exactly the group members whose names matter most. The conversation the message arrived in now selects the endpoint.

Both lookups are cached for five minutes through the bounded record the plugin already used for profiles, both run in parallel, and either one failing degrades to the raw id rather than failing the turn. Client construction moved inside that guard for the same reason — it resolves the account token and can throw, and an unresolvable name must never cost an inbound message.

Multi-person rooms keep their room id: LINE has no room-name API.

## User Impact

The agent now sees who is speaking and where. A LINE group session is titled with the group's name instead of a hex id, and in a group the model can address people by name.

No configuration changes and no new options. If LINE cannot answer either lookup, behaviour is exactly what it is today.

The cost is one extra cached API read per uncached group conversation. The sender lookup is not new — it was already happening on every message; it is now used instead of discarded.

Production delta is +187/-76, net +111, across four files after maintainer repair. That buys correct endpoint selection per conversation type, a cached group-name owner, and two identity facts the agent never had; `monitor.ts` (-2) and `bot-handlers.ts` (-5) both shrink. I could not find a way to express it smaller without dropping the group/room endpoint distinction, which is the part that decides whether a name resolves at all.

## Evidence

**Live A/B against the real LINE API, same real message both times.** A message sent from LINE for macOS in a real two-member group, captured at the tunnel, then replayed with its original `X-Line-Signature` into two gateways built from two commits. Both runs used a fresh state dir. The names below were resolved by real `getGroupSummary` and `getGroupMemberProfile` calls, not stubs.

Before (`dist/.buildstamp` head `28c915b239d` — a build without this change):

```
line inbound: from=line:group:C5aeb18d690759492f1a8c391c37549a0 len=166
  preview="[LINE group:C5aeb18d690759492f1a8c391c37549a0 Sat 2026-08-29 04:46:18 GMT+8] U47f0bbc534dc503c4e4cadc86e619b63: openclaw please confirm you can see this group message"
```

After (`dist/.buildstamp` head `911ffc9d722`, this PR's head):

```
line inbound: from=line:group:C5aeb18d690759492f1a8c391c37549a0 len=154
  preview="[LINE openclaw3 lane C test Sat 2026-08-29 04:46:18 GMT+8] <display name> (U47f0bbc534dc503c4e4cadc86e619b63): openclaw please confirm you can see this group message"
```

`openclaw3 lane C test` is the real group name. `<display name>` is the operator's real LINE display name, redacted here; it appeared in full in the captured log.

Both gateways ran with `requireMention` off for groups so the plain-text message activated a turn at all. That is a supported group setting and is orthogonal to this change — it decides whether the turn happens, not what the turn is labelled with.

**Regression proof.** Reverting the four production files with the tests in place:

```
× buildLineMessageContext > gives the agent the sender's and the group's name instead of their ids
  → expected undefined to be 'Sora'
× buildLineMessageContext > asks LINE for the sender's profile through the conversation they wrote in
  → expected "vi.fn()" to be called with arguments: [ …(2) ]
× LINE identity lookups > asks the group endpoint for a group member
  → expected undefined to be 'Sora'
× LINE identity lookups > asks the room endpoint for a room member
  → expected undefined to be 'Sora'
× LINE identity lookups > resolves a group name once and serves the rest from cache
  → sendModule.getLineGroupName is not a function
× LINE identity lookups > degrades to no group name when the summary call fails
  → sendModule.getLineGroupName is not a function

Tests  6 failed | 579 passed (585)
```

Restored: `Test Files 39 passed (39) · Tests 585 passed (585)`.

The two endpoint tests fail on the assertion rather than on a missing import, which is the point — pre-fix code resolves a profile, it just asks the wrong endpoint.

**Checks.** `node scripts/check-changed.mjs` over all eight touched files: both tsgo lanes, oxfmt, extension lint, max-lines and assertion-safety ratchets, coercion-helper guard, dead-export scan, plugin boundaries, and import cycles.

**A note on one test I had to change.** `bot-handlers.join-intro.test.ts` asserted that a failed group-summary request yields a thin snapshot. With a cache in front of the lookup, a group whose name was already resolved keeps serving it through a transient failure — which is the behaviour I want, since losing a known name to a blip is worse than serving it. The test now uses a group nothing has resolved before, so it still asserts exactly what it was written to assert: when LINE will not give a name, none is invented.


**Pinned SDK contract, checked at this head.** `extensions/line/package.json` pins `"@line/bot-sdk": "11.2.0"`, and the installed package reports `11.2.0`. All three methods this change calls are declared in that exact version's client typings, `node_modules/@line/bot-sdk/dist/messaging-api/api/messagingApiClient.d.ts`:

```
376:    getGroupMemberProfile(groupId: string, userId: string): Promise<GroupUserProfileResponse>;
415:    getGroupSummary(groupId: string): Promise<GroupSummaryResponse>;
629:    getProfile(userId: string): Promise<UserProfileResponse>;
770:    getRoomMemberProfile(roomId: string, userId: string): Promise<RoomUserProfileResponse>;
```

`GroupUserProfileResponse` and `RoomUserProfileResponse` both carry a required `displayName: string`, and `GroupSummaryResponse` a required `groupName: string`, which is what the resolvers read. The `tsgo` extensions lane in the checks above compiles against these same typings at this head, so the calls are contract-checked rather than assumed — and the live run further up exercised all three against the real API.


## Maintainer verification

<!-- maintainer-verification-132108 -->

- Rebased patch-identically onto current main `5b605da389460fd035d9a2031064ed949303b14f`; exact head is `3dbee0282cb0f0ba7c0dffb483280e9a5d19a177`.
- A full isolated Linux build and CLI smoke passed at both exact revisions.
- The duplicate-display-name regression failed before the owner repair, then 61 focused tests passed. The complete LINE plugin suite passed: 39 files and 592 tests.
- The repair names ambient group history while keeping each stable user ID, scopes profile cache entries by account and conversation, coalesces concurrent misses, and briefly caches failed lookups.
- Final judged delta: production +189/-76 (net +113), tests +332/-20, docs +6. The growth records agent-visible identity facts and one bounded cache owner; the old monitor-only lookup was removed.
- Live proof remains the signed real LINE group webhook replay above. The retained input and credentials were not available for a second independent replay; the pre-review full build and exact-head regression evidence cover the maintainer repair.