### PR TITLE
fix(tui): keep failed attachments visible beside replies

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3843,7 +3843,7 @@ src/tui/gateway-chat.ts	2
 src/tui/tui-autocomplete.ts	1
 src/tui/tui-command-handlers.ts	5
 src/tui/tui-event-handlers.ts	5
-src/tui/tui-formatters.ts	5
+src/tui/tui-formatters.ts	4
 src/tui/tui-session-actions.ts	5
 src/tui/tui-session-events.ts	1
 src/tui/tui-session-projection.ts	2

--- a/docs/web/tui.md
+++ b/docs/web/tui.md
@@ -230,6 +230,7 @@ Tips:
 - On connect, the TUI loads the latest history (default 200 messages).
 - Reconnect and event-gap recovery reconcile active runs with history, retaining concurrent and newly observed runs without reviving runs that exact history has excluded.
 - Streaming responses update in place until finalized.
+- Failed assistant attachments show an actionable warning alongside any reply text. Attachment summaries use generic media kinds without exposing filenames or source URLs.
 - Messages sent to the same session from another client appear automatically.
 - The TUI also listens to agent tool events for richer tool cards.
 

--- a/src/tui/tui-attachment-failures.test.ts
+++ b/src/tui/tui-attachment-failures.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it, vi } from "vitest";
+import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
+import { ChatLog } from "./components/chat-log.js";
+import { createEventHandlers } from "./tui-event-handlers.js";
+import { extractTextFromMessage, extractTuiAbortedText } from "./tui-formatters.js";
+import { getTuiSessionProjection, reduceTuiSessionProjection } from "./tui-session-projection.js";
+import { TuiStreamAssembler } from "./tui-stream-assembler.js";
+import type { TuiStateAccess } from "./tui-types.js";
+
+const audioFailure = {
+  type: "attachment_error",
+  attachment: { code: "delivery-failed", kind: "audio", label: "Generated audio 1" },
+};
+const audioReceipt = "⚠️ audio attachment: Delivery failed. Try sending this file again.";
+const caption = { type: "text", text: "Your recording" };
+const image = { type: "image", url: "file:///private/image.png" };
+const assistant = (content: unknown[]) => ({ role: "assistant", content });
+
+function createDisplayHarness() {
+  const state: TuiStateAccess = {
+    agentDefaultId: "main",
+    sessionMainKey: "main",
+    sessionScope: "per-sender",
+    agents: [],
+    currentAgentId: "main",
+    currentSessionKey: "agent:main:main",
+    currentSessionId: "session-1",
+    activeChatRunId: null,
+    pendingSubmit: null,
+    historyLoaded: true,
+    sessionInfo: {},
+    initialSessionApplied: true,
+    isConnected: true,
+    autoMessageSent: false,
+    toolsExpanded: false,
+    showThinking: false,
+    connectionStatus: "connected",
+    activityStatus: "idle",
+    statusTimeout: null,
+    lastCtrlCAt: 0,
+  };
+  const chatLog = new ChatLog();
+  const handlers = createEventHandlers({
+    state,
+    chatLog,
+    tui: { requestRender: vi.fn() },
+    btw: { clear: vi.fn(), showResult: vi.fn() },
+    setActivityStatus: (value) => {
+      state.activityStatus = value;
+    },
+    streamingWatchdogMs: 0,
+  });
+  return {
+    state,
+    chatLog,
+    ...handlers,
+    visible: () =>
+      chatLog
+        .render(160)
+        .map((line) => stripAnsi(line).trimEnd())
+        .join("\n")
+        .trim(),
+  };
+}
+
+describe("TUI attachment failure presentation", () => {
+  it.each([
+    { name: "failure only", content: [audioFailure], expected: audioReceipt },
+    {
+      name: "caption and failure",
+      content: [caption, audioFailure],
+      expected: `Your recording\n${audioReceipt}`,
+    },
+    {
+      name: "success and failure",
+      content: [image, audioFailure],
+      expected: `Attached image\n${audioReceipt}`,
+    },
+    {
+      name: "caption, success and failure",
+      content: [caption, image, audioFailure],
+      expected: `Your recording\n${audioReceipt}`,
+    },
+    {
+      name: "multiple failures",
+      content: [audioFailure, audioFailure],
+      expected: `${audioReceipt}\n${audioReceipt}`,
+    },
+  ])("keeps $name in history and final output", ({ content, expected }) => {
+    const message = assistant(content);
+    expect(extractTextFromMessage(message)).toBe(expected);
+    expect(new TuiStreamAssembler().finalize("run-1", message, false)).toBe(expected);
+  });
+
+  it.each([
+    {
+      kind: "image",
+      code: "file-not-found",
+      expected: "⚠️ image attachment: File not found. Check the path and try again.",
+    },
+    {
+      kind: "video",
+      code: "unsupported-format",
+      expected:
+        "⚠️ video attachment: Rejected by the local attachment allowlist. Send a supported file type.",
+    },
+    {
+      kind: "document",
+      code: "delivery-failed",
+      expected: "⚠️ file attachment: Delivery failed. Try sending this file again.",
+    },
+  ])(
+    "renders actionable $kind/$code receipts without source metadata",
+    ({ kind, code, expected }) => {
+      const message = assistant([
+        {
+          type: "attachment_error",
+          attachment: {
+            kind,
+            code,
+            label: "\x1b]52;c;private-clipboard\x07file:///private/name",
+            url: "https://private.invalid/file?ticket=private",
+            mimeType: "private/type",
+          },
+        },
+      ]);
+      expect(extractTextFromMessage(message)).toBe(expected);
+      expect(new TuiStreamAssembler().finalize("run-1", message, false)).toBe(expected);
+    },
+  );
+
+  it.each([false, true])(
+    "retains streamed captions and thinking visibility (%s) before a failure-only final",
+    (showThinking) => {
+      const assembler = new TuiStreamAssembler();
+      assembler.ingestDelta(
+        "run-1",
+        assistant([caption, { type: "thinking", thinking: "Preparing" }]),
+        showThinking,
+      );
+      expect(assembler.finalize("run-1", assistant([audioFailure]), showThinking)).toBe(
+        `${showThinking ? "[thinking]\nPreparing\n\n" : ""}Your recording\n${audioReceipt}`,
+      );
+    },
+  );
+
+  it("keeps genuine errors ahead of success fallback while appending the failure receipt", () => {
+    const message = {
+      ...assistant([image, audioFailure]),
+      stopReason: "error",
+      errorMessage: "generation stopped",
+    };
+    expect(extractTextFromMessage(message)).toBe(`generation stopped\n${audioReceipt}`);
+    expect(
+      new TuiStreamAssembler().finalize(
+        "run-1",
+        assistant([image, audioFailure]),
+        false,
+        "generation stopped",
+      ),
+    ).toBe(`generation stopped\n${audioReceipt}`);
+  });
+
+  it.each([
+    { name: "failure only", content: [audioFailure], streamed: false, expected: audioReceipt },
+    {
+      name: "mixed attachments",
+      content: [image, audioFailure],
+      streamed: false,
+      expected: `Attached image\n${audioReceipt}`,
+    },
+    {
+      name: "streamed caption",
+      content: [image, audioFailure],
+      streamed: true,
+      expected: `Your recording\n${audioReceipt}`,
+    },
+  ])(
+    "renders one receipt through optimistic and authoritative history: $name",
+    ({ content, streamed, expected }) => {
+      const harness = createDisplayHarness();
+      const event = { runId: "run-1", sessionKey: harness.state.currentSessionKey };
+      try {
+        if (streamed) {
+          harness.handleChatEvent({ ...event, state: "delta", message: assistant([caption]) });
+          expect(harness.visible()).toBe("Your recording");
+        }
+        const message = assistant(content);
+        harness.handleChatEvent({ ...event, state: "final", message });
+        expect(harness.visible()).toBe(expected);
+        expect(harness.state.activityStatus).toBe("idle");
+
+        for (const messages of [
+          [],
+          [
+            {
+              ...assistant(streamed ? [caption, ...content] : content),
+              __openclaw: { id: "assistant-1", seq: 1, runId: event.runId },
+            },
+          ],
+        ]) {
+          const projection = reduceTuiSessionProjection(harness.state, {
+            type: "snapshotLoaded",
+            messages,
+          });
+          expect(projection.messages).toHaveLength(1);
+          harness.chatLog.clearAll();
+          for (const row of projection.messages) {
+            harness.chatLog.finalizeAssistant(extractTextFromMessage(row));
+          }
+          expect(harness.visible()).toBe(expected);
+        }
+      } finally {
+        harness.dispose();
+      }
+    },
+  );
+
+  it("keeps failure-only aborts diagnostic and ignores a late attachment final", () => {
+    const harness = createDisplayHarness();
+    const event = {
+      runId: "run-1",
+      sessionKey: harness.state.currentSessionKey,
+      message: assistant([audioFailure]),
+    };
+    try {
+      expect(extractTuiAbortedText(event.message, false)).toBe("");
+      harness.handleChatEvent({ ...event, state: "aborted" });
+      harness.handleChatEvent({ ...event, state: "final" });
+      expect(harness.visible()).toBe("run aborted");
+      expect(getTuiSessionProjection(harness.state).messages).toHaveLength(0);
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it("does not invent failure output for empty or unsupported blocks", () => {
+    for (const content of [
+      [],
+      [{ type: "tool_use", name: "search" }],
+      [{ type: "attachment_error", attachment: { code: "unknown", kind: "audio" } }],
+    ]) {
+      const message = assistant(content);
+      expect(extractTextFromMessage(message)).toBe("");
+      expect(new TuiStreamAssembler().finalize("run-1", message, false)).toBe("(no output)");
+    }
+  });
+});

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -1,7 +1,9 @@
+import { asOptionalObjectRecord as asMessageRecord } from "@openclaw/normalization-core/record-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 // Formats terminal-safe strings for TUI messages and status surfaces.
 import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
 import { splitTrailingAuthProfile } from "../agents/model-ref-profile.js";
+import { appendReplyMediaFailures, type ReplyMediaFailure } from "../auto-reply/reply-payload.js";
 import { stripLeadingInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
 import type { SessionGoal } from "../config/sessions/types.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -316,25 +318,12 @@ export function resolveFinalAssistantText(params: {
   finalText?: string | null;
   streamedText?: string | null;
   errorMessage?: string | null;
-  attachmentText?: string | null;
+  message?: unknown;
 }) {
-  const finalText = params.finalText ?? "";
-  if (finalText.trim()) {
-    return finalText;
-  }
-  const streamedText = params.streamedText ?? "";
-  if (streamedText.trim()) {
-    return streamedText;
-  }
-  const errorMessage = params.errorMessage ?? "";
-  if (errorMessage.trim()) {
-    return formatRawAssistantErrorForUi(errorMessage);
-  }
-  const attachmentText = params.attachmentText ?? "";
-  if (attachmentText.trim()) {
-    return attachmentText;
-  }
-  return "(no output)";
+  const contentText =
+    [params.finalText, params.streamedText].find((text) => text?.trim()) ??
+    (params.errorMessage?.trim() ? formatRawAssistantErrorForUi(params.errorMessage) : "");
+  return formatTuiAssistantContent(params.message, contentText) || "(no output)";
 }
 
 export function composeThinkingAndContent(params: {
@@ -354,13 +343,6 @@ export function composeThinkingAndContent(params: {
   }
 
   return parts.join("\n\n").trim();
-}
-
-function asMessageRecord(message: unknown): Record<string, unknown> | undefined {
-  if (!message || typeof message !== "object") {
-    return undefined;
-  }
-  return message as Record<string, unknown>;
 }
 
 type TuiAttachmentKind = "image" | "audio" | "video" | "file" | "media";
@@ -416,7 +398,7 @@ function resolvePersistedTuiAttachmentKind(
 }
 
 /** Render assistant attachments without exposing their sources or capability URLs. */
-export function extractAssistantAttachmentText(message: unknown): string {
+function extractAssistantAttachmentText(message: unknown): string {
   const record = asMessageRecord(message);
   if (!record) {
     return "";
@@ -446,6 +428,29 @@ export function extractAssistantAttachmentText(message: unknown): string {
       : []),
   ];
   return legacyMedia.map(() => "Attached media").join("\n");
+}
+
+function formatTuiAssistantContent(message: unknown, contentText: string): string {
+  const content = asMessageRecord(message)?.content;
+  const failures: ReplyMediaFailure[] = [];
+  for (const block of Array.isArray(content) ? content : []) {
+    const entry = asMessageRecord(block);
+    const attachment =
+      entry?.type === "attachment_error" ? asMessageRecord(entry.attachment) : undefined;
+    const code = attachment?.code;
+    const kind = attachment?.kind;
+    if (
+      (code === "file-not-found" || code === "unsupported-format" || code === "delivery-failed") &&
+      (kind === "image" || kind === "audio" || kind === "video" || kind === "document")
+    ) {
+      // Assistant attachment labels can contain private paths or capability URLs.
+      // Reuse the actionable receipt wording, but keep the TUI's generic labels.
+      failures.push({ code, kind, label: `${kind === "document" ? "file" : kind} attachment` });
+    }
+  }
+  return (
+    appendReplyMediaFailures(contentText || extractAssistantAttachmentText(message), failures) ?? ""
+  );
 }
 
 function resolveMessageRecord(
@@ -651,8 +656,9 @@ export function extractTextFromMessage(
     return composeThinkingAndContent({
       thinkingText: extractThinkingFromMessage(record),
       contentText:
-        contentText ||
-        (opts?.includeAttachments !== false ? extractAssistantAttachmentText(record) : ""),
+        opts?.includeAttachments !== false
+          ? formatTuiAssistantContent(record, contentText)
+          : contentText,
       showThinking: opts?.includeThinking ?? false,
     });
   }

--- a/src/tui/tui-session-projection.ts
+++ b/src/tui/tui-session-projection.ts
@@ -157,6 +157,8 @@ export function projectTuiSessionFinal(
     event.message && typeof event.message === "object" && !Array.isArray(event.message)
       ? (event.message as Record<string, unknown>)
       : {};
+  // Failure receipts are already in finalText; retain only successful blocks
+  // so a history rebuild cannot append the same failure a second time.
   const attachments = Array.isArray(source.content)
     ? source.content.filter(isTuiAssistantAttachmentBlock)
     : [];

--- a/src/tui/tui-stream-assembler.ts
+++ b/src/tui/tui-stream-assembler.ts
@@ -1,7 +1,6 @@
 // Assembles streamed backend events into TUI-visible messages.
 import {
   composeThinkingAndContent,
-  extractAssistantAttachmentText,
   extractContentFromMessage,
   extractThinkingFromMessage,
   resolveFinalAssistantText,
@@ -232,7 +231,7 @@ export class TuiStreamAssembler {
       finalText: shouldKeepStreamedText ? streamedContentText : state.contentText,
       streamedText: streamedContentText,
       errorMessage,
-      attachmentText: extractAssistantAttachmentText(message),
+      message,
     });
     // Thinking is optional presentation around the selected response content;
     // it must not hide errors or attachments when the final has no text.


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where TUI users received no visible failed-attachment outcome when an assistant reply contained a typed attachment error. A failure-only reply became empty history or `(no output)`, while a caption hid the error entirely.

## Why This Change Was Made

The TUI's canonical content formatter now combines the selected reply with actionable attachment failures instead of treating all attachments as a fallback for missing text. History and final stream assembly share that owner. The existing reply-media formatter supplies the wording, while the TUI retains generic media-kind labels so private filenames, source URLs and terminal escape sequences do not leak into the display.

Final text still takes precedence over streamed text, then an actual error and successful-attachment fallback. Failure receipts are composed after that selection, so a failure-only final cannot erase an already streamed caption. The optimistic projection keeps the rendered receipt once; authoritative history can replace it without duplicating it. Failure-only aborts remain cancellation diagnostics rather than successful final output.

This removes the duplicate record-coercion helper and makes the successful-attachment helper private after migrating its sole production caller. Production LOC: +37/-30 (net +7; including the ownership comment). The small remaining growth implements validation and presentation of a typed failure variant the TUI previously could not render; failure wording and final selection are reused rather than duplicated. The assertion baseline is reduced by one, not relaxed. No configuration, protocol, SDK, dependency or persistent-store change.

Provenance: #131826 introduced the typed failure producer (8bd895862d13c46618d8a331998970c2f3ea7180, 2026-08-28; code author, PR author and merger @vyctorbrzezowski). That made the missing TUI consumer visible. The successful-attachment-only fallback dates to #117460 (b83a966c056288adaef187e3e5826188d9f67724, code author @steipete); it predates the new failure variant.

## User Impact

TUI replies and reloaded history now retain the actionable attachment failure beside the answer, without exposing attachment sources. The TUI documentation describes this behavior. This is the release-note context for the repair.

## Evidence

The complete six-path changed-file gate passed, including production/test typechecking, core/script lint and the selected architecture guards. Independent isolated Codex review found no actionable findings. No landing is claimed before exact-head hosted CI and the native merge workflow complete.

Root reproduction on unchanged main observed empty history and `(no output)` for a failure-only reply, and only `Your recording` for a caption plus failure. The first regression run had 12 intended failures. The repaired owner/formatter/assembler suite passes 126 tests; 94 selected event, ChatLog and Markdown sibling tests also pass (172 others intentionally filtered, not counted). Root independently reran the original formatter/assembler reproduction on Node 24 and confirmed both repaired outcomes.

The real ChatLog renderer is exercised through final events, streamed captions, optimistic history and authoritative history replacement, with an exactly-once receipt assertion. All media kinds and failure codes, mixed success/failure content, error precedence, thinking visibility, aborted runs and private source metadata are covered.

Before, caption plus failed audio:

```text
Your recording
```

After:

```text
Your recording
⚠️ audio attachment: Delivery failed. Try sending this file again.
```

Native PTY replays are on an explicit campaign hold, so this is real renderer/event-flow proof, not a launched terminal UI, authenticated Gateway, provider or live-channel test. No held test, operator Gateway, state directory or credentials were touched.

Validation recovery: the assertion ratchet required its legitimate 5-to-4 reduction after removing a cast. A missing isolated-checkout UI dependency link initially selected old transitive `pako`; linking the already-installed declared UI package resolved it, and the full gate passed. No dependency installation or guard suppression was used.

Shared CI follow-up: #132102 and #132105 independently encounter the current main-composition startup gzip budget overrun. This TUI patch does not alter UI source, the budget, or its baseline; that owner-level repair is being investigated separately before landing.
