### PR TITLE
fix(talk): bind steering to exact run authority

### DIFF
--- a/qa/scenarios/runtime/active-talk-agent-run-status.yaml
+++ b/qa/scenarios/runtime/active-talk-agent-run-status.yaml
@@ -12,6 +12,7 @@ scenario:
     - A registered mock realtime provider creates a browser-owned Talk session with consult and control tools through Gateway RPC.
     - A consult tool call starts a real active agent run through the Gateway chat path.
     - Status, steering, and follow-up RPCs observe and queue work to that active run.
+    - A separately authenticated Gateway connection cannot steer or cancel the browser-owned run.
     - Cancellation RPC aborts that same active run from the owning browser connection.
     - Both active-run injections remain observable without increasing backlog, and the completed run returns diagnostics to idle with queue depth zero.
   docsRefs:
@@ -26,7 +27,7 @@ scenario:
     kind: script
     parallelSafe: true
     path: test/e2e/qa-lab/runtime/media-talk-gateway.ts
-    summary: Starts a real Gateway and persistent WebChat client, creates a Talk session, starts an agent consult, and exercises status, steer, follow-up, and cancel RPCs.
+    summary: Starts a real Gateway and two clients, then proves owner control and cross-connection rejection for one active Talk run.
     args:
       - --scenario
       - active-talk-agent-run-status

