### PR TITLE
improve(codex): guard native discovery against model-name restrictions

### DIFF
--- a/extensions/codex/harness.test.ts
+++ b/extensions/codex/harness.test.ts
@@ -239,30 +239,36 @@ describe("Codex agent harness supports()", () => {
     expect(!result.supported ? result.reason : undefined).toContain("not declared");
   });
 
-  it("lets explicitly selected Codex discover unlisted models with its own account", () => {
-    expect(
-      harness.supports({
-        provider: "openai",
-        modelId: "gpt-future",
-        requestedRuntime: "codex",
-        modelProvider: {
-          requestTransportOverrides: "none",
-          preparedAuth: { source: "harness" },
-        },
-      }),
-    ).toEqual({ supported: true, priority: 100 });
-  });
+  it.each(["gpt-future", "umbreon-latest"])(
+    "lets explicitly selected Codex discover %s with its own account",
+    (modelId) => {
+      expect(
+        harness.supports({
+          provider: "openai",
+          modelId,
+          requestedRuntime: "codex",
+          modelProvider: {
+            requestTransportOverrides: "none",
+            preparedAuth: { source: "harness" },
+          },
+        }),
+      ).toEqual({ supported: true, priority: 100 });
+    },
+  );
 
-  it("lets explicit Codex model discovery run before auth has been prepared", () => {
-    expect(
-      harness.supports({
-        provider: "openai",
-        modelId: "gpt-future",
-        requestedRuntime: "codex",
-        modelProvider: { requestTransportOverrides: "none" },
-      }),
-    ).toEqual({ supported: true, priority: 100 });
-  });
+  it.each(["gpt-future", "umbreon-latest"])(
+    "lets explicit Codex discovery of %s run before auth has been prepared",
+    (modelId) => {
+      expect(
+        harness.supports({
+          provider: "openai",
+          modelId,
+          requestedRuntime: "codex",
+          modelProvider: { requestTransportOverrides: "none" },
+        }),
+      ).toEqual({ supported: true, priority: 100 });
+    },
+  );
 
   it.each([
     {


### PR DESCRIPTION
Related: #127322 (native-account discovery for unlisted models), #127394 (discovery before auth preparation).

<details>
<summary>Additional instructions</summary>

Maintainers can update this same-repository branch.

</details>

## What Problem This Solves

The Codex harness's positive native-discovery tests only exercised GPT-shaped model names. A regression that restricted discovery eligibility to a `gpt-` prefix would pass those tests while rejecting opaque model identifiers.

## Why This Change Was Made

Table-drive the two existing discovery cases with `gpt-future` and `umbreon-latest`. The latter is an opaque model-ID fixture that checks eligibility both with harness-owned authentication and before authentication has been prepared. Keep the existing rejection cases for automatic runtime selection, authored endpoints, and owner-selected credentials unchanged.

This strengthens coverage of the existing model-agnostic owner boundary; it does not add a model, change account entitlement, or alter runtime behavior. Codex's supplied-model contract preserves the provided string: [`rust-v0.150.1`, `models-manager/src/manager.rs:153–183`](https://github.com/openai/codex/blob/rust-v0.150.1/codex-rs/models-manager/src/manager.rs#L153).

## User Impact

No user-visible behavior change. The tests now guard native model discovery against accidental model-name prefix restrictions. Production code, model catalogs, configuration, and dependencies are unchanged.

## Evidence

- `node scripts/run-vitest.mjs extensions/codex/harness.test.ts extensions/codex/src/app-server/models.test.ts extensions/codex/src/app-server/model-catalog.test.ts` — 69 tests passed across 3 files.
- `node scripts/check-changed.mjs -- extensions/codex/harness.test.ts` — formatting, extension test types, targeted lint, and selected guards passed.
- Mutation check: temporarily required a `gpt-` prefix at the existing eligibility predicate. Both opaque-ID cases failed while both GPT-shaped cases passed. Removed the mutation and reran the full focused proof above.
- `git diff --check` — passed.
- AI-assisted. Codex autoreview reported no accepted/actionable P0 findings.
- Production LOC: +0/-0. Tests: +30/-24, net +6.

No live inference or UI proof is claimed: this is a test-only change, and the identifiers are test inputs rather than live model probes.
