### PR TITLE
improve: minify the sealed worker artifact

### DIFF
--- a/src/infra/tsdown-config.test.ts
+++ b/src/infra/tsdown-config.test.ts
@@ -17,6 +17,7 @@ type TsdownConfigEntry = {
   };
   entry?: Record<string, string> | string[];
   inputOptions?: TsdownInputOptions;
+  minify?: unknown;
   outDir?: string;
   plugins?: Array<{ name?: string }>;
 };
@@ -94,6 +95,22 @@ function readAgentAuthDiscoverySource(): string {
 }
 
 describe("tsdown config", () => {
+  it("minifies only the sealed deploy worker while preserving runtime names", () => {
+    const configs = asConfigArray(tsdownConfig);
+    const deployWorker = configs.find((config) => entryKeys(config).includes("worker/worker"));
+    const rsyncReceiver = configs.find((config) =>
+      entryKeys(config).includes("worker/workspace-rsync-receiver"),
+    );
+
+    expect(deployWorker?.minify).toEqual({
+      codegen: true,
+      compress: true,
+      mangle: { keepNames: true },
+    });
+    expect(rsyncReceiver?.minify).toBeUndefined();
+    expect(requireUnifiedDistGraph().minify).toBeUndefined();
+  });
+
   it.each([
     {
       exportName: "OPENCLAW_STATE_SCHEMA_SQL",

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -209,6 +209,7 @@ function workerDeployBuildConfig(): UserConfig {
       onlyBundle: false,
     },
     fixedExtension: false,
+    minify: { codegen: true, compress: true, mangle: { keepNames: true } },
     outExtensions: () => ({ js: ".mjs", dts: ".d.ts" }),
     outputOptions: { codeSplitting: false, assetFileNames: "worker/[name][extname]" },
     plugins: [createStateSchemaInlinePlugin(), createWorkerDeployBuildPlugin()],


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the sealed deploy worker adds about 67 MiB to the unpacked npm package and pushes release contents toward or beyond the package-size budget.

## Why This Change Was Made

Minify only the self-contained deploy worker, using compression and identifier mangling while retaining function and class names for useful stack traces and runtime name-sensitive behavior. The ordinary runtime graph and workspace rsync receiver remain unminified and inspectable.

This does not externalize dependencies or change the worker's deployment/runtime architecture.

## User Impact

Operators receive the same sealed worker behavior with 22.26 MiB fewer unpacked bytes. This is a packaging-only change with no intended user-visible behavior change.

## Evidence

- Exact `origin/main` worker: 70,436,649 bytes (67.17 MiB).
- Worker with this change: 47,096,783 bytes (44.91 MiB).
- Reduction: 23,339,866 bytes (22.26 MiB, 33.1%).
- Regression proof: the new config test fails before the config change because the worker has no minification policy, then passes afterward.
- `node scripts/run-vitest.mjs src/infra/tsdown-config.test.ts test/scripts/worker-deploy-build-plugin.test.ts src/gateway/worker-environments/bundle.test.ts` — 44 tests passed.
- Exact deploy-worker build completed successfully with Rolldown/tsdown.
- Full TypeScript/runtime build completed successfully.
- `pnpm format:check --no-error-on-unmatched-pattern -- src/infra/tsdown-config.test.ts tsdown.config.ts` — passed.
- Local autoreview — clean, no actionable findings.
- The Node worker launch-wire E2E reached worker launch, transfer, reconciliation, and execution, but failed twice at the later existing permission-fixture assertion because `worker-permission-outside.txt` existed when the test expected `ENOENT`. This change does not touch that path; the focused worker build/archive tests above pass.
