### PR TITLE
fix: report missing requirements for agent-excluded skills

### DIFF
--- a/docs/cli/skills.md
+++ b/docs/cli/skills.md
@@ -93,6 +93,11 @@ commands resolve the target workspace from `--agent <id>`, then the current
 working directory when it is inside a configured agent workspace, then the
 default agent.
 
+`check` reports missing prerequisites independently of agent exclusion: a skill
+excluded by the agent allowlist can also appear under **Missing requirements**.
+Disabled skills and skills blocked by the bundled allowlist keep their separate
+readiness categories.
+
 Curator `status`, `pin`, `unpin`, and `restore`, plus Workshop `apply`, preserve
 the same target boundary. They never read or mutate client-local state after an
 explicitly selected Gateway fails; intentional offline behavior remains
@@ -142,7 +147,7 @@ Notes:
 | `verify @owner/<slug>`           | Prints ClawHub's `clawhub.skill.verify.v1` JSON envelope by default. `--json` is accepted as the explicit machine-output spelling. Bare slugs are accepted for compatibility when the skill is already installed or unambiguous; owner-qualified refs avoid publisher ambiguity.                                                  |
 | `verify` provenance              | When ClawHub returns server-resolved source provenance, verify JSON also includes a commit-pinned `openclaw.verifiedSourceUrl`. Unavailable or self-declared source URLs stay only in the raw provenance envelope and are not promoted.                                                                                           |
 | `verify` version selector        | `verify` uses `.clawhub/origin.json` for installed ClawHub skills, so it verifies the installed version against the registry it came from. `--version` and `--tag` override the version selector but keep that installed registry when origin metadata exists.                                                                    |
