### PR TITLE
fix: completed restart recovery no longer blocks sessions

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -3221,12 +3221,21 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     expect(state.runAgentAttemptMock).not.toHaveBeenCalled();
   });
 
-  it("retains and clears a preclaimed transcript-only recovery run", async () => {
+  it("clears the recovery cycle when a preclaimed transcript-only recovery run completes", async () => {
     setupSingleAttemptFallback();
     state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
     setupBareStoredSession({
       restartRecoveryDeliveryRunId: "recovery-run",
       restartRecoveryDeliverySourceRunId: "control-ui-run",
+      restartRecoveryRuns: [
+        { runId: "older-recovery", lifecycleGeneration: "pre-restart" },
+        { runId: "recovery-run", lifecycleGeneration: "test-generation" },
+      ],
+      mainRestartRecovery: {
+        cycleId: "cycle-1",
+        revision: 5,
+        chargedAttempts: 2,
+      },
     });
 
     await agentCommand({
@@ -3234,6 +3243,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       sessionKey: "agent:main:main",
       deliver: false,
       runId: "recovery-run",
+      preserveUserFacingSessionModelState: true,
     });
 
     const persistedClaims = state.persistSessionEntryMock.mock.calls.map((call) => {
@@ -3264,6 +3274,10 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     expect(stored?.restartRecoveryDeliveryRunId).toBeUndefined();
     expect(stored?.restartRecoveryDeliverySourceRunId).toBeUndefined();
     expect(stored?.restartRecoveryTerminalRunIds).toEqual(["control-ui-run", "recovery-run"]);
+    expect(stored?.restartRecoveryRuns).toBeUndefined();
+    expect(
+      (stored as SessionEntry & { mainRestartRecovery?: unknown }).mainRestartRecovery,
+    ).toBeUndefined();
   });
 
   it("refreshes delivery session entries through the session accessor", async () => {
@@ -3452,6 +3466,12 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
         accountId: "main",
       },
       restartRecoveryDeliveryRunId: "later-run",
+      restartRecoveryRuns: [{ runId: "later-run", lifecycleGeneration: "later-generation" }],
+      mainRestartRecovery: {
+        cycleId: "later-cycle",
+        revision: 1,
+        chargedAttempts: 0,
+      },
     });
     const sessionStore = { "agent:main:main": laterRunEntry };
     state.sessionEntryMock = staleEntry;
@@ -3464,16 +3484,32 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       laterRunEntry.restartRecoveryDeliveryContext,
     );
     expect(sessionStore["agent:main:main"]?.restartRecoveryDeliveryRunId).toBe("later-run");
+    expect(sessionStore["agent:main:main"]?.restartRecoveryRuns).toEqual(
+      laterRunEntry.restartRecoveryRuns,
+    );
+    expect(sessionStore["agent:main:main"]?.mainRestartRecovery).toEqual(
+      laterRunEntry.mainRestartRecovery,
+    );
   });
 
