### PR TITLE
fix(ui): restore the Control UI startup JavaScript budget

### DIFF
--- a/ui/src/lib/agents/display.ts
+++ b/ui/src/lib/agents/display.ts
@@ -5,11 +5,6 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
-import {
-  expandToolGroups,
-  normalizeToolPolicyName,
-  resolveToolProfilePolicy,
-} from "../../../../src/agents/tool-policy-shared.js";
 import type {
   AgentIdentityResult,
   AgentsFilesListResult,
@@ -200,11 +195,6 @@ export function resolveToolProfileOptions(
     label: t(profile.labelKey),
   }));
 }
-
-type ToolPolicy = {
-  allow?: string[];
-  deny?: string[];
-};
 
 type GitHubIdentityConfigValue = {
   profileId?: string;
@@ -591,91 +581,4 @@ export function buildModelOptions(
   }
 
   return options;
-}
-
-type CompiledPattern =
-  | { kind: "all" }
-  | { kind: "exact"; value: string }
-  | { kind: "regex"; value: RegExp };
-
-function compilePattern(pattern: string): CompiledPattern {
-  const normalized = normalizeToolPolicyName(pattern);
-  if (!normalized) {
-    return { kind: "exact", value: "" };
-  }
-  if (normalized === "*") {
-    return { kind: "all" };
-  }
-  if (!normalized.includes("*")) {
-    return { kind: "exact", value: normalized };
-  }
-  const escaped = normalized.replace(/[.*+?^${}()|[\\]\\]/g, "\\$&");
-  return { kind: "regex", value: new RegExp(`^${escaped.replaceAll("\\*", ".*")}$`) };
-}
-
-function compilePatterns(patterns?: string[]): CompiledPattern[] {
-  if (!Array.isArray(patterns)) {
-    return [];
-  }
-  return expandToolGroups(patterns)
-    .map(compilePattern)
-    .filter((pattern) => {
-      return pattern.kind !== "exact" || pattern.value.length > 0;
-    });
-}
-
-function matchesAny(name: string, patterns: CompiledPattern[]) {
-  for (const pattern of patterns) {
-    if (pattern.kind === "all") {
-      return true;
-    }
-    if (pattern.kind === "exact" && name === pattern.value) {
-      return true;
-    }
-    if (pattern.kind === "regex" && pattern.value.test(name)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-export function isAllowedByPolicy(name: string, policy?: ToolPolicy) {
-  if (!policy) {
-    return true;
-  }
-  const normalized = normalizeToolPolicyName(name);
-  const deny = compilePatterns(policy.deny);
-  if (matchesAny(normalized, deny)) {
-    return false;
-  }
-  const allow = compilePatterns(policy.allow);
-  if (allow.length === 0) {
-    return true;
-  }
-  if (matchesAny(normalized, allow)) {
-    return true;
-  }
-  if (normalized === "apply_patch" && matchesAny("exec", allow)) {
-    return true;
-  }
-  return false;
-}
-
-export function matchesList(name: string, list?: string[]) {
-  if (!Array.isArray(list) || list.length === 0) {
-    return false;
-  }
-  const normalized = normalizeToolPolicyName(name);
-  const patterns = compilePatterns(list);
-  if (matchesAny(normalized, patterns)) {
-    return true;
-  }
-  if (normalized === "apply_patch" && matchesAny("exec", patterns)) {
-    return true;
-  }
-  return false;
-}
-
-export function resolveToolProfile(profile: string) {
-  return resolveToolProfilePolicy(profile) ?? undefined;
 }

--- a/ui/src/pages/agents/panels-tools-skills.ts
+++ b/ui/src/pages/agents/panels-tools-skills.ts
@@ -2,7 +2,10 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 // Control UI view renders agents panels tools skills screen content.
 import { html, nothing } from "lit";
-import { normalizeToolPolicyName } from "../../../../src/agents/tool-policy-shared.js";
+import {
+  normalizeToolPolicyName,
+  resolveToolProfilePolicy,
+} from "../../../../src/agents/tool-policy-shared.js";
 import type {
   SkillStatusEntry,
   SkillStatusReport,
@@ -20,12 +23,9 @@ import { t } from "../../i18n/index.ts";
 import {
   type AgentToolEntry,
   type AgentToolSection,
-  isAllowedByPolicy,
-  matchesList,
   resolveAgentConfig,
   resolveAgentSkillsFilter,
   resolveToolProfileOptions,
-  resolveToolProfile,
   resolveToolSections,
 } from "../../lib/agents/display.ts";
 import { formatUiExternalText } from "../../lib/format-error.ts";
@@ -39,6 +39,7 @@ import {
 } from "../../lib/skills-shared.ts";
 import type { GitHubIdentityController } from "./github-identity-controller.ts";
 import { renderGitHubIdentity } from "./github-identity-view.ts";
+import { isAllowedByPolicy, matchesList } from "./tool-policy.ts";
 
 function renderToolMetaBadges(labels: string[]) {
   if (labels.length === 0) {
@@ -272,7 +273,7 @@ export function renderAgentTools(params: {
   const deny = hasAgentAllow ? [] : Array.isArray(agentTools.deny) ? agentTools.deny : [];
   const basePolicy = hasAgentAllow
     ? { allow: agentTools.allow ?? [], deny: agentTools.deny ?? [] }
-    : (resolveToolProfile(profile) ?? undefined);
+    : resolveToolProfilePolicy(profile);
   const toolIds = toolSections.flatMap((section) => section.tools.map((tool) => tool.id));
 
   const resolveAllowed = (toolId: string) => {

--- a/ui/src/pages/agents/tool-policy.ts
+++ b/ui/src/pages/agents/tool-policy.ts
@@ -1,0 +1,94 @@
+// Keep catalog-backed policy evaluation behind the Agents page's lazy boundary;
+// importing it from shared agent display helpers loads tool descriptions at startup.
+import {
+  expandToolGroups,
+  normalizeToolPolicyName,
+} from "../../../../src/agents/tool-policy-shared.js";
+
+type ToolPolicy = {
+  allow?: string[];
+  deny?: string[];
+};
+
+type CompiledPattern =
+  | { kind: "all" }
+  | { kind: "exact"; value: string }
+  | { kind: "regex"; value: RegExp };
+
+function compilePattern(pattern: string): CompiledPattern {
+  const normalized = normalizeToolPolicyName(pattern);
+  if (!normalized) {
+    return { kind: "exact", value: "" };
+  }
+  if (normalized === "*") {
+    return { kind: "all" };
+  }
+  if (!normalized.includes("*")) {
+    return { kind: "exact", value: normalized };
+  }
+  const escaped = normalized.replace(/[.*+?^${}()|[\\]\\]/g, "\\$&");
+  return { kind: "regex", value: new RegExp(`^${escaped.replaceAll("\\*", ".*")}$`) };
+}
+
+function compilePatterns(patterns?: string[]): CompiledPattern[] {
+  if (!Array.isArray(patterns)) {
+    return [];
+  }
+  return expandToolGroups(patterns)
+    .map(compilePattern)
+    .filter((pattern) => {
+      return pattern.kind !== "exact" || pattern.value.length > 0;
+    });
+}
+
+function matchesAny(name: string, patterns: CompiledPattern[]) {
+  for (const pattern of patterns) {
+    if (pattern.kind === "all") {
+      return true;
+    }
+    if (pattern.kind === "exact" && name === pattern.value) {
+      return true;
+    }
+    if (pattern.kind === "regex" && pattern.value.test(name)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function isAllowedByPolicy(name: string, policy?: ToolPolicy) {
+  if (!policy) {
+    return true;
+  }
+  const normalized = normalizeToolPolicyName(name);
+  const deny = compilePatterns(policy.deny);
+  if (matchesAny(normalized, deny)) {
+    return false;
+  }
+  const allow = compilePatterns(policy.allow);
+  if (allow.length === 0) {
+    return true;
+  }
+  if (matchesAny(normalized, allow)) {
+    return true;
+  }
+  if (normalized === "apply_patch" && matchesAny("exec", allow)) {
+    return true;
+  }
+  return false;
+}
+
+export function matchesList(name: string, list?: string[]) {
+  if (!Array.isArray(list) || list.length === 0) {
+    return false;
+  }
+  const normalized = normalizeToolPolicyName(name);
+  const patterns = compilePatterns(list);
+  if (matchesAny(normalized, patterns)) {
+    return true;
+  }
+  if (normalized === "apply_patch" && matchesAny("exec", patterns)) {
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
Related: #132091 (qualified admission-test performance PR blocked by this mainline build failure).

## What Problem This Solves

Resolves a problem where Control UI builds on current main exceed the unchanged startup JavaScript gzip budget, blocking CI for unrelated changes. Clean main `3f02452df0c3dd2b8573c67356e6507a57824ce0` measures **347,427 B**, above **347,037 B**. The last passing main build inspected was `993f82e1b36478a555577e85bfc79086b9cdefdf` at **346,597 B** ([CI](https://github.com/openclaw/openclaw/actions/runs/33208263109/job/98975785780)); the admission PR's failing Linux build reports **347,195 B** ([CI](https://github.com/openclaw/openclaw/actions/runs/33209653401/job/98979707799)).

## Why This Change Was Made

Shared agent display helpers imported tool-policy evaluation, which pulled the core tool catalog and its descriptions into every initial HTML/preload graph. Only the already-lazy Agents tools panel consumes that policy evaluation. Move those unchanged helper bodies to the page owner and call the canonical profile resolver directly, deleting its redundant wrapper.

This is older loading-boundary debt exposed by accumulated startup growth, not a claim that one recent feature caused the entire overage. Recent initial-graph additions since the last green include missing-session/error rendering (#131823), session usage/roster handling (#132064/#131958), service-worker probes (#132024), first-command-palette loading (#132028), and English strings. The eager policy edge dates to `6c445889b386` (Peter Steinberger, February 13, 2026), carried through later UI moves. No policy, catalog, or tool-description source changed since the last budget baseline.

No dependency, configuration, protocol, schema, locale memory, stylesheet, budget, tolerance, baseline, or assertion change. Existing route chunking is retained; no additional dynamic import or compatibility path.

## User Impact

The initial Control UI payload fits the existing budget again. Agent labels, tool profiles, allow/deny matching, tool toggles, save errors, and navigation retain their behavior. No visible UI or documented behavior change.

The scope of the saving matters: shared catalog/policy still occur in the existing deferred boot group fetched during default Chat. This removes them from the initial HTML/preload graph; it does not claim to remove the catalog from all default-chat downloads. The page-specific matching helpers are emitted only in the lazy Agents page.

Production LOC: **+100/-102 (net -2)**, mostly byte-identical moves. Tests: **+0/-0**. Existing canonical budget enforcement is the failing-before/passing-after regression proof; duplicating its byte assertion in a new test would add no independent coverage.

## Evidence

AI-assisted implementation; deslop complete; fresh isolated Codex autoreview reports no accepted/actionable P0 findings. Moved matching helper bodies were checked byte-for-byte against pre-fix source. Codex review CLI isolation was checked directly in sibling Codex source (`codex-rs/exec/src/cli.rs:37-44`, `codex-rs/exec/src/lib.rs:328-333`).

### Canonical production build

`pnpm ui:build`, followed by `node --import ./scripts/tsx.mjs scripts/check-control-ui-performance.mts --json`:

| Metric | Clean main before | Candidate after |
|---|---:|---:|
| Initial JS requests | 8 | 8 |
| Initial JS raw bytes | 1,147,461 | 1,137,951 |
| Initial JS gzip bytes | 347,427 | 345,131 |
| Initial JS Brotli bytes | 320,430 | 318,002 |
| Initial CSS requests | 1 | 1 |
| Initial CSS raw / gzip bytes | 279,894 / 44,570 | 279,894 / 44,570 |
| Total JS assets | 340 | 340 |
| Total JS raw / gzip bytes | 15,173,865 / 4,534,142 | 15,173,894 / 4,534,386 |

The canonical initial gzip saving is **2,296 B**, with **1,906 B** headroom. Whole-bundle gzip is **244 B larger** because chunk compression changes; this is an initial-loading boundary repair, not a whole-bundle-size claim. All 774 finalized sidecars verify. No ineffective dynamic-import warning in the UI build.

Initial chunk gzip composition (before → after):

| Chunk family | Before | After |
|---|---:|---:|
| Core display/locale | 113,058 | 113,067 |
| Core library | 69,804 | 69,502 |
| Core shell | 67,375 | 67,415 |
| Foundation | 78,670 | 76,627 |
| Gateway | 7,740 | 7,739 |
| Lit | 10,026 | 10,027 |
| Entry | 80 | 80 |
| Rolldown | 674 | 674 |

Build metadata differs between runs; final exact-head CI remains the Linux authority.

### Behavioral and owner proof

- Focused owner/UI and budget tests: **102/102** (`pnpm test ui/src/lib/agents/display.test.ts ui/src/pages/agents/view.test.ts ui/src/pages/agents/panels-tools-skills.browser.test.ts ui/src/app/control-ui-chunking.test.ts test/scripts/control-ui-performance.test.ts`). An initial mistyped test filename was rejected before execution; the corrected command above passed.
- Existing real-Chromium mocked-Gateway E2E: **3/3 before**, **9/9 after**, using `agent-config-save.e2e.test.ts` and `agent-model-fallback-ownership.e2e.test.ts` with the canonical UI E2E config. Covers tool toggles/config writes, visible rejected saves, inherited skill selection, and agent navigation/model ownership.
- Additional real Chromium runs of both **production bundles**: Chat reaches composer readiness, Agents deep-link opens, toggling `read` sends the same keyed config with `deny: ["read"]`, rejected saves remain visible, and no page exceptions occur. Both traces record 37 JS requests through Chat readiness. Their raw/gzip transfer totals are 4,006,829/1,167,015 before and 4,005,990/1,166,818 after; these are readiness traces, not a latency benchmark. Only synthetic Gateway fixtures; no live Gateway/provider/credentials used.

Before (production bundle, synthetic tool-toggle/save-error state):

![Before: unchanged Agents tools panel and visible save failure](https://github.com/user-attachments/assets/4d1d33c1-7be5-441f-b00e-1b3b7d1f7d47)

After (same scenario):

![After: preserved Agents tools panel and visible save failure](https://github.com/user-attachments/assets/1b38817f-0cd9-423b-af94-87c8063513ee)

The unrelated GitHub identity warning in both captures comes from the synthetic fixture lacking that response, not a connected account or product change. Captures were inspected before upload.

Full `pnpm build` also passes (6m13.6s), including startup gzip **345,119 B**. Complete `check:changed` passed on a dedicated Linux Testbox (13m33.763s command, exit 0; [run](https://github.com/openclaw/openclaw/actions/runs/33211302604)): guards, Knip, formatting, core-test/UI typechecks, lint and style. Its one-shot lease is verified completed. Exact-head PR CI remains required before landing.

Exact-head Linux build is green: startup gzip **345,110 B**, **1,927 B** below the unchanged347,037 B enforcement limit; all774 finalized sidecars verified ([build job](https://github.com/openclaw/openclaw/actions/runs/33212212671/job/98988058967)). Remaining full-CI checks must pass before merge.