-| `verify --card`                  | Prints the generated Skill Card Markdown instead of JSON. Exits non-zero when ClawHub returns `ok: false` or `decision: "fail".                                                                                                                                                                                                   |
+| `verify --card`                  | Prints the generated Skill Card Markdown instead of JSON. Exits non-zero when ClawHub returns `ok: false` or `decision: "fail"`.                                                                                                                                                                                                  |
 | Skill Card fingerprint           | Installed ClawHub bundles can include a generated `skill-card.md`. OpenClaw treats verification as a ClawHub server decision and does not reject an installed skill just because that generated card changes the bundle fingerprint.                                                                                              |
 | `check --agent <id>`             | Checks the selected agent's workspace and reports which ready skills are actually visible to that agent's prompt or command surface.                                                                                                                                                                                              |
 | `workshop --agent <id>`          | Accepted before or after a Workshop leaf command, for example `workshop --agent <id> list` or `workshop list --agent <id>`. If both are provided, the leaf value wins.                                                                                                                                                            |

--- a/src/cli/skills-cli.format.ts
+++ b/src/cli/skills-cli.format.ts
@@ -312,12 +312,13 @@ export function formatSkillsCheck(report: SkillStatusReport, opts: SkillsCheckOp
   const commandVisible = report.skills.filter((s) => s.commandVisible);
   const disabled = report.skills.filter((s) => s.disabled);
   const blocked = report.skills.filter((s) => s.blockedByAllowlist && !s.disabled);
-  const agentFiltered = report.skills.filter((s) => s.eligible && s.blockedByAgentFilter);
+  // Agent exclusion is independent of readiness; report both when a skill needs setup.
+  const agentFiltered = report.skills.filter((s) => s.blockedByAgentFilter);
   const promptHidden = report.skills.filter(
     (s) => s.eligible && !s.blockedByAgentFilter && !s.modelVisible,
   );
   const missingReqs = report.skills.filter(
-    (s) => !s.eligible && !s.disabled && !s.blockedByAllowlist && !s.blockedByAgentFilter,
+    (s) => !s.eligible && !s.disabled && !s.blockedByAllowlist,
   );
   const agentId = report.agentId ?? opts.agent;
 

--- a/src/cli/skills-cli.formatting.test.ts
+++ b/src/cli/skills-cli.formatting.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { buildWorkspaceSkillStatus } from "../skills/discovery/status.js";
+import { writeWorkspaceSkills } from "../skills/test-support/e2e-test-helpers.js";
 import { createCanonicalFixtureSkill } from "../skills/test-support/test-helpers.js";
 import type { SkillEntry } from "../skills/types.js";
 import { captureEnv } from "../test-utils/env.js";
@@ -110,6 +111,55 @@ describe("skills-cli (e2e)", () => {
     const output = formatSkillInfo(report, "peekaboo", {});
     expect(output).toContain("peekaboo");
     expect(output).toContain("Details:");
+  });
+
+  it("reports missing prerequisites for discovered agent-excluded skills", async () => {
+    const missingBin = "qa35-fixture-absent-binary";
+    await writeWorkspaceSkills(tempWorkspaceDir, [
+      { name: "ready", description: "Allowed ready control" },
+      { name: "excluded-ready", description: "Excluded ready control" },
+      ...["missing", "excluded-missing"].map((name) => ({
+        name,
+        description: "Missing prerequisite fixture",
+        metadata: JSON.stringify({ openclaw: { requires: { bins: [missingBin] } } }),
+      })),
+    ]);
+    const report = buildWorkspaceSkillStatus(tempWorkspaceDir, {
+      managedSkillsDir: path.join(tempWorkspaceDir, "managed"),
+      agentId: "qa",
+      config: {
+        plugins: { enabled: false },
+        agents: { entries: { qa: { workspace: tempWorkspaceDir, skills: ["ready", "missing"] } } },
+      },
+    });
+    expect(report.skills).toHaveLength(4);
+    expect(report.skills.find((skill) => skill.name === "excluded-missing")).toMatchObject({
+      eligible: false,
+      disabled: false,
+      blockedByAllowlist: false,
+      blockedByAgentFilter: true,
+      modelVisible: false,
+      commandVisible: false,
+      missing: { bins: [missingBin] },
+    });
+    const parsed = JSON.parse(formatSkillsCheck(report, { json: true }));
+    expect(parsed.missingRequirements.map((skill: { name: string }) => skill.name)).toEqual([
+      "excluded-missing",
+      "missing",
+    ]);
+    expect(parsed.agentFiltered).toEqual(["excluded-missing", "excluded-ready"]);
+    expect(parsed.eligible).toEqual(["excluded-ready", "ready"]);
+    expect(parsed.modelVisible).toEqual(["ready"]);
+    expect(parsed.commandVisible).toEqual(["ready"]);
+    const human = formatSkillsCheck(report, {});
+    expect(human).toContain(`excluded-missing (bins: ${missingBin})`);
+    expect(human).toContain("excluded-ready (loaded, but this agent is not allowed to see/use it)");
+
+    const readyList = JSON.parse(formatSkillsList(report, { eligible: true, json: true }));
+    expect(readyList.skills.map((skill: { name: string }) => skill.name)).toEqual(["ready"]);
+    const info = formatSkillInfo(report, "excluded-missing", {});
+    expect(info).toContain("Excluded by agent allowlist");
+    expect(info).toContain(`✗ ${missingBin}`);
   });
 });
 

--- a/src/cli/skills-cli.test.ts
+++ b/src/cli/skills-cli.test.ts
@@ -422,76 +422,117 @@ describe("skills-cli", () => {
       expect(output).not.toContain("commands/cron may still use it");
     });
 
-    it("summarizes a mixed bad skill pack in JSON", () => {
-      const output = formatSkillsCheck(
-        {
-          ...createMockReport([
-            createMockSkill({ name: "ready", eligible: true }),
-            createMockSkill({
-              name: "prompt-hidden",
-              eligible: true,
-              platformIncompatible: false,
-              modelVisible: false,
-              commandVisible: true,
-            }),
-            createMockSkill({
-              name: "slash-hidden",
-              eligible: true,
-              platformIncompatible: false,
-              modelVisible: true,
-              userInvocable: false,
-              commandVisible: false,
-            }),
-            createMockSkill({
-              name: "agent-filtered",
-              eligible: true,
-              platformIncompatible: false,
-              blockedByAgentFilter: true,
-            }),
-            createMockSkill({
-              name: "missing-bin",
-              eligible: false,
-              platformIncompatible: false,
-              missing: { bins: ["missing-tool"], anyBins: [], env: [], config: [], os: [] },
-            }),
-            createMockSkill({ name: "disabled", eligible: false, disabled: true }),
-            createMockSkill({
-              name: "blocked-bundled",
-              eligible: false,
-              platformIncompatible: false,
-              blockedByAllowlist: true,
-            }),
-          ]),
-          agentId: "specialist",
-          agentSkillFilter: ["ready", "prompt-hidden", "slash-hidden", "missing-bin"],
-        },
-        { json: true },
-      );
+    it("accounts for readiness independently of agent exclusion in a mixed skill pack", () => {
+      const report = {
+        ...createMockReport([
+          createMockSkill({ name: "ready", eligible: true }),
+          createMockSkill({
+            name: "prompt-hidden",
+            eligible: true,
+            platformIncompatible: false,
+            modelVisible: false,
+            commandVisible: true,
+          }),
+          createMockSkill({
+            name: "slash-hidden",
+            eligible: true,
+            platformIncompatible: false,
+            modelVisible: true,
+            userInvocable: false,
+            commandVisible: false,
+          }),
+          createMockSkill({
+            name: "agent-filtered",
+            eligible: true,
+            platformIncompatible: false,
+            blockedByAgentFilter: true,
+          }),
+          createMockSkill({
+            name: "excluded-missing",
+            eligible: false,
+            blockedByAgentFilter: true,
+            missing: { bins: ["missing-tool"], anyBins: [], env: [], config: [], os: [] },
+          }),
+          createMockSkill({
+            name: "missing-bin",
+            eligible: false,
+            platformIncompatible: false,
+            missing: { bins: ["missing-tool"], anyBins: [], env: [], config: [], os: [] },
+          }),
+          createMockSkill({
+            name: "disabled",
+            eligible: false,
+            disabled: true,
+            blockedByAllowlist: true,
+            blockedByAgentFilter: true,
+            missing: { bins: ["missing-tool"], anyBins: [], env: [], config: [], os: [] },
+          }),
+          createMockSkill({
+            name: "blocked-bundled",
+            eligible: false,
+            platformIncompatible: false,
+            blockedByAllowlist: true,
+            blockedByAgentFilter: true,
+            missing: { bins: ["missing-tool"], anyBins: [], env: [], config: [], os: [] },
+          }),
+        ]),
+        agentId: "specialist",
+        agentSkillFilter: ["ready", "prompt-hidden", "slash-hidden", "missing-bin"],
+      };
+      const output = formatSkillsCheck(report, { json: true });
 
       const parsed = JSON.parse(output) as {
         summary: Record<string, number>;
+        eligible: string[];
+        disabled: string[];
+        blocked: string[];
         modelVisible: string[];
         commandVisible: string[];
         agentFiltered: string[];
         notInjected: Array<{ name: string; reason: string }>;
         missingRequirements: Array<{ name: string }>;
       };
-      expect(parsed.summary.total).toBe(7);
+      const readinessNames = [
+        ...parsed.eligible,
+        ...parsed.disabled,
+        ...parsed.blocked,
+        ...parsed.missingRequirements.map((entry) => entry.name),
+      ];
+      expect(readinessNames.toSorted()).toEqual(
+        report.skills.map((skill) => skill.name).toSorted(),
+      );
+      expect(readinessNames.length).toBe(parsed.summary.total);
+      expect(parsed.summary.total).toBe(8);
       expect(parsed.summary.eligible).toBe(4);
       expect(parsed.summary.modelVisible).toBe(2);
       expect(parsed.summary.commandVisible).toBe(2);
       expect(parsed.summary.disabled).toBe(1);
       expect(parsed.summary.blocked).toBe(1);
-      expect(parsed.summary.agentFiltered).toBe(1);
+      expect(parsed.summary.agentFiltered).toBe(4);
       expect(parsed.summary.notInjected).toBe(1);
-      expect(parsed.summary.missingRequirements).toBe(1);
+      expect(parsed.summary.missingRequirements).toBe(2);
       expect(parsed.modelVisible).toEqual(["ready", "slash-hidden"]);
       expect(parsed.commandVisible).toEqual(["ready", "prompt-hidden"]);
-      expect(parsed.agentFiltered).toEqual(["agent-filtered"]);
+      expect(parsed.agentFiltered).toEqual([
+        "agent-filtered",
+        "excluded-missing",
+        "disabled",
+        "blocked-bundled",
+      ]);
+      expect(parsed.disabled).toEqual(["disabled"]);
+      expect(parsed.blocked).toEqual(["blocked-bundled"]);
       expect(parsed.notInjected).toEqual([
         { name: "prompt-hidden", reason: "disable-model-invocation" },
       ]);
-      expect(parsed.missingRequirements.map((entry) => entry.name)).toEqual(["missing-bin"]);
+      expect(parsed.missingRequirements.map((entry) => entry.name)).toEqual([
+        "excluded-missing",
+        "missing-bin",
+      ]);
+      const human = formatSkillsCheck(report, {});
+      expect(human).toContain("excluded-missing (bins: missing-tool)");
+      for (const name of parsed.agentFiltered) {
+        expect(human).toContain(`${name} (loaded, but this agent is not allowed to see/use it)`);
+      }
     });
   });
 


### PR DESCRIPTION
Closes #132022

## What Problem This Solves

Fixes an issue where operators running `openclaw skills check` would not see a skill's missing prerequisites when the same skill was excluded by the selected agent's allowlist. The discovered skill counted toward the total but disappeared from both the missing-requirements list and the agent-exclusion diagnostics, in human and JSON output.

## Why This Change Was Made

Readiness and agent visibility are independent facts already recorded by skill discovery. The formatter now reports those facts independently instead of cross-filtering them: an excluded skill can also need setup. Disabled and bundled-allowlist-blocked skills retain their existing primary readiness categories; visibility diagnostics may overlap them.

This fixes the reporting owner without changing discovery, eligibility, actual model/command access, Gateway selection, JSON field shape, CLI flags, configuration, or storage. No helper, fallback, or test-only production seam is added. The Skills CLI docs explain the overlap; a nearby broken inline-code delimiter is also corrected.

History: the two predicates date to the agent-visibility change in #75983 (May 2, 2026; code author and PR merger @mbelinky).

## User Impact

Operators can see all required setup work, including for skills that their selected agent cannot currently use. Excluded skills remain excluded: they do not become model-visible, command-visible, or eligible for the agent's ready-only listing.

## Evidence

- Before the production change, the extended mixed-readiness test and real `SKILL.md` discovery regression both failed for the intended omission; 30 controls passed. After the repair, all 32 focused tests passed. The combined owner/sibling selection passed **197 tests across five files**, including those focused tests, CLI target/fallback behavior, and status production.
- The full declaration-producing **`pnpm build` passed**, as did the complete changed-path gate, formatting, and `git diff --check`. An earlier worker build was deliberately stopped at its time budget; the completed parent-owned build supersedes that incomplete attempt.
- **Five real CLI commands passed against the full build** with four actual skill descriptors, isolated HOME/config/state, and an owned closing loopback TCP listener. Human check, leaf `--json`, parent `--json`, eligible-only list, and info were exercised. Both JSON forms reported total 4, eligible 2, missing requirements 2, agent-excluded 2, model-visible 1, and command-visible 1. The excluded/missing entry appeared in both appropriate diagnostics; ready-only listing returned only the allowed ready control. Config bytes stayed unchanged after every command, and no fixture handler executed.
- Fresh independent Codex review of the complete final four-file patch found **no actionable P0/P1 findings**. Review included the complete status producer, CLI caller, agent-filter owner, modified tests, and applicable policy.

Focused owner/sibling command:

```bash
node scripts/run-vitest.mjs src/cli/skills-cli.test.ts src/cli/skills-cli.formatting.test.ts src/cli/skills-cli.commands.test.ts src/skills/discovery/status.test.ts src/skills/discovery/status-workspace.test.ts
```

Complete changed-path gate:

```bash
pnpm check:changed -- src/cli/skills-cli.format.ts src/cli/skills-cli.test.ts src/cli/skills-cli.formatting.test.ts docs/cli/skills.md
```

Production LOC: **+3/-2**; executable LOC net-neutral, with one added line documenting the independent-diagnostics invariant. Tests: **+141/-50** (net +91). Docs: **+6/-1**.

Proof boundary: this is real offline CLI execution, not a live-provider or running-Gateway test. The CLI exercised its existing implicit-local fallback against the owned endpoint; no operator Gateway or live state was used. The initial full-build proof was at `52f8848ce046d4e82f270a5d111c4dc2f03d7ceb`. Current reviewed head is **`f7662a07aaa5b8ea1cbc6afa4bbcceeaadc21077`**, mechanically rebased onto main `5b605da389460fd035d9a2031064ed949303b14f` after a shared UI build failure. The four-file patch is byte-identical. On this rebased head, all 197 owner/sibling tests, the complete changed-path gate, `pnpm build qaRuntime`, and all five actual CLI flows passed again; a fresh independent review found no actionable P0/P1 findings. The original hosted failure is documented in the [proof/CI note](https://github.com/openclaw/openclaw/pull/132110#issuecomment-5457931376). Main's uncached artifact build now passes its UI gate at 345124 B, below even the original limit; no UI budget change was added to this PR. Fresh exact-head [CI run 33215058707](https://github.com/openclaw/openclaw/actions/runs/33215058707) completed successfully for `f7662a07aaa5b8ea1cbc6afa4bbcceeaadc21077`. The latest ClawSweeper review at 22:11 UTC found no actionable patch issue; its remaining exact-head CI/rank-up requirement is now satisfied.
