### PR TITLE
chore(ui): record the current Control UI startup baseline

### DIFF
--- a/config/control-ui-startup-budget-baseline.json
+++ b/config/control-ui-startup-budget-baseline.json
@@ -1,5 +1,5 @@
 {
-  "startupJsGzipBytes": 346461,
-  "reason": "standing-grant scope line + grants ledger (#131602); recorded at the CI e2e-lane build (346461 B) — checks-ui and local builds of the same tree measure ~600 B less, beyond the 64 B variance allowance",
+  "startupJsGzipBytes": 347134,
+  "reason": "main drift past the recorded baseline (#131602); recorded at the CI build-artifacts lane (347134 B), which measures ~1.3 KiB above local and checks-ui builds of the same tree",
   "updatedAt": "2026-08-28"
 }


### PR DESCRIPTION
## What Problem This Solves

`build-artifacts` fails on every PR right now, regardless of what it changes:

```
startup JS gzip: 339.0 KiB exceeds 338.9 KiB
startup JS gzip vs baseline: 347134 B (baseline 346461 B + growth allowance 512 B
  = growth limit 346973 B; build-variance allowance 64 B; enforcement limit 347037 B)
```

main has drifted **97 B** past the enforcement limit. I hit this on an unrelated server-side PR ([#132041](https://github.com/openclaw/openclaw/pull/132041)) whose diff touches only `src/config/sessions/**` — no `ui/`, `packages/`, or `src/shared/` files, so nothing that can reach the Control UI bundle.

## Why This Change Was Made

This is the ratchet doing its job after a run of UI feature work — the baseline's recent history is the font pickers (#131275), the mobile drawer (#130319), the mobile topbar (#130318), and the grants ledger (#131602). Each nudged startup JS up, and the accumulated drift finally crossed the line.

The new value is recorded from the **CI** `build-artifacts` measurement (347134 B), not a local build. The same tree measures ~1.3 KiB lighter locally — the exact build variance the previous baseline entry already documented ("checks-ui and local builds of the same tree measure ~600 B less, beyond the 64 B variance allowance"). Recording a local number would leave CI failing.

This is ratchet maintenance, not a budget increase: the hard cap `startupJsGzipBytes: 350 * KIB` (358400 B) is unchanged, and the new baseline leaves **11266 B of headroom** under it.

## User Impact

None. No shipped behaviour changes; this only records the measured size so the performance gate reflects reality.

## Evidence

- Produced with the script's own path: `scripts/check-control-ui-performance.mts --update-baseline --startup-js-bytes 347134 --reason ...`, not a hand-edited file.
- `pnpm ui:build` locally passes with the new baseline: startup JS 337.7 KiB against an enforcement limit of 347710 B, no violations.
- Hard cap untouched at 358400 B; headroom 11266 B.

Worth a separate look: startup JS has grown steadily and the ratchet is now being raised rather than defended. If that trend continues it is worth a real bundle-size pass rather than repeated baseline refreshes.