--- a/src/agents/embedded-agent-runner.ts
+++ b/src/agents/embedded-agent-runner.ts
@@ -13,7 +13,6 @@ export {
   isEmbeddedAgentRunActive,
   isEmbeddedAgentRunHandleActive,
   isEmbeddedAgentRunStreaming,
-  observeEmbeddedAgentMessageInjectionTarget,
   queueEmbeddedAgentMessageWithOutcome,
   resolveActiveEmbeddedRunSessionIdBySessionFile,
   waitForEmbeddedAgentRunEnd,

--- a/src/agents/embedded-agent-runner.ts
+++ b/src/agents/embedded-agent-runner.ts
@@ -18,7 +18,7 @@ export {
   resolveActiveEmbeddedRunSessionIdBySessionFile,
   waitForEmbeddedAgentRunEnd,
 } from "./embedded-agent-runner/runs.js";
-export type { EmbeddedAgentMessageInjectionTarget } from "./embedded-agent-runner/runs.js";
+export type { ActiveEmbeddedRunOwner } from "./embedded-agent-runner/runs.js";
 export type {
   EmbeddedAgentMeta,
   EmbeddedAgentCompactResult,

--- a/src/agents/embedded-agent-runner.ts
+++ b/src/agents/embedded-agent-runner.ts
@@ -13,10 +13,12 @@ export {
   isEmbeddedAgentRunActive,
   isEmbeddedAgentRunHandleActive,
   isEmbeddedAgentRunStreaming,
+  observeEmbeddedAgentMessageInjectionTarget,
   queueEmbeddedAgentMessageWithOutcome,
   resolveActiveEmbeddedRunSessionIdBySessionFile,
   waitForEmbeddedAgentRunEnd,
 } from "./embedded-agent-runner/runs.js";
+export type { EmbeddedAgentMessageInjectionTarget } from "./embedded-agent-runner/runs.js";
 export type {
   EmbeddedAgentMeta,
   EmbeddedAgentCompactResult,

--- a/src/agents/embedded-agent-runner/run/attempt-stream-prepare.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-prepare.test.ts
@@ -160,6 +160,7 @@ describe("prepareEmbeddedAttemptStream", () => {
         expect.objectContaining({ preemptByVisibleTurn: expect.any(Function) }),
         "agent:main:main",
         undefined,
+        undefined,
       );
     } finally {
       operation.complete();

--- a/src/agents/embedded-agent-runner/run/attempt-stream-prepare.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-prepare.test.ts
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => ({
   clearActiveRun: vi.fn(),
   notifyToolActivity: vi.fn(),
   runBeforeFinalizeHook: vi.fn(),
+  resolveActiveRunOwner: vi.fn(),
   setActiveRun: vi.fn(),
   subscribe: vi.fn(),
 }));
@@ -30,6 +31,7 @@ vi.mock("../../embedded-agent-subscribe.js", () => ({
 }));
 vi.mock("../runs.js", () => ({
   clearActiveEmbeddedRun: mocks.clearActiveRun,
+  resolveActiveEmbeddedRunOwnerByRunId: mocks.resolveActiveRunOwner,
   setActiveEmbeddedRun: mocks.setActiveRun,
 }));
 vi.mock("./tool-activity-heartbeat.js", () => ({
@@ -62,6 +64,7 @@ function prepareCatalogExecutor(
     onAttemptAbort?: () => void;
     abortRun?: (isTimeout?: boolean, reason?: unknown) => void;
     markExternalAbort?: () => void;
+    onActiveRunOwner?: (owner: unknown) => void;
   },
 ) {
   const runAbortController = options?.runAbortController ?? new AbortController();
@@ -72,6 +75,7 @@ function prepareCatalogExecutor(
       sessionKey: options?.sessionKey ?? "agent:main:main",
       replyOperation: options?.replyOperation,
       onAttemptAbort: options?.onAttemptAbort,
+      onActiveRunOwner: options?.onActiveRunOwner,
     } as never,
     activeSession: {
       agent: {},
@@ -113,6 +117,7 @@ describe("prepareEmbeddedAttemptStream", () => {
     mocks.setActiveRun.mockImplementation((sessionId, handle) =>
       ACTIVE_EMBEDDED_RUNS.set(sessionId, handle),
     );
+    mocks.resolveActiveRunOwner.mockReturnValue(undefined);
     mocks.subscribe.mockReturnValue({
       toolMetas: [],
       runToolLifecycle: vi.fn(async ({ args, execute, onTerminal }) => {
@@ -160,11 +165,21 @@ describe("prepareEmbeddedAttemptStream", () => {
         expect.objectContaining({ preemptByVisibleTurn: expect.any(Function) }),
         "agent:main:main",
         undefined,
-        undefined,
       );
     } finally {
       operation.complete();
     }
+  });
+
+  it("publishes the exact owner only after active registration", () => {
+    const owner = { runId: "run-output-schema", sessionId: "session-output-schema" };
+    const onActiveRunOwner = vi.fn();
+    mocks.resolveActiveRunOwner.mockReturnValue(owner);
+
+    prepareCatalogExecutor([], { onActiveRunOwner });
+
+    expect(mocks.setActiveRun).toHaveBeenCalledOnce();
+    expect(onActiveRunOwner).toHaveBeenCalledWith(owner);
   });
 
   it("uses the persisted assistant entry id and closes steering during revision settlement", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
@@ -50,6 +50,7 @@ import { ACTIVE_EMBEDDED_RUNS, setActiveEmbeddedRunLifecycleGeneration } from ".
 import {
   clearActiveEmbeddedRun,
   type EmbeddedAgentQueueHandle,
+  resolveActiveEmbeddedRunOwnerByRunId,
   setActiveEmbeddedRun,
 } from "../runs.js";
 import {
@@ -565,13 +566,11 @@ export function prepareEmbeddedAttemptStream(input: {
     queueHandle,
     attempt.lifecycleGeneration ?? captureAgentRunLifecycleGeneration(attempt.runId),
   );
-  setActiveEmbeddedRun(
-    attempt.sessionId,
-    queueHandle,
-    attempt.sessionKey,
-    attempt.sessionFile,
-    attempt.admittedRunContext,
-  );
+  setActiveEmbeddedRun(attempt.sessionId, queueHandle, attempt.sessionKey, attempt.sessionFile);
+  const activeOwner = resolveActiveEmbeddedRunOwnerByRunId(attempt.runId);
+  if (activeOwner) {
+    attempt.onActiveRunOwner?.(activeOwner);
+  }
   if (attempt.deferTerminalLifecycle && attempt.onDeferredLifecycleOwner) {
     deferredLifecycleOwner = createEmbeddedAttemptDeferredLifecycleOwner({
       runId: attempt.runId,

--- a/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
@@ -565,7 +565,13 @@ export function prepareEmbeddedAttemptStream(input: {
     queueHandle,
     attempt.lifecycleGeneration ?? captureAgentRunLifecycleGeneration(attempt.runId),
   );
-  setActiveEmbeddedRun(attempt.sessionId, queueHandle, attempt.sessionKey, attempt.sessionFile);
+  setActiveEmbeddedRun(
+    attempt.sessionId,
+    queueHandle,
+    attempt.sessionKey,
+    attempt.sessionFile,
+    attempt.admittedRunContext,
+  );
   if (attempt.deferTerminalLifecycle && attempt.onDeferredLifecycleOwner) {
     deferredLifecycleOwner = createEmbeddedAttemptDeferredLifecycleOwner({
       runId: attempt.runId,

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -92,6 +92,8 @@ export type RunEmbeddedAgentParams = {
   admittedRunContext?: AdmittedRunContext;
   /** Host-only post-prepare continuation, removed before plugin invocation. */
   preparedRunAdmission?: PreparedAgentRunAdmission;
+  /** Host callback published only after this exact run owns the active registry slots. */
+  onActiveRunOwner?: (owner: import("../runs.js").ActiveEmbeddedRunOwner) => void;
   /** Caller-owned in-memory transcript for ephemeral helper runs. */
   sessionManager?: SessionManager;
   /** Detached runs may read session identity but never write its durable transcript or metadata. */

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
@@ -277,6 +277,7 @@ export async function dispatchEmbeddedRunAttempt(input: {
   });
   const attemptParams: EmbeddedRunAttemptInternalParams = {
     admittedRunContext: params.admittedRunContext,
+    onActiveRunOwner: params.onActiveRunOwner,
     startedAtMs: input.runStartedAtMs,
     contextEngineAgentId: runtime.contextEngineAgentId,
     ...(control.pluginHarnessOwnsTransport ? { sandbox: pluginSandbox } : {}),

--- a/src/agents/embedded-agent-runner/runs.steering.test.ts
+++ b/src/agents/embedded-agent-runner/runs.steering.test.ts
@@ -11,8 +11,10 @@ import {
   clearActiveEmbeddedRun,
   formatEmbeddedAgentQueueFailureSummary,
   preemptAndDrainEmbeddedHeartbeatRun,
+  queueEmbeddedAgentMessageInjectionTarget,
   queueEmbeddedAgentMessageWithOutcome,
   queueEmbeddedAgentMessageWithOutcomeAsync,
+  resolveEmbeddedAgentMessageInjectionTarget,
   setActiveEmbeddedRun,
   type EmbeddedAgentQueueHandle,
 } from "./runs.js";
@@ -25,6 +27,45 @@ describe("embedded-agent active-run steering", () => {
     resetDiagnosticSessionStateForTest();
     setDiagnosticsEnabledForProcess(false);
     vi.restoreAllMocks();
+  });
+
+  it("projects authority only into the exact captured run", async () => {
+    const firstQueue = vi.fn(async () => {});
+    const first = createEmbeddedRunHandle({ queueMessage: firstQueue });
+    Object.assign(first, { runId: "run-first", toolAuthorityFingerprint: "authority-first" });
+    setActiveEmbeddedRun("session-talk", first, "agent:main:main");
+    const target = resolveEmbeddedAgentMessageInjectionTarget({
+      sessionId: "session-talk",
+      runId: "run-first",
+    });
+    expect(target).toBeDefined();
+
+    await expect(
+      queueEmbeddedAgentMessageInjectionTarget(target!, "steer", {
+        isInboundUserMessage: true,
+        steeringMode: "all",
+      }),
+    ).resolves.toMatchObject({ queued: true });
+    expect(firstQueue).toHaveBeenCalledWith("steer", {
+      isInboundUserMessage: true,
+      steeringMode: "all",
+      toolAuthorityFingerprint: "authority-first",
+    });
+
+    const replacementQueue = vi.fn(async () => {});
+    const replacement = createEmbeddedRunHandle({ queueMessage: replacementQueue });
+    Object.assign(replacement, {
+      runId: "run-replacement",
+      toolAuthorityFingerprint: "authority-replacement",
+    });
+    setActiveEmbeddedRun("session-talk", replacement, "agent:main:main");
+
+    await expect(
+      queueEmbeddedAgentMessageInjectionTarget(target!, "stale steer", {
+        isInboundUserMessage: true,
+      }),
+    ).resolves.toMatchObject({ queued: false, reason: "tool_authority_mismatch" });
+    expect(replacementQueue).not.toHaveBeenCalled();
   });
 
   it("aborts and drains the exact heartbeat handle through session replacement", async () => {

--- a/src/agents/embedded-agent-runner/runs.steering.test.ts
+++ b/src/agents/embedded-agent-runner/runs.steering.test.ts
@@ -10,10 +10,10 @@ import { createTestUserTurnTranscriptTarget } from "../../sessions/user-turn-tra
 import {
   clearActiveEmbeddedRun,
   formatEmbeddedAgentQueueFailureSummary,
-  observeEmbeddedAgentMessageInjectionTarget,
   preemptAndDrainEmbeddedHeartbeatRun,
   queueEmbeddedAgentMessageWithOutcome,
   queueEmbeddedAgentMessageWithOutcomeAsync,
+  resolveActiveEmbeddedRunOwnerByRunId,
   setActiveEmbeddedRun,
   type EmbeddedAgentQueueHandle,
 } from "./runs.js";
@@ -29,17 +29,15 @@ describe("embedded-agent active-run steering", () => {
   });
 
   it("projects authority only into the exact captured run", async () => {
-    const context = {
-      operationalRunInstance: { instanceId: "instance-talk", runId: "run-first" },
-    };
-    const observer = vi.fn();
-    observeEmbeddedAgentMessageInjectionTarget(context, observer);
     const firstQueue = vi.fn(async () => {});
     const first = createEmbeddedRunHandle({ queueMessage: firstQueue });
     Object.assign(first, { runId: "run-first", toolAuthorityFingerprint: "authority-first" });
-    setActiveEmbeddedRun("session-talk", first, "agent:main:main", undefined, context);
-    expect(observer).toHaveBeenCalledOnce();
-    const target = observer.mock.calls[0]![0];
+    setActiveEmbeddedRun("session-talk", first, "agent:main:main");
+    const target = resolveActiveEmbeddedRunOwnerByRunId("run-first");
+    expect(target).toBeDefined();
+    if (!target) {
+      throw new Error("expected active run owner");
+    }
 
     await expect(
       target.queueMessage("steer", {

--- a/src/agents/embedded-agent-runner/runs.steering.test.ts
+++ b/src/agents/embedded-agent-runner/runs.steering.test.ts
@@ -12,6 +12,7 @@ import {
   abortEmbeddedAgentMessageInjectionTarget,
   clearActiveEmbeddedRun,
   formatEmbeddedAgentQueueFailureSummary,
+  observeEmbeddedAgentMessageInjectionTarget,
   preemptAndDrainEmbeddedHeartbeatRun,
   queueEmbeddedAgentMessageInjectionTarget,
   queueEmbeddedAgentMessageWithOutcome,
@@ -29,6 +30,28 @@ describe("embedded-agent active-run steering", () => {
     resetDiagnosticSessionStateForTest();
     setDiagnosticsEnabledForProcess(false);
     vi.restoreAllMocks();
+  });
+
+  it("publishes an admitted run target only after active registration", async () => {
+    const context = {
+      operationalRunInstance: { instanceId: "instance-talk", runId: "run-talk" },
+    };
+    const observer = vi.fn();
+    observeEmbeddedAgentMessageInjectionTarget(context, observer);
+    expect(observer).not.toHaveBeenCalled();
+
+    const queueMessage = vi.fn(async () => {});
+    const handle = createEmbeddedRunHandle({ queueMessage });
+    Object.assign(handle, { runId: "run-talk", toolAuthorityFingerprint: "authority-talk" });
+    setActiveEmbeddedRun("session-talk", handle, "agent:main:main", undefined, context);
+
+    expect(observer).toHaveBeenCalledOnce();
+    await expect(
+      queueEmbeddedAgentMessageInjectionTarget(observer.mock.calls[0]![0], "early steer"),
+    ).resolves.toMatchObject({ queued: true });
+    expect(queueMessage).toHaveBeenCalledWith("early steer", {
+      toolAuthorityFingerprint: "authority-talk",
+    });
   });
 
   it("projects authority only into the exact captured run", async () => {

--- a/src/agents/embedded-agent-runner/runs.steering.test.ts
+++ b/src/agents/embedded-agent-runner/runs.steering.test.ts
@@ -7,7 +7,9 @@ import { markDiagnosticToolStartedForTest } from "../../logging/diagnostic-run-a
 import { resetDiagnosticSessionStateForTest } from "../../logging/diagnostic-session-state.js";
 import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
 import { createTestUserTurnTranscriptTarget } from "../../sessions/user-turn-transcript.test-support.js";
+import { controlOwnedRealtimeVoiceAgentRun } from "../../talk/agent-run-control.js";
 import {
+  abortEmbeddedAgentMessageInjectionTarget,
   clearActiveEmbeddedRun,
   formatEmbeddedAgentQueueFailureSummary,
   preemptAndDrainEmbeddedHeartbeatRun,
@@ -53,7 +55,11 @@ describe("embedded-agent active-run steering", () => {
     });
 
     const replacementQueue = vi.fn(async () => {});
-    const replacement = createEmbeddedRunHandle({ queueMessage: replacementQueue });
+    const replacementAbort = vi.fn();
+    const replacement = createEmbeddedRunHandle({
+      queueMessage: replacementQueue,
+      abort: replacementAbort,
+    });
     Object.assign(replacement, {
       runId: "run-replacement",
       toolAuthorityFingerprint: "authority-replacement",
@@ -65,6 +71,53 @@ describe("embedded-agent active-run steering", () => {
         isInboundUserMessage: true,
       }),
     ).resolves.toMatchObject({ queued: false, reason: "tool_authority_mismatch" });
+    expect(replacementQueue).not.toHaveBeenCalled();
+
+    expect(abortEmbeddedAgentMessageInjectionTarget(target!)).toBe(false);
+    expect(replacementAbort).not.toHaveBeenCalled();
+  });
+
+  it("steers and cancels through the production adapter without reaching a replacement", async () => {
+    const firstQueue = vi.fn(async () => {});
+    const firstAbort = vi.fn();
+    const first = createEmbeddedRunHandle({
+      queueMessage: firstQueue,
+      abort: firstAbort,
+      runId: "run-first",
+    });
+    Object.assign(first, { toolAuthorityFingerprint: "authority-first" });
+    setActiveEmbeddedRun("session-talk", first, "agent:main:main");
+    const target = resolveEmbeddedAgentMessageInjectionTarget({
+      sessionId: "session-talk",
+      runId: "run-first",
+    });
+
+    await expect(
+      controlOwnedRealtimeVoiceAgentRun(
+        { sessionKey: "agent:main:main", text: "use the safer plan", mode: "steer" },
+        target,
+      ),
+    ).resolves.toMatchObject({ ok: true, queued: true, sessionId: "session-talk" });
+    expect(firstQueue).toHaveBeenCalledTimes(1);
+
+    const replacementQueue = vi.fn(async () => {});
+    const replacementAbort = vi.fn();
+    const replacement = createEmbeddedRunHandle({
+      queueMessage: replacementQueue,
+      abort: replacementAbort,
+      runId: "run-replacement",
+    });
+    Object.assign(replacement, { toolAuthorityFingerprint: "authority-replacement" });
+    setActiveEmbeddedRun("session-talk", replacement, "agent:main:main");
+
+    await expect(
+      controlOwnedRealtimeVoiceAgentRun(
+        { sessionKey: "agent:main:main", text: "cancel", mode: "cancel" },
+        target,
+      ),
+    ).resolves.toMatchObject({ ok: false, aborted: false, reason: "abort_rejected" });
+    expect(firstAbort).not.toHaveBeenCalled();
+    expect(replacementAbort).not.toHaveBeenCalled();
     expect(replacementQueue).not.toHaveBeenCalled();
   });
 

--- a/src/agents/embedded-agent-runner/runs.steering.test.ts
+++ b/src/agents/embedded-agent-runner/runs.steering.test.ts
@@ -7,17 +7,13 @@ import { markDiagnosticToolStartedForTest } from "../../logging/diagnostic-run-a
 import { resetDiagnosticSessionStateForTest } from "../../logging/diagnostic-session-state.js";
 import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
 import { createTestUserTurnTranscriptTarget } from "../../sessions/user-turn-transcript.test-support.js";
-import { controlOwnedRealtimeVoiceAgentRun } from "../../talk/agent-run-control.js";
 import {
-  abortEmbeddedAgentMessageInjectionTarget,
   clearActiveEmbeddedRun,
   formatEmbeddedAgentQueueFailureSummary,
   observeEmbeddedAgentMessageInjectionTarget,
   preemptAndDrainEmbeddedHeartbeatRun,
-  queueEmbeddedAgentMessageInjectionTarget,
   queueEmbeddedAgentMessageWithOutcome,
   queueEmbeddedAgentMessageWithOutcomeAsync,
-  resolveEmbeddedAgentMessageInjectionTarget,
   setActiveEmbeddedRun,
   type EmbeddedAgentQueueHandle,
 } from "./runs.js";
@@ -32,41 +28,21 @@ describe("embedded-agent active-run steering", () => {
     vi.restoreAllMocks();
   });
 
-  it("publishes an admitted run target only after active registration", async () => {
+  it("projects authority only into the exact captured run", async () => {
     const context = {
-      operationalRunInstance: { instanceId: "instance-talk", runId: "run-talk" },
+      operationalRunInstance: { instanceId: "instance-talk", runId: "run-first" },
     };
     const observer = vi.fn();
     observeEmbeddedAgentMessageInjectionTarget(context, observer);
-    expect(observer).not.toHaveBeenCalled();
-
-    const queueMessage = vi.fn(async () => {});
-    const handle = createEmbeddedRunHandle({ queueMessage });
-    Object.assign(handle, { runId: "run-talk", toolAuthorityFingerprint: "authority-talk" });
-    setActiveEmbeddedRun("session-talk", handle, "agent:main:main", undefined, context);
-
-    expect(observer).toHaveBeenCalledOnce();
-    await expect(
-      queueEmbeddedAgentMessageInjectionTarget(observer.mock.calls[0]![0], "early steer"),
-    ).resolves.toMatchObject({ queued: true });
-    expect(queueMessage).toHaveBeenCalledWith("early steer", {
-      toolAuthorityFingerprint: "authority-talk",
-    });
-  });
-
-  it("projects authority only into the exact captured run", async () => {
     const firstQueue = vi.fn(async () => {});
     const first = createEmbeddedRunHandle({ queueMessage: firstQueue });
     Object.assign(first, { runId: "run-first", toolAuthorityFingerprint: "authority-first" });
-    setActiveEmbeddedRun("session-talk", first, "agent:main:main");
-    const target = resolveEmbeddedAgentMessageInjectionTarget({
-      sessionId: "session-talk",
-      runId: "run-first",
-    });
-    expect(target).toBeDefined();
+    setActiveEmbeddedRun("session-talk", first, "agent:main:main", undefined, context);
+    expect(observer).toHaveBeenCalledOnce();
+    const target = observer.mock.calls[0]![0];
 
     await expect(
-      queueEmbeddedAgentMessageInjectionTarget(target!, "steer", {
+      target.queueMessage("steer", {
         isInboundUserMessage: true,
         steeringMode: "all",
       }),
@@ -90,58 +66,14 @@ describe("embedded-agent active-run steering", () => {
     setActiveEmbeddedRun("session-talk", replacement, "agent:main:main");
 
     await expect(
-      queueEmbeddedAgentMessageInjectionTarget(target!, "stale steer", {
+      target.queueMessage("stale steer", {
         isInboundUserMessage: true,
       }),
     ).resolves.toMatchObject({ queued: false, reason: "tool_authority_mismatch" });
     expect(replacementQueue).not.toHaveBeenCalled();
 
-    expect(abortEmbeddedAgentMessageInjectionTarget(target!)).toBe(false);
+    expect(target.abort()).toBe(false);
     expect(replacementAbort).not.toHaveBeenCalled();
-  });
-
-  it("steers and cancels through the production adapter without reaching a replacement", async () => {
-    const firstQueue = vi.fn(async () => {});
-    const firstAbort = vi.fn();
-    const first = createEmbeddedRunHandle({
-      queueMessage: firstQueue,
-      abort: firstAbort,
-      runId: "run-first",
-    });
-    Object.assign(first, { toolAuthorityFingerprint: "authority-first" });
-    setActiveEmbeddedRun("session-talk", first, "agent:main:main");
-    const target = resolveEmbeddedAgentMessageInjectionTarget({
-      sessionId: "session-talk",
-      runId: "run-first",
-    });
-
-    await expect(
-      controlOwnedRealtimeVoiceAgentRun(
-        { sessionKey: "agent:main:main", text: "use the safer plan", mode: "steer" },
-        target,
-      ),
-    ).resolves.toMatchObject({ ok: true, queued: true, sessionId: "session-talk" });
-    expect(firstQueue).toHaveBeenCalledTimes(1);
-
-    const replacementQueue = vi.fn(async () => {});
-    const replacementAbort = vi.fn();
-    const replacement = createEmbeddedRunHandle({
-      queueMessage: replacementQueue,
-      abort: replacementAbort,
-      runId: "run-replacement",
-    });
-    Object.assign(replacement, { toolAuthorityFingerprint: "authority-replacement" });
-    setActiveEmbeddedRun("session-talk", replacement, "agent:main:main");
-
-    await expect(
-      controlOwnedRealtimeVoiceAgentRun(
-        { sessionKey: "agent:main:main", text: "cancel", mode: "cancel" },
-        target,
-      ),
-    ).resolves.toMatchObject({ ok: false, aborted: false, reason: "abort_rejected" });
-    expect(firstAbort).not.toHaveBeenCalled();
-    expect(replacementAbort).not.toHaveBeenCalled();
-    expect(replacementQueue).not.toHaveBeenCalled();
   });
 
   it("aborts and drains the exact heartbeat handle through session replacement", async () => {

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -114,6 +114,16 @@ type PreparedEmbeddedAgentQueueMessage =
       queueMessage: EmbeddedAgentQueueHandle["queueMessage"];
     };
 
+const embeddedAgentMessageInjectionTargetHandle = Symbol(
+  "embeddedAgentMessageInjectionTargetHandle",
+);
+
+/** Opaque exact-run capability minted only after an ingress proves ownership. */
+export type EmbeddedAgentMessageInjectionTarget = {
+  readonly [embeddedAgentMessageInjectionTargetHandle]: EmbeddedAgentQueueHandle;
+  readonly sessionId: string;
+};
+
 function createQueueFailureOutcome(
   sessionId: string,
   reason: EmbeddedAgentQueueFailureReason,
@@ -581,6 +591,40 @@ export async function queueEmbeddedAgentMessageWithOutcomeAsync(
     diag.debug(`queue message rejected: sessionId=${sessionId} err=${errorMessage}`);
     return createQueueFailureOutcome(sessionId, "runtime_rejected", errorMessage);
   }
+}
+
+/** Capture one exact active run without exposing its authority fingerprint. */
+export function resolveEmbeddedAgentMessageInjectionTarget(params: {
+  sessionId: string;
+  runId: string;
+}): EmbeddedAgentMessageInjectionTarget | undefined {
+  const sessionId = params.sessionId.trim();
+  const runId = params.runId.trim();
+  const handle = sessionId && runId ? ACTIVE_EMBEDDED_RUNS.get(sessionId) : undefined;
+  if (!handle || handle.runId !== runId || ACTIVE_EMBEDDED_RUNS_BY_RUN_ID.get(runId) !== handle) {
+    return undefined;
+  }
+  return { [embeddedAgentMessageInjectionTargetHandle]: handle, sessionId };
+}
+
+/** Inject owner-proven input only while the captured run remains the exact live owner. */
+export function queueEmbeddedAgentMessageInjectionTarget(
+  target: EmbeddedAgentMessageInjectionTarget,
+  text: string,
+  options?: Omit<
+    EmbeddedAgentQueueMessageOptions,
+    "toolAuthorityFingerprint" | "pendingInputAuthorityFingerprint"
+  >,
+): Promise<EmbeddedAgentQueueMessageOutcome> {
+  const handle = target[embeddedAgentMessageInjectionTargetHandle];
+  const fingerprint = normalizeOptionalString(handle.toolAuthorityFingerprint);
+  if (ACTIVE_EMBEDDED_RUNS.get(target.sessionId) !== handle || !fingerprint) {
+    return Promise.resolve(createQueueFailureOutcome(target.sessionId, "tool_authority_mismatch"));
+  }
+  return queueEmbeddedAgentMessageWithOutcomeAsync(target.sessionId, text, {
+    ...options,
+    toolAuthorityFingerprint: fingerprint,
+  });
 }
 
 function prepareEmbeddedAgentQueueMessage(

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -115,26 +115,15 @@ type PreparedEmbeddedAgentQueueMessage =
       queueMessage: EmbeddedAgentQueueHandle["queueMessage"];
     };
 
-const embeddedAgentMessageInjectionTargetHandle = Symbol(
-  "embeddedAgentMessageInjectionTargetHandle",
-);
-
-/** Opaque exact-run capability minted only after an ingress proves ownership. */
-export type EmbeddedAgentMessageInjectionTarget = {
-  readonly [embeddedAgentMessageInjectionTargetHandle]: EmbeddedAgentQueueHandle;
-  readonly runId: string;
-  readonly sessionId: string;
-};
-
 const embeddedRunTargetObservers = new WeakMap<
   AdmittedRunContext,
-  (target: EmbeddedAgentMessageInjectionTarget) => void
+  (target: ActiveEmbeddedRunOwner) => void
 >();
 
 /** Observe the exact active handle created for one admitted operational instance. */
 export function observeEmbeddedAgentMessageInjectionTarget(
   context: AdmittedRunContext,
-  observer: (target: EmbeddedAgentMessageInjectionTarget) => void,
+  observer: (target: ActiveEmbeddedRunOwner) => void,
 ): () => void {
   embeddedRunTargetObservers.set(context, observer);
   return () => {
@@ -613,65 +602,6 @@ export async function queueEmbeddedAgentMessageWithOutcomeAsync(
   }
 }
 
-/** Capture one exact active run without exposing its authority fingerprint. */
-export function resolveEmbeddedAgentMessageInjectionTarget(params: {
-  sessionId: string;
-  runId: string;
-}): EmbeddedAgentMessageInjectionTarget | undefined {
-  const sessionId = params.sessionId.trim();
-  const runId = params.runId.trim();
-  const handle = sessionId && runId ? ACTIVE_EMBEDDED_RUNS.get(sessionId) : undefined;
-  if (!handle || handle.runId !== runId || ACTIVE_EMBEDDED_RUNS_BY_RUN_ID.get(runId) !== handle) {
-    return undefined;
-  }
-  return { [embeddedAgentMessageInjectionTargetHandle]: handle, runId, sessionId };
-}
-
-/** Inject owner-proven input only while the captured run remains the exact live owner. */
-export function queueEmbeddedAgentMessageInjectionTarget(
-  target: EmbeddedAgentMessageInjectionTarget,
-  text: string,
-  options?: Omit<
-    EmbeddedAgentQueueMessageOptions,
-    "toolAuthorityFingerprint" | "pendingInputAuthorityFingerprint"
-  >,
-): Promise<EmbeddedAgentQueueMessageOutcome> {
-  const handle = target[embeddedAgentMessageInjectionTargetHandle];
-  const fingerprint = normalizeOptionalString(handle.toolAuthorityFingerprint);
-  if (
-    ACTIVE_EMBEDDED_RUNS.get(target.sessionId) !== handle ||
-    ACTIVE_EMBEDDED_RUNS_BY_RUN_ID.get(target.runId) !== handle ||
-    !fingerprint
-  ) {
-    return Promise.resolve(createQueueFailureOutcome(target.sessionId, "tool_authority_mismatch"));
-  }
-  return queueEmbeddedAgentMessageWithOutcomeAsync(target.sessionId, text, {
-    ...options,
-    toolAuthorityFingerprint: fingerprint,
-  });
-}
-
-/** Abort only while the captured run remains the exact live owner. */
-export function abortEmbeddedAgentMessageInjectionTarget(
-  target: EmbeddedAgentMessageInjectionTarget,
-): boolean {
-  const handle = target[embeddedAgentMessageInjectionTargetHandle];
-  if (
-    ACTIVE_EMBEDDED_RUNS.get(target.sessionId) !== handle ||
-    ACTIVE_EMBEDDED_RUNS_BY_RUN_ID.get(target.runId) !== handle ||
-    !isEmbeddedRunHandleAbortable(target.sessionId, handle)
-  ) {
-    return false;
-  }
-  try {
-    handle.abort();
-    return true;
-  } catch (err) {
-    diag.warn(`abort failed: sessionId=${target.sessionId} err=${String(err)}`);
-    return false;
-  }
-}
-
 function prepareEmbeddedAgentQueueMessage(
   sessionId: string,
   options?: EmbeddedAgentQueueMessageOptions,
@@ -965,6 +895,13 @@ export type ActiveEmbeddedRunOwner = {
   sessionKey?: string;
   startedAtMs?: number;
   abort: () => boolean;
+  queueMessage: (
+    text: string,
+    options?: Omit<
+      EmbeddedAgentQueueMessageOptions,
+      "toolAuthorityFingerprint" | "pendingInputAuthorityFingerprint"
+    >,
+  ) => Promise<EmbeddedAgentQueueMessageOutcome>;
 };
 
 function projectActiveEmbeddedRunOwner(
@@ -1000,6 +937,22 @@ function projectActiveEmbeddedRunOwner(
       } catch {
         return false;
       }
+    },
+    queueMessage: (text, options) => {
+      const fingerprint = normalizeOptionalString(handle.toolAuthorityFingerprint);
+      if (
+        ACTIVE_EMBEDDED_RUNS.get(registration.sessionId) !== handle ||
+        ACTIVE_EMBEDDED_RUNS_BY_RUN_ID.get(runId) !== handle ||
+        !fingerprint
+      ) {
+        return Promise.resolve(
+          createQueueFailureOutcome(registration.sessionId, "tool_authority_mismatch"),
+        );
+      }
+      return queueEmbeddedAgentMessageWithOutcomeAsync(registration.sessionId, text, {
+        ...options,
+        toolAuthorityFingerprint: fingerprint,
+      });
     },
   };
 }
@@ -1434,11 +1387,10 @@ export function setActiveEmbeddedRun(
     embeddedRunTargetObservers.delete(admittedRunContext);
     // Publish only after both active indexes own this exact handle; delayed
     // controls then cannot bind to a predecessor or an unregistered run.
-    observer({
-      [embeddedAgentMessageInjectionTargetHandle]: handle,
-      runId: handle.runId,
-      sessionId,
-    });
+    const owner = resolveActiveEmbeddedRunOwnerByRunId(handle.runId);
+    if (owner) {
+      observer(owner);
+    }
   }
 }
 

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -121,6 +121,7 @@ const embeddedAgentMessageInjectionTargetHandle = Symbol(
 /** Opaque exact-run capability minted only after an ingress proves ownership. */
 export type EmbeddedAgentMessageInjectionTarget = {
   readonly [embeddedAgentMessageInjectionTargetHandle]: EmbeddedAgentQueueHandle;
+  readonly runId: string;
   readonly sessionId: string;
 };
 
@@ -604,7 +605,7 @@ export function resolveEmbeddedAgentMessageInjectionTarget(params: {
   if (!handle || handle.runId !== runId || ACTIVE_EMBEDDED_RUNS_BY_RUN_ID.get(runId) !== handle) {
     return undefined;
   }
-  return { [embeddedAgentMessageInjectionTargetHandle]: handle, sessionId };
+  return { [embeddedAgentMessageInjectionTargetHandle]: handle, runId, sessionId };
 }
 
 /** Inject owner-proven input only while the captured run remains the exact live owner. */
@@ -618,13 +619,38 @@ export function queueEmbeddedAgentMessageInjectionTarget(
 ): Promise<EmbeddedAgentQueueMessageOutcome> {
   const handle = target[embeddedAgentMessageInjectionTargetHandle];
   const fingerprint = normalizeOptionalString(handle.toolAuthorityFingerprint);
-  if (ACTIVE_EMBEDDED_RUNS.get(target.sessionId) !== handle || !fingerprint) {
+  if (
+    ACTIVE_EMBEDDED_RUNS.get(target.sessionId) !== handle ||
+    ACTIVE_EMBEDDED_RUNS_BY_RUN_ID.get(target.runId) !== handle ||
+    !fingerprint
+  ) {
     return Promise.resolve(createQueueFailureOutcome(target.sessionId, "tool_authority_mismatch"));
   }
   return queueEmbeddedAgentMessageWithOutcomeAsync(target.sessionId, text, {
     ...options,
     toolAuthorityFingerprint: fingerprint,
   });
+}
+
+/** Abort only while the captured run remains the exact live owner. */
+export function abortEmbeddedAgentMessageInjectionTarget(
+  target: EmbeddedAgentMessageInjectionTarget,
+): boolean {
+  const handle = target[embeddedAgentMessageInjectionTargetHandle];
+  if (
+    ACTIVE_EMBEDDED_RUNS.get(target.sessionId) !== handle ||
+    ACTIVE_EMBEDDED_RUNS_BY_RUN_ID.get(target.runId) !== handle ||
+    !isEmbeddedRunHandleAbortable(target.sessionId, handle)
+  ) {
+    return false;
+  }
+  try {
+    handle.abort();
+    return true;
+  } catch (err) {
+    diag.warn(`abort failed: sessionId=${target.sessionId} err=${String(err)}`);
+    return false;
+  }
 }
 
 function prepareEmbeddedAgentQueueMessage(

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -45,6 +45,7 @@ import {
 import { logMessageQueuedWithBacklogPolicy } from "../../logging/diagnostic-runtime.js";
 import { diagnosticLogger as diag, logSessionStateChange } from "../../logging/diagnostic.js";
 import { hasPromptImageInput } from "../../media/prompt-image-input.js";
+import type { AdmittedRunContext } from "../admitted-run-context.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
 import { resolveSessionPlacementForcedTerminalSettlement } from "../session-placement-admission.js";
 import { getGatewayToolCallerIdentity } from "../tools/gateway-caller-context.js";
@@ -124,6 +125,24 @@ export type EmbeddedAgentMessageInjectionTarget = {
   readonly runId: string;
   readonly sessionId: string;
 };
+
+const embeddedRunTargetObservers = new WeakMap<
+  AdmittedRunContext,
+  (target: EmbeddedAgentMessageInjectionTarget) => void
+>();
+
+/** Observe the exact active handle created for one admitted operational instance. */
+export function observeEmbeddedAgentMessageInjectionTarget(
+  context: AdmittedRunContext,
+  observer: (target: EmbeddedAgentMessageInjectionTarget) => void,
+): () => void {
+  embeddedRunTargetObservers.set(context, observer);
+  return () => {
+    if (embeddedRunTargetObservers.get(context) === observer) {
+      embeddedRunTargetObservers.delete(context);
+    }
+  };
+}
 
 function createQueueFailureOutcome(
   sessionId: string,
@@ -1323,6 +1342,7 @@ export function setActiveEmbeddedRun(
   handle: EmbeddedAgentQueueHandle,
   sessionKey?: string,
   sessionFile?: string,
+  admittedRunContext?: AdmittedRunContext,
 ) {
   const currentLifecycleGeneration = getAgentEventLifecycleGeneration();
   const incomingLifecycleGeneration = setActiveEmbeddedRunLifecycleGeneration(
@@ -1406,6 +1426,19 @@ export function setActiveEmbeddedRun(
   });
   if (!sessionId.startsWith("probe-")) {
     diag.debug(`run registered: sessionId=${sessionId} totalActive=${ACTIVE_EMBEDDED_RUNS.size}`);
+  }
+  const observer = admittedRunContext
+    ? embeddedRunTargetObservers.get(admittedRunContext)
+    : undefined;
+  if (admittedRunContext && observer && handle.runId) {
+    embeddedRunTargetObservers.delete(admittedRunContext);
+    // Publish only after both active indexes own this exact handle; delayed
+    // controls then cannot bind to a predecessor or an unregistered run.
+    observer({
+      [embeddedAgentMessageInjectionTargetHandle]: handle,
+      runId: handle.runId,
+      sessionId,
+    });
   }
 }
 

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -45,7 +45,6 @@ import {
 import { logMessageQueuedWithBacklogPolicy } from "../../logging/diagnostic-runtime.js";
 import { diagnosticLogger as diag, logSessionStateChange } from "../../logging/diagnostic.js";
 import { hasPromptImageInput } from "../../media/prompt-image-input.js";
-import type { AdmittedRunContext } from "../admitted-run-context.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
 import { resolveSessionPlacementForcedTerminalSettlement } from "../session-placement-admission.js";
 import { getGatewayToolCallerIdentity } from "../tools/gateway-caller-context.js";
@@ -114,24 +113,6 @@ type PreparedEmbeddedAgentQueueMessage =
       kind: "embedded_run";
       queueMessage: EmbeddedAgentQueueHandle["queueMessage"];
     };
-
-const embeddedRunTargetObservers = new WeakMap<
-  AdmittedRunContext,
-  (target: ActiveEmbeddedRunOwner) => void
->();
-
-/** Observe the exact active handle created for one admitted operational instance. */
-export function observeEmbeddedAgentMessageInjectionTarget(
-  context: AdmittedRunContext,
-  observer: (target: ActiveEmbeddedRunOwner) => void,
-): () => void {
-  embeddedRunTargetObservers.set(context, observer);
-  return () => {
-    if (embeddedRunTargetObservers.get(context) === observer) {
-      embeddedRunTargetObservers.delete(context);
-    }
-  };
-}
 
 function createQueueFailureOutcome(
   sessionId: string,
@@ -1295,7 +1276,6 @@ export function setActiveEmbeddedRun(
   handle: EmbeddedAgentQueueHandle,
   sessionKey?: string,
   sessionFile?: string,
-  admittedRunContext?: AdmittedRunContext,
 ) {
   const currentLifecycleGeneration = getAgentEventLifecycleGeneration();
   const incomingLifecycleGeneration = setActiveEmbeddedRunLifecycleGeneration(
@@ -1379,18 +1359,6 @@ export function setActiveEmbeddedRun(
   });
   if (!sessionId.startsWith("probe-")) {
     diag.debug(`run registered: sessionId=${sessionId} totalActive=${ACTIVE_EMBEDDED_RUNS.size}`);
-  }
-  const observer = admittedRunContext
-    ? embeddedRunTargetObservers.get(admittedRunContext)
-    : undefined;
-  if (admittedRunContext && observer && handle.runId) {
-    embeddedRunTargetObservers.delete(admittedRunContext);
-    // Publish only after both active indexes own this exact handle; delayed
-    // controls then cannot bind to a predecessor or an unregistered run.
-    const owner = resolveActiveEmbeddedRunOwnerByRunId(handle.runId);
-    if (owner) {
-      observer(owner);
-    }
   }
 }
 

--- a/src/agents/embedded-agent.ts
+++ b/src/agents/embedded-agent.ts
@@ -1,6 +1,7 @@
 // Public embedded-agent barrel. Re-export the runner API used by gateway,
 // command, and plugin surfaces without exposing internal runner file layout.
 export type {
+  EmbeddedAgentMessageInjectionTarget,
   EmbeddedAgentCompactResult,
   EmbeddedAgentMeta,
   EmbeddedAgentRunMeta,
@@ -15,6 +16,7 @@ export {
   isEmbeddedAgentRunActive,
   isEmbeddedAgentRunHandleActive,
   isEmbeddedAgentRunStreaming,
+  observeEmbeddedAgentMessageInjectionTarget,
   queueEmbeddedAgentMessageWithOutcome,
   resolveActiveEmbeddedRunSessionId,
   resolveActiveEmbeddedRunSessionIdBySessionFile,

--- a/src/agents/embedded-agent.ts
+++ b/src/agents/embedded-agent.ts
@@ -1,7 +1,7 @@
 // Public embedded-agent barrel. Re-export the runner API used by gateway,
 // command, and plugin surfaces without exposing internal runner file layout.
 export type {
-  EmbeddedAgentMessageInjectionTarget,
+  ActiveEmbeddedRunOwner,
   EmbeddedAgentCompactResult,
   EmbeddedAgentMeta,
   EmbeddedAgentRunMeta,

--- a/src/agents/embedded-agent.ts
+++ b/src/agents/embedded-agent.ts
@@ -16,7 +16,6 @@ export {
   isEmbeddedAgentRunActive,
   isEmbeddedAgentRunHandleActive,
   isEmbeddedAgentRunStreaming,
-  observeEmbeddedAgentMessageInjectionTarget,
   queueEmbeddedAgentMessageWithOutcome,
   resolveActiveEmbeddedRunSessionId,
   resolveActiveEmbeddedRunSessionIdBySessionFile,

--- a/src/gateway/server-methods/talk-client-create.ts
+++ b/src/gateway/server-methods/talk-client-create.ts
@@ -244,6 +244,12 @@ export const createTalkClient: GatewayRequestHandler = async ({
         );
         return;
       }
+      const captureAgentRunControl = () =>
+        resolveOwnedActiveTalkClientInjectionTarget({
+          context,
+          clientConnId: ownerConnId,
+          sessionKey,
+        });
       const consultRunner = createTalkClientAgentConsultRunner({
         config: runtimeConfig,
         context,
@@ -253,6 +259,7 @@ export const createTalkClient: GatewayRequestHandler = async ({
         authority: resolveTalkAgentConsultAuthority(client?.connect?.scopes),
         getVoiceSessionId: () => activeVoiceSessionId,
         initialItems,
+        captureRunControl: captureAgentRunControl,
       });
       const gatewayControlOwner = ownsProvider
         ? createTalkClientGatewayControlOwner({
@@ -270,12 +277,7 @@ export const createTalkClient: GatewayRequestHandler = async ({
               }
             },
             runAgentConsult: consultRunner.runArgs,
-            captureAgentRunControl: () =>
-              resolveOwnedActiveTalkClientInjectionTarget({
-                context,
-                clientConnId: ownerConnId,
-                sessionKey,
-              }),
+            captureAgentRunControl,
             controlAgentRun: async (controlParams, target) => {
               return controlOwnedRealtimeVoiceAgentRun(controlParams, target);
             },

--- a/src/gateway/server-methods/talk-client-create.ts
+++ b/src/gateway/server-methods/talk-client-create.ts
@@ -38,11 +38,11 @@ import {
   resolveSandboxedSessionCreation,
 } from "../operator-role-policy.js";
 import { readSessionPreviewItemsFromTranscript } from "../session-transcript-readers.js";
+import { resolveTalkAgentConsultAuthority } from "../talk-agent-consult-authority.js";
 import {
   boundTalkClientRealtimeInitialItems,
   createTalkClientAgentConsultRunner,
   createTalkClientGatewayControlOwner,
-  resolveTalkAgentConsultAuthority,
 } from "../talk-client-gateway-control.js";
 import { formatForLog } from "../ws-log.js";
 import {

--- a/src/gateway/server-methods/talk-client-create.ts
+++ b/src/gateway/server-methods/talk-client-create.ts
@@ -13,6 +13,10 @@ import { buildAgentMainSessionKey } from "../../routing/session-key.js";
 import { assertSecretOwnerAvailable } from "../../secrets/runtime-degraded-state.js";
 import { REALTIME_VOICE_AGENT_CONSULT_TOOL } from "../../talk/agent-consult-tool.js";
 import { REALTIME_VOICE_AGENT_CONTROL_TOOL } from "../../talk/agent-run-control-shared.js";
+import {
+  controlOwnedRealtimeVoiceAgentRun,
+  controlRealtimeVoiceAgentRun,
+} from "../../talk/agent-run-control.js";
 import { resolveTalkSessionAgentId } from "../../talk/agent-target.js";
 import {
   appendClientVoiceTranscript,
@@ -48,6 +52,7 @@ import {
   forgetLegacyVoiceBinding,
   rememberLegacyVoiceBinding,
 } from "./talk-client-legacy-voice-bindings.js";
+import { resolveOwnedActiveTalkClientInjectionTarget } from "./talk-client-run-ownership.js";
 import {
   buildRealtimeInstructions,
   buildRealtimeVoiceLaunchOptions,
@@ -268,6 +273,16 @@ export const createTalkClient: GatewayRequestHandler = async ({
               }
             },
             runAgentConsult: consultRunner.runArgs,
+            controlAgentRun: async (controlParams) => {
+              const target = resolveOwnedActiveTalkClientInjectionTarget({
+                context,
+                clientConnId: ownerConnId,
+                sessionKey,
+              });
+              return target
+                ? await controlOwnedRealtimeVoiceAgentRun(controlParams, target)
+                : await controlRealtimeVoiceAgentRun(controlParams);
+            },
             appendTranscript: ({ entryId, role, text }) =>
               appendClientVoiceTranscript({
                 agentId,

--- a/src/gateway/server-methods/talk-client-create.ts
+++ b/src/gateway/server-methods/talk-client-create.ts
@@ -270,12 +270,13 @@ export const createTalkClient: GatewayRequestHandler = async ({
               }
             },
             runAgentConsult: consultRunner.runArgs,
-            controlAgentRun: async (controlParams) => {
-              const target = resolveOwnedActiveTalkClientInjectionTarget({
+            captureAgentRunControl: () =>
+              resolveOwnedActiveTalkClientInjectionTarget({
                 context,
                 clientConnId: ownerConnId,
                 sessionKey,
-              });
+              }),
+            controlAgentRun: async (controlParams, target) => {
               return controlOwnedRealtimeVoiceAgentRun(controlParams, target);
             },
             appendTranscript: ({ entryId, role, text }) =>

--- a/src/gateway/server-methods/talk-client-create.ts
+++ b/src/gateway/server-methods/talk-client-create.ts
@@ -13,10 +13,7 @@ import { buildAgentMainSessionKey } from "../../routing/session-key.js";
 import { assertSecretOwnerAvailable } from "../../secrets/runtime-degraded-state.js";
 import { REALTIME_VOICE_AGENT_CONSULT_TOOL } from "../../talk/agent-consult-tool.js";
 import { REALTIME_VOICE_AGENT_CONTROL_TOOL } from "../../talk/agent-run-control-shared.js";
-import {
-  controlOwnedRealtimeVoiceAgentRun,
-  controlRealtimeVoiceAgentRun,
-} from "../../talk/agent-run-control.js";
+import { controlOwnedRealtimeVoiceAgentRun } from "../../talk/agent-run-control.js";
 import { resolveTalkSessionAgentId } from "../../talk/agent-target.js";
 import {
   appendClientVoiceTranscript,
@@ -279,9 +276,7 @@ export const createTalkClient: GatewayRequestHandler = async ({
                 clientConnId: ownerConnId,
                 sessionKey,
               });
-              return target
-                ? await controlOwnedRealtimeVoiceAgentRun(controlParams, target)
-                : await controlRealtimeVoiceAgentRun(controlParams);
+              return controlOwnedRealtimeVoiceAgentRun(controlParams, target);
             },
             appendTranscript: ({ entryId, role, text }) =>
               appendClientVoiceTranscript({

--- a/src/gateway/server-methods/talk-client-run-ownership.ts
+++ b/src/gateway/server-methods/talk-client-run-ownership.ts
@@ -1,20 +1,30 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import {
+  resolveEmbeddedAgentMessageInjectionTarget,
+  type EmbeddedAgentMessageInjectionTarget,
+} from "../../agents/embedded-agent-runner/runs.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
-export function hasOwnedActiveTalkClientRun(params: {
+export function resolveOwnedActiveTalkClientInjectionTarget(params: {
   context: Parameters<GatewayRequestHandlers[string]>[0]["context"];
   clientConnId?: string;
   sessionKey: string;
-}): boolean {
+}): EmbeddedAgentMessageInjectionTarget | undefined {
   const connId = normalizeOptionalString(params.clientConnId);
   const sessionKey = params.sessionKey.trim();
   if (!connId || !sessionKey) {
-    return false;
+    return undefined;
   }
-  for (const entry of params.context.chatAbortControllers.values()) {
+  for (const [runId, entry] of params.context.chatAbortControllers) {
     if (entry.sessionKey === sessionKey && entry.ownerConnId === connId && entry.kind !== "agent") {
-      return true;
+      const target = resolveEmbeddedAgentMessageInjectionTarget({
+        runId,
+        sessionId: entry.sessionId,
+      });
+      if (target) {
+        return target;
+      }
     }
   }
-  return false;
+  return undefined;
 }

--- a/src/gateway/server-methods/talk-client-run-ownership.ts
+++ b/src/gateway/server-methods/talk-client-run-ownership.ts
@@ -1,7 +1,7 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
-  resolveEmbeddedAgentMessageInjectionTarget,
-  type EmbeddedAgentMessageInjectionTarget,
+  resolveActiveEmbeddedRunOwnerByRunId,
+  type ActiveEmbeddedRunOwner,
 } from "../../agents/embedded-agent-runner/runs.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
@@ -9,7 +9,7 @@ export function resolveOwnedActiveTalkClientInjectionTarget(params: {
   context: Parameters<GatewayRequestHandlers[string]>[0]["context"];
   clientConnId?: string;
   sessionKey: string;
-}): EmbeddedAgentMessageInjectionTarget | undefined {
+}): ActiveEmbeddedRunOwner | undefined {
   const connId = normalizeOptionalString(params.clientConnId);
   const sessionKey = params.sessionKey.trim();
   if (!connId || !sessionKey) {
@@ -17,11 +17,8 @@ export function resolveOwnedActiveTalkClientInjectionTarget(params: {
   }
   for (const [runId, entry] of params.context.chatAbortControllers) {
     if (entry.sessionKey === sessionKey && entry.ownerConnId === connId && entry.kind !== "agent") {
-      const target = resolveEmbeddedAgentMessageInjectionTarget({
-        runId,
-        sessionId: entry.sessionId,
-      });
-      if (target) {
+      const target = resolveActiveEmbeddedRunOwnerByRunId(runId);
+      if (target?.sessionId === entry.sessionId) {
         return target;
       }
     }

--- a/src/gateway/server-methods/talk-client.ts
+++ b/src/gateway/server-methods/talk-client.ts
@@ -14,7 +14,7 @@ import {
   REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
   parseRealtimeVoiceAgentConsultArgs,
 } from "../../talk/agent-consult-tool.js";
-import { controlRealtimeVoiceAgentRun } from "../../talk/agent-run-control.js";
+import { controlOwnedRealtimeVoiceAgentRun } from "../../talk/agent-run-control.js";
 import { resolveTalkSessionAgentId } from "../../talk/agent-target.js";
 import {
   authorizeClientVoiceConfirmation,
@@ -48,7 +48,7 @@ import {
   readLegacyVoiceBinding,
   rememberLegacyVoiceBinding,
 } from "./talk-client-legacy-voice-bindings.js";
-import { hasOwnedActiveTalkClientRun } from "./talk-client-run-ownership.js";
+import { resolveOwnedActiveTalkClientInjectionTarget } from "./talk-client-run-ownership.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
@@ -265,13 +265,12 @@ export const talkClientHandlers: GatewayRequestHandlers = {
     if (!assertValidParams(params, validateTalkClientSteerParams, "talk.client.steer", respond)) {
       return;
     }
-    if (
-      !hasOwnedActiveTalkClientRun({
-        context,
-        clientConnId: client?.connId,
-        sessionKey: params.sessionKey,
-      })
-    ) {
+    const injectionTarget = resolveOwnedActiveTalkClientInjectionTarget({
+      context,
+      clientConnId: client?.connId,
+      sessionKey: params.sessionKey,
+    });
+    if (!injectionTarget) {
       respond(
         false,
         undefined,
@@ -283,11 +282,14 @@ export const talkClientHandlers: GatewayRequestHandlers = {
       return;
     }
     try {
-      const result = await controlRealtimeVoiceAgentRun({
-        sessionKey: params.sessionKey,
-        text: params.text,
-        mode: params.mode,
-      });
+      const result = await controlOwnedRealtimeVoiceAgentRun(
+        {
+          sessionKey: params.sessionKey,
+          text: params.text,
+          mode: params.mode,
+        },
+        injectionTarget,
+      );
       respond(true, result, undefined);
     } catch (err) {
       respond(

--- a/src/gateway/server-methods/talk-session.ts
+++ b/src/gateway/server-methods/talk-session.ts
@@ -28,7 +28,7 @@ import {
 import { ADMIN_SCOPE } from "../operator-scopes.js";
 import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
 import { resolveSessionKeyFromResolveParams } from "../sessions-resolve.js";
-import { resolveTalkAgentConsultAuthority } from "../talk-client-gateway-control.js";
+import { resolveTalkAgentConsultAuthority } from "../talk-agent-consult-authority.js";
 import { createTalkHandoff, getTalkHandoff, revokeTalkHandoff } from "../talk-handoff.js";
 import {
   cancelTalkRealtimeRelayTurn,

--- a/src/gateway/server-methods/talk.test.ts
+++ b/src/gateway/server-methods/talk.test.ts
@@ -73,8 +73,8 @@ const mocks = vi.hoisted(() => ({
   stopTalkTranscriptionRelaySession: vi.fn(),
   chatSend: vi.fn(),
   controlRealtimeVoiceAgentRun: vi.fn(),
-  injectionTarget: {},
-  resolveEmbeddedAgentMessageInjectionTarget: vi.fn(),
+  injectionTarget: { sessionId: "session-active" },
+  resolveActiveEmbeddedRunOwnerByRunId: vi.fn(),
   steerTalkRealtimeRelayAgentRun: vi.fn(),
   resolveSessionKeyFromResolveParams: vi.fn(),
   resolveRealtimeBootstrapContextInstructions: vi.fn(
@@ -165,7 +165,7 @@ vi.mock("../../talk/agent-run-control.js", () => ({
 
 vi.mock("../../agents/embedded-agent-runner/runs.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../agents/embedded-agent-runner/runs.js")>()),
-  resolveEmbeddedAgentMessageInjectionTarget: mocks.resolveEmbeddedAgentMessageInjectionTarget,
+  resolveActiveEmbeddedRunOwnerByRunId: mocks.resolveActiveEmbeddedRunOwnerByRunId,
 }));
 
 vi.mock("../../talk/agent-consult-runtime.js", async (importOriginal) => {
@@ -2956,7 +2956,7 @@ describe("talk.client.steer handler", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.resolveEmbeddedAgentMessageInjectionTarget.mockReturnValue(mocks.injectionTarget);
+    mocks.resolveActiveEmbeddedRunOwnerByRunId.mockReturnValue(mocks.injectionTarget);
     mocks.controlRealtimeVoiceAgentRun.mockResolvedValue({
       ok: true,
       mode: "steer",
@@ -3494,6 +3494,8 @@ describe("talk.client.create handler", () => {
       show: true,
       suppress: false,
     });
+    const currentTarget = { ...mocks.injectionTarget, sessionId: "session-main" };
+    mocks.resolveActiveEmbeddedRunOwnerByRunId.mockReturnValue(currentTarget);
     const steerRespond = vi.fn();
     await callTalkHandler("talk.client.steer", {
       params: { sessionKey: "main", text: "Use the safer plan", mode: "steer" },
@@ -3506,7 +3508,7 @@ describe("talk.client.create handler", () => {
         text: "Use the safer plan",
         mode: "steer",
       },
-      mocks.injectionTarget,
+      currentTarget,
     );
     expectRespondOk(steerRespond, { ok: true, mode: "steer" });
 

--- a/src/gateway/server-methods/talk.test.ts
+++ b/src/gateway/server-methods/talk.test.ts
@@ -73,6 +73,8 @@ const mocks = vi.hoisted(() => ({
   stopTalkTranscriptionRelaySession: vi.fn(),
   chatSend: vi.fn(),
   controlRealtimeVoiceAgentRun: vi.fn(),
+  injectionTarget: {},
+  resolveEmbeddedAgentMessageInjectionTarget: vi.fn(),
   steerTalkRealtimeRelayAgentRun: vi.fn(),
   resolveSessionKeyFromResolveParams: vi.fn(),
   resolveRealtimeBootstrapContextInstructions: vi.fn(
@@ -158,6 +160,12 @@ vi.mock("../../talk/provider-internal.js", async (importOriginal) => {
 
 vi.mock("../../talk/agent-run-control.js", () => ({
   controlRealtimeVoiceAgentRun: mocks.controlRealtimeVoiceAgentRun,
+  controlOwnedRealtimeVoiceAgentRun: mocks.controlRealtimeVoiceAgentRun,
+}));
+
+vi.mock("../../agents/embedded-agent-runner/runs.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../agents/embedded-agent-runner/runs.js")>()),
+  resolveEmbeddedAgentMessageInjectionTarget: mocks.resolveEmbeddedAgentMessageInjectionTarget,
 }));
 
 vi.mock("../../talk/agent-consult-runtime.js", async (importOriginal) => {
@@ -2948,6 +2956,7 @@ describe("talk.client.steer handler", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.resolveEmbeddedAgentMessageInjectionTarget.mockReturnValue(mocks.injectionTarget);
     mocks.controlRealtimeVoiceAgentRun.mockResolvedValue({
       ok: true,
       mode: "steer",
@@ -2975,11 +2984,14 @@ describe("talk.client.steer handler", () => {
       context: createSteerContext(),
     });
 
-    expect(mocks.controlRealtimeVoiceAgentRun).toHaveBeenCalledWith({
-      sessionKey: "agent:main:main",
-      text: "use the safer plan",
-      mode: "steer",
-    });
+    expect(mocks.controlRealtimeVoiceAgentRun).toHaveBeenCalledWith(
+      {
+        sessionKey: "agent:main:main",
+        text: "use the safer plan",
+        mode: "steer",
+      },
+      mocks.injectionTarget,
+    );
     expectRespondOk(respond, {
       ok: true,
       mode: "steer",
@@ -3488,11 +3500,14 @@ describe("talk.client.create handler", () => {
       respond: steerRespond,
       context,
     });
-    expect(mocks.controlRealtimeVoiceAgentRun).toHaveBeenCalledWith({
-      sessionKey: "main",
-      text: "Use the safer plan",
-      mode: "steer",
-    });
+    expect(mocks.controlRealtimeVoiceAgentRun).toHaveBeenCalledWith(
+      {
+        sessionKey: "main",
+        text: "Use the safer plan",
+        mode: "steer",
+      },
+      mocks.injectionTarget,
+    );
     expectRespondOk(steerRespond, { ok: true, mode: "steer" });
 
     release.resolve();

--- a/src/gateway/talk-agent-consult-authority.ts
+++ b/src/gateway/talk-agent-consult-authority.ts
@@ -1,0 +1,20 @@
+import { resolveRealtimeVoiceAgentConsultToolsAllow } from "../talk/agent-consult-tool.js";
+import { ADMIN_SCOPE, WRITE_SCOPE } from "./operator-scopes.js";
+
+export type TalkAgentConsultAuthority = {
+  senderIsOwner: boolean;
+  toolsAllow?: string[];
+};
+
+export function resolveTalkAgentConsultAuthority(
+  scopes: readonly string[] | undefined,
+): TalkAgentConsultAuthority {
+  const senderIsOwner = scopes?.includes(ADMIN_SCOPE) === true;
+  if (senderIsOwner || scopes?.includes(WRITE_SCOPE) === true) {
+    return { senderIsOwner };
+  }
+  return {
+    senderIsOwner: false,
+    toolsAllow: resolveRealtimeVoiceAgentConsultToolsAllow("safe-read-only"),
+  };
+}

--- a/src/gateway/talk-agent-consult.ts
+++ b/src/gateway/talk-agent-consult.ts
@@ -19,7 +19,7 @@ import type {
   GatewayRequestContext,
   GatewayRequestHandlerOptions,
 } from "./server-methods/shared-types.js";
-import { resolveTalkAgentConsultAuthority } from "./talk-client-gateway-control.js";
+import { resolveTalkAgentConsultAuthority } from "./talk-agent-consult-authority.js";
 import { registerTalkRealtimeRelayAgentRun } from "./talk-realtime-relay.js";
 import { formatForLog } from "./ws-log.js";
 

--- a/src/gateway/talk-client-gateway-control.agent-consult.test.ts
+++ b/src/gateway/talk-client-gateway-control.agent-consult.test.ts
@@ -37,16 +37,15 @@ vi.mock("../agents/admitted-run-context.js", () => ({
   prepareAgentRunAdmission: mocks.prepareAgentRunAdmission,
 }));
 vi.mock("../agents/embedded-agent.js", () => ({
+  observeEmbeddedAgentMessageInjectionTarget: vi.fn(),
   runEmbeddedAgent: mocks.runEmbeddedAgentCore,
 }));
 vi.mock("../talk/agent-consult-runtime.js", () => ({
   consultRealtimeVoiceAgent: mocks.consultRealtimeVoiceAgent,
 }));
 
-import {
-  createTalkClientAgentConsultRunner,
-  type TalkAgentConsultAuthority,
-} from "./talk-client-gateway-control.js";
+import type { TalkAgentConsultAuthority } from "./talk-agent-consult-authority.js";
+import { createTalkClientAgentConsultRunner } from "./talk-client-gateway-control.js";
 
 const config = {} as OpenClawConfig;
 const coreParams = {
@@ -116,6 +115,7 @@ describe("Talk client agent consult admission", () => {
           state: "present",
         },
       },
+      onAdmitted: expect.any(Function),
     });
     expect(mocks.runEmbeddedAgentCore).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/gateway/talk-client-gateway-control.test.ts
+++ b/src/gateway/talk-client-gateway-control.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { ActiveEmbeddedRunOwner } from "../agents/embedded-agent.js";
 import type { RealtimeVoiceBridge } from "../talk/provider-types.js";
 import {
   closeTalkClientGatewayControlSession,
@@ -13,6 +14,15 @@ function deferred<T>() {
     resolve = done;
   });
   return { promise, resolve };
+}
+
+function createControlTarget(runId: string): ActiveEmbeddedRunOwner {
+  return {
+    runId,
+    sessionId: `session-${runId}`,
+    abort: vi.fn(() => true),
+    queueMessage: vi.fn(),
+  };
 }
 
 function controlContext(
@@ -31,21 +41,24 @@ function controlContext(
 
 describe("Talk client Gateway control owner", () => {
   it("waits for a relay target captured during run registration", async () => {
-    const targetReady = deferred<string | undefined>();
+    const target = createControlTarget("relay");
+    const targetReady = deferred<typeof target | undefined>();
     const applied = vi.fn();
-    const execute = vi.fn(async (_args: unknown, target?: Promise<string | undefined>) => {
-      applied(await target);
-      return {
-        ok: true,
-        mode: "cancel" as const,
-        sessionKey: "agent:main:main",
-        active: true,
-        message: "ok",
-        speak: false,
-        show: false,
-        suppress: false,
-      };
-    });
+    const execute = vi.fn(
+      async (_args: unknown, captured?: Promise<ActiveEmbeddedRunOwner | undefined>) => {
+        applied(await captured);
+        return {
+          ok: true,
+          mode: "cancel" as const,
+          sessionKey: "agent:main:main",
+          active: true,
+          message: "ok",
+          speak: false,
+          show: false,
+          suppress: false,
+        };
+      },
+    );
     const owner = createTalkRealtimeRunControlOwner({
       hasActiveRun: () => true,
       capture: () => targetReady.promise,
@@ -57,8 +70,8 @@ describe("Talk client Gateway control owner", () => {
     expect(owner.enqueue({ text: "cancel" })).toBe(true);
     await Promise.resolve();
     expect(applied).not.toHaveBeenCalled();
-    targetReady.resolve("exact-relay-target");
-    await vi.waitFor(() => expect(applied).toHaveBeenCalledWith("exact-relay-target"));
+    targetReady.resolve(target);
+    await vi.waitFor(() => expect(applied).toHaveBeenCalledWith(target));
   });
   it.each(["failed", "incomplete"] as const)(
     "keeps Gateway-controlled browser Talk reusable after a %s response",
@@ -316,9 +329,9 @@ describe("Talk client Gateway control owner", () => {
   });
 
   it("captures browser run authority before queued control executes", async () => {
-    let currentTarget = { id: "first" };
+    let currentTarget = createControlTarget("first");
     const controlAgentRun = vi.fn(
-      async (_params: unknown, _captured: { id: string } | undefined) => ({
+      async (_params: unknown, _captured: ActiveEmbeddedRunOwner | undefined) => ({
         ok: false,
         mode: "steer" as const,
         sessionKey: "agent:main:main",
@@ -360,7 +373,7 @@ describe("Talk client Gateway control owner", () => {
       args: { text: "steer" },
     });
     const admittedTarget = currentTarget;
-    currentTarget = { id: "replacement" };
+    currentTarget = createControlTarget("replacement");
 
     await vi.waitFor(() => expect(controlAgentRun).toHaveBeenCalledTimes(1));
     expect(controlAgentRun.mock.calls[0]?.[1]).toBe(admittedTarget);
@@ -370,10 +383,10 @@ describe("Talk client Gateway control owner", () => {
   it("binds control admitted before run registration to that consult's exact target", async () => {
     const registration = deferred<void>();
     const consultResult = deferred<{ text: string }>();
-    const target = { id: "registered" };
+    const target = createControlTarget("registered");
     let currentTarget: typeof target | undefined;
     const controlAgentRun = vi.fn(
-      async (_params: unknown, _captured: typeof target | undefined) => ({
+      async (_params: unknown, _captured: ActiveEmbeddedRunOwner | undefined) => ({
         ok: true,
         mode: "steer" as const,
         sessionKey: "agent:main:main",

--- a/src/gateway/talk-client-gateway-control.test.ts
+++ b/src/gateway/talk-client-gateway-control.test.ts
@@ -3,6 +3,7 @@ import type { RealtimeVoiceBridge } from "../talk/provider-types.js";
 import {
   closeTalkClientGatewayControlSession,
   createTalkClientGatewayControlOwner,
+  createTalkRealtimeRunControlOwner,
 } from "./talk-client-gateway-control.js";
 import { cleanupTalkConnection } from "./talk-session-registry.js";
 
@@ -29,6 +30,27 @@ function controlContext(
 }
 
 describe("Talk client Gateway control owner", () => {
+  it("waits for a relay target captured during run registration", async () => {
+    const targetReady = deferred<string | undefined>();
+    const applied = vi.fn();
+    const execute = vi.fn(async (_args: unknown, target: Promise<string | undefined>) => {
+      applied(await target);
+      return { message: "ok", speak: false, suppress: false };
+    });
+    const owner = createTalkRealtimeRunControlOwner({
+      hasActiveRun: () => true,
+      capture: () => targetReady.promise,
+      execute,
+      speak: vi.fn(),
+      warn: vi.fn(),
+    });
+
+    expect(owner.enqueue({ text: "cancel" })).toBe(true);
+    await Promise.resolve();
+    expect(applied).not.toHaveBeenCalled();
+    targetReady.resolve("exact-relay-target");
+    await vi.waitFor(() => expect(applied).toHaveBeenCalledWith("exact-relay-target"));
+  });
   it.each(["failed", "incomplete"] as const)(
     "keeps Gateway-controlled browser Talk reusable after a %s response",
     async (status) => {

--- a/src/gateway/talk-client-gateway-control.test.ts
+++ b/src/gateway/talk-client-gateway-control.test.ts
@@ -336,6 +336,76 @@ describe("Talk client Gateway control owner", () => {
     await owner.close();
   });
 
+  it("binds control admitted before run registration to that consult's exact target", async () => {
+    const registration = deferred<void>();
+    const consultResult = deferred<{ text: string }>();
+    const target = { id: "registered" };
+    let currentTarget: typeof target | undefined;
+    const controlAgentRun = vi.fn(
+      async (_params: unknown, _captured: typeof target | undefined) => ({
+        ok: true,
+        mode: "steer" as const,
+        sessionKey: "agent:main:main",
+        active: true,
+        queued: true,
+        message: "queued",
+        speak: false,
+        show: true,
+        suppress: false,
+      }),
+    );
+    const bridge = {
+      connect: vi.fn(async () => undefined),
+      close: vi.fn(),
+      sendAudio: vi.fn(),
+      setMediaTimestamp: vi.fn(),
+      submitToolResult: vi.fn(async () => undefined),
+      acknowledgeMark: vi.fn(),
+      isConnected: vi.fn(() => true),
+    } satisfies RealtimeVoiceBridge;
+    const owner = createTalkClientGatewayControlOwner({
+      voiceSessionId: "voice-starting",
+      sessionKey: "agent:main:main",
+      connId: "conn-starting",
+      context: controlContext(),
+      runAgentConsult: async (_args, _signal, onRunControlReady) => {
+        await registration.promise;
+        currentTarget = target;
+        onRunControlReady?.(target);
+        return await consultResult.promise;
+      },
+      captureAgentRunControl: () => currentTarget,
+      controlAgentRun,
+      appendTranscript: vi.fn(async () => undefined),
+      flushTranscript: vi.fn(async () => undefined),
+      closeLogicalSession: vi.fn(async () => undefined),
+    });
+    owner.control.bindBridge(bridge);
+    owner.control.onToolCall?.({
+      itemId: "item-consult",
+      callId: "call-consult",
+      name: "openclaw_agent_consult",
+      args: { question: "inspect startup" },
+    });
+    owner.control.onToolCall?.({
+      itemId: "item-control",
+      callId: "call-control",
+      name: "openclaw_agent_control",
+      args: { text: "steer" },
+    });
+
+    expect(controlAgentRun).not.toHaveBeenCalled();
+    registration.resolve();
+    await vi.waitFor(() => expect(controlAgentRun).toHaveBeenCalledOnce());
+    expect(controlAgentRun.mock.calls[0]?.[1]).toBe(target);
+
+    consultResult.resolve({ text: "done" });
+    await vi.waitFor(() =>
+      expect(bridge.submitToolResult).toHaveBeenCalledWith("call-consult", { result: "done" }),
+    );
+    await owner.close();
+  });
+
   it("closes the provider and logical session when the owning client disconnects", async () => {
     const closeProvider = vi.fn(async () => undefined);
     const closeLogicalSession = vi.fn(async () => undefined);

--- a/src/gateway/talk-client-gateway-control.test.ts
+++ b/src/gateway/talk-client-gateway-control.test.ts
@@ -33,9 +33,18 @@ describe("Talk client Gateway control owner", () => {
   it("waits for a relay target captured during run registration", async () => {
     const targetReady = deferred<string | undefined>();
     const applied = vi.fn();
-    const execute = vi.fn(async (_args: unknown, target: Promise<string | undefined>) => {
+    const execute = vi.fn(async (_args: unknown, target?: Promise<string | undefined>) => {
       applied(await target);
-      return { message: "ok", speak: false, suppress: false };
+      return {
+        ok: true,
+        mode: "cancel" as const,
+        sessionKey: "agent:main:main",
+        active: true,
+        message: "ok",
+        speak: false,
+        show: false,
+        suppress: false,
+      };
     });
     const owner = createTalkRealtimeRunControlOwner({
       hasActiveRun: () => true,

--- a/src/gateway/talk-client-gateway-control.test.ts
+++ b/src/gateway/talk-client-gateway-control.test.ts
@@ -284,6 +284,58 @@ describe("Talk client Gateway control owner", () => {
     await owner.close();
   });
 
+  it("captures browser run authority before queued control executes", async () => {
+    let currentTarget = { id: "first" };
+    const controlAgentRun = vi.fn(
+      async (_params: unknown, _captured: { id: string } | undefined) => ({
+        ok: false,
+        mode: "steer" as const,
+        sessionKey: "agent:main:main",
+        active: false,
+        queued: false,
+        reason: "no_active_run" as const,
+        message: "stale target rejected",
+        speak: false,
+        show: true,
+        suppress: false,
+      }),
+    );
+    const bridge = {
+      connect: vi.fn(async () => undefined),
+      close: vi.fn(),
+      sendAudio: vi.fn(),
+      setMediaTimestamp: vi.fn(),
+      submitToolResult: vi.fn(async () => undefined),
+      acknowledgeMark: vi.fn(),
+      isConnected: vi.fn(() => true),
+    } satisfies RealtimeVoiceBridge;
+    const owner = createTalkClientGatewayControlOwner({
+      voiceSessionId: "voice-capture",
+      sessionKey: "agent:main:main",
+      connId: "conn-capture",
+      context: controlContext(),
+      runAgentConsult: vi.fn(async () => ({ text: "done" })),
+      captureAgentRunControl: () => currentTarget,
+      controlAgentRun,
+      appendTranscript: vi.fn(async () => undefined),
+      flushTranscript: vi.fn(async () => undefined),
+      closeLogicalSession: vi.fn(async () => undefined),
+    });
+    owner.control.bindBridge(bridge);
+    owner.control.onToolCall?.({
+      itemId: "item-control",
+      callId: "call-control",
+      name: "openclaw_agent_control",
+      args: { text: "steer" },
+    });
+    const admittedTarget = currentTarget;
+    currentTarget = { id: "replacement" };
+
+    await vi.waitFor(() => expect(controlAgentRun).toHaveBeenCalledTimes(1));
+    expect(controlAgentRun.mock.calls[0]?.[1]).toBe(admittedTarget);
+    await owner.close();
+  });
+
   it("closes the provider and logical session when the owning client disconnects", async () => {
     const closeProvider = vi.fn(async () => undefined);
     const closeLogicalSession = vi.fn(async () => undefined);

--- a/src/gateway/talk-client-gateway-control.ts
+++ b/src/gateway/talk-client-gateway-control.ts
@@ -42,6 +42,7 @@ import { registerChatAbortController } from "./chat-abort.js";
 import { ADMIN_SCOPE, WRITE_SCOPE } from "./operator-scopes.js";
 import type { GatewayRequestContext } from "./server-methods/shared-types.js";
 import { formatError } from "./server-utils.js";
+import { createPendingTalkConsult, type PendingConsult } from "./talk-client-pending-consult.js";
 import { registerTalkConnectionCleanup } from "./talk-session-registry.js";
 
 type GatewayControlOwner = {
@@ -242,7 +243,7 @@ export function boundTalkClientRealtimeInitialItems(
   return newestFirst.toReversed();
 }
 
-export function createTalkClientAgentConsultRunner(params: {
+export function createTalkClientAgentConsultRunner<CapturedControl = undefined>(params: {
   config: OpenClawConfig;
   context: Pick<GatewayRequestContext, "chatAbortControllers" | "logGateway">;
   agentId: string;
@@ -254,10 +255,15 @@ export function createTalkClientAgentConsultRunner(params: {
   runIdPrefix?: string;
   surface?: string;
   registerRun?: (params: { runId: string }) => void;
+  captureRunControl?: () => CapturedControl | undefined;
 }) {
   const authority = params.authority ?? resolveTalkAgentConsultAuthority(undefined);
   let agentRuntime: ReturnType<typeof createPluginRuntime>["agent"] | undefined;
-  const runArgs = async (args: unknown, signal?: AbortSignal) => {
+  const runArgs = async (
+    args: unknown,
+    signal?: AbortSignal,
+    onRunControlReady?: (captured: CapturedControl | undefined) => void,
+  ) => {
     const parsedArgs = parseRealtimeVoiceAgentConsultArgs(args);
     const voiceSessionId = params.getVoiceSessionId();
     if (!voiceSessionId) {
@@ -332,6 +338,7 @@ export function createTalkClientAgentConsultRunner(params: {
           controlUiVisible: false,
           kind: "chat-send",
         });
+        onRunControlReady?.(params.captureRunControl?.());
         return { abortSignal: registration.controller.signal, cleanup: registration.cleanup };
       },
     });
@@ -350,7 +357,11 @@ export function createTalkClientGatewayControlOwner<CapturedControl = undefined>
   connId: string;
   context: Pick<GatewayRequestContext, "broadcastToConnIds" | "logGateway">;
   assertConnectionOpen?: () => void;
-  runAgentConsult: (args: unknown, signal: AbortSignal) => Promise<{ text: string }>;
+  runAgentConsult: (
+    args: unknown,
+    signal: AbortSignal,
+    onRunControlReady?: (captured: CapturedControl | undefined) => void,
+  ) => Promise<{ text: string }>;
   appendTranscript: (entry: {
     entryId: string;
     role: "user" | "assistant";
@@ -358,7 +369,7 @@ export function createTalkClientGatewayControlOwner<CapturedControl = undefined>
   }) => Promise<void>;
   flushTranscript: () => Promise<void>;
   closeLogicalSession: () => Promise<void>;
-  captureAgentRunControl?: () => CapturedControl;
+  captureAgentRunControl?: () => CapturedControl | undefined;
   controlAgentRun?: (
     params: { sessionKey: string; text: string; mode?: unknown },
     captured: CapturedControl | undefined,
@@ -372,7 +383,7 @@ export function createTalkClientGatewayControlOwner<CapturedControl = undefined>
   let transcriptSequence = 0;
   const entryPrefix = `gateway-${randomUUID()}`;
   const consultQueue = createRealtimeControlQueue();
-  const consultControllers = new Map<string, AbortController>();
+  const consultControllers = new Map<string, PendingConsult<CapturedControl>>();
   const warn = (message: string) => params.context.logGateway.warn(message);
   const talkPayload = () => ({ voiceSessionId: params.voiceSessionId });
   const harness = createRealtimeVoiceSessionHarness({
@@ -419,8 +430,8 @@ export function createTalkClientGatewayControlOwner<CapturedControl = undefined>
       ? await params.controlAgentRun(controlParams, captured)
       : await controlRealtimeVoiceAgentRun(controlParams);
     if (result.mode === "cancel" && result.ok) {
-      for (const controller of consultControllers.values()) {
-        controller.abort(new Error("Realtime voice consult cancelled"));
+      for (const consult of consultControllers.values()) {
+        consult.controller.abort(new Error("Realtime voice consult cancelled"));
       }
     }
     return result;
@@ -428,12 +439,17 @@ export function createTalkClientGatewayControlOwner<CapturedControl = undefined>
 
   const runConsult = async (
     event: RealtimeVoiceToolCallEvent,
-    controller: AbortController,
+    consult: PendingConsult<CapturedControl>,
   ): Promise<void> => {
+    const { controller } = consult;
     try {
       controller.signal.throwIfAborted();
       await params.flushTranscript();
-      const result = await params.runAgentConsult(event.args, controller.signal);
+      const result = await params.runAgentConsult(
+        event.args,
+        controller.signal,
+        consult.resolveControlTarget,
+      );
       if (signal.aborted) {
         return;
       }
@@ -447,7 +463,8 @@ export function createTalkClientGatewayControlOwner<CapturedControl = undefined>
         : { error: formatError(error) };
       await submit(event.callId, result);
     } finally {
-      if (consultControllers.get(event.callId) === controller) {
+      consult.resolveControlTarget(undefined);
+      if (consultControllers.get(event.callId) === consult) {
         consultControllers.delete(event.callId);
       }
     }
@@ -455,8 +472,17 @@ export function createTalkClientGatewayControlOwner<CapturedControl = undefined>
 
   const runControl = createTalkRealtimeRunControlOwner({
     hasActiveRun: () => consultControllers.size > 0,
-    ...(params.captureAgentRunControl ? { capture: params.captureAgentRunControl } : {}),
-    execute: applyControl,
+    ...(params.captureAgentRunControl
+      ? {
+          capture: () => {
+            const target = params.captureAgentRunControl?.();
+            return target
+              ? Promise.resolve(target)
+              : consultControllers.values().next().value?.controlTarget;
+          },
+        }
+      : {}),
+    execute: async (args, captured) => await applyControl(args, await captured),
     speak: (message) => bridge?.sendUserMessage?.(message),
     warn,
   });
@@ -466,9 +492,11 @@ export function createTalkClientGatewayControlOwner<CapturedControl = undefined>
       return;
     }
     if (event.name === REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME) {
-      const controller = new AbortController();
-      consultControllers.set(event.callId, controller);
-      const admission = consultQueue.enqueue(() => runConsult(event, controller));
+      // Controls accepted during consult startup bind to this consult's eventual
+      // exact target; they never re-resolve whichever run happens to be current later.
+      const consult = createPendingTalkConsult<CapturedControl>();
+      consultControllers.set(event.callId, consult);
+      const admission = consultQueue.enqueue(() => runConsult(event, consult));
       if (!admission.accepted) {
         consultControllers.delete(event.callId);
         void submit(event.callId, { error: "Realtime Talk consult queue is full" });
@@ -642,8 +670,8 @@ export function createTalkClientGatewayControlOwner<CapturedControl = undefined>
           owners.delete(params.voiceSessionId);
         }
         if (!options?.preserveRuns) {
-          for (const controller of consultControllers.values()) {
-            controller.abort(new Error("Realtime voice session closed"));
+          for (const consult of consultControllers.values()) {
+            consult.controller.abort(new Error("Realtime voice session closed"));
           }
         }
         consultQueue.seal();

--- a/src/gateway/talk-client-gateway-control.ts
+++ b/src/gateway/talk-client-gateway-control.ts
@@ -79,8 +79,6 @@ const loadTalkAgentExecution = createLazyRuntimeModule(async () => {
   ]);
   return {
     runEmbeddedAgent: embeddedAgent.runEmbeddedAgent,
-    observeEmbeddedAgentMessageInjectionTarget:
-      embeddedAgent.observeEmbeddedAgentMessageInjectionTarget,
     createOperationalRunInstanceRef: admission.createOperationalRunInstanceRef,
     prepareAgentRunAdmission: admission.prepareAgentRunAdmission,
   };
@@ -97,7 +95,6 @@ function createTalkClientAgentRuntime(params: {
     runParams.abortSignal?.throwIfAborted();
     const execution = await loadTalkAgentExecution();
     runParams.abortSignal?.throwIfAborted();
-    let stopObserving = () => {};
     const preparedRunAdmission = execution.prepareAgentRunAdmission({
       cfg: params.config,
       operationalRunInstance: execution.createOperationalRunInstanceRef(runParams.runId),
@@ -111,14 +108,6 @@ function createTalkClientAgentRuntime(params: {
           ...(params.rawSourceRef ? { rawSourceRef: params.rawSourceRef } : {}),
         },
       },
-      onAdmitted: (context) => {
-        if (params.onControlTargetReady) {
-          stopObserving = execution.observeEmbeddedAgentMessageInjectionTarget(
-            context,
-            params.onControlTargetReady,
-          );
-        }
-      },
     });
     let closed = false;
     const close = () => {
@@ -131,9 +120,12 @@ function createTalkClientAgentRuntime(params: {
     runParams.abortSignal?.addEventListener("abort", close, { once: true });
     try {
       runParams.abortSignal?.throwIfAborted();
-      return await execution.runEmbeddedAgent({ ...runParams, preparedRunAdmission });
+      return await execution.runEmbeddedAgent({
+        ...runParams,
+        preparedRunAdmission,
+        onActiveRunOwner: params.onControlTargetReady,
+      });
     } finally {
-      stopObserving();
       runParams.abortSignal?.removeEventListener("abort", close);
       close();
     }

--- a/src/gateway/talk-client-gateway-control.ts
+++ b/src/gateway/talk-client-gateway-control.ts
@@ -153,9 +153,13 @@ function createTalkClientAgentRuntime(params: {
   return agentRuntime;
 }
 
-export function createTalkRealtimeRunControlOwner(params: {
+export function createTalkRealtimeRunControlOwner<Captured = undefined>(params: {
   hasActiveRun: () => boolean;
-  execute: (args: unknown) => Promise<RealtimeVoiceAgentControlResult>;
+  capture?: (args: unknown) => Captured;
+  execute: (
+    args: unknown,
+    captured: Captured | undefined,
+  ) => Promise<RealtimeVoiceAgentControlResult>;
   speak: (message: string) => void;
   warn: (message: string) => void;
 }) {
@@ -168,10 +172,11 @@ export function createTalkRealtimeRunControlOwner(params: {
       onError?: (error: unknown) => void | Promise<void>;
     } = {},
   ): boolean => {
+    const captured = params.capture?.(args);
     const admission = queue.enqueue(async () => {
       await options.ready;
       try {
-        const result = await params.execute(args);
+        const result = await params.execute(args, captured);
         await options.onResult?.(result);
       } catch (error) {
         if (!options.onError) {
@@ -338,7 +343,7 @@ export function createTalkClientAgentConsultRunner(params: {
   };
 }
 
-export function createTalkClientGatewayControlOwner(params: {
+export function createTalkClientGatewayControlOwner<CapturedControl = undefined>(params: {
   voiceSessionId: string;
   providerId?: string;
   sessionKey: string;
@@ -353,11 +358,11 @@ export function createTalkClientGatewayControlOwner(params: {
   }) => Promise<void>;
   flushTranscript: () => Promise<void>;
   closeLogicalSession: () => Promise<void>;
-  controlAgentRun?: (params: {
-    sessionKey: string;
-    text: string;
-    mode?: unknown;
-  }) => Promise<RealtimeVoiceAgentControlResult>;
+  captureAgentRunControl?: () => CapturedControl;
+  controlAgentRun?: (
+    params: { sessionKey: string; text: string; mode?: unknown },
+    captured: CapturedControl | undefined,
+  ) => Promise<RealtimeVoiceAgentControlResult>;
 }): GatewayControlOwner {
   let bridge: RealtimeVoiceBridge | undefined;
   let closeProvider: (() => Promise<void>) | undefined;
@@ -403,13 +408,16 @@ export function createTalkClientGatewayControlOwner(params: {
     await bridge.submitToolResult(callId, result);
   };
 
-  const applyControl = async (args: unknown) => {
+  const applyControl = async (args: unknown, captured: CapturedControl | undefined) => {
     const parsed = parseRealtimeVoiceAgentControlToolArgs(args);
-    const result = await (params.controlAgentRun ?? controlRealtimeVoiceAgentRun)({
+    const controlParams = {
       sessionKey: params.sessionKey,
       text: parsed.text,
       mode: parsed.mode,
-    });
+    };
+    const result = params.controlAgentRun
+      ? await params.controlAgentRun(controlParams, captured)
+      : await controlRealtimeVoiceAgentRun(controlParams);
     if (result.mode === "cancel" && result.ok) {
       for (const controller of consultControllers.values()) {
         controller.abort(new Error("Realtime voice consult cancelled"));
@@ -447,6 +455,7 @@ export function createTalkClientGatewayControlOwner(params: {
 
   const runControl = createTalkRealtimeRunControlOwner({
     hasActiveRun: () => consultControllers.size > 0,
+    ...(params.captureAgentRunControl ? { capture: params.captureAgentRunControl } : {}),
     execute: applyControl,
     speak: (message) => bridge?.sendUserMessage?.(message),
     warn,

--- a/src/gateway/talk-client-gateway-control.ts
+++ b/src/gateway/talk-client-gateway-control.ts
@@ -3,13 +3,11 @@ import type { EmbeddedAgentMessageInjectionTarget } from "../agents/embedded-age
 import { normalizeTalkSection } from "../config/talk.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createPluginRuntime } from "../plugins/runtime/index.js";
-import { BoundedSerialQueue } from "../shared/bounded-serial-queue.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { consultRealtimeVoiceAgent } from "../talk/agent-consult-runtime.js";
 import {
   REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
   parseRealtimeVoiceAgentConsultArgs,
-  resolveRealtimeVoiceAgentConsultToolsAllow,
 } from "../talk/agent-consult-tool.js";
 import {
   buildRealtimeVoiceAgentCancelProviderResult,
@@ -40,10 +38,17 @@ import {
 } from "../talk/realtime-session-harness.js";
 import type { TalkEvent } from "../talk/talk-events.js";
 import { registerChatAbortController } from "./chat-abort.js";
-import { ADMIN_SCOPE, WRITE_SCOPE } from "./operator-scopes.js";
 import type { GatewayRequestContext } from "./server-methods/shared-types.js";
 import { formatError } from "./server-utils.js";
-import { createPendingTalkConsult, type PendingConsult } from "./talk-client-pending-consult.js";
+import {
+  resolveTalkAgentConsultAuthority,
+  type TalkAgentConsultAuthority,
+} from "./talk-agent-consult-authority.js";
+import {
+  createPendingTalkConsult,
+  createRealtimeControlQueue,
+  type PendingConsult,
+} from "./talk-client-pending-consult.js";
 import { registerTalkConnectionCleanup } from "./talk-session-registry.js";
 
 type GatewayControlOwner = {
@@ -66,25 +71,6 @@ const owners = new Map<string, GatewayControlOwner>();
 const pendingOwners = new Set<GatewayControlOwner>();
 
 const REALTIME_VOICE_CONTEXT_MAX_UTF8_BYTES = 8_000;
-const REALTIME_CONTROL_MAX_PENDING = 8;
-
-export type TalkAgentConsultAuthority = {
-  senderIsOwner: boolean;
-  toolsAllow?: string[];
-};
-
-export function resolveTalkAgentConsultAuthority(
-  scopes: readonly string[] | undefined,
-): TalkAgentConsultAuthority {
-  const senderIsOwner = scopes?.includes(ADMIN_SCOPE) === true;
-  if (senderIsOwner || scopes?.includes(WRITE_SCOPE) === true) {
-    return { senderIsOwner };
-  }
-  return {
-    senderIsOwner: false,
-    toolsAllow: resolveRealtimeVoiceAgentConsultToolsAllow("safe-read-only"),
-  };
-}
 
 const loadTalkAgentExecution = createLazyRuntimeModule(async () => {
   const [embeddedAgent, admission] = await Promise.all([
@@ -99,13 +85,6 @@ const loadTalkAgentExecution = createLazyRuntimeModule(async () => {
     prepareAgentRunAdmission: admission.prepareAgentRunAdmission,
   };
 });
-
-function createRealtimeControlQueue(): BoundedSerialQueue {
-  return new BoundedSerialQueue({
-    maxPendingCount: REALTIME_CONTROL_MAX_PENDING,
-    maxPendingWeight: REALTIME_CONTROL_MAX_PENDING,
-  });
-}
 
 function createTalkClientAgentRuntime(params: {
   config: OpenClawConfig;
@@ -148,8 +127,7 @@ function createTalkClientAgentRuntime(params: {
         preparedRunAdmission.close();
       }
     };
-    // Abort owns authority revocation independently of core completion; the
-    // post-registration check closes the prepare-to-listener race.
+    // Abort revokes authority independently; the later check closes the listener race.
     runParams.abortSignal?.addEventListener("abort", close, { once: true });
     try {
       runParams.abortSignal?.throwIfAborted();
@@ -282,8 +260,7 @@ export function createTalkClientAgentConsultRunner(params: {
     if (!voiceSessionId) {
       throw new Error("Realtime browser voice session is not ready for agent consult");
     }
-    // Relays own admission before their lazy record registration. Browser callbacks
-    // must validate the durable call before accepting a new run.
+    // Browser callbacks validate durable admission; relays register lazily after admission.
     if (!params.registerRun) {
       assertClientVoiceSessionOpen({
         agentId: params.agentId,
@@ -509,8 +486,7 @@ export function createTalkClientGatewayControlOwner<CapturedControl = undefined>
       return;
     }
     if (event.name === REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME) {
-      // Controls accepted during consult startup bind to this consult's eventual
-      // exact target; they never re-resolve whichever run happens to be current later.
+      // Startup controls bind to this consult's eventual target, never the later current run.
       const consult = createPendingTalkConsult<CapturedControl>();
       consultControllers.set(event.callId, consult);
       const admission = consultQueue.enqueue(() => runConsult(event, consult));
@@ -586,8 +562,7 @@ export function createTalkClientGatewayControlOwner<CapturedControl = undefined>
       if (owners.get(params.voiceSessionId) !== owner) {
         throw new Error("Realtime voice session is not active");
       }
-      // Admission ends here: transport closure fences future requests, while the
-      // provider's consult signal continues to own already accepted work.
+      // Closure fences new requests; the provider signal owns already accepted work.
       return await params.runAgentConsult({ question: prompt }, consultSignal);
     },
     control: {

--- a/src/gateway/talk-client-gateway-control.ts
+++ b/src/gateway/talk-client-gateway-control.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import type { EmbeddedAgentMessageInjectionTarget } from "../agents/embedded-agent.js";
 import { normalizeTalkSection } from "../config/talk.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createPluginRuntime } from "../plugins/runtime/index.js";
@@ -92,6 +93,8 @@ const loadTalkAgentExecution = createLazyRuntimeModule(async () => {
   ]);
   return {
     runEmbeddedAgent: embeddedAgent.runEmbeddedAgent,
+    observeEmbeddedAgentMessageInjectionTarget:
+      embeddedAgent.observeEmbeddedAgentMessageInjectionTarget,
     createOperationalRunInstanceRef: admission.createOperationalRunInstanceRef,
     prepareAgentRunAdmission: admission.prepareAgentRunAdmission,
   };
@@ -108,12 +111,14 @@ function createTalkClientAgentRuntime(params: {
   config: OpenClawConfig;
   agentId: string;
   rawSourceRef?: string;
+  onControlTargetReady?: (target: EmbeddedAgentMessageInjectionTarget) => void;
 }) {
   const agentRuntime = createPluginRuntime().agent;
   const runEmbeddedAgent: typeof agentRuntime.runEmbeddedAgent = async (runParams) => {
     runParams.abortSignal?.throwIfAborted();
     const execution = await loadTalkAgentExecution();
     runParams.abortSignal?.throwIfAborted();
+    let stopObserving = () => {};
     const preparedRunAdmission = execution.prepareAgentRunAdmission({
       cfg: params.config,
       operationalRunInstance: execution.createOperationalRunInstanceRef(runParams.runId),
@@ -126,6 +131,14 @@ function createTalkClientAgentRuntime(params: {
           state: "present",
           ...(params.rawSourceRef ? { rawSourceRef: params.rawSourceRef } : {}),
         },
+      },
+      onAdmitted: (context) => {
+        if (params.onControlTargetReady) {
+          stopObserving = execution.observeEmbeddedAgentMessageInjectionTarget(
+            context,
+            params.onControlTargetReady,
+          );
+        }
       },
     });
     let closed = false;
@@ -142,6 +155,7 @@ function createTalkClientAgentRuntime(params: {
       runParams.abortSignal?.throwIfAborted();
       return await execution.runEmbeddedAgent({ ...runParams, preparedRunAdmission });
     } finally {
+      stopObserving();
       runParams.abortSignal?.removeEventListener("abort", close);
       close();
     }
@@ -243,7 +257,7 @@ export function boundTalkClientRealtimeInitialItems(
   return newestFirst.toReversed();
 }
 
-export function createTalkClientAgentConsultRunner<CapturedControl = undefined>(params: {
+export function createTalkClientAgentConsultRunner(params: {
   config: OpenClawConfig;
   context: Pick<GatewayRequestContext, "chatAbortControllers" | "logGateway">;
   agentId: string;
@@ -255,14 +269,13 @@ export function createTalkClientAgentConsultRunner<CapturedControl = undefined>(
   runIdPrefix?: string;
   surface?: string;
   registerRun?: (params: { runId: string }) => void;
-  captureRunControl?: () => CapturedControl | undefined;
+  captureRunControl?: () => EmbeddedAgentMessageInjectionTarget | undefined;
 }) {
   const authority = params.authority ?? resolveTalkAgentConsultAuthority(undefined);
-  let agentRuntime: ReturnType<typeof createPluginRuntime>["agent"] | undefined;
   const runArgs = async (
     args: unknown,
     signal?: AbortSignal,
-    onRunControlReady?: (captured: CapturedControl | undefined) => void,
+    onRunControlReady?: (captured: EmbeddedAgentMessageInjectionTarget | undefined) => void,
   ) => {
     const parsedArgs = parseRealtimeVoiceAgentConsultArgs(args);
     const voiceSessionId = params.getVoiceSessionId();
@@ -285,10 +298,15 @@ export function createTalkClientAgentConsultRunner<CapturedControl = undefined>(
           confirmationId: parsedArgs.confirmationId,
         })
       : undefined;
-    agentRuntime ??= createTalkClientAgentRuntime({
+    const agentRuntime = createTalkClientAgentRuntime({
       config: params.config,
       agentId: params.agentId,
       ...(params.ownerConnId ? { rawSourceRef: params.ownerConnId } : {}),
+      ...(onRunControlReady
+        ? {
+            onControlTargetReady: onRunControlReady,
+          }
+        : {}),
     });
     const talkConfig = normalizeTalkSection(params.config.talk);
     return await consultRealtimeVoiceAgent({
@@ -338,7 +356,6 @@ export function createTalkClientAgentConsultRunner<CapturedControl = undefined>(
           controlUiVisible: false,
           kind: "chat-send",
         });
-        onRunControlReady?.(params.captureRunControl?.());
         return { abortSignal: registration.controller.signal, cleanup: registration.cleanup };
       },
     });

--- a/src/gateway/talk-client-gateway-control.ts
+++ b/src/gateway/talk-client-gateway-control.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import type { EmbeddedAgentMessageInjectionTarget } from "../agents/embedded-agent.js";
+import type { ActiveEmbeddedRunOwner } from "../agents/embedded-agent.js";
 import { normalizeTalkSection } from "../config/talk.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createPluginRuntime } from "../plugins/runtime/index.js";
@@ -90,7 +90,7 @@ function createTalkClientAgentRuntime(params: {
   config: OpenClawConfig;
   agentId: string;
   rawSourceRef?: string;
-  onControlTargetReady?: (target: EmbeddedAgentMessageInjectionTarget) => void;
+  onControlTargetReady?: (target: ActiveEmbeddedRunOwner) => void;
 }) {
   const agentRuntime = createPluginRuntime().agent;
   const runEmbeddedAgent: typeof agentRuntime.runEmbeddedAgent = async (runParams) => {
@@ -146,12 +146,12 @@ function createTalkClientAgentRuntime(params: {
   return agentRuntime;
 }
 
-export function createTalkRealtimeRunControlOwner<Captured = undefined>(params: {
+export function createTalkRealtimeRunControlOwner(params: {
   hasActiveRun: () => boolean;
-  capture?: (args: unknown) => Captured;
+  capture?: (args: unknown) => Promise<ActiveEmbeddedRunOwner | undefined> | undefined;
   execute: (
     args: unknown,
-    captured: Captured | undefined,
+    captured: Promise<ActiveEmbeddedRunOwner | undefined> | undefined,
   ) => Promise<RealtimeVoiceAgentControlResult>;
   speak: (message: string) => void;
   warn: (message: string) => void;
@@ -247,13 +247,13 @@ export function createTalkClientAgentConsultRunner(params: {
   runIdPrefix?: string;
   surface?: string;
   registerRun?: (params: { runId: string }) => void;
-  captureRunControl?: () => EmbeddedAgentMessageInjectionTarget | undefined;
+  captureRunControl?: () => ActiveEmbeddedRunOwner | undefined;
 }) {
   const authority = params.authority ?? resolveTalkAgentConsultAuthority(undefined);
   const runArgs = async (
     args: unknown,
     signal?: AbortSignal,
-    onRunControlReady?: (captured: EmbeddedAgentMessageInjectionTarget | undefined) => void,
+    onRunControlReady?: (captured: ActiveEmbeddedRunOwner | undefined) => void,
   ) => {
     const parsedArgs = parseRealtimeVoiceAgentConsultArgs(args);
     const voiceSessionId = params.getVoiceSessionId();
@@ -344,7 +344,7 @@ export function createTalkClientAgentConsultRunner(params: {
   };
 }
 
-export function createTalkClientGatewayControlOwner<CapturedControl = undefined>(params: {
+export function createTalkClientGatewayControlOwner(params: {
   voiceSessionId: string;
   providerId?: string;
   sessionKey: string;
@@ -354,7 +354,7 @@ export function createTalkClientGatewayControlOwner<CapturedControl = undefined>
   runAgentConsult: (
     args: unknown,
     signal: AbortSignal,
-    onRunControlReady?: (captured: CapturedControl | undefined) => void,
+    onRunControlReady?: (captured: ActiveEmbeddedRunOwner | undefined) => void,
   ) => Promise<{ text: string }>;
   appendTranscript: (entry: {
     entryId: string;
@@ -363,10 +363,10 @@ export function createTalkClientGatewayControlOwner<CapturedControl = undefined>
   }) => Promise<void>;
   flushTranscript: () => Promise<void>;
   closeLogicalSession: () => Promise<void>;
-  captureAgentRunControl?: () => CapturedControl | undefined;
+  captureAgentRunControl?: () => ActiveEmbeddedRunOwner | undefined;
   controlAgentRun?: (
     params: { sessionKey: string; text: string; mode?: unknown },
-    captured: CapturedControl | undefined,
+    captured: ActiveEmbeddedRunOwner | undefined,
   ) => Promise<RealtimeVoiceAgentControlResult>;
 }): GatewayControlOwner {
   let bridge: RealtimeVoiceBridge | undefined;
@@ -377,7 +377,7 @@ export function createTalkClientGatewayControlOwner<CapturedControl = undefined>
   let transcriptSequence = 0;
   const entryPrefix = `gateway-${randomUUID()}`;
   const consultQueue = createRealtimeControlQueue();
-  const consultControllers = new Map<string, PendingConsult<CapturedControl>>();
+  const consultControllers = new Map<string, PendingConsult>();
   const warn = (message: string) => params.context.logGateway.warn(message);
   const talkPayload = () => ({ voiceSessionId: params.voiceSessionId });
   const harness = createRealtimeVoiceSessionHarness({
@@ -413,7 +413,7 @@ export function createTalkClientGatewayControlOwner<CapturedControl = undefined>
     await bridge.submitToolResult(callId, result);
   };
 
-  const applyControl = async (args: unknown, captured: CapturedControl | undefined) => {
+  const applyControl = async (args: unknown, captured: ActiveEmbeddedRunOwner | undefined) => {
     const parsed = parseRealtimeVoiceAgentControlToolArgs(args);
     const controlParams = {
       sessionKey: params.sessionKey,
@@ -433,7 +433,7 @@ export function createTalkClientGatewayControlOwner<CapturedControl = undefined>
 
   const runConsult = async (
     event: RealtimeVoiceToolCallEvent,
-    consult: PendingConsult<CapturedControl>,
+    consult: PendingConsult,
   ): Promise<void> => {
     const { controller } = consult;
     try {
@@ -487,7 +487,7 @@ export function createTalkClientGatewayControlOwner<CapturedControl = undefined>
     }
     if (event.name === REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME) {
       // Startup controls bind to this consult's eventual target, never the later current run.
-      const consult = createPendingTalkConsult<CapturedControl>();
+      const consult = createPendingTalkConsult();
       consultControllers.set(event.callId, consult);
       const admission = consultQueue.enqueue(() => runConsult(event, consult));
       if (!admission.accepted) {

--- a/src/gateway/talk-client-pending-consult.ts
+++ b/src/gateway/talk-client-pending-consult.ts
@@ -1,3 +1,4 @@
+import type { ActiveEmbeddedRunOwner } from "../agents/embedded-agent.js";
 import { BoundedSerialQueue } from "../shared/bounded-serial-queue.js";
 import { createDeferredCore } from "../shared/deferred.js";
 
@@ -10,14 +11,14 @@ export function createRealtimeControlQueue(): BoundedSerialQueue {
   });
 }
 
-export type PendingConsult<CapturedControl> = {
+export type PendingConsult = {
   controller: AbortController;
-  controlTarget: Promise<CapturedControl | undefined>;
-  resolveControlTarget: (captured: CapturedControl | undefined) => void;
+  controlTarget: Promise<ActiveEmbeddedRunOwner | undefined>;
+  resolveControlTarget: (captured: ActiveEmbeddedRunOwner | undefined) => void;
 };
 
-export function createPendingTalkConsult<CapturedControl>(): PendingConsult<CapturedControl> {
-  const targetReady = createDeferredCore<CapturedControl | undefined>();
+export function createPendingTalkConsult(): PendingConsult {
+  const targetReady = createDeferredCore<ActiveEmbeddedRunOwner | undefined>();
   return {
     controller: new AbortController(),
     controlTarget: targetReady.promise,

--- a/src/gateway/talk-client-pending-consult.ts
+++ b/src/gateway/talk-client-pending-consult.ts
@@ -1,0 +1,16 @@
+import { createDeferredCore } from "../shared/deferred.js";
+
+export type PendingConsult<CapturedControl> = {
+  controller: AbortController;
+  controlTarget: Promise<CapturedControl | undefined>;
+  resolveControlTarget: (captured: CapturedControl | undefined) => void;
+};
+
+export function createPendingTalkConsult<CapturedControl>(): PendingConsult<CapturedControl> {
+  const targetReady = createDeferredCore<CapturedControl | undefined>();
+  return {
+    controller: new AbortController(),
+    controlTarget: targetReady.promise,
+    resolveControlTarget: targetReady.resolve,
+  };
+}

--- a/src/gateway/talk-client-pending-consult.ts
+++ b/src/gateway/talk-client-pending-consult.ts
@@ -1,4 +1,14 @@
+import { BoundedSerialQueue } from "../shared/bounded-serial-queue.js";
 import { createDeferredCore } from "../shared/deferred.js";
+
+const REALTIME_CONTROL_MAX_PENDING = 8;
+
+export function createRealtimeControlQueue(): BoundedSerialQueue {
+  return new BoundedSerialQueue({
+    maxPendingCount: REALTIME_CONTROL_MAX_PENDING,
+    maxPendingWeight: REALTIME_CONTROL_MAX_PENDING,
+  });
+}
 
 export type PendingConsult<CapturedControl> = {
   controller: AbortController;

--- a/src/gateway/talk-realtime-relay-operations.ts
+++ b/src/gateway/talk-realtime-relay-operations.ts
@@ -1,7 +1,12 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import {
+  resolveActiveEmbeddedRunOwnerByRunId,
+  resolveEmbeddedAgentMessageInjectionTarget,
+} from "../agents/embedded-agent-runner/runs.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { buildRealtimeVoiceAgentCancelProviderResult } from "../talk/agent-run-control-shared.js";
 import {
+  controlOwnedRealtimeVoiceAgentRun,
   controlRealtimeVoiceAgentRun,
   type RealtimeVoiceAgentControlResult,
 } from "../talk/agent-run-control.js";
@@ -487,12 +492,20 @@ export async function steerTalkRealtimeRelayAgentRun(params: {
   if (requestedSessionKey && requestedSessionKey !== sessionKey) {
     throw new Error("Realtime relay steering session key does not match the relay session");
   }
-  const result = await controlRealtimeVoiceAgentRun({
+  const activeRunId = [...session.activeAgentRuns.entries()].find(
+    ([, key]) => key === sessionKey,
+  )?.[0];
+  const activeOwner = activeRunId ? resolveActiveEmbeddedRunOwnerByRunId(activeRunId) : undefined;
+  const target = activeOwner ? resolveEmbeddedAgentMessageInjectionTarget(activeOwner) : undefined;
+  const controlParams = {
     sessionKey,
     text: params.text,
     mode: params.mode,
     recentEvents: session.harness.talk.recentEvents,
-  });
+  };
+  const result = target
+    ? await controlOwnedRealtimeVoiceAgentRun(controlParams, target)
+    : await controlRealtimeVoiceAgentRun(controlParams);
   if (relaySessions.get(session.id) !== session) {
     throw new Error("Realtime relay session closed while steering the agent run");
   }

--- a/src/gateway/talk-realtime-relay-operations.ts
+++ b/src/gateway/talk-realtime-relay-operations.ts
@@ -2,6 +2,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import {
   resolveActiveEmbeddedRunOwnerByRunId,
   resolveEmbeddedAgentMessageInjectionTarget,
+  type EmbeddedAgentMessageInjectionTarget,
 } from "../agents/embedded-agent-runner/runs.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { buildRealtimeVoiceAgentCancelProviderResult } from "../talk/agent-run-control-shared.js";
@@ -474,6 +475,30 @@ export async function flushTalkRealtimeRelayVoiceWrites(params: {
   await session.voiceTranscriptQueue.flush();
 }
 
+export function captureTalkRealtimeRelayAgentRunControlTarget(params: {
+  relaySessionId: string;
+  connId: string;
+}): EmbeddedAgentMessageInjectionTarget | null {
+  const session = getRelaySession(params.relaySessionId, params.connId);
+  const sessionKey = session.sessionKey;
+  if (!sessionKey) {
+    return null;
+  }
+  for (const [runId, key] of session.activeAgentRuns) {
+    if (key !== sessionKey) {
+      continue;
+    }
+    const activeOwner = resolveActiveEmbeddedRunOwnerByRunId(runId);
+    const target = activeOwner
+      ? resolveEmbeddedAgentMessageInjectionTarget(activeOwner)
+      : undefined;
+    if (target) {
+      return target;
+    }
+  }
+  return null;
+}
+
 /** Applies realtime voice-control text to the active agent-consult chat run. */
 export async function steerTalkRealtimeRelayAgentRun(params: {
   relaySessionId: string;
@@ -481,6 +506,7 @@ export async function steerTalkRealtimeRelayAgentRun(params: {
   sessionKey?: string;
   text: string;
   mode?: string;
+  controlTarget?: EmbeddedAgentMessageInjectionTarget | null;
 }): Promise<RealtimeVoiceAgentControlResult> {
   const session = getRelaySession(params.relaySessionId, params.connId);
   const sessionKey = session.sessionKey;
@@ -491,11 +517,13 @@ export async function steerTalkRealtimeRelayAgentRun(params: {
   if (requestedSessionKey && requestedSessionKey !== sessionKey) {
     throw new Error("Realtime relay steering session key does not match the relay session");
   }
-  const activeRunId = [...session.activeAgentRuns.entries()].find(
-    ([, key]) => key === sessionKey,
-  )?.[0];
-  const activeOwner = activeRunId ? resolveActiveEmbeddedRunOwnerByRunId(activeRunId) : undefined;
-  const target = activeOwner ? resolveEmbeddedAgentMessageInjectionTarget(activeOwner) : undefined;
+  const target =
+    params.controlTarget !== undefined
+      ? (params.controlTarget ?? undefined)
+      : (captureTalkRealtimeRelayAgentRunControlTarget({
+          relaySessionId: params.relaySessionId,
+          connId: params.connId,
+        }) ?? undefined);
   const controlParams = {
     sessionKey,
     text: params.text,

--- a/src/gateway/talk-realtime-relay-operations.ts
+++ b/src/gateway/talk-realtime-relay-operations.ts
@@ -7,7 +7,6 @@ import { createDeferredCore } from "../shared/deferred.js";
 import { buildRealtimeVoiceAgentCancelProviderResult } from "../talk/agent-run-control-shared.js";
 import {
   controlOwnedRealtimeVoiceAgentRun,
-  controlRealtimeVoiceAgentRun,
   type RealtimeVoiceAgentControlResult,
 } from "../talk/agent-run-control.js";
 import { registerClientVoiceConsultRun } from "../talk/client-voice-session.js";
@@ -503,9 +502,7 @@ export async function steerTalkRealtimeRelayAgentRun(params: {
     mode: params.mode,
     recentEvents: session.harness.talk.recentEvents,
   };
-  const result = target
-    ? await controlOwnedRealtimeVoiceAgentRun(controlParams, target)
-    : await controlRealtimeVoiceAgentRun(controlParams);
+  const result = await controlOwnedRealtimeVoiceAgentRun(controlParams, target);
   if (relaySessions.get(session.id) !== session) {
     throw new Error("Realtime relay session closed while steering the agent run");
   }

--- a/src/gateway/talk-realtime-relay-operations.ts
+++ b/src/gateway/talk-realtime-relay-operations.ts
@@ -1,8 +1,7 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   resolveActiveEmbeddedRunOwnerByRunId,
-  resolveEmbeddedAgentMessageInjectionTarget,
-  type EmbeddedAgentMessageInjectionTarget,
+  type ActiveEmbeddedRunOwner,
 } from "../agents/embedded-agent-runner/runs.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { buildRealtimeVoiceAgentCancelProviderResult } from "../talk/agent-run-control-shared.js";
@@ -478,7 +477,7 @@ export async function flushTalkRealtimeRelayVoiceWrites(params: {
 export function captureTalkRealtimeRelayAgentRunControlTarget(params: {
   relaySessionId: string;
   connId: string;
-}): EmbeddedAgentMessageInjectionTarget | null {
+}): ActiveEmbeddedRunOwner | null {
   const session = getRelaySession(params.relaySessionId, params.connId);
   const sessionKey = session.sessionKey;
   if (!sessionKey) {
@@ -488,12 +487,9 @@ export function captureTalkRealtimeRelayAgentRunControlTarget(params: {
     if (key !== sessionKey) {
       continue;
     }
-    const activeOwner = resolveActiveEmbeddedRunOwnerByRunId(runId);
-    const target = activeOwner
-      ? resolveEmbeddedAgentMessageInjectionTarget(activeOwner)
-      : undefined;
-    if (target) {
-      return target;
+    const owner = resolveActiveEmbeddedRunOwnerByRunId(runId);
+    if (owner) {
+      return owner;
     }
   }
   return null;
@@ -506,7 +502,7 @@ export async function steerTalkRealtimeRelayAgentRun(params: {
   sessionKey?: string;
   text: string;
   mode?: string;
-  controlTarget?: EmbeddedAgentMessageInjectionTarget | null;
+  controlTarget?: ActiveEmbeddedRunOwner | null;
 }): Promise<RealtimeVoiceAgentControlResult> {
   const session = getRelaySession(params.relaySessionId, params.connId);
   const sessionKey = session.sessionKey;

--- a/src/gateway/talk-realtime-relay-session-create.ts
+++ b/src/gateway/talk-realtime-relay-session-create.ts
@@ -27,6 +27,7 @@ import {
 } from "./talk-realtime-relay-issues.js";
 import {
   cancelTalkRealtimeRelayProviderToolCall,
+  captureTalkRealtimeRelayAgentRunControlTarget,
   closeRelaySession,
   closeTalkRealtimeRelaySessionsForConnection,
   enforceRelaySessionLimits,
@@ -170,7 +171,12 @@ export function createTalkRealtimeRelaySession(
       const relay = getActiveRelay();
       return Boolean(relay && pruneInactiveRelayAgentRuns(relay) > 0);
     },
-    execute: async (args) => {
+    capture: () =>
+      captureTalkRealtimeRelayAgentRunControlTarget({
+        relaySessionId,
+        connId: params.connId,
+      }),
+    execute: async (args, controlTarget) => {
       const relay = getActiveRelay();
       if (!relay || !args || typeof args !== "object" || Array.isArray(args)) {
         throw new Error("Realtime relay control session is closed");
@@ -183,6 +189,7 @@ export function createTalkRealtimeRelaySession(
         relaySessionId,
         connId: params.connId,
         text,
+        controlTarget,
       });
     },
     speak: (message) => bridgeRef.current?.sendUserMessage?.(message),

--- a/src/gateway/talk-realtime-relay-session-create.ts
+++ b/src/gateway/talk-realtime-relay-session-create.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { resolveExpiresAtMsFromDurationMs } from "@openclaw/normalization-core/number-coercion";
-import type { EmbeddedAgentMessageInjectionTarget } from "../agents/embedded-agent.js";
+import type { ActiveEmbeddedRunOwner } from "../agents/embedded-agent.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME } from "../talk/agent-consult-tool.js";
@@ -159,7 +159,7 @@ export function createTalkRealtimeRelaySession(
           }),
       })
     : undefined;
-  let pendingControlTarget: Promise<EmbeddedAgentMessageInjectionTarget | undefined> | undefined;
+  let pendingControlTarget: Promise<ActiveEmbeddedRunOwner | undefined> | undefined;
   const runAgentConsult = async ({ prompt, signal }: { prompt: string; signal?: AbortSignal }) => {
     if (!getActiveRelay()) {
       throw new Error("Realtime gateway-relay session is closed");
@@ -167,7 +167,7 @@ export function createTalkRealtimeRelaySession(
     if (!consultRunner) {
       throw new Error("Realtime gateway-relay agent consult requires a pinned session key");
     }
-    const targetReady = createDeferredCore<EmbeddedAgentMessageInjectionTarget | undefined>();
+    const targetReady = createDeferredCore<ActiveEmbeddedRunOwner | undefined>();
     pendingControlTarget = targetReady.promise;
     try {
       return await consultRunner.runArgs({ question: prompt }, signal, targetReady.resolve);

--- a/src/gateway/talk-realtime-relay-session-create.ts
+++ b/src/gateway/talk-realtime-relay-session-create.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from "node:crypto";
 import { resolveExpiresAtMsFromDurationMs } from "@openclaw/normalization-core/number-coercion";
+import type { EmbeddedAgentMessageInjectionTarget } from "../agents/embedded-agent.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import { REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME } from "../talk/agent-consult-tool.js";
 import { buildRealtimeVoiceAgentCancelProviderResult } from "../talk/agent-run-control-shared.js";
 import { resolveTalkSessionAgentId } from "../talk/agent-target.js";
@@ -157,6 +159,7 @@ export function createTalkRealtimeRelaySession(
           }),
       })
     : undefined;
+  let pendingControlTarget: Promise<EmbeddedAgentMessageInjectionTarget | undefined> | undefined;
   const runAgentConsult = async ({ prompt, signal }: { prompt: string; signal?: AbortSignal }) => {
     if (!getActiveRelay()) {
       throw new Error("Realtime gateway-relay session is closed");
@@ -164,18 +167,29 @@ export function createTalkRealtimeRelaySession(
     if (!consultRunner) {
       throw new Error("Realtime gateway-relay agent consult requires a pinned session key");
     }
-    return await consultRunner.runPrompt({ prompt, signal });
+    const targetReady = createDeferredCore<EmbeddedAgentMessageInjectionTarget | undefined>();
+    pendingControlTarget = targetReady.promise;
+    try {
+      return await consultRunner.runArgs({ question: prompt }, signal, targetReady.resolve);
+    } finally {
+      targetReady.resolve(undefined);
+      if (pendingControlTarget === targetReady.promise) {
+        pendingControlTarget = undefined;
+      }
+    }
   };
   const runControl = createTalkRealtimeRunControlOwner({
     hasActiveRun: () => {
       const relay = getActiveRelay();
       return Boolean(relay && pruneInactiveRelayAgentRuns(relay) > 0);
     },
-    capture: () =>
-      captureTalkRealtimeRelayAgentRunControlTarget({
+    capture: () => {
+      const target = captureTalkRealtimeRelayAgentRunControlTarget({
         relaySessionId,
         connId: params.connId,
-      }),
+      });
+      return target ? Promise.resolve(target) : pendingControlTarget;
+    },
     execute: async (args, controlTarget) => {
       const relay = getActiveRelay();
       if (!relay || !args || typeof args !== "object" || Array.isArray(args)) {
@@ -189,7 +203,7 @@ export function createTalkRealtimeRelaySession(
         relaySessionId,
         connId: params.connId,
         text,
-        controlTarget,
+        controlTarget: await controlTarget,
       });
     },
     speak: (message) => bridgeRef.current?.sendUserMessage?.(message),

--- a/src/gateway/talk-realtime-relay-state.ts
+++ b/src/gateway/talk-realtime-relay-state.ts
@@ -15,7 +15,7 @@ import type { RealtimeVoiceSessionHarness } from "../talk/realtime-session-harne
 import type { RealtimeVoiceBridgeSession } from "../talk/session-runtime.js";
 import type { TalkEvent } from "../talk/talk-session-controller.js";
 import type { GatewayRequestContext } from "./server-methods/shared-types.js";
-import type { TalkAgentConsultAuthority } from "./talk-client-gateway-control.js";
+import type { TalkAgentConsultAuthority } from "./talk-agent-consult-authority.js";
 import type { RelayToolCallLedger } from "./talk-realtime-relay-tool-call-ledger.js";
 
 export const RELAY_SESSION_TTL_MS = 30 * 60 * 1000;

--- a/src/gateway/talk-realtime-relay.test.ts
+++ b/src/gateway/talk-realtime-relay.test.ts
@@ -4041,6 +4041,7 @@ describe("talk realtime gateway relay", () => {
       setActiveEmbeddedRun(
         "embedded-session-1",
         {
+          runId: "run-1",
           queueMessage: vi.fn(async () => undefined),
           isStreaming: () => true,
           isCompacting: () => false,
@@ -4111,6 +4112,7 @@ describe("talk realtime gateway relay", () => {
     setActiveEmbeddedRun(
       "embedded-session-1",
       {
+        runId: "run-1",
         queueMessage: vi.fn(async () => undefined),
         isStreaming: () => true,
         isCompacting: () => false,
@@ -4179,6 +4181,7 @@ describe("talk realtime gateway relay", () => {
     setActiveEmbeddedRun(
       "embedded-session-1",
       {
+        runId: "run-1",
         queueMessage: vi.fn(async () => undefined),
         isStreaming: () => true,
         isCompacting: () => false,
@@ -4223,6 +4226,7 @@ describe("talk realtime gateway relay", () => {
     setActiveEmbeddedRun(
       "embedded-session-1",
       {
+        runId: "run-1",
         queueMessage: vi.fn(async () => undefined),
         isStreaming: () => true,
         isCompacting: () => false,
@@ -4451,6 +4455,7 @@ describe("talk realtime gateway relay", () => {
     setActiveEmbeddedRun(
       "embedded-session-1",
       {
+        runId: "run-1",
         queueMessage: vi.fn(async () => undefined),
         isStreaming: () => true,
         isCompacting: () => false,

--- a/src/gateway/talk-realtime-relay.test.ts
+++ b/src/gateway/talk-realtime-relay.test.ts
@@ -4027,6 +4027,52 @@ describe("talk realtime gateway relay", () => {
     });
   });
 
+  it("skips a stale relay run before a later live target", async () => {
+    const abortLiveRun = vi.fn();
+    setActiveEmbeddedRun(
+      "embedded-session-live",
+      {
+        runId: "run-live",
+        queueMessage: vi.fn(async () => undefined),
+        isStreaming: () => true,
+        isCompacting: () => false,
+        abort: abortLiveRun,
+      },
+      "agent:main:main",
+    );
+    const session = createTalkRealtimeRelaySession({
+      context: { broadcastToConnIds: vi.fn(), chatAbortControllers: new Map() } as never,
+      connId: "conn-1",
+      provider: createIdleRelayProvider(),
+      providerConfig: {},
+      instructions: "brief",
+      tools: [],
+      sessionKey: "agent:main:main",
+    });
+    registerTalkRealtimeRelayAgentRun({
+      relaySessionId: session.relaySessionId,
+      connId: "conn-1",
+      sessionKey: "agent:main:main",
+      runId: "run-stale",
+    });
+    registerTalkRealtimeRelayAgentRun({
+      relaySessionId: session.relaySessionId,
+      connId: "conn-1",
+      sessionKey: "agent:main:main",
+      runId: "run-live",
+    });
+
+    await expect(
+      steerTalkRealtimeRelayAgentRun({
+        relaySessionId: session.relaySessionId,
+        connId: "conn-1",
+        text: "cancel",
+        mode: "cancel",
+      }),
+    ).resolves.toMatchObject({ ok: true, aborted: true });
+    expect(abortLiveRun).toHaveBeenCalledOnce();
+  });
+
   it.each([
     {
       supportsSuppression: undefined,

--- a/src/talk/agent-run-control.test.ts
+++ b/src/talk/agent-run-control.test.ts
@@ -44,6 +44,7 @@ function createDeps(options: {
               enqueuedAtMs: 123,
             },
     ),
+    queueEmbeddedAgentMessageInjectionTarget: vi.fn(),
     getDiagnosticSessionActivitySnapshot: vi.fn(() => options.activity ?? {}),
     resolveActiveEmbeddedRunSessionId: vi.fn(() => options.activeSessionId),
   };

--- a/src/talk/agent-run-control.test.ts
+++ b/src/talk/agent-run-control.test.ts
@@ -19,6 +19,7 @@ function createDeps(options: {
 }) {
   return {
     abortEmbeddedAgentRun: vi.fn(() => options.abortResult ?? true),
+    abortEmbeddedAgentMessageInjectionTarget: vi.fn(() => options.abortResult ?? true),
     queueEmbeddedAgentMessageWithOutcomeAsync: vi.fn(
       async (
         sessionId: string,

--- a/src/talk/agent-run-control.test.ts
+++ b/src/talk/agent-run-control.test.ts
@@ -19,7 +19,6 @@ function createDeps(options: {
 }) {
   return {
     abortEmbeddedAgentRun: vi.fn(() => options.abortResult ?? true),
-    abortEmbeddedAgentMessageInjectionTarget: vi.fn(() => options.abortResult ?? true),
     queueEmbeddedAgentMessageWithOutcomeAsync: vi.fn(
       async (
         sessionId: string,
@@ -45,7 +44,6 @@ function createDeps(options: {
               enqueuedAtMs: 123,
             },
     ),
-    queueEmbeddedAgentMessageInjectionTarget: vi.fn(),
     getDiagnosticSessionActivitySnapshot: vi.fn(() => options.activity ?? {}),
     resolveActiveEmbeddedRunSessionId: vi.fn(() => options.activeSessionId),
   };

--- a/src/talk/agent-run-control.ts
+++ b/src/talk/agent-run-control.ts
@@ -5,7 +5,7 @@
  * binds those contracts to embedded-run abort, status, and steering primitives.
  */
 import type {
-  EmbeddedAgentMessageInjectionTarget,
+  ActiveEmbeddedRunOwner,
   EmbeddedAgentQueueMessageOutcome,
 } from "../agents/embedded-agent-runner/runs.js";
 import { getDiagnosticSessionActivitySnapshot } from "../logging/diagnostic-run-activity.js";
@@ -39,9 +39,6 @@ export {
 
 type RealtimeVoiceAgentControlDeps = {
   abortEmbeddedAgentRun: (sessionId: string) => boolean;
-  abortEmbeddedAgentMessageInjectionTarget: (
-    target: EmbeddedAgentMessageInjectionTarget,
-  ) => boolean;
   queueEmbeddedAgentMessageWithOutcomeAsync: (
     sessionId: string,
     text: string,
@@ -57,16 +54,6 @@ type RealtimeVoiceAgentControlDeps = {
     sessionKey?: string;
   }) => RealtimeVoiceAgentRunActivity;
   resolveActiveEmbeddedRunSessionId: (sessionKey: string) => string | undefined;
-  queueEmbeddedAgentMessageInjectionTarget: (
-    target: EmbeddedAgentMessageInjectionTarget,
-    text: string,
-    options?: {
-      steeringMode?: "all";
-      debounceMs?: number;
-      isInboundUserMessage?: boolean;
-      taskSuggestionDeliveryMode?: undefined;
-    },
-  ) => Promise<EmbeddedAgentQueueMessageOutcome>;
 };
 
 type RealtimeVoiceAgentControlParams = {
@@ -81,21 +68,20 @@ export async function controlRealtimeVoiceAgentRun(
   params: RealtimeVoiceAgentControlParams,
   providedDeps?: RealtimeVoiceAgentControlDeps,
 ): Promise<RealtimeVoiceAgentControlResult> {
-  return controlRealtimeVoiceAgentRunWithTarget(params, undefined, false, providedDeps);
+  return controlRealtimeVoiceAgentRunWithTarget(params, undefined, providedDeps);
 }
 
 /** Apply control from an ingress that already proved ownership of this exact opaque run. */
 export async function controlOwnedRealtimeVoiceAgentRun(
   params: RealtimeVoiceAgentControlParams,
-  target: EmbeddedAgentMessageInjectionTarget | undefined,
+  target: ActiveEmbeddedRunOwner | undefined,
 ): Promise<RealtimeVoiceAgentControlResult> {
-  return controlRealtimeVoiceAgentRunWithTarget(params, target, true);
+  return controlRealtimeVoiceAgentRunWithTarget(params, target ?? null);
 }
 
 async function controlRealtimeVoiceAgentRunWithTarget(
   params: RealtimeVoiceAgentControlParams,
-  target: EmbeddedAgentMessageInjectionTarget | undefined,
-  exactTargetRequired: boolean,
+  target: ActiveEmbeddedRunOwner | null | undefined,
   providedDeps?: RealtimeVoiceAgentControlDeps,
 ): Promise<RealtimeVoiceAgentControlResult> {
   // Provider registration consumes the shared policy without starting the agent runtime.
@@ -108,9 +94,8 @@ async function controlRealtimeVoiceAgentRunWithTarget(
   const text = params.text.trim();
   const intent = resolveRealtimeVoiceAgentControlIntent({ text, mode: params.mode });
   const mode = intent.mode;
-  const sessionId = exactTargetRequired
-    ? target?.sessionId
-    : deps.resolveActiveEmbeddedRunSessionId(sessionKey);
+  const sessionId =
+    target === undefined ? deps.resolveActiveEmbeddedRunSessionId(sessionKey) : target?.sessionId;
   const activity = deps.getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey });
   const active = Boolean(sessionId || activity.activeWorkKind || activity.hasActiveEmbeddedRun);
 
@@ -151,9 +136,7 @@ async function controlRealtimeVoiceAgentRunWithTarget(
         suppress: false,
       };
     }
-    const aborted = target
-      ? deps.abortEmbeddedAgentMessageInjectionTarget(target)
-      : deps.abortEmbeddedAgentRun(sessionId);
+    const aborted = target ? target.abort() : deps.abortEmbeddedAgentRun(sessionId);
     const message = aborted
       ? "Cancelled the active OpenClaw run."
       : "OpenClaw could not cancel the active run.";
@@ -192,12 +175,7 @@ async function controlRealtimeVoiceAgentRunWithTarget(
   // so the runner treats it as deferred context instead of an immediate pivot.
   const steerText = mode === "followup" ? buildRealtimeVoiceAgentFollowupSteeringText(text) : text;
   const queueMessage = target
-    ? (
-        message: string,
-        options: Parameters<
-          RealtimeVoiceAgentControlDeps["queueEmbeddedAgentMessageInjectionTarget"]
-        >[2],
-      ) => deps.queueEmbeddedAgentMessageInjectionTarget(target, message, options)
+    ? target.queueMessage
     : (
         message: string,
         options: Parameters<

--- a/src/talk/agent-run-control.ts
+++ b/src/talk/agent-run-control.ts
@@ -39,6 +39,9 @@ export {
 
 type RealtimeVoiceAgentControlDeps = {
   abortEmbeddedAgentRun: (sessionId: string) => boolean;
+  abortEmbeddedAgentMessageInjectionTarget: (
+    target: EmbeddedAgentMessageInjectionTarget,
+  ) => boolean;
   queueEmbeddedAgentMessageWithOutcomeAsync: (
     sessionId: string,
     text: string,
@@ -78,20 +81,21 @@ export async function controlRealtimeVoiceAgentRun(
   params: RealtimeVoiceAgentControlParams,
   providedDeps?: RealtimeVoiceAgentControlDeps,
 ): Promise<RealtimeVoiceAgentControlResult> {
-  return controlRealtimeVoiceAgentRunWithTarget(params, undefined, providedDeps);
+  return controlRealtimeVoiceAgentRunWithTarget(params, undefined, false, providedDeps);
 }
 
 /** Apply control from an ingress that already proved ownership of this exact opaque run. */
 export async function controlOwnedRealtimeVoiceAgentRun(
   params: RealtimeVoiceAgentControlParams,
-  target: EmbeddedAgentMessageInjectionTarget,
+  target: EmbeddedAgentMessageInjectionTarget | undefined,
 ): Promise<RealtimeVoiceAgentControlResult> {
-  return controlRealtimeVoiceAgentRunWithTarget(params, target);
+  return controlRealtimeVoiceAgentRunWithTarget(params, target, true);
 }
 
 async function controlRealtimeVoiceAgentRunWithTarget(
   params: RealtimeVoiceAgentControlParams,
   target: EmbeddedAgentMessageInjectionTarget | undefined,
+  exactTargetRequired: boolean,
   providedDeps?: RealtimeVoiceAgentControlDeps,
 ): Promise<RealtimeVoiceAgentControlResult> {
   // Provider registration consumes the shared policy without starting the agent runtime.
@@ -104,7 +108,9 @@ async function controlRealtimeVoiceAgentRunWithTarget(
   const text = params.text.trim();
   const intent = resolveRealtimeVoiceAgentControlIntent({ text, mode: params.mode });
   const mode = intent.mode;
-  const sessionId = deps.resolveActiveEmbeddedRunSessionId(sessionKey);
+  const sessionId = exactTargetRequired
+    ? target?.sessionId
+    : deps.resolveActiveEmbeddedRunSessionId(sessionKey);
   const activity = deps.getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey });
   const active = Boolean(sessionId || activity.activeWorkKind || activity.hasActiveEmbeddedRun);
 
@@ -145,7 +151,9 @@ async function controlRealtimeVoiceAgentRunWithTarget(
         suppress: false,
       };
     }
-    const aborted = deps.abortEmbeddedAgentRun(sessionId);
+    const aborted = target
+      ? deps.abortEmbeddedAgentMessageInjectionTarget(target)
+      : deps.abortEmbeddedAgentRun(sessionId);
     const message = aborted
       ? "Cancelled the active OpenClaw run."
       : "OpenClaw could not cancel the active run.";

--- a/src/talk/agent-run-control.ts
+++ b/src/talk/agent-run-control.ts
@@ -4,7 +4,10 @@
  * The shared module owns classification and message contracts; this adapter
  * binds those contracts to embedded-run abort, status, and steering primitives.
  */
-import type { EmbeddedAgentQueueMessageOutcome } from "../agents/embedded-agent-runner/runs.js";
+import type {
+  EmbeddedAgentMessageInjectionTarget,
+  EmbeddedAgentQueueMessageOutcome,
+} from "../agents/embedded-agent-runner/runs.js";
 import { getDiagnosticSessionActivitySnapshot } from "../logging/diagnostic-run-activity.js";
 import {
   buildRealtimeVoiceAgentCancelProviderResult,
@@ -51,16 +54,44 @@ type RealtimeVoiceAgentControlDeps = {
     sessionKey?: string;
   }) => RealtimeVoiceAgentRunActivity;
   resolveActiveEmbeddedRunSessionId: (sessionKey: string) => string | undefined;
+  queueEmbeddedAgentMessageInjectionTarget: (
+    target: EmbeddedAgentMessageInjectionTarget,
+    text: string,
+    options?: {
+      steeringMode?: "all";
+      debounceMs?: number;
+      isInboundUserMessage?: boolean;
+      taskSuggestionDeliveryMode?: undefined;
+    },
+  ) => Promise<EmbeddedAgentQueueMessageOutcome>;
+};
+
+type RealtimeVoiceAgentControlParams = {
+  sessionKey: string;
+  text: string;
+  mode?: unknown;
+  recentEvents?: readonly TalkEvent[];
 };
 
 /** Apply a spoken status, cancel, steer, or follow-up request to an active run. */
 export async function controlRealtimeVoiceAgentRun(
-  params: {
-    sessionKey: string;
-    text: string;
-    mode?: unknown;
-    recentEvents?: readonly TalkEvent[];
-  },
+  params: RealtimeVoiceAgentControlParams,
+  providedDeps?: RealtimeVoiceAgentControlDeps,
+): Promise<RealtimeVoiceAgentControlResult> {
+  return controlRealtimeVoiceAgentRunWithTarget(params, undefined, providedDeps);
+}
+
+/** Apply control from an ingress that already proved ownership of this exact opaque run. */
+export async function controlOwnedRealtimeVoiceAgentRun(
+  params: RealtimeVoiceAgentControlParams,
+  target: EmbeddedAgentMessageInjectionTarget,
+): Promise<RealtimeVoiceAgentControlResult> {
+  return controlRealtimeVoiceAgentRunWithTarget(params, target);
+}
+
+async function controlRealtimeVoiceAgentRunWithTarget(
+  params: RealtimeVoiceAgentControlParams,
+  target: EmbeddedAgentMessageInjectionTarget | undefined,
   providedDeps?: RealtimeVoiceAgentControlDeps,
 ): Promise<RealtimeVoiceAgentControlResult> {
   // Provider registration consumes the shared policy without starting the agent runtime.
@@ -152,7 +183,20 @@ export async function controlRealtimeVoiceAgentRun(
   // Steering and follow-up both enqueue to the active run; follow-up is wrapped
   // so the runner treats it as deferred context instead of an immediate pivot.
   const steerText = mode === "followup" ? buildRealtimeVoiceAgentFollowupSteeringText(text) : text;
-  const outcome = await deps.queueEmbeddedAgentMessageWithOutcomeAsync(sessionId, steerText, {
+  const queueMessage = target
+    ? (
+        message: string,
+        options: Parameters<
+          RealtimeVoiceAgentControlDeps["queueEmbeddedAgentMessageInjectionTarget"]
+        >[2],
+      ) => deps.queueEmbeddedAgentMessageInjectionTarget(target, message, options)
+    : (
+        message: string,
+        options: Parameters<
+          RealtimeVoiceAgentControlDeps["queueEmbeddedAgentMessageWithOutcomeAsync"]
+        >[2],
+      ) => deps.queueEmbeddedAgentMessageWithOutcomeAsync(sessionId, message, options);
+  const outcome = await queueMessage(steerText, {
     steeringMode: "all",
     debounceMs: 0,
     isInboundUserMessage: true,

--- a/test/e2e/qa-lab/runtime/media-talk-gateway.ts
+++ b/test/e2e/qa-lab/runtime/media-talk-gateway.ts
@@ -16,6 +16,7 @@ import {
 } from "../../../../extensions/qa-lab/src/gateway-child.js";
 import { startQaMockOpenAiServer } from "../../../../extensions/qa-lab/src/providers/mock-openai/server.js";
 import { GatewayClient, type GatewayClientOptions } from "../../../../src/gateway/client.js";
+import { generateStoredDeviceIdentity } from "../../../../src/infra/device-identity-store.js";
 import type { DiagnosticStabilitySnapshot } from "../../../../src/logging/diagnostic-stability.js";
 import {
   GATEWAY_CLIENT_MODES,
@@ -185,6 +186,7 @@ function withFixturePlugin(config: OpenClawConfig, pluginDir: string): OpenClawC
 
 async function connectGatewayClient(params: {
   clientName: GatewayClientName;
+  deviceIdentity?: GatewayClientOptions["deviceIdentity"];
   mode: GatewayClientMode;
   onEvent?: GatewayClientOptions["onEvent"];
   token: string;
@@ -203,6 +205,7 @@ async function connectGatewayClient(params: {
     origin: gatewayUrl.origin,
     token: params.token,
     clientName: params.clientName,
+    ...(params.deviceIdentity !== undefined ? { deviceIdentity: params.deviceIdentity } : {}),
     mode: params.mode,
     role: "operator",
     scopes: [
@@ -210,6 +213,7 @@ async function connectGatewayClient(params: {
       "operator.write",
       "operator.admin",
       "operator.approvals",
+      "operator.talk",
       "operator.talk.secrets",
     ],
     platform: "qa",
@@ -490,6 +494,7 @@ async function runActiveTalkAgentRunProof(options: ProducerOptions): Promise<str
   const gatewayOwner = createQaGatewayChild();
   let gateway: QaGatewayChild | undefined;
   let client: GatewayClient | undefined;
+  let foreignClient: GatewayClient | undefined;
   try {
     gateway = await gatewayOwner.start({
       repoRoot: options.repoRoot,
@@ -545,6 +550,13 @@ async function runActiveTalkAgentRunProof(options: ProducerOptions): Promise<str
         `Talk provider did not receive consult/control tools: ${JSON.stringify(tools)}`,
       );
     }
+    foreignClient = await connectGatewayClient({
+      clientName: GATEWAY_CLIENT_NAMES.WEBCHAT_UI,
+      deviceIdentity: generateStoredDeviceIdentity(),
+      mode: GATEWAY_CLIENT_MODES.WEBCHAT,
+      token: gateway.token,
+      url: gateway.wsUrl,
+    });
     const consultRequest = client.request("talk.client.toolCall", {
       sessionKey,
       callId: `qa-talk-${randomUUID()}`,
@@ -556,6 +568,19 @@ async function runActiveTalkAgentRunProof(options: ProducerOptions): Promise<str
     void consultRequest.catch(() => undefined);
     const steer = await waitForQueuedTalkSteer(client, sessionKey);
     assertControlResult(steer, { mode: "steer", active: true, queued: true });
+    try {
+      await foreignClient.request("talk.client.steer", {
+        sessionKey,
+        text: "cancel",
+        mode: "cancel",
+      });
+      throw new Error("foreign Talk connection unexpectedly controlled the active run");
+    } catch (error) {
+      const message = formatErrorMessage(error);
+      if (!message.includes("active browser-owned Talk run")) {
+        throw error;
+      }
+    }
     await waitForActiveTalkStatus(client, sessionKey);
     const followup = await client.request("talk.client.steer", {
       sessionKey,
@@ -594,8 +619,9 @@ async function runActiveTalkAgentRunProof(options: ProducerOptions): Promise<str
         `Talk run did not finish with empty diagnostic backlog: ${JSON.stringify(stateDiagnostics.events)}`,
       );
     }
-    return `real Gateway pid=${gateway.pid ?? "unknown"}; persistent WebChat connection completed status, steer, follow-up, cancel RPCs; steeringQueueDepths=${steeringQueueDepths.join(",")}; finalState=${finalState.outcome}; finalQueueDepth=${finalState.queueDepth}`;
+    return `real Gateway pid=${gateway.pid ?? "unknown"}; persistent WebChat connection completed status, steer, follow-up, cancel RPCs; foreign connection rejected before abort; steeringQueueDepths=${steeringQueueDepths.join(",")}; finalState=${finalState.outcome}; finalQueueDepth=${finalState.queueDepth}`;
   } finally {
+    foreignClient?.stop();
     client?.stop();
     await stopQaGatewayFixture(gatewayOwner).catch(() => undefined);
     await mock.stop();


### PR DESCRIPTION
Closes #126733

## What Problem This Solves

Fixes an issue where browser or relay Talk steering and cancellation could fail with `tool_authority_mismatch` even when the Talk connection owned the active run.

The original Talk path checked connection and session ownership, then discarded that proof and called mutable session-key control. It therefore could not supply the embedded runner's current-run injection authority. A delayed control callback could also select a replacement run, and one stale relay registration could mask a later live run.

## Why This Change Was Made

The embedded runner now owns one opaque exact-run control target. Resolution requires the session registry and run-id registry to identify the same handle. Queue and abort operations synchronously revalidate that captured handle immediately before their effect. Closure, replacement, missing authority, and another owner all fail closed; raw fingerprints and run IDs remain correlation rather than authority.

Browser direct control, browser Gateway-control, and realtime relay control use this exact target. The asynchronous Talk control queue captures the target at admission and carries it unchanged through readiness waits. Relay capture scans past stale registrations to the first live target. There are no mutable session-key fallbacks from these owner-bound paths.

## User Impact

Browser and relay Talk can steer or cancel the run they own. A delayed callback cannot steer or abort a replacement run, while a stale relay registration no longer prevents control of a later live run.

No config, schema, protocol, migration, or public plugin SDK changes.

## Evidence

Pre-fix production scenario:

- The original maturity run reached `tool_authority_mismatch` after the browser owner had identified the active run.
- Earlier isolated runs stopped first at #126730. Current `main` now includes #133019, which independently repairs that preceding browser ownership handoff, so the same real-Gateway scenario reaches this PR's authority boundary.

Exact-head real production-boundary proof:

- `pnpm openclaw qa run --qa-profile all --scenario active-talk-agent-run-status --provider-mode mock-openai --output-dir .artifacts/qa-126733-exact-head`
- Result: 1 passed, 0 failed on `a05aa490a59`.
- A persistent owning WebChat connection completed status, steer, follow-up, and cancel RPCs against one real active agent run.
- A separately authenticated Gateway connection was rejected before it could abort the browser-owned run.
- The owner remained active after that rejection, both injections were observed with queue depths `1,1`, and the cancelled run finished `idle` with queue depth `0`.

Startup-order proof:

- A control admitted after consult admission but before embedded-run registration waits on that specific consult and receives its exact opaque target only after both active-run indexes register the admitted handle; it never re-resolves a later current run.
- The regression fails on the prior branch because control executes immediately with an absent target, and passes after the exact admitted context carries registration readiness from the runner owner boundary.

Replacement and sibling proof:

- Replacing a captured run makes the retained target reject queue and cancellation; neither the old nor replacement abort callback executes.
- Browser Gateway-control captures authority synchronously before queued execution; changing the current target before the queue runs does not change the admitted target.
- Relay control skips a stale first registration, captures the later live exact target, and cancels only that handle.

Verification:

- Focused Talk/runner suite: 218 passed on the exact head.
- `pnpm tsgo:core && pnpm tsgo:core:test` — passed.
- Diff-scoped deslop — clean after removing a diagnostic-only wrapper.
- Test audit — the added real-Gateway case protects cross-connection rejection at the final effect and introduces no production-only test seam.
- Exact-head P1 autoreview against current `origin/main` — scoped clean; patch correct (0.91 confidence).
- The all-lane changed check reached only unrelated current-main Telegram/grammY type drift (`RichMessageButton`, `stopped_message_generation`, and body variants); focused core and Talk checks are green.

Exact-head LOC: production +306/-61 (net +245); tests/test support +321/-11 (net +310); scenario metadata +2/-1. Production growth establishes and carries the opaque authority boundary across three ingress paths and the shared asynchronous control queue; the previous mutable fallback paths are removed.