### PR TITLE
fix: keep CJK compaction summaries within budget

### DIFF
--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -16,6 +16,8 @@ Every model has a context window: the maximum number of tokens it can process. W
 
 OpenClaw keeps assistant tool calls paired with their matching `toolResult` entries when it picks a compaction split point. If the point lands inside a tool block, OpenClaw moves the boundary so the pair stays together and the current unsummarized tail is preserved.
 
+The built-in summarizer accounts for Chinese, Japanese, and Korean (CJK) characters in both message text and tool arguments when estimating chunk sizes. These budgets are approximate; a tool call and its results stay together even when that group exceeds a chunk target.
+
 The full conversation history stays on disk. Compaction only changes what the model sees on the next turn.
 
 <Note>

--- a/src/agents/compaction-partial-summary.test.ts
+++ b/src/agents/compaction-partial-summary.test.ts
@@ -2,35 +2,17 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentMessage } from "./runtime/index.js";
 import type { ExtensionContext } from "./sessions/index.js";
+import { makeAgentAssistantMessage } from "./test-helpers/agent-message-fixtures.js";
 
-const compactionMocks = vi.hoisted(() => {
-  function readText(value: unknown): string {
-    if (typeof value === "string") {
-      return value;
-    }
-    if (Array.isArray(value)) {
-      return value.map(readText).join("");
-    }
-    if (value && typeof value === "object") {
-      const record = value as { text?: unknown; content?: unknown; arguments?: unknown };
-      return `${readText(record.text)}${readText(record.content)}${readText(record.arguments)}`;
-    }
-    return "";
-  }
-  return {
-    estimateTokens: vi.fn((message: unknown) =>
-      Math.max(1, Math.ceil(readText(message).length / 4)),
-    ),
-    generateSummary: vi.fn(),
-    logWarn: vi.fn(),
-  };
-});
+const compactionMocks = vi.hoisted(() => ({
+  generateSummary: vi.fn(),
+  logWarn: vi.fn(),
+}));
 
 vi.mock("./sessions/index.js", async () => {
   const actual = await vi.importActual<typeof import("./sessions/index.js")>("./sessions/index.js");
   return {
     ...actual,
-    estimateTokens: compactionMocks.estimateTokens,
     generateSummary: compactionMocks.generateSummary,
   };
 });
