### PR TITLE
fix(line): retire the credential a rotation replaces

### DIFF
--- a/extensions/line/src/setup-core.test.ts
+++ b/extensions/line/src/setup-core.test.ts
@@ -4,15 +4,25 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/setup";
 import { describe, expect, it } from "vitest";
 import { lineSetupAdapter, patchLineAccountConfig } from "./setup-core.js";
 
-type LineChannelConfig = { channelAccessToken?: string };
+type LineChannelConfig = {
+  channelAccessToken?: string;
+  channelSecret?: string;
+  tokenFile?: string;
+  secretFile?: string;
+};
 
-function appliedLineConfig(input: Record<string, unknown>): LineChannelConfig {
-  const cfg = lineSetupAdapter.applyAccountConfig({
-    cfg: {} as OpenClawConfig,
-    accountId: "default",
-    input,
-  });
-  return (cfg.channels?.line ?? {}) as LineChannelConfig;
+function applyLineSetup(
+  input: Record<string, unknown>,
+  cfg: OpenClawConfig = {} as OpenClawConfig,
+): OpenClawConfig {
+  return lineSetupAdapter.applyAccountConfig({ cfg, accountId: "default", input });
+}
+
+function appliedLineConfig(
+  input: Record<string, unknown>,
+  cfg?: OpenClawConfig,
+): LineChannelConfig {
+  return (applyLineSetup(input, cfg).channels?.line ?? {}) as LineChannelConfig;
 }
 
 describe("line setup token alias", () => {
@@ -83,5 +93,49 @@ describe("LINE scoped setup config", () => {
       enabled: true,
       channelAccessToken: "new-token",
     });
+  });
+});
+
+describe("LINE credential rotation", () => {
+  // The inline value wins over its file at resolution time, so a rotation that
+  // leaves it behind silently keeps using the credential it was meant to replace.
+  const inlineFirst = () =>
+    applyLineSetup({ channelAccessToken: "inline-token", channelSecret: "inline-secret" });
+
+  it("retires an inline credential when its file replaces it", () => {
+    const rotated = appliedLineConfig(
+      { tokenFile: "/run/secrets/line-token", secretFile: "/run/secrets/line-secret" },
+      inlineFirst(),
+    );
+
+    expect(rotated.tokenFile).toBe("/run/secrets/line-token");
+    expect(rotated.secretFile).toBe("/run/secrets/line-secret");
+    expect(rotated.channelAccessToken).toBeUndefined();
+    expect(rotated.channelSecret).toBeUndefined();
+  });
+
+  it("retires a credential file when an inline value replaces it", () => {
+    const fromFiles = applyLineSetup({
+      tokenFile: "/run/secrets/line-token",
+      secretFile: "/run/secrets/line-secret",
+    });
+
+    const rotated = appliedLineConfig(
+      { channelAccessToken: "inline-token", channelSecret: "inline-secret" },
+      fromFiles,
+    );
+
+    expect(rotated.channelAccessToken).toBe("inline-token");
+    expect(rotated.channelSecret).toBe("inline-secret");
+    expect(rotated.tokenFile).toBeUndefined();
+    expect(rotated.secretFile).toBeUndefined();
+  });
+
+  it("leaves the credential that was not replaced alone", () => {
+    const rotated = appliedLineConfig({ tokenFile: "/run/secrets/line-token" }, inlineFirst());
+
+    expect(rotated.tokenFile).toBe("/run/secrets/line-token");
+    expect(rotated.channelSecret).toBe("inline-secret");
+    expect(rotated.channelAccessToken).toBeUndefined();
   });
 });

