### PR TITLE
docs(line): scope the loading animation to one-to-one chats

### DIFF
--- a/docs/channels/line.md
+++ b/docs/channels/line.md
@@ -180,8 +180,9 @@ as untrusted.
 - Text is chunked at 5000 characters.
 - Markdown formatting is stripped; code blocks and tables are converted into Flex
   cards when possible.
-- Streaming responses are buffered; LINE receives full chunks with a loading
-  animation while the agent works.
+- Streaming responses are buffered; LINE receives full chunks. The loading
+  animation runs only in one-to-one chats — LINE's loading API accepts a user id
+  and rejects group and room ids — so a group reply arrives without one.
 - Media downloads are capped by `channels.line.mediaMaxMb` (default 10).
 - Inbound media is saved under `~/.openclaw/media/inbound/` before it is passed
   to the agent, matching the shared media store used by other channel plugins.


### PR DESCRIPTION
## What Problem This Solves

The LINE channel page promised a loading animation that group chats never get.

The message-behavior list said "Streaming responses are buffered; LINE receives full chunks with a loading animation while the agent works", with no scope on it. In a group the animation never appears, so an operator running a group bot reads this page, sees nothing while the agent thinks, and has no way to tell whether that is a bug in their setup.

## Why This Change Was Made

It is a platform limit, not an OpenClaw defect, so the fix is to say so on the page rather than change behavior. `extensions/line/src/monitor.ts` already gates the call on `ctx.userId && !ctx.isGroup`, which is correct — LINE's loading endpoint only accepts a user id.

I checked that against the live API rather than inferring it from the code, because a doc claim about a provider limit is only worth writing if the limit is real:

```
POST https://api.line.me/v2/bot/chat/loading/start
{ "chatId": "C5aeb18d…", "loadingSeconds": 5 }

HTTP 400 {"message":"The request body has 1 error(s)",
  "details":[{"message":"Only user id is acceptable, please confirm if there are
  any group/room ids or ille…"}]}
```

The wording now names the constraint and its consequence, so the absence of the animation in a group reads as expected behavior instead of a symptom.

## User Impact

Documentation only. No code, no config, no behavior change.

An operator running LINE groups no longer has a documented feature that silently does not apply to them.

## Evidence

The live API response above is the whole basis for the claim; it is quoted in full, including LINE's own error text naming group and room ids as unacceptable.

`node scripts/check-changed.mjs -- docs/channels/line.md` passes, and `git diff --check` is clean.
