### PR TITLE
fix: stale cloud workers no longer strand session results

### DIFF
--- a/extensions/browser/src/node-host/invoke-browser.test.ts
+++ b/extensions/browser/src/node-host/invoke-browser.test.ts
@@ -13,6 +13,10 @@ import { toErrorObject } from "../infra/errors.js";
 
 const BROWSER_PROXY_MAX_FILES = 256;
 const BROWSER_PROXY_MAX_TOTAL_FILE_BYTES = 16 * 1024 * 1024;
+const stagedReportUpload = {
+  body: { paths: ["/tmp/openclaw/uploads/.proxy-upload-1/0/report.txt"] },
+  directory: "/tmp/openclaw/uploads/.proxy-upload-1",
+};
 
 const controlServiceMocks = vi.hoisted(() => ({
   createBrowserControlContext: vi.fn(() => ({ control: true })),
@@ -410,10 +414,7 @@ describe("runBrowserProxyCommand", () => {
   });
 
   it("discards staged copies when the route rejects the upload", async () => {
-    const staged = {
-      body: { paths: ["/tmp/openclaw/uploads/.proxy-upload-1/0/report.txt"] },
-      directory: "/tmp/openclaw/uploads/.proxy-upload-1",
-    };
+    const staged = stagedReportUpload;
     uploadMocks.stageBrowserProxyUploadRequest.mockResolvedValueOnce(staged);
     dispatcherMocks.dispatch.mockResolvedValueOnce({
       status: 400,
@@ -439,10 +440,7 @@ describe("runBrowserProxyCommand", () => {
   });
 
   it("retains staged copies when dispatch fails after Browser ownership is uncertain", async () => {
-    const staged = {
-      body: { paths: ["/tmp/openclaw/uploads/.proxy-upload-1/0/report.txt"] },
-      directory: "/tmp/openclaw/uploads/.proxy-upload-1",
-    };
+    const staged = stagedReportUpload;
     uploadMocks.stageBrowserProxyUploadRequest.mockResolvedValueOnce(staged);
     dispatcherMocks.dispatch.mockRejectedValueOnce(new Error("dispatch failed"));
 
@@ -465,10 +463,8 @@ describe("runBrowserProxyCommand", () => {
   });
 
   it("retains staged copies when the timeout wins before dispatch settles", async () => {
-    const staged = {
-      body: { paths: ["/tmp/openclaw/uploads/.proxy-upload-1/0/report.txt"] },
-      directory: "/tmp/openclaw/uploads/.proxy-upload-1",
-    };
+    const now = vi.spyOn(Date, "now").mockReturnValue(0);
+    const staged = stagedReportUpload;
     uploadMocks.stageBrowserProxyUploadRequest.mockResolvedValueOnce(staged);
     dispatcherMocks.dispatch
       .mockImplementationOnce(() => new Promise(() => {}))
@@ -491,7 +487,9 @@ describe("runBrowserProxyCommand", () => {
         }),
         "browser.proxy.upload.v1",
       ),
-    ).rejects.toThrow("browser proxy timed out");
+    )
+      .rejects.toThrow("browser proxy timed out")
+      .finally(() => now.mockRestore());
 
     expect(uploadMocks.discardStagedBrowserProxyUpload).not.toHaveBeenCalled();
   });

--- a/src/gateway/worker-environments/credential-broker.test.ts
+++ b/src/gateway/worker-environments/credential-broker.test.ts
@@ -37,6 +37,7 @@ describe("worker environment service", () => {
       validateWorkerTurn: vi.fn(() => true),
       isWorkerTurnToolAuthorized: vi.fn(() => true),
       updateAckCursors: vi.fn(),
+      prepareWorkspaceResultOwnerRevocation: vi.fn(),
       registerTurnClaimClosedHandler: vi.fn(() => () => {}),
     };
     const workerService = support.createService(support.createProvider(), {

--- a/src/gateway/worker-environments/placement-worker-gate.test.ts
+++ b/src/gateway/worker-environments/placement-worker-gate.test.ts
@@ -39,8 +39,8 @@ describe("worker session placement gate", () => {
     await fs.rm(root, { recursive: true, force: true });
   });
 
-  function activate() {
-    let placement = store.startDispatch(SESSION);
+  function activate(executionMode: "worker-turn" | "remote-exec" = "worker-turn") {
+    let placement = store.startDispatch({ ...SESSION, executionMode });
     placement = store.transition({
       sessionId: SESSION.sessionId,
       from: "requested",
@@ -113,6 +113,12 @@ describe("worker session placement gate", () => {
     expect(gate.readWorkerTurnClaim(binding)).toEqual(claim);
     expect(gate.isWorkerTurnToolAuthorized(claim, "sessions_send")).toBe(false);
     expect(() => gate.updateAckCursors({ claim, transcriptSeq: 2 })).toThrow("stale worker turn");
+    expect(() =>
+      gate.prepareWorkspaceResultOwnerRevocation(binding, new Error("restart owner revoked")),
+    ).not.toThrow();
+    expect(restartedStore.listPendingWorkspaceResults()).toMatchObject([
+      { sessionId: claim.sessionId, recoveryRequestedAtMs: null },
+    ]);
   });
 
   it("does not classify a same-id claim from a different run as inherited", () => {
@@ -186,6 +192,81 @@ describe("worker session placement gate", () => {
     store.completeWorkspaceResultAndReleaseTurn(claim);
     expect(store.get(SESSION.sessionId)?.turnClaim).toBeNull();
     expect(gate.validateWorkerTurn(binding)).toBe(false);
+  });
+
+  it("hands a worker-owned pending result to recovery before owner revocation", () => {
+    const claim = preclaim("run-worker-revoked");
+    const gate = createWorkerSessionPlacementGate(store);
+    gate.updateAckCursors({ claim, liveSeq: 1 });
+
+    gate.prepareWorkspaceResultOwnerRevocation(
+      { sessionId: claim.sessionId, environmentId: ENVIRONMENT_ID, ownerEpoch: OWNER_EPOCH },
+      new Error("worker owner revoked"),
+    );
+
+    expect(store.listPendingWorkspaceResults()).toMatchObject([
+      { sessionId: claim.sessionId, recoveryRequestedAtMs: expect.any(Number) },
+    ]);
+    expect(store.get(claim.sessionId)).toMatchObject({
+      state: "active",
+      turnClaim: expect.anything(),
+    });
+  });
+
+  it("fails a Gateway-owned pending result before owner revocation", () => {
+    const placement = activate("remote-exec");
+    const claim = store.claimTurn({
+      sessionId: placement.sessionId,
+      agentId: placement.agentId,
+      sessionKey: placement.sessionKey,
+      claimId: "claim:run-local-revoked",
+      runId: "run-local-revoked",
+      owner: { kind: "local", environmentId: ENVIRONMENT_ID, ownerEpoch: OWNER_EPOCH },
+    });
+    store.markWorkspaceResultPending(claim);
+
+    createWorkerSessionPlacementGate(store).prepareWorkspaceResultOwnerRevocation(
+      { sessionId: claim.sessionId, environmentId: ENVIRONMENT_ID, ownerEpoch: OWNER_EPOCH },
+      new Error("local owner revoked"),
+    );
+
+    expect(store.listPendingWorkspaceResults()).toEqual([]);
+    expect(store.get(claim.sessionId)).toMatchObject({
+      state: "failed",
+      recoveryError: "local owner revoked",
+      turnClaim: null,
+    });
+  });
+
+  it("preserves a staged Gateway-owned result during owner revocation", () => {
+    const placement = activate("remote-exec");
+    const claim = store.claimTurn({
+      sessionId: placement.sessionId,
+      agentId: placement.agentId,
+      sessionKey: placement.sessionKey,
+      claimId: "claim:run-local-staged",
+      runId: "run-local-staged",
+      owner: { kind: "local", environmentId: ENVIRONMENT_ID, ownerEpoch: OWNER_EPOCH },
+    });
+    store.markWorkspaceResultPending(claim);
+    store.recordStagedWorkspaceResult(claim, "refs/openclaw/worker-results/local-staged");
+
+    createWorkerSessionPlacementGate(store).prepareWorkspaceResultOwnerRevocation(
+      { sessionId: claim.sessionId, environmentId: ENVIRONMENT_ID, ownerEpoch: OWNER_EPOCH },
+      new Error("local owner revoked"),
+    );
+
+    expect(store.listPendingWorkspaceResults()).toMatchObject([
+      {
+        sessionId: claim.sessionId,
+        recoveryRequestedAtMs: expect.any(Number),
+        stagedResultRef: "refs/openclaw/worker-results/local-staged",
+      },
+    ]);
+    expect(store.get(claim.sessionId)).toMatchObject({
+      state: "active",
+      turnClaim: expect.anything(),
+    });
   });
 
   it("lets the admitted worker finish acknowledgements after draining closes admission", () => {

--- a/src/gateway/worker-environments/placement-worker-gate.ts
+++ b/src/gateway/worker-environments/placement-worker-gate.ts
@@ -1,4 +1,5 @@
 import {
+  placementTurnOwner,
   projectWorkerSessionTurnClaim,
   serializeWorkerSessionTurnClaim,
   type WorkerSessionPlacementRecord,
@@ -30,6 +31,7 @@ export type WorkerSessionPlacementGate = {
     transcriptSeq?: number;
     liveSeq?: number;
   }): void;
+  prepareWorkspaceResultOwnerRevocation(binding: WorkerPlacementBinding, error: Error): void;
   registerTurnClaimClosedHandler(handler: (claim: WorkerSessionTurnClaim) => void): () => void;
 };
 
@@ -43,6 +45,27 @@ function claimForBinding(
     claim.owner.ownerEpoch === binding.ownerEpoch
     ? claim
     : undefined;
+}
+
+function claimForOwnerRevocation(
+  record: WorkerSessionPlacementRecord | undefined,
+  binding: WorkerPlacementBinding,
+): WorkerSessionTurnClaim | undefined {
+  if (
+    (record?.state !== "active" && record?.state !== "draining") ||
+    record.environmentId !== binding.environmentId ||
+    record.activeOwnerEpoch !== binding.ownerEpoch ||
+    !record.turnClaim
+  ) {
+    return undefined;
+  }
+  return {
+    sessionId: record.sessionId,
+    claimId: record.turnClaim.claimId,
+    runId: record.turnClaim.runId,
+    placementGeneration: record.turnClaim.generation,
+    owner: placementTurnOwner(record),
+  };
 }
 
 export function createWorkerSessionPlacementGate(
@@ -98,6 +121,36 @@ export function createWorkerSessionPlacementGate(
         ...(input.transcriptSeq === undefined ? {} : { transcript: input.transcriptSeq }),
         ...(input.liveSeq === undefined ? {} : { liveEvent: input.liveSeq }),
       });
+    },
+
+    prepareWorkspaceResultOwnerRevocation(binding, error): void {
+      const claim = claimForOwnerRevocation(store.get(binding.sessionId), binding);
+      if (!claim) {
+        return;
+      }
+      const pending = store
+        .listPendingWorkspaceResults()
+        .find(
+          (candidate) =>
+            candidate.sessionId === claim.sessionId &&
+            candidate.claimId === claim.claimId &&
+            candidate.runId === claim.runId,
+        );
+      if (!pending) {
+        return;
+      }
+      if (pending.gatewayInstanceId !== store.workspaceResultInstanceId()) {
+        return;
+      }
+      if (
+        claim.owner.kind === "local" &&
+        pending.stagedResultRef === null &&
+        pending.workspaceAcceptedAtMs === null
+      ) {
+        store.failWorkspaceResultAndReleaseTurn(pending, error);
+        return;
+      }
+      store.handoffWorkspaceResultRecovery(claim);
     },
 
     registerTurnClaimClosedHandler: (handler) => store.registerTurnClaimClosedHandler(handler),

--- a/src/gateway/worker-environments/provider-lifecycle.types.ts
+++ b/src/gateway/worker-environments/provider-lifecycle.types.ts
@@ -11,6 +11,7 @@ import type {
 } from "../../plugins/types.js";
 import type { WorkerInstallationArtifact } from "./bundle.js";
 import type { WorkerCredentialBroker } from "./credential-broker.js";
+import type { WorkerSessionPlacementGate } from "./placement-worker-gate.js";
 import type { WorkerEnvironmentState } from "./state.js";
 import type {
   WorkerEnvironmentRecord,
@@ -53,6 +54,7 @@ export type WorkerProviderLifecycleInputOptions = {
   closeNodeEnrollment?: (enrollment: WorkerNodeEnrollment) => void;
   retireNodeEnrollment?: (record: WorkerEnvironmentRecord) => Promise<void>;
   projectNamespace?: string;
+  placementStore?: WorkerSessionPlacementGate;
   providerCallTimeoutMs?: number;
 };
 

--- a/src/gateway/worker-environments/provider-owner-lifecycle.ts
+++ b/src/gateway/worker-environments/provider-owner-lifecycle.ts
@@ -8,7 +8,12 @@ import type { WorkerTunnelStopReason } from "./tunnel-contract.js";
 export function createWorkerProviderOwnerLifecycle(
   options: Pick<
     WorkerProviderLifecycleOptions,
-    "store" | "tunnelManager" | "serviceError" | "callProvider" | "providerCallTimeoutMs"
+    | "store"
+    | "tunnelManager"
+    | "serviceError"
+    | "callProvider"
+    | "providerCallTimeoutMs"
+    | "placementStore"
   >,
 ) {
   const { store, serviceError } = options;
@@ -35,6 +40,15 @@ export function createWorkerProviderOwnerLifecycle(
     reason?: WorkerTunnelStopReason,
   ): Promise<WorkerEnvironmentRecord> => {
     requireCurrentOwner(record);
+    const sessionId = record.attachedSessionIds.length === 1 ? record.attachedSessionIds[0] : null;
+    if (sessionId) {
+      // Transfer an exact pending-result owner before credential revocation makes its
+      // same-lifecycle worker permanently unreachable to recovery.
+      options.placementStore?.prepareWorkspaceResultOwnerRevocation(
+        { sessionId, environmentId: record.environmentId, ownerEpoch: record.ownerEpoch },
+        new Error(record.lastError ?? "Cloud worker owner revoked before workspace recovery"),
+      );
+    }
     // Fence admission without erasing the attachment needed to stop a retained node worker.
     // A crash or failed stop leaves the exact scope available for teardown replay.
     store.revokeEnvironmentCredential(record.environmentId);

--- a/src/gateway/worker-environments/provider-owner-revocation.test.ts
+++ b/src/gateway/worker-environments/provider-owner-revocation.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import { createWorkerSessionPlacementStore } from "./placement-store.js";
+import { createWorkerSessionPlacementGate } from "./placement-worker-gate.js";
+import * as support from "./service.test-support.js";
+import type { WorkerTunnelManager } from "./tunnel.js";
+
+const ENVIRONMENT_ID = "worker-stale-result-owner";
+const SESSION_ID = "session-stale-result-owner";
+
+describe("worker environment owner revocation", () => {
+  support.setupWorkerEnvironmentServiceSuite();
+
+  it("hands off a pending worker result before stale-build owner revocation", async () => {
+    const ready = support.seedReady(ENVIRONMENT_ID);
+    const attached = support.testState.store.transition({
+      environmentId: ENVIRONMENT_ID,
+      from: ready.state,
+      to: "attached",
+      patch: support.attachedPatch(ENVIRONMENT_ID, SESSION_ID),
+    });
+    const placements = createWorkerSessionPlacementStore({ database: support.testState.stateDb });
+    let placement = placements.startDispatch({
+      sessionId: SESSION_ID,
+      sessionKey: "agent:main:stale-result-owner",
+      agentId: "main",
+      executionMode: "worker-turn",
+    });
+    placement = placements.transition({
+      sessionId: SESSION_ID,
+      from: "requested",
+      to: "provisioning",
+      expectedGeneration: placement.generation,
+      patch: { environmentId: ENVIRONMENT_ID },
+    });
+    placement = placements.transition({
+      sessionId: SESSION_ID,
+      from: "provisioning",
+      to: "syncing",
+      expectedGeneration: placement.generation,
+      patch: { workerBundleHash: "b".repeat(64) },
+    });
+    placement = placements.transition({
+      sessionId: SESSION_ID,
+      from: "syncing",
+      to: "starting",
+      expectedGeneration: placement.generation,
+      patch: {
+        remoteWorkspaceDir: "/worker/stale-result-owner",
+        workspaceBaseManifestRef: `sha256:${"c".repeat(64)}`,
+      },
+    });
+    placement = placements.transition({
+      sessionId: SESSION_ID,
+      from: "starting",
+      to: "active",
+      expectedGeneration: placement.generation,
+      patch: { activeOwnerEpoch: attached.ownerEpoch },
+    });
+    const claim = placements.claimTurn({
+      sessionId: SESSION_ID,
+      sessionKey: placement.sessionKey,
+      agentId: placement.agentId,
+      claimId: "claim-stale-result-owner",
+      runId: "run-stale-result-owner",
+      owner: {
+        kind: "worker",
+        environmentId: ENVIRONMENT_ID,
+        ownerEpoch: attached.ownerEpoch,
+      },
+    });
+    const placementStore = createWorkerSessionPlacementGate(placements);
+    placementStore.updateAckCursors({ claim, liveSeq: 1 });
+    const tunnelManager = {
+      status: () => "connected" as const,
+      start: vi.fn(),
+      stop: vi.fn(async () => {
+        expect(placements.listPendingWorkspaceResults()).toMatchObject([
+          { sessionId: SESSION_ID, recoveryRequestedAtMs: expect.any(Number) },
+        ]);
+      }),
+      stopAll: vi.fn(async () => {}),
+    } as unknown as WorkerTunnelManager;
+    support.testState.stateDb.db
+      .prepare(
+        "UPDATE worker_environments SET bootstrap_bundle_hash = ?, bootstrap_install_kind = 'local' WHERE environment_id = ?",
+      )
+      .run("b".repeat(64), ENVIRONMENT_ID);
+
+    await support
+      .createService(support.createProvider({ destroy: vi.fn(async () => {}) }), {
+        placementStore,
+        tunnelManager,
+      })
+      .reconcileOnce();
+
+    expect(tunnelManager.stop).toHaveBeenCalledOnce();
+    expect(placements.listPendingWorkspaceResults()).toMatchObject([
+      { sessionId: SESSION_ID, recoveryRequestedAtMs: expect.any(Number) },
+    ]);
+  });
+});

--- a/src/gateway/worker-environments/service-lifetime.test.ts
+++ b/src/gateway/worker-environments/service-lifetime.test.ts
@@ -129,6 +129,7 @@ describe("worker environment service", () => {
       validateWorkerTurn: vi.fn(() => false),
       isWorkerTurnToolAuthorized: vi.fn(() => false),
       updateAckCursors: vi.fn(),
+      prepareWorkspaceResultOwnerRevocation: vi.fn(),
       registerTurnClaimClosedHandler: vi.fn(() => unsubscribeTurnClaimClosed),
     };
     const workerService = support.createService(support.createProvider({ inspect }), {

--- a/src/gateway/worker-environments/service.test-support.ts
+++ b/src/gateway/worker-environments/service.test-support.ts
@@ -536,6 +536,7 @@ export function placementHarness(
     validateWorkerTurn: vi.fn(() => true),
     isWorkerTurnToolAuthorized: vi.fn(() => true),
     updateAckCursors: vi.fn(),
+    prepareWorkspaceResultOwnerRevocation: vi.fn(),
     registerTurnClaimClosedHandler: vi.fn(() => () => {}),
   };
   const workerService = createService(createProvider(), { ...serviceOptions, placementStore });

--- a/src/gateway/worker-environments/service.ts
+++ b/src/gateway/worker-environments/service.ts
@@ -309,6 +309,7 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
     prepareNodeEnrollment: options.prepareNodeEnrollment,
     closeNodeEnrollment: options.closeNodeEnrollment,
     retireNodeEnrollment: options.retireNodeEnrollment,
+    placementStore: options.placementStore,
     providerCallTimeoutMs: options.providerCallTimeoutMs,
     tunnelManager: tunnelLifecycle,
     credentialBroker,


### PR DESCRIPTION
Related: #131992

## What Problem This Solves

Fixes an issue where cloud-backed sessions could become permanently stuck in `draining` when OpenClaw revoked a stale worker owner while that worker still owned a pending workspace result.

The owner became unreachable before the result was transferred to recovery, leaving the session unable to settle or archive through the normal lifecycle.

## Why This Change Was Made

Worker-environment teardown now resolves the exact pending-result owner before revoking its credential. Worker-owned, staged, or accepted results transfer to durable recovery; an unstaged and unaccepted Gateway-owned result fails atomically and releases its turn.

The handoff is scoped to the exact session, environment, owner epoch, turn claim, run, and current Gateway result owner. It does not revive stale workers, weaken credential fencing, or add a fallback execution path.

This prevents new stranded placements. It intentionally does not silently abandon or delete workspace residue from sessions that were already wedged before the fix; those require explicit terminalization or operator abandonment.

## User Impact

Future stale-worker teardown converges instead of leaving cloud sessions permanently draining: recoverable workspace work remains protected, while unrecoverable work ends with an explicit failure that releases the session lifecycle.

Already-stranded sessions are not automatically modified by this change.

## Evidence

- The provider-owner regression verifies that result recovery is requested before tunnel stop during stale-build reconciliation.
- Placement-gate coverage verifies worker-owned handoff, atomic failure of unrecoverable Gateway-owned results, preservation of staged results, exact owner matching, and restart-inherited claim fencing.
- `node scripts/run-vitest.mjs src/gateway/worker-environments/credential-broker.test.ts src/gateway/worker-environments/placement-worker-gate.test.ts src/gateway/worker-environments/provider-owner-revocation.test.ts src/gateway/worker-environments/service-lifetime.test.ts` passed 4 files / 34 tests.
- `node scripts/check-changed.mjs --base origin/main --head HEAD --timed` passed all selected core and core-test checks, including production/test typechecks, type-aware lint, database-first guards, and import-cycle checks.
- `pnpm build` passed core, package, runtime, plugin SDK, and worker artifact phases. It then failed the unrelated Control UI startup gzip budget by 133 bytes; this PR changes only `src/gateway/worker-environments/**` and has no UI dependency-surface changes.
- Fresh Codex autoreview reported no accepted/actionable findings at 0.98 confidence.
- Production delta: +69/-1. Tests/test support: +187/-2. No config, protocol, or schema changes.

AI-assisted with Codex. I reviewed the implementation and validation results.
