### PR TITLE
fix(cli): report failed local agent turns as unsuccessful

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -1146,7 +1146,15 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       resolvedSkills: [],
       version: 0,
     });
-    state.deliverAgentCommandResultMock.mockResolvedValue(undefined);
+    state.deliverAgentCommandResultMock.mockImplementation(
+      async ({
+        result,
+        payloads,
+      }: Parameters<typeof import("./command/delivery.js").deliverAgentCommandResult>[0]) => ({
+        payloads: payloads ?? [],
+        meta: result.meta,
+      }),
+    );
     state.resolveAgentOutboundTargetMock.mockImplementation(
       (params: { plan?: { resolvedTo?: string }; targetMode?: string }) => ({
         resolvedTarget: null,
@@ -3642,7 +3650,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
         deliver: true,
         bestEffortDeliver: true,
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toMatchObject({ payloads: [{ text: "ok" }] });
 
     expect(state.runAgentAttemptMock).toHaveBeenCalled();
     expect(state.deliverAgentCommandResultMock).toHaveBeenCalledWith(
@@ -3665,8 +3673,6 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
         intentId: "intent-1",
       },
     });
-    state.deliverAgentCommandResultMock.mockResolvedValue(undefined);
-
     await agentCommand({
       message: "hello",
       channel: "whatsapp",
@@ -3933,7 +3939,9 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       new Error("database is locked"),
     );
 
-    await expect(runInternalModelCommand("model-run-cleanup-failure")).resolves.toBeUndefined();
+    await expect(runInternalModelCommand("model-run-cleanup-failure")).resolves.toMatchObject({
+      payloads: [{ text: "ok" }],
+    });
 
     expect(state.removeInternalSessionEffectsSessionMock).toHaveBeenCalled();
   });

--- a/src/agents/command/acp-execution.ts
+++ b/src/agents/command/acp-execution.ts
@@ -1,5 +1,6 @@
 import { createLazyAcpElicitationHandler } from "../../auto-reply/reply/acp-elicitation-handler-lazy.js";
 import { resolveInlineAgentImageAttachments } from "../../auto-reply/reply/agent-turn-attachments.js";
+import { recordAgentRunTerminalOutcome } from "../../channels/turn/agent-run-terminal-outcome.js";
 import type { CliDeps } from "../../cli/deps.types.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -13,6 +14,10 @@ import {
   getAdmittedRunDelegatedAuthority,
   type PreparedAgentRunAdmission,
 } from "../admitted-run-context.js";
+import {
+  buildAgentRunTerminalOutcomeFromLifecycleEvent,
+  classifyAgentRunTerminalOutcome,
+} from "../agent-run-terminal-outcome.js";
 import { prepareInternalSessionEffectsSession } from "../internal-session-effects.js";
 import type { AgentRunSessionTarget } from "../run-session-target.js";
 import { isAgentRunRestartAbortReason } from "../run-termination.js";