@@ -210,7 +192,10 @@ describe("summarizeChunks partial summary preservation (#82952)", () => {
       // Small message (chunk 1)
       { role: "user", content: "Short question about code", timestamp: 1 },
       // Oversized message (will be in chunk 2, triggers the oversized retry)
-      { role: "assistant", content: "x".repeat(500_000), timestamp: 2 } as unknown as AgentMessage,
+      makeAgentAssistantMessage({
+        content: [{ type: "text", text: "x".repeat(500_000) }],
+        timestamp: 2,
+      }),
       // Small message after oversized (should be recovered by oversized retry)
       { role: "user", content: "Follow-up question", timestamp: 3 },
     ];
@@ -241,7 +226,10 @@ describe("summarizeChunks partial summary preservation (#82952)", () => {
     const mixedMessages: AgentMessage[] = [
       { role: "user", content: "Short question", timestamp: 1 },
       // Oversized message that will be filtered in the retry
-      { role: "assistant", content: "x".repeat(500_000), timestamp: 2 } as unknown as AgentMessage,
+      makeAgentAssistantMessage({
+        content: [{ type: "text", text: "x".repeat(500_000) }],
+        timestamp: 2,
+      }),
       { role: "user", content: "a".repeat(400), timestamp: 3 },
       { role: "user", content: "b".repeat(400), timestamp: 4 },
     ];

--- a/src/agents/compaction-planning-projection.ts
+++ b/src/agents/compaction-planning-projection.ts
@@ -1,4 +1,5 @@
 /** Builds bounded transcript projections for compaction worker planning. */
+import { estimateStringChars } from "@openclaw/normalization-core/cjk-chars";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { AgentMessage } from "./runtime/index.js";
 
@@ -7,6 +8,7 @@ const TEXT_SAMPLE_CHARS = 8_192;
 const PLANNING_MAX_CHARS = 256 * 1024;
 const MAX_ARGUMENT_ESTIMATE_CHARS = 1_000_000;
 const UNMEASURABLE_ARGUMENT_OMITTED_CHARS = Number.MAX_SAFE_INTEGER;
+// Omitted chars use token-estimate weights; payload limits remain raw serialized lengths.
 const OMITTED_CHARS_FIELD = "__openclawCompactionPlanningOmittedChars";
 
 type ProjectionBudget = {
@@ -30,11 +32,15 @@ function projectText(
   budget.remainingChars -= sample.length;
   return {
     text: sample,
-    omittedChars: text.length - sample.length,
+    omittedChars: estimateStringChars(text.slice(sample.length)),
   };
 }
 
-function jsonStringLengthWithin(text: string, maxChars: number): number | undefined {
+function jsonStringLengthWithin(
+  text: string,
+  maxChars: number,
+  estimate: { cjkChars: number },
+): number | undefined {
   let length = 2;
   for (let index = 0; index < text.length; index += 1) {
     const char = text[index] ?? "";
@@ -64,16 +70,18 @@ function jsonStringLengthWithin(text: string, maxChars: number): number | undefi
       return undefined;
     }
   }
+  estimate.cjkChars += estimateStringChars(text) - text.length;
   return length;
 }
 
 function jsonLengthWithin(
   value: unknown,
   maxChars: number,
+  estimate: { cjkChars: number },
   seen = new Set<object>(),
 ): number | undefined {
   if (typeof value === "string") {
-    return jsonStringLengthWithin(value, maxChars);
+    return jsonStringLengthWithin(value, maxChars, estimate);
   }
   if (value === null) {
     return 4;
@@ -91,7 +99,12 @@ function jsonLengthWithin(
   if (Array.isArray(value)) {
     for (const entry of value) {
       const separatorLength = length === 2 ? 0 : 1;
-      const entryLength = jsonLengthWithin(entry, maxChars - length - separatorLength, seen);
+      const entryLength = jsonLengthWithin(
+        entry,
+        maxChars - length - separatorLength,
+        estimate,
+        seen,
+      );
       if (entryLength === undefined) {
         return undefined;
       }
@@ -107,10 +120,11 @@ function jsonLengthWithin(
         continue;
       }
       const separatorLength = length === 2 ? 0 : 1;
-      const keyLength = jsonStringLengthWithin(key, maxChars - length - separatorLength);
+      const keyLength = jsonStringLengthWithin(key, maxChars - length - separatorLength, estimate);
       const entryLength = jsonLengthWithin(
         record[key],
         maxChars - length - separatorLength - (keyLength ?? 0) - 1,
+        estimate,
         seen,
       );
       if (keyLength === undefined || entryLength === undefined) {
@@ -127,16 +141,18 @@ function jsonLengthWithin(
 }
 
 function projectToolArguments(value: unknown, budget: ProjectionBudget): number | undefined {
-  const length = jsonLengthWithin(value, budget.remainingChars);
-  if (length !== undefined) {
+  const estimate = { cjkChars: 0 };
+  const length = jsonLengthWithin(value, MAX_ARGUMENT_ESTIMATE_CHARS, estimate);
+  if (length !== undefined && length <= budget.remainingChars) {
     budget.remainingChars -= length;
     return undefined;
   }
   budget.remainingChars = 0;
   // Unmeasurable arguments must force an oversized plan, never understate token pressure.
-  return (
-    jsonLengthWithin(value, MAX_ARGUMENT_ESTIMATE_CHARS) ?? UNMEASURABLE_ARGUMENT_OMITTED_CHARS
-  );
+  // The replacement {} already contributes two chars to the projected estimate.
+  return length === undefined
+    ? UNMEASURABLE_ARGUMENT_OMITTED_CHARS
+    : length + estimate.cjkChars - 2;
 }
 
 function projectContentBlock(

--- a/src/agents/compaction-planning-worker.test.ts
+++ b/src/agents/compaction-planning-worker.test.ts
@@ -1,7 +1,9 @@
 // Covers the compaction planning worker boundary and timeout behavior.
+import { createAssistantMessageEventStream } from "@openclaw/llm-core";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { serializeConversation } from "openclaw/plugin-sdk/agent-core";
 import { beforeAll, describe, expect, it, vi } from "vitest";
+import { estimateTokens } from "../../packages/agent-core/src/harness/compaction/compaction.js";
 import * as compactionPlanningWorkerRuntime from "./compaction-planning-worker-runtime.js";
 import {
   CompactionPlanningWorkerError,
@@ -13,8 +15,9 @@ import {
   buildSummaryChunksWithWorker,
   computeAdaptiveChunkRatioWithWorker,
 } from "./compaction-planning-worker.js";
-import { estimateMessagesTokens } from "./compaction-planning.js";
+import { buildSummaryChunks, estimateMessagesTokens } from "./compaction-planning.js";
 import { runCompactionPlanningWorkerInput } from "./compaction-planning.worker.js";
+import { summarizeInStages } from "./compaction.js";
 import type { AgentMessage } from "./runtime/index.js";
 import { makeAgentAssistantMessage } from "./test-helpers/agent-message-fixtures.js";
 
@@ -213,25 +216,159 @@ describe("compaction planning worker", () => {
     );
   }, 45_000);
 
-  it("preserves oversized tool-result text in returned summary input", async () => {
-    const hugeText = "x".repeat(120_000);
-    const messages: AgentMessage[] = [
-      {
-        role: "toolResult",
-        toolCallId: "call_large",
-        toolName: "browser",
-        isError: false,
-        content: [{ type: "text", text: hugeText }],
-        timestamp: 1,
+  it.each(
+    [
+      { script: "ASCII", glyph: "x" },
+      { script: "common CJK", glyph: "漢" },
+      { script: "rare BMP CJK", glyph: "㐀" },
+      { script: "supplementary CJK", glyph: "𠀀" },
+    ].flatMap(({ script, glyph }) =>
+      ["text", "arguments"].map((source) => ({ script, glyph, source })),
+    ),
+  )(
+    "preserves $script $source chunk budgets after restoring originals",
+    async ({ glyph, source }) => {
+      const hugeText = glyph.repeat(40_000);
+      const messages: AgentMessage[] =
+        source === "text"
+          ? Array.from({ length: 64 }, (_, index) =>
+              index === 0
+                ? {
+                    role: "toolResult",
+                    toolCallId: "call_large",
+                    toolName: "browser",
+                    isError: false,
+                    content: [{ type: "text", text: hugeText }],
+                    timestamp: 0,
+                  }
+                : makeMessage(index, hugeText),
+            )
+          : Array.from({ length: 32 }, (_, index) => [
+              makeAgentAssistantMessage({
+                content: [
+                  {
+                    type: "toolCall",
+                    id: `call_${index}`,
+                    name: "write",
+                    arguments: { [hugeText]: { nested: [hugeText] } },
+                  },
+                ],
+                stopReason: "toolUse",
+                timestamp: index * 2,
+              }),
+              {
+                role: "toolResult" as const,
+                toolCallId: `call_${index}`,
+                toolName: "write",
+                isError: false,
+                content: [{ type: "text" as const, text: "ok" }],
+                timestamp: index * 2 + 1,
+              },
+            ]).flat();
+      const groupSize = source === "text" ? 1 : 2;
+      const groupTokens = estimateMessagesTokens(messages.slice(0, groupSize));
+      const maxChunkTokens = Math.ceil(groupTokens * 1.75);
+      const chunks = await buildSummaryChunksWithWorker({ messages, maxChunkTokens });
+
+      expect(chunks.map((chunk) => chunk.length)).toEqual(
+        buildSummaryChunks({ messages, maxChunkTokens }).map((chunk) => chunk.length),
+      );
+      expect(chunks).toHaveLength(messages.length / groupSize);
+      expect(Math.max(...chunks.map(estimateMessagesTokens))).toBeLessThanOrEqual(maxChunkTokens);
+      chunks.flat().forEach((message, index) => expect(message).toBe(messages[index]));
+      const fallback = await buildOversizedFallbackPlanWithWorker({
+        messages,
+        contextWindow: maxChunkTokens,
+      });
+      expect(fallback.smallMessages).toEqual([]);
+      expect(fallback.oversizedNotes).toHaveLength(messages.length / groupSize);
+    },
+    45_000,
+  );
+
+  it("summarizes CJK history after ASCII exhausts the worker projection budget", async () => {
+    const model = {
+      id: "gpt-5.6-luna",
+      name: "Synthetic context-limit model",
+      api: "openai-responses",
+      provider: "openai",
+      baseUrl: "https://unused.invalid",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 1_000_000,
+      maxTokens: 8_192,
+    } satisfies Parameters<typeof summarizeInStages>[0]["model"];
+    const markers = Array.from(
+      { length: 64 },
+      (_, index) => `[history-${String(index).padStart(2, "0")}]`,
+    );
+    // The ASCII prefix fills the 256 KiB payload budget. Without weighted omitted
+    // pressure, stage planning keeps all 64 messages and restores an overflowing chunk.
+    const messages = markers.map((marker, index) =>
+      makeMessage(
+        index + 1,
+        index < 32 ? "x".repeat(8_192 - marker.length) + marker : "漢".repeat(40_000) + marker,
+      ),
+    );
+    const inputTokens: number[] = [];
+    const seen = new Set<string>();
+    let omissionNotes = false;
+    const maxChunkTokens = 395_904;
+
+    const summary = await summarizeInStages({
+      messages,
+      model,
+      apiKey: "synthetic-no-credential", // pragma: allowlist secret
+      signal: AbortSignal.timeout(45_000),
+      reserveTokens: 4_096,
+      maxChunkTokens,
+      contextWindow: model.contextWindow,
+      streamFn: (_model, context) => {
+        const tokens = context.messages.reduce(
+          (sum, message) => sum + estimateTokens(message),
+          estimateTokens(makeMessage(0, context.systemPrompt ?? "")),
+        );
+        inputTokens.push(tokens);
+        const text = context.messages
+          .map((message) =>
+            typeof message.content === "string"
+              ? message.content
+              : message.content
+                  .filter((block) => block.type === "text")
+                  .map((block) => block.text)
+                  .join("\n"),
+          )
+          .join("\n");
+        for (const marker of markers) {
+          if (text.includes(marker)) {
+            seen.add(marker);
+          }
+        }
+        omissionNotes ||= /\[Large .*omitted from summary\]|\[Partial summary:/.test(text);
+        if (tokens > model.contextWindow) {
+          throw new Error(`context length exceeded: ${tokens} > ${model.contextWindow}`);
+        }
+        const stream = createAssistantMessageEventStream();
+        stream.push({
+          type: "done",
+          reason: "stop",
+          message: makeAgentAssistantMessage({
+            content: [{ type: "text", text: "Compact summary." }],
+          }),
+        });
+        stream.end();
+        return stream;
       },
-      ...Array.from({ length: 63 }, (_, index) => makeMessage(index + 2)),
-    ];
+    });
 
-    const chunks = await buildSummaryChunksWithWorker({ messages, maxChunkTokens: 8_000 });
-    const returnedMessages = chunks.flat();
-
-    expect(JSON.stringify(returnedMessages)).toBe(JSON.stringify(messages));
-    expect(JSON.stringify(returnedMessages)).toContain(hugeText);
+    expect(summary).toBe("Compact summary.");
+    expect(inputTokens.length).toBeGreaterThan(0);
+    expect(Math.max(...inputTokens)).toBeLessThanOrEqual(model.contextWindow);
+    expect(Math.max(...inputTokens)).toBeLessThanOrEqual(maxChunkTokens);
+    expect([...seen].toSorted()).toEqual(markers.toSorted());
+    expect(omissionNotes).toBe(false);
+    expect(summary).not.toMatch(/\[Large .*omitted from summary\]|\[Partial summary:/);
   }, 45_000);
 
   it("plans summary chunks for worker input", () => {

--- a/src/agents/compaction-planning.ts
+++ b/src/agents/compaction-planning.ts
@@ -3,6 +3,7 @@
  * token usage, chooses chunking strategy, and preserves active tool-use pairs
  * while splitting history for summaries.
  */
+import { estimateTokens } from "../../packages/agent-core/src/harness/compaction/compaction.js";
 import { createToolCallOccurrenceQueue } from "../../packages/agent-core/src/harness/session/tool-result-pairing.js";
 import {
   projectCompactionPlanningMessages,
@@ -11,7 +12,6 @@ import {
 import { stripRuntimeContextCustomMessages } from "./internal-runtime-context.js";
 import type { AgentMessage } from "./runtime/index.js";
 import { repairToolUseResultPairing, stripToolResultDetails } from "./session-transcript-repair.js";
-import { estimateTokens } from "./sessions/index.js";
 import { extractToolCallsFromAssistant, extractToolResultId } from "./tool-call-id.js";
 
 /** Default share of context window targeted for compaction chunks. */

--- a/src/agents/compaction.summarize-fallback.test.ts
+++ b/src/agents/compaction.summarize-fallback.test.ts
@@ -8,7 +8,6 @@ import { summarizeWithFallback } from "./compaction.test-support.js";
 
 const agentSessionMocks = vi.hoisted(() => ({
   generateSummary: vi.fn(),
-  estimateTokens: vi.fn((_message: unknown) => 100),
 }));
 
 vi.mock("openclaw/plugin-sdk/agent-sessions", async () => {
@@ -18,7 +17,6 @@ vi.mock("openclaw/plugin-sdk/agent-sessions", async () => {
   return {
     ...actual,
     generateSummary: agentSessionMocks.generateSummary,
-    estimateTokens: agentSessionMocks.estimateTokens,
   };
 });
 
@@ -27,7 +25,6 @@ vi.mock("./sessions/index.js", async () => {
   return {
     ...actual,
     generateSummary: agentSessionMocks.generateSummary,
-    estimateTokens: agentSessionMocks.estimateTokens,
   };
 });
 
@@ -45,8 +42,6 @@ describe("summarizeWithFallback", () => {
     agentSessionMocks.generateSummary.mockRejectedValue(
       new Error("Summarization failed: fetch failed"),
     );
-    agentSessionMocks.estimateTokens.mockReset();
-    agentSessionMocks.estimateTokens.mockImplementation(() => 100);
   });
 
   it("throws CompactionError when all summarization attempts fail", async () => {
@@ -198,14 +193,6 @@ describe("summarizeWithFallback", () => {
   it("throws CompactionError when both full and partial summarization fail", async () => {
     // Oversized-message fallback tries the safe subset so a huge attachment or
     // tool output does not prevent summarizing the rest of the transcript.
-    agentSessionMocks.estimateTokens.mockImplementation((message: unknown) => {
-      const content =
-        typeof (message as { content?: unknown }).content === "string"
-          ? (message as { content: string }).content
-          : "";
-      return content.length > 10_000 ? 500_000 : 100;
-    });
-
     const messages: AgentMessage[] = [
       {
         role: "user",

--- a/src/agents/compaction.token-sanitize.test.ts
+++ b/src/agents/compaction.token-sanitize.test.ts
@@ -1,63 +1,14 @@
 // Verifies compaction token planning strips private/non-model fields first.
 import { serializeConversation, type AgentMessage } from "openclaw/plugin-sdk/agent-core";
-import { describe, expect, it, vi } from "vitest";
-
-const agentSessionMocks = vi.hoisted(() => ({
-  estimateTokens: vi.fn((_message: unknown) => 1),
-  generateSummary: vi.fn(async () => "summary"),
-}));
-
-vi.mock("openclaw/plugin-sdk/agent-sessions", async () => {
-  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/agent-sessions")>(
-    "openclaw/plugin-sdk/agent-sessions",
-  );
-  return {
-    ...actual,
-    estimateTokens: agentSessionMocks.estimateTokens,
-    generateSummary: agentSessionMocks.generateSummary,
-  };
-});
-
+import { describe, expect, it } from "vitest";
 import {
-  buildStageSplitPlan,
-  buildSummaryChunks,
+  buildOversizedFallbackPlan,
   estimateMessagesTokens,
   projectCompactionMessagesForPlanning,
-  sanitizeCompactionMessages,
 } from "./compaction-planning.js";
+import { makeAgentAssistantMessage } from "./test-helpers/agent-message-fixtures.js";
 
 describe("compaction token accounting sanitization", () => {
-  it("does not pass toolResult.details into per-message token estimates", () => {
-    // details can contain raw tool payloads or private diagnostics; token
-    // estimates should account only for model-visible message content.
-    const messages: AgentMessage[] = [
-      {
-        role: "toolResult",
-        toolCallId: "call_1",
-        toolName: "browser",
-        isError: false,
-        content: [{ type: "text", text: "ok" }],
-        details: { raw: "x".repeat(50_000) },
-        timestamp: 1,
-      } as AgentMessage,
-      {
-        role: "user",
-        content: "next",
-        timestamp: 2,
-      },
-    ];
-
-    buildStageSplitPlan({ messages, maxChunkTokens: 0, parts: 2, minMessagesForSplit: 2 });
-    buildSummaryChunks({ messages, maxChunkTokens: 16 });
-
-    const calledWithDetails = agentSessionMocks.estimateTokens.mock.calls.some((call) => {
-      const message = call[0] as { details?: unknown } | undefined;
-      return Boolean(message?.details);
-    });
-
-    expect(calledWithDetails).toBe(false);
-  });
-
   it("projects worker inputs to planning-safe messages before cloning", () => {
     // Worker input is cloned across threads, so sanitize before clone to remove
     // hidden runtime context and oversized diagnostic details.
@@ -84,15 +35,22 @@ describe("compaction token accounting sanitization", () => {
       },
     ];
 
-    const sanitized = sanitizeCompactionMessages(messages);
+    const sanitized = projectCompactionMessagesForPlanning(messages);
 
+    expect(estimateMessagesTokens(messages)).toBe(estimateMessagesTokens(sanitized));
     expect(sanitized[0]).not.toHaveProperty("details");
     expect(sanitized.map((message) => message.role)).toEqual(["toolResult", "user"]);
   });
 
-  it("bounds oversized tool-result text before worker cloning while preserving token pressure", () => {
-    const hugeText = "x".repeat(120_000);
+  it.each([
+    { script: "ASCII", glyph: "x" },
+    { script: "common CJK", glyph: "漢" },
+    { script: "rare BMP CJK", glyph: "㐀" },
+    { script: "supplementary CJK", glyph: "𠀀" },
+  ])("bounds $script text and arguments without losing token pressure", ({ glyph }) => {
+    const hugeText = glyph.repeat(40_000);
     const messages: AgentMessage[] = [
+      { role: "user", content: hugeText, timestamp: 0 },
       {
         role: "toolResult",
         toolCallId: "call_1",
@@ -100,18 +58,52 @@ describe("compaction token accounting sanitization", () => {
         isError: false,
         content: [{ type: "text", text: hugeText }],
         timestamp: 1,
-      } satisfies AgentMessage,
+      },
+      makeAgentAssistantMessage({
+        content: [{ type: "thinking", thinking: hugeText, thinkingSignature: hugeText }],
+      }),
+      // Fill the payload budget so even small later JSON values must be projected.
+      ...Array.from({ length: 8 }, (_, timestamp) => ({
+        role: "user" as const,
+        content: "x".repeat(32_768),
+        timestamp: timestamp + 2,
+      })),
+      ...[hugeText, "small"].map((text) =>
+        makeAgentAssistantMessage({
+          content: [
+            {
+              type: "toolCall",
+              id: "call_args",
+              name: "write",
+              arguments: { [text]: { nested: [text, '\n"\\\ud800'] } },
+            },
+          ],
+        }),
+      ),
     ];
 
     const projected = projectCompactionMessagesForPlanning(messages);
-    const originalJson = JSON.stringify(messages);
     const projectedJson = JSON.stringify(projected);
-
-    expect(projectedJson.length).toBeLessThan(originalJson.length / 4);
+    expect(projectedJson.length).toBeLessThan(280_000);
+    expect(projectedJson.length).toBeLessThan(JSON.stringify(messages).length);
     expect(projectedJson).not.toContain(hugeText);
-    expect(estimateMessagesTokens(projected)).toBeGreaterThanOrEqual(
-      estimateMessagesTokens(messages),
-    );
+    expect(projectedJson).not.toContain("thinkingSignature");
+    for (const [index, message] of messages.entries()) {
+      const tokens = estimateMessagesTokens([message]);
+      const projectedTokens = estimateMessagesTokens([projected[index]!]);
+      expect(projectedTokens).toBeGreaterThanOrEqual(tokens);
+      // Independently rounded retained and omitted estimates can add one token.
+      expect(projectedTokens).toBeLessThanOrEqual(tokens + 1);
+      for (const contextWindow of [tokens * 2, tokens * 3]) {
+        const direct = buildOversizedFallbackPlan({ messages: [message], contextWindow });
+        const planned = buildOversizedFallbackPlan({
+          messages: [projected[index]!],
+          contextWindow,
+        });
+        expect(planned.oversizedNotes).toEqual(direct.oversizedNotes);
+        expect(planned.smallMessages).toHaveLength(direct.smallMessages.length);
+      }
+    }
   });
 
   it("bounds thinking and nested tool-call arguments before worker cloning", () => {

--- a/src/agents/compaction.tool-result-details.test.ts
+++ b/src/agents/compaction.tool-result-details.test.ts
@@ -6,7 +6,6 @@ import { makeAgentAssistantMessage } from "./test-helpers/agent-message-fixtures
 
 const agentSessionMocks = vi.hoisted(() => ({
   generateSummary: vi.fn(async () => "summary"),
-  estimateTokens: vi.fn((_message: unknown) => 1),
 }));
 
 vi.mock("./sessions/index.js", async () => {
@@ -14,7 +13,6 @@ vi.mock("./sessions/index.js", async () => {
   return {
     ...actual,
     generateSummary: agentSessionMocks.generateSummary,
-    estimateTokens: agentSessionMocks.estimateTokens,
   };
 });
 
@@ -53,8 +51,6 @@ describe("compaction toolResult details stripping", () => {
   beforeEach(() => {
     agentSessionMocks.generateSummary.mockReset();
     agentSessionMocks.generateSummary.mockResolvedValue("summary");
-    agentSessionMocks.estimateTokens.mockReset();
-    agentSessionMocks.estimateTokens.mockImplementation((_message: unknown) => 1);
   });
 
   it("does not pass toolResult.details into generateSummary", async () => {
@@ -121,7 +117,11 @@ describe("compaction toolResult details stripping", () => {
   });
 
   it("does not pass runtime-context custom messages into generateSummary", async () => {
-    const messages = [
+    const assistant = makeAgentAssistantMessage({
+      content: [{ type: "text", text: "visible answer" }],
+      timestamp: 3,
+    });
+    const messages: AgentMessage[] = [
       { role: "user", content: "visible ask", timestamp: 1 },
       {
         role: "custom",
@@ -130,8 +130,8 @@ describe("compaction toolResult details stripping", () => {
         display: false,
         timestamp: 2,
       },
-      { role: "assistant", content: "visible answer", timestamp: 3 },
-    ] as unknown as AgentMessage[];
+      assistant,
+    ];
 
     await summarizeWithFallback({
       messages,
@@ -149,7 +149,7 @@ describe("compaction toolResult details stripping", () => {
     )[0]?.[0];
     expect(chunk).toStrictEqual([
       { role: "user", content: "visible ask", timestamp: 1 },
-      { role: "assistant", content: "visible answer", timestamp: 3 },
+      assistant,
     ]);
     const serialized = JSON.stringify(chunk);
     expect(serialized).toContain("visible ask");
@@ -158,11 +158,6 @@ describe("compaction toolResult details stripping", () => {
   });
 
   it("ignores toolResult.details when estimating compaction tokens", () => {
-    agentSessionMocks.estimateTokens.mockImplementation((message: unknown) => {
-      const record = message as { details?: unknown };
-      return record.details ? 10_000 : 10;
-    });
-
     const toolResult: ToolResultMessage<{ raw: string }> = {
       role: "toolResult",
       toolCallId: "call_1",


### PR DESCRIPTION
Closes #132037 — compaction worker projection loses CJK token pressure.

## What Problem This Solves

Fixes an issue where users compacting large Chinese, Japanese, or Korean conversations could get oversized summary requests even though OpenClaw's planner considered the chunks in budget. Large CJK tool-call arguments were affected too. The bounded worker projection discarded the canonical estimator's CJK weights, then restored the original messages into underbudgeted chunks.

## Why This Change Was Made

Preserve canonical weighted pressure where the projection omits text, argument keys, and argument values, while keeping the separate 262,144-character text/argument projection budget and bounded JSON traversal. Reuse the existing estimator rather than adding a tokenizer, larger safety margin, downstream correction, or provider special case; subtract the replacement `{}` so omitted arguments are not counted twice.

The planner also imports that same pure estimator directly instead of loading the session/provider runtime barrel in each worker. Function-identity checks and real-worker benchmarks confirmed this removes unnecessary initialization without changing estimation policy. Tool-call/result grouping and original-message restoration remain unchanged.

Production: **+27/-11, net +16**. The growth separates raw serialized length from weighted pressure in the existing bounded JSON walker; full `JSON.stringify` would discard its bounded/cyclic-input contract. Tests: **+230/-131, net +99**. Docs: **+2/-0**. No new configuration, public API, dependency, persistence/schema, native Codex, or provider checkpoint behavior.

## User Impact

CJK-heavy histories and tool arguments retain their estimated pressure across the worker boundary, so the built-in summarizer chooses appropriately sized chunks instead of restoring unexpectedly oversized requests. ASCII accounting, images, cancellation, and atomic tool groups keep their existing behavior. These remain approximate budgets, not exact vendor tokenizer counts; an indivisible tool group can legitimately exceed a chunk target.

Documentation: https://docs.openclaw.ai/concepts/compaction

## Evidence

### Before and after

Before changing production, the projection tests failed in all three intended Unicode cases and the real-worker suite failed in all six CJK text/argument cases; ASCII and lifecycle controls passed. A 64-message common-CJK case restored 200,000 estimated tokens into a 70,000-token target. The repaired tests compare actual restored chunks with synchronous planning and preserve original message identity.

A separate real `summarizeInStages` consumer probe uses 32 ASCII messages that exhaust the 256 KiB projection budget, followed by 32 CJK messages. With a synthetic 1M-context model, the old producer estimated 385,632 tokens instead of 1,345,632 and sent an overflowing 1,106,110-token prompt three times. The candidate split the history, kept the largest provider input at 320,504 estimated tokens, delivered all 64 history markers, and produced a summary without omission fallback. Both consumer variants used the direct estimator import to isolate the old/new projection; the nine baseline Vitest failures provide unchanged-production regression evidence. No external model or exact tokenizer claim is made.

### Focused local validation

- `node scripts/run-vitest.mjs src/agents/compaction.token-sanitize.test.ts src/agents/compaction-planning-worker.test.ts src/agents/compaction.test.ts` — 65 passed.
- `node scripts/run-vitest.mjs src/agents/compaction-planning-worker.test.ts` — final 30-test rerun passed after a test-fixture lint correction.
- `corepack pnpm build` — passed; ordinary third-party eval warnings only.
- `node scripts/check-changed.mjs -- docs/concepts/compaction.md src/agents/compaction-planning.ts src/agents/compaction-planning-projection.ts src/agents/compaction-planning-worker.test.ts src/agents/compaction.token-sanitize.test.ts src/agents/compaction-partial-summary.test.ts src/agents/compaction.summarize-fallback.test.ts src/agents/compaction.tool-result-details.test.ts` — final eight-file gate passed, including core/core-test types, formatting, lint, dead exports, and import-cycle guards.
- `node scripts/run-vitest.mjs src/agents/compaction-partial-summary.test.ts src/agents/compaction.failure-proof.test.ts src/agents/compaction.identifier-preservation.test.ts src/agents/compaction.summarize-fallback.test.ts src/agents/compaction.tool-result-details.test.ts` — 38 additional sibling tests passed. Together with the original focused run, 103 distinct tests passed.
- Fresh isolated Codex autoreview of the complete eight-file candidate after CI repair — exit 0, no accepted/actionable P0 findings; lower priorities were excluded by the configured threshold.

The [first exact-head CI run](https://github.com/openclaw/openclaw/actions/runs/33214057058) failed two older oversized-fallback tests (and the aggregate gate). Both failures reproduced locally as 2 failed / 7 passed. Their assistant fixtures cast string content into an assistant message, hidden by a fake estimator that tolerated the invalid shape. The fixtures now use canonical assistant text blocks, and obsolete estimator mocks are removed from three sibling suites. The same nine tests and all 38 sibling tests pass with unchanged fallback assertions; this follow-up removes 30 test lines and changes no production bytes. The [final-head CI run](https://github.com/openclaw/openclaw/actions/runs/33215586074) passed for `288c97b064b20f35e4e3703ac2a3f3b2b6cd6683`, including the previously failing shard.

The [latest ClawSweeper review](https://github.com/openclaw/openclaw/pull/132145#issuecomment-5458185848), refreshed on the final head at 22:16 UTC, found no code or security findings. Its three before-merge items are addressed: exact-head CI is green, and the +16 production lines preserve separate weighted pressure and bounded raw-size accounting as explained above, while removing the duplicate traversal.

The first candidate runs hit unchanged 30s/45s worker deadlines while booting the broad runtime barrel. No deadlines were raised. Alternating fresh-process source-worker measurements on Node 26/macOS were 16.63–17.00s and 718,736–754,480 KiB maximum process RSS before, versus 1.05–2.81s and 237,056–237,968 KiB after, with identical plans. This is source-worker startup evidence, not a packaged production speed claim.

### Packaged Gateway proof

**PASS** on Linux Node 24.19.0 / pnpm 11.22.0, using `blacksmith-testbox`, lease `tbx_01m1542jg13xw2reys2crwarzd`, [hosted run 33212319732](https://github.com/openclaw/openclaw/actions/runs/33212319732). Built with `OPENCLAW_BUILD_PRIVATE_QA=1 corepack pnpm build`; the candidate-only Gateway scenario ran in 44.3s with exit 0. The lease is stopped.

The actual built Gateway and planning worker used local mock-openai HTTP and qa-channel. An ordinary channel turn created the session, the public SQLite SessionManager seeded a synthetic active branch without discarding the warm-up DAG, and the real `sessions.compact({key})` RPC summarized 64 messages with default safeguard and quality auditing. The observed worker split was 47+17 at the configured 1M summary context and 395,904 chunk target. All 64 markers reached the provider exactly once across six history requests plus one merge, with no retry/omission fallback. Actual input estimates were `306274, 320832, 40782, 320652, 320843, 40783, 916`.

SQLite contained one real safeguard summary and one count increment. The next ordinary channel reply used that persisted summary and retained tail, delivered `CJK_FOLLOWUP_OK`, and finished `done` in the same session and route. The session projection exposed no lifecycle revision; no non-null generation claim is made. All owned services stopped, temporary Gateway state was removed, and all three ports refused connections.

```json
{"verdict":"PASS","runtime":"openclaw","provider":"mock-openai","channel":"qa-channel","manualRpc":"sessions.compact","summaryContextTokens":1000000,"chunkTarget":395904,"workerSplit":[47,17],"summaryRequests":7,"historyMarkers":64,"eachMarkerExactlyOnce":true,"maxInputEstimate":320843,"compactionCount":1,"followupDelivered":true,"terminalStatus":"done","sameSessionAndRoute":true,"ownedCleanupPassed":true}
```

Source snapshot `ba7771883dd11568f7f1efc112894a44404d1ced` is the Testbox sync commit over parent `54f0322557d38123febe934b482e019e16758511`; both repaired production hashes match the reviewed candidate. The parent built that synced tree, and the driver checked 4,060 built-file hashes remained unchanged during the flow. Driver SHA-256: `4a8cca1b5e6124f0f932333815f84e512c313e5d984ad45f617ae81fcfdc9873`.

Earlier driver attempts failed before compaction because of a JSDoc false positive in its import scan, concurrent source/built module loading, an unlinked private-package specifier, and retired route-field lookup. Those were corrected in the temporary proof driver; no production workaround, increased deadline, disabled quality guard, or relaxed budget assertion was used. The final verdict is from the canonical delivery record and exact built entry points.

Proof limits: synthetic summaries verify complete input delivery, persistence, and continuation—not semantic fidelity or exact vendor tokenization. This is a built source Gateway with private QA plugins, not a published npm install, external channel/provider, or native Codex proof. No real credentials or operator state were used.

### Scope and provenance

The projection came from #112593 — bounded worker planning — and the canonical CJK estimator from #114386 — CJK-aware token accounting. This is the remaining producer-boundary mismatch, not a replacement for #103930 — the earlier core CJK estimator issue. The current owner/consumer files remain unchanged on inspected main. The known local containing version tags are betas; this PR does not assert a stable-release regression.

AI-assisted audit and repair. No transcripts or credential-bearing artifacts included.
