### PR TITLE
fix(test): preserve trailing Vitest task updates

### DIFF
--- a/patches/@vitest__runner@4.1.11.patch
+++ b/patches/@vitest__runner@4.1.11.patch
@@ -1,0 +1,24 @@
+diff --git a/dist/chunk-artifact.js b/dist/chunk-artifact.js
+index 1f3db9bac2448d085c881ded1ec0f3a37cda6a13..62d6532b38245750b4fc53529cfd856d34e5f75b 100644
+--- a/dist/chunk-artifact.js
++++ b/dist/chunk-artifact.js
+@@ -2843,14 +2843,17 @@ function throttle(fn, ms) {
+ 	let pendingCall;
+ 	return function call(...args) {
+ 		const now = unixNow();
+-		if (now - last > ms) {
++		if (now - last >= ms) {
+ 			last = now;
+ 			clearTimeout(pendingCall);
+ 			pendingCall = undefined;
+ 			return fn.apply(this, args);
+ 		}
+ 		// Make sure fn is still called even if there are no further calls
+-		pendingCall ??= setTimeout(() => call.bind(this)(...args), ms);
++		pendingCall ??= setTimeout(() => {
++			pendingCall = undefined;
++			call.apply(this, args);
++		}, ms);
+ 	};
+ }
+ // throttle based on summary reporter's DURATION_UPDATE_INTERVAL_MS

--- a/patches/@vitest__runner@4.1.11.patch
+++ b/patches/@vitest__runner@4.1.11.patch
@@ -2,23 +2,12 @@ diff --git a/dist/chunk-artifact.js b/dist/chunk-artifact.js
 index 1f3db9bac2448d085c881ded1ec0f3a37cda6a13..62d6532b38245750b4fc53529cfd856d34e5f75b 100644
 --- a/dist/chunk-artifact.js
 +++ b/dist/chunk-artifact.js
-@@ -2843,14 +2843,17 @@ function throttle(fn, ms) {
- 	let pendingCall;
- 	return function call(...args) {
- 		const now = unixNow();
+@@ -2846 +2846 @@ function throttle(fn, ms) {
 -		if (now - last > ms) {
 +		if (now - last >= ms) {
- 			last = now;
- 			clearTimeout(pendingCall);
- 			pendingCall = undefined;
- 			return fn.apply(this, args);
- 		}
- 		// Make sure fn is still called even if there are no further calls
+@@ -2853 +2853,4 @@ function throttle(fn, ms) {
 -		pendingCall ??= setTimeout(() => call.bind(this)(...args), ms);
 +		pendingCall ??= setTimeout(() => {
 +			pendingCall = undefined;
 +			call.apply(this, args);
 +		}, ms);
- 	};
- }
- // throttle based on summary reporter's DURATION_UPDATE_INTERVAL_MS

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,5 @@
+# Temporary dependency patches
+
+`@vitest/runner@4.1.11` has an approved temporary pnpm patch for lost trailing task updates. It accepts the exact batching deadline and clears the consumed timer handle before re-entering the throttle, allowing an early callback to rearm. The 100 ms batching interval and immediate-call cancellation stay unchanged; this is not a maintained fork or a reporting SLA.
+
+Remove the runner patch, its registration, and its exact-version guard exception when upgrading to an upstream fixed version with `test/scripts/vitest-runner-task-updates.test.ts` green. Keep that regression to verify completion delivery without later task events or file-finalization rescue. Generate and register patches through pnpm; never edit installed dependency files manually.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ overrides:
 packageExtensionsChecksum: sha256-zZ8fyodhMTumshonC7kktCqTPsiHL3UAyS9vltFAlMo=
 
 patchedDependencies:
-  '@vitest/runner@4.1.11': 1af06c7260d5e711f6b44e5f092ce072699d94320dbc6fff966265c16effe6c4
+  '@vitest/runner@4.1.11': 55258cdf55f944f5e9bfbc52251b3696225ca2993e2d9f56b90b88f764193d93
 
 importers:
 
@@ -13071,7 +13071,7 @@ snapshots:
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.11(patch_hash=1af06c7260d5e711f6b44e5f092ce072699d94320dbc6fff966265c16effe6c4)':
+  '@vitest/runner@4.1.11(patch_hash=55258cdf55f944f5e9bfbc52251b3696225ca2993e2d9f56b90b88f764193d93)':
     dependencies:
       '@vitest/utils': 4.1.11
       pathe: 2.0.3
@@ -16974,7 +16974,7 @@ snapshots:
       '@vitest/expect': 4.1.11
       '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.11
-      '@vitest/runner': 4.1.11(patch_hash=1af06c7260d5e711f6b44e5f092ce072699d94320dbc6fff966265c16effe6c4)
+      '@vitest/runner': 4.1.11(patch_hash=55258cdf55f944f5e9bfbc52251b3696225ca2993e2d9f56b90b88f764193d93)
       '@vitest/snapshot': 4.1.11
       '@vitest/spy': 4.1.11
       '@vitest/utils': 4.1.11

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ overrides:
 
 packageExtensionsChecksum: sha256-zZ8fyodhMTumshonC7kktCqTPsiHL3UAyS9vltFAlMo=
 
+patchedDependencies:
+  '@vitest/runner@4.1.11': 1af06c7260d5e711f6b44e5f092ce072699d94320dbc6fff966265c16effe6c4
+
 importers:
 
   .:
@@ -13068,7 +13071,7 @@ snapshots:
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.11':
+  '@vitest/runner@4.1.11(patch_hash=1af06c7260d5e711f6b44e5f092ce072699d94320dbc6fff966265c16effe6c4)':
     dependencies:
       '@vitest/utils': 4.1.11
       pathe: 2.0.3
@@ -16971,7 +16974,7 @@ snapshots:
       '@vitest/expect': 4.1.11
       '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.11
-      '@vitest/runner': 4.1.11
+      '@vitest/runner': 4.1.11(patch_hash=1af06c7260d5e711f6b44e5f092ce072699d94320dbc6fff966265c16effe6c4)
       '@vitest/snapshot': 4.1.11
       '@vitest/spy': 4.1.11
       '@vitest/utils': 4.1.11

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -190,3 +190,6 @@ packageExtensions:
     peerDependenciesMeta:
       sharp:
         optional: true
+
+patchedDependencies:
+  "@vitest/runner@4.1.11": patches/@vitest__runner@4.1.11.patch

--- a/scripts/check-package-patches.mts
+++ b/scripts/check-package-patches.mts
@@ -9,6 +9,7 @@ import { asRecord } from "@openclaw/normalization-core/record-coerce";
 import YAML from "yaml";
 
 const ALLOWED_PATCHED_DEPENDENCIES = new Map([
+  ["@vitest/runner@4.1.11", "patches/@vitest__runner@4.1.11.patch"],
   ["baileys@7.0.0-rc12", "patches/baileys@7.0.0-rc12.patch"],
   ["baileys@7.0.0-rc13", "patches/baileys@7.0.0-rc13.patch"],
 ]);

--- a/test/fixtures/vitest-runner-task-updates.mjs
+++ b/test/fixtures/vitest-runner-task-updates.mjs
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// The runner captures Date.now and safe timers at import time. This fixture runs
+// in its own process so its clock cannot leak into the enclosing Vitest worker.
+let clock = 1_000;
+const timers = new Set();
+Date.now = () => clock;
+globalThis.setTimeout = (callback, delay, ...args) => {
+  const timer = { delay, callback: () => callback(...args) };
+  timers.add(timer);
+  return timer;
+};
+globalThis.clearTimeout = (timer) => timers.delete(timer);
+
+const { startTests, test } = await import("@vitest/runner");
+const filepath = fileURLToPath(import.meta.url);
+const firstFireAt = Number(process.argv[2]);
+const names = new Map();
+const batches = [];
+const completed = [];
+const checkpoints = [];
+const snapshot = () =>
+  structuredClone({ batches, completed, pendingDelays: [...timers].map((timer) => timer.delay) });
+function fireTimers(elapsed) {
+  clock = 1_000 + elapsed;
+  for (const timer of [...timers]) {
+    timers.delete(timer);
+    timer.callback();
+  }
+}
+
+const files = await startTests([filepath], {
+  config: {
+    root: dirname(filepath),
+    setupFiles: [],
+    name: "task-updates",
+    passWithNoTests: false,
+    testNamePattern: undefined,
+    allowOnly: true,
+    sequence: { hooks: "stack", setupFiles: "list", seed: 1 },
+    chaiConfig: undefined,
+    maxConcurrency: 1,
+    testTimeout: 5_000,
+    hookTimeout: 10_000,
+    retry: 0,
+    includeTaskLocation: false,
+    tags: [],
+    tagsFilter: undefined,
+    strictTags: true,
+  },
+  importFile() {
+    // Register ordinary passive tests through the public collector; neither
+    // test's execution depends on the reporter observing its completion.
+    test("completed case", () => {});
+    test("independent next case", () => {});
+  },
+  onCollected(files) {
+    for (const file of files) {
+      names.set(file.id, file.name);
+      for (const task of file.tasks) names.set(task.id, task.name);
+    }
+  },
+  onAfterRunTask(task) {
+    completed.push({ name: task.name, state: task.result.state });
+  },
+  onBeforeRunTask(task) {
+    if (task.name !== "independent next case") return;
+    // runTest has queued the previous test-finished, but has not produced the
+    // next test-prepare. No later task event or file flush can rescue delivery.
+    checkpoints.push(snapshot());
+    assert.deepEqual(completed, [{ name: "completed case", state: "pass" }]);
+    assert.deepEqual(
+      [...timers].map((timer) => timer.delay),
+      [100],
+    );
+    fireTimers(firstFireAt);
+    checkpoints.push(snapshot());
+    if (firstFireAt < 100) {
+      fireTimers(firstFireAt + 100);
+      checkpoints.push(snapshot());
+    }
+  },
+  async onTaskUpdate(packs, events) {
+    // Copy synchronously: the runner clears events and mutates task results.
+    batches.push({
+      results: packs.map(([id, result]) => ({ name: names.get(id), state: result?.state })),
+      events: events.map(([id, event]) => ({ name: names.get(id), event })),
+    });
+  },
+});
+const final = snapshot();
+fireTimers(firstFireAt + 200);
+console.log(
+  JSON.stringify({
+    checkpoints,
+    final,
+    drained: snapshot(),
+    fileStates: files.map((file) => file.result.state),
+  }),
+);

--- a/test/scripts/check-package-patches.test.ts
+++ b/test/scripts/check-package-patches.test.ts
@@ -53,7 +53,11 @@ afterEach(() => {
 });
 
 describe("check-package-patches", () => {
-  it("allows approved pnpm patches", () => {
+  it.each([
+    ["baileys@7.0.0-rc12", "patches/baileys@7.0.0-rc12.patch"],
+    ["baileys@7.0.0-rc13", "patches/baileys@7.0.0-rc13.patch"],
+    ["@vitest/runner@4.1.11", "patches/@vitest__runner@4.1.11.patch"],
+  ])("allows approved pnpm patch %s", (specifier, patchPath) => {
     const dir = makeRepo();
     mkdirSync(path.join(dir, "patches"), { recursive: true });
     writeFileSync(
@@ -61,7 +65,7 @@ describe("check-package-patches", () => {
       `packages:
   - .
 patchedDependencies:
-  "baileys@7.0.0-rc12": "patches/baileys@7.0.0-rc12.patch"
+  "${specifier}": "${patchPath}"
 `,
       "utf8",
     );
@@ -69,11 +73,11 @@ patchedDependencies:
       path.join(dir, "pnpm-lock.yaml"),
       `lockfileVersion: '9.0'
 patchedDependencies:
-  baileys@7.0.0-rc12: a9aea1790d2c65b1ae543c77faca4119bbfb91ee3b6ca6c38d1cad4f5702ada2
+  "${specifier}": a9aea1790d2c65b1ae543c77faca4119bbfb91ee3b6ca6c38d1cad4f5702ada2
 `,
       "utf8",
     );
-    writeFileSync(path.join(dir, "patches", "baileys@7.0.0-rc12.patch"), "diff\n", "utf8");
+    writeFileSync(path.join(dir, patchPath), "diff\n", "utf8");
     git(dir, ["add", "pnpm-workspace.yaml", "pnpm-lock.yaml", "patches"]);
 
     expect(collectPackagePatchViolations(dir)).toEqual([]);

--- a/test/scripts/vitest-runner-task-updates.test.ts
+++ b/test/scripts/vitest-runner-task-updates.test.ts
@@ -1,0 +1,67 @@
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+type TaskResult = { name: string; state: string };
+type Batch = {
+  results: TaskResult[];
+  events: { name: string; event: string }[];
+};
+type Checkpoint = { batches: Batch[]; completed: TaskResult[]; pendingDelays: number[] };
+type Observation = {
+  checkpoints: [before: Checkpoint, afterFirstCallback: Checkpoint, afterRearm?: Checkpoint];
+  final: Checkpoint;
+  drained: Checkpoint;
+  fileStates: string[];
+};
+
+const fixture = fileURLToPath(
+  new URL("../fixtures/vitest-runner-task-updates.mjs", import.meta.url),
+);
+const finished = { name: "completed case", event: "test-finished" };
+
+describe("Vitest runner trailing task updates", () => {
+  it.each([
+    { timing: "at the exact 100 ms deadline", firstFireAt: 100 },
+    { timing: "after an early 99 ms callback rearms", firstFireAt: 99 },
+    { timing: "after a late 101 ms callback", firstFireAt: 101 },
+  ])("delivers actual task completion $timing without later task events", ({ firstFireAt }) => {
+    const child = spawnSync(process.execPath, [fixture, String(firstFireAt)], {
+      encoding: "utf8",
+      timeout: 5_000,
+      killSignal: "SIGKILL",
+    });
+    expect(child.error, child.stderr).toBeUndefined();
+    expect(child.status, child.stderr).toBe(0);
+    const observation: Observation = JSON.parse(child.stdout);
+    const [before, firstCallback, afterRearm] = observation.checkpoints;
+    const trailing = afterRearm ?? firstCallback;
+
+    expect(before.completed).toEqual([{ name: "completed case", state: "pass" }]);
+    expect(before.batches.flatMap((batch) => batch.events)).not.toContainEqual(finished);
+    expect(trailing.completed).toEqual(before.completed);
+    expect(trailing.batches.flatMap((batch) => batch.events)).toContainEqual(finished);
+    expect(trailing.batches.flatMap((batch) => batch.results)).toContainEqual({
+      name: "completed case",
+      state: "pass",
+    });
+    expect(trailing.pendingDelays).toEqual([]);
+    if (firstFireAt < 100) {
+      expect(firstCallback.batches).toEqual(before.batches);
+      expect(firstCallback.pendingDelays).toEqual([100]);
+    }
+
+    expect(observation.fileStates).toEqual(["pass"]);
+    expect(observation.final.completed).toEqual([
+      { name: "completed case", state: "pass" },
+      { name: "independent next case", state: "pass" },
+    ]);
+    expect(
+      observation.final.batches
+        .flatMap((batch) => batch.events)
+        .filter((event) => event.name === finished.name && event.event === finished.event),
+    ).toEqual([finished]);
+    expect(observation.drained.batches).toEqual(observation.final.batches);
+    expect(observation.drained.pendingDelays).toEqual([]);
+  });
+});


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/131448 (the separate, already-landed reporter-selection fix).
Upstream context: https://github.com/vitest-dev/vitest/pull/8121 (trailing updates must flush without another invocation).

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled through this same-repository branch.

</details>

## What Problem This Solves

Resolves a problem where completed Vitest cases can remain unreported until another task update or file-finalization flush. This makes progress in the repository's test/watchdog workflow appear stale even while independent tests continue executing.

This is a reporting-liveness defect, not evidence of ordinary-suite deadlocks, permanent result loss, or a guaranteed 100 ms reporting deadline. It is separate from the verbose-reporter selection fixed in the linked OpenClaw PR.

## Why This Change Was Made

Apply a maintainer-approved temporary pnpm patch pinned to `@vitest/runner@4.1.11`. The timer callback can observe exactly the previous send time plus 100 ms; the original strict comparison rejects the send, while its retained, already-fired timer handle prevents rearming. The patch accepts equality and releases the consumed handle before re-entering the throttle, so an early callback can schedule another attempt.

Keep the existing 100 ms batching interval, immediate-call cancellation, reporter selection, and watchdog timeouts. Add only this exact version/path to the existing patch approval guard. There is no maintained fork, dependency version upgrade, extra heartbeat, runtime monkey-patch, or production test seam. Remove the patch, registration, and guard exception once an upstream fixed version passes the regression.

The dependency runtime delta is **+5/-2 (net +3)**, required to consume and rearm the timer at its owner. OpenClaw runtime code is unchanged; the approval guard is **+1** line. Tests/test support are **+177/-4 (net +173)**. Patch headers and package-manager metadata are not runtime LOC.

## User Impact

Developers get the intended trailing test-progress updates without depending on another test event to wake the sender. Ordinary test execution and final-result flushing are unchanged. There is no Gateway, channel, app, or user-configuration behavior change.

AI-assisted; the dependency source, reproduction, and repair were independently reviewed.

## Evidence

- **Fail-before/pass-after:** the maintained real-runner subprocess regression fails against untouched 4.1.11 at exact 100 ms and at an early 99 ms callback without rearming; the 101 ms control passes. With the patch, all three pass. Both test bodies run independently; no reporter acknowledgement gates execution.
- **Paired adversarial verification:** six fresh Node 24.20.0 processes, identical fixture bytes, identical physical dependency files, and package hashes checked before/after. The original runner misses the automatic flush at 100 ms and cannot rearm at 99 ms; the patched runner delivers once. Both pass at 101 ms. Every test eventually passes and finalization emits no duplicates.
- **Real CLI proof:** 12 passive runs through the repository wrapper and the unmodified built-in verbose reporter after patch installation. Every run reports the first completion before the independent second test ends. No clock/timer instrumentation or acknowledgement loop in this CLI proof; these observations are not a latency SLA or incidence estimate.
- **Package-manager proof:** generated with pnpm 11.22.0. The final zero-context patch passes fresh pnpm and Bun 1.4.0 installations with empty stores; all six timing cases pass and both produce the same verified patched runtime bytes. Zero-context hunks avoid Git treating upstream tab-indented diff context as bad source whitespace; no whitespace exemption is added. The checkout's frozen online reinstall also passes supply-chain checks and applies the final patch. An offline attempt needed online registry metadata and stopped safely. Bun migrates the pnpm lock/workspace metadata only in the disposable proof project; no Bun lockfile is introduced.
- **Focused checkout tests:** all 10 tests passed again after the final patch-format/hash regeneration. Earlier validation corrected the new test's checkpoint tuple typing, then reran its three cases and the root test typecheck successfully.
- **Static validation:** all selected guard/type stages passed, including 94 transient npm package-lock validations. The initial run found the test-only tuple typing error; the corrected root test typecheck plus the remaining full lint and import-cycle stages passed. Import cycles: 0. No full Vitest suite is claimed.
- **Independent review:** fresh pre-commit Codex autoreview completed with no accepted/actionable P0 findings. Exact-head CI and native landing proof will be recorded before merge.
- **Provenance:** the retained trailing-timer path is carried forward from [Vitest PR #8121 — trailing task updates](https://github.com/vitest-dev/vitest/pull/8121), authored by `AriPerkkio` and merged by `sheremet-va` on 2025-06-09 as [7bd11a9](https://github.com/vitest-dev/vitest/commit/7bd11a9b32d413efa47a3262ce9c91606158f2fc). This completes that existing trailing-delivery intent; it is not attributed as a newly introduced OpenClaw regression.

Focused commands:

```bash
node scripts/run-vitest.mjs test/scripts/vitest-runner-task-updates.test.ts test/scripts/check-package-patches.test.ts
```

```bash
pnpm tsgo:test:root
```

```bash
pnpm lint
```

```bash
pnpm check:import-cycles
```

Dependency contract: https://github.com/vitest-dev/vitest/blob/v4.1.11/packages/runner/src/run.ts#L474-L529