@@ -313,7 +318,7 @@ export async function runAcpAgentCommand(params: {
     params.opts.abortSignal,
   );
   const { deliverAgentCommandResult } = await loadDeliveryRuntime();
-  return await deliverAgentCommandResult({
+  const deliveryResult = await deliverAgentCommandResult({
     cfg: params.cfg,
     deps: params.deps,
     runtime: params.runtime,
@@ -325,4 +330,14 @@ export async function runAcpAgentCommand(params: {
     assertDeliveryCurrent: () =>
       assertAgentRunLifecycleGenerationCurrent(params.lifecycleGeneration),
   });
+  // Use the owner's status and current signal: delivery may outlive the result snapshot.
+  const outcome = buildAgentRunTerminalOutcomeFromLifecycleEvent({
+    phase: "end",
+    data: { status: resultStatus, stopReason },
+    abortSignal: params.opts.abortSignal,
+  });
+  return recordAgentRunTerminalOutcome(
+    deliveryResult,
+    classifyAgentRunTerminalOutcome(outcome) === "success" ? "completed" : "failed",
+  );
 }

--- a/src/agents/command/post-run.ts
+++ b/src/agents/command/post-run.ts
@@ -1,5 +1,6 @@
 import { getReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
 import type { FollowupRun } from "../../auto-reply/reply/queue.js";
+import { recordAgentRunTerminalOutcome } from "../../channels/turn/agent-run-terminal-outcome.js";
 import type { CliDeps } from "../../cli/deps.types.js";
 import { resolveSessionAuthProfileOverrideSource } from "../../config/sessions/auth-profile-override-provenance.js";
 import { formatSqliteSessionFileMarker } from "../../config/sessions/legacy-sqlite-marker.js";
@@ -18,6 +19,11 @@ import {
   shouldPersistCurrentRunSessionCleanup,
 } from "../agent-command-restart-recovery.js";
 import { normalizeAgentRunTerminalDeliverySnapshot } from "../agent-run-terminal-delivery.js";
+import {
+  buildAgentRunTerminalOutcomeFromLifecycleEvent,
+  classifyAgentRunTerminalOutcome,
+  mergeAgentRunTerminalOutcome,
+} from "../agent-run-terminal-outcome.js";
 import { OPENCLAW_AGENT_RUNTIME_ID } from "../agent-runtime-id.js";
 import { isHeartbeatLifecycleRunKind } from "../bootstrap-mode.js";
 import { persistPendingFinalDeliveryMarker } from "../pending-final-delivery-marker.js";
@@ -25,6 +31,7 @@ import type { AgentRunSessionTarget } from "../run-session-target.js";
 import { throwAgentRunRestartAbortReason } from "../run-termination.js";
 import { persistAssistantTranscriptRepairRecord } from "./assistant-transcript-repair.js";
 import { persistAgentSession } from "./attempt-execution.shared.js";
+import type { deliverAgentCommandResult } from "./delivery.js";
 import type { PreparedAgentCommandExecution } from "./prepare.js";
 import type { runEmbeddedAgentAttempt } from "./run-embedded-attempt.js";
 import {
@@ -104,6 +111,8 @@ export async function finalizeEmbeddedAgentCommand(params: {
   const isHeartbeatLifecycleRun = isHeartbeatLifecycleRunKind(params.opts.bootstrapContextRunKind);
   let sessionEntry = params.sessionEntry;
   let result = params.attempt.result;
+  let deliveryResult: Awaited<ReturnType<typeof deliverAgentCommandResult>>;
+  let hasResultError: boolean;
   let { runOwnedSessionId, sessionReboundDuringRun } = params.sessionOwnership;
   const publishSessionOwnership = () => {
     // Outer restart-recovery cleanup runs even after later delivery failures.
@@ -506,11 +515,11 @@ export async function finalizeEmbeddedAgentCommand(params: {
       payloads,
       assertDeliveryCurrent: () => assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration),
       onDeliveryResult: (
-        deliveryResult: Parameters<
+        delivered: Parameters<
           NonNullable<Parameters<typeof deliverAgentCommandResult>[0]["onDeliveryResult"]>
         >[0],
       ) => {
-        const deliveryStatus = deliveryResult.deliveryStatus;
+        const deliveryStatus = delivered.deliveryStatus;
         const terminalDelivery = normalizeAgentRunTerminalDeliverySnapshot(
           deliveryStatus && {
             status: deliveryStatus.status,
@@ -521,11 +530,11 @@ export async function finalizeEmbeddedAgentCommand(params: {
           terminal.metadata.terminalDelivery = terminalDelivery;
         }
         params.onTerminalDeliveryEvidenceChanged(
-          buildRestartRecoveryTerminalDeliveryEvidence(deliveryResult),
+          buildRestartRecoveryTerminalDeliveryEvidence(delivered),
         );
       },
     };
-    const deliveryResult = await deliverAgentCommandResult(
+    deliveryResult = await deliverAgentCommandResult(
       resolveFreshSessionEntryForDelivery
         ? {
             ...deliveryParams,
@@ -605,21 +614,39 @@ export async function finalizeEmbeddedAgentCommand(params: {
       }
     }
 
-    if (fallbackExhausted || lifecycle.resolveResultError(result, false)) {
+    hasResultError = Boolean(fallbackExhausted || lifecycle.resolveResultError(result, false));
+    if (hasResultError) {
       lifecycle.emitResultError(result, fallbackExhausted, terminal);
     } else {
       lifecycle.emitEnd(terminal);
     }
-    return {
-      deliveryResult,
-      sessionEntry,
-      runOwnedSessionId,
-      sessionReboundDuringRun,
-    };
   } catch (error) {
     lifecycle.emitPostTurnError(error, terminal);
     throw error;
   } finally {
     await deferredLifecycle.complete();
   }
+
+  // Cancellation can arrive while delivery or deferred cleanup still owns the run.
+  // Record the final fact on the projected reply without changing its JSON output.
+  const outcome = deferredLifecycle.signal.aborted
+    ? mergeAgentRunTerminalOutcome(
+        terminal.outcome,
+        buildAgentRunTerminalOutcomeFromLifecycleEvent({
+          phase: "end",
+          abortSignal: deferredLifecycle.signal,
+        }),
+      )
+    : terminal.outcome;
+  return {
+    deliveryResult: recordAgentRunTerminalOutcome(
+      deliveryResult,
+      hasResultError || classifyAgentRunTerminalOutcome(outcome) !== "success"
+        ? "failed"
+        : "completed",
+    ),
+    sessionEntry,
+    runOwnedSessionId,
+    sessionReboundDuringRun,
+  };
 }

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -1998,35 +1998,46 @@ describe("agentCliCommand", () => {
     });
   });
 
-  it("exits for local runs that resolve after SIGTERM aborts them", async () => {
-    await withTempStore(async () => {
-      const signals = createSignalProcess();
-      agentCommand.mockImplementationOnce(async (opts: { abortSignal?: AbortSignal }) => {
-        return await new Promise((resolve) => {
-          opts.abortSignal?.addEventListener(
-            "abort",
-            () => {
-              resolve({
-                payloads: [],
-                meta: { aborted: true },
-              } as unknown as Awaited<ReturnType<typeof AgentCommand>>);
-            },
-            { once: true },
-          );
+  it.each([
+    ["SIGTERM", 143],
+    ["SIGINT", 130],
+  ] as const)(
+    "preserves %s when a local run returns a failed outcome",
+    async (signal, exitCode) => {
+      await withTempStore(async () => {
+        const signals = createSignalProcess();
+        agentCommand.mockImplementationOnce(async (opts: { abortSignal?: AbortSignal }) => {
+          return await new Promise((resolve) => {
+            opts.abortSignal?.addEventListener(
+              "abort",
+              () => {
+                resolve(
+                  recordAgentRunTerminalOutcome(
+                    {
+                      payloads: [],
+                      meta: { aborted: true },
+                    },
+                    "failed",
+                  ) as unknown as Awaited<ReturnType<typeof AgentCommand>>,
+                );
+              },
+              { once: true },
+            );
+          });
         });
-      });
 
-      const run = agentCliCommand({ message: "hi", to: "+1555", local: true }, runtime, {
-        process: signals.processLike,
-      });
-      await waitForAgentCommandCall();
-      signals.emit("SIGTERM");
+        const run = agentCliCommand({ message: "hi", to: "+1555", local: true }, runtime, {
+          process: signals.processLike,
+        });
+        await waitForAgentCommandCall();
+        signals.emit(signal);
 
-      await expect(run).resolves.toBeUndefined();
-      expect(callGateway).not.toHaveBeenCalled();
-      expect(runtime.exit).toHaveBeenCalledWith(143);
-    });
-  });
+        await expect(run).resolves.toBeUndefined();
+        expect(callGateway).not.toHaveBeenCalled();
+        expect(runtime.exit).toHaveBeenCalledWith(exitCode);
+      });
+    },
+  );
 
   it("does not classify abort errors as gateway transport failures", async () => {
     await withTempStore(async () => {
@@ -2477,7 +2488,10 @@ describe("agentCliCommand", () => {
     });
   });
 
-  it("marks a failed local terminal outcome unsuccessful", async () => {
+  it.each([
+    ["failed", 1],
+    ["completed", 0],
+  ] as const)("maps a %s local terminal outcome to exit %s", async (outcome, exitCode) => {
     await withTempStore(async () => {
       const signals = createSignalProcess();
       agentCommand.mockResolvedValueOnce(
@@ -2486,7 +2500,7 @@ describe("agentCliCommand", () => {
             payloads: [{ text: "provider failed", isError: true }],
             meta: { error: new Error("provider failed") },
           },
-          "failed",
+          outcome,
         ),
       );
 
@@ -2494,7 +2508,7 @@ describe("agentCliCommand", () => {
         process: signals.processLike,
       });
 
-      expect(signals.processLike.exitCode).toBe(1);
+      expect(signals.processLike.exitCode).toBe(exitCode);
     });
   });
 

--- a/src/commands/agent.acp.test.ts
+++ b/src/commands/agent.acp.test.ts
@@ -6,7 +6,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import "./agent-command.test-mocks.js";
 import * as acpManagerModule from "../acp/control-plane/manager.js";
 import { AcpRuntimeError } from "../acp/runtime/errors.js";
+import { deliverAgentCommandResult } from "../agents/command/delivery.runtime.js";
 import * as embeddedModule from "../agents/embedded-agent.js";
+import { readAgentRunTerminalOutcome } from "../channels/turn/agent-run-terminal-outcome.js";
 import * as configIoModule from "../config/io.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -63,17 +65,25 @@ vi.mock("../infra/agent-run-registry.js", async (importOriginal) => {
 
 vi.mock("../agents/command/delivery.runtime.js", () => ({
   deliverAgentCommandResult: vi.fn(
-    async (params: { runtime: RuntimeEnv; payloads?: Array<{ text?: string }> }) => {
+    async (params: {
+      runtime: RuntimeEnv;
+      payloads?: Array<{ text?: string }>;
+      result: { meta: object };
+    }) => {
       for (const payload of params.payloads ?? []) {
         if (payload.text) {
           params.runtime.log(payload.text);
         }
       }
+      return { payloads: params.payloads ?? [], meta: params.result.meta };
     },
   ),
 }));
 
-vi.mock("../agents/command/attempt-execution.runtime.js", () => {
+vi.mock("../agents/command/attempt-execution.runtime.js", async () => {
+  const { buildAcpResult } = await vi.importActual<
+    typeof import("../agents/command/attempt-execution.js")
+  >("../agents/command/attempt-execution.js");
   const createAcpVisibleTextAccumulator = () => {
     let text = "";
     let silent = false;
@@ -123,24 +133,7 @@ vi.mock("../agents/command/attempt-execution.runtime.js", () => {
         stream: "assistant",
         data: { text, delta },
       }),
-    buildAcpResult: ({
-      payloadText,
-      startedAt,
-      stopReason,
-      abortSignal,
-    }: {
-      payloadText: string;
-      startedAt: number;
-      stopReason?: string;
-      abortSignal?: AbortSignal;
-    }) => ({
-      payloads: payloadText ? [{ text: payloadText }] : [],
-      meta: {
-        durationMs: Date.now() - startedAt,
-        aborted: abortSignal?.aborted === true,
-        stopReason,
-      },
-    }),
+    buildAcpResult,
     persistAcpTurnTranscript: attemptExecutionMocks.persistAcpTurnTranscript,
   };
 });
@@ -395,6 +388,60 @@ describe("agentCommand ACP runtime routing", () => {
       },
     } as never);
   });
+
+  it.each([
+    { name: "completed stop", status: "completed", outcome: "completed" },
+    { name: "cancelled result", status: "cancelled", outcome: "failed" },
+    { name: "runtime timeout", status: "completed", abort: "timeout", outcome: "failed" },
+    { name: "late cancellation", status: "completed", abort: "delivery", outcome: "failed" },
+  ] as const)(
+    "hands off the terminal outcome after real ACP projection: $name",
+    async (scenario) => {
+      await withAcpSessionEnv(async () => {
+        const controller = new AbortController();
+        const runTurn = vi.fn(async (input: unknown) => {
+          const params = input as Parameters<
+            ReturnType<typeof acpManagerModule.getAcpSessionManager>["runTurn"]
+          >[0];
+          await params.onEvent?.({ type: "text_delta", text: "ACP reply" });
+          if ("abort" in scenario && scenario.abort === "timeout") {
+            controller.abort(new DOMException("deadline", "TimeoutError"));
+          }
+          await params.onEvent?.({ type: "done", status: scenario.status, stopReason: "stop" });
+        });
+        mockAcpManager({ runTurn });
+        const actualDelivery = await vi.importActual<
+          typeof import("../agents/command/delivery.js")
+        >("../agents/command/delivery.js");
+        vi.mocked(deliverAgentCommandResult).mockImplementationOnce(async (params) => {
+          const projected = await actualDelivery.deliverAgentCommandResult(params);
+          if ("abort" in scenario && scenario.abort === "delivery") {
+            controller.abort();
+          }
+          return projected;
+        });
+
+        const result = await agentCommand(
+          {
+            message: "probe",
+            sessionKey: "agent:codex:acp:test",
+            json: true,
+            abortSignal: controller.signal,
+          },
+          runtime,
+        );
+
+        expect(runTurn).toHaveBeenCalledOnce();
+        expect(runEmbeddedAgentSpy).not.toHaveBeenCalled();
+        expect(result?.payloads).toEqual([{ text: "ACP reply", mediaUrl: null }]);
+        expect(result?.meta.aborted).toBe(
+          scenario.status === "cancelled" || ("abort" in scenario && scenario.abort === "timeout"),
+        );
+        expect(vi.mocked(runtime.log).mock.calls.at(-1)?.[0]).toBe(JSON.stringify(result, null, 2));
+        expect(readAgentRunTerminalOutcome(result)).toBe(scenario.outcome);
+      });
+    },
+  );
 
   it("routes ACP sessions and preserves exact transcript text", async () => {
     await withAcpSessionEnvInfo(async () => {

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -22,6 +22,7 @@ import { isAgentRunRestartAbortReason } from "../agents/run-termination.js";
 import { ensureAgentWorkspace } from "../agents/workspace.js";
 import { managedWorktrees } from "../agents/worktrees/service.js";
 import { BASE_THINKING_LEVELS } from "../auto-reply/thinking.shared.js";
+import { readAgentRunTerminalOutcome } from "../channels/turn/agent-run-terminal-outcome.js";
 import * as runtimeSnapshotModule from "../config/runtime-snapshot.js";
 import { parseSqliteSessionFileMarker } from "../config/sessions/legacy-sqlite-marker.js";
 import {
@@ -329,9 +330,10 @@ vi.mock("../agents/command/delivery.runtime.js", () => {
         payloads?: Array<{ text?: string; mediaUrl?: string | null }>;
       }) => {
         const payloads = params.payloads ?? [];
+        const deliveryResult = { payloads, meta: params.result.meta ?? {} };
         if (params.opts.json) {
-          params.runtime.log(JSON.stringify({ payloads, meta: params.result.meta ?? {} }));
-          return;
+          params.runtime.log(JSON.stringify(deliveryResult));
+          return deliveryResult;
         }
         if (params.opts.deliver && params.opts.channel === "telegram" && params.opts.to) {
           for (const payload of payloads) {
@@ -341,13 +343,14 @@ vi.mock("../agents/command/delivery.runtime.js", () => {
               verbose: false,
             });
           }
-          return;
+          return deliveryResult;
         }
         for (const payload of payloads) {
           if (payload.text) {
             params.runtime.log(payload.text);
           }
         }
+        return deliveryResult;
       },
     ),
   };
@@ -389,8 +392,6 @@ const runtime = createThrowingTestRuntime();
 async function withTempHome<T>(fn: (home: string) => Promise<T>): Promise<T> {
   return withTempHomeBase(fn, {
     prefix: "openclaw-agent-",
-    skipHomeCleanup: true,
-    skipSessionCleanup: true,
   });
 }
 
@@ -593,6 +594,150 @@ beforeEach(() => {
 });
 
 describe("agentCommand", () => {
+  it.each([
+    { name: "completed stop", meta: { stopReason: "stop" }, outcome: "completed" },
+    {
+      name: "structured blocked result",
+      meta: {
+        replayInvalid: true,
+        livenessState: "blocked" as const,
+        finalAssistantVisibleText: "Prompt exceeds model context",
+        finalAssistantRawText: "Prompt exceeds model context",
+        error: { kind: "context_overflow" as const, message: "Prompt exceeds model context" },
+      },
+      outcome: "failed",
+    },
+    { name: "cancelled result", meta: { aborted: true, stopReason: "stop" }, outcome: "failed" },
+    {
+      name: "provider timeout",
+      meta: { aborted: true, stopReason: "timeout", timeoutPhase: "provider" as const },
+      outcome: "failed",
+    },
+    { name: "yielded turn", meta: { yielded: true }, outcome: "completed" },
+    {
+      name: "exhausted fallback",
+      meta: {
+        error: {
+          kind: "incomplete_turn" as const,
+          message: "Incomplete terminal response",
+          fallbackSafe: true,
+          terminalPresentation: true,
+        },
+      },
+      outcome: "failed",
+    },
+    { name: "callback error", meta: {}, fault: "callback", outcome: "failed" },
+    { name: "late cancellation", meta: {}, fault: "abort", outcome: "failed" },
+  ])(
+    "hands off the terminal outcome after real delivery projection: $name",
+    async ({ meta, outcome, fault }) => {
+      await withTempHome(async (home) => {
+        mockConfig(home, path.join(home, "sessions.json"));
+        const controller = new AbortController();
+        const text = meta.error?.message ?? "ok";
+        const rawResult = {
+          ...createDefaultAgentResult(),
+          payloads: [{ text, ...(meta.error ? { isError: true } : {}) }],
+          meta: { ...createDefaultAgentResult().meta, ...meta },
+        };
+        vi.mocked(runEmbeddedAgent).mockImplementationOnce(async (params) => {
+          if (fault === "callback") {
+            await params.onAgentEvent?.({
+              stream: "lifecycle",
+              data: { phase: "finishing", error: "Deferred provider failure" },
+            });
+          }
+          return rawResult;
+        });
+        const actualDelivery = await vi.importActual<
+          typeof import("../agents/command/delivery.js")
+        >("../agents/command/delivery.js");
+        vi.mocked(deliverAgentCommandResult).mockImplementationOnce(async (params) => {
+          const projected = await actualDelivery.deliverAgentCommandResult(params);
+          if (fault === "abort") {
+            controller.abort();
+          }
+          return projected;
+        });
+
+        const result = await agentCommand(
+          { message: "probe", agentId: "main", json: true, abortSignal: controller.signal },
+          runtime,
+        );
+
+        expect(runEmbeddedAgent).toHaveBeenCalledTimes(1);
+        expect(result?.payloads).toEqual([{ text, mediaUrl: null }]);
+        expect(vi.mocked(runtime.log).mock.calls.at(-1)?.[0]).toBe(JSON.stringify(result, null, 2));
+        expect(readAgentRunTerminalOutcome(rawResult)).toBeUndefined();
+        expect(readAgentRunTerminalOutcome(result)).toBe(outcome);
+      });
+    },
+  );
+
+  it("keeps best-effort delivery failure separate from the completed run outcome", async () => {
+    await withTempHome(async (home) => {
+      mockConfig(home, path.join(home, "sessions.json"));
+      const actualDelivery = await vi.importActual<typeof import("../agents/command/delivery.js")>(
+        "../agents/command/delivery.js",
+      );
+      vi.mocked(deliverAgentCommandResult).mockImplementationOnce(
+        actualDelivery.deliverAgentCommandResult,
+      );
+
+      const result = await agentCommand(
+        {
+          message: "probe",
+          agentId: "main",
+          json: true,
+          deliver: true,
+          channel: "webchat",
+          bestEffortDeliver: true,
+        },
+        runtime,
+      );
+
+      expect(runEmbeddedAgent).toHaveBeenCalledOnce();
+      expect(result?.deliveryStatus).toMatchObject({ status: "failed", succeeded: false });
+      expect(readAgentRunTerminalOutcome(result)).toBe("completed");
+    });
+  });
+
+  it.each(["rejection", "cancellation"] as const)(
+    "settles deferred cleanup %s before handing off the reply",
+    async (fault) => {
+      await withTempHome(async (home) => {
+        mockConfig(home, path.join(home, "sessions.json"));
+        const controller = new AbortController();
+        const failure = new Error("Deferred cleanup failed");
+        vi.mocked(attemptExecutionRuntime.runAgentAttempt).mockImplementationOnce(
+          async (params) => {
+            params.deferredLifecycle?.adopt({
+              complete: async () => {
+                if (fault === "rejection") {
+                  throw failure;
+                }
+                controller.abort();
+              },
+              discard: () => {},
+            });
+            return createDefaultAgentResult();
+          },
+        );
+
+        const command = agentCommand(
+          { message: "probe", agentId: "main", abortSignal: controller.signal },
+          runtime,
+        );
+        if (fault === "rejection") {
+          await expect(command).rejects.toBe(failure);
+        } else {
+          expect(readAgentRunTerminalOutcome(await command)).toBe("failed");
+        }
+        expect(runtime.log).toHaveBeenCalledWith("ok");
+      });
+    },
+  );
+
   it("carries an external cwd into the direct agent session skill snapshot", async () => {
     await withTempHome(async (home) => {
       const store = path.join(home, "sessions.json");


### PR DESCRIPTION
Closes #132154
Related: #125557 (merged CLI consumer/documentation fix).

## What Problem This Solves

Fixes an issue where scripts using `openclaw agent --local` would receive exit `0` when an embedded or ACP turn returned a normally resolved failure or cancellation. The [documented CLI contract](https://docs.openclaw.ai/cli/agent) already promises exit `1` for failed, timed-out, or cancelled turns.

## Why This Change Was Made

The local consumer reads an existing private terminal-outcome marker, but both command owners returned a fresh real delivery projection without marking it. Record the existing canonical outcome at those owners after delivery; the embedded path also waits for deferred cleanup before recording a cancellation that arrived during that await. The canonical lifecycle/outcome classifier remains the policy owner, and best-effort transport failure stays separate from execution success.

No JSON/status heuristics, new compatibility paths, consumer changes, configuration, environment variables, schema, dependencies, or public output fields. The return moves after awaited cleanup rather than keeping an early return that misses late cancellation. Normal deferred completion does not abort its controller.

## User Impact

Local scripts can detect failed turns through exit status after output is written. Success remains `0`, failure/timeout/cancellation becomes `1`, and received SIGINT/SIGTERM still takes precedence as `130`/`143`. Text and structured JSON shape remain unchanged. This completes the producer handoff left untested by the pre-marked local mocks in #125557; no stable-release introduction is claimed.

## Evidence

AI-assisted implementation and review. The final six-file patch was tested at base `2133a924eef01500a24d8e57ac93c6b45fc5de89`, then replayed as a single commit onto main `15046d38039c427819bb9fd410bec9db53dba132`. `git range-diff` reports equality and original/rebased diff bytes have the same SHA-256: `781882d122bfe011b98de5bccee35872f304245d26a5b4ba4938f58c0dd2f721`.

**Before/after process proof:** actual public dist-backed `pnpm openclaw agent --local --agent main --message cancel-proof --json --timeout 60` with a synthetic task-private harness naturally exited `0` before and `1` after. The completed control exited `0` both times. No kills, credentials, Gateway, or live provider; fresh HOME/state/config/XDG roots were removed after the probes. Stable JSON matches after excluding only durationMs/runId/sessionId/turnId. pnpm adds its standard lifecycle-failure footer on exit `1`; raw wrapper stdout bytes are not claimed identical.

**Regression proof:** twelve pre-fix owner assertions failed specifically on the missing marker, plus the deferred-cleanup cancellation regression. Tests exercise real delivery projection and ACP result building, covering success, structured blocked/error results, cancellation, timeout, callback error, exhausted fallback, late delivery/cleanup cancellation, yielded success, cleanup rejection, transport separation, local exit mapping, and signal precedence. Existing unrealistic undefined-return delivery mocks now return the real narrow result shape.

**Final verification:** 13 files, 487 tests passed, one expected macOS procfs file-descriptor skip, five canonical wrapper shards (219.65s). Full `pnpm build`, complete `node scripts/check-changed.mjs` for the six changed paths, and managed Codex P0 autoreview passed; findings `[]`, confidence `0.97`. Tests and build were serialized for final proof. Earlier failed mechanical-rename/artifact-replacement attempts are not counted as passes.

The relevant sibling suites include local CLI, ACP command and manager, delivery/lifecycle, deferred lifecycle owner, model switching, restart recovery, post-turn maintenance and compaction. Personal contract inspection also checked Codex `rust-v0.150.1` (`90854393966b21e9ebfd21b122334eb09a20c93d`): app-server protocol `v2/turn.rs:30-35,407-410`, `protocol/src/protocol.rs:3981-4006`, and `app-server/src/bespoke_event_handling.rs:1482-1544`; completion notifications independently carry completed/failed/interrupted status. No Codex plugin or upstream protocol changes are made.

**LOC:** production +54/-12 (net +42), tests +273/-59 (net +214). Growth implements the missing handoff at two independent producer boundaries and preserves late cancellation after awaited cleanup. Moving policy into delivery would lose lifecycle ownership; moving it into the CLI would duplicate the canonical classifier. Existing abstractions are reused without an extra wrapper or alias.

**Limits:** no ACP/public blocked-provider process probe or authenticated live-provider continuation proof. Native preparation completed successfully without changing the reviewed head. [Full validation run 33154285571](https://github.com/openclaw/openclaw/actions/runs/33154285571) is investigation context only; its historical trajectory failure cause is unknown. This scoped fix does not make full release verification green.

Post-rebase sanity: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/commands/agent.test.ts src/commands/agent.acp.test.ts src/commands/agent-via-gateway.test.ts -t 'hands off the terminal outcome|settles deferred cleanup|best-effort delivery failure|local terminal outcome|preserves SIG'` passed 19 selected tests in three files (49.74s wrapper; 158 deliberately filtered out).

Hosted CI: [run 33214936531, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33214936531) passed, including the required `openclaw/ci-gate`, on head `2be9d4f2d78b4d335a927340ca42abb24ce698aa`. Actual effective checkout/workflow revision was merge `5fd6d495b9b463e7589ff1ee46450e732d7ecb74` (that head into main `d42e19dd2f77fa3559a915af2b4aaf85c628c887`), verified from preflight checkout and revision logs. Native review artifacts validate for the same head. No CI retries or bypasses.

ClawSweeper follow-through: [completed review](https://github.com/openclaw/openclaw/pull/132155#issuecomment-5458312944) covers the exact head and reports no actionable correctness or security finding. Its Rank-up move, completing exact-head checks, is satisfied by the green CI run above. The compatibility concern is acknowledged: this PR intentionally restores the already-documented exit `1` for failed/cancelled local turns; scripts that accidentally relied on silent success must now handle failure. Under the scoped maintainer-directed fix, the chosen behavior is the documented contract correction, without a compatibility shim. No re-review is requested because the reviewed source has not changed.

Native preparation: `scripts/pr review-init 132155`, main-baseline/PR-head inspection, `scripts/pr review-artifacts-init 132155`, `scripts/pr review-validate-artifacts 132155`, and `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 132155` passed. The wrapper verified hosted CI and matching local/remote trees, then skipped an unnecessary push. Prepared head remains `2be9d4f2d78b4d335a927340ca42abb24ce698aa`, tree `8d1b37415bb4634f971071265f96971e9c869da8`. Prepared for final maintainer verification; not merged, and `merge-run` has not been invoked.
