### PR TITLE
test(codex): cover model identity across native resume

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -6422,10 +6422,10 @@ describe("runCodexAppServerAttempt", () => {
     expect(calledWithFailedClient).toBe(true);
     retireSpy.mockRestore();
   });
-  it("uses the prepared execution model without exposing it in lifecycle events", async () => {
+  it("retains the prepared execution model across native resume without exposing it in lifecycle events", async () => {
     const { sessionFile, workspaceDir } = createRunPaths();
-    const runtimeModelId = "codex-execution-model";
-    const { requests, waitForMethod, completeTurn } = createStartedThreadHarness(async (method) =>
+    const runtimeModelId = "umbreon-latest";
+    const freshHarness = createStartedThreadHarness(async (method) =>
       method === "thread/start" ? { ...threadStartResult(), model: runtimeModelId } : undefined,
     );
     const params = createParams(sessionFile, workspaceDir);
@@ -6438,21 +6438,54 @@ describe("runCodexAppServerAttempt", () => {
         ...buildCodexRuntimeModelParams("gpt-5.6-sol", runtimeModelId),
       },
     };
-    const onAgentEvent = vi.fn();
-    params.onAgentEvent = onAgentEvent;
+    const onFreshAgentEvent = vi.fn();
+    params.onAgentEvent = onFreshAgentEvent;
 
-    const run = runCodexAppServerAttempt(params, { runtimeModelId });
-    await completeStartedRun(run, waitForMethod, completeTurn);
+    const freshRun = runCodexAppServerAttempt(params, { runtimeModelId });
+    await completeStartedRun(freshRun, freshHarness.waitForMethod, freshHarness.completeTurn);
 
     for (const method of ["thread/start", "turn/start"]) {
-      const request = requests.find((entry) => entry.method === method);
-      const requestParams = request?.params as Record<string, unknown> | undefined;
-      expect(requestParams?.model).toBe(runtimeModelId);
+      expect(freshHarness.requests.find((entry) => entry.method === method)).toMatchObject({
+        params: { model: runtimeModelId },
+      });
     }
-    expect(onAgentEvent).toHaveBeenCalledWith({
-      stream: "codex_app_server.lifecycle",
-      data: expect.objectContaining({ phase: "turn_starting", model: "gpt-5.6-sol" }),
+    await expect(readCodexAppServerBinding(sessionFile)).resolves.toMatchObject({
+      threadId: "thread-1",
+      model: runtimeModelId,
+      clientId: "test-client-1",
     });
+
+    const resumedHarness = createStartedThreadHarness(async (method) =>
+      method === "thread/resume" ? { ...threadStartResult(), model: runtimeModelId } : undefined,
+    );
+    // A different physical client forces native resume instead of warm thread reuse.
+    vi.spyOn(resumedHarness.client, "getInstanceId").mockReturnValue("test-client-2");
+    const onResumedAgentEvent = vi.fn();
+    const resumedRun = runCodexAppServerAttempt(
+      { ...params, runId: "run-2", onAgentEvent: onResumedAgentEvent },
+      { runtimeModelId },
+    );
+    await completeStartedRun(resumedRun, resumedHarness.waitForMethod, resumedHarness.completeTurn);
+
+    expectResumeRequest(resumedHarness.requests, {
+      threadId: "thread-1",
+      model: runtimeModelId,
+    });
+    expect(resumedHarness.requests.map((entry) => entry.method)).not.toContain("thread/start");
+    expect(resumedHarness.requests.find((entry) => entry.method === "turn/start")).toMatchObject({
+      params: { threadId: "thread-1", model: runtimeModelId },
+    });
+    await expect(readCodexAppServerBinding(sessionFile)).resolves.toMatchObject({
+      threadId: "thread-1",
+      model: runtimeModelId,
+      clientId: "test-client-2",
+    });
+    for (const onAgentEvent of [onFreshAgentEvent, onResumedAgentEvent]) {
+      expect(onAgentEvent).toHaveBeenCalledWith({
+        stream: "codex_app_server.lifecycle",
+        data: expect.objectContaining({ phase: "turn_starting", model: "gpt-5.6-sol" }),
+      });
+    }
   });
 
   it("passes configured app-server policy, sandbox, service tier, and model on resume", async () => {


### PR DESCRIPTION
Related: [#126182 — reasoning options and catalog/execution model identity separation](https://github.com/openclaw/openclaw/pull/126182), [#128751 — native binding model ownership](https://github.com/openclaw/openclaw/pull/128751).

<details>
<summary>Additional instructions</summary>

Maintainers can update this same-repository branch.

</details>

## What Problem This Solves

The prepared execution-model test checked fresh Codex threads, but did not read the resulting binding or continue through a native resume when the catalog ID differs from the execution model ID. A resume-only substitution of the catalog ID could therefore leave the original test green.

This is a coverage gap, not a claim that current production behavior is broken.

## Why This Change Was Made

Extend the existing scenario rather than add another fresh-start test. The synthetic execution model `umbreon-latest` now travels through thread start, binding readback, native resume on a replacement client, and the resumed turn. Both lifecycle callbacks must still report the logical catalog identity.

The replacement client has a distinct instance ID so the test actually exercises `thread/resume` instead of warm-thread reuse. Binding reads and writes use the production binding owner with the existing in-memory test backend; no new test-only production seam is introduced.

Checked against the pinned Codex `0.150.1` source: [catalog mapping preserves separate IDs](https://github.com/openai/codex/blob/rust-v0.150.1/codex-rs/app-server/src/models.rs#L27-L30), [resume applies model overrides](https://github.com/openai/codex/blob/rust-v0.150.1/codex-rs/app-server/src/request_processors/thread_processor.rs#L3687-L3700), and [resume returns the effective model](https://github.com/openai/codex/blob/rust-v0.150.1/codex-rs/app-server/src/request_processors/thread_processor.rs#L3932-L3935).

## User Impact

No runtime behavior, supported-model catalog, configuration, or storage-schema changes. The added coverage protects execution-model identity across binding reuse while keeping lifecycle attribution on the catalog model.

Production LOC: **+0/-0**. Tests: **+46/-13** (one existing test extended).

## Evidence

- **452 tests passed** across the changed run-attempt suite and both thread-lifecycle sibling suites.
- The focused prepared-execution-model scenario passed, including an independent final rerun.
- **Mutation proof:** temporarily replaced only the resumed binding's effective model assignment with the catalog ID. The original fresh-only test still passed; the extended test failed because resumed `turn/start` received `gpt-5.6-sol` instead of `umbreon-latest`. The production file was then restored byte-for-byte and the full three-file run passed.
- Scoped formatting, typecheck, lint, and repository guards passed.
- Codex autoreview of the test-only diff: **scoped-clean**, no accepted/actionable findings.

```bash
node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts -t 'prepared execution model'
```

```bash
node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/thread-lifecycle.test.ts extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
```

```bash
node scripts/check-changed.mjs -- extensions/codex/src/app-server/run-attempt.test.ts
```

The app-server is a test double and the binding backend is in-memory. This proves the request/binding owner boundary, not live provider acceptance or SQLite reopening.

AI-assisted.
