### PR TITLE
fix(ci): re-baseline the Control UI startup budget so build-artifacts passes

### DIFF
--- a/config/control-ui-startup-budget-baseline.json
+++ b/config/control-ui-startup-budget-baseline.json
@@ -1,5 +1,5 @@
 {
-  "startupJsGzipBytes": 346461,
-  "reason": "standing-grant scope line + grants ledger (#131602); recorded at the CI e2e-lane build (346461 B) — checks-ui and local builds of the same tree measure ~600 B less, beyond the 64 B variance allowance",
+  "startupJsGzipBytes": 347423,
+  "reason": "twelve Control UI fixes landed after the #131602 baseline (b9e0c66e090 side-panel loading states through 293699e0bf9 mobile Inbox polish); measured 347423 B locally and 347430 B on the CI build-artifacts lane of UI-neutral PR #132108",
   "updatedAt": "2026-08-28"
 }


### PR DESCRIPTION
## What Problem This Solves

`build-artifacts` is failing on every open pull request, and because that job produces the build the rest of the matrix consumes, the failure cascades into the compact and changed-extensions shards. A contributor opening a PR right now sees five or six red checks that have nothing to do with their change.

The cause is the Control UI startup budget. The baseline was last recorded at 346461 B for #131602. Twelve Control UI fixes have landed since, and the bundle is now past the enforcement limit:

```
startup JS gzip vs baseline: 347423 B
  (baseline 346461 + growth allowance 512 = growth limit 346973;
   build-variance allowance 64; enforcement limit 347037)
violations:
  - startup JS gzip: 339.3 KiB exceeds 338.9 KiB
```

## Why This Change Was Made

This is the accumulated cost of merged work, not a regression in any one branch, so the sanctioned response is a conscious baseline raise with the growth window named. The growth window is `b9e0c66e090` (side-panel loading states) through `293699e0bf9` (mobile Inbox polish).

I did not touch any Control UI code. The only file in this diff is the baseline, updated through `scripts/check-control-ui-performance.mts --update-baseline`, and the new value sits well under the 358400 B max committed baseline.

## User Impact

None at runtime. This unblocks CI so that real failures are visible again instead of being buried under a cascade every PR shares.

## Evidence

Main itself is over the limit, measured three independent ways:

- local `node scripts/ui.js build` on pristine `upstream/main`: **347423 B**
- CI `build-artifacts` on #132108, whose diff touches only `extensions/line/` and `docs/` and no UI files: **347430 B**
- six other open PRs from other authors failing `build-artifacts` at the same time: #132101, #132102, #132104, #132105, #132107, #132108

The local and CI-lane numbers agree to within 7 B, comfortably inside the 64 B build-variance allowance, so the two lanes are measuring the same tree.

After this change, rebased onto current `main`:

```
startup JS gzip vs baseline: 347455 B
  (baseline 347423 + growth allowance 512 = growth limit 347935;
   build-variance allowance 64; enforcement limit 347999)
```

No violations, and `check-control-ui-performance.mts` exits 0. The 32 B difference between my recorded value and the rebased measurement is absorbed by the growth allowance, which is what it is there for.

AI-assisted: written with Claude Code, reviewed and validated by me before pushing.

---

I am new to this codebase, so if the preferred fix is to trim the startup path rather than raise the baseline, please say so and I will close this.
