### PR TITLE
fix(plugins): load source artifacts without losing credential targets

### DIFF
--- a/docs/reference/secretref-credential-surface.md
+++ b/docs/reference/secretref-credential-surface.md
@@ -16,6 +16,8 @@ Scope:
 
 The lists below are generated from the source target registry and checked against `docs/reference/secretref-user-supplied-credentials-matrix.json` in CI; do not hand-edit entries.
 
+Source generation fails if a present channel secret-contract artifact cannot load, rather than publishing an incomplete list. A plugin without that optional artifact contributes no channel targets. This generation check does not change runtime SecretRef owner-isolation behavior.
+
 ## Supported credentials
 
 ### `openclaw.json` targets (`secrets configure` + `secrets apply` + `secrets audit`)

--- a/src/plugins/native-module-require.test.ts
+++ b/src/plugins/native-module-require.test.ts
@@ -7,7 +7,7 @@ import { pathToFileURL } from "node:url";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import {
-  clearNativeRequireJavaScriptModuleCache,
+  clearPluginModuleRequireCache,
   isJavaScriptModulePath,
   tryNativeRequireJavaScriptModule,
 } from "./native-module-require.js";
@@ -207,7 +207,7 @@ describe("tryNativeRequireJavaScriptModule", () => {
     });
 
     fs.writeFileSync(modulePath, 'module.exports = { marker: "after" };\n', "utf8");