--- a/extensions/line/src/setup-core.ts
+++ b/extensions/line/src/setup-core.ts
@@ -79,27 +79,45 @@ export const lineSetupAdapter: ChannelSetupAdapter = {
     const accessToken = typedInput.channelAccessToken ?? typedInput.token;
     const normalizedAccountId = normalizeAccountId(accountId);
     const useEnv = normalizedAccountId === DEFAULT_ACCOUNT_ID && Boolean(typedInput.useEnv);
+    // A credential resolves from the inline value first and only then from its
+    // file, so writing one form has to retire the other. Leaving both behind
+    // makes a rotation onto a file a silent no-op: the stale inline value keeps
+    // winning and setup still reports success.
+    const credentials = [
+      {
+        fileKey: "tokenFile",
+        file: typedInput.tokenFile,
+        inlineKey: "channelAccessToken",
+        inline: accessToken,
+      },
+      {
+        fileKey: "secretFile",
+        file: typedInput.secretFile,
+        inlineKey: "channelSecret",
+        inline: typedInput.channelSecret,
+      },
+    ] as const;
+    const patch: Record<string, string> = {};
+    const retired: string[] = [];
+    for (const credential of credentials) {
+      if (credential.file) {
+        patch[credential.fileKey] = credential.file;
+        retired.push(credential.inlineKey);
+      } else if (credential.inline) {
+        patch[credential.inlineKey] = credential.inline;
+        retired.push(credential.fileKey);
+      }
+    }
     return patchLineAccountConfig({
       cfg,
       accountId: normalizedAccountId,
       enabled: true,
       clearFields: useEnv
         ? ["channelAccessToken", "channelSecret", "tokenFile", "secretFile"]
-        : undefined,
-      patch: useEnv
-        ? {}
-        : {
-            ...(typedInput.tokenFile
-              ? { tokenFile: typedInput.tokenFile }
-              : accessToken
-                ? { channelAccessToken: accessToken }
-                : {}),
-            ...(typedInput.secretFile
-              ? { secretFile: typedInput.secretFile }
-              : typedInput.channelSecret
-                ? { channelSecret: typedInput.channelSecret }
-                : {}),
-          },
+        : retired.length > 0
+          ? retired
+          : undefined,
+      patch: useEnv ? {} : patch,
     });
   },
 };


### PR DESCRIPTION
Fixes #132143

## What Problem This Solves

Rotating a LINE credential from an inline config value onto a credential file did nothing. The CLI reported success and wrote the file path, but the bot kept using the old inline value.

`resolveLineCredential` correctly gives an inline value precedence over its file. The setup adapter caused the bug because it wrote the new form without removing the old form. Both fields then remained, so the stale inline value kept winning.

## Why This Change Was Made

Writing either credential form now retires the other form for that same credential and account. The other credential remains unchanged.

This uses the existing scoped `clearFields` path in `patchLineAccountConfig`. The interactive wizard already uses the same replace-and-clear rule when an inline value replaces a file. The non-interactive adapter was the divergent path.

The two credential pairs use one small table and one loop. This removes duplicated selection logic and keeps token and secret replacement symmetric.

## User Impact

Moving LINE credentials from inline config values to files now takes effect immediately. Existing configs that use only one form do not change. No option, flag, schema, migration, or credential precedence changes.

Production code changes by +33/-15 lines. Tests change by +62/-8 lines.

## Evidence

### Live CLI red and green

I built and identity-checked exact current main `a79e6517be830ad930fc9be36d5cc7536f86089c` and exact PR head `be87736c831eb02fc43c8f5ed4ff75b09569a788` in separate isolated Linux checkouts. Each runtime passed its built CLI version smoke check.

Both runtimes then received the same real non-interactive CLI flow in fresh state:

```sh
openclaw channels add --channel line \
  --channel-access-token INLINE_TOKEN_AAA \
  --channel-secret INLINE_SECRET_AAA

openclaw channels add --channel line \
  --token-file ./token.txt \
  --secret-file ./secret.txt
```

On main, both commands reported success, but config retained all four fields. The resolver returned `tokenSource: config` and `signingSecretSource: config` with both old inline values.

On the PR head, config retained only `tokenFile` and `secretFile`. The resolver returned `tokenSource: file` and `signingSecretSource: file` with both file values.

For the anti-cheat check, I changed both fake file values without another config write. Main still returned both stale inline values. The PR head returned both changed file values.

### Regression and scope checks

The PR test file against exact main production code fails all three rotation cases for the intended stale-field reason:

```text
Tests  3 failed | 4 passed (7)
```

The exact PR head passes the focused test and the complete LINE suite:

```text
Tests  7 passed (7)
Tests  584 passed (584)
```

The changed-file planner selected the LINE plugin boundary. Every permitted formatting, lint, dependency, plugin-boundary, dead-code, database-first, media, runtime-sidecar, import-cycle, and doctor-contract check passed. Hosted CI owns the two typecheck lanes.
