### PR TITLE
fix(release): recover historical plugin consent updates

### DIFF
--- a/scripts/e2e/lib/upgrade-survivor/assertions.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/assertions.mjs
@@ -1153,6 +1153,66 @@ function assertStatusJson([file]) {
   assert(/running|connected|ok|ready/u.test(text), "gateway status did not report a healthy state");
 }
 
+function assertRecoverableUpdateJson([file, expectedVersion]) {
+  assert(file && expectedVersion, "assert-recoverable-update-json requires a path and version");
+  const result = readJson(file);
+  const steps = result?.steps;
+  const plugins = result?.postUpdate?.plugins;
+  assert(result?.status === "error", "recoverable update did not report error status");
+  assert(result?.mode === "npm", `recoverable update mode changed: ${String(result?.mode)}`);
+  assert(
+    result?.reason === "post-update-plugins",
+    `update failed before plugin convergence: ${String(result?.reason)}`,
+  );
+  assert(
+    result?.after?.version === expectedVersion,
+    `candidate version was not installed: ${String(result?.after?.version)}`,
+  );
+  assert(Array.isArray(steps) && steps.length > 0, "recoverable update reported no steps");
+  for (const stepName of ["global update", "global install swap"]) {
+    const step = steps.find((entry) => entry?.name === stepName);
+    assert(step?.exitCode === 0, `${stepName} did not complete successfully`);
+  }
+  assert(
+    steps.every((step) => step?.exitCode === 0),
+    "recoverable update contained a failed core step",
+  );
+  assert(plugins?.status === "error", "recoverable update did not fail plugin convergence");
+  assert(
+    plugins?.reason === "post-plugin-doctor-invalid-config",
+    `unexpected plugin convergence failure: ${String(plugins?.reason)}`,
+  );
+  assert(
+    Array.isArray(plugins?.warnings) &&
+      plugins.warnings.some((warning) => warning?.reason?.includes("requires capability consent")),
+    "plugin convergence failure did not require capability consent",
+  );
+}
+
+function assertSuccessfulUpdateJson([file, expectedVersion]) {
+  assert(file && expectedVersion, "assert-successful-update-json requires a path and version");
+  const result = readJson(file);
+  assert(result?.status === "ok", `update did not report ok: ${String(result?.status)}`);
+  assert(
+    result?.after?.version === expectedVersion,
+    `successful update version changed: ${String(result?.after?.version)}`,
+  );
+  assert(
+    Array.isArray(result?.steps) && result.steps.every((step) => step?.exitCode === 0),
+    "successful update contained a failed core step",
+  );
+}
+
+function assertRepairJson([file]) {
+  assert(file, "assert-repair-json requires a path");
+  const result = readJson(file);
+  assert(result?.status === "ok", `update repair did not report ok: ${String(result?.status)}`);
+  assert(result?.mode === "finalize", `update repair mode changed: ${String(result?.mode)}`);
+  assert(result?.restart === false, "update repair unexpectedly restarted the Gateway");
+  assert(result?.postUpdate?.doctor?.status === "ok", "update repair doctor did not pass");
+  assert(result?.postUpdate?.plugins?.status === "ok", "update repair plugins did not pass");
+}
+
 function parseStableVersion(version) {
   const match = /^(\d+)\.(\d+)\.(\d+)(?:-(\d+))?$/u.exec(version ?? "");
   assert(match, `invalid stable package version: ${String(version)}`);
@@ -1325,6 +1385,12 @@ if (command === "list-scenarios") {
   assertCompanionPluginInstalls(process.argv.slice(3));
 } else if (command === "assert-status-json") {
   assertStatusJson(process.argv.slice(3));
+} else if (command === "assert-recoverable-update-json") {
+  assertRecoverableUpdateJson(process.argv.slice(3));
+} else if (command === "assert-successful-update-json") {
+  assertSuccessfulUpdateJson(process.argv.slice(3));
+} else if (command === "assert-repair-json") {
+  assertRepairJson(process.argv.slice(3));
 } else if (command === "assert-update-run-self-upgrade") {
   assertUpdateRunSelfUpgrade(process.argv.slice(3));
 } else {

--- a/scripts/e2e/lib/upgrade-survivor/assertions.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/assertions.mjs
@@ -62,6 +62,24 @@ function readJson(file) {
   return JSON.parse(fs.readFileSync(file, "utf8"));
 }
 
+function readUpdateJson(file) {
+  const raw = fs.readFileSync(file, "utf8");
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    // Published baselines may emit legacy service-control logs before the JSON payload.
+    const jsonStart = raw.indexOf("{");
+    if (jsonStart === -1) {
+      throw error;
+    }
+    return JSON.parse(raw.slice(jsonStart));
+  }
+}
+
+function isCapabilityConsentReason(value) {
+  return typeof value === "string" && value.includes("requires capability consent");
+}
+
 function resolveHomePath(value) {
   if (typeof value !== "string" || value.length === 0) {
     return "";
@@ -1155,7 +1173,7 @@ function assertStatusJson([file]) {
 
 function assertRecoverableUpdateJson([file, expectedVersion]) {
   assert(file && expectedVersion, "assert-recoverable-update-json requires a path and version");
-  const result = readJson(file);
+  const result = readUpdateJson(file);
   const steps = result?.steps;
   const plugins = result?.postUpdate?.plugins;
   assert(result?.status === "error", "recoverable update did not report error status");
@@ -1182,16 +1200,40 @@ function assertRecoverableUpdateJson([file, expectedVersion]) {
     plugins?.reason === "post-plugin-doctor-invalid-config",
     `unexpected plugin convergence failure: ${String(plugins?.reason)}`,
   );
+  const syncErrors = plugins?.sync?.errors;
+  const npmOutcomes = plugins?.npm?.outcomes;
+  const integrityDrifts = plugins?.integrityDrifts;
   assert(
-    Array.isArray(plugins?.warnings) &&
-      plugins.warnings.some((warning) => warning?.reason?.includes("requires capability consent")),
+    Array.isArray(syncErrors) && syncErrors.every(isCapabilityConsentReason),
+    "recoverable update contained a non-consent plugin synchronization error",
+  );
+  assert(
+    Array.isArray(npmOutcomes) &&
+      npmOutcomes.every(
+        (outcome) =>
+          outcome?.status !== "error" || outcome?.code === "PLUGIN_CAPABILITY_CONSENT_REQUIRED",
+      ),
+    "recoverable update contained a non-consent failed plugin update",
+  );
+  assert(
+    Array.isArray(integrityDrifts) && integrityDrifts.length === 0,
+    "recoverable update contained a plugin integrity drift",
+  );
+  assert(
+    (Array.isArray(plugins?.warnings) &&
+      plugins.warnings.some((warning) => isCapabilityConsentReason(warning?.reason))) ||
+      syncErrors.some(isCapabilityConsentReason) ||
+      npmOutcomes.some(
+        (outcome) =>
+          outcome?.status === "error" && outcome?.code === "PLUGIN_CAPABILITY_CONSENT_REQUIRED",
+      ),
     "plugin convergence failure did not require capability consent",
   );
 }
 
 function assertSuccessfulUpdateJson([file, expectedVersion]) {
   assert(file && expectedVersion, "assert-successful-update-json requires a path and version");
-  const result = readJson(file);
+  const result = readUpdateJson(file);
   assert(result?.status === "ok", `update did not report ok: ${String(result?.status)}`);
   assert(
     result?.after?.version === expectedVersion,

--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -1412,11 +1412,10 @@ update_candidate() {
   if [ "$update_status" -eq 0 ]; then
     node scripts/e2e/lib/upgrade-survivor/assertions.mjs \
       assert-successful-update-json "$UPDATE_JSON" "$candidate_version"
-    # This tagged baseline predates capability consent and owns the recovery regression proof.
-    # Newer/dynamic baselines may already have consent and legitimately update without repair.
+    # This tagged baseline predates capability consent, even when its updater exits cleanly.
+    # Run candidate-owned repair before post-update validation; newer baselines need no repair.
     if [ "$baseline_version" = "2026.7.1-2" ]; then
-      echo "baseline $baseline_spec unexpectedly skipped capability-consent recovery" >&2
-      return 1
+      update_repair_required="1"
     fi
     if [ "$UPDATE_RESTART_MODE" = "auto-auth" ]; then
       update_end="$(node -e "process.stdout.write(String(Date.now()))")"

--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -91,6 +91,7 @@ status_seconds=""
 healthz_seconds=""
 readyz_seconds=""
 update_restart_seconds=""
+update_repair_required="0"
 migration_seconds=""
 idempotence_seconds=""
 run_completed="0"
@@ -101,6 +102,7 @@ UPDATE_ERR="$ARTIFACT_ROOT/update.err"
 POST_UPDATE_VALIDATE_JSON="$ARTIFACT_ROOT/post-update-validate.json"
 POST_UPDATE_VALIDATE_ERR="$ARTIFACT_ROOT/post-update-validate.err"
 DOCTOR_LOG="$ARTIFACT_ROOT/doctor.log"
+REPAIR_JSON="$ARTIFACT_ROOT/repair.json"
 BASELINE_DOCTOR_LOG="$ARTIFACT_ROOT/baseline-doctor.log"
 GATEWAY_LOG="$ARTIFACT_ROOT/gateway.log"
 HEALTHZ_JSON="$ARTIFACT_ROOT/healthz.json"
@@ -1383,29 +1385,6 @@ candidate_update_spec() {
   esac
 }
 
-assert_update_json_ok() {
-  local file="$1"
-  node -e '
-    const fs = require("node:fs");
-    const file = process.argv[1];
-    const raw = fs.readFileSync(file, "utf8");
-    let result;
-    try {
-      result = JSON.parse(raw);
-    } catch (err) {
-      // Published baselines may emit legacy service-control logs before the JSON payload.
-      const jsonStart = raw.indexOf("{");
-      if (jsonStart === -1) {
-        throw err;
-      }
-      result = JSON.parse(raw.slice(jsonStart));
-    }
-    if (!result || result.status !== "ok") {
-      throw new Error(`update JSON did not report ok status: ${JSON.stringify(result)}`);
-    }
-  ' "$file"
-}
-
 update_candidate() {
   local update_spec
   update_spec="$(candidate_update_spec)"
@@ -1430,8 +1409,24 @@ update_candidate() {
   update_env+=("NODE_OPTIONS=${NODE_OPTIONS:+$NODE_OPTIONS }--import=$PWD/scripts/e2e/lib/upgrade-survivor/diagnostics.mjs")
   local update_status=0
   openclaw_e2e_maybe_timeout "$COMMAND_TIMEOUT" "${update_env[@]}" openclaw "${update_args[@]}" >"$UPDATE_JSON" 2>"$UPDATE_ERR" || update_status=$?
-  if [ "$update_status" -ne 0 ]; then
-    echo "openclaw update failed" >&2
+  if [ "$update_status" -eq 0 ]; then
+    node scripts/e2e/lib/upgrade-survivor/assertions.mjs \
+      assert-successful-update-json "$UPDATE_JSON" "$candidate_version"
+    # This tagged baseline predates capability consent and owns the recovery regression proof.
+    # Newer/dynamic baselines may already have consent and legitimately update without repair.
+    if [ "$baseline_version" = "2026.7.1-2" ]; then
+      echo "baseline $baseline_spec unexpectedly skipped capability-consent recovery" >&2
+      return 1
+    fi
+    if [ "$UPDATE_RESTART_MODE" = "auto-auth" ]; then
+      update_end="$(node -e "process.stdout.write(String(Date.now()))")"
+      update_restart_seconds=$(((update_end - update_start + 999) / 1000))
+    fi
+  elif node scripts/e2e/lib/upgrade-survivor/assertions.mjs \
+    assert-recoverable-update-json "$UPDATE_JSON" "$candidate_version"; then
+    update_repair_required="1"
+  else
+    echo "openclaw update failed before the recoverable post-core boundary" >&2
     local validate_status=0
     openclaw_e2e_maybe_timeout "$COMMAND_TIMEOUT" openclaw config validate --json >"$POST_UPDATE_VALIDATE_JSON" 2>"$POST_UPDATE_VALIDATE_ERR" || validate_status=$?
     echo "post-update config validation probe status=$validate_status" >&2
@@ -1441,12 +1436,11 @@ update_candidate() {
     openclaw_e2e_print_log "$UPDATE_JSON" >&2 || true
     return "$update_status"
   fi
-  if [ "$UPDATE_RESTART_MODE" = "auto-auth" ]; then
-    update_end="$(node -e "process.stdout.write(String(Date.now()))")"
-    update_restart_seconds=$(((update_end - update_start + 999) / 1000))
-    assert_update_json_ok "$UPDATE_JSON"
-  fi
   installed_version="$(read_installed_version)"
+  if [ "$installed_version" != "$candidate_version" ]; then
+    echo "update did not leave the candidate installed: $installed_version" >&2
+    return 1
+  fi
 }
 
 assert_root_managed_vps_cli_usable() {
@@ -1463,10 +1457,26 @@ assert_root_managed_vps_cli_usable() {
   openclaw_e2e_maybe_timeout "$COMMAND_TIMEOUT" "${root_cli_env[@]}" openclaw plugins >"$ARTIFACT_ROOT/root-vps-plugins.out" 2>"$ARTIFACT_ROOT/root-vps-plugins.err"
 }
 
-run_doctor() {
-  local started_at budget
+run_post_update_repair() {
+  local started_at budget restart_start restart_end
   started_at="$(date +%s)"
-  if ! openclaw_e2e_maybe_timeout "$COMMAND_TIMEOUT" openclaw doctor --fix --non-interactive >"$DOCTOR_LOG" 2>&1; then
+  if [ "$update_repair_required" = "1" ]; then
+    if ! openclaw_e2e_maybe_timeout "$COMMAND_TIMEOUT" openclaw update repair \
+      --accept-capabilities --yes --no-restart --json >"$REPAIR_JSON" 2>"$DOCTOR_LOG"; then
+      echo "openclaw update repair failed" >&2
+      openclaw_e2e_print_log "$DOCTOR_LOG" >&2
+      openclaw_e2e_print_log "$REPAIR_JSON" >&2
+      return 1
+    fi
+    node scripts/e2e/lib/upgrade-survivor/assertions.mjs assert-repair-json "$REPAIR_JSON"
+    if [ "$UPDATE_RESTART_MODE" = "auto-auth" ]; then
+      restart_start="$(node -e "process.stdout.write(String(Date.now()))")"
+      openclaw_e2e_maybe_timeout "$COMMAND_TIMEOUT" \
+        systemctl --user restart openclaw-gateway.service
+      restart_end="$(node -e "process.stdout.write(String(Date.now()))")"
+      update_restart_seconds=$(((restart_end - restart_start + 999) / 1000))
+    fi
+  elif ! openclaw_e2e_maybe_timeout "$COMMAND_TIMEOUT" openclaw doctor --fix --non-interactive >"$DOCTOR_LOG" 2>&1; then
     echo "openclaw doctor failed" >&2
     openclaw_e2e_print_log "$DOCTOR_LOG" >&2
     return 1
@@ -1669,7 +1679,7 @@ if [ -n "${OPENCLAW_CLAWHUB_URL:-}" ]; then
 fi
 phase root-managed-vps-cli-usable assert_root_managed_vps_cli_usable
 phase assert-legacy-plugin-dependency-debris-before-doctor assert_legacy_plugin_dependency_debris_before_doctor
-phase doctor run_doctor
+phase post-update-repair run_post_update_repair
 phase assert-legacy-plugin-dependency-debris-cleaned assert_legacy_plugin_dependency_debris_cleaned
 phase assert-legacy-runtime-deps-symlink-repaired assert_legacy_runtime_deps_symlink_repaired
 phase validate-post-doctor-config validate_post_doctor_config

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -4803,7 +4803,7 @@ if (starts === 1) {
       'if [ "$update_status" -eq 0 ]; then',
       "assert-successful-update-json",
       'if [ "$baseline_version" = "2026.7.1-2" ]; then',
-      'echo "baseline $baseline_spec unexpectedly skipped capability-consent recovery" >&2',
+      'update_repair_required="1"',
       "assert-recoverable-update-json",
       'echo "openclaw update failed before the recoverable post-core boundary" >&2',
       'openclaw config validate --json >"$POST_UPDATE_VALIDATE_JSON"',

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -2690,7 +2690,7 @@ docker_e2e_docker_run_cmd run demo
     );
     expect(publishedRunner).toContain('"$clawhub_security_mode"');
     expect(publishedRunner.indexOf("phase assert-prepublish-requests node")).toBeLessThan(
-      publishedRunner.indexOf("phase doctor run_doctor"),
+      publishedRunner.indexOf("phase post-update-repair run_post_update_repair"),
     );
     const discordInstallIndex = runner.indexOf(
       'openclaw_e2e_fixture_plugin_command openclaw -- \\\n    plugins install "npm:@openclaw/discord@$package_version" --pin',
@@ -3267,8 +3267,9 @@ fi
       'openclaw_e2e_maybe_timeout "$COMMAND_TIMEOUT" "${root_cli_env[@]}" openclaw',
     );
     expect(publishedRunner).toContain(
-      'openclaw_e2e_maybe_timeout "$COMMAND_TIMEOUT" openclaw doctor --fix --non-interactive',
+      'openclaw_e2e_maybe_timeout "$COMMAND_TIMEOUT" openclaw update repair',
     );
+    expect(publishedRunner).toContain("--accept-capabilities --yes --no-restart --json");
     expect(publishedRunner).toContain(
       'openclaw_e2e_maybe_timeout "$COMMAND_TIMEOUT" openclaw config validate',
     );
@@ -4799,8 +4800,12 @@ if (starts === 1) {
     expectTextToIncludeInOrder(publishedRunner, [
       "local update_status=0",
       'openclaw "${update_args[@]}" >"$UPDATE_JSON" 2>"$UPDATE_ERR" || update_status=$?',
-      'if [ "$update_status" -ne 0 ]; then',
-      'echo "openclaw update failed" >&2',
+      'if [ "$update_status" -eq 0 ]; then',
+      "assert-successful-update-json",
+      'if [ "$baseline_version" = "2026.7.1-2" ]; then',
+      'echo "baseline $baseline_spec unexpectedly skipped capability-consent recovery" >&2',
+      "assert-recoverable-update-json",
+      'echo "openclaw update failed before the recoverable post-core boundary" >&2',
       'openclaw config validate --json >"$POST_UPDATE_VALIDATE_JSON"',
       'echo "post-update config validation probe status=$validate_status" >&2',
       'openclaw_e2e_print_log "$POST_UPDATE_VALIDATE_ERR" >&2 || true',
@@ -4809,6 +4814,7 @@ if (starts === 1) {
       'openclaw_e2e_print_log "$UPDATE_JSON" >&2 || true',
       'return "$update_status"',
     ]);
+    expect(publishedRunner).not.toContain("update_args+=(--accept-capabilities)");
 
     expectTextToIncludeAll(runner, [
       'openclaw_e2e_print_log "$OPENCLAW_UPGRADE_SURVIVOR_ARTIFACT_ROOT/update.err"',

--- a/test/scripts/upgrade-survivor-assertions.test.ts
+++ b/test/scripts/upgrade-survivor-assertions.test.ts
@@ -28,19 +28,41 @@ const RECOVERABLE_UPDATE = {
       status: "error",
       reason: "post-plugin-doctor-invalid-config",
       warnings: [{ reason: 'Plugin "discord" requires capability consent.' }],
+      sync: { errors: [] },
+      npm: { outcomes: [] },
+      integrityDrifts: [],
     },
   },
 };
 
 function runJsonAssertion(command: string, value: unknown, ...args: string[]) {
+  return runJsonTextAssertion(command, `${JSON.stringify(value, null, 2)}\n`, ...args);
+}
+
+function runJsonTextAssertion(command: string, contents: string, ...args: string[]) {
   const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-json-"));
   const file = join(root, "result.json");
-  writeJson(file, value);
+  writeFileSync(file, contents);
   const result = spawnSync(process.execPath, [ASSERTIONS_PATH, command, file, ...args], {
     encoding: "utf8",
   });
   rmSync(root, { force: true, recursive: true });
   return result;
+}
+
+function runPrefixedJsonAssertion(command: string, value: unknown, ...args: string[]) {
+  return runJsonTextAssertion(
+    command,
+    `Stopped legacy service before update\n${JSON.stringify(value)}\n`,
+    ...args,
+  );
+}
+
+function withPluginResult(patch: Record<string, unknown>) {
+  return {
+    ...RECOVERABLE_UPDATE,
+    postUpdate: { plugins: { ...RECOVERABLE_UPDATE.postUpdate.plugins, ...patch } },
+  };
 }
 
 describe("upgrade recovery result assertions", () => {
@@ -54,16 +76,37 @@ describe("upgrade recovery result assertions", () => {
     expect(
       runJsonAssertion(
         "assert-successful-update-json",
-        { ...result, steps: [{ name: "global update", exitCode: 1 }] },
+        {
+          ...result,
+          steps: [{ name: "global update", exitCode: 1 }],
+        },
         "2026.8.1",
       ).status,
     ).not.toBe(0);
+    expect(
+      runPrefixedJsonAssertion("assert-successful-update-json", result, "2026.8.1").status,
+    ).toBe(0);
   });
 
   it("accepts only a completed core swap stranded on capability consent", () => {
     expect(
-      runJsonAssertion("assert-recoverable-update-json", RECOVERABLE_UPDATE, "2026.8.1").status,
+      runPrefixedJsonAssertion("assert-recoverable-update-json", RECOVERABLE_UPDATE, "2026.8.1")
+        .status,
     ).toBe(0);
+    const consentError = 'Plugin "discord" requires capability consent.';
+    const consentOutcome = {
+      pluginId: "discord",
+      status: "error",
+      code: "PLUGIN_CAPABILITY_CONSENT_REQUIRED",
+    };
+    const validResults = [
+      RECOVERABLE_UPDATE,
+      withPluginResult({ warnings: [], sync: { errors: [consentError] } }),
+      withPluginResult({ warnings: [], npm: { outcomes: [consentOutcome] } }),
+    ];
+    for (const value of validResults) {
+      expect(runJsonAssertion("assert-recoverable-update-json", value, "2026.8.1").status).toBe(0);
+    }
 
     const invalidResults = [
       { ...RECOVERABLE_UPDATE, reason: "global-update-failed" },
@@ -74,12 +117,13 @@ describe("upgrade recovery result assertions", () => {
           index === 0 ? { ...step, exitCode: 1 } : step,
         ),
       },
-      {
-        ...RECOVERABLE_UPDATE,
-        postUpdate: {
-          plugins: { status: "error", reason: "registry-timeout", warnings: [] },
-        },
-      },
+      { ...RECOVERABLE_UPDATE, postUpdate: { plugins: { reason: "registry-timeout" } } },
+      withPluginResult({ sync: { errors: [consentError, "registry unavailable"] } }),
+      withPluginResult({ npm: { outcomes: [{ status: "error", code: "EIO" }] } }),
+      withPluginResult({ integrityDrifts: [{ pluginId: "discord" }] }),
+      ...["sync", "npm", "integrityDrifts"].map((field) =>
+        withPluginResult({ [field]: undefined }),
+      ),
     ];
     for (const value of invalidResults) {
       expect(runJsonAssertion("assert-recoverable-update-json", value, "2026.8.1").status).not.toBe(

--- a/test/scripts/upgrade-survivor-assertions.test.ts
+++ b/test/scripts/upgrade-survivor-assertions.test.ts
@@ -1,5 +1,5 @@
 // Upgrade Survivor Assertions tests cover upgrade survivor assertions script behavior.
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -12,6 +12,98 @@ const ASSERTIONS_PATH = "scripts/e2e/lib/upgrade-survivor/assertions.mjs";
 function writeJson(path: string, value: unknown): void {
   writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
 }
+
+const RECOVERABLE_UPDATE = {
+  status: "error",
+  mode: "npm",
+  reason: "post-update-plugins",
+  after: { version: "2026.8.1" },
+  steps: [
+    { name: "global update", exitCode: 0 },
+    { name: "global install swap", exitCode: 0 },
+    { name: "openclaw doctor", exitCode: 0 },
+  ],
+  postUpdate: {
+    plugins: {
+      status: "error",
+      reason: "post-plugin-doctor-invalid-config",
+      warnings: [{ reason: 'Plugin "discord" requires capability consent.' }],
+    },
+  },
+};
+
+function runJsonAssertion(command: string, value: unknown, ...args: string[]) {
+  const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-json-"));
+  const file = join(root, "result.json");
+  writeJson(file, value);
+  const result = spawnSync(process.execPath, [ASSERTIONS_PATH, command, file, ...args], {
+    encoding: "utf8",
+  });
+  rmSync(root, { force: true, recursive: true });
+  return result;
+}
+
+describe("upgrade recovery result assertions", () => {
+  it("accepts clean updates for baselines that already have consent", () => {
+    const result = {
+      status: "ok",
+      after: { version: "2026.8.1" },
+      steps: [{ name: "global update", exitCode: 0 }],
+    };
+    expect(runJsonAssertion("assert-successful-update-json", result, "2026.8.1").status).toBe(0);
+    expect(
+      runJsonAssertion(
+        "assert-successful-update-json",
+        { ...result, steps: [{ name: "global update", exitCode: 1 }] },
+        "2026.8.1",
+      ).status,
+    ).not.toBe(0);
+  });
+
+  it("accepts only a completed core swap stranded on capability consent", () => {
+    expect(
+      runJsonAssertion("assert-recoverable-update-json", RECOVERABLE_UPDATE, "2026.8.1").status,
+    ).toBe(0);
+
+    const invalidResults = [
+      { ...RECOVERABLE_UPDATE, reason: "global-update-failed" },
+      { ...RECOVERABLE_UPDATE, after: { version: "2026.7.1-2" } },
+      {
+        ...RECOVERABLE_UPDATE,
+        steps: RECOVERABLE_UPDATE.steps.map((step, index) =>
+          index === 0 ? { ...step, exitCode: 1 } : step,
+        ),
+      },
+      {
+        ...RECOVERABLE_UPDATE,
+        postUpdate: {
+          plugins: { status: "error", reason: "registry-timeout", warnings: [] },
+        },
+      },
+    ];
+    for (const value of invalidResults) {
+      expect(runJsonAssertion("assert-recoverable-update-json", value, "2026.8.1").status).not.toBe(
+        0,
+      );
+    }
+  });
+
+  it("requires repair to finish doctor and plugin convergence without restart", () => {
+    const repaired = {
+      status: "ok",
+      mode: "finalize",
+      restart: false,
+      postUpdate: { doctor: { status: "ok" }, plugins: { status: "ok" } },
+    };
+    expect(runJsonAssertion("assert-repair-json", repaired).status).toBe(0);
+    expect(
+      runJsonAssertion("assert-repair-json", {
+        ...repaired,
+        postUpdate: { ...repaired.postUpdate, plugins: { status: "warning" } },
+      }).status,
+    ).not.toBe(0);
+  });
+});
 
 function writeMigratedSessionState(stateDir: string): void {
   const agentSessionsDir = join(stateDir, "agents", "main", "sessions");


### PR DESCRIPTION
## What this fixes

Historical upgrade-survivor lanes correctly hit the new fail-closed plugin capability boundary after replacing core, but the harness treated that recoverable post-core exit as an ordinary update failure. The release loop therefore never exercised the documented `openclaw update repair --accept-capabilities` recovery path.

## Fix

- Accept only the structured recoverable result: npm mode, candidate version installed, `reason=post-update-plugins`, every executed core step successful, both global update and swap successful, and plugin convergence specifically stranded on capability consent.
- Preserve normal successful updates for newer/dynamic baselines that already carry consent. The exact `2026.7.1-2` historical baseline remains the explicit recovery regression contract and must traverse repair.
- Preserve the historical-baseline stdout contract: update result artifacts may contain legacy service-control text before their JSON payload. Both clean-success and consent-recovery classification retain that tolerant parsing before applying strict structural checks.
- Reject malformed output, pre-core failures, failed core steps, version mismatches, and unrelated plugin failures.
- Run the installed candidate's `update repair --accept-capabilities --yes --no-restart --json` and require `mode=finalize`, Doctor `ok`, plugins `ok`, and no implicit restart.
- Preserve the auto-auth lane by explicitly restarting its managed service only after successful repair, then running the existing health/auth proof.

Production LOC: **0**. E2E support: **+152/-34**. Tests: **+147/-5**.