### PR TITLE
refactor: share the sealed-service busctl fixture

### DIFF
--- a/scripts/e2e/systemd-sealed-service-definition.sh
+++ b/scripts/e2e/systemd-sealed-service-definition.sh
@@ -32,72 +32,13 @@ install -d -o appuser -g appuser -m 0700 "$state_dir"
 install -d -o root -g root -m 0555 "$unit_dir"
 install -d -o root -g root -m 0755 "$shim_dir"
 install -o root -g root -m 0755 scripts/e2e/lib/doctor-install-switch/shims/systemctl "$shim_dir/systemctl"
-install -o root -g root -m 0755 /dev/stdin "$shim_dir/busctl" <<'BUSCTL'
-#!/usr/bin/env bash
-set -euo pipefail
-
-manager=org.freedesktop.systemd1
-object_path=/org/freedesktop/systemd1/unit/openclaw_2dgateway_2eservice
-actual=("$@")
-expected=(--user --json=short)
-
-reject_invocation() {
-  printf '%s\n' 'Unsupported sealed systemd busctl invocation.' >&2
-  exit 1
-}
-
-case "${actual[2]:-}" in
-  call)
-    expected+=(call "$manager" /org/freedesktop/systemd1 "$manager.Manager" LoadUnit s openclaw-gateway.service)
-    response=manager
-    ;;
-  get-property)
-    case "${actual[5]:-}" in
-      "$manager.Service")
-        expected+=(get-property "$manager" "$object_path" "$manager.Service" ExecStart WorkingDirectory Environment EnvironmentFiles UnsetEnvironment)
-        response=service
-        ;;
-      "$manager.Unit")
-        expected+=(get-property "$manager" "$object_path" "$manager.Unit" FragmentPath DropInPaths NeedDaemonReload LoadState)
-        response=unit
-        ;;
-      *) reject_invocation ;;
-    esac
-    ;;
-  *) reject_invocation ;;
-esac
-
-[[ "${#actual[@]}" -eq "${#expected[@]}" ]] || reject_invocation
-for index in "${!expected[@]}"; do
-  [[ "${actual[$index]}" == "${expected[$index]}" ]] || reject_invocation
-done
-
-case "$response" in
-  manager)
-    printf '%s\n' '{"type":"o","data":["/org/freedesktop/systemd1/unit/openclaw_2dgateway_2eservice"]}'
-    ;;
-  service)
-    printf '%s\n' \
-      '{"type":"a(sasbttttuii)","data":[["/usr/local/bin/node",["/usr/local/bin/node","/app/openclaw.mjs","gateway","--port","18789"],false,0,0,0,0,0,0,0]]}' \
-      '{"type":"s","data":"/app"}' \
-      '{"type":"as","data":["OPENCLAW_GATEWAY_PORT=18789"]}' \
-      '{"type":"a(sb)","data":[["/home/appuser/.openclaw/gateway.systemd.env",false]]}' \
-      '{"type":"as","data":[]}'
-    ;;
-  unit)
-    printf '%s\n' \
-      '{"type":"s","data":"/home/appuser/.config/systemd/user/openclaw-gateway.service"}' \
-      '{"type":"as","data":[]}' \
-      '{"type":"b","data":false}' \
-      '{"type":"s","data":"loaded"}'
-    ;;
-esac
-BUSCTL
+install -o root -g root -m 0755 scripts/e2e/lib/doctor-install-switch/shims/busctl "$shim_dir/busctl"
+install -o root -g root -m 0644 scripts/e2e/lib/doctor-install-switch/shims/systemd-exec-start.mjs "$shim_dir/systemd-exec-start.mjs"
 
 install_sealed_unit() {
   install -o root -g "$1" -m "$2" /dev/stdin "$unit_path" <<'UNIT'
 [Unit]
-Description=OpenClaw Gateway (sealed ownership proof)
+Description=OpenClaw Gateway (umbreon-latest sealed ownership proof)
 [Service]
 ExecStart=/usr/local/bin/node /app/openclaw.mjs gateway --port 18789
 WorkingDirectory=/app

--- a/test/scripts/plugin-sdk-api-diff.test.ts
+++ b/test/scripts/plugin-sdk-api-diff.test.ts
@@ -24,10 +24,28 @@ async function waitFor(check: () => boolean, timeoutMs: number): Promise<void> {
 
 describe("Plugin SDK API diff CLI", () => {
   it("interrupts a running child and removes its registered worktree", async () => {
-    const repo = git(process.cwd(), ["rev-parse", "--show-toplevel"]).trim();
+    // Keep revision checkout bounded so startup reaches the child this test cancels.
+    const repo = tempDirs.make("plugin-sdk-api-diff-repo-");
     const runnerTemp = tempDirs.make("plugin-sdk-api-diff-temp-");
     const binDir = tempDirs.make("plugin-sdk-api-diff-bin-");
     const pnpmMarker = join(binDir, "pnpm-started");
+
+    git(repo, ["init", "--quiet", "--initial-branch=main"]);
+    writeFileSync(join(repo, "README.md"), "fixture\n");
+    git(repo, ["add", "README.md"]);
+    git(repo, [
+      "-c",
+      "user.name=Test",
+      "-c",
+      "user.email=test@example.com",
+      "-c",
+      "core.hooksPath=/dev/null",
+      "commit",
+      "--no-gpg-sign",
+      "--quiet",
+      "-m",
+      "fixture",
+    ]);
 
     const fakePnpm = join(binDir, "pnpm");
     writeFileSync(
@@ -54,6 +72,8 @@ describe("Plugin SDK API diff CLI", () => {
           PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}`,
           PNPM_MARKER: pnpmMarker,
           RUNNER_TEMP: runnerTemp,
+          // The fixture owns Git state; the source CLI still needs its workspace aliases.
+          TSX_TSCONFIG_PATH: resolve("tsconfig.json"),
         },
         stdio: ["ignore", "ignore", "pipe"],
       },

--- a/test/scripts/release-telegram-candidate-archive.test.ts
+++ b/test/scripts/release-telegram-candidate-archive.test.ts
@@ -448,7 +448,8 @@ describe("release Telegram candidate archive guard", () => {
   });
 
   it("rejects a socket entry", async () => {
-    const root = tempDirs.make("openclaw-archive-guard-");
+    // Keep the socket path below macOS's 104-byte sockaddr_un buffer.
+    const root = tempDirs.make("sock-");
     const socketPath = path.join(root, "candidate.sock");
     const server = createServer();
     await new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
Related: [the sealed-service ownership repair](https://github.com/openclaw/openclaw/pull/131021), which keeps code updates working with protected service definitions.

## What Problem This Solves

The standalone sealed-systemd package proof maintained its own embedded `busctl` responder even though the doctor install-switch fixture already provides the strict manager contract. That duplicate could drift independently from the shared fixture and production effective-service reader. This finishes the maintainer-requested test-support consolidation previously deferred until fresh package proof was available.

Qualifying the PR also exposed two existing fixture-setup failures: the Plugin SDK cancellation test could time out while preparing revisions of the entire checkout, before its intended child started; a neighboring archive test could not create its Unix socket under macOS's long temporary path. Both are repaired at fixture setup rather than by increasing deadlines or weakening assertions.

## Why This Change Was Made

Install the existing `busctl` executable and adjacent `systemd-exec-start.mjs` parser beside the already-shared `systemctl` fixture. Both remain root-owned; the executable is `0755` and the parser is `0644`. This removes the second responder without a new abstraction. The existing test-unit description uses the requested `umbreon-latest` fixture label; it does not select or call a model.

The cancellation test now supplies a tiny committed Git repository while still invoking the real source CLI with its source TypeScript configuration. Its real package-manager child handshake, registered-worktree checks, SIGTERM, exit `143`, cleanup assertions, and **10s/5s/15s deadlines are unchanged**. The socket test only uses a shorter temporary-directory prefix so its real socket fits macOS's 104-byte `sockaddr_un` buffer; the archive rejection assertion is unchanged. The broader [tooling-stall runtime/planner refactor](https://github.com/openclaw/openclaw/pull/125391) remains separate and was not imported or landed.

All four sealed-service refusal cases, bytes/mode/owner/inode/directory snapshots, token-redaction assertions, both file-mount and both paired-mount cases, budgets, capabilities, cleanup, and lifecycle/trust checks remain intact. No runtime code, CI selector, config option, dependency, or model route changes.

## User Impact

No user-visible runtime change. Maintainers have one fewer systemd emulator to maintain and fixture setup that reaches the behavior under test without depending on repository size or an oversized socket path.

Production LOC: `+0/-0`; tests: `+23/-2` (net +21); test support: `+3/-62` (net -59). Combined PR: **+26/-64, net -38**.

## Evidence

AI-assisted implementation and review. Existing boundary tests are retained; no duplicate test or test-only production seam was added.

### Focused validation and CI repair

```bash
node scripts/run-vitest.mjs test/scripts/docker-build-helper.test.ts test/scripts/upgrade-survivor-systemd.test.ts
```

Passed **210 + 2 tests**. The sealed-service script's bytes are unchanged since this run.

Initial [PR CI run 33213231521](https://github.com/openclaw/openclaw/actions/runs/33213231521/job/98991282316) failed only the Plugin SDK cancellation test in `core-tooling-2`; its child-start wait expired after 10 seconds. The same failure reproduced locally before editing. The fixture revision input shrank from **17,440 tracked paths** in selected source directories to one fixture file; cancellation then passed in **2.305s focused** and **2.452s in the owning-lane replay**, with all deadlines and cleanup assertions unchanged. No claim is made that the precise slow Git subcommand or registry-size contribution was isolated.

A native 67-file replay of the failed lane's file inventory on macOS passed the repaired cancellation case and 1,256 tests, but exposed the separate archive socket setup failure (`EINVAL`, 114-byte path). That replay is not represented as a green run or exact Linux-order reproduction. After the one-line socket-prefix repair, both complete changed test files passed:

```bash
node scripts/run-vitest.mjs test/scripts/plugin-sdk-api-diff.test.ts test/scripts/release-telegram-candidate-archive.test.ts
```

**37 passed, 1 existing GNU-tar-only case skipped on macOS.** The real socket-rejection case ran and passed.

```bash
node scripts/check-changed.mjs -- scripts/e2e/systemd-sealed-service-definition.sh test/scripts/plugin-sdk-api-diff.test.ts test/scripts/release-telegram-candidate-archive.test.ts
```

Passed the complete changed gate. Targeted formatting, shell syntax and `git diff --check` passed. Fresh isolated Codex autoreview of the entire three-file candidate was scoped-clean with no accepted/actionable findings at its default P0 threshold. Final exact-head Linux CI remains the merge gate.

### Fresh package and protected filesystem

Configured backend: **Blacksmith Testbox** (`provider=blacksmith-testbox`, `syncDelegated=true`), [run 33216326947](https://github.com/openclaw/openclaw/actions/runs/33216326947), lease `tbx_01m1579k3knvs4fd246wgm8q7j`.

The native Crabbox wrapper verified the full three-file candidate Git tree `8ed3e2ee2cf6c48d0ee05af4d8fdb7753e214b9a`, rejected inherited package/build-skip/source/budget overrides, and required an absent run-specific image before executing:

```bash
OPENCLAW_SYSTEMD_SEALED_SERVICE_DEFINITION_E2E_IMAGE=openclaw-systemd-sealed-repaired-8ed3e2ee-dpee5l bash scripts/e2e/systemd-sealed-service-definition.sh
```

Observed the canonical helper clean `dist`, build the candidate, write inventory, pack and validate a new tarball, and install that package into a new functional image. Image ID: `sha256:44ea382f8f6fb84eed9f634f6619e5f554791adc441a0aa3227cf4d613df7307`, created `2026-08-28T22:26:16.051744663Z`. Wrapper exit code **0**, elapsed **432.67 seconds**.

- All four unprivileged refusal cases passed without protected writes or token disclosure: missing mode, missing token, missing config, and group-writable/root-owned unit.
- Both **packaged force-install** denials passed against real same-UID read-only file mounts, modes `0400` and `0644`; not kernel-only proof.
- Both paired read-only bind-mount checks passed: matching release accepted, different release rejected.
- The lease was verified **completed** after one-shot cleanup.

An earlier attempt stopped before the scenario because a fresh Testbox already contained the default image tag. It was not counted as passing evidence. Subsequent proof used new leases, absent run-specific image names, and freshly built candidate packages on the same configured provider. No prior qualification image/evidence reuse, provider substitution, increased timeout, weakened assertion, or CI bypass.

The sealed-service scenario remains standalone and unregistered in existing CI selectors, so it was run explicitly rather than treating ordinary CI as package proof. The external Testbox command's terminal `exitCode=0`, exact-tree verification, eight observed outcomes and completed lease are the proof receipt; controller cleanup may cancel the linked Actions controller after the external command finishes.
