### PR TITLE
fix(ui): dashboard widgets fill mobile width

### DIFF
--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -1178,7 +1178,7 @@ function buildConfigMocks(options: { swarmEnabled?: boolean; workboardEnabled?: 
   };
 }
 
-function buildWorkboardMocks(baseTime: number) {
+function buildWorkboardMocks(baseTime: number, approval = false) {
   const boardId = "peter-tasks";
   const card = (
     id: string,
@@ -1233,34 +1233,61 @@ function buildWorkboardMocks(baseTime: number) {
         sessionKey,
         revision: 1,
         tabs: [{ tabId: "main", title: "Workboard", position: 0, chatDock: "hidden" }],
-        widgets: [
-          {
-            name: "session-progress",
-            tabId: "main",
-            title: "Session progress",
-            contentKind: "plugin",
-            pluginKind: "session:progress",
-            sizeW: 6,
-            sizeH: 5,
-            position: 0,
-            grantState: "none",
-            revision: 1,
-          },
-          {
-            name: "workboard-product-operations",
-            tabId: "main",
-            title: "Product Operations",
-            contentKind: "plugin",
-            pluginKind: "workboard:board",
-            props: { boardId },
-            heightMode: "fixed",
-            sizeW: 12,
-            sizeH: 16,
-            position: 1,
-            grantState: "none",
-            revision: 1,
-          },
-        ],
+        widgets: approval
+          ? [
+              {
+                name: "approval-request",
+                tabId: "main",
+                title: "Production access",
+                contentKind: "html",
+                sizeW: 6,
+                sizeH: 4,
+                position: 0,
+                grantState: "pending",
+                declared: { netOrigins: ["https://api.example.test"] },
+                revision: 1,
+              },
+              {
+                name: "session-progress",
+                tabId: "main",
+                title: "Session progress",
+                contentKind: "plugin",
+                pluginKind: "session:progress",
+                sizeW: 12,
+                sizeH: 5,
+                position: 1,
+                grantState: "none",
+                revision: 1,
+              },
+            ]
+          : [
+              {
+                name: "session-progress",
+                tabId: "main",
+                title: "Session progress",
+                contentKind: "plugin",
+                pluginKind: "session:progress",
+                sizeW: 6,
+                sizeH: 5,
+                position: 0,
+                grantState: "none",
+                revision: 1,
+              },
+              {
+                name: "workboard-product-operations",
+                tabId: "main",
+                title: "Product Operations",
+                contentKind: "plugin",
+                pluginKind: "workboard:board",
+                props: { boardId },
+                heightMode: "fixed",
+                sizeW: 12,
+                sizeH: 16,
+                position: 1,
+                grantState: "none",
+                revision: 1,
+              },
+            ],
       },
       "workboard.boards.list": { boards: [board] },
       "workboard.cards.list": { boards: [board], cards, statuses },
@@ -1699,7 +1726,8 @@ async function createChatPickerScenario(
           }),
         ]
       : [];
-  const workboardMocks = buildWorkboardMocks(baseTime);
+  const dashboardFixture = fixture === "workboard" || fixture === "approval";
+  const workboardMocks = buildWorkboardMocks(baseTime, fixture === "approval");
   const activityTime = Date.now();
   const activitySessions = buildActivitySessionRows(activityTime);
   const activeGoal = {
@@ -1718,7 +1746,7 @@ async function createChatPickerScenario(
   };
   const sessions = [
     ...activitySessions,
-    ...(fixture === "workboard"
+    ...(dashboardFixture
       ? [
           sessionRow(workboardMocks.sessionKey, "Product operations dashboard", baseTime, {
             boardFace: "dashboard",
@@ -2041,7 +2069,7 @@ async function createChatPickerScenario(
       "system.info",
       "terminal.open",
       ...(updateFixture ? ["update.hold", "update.run", "update.status"] : []),
-      ...(fixture === "workboard"
+      ...(dashboardFixture
         ? [
             "board.get",
             "workboard.boards.list",
@@ -3002,7 +3030,7 @@ async function createChatPickerScenario(
         ],
       },
       "sessions.search": { results: [] },
-      ...(fixture === "workboard" ? workboardMocks.methodResponses : {}),
+      ...(dashboardFixture ? workboardMocks.methodResponses : {}),
     },
     models: modelProviders.models,
     repeatingSessionEvents: {
@@ -3069,7 +3097,7 @@ async function createChatPickerScenario(
       ],
     },
     sessionArchiveFiltering: true,
-    sessionKey: fixture === "workboard" ? workboardMocks.sessionKey : "agent:main:main",
+    sessionKey: dashboardFixture ? workboardMocks.sessionKey : "agent:main:main",
     workspace: "/Users/peter/Projects/openclaw",
     workspaceGit: true,
   };

--- a/ui/src/components/board/board-view.browser.test.ts
+++ b/ui/src/components/board/board-view.browser.test.ts
@@ -89,6 +89,19 @@ describe.skipIf(!hasBrowserLayout)("openclaw-board-view browser layout", () => {
     expect(Math.round(first?.height ?? 0)).toBe(BOARD_GRID_ROW_HEIGHT * 3 + BOARD_GRID_GAP * 2);
   });
 
+  it("stacks every widget at full width when the board column is narrow", async () => {
+    const view = await mount();
+    view.style.width = "350px";
+    const grid = view.querySelector<HTMLElement>(".board-grid");
+    const cells = [...view.querySelectorAll<HTMLElement>('[data-test-id="board-widget"]')];
+    const [first, second] = cells.map((cell) => cell.getBoundingClientRect());
+    const gridBounds = grid!.getBoundingClientRect();
+
+    expect(first?.width).toBeCloseTo(gridBounds.width, 0);
+    expect(second?.width).toBeCloseTo(gridBounds.width, 0);
+    expect(second?.top).toBeGreaterThanOrEqual((first?.bottom ?? 0) + BOARD_GRID_GAP - 1);
+  });
+
   it("hides widget chrome by default on fine-pointer devices", async () => {
     const view = await mount();
     const bar = view.querySelector<HTMLElement>(".board-widget__bar");

--- a/ui/src/components/board/board-widget-cell.ts
+++ b/ui/src/components/board/board-widget-cell.ts
@@ -424,7 +424,7 @@ class OpenClawBoardWidgetCell extends OpenClawLightDomElement {
     return html`
       <section
         class=${`board-widget ${this.dragging ? "board-widget--dragging" : ""} ${presentation ? `board-widget--${presentation}` : ""}`}
-        style=${`${toCssPlacement(rect)}${exactHeightStyle}`}
+        style=${`${toCssPlacement(rect)} --board-widget-rows: ${rect.h};${exactHeightStyle}`}
         role="listitem"
         tabindex=${this.focusTabIndex}
         aria-posinset=${this.positionInSet}

--- a/ui/src/styles/board.css
+++ b/ui/src/styles/board.css
@@ -127,12 +127,22 @@ openclaw-board-view {
 }
 
 .board-grid {
+  container-type: inline-size;
   display: grid;
   gap: 12px;
   grid-auto-rows: 56px;
   grid-template-columns: repeat(12, minmax(0, 1fr));
   min-width: 0;
   position: relative;
+}
+
+@container (max-width: 560px) {
+  /* Narrow boards stack every persisted desktop rect. Both axes need an
+     override because adjacent desktop cells can share the same inline row. */
+  .board-widget {
+    grid-column: 1 / -1 !important;
+    grid-row: auto / span var(--board-widget-rows) !important;
+  }
 }
 
 .board-grid__append-zone {


### PR DESCRIPTION
Closes #132147

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users viewing a session dashboard on a narrow mobile viewport would see partial-width widgets compressed against the left edge with a large unused area on the right. A six-column approval widget measured 169px inside a 350px board column at 390x844.

## Why This Change Was Made

Narrow board containers now stack every persisted desktop widget rectangle at full width while preserving its row span. The rule is container-based, so it covers dashboard embeddings and every widget kind without changing desktop sizing or special-casing approval cards.

The mock approval fixture now includes the dashboard state needed to reproduce this layout alongside a full-width sibling.

## User Impact

Mobile dashboard widgets now use the available column width and stack cleanly. Approval controls and other partial-width widgets are easier to read and operate, while desktop multi-column layouts remain unchanged.

## Evidence

### Before

Dark theme, 390x844:

![Half-width approval widget before the fix in dark theme](https://github.com/user-attachments/assets/c68b383f-edc9-4663-8ce4-e2968f3e0a24)

Light theme, 390x844:

![Half-width approval widget before the fix in light theme](https://github.com/user-attachments/assets/147d1c1c-c4c4-4b26-849e-e22d3e761aad)

### After

Dark theme, 390x844:

![Full-width stacked dashboard widgets after the fix in dark theme](https://github.com/user-attachments/assets/536cf26b-12c4-4f98-9c24-78cfb8e4b10a)

Light theme, 390x844:

![Full-width stacked dashboard widgets after the fix in light theme](https://github.com/user-attachments/assets/8e403c0b-1225-47ce-9dc0-f6cb31770fd3)

Observed after the fix in both themes: approval widget 350px, grid 350px, sibling widget 350px, with a 12px vertical gap and no overlap.

Validation:

- `node scripts/check-changed.mjs`
- `node scripts/run-vitest.mjs --config ui/vitest.config.ts --project browser ui/src/components/board/board-view.browser.test.ts`
- `node scripts/run-vitest.mjs ui/src/components/board/board-view-sizing.test.ts ui/src/components/board/board-view.test.ts` (46 tests passed)
- Mocked Control UI visual verification in Chromium at 390x844, dark and light themes