-  it("keeps current run delivery context when restart marker wins the cleanup race", async () => {
+  it("preserves a newly marked recovery cycle when restart wins the cleanup race", async () => {
     setupSingleAttemptFallback();
     state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
     const { store: sessionStore } = setupBareStoredSession();
+    const nextRecoveryRuns = [{ runId: "session-1", lifecycleGeneration: "next-generation" }];
+    const nextRecoveryCycle = {
+      cycleId: "next-cycle",
+      revision: 1,
+      chargedAttempts: 0,
+    };
     state.deliverAgentCommandResultMock.mockImplementation(async () => {
-      const current = sessionStore["agent:main:main"];
+      const current = sessionStore["agent:main:main"] as
+        | (SessionEntry & { mainRestartRecovery?: typeof nextRecoveryCycle })
+        | undefined;
       if (current) {
         current.abortedLastRun = true;
+        current.restartRecoveryRuns = nextRecoveryRuns;
+        current.mainRestartRecovery = nextRecoveryCycle;
       }
       return { deliverySucceeded: false };
     });
@@ -3481,6 +3517,14 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     await runDiscordDelivery();
 
     expect(sessionStore["agent:main:main"]?.abortedLastRun).toBe(true);
+    expect(sessionStore["agent:main:main"]?.restartRecoveryRuns).toEqual(nextRecoveryRuns);
+    expect(
+      (
+        sessionStore["agent:main:main"] as SessionEntry & {
+          mainRestartRecovery?: typeof nextRecoveryCycle;
+        }
+      ).mainRestartRecovery,
+    ).toEqual(nextRecoveryCycle);
     expect(state.persistSessionEntryMock).toHaveBeenCalledWith(
       expect.objectContaining({
         entry: expect.objectContaining({

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -1,4 +1,3 @@
-/** Main agent command orchestration for sessions, model selection, delivery, and attempts. */
 import path from "node:path";
 import { coerceErrorMessage } from "@openclaw/normalization-core/error-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
@@ -10,7 +9,6 @@ import {
 } from "../config/sessions/lifecycle.js";
 import { buildRestartRecoveryClaimCleanupPatch } from "../config/sessions/restart-recovery-state.js";
 import type { RestartRecoveryTerminalDeliveryEvidenceResult } from "../config/sessions/restart-recovery-types.js";
-import type { InternalSessionEntry } from "../config/sessions/types.js";
 import {
   assertAgentRunLifecycleGenerationCurrent,
   captureAgentRunLifecycleGeneration,
@@ -66,6 +64,7 @@ import {
   resolveInternalSessionEffectsTarget,
 } from "./internal-session-effects.js";
 import { AGENT_LANE_SUBAGENT } from "./lanes.js";
+import { buildMainSessionRecoveryClearPatch } from "./main-session-recovery/main-session-recovery-clear.js";
 import type { MainSessionRecoveryPendingTarget } from "./main-session-recovery/main-session-recovery-store.js";
 import type { AgentRunSessionTarget } from "./run-session-target.js";
 import { createAgentRunRestartAbortError } from "./run-termination.js";
@@ -286,7 +285,7 @@ async function agentCommandInternal(
       }
 
       let currentRunDeliveryPrepared = false;
-      const prepareDeliveryForRun = async (candidateSessionEntry?: InternalSessionEntry) => {
+      const prepareDeliveryForRun = async (candidateSessionEntry?: typeof sessionEntry) => {
         if (currentRunDeliveryPrepared || opts.deliver !== true) {
           return;
         }
@@ -344,7 +343,7 @@ async function agentCommandInternal(
             ? runId
             : undefined;
         assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
-        const next: InternalSessionEntry = {
+        const next = {
           ...entry,
           sessionId,
           updatedAt: now,
@@ -570,22 +569,22 @@ async function agentCommandInternal(
       try {
         const entry = sessionStore[sessionKey] ?? sessionEntry;
         if (entry?.restartRecoveryDeliveryRunId === runId) {
-          const next: InternalSessionEntry = {
-            ...entry,
-            ...buildRestartRecoveryClaimCleanupPatch({
-              entry,
-              recordTerminalSource: true,
-              terminalRunId: runId,
-              terminalDeliveryEvidence: restartRecoveryTerminalDeliveryEvidence,
-            }),
-            updatedAt: Date.now(),
-          };
           const persisted = await persistAgentSession({
             sessionStore,
             sessionKey,
             storePath,
             initialEntry: entry,
-            entry: next,
+            entry: {
+              ...entry,
+              ...buildRestartRecoveryClaimCleanupPatch({
+                entry,
+                recordTerminalSource: true,
+                terminalRunId: runId,
+                terminalDeliveryEvidence: restartRecoveryTerminalDeliveryEvidence,
+              }),
+              ...buildMainSessionRecoveryClearPatch(entry),
+              updatedAt: Date.now(),
+            },
             shouldPersist: (current) =>
               shouldPersistRestartRecoveryCleanup(current, runOwnedSessionId, runId),
           });
@@ -710,8 +709,7 @@ export async function agentCommandFromIngress(
   runtime: RuntimeEnv = defaultRuntime,
   deps?: CliDeps,
 ) {
-  // Plugin SDK callers may be plain JavaScript. Enforce the private recovery
-  // boundary at runtime so extra or inherited properties cannot author audit identity.
+  // Enforce the private recovery boundary for JavaScript Plugin SDK callers.
   return await agentCommandFromIngressInternal(
     sanitizePublicAgentCommandIngressOpts(opts),
     runtime,

--- a/src/agents/command/post-run.ts
+++ b/src/agents/command/post-run.ts
@@ -20,6 +20,7 @@ import {
 import { normalizeAgentRunTerminalDeliverySnapshot } from "../agent-run-terminal-delivery.js";
 import { OPENCLAW_AGENT_RUNTIME_ID } from "../agent-runtime-id.js";
 import { isHeartbeatLifecycleRunKind } from "../bootstrap-mode.js";
+import { buildMainSessionRecoveryClearPatch } from "../main-session-recovery/main-session-recovery-clear.js";
 import { persistPendingFinalDeliveryMarker } from "../pending-final-delivery-marker.js";
 import type { AgentRunSessionTarget } from "../run-session-target.js";
 import { throwAgentRunRestartAbortReason } from "../run-termination.js";
@@ -555,8 +556,8 @@ export async function finalizeEmbeddedAgentCommand(params: {
       const clearOwnedPendingFinal =
         deliveryResult?.deliverySucceeded === true &&
         pendingFinalDeliveryMarker.pendingFinalDeliveryIntentId !== undefined;
-      // Preserve the exact local claim through sibling session writes so a delivered
-      // source is tombstoned before admission release can erase its ownership fields.
+      // Preserve the exact claim snapshot through sibling session writes, then
+      // revalidate its durable owner immediately before committing cleanup.
       const recoveryClaimEntry =
         entry.restartRecoveryDeliveryRunId === runId
           ? entry
@@ -565,6 +566,7 @@ export async function finalizeEmbeddedAgentCommand(params: {
             : params.sessionEntry?.restartRecoveryDeliveryRunId === runId
               ? params.sessionEntry
               : undefined;
+      const clearsRecoveryCycle = entry.restartRecoveryDeliveryRunId === runId;
       if (clearOwnedPendingFinal || clearStaleTransportOnly || recoveryClaimEntry) {
         const now = Date.now();
         sessionEntry = await persistAgentSession({
@@ -591,12 +593,13 @@ export async function finalizeEmbeddedAgentCommand(params: {
                   terminalRunId: runId,
                 })
               : {}),
+            ...(clearsRecoveryCycle ? buildMainSessionRecoveryClearPatch(entry) : {}),
           },
           shouldPersist: (current) =>
             shouldPersistCurrentRunSessionCleanup(current, runOwnedSessionId) &&
             (!recoveryClaimEntry ||
-              current?.restartRecoveryDeliveryRunId === undefined ||
-              current.restartRecoveryDeliveryRunId === runId) &&
+              current?.restartRecoveryDeliveryRunId === runId ||
+              (!clearsRecoveryCycle && current?.restartRecoveryDeliveryRunId === undefined)) &&
             (!clearOwnedPendingFinal ||
               current?.pendingFinalDelivery?.intentId ===
                 pendingFinalDeliveryMarker.pendingFinalDeliveryIntentId) &&


### PR DESCRIPTION
Related: #117096
Related: #118873

## What Problem This Solves

Fixes an issue where users could remain permanently unable to start another turn after Gateway restart recovery completed while an older recovery fence remained in the session aggregate. Later messages failed before model execution with `Session "…" changed while starting work. Retry.`

## Why This Change Was Made

The exact delivery-claim finalizer now clears the completed main-session recovery aggregate in the same compare-and-set persistence operation. Cleanup still requires the latest durable entry to have the same session and delivery owner and not be restart-marked, so a stale finalizer cannot erase a successor run's recovery cycle or delivery context.

This is the mixed-residue sibling of the terminal-only state repaired by #126671. Blame traces the incomplete claim-only cleanup to #121908: it terminalized the delivery claim without retiring `restartRecoveryRuns` and `mainRestartRecovery` together.

## User Impact

After an interrupted main-session turn is successfully recovered, later messages can start normally even when an older restart-recovery fence was retained across overlapping Gateway restarts. Active successor recovery work remains fenced.

AI-assisted: yes (Codex).

## Evidence

- Pre-fix regression: the completed `recovery-run` claim cleared, but `restartRecoveryRuns` still retained `older-recovery`, reproducing the permanent admission wedge.
- Exact-head focused tests: `node scripts/run-vitest.mjs src/agents/agent-command.live-model-switch.test.ts src/agents/main-session-recovery/main-session-recovery-state.test.ts src/agents/main-session-recovery/main-session-recovery-run-ownership.test.ts` — 3 files, 169 tests passed.
- Second-restart counterproof: the command-boundary test marks the latest row interrupted during delivery, installs a successor aggregate/fence, and verifies both cleanup sites preserve `abortedLastRun`, `restartRecoveryRuns`, `mainRestartRecovery`, and the prior delivery claim.
- CAS proof: `shouldPersistCurrentRunSessionCleanup` rejects restart-marked latest rows; `persistAgentSession` evaluates that predicate against the latest durable entry; SQLite revalidates the prepared snapshot at commit.
- Exact-head changed gate: `node scripts/check-changed.mjs` — passed, including core/test typechecks, lint, formatting, dead exports, import cycles, and database/schema policy guards.
- Exact-head autoreview: clean with no accepted/actionable findings (Codex, 0.97 confidence).
- Isolated real-Gateway proof before the conflict-free rebase: interrupted turn recovered, mixed residue cleared, a second `chat.send` started, and `agent.wait` returned `ok` using disposable state and a non-operator port.
- Prior CI failure was not attributable: the PR base failed the same Control UI gzip budget, and current `main` fixed it in #132020; this head is rebased onto that fix.
- Production LOC: +22/-21 (net +1). Tests: +38/-2.
- Visual proof gap: no Control UI recording was captured; the real-flow proof exercised the isolated Gateway RPC path directly.