-    clearNativeRequireJavaScriptModuleCache(modulePath);
+    clearPluginModuleRequireCache(modulePath);
 
     expect(tryNativeRequireJavaScriptModule(modulePath, { allowWindows: true })).toEqual({
       ok: true,
@@ -227,7 +227,7 @@ describe("tryNativeRequireJavaScriptModule", () => {
     });
 
     fs.writeFileSync(helperPath, 'module.exports = { marker: "after" };\n', "utf8");
-    clearNativeRequireJavaScriptModuleCache(modulePath, { dependencyRoot: dir });
+    clearPluginModuleRequireCache(modulePath, { dependencyRoot: dir });
 
     expect(tryNativeRequireJavaScriptModule(modulePath, { allowWindows: true })).toEqual({
       ok: true,

--- a/src/plugins/native-module-require.ts
+++ b/src/plugins/native-module-require.ts
@@ -91,14 +91,11 @@ export function tryNativeRequireJavaScriptModule(
   }
 }
 
-/** Clears a native-loaded module and dependency subtree under the plugin dependency root. */
-export function clearNativeRequireJavaScriptModuleCache(
+/** Clears native and source-transformed modules within the plugin dependency root. */
+export function clearPluginModuleRequireCache(
   modulePath: string,
   options: { dependencyRoot?: string } = {},
 ): void {
-  if (!isJavaScriptModulePath(modulePath)) {
-    return;
-  }
   try {
     const resolved = nodeRequire.resolve(modulePath);
     clearRequireCacheSubtree(
@@ -107,7 +104,7 @@ export function clearNativeRequireJavaScriptModuleCache(
       new Set(),
     );
   } catch {
-    // Best-effort lifecycle cleanup: unresolved paths were not native-loaded.
+    // Best-effort lifecycle cleanup: unresolved paths were not loaded.
   }
 }
 

--- a/src/plugins/plugin-module-loader-cache.test.ts
+++ b/src/plugins/plugin-module-loader-cache.test.ts
@@ -935,10 +935,10 @@ describe("plugin module cache generation cleanup", () => {
     { boundaryRoot: "/repo/dist/extensions", dependencyRoot: "/repo/dist" },
     { boundaryRoot: "/repo/installed/demo", dependencyRoot: "/repo/installed/demo" },
   ])("evicts native dependencies under $dependencyRoot for $boundaryRoot", async (params) => {
-    const clearNativeRequireJavaScriptModuleCache = vi.fn();
+    const clearPluginModuleRequireCache = vi.fn();
     vi.doMock("./native-module-require.js", async (importOriginal) => ({
       ...(await importOriginal<typeof import("./native-module-require.js")>()),
-      clearNativeRequireJavaScriptModuleCache,
+      clearPluginModuleRequireCache,
     }));
     const { recordPluginModuleRoot } = await importPluginModuleLoader(
       "./plugin-module-loader-cache.js?scope=lifecycle-disposal",
@@ -949,7 +949,7 @@ describe("plugin module cache generation cleanup", () => {
 
     resetPluginCache();
 
-    expect(clearNativeRequireJavaScriptModuleCache).toHaveBeenCalledWith(modulePath, {
+    expect(clearPluginModuleRequireCache).toHaveBeenCalledWith(modulePath, {
       dependencyRoot: params.dependencyRoot,
     });
     expect(getPluginCache()).not.toBe(previous);

--- a/src/plugins/plugin-module-loader-cache.ts
+++ b/src/plugins/plugin-module-loader-cache.ts
@@ -8,7 +8,7 @@ import { openRootFileSync } from "../infra/boundary-file-read.js";
 import { sameFileIdentity } from "../infra/fs-safe-advanced.js";
 import { toSafeImportPath } from "../shared/import-specifier.js";
 import {
-  clearNativeRequireJavaScriptModuleCache,
+  clearPluginModuleRequireCache,
   tryNativeRequireJavaScriptModule,
 } from "./native-module-require.js";
 import {
@@ -133,7 +133,7 @@ function retainModuleLifecycle(cache: ReturnType<typeof getPluginCache>): void {
         path.basename(extensionsDir) === "extensions" && path.basename(distDir) === "dist"
           ? distDir
           : rootDir;
-      clearNativeRequireJavaScriptModuleCache(modulePath, { dependencyRoot });
+      clearPluginModuleRequireCache(modulePath, { dependencyRoot });
     }
   };
 }

--- a/src/plugins/public-surface-loader.test.ts
+++ b/src/plugins/public-surface-loader.test.ts
@@ -1,10 +1,12 @@
 // Verifies plugin public surface loading and fallback behavior.
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { MissingPublicSurfaceError } from "../plugin-sdk/facade-loader.js";
+import { spawnNodeEvalSync } from "../test-utils/node-process.js";
 import { withMockedWindowsPlatform } from "../test-utils/vitest-spies.js";
 import { resetPluginCache } from "./plugin-cache.js";
 
@@ -32,7 +34,6 @@ afterEach(() => {
   vi.doUnmock("./bundled-dir.js");
   vi.doUnmock("./native-module-require.js");
   vi.doUnmock("./public-surface-runtime.js");
-  vi.doUnmock("node:module");
   if (originalBundledPluginsDir === undefined) {
     delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
   } else {
@@ -131,45 +132,74 @@ describe("bundled plugin public surface loader", () => {
     });
   });
 
-  it("prefers source require for bundled source public artifacts when a ts require hook exists", async () => {
-    const createJiti = vi.fn(() => vi.fn(() => ({ marker: "jiti-should-not-run" })));
-    vi.doMock("jiti", () => ({
-      createJiti,
-    }));
-    const requireLoader = Object.assign(
-      vi.fn(() => ({ marker: "source-require-ok" })),
+  it("loads import-only dependencies under tsx and shares source artifacts for one cache generation", () => {
+    const tempRoot = tempDirs.make("openclaw-public-surface-source-");
+    const bundledPluginsDir = path.join(tempRoot, "extensions");
+    const pluginRoot = path.join(bundledPluginsDir, "demo");
+    const dependencyRoot = path.join(pluginRoot, "node_modules", "import-only-fixture");
+    const modulePath = path.join(pluginRoot, "secret-contract-api.ts");
+    const dependencyPath = path.join(dependencyRoot, "index.js");
+    fs.mkdirSync(dependencyRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(dependencyRoot, "package.json"),
+      JSON.stringify({ type: "module", exports: { node: { import: "./index.js" } } }),
+    );
+    fs.writeFileSync(dependencyPath, 'export const marker = "original";\n');
+    fs.writeFileSync(path.join(tempRoot, "shared.cjs"), "module.exports = {};\n");
+    fs.writeFileSync(
+      modulePath,
+      'export { marker } from "import-only-fixture";\nexport { default as shared } from "../../shared.cjs";\n',
+    );
+
+    const moduleUrl = (relativePath: string) =>
+      JSON.stringify(pathToFileURL(path.join(process.cwd(), relativePath)).href);
+    const result = spawnNodeEvalSync(
+      `
+        import assert from "node:assert/strict";
+        import fs from "node:fs";
+        import { createRequire } from "node:module";
+        import { loadBundledPluginPublicArtifactModuleSync, loadPluginPublicArtifactModuleSync } from ${moduleUrl("src/plugins/public-surface-loader.ts")};
+        import { loadFacadeModuleAtLocationSync } from ${moduleUrl("src/plugin-sdk/facade-loader.ts")};
+        import { clearPluginMetadataLifecycleCaches } from ${moduleUrl("src/plugins/plugin-metadata-lifecycle.ts")};
+        assert.equal(typeof createRequire(import.meta.url).extensions[".ts"], "function");
+        const load = () => loadBundledPluginPublicArtifactModuleSync({ dirName: "demo", artifactBasename: "secret-contract-api.js" });
+        const first = load();
+        assert.equal(first.marker, "original");
+        assert.equal(load(), first);
+        assert.equal(loadPluginPublicArtifactModuleSync({ pluginRoot: ${JSON.stringify(pluginRoot)}, artifactBasename: "secret-contract-api.js" }), first);
+        assert.equal(loadFacadeModuleAtLocationSync({ location: { modulePath: ${JSON.stringify(modulePath)}, boundaryRoot: ${JSON.stringify(pluginRoot)} }, trackedPluginId: "demo" }), first);
+        fs.writeFileSync(${JSON.stringify(dependencyPath)}, 'export const marker = "replacement";\\n');
+        assert.equal(load(), first);
+        clearPluginMetadataLifecycleCaches();
+        const replacement = load();
+        assert.notEqual(replacement, first);
+        assert.equal(replacement.marker, "replacement");
+        assert.equal(replacement.shared, first.shared);
+        console.log("source artifact import, identity, and lifecycle verified");
+      `,
       {
-        extensions: {
-          ".ts": vi.fn(),
+        imports: [pathToFileURL(path.join(process.cwd(), "scripts/tsx.mjs")).href],
+        timeout: 30_000,
+        env: {
+          PATH: process.env.PATH,
+          SystemRoot: process.env.SystemRoot,
+          HOME: tempRoot,
+          USERPROFILE: tempRoot,
+          TMPDIR: tempRoot,
+          TMP: tempRoot,
+          TEMP: tempRoot,
+          VITEST: "true",
+          OPENCLAW_STATE_DIR: path.join(tempRoot, "state"),
+          OPENCLAW_BUNDLED_PLUGINS_DIR: bundledPluginsDir,
+          OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+          JITI_FS_CACHE: "0",
         },
       },
     );
-    vi.doMock("node:module", async () => {
-      const actual = await vi.importActual<typeof import("node:module")>("node:module");
-      return Object.assign({}, actual, {
-        createRequire: vi.fn(() => requireLoader),
-      });
-    });
-
-    const publicSurfaceLoader = await importFreshModule<
-      typeof import("./public-surface-loader.js")
-    >(import.meta.url, "./public-surface-loader.js?scope=source-require-fast-path");
-    const tempRoot = tempDirs.make("openclaw-public-surface-loader-");
-    const bundledPluginsDir = path.join(tempRoot, "extensions");
-    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = bundledPluginsDir;
-
-    const modulePath = path.join(bundledPluginsDir, "demo", "secret-contract-api.ts");
-    fs.mkdirSync(path.dirname(modulePath), { recursive: true });
-    fs.writeFileSync(modulePath, 'export const marker = "source-require-ok";\n', "utf8");
-
-    expect(
-      publicSurfaceLoader.loadBundledPluginPublicArtifactModuleSync<{ marker: string }>({
-        dirName: "demo",
-        artifactBasename: "secret-contract-api.js",
-      }).marker,
-    ).toBe("source-require-ok");
-    expect(requireLoader).toHaveBeenCalledWith(fs.realpathSync(modulePath));
-    expect(createJiti).not.toHaveBeenCalled();
+    expect(result.error).toBeUndefined();
+    expect(result.stderr).toBe("");
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("source artifact import, identity, and lifecycle verified");
   });
 
   it("keeps bundled dist public artifacts on the native path", async () => {

--- a/src/plugins/public-surface-loader.ts
+++ b/src/plugins/public-surface-loader.ts
@@ -1,5 +1,4 @@
 // Loads documented plugin public surfaces while preserving lazy boundaries.
-import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { MissingPublicSurfaceError } from "../plugin-sdk/facade-loader.js";
@@ -14,40 +13,17 @@ import {
   resolveBundledPluginPublicSurfacePath,
   resolvePluginRootPublicSurfacePath,
 } from "./public-surface-runtime.js";
-import { resolvePluginLoaderTryNative, resolveLoaderPackageRoot } from "./sdk-alias.js";
+import { resolveLoaderPackageRoot } from "./sdk-alias.js";
 
 const OPENCLAW_PACKAGE_ROOT =
   resolveLoaderPackageRoot({
     modulePath: fileURLToPath(import.meta.url),
     moduleUrl: import.meta.url,
   }) ?? fileURLToPath(new URL("../..", import.meta.url));
-const sourceArtifactRequire = createRequire(import.meta.url);
 type PublicSurfaceLocation = {
   modulePath: string;
   boundaryRoot: string;
 };
-
-function isSourceArtifactPath(modulePath: string): boolean {
-  switch (path.extname(modulePath).toLowerCase()) {
-    case ".ts":
-    case ".tsx":
-    case ".mts":
-    case ".cts":
-    case ".mtsx":
-    case ".ctsx":
-      return true;
-    default:
-      return false;
-  }
-}
-
-function canUseSourceArtifactRequire(params: { modulePath: string; tryNative: boolean }): boolean {
-  return (
-    !params.tryNative &&
-    isSourceArtifactPath(params.modulePath) &&
-    typeof sourceArtifactRequire.extensions?.[".ts"] === "function"
-  );
-}
 
 function createResolutionKey(params: { dirName: string; artifactBasename: string }): string {
   const bundledPluginsDir = resolveBundledPluginsDir();
@@ -92,21 +68,16 @@ function resolvePublicSurfaceLocation(params: {
   return resolved;
 }
 
-function getModuleLoader(modulePath: string) {
-  return getCachedPluginModuleLoader({
+function loadPublicSurfaceModule(modulePath: string): unknown {
+  // A TS require hook can force import-only dependencies through CommonJS resolution.
+  // Keep source transforms and built-artifact native loading on the same canonical owner.
+  const load = getCachedPluginModuleLoader({
     modulePath,
     importerUrl: import.meta.url,
     preferBuiltDist: true,
     loaderFilename: import.meta.url,
   });
-}
-
-function loadPublicSurfaceModule(modulePath: string): unknown {
-  const tryNative = resolvePluginLoaderTryNative(modulePath, { preferBuiltDist: true });
-  if (canUseSourceArtifactRequire({ modulePath, tryNative })) {
-    return sourceArtifactRequire(modulePath);
-  }
-  return getModuleLoader(modulePath)(modulePath);
+  return load(modulePath);
 }
 
 function loadValidatedPublicSurfaceModule(params: {

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -10,12 +10,12 @@ import {
 } from "openclaw/plugin-sdk/test-fixtures";
 import { afterAll, describe, expect, it, vi } from "vitest";
 import { withEnv, withEnvAsync } from "../test-utils/env.js";
+import { createPluginCache, withPluginCache } from "./plugin-cache.js";
 import {
   buildPluginLoaderAliasMap,
   createPluginLoaderModuleCacheKey,
   buildPluginLoaderJitiOptions,
   resolvePluginLoaderModuleConfig,
-  resolvePluginLoaderTryNative,
   resolvePluginRuntimeModulePathWithDiagnostics,
   type PluginSdkResolutionPreference,
 } from "./sdk-alias.js";
@@ -1613,104 +1613,42 @@ describe("plugin sdk alias helpers", () => {
     expect(options.nativeModules).toEqual(["native-addon", "openclaw"]);
   });
 
-  it("uses transpiled module loads for source TypeScript plugin entries", () => {
-    expect(resolvePluginLoaderTryNative("/repo/dist/plugins/runtime/index.js")).toBe(true);
-    expect(
-      resolvePluginLoaderTryNative(
-        `/repo/${bundledPluginFile("discord", "src/channel.runtime.ts")}`,
-      ),
-    ).toBe(false);
-  });
-
-  it("disables native module loads under Bun even for built JavaScript entries", () => {
-    const originalVersions = process.versions;
-    Object.defineProperty(process, "versions", {
-      configurable: true,
-      value: {
-        ...originalVersions,
-        bun: "1.2.0",
-      },
-    });
-
-    try {
-      expect(resolvePluginLoaderTryNative("/repo/dist/plugins/runtime/index.js")).toBe(false);
-      expect(
-        resolvePluginLoaderTryNative(`/repo/${bundledDistPluginFile("browser", "index.js")}`),
-      ).toBe(false);
-    } finally {
+  it.each([
+    ["node", "linux", "dist/plugins/runtime/index.js", false, true],
+    ["node", "linux", "extensions/demo/index.ts", false, false],
+    ["bun", "linux", "dist/plugins/runtime/index.js", false, false],
+    ["bun", "linux", "dist/extensions/demo/index.js", true, false],
+    ["node", "win32", "dist/plugins/runtime/index.js", false, true],
+    ["node", "win32", "dist/extensions/demo/index.js", true, true],
+    ["node", "win32", "dist/extensions/demo/helper.ts", true, false],
+    ["node", "linux", "dist/extensions/demo/index.js", true, true],
+    ["node", "linux", "dist/extensions/demo/helper.ts", true, false],
+  ] as const)(
+    "selects native loading for %s on %s with %s (prefer dist=%s): %s",
+    (runtime, platform, entry, preferBuiltDist, expected) => {
+      const fixture = createPluginSdkAliasFixture();
+      const originalPlatform = process.platform;
+      const originalVersions = process.versions;
+      Object.defineProperty(process, "platform", { configurable: true, value: platform });
       Object.defineProperty(process, "versions", {
         configurable: true,
-        value: originalVersions,
+        value: { ...originalVersions, bun: runtime === "bun" ? "1.2.0" : undefined },
       });
-    }
-  });
-
-  it("enables native module loads on Windows for built JavaScript entries", () => {
-    const originalPlatform = process.platform;
-    Object.defineProperty(process, "platform", {
-      configurable: true,
-      value: "win32",
-    });
-
-    try {
-      expect(resolvePluginLoaderTryNative("/repo/dist/plugins/runtime/index.js")).toBe(true);
-      expect(
-        resolvePluginLoaderTryNative(`/repo/${bundledDistPluginFile("browser", "index.js")}`),
-      ).toBe(true);
-    } finally {
-      Object.defineProperty(process, "platform", {
-        configurable: true,
-        value: originalPlatform,
-      });
-    }
-  });
-
-  it("keeps plugin loader dist shortcuts on native module loading on Windows for JS entries", () => {
-    const originalPlatform = process.platform;
-    Object.defineProperty(process, "platform", {
-      configurable: true,
-      value: "win32",
-    });
-
-    try {
-      expect(
-        resolvePluginLoaderTryNative(`/repo/${bundledDistPluginFile("browser", "index.js")}`, {
-          preferBuiltDist: true,
-        }),
-      ).toBe(true);
-      expect(
-        resolvePluginLoaderTryNative(`/repo/${bundledDistPluginFile("browser", "helper.ts")}`, {
-          preferBuiltDist: true,
-        }),
-      ).toBe(false);
-    } finally {
-      Object.defineProperty(process, "platform", {
-        configurable: true,
-        value: originalPlatform,
-      });
-    }
-  });
-
-  it("prefers native module loading for bundled plugin dist .js modules, keeps .ts on aliased path", () => {
-    // Built .js/.mjs/.cjs files under dist/extensions/ should now delegate
-    // to native loading on Node for compiled artifacts, avoiding the slow jiti transform path.
-    expect(
-      resolvePluginLoaderTryNative(`/repo/${bundledDistPluginFile("browser", "index.js")}`, {
-        preferBuiltDist: true,
-      }),
-    ).toBe(true);
-    // TypeScript source files still need jiti's transform pipeline.
-    expect(
-      resolvePluginLoaderTryNative(`/repo/${bundledDistPluginFile("browser", "helper.ts")}`, {
-        preferBuiltDist: true,
-      }),
-    ).toBe(false);
-    expect(
-      resolvePluginLoaderTryNative("/repo/dist/plugins/runtime/index.js", {
-        preferBuiltDist: true,
-      }),
-    ).toBe(true);
-  });
+      try {
+        const config = withPluginCache(createPluginCache(), () =>
+          resolvePluginLoaderModuleConfig({
+            modulePath: path.join(fixture.root, entry),
+            moduleUrl: pathToFileURL(path.join(fixture.root, "dist", "entry.js")).href,
+            preferBuiltDist,
+          }),
+        );
+        expect(config.tryNative).toBe(expected);
+      } finally {
+        Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+        Object.defineProperty(process, "versions", { configurable: true, value: originalVersions });
+      }
+    },
+  );
 
   it("keeps plugin loader module cache keys stable across alias insertion order", () => {
     expect(

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -1663,7 +1663,7 @@ function shouldPreferNativeModuleLoad(modulePath: string): boolean {
   }
 }
 
-export function resolvePluginLoaderTryNative(
+function resolvePluginLoaderTryNative(
   modulePath: string,
   options?: {
     preferBuiltDist?: boolean;

--- a/src/secrets/channel-contract-api.external.test.ts
+++ b/src/secrets/channel-contract-api.external.test.ts
@@ -8,15 +8,11 @@ const tempDirs: string[] = [];
 
 const {
   loadPluginMetadataSnapshotMock,
-  loadBundledPluginPublicArtifactModuleSyncMock,
+  loadBundledPublicArtifactMock,
   shouldRejectHardlinkedPluginFilesMock,
 } = vi.hoisted(() => ({
   loadPluginMetadataSnapshotMock: vi.fn(),
-  loadBundledPluginPublicArtifactModuleSyncMock: vi.fn(() => {
-    throw new Error(
-      "Unable to resolve bundled plugin public surface discord/secret-contract-api.js",
-    );
-  }),
+  loadBundledPublicArtifactMock: vi.fn(() => null),
   shouldRejectHardlinkedPluginFilesMock: vi.fn(() => true),
 }));
 
@@ -32,7 +28,7 @@ vi.mock("../config/io.plugin-metadata.js", () => ({
 }));
 
 vi.mock("../plugins/public-surface-loader.js", () => ({
-  loadBundledPluginPublicArtifactModuleSync: loadBundledPluginPublicArtifactModuleSyncMock,
+  loadBundledPluginPublicArtifactModuleFromCandidatesSync: loadBundledPublicArtifactMock,
 }));
 
 vi.mock("../plugins/hardlink-policy.js", () => ({
@@ -105,7 +101,7 @@ function writeExternalChannelPlugin(params: { pluginId: string; channelId: strin
 describe("external channel secret contract api", () => {
   beforeEach(() => {
     loadPluginMetadataSnapshotMock.mockReset();
-    loadBundledPluginPublicArtifactModuleSyncMock.mockClear();
+    loadBundledPublicArtifactMock.mockClear();
     shouldRejectHardlinkedPluginFilesMock.mockReset();
     shouldRejectHardlinkedPluginFilesMock.mockReturnValue(true);
   });
@@ -130,6 +126,22 @@ describe("external channel secret contract api", () => {
     const contractApi = requireChannelSecretContractApi(api);
     expectDiscordTokenRegistryEntry(contractApi);
     expect(contractApi.collectRuntimeConfigAssignments).toBeTypeOf("function");
+  });
+
+  it("keeps a healthy external contract available when another artifact fails to load", () => {
+    const broken = writeExternalChannelPlugin({ pluginId: "custom", channelId: "custom" });
+    const healthy = writeExternalChannelPlugin({ pluginId: "custom-alt", channelId: "custom" });
+    fs.writeFileSync(
+      path.join(broken.rootDir, "secret-contract-api.cjs"),
+      'throw new Error("contract dependency unavailable");\n',
+    );
+    loadPluginMetadataSnapshotMock.mockReturnValue({ plugins: [broken, healthy] });
+
+    const api = loadChannelSecretContractApi({ channelId: "custom", config: {}, env: {} });
+
+    expect(api?.secretTargetRegistryEntries?.map((entry) => entry.id)).toEqual([
+      "channels.custom.token",
+    ]);
   });
 
   it("loads dist/ secret-contract-api sidecars for compiled npm-published external channel plugins", () => {

--- a/src/secrets/channel-contract-api.fast-path.test.ts
+++ b/src/secrets/channel-contract-api.fast-path.test.ts
@@ -5,10 +5,10 @@ import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.
 const { loadPluginMetadataSnapshotMock } = vi.hoisted(() => ({
   loadPluginMetadataSnapshotMock: vi.fn((_params: unknown) => ({ plugins: [] })),
 }));
-const { loadBundledPluginPublicArtifactModuleSyncMock } = vi.hoisted(() => ({
-  loadBundledPluginPublicArtifactModuleSyncMock: vi.fn(
-    ({ artifactBasename, dirName }: { artifactBasename: string; dirName: string }) => {
-      if (dirName === "discord" && artifactBasename === "secret-contract-api.js") {
+const { loadBundledPublicArtifactMock } = vi.hoisted(() => ({
+  loadBundledPublicArtifactMock: vi.fn(
+    ({ artifactCandidates, dirName }: { artifactCandidates: string[]; dirName: string }) => {
+      if (dirName === "discord" && artifactCandidates[0] === "secret-contract-api.js") {
         return {
           collectRuntimeConfigAssignments: () => undefined,
           secretTargetRegistryEntries: [
@@ -20,9 +20,7 @@ const { loadBundledPluginPublicArtifactModuleSyncMock } = vi.hoisted(() => ({
           ],
         };
       }
-      throw new Error(
-        `Unable to resolve bundled plugin public surface ${dirName}/${artifactBasename}`,
-      );
+      return null;
     },
   ),
 }));
@@ -38,7 +36,7 @@ vi.mock("../plugins/plugin-metadata-snapshot.js", async (importOriginal) => ({
 }));
 
 vi.mock("../plugins/public-surface-loader.js", () => ({
-  loadBundledPluginPublicArtifactModuleSync: loadBundledPluginPublicArtifactModuleSyncMock,
+  loadBundledPluginPublicArtifactModuleFromCandidatesSync: loadBundledPublicArtifactMock,
 }));
 
 import { loadChannelSecretContractApi } from "./channel-contract-api.js";
@@ -52,9 +50,9 @@ describe("channel contract api explicit fast path", () => {
     const api = loadChannelSecretContractApi({ channelId: "discord", config: {} });
 
     expect(api?.collectRuntimeConfigAssignments).toBeTypeOf("function");
-    expect(loadBundledPluginPublicArtifactModuleSyncMock).toHaveBeenCalledWith({
+    expect(loadBundledPublicArtifactMock).toHaveBeenCalledWith({
       dirName: "discord",
-      artifactBasename: "secret-contract-api.js",
+      artifactCandidates: ["secret-contract-api.js"],
     });
     const tokenEntry = api?.secretTargetRegistryEntries?.find(
       (entry) => entry.id === "channels.discord.accounts.*.token",
@@ -67,13 +65,13 @@ describe("channel contract api explicit fast path", () => {
     const api = loadChannelSecretContractApi({ channelId: "missing", config: {} });
 
     expect(api).toBeUndefined();
-    expect(loadBundledPluginPublicArtifactModuleSyncMock).toHaveBeenCalledWith({
+    expect(loadBundledPublicArtifactMock).toHaveBeenCalledWith({
       dirName: "missing",
-      artifactBasename: "secret-contract-api.js",
+      artifactCandidates: ["secret-contract-api.js"],
     });
-    expect(loadBundledPluginPublicArtifactModuleSyncMock).not.toHaveBeenCalledWith({
+    expect(loadBundledPublicArtifactMock).not.toHaveBeenCalledWith({
       dirName: "missing",
-      artifactBasename: "contract-api.js",
+      artifactCandidates: ["contract-api.js"],
     });
     expect(loadPluginMetadataSnapshotMock).toHaveBeenCalledTimes(1);
     expect(loadPluginMetadataSnapshotMock.mock.calls[0]?.[0]).toMatchObject({

--- a/src/secrets/channel-contract-api.ts
+++ b/src/secrets/channel-contract-api.ts
@@ -11,7 +11,7 @@ import { pluginCacheExistsSync } from "../plugins/plugin-cache-files.js";
 import { getPluginCacheRoot } from "../plugins/plugin-cache.js";
 import { getCachedPluginModuleLoader } from "../plugins/plugin-module-loader-cache.js";
 import type { PluginOrigin } from "../plugins/plugin-origin.types.js";
-import { loadBundledPluginPublicArtifactModuleSync } from "../plugins/public-surface-loader.js";
+import { loadBundledPluginPublicArtifactModuleFromCandidatesSync } from "../plugins/public-surface-loader.js";
 import { loadOfficialExternalChannelSecretContractApi } from "./official-external-channel-secret-contract.js";
 import type { ResolverContext, SecretDefaults } from "./runtime-shared.js";
 import type { SecretTargetRegistryEntry } from "./target-registry-types.js";
@@ -31,26 +31,6 @@ const RUNNING_FROM_BUILT_ARTIFACT =
   CURRENT_MODULE_PATH.includes(`${path.sep}dist${path.sep}`) ||
   CURRENT_MODULE_PATH.includes(`${path.sep}dist-runtime${path.sep}`);
 
-function loadBundledChannelPublicArtifact(
-  channelId: string,
-  artifactBasename: string,
-): BundledChannelContractApi | undefined {
-  try {
-    return loadBundledPluginPublicArtifactModuleSync<BundledChannelContractApi>({
-      dirName: channelId,
-      artifactBasename,
-    });
-  } catch (error) {
-    if (
-      error instanceof Error &&
-      error.message.startsWith("Unable to resolve bundled plugin public surface ")
-    ) {
-      return undefined;
-    }
-    throw error;
-  }
-}
-
 type BundledChannelSecretContractApi = Pick<
   BundledChannelContractApi,
   "collectRuntimeConfigAssignments" | "secretTargetRegistryEntries"
@@ -60,7 +40,12 @@ type BundledChannelSecretContractApi = Pick<
 function loadBundledChannelSecretContractApi(
   channelId: string,
 ): BundledChannelSecretContractApi | undefined {
-  return loadBundledChannelPublicArtifact(channelId, "secret-contract-api.js");
+  return (
+    loadBundledPluginPublicArtifactModuleFromCandidatesSync<BundledChannelSecretContractApi>({
+      dirName: channelId,
+      artifactCandidates: ["secret-contract-api.js"],
+    }) ?? undefined
+  );
 }
 
 function orderedContractApiExtensions(): readonly string[] {
@@ -109,6 +94,7 @@ function loadPluginContractModule(modulePath: string, rootDir: string): BundledC
 function loadExternalChannelSecretContractFromRecord(
   record: PluginManifestRecord,
   env: NodeJS.ProcessEnv = process.env,
+  throwOnLoadError = false,
 ): BundledChannelSecretContractApi | undefined {
   const contractPath = resolvePluginContractApiPath(record.rootDir);
   if (!contractPath) {
@@ -130,15 +116,18 @@ function loadExternalChannelSecretContractFromRecord(
       rejectHardlinks,
       skipLexicalRootCheck: true,
     });
-    if (!opened.ok) {
-      artifacts.set(boundary, null);
-      return undefined;
+    if (opened.ok) {
+      fs.closeSync(opened.fd);
+      validated = { modulePath: opened.path, boundaryRoot: record.rootDir };
+    } else {
+      validated = null;
     }
-    fs.closeSync(opened.fd);
-    validated = { modulePath: opened.path, boundaryRoot: record.rootDir };
     artifacts.set(boundary, validated);
   }
   if (!validated) {
+    if (throwOnLoadError) {
+      throw new Error(`Unable to open channel secret contract for ${record.id}`);
+    }
     return undefined;
   }
   try {
@@ -147,6 +136,9 @@ function loadExternalChannelSecretContractFromRecord(
       return mod;
     }
   } catch (error) {
+    if (throwOnLoadError) {
+      throw error;
+    }
     if (process.env.OPENCLAW_DEBUG_CHANNEL_CONTRACT_API === "1") {
       const detail = error instanceof Error ? error.message : String(error);
       console.warn(
@@ -237,9 +229,14 @@ export function loadChannelSecretContractApi(params: {
 /** Loads a channel secret contract directly from a manifest record. */
 export function loadChannelSecretContractApiForRecord(
   record: PluginManifestRecord,
+  options?: { throwOnLoadError?: boolean },
 ): BundledChannelSecretContractApi | undefined {
   if (record.origin === "bundled") {
     return loadBundledChannelSecretContractApi(record.id);
   }
-  return loadExternalChannelSecretContractFromRecord(record);
+  return loadExternalChannelSecretContractFromRecord(
+    record,
+    process.env,
+    options?.throwOnLoadError,
+  );
 }

--- a/src/secrets/runtime-external-channel-audit.test.ts
+++ b/src/secrets/runtime-external-channel-audit.test.ts
@@ -14,11 +14,11 @@ import { activateSecretsRuntimeSnapshot } from "./runtime.js";
 
 const {
   getBootstrapChannelSecretsMock,
-  loadBundledPluginPublicArtifactModuleSyncMock,
+  loadBundledPublicArtifactMock,
   loadPluginMetadataSnapshotMock,
 } = vi.hoisted(() => ({
   getBootstrapChannelSecretsMock: vi.fn(),
-  loadBundledPluginPublicArtifactModuleSyncMock: vi.fn(),
+  loadBundledPublicArtifactMock: vi.fn(),
   loadPluginMetadataSnapshotMock: vi.fn(),
 }));
 
@@ -36,7 +36,7 @@ vi.mock("../plugins/plugin-metadata-snapshot.js", async (importOriginal) => ({
 }));
 
 vi.mock("../plugins/public-surface-loader.js", () => ({
-  loadBundledPluginPublicArtifactModuleSync: loadBundledPluginPublicArtifactModuleSyncMock,
+  loadBundledPluginPublicArtifactModuleFromCandidatesSync: loadBundledPublicArtifactMock,
 }));
 
 vi.mock("../channels/plugins/bootstrap-registry.js", () => ({
@@ -99,14 +99,15 @@ function externalChannelOrigins(records: readonly PluginManifestRecord[]) {
 }
 
 function mockBundledPublicArtifactMiss() {
-  loadBundledPluginPublicArtifactModuleSyncMock.mockImplementation(
-    (params: { dirName: string; artifactBasename: string }) => {
-      if (params.dirName === "googlechat" && params.artifactBasename === "secret-contract-api.js") {
+  loadBundledPublicArtifactMock.mockImplementation(
+    (params: { dirName: string; artifactCandidates: string[] }) => {
+      if (
+        params.dirName === "googlechat" &&
+        params.artifactCandidates[0] === "secret-contract-api.js"
+      ) {
         return createGoogleChatSecretContractApi();
       }
-      throw new Error(
-        `Unable to resolve bundled plugin public surface ${params.dirName}/${params.artifactBasename}`,
-      );
+      return null;
     },
   );
 }
@@ -202,13 +203,13 @@ function expectMetadataBackedContractsWereUsed(
     expect(loadPluginMetadataSnapshotMock).toHaveBeenCalled();
   }
   for (const channelId of channelIds) {
-    expect(loadBundledPluginPublicArtifactModuleSyncMock).toHaveBeenCalledWith({
+    expect(loadBundledPublicArtifactMock).toHaveBeenCalledWith({
       dirName: channelId,
-      artifactBasename: "secret-contract-api.js",
+      artifactCandidates: ["secret-contract-api.js"],
     });
-    expect(loadBundledPluginPublicArtifactModuleSyncMock).not.toHaveBeenCalledWith({
+    expect(loadBundledPublicArtifactMock).not.toHaveBeenCalledWith({
       dirName: channelId,
-      artifactBasename: "contract-api.js",
+      artifactCandidates: ["contract-api.js"],
     });
   }
 }
@@ -223,7 +224,7 @@ describe("secrets runtime externalized channel SecretRef audit", () => {
   beforeEach(() => {
     getBootstrapChannelSecretsMock.mockReset();
     getBootstrapChannelSecretsMock.mockReturnValue(undefined);
-    loadBundledPluginPublicArtifactModuleSyncMock.mockReset();
+    loadBundledPublicArtifactMock.mockReset();
     mockBundledPublicArtifactMiss();
     loadPluginMetadataSnapshotMock.mockReset();
   });

--- a/src/secrets/target-registry-data.current-snapshot.test.ts
+++ b/src/secrets/target-registry-data.current-snapshot.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetPluginCache } from "../plugins/plugin-cache.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "../plugins/test-helpers/fs-fixtures.js";
 
 const tempDirs: string[] = [];
@@ -67,8 +68,89 @@ describe("getSecretTargetRegistry metadata reuse", () => {
   });
 
   afterEach(() => {
+    resetPluginCache();
+    vi.unstubAllEnvs();
     cleanupTrackedTempDirs(tempDirs);
   });
+
+  it.each(["bundled", "config"])(
+    "rejects a broken %s contract during source docs generation without changing runtime tolerance",
+    async (origin) => {
+      const healthy = writeChannelContract({
+        channelId: "healthy",
+        pluginId: "healthy",
+        targetId: "channels.healthy.token",
+        ownership: "channels",
+      });
+      const broken = writeChannelContract({
+        channelId: "broken",
+        pluginId: "broken",
+        targetId: "channels.broken.token",
+        ownership: "channels",
+      });
+      const missing = {
+        ...broken,
+        id: "missing",
+        rootDir: makeTrackedTempDir("openclaw-target-registry-missing", tempDirs),
+      };
+      // A dependency failure can resemble the old missing-artifact message; it is not absence.
+      const failure = "Unable to resolve bundled plugin public surface fixture dependency failed";
+      fs.writeFileSync(
+        path.join(broken.rootDir, "secret-contract-api.cjs"),
+        `throw new Error(${JSON.stringify(failure)});`,
+      );
+      const records = [healthy, broken, missing].map((record) =>
+        Object.assign({}, record, {
+          origin,
+          id: origin === "bundled" ? path.basename(record.rootDir) : record.id,
+        }),
+      );
+      vi.stubEnv("OPENCLAW_BUNDLED_PLUGINS_DIR", path.dirname(healthy.rootDir));
+      vi.stubEnv("OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR", "1");
+      metadataMocks.resolvePluginMetadataSnapshot.mockReturnValue({ plugins: records } as never);
+      const { getSecretTargetRegistry } = await import("./target-registry-data.js");
+      const { buildSecretRefCredentialMatrix } =
+        await import("./credential-matrix.test-support.js");
+
+      const runtimeIds = getSecretTargetRegistry({ config: {}, env: {} }).map((entry) => entry.id);
+      expect(runtimeIds).toContain("channels.healthy.token");
+      expect(runtimeIds).toContain("gateway.auth.token");
+      expect(runtimeIds).not.toContain("channels.broken.token");
+      expect(() => buildSecretRefCredentialMatrix()).toThrow(failure);
+
+      metadataMocks.resolvePluginMetadataSnapshot.mockReturnValue({
+        plugins: [records[0], records[2]],
+      } as never);
+      const matrixIds = buildSecretRefCredentialMatrix().entries.map((entry) => entry.id);
+      expect(matrixIds).toContain("channels.healthy.token");
+      expect(matrixIds).toContain("gateway.auth.token");
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "reports a rejected contract boundary during source generation after runtime cached the rejection",
+    async () => {
+      const record = writeChannelContract({
+        channelId: "blocked",
+        pluginId: "blocked",
+        targetId: "channels.blocked.token",
+        ownership: "channels",
+      });
+      const outsideDir = makeTrackedTempDir("openclaw-contract-outside", tempDirs);
+      fs.linkSync(
+        path.join(record.rootDir, "secret-contract-api.cjs"),
+        path.join(outsideDir, "linked-contract.cjs"),
+      );
+      metadataMocks.resolvePluginMetadataSnapshot.mockReturnValue({ plugins: [record] } as never);
+      const { getSecretTargetRegistry } = await import("./target-registry-data.js");
+      expect(
+        getSecretTargetRegistry({ config: {}, env: {} }).map((entry) => entry.id),
+      ).not.toContain("channels.blocked.token");
+      expect(() => getSecretTargetRegistry({ sourceTree: true })).toThrow(
+        "Unable to open channel secret contract for blocked",
+      );
+    },
+  );
 
   it("allows configless runtime targets to reuse the lifecycle workspace", async () => {
     const { getSecretTargetRegistry } = await import("./target-registry-data.js");

--- a/src/secrets/target-registry-data.ts
+++ b/src/secrets/target-registry-data.ts
@@ -92,15 +92,19 @@ function listPluginConfigSecretTargetRegistryEntries(
 
 function listChannelSecretTargetRegistryEntries(
   channelPlugins: readonly PluginManifestRecord[],
+  throwOnLoadError = false,
 ): SecretTargetRegistryEntry[] {
   const entries: SecretTargetRegistryEntry[] = [];
 
   for (const record of channelPlugins) {
     try {
-      const contractApi = loadChannelSecretContractApiForRecord(record);
+      const contractApi = loadChannelSecretContractApiForRecord(record, { throwOnLoadError });
       entries.push(...(contractApi?.secretTargetRegistryEntries ?? []));
-    } catch {
-      // Ignore channels that do not expose a usable secret contract artifact.
+    } catch (error) {
+      // Runtime can isolate unavailable owners; generated docs must never silently lose targets.
+      if (throwOnLoadError) {
+        throw error;
+      }
     }
   }
   return entries;
@@ -448,6 +452,7 @@ function loadSecretTargetRegistryFromPluginMetadata(params: {
   config?: OpenClawConfig;
   env: NodeJS.ProcessEnv;
   preferPersisted?: boolean;
+  throwOnLoadError?: boolean;
 }): SecretTargetRegistryEntry[] {
   const plugins = resolvePluginMetadataSnapshot({
     ...(params.config !== undefined ? { config: params.config } : {}),
@@ -455,12 +460,13 @@ function loadSecretTargetRegistryFromPluginMetadata(params: {
     allowWorkspaceScopedCurrent: true,
     ...(params.preferPersisted !== undefined ? { preferPersisted: params.preferPersisted } : {}),
   }).plugins;
-  return buildSecretTargetRegistryFromPlugins(plugins);
+  return buildSecretTargetRegistryFromPlugins(plugins, params);
 }
 
 /** Builds secret targets from one exact manifest-registry plugin set. */
 export function buildSecretTargetRegistryFromPlugins(
   plugins: readonly PluginManifestRecord[],
+  options?: { throwOnLoadError?: boolean },
 ): SecretTargetRegistryEntry[] {
   const channelPlugins = plugins.filter(
     (record) =>
@@ -479,7 +485,7 @@ export function buildSecretTargetRegistryFromPlugins(
     ...CORE_SECRET_TARGET_REGISTRY,
     ...listPluginWebProviderSecretTargetRegistryEntries(plugins),
     ...listPluginConfigSecretTargetRegistryEntries(plugins),
-    ...listChannelSecretTargetRegistryEntries(channelPlugins),
+    ...listChannelSecretTargetRegistryEntries(channelPlugins, options?.throwOnLoadError),
     ...listOfficialExternalChannelSecretTargetRegistryEntries(),
   ];
   const seen = new Set<string>();
@@ -514,6 +520,7 @@ export function getSecretTargetRegistry(params?: {
         OPENCLAW_BUNDLED_PLUGINS_DIR: process.env.OPENCLAW_BUNDLED_PLUGINS_DIR ?? "extensions",
       },
       preferPersisted: false,
+      throwOnLoadError: true,
     });
   }
   if (params?.config) {

--- a/src/secrets/target-registry.fast-path.test.ts
+++ b/src/secrets/target-registry.fast-path.test.ts
@@ -11,10 +11,10 @@ const { getSecretTargetRegistryMock } = vi.hoisted(() => ({
   getSecretTargetRegistryMock: vi.fn(),
 }));
 
-const { loadBundledPluginPublicArtifactModuleSyncMock } = vi.hoisted(() => ({
-  loadBundledPluginPublicArtifactModuleSyncMock: vi.fn(
-    ({ artifactBasename, dirName }: { artifactBasename: string; dirName: string }) => {
-      if (dirName === "googlechat" && artifactBasename === "secret-contract-api.js") {
+const { loadBundledPublicArtifactMock } = vi.hoisted(() => ({
+  loadBundledPublicArtifactMock: vi.fn(
+    ({ artifactCandidates, dirName }: { artifactCandidates: string[]; dirName: string }) => {
+      if (dirName === "googlechat" && artifactCandidates[0] === "secret-contract-api.js") {
         return {
           secretTargetRegistryEntries: [
             {
@@ -31,7 +31,7 @@ const { loadBundledPluginPublicArtifactModuleSyncMock } = vi.hoisted(() => ({
           ],
         };
       }
-      if (dirName === "telegram" && artifactBasename === "secret-contract-api.js") {
+      if (dirName === "telegram" && artifactCandidates[0] === "secret-contract-api.js") {
         return {
           secretTargetRegistryEntries: [
             {
@@ -49,9 +49,7 @@ const { loadBundledPluginPublicArtifactModuleSyncMock } = vi.hoisted(() => ({
           ],
         };
       }
-      throw new Error(
-        `Unable to resolve bundled plugin public surface ${dirName}/${artifactBasename}`,
-      );
+      return null;
     },
   ),
 }));
@@ -61,7 +59,7 @@ vi.mock("../plugins/manifest-registry.js", () => ({
 }));
 
 vi.mock("../plugins/public-surface-loader.js", () => ({
-  loadBundledPluginPublicArtifactModuleSync: loadBundledPluginPublicArtifactModuleSyncMock,
+  loadBundledPluginPublicArtifactModuleFromCandidatesSync: loadBundledPublicArtifactMock,
 }));
 
 vi.mock("./target-registry-data.js", async (importOriginal) => {
@@ -104,7 +102,7 @@ import {
 describe("secret target registry fast path", () => {
   beforeEach(() => {
     loadPluginManifestRegistryMock.mockClear();
-    loadBundledPluginPublicArtifactModuleSyncMock.mockClear();
+    loadBundledPublicArtifactMock.mockClear();
     getSecretTargetRegistryMock.mockClear();
   });
 
@@ -116,9 +114,9 @@ describe("secret target registry fast path", () => {
     }
     expect(target.entry.id).toBe("channels.googlechat.serviceAccount");
     expect(target.refPathSegments).toBeUndefined();
-    expect(loadBundledPluginPublicArtifactModuleSyncMock).toHaveBeenCalledWith({
+    expect(loadBundledPublicArtifactMock).toHaveBeenCalledWith({
       dirName: "googlechat",
-      artifactBasename: "secret-contract-api.js",
+      artifactCandidates: ["secret-contract-api.js"],
     });
     expect(loadPluginManifestRegistryMock).not.toHaveBeenCalled();
   });
@@ -133,7 +131,7 @@ describe("secret target registry fast path", () => {
     );
 
     expect(targets.map((target) => target.entry.id)).toEqual(["gateway.auth.token"]);
-    expect(loadBundledPluginPublicArtifactModuleSyncMock).not.toHaveBeenCalled();
+    expect(loadBundledPublicArtifactMock).not.toHaveBeenCalled();
     expect(loadPluginManifestRegistryMock).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers loading source plugin artifacts could get `ERR_PACKAGE_PATH_NOT_EXPORTED` despite valid installed dependencies, and credential-reference generation could silently omit a channel's targets after that failure.

Closes #132153. Found while validating Buzz multi-account setup; this repair leaves Google Chat's source and all dependency versions unchanged. AI-assisted maintainer repair.

## Why This Change Was Made

Source and compiled public artifacts now share the existing canonical plugin loader instead of choosing a second `require` path whenever a TypeScript hook exists. Cache retirement clears transformed source modules and their plugin-local dependencies while preserving shared modules outside that boundary. Source credential-reference generation reports a present but broken contract; ordinary runtime discovery still isolates unavailable owners and retains healthy siblings. Optional artifact absence is resolved structurally rather than inferred from an error-message prefix.

## User Impact

Source-checkout plugin tooling works with import-only package exports. Credential metadata cannot silently lose an affected owner's entries during generation. Built native loading, module identity, runtime degradation, and plugin boundary checks retain their existing contracts. There are no new configuration settings, dependency changes, migrations, or schema/version changes.

## Evidence

Final normal build and [hosted CI run 33217830954](https://github.com/openclaw/openclaw/actions/runs/33217830954) passed on exact head `3af5ae1da35c4c5330846c62046bef79c1021a64`.

- Reproduced the original error in a fresh Node 24.20 process under the real repository TypeScript hook; native ESM and the canonical cached loader succeeded with the same installed dependencies. A generated tiny plugin with import-only exports independently reproduces the failure.
- The initial repair exposed stale source dependency exports after cache retirement. The regression now checks exact module identity across bundled, installed, and SDK-facade access; same-generation stability; replacement after retirement; and unchanged outside-root shared identity.
- Focused owner/sibling suite: 135 tests across 13 files passed. Follow-ups cover the private native-selection helper through its actual production config owner, and the corrected final source-generation fixtures. Counts overlap and are not summed.
- Actual source credential-matrix generation, with network access and operator home denied: all 108 entries exactly match the committed matrix, including both Google Chat service-account targets.
- Source-generation tests cover missing optional artifacts, throwing bundled/external contracts, dependency errors resembling the old missing-artifact prefix, cached boundary rejection, and healthy runtime sibling retention.
- Full changed-file checks passed, including core/test types, lint, unused exports, and architecture guards. Independent Codex review found no actionable P0–P2 findings in the selected tracked diff; two optional owner-context packets were omitted under the helper's filename safety policy, with full owner reading performed separately.
- The actual final-head built Google Chat entrypoint imported successfully in a fresh process with network access and the operator home denied: 131.66 MiB RSS, 88.64 MiB above baseline. The profile used the completed runtime output without triggering a rebuild.
- Final local `pnpm build` passed all runtime/package bundles, 63 external plugins, 48 native control-plane module checks, public SDK checks, and UI performance checks. The first build on the older base failed the final UI guard at 347,446 gzip bytes against 347,037 allowed. None of this repair's six production owners occur in its UI source maps. Integrating upstream main at `64f9e1302eda8e99479099a111ec9bb00601928b`, including the existing #132020 and #131788 UI changes, resolved that build failure; `git range-diff` confirms this repair's patch stayed identical. No limit or assertion was relaxed by this PR.

Production LOC: +49/-77 (net -28). Tests: +246/-187. Docs: +2. The duplicate loader branch and obsolete export are removed; no replacement fallback or dependency workaround is added.

Provenance: the available shallow history ends at a carrier snapshot, so original introduction and merger are unknown. The carrier commit is not attributed as the cause. Installed Jiti 2.7.0 and executing Node 24.20 resolver/cache source were inspected directly.

Nearby follow-up: the separate bundled-channel metadata generator still has an older optional security-artifact prefix catch. Its actual check passes here; no defect was established for that path, so it is not changed in this PR.

Release context: plugin source artifacts correctly load import-only dependencies, and credential-reference generation reports broken owners instead of silently omitting targets.
